### PR TITLE
fix(info): brew-style output on fresh machines

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -99,6 +99,7 @@ pub fn build(b: *std.Build) void {
         "tests/dsl_interpreter_extra_test.zig",
         "tests/list_test.zig",
         "tests/search_test.zig",
+        "tests/info_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -8,97 +8,347 @@ const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
 const api_mod = @import("../net/api.zig");
 const client_mod = @import("../net/client.zig");
+const formula_mod = @import("../core/formula.zig");
 const cask_mod = @import("../core/cask.zig");
 const help = @import("help.zig");
 
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "info")) return;
 
-    // Parse flags and positional args
-    var json_mode = false;
+    // Parse flags and positional args. Note: `--json` and `--quiet`
+    // are consumed by the global arg parser in `main.zig` and stored
+    // on the `output` module — they never appear in `args` here,
+    // which is why this loop does not scan for them.
     var force_cask = false;
     var force_formula = false;
     var pkg_name: ?[]const u8 = null;
 
     for (args) |arg| {
-        if (std.mem.eql(u8, arg, "--json")) {
-            json_mode = true;
-        } else if (std.mem.eql(u8, arg, "--cask")) {
+        if (std.mem.eql(u8, arg, "--cask")) {
             force_cask = true;
         } else if (std.mem.eql(u8, arg, "--formula")) {
             force_formula = true;
-        } else if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
-            output.setQuiet(true);
         } else if (arg.len > 0 and arg[0] != '-') {
             if (pkg_name == null) pkg_name = arg;
         }
     }
+
+    const json_mode = output.isJson();
 
     const name = pkg_name orelse {
         output.err("Usage: mt info <package>", .{});
         return;
     };
 
-    // Open DB
+    // Open DB (optional). On a fresh machine the prefix's `db/` dir
+    // may not exist yet — SQLite's OPEN_CREATE creates the file but
+    // not intermediate directories, so the first-ever open fails.
+    // `info` is purely informational: if we can't read local state
+    // we fall through to the "not installed" output rather than
+    // erroring, which matches what a populated DB would report for
+    // a package that has never been installed.
     const prefix = atomic.maltPrefix();
-    var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
-    var db = sqlite.Database.open(db_path) catch {
-        output.err("Failed to open database", .{});
-        return;
-    };
-    defer db.close();
-    schema.initSchema(&db) catch return;
+    var db_opt: ?sqlite.Database = openDb(prefix);
+    defer if (db_opt) |*d| d.close();
 
-    // Check formula first (unless --cask)
-    var formula_installed = false;
-    if (!force_cask) {
-        var stmt = db.prepare(
-            "SELECT name, version, tap, cellar_path, pinned, installed_at FROM kegs WHERE name = ?1 LIMIT 1;",
-        ) catch return;
-        defer stmt.finalize();
-        stmt.bindText(1, name) catch return;
-
-        formula_installed = stmt.step() catch false;
-
-        if (formula_installed) {
-            const stdout = std.fs.File.stdout();
-            if (json_mode) {
-                try writeJsonInfo(allocator, &db, name, true, &stmt, stdout);
-            } else {
-                try writeHumanInfo(name, true, &stmt, prefix, stdout);
-            }
-            return;
-        }
-    }
-
-    // Check cask (unless --formula)
-    if (!force_formula) {
-        const cask_installed = cask_mod.lookupInstalled(&db, name);
-        if (cask_installed != null) {
-            const stdout = std.fs.File.stdout();
-            if (json_mode) {
-                try writeJsonCaskInfo(allocator, &db, name, stdout);
-            } else {
-                try writeHumanCaskInfo(&db, name, stdout);
-            }
-            return;
-        }
-    }
-
-    // Not installed as either
     const stdout = std.fs.File.stdout();
-    if (json_mode) {
-        var stmt = db.prepare(
-            "SELECT name, version, tap, cellar_path, pinned, installed_at FROM kegs WHERE name = ?1 LIMIT 1;",
-        ) catch return;
-        defer stmt.finalize();
-        try writeJsonInfo(allocator, &db, name, false, &stmt, stdout);
-    } else {
-        var buf: [4096]u8 = undefined;
-        const line = std.fmt.bufPrint(&buf, "{s}: not installed\n", .{name}) catch return;
-        stdout.writeAll(line) catch {};
+
+    if (db_opt) |*db| {
+        schema.initSchema(db) catch {};
+        if (!force_cask and try emitInstalledFormula(allocator, db, name, prefix, stdout, json_mode)) return;
+        if (!force_formula and try emitInstalledCask(allocator, db, name, stdout, json_mode)) return;
     }
+
+    // Not locally installed — fall back to Homebrew API metadata so
+    // the output matches `brew info`'s discovery UX (description,
+    // homepage, version, dependencies) instead of just "not
+    // installed". We only reach this path when the local DB lookup
+    // missed or the DB was absent entirely.
+    if (try emitApiMetadata(allocator, name, stdout, json_mode, force_cask, force_formula)) return;
+
+    try emitNotFound(allocator, name, stdout, json_mode);
+}
+
+/// If `name` is an installed formula, write its info row and return
+/// true (caller stops). Returns false when the lookup misses so the
+/// caller can try the cask path.
+fn emitInstalledFormula(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    name: []const u8,
+    prefix: []const u8,
+    stdout: std.fs.File,
+    json_mode: bool,
+) !bool {
+    var stmt = db.prepare(
+        "SELECT name, version, tap, cellar_path, pinned, installed_at FROM kegs WHERE name = ?1 LIMIT 1;",
+    ) catch return false;
+    defer stmt.finalize();
+    stmt.bindText(1, name) catch return false;
+
+    const installed = stmt.step() catch false;
+    if (!installed) return false;
+
+    if (json_mode) {
+        try writeJsonInfo(allocator, db, name, true, &stmt, stdout);
+    } else {
+        try writeHumanInfo(name, true, &stmt, prefix, stdout);
+    }
+    return true;
+}
+
+/// Cask counterpart to `emitInstalledFormula`.
+fn emitInstalledCask(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    name: []const u8,
+    stdout: std.fs.File,
+    json_mode: bool,
+) !bool {
+    if (cask_mod.lookupInstalled(db, name) == null) return false;
+    if (json_mode) {
+        try writeJsonCaskInfo(allocator, db, name, stdout);
+    } else {
+        try writeHumanCaskInfo(db, name, stdout);
+    }
+    return true;
+}
+
+/// Terminal output for a package the user asked about that is
+/// neither installed locally nor known to the Homebrew API.
+fn emitNotFound(
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    stdout: std.fs.File,
+    json_mode: bool,
+) !void {
+    if (json_mode) {
+        try writeJsonNotInstalled(allocator, name, stdout);
+        return;
+    }
+    var buf: [4096]u8 = undefined;
+    const line = std.fmt.bufPrint(&buf, "{s}: not installed\n", .{name}) catch return;
+    stdout.writeAll(line) catch {};
+}
+
+/// Fetch Homebrew API metadata for a not-locally-installed package and
+/// emit it. Tries formula first (unless `--cask`), then cask (unless
+/// `--formula`). Returns true on any hit so the caller knows to stop.
+/// Silently returns false on network / parse failures — offline machines
+/// should still fall through cleanly to the "not installed" shape.
+fn emitApiMetadata(
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    stdout: std.fs.File,
+    json_mode: bool,
+    force_cask: bool,
+    force_formula: bool,
+) !bool {
+    const cache_dir = atomic.maltCacheDir(allocator) catch return false;
+    defer allocator.free(cache_dir);
+
+    var http = client_mod.HttpClient.init(allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(allocator, &http, cache_dir);
+
+    if (!force_cask) {
+        if (try emitApiFormula(allocator, &api, name, stdout, json_mode)) return true;
+    }
+    if (!force_formula) {
+        if (try emitApiCask(allocator, &api, name, stdout, json_mode)) return true;
+    }
+    return false;
+}
+
+fn emitApiFormula(
+    allocator: std.mem.Allocator,
+    api: *api_mod.BrewApi,
+    name: []const u8,
+    stdout: std.fs.File,
+    json_mode: bool,
+) !bool {
+    const body = api.fetchFormula(name) catch return false;
+    defer allocator.free(body);
+
+    var f = formula_mod.parseFormula(allocator, body) catch return false;
+    defer f.deinit();
+
+    if (json_mode) try writeApiFormulaJson(allocator, &f, stdout) else try writeApiFormulaHuman(&f, stdout);
+    return true;
+}
+
+fn emitApiCask(
+    allocator: std.mem.Allocator,
+    api: *api_mod.BrewApi,
+    name: []const u8,
+    stdout: std.fs.File,
+    json_mode: bool,
+) !bool {
+    const body = api.fetchCask(name) catch return false;
+    defer allocator.free(body);
+
+    var c = cask_mod.parseCask(allocator, body) catch return false;
+    defer c.deinit();
+
+    if (json_mode) try writeApiCaskJson(allocator, &c, stdout) else try writeApiCaskHuman(&c, stdout);
+    return true;
+}
+
+fn writeApiFormulaHuman(f: *const formula_mod.Formula, stdout: std.fs.File) !void {
+    var buf: [4096]u8 = undefined;
+    try encodeApiFormulaHuman(stdout, &buf, f, output.isQuiet());
+}
+
+fn writeApiCaskHuman(c: *const cask_mod.Cask, stdout: std.fs.File) !void {
+    var buf: [4096]u8 = undefined;
+    try encodeApiCaskHuman(stdout, &buf, c, output.isQuiet());
+}
+
+fn writeApiFormulaJson(
+    allocator: std.mem.Allocator,
+    f: *const formula_mod.Formula,
+    stdout: std.fs.File,
+) !void {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    try encodeApiFormulaJson(buf.writer(allocator), f);
+    stdout.writeAll(buf.items) catch {};
+}
+
+fn writeApiCaskJson(
+    allocator: std.mem.Allocator,
+    c: *const cask_mod.Cask,
+    stdout: std.fs.File,
+) !void {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    try encodeApiCaskJson(buf.writer(allocator), c);
+    stdout.writeAll(buf.items) catch {};
+}
+
+// --- pure encoders (testable) -----------------------------------------------
+//
+// The four `encode*` fns below are the isolated pieces that turn a
+// parsed `Formula` / `Cask` into bytes. They take any writer target
+// — `std.fs.File` in the CLI, `ArrayList` in tests — so the emission
+// shape (install hint wording, JSON keys, line order) can be asserted
+// without touching the filesystem.
+
+pub fn encodeApiFormulaHuman(
+    w: anytype,
+    scratch: []u8,
+    f: *const formula_mod.Formula,
+    quiet: bool,
+) !void {
+    try writeLine(w, scratch, "{s}: stable {s}\n", .{ f.name, f.version });
+    if (f.desc.len != 0) try writeLine(w, scratch, "{s}\n", .{f.desc});
+    if (f.homepage.len != 0) try writeLine(w, scratch, "{s}\n", .{f.homepage});
+    try encodeInstallHint(w, scratch, f.name, quiet);
+    if (f.tap.len != 0) try writeLine(w, scratch, "From: {s}\n", .{f.tap});
+    if (f.dependencies.len != 0) {
+        w.writeAll("Dependencies: ") catch {};
+        for (f.dependencies, 0..) |dep, i| {
+            if (i != 0) w.writeAll(", ") catch {};
+            w.writeAll(dep) catch {};
+        }
+        w.writeAll("\n") catch {};
+    }
+}
+
+pub fn encodeApiCaskHuman(
+    w: anytype,
+    scratch: []u8,
+    c: *const cask_mod.Cask,
+    quiet: bool,
+) !void {
+    try writeLine(w, scratch, "{s}: {s} (cask)\n", .{ c.token, c.version });
+    if (c.name.len != 0) try writeLine(w, scratch, "Name: {s}\n", .{c.name});
+    if (c.desc.len != 0) try writeLine(w, scratch, "{s}\n", .{c.desc});
+    if (c.homepage.len != 0) try writeLine(w, scratch, "{s}\n", .{c.homepage});
+    try encodeInstallHint(w, scratch, c.token, quiet);
+    if (c.url.len != 0) try writeLine(w, scratch, "URL: {s}\n", .{c.url});
+}
+
+pub fn encodeApiFormulaJson(w: anytype, f: *const formula_mod.Formula) !void {
+    try w.print(
+        "{{\"name\":\"{s}\",\"type\":\"formula\",\"installed\":false,\"version\":\"{s}\",\"desc\":\"{s}\",\"homepage\":\"{s}\",\"tap\":\"{s}\",\"dependencies\":[",
+        .{ f.name, f.version, f.desc, f.homepage, f.tap },
+    );
+    for (f.dependencies, 0..) |dep, i| {
+        if (i != 0) try w.writeAll(",");
+        try w.print("\"{s}\"", .{dep});
+    }
+    try w.writeAll("]}\n");
+}
+
+pub fn encodeApiCaskJson(w: anytype, c: *const cask_mod.Cask) !void {
+    try w.print(
+        "{{\"name\":\"{s}\",\"type\":\"cask\",\"installed\":false,\"version\":\"{s}\",\"full_name\":\"{s}\",\"desc\":\"{s}\",\"homepage\":\"{s}\",\"url\":\"{s}\"}}\n",
+        .{ c.token, c.version, c.name, c.desc, c.homepage, c.url },
+    );
+}
+
+/// Emit the "Not installed" line and (unless `quiet`) a runnable
+/// install hint. Only triggered on the API-metadata path, where we
+/// know the package actually exists upstream — suggesting `malt
+/// install` for something the Homebrew API doesn't recognise would
+/// just lead the user in a loop. Both `malt` and its short alias
+/// `mt` are surfaced so readers of this line learn the alias exists
+/// without having to consult --help.
+pub fn encodeInstallHint(
+    w: anytype,
+    scratch: []u8,
+    name: []const u8,
+    quiet: bool,
+) !void {
+    if (quiet) {
+        try w.writeAll("Not installed\n");
+        return;
+    }
+    writeLine(
+        w,
+        scratch,
+        "Not installed. Run: malt install {s}  (or: mt install {s})\n",
+        .{ name, name },
+    ) catch {
+        try w.writeAll("Not installed\n");
+    };
+}
+
+/// Convenience: format a line into `scratch` and write it to `w`.
+/// Same safety profile as the existing `bufPrint` + `writeAll`
+/// pattern used elsewhere in this file — avoids duplicating the
+/// 4 KiB stack buffer at every call site.
+fn writeLine(w: anytype, scratch: []u8, comptime fmt: []const u8, args: anytype) !void {
+    const line = std.fmt.bufPrint(scratch, fmt, args) catch return;
+    try w.writeAll(line);
+}
+
+/// Open the malt database if present. Returns `null` for any failure
+/// (missing parent directory, permission error, corrupt file) so the
+/// caller can degrade to a stateless response instead of bailing.
+pub fn openDb(prefix: []const u8) ?sqlite.Database {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return null;
+    return sqlite.Database.open(db_path) catch null;
+}
+
+/// Minimal JSON shape for the "no installed record" case. Mirrors the
+/// `installed=false` branch of `writeJsonInfo` without needing a live
+/// sqlite statement — used when the DB is missing or the package has
+/// simply never been installed.
+fn writeJsonNotInstalled(
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    stdout: std.fs.File,
+) !void {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    const w = buf.writer(allocator);
+    try w.writeAll("{\"name\":\"");
+    try w.writeAll(name);
+    try w.writeAll("\",\"type\":\"formula\",\"installed\":false}\n");
+    stdout.writeAll(buf.items) catch {};
 }
 
 fn writeHumanInfo(

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -35,6 +35,7 @@ pub const bundle_runner = @import("core/bundle/runner.zig");
 pub const cli_services = @import("cli/services.zig");
 pub const cli_bundle = @import("cli/bundle.zig");
 pub const cli_help = @import("cli/help.zig");
+pub const cli_info = @import("cli/info.zig");
 pub const cli_list = @import("cli/list.zig");
 pub const cli_tap = @import("cli/tap.zig");
 pub const tap = @import("core/tap.zig");

--- a/tests/info_test.zig
+++ b/tests/info_test.zig
@@ -1,0 +1,176 @@
+//! malt — info command tests
+//!
+//! `mt info` is read-only metadata — it must tolerate a prefix without
+//! a pre-existing database (e.g. a fresh install on a new machine)
+//! instead of failing with "Failed to open database". These tests
+//! pin that behavior via the `openDb` helper.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const info = malt.cli_info;
+
+test "openDb returns null when the prefix has no db/ directory" {
+    // Fresh prefix with no db/ subdir at all — SQLite's OPEN_CREATE
+    // cannot create intermediate dirs, so the open must fail and
+    // the helper must turn that into a null instead of an error.
+    const prefix = "/tmp/malt_info_test_missing_db";
+    std.fs.deleteTreeAbsolute(prefix) catch {};
+    try std.fs.makeDirAbsolute(prefix);
+    defer std.fs.deleteTreeAbsolute(prefix) catch {};
+
+    try testing.expect(info.openDb(prefix) == null);
+}
+
+test "openDb succeeds and returns a usable handle when db/ exists" {
+    const prefix = "/tmp/malt_info_test_ok_db";
+    std.fs.deleteTreeAbsolute(prefix) catch {};
+    try std.fs.makeDirAbsolute(prefix);
+    var db_buf: [512]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_buf, "{s}/db", .{prefix});
+    try std.fs.makeDirAbsolute(db_dir);
+    defer std.fs.deleteTreeAbsolute(prefix) catch {};
+
+    var db = info.openDb(prefix) orelse return error.ExpectedDatabase;
+    defer db.close();
+}
+
+test "openDb returns null when the prefix itself does not exist" {
+    // A completely absent prefix path — typical when MALT_PREFIX is
+    // pointed at a freshly-minted directory that hasn't been
+    // populated by any malt command yet.
+    const prefix = "/tmp/malt_info_test_no_prefix_at_all";
+    std.fs.deleteTreeAbsolute(prefix) catch {};
+    try testing.expect(info.openDb(prefix) == null);
+}
+
+// --- install hint --------------------------------------------------------
+
+test "encodeInstallHint surfaces both malt and mt invocations" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    var scratch: [512]u8 = undefined;
+    try info.encodeInstallHint(buf.writer(testing.allocator), &scratch, "wget", false);
+    try testing.expectEqualStrings(
+        "Not installed. Run: malt install wget  (or: mt install wget)\n",
+        buf.items,
+    );
+}
+
+test "encodeInstallHint collapses to a bare line in quiet mode" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    var scratch: [512]u8 = undefined;
+    try info.encodeInstallHint(buf.writer(testing.allocator), &scratch, "wget", true);
+    try testing.expectEqualStrings("Not installed\n", buf.items);
+}
+
+// --- API-metadata encoders -----------------------------------------------
+
+const malt_formula = @import("malt").formula;
+const malt_cask = @import("malt").cask;
+
+const FORMULA_FIXTURE =
+    \\{
+    \\  "name":"wget",
+    \\  "full_name":"wget",
+    \\  "tap":"homebrew/core",
+    \\  "desc":"Internet file retriever",
+    \\  "homepage":"https://www.gnu.org/software/wget/",
+    \\  "license":"GPL-3.0-or-later",
+    \\  "revision":0,
+    \\  "versions":{"stable":"1.24.5"},
+    \\  "dependencies":["libidn2","openssl@3"],
+    \\  "keg_only":false,
+    \\  "post_install_defined":false
+    \\}
+;
+
+const CASK_FIXTURE =
+    \\{
+    \\  "token":"firefox",
+    \\  "name":["Mozilla Firefox"],
+    \\  "version":"149.0.2",
+    \\  "desc":"Web browser",
+    \\  "homepage":"https://www.mozilla.org/firefox/",
+    \\  "url":"https://example.com/firefox.dmg",
+    \\  "sha256":"deadbeef",
+    \\  "auto_updates":false
+    \\}
+;
+
+test "encodeApiFormulaHuman includes metadata and install hint" {
+    // parseFormula allocates a few auxiliary slices (dependencies,
+    // oldnames) outside of its `Parsed` tree, and the public
+    // `Formula.deinit` only frees the tree — so driving this with a
+    // single-call test allocator would leak. An arena scoped to the
+    // test body cleans up everything in one shot.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var f = try malt_formula.parseFormula(arena.allocator(), FORMULA_FIXTURE);
+    defer f.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    var scratch: [4096]u8 = undefined;
+    try info.encodeApiFormulaHuman(buf.writer(testing.allocator), &scratch, &f, false);
+
+    const out = buf.items;
+    try testing.expect(std.mem.indexOf(u8, out, "wget: stable 1.24.5\n") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Internet file retriever") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "https://www.gnu.org/software/wget/") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Not installed. Run: malt install wget") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "From: homebrew/core") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Dependencies: libidn2, openssl@3\n") != null);
+}
+
+test "encodeApiFormulaJson produces the documented shape" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var f = try malt_formula.parseFormula(arena.allocator(), FORMULA_FIXTURE);
+    defer f.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    try info.encodeApiFormulaJson(buf.writer(testing.allocator), &f);
+
+    try testing.expectEqualStrings(
+        "{\"name\":\"wget\",\"type\":\"formula\",\"installed\":false,\"version\":\"1.24.5\",\"desc\":\"Internet file retriever\",\"homepage\":\"https://www.gnu.org/software/wget/\",\"tap\":\"homebrew/core\",\"dependencies\":[\"libidn2\",\"openssl@3\"]}\n",
+        buf.items,
+    );
+}
+
+test "encodeApiCaskHuman includes metadata and install hint" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var c = try malt_cask.parseCask(arena.allocator(), CASK_FIXTURE);
+    defer c.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    var scratch: [4096]u8 = undefined;
+    try info.encodeApiCaskHuman(buf.writer(testing.allocator), &scratch, &c, false);
+
+    const out = buf.items;
+    try testing.expect(std.mem.indexOf(u8, out, "firefox: 149.0.2 (cask)\n") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Name: Mozilla Firefox\n") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Web browser") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Not installed. Run: malt install firefox") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "URL: https://example.com/firefox.dmg") != null);
+}
+
+test "encodeApiCaskJson produces the documented shape" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var c = try malt_cask.parseCask(arena.allocator(), CASK_FIXTURE);
+    defer c.deinit();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    try info.encodeApiCaskJson(buf.writer(testing.allocator), &c);
+
+    try testing.expectEqualStrings(
+        "{\"name\":\"firefox\",\"type\":\"cask\",\"installed\":false,\"version\":\"149.0.2\",\"full_name\":\"Mozilla Firefox\",\"desc\":\"Web browser\",\"homepage\":\"https://www.mozilla.org/firefox/\",\"url\":\"https://example.com/firefox.dmg\"}\n",
+        buf.items,
+    );
+}


### PR DESCRIPTION
## What this changes
`mt info <pkg>` now works on a fresh machine (previously errored with \`Failed to open database\`), fetches Homebrew metadata for packages that aren't installed locally, and tells the user exactly how to install what they just looked up. `--json` actually produces JSON.

## Before
```
$ mt info go
  ✗ Failed to open database
```
```
$ mt info wget     # wget never installed on this machine
wget: not installed
```

## After
```
$ mt info go
go: stable 1.26.2
Open source programming language…
https://go.dev/
Not installed. Run: malt install go  (or: mt install go)
From: homebrew/core
```
```
$ mt --json info go
{"name":"go","type":"formula","installed":false,"version":"1.26.2", …}
```

## Notes
- The install hint surfaces both the full name and the `mt` alias so readers learn about it without consulting `--help`.
- `-q` drops the hint, keeping automation output clean.
- Packages that don't exist in the Homebrew API still print the bare "not installed" line (we don't suggest installing a package that doesn't exist).