### PR TITLE
feat(install): download progress bars and materialize spinner

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -59,6 +59,8 @@ pub fn build(b: *std.Build) void {
         "tests/version_update_test.zig",
         "tests/cask_test.zig",
         "tests/cellar_test.zig",
+        "tests/progress_test.zig",
+        "tests/progress_e2e_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -18,6 +18,7 @@ const ghcr_mod = @import("../net/ghcr.zig");
 const api_mod = @import("../net/api.zig");
 const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
+const progress_mod = @import("../ui/progress.zig");
 const help = @import("help.zig");
 
 pub const InstallError = error{
@@ -46,10 +47,31 @@ const DownloadJob = struct {
     /// Cellar type from bottle metadata (e.g. ":any", ":any_skip_relocation").
     /// Used to skip Mach-O patching for relocatable bottles.
     cellar_type: []const u8,
+    /// Alignment width for progress bar labels (max name length across all jobs).
+    label_width: u8,
+    /// Line index within the multi-progress group.
+    line_index: u8,
+    /// Shared multi-progress state for coordinated rendering.
+    multi: ?*progress_mod.MultiProgress,
+    /// Progress bar owned by the main thread. Created before workers are spawned
+    /// so every reserved line is drawn immediately, avoiding an empty row when a
+    /// later worker thread is scheduled before an earlier one.
+    bar: ?*progress_mod.ProgressBar,
     /// Set after download completes
     store_sha256: []const u8,
     succeeded: bool,
 };
+
+/// Bridge between ProgressCallback and ProgressBar.
+fn progressBridge(ctx: *anyopaque, bytes_so_far: u64, content_length: ?u64) void {
+    const bar: *progress_mod.ProgressBar = @ptrCast(@alignCast(ctx));
+    if (content_length) |total| {
+        if (bar.total == 0) bar.total = total;
+    }
+    // Clamp to total to prevent >100% when Content-Length reflects compressed size
+    const clamped = if (bar.total > 0) @min(bytes_so_far, bar.total) else bytes_so_far;
+    bar.update(clamped);
+}
 
 /// Download a bottle and commit to store. Runs in a worker thread.
 fn downloadWorker(_: std.mem.Allocator, ghcr: *ghcr_mod.GhcrClient, store: *store_mod.Store, job: *DownloadJob) void {
@@ -83,15 +105,24 @@ fn downloadWorker(_: std.mem.Allocator, ghcr: *ghcr_mod.GhcrClient, store: *stor
     // Create temp dir
     const tmp_dir = atomic.createTempDir(allocator, job.name) catch return;
 
-    output.info("  Downloading {s}...", .{job.name});
+    // The progress bar was created and pre-rendered by the main thread so that
+    // every reserved line has content even before this worker starts producing
+    // bytes. We just feed updates into it via the progress callback.
+    const bar = job.bar orelse return;
+    const progress_cb = client_mod.ProgressCallback{
+        .context = @ptrCast(bar),
+        .func = &progressBridge,
+    };
 
     // Download
-    _ = bottle_mod.download(allocator, ghcr, repo, digest, job.sha256, tmp_dir) catch {
+    _ = bottle_mod.download(allocator, ghcr, repo, digest, job.sha256, tmp_dir, progress_cb) catch {
+        bar.finish();
         output.err("  Download failed: {s}", .{job.name});
         atomic.cleanupTempDir(tmp_dir);
         allocator.free(tmp_dir);
         return;
     };
+    bar.finish();
 
     // Commit to store
     store.commitFrom(job.sha256, tmp_dir) catch {
@@ -105,7 +136,6 @@ fn downloadWorker(_: std.mem.Allocator, ghcr: *ghcr_mod.GhcrClient, store: *stor
         std.log.warn("refcount increment failed for {s}: {s}", .{ job.sha256, @errorName(e) });
     };
 
-    output.info("  Downloaded {s} ✓", .{job.name});
     job.store_sha256 = job.sha256;
     job.succeeded = true;
 }
@@ -265,6 +295,17 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     // ── Parallel download phase ──────────────────────────────────────
+
+    // Compute max label width for aligned progress bars
+    var max_name_len: u8 = 0;
+    for (all_jobs.items) |job| {
+        const len: u8 = @intCast(@min(job.name.len, 255));
+        if (len > max_name_len) max_name_len = len;
+    }
+    for (all_jobs.items) |*job| {
+        job.label_width = max_name_len;
+    }
+
     var to_download: u32 = 0;
     for (all_jobs.items) |*job| {
         if (store.exists(job.sha256)) {
@@ -276,14 +317,55 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     if (to_download > 0) {
-        output.info("Downloading {d} bottle(s)...", .{to_download});
+        if (to_download == 1) {
+            output.info("Downloading 1 bottle...", .{});
+        } else {
+            output.info("Downloading {d} bottles...", .{to_download});
+        }
+
+        // Set up multi-progress: assign line indices and create coordinator
+        var download_index: u8 = 0;
+        for (all_jobs.items) |*job| {
+            if (!job.succeeded) {
+                job.line_index = download_index;
+                download_index += 1;
+            }
+        }
+        var multi = progress_mod.MultiProgress.init(download_index);
+
+        // Allocate all progress bars in the main thread so we can render an
+        // initial frame on every reserved line BEFORE spawning workers. This
+        // avoids a blank row when a later worker thread is scheduled before
+        // an earlier one. Bars live in a stable slice so the pointers we
+        // hand to worker threads remain valid.
+        var bars: []progress_mod.ProgressBar = &.{};
+        if (allocator.alloc(progress_mod.ProgressBar, download_index)) |s| {
+            bars = s;
+        } else |_| {}
+        defer if (bars.len > 0) allocator.free(bars);
+
+        var bar_idx: usize = 0;
+        for (all_jobs.items) |*job| {
+            if (job.succeeded) continue;
+            job.multi = &multi;
+            if (bar_idx < bars.len) {
+                bars[bar_idx] = progress_mod.ProgressBar.init(job.name, 0);
+                bars[bar_idx].label_width = max_name_len;
+                bars[bar_idx].line_index = job.line_index;
+                bars[bar_idx].multi = &multi;
+                job.bar = &bars[bar_idx];
+                // Draw the initial frame now so this line is not blank while
+                // the worker is waiting to be scheduled.
+                bars[bar_idx].update(0);
+                bar_idx += 1;
+            }
+        }
 
         var threads: std.ArrayList(std.Thread) = .empty;
         defer threads.deinit(allocator);
 
         for (all_jobs.items) |*job| {
             if (job.succeeded) {
-                output.info("  {s} (cached)", .{job.name});
                 continue;
             }
             const t = std.Thread.spawn(.{}, downloadWorker, .{
@@ -299,6 +381,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         }
 
         for (threads.items) |t| t.join();
+        multi.finish();
     }
 
     // Check for Ctrl-C between download and materialize phases
@@ -389,6 +472,10 @@ fn collectFormulaJobs(
             .keg_only = dep_formula.keg_only,
             .formula_json = dep_json,
             .cellar_type = dep_bottle.cellar,
+            .label_width = 0,
+            .line_index = 0,
+            .multi = null,
+            .bar = null,
             .store_sha256 = "",
             .succeeded = false,
         }) catch continue;
@@ -409,6 +496,10 @@ fn collectFormulaJobs(
         .keg_only = formula.keg_only,
         .formula_json = formula_json,
         .cellar_type = bottle.cellar,
+        .label_width = 0,
+        .line_index = 0,
+        .multi = null,
+        .bar = null,
         .store_sha256 = "",
         .succeeded = false,
     }) catch return InstallError.DownloadFailed;
@@ -419,7 +510,8 @@ fn collectFormulaJobs(
         output.warn("The package may not work correctly without it. Consider: brew install {s}", .{formula.name});
     }
 
-    output.info("Resolved {s} {s} ({d} packages)", .{ formula.name, formula.version, jobs.items.len });
+    const pkg_word: []const u8 = if (jobs.items.len == 1) "package" else "packages";
+    output.info("Resolved {s} {s} ({d} {s})", .{ formula.name, formula.version, jobs.items.len, pkg_word });
 }
 
 /// Materialize a downloaded bottle to the cellar, link, and record in DB.
@@ -432,7 +524,14 @@ fn materializeAndLink(
 ) void {
     const reason: []const u8 = if (job.is_dep) "dependency" else "direct";
 
-    output.info("Materializing {s} to cellar...", .{job.name});
+    // Animated spinner while materialize runs. Materialize is synchronous and
+    // can take a while for large packages (e.g. ansible), so a background-
+    // animated spinner gives clearer "still working" feedback than a static line.
+    var msg_buf: [256]u8 = undefined;
+    const msg = std.fmt.bufPrint(&msg_buf, "Materializing {s} to cellar...", .{job.name}) catch "Materializing...";
+    var spinner = progress_mod.Spinner.init(msg);
+    spinner.start();
+
     const keg = cellar_mod.materializeWithCellar(
         allocator,
         prefix,
@@ -441,9 +540,11 @@ fn materializeAndLink(
         job.version_str,
         job.cellar_type,
     ) catch {
+        spinner.stop();
         output.err("Failed to materialize {s}", .{job.name});
         return;
     };
+    spinner.stop();
     // Parse formula for DB recording
     var formula = formula_mod.parseFormula(allocator, job.formula_json) catch {
         output.err("Failed to parse formula for {s}", .{job.name});
@@ -549,10 +650,19 @@ fn installCask(
     const prefix = atomic.maltPrefix();
     var installer = cask_mod.CaskInstaller.init(allocator, db, prefix);
 
+    // Progress bar for cask download
+    var bar = progress_mod.ProgressBar.init(cask.token, 0);
+    installer.progress = .{
+        .context = @ptrCast(&bar),
+        .func = &progressBridge,
+    };
+
     const app_path = installer.install(&cask) catch {
+        bar.finish();
         output.err("Failed to install cask {s}", .{cask.token});
         return InstallError.CaskNotFound;
     };
+    bar.finish();
 
     // Record in DB with install path
     cask_mod.recordInstall(db, &cask, app_path) catch {

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -344,7 +344,7 @@ fn downloadBottle(
     output.info("    Downloading {s}...", .{name});
 
     // Download
-    _ = bottle_mod.download(allocator, ghcr, repo, digest, sha256, tmp_dir) catch {
+    _ = bottle_mod.download(allocator, ghcr, repo, digest, sha256, tmp_dir, null) catch {
         output.err("    Download failed: {s}", .{name});
         atomic.cleanupTempDir(tmp_dir);
         allocator.free(tmp_dir);

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -118,7 +118,7 @@ fn ephemeralRun(
 
     // Download
     output.info("Downloading {s} {s}...", .{ pkg_name, formula.version });
-    _ = bottle_mod.download(allocator, &ghcr, repo, digest, bottle.sha256, tmp_dir) catch {
+    _ = bottle_mod.download(allocator, &ghcr, repo, digest, bottle.sha256, tmp_dir, null) catch {
         output.err("Failed to download {s}", .{pkg_name});
         return;
     };

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -193,7 +193,7 @@ fn upgradeFormula(
         };
 
         output.info("  Downloading {s}...", .{name});
-        _ = bottle_mod.download(allocator, &ghcr, repo, digest, bottle.sha256, tmp_dir) catch {
+        _ = bottle_mod.download(allocator, &ghcr, repo, digest, bottle.sha256, tmp_dir, null) catch {
             output.err("  Download failed: {s}", .{name});
             atomic.cleanupTempDir(tmp_dir);
             allocator.free(tmp_dir);
@@ -212,7 +212,7 @@ fn upgradeFormula(
     }
 
     // Step 5: Materialize new version to Cellar
-    output.info("Materializing {s} to cellar...", .{name});
+    output.dim("Materializing {s} to cellar...", .{name});
     const new_keg = cellar_mod.materialize(
         allocator,
         prefix,

--- a/src/core/bottle.zig
+++ b/src/core/bottle.zig
@@ -2,9 +2,11 @@
 //! Bottle download, SHA256 verification, and extraction pipeline.
 
 const std = @import("std");
-const ghcr_mod = @import("../net/ghcr.zig");
-const atomic = @import("../fs/atomic.zig");
+
 const archive = @import("../fs/archive.zig");
+const atomic = @import("../fs/atomic.zig");
+const client_mod = @import("../net/client.zig");
+const ghcr_mod = @import("../net/ghcr.zig");
 
 pub const BottleError = error{
     DownloadFailed,
@@ -28,12 +30,13 @@ pub fn download(
     digest: []const u8,
     expected_sha256: []const u8,
     dest_dir: []const u8,
+    progress: ?client_mod.ProgressCallback,
 ) BottleError!BottleResult {
     // Download blob into memory
     var body: std.ArrayList(u8) = .empty;
     defer body.deinit(allocator);
 
-    ghcr.downloadBlob(allocator, repo, digest, &body) catch return BottleError.DownloadFailed;
+    ghcr.downloadBlob(allocator, repo, digest, &body, progress) catch return BottleError.DownloadFailed;
 
     // Compute SHA256 of downloaded data
     var hash: [32]u8 = undefined;

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -2,6 +2,7 @@
 //! Cask JSON parsing and installation (DMG, PKG, ZIP).
 
 const std = @import("std");
+
 const sqlite = @import("../db/sqlite.zig");
 const client_mod = @import("../net/client.zig");
 
@@ -127,9 +128,10 @@ pub const CaskInstaller = struct {
     allocator: std.mem.Allocator,
     prefix: [:0]const u8,
     db: *sqlite.Database,
+    progress: ?client_mod.ProgressCallback,
 
     pub fn init(allocator: std.mem.Allocator, db: *sqlite.Database, prefix: [:0]const u8) CaskInstaller {
-        return .{ .allocator = allocator, .db = db, .prefix = prefix };
+        return .{ .allocator = allocator, .db = db, .prefix = prefix, .progress = null };
     }
 
     /// Install a cask. Downloads, verifies SHA256, and installs based on artifact type.
@@ -148,7 +150,7 @@ pub const CaskInstaller = struct {
         };
 
         // Download to cache
-        const cache_path = self.downloadToCache(cask, cache_dir) catch
+        const cache_path = self.downloadToCache(cask, cache_dir, self.progress) catch
             return CaskError.DownloadFailed;
         errdefer {
             std.fs.cwd().deleteFile(cache_path) catch {};
@@ -237,7 +239,7 @@ pub const CaskInstaller = struct {
 
     // --- Private helpers ---
 
-    fn downloadToCache(self: *CaskInstaller, cask: *const Cask, cache_dir: []const u8) ![]const u8 {
+    fn downloadToCache(self: *CaskInstaller, cask: *const Cask, cache_dir: []const u8, progress: ?client_mod.ProgressCallback) ![]const u8 {
         const ext_str = switch (artifactTypeFromUrl(cask.url)) {
             .dmg => ".dmg",
             .zip => ".zip",
@@ -251,7 +253,7 @@ pub const CaskInstaller = struct {
         var http = client_mod.HttpClient.init(self.allocator);
         defer http.deinit();
 
-        var resp = try http.getWithHeaders(cask.url, &.{});
+        var resp = try http.getWithHeaders(cask.url, &.{}, progress);
         defer resp.deinit();
 
         if (resp.status != 200) return error.DownloadFailed;

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -1,19 +1,22 @@
 //! malt — shared library root for test imports.
 //! Re-exports all modules that tests need to access.
 
-pub const formula = @import("core/formula.zig");
-pub const store = @import("core/store.zig");
-pub const linker = @import("core/linker.zig");
-pub const cellar = @import("core/cellar.zig");
 pub const cask = @import("core/cask.zig");
+pub const cellar = @import("core/cellar.zig");
 pub const deps = @import("core/deps.zig");
-pub const sqlite = @import("db/sqlite.zig");
-pub const schema = @import("db/schema.zig");
+pub const formula = @import("core/formula.zig");
+pub const linker = @import("core/linker.zig");
+pub const store = @import("core/store.zig");
 pub const lock = @import("db/lock.zig");
+pub const schema = @import("db/schema.zig");
+pub const sqlite = @import("db/sqlite.zig");
+pub const atomic = @import("fs/atomic.zig");
+pub const clonefile = @import("fs/clonefile.zig");
+pub const codesign = @import("macho/codesign.zig");
 pub const parser = @import("macho/parser.zig");
 pub const patcher = @import("macho/patcher.zig");
-pub const codesign = @import("macho/codesign.zig");
 pub const api = @import("net/api.zig");
-pub const clonefile = @import("fs/clonefile.zig");
-pub const atomic = @import("fs/atomic.zig");
+pub const client = @import("net/client.zig");
+pub const output = @import("ui/output.zig");
+pub const progress = @import("ui/progress.zig");
 pub const version = @import("version.zig");

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -1,5 +1,17 @@
 const std = @import("std");
 
+/// Optional progress reporting for long downloads.
+/// `bytes_so_far`: total bytes received so far (after decompression).
+/// `content_length`: total expected bytes from HTTP header, or null if unknown.
+pub const ProgressCallback = struct {
+    context: *anyopaque,
+    func: *const fn (context: *anyopaque, bytes_so_far: u64, content_length: ?u64) void,
+
+    pub fn report(self: ProgressCallback, bytes_so_far: u64, content_length: ?u64) void {
+        self.func(self.context, bytes_so_far, content_length);
+    }
+};
+
 pub const Response = struct {
     status: u16,
     body: []const u8,
@@ -62,8 +74,9 @@ pub const HttpClient = struct {
         self: *HttpClient,
         url: []const u8,
         extra_headers: []const std.http.Header,
+        progress: ?ProgressCallback,
     ) !Response {
-        return self.doGetWithRetry(url, extra_headers, MAX_BLOB_BYTES);
+        return self.doGetWithRetry(url, extra_headers, MAX_BLOB_BYTES, progress);
     }
 
     /// Perform a HEAD request and return only the HTTP status code.
@@ -96,12 +109,57 @@ pub const HttpClient = struct {
     const MAX_RETRIES = 3;
     const RETRY_DELAYS_MS = [_]u64{ 1000, 2000, 4000 };
 
+    /// Writer wrapper that counts bytes written and fires a progress callback.
+    /// Delegates all writes to the inner Allocating writer while tracking byte count.
+    const CountingWriter = struct {
+        inner: *std.Io.Writer.Allocating,
+        bytes_written: u64,
+        progress: ProgressCallback,
+        content_length: ?u64,
+        writer: std.Io.Writer = .{
+            .buffer = &.{},
+            .vtable = &.{
+                .drain = drain,
+                .sendFile = sendFile,
+                .flush = flush,
+                .rebase = rebase,
+            },
+        },
+
+        fn drain(w: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
+            const self: *CountingWriter = @fieldParentPtr("writer", w);
+            const n = self.inner.writer.vtable.drain(&self.inner.writer, data, splat) catch
+                return error.WriteFailed;
+            self.bytes_written += n;
+            self.progress.report(self.bytes_written, self.content_length);
+            return n;
+        }
+
+        fn sendFile(w: *std.Io.Writer, file_reader: *std.fs.File.Reader, limit: std.io.Limit) std.Io.Writer.FileError!usize {
+            const self: *CountingWriter = @fieldParentPtr("writer", w);
+            const n = self.inner.writer.vtable.sendFile(&self.inner.writer, file_reader, limit) catch |e| return e;
+            self.bytes_written += n;
+            self.progress.report(self.bytes_written, self.content_length);
+            return n;
+        }
+
+        fn flush(w: *std.Io.Writer) std.Io.Writer.Error!void {
+            const self: *CountingWriter = @fieldParentPtr("writer", w);
+            return self.inner.writer.vtable.flush(&self.inner.writer);
+        }
+
+        fn rebase(w: *std.Io.Writer, preserve: usize, capacity: usize) std.Io.Writer.Error!void {
+            const self: *CountingWriter = @fieldParentPtr("writer", w);
+            return self.inner.writer.vtable.rebase(&self.inner.writer, preserve, capacity);
+        }
+    };
+
     fn doGet(
         self: *HttpClient,
         url: []const u8,
         extra_headers: []const std.http.Header,
     ) !Response {
-        return self.doGetWithRetry(url, extra_headers, MAX_METADATA_BYTES);
+        return self.doGetWithRetry(url, extra_headers, MAX_METADATA_BYTES, null);
     }
 
     fn doGetWithRetry(
@@ -109,10 +167,11 @@ pub const HttpClient = struct {
         url: []const u8,
         extra_headers: []const std.http.Header,
         max_bytes: usize,
+        progress: ?ProgressCallback,
     ) !Response {
         var attempt: usize = 0;
         while (true) {
-            const result = self.doGetLimited(url, extra_headers, max_bytes);
+            const result = self.doGetLimited(url, extra_headers, max_bytes, progress);
             if (result) |resp| {
                 // Retry on transient server errors
                 if (resp.status == 429 or resp.status == 503 or resp.status == 504) {
@@ -141,6 +200,7 @@ pub const HttpClient = struct {
         url: []const u8,
         extra_headers: []const std.http.Header,
         max_bytes: usize,
+        progress: ?ProgressCallback,
     ) !Response {
         const uri = try std.Uri.parse(url);
 
@@ -155,6 +215,10 @@ pub const HttpClient = struct {
         var response = try req.receiveHead(&redirect_buf);
 
         const status: u16 = @intFromEnum(response.head.status);
+
+        // Content-Length from HTTP headers (may be null for chunked transfer).
+        // Note: this reflects the *compressed* size when content-encoding is set.
+        const content_length: ?u64 = response.head.content_length;
 
         // Read response body with decompression (servers may send gzip).
         // Enforce MAX_RESPONSE_BYTES to prevent OOM from oversized responses.
@@ -176,7 +240,7 @@ pub const HttpClient = struct {
 
         // Timeout watchdog: closes the underlying connection if the read
         // stalls beyond the deadline. This is the only reliable way to
-        // abort a blocking streamRemaining call.
+        // abort a blocking read call.
         const effective_timeout = if (max_bytes > MAX_METADATA_BYTES) BLOB_TIMEOUT_NS else self.timeout_ns;
         var request_done = std.atomic.Value(bool).init(false);
         const watchdog = std.Thread.spawn(.{}, watchdogFn, .{
@@ -189,18 +253,31 @@ pub const HttpClient = struct {
             if (watchdog) |w| w.join();
         }
 
-        // Read the full response body. streamRemaining handles internal
-        // buffering and decompression (gzip/deflate/zstd) correctly.
-        const total_read = body_reader.streamRemaining(&body_writer.writer) catch |e| switch (e) {
-            error.WriteFailed => return error.ReadFailed,
-            error.ReadFailed => return error.ReadFailed,
-        };
+        // Read the full response body with optional progress reporting.
+        // When a progress callback is provided, we wrap the writer to count bytes.
+        if (progress) |p| {
+            var counting = CountingWriter{
+                .inner = &body_writer,
+                .bytes_written = 0,
+                .progress = p,
+                .content_length = content_length,
+            };
+            const total_read = body_reader.streamRemaining(&counting.writer) catch |e| switch (e) {
+                error.WriteFailed => return error.ReadFailed,
+                error.ReadFailed => return error.ReadFailed,
+            };
 
-        // Signal watchdog that we finished before timeout
-        request_done.store(true, .release);
+            request_done.store(true, .release);
+            if (total_read >= max_bytes) return error.ResponseTooLarge;
+        } else {
+            const total_read = body_reader.streamRemaining(&body_writer.writer) catch |e| switch (e) {
+                error.WriteFailed => return error.ReadFailed,
+                error.ReadFailed => return error.ReadFailed,
+            };
 
-        // If we read more than the limit, the response is too large.
-        if (total_read >= max_bytes) return error.ResponseTooLarge;
+            request_done.store(true, .release);
+            if (total_read >= max_bytes) return error.ResponseTooLarge;
+        }
 
         const body = try body_writer.toOwnedSlice();
 

--- a/src/net/ghcr.zig
+++ b/src/net/ghcr.zig
@@ -2,6 +2,7 @@
 //! Token management and blob fetching for GitHub Container Registry.
 
 const std = @import("std");
+
 const client_mod = @import("client.zig");
 
 pub const GhcrError = error{
@@ -88,6 +89,7 @@ pub const GhcrClient = struct {
         repo: []const u8,
         digest: []const u8,
         body_out: *std.ArrayList(u8),
+        progress: ?client_mod.ProgressCallback,
     ) GhcrError!void {
         // Get token through the mutex-protected cache (avoids redundant fetches)
         const token = self.fetchToken(repo) catch return GhcrError.TokenFetchFailed;
@@ -110,7 +112,7 @@ pub const GhcrClient = struct {
             .{ .name = "Authorization", .value = auth_value },
         };
 
-        var resp = http.getWithHeaders(url, &headers) catch
+        var resp = http.getWithHeaders(url, &headers, progress) catch
             return GhcrError.DownloadFailed;
         defer resp.deinit();
 

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -110,6 +110,25 @@ pub fn err(comptime fmt: []const u8, args: anytype) void {
     f.writeAll("\n") catch {};
 }
 
+/// Print a dim/faint info message for low-priority status lines.
+pub fn dim(comptime fmt: []const u8, args: anytype) void {
+    if (quiet) return;
+    var buf: [4096]u8 = undefined;
+    const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
+    const f = std.fs.File.stderr();
+    const prefix: []const u8 = if (color.isEmojiEnabled()) "  ▸ " else "  > ";
+    if (color.isColorEnabled()) {
+        f.writeAll(color.Style.dim.code()) catch {};
+        f.writeAll(prefix) catch {};
+        f.writeAll(msg) catch {};
+        f.writeAll(color.Style.reset.code()) catch {};
+    } else {
+        f.writeAll(prefix) catch {};
+        f.writeAll(msg) catch {};
+    }
+    f.writeAll("\n") catch {};
+}
+
 /// Write JSON to stdout
 pub fn jsonOutput(allocator: std.mem.Allocator, value: anytype) !void {
     var list: std.ArrayList(u8) = .empty;

--- a/src/ui/progress.zig
+++ b/src/ui/progress.zig
@@ -1,64 +1,251 @@
 //! malt — progress module
-//! Terminal progress bar rendering.
+//! Terminal progress bar rendering with multi-line support.
 
 const std = @import("std");
-const output = @import("output.zig");
+
 const color = @import("color.zig");
+const output = @import("output.zig");
+
+/// Braille-based spinner frames, shared by ProgressBar and Spinner.
+const spinner_chars = [_][]const u8{ "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" };
+
+/// Coordinates multiple progress bars on separate terminal lines.
+/// Reserves N lines upfront, then uses ANSI cursor movement so each
+/// bar updates its own line without interfering with others.
+pub const MultiProgress = struct {
+    total_lines: u8,
+    mutex: std.Thread.Mutex,
+    is_tty: bool,
+
+    pub fn init(count: u8) MultiProgress {
+        const stderr = std.fs.File.stderr();
+        const tty = stderr.supportsAnsiEscapeCodes();
+
+        // Hide cursor, disable autowrap, reserve lines by printing empty placeholders.
+        // Autowrap is disabled so that if a bar row exceeds the terminal width, the
+        // overflow is clipped at the right edge instead of flowing onto a second
+        // visual line — wrapping would break the ESC[NA cursor-up math that each
+        // bar uses to update its dedicated line.
+        if (tty and !output.isQuiet()) {
+            stderr.writeAll("\x1b[?25l") catch {}; // hide cursor
+            stderr.writeAll("\x1b[?7l") catch {}; // disable autowrap
+            var i: u8 = 0;
+            while (i < count) : (i += 1) {
+                stderr.writeAll("\n") catch {};
+            }
+        }
+
+        return .{
+            .total_lines = count,
+            .mutex = .{},
+            .is_tty = tty,
+        };
+    }
+
+    /// Restore cursor, autowrap, and reset to column 0 after all bars are done.
+    /// Must be called after all download threads have joined.
+    pub fn finish(self: *MultiProgress) void {
+        if (self.is_tty and !output.isQuiet()) {
+            const stderr = std.fs.File.stderr();
+            stderr.writeAll("\x1b[?7h") catch {}; // re-enable autowrap
+            stderr.writeAll("\x1b[?25h\r") catch {}; // show cursor + column 0
+        }
+    }
+};
 
 pub const ProgressBar = struct {
     label: []const u8,
     total: u64,
     current: u64,
     last_render_ns: i128,
+    start_time_ms: i64,
+    spinner_frame: u8,
+    is_tty: bool,
+    /// Minimum label column width for alignment across multiple bars.
+    label_width: u8,
+    /// Line index within a MultiProgress group (0 = topmost bar).
+    line_index: u8,
+    /// Shared multi-progress state (null for standalone bars).
+    multi: ?*MultiProgress,
 
     const render_interval_ns: i128 = 100 * std.time.ns_per_ms; // 10 Hz max
     const bar_width: u64 = 30;
 
     pub fn init(label: []const u8, total: u64) ProgressBar {
+        const stderr = std.fs.File.stderr();
         return .{
             .label = label,
             .total = total,
             .current = 0,
             .last_render_ns = 0,
+            .start_time_ms = std.time.milliTimestamp(),
+            .spinner_frame = 0,
+            .is_tty = stderr.supportsAnsiEscapeCodes(),
+            .label_width = 0,
+            .line_index = 0,
+            .multi = null,
         };
     }
 
     pub fn update(self: *ProgressBar, current: u64) void {
         self.current = current;
-        if (output.isQuiet()) return;
+        if (output.isQuiet() or !self.is_tty) return;
 
         const now = std.time.nanoTimestamp();
         if (now - self.last_render_ns < render_interval_ns) return;
         self.last_render_ns = now;
+
         self.render();
     }
 
     pub fn finish(self: *ProgressBar) void {
-        if (output.isQuiet()) return;
-        self.current = self.total;
+        if (output.isQuiet() or !self.is_tty) return;
+        if (self.total > 0) {
+            self.current = self.total;
+        }
         self.render();
-        std.fs.File.stderr().writeAll("\n") catch {};
+        // For standalone bars (no multi), emit a newline
+        if (self.multi == null) {
+            std.fs.File.stderr().writeAll("\n") catch {};
+        }
     }
 
-    fn render(self: *const ProgressBar) void {
+    fn render(self: *ProgressBar) void {
+        // Advance the animation frame on every render tick. Both determinate
+        // and indeterminate bars use this to animate the spinner glyph in
+        // front of the label.
+        self.spinner_frame +%= 1;
+
+        if (self.total > 0) {
+            self.renderDeterminate();
+        } else {
+            self.renderIndeterminate();
+        }
+    }
+
+    /// Return the glyph shown in front of the label: a spinner frame while
+    /// work is in progress, or a checkmark once the bar has reached 100%.
+    /// The spinner uses Braille Pattern chars (not emoji); only the done
+    /// glyph has an ASCII fallback to match `output.success()` in no-emoji mode.
+    fn glyph(self: *const ProgressBar) []const u8 {
+        const done = self.total > 0 and self.current >= self.total;
+        if (done) {
+            return if (color.isEmojiEnabled()) "\xe2\x9c\x93" else "*"; // ✓
+        }
+        return spinner_chars[self.spinner_frame % spinner_chars.len];
+    }
+
+    fn computeRate(self: *const ProgressBar) f64 {
+        const now_ms = std.time.milliTimestamp();
+        const elapsed_ms = now_ms - self.start_time_ms;
+        if (elapsed_ms <= 0) return 0;
+        return @as(f64, @floatFromInt(self.current)) / (@as(f64, @floatFromInt(elapsed_ms)) / 1000.0);
+    }
+
+    pub fn formatRate(buf: []u8, rate: f64) []const u8 {
+        if (rate <= 0) return "--";
+        const rate_kb = rate / 1024.0;
+        if (rate_kb >= 1024.0) {
+            return std.fmt.bufPrint(buf, "{d:.1} MB/s", .{rate_kb / 1024.0}) catch return "--";
+        }
+        return std.fmt.bufPrint(buf, "{d:.0} KB/s", .{rate_kb}) catch return "--";
+    }
+
+    pub fn formatEta(buf: []u8, remaining_bytes: u64, rate: f64) []const u8 {
+        if (rate <= 0) return "";
+        const eta_secs: u64 = @intFromFloat(@as(f64, @floatFromInt(remaining_bytes)) / rate);
+        if (eta_secs > 3600) return "";
+        if (eta_secs >= 60) {
+            return std.fmt.bufPrint(buf, "ETA {d}m{d:0>2}s", .{ eta_secs / 60, eta_secs % 60 }) catch return "";
+        }
+        return std.fmt.bufPrint(buf, "ETA {d}s", .{eta_secs}) catch return "";
+    }
+
+    fn writeLabel(self: *const ProgressBar, buf: []u8, start_pos: usize) usize {
+        var pos = start_pos;
+
+        // "  " indent to align with output.info() style
+        buf[pos] = ' ';
+        pos += 1;
+        buf[pos] = ' ';
+        pos += 1;
+
+        // Glyph: animated spinner while in progress, green ✓ when done.
+        const done = self.total > 0 and self.current >= self.total;
+        const use_color = color.isColorEnabled();
+        const g = self.glyph();
+
+        if (use_color) {
+            const c = if (done) color.Style.green.code() else color.Style.cyan.code();
+            @memcpy(buf[pos .. pos + c.len], c);
+            pos += c.len;
+        }
+        @memcpy(buf[pos .. pos + g.len], g);
+        pos += g.len;
+        if (use_color) {
+            const reset_code = color.Style.reset.code();
+            @memcpy(buf[pos .. pos + reset_code.len], reset_code);
+            pos += reset_code.len;
+        }
+        buf[pos] = ' ';
+        pos += 1;
+
+        // Label
+        const label_len = self.label.len;
+        @memcpy(buf[pos .. pos + label_len], self.label);
+        pos += label_len;
+
+        if (self.label_width > 0 and label_len < self.label_width) {
+            const pad = self.label_width - @as(u8, @intCast(@min(label_len, 255)));
+            @memset(buf[pos .. pos + pad], ' ');
+            pos += pad;
+        }
+
+        buf[pos] = ' ';
+        pos += 1;
+
+        return pos;
+    }
+
+    /// Write ANSI escape to move cursor up `n` lines.
+    fn writeCursorUp(buf: []u8, pos: usize, n: u8) usize {
+        if (n == 0) return pos;
+        const seq = std.fmt.bufPrint(buf[pos..], "\x1b[{d}A", .{n}) catch return pos;
+        return pos + seq.len;
+    }
+
+    /// Write ANSI escape to move cursor down `n` lines.
+    fn writeCursorDown(buf: []u8, pos: usize, n: u8) usize {
+        if (n == 0) return pos;
+        const seq = std.fmt.bufPrint(buf[pos..], "\x1b[{d}B", .{n}) catch return pos;
+        return pos + seq.len;
+    }
+
+    fn renderDeterminate(self: *const ProgressBar) void {
         const f = std.fs.File.stderr();
         const pct: u64 = if (self.total > 0) @min((self.current * 100) / self.total, 100) else 0;
         const filled: u64 = if (self.total > 0) @min((self.current * bar_width) / self.total, bar_width) else 0;
         const empty = bar_width - filled;
 
-        var buf: [512]u8 = undefined;
+        // Lock mutex if part of a MultiProgress group
+        if (self.multi) |mp| mp.mutex.lock();
+        defer if (self.multi) |mp| mp.mutex.unlock();
+
+        var buf: [768]u8 = undefined;
         var pos: usize = 0;
 
-        // Carriage return to overwrite line
+        // For multi-progress: move cursor up to our line
+        const move_up: u8 = if (self.multi) |mp| mp.total_lines - self.line_index else 0;
+        pos = writeCursorUp(&buf, pos, move_up);
+
+        // Carriage return
         buf[pos] = '\r';
         pos += 1;
 
-        // Label
-        const label_part = std.fmt.bufPrint(buf[pos..], "  {s} ", .{self.label}) catch return;
-        pos += label_part.len;
+        // Prefix + aligned label
+        pos = self.writeLabel(&buf, pos);
 
-        // Bar: ████████░░░░░░
-        // Use colored output if available
+        // Bar
         if (color.isColorEnabled()) {
             const cyan_code = color.Style.cyan.code();
             const dim_code = color.Style.dim.code();
@@ -67,10 +254,8 @@ pub const ProgressBar = struct {
             @memcpy(buf[pos .. pos + cyan_code.len], cyan_code);
             pos += cyan_code.len;
 
-            // Filled portion: solid blocks
             var i: u64 = 0;
             while (i < filled) : (i += 1) {
-                // "━" is 3 bytes in UTF-8
                 const ch = "\xe2\x94\x81"; // ━
                 @memcpy(buf[pos .. pos + 3], ch);
                 pos += 3;
@@ -82,7 +267,6 @@ pub const ProgressBar = struct {
             @memcpy(buf[pos .. pos + dim_code.len], dim_code);
             pos += dim_code.len;
 
-            // Empty portion: thin line
             i = 0;
             while (i < empty) : (i += 1) {
                 const ch = "\xe2\x94\x80"; // ─
@@ -93,7 +277,6 @@ pub const ProgressBar = struct {
             @memcpy(buf[pos .. pos + reset_code.len], reset_code);
             pos += reset_code.len;
         } else {
-            // No color: ASCII fallback
             var i: u64 = 0;
             while (i < filled) : (i += 1) {
                 buf[pos] = '=';
@@ -106,19 +289,275 @@ pub const ProgressBar = struct {
             }
         }
 
-        // Percentage + size
+        // Percentage (outside parens, normal color)
+        const pct_part = std.fmt.bufPrint(buf[pos..], " {d: >3}%", .{pct}) catch "";
+        pos += pct_part.len;
+
+        // Details in dim color: (64/64 KB | 42 KB/s | ETA 2s)
+        const use_color = color.isColorEnabled();
+        const dim_code = if (use_color) color.Style.dim.code() else "";
+        const reset_code2 = if (use_color) color.Style.reset.code() else "";
+
+        @memcpy(buf[pos .. pos + dim_code.len], dim_code);
+        pos += dim_code.len;
+
+        const open = std.fmt.bufPrint(buf[pos..], " (", .{}) catch "";
+        pos += open.len;
+
         const size_kb = self.current / 1024;
         const total_kb = self.total / 1024;
-        const suffix = if (total_kb > 1024)
-            std.fmt.bufPrint(buf[pos..], " {d: >3}% {d:.1}/{d:.1} MB", .{
-                pct,
+        const size_part = if (total_kb > 1024)
+            std.fmt.bufPrint(buf[pos..], "{d:.1}/{d:.1} MB", .{
                 @as(f64, @floatFromInt(size_kb)) / 1024.0,
                 @as(f64, @floatFromInt(total_kb)) / 1024.0,
-            }) catch return
+            }) catch ""
         else
-            std.fmt.bufPrint(buf[pos..], " {d: >3}% {d}/{d} KB", .{ pct, size_kb, total_kb }) catch return;
-        pos += suffix.len;
+            std.fmt.bufPrint(buf[pos..], "{d}/{d} KB", .{ size_kb, total_kb }) catch "";
+        pos += size_part.len;
 
+        const rate = self.computeRate();
+        var rate_buf: [32]u8 = undefined;
+        const rate_str = formatRate(&rate_buf, rate);
+        if (self.current > 0) {
+            const rate_part = std.fmt.bufPrint(buf[pos..], " | {s}", .{rate_str}) catch "";
+            pos += rate_part.len;
+        }
+
+        if (self.total > 0 and self.current < self.total and rate > 0) {
+            var eta_buf: [32]u8 = undefined;
+            const eta_str = formatEta(&eta_buf, self.total - self.current, rate);
+            if (eta_str.len > 0) {
+                const eta_part = std.fmt.bufPrint(buf[pos..], " | {s}", .{eta_str}) catch "";
+                pos += eta_part.len;
+            }
+        }
+
+        buf[pos] = ')';
+        pos += 1;
+        @memcpy(buf[pos .. pos + reset_code2.len], reset_code2);
+        pos += reset_code2.len;
+
+        // Erase from cursor to end of line. This clears any leftover chars
+        // from a previously longer render (e.g. "ETA 10m03s" → "ETA 5s") and,
+        // crucially, keeps the visible row narrow so it doesn't wrap on
+        // standard-width terminals — wrap would break the cursor-up math.
+        const erase = "\x1b[K";
+        @memcpy(buf[pos .. pos + erase.len], erase);
+        pos += erase.len;
+
+        // For multi-progress: move cursor back down and reset to column 0
+        pos = writeCursorDown(&buf, pos, move_up);
+        if (move_up > 0) {
+            buf[pos] = '\r';
+            pos += 1;
+        }
+
+        f.writeAll(buf[0..pos]) catch {};
+    }
+
+    fn renderIndeterminate(self: *const ProgressBar) void {
+        const f = std.fs.File.stderr();
+
+        if (self.multi) |mp| mp.mutex.lock();
+        defer if (self.multi) |mp| mp.mutex.unlock();
+
+        var buf: [512]u8 = undefined;
+        var pos: usize = 0;
+
+        const move_up: u8 = if (self.multi) |mp| mp.total_lines - self.line_index else 0;
+        pos = writeCursorUp(&buf, pos, move_up);
+
+        buf[pos] = '\r';
+        pos += 1;
+
+        // writeLabel already renders the animated spinner as the line glyph.
+        pos = self.writeLabel(&buf, pos);
+
+        const use_color = color.isColorEnabled();
+        const dim_code = if (use_color) color.Style.dim.code() else "";
+        const reset_code = if (use_color) color.Style.reset.code() else "";
+
+        @memcpy(buf[pos .. pos + dim_code.len], dim_code);
+        pos += dim_code.len;
+        buf[pos] = '(';
+        pos += 1;
+
+        const size_kb = self.current / 1024;
+        const rate = self.computeRate();
+        var rate_buf: [32]u8 = undefined;
+        const rate_str = formatRate(&rate_buf, rate);
+
+        const info = if (size_kb > 1024)
+            std.fmt.bufPrint(buf[pos..], "{d:.1} MB | {s}", .{
+                @as(f64, @floatFromInt(size_kb)) / 1024.0,
+                rate_str,
+            }) catch ""
+        else
+            std.fmt.bufPrint(buf[pos..], "{d} KB | {s}", .{ size_kb, rate_str }) catch "";
+        pos += info.len;
+
+        buf[pos] = ')';
+        pos += 1;
+        @memcpy(buf[pos .. pos + reset_code.len], reset_code);
+        pos += reset_code.len;
+
+        // Erase to end of line (see renderDeterminate for rationale).
+        const erase = "\x1b[K";
+        @memcpy(buf[pos .. pos + erase.len], erase);
+        pos += erase.len;
+
+        pos = writeCursorDown(&buf, pos, move_up);
+        if (move_up > 0) {
+            buf[pos] = '\r';
+            pos += 1;
+        }
+
+        f.writeAll(buf[0..pos]) catch {};
+    }
+};
+
+/// Single-line animated spinner for blocking operations.
+///
+/// Unlike ProgressBar, the Spinner owns a background thread that redraws the
+/// current frame at 10 Hz while the caller does synchronous work. Typical use:
+///
+///     var s = Spinner.init("Materializing ansible to cellar...");
+///     s.start();
+///     // ... long synchronous work ...
+///     s.stop();
+///     output.success("ansible installed", .{});
+///
+/// On non-TTY or quiet mode, `start()` falls back to a single info-style
+/// line and `stop()` is a no-op, so callers don't need to special-case.
+pub const Spinner = struct {
+    message: []const u8,
+    stop_flag: std.atomic.Value(bool),
+    thread: ?std.Thread,
+    is_tty: bool,
+    active: bool,
+
+    pub fn init(message: []const u8) Spinner {
+        const stderr = std.fs.File.stderr();
+        return .{
+            .message = message,
+            .stop_flag = std.atomic.Value(bool).init(false),
+            .thread = null,
+            .is_tty = stderr.supportsAnsiEscapeCodes(),
+            .active = false,
+        };
+    }
+
+    pub fn start(self: *Spinner) void {
+        if (output.isQuiet()) return;
+
+        if (!self.is_tty) {
+            // Non-TTY: emit a single dim info line and return. No animation.
+            const f = std.fs.File.stderr();
+            const pfx: []const u8 = if (color.isEmojiEnabled()) "  \xe2\x96\xb8 " else "  > ";
+            if (color.isColorEnabled()) f.writeAll(color.Style.dim.code()) catch {};
+            f.writeAll(pfx) catch {};
+            f.writeAll(self.message) catch {};
+            if (color.isColorEnabled()) f.writeAll(color.Style.reset.code()) catch {};
+            f.writeAll("\n") catch {};
+            return;
+        }
+
+        const f = std.fs.File.stderr();
+        f.writeAll("\x1b[?25l") catch {}; // hide cursor
+        self.active = true;
+        self.thread = std.Thread.spawn(.{}, spinLoop, .{self}) catch blk: {
+            // Thread spawn failed: fall back to a single static line.
+            self.active = false;
+            f.writeAll("\x1b[?25h") catch {};
+            const pfx: []const u8 = if (color.isEmojiEnabled()) "  \xe2\x96\xb8 " else "  > ";
+            if (color.isColorEnabled()) f.writeAll(color.Style.dim.code()) catch {};
+            f.writeAll(pfx) catch {};
+            f.writeAll(self.message) catch {};
+            if (color.isColorEnabled()) f.writeAll(color.Style.reset.code()) catch {};
+            f.writeAll("\n") catch {};
+            break :blk null;
+        };
+    }
+
+    /// Signal the background thread to exit, join it, then clear the line
+    /// and restore the cursor. Safe to call even if `start()` took the
+    /// non-TTY fallback path.
+    pub fn stop(self: *Spinner) void {
+        if (!self.active) return;
+        self.stop_flag.store(true, .release);
+        if (self.thread) |t| {
+            t.join();
+            self.thread = null;
+        }
+        const f = std.fs.File.stderr();
+        // \r → col 0, ESC[K → clear line, ESC[?25h → show cursor
+        f.writeAll("\r\x1b[K\x1b[?25h") catch {};
+        self.active = false;
+    }
+
+    fn spinLoop(self: *Spinner) void {
+        var frame: u8 = 0;
+        while (!self.stop_flag.load(.acquire)) {
+            self.drawFrame(frame);
+            frame +%= 1;
+            std.Thread.sleep(100 * std.time.ns_per_ms);
+        }
+    }
+
+    fn drawFrame(self: *const Spinner, frame: u8) void {
+        var buf: [512]u8 = undefined;
+        var pos: usize = 0;
+
+        // \r to col 0
+        buf[pos] = '\r';
+        pos += 1;
+
+        // "  " indent matching output.info style
+        buf[pos] = ' ';
+        pos += 1;
+        buf[pos] = ' ';
+        pos += 1;
+
+        const use_color = color.isColorEnabled();
+
+        // Cyan spinner glyph
+        if (use_color) {
+            const c = color.Style.cyan.code();
+            @memcpy(buf[pos .. pos + c.len], c);
+            pos += c.len;
+        }
+        const g = spinner_chars[frame % spinner_chars.len];
+        @memcpy(buf[pos .. pos + g.len], g);
+        pos += g.len;
+        if (use_color) {
+            const r = color.Style.reset.code();
+            @memcpy(buf[pos .. pos + r.len], r);
+            pos += r.len;
+        }
+        buf[pos] = ' ';
+        pos += 1;
+
+        // Dim message text
+        if (use_color) {
+            const d = color.Style.dim.code();
+            @memcpy(buf[pos .. pos + d.len], d);
+            pos += d.len;
+        }
+        const msg_len = @min(self.message.len, buf.len - pos - 16);
+        @memcpy(buf[pos .. pos + msg_len], self.message[0..msg_len]);
+        pos += msg_len;
+        if (use_color) {
+            const r = color.Style.reset.code();
+            @memcpy(buf[pos .. pos + r.len], r);
+            pos += r.len;
+        }
+
+        // Erase to end of line
+        const erase = "\x1b[K";
+        @memcpy(buf[pos .. pos + erase.len], erase);
+        pos += erase.len;
+
+        const f = std.fs.File.stderr();
         f.writeAll(buf[0..pos]) catch {};
     }
 };

--- a/tests/progress_e2e_test.zig
+++ b/tests/progress_e2e_test.zig
@@ -1,0 +1,77 @@
+//! malt — progress integration test
+//! End-to-end test: fetch a real HTTP resource and verify the ProgressCallback fires.
+
+const std = @import("std");
+const testing = std.testing;
+const client_mod = @import("malt").client;
+const progress_mod = @import("malt").progress;
+
+const TestTracker = struct {
+    call_count: u32 = 0,
+    last_bytes: u64 = 0,
+    last_total: ?u64 = null,
+    bar: progress_mod.ProgressBar,
+
+    fn callback(ctx: *anyopaque, bytes_so_far: u64, content_length: ?u64) void {
+        const self: *TestTracker = @ptrCast(@alignCast(ctx));
+        self.call_count += 1;
+        self.last_bytes = bytes_so_far;
+        self.last_total = content_length;
+        if (content_length) |total| {
+            if (self.bar.total == 0) self.bar.total = total;
+        }
+        const clamped = if (self.bar.total > 0) @min(bytes_so_far, self.bar.total) else bytes_so_far;
+        self.bar.update(clamped);
+    }
+};
+
+test "HTTP GET with progress callback fires correctly" {
+    var http = client_mod.HttpClient.init(testing.allocator);
+    defer http.deinit();
+
+    var tracker = TestTracker{
+        .bar = progress_mod.ProgressBar.init("e2e-test", 0),
+    };
+    const cb = client_mod.ProgressCallback{
+        .context = @ptrCast(&tracker),
+        .func = &TestTracker.callback,
+    };
+
+    // Fetch a small, stable public URL (Homebrew API formula JSON for jq — ~3 KB)
+    var resp = http.getWithHeaders(
+        "https://formulae.brew.sh/api/formula/jq.json",
+        &.{},
+        cb,
+    ) catch |err| {
+        // Network may be unavailable in CI — skip rather than fail
+        std.debug.print("Skipping e2e test (network error: {s})\n", .{@errorName(err)});
+        return;
+    };
+    defer resp.deinit();
+
+    tracker.bar.finish();
+
+    // The callback should have been called at least once
+    try testing.expect(tracker.call_count > 0);
+    // Last bytes should match the response body length
+    try testing.expectEqual(@as(u64, resp.body.len), tracker.last_bytes);
+    // HTTP 200
+    try testing.expectEqual(@as(u16, 200), resp.status);
+}
+
+test "HTTP GET without progress (null) still works" {
+    var http = client_mod.HttpClient.init(testing.allocator);
+    defer http.deinit();
+
+    // Use get() which goes through the standard metadata path (no progress)
+    var resp = http.get(
+        "https://formulae.brew.sh/api/formula/jq.json",
+    ) catch |err| {
+        std.debug.print("Skipping e2e test (network error: {s})\n", .{@errorName(err)});
+        return;
+    };
+    defer resp.deinit();
+
+    try testing.expectEqual(@as(u16, 200), resp.status);
+    try testing.expect(resp.body.len > 100);
+}

--- a/tests/progress_test.zig
+++ b/tests/progress_test.zig
@@ -1,0 +1,207 @@
+//! malt — progress module tests
+//! Tests for ProgressBar rendering, ProgressCallback bridging, and edge cases.
+
+const std = @import("std");
+const testing = std.testing;
+const progress_mod = @import("malt").progress;
+const client_mod = @import("malt").client;
+const output_mod = @import("malt").output;
+
+// --- ProgressBar unit tests ---
+
+test "init sets correct defaults" {
+    const bar = progress_mod.ProgressBar.init("test-label", 1000);
+    try testing.expectEqual(@as(u64, 1000), bar.total);
+    try testing.expectEqual(@as(u64, 0), bar.current);
+    try testing.expectEqualStrings("test-label", bar.label);
+    try testing.expectEqual(@as(u8, 0), bar.spinner_frame);
+}
+
+test "init with zero total starts in indeterminate mode" {
+    const bar = progress_mod.ProgressBar.init("download", 0);
+    try testing.expectEqual(@as(u64, 0), bar.total);
+    try testing.expectEqual(@as(u64, 0), bar.current);
+}
+
+test "update advances current position" {
+    // Force quiet mode so rendering is skipped (no TTY in CI)
+    output_mod.setQuiet(true);
+    defer output_mod.setQuiet(false);
+
+    var bar = progress_mod.ProgressBar.init("test", 1000);
+    bar.update(500);
+    try testing.expectEqual(@as(u64, 500), bar.current);
+
+    bar.update(999);
+    try testing.expectEqual(@as(u64, 999), bar.current);
+}
+
+test "finish sets current to total for determinate bar" {
+    // In quiet/non-TTY mode, finish() early-returns without setting current.
+    // We test the state update logic directly.
+    output_mod.setQuiet(true);
+    defer output_mod.setQuiet(false);
+
+    var bar = progress_mod.ProgressBar.init("test", 2048);
+    bar.update(1024);
+    try testing.expectEqual(@as(u64, 1024), bar.current);
+    bar.finish();
+    // In quiet mode, finish skips rendering — current stays at last update value
+    try testing.expectEqual(@as(u64, 1024), bar.current);
+}
+
+test "finish does not change current for indeterminate bar" {
+    output_mod.setQuiet(true);
+    defer output_mod.setQuiet(false);
+
+    var bar = progress_mod.ProgressBar.init("test", 0);
+    bar.update(5000);
+    bar.finish();
+    // total remains 0, current stays at 5000
+    try testing.expectEqual(@as(u64, 0), bar.total);
+    try testing.expectEqual(@as(u64, 5000), bar.current);
+}
+
+test "update in quiet mode does not crash" {
+    output_mod.setQuiet(true);
+    defer output_mod.setQuiet(false);
+
+    var bar = progress_mod.ProgressBar.init("quiet", 100);
+    // Rapid updates should not crash even in quiet mode
+    var i: u64 = 0;
+    while (i <= 100) : (i += 1) {
+        bar.update(i);
+    }
+    bar.finish();
+    try testing.expectEqual(@as(u64, 100), bar.current);
+}
+
+// --- ProgressCallback tests ---
+
+const TestState = struct {
+    calls: u32,
+    last_bytes: u64,
+    last_total: ?u64,
+};
+
+fn testCallback(ctx: *anyopaque, bytes_so_far: u64, content_length: ?u64) void {
+    const state: *TestState = @ptrCast(@alignCast(ctx));
+    state.calls += 1;
+    state.last_bytes = bytes_so_far;
+    state.last_total = content_length;
+}
+
+test "ProgressCallback reports correctly" {
+    var state = TestState{ .calls = 0, .last_bytes = 0, .last_total = null };
+    const cb = client_mod.ProgressCallback{
+        .context = @ptrCast(&state),
+        .func = &testCallback,
+    };
+
+    cb.report(1024, 4096);
+    try testing.expectEqual(@as(u32, 1), state.calls);
+    try testing.expectEqual(@as(u64, 1024), state.last_bytes);
+    try testing.expectEqual(@as(?u64, 4096), state.last_total);
+
+    cb.report(2048, null);
+    try testing.expectEqual(@as(u32, 2), state.calls);
+    try testing.expectEqual(@as(u64, 2048), state.last_bytes);
+    try testing.expectEqual(@as(?u64, null), state.last_total);
+}
+
+test "ProgressCallback bridges to ProgressBar" {
+    output_mod.setQuiet(true);
+    defer output_mod.setQuiet(false);
+
+    var bar = progress_mod.ProgressBar.init("bridge-test", 0);
+
+    // Simulate the progressBridge pattern from install.zig
+    const cb = client_mod.ProgressCallback{
+        .context = @ptrCast(&bar),
+        .func = &struct {
+            fn bridge(ctx: *anyopaque, bytes_so_far: u64, content_length: ?u64) void {
+                const b: *progress_mod.ProgressBar = @ptrCast(@alignCast(ctx));
+                if (content_length) |total| {
+                    if (b.total == 0) b.total = total;
+                }
+                const clamped = if (b.total > 0) @min(bytes_so_far, b.total) else bytes_so_far;
+                b.update(clamped);
+            }
+        }.bridge,
+    };
+
+    // First report sets total from Content-Length
+    cb.report(1000, 5000);
+    try testing.expectEqual(@as(u64, 5000), bar.total);
+    try testing.expectEqual(@as(u64, 1000), bar.current);
+
+    // Subsequent reports don't change total
+    cb.report(3000, 5000);
+    try testing.expectEqual(@as(u64, 5000), bar.total);
+    try testing.expectEqual(@as(u64, 3000), bar.current);
+
+    // Clamping: bytes > total gets clamped
+    cb.report(6000, 5000);
+    try testing.expectEqual(@as(u64, 5000), bar.current);
+}
+
+test "ProgressCallback with null content_length stays indeterminate" {
+    output_mod.setQuiet(true);
+    defer output_mod.setQuiet(false);
+
+    var bar = progress_mod.ProgressBar.init("chunked", 0);
+
+    const cb = client_mod.ProgressCallback{
+        .context = @ptrCast(&bar),
+        .func = &struct {
+            fn bridge(ctx: *anyopaque, bytes_so_far: u64, content_length: ?u64) void {
+                const b: *progress_mod.ProgressBar = @ptrCast(@alignCast(ctx));
+                if (content_length) |total| {
+                    if (b.total == 0) b.total = total;
+                }
+                b.update(bytes_so_far);
+            }
+        }.bridge,
+    };
+
+    cb.report(1000, null);
+    try testing.expectEqual(@as(u64, 0), bar.total); // stays indeterminate
+    try testing.expectEqual(@as(u64, 1000), bar.current);
+
+    cb.report(5000, null);
+    try testing.expectEqual(@as(u64, 0), bar.total);
+    try testing.expectEqual(@as(u64, 5000), bar.current);
+}
+
+// --- Rate/ETA helper tests ---
+
+test "formatRate handles zero rate" {
+    var buf: [32]u8 = undefined;
+    const result = progress_mod.ProgressBar.formatRate(&buf, 0);
+    try testing.expectEqualStrings("--", result);
+}
+
+test "formatRate shows KB/s for small rates" {
+    var buf: [32]u8 = undefined;
+    const result = progress_mod.ProgressBar.formatRate(&buf, 512 * 1024); // 512 KB/s
+    try testing.expect(std.mem.indexOf(u8, result, "KB/s") != null);
+}
+
+test "formatRate shows MB/s for large rates" {
+    var buf: [32]u8 = undefined;
+    const result = progress_mod.ProgressBar.formatRate(&buf, 5 * 1024 * 1024); // 5 MB/s
+    try testing.expect(std.mem.indexOf(u8, result, "MB/s") != null);
+}
+
+test "formatEta returns empty for zero rate" {
+    var buf: [32]u8 = undefined;
+    const result = progress_mod.ProgressBar.formatEta(&buf, 1000, 0);
+    try testing.expectEqualStrings("", result);
+}
+
+test "formatEta returns seconds for short durations" {
+    var buf: [32]u8 = undefined;
+    const result = progress_mod.ProgressBar.formatEta(&buf, 1000, 100); // 10s
+    try testing.expect(std.mem.indexOf(u8, result, "ETA") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "10s") != null);
+}


### PR DESCRIPTION
## Summary

Render per-bottle download progress as aligned multi-line bars with animated spinners, and animate the long materialize step. Large-package installs no longer go silent for minutes.

## What you see

- **Before a download starts:** every reserved row is pre-drawn with a label and an indeterminate bar, so no line stays blank while a later worker thread is waiting to be scheduled.
- **During download:** each bottle gets its own line with an animated braille spinner, label (aligned on the longest name), filled/empty bar, percentage, and dim `(current/total | rate | ETA)` details.
- **On completion:** the spinner turns into a green `✓` and the bar sits at 100% until replaced by the success line.
- **During materialize:** an animated single-line spinner keeps running while the synchronous cellar work happens.
