### PR TITLE
docs: document bru cache caveat via Methodology callout

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -125,7 +125,8 @@ jobs:
           # bottles under ~/.bru/ and ~/Library/Caches/bru/, outside the
           # wiped /tmp/bru prefix, so its "cold" numbers reflect warm
           # cache + materialise rather than a real network fetch. The
-          # matching footnote lives in README.md outside the markers.
+          # matching explanation lives in README.md's Methodology
+          # paragraph (outside the markers).
           cat > /tmp/cold_table.md << TABLE
           <!-- BENCH:COLD:START -->
           ### Cold Install

--- a/README.md
+++ b/README.md
@@ -743,7 +743,12 @@ malt trades a few ms against correctness and features that the lighter tools ski
 - **Ad-hoc codesign on arm64 (~15 ms/pkg)** — every Mach-O patched to rewrite `/opt/homebrew` → `MALT_PREFIX` is re-signed so `dyld` will load it.
 - **Global install lock + pre-link conflict check (~3 ms)** — `flock` on `db/malt.lock` + a symlink-tree walk refusing to overwrite another keg's files.
 
-**Methodology.** `BENCH_TRUE_COLD=1` wipes each tool's prefix between cold and warm runs, so "cold" really means "no bottle in the store." See [`scripts/bench.sh`](scripts/bench.sh). One caveat: bru keeps its download cache under `~/.bru/` and `~/Library/Caches/bru/`, outside the wiped prefix, so bru's cold numbers reflect warm cache + materialise rather than a real network fetch. bru's warm row is apples-to-apples.
+> [!NOTE]
+> **Methodology.**
+>
+> `BENCH_TRUE_COLD=1` wipes each tool's prefix between cold and warm runs, so "cold" really means "no bottle in the store." See [`scripts/bench.sh`](scripts/bench.sh).
+>
+> **bru caveat (cells marked `‡`).** bru keeps its download cache under `~/.bru/` and `~/Library/Caches/bru/`, outside the wiped prefix, so its cold numbers reflect warm cache + materialise rather than a real network fetch. bru's warm row is apples-to-apples.
 
 ---
 


### PR DESCRIPTION
The cold-install table marks bru's cells with `‡` but the benchmark section never defined what the symbol meant. Promote the methodology paragraph to a `[!NOTE]` callout and anchor the `‡` explicitly, so readers don't have to guess which cells the caveat applies to.