### PR TITLE
fix(core/deps): free orphaned dep strings in resolve BFS

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -65,6 +65,7 @@ pub fn build(b: *std.Build) void {
         "tests/backup_test.zig",
         "tests/purge_test.zig",
         "tests/install_test.zig",
+        "tests/deps_leak_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/core/deps.zig
+++ b/src/core/deps.zig
@@ -19,6 +19,14 @@ pub const ResolvedDep = struct {
 /// Resolve all dependencies for a formula using BFS.
 /// Returns dependencies in topological order (deps before dependents).
 /// Skips already-installed packages.
+///
+/// Ownership: each returned `ResolvedDep.name` is heap-allocated with
+/// `allocator` and the caller must free both every `name` and the outer
+/// slice. `getDeps` already hands us duped strings, so every string we
+/// receive from it is either (a) moved into `result`, (b) moved into
+/// `queue` for later processing, or (c) freed on the spot. Nothing is
+/// allowed to escape silently — earlier versions leaked duped dep
+/// strings any time BFS skipped a name via the `visited` set.
 pub fn resolve(
     allocator: std.mem.Allocator,
     root_name: []const u8,
@@ -26,51 +34,95 @@ pub fn resolve(
     db: *sqlite.Database,
 ) ![]ResolvedDep {
     var result: std.ArrayList(ResolvedDep) = .empty;
+
     var visited = std.StringHashMap(void).init(allocator);
     defer visited.deinit();
 
-    // Queue for BFS
+    // Queue of owned, heap-duped dep name strings. On scope exit anything
+    // still sitting in the queue gets freed so partial BFS walks don't
+    // leak.
     var queue: std.ArrayList([]const u8) = .empty;
-    defer queue.deinit(allocator);
+    defer {
+        for (queue.items) |s| allocator.free(s);
+        queue.deinit(allocator);
+    }
 
-    // Get root formula's dependencies
-    const root_deps = getDeps(allocator, root_name, api) catch return result.toOwnedSlice(allocator) catch &.{};
+    // Seed the queue with the root formula's direct deps. getDeps returns
+    // a slice of duped strings; we transfer each into the queue (or free
+    // it on append failure) and then free the container itself.
+    const root_deps = getDeps(allocator, root_name, api) catch {
+        return result.toOwnedSlice(allocator) catch blk: {
+            result.deinit(allocator);
+            break :blk &.{};
+        };
+    };
     defer allocator.free(root_deps);
 
     for (root_deps) |dep| {
-        queue.append(allocator, dep) catch continue;
+        queue.append(allocator, dep) catch {
+            allocator.free(dep);
+            continue;
+        };
     }
 
+    // Mark the root so sub-deps never try to recurse into it.
     visited.put(root_name, {}) catch {};
 
     while (queue.items.len > 0) {
         const dep_name = queue.orderedRemove(0);
 
-        // Skip if already visited
-        if (visited.get(dep_name) != null) continue;
-        visited.put(dep_name, {}) catch continue;
+        // Dedup: already processed → free the duplicate.
+        if (visited.get(dep_name) != null) {
+            allocator.free(dep_name);
+            continue;
+        }
 
-        // Check if already installed
+        // Transfer ownership of `dep_name` into `result` BEFORE marking it
+        // in `visited`. That way `visited`'s key borrows from `result`'s
+        // stable storage — if we did it the other way round and the
+        // append failed, we'd either leak the string or leave `visited`
+        // with a dangling key.
         const installed = isInstalled(db, dep_name);
-
         result.append(allocator, .{
             .name = dep_name,
             .already_installed = installed,
-        }) catch continue;
+        }) catch {
+            allocator.free(dep_name);
+            continue;
+        };
 
-        // If not installed, resolve its dependencies too
+        // visited.put failure is non-fatal: worst case we re-process the
+        // name later, which the dedup check above will handle.
+        visited.put(dep_name, {}) catch {};
+
+        // Fan out into this dep's own dependencies.
         if (!installed) {
             const sub_deps = getDeps(allocator, dep_name, api) catch continue;
             defer allocator.free(sub_deps);
+
             for (sub_deps) |sub_dep| {
-                if (visited.get(sub_dep) == null) {
-                    queue.append(allocator, sub_dep) catch continue;
+                // Free duplicates immediately instead of dropping them on
+                // the floor — the previous code's silent leak was here.
+                if (visited.get(sub_dep) != null) {
+                    allocator.free(sub_dep);
+                    continue;
                 }
+                queue.append(allocator, sub_dep) catch {
+                    allocator.free(sub_dep);
+                    continue;
+                };
             }
         }
     }
 
-    return result.toOwnedSlice(allocator) catch &.{};
+    return result.toOwnedSlice(allocator) catch blk: {
+        // toOwnedSlice can only fail if the shrink-realloc fails; in that
+        // case `result` still owns everything, so free every name before
+        // giving up.
+        for (result.items) |r| allocator.free(r.name);
+        result.deinit(allocator);
+        break :blk &.{};
+    };
 }
 
 /// Find orphaned dependencies (install_reason='dependency' but not needed by any direct install).
@@ -128,11 +180,23 @@ fn getDeps(allocator: std.mem.Allocator, name: []const u8, api: *api_mod.BrewApi
         switch (item) {
             .string => |s| {
                 const owned = allocator.dupe(u8, s) catch continue;
-                deps.append(allocator, owned) catch continue;
+                // Free the duped bytes if appending to the list fails —
+                // otherwise they leak silently.
+                deps.append(allocator, owned) catch {
+                    allocator.free(owned);
+                    continue;
+                };
             },
             else => {},
         }
     }
 
-    return deps.toOwnedSlice(allocator) catch &.{};
+    return deps.toOwnedSlice(allocator) catch blk: {
+        // toOwnedSlice can fail on shrink-realloc; in that case every
+        // duped string is still owned by `deps`. Free them before
+        // returning an empty slice so callers see a clean state.
+        for (deps.items) |d| allocator.free(d);
+        deps.deinit(allocator);
+        break :blk &.{};
+    };
 }

--- a/tests/deps_leak_test.zig
+++ b/tests/deps_leak_test.zig
@@ -1,0 +1,154 @@
+//! malt — regression test for the deps.resolve() memory leak
+//!
+//! Runs exclusively under `testing.allocator` so Zig's leak detector
+//! catches any regression of the bug that used to orphan duped dep
+//! strings on the BFS visited-dedup path.
+//!
+//! Before the fix: every time a sub-dep was already present in the
+//! `visited` set, its heap-duped slice was silently dropped on the
+//! floor (no `allocator.free`). `getDeps` also leaked individual
+//! duped strings whenever its internal `ArrayList.append` failed.
+//!
+//! The graph below has a diamond dep (`d` reached via both `b` and
+//! `c`) and a back-edge (`d → b` after `b` is already visited), so
+//! every path through the BFS dedup branch is exercised at least
+//! once.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const deps_mod = malt.deps;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+const api_mod = malt.api;
+const client_mod = malt.client;
+
+/// Minimal on-disk SQLite DB wrapper: just enough to let
+/// `deps.resolve()` run `isInstalled` lookups.
+const TempDb = struct {
+    dir: []const u8,
+    db: sqlite.Database,
+
+    fn init(comptime tag: []const u8) !TempDb {
+        const dir = "/tmp/malt_deps_leak_test_" ++ tag;
+        std.fs.makeDirAbsolute(dir) catch {};
+        var buf: [256]u8 = undefined;
+        const path = try std.fmt.bufPrint(&buf, "{s}/test.db", .{dir});
+        var db = try sqlite.Database.open(path);
+        errdefer db.close();
+        try schema.initSchema(&db);
+        return .{ .dir = dir, .db = db };
+    }
+
+    fn deinit(self: *TempDb) void {
+        self.db.close();
+        std.fs.deleteTreeAbsolute(self.dir) catch {};
+    }
+};
+
+/// Cache directory wrapper used to pre-seed `BrewApi` with fake
+/// formula JSON files, short-circuiting the network.
+const TempCacheDir = struct {
+    path: []const u8,
+
+    fn init(comptime tag: []const u8) !TempCacheDir {
+        const p = "/tmp/malt_deps_leak_cache_" ++ tag;
+        std.fs.deleteTreeAbsolute(p) catch {};
+        try std.fs.makeDirAbsolute(p);
+        return .{ .path = p };
+    }
+
+    fn deinit(self: *TempCacheDir) void {
+        std.fs.deleteTreeAbsolute(self.path) catch {};
+    }
+
+    fn writeFormula(self: *TempCacheDir, name: []const u8, json: []const u8) !void {
+        var api_buf: [512]u8 = undefined;
+        const api_dir = try std.fmt.bufPrint(&api_buf, "{s}/api", .{self.path});
+        std.fs.makeDirAbsolute(api_dir) catch |e| switch (e) {
+            error.PathAlreadyExists => {},
+            else => return e,
+        };
+        var path_buf: [512]u8 = undefined;
+        const full = try std.fmt.bufPrint(&path_buf, "{s}/api/formula_{s}.json", .{ self.path, name });
+        const f = try std.fs.cwd().createFile(full, .{});
+        defer f.close();
+        try f.writeAll(json);
+    }
+};
+
+/// Free the slice returned by `deps.resolve()`. Each `ResolvedDep.name`
+/// is heap-allocated by resolve, and so is the outer slice.
+fn freeResolved(alloc: std.mem.Allocator, r: []deps_mod.ResolvedDep) void {
+    for (r) |d| alloc.free(d.name);
+    alloc.free(r);
+}
+
+test "resolve frees duped dep strings on the BFS visited-dedup path" {
+    // Graph:
+    //   a → [b, c]
+    //   b → [d]
+    //   c → [d]          (d appears via both b and c → diamond dedup)
+    //   d → [b]          (b appears again after b is visited → back-edge dedup)
+    //
+    // With the fix, every string returned by getDeps is either placed
+    // in `result` or freed explicitly — the Zig testing allocator would
+    // otherwise flag the leak.
+    const alloc = testing.allocator;
+
+    var dir = try TempCacheDir.init("dedup");
+    defer dir.deinit();
+
+    try dir.writeFormula("a", "{\"dependencies\":[\"b\",\"c\"]}");
+    try dir.writeFormula("b", "{\"dependencies\":[\"d\"]}");
+    try dir.writeFormula("c", "{\"dependencies\":[\"d\"]}");
+    try dir.writeFormula("d", "{\"dependencies\":[\"b\"]}");
+
+    var http = client_mod.HttpClient.init(alloc);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(alloc, &http, dir.path);
+
+    var tdb = try TempDb.init("dedup");
+    defer tdb.deinit();
+
+    const result = try deps_mod.resolve(alloc, "a", &api, &tdb.db);
+    defer freeResolved(alloc, result);
+
+    // Each distinct dep appears exactly once.
+    try testing.expectEqual(@as(usize, 3), result.len);
+    var seen_b = false;
+    var seen_c = false;
+    var seen_d = false;
+    for (result) |r| {
+        if (std.mem.eql(u8, r.name, "b")) seen_b = true;
+        if (std.mem.eql(u8, r.name, "c")) seen_c = true;
+        if (std.mem.eql(u8, r.name, "d")) seen_d = true;
+    }
+    try testing.expect(seen_b);
+    try testing.expect(seen_c);
+    try testing.expect(seen_d);
+}
+
+test "resolve empty dep graph still returns a freeable slice" {
+    // An already-installed root with no queued deps still goes through
+    // the final `toOwnedSlice` path. `testing.allocator` will flag any
+    // missed free.
+    const alloc = testing.allocator;
+
+    var dir = try TempCacheDir.init("empty");
+    defer dir.deinit();
+
+    try dir.writeFormula("solo", "{\"dependencies\":[]}");
+
+    var http = client_mod.HttpClient.init(alloc);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(alloc, &http, dir.path);
+
+    var tdb = try TempDb.init("empty");
+    defer tdb.deinit();
+
+    const result = try deps_mod.resolve(alloc, "solo", &api, &tdb.db);
+    defer freeResolved(alloc, result);
+
+    try testing.expectEqual(@as(usize, 0), result.len);
+}


### PR DESCRIPTION
## Summary
- Fixes a memory leak in `deps.resolve()` where duplicate dep names were silently dropped during BFS dedup.
- Adds a regression test that fails under Zig's leak detector if the bug comes back.

## Test plan
- [x] `zig build test` — all tests pass, no leak warnings