### PR TITLE
fix(upgrade): skip "Upgrading…" line when dry-running

### DIFF
--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -156,12 +156,12 @@ fn upgradeFormula(
         return;
     }
 
-    output.info("Upgrading {s} {s} -> {s}...", .{ name, old_version, formula.version });
-
     if (dry_run) {
         output.info("Dry run: would upgrade {s} {s} -> {s}", .{ name, old_version, formula.version });
         return;
     }
+
+    output.info("Upgrading {s} {s} -> {s}...", .{ name, old_version, formula.version });
 
     // Step 3: Resolve bottle for new version
     const bottle = formula_mod.resolveBottle(allocator, &formula) catch {


### PR DESCRIPTION
## Summary

In `--dry-run` mode, `malt upgrade <pkg>` used to print both an "Upgrading …" line and a "Dry run: would upgrade …" line for the same package — implying work was happening even though nothing was being changed.

Dry-run output now shows only the "Dry run: would upgrade …" line, making the preview unambiguous.