### PR TITLE
fix(cellar): always substitute @@HOMEBREW_*@@ placeholders in text files

### DIFF
--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -39,9 +39,9 @@ pub fn materialize(
 }
 
 /// Materialize with an explicit cellar type from the bottle metadata.
-/// When cellar_type is ":any" or ":any_skip_relocation", Mach-O patching
-/// and text-file prefix rewriting are skipped because the bottle is
-/// already relocatable.
+/// When cellar_type is ":any" or ":any_skip_relocation", Mach-O binary
+/// patching is skipped (relocatable bottle). Text placeholder substitution
+/// (@@HOMEBREW_PREFIX@@, @@HOMEBREW_CELLAR@@) always runs.
 pub fn materializeWithCellar(
     allocator: std.mem.Allocator,
     prefix: []const u8,
@@ -114,30 +114,32 @@ pub fn materializeWithCellar(
     const new_prefix = atomic.maltPrefix();
 
     // Relocatable bottles (cellar: ":any" or ":any_skip_relocation") do not
-    // need Mach-O patching or text-file prefix rewriting — they are built to
-    // work from any prefix without modification.
-    const skip_patching = std.mem.eql(u8, cellar_type, ":any") or
+    // need Mach-O binary patching — they are built to work from any prefix.
+    // However, @@HOMEBREW_PREFIX@@ / @@HOMEBREW_CELLAR@@ text placeholders
+    // must ALWAYS be substituted, even for relocatable bottles, because
+    // Homebrew performs this substitution unconditionally during bottle pour.
+    const skip_macho = std.mem.eql(u8, cellar_type, ":any") or
         std.mem.eql(u8, cellar_type, ":any_skip_relocation");
 
-    if (!skip_patching) {
-        // Build cellar replacement for @@HOMEBREW_CELLAR@@
-        var new_cellar_buf: [256]u8 = undefined;
-        const new_cellar = std.fmt.bufPrint(&new_cellar_buf, "{s}/Cellar", .{new_prefix}) catch new_prefix;
+    // Build cellar replacement for @@HOMEBREW_CELLAR@@
+    var new_cellar_buf: [256]u8 = undefined;
+    const new_cellar = std.fmt.bufPrint(&new_cellar_buf, "{s}/Cellar", .{new_prefix}) catch new_prefix;
 
+    if (!skip_macho) {
         // Walk cellar directory and patch each Mach-O binary
         patchAllMachO(allocator, cellar_path, new_prefix, new_cellar) catch
             return CellarError.PatchFailed;
-
-        // Patch text files (scripts, .pc files, configs).
-        // Failures here mean .pc files and scripts will have wrong prefixes,
-        // causing build/runtime errors for dependents. Warn but don't abort.
-        _ = patcher.patchTextFiles(allocator, cellar_path, "/opt/homebrew", new_prefix) catch |e| {
-            std.log.warn("text patching failed for {s}: {s}", .{ cellar_path, @errorName(e) });
-        };
-        _ = patcher.patchTextFiles(allocator, cellar_path, "/usr/local", new_prefix) catch |e| {
-            std.log.warn("text patching failed for {s}: {s}", .{ cellar_path, @errorName(e) });
-        };
     }
+
+    // Always patch text files — @@HOMEBREW_PREFIX@@ and @@HOMEBREW_CELLAR@@
+    // placeholders appear in scripts, .pc files, and configs regardless of
+    // whether the bottle is relocatable.
+    _ = patcher.patchTextFiles(allocator, cellar_path, "/opt/homebrew", new_prefix) catch |e| {
+        std.log.warn("text patching failed for {s}: {s}", .{ cellar_path, @errorName(e) });
+    };
+    _ = patcher.patchTextFiles(allocator, cellar_path, "/usr/local", new_prefix) catch |e| {
+        std.log.warn("text patching failed for {s}: {s}", .{ cellar_path, @errorName(e) });
+    };
 
     // Ad-hoc codesign on arm64. Without this, binaries won't execute on Apple Silicon.
     if (codesign.isArm64()) {

--- a/tests/cellar_test.zig
+++ b/tests/cellar_test.zig
@@ -1,9 +1,10 @@
 //! malt — cellar module tests
-//! Tests for keg materialization and directory flattening.
+//! Tests for keg materialization, placeholder substitution, and directory flattening.
 
 const std = @import("std");
 const testing = std.testing;
 const cellar_mod = @import("malt").cellar;
+const patcher = @import("malt").patcher;
 
 // libc setenv/unsetenv — available because tests link with libc
 const c = struct {
@@ -51,13 +52,21 @@ fn createBottleFixture(allocator: std.mem.Allocator, prefix: []const u8, sha: []
     defer allocator.free(script_path);
     {
         const f = try std.fs.createFileAbsolute(script_path, .{});
-        try f.writeAll("#!/bin/sh\necho hello\n");
+        try f.writeAll("#!/bin/sh\nprefix=@@HOMEBREW_PREFIX@@\ncellar=@@HOMEBREW_CELLAR@@\necho $prefix\n");
         f.close();
     }
 
     const lib_dir = try std.fmt.allocPrint(allocator, "{s}/lib", .{keg});
     defer allocator.free(lib_dir);
     try std.fs.makeDirAbsolute(lib_dir);
+
+    const pc_path = try std.fmt.allocPrint(allocator, "{s}/lib/test.pc", .{keg});
+    defer allocator.free(pc_path);
+    {
+        const f = try std.fs.createFileAbsolute(pc_path, .{});
+        try f.writeAll("prefix=@@HOMEBREW_PREFIX@@\nlibdir=${prefix}/lib\ncellar=@@HOMEBREW_CELLAR@@\n");
+        f.close();
+    }
 }
 
 fn setupMaltDirs(allocator: std.mem.Allocator, prefix: []const u8) !void {
@@ -69,8 +78,17 @@ fn setupMaltDirs(allocator: std.mem.Allocator, prefix: []const u8) !void {
     }
 }
 
+fn readFile(allocator: std.mem.Allocator, path: []const u8) ![]const u8 {
+    const file = try std.fs.openFileAbsolute(path, .{});
+    defer file.close();
+    const stat = try file.stat();
+    const buf = try allocator.alloc(u8, stat.size);
+    const n = try file.readAll(buf);
+    return buf[0..n];
+}
+
 // ---------------------------------------------------------------------------
-// Bug-2 tests: keg directory flattening (revision suffix handling)
+// Keg directory flattening (revision suffix handling)
 // ---------------------------------------------------------------------------
 
 test "materialize handles version with revision suffix" {
@@ -137,4 +155,204 @@ test "materialize handles exact version match (no revision)" {
     var buf: [512]u8 = undefined;
     const bin_path = try std.fmt.bufPrint(&buf, "{s}/bin/hello", .{keg.path});
     try std.fs.accessAbsolute(bin_path, .{});
+}
+
+// ---------------------------------------------------------------------------
+// Placeholder substitution for relocatable bottles
+// ---------------------------------------------------------------------------
+
+test "placeholder substitution runs for relocatable bottles" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        std.fs.deleteTreeAbsolute(prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+
+    try setupMaltDirs(testing.allocator, prefix);
+    try createBottleFixture(testing.allocator, prefix, "rel123", "stow", "2.4.1");
+
+    const old_env = setMaltPrefix(prefix);
+    defer restoreMaltPrefix(old_env);
+
+    const keg = try cellar_mod.materializeWithCellar(
+        testing.allocator,
+        prefix,
+        "rel123",
+        "stow",
+        "2.4.1",
+        ":any", // relocatable — the bug scenario
+    );
+    defer testing.allocator.free(keg.path);
+
+    var script_buf: [512]u8 = undefined;
+    const script_path = try std.fmt.bufPrint(&script_buf, "{s}/bin/hello", .{keg.path});
+    const content = try readFile(testing.allocator, script_path);
+    defer testing.allocator.free(content);
+
+    // Must NOT contain any unreplaced @@...@@ tokens
+    try testing.expect(std.mem.indexOf(u8, content, "@@HOMEBREW_PREFIX@@") == null);
+    try testing.expect(std.mem.indexOf(u8, content, "@@HOMEBREW_CELLAR@@") == null);
+
+    // Must contain the actual malt prefix
+    try testing.expect(std.mem.indexOf(u8, content, prefix) != null);
+}
+
+test "placeholder substitution replaces multiple tokens in single file" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        std.fs.deleteTreeAbsolute(prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+
+    try setupMaltDirs(testing.allocator, prefix);
+    try createBottleFixture(testing.allocator, prefix, "multi123", "pkg", "1.0");
+
+    const old_env = setMaltPrefix(prefix);
+    defer restoreMaltPrefix(old_env);
+
+    const keg = try cellar_mod.materializeWithCellar(
+        testing.allocator,
+        prefix,
+        "multi123",
+        "pkg",
+        "1.0",
+        "",
+    );
+    defer testing.allocator.free(keg.path);
+
+    var pc_buf: [512]u8 = undefined;
+    const pc_path = try std.fmt.bufPrint(&pc_buf, "{s}/lib/test.pc", .{keg.path});
+    const content = try readFile(testing.allocator, pc_path);
+    defer testing.allocator.free(content);
+
+    try testing.expect(std.mem.indexOf(u8, content, "@@HOMEBREW_PREFIX@@") == null);
+    try testing.expect(std.mem.indexOf(u8, content, "@@HOMEBREW_CELLAR@@") == null);
+
+    var cellar_str_buf: [256]u8 = undefined;
+    const expected_cellar = try std.fmt.bufPrint(&cellar_str_buf, "{s}/Cellar", .{prefix});
+    try testing.expect(std.mem.indexOf(u8, content, expected_cellar) != null);
+}
+
+test "files with no placeholders are left unchanged" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        std.fs.deleteTreeAbsolute(prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+
+    try setupMaltDirs(testing.allocator, prefix);
+
+    const keg_dir = try std.fmt.allocPrint(testing.allocator, "{s}/store/clean123/noop/1.0", .{prefix});
+    defer testing.allocator.free(keg_dir);
+    try std.fs.cwd().makePath(keg_dir);
+
+    const bin_dir = try std.fmt.allocPrint(testing.allocator, "{s}/bin", .{keg_dir});
+    defer testing.allocator.free(bin_dir);
+    try std.fs.makeDirAbsolute(bin_dir);
+
+    const file_path = try std.fmt.allocPrint(testing.allocator, "{s}/bin/clean", .{keg_dir});
+    defer testing.allocator.free(file_path);
+    {
+        const f = try std.fs.createFileAbsolute(file_path, .{});
+        try f.writeAll("#!/bin/sh\necho hello world\n");
+        f.close();
+    }
+
+    const old_env = setMaltPrefix(prefix);
+    defer restoreMaltPrefix(old_env);
+
+    const keg = try cellar_mod.materializeWithCellar(
+        testing.allocator,
+        prefix,
+        "clean123",
+        "noop",
+        "1.0",
+        ":any",
+    );
+    defer testing.allocator.free(keg.path);
+
+    var buf: [512]u8 = undefined;
+    const out_path = try std.fmt.bufPrint(&buf, "{s}/bin/clean", .{keg.path});
+    const content = try readFile(testing.allocator, out_path);
+    defer testing.allocator.free(content);
+
+    try testing.expectEqualStrings("#!/bin/sh\necho hello world\n", content);
+}
+
+test "binary files are skipped by text patching without error" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        std.fs.deleteTreeAbsolute(prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+
+    try setupMaltDirs(testing.allocator, prefix);
+
+    const keg_dir = try std.fmt.allocPrint(testing.allocator, "{s}/store/bin123/binpkg/1.0", .{prefix});
+    defer testing.allocator.free(keg_dir);
+    try std.fs.cwd().makePath(keg_dir);
+
+    const bin_dir = try std.fmt.allocPrint(testing.allocator, "{s}/bin", .{keg_dir});
+    defer testing.allocator.free(bin_dir);
+    try std.fs.makeDirAbsolute(bin_dir);
+
+    const file_path = try std.fmt.allocPrint(testing.allocator, "{s}/bin/fakemach", .{keg_dir});
+    defer testing.allocator.free(file_path);
+    {
+        const f = try std.fs.createFileAbsolute(file_path, .{});
+        try f.writeAll("\xcf\xfa\xed\xfe\x00\x00\x00@@HOMEBREW_PREFIX@@\x00more\x00binary");
+        f.close();
+    }
+
+    const old_env = setMaltPrefix(prefix);
+    defer restoreMaltPrefix(old_env);
+
+    const keg = try cellar_mod.materializeWithCellar(
+        testing.allocator,
+        prefix,
+        "bin123",
+        "binpkg",
+        "1.0",
+        ":any",
+    );
+    defer testing.allocator.free(keg.path);
+
+    var buf: [512]u8 = undefined;
+    const out_path = try std.fmt.bufPrint(&buf, "{s}/bin/fakemach", .{keg.path});
+    const content = try readFile(testing.allocator, out_path);
+    defer testing.allocator.free(content);
+
+    // Text patcher skips binary files (null bytes detected), so placeholder remains
+    try testing.expect(std.mem.indexOf(u8, content, "@@HOMEBREW_PREFIX@@") != null);
+}
+
+// ---------------------------------------------------------------------------
+// patchTextFiles direct test
+// ---------------------------------------------------------------------------
+
+test "patchTextFiles replaces all placeholder occurrences" {
+    const dir = try createTestDir(testing.allocator);
+    defer {
+        std.fs.deleteTreeAbsolute(dir) catch {};
+        testing.allocator.free(dir);
+    }
+
+    const file_path = try std.fmt.allocPrint(testing.allocator, "{s}/multi.txt", .{dir});
+    defer testing.allocator.free(file_path);
+    {
+        const f = try std.fs.createFileAbsolute(file_path, .{});
+        try f.writeAll("a=@@HOMEBREW_PREFIX@@\nb=@@HOMEBREW_PREFIX@@\nc=@@HOMEBREW_CELLAR@@\n");
+        f.close();
+    }
+
+    const count = try patcher.patchTextFiles(testing.allocator, dir, "/unused", "/opt/malt");
+    try testing.expect(count > 0);
+
+    const content = try readFile(testing.allocator, file_path);
+    defer testing.allocator.free(content);
+
+    try testing.expect(std.mem.indexOf(u8, content, "@@HOMEBREW_PREFIX@@") == null);
+    try testing.expect(std.mem.indexOf(u8, content, "@@HOMEBREW_CELLAR@@") == null);
+    try testing.expect(std.mem.indexOf(u8, content, "/opt/malt") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "/opt/malt/Cellar") != null);
 }


### PR DESCRIPTION
## Summary
- Relocatable bottles (`:any` / `:any_skip_relocation`) had `@@HOMEBREW_PREFIX@@` and `@@HOMEBREW_CELLAR@@` left as literal strings in scripts, .pc files, and configs
- Root cause: text-file placeholder substitution was inside the same conditional as Mach-O patching — both were skipped for relocatable bottles
- Fix: move `patchTextFiles()` outside the `skip_macho` gate so it always runs, matching Homebrew's behaviour

## Test plan
- [x] New test: relocatable bottle gets placeholders replaced
- [x] New test: multiple tokens in single file all substituted
- [x] New test: files with no placeholders left unchanged
- [x] New test: binary files (null bytes) skipped without error
- [x] New test: `patchTextFiles` replaces all occurrences directly
- [x] All existing tests pass
- [x] `zig fmt --check` passes