### PR TITLE
 chore: dev tooling polish, and coverage script

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 indaco
+Copyright (c) 2026 indaco (Mirco Veltri)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -48,5 +48,9 @@ malt uses or interacts with the following projects:
 ### Homebrew-core
 - License: BSD-2-Clause
 - https://github.com/Homebrew/homebrew-core/blob/master/LICENSE.txt
-- Formula metadata is consumed via the public API. No formula definitions
-  are bundled.
+- Formula metadata is consumed via the public API. Formula source files
+  (`.rb`) may be fetched at runtime from the public GitHub repository when
+  a local tap clone is not available, for the sole purpose of extracting
+  and executing the user-facing `post_install` block on behalf of the user.
+  No formula definitions are bundled in the malt binary or distributed
+  with it.

--- a/devbox.json
+++ b/devbox.json
@@ -11,7 +11,8 @@
       "fmt": ["just fmt"],
       "fmt-check": ["just fmt-check"],
       "lint": ["just lint"],
-      "universal": ["just build-universal"]
+      "universal": ["just build-universal"],
+      "bench": ["just bench"]
     }
   }
 }

--- a/devbox.json
+++ b/devbox.json
@@ -6,6 +6,8 @@
       "dev": ["just build"],
       "build": ["just build-release"],
       "test": ["just test"],
+      "coverage": ["just coverage"],
+      "install": ["just install"],
       "fmt": ["just fmt"],
       "fmt-check": ["just fmt-check"],
       "lint": ["just lint"],

--- a/devbox.lock
+++ b/devbox.lock
@@ -198,8 +198,8 @@
       }
     },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "last_modified": "2026-04-07T16:32:49Z",
-      "resolved": "github:NixOS/nixpkgs/dfd9566f82a6e1d55c30f861879186440614696e?lastModified=1775579569&narHash=sha256-%2Fm3yyS%2FEnXqoPGBJYVy4jTOsirdgsEZ3JdN2gGkBr14%3D"
+      "last_modified": "2026-04-11T06:17:25Z",
+      "resolved": "github:NixOS/nixpkgs/13043924aaa7375ce482ebe2494338e058282925?lastModified=1775888245&narHash=sha256-nwASzrRDD1JBEu%2Fo8ekKYEXm%2FoJW6EMCzCRdrwcLe90%3D"
     },
     "just@latest": {
       "last_modified": "2026-04-06T08:39:25Z",

--- a/justfile
+++ b/justfile
@@ -112,6 +112,16 @@ hooks-uninstall:
     @echo "pre-commit and pre-push hooks removed."
 
 # ---------------------------------------------------------------------------
+# Benchmarks
+# ---------------------------------------------------------------------------
+
+# Run local benchmarks against malt + peer tools (tree, wget, ffmpeg by default).
+# Pass package names or env vars (BENCH_TRUE_COLD=1, SKIP_OTHERS=1, etc).
+[group('bench')]
+bench *args:
+    ./scripts/bench.sh {{args}}
+
+# ---------------------------------------------------------------------------
 # Docs & media
 # ---------------------------------------------------------------------------
 

--- a/justfile
+++ b/justfile
@@ -1,24 +1,39 @@
+set unstable := true
+
 # Default recipe
 default:
     @just --list
 
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+
 # Build the project
+[group('build')]
 build:
     zig build
 
 # Build with ReleaseSafe optimization
+[group('build')]
 build-release:
     zig build -Doptimize=ReleaseSafe
 
 # Build universal binary (macOS arm64 + x86_64)
+[group('build')]
 build-universal:
     zig build universal -Doptimize=ReleaseSafe
 
 # Install malt globally (builds from source, installs to /usr/local/bin)
+[group('build')]
 install:
     ./scripts/install.sh
 
+# ---------------------------------------------------------------------------
+# Test & coverage
+# ---------------------------------------------------------------------------
+
 # Run unit tests
+[group('test')]
 test:
     zig build test
 
@@ -26,89 +41,40 @@ test:
 # the README badge SVG at .github/badges/coverage.svg.
 # HTML report lands at coverage/merged/kcov-merged/index.html.
 # Requires kcov (brew install kcov). Internet is needed for the badge fetch.
+[group('test')]
 coverage:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if ! command -v kcov >/dev/null 2>&1; then
-        echo "error: kcov not found. Install with: brew install kcov" >&2
-        exit 1
-    fi
-    rm -rf coverage
-    mkdir -p coverage
-    zig build test-bin
-    # Only report coverage for files under the project's src/ directory.
-    # --include-path takes an absolute path and is more reliable than --include-pattern.
-    src_dir="$(pwd)/src"
-    # Run kcov once per test binary into a shared outdir
-    for bin in zig-out/test-bin/*; do
-        # Skip .dSYM debug bundles and any non-regular files
-        [ -f "$bin" ] || continue
-        [ -x "$bin" ] || continue
-        echo "→ kcov: $(basename "$bin")"
-        kcov --include-path="$src_dir" coverage "$bin" >/dev/null
-    done
-    # kcov 43 on macOS doesn't reliably auto-merge, so do it explicitly.
-    # The per-binary reports are in hash-suffixed dirs (e.g. cellar_test.a934ecd0).
-    shopt -s nullglob
-    per_bin_dirs=(coverage/*_test.*)
-    shopt -u nullglob
-    if [ ${#per_bin_dirs[@]} -eq 0 ]; then
-        echo "error: kcov produced no per-binary reports" >&2
-        exit 1
-    fi
-    kcov --merge coverage/merged "${per_bin_dirs[@]}" >/dev/null
-    report="coverage/merged/kcov-merged/coverage.json"
-    if [ ! -f "$report" ]; then
-        echo "error: merged report not found at $report" >&2
-        exit 1
-    fi
-    if command -v jq >/dev/null 2>&1; then
-        percent=$(jq -r '.percent_covered' "$report")
-    else
-        percent=$(grep -oE '"percent_covered"[^,}]*' "$report" | grep -oE '[0-9]+(\.[0-9]+)?' | head -1)
-    fi
-    # Pick a shields.io color based on the integer part of the percentage.
-    pct_int=${percent%.*}
-    if   [ "$pct_int" -ge 90 ]; then color="brightgreen"
-    elif [ "$pct_int" -ge 80 ]; then color="green"
-    elif [ "$pct_int" -ge 70 ]; then color="yellowgreen"
-    elif [ "$pct_int" -ge 60 ]; then color="yellow"
-    elif [ "$pct_int" -ge 50 ]; then color="orange"
-    else                             color="red"
-    fi
-    # Fetch the static badge SVG from shields.io and commit it under .github/badges/.
-    # This keeps the README badge in-repo so it updates with normal commits — no CI needed.
-    mkdir -p .github/badges
-    badge_url="https://img.shields.io/badge/coverage-${percent}%25-${color}"
-    if curl -sSLf "$badge_url" -o .github/badges/coverage.svg; then
-        badge_msg=".github/badges/coverage.svg (refreshed — remember to commit it)"
-    else
-        badge_msg="warning: could not fetch badge from shields.io (offline?) — badge not refreshed"
-    fi
-    echo ""
-    echo "Coverage: ${percent}%"
-    echo "Report:   coverage/merged/kcov-merged/index.html"
-    echo "Badge:    ${badge_msg}"
+    ./scripts/coverage.sh
+
+# ---------------------------------------------------------------------------
+# Format & lint
+# ---------------------------------------------------------------------------
 
 # Check formatting
+[group('lint')]
 fmt-check:
     zig fmt --check src/ tests/
 
 # Fix formatting
+[group('lint')]
 fmt:
     zig fmt src/ tests/
 
 # Lint: format check + build + test
+[group('lint')]
 lint:
     zig fmt --check src/ tests/
     zig build
     zig build test
 
+# ---------------------------------------------------------------------------
+# Git hooks
+# ---------------------------------------------------------------------------
+
 # Pre-commit hook: auto-format staged .zig files in place and re-stage them
 # so the formatted version is what actually lands in the commit.
 # Note: if you `git add -p` partial hunks of a file, this will pick up the
-
 # unstaged hunks too — a known limitation of format-on-commit hooks.
+[group('hooks')]
 pre-commit:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -124,10 +90,12 @@ pre-commit:
     echo "Auto-formatted ${#files[@]} staged .zig file(s)."
 
 # Pre-push hook: everything that CI checks
+[group('hooks')]
 pre-push: fmt-check test
     @echo "All pre-push checks passed."
 
 # Install git hooks (pre-commit + pre-push)
+[group('hooks')]
 hooks-install:
     @echo '#!/bin/sh' > .git/hooks/pre-commit
     @echo 'just pre-commit' >> .git/hooks/pre-commit
@@ -138,6 +106,16 @@ hooks-install:
     @echo "pre-commit and pre-push hooks installed."
 
 # Remove git hooks
+[group('hooks')]
 hooks-uninstall:
     @rm -f .git/hooks/pre-commit .git/hooks/pre-push
     @echo "pre-commit and pre-push hooks removed."
+
+# ---------------------------------------------------------------------------
+# Docs & media
+# ---------------------------------------------------------------------------
+
+# Record the README demo gif via VHS into docs/demo.gif.
+[group('docs')]
+record-demo:
+    ./scripts/record-demo.sh

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Run unit tests under kcov, print line-coverage percentage, and refresh
+# the README badge SVG at .github/badges/coverage.svg.
+#
+# HTML report lands at coverage/merged/kcov-merged/index.html.
+# Requires kcov (brew install kcov). Internet is needed for the badge fetch.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if ! command -v kcov >/dev/null 2>&1; then
+    echo "error: kcov not found. Install with: brew install kcov" >&2
+    exit 1
+fi
+
+rm -rf coverage
+mkdir -p coverage
+zig build test-bin
+
+# Only report coverage for files under the project's src/ directory.
+# --include-path takes an absolute path and is more reliable than --include-pattern.
+src_dir="$(pwd)/src"
+
+# Run kcov once per test binary into a shared outdir
+for bin in zig-out/test-bin/*; do
+    # Skip .dSYM debug bundles and any non-regular files
+    [ -f "$bin" ] || continue
+    [ -x "$bin" ] || continue
+    echo "→ kcov: $(basename "$bin")"
+    kcov --include-path="$src_dir" coverage "$bin" >/dev/null
+done
+
+# kcov 43 on macOS doesn't reliably auto-merge, so do it explicitly.
+# The per-binary reports are in hash-suffixed dirs (e.g. cellar_test.a934ecd0).
+shopt -s nullglob
+per_bin_dirs=(coverage/*_test.*)
+shopt -u nullglob
+if [ ${#per_bin_dirs[@]} -eq 0 ]; then
+    echo "error: kcov produced no per-binary reports" >&2
+    exit 1
+fi
+kcov --merge coverage/merged "${per_bin_dirs[@]}" >/dev/null
+
+report="coverage/merged/kcov-merged/coverage.json"
+if [ ! -f "$report" ]; then
+    echo "error: merged report not found at $report" >&2
+    exit 1
+fi
+
+if command -v jq >/dev/null 2>&1; then
+    percent=$(jq -r '.percent_covered' "$report")
+else
+    percent=$(grep -oE '"percent_covered"[^,}]*' "$report" | grep -oE '[0-9]+(\.[0-9]+)?' | head -1)
+fi
+
+# Pick a shields.io color based on the integer part of the percentage.
+pct_int=${percent%.*}
+if   [ "$pct_int" -ge 90 ]; then color="brightgreen"
+elif [ "$pct_int" -ge 80 ]; then color="green"
+elif [ "$pct_int" -ge 70 ]; then color="yellowgreen"
+elif [ "$pct_int" -ge 60 ]; then color="yellow"
+elif [ "$pct_int" -ge 50 ]; then color="orange"
+else                             color="red"
+fi
+
+# Fetch the static badge SVG from shields.io and commit it under .github/badges/.
+# This keeps the README badge in-repo so it updates with normal commits — no CI needed.
+mkdir -p .github/badges
+badge_url="https://img.shields.io/badge/coverage-${percent}%25-${color}"
+if curl -sSLf "$badge_url" -o .github/badges/coverage.svg; then
+    badge_msg=".github/badges/coverage.svg (refreshed — remember to commit it)"
+else
+    badge_msg="warning: could not fetch badge from shields.io (offline?) — badge not refreshed"
+fi
+
+echo ""
+echo "Coverage: ${percent}%"
+echo "Report:   coverage/merged/kcov-merged/index.html"
+echo "Badge:    ${badge_msg}"

--- a/scripts/demo.tape
+++ b/scripts/demo.tape
@@ -21,10 +21,30 @@ Set PlaybackSpeed 1.0
 # Let bash settle before the first keystroke.
 Sleep 500ms
 
+Type "# Install a few common formulae in parallel"
+Sleep 400ms
+Enter
+Sleep 800ms
+
 Type "malt install jq tree ripgrep"
 Sleep 400ms
 Enter
-Sleep 15s
+Sleep 7s
+
+Type "# Now a package with post_install — configured natively, no Ruby needed"
+Sleep 400ms
+Enter
+Sleep 800ms
+
+Type "malt install node"
+Sleep 400ms
+Enter
+Sleep 12s
+
+Type "# List installed kegs with their versions"
+Sleep 400ms
+Enter
+Sleep 800ms
 
 Type "malt list --versions"
 Sleep 400ms


### PR DESCRIPTION
## Summary

- Reorganize `justfile` with grouped recipes; add `bench` recipe wrapping `scripts/bench.sh` and move coverage inline logic into `scripts/coverage.sh`.
-  Expose `coverage`, `install`, and `bench` in `devbox.json` scripts.
- Update `LICENSE` to cover the embedded homebrew-core bits.
- Refresh `demo.tape` to showcase a `post_install` formula (node) and add narration comments for each step.