### PR TITLE
feat(security): audit /opt/malt permissions in malt doctor

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -152,6 +152,7 @@ pub fn build(b: *std.Build) void {
         "tests/spawn_invariant_test.zig",
         "tests/net_client_test.zig",
         "tests/term_sanitize_test.zig",
+        "tests/perms_test.zig",
         "tests/cli_tap_test.zig",
         "tests/cli_services_test.zig",
         "tests/install_execute_test.zig",

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -14,6 +14,7 @@ const color = @import("../ui/color.zig");
 const help = @import("help.zig");
 const install_mod = @import("install.zig");
 const parser = @import("../macho/parser.zig");
+const perms_mod = @import("../core/perms.zig");
 
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "doctor")) return;
@@ -144,6 +145,49 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     } else {
         printCheck("APFS volume", .warn_status, "Not on APFS — clonefile unavailable");
         warnings += 1;
+    }
+
+    // 4b. Prefix permissions — surfaces world/group-writable paths or
+    //     unexpected ownership. Only meaningful on shared systems, but
+    //     cheap to check and a clear signal when someone's chmod'd the
+    //     tree.
+    blk_perms: {
+        const findings = perms_mod.walkPrefix(
+            allocator,
+            prefix,
+            perms_mod.currentUid(),
+            32, // cap so pathological trees don't balloon doctor's memory
+        ) catch {
+            printCheck("Prefix permissions", .warn_status, "Walk failed");
+            warnings += 1;
+            break :blk_perms;
+        };
+        defer perms_mod.freeFindings(allocator, findings);
+
+        if (findings.len == 0) {
+            printCheck("Prefix permissions", .ok, null);
+        } else {
+            var pm_buf: [256]u8 = undefined;
+            const pm_msg = std.fmt.bufPrint(
+                &pm_buf,
+                "{d} path(s) with weak permissions under {s} — run `ls -l` or `chmod`",
+                .{ findings.len, prefix },
+            ) catch "Weak-permission paths under prefix";
+            printCheck("Prefix permissions", .warn_status, pm_msg);
+            warnings += 1;
+            // First couple as a hint so the user knows where to look.
+            for (findings[0..@min(findings.len, 3)]) |f| {
+                var line_buf: [1024]u8 = undefined;
+                const reason = if (f.report.other_writable)
+                    "other-writable"
+                else if (f.report.group_writable)
+                    "group-writable"
+                else
+                    "wrong owner";
+                const line = std.fmt.bufPrint(&line_buf, "        {s} ({s})", .{ f.path, reason }) catch continue;
+                std.debug.print("{s}\n", .{line});
+            }
+        }
     }
 
     // 5. API reachable

--- a/src/core/perms.zig
+++ b/src/core/perms.zig
@@ -1,0 +1,129 @@
+//! malt — filesystem permission audits for the install prefix.
+//!
+//! Detects the class of weak-permissions setup that lets a local
+//! attacker substitute a binary out from under a later `malt run`:
+//! other-writable (`o+w`), group-writable (`g+w`) when the group is
+//! unexpected, or ownership by a user other than the current caller.
+//! Shared-system-only concern; single-user macOS setups are fine.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const fs_compat = @import("../fs/compat.zig");
+
+pub const PermReport = struct {
+    group_writable: bool,
+    other_writable: bool,
+    wrong_owner: bool,
+
+    pub fn isOk(self: PermReport) bool {
+        return !self.group_writable and !self.other_writable and !self.wrong_owner;
+    }
+};
+
+/// Classify a single path's stat result. Pure function so the logic
+/// is unit-testable without real files.
+pub fn classifyPermissions(
+    mode: u16,
+    file_uid: std.c.uid_t,
+    current_uid: std.c.uid_t,
+) PermReport {
+    return .{
+        .group_writable = (mode & 0o020) != 0,
+        .other_writable = (mode & 0o002) != 0,
+        .wrong_owner = file_uid != current_uid,
+    };
+}
+
+pub const WalkFinding = struct {
+    /// Caller-owned. Freed via `freeFindings`.
+    path: []const u8,
+    report: PermReport,
+};
+
+pub fn freeFindings(allocator: std.mem.Allocator, findings: []WalkFinding) void {
+    for (findings) |f| allocator.free(f.path);
+    allocator.free(findings);
+}
+
+/// macOS lstat — doesn't follow symlinks; used here so a malicious
+/// symlink can't make the walker stat the target instead of the link
+/// itself. The Stat shape matches std.c.Stat on macOS.
+extern "c" fn lstat(path: [*:0]const u8, buf: *std.c.Stat) c_int;
+
+/// Walk `prefix` recursively and collect every entry whose permissions
+/// violate `classifyPermissions`. Caps at `max_findings` to bound
+/// memory on pathologically large prefixes.
+pub fn walkPrefix(
+    allocator: std.mem.Allocator,
+    prefix: []const u8,
+    current_uid: std.c.uid_t,
+    max_findings: usize,
+) ![]WalkFinding {
+    var findings: std.ArrayList(WalkFinding) = .empty;
+    errdefer {
+        for (findings.items) |f| allocator.free(f.path);
+        findings.deinit(allocator);
+    }
+
+    try checkPath(allocator, prefix, current_uid, &findings, max_findings);
+    if (findings.items.len >= max_findings) return findings.toOwnedSlice(allocator);
+
+    var dir = fs_compat.openDirAbsolute(prefix, .{ .iterate = true }) catch |e| switch (e) {
+        error.FileNotFound => return findings.toOwnedSlice(allocator),
+        else => return e,
+    };
+    defer dir.close();
+
+    var walker = try dir.walk(allocator);
+    defer walker.deinit();
+
+    while (walker.next() catch null) |entry| {
+        if (findings.items.len >= max_findings) break;
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const full = std.fmt.bufPrint(&buf, "{s}/{s}", .{ prefix, entry.path }) catch continue;
+        try checkPath(allocator, full, current_uid, &findings, max_findings);
+    }
+
+    return findings.toOwnedSlice(allocator);
+}
+
+fn checkPath(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    current_uid: std.c.uid_t,
+    findings: *std.ArrayList(WalkFinding),
+    max_findings: usize,
+) !void {
+    if (findings.items.len >= max_findings) return;
+    if (path.len >= std.fs.max_path_bytes) return;
+
+    var cstr_buf: [std.fs.max_path_bytes + 1]u8 = undefined;
+    @memcpy(cstr_buf[0..path.len], path);
+    cstr_buf[path.len] = 0;
+    const cstr: [*:0]const u8 = @ptrCast(&cstr_buf);
+
+    var st: std.c.Stat = undefined;
+    if (lstat(cstr, &st) != 0) return; // skip unstatable entries silently
+
+    const mode: u16 = @intCast(st.mode & 0o777);
+    const report = classifyPermissions(mode, st.uid, current_uid);
+    if (report.isOk()) return;
+
+    const owned = try allocator.dupe(u8, path);
+    findings.append(allocator, .{ .path = owned, .report = report }) catch |e| {
+        allocator.free(owned);
+        return e;
+    };
+}
+
+pub fn currentUid() std.c.uid_t {
+    return std.c.getuid();
+}
+
+// Re-exports for non-macOS callers that want the type-level surface
+// without pulling in the walker.
+comptime {
+    if (builtin.os.tag != .macos) {
+        @compileError("perms.zig is macOS-only for now");
+    }
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -51,4 +51,5 @@ pub const archive = @import("fs/archive.zig");
 pub const ghcr = @import("net/ghcr.zig");
 pub const ruby_subprocess = @import("core/ruby_subprocess.zig");
 pub const pins = @import("core/pins.zig");
+pub const perms = @import("core/perms.zig");
 pub const sandbox_macos = @import("core/sandbox/macos.zig");

--- a/tests/perms_test.zig
+++ b/tests/perms_test.zig
@@ -1,0 +1,136 @@
+//! malt — permission audit tests
+//!
+//! Covers the pure classifier exhaustively and exercises the walker
+//! against a scratch /tmp tree with known mode bits.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const perms = malt.perms;
+
+test "classify: 0755 + current uid is ok" {
+    const r = perms.classifyPermissions(0o755, 501, 501);
+    try testing.expect(r.isOk());
+}
+
+test "classify: 0644 + current uid is ok" {
+    const r = perms.classifyPermissions(0o644, 501, 501);
+    try testing.expect(r.isOk());
+}
+
+test "classify: 0777 flagged as group+other writable" {
+    const r = perms.classifyPermissions(0o777, 501, 501);
+    try testing.expect(!r.isOk());
+    try testing.expect(r.group_writable);
+    try testing.expect(r.other_writable);
+    try testing.expect(!r.wrong_owner);
+}
+
+test "classify: 0775 flagged as group writable only" {
+    const r = perms.classifyPermissions(0o775, 501, 501);
+    try testing.expect(!r.isOk());
+    try testing.expect(r.group_writable);
+    try testing.expect(!r.other_writable);
+}
+
+test "classify: 0757 flagged as other writable (non-standard but real)" {
+    const r = perms.classifyPermissions(0o757, 501, 501);
+    try testing.expect(!r.isOk());
+    try testing.expect(!r.group_writable);
+    try testing.expect(r.other_writable);
+}
+
+test "classify: wrong_owner flagged independently" {
+    const r = perms.classifyPermissions(0o755, 0, 501); // root-owned
+    try testing.expect(!r.isOk());
+    try testing.expect(r.wrong_owner);
+    try testing.expect(!r.group_writable);
+    try testing.expect(!r.other_writable);
+}
+
+test "classify: all three flags compose" {
+    const r = perms.classifyPermissions(0o777, 0, 501);
+    try testing.expect(r.wrong_owner);
+    try testing.expect(r.group_writable);
+    try testing.expect(r.other_writable);
+}
+
+test "classify: setuid bit does not count as writable" {
+    const r = perms.classifyPermissions(0o4755, 501, 501);
+    try testing.expect(r.isOk());
+}
+
+// ── walker integration ────────────────────────────────────────────
+
+test "walkPrefix: clean tree yields no findings" {
+    const base = "/tmp/malt_perms_clean";
+    malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    try malt.fs_compat.cwd().makePath(base ++ "/bin");
+    (try malt.fs_compat.createFileAbsolute(base ++ "/bin/foo", .{})).close();
+
+    const findings = try perms.walkPrefix(testing.allocator, base, perms.currentUid(), 64);
+    defer perms.freeFindings(testing.allocator, findings);
+    try testing.expectEqual(@as(usize, 0), findings.len);
+}
+
+test "walkPrefix: detects other-writable file" {
+    const base = "/tmp/malt_perms_other_writable";
+    malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    try malt.fs_compat.cwd().makePath(base);
+    const path = base ++ "/world_writable.txt";
+    (try malt.fs_compat.createFileAbsolute(path, .{})).close();
+
+    // chmod o+w
+    const c = struct {
+        extern "c" fn chmod(path: [*:0]const u8, mode: u16) c_int;
+    };
+    if (c.chmod(path, 0o666) != 0) return error.TestUnexpectedResult;
+
+    const findings = try perms.walkPrefix(testing.allocator, base, perms.currentUid(), 64);
+    defer perms.freeFindings(testing.allocator, findings);
+
+    // Must find at least the world_writable file; may also flag the
+    // base dir if its default mode is 0o775 (umask-dependent).
+    var saw_target = false;
+    for (findings) |f| {
+        if (std.mem.endsWith(u8, f.path, "/world_writable.txt")) {
+            try testing.expect(f.report.other_writable);
+            saw_target = true;
+        }
+    }
+    try testing.expect(saw_target);
+}
+
+test "walkPrefix: missing prefix returns empty findings, no error" {
+    const findings = try perms.walkPrefix(
+        testing.allocator,
+        "/tmp/malt_perms_definitely_does_not_exist_xyz",
+        perms.currentUid(),
+        64,
+    );
+    defer perms.freeFindings(testing.allocator, findings);
+    try testing.expectEqual(@as(usize, 0), findings.len);
+}
+
+test "walkPrefix: respects max_findings cap" {
+    const base = "/tmp/malt_perms_cap";
+    malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    try malt.fs_compat.cwd().makePath(base);
+    const c = struct {
+        extern "c" fn chmod(path: [*:0]const u8, mode: u16) c_int;
+    };
+    // Seed 5 world-writable files.
+    for (0..5) |i| {
+        var buf: [64]u8 = undefined;
+        const p = try std.fmt.bufPrintSentinel(&buf, "{s}/f{d}", .{ base, i }, 0);
+        (try malt.fs_compat.createFileAbsolute(p, .{})).close();
+        if (c.chmod(p.ptr, 0o666) != 0) return error.TestUnexpectedResult;
+    }
+
+    const findings = try perms.walkPrefix(testing.allocator, base, perms.currentUid(), 2);
+    defer perms.freeFindings(testing.allocator, findings);
+    try testing.expect(findings.len <= 2);
+}


### PR DESCRIPTION
## Summary

`malt doctor` now walks the install prefix and flags any path that's world-writable, group-writable, or owned by a user other than the one running malt. Shared-system concern: a local attacker with write access to anything under the prefix can swap a binary out from under a later `malt run`. 

You now see it at a glance instead of learning the hard way.