### PR TITLE
ci: drop unused binary artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,6 @@ jobs:
       - name: Build universal binary
         run: zig build universal -Doptimize=ReleaseSafe
 
-      - name: Upload macOS binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: malt-macos-arm64
-          path: zig-out/bin/malt
-          retention-days: 7
-
   lint:
     name: Lint
     runs-on: macos-14


### PR DESCRIPTION
The CI step uploaded the built binary with 7-day retention, but releases are published by GoReleaser from a fresh build — nothing consumed this artifact. Removing a knob we don't use.