### PR TITLE
feat(uses): reverse-dependency query command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ malt uninstall wget
 
 ## Command Reference
 
+> [!NOTE]
 > The examples below use `mt` (the shorter alias). All commands work identically with `malt`.
 
 ### `mt install`
@@ -137,7 +138,7 @@ mt install <package> [<package> ...]     # multiple packages
 | `--quiet`, `-q`     | Suppress all output except errors                 |
 | `--json`            | Output result as JSON                             |
 
-> [!INFO]
+> [!NOTE]
 > **Post-install scripts run natively.** malt includes a built-in interpreter that executes Homebrew `post_install` blocks in Zig — no Ruby required. Packages like `node`, `openssl`, `fontconfig`, and `docbook` are fully configured at install time. For the small number of scripts the interpreter doesn't cover, add `--use-system-ruby` to delegate to any available Ruby, or use `brew install` as a fallback. See [Post-Install DSL Interpreter](#post-install-dsl-interpreter) for details.
 
 ### `mt uninstall`
@@ -252,6 +253,16 @@ mt search <query>
 mt search <query> --formula
 mt search <query> --cask
 mt search <query> --json
+```
+
+### `mt uses`
+
+Show installed packages that depend on a given formula. Default is direct dependents only; `--recursive` walks the transitive closure.
+
+```bash
+mt uses <formula>
+mt uses --recursive <formula>
+mt uses <formula> --json
 ```
 
 ### `mt doctor`

--- a/build.zig
+++ b/build.zig
@@ -100,6 +100,7 @@ pub fn build(b: *std.Build) void {
         "tests/list_test.zig",
         "tests/search_test.zig",
         "tests/info_test.zig",
+        "tests/uses_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -84,7 +84,7 @@ pub const bash_script =
     \\    words=("${COMP_WORDS[@]}")
     \\    cword=$COMP_CWORD
     \\
-    \\    local commands="install uninstall remove upgrade update outdated list ls info search doctor tap untap migrate rollback link unlink run version completions backup restore purge services bundle help"
+    \\    local commands="install uninstall remove upgrade update outdated list ls info search uses doctor tap untap migrate rollback link unlink run version completions backup restore purge services bundle help"
     \\    local global_flags="--verbose -v --quiet -q --json --dry-run --help -h --version"
     \\
     \\    # Find the first non-flag word after the program — that's the subcommand.
@@ -144,6 +144,7 @@ pub const bash_script =
     \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --json --quiet -q" ;;
     \\        info)             cmd_flags="--formula --cask --json" ;;
     \\        search)           cmd_flags="--formula --cask --json" ;;
+    \\        uses)             cmd_flags="--recursive -r --json --quiet -q" ;;
     \\        migrate|rollback) cmd_flags="--dry-run" ;;
     \\        link)             cmd_flags="--overwrite --force -f" ;;
     \\        services)         cmd_flags="--tail --stderr --system --json" ;;
@@ -193,6 +194,7 @@ pub const zsh_script =
     \\        'ls:List installed packages (alias for list)'
     \\        'info:Show detailed package information'
     \\        'search:Search formulas and casks'
+    \\        'uses:Show installed packages that depend on a formula'
     \\        'doctor:System health check'
     \\        'tap:Manage taps'
     \\        'untap:Remove a tap'
@@ -419,6 +421,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n __malt_needs_command -a ls          -d 'List installed packages (alias)'
     \\    complete -c $__malt_bin -n __malt_needs_command -a info        -d 'Show detailed package information'
     \\    complete -c $__malt_bin -n __malt_needs_command -a search      -d 'Search formulas and casks'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a uses        -d 'Show packages that depend on a formula'
     \\    complete -c $__malt_bin -n __malt_needs_command -a doctor      -d 'System health check'
     \\    complete -c $__malt_bin -n __malt_needs_command -a tap         -d 'Manage taps'
     \\    complete -c $__malt_bin -n __malt_needs_command -a untap       -d 'Remove a tap'
@@ -483,6 +486,11 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command search' -l formula -d 'Formulas only'
     \\    complete -c $__malt_bin -n '__malt_using_command search' -l cask    -d 'Casks only'
     \\    complete -c $__malt_bin -n '__malt_using_command search' -l json    -d 'JSON output'
+    \\
+    \\    # uses
+    \\    complete -c $__malt_bin -n '__malt_using_command uses' -l recursive -s r -d 'Include transitive dependents'
+    \\    complete -c $__malt_bin -n '__malt_using_command uses' -l json               -d 'JSON output'
+    \\    complete -c $__malt_bin -n '__malt_using_command uses' -l quiet     -s q    -d 'Suppress status messages'
     \\
     \\    # migrate / rollback
     \\    complete -c $__malt_bin -n '__malt_using_command migrate'    -l dry-run -d 'Preview'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -36,6 +36,7 @@ fn helpFor(command: []const u8) []const u8 {
         .{ "backup", backup_help },
         .{ "restore", restore_help },
         .{ "purge", purge_help },
+        .{ "uses", uses_help },
     });
     return map.get(command) orelse "No help available.\n";
 }
@@ -308,5 +309,24 @@ const restore_help =
     \\
     \\Example:
     \\  malt restore malt-backup-2026-04-10T14-32-05.txt
+    \\
+;
+
+const uses_help =
+    \\Usage: malt uses <formula> [flags]
+    \\
+    \\Show installed packages that depend on <formula>. By default only
+    \\direct dependents are shown — pass --recursive for the transitive
+    \\closure.
+    \\
+    \\Flags:
+    \\  --recursive, -r   Include transitive dependents
+    \\  --json            Output as JSON
+    \\  --quiet, -q       Suppress status messages
+    \\
+    \\Examples:
+    \\  malt uses openssl@3
+    \\  malt uses --recursive icu4c@78
+    \\  malt --json uses node@20
     \\
 ;

--- a/src/cli/uses.zig
+++ b/src/cli/uses.zig
@@ -1,0 +1,175 @@
+//! malt — uses command
+//! Show installed packages that depend on a given formula.
+
+const std = @import("std");
+const sqlite = @import("../db/sqlite.zig");
+const schema = @import("../db/schema.zig");
+const atomic = @import("../fs/atomic.zig");
+const output = @import("../ui/output.zig");
+const color = @import("../ui/color.zig");
+const cli_info = @import("info.zig");
+const help = @import("help.zig");
+
+pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
+    if (help.showIfRequested(args, "uses")) return;
+
+    // Parse flags. `--json` is consumed by the global parser and read
+    // off the `output` module, mirroring the pattern in `info`.
+    var recursive = false;
+    var target: ?[]const u8 = null;
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--recursive") or std.mem.eql(u8, arg, "-r")) {
+            recursive = true;
+        } else if (arg.len > 0 and arg[0] != '-') {
+            if (target == null) target = arg;
+        }
+    }
+
+    const name = target orelse {
+        output.err("Usage: mt uses <formula>", .{});
+        return;
+    };
+
+    const json_mode = output.isJson();
+
+    const prefix = atomic.maltPrefix();
+    var db_opt: ?sqlite.Database = cli_info.openDb(prefix);
+    defer if (db_opt) |*d| d.close();
+
+    const stdout = std.fs.File.stdout();
+
+    // Without a local DB nothing is installed, so nothing can "use"
+    // anything. Emit an empty result in the shape each mode expects
+    // rather than erroring — same graceful-degradation contract as
+    // `mt info` on a fresh prefix.
+    var dependents: [][]const u8 = &.{};
+    defer freeDependents(allocator, dependents);
+
+    if (db_opt) |*db| {
+        schema.initSchema(db) catch {};
+        dependents = collectDependents(allocator, db, name, recursive) catch &.{};
+    }
+
+    if (json_mode) {
+        try writeJson(allocator, stdout, name, dependents);
+    } else {
+        try writeHuman(stdout, name, dependents);
+    }
+}
+
+/// Walk the dependencies table to collect every installed keg that
+/// directly (or transitively, if `recursive`) depends on `target`.
+/// The returned slice is caller-owned; each element is an
+/// `allocator.dupe`'d copy of the keg name, so the caller must free
+/// both the slice and every entry.
+pub fn collectDependents(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    target: []const u8,
+    recursive: bool,
+) ![][]const u8 {
+    var names: std.StringHashMap(void) = .init(allocator);
+    defer names.deinit();
+
+    var frontier: std.ArrayList([]const u8) = .empty;
+    defer frontier.deinit(allocator);
+    try frontier.append(allocator, try allocator.dupe(u8, target));
+    defer {
+        // Anything that never made it into `names` (e.g. the initial
+        // target itself, or a node rejected as a cycle) still owns
+        // its bytes via this frontier. Free what the hash map didn't
+        // steal so we don't leak on early returns.
+        for (frontier.items) |f| allocator.free(f);
+    }
+
+    while (frontier.items.len > 0) {
+        const current = frontier.orderedRemove(0);
+        defer allocator.free(current);
+
+        var stmt = db.prepare(
+            "SELECT k.name FROM kegs k " ++
+                "JOIN dependencies d ON d.keg_id = k.id " ++
+                "WHERE d.dep_name = ?1 ORDER BY k.name;",
+        ) catch continue;
+        defer stmt.finalize();
+        stmt.bindText(1, current) catch continue;
+
+        while (stmt.step() catch false) {
+            const raw = stmt.columnText(0) orelse continue;
+            const dep = std.mem.sliceTo(raw, 0);
+            if (names.contains(dep)) continue;
+
+            const owned = try allocator.dupe(u8, dep);
+            errdefer allocator.free(owned);
+            try names.put(owned, {});
+            if (recursive) try frontier.append(allocator, try allocator.dupe(u8, dep));
+        }
+    }
+
+    // Sort the keys for deterministic output — both CLI readability
+    // and test assertions depend on it. StringHashMap iteration
+    // order is unspecified.
+    var out: std.ArrayList([]const u8) = .empty;
+    errdefer freeDependents(allocator, out.items);
+    try out.ensureTotalCapacity(allocator, names.count());
+    var it = names.keyIterator();
+    while (it.next()) |k| try out.append(allocator, k.*);
+    std.mem.sort([]const u8, out.items, {}, lessThanSlice);
+    return out.toOwnedSlice(allocator);
+}
+
+fn lessThanSlice(_: void, a: []const u8, b: []const u8) bool {
+    return std.mem.lessThan(u8, a, b);
+}
+
+/// Free a slice produced by `collectDependents`: both the outer slice
+/// and every name it holds.
+pub fn freeDependents(allocator: std.mem.Allocator, deps: [][]const u8) void {
+    for (deps) |d| allocator.free(d);
+    allocator.free(deps);
+}
+
+pub fn writeHuman(stdout: std.fs.File, target: []const u8, dependents: [][]const u8) !void {
+    if (dependents.len == 0) {
+        var buf: [512]u8 = undefined;
+        const line = std.fmt.bufPrint(
+            &buf,
+            "No installed formula uses {s}.\n",
+            .{target},
+        ) catch return;
+        stdout.writeAll(line) catch {};
+        return;
+    }
+    const use_color = color.isColorEnabled();
+    for (dependents) |d| {
+        if (use_color) stdout.writeAll(color.Style.cyan.code()) catch {};
+        stdout.writeAll("  \xe2\x96\xb8 ") catch {};
+        if (use_color) stdout.writeAll(color.Style.reset.code()) catch {};
+        stdout.writeAll(d) catch {};
+        stdout.writeAll("\n") catch {};
+    }
+}
+
+pub fn writeJson(
+    allocator: std.mem.Allocator,
+    stdout: std.fs.File,
+    target: []const u8,
+    dependents: [][]const u8,
+) !void {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    try encodeJson(buf.writer(allocator), target, dependents);
+    stdout.writeAll(buf.items) catch {};
+}
+
+/// Pure encoder: emits `{"formula":"<target>","uses":["a","b"]}\n`.
+/// Exposed for tests so the output shape can be asserted without a
+/// live file descriptor.
+pub fn encodeJson(w: anytype, target: []const u8, dependents: [][]const u8) !void {
+    try w.print("{{\"formula\":\"{s}\",\"uses\":[", .{target});
+    for (dependents, 0..) |d, i| {
+        if (i != 0) try w.writeAll(",");
+        try w.print("\"{s}\"", .{d});
+    }
+    try w.writeAll("]}\n");
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -36,6 +36,7 @@ pub const cli_services = @import("cli/services.zig");
 pub const cli_bundle = @import("cli/bundle.zig");
 pub const cli_help = @import("cli/help.zig");
 pub const cli_info = @import("cli/info.zig");
+pub const cli_uses = @import("cli/uses.zig");
 pub const cli_list = @import("cli/list.zig");
 pub const cli_tap = @import("cli/tap.zig");
 pub const tap = @import("core/tap.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -228,6 +228,7 @@ fn printUsage() void {
         \\  list          List installed packages
         \\  info          Show detailed package information
         \\  search        Search formulas and casks
+        \\  uses          Show installed packages that depend on a formula
         \\  doctor        System health check
         \\  tap/untap     Manage taps
         \\  migrate       Import existing Homebrew installation

--- a/src/main.zig
+++ b/src/main.zig
@@ -36,6 +36,7 @@ const restore = @import("cli/restore.zig");
 const purge = @import("cli/purge.zig");
 const services = @import("cli/services.zig");
 const bundle = @import("cli/bundle.zig");
+const uses = @import("cli/uses.zig");
 
 const version_mod = @import("version.zig");
 const version = version_mod.value;
@@ -64,6 +65,7 @@ const Command = enum {
     purge,
     services,
     bundle,
+    uses,
     help,
     version,
 };
@@ -93,6 +95,7 @@ const command_map = std.StaticStringMap(Command).initComptime(.{
     .{ "purge", .purge },
     .{ "services", .services },
     .{ "bundle", .bundle },
+    .{ "uses", .uses },
     .{ "help", .help },
     .{ "--help", .help },
     .{ "-h", .help },
@@ -191,6 +194,7 @@ pub fn main() !void {
             .purge => try purge.execute(allocator, cmd_args),
             .services => try services.execute(allocator, cmd_args),
             .bundle => try bundle.execute(allocator, cmd_args),
+            .uses => try uses.execute(allocator, cmd_args),
             .version_cmd => {
                 // "mt version" — check for "mt version update" subcommand
                 if (cmd_args.len > 0 and std.mem.eql(u8, cmd_args[0], "update")) {

--- a/tests/uses_test.zig
+++ b/tests/uses_test.zig
@@ -1,0 +1,151 @@
+//! malt — uses command tests
+//!
+//! Covers the reverse-dep query, the BFS recursive walk, the JSON
+//! encoder shape, and the empty-result path. Each test builds a tiny
+//! kegs+dependencies graph in a temporary sqlite DB and asserts the
+//! caller-observable contract of `collectDependents` / `encodeJson`.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const uses = malt.cli_uses;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+
+fn makeDb(tag: []const u8) !sqlite.Database {
+    var path_buf: [256]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "/tmp/malt_uses_test_{s}.db", .{tag});
+    std.fs.deleteFileAbsolute(path) catch {};
+    var db = try sqlite.Database.open(path);
+    try schema.initSchema(&db);
+    return db;
+}
+
+/// Insert a keg row and return its id. Minimises boilerplate in the
+/// tests below — the full `install` path would be overkill here since
+/// we only exercise the dependencies table.
+fn insertKeg(db: *sqlite.Database, name: []const u8) !i64 {
+    var stmt = try db.prepare(
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)" ++
+            " VALUES (?1, ?1, '1.0', ?1, '/tmp/cellar') RETURNING id;",
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    _ = try stmt.step();
+    return stmt.columnInt(0);
+}
+
+fn addDep(db: *sqlite.Database, keg_id: i64, dep_name: []const u8) !void {
+    var stmt = try db.prepare(
+        "INSERT INTO dependencies (keg_id, dep_name) VALUES (?1, ?2);",
+    );
+    defer stmt.finalize();
+    try stmt.bindInt(1, keg_id);
+    try stmt.bindText(2, dep_name);
+    _ = try stmt.step();
+}
+
+test "collectDependents returns direct dependents, sorted" {
+    var db = try makeDb("direct");
+    defer db.close();
+
+    // openssl@3 is used by node@20 and wget; icu4c@78 is unrelated.
+    const node_id = try insertKeg(&db, "node@20");
+    const wget_id = try insertKeg(&db, "wget");
+    _ = try insertKeg(&db, "icu4c@78");
+    try addDep(&db, node_id, "openssl@3");
+    try addDep(&db, wget_id, "openssl@3");
+
+    const hits = try uses.collectDependents(testing.allocator, &db, "openssl@3", false);
+    defer uses.freeDependents(testing.allocator, hits);
+
+    try testing.expectEqual(@as(usize, 2), hits.len);
+    try testing.expectEqualStrings("node@20", hits[0]);
+    try testing.expectEqualStrings("wget", hits[1]);
+}
+
+test "collectDependents in non-recursive mode ignores transitive links" {
+    var db = try makeDb("notrans");
+    defer db.close();
+
+    // icu4c <- node <- whisper.  Non-recursive on icu4c should surface
+    // only `node`, not `whisper`.
+    const node_id = try insertKeg(&db, "node");
+    const whisper_id = try insertKeg(&db, "whisper");
+    try addDep(&db, node_id, "icu4c");
+    try addDep(&db, whisper_id, "node");
+
+    const hits = try uses.collectDependents(testing.allocator, &db, "icu4c", false);
+    defer uses.freeDependents(testing.allocator, hits);
+    try testing.expectEqual(@as(usize, 1), hits.len);
+    try testing.expectEqualStrings("node", hits[0]);
+}
+
+test "collectDependents --recursive walks the transitive closure" {
+    var db = try makeDb("recursive");
+    defer db.close();
+
+    // Graph: icu4c <- node <- {whisper, tauri}; tauri <- nothing.
+    const node_id = try insertKeg(&db, "node");
+    const whisper_id = try insertKeg(&db, "whisper");
+    const tauri_id = try insertKeg(&db, "tauri");
+    try addDep(&db, node_id, "icu4c");
+    try addDep(&db, whisper_id, "node");
+    try addDep(&db, tauri_id, "node");
+
+    const hits = try uses.collectDependents(testing.allocator, &db, "icu4c", true);
+    defer uses.freeDependents(testing.allocator, hits);
+    try testing.expectEqual(@as(usize, 3), hits.len);
+    try testing.expectEqualStrings("node", hits[0]);
+    try testing.expectEqualStrings("tauri", hits[1]);
+    try testing.expectEqualStrings("whisper", hits[2]);
+}
+
+test "collectDependents returns empty slice when nothing depends on target" {
+    var db = try makeDb("empty");
+    defer db.close();
+
+    _ = try insertKeg(&db, "standalone");
+
+    const hits = try uses.collectDependents(testing.allocator, &db, "not-a-real-formula", false);
+    defer uses.freeDependents(testing.allocator, hits);
+    try testing.expectEqual(@as(usize, 0), hits.len);
+}
+
+test "collectDependents tolerates cycles without spinning" {
+    // Shouldn't happen in a real malt DB (install refuses cyclic deps)
+    // but the BFS must terminate regardless so a corrupt database can
+    // never hang the command. `a` depends on `b`, `b` depends on `a`.
+    var db = try makeDb("cycle");
+    defer db.close();
+
+    const a_id = try insertKeg(&db, "a");
+    const b_id = try insertKeg(&db, "b");
+    try addDep(&db, a_id, "b");
+    try addDep(&db, b_id, "a");
+
+    const hits = try uses.collectDependents(testing.allocator, &db, "a", true);
+    defer uses.freeDependents(testing.allocator, hits);
+    try testing.expectEqual(@as(usize, 2), hits.len);
+    try testing.expectEqualStrings("a", hits[0]);
+    try testing.expectEqualStrings("b", hits[1]);
+}
+
+test "encodeJson shape: target + dependents array" {
+    const deps = [_][]const u8{ "node@20", "wget" };
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    try uses.encodeJson(buf.writer(testing.allocator), "openssl@3", @constCast(deps[0..]));
+
+    try testing.expectEqualStrings(
+        "{\"formula\":\"openssl@3\",\"uses\":[\"node@20\",\"wget\"]}\n",
+        buf.items,
+    );
+}
+
+test "encodeJson handles an empty dependents list" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    try uses.encodeJson(buf.writer(testing.allocator), "lonely", &.{});
+    try testing.expectEqualStrings("{\"formula\":\"lonely\",\"uses\":[]}\n", buf.items);
+}


### PR DESCRIPTION
Adds `mt uses <formula>` - shows which installed packages depend on a given formula and matches the shape of `brew uses --installed`.

## Examples
```bash
$ mt uses openssl@3
  ▸ node@20

$ mt uses --recursive icu4c@78
  ▸ node@20

$ mt --json uses openssl@3
{"formula":"openssl@3","uses":["node@20"]}
```

## Flags
- `--recursive`, `-r`: walk the transitive closure of dependents
- `--json`: machine-readable output
- `--quiet`, `-q`: suppress status messages

## Notes
- Graceful on a fresh prefix (no DB -> empty result, not an error).
- BFS terminates even if the dependency graph has a cycle.