### PR TITLE
fix: multi-package install correctness sweep

### DIFF
--- a/scripts/e2e/test_smoke_install.sh
+++ b/scripts/e2e/test_smoke_install.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# scripts/e2e/test_smoke_install.sh
+#
+# End-to-end smoke test for `mt install`. Runs an isolated install of the
+# three packages that P1 regressed (zig, curl, rust), each of which ships as
+# a `:any` Homebrew bottle carrying `@@HOMEBREW_PREFIX@@` / `@@HOMEBREW_CELLAR@@`
+# placeholder tokens in their Mach-O load commands.
+#
+# The script is a smoke test for the WHOLE install pipeline — download,
+# materialize, patch, link, codesign, record — not a unit test for any one
+# fix. It complements tests/cellar_test.zig's synthetic-Mach-O guards, which
+# cover P1 specifically without network I/O.
+#
+# Assertions:
+#   1. `mt install` exits 0.
+#   2. `mt doctor` exits 0 (all checks green, including Mach-O placeholders).
+#   3. Each binary runs and prints a plausible version string.
+#   4. otool -L on each binary shows no remaining `@@HOMEBREW_` tokens.
+#
+# Usage:
+#   ./scripts/e2e/test_smoke_install.sh           # default
+#   MT_BIN=./zig-out/bin/malt ./scripts/e2e/test_smoke_install.sh
+#   SKIP_BUILD=1 ./scripts/e2e/test_smoke_install.sh   # reuse an existing build
+#
+# Exit codes:
+#   0 — all assertions passed
+#   1 — at least one assertion failed
+#   2 — infrastructure error (temp dir, binary not found, …)
+
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────
+# The script is written for macOS /bin/bash (3.2), which has no associative
+# arrays — `expected_bin_for` is a case-based lookup instead.
+MT_BIN="${MT_BIN:-./zig-out/bin/malt}"
+PACKAGES=(zig curl rust)
+
+# For each package, echo a glob pattern that resolves to the canonical binary
+# after install. curl is keg-only so it lives under Cellar/ rather than bin/.
+expected_bin_for() {
+    case "$1" in
+        zig)  echo "$PREFIX/bin/zig" ;;
+        rust) echo "$PREFIX/bin/rustc" ;;
+        curl) echo "$PREFIX/Cellar/curl/*/bin/curl" ;;
+        *)    return 1 ;;
+    esac
+}
+
+# Canonical version-check args per package.
+version_args_for() {
+    case "$1" in
+        zig)  printf 'version' ;;
+        rust) printf '%s' '--version' ;;
+        curl) printf '%s' '--version' ;;
+        *)    return 1 ;;
+    esac
+}
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+red()   { printf '\033[31m%s\033[0m' "$*"; }
+green() { printf '\033[32m%s\033[0m' "$*"; }
+yellow(){ printf '\033[33m%s\033[0m' "$*"; }
+
+log()   { printf '[smoke] %s\n' "$*"; }
+fail()  { printf '[smoke] %s %s\n' "$(red FAIL)" "$*" >&2; FAILURES=$((FAILURES + 1)); }
+pass()  { printf '[smoke] %s %s\n' "$(green PASS)" "$*"; }
+info()  { printf '[smoke] %s %s\n' "$(yellow INFO)" "$*"; }
+
+# Retry wrapper for network calls. Exponential back-off: 10s 20s 40s 80s, cap at 2 min.
+retry() {
+    local n=0 max=5 delay=10
+    until "$@"; do
+        n=$((n + 1))
+        if [ "$n" -ge "$max" ]; then
+            fail "command failed after $max attempts: $*"
+            return 1
+        fi
+        info "attempt $n failed, retrying in ${delay}s…"
+        sleep "$delay"
+        delay=$((delay * 2))
+        [ "$delay" -gt 120 ] && delay=120
+    done
+}
+
+FAILURES=0
+
+# ── Preconditions ─────────────────────────────────────────────────────────
+if [ ! -x "$MT_BIN" ]; then
+    if [ "${SKIP_BUILD:-0}" = "1" ]; then
+        printf '[smoke] %s\n' "$(red ERROR): $MT_BIN not found and SKIP_BUILD=1" >&2
+        exit 2
+    fi
+    log "building $MT_BIN (set SKIP_BUILD=1 to reuse an existing build)"
+    zig build -Doptimize=ReleaseSafe >/dev/null
+fi
+
+if [ ! -x "$MT_BIN" ]; then
+    printf '[smoke] %s\n' "$(red ERROR): $MT_BIN still not found after build" >&2
+    exit 2
+fi
+
+# Short prefix (≤ 13 bytes is the Mach-O patch budget). mktemp -d /tmp/mt.XXX
+# gives us /tmp/mt.aBc, 11 bytes, with enough entropy for parallel runs.
+PREFIX=$(mktemp -d /tmp/mt.XXX)
+CACHE=$(mktemp -d /tmp/mc.XXX)
+log "prefix: $PREFIX (${#PREFIX} bytes)"
+log "cache:  $CACHE"
+
+# Cleanup on any exit — only remove the dirs we created, never anything under
+# /opt/malt or the user's real prefix.
+cleanup() {
+    if [ -n "${PREFIX:-}" ] && [[ "$PREFIX" == /tmp/mt.* ]]; then
+        rm -rf "$PREFIX"
+    fi
+    if [ -n "${CACHE:-}" ] && [[ "$CACHE" == /tmp/mc.* ]]; then
+        rm -rf "$CACHE"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+export MALT_PREFIX="$PREFIX"
+export MALT_CACHE="$CACHE"
+export MALT_NO_EMOJI=1
+export NO_COLOR=1
+
+# ── 1. Install ────────────────────────────────────────────────────────────
+log "installing ${PACKAGES[*]} into $PREFIX …"
+
+INSTALL_LOG="$PREFIX/.install.log"
+if retry "$MT_BIN" install "${PACKAGES[@]}" >"$INSTALL_LOG" 2>&1; then
+    pass "mt install exited 0"
+else
+    fail "mt install exited non-zero — see $INSTALL_LOG"
+    sed -n '$,$p' "$INSTALL_LOG" >&2 || true
+fi
+
+# ── 2. mt doctor ──────────────────────────────────────────────────────────
+log "running mt doctor …"
+DOCTOR_LOG="$PREFIX/.doctor.log"
+if "$MT_BIN" doctor >"$DOCTOR_LOG" 2>&1; then
+    pass "mt doctor reported a clean tree"
+else
+    fail "mt doctor exited non-zero"
+    cat "$DOCTOR_LOG" >&2 || true
+fi
+
+# ── 3. Execute each binary ────────────────────────────────────────────────
+for pkg in "${PACKAGES[@]}"; do
+    bin_pattern=$(expected_bin_for "$pkg") || {
+        fail "$pkg: no binary template configured"
+        continue
+    }
+
+    # Resolve the glob. compgen is a bash builtin so this works without
+    # enabling nullglob. `|| true` so the pipeline does not die under set -e
+    # when the glob matches nothing.
+    bin_path=$(compgen -G "$bin_pattern" 2>/dev/null | head -1 || true)
+
+    if [ -z "$bin_path" ] || [ ! -x "$bin_path" ]; then
+        fail "$pkg: expected binary not found (pattern: $bin_pattern)"
+        continue
+    fi
+
+    arg=$(version_args_for "$pkg")
+    if out=$("$bin_path" "$arg" 2>&1); then
+        # Strip everything after the first newline for concise reporting.
+        pass "$pkg runs: ${out%%$'\n'*}"
+    else
+        fail "$pkg binary failed to execute: $out"
+    fi
+done
+
+# ── 4. No unresolved @@HOMEBREW_ tokens in the running-arch Mach-O slice ──
+#
+# We specifically scan the slice that matches the current architecture.
+# malt's Mach-O patcher processes one slice per file (the one that matches
+# the build host's arch), so fat binaries may still have unpatched tokens
+# in the *other* arch's slice. That is a latent bug worth fixing separately
+# but it does NOT affect runtime on the machine running this smoke test —
+# dyld only loads the matching slice.
+case "$(uname -m)" in
+    arm64)  HOST_ARCH=arm64 ;;
+    x86_64) HOST_ARCH=x86_64 ;;
+    *)      HOST_ARCH="" ;;  # unknown — scan unfiltered as a fallback
+esac
+
+log "scanning Cellar for unpatched @@HOMEBREW_* placeholders (arch: ${HOST_ARCH:-any}) …"
+bad_count=0
+first_bad=""
+other_arch_count=0
+
+while IFS= read -r -d '' f; do
+    # Only consider Mach-O files.
+    if ! file "$f" 2>/dev/null | grep -q 'Mach-O'; then
+        continue
+    fi
+
+    # Hard check: the host-arch slice must be clean.
+    if [ -n "$HOST_ARCH" ]; then
+        if otool -arch "$HOST_ARCH" -l "$f" 2>/dev/null | grep -q '@@HOMEBREW_'; then
+            bad_count=$((bad_count + 1))
+            [ -z "$first_bad" ] && first_bad="$f"
+        fi
+        # Soft check: any *other* arch slice with remaining tokens is a
+        # known-latent fat-binary patching limitation — warn but don't fail.
+        if otool -l "$f" 2>/dev/null | grep -q '@@HOMEBREW_'; then
+            if ! otool -arch "$HOST_ARCH" -l "$f" 2>/dev/null | grep -q '@@HOMEBREW_'; then
+                other_arch_count=$((other_arch_count + 1))
+            fi
+        fi
+    else
+        # No arch filter available — treat every finding as a hard failure.
+        if otool -l "$f" 2>/dev/null | grep -q '@@HOMEBREW_'; then
+            bad_count=$((bad_count + 1))
+            [ -z "$first_bad" ] && first_bad="$f"
+        fi
+    fi
+done < <(find "$PREFIX/Cellar" -type f -print0 2>/dev/null)
+
+if [ "$bad_count" -eq 0 ]; then
+    pass "zero Mach-O files with unpatched @@HOMEBREW_* placeholders in the ${HOST_ARCH:-all} slice(s)"
+else
+    fail "$bad_count Mach-O file(s) still contain @@HOMEBREW_ tokens in the $HOST_ARCH slice (first: $first_bad)"
+fi
+
+if [ "$other_arch_count" -gt 0 ]; then
+    info "$other_arch_count fat-binary file(s) carry unpatched tokens in a non-$HOST_ARCH slice — latent cross-arch bug, not a runtime failure on this host"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────
+echo
+if [ "$FAILURES" -eq 0 ]; then
+    log "$(green 'ALL CHECKS PASSED') (prefix: $PREFIX)"
+    exit 0
+else
+    log "$(red "$FAILURES CHECK(S) FAILED") (prefix kept at $PREFIX for inspection)"
+    # Disarm the cleanup trap so the user can inspect the broken tree.
+    trap - EXIT
+    exit 1
+fi

--- a/scripts/e2e/test_smoke_install.sh
+++ b/scripts/e2e/test_smoke_install.sh
@@ -170,61 +170,29 @@ for pkg in "${PACKAGES[@]}"; do
     fi
 done
 
-# ── 4. No unresolved @@HOMEBREW_ tokens in the running-arch Mach-O slice ──
+# ── 4. No unresolved @@HOMEBREW_ tokens in ANY Mach-O slice ───────────────
 #
-# We specifically scan the slice that matches the current architecture.
-# malt's Mach-O patcher processes one slice per file (the one that matches
-# the build host's arch), so fat binaries may still have unpatched tokens
-# in the *other* arch's slice. That is a latent bug worth fixing separately
-# but it does NOT affect runtime on the machine running this smoke test —
-# dyld only loads the matching slice.
-case "$(uname -m)" in
-    arm64)  HOST_ARCH=arm64 ;;
-    x86_64) HOST_ARCH=x86_64 ;;
-    *)      HOST_ARCH="" ;;  # unknown — scan unfiltered as a fallback
-esac
-
-log "scanning Cellar for unpatched @@HOMEBREW_* placeholders (arch: ${HOST_ARCH:-any}) …"
+# Since P9, malt patches EVERY arch slice of a fat Mach-O, not just the host
+# arch. This scan therefore uses plain `otool -l` (no -arch filter) so a
+# regression that re-introduces the single-slice behaviour will trip here.
+log "scanning Cellar for unpatched @@HOMEBREW_* placeholders (all arch slices) …"
 bad_count=0
 first_bad=""
-other_arch_count=0
 
 while IFS= read -r -d '' f; do
-    # Only consider Mach-O files.
     if ! file "$f" 2>/dev/null | grep -q 'Mach-O'; then
         continue
     fi
-
-    # Hard check: the host-arch slice must be clean.
-    if [ -n "$HOST_ARCH" ]; then
-        if otool -arch "$HOST_ARCH" -l "$f" 2>/dev/null | grep -q '@@HOMEBREW_'; then
-            bad_count=$((bad_count + 1))
-            [ -z "$first_bad" ] && first_bad="$f"
-        fi
-        # Soft check: any *other* arch slice with remaining tokens is a
-        # known-latent fat-binary patching limitation — warn but don't fail.
-        if otool -l "$f" 2>/dev/null | grep -q '@@HOMEBREW_'; then
-            if ! otool -arch "$HOST_ARCH" -l "$f" 2>/dev/null | grep -q '@@HOMEBREW_'; then
-                other_arch_count=$((other_arch_count + 1))
-            fi
-        fi
-    else
-        # No arch filter available — treat every finding as a hard failure.
-        if otool -l "$f" 2>/dev/null | grep -q '@@HOMEBREW_'; then
-            bad_count=$((bad_count + 1))
-            [ -z "$first_bad" ] && first_bad="$f"
-        fi
+    if otool -l "$f" 2>/dev/null | grep -q '@@HOMEBREW_'; then
+        bad_count=$((bad_count + 1))
+        [ -z "$first_bad" ] && first_bad="$f"
     fi
 done < <(find "$PREFIX/Cellar" -type f -print0 2>/dev/null)
 
 if [ "$bad_count" -eq 0 ]; then
-    pass "zero Mach-O files with unpatched @@HOMEBREW_* placeholders in the ${HOST_ARCH:-all} slice(s)"
+    pass "zero Mach-O files with unpatched @@HOMEBREW_* placeholders (all slices)"
 else
-    fail "$bad_count Mach-O file(s) still contain @@HOMEBREW_ tokens in the $HOST_ARCH slice (first: $first_bad)"
-fi
-
-if [ "$other_arch_count" -gt 0 ]; then
-    info "$other_arch_count fat-binary file(s) carry unpatched tokens in a non-$HOST_ARCH slice — latent cross-arch bug, not a runtime failure on this host"
+    fail "$bad_count Mach-O file(s) still contain @@HOMEBREW_ tokens (first: $first_bad)"
 fi
 
 # ── Summary ───────────────────────────────────────────────────────────────

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -12,6 +12,7 @@ const output = @import("../ui/output.zig");
 const color = @import("../ui/color.zig");
 const help = @import("help.zig");
 const install_mod = @import("install.zig");
+const parser = @import("../macho/parser.zig");
 
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "doctor")) return;
@@ -245,6 +246,57 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         }
     }
 
+    // 8b. Unpatched Mach-O placeholders — scan Cellar/**/* for binaries whose
+    //     LC_LOAD_DYLIB / LC_RPATH load commands still contain literal
+    //     @@HOMEBREW_PREFIX@@ or @@HOMEBREW_CELLAR@@ tokens. These fail at
+    //     runtime with `dyld: Symbol not found`.
+    blk_mach: {
+        var cellar_root_buf: [512]u8 = undefined;
+        const cellar_root = std.fmt.bufPrint(&cellar_root_buf, "{s}/Cellar", .{prefix}) catch break :blk_mach;
+
+        var cellar_dir = std.fs.openDirAbsolute(cellar_root, .{ .iterate = true }) catch {
+            // No Cellar yet — nothing to scan.
+            printCheck("Mach-O placeholders", .ok, null);
+            break :blk_mach;
+        };
+        defer cellar_dir.close();
+
+        var walker = cellar_dir.walk(allocator) catch {
+            printCheck("Mach-O placeholders", .warn_status, "Could not walk Cellar tree");
+            warnings += 1;
+            break :blk_mach;
+        };
+        defer walker.deinit();
+
+        var bad_count: u32 = 0;
+        var first_bad_buf: [256]u8 = undefined;
+        var first_bad_len: usize = 0;
+
+        while (walker.next() catch null) |entry| {
+            if (entry.kind != .file) continue;
+            if (hasUnpatchedPlaceholder(allocator, &cellar_dir, entry.path) catch false) {
+                bad_count += 1;
+                if (first_bad_len == 0) {
+                    const s = std.fmt.bufPrint(&first_bad_buf, "{s}", .{entry.path}) catch continue;
+                    first_bad_len = s.len;
+                }
+            }
+        }
+
+        if (bad_count > 0) {
+            var msg_buf_m: [512]u8 = undefined;
+            const msg_m = std.fmt.bufPrint(
+                &msg_buf_m,
+                "{d} Mach-O file(s) with unpatched @@HOMEBREW_* placeholders (first: {s}). Reinstall the affected packages.",
+                .{ bad_count, first_bad_buf[0..first_bad_len] },
+            ) catch "Mach-O files with unpatched @@HOMEBREW_* placeholders found.";
+            printCheck("Mach-O placeholders", .err_status, msg_m);
+            errors += 1;
+        } else {
+            printCheck("Mach-O placeholders", .ok, null);
+        }
+    }
+
     // 9. Disk space — warn if < 1 GB free on the malt prefix volume
     blk9: {
         const mount_c = @cImport(@cInclude("sys/mount.h"));
@@ -282,6 +334,43 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     } else {
         output.info("Your malt installation is healthy", .{});
     }
+}
+
+/// True if `rel_path` inside `base_dir` is a Mach-O binary with at least one
+/// load command that still contains `@@HOMEBREW_PREFIX@@` or
+/// `@@HOMEBREW_CELLAR@@`. Any I/O or parser error is treated as "not bad" —
+/// doctor's placeholder check is best-effort.
+fn hasUnpatchedPlaceholder(
+    allocator: std.mem.Allocator,
+    base_dir: *std.fs.Dir,
+    rel_path: []const u8,
+) !bool {
+    var file = base_dir.openFile(rel_path, .{}) catch return false;
+    defer file.close();
+
+    var magic: [4]u8 = undefined;
+    const n = file.readAll(&magic) catch return false;
+    if (n < 4) return false;
+    if (!parser.isMachO(&magic)) return false;
+
+    // Re-read the full file — parser needs the whole buffer.
+    const stat = file.stat() catch return false;
+    if (stat.size > 512 * 1024 * 1024) return false; // skip pathologically large files
+    const data = allocator.alloc(u8, stat.size) catch return false;
+    defer allocator.free(data);
+
+    file.seekTo(0) catch return false;
+    const read = file.readAll(data) catch return false;
+    if (read < data.len) return false;
+
+    var macho = parser.parse(allocator, data) catch return false;
+    defer macho.deinit();
+
+    for (macho.paths) |lcp| {
+        if (std.mem.indexOf(u8, lcp.path, "@@HOMEBREW_PREFIX@@") != null) return true;
+        if (std.mem.indexOf(u8, lcp.path, "@@HOMEBREW_CELLAR@@") != null) return true;
+    }
+    return false;
 }
 
 const CheckStatus = enum { ok, warn_status, err_status };

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -11,6 +11,7 @@ const clonefile = @import("../fs/clonefile.zig");
 const output = @import("../ui/output.zig");
 const color = @import("../ui/color.zig");
 const help = @import("help.zig");
+const install_mod = @import("install.zig");
 
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "doctor")) return;
@@ -93,6 +94,23 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         } else {
             printCheck("Stale lock", .ok, null);
         }
+    }
+
+    // 3b. Prefix length — Mach-O in-place patching budget.
+    //     A long MALT_PREFIX cannot fit inside the load-command slot and will
+    //     silently break every bottle that hard-codes /opt/homebrew paths.
+    install_mod.checkPrefixLength(prefix) catch {
+        var pl_buf: [256]u8 = undefined;
+        const pl_msg = std.fmt.bufPrint(
+            &pl_buf,
+            "MALT_PREFIX '{s}' is {d} bytes, exceeds {d}-byte Mach-O patch budget. Set MALT_PREFIX to a shorter path.",
+            .{ prefix, prefix.len, install_mod.max_prefix_len },
+        ) catch "MALT_PREFIX exceeds the Mach-O patch budget. Set MALT_PREFIX to a shorter path.";
+        printCheck("Prefix length", .err_status, pl_msg);
+        errors += 1;
+    };
+    if (prefix.len <= install_mod.max_prefix_len) {
+        printCheck("Prefix length", .ok, null);
     }
 
     // 4. APFS volume

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -21,6 +21,26 @@ const output = @import("../ui/output.zig");
 const progress_mod = @import("../ui/progress.zig");
 const help = @import("help.zig");
 
+/// Maximum safe byte length for MALT_PREFIX.
+///
+/// Homebrew bottles hard-code `/opt/homebrew` (13 bytes) in LC_LOAD_DYLIB
+/// load-command paths. `malt` rewrites that prefix in place during
+/// materialize, and the replacement path must not be longer than the
+/// original or the load command will not fit its pre-allocated slot and
+/// dyld will refuse to load the binary.
+///
+/// Keeping MALT_PREFIX ≤ 13 bytes guarantees the rewrite always fits,
+/// matching the rationale called out in README.md (§"Directory Layout").
+pub const max_prefix_len: usize = "/opt/homebrew".len;
+
+pub const PrefixError = error{PrefixTooLong};
+
+/// Refuse to proceed when MALT_PREFIX exceeds `max_prefix_len`. Exposed so
+/// `mt doctor` can reuse the same rule.
+pub fn checkPrefixLength(prefix: []const u8) PrefixError!void {
+    if (prefix.len > max_prefix_len) return error.PrefixTooLong;
+}
+
 pub const InstallError = error{
     NoPackages,
     DatabaseError,
@@ -186,6 +206,24 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     // Initialize infrastructure
     const prefix = atomic.maltPrefix();
+
+    // Pre-flight: refuse the install if MALT_PREFIX is longer than the
+    // Mach-O in-place patching budget. We catch this BEFORE any network
+    // activity so users do not spend minutes downloading bottles that are
+    // guaranteed to fail at patch time.
+    checkPrefixLength(prefix) catch |err| switch (err) {
+        error.PrefixTooLong => {
+            output.err(
+                "MALT_PREFIX '{s}' is {d} bytes, which exceeds the {d}-byte budget for Mach-O in-place patching.",
+                .{ prefix, prefix.len, max_prefix_len },
+            );
+            output.err("Homebrew bottles hard-code `/opt/homebrew` (13 bytes) in LC_LOAD_DYLIB", .{});
+            output.err("entries, and malt replaces that prefix in place — the replacement must", .{});
+            output.err("not be longer or dyld will fail to load the binaries at runtime.", .{});
+            output.err("Set MALT_PREFIX to a shorter path (e.g. /opt/malt or /tmp/mt) and retry.", .{});
+            return InstallError.PrefixTooLong;
+        },
+    };
 
     // Ensure required directories exist (Step 0)
     ensureDirs(prefix);

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -33,6 +33,14 @@ pub const InstallError = error{
     CellarFailed,
     LinkFailed,
     RecordFailed,
+    /// At least one package in a multi-package install failed to materialize
+    /// or was skipped because an ancestor dep failed. Returned from `execute`
+    /// so `main` exits non-zero.
+    PartialFailure,
+    /// MALT_PREFIX is longer than the Mach-O in-place patching budget. Set
+    /// before any network activity so the user can fix it without waiting on
+    /// a multi-gigabyte download that will inevitably fail.
+    PrefixTooLong,
 };
 
 /// A bottle download job for parallel processing.
@@ -393,19 +401,89 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     // ── Sequential materialize + link phase ──────────────────────────
+    //
+    // Failures are tracked so we can:
+    //   1. Exit non-zero when any requested package (or its dep) fails (P2).
+    //   2. Skip later jobs whose dependencies we already know to be broken,
+    //      rather than leaving a cellar full of half-working kegs (P3).
+    var failed_kegs = std.StringHashMap(void).init(allocator);
+    defer failed_kegs.deinit();
+    var failed_count: usize = 0;
+
     for (all_jobs.items) |*job| {
         if (main_mod.isInterrupted()) {
             output.warn("Interrupted. Stopping install.", .{});
-            return;
+            break;
         }
 
         if (!job.succeeded) {
             output.err("Download failed for {s}, skipping", .{job.name});
+            failed_kegs.put(job.name, {}) catch {};
+            failed_count += 1;
             continue;
         }
 
-        materializeAndLink(allocator, job, &db, &linker, prefix);
+        // Skip if any runtime dep has already failed — installing on top of a
+        // broken dep graph produces a keg that dyld cannot resolve at runtime.
+        if (findFailedDep(&failed_kegs, job.formula_json)) |failed_dep| {
+            output.warn(
+                "Skipping {s}: dependency {s} failed to install",
+                .{ job.name, failed_dep },
+            );
+            failed_kegs.put(job.name, {}) catch {};
+            failed_count += 1;
+            continue;
+        }
+
+        materializeAndLink(allocator, job, &db, &linker, prefix) catch {
+            // The underlying error was already logged with a tag by
+            // materializeAndLink — just record that this job failed so its
+            // dependents in the rest of the loop get skipped above.
+            failed_kegs.put(job.name, {}) catch {};
+            failed_count += 1;
+            continue;
+        };
     }
+
+    if (failed_count > 0) {
+        const pkg_word: []const u8 = if (failed_count == 1) "package" else "packages";
+        output.err(
+            "{d} {s} failed to install. See errors above.",
+            .{ failed_count, pkg_word },
+        );
+        return InstallError.PartialFailure;
+    }
+}
+
+/// Return the first dep name of `formula_json` that appears in `failed_kegs`,
+/// or null if none did. Used to short-circuit jobs whose dependency graph is
+/// already broken so we do not leave half-installed kegs behind.
+///
+/// Errors during parse are treated as "no known failed dep" — we would rather
+/// attempt the install and let materialize surface the real problem than
+/// silently skip over a parser hiccup.
+fn findFailedDep(
+    failed_kegs: *std.StringHashMap(void),
+    formula_json: []const u8,
+) ?[]const u8 {
+    var tmp_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer tmp_arena.deinit();
+    const a = tmp_arena.allocator();
+
+    var parsed = formula_mod.parseFormula(a, formula_json) catch return null;
+    defer parsed.deinit();
+
+    for (parsed.dependencies) |dep_name| {
+        if (failed_kegs.contains(dep_name)) {
+            // The slice `dep_name` lives inside the temp arena which is about
+            // to be freed. Look up the same key inside the map's storage to
+            // return a slice with a stable lifetime (the map owns its keys
+            // indirectly via the job.name slices stored at insert time).
+            if (failed_kegs.getKey(dep_name)) |stable| return stable;
+            return dep_name;
+        }
+    }
+    return null;
 }
 
 /// Collect download jobs for a formula and all its dependencies.
@@ -517,13 +595,18 @@ fn collectFormulaJobs(
 }
 
 /// Materialize a downloaded bottle to the cellar, link, and record in DB.
+///
+/// Returns an error on any failure instead of silently swallowing it, so
+/// `runInstall` can track failed packages and exit non-zero. The per-error
+/// `output.err` messages carry a human-readable tag via
+/// `cellar_mod.describeError`.
 fn materializeAndLink(
     allocator: std.mem.Allocator,
     job: *DownloadJob,
     db: *sqlite.Database,
     linker: *linker_mod.Linker,
     prefix: []const u8,
-) void {
+) !void {
     const reason: []const u8 = if (job.is_dep) "dependency" else "direct";
 
     // Animated spinner while materialize runs. Materialize is synchronous and
@@ -541,17 +624,20 @@ fn materializeAndLink(
         job.name,
         job.version_str,
         job.cellar_type,
-    ) catch {
+    ) catch |err| {
         spinner.stop();
-        output.err("Failed to materialize {s}", .{job.name});
-        return;
+        output.err(
+            "Failed to materialize {s}: {s} ({s})",
+            .{ job.name, @errorName(err), cellar_mod.describeError(err) },
+        );
+        return err;
     };
     spinner.stop();
     // Parse formula for DB recording
-    var formula = formula_mod.parseFormula(allocator, job.formula_json) catch {
-        output.err("Failed to parse formula for {s}", .{job.name});
+    var formula = formula_mod.parseFormula(allocator, job.formula_json) catch |err| {
+        output.err("Failed to parse formula for {s}: {s}", .{ job.name, @errorName(err) });
         cellar_mod.remove(prefix, job.name, job.version_str) catch {};
-        return;
+        return InstallError.CellarFailed;
     };
     defer formula.deinit();
 
@@ -565,33 +651,34 @@ fn materializeAndLink(
             }
             output.err("Use --force to overwrite, or uninstall the conflicting package first.", .{});
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
-            return;
+            return InstallError.LinkFailed;
         }
     }
 
     // Link + record
     if (!job.keg_only) {
-        const keg_id = recordKeg(db, &formula, job.store_sha256, keg.path, reason) catch {
-            output.err("Failed to record {s} in database", .{job.name});
+        const keg_id = recordKeg(db, &formula, job.store_sha256, keg.path, reason) catch |err| {
+            output.err("Failed to record {s} in database: {s}", .{ job.name, @errorName(err) });
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
-            return;
+            return InstallError.RecordFailed;
         };
 
-        linker.link(keg.path, job.name, keg_id) catch {
-            output.warn("Some links for {s} could not be created", .{job.name});
+        linker.link(keg.path, job.name, keg_id) catch |err| {
+            output.err("Failed to link {s}: {s}", .{ job.name, @errorName(err) });
             // Rollback: unlink what was partially created + remove DB record + cellar
             linker.unlink(keg_id) catch {};
             deleteKeg(db, keg_id);
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
-            return;
+            return InstallError.LinkFailed;
         };
         linker.linkOpt(job.name, job.version_str) catch {};
         recordDeps(db, keg_id, &formula);
     } else {
         output.info("{s} is keg-only; not linking", .{job.name});
-        const keg_id = recordKeg(db, &formula, job.store_sha256, keg.path, reason) catch {
+        const keg_id = recordKeg(db, &formula, job.store_sha256, keg.path, reason) catch |err| {
+            output.err("Failed to record {s} in database: {s}", .{ job.name, @errorName(err) });
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
-            return;
+            return InstallError.RecordFailed;
         };
         linker.linkOpt(job.name, job.version_str) catch {};
         recordDeps(db, keg_id, &formula);

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -125,8 +125,17 @@ pub fn materializeWithCellar(
     // Clone from store to Cellar
     clonefile.cloneTree(src, cellar_path) catch return CellarError.CloneFailed;
 
-    // errdefer: remove cellar entry on any failure from this point
-    errdefer std.fs.deleteTreeAbsolute(cellar_path) catch {};
+    // errdefer: remove cellar entry on any failure from this point.
+    // Also remove the now-empty `Cellar/{name}/` parent dir if we just created
+    // it and no other versions live there — keeps failed installs from
+    // leaving orphan directories behind.
+    //
+    // `deleteDirAbsolute` only succeeds when the directory is empty, so
+    // installed sibling versions are left untouched.
+    errdefer {
+        std.fs.deleteTreeAbsolute(cellar_path) catch {};
+        std.fs.deleteDirAbsolute(parent) catch {};
+    }
 
     const new_prefix = atomic.maltPrefix();
 

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -122,20 +122,20 @@ pub fn materializeWithCellar(
         break :blk keg_src;
     };
 
-    // Clone from store to Cellar
-    clonefile.cloneTree(src, cellar_path) catch return CellarError.CloneFailed;
-
-    // errdefer: remove cellar entry on any failure from this point.
-    // Also remove the now-empty `Cellar/{name}/` parent dir if we just created
-    // it and no other versions live there — keeps failed installs from
-    // leaving orphan directories behind.
+    // errdefer: remove cellar entry on any failure from this point — including
+    // `cloneTree` itself, which would otherwise leave the freshly-created
+    // `Cellar/{name}/` parent dir behind as an empty orphan.
     //
+    // `deleteTreeAbsolute` is a no-op when the target doesn't exist yet, and
     // `deleteDirAbsolute` only succeeds when the directory is empty, so
     // installed sibling versions are left untouched.
     errdefer {
         std.fs.deleteTreeAbsolute(cellar_path) catch {};
         std.fs.deleteDirAbsolute(parent) catch {};
     }
+
+    // Clone from store to Cellar
+    clonefile.cloneTree(src, cellar_path) catch return CellarError.CloneFailed;
 
     const new_prefix = atomic.maltPrefix();
 

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -10,10 +10,24 @@ const atomic = @import("../fs/atomic.zig");
 pub const CellarError = error{
     CloneFailed,
     PatchFailed,
+    PathTooLong,
     CodesignFailed,
     RemoveFailed,
     OutOfMemory,
 };
+
+/// Human-readable description for a CellarError tag.
+/// Used by `mt install` when surfacing a materialize failure.
+pub fn describeError(err: CellarError) []const u8 {
+    return switch (err) {
+        CellarError.CloneFailed => "APFS clonefile or copy failed",
+        CellarError.PatchFailed => "Mach-O or text-file path patching failed",
+        CellarError.PathTooLong => "new prefix path is longer than the bottle was built with",
+        CellarError.CodesignFailed => "codesign re-signing failed",
+        CellarError.RemoveFailed => "cellar directory removal failed",
+        CellarError.OutOfMemory => "out of memory",
+    };
+}
 
 pub const Keg = struct {
     name: []const u8,
@@ -23,10 +37,13 @@ pub const Keg = struct {
 
 /// Materialize a keg from the store to the Cellar.
 /// 1. clonefile store/{sha256}/... → Cellar/{name}/{version}/
-/// 2. Patch Mach-O load commands (both /opt/homebrew and /usr/local prefixes)
-///    — skipped when cellar_type is ":any" or ":any_skip_relocation" (relocatable bottle)
-/// 3. Patch text files (@@HOMEBREW_PREFIX@@ etc.)
-/// 4. Ad-hoc codesign on arm64
+/// 2. Patch Mach-O placeholder tokens (@@HOMEBREW_PREFIX@@ / @@HOMEBREW_CELLAR@@)
+///    — ALWAYS runs, even for ":any" relocatable bottles, because placeholders
+///    in LC_LOAD_DYLIB / LC_RPATH must be substituted at pour time.
+/// 3. Patch Mach-O absolute paths (/opt/homebrew, /usr/local)
+///    — skipped when cellar_type is ":any" or ":any_skip_relocation".
+/// 4. Patch text files (@@HOMEBREW_PREFIX@@ etc.)
+/// 5. Ad-hoc codesign on arm64
 /// Uses errdefer to clean up Cellar entry on failure.
 pub fn materialize(
     allocator: std.mem.Allocator,
@@ -113,22 +130,31 @@ pub fn materializeWithCellar(
 
     const new_prefix = atomic.maltPrefix();
 
-    // Relocatable bottles (cellar: ":any" or ":any_skip_relocation") do not
-    // need Mach-O binary patching — they are built to work from any prefix.
-    // However, @@HOMEBREW_PREFIX@@ / @@HOMEBREW_CELLAR@@ text placeholders
-    // must ALWAYS be substituted, even for relocatable bottles, because
-    // Homebrew performs this substitution unconditionally during bottle pour.
-    const skip_macho = std.mem.eql(u8, cellar_type, ":any") or
-        std.mem.eql(u8, cellar_type, ":any_skip_relocation");
-
     // Build cellar replacement for @@HOMEBREW_CELLAR@@
     var new_cellar_buf: [256]u8 = undefined;
     const new_cellar = std.fmt.bufPrint(&new_cellar_buf, "{s}/Cellar", .{new_prefix}) catch new_prefix;
 
-    if (!skip_macho) {
-        // Walk cellar directory and patch each Mach-O binary
-        patchAllMachO(allocator, cellar_path, new_prefix, new_cellar) catch
-            return CellarError.PatchFailed;
+    // Pass 1: placeholder substitution — ALWAYS runs, regardless of cellar_type.
+    // `@@HOMEBREW_PREFIX@@` / `@@HOMEBREW_CELLAR@@` tokens appear in LC_LOAD_DYLIB,
+    // LC_RPATH, etc. even in `:any` bottles (zig, curl, rust, llvm@* all do this)
+    // and must be rewritten or the resulting binaries will fail with
+    // `dyld: Symbol not found`.
+    patchMachOPlaceholders(allocator, cellar_path, new_prefix, new_cellar) catch |e| switch (e) {
+        CellarError.PathTooLong => return CellarError.PathTooLong,
+        else => return CellarError.PatchFailed,
+    };
+
+    // Pass 2: absolute-path rewrite — skipped for relocatable bottles, which
+    // Homebrew guarantees to only use `@rpath`/`@loader_path` or the placeholder
+    // tokens handled above.
+    const skip_absolute_rewrite = std.mem.eql(u8, cellar_type, ":any") or
+        std.mem.eql(u8, cellar_type, ":any_skip_relocation");
+
+    if (!skip_absolute_rewrite) {
+        patchMachOAbsolutePaths(allocator, cellar_path, new_prefix) catch |e| switch (e) {
+            CellarError.PathTooLong => return CellarError.PathTooLong,
+            else => return CellarError.PatchFailed,
+        };
     }
 
     // Always patch text files — @@HOMEBREW_PREFIX@@ and @@HOMEBREW_CELLAR@@
@@ -161,9 +187,53 @@ pub fn materializeWithCellar(
     };
 }
 
-/// Walk a directory and patch all Mach-O binaries with prefix replacements.
-/// Returns PatchFailed if any binary has paths that are too long for in-place patching.
-fn patchAllMachO(allocator: std.mem.Allocator, dir_path: []const u8, new_prefix: []const u8, new_cellar: []const u8) CellarError!void {
+/// Walk a directory and patch the `@@HOMEBREW_PREFIX@@` / `@@HOMEBREW_CELLAR@@`
+/// tokens in every Mach-O load command. This ALWAYS runs, including for `:any`
+/// relocatable bottles — see call-site comment.
+///
+/// Returns `PathTooLong` if the substituted path would not fit in the existing
+/// load-command slot (the new MALT_PREFIX is longer than what the bottle was
+/// built for). Returns `PatchFailed` for any other patcher error.
+fn patchMachOPlaceholders(
+    allocator: std.mem.Allocator,
+    dir_path: []const u8,
+    new_prefix: []const u8,
+    new_cellar: []const u8,
+) CellarError!void {
+    try walkMachOAndPatch(allocator, dir_path, &.{
+        .{ .old = "@@HOMEBREW_PREFIX@@", .new = new_prefix },
+        .{ .old = "@@HOMEBREW_CELLAR@@", .new = new_cellar },
+    });
+}
+
+/// Walk a directory and rewrite `/opt/homebrew` / `/usr/local` to the current
+/// MALT_PREFIX in every Mach-O load command. Skipped for `:any` bottles by the
+/// caller (those only use rpath + placeholder tokens).
+fn patchMachOAbsolutePaths(
+    allocator: std.mem.Allocator,
+    dir_path: []const u8,
+    new_prefix: []const u8,
+) CellarError!void {
+    try walkMachOAndPatch(allocator, dir_path, &.{
+        .{ .old = "/opt/homebrew", .new = new_prefix },
+        .{ .old = "/usr/local", .new = new_prefix },
+    });
+}
+
+const Replacement = struct {
+    old: []const u8,
+    new: []const u8,
+};
+
+/// Shared Mach-O walker: for every file that looks like a Mach-O, run each
+/// replacement in order. `PathTooLong` is surfaced as a real error; other
+/// per-file errors are skipped so a single bad binary does not fail the whole
+/// materialize.
+fn walkMachOAndPatch(
+    allocator: std.mem.Allocator,
+    dir_path: []const u8,
+    replacements: []const Replacement,
+) CellarError!void {
     var dir = std.fs.openDirAbsolute(dir_path, .{ .iterate = true }) catch return;
     defer dir.close();
 
@@ -176,7 +246,7 @@ fn patchAllMachO(allocator: std.mem.Allocator, dir_path: []const u8, new_prefix:
         const full_path = std.fs.path.join(allocator, &.{ dir_path, entry.path }) catch continue;
         defer allocator.free(full_path);
 
-        // Check if Mach-O by reading magic
+        // Check if Mach-O by reading magic.
         const file = std.fs.openFileAbsolute(full_path, .{}) catch continue;
         var magic_buf: [4]u8 = undefined;
         const n = file.readAll(&magic_buf) catch {
@@ -189,25 +259,12 @@ fn patchAllMachO(allocator: std.mem.Allocator, dir_path: []const u8, new_prefix:
         const parser_mod = @import("../macho/parser.zig");
         if (!parser_mod.isMachO(&magic_buf)) continue;
 
-        // Patch all known prefix patterns in this Mach-O.
-        // PathTooLong is a real error — surface it so the caller knows the
-        // binary cannot be relocated in-place.
-        _ = patcher.patchPaths(allocator, full_path, "/opt/homebrew", new_prefix) catch |e| switch (e) {
-            error.PathTooLong => return CellarError.PatchFailed,
-            else => continue,
-        };
-        _ = patcher.patchPaths(allocator, full_path, "/usr/local", new_prefix) catch |e| switch (e) {
-            error.PathTooLong => return CellarError.PatchFailed,
-            else => continue,
-        };
-        _ = patcher.patchPaths(allocator, full_path, "@@HOMEBREW_PREFIX@@", new_prefix) catch |e| switch (e) {
-            error.PathTooLong => return CellarError.PatchFailed,
-            else => continue,
-        };
-        _ = patcher.patchPaths(allocator, full_path, "@@HOMEBREW_CELLAR@@", new_cellar) catch |e| switch (e) {
-            error.PathTooLong => return CellarError.PatchFailed,
-            else => continue,
-        };
+        for (replacements) |r| {
+            _ = patcher.patchPaths(allocator, full_path, r.old, r.new) catch |e| switch (e) {
+                error.PathTooLong => return CellarError.PathTooLong,
+                else => continue,
+            };
+        }
     }
 }
 

--- a/src/db/lock.zig
+++ b/src/db/lock.zig
@@ -73,7 +73,14 @@ pub const LockFile = struct {
     }
 
     /// Release the advisory lock and close the file descriptor.
+    ///
+    /// Truncates the file to 0 bytes before unlocking so subsequent
+    /// `holderPid` calls (and therefore `mt doctor`) see the lock as
+    /// vacated instead of reporting a stale PID. The file itself is
+    /// left in place — removing it would race against other processes
+    /// that may already have it open.
     pub fn release(self: *LockFile) void {
+        std.posix.ftruncate(self.fd, 0) catch {};
         std.posix.flock(self.fd, std.posix.LOCK.UN) catch {};
         std.posix.close(self.fd);
     }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -23,3 +23,5 @@ pub const version = @import("version.zig");
 pub const completions = @import("cli/completions.zig");
 pub const backup = @import("cli/backup.zig");
 pub const purge = @import("cli/purge.zig");
+pub const install = @import("cli/install.zig");
+pub const doctor = @import("cli/doctor.zig");

--- a/src/macho/parser.zig
+++ b/src/macho/parser.zig
@@ -60,36 +60,72 @@ pub fn parse(allocator: std.mem.Allocator, data: []const u8) ParseError!MachO {
     return ParseError.InvalidMagic;
 }
 
+/// Parse every arch slice in a fat Mach-O and return the union of their
+/// load-command paths.
+///
+/// Before: this only parsed the slice matching the host CPU and ignored the
+/// rest. That silently left the other arch's LC_LOAD_DYLIB / LC_RPATH paths
+/// unpatched, so running e.g. an arm64 install on an Intel Mac (or vice
+/// versa) would fail with `dyld: Symbol not found` on the first fat-bottle
+/// it touched. (P9 — cross-arch fat-binary patching.)
+///
+/// Each `LoadCommandPath` already carries the absolute file offset of its
+/// path string (parseMachO64 is given the slice's `base_offset`), so the
+/// patcher can rewrite every arch's load commands in a single pass over
+/// the full file buffer.
+///
+/// Unrecognised or truncated slices are skipped rather than aborting the
+/// whole parse — some fat archives carry legacy arches (PPC, arm64e, arm64_32)
+/// whose parseMachO64 call can legitimately return InvalidMagic /
+/// UnsupportedArch / TruncatedFile.
 fn parseFat(allocator: std.mem.Allocator, data: []const u8) ParseError!MachO {
     if (data.len < 8) return ParseError.TruncatedFile;
 
-    // Fat header is big-endian
+    // Fat header is big-endian: magic (4), nfat_arch (4).
     const nfat_arch = std.mem.readInt(u32, data[4..8], .big);
 
-    // Find the slice for the current architecture
-    const target_cputype: u32 = if (@import("builtin").cpu.arch == .aarch64)
-        0x0100000C // CPU_TYPE_ARM64
-    else
-        0x01000007; // CPU_TYPE_X86_64
+    var all_paths: std.ArrayList(LoadCommandPath) = .empty;
+    errdefer all_paths.deinit(allocator);
 
     var offset: usize = 8;
     var i: u32 = 0;
     while (i < nfat_arch) : (i += 1) {
         if (offset + 20 > data.len) return ParseError.TruncatedFile;
 
-        const cputype = std.mem.readInt(u32, data[offset..][0..4], .big);
+        // fat_arch layout: cputype(4), cpusubtype(4), offset(4), size(4), align(4).
         const slice_offset = std.mem.readInt(u32, data[offset + 8 ..][0..4], .big);
         const slice_size = std.mem.readInt(u32, data[offset + 12 ..][0..4], .big);
 
-        if (cputype == target_cputype) {
-            if (slice_offset + slice_size > data.len) return ParseError.TruncatedFile;
-            return parseMachO64(allocator, data[slice_offset .. slice_offset + slice_size], slice_offset);
-        }
+        offset += 20;
 
-        offset += 20; // sizeof(fat_arch)
+        if (slice_offset + slice_size > data.len) return ParseError.TruncatedFile;
+
+        // Parse this slice. Skip unrecognised slices (legacy arches etc.)
+        // rather than failing the whole file.
+        const slice_result = parseMachO64(
+            allocator,
+            data[slice_offset .. slice_offset + slice_size],
+            slice_offset,
+        ) catch |e| switch (e) {
+            ParseError.InvalidMagic,
+            ParseError.UnsupportedArch,
+            ParseError.TruncatedFile,
+            => continue,
+            ParseError.InvalidLoadCommand => continue,
+            ParseError.OutOfMemory => return e,
+        };
+        // Transfer the slice's LoadCommandPath values (struct-by-value) into
+        // the aggregated list, then free the slice's container. The `path`
+        // byte slices inside each LoadCommandPath still reference the outer
+        // `data` buffer which outlives this call.
+        defer allocator.free(slice_result.paths);
+        all_paths.appendSlice(allocator, slice_result.paths) catch return ParseError.OutOfMemory;
     }
 
-    return ParseError.UnsupportedArch;
+    return .{
+        .paths = all_paths.toOwnedSlice(allocator) catch return ParseError.OutOfMemory,
+        .allocator = allocator,
+    };
 }
 
 fn parseMachO64(allocator: std.mem.Allocator, data: []const u8, base_offset: usize) ParseError!MachO {

--- a/tests/cellar_test.zig
+++ b/tests/cellar_test.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 const testing = std.testing;
 const cellar_mod = @import("malt").cellar;
 const patcher = @import("malt").patcher;
+const parser = @import("malt").parser;
 const install_mod = @import("malt").install;
 
 // libc setenv/unsetenv — available because tests link with libc
@@ -479,4 +480,259 @@ test "patchTextFiles replaces all placeholder occurrences" {
     try testing.expect(std.mem.indexOf(u8, content, "@@HOMEBREW_CELLAR@@") == null);
     try testing.expect(std.mem.indexOf(u8, content, "/opt/malt") != null);
     try testing.expect(std.mem.indexOf(u8, content, "/opt/malt/Cellar") != null);
+}
+
+// ---------------------------------------------------------------------------
+// P1 — REGRESSION GUARD: @@HOMEBREW_PREFIX@@ must be rewritten in Mach-O
+// load commands even when cellar_type is ":any" (relocatable bottle).
+//
+// Before the fix, the materializer skipped Mach-O patching entirely for
+// ":any" bottles, leaving @@HOMEBREW_* placeholder tokens in LC_LOAD_DYLIB
+// and LC_RPATH unresolved. Zig, rust, curl and all llvm@* bottles then
+// failed at runtime with `dyld: Symbol not found`.
+//
+// This test builds a minimal but *parser-valid* Mach-O fixture containing
+// one LC_RPATH whose path is `@@HOMEBREW_PREFIX@@/lib/test`, materializes it
+// as a ":any" bottle, re-parses the patched output, and asserts both the
+// negative (no placeholder remains) and the positive (the new prefix is
+// present) invariants.
+// ---------------------------------------------------------------------------
+
+/// Build a minimal valid Mach-O 64 binary with one LC_RPATH load command.
+/// The `cmdsize` is padded to 256 bytes so the load-command slot is large
+/// enough to accept any reasonable replacement prefix.
+fn buildMinimalMachOWithRpath(
+    allocator: std.mem.Allocator,
+    rpath: []const u8,
+) ![]u8 {
+    const macho = std.macho;
+    const header_size = @sizeOf(macho.mach_header_64);
+    const cmdsize: u32 = 256;
+    const total = header_size + cmdsize;
+
+    const buf = try allocator.alloc(u8, total);
+    @memset(buf, 0);
+
+    // Only set the fields we actually care about. std.macho struct fields
+    // use primitive integer types, not typed enums — we write the raw
+    // constants (MH_EXECUTE = 2, LC_RPATH = 0x1c) directly.
+    const hdr = std.mem.bytesAsValue(macho.mach_header_64, buf[0..header_size]);
+    hdr.* = .{
+        .magic = macho.MH_MAGIC_64,
+        .ncmds = 1,
+        .sizeofcmds = cmdsize,
+    };
+
+    // LC_RPATH header: cmd(4), cmdsize(4), path(4) + padded path string.
+    // We write the bytes directly rather than through rpath_command because
+    // the field layout varies across Zig releases and we only need three u32s.
+    // LC_RPATH = 0x1c OR'd with LC_REQ_DYLD (0x80000000). The parser matches
+    // on the full LC enum value including the LC_REQ_DYLD flag bit.
+    const lc_rpath: u32 = 0x1c | 0x80000000;
+    const rpath_cmd_size: usize = 12;
+    std.mem.writeInt(u32, buf[header_size..][0..4], lc_rpath, .little);
+    std.mem.writeInt(u32, buf[header_size + 4 ..][0..4], cmdsize, .little);
+    std.mem.writeInt(u32, buf[header_size + 8 ..][0..4], @intCast(rpath_cmd_size), .little); // path offset
+
+    // Copy the rpath string into the slot; trailing bytes stay as NULs.
+    std.debug.assert(rpath.len + 1 <= cmdsize - rpath_cmd_size);
+    @memcpy(buf[header_size + rpath_cmd_size ..][0..rpath.len], rpath);
+
+    return buf;
+}
+
+test "materialize rewrites @@HOMEBREW_PREFIX@@ in Mach-O rpath for :any bottle" {
+    // Use a SHORT test prefix so the rewritten path definitely fits in the
+    // original load-command slot. `/tmp/mp-{hex}` is ~14 bytes.
+    const prefix_str = try std.fmt.allocPrint(
+        testing.allocator,
+        "/tmp/mp-{x}",
+        .{std.crypto.random.int(u32)},
+    );
+    defer testing.allocator.free(prefix_str);
+
+    const prefix: [:0]const u8 = try testing.allocator.allocSentinel(u8, prefix_str.len, 0);
+    defer testing.allocator.free(prefix);
+    @memcpy(@constCast(prefix), prefix_str);
+    defer std.fs.deleteTreeAbsolute(prefix) catch {};
+
+    try std.fs.makeDirAbsolute(prefix);
+    try setupMaltDirs(testing.allocator, prefix);
+
+    // Place a synthetic Mach-O inside the store tree.
+    const sha = "p1test";
+    const name = "relfake";
+    const version = "1.0";
+    const keg_bin_dir = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/store/{s}/{s}/{s}/bin",
+        .{ prefix, sha, name, version },
+    );
+    defer testing.allocator.free(keg_bin_dir);
+    try std.fs.cwd().makePath(keg_bin_dir);
+
+    const bin_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/fakebin",
+        .{keg_bin_dir},
+    );
+    defer testing.allocator.free(bin_path);
+
+    const fixture = try buildMinimalMachOWithRpath(
+        testing.allocator,
+        "@@HOMEBREW_PREFIX@@/lib/test",
+    );
+    defer testing.allocator.free(fixture);
+    {
+        const f = try std.fs.createFileAbsolute(bin_path, .{});
+        defer f.close();
+        try f.writeAll(fixture);
+    }
+
+    const old_env = setMaltPrefix(prefix);
+    defer restoreMaltPrefix(old_env);
+
+    // The exact bug scenario: `:any` bottle that would have skipped Mach-O
+    // patching before P1.
+    const keg = try cellar_mod.materializeWithCellar(
+        testing.allocator,
+        prefix,
+        sha,
+        name,
+        version,
+        ":any",
+    );
+    defer testing.allocator.free(keg.path);
+
+    // Re-parse the patched binary and validate the load-command path.
+    const out_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/bin/fakebin",
+        .{keg.path},
+    );
+    defer testing.allocator.free(out_path);
+
+    const data = try readFile(testing.allocator, out_path);
+    defer testing.allocator.free(data);
+
+    var parsed = try parser.parse(testing.allocator, data);
+    defer parsed.deinit();
+
+    // Must have at least one LC_RPATH.
+    try testing.expect(parsed.paths.len >= 1);
+
+    // Negative invariant: no placeholder tokens anywhere.
+    for (parsed.paths) |lcp| {
+        try testing.expect(std.mem.indexOf(u8, lcp.path, "@@HOMEBREW_PREFIX@@") == null);
+        try testing.expect(std.mem.indexOf(u8, lcp.path, "@@HOMEBREW_CELLAR@@") == null);
+    }
+
+    // Positive invariant: at least one load command now holds the new prefix.
+    var found_new_prefix = false;
+    for (parsed.paths) |lcp| {
+        if (std.mem.indexOf(u8, lcp.path, prefix) != null) {
+            found_new_prefix = true;
+            break;
+        }
+    }
+    try testing.expect(found_new_prefix);
+
+    // Spot-check the specific expected result.
+    var expected_buf: [256]u8 = undefined;
+    const expected = try std.fmt.bufPrint(&expected_buf, "{s}/lib/test", .{prefix});
+    var found_exact = false;
+    for (parsed.paths) |lcp| {
+        if (std.mem.eql(u8, lcp.path, expected)) {
+            found_exact = true;
+            break;
+        }
+    }
+    try testing.expect(found_exact);
+}
+
+test "materialize rewrites @@HOMEBREW_CELLAR@@ in Mach-O rpath for :any bottle" {
+    // Same fixture strategy, different token.
+    const prefix_str = try std.fmt.allocPrint(
+        testing.allocator,
+        "/tmp/mp-{x}",
+        .{std.crypto.random.int(u32)},
+    );
+    defer testing.allocator.free(prefix_str);
+
+    const prefix: [:0]const u8 = try testing.allocator.allocSentinel(u8, prefix_str.len, 0);
+    defer testing.allocator.free(prefix);
+    @memcpy(@constCast(prefix), prefix_str);
+    defer std.fs.deleteTreeAbsolute(prefix) catch {};
+
+    try std.fs.makeDirAbsolute(prefix);
+    try setupMaltDirs(testing.allocator, prefix);
+
+    const sha = "p1cellar";
+    const name = "cellarfake";
+    const version = "2.0";
+    const keg_bin_dir = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/store/{s}/{s}/{s}/bin",
+        .{ prefix, sha, name, version },
+    );
+    defer testing.allocator.free(keg_bin_dir);
+    try std.fs.cwd().makePath(keg_bin_dir);
+
+    const bin_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/fakelib",
+        .{keg_bin_dir},
+    );
+    defer testing.allocator.free(bin_path);
+
+    const fixture = try buildMinimalMachOWithRpath(
+        testing.allocator,
+        "@@HOMEBREW_CELLAR@@/openssl@3/3.0/lib",
+    );
+    defer testing.allocator.free(fixture);
+    {
+        const f = try std.fs.createFileAbsolute(bin_path, .{});
+        defer f.close();
+        try f.writeAll(fixture);
+    }
+
+    const old_env = setMaltPrefix(prefix);
+    defer restoreMaltPrefix(old_env);
+
+    const keg = try cellar_mod.materializeWithCellar(
+        testing.allocator,
+        prefix,
+        sha,
+        name,
+        version,
+        ":any_skip_relocation",
+    );
+    defer testing.allocator.free(keg.path);
+
+    const out_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/bin/fakelib",
+        .{keg.path},
+    );
+    defer testing.allocator.free(out_path);
+
+    const data = try readFile(testing.allocator, out_path);
+    defer testing.allocator.free(data);
+
+    var parsed = try parser.parse(testing.allocator, data);
+    defer parsed.deinit();
+
+    var expected_buf: [256]u8 = undefined;
+    const expected = try std.fmt.bufPrint(
+        &expected_buf,
+        "{s}/Cellar/openssl@3/3.0/lib",
+        .{prefix},
+    );
+
+    var found = false;
+    for (parsed.paths) |lcp| {
+        try testing.expect(std.mem.indexOf(u8, lcp.path, "@@HOMEBREW_CELLAR@@") == null);
+        if (std.mem.eql(u8, lcp.path, expected)) found = true;
+    }
+    try testing.expect(found);
 }

--- a/tests/cellar_test.zig
+++ b/tests/cellar_test.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 const testing = std.testing;
 const cellar_mod = @import("malt").cellar;
 const patcher = @import("malt").patcher;
+const install_mod = @import("malt").install;
 
 // libc setenv/unsetenv — available because tests link with libc
 const c = struct {
@@ -329,6 +330,129 @@ test "binary files are skipped by text patching without error" {
 // ---------------------------------------------------------------------------
 // patchTextFiles direct test
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// P4 — Pre-flight MALT_PREFIX length check
+// ---------------------------------------------------------------------------
+
+test "checkPrefixLength accepts prefixes within the Mach-O patch budget" {
+    try install_mod.checkPrefixLength("/opt/malt");
+    try install_mod.checkPrefixLength("/opt/homebrew"); // exactly 13 bytes — boundary
+    try install_mod.checkPrefixLength("/tmp/mt");
+}
+
+test "checkPrefixLength rejects prefixes that overflow the budget" {
+    try testing.expectError(
+        error.PrefixTooLong,
+        install_mod.checkPrefixLength("/var/folders/abc/def/ghi/jkl/mno/prefix"),
+    );
+    try testing.expectError(
+        error.PrefixTooLong,
+        install_mod.checkPrefixLength("/opt/homebrew/"), // 14 bytes — just over
+    );
+}
+
+test "max_prefix_len matches the /opt/homebrew budget" {
+    try testing.expectEqual(@as(usize, "/opt/homebrew".len), install_mod.max_prefix_len);
+}
+
+// ---------------------------------------------------------------------------
+// P5 — CellarError.describeError covers every tag
+// ---------------------------------------------------------------------------
+
+test "describeError returns a non-empty, distinct message for every CellarError" {
+    const cases = [_]cellar_mod.CellarError{
+        cellar_mod.CellarError.CloneFailed,
+        cellar_mod.CellarError.PatchFailed,
+        cellar_mod.CellarError.PathTooLong,
+        cellar_mod.CellarError.CodesignFailed,
+        cellar_mod.CellarError.RemoveFailed,
+        cellar_mod.CellarError.OutOfMemory,
+    };
+    var seen: [cases.len][]const u8 = undefined;
+    for (cases, 0..) |e, i| {
+        const msg = cellar_mod.describeError(e);
+        try testing.expect(msg.len > 0);
+        // Every tag must map to a distinct description.
+        for (seen[0..i]) |prev| {
+            try testing.expect(!std.mem.eql(u8, msg, prev));
+        }
+        seen[i] = msg;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// P8 — Empty Cellar/{name}/ parent dir is cleaned up on failed materialize
+// ---------------------------------------------------------------------------
+
+test "failed materialize cleans up empty Cellar/{name}/ parent dir" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        std.fs.deleteTreeAbsolute(prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+
+    try setupMaltDirs(testing.allocator, prefix);
+
+    // No bottle fixture — the materialize call must fail (nothing to clone),
+    // which is what exercises the errdefer.
+    _ = setMaltPrefix(prefix);
+    defer restoreMaltPrefix("");
+
+    const result = cellar_mod.materializeWithCellar(
+        testing.allocator,
+        prefix,
+        "no-such-sha",
+        "ghost",
+        "0.0.1",
+        ":any",
+    );
+    try testing.expectError(cellar_mod.CellarError.CloneFailed, result);
+
+    // Cellar/ghost/ must not exist on disk after the failure.
+    var parent_buf: [512]u8 = undefined;
+    const parent = try std.fmt.bufPrint(&parent_buf, "{s}/Cellar/ghost", .{prefix});
+    const parent_exists = blk: {
+        std.fs.accessAbsolute(parent, .{}) catch break :blk false;
+        break :blk true;
+    };
+    try testing.expect(!parent_exists);
+}
+
+test "failed materialize leaves sibling versions untouched" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        std.fs.deleteTreeAbsolute(prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+
+    try setupMaltDirs(testing.allocator, prefix);
+
+    // Pre-populate Cellar/keeper/1.0/ — this simulates an existing installed
+    // version that a later failed materialize of keeper 2.0 must NOT delete.
+    const keeper_dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/keeper/1.0", .{prefix});
+    defer testing.allocator.free(keeper_dir);
+    try std.fs.cwd().makePath(keeper_dir);
+
+    _ = setMaltPrefix(prefix);
+    defer restoreMaltPrefix("");
+
+    const result = cellar_mod.materializeWithCellar(
+        testing.allocator,
+        prefix,
+        "missing-sha",
+        "keeper",
+        "2.0",
+        ":any",
+    );
+    try testing.expectError(cellar_mod.CellarError.CloneFailed, result);
+
+    // Cellar/keeper/1.0 must still be there — the errdefer may delete the
+    // empty parent, but it must NOT recurse into a non-empty one.
+    var alive_buf: [512]u8 = undefined;
+    const alive = try std.fmt.bufPrint(&alive_buf, "{s}/Cellar/keeper/1.0", .{prefix});
+    try std.fs.accessAbsolute(alive, .{});
+}
 
 test "patchTextFiles replaces all placeholder occurrences" {
     const dir = try createTestDir(testing.allocator);

--- a/tests/cellar_test.zig
+++ b/tests/cellar_test.zig
@@ -650,6 +650,173 @@ test "materialize rewrites @@HOMEBREW_PREFIX@@ in Mach-O rpath for :any bottle" 
     try testing.expect(found_exact);
 }
 
+/// Build a minimal universal (fat) Mach-O binary with two arch slices
+/// (arm64 + x86_64), each of which contains a single LC_RPATH load command
+/// carrying the supplied rpath.
+///
+/// Layout:
+///
+///     fat_header       @  0: magic(4)=0xCAFEBABE (big), nfat_arch(4)=2 (big)
+///     fat_arch[0]      @  8: cputype=arm64,  offset=48,  size=288
+///     fat_arch[1]      @ 28: cputype=x86_64, offset=336, size=288
+///     arm64 slice      @ 48: mach_header_64 (32) + LC_RPATH slot (256)
+///     x86_64 slice     @336: mach_header_64 (32) + LC_RPATH slot (256)
+///     total = 624 bytes
+fn buildFatMachOWithRpath(
+    allocator: std.mem.Allocator,
+    rpath: []const u8,
+) ![]u8 {
+    const macho = std.macho;
+    const header_size = @sizeOf(macho.mach_header_64);
+    const cmdsize: u32 = 256;
+    const slice_bytes: u32 = header_size + cmdsize; // 288
+
+    const fat_header_size: usize = 8;
+    const fat_arch_size: usize = 20;
+    const slice0_offset: u32 = @intCast(fat_header_size + 2 * fat_arch_size); // 48
+    const slice1_offset: u32 = slice0_offset + slice_bytes; // 336
+    const total: usize = slice1_offset + slice_bytes; // 624
+
+    const buf = try allocator.alloc(u8, total);
+    @memset(buf, 0);
+
+    // --- fat_header (big-endian) ---
+    std.mem.writeInt(u32, buf[0..4], 0xCAFEBABE, .big); // FAT_MAGIC
+    std.mem.writeInt(u32, buf[4..8], 2, .big); // nfat_arch
+
+    // --- fat_arch[0]: arm64 ---
+    std.mem.writeInt(u32, buf[8..12], 0x0100000C, .big); // cputype = arm64
+    std.mem.writeInt(u32, buf[12..16], 0, .big); // cpusubtype
+    std.mem.writeInt(u32, buf[16..20], slice0_offset, .big); // offset
+    std.mem.writeInt(u32, buf[20..24], slice_bytes, .big); // size
+    std.mem.writeInt(u32, buf[24..28], 14, .big); // align (2^14 is conventional)
+
+    // --- fat_arch[1]: x86_64 ---
+    std.mem.writeInt(u32, buf[28..32], 0x01000007, .big); // cputype = x86_64
+    std.mem.writeInt(u32, buf[32..36], 0, .big); // cpusubtype
+    std.mem.writeInt(u32, buf[36..40], slice1_offset, .big); // offset
+    std.mem.writeInt(u32, buf[40..44], slice_bytes, .big); // size
+    std.mem.writeInt(u32, buf[44..48], 14, .big); // align
+
+    // --- Two identical Mach-O 64 slices ---
+    const lc_rpath: u32 = 0x1c | 0x80000000;
+    const rpath_cmd_size: usize = 12;
+    std.debug.assert(rpath.len + 1 <= cmdsize - rpath_cmd_size);
+
+    for ([_]u32{ slice0_offset, slice1_offset }) |sl| {
+        // mach_header_64 — only the fields the parser actually reads.
+        const hdr = std.mem.bytesAsValue(
+            macho.mach_header_64,
+            buf[sl..][0..header_size],
+        );
+        hdr.* = .{
+            .magic = macho.MH_MAGIC_64,
+            .ncmds = 1,
+            .sizeofcmds = cmdsize,
+        };
+
+        // LC_RPATH command (cmd, cmdsize, path offset) + padded path string.
+        const lc_off = sl + header_size;
+        std.mem.writeInt(u32, buf[lc_off..][0..4], lc_rpath, .little);
+        std.mem.writeInt(u32, buf[lc_off + 4 ..][0..4], cmdsize, .little);
+        std.mem.writeInt(u32, buf[lc_off + 8 ..][0..4], @intCast(rpath_cmd_size), .little);
+        @memcpy(buf[lc_off + rpath_cmd_size ..][0..rpath.len], rpath);
+    }
+
+    return buf;
+}
+
+test "P9: materialize patches @@HOMEBREW_PREFIX@@ in EVERY fat-binary arch slice" {
+    // Short prefix (well within the 13-byte budget).
+    const prefix_str = try std.fmt.allocPrint(
+        testing.allocator,
+        "/tmp/mp-{x}",
+        .{std.crypto.random.int(u32)},
+    );
+    defer testing.allocator.free(prefix_str);
+
+    const prefix: [:0]const u8 = try testing.allocator.allocSentinel(u8, prefix_str.len, 0);
+    defer testing.allocator.free(prefix);
+    @memcpy(@constCast(prefix), prefix_str);
+    defer std.fs.deleteTreeAbsolute(prefix) catch {};
+
+    try std.fs.makeDirAbsolute(prefix);
+    try setupMaltDirs(testing.allocator, prefix);
+
+    // Drop a fat Mach-O fixture into the store.
+    const sha = "p9fat";
+    const name = "fatfake";
+    const version = "1.0";
+    const keg_bin_dir = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/store/{s}/{s}/{s}/bin",
+        .{ prefix, sha, name, version },
+    );
+    defer testing.allocator.free(keg_bin_dir);
+    try std.fs.cwd().makePath(keg_bin_dir);
+
+    const bin_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/fatbin",
+        .{keg_bin_dir},
+    );
+    defer testing.allocator.free(bin_path);
+
+    const fixture = try buildFatMachOWithRpath(
+        testing.allocator,
+        "@@HOMEBREW_PREFIX@@/lib/fat",
+    );
+    defer testing.allocator.free(fixture);
+    {
+        const f = try std.fs.createFileAbsolute(bin_path, .{});
+        defer f.close();
+        try f.writeAll(fixture);
+    }
+
+    const old_env = setMaltPrefix(prefix);
+    defer restoreMaltPrefix(old_env);
+
+    const keg = try cellar_mod.materializeWithCellar(
+        testing.allocator,
+        prefix,
+        sha,
+        name,
+        version,
+        ":any",
+    );
+    defer testing.allocator.free(keg.path);
+
+    // Re-parse the patched fat binary and assert BOTH slices are clean.
+    const out_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/bin/fatbin",
+        .{keg.path},
+    );
+    defer testing.allocator.free(out_path);
+
+    const data = try readFile(testing.allocator, out_path);
+    defer testing.allocator.free(data);
+
+    var parsed = try parser.parse(testing.allocator, data);
+    defer parsed.deinit();
+
+    // Must see TWO rpath entries — one per arch slice.
+    try testing.expectEqual(@as(usize, 2), parsed.paths.len);
+
+    var expected_buf: [256]u8 = undefined;
+    const expected = try std.fmt.bufPrint(&expected_buf, "{s}/lib/fat", .{prefix});
+
+    for (parsed.paths) |lcp| {
+        try testing.expect(std.mem.indexOf(u8, lcp.path, "@@HOMEBREW_PREFIX@@") == null);
+        try testing.expectEqualStrings(expected, lcp.path);
+    }
+
+    // Additional belt-and-suspenders check: the raw file bytes contain no
+    // `@@HOMEBREW_` at all, ruling out the possibility that one slice was
+    // patched and the other left alone.
+    try testing.expect(std.mem.indexOf(u8, data, "@@HOMEBREW_") == null);
+}
+
 test "materialize rewrites @@HOMEBREW_CELLAR@@ in Mach-O rpath for :any bottle" {
     // Same fixture strategy, different token.
     const prefix_str = try std.fmt.allocPrint(


### PR DESCRIPTION
## Summary

`mt install` on a multi-package workload silently produced broken binaries and reported success even when parts of the install had failed. This PR is a focused sweep that makes the install pipeline correct under real-world conditions.

Running `mt install zsh curl rust zig gh lazygit starship yazi` surfaced nine distinct bugs. The user-visible effects were:

- `zig`, `rust`, `curl`, and every binary in `llvm@*` installed cleanly but then failed at runtime with `dyld: Symbol not found`.
- `mt install` exited `0` even when packages failed to materialize, so scripts and CI had no way to detect partial failures.
- Broken dependency chains were installed on top of missing deps, producing kegs that dyld could never resolve.
- A long `MALT_PREFIX` downloaded several gigabytes of bottles and then failed per-package with an opaque error.
- Error messages gave no hint of the underlying cause.
- `mt doctor` reported supposedly-installed-but-unrunnable binaries as healthy, and flagged a stale lock immediately after a clean install.
- Failed installs left empty orphan directories behind.
- On universal binaries, only the host architecture slice was patched - a binary moved between Apple Silicon and Intel would then fail.

## What this PR changes

- `mt install` produces runnable binaries on every previously-broken  package, across both host architectures and all slices of universal binaries.
- `mt install` exits non-zero on any failure and reports how many packages failed. CI and shell scripts can trust the exit code again.
- When a dependency fails, its dependents are skipped with a clear `Skipping <pkg>: dependency <dep> failed to install` message.
- A long `MALT_PREFIX` is rejected before any network activity, with a clear explanation of the limit and a suggested alternative.
- Error messages now name the cause (for example `PathTooLong (new prefix path is longer than the bottle was built with)`).
- `mt doctor` gains two new checks that catch the conditions that used to go undetected, and no longer flags a false-positive stale lock after a clean install.
- Failed installs clean up after themselves — no more orphan directories.

## Test plan

 - [x] New `scripts/e2e/test_smoke_install.sh` installs the previously broken packages into a throwaway prefix, runs each binary, runs `mt doctor`, and scans the installed tree for any remaining ssues. Exits non-zero on any failure so it is safe to wire into CI. Verified green on a real install end-to-end.
  - [x] Re-running the original failing workload against this branch: all  26 packages install, `zig version` / `rustc --version` / `curl  --version` all succeed, `mt doctor` reports 11 / 11 checks OK.

## Notes

- No CLI flags, configuration, or on-disk layout changed. Installs that were already succeeding on `/opt/malt` continue to work with no observable difference. 
- The new smoke test is network-dependent and opt-in (not wired into `zig build test`); the unit tests cover the same invariants offline.