### PR TITLE
feat(security): filter terminal escapes from ruby post_install output

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -151,6 +151,7 @@ pub fn build(b: *std.Build) void {
         "tests/services_validate_test.zig",
         "tests/spawn_invariant_test.zig",
         "tests/net_client_test.zig",
+        "tests/term_sanitize_test.zig",
         "tests/cli_tap_test.zig",
         "tests/cli_services_test.zig",
         "tests/install_execute_test.zig",

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -20,6 +20,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const fs_compat = @import("../../fs/compat.zig");
+const term_sanitize = @import("../../ui/term_sanitize.zig");
 
 pub const SandboxError = error{
     SandboxUnsupported,
@@ -220,6 +221,12 @@ fn freeArgv(allocator: std.mem.Allocator, argv: [:null]?[*:0]u8) void {
 /// Returns the child's exit code on normal exit, or a SandboxError
 /// if the child was killed by a signal / the sandbox couldn't be
 /// applied / the fork-exec itself failed.
+///
+/// The child's stdout/stderr are filtered through a terminal escape-
+/// sequence sanitizer (`term_sanitize`) before being forwarded to the
+/// parent's fds, so a hostile formula cannot emit OSC/DCS/cursor
+/// commands that rewrite scrollback or exfiltrate via terminal
+/// extensions. Set `MALT_ALLOW_RAW_POST_INSTALL=1` to bypass.
 pub fn runRubySandboxed(
     allocator: std.mem.Allocator,
     ruby_path: []const u8,
@@ -243,23 +250,121 @@ pub fn runRubySandboxed(
     const envp = try buildEnvp(allocator, env);
     defer freeEnvp(allocator, envp);
 
+    if (rawPassthroughEnabled()) {
+        return spawnInherit(argv_z, envp, limits);
+    }
+    return spawnFiltered(argv_z, envp, limits);
+}
+
+fn rawPassthroughEnabled() bool {
+    const v = fs_compat.getenv("MALT_ALLOW_RAW_POST_INSTALL") orelse return false;
+    return std.mem.eql(u8, std.mem.sliceTo(v, 0), "1");
+}
+
+fn spawnInherit(
+    argv_z: [:null]?[*:0]u8,
+    envp: [:null]?[*:0]u8,
+    limits: Limits,
+) SandboxError!u8 {
     const pid = std.c.fork();
     if (pid < 0) return SandboxError.ForkFailed;
     if (pid == 0) {
-        // child: apply rlimits, then exec. Any failure here must call
-        // _exit, not return — we are post-fork and must not run parent
-        // cleanup code.
         applyRlimits(limits) catch std.c._exit(127);
         _ = std.c.execve(argv_z[0].?, argv_z.ptr, envp.ptr);
         std.c._exit(127);
     }
-    // parent
     var status: c_int = 0;
     const w = std.c.waitpid(pid, &status, 0);
     if (w < 0) return SandboxError.WaitFailed;
     if (wifsignaled(status)) return SandboxError.ChildSignaled;
     if (!wifexited(status)) return SandboxError.ChildCrashed;
     return @intCast(wexitstatus(status));
+}
+
+fn spawnFiltered(
+    argv_z: [:null]?[*:0]u8,
+    envp: [:null]?[*:0]u8,
+    limits: Limits,
+) SandboxError!u8 {
+    var out_pipe: [2]c_int = undefined;
+    var err_pipe: [2]c_int = undefined;
+    if (std.c.pipe(&out_pipe) != 0) return SandboxError.ForkFailed;
+    errdefer {
+        _ = std.c.close(out_pipe[0]);
+        _ = std.c.close(out_pipe[1]);
+    }
+    if (std.c.pipe(&err_pipe) != 0) return SandboxError.ForkFailed;
+    errdefer {
+        _ = std.c.close(err_pipe[0]);
+        _ = std.c.close(err_pipe[1]);
+    }
+
+    const pid = std.c.fork();
+    if (pid < 0) return SandboxError.ForkFailed;
+    if (pid == 0) {
+        // Child: wire pipes to fd 1/2, drop the read ends, exec.
+        _ = std.c.close(out_pipe[0]);
+        _ = std.c.close(err_pipe[0]);
+        _ = std.c.dup2(out_pipe[1], 1);
+        _ = std.c.dup2(err_pipe[1], 2);
+        _ = std.c.close(out_pipe[1]);
+        _ = std.c.close(err_pipe[1]);
+        applyRlimits(limits) catch std.c._exit(127);
+        _ = std.c.execve(argv_z[0].?, argv_z.ptr, envp.ptr);
+        std.c._exit(127);
+    }
+
+    // Parent: drop write ends, spawn reader threads that sanitize
+    // into the parent's real stdout/stderr.
+    _ = std.c.close(out_pipe[1]);
+    _ = std.c.close(err_pipe[1]);
+
+    const out_thread = std.Thread.spawn(.{}, filterLoop, .{ out_pipe[0], @as(c_int, 1) }) catch
+        return SandboxError.ForkFailed;
+    const err_thread = std.Thread.spawn(.{}, filterLoop, .{ err_pipe[0], @as(c_int, 2) }) catch
+        return SandboxError.ForkFailed;
+
+    var status: c_int = 0;
+    const w = std.c.waitpid(pid, &status, 0);
+
+    // Reader threads exit when their pipe returns EOF (child's fd
+    // closed), so we can safely join after waitpid.
+    out_thread.join();
+    err_thread.join();
+
+    if (w < 0) return SandboxError.WaitFailed;
+    if (wifsignaled(status)) return SandboxError.ChildSignaled;
+    if (!wifexited(status)) return SandboxError.ChildCrashed;
+    return @intCast(wexitstatus(status));
+}
+
+const FdSinkCtx = struct { fd: c_int };
+
+fn fdSinkWrite(ctx: *anyopaque, bytes: []const u8) anyerror!void {
+    const self: *FdSinkCtx = @ptrCast(@alignCast(ctx));
+    var off: usize = 0;
+    while (off < bytes.len) {
+        const n = std.c.write(self.fd, bytes.ptr + off, bytes.len - off);
+        if (n < 0) return error.WriteFailed;
+        off += @intCast(n);
+    }
+}
+
+/// Reader thread: pull from the pipe, run through the sanitizer,
+/// push the surviving bytes to the parent's real fd. Exits on EOF
+/// or write error.
+fn filterLoop(pipe_fd: c_int, out_fd: c_int) void {
+    defer _ = std.c.close(pipe_fd);
+    var sanitizer = term_sanitize.Sanitizer.init();
+    var ctx = FdSinkCtx{ .fd = out_fd };
+    const sink = term_sanitize.Sink{ .ctx = &ctx, .write_fn = fdSinkWrite };
+    var buf: [4096]u8 = undefined;
+    while (true) {
+        const n = std.c.read(pipe_fd, &buf, buf.len);
+        if (n <= 0) break;
+        sanitizer.feed(buf[0..@intCast(n)], sink) catch break;
+    }
+    sanitizer.flush(sink) catch {};
 }
 
 // macOS <sys/wait.h> status macros, open-coded.

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -21,6 +21,7 @@ pub const patcher = @import("macho/patcher.zig");
 pub const api = @import("net/api.zig");
 pub const client = @import("net/client.zig");
 pub const output = @import("ui/output.zig");
+pub const term_sanitize = @import("ui/term_sanitize.zig");
 pub const progress = @import("ui/progress.zig");
 pub const version = @import("version.zig");
 pub const completions = @import("cli/completions.zig");

--- a/src/ui/term_sanitize.zig
+++ b/src/ui/term_sanitize.zig
@@ -1,0 +1,159 @@
+//! malt — terminal escape-sequence sanitizer
+//!
+//! Filters bytes from an untrusted child process before they reach
+//! the user's terminal. Permits printable ASCII + CR/LF/TAB + the
+//! common UTF-8 continuation range + a whitelisted subset of CSI
+//! escape sequences (SGR colours and cursor positioning). Everything
+//! else — OSC (including clipboard-reading OSC 52), DCS, SOS/PM/APC,
+//! other CSI commands, C0 controls, stray ESC — is dropped.
+//!
+//! Used to wrap post_install stdout/stderr so a hostile formula
+//! cannot rewrite scrollback or exfiltrate via terminal extensions.
+
+const std = @import("std");
+
+/// Bytes-out callback. The sink is allowed to fail; the sanitizer
+/// propagates that error to its caller.
+pub const Sink = struct {
+    ctx: *anyopaque,
+    write_fn: *const fn (ctx: *anyopaque, bytes: []const u8) anyerror!void,
+
+    pub fn write(self: Sink, bytes: []const u8) anyerror!void {
+        return self.write_fn(self.ctx, bytes);
+    }
+};
+
+/// CSI parameter buffer cap. Real SGR/cursor sequences rarely exceed
+/// a handful of bytes; an attacker can still overflow, in which case
+/// we drop the whole sequence at its final byte.
+pub const CSI_PARAM_MAX: usize = 32;
+pub const OUT_BUF: usize = 256;
+
+pub const Sanitizer = struct {
+    state: State = .normal,
+    csi_buf: [CSI_PARAM_MAX]u8 = undefined,
+    csi_len: usize = 0,
+    csi_overflow: bool = false,
+    out_buf: [OUT_BUF]u8 = undefined,
+    out_len: usize = 0,
+
+    const State = enum {
+        normal,
+        esc, // just saw ESC (0x1B)
+        csi, // in ESC [ ... sequence
+        osc, // in ESC ] ... ST  (always dropped)
+        dcs, // DCS/SOS/PM/APC (always dropped)
+        st_maybe, // inside OSC/DCS, just saw ESC — looking for ST's `\\`
+    };
+
+    pub fn init() Sanitizer {
+        return .{};
+    }
+
+    /// Feed one chunk of input. Safe to call repeatedly; state is
+    /// preserved across calls so a sequence split across chunks is
+    /// still recognised.
+    pub fn feed(self: *Sanitizer, input: []const u8, sink: Sink) !void {
+        for (input) |b| try self.feedByte(b, sink);
+    }
+
+    /// Flush buffered passable bytes. Call at end-of-stream.
+    pub fn flush(self: *Sanitizer, sink: Sink) !void {
+        if (self.out_len > 0) {
+            try sink.write(self.out_buf[0..self.out_len]);
+            self.out_len = 0;
+        }
+    }
+
+    fn feedByte(self: *Sanitizer, b: u8, sink: Sink) !void {
+        switch (self.state) {
+            .normal => {
+                if (b == 0x1B) {
+                    try self.flush(sink);
+                    self.state = .esc;
+                } else if (passable(b)) {
+                    try self.emit(b, sink);
+                }
+                // else: drop silently
+            },
+            .esc => switch (b) {
+                '[' => {
+                    self.state = .csi;
+                    self.csi_len = 0;
+                    self.csi_overflow = false;
+                },
+                ']' => self.state = .osc,
+                'P', 'X', '^', '_' => self.state = .dcs,
+                // Two-byte ESC X: drop both (we already dropped ESC).
+                else => self.state = .normal,
+            },
+            .csi => {
+                if (b >= 0x40 and b <= 0x7E) {
+                    // Final byte: decide.
+                    if (!self.csi_overflow and csiAllowed(b)) {
+                        try self.emit(0x1B, sink);
+                        try self.emit('[', sink);
+                        for (self.csi_buf[0..self.csi_len]) |p| try self.emit(p, sink);
+                        try self.emit(b, sink);
+                    }
+                    self.state = .normal;
+                } else if (self.csi_len < self.csi_buf.len) {
+                    self.csi_buf[self.csi_len] = b;
+                    self.csi_len += 1;
+                } else {
+                    // Too many param bytes — fail-closed when the
+                    // final byte arrives.
+                    self.csi_overflow = true;
+                }
+            },
+            .osc, .dcs => {
+                if (b == 0x07) {
+                    self.state = .normal; // BEL terminates OSC
+                } else if (b == 0x1B) {
+                    self.state = .st_maybe;
+                }
+                // else: drop
+            },
+            .st_maybe => {
+                if (b == '\\') {
+                    self.state = .normal;
+                } else if (b == 0x1B) {
+                    // Stay waiting.
+                } else {
+                    // Not ST; back into OSC/DCS body.
+                    self.state = .osc;
+                }
+            },
+        }
+    }
+
+    fn emit(self: *Sanitizer, b: u8, sink: Sink) !void {
+        if (self.out_len == self.out_buf.len) try self.flush(sink);
+        self.out_buf[self.out_len] = b;
+        self.out_len += 1;
+    }
+};
+
+fn passable(b: u8) bool {
+    // Printable ASCII, common whitespace, and UTF-8 continuation /
+    // leading bytes. UTF-8 is passed raw rather than validated —
+    // the terminal will do its own validation, and stripping mid-
+    // sequence would corrupt legitimate non-ASCII output.
+    return (b >= 0x20 and b <= 0x7E) or
+        b == '\n' or b == '\r' or b == '\t' or
+        b >= 0x80;
+}
+
+fn csiAllowed(final: u8) bool {
+    return switch (final) {
+        'm' => true, // SGR: colours, bold, underline
+        'A', 'B', 'C', 'D' => true, // cursor up/down/right/left
+        'E', 'F' => true, // cursor next/prev line
+        'G' => true, // cursor column
+        'H', 'f' => true, // cursor position
+        'J' => true, // erase display
+        'K' => true, // erase line
+        's', 'u' => true, // save/restore cursor
+        else => false,
+    };
+}

--- a/tests/term_sanitize_test.zig
+++ b/tests/term_sanitize_test.zig
@@ -1,0 +1,193 @@
+//! malt — term_sanitize tests
+//!
+//! Exhaustive coverage of the escape-sequence state machine. Inputs
+//! are byte literals; outputs are compared against expected byte
+//! strings. State is preserved across feed() calls so split-across-
+//! chunks inputs are also covered.
+
+const std = @import("std");
+const testing = std.testing;
+const ts = @import("malt").term_sanitize;
+
+const Buf = struct {
+    list: std.ArrayList(u8) = .empty,
+
+    fn sink(self: *Buf) ts.Sink {
+        return .{ .ctx = self, .write_fn = writeFn };
+    }
+
+    fn writeFn(ctx: *anyopaque, bytes: []const u8) anyerror!void {
+        const self: *Buf = @ptrCast(@alignCast(ctx));
+        try self.list.appendSlice(testing.allocator, bytes);
+    }
+
+    fn deinit(self: *Buf) void {
+        self.list.deinit(testing.allocator);
+    }
+};
+
+fn check(input: []const u8, expected: []const u8) !void {
+    var buf: Buf = .{};
+    defer buf.deinit();
+    var s = ts.Sanitizer.init();
+    try s.feed(input, buf.sink());
+    try s.flush(buf.sink());
+    try testing.expectEqualSlices(u8, expected, buf.list.items);
+}
+
+test "plain ASCII passes through" {
+    try check("hello world", "hello world");
+}
+
+test "whitespace preserved" {
+    try check("a\tb\nc\r\n", "a\tb\nc\r\n");
+}
+
+test "UTF-8 multibyte preserved" {
+    // "café — 日本語"
+    try check("caf\xc3\xa9 \xe2\x80\x94 \xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e", "caf\xc3\xa9 \xe2\x80\x94 \xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e");
+}
+
+test "NUL dropped" {
+    try check("a\x00b", "ab");
+}
+
+test "BEL dropped" {
+    try check("a\x07b\x07c", "abc");
+}
+
+test "BS dropped" {
+    try check("a\x08b", "ab");
+}
+
+test "stray ESC dropped with its follower" {
+    // ESC followed by a non-special byte: drop both.
+    try check("a\x1bZb", "ab");
+}
+
+// ── CSI SGR allowed ─────────────────────────────────────────────────
+
+test "SGR colour passes" {
+    try check("\x1b[31mred\x1b[0m", "\x1b[31mred\x1b[0m");
+}
+
+test "SGR with multiple params passes" {
+    try check("\x1b[1;32;40mx", "\x1b[1;32;40mx");
+}
+
+// ── CSI cursor motion allowed ───────────────────────────────────────
+
+test "cursor up passes" {
+    try check("\x1b[3A", "\x1b[3A");
+}
+
+test "cursor position passes" {
+    try check("\x1b[10;20H", "\x1b[10;20H");
+}
+
+test "erase line passes" {
+    try check("\x1b[2K", "\x1b[2K");
+}
+
+test "save/restore cursor passes" {
+    try check("\x1b[s\x1b[u", "\x1b[s\x1b[u");
+}
+
+// ── CSI other commands dropped ──────────────────────────────────────
+
+test "mode set CSI ? h dropped" {
+    // ESC [ ? 1049 h — alt-screen toggle, not in allowlist
+    try check("a\x1b[?1049hb", "ab");
+}
+
+test "mode reset CSI l dropped" {
+    try check("a\x1b[?25lb", "ab");
+}
+
+test "scroll region CSI r dropped" {
+    try check("a\x1b[1;24rb", "ab");
+}
+
+// ── OSC always dropped ──────────────────────────────────────────────
+
+test "OSC 52 clipboard attempt dropped" {
+    // ESC ] 52;c;BASE64 ST — iTerm2 clipboard read/write
+    try check("a\x1b]52;c;aGVsbG8=\x1b\\b", "ab");
+}
+
+test "OSC terminated by BEL dropped" {
+    try check("a\x1b]0;window title\x07b", "ab");
+}
+
+test "OSC terminated by ST dropped" {
+    try check("a\x1b]8;;https://example.com\x1b\\label\x1b]8;;\x1b\\b", "alabelb");
+}
+
+// ── DCS always dropped ──────────────────────────────────────────────
+
+test "DCS always dropped" {
+    try check("a\x1bP1$rm\x1b\\b", "ab");
+}
+
+test "APC always dropped" {
+    try check("a\x1b_payload\x1b\\b", "ab");
+}
+
+test "PM always dropped" {
+    try check("a\x1b^data\x1b\\b", "ab");
+}
+
+test "SOS always dropped" {
+    try check("a\x1bXdata\x1b\\b", "ab");
+}
+
+// ── CSI overflow fails closed ───────────────────────────────────────
+
+test "CSI with oversized params fails closed" {
+    var big: [ts.CSI_PARAM_MAX + 10]u8 = undefined;
+    @memset(&big, '1');
+    var input: std.ArrayList(u8) = .empty;
+    defer input.deinit(testing.allocator);
+    try input.appendSlice(testing.allocator, "a\x1b[");
+    try input.appendSlice(testing.allocator, big[0..]);
+    try input.append(testing.allocator, 'm');
+    try input.append(testing.allocator, 'b');
+    try check(input.items, "ab");
+}
+
+// ── split-across-chunks: state preserved ───────────────────────────
+
+test "CSI split across feed() calls is reassembled" {
+    var buf: Buf = .{};
+    defer buf.deinit();
+    var s = ts.Sanitizer.init();
+    try s.feed("hi \x1b[3", buf.sink());
+    try s.feed("1mred\x1b[0m bye", buf.sink());
+    try s.flush(buf.sink());
+    try testing.expectEqualStrings("hi \x1b[31mred\x1b[0m bye", buf.list.items);
+}
+
+test "OSC split across chunks is dropped end-to-end" {
+    var buf: Buf = .{};
+    defer buf.deinit();
+    var s = ts.Sanitizer.init();
+    try s.feed("a\x1b]52;c;", buf.sink());
+    try s.feed("PAYLOAD", buf.sink());
+    try s.feed("\x1b\\b", buf.sink());
+    try s.flush(buf.sink());
+    try testing.expectEqualStrings("ab", buf.list.items);
+}
+
+// ── empty + pathological inputs ─────────────────────────────────────
+
+test "empty input yields empty output" {
+    try check("", "");
+}
+
+test "bare ESC at end of input is dropped" {
+    try check("abc\x1b", "abc");
+}
+
+test "bare ESC [ at end of input is dropped" {
+    try check("abc\x1b[", "abc");
+}


### PR DESCRIPTION
## Summary

A hostile formula running under `--use-system-ruby` can no longer emit escape sequences that rewrite your terminal's scrollback, read its clipboard, or toggle the alt-screen buffer under your feet. Post_install stdout/stderr now pass through a filter that allows printable bytes, SGR colours, and cursor positioning - and
drops everything else. 

Set `MALT_ALLOW_RAW_POST_INSTALL=1` to keep the old raw passthrough.

Stacked on #61 - retarget to main after that squash-merges.