### PR TITLE
 fix(install): skip formulae that need post_install hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ mt install <package> [<package> ...]     # multiple packages
 | `--quiet`, `-q` | Suppress all output except errors               |
 | `--json`        | Output result as JSON                           |
 
+> [Note]
+> malt does not execute Ruby `post_install` hooks. Formulae that define one (e.g. `node`, `postgresql@16`) are skipped before any download with a message pointing you at `brew install <formula>` — nothing is written to the store, Cellar, or prefix for that package. Its dependencies in the same invocation are also skipped, since they would otherwise be orphaned until another install pulls them in.
+
 ### `mt uninstall`
 
 Remove installed packages.
@@ -529,7 +532,7 @@ Every install follows a strict 9-step protocol. Failure at any step triggers cle
 ## Safety Guarantees
 
 - **SHA256 verification** — streaming hash computed during download, verified before extraction. No unverified data touches the store.
-- **Pre-flight checks** — dependencies resolved, disk space verified, link conflicts detected, and `post_install` hooks flagged before any download begins.
+- **Pre-flight checks** — dependencies resolved, disk space verified, link conflicts detected, and formulae requiring `post_install` hooks rejected before any download begins. No bottle is fetched, no file is written under the prefix, and no DB row is created for a skipped formula.
 - **Link conflict detection** — all target symlink paths scanned before creating any links. Conflicts abort the operation with a clear report.
 - **Atomic installs** — the 9-step protocol uses `errdefer` at every stage. Interrupted installs leave no partial state.
 - **Concurrent access** — an advisory file lock with a 30-second timeout prevents concurrent mutations. Read-only commands (`list`, `info`, `search`) do not acquire the lock.

--- a/build.zig
+++ b/build.zig
@@ -64,6 +64,7 @@ pub fn build(b: *std.Build) void {
         "tests/completions_test.zig",
         "tests/backup_test.zig",
         "tests/purge_test.zig",
+        "tests/install_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -61,10 +61,17 @@ pub const InstallError = error{
     /// before any network activity so the user can fix it without waiting on
     /// a multi-gigabyte download that will inevitably fail.
     PrefixTooLong,
+    /// Formula defines a Ruby `post_install` hook that malt cannot execute.
+    /// Raised before any dep resolution or job queueing so nothing is
+    /// downloaded, materialised, or linked for the affected package.
+    PostInstallUnsupported,
 };
 
 /// A bottle download job for parallel processing.
-const DownloadJob = struct {
+///
+/// Public so integration tests can construct an empty jobs list and assert
+/// that `collectFormulaJobs` early-return branches leave it untouched.
+pub const DownloadJob = struct {
     name: []const u8,
     version_str: []const u8,
     sha256: []const u8,
@@ -349,7 +356,12 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
             // Collect jobs for this formula + its deps
             collectFormulaJobs(allocator, pkg_name, formula_json, &api, &http_pool, &db, &store, force, &all_jobs) catch |e| {
-                output.err("Failed to resolve {s}: {s}", .{ pkg_name, @errorName(e) });
+                // `PostInstallUnsupported` already printed its own user-facing
+                // message inside `collectFormulaJobs`; do not pile a generic
+                // "Failed to resolve" error on top of it.
+                if (e != InstallError.PostInstallUnsupported) {
+                    output.err("Failed to resolve {s}: {s}", .{ pkg_name, @errorName(e) });
+                }
                 continue;
             };
         } else {
@@ -646,7 +658,11 @@ fn fetchFormulaWorker(
 
 /// Collect download jobs for a formula and all its dependencies.
 /// Appends to the shared jobs list for parallel download.
-fn collectFormulaJobs(
+///
+/// Public so integration tests can exercise the early-abort branches
+/// (already-installed, post_install_defined) with a real SQLite DB and
+/// without a live Homebrew API connection.
+pub fn collectFormulaJobs(
     allocator: std.mem.Allocator,
     pkg_name: []const u8,
     formula_json: []const u8,
@@ -668,6 +684,19 @@ fn collectFormulaJobs(
         output.info("{s} is already installed", .{formula.name});
         formula.deinit();
         return;
+    }
+
+    // Refuse formulae that define a Ruby `post_install` hook — malt cannot
+    // execute Ruby, and running the bottle without the hook leaves the
+    // package in a subtly broken state (configs not generated, caches not
+    // primed, etc.). Abort BEFORE any dep resolution or job queueing so
+    // no bottle is downloaded, materialised, or linked for this formula
+    // or its transitive deps in this invocation.
+    if (formula.post_install_defined) {
+        output.warn("{s} defines a post_install script that malt cannot execute.", .{formula.name});
+        output.warn("Skipping {s}. Install it with: brew install {s}", .{ formula.name, formula.name });
+        formula.deinit();
+        return InstallError.PostInstallUnsupported;
     }
 
     // Resolve dependencies
@@ -784,12 +813,6 @@ fn collectFormulaJobs(
         .store_sha256 = "",
         .succeeded = false,
     }) catch return InstallError.DownloadFailed;
-
-    // Warn if formula defines post_install — malt cannot run Ruby post-install scripts
-    if (formula.post_install_defined) {
-        output.warn("{s} defines a post_install script that malt cannot execute.", .{formula.name});
-        output.warn("The package may not work correctly without it. Consider: brew install {s}", .{formula.name});
-    }
 
     const pkg_word: []const u8 = if (jobs.items.len == 1) "package" else "packages";
     output.info("Resolved {s} {s} ({d} {s})", .{ formula.name, formula.version, jobs.items.len, pkg_word });

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -1,0 +1,150 @@
+//! malt — install command tests
+//!
+//! Covers the early-abort branches of `collectFormulaJobs` that can be
+//! exercised without a live Homebrew API. A formula with a Ruby
+//! `post_install` hook must be rejected BEFORE any dep resolution or job
+//! queueing so nothing is downloaded, materialised, or linked for it —
+//! this test is the regression guard for that behaviour.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const install = malt.install;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+
+const post_install_formula_json =
+    \\{
+    \\  "name": "needs-ruby",
+    \\  "full_name": "needs-ruby",
+    \\  "tap": "homebrew/core",
+    \\  "desc": "Fixture formula with a post_install hook",
+    \\  "homepage": "",
+    \\  "license": "MIT",
+    \\  "revision": 0,
+    \\  "keg_only": false,
+    \\  "post_install_defined": true,
+    \\  "versions": { "stable": "1.0" },
+    \\  "dependencies": ["openssl@3"],
+    \\  "oldnames": [],
+    \\  "bottle": {
+    \\    "stable": {
+    \\      "root_url": "https://ghcr.io/v2/homebrew/core/needs-ruby/blobs",
+    \\      "files": {
+    \\        "arm64_sequoia": { "cellar": ":any", "url": "https://ghcr.io/v2/needs-ruby", "sha256": "deadbeef" },
+    \\        "x86_64_linux":  { "cellar": ":any", "url": "https://ghcr.io/v2/needs-ruby", "sha256": "deadbeef" }
+    \\      }
+    \\    }
+    \\  }
+    \\}
+;
+
+/// Opens a fresh temp-dir SQLite DB with the current schema applied.
+/// The caller is responsible for closing the returned DB and removing
+/// the temp dir.
+const TempDb = struct {
+    dir: []const u8,
+    db: sqlite.Database,
+
+    fn init(comptime tag: []const u8) !TempDb {
+        const dir = "/tmp/malt_install_test_" ++ tag;
+        std.fs.makeDirAbsolute(dir) catch {};
+        var db_path_buf: [256]u8 = undefined;
+        const db_path = try std.fmt.bufPrint(&db_path_buf, "{s}/test.db", .{dir});
+        var db = try sqlite.Database.open(db_path);
+        errdefer db.close();
+        try schema.initSchema(&db);
+        return .{ .dir = dir, .db = db };
+    }
+
+    fn deinit(self: *TempDb) void {
+        self.db.close();
+        std.fs.deleteTreeAbsolute(self.dir) catch {};
+    }
+};
+
+// Formula.deinit() doesn't free derived allocations (bottle_files map,
+// dependencies slice, oldnames), so collectFormulaJobs — which calls
+// parseFormula on our behalf — leaks if we hand it the testing allocator
+// directly. Using an arena mirrors the pattern in tests/formula_test.zig
+// and avoids false-positive leak reports from testing.allocator.
+fn testArena() std.heap.ArenaAllocator {
+    return std.heap.ArenaAllocator.init(testing.allocator);
+}
+
+test "collectFormulaJobs rejects a formula with a post_install hook" {
+    var arena = testArena();
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tdb = try TempDb.init("postinstall_reject");
+    defer tdb.deinit();
+
+    // The post_install branch returns BEFORE the BrewApi / HttpClientPool
+    // are ever touched, so passing `undefined` here is safe. If the
+    // implementation ever starts reading them earlier, this test will
+    // crash loudly and alert us to the regression — which is exactly
+    // the guarantee we want.
+    var api: malt.api.BrewApi = undefined;
+    var http_pool: malt.client.HttpClientPool = undefined;
+    var store_inst: malt.store.Store = undefined;
+
+    var jobs: std.ArrayList(install.DownloadJob) = .empty;
+    defer jobs.deinit(alloc);
+
+    const result = install.collectFormulaJobs(
+        alloc,
+        "needs-ruby",
+        post_install_formula_json,
+        &api,
+        &http_pool,
+        &tdb.db,
+        &store_inst,
+        false,
+        &jobs,
+    );
+
+    try testing.expectError(install.InstallError.PostInstallUnsupported, result);
+
+    // No job — neither the main formula nor any dep — may be queued,
+    // because queued jobs flow straight into the download + materialise
+    // pipeline inside execute(). An empty list is the whole guarantee
+    // the user is paying for.
+    try testing.expectEqual(@as(usize, 0), jobs.items.len);
+}
+
+test "collectFormulaJobs rejection leaves the DB untouched" {
+    var arena = testArena();
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tdb = try TempDb.init("postinstall_db");
+    defer tdb.deinit();
+
+    var api: malt.api.BrewApi = undefined;
+    var http_pool: malt.client.HttpClientPool = undefined;
+    var store_inst: malt.store.Store = undefined;
+
+    var jobs: std.ArrayList(install.DownloadJob) = .empty;
+    defer jobs.deinit(alloc);
+
+    _ = install.collectFormulaJobs(
+        alloc,
+        "needs-ruby",
+        post_install_formula_json,
+        &api,
+        &http_pool,
+        &tdb.db,
+        &store_inst,
+        false,
+        &jobs,
+    ) catch {};
+
+    // kegs table must still be empty: aborting must not have recorded
+    // anything about the rejected formula.
+    var stmt = try tdb.db.prepare("SELECT COUNT(*) FROM kegs;");
+    defer stmt.finalize();
+    const has_row = try stmt.step();
+    try testing.expect(has_row);
+    try testing.expectEqual(@as(i64, 0), stmt.columnInt(0));
+}


### PR DESCRIPTION
## Summary

- Formulae that define a Ruby `post_install` hook (e.g. `node`, `postgresql@16`) are now rejected before any download — nothing lands in the store, Cellar, or DB for a skipped package.
- Previously malt warned and installed anyway, leaving the package in a subtly broken state. Users are now pointed at `brew install <formula>` for those cases.
- README updated to document the limitation.