### PR TITLE
fix(cli): honour global --dry-run flag in subcommands

### DIFF
--- a/src/cli/autoremove.zig
+++ b/src/cli/autoremove.zig
@@ -16,7 +16,7 @@ const help = @import("help.zig");
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "autoremove")) return;
 
-    var dry_run = false;
+    var dry_run = output.isDryRun();
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "--dry-run")) dry_run = true;
     }

--- a/src/cli/cleanup.zig
+++ b/src/cli/cleanup.zig
@@ -11,7 +11,7 @@ const help = @import("help.zig");
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "cleanup")) return;
 
-    var dry_run = false;
+    var dry_run = output.isDryRun();
     var prune_days: ?i64 = null;
     var scrub = false;
 

--- a/src/cli/gc.zig
+++ b/src/cli/gc.zig
@@ -13,7 +13,7 @@ const help = @import("help.zig");
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "gc")) return;
 
-    var dry_run = false;
+    var dry_run = output.isDryRun();
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "--dry-run")) dry_run = true;
     }

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -148,7 +148,9 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer packages.deinit(allocator);
     var force_cask = false;
     var force_formula = false;
-    var dry_run = false;
+    // Honour the global `--dry-run` flag consumed by main.zig, while still
+    // allowing programmatic callers to pass `--dry-run` directly in `args`.
+    var dry_run = output.isDryRun();
     var force = false;
 
     for (args) |arg| {

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -35,7 +35,7 @@ const KegResult = enum {
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "migrate")) return;
 
-    var dry_run = false;
+    var dry_run = output.isDryRun();
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "--dry-run")) dry_run = true;
         if (std.mem.eql(u8, arg, "--quiet") or std.mem.eql(u8, arg, "-q")) output.setQuiet(true);

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -21,7 +21,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     const name = args[0];
-    var dry_run = false;
+    var dry_run = output.isDryRun();
     for (args[1..]) |arg| {
         if (std.mem.eql(u8, arg, "--dry-run")) dry_run = true;
     }

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -23,7 +23,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     var cask_only = false;
     var formula_only = false;
-    var dry_run = false;
+    var dry_run = output.isDryRun();
     var pkg_name: ?[]const u8 = null;
 
     for (args) |arg| {


### PR DESCRIPTION
## Summary

`malt install --dry-run git` (and friends) actually installed instead of previewing. `main.zig` strips `--dry-run` from the args it dispatches to each subcommand and sets the flag via `output.setDryRun(true)`, but every command that cared about it kept its own `var dry_run = false` seeded from a local arg loop that never saw the flag.

Seed the local from `output.isDryRun()` so the global wins, while still letting the local loop OR-set it for programmatic callers that pass `--dry-run` directly in `args`.

**Affected commands:** `install`, `autoremove`, `cleanup`, `gc`, `migrate`, `rollback`, `upgrade`.