### PR TITLE
feat(security): validate MALT_PREFIX at the env boundary

### DIFF
--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -31,6 +31,20 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var warnings: u32 = 0;
     var errors: u32 = 0;
 
+    // 0. MALT_PREFIX visibility. atomic.maltPrefix() already aborts on a
+    //    malformed env, so by this point the value is validated — doctor
+    //    just surfaces it for operator context.
+    {
+        const is_default = std.mem.eql(u8, prefix, "/opt/malt");
+        var pbuf: [600]u8 = undefined;
+        const detail = std.fmt.bufPrint(
+            &pbuf,
+            "{s} {s}",
+            .{ prefix, if (is_default) "(default)" else "(from MALT_PREFIX)" },
+        ) catch prefix;
+        printCheck("MALT_PREFIX", .ok, detail);
+    }
+
     // 1. SQLite integrity
     blk: {
         var db_path_buf: [512]u8 = undefined;

--- a/src/fs/atomic.zig
+++ b/src/fs/atomic.zig
@@ -2,10 +2,77 @@ const std = @import("std");
 const fs_compat = @import("compat.zig");
 const clonefile = @import("clonefile.zig");
 
-/// Return the malt install prefix, honouring the MALT_PREFIX environment
-/// variable and falling back to "/opt/malt".
+/// 512 bytes: ~4× real Homebrew prefix length, still small enough that
+/// anything past it is either a bug or overflow bait.
+pub const MAX_PREFIX_LEN: usize = 512;
+
+pub const PrefixError = error{
+    Empty,
+    NotAbsolute,
+    DotDotComponent,
+    EmbeddedNul,
+    TooLong,
+    EmptyComponent,
+};
+
+/// Validate a candidate install prefix. Called at the env boundary so
+/// downstream code can assume absolute, NUL-free, traversal-free.
+pub fn validatePrefix(prefix: []const u8) PrefixError!void {
+    if (prefix.len == 0) return PrefixError.Empty;
+    if (prefix.len > MAX_PREFIX_LEN) return PrefixError.TooLong;
+    if (prefix[0] != '/') return PrefixError.NotAbsolute;
+    if (std.mem.indexOfScalar(u8, prefix, 0) != null) return PrefixError.EmbeddedNul;
+
+    // Strip one trailing slash; `/opt/malt/` is fine, `//` inside is not.
+    const trimmed = if (prefix.len > 1 and prefix[prefix.len - 1] == '/')
+        prefix[0 .. prefix.len - 1]
+    else
+        prefix;
+    if (trimmed.len == 1) return; // just "/" — no components to scan
+
+    var it = std.mem.splitScalar(u8, trimmed, '/');
+    _ = it.next(); // leading "/" yields an empty first slice
+    while (it.next()) |comp| {
+        if (comp.len == 0) return PrefixError.EmptyComponent;
+        if (std.mem.eql(u8, comp, "..")) return PrefixError.DotDotComponent;
+    }
+}
+
+pub fn describePrefixError(e: PrefixError) []const u8 {
+    return switch (e) {
+        PrefixError.Empty => "empty",
+        PrefixError.NotAbsolute => "not an absolute path",
+        PrefixError.DotDotComponent => "contains '..' component",
+        PrefixError.EmbeddedNul => "contains NUL byte",
+        PrefixError.TooLong => "exceeds 512 bytes",
+        PrefixError.EmptyComponent => "contains empty path component ('//')",
+    };
+}
+
+/// Validated form of `maltPrefix`, returns an error on bad env so tests
+/// can inspect the failure without the process exiting.
+pub fn maltPrefixChecked() PrefixError![:0]const u8 {
+    const raw = fs_compat.getenv("MALT_PREFIX") orelse return "/opt/malt";
+    try validatePrefix(raw);
+    return raw;
+}
+
+/// Install prefix with a fail-closed env check. A malformed MALT_PREFIX
+/// is a startup misconfig or traversal attempt — abort loudly rather
+/// than falling back silently.
 pub fn maltPrefix() [:0]const u8 {
-    return fs_compat.getenv("MALT_PREFIX") orelse "/opt/malt";
+    return maltPrefixChecked() catch |e| {
+        const raw = fs_compat.getenv("MALT_PREFIX") orelse "<unset>";
+        // Bypass the UI layer — atomic.zig sits below it in the dep graph.
+        var buf: [1024]u8 = undefined;
+        const msg = std.fmt.bufPrint(
+            &buf,
+            "malt: refusing to use MALT_PREFIX='{s}': {s}\n",
+            .{ raw, describePrefixError(e) },
+        ) catch "malt: MALT_PREFIX rejected; refusing to proceed\n";
+        _ = std.c.write(std.c.STDERR_FILENO, msg.ptr, msg.len);
+        std.process.exit(78); // EX_CONFIG
+    };
 }
 
 /// Rename `src_path` to `dst_path`. Tries a single `rename(2)` first — the

--- a/tests/atomic_test.zig
+++ b/tests/atomic_test.zig
@@ -37,6 +37,126 @@ test "maltPrefix honours MALT_PREFIX env var" {
     try testing.expectEqualStrings("/tmp/malt_atomic_prefix_env", got);
 }
 
+// ────────────────────────────────────────────────────────────────────
+// validatePrefix — pure-function tests, exhaustive over the error set.
+// maltPrefixChecked() is exercised via these + the env-based tests
+// above, which establish the happy path through the same validator.
+// ────────────────────────────────────────────────────────────────────
+
+test "validatePrefix: default path is accepted" {
+    try atomic.validatePrefix("/opt/malt");
+}
+
+test "validatePrefix: tmp sandbox prefix is accepted" {
+    try atomic.validatePrefix("/tmp/malt_test_prefix");
+}
+
+test "validatePrefix: root '/' is accepted" {
+    // Root alone is technically absolute and has no bad components; we
+    // don't get to veto unusual-but-syntactically-valid prefixes.
+    try atomic.validatePrefix("/");
+}
+
+test "validatePrefix: trailing slash is tolerated" {
+    try atomic.validatePrefix("/opt/malt/");
+}
+
+test "validatePrefix: empty string rejected" {
+    try testing.expectError(error.Empty, atomic.validatePrefix(""));
+}
+
+test "validatePrefix: relative path rejected" {
+    try testing.expectError(error.NotAbsolute, atomic.validatePrefix("opt/malt"));
+    try testing.expectError(error.NotAbsolute, atomic.validatePrefix("./malt"));
+    try testing.expectError(error.NotAbsolute, atomic.validatePrefix("malt"));
+}
+
+test "validatePrefix: .. component rejected" {
+    try testing.expectError(error.DotDotComponent, atomic.validatePrefix("/opt/../etc"));
+    try testing.expectError(error.DotDotComponent, atomic.validatePrefix("/.."));
+    try testing.expectError(error.DotDotComponent, atomic.validatePrefix("/opt/malt/.."));
+}
+
+test "validatePrefix: NUL byte rejected" {
+    try testing.expectError(error.EmbeddedNul, atomic.validatePrefix("/opt/\x00malt"));
+    try testing.expectError(error.EmbeddedNul, atomic.validatePrefix("/opt/malt\x00"));
+}
+
+test "validatePrefix: length > MAX_PREFIX_LEN rejected" {
+    var buf: [atomic.MAX_PREFIX_LEN + 1]u8 = undefined;
+    @memset(&buf, 'a');
+    buf[0] = '/';
+    try testing.expectError(error.TooLong, atomic.validatePrefix(&buf));
+}
+
+test "validatePrefix: length == MAX_PREFIX_LEN accepted" {
+    var buf: [atomic.MAX_PREFIX_LEN]u8 = undefined;
+    @memset(&buf, 'a');
+    buf[0] = '/';
+    try atomic.validatePrefix(&buf);
+}
+
+test "validatePrefix: '//' inside rejected" {
+    try testing.expectError(error.EmptyComponent, atomic.validatePrefix("/opt//malt"));
+    try testing.expectError(error.EmptyComponent, atomic.validatePrefix("//opt/malt"));
+}
+
+test "validatePrefix: single dot component is permitted (not our job to canonicalise)" {
+    // A lone `.` is a valid filesystem path component; we only reject
+    // the traversal primitive `..`. Keeping this permissive avoids
+    // surprising users on paths like /opt/./malt.
+    try atomic.validatePrefix("/opt/./malt");
+}
+
+test "validatePrefix: dotdot-like-but-not-exact component accepted" {
+    // Make sure we don't over-match on .. — names like `foo..bar` are
+    // not path traversal.
+    try atomic.validatePrefix("/opt/foo..bar");
+    try atomic.validatePrefix("/opt/..malt");
+    try atomic.validatePrefix("/opt/malt..");
+}
+
+test "maltPrefixChecked: empty MALT_PREFIX returns Empty error" {
+    setPrefix("");
+    defer unsetPrefix();
+    try testing.expectError(error.Empty, atomic.maltPrefixChecked());
+}
+
+test "maltPrefixChecked: traversal MALT_PREFIX returns DotDotComponent" {
+    setPrefix("/tmp/malt/../etc");
+    defer unsetPrefix();
+    try testing.expectError(error.DotDotComponent, atomic.maltPrefixChecked());
+}
+
+test "maltPrefixChecked: relative MALT_PREFIX returns NotAbsolute" {
+    setPrefix("relative/path");
+    defer unsetPrefix();
+    try testing.expectError(error.NotAbsolute, atomic.maltPrefixChecked());
+}
+
+test "maltPrefixChecked: unset returns default" {
+    unsetPrefix();
+    const got = try atomic.maltPrefixChecked();
+    try testing.expectEqualStrings("/opt/malt", got);
+}
+
+test "describePrefixError: every error has a descriptive string" {
+    // Compile-time-ish coverage: every arm of the switch must return
+    // something non-empty so error output is useful.
+    const cases = [_]atomic.PrefixError{
+        error.Empty,
+        error.NotAbsolute,
+        error.DotDotComponent,
+        error.EmbeddedNul,
+        error.TooLong,
+        error.EmptyComponent,
+    };
+    for (cases) |e| {
+        const desc = atomic.describePrefixError(e);
+        try testing.expect(desc.len > 0);
+    }
+}
+
 test "maltTmpDir composes {prefix}/tmp" {
     setPrefix("/tmp/malt_atomic_tmp_env");
     defer unsetPrefix();


### PR DESCRIPTION
A malformed `MALT_PREFIX` - empty, relative, containing `..`, with a NUL byte, over 512 bytes, or with `//` inside — is now refused at startup with a clear error. 

Previously such values were trusted verbatim and flowed into every derived path. `malt doctor` also surfaces the active prefix for visibility.