### PR TITLE
feat(security): refuse https → http redirect downgrades

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -150,6 +150,7 @@ pub fn build(b: *std.Build) void {
         "tests/sandbox_macos_test.zig",
         "tests/services_validate_test.zig",
         "tests/spawn_invariant_test.zig",
+        "tests/net_client_test.zig",
         "tests/cli_tap_test.zig",
         "tests/cli_services_test.zig",
         "tests/install_execute_test.zig",

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -24,6 +24,12 @@ pub const Response = struct {
     }
 };
 
+/// True if the URI scheme is exactly "https" (ascii case-insensitive).
+/// Exposed for the downgrade-guard tests; inlined at the only call site.
+pub fn schemeIsHttps(scheme: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(scheme, "https");
+}
+
 pub const HttpClient = struct {
     allocator: std.mem.Allocator,
     client: std.http.Client,
@@ -254,6 +260,7 @@ pub const HttpClient = struct {
         progress: ?ProgressCallback,
     ) !Response {
         const uri = try std.Uri.parse(url);
+        const https_origin = schemeIsHttps(uri.scheme);
 
         var req = try self.client.request(.GET, uri, .{
             .extra_headers = extra_headers,
@@ -267,6 +274,15 @@ pub const HttpClient = struct {
         // past the old 8 KiB budget.
         var redirect_buf: [32 * 1024]u8 = undefined;
         var response = try req.receiveHead(&redirect_buf);
+
+        // Refuse an https → http downgrade across a 3xx chain. The
+        // stdlib already strips privileged headers on scheme change,
+        // but letting the body itself come back over plaintext with
+        // no CA validation is still a metadata-substitution vector
+        // for every endpoint whose integrity check depends on what
+        // the response says.
+        if (https_origin and !schemeIsHttps(req.uri.scheme))
+            return error.TlsDowngradeRefused;
 
         const status: u16 = @intFromEnum(response.head.status);
 

--- a/tests/net_client_test.zig
+++ b/tests/net_client_test.zig
@@ -1,0 +1,37 @@
+//! malt — net/client tests
+//! Covers the TLS downgrade guard; the full request path is
+//! exercised via smoke scripts against real endpoints.
+
+const std = @import("std");
+const testing = std.testing;
+const client = @import("malt").client;
+
+test "schemeIsHttps: https accepted" {
+    try testing.expect(client.schemeIsHttps("https"));
+}
+
+test "schemeIsHttps: case-insensitive" {
+    try testing.expect(client.schemeIsHttps("HTTPS"));
+    try testing.expect(client.schemeIsHttps("Https"));
+}
+
+test "schemeIsHttps: http rejected" {
+    try testing.expect(!client.schemeIsHttps("http"));
+}
+
+test "schemeIsHttps: empty rejected" {
+    try testing.expect(!client.schemeIsHttps(""));
+}
+
+test "schemeIsHttps: unrelated schemes rejected" {
+    try testing.expect(!client.schemeIsHttps("ftp"));
+    try testing.expect(!client.schemeIsHttps("file"));
+    try testing.expect(!client.schemeIsHttps("https-but-not-quite"));
+}
+
+test "schemeIsHttps: substring traps rejected" {
+    // An attacker who can influence the scheme byte comparison
+    // shouldn't sneak through with `httpsx` or `xhttps`.
+    try testing.expect(!client.schemeIsHttps("httpsx"));
+    try testing.expect(!client.schemeIsHttps("xhttps"));
+}


### PR DESCRIPTION
A 3xx chain that tries to step an https-origin request down to plaintext now aborts with a clear error.

Stacked on #60 - retarget to main after that squash-merges.