### PR TITLE
refactor(cli): drop redundant flag re-parsing

### DIFF
--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -12,12 +12,13 @@ const help = @import("help.zig");
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "list")) return;
 
-    // Parse flags
+    // Parse per-command flags. `--json`, `--quiet`/`-q`, `--verbose`/`-v`,
+    // and `--dry-run` are stripped by the global parser in `main.zig`
+    // before we get here — read them via `output.isJson()` etc.
     var show_formula = false;
     var show_cask = false;
     var show_versions = false;
     var show_pinned = false;
-    var json_mode = false;
 
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "--formula") or std.mem.eql(u8, arg, "--formulae")) {
@@ -28,12 +29,9 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             show_versions = true;
         } else if (std.mem.eql(u8, arg, "--pinned")) {
             show_pinned = true;
-        } else if (std.mem.eql(u8, arg, "--json")) {
-            json_mode = true;
-        } else if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
-            output.setQuiet(true);
         }
     }
+    const json_mode = output.isJson();
 
     // If neither specified, show both
     if (!show_formula and !show_cask) {

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -14,21 +14,18 @@ const help = @import("help.zig");
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "outdated")) return;
 
-    var json_mode = false;
     var cask_only = false;
     var formula_only = false;
 
     for (args) |arg| {
-        if (std.mem.eql(u8, arg, "--json")) {
-            json_mode = true;
-        } else if (std.mem.eql(u8, arg, "--cask")) {
+        if (std.mem.eql(u8, arg, "--cask")) {
             cask_only = true;
         } else if (std.mem.eql(u8, arg, "--formula") or std.mem.eql(u8, arg, "--formulae")) {
             formula_only = true;
-        } else if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
-            output.setQuiet(true);
         }
     }
+    // `--json` and `--quiet` are stripped by the global parser in main.zig.
+    const json_mode = output.isJson();
 
     // Open DB
     const prefix = atomic.maltPrefix();

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -38,8 +38,6 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             search_formula = true;
         } else if (std.mem.eql(u8, arg, "--cask") or std.mem.eql(u8, arg, "--casks")) {
             search_cask = true;
-        } else if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
-            output.setQuiet(true);
         } else if (arg.len > 0 and arg[0] != '-') {
             if (query == null) query = arg;
         }


### PR DESCRIPTION
## Summary

`--json`, `--quiet`/`-q`, `--dry-run`, and `--verbose`/`-v` are already stripped by the global flag parser in `main.zig` and stored on the `output` module before any command sees its argv. Three read commands — `list`, `search`, `outdated` — were re-parsing the same flags locally into shadow variables.

The shadow parsing wasn't just redundant — it was quietly drifting. `outdated` accepted `--quiet` and `-q` via its local loop, but `list` and `search` each missed one form depending on ordering. Removing the duplicate code makes all three read `output.isJson()` / `output.isQuiet()` — single source of truth.

## What changes

- `src/cli/list.zig` — drop local `json_mode` parse; read `output.isJson()`.
- `src/cli/search.zig` — drop the `--quiet`/`-q` branch (already handled globally).
- `src/cli/outdated.zig` — drop `--json` + `--quiet` parsing; read from `output`.

No behaviour change for end users: every flag still works exactly as before, just via the central parser.
