### PR TITLE
fix(install): heal dep opt/ symlinks so bottled binaries keep loading

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -845,6 +845,13 @@ pub fn collectFormulaJobs(
     // Resolve dependencies
     const deps = deps_mod.resolve(allocator, formula.name, api, db) catch &.{};
 
+    // Keep each already-installed dep's opt/ symlink pointing at its Cellar.
+    const heal_prefix = atomic.maltPrefix();
+    for (deps) |dep| {
+        if (!dep.already_installed) continue;
+        deps_mod.ensureOptLink(db, heal_prefix, dep.name);
+    }
+
     // Fetch every dep's formula JSON **in parallel**. Each worker
     // borrows a client from the shared `http_pool` for the duration
     // of its request so TLS contexts are reused across deps.

--- a/src/core/deps.zig
+++ b/src/core/deps.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 const sqlite = @import("../db/sqlite.zig");
 const api_mod = @import("../net/api.zig");
+const fs_compat = @import("../fs/compat.zig");
 
 pub const DepError = error{
     CycleDetected,
@@ -160,10 +161,47 @@ pub fn findOrphans(allocator: std.mem.Allocator, db: *sqlite.Database) ![]const 
 // --- helpers ---
 
 fn isInstalled(db: *sqlite.Database, name: []const u8) bool {
-    var stmt = db.prepare("SELECT id FROM kegs WHERE name = ?1 LIMIT 1;") catch return false;
+    var stmt = db.prepare("SELECT cellar_path FROM kegs WHERE name = ?1 LIMIT 1;") catch return false;
     defer stmt.finalize();
     stmt.bindText(1, name) catch return false;
-    return stmt.step() catch false;
+    if (!(stmt.step() catch false)) return false;
+
+    // Trust the DB only when the cellar_path is still on disk.
+    const cp_raw = stmt.columnText(0) orelse return false;
+    const cellar_path = std.mem.sliceTo(cp_raw, 0);
+    fs_compat.accessAbsolute(cellar_path, .{}) catch return false;
+    return true;
+}
+
+/// Keep `opt/{name}` pointing at the keg's DB-recorded cellar_path.
+/// No-op when already correct; silent on failure.
+pub fn ensureOptLink(db: *sqlite.Database, prefix: []const u8, name: []const u8) void {
+    var stmt = db.prepare("SELECT cellar_path FROM kegs WHERE name = ?1 LIMIT 1;") catch return;
+    defer stmt.finalize();
+    stmt.bindText(1, name) catch return;
+    if (!(stmt.step() catch false)) return;
+    const cp_raw = stmt.columnText(0) orelse return;
+    const cellar_path = std.mem.sliceTo(cp_raw, 0);
+
+    var opt_buf: [512]u8 = undefined;
+    const opt_path = std.fmt.bufPrint(&opt_buf, "{s}/opt/{s}", .{ prefix, name }) catch return;
+
+    // Fast path: symlink already resolves to the DB's cellar_path.
+    var target_buf: [std.fs.max_path_bytes]u8 = undefined;
+    if (fs_compat.readLinkAbsolute(opt_path, &target_buf)) |target| {
+        if (std.mem.eql(u8, target, cellar_path)) return;
+    } else |_| {}
+
+    var opt_parent_buf: [512]u8 = undefined;
+    const opt_parent = std.fmt.bufPrint(&opt_parent_buf, "{s}/opt", .{prefix}) catch return;
+    fs_compat.makeDirAbsolute(opt_parent) catch |e| switch (e) {
+        error.PathAlreadyExists => {},
+        else => return,
+    };
+    var parent_dir = fs_compat.openDirAbsolute(opt_parent, .{}) catch return;
+    defer parent_dir.close();
+    parent_dir.deleteFile(name) catch {};
+    parent_dir.symLink(cellar_path, name, .{}) catch {};
 }
 
 fn getDeps(allocator: std.mem.Allocator, name: []const u8, api: *api_mod.BrewApi) ![][]const u8 {

--- a/tests/deps_test.zig
+++ b/tests/deps_test.zig
@@ -71,13 +71,23 @@ fn insertKeg(
     name: []const u8,
     reason: []const u8,
 ) !i64 {
+    return insertKegWithCellar(db, name, reason, "/tmp");
+}
+
+fn insertKegWithCellar(
+    db: *sqlite.Database,
+    name: []const u8,
+    reason: []const u8,
+    cellar_path: []const u8,
+) !i64 {
     var stmt = try db.prepare(
         \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, install_reason)
-        \\VALUES (?1, ?1, '1.0', 'sha', '/tmp', ?2) RETURNING id;
+        \\VALUES (?1, ?1, '1.0', 'sha', ?3, ?2) RETURNING id;
     );
     defer stmt.finalize();
     try stmt.bindText(1, name);
     try stmt.bindText(2, reason);
+    try stmt.bindText(3, cellar_path);
     const has = try stmt.step();
     try testing.expect(has);
     return stmt.columnInt(0);
@@ -295,6 +305,161 @@ test "resolve handles a dep whose sub-fetch fails by falling through" {
 
     try testing.expectEqual(@as(usize, 1), result.len);
     try testing.expectEqualStrings("missing", result[0].name);
+}
+
+// --- ensureOptLink / stale-cellar heal coverage ---------------------------
+
+test "resolve treats a DB keg with a vanished cellar_path as not-installed" {
+    // Reproduces the zig→zstd bug: DB still holds the row after the Cellar
+    // dir was removed (manual cleanup, interrupted uninstall, prefix move).
+    // Without the fs check, BFS would skip the dep and the install would
+    // succeed while leaving dylib consumers pointing at a dead symlink.
+    const alloc = testing.allocator;
+
+    var dir = try TempCacheDir.init("resolve_missing_cellar");
+    defer dir.deinit();
+
+    try dir.writeFormula("alpha", "{\"dependencies\":[\"beta\"]}");
+    try dir.writeFormula("beta", "{\"dependencies\":[]}");
+
+    var http = client_mod.HttpClient.init(alloc);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(alloc, &http, dir.path);
+
+    var tdb = try TempDb.init("resolve_missing_cellar");
+    defer tdb.deinit();
+    // Point beta's cellar_path at a directory that definitely doesn't exist.
+    _ = try insertKegWithCellar(&tdb.db, "beta", "dependency", "/tmp/malt_missing_xyz_9273");
+
+    const result = try deps_mod.resolve(alloc, "alpha", &api, &tdb.db);
+    defer freeResolved(alloc, result);
+
+    try testing.expectEqual(@as(usize, 1), result.len);
+    try testing.expectEqualStrings("beta", result[0].name);
+    // Filesystem says no — fall back to reinstall, never skip.
+    try testing.expect(!result[0].already_installed);
+}
+
+const TempPrefix = struct {
+    root: []const u8,
+    db: sqlite.Database,
+
+    fn init(comptime tag: []const u8) !TempPrefix {
+        const root = "/tmp/malt_opt_link_" ++ tag;
+        malt.fs_compat.deleteTreeAbsolute(root) catch {};
+        try malt.fs_compat.makeDirAbsolute(root);
+        errdefer malt.fs_compat.deleteTreeAbsolute(root) catch {};
+
+        var db_buf: [256]u8 = undefined;
+        const db_path = try std.fmt.bufPrint(&db_buf, "{s}/malt.db", .{root});
+        var db = try sqlite.Database.open(db_path);
+        errdefer db.close();
+        try schema.initSchema(&db);
+        return .{ .root = root, .db = db };
+    }
+
+    fn deinit(self: *TempPrefix) void {
+        self.db.close();
+        malt.fs_compat.deleteTreeAbsolute(self.root) catch {};
+    }
+
+    fn cellarFor(self: *const TempPrefix, name: []const u8, version: []const u8) ![]const u8 {
+        var cellar_root_buf: [512]u8 = undefined;
+        const cellar_root = try std.fmt.bufPrint(&cellar_root_buf, "{s}/Cellar", .{self.root});
+        malt.fs_compat.makeDirAbsolute(cellar_root) catch |e| switch (e) {
+            error.PathAlreadyExists => {},
+            else => return e,
+        };
+        var name_buf: [512]u8 = undefined;
+        const name_dir = try std.fmt.bufPrint(&name_buf, "{s}/{s}", .{ cellar_root, name });
+        malt.fs_compat.makeDirAbsolute(name_dir) catch |e| switch (e) {
+            error.PathAlreadyExists => {},
+            else => return e,
+        };
+        var path_buf: [512]u8 = undefined;
+        const path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ name_dir, version });
+        malt.fs_compat.makeDirAbsolute(path) catch |e| switch (e) {
+            error.PathAlreadyExists => {},
+            else => return e,
+        };
+        return try testing.allocator.dupe(u8, path);
+    }
+
+    fn readOptLink(self: *const TempPrefix, name: []const u8, buf: []u8) ![]u8 {
+        var path_buf: [512]u8 = undefined;
+        const opt_path = try std.fmt.bufPrint(&path_buf, "{s}/opt/{s}", .{ self.root, name });
+        return malt.fs_compat.readLinkAbsolute(opt_path, buf);
+    }
+};
+
+test "ensureOptLink recreates a missing opt/<name> symlink" {
+    var p = try TempPrefix.init("missing");
+    defer p.deinit();
+
+    const cellar = try p.cellarFor("zstd", "1.5.7");
+    defer testing.allocator.free(cellar);
+    _ = try insertKegWithCellar(&p.db, "zstd", "dependency", cellar);
+
+    // Precondition: no opt/ symlink yet.
+    var miss_buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expectError(error.FileNotFound, p.readOptLink("zstd", &miss_buf));
+
+    deps_mod.ensureOptLink(&p.db, p.root, "zstd");
+
+    var got_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const target = try p.readOptLink("zstd", &got_buf);
+    try testing.expectEqualStrings(cellar, target);
+}
+
+test "ensureOptLink is idempotent when the symlink is already correct" {
+    var p = try TempPrefix.init("idempotent");
+    defer p.deinit();
+
+    const cellar = try p.cellarFor("zstd", "1.5.7");
+    defer testing.allocator.free(cellar);
+    _ = try insertKegWithCellar(&p.db, "zstd", "dependency", cellar);
+
+    deps_mod.ensureOptLink(&p.db, p.root, "zstd"); // first call creates
+    deps_mod.ensureOptLink(&p.db, p.root, "zstd"); // second call must be a no-op
+
+    var got_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const target = try p.readOptLink("zstd", &got_buf);
+    try testing.expectEqualStrings(cellar, target);
+}
+
+test "ensureOptLink replaces a stale symlink pointing at an old cellar" {
+    var p = try TempPrefix.init("stale");
+    defer p.deinit();
+
+    // Pre-create a symlink to an OLD cellar path that the DB no longer knows.
+    var opt_parent_buf: [512]u8 = undefined;
+    const opt_parent = try std.fmt.bufPrint(&opt_parent_buf, "{s}/opt", .{p.root});
+    try malt.fs_compat.makeDirAbsolute(opt_parent);
+    var dir = try malt.fs_compat.openDirAbsolute(opt_parent, .{});
+    defer dir.close();
+    try dir.symLink("/tmp/malt_stale_old_zstd", "zstd", .{});
+
+    // DB points at the CURRENT cellar path.
+    const cellar = try p.cellarFor("zstd", "1.5.7");
+    defer testing.allocator.free(cellar);
+    _ = try insertKegWithCellar(&p.db, "zstd", "dependency", cellar);
+
+    deps_mod.ensureOptLink(&p.db, p.root, "zstd");
+
+    var got_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const target = try p.readOptLink("zstd", &got_buf);
+    try testing.expectEqualStrings(cellar, target);
+}
+
+test "ensureOptLink silently skips names the DB does not know" {
+    var p = try TempPrefix.init("unknown");
+    defer p.deinit();
+
+    // No DB row for 'ghost' → ensureOptLink must be a no-op, not panic.
+    deps_mod.ensureOptLink(&p.db, p.root, "ghost");
+
+    var miss_buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expectError(error.FileNotFound, p.readOptLink("ghost", &miss_buf));
 }
 
 test "formula with empty dependencies" {


### PR DESCRIPTION
## Summary

- Installed packages whose deps were in the DB but had a missing or stale `opt/<name>` symlink passed install cleanly and then failed at runtime with `dyld: Library not loaded: /opt/malt/opt/<dep>/lib/...`. The issue predates the 0.16 migration.
- Every install now heals already-installed deps' `opt/` symlinks inline, so bottled binaries find their dylibs without a separate `mt doctor` step.
- A vanished Cellar on a DB-known keg now forces a reinstall instead of being silently skipped.

## Reproduction

```
$ mt install zig
  ...
  ✓ zig 0.16.0 installed
$ rm /opt/malt/opt/zstd              # or any dep's opt/ link gets damaged
$ zig --version
dyld: Library not loaded: /opt/malt/opt/zstd/lib/libzstd.1.dylib
$ mt install rust                    # any subsequent install with zstd as a dep
$ zig --version                      # opt/zstd is healed, resolves again
0.16.0
```
