### PR TITLE
fix(cellar): resolve nested directory in keg after bottle extraction

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -58,6 +58,7 @@ pub fn build(b: *std.Build) void {
         "tests/run_test.zig",
         "tests/version_update_test.zig",
         "tests/cask_test.zig",
+        "tests/cellar_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -59,8 +59,11 @@ pub fn materializeWithCellar(
     const cellar_path = std.fmt.bufPrint(&cellar_buf, "{s}/Cellar/{s}/{s}", .{ prefix, name, version }) catch
         return CellarError.OutOfMemory;
 
-    // Find the actual keg subdirectory inside the store entry
-    // Bottles extract as: store/{sha256}/{name}/{version}/
+    // Find the actual keg subdirectory inside the store entry.
+    // Bottles extract as: store/{sha256}/{name}/{version}/ but the version
+    // directory may include a Homebrew revision suffix (e.g. "10.47_1" for
+    // formula version "10.47"). We first try an exact match, then scan for
+    // a directory that starts with the version string followed by "_".
     var keg_src_buf: [512]u8 = undefined;
     const keg_src = std.fmt.bufPrint(&keg_src_buf, "{s}/{s}/{s}", .{ store_path, name, version }) catch
         return CellarError.OutOfMemory;
@@ -74,9 +77,31 @@ pub fn materializeWithCellar(
         else => return CellarError.CloneFailed,
     };
 
-    // Try keg_src first, fall back to store_path if it doesn't exist
+    // Try keg_src first (exact version match), then scan for a revision
+    // suffix variant (e.g. "10.47_1"), fall back to store_path.
+    var keg_rev_buf: [512]u8 = undefined;
     const src = blk: {
-        std.fs.accessAbsolute(keg_src, .{}) catch break :blk store_path;
+        // 1. Exact match: {store}/{name}/{version}
+        std.fs.accessAbsolute(keg_src, .{}) catch {
+            // 2. Scan {store}/{name}/ for a dir starting with "{version}_"
+            var name_dir_buf: [512]u8 = undefined;
+            const name_dir_path = std.fmt.bufPrint(&name_dir_buf, "{s}/{s}", .{ store_path, name }) catch break :blk store_path;
+            var name_dir = std.fs.openDirAbsolute(name_dir_path, .{ .iterate = true }) catch break :blk store_path;
+            defer name_dir.close();
+            var it = name_dir.iterate();
+            while (it.next() catch null) |entry| {
+                if (entry.kind != .directory) continue;
+                // Match "{version}_..." (revision suffix)
+                if (entry.name.len > version.len and
+                    std.mem.eql(u8, entry.name[0..version.len], version) and
+                    entry.name[version.len] == '_')
+                {
+                    const rev_path = std.fmt.bufPrint(&keg_rev_buf, "{s}/{s}", .{ name_dir_path, entry.name }) catch break :blk store_path;
+                    break :blk rev_path;
+                }
+            }
+            break :blk store_path;
+        };
         break :blk keg_src;
     };
 

--- a/tests/cellar_test.zig
+++ b/tests/cellar_test.zig
@@ -1,0 +1,140 @@
+//! malt — cellar module tests
+//! Tests for keg materialization and directory flattening.
+
+const std = @import("std");
+const testing = std.testing;
+const cellar_mod = @import("malt").cellar;
+
+// libc setenv/unsetenv — available because tests link with libc
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setMaltPrefix(prefix: [:0]const u8) [:0]const u8 {
+    const old = std.posix.getenv("MALT_PREFIX") orelse "";
+    _ = c.setenv("MALT_PREFIX", prefix.ptr, 1);
+    return old;
+}
+
+fn restoreMaltPrefix(old: [:0]const u8) void {
+    if (old.len == 0) {
+        _ = c.unsetenv("MALT_PREFIX");
+    } else {
+        _ = c.setenv("MALT_PREFIX", old.ptr, 1);
+    }
+}
+
+fn createTestDir(allocator: std.mem.Allocator) ![:0]const u8 {
+    const path = try std.fmt.allocPrint(allocator, "/tmp/malt_cellar_test_{x}", .{std.crypto.random.int(u64)});
+    defer allocator.free(path);
+    const z = try allocator.allocSentinel(u8, path.len, 0);
+    @memcpy(z, path);
+    try std.fs.makeDirAbsolute(z);
+    return z;
+}
+
+fn createBottleFixture(allocator: std.mem.Allocator, prefix: []const u8, sha: []const u8, name: []const u8, ver_dir: []const u8) !void {
+    const keg = try std.fmt.allocPrint(allocator, "{s}/store/{s}/{s}/{s}", .{ prefix, sha, name, ver_dir });
+    defer allocator.free(keg);
+    try std.fs.cwd().makePath(keg);
+
+    const bin_dir = try std.fmt.allocPrint(allocator, "{s}/bin", .{keg});
+    defer allocator.free(bin_dir);
+    try std.fs.makeDirAbsolute(bin_dir);
+
+    const script_path = try std.fmt.allocPrint(allocator, "{s}/bin/hello", .{keg});
+    defer allocator.free(script_path);
+    {
+        const f = try std.fs.createFileAbsolute(script_path, .{});
+        try f.writeAll("#!/bin/sh\necho hello\n");
+        f.close();
+    }
+
+    const lib_dir = try std.fmt.allocPrint(allocator, "{s}/lib", .{keg});
+    defer allocator.free(lib_dir);
+    try std.fs.makeDirAbsolute(lib_dir);
+}
+
+fn setupMaltDirs(allocator: std.mem.Allocator, prefix: []const u8) !void {
+    const dirs = [_][]const u8{ "store", "Cellar", "opt", "bin", "lib" };
+    for (dirs) |d| {
+        const p = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ prefix, d });
+        defer allocator.free(p);
+        std.fs.cwd().makePath(p) catch {};
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bug-2 tests: keg directory flattening (revision suffix handling)
+// ---------------------------------------------------------------------------
+
+test "materialize handles version with revision suffix" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        std.fs.deleteTreeAbsolute(prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+
+    try setupMaltDirs(testing.allocator, prefix);
+    try createBottleFixture(testing.allocator, prefix, "abc123", "pcre2", "10.47_1");
+
+    const old_env = setMaltPrefix(prefix);
+    defer restoreMaltPrefix(old_env);
+
+    const keg = try cellar_mod.materializeWithCellar(
+        testing.allocator,
+        prefix,
+        "abc123",
+        "pcre2",
+        "10.47",
+        ":any",
+    );
+    defer testing.allocator.free(keg.path);
+
+    // Verify flat structure: Cellar/pcre2/10.47/bin/hello should exist
+    var bin_buf: [512]u8 = undefined;
+    const bin_path = try std.fmt.bufPrint(&bin_buf, "{s}/bin/hello", .{keg.path});
+    try std.fs.accessAbsolute(bin_path, .{});
+
+    // Verify no extra nesting: Cellar/pcre2/10.47/pcre2/ should NOT exist
+    var nested_buf: [512]u8 = undefined;
+    const nested_path = try std.fmt.bufPrint(&nested_buf, "{s}/pcre2", .{keg.path});
+    const nested_exists = blk: {
+        std.fs.accessAbsolute(nested_path, .{}) catch break :blk false;
+        break :blk true;
+    };
+    try testing.expect(!nested_exists);
+}
+
+test "materialize handles exact version match (no revision)" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        std.fs.deleteTreeAbsolute(prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+
+    try setupMaltDirs(testing.allocator, prefix);
+    try createBottleFixture(testing.allocator, prefix, "def456", "jq", "1.7.1");
+
+    const old_env = setMaltPrefix(prefix);
+    defer restoreMaltPrefix(old_env);
+
+    const keg = try cellar_mod.materializeWithCellar(
+        testing.allocator,
+        prefix,
+        "def456",
+        "jq",
+        "1.7.1",
+        ":any",
+    );
+    defer testing.allocator.free(keg.path);
+
+    var buf: [512]u8 = undefined;
+    const bin_path = try std.fmt.bufPrint(&buf, "{s}/bin/hello", .{keg.path});
+    try std.fs.accessAbsolute(bin_path, .{});
+}


### PR DESCRIPTION
## Summary
- Bottles with a Homebrew revision suffix (e.g. `10.47_1` for formula version `10.47`) produced a double-nested keg: `Cellar/pcre2/10.47/pcre2/10.47_1/lib/` instead of `Cellar/pcre2/10.47/lib/`
- Root cause: keg source path used the exact formula version, which didn't match the revision-suffixed directory inside the store — fallback cloned the entire store entry, preserving inner nesting
- Fix: after exact version match fails, scan `{store}/{name}/` for a `{version}_*` entry before falling back to store root

## Test plan
- [x] New test: revision suffix (`10.47_1`) produces flat keg with `bin/`, `lib/` at top level
- [x] New test: exact version match (no revision) still works
- [x] All existing tests pass
- [x] `zig fmt --check` passes