### PR TITLE
fix(cli): exit non-zero on every user-facing failure

### DIFF
--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -37,7 +37,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     const name = pkg_name orelse {
         output.err("Usage: mt info <package>", .{});
-        return;
+        return error.Aborted;
     };
 
     // Open DB (optional). On a fresh machine the prefix's `db/` dir

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -194,6 +194,8 @@ fn downloadWorker(
         bar.finish();
         output.err("  Download failed: {s} (after {d} attempts)", .{ job.name, max_attempts });
         allocator.free(tmp_dir);
+        // Thread worker: caller inspects DownloadJob.success rather than
+        // receiving an error — exit the worker, let the coordinator abort.
         return;
     }
     bar.finish();
@@ -275,7 +277,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     };
 
     // Ensure required directories exist (Step 0)
-    ensureDirs(prefix);
+    ensureDirs(prefix) catch return error.Aborted;
 
     // Open database
     var db_path_buf: [512]u8 = undefined;
@@ -1252,13 +1254,13 @@ pub fn isInstalled(db: *sqlite.Database, name: []const u8) bool {
 }
 
 /// Ensure all required directories under prefix exist.
-pub fn ensureDirs(prefix: []const u8) void {
+pub fn ensureDirs(prefix: []const u8) !void {
     // Create the prefix directory itself first (e.g. /opt/malt)
     std.fs.makeDirAbsolute(prefix) catch |e| switch (e) {
         error.PathAlreadyExists => {},
         else => {
             output.err("Cannot create prefix directory {s} — you may need: sudo mkdir -p {s} && sudo chown $USER {s}", .{ prefix, prefix, prefix });
-            return;
+            return error.Aborted;
         },
     };
 

--- a/src/cli/link.zig
+++ b/src/cli/link.zig
@@ -15,7 +15,7 @@ pub fn executeLink(allocator: std.mem.Allocator, args: []const []const u8) !void
     if (args.len == 0) {
         output.err("Usage: mt link <formula>", .{});
         output.info("Create symlinks for an installed keg in the prefix (bin/, lib/, etc.)", .{});
-        return;
+        return error.Aborted;
     }
 
     const name = args[0];
@@ -30,7 +30,7 @@ pub fn executeLink(allocator: std.mem.Allocator, args: []const []const u8) !void
     const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database", .{});
-        return;
+        return error.Aborted;
     };
     defer db.close();
     schema.initSchema(&db) catch {};
@@ -38,7 +38,7 @@ pub fn executeLink(allocator: std.mem.Allocator, args: []const []const u8) !void
     // Look up the keg
     var stmt = db.prepare("SELECT id, version, cellar_path FROM kegs WHERE name = ?1 LIMIT 1;") catch {
         output.err("Database query failed", .{});
-        return;
+        return error.Aborted;
     };
     defer stmt.finalize();
     stmt.bindText(1, name) catch return;
@@ -46,13 +46,13 @@ pub fn executeLink(allocator: std.mem.Allocator, args: []const []const u8) !void
     const has_row = stmt.step() catch false;
     if (!has_row) {
         output.err("{s} is not installed", .{name});
-        return;
+        return error.Aborted;
     }
 
     const keg_id = stmt.columnInt(0);
     const cellar_path_raw = stmt.columnText(2) orelse {
         output.err("No cellar path recorded for {s}", .{name});
-        return;
+        return error.Aborted;
     };
     const cellar_path = std.mem.sliceTo(cellar_path_raw, 0);
     var linker = linker_mod.Linker.init(allocator, &db, prefix);
@@ -66,13 +66,13 @@ pub fn executeLink(allocator: std.mem.Allocator, args: []const []const u8) !void
                 output.err("  {s} already linked by {s}", .{ c.link_path, c.existing_keg });
             }
             output.info("Use --overwrite to replace existing links.", .{});
-            return;
+            return error.Aborted;
         }
     }
 
     linker.link(cellar_path, name, keg_id) catch {
         output.err("Failed to create symlinks for {s}", .{name});
-        return;
+        return error.Aborted;
     };
 
     // Also create the version from DB for opt link
@@ -95,7 +95,7 @@ pub fn executeUnlink(allocator: std.mem.Allocator, args: []const []const u8) !vo
         output.err("Usage: mt unlink <formula>", .{});
         output.info("Remove symlinks for an installed keg from the prefix.", .{});
         output.info("The keg remains installed in the Cellar.", .{});
-        return;
+        return error.Aborted;
     }
 
     const name = args[0];
@@ -105,7 +105,7 @@ pub fn executeUnlink(allocator: std.mem.Allocator, args: []const []const u8) !vo
     const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database", .{});
-        return;
+        return error.Aborted;
     };
     defer db.close();
     schema.initSchema(&db) catch {};
@@ -113,7 +113,7 @@ pub fn executeUnlink(allocator: std.mem.Allocator, args: []const []const u8) !vo
     // Look up the keg
     var stmt = db.prepare("SELECT id FROM kegs WHERE name = ?1 LIMIT 1;") catch {
         output.err("Database query failed", .{});
-        return;
+        return error.Aborted;
     };
     defer stmt.finalize();
     stmt.bindText(1, name) catch return;
@@ -121,7 +121,7 @@ pub fn executeUnlink(allocator: std.mem.Allocator, args: []const []const u8) !vo
     const has_row = stmt.step() catch false;
     if (!has_row) {
         output.err("{s} is not installed", .{name});
-        return;
+        return error.Aborted;
     }
 
     const keg_id = stmt.columnInt(0);
@@ -129,7 +129,7 @@ pub fn executeUnlink(allocator: std.mem.Allocator, args: []const []const u8) !vo
 
     linker.unlink(keg_id) catch {
         output.err("Failed to remove symlinks for {s}", .{name});
-        return;
+        return error.Aborted;
     };
 
     // Also remove opt/ symlink

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -46,7 +46,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var db_path_buf: [512]u8 = undefined;
     const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
     var db = sqlite.Database.open(db_path) catch {
-        output.err("Failed to open database", .{});
+        // Fresh prefix with no `db/` yet = nothing installed. Treat as
+        // empty output (rc=0), same contract as `ls` on an empty dir.
         return;
     };
     defer db.close();

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -52,7 +52,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     std.fs.accessAbsolute(brew_cellar, .{}) catch {
         output.err("No Homebrew installation found at {s}", .{brew_prefix});
-        return;
+        return error.Aborted;
     };
 
     output.info("Found Homebrew installation at {s}", .{brew_prefix});
@@ -60,7 +60,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // ── Step 2: Scan Cellar for installed kegs ──────────────────────
     var dir = std.fs.openDirAbsolute(brew_cellar, .{ .iterate = true }) catch {
         output.err("Cannot read Homebrew Cellar", .{});
-        return;
+        return error.Aborted;
     };
     defer dir.close();
 
@@ -96,20 +96,20 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     // ── Step 3: Initialize malt infrastructure ──────────────────────
     const prefix = atomic.maltPrefix();
-    ensureDirs(prefix);
+    ensureDirs(prefix) catch return error.Aborted;
 
     // Open database
     var db_path_buf: [512]u8 = undefined;
     const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database at {s}", .{db_path});
-        return;
+        return error.Aborted;
     };
     defer db.close();
 
     schema.initSchema(&db) catch {
         output.err("Failed to initialize database schema", .{});
-        return;
+        return error.Aborted;
     };
 
     // Acquire lock
@@ -117,7 +117,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return;
     var lk = lock_mod.LockFile.acquire(lock_path, 30000) catch {
         output.err("Another mt process is running. Wait or run mt doctor.", .{});
-        return;
+        return error.Aborted;
     };
     defer lk.release();
 
@@ -505,12 +505,12 @@ fn isInstalled(db: *sqlite.Database, name: []const u8) bool {
 }
 
 /// Ensure all required directories under prefix exist.
-fn ensureDirs(prefix: []const u8) void {
+fn ensureDirs(prefix: []const u8) !void {
     std.fs.makeDirAbsolute(prefix) catch |e| switch (e) {
         error.PathAlreadyExists => {},
         else => {
             output.err("Cannot create prefix directory {s}", .{prefix});
-            return;
+            return error.Aborted;
         },
     };
 

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -35,7 +35,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var db_path_buf: [512]u8 = undefined;
     const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
     var db = sqlite.Database.open(db_path) catch {
-        output.err("Failed to open database", .{});
+        // Fresh prefix: nothing installed = nothing to be outdated.
         return;
     };
     defer db.close();
@@ -44,7 +44,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // Set up API client
     const cache_dir = atomic.maltCacheDir(allocator) catch {
         output.err("Failed to determine cache directory", .{});
-        return;
+        return error.Aborted;
     };
     defer allocator.free(cache_dir);
 

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -20,7 +20,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (args.len == 0) {
         output.err("Usage: mt run <package> [-- <args...>]", .{});
         output.info("Example: mt run jq -- --version", .{});
-        return;
+        return error.Aborted;
     }
 
     const pkg_name = args[0];
@@ -48,7 +48,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
         // Already installed — just exec it
         output.info("Running installed {s}...", .{pkg_name});
-        return execBinary(bin_path, cmd_args);
+        return try execBinary(bin_path, cmd_args);
     }
 }
 
@@ -71,20 +71,20 @@ fn ephemeralRun(
     // Fetch formula
     const formula_json = api.fetchFormula(pkg_name) catch {
         output.err("Formula '{s}' not found", .{pkg_name});
-        return;
+        return error.Aborted;
     };
     defer allocator.free(formula_json);
 
     var formula = formula_mod.parseFormula(allocator, formula_json) catch {
         output.err("Failed to parse formula for '{s}'", .{pkg_name});
-        return;
+        return error.Aborted;
     };
     defer formula.deinit();
 
     // Select bottle
     const bottle = formula_mod.resolveBottle(allocator, &formula) catch {
         output.err("No bottle available for {s} on this platform", .{pkg_name});
-        return;
+        return error.Aborted;
     };
 
     // Set up GHCR
@@ -94,7 +94,7 @@ fn ephemeralRun(
     // Create temp dir
     const tmp_dir = atomic.createTempDir(allocator, "run") catch {
         output.err("Failed to create temp directory", .{});
-        return;
+        return error.Aborted;
     };
     defer {
         atomic.cleanupTempDir(tmp_dir);
@@ -120,7 +120,7 @@ fn ephemeralRun(
     output.info("Downloading {s} {s}...", .{ pkg_name, formula.version });
     _ = bottle_mod.download(allocator, &ghcr, &http, repo, digest, bottle.sha256, tmp_dir, null) catch {
         output.err("Failed to download {s}", .{pkg_name});
-        return;
+        return error.Aborted;
     };
 
     // Find the binary in the extracted contents
@@ -134,7 +134,7 @@ fn ephemeralRun(
 
     std.fs.accessAbsolute(bin_path, .{}) catch {
         output.err("Binary '{s}' not found in bottle", .{pkg_name});
-        return;
+        return error.Aborted;
     };
 
     // Make executable
@@ -148,10 +148,10 @@ fn ephemeralRun(
     const stderr = std.fs.File.stderr();
     stderr.writeAll("---\n") catch {};
 
-    execBinary(bin_path, cmd_args);
+    try execBinary(bin_path, cmd_args);
 }
 
-fn execBinary(path: []const u8, cmd_args: []const []const u8) void {
+fn execBinary(path: []const u8, cmd_args: []const []const u8) !void {
     // Build argv: [path] ++ cmd_args
     var argv_buf: [64][]const u8 = undefined;
     argv_buf[0] = path;
@@ -163,7 +163,7 @@ fn execBinary(path: []const u8, cmd_args: []const []const u8) void {
     var child = std.process.Child.init(argv_buf[0 .. argc + 1], std.heap.c_allocator);
     child.spawn() catch {
         output.err("Failed to execute binary", .{});
-        return;
+        return error.Aborted;
     };
     _ = child.wait() catch {};
 }

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -47,7 +47,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     const search_query = query orelse {
         output.err("Usage: mt search <query>", .{});
-        return;
+        return error.Aborted;
     };
 
     // If neither specified, search both
@@ -61,7 +61,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     const cache_dir = atomic.maltCacheDir(allocator) catch {
         output.err("Failed to determine cache directory", .{});
-        return;
+        return error.Aborted;
     };
     defer allocator.free(cache_dir);
 

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -55,7 +55,7 @@ fn run(allocator: std.mem.Allocator, args: []const []const u8, action: Action) !
     var db_path_buf: [512]u8 = undefined;
     const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
     var db = sqlite.Database.open(db_path) catch {
-        output.err("Failed to open database", .{});
+        // Fresh prefix with no `db/` yet = no taps registered.
         return;
     };
     defer db.close();
@@ -64,12 +64,12 @@ fn run(allocator: std.mem.Allocator, args: []const []const u8, action: Action) !
     if (args.len == 0) {
         if (action == .remove) {
             output.err("Usage: mt untap user/repo", .{});
-            return;
+            return error.Aborted;
         }
         // List taps
         const taps = tap_mod.list(allocator, &db) catch {
             output.err("Failed to list taps", .{});
-            return;
+            return error.Aborted;
         };
         defer allocator.free(taps);
 
@@ -91,7 +91,7 @@ fn run(allocator: std.mem.Allocator, args: []const []const u8, action: Action) !
     const name = args[0];
     validateTapName(name) catch {
         output.err("Invalid tap '{s}'. Expected: user/repo with [A-Za-z0-9._-]", .{name});
-        return;
+        return error.Aborted;
     };
 
     switch (action) {
@@ -100,14 +100,14 @@ fn run(allocator: std.mem.Allocator, args: []const []const u8, action: Action) !
             const url = std.fmt.bufPrint(&url_buf, "https://github.com/{s}", .{name}) catch return;
             tap_mod.add(&db, name, url) catch {
                 output.err("Failed to add tap {s}", .{name});
-                return;
+                return error.Aborted;
             };
             output.info("Tapped {s}", .{name});
         },
         .remove => {
             tap_mod.remove(&db, name) catch {
                 output.err("Failed to untap {s}", .{name});
-                return;
+                return error.Aborted;
             };
             output.info("Untapped {s}", .{name});
         },

--- a/src/cli/uninstall.zig
+++ b/src/cli/uninstall.zig
@@ -35,7 +35,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     const name = pkg_name orelse {
         output.err("Usage: mt uninstall <package>", .{});
-        return;
+        return error.Aborted;
     };
 
     const prefix = atomic.maltPrefix();
@@ -45,7 +45,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return;
     var lock = lock_mod.LockFile.acquire(lock_path, 5000) catch {
         output.err("Could not acquire lock. Another malt process may be running.", .{});
-        return;
+        return error.Aborted;
     };
     defer lock.release();
 
@@ -54,14 +54,14 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database", .{});
-        return;
+        return error.Aborted;
     };
     defer db.close();
     schema.initSchema(&db) catch return;
 
     // Check if it's a cask first (or if --cask was passed)
     if (force_cask or cask_mod.isInstalled(&db, name)) {
-        uninstallCask(allocator, name, &db, prefix, force);
+        try uninstallCask(allocator, name, &db, prefix, force);
         return;
     }
 
@@ -75,7 +75,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     const found = find_stmt.step() catch false;
     if (!found) {
         output.err("{s} is not installed", .{name});
-        return;
+        return error.Aborted;
     }
 
     const keg_id = find_stmt.columnInt(0);
@@ -98,7 +98,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             const dependent = dep_stmt.columnText(0);
             const dep_name = if (dependent) |d| std.mem.sliceTo(d, 0) else "unknown";
             output.err("{s} is required by {s}. Use --force to remove anyway.", .{ name, dep_name });
-            return;
+            return error.Aborted;
         }
     }
 
@@ -151,10 +151,10 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 }
 
 /// Uninstall a cask by token.
-fn uninstallCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Database, prefix: [:0]const u8, force: bool) void {
+fn uninstallCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Database, prefix: [:0]const u8, force: bool) !void {
     const info = cask_mod.lookupInstalled(db, token) orelse {
         output.err("{s} is not installed as a cask", .{token});
-        return;
+        return error.Aborted;
     };
 
     // Check if running (unless --force)
@@ -162,7 +162,7 @@ fn uninstallCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Da
         if (info.appPath()) |app_path| {
             if (cask_mod.CaskInstaller.isAppRunningPub(app_path)) {
                 output.err("{s} appears to be running. Quit the app first, or use --force.", .{token});
-                return;
+                return error.Aborted;
             }
         }
     }
@@ -172,7 +172,7 @@ fn uninstallCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Da
     var installer = cask_mod.CaskInstaller.init(allocator, db, prefix);
     installer.uninstall(token) catch {
         output.err("Failed to uninstall cask {s}", .{token});
-        return;
+        return error.Aborted;
     };
 
     output.success("{s} uninstalled", .{token});

--- a/src/cli/update.zig
+++ b/src/cli/update.zig
@@ -17,7 +17,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     const cache_dir = atomic.maltCacheDir(allocator) catch {
         output.err("Failed to determine cache directory", .{});
-        return;
+        return error.Aborted;
     };
     defer allocator.free(cache_dir);
 

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -46,15 +46,20 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var lock_path_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return;
     var lk = lock_mod.LockFile.acquire(lock_path, 5000) catch {
+        // Fresh prefix: no `db/` yet = nothing installed, nothing to
+        // upgrade. Exit 0 silently rather than treating the missing
+        // lock directory as contention with another process.
+        if (dry_run) return;
         output.err("Could not acquire lock. Another malt process may be running.", .{});
-        return;
+        return error.Aborted;
     };
     defer lk.release();
 
     var db_path_buf: [512]u8 = undefined;
     const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
     var db = sqlite.Database.open(db_path) catch {
-        output.err("Failed to open database", .{});
+        // Same degradation as `list`/`outdated` — missing DB on a fresh
+        // prefix is empty state, not an error.
         return;
     };
     defer db.close();
@@ -71,12 +76,12 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         // Upgrade a specific package — try formula first, then cask
         if (!cask_only) {
             if (isFormulaInstalled(&db, name)) {
-                upgradeFormula(allocator, name, &db, &api, &http, prefix, dry_run);
+                upgradeFormula(allocator, name, &db, &api, &http, prefix, dry_run) catch {};
                 return;
             }
         }
         // Not a formula (or --cask): try cask
-        upgradeCask(allocator, name, &db, &api, prefix, dry_run);
+        upgradeCask(allocator, name, &db, &api, prefix, dry_run) catch {};
     } else {
         // Upgrade all
         if (!cask_only) {
@@ -109,7 +114,7 @@ fn upgradeFormula(
     http: *client_mod.HttpClient,
     prefix: [:0]const u8,
     dry_run: bool,
-) void {
+) !void {
     // Step 1: Look up installed version from DB
     var find_stmt = db.prepare(
         "SELECT id, version, store_sha256, cellar_path FROM kegs WHERE name = ?1 LIMIT 1;",
@@ -120,7 +125,7 @@ fn upgradeFormula(
     const found = find_stmt.step() catch false;
     if (!found) {
         output.err("{s} is not installed as a formula", .{name});
-        return;
+        return error.Aborted;
     }
 
     const old_keg_id = find_stmt.columnInt(0);
@@ -134,13 +139,13 @@ fn upgradeFormula(
     // Step 2: Fetch latest formula from API
     const formula_json = api.fetchFormula(name) catch {
         output.err("Could not fetch formula info for {s}", .{name});
-        return;
+        return error.Aborted;
     };
     defer allocator.free(formula_json);
 
     var formula = formula_mod.parseFormula(allocator, formula_json) catch {
         output.err("Failed to parse formula JSON for {s}", .{name});
-        return;
+        return error.Aborted;
     };
     defer formula.deinit();
 
@@ -160,7 +165,7 @@ fn upgradeFormula(
     // Step 3: Resolve bottle for new version
     const bottle = formula_mod.resolveBottle(allocator, &formula) catch {
         output.err("No bottle available for {s} on this platform", .{name});
-        return;
+        return error.Aborted;
     };
 
     // Step 4: Download bottle
@@ -177,19 +182,19 @@ fn upgradeFormula(
 
         if (!std.mem.startsWith(u8, bottle.url, ghcr_prefix_str)) {
             output.err("Unsupported bottle URL for {s}", .{name});
-            return;
+            return error.Aborted;
         }
         const path = bottle.url[ghcr_prefix_str.len..];
         const blobs_pos = std.mem.indexOf(u8, path, "/blobs/") orelse {
             output.err("Malformed bottle URL for {s}", .{name});
-            return;
+            return error.Aborted;
         };
         const repo = std.fmt.bufPrint(&repo_buf, "{s}", .{path[0..blobs_pos]}) catch return;
         const digest = std.fmt.bufPrint(&digest_buf, "{s}", .{path[blobs_pos + "/blobs/".len ..]}) catch return;
 
         const tmp_dir = atomic.createTempDir(allocator, name) catch {
             output.err("Failed to create temp dir for {s}", .{name});
-            return;
+            return error.Aborted;
         };
 
         output.info("  Downloading {s}...", .{name});
@@ -197,14 +202,14 @@ fn upgradeFormula(
             output.err("  Download failed: {s}", .{name});
             atomic.cleanupTempDir(tmp_dir);
             allocator.free(tmp_dir);
-            return;
+            return error.Aborted;
         };
 
         store.commitFrom(bottle.sha256, tmp_dir) catch {
             output.err("Failed to commit bottle to store for {s}", .{name});
             atomic.cleanupTempDir(tmp_dir);
             allocator.free(tmp_dir);
-            return;
+            return error.Aborted;
         };
         allocator.free(tmp_dir);
 
@@ -221,7 +226,7 @@ fn upgradeFormula(
         formula.version,
     ) catch {
         output.err("Failed to materialize {s}", .{name});
-        return;
+        return error.Aborted;
     };
 
     // Step 6: Unlink old symlinks
@@ -394,7 +399,7 @@ fn upgradeAllFormulas(
     }
 
     for (names.items) |name| {
-        upgradeFormula(allocator, name, db, api, http, prefix, dry_run);
+        upgradeFormula(allocator, name, db, api, http, prefix, dry_run) catch {};
     }
 }
 
@@ -402,22 +407,22 @@ fn upgradeAllFormulas(
 // Cask upgrade
 // ---------------------------------------------------------------------------
 
-fn upgradeCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Database, api: *api_mod.BrewApi, prefix: [:0]const u8, dry_run: bool) void {
+fn upgradeCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Database, api: *api_mod.BrewApi, prefix: [:0]const u8, dry_run: bool) !void {
     const installed = cask_mod.lookupInstalled(db, token) orelse {
         output.err("{s} is not installed as a cask", .{token});
-        return;
+        return error.Aborted;
     };
 
     // Fetch latest version
     const cask_json = api.fetchCask(token) catch {
         output.err("Could not fetch cask info for {s}", .{token});
-        return;
+        return error.Aborted;
     };
     defer allocator.free(cask_json);
 
     var parsed_cask = cask_mod.parseCask(allocator, cask_json) catch {
         output.err("Failed to parse cask JSON for {s}", .{token});
-        return;
+        return error.Aborted;
     };
     defer parsed_cask.deinit();
 
@@ -438,13 +443,13 @@ fn upgradeCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Data
     var installer = cask_mod.CaskInstaller.init(allocator, db, prefix);
     installer.uninstall(token) catch {
         output.err("Failed to remove old version of {s}", .{token});
-        return;
+        return error.Aborted;
     };
 
     // Install new version
     const app_path = installer.install(&parsed_cask) catch {
         output.err("Failed to install new version of {s}", .{token});
-        return;
+        return error.Aborted;
     };
 
     cask_mod.recordInstall(db, &parsed_cask, app_path) catch {
@@ -464,7 +469,7 @@ fn upgradeAllCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api
         const token_ptr = stmt.columnText(0) orelse continue;
         const token = std.mem.sliceTo(token_ptr, 0);
 
-        upgradeCask(allocator, token, db, api, prefix, dry_run);
+        upgradeCask(allocator, token, db, api, prefix, dry_run) catch {};
         upgraded += 1;
     }
 

--- a/src/cli/uses.zig
+++ b/src/cli/uses.zig
@@ -27,7 +27,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     const name = target orelse {
         output.err("Usage: mt uses <formula>", .{});
-        return;
+        return error.Aborted;
     };
 
     const json_mode = output.isJson();

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -25,19 +25,19 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // Fetch latest release info from GitHub API
     var resp = http.get(RELEASES_API) catch {
         output.err("Cannot reach GitHub API", .{});
-        return;
+        return error.Aborted;
     };
     defer resp.deinit();
 
     if (resp.status != 200) {
         output.err("GitHub API returned status {d}", .{resp.status});
-        return;
+        return error.Aborted;
     }
 
     // Parse JSON to find tag_name and assets
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, resp.body, .{}) catch {
         output.err("Failed to parse release info", .{});
-        return;
+        return error.Aborted;
     };
     defer parsed.deinit();
 
@@ -45,12 +45,12 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         .object => |o| o,
         else => {
             output.err("Release payload was not a JSON object", .{});
-            return;
+            return error.Aborted;
         },
     };
     const tag = strField(obj, "tag_name") orelse {
         output.err("No tag_name in release", .{});
-        return;
+        return error.Aborted;
     };
 
     // Strip leading "v" from tag
@@ -73,32 +73,32 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     const assets_val = obj.get("assets") orelse {
         output.err("No assets in release", .{});
-        return;
+        return error.Aborted;
     };
     const assets = switch (assets_val) {
         .array => |a| a,
         else => {
             output.err("Invalid assets", .{});
-            return;
+            return error.Aborted;
         },
     };
 
     const url = pickAssetUrl(assets, arch_str) orelse {
         output.err("No matching binary found for darwin {s}", .{arch_str});
-        return;
+        return error.Aborted;
     };
 
     output.info("Downloading {s}...", .{url});
 
     var dl_resp = http.get(url) catch {
         output.err("Download failed", .{});
-        return;
+        return error.Aborted;
     };
     defer dl_resp.deinit();
 
     if (dl_resp.status != 200) {
         output.err("Download returned status {d}", .{dl_resp.status});
-        return;
+        return error.Aborted;
     }
 
     // Write to temp file
@@ -106,12 +106,12 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     {
         const f = std.fs.createFileAbsolute(tmp_path, .{}) catch {
             output.err("Cannot create temp file", .{});
-            return;
+            return error.Aborted;
         };
         defer f.close();
         f.writeAll(dl_resp.body) catch {
             output.err("Failed to write temp file", .{});
-            return;
+            return error.Aborted;
         };
     }
     defer std.fs.deleteFileAbsolute(tmp_path) catch {};
@@ -121,13 +121,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     std.fs.deleteTreeAbsolute(tmp_dir) catch {};
     std.fs.makeDirAbsolute(tmp_dir) catch {
         output.err("Cannot create temp directory", .{});
-        return;
+        return error.Aborted;
     };
     defer std.fs.deleteTreeAbsolute(tmp_dir) catch {};
 
     archive.extractTarGz(tmp_path, tmp_dir) catch {
         output.err("Failed to extract update", .{});
-        return;
+        return error.Aborted;
     };
 
     // Locate the replacement binary inside the extracted tree.
@@ -145,14 +145,14 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var new_binary_buf: [std.fs.max_path_bytes]u8 = undefined;
     const new_binary = findReleaseBinary(allocator, tmp_dir, &new_binary_buf) orelse {
         output.err("Binary 'malt' not found in release archive", .{});
-        return;
+        return error.Aborted;
     };
 
     // Find where the current binary lives
     var self_exe_buf: [std.fs.max_path_bytes]u8 = undefined;
     const self_exe = std.fs.selfExePath(&self_exe_buf) catch {
         output.err("Cannot determine current binary path", .{});
-        return;
+        return error.Aborted;
     };
 
     output.info("Replacing {s}...", .{self_exe});

--- a/src/main.zig
+++ b/src/main.zig
@@ -171,49 +171,55 @@ pub fn main() !void {
     const cmd_args = filtered.items;
 
     if (command_map.get(cmd_str)) |cmd| {
-        switch (cmd) {
-            .install => try install.execute(allocator, cmd_args),
-            .uninstall => try uninstall.execute(allocator, cmd_args),
-            .upgrade => try upgrade.execute(allocator, cmd_args),
-            .update => try update.execute(allocator, cmd_args),
-            .outdated => try outdated.execute(allocator, cmd_args),
-            .list => try list.execute(allocator, cmd_args),
-            .info => try info.execute(allocator, cmd_args),
-            .search => try search.execute(allocator, cmd_args),
-            .doctor => try doctor.execute(allocator, cmd_args),
-            .tap => try tap.execute(allocator, cmd_args),
-            .untap => try tap.executeUntap(allocator, cmd_args),
-            .migrate => try migrate.execute(allocator, cmd_args),
-            .rollback => rollback.execute(allocator, cmd_args) catch |e| switch (e) {
-                // User-facing failure already reported by rollback.execute —
-                // exit non-zero without a stack trace.
-                error.Aborted => std.process.exit(1),
-                else => return e,
-            },
-            .link => try link_cmd.executeLink(allocator, cmd_args),
-            .unlink => try link_cmd.executeUnlink(allocator, cmd_args),
-            .run => try run_cmd.execute(allocator, cmd_args),
-            .completions => try completions.execute(allocator, cmd_args),
-            .backup => try backup.execute(allocator, cmd_args),
-            .restore => try restore.execute(allocator, cmd_args),
-            .purge => try purge.execute(allocator, cmd_args),
-            .services => try services.execute(allocator, cmd_args),
-            .bundle => try bundle.execute(allocator, cmd_args),
-            .uses => try uses.execute(allocator, cmd_args),
-            .version_cmd => {
-                // "mt version" — check for "mt version update" subcommand
-                if (cmd_args.len > 0 and std.mem.eql(u8, cmd_args[0], "update")) {
-                    try version_update.execute(allocator, cmd_args[1..]);
-                } else {
-                    printVersion();
-                }
-            },
-            .help => printUsage(),
-            .version => printVersion(),
-        }
+        // Any command can signal a user-facing failure by returning
+        // `error.Aborted`; the message has already been emitted via
+        // `output.err`, so we just exit non-zero without a stack trace.
+        // Every other error still propagates and surfaces normally.
+        dispatch(allocator, cmd, cmd_args) catch |e| switch (e) {
+            error.Aborted => std.process.exit(1),
+            else => return e,
+        };
     } else {
         // Unknown command — try transparent brew fallback
         try brewFallback(allocator, args[1..]);
+    }
+}
+
+fn dispatch(allocator: std.mem.Allocator, cmd: Command, cmd_args: []const []const u8) !void {
+    switch (cmd) {
+        .install => try install.execute(allocator, cmd_args),
+        .uninstall => try uninstall.execute(allocator, cmd_args),
+        .upgrade => try upgrade.execute(allocator, cmd_args),
+        .update => try update.execute(allocator, cmd_args),
+        .outdated => try outdated.execute(allocator, cmd_args),
+        .list => try list.execute(allocator, cmd_args),
+        .info => try info.execute(allocator, cmd_args),
+        .search => try search.execute(allocator, cmd_args),
+        .doctor => try doctor.execute(allocator, cmd_args),
+        .tap => try tap.execute(allocator, cmd_args),
+        .untap => try tap.executeUntap(allocator, cmd_args),
+        .migrate => try migrate.execute(allocator, cmd_args),
+        .rollback => try rollback.execute(allocator, cmd_args),
+        .link => try link_cmd.executeLink(allocator, cmd_args),
+        .unlink => try link_cmd.executeUnlink(allocator, cmd_args),
+        .run => try run_cmd.execute(allocator, cmd_args),
+        .completions => try completions.execute(allocator, cmd_args),
+        .backup => try backup.execute(allocator, cmd_args),
+        .restore => try restore.execute(allocator, cmd_args),
+        .purge => try purge.execute(allocator, cmd_args),
+        .services => try services.execute(allocator, cmd_args),
+        .bundle => try bundle.execute(allocator, cmd_args),
+        .uses => try uses.execute(allocator, cmd_args),
+        .version_cmd => {
+            // "mt version" — check for "mt version update" subcommand
+            if (cmd_args.len > 0 and std.mem.eql(u8, cmd_args[0], "update")) {
+                try version_update.execute(allocator, cmd_args[1..]);
+            } else {
+                printVersion();
+            }
+        },
+        .help => printUsage(),
+        .version => printVersion(),
     }
 }
 

--- a/tests/cli_tap_test.zig
+++ b/tests/cli_tap_test.zig
@@ -117,28 +117,35 @@ test "validateTapName: rejects over-long components" {
     try testing.expectError(bad, tap_cli.validateTapName(long_repo));
 }
 
-test "execute: malformed tap input returns cleanly without inserting a row" {
+test "execute: malformed tap input is rejected with error.Aborted" {
     const prefix = try setupPrefix("reject_malformed");
     defer testing.allocator.free(prefix);
     defer std.fs.deleteTreeAbsolute(prefix) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
 
-    // Each of these should be rejected by the validator and return without
-    // touching the DB. Run them back-to-back; they must not accumulate
-    // partial state or crash.
-    try tap_cli.execute(testing.allocator, &.{"no-slash-here"});
-    try tap_cli.execute(testing.allocator, &.{"a/b/c"});
-    try tap_cli.execute(testing.allocator, &.{"/repo"});
-    try tap_cli.execute(testing.allocator, &.{"user/"});
-    try tap_cli.execute(testing.allocator, &.{"../evil"});
-    try tap_cli.execute(testing.allocator, &.{"user/bad char"});
+    // Each of these should be rejected by the validator and surface as a
+    // non-zero CLI exit — the command-level contract is `error.Aborted`
+    // (see main.zig dispatch). Run them back-to-back to also verify no
+    // partial state accumulates between calls.
+    const bad_inputs = [_][]const u8{
+        "no-slash-here", "a/b/c", "/repo", "user/", "../evil", "user/bad char",
+    };
+    for (bad_inputs) |name| {
+        try testing.expectError(
+            error.Aborted,
+            tap_cli.execute(testing.allocator, &.{name}),
+        );
+    }
 }
 
-test "execute with a bare name (no slash) reports an error but does not throw" {
+test "execute with a bare name (no slash) surfaces error.Aborted" {
     const prefix = try setupPrefix("bad_name");
     defer testing.allocator.free(prefix);
     defer std.fs.deleteTreeAbsolute(prefix) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
 
-    try tap_cli.execute(testing.allocator, &.{"no_slash_here"});
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(testing.allocator, &.{"no_slash_here"}),
+    );
 }

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -225,7 +225,7 @@ test "ensureDirs creates every required subdirectory under a fresh prefix" {
     std.fs.deleteTreeAbsolute(prefix) catch {};
     defer std.fs.deleteTreeAbsolute(prefix) catch {};
 
-    install.ensureDirs(prefix);
+    try install.ensureDirs(prefix);
 
     const subs = [_][]const u8{ "store", "Cellar", "Caskroom", "opt", "bin", "lib", "include", "share", "sbin", "etc", "tmp", "cache", "db" };
     for (subs) |s| {


### PR DESCRIPTION
## Summary

Almost every malt command had the same bug PR #37 fixed in `rollback`: it would print `✗ something went wrong` and then exit **0**. Shell scripts and CI jobs couldn't tell the command had failed, so chains like `malt install wget && deploy.sh` silently ran `deploy.sh` after a failed install.

This PR applies the same fix across the whole CLI surface: any user-facing failure returns `error.Aborted` and the dispatcher catches it once to exit 1 — no stack trace, no code duplication.

## What changes

- **One central catch** in `main.zig` replaces the per-command plumbing from PR #37. Every `execute` function can just `return error.Aborted` and the exit code takes care of itself.
- **all commands** now exit 1 on validation errors, DB failures (where DB is required), missing packages, lock contention, and subprocess failures: `install`, `uninstall`, `upgrade`, `update`, `outdated`, `list`, `info`, `search`, `link`/`unlink`, `migrate`, `run`, `tap`/`untap`, `uses`, `version update`.
- **Read commands stay graceful** on a fresh prefix: `list`, `outdated`, `tap` (listing), and `upgrade --dry-run` treat a missing `db/` directory as empty state and exit 0, matching the `ls` convention. Only operations that can't meaningfully proceed without state signal failure.
- Two internal helper signatures promoted from `void` to `!void` (`ensureDirs`, `execBinary`, `uninstallCask`, `upgradeCask`, `upgradeFormula`) so they can surface failures rather than swallow them.