### PR TITLE
feat(cli): add backup and restore commands

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -62,6 +62,7 @@ pub fn build(b: *std.Build) void {
         "tests/progress_test.zig",
         "tests/progress_e2e_test.zig",
         "tests/completions_test.zig",
+        "tests/backup_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/cli/backup.zig
+++ b/src/cli/backup.zig
@@ -1,0 +1,265 @@
+//! malt — backup command
+//! Dumps the list of currently installed formulae and casks to a plain-text
+//! file that `malt restore` can consume to reproduce the environment on
+//! another machine.
+//!
+//! File format (one entry per line):
+//!
+//!   # comments start with a '#' and are ignored
+//!   formula git
+//!   formula wget
+//!   cask firefox
+//!   cask slack
+//!
+//! An optional `@<version>` suffix is written when `--versions` is passed and
+//! honoured by `malt restore`.
+
+const std = @import("std");
+const sqlite = @import("../db/sqlite.zig");
+const schema = @import("../db/schema.zig");
+const atomic = @import("../fs/atomic.zig");
+const output = @import("../ui/output.zig");
+const help = @import("help.zig");
+
+pub const Kind = enum { formula, cask };
+
+/// A parsed backup entry. For entries produced by `parseBackup`, `name` and
+/// `version` are slices into the input text and live as long as that text.
+pub const Entry = struct {
+    kind: Kind,
+    name: []const u8,
+    version: []const u8,
+};
+
+pub const Error = error{
+    InvalidArgs,
+    DatabaseError,
+    OpenFileFailed,
+    WriteFailed,
+};
+
+pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
+    if (help.showIfRequested(args, "backup")) return;
+
+    var output_path: ?[]const u8 = null;
+    var include_versions = false;
+
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        if (std.mem.eql(u8, arg, "--output") or std.mem.eql(u8, arg, "-o")) {
+            if (i + 1 >= args.len) {
+                output.err("--output requires a path argument", .{});
+                return Error.InvalidArgs;
+            }
+            i += 1;
+            output_path = args[i];
+        } else if (std.mem.startsWith(u8, arg, "--output=")) {
+            output_path = arg["--output=".len..];
+        } else if (std.mem.eql(u8, arg, "--versions")) {
+            include_versions = true;
+        } else if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
+            output.setQuiet(true);
+        } else {
+            output.err("Unknown argument for backup: {s}", .{arg});
+            return Error.InvalidArgs;
+        }
+    }
+
+    // ── Open the database ────────────────────────────────────────────────
+    const prefix = atomic.maltPrefix();
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch
+        return Error.DatabaseError;
+
+    var db = sqlite.Database.open(db_path) catch {
+        output.err("Failed to open database at {s}", .{db_path});
+        return Error.DatabaseError;
+    };
+    defer db.close();
+    schema.initSchema(&db) catch {};
+
+    // ── Serialize into an in-memory buffer ───────────────────────────────
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    const w = buf.writer(allocator);
+
+    try writeHeader(w);
+    var count: usize = 0;
+
+    // Directly-installed formulae only — dependencies are pulled transitively
+    // by `malt install` during restore.
+    const formulae_sql =
+        "SELECT name, version FROM kegs " ++
+        "WHERE install_reason = 'direct' " ++
+        "ORDER BY name;";
+    var fstmt = db.prepare(formulae_sql) catch null;
+    if (fstmt) |*s| {
+        defer s.finalize();
+        while (s.step() catch false) {
+            const name_ptr = s.columnText(0) orelse continue;
+            const ver_ptr = s.columnText(1);
+            const name = std.mem.sliceTo(name_ptr, 0);
+            const version = if (ver_ptr) |p| std.mem.sliceTo(p, 0) else "";
+            try writeEntry(w, .formula, name, version, include_versions);
+            count += 1;
+        }
+    }
+
+    var cstmt = db.prepare("SELECT token, version FROM casks ORDER BY token;") catch null;
+    if (cstmt) |*s| {
+        defer s.finalize();
+        while (s.step() catch false) {
+            const name_ptr = s.columnText(0) orelse continue;
+            const ver_ptr = s.columnText(1);
+            const name = std.mem.sliceTo(name_ptr, 0);
+            const version = if (ver_ptr) |p| std.mem.sliceTo(p, 0) else "";
+            try writeEntry(w, .cask, name, version, include_versions);
+            count += 1;
+        }
+    }
+
+    // ── Resolve destination and write ────────────────────────────────────
+    if (output_path) |p| {
+        if (std.mem.eql(u8, p, "-")) {
+            std.fs.File.stdout().writeAll(buf.items) catch return Error.WriteFailed;
+            return;
+        }
+        try writeToPath(p, buf.items);
+        output.success("Backup written to {s} ({d} packages)", .{ p, count });
+        return;
+    }
+
+    const default_path = try defaultBackupPath(allocator);
+    defer allocator.free(default_path);
+    try writeToPath(default_path, buf.items);
+    output.success("Backup written to {s} ({d} packages)", .{ default_path, count });
+}
+
+fn writeToPath(path: []const u8, bytes: []const u8) Error!void {
+    // Create parent directories when the user supplied a nested path.
+    if (std.fs.path.dirname(path)) |dir| {
+        if (dir.len > 0) {
+            if (std.fs.path.isAbsolute(dir)) {
+                std.fs.makeDirAbsolute(dir) catch |e| switch (e) {
+                    error.PathAlreadyExists => {},
+                    else => {},
+                };
+            } else {
+                std.fs.cwd().makePath(dir) catch {};
+            }
+        }
+    }
+
+    const file = if (std.fs.path.isAbsolute(path))
+        std.fs.createFileAbsolute(path, .{ .truncate = true }) catch {
+            output.err("Failed to create {s}", .{path});
+            return Error.OpenFileFailed;
+        }
+    else
+        std.fs.cwd().createFile(path, .{ .truncate = true }) catch {
+            output.err("Failed to create {s}", .{path});
+            return Error.OpenFileFailed;
+        };
+    defer file.close();
+    file.writeAll(bytes) catch return Error.WriteFailed;
+}
+
+/// Write the canonical header block at the top of a backup file.
+pub fn writeHeader(w: anytype) !void {
+    try w.writeAll("# malt backup\n");
+    try w.writeAll("# Generated by `malt backup`. Restore with `malt restore <file>`.\n");
+    try w.writeAll("# Format: one entry per line — `formula <name>` or `cask <token>`.\n");
+    try w.writeAll("# Lines starting with `#` are comments and are ignored on restore.\n");
+    try w.writeAll("\n");
+}
+
+/// Serialize a single entry to `w` in the canonical format.
+pub fn writeEntry(w: anytype, kind: Kind, name: []const u8, version: []const u8, include_versions: bool) !void {
+    const prefix: []const u8 = switch (kind) {
+        .formula => "formula ",
+        .cask => "cask ",
+    };
+    try w.writeAll(prefix);
+    try w.writeAll(name);
+    if (include_versions and version.len > 0) {
+        try w.writeAll("@");
+        try w.writeAll(version);
+    }
+    try w.writeAll("\n");
+}
+
+/// Parse a single line. Returns null for blank lines, comments, and any line
+/// that does not match the canonical `<kind> <name>[@<version>]` shape.
+/// The returned `name` and `version` slices point into `line`.
+pub fn parseLine(line: []const u8) ?Entry {
+    var s = std.mem.trim(u8, line, " \t\r\n");
+    if (s.len == 0) return null;
+    if (s[0] == '#') return null;
+
+    var kind: Kind = undefined;
+    if (std.mem.startsWith(u8, s, "formula ")) {
+        kind = .formula;
+        s = std.mem.trim(u8, s["formula ".len..], " \t\r\n");
+    } else if (std.mem.startsWith(u8, s, "cask ")) {
+        kind = .cask;
+        s = std.mem.trim(u8, s["cask ".len..], " \t\r\n");
+    } else {
+        return null;
+    }
+    if (s.len == 0) return null;
+
+    var name = s;
+    var version: []const u8 = "";
+    if (std.mem.indexOfScalar(u8, s, '@')) |idx| {
+        name = s[0..idx];
+        version = s[idx + 1 ..];
+    }
+    if (name.len == 0) return null;
+    return .{ .kind = kind, .name = name, .version = version };
+}
+
+/// Parse an entire backup file into a freshly-allocated slice of entries.
+/// The entries reference slices inside `text`, which must outlive them.
+/// Callers own the returned slice and must free it via `allocator.free`.
+pub fn parseBackup(allocator: std.mem.Allocator, text: []const u8) ![]Entry {
+    var list: std.ArrayList(Entry) = .empty;
+    errdefer list.deinit(allocator);
+
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    while (lines.next()) |line| {
+        if (parseLine(line)) |entry| {
+            try list.append(allocator, entry);
+        }
+    }
+    return try list.toOwnedSlice(allocator);
+}
+
+/// Compute a default backup filename of the form
+/// `malt-backup-YYYY-MM-DDTHH-MM-SS.txt` in the current working directory.
+/// The timestamp uses UTC so two backups taken at the same wall-clock moment
+/// collide deterministically across time zones.
+pub fn defaultBackupPath(allocator: std.mem.Allocator) ![]u8 {
+    const secs = std.time.timestamp();
+    const epoch_seconds: std.time.epoch.EpochSeconds = .{
+        .secs = @intCast(@max(secs, 0)),
+    };
+    const epoch_day = epoch_seconds.getEpochDay();
+    const day_seconds = epoch_seconds.getDaySeconds();
+    const year_day = epoch_day.calculateYearDay();
+    const month_day = year_day.calculateMonthDay();
+
+    const day_of_month: u16 = @as(u16, month_day.day_index) + 1;
+    return std.fmt.allocPrint(
+        allocator,
+        "malt-backup-{d:0>4}-{d:0>2}-{d:0>2}T{d:0>2}-{d:0>2}-{d:0>2}.txt",
+        .{
+            year_day.year,
+            month_day.month.numeric(),
+            day_of_month,
+            day_seconds.getHoursIntoDay(),
+            day_seconds.getMinutesIntoHour(),
+            day_seconds.getSecondsIntoMinute(),
+        },
+    );
+}

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -84,7 +84,7 @@ pub const bash_script =
     \\    words=("${COMP_WORDS[@]}")
     \\    cword=$COMP_CWORD
     \\
-    \\    local commands="install uninstall remove upgrade update outdated list ls info search cleanup doctor tap untap gc migrate autoremove rollback link unlink run version completions help"
+    \\    local commands="install uninstall remove upgrade update outdated list ls info search cleanup doctor tap untap gc migrate autoremove rollback link unlink run version completions backup restore help"
     \\    local global_flags="--verbose -v --quiet -q --json --dry-run --help -h --version"
     \\
     \\    # Find the first non-flag word after the program — that's the subcommand.
@@ -123,6 +123,8 @@ pub const bash_script =
     \\    local cmd_flags=""
     \\    case "$cmd" in
     \\        install)          cmd_flags="--cask --formula --dry-run --force --quiet -q --json" ;;
+    \\        backup)           cmd_flags="--output -o --versions --quiet -q" ;;
+    \\        restore)          cmd_flags="--dry-run --force --quiet -q" ;;
     \\        uninstall|remove) cmd_flags="--force --zap --dry-run" ;;
     \\        upgrade)          cmd_flags="--all --cask --formula --dry-run" ;;
     \\        outdated)         cmd_flags="--json --formula --cask --quiet -q" ;;
@@ -190,6 +192,8 @@ pub const zsh_script =
     \\        'run:Run a package binary without installing'
     \\        'version:Show version or self-update'
     \\        'completions:Generate shell completion scripts'
+    \\        'backup:Dump installed packages to a restorable text file'
+    \\        'restore:Reinstall every package listed in a backup file'
     \\        'help:Show help'
     \\    )
     \\
@@ -282,6 +286,19 @@ pub const zsh_script =
     \\                completions)
     \\                    _values 'shell' bash zsh fish
     \\                    ;;
+    \\                backup)
+    \\                    _arguments \
+    \\                        '(--output -o)'{--output,-o}'[Write to a specific file]:path:_files' \
+    \\                        '--versions[Pin each entry to its current version]' \
+    \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]'
+    \\                    ;;
+    \\                restore)
+    \\                    _arguments \
+    \\                        '--dry-run[Preview without installing]' \
+    \\                        '--force[Pass --force to the install]' \
+    \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
+    \\                        '*:file:_files'
+    \\                    ;;
     \\                version)
     \\                    _values 'subcommand' 'update[Self-update the binary]'
     \\                    ;;
@@ -372,6 +389,8 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n __malt_needs_command -a run         -d 'Run package binary without installing'
     \\    complete -c $__malt_bin -n __malt_needs_command -a version     -d 'Show version or self-update'
     \\    complete -c $__malt_bin -n __malt_needs_command -a completions -d 'Generate shell completion scripts'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a backup      -d 'Dump installed packages to a text file'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a restore     -d 'Reinstall every package in a backup file'
     \\    complete -c $__malt_bin -n __malt_needs_command -a help        -d 'Show help'
     \\
     \\    # install
@@ -439,6 +458,15 @@ pub const fish_script =
     \\
     \\    # completions — shell name as positional
     \\    complete -c $__malt_bin -n '__malt_using_command completions' -f -a 'bash zsh fish'
+    \\
+    \\    # backup
+    \\    complete -c $__malt_bin -n '__malt_using_command backup' -s o -l output   -r -d 'Output file (use - for stdout)'
+    \\    complete -c $__malt_bin -n '__malt_using_command backup'      -l versions    -d 'Pin each entry to its current version'
+    \\
+    \\    # restore — positional backup file
+    \\    complete -c $__malt_bin -n '__malt_using_command restore' -l dry-run -d 'Preview without installing'
+    \\    complete -c $__malt_bin -n '__malt_using_command restore' -l force   -d 'Pass --force to install'
+    \\    complete -c $__malt_bin -n '__malt_using_command restore' -F
     \\
     \\    # version — sub-subcommand
     \\    complete -c $__malt_bin -n '__malt_using_command version' -f -a 'update' -d 'Self-update'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -36,6 +36,8 @@ fn helpFor(command: []const u8) []const u8 {
         .{ "link", link_help },
         .{ "unlink", unlink_help2 },
         .{ "completions", completions_help },
+        .{ "backup", backup_help },
+        .{ "restore", restore_help },
     });
     return map.get(command) orelse "No help available.\n";
 }
@@ -263,5 +265,44 @@ const completions_help =
     \\  bash    malt completions bash > /usr/local/etc/bash_completion.d/malt
     \\  zsh     malt completions zsh  > "${fpath[1]}/_malt"
     \\  fish    malt completions fish > ~/.config/fish/completions/malt.fish
+    \\
+;
+
+const backup_help =
+    \\Usage: malt backup [flags]
+    \\
+    \\Dump the list of directly-installed formulae and casks to a plain-text
+    \\file that `malt restore` can consume to reproduce the environment on
+    \\another machine.
+    \\
+    \\By default the file is written to the current directory with a
+    \\timestamped name, e.g. `malt-backup-2026-04-10T14-32-05.txt`.
+    \\
+    \\Flags:
+    \\  --output, -o <path>  Write to a specific file (use `-` for stdout)
+    \\  --versions           Pin each entry to its current version (@ver)
+    \\  --quiet, -q          Suppress non-error output
+    \\
+    \\Examples:
+    \\  malt backup
+    \\  malt backup -o ~/dotfiles/packages.txt
+    \\  malt backup --versions -o - > snapshot.txt
+    \\
+;
+
+const restore_help =
+    \\Usage: malt restore <file> [flags]
+    \\
+    \\Read a backup file produced by `malt backup` and install every entry
+    \\it lists. Formulae and casks are installed in a single batched run each
+    \\so dependency resolution and parallel downloads apply normally.
+    \\
+    \\Flags:
+    \\  --dry-run     Print the list of packages that would be installed
+    \\  --force       Pass --force to the underlying install
+    \\  --quiet, -q   Suppress non-error output
+    \\
+    \\Example:
+    \\  malt restore malt-backup-2026-04-10T14-32-05.txt
     \\
 ;

--- a/src/cli/restore.zig
+++ b/src/cli/restore.zig
@@ -1,0 +1,155 @@
+//! malt — restore command
+//! Reads a backup file produced by `malt backup` and installs every entry
+//! it contains. Thin wrapper over `malt install` — the install command does
+//! the heavy lifting (DB lock, download, dependency resolution).
+
+const std = @import("std");
+const backup_mod = @import("backup.zig");
+const install_mod = @import("install.zig");
+const output = @import("../ui/output.zig");
+const help = @import("help.zig");
+
+pub const Error = error{
+    MissingFileArgument,
+    FileNotFound,
+    ReadFailed,
+    Empty,
+    InvalidArgs,
+};
+
+pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
+    if (help.showIfRequested(args, "restore")) return;
+
+    // `--dry-run` is a global flag consumed by main.zig before we get here,
+    // so we read it via `output.isDryRun()` rather than from `args`.
+    const dry_run = output.isDryRun();
+    var file_path: ?[]const u8 = null;
+    var force = false;
+
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--force")) {
+            force = true;
+        } else if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
+            output.setQuiet(true);
+        } else if (std.mem.startsWith(u8, arg, "-")) {
+            output.err("Unknown argument for restore: {s}", .{arg});
+            return Error.InvalidArgs;
+        } else if (file_path == null) {
+            file_path = arg;
+        } else {
+            output.err("restore accepts a single file argument (got extra: {s})", .{arg});
+            return Error.InvalidArgs;
+        }
+    }
+
+    const path = file_path orelse {
+        output.err("Usage: malt restore <file>", .{});
+        return Error.MissingFileArgument;
+    };
+
+    // ── Read the file ────────────────────────────────────────────────────
+    const text = readFile(allocator, path) catch |e| switch (e) {
+        error.FileNotFound => {
+            output.err("Backup file not found: {s}", .{path});
+            return Error.FileNotFound;
+        },
+        else => {
+            output.err("Failed to read {s}", .{path});
+            return Error.ReadFailed;
+        },
+    };
+    defer allocator.free(text);
+
+    const entries = backup_mod.parseBackup(allocator, text) catch {
+        output.err("Failed to parse backup file: {s}", .{path});
+        return Error.ReadFailed;
+    };
+    defer allocator.free(entries);
+
+    if (entries.len == 0) {
+        output.warn("No entries found in {s}", .{path});
+        return;
+    }
+
+    // ── Split into formula / cask arg lists ──────────────────────────────
+    var formulae: std.ArrayList([]const u8) = .empty;
+    defer formulae.deinit(allocator);
+    var casks: std.ArrayList([]const u8) = .empty;
+    defer casks.deinit(allocator);
+
+    for (entries) |e| {
+        // Reconstruct the install-style argument: `<name>` or `<name>@<version>`
+        const arg = if (e.version.len > 0)
+            try std.fmt.allocPrint(allocator, "{s}@{s}", .{ e.name, e.version })
+        else
+            try allocator.dupe(u8, e.name);
+
+        switch (e.kind) {
+            .formula => try formulae.append(allocator, arg),
+            .cask => try casks.append(allocator, arg),
+        }
+    }
+
+    output.info("Restoring {d} formula(e) and {d} cask(s) from {s}", .{
+        formulae.items.len,
+        casks.items.len,
+        path,
+    });
+
+    if (dry_run) {
+        for (formulae.items) |name| output.info("  formula {s}", .{name});
+        for (casks.items) |name| output.info("  cask    {s}", .{name});
+        output.info("Dry run — no packages installed.", .{});
+        return;
+    }
+
+    // ── Delegate to `malt install` ───────────────────────────────────────
+    // Two calls: one batched for formulae, one batched for casks. install.zig
+    // already prints per-package success/failure, so we do not re-summarise.
+    var any_failed = false;
+
+    if (formulae.items.len > 0) {
+        var argv: std.ArrayList([]const u8) = .empty;
+        defer argv.deinit(allocator);
+        try argv.append(allocator, "--formula");
+        if (force) try argv.append(allocator, "--force");
+        for (formulae.items) |name| try argv.append(allocator, name);
+
+        install_mod.execute(allocator, argv.items) catch |e| {
+            output.err("Formula restore returned error: {s}", .{@errorName(e)});
+            any_failed = true;
+        };
+    }
+
+    if (casks.items.len > 0) {
+        var argv: std.ArrayList([]const u8) = .empty;
+        defer argv.deinit(allocator);
+        try argv.append(allocator, "--cask");
+        if (force) try argv.append(allocator, "--force");
+        for (casks.items) |name| try argv.append(allocator, name);
+
+        install_mod.execute(allocator, argv.items) catch |e| {
+            output.err("Cask restore returned error: {s}", .{@errorName(e)});
+            any_failed = true;
+        };
+    }
+
+    if (any_failed) {
+        return error.RestoreFailed;
+    }
+}
+
+fn readFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    const file = if (std.fs.path.isAbsolute(path))
+        try std.fs.openFileAbsolute(path, .{})
+    else
+        try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+
+    const stat = try file.stat();
+    const bytes = try allocator.alloc(u8, stat.size);
+    errdefer allocator.free(bytes);
+    const n = try file.readAll(bytes);
+    if (n != stat.size) return error.ReadFailed;
+    return bytes;
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -21,3 +21,4 @@ pub const output = @import("ui/output.zig");
 pub const progress = @import("ui/progress.zig");
 pub const version = @import("version.zig");
 pub const completions = @import("cli/completions.zig");
+pub const backup = @import("cli/backup.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -34,6 +34,8 @@ const link_cmd = @import("cli/link.zig");
 const run_cmd = @import("cli/run.zig");
 const version_update = @import("cli/version_update.zig");
 const completions = @import("cli/completions.zig");
+const backup = @import("cli/backup.zig");
+const restore = @import("cli/restore.zig");
 
 const version_mod = @import("version.zig");
 const version = version_mod.value;
@@ -60,6 +62,8 @@ const Command = enum {
     run,
     version_cmd,
     completions,
+    backup,
+    restore,
     help,
     version,
 };
@@ -87,6 +91,8 @@ const command_map = std.StaticStringMap(Command).initComptime(.{
     .{ "unlink", .unlink },
     .{ "run", .run },
     .{ "completions", .completions },
+    .{ "backup", .backup },
+    .{ "restore", .restore },
     .{ "help", .help },
     .{ "--help", .help },
     .{ "-h", .help },
@@ -182,6 +188,8 @@ pub fn main() !void {
             .unlink => try link_cmd.executeUnlink(allocator, cmd_args),
             .run => try run_cmd.execute(allocator, cmd_args),
             .completions => try completions.execute(allocator, cmd_args),
+            .backup => try backup.execute(allocator, cmd_args),
+            .restore => try restore.execute(allocator, cmd_args),
             .version_cmd => {
                 // "mt version" — check for "mt version update" subcommand
                 if (cmd_args.len > 0 and std.mem.eql(u8, cmd_args[0], "update")) {
@@ -226,6 +234,8 @@ fn printUsage() void {
         \\  unlink        Remove symlinks (keg stays installed)
         \\  run           Run a package binary without installing
         \\  completions   Generate shell completion scripts (bash, zsh, fish)
+        \\  backup        Dump installed packages to a restorable text file
+        \\  restore       Reinstall every package listed in a backup file
         \\  version       Show version (use 'version update' to self-update)
         \\
         \\Global flags:

--- a/tests/backup_test.zig
+++ b/tests/backup_test.zig
@@ -1,0 +1,234 @@
+//! malt — backup command tests
+//! The execute() function touches the SQLite database and writes to the
+//! filesystem, so these tests cover the pure helpers (writeEntry, parseLine,
+//! parseBackup, defaultBackupPath) that do the actual work.
+
+const std = @import("std");
+const testing = std.testing;
+const backup = @import("malt").backup;
+
+// ── writeEntry / writeHeader ─────────────────────────────────────────────
+
+test "writeEntry writes a bare formula line without a version" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    try backup.writeEntry(buf.writer(testing.allocator), .formula, "git", "2.44.0", false);
+    try testing.expectEqualStrings("formula git\n", buf.items);
+}
+
+test "writeEntry writes a bare cask line without a version" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    try backup.writeEntry(buf.writer(testing.allocator), .cask, "firefox", "124.0", false);
+    try testing.expectEqualStrings("cask firefox\n", buf.items);
+}
+
+test "writeEntry includes @version when include_versions is true" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    try backup.writeEntry(buf.writer(testing.allocator), .formula, "wget", "1.24.5", true);
+    try testing.expectEqualStrings("formula wget@1.24.5\n", buf.items);
+}
+
+test "writeEntry omits @version even with include_versions when version is empty" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    try backup.writeEntry(buf.writer(testing.allocator), .cask, "slack", "", true);
+    try testing.expectEqualStrings("cask slack\n", buf.items);
+}
+
+test "writeHeader emits comment lines and a trailing blank line" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    try backup.writeHeader(buf.writer(testing.allocator));
+
+    // Every non-blank line in the header must start with `#` so that
+    // `parseBackup` ignores them when the file is restored.
+    var lines = std.mem.splitScalar(u8, buf.items, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        try testing.expectEqual(@as(u8, '#'), line[0]);
+    }
+}
+
+// ── parseLine ────────────────────────────────────────────────────────────
+
+test "parseLine returns null for blank lines and comments" {
+    try testing.expect(backup.parseLine("") == null);
+    try testing.expect(backup.parseLine("   ") == null);
+    try testing.expect(backup.parseLine("\t") == null);
+    try testing.expect(backup.parseLine("# malt backup") == null);
+    try testing.expect(backup.parseLine("   # indented comment") == null);
+}
+
+test "parseLine parses a bare formula line" {
+    const e = backup.parseLine("formula git").?;
+    try testing.expectEqual(backup.Kind.formula, e.kind);
+    try testing.expectEqualStrings("git", e.name);
+    try testing.expectEqualStrings("", e.version);
+}
+
+test "parseLine parses a bare cask line" {
+    const e = backup.parseLine("cask firefox").?;
+    try testing.expectEqual(backup.Kind.cask, e.kind);
+    try testing.expectEqualStrings("firefox", e.name);
+    try testing.expectEqualStrings("", e.version);
+}
+
+test "parseLine parses the @version suffix" {
+    const f = backup.parseLine("formula wget@1.24.5").?;
+    try testing.expectEqual(backup.Kind.formula, f.kind);
+    try testing.expectEqualStrings("wget", f.name);
+    try testing.expectEqualStrings("1.24.5", f.version);
+
+    const c = backup.parseLine("cask slack@4.36.140").?;
+    try testing.expectEqual(backup.Kind.cask, c.kind);
+    try testing.expectEqualStrings("slack", c.name);
+    try testing.expectEqualStrings("4.36.140", c.version);
+}
+
+test "parseLine tolerates trailing carriage returns and surrounding whitespace" {
+    const a = backup.parseLine("  formula git  \r").?;
+    try testing.expectEqualStrings("git", a.name);
+
+    const b = backup.parseLine("cask firefox\r").?;
+    try testing.expectEqualStrings("firefox", b.name);
+}
+
+test "parseLine returns null for unknown kinds and malformed lines" {
+    // Unknown kind prefix.
+    try testing.expect(backup.parseLine("bottle git") == null);
+    // Kind prefix without a name.
+    try testing.expect(backup.parseLine("formula ") == null);
+    try testing.expect(backup.parseLine("cask   ") == null);
+    // No space between kind and name (missed prefix).
+    try testing.expect(backup.parseLine("formulagit") == null);
+}
+
+// ── parseBackup + round-trip ─────────────────────────────────────────────
+
+test "parseBackup ignores comments and parses every data line in order" {
+    const text =
+        "# malt backup\n" ++
+        "# some header comment\n" ++
+        "\n" ++
+        "formula git\n" ++
+        "formula wget@1.24.5\n" ++
+        "# mid-file comment\n" ++
+        "cask firefox\n" ++
+        "cask slack@4.36.140\n";
+
+    const entries = try backup.parseBackup(testing.allocator, text);
+    defer testing.allocator.free(entries);
+
+    try testing.expectEqual(@as(usize, 4), entries.len);
+
+    try testing.expectEqual(backup.Kind.formula, entries[0].kind);
+    try testing.expectEqualStrings("git", entries[0].name);
+    try testing.expectEqualStrings("", entries[0].version);
+
+    try testing.expectEqual(backup.Kind.formula, entries[1].kind);
+    try testing.expectEqualStrings("wget", entries[1].name);
+    try testing.expectEqualStrings("1.24.5", entries[1].version);
+
+    try testing.expectEqual(backup.Kind.cask, entries[2].kind);
+    try testing.expectEqualStrings("firefox", entries[2].name);
+
+    try testing.expectEqual(backup.Kind.cask, entries[3].kind);
+    try testing.expectEqualStrings("slack", entries[3].name);
+    try testing.expectEqualStrings("4.36.140", entries[3].version);
+}
+
+test "parseBackup handles an empty input" {
+    const entries = try backup.parseBackup(testing.allocator, "");
+    defer testing.allocator.free(entries);
+    try testing.expectEqual(@as(usize, 0), entries.len);
+}
+
+test "parseBackup handles a file with only comments and blank lines" {
+    const text =
+        "# header\n" ++
+        "\n" ++
+        "   \n" ++
+        "# another\n";
+    const entries = try backup.parseBackup(testing.allocator, text);
+    defer testing.allocator.free(entries);
+    try testing.expectEqual(@as(usize, 0), entries.len);
+}
+
+test "parseBackup tolerates a file that does not end with a newline" {
+    const text = "formula git\ncask firefox";
+    const entries = try backup.parseBackup(testing.allocator, text);
+    defer testing.allocator.free(entries);
+    try testing.expectEqual(@as(usize, 2), entries.len);
+    try testing.expectEqualStrings("git", entries[0].name);
+    try testing.expectEqualStrings("firefox", entries[1].name);
+}
+
+test "parseBackup skips junk lines instead of failing" {
+    // Unknown kinds and broken lines should be silently dropped so one bad
+    // edit does not invalidate the whole backup file.
+    const text =
+        "formula git\n" ++
+        "gibberish line\n" ++
+        "formula \n" ++ // empty name
+        "cask firefox\n" ++
+        "pkg nope\n";
+    const entries = try backup.parseBackup(testing.allocator, text);
+    defer testing.allocator.free(entries);
+    try testing.expectEqual(@as(usize, 2), entries.len);
+    try testing.expectEqualStrings("git", entries[0].name);
+    try testing.expectEqualStrings("firefox", entries[1].name);
+}
+
+test "writeEntry + parseBackup round-trip preserves every entry" {
+    const fixtures = [_]struct {
+        kind: backup.Kind,
+        name: []const u8,
+        version: []const u8,
+    }{
+        .{ .kind = .formula, .name = "git", .version = "2.44.0" },
+        .{ .kind = .formula, .name = "wget", .version = "1.24.5" },
+        .{ .kind = .cask, .name = "firefox", .version = "124.0" },
+        .{ .kind = .cask, .name = "slack", .version = "4.36.140" },
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const w = buf.writer(testing.allocator);
+    try backup.writeHeader(w);
+    for (fixtures) |f| {
+        try backup.writeEntry(w, f.kind, f.name, f.version, true);
+    }
+
+    const entries = try backup.parseBackup(testing.allocator, buf.items);
+    defer testing.allocator.free(entries);
+
+    try testing.expectEqual(fixtures.len, entries.len);
+    inline for (fixtures, 0..) |f, i| {
+        try testing.expectEqual(f.kind, entries[i].kind);
+        try testing.expectEqualStrings(f.name, entries[i].name);
+        try testing.expectEqualStrings(f.version, entries[i].version);
+    }
+}
+
+// ── defaultBackupPath ────────────────────────────────────────────────────
+
+test "defaultBackupPath has the expected shape" {
+    const path = try backup.defaultBackupPath(testing.allocator);
+    defer testing.allocator.free(path);
+
+    // Expected shape: "malt-backup-YYYY-MM-DDTHH-MM-SS.txt" (35 chars).
+    try testing.expect(std.mem.startsWith(u8, path, "malt-backup-"));
+    try testing.expect(std.mem.endsWith(u8, path, ".txt"));
+    try testing.expectEqual(@as(usize, 35), path.len);
+
+    // Every non-separator character must be a digit so the filename is
+    // safe on every filesystem (no spaces, no colons).
+    const body = path["malt-backup-".len .. path.len - ".txt".len];
+    for (body) |ch| {
+        const is_digit = ch >= '0' and ch <= '9';
+        const is_sep = ch == '-' or ch == 'T';
+        try testing.expect(is_digit or is_sep);
+    }
+}

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -40,7 +40,8 @@ const all_commands = [_][]const u8{
     "info",       "search",    "cleanup",     "doctor",
     "tap",        "untap",     "gc",          "migrate",
     "autoremove", "rollback",  "link",        "unlink",
-    "run",        "version",   "completions",
+    "run",        "version",   "completions", "backup",
+    "restore",
 };
 
 fn expectContains(haystack: []const u8, needle: []const u8) !void {


### PR DESCRIPTION
## Summary 

Add two CLI commands that let users snapshot and reproduce a `malt` installation:

- **`malt backup`**:  dumps directly-installed formulae and casks to a plain-text file (default: `./malt-backup-<timestamp>.txt`). Supports `--output PATH` (use `-` for stdout) and `--versions` to pin entries.
- **`malt restore <file>`**: parses a backup file and delegates to `install` in two batched calls (one `--formula`, one `--cask`),  so dependency resolution, parallel downloads, and per-package error reporting come for free. 

File format is line-oriented and hand-editable:

```text
formula git
formula wget@1.24.5
cask firefox
cask slack
```