### PR TITLE
fix(version-update): make self-update actually replace the binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,14 @@ builds:
 universal_binaries:
   - replace: true
     name_template: malt
+    # Drop the `mt` alias next to the universal binary so it ends up
+    # inside the release tarball. Matches what `zig build` produces,
+    # what install.sh creates via symlink, and what the homebrew_casks
+    # stanza below already declares — the release tarball was the
+    # only distribution path that shipped `malt` without `mt`.
+    hooks:
+      post:
+        - cmd: cp "{{ .Path }}" "{{ dir .Path }}/mt"
 
 archives:
   - formats: ["tar.gz"]
@@ -25,6 +33,11 @@ archives:
     files:
       - README.md
       - LICENSE
+      # Pick up the `mt` copy produced by the universal-binaries
+      # post-hook above. `dst: "."` lands it next to `malt` at the
+      # archive root instead of inside an `mt/` subdir.
+      - src: "dist/*_darwin_all*/mt"
+        dst: "."
     wrap_in_directory: true
 
 checksum:

--- a/build.zig
+++ b/build.zig
@@ -203,4 +203,10 @@ pub fn build(b: *std.Build) void {
 
     const install_universal = b.addInstallBinFile(universal_output, "malt");
     universal_step.dependOn(&install_universal.step);
+
+    // Ship the `mt` alias alongside the universal binary so the
+    // release tarball contains both names — matches the default
+    // `zig build` install layout and what the README promises.
+    const install_universal_mt = b.addInstallBinFile(universal_output, "mt");
+    universal_step.dependOn(&install_universal_mt.step);
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -99,7 +99,11 @@ else
   info "Latest version: ${VERSION}"
 
   # ── Download ────────────────────────────────────────────────────
-  ARCHIVE_NAME="malt_${VERSION}_Darwin_${ARCH_LABEL}.tar.gz"
+  # GoReleaser publishes a single universal binary as `_darwin_all`
+  # (lowercase os, arch literal `all`). `$ARCH_LABEL` is only used
+  # for the "Detected macOS …" banner; the tarball name no longer
+  # depends on the host arch.
+  ARCHIVE_NAME="malt_${VERSION}_darwin_all.tar.gz"
   DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST}/${ARCHIVE_NAME}"
 
   TMPDIR=$(mktemp -d)

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const client_mod = @import("../net/client.zig");
+const archive = @import("../fs/archive.zig");
 const output = @import("../ui/output.zig");
 
 const CURRENT_VERSION = @import("../version.zig").value;
@@ -40,17 +41,16 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     };
     defer parsed.deinit();
 
-    const obj = parsed.value.object;
-    const tag_val = obj.get("tag_name") orelse {
-        output.err("No tag_name in release", .{});
-        return;
-    };
-    const tag = switch (tag_val) {
-        .string => |s| s,
+    const obj = switch (parsed.value) {
+        .object => |o| o,
         else => {
-            output.err("Invalid tag_name", .{});
+            output.err("Release payload was not a JSON object", .{});
             return;
         },
+    };
+    const tag = strField(obj, "tag_name") orelse {
+        output.err("No tag_name in release", .{});
+        return;
     };
 
     // Strip leading "v" from tag
@@ -68,9 +68,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         return;
     }
 
-    // Find the right asset for this platform
+    // Find the right asset for this platform.
     const arch_str = if (builtin.cpu.arch == .aarch64) "arm64" else "x86_64";
-    const os_str = "Darwin";
 
     const assets_val = obj.get("assets") orelse {
         output.err("No assets in release", .{});
@@ -84,35 +83,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         },
     };
 
-    var download_url: ?[]const u8 = null;
-    for (assets.items) |asset| {
-        switch (asset) {
-            .object => |asset_obj| {
-                const name_val = asset_obj.get("name") orelse continue;
-                const asset_name = switch (name_val) {
-                    .string => |s| s,
-                    else => continue,
-                };
-
-                // Look for a matching binary (e.g., malt_0.2.0_Darwin_arm64.tar.gz)
-                if (std.mem.indexOf(u8, asset_name, os_str) != null and
-                    std.mem.indexOf(u8, asset_name, arch_str) != null and
-                    std.mem.endsWith(u8, asset_name, ".tar.gz"))
-                {
-                    const url_val = asset_obj.get("browser_download_url") orelse continue;
-                    download_url = switch (url_val) {
-                        .string => |s| s,
-                        else => continue,
-                    };
-                    break;
-                }
-            },
-            else => continue,
-        }
-    }
-
-    const url = download_url orelse {
-        output.err("No matching binary found for {s} {s}", .{ os_str, arch_str });
+    const url = pickAssetUrl(assets, arch_str) orelse {
+        output.err("No matching binary found for darwin {s}", .{arch_str});
         return;
     };
 
@@ -153,29 +125,32 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     };
     defer std.fs.deleteTreeAbsolute(tmp_dir) catch {};
 
-    const archive = @import("../fs/archive.zig");
-    archive.extractTarXzFile(tmp_path, tmp_dir) catch {
-        // Try tar.gz extraction via system tar as fallback
-        const argv = [_][]const u8{ "tar", "xf", tmp_path, "-C", tmp_dir };
-        var child = std.process.Child.init(&argv, std.heap.page_allocator);
-        child.spawn() catch {
-            output.err("Failed to extract update", .{});
-            return;
-        };
-        _ = child.wait() catch {};
+    archive.extractTarGz(tmp_path, tmp_dir) catch {
+        output.err("Failed to extract update", .{});
+        return;
     };
 
-    // Find the mt binary in the extracted contents
-    var mt_buf: [256]u8 = undefined;
-    const new_binary = std.fmt.bufPrint(&mt_buf, "{s}/mt", .{tmp_dir}) catch return;
-
-    std.fs.accessAbsolute(new_binary, .{}) catch {
-        output.err("Binary 'mt' not found in release archive", .{});
+    // Locate the replacement binary inside the extracted tree.
+    //
+    // GoReleaser wraps the binary in a versioned directory (e.g.
+    // `malt_0.3.1_darwin_all/malt`) and emits it under the long name
+    // `malt`, regardless of whether the user invoked `malt` or `mt`.
+    // Walk the extracted tree and take the first file whose basename
+    // matches either alias so both install layouts keep working.
+    //
+    // Separate stack buffers for `new_binary` and `self_exe` — the
+    // previous code shared one, and `selfExePath` overwrites the
+    // buffer, making the eventual copy a no-op `copy(self_exe,
+    // self_exe)` that silently failed to replace the binary.
+    var new_binary_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const new_binary = findReleaseBinary(allocator, tmp_dir, &new_binary_buf) orelse {
+        output.err("Binary 'malt' not found in release archive", .{});
         return;
     };
 
     // Find where the current binary lives
-    const self_exe = std.fs.selfExePath(&mt_buf) catch {
+    var self_exe_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const self_exe = std.fs.selfExePath(&self_exe_buf) catch {
         output.err("Cannot determine current binary path", .{});
         return;
     };
@@ -197,4 +172,87 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     output.info("Updated to {s}", .{latest});
+}
+
+/// Pick the right release asset download URL for the running machine.
+///
+/// The published tarballs follow GoReleaser's default naming scheme,
+/// which the old matcher got wrong on two axes: case (we're given
+/// `Darwin`, GoReleaser emits `darwin`) and architecture (the release
+/// is a single universal binary suffixed `_all`, not `_arm64`/`_x86_64`).
+///
+/// Accept both the traditional per-arch suffix and the universal
+/// `all` build, lowercasing the comparison so future releases that
+/// tweak the template don't silently break self-update again. Exposed
+/// so tests can pin the matching rules without spinning up an HTTP
+/// fixture.
+pub fn pickAssetUrl(assets: std.json.Array, arch_str: []const u8) ?[]const u8 {
+    for (assets.items) |asset| {
+        const obj = switch (asset) {
+            .object => |o| o,
+            else => continue,
+        };
+        const name = strField(obj, "name") orelse continue;
+        if (!matchesAssetName(name, arch_str)) continue;
+        return strField(obj, "browser_download_url");
+    }
+    return null;
+}
+
+/// True when `name` is a darwin tarball that covers the running arch
+/// (either a per-arch binary or a universal one). ASCII lowercasing
+/// matches GoReleaser's own normalization; package managers don't
+/// publish mixed-case release artifact names in practice.
+pub fn matchesAssetName(name: []const u8, arch_str: []const u8) bool {
+    if (!std.mem.endsWith(u8, name, ".tar.gz")) return false;
+
+    var lower_buf: [256]u8 = undefined;
+    if (name.len > lower_buf.len) return false;
+    const lower = std.ascii.lowerString(lower_buf[0..name.len], name);
+
+    if (std.mem.indexOf(u8, lower, "darwin") == null) return false;
+    if (std.mem.indexOf(u8, lower, arch_str) != null) return true;
+    // Universal binary covers every darwin arch.
+    if (std.mem.indexOf(u8, lower, "_all") != null) return true;
+    if (std.mem.indexOf(u8, lower, "universal") != null) return true;
+    return false;
+}
+
+/// Walk the extracted release tree and return the absolute path to
+/// the first file named `malt` or `mt`. `out_buf` is filled with the
+/// full path and a slice into it is returned; the caller keeps
+/// ownership of the buffer.
+///
+/// `allocator` is borrowed for `Dir.walk`'s internal path-tracking
+/// arena only — nothing produced by this function outlives the call.
+/// Returns null if the binary isn't present, which means the release
+/// packaging changed shape; callers should surface a clear error
+/// rather than silently no-op.
+pub fn findReleaseBinary(
+    allocator: std.mem.Allocator,
+    tmp_dir: []const u8,
+    out_buf: []u8,
+) ?[]const u8 {
+    var dir = std.fs.openDirAbsolute(tmp_dir, .{ .iterate = true }) catch return null;
+    defer dir.close();
+
+    var walker = dir.walk(allocator) catch return null;
+    defer walker.deinit();
+
+    while (walker.next() catch null) |entry| {
+        if (entry.kind != .file) continue;
+        const base = std.fs.path.basename(entry.path);
+        if (!std.mem.eql(u8, base, "malt") and !std.mem.eql(u8, base, "mt")) continue;
+        const full = std.fmt.bufPrint(out_buf, "{s}/{s}", .{ tmp_dir, entry.path }) catch return null;
+        return full;
+    }
+    return null;
+}
+
+fn strField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const v = obj.get(key) orelse return null;
+    return switch (v) {
+        .string => |s| s,
+        else => null,
+    };
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -37,6 +37,7 @@ pub const cli_bundle = @import("cli/bundle.zig");
 pub const cli_help = @import("cli/help.zig");
 pub const cli_info = @import("cli/info.zig");
 pub const cli_uses = @import("cli/uses.zig");
+pub const cli_version_update = @import("cli/version_update.zig");
 pub const cli_list = @import("cli/list.zig");
 pub const cli_tap = @import("cli/tap.zig");
 pub const tap = @import("core/tap.zig");

--- a/tests/version_update_test.zig
+++ b/tests/version_update_test.zig
@@ -1,13 +1,202 @@
 //! malt — version update tests
-//! Network-dependent tests deferred. Unit tests cover version parsing.
+//! Network-dependent tests deferred. Unit tests cover version parsing
+//! and the release-asset matcher — the latter is pure and was the
+//! silent failure point on every real self-update attempt before the
+//! fix (GoReleaser emits lowercase `darwin` + `_all` suffix, old
+//! matcher looked for `Darwin` + per-arch suffix).
 
 const std = @import("std");
 const testing = std.testing;
-const version_mod = @import("malt").version;
+const malt = @import("malt");
+const version_mod = malt.version;
+const updater = malt.cli_version_update;
 
 test "version value is non-empty and trimmed" {
     try testing.expect(version_mod.value.len > 0);
     // Should not have trailing whitespace
     try testing.expect(version_mod.value[version_mod.value.len - 1] != '\n');
     try testing.expect(version_mod.value[version_mod.value.len - 1] != ' ');
+}
+
+// --- asset matcher --------------------------------------------------------
+
+test "matchesAssetName accepts goreleaser's darwin_all tarball" {
+    // This is the exact name shape published by our release workflow.
+    // Regression for the old matcher that required `Darwin` + an
+    // explicit arch, which missed this asset on every invocation.
+    try testing.expect(updater.matchesAssetName("malt_0.3.1_darwin_all.tar.gz", "arm64"));
+    try testing.expect(updater.matchesAssetName("malt_0.3.1_darwin_all.tar.gz", "x86_64"));
+}
+
+test "matchesAssetName accepts per-arch tarballs for either arch" {
+    try testing.expect(updater.matchesAssetName("malt_0.3.1_darwin_arm64.tar.gz", "arm64"));
+    try testing.expect(updater.matchesAssetName("malt_0.3.1_darwin_x86_64.tar.gz", "x86_64"));
+}
+
+test "matchesAssetName accepts capitalized darwin (legacy name shape)" {
+    // GoReleaser's template is configurable — callers may switch back
+    // to the capitalized form. Lowercasing keeps both shapes working.
+    try testing.expect(updater.matchesAssetName("malt_0.3.1_Darwin_arm64.tar.gz", "arm64"));
+}
+
+test "matchesAssetName rejects non-darwin builds" {
+    try testing.expect(!updater.matchesAssetName("malt_0.3.1_linux_arm64.tar.gz", "arm64"));
+    try testing.expect(!updater.matchesAssetName("malt_0.3.1_windows_x86_64.tar.gz", "x86_64"));
+}
+
+test "matchesAssetName rejects the wrong arch on a per-arch build" {
+    try testing.expect(!updater.matchesAssetName("malt_0.3.1_darwin_x86_64.tar.gz", "arm64"));
+    try testing.expect(!updater.matchesAssetName("malt_0.3.1_darwin_arm64.tar.gz", "x86_64"));
+}
+
+test "matchesAssetName rejects the non-tarball sibling assets" {
+    // Release artefact set always includes the tarball plus checksums
+    // and signatures. Only the tarball should ever be picked.
+    try testing.expect(!updater.matchesAssetName("checksums.txt", "arm64"));
+    try testing.expect(!updater.matchesAssetName("malt_0.3.1_darwin_all.zip", "arm64"));
+    try testing.expect(!updater.matchesAssetName("malt_0.3.1_darwin_all.tar.gz.sig", "arm64"));
+}
+
+test "pickAssetUrl returns the browser_download_url of the first match" {
+    const json =
+        \\[
+        \\  {"name":"checksums.txt","browser_download_url":"https://example.com/checksums.txt"},
+        \\  {"name":"malt_0.3.1_darwin_all.tar.gz","browser_download_url":"https://example.com/malt.tgz"}
+        \\]
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    const arr = switch (parsed.value) {
+        .array => |a| a,
+        else => return error.Unexpected,
+    };
+    const url = updater.pickAssetUrl(arr, "arm64") orelse return error.NoMatch;
+    try testing.expectEqualStrings("https://example.com/malt.tgz", url);
+}
+
+test "pickAssetUrl returns null when nothing matches" {
+    const json =
+        \\[
+        \\  {"name":"malt_0.3.1_linux_arm64.tar.gz","browser_download_url":"https://example.com/linux.tgz"}
+        \\]
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    const arr = switch (parsed.value) {
+        .array => |a| a,
+        else => return error.Unexpected,
+    };
+    try testing.expect(updater.pickAssetUrl(arr, "arm64") == null);
+}
+
+// --- extracted-tarball layout ---------------------------------------------
+
+/// Reset a scratch directory tree for a single test. The tree under
+/// `path` is fully deleted so fixtures from previous runs (or earlier
+/// failed assertions) cannot influence the current one.
+fn resetTree(path: []const u8) !std.fs.Dir {
+    std.fs.deleteTreeAbsolute(path) catch {};
+    try std.fs.makeDirAbsolute(path);
+    return std.fs.openDirAbsolute(path, .{ .iterate = true });
+}
+
+fn touch(dir: std.fs.Dir, rel: []const u8, content: []const u8) !void {
+    const f = try dir.createFile(rel, .{});
+    defer f.close();
+    try f.writeAll(content);
+}
+
+test "findReleaseBinary locates malt nested under GoReleaser's versioned dir" {
+    // Mirrors the real tarball layout:
+    //   malt_0.3.1_darwin_all/
+    //     LICENSE
+    //     README.md
+    //     malt
+    // Confirms the walker descends into the wrap-in-directory layer
+    // and returns the binary's path, not just its basename.
+    const base = "/tmp/malt_findbin_nested";
+    var dir = try resetTree(base);
+    defer dir.close();
+    defer std.fs.deleteTreeAbsolute(base) catch {};
+
+    try dir.makePath("malt_0.3.1_darwin_all");
+    var sub = try dir.openDir("malt_0.3.1_darwin_all", .{});
+    defer sub.close();
+    try touch(sub, "LICENSE", "MIT");
+    try touch(sub, "README.md", "# malt");
+    try touch(sub, "malt", "binary-bytes");
+
+    var out_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const found = updater.findReleaseBinary(testing.allocator, base, &out_buf) orelse
+        return error.ExpectedMatch;
+
+    try testing.expect(std.mem.endsWith(u8, found, "/malt_0.3.1_darwin_all/malt"));
+    // The returned path must actually exist and be the file we wrote.
+    const f = try std.fs.openFileAbsolute(found, .{});
+    defer f.close();
+    var buf: [64]u8 = undefined;
+    const n = try f.readAll(&buf);
+    try testing.expectEqualStrings("binary-bytes", buf[0..n]);
+}
+
+test "findReleaseBinary accepts a flat layout with the binary at the root" {
+    // Future tarballs or third-party forks may drop the wrap-in-dir.
+    // Make sure the walker handles that shape too.
+    const base = "/tmp/malt_findbin_flat";
+    var dir = try resetTree(base);
+    defer dir.close();
+    defer std.fs.deleteTreeAbsolute(base) catch {};
+
+    try touch(dir, "malt", "binary-bytes");
+
+    var out_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const found = updater.findReleaseBinary(testing.allocator, base, &out_buf) orelse
+        return error.ExpectedMatch;
+    try testing.expect(std.mem.endsWith(u8, found, "/malt"));
+}
+
+test "findReleaseBinary accepts the `mt` alias when `malt` is absent" {
+    // Not the shape we ship today, but the self-update code has to
+    // survive a release that drops `malt` in favour of `mt` (or a
+    // user manually repackaging). Treating both names as equivalent
+    // avoids a "Binary not found" false negative.
+    const base = "/tmp/malt_findbin_mt_only";
+    var dir = try resetTree(base);
+    defer dir.close();
+    defer std.fs.deleteTreeAbsolute(base) catch {};
+
+    try dir.makePath("wrap");
+    var sub = try dir.openDir("wrap", .{});
+    defer sub.close();
+    try touch(sub, "mt", "binary-bytes");
+
+    var out_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const found = updater.findReleaseBinary(testing.allocator, base, &out_buf) orelse
+        return error.ExpectedMatch;
+    try testing.expect(std.mem.endsWith(u8, found, "/wrap/mt"));
+}
+
+test "findReleaseBinary returns null when the archive has no matching binary" {
+    // Simulates a future release where the binary name changed.
+    // The caller surfaces a clear "binary not found" error instead
+    // of silently no-op'ing the update.
+    const base = "/tmp/malt_findbin_missing";
+    var dir = try resetTree(base);
+    defer dir.close();
+    defer std.fs.deleteTreeAbsolute(base) catch {};
+
+    try touch(dir, "LICENSE", "MIT");
+    try touch(dir, "README.md", "# malt");
+
+    var out_buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expect(updater.findReleaseBinary(testing.allocator, base, &out_buf) == null);
+}
+
+test "findReleaseBinary returns null when the prefix does not exist" {
+    var out_buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expect(
+        updater.findReleaseBinary(testing.allocator, "/tmp/malt_findbin_absent_xyz_99", &out_buf) == null,
+    );
 }


### PR DESCRIPTION
## Summary 

`mt version update` has been silently broken since the first release. Three chained bugs meant even a successful-looking run would never replace the binary. This PR fixes them and makes every install path hand the user the same pair of commands (`malt` + `mt`).

### What was wrong

1. **Asset matcher missed every release.** The matcher expected `Darwin` + `arm64`|`x86_64` in the filename; GoReleaser publishes a lowercase, universal `malt_<ver>_darwin_all.tar.gz`. Every update attempt stopped at "No matching binary found".
2. **Shared stack buffer made the copy a no-op.** The path to the new binary and the path to the current binary both used the same `[256]u8`; `selfExePath` overwrote it, so `copyFileAbsolute(new_binary, self_exe)` effectively became `copyFileAbsolute(self_exe, self_exe)`.
3. **Wrong binary name / layout.** The code looked for a flat `\${tmp_dir}/mt`; GoReleaser wraps the binary as `malt_<ver>_darwin_all/malt`. Even with Bug 1 fixed, the copy would still fail with "Binary 'mt' not found".

### What's in the fix

- Case-insensitive darwin + arch match, with universal fallback (`_all`, `universal`).
- Separate stack buffers for `new_binary` and `self_exe`.
- A walker that finds `malt` (or `mt`) anywhere under the extracted tree.
- `extractTarGz` instead of `extractTarXzFile` on the .tar.gz download.

### Companion fix: \`mt\` everywhere

Second commit makes the `mt` alias part of every distribution so behavior matches the README claim:
- `zig build universal` now installs both (like plain `zig build` already did).
- `.goreleaser.yaml` drops `mt` next to `malt` inside the release tarball.
- `scripts/install.sh` corrects the tarball filename it downloads (same casing bug as the self-update matcher).

