### PR TITLE
ci: unblock unit tests on Zig 0.15 / macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,24 @@ jobs:
         run: zig build -Doptimize=ReleaseSafe
 
       - name: Run unit tests
-        run: zig build test
+        # `zig build test` deadlocks under Zig 0.15 (test-runner server
+        # protocol hangs once children finish), so install the test
+        # binaries and execute each one directly. Identical coverage.
+        run: |
+          set -euo pipefail
+          zig build test-bin
+          fail=0
+          for t in zig-out/test-bin/*_test; do
+              name=$(basename "$t")
+              if ! "$t"; then
+                  echo "FAIL: $name"
+                  fail=$((fail + 1))
+              fi
+          done
+          if [ "$fail" -ne 0 ]; then
+              echo "$fail test binary(ies) failed."
+              exit 1
+          fi
 
       - name: Smoke test — version flag
         run: ./zig-out/bin/malt --version

--- a/justfile
+++ b/justfile
@@ -35,7 +35,28 @@ install:
 # Run unit tests
 [group('test')]
 test:
-    zig build test
+    #!/usr/bin/env bash
+    # Build then run each test binary directly. Bypasses Zig 0.15's
+    # `zig build test` runner, which deadlocks on macOS in
+    # `Server.receiveMessage` once the test binaries finish their work
+    # (the parent build never sends "exit", children block on `readv`).
+    # Identical coverage, ~60s versus indefinite hang.
+    set -euo pipefail
+    zig build test-bin
+    fail=0
+    for t in zig-out/test-bin/*_test; do
+        name=$(basename "$t")
+        if ! "$t" >/tmp/malt_test_${name}.log 2>&1; then
+            echo "FAIL: $name"
+            tail -5 /tmp/malt_test_${name}.log | sed 's/^/  /'
+            fail=$((fail + 1))
+        fi
+    done
+    if [ "$fail" -ne 0 ]; then
+        echo "$fail test binary(ies) failed."
+        exit 1
+    fi
+    echo "All test binaries passed."
 
 # Run tests under kcov, print line-coverage percentage, and refresh
 # the README badge SVG at .github/badges/coverage.svg.
@@ -61,10 +82,7 @@ fmt:
 
 # Lint: format check + build + test
 [group('lint')]
-lint:
-    zig fmt --check src/ tests/
-    zig build
-    zig build test
+lint: fmt-check build test
 
 # ---------------------------------------------------------------------------
 # Git hooks


### PR DESCRIPTION
## Summary

`zig build test` deadlocks after the test binaries finish their work — the runner's server protocol leaves children blocked in `Server.receiveMessage` while the parent waits for them. The hang is reproducible on a recent macOS / Zig 0.15.x combination and affects both the local pre-push hook and CI's "Run unit tests" step.

This swaps the call sites to build the test binaries (`zig build test-bin`) and execute each one directly. Same coverage, predictable runtime (~60s), no protocol involved.

## What changes

- **`justfile`** — `test:` recipe builds + iterates the binaries; `lint:` reuses it.
- **`.github/workflows/ci.yml`** — "Run unit tests" step does the same loop.

No source code touched.
