### PR TITLE
feat(search): match brew's substring behavior

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -98,6 +98,7 @@ pub fn build(b: *std.Build) void {
         "tests/cask_extra_test.zig",
         "tests/dsl_interpreter_extra_test.zig",
         "tests/list_test.zig",
+        "tests/search_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/scripts/smoke_search.sh
+++ b/scripts/smoke_search.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Smoke test for `malt search`.
+#
+# Verifies the substring-search command returns brew-parity results for
+# a known-populated query ("go"), that the exact match is present, and
+# that --json / nonexistent-query paths behave. Hits the live Homebrew
+# API, so it requires network; safe to run locally (no install side
+# effects).
+#
+# Usage: scripts/smoke_search.sh
+# Requirements: built `malt` binary in zig-out/bin or $MALT_BIN.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || { echo "build malt first: zig build" >&2; exit 2; }
+
+# Minimum result count for `go` — brew returns >300; we set the floor
+# well below that so the test isn't fragile to daily index drift.
+MIN_HITS=100
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() { printf '  ✗ %s\n' "$*" >&2; exit 1; }
+
+printf '▸ human output: mt search go\n'
+out=$("$BIN" search go)
+hits=$(printf '%s\n' "$out" | wc -l | tr -d ' ')
+(( hits >= MIN_HITS )) || fail "expected ≥$MIN_HITS rows, got $hits"
+pass "$hits rows returned"
+
+printf '%s\n' "$out" | grep -q '^  ▸ go (formula)$' \
+  || fail "exact match 'go (formula)' missing from output"
+pass "exact formula match present"
+
+printf '%s\n' "$out" | grep -q '(cask)$' \
+  || fail "no cask results — expected at least one"
+pass "cask results present"
+
+printf '\n▸ json output: mt --json search wget\n'
+json=$("$BIN" --json search wget)
+printf '%s\n' "$json" | grep -q '"formulae":\[{"name":"wget"}' \
+  || fail "JSON missing wget formula entry"
+pass "JSON shape ok ($json)"
+
+printf '\n▸ empty result: mt search xyz-no-such-pkg-abc-123\n'
+miss=$("$BIN" search xyz-no-such-pkg-abc-123 2>&1 || true)
+printf '%s\n' "$miss" | grep -q 'No results found' \
+  || fail "missing 'No results found' line for empty query"
+pass "empty-query message shown"
+
+printf '\n✓ all smoke checks passed\n'

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -81,14 +81,25 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer cask.deinit(allocator);
 
     if (search_formula and search_cask) {
+        // malt's main allocator is an `ArenaAllocator` which is not
+        // safe to call concurrently — two threads racing on the same
+        // arena can see misaligned returns and corrupted free lists
+        // (observed on release builds as "thread panic: incorrect
+        // alignment" inside `std.http.Client.Connection.Tls.create`).
+        // Wrap it with a mutex-guarded allocator for the parallel
+        // section; results flow back to the caller's allocator via
+        // `dupe`, so the safe wrapper can go out of scope after join.
+        var safe: std.heap.ThreadSafeAllocator = .{ .child_allocator = allocator };
+        const shared = safe.allocator();
+
         var cask_task: KindTask = .{
-            .allocator = allocator,
+            .allocator = shared,
             .cache_dir = cache_dir,
             .kind = .cask,
             .query = search_query,
         };
         const worker = std.Thread.spawn(.{}, KindTask.run, .{&cask_task}) catch null;
-        formula = runKindIsolated(allocator, cache_dir, .formula, search_query);
+        formula = runKindIsolated(shared, cache_dir, .formula, search_query);
         if (worker) |w| {
             w.join();
             cask = cask_task.result;

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -9,6 +9,22 @@ const api_mod = @import("../net/api.zig");
 const client_mod = @import("../net/client.zig");
 const help = @import("help.zig");
 
+/// Results for a single kind (formula or cask) of a search query.
+///
+/// `index` and `matches` are separately owned because `matches` elements
+/// are slices *into* `index` — freeing `index` invalidates them. Callers
+/// must deinit via `deinit` to release both in the right order.
+const KindResults = struct {
+    exact: bool = false,
+    index: ?[]const u8 = null,
+    matches: []const []const u8 = &.{},
+
+    fn deinit(self: *KindResults, allocator: std.mem.Allocator) void {
+        if (self.matches.len != 0) allocator.free(self.matches);
+        if (self.index) |b| allocator.free(b);
+    }
+};
+
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "search")) return;
 
@@ -53,59 +69,111 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer http.deinit();
     var api = api_mod.BrewApi.init(allocator, &http, cache_dir);
 
+    var formula = if (search_formula) runKind(allocator, &api, .formula, search_query) else KindResults{};
+    defer formula.deinit(allocator);
+    var cask = if (search_cask) runKind(allocator, &api, .cask, search_query) else KindResults{};
+    defer cask.deinit(allocator);
+
     const stdout = std.fs.File.stdout();
-
-    // Track whether anything was found (for "not found" messages)
-    var found_formula = false;
-    var found_cask = false;
-
-    // Search formulas/casks via the cache-aware existence probe. On a warm
-    // cache this is just a `statFile` — the previous `fetchFormula` path
-    // always opened and read the (potentially 40 KiB) cached JSON body
-    // even though we only needed to know whether the key existed.
-    if (search_formula) {
-        found_formula = api.exists(search_query, .formula) catch false;
-    }
-
-    if (search_cask) {
-        found_cask = api.exists(search_query, .cask) catch false;
-    }
-
-    // Output results
     if (json_mode) {
-        var out_buf: std.ArrayList(u8) = .empty;
-        defer out_buf.deinit(allocator);
-        const w = out_buf.writer(allocator);
-
-        try w.writeAll("{");
-        if (search_formula) {
-            try w.writeAll("\"formulae\":[");
-            if (found_formula) {
-                try w.writeAll("{\"name\":\"");
-                try w.writeAll(search_query);
-                try w.writeAll("\"}");
-            }
-            try w.writeAll("]");
-        }
-        if (search_cask) {
-            if (search_formula) try w.writeAll(",");
-            try w.writeAll("\"casks\":[");
-            if (found_cask) {
-                try w.writeAll("{\"token\":\"");
-                try w.writeAll(search_query);
-                try w.writeAll("\"}");
-            }
-            try w.writeAll("]");
-        }
-        try w.writeAll("}\n");
-        stdout.writeAll(out_buf.items) catch {};
+        try emitJson(allocator, stdout, search_formula, search_cask, formula, cask, search_query);
     } else {
-        if (found_formula) writeResult(stdout, search_query, "formula");
-        if (found_cask) writeResult(stdout, search_query, "cask");
+        emitHuman(stdout, formula, cask, search_query);
+    }
+}
 
-        if (!found_formula and !found_cask and !output.isQuiet()) {
-            output.info("No results found for \"{s}\"", .{search_query});
-        }
+/// Run the exact + substring search for one kind. Errors from the API
+/// are swallowed into empty results — `mt search` is best-effort and a
+/// transient network failure should not abort the whole command.
+fn runKind(
+    allocator: std.mem.Allocator,
+    api: *api_mod.BrewApi,
+    kind: api_mod.BrewApi.Kind,
+    query: []const u8,
+) KindResults {
+    var r: KindResults = .{};
+    r.exact = api.exists(query, kind) catch false;
+    if (api.fetchNamesIndex(kind)) |idx| {
+        r.index = idx;
+        r.matches = api_mod.findNameMatches(allocator, idx, query) catch &.{};
+    } else |_| {}
+    return r;
+}
+
+fn emitHuman(
+    stdout: std.fs.File,
+    formula: KindResults,
+    cask: KindResults,
+    query: []const u8,
+) void {
+    writeHuman(stdout, "formula", formula, query);
+    writeHuman(stdout, "cask", cask, query);
+
+    const any = formula.exact or cask.exact or
+        formula.matches.len != 0 or cask.matches.len != 0;
+    if (!any and !output.isQuiet()) {
+        output.info("No results found for \"{s}\"", .{query});
+    }
+}
+
+/// Write substring matches for one kind, with the exact match (if any)
+/// pinned to the top and deduped against the substring list. The index
+/// may not yet include a brand-new formula the API already serves, so
+/// relying on substring membership alone to surface exact matches would
+/// under-report on the day of a new release.
+fn writeHuman(
+    stdout: std.fs.File,
+    kind: []const u8,
+    r: KindResults,
+    query: []const u8,
+) void {
+    if (r.exact) writeResult(stdout, query, kind);
+    for (r.matches) |m| {
+        if (r.exact and std.mem.eql(u8, m, query)) continue;
+        writeResult(stdout, m, kind);
+    }
+}
+
+fn emitJson(
+    allocator: std.mem.Allocator,
+    stdout: std.fs.File,
+    search_formula: bool,
+    search_cask: bool,
+    formula: KindResults,
+    cask: KindResults,
+    query: []const u8,
+) !void {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    const w = buf.writer(allocator);
+
+    try w.writeAll("{");
+    if (search_formula) {
+        try w.writeAll("\"formulae\":[");
+        try writeJson(w, "name", formula, query);
+        try w.writeAll("]");
+    }
+    if (search_cask) {
+        if (search_formula) try w.writeAll(",");
+        try w.writeAll("\"casks\":[");
+        try writeJson(w, "token", cask, query);
+        try w.writeAll("]");
+    }
+    try w.writeAll("}\n");
+    stdout.writeAll(buf.items) catch {};
+}
+
+fn writeJson(w: anytype, field: []const u8, r: KindResults, query: []const u8) !void {
+    var first = true;
+    if (r.exact) {
+        try w.print("{{\"{s}\":\"{s}\"}}", .{ field, query });
+        first = false;
+    }
+    for (r.matches) |m| {
+        if (r.exact and std.mem.eql(u8, m, query)) continue;
+        if (!first) try w.writeAll(",");
+        try w.print("{{\"{s}\":\"{s}\"}}", .{ field, m });
+        first = false;
     }
 }
 

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -65,14 +65,44 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     };
     defer allocator.free(cache_dir);
 
-    var http = client_mod.HttpClient.init(allocator);
-    defer http.deinit();
-    var api = api_mod.BrewApi.init(allocator, &http, cache_dir);
-
-    var formula = if (search_formula) runKind(allocator, &api, .formula, search_query) else KindResults{};
+    // When both kinds are requested we dispatch the cask work to a
+    // worker thread so the two independent JSON index downloads
+    // (formula ~29 MiB, cask ~14 MiB) overlap. On a cold cache this
+    // roughly halves wall time; on a warm cache the thread is created
+    // and joined in under a millisecond so the overhead is noise.
+    //
+    // `std.http.Client` is not safe to share across threads, so each
+    // path owns its own `HttpClient`. The synchronous single-kind
+    // paths keep the original one-client shape to avoid pointless
+    // thread spawns.
+    var formula: KindResults = .{};
+    var cask: KindResults = .{};
     defer formula.deinit(allocator);
-    var cask = if (search_cask) runKind(allocator, &api, .cask, search_query) else KindResults{};
     defer cask.deinit(allocator);
+
+    if (search_formula and search_cask) {
+        var cask_task: KindTask = .{
+            .allocator = allocator,
+            .cache_dir = cache_dir,
+            .kind = .cask,
+            .query = search_query,
+        };
+        const worker = std.Thread.spawn(.{}, KindTask.run, .{&cask_task}) catch null;
+        formula = runKindIsolated(allocator, cache_dir, .formula, search_query);
+        if (worker) |w| {
+            w.join();
+            cask = cask_task.result;
+        } else {
+            // Spawn failed — fall back to running cask inline. Rare
+            // enough (only on thread-creation failure) that the
+            // sequential path is fine.
+            cask = runKindIsolated(allocator, cache_dir, .cask, search_query);
+        }
+    } else if (search_formula) {
+        formula = runKindIsolated(allocator, cache_dir, .formula, search_query);
+    } else if (search_cask) {
+        cask = runKindIsolated(allocator, cache_dir, .cask, search_query);
+    }
 
     const stdout = std.fs.File.stdout();
     if (json_mode) {
@@ -82,15 +112,19 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 }
 
-/// Run the exact + substring search for one kind. Errors from the API
-/// are swallowed into empty results — `mt search` is best-effort and a
-/// transient network failure should not abort the whole command.
-fn runKind(
+/// Run the exact + substring search for one kind with a locally-owned
+/// HTTP client. Errors from the API are swallowed into empty results —
+/// `mt search` is best-effort and a transient network failure should
+/// not abort the whole command.
+fn runKindIsolated(
     allocator: std.mem.Allocator,
-    api: *api_mod.BrewApi,
+    cache_dir: []const u8,
     kind: api_mod.BrewApi.Kind,
     query: []const u8,
 ) KindResults {
+    var http = client_mod.HttpClient.init(allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(allocator, &http, cache_dir);
     var r: KindResults = .{};
     r.exact = api.exists(query, kind) catch false;
     if (api.fetchNamesIndex(kind)) |idx| {
@@ -99,6 +133,21 @@ fn runKind(
     } else |_| {}
     return r;
 }
+
+/// Thread entry-point wrapper so `std.Thread.spawn` can call it with a
+/// single pointer argument. The result is written back into the struct
+/// the caller allocated on its stack, read after `join()`.
+const KindTask = struct {
+    allocator: std.mem.Allocator,
+    cache_dir: []const u8,
+    kind: api_mod.BrewApi.Kind,
+    query: []const u8,
+    result: KindResults = .{},
+
+    fn run(self: *KindTask) void {
+        self.result = runKindIsolated(self.allocator, self.cache_dir, self.kind, self.query);
+    }
+};
 
 fn emitHuman(
     stdout: std.fs.File,

--- a/src/net/api.zig
+++ b/src/net/api.zig
@@ -7,6 +7,11 @@ const client_mod = @import("client.zig");
 const BASE_URL = "https://formulae.brew.sh/api";
 const CACHE_TTL_SECS: i64 = 300; // 5 minutes
 
+/// Names-index TTL. The full Homebrew name list changes on the order of days
+/// (new formulae merged, tokens renamed), so a 24 h window avoids burning
+/// ~40 MiB of fetch per search while still picking up changes within a day.
+pub const INDEX_TTL_SECS: i64 = 24 * 60 * 60;
+
 pub const ApiError = error{
     NotFound,
     ApiUnreachable,
@@ -27,6 +32,89 @@ pub fn validateName(name: []const u8) ApiError!void {
             else => return ApiError.InvalidName,
         }
     }
+}
+
+/// Parse a Homebrew formula.json / cask.json body and emit a newline-
+/// delimited list of names (formulae) or tokens (casks). The caller owns
+/// the returned bytes. Uses `ignore_unknown_fields` so the parser skips
+/// the megabytes of metadata we don't need — only the name/token string
+/// per entry is retained.
+pub fn extractNames(
+    allocator: std.mem.Allocator,
+    kind: BrewApi.Kind,
+    json_body: []const u8,
+) ![]const u8 {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    switch (kind) {
+        .formula => {
+            const Entry = struct { name: []const u8 };
+            const parsed = try std.json.parseFromSliceLeaky(
+                []Entry,
+                a,
+                json_body,
+                .{ .ignore_unknown_fields = true },
+            );
+            for (parsed) |e| {
+                if (e.name.len == 0) continue;
+                try out.appendSlice(allocator, e.name);
+                try out.append(allocator, '\n');
+            }
+        },
+        .cask => {
+            const Entry = struct { token: []const u8 };
+            const parsed = try std.json.parseFromSliceLeaky(
+                []Entry,
+                a,
+                json_body,
+                .{ .ignore_unknown_fields = true },
+            );
+            for (parsed) |e| {
+                if (e.token.len == 0) continue;
+                try out.appendSlice(allocator, e.token);
+                try out.append(allocator, '\n');
+            }
+        },
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// Case-insensitive substring scan over a newline-delimited names index.
+/// Returns a list of slices into `index` (caller-owned container, elements
+/// are borrowed — caller must keep `index` alive for their lifetime).
+///
+/// Matches brew's `search <term>` UX: a single substring test per entry,
+/// no ranking. Queries are lowercased once, the index once, and compared
+/// with `indexOf`. For a ~200 KiB combined index this is well under 1 ms.
+pub fn findNameMatches(
+    allocator: std.mem.Allocator,
+    index: []const u8,
+    query: []const u8,
+) ![][]const u8 {
+    var out: std.ArrayList([]const u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    // Pre-lowercase the query once. Names from the Homebrew index are
+    // already lowercase by convention, so the scan is effectively
+    // case-insensitive without an extra transform per candidate.
+    var qbuf: [128]u8 = undefined;
+    if (query.len == 0 or query.len > qbuf.len) return out.toOwnedSlice(allocator);
+    const qlower = std.ascii.lowerString(qbuf[0..query.len], query);
+
+    var it = std.mem.splitScalar(u8, index, '\n');
+    while (it.next()) |name| {
+        if (name.len == 0) continue;
+        if (std.mem.indexOf(u8, name, qlower) != null) {
+            try out.append(allocator, name);
+        }
+    }
+    return out.toOwnedSlice(allocator);
 }
 
 pub const BrewApi = struct {
@@ -100,6 +188,75 @@ pub const BrewApi = struct {
         const now = std.time.timestamp();
         const mtime_secs: i64 = @intCast(@divTrunc(stat.mtime, std.time.ns_per_s));
         return now - mtime_secs <= CACHE_TTL_SECS;
+    }
+
+    /// Fetch the newline-delimited names index for all formulae or casks.
+    /// Caller-owned bytes. Backed by a 24 h on-disk cache: the one-time
+    /// parse of the ~28 MiB / ~14 MiB Homebrew JSON dump produces a
+    /// ~130 KiB / ~70 KiB plain-text list, which substring search can
+    /// then linear-scan in well under 1 ms.
+    pub fn fetchNamesIndex(self: *BrewApi, kind: Kind) ApiError![]const u8 {
+        const key: []const u8 = switch (kind) {
+            .formula => "formula",
+            .cask => "cask",
+        };
+        if (self.readNamesIndex(key)) |cached| return cached;
+
+        const url: []const u8 = switch (kind) {
+            .formula => BASE_URL ++ "/formula.json",
+            .cask => BASE_URL ++ "/cask.json",
+        };
+        var resp = self.http.get(url) catch return ApiError.ApiUnreachable;
+        defer resp.deinit();
+        if (resp.status != 200) return ApiError.ApiUnreachable;
+
+        const index = extractNames(self.allocator, kind, resp.body) catch |e| switch (e) {
+            error.OutOfMemory => return ApiError.OutOfMemory,
+            else => return ApiError.InvalidResponse,
+        };
+        self.writeNamesIndex(key, index);
+        return index;
+    }
+
+    /// Return the cached names index for `key` if fresh, else null.
+    fn readNamesIndex(self: *BrewApi, key: []const u8) ?[]const u8 {
+        var path_buf: [512]u8 = undefined;
+        const p = std.fmt.bufPrint(&path_buf, "{s}/api/names_{s}.txt", .{ self.cache_dir, key }) catch return null;
+
+        const stat = std.fs.cwd().statFile(p) catch return null;
+        const now = std.time.timestamp();
+        const mtime_secs: i64 = @intCast(@divTrunc(stat.mtime, std.time.ns_per_s));
+        if (now - mtime_secs > INDEX_TTL_SECS) return null;
+
+        const file = std.fs.cwd().openFile(p, .{}) catch return null;
+        defer file.close();
+        const s = file.stat() catch return null;
+        const buf = self.allocator.alloc(u8, s.size) catch return null;
+        const n = file.readAll(buf) catch {
+            self.allocator.free(buf);
+            return null;
+        };
+        if (n < buf.len) {
+            self.allocator.free(buf);
+            return null;
+        }
+        return buf;
+    }
+
+    fn writeNamesIndex(self: *const BrewApi, key: []const u8, data: []const u8) void {
+        var dir_buf: [512]u8 = undefined;
+        const dir = std.fmt.bufPrint(&dir_buf, "{s}/api", .{self.cache_dir}) catch return;
+        std.fs.makeDirAbsolute(dir) catch |e| switch (e) {
+            error.PathAlreadyExists => {},
+            else => return,
+        };
+
+        var path_buf: [512]u8 = undefined;
+        const p = std.fmt.bufPrint(&path_buf, "{s}/api/names_{s}.txt", .{ self.cache_dir, key }) catch return;
+
+        const f = std.fs.cwd().createFile(p, .{}) catch return;
+        defer f.close();
+        f.writeAll(data) catch {};
     }
 
     /// Invalidate all cached API responses.

--- a/tests/search_test.zig
+++ b/tests/search_test.zig
@@ -1,0 +1,154 @@
+//! malt — substring search tests
+//!
+//! Exercises the pure helpers behind `mt search <query>`:
+//!   - `api.extractNames` parses a Homebrew-shaped JSON body and emits a
+//!     newline-delimited names index.
+//!   - `api.findNameMatches` scans that index for substring hits.
+//!   - `BrewApi.fetchNamesIndex` reads a pre-seeded cache without touching
+//!     the network (same pattern as `api_test.zig`).
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const api_mod = malt.api;
+const client_mod = malt.client;
+
+test "extractNames pulls formula names out of a JSON array" {
+    const body =
+        \\[
+        \\  {"name":"go","desc":"…"},
+        \\  {"name":"wget","desc":"…"},
+        \\  {"name":"openssl@3","desc":"…"}
+        \\]
+    ;
+    const idx = try api_mod.extractNames(testing.allocator, .formula, body);
+    defer testing.allocator.free(idx);
+    try testing.expectEqualStrings("go\nwget\nopenssl@3\n", idx);
+}
+
+test "extractNames pulls cask tokens and skips unknown fields" {
+    const body =
+        \\[
+        \\  {"token":"firefox","name":["Firefox"],"url":"…"},
+        \\  {"token":"visual-studio-code","name":["Visual Studio Code"]}
+        \\]
+    ;
+    const idx = try api_mod.extractNames(testing.allocator, .cask, body);
+    defer testing.allocator.free(idx);
+    try testing.expectEqualStrings("firefox\nvisual-studio-code\n", idx);
+}
+
+test "extractNames handles an empty array" {
+    const idx = try api_mod.extractNames(testing.allocator, .formula, "[]");
+    defer testing.allocator.free(idx);
+    try testing.expectEqualStrings("", idx);
+}
+
+test "findNameMatches returns every substring hit" {
+    const idx = "argo\ncargo\ncargo-audit\nffmpeg\ngo\nnode\n";
+    const hits = try api_mod.findNameMatches(testing.allocator, idx, "go");
+    defer testing.allocator.free(hits);
+    try testing.expectEqual(@as(usize, 4), hits.len);
+    try testing.expectEqualStrings("argo", hits[0]);
+    try testing.expectEqualStrings("cargo", hits[1]);
+    try testing.expectEqualStrings("cargo-audit", hits[2]);
+    try testing.expectEqualStrings("go", hits[3]);
+}
+
+test "findNameMatches is case-insensitive on the query" {
+    const idx = "ffmpeg\nnode\nopenssl@3\n";
+    const hits = try api_mod.findNameMatches(testing.allocator, idx, "FFMPEG");
+    defer testing.allocator.free(hits);
+    try testing.expectEqual(@as(usize, 1), hits.len);
+    try testing.expectEqualStrings("ffmpeg", hits[0]);
+}
+
+test "findNameMatches returns empty slice for no hits" {
+    const idx = "wget\ncurl\n";
+    const hits = try api_mod.findNameMatches(testing.allocator, idx, "python");
+    defer testing.allocator.free(hits);
+    try testing.expectEqual(@as(usize, 0), hits.len);
+}
+
+test "findNameMatches tolerates an empty index" {
+    const hits = try api_mod.findNameMatches(testing.allocator, "", "go");
+    defer testing.allocator.free(hits);
+    try testing.expectEqual(@as(usize, 0), hits.len);
+}
+
+test "findNameMatches rejects over-long queries to keep lowercase buf bounded" {
+    // Guard against accidental buffer-overflow if someone ever passes a
+    // 200-char query. Today the CLI caps at 128 via validateName, but the
+    // substring helper is callable from tests and other consumers.
+    var q: [200]u8 = undefined;
+    @memset(&q, 'x');
+    const hits = try api_mod.findNameMatches(testing.allocator, "xxx\nabc\n", &q);
+    defer testing.allocator.free(hits);
+    try testing.expectEqual(@as(usize, 0), hits.len);
+}
+
+// --- fetchNamesIndex cache read path (no network) ---
+
+const TempCacheDir = struct {
+    path: []const u8,
+
+    fn init(comptime tag: []const u8) !TempCacheDir {
+        const p = "/tmp/malt_search_test_" ++ tag;
+        std.fs.deleteTreeAbsolute(p) catch {};
+        try std.fs.makeDirAbsolute(p);
+        return .{ .path = p };
+    }
+
+    fn deinit(self: *TempCacheDir) void {
+        std.fs.deleteTreeAbsolute(self.path) catch {};
+    }
+
+    fn writeCacheFile(self: *TempCacheDir, rel: []const u8, content: []const u8) !void {
+        var api_buf: [512]u8 = undefined;
+        const api_dir = try std.fmt.bufPrint(&api_buf, "{s}/api", .{self.path});
+        std.fs.makeDirAbsolute(api_dir) catch |e| switch (e) {
+            error.PathAlreadyExists => {},
+            else => return e,
+        };
+        var path_buf: [512]u8 = undefined;
+        const full = try std.fmt.bufPrint(&path_buf, "{s}/api/{s}", .{ self.path, rel });
+        const f = try std.fs.cwd().createFile(full, .{});
+        defer f.close();
+        try f.writeAll(content);
+    }
+};
+
+test "fetchNamesIndex returns a pre-seeded cache without touching the network" {
+    var http = client_mod.HttpClient.init(testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("fetchidx_hit");
+    defer dir.deinit();
+
+    try dir.writeCacheFile("names_formula.txt", "go\nwget\n");
+    try dir.writeCacheFile("names_cask.txt", "firefox\n");
+
+    var api = api_mod.BrewApi.init(testing.allocator, &http, dir.path);
+
+    const f = try api.fetchNamesIndex(.formula);
+    defer testing.allocator.free(f);
+    try testing.expectEqualStrings("go\nwget\n", f);
+
+    const c = try api.fetchNamesIndex(.cask);
+    defer testing.allocator.free(c);
+    try testing.expectEqualStrings("firefox\n", c);
+}
+
+test "fetchNamesIndex reports missing cache as null via absence of the file" {
+    // Sanity check: with no cache file and no seeded content, the cache
+    // read path returns null; exercising it via fetchNamesIndex would
+    // hit the network, so instead we just verify a fresh api.cacheSize
+    // is zero and the cache file does not yet exist. TTL-expiry logic
+    // shares a code path with readCache (already covered in api_test.zig).
+    var http = client_mod.HttpClient.init(testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("fetchidx_miss");
+    defer dir.deinit();
+
+    var api = api_mod.BrewApi.init(testing.allocator, &http, dir.path);
+    try testing.expectEqual(@as(u64, 0), api.cacheSize());
+}

--- a/tests/search_test.zig
+++ b/tests/search_test.zig
@@ -138,6 +138,36 @@ test "fetchNamesIndex returns a pre-seeded cache without touching the network" {
     try testing.expectEqualStrings("firefox\n", c);
 }
 
+test "exists + fetchNamesIndex + findNameMatches compose end-to-end" {
+    // Full search pipeline against a pre-seeded cache — mirrors what
+    // `mt search <query>` does per kind: exact-hit check, full names
+    // index lookup, substring scan. Guards the composition after the
+    // per-kind path was split into an isolated-HttpClient helper so
+    // the two kinds could run on separate threads.
+    var http = client_mod.HttpClient.init(testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("compose");
+    defer dir.deinit();
+
+    try dir.writeCacheFile("formula_go.json", "{\"name\":\"go\"}");
+    try dir.writeCacheFile("names_formula.txt", "argo\ncargo\ngo\ngolangci-lint\nnode\n");
+
+    var api = api_mod.BrewApi.init(testing.allocator, &http, dir.path);
+
+    try testing.expect(try api.exists("go", .formula));
+
+    const idx = try api.fetchNamesIndex(.formula);
+    defer testing.allocator.free(idx);
+
+    const hits = try api_mod.findNameMatches(testing.allocator, idx, "go");
+    defer testing.allocator.free(hits);
+    try testing.expectEqual(@as(usize, 4), hits.len);
+    try testing.expectEqualStrings("argo", hits[0]);
+    try testing.expectEqualStrings("cargo", hits[1]);
+    try testing.expectEqualStrings("go", hits[2]);
+    try testing.expectEqualStrings("golangci-lint", hits[3]);
+}
+
 test "fetchNamesIndex reports missing cache as null via absence of the file" {
     // Sanity check: with no cache file and no seeded content, the cache
     // read path returns null; exercising it via fetchNamesIndex would


### PR DESCRIPTION
## What this changes
`mt search <query>` now returns every formula and cask whose name contains the query — the same UX as `brew search`. Previously only exact-name matches were surfaced, so `mt search go` returned a single result while `brew search go` returned hundreds.

## Why
Users reasonably expected search to be discovery, not an existence check. Silent empty results trained people not to trust the command.

## Notes
- Exact-match lookups stay on the existing fast path — no latency regression for install-precheck flows.
- The first substring query per day downloads the Homebrew index once and caches a compact names list locally; subsequent searches complete in a few milliseconds.