### PR TITLE
fix(tests): run zig build test without deadlocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,24 +33,7 @@ jobs:
         run: zig build -Doptimize=ReleaseSafe
 
       - name: Run unit tests
-        # `zig build test` deadlocks under Zig 0.16 (test-runner IPC
-        # pipe hangs once children finish), so install the test
-        # binaries and execute each one directly. Identical coverage.
-        run: |
-          set -euo pipefail
-          zig build test-bin
-          fail=0
-          for t in zig-out/test-bin/*_test; do
-              name=$(basename "$t")
-              if ! "$t"; then
-                  echo "FAIL: $name"
-                  fail=$((fail + 1))
-              fi
-          done
-          if [ "$fail" -ne 0 ]; then
-              echo "$fail test binary(ies) failed."
-              exit 1
-          fi
+        run: zig build test --summary all
 
       - name: Smoke test — version flag
         run: ./zig-out/bin/malt --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,24 +55,7 @@ jobs:
           version: 0.16.0
 
       - name: Run unit tests
-        # `zig build test` deadlocks under Zig 0.16 (test-runner IPC
-        # pipe hangs once children finish), so install the test
-        # binaries and execute each one directly. Identical coverage.
-        run: |
-          set -euo pipefail
-          zig build test-bin
-          fail=0
-          for t in zig-out/test-bin/*_test; do
-              name=$(basename "$t")
-              if ! "$t"; then
-                  echo "FAIL: $name"
-                  fail=$((fail + 1))
-              fi
-          done
-          if [ "$fail" -ne 0 ]; then
-              echo "$fail test binary(ies) failed."
-              exit 1
-          fi
+        run: zig build test --summary all
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/justfile
+++ b/justfile
@@ -35,28 +35,7 @@ install:
 # Run unit tests
 [group('test')]
 test:
-    #!/usr/bin/env bash
-    # Build then run each test binary directly. Bypasses Zig 0.15's
-    # `zig build test` runner, which deadlocks on macOS in
-    # `Server.receiveMessage` once the test binaries finish their work
-    # (the parent build never sends "exit", children block on `readv`).
-    # Identical coverage, ~60s versus indefinite hang.
-    set -euo pipefail
-    zig build test-bin
-    fail=0
-    for t in zig-out/test-bin/*_test; do
-        name=$(basename "$t")
-        if ! "$t" >/tmp/malt_test_${name}.log 2>&1; then
-            echo "FAIL: $name"
-            tail -5 /tmp/malt_test_${name}.log | sed 's/^/  /'
-            fail=$((fail + 1))
-        fi
-    done
-    if [ "$fail" -ne 0 ]; then
-        echo "$fail test binary(ies) failed."
-        exit 1
-    fi
-    echo "All test binaries passed."
+    zig build test --summary all
 
 # Run tests under kcov, print line-coverage percentage, and refresh
 # the README badge SVG at .github/badges/coverage.svg.

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -179,7 +179,7 @@ fn cmdExport(allocator: std.mem.Allocator, rest: []const []const u8) !void {
         try populateFromInstalled(&manifest, &db);
     }
 
-    const stdout = std.Io.File.stdout();
+    const stdout = io_mod.stdoutFile();
     var write_buf: [4096]u8 = undefined;
     var stdout_writer = stdout.writer(io_mod.ctx(), &write_buf);
     const w = &stdout_writer.interface;

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -54,7 +54,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer if (db_opt) |*d| d.close();
 
     var stdout_buf: [4096]u8 = undefined;
-    var stdout_fw = std.Io.File.stdout().writer(io_mod.ctx(), &stdout_buf);
+    var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
     const stdout: *std.Io.Writer = &stdout_fw.interface;
     defer stdout.flush() catch {};
 

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -54,7 +54,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     schema.initSchema(&db) catch return;
 
     var stdout_buf: [4096]u8 = undefined;
-    var stdout_fw = std.Io.File.stdout().writer(io_mod.ctx(), &stdout_buf);
+    var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
     const stdout: *std.Io.Writer = &stdout_fw.interface;
     defer stdout.flush() catch {};
 

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -51,7 +51,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var api = api_mod.BrewApi.init(allocator, &http, cache_dir);
 
     var stdout_buf: [4096]u8 = undefined;
-    var stdout_fw = std.Io.File.stdout().writer(io_mod.ctx(), &stdout_buf);
+    var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
     const stdout: *std.Io.Writer = &stdout_fw.interface;
     defer stdout.flush() catch {};
 
@@ -130,7 +130,7 @@ fn checkOutdatedCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *
     defer stmt.finalize();
 
     var stdout_buf: [4096]u8 = undefined;
-    var stdout_fw = std.Io.File.stdout().writer(io_mod.ctx(), &stdout_buf);
+    var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
     const stdout: *std.Io.Writer = &stdout_fw.interface;
     defer stdout.flush() catch {};
     var found_any = false;

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -107,7 +107,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     var stdout_buf: [4096]u8 = undefined;
-    var stdout_fw = std.Io.File.stdout().writer(io_mod.ctx(), &stdout_buf);
+    var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
     const stdout: *std.Io.Writer = &stdout_fw.interface;
     defer stdout.flush() catch {};
     if (json_mode) {

--- a/src/cli/uses.zig
+++ b/src/cli/uses.zig
@@ -38,7 +38,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer if (db_opt) |*d| d.close();
 
     var stdout_buf: [4096]u8 = undefined;
-    var stdout_fw = std.Io.File.stdout().writer(io_mod.ctx(), &stdout_buf);
+    var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
     const stdout: *std.Io.Writer = &stdout_fw.interface;
     defer stdout.flush() catch {};
 

--- a/src/fs/compat.zig
+++ b/src/fs/compat.zig
@@ -152,7 +152,7 @@ pub fn stderrFile() File {
 }
 
 pub fn stdoutFile() File {
-    return .{ .inner = std.Io.File.stdout() };
+    return .{ .inner = io_mod.stdoutFile() };
 }
 
 pub fn stdinFile() File {

--- a/src/fs/compat.zig
+++ b/src/fs/compat.zig
@@ -148,7 +148,7 @@ pub fn cwd() Dir {
 /// shim wrapper so `.writeAll` / `.supportsAnsiEscapeCodes` etc. work
 /// without threading `io` through callers.
 pub fn stderrFile() File {
-    return .{ .inner = std.Io.File.stderr() };
+    return .{ .inner = io_mod.stderrFile() };
 }
 
 pub fn stdoutFile() File {

--- a/src/ui/io.zig
+++ b/src/ui/io.zig
@@ -4,10 +4,18 @@
 //! a real `Io` through the call graph.
 
 const std = @import("std");
+const builtin = @import("builtin");
 
 /// Default process-wide Io used for stdout/stderr writes.
 pub fn ctx() std.Io {
     return std.Options.debug_io;
+}
+
+/// Stdout for user-visible output. Under the test runner the `--listen=-`
+/// IPC owns fd 1, so redirect to stderr to keep the pipe pristine.
+pub fn stdoutFile() std.Io.File {
+    if (builtin.is_test) return std.Io.File.stderr();
+    return std.Io.File.stdout();
 }
 
 pub fn stderrWriteAll(bytes: []const u8) void {
@@ -15,5 +23,5 @@ pub fn stderrWriteAll(bytes: []const u8) void {
 }
 
 pub fn stdoutWriteAll(bytes: []const u8) void {
-    std.Io.File.stdout().writeStreamingAll(ctx(), bytes) catch return;
+    stdoutFile().writeStreamingAll(ctx(), bytes) catch return;
 }

--- a/src/ui/io.zig
+++ b/src/ui/io.zig
@@ -11,15 +11,43 @@ pub fn ctx() std.Io {
     return std.Options.debug_io;
 }
 
-/// Stdout for user-visible output. Under the test runner the `--listen=-`
-/// IPC owns fd 1, so redirect to stderr to keep the pipe pristine.
+/// Lazy `/dev/null` handle used to sink writes under the test runner. The
+/// runner owns fd 1 for its IPC protocol, and dumps any captured stderr
+/// next to a "failed command:" trailer — both swamp the summary with noise
+/// when tests pass. Funneling user-visible writes here keeps runs quiet.
+var test_sink_fd: std.atomic.Value(std.c.fd_t) = .init(-1);
+
+fn testSink() std.Io.File {
+    var current = test_sink_fd.load(.acquire);
+    if (current < 0) {
+        const fd = std.c.open("/dev/null", .{ .ACCMODE = .WRONLY }, @as(std.c.mode_t, 0));
+        if (fd < 0) return std.Io.File.stderr();
+        if (test_sink_fd.cmpxchgStrong(-1, fd, .release, .acquire)) |winner| {
+            _ = std.c.close(fd);
+            current = winner;
+        } else {
+            current = fd;
+        }
+    }
+    return .{ .handle = current, .flags = .{ .nonblocking = false } };
+}
+
+/// Stdout for user-visible output. Non-test builds write to fd 1; tests
+/// funnel to `/dev/null` — see `testSink`.
 pub fn stdoutFile() std.Io.File {
-    if (builtin.is_test) return std.Io.File.stderr();
+    if (builtin.is_test) return testSink();
     return std.Io.File.stdout();
 }
 
+/// Stderr for log/diagnostic output. Non-test builds write to fd 2; tests
+/// funnel to `/dev/null` — see `testSink`.
+pub fn stderrFile() std.Io.File {
+    if (builtin.is_test) return testSink();
+    return std.Io.File.stderr();
+}
+
 pub fn stderrWriteAll(bytes: []const u8) void {
-    std.Io.File.stderr().writeStreamingAll(ctx(), bytes) catch return;
+    stderrFile().writeStreamingAll(ctx(), bytes) catch return;
 }
 
 pub fn stdoutWriteAll(bytes: []const u8) void {

--- a/tests/cli_tap_test.zig
+++ b/tests/cli_tap_test.zig
@@ -46,10 +46,10 @@ test "execute with user/repo adds a tap idempotently" {
     try tap_cli.execute(testing.allocator, &.{"user/repo"});
     // A second call is idempotent via INSERT OR IGNORE.
     try tap_cli.execute(testing.allocator, &.{"user/repo"});
-    // NOTE: we deliberately do not exercise the bare-`execute` list path when
-    // rows are present — in the zig-test-runner listen protocol, writing tap
-    // names to stdout deadlocks the parent pipe. The bare list (empty case)
-    // is covered by the sibling test above.
+    // Bare-list path with rows present — `io_mod.stdoutFile()` routes the
+    // tap-name writes to stderr under the test runner, so this no longer
+    // deadlocks the IPC pipe.
+    try tap_cli.execute(testing.allocator, &.{});
 }
 
 test "execute with --help short-circuits before touching the database" {

--- a/tests/help_test.zig
+++ b/tests/help_test.zig
@@ -12,8 +12,8 @@ test "showIfRequested returns false when -h/--help absent" {
 }
 
 test "showIfRequested returns true for short -h" {
-    // NOTE: this writes the help text to stderr as a side effect; that's
-    // fine for kcov and is silenced by zig test runners.
+    // Writes help text — redirected to stderr under the test runner by
+    // `io_mod.stdoutFile()`, so it doesn't corrupt the IPC pipe.
     const args = [_][]const u8{"-h"};
     try testing.expect(help.showIfRequested(&args, "install"));
 }

--- a/tests/output_test.zig
+++ b/tests/output_test.zig
@@ -7,6 +7,7 @@
 const std = @import("std");
 const testing = std.testing;
 const output = @import("malt").output;
+const io_mod = @import("malt").io_mod;
 
 fn encode(s: []const u8) ![]u8 {
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
@@ -44,6 +45,23 @@ test "jsonStr passes UTF-8 bytes through unchanged" {
     const got = try encode("café 🍺");
     defer testing.allocator.free(got);
     try testing.expectEqualStrings("\"café 🍺\"", got);
+}
+
+// Regression: under the test runner, `io_mod.stdoutFile()` must resolve to
+// stderr. The runner owns fd 1 for its IPC; any byte on it wedges the
+// build runner in `read()`. If this assertion breaks, `zig build test`
+// starts deadlocking again.
+test "stdoutFile redirects to stderr under the test runner" {
+    try testing.expectEqual(std.Io.File.stderr().handle, io_mod.stdoutFile().handle);
+}
+
+// Regression (paired with the helper above): exercising a call site that
+// previously deadlocked — `stdoutWriteAll` of a multi-KB payload — must
+// complete without hanging and must not land on fd 1.
+test "stdoutWriteAll through the redirected path completes without blocking" {
+    var buf: [4096]u8 = undefined;
+    @memset(&buf, 'x');
+    io_mod.stdoutWriteAll(&buf);
 }
 
 test "jsonStr output round-trips through std.json parser" {

--- a/tests/output_test.zig
+++ b/tests/output_test.zig
@@ -47,17 +47,17 @@ test "jsonStr passes UTF-8 bytes through unchanged" {
     try testing.expectEqualStrings("\"café 🍺\"", got);
 }
 
-// Regression: under the test runner, `io_mod.stdoutFile()` must resolve to
-// stderr. The runner owns fd 1 for its IPC; any byte on it wedges the
-// build runner in `read()`. If this assertion breaks, `zig build test`
-// starts deadlocking again.
-test "stdoutFile redirects to stderr under the test runner" {
-    try testing.expectEqual(std.Io.File.stderr().handle, io_mod.stdoutFile().handle);
+// Regression: under the test runner, `io_mod.stdoutFile()` must not
+// resolve to fd 1. The runner owns fd 1 for its IPC; any byte on it
+// wedges the build runner in `read()`. If this assertion breaks,
+// `zig build test` starts deadlocking again.
+test "stdoutFile is not fd 1 under the test runner" {
+    try testing.expect(io_mod.stdoutFile().handle != std.Io.File.stdout().handle);
 }
 
 // Regression (paired with the helper above): exercising a call site that
 // previously deadlocked — `stdoutWriteAll` of a multi-KB payload — must
-// complete without hanging and must not land on fd 1.
+// complete without hanging.
 test "stdoutWriteAll through the redirected path completes without blocking" {
     var buf: [4096]u8 = undefined;
     @memset(&buf, 'x');


### PR DESCRIPTION
`zig build test` now completes reliably — CI and local dev no longer need the `test-bin` workaround.

Previously, running the full test suite would hang forever on macOS: tests that exercised `--help` or listed taps wrote to stdout, which the test runner owns for its internal protocol, and the build runner would wait indefinitely for a response that never came.