### PR TITLE
feat(cli): add `mt purge` to wipe a malt installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,32 @@ mt restore my-setup.txt --force          # pass --force to the underlying instal
 
 Formulas and casks are batched into two `mt install` invocations, so dependency resolution, parallel downloads, and the atomic install protocol all apply. Lines prefixed with `#` and blank lines are ignored, and entries with a `@<version>` suffix are installed at that exact version.
 
+### `mt purge`
+
+Completely wipe a malt installation from disk — every package, the content-addressable store, linked binaries, the cache, and the SQLite database.
+
+```bash
+mt purge                                 # interactive, requires typing `purge`
+mt purge --dry-run                       # preview every target with sizes
+mt purge --backup ~/malt-snapshot.txt    # dump restorable manifest first
+mt purge --keep-cache                    # leave cache/ intact (faster reinstall)
+mt purge --remove-binary --yes           # also unlink /usr/local/bin/{mt,malt}
+```
+
+| Flag                    | Description                                                                                        |
+| ----------------------- | -------------------------------------------------------------------------------------------------- |
+| `--backup`, `-b` _path_ | Write a `mt restore`-compatible manifest of installed packages **before** any deletion             |
+| `--keep-cache`          | Preserve the cache directory (downloaded bottles stay on disk for a later reinstall)               |
+| `--remove-binary`       | Also unlink `/usr/local/bin/mt` and `/usr/local/bin/malt` (opt-in — these live outside the prefix) |
+| `--yes`, `-y`           | Skip the typed confirmation (required for non-interactive / CI use)                                |
+| `--dry-run`             | Preview every target without touching disk                                                         |
+
+Interactive by default: prints a warning banner with every target and its size, then requires you to type the literal word `purge` (not `y`) to proceed. Refuses to run when stdin is not a TTY unless `--yes` is passed, so a stray `echo y | mt purge` cannot trigger a wipe.
+
+Acquires `{prefix}/db/malt.lock` before deleting so concurrent malt processes cannot race, and releases the lock before removing the `db/` directory itself. Honours `MALT_PREFIX` and `MALT_CACHE`, so pointing those at a throwaway path is the safe way to test the command end-to-end.
+
+Use `mt uninstall <name>` for per-package removal, `mt cleanup` for cache-only cleanup, and `mt autoremove` / `mt gc` for orphan removal — `mt purge` is specifically the nuclear option for uninstalling malt entirely.
+
 ### `mt rollback`
 
 Revert a formula to its previous version using the content-addressable store.

--- a/build.zig
+++ b/build.zig
@@ -63,6 +63,7 @@ pub fn build(b: *std.Build) void {
         "tests/progress_e2e_test.zig",
         "tests/completions_test.zig",
         "tests/backup_test.zig",
+        "tests/purge_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -84,7 +84,7 @@ pub const bash_script =
     \\    words=("${COMP_WORDS[@]}")
     \\    cword=$COMP_CWORD
     \\
-    \\    local commands="install uninstall remove upgrade update outdated list ls info search cleanup doctor tap untap gc migrate autoremove rollback link unlink run version completions backup restore help"
+    \\    local commands="install uninstall remove upgrade update outdated list ls info search cleanup doctor tap untap gc migrate autoremove rollback link unlink run version completions backup restore purge help"
     \\    local global_flags="--verbose -v --quiet -q --json --dry-run --help -h --version"
     \\
     \\    # Find the first non-flag word after the program — that's the subcommand.
@@ -125,6 +125,7 @@ pub const bash_script =
     \\        install)          cmd_flags="--cask --formula --dry-run --force --quiet -q --json" ;;
     \\        backup)           cmd_flags="--output -o --versions --quiet -q" ;;
     \\        restore)          cmd_flags="--dry-run --force --quiet -q" ;;
+    \\        purge)            cmd_flags="--backup -b --keep-cache --remove-binary --yes -y --dry-run" ;;
     \\        uninstall|remove) cmd_flags="--force --zap --dry-run" ;;
     \\        upgrade)          cmd_flags="--all --cask --formula --dry-run" ;;
     \\        outdated)         cmd_flags="--json --formula --cask --quiet -q" ;;
@@ -194,6 +195,7 @@ pub const zsh_script =
     \\        'completions:Generate shell completion scripts'
     \\        'backup:Dump installed packages to a restorable text file'
     \\        'restore:Reinstall every package listed in a backup file'
+    \\        'purge:Completely wipe the malt installation from disk'
     \\        'help:Show help'
     \\    )
     \\
@@ -299,6 +301,14 @@ pub const zsh_script =
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
     \\                        '*:file:_files'
     \\                    ;;
+    \\                purge)
+    \\                    _arguments \
+    \\                        '(--backup -b)'{--backup,-b}'[Write a restorable manifest before deleting]:path:_files' \
+    \\                        '--keep-cache[Leave the cache directory intact]' \
+    \\                        '--remove-binary[Also unlink /usr/local/bin/{mt,malt}]' \
+    \\                        '(--yes -y)'{--yes,-y}'[Skip the typed confirmation]' \
+    \\                        '--dry-run[Preview every target without deleting]'
+    \\                    ;;
     \\                version)
     \\                    _values 'subcommand' 'update[Self-update the binary]'
     \\                    ;;
@@ -391,6 +401,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n __malt_needs_command -a completions -d 'Generate shell completion scripts'
     \\    complete -c $__malt_bin -n __malt_needs_command -a backup      -d 'Dump installed packages to a text file'
     \\    complete -c $__malt_bin -n __malt_needs_command -a restore     -d 'Reinstall every package in a backup file'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a purge       -d 'Completely wipe the malt installation'
     \\    complete -c $__malt_bin -n __malt_needs_command -a help        -d 'Show help'
     \\
     \\    # install
@@ -467,6 +478,13 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command restore' -l dry-run -d 'Preview without installing'
     \\    complete -c $__malt_bin -n '__malt_using_command restore' -l force   -d 'Pass --force to install'
     \\    complete -c $__malt_bin -n '__malt_using_command restore' -F
+    \\
+    \\    # purge
+    \\    complete -c $__malt_bin -n '__malt_using_command purge' -s b -l backup        -r -d 'Write a restorable manifest before deleting'
+    \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l keep-cache       -d 'Leave the cache directory intact'
+    \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l remove-binary    -d 'Also unlink /usr/local/bin/{mt,malt}'
+    \\    complete -c $__malt_bin -n '__malt_using_command purge' -s y -l yes             -d 'Skip the typed confirmation'
+    \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l dry-run          -d 'Preview every target without deleting'
     \\
     \\    # version — sub-subcommand
     \\    complete -c $__malt_bin -n '__malt_using_command version' -f -a 'update' -d 'Self-update'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -38,6 +38,7 @@ fn helpFor(command: []const u8) []const u8 {
         .{ "completions", completions_help },
         .{ "backup", backup_help },
         .{ "restore", restore_help },
+        .{ "purge", purge_help },
     });
     return map.get(command) orelse "No help available.\n";
 }
@@ -287,6 +288,39 @@ const backup_help =
     \\  malt backup
     \\  malt backup -o ~/dotfiles/packages.txt
     \\  malt backup --versions -o - > snapshot.txt
+    \\
+;
+
+const purge_help =
+    \\Usage: malt purge [flags]
+    \\
+    \\Completely wipe a malt installation from disk. Destructive: removes
+    \\every package, the content-addressable store, linked binaries, the
+    \\cache, and the sqlite database.
+    \\
+    \\By default the command is interactive and requires typing the word
+    \\`purge` to confirm. Use `--dry-run` to preview, `--yes` for scripts.
+    \\
+    \\Flags:
+    \\  --backup, -b <path>  Write a `mt restore`-compatible manifest of
+    \\                       the currently-installed packages before
+    \\                       deleting anything.
+    \\  --keep-cache         Do not delete the cache directory (keeps
+    \\                       downloaded bottles for a later reinstall).
+    \\  --remove-binary      Also unlink /usr/local/bin/mt and
+    \\                       /usr/local/bin/malt. Opt-in because these
+    \\                       live outside the prefix.
+    \\  --yes, -y            Skip the typed confirmation (for CI).
+    \\  --dry-run            Preview every target without touching disk.
+    \\
+    \\Examples:
+    \\  malt purge --dry-run
+    \\  malt purge --backup ~/malt-snapshot.txt
+    \\  malt purge --keep-cache --yes
+    \\  malt purge --remove-binary --yes
+    \\
+    \\For per-package removal use `mt uninstall <name>`; for cache-only
+    \\cleanup use `mt cleanup`.
     \\
 ;
 

--- a/src/cli/purge.zig
+++ b/src/cli/purge.zig
@@ -1,0 +1,459 @@
+//! malt — purge command
+//! Completely wipe a malt installation from disk.
+//!
+//! Deletes (under `{prefix}` by default):
+//!   Cellar, Caskroom, store, opt, linked dirs (bin/lib/…), cache, tmp, db,
+//!   and finally the prefix directory itself when empty.
+//!
+//! With `--remove-binary`, also unlinks `/usr/local/bin/mt` and
+//! `/usr/local/bin/malt` after the rest of the install is gone.
+//!
+//! Safety model:
+//!   * Interactive by default — requires typing the word `purge` to proceed.
+//!   * Honours the global `--dry-run` flag and previews every target.
+//!   * `--backup <path>` snapshots the installed package list to a manifest
+//!     (in the same format as `mt backup --versions`) before any deletion.
+//!   * Acquires `{prefix}/db/malt.lock` to serialise against other malt runs,
+//!     and releases it before removing the db directory itself.
+//!
+//! Non-goals:
+//!   * Per-package removal — use `mt uninstall <name>`.
+//!   * Cache-only cleanup — use `mt cleanup`.
+//!   * Orphan removal — use `mt autoremove` / `mt gc`.
+
+const std = @import("std");
+const atomic = @import("../fs/atomic.zig");
+const output = @import("../ui/output.zig");
+const lock_mod = @import("../db/lock.zig");
+const backup_mod = @import("backup.zig");
+const sqlite = @import("../db/sqlite.zig");
+const help = @import("help.zig");
+
+pub const Error = error{
+    InvalidArgs,
+    UserAborted,
+    LockFailed,
+    DatabaseError,
+    OpenFileFailed,
+    WriteFailed,
+    OutOfMemory,
+};
+
+/// User-controllable options parsed from the purge subcommand's argv.
+pub const Options = struct {
+    keep_cache: bool = false,
+    backup_path: ?[]const u8 = null,
+    yes: bool = false,
+    remove_binary: bool = false,
+};
+
+/// Category of a deletion target — used for grouping output and for the
+/// lock-aware ordering in `execute`.
+pub const Category = enum {
+    linked_dir, // {prefix}/bin, sbin, lib, include, share, etc
+    opt, // {prefix}/opt
+    cellar, // {prefix}/Cellar
+    caskroom, // {prefix}/Caskroom
+    store, // {prefix}/store
+    cache, // {prefix}/cache (or $MALT_CACHE)
+    tmp, // {prefix}/tmp
+    db, // {prefix}/db — removed AFTER the lock is released
+    prefix_root, // {prefix} itself — only removed if empty
+    binary, // /usr/local/bin/{mt,malt} — opt-in via --remove-binary
+
+    pub fn label(self: Category) []const u8 {
+        return switch (self) {
+            .linked_dir => "linked",
+            .opt => "opt",
+            .cellar => "Cellar",
+            .caskroom => "Caskroom",
+            .store => "store",
+            .cache => "cache",
+            .tmp => "tmp",
+            .db => "db",
+            .prefix_root => "prefix",
+            .binary => "binary",
+        };
+    }
+};
+
+/// A single path scheduled for deletion.
+pub const Target = struct {
+    path: []const u8,
+    category: Category,
+};
+
+/// Parse the purge-specific flags.  Global flags (`--dry-run`, `--quiet`,
+/// etc.) are consumed by `main.zig` before dispatch and must NOT appear
+/// here.  Unknown flags produce `Error.InvalidArgs`.
+pub fn parseArgs(args: []const []const u8) Error!Options {
+    var opts: Options = .{};
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        if (std.mem.eql(u8, arg, "--keep-cache")) {
+            opts.keep_cache = true;
+        } else if (std.mem.eql(u8, arg, "--yes") or std.mem.eql(u8, arg, "-y")) {
+            opts.yes = true;
+        } else if (std.mem.eql(u8, arg, "--remove-binary")) {
+            opts.remove_binary = true;
+        } else if (std.mem.eql(u8, arg, "--backup") or std.mem.eql(u8, arg, "-b")) {
+            if (i + 1 >= args.len) return Error.InvalidArgs;
+            i += 1;
+            opts.backup_path = args[i];
+        } else if (std.mem.startsWith(u8, arg, "--backup=")) {
+            opts.backup_path = arg["--backup=".len..];
+        } else {
+            return Error.InvalidArgs;
+        }
+    }
+    return opts;
+}
+
+/// Build the ordered deletion plan for the given options.  Returned slice
+/// and every `path` inside it are owned by the caller; free via `freePlan`.
+///
+/// Order is intentional: sub-trees first (linked dirs, Cellar, Caskroom,
+/// store, cache, tmp), then the db directory (which holds the lock file —
+/// execute() removes it after releasing the lock), then the prefix root.
+pub fn buildPlan(
+    allocator: std.mem.Allocator,
+    opts: Options,
+    prefix: []const u8,
+    cache_dir: []const u8,
+) Error![]Target {
+    var list: std.ArrayList(Target) = .empty;
+    errdefer freeList(allocator, &list);
+
+    // Linked dirs first so dangling symlinks are cleaned before the Cellar
+    // targets they point at.
+    const linked = [_][]const u8{ "bin", "sbin", "lib", "include", "share", "etc" };
+    for (linked) |name| {
+        const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ prefix, name }) catch return Error.OutOfMemory;
+        list.append(allocator, .{ .path = path, .category = .linked_dir }) catch return Error.OutOfMemory;
+    }
+
+    list.append(allocator, .{
+        .path = std.fmt.allocPrint(allocator, "{s}/opt", .{prefix}) catch return Error.OutOfMemory,
+        .category = .opt,
+    }) catch return Error.OutOfMemory;
+    list.append(allocator, .{
+        .path = std.fmt.allocPrint(allocator, "{s}/Cellar", .{prefix}) catch return Error.OutOfMemory,
+        .category = .cellar,
+    }) catch return Error.OutOfMemory;
+    list.append(allocator, .{
+        .path = std.fmt.allocPrint(allocator, "{s}/Caskroom", .{prefix}) catch return Error.OutOfMemory,
+        .category = .caskroom,
+    }) catch return Error.OutOfMemory;
+    list.append(allocator, .{
+        .path = std.fmt.allocPrint(allocator, "{s}/store", .{prefix}) catch return Error.OutOfMemory,
+        .category = .store,
+    }) catch return Error.OutOfMemory;
+
+    if (!opts.keep_cache) {
+        const dup = allocator.dupe(u8, cache_dir) catch return Error.OutOfMemory;
+        list.append(allocator, .{ .path = dup, .category = .cache }) catch return Error.OutOfMemory;
+    }
+
+    list.append(allocator, .{
+        .path = std.fmt.allocPrint(allocator, "{s}/tmp", .{prefix}) catch return Error.OutOfMemory,
+        .category = .tmp,
+    }) catch return Error.OutOfMemory;
+    list.append(allocator, .{
+        .path = std.fmt.allocPrint(allocator, "{s}/db", .{prefix}) catch return Error.OutOfMemory,
+        .category = .db,
+    }) catch return Error.OutOfMemory;
+    list.append(allocator, .{
+        .path = allocator.dupe(u8, prefix) catch return Error.OutOfMemory,
+        .category = .prefix_root,
+    }) catch return Error.OutOfMemory;
+
+    if (opts.remove_binary) {
+        const bin_paths = [_][]const u8{ "/usr/local/bin/mt", "/usr/local/bin/malt" };
+        for (bin_paths) |p| {
+            const dup = allocator.dupe(u8, p) catch return Error.OutOfMemory;
+            list.append(allocator, .{ .path = dup, .category = .binary }) catch return Error.OutOfMemory;
+        }
+    }
+
+    return list.toOwnedSlice(allocator) catch return Error.OutOfMemory;
+}
+
+pub fn freePlan(allocator: std.mem.Allocator, plan: []const Target) void {
+    for (plan) |t| allocator.free(t.path);
+    allocator.free(plan);
+}
+
+fn freeList(allocator: std.mem.Allocator, list: *std.ArrayList(Target)) void {
+    for (list.items) |t| allocator.free(t.path);
+    list.deinit(allocator);
+}
+
+/// Format a byte count as a human-readable string (e.g. "1.4 GB") into `buf`.
+pub fn formatBytes(bytes: u64, buf: []u8) []const u8 {
+    const units = [_][]const u8{ "B", "KB", "MB", "GB", "TB" };
+    var value: f64 = @floatFromInt(bytes);
+    var unit: usize = 0;
+    while (value >= 1024.0 and unit + 1 < units.len) {
+        value /= 1024.0;
+        unit += 1;
+    }
+    return std.fmt.bufPrint(buf, "{d:.1} {s}", .{ value, units[unit] }) catch "?";
+}
+
+/// Best-effort recursive size of a directory (or single file) at `path`.
+/// Returns 0 when the path cannot be opened — sizes are informational
+/// only, so silent failures are preferable to aborting the dry-run.
+fn pathSize(allocator: std.mem.Allocator, path: []const u8) u64 {
+    // Non-directory fast path — stat and return.
+    if (std.fs.cwd().statFile(path)) |st| {
+        if (st.kind != .directory) return st.size;
+    } else |_| {}
+
+    var dir = std.fs.openDirAbsolute(path, .{ .iterate = true }) catch return 0;
+    defer dir.close();
+
+    var walker = dir.walk(allocator) catch return 0;
+    defer walker.deinit();
+
+    var total: u64 = 0;
+    while (walker.next() catch null) |entry| {
+        if (entry.kind == .file) {
+            const s = entry.dir.statFile(entry.basename) catch continue;
+            total += s.size;
+        }
+    }
+    return total;
+}
+
+/// Write the warning banner.  Uses `output.warnPlain` so the repeated `⚠`
+/// icon does not clutter every line of a multi-line warning block.
+fn warnBanner() void {
+    const rule = "────────────────────────────────────────────────────────────";
+    output.warnPlain("{s}", .{rule});
+    output.warnPlain("WARNING: this will permanently wipe your malt installation.", .{});
+    output.warnPlain("{s}", .{rule});
+}
+
+/// Dump the currently-installed package list to `path` as a `mt backup`
+/// manifest so the user can rebuild their environment with `mt restore`.
+fn writeManifest(allocator: std.mem.Allocator, path: []const u8) Error!void {
+    const prefix = atomic.maltPrefix();
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return Error.DatabaseError;
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    const w = buf.writer(allocator);
+    backup_mod.writeHeader(w) catch return Error.WriteFailed;
+
+    // When there's no DB we still write a header-only manifest so that the
+    // --backup path is honoured and the caller gets a predictable artefact.
+    if (sqlite.Database.open(db_path)) |*db_val| {
+        var db = db_val.*;
+        defer db.close();
+
+        var fstmt = db.prepare(
+            "SELECT name, version FROM kegs WHERE install_reason = 'direct' ORDER BY name;",
+        ) catch null;
+        if (fstmt) |*s| {
+            defer s.finalize();
+            while (s.step() catch false) {
+                const name_ptr = s.columnText(0) orelse continue;
+                const ver_ptr = s.columnText(1);
+                const name = std.mem.sliceTo(name_ptr, 0);
+                const version = if (ver_ptr) |p| std.mem.sliceTo(p, 0) else "";
+                backup_mod.writeEntry(w, .formula, name, version, true) catch return Error.WriteFailed;
+            }
+        }
+
+        var cstmt = db.prepare("SELECT token, version FROM casks ORDER BY token;") catch null;
+        if (cstmt) |*s| {
+            defer s.finalize();
+            while (s.step() catch false) {
+                const name_ptr = s.columnText(0) orelse continue;
+                const ver_ptr = s.columnText(1);
+                const name = std.mem.sliceTo(name_ptr, 0);
+                const version = if (ver_ptr) |p| std.mem.sliceTo(p, 0) else "";
+                backup_mod.writeEntry(w, .cask, name, version, true) catch return Error.WriteFailed;
+            }
+        }
+    } else |_| {}
+
+    try writeBytesToPath(path, buf.items);
+}
+
+fn writeBytesToPath(path: []const u8, bytes: []const u8) Error!void {
+    if (std.fs.path.dirname(path)) |dir| {
+        if (dir.len > 0) {
+            if (std.fs.path.isAbsolute(dir)) {
+                std.fs.makeDirAbsolute(dir) catch {};
+            } else {
+                std.fs.cwd().makePath(dir) catch {};
+            }
+        }
+    }
+    const file = if (std.fs.path.isAbsolute(path))
+        std.fs.createFileAbsolute(path, .{ .truncate = true }) catch return Error.OpenFileFailed
+    else
+        std.fs.cwd().createFile(path, .{ .truncate = true }) catch return Error.OpenFileFailed;
+    defer file.close();
+    file.writeAll(bytes) catch return Error.WriteFailed;
+}
+
+/// Try to remove `path`.  Returns `true` when the path is gone after the
+/// call (either we removed it, or it never existed).
+fn deleteTarget(path: []const u8) bool {
+    std.fs.deleteTreeAbsolute(path) catch |e| switch (e) {
+        error.FileNotFound => return true,
+        else => {
+            output.warn("could not remove {s}", .{path});
+            return false;
+        },
+    };
+    return true;
+}
+
+fn deletePrefixRoot(path: []const u8) bool {
+    std.fs.deleteDirAbsolute(path) catch |e| switch (e) {
+        error.FileNotFound => return true,
+        error.DirNotEmpty => {
+            output.info("prefix {s} not empty — leaving it in place", .{path});
+            return false;
+        },
+        else => {
+            output.warn("could not remove prefix {s}", .{path});
+            return false;
+        },
+    };
+    return true;
+}
+
+fn verify(plan: []const Target) void {
+    var leaks: usize = 0;
+    for (plan) |t| {
+        if (t.category == .prefix_root) continue; // allowed to remain
+        std.fs.accessAbsolute(t.path, .{}) catch continue;
+        output.warn("verification: {s} still present", .{t.path});
+        leaks += 1;
+    }
+    if (leaks == 0) {
+        output.info("verification: all targeted paths are gone", .{});
+    }
+}
+
+pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
+    if (help.showIfRequested(args, "purge")) return;
+
+    const opts = parseArgs(args) catch {
+        output.err("invalid arguments — run `mt purge --help` for usage", .{});
+        return Error.InvalidArgs;
+    };
+
+    const dry_run = output.isDryRun();
+    const prefix = atomic.maltPrefix();
+    const cache_dir = atomic.maltCacheDir(allocator) catch {
+        output.err("failed to determine cache directory", .{});
+        return Error.OpenFileFailed;
+    };
+    defer allocator.free(cache_dir);
+
+    // ── Banner + target preview ──────────────────────────────────────────
+    // Visual hierarchy:
+    //   banner  → yellow (the alarm)
+    //   context → dim    (prefix/cache/flags — supporting info)
+    //   rows    → plain  (the paths you need to actually read)
+    //   total   → bold   (the headline number)
+    warnBanner();
+    output.dimPlain("prefix:  {s}", .{prefix});
+    output.dimPlain("cache:   {s}", .{cache_dir});
+    if (opts.keep_cache) output.dimPlain("keep-cache: on", .{});
+    if (opts.remove_binary) output.dimPlain("remove-binary: on (/usr/local/bin/{{mt,malt}})", .{});
+
+    const plan = try buildPlan(allocator, opts, prefix, cache_dir);
+    defer freePlan(allocator, plan);
+
+    var total_bytes: u64 = 0;
+    for (plan) |t| {
+        const size = pathSize(allocator, t.path);
+        total_bytes += size;
+        var sz_buf: [32]u8 = undefined;
+        const sz = formatBytes(size, &sz_buf);
+        output.plain("  [{s:<8}] {s} ({s})", .{ t.category.label(), t.path, sz });
+    }
+    {
+        var buf: [64]u8 = undefined;
+        const total_str = formatBytes(total_bytes, &buf);
+        output.boldPlain("total: {s}", .{total_str});
+    }
+
+    // ── Backup manifest ──────────────────────────────────────────────────
+    if (opts.backup_path) |bp| {
+        if (dry_run) {
+            output.info("would write backup manifest to {s}", .{bp});
+        } else {
+            try writeManifest(allocator, bp);
+            output.success("backup manifest written to {s}", .{bp});
+        }
+    }
+
+    if (dry_run) {
+        output.info("dry run — nothing was removed", .{});
+        return;
+    }
+
+    // ── Confirmation gate ────────────────────────────────────────────────
+    if (!opts.yes) {
+        const confirmed = output.confirmTyped(
+            "purge",
+            "Type `purge` to continue (anything else aborts): ",
+        );
+        if (!confirmed) {
+            output.info("aborted", .{});
+            return Error.UserAborted;
+        }
+    }
+
+    // ── Acquire lock (best-effort — absent db dir means nothing to race)
+    var lock_path_buf: [512]u8 = undefined;
+    const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return;
+    var lk_maybe: ?lock_mod.LockFile = lock_mod.LockFile.acquire(lock_path, 30_000) catch null;
+
+    // ── Deletions ────────────────────────────────────────────────────────
+    var removed: usize = 0;
+    var skipped: usize = 0;
+    var db_idx: ?usize = null;
+    var prefix_idx: ?usize = null;
+
+    for (plan, 0..) |t, idx| {
+        switch (t.category) {
+            .db => {
+                db_idx = idx;
+                continue; // deferred until after lock release
+            },
+            .prefix_root => {
+                prefix_idx = idx;
+                continue; // deferred until last
+            },
+            else => {},
+        }
+        if (deleteTarget(t.path)) removed += 1 else skipped += 1;
+    }
+
+    // Release the lock before removing its parent directory.
+    if (lk_maybe) |*lk| lk.release();
+
+    if (db_idx) |idx| {
+        if (deleteTarget(plan[idx].path)) removed += 1 else skipped += 1;
+    }
+
+    if (prefix_idx) |idx| {
+        if (deletePrefixRoot(plan[idx].path)) removed += 1 else skipped += 1;
+    }
+
+    verify(plan);
+
+    var sum_buf: [128]u8 = undefined;
+    const sum = std.fmt.bufPrint(&sum_buf, "removed {d} target(s), skipped {d}", .{ removed, skipped }) catch "";
+    output.success("{s}", .{sum});
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -22,3 +22,4 @@ pub const progress = @import("ui/progress.zig");
 pub const version = @import("version.zig");
 pub const completions = @import("cli/completions.zig");
 pub const backup = @import("cli/backup.zig");
+pub const purge = @import("cli/purge.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -36,6 +36,7 @@ const version_update = @import("cli/version_update.zig");
 const completions = @import("cli/completions.zig");
 const backup = @import("cli/backup.zig");
 const restore = @import("cli/restore.zig");
+const purge = @import("cli/purge.zig");
 
 const version_mod = @import("version.zig");
 const version = version_mod.value;
@@ -64,6 +65,7 @@ const Command = enum {
     completions,
     backup,
     restore,
+    purge,
     help,
     version,
 };
@@ -93,6 +95,7 @@ const command_map = std.StaticStringMap(Command).initComptime(.{
     .{ "completions", .completions },
     .{ "backup", .backup },
     .{ "restore", .restore },
+    .{ "purge", .purge },
     .{ "help", .help },
     .{ "--help", .help },
     .{ "-h", .help },
@@ -190,6 +193,7 @@ pub fn main() !void {
             .completions => try completions.execute(allocator, cmd_args),
             .backup => try backup.execute(allocator, cmd_args),
             .restore => try restore.execute(allocator, cmd_args),
+            .purge => try purge.execute(allocator, cmd_args),
             .version_cmd => {
                 // "mt version" — check for "mt version update" subcommand
                 if (cmd_args.len > 0 and std.mem.eql(u8, cmd_args[0], "update")) {
@@ -236,6 +240,7 @@ fn printUsage() void {
         \\  completions   Generate shell completion scripts (bash, zsh, fish)
         \\  backup        Dump installed packages to a restorable text file
         \\  restore       Reinstall every package listed in a backup file
+        \\  purge         Completely wipe the malt installation from disk
         \\  version       Show version (use 'version update' to self-update)
         \\
         \\Global flags:

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -110,6 +110,45 @@ pub fn err(comptime fmt: []const u8, args: anytype) void {
     f.writeAll("\n") catch {};
 }
 
+/// Internal: write a single styled line to stderr with no icon prefix.
+/// `style` is `null` for plain text. Respects `--quiet`.
+fn lineStyled(style: ?color.Style, comptime fmt: []const u8, args: anytype) void {
+    if (quiet) return;
+    var buf: [4096]u8 = undefined;
+    const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
+    const f = std.fs.File.stderr();
+    if (style != null and color.isColorEnabled()) {
+        f.writeAll(style.?.code()) catch {};
+        f.writeAll(msg) catch {};
+        f.writeAll(color.Style.reset.code()) catch {};
+    } else {
+        f.writeAll(msg) catch {};
+    }
+    f.writeAll("\n") catch {};
+}
+
+/// Yellow line with no prefix — for multi-line warning blocks (banners,
+/// tables) where a repeated `⚠` icon is more noise than signal.
+pub fn warnPlain(comptime fmt: []const u8, args: anytype) void {
+    lineStyled(.yellow, fmt, args);
+}
+
+/// Plain (un-styled, un-prefixed) line — for body text in multi-line
+/// output where color would compete with a warning block above it.
+pub fn plain(comptime fmt: []const u8, args: anytype) void {
+    lineStyled(null, fmt, args);
+}
+
+/// Dim/faint line with no prefix — for low-priority context lines.
+pub fn dimPlain(comptime fmt: []const u8, args: anytype) void {
+    lineStyled(.dim, fmt, args);
+}
+
+/// Bold line with no prefix — for headline values (totals, summaries).
+pub fn boldPlain(comptime fmt: []const u8, args: anytype) void {
+    lineStyled(.bold, fmt, args);
+}
+
 /// Print a dim/faint info message for low-priority status lines.
 pub fn dim(comptime fmt: []const u8, args: anytype) void {
     if (quiet) return;
@@ -127,6 +166,30 @@ pub fn dim(comptime fmt: []const u8, args: anytype) void {
         f.writeAll(msg) catch {};
     }
     f.writeAll("\n") catch {};
+}
+
+/// Read a single line from stdin and return true iff the trimmed input
+/// matches `expected` exactly.  Prints `prompt` to stderr first.
+///
+/// Returns false when stdin is not a TTY so that destructive commands
+/// refuse to run unattended without an explicit `--yes` opt-in.
+pub fn confirmTyped(expected: []const u8, prompt: []const u8) bool {
+    if (!std.posix.isatty(std.posix.STDIN_FILENO)) return false;
+
+    const f = std.fs.File.stderr();
+    if (color.isColorEnabled()) {
+        f.writeAll(color.Style.bold.code()) catch {};
+        f.writeAll(prompt) catch {};
+        f.writeAll(color.Style.reset.code()) catch {};
+    } else {
+        f.writeAll(prompt) catch {};
+    }
+
+    var buf: [128]u8 = undefined;
+    const n = std.posix.read(std.posix.STDIN_FILENO, &buf) catch return false;
+    if (n == 0) return false;
+    const input = std.mem.trim(u8, buf[0..n], " \t\r\n");
+    return std.mem.eql(u8, input, expected);
 }
 
 /// Write JSON to stdout

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -41,7 +41,7 @@ const all_commands = [_][]const u8{
     "tap",        "untap",     "gc",          "migrate",
     "autoremove", "rollback",  "link",        "unlink",
     "run",        "version",   "completions", "backup",
-    "restore",
+    "restore",    "purge",
 };
 
 fn expectContains(haystack: []const u8, needle: []const u8) !void {

--- a/tests/purge_test.zig
+++ b/tests/purge_test.zig
@@ -1,0 +1,325 @@
+//! malt — purge command tests
+//! Covers the pure helpers (parseArgs, buildPlan, formatBytes) plus a
+//! filesystem-level check that the plan, when applied with
+//! std.fs.deleteTreeAbsolute, actually removes every target path under
+//! a throwaway prefix built in /tmp.  The execute() function is NOT
+//! exercised here because it touches global output state, stdin, and
+//! the real database — covered by manual end-to-end runs instead.
+
+const std = @import("std");
+const testing = std.testing;
+const purge = @import("malt").purge;
+
+// ── parseArgs ────────────────────────────────────────────────────────────
+
+test "parseArgs returns defaults for an empty argv" {
+    const opts = try purge.parseArgs(&.{});
+    try testing.expectEqual(false, opts.keep_cache);
+    try testing.expectEqual(false, opts.yes);
+    try testing.expectEqual(false, opts.remove_binary);
+    try testing.expectEqual(@as(?[]const u8, null), opts.backup_path);
+}
+
+test "parseArgs recognises every long flag" {
+    const argv = [_][]const u8{ "--keep-cache", "--yes", "--remove-binary" };
+    const opts = try purge.parseArgs(&argv);
+    try testing.expect(opts.keep_cache);
+    try testing.expect(opts.yes);
+    try testing.expect(opts.remove_binary);
+}
+
+test "parseArgs recognises short aliases" {
+    const argv = [_][]const u8{"-y"};
+    const opts = try purge.parseArgs(&argv);
+    try testing.expect(opts.yes);
+}
+
+test "parseArgs reads --backup with a separate value" {
+    const argv = [_][]const u8{ "--backup", "/tmp/snap.txt" };
+    const opts = try purge.parseArgs(&argv);
+    try testing.expectEqualStrings("/tmp/snap.txt", opts.backup_path.?);
+}
+
+test "parseArgs reads --backup=<path>" {
+    const argv = [_][]const u8{"--backup=/tmp/snap.txt"};
+    const opts = try purge.parseArgs(&argv);
+    try testing.expectEqualStrings("/tmp/snap.txt", opts.backup_path.?);
+}
+
+test "parseArgs reads -b <path>" {
+    const argv = [_][]const u8{ "-b", "/tmp/snap.txt" };
+    const opts = try purge.parseArgs(&argv);
+    try testing.expectEqualStrings("/tmp/snap.txt", opts.backup_path.?);
+}
+
+test "parseArgs errors when --backup lacks a value" {
+    const argv = [_][]const u8{"--backup"};
+    try testing.expectError(purge.Error.InvalidArgs, purge.parseArgs(&argv));
+}
+
+test "parseArgs errors on unknown flags" {
+    const argv = [_][]const u8{"--nope"};
+    try testing.expectError(purge.Error.InvalidArgs, purge.parseArgs(&argv));
+}
+
+test "parseArgs rejects positional arguments" {
+    // purge takes no positional args — stray tokens should error, not be
+    // silently accepted as package names.
+    const argv = [_][]const u8{"git"};
+    try testing.expectError(purge.Error.InvalidArgs, purge.parseArgs(&argv));
+}
+
+// ── buildPlan ────────────────────────────────────────────────────────────
+
+fn findCategory(plan: []const purge.Target, cat: purge.Category) ?usize {
+    for (plan, 0..) |t, i| {
+        if (t.category == cat) return i;
+    }
+    return null;
+}
+
+fn countCategory(plan: []const purge.Target, cat: purge.Category) usize {
+    var n: usize = 0;
+    for (plan) |t| {
+        if (t.category == cat) n += 1;
+    }
+    return n;
+}
+
+test "buildPlan includes every core prefix target by default" {
+    const opts: purge.Options = .{};
+    const plan = try purge.buildPlan(testing.allocator, opts, "/tmp/mt-fake", "/tmp/mt-fake/cache");
+    defer purge.freePlan(testing.allocator, plan);
+
+    // Core categories that must always be present.
+    try testing.expect(findCategory(plan, .cellar) != null);
+    try testing.expect(findCategory(plan, .caskroom) != null);
+    try testing.expect(findCategory(plan, .store) != null);
+    try testing.expect(findCategory(plan, .opt) != null);
+    try testing.expect(findCategory(plan, .cache) != null);
+    try testing.expect(findCategory(plan, .tmp) != null);
+    try testing.expect(findCategory(plan, .db) != null);
+    try testing.expect(findCategory(plan, .prefix_root) != null);
+
+    // Six standard linked dirs: bin, sbin, lib, include, share, etc.
+    try testing.expectEqual(@as(usize, 6), countCategory(plan, .linked_dir));
+
+    // No binary targets without --remove-binary.
+    try testing.expectEqual(@as(usize, 0), countCategory(plan, .binary));
+}
+
+test "buildPlan omits the cache target when --keep-cache is set" {
+    const opts: purge.Options = .{ .keep_cache = true };
+    const plan = try purge.buildPlan(testing.allocator, opts, "/tmp/mt-fake", "/tmp/mt-fake/cache");
+    defer purge.freePlan(testing.allocator, plan);
+    try testing.expectEqual(@as(usize, 0), countCategory(plan, .cache));
+}
+
+test "buildPlan adds both binary paths when --remove-binary is set" {
+    const opts: purge.Options = .{ .remove_binary = true };
+    const plan = try purge.buildPlan(testing.allocator, opts, "/tmp/mt-fake", "/tmp/mt-fake/cache");
+    defer purge.freePlan(testing.allocator, plan);
+
+    try testing.expectEqual(@as(usize, 2), countCategory(plan, .binary));
+
+    var found_mt = false;
+    var found_malt = false;
+    for (plan) |t| {
+        if (t.category != .binary) continue;
+        if (std.mem.eql(u8, t.path, "/usr/local/bin/mt")) found_mt = true;
+        if (std.mem.eql(u8, t.path, "/usr/local/bin/malt")) found_malt = true;
+    }
+    try testing.expect(found_mt);
+    try testing.expect(found_malt);
+}
+
+test "buildPlan orders the db target after the store target" {
+    // The lock file lives under {prefix}/db, so `db` must be the last
+    // in-prefix target so execute() can drop the lock before unlinking it.
+    const opts: purge.Options = .{};
+    const plan = try purge.buildPlan(testing.allocator, opts, "/tmp/mt-fake", "/tmp/mt-fake/cache");
+    defer purge.freePlan(testing.allocator, plan);
+
+    const store_idx = findCategory(plan, .store).?;
+    const db_idx = findCategory(plan, .db).?;
+    const prefix_idx = findCategory(plan, .prefix_root).?;
+    try testing.expect(store_idx < db_idx);
+    try testing.expect(db_idx < prefix_idx);
+}
+
+test "buildPlan uses the passed cache_dir path literally" {
+    // Lets callers point purge at $MALT_CACHE values that live outside
+    // {prefix}. If this test fails, a custom cache location would leak.
+    const opts: purge.Options = .{};
+    const plan = try purge.buildPlan(testing.allocator, opts, "/tmp/mt-fake", "/var/tmp/malt-cache-xyz");
+    defer purge.freePlan(testing.allocator, plan);
+    const cache_idx = findCategory(plan, .cache).?;
+    try testing.expectEqualStrings("/var/tmp/malt-cache-xyz", plan[cache_idx].path);
+}
+
+test "buildPlan produces absolute paths for every target" {
+    const opts: purge.Options = .{ .remove_binary = true };
+    const plan = try purge.buildPlan(testing.allocator, opts, "/tmp/mt-fake", "/tmp/mt-fake/cache");
+    defer purge.freePlan(testing.allocator, plan);
+    for (plan) |t| {
+        try testing.expect(std.fs.path.isAbsolute(t.path));
+    }
+}
+
+// ── formatBytes ──────────────────────────────────────────────────────────
+
+test "formatBytes renders common magnitudes" {
+    var buf: [32]u8 = undefined;
+    try testing.expectEqualStrings("0.0 B", purge.formatBytes(0, &buf));
+    try testing.expectEqualStrings("512.0 B", purge.formatBytes(512, &buf));
+    try testing.expectEqualStrings("1.0 KB", purge.formatBytes(1024, &buf));
+    try testing.expectEqualStrings("1.5 KB", purge.formatBytes(1536, &buf));
+    try testing.expectEqualStrings("1.0 MB", purge.formatBytes(1024 * 1024, &buf));
+    try testing.expectEqualStrings("2.0 GB", purge.formatBytes(2 * 1024 * 1024 * 1024, &buf));
+}
+
+test "formatBytes caps at TB and never overflows the buffer" {
+    var buf: [32]u8 = undefined;
+    const huge: u64 = 5 * 1024 * 1024 * 1024 * 1024; // 5 TB
+    const s = purge.formatBytes(huge, &buf);
+    try testing.expect(std.mem.endsWith(u8, s, "TB"));
+}
+
+// ── Filesystem-level plan application ────────────────────────────────────
+// Pre-populate a temp prefix with the directory layout that purge expects,
+// then call std.fs.deleteTreeAbsolute on each plan target and verify that
+// everything is gone.  This covers the deletion ordering that execute()
+// relies on without requiring stdin, sqlite, or the global output state.
+
+fn makeDir(path: []const u8) !void {
+    std.fs.makeDirAbsolute(path) catch |e| switch (e) {
+        error.PathAlreadyExists => {},
+        else => return e,
+    };
+}
+
+fn makeFile(path: []const u8, content: []const u8) !void {
+    const f = try std.fs.createFileAbsolute(path, .{ .truncate = true });
+    defer f.close();
+    try f.writeAll(content);
+}
+
+fn pathExists(path: []const u8) bool {
+    std.fs.accessAbsolute(path, .{}) catch return false;
+    return true;
+}
+
+test "applying the plan removes every pre-populated directory under a temp prefix" {
+    const allocator = testing.allocator;
+
+    // Unique temp prefix — std.crypto random bytes keep parallel runs safe.
+    var rand_bytes: [8]u8 = undefined;
+    std.crypto.random.bytes(&rand_bytes);
+    var hex_buf: [16]u8 = undefined;
+    const hex_chars = "0123456789abcdef";
+    for (rand_bytes, 0..) |b, i| {
+        hex_buf[i * 2] = hex_chars[b >> 4];
+        hex_buf[i * 2 + 1] = hex_chars[b & 0x0f];
+    }
+
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try std.fmt.bufPrint(&prefix_buf, "/tmp/malt-purge-test-{s}", .{&hex_buf});
+
+    // Best-effort cleanup in case a prior run aborted mid-way.
+    std.fs.deleteTreeAbsolute(prefix) catch {};
+    try makeDir(prefix);
+    defer std.fs.deleteTreeAbsolute(prefix) catch {};
+
+    // Populate the directories the plan will target.
+    const subdirs = [_][]const u8{
+        "bin",      "sbin",  "lib",   "include",
+        "share",    "etc",   "opt",   "Cellar",
+        "Caskroom", "store", "cache", "tmp",
+        "db",
+    };
+    for (subdirs) |name| {
+        var sub_buf: [256]u8 = undefined;
+        const sub = try std.fmt.bufPrint(&sub_buf, "{s}/{s}", .{ prefix, name });
+        try makeDir(sub);
+        // Drop a file inside so the directory isn't empty — exercises
+        // deleteTree's recursive branch, not the fast path.
+        var file_buf: [256]u8 = undefined;
+        const file = try std.fmt.bufPrint(&file_buf, "{s}/marker", .{sub});
+        try makeFile(file, "x");
+    }
+
+    // Build the plan pointing at the temp prefix (cache stays in-prefix).
+    var cache_buf: [256]u8 = undefined;
+    const cache_dir = try std.fmt.bufPrint(&cache_buf, "{s}/cache", .{prefix});
+
+    const plan = try purge.buildPlan(allocator, .{}, prefix, cache_dir);
+    defer purge.freePlan(allocator, plan);
+
+    // Apply the plan in order (skipping .prefix_root; we verify it separately).
+    for (plan) |t| {
+        if (t.category == .prefix_root) continue;
+        std.fs.deleteTreeAbsolute(t.path) catch |e| switch (e) {
+            error.FileNotFound => {},
+            else => return e,
+        };
+    }
+
+    // Every target except the prefix root must now be gone.
+    for (plan) |t| {
+        if (t.category == .prefix_root) continue;
+        try testing.expect(!pathExists(t.path));
+    }
+
+    // Prefix itself should be empty — a final deleteDirAbsolute succeeds.
+    try std.fs.deleteDirAbsolute(prefix);
+    try testing.expect(!pathExists(prefix));
+}
+
+test "applying the plan with --keep-cache leaves the cache directory intact" {
+    const allocator = testing.allocator;
+
+    var rand_bytes: [8]u8 = undefined;
+    std.crypto.random.bytes(&rand_bytes);
+    var hex_buf: [16]u8 = undefined;
+    const hex_chars = "0123456789abcdef";
+    for (rand_bytes, 0..) |b, i| {
+        hex_buf[i * 2] = hex_chars[b >> 4];
+        hex_buf[i * 2 + 1] = hex_chars[b & 0x0f];
+    }
+
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try std.fmt.bufPrint(&prefix_buf, "/tmp/malt-purge-keepcache-{s}", .{&hex_buf});
+    std.fs.deleteTreeAbsolute(prefix) catch {};
+    try makeDir(prefix);
+    defer std.fs.deleteTreeAbsolute(prefix) catch {};
+
+    // Pre-create cache, Cellar, and db — enough to prove the kept path
+    // survives while deleted paths do not.
+    var cache_buf: [256]u8 = undefined;
+    const cache_dir = try std.fmt.bufPrint(&cache_buf, "{s}/cache", .{prefix});
+    try makeDir(cache_dir);
+
+    var cellar_buf: [256]u8 = undefined;
+    const cellar_dir = try std.fmt.bufPrint(&cellar_buf, "{s}/Cellar", .{prefix});
+    try makeDir(cellar_dir);
+    var marker_buf: [256]u8 = undefined;
+    const marker = try std.fmt.bufPrint(&marker_buf, "{s}/CANARY", .{cache_dir});
+    try makeFile(marker, "keep me");
+
+    const plan = try purge.buildPlan(allocator, .{ .keep_cache = true }, prefix, cache_dir);
+    defer purge.freePlan(allocator, plan);
+
+    for (plan) |t| {
+        if (t.category == .prefix_root) continue;
+        std.fs.deleteTreeAbsolute(t.path) catch |e| switch (e) {
+            error.FileNotFound => {},
+            else => return e,
+        };
+    }
+
+    // Cache must still exist and still contain the canary file.
+    try testing.expect(pathExists(cache_dir));
+    try testing.expect(pathExists(marker));
+    // Cellar must be gone.
+    try testing.expect(!pathExists(cellar_dir));
+}


### PR DESCRIPTION
## Summary

- New `mt purge` command for complete removal of a malt installation (Cellar, Caskroom, store, linked binaries, cache, db).
- Interactive by default: prints a yellow warning banner with an itemized target list and requires typing the literal word `purge` to proceed. Refuses to run from a non-TTY stdin unless `--yes` is passed.
- Flags: `--dry-run`, `--backup <path>` (writes a `mt restore`-compatible manifest before any deletion), `--keep-cache`, `--yes`, `--remove-binary` (opt-in for `/usr/local/bin/{mt,malt}`).
- Shell completions updated for bash, zsh, and fish
- README section added