### PR TITLE
fix(help): send --help output to stdout

### DIFF
--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -3,19 +3,21 @@
 
 const std = @import("std");
 
-/// Check if args contain -h or --help. If so, print help and return true.
+/// Check if args contain -h or --help. If so, print help to stdout (so the
+/// output is pipeable — `malt install --help | less`) and return true.
 pub fn showIfRequested(args: []const []const u8, command: []const u8) bool {
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
-            const text = helpFor(command);
-            std.fs.File.stderr().writeAll(text) catch {};
+            std.fs.File.stdout().writeAll(helpFor(command)) catch {};
             return true;
         }
     }
     return false;
 }
 
-fn helpFor(command: []const u8) []const u8 {
+/// Return the help text for a given command, or a generic fallback. Exposed
+/// so tests can assert content without spawning the binary.
+pub fn helpFor(command: []const u8) []const u8 {
     const map = std.StaticStringMap([]const u8).initComptime(.{
         .{ "install", install_help },
         .{ "uninstall", uninstall_help },

--- a/tests/help_test.zig
+++ b/tests/help_test.zig
@@ -35,3 +35,33 @@ test "showIfRequested covers every documented command (exercises every branch of
         try testing.expect(help.showIfRequested(&args, cmd));
     }
 }
+
+test "helpFor returns command-specific text for known commands" {
+    try testing.expect(std.mem.indexOf(u8, help.helpFor("install"), "malt install") != null);
+    try testing.expect(std.mem.indexOf(u8, help.helpFor("rollback"), "malt rollback") != null);
+    try testing.expect(std.mem.indexOf(u8, help.helpFor("purge"), "--housekeeping") != null);
+}
+
+test "helpFor falls back gracefully for unknown commands" {
+    try testing.expectEqualStrings("No help available.\n", help.helpFor("not-a-real-command"));
+}
+
+// Integration: verify that `malt <cmd> --help` writes to stdout (not stderr).
+// Relies on the pre-built binary under zig-out/bin/malt; skipped if absent.
+test "--help output lands on stdout, not stderr" {
+    const bin_path = "zig-out/bin/malt";
+    std.fs.cwd().access(bin_path, .{}) catch return error.SkipZigTest;
+
+    const result = try std.process.Child.run(.{
+        .allocator = testing.allocator,
+        .argv = &[_][]const u8{ bin_path, "install", "--help" },
+        .max_output_bytes = 1 << 16,
+    });
+    defer testing.allocator.free(result.stdout);
+    defer testing.allocator.free(result.stderr);
+
+    try testing.expectEqual(std.process.Child.Term{ .Exited = 0 }, result.term);
+    try testing.expect(result.stdout.len > 0);
+    try testing.expectEqual(@as(usize, 0), result.stderr.len);
+    try testing.expect(std.mem.indexOf(u8, result.stdout, "malt install") != null);
+}


### PR DESCRIPTION
## Summary

`malt install --help` (and every other per-command `--help`) wrote its text to **stderr**, while the top-level `malt --help` already wrote to **stdout**. This made in-tool behaviour inconsistent and broke piping:

```sh
malt install --help | less   # before: empty — nothing on stdout
malt install --help | less   # after:  pages the help text as expected
```

## What's in this PR

- Per-command `--help` text now goes to stdout.
- `helpFor` made public so tests can assert content without spawning the binary.
