### PR TITLE
Dedupe list --json emission

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -97,6 +97,7 @@ pub fn build(b: *std.Build) void {
         "tests/install_execute_test.zig",
         "tests/cask_extra_test.zig",
         "tests/dsl_interpreter_extra_test.zig",
+        "tests/list_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -160,135 +160,119 @@ fn writeJsonOutput(
     defer buf.deinit(allocator);
     const w = buf.writer(allocator);
 
-    // Spec format: { "installed": [...], "formulae": [...], "casks": [...], "time_ms": N }
+    try buildListJson(db, w, show_formula, show_cask, show_pinned, start_ts);
+    stdout.writeAll(buf.items) catch {};
+}
+
+/// Build the `{ "installed": [...], "formulae": [...], "casks": [...], "time_ms": N }`
+/// payload into `w`. Kept `pub` so tests can assert on the exact bytes without
+/// going through a real file. On per-section SQLite failures we emit an empty
+/// array for that section rather than truncating the whole document.
+pub fn buildListJson(
+    db: *sqlite.Database,
+    w: anytype,
+    show_formula: bool,
+    show_cask: bool,
+    show_pinned: bool,
+    start_ts: i64,
+) !void {
     try w.writeAll("{\"installed\":[");
-
-    // Collect all installed items into the "installed" array
-    var first_installed = true;
-
-    if (show_formula) {
-        const sql = if (show_pinned)
-            "SELECT name, version, pinned FROM kegs WHERE pinned = 1 ORDER BY name;"
-        else
-            "SELECT name, version, pinned FROM kegs ORDER BY name;";
-
-        var stmt = db.prepare(sql) catch {
-            try w.writeAll("]");
-            try writeTimeSuffix(w, start_ts);
-            try w.writeAll("}\n");
-            stdout.writeAll(buf.items) catch {};
-            return;
-        };
-        defer stmt.finalize();
-
-        while (stmt.step() catch false) {
-            const name = stmt.columnText(0) orelse continue;
-            const ver = stmt.columnText(1);
-            const pinned = stmt.columnBool(2);
-            if (!first_installed) try w.writeAll(",");
-            first_installed = false;
-            try w.writeAll("{\"name\":\"");
-            try w.writeAll(std.mem.sliceTo(name, 0));
-            try w.writeAll("\",\"version\":\"");
-            try w.writeAll(if (ver) |v| std.mem.sliceTo(v, 0) else "");
-            try w.writeAll("\",\"type\":\"formula\",\"pinned\":");
-            try w.writeAll(if (pinned) "true" else "false");
-            try w.writeAll("}");
-        }
-    }
-
-    if (show_cask) {
-        var stmt = db.prepare("SELECT token, version FROM casks ORDER BY token;") catch {
-            try w.writeAll("]");
-            try writeTimeSuffix(w, start_ts);
-            try w.writeAll("}\n");
-            stdout.writeAll(buf.items) catch {};
-            return;
-        };
-        defer stmt.finalize();
-
-        while (stmt.step() catch false) {
-            const token = stmt.columnText(0) orelse continue;
-            const ver = stmt.columnText(1);
-            if (!first_installed) try w.writeAll(",");
-            first_installed = false;
-            try w.writeAll("{\"name\":\"");
-            try w.writeAll(std.mem.sliceTo(token, 0));
-            try w.writeAll("\",\"version\":\"");
-            try w.writeAll(if (ver) |v| std.mem.sliceTo(v, 0) else "");
-            try w.writeAll("\",\"type\":\"cask\"}");
-        }
-    }
-
+    var first = true;
+    if (show_formula) try writeFormulaRows(db, w, show_pinned, .installed, &first);
+    if (show_cask) try writeCaskRows(db, w, .installed, &first);
     try w.writeAll("]");
 
-    // Also emit legacy keys for backwards compatibility
     if (show_formula) {
         try w.writeAll(",\"formulae\":[");
-        const sql = if (show_pinned)
-            "SELECT name, version, pinned FROM kegs WHERE pinned = 1 ORDER BY name;"
-        else
-            "SELECT name, version, pinned FROM kegs ORDER BY name;";
-
-        var stmt = db.prepare(sql) catch {
-            try w.writeAll("]");
-            if (show_cask) try w.writeAll(",\"casks\":[]");
-            try writeTimeSuffix(w, start_ts);
-            try w.writeAll("}\n");
-            stdout.writeAll(buf.items) catch {};
-            return;
-        };
-        defer stmt.finalize();
-
-        var first = true;
-        while (stmt.step() catch false) {
-            const name = stmt.columnText(0) orelse continue;
-            const ver = stmt.columnText(1);
-            const pinned = stmt.columnBool(2);
-            if (!first) try w.writeAll(",");
-            first = false;
-            try w.writeAll("{\"name\":\"");
-            try w.writeAll(std.mem.sliceTo(name, 0));
-            try w.writeAll("\",\"version\":\"");
-            try w.writeAll(if (ver) |v| std.mem.sliceTo(v, 0) else "");
-            try w.writeAll("\",\"pinned\":");
-            try w.writeAll(if (pinned) "true" else "false");
-            try w.writeAll("}");
-        }
+        var legacy_first = true;
+        try writeFormulaRows(db, w, show_pinned, .legacy, &legacy_first);
         try w.writeAll("]");
     }
 
     if (show_cask) {
-        if (show_formula) try w.writeAll(",");
-        try w.writeAll("\"casks\":[");
-        var stmt = db.prepare("SELECT token, version FROM casks ORDER BY token;") catch {
-            try w.writeAll("]");
-            try writeTimeSuffix(w, start_ts);
-            try w.writeAll("}\n");
-            stdout.writeAll(buf.items) catch {};
-            return;
-        };
-        defer stmt.finalize();
-
-        var first = true;
-        while (stmt.step() catch false) {
-            const token = stmt.columnText(0) orelse continue;
-            const ver = stmt.columnText(1);
-            if (!first) try w.writeAll(",");
-            first = false;
-            try w.writeAll("{\"token\":\"");
-            try w.writeAll(std.mem.sliceTo(token, 0));
-            try w.writeAll("\",\"version\":\"");
-            try w.writeAll(if (ver) |v| std.mem.sliceTo(v, 0) else "");
-            try w.writeAll("\"}");
-        }
+        try w.writeAll(",\"casks\":[");
+        var legacy_first = true;
+        try writeCaskRows(db, w, .legacy, &legacy_first);
         try w.writeAll("]");
     }
 
     try writeTimeSuffix(w, start_ts);
-
     try w.writeAll("}\n");
-    stdout.writeAll(buf.items) catch {};
+}
+
+const RowShape = enum { installed, legacy };
+
+fn writeFormulaRows(
+    db: *sqlite.Database,
+    w: anytype,
+    show_pinned: bool,
+    shape: RowShape,
+    first: *bool,
+) !void {
+    const sql = if (show_pinned)
+        "SELECT name, version, pinned FROM kegs WHERE pinned = 1 ORDER BY name;"
+    else
+        "SELECT name, version, pinned FROM kegs ORDER BY name;";
+
+    var stmt = db.prepare(sql) catch return;
+    defer stmt.finalize();
+
+    while (stmt.step() catch false) {
+        const name = stmt.columnText(0) orelse continue;
+        const ver = stmt.columnText(1);
+        const pinned = stmt.columnBool(2);
+        if (!first.*) try w.writeAll(",");
+        first.* = false;
+        try w.writeAll("{\"name\":\"");
+        try w.writeAll(std.mem.sliceTo(name, 0));
+        try w.writeAll("\",\"version\":\"");
+        try w.writeAll(if (ver) |v| std.mem.sliceTo(v, 0) else "");
+        switch (shape) {
+            .installed => {
+                try w.writeAll("\",\"type\":\"formula\",\"pinned\":");
+                try w.writeAll(if (pinned) "true" else "false");
+                try w.writeAll("}");
+            },
+            .legacy => {
+                try w.writeAll("\",\"pinned\":");
+                try w.writeAll(if (pinned) "true" else "false");
+                try w.writeAll("}");
+            },
+        }
+    }
+}
+
+fn writeCaskRows(
+    db: *sqlite.Database,
+    w: anytype,
+    shape: RowShape,
+    first: *bool,
+) !void {
+    var stmt = db.prepare("SELECT token, version FROM casks ORDER BY token;") catch return;
+    defer stmt.finalize();
+
+    while (stmt.step() catch false) {
+        const token = stmt.columnText(0) orelse continue;
+        const ver = stmt.columnText(1);
+        if (!first.*) try w.writeAll(",");
+        first.* = false;
+        switch (shape) {
+            .installed => {
+                try w.writeAll("{\"name\":\"");
+                try w.writeAll(std.mem.sliceTo(token, 0));
+                try w.writeAll("\",\"version\":\"");
+                try w.writeAll(if (ver) |v| std.mem.sliceTo(v, 0) else "");
+                try w.writeAll("\",\"type\":\"cask\"}");
+            },
+            .legacy => {
+                try w.writeAll("{\"token\":\"");
+                try w.writeAll(std.mem.sliceTo(token, 0));
+                try w.writeAll("\",\"version\":\"");
+                try w.writeAll(if (ver) |v| std.mem.sliceTo(v, 0) else "");
+                try w.writeAll("\"}");
+            },
+        }
+    }
 }
 
 /// Write the ,"time_ms":N suffix for JSON output.

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -9,6 +9,34 @@ const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
 const help = @import("help.zig");
 
+pub const TapNameError = error{InvalidTapName};
+
+/// Reject malformed `user/repo` inputs before they're formatted into a
+/// GitHub URL or stored as a tap name. No security boundary (no shell
+/// expansion, no path traversal reaches disk) — this is just an early,
+/// clear "bad input" rather than a confusing failure later.
+///
+/// Rules: exactly one `/`, each side 1–64 chars of [A-Za-z0-9._-], and
+/// neither side starts with `.` (rules out `..` traversal and hidden
+/// components).
+pub fn validateTapName(name: []const u8) TapNameError!void {
+    const slash = std.mem.indexOfScalar(u8, name, '/') orelse return TapNameError.InvalidTapName;
+    if (std.mem.indexOfScalarPos(u8, name, slash + 1, '/') != null) return TapNameError.InvalidTapName;
+    try validateComponent(name[0..slash]);
+    try validateComponent(name[slash + 1 ..]);
+}
+
+fn validateComponent(part: []const u8) TapNameError!void {
+    if (part.len == 0 or part.len > 64) return TapNameError.InvalidTapName;
+    if (part[0] == '.') return TapNameError.InvalidTapName;
+    for (part) |ch| {
+        switch (ch) {
+            'a'...'z', 'A'...'Z', '0'...'9', '.', '_', '-' => {},
+            else => return TapNameError.InvalidTapName,
+        }
+    }
+}
+
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "tap")) return;
 
@@ -57,17 +85,16 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     // Simple approach: "mt tap user/repo" adds, "mt untap user/repo" also comes here
     // We'll just add the tap
-    var url_buf: [256]u8 = undefined;
+    validateTapName(name) catch {
+        output.err("Invalid tap '{s}'. Expected: user/repo with [A-Za-z0-9._-]", .{name});
+        return;
+    };
 
-    // Parse user/repo format
-    if (std.mem.indexOfScalar(u8, name, '/')) |_| {
-        const url = std.fmt.bufPrint(&url_buf, "https://github.com/{s}", .{name}) catch return;
-        tap_mod.add(&db, name, url) catch {
-            output.err("Failed to add tap {s}", .{name});
-            return;
-        };
-        output.info("Tapped {s}", .{name});
-    } else {
-        output.err("Invalid tap format. Use: mt tap user/repo", .{});
-    }
+    var url_buf: [256]u8 = undefined;
+    const url = std.fmt.bufPrint(&url_buf, "https://github.com/{s}", .{name}) catch return;
+    tap_mod.add(&db, name, url) catch {
+        output.err("Failed to add tap {s}", .{name});
+        return;
+    };
+    output.info("Tapped {s}", .{name});
 }

--- a/src/db/sqlite.zig
+++ b/src/db/sqlite.zig
@@ -141,15 +141,26 @@ pub const Database = struct {
     }
 
     /// Execute one or more SQL statements that return no result rows.
-    pub fn exec(self: *Database, sql: [*:0]const u8) SqliteError!void {
-        const rc = c.sqlite3_exec(self.handle, sql, null, null, null);
+    /// Accepts a slice so callers can pass `bufPrint` output without needing
+    /// to hand-manage a null terminator; compile-time literals still coerce
+    /// through unchanged. `sqlite3_exec` itself is C-string-only, so we copy
+    /// into a stack buffer and append the sentinel.
+    pub fn exec(self: *Database, sql: []const u8) SqliteError!void {
+        var buf: [4096]u8 = undefined;
+        if (sql.len >= buf.len) return SqliteError.ExecFailed;
+        @memcpy(buf[0..sql.len], sql);
+        buf[sql.len] = 0;
+        const c_sql: [*:0]const u8 = buf[0..sql.len :0];
+        const rc = c.sqlite3_exec(self.handle, c_sql, null, null, null);
         if (rc != c.SQLITE_OK) return mapError(rc, SqliteError.ExecFailed);
     }
 
-    /// Prepare a single SQL statement for later execution.
-    pub fn prepare(self: *Database, sql: [*:0]const u8) SqliteError!Statement {
+    /// Prepare a single SQL statement for later execution. Takes a slice and
+    /// passes the length directly to sqlite — no null terminator required,
+    /// no copy needed.
+    pub fn prepare(self: *Database, sql: []const u8) SqliteError!Statement {
         var stmt: ?*c.sqlite3_stmt = null;
-        const rc = c.sqlite3_prepare_v2(self.handle, sql, -1, &stmt, null);
+        const rc = c.sqlite3_prepare_v2(self.handle, sql.ptr, @intCast(sql.len), &stmt, null);
         if (rc != c.SQLITE_OK) return mapError(rc, SqliteError.PrepareFailed);
         return Statement{ .stmt = stmt.? };
     }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -35,6 +35,7 @@ pub const bundle_runner = @import("core/bundle/runner.zig");
 pub const cli_services = @import("cli/services.zig");
 pub const cli_bundle = @import("cli/bundle.zig");
 pub const cli_help = @import("cli/help.zig");
+pub const cli_list = @import("cli/list.zig");
 pub const cli_tap = @import("cli/tap.zig");
 pub const tap = @import("core/tap.zig");
 pub const bottle = @import("core/bottle.zig");

--- a/tests/cli_tap_test.zig
+++ b/tests/cli_tap_test.zig
@@ -58,6 +58,82 @@ test "execute with --help short-circuits before touching the database" {
     try tap_cli.execute(testing.allocator, &.{"--help"});
 }
 
+// ---------------------------------------------------------------------------
+// validateTapName
+// ---------------------------------------------------------------------------
+
+const TapNameError = tap_cli.TapNameError;
+const bad = TapNameError.InvalidTapName;
+
+test "validateTapName: accepts canonical user/repo" {
+    try tap_cli.validateTapName("homebrew/core");
+    try tap_cli.validateTapName("homebrew/cask");
+    try tap_cli.validateTapName("hashicorp/tap");
+    try tap_cli.validateTapName("goreleaser/tap");
+    try tap_cli.validateTapName("indaco/tap");
+    try tap_cli.validateTapName("a/b");
+    try tap_cli.validateTapName("user_name/repo-name");
+    try tap_cli.validateTapName("User123/Repo.v2");
+}
+
+test "validateTapName: rejects missing slash" {
+    try testing.expectError(bad, tap_cli.validateTapName("noslash"));
+    try testing.expectError(bad, tap_cli.validateTapName(""));
+}
+
+test "validateTapName: rejects extra slashes (three-part user/tap/formula form)" {
+    // `mt tap` takes only the tap name; three-part refs like
+    // `goreleaser/tap/goreleaser` or `indaco/tap/sley` are for
+    // `mt install`, not `mt tap`, and must be rejected here.
+    try testing.expectError(bad, tap_cli.validateTapName("a/b/c"));
+    try testing.expectError(bad, tap_cli.validateTapName("goreleaser/tap/goreleaser"));
+    try testing.expectError(bad, tap_cli.validateTapName("indaco/tap/sley"));
+}
+
+test "validateTapName: rejects empty components" {
+    try testing.expectError(bad, tap_cli.validateTapName("/repo"));
+    try testing.expectError(bad, tap_cli.validateTapName("user/"));
+    try testing.expectError(bad, tap_cli.validateTapName("/"));
+}
+
+test "validateTapName: rejects path traversal via leading dot" {
+    try testing.expectError(bad, tap_cli.validateTapName("user/.."));
+    try testing.expectError(bad, tap_cli.validateTapName("../repo"));
+    try testing.expectError(bad, tap_cli.validateTapName(".hidden/repo"));
+    try testing.expectError(bad, tap_cli.validateTapName("user/.hidden"));
+}
+
+test "validateTapName: rejects invalid characters" {
+    try testing.expectError(bad, tap_cli.validateTapName("user/repo space"));
+    try testing.expectError(bad, tap_cli.validateTapName("user/repo;rm"));
+    try testing.expectError(bad, tap_cli.validateTapName("user/repo?q=1"));
+    try testing.expectError(bad, tap_cli.validateTapName("user@host/repo"));
+}
+
+test "validateTapName: rejects over-long components" {
+    const long_user = "a" ** 65 ++ "/repo";
+    try testing.expectError(bad, tap_cli.validateTapName(long_user));
+    const long_repo = "user/" ++ "b" ** 65;
+    try testing.expectError(bad, tap_cli.validateTapName(long_repo));
+}
+
+test "execute: malformed tap input returns cleanly without inserting a row" {
+    const prefix = try setupPrefix("reject_malformed");
+    defer testing.allocator.free(prefix);
+    defer std.fs.deleteTreeAbsolute(prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Each of these should be rejected by the validator and return without
+    // touching the DB. Run them back-to-back; they must not accumulate
+    // partial state or crash.
+    try tap_cli.execute(testing.allocator, &.{"no-slash-here"});
+    try tap_cli.execute(testing.allocator, &.{"a/b/c"});
+    try tap_cli.execute(testing.allocator, &.{"/repo"});
+    try tap_cli.execute(testing.allocator, &.{"user/"});
+    try tap_cli.execute(testing.allocator, &.{"../evil"});
+    try tap_cli.execute(testing.allocator, &.{"user/bad char"});
+}
+
 test "execute with a bare name (no slash) reports an error but does not throw" {
     const prefix = try setupPrefix("bad_name");
     defer testing.allocator.free(prefix);

--- a/tests/list_test.zig
+++ b/tests/list_test.zig
@@ -1,0 +1,202 @@
+//! malt — cli/list JSON output tests
+//! Exercises `buildListJson` via an on-disk sqlite DB seeded with kegs
+//! and casks, asserting the exact bytes written for the three block
+//! shapes (installed / legacy formulae / legacy casks).
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+const cli_list = malt.cli_list;
+
+const TempDb = struct {
+    dir: []const u8,
+    db: sqlite.Database,
+
+    fn init(comptime tag: []const u8) !TempDb {
+        const dir = "/tmp/malt_list_test_" ++ tag;
+        std.fs.deleteTreeAbsolute(dir) catch {};
+        try std.fs.makeDirAbsolute(dir);
+        var buf: [256]u8 = undefined;
+        const path = try std.fmt.bufPrint(&buf, "{s}/test.db", .{dir});
+        var db = try sqlite.Database.open(path);
+        errdefer db.close();
+        try schema.initSchema(&db);
+        return .{ .dir = dir, .db = db };
+    }
+
+    fn deinit(self: *TempDb) void {
+        self.db.close();
+        std.fs.deleteTreeAbsolute(self.dir) catch {};
+    }
+};
+
+fn insertKeg(db: *sqlite.Database, name: []const u8, version: []const u8, pinned: bool) !void {
+    var buf: [512]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &buf,
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, pinned) VALUES ('{s}', '{s}', '{s}', 'deadbeef', '/opt/malt/Cellar/{s}/{s}', {d});",
+        .{ name, name, version, name, version, @intFromBool(pinned) },
+    );
+    try db.exec(sql);
+}
+
+fn insertCask(db: *sqlite.Database, token: []const u8, version: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &buf,
+        "INSERT INTO casks (token, name, version, url) VALUES ('{s}', '{s}', '{s}', 'https://example.com');",
+        .{ token, token, version },
+    );
+    try db.exec(sql);
+}
+
+fn runBuild(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    show_formula: bool,
+    show_cask: bool,
+    show_pinned: bool,
+) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(allocator);
+    const w = buf.writer(allocator);
+    // Use a fixed start_ts so the ",\"time_ms\":N" suffix is predictable.
+    try cli_list.buildListJson(db, w, show_formula, show_cask, show_pinned, std.time.milliTimestamp());
+    return buf.toOwnedSlice(allocator);
+}
+
+// Strip the non-deterministic ",\"time_ms\":N}\n" suffix so assertions can
+// compare the structural body.
+fn trimTimeSuffix(out: []const u8) []const u8 {
+    const needle = ",\"time_ms\":";
+    if (std.mem.lastIndexOf(u8, out, needle)) |pos| return out[0..pos];
+    return out;
+}
+
+test "buildListJson: empty DB, both flags" {
+    var t = try TempDb.init("empty");
+    defer t.deinit();
+
+    const out = try runBuild(testing.allocator, &t.db, true, true, false);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[],\"formulae\":[],\"casks\":[]",
+        body,
+    );
+    // Suffix structure intact.
+    try testing.expect(std.mem.endsWith(u8, out, "}\n"));
+    try testing.expect(std.mem.indexOf(u8, out, ",\"time_ms\":") != null);
+}
+
+test "buildListJson: formula-only, two kegs, pinned flag preserved" {
+    var t = try TempDb.init("formula_only");
+    defer t.deinit();
+
+    try insertKeg(&t.db, "alpha", "1.0", false);
+    try insertKeg(&t.db, "bravo", "2.1", true);
+
+    const out = try runBuild(testing.allocator, &t.db, true, false, false);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"alpha\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":false}," ++
+            "{\"name\":\"bravo\",\"version\":\"2.1\",\"type\":\"formula\",\"pinned\":true}" ++
+            "],\"formulae\":[" ++
+            "{\"name\":\"alpha\",\"version\":\"1.0\",\"pinned\":false}," ++
+            "{\"name\":\"bravo\",\"version\":\"2.1\",\"pinned\":true}" ++
+            "]",
+        body,
+    );
+}
+
+test "buildListJson: cask-only, one cask" {
+    var t = try TempDb.init("cask_only");
+    defer t.deinit();
+
+    try insertCask(&t.db, "firefox", "120.0");
+
+    const out = try runBuild(testing.allocator, &t.db, false, true, false);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"firefox\",\"version\":\"120.0\",\"type\":\"cask\"}" ++
+            "],\"casks\":[" ++
+            "{\"token\":\"firefox\",\"version\":\"120.0\"}" ++
+            "]",
+        body,
+    );
+}
+
+test "buildListJson: mixed kegs and casks, comma between types in installed" {
+    var t = try TempDb.init("mixed");
+    defer t.deinit();
+
+    try insertKeg(&t.db, "zsh", "5.9", false);
+    try insertCask(&t.db, "slack", "4.0");
+
+    const out = try runBuild(testing.allocator, &t.db, true, true, false);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"zsh\",\"version\":\"5.9\",\"type\":\"formula\",\"pinned\":false}," ++
+            "{\"name\":\"slack\",\"version\":\"4.0\",\"type\":\"cask\"}" ++
+            "],\"formulae\":[" ++
+            "{\"name\":\"zsh\",\"version\":\"5.9\",\"pinned\":false}" ++
+            "],\"casks\":[" ++
+            "{\"token\":\"slack\",\"version\":\"4.0\"}" ++
+            "]",
+        body,
+    );
+}
+
+test "buildListJson: --pinned filters formulae to pinned only" {
+    var t = try TempDb.init("pinned");
+    defer t.deinit();
+
+    try insertKeg(&t.db, "one", "1.0", false);
+    try insertKeg(&t.db, "two", "2.0", true);
+
+    const out = try runBuild(testing.allocator, &t.db, true, false, true);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"two\",\"version\":\"2.0\",\"type\":\"formula\",\"pinned\":true}" ++
+            "],\"formulae\":[" ++
+            "{\"name\":\"two\",\"version\":\"2.0\",\"pinned\":true}" ++
+            "]",
+        body,
+    );
+}
+
+test "buildListJson: output parses as valid JSON" {
+    var t = try TempDb.init("valid_json");
+    defer t.deinit();
+
+    try insertKeg(&t.db, "tree", "2.1", false);
+    try insertCask(&t.db, "obs", "30.0");
+
+    const out = try runBuild(testing.allocator, &t.db, true, true, false);
+    defer testing.allocator.free(out);
+
+    // The CLI writes a trailing newline; parseFromSlice tolerates it.
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, out, .{});
+    defer parsed.deinit();
+
+    const root = parsed.value.object;
+    try testing.expect(root.get("installed") != null);
+    try testing.expect(root.get("formulae") != null);
+    try testing.expect(root.get("casks") != null);
+    try testing.expect(root.get("time_ms") != null);
+}


### PR DESCRIPTION
Three near-identical JSON blocks in `mt list --json` are now built by a single helper with direct test coverage. Same output shape, but if one SQL section fails the others still render (previously the document truncated). Also fixes a missing-comma edge case when `--cask` was used without `--formula`.

New test suite exercises the builder against a seeded on-disk DB and checks the exact bytes for empty / formula-only / cask-only / mixed / pinned cases plus one full JSON round-trip.

No bench regression; binary +128 B.