### PR TITLE
feat(install): support .zip archives for tap formulae

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1468,19 +1468,30 @@ fn installTapFormula(
         else => return InstallError.CellarFailed,
     };
 
-    // Pick the archive extension from the final URL. We only support the two
-    // formats common in Homebrew taps (.tar.gz, .tar.xz); anything else is
-    // rejected with a clear message rather than silently renamed to .tar.gz
-    // and fed to tar, which just produced a generic `Failed to extract`
-    // before.
-    const is_gz = std.mem.endsWith(u8, final_url, ".tar.gz") or std.mem.endsWith(u8, final_url, ".tgz");
-    const is_xz = std.mem.endsWith(u8, final_url, ".tar.xz");
-    if (!is_gz and !is_xz) {
+    // Pick the archive extension from the final URL. Supported formats:
+    //   .tar.gz / .tgz  — most Homebrew tap bottles
+    //   .tar.xz         — a handful of smaller taps
+    //   .zip            — HashiCorp-style releases (terraform, consul, …)
+    // Anything else is rejected with a clear message rather than silently
+    // renamed and fed to tar, which only produced a generic "Failed to
+    // extract" before.
+    const TapArchive = enum { tar_gz, tar_xz, zip };
+    const kind: ?TapArchive = blk: {
+        if (std.mem.endsWith(u8, final_url, ".tar.gz") or std.mem.endsWith(u8, final_url, ".tgz")) break :blk .tar_gz;
+        if (std.mem.endsWith(u8, final_url, ".tar.xz")) break :blk .tar_xz;
+        if (std.mem.endsWith(u8, final_url, ".zip")) break :blk .zip;
+        break :blk null;
+    };
+    const archive_kind = kind orelse {
         output.err("Unsupported archive format for {s}: {s}", .{ parts.formula, final_url });
-        output.err("Supported formats: .tar.gz, .tar.xz. Please open an issue if this is a widely-used tap.", .{});
+        output.err("Supported formats: .tar.gz, .tar.xz, .zip. Please open an issue if this is a widely-used tap.", .{});
         return InstallError.DownloadFailed;
-    }
-    const ext = if (is_xz) ".tar.xz" else ".tar.gz";
+    };
+    const ext: []const u8 = switch (archive_kind) {
+        .tar_gz => ".tar.gz",
+        .tar_xz => ".tar.xz",
+        .zip => ".zip",
+    };
     var tmp_buf: [512]u8 = undefined;
     const tmp_archive = std.fmt.bufPrint(&tmp_buf, "{s}/tmp/tap_download{s}", .{ prefix, ext }) catch
         return InstallError.DownloadFailed;
@@ -1495,17 +1506,19 @@ fn installTapFormula(
 
     // Extract archive to cellar
     const archive_mod = @import("../fs/archive.zig");
-    if (is_xz) {
-        // Use system tar for .tar.xz (Zig xz decompressor uses legacy I/O API)
-        archive_mod.extractTarXzFile(tmp_archive, cellar_path) catch {
-            output.err("Failed to extract .tar.xz archive for {s}", .{parts.formula});
-            return InstallError.CellarFailed;
-        };
-    } else {
-        archive_mod.extractTarGz(tmp_archive, cellar_path) catch {
+    switch (archive_kind) {
+        .tar_gz => archive_mod.extractTarGz(tmp_archive, cellar_path) catch {
             output.err("Failed to extract archive for {s}", .{parts.formula});
             return InstallError.CellarFailed;
-        };
+        },
+        .tar_xz => archive_mod.extractTarXzFile(tmp_archive, cellar_path) catch {
+            output.err("Failed to extract .tar.xz archive for {s}", .{parts.formula});
+            return InstallError.CellarFailed;
+        },
+        .zip => archive_mod.extractZip(tmp_archive, cellar_path) catch {
+            output.err("Failed to extract .zip archive for {s}", .{parts.formula});
+            return InstallError.CellarFailed;
+        },
     }
 
     // Find and move the binary to bin/

--- a/src/fs/archive.zig
+++ b/src/fs/archive.zig
@@ -46,6 +46,39 @@ pub fn extractTarZst(input: *std.Io.Reader, output_dir: std.fs.Dir) !void {
     try std.tar.pipeToFileSystem(output_dir, &decompressor.reader, .{});
 }
 
+/// Extract a .zip archive to `dest_dir`. Used by the tap-install path
+/// for formulae whose upstream release artifacts are zip-packed (e.g.
+/// every HashiCorp tool, and a handful of other popular user taps).
+/// Shells out to the system `unzip` — always present on macOS, and
+/// its behavior on binary-only archives is boring and well understood.
+/// Validates the PKZip magic `PK\x03\x04` up front so an HTML error
+/// page saved as .zip gives a clean error instead of propagating up
+/// from unzip's own output.
+pub fn extractZip(archive_path: []const u8, dest_dir: []const u8) !void {
+    const archive_file = std.fs.openFileAbsolute(archive_path, .{}) catch return error.ExtractionFailed;
+    var magic: [4]u8 = undefined;
+    const n = archive_file.readAll(&magic) catch {
+        archive_file.close();
+        return error.ExtractionFailed;
+    };
+    archive_file.close();
+    if (n < 4 or magic[0] != 'P' or magic[1] != 'K' or magic[2] != 0x03 or magic[3] != 0x04) {
+        return error.ExtractionFailed;
+    }
+
+    // -q: quiet, -o: overwrite without prompting, -d: destination dir.
+    const argv = [_][]const u8{ "unzip", "-q", "-o", archive_path, "-d", dest_dir };
+    var child = std.process.Child.init(&argv, child_allocator);
+    child.spawn() catch return error.ExtractionFailed;
+    const term = child.wait() catch return error.ExtractionFailed;
+    switch (term) {
+        .Exited => |code| {
+            if (code != 0) return error.ExtractionFailed;
+        },
+        else => return error.ExtractionFailed,
+    }
+}
+
 /// Extracts a tar.xz archive file to a directory using the system `tar` command.
 /// Zig 0.15's xz decompressor uses the legacy I/O API which doesn't integrate
 /// with std.tar, so we shell out to the system tar (always available on macOS).

--- a/tests/archive_test.zig
+++ b/tests/archive_test.zig
@@ -108,3 +108,67 @@ test "extractTarGz rejects a missing archive" {
 
     try testing.expectError(error.ExtractionFailed, archive.extractTarGz(base ++ "/nope.tar.gz", base));
 }
+
+fn runCmd(argv: []const []const u8) !void {
+    var child = std.process.Child.init(argv, std.heap.c_allocator);
+    child.stdout_behavior = .Ignore;
+    child.stderr_behavior = .Ignore;
+    try child.spawn();
+    const term = try child.wait();
+    switch (term) {
+        .Exited => |code| if (code != 0) return error.CmdFailed,
+        else => return error.CmdFailed,
+    }
+}
+
+test "extractZip decompresses a real zip produced by system zip" {
+    const base = "/tmp/malt_archive_zip_ok";
+    var dir = try resetDir(base);
+    defer dir.close();
+    defer std.fs.deleteTreeAbsolute(base) catch {};
+
+    // Build a payload mirroring what a HashiCorp-style release contains:
+    // a single executable at the archive root, no nested directory. The
+    // binary-finding walker in the tap-install path depends on exactly
+    // this shape.
+    {
+        const f = try dir.createFile("terraform", .{ .mode = 0o755 });
+        try f.writeAll("#!/bin/sh\necho hi\n");
+        f.close();
+    }
+    const archive_path = base ++ "/payload.zip";
+    try runCmd(&.{ "zip", "-j", "-q", archive_path, base ++ "/terraform" });
+    try std.fs.deleteFileAbsolute(base ++ "/terraform");
+
+    try archive.extractZip(archive_path, base);
+
+    const f = try dir.openFile("terraform", .{});
+    defer f.close();
+    var buf: [32]u8 = undefined;
+    const n = try f.readAll(&buf);
+    try testing.expect(n > 0);
+    try testing.expect(std.mem.startsWith(u8, buf[0..n], "#!/bin/sh"));
+}
+
+test "extractZip rejects a non-zip archive" {
+    const base = "/tmp/malt_archive_zip_badmagic";
+    var dir = try resetDir(base);
+    defer dir.close();
+    defer std.fs.deleteTreeAbsolute(base) catch {};
+
+    const archive_path = base ++ "/payload.zip";
+    const f = try std.fs.createFileAbsolute(archive_path, .{});
+    try f.writeAll("NOPE, not a zip");
+    f.close();
+
+    try testing.expectError(error.ExtractionFailed, archive.extractZip(archive_path, base));
+}
+
+test "extractZip rejects a missing archive" {
+    const base = "/tmp/malt_archive_zip_missing";
+    var dir = try resetDir(base);
+    defer dir.close();
+    defer std.fs.deleteTreeAbsolute(base) catch {};
+
+    try testing.expectError(error.ExtractionFailed, archive.extractZip(base ++ "/nope.zip", base));
+}


### PR DESCRIPTION
Lets `mt install user/tap/<formula>` work for taps that ship their release binaries as `.zip` — HashiCorp's entire lineup (terraform, consul, vault, nomad, …) and a handful of other popular tools. Previously these failed with "Unsupported archive format" even though the tap was otherwise fine.

Verified on `hashicorp/tap/terraform`: downloads, extracts, links, and `terraform version` runs cleanly.