### PR TITLE
feat(security): harden post-install pipeline and service declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,21 @@ jobs:
       - name: Smoke test — help flag
         run: ./zig-out/bin/malt --help
 
+      # Offline CLI smoke: exercises every documented command + alias
+      # against an isolated MALT_PREFIX. Tier 3 (network installs) is
+      # skipped in CI — it lives in the benchmark workflow already.
+      - name: CLI smoke (offline tiers)
+        env:
+          SMOKE_SKIP_NETWORK: "1"
+        run: ./scripts/e2e/smoke_test.sh
+
+      # Security smoke: flag-scope enforcement, argv-only lint,
+      # pins-manifest shape, install.sh fail-closed regression suite.
+      # Subsumes the individual install.sh step that used to live in
+      # the Lint job.
+      - name: Security smoke
+        run: ./scripts/e2e/smoke_security.sh
+
       - name: Build universal binary
         run: zig build universal -Doptimize=ReleaseSafe
 
@@ -57,8 +72,13 @@ jobs:
         with:
           version: 0.16.0
 
-      - name: Check formatting
+      - name: Check Zig formatting
         run: zig fmt --check src/ tests/
 
-      - name: install.sh fail-closed regression tests
-        run: ./scripts/test/install_sh_test.sh
+      - name: Install shell-lint tools
+        run: brew install shellcheck shfmt
+
+      - name: Lint shell scripts (shellcheck + shfmt)
+        run: |
+          shellcheck scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh
+          shfmt -i 2 -d scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing
+
+malt is a Homebrew-compatible package manager written in Zig. These notes
+capture invariants and security rules that every patch is expected to
+honour. If a change can't satisfy one of them, raise the trade-off in
+the PR rather than silently relaxing the rule.
+
+## Security invariants
+
+### Argv-only spawn
+
+Every Zig-side subprocess is spawned through argv-style APIs —
+`fs_compat.Child.init(argv, allocator)` (which forwards to
+`std.process.spawn`). **No `sh -c <string>`, no `/bin/sh`, no shell
+interpolation.** Building argv as a static `[_][]const u8{ … }` is the
+norm; anything that looks like a shell command string in a spawn call
+site is a security regression.
+
+- Enforcement: `scripts/lint-spawn-invariants.sh` runs in CI.
+- Local guard: `tests/spawn_invariant_test.zig` walks `src/` and fails
+  `zig build test` on violations.
+- Legitimate exceptions: only the rejection list in
+  `src/core/services/plist.zig` names `/bin/sh`-style paths, because
+  it's the validator that _refuses_ them in formula-declared services.
+
+### Ruby post_install sandbox
+
+The `--use-system-ruby` path runs in a macOS `sandbox-exec` profile
+that denies network, denies writes outside the formula's cellar and
+`MALT_PREFIX/{etc,var,share,opt}`, strips the environment down to
+`HOME`, a minimal `PATH`, `MALT_PREFIX`, and `TMPDIR`, and applies
+`RLIMIT_CPU`/`RLIMIT_AS`/`RLIMIT_FSIZE` to the child. See
+`src/core/sandbox/macos.zig`. The flag is per-formula — a bare
+`--use-system-ruby` only works when a single package is being
+installed, and is rejected outright on `migrate`.
+
+### Homebrew-core pin
+
+Formula Ruby source fetched over the wire is checked against
+`src/core/pins_manifest.txt` and executed only if the SHA256 matches
+the pinned `homebrew-core` commit in `src/core/pins.zig`. No manifest
+entry = no execution. Regenerate both with `scripts/gen-pins.sh` when
+bumping the pin.
+
+### Service declarations
+
+Formula `service:` blocks flow through `plist_mod.validate` before
+launchd ever sees them: `program_args[0]` must live under the
+formula's own cellar or `MALT_PREFIX/opt/<formula>`, interpreter
+shebangs (`/bin/sh` etc.) are refused as the leading executable,
+argv length / per-arg length are capped, and NUL bytes are rejected.
+
+### Release signing
+
+Releases are signed keyless via cosign in the goreleaser workflow;
+`scripts/install.sh` re-verifies the signature before the SHA check.
+Fail-closed: no signature, no install (bypass requires explicit
+`MALT_ALLOW_UNVERIFIED=1`). The
+`scripts/test/install_sh_test.sh` suite locks the fail-closed paths
+against regression.
+
+## Build & test
+
+```bash
+zig build                                        # Debug binary
+zig build -Doptimize=ReleaseSafe                 # release-equivalent binary
+zig build test                                   # unit tests
+./scripts/lint-spawn-invariants.sh               # argv-only lint
+./scripts/test/install_sh_test.sh                # install.sh regression
+./scripts/local-bench.sh                         # full bench suite (slow)
+./scripts/e2e/smoke_test.sh                      # CLI smoke coverage
+./scripts/e2e/smoke_security.sh                  # security-surface smoke
+```
+
+After any change that touches the items in the **Security invariants**
+section above — sandbox, pins, plist validator, install.sh,
+`--use-system-ruby`, argv-only spawn — run `./scripts/e2e/smoke_security.sh`
+before opening the PR. It's the single entry point that exercises every
+protection end-to-end (flag scoping, argv-only lint, pins-manifest
+shape, install.sh fail-closed suite) in ~10 seconds, fully offline.
+
+## Coding conventions
+
+Follow the idiomatic-Zig patterns already present in the file you're
+editing: explicit error sets, `defer` / `errdefer` for cleanup,
+`anytype` writers, allocator threading over global state. Keep
+comments short and focused on _why_ a non-obvious choice was made —
+don't restate the code.

--- a/build.zig
+++ b/build.zig
@@ -148,6 +148,7 @@ pub fn build(b: *std.Build) void {
         "tests/ruby_subprocess_test.zig",
         "tests/pins_test.zig",
         "tests/sandbox_macos_test.zig",
+        "tests/services_validate_test.zig",
         "tests/cli_tap_test.zig",
         "tests/cli_services_test.zig",
         "tests/install_execute_test.zig",

--- a/build.zig
+++ b/build.zig
@@ -146,6 +146,8 @@ pub fn build(b: *std.Build) void {
         "tests/install_pure_test.zig",
         "tests/dsl_builtins_test.zig",
         "tests/ruby_subprocess_test.zig",
+        "tests/pins_test.zig",
+        "tests/sandbox_macos_test.zig",
         "tests/cli_tap_test.zig",
         "tests/cli_services_test.zig",
         "tests/install_execute_test.zig",

--- a/build.zig
+++ b/build.zig
@@ -149,6 +149,7 @@ pub fn build(b: *std.Build) void {
         "tests/pins_test.zig",
         "tests/sandbox_macos_test.zig",
         "tests/services_validate_test.zig",
+        "tests/spawn_invariant_test.zig",
         "tests/cli_tap_test.zig",
         "tests/cli_services_test.zig",
         "tests/install_execute_test.zig",

--- a/scripts/.spawn-lint-allow
+++ b/scripts/.spawn-lint-allow
@@ -1,0 +1,15 @@
+# scripts/.spawn-lint-allow — exceptions for lint-spawn-invariants.sh
+#
+# Each non-comment line is a grep -E regex. A line that matches any rule
+# is dropped before the violation check. Add entries sparingly — every
+# exception is a potential regression vector.
+
+# The service-file validator lists forbidden interpreter paths on
+# purpose: these are the `program_args[0]` values we *reject* from
+# formula-declared services. They never reach a spawn.
+src/core/services/plist\.zig:.*"/(bin|usr/bin)/(sh|bash|zsh|ksh|env|tcsh|python|perl)"
+
+# Comment lines in plist.zig that name the same interpreters in
+# docstrings/error messages.
+src/core/services/plist\.zig:.*///.*/bin/sh
+src/core/services/plist\.zig:.*//.*/bin/sh

--- a/scripts/e2e/smoke_security.sh
+++ b/scripts/e2e/smoke_security.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# scripts/e2e/smoke_security.sh
+#
+# End-to-end smoke coverage for malt's security-critical surfaces.
+# Each check is a thin exercise of one protection added in the
+# 2026-04-17 audit remediation. Kept separate from smoke_test.sh so
+# "did anything regress on the security story?" has a single, fail-
+# loud entry point.
+#
+# Tiers:
+#   1. CLI flag surface      (--use-system-ruby scoping, help text)
+#   2. Static guards         (argv-only lint, pins_manifest shape)
+#   3. Integration harness   (install.sh fail-closed regression suite)
+#
+# Safe to run anywhere — no network, no real installs, no launchd.
+# Cleans up its tmp prefix on exit.
+#
+# Usage:
+#   ./scripts/e2e/smoke_security.sh
+#   MT_BIN=./zig-out/bin/mt ./scripts/e2e/smoke_security.sh
+
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT" || exit 2
+
+MT_BIN="${MT_BIN:-./zig-out/bin/malt}"
+if [[ ! -x "$MT_BIN" ]]; then
+  echo "smoke-security: $MT_BIN not found — run 'zig build' first" >&2
+  exit 2
+fi
+MT_BIN="$(cd "$(dirname "$MT_BIN")" && pwd)/$(basename "$MT_BIN")"
+
+PREFIX=$(mktemp -d /tmp/mt_sec.XXX)
+CACHE=$(mktemp -d /tmp/mc_sec.XXX)
+LOGDIR=$(mktemp -d /tmp/ml_sec.XXX)
+trap 'rm -rf "$PREFIX" "$CACHE" "$LOGDIR"' EXIT
+
+export MALT_PREFIX="$PREFIX"
+export MALT_CACHE="$CACHE"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+# ── Helpers (same shape as smoke_test.sh so the two read alike) ────────
+
+run() {
+  local tag="$1" expected="$2"
+  shift 2
+  [[ "$1" == "--" ]] && shift
+  local log
+  log="$LOGDIR/$(printf '%s' "$tag" | tr -c 'A-Za-z0-9' _).log"
+  "$@" >"$log" 2>&1
+  local rc=$?
+  if [[ "$rc" == "$expected" ]]; then
+    printf '  PASS  [%s] %s\n' "$tag" "$*"
+    PASS=$((PASS + 1))
+  else
+    printf '  FAIL  [%s] expected exit=%s got=%s :: %s\n' "$tag" "$expected" "$rc" "$*"
+    printf '        log: %s\n' "$log"
+    sed -n '1,10p' "$log" | sed 's/^/        | /'
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$tag")
+  fi
+}
+
+run_ok() {
+  local t="$1"
+  shift
+  run "$t" 0 "$@"
+}
+
+run_grep() {
+  local tag="$1" pat="$2"
+  shift 2
+  [[ "$1" == "--" ]] && shift
+  local log
+  log="$LOGDIR/$(printf '%s' "$tag" | tr -c 'A-Za-z0-9' _).log"
+  "$@" >"$log" 2>&1
+  local rc=$?
+  if [[ "$rc" == 0 ]] && grep -qE "$pat" "$log"; then
+    printf '  PASS  [%s] %s\n' "$tag" "$*"
+    PASS=$((PASS + 1))
+  else
+    printf '  FAIL  [%s] rc=%s, /%s/ missing :: %s\n' "$tag" "$rc" "$pat" "$*"
+    printf '        log: %s\n' "$log"
+    sed -n '1,10p' "$log" | sed 's/^/        | /'
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$tag")
+  fi
+}
+
+manual_pass() {
+  printf '  PASS  [%s] %s\n' "$1" "$2"
+  PASS=$((PASS + 1))
+}
+manual_fail() {
+  printf '  FAIL  [%s] %s\n' "$1" "$2" >&2
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$1")
+}
+
+section() { printf '\n── %s ───────────────────────────────────────\n' "$1"; }
+
+# ── Tier 1 — CLI flag surface ──────────────────────────────────────────
+
+section "Tier 1 — --use-system-ruby scope enforcement + help text"
+
+# The audit (Finding #2) asked us to scope --use-system-ruby per-formula
+# so a DSL parse failure on one package can't auto-widen the trust
+# boundary for all the others. These three exit-code probes lock that in.
+
+# Bare flag with multiple packages is ambiguous → refuse.
+run s1.install.ambiguous 1 -- \
+  "$MT_BIN" install --use-system-ruby fake-pkg-a fake-pkg-b
+
+# Bare flag on migrate is never allowed — would apply to every keg the
+# Homebrew Cellar happens to carry.
+run s1.migrate.bare-rejected 1 -- "$MT_BIN" migrate --use-system-ruby
+
+# Help text must mention the scoped form so users find it.
+run_grep s1.help.install "use-system-ruby" -- "$MT_BIN" install --help
+run_grep s1.help.migrate "use-system-ruby=" -- "$MT_BIN" migrate --help
+
+# ── Tier 2 — static guards ─────────────────────────────────────────────
+
+section "Tier 2 — argv-only lint + pinned-manifest shape"
+
+# Finding #4: shell-invocation patterns in src/ are a regression. The
+# lint script fails non-zero on any hit; re-run it here so "zig build
+# finishes" isn't the only gate.
+run_ok s2.lint.argv -- "$ROOT/scripts/lint-spawn-invariants.sh"
+
+# Finding #1: pins_manifest.txt is the allowlist for the Ruby fetch
+# path. Entries here must have a 64-char lowercase hex SHA256, or the
+# runtime parser will reject them. This catches a botched gen-pins.sh
+# run before release rather than at install time.
+MANIFEST="$ROOT/src/core/pins_manifest.txt"
+if [[ ! -f "$MANIFEST" ]]; then
+  manual_fail s2.manifest.exists "src/core/pins_manifest.txt missing"
+else
+  bad_line=""
+  entries=0
+  while IFS= read -r raw; do
+    line="${raw%%$'\r'*}"
+    # Skip comments + blanks (same parser as src/core/pins.zig).
+    [[ -z "$line" ]] && continue
+    [[ "${line:0:1}" == "#" ]] && continue
+    entries=$((entries + 1))
+    name="${line%% *}"
+    rest="${line#* }"
+    # Strip leading whitespace.
+    rest="${rest#"${rest%%[! $'\t']*}"}"
+    hash="${rest:0:64}"
+    if [[ ! "$hash" =~ ^[0-9a-f]{64}$ ]]; then
+      bad_line="$raw"
+      break
+    fi
+    if [[ -z "$name" ]]; then
+      bad_line="$raw"
+      break
+    fi
+  done <"$MANIFEST"
+  if [[ -n "$bad_line" ]]; then
+    manual_fail s2.manifest.shape "malformed entry: $bad_line"
+  else
+    manual_pass s2.manifest.shape "$entries entries, all well-formed (64-char lowercase hex SHA256)"
+  fi
+fi
+
+# The pinned commit constant should be a 40-char lowercase hex SHA.
+PINS_ZIG="$ROOT/src/core/pins.zig"
+sha=$(grep -E 'HOMEBREW_CORE_COMMIT_SHA.*=.*"' "$PINS_ZIG" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+if [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+  manual_pass s2.pins.commit-sha "pinned commit: $sha"
+else
+  manual_fail s2.pins.commit-sha "HOMEBREW_CORE_COMMIT_SHA is not 40-char hex: '$sha'"
+fi
+
+# ── Tier 3 — install.sh fail-closed regression harness ────────────────
+
+section "Tier 3 — install.sh fail-closed regression suite"
+
+# The suite under scripts/test/ owns the detailed assertions (happy
+# path + missing checksums + unlisted archive + SHA mismatch). We
+# shell out so one top-level smoke run covers the integrity story.
+if "$ROOT/scripts/test/install_sh_test.sh" >"$LOGDIR/install_sh.log" 2>&1; then
+  manual_pass s3.install_sh "checksum/signature paths all fail-closed"
+else
+  manual_fail s3.install_sh "install_sh_test.sh suite failed — see $LOGDIR/install_sh.log"
+  sed -n '1,30p' "$LOGDIR/install_sh.log" | sed 's/^/        | /' >&2
+fi
+
+# Informational: cosign presence. Missing cosign forces MALT_ALLOW_UNVERIFIED
+# in production, which is a degraded mode. We just report it.
+if command -v cosign >/dev/null 2>&1; then
+  printf '  INFO  [s3.cosign] cosign on PATH — install.sh will verify signatures\n'
+else
+  printf '  INFO  [s3.cosign] cosign NOT on PATH — install.sh will demand MALT_ALLOW_UNVERIFIED=1\n'
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────
+
+section "Summary"
+TOTAL=$((PASS + FAIL))
+printf 'Ran %d security checks — %d passed, %d failed.\n' "$TOTAL" "$PASS" "$FAIL"
+if ((FAIL > 0)); then
+  printf 'Failures:\n'
+  for t in "${FAILURES[@]}"; do printf '  - %s\n' "$t"; done
+  printf 'Logs in: %s (preserved on failure)\n' "$LOGDIR"
+  trap - EXIT
+  exit 1
+fi
+exit 0

--- a/scripts/gen-pins.sh
+++ b/scripts/gen-pins.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# scripts/gen-pins.sh — regenerate src/core/pins.zig + pins_manifest.txt
+#
+# Pins the homebrew-core fetch path in malt to a specific commit and
+# records the SHA256 of every formula's .rb blob at that commit. The
+# runtime refuses any formula whose fetched source doesn't match an
+# entry here (see src/core/pins.zig::expectedSha256).
+#
+# Usage:
+#   scripts/gen-pins.sh                        # auto-pin to current HEAD
+#   scripts/gen-pins.sh <commit-sha>           # pin to specific commit
+#   FORMULAS="fontconfig openssl@3" scripts/gen-pins.sh
+#
+# Env:
+#   FORMULAS  — space-separated list of formulas to seed. Defaults to a
+#               small set covering the most common post_install paths.
+#
+# Output: writes src/core/pins.zig's SHA constant and rewrites
+#         src/core/pins_manifest.txt in place. Run `git diff` after.
+#
+# Network: fetches from raw.githubusercontent.com; safe to run offline
+#          only if the target commit is already cached (rare — don't).
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT"
+
+# Default seed set — formulas commonly hit by the --use-system-ruby
+# fallback path. Callers can override via FORMULAS env var.
+DEFAULT_FORMULAS=(
+  fontconfig
+  node
+  openssl@3
+  python@3.12
+  ruby
+)
+# shellcheck disable=SC2206
+read -r -a FORMULAS_ARR <<<"${FORMULAS:-${DEFAULT_FORMULAS[*]}}"
+
+if [ $# -ge 1 ]; then
+  COMMIT="$1"
+else
+  printf '▸ resolving homebrew-core HEAD\n' >&2
+  COMMIT=$(curl -fsSL --max-time 10 \
+    "https://api.github.com/repos/Homebrew/homebrew-core/commits/HEAD" |
+    awk -F'"' '/^  "sha":/ {print $4; exit}')
+  [ -n "$COMMIT" ] || {
+    echo "failed to resolve HEAD" >&2
+    exit 1
+  }
+fi
+
+case "$COMMIT" in
+[0-9a-f]*)
+  [ ${#COMMIT} -eq 40 ] || {
+    echo "not a 40-char SHA: $COMMIT" >&2
+    exit 1
+  }
+  ;;
+*)
+  echo "not a hex SHA: $COMMIT" >&2
+  exit 1
+  ;;
+esac
+printf '▸ pinning to %s\n' "$COMMIT" >&2
+
+# Rewrite pins.zig's commit constant. sed -i portability: BSD sed needs
+# -i '' (empty extension); GNU sed accepts -i with no arg. Detect.
+if sed --version >/dev/null 2>&1; then
+  SED_INPLACE=(sed -i)
+else
+  SED_INPLACE=(sed -i '')
+fi
+"${SED_INPLACE[@]}" \
+  "s|^pub const HOMEBREW_CORE_COMMIT_SHA: \\[\\]const u8 = .*|pub const HOMEBREW_CORE_COMMIT_SHA: []const u8 = \"${COMMIT}\";|" \
+  src/core/pins.zig
+
+# Regenerate the manifest.
+MANIFEST=src/core/pins_manifest.txt
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+
+cat >"$TMP" <<'HEADER'
+# malt — pinned formula source manifest
+#
+# One record per line:  <formula-name> <sha256-of-.rb-at-pinned-commit>
+#
+# Entries here authorize fetchPostInstallFromGitHub() to execute the
+# matching Ruby source after verifying its SHA256. Formulas with no
+# entry are refused — the code path is fail-closed.
+#
+# Regenerate with: scripts/gen-pins.sh
+# Pinned commit lives in src/core/pins.zig (HOMEBREW_CORE_COMMIT_SHA).
+#
+# Lines starting with '#' and blank lines are ignored.
+HEADER
+printf '\n' >>"$TMP"
+
+for name in "${FORMULAS_ARR[@]}"; do
+  [ -n "$name" ] || continue
+  first=${name:0:1}
+  url="https://raw.githubusercontent.com/Homebrew/homebrew-core/${COMMIT}/Formula/${first}/${name}.rb"
+  body=$(curl -fsSL --max-time 15 "$url" || true)
+  if [ -z "$body" ]; then
+    printf '  ⚠ %s: fetch failed (skipping)\n' "$name" >&2
+    continue
+  fi
+  # Use /usr/bin paths directly — some dev environments shadow shasum
+  # with a broken homebrew/nanobrew perl-backed wrapper ahead of the
+  # system one (the same bug that bit scripts/test/install_sh_test.sh).
+  sha=$(printf '%s' "$body" | /usr/bin/shasum -a 256 | awk '{print $1}')
+  printf '%s %s\n' "$name" "$sha" >>"$TMP"
+  printf '  ✓ %-24s %s\n' "$name" "$sha" >&2
+done
+
+mv "$TMP" "$MANIFEST"
+trap - EXIT
+printf '\n▸ wrote %s\n' "$MANIFEST" >&2
+printf '▸ review the diff, then commit:\n' >&2
+printf '    git diff src/core/pins.zig src/core/pins_manifest.txt\n' >&2

--- a/scripts/lint-spawn-invariants.sh
+++ b/scripts/lint-spawn-invariants.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# scripts/lint-spawn-invariants.sh — fail on shell-invocation patterns
+#
+# Every Zig-side process spawn in malt goes through argv-style APIs
+# (`std.process.spawn` via `fs_compat.Child.init`). A bare `sh -c …`
+# or `/bin/sh …` argv in src/ would quietly restore the shell-injection
+# surface we've spent time eliminating — run this in CI to catch
+# regressions before they merge.
+#
+# Exits 0 if src/ is clean, non-zero with offending lines on violation.
+#
+# Usage:
+#   scripts/lint-spawn-invariants.sh           # check the tree
+#
+# The allowlist file lives at scripts/.spawn-lint-allow. Each line is a
+# `path:regex` that excuses a specific match; keep it empty unless you
+# have a real reason.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT"
+
+ALLOW_FILE="scripts/.spawn-lint-allow"
+
+PATTERN='sh -c|bash -c|zsh -c|/bin/sh|/bin/bash|/bin/zsh|/usr/bin/env '
+hits=$(grep -RnE --include='*.zig' "$PATTERN" src || true)
+
+# Drop allowlisted matches.
+if [ -s "$ALLOW_FILE" ]; then
+  while IFS= read -r rule; do
+    [ -z "$rule" ] && continue
+    [[ "$rule" == \#* ]] && continue
+    hits=$(printf '%s\n' "$hits" | grep -vE "$rule" || true)
+  done <"$ALLOW_FILE"
+fi
+
+if [ -n "$hits" ]; then
+  printf '✗ argv-only spawn invariant violated:\n\n' >&2
+  printf '%s\n' "$hits" >&2
+  printf '\nIf a match is intentional (it almost never is), add a line to %s.\n' "$ALLOW_FILE" >&2
+  exit 1
+fi
+
+printf '✓ argv-only spawn invariant holds across src/\n'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -60,7 +60,9 @@ const install_help =
     \\  --formula          Force formula installation
     \\  --dry-run          Show what would be installed
     \\  --force            Overwrite existing installations
-    \\  --use-system-ruby  Execute post_install scripts via system Ruby (experimental)
+    \\  --use-system-ruby[=<name>,...]  Run post_install via the system Ruby interpreter
+    \\                     (experimental, sandboxed). A bare flag requires a single
+    \\                     package; use =<name>,... to scope when installing multiple.
     \\  --quiet, -q        Suppress non-error output
     \\  --json             Output result as JSON
     \\
@@ -175,7 +177,10 @@ const migrate_help =
     \\
     \\Flags:
     \\  --dry-run          Show what would be migrated
-    \\  --use-system-ruby  Execute post_install scripts via system Ruby (experimental)
+    \\  --use-system-ruby=<name>,...  Run post_install via the system Ruby interpreter
+    \\                     (experimental, sandboxed) for the named kegs only. A bare
+    \\                     `--use-system-ruby` is not allowed here — it would widen
+    \\                     the trust boundary to every keg discovered in the Cellar.
     \\
 ;
 

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -95,7 +95,19 @@ pub const InstallError = error{
     /// Raised before any dep resolution or job queueing so nothing is
     /// downloaded, materialised, or linked for the affected package.
     PostInstallUnsupported,
+    /// `--use-system-ruby` used with multiple formulas and no explicit
+    /// scope list. The flag widens the trust boundary (runs full Ruby
+    /// with only OS-level sandboxing), so malt requires the user to
+    /// name which formulas it should apply to when ambiguity exists.
+    AmbiguousSystemRubyScope,
 };
+
+/// Whether --use-system-ruby opts the named formula into the Ruby
+/// post_install path. Caller carries the parsed scope from the flag.
+fn useSystemRubyForFormula(scope: []const []const u8, formula_name: []const u8) bool {
+    for (scope) |n| if (std.mem.eql(u8, n, formula_name)) return true;
+    return false;
+}
 
 /// A bottle download job for parallel processing.
 ///
@@ -246,7 +258,15 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // allowing programmatic callers to pass `--dry-run` directly in `args`.
     var dry_run = output.isDryRun();
     var force = false;
-    var use_system_ruby = false;
+    // `--use-system-ruby` scope: the audit flagged a session-wide flag
+    // as an auto-fallback trust widener. We keep the flag ergonomic
+    // when a single formula is installed (bare flag implies that
+    // formula) but require an explicit `--use-system-ruby=name[,name]`
+    // list when multiple formulas are queued, so a DSL parse failure
+    // on one never enables Ruby for the rest.
+    var use_system_ruby_bare = false;
+    var use_system_ruby_scope: std.ArrayList([]const u8) = .empty;
+    defer use_system_ruby_scope.deinit(allocator);
 
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "--cask")) {
@@ -258,7 +278,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         } else if (std.mem.eql(u8, arg, "--force")) {
             force = true;
         } else if (std.mem.eql(u8, arg, "--use-system-ruby")) {
-            use_system_ruby = true;
+            use_system_ruby_bare = true;
+        } else if (std.mem.startsWith(u8, arg, "--use-system-ruby=")) {
+            const list = arg["--use-system-ruby=".len..];
+            var it = std.mem.splitScalar(u8, list, ',');
+            while (it.next()) |name| {
+                if (name.len > 0) try use_system_ruby_scope.append(allocator, name);
+            }
         } else if (std.mem.eql(u8, arg, "--quiet") or std.mem.eql(u8, arg, "-q")) {
             output.setQuiet(true);
         } else if (std.mem.eql(u8, arg, "--json")) {
@@ -272,6 +298,22 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         output.err("No package names specified", .{});
         return InstallError.NoPackages;
     }
+
+    // Disambiguate bare `--use-system-ruby`: accept it as shorthand
+    // when exactly one formula was listed; otherwise the user must
+    // name which formulas should get the wider path.
+    if (use_system_ruby_bare) {
+        if (packages.items.len == 1) {
+            try use_system_ruby_scope.append(allocator, packages.items[0]);
+        } else {
+            output.err(
+                "--use-system-ruby needs a scope when multiple packages are installed; use --use-system-ruby={s}[,<name>...]",
+                .{packages.items[0]},
+            );
+            return InstallError.AmbiguousSystemRubyScope;
+        }
+    }
+    const use_system_ruby_list: []const []const u8 = use_system_ruby_scope.items;
 
     // Initialize infrastructure
     const prefix = atomic.maltPrefix();
@@ -685,13 +727,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
                             flog.printFatal(job.name);
                             break :post_install;
                         }
-                        if (use_system_ruby) {
+                        if (useSystemRubyForFormula(use_system_ruby_list, job.name)) {
                             output.warn("post_install DSL incomplete for {s}, falling back to system Ruby...", .{job.name});
                             ruby_sub.runPostInstall(allocator, job.name, job.version_str, prefix) catch |e| {
                                 output.warn("post_install subprocess failed for {s}: {s}", .{ job.name, @errorName(e) });
                             };
                         } else {
-                            output.warn("{s}: post_install partially skipped (use --use-system-ruby to attempt via Ruby)", .{job.name});
+                            output.warn("{s}: post_install partially skipped (use --use-system-ruby={s} to attempt via Ruby)", .{ job.name, job.name });
                         }
                         break :post_install;
                     };
@@ -719,12 +761,12 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
                         flog.printFatal(job.name);
                         break :post_install;
                     }
-                    if (use_system_ruby) {
+                    if (useSystemRubyForFormula(use_system_ruby_list, job.name)) {
                         ruby_sub.runPostInstall(allocator, job.name, job.version_str, prefix) catch |e| {
                             output.warn("post_install subprocess failed for {s}: {s}", .{ job.name, @errorName(e) });
                         };
                     } else {
-                        output.warn("{s}: post_install partially skipped (use --use-system-ruby to attempt via Ruby)", .{job.name});
+                        output.warn("{s}: post_install partially skipped (use --use-system-ruby={s} to attempt via Ruby)", .{ job.name, job.name });
                     }
                     break :post_install;
                 };
@@ -733,13 +775,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             }
 
             // No source available — fall back to subprocess or skip
-            if (use_system_ruby) {
+            if (useSystemRubyForFormula(use_system_ruby_list, job.name)) {
                 output.warn("Running post_install for {s} via system Ruby...", .{job.name});
                 ruby_sub.runPostInstall(allocator, job.name, job.version_str, prefix) catch |e| {
                     output.warn("post_install failed for {s}: {s}", .{ job.name, @errorName(e) });
                 };
             } else {
-                output.warn("{s}: post_install skipped (use --use-system-ruby or brew install {s})", .{ job.name, job.name });
+                output.warn("{s}: post_install skipped (use --use-system-ruby={s} or brew install {s})", .{ job.name, job.name, job.name });
             }
         }
     }
@@ -1131,6 +1173,9 @@ fn linkAndRecord(
 
 /// Register a launchd service when the formula carries a `service:` block.
 /// Best-effort: failures only emit a warning so they don't fail the install.
+/// Path validation (interpreter bait, path escape, argv caps) is run
+/// inside `supervisor.register` against the formula's cellar + the
+/// install prefix.
 fn maybeRegisterService(
     allocator: std.mem.Allocator,
     db: *sqlite.Database,
@@ -1156,6 +1201,13 @@ fn maybeRegisterService(
         fs_compat.cwd().makePath(dir) catch {};
     } else |_| {}
 
+    var cellar_buf: [512]u8 = undefined;
+    const cellar_path = std.fmt.bufPrint(
+        &cellar_buf,
+        "{s}/Cellar/{s}/{s}",
+        .{ prefix, formula.name, formula.version },
+    ) catch return;
+
     const spec: plist_mod.ServiceSpec = .{
         .label = label,
         .program_args = def.run,
@@ -1166,7 +1218,7 @@ fn maybeRegisterService(
         .keep_alive = def.keep_alive,
     };
 
-    supervisor_mod.register(allocator, db, spec, formula.name, false) catch |err| {
+    supervisor_mod.register(allocator, db, spec, formula.name, false, cellar_path, prefix) catch |err| {
         output.warn("could not register service for {s}: {s}", .{ formula.name, @errorName(err) });
     };
 }

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -24,6 +24,11 @@ const ruby_sub = @import("../core/ruby_subprocess.zig");
 const dsl = @import("../core/dsl/root.zig");
 const help = @import("help.zig");
 
+fn inScope(scope: []const []const u8, name: []const u8) bool {
+    for (scope) |n| if (std.mem.eql(u8, n, name)) return true;
+    return false;
+}
+
 /// Result of migrating a single keg.
 const KegResult = enum {
     migrated,
@@ -39,11 +44,30 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "migrate")) return;
 
     var dry_run = output.isDryRun();
-    var use_system_ruby = false;
+    // Ruby is opt-in per keg only. A bare --use-system-ruby across a
+    // whole `migrate` would widen the trust boundary to every
+    // Homebrew-Cellar entry at once; refuse it and require names.
+    var use_system_ruby_bare = false;
+    var use_system_ruby_scope: std.ArrayList([]const u8) = .empty;
+    defer use_system_ruby_scope.deinit(allocator);
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "--dry-run")) dry_run = true;
-        if (std.mem.eql(u8, arg, "--use-system-ruby")) use_system_ruby = true;
+        if (std.mem.eql(u8, arg, "--use-system-ruby")) use_system_ruby_bare = true;
+        if (std.mem.startsWith(u8, arg, "--use-system-ruby=")) {
+            const list = arg["--use-system-ruby=".len..];
+            var it = std.mem.splitScalar(u8, list, ',');
+            while (it.next()) |name| {
+                if (name.len > 0) try use_system_ruby_scope.append(allocator, name);
+            }
+        }
         if (std.mem.eql(u8, arg, "--quiet") or std.mem.eql(u8, arg, "-q")) output.setQuiet(true);
+    }
+    if (use_system_ruby_bare) {
+        output.err(
+            "bare --use-system-ruby is not allowed with `migrate`; scope it: --use-system-ruby=<name>[,<name>...]",
+            .{},
+        );
+        return error.Aborted;
     }
 
     // ── Step 1: Detect Homebrew prefix ──────────────────────────────
@@ -158,7 +182,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             &linker,
             &db,
             prefix,
-            use_system_ruby,
+            use_system_ruby_scope.items,
         );
 
         switch (result) {
@@ -214,7 +238,7 @@ fn migrateKeg(
     linker: *linker_mod.Linker,
     db: *sqlite.Database,
     prefix: []const u8,
-    use_system_ruby: bool,
+    use_system_ruby_scope: []const []const u8,
 ) KegResult {
     // 1. Check if already installed in malt
     if (isInstalled(db, keg_name)) {
@@ -326,12 +350,12 @@ fn migrateKeg(
                         flog.printFatal(formula.name);
                         break :post_install;
                     }
-                    if (use_system_ruby) {
+                    if (inScope(use_system_ruby_scope, formula.name)) {
                         ruby_sub.runPostInstall(allocator, formula.name, formula.version, prefix) catch |e| {
                             output.warn("  post_install subprocess failed for {s}: {s}", .{ formula.name, @errorName(e) });
                         };
                     } else {
-                        output.warn("  {s}: post_install partially skipped (use --use-system-ruby to attempt via Ruby)", .{formula.name});
+                        output.warn("  {s}: post_install partially skipped (use --use-system-ruby={s} to attempt via Ruby)", .{ formula.name, formula.name });
                     }
                     break :post_install;
                 };
@@ -353,12 +377,12 @@ fn migrateKeg(
                     flog2.printFatal(formula.name);
                     break :post_install;
                 }
-                if (use_system_ruby) {
+                if (inScope(use_system_ruby_scope, formula.name)) {
                     ruby_sub.runPostInstall(allocator, formula.name, formula.version, prefix) catch |e| {
                         output.warn("  post_install subprocess failed for {s}: {s}", .{ formula.name, @errorName(e) });
                     };
                 } else {
-                    output.warn("  {s}: post_install partially skipped (use --use-system-ruby to attempt via Ruby)", .{formula.name});
+                    output.warn("  {s}: post_install partially skipped (use --use-system-ruby={s} to attempt via Ruby)", .{ formula.name, formula.name });
                 }
                 break :post_install;
             };
@@ -367,13 +391,13 @@ fn migrateKeg(
         }
 
         // No source available — fall back to subprocess or skip
-        if (use_system_ruby) {
+        if (inScope(use_system_ruby_scope, formula.name)) {
             output.warn("  Running post_install for {s} via system Ruby...", .{formula.name});
             ruby_sub.runPostInstall(allocator, formula.name, formula.version, prefix) catch |e| {
                 output.warn("  post_install failed for {s}: {s}", .{ formula.name, @errorName(e) });
             };
         } else {
-            output.warn("  {s}: post_install skipped (use --use-system-ruby or brew install {s})", .{ formula.name, formula.name });
+            output.warn("  {s}: post_install skipped (use --use-system-ruby={s} or brew install {s})", .{ formula.name, formula.name, formula.name });
         }
     }
 

--- a/src/core/dsl/sandbox.zig
+++ b/src/core/dsl/sandbox.zig
@@ -74,7 +74,7 @@ fn containsDotDot(path: []const u8) bool {
 /// path-component boundary. Guards against substring matches such as
 /// `prefix="/opt/malt"` vs `path="/opt/malthack"` where a plain
 /// `std.mem.startsWith` would incorrectly return true.
-fn pathHasPrefix(path: []const u8, prefix: []const u8) bool {
+pub fn pathHasPrefix(path: []const u8, prefix: []const u8) bool {
     if (prefix.len == 0) return false;
     if (!std.mem.startsWith(u8, path, prefix)) return false;
     if (path.len == prefix.len) return true;

--- a/src/core/pins.zig
+++ b/src/core/pins.zig
@@ -1,0 +1,92 @@
+//! malt — pinned homebrew-core source integrity
+//!
+//! Ruby formula sources fetched from GitHub over the wire are untrusted
+//! until verified. This module ships (a) a compile-time-embedded commit
+//! SHA identifying the snapshot of homebrew-core this release of malt
+//! was built against, and (b) an embedded manifest mapping formula name
+//! -> expected SHA256 of the .rb blob at that commit. The fetch path in
+//! ruby_subprocess.zig uses both to refuse anything outside this pin.
+//!
+//! Regenerate with `scripts/gen-pins.sh` whenever the pinned commit
+//! bumps — the release should never ship with a stale pin.
+
+const std = @import("std");
+
+/// Pinned homebrew-core commit. Floating `HEAD` gave every release a
+/// TOFU window against a silent upstream rewrite; this constant nails
+/// the fetch URL to a single tree an auditor can reproduce.
+///
+/// Bump at release time via `scripts/gen-pins.sh`.
+pub const HOMEBREW_CORE_COMMIT_SHA: []const u8 = "5d3790f92c7873f1fd8e5e2ecd6fbc689a78a96f";
+
+const MANIFEST_TEXT: []const u8 = @embedFile("pins_manifest.txt");
+
+/// Length of a lowercase hex SHA256 digest.
+pub const SHA256_HEX_LEN: usize = 64;
+
+/// Look up the expected SHA256 (as lowercase hex) for a formula at the
+/// pinned commit. Returns null when no entry exists — the caller must
+/// treat "no entry" as a refusal, not a pass-through.
+///
+/// Linear scan: the manifest is in the thousands of bytes and this
+/// function is hit at most once per formula install, behind a network
+/// round-trip, so a StringHashMap would cost more than it saves.
+pub fn expectedSha256(name: []const u8) ?[]const u8 {
+    if (name.len == 0) return null;
+    var it = std.mem.splitScalar(u8, MANIFEST_TEXT, '\n');
+    while (it.next()) |raw| {
+        const line = std.mem.trim(u8, raw, " \t\r");
+        if (line.len == 0 or line[0] == '#') continue;
+
+        // Split on the first run of whitespace. Names are
+        // [a-z0-9@._+-], so any space/tab ends the name field.
+        const sep = std.mem.indexOfAny(u8, line, " \t") orelse continue;
+        const entry_name = line[0..sep];
+        if (!std.mem.eql(u8, entry_name, name)) continue;
+
+        const rest = std.mem.trimStart(u8, line[sep..], " \t");
+        if (rest.len < SHA256_HEX_LEN) return null;
+        const hash = rest[0..SHA256_HEX_LEN];
+        if (!isHexLower(hash)) return null;
+        return hash;
+    }
+    return null;
+}
+
+fn isHexLower(s: []const u8) bool {
+    for (s) |c| switch (c) {
+        '0'...'9', 'a'...'f' => {},
+        else => return false,
+    };
+    return true;
+}
+
+/// Compute the SHA256 of `bytes` as lowercase hex. Returns the caller-
+/// owned `[SHA256_HEX_LEN]u8` written in-place to `out`.
+pub fn sha256Hex(bytes: []const u8, out: *[SHA256_HEX_LEN]u8) void {
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+    const hex = std.fmt.bytesToHex(digest, .lower);
+    @memcpy(out, hex[0..]);
+}
+
+test "expectedSha256 — missing entry returns null" {
+    try std.testing.expectEqual(@as(?[]const u8, null), expectedSha256("definitely-not-in-manifest"));
+    try std.testing.expectEqual(@as(?[]const u8, null), expectedSha256(""));
+}
+
+test "expectedSha256 — comment/blank tolerant parser" {
+    // This test exercises the parser shape. The manifest ships empty by
+    // default (header-only), so we confirm lookup-on-empty returns null
+    // without crashing on the comment lines.
+    try std.testing.expectEqual(@as(?[]const u8, null), expectedSha256("fontconfig"));
+}
+
+test "sha256Hex — known vector" {
+    var out: [SHA256_HEX_LEN]u8 = undefined;
+    sha256Hex("hello", &out);
+    try std.testing.expectEqualStrings(
+        "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+        &out,
+    );
+}

--- a/src/core/pins.zig
+++ b/src/core/pins.zig
@@ -27,13 +27,20 @@ pub const SHA256_HEX_LEN: usize = 64;
 /// Look up the expected SHA256 (as lowercase hex) for a formula at the
 /// pinned commit. Returns null when no entry exists — the caller must
 /// treat "no entry" as a refusal, not a pass-through.
-///
-/// Linear scan: the manifest is in the thousands of bytes and this
-/// function is hit at most once per formula install, behind a network
-/// round-trip, so a StringHashMap would cost more than it saves.
 pub fn expectedSha256(name: []const u8) ?[]const u8 {
+    return lookupIn(MANIFEST_TEXT, name);
+}
+
+/// Parser shared by `expectedSha256` and the unit tests. Split out so
+/// manifest-parsing edge cases (malformed hex, wrong separator, weird
+/// whitespace) can be covered without rebuilding the embedded manifest.
+///
+/// Linear scan: manifests are in the thousands of bytes and this runs
+/// at most once per formula install, behind a network round-trip, so a
+/// StringHashMap would cost more than it saves.
+pub fn lookupIn(manifest: []const u8, name: []const u8) ?[]const u8 {
     if (name.len == 0) return null;
-    var it = std.mem.splitScalar(u8, MANIFEST_TEXT, '\n');
+    var it = std.mem.splitScalar(u8, manifest, '\n');
     while (it.next()) |raw| {
         const line = std.mem.trim(u8, raw, " \t\r");
         if (line.len == 0 or line[0] == '#') continue;

--- a/src/core/pins_manifest.txt
+++ b/src/core/pins_manifest.txt
@@ -1,0 +1,12 @@
+# malt — pinned formula source manifest
+#
+# One record per line:  <formula-name> <sha256-of-.rb-at-pinned-commit>
+#
+# Entries here authorize fetchPostInstallFromGitHub() to execute the
+# matching Ruby source after verifying its SHA256. Formulas with no
+# entry are refused — the code path is fail-closed.
+#
+# Regenerate with: scripts/gen-pins.sh
+# Pinned commit lives in src/core/pins.zig (HOMEBREW_CORE_COMMIT_SHA).
+#
+# Lines starting with '#' and blank lines are ignored.

--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -8,6 +8,10 @@ const fs_compat = @import("../fs/compat.zig");
 const builtin = @import("builtin");
 const output = @import("../ui/output.zig");
 const codesign = @import("../macho/codesign.zig");
+const pins = @import("pins.zig");
+const http_client = @import("../net/client.zig");
+const api_mod = @import("../net/api.zig");
+const sandbox = @import("sandbox/macos.zig");
 
 pub const RubyError = error{
     RubyNotFound,
@@ -18,6 +22,11 @@ pub const RubyError = error{
     PostInstallFailed,
     OutOfMemory,
 };
+
+/// Upper bound on a fetched formula .rb blob. The Homebrew-wide 99th
+/// percentile is ~40 KiB; 1 MiB is orders of magnitude of headroom
+/// without giving a hostile response room to grow.
+const MAX_FORMULA_RB_BYTES: usize = 1024 * 1024;
 
 /// Detect a usable Ruby interpreter. Returns a caller-owned absolute path
 /// or null. Caller must free the returned slice with `allocator.free`.
@@ -101,49 +110,62 @@ pub fn resolveFormulaRbPath(buf: *[1024]u8, tap_path: []const u8, name: []const 
     return new_path;
 }
 
-/// Fetch a formula's .rb source from GitHub and extract the post_install body.
-/// This is the fallback when the homebrew-core tap is not cloned locally.
-/// Uses curl for simplicity and TLS handling.
-/// Returns the post_install body or null if the fetch fails or no post_install exists.
+/// Fetch a formula's .rb source from the pinned homebrew-core commit,
+/// verify its SHA256 against the embedded manifest, and extract the
+/// post_install body.
+///
+/// This path is the fallback when the homebrew-core tap is not cloned
+/// locally. It refuses anything whose hash isn't pre-authorized in
+/// `pins_manifest.txt` — a floating-HEAD fetch would give an attacker
+/// who controls the raw.githubusercontent.com response (MITM with a
+/// valid cert, compromised CDN edge, branch rewrite) a direct path to
+/// code execution via `--use-system-ruby`.
+///
+/// Returns the post_install body or null on any fetch / verify / parse
+/// failure. All failures are silent-to-caller; the caller decides
+/// whether to warn.
 pub fn fetchPostInstallFromGitHub(allocator: std.mem.Allocator, name: []const u8) ?[]const u8 {
-    if (name.len == 0) return null;
+    // Reject anything that wouldn't pass the API name allowlist
+    // ([a-z0-9@._+-]) — the URL path substitutes the name directly.
+    api_mod.validateName(name) catch return null;
 
-    // Build the GitHub raw URL: Formula/FIRST_LETTER/NAME.rb
-    var url_buf: [256]u8 = undefined;
-    const url = std.fmt.bufPrint(&url_buf, "https://raw.githubusercontent.com/Homebrew/homebrew-core/HEAD/Formula/{c}/{s}.rb", .{
-        name[0], name,
-    }) catch return null;
+    const expected_hash = pins.expectedSha256(name) orelse {
+        // Fail-closed: no manifest entry, no fetch. Logged so users
+        // hitting this path know *why* rather than guessing that the
+        // network is down.
+        output.warn(
+            "post_install fetch refused for {s}: no entry in pins_manifest.txt (run scripts/gen-pins.sh)",
+            .{name},
+        );
+        return null;
+    };
 
-    const argv = [_][]const u8{ "curl", "-fsSL", "--max-time", "10", url };
-    var child = fs_compat.Child.init(&argv, allocator);
-    child.stdout_behavior = .pipe;
-    child.stderr_behavior = .ignore;
-    child.spawn() catch return null;
+    var url_buf: [512]u8 = undefined;
+    const url = std.fmt.bufPrint(
+        &url_buf,
+        "https://raw.githubusercontent.com/Homebrew/homebrew-core/{s}/Formula/{c}/{s}.rb",
+        .{ pins.HOMEBREW_CORE_COMMIT_SHA, name[0], name },
+    ) catch return null;
 
-    const stdout = child.stdout orelse return null;
-    const body = fs_compat.readFileToEndAlloc(stdout, allocator, 1024 * 1024) catch return null;
-    const term = child.wait() catch return null;
+    var http = http_client.HttpClient.init(allocator);
+    defer http.deinit();
 
-    switch (term) {
-        .exited => |code| if (code != 0) {
-            allocator.free(body);
-            return null;
-        },
-        else => {
-            allocator.free(body);
-            return null;
-        },
-    }
+    var resp = http.get(url) catch return null;
+    defer resp.deinit();
+    if (resp.status != 200) return null;
+    if (resp.body.len == 0 or resp.body.len > MAX_FORMULA_RB_BYTES) return null;
 
-    if (body.len == 0) {
-        allocator.free(body);
+    var actual_hex: [pins.SHA256_HEX_LEN]u8 = undefined;
+    pins.sha256Hex(resp.body, &actual_hex);
+    if (!std.mem.eql(u8, actual_hex[0..], expected_hash)) {
+        output.err(
+            "post_install fetch refused for {s}: SHA256 mismatch at pinned commit (expected {s}, got {s})",
+            .{ name, expected_hash, actual_hex[0..] },
+        );
         return null;
     }
 
-    // Extract post_install from the fetched source
-    const result = extractPostInstallFromSource(allocator, body);
-    allocator.free(body);
-    return result;
+    return extractPostInstallFromSource(allocator, resp.body);
 }
 
 /// Extract post_install body from Ruby source text (in-memory version).
@@ -436,23 +458,41 @@ pub fn runPostInstall(
     // Ensure cleanup
     defer fs_compat.deleteFileAbsolute(tmp_path) catch {};
 
-    // 7. Spawn Ruby subprocess — inherit stdout/stderr so post_install
-    // output flows directly to the user's terminal.
-    const argv = [_][]const u8{ ruby_path, tmp_path };
-    var child = fs_compat.Child.init(&argv, allocator);
-    child.stdout_behavior = .inherit;
-    child.stderr_behavior = .inherit;
+    // 7. Spawn Ruby under sandbox-exec with a per-formula profile,
+    //    scrubbed env, and resource limits. stdout/stderr inherit the
+    //    parent's so post_install output still reaches the user.
+    //    The parent's env is intentionally NOT forwarded — only HOME,
+    //    a minimal PATH, MALT_PREFIX, and a formula-scoped TMPDIR pass.
 
-    child.spawn() catch return RubyError.PostInstallFailed;
+    var cellar_buf: [512]u8 = undefined;
+    const cellar_path = std.fmt.bufPrint(
+        &cellar_buf,
+        "{s}/Cellar/{s}/{s}",
+        .{ prefix, name, version },
+    ) catch return RubyError.PostInstallFailed;
 
-    const term = child.wait() catch return RubyError.PostInstallFailed;
-    switch (term) {
-        .exited => |code| {
-            if (code != 0) {
-                output.err("post_install script exited with code {d}", .{code});
-                return RubyError.PostInstallFailed;
-            }
-        },
-        else => return RubyError.PostInstallFailed,
+    const home = fs_compat.getenv("HOME") orelse "/tmp";
+    const env: sandbox.ScrubbedEnv = .{
+        .home = home,
+        .path = sandbox.SANDBOX_PATH,
+        .malt_prefix = prefix,
+        .tmpdir = "/tmp",
+    };
+
+    const exit_code = sandbox.runRubySandboxed(
+        allocator,
+        ruby_path,
+        tmp_path,
+        cellar_path,
+        prefix,
+        env,
+        .{},
+    ) catch |e| {
+        output.err("post_install sandbox spawn failed: {s}", .{@errorName(e)});
+        return RubyError.PostInstallFailed;
+    };
+    if (exit_code != 0) {
+        output.err("post_install script exited with code {d}", .{exit_code});
+        return RubyError.PostInstallFailed;
     }
 }

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -1,0 +1,313 @@
+//! malt — macOS sandbox-exec profile + spawn wrapper for the Ruby
+//! post_install subprocess.
+//!
+//! This module is the OS-level containment layer for the explicit
+//! `--use-system-ruby` path. Ruby code from a hostile formula running
+//! under the user's UID is the threat; the containment goal is:
+//!
+//!   - confine writes to the formula's own cellar and a small set of
+//!     shared directories under MALT_PREFIX (etc, var, share, opt),
+//!   - block network entirely,
+//!   - strip environment vars that alter dynamic-loader or Ruby
+//!     behaviour (DYLD_*, RUBYOPT, etc.),
+//!   - clamp CPU / memory / file-size budgets so a runaway script
+//!     fails fast instead of exhausting the user's machine.
+//!
+//! The sandbox profile is rendered per formula at spawn time. Paths are
+//! validated against a conservative charset before interpolation to
+//! keep the profile string free of SCL metacharacters.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const fs_compat = @import("../../fs/compat.zig");
+
+pub const SandboxError = error{
+    SandboxUnsupported,
+    UnsafePath,
+    ProfileBuildFailed,
+    EnvBuildFailed,
+    ForkFailed,
+    RlimitFailed,
+    WaitFailed,
+    ChildSignaled,
+    ChildCrashed,
+    ChildExited,
+};
+
+/// Resource caps applied to the sandboxed child before `execve`.
+/// Conservative defaults — a well-behaved post_install hook never hits
+/// any of these. Operators can widen via formula-level config later if
+/// a real regression shows up.
+pub const Limits = struct {
+    /// Wall-clock CPU seconds. macOS counts user+system.
+    cpu_seconds: u64 = 300,
+    /// Virtual address space ceiling (RLIMIT_AS). 2 GiB is generous
+    /// for any post_install that isn't mining.
+    address_space_bytes: u64 = 2 * 1024 * 1024 * 1024,
+    /// Largest single file the child may create (RLIMIT_FSIZE).
+    file_size_bytes: u64 = 512 * 1024 * 1024,
+};
+
+/// Environment slots propagated to the sandboxed child. Everything not
+/// in this list is dropped at `execve` time — in particular the
+/// dynamic-loader knobs and Ruby's global preload hooks.
+pub const ScrubbedEnv = struct {
+    home: []const u8,
+    path: []const u8,
+    malt_prefix: []const u8,
+    tmpdir: []const u8,
+};
+
+/// Minimal PATH passed through to the sandboxed child. Anything more
+/// ambitious lets a hostile formula exploit whatever random binary
+/// happens to live in the user's homebrew/cargo/npm prefixes.
+pub const SANDBOX_PATH: []const u8 = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+/// Validate that a path is safe to splice into a sandbox-exec profile
+/// string. Rejects quote, backslash, parenthesis, newline, and NUL —
+/// any of which could break out of the `(subpath "...")` token.
+///
+/// malt's cellar paths are built from [a-z0-9@._+-/] formula names and
+/// version strings concatenated with a known prefix, so well-formed
+/// input passes; this guards against a malformed MALT_PREFIX or an
+/// unusual formula version slipping through.
+pub fn validatePathForProfile(p: []const u8) SandboxError!void {
+    if (p.len == 0 or p[0] != '/') return SandboxError.UnsafePath;
+    for (p) |c| switch (c) {
+        0, '"', '\\', '(', ')', '\n', '\r' => return SandboxError.UnsafePath,
+        else => {},
+    };
+}
+
+/// Render a sandbox-exec profile SCL string for a Ruby post_install
+/// run. Deny-by-default; file-read broadly; file-write only under
+/// `cellar_path` and the four shared subtrees of `malt_prefix`.
+///
+/// Caller owns the returned slice.
+pub fn renderRubyProfile(
+    allocator: std.mem.Allocator,
+    cellar_path: []const u8,
+    malt_prefix: []const u8,
+) SandboxError![]const u8 {
+    try validatePathForProfile(cellar_path);
+    try validatePathForProfile(malt_prefix);
+
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(allocator);
+
+    const header =
+        \\(version 1)
+        \\(deny default)
+        \\(allow process-fork)
+        \\(allow process-exec*)
+        \\(allow signal (target self))
+        \\(allow sysctl-read)
+        \\(allow mach-lookup)
+        \\(allow iokit-open)
+        \\(allow file-read*)
+        \\(deny network*)
+        \\(allow file-write-data
+        \\  (regex #"^/dev/(null|dtracehelper|tty|stdout|stderr)$")
+        \\  (regex #"^/private/tmp/")
+        \\  (regex #"^/private/var/folders/")
+        \\  (regex #"^/tmp/"))
+        \\
+    ;
+    buf.appendSlice(allocator, header) catch return SandboxError.ProfileBuildFailed;
+
+    var aw: std.Io.Writer.Allocating = .fromArrayList(allocator, &buf);
+    aw.writer.print(
+        \\(allow file-write*
+        \\  (subpath "{s}")
+        \\  (subpath "{s}/etc")
+        \\  (subpath "{s}/var")
+        \\  (subpath "{s}/share")
+        \\  (subpath "{s}/opt"))
+        \\
+    , .{ cellar_path, malt_prefix, malt_prefix, malt_prefix, malt_prefix }) catch
+        return SandboxError.ProfileBuildFailed;
+    return aw.toOwnedSlice() catch SandboxError.ProfileBuildFailed;
+}
+
+/// RLIMIT constants. Zig's `std.posix.rlimit_resource` is an enum on
+/// macOS whose integer values match the platform headers; we name
+/// them here so the call sites below stay readable.
+const RLIMIT = struct {
+    const CPU: std.posix.rlimit_resource = @enumFromInt(0);
+    const FSIZE: std.posix.rlimit_resource = @enumFromInt(1);
+    const AS: std.posix.rlimit_resource = @enumFromInt(5);
+};
+
+fn applyRlimits(limits: Limits) SandboxError!void {
+    const as_max: std.posix.rlim_t = @intCast(limits.address_space_bytes);
+    const fs_max: std.posix.rlim_t = @intCast(limits.file_size_bytes);
+    const cpu_max: std.posix.rlim_t = @intCast(limits.cpu_seconds);
+
+    std.posix.setrlimit(RLIMIT.CPU, .{ .cur = cpu_max, .max = cpu_max }) catch
+        return SandboxError.RlimitFailed;
+    std.posix.setrlimit(RLIMIT.FSIZE, .{ .cur = fs_max, .max = fs_max }) catch
+        return SandboxError.RlimitFailed;
+    std.posix.setrlimit(RLIMIT.AS, .{ .cur = as_max, .max = as_max }) catch
+        return SandboxError.RlimitFailed;
+}
+
+/// Build a null-terminated envp array from an allowlist. Everything
+/// outside the allowlist is dropped — in particular DYLD_*, RUBYOPT,
+/// RUBYLIB, GEM_* and friends.
+fn buildEnvp(
+    allocator: std.mem.Allocator,
+    env: ScrubbedEnv,
+) SandboxError![:null]?[*:0]u8 {
+    var list: std.ArrayList(?[*:0]u8) = .empty;
+    errdefer {
+        for (list.items) |maybe| if (maybe) |s| allocator.free(std.mem.span(s));
+        list.deinit(allocator);
+    }
+    const entries = [_]struct { k: []const u8, v: []const u8 }{
+        .{ .k = "HOME", .v = env.home },
+        .{ .k = "PATH", .v = env.path },
+        .{ .k = "MALT_PREFIX", .v = env.malt_prefix },
+        .{ .k = "TMPDIR", .v = env.tmpdir },
+    };
+    for (entries) |e| {
+        const s = std.fmt.allocPrintSentinel(allocator, "{s}={s}", .{ e.k, e.v }, 0) catch
+            return SandboxError.EnvBuildFailed;
+        list.append(allocator, s) catch {
+            allocator.free(s);
+            return SandboxError.EnvBuildFailed;
+        };
+    }
+    return list.toOwnedSliceSentinel(allocator, null) catch SandboxError.EnvBuildFailed;
+}
+
+fn freeEnvp(allocator: std.mem.Allocator, envp: [:null]?[*:0]u8) void {
+    var i: usize = 0;
+    while (envp[i]) |s| : (i += 1) allocator.free(std.mem.span(s));
+    allocator.free(envp[0 .. i + 1]);
+}
+
+/// Build a null-terminated argv array. Caller owns; free with
+/// `freeArgv`.
+fn buildArgv(
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+) SandboxError![:null]?[*:0]u8 {
+    var list: std.ArrayList(?[*:0]u8) = .empty;
+    errdefer {
+        for (list.items) |maybe| if (maybe) |s| allocator.free(std.mem.span(s));
+        list.deinit(allocator);
+    }
+    for (argv) |a| {
+        const s = allocator.dupeZ(u8, a) catch return SandboxError.EnvBuildFailed;
+        list.append(allocator, s) catch {
+            allocator.free(s);
+            return SandboxError.EnvBuildFailed;
+        };
+    }
+    return list.toOwnedSliceSentinel(allocator, null) catch SandboxError.EnvBuildFailed;
+}
+
+fn freeArgv(allocator: std.mem.Allocator, argv: [:null]?[*:0]u8) void {
+    var i: usize = 0;
+    while (argv[i]) |s| : (i += 1) allocator.free(std.mem.span(s));
+    allocator.free(argv[0 .. i + 1]);
+}
+
+/// Spawn `ruby tmp_script` under `sandbox-exec -p <profile>`, a
+/// scrubbed env, and the resource limits. Streams stdout/stderr from
+/// the child directly to the current process's stdout/stderr.
+///
+/// Returns the child's exit code on normal exit, or a SandboxError
+/// if the child was killed by a signal / the sandbox couldn't be
+/// applied / the fork-exec itself failed.
+pub fn runRubySandboxed(
+    allocator: std.mem.Allocator,
+    ruby_path: []const u8,
+    script_path: []const u8,
+    cellar_path: []const u8,
+    malt_prefix: []const u8,
+    env: ScrubbedEnv,
+    limits: Limits,
+) SandboxError!u8 {
+    if (builtin.os.tag != .macos) return SandboxError.SandboxUnsupported;
+
+    const profile = try renderRubyProfile(allocator, cellar_path, malt_prefix);
+    defer allocator.free(profile);
+
+    const argv = [_][]const u8{
+        "/usr/bin/sandbox-exec", "-p", profile, ruby_path, script_path,
+    };
+    const argv_z = try buildArgv(allocator, argv[0..]);
+    defer freeArgv(allocator, argv_z);
+
+    const envp = try buildEnvp(allocator, env);
+    defer freeEnvp(allocator, envp);
+
+    const pid = std.c.fork();
+    if (pid < 0) return SandboxError.ForkFailed;
+    if (pid == 0) {
+        // child: apply rlimits, then exec. Any failure here must call
+        // _exit, not return — we are post-fork and must not run parent
+        // cleanup code.
+        applyRlimits(limits) catch std.c._exit(127);
+        _ = std.c.execve(argv_z[0].?, argv_z.ptr, envp.ptr);
+        std.c._exit(127);
+    }
+    // parent
+    var status: c_int = 0;
+    const w = std.c.waitpid(pid, &status, 0);
+    if (w < 0) return SandboxError.WaitFailed;
+    if (wifsignaled(status)) return SandboxError.ChildSignaled;
+    if (!wifexited(status)) return SandboxError.ChildCrashed;
+    return @intCast(wexitstatus(status));
+}
+
+// macOS <sys/wait.h> status macros, open-coded.
+fn wifexited(status: c_int) bool {
+    return (status & 0x7f) == 0;
+}
+fn wifsignaled(status: c_int) bool {
+    const term = status & 0x7f;
+    return term != 0 and term != 0x7f;
+}
+fn wexitstatus(status: c_int) u8 {
+    return @intCast((status >> 8) & 0xff);
+}
+
+// ---------------------------------------------------------------------------
+// tests
+
+test "validatePathForProfile accepts normal absolute paths" {
+    try validatePathForProfile("/opt/malt");
+    try validatePathForProfile("/opt/malt/Cellar/foo/1.2.3");
+}
+
+test "validatePathForProfile rejects SCL metacharacters" {
+    try std.testing.expectError(SandboxError.UnsafePath, validatePathForProfile("/tmp/\"hack"));
+    try std.testing.expectError(SandboxError.UnsafePath, validatePathForProfile("/tmp/ha(ck"));
+    try std.testing.expectError(SandboxError.UnsafePath, validatePathForProfile("/tmp/ha\\ck"));
+    try std.testing.expectError(SandboxError.UnsafePath, validatePathForProfile("relative/path"));
+    try std.testing.expectError(SandboxError.UnsafePath, validatePathForProfile(""));
+}
+
+test "renderRubyProfile emits deny-default + cellar + prefix subpaths" {
+    const profile = try renderRubyProfile(
+        std.testing.allocator,
+        "/opt/malt/Cellar/foo/1.0",
+        "/opt/malt",
+    );
+    defer std.testing.allocator.free(profile);
+    try std.testing.expect(std.mem.indexOf(u8, profile, "(deny default)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, profile, "(deny network*)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/Cellar/foo/1.0\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/etc\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/var\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/opt\")") != null);
+}
+
+test "renderRubyProfile rejects unsafe cellar path" {
+    try std.testing.expectError(
+        SandboxError.UnsafePath,
+        renderRubyProfile(std.testing.allocator, "/opt/malt\"/evil", "/opt/malt"),
+    );
+}

--- a/src/core/services/plist.zig
+++ b/src/core/services/plist.zig
@@ -4,6 +4,7 @@
 //! deterministic (fixed key order) so golden tests can byte-compare.
 
 const std = @import("std");
+const dsl_sandbox = @import("../dsl/sandbox.zig");
 
 pub const EnvPair = struct {
     key: []const u8,
@@ -20,6 +21,108 @@ pub const ServiceSpec = struct {
     run_at_load: bool = true,
     keep_alive: bool = true,
 };
+
+pub const ValidationError = error{
+    /// program_args was empty; launchd would reject it, but we should
+    /// refuse earlier with a clearer error.
+    Empty,
+    /// program_args[0] is `/bin/sh`-style — the formula is trying to
+    /// reach outside its own bin tree by invoking an interpreter.
+    InterpreterBait,
+    /// program_args[0] or working_dir / log paths point outside the
+    /// formula's cellar and the shared malt_prefix/opt subtree.
+    PathEscape,
+    /// program_args carries more arguments than we're willing to
+    /// shuttle through plist + launchctl. 64 is generous for any
+    /// real service.
+    TooManyArgs,
+    /// A single argv or path string is longer than 4 KiB. Real launchd
+    /// entries are a few hundred bytes end to end; anything larger is
+    /// either a bug or an attempted overflow.
+    ArgTooLong,
+    /// An argv or path contains a NUL byte — splitting point for C
+    /// string APIs and nonsensical in launchd.
+    EmbeddedNul,
+    /// program_args[0] is not an absolute path.
+    RelativeExecutable,
+};
+
+/// Cap on argv count. Real launchd services carry fewer than a dozen.
+pub const MAX_PROGRAM_ARGS: usize = 64;
+/// Cap on a single argv or path string.
+pub const MAX_ARG_LEN: usize = 4096;
+
+/// Reject launchd interpreters as the leading executable. If a formula
+/// actually ships its own cellar-local `sh` it must invoke it via its
+/// cellar path — not `/bin/sh`, which launchd would happily run with
+/// whatever argv follows.
+const FORBIDDEN_HEADS = [_][]const u8{
+    "/bin/sh",      "/bin/bash",     "/bin/zsh",        "/bin/ksh",
+    "/usr/bin/sh",  "/usr/bin/bash", "/usr/bin/zsh",    "/usr/bin/env",
+    "/usr/bin/ksh", "/usr/bin/tcsh", "/usr/bin/python", "/usr/bin/perl",
+};
+
+/// Validate a ServiceSpec before it's rendered to a plist. All writes
+/// to disk and all `launchctl bootstrap` calls flow through this gate;
+/// if a formula's `service:` block fails here, the install surfaces an
+/// error instead of materialising an attacker-controlled LaunchAgent.
+///
+/// `cellar_path` is the formula's own keg directory (e.g.
+/// `/opt/malt/Cellar/foo/1.0`). `malt_prefix` is the install prefix
+/// (e.g. `/opt/malt`). Allowed executable locations:
+///   - anywhere under `cellar_path`,
+///   - anywhere under `malt_prefix/opt` (formula-scoped opt symlinks).
+pub fn validate(
+    spec: ServiceSpec,
+    cellar_path: []const u8,
+    malt_prefix: []const u8,
+) ValidationError!void {
+    if (spec.program_args.len == 0) return ValidationError.Empty;
+    if (spec.program_args.len > MAX_PROGRAM_ARGS) return ValidationError.TooManyArgs;
+
+    for (spec.program_args) |a| try checkString(a);
+    try checkString(spec.label);
+    try checkString(spec.stdout_path);
+    try checkString(spec.stderr_path);
+    if (spec.working_dir) |wd| try checkString(wd);
+    for (spec.env) |p| {
+        try checkString(p.key);
+        try checkString(p.value);
+    }
+
+    const head = spec.program_args[0];
+    if (head.len == 0 or head[0] != '/') return ValidationError.RelativeExecutable;
+    for (FORBIDDEN_HEADS) |h| {
+        if (std.mem.eql(u8, head, h)) return ValidationError.InterpreterBait;
+    }
+
+    // Allowed roots: formula's own cellar, OR malt_prefix/opt. Both
+    // checked with a component-boundary-aware prefix match so
+    // `/opt/malt/evilopt/x` doesn't pass as `/opt/malt/opt`.
+    var opt_buf: [512]u8 = undefined;
+    const opt_prefix = std.fmt.bufPrint(&opt_buf, "{s}/opt", .{malt_prefix}) catch
+        return ValidationError.PathEscape;
+
+    if (!dsl_sandbox.pathHasPrefix(head, cellar_path) and
+        !dsl_sandbox.pathHasPrefix(head, opt_prefix))
+    {
+        return ValidationError.PathEscape;
+    }
+
+    // Working dir and log paths: anywhere under cellar_path or
+    // malt_prefix (var/log lives there). The DSL sandbox
+    // validatePath already has the right rules; defer to it.
+    for (&[_]?[]const u8{ spec.working_dir, spec.stdout_path, spec.stderr_path }) |maybe| {
+        const p = maybe orelse continue;
+        dsl_sandbox.validatePath(p, cellar_path, malt_prefix) catch
+            return ValidationError.PathEscape;
+    }
+}
+
+fn checkString(s: []const u8) ValidationError!void {
+    if (s.len > MAX_ARG_LEN) return ValidationError.ArgTooLong;
+    if (std.mem.indexOfScalar(u8, s, 0) != null) return ValidationError.EmbeddedNul;
+}
 
 pub fn render(spec: ServiceSpec, writer: anytype) !void {
     try writer.writeAll(

--- a/src/core/services/supervisor.zig
+++ b/src/core/services/supervisor.zig
@@ -42,6 +42,10 @@ pub const SupervisorError = error{
     IoFailed,
     DatabaseError,
     OutOfMemory,
+    /// Service definition violated the validation rules in
+    /// `plist_mod.validate` — interpreter bait, path escape, or
+    /// oversize/NUL-bearing argv. See the render path for specifics.
+    InvalidService,
 };
 
 pub fn describeError(err: SupervisorError) []const u8 {
@@ -52,6 +56,7 @@ pub fn describeError(err: SupervisorError) []const u8 {
         SupervisorError.IoFailed => "filesystem error while managing service",
         SupervisorError.DatabaseError => "database error while managing service",
         SupervisorError.OutOfMemory => "out of memory",
+        SupervisorError.InvalidService => "service definition rejected by malt validator",
     };
 }
 
@@ -127,14 +132,23 @@ pub fn freeServiceInfos(allocator: std.mem.Allocator, services: []ServiceInfo) v
 
 /// Register a new service row. The plist file is written to disk; the
 /// launchctl bootstrap happens on `start`.
+///
+/// `cellar_path` / `malt_prefix` are the allowlist roots used to reject
+/// interpreter bait, path escapes, and pathologically large argvs
+/// before the plist lands on disk or launchctl sees it. See
+/// `plist_mod.validate`.
 pub fn register(
     allocator: std.mem.Allocator,
     db: *sqlite.Database,
     spec: plist_mod.ServiceSpec,
     keg_name: []const u8,
     auto_start: bool,
+    cellar_path: []const u8,
+    malt_prefix: []const u8,
 ) SupervisorError!void {
     if (builtin.os.tag != .macos) return SupervisorError.OsNotSupported;
+
+    plist_mod.validate(spec, cellar_path, malt_prefix) catch return SupervisorError.InvalidService;
 
     const dir = try serviceDir(allocator, spec.label);
     defer allocator.free(dir);

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -49,3 +49,5 @@ pub const bottle = @import("core/bottle.zig");
 pub const archive = @import("fs/archive.zig");
 pub const ghcr = @import("net/ghcr.zig");
 pub const ruby_subprocess = @import("core/ruby_subprocess.zig");
+pub const pins = @import("core/pins.zig");
+pub const sandbox_macos = @import("core/sandbox/macos.zig");

--- a/tests/dsl_sandbox_test.zig
+++ b/tests/dsl_sandbox_test.zig
@@ -242,3 +242,44 @@ test "sandbox: lookalike cellar prefix rejected when prefixes disjoint" {
     );
     try testing.expectError(SandboxError.PathSandboxViolation, result);
 }
+
+// ────────────────────────────────────────────────────────────────────
+// pathHasPrefix direct tests. This helper is now public and re-used by
+// the plist validator (src/core/services/plist.zig) for the argv path
+// allowlist, so its boundary behaviour is load-bearing for two
+// independent security checks. Regression here = silent bypass in
+// either place.
+// ────────────────────────────────────────────────────────────────────
+
+test "pathHasPrefix: identical paths accepted" {
+    try testing.expect(sandbox.pathHasPrefix("/opt/malt", "/opt/malt"));
+}
+
+test "pathHasPrefix: component-boundary extension accepted" {
+    try testing.expect(sandbox.pathHasPrefix("/opt/malt/bin/foo", "/opt/malt"));
+}
+
+test "pathHasPrefix: substring-without-boundary rejected" {
+    // The whole point of this helper: `/opt/malthack` must NOT match
+    // prefix `/opt/malt`. Plain `startsWith` would say yes.
+    try testing.expect(!sandbox.pathHasPrefix("/opt/malthack", "/opt/malt"));
+    try testing.expect(!sandbox.pathHasPrefix("/opt/malthack/x", "/opt/malt"));
+}
+
+test "pathHasPrefix: trailing-slash prefix still accepts bare path" {
+    // e.g. prefix computed with a stray trailing '/'
+    try testing.expect(sandbox.pathHasPrefix("/opt/malt/bin/foo", "/opt/malt/"));
+}
+
+test "pathHasPrefix: empty prefix rejected" {
+    // An empty prefix would accept every absolute path — explicitly refuse.
+    try testing.expect(!sandbox.pathHasPrefix("/opt/malt", ""));
+}
+
+test "pathHasPrefix: shorter path than prefix rejected" {
+    try testing.expect(!sandbox.pathHasPrefix("/opt", "/opt/malt"));
+}
+
+test "pathHasPrefix: disjoint paths rejected" {
+    try testing.expect(!sandbox.pathHasPrefix("/usr/local/bin", "/opt/malt"));
+}

--- a/tests/pins_test.zig
+++ b/tests/pins_test.zig
@@ -1,0 +1,45 @@
+//! malt — pins module tests
+//!
+//! Covers the manifest parser and SHA helper used by the pinned
+//! homebrew-core fetch path (`ruby_subprocess.fetchPostInstallFromGitHub`).
+//! Intentionally does no network: the fetch path itself is guarded by
+//! manifest lookup, and `expectedSha256` is the load-bearing check.
+
+const std = @import("std");
+const testing = std.testing;
+const pins = @import("malt").pins;
+
+test "HOMEBREW_CORE_COMMIT_SHA is a 40-char lowercase hex digest" {
+    const sha = pins.HOMEBREW_CORE_COMMIT_SHA;
+    try testing.expectEqual(@as(usize, 40), sha.len);
+    for (sha) |c| switch (c) {
+        '0'...'9', 'a'...'f' => {},
+        else => return error.TestUnexpectedResult,
+    };
+}
+
+test "expectedSha256 rejects unknown formula" {
+    try testing.expectEqual(@as(?[]const u8, null), pins.expectedSha256("definitely-not-here-xyz"));
+}
+
+test "expectedSha256 rejects empty name" {
+    try testing.expectEqual(@as(?[]const u8, null), pins.expectedSha256(""));
+}
+
+test "sha256Hex — empty input matches SHA256('')" {
+    var out: [pins.SHA256_HEX_LEN]u8 = undefined;
+    pins.sha256Hex("", &out);
+    try testing.expectEqualStrings(
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        &out,
+    );
+}
+
+test "sha256Hex — short known vector" {
+    var out: [pins.SHA256_HEX_LEN]u8 = undefined;
+    pins.sha256Hex("abc", &out);
+    try testing.expectEqualStrings(
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        &out,
+    );
+}

--- a/tests/pins_test.zig
+++ b/tests/pins_test.zig
@@ -43,3 +43,87 @@ test "sha256Hex — short known vector" {
         &out,
     );
 }
+
+// ────────────────────────────────────────────────────────────────────
+// Manifest parser edge cases. These run against an in-memory fixture
+// via `lookupIn` so they can't be masked by a well-formed shipping
+// manifest — each one isolates one property of the parser.
+// ────────────────────────────────────────────────────────────────────
+
+const good_hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+test "lookupIn — space-separated entry found" {
+    const m = "fontconfig " ++ good_hash ++ "\n";
+    const h = pins.lookupIn(m, "fontconfig") orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings(good_hash, h);
+}
+
+test "lookupIn — tab-separated entry found" {
+    const m = "fontconfig\t" ++ good_hash ++ "\n";
+    const h = pins.lookupIn(m, "fontconfig") orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings(good_hash, h);
+}
+
+test "lookupIn — blank lines and comments are ignored" {
+    const m =
+        "\n" ++
+        "# comment\n" ++
+        "  # indented comment\n" ++
+        "\n" ++
+        "node " ++ good_hash ++ "\n";
+    const h = pins.lookupIn(m, "node") orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings(good_hash, h);
+}
+
+test "lookupIn — uppercase hex rejected" {
+    const bad = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const m = "node " ++ bad ++ "\n";
+    try testing.expectEqual(@as(?[]const u8, null), pins.lookupIn(m, "node"));
+}
+
+test "lookupIn — non-hex chars rejected" {
+    const bad = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+    const m = "node " ++ bad ++ "\n";
+    try testing.expectEqual(@as(?[]const u8, null), pins.lookupIn(m, "node"));
+}
+
+test "lookupIn — short hash rejected" {
+    const m = "node deadbeef\n";
+    try testing.expectEqual(@as(?[]const u8, null), pins.lookupIn(m, "node"));
+}
+
+test "lookupIn — name-without-hash line skipped" {
+    const m = "badline\ngood " ++ good_hash ++ "\n";
+    try testing.expectEqual(@as(?[]const u8, null), pins.lookupIn(m, "badline"));
+    const h = pins.lookupIn(m, "good") orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings(good_hash, h);
+}
+
+test "lookupIn — substring-of-name does NOT match" {
+    // pathological case: don't let `nodejs` accidentally satisfy a query
+    // for `node`.
+    const m = "nodejs " ++ good_hash ++ "\n";
+    try testing.expectEqual(@as(?[]const u8, null), pins.lookupIn(m, "node"));
+}
+
+test "lookupIn — first match wins when name appears twice" {
+    const h1 = "1111111111111111111111111111111111111111111111111111111111111111";
+    const h2 = "2222222222222222222222222222222222222222222222222222222222222222";
+    const m = "node " ++ h1 ++ "\nnode " ++ h2 ++ "\n";
+    const got = pins.lookupIn(m, "node") orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings(h1, got);
+}
+
+test "lookupIn — CRLF line endings tolerated" {
+    const m = "node " ++ good_hash ++ "\r\n";
+    const h = pins.lookupIn(m, "node") orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings(good_hash, h);
+}
+
+test "lookupIn — trailing text after hash ignored (length gate)" {
+    // lookupIn slices exactly SHA256_HEX_LEN chars; anything after is
+    // out of bounds of the returned hash but mustn't crash the parser.
+    const m = "node " ++ good_hash ++ "  # with comment\n";
+    const h = pins.lookupIn(m, "node") orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings(good_hash, h);
+}

--- a/tests/sandbox_macos_test.zig
+++ b/tests/sandbox_macos_test.zig
@@ -1,0 +1,79 @@
+//! malt — sandbox/macos module tests
+//!
+//! Covers the profile renderer and path-safety guard. The fork/exec
+//! path itself is integration-tested via a small Ruby fixture under
+//! tests/fixtures/ (see sandbox_macos_exec_test.zig — TODO once the
+//! Ruby interpreter is available in CI) — this file stays pure so it
+//! runs without a Ruby toolchain.
+
+const std = @import("std");
+const testing = std.testing;
+const sandbox = @import("malt").sandbox_macos;
+
+test "validatePathForProfile accepts clean absolute paths" {
+    try sandbox.validatePathForProfile("/opt/malt");
+    try sandbox.validatePathForProfile("/opt/malt/Cellar/foo/1.2.3");
+    try sandbox.validatePathForProfile("/tmp/x-y_z.0+1");
+}
+
+test "validatePathForProfile rejects SCL metacharacters" {
+    try testing.expectError(error.UnsafePath, sandbox.validatePathForProfile("/tmp/\"hack"));
+    try testing.expectError(error.UnsafePath, sandbox.validatePathForProfile("/tmp/ha(ck"));
+    try testing.expectError(error.UnsafePath, sandbox.validatePathForProfile("/tmp/ha)ck"));
+    try testing.expectError(error.UnsafePath, sandbox.validatePathForProfile("/tmp/ha\\ck"));
+    try testing.expectError(error.UnsafePath, sandbox.validatePathForProfile("/tmp/ha\nck"));
+}
+
+test "validatePathForProfile rejects relative / empty" {
+    try testing.expectError(error.UnsafePath, sandbox.validatePathForProfile(""));
+    try testing.expectError(error.UnsafePath, sandbox.validatePathForProfile("relative"));
+    try testing.expectError(error.UnsafePath, sandbox.validatePathForProfile("./also"));
+}
+
+test "renderRubyProfile deny-by-default, network denied, cellar + prefix subpaths allowed" {
+    const profile = try sandbox.renderRubyProfile(
+        testing.allocator,
+        "/opt/malt/Cellar/foo/1.0",
+        "/opt/malt",
+    );
+    defer testing.allocator.free(profile);
+    try testing.expect(std.mem.indexOf(u8, profile, "(deny default)") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(deny network*)") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(allow file-read*)") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/Cellar/foo/1.0\")") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/etc\")") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/var\")") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/share\")") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/opt\")") != null);
+}
+
+test "renderRubyProfile refuses unsafe cellar path" {
+    try testing.expectError(
+        error.UnsafePath,
+        sandbox.renderRubyProfile(testing.allocator, "/opt/malt\"/evil", "/opt/malt"),
+    );
+}
+
+test "renderRubyProfile refuses unsafe prefix path" {
+    try testing.expectError(
+        error.UnsafePath,
+        sandbox.renderRubyProfile(testing.allocator, "/opt/malt/Cellar/foo/1.0", "/opt/m)alt"),
+    );
+}
+
+test "ScrubbedEnv type smoke — only allowlisted keys" {
+    // Compile-time check: the struct has exactly the four allowed env
+    // slots and nothing else. If someone ever adds a field here without
+    // also thinking through the trust implications, this test fails.
+    const info = @typeInfo(sandbox.ScrubbedEnv).@"struct";
+    try testing.expectEqual(@as(usize, 4), info.fields.len);
+    try testing.expectEqualStrings("home", info.fields[0].name);
+    try testing.expectEqualStrings("path", info.fields[1].name);
+    try testing.expectEqualStrings("malt_prefix", info.fields[2].name);
+    try testing.expectEqualStrings("tmpdir", info.fields[3].name);
+}
+
+test "SANDBOX_PATH restricts to system directories only" {
+    // Nothing in the minimal PATH should be user-writable.
+    try testing.expectEqualStrings("/usr/bin:/bin:/usr/sbin:/sbin", sandbox.SANDBOX_PATH);
+}

--- a/tests/services_validate_test.zig
+++ b/tests/services_validate_test.zig
@@ -1,0 +1,141 @@
+//! malt — plist_mod.validate rules
+//!
+//! Locks in the service-file validation surface: no interpreter bait,
+//! no path escape, argv length caps, NUL rejection, per-log-path
+//! sandboxing. A hostile formula that smuggled a `service:` block in
+//! through the post_install integrity gap (Finding #1) would still
+//! have to pass these checks before launchd sees a plist.
+
+const std = @import("std");
+const testing = std.testing;
+const plist = @import("malt").services_plist;
+
+const cellar = "/opt/malt/Cellar/foo/1.0";
+const prefix = "/opt/malt";
+const good_out = "/opt/malt/var/log/foo.out";
+const good_err = "/opt/malt/var/log/foo.err";
+
+test "validate: happy path under cellar/bin passes" {
+    const args = [_][]const u8{ "/opt/malt/Cellar/foo/1.0/bin/foo", "arg" };
+    try plist.validate(.{
+        .label = "com.malt.foo",
+        .program_args = args[0..],
+        .stdout_path = good_out,
+        .stderr_path = good_err,
+    }, cellar, prefix);
+}
+
+test "validate: happy path under malt_prefix/opt passes" {
+    const args = [_][]const u8{ "/opt/malt/opt/foo/bin/foo", "arg" };
+    try plist.validate(.{
+        .label = "com.malt.foo",
+        .program_args = args[0..],
+        .stdout_path = good_out,
+        .stderr_path = good_err,
+    }, cellar, prefix);
+}
+
+fn expectHeadRejected(head: []const u8, expected: anyerror) !void {
+    const args = [_][]const u8{ head, "arg" };
+    const res = plist.validate(.{
+        .label = "com.malt.foo",
+        .program_args = args[0..],
+        .stdout_path = good_out,
+        .stderr_path = good_err,
+    }, cellar, prefix);
+    try testing.expectError(expected, res);
+}
+
+test "validate: /bin/sh rejected as interpreter bait" {
+    try expectHeadRejected("/bin/sh", error.InterpreterBait);
+}
+
+test "validate: /bin/bash rejected as interpreter bait" {
+    try expectHeadRejected("/bin/bash", error.InterpreterBait);
+}
+
+test "validate: /usr/bin/env rejected as interpreter bait" {
+    try expectHeadRejected("/usr/bin/env", error.InterpreterBait);
+}
+
+test "validate: head outside cellar and prefix/opt rejected" {
+    try expectHeadRejected("/usr/local/bin/evil", error.PathEscape);
+}
+
+test "validate: relative head rejected" {
+    try expectHeadRejected("bin/foo", error.RelativeExecutable);
+}
+
+test "validate: empty program_args rejected" {
+    try testing.expectError(error.Empty, plist.validate(.{
+        .label = "com.malt.foo",
+        .program_args = &.{},
+        .stdout_path = good_out,
+        .stderr_path = good_err,
+    }, cellar, prefix));
+}
+
+test "validate: embedded NUL in arg rejected" {
+    const args = [_][]const u8{ "/opt/malt/Cellar/foo/1.0/bin/foo", "ev\x00il" };
+    try testing.expectError(error.EmbeddedNul, plist.validate(.{
+        .label = "com.malt.foo",
+        .program_args = args[0..],
+        .stdout_path = good_out,
+        .stderr_path = good_err,
+    }, cellar, prefix));
+}
+
+test "validate: oversize arg rejected" {
+    var big: [plist.MAX_ARG_LEN + 1]u8 = undefined;
+    @memset(&big, 'a');
+    const args = [_][]const u8{ "/opt/malt/Cellar/foo/1.0/bin/foo", big[0..] };
+    try testing.expectError(error.ArgTooLong, plist.validate(.{
+        .label = "com.malt.foo",
+        .program_args = args[0..],
+        .stdout_path = good_out,
+        .stderr_path = good_err,
+    }, cellar, prefix));
+}
+
+test "validate: too many args rejected" {
+    var args: [plist.MAX_PROGRAM_ARGS + 1][]const u8 = undefined;
+    args[0] = "/opt/malt/Cellar/foo/1.0/bin/foo";
+    for (args[1..]) |*a| a.* = "x";
+    try testing.expectError(error.TooManyArgs, plist.validate(.{
+        .label = "com.malt.foo",
+        .program_args = args[0..],
+        .stdout_path = good_out,
+        .stderr_path = good_err,
+    }, cellar, prefix));
+}
+
+test "validate: working_dir escape rejected" {
+    const args = [_][]const u8{"/opt/malt/Cellar/foo/1.0/bin/foo"};
+    try testing.expectError(error.PathEscape, plist.validate(.{
+        .label = "com.malt.foo",
+        .program_args = args[0..],
+        .working_dir = "/etc",
+        .stdout_path = good_out,
+        .stderr_path = good_err,
+    }, cellar, prefix));
+}
+
+test "validate: stdout_path escape rejected" {
+    const args = [_][]const u8{"/opt/malt/Cellar/foo/1.0/bin/foo"};
+    try testing.expectError(error.PathEscape, plist.validate(.{
+        .label = "com.malt.foo",
+        .program_args = args[0..],
+        .stdout_path = "/etc/malt.log",
+        .stderr_path = good_err,
+    }, cellar, prefix));
+}
+
+test "validate: stderr_path dot-dot escape rejected" {
+    const args = [_][]const u8{"/opt/malt/Cellar/foo/1.0/bin/foo"};
+    try testing.expectError(error.PathEscape, plist.validate(.{
+        .label = "com.malt.foo",
+        .program_args = args[0..],
+        .stdout_path = good_out,
+        .stderr_path = "/opt/malt/../etc/foo.err",
+    }, cellar, prefix));
+}

--- a/tests/spawn_invariant_test.zig
+++ b/tests/spawn_invariant_test.zig
@@ -1,0 +1,96 @@
+//! malt — argv-only spawn invariant
+//!
+//! Locks in Finding #4 of the 2026-04-17 audit: all Zig-side process
+//! spawns pass through argv-style APIs (`fs_compat.Child.init`,
+//! `std.process.spawn`), and never take the `sh -c <string>` /
+//! `/bin/sh` shortcut. This test is a grep against the repo tree — if
+//! a future change reintroduces a shell invocation, `zig build test`
+//! fails loudly.
+//!
+//! The CI grep (`scripts/lint-spawn-invariants.sh`) runs the same
+//! check at PR time; this one keeps the guard local to `zig build
+//! test` so offline development catches regressions without waiting
+//! on CI.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const fs_compat = malt.fs_compat;
+
+fn isBanned(line: []const u8) bool {
+    const banned = [_][]const u8{
+        "sh -c",        "bash -c",      "zsh -c",
+        "/bin/sh",      "/bin/bash",    "/bin/zsh",
+        "/bin/ksh",     "/usr/bin/sh",  "/usr/bin/bash",
+        "/usr/bin/zsh", "/usr/bin/ksh",
+    };
+    for (banned) |b| if (std.mem.indexOf(u8, line, b) != null) return true;
+    return false;
+}
+
+fn stripLineComment(line: []const u8) []const u8 {
+    const idx = std.mem.indexOf(u8, line, "//") orelse return line;
+    return line[0..idx];
+}
+
+// Files in src/core/services/plist.zig legitimately name the forbidden
+// interpreter paths in FORBIDDEN_HEADS — they're the *rejection list*
+// for formula-declared services. Exempt that exact context.
+fn allowedContext(path: []const u8, line: []const u8) bool {
+    if (std.mem.endsWith(u8, path, "core/services/plist.zig")) {
+        // FORBIDDEN_HEADS declaration + error docstrings — both live in
+        // that file by design. Any other usage still has to pass.
+        if (std.mem.indexOf(u8, line, "FORBIDDEN_HEADS") != null) return true;
+        // Quoted-string list entries: `"/bin/sh",`
+        if (std.mem.indexOf(u8, line, "\"/bin/") != null) return true;
+        if (std.mem.indexOf(u8, line, "\"/usr/bin/") != null) return true;
+    }
+    return false;
+}
+
+test "no shell-invocation patterns anywhere under src/" {
+    const alloc = testing.allocator;
+    // Walk src/ from the project root. Tests run with CWD at project
+    // root per build.zig conventions.
+    var dir = try fs_compat.cwd().openDir("src", .{ .iterate = true });
+    defer dir.close();
+    var walker = try dir.walk(alloc);
+    defer walker.deinit();
+
+    var violations: std.ArrayList(u8) = .empty;
+    defer violations.deinit(alloc);
+
+    while (try walker.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.basename, ".zig")) continue;
+
+        const f = try entry.dir.openFile(malt.io_mod.ctx(), entry.basename, .{});
+        defer f.close(malt.io_mod.ctx());
+        const src = try fs_compat.readFileToEndAlloc(f, alloc, 4 * 1024 * 1024);
+        defer alloc.free(src);
+
+        var it = std.mem.splitScalar(u8, src, '\n');
+        var lineno: usize = 0;
+        while (it.next()) |line| {
+            lineno += 1;
+            const stripped = stripLineComment(line);
+            if (!isBanned(stripped)) continue;
+            if (allowedContext(entry.path, stripped)) continue;
+            const buf = try std.fmt.allocPrint(
+                alloc,
+                "src/{s}:{d}: {s}\n",
+                .{ entry.path, lineno, line },
+            );
+            defer alloc.free(buf);
+            try violations.appendSlice(alloc, buf);
+        }
+    }
+
+    if (violations.items.len != 0) {
+        std.debug.print(
+            "argv-only spawn invariant violated:\n{s}\n",
+            .{violations.items},
+        );
+        return error.TestUnexpectedResult;
+    }
+}

--- a/tests/supervisor_pure_test.zig
+++ b/tests/supervisor_pure_test.zig
@@ -77,6 +77,7 @@ test "list is empty on a fresh database and hasService returns false" {
 
 test "register writes a plist and a DB row that list reports back" {
     const prefix = "/tmp/malt_sup_register";
+    const cellar = "/tmp/malt_sup_register/Cellar/testkeg/1.0";
     malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
     _ = c.setenv("MALT_PREFIX", prefix, 1);
     defer _ = c.unsetenv("MALT_PREFIX");
@@ -86,9 +87,11 @@ test "register writes a plist and a DB row that list reports back" {
     defer db.close();
     try schema.initSchema(&db);
 
+    // program_args[0] must live under cellar (new path-allowlist rule);
+    // log paths must live under malt_prefix.
     const spec = plist_mod.ServiceSpec{
         .label = "com.malt.test.svc",
-        .program_args = &.{ "/bin/echo", "hi" },
+        .program_args = &.{ "/tmp/malt_sup_register/Cellar/testkeg/1.0/bin/echo", "hi" },
         .working_dir = null,
         .env = &.{},
         .run_at_load = false,
@@ -96,7 +99,7 @@ test "register writes a plist and a DB row that list reports back" {
         .stdout_path = "/tmp/malt_sup_register/out.log",
         .stderr_path = "/tmp/malt_sup_register/err.log",
     };
-    try supervisor.register(testing.allocator, &db, spec, "testkeg", true);
+    try supervisor.register(testing.allocator, &db, spec, "testkeg", true, cellar, prefix);
 
     try testing.expect(supervisor.hasService(&db, "com.malt.test.svc"));
 


### PR DESCRIPTION
## Summary

Three hardenings of the Ruby post_install path:

1. Formula source is pinned to a specific homebrew-core commit and SHA256-verified before execution.
2. The opt-in Ruby path runs inside a macOS sandbox-exec profile confined to the formula's own cellar, with scrubbed env and rlimits, so a hostile formula can't reach outside its install prefix.
3. `--use-system-ruby` is per-formula now; a DSL parse failure on one package no longer widens the trust boundary for the rest.

Plus a hard gate on launchd service declarations (argv path allowlist, interpreter-bait rejection, path escape + NUL/oversize rejection), and lock-in regression tests for the already-clean argv-only spawn surface and install.sh fail-closed behaviour.