### PR TITLE
fix(json): escape strings in --json output

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -101,6 +101,7 @@ pub fn build(b: *std.Build) void {
         "tests/search_test.zig",
         "tests/info_test.zig",
         "tests/uses_test.zig",
+        "tests/output_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -270,22 +270,38 @@ pub fn encodeApiCaskHuman(
 }
 
 pub fn encodeApiFormulaJson(w: anytype, f: *const formula_mod.Formula) !void {
-    try w.print(
-        "{{\"name\":\"{s}\",\"type\":\"formula\",\"installed\":false,\"version\":\"{s}\",\"desc\":\"{s}\",\"homepage\":\"{s}\",\"tap\":\"{s}\",\"dependencies\":[",
-        .{ f.name, f.version, f.desc, f.homepage, f.tap },
-    );
+    try w.writeAll("{\"name\":");
+    try output.jsonStr(w, f.name);
+    try w.writeAll(",\"type\":\"formula\",\"installed\":false,\"version\":");
+    try output.jsonStr(w, f.version);
+    try w.writeAll(",\"desc\":");
+    try output.jsonStr(w, f.desc);
+    try w.writeAll(",\"homepage\":");
+    try output.jsonStr(w, f.homepage);
+    try w.writeAll(",\"tap\":");
+    try output.jsonStr(w, f.tap);
+    try w.writeAll(",\"dependencies\":[");
     for (f.dependencies, 0..) |dep, i| {
         if (i != 0) try w.writeAll(",");
-        try w.print("\"{s}\"", .{dep});
+        try output.jsonStr(w, dep);
     }
     try w.writeAll("]}\n");
 }
 
 pub fn encodeApiCaskJson(w: anytype, c: *const cask_mod.Cask) !void {
-    try w.print(
-        "{{\"name\":\"{s}\",\"type\":\"cask\",\"installed\":false,\"version\":\"{s}\",\"full_name\":\"{s}\",\"desc\":\"{s}\",\"homepage\":\"{s}\",\"url\":\"{s}\"}}\n",
-        .{ c.token, c.version, c.name, c.desc, c.homepage, c.url },
-    );
+    try w.writeAll("{\"name\":");
+    try output.jsonStr(w, c.token);
+    try w.writeAll(",\"type\":\"cask\",\"installed\":false,\"version\":");
+    try output.jsonStr(w, c.version);
+    try w.writeAll(",\"full_name\":");
+    try output.jsonStr(w, c.name);
+    try w.writeAll(",\"desc\":");
+    try output.jsonStr(w, c.desc);
+    try w.writeAll(",\"homepage\":");
+    try output.jsonStr(w, c.homepage);
+    try w.writeAll(",\"url\":");
+    try output.jsonStr(w, c.url);
+    try w.writeAll("}\n");
 }
 
 /// Emit the "Not installed" line and (unless `quiet`) a runnable
@@ -345,9 +361,9 @@ fn writeJsonNotInstalled(
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(allocator);
     const w = buf.writer(allocator);
-    try w.writeAll("{\"name\":\"");
-    try w.writeAll(name);
-    try w.writeAll("\",\"type\":\"formula\",\"installed\":false}\n");
+    try w.writeAll("{\"name\":");
+    try output.jsonStr(w, name);
+    try w.writeAll(",\"type\":\"formula\",\"installed\":false}\n");
     stdout.writeAll(buf.items) catch {};
 }
 
@@ -411,9 +427,9 @@ fn writeJsonInfo(
     defer buf.deinit(allocator);
     const w = buf.writer(allocator);
 
-    try w.writeAll("{\"name\":\"");
-    try w.writeAll(name);
-    try w.writeAll("\",\"type\":\"formula\",\"installed\":");
+    try w.writeAll("{\"name\":");
+    try output.jsonStr(w, name);
+    try w.writeAll(",\"type\":\"formula\",\"installed\":");
     try w.writeAll(if (installed) "true" else "false");
 
     if (installed) {
@@ -422,15 +438,14 @@ fn writeJsonInfo(
         const pinned = stmt.columnBool(4);
         const installed_at = stmt.columnText(5);
 
-        try w.writeAll(",\"version\":\"");
-        try w.writeAll(if (ver) |v| std.mem.sliceTo(v, 0) else "");
-        try w.writeAll("\",\"tap\":\"");
-        try w.writeAll(if (tap) |t| std.mem.sliceTo(t, 0) else "");
-        try w.writeAll("\",\"pinned\":");
+        try w.writeAll(",\"version\":");
+        try output.jsonStr(w, if (ver) |v| std.mem.sliceTo(v, 0) else "");
+        try w.writeAll(",\"tap\":");
+        try output.jsonStr(w, if (tap) |t| std.mem.sliceTo(t, 0) else "");
+        try w.writeAll(",\"pinned\":");
         try w.writeAll(if (pinned) "true" else "false");
-        try w.writeAll(",\"installed_at\":\"");
-        try w.writeAll(if (installed_at) |d| std.mem.sliceTo(d, 0) else "");
-        try w.writeAll("\"");
+        try w.writeAll(",\"installed_at\":");
+        try output.jsonStr(w, if (installed_at) |d| std.mem.sliceTo(d, 0) else "");
     }
 
     try w.writeAll("}\n");
@@ -513,20 +528,20 @@ fn writeJsonCaskInfo(
     const auto_updates = stmt.columnBool(6);
     const installed_at = if (stmt.columnText(7)) |d| std.mem.sliceTo(d, 0) else "";
 
-    try w.writeAll("{\"name\":\"");
-    try w.writeAll(token);
-    try w.writeAll("\",\"type\":\"cask\",\"installed\":true,\"version\":\"");
-    try w.writeAll(ver);
-    try w.writeAll("\",\"full_name\":\"");
-    try w.writeAll(cask_name);
-    try w.writeAll("\",\"url\":\"");
-    try w.writeAll(url);
-    try w.writeAll("\",\"app_path\":\"");
-    try w.writeAll(app_path);
-    try w.writeAll("\",\"auto_updates\":");
+    try w.writeAll("{\"name\":");
+    try output.jsonStr(w, token);
+    try w.writeAll(",\"type\":\"cask\",\"installed\":true,\"version\":");
+    try output.jsonStr(w, ver);
+    try w.writeAll(",\"full_name\":");
+    try output.jsonStr(w, cask_name);
+    try w.writeAll(",\"url\":");
+    try output.jsonStr(w, url);
+    try w.writeAll(",\"app_path\":");
+    try output.jsonStr(w, app_path);
+    try w.writeAll(",\"auto_updates\":");
     try w.writeAll(if (auto_updates) "true" else "false");
-    try w.writeAll(",\"installed_at\":\"");
-    try w.writeAll(installed_at);
-    try w.writeAll("\"}\n");
+    try w.writeAll(",\"installed_at\":");
+    try output.jsonStr(w, installed_at);
+    try w.writeAll("}\n");
     stdout.writeAll(buf.items) catch {};
 }

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -223,18 +223,18 @@ fn writeFormulaRows(
         const pinned = stmt.columnBool(2);
         if (!first.*) try w.writeAll(",");
         first.* = false;
-        try w.writeAll("{\"name\":\"");
-        try w.writeAll(std.mem.sliceTo(name, 0));
-        try w.writeAll("\",\"version\":\"");
-        try w.writeAll(if (ver) |v| std.mem.sliceTo(v, 0) else "");
+        try w.writeAll("{\"name\":");
+        try output.jsonStr(w, std.mem.sliceTo(name, 0));
+        try w.writeAll(",\"version\":");
+        try output.jsonStr(w, if (ver) |v| std.mem.sliceTo(v, 0) else "");
         switch (shape) {
             .installed => {
-                try w.writeAll("\",\"type\":\"formula\",\"pinned\":");
+                try w.writeAll(",\"type\":\"formula\",\"pinned\":");
                 try w.writeAll(if (pinned) "true" else "false");
                 try w.writeAll("}");
             },
             .legacy => {
-                try w.writeAll("\",\"pinned\":");
+                try w.writeAll(",\"pinned\":");
                 try w.writeAll(if (pinned) "true" else "false");
                 try w.writeAll("}");
             },
@@ -254,22 +254,23 @@ fn writeCaskRows(
     while (stmt.step() catch false) {
         const token = stmt.columnText(0) orelse continue;
         const ver = stmt.columnText(1);
+        const ver_str: []const u8 = if (ver) |v| std.mem.sliceTo(v, 0) else "";
         if (!first.*) try w.writeAll(",");
         first.* = false;
         switch (shape) {
             .installed => {
-                try w.writeAll("{\"name\":\"");
-                try w.writeAll(std.mem.sliceTo(token, 0));
-                try w.writeAll("\",\"version\":\"");
-                try w.writeAll(if (ver) |v| std.mem.sliceTo(v, 0) else "");
-                try w.writeAll("\",\"type\":\"cask\"}");
+                try w.writeAll("{\"name\":");
+                try output.jsonStr(w, std.mem.sliceTo(token, 0));
+                try w.writeAll(",\"version\":");
+                try output.jsonStr(w, ver_str);
+                try w.writeAll(",\"type\":\"cask\"}");
             },
             .legacy => {
-                try w.writeAll("{\"token\":\"");
-                try w.writeAll(std.mem.sliceTo(token, 0));
-                try w.writeAll("\",\"version\":\"");
-                try w.writeAll(if (ver) |v| std.mem.sliceTo(v, 0) else "");
-                try w.writeAll("\"}");
+                try w.writeAll("{\"token\":");
+                try output.jsonStr(w, std.mem.sliceTo(token, 0));
+                try w.writeAll(",\"version\":");
+                try output.jsonStr(w, ver_str);
+                try w.writeAll("}");
             },
         }
     }

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -78,13 +78,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
                 if (!std.mem.eql(u8, ver_slice, latest)) {
                     if (!first) try w.writeAll(",");
                     first = false;
-                    try w.writeAll("{\"name\":\"");
-                    try w.writeAll(name_slice);
-                    try w.writeAll("\",\"installed\":\"");
-                    try w.writeAll(ver_slice);
-                    try w.writeAll("\",\"latest\":\"");
-                    try w.writeAll(latest);
-                    try w.writeAll("\",\"type\":\"formula\"}");
+                    try w.writeAll("{\"name\":");
+                    try output.jsonStr(w, name_slice);
+                    try w.writeAll(",\"installed\":");
+                    try output.jsonStr(w, ver_slice);
+                    try w.writeAll(",\"latest\":");
+                    try output.jsonStr(w, latest);
+                    try w.writeAll(",\"type\":\"formula\"}");
                 }
             }
 
@@ -146,12 +146,17 @@ fn checkOutdatedCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *
         if (!std.mem.eql(u8, installed_ver, cask.version)) {
             found_any = true;
             if (json_mode) {
-                var buf: [512]u8 = undefined;
-                const line = std.fmt.bufPrint(&buf, "{{\"name\":\"{s}\",\"installed\":\"{s}\",\"latest\":\"{s}\",\"type\":\"cask\"}}", .{
-                    token, installed_ver, cask.version,
-                }) catch continue;
-                stdout.writeAll(line) catch {};
-                stdout.writeAll("\n") catch {};
+                var buf: std.ArrayList(u8) = .empty;
+                defer buf.deinit(allocator);
+                const w = buf.writer(allocator);
+                w.writeAll("{\"name\":") catch continue;
+                output.jsonStr(w, token) catch continue;
+                w.writeAll(",\"installed\":") catch continue;
+                output.jsonStr(w, installed_ver) catch continue;
+                w.writeAll(",\"latest\":") catch continue;
+                output.jsonStr(w, cask.version) catch continue;
+                w.writeAll(",\"type\":\"cask\"}\n") catch continue;
+                stdout.writeAll(buf.items) catch {};
             } else {
                 var buf: [512]u8 = undefined;
                 const line = std.fmt.bufPrint(&buf, "{s} ({s}) < {s} [cask]\n", .{ token, installed_ver, cask.version }) catch continue;

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -226,15 +226,23 @@ fn emitJson(
 fn writeJson(w: anytype, field: []const u8, r: KindResults, query: []const u8) !void {
     var first = true;
     if (r.exact) {
-        try w.print("{{\"{s}\":\"{s}\"}}", .{ field, query });
+        try writeJsonObj(w, field, query);
         first = false;
     }
     for (r.matches) |m| {
         if (r.exact and std.mem.eql(u8, m, query)) continue;
         if (!first) try w.writeAll(",");
-        try w.print("{{\"{s}\":\"{s}\"}}", .{ field, m });
+        try writeJsonObj(w, field, m);
         first = false;
     }
+}
+
+fn writeJsonObj(w: anytype, field: []const u8, value: []const u8) !void {
+    try w.writeAll("{\"");
+    try w.writeAll(field);
+    try w.writeAll("\":");
+    try output.jsonStr(w, value);
+    try w.writeAll("}");
 }
 
 /// Write a single search result with the same ▸ prefix style used by `list`.

--- a/src/cli/uses.zig
+++ b/src/cli/uses.zig
@@ -166,10 +166,12 @@ pub fn writeJson(
 /// Exposed for tests so the output shape can be asserted without a
 /// live file descriptor.
 pub fn encodeJson(w: anytype, target: []const u8, dependents: [][]const u8) !void {
-    try w.print("{{\"formula\":\"{s}\",\"uses\":[", .{target});
+    try w.writeAll("{\"formula\":");
+    try output.jsonStr(w, target);
+    try w.writeAll(",\"uses\":[");
     for (dependents, 0..) |d, i| {
         if (i != 0) try w.writeAll(",");
-        try w.print("\"{s}\"", .{d});
+        try output.jsonStr(w, d);
     }
     try w.writeAll("]}\n");
 }

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -176,6 +176,43 @@ pub fn confirmTyped(expected: []const u8, prompt: []const u8) bool {
     return std.mem.eql(u8, input, expected);
 }
 
+/// Write `s` to `w` as a JSON string literal — surrounding quotes plus RFC 8259
+/// escapes for `"`, `\`, and control characters. Use this wherever handwritten
+/// JSON output embeds an identifier, tap name, version string, file path, or
+/// anything else that might contain special characters.
+///
+/// Kept as `anytype` so it works with both the legacy `std.io.GenericWriter`
+/// and the new `std.Io.Writer` interface; the common path is branch-free.
+pub fn jsonStr(w: anytype, s: []const u8) !void {
+    try w.writeAll("\"");
+    var start: usize = 0;
+    for (s, 0..) |byte, i| {
+        const escape: ?[]const u8 = switch (byte) {
+            '"' => "\\\"",
+            '\\' => "\\\\",
+            '\n' => "\\n",
+            '\r' => "\\r",
+            '\t' => "\\t",
+            0x08 => "\\b",
+            0x0c => "\\f",
+            else => null,
+        };
+        if (escape) |esc| {
+            if (i > start) try w.writeAll(s[start..i]);
+            try w.writeAll(esc);
+            start = i + 1;
+        } else if (byte < 0x20) {
+            if (i > start) try w.writeAll(s[start..i]);
+            var hex_buf: [6]u8 = undefined;
+            const hex = std.fmt.bufPrint(&hex_buf, "\\u{x:0>4}", .{byte}) catch unreachable;
+            try w.writeAll(hex);
+            start = i + 1;
+        }
+    }
+    if (start < s.len) try w.writeAll(s[start..]);
+    try w.writeAll("\"");
+}
+
 /// Write JSON to stdout
 pub fn jsonOutput(allocator: std.mem.Allocator, value: anytype) !void {
     var list: std.ArrayList(u8) = .empty;

--- a/tests/output_test.zig
+++ b/tests/output_test.zig
@@ -1,0 +1,66 @@
+//! malt — ui/output tests
+//! Pinpoint coverage for `output.jsonStr`, the helper every CLI command uses
+//! to emit JSON-safe string values. Verifies the RFC 8259 escape contract on
+//! adversarial inputs and round-trips the result through std.json to prove
+//! the bytes are accepted by a strict parser.
+
+const std = @import("std");
+const testing = std.testing;
+const output = @import("malt").output;
+
+fn encode(s: []const u8) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(testing.allocator);
+    try output.jsonStr(buf.writer(testing.allocator), s);
+    return buf.toOwnedSlice(testing.allocator);
+}
+
+test "jsonStr leaves plain ASCII alone" {
+    const got = try encode("openssl@3");
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("\"openssl@3\"", got);
+}
+
+test "jsonStr emits empty quoted string for empty input" {
+    const got = try encode("");
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("\"\"", got);
+}
+
+test "jsonStr escapes the seven RFC 8259 short-form characters" {
+    const got = try encode("a\"b\\c\nd\re\tf\x08g\x0ch");
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("\"a\\\"b\\\\c\\nd\\re\\tf\\bg\\fh\"", got);
+}
+
+test "jsonStr emits \\u00XX for control characters below 0x20" {
+    const got = try encode("\x01\x1f");
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("\"\\u0001\\u001f\"", got);
+}
+
+test "jsonStr passes UTF-8 bytes through unchanged" {
+    // emoji, accented letter — outside the escape set, must round-trip.
+    const got = try encode("café 🍺");
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("\"café 🍺\"", got);
+}
+
+test "jsonStr output round-trips through std.json parser" {
+    const inputs = [_][]const u8{
+        "name with \"quote\"",
+        "C:\\path\\to\\file",
+        "line\nbreak",
+        "\t\rmixed\x05controls",
+        "",
+        "café 🍺",
+    };
+    for (inputs) |s| {
+        const encoded = try encode(s);
+        defer testing.allocator.free(encoded);
+
+        const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, encoded, .{});
+        defer parsed.deinit();
+        try testing.expectEqualStrings(s, parsed.value.string);
+    }
+}

--- a/tests/uses_test.zig
+++ b/tests/uses_test.zig
@@ -149,3 +149,31 @@ test "encodeJson handles an empty dependents list" {
     try uses.encodeJson(buf.writer(testing.allocator), "lonely", &.{});
     try testing.expectEqualStrings("{\"formula\":\"lonely\",\"uses\":[]}\n", buf.items);
 }
+
+test "encodeJson escapes special characters in target and dependents" {
+    // A formula name containing a literal quote/backslash/newline would
+    // produce invalid JSON if the encoder concatenated raw bytes. Real
+    // formula names won't carry these, but tap-prefixed names and upstream
+    // metadata can — so the encoder must escape unconditionally.
+    const deps = [_][]const u8{ "weird\"name", "back\\slash", "with\nnewline" };
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    try uses.encodeJson(buf.writer(testing.allocator), "tap\"name", @constCast(deps[0..]));
+
+    // The exact expected bytes verify the escape contract precisely.
+    try testing.expectEqualStrings(
+        "{\"formula\":\"tap\\\"name\",\"uses\":[\"weird\\\"name\",\"back\\\\slash\",\"with\\nnewline\"]}\n",
+        buf.items,
+    );
+
+    // And the result must round-trip through a strict JSON parser.
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        std.mem.trimRight(u8, buf.items, "\n"),
+        .{},
+    );
+    defer parsed.deinit();
+    try testing.expectEqualStrings("tap\"name", parsed.value.object.get("formula").?.string);
+    try testing.expectEqual(@as(usize, 3), parsed.value.object.get("uses").?.array.items.len);
+}


### PR DESCRIPTION
## Summary

malt's `--json` output across `list`, `info`, `search`, `uses`, and `outdated` concatenated raw field values into the JSON document. A name, description, or URL containing a quote, backslash, or control character produced malformed JSON that parsers like `jq` reject — silently corrupting any pipeline that consumes malt's machine-readable output.

This PR introduces a single RFC 8259 string encoder, `output.jsonStr`, and routes every string field through it. Integers and booleans continue to be emitted directly (no escaping needed).

## Why this matters

Real-world triggers in the Homebrew ecosystem:

- Cask descriptions that contain `"quotes"` or apostrophes
- Formula homepages or download URLs with embedded special characters
- Tap names coming through the API that carry newlines or unicode punctuation

Before this PR, any of these would break `malt info <pkg> --json | jq .`. After this PR, every value is round-trippable through a strict JSON parser.
