### PR TITLE
feat(security): pin third-party taps to a commit SHA

### DIFF
--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -162,10 +162,17 @@ const doctor_help =
 
 const tap_help =
     \\Usage: malt tap [<user>/<repo>]
+    \\       malt tap --refresh <user>/<repo>
     \\       malt untap <user>/<repo>
     \\
-    \\Manage taps. Without arguments, lists registered taps.
-    \\Taps are auto-resolved during install, so explicit tap is optional.
+    \\Manage taps. Without arguments, lists registered taps + their
+    \\pinned commit. `tap <slug>` resolves the repo's HEAD commit at
+    \\that moment and stores it; subsequent installs from the tap fetch
+    \\against the pin, not whatever HEAD happens to point to later.
+    \\`--refresh` explicitly advances the pin to the current HEAD.
+    \\
+    \\Taps are auto-resolved during install, so explicit `tap` is
+    \\usually unnecessary — the auto-tap also pins the SHA on first use.
     \\
 ;
 

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1467,14 +1467,33 @@ fn installTapFormula(
 
     output.info("Resolving tap {s}/{s}/{s}...", .{ parts.user, parts.repo, parts.formula });
 
+    // Determine the commit SHA to fetch against. Prefer the pin
+    // already in the DB (set at tap-add or last --refresh); if no pin
+    // exists yet, resolve HEAD once and record it below. Refuses to
+    // build a URL from a floating HEAD at install time.
+    var tap_slug_buf: [128]u8 = undefined;
+    const tap_slug = std.fmt.bufPrint(&tap_slug_buf, "{s}/{s}", .{ parts.user, parts.repo }) catch
+        return InstallError.FormulaNotFound;
+    const commit_sha = blk: {
+        if ((tap_mod.getCommitSha(allocator, db, tap_slug) catch null)) |cached| {
+            break :blk cached;
+        }
+        break :blk tap_mod.resolveHeadCommit(allocator, parts.user, parts.repo) catch {
+            output.err("Could not resolve {s}'s HEAD commit — refusing to install from a floating HEAD.", .{tap_slug});
+            return InstallError.FormulaNotFound;
+        };
+    };
+    defer allocator.free(commit_sha);
+
     var http = client_mod.HttpClient.init(allocator);
     defer http.deinit();
 
     // Try Formula/ first, then Casks/
     var url_buf: [512]u8 = undefined;
-    const rb_url = std.fmt.bufPrint(&url_buf, "https://raw.githubusercontent.com/{s}/homebrew-{s}/HEAD/Formula/{s}.rb", .{
+    const rb_url = std.fmt.bufPrint(&url_buf, "https://raw.githubusercontent.com/{s}/homebrew-{s}/{s}/Formula/{s}.rb", .{
         parts.user,
         parts.repo,
+        commit_sha,
         parts.formula,
     }) catch return InstallError.FormulaNotFound;
 
@@ -1486,9 +1505,10 @@ fn installTapFormula(
     if (resp.status != 200) {
         resp.deinit();
         // Try Casks/ directory
-        const cask_url = std.fmt.bufPrint(&url_buf, "https://raw.githubusercontent.com/{s}/homebrew-{s}/HEAD/Casks/{s}.rb", .{
+        const cask_url = std.fmt.bufPrint(&url_buf, "https://raw.githubusercontent.com/{s}/homebrew-{s}/{s}/Casks/{s}.rb", .{
             parts.user,
             parts.repo,
+            commit_sha,
             parts.formula,
         }) catch return InstallError.FormulaNotFound;
 
@@ -1699,12 +1719,12 @@ fn installTapFormula(
 
         keg_id = getLastInsertId(db) catch return InstallError.RecordFailed;
 
-        // Register the tap so `mt tap` lists it and `mt untap` can remove
-        // it. Homebrew auto-taps on install; we mirror that. INSERT OR
-        // IGNORE inside tap_mod.add keeps this idempotent.
+        // Register the tap so `mt tap` lists it and `mt untap` can
+        // remove it. Carry the resolved commit SHA so `COALESCE` in
+        // tap_mod.add pins this tap on first install.
         var tap_url_buf: [256]u8 = undefined;
         const tap_url = std.fmt.bufPrint(&tap_url_buf, "https://github.com/{s}", .{tap_name}) catch return InstallError.RecordFailed;
-        tap_mod.add(db, tap_name, tap_url) catch {};
+        tap_mod.add(db, tap_name, tap_url, commit_sha) catch {};
     }
 
     linker.link(cellar_path, parts.formula, keg_id) catch {

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -51,6 +51,24 @@ const Action = enum { add, remove };
 fn run(allocator: std.mem.Allocator, args: []const []const u8, action: Action) !void {
     if (help.showIfRequested(args, if (action == .add) "tap" else "untap")) return;
 
+    // --refresh <name>: update the stored commit pin to current HEAD.
+    var refresh_target: ?[]const u8 = null;
+    var positional: ?[]const u8 = null;
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--refresh")) {
+            // `--refresh` without a name refreshes the positional,
+            // resolved below. We just flag the mode here.
+            refresh_target = "";
+        } else if (std.mem.startsWith(u8, arg, "--refresh=")) {
+            refresh_target = arg["--refresh=".len..];
+        } else if (!std.mem.startsWith(u8, arg, "-")) {
+            if (positional == null) positional = arg;
+        }
+    }
+    if (refresh_target) |rt| {
+        if (rt.len == 0) refresh_target = positional;
+    }
+
     const prefix = atomic.maltPrefix();
 
     var db_path_buf: [512]u8 = undefined;
@@ -62,7 +80,16 @@ fn run(allocator: std.mem.Allocator, args: []const []const u8, action: Action) !
     defer db.close();
     schema.initSchema(&db) catch return;
 
-    if (args.len == 0) {
+    if (refresh_target) |target| {
+        if (action != .add) {
+            output.err("--refresh is only valid with `mt tap`", .{});
+            return error.Aborted;
+        }
+        try refreshTap(allocator, &db, target);
+        return;
+    }
+
+    if (positional == null) {
         if (action == .remove) {
             output.err("Usage: mt untap user/repo", .{});
             return error.Aborted;
@@ -82,14 +109,25 @@ fn run(allocator: std.mem.Allocator, args: []const []const u8, action: Action) !
         for (taps) |t| {
             const f = fs_compat.stdoutFile();
             f.writeAll(t.name) catch {};
+            if (t.commit_sha) |sha| {
+                f.writeAll(" @ ") catch {};
+                // Print just the 7-char short SHA to keep the listing compact.
+                const short_len = @min(sha.len, 7);
+                f.writeAll(sha[0..short_len]) catch {};
+            } else {
+                f.writeAll(" (unpinned — run `mt tap --refresh ") catch {};
+                f.writeAll(t.name) catch {};
+                f.writeAll("`)") catch {};
+            }
             f.writeAll("\n") catch {};
             allocator.free(t.name);
             allocator.free(t.url);
+            if (t.commit_sha) |sha| allocator.free(sha);
         }
         return;
     }
 
-    const name = args[0];
+    const name = positional.?;
     validateTapName(name) catch {
         output.err("Invalid tap '{s}'. Expected: user/repo with [A-Za-z0-9._-]", .{name});
         return error.Aborted;
@@ -97,13 +135,23 @@ fn run(allocator: std.mem.Allocator, args: []const []const u8, action: Action) !
 
     switch (action) {
         .add => {
+            const slash = std.mem.findScalar(u8, name, '/').?;
+            const user = name[0..slash];
+            const repo = name[slash + 1 ..];
+            // Resolve HEAD so the tap is pinned from day one. Failing
+            // here beats silently registering an unpinned tap.
+            const sha = tap_mod.resolveHeadCommit(allocator, user, repo) catch {
+                output.err("Could not resolve {s}'s HEAD commit. Network down?", .{name});
+                return error.Aborted;
+            };
+            defer allocator.free(sha);
             var url_buf: [256]u8 = undefined;
             const url = std.fmt.bufPrint(&url_buf, "https://github.com/{s}", .{name}) catch return;
-            tap_mod.add(&db, name, url) catch {
+            tap_mod.add(&db, name, url, sha) catch {
                 output.err("Failed to add tap {s}", .{name});
                 return error.Aborted;
             };
-            output.info("Tapped {s}", .{name});
+            output.info("Tapped {s} @ {s}", .{ name, sha[0..@min(sha.len, 7)] });
         },
         .remove => {
             tap_mod.remove(&db, name) catch {
@@ -113,4 +161,24 @@ fn run(allocator: std.mem.Allocator, args: []const []const u8, action: Action) !
             output.info("Untapped {s}", .{name});
         },
     }
+}
+
+fn refreshTap(allocator: std.mem.Allocator, db: *sqlite.Database, name: []const u8) !void {
+    validateTapName(name) catch {
+        output.err("Invalid tap '{s}'. Expected: user/repo with [A-Za-z0-9._-]", .{name});
+        return error.Aborted;
+    };
+    const slash = std.mem.findScalar(u8, name, '/').?;
+    const user = name[0..slash];
+    const repo = name[slash + 1 ..];
+    const sha = tap_mod.resolveHeadCommit(allocator, user, repo) catch {
+        output.err("Could not resolve {s}'s HEAD commit. Network down?", .{name});
+        return error.Aborted;
+    };
+    defer allocator.free(sha);
+    tap_mod.updateCommit(db, name, sha) catch {
+        output.err("Failed to update commit pin for {s}", .{name});
+        return error.Aborted;
+    };
+    output.info("Refreshed {s} to {s}", .{ name, sha[0..@min(sha.len, 7)] });
 }

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -119,6 +119,27 @@ pub fn validateCommitSha(sha: []const u8) TapError!void {
     };
 }
 
+/// Pull the first top-level `"sha"` field out of a GitHub commits/HEAD
+/// response. Exposed for unit tests; production code reaches it via
+/// `resolveHeadCommit`.
+///
+/// Takes only the first match because GitHub's response always has
+/// the commit SHA before the nested tree/parent objects. The result
+/// is validated as a 40-char lowercase hex string — malformed or
+/// unexpected shapes return null rather than misleading SHAs.
+pub fn parseCommitShaFromJson(body: []const u8) ?[]const u8 {
+    const marker = "\"sha\"";
+    const idx = std.mem.indexOf(u8, body, marker) orelse return null;
+    var cur = idx + marker.len;
+    while (cur < body.len and (body[cur] == ' ' or body[cur] == ':' or body[cur] == '\t')) : (cur += 1) {}
+    if (cur >= body.len or body[cur] != '"') return null;
+    cur += 1;
+    const end = std.mem.indexOfScalarPos(u8, body, cur, '"') orelse return null;
+    const sha = body[cur..end];
+    validateCommitSha(sha) catch return null;
+    return sha;
+}
+
 /// Ask GitHub for the current HEAD commit of a tap's repo. Returns
 /// the 40-char lowercase hex SHA or an error on network / malformed
 /// response. Caller owns the returned slice.
@@ -141,17 +162,6 @@ pub fn resolveHeadCommit(
     defer resp.deinit();
     if (resp.status != 200) return TapError.ResolveFailed;
 
-    // Pull the top-level "sha" field without a full JSON parse — the
-    // first occurrence in a commits/HEAD response is always the commit
-    // SHA, before any nested tree/parent objects.
-    const marker = "\"sha\"";
-    const idx = std.mem.indexOf(u8, resp.body, marker) orelse return TapError.ResolveFailed;
-    var cur = idx + marker.len;
-    while (cur < resp.body.len and (resp.body[cur] == ' ' or resp.body[cur] == ':' or resp.body[cur] == '\t')) : (cur += 1) {}
-    if (cur >= resp.body.len or resp.body[cur] != '"') return TapError.ResolveFailed;
-    cur += 1;
-    const end = std.mem.indexOfScalarPos(u8, resp.body, cur, '"') orelse return TapError.ResolveFailed;
-    const sha = resp.body[cur..end];
-    try validateCommitSha(sha);
+    const sha = parseCommitShaFromJson(resp.body) orelse return TapError.ResolveFailed;
     return allocator.dupe(u8, sha) catch TapError.OutOfMemory;
 }

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -1,16 +1,45 @@
 const std = @import("std");
 const sqlite = @import("../db/sqlite.zig");
+const client_mod = @import("../net/client.zig");
 
 pub const TapInfo = struct {
     name: []const u8,
     url: []const u8,
+    /// 40-char lowercase hex commit SHA the tap was pinned to. Null
+    /// for rows carried over from pre-pin schema or for additions that
+    /// couldn't resolve a remote commit at tap time.
+    commit_sha: ?[]const u8 = null,
 };
 
-pub fn add(db: *sqlite.Database, name: []const u8, url: []const u8) !void {
-    var stmt = db.prepare("INSERT OR IGNORE INTO taps (name, url) VALUES (?1, ?2);") catch return;
+pub const TapError = error{
+    ResolveFailed,
+    InvalidSha,
+    NotFound,
+    OutOfMemory,
+};
+
+pub fn add(
+    db: *sqlite.Database,
+    name: []const u8,
+    url: []const u8,
+    commit_sha: ?[]const u8,
+) !void {
+    // URL is sticky on conflict (URL doesn't change once registered);
+    // commit_sha is sticky unless the caller passes a new one. Refresh
+    // goes through `updateCommit` which forces a replacement.
+    var stmt = db.prepare(
+        \\INSERT INTO taps (name, url, commit_sha) VALUES (?1, ?2, ?3)
+        \\ON CONFLICT(name) DO UPDATE SET
+        \\    commit_sha = COALESCE(excluded.commit_sha, taps.commit_sha);
+    ) catch return;
     defer stmt.finalize();
     stmt.bindText(1, name) catch return;
     stmt.bindText(2, url) catch return;
+    if (commit_sha) |s| {
+        stmt.bindText(3, s) catch return;
+    } else {
+        stmt.bindNull(3) catch return;
+    }
     _ = stmt.step() catch {};
 }
 
@@ -21,11 +50,39 @@ pub fn remove(db: *sqlite.Database, name: []const u8) !void {
     _ = stmt.step() catch {};
 }
 
+/// Replace the stored commit SHA for an existing tap. Called by
+/// `malt tap --refresh`; fails if the tap isn't already registered.
+pub fn updateCommit(db: *sqlite.Database, name: []const u8, commit_sha: []const u8) !void {
+    try validateCommitSha(commit_sha);
+    var stmt = try db.prepare(
+        "UPDATE taps SET commit_sha = ?1 WHERE name = ?2;",
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, commit_sha);
+    try stmt.bindText(2, name);
+    _ = try stmt.step();
+}
+
+pub fn getCommitSha(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    name: []const u8,
+) !?[]const u8 {
+    var stmt = try db.prepare("SELECT commit_sha FROM taps WHERE name = ?1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    if (!(try stmt.step())) return null;
+    const raw = stmt.columnText(0) orelse return null;
+    const trimmed = std.mem.sliceTo(raw, 0);
+    if (trimmed.len == 0) return null;
+    return try allocator.dupe(u8, trimmed);
+}
+
 pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) ![]TapInfo {
     var taps: std.ArrayList(TapInfo) = .empty;
     errdefer taps.deinit(allocator);
 
-    var stmt = try db.prepare("SELECT name, url FROM taps;");
+    var stmt = try db.prepare("SELECT name, url, commit_sha FROM taps;");
     defer stmt.finalize();
 
     while (try stmt.step()) {
@@ -33,7 +90,16 @@ pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) ![]TapInfo {
         const u = stmt.columnText(1) orelse continue;
         const name_owned = try allocator.dupe(u8, std.mem.sliceTo(n, 0));
         const url_owned = try allocator.dupe(u8, std.mem.sliceTo(u, 0));
-        try taps.append(allocator, .{ .name = name_owned, .url = url_owned });
+        const sha_owned = if (stmt.columnText(2)) |s| blk: {
+            const trimmed = std.mem.sliceTo(s, 0);
+            if (trimmed.len == 0) break :blk null;
+            break :blk try allocator.dupe(u8, trimmed);
+        } else null;
+        try taps.append(allocator, .{
+            .name = name_owned,
+            .url = url_owned,
+            .commit_sha = sha_owned,
+        });
     }
 
     return taps.toOwnedSlice(allocator);
@@ -42,4 +108,50 @@ pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) ![]TapInfo {
 /// Resolve a tap formula — builds the full tap formula name.
 pub fn resolveFormula(allocator: std.mem.Allocator, user: []const u8, repo: []const u8, formula: []const u8) ![]const u8 {
     return std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{ user, repo, formula });
+}
+
+/// A 40-char lowercase hex commit SHA — matches git's printable form.
+pub fn validateCommitSha(sha: []const u8) TapError!void {
+    if (sha.len != 40) return TapError.InvalidSha;
+    for (sha) |c| switch (c) {
+        '0'...'9', 'a'...'f' => {},
+        else => return TapError.InvalidSha,
+    };
+}
+
+/// Ask GitHub for the current HEAD commit of a tap's repo. Returns
+/// the 40-char lowercase hex SHA or an error on network / malformed
+/// response. Caller owns the returned slice.
+pub fn resolveHeadCommit(
+    allocator: std.mem.Allocator,
+    user: []const u8,
+    repo_bare: []const u8,
+) TapError![]const u8 {
+    var url_buf: [512]u8 = undefined;
+    const url = std.fmt.bufPrint(
+        &url_buf,
+        "https://api.github.com/repos/{s}/homebrew-{s}/commits/HEAD",
+        .{ user, repo_bare },
+    ) catch return TapError.ResolveFailed;
+
+    var http = client_mod.HttpClient.init(allocator);
+    defer http.deinit();
+
+    var resp = http.get(url) catch return TapError.ResolveFailed;
+    defer resp.deinit();
+    if (resp.status != 200) return TapError.ResolveFailed;
+
+    // Pull the top-level "sha" field without a full JSON parse — the
+    // first occurrence in a commits/HEAD response is always the commit
+    // SHA, before any nested tree/parent objects.
+    const marker = "\"sha\"";
+    const idx = std.mem.indexOf(u8, resp.body, marker) orelse return TapError.ResolveFailed;
+    var cur = idx + marker.len;
+    while (cur < resp.body.len and (resp.body[cur] == ' ' or resp.body[cur] == ':' or resp.body[cur] == '\t')) : (cur += 1) {}
+    if (cur >= resp.body.len or resp.body[cur] != '"') return TapError.ResolveFailed;
+    cur += 1;
+    const end = std.mem.indexOfScalarPos(u8, resp.body, cur, '"') orelse return TapError.ResolveFailed;
+    const sha = resp.body[cur..end];
+    try validateCommitSha(sha);
+    return allocator.dupe(u8, sha) catch TapError.OutOfMemory;
 }

--- a/src/db/schema.zig
+++ b/src/db/schema.zig
@@ -79,7 +79,8 @@ pub fn initSchema(db: *sqlite.Database) sqlite.SqliteError!void {
         \\);
     );
 
-    // 7. taps
+    // 7. taps. `commit_sha` is added by the v2→v3 migration below so
+    //    fresh and upgraded DBs converge on the same final shape.
     try db.exec(
         \\CREATE TABLE IF NOT EXISTS taps (
         \\    id         INTEGER PRIMARY KEY,
@@ -101,6 +102,7 @@ pub fn initSchema(db: *sqlite.Database) sqlite.SqliteError!void {
 pub fn migrate(db: *sqlite.Database) sqlite.SqliteError!void {
     const ver = try currentVersion(db);
     if (ver < 2) try migrateV1toV2(db);
+    if (ver < 3) try migrateV2toV3(db);
 }
 
 fn migrateV1toV2(db: *sqlite.Database) sqlite.SqliteError!void {
@@ -138,6 +140,36 @@ fn migrateV1toV2(db: *sqlite.Database) sqlite.SqliteError!void {
     );
 
     try db.exec("INSERT OR IGNORE INTO schema_version (version) VALUES (2);");
+
+    try db.commit();
+}
+
+/// v3 — pin third-party taps to a specific commit SHA so a hostile
+/// HEAD can't silently swap a formula's URL/SHA256 out from under us.
+fn migrateV2toV3(db: *sqlite.Database) sqlite.SqliteError!void {
+    try db.beginTransaction();
+    errdefer db.rollback();
+
+    // ALTER guarded by PRAGMA so the migration is truly idempotent on
+    // any DB that already carries the column (e.g. rerun against a
+    // test fixture mid-development).
+    var have_column = false;
+    {
+        var stmt = try db.prepare("PRAGMA table_info(taps);");
+        defer stmt.finalize();
+        while (try stmt.step()) {
+            const name = stmt.columnText(1) orelse continue;
+            if (std.mem.eql(u8, std.mem.sliceTo(name, 0), "commit_sha")) {
+                have_column = true;
+                break;
+            }
+        }
+    }
+    if (!have_column) {
+        try db.exec("ALTER TABLE taps ADD COLUMN commit_sha TEXT;");
+    }
+
+    try db.exec("INSERT OR IGNORE INTO schema_version (version) VALUES (3);");
 
     try db.commit();
 }

--- a/tests/cli_tap_test.zig
+++ b/tests/cli_tap_test.zig
@@ -37,19 +37,20 @@ test "execute with no args prints an empty list (no taps registered)" {
     try tap_cli.execute(testing.allocator, &.{});
 }
 
-test "execute with user/repo adds a tap idempotently" {
-    const prefix = try setupPrefix("add_then_list");
+test "execute with unresolvable user/repo aborts (no network pin = no add)" {
+    const prefix = try setupPrefix("unresolvable");
     defer testing.allocator.free(prefix);
     defer malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
 
-    try tap_cli.execute(testing.allocator, &.{"user/repo"});
-    // A second call is idempotent via INSERT OR IGNORE.
-    try tap_cli.execute(testing.allocator, &.{"user/repo"});
-    // Bare-list path with rows present — `io_mod.stdoutFile()` routes the
-    // tap-name writes to stderr under the test runner, so this no longer
-    // deadlocks the IPC pipe.
-    try tap_cli.execute(testing.allocator, &.{});
+    // `user/repo` isn't a real GitHub repo; HEAD resolution fails and
+    // we refuse to register an unpinned tap. Idempotency + list-with-
+    // rows paths are covered by tests/tap_test.zig directly against
+    // `tap_mod`, which doesn't need network.
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(testing.allocator, &.{"user/repo"}),
+    );
 }
 
 test "execute with --help short-circuits before touching the database" {

--- a/tests/db_schema_v2_test.zig
+++ b/tests/db_schema_v2_test.zig
@@ -40,7 +40,7 @@ fn tableExists(db: *sqlite.Database, name: [:0]const u8) !bool {
     return stmt.columnInt(0) == 1;
 }
 
-test "initSchema runs v1 then migrates to v2" {
+test "initSchema runs v1 then migrates to v3" {
     var tdb = try TempDb.init("init");
     defer tdb.deinit();
 
@@ -52,7 +52,7 @@ test "initSchema runs v1 then migrates to v2" {
     try testing.expect(try tableExists(&tdb.db, "bundle_members"));
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 2), ver);
+    try testing.expectEqual(@as(i64, 3), ver);
 }
 
 test "migrate is idempotent on re-run" {
@@ -64,7 +64,30 @@ test "migrate is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 2), ver);
+    try testing.expectEqual(@as(i64, 3), ver);
+}
+
+test "v3 migration adds commit_sha column to taps" {
+    var tdb = try TempDb.init("v3_column");
+    defer tdb.deinit();
+
+    try schema.initSchema(&tdb.db);
+
+    // INSERT should accept a value in commit_sha without blowing up.
+    try tdb.db.exec(
+        \\INSERT INTO taps(name, url, commit_sha)
+        \\VALUES ('user/repo', 'https://github.com/user/repo',
+        \\        '0123456789abcdef0123456789abcdef01234567');
+    );
+
+    var stmt = try tdb.db.prepare("SELECT commit_sha FROM taps WHERE name='user/repo';");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    const raw = stmt.columnText(0) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings(
+        "0123456789abcdef0123456789abcdef01234567",
+        std.mem.sliceTo(raw, 0),
+    );
 }
 
 test "services table accepts inserts and enforces PK" {

--- a/tests/tap_test.zig
+++ b/tests/tap_test.zig
@@ -92,6 +92,19 @@ test "add preserves existing commit pin when new add passes null" {
     try testing.expectEqualStrings(valid_sha, taps[0].commit_sha.?);
 }
 
+test "add replaces existing pin when new add passes a different non-null SHA" {
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "user/repo", "https://x", valid_sha);
+    try tap.add(&db, "user/repo", "https://x", other_sha);
+
+    const taps = try tap.list(testing.allocator, &db);
+    defer freeTaps(taps);
+    try testing.expectEqualStrings(other_sha, taps[0].commit_sha.?);
+}
+
 test "updateCommit replaces an existing pin" {
     var db = try openDb();
     defer db.close();
@@ -113,6 +126,18 @@ test "updateCommit rejects malformed SHA" {
     try tap.add(&db, "user/repo", "https://x", valid_sha);
     try testing.expectError(error.InvalidSha, tap.updateCommit(&db, "user/repo", "notasha"));
     try testing.expectError(error.InvalidSha, tap.updateCommit(&db, "user/repo", "XXXX567890abcdef0123456789abcdef01234567"));
+}
+
+test "updateCommit on an unknown tap is a no-op (no rows affected, no error)" {
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.updateCommit(&db, "nobody/never-added", valid_sha);
+
+    const taps = try tap.list(testing.allocator, &db);
+    defer freeTaps(taps);
+    try testing.expectEqual(@as(usize, 0), taps.len);
 }
 
 test "getCommitSha returns the stored pin" {
@@ -187,4 +212,80 @@ test "resolveFormula joins user/repo/formula with slashes" {
     const s = try tap.resolveFormula(testing.allocator, "u", "r", "f");
     defer testing.allocator.free(s);
     try testing.expectEqualStrings("u/r/f", s);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// parseCommitShaFromJson — security-sensitive: picking up the wrong
+// "sha" field would pin malt to an attacker-influenced commit instead
+// of the real HEAD. Exhaustive coverage of shapes a real GitHub
+// `commits/HEAD` response can take.
+// ────────────────────────────────────────────────────────────────────
+
+test "parseCommitShaFromJson: canonical GitHub response" {
+    const body =
+        \\{"sha":"0123456789abcdef0123456789abcdef01234567","node_id":"X","commit":{"author":{"name":"x"}}}
+    ;
+    const got = tap.parseCommitShaFromJson(body) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings(valid_sha, got);
+}
+
+test "parseCommitShaFromJson: tolerates whitespace around ':' and value" {
+    const body =
+        \\{  "sha"  :  "0123456789abcdef0123456789abcdef01234567" , "other": 1 }
+    ;
+    const got = tap.parseCommitShaFromJson(body) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings(valid_sha, got);
+}
+
+test "parseCommitShaFromJson: returns first top-level sha even when nested sha exists" {
+    // Real responses have `commit.tree.sha` as a separate field —
+    // the parser's first-match behaviour is the whole point: the
+    // top-level commit SHA appears first.
+    const body =
+        \\{"sha":"0123456789abcdef0123456789abcdef01234567","commit":{"tree":{"sha":"ffffffffffffffffffffffffffffffffffffffff"}}}
+    ;
+    const got = tap.parseCommitShaFromJson(body) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings(valid_sha, got);
+}
+
+test "parseCommitShaFromJson: missing sha field yields null" {
+    const body =
+        \\{"node_id":"X","commit":{"author":{"name":"x"}}}
+    ;
+    try testing.expectEqual(@as(?[]const u8, null), tap.parseCommitShaFromJson(body));
+}
+
+test "parseCommitShaFromJson: non-string value yields null" {
+    // Defense: if upstream ever returned a number or null for sha we'd
+    // rather refuse than misparse.
+    const body =
+        \\{"sha": 42}
+    ;
+    try testing.expectEqual(@as(?[]const u8, null), tap.parseCommitShaFromJson(body));
+}
+
+test "parseCommitShaFromJson: truncated value yields null" {
+    const body =
+        \\{"sha":"deadbeef
+    ;
+    try testing.expectEqual(@as(?[]const u8, null), tap.parseCommitShaFromJson(body));
+}
+
+test "parseCommitShaFromJson: malformed SHA value yields null" {
+    // Right structural shape, wrong content — validator rejects.
+    const body =
+        \\{"sha":"not-a-valid-sha"}
+    ;
+    try testing.expectEqual(@as(?[]const u8, null), tap.parseCommitShaFromJson(body));
+}
+
+test "parseCommitShaFromJson: empty body yields null" {
+    try testing.expectEqual(@as(?[]const u8, null), tap.parseCommitShaFromJson(""));
+}
+
+test "parseCommitShaFromJson: uppercase hex in value is rejected" {
+    const body =
+        \\{"sha":"0123456789ABCDEF0123456789ABCDEF01234567"}
+    ;
+    try testing.expectEqual(@as(?[]const u8, null), tap.parseCommitShaFromJson(body));
 }

--- a/tests/tap_test.zig
+++ b/tests/tap_test.zig
@@ -1,5 +1,6 @@
 //! malt — core/tap module tests
-//! Covers add/remove/list round-trip and resolveFormula helper.
+//! Covers add/remove/list round-trip, resolveFormula helper, and the
+//! commit-pin lifecycle (tap_mod.add with SHA, updateCommit, validator).
 
 const std = @import("std");
 const testing = std.testing;
@@ -9,8 +10,20 @@ const schema = malt.schema;
 
 const tap = malt.tap;
 
+const valid_sha = "0123456789abcdef0123456789abcdef01234567";
+const other_sha = "abcdef0123456789abcdef0123456789abcdef01";
+
 fn openDb() !sqlite.Database {
     return sqlite.Database.open(":memory:");
+}
+
+fn freeTaps(taps: []tap.TapInfo) void {
+    for (taps) |t| {
+        testing.allocator.free(t.name);
+        testing.allocator.free(t.url);
+        if (t.commit_sha) |sha| testing.allocator.free(sha);
+    }
+    testing.allocator.free(taps);
 }
 
 test "list returns empty slice on a fresh database" {
@@ -19,48 +32,140 @@ test "list returns empty slice on a fresh database" {
     try schema.initSchema(&db);
 
     const taps = try tap.list(testing.allocator, &db);
-    defer testing.allocator.free(taps);
+    defer freeTaps(taps);
     try testing.expectEqual(@as(usize, 0), taps.len);
 }
 
-test "add then list round-trips tap name and url" {
+test "add then list round-trips tap name, url, and commit SHA" {
     var db = try openDb();
     defer db.close();
     try schema.initSchema(&db);
 
-    try tap.add(&db, "user/repo", "https://github.com/user/repo");
+    try tap.add(&db, "user/repo", "https://github.com/user/repo", valid_sha);
 
     const taps = try tap.list(testing.allocator, &db);
-    defer {
-        for (taps) |t| {
-            testing.allocator.free(t.name);
-            testing.allocator.free(t.url);
-        }
-        testing.allocator.free(taps);
-    }
+    defer freeTaps(taps);
     try testing.expectEqual(@as(usize, 1), taps.len);
     try testing.expectEqualStrings("user/repo", taps[0].name);
     try testing.expectEqualStrings("https://github.com/user/repo", taps[0].url);
+    try testing.expectEqualStrings(valid_sha, taps[0].commit_sha.?);
 }
 
-test "add is idempotent (INSERT OR IGNORE)" {
+test "add with null SHA persists as unpinned" {
     var db = try openDb();
     defer db.close();
     try schema.initSchema(&db);
 
-    try tap.add(&db, "user/repo", "https://github.com/user/repo");
-    try tap.add(&db, "user/repo", "https://github.com/user/repo-other");
+    try tap.add(&db, "user/repo", "https://github.com/user/repo", null);
 
     const taps = try tap.list(testing.allocator, &db);
-    defer {
-        for (taps) |t| {
-            testing.allocator.free(t.name);
-            testing.allocator.free(t.url);
-        }
-        testing.allocator.free(taps);
-    }
+    defer freeTaps(taps);
+    try testing.expectEqual(@as(usize, 1), taps.len);
+    try testing.expectEqual(@as(?[]const u8, null), taps[0].commit_sha);
+}
+
+test "add preserves URL on conflict (URL is sticky)" {
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "user/repo", "https://github.com/user/repo", null);
+    try tap.add(&db, "user/repo", "https://github.com/user/repo-other", null);
+
+    const taps = try tap.list(testing.allocator, &db);
+    defer freeTaps(taps);
     try testing.expectEqual(@as(usize, 1), taps.len);
     try testing.expectEqualStrings("https://github.com/user/repo", taps[0].url);
+}
+
+test "add preserves existing commit pin when new add passes null" {
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "user/repo", "https://x", valid_sha);
+    // Second add without a SHA must NOT wipe the pin.
+    try tap.add(&db, "user/repo", "https://x", null);
+
+    const taps = try tap.list(testing.allocator, &db);
+    defer freeTaps(taps);
+    try testing.expectEqualStrings(valid_sha, taps[0].commit_sha.?);
+}
+
+test "updateCommit replaces an existing pin" {
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "user/repo", "https://x", valid_sha);
+    try tap.updateCommit(&db, "user/repo", other_sha);
+
+    const taps = try tap.list(testing.allocator, &db);
+    defer freeTaps(taps);
+    try testing.expectEqualStrings(other_sha, taps[0].commit_sha.?);
+}
+
+test "updateCommit rejects malformed SHA" {
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "user/repo", "https://x", valid_sha);
+    try testing.expectError(error.InvalidSha, tap.updateCommit(&db, "user/repo", "notasha"));
+    try testing.expectError(error.InvalidSha, tap.updateCommit(&db, "user/repo", "XXXX567890abcdef0123456789abcdef01234567"));
+}
+
+test "getCommitSha returns the stored pin" {
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "user/repo", "https://x", valid_sha);
+    const got = (try tap.getCommitSha(testing.allocator, &db, "user/repo")) orelse
+        return error.TestUnexpectedResult;
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings(valid_sha, got);
+}
+
+test "getCommitSha returns null for unpinned tap" {
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "user/repo", "https://x", null);
+    try testing.expectEqual(
+        @as(?[]const u8, null),
+        try tap.getCommitSha(testing.allocator, &db, "user/repo"),
+    );
+}
+
+test "getCommitSha returns null for unknown tap" {
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+    try testing.expectEqual(
+        @as(?[]const u8, null),
+        try tap.getCommitSha(testing.allocator, &db, "nobody/unregistered"),
+    );
+}
+
+test "validateCommitSha accepts 40-char lowercase hex" {
+    try tap.validateCommitSha(valid_sha);
+}
+
+test "validateCommitSha rejects wrong length" {
+    try testing.expectError(error.InvalidSha, tap.validateCommitSha("deadbeef"));
+    try testing.expectError(error.InvalidSha, tap.validateCommitSha(valid_sha ++ "00"));
+}
+
+test "validateCommitSha rejects uppercase" {
+    const upper = "ABCDEF0123456789ABCDEF0123456789ABCDEF01";
+    try testing.expectError(error.InvalidSha, tap.validateCommitSha(upper));
+}
+
+test "validateCommitSha rejects non-hex chars" {
+    const bad = "ggggggggggggggggggggggggggggggggggggggg0";
+    try testing.expectError(error.InvalidSha, tap.validateCommitSha(bad));
 }
 
 test "remove deletes a tap" {
@@ -68,18 +173,12 @@ test "remove deletes a tap" {
     defer db.close();
     try schema.initSchema(&db);
 
-    try tap.add(&db, "a/b", "https://x");
-    try tap.add(&db, "c/d", "https://y");
+    try tap.add(&db, "a/b", "https://x", valid_sha);
+    try tap.add(&db, "c/d", "https://y", valid_sha);
     try tap.remove(&db, "a/b");
 
     const taps = try tap.list(testing.allocator, &db);
-    defer {
-        for (taps) |t| {
-            testing.allocator.free(t.name);
-            testing.allocator.free(t.url);
-        }
-        testing.allocator.free(taps);
-    }
+    defer freeTaps(taps);
     try testing.expectEqual(@as(usize, 1), taps.len);
     try testing.expectEqualStrings("c/d", taps[0].name);
 }


### PR DESCRIPTION
## Summary

Third-party taps (anything other than homebrew-core) were fetched on every install against the tap's floating `HEAD` - a single force-push or compromised tap-owner account was enough to swap a formula's URL and SHA256 between `malt tap` and `malt install`, and nothing downstream would notice. 

Taps are now pinned to a specific commit SHA at tap-add time (and auto-tap time during `malt install`), and subsequent formula fetches use that pin. 

Updating is explicit: `malt tap --refresh <name>`. Pre-existing taps show up as (unpinned - run `mt tap --refresh …`) until refreshed.