### PR TITLE
feat(upgrade): dim already-at-latest lines so real work pops

### DIFF
--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -152,7 +152,7 @@ fn upgradeFormula(
 
     // Compare versions
     if (std.mem.eql(u8, old_version, formula.version)) {
-        output.info("{s} is already at latest version {s}", .{ name, formula.version });
+        output.skip("{s} is already at latest version {s}", .{ name, formula.version });
         return;
     }
 
@@ -429,7 +429,7 @@ fn upgradeCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Data
 
     const installed_version = installed.version();
     if (std.mem.eql(u8, installed_version, parsed_cask.version)) {
-        output.info("{s} is already at latest version {s}", .{ token, parsed_cask.version });
+        output.skip("{s} is already at latest version {s}", .{ token, parsed_cask.version });
         return;
     }
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -13,6 +13,7 @@ pub const sqlite = @import("db/sqlite.zig");
 pub const atomic = @import("fs/atomic.zig");
 pub const clonefile = @import("fs/clonefile.zig");
 pub const fs_compat = @import("fs/compat.zig");
+pub const color = @import("ui/color.zig");
 pub const io_mod = @import("ui/io.zig");
 pub const codesign = @import("macho/codesign.zig");
 pub const parser = @import("macho/parser.zig");

--- a/src/ui/color.zig
+++ b/src/ui/color.zig
@@ -2,6 +2,7 @@
 //! Terminal color output (NO_COLOR aware).
 
 const std = @import("std");
+const builtin = @import("builtin");
 const fs_compat = @import("../fs/compat.zig");
 
 pub const Style = enum {
@@ -49,6 +50,14 @@ pub fn isEmojiEnabled() bool {
     const result = no_emoji == null;
     emoji_enabled = result;
     return result;
+}
+
+/// Test-only override for the color/emoji caches. Pass `null` to let
+/// the next `is*Enabled` call recompute from env.
+pub fn setForTest(c: ?bool, e: ?bool) void {
+    if (!builtin.is_test) return;
+    color_enabled = c;
+    emoji_enabled = e;
 }
 
 /// Write styled text to stderr. If colors disabled, writes text only.

--- a/src/ui/io.zig
+++ b/src/ui/io.zig
@@ -46,7 +46,31 @@ pub fn stderrFile() std.Io.File {
     return std.Io.File.stderr();
 }
 
+/// Test-only stderr capture. Tests run sequentially in a binary, so no
+/// lock; elided from release via `builtin.is_test` guards.
+var capture_list: ?*std.ArrayList(u8) = null;
+var capture_allocator: std.mem.Allocator = undefined;
+
+/// Test-only: redirect `stderrWriteAll` into `buf`. Pair with `endStderrCapture`.
+pub fn beginStderrCapture(allocator: std.mem.Allocator, buf: *std.ArrayList(u8)) void {
+    if (!builtin.is_test) return;
+    capture_list = buf;
+    capture_allocator = allocator;
+}
+
+/// Test-only: stop redirecting `stderrWriteAll`.
+pub fn endStderrCapture() void {
+    if (!builtin.is_test) return;
+    capture_list = null;
+}
+
 pub fn stderrWriteAll(bytes: []const u8) void {
+    if (builtin.is_test) {
+        if (capture_list) |list| {
+            list.appendSlice(capture_allocator, bytes) catch {};
+            return;
+        }
+    }
     stderrFile().writeStreamingAll(ctx(), bytes) catch return;
 }
 

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -151,6 +151,25 @@ pub fn dim(comptime fmt: []const u8, args: anytype) void {
     io_mod.stderrWriteAll("\n");
 }
 
+/// Dim "nothing to do" status line (e.g. already-at-latest). The bullet
+/// glyph makes it recede next to `▸` activity lines in bulk commands.
+pub fn skip(comptime fmt: []const u8, args: anytype) void {
+    if (quiet) return;
+    var buf: [4096]u8 = undefined;
+    const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
+    const prefix: []const u8 = if (color.isEmojiEnabled()) "  · " else "  . ";
+    if (color.isColorEnabled()) {
+        io_mod.stderrWriteAll(color.Style.dim.code());
+        io_mod.stderrWriteAll(prefix);
+        io_mod.stderrWriteAll(msg);
+        io_mod.stderrWriteAll(color.Style.reset.code());
+    } else {
+        io_mod.stderrWriteAll(prefix);
+        io_mod.stderrWriteAll(msg);
+    }
+    io_mod.stderrWriteAll("\n");
+}
+
 /// Read a single line from stdin and return true iff the trimmed input
 /// matches `expected` exactly.  Prints `prompt` to stderr first.
 ///

--- a/tests/output_test.zig
+++ b/tests/output_test.zig
@@ -8,6 +8,30 @@ const std = @import("std");
 const testing = std.testing;
 const output = @import("malt").output;
 const io_mod = @import("malt").io_mod;
+const color = @import("malt").color;
+
+/// Set up stderr capture with an explicit color/emoji state. Returns a
+/// guard the caller defers to tear down both the capture and the state
+/// override — keeps each byte-level assertion below a single assertion
+/// in length.
+const Capture = struct {
+    buf: *std.ArrayList(u8),
+    prior_quiet: bool,
+
+    fn init(buf: *std.ArrayList(u8), color_on: bool, emoji_on: bool, quiet: bool) Capture {
+        const prior_quiet = output.isQuiet();
+        color.setForTest(color_on, emoji_on);
+        output.setQuiet(quiet);
+        io_mod.beginStderrCapture(testing.allocator, buf);
+        return .{ .buf = buf, .prior_quiet = prior_quiet };
+    }
+
+    fn deinit(self: Capture) void {
+        io_mod.endStderrCapture();
+        color.setForTest(null, null);
+        output.setQuiet(self.prior_quiet);
+    }
+};
 
 fn encode(s: []const u8) ![]u8 {
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
@@ -62,6 +86,148 @@ test "stdoutWriteAll through the redirected path completes without blocking" {
     var buf: [4096]u8 = undefined;
     @memset(&buf, 'x');
     io_mod.stdoutWriteAll(&buf);
+}
+
+// ---------------------------------------------------------------------------
+// Prefixed-line helpers — byte-level contract.
+//
+// Under the test runner, stderr is funneled to /dev/null (see `io_mod`).
+// The `Capture` guard above swaps in an in-memory buffer so each emit can
+// be asserted at the byte level — including the ANSI wrap shape, which
+// differs between the prefix-only helpers (info/warn/success/err) and the
+// full-line helpers (dim/skip). Keeping these locked down guards against
+// accidental style regressions when the helpers are tweaked.
+// ---------------------------------------------------------------------------
+
+test "info wraps only the emoji prefix in cyan; msg stays unstyled" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, true, true, false);
+    defer cap.deinit();
+
+    output.info("hello {s}", .{"world"});
+    try testing.expectEqualStrings("\x1b[36m  ▸ \x1b[0mhello world\n", buf.items);
+}
+
+test "info falls back to ASCII prefix with color and emoji disabled" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, false, false, false);
+    defer cap.deinit();
+
+    output.info("plain", .{});
+    try testing.expectEqualStrings("  > plain\n", buf.items);
+}
+
+test "info is suppressed by --quiet" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, true, true, true);
+    defer cap.deinit();
+
+    output.info("hidden", .{});
+    try testing.expectEqualStrings("", buf.items);
+}
+
+test "warn wraps the yellow prefix and uses the warning glyph" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, true, true, false);
+    defer cap.deinit();
+
+    output.warn("careful", .{});
+    try testing.expectEqualStrings("\x1b[33m  ⚠ \x1b[0mcareful\n", buf.items);
+}
+
+test "success wraps the green prefix and uses the check glyph" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, true, true, false);
+    defer cap.deinit();
+
+    output.success("done", .{});
+    try testing.expectEqualStrings("\x1b[32m  ✓ \x1b[0mdone\n", buf.items);
+}
+
+test "err wraps the red prefix and uses the cross glyph" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, true, true, false);
+    defer cap.deinit();
+
+    output.err("nope", .{});
+    try testing.expectEqualStrings("\x1b[31m  ✗ \x1b[0mnope\n", buf.items);
+}
+
+// Contract: errors always print, even under `--quiet`. If this ever flips,
+// users will stop seeing failure reasons when they pass `-q` to scripts.
+test "err is NOT suppressed by --quiet" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, false, false, true);
+    defer cap.deinit();
+
+    output.err("boom", .{});
+    try testing.expectEqualStrings("  x boom\n", buf.items);
+}
+
+// `dim` and `skip` are full-line wrappers — the dim ANSI must span the
+// whole line (prefix + msg) rather than just the prefix, so the entire
+// line visually recedes.
+test "dim wraps prefix and msg in a single dim ANSI block" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, true, true, false);
+    defer cap.deinit();
+
+    output.dim("background", .{});
+    try testing.expectEqualStrings("\x1b[2m  ▸ background\x1b[0m\n", buf.items);
+}
+
+test "skip uses the bullet glyph and wraps the whole line in dim" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, true, true, false);
+    defer cap.deinit();
+
+    output.skip("{s} is already at latest version {s}", .{ "ripgrep", "14.1.1" });
+    try testing.expectEqualStrings(
+        "\x1b[2m  · ripgrep is already at latest version 14.1.1\x1b[0m\n",
+        buf.items,
+    );
+}
+
+test "skip falls back to ASCII dot when emoji is disabled" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, false, false, false);
+    defer cap.deinit();
+
+    output.skip("fd is already at latest version 10.2.0", .{});
+    try testing.expectEqualStrings("  . fd is already at latest version 10.2.0\n", buf.items);
+}
+
+test "skip is suppressed by --quiet" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, true, true, true);
+    defer cap.deinit();
+
+    output.skip("hidden", .{});
+    try testing.expectEqualStrings("", buf.items);
+}
+
+// Emoji off + color on is a real combination: NO_COLOR unset but
+// MALT_NO_EMOJI set. Make sure the ANSI wrap still lands around the
+// ASCII prefix (no accidental double-styling or missing reset).
+test "info emits ANSI around the ASCII prefix when only emoji is disabled" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, true, false, false);
+    defer cap.deinit();
+
+    output.info("mixed", .{});
+    try testing.expectEqualStrings("\x1b[36m  > \x1b[0mmixed\n", buf.items);
 }
 
 test "jsonStr output round-trips through std.json parser" {


### PR DESCRIPTION
## Summary

When running `malt upgrade` with many already-current packages, every line used to share the same cyan weight — making real upgrade activity hard to spot in the noise.

Already-at-latest lines now render as dim `·` bullets, so actual upgrades (`▸`) and success markers (`✓`) stand out against a calmer background.