### PR TITLE
feat(cli): add `completions` command for bash, zsh, and fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,24 @@ mt version update --check     # check without installing
 
 `update` queries the GitHub releases API, downloads the correct binary for the current platform, and replaces the running binary in-place.
 
+### `mt completions`
+
+Generate a shell completion script for `bash`, `zsh`, or `fish`. The script is printed to stdout, so it can be eval'd immediately or redirected to a file for permanent install.
+
+```bash
+# Temporary (current shell only)
+eval "$(malt completions bash)"
+eval "$(malt completions zsh)"       # run AFTER `compinit`
+malt completions fish | source
+
+# Permanent
+malt completions bash > /usr/local/etc/bash_completion.d/malt
+malt completions zsh  > "${fpath[1]}/_malt"
+malt completions fish > ~/.config/fish/completions/malt.fish
+```
+
+Completes subcommands (for both `malt` and `mt`), per-command flags, global flags, and the positional shell name for `completions` itself. Unknown shell names exit non-zero with an error.
+
 ### Global Flags
 
 | Flag              | Description                                   |

--- a/build.zig
+++ b/build.zig
@@ -61,6 +61,7 @@ pub fn build(b: *std.Build) void {
         "tests/cellar_test.zig",
         "tests/progress_test.zig",
         "tests/progress_e2e_test.zig",
+        "tests/completions_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/justfile
+++ b/justfile
@@ -32,18 +32,39 @@ lint:
     zig build
     zig build test
 
+# Pre-commit hook: auto-format staged .zig files in place and re-stage them
+# so the formatted version is what actually lands in the commit.
+# Note: if you `git add -p` partial hunks of a file, this will pick up the
+# unstaged hunks too — a known limitation of format-on-commit hooks.
+pre-commit:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    files=()
+    while IFS= read -r f; do
+        files+=("$f")
+    done < <(git diff --cached --name-only --diff-filter=ACM | grep -E '\.zig$' || true)
+    if [ ${#files[@]} -eq 0 ]; then
+        exit 0
+    fi
+    zig fmt "${files[@]}"
+    git add "${files[@]}"
+    echo "Auto-formatted ${#files[@]} staged .zig file(s)."
+
 # Pre-push hook: everything that CI checks
 pre-push: fmt-check test
     @echo "All pre-push checks passed."
 
-# Install git hooks
+# Install git hooks (pre-commit + pre-push)
 hooks-install:
+    @echo '#!/bin/sh' > .git/hooks/pre-commit
+    @echo 'just pre-commit' >> .git/hooks/pre-commit
+    @chmod +x .git/hooks/pre-commit
     @echo '#!/bin/sh' > .git/hooks/pre-push
     @echo 'just pre-push' >> .git/hooks/pre-push
     @chmod +x .git/hooks/pre-push
-    @echo "pre-push hook installed."
+    @echo "pre-commit and pre-push hooks installed."
 
 # Remove git hooks
 hooks-uninstall:
-    @rm -f .git/hooks/pre-push
-    @echo "pre-push hook removed."
+    @rm -f .git/hooks/pre-commit .git/hooks/pre-push
+    @echo "pre-commit and pre-push hooks removed."

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -1,0 +1,449 @@
+//! malt — completions command
+//! Prints shell completion scripts for bash, zsh, or fish to stdout.
+
+const std = @import("std");
+const help = @import("help.zig");
+
+pub const Shell = enum { bash, zsh, fish };
+
+/// Parse a shell name into a Shell enum. Returns null for unknown shells.
+pub fn parseShell(name: []const u8) ?Shell {
+    if (std.mem.eql(u8, name, "bash")) return .bash;
+    if (std.mem.eql(u8, name, "zsh")) return .zsh;
+    if (std.mem.eql(u8, name, "fish")) return .fish;
+    return null;
+}
+
+/// Return the completion script for a given shell.
+pub fn scriptFor(shell: Shell) []const u8 {
+    return switch (shell) {
+        .bash => bash_script,
+        .zsh => zsh_script,
+        .fish => fish_script,
+    };
+}
+
+pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
+    _ = allocator;
+    if (help.showIfRequested(args, "completions")) return;
+
+    if (args.len == 0) {
+        printUsage();
+        std.process.exit(2);
+    }
+
+    const shell = parseShell(args[0]) orelse {
+        const stderr = std.fs.File.stderr();
+        var buf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrint(
+            &buf,
+            "malt: unknown shell '{s}'. Supported shells: bash, zsh, fish\n",
+            .{args[0]},
+        ) catch "malt: unknown shell. Supported shells: bash, zsh, fish\n";
+        stderr.writeAll(msg) catch {};
+        std.process.exit(2);
+    };
+
+    try std.fs.File.stdout().writeAll(scriptFor(shell));
+}
+
+fn printUsage() void {
+    const usage =
+        \\Usage: malt completions <shell>
+        \\
+        \\Generate a shell completion script for bash, zsh, or fish.
+        \\The script is printed to stdout so it can be eval'd or redirected.
+        \\
+        \\Shells:
+        \\  bash    source with: eval "$(malt completions bash)"
+        \\  zsh     source with: eval "$(malt completions zsh)"
+        \\  fish    source with: malt completions fish | source
+        \\
+    ;
+    std.fs.File.stderr().writeAll(usage) catch {};
+}
+
+// ---------------------------------------------------------------------------
+// bash
+// ---------------------------------------------------------------------------
+
+pub const bash_script =
+    \\# bash completion for malt
+    \\#
+    \\# Install (temporary, current shell only):
+    \\#   eval "$(malt completions bash)"
+    \\#
+    \\# Install (permanent):
+    \\#   malt completions bash > /usr/local/etc/bash_completion.d/malt
+    \\#
+    \\# Requires bash-completion (brew install bash-completion@2).
+    \\
+    \\_malt_complete() {
+    \\    local cur words cword
+    \\    cur="${COMP_WORDS[COMP_CWORD]}"
+    \\    words=("${COMP_WORDS[@]}")
+    \\    cword=$COMP_CWORD
+    \\
+    \\    local commands="install uninstall remove upgrade update outdated list ls info search cleanup doctor tap untap gc migrate autoremove rollback link unlink run version completions help"
+    \\    local global_flags="--verbose -v --quiet -q --json --dry-run --help -h --version"
+    \\
+    \\    # Find the first non-flag word after the program — that's the subcommand.
+    \\    local cmd="" i
+    \\    for (( i=1; i<cword; i++ )); do
+    \\        if [[ "${words[i]}" != -* ]]; then
+    \\            cmd="${words[i]}"
+    \\            break
+    \\        fi
+    \\    done
+    \\
+    \\    if [[ -z "$cmd" ]]; then
+    \\        if [[ "$cur" == -* ]]; then
+    \\            COMPREPLY=( $(compgen -W "$global_flags" -- "$cur") )
+    \\        else
+    \\            COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
+    \\        fi
+    \\        return 0
+    \\    fi
+    \\
+    \\    case "$cmd" in
+    \\        completions)
+    \\            if [[ "$cur" != -* ]]; then
+    \\                COMPREPLY=( $(compgen -W "bash zsh fish" -- "$cur") )
+    \\                return 0
+    \\            fi
+    \\            ;;
+    \\        version)
+    \\            if [[ "$cur" != -* ]]; then
+    \\                COMPREPLY=( $(compgen -W "update" -- "$cur") )
+    \\                return 0
+    \\            fi
+    \\            ;;
+    \\    esac
+    \\
+    \\    local cmd_flags=""
+    \\    case "$cmd" in
+    \\        install)          cmd_flags="--cask --formula --dry-run --force --quiet -q --json" ;;
+    \\        uninstall|remove) cmd_flags="--force --zap --dry-run" ;;
+    \\        upgrade)          cmd_flags="--all --cask --formula --dry-run" ;;
+    \\        outdated)         cmd_flags="--json --formula --cask --quiet -q" ;;
+    \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --json --quiet -q" ;;
+    \\        info)             cmd_flags="--formula --cask --json" ;;
+    \\        search)           cmd_flags="--formula --cask --json" ;;
+    \\        cleanup)          cmd_flags="--dry-run --prune= -s" ;;
+    \\        gc|autoremove|migrate|rollback) cmd_flags="--dry-run" ;;
+    \\        link)             cmd_flags="--overwrite --force -f" ;;
+    \\    esac
+    \\
+    \\    if [[ "$cur" == -* ]]; then
+    \\        COMPREPLY=( $(compgen -W "$cmd_flags $global_flags" -- "$cur") )
+    \\    fi
+    \\    return 0
+    \\}
+    \\
+    \\complete -F _malt_complete malt
+    \\complete -F _malt_complete mt
+    \\
+;
+
+// ---------------------------------------------------------------------------
+// zsh
+// ---------------------------------------------------------------------------
+
+pub const zsh_script =
+    \\#compdef malt mt
+    \\#
+    \\# zsh completion for malt
+    \\#
+    \\# Install (temporary, current shell only) — run AFTER `compinit`:
+    \\#   eval "$(malt completions zsh)"
+    \\#
+    \\# Install (permanent):
+    \\#   malt completions zsh > "${fpath[1]}/_malt"
+    \\#
+    \\# Requires: autoload -Uz compinit && compinit
+    \\
+    \\_malt() {
+    \\    local curcontext="$curcontext" state line
+    \\    local -a commands
+    \\
+    \\    commands=(
+    \\        'install:Install formulas, casks, or tap formulas'
+    \\        'uninstall:Remove installed packages'
+    \\        'remove:Remove installed packages (alias for uninstall)'
+    \\        'upgrade:Upgrade installed packages'
+    \\        'update:Refresh metadata cache'
+    \\        'outdated:List packages with newer versions available'
+    \\        'list:List installed packages'
+    \\        'ls:List installed packages (alias for list)'
+    \\        'info:Show detailed package information'
+    \\        'search:Search formulas and casks'
+    \\        'cleanup:Remove old versions and prune caches'
+    \\        'doctor:System health check'
+    \\        'tap:Manage taps'
+    \\        'untap:Remove a tap'
+    \\        'gc:Garbage collect unreferenced store entries'
+    \\        'migrate:Import existing Homebrew installation'
+    \\        'autoremove:Remove orphaned dependencies'
+    \\        'rollback:Revert a package to its previous version'
+    \\        'link:Create symlinks for an installed keg'
+    \\        'unlink:Remove symlinks (keg stays installed)'
+    \\        'run:Run a package binary without installing'
+    \\        'version:Show version or self-update'
+    \\        'completions:Generate shell completion scripts'
+    \\        'help:Show help'
+    \\    )
+    \\
+    \\    _arguments -C \
+    \\        '(--verbose -v)'{--verbose,-v}'[Verbose output]' \
+    \\        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
+    \\        '--json[JSON output]' \
+    \\        '--dry-run[Preview without executing]' \
+    \\        '(- : *)'{--help,-h}'[Show help]' \
+    \\        '(- : *)--version[Show version]' \
+    \\        '1: :->command' \
+    \\        '*:: :->args' && return 0
+    \\
+    \\    case $state in
+    \\        command)
+    \\            _describe -t commands 'malt command' commands
+    \\            ;;
+    \\        args)
+    \\            case $words[1] in
+    \\                install)
+    \\                    _arguments \
+    \\                        '--cask[Force cask installation]' \
+    \\                        '--formula[Force formula installation]' \
+    \\                        '--dry-run[Show what would be installed]' \
+    \\                        '--force[Overwrite existing installations]' \
+    \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
+    \\                        '--json[Output result as JSON]' \
+    \\                        '*::package:'
+    \\                    ;;
+    \\                uninstall|remove)
+    \\                    _arguments \
+    \\                        '--force[Remove even if depended on]' \
+    \\                        '--zap[Deep clean (cask only)]' \
+    \\                        '--dry-run[Show what would be removed]' \
+    \\                        '*::package:'
+    \\                    ;;
+    \\                upgrade)
+    \\                    _arguments \
+    \\                        '--all[Upgrade everything]' \
+    \\                        '--cask[Upgrade casks only]' \
+    \\                        '--formula[Upgrade formulas only]' \
+    \\                        '--dry-run[Show what would be upgraded]' \
+    \\                        '*::package:'
+    \\                    ;;
+    \\                outdated)
+    \\                    _arguments \
+    \\                        '--json[Output as JSON]' \
+    \\                        '--formula[Show outdated formulas only]' \
+    \\                        '--cask[Show outdated casks only]' \
+    \\                        '(--quiet -q)'{--quiet,-q}'[Suppress status messages]'
+    \\                    ;;
+    \\                list|ls)
+    \\                    _arguments \
+    \\                        '--versions[Show version numbers]' \
+    \\                        '--formula[Formulas only]' \
+    \\                        '--cask[Casks only]' \
+    \\                        '--pinned[Pinned packages only]' \
+    \\                        '--json[Output as JSON]' \
+    \\                        '(--quiet -q)'{--quiet,-q}'[Names only]'
+    \\                    ;;
+    \\                info)
+    \\                    _arguments \
+    \\                        '--formula[Show formula info only]' \
+    \\                        '--cask[Show cask info only]' \
+    \\                        '--json[Output as JSON]' \
+    \\                        '*::package:'
+    \\                    ;;
+    \\                search)
+    \\                    _arguments \
+    \\                        '--formula[Search formulas only]' \
+    \\                        '--cask[Search casks only]' \
+    \\                        '--json[Output as JSON]' \
+    \\                        '*::query:'
+    \\                    ;;
+    \\                cleanup)
+    \\                    _arguments \
+    \\                        '--dry-run[Show what would be removed]' \
+    \\                        '--prune=-[Cache age threshold]:days:' \
+    \\                        '-s[Scrub entire download cache]'
+    \\                    ;;
+    \\                gc|autoremove|migrate|rollback)
+    \\                    _arguments '--dry-run[Preview without executing]'
+    \\                    ;;
+    \\                link)
+    \\                    _arguments \
+    \\                        '--overwrite[Replace existing symlinks]' \
+    \\                        '(--force -f)'{--force,-f}'[Same as --overwrite]' \
+    \\                        '*::formula:'
+    \\                    ;;
+    \\                completions)
+    \\                    _values 'shell' bash zsh fish
+    \\                    ;;
+    \\                version)
+    \\                    _values 'subcommand' 'update[Self-update the binary]'
+    \\                    ;;
+    \\            esac
+    \\            ;;
+    \\    esac
+    \\}
+    \\
+    \\# When sourced via `eval`, register the completion with the running shell.
+    \\# When placed in fpath as `_malt`, the `#compdef` line above handles it and
+    \\# this call is harmless.
+    \\compdef _malt malt mt 2>/dev/null || true
+    \\
+;
+
+// ---------------------------------------------------------------------------
+// fish
+// ---------------------------------------------------------------------------
+
+pub const fish_script =
+    \\# fish completion for malt
+    \\#
+    \\# Install (temporary, current shell only):
+    \\#   malt completions fish | source
+    \\#
+    \\# Install (permanent):
+    \\#   malt completions fish > ~/.config/fish/completions/malt.fish
+    \\
+    \\function __malt_needs_command
+    \\    set -l tokens (commandline -opc)
+    \\    set -l i 2
+    \\    while test $i -le (count $tokens)
+    \\        if not string match -q -- '-*' $tokens[$i]
+    \\            return 1
+    \\        end
+    \\        set i (math $i + 1)
+    \\    end
+    \\    return 0
+    \\end
+    \\
+    \\function __malt_using_command
+    \\    set -l tokens (commandline -opc)
+    \\    set -l i 2
+    \\    while test $i -le (count $tokens)
+    \\        if not string match -q -- '-*' $tokens[$i]
+    \\            if test "$tokens[$i]" = "$argv[1]"
+    \\                return 0
+    \\            end
+    \\            return 1
+    \\        end
+    \\        set i (math $i + 1)
+    \\    end
+    \\    return 1
+    \\end
+    \\
+    \\for __malt_bin in malt mt
+    \\    complete -c $__malt_bin -f
+    \\
+    \\    # Global flags
+    \\    complete -c $__malt_bin -s v -l verbose -d 'Verbose output'
+    \\    complete -c $__malt_bin -s q -l quiet   -d 'Suppress non-error output'
+    \\    complete -c $__malt_bin      -l json    -d 'JSON output'
+    \\    complete -c $__malt_bin      -l dry-run -d 'Preview without executing'
+    \\    complete -c $__malt_bin -s h -l help    -d 'Show help'
+    \\    complete -c $__malt_bin      -l version -d 'Show version'
+    \\
+    \\    # Subcommands
+    \\    complete -c $__malt_bin -n __malt_needs_command -a install     -d 'Install formulas, casks, or tap formulas'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a uninstall   -d 'Remove installed packages'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a remove      -d 'Remove installed packages (alias)'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a upgrade     -d 'Upgrade installed packages'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a update      -d 'Refresh metadata cache'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a outdated    -d 'List packages with newer versions'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a list        -d 'List installed packages'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a ls          -d 'List installed packages (alias)'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a info        -d 'Show detailed package information'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a search      -d 'Search formulas and casks'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a cleanup     -d 'Remove old versions, prune caches'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a doctor      -d 'System health check'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a tap         -d 'Manage taps'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a untap       -d 'Remove a tap'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a gc          -d 'Garbage collect store entries'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a migrate     -d 'Import existing Homebrew'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a autoremove  -d 'Remove orphaned dependencies'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a rollback    -d 'Revert package to previous version'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a link        -d 'Create symlinks for a keg'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a unlink      -d 'Remove symlinks (keg stays)'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a run         -d 'Run package binary without installing'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a version     -d 'Show version or self-update'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a completions -d 'Generate shell completion scripts'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a help        -d 'Show help'
+    \\
+    \\    # install
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l cask    -d 'Force cask'
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l formula -d 'Force formula'
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l dry-run -d 'Preview'
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l force   -d 'Overwrite existing'
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l json    -d 'JSON output'
+    \\
+    \\    # uninstall / remove
+    \\    complete -c $__malt_bin -n '__malt_using_command uninstall' -l force   -d 'Remove even if depended on'
+    \\    complete -c $__malt_bin -n '__malt_using_command uninstall' -l zap     -d 'Deep clean (cask only)'
+    \\    complete -c $__malt_bin -n '__malt_using_command uninstall' -l dry-run -d 'Preview'
+    \\    complete -c $__malt_bin -n '__malt_using_command remove'    -l force   -d 'Remove even if depended on'
+    \\    complete -c $__malt_bin -n '__malt_using_command remove'    -l zap     -d 'Deep clean (cask only)'
+    \\    complete -c $__malt_bin -n '__malt_using_command remove'    -l dry-run -d 'Preview'
+    \\
+    \\    # upgrade
+    \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l all     -d 'Upgrade everything'
+    \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l cask    -d 'Casks only'
+    \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l formula -d 'Formulas only'
+    \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l dry-run -d 'Preview'
+    \\
+    \\    # outdated
+    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l json    -d 'JSON output'
+    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l formula -d 'Formulas only'
+    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l cask    -d 'Casks only'
+    \\
+    \\    # list / ls
+    \\    complete -c $__malt_bin -n '__malt_using_command list' -l versions -d 'Show version numbers'
+    \\    complete -c $__malt_bin -n '__malt_using_command list' -l formula  -d 'Formulas only'
+    \\    complete -c $__malt_bin -n '__malt_using_command list' -l cask     -d 'Casks only'
+    \\    complete -c $__malt_bin -n '__malt_using_command list' -l pinned   -d 'Pinned only'
+    \\    complete -c $__malt_bin -n '__malt_using_command list' -l json     -d 'JSON output'
+    \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l versions -d 'Show version numbers'
+    \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l formula  -d 'Formulas only'
+    \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l cask     -d 'Casks only'
+    \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l pinned   -d 'Pinned only'
+    \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l json     -d 'JSON output'
+    \\
+    \\    # info
+    \\    complete -c $__malt_bin -n '__malt_using_command info' -l formula -d 'Formula only'
+    \\    complete -c $__malt_bin -n '__malt_using_command info' -l cask    -d 'Cask only'
+    \\    complete -c $__malt_bin -n '__malt_using_command info' -l json    -d 'JSON output'
+    \\
+    \\    # search
+    \\    complete -c $__malt_bin -n '__malt_using_command search' -l formula -d 'Formulas only'
+    \\    complete -c $__malt_bin -n '__malt_using_command search' -l cask    -d 'Casks only'
+    \\    complete -c $__malt_bin -n '__malt_using_command search' -l json    -d 'JSON output'
+    \\
+    \\    # cleanup
+    \\    complete -c $__malt_bin -n '__malt_using_command cleanup' -l dry-run -d 'Preview'
+    \\    complete -c $__malt_bin -n '__malt_using_command cleanup' -l prune   -d 'Cache age threshold (days)'
+    \\    complete -c $__malt_bin -n '__malt_using_command cleanup' -s s       -d 'Scrub entire download cache'
+    \\
+    \\    # gc / autoremove / migrate / rollback
+    \\    complete -c $__malt_bin -n '__malt_using_command gc'         -l dry-run -d 'Preview'
+    \\    complete -c $__malt_bin -n '__malt_using_command autoremove' -l dry-run -d 'Preview'
+    \\    complete -c $__malt_bin -n '__malt_using_command migrate'    -l dry-run -d 'Preview'
+    \\    complete -c $__malt_bin -n '__malt_using_command rollback'   -l dry-run -d 'Preview'
+    \\
+    \\    # link
+    \\    complete -c $__malt_bin -n '__malt_using_command link' -l overwrite -d 'Replace existing symlinks'
+    \\    complete -c $__malt_bin -n '__malt_using_command link' -s f -l force -d 'Same as --overwrite'
+    \\
+    \\    # completions — shell name as positional
+    \\    complete -c $__malt_bin -n '__malt_using_command completions' -f -a 'bash zsh fish'
+    \\
+    \\    # version — sub-subcommand
+    \\    complete -c $__malt_bin -n '__malt_using_command version' -f -a 'update' -d 'Self-update'
+    \\end
+    \\
+    \\set -e __malt_bin
+    \\
+;

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -35,6 +35,7 @@ fn helpFor(command: []const u8) []const u8 {
         .{ "run", run_help },
         .{ "link", link_help },
         .{ "unlink", unlink_help2 },
+        .{ "completions", completions_help },
     });
     return map.get(command) orelse "No help available.\n";
 }
@@ -244,5 +245,23 @@ const unlink_help2 =
     \\
     \\Remove symlinks for an installed keg from the prefix.
     \\The keg remains installed in the Cellar.
+    \\
+;
+
+const completions_help =
+    \\Usage: malt completions <shell>
+    \\
+    \\Generate a shell completion script. The script is printed to stdout
+    \\so it can be eval'd for the current shell or redirected to a file.
+    \\
+    \\Shells:
+    \\  bash    Source with: eval "$(malt completions bash)"
+    \\  zsh     Source with: eval "$(malt completions zsh)"
+    \\  fish    Source with: malt completions fish | source
+    \\
+    \\Permanent install:
+    \\  bash    malt completions bash > /usr/local/etc/bash_completion.d/malt
+    \\  zsh     malt completions zsh  > "${fpath[1]}/_malt"
+    \\  fish    malt completions fish > ~/.config/fish/completions/malt.fish
     \\
 ;

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -20,3 +20,4 @@ pub const client = @import("net/client.zig");
 pub const output = @import("ui/output.zig");
 pub const progress = @import("ui/progress.zig");
 pub const version = @import("version.zig");
+pub const completions = @import("cli/completions.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -33,6 +33,7 @@ const rollback = @import("cli/rollback.zig");
 const link_cmd = @import("cli/link.zig");
 const run_cmd = @import("cli/run.zig");
 const version_update = @import("cli/version_update.zig");
+const completions = @import("cli/completions.zig");
 
 const version_mod = @import("version.zig");
 const version = version_mod.value;
@@ -58,6 +59,7 @@ const Command = enum {
     unlink,
     run,
     version_cmd,
+    completions,
     help,
     version,
 };
@@ -84,6 +86,7 @@ const command_map = std.StaticStringMap(Command).initComptime(.{
     .{ "link", .link },
     .{ "unlink", .unlink },
     .{ "run", .run },
+    .{ "completions", .completions },
     .{ "help", .help },
     .{ "--help", .help },
     .{ "-h", .help },
@@ -178,6 +181,7 @@ pub fn main() !void {
             .link => try link_cmd.executeLink(allocator, cmd_args),
             .unlink => try link_cmd.executeUnlink(allocator, cmd_args),
             .run => try run_cmd.execute(allocator, cmd_args),
+            .completions => try completions.execute(allocator, cmd_args),
             .version_cmd => {
                 // "mt version" — check for "mt version update" subcommand
                 if (cmd_args.len > 0 and std.mem.eql(u8, cmd_args[0], "update")) {
@@ -221,6 +225,7 @@ fn printUsage() void {
         \\  link          Create symlinks for an installed keg
         \\  unlink        Remove symlinks (keg stays installed)
         \\  run           Run a package binary without installing
+        \\  completions   Generate shell completion scripts (bash, zsh, fish)
         \\  version       Show version (use 'version update' to self-update)
         \\
         \\Global flags:

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -1,0 +1,93 @@
+//! malt — completions command tests
+//! Exercises shell parsing and verifies that generated scripts reference
+//! every subcommand exposed by the CLI. The execute() function writes to
+//! stdout and calls std.process.exit on error, so tests target the pure
+//! helpers (parseShell, scriptFor) and the script constants instead.
+
+const std = @import("std");
+const testing = std.testing;
+const completions = @import("malt").completions;
+
+test "parseShell recognises the three supported shells" {
+    try testing.expectEqual(completions.Shell.bash, completions.parseShell("bash").?);
+    try testing.expectEqual(completions.Shell.zsh, completions.parseShell("zsh").?);
+    try testing.expectEqual(completions.Shell.fish, completions.parseShell("fish").?);
+}
+
+test "parseShell returns null for unknown shells" {
+    // malt is macOS-only, so the realistic miss-cases are other POSIX shells
+    // that ship on macOS (or an empty / wrong-case input), not PowerShell.
+    try testing.expect(completions.parseShell("tcsh") == null);
+    try testing.expect(completions.parseShell("ksh") == null);
+    try testing.expect(completions.parseShell("sh") == null);
+    try testing.expect(completions.parseShell("Bash") == null); // case-sensitive
+    try testing.expect(completions.parseShell("") == null);
+}
+
+test "scriptFor routes each shell to a non-empty script" {
+    try testing.expect(completions.scriptFor(.bash).len > 0);
+    try testing.expect(completions.scriptFor(.zsh).len > 0);
+    try testing.expect(completions.scriptFor(.fish).len > 0);
+    // Routing must be distinct — each variant returns a different script.
+    try testing.expect(!std.mem.eql(u8, completions.scriptFor(.bash), completions.scriptFor(.zsh)));
+    try testing.expect(!std.mem.eql(u8, completions.scriptFor(.bash), completions.scriptFor(.fish)));
+    try testing.expect(!std.mem.eql(u8, completions.scriptFor(.zsh), completions.scriptFor(.fish)));
+}
+
+const all_commands = [_][]const u8{
+    "install",     "uninstall",   "remove",  "upgrade",
+    "update",      "outdated",    "list",    "ls",
+    "info",        "search",      "cleanup", "doctor",
+    "tap",         "untap",       "gc",      "migrate",
+    "autoremove",  "rollback",    "link",    "unlink",
+    "run",         "version",     "completions",
+};
+
+fn expectContains(haystack: []const u8, needle: []const u8) !void {
+    if (std.mem.indexOf(u8, haystack, needle) == null) {
+        std.debug.print("expected script to contain '{s}'\n", .{needle});
+        return error.MissingSubstring;
+    }
+}
+
+test "bash script covers every subcommand and both binary names" {
+    const script = completions.bash_script;
+    for (all_commands) |cmd| try expectContains(script, cmd);
+    // Binary registrations.
+    try expectContains(script, "complete -F _malt_complete malt");
+    try expectContains(script, "complete -F _malt_complete mt");
+    // Install hint.
+    try expectContains(script, "eval \"$(malt completions bash)\"");
+}
+
+test "zsh script covers every subcommand and registers compdef" {
+    const script = completions.zsh_script;
+    try expectContains(script, "#compdef malt mt");
+    try expectContains(script, "_malt()");
+    try expectContains(script, "compdef _malt malt mt");
+    for (all_commands) |cmd| try expectContains(script, cmd);
+    // Install hint.
+    try expectContains(script, "eval \"$(malt completions zsh)\"");
+}
+
+test "fish script covers every subcommand and both binary names" {
+    const script = completions.fish_script;
+    try expectContains(script, "for __malt_bin in malt mt");
+    try expectContains(script, "__malt_needs_command");
+    try expectContains(script, "__malt_using_command");
+    for (all_commands) |cmd| try expectContains(script, cmd);
+    // Install hint.
+    try expectContains(script, "malt completions fish | source");
+}
+
+test "all scripts complete the three shells for the completions subcommand" {
+    for ([_][]const u8{
+        completions.bash_script,
+        completions.zsh_script,
+        completions.fish_script,
+    }) |script| {
+        try expectContains(script, "bash");
+        try expectContains(script, "zsh");
+        try expectContains(script, "fish");
+    }
+}

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -35,12 +35,12 @@ test "scriptFor routes each shell to a non-empty script" {
 }
 
 const all_commands = [_][]const u8{
-    "install",     "uninstall",   "remove",  "upgrade",
-    "update",      "outdated",    "list",    "ls",
-    "info",        "search",      "cleanup", "doctor",
-    "tap",         "untap",       "gc",      "migrate",
-    "autoremove",  "rollback",    "link",    "unlink",
-    "run",         "version",     "completions",
+    "install",    "uninstall", "remove",      "upgrade",
+    "update",     "outdated",  "list",        "ls",
+    "info",       "search",    "cleanup",     "doctor",
+    "tap",        "untap",     "gc",          "migrate",
+    "autoremove", "rollback",  "link",        "unlink",
+    "run",        "version",   "completions",
 };
 
 fn expectContains(haystack: []const u8, needle: []const u8) !void {


### PR DESCRIPTION
## Summary

Adds `malt completions <shell>` which prints a shell completion script to stdout. Supports `bash`, `zsh`, and `fish`. Unknown shells exit non-zero with a clear message.

Each script completes every subcommand (for both the `malt` and `mt` binaries), per-command flags, global flags, and the positional shell name for `completions` itself.

## Usage

```bash
# Temporary
eval "$(malt completions bash)"
eval "$(malt completions zsh)"       # run AFTER `compinit`
malt completions fish | source

# Permanent
malt completions bash > /usr/local/etc/bash_completion.d/malt
malt completions zsh  > "${fpath[1]}/_malt"
malt completions fish > ~/.config/fish/completions/malt.fish
```