### PR TITLE
fix(rollback): exit non-zero on failure

### DIFF
--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# scripts/e2e/smoke_test.sh
+#
+# Comprehensive CLI smoke test for malt. Exercises every command and subcommand
+# documented in README.md under an isolated MALT_PREFIX / MALT_CACHE, so the
+# user's real /opt/malt is never touched.
+#
+# Tiers:
+#   1. offline-only (help, version, completions, --help for every command)
+#   2. api-only    (update, search, info, outdated, doctor, list on empty)
+#   3. network     (install, uses, link/unlink, backup/restore, rollback,
+#                   uninstall, purge, bundle, tap/untap)
+#
+# Each test prints a PASS/FAIL line with the exact command string; a final
+# summary is emitted. Exit code 0 iff every test passes.
+#
+# Usage:
+#   ./scripts/e2e/smoke_test.sh                      # full run
+#   SMOKE_SKIP_NETWORK=1 ./scripts/e2e/smoke_test.sh # tiers 1+2 only
+#   MT_BIN=./zig-out/bin/mt ./scripts/e2e/smoke_test.sh
+
+set -uo pipefail
+
+MT_BIN="${MT_BIN:-./zig-out/bin/malt}"
+SKIP_NETWORK="${SMOKE_SKIP_NETWORK:-0}"
+
+if [[ ! -x "$MT_BIN" ]]; then
+    echo "smoke: $MT_BIN not found or not executable" >&2
+    echo "smoke: run 'zig build' first (or set MT_BIN)" >&2
+    exit 2
+fi
+MT_BIN="$(cd "$(dirname "$MT_BIN")" && pwd)/$(basename "$MT_BIN")"
+
+PREFIX=$(mktemp -d /tmp/mt.XXX)
+CACHE=$(mktemp -d /tmp/mc.XXX)
+LOGDIR=$(mktemp -d /tmp/ml.XXX)
+trap 'rm -rf "$PREFIX" "$CACHE" "$LOGDIR"' EXIT
+
+export MALT_PREFIX="$PREFIX"
+export MALT_CACHE="$CACHE"
+# Deterministic, machine-parseable output.
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+# run <tag> <expected-exit> -- <cmd...>
+#   Runs the command; passes if exit matches expected.
+run() {
+    local tag="$1" expected="$2"
+    shift 2
+    [[ "$1" == "--" ]] && shift
+    local log
+    log="$LOGDIR/$(printf '%s' "$tag" | tr -c 'A-Za-z0-9' _).log"
+    "$@" >"$log" 2>&1
+    local rc=$?
+    if [[ "$rc" == "$expected" ]]; then
+        printf '  PASS  [%s] %s\n' "$tag" "$*"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  [%s] expected exit=%s got=%s :: %s\n' "$tag" "$expected" "$rc" "$*"
+        printf '        log: %s\n' "$log"
+        sed -n '1,6p' "$log" | sed 's/^/        | /'
+        FAIL=$((FAIL + 1))
+        FAILURES+=("$tag")
+    fi
+}
+
+# run_ok <tag> -- <cmd...>   (expects exit 0)
+run_ok() {
+    local t="$1"
+    shift
+    run "$t" 0 "$@"
+}
+
+# run_grep <tag> <regex> -- <cmd...>
+#   Runs, expects exit 0 AND stdout/stderr match regex.
+run_grep() {
+    local tag="$1" pat="$2"
+    shift 2
+    [[ "$1" == "--" ]] && shift
+    local log
+    log="$LOGDIR/$(printf '%s' "$tag" | tr -c 'A-Za-z0-9' _).log"
+    "$@" >"$log" 2>&1
+    local rc=$?
+    if [[ "$rc" == 0 ]] && grep -qE "$pat" "$log"; then
+        printf '  PASS  [%s] %s\n' "$tag" "$*"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL  [%s] rc=%s, pattern /%s/ missing :: %s\n' "$tag" "$rc" "$pat" "$*"
+        printf '        log: %s\n' "$log"
+        sed -n '1,6p' "$log" | sed 's/^/        | /'
+        FAIL=$((FAIL + 1))
+        FAILURES+=("$tag")
+    fi
+}
+
+section() { printf '\n── %s ───────────────────────────────────────\n' "$1"; }
+
+# ── Tier 1: offline, no state ──────────────────────────────────────────────
+
+section "Tier 1 — offline, no network, no state"
+
+run_ok t1.version -- "$MT_BIN" version
+run_ok t1.help.top -- "$MT_BIN" --help
+run_ok t1.help.short -- "$MT_BIN" -h
+run_ok t1.help.cmd -- "$MT_BIN" help
+run_ok t1.completions.bash -- "$MT_BIN" completions bash
+run_ok t1.completions.zsh -- "$MT_BIN" completions zsh
+run_ok t1.completions.fish -- "$MT_BIN" completions fish
+
+# Unknown shell should error non-zero (README: "exit non-zero with an error").
+"$MT_BIN" completions tcsh >/dev/null 2>&1
+rc=$?
+if [[ "$rc" != 0 ]]; then
+    printf '  PASS  [t1.completions.bad] exit=%s (non-zero)\n' "$rc"
+    PASS=$((PASS + 1))
+else
+    printf '  FAIL  [t1.completions.bad] expected non-zero, got %s\n' "$rc"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("t1.completions.bad")
+fi
+
+# Per-command --help on everything documented.
+for cmd in install uninstall upgrade update outdated list info search uses \
+    doctor purge tap untap migrate backup restore services bundle \
+    rollback run link unlink version completions; do
+    run_ok "t1.help.$cmd" -- "$MT_BIN" "$cmd" --help
+done
+
+# Alias dispatch (`mt` and `malt` both installed in zig-out/bin).
+run_ok t1.alias.mt -- "$(dirname "$MT_BIN")/mt" version
+
+# `purge` with no scope must error per README.
+run t1.purge.no-scope 1 -- "$MT_BIN" purge
+
+# Unknown command should trigger brew fallback OR clean error (documented).
+run t1.unknown 1 -- "$MT_BIN" this-is-not-a-command
+
+# ── Tier 2: hits Homebrew API, no install ──────────────────────────────────
+
+section "Tier 2 — API-only (read commands, empty sandbox)"
+
+run_ok t2.list.empty -- "$MT_BIN" list
+run_ok t2.list.versions -- "$MT_BIN" list --versions
+run_ok t2.list.json -- "$MT_BIN" list --json
+run_grep t2.search.jq "jq" -- "$MT_BIN" search jq
+run_ok t2.search.json -- "$MT_BIN" search jq --json
+run_grep t2.info.jq "jq" -- "$MT_BIN" info jq
+run_ok t2.info.json -- "$MT_BIN" info jq --json
+run_ok t2.outdated -- "$MT_BIN" outdated
+run_ok t2.outdated.json -- "$MT_BIN" outdated --json
+run_ok t2.update -- "$MT_BIN" update
+run_ok t2.tap.list -- "$MT_BIN" tap
+
+# doctor: README documents exit 0/1/2 as valid semantics — accept all three on a
+# fresh sandbox (2 = "errors found" is the correct signal when the DB is absent).
+"$MT_BIN" doctor >"$LOGDIR/t2.doctor.log" 2>&1
+rc=$?
+if [[ "$rc" == 0 || "$rc" == 1 || "$rc" == 2 ]]; then
+    printf '  PASS  [t2.doctor] exit=%s (0/1/2 documented)\n' "$rc"
+    PASS=$((PASS + 1))
+else
+    printf '  FAIL  [t2.doctor] unexpected exit=%s\n' "$rc"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("t2.doctor")
+fi
+
+# Dry-run upgrade on empty prefix should succeed with nothing to do.
+run_ok t2.upgrade.dry -- "$MT_BIN" upgrade --dry-run
+
+# ── Tier 3: network installs (small, fast package: tree — 0 deps) ──────────
+
+if [[ "$SKIP_NETWORK" == "1" ]]; then
+    section "Tier 3 — SKIPPED (SMOKE_SKIP_NETWORK=1)"
+else
+    section "Tier 3 — network installs (sandboxed)"
+
+    run_ok t3.install.dry -- "$MT_BIN" install --dry-run tree
+    run_ok t3.install.tree -- "$MT_BIN" install tree
+    run_grep t3.list.has-tree "tree" -- "$MT_BIN" list
+    run_grep t3.info.tree "tree" -- "$MT_BIN" info tree
+    run_ok t3.uses.tree -- "$MT_BIN" uses tree
+    run_ok t3.uses.recursive -- "$MT_BIN" uses --recursive tree
+
+    # link is already done by install; unlink + re-link exercises the code path.
+    run_ok t3.unlink -- "$MT_BIN" unlink tree
+    run_ok t3.link -- "$MT_BIN" link tree
+    run_ok t3.link.overwrite -- "$MT_BIN" link tree --overwrite
+
+    # backup / restore round-trip.
+    run_ok t3.backup -- "$MT_BIN" backup --output "$LOGDIR/backup.txt"
+    run_ok t3.backup.versions -- "$MT_BIN" backup --versions --output "$LOGDIR/backup-v.txt"
+    run_ok t3.restore.dry -- "$MT_BIN" restore "$LOGDIR/backup.txt" --dry-run
+
+    # bundle round-trip.
+    run_ok t3.bundle.export -- "$MT_BIN" bundle export
+    run_ok t3.bundle.create -- "$MT_BIN" bundle create --format json "$LOGDIR/Maltfile.json"
+    run_ok t3.bundle.list -- "$MT_BIN" bundle list
+    run_ok t3.bundle.install.dry -- "$MT_BIN" bundle install --dry-run "$LOGDIR/Maltfile.json"
+
+    # run: already-installed path (no re-download).
+    run_ok t3.run.tree -- "$MT_BIN" run tree -- --version
+
+    # purge dry-runs only — never destructive here.
+    run_ok t3.purge.store.dry -- "$MT_BIN" purge --store-orphans --dry-run
+    run_ok t3.purge.house.dry -- "$MT_BIN" purge --housekeeping --dry-run
+    run_ok t3.purge.cache.dry -- "$MT_BIN" purge --cache=7 --dry-run
+
+    # uninstall — removes from sandbox.
+    run_ok t3.uninstall -- "$MT_BIN" uninstall tree
+
+    # After uninstall, rollback on an uninstalled package should fail cleanly.
+    run t3.rollback.none 1 -- "$MT_BIN" rollback tree
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+section "Summary"
+TOTAL=$((PASS + FAIL))
+printf 'Ran %d tests — %d passed, %d failed.\n' "$TOTAL" "$PASS" "$FAIL"
+if ((FAIL > 0)); then
+    printf 'Failures:\n'
+    for t in "${FAILURES[@]}"; do printf '  - %s\n' "$t"; done
+    printf 'Logs in: %s (preserved on failure)\n' "$LOGDIR"
+    trap - EXIT # keep logs for post-mortem
+    exit 1
+fi
+exit 0

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -12,12 +12,15 @@ const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
 const help = @import("help.zig");
 
+/// `error.Aborted` is returned on every user-facing failure. The caller has
+/// already emitted a message via `output.err`; main.zig catches it and exits
+/// non-zero without printing a stack trace.
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "rollback")) return;
 
     if (args.len == 0) {
         output.err("Usage: mt rollback <package>", .{});
-        return;
+        return error.Aborted;
     }
 
     const name = args[0];
@@ -29,24 +32,24 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     const prefix = atomic.maltPrefix();
 
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
+    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return error.Aborted;
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database", .{});
-        return;
+        return error.Aborted;
     };
     defer db.close();
-    schema.initSchema(&db) catch return;
+    schema.initSchema(&db) catch return error.Aborted;
 
     // Find current installed version
     var cur_stmt = db.prepare(
         "SELECT id, version, store_sha256 FROM kegs WHERE name = ?1 ORDER BY installed_at DESC LIMIT 1;",
-    ) catch return;
+    ) catch return error.Aborted;
     defer cur_stmt.finalize();
-    cur_stmt.bindText(1, name) catch return;
+    cur_stmt.bindText(1, name) catch return error.Aborted;
 
     if (!(cur_stmt.step() catch false)) {
         output.err("{s} is not installed", .{name});
-        return;
+        return error.Aborted;
     }
 
     const current_id = cur_stmt.columnInt(0);
@@ -56,11 +59,11 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // Look for other store entries that contain this formula
     // by scanning the store directory for entries that have {name}/ subdirectory
     var store_buf: [512]u8 = undefined;
-    const store_dir_path = std.fmt.bufPrint(&store_buf, "{s}/store", .{prefix}) catch return;
+    const store_dir_path = std.fmt.bufPrint(&store_buf, "{s}/store", .{prefix}) catch return error.Aborted;
 
     var store_dir = std.fs.openDirAbsolute(store_dir_path, .{ .iterate = true }) catch {
         output.err("Cannot read store directory", .{});
-        return;
+        return error.Aborted;
     };
     defer store_dir.close();
 
@@ -97,7 +100,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (entries.items.len == 0) {
         output.err("No previous version found for {s} in the store", .{name});
         output.info("The store only contains the current version ({s})", .{current_ver});
-        return;
+        return error.Aborted;
     }
 
     // Use the most recent previous version (last entry)
@@ -112,10 +115,10 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     // Acquire lock
     var lock_buf: [512]u8 = undefined;
-    const lock_path = std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix}) catch return;
+    const lock_path = std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix}) catch return error.Aborted;
     var lk = lock_mod.LockFile.acquire(lock_path, 30000) catch {
         output.err("Another mt process is running", .{});
-        return;
+        return error.Aborted;
     };
     defer lk.release();
 
@@ -133,17 +136,17 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // Materialize the old version from store
     const keg = cellar.materialize(allocator, prefix, target.sha256, name, target.version) catch {
         output.err("Failed to materialize {s} {s} from store", .{ name, target.version });
-        return;
+        return error.Aborted;
     };
 
     // Update DB: delete old record, insert new one
-    db.beginTransaction() catch return;
+    db.beginTransaction() catch return error.Aborted;
     errdefer db.rollback();
 
     {
-        var del = db.prepare("DELETE FROM kegs WHERE id = ?1;") catch return;
+        var del = db.prepare("DELETE FROM kegs WHERE id = ?1;") catch return error.Aborted;
         defer del.finalize();
-        del.bindInt(1, current_id) catch return;
+        del.bindInt(1, current_id) catch return error.Aborted;
         _ = del.step() catch {};
     }
 
@@ -151,19 +154,19 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         var ins = db.prepare(
             "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, install_reason)" ++
                 " VALUES (?1, ?1, ?2, ?3, ?4, 'direct');",
-        ) catch return;
+        ) catch return error.Aborted;
         defer ins.finalize();
-        ins.bindText(1, name) catch return;
-        ins.bindText(2, target.version) catch return;
-        ins.bindText(3, target.sha256) catch return;
-        ins.bindText(4, keg.path) catch return;
+        ins.bindText(1, name) catch return error.Aborted;
+        ins.bindText(2, target.version) catch return error.Aborted;
+        ins.bindText(3, target.sha256) catch return error.Aborted;
+        ins.bindText(4, keg.path) catch return error.Aborted;
         _ = ins.step() catch {};
     }
 
     // Get new keg_id for linking
-    var id_stmt = db.prepare("SELECT last_insert_rowid();") catch return;
+    var id_stmt = db.prepare("SELECT last_insert_rowid();") catch return error.Aborted;
     defer id_stmt.finalize();
-    const keg_id = if (id_stmt.step() catch false) id_stmt.columnInt(0) else return;
+    const keg_id = if (id_stmt.step() catch false) id_stmt.columnInt(0) else return error.Aborted;
 
     // Link the old version
     linker.link(keg.path, name, keg_id) catch {
@@ -173,7 +176,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         output.warn("Could not create opt link for {s}", .{name});
     };
 
-    db.commit() catch return;
+    db.commit() catch return error.Aborted;
 
     output.info("{s} rolled back to {s}", .{ name, target.version });
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -40,6 +40,7 @@ pub const cli_uses = @import("cli/uses.zig");
 pub const cli_version_update = @import("cli/version_update.zig");
 pub const cli_list = @import("cli/list.zig");
 pub const cli_tap = @import("cli/tap.zig");
+pub const cli_rollback = @import("cli/rollback.zig");
 pub const tap = @import("core/tap.zig");
 pub const bottle = @import("core/bottle.zig");
 pub const archive = @import("fs/archive.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -184,7 +184,12 @@ pub fn main() !void {
             .tap => try tap.execute(allocator, cmd_args),
             .untap => try tap.executeUntap(allocator, cmd_args),
             .migrate => try migrate.execute(allocator, cmd_args),
-            .rollback => try rollback.execute(allocator, cmd_args),
+            .rollback => rollback.execute(allocator, cmd_args) catch |e| switch (e) {
+                // User-facing failure already reported by rollback.execute —
+                // exit non-zero without a stack trace.
+                error.Aborted => std.process.exit(1),
+                else => return e,
+            },
             .link => try link_cmd.executeLink(allocator, cmd_args),
             .unlink => try link_cmd.executeUnlink(allocator, cmd_args),
             .run => try run_cmd.execute(allocator, cmd_args),

--- a/tests/rollback_test.zig
+++ b/tests/rollback_test.zig
@@ -1,11 +1,42 @@
 //! malt — rollback command tests
 //! Integration tests for rollback require a full install cycle.
-//! Unit tests here cover the DB query logic.
+//! Unit tests here cover the DB query logic and the error-exit-code contract
+//! (every user-facing failure must return `error.Aborted`, not a silent `void`).
 
 const std = @import("std");
 const testing = std.testing;
 const sqlite = @import("malt").sqlite;
 const schema = @import("malt").schema;
+const rollback = @import("malt").cli_rollback;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+fn setPrefix(v: [:0]const u8) void {
+    _ = c.setenv("MALT_PREFIX", v.ptr, 1);
+}
+fn unsetPrefix() void {
+    _ = c.unsetenv("MALT_PREFIX");
+}
+
+/// Create a sandboxed malt prefix with an initialized empty DB. Caller must
+/// `deleteTreeAbsolute` on the returned path.
+fn makeSandbox(path: [:0]const u8) !void {
+    std.fs.deleteTreeAbsolute(path) catch {};
+    try std.fs.makeDirAbsolute(path);
+
+    var db_sub_buf: [512]u8 = undefined;
+    const db_sub = try std.fmt.bufPrint(&db_sub_buf, "{s}/db", .{path});
+    try std.fs.makeDirAbsolute(db_sub);
+
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintZ(&db_path_buf, "{s}/db/malt.db", .{path});
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+}
 
 test "schema creates kegs table with expected columns" {
     const prefix = "/tmp/malt_rb_test";
@@ -26,6 +57,46 @@ test "schema creates kegs table with expected columns" {
 
     const name = stmt.columnText(0) orelse return error.TestUnexpectedResult;
     try testing.expectEqualStrings("wget", std.mem.sliceTo(name, 0));
+}
+
+test "rollback returns error.Aborted when no package name given" {
+    // Even without a prefix, the usage check fires first and must error.
+    const err = rollback.execute(testing.allocator, &.{});
+    try testing.expectError(error.Aborted, err);
+}
+
+test "rollback returns error.Aborted for package not installed" {
+    const prefix: [:0]const u8 = "/tmp/malt_rb_notinstalled";
+    try makeSandbox(prefix);
+    defer std.fs.deleteTreeAbsolute(prefix) catch {};
+
+    setPrefix(prefix);
+    defer unsetPrefix();
+
+    const args = [_][]const u8{"nonexistent-pkg"};
+    const err = rollback.execute(testing.allocator, &args);
+    try testing.expectError(error.Aborted, err);
+}
+
+test "rollback returns error.Aborted when no previous version exists in store" {
+    const prefix: [:0]const u8 = "/tmp/malt_rb_nostore";
+    try makeSandbox(prefix);
+    defer std.fs.deleteTreeAbsolute(prefix) catch {};
+
+    // Record an installed keg but deliberately omit the store/ directory so
+    // the store-scan path fails with "Cannot read store directory".
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintZ(&db_path_buf, "{s}/db/malt.db", .{prefix});
+    var db = try sqlite.Database.open(db_path);
+    try db.exec("INSERT INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason) VALUES ('wget', 'wget', '1.24', 0, 'homebrew/core', 'deadbeef', '/tmp/none', 'direct');");
+    db.close();
+
+    setPrefix(prefix);
+    defer unsetPrefix();
+
+    const args = [_][]const u8{"wget"};
+    const err = rollback.execute(testing.allocator, &args);
+    try testing.expectError(error.Aborted, err);
 }
 
 test "schema version table exists" {


### PR DESCRIPTION
## Summary

`malt rollback` would print an error like `x wget is not installed` but exit with code 0. Scripts, CI jobs, and shell one-liners (`malt rollback x && echo done`) could not tell the command had failed.

This makes every error path surface as a real non-zero exit, so automation around malt can trust the exit code.

No user-visible output changes, no behaviour changes on the happy path.

## What's in this PR

- **`malt rollback` now exits 1 on every failure** — missing argument, unknown package, no previous version in the store, lock contention, DB or filesystem errors.
- **New CLI smoke-test harness** (`scripts/e2e/smoke_test.sh`) — a sandboxed, tests run across every command and flag documented in the README. Runs against a throwaway `MALT_PREFIX`, so it never touches `/opt/malt`. Catches exactly this kind of regression going forward.

## Test plan

- [x] `zig build test` — all unit tests pass.
- [x] `./scripts/e2e/smoke_test.sh` — green.
- [x] `malt rollback` and `malt rollback <uninstalled>` exit 1 with a clean message (no stack trace).