### PR TITLE
docs(readme): note --casks / --formulae plural aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ malt uninstall wget
 
 > [!NOTE]
 > The examples below use `mt` (the shorter alias). All commands work identically with `malt`.
+>
+> **Plural flag forms.** Wherever a command accepts `--formula` or `--cask`, it also accepts `--formulae` or `--casks` — whichever reads more naturally for the number of packages involved.
 
 ### `mt install`
 


### PR DESCRIPTION
## Summary

`malt list`, `malt search`, and `malt outdated` have always accepted both `--formula` / `--formulae` and `--cask` / `--casks`, but the README only documented the singular forms — an easy papercut to hit when `malt outdated --formulae` reads more naturally than `--formula` in a sentence.

This adds a single callout at the top of Command Reference rather than sprinkling the aliases across every per-command flag table.
