### PR TITLE
feat: cask command parity for info, outdated, cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,14 +174,17 @@ List packages with newer versions available.
 mt outdated
 mt outdated --json
 mt outdated --cask
+mt outdated --formula
 ```
 
-| Flag     | Description              |
-| -------- | ------------------------ |
-| `--json` | Output as JSON           |
-| `--cask` | Show outdated casks only |
+| Flag            | Description                 |
+| --------------- | --------------------------- |
+| `--json`        | Output as JSON              |
+| `--formula`     | Show outdated formulas only |
+| `--cask`        | Show outdated casks only    |
+| `--quiet`, `-q` | Suppress status messages    |
 
-Compares installed versions against the latest from the Homebrew API. Checks both formulas and casks.
+Compares installed versions against the latest from the Homebrew API. Checks both formulas and casks by default.
 
 ```
 wget (1.24.5) < 1.25.0
@@ -203,23 +206,22 @@ mt list --json
 
 ### `mt info`
 
-Show detailed information about a package.
+Show detailed information about a formula or cask.
 
 ```bash
 mt info <package>
 mt info <package> --json
+mt info --cask <app>
+mt info --formula <name>
 ```
 
-```
-wget: Internet file retriever
-https://www.gnu.org/software/wget/
-/opt/malt/Cellar/wget/1.25.0 (12 files, 2.1MB)
-  Poured from bottle on 2026-04-08
-From: homebrew/core
-License: GPL-3.0-or-later
-Dependencies: libidn2, openssl@3
-Post-install hook: No
-```
+| Flag        | Description            |
+| ----------- | ---------------------- |
+| `--formula` | Show formula info only |
+| `--cask`    | Show cask info only    |
+| `--json`    | Output as JSON         |
+
+Auto-detects whether the package is a formula or cask. For formulas, shows version, tap, cellar path, and pinned status. For casks, shows version, download URL, app path, and auto-update status.
 
 ### `mt search`
 
@@ -493,34 +495,40 @@ zig build universal                      # universal binary (arm64 + x86_64 via 
 Install times on macOS 14 (Apple Silicon), comparing malt against other Homebrew-compatible package managers.
 
 <!-- BENCH:SIZE:START -->
+
 ### Binary Size
 
-| Tool | Size |
-| ---- | ---- |
+| Tool     | Size |
+| -------- | ---- |
 | **malt** | 3.0M |
 | nanobrew | 1.4M |
 | zerobrew | 8.6M |
-| bru | 1.8M |
+| bru      | 1.8M |
+
 <!-- BENCH:SIZE:END -->
 
 <!-- BENCH:COLD:START -->
+
 ### Cold Install
 
-| Package | malt | nanobrew | zerobrew | bru | Homebrew |
-| ------- | ---- | -------- | -------- | --- | -------- |
-| **tree** (0 deps) | 0.015s | 0.566s | 2.073s | 0.981s | 5.849s |
-| **wget** (6 deps) | 0.003s | 6.299s | 7.877s | 0.006s | 5.145s |
-| **ffmpeg** (11 deps) | 0.017s | 2.568s | 6.771s | 4.022s | 8.469s |
+| Package              | malt   | nanobrew | zerobrew | bru    | Homebrew |
+| -------------------- | ------ | -------- | -------- | ------ | -------- |
+| **tree** (0 deps)    | 0.015s | 0.566s   | 2.073s   | 0.981s | 5.849s   |
+| **wget** (6 deps)    | 0.003s | 6.299s   | 7.877s   | 0.006s | 5.145s   |
+| **ffmpeg** (11 deps) | 0.017s | 2.568s   | 6.771s   | 4.022s | 8.469s   |
+
 <!-- BENCH:COLD:END -->
 
 <!-- BENCH:WARM:START -->
+
 ### Warm Install
 
-| Package | malt | nanobrew | zerobrew | bru |
-| ------- | ---- | -------- | -------- | --- |
-| **tree** (0 deps) | 0.002s | 0.008s | 0.394s | 0.077s |
-| **wget** (6 deps) | 0.002s | 0.695s | 0.911s | 0.644s |
-| **ffmpeg** (11 deps) | 0.003s | 2.217s | 4.096s | 1.699s |
+| Package              | malt   | nanobrew | zerobrew | bru    |
+| -------------------- | ------ | -------- | -------- | ------ |
+| **tree** (0 deps)    | 0.002s | 0.008s   | 0.394s   | 0.077s |
+| **wget** (6 deps)    | 0.002s | 0.695s   | 0.911s   | 0.644s |
+| **ffmpeg** (11 deps) | 0.003s | 2.217s   | 4.096s   | 1.699s |
+
 <!-- BENCH:WARM:END -->
 
 > Benchmarks on Apple Silicon (GitHub Actions macos-14), 2026-04-09. Auto-updated weekly via [benchmark workflow](.github/workflows/benchmark.yml).

--- a/src/cli/cleanup.zig
+++ b/src/cli/cleanup.zig
@@ -57,6 +57,9 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // Clean old Cellar versions (keep only latest per formula)
     total_freed += cleanOldVersions(allocator, prefix, dry_run);
 
+    // Clean stale cask cache entries (downloads for uninstalled casks)
+    total_freed += cleanCaskCache(allocator, prefix, dry_run);
+
     if (dry_run) {
         var buf: [128]u8 = undefined;
         const msg = std.fmt.bufPrint(&buf, "Would free approximately {d} bytes (dry run)", .{total_freed}) catch return;
@@ -157,6 +160,91 @@ fn cleanOldVersions(allocator: std.mem.Allocator, prefix: []const u8, dry_run: b
         }
         // Actual old version cleanup would require sorting by version
         // and removing older ones. For safety, we only report here.
+    }
+
+    return freed;
+}
+
+/// Clean stale cask cache entries — remove cached downloads for casks
+/// that are no longer installed.
+fn cleanCaskCache(allocator: std.mem.Allocator, prefix: []const u8, dry_run: bool) u64 {
+    var cask_cache_buf: [512]u8 = undefined;
+    const cask_cache_path = std.fmt.bufPrint(&cask_cache_buf, "{s}/cache/Cask", .{prefix}) catch return 0;
+
+    var dir = std.fs.openDirAbsolute(cask_cache_path, .{ .iterate = true }) catch return 0;
+    defer dir.close();
+
+    // Open DB to check which casks are still installed
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return 0;
+    var db = sqlite.Database.open(db_path) catch return 0;
+    defer db.close();
+
+    var freed: u64 = 0;
+    var iter = dir.iterate();
+    while (iter.next() catch null) |entry| {
+        if (entry.kind == .directory) continue;
+
+        // Extract token from filename: "token.dmg" / "token.zip" / "token.pkg"
+        const name = entry.name;
+        const token = blk: {
+            for ([_][]const u8{ ".dmg", ".zip", ".pkg" }) |ext| {
+                if (std.mem.endsWith(u8, name, ext)) {
+                    break :blk name[0 .. name.len - ext.len];
+                }
+            }
+            break :blk name;
+        };
+
+        // Check if this cask is still installed
+        const token_z = allocator.dupeZ(u8, token) catch continue;
+        defer allocator.free(token_z);
+
+        var stmt = db.prepare("SELECT token FROM casks WHERE token = ?1 LIMIT 1;") catch continue;
+        defer stmt.finalize();
+        stmt.bindText(1, token_z) catch continue;
+
+        const still_installed = stmt.step() catch false;
+        if (still_installed) continue;
+
+        // Not installed — remove the cache file
+        const stat = dir.statFile(entry.name) catch continue;
+        freed += stat.size;
+        if (dry_run) {
+            output.info("  Would remove stale cask cache: {s}", .{entry.name});
+        } else {
+            dir.deleteFile(entry.name) catch {};
+        }
+    }
+
+    // Also clean stale Caskroom entries
+    var caskroom_buf: [512]u8 = undefined;
+    const caskroom_path = std.fmt.bufPrint(&caskroom_buf, "{s}/Caskroom", .{prefix}) catch return freed;
+
+    var caskroom = std.fs.openDirAbsolute(caskroom_path, .{ .iterate = true }) catch return freed;
+    defer caskroom.close();
+
+    var cr_iter = caskroom.iterate();
+    while (cr_iter.next() catch null) |entry| {
+        if (entry.kind != .directory) continue;
+
+        const token_z = allocator.dupeZ(u8, entry.name) catch continue;
+        defer allocator.free(token_z);
+
+        var stmt = db.prepare("SELECT token FROM casks WHERE token = ?1 LIMIT 1;") catch continue;
+        defer stmt.finalize();
+        stmt.bindText(1, token_z) catch continue;
+
+        const still_installed = stmt.step() catch false;
+        if (still_installed) continue;
+
+        if (dry_run) {
+            output.info("  Would remove stale Caskroom entry: {s}", .{entry.name});
+        } else {
+            std.fs.deleteTreeAbsolute(
+                std.fmt.bufPrint(&caskroom_buf, "{s}/Caskroom/{s}", .{ prefix, entry.name }) catch continue,
+            ) catch {};
+        }
     }
 
     return freed;

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -33,6 +33,8 @@ fn helpFor(command: []const u8) []const u8 {
         .{ "migrate", migrate_help },
         .{ "rollback", rollback_help },
         .{ "run", run_help },
+        .{ "link", link_help },
+        .{ "unlink", unlink_help2 },
     });
     return map.get(command) orelse "No help available.\n";
 }
@@ -97,8 +99,9 @@ const outdated_help =
     \\
     \\Flags:
     \\  --json         Output as JSON
-    \\  --formula      Formulas only
-    \\  --cask         Casks only
+    \\  --formula      Show outdated formulas only
+    \\  --cask         Show outdated casks only
+    \\  --quiet, -q    Suppress status messages
     \\
 ;
 
@@ -120,9 +123,11 @@ const list_help =
 const info_help =
     \\Usage: malt info <package> [flags]
     \\
-    \\Show detailed information about a package.
+    \\Show detailed information about a formula or cask.
     \\
     \\Flags:
+    \\  --formula      Show formula info only
+    \\  --cask         Show cask info only
     \\  --json         Output as JSON
     \\
 ;
@@ -220,5 +225,24 @@ const run_help =
     \\
     \\Example:
     \\  malt run jq -- --version
+    \\
+;
+
+const link_help =
+    \\Usage: malt link <formula> [flags]
+    \\
+    \\Create symlinks for an installed keg in the prefix (bin/, lib/, etc.).
+    \\
+    \\Flags:
+    \\  --overwrite    Replace existing symlinks
+    \\  --force, -f    Same as --overwrite
+    \\
+;
+
+const unlink_help2 =
+    \\Usage: malt unlink <formula>
+    \\
+    \\Remove symlinks for an installed keg from the prefix.
+    \\The keg remains installed in the Cellar.
     \\
 ;

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -1,5 +1,5 @@
 //! malt — info command
-//! Show package info.
+//! Show package info (formulas and casks).
 
 const std = @import("std");
 const sqlite = @import("../db/sqlite.zig");
@@ -8,6 +8,7 @@ const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
 const api_mod = @import("../net/api.zig");
 const client_mod = @import("../net/client.zig");
+const cask_mod = @import("../core/cask.zig");
 const help = @import("help.zig");
 
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
@@ -15,11 +16,17 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     // Parse flags and positional args
     var json_mode = false;
+    var force_cask = false;
+    var force_formula = false;
     var pkg_name: ?[]const u8 = null;
 
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "--json")) {
             json_mode = true;
+        } else if (std.mem.eql(u8, arg, "--cask")) {
+            force_cask = true;
+        } else if (std.mem.eql(u8, arg, "--formula")) {
+            force_formula = true;
         } else if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
             output.setQuiet(true);
         } else if (arg.len > 0 and arg[0] != '-') {
@@ -43,21 +50,54 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer db.close();
     schema.initSchema(&db) catch return;
 
-    // Query installed info from kegs
-    var stmt = db.prepare(
-        "SELECT name, version, tap, cellar_path, pinned, installed_at FROM kegs WHERE name = ?1 LIMIT 1;",
-    ) catch return;
-    defer stmt.finalize();
-    stmt.bindText(1, name) catch return;
+    // Check formula first (unless --cask)
+    var formula_installed = false;
+    if (!force_cask) {
+        var stmt = db.prepare(
+            "SELECT name, version, tap, cellar_path, pinned, installed_at FROM kegs WHERE name = ?1 LIMIT 1;",
+        ) catch return;
+        defer stmt.finalize();
+        stmt.bindText(1, name) catch return;
 
-    const installed = stmt.step() catch false;
+        formula_installed = stmt.step() catch false;
 
+        if (formula_installed) {
+            const stdout = std.fs.File.stdout();
+            if (json_mode) {
+                try writeJsonInfo(allocator, &db, name, true, &stmt, stdout);
+            } else {
+                try writeHumanInfo(allocator, &db, name, true, &stmt, prefix, stdout);
+            }
+            return;
+        }
+    }
+
+    // Check cask (unless --formula)
+    if (!force_formula) {
+        const cask_installed = cask_mod.lookupInstalled(&db, name);
+        if (cask_installed != null) {
+            const stdout = std.fs.File.stdout();
+            if (json_mode) {
+                try writeJsonCaskInfo(allocator, &db, name, stdout);
+            } else {
+                try writeHumanCaskInfo(&db, name, stdout);
+            }
+            return;
+        }
+    }
+
+    // Not installed as either
     const stdout = std.fs.File.stdout();
-
     if (json_mode) {
-        try writeJsonInfo(allocator, &db, name, installed, &stmt, stdout);
+        var stmt = db.prepare(
+            "SELECT name, version, tap, cellar_path, pinned, installed_at FROM kegs WHERE name = ?1 LIMIT 1;",
+        ) catch return;
+        defer stmt.finalize();
+        try writeJsonInfo(allocator, &db, name, false, &stmt, stdout);
     } else {
-        try writeHumanInfo(allocator, &db, name, installed, &stmt, prefix, stdout);
+        var buf: [4096]u8 = undefined;
+        const line = std.fmt.bufPrint(&buf, "{s}: not installed\n", .{name}) catch return;
+        stdout.writeAll(line) catch {};
     }
 }
 
@@ -127,7 +167,7 @@ fn writeJsonInfo(
 
     try w.writeAll("{\"name\":\"");
     try w.writeAll(name);
-    try w.writeAll("\",\"installed\":");
+    try w.writeAll("\",\"type\":\"formula\",\"installed\":");
     try w.writeAll(if (installed) "true" else "false");
 
     if (installed) {
@@ -148,5 +188,99 @@ fn writeJsonInfo(
     }
 
     try w.writeAll("}\n");
+    stdout.writeAll(buf.items) catch {};
+}
+
+fn writeHumanCaskInfo(
+    db: *sqlite.Database,
+    name: []const u8,
+    stdout: std.fs.File,
+) !void {
+    var stmt = db.prepare(
+        "SELECT token, name, version, url, sha256, app_path, auto_updates, installed_at FROM casks WHERE token = ?1 LIMIT 1;",
+    ) catch return;
+    defer stmt.finalize();
+    stmt.bindText(1, name) catch return;
+
+    const found = stmt.step() catch false;
+    if (!found) return;
+
+    var buf: [4096]u8 = undefined;
+
+    const token = if (stmt.columnText(0)) |t| std.mem.sliceTo(t, 0) else name;
+    const cask_name = if (stmt.columnText(1)) |n| std.mem.sliceTo(n, 0) else name;
+    const ver = if (stmt.columnText(2)) |v| std.mem.sliceTo(v, 0) else "unknown";
+    const url = if (stmt.columnText(3)) |u| std.mem.sliceTo(u, 0) else "N/A";
+    const app_path = if (stmt.columnText(5)) |p| std.mem.sliceTo(p, 0) else "N/A";
+    const auto_updates = stmt.columnBool(6);
+    const installed_at = if (stmt.columnText(7)) |d| std.mem.sliceTo(d, 0) else "N/A";
+
+    {
+        const line = std.fmt.bufPrint(&buf, "{s}: {s} (cask)\n", .{ token, ver }) catch return;
+        stdout.writeAll(line) catch {};
+    }
+    {
+        const line = std.fmt.bufPrint(&buf, "Name: {s}\n", .{cask_name}) catch return;
+        stdout.writeAll(line) catch {};
+    }
+    {
+        const line = std.fmt.bufPrint(&buf, "URL: {s}\n", .{url}) catch return;
+        stdout.writeAll(line) catch {};
+    }
+    {
+        const line = std.fmt.bufPrint(&buf, "App: {s}\n", .{app_path}) catch return;
+        stdout.writeAll(line) catch {};
+    }
+    if (auto_updates) {
+        stdout.writeAll("Auto-updates: yes\n") catch {};
+    }
+    {
+        const line = std.fmt.bufPrint(&buf, "Installed: {s}\n", .{installed_at}) catch return;
+        stdout.writeAll(line) catch {};
+    }
+}
+
+fn writeJsonCaskInfo(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    name: []const u8,
+    stdout: std.fs.File,
+) !void {
+    var stmt = db.prepare(
+        "SELECT token, name, version, url, sha256, app_path, auto_updates, installed_at FROM casks WHERE token = ?1 LIMIT 1;",
+    ) catch return;
+    defer stmt.finalize();
+    stmt.bindText(1, name) catch return;
+
+    const found = stmt.step() catch false;
+    if (!found) return;
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    const w = buf.writer(allocator);
+
+    const token = if (stmt.columnText(0)) |t| std.mem.sliceTo(t, 0) else name;
+    const cask_name = if (stmt.columnText(1)) |n| std.mem.sliceTo(n, 0) else name;
+    const ver = if (stmt.columnText(2)) |v| std.mem.sliceTo(v, 0) else "";
+    const url = if (stmt.columnText(3)) |u| std.mem.sliceTo(u, 0) else "";
+    const app_path = if (stmt.columnText(5)) |p| std.mem.sliceTo(p, 0) else "";
+    const auto_updates = stmt.columnBool(6);
+    const installed_at = if (stmt.columnText(7)) |d| std.mem.sliceTo(d, 0) else "";
+
+    try w.writeAll("{\"name\":\"");
+    try w.writeAll(token);
+    try w.writeAll("\",\"type\":\"cask\",\"installed\":true,\"version\":\"");
+    try w.writeAll(ver);
+    try w.writeAll("\",\"full_name\":\"");
+    try w.writeAll(cask_name);
+    try w.writeAll("\",\"url\":\"");
+    try w.writeAll(url);
+    try w.writeAll("\",\"app_path\":\"");
+    try w.writeAll(app_path);
+    try w.writeAll("\",\"auto_updates\":");
+    try w.writeAll(if (auto_updates) "true" else "false");
+    try w.writeAll(",\"installed_at\":\"");
+    try w.writeAll(installed_at);
+    try w.writeAll("\"}\n");
     stdout.writeAll(buf.items) catch {};
 }

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -16,12 +16,15 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     var json_mode = false;
     var cask_only = false;
+    var formula_only = false;
 
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "--json")) {
             json_mode = true;
         } else if (std.mem.eql(u8, arg, "--cask")) {
             cask_only = true;
+        } else if (std.mem.eql(u8, arg, "--formula") or std.mem.eql(u8, arg, "--formulae")) {
+            formula_only = true;
         } else if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
             output.setQuiet(true);
         }
@@ -49,69 +52,73 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer http.deinit();
     var api = api_mod.BrewApi.init(allocator, &http, cache_dir);
 
-    // Query all installed kegs
-    var stmt = db.prepare("SELECT name, version FROM kegs ORDER BY name;") catch return;
-    defer stmt.finalize();
-
     const stdout = std.fs.File.stdout();
 
-    if (json_mode) {
-        var buf: std.ArrayList(u8) = .empty;
-        defer buf.deinit(allocator);
-        const w = buf.writer(allocator);
-        try w.writeAll("[");
+    // Check outdated formulas (unless --cask)
+    if (!cask_only) {
+        var stmt = db.prepare("SELECT name, version FROM kegs ORDER BY name;") catch return;
+        defer stmt.finalize();
 
-        var first = true;
-        while (stmt.step() catch false) {
-            const name_ptr = stmt.columnText(0) orelse continue;
-            const ver_ptr = stmt.columnText(1);
-            const name_slice = std.mem.sliceTo(name_ptr, 0);
-            const ver_slice = if (ver_ptr) |v| std.mem.sliceTo(v, 0) else "0";
+        if (json_mode) {
+            var buf: std.ArrayList(u8) = .empty;
+            defer buf.deinit(allocator);
+            const w = buf.writer(allocator);
+            try w.writeAll("[");
 
-            const latest = getLatestVersion(allocator, &api, name_slice) orelse continue;
-            defer allocator.free(latest);
+            var first = true;
+            while (stmt.step() catch false) {
+                const name_ptr = stmt.columnText(0) orelse continue;
+                const ver_ptr = stmt.columnText(1);
+                const name_slice = std.mem.sliceTo(name_ptr, 0);
+                const ver_slice = if (ver_ptr) |v| std.mem.sliceTo(v, 0) else "0";
 
-            if (!std.mem.eql(u8, ver_slice, latest)) {
-                if (!first) try w.writeAll(",");
-                first = false;
-                try w.writeAll("{\"name\":\"");
-                try w.writeAll(name_slice);
-                try w.writeAll("\",\"installed\":\"");
-                try w.writeAll(ver_slice);
-                try w.writeAll("\",\"latest\":\"");
-                try w.writeAll(latest);
-                try w.writeAll("\"}");
+                const latest = getLatestVersion(allocator, &api, name_slice) orelse continue;
+                defer allocator.free(latest);
+
+                if (!std.mem.eql(u8, ver_slice, latest)) {
+                    if (!first) try w.writeAll(",");
+                    first = false;
+                    try w.writeAll("{\"name\":\"");
+                    try w.writeAll(name_slice);
+                    try w.writeAll("\",\"installed\":\"");
+                    try w.writeAll(ver_slice);
+                    try w.writeAll("\",\"latest\":\"");
+                    try w.writeAll(latest);
+                    try w.writeAll("\",\"type\":\"formula\"}");
+                }
             }
-        }
 
-        try w.writeAll("]\n");
-        stdout.writeAll(buf.items) catch {};
-    } else {
-        var found_any = false;
-        while (stmt.step() catch false) {
-            const name_ptr = stmt.columnText(0) orelse continue;
-            const ver_ptr = stmt.columnText(1);
-            const name_slice = std.mem.sliceTo(name_ptr, 0);
-            const ver_slice = if (ver_ptr) |v| std.mem.sliceTo(v, 0) else "0";
+            try w.writeAll("]\n");
+            stdout.writeAll(buf.items) catch {};
+        } else {
+            var found_any = false;
+            while (stmt.step() catch false) {
+                const name_ptr = stmt.columnText(0) orelse continue;
+                const ver_ptr = stmt.columnText(1);
+                const name_slice = std.mem.sliceTo(name_ptr, 0);
+                const ver_slice = if (ver_ptr) |v| std.mem.sliceTo(v, 0) else "0";
 
-            const latest = getLatestVersion(allocator, &api, name_slice) orelse continue;
-            defer allocator.free(latest);
+                const latest = getLatestVersion(allocator, &api, name_slice) orelse continue;
+                defer allocator.free(latest);
 
-            if (!std.mem.eql(u8, ver_slice, latest)) {
-                found_any = true;
-                var line_buf: [512]u8 = undefined;
-                const line = std.fmt.bufPrint(&line_buf, "{s} ({s}) < {s}\n", .{ name_slice, ver_slice, latest }) catch continue;
-                stdout.writeAll(line) catch {};
+                if (!std.mem.eql(u8, ver_slice, latest)) {
+                    found_any = true;
+                    var line_buf: [512]u8 = undefined;
+                    const line = std.fmt.bufPrint(&line_buf, "{s} ({s}) < {s}\n", .{ name_slice, ver_slice, latest }) catch continue;
+                    stdout.writeAll(line) catch {};
+                }
             }
-        }
 
-        if (!found_any and !cask_only and !output.isQuiet()) {
-            output.info("All formulas are up to date.", .{});
+            if (!found_any and !output.isQuiet()) {
+                output.info("All formulas are up to date.", .{});
+            }
         }
     }
 
-    // Check outdated casks
-    checkOutdatedCasks(allocator, &db, &api, json_mode);
+    // Check outdated casks (unless --formula)
+    if (!formula_only) {
+        checkOutdatedCasks(allocator, &db, &api, json_mode);
+    }
 }
 
 fn checkOutdatedCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api_mod.BrewApi, json_mode: bool) void {


### PR DESCRIPTION
## Summary

- **info**: Now queries both kegs and casks tables. Cask-installed packages no longer show as "not installed". Supports `--cask`/`--formula` flags and displays cask-specific fields (token, app_path, URL, auto_updates) in human and JSON output.
 - **outdated**: Added `--formula` flag for symmetry with `--cask`. Users can now filter to formula-only or cask-only outdated results. Added `type` field to JSON output entries.
 - **cleanup**: Added `cleanCaskCache()` to remove cached `.dmg`/`.zip`/`.pkg` downloads for uninstalled casks and prune stale `Caskroom/` entries.
 - **help**: Updated help text for info, outdated; added missing link/unlink help entries.
 - **README**: Updated command reference for info and outdated to document new flags.

 ### Audit summary

Commands with full formula/cask parity: `install`, `uninstall`, `upgrade`, `list`, `search`, `info`, `outdated`, `cleanup`.

Formula-only by design (casks use a different model): 

- `link`/`unlink` (symlinks vs .app bundles)
- `autoremove` (no cask dependency graph)
- `gc` (casks don't use the content-addressable store)
- `run` (casks are GUI apps)
- `rollback` (casks lack store history)
- `migrate`