### PR TITLE
docs: add polished-output bullet and extend demo with info

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Unlike other alternative clients, malt runs Homebrew `post_install` blocks nativ
 - **Ephemeral run** — `malt run` launches a formula without installing it permanently
 - **Services** — `malt services` manages long-running launchd processes, `brew services`-compatible
 - **Bundles** — `malt bundle install` reads existing `Brewfile`s with no conversion
+- **Polished output** — readable by default, scriptable via `--json`
 - **Path-sandboxed execution** — the DSL interpreter validates all writes stay within the package prefix
 - **Safe under concurrency** — multiple malt processes won't corrupt state
 

--- a/scripts/demo.tape
+++ b/scripts/demo.tape
@@ -60,3 +60,23 @@ Type "malt list --versions"
 Sleep 400ms
 Enter
 Sleep 3s
+
+Type "# Inspect an installed package"
+Sleep 400ms
+Enter
+Sleep 800ms
+
+Type "malt info node"
+Sleep 400ms
+Enter
+Sleep 4s
+
+Type "# …and one that isn't installed yet"
+Sleep 400ms
+Enter
+Sleep 800ms
+
+Type "malt info wget"
+Sleep 400ms
+Enter
+Sleep 4s


### PR DESCRIPTION
## Summary

- Update the "Features" section on README.md
- Demo tape now demonstrates `mt info` for both an installed package and a not-yet-installed one