### PR TITLE
feat(security): pin install.sh source fallback to a release tag

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -120,8 +120,25 @@ if [ -z "$LATEST" ]; then
     TMPDIR=$(mktemp -d)
     trap 'rm -rf "$TMPDIR"' EXIT
 
-    info "Cloning repository..."
-    git clone --depth 1 "https://github.com/${REPO}.git" "$TMPDIR/malt"
+    # Resolve the latest release tag without the GitHub API. Rewriting
+    # git refs is a higher bar than rewriting main at a single moment.
+    CLONE_REF=""
+    if command -v git >/dev/null 2>&1; then
+      CLONE_REF=$(git ls-remote --tags --refs "https://github.com/${REPO}.git" 'refs/tags/v*' 2>/dev/null |
+        awk -F/ '{print $NF}' | sort -V | tail -1)
+    fi
+
+    if [ -n "$CLONE_REF" ]; then
+      info "Cloning repository at ${CLONE_REF}..."
+      git clone --depth 1 --branch "$CLONE_REF" "https://github.com/${REPO}.git" "$TMPDIR/malt"
+    elif [ "${MALT_ALLOW_UNVERIFIED_SOURCE:-0}" = "1" ]; then
+      warn "MALT_ALLOW_UNVERIFIED_SOURCE=1 — cloning default branch without a pinned tag"
+      git clone --depth 1 "https://github.com/${REPO}.git" "$TMPDIR/malt"
+    else
+      error "Could not resolve a release tag to clone.
+  Refusing to build from the default branch (untrusted).
+  To bypass (not recommended): MALT_ALLOW_UNVERIFIED_SOURCE=1 curl … | bash"
+    fi
 
     info "Building (this may take a minute)..."
     cd "$TMPDIR/malt"

--- a/scripts/test/install_sh_test.sh
+++ b/scripts/test/install_sh_test.sh
@@ -240,6 +240,68 @@ fi
   failures+=("sha-mismatch-artifact")
 }
 
+# ── test 5: source-fallback refuses unverified clone ────────────────
+# When the API is unreachable AND `git ls-remote` surfaces no tags,
+# install.sh must refuse to build from the default branch. We fake
+# both: API URL points at a dead port; a shim `git ls-remote` returns
+# empty so no release tag can be resolved offline either.
+printf '▸ source fallback refuses unverified clone\n'
+
+FAKE_BIN="$TMP/fake-bin-5"
+mkdir -p "$FAKE_BIN"
+cat >"$FAKE_BIN/git" <<'EOF'
+#!/bin/bash
+if [ "$1" = "ls-remote" ]; then exit 0; fi
+exec /usr/bin/git "$@"
+EOF
+# install.sh aborts early if zig isn't on PATH. The refuse-unverified
+# check happens after that probe but before any real zig invocation —
+# a stub that satisfies `command -v` is enough.
+cat >"$FAKE_BIN/zig" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+chmod +x "$FAKE_BIN/git" "$FAKE_BIN/zig"
+
+prefix5="$TMP/prefix_5"
+install_dir5="$TMP/bin_5"
+mkdir -p "$prefix5" "$install_dir5"
+rc5=0
+env -i \
+  HOME="$HOME" \
+  PATH="$FAKE_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  USER="$USER" \
+  PREFIX="$prefix5" \
+  INSTALL_DIR="$install_dir5" \
+  MALT_ALLOW_UNVERIFIED=1 \
+  MALT_TEST_RELEASES_URL="http://127.0.0.1:1" \
+  MALT_TEST_API_URL="http://127.0.0.1:1/unreachable" \
+  NO_COLOR=1 \
+  bash "$INSTALLER" >"$TMP/out.log" 2>&1 || rc5=$?
+
+if [ "$rc5" != "0" ]; then
+  printf '  ✓ unverified source clone rejected (rc=%s)\n' "$rc5"
+  pass=$((pass + 1))
+else
+  printf '  ✗ unverified source clone did NOT fail\n' >&2
+  fail=$((fail + 1))
+  failures+=("source-fallback-allowed")
+  sed 's/^/      /' "$TMP/out.log" >&2 || true
+fi
+[ ! -e "$install_dir5/malt" ] || {
+  printf '  ✗ source fallback: artifact landed anyway\n' >&2
+  fail=$((fail + 1))
+  failures+=("source-fallback-artifact")
+}
+if grep -q "MALT_ALLOW_UNVERIFIED_SOURCE" "$TMP/out.log"; then
+  printf '  ✓ refuse message references the opt-out env\n'
+  pass=$((pass + 1))
+else
+  printf '  ✗ refuse message missing the opt-out env hint\n' >&2
+  fail=$((fail + 1))
+  failures+=("source-fallback-message")
+fi
+
 printf '\n── summary ──\n'
 printf 'pass: %d\n' "$pass"
 printf 'fail: %d\n' "$fail"


### PR DESCRIPTION
install.sh's build-from-source fallback no longer trusts the default branch of this repo. It now clones the latest release tag (resolved via `git ls-remote` when the GitHub API is unreachable) and refuses to proceed at all when no tag can be resolved, unless `MALT_ALLOW_UNVERIFIED_SOURCE=1` is explicit.

Stacked on #59 — retarget to `main` after that squash-merges.