### PR TITLE
ci(release): sign artifacts with cosign keyless

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - "**/*.zig"
       - "**/*.zon"
+      - "scripts/**/*.sh"
       - ".github/workflows/ci.yml"
   pull_request:
     branches: [main]
     paths:
       - "**/*.zig"
       - "**/*.zon"
+      - "scripts/**/*.sh"
       - ".github/workflows/ci.yml"
 
 jobs:
@@ -35,11 +37,28 @@ jobs:
       - name: Run unit tests
         run: zig build test --summary all
 
-      - name: Smoke test — version flag
+      # Fast sanity probes - catch a totally broken binary before any
+      # of the longer smoke suites run.
+      - name: Smoke - version flag
         run: ./zig-out/bin/malt --version
 
-      - name: Smoke test — help flag
+      - name: Smoke - help flag
         run: ./zig-out/bin/malt --help
+
+      # Offline CLI smoke: exercises every documented command + alias
+      # against an isolated MALT_PREFIX. Tier 3 (network installs) is
+      # skipped in CI - it lives in the benchmark workflow already.
+      - name: CLI smoke (offline tiers)
+        env:
+          SMOKE_SKIP_NETWORK: "1"
+        run: ./scripts/e2e/smoke_test.sh
+
+      # Security smoke: flag-scope enforcement, argv-only lint,
+      # pins-manifest shape, install.sh fail-closed regression suite.
+      # Subsumes the individual lint + install.sh steps that used to
+      # live in the Lint job.
+      - name: Security smoke
+        run: ./scripts/e2e/smoke_security.sh
 
       - name: Build universal binary
         run: zig build universal -Doptimize=ReleaseSafe
@@ -55,5 +74,13 @@ jobs:
         with:
           version: 0.16.0
 
-      - name: Check formatting
+      - name: Check Zig formatting
         run: zig fmt --check src/ tests/
+
+      - name: Install shell-lint tools
+        run: brew install shellcheck shfmt
+
+      - name: Lint shell scripts (shellcheck + shfmt)
+        run: |
+          shellcheck scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh
+          shfmt -i 2 -d scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,28 +37,11 @@ jobs:
       - name: Run unit tests
         run: zig build test --summary all
 
-      # Fast sanity probes - catch a totally broken binary before any
-      # of the longer smoke suites run.
-      - name: Smoke - version flag
+      - name: Smoke test — version flag
         run: ./zig-out/bin/malt --version
 
-      - name: Smoke - help flag
+      - name: Smoke test — help flag
         run: ./zig-out/bin/malt --help
-
-      # Offline CLI smoke: exercises every documented command + alias
-      # against an isolated MALT_PREFIX. Tier 3 (network installs) is
-      # skipped in CI - it lives in the benchmark workflow already.
-      - name: CLI smoke (offline tiers)
-        env:
-          SMOKE_SKIP_NETWORK: "1"
-        run: ./scripts/e2e/smoke_test.sh
-
-      # Security smoke: flag-scope enforcement, argv-only lint,
-      # pins-manifest shape, install.sh fail-closed regression suite.
-      # Subsumes the individual lint + install.sh steps that used to
-      # live in the Lint job.
-      - name: Security smoke
-        run: ./scripts/e2e/smoke_security.sh
 
       - name: Build universal binary
         run: zig build universal -Doptimize=ReleaseSafe
@@ -74,13 +57,8 @@ jobs:
         with:
           version: 0.16.0
 
-      - name: Check Zig formatting
+      - name: Check formatting
         run: zig fmt --check src/ tests/
 
-      - name: Install shell-lint tools
-        run: brew install shellcheck shfmt
-
-      - name: Lint shell scripts (shellcheck + shfmt)
-        run: |
-          shellcheck scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh
-          shfmt -i 2 -d scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh
+      - name: install.sh fail-closed regression tests
+        run: ./scripts/test/install_sh_test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,12 @@ jobs:
     name: goreleaser
     runs-on: macos-14
     needs: create-release-notes
+    # id-token: write is the minimum for cosign keyless - it lets the
+    # job mint a GitHub OIDC token that Sigstore exchanges for a
+    # short-lived signing certificate. Nothing else is widened.
     permissions:
       contents: write
+      id-token: write
     environment:
       name: Release
 
@@ -62,6 +66,9 @@ jobs:
         with:
           go-version: stable
           cache: false
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,8 +21,7 @@ universal_binaries:
     # Drop the `mt` alias next to the universal binary so it ends up
     # inside the release tarball. Matches what `zig build` produces,
     # what install.sh creates via symlink, and what the homebrew_casks
-    # stanza below already declares — the release tarball was the
-    # only distribution path that shipped `malt` without `mt`.
+    # stanza below already declares.
     hooks:
       post:
         - cmd: cp "{{ .Path }}" "{{ dir .Path }}/mt"
@@ -35,7 +34,7 @@ archives:
       - LICENSE
       # Pick up the `mt` copy produced by the universal-binaries
       # post-hook above. `dst: "."` lands it next to `malt` at the
-      # archive root instead of inside an `mt/` subdir.
+      # archive root.
       - src: "dist/*_darwin_all*/mt"
         dst: "."
     wrap_in_directory: true
@@ -43,6 +42,23 @@ archives:
 checksum:
   name_template: checksums.txt
   algorithm: sha256
+
+# Keyless cosign signing of the checksums file. With id-token: write on
+# the release job, cosign mints a short-lived certificate from Sigstore
+# bound to the GitHub Actions OIDC identity of this workflow, signs
+# checksums.txt with it, and publishes a single .sigstore.json bundle
+# (signature + certificate inline).
+# install.sh re-verifies the identity against the workflow URL,
+# so a leaked token cannot forge a release from an arbitrary workflow.
+signs:
+  - cmd: cosign
+    artifacts: checksum
+    signature: ${artifact}.sigstore.json
+    args:
+      - sign-blob
+      - --bundle=${signature}
+      - ${artifact}
+      - --yes
 
 changelog:
   disable: true

--- a/README.md
+++ b/README.md
@@ -57,7 +57,24 @@ Unlike other alternative clients, malt runs Homebrew `post_install` blocks nativ
 curl -fsSL https://raw.githubusercontent.com/indaco/malt/main/scripts/install.sh | bash
 ```
 
-Downloads the latest release, verifies the SHA256 checksum, installs the binary to `/usr/local/bin/`, and creates `/opt/malt` with proper ownership. Falls back to building from source if no release is available.
+Downloads the latest release, verifies the SHA256 checksum **and a cosign keyless signature**, installs the binary to `/usr/local/bin/`, and creates `/opt/malt` with proper ownership. Falls back to building from source if no release is available.
+
+> [!NOTE]
+> The installer requires [`cosign`](https://docs.sigstore.dev/cosign/system_config/installation/) on your `PATH` to cryptographically verify that the release was produced by malt's GitHub Actions workflow. To bypass (not recommended), set `MALT_ALLOW_UNVERIFIED=1`.
+
+#### Verifying `install.sh` itself
+
+The pipe-to-bash pattern can't verify the script that's fetching it. To verify `install.sh` out of band, check it against the tagged copy in this repository:
+
+```bash
+# Pin to a release tag (recommended):
+curl -fsSL "https://raw.githubusercontent.com/indaco/malt/v0.5.1/scripts/install.sh" -o install.sh
+shasum -a 256 install.sh
+# Compare against the SHA printed in the release notes for v0.5.1, then:
+bash install.sh
+```
+
+Once `install.sh` runs, it re-verifies every subsequent download with cosign, so the trust anchor shifts from "whatever HTTPS returned" to "the Sigstore-pinned workflow identity".
 
 ### Via Homebrew
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,6 +12,14 @@ BINARY="malt"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 PREFIX="${PREFIX:-/opt/malt}"
 
+# URL overrides — TESTING ONLY. In production both point at github.com.
+# The regression tests under scripts/test/install_sh_test.sh drive the
+# installer against a local fixture HTTP server, so each integrity-check
+# code path (missing checksums, name not listed, SHA mismatch, happy
+# path) can be exercised without hitting the real release surface.
+RELEASES_BASE_URL="${MALT_TEST_RELEASES_URL:-https://github.com/${REPO}/releases/download}"
+API_LATEST_URL="${MALT_TEST_API_URL:-https://api.github.com/repos/${REPO}/releases/latest}"
+
 # Use sudo only when we actually need it. Root obviously skips it; a
 # non-root run skips it too when INSTALL_DIR and PREFIX are already
 # writable (the common case when testing against /tmp).
@@ -57,9 +65,9 @@ ARCH="$(uname -m)"
 [ "$OS" = "Darwin" ] || error "malt is macOS only. Detected: $OS"
 
 case "$ARCH" in
-  arm64 | aarch64) ARCH_LABEL="arm64" ;;
-  x86_64) ARCH_LABEL="x86_64" ;;
-  *) error "Unsupported architecture: $ARCH" ;;
+arm64 | aarch64) ARCH_LABEL="arm64" ;;
+x86_64) ARCH_LABEL="x86_64" ;;
+*) error "Unsupported architecture: $ARCH" ;;
 esac
 
 info "Detected macOS $ARCH_LABEL"
@@ -82,7 +90,7 @@ if [ -n "$REPO_ROOT" ] && [ -f "${REPO_ROOT}/build.zig" ] && [ -f "${REPO_ROOT}/
 else
   # ── Find latest release ──────────────────────────────────────────
   info "Fetching latest release..."
-  if API_RESPONSE=$(curl -fsSL --connect-timeout 5 --max-time 10 "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null); then
+  if API_RESPONSE=$(curl -fsSL --connect-timeout 5 --max-time 10 "$API_LATEST_URL" 2>/dev/null); then
     LATEST=$(printf '%s' "$API_RESPONSE" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//')
   else
     API_FAILED=1
@@ -147,7 +155,7 @@ else
   # for the "Detected macOS …" banner; the tarball name no longer
   # depends on the host arch.
   ARCHIVE_NAME="malt_${VERSION}_darwin_all.tar.gz"
-  DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST}/${ARCHIVE_NAME}"
+  DOWNLOAD_URL="${RELEASES_BASE_URL}/${LATEST}/${ARCHIVE_NAME}"
 
   TMPDIR=$(mktemp -d)
   trap 'rm -rf "$TMPDIR"' EXIT
@@ -158,10 +166,47 @@ else
 
   # ── Verify checksum (required) ──────────────────────────────────
   # README promises SHA256 verification, so refuse to install without it.
-  CHECKSUM_URL="https://github.com/${REPO}/releases/download/${LATEST}/checksums.txt"
+  CHECKSUM_URL="${RELEASES_BASE_URL}/${LATEST}/checksums.txt"
   info "Verifying SHA256 checksum..."
   curl -fsSL "$CHECKSUM_URL" -o "$TMPDIR/checksums.txt" ||
     error "Could not fetch checksums.txt from ${CHECKSUM_URL}. Refusing to install without verification."
+
+  # ── Verify cosign signature (required unless explicitly opted out) ──
+  # The checksums file is signed keyless at release time by the
+  # goreleaser workflow, producing a single .sigstore.json bundle that
+  # carries both the signature and the Sigstore certificate. Verifying
+  # here ties the SHA list to the exact workflow identity that produced
+  # it; a token capable of uploading a replacement checksums.txt cannot
+  # forge this signature without also being able to run that workflow.
+  BUNDLE_URL="${CHECKSUM_URL}.sigstore.json"
+  CERT_IDENTITY_REGEX="^https://github.com/${REPO}/\\.github/workflows/release\\.yml@"
+  OIDC_ISSUER="https://token.actions.githubusercontent.com"
+
+  if command -v cosign >/dev/null 2>&1; then
+    info "Verifying cosign signature..."
+    # Missing .sigstore.json is a signed-release regression, not a soft
+    # fallback — fail the same way a missing checksum file would.
+    curl -fsSL "$BUNDLE_URL" -o "$TMPDIR/checksums.txt.sigstore.json" ||
+      error "Could not fetch ${BUNDLE_URL}. Refusing to install without signature verification."
+
+    cosign verify-blob \
+      --bundle "$TMPDIR/checksums.txt.sigstore.json" \
+      --certificate-identity-regexp "$CERT_IDENTITY_REGEX" \
+      --certificate-oidc-issuer "$OIDC_ISSUER" \
+      "$TMPDIR/checksums.txt" >/dev/null 2>&1 ||
+      error "cosign signature verification failed for checksums.txt."
+    ok "cosign signature verified"
+  elif [ "${MALT_ALLOW_UNVERIFIED:-0}" = "1" ]; then
+    # Loud on purpose: users who hit this have stepped around a
+    # trust anchor, not a cosmetic check.
+    warn "cosign not installed; MALT_ALLOW_UNVERIFIED=1 — skipping signature verification"
+    warn "install cosign to cryptographically verify the release: https://docs.sigstore.dev/cosign/system_config/installation/"
+  else
+    error "cosign is required to verify the release signature.
+  Install: https://docs.sigstore.dev/cosign/system_config/installation/ (e.g. \`brew install cosign\`)
+  To bypass (not recommended): MALT_ALLOW_UNVERIFIED=1 curl … | bash"
+  fi
+
   EXPECTED=$(grep "$ARCHIVE_NAME" "$TMPDIR/checksums.txt" | awk '{print $1}')
   [ -n "$EXPECTED" ] || error "Checksum for ${ARCHIVE_NAME} not listed in checksums.txt."
   ACTUAL=$(shasum -a 256 "$TMPDIR/$ARCHIVE_NAME" | awk '{print $1}')

--- a/scripts/test/install_sh_test.sh
+++ b/scripts/test/install_sh_test.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# scripts/test/install_sh_test.sh — fail-closed regression tests
+#
+# Exercises the integrity-check paths in scripts/install.sh against a
+# local HTTP fixture server. Locks in Finding #5 of the 2026-04-17
+# audit: every failure mode that could otherwise silently install an
+# attacker-supplied tarball must exit non-zero with nothing installed.
+#
+# Paths covered:
+#   1. missing checksums.txt          → fail, no binary installed
+#   2. archive name not listed in it  → fail, no binary installed
+#   3. SHA256 mismatch                → fail, no binary installed
+#   4. happy path                     → success, binary installed
+#
+# Usage:
+#   ./scripts/test/install_sh_test.sh
+#
+# Requirements: python3 on PATH (used for the fixture HTTP server).
+# The cosign signature path is bypassed via MALT_ALLOW_UNVERIFIED=1 so
+# the harness doesn't need to materialise a live Sigstore certificate.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+command -v python3 >/dev/null 2>&1 || {
+  echo "python3 required for install.sh regression tests" >&2
+  exit 2
+}
+
+TMP=$(mktemp -d /tmp/malt_install_sh_test.XXXXXX)
+SERVER_PID=""
+cleanup() {
+  if [ -n "$SERVER_PID" ]; then
+    disown "$SERVER_PID" 2>/dev/null || true
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+# Copy install.sh to a location far from the malt repo. install.sh's
+# own "Local repository detected?" probe uses `dirname $BASH_SOURCE/..`
+# to find `build.zig`; running it from inside the repo would take the
+# build-from-source branch and never hit the checksum/sig paths we're
+# trying to exercise.
+cp scripts/install.sh "$TMP/install.sh"
+INSTALLER="$TMP/install.sh"
+
+pass=0
+fail=0
+failures=()
+
+start_server() {
+  local root="$1"
+  PORT=$(python3 -c 'import socket;s=socket.socket();s.bind(("",0));print(s.getsockname()[1]);s.close()')
+  python3 -m http.server --directory "$root" --bind 127.0.0.1 "$PORT" >/dev/null 2>&1 &
+  SERVER_PID=$!
+  # Wait for listen.
+  for _ in $(seq 1 50); do
+    if curl -fsSL "http://127.0.0.1:${PORT}/" >/dev/null 2>&1; then return; fi
+    sleep 0.05
+  done
+  echo "fixture http server never came up" >&2
+  exit 2
+}
+stop_server() {
+  if [ -n "$SERVER_PID" ]; then
+    # Suppress the shell's "Terminated: 15" job-control banner by
+    # detaching before killing.
+    disown "$SERVER_PID" 2>/dev/null || true
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  SERVER_PID=""
+}
+
+# Build a minimal "release" layout: a tarball that install.sh will
+# accept on the happy path. Every test case starts from this snapshot
+# and then mutates it (deletes checksums, scrambles entries, etc).
+make_release_fixture() {
+  local dest="$1"
+  local version="$2"
+  rm -rf "$dest"
+  mkdir -p "$dest/v${version}"
+  local archive_name="malt_${version}_darwin_all.tar.gz"
+  local stage="$TMP/stage_${version}"
+  rm -rf "$stage"
+  mkdir -p "$stage/malt_${version}_darwin_all"
+  # Minimal contents: install.sh does a `find -name malt -type f -perm
+  # -u+x` after extraction. A shell script with the exec bit satisfies
+  # it without requiring a real binary.
+  cat >"$stage/malt_${version}_darwin_all/malt" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$stage/malt_${version}_darwin_all/malt"
+  tar -C "$stage" -czf "$dest/v${version}/${archive_name}" "malt_${version}_darwin_all"
+  # Correct checksum so the happy path passes. install.sh itself uses
+  # /usr/bin/shasum; the fixture generator avoids it because some
+  # developer environments ship a broken perl-backed shasum ahead of
+  # it on PATH. Use openssl for deterministic hashing regardless.
+  local hash
+  hash=$(/usr/bin/openssl dgst -sha256 "$dest/v${version}/${archive_name}" | awk '{print $NF}')
+  printf '%s  %s\n' "$hash" "$archive_name" >"$dest/v${version}/checksums.txt"
+  # GitHub API shape for the /releases/latest endpoint.
+  cat >"$dest/latest.json" <<JSON
+{"tag_name": "v${version}", "name": "${version}"}
+JSON
+}
+
+run_installer() {
+  local prefix="$TMP/prefix_$RANDOM"
+  local install_dir="$TMP/bin_$RANDOM"
+  mkdir -p "$prefix" "$install_dir"
+  local rc=0
+  # Force a minimal PATH so the test is stable across dev machines
+  # that shadow `shasum` or `curl` with broken homebrew/nanobrew
+  # binaries ahead of the system install.
+  env -i \
+    HOME="$HOME" \
+    PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+    USER="$USER" \
+    PREFIX="$prefix" \
+    INSTALL_DIR="$install_dir" \
+    MALT_ALLOW_UNVERIFIED=1 \
+    MALT_TEST_RELEASES_URL="http://127.0.0.1:${PORT}" \
+    MALT_TEST_API_URL="http://127.0.0.1:${PORT}/latest.json" \
+    NO_COLOR=1 \
+    bash "$INSTALLER" >"$TMP/out.log" 2>&1 || rc=$?
+  # Caller wants rc, prefix, install_dir. Use distinct separators so
+  # downstream parsers never trip on embedded ':' (there aren't any
+  # here, but future paths may grow).
+  printf '%s|%s|%s\n' "$rc" "$prefix" "$install_dir"
+}
+
+case_result() {
+  local name="$1" expect="$2" got="$3"
+  if [ "$got" = "$expect" ]; then
+    printf '  ✓ %s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf '  ✗ %s (expected rc=%s, got rc=%s)\n' "$name" "$expect" "$got" >&2
+    fail=$((fail + 1))
+    failures+=("$name")
+    sed 's/^/      /' "$TMP/out.log" >&2 || true
+  fi
+}
+
+split_result() {
+  local line="$1"
+  RC=${line%%|*}
+  local rest=${line#*|}
+  # We only track the install_dir side — callers assert on the
+  # binary landing (or not) there. The prefix dir is populated by
+  # run_installer but never inspected after the fact.
+  INSTALL_DIR_USED=${rest#*|}
+}
+
+# ── test 1: happy path ────────────────────────────────────────────────
+printf '▸ happy path\n'
+make_release_fixture "$TMP/releases1" "9.9.9"
+start_server "$TMP/releases1"
+split_result "$(run_installer)"
+stop_server
+case_result "happy path: rc=0" 0 "$RC"
+if [ -x "$INSTALL_DIR_USED/malt" ]; then
+  printf '  ✓ happy path: binary installed\n'
+  pass=$((pass + 1))
+else
+  printf '  ✗ happy path: binary NOT installed at %s\n' "$INSTALL_DIR_USED/malt" >&2
+  fail=$((fail + 1))
+  failures+=("binary-missing")
+fi
+
+# ── test 2: missing checksums.txt ────────────────────────────────────
+printf '▸ missing checksums.txt\n'
+make_release_fixture "$TMP/releases2" "9.9.9"
+rm "$TMP/releases2/v9.9.9/checksums.txt"
+start_server "$TMP/releases2"
+split_result "$(run_installer)"
+stop_server
+if [ "$RC" != "0" ]; then
+  printf '  ✓ missing checksums.txt rejected (rc=%s)\n' "$RC"
+  pass=$((pass + 1))
+else
+  printf '  ✗ missing checksums.txt did NOT fail\n' >&2
+  fail=$((fail + 1))
+  failures+=("missing-checksums-allowed")
+fi
+[ ! -e "$INSTALL_DIR_USED/malt" ] || {
+  printf '  ✗ missing checksums.txt: artifact landed anyway (%s)\n' "$INSTALL_DIR_USED/malt" >&2
+  fail=$((fail + 1))
+  failures+=("missing-checksums-artifact")
+}
+
+# ── test 3: archive name not listed ──────────────────────────────────
+printf '▸ archive not listed in checksums.txt\n'
+make_release_fixture "$TMP/releases3" "9.9.9"
+printf 'deadbeef  other.tar.gz\n' >"$TMP/releases3/v9.9.9/checksums.txt"
+start_server "$TMP/releases3"
+split_result "$(run_installer)"
+stop_server
+if [ "$RC" != "0" ]; then
+  printf '  ✓ unlisted archive rejected (rc=%s)\n' "$RC"
+  pass=$((pass + 1))
+else
+  printf '  ✗ unlisted archive did NOT fail\n' >&2
+  fail=$((fail + 1))
+  failures+=("unlisted-allowed")
+fi
+[ ! -e "$INSTALL_DIR_USED/malt" ] || {
+  printf '  ✗ unlisted archive: artifact landed anyway\n' >&2
+  fail=$((fail + 1))
+  failures+=("unlisted-artifact")
+}
+
+# ── test 4: SHA mismatch ─────────────────────────────────────────────
+printf '▸ SHA256 mismatch\n'
+make_release_fixture "$TMP/releases4" "9.9.9"
+archive_name="malt_9.9.9_darwin_all.tar.gz"
+printf 'dead000000000000000000000000000000000000000000000000000000000000  %s\n' "$archive_name" \
+  >"$TMP/releases4/v9.9.9/checksums.txt"
+start_server "$TMP/releases4"
+split_result "$(run_installer)"
+stop_server
+if [ "$RC" != "0" ]; then
+  printf '  ✓ SHA mismatch rejected (rc=%s)\n' "$RC"
+  pass=$((pass + 1))
+else
+  printf '  ✗ SHA mismatch did NOT fail\n' >&2
+  fail=$((fail + 1))
+  failures+=("sha-mismatch-allowed")
+fi
+[ ! -e "$INSTALL_DIR_USED/malt" ] || {
+  printf '  ✗ SHA mismatch: artifact landed anyway\n' >&2
+  fail=$((fail + 1))
+  failures+=("sha-mismatch-artifact")
+}
+
+printf '\n── summary ──\n'
+printf 'pass: %d\n' "$pass"
+printf 'fail: %d\n' "$fail"
+if [ "$fail" -gt 0 ]; then
+  printf 'failures: %s\n' "${failures[*]}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Users can now cryptographically verify that a malt release came from the official GitHub Actions workflow, not just that its checksum matches what some HTTPS endpoint served. 

Installer fails closed on signature mismatch; absence of `cosign` requires an explicit opt-out env var.