### PR TITLE
fix(doctor): match the rest of malt's UI palette

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -153,6 +153,7 @@ pub fn build(b: *std.Build) void {
         "tests/net_client_test.zig",
         "tests/term_sanitize_test.zig",
         "tests/perms_test.zig",
+        "tests/doctor_render_test.zig",
         "tests/cli_tap_test.zig",
         "tests/cli_services_test.zig",
         "tests/install_execute_test.zig",

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -32,6 +32,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var warnings: u32 = 0;
     var errors: u32 = 0;
 
+    output.info("Running health checks...", .{});
+
     // 0. MALT_PREFIX visibility. atomic.maltPrefix() already aborts on a
     //    malformed env, so by this point the value is validated — doctor
     //    just surfaces it for operator context.
@@ -390,17 +392,17 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         }
     }
 
-    // Summary + exit code
-    const f = fs_compat.stderrFile();
-    f.writeAll("\n") catch {};
+    // Summary + exit code. Blank line first so the summary separates
+    // visually from the check rows above it.
+    output.plain("", .{});
     if (errors > 0) {
-        output.err("mt doctor found {d} error(s) and {d} warning(s)", .{ errors, warnings });
+        output.err("{d} error(s), {d} warning(s)", .{ errors, warnings });
         std.process.exit(2);
     } else if (warnings > 0) {
-        output.warn("mt doctor found {d} warning(s)", .{warnings});
+        output.warn("{d} warning(s)", .{warnings});
         std.process.exit(1);
     } else {
-        output.info("Your malt installation is healthy", .{});
+        output.success("Your malt installation is healthy", .{});
     }
 }
 
@@ -538,43 +540,90 @@ fn hasUnpatchedPlaceholder(
     return false;
 }
 
-const CheckStatus = enum { ok, warn_status, err_status };
+pub const CheckStatus = enum { ok, warn_status, err_status };
+
+pub const CheckStyle = struct {
+    /// Emit ANSI colour codes. False for plain terminals and tests.
+    color: bool,
+    /// Use the ✓/⚠/✗ glyphs. False falls back to ASCII */!/x.
+    emoji: bool,
+};
+
+fn glyphFor(status: CheckStatus, emoji: bool) []const u8 {
+    return if (emoji) switch (status) {
+        .ok => "✓",
+        .warn_status => "⚠",
+        .err_status => "✗",
+    } else switch (status) {
+        .ok => "*",
+        .warn_status => "!",
+        .err_status => "x",
+    };
+}
+
+fn styleFor(status: CheckStatus) color.Style {
+    return switch (status) {
+        .ok => .green,
+        .warn_status => .yellow,
+        .err_status => .red,
+    };
+}
+
+/// Render one check row. Pure (no stderr / global state), so tests
+/// can drive it against a buffer writer and assert on the bytes.
+///
+/// Row shape: `  <glyph> <name>[ — <detail>]\n`. With `color=true`,
+/// the glyph is painted in the status colour and the detail is dim.
+pub fn renderCheckRow(
+    writer: anytype,
+    status: CheckStatus,
+    name: []const u8,
+    detail: ?[]const u8,
+    style_opts: CheckStyle,
+) !void {
+    const glyph = glyphFor(status, style_opts.emoji);
+    try writer.writeAll("  ");
+    if (style_opts.color) {
+        try writer.writeAll(styleFor(status).code());
+        try writer.writeAll(glyph);
+        try writer.writeAll(color.Style.reset.code());
+    } else {
+        try writer.writeAll(glyph);
+    }
+    try writer.writeAll(" ");
+    try writer.writeAll(name);
+
+    if (detail) |d| {
+        if (style_opts.color) {
+            try writer.writeAll(" ");
+            try writer.writeAll(color.Style.dim.code());
+            try writer.writeAll("— ");
+            try writer.writeAll(d);
+            try writer.writeAll(color.Style.reset.code());
+        } else {
+            try writer.writeAll(" — ");
+            try writer.writeAll(d);
+        }
+    }
+    try writer.writeAll("\n");
+}
 
 fn printCheck(name: []const u8, status: CheckStatus, detail: ?[]const u8) void {
+    if (output.isQuiet()) return;
     const f = fs_compat.stderrFile();
-    switch (status) {
-        .ok => {
-            if (color.isColorEnabled()) {
-                f.writeAll(color.Style.green.code()) catch {};
-                f.writeAll("[OK]    ") catch {};
-                f.writeAll(color.Style.reset.code()) catch {};
-            } else {
-                f.writeAll("[OK]    ") catch {};
-            }
-        },
-        .warn_status => {
-            if (color.isColorEnabled()) {
-                f.writeAll(color.Style.yellow.code()) catch {};
-                f.writeAll("[WARN]  ") catch {};
-                f.writeAll(color.Style.reset.code()) catch {};
-            } else {
-                f.writeAll("[WARN]  ") catch {};
-            }
-        },
-        .err_status => {
-            if (color.isColorEnabled()) {
-                f.writeAll(color.Style.red.code()) catch {};
-                f.writeAll("[ERROR] ") catch {};
-                f.writeAll(color.Style.reset.code()) catch {};
-            } else {
-                f.writeAll("[ERROR] ") catch {};
-            }
-        },
-    }
-    f.writeAll(name) catch {};
-    if (detail) |d| {
-        f.writeAll(" — ") catch {};
-        f.writeAll(d) catch {};
-    }
-    f.writeAll("\n") catch {};
+    var w = FileWriter{ .file = f };
+    renderCheckRow(&w, status, name, detail, .{
+        .color = color.isColorEnabled(),
+        .emoji = color.isEmojiEnabled(),
+    }) catch {};
 }
+
+/// Thin writer shim so renderCheckRow can call `writer.writeAll`
+/// against `fs_compat.File`. We only need `writeAll`; nothing else.
+const FileWriter = struct {
+    file: fs_compat.File,
+
+    pub fn writeAll(self: *FileWriter, bytes: []const u8) !void {
+        return self.file.writeAll(bytes);
+    }
+};

--- a/tests/doctor_render_test.zig
+++ b/tests/doctor_render_test.zig
@@ -1,0 +1,145 @@
+//! malt — doctor row renderer tests
+//!
+//! Covers `doctor.renderCheckRow` in all combinations of status,
+//! color, and emoji. The renderer is what keeps `mt doctor` visually
+//! consistent with the rest of malt's UI (✓/⚠/✗ glyphs, dim detail
+//! suffix); a regression here is a visible UX drift, so the render
+//! shape is worth locking in.
+
+const std = @import("std");
+const testing = std.testing;
+const doctor = @import("malt").doctor;
+
+const Buf = struct {
+    list: std.ArrayList(u8) = .empty,
+
+    pub fn writeAll(self: *Buf, bytes: []const u8) !void {
+        try self.list.appendSlice(testing.allocator, bytes);
+    }
+
+    fn deinit(self: *Buf) void {
+        self.list.deinit(testing.allocator);
+    }
+};
+
+fn render(
+    status: doctor.CheckStatus,
+    name: []const u8,
+    detail: ?[]const u8,
+    opts: doctor.CheckStyle,
+) ![]const u8 {
+    var buf: Buf = .{};
+    try doctor.renderCheckRow(&buf, status, name, detail, opts);
+    return buf.list.toOwnedSlice(testing.allocator);
+}
+
+// ── plain (no color, no emoji) ───────────────────────────────────────
+
+test "plain: ok without detail" {
+    const s = try render(.ok, "SQLite integrity", null, .{ .color = false, .emoji = false });
+    defer testing.allocator.free(s);
+    try testing.expectEqualStrings("  * SQLite integrity\n", s);
+}
+
+test "plain: warn with detail uses em-dash separator" {
+    const s = try render(.warn_status, "Disk space", "Only 500 MB free", .{ .color = false, .emoji = false });
+    defer testing.allocator.free(s);
+    try testing.expectEqualStrings("  ! Disk space — Only 500 MB free\n", s);
+}
+
+test "plain: err with detail" {
+    const s = try render(.err_status, "Missing kegs", "3 keg(s) missing", .{ .color = false, .emoji = false });
+    defer testing.allocator.free(s);
+    try testing.expectEqualStrings("  x Missing kegs — 3 keg(s) missing\n", s);
+}
+
+// ── emoji-only (no color) ────────────────────────────────────────────
+
+test "emoji no color: ok uses ✓ glyph" {
+    const s = try render(.ok, "APFS volume", null, .{ .color = false, .emoji = true });
+    defer testing.allocator.free(s);
+    try testing.expectEqualStrings("  ✓ APFS volume\n", s);
+}
+
+test "emoji no color: warn uses ⚠ glyph" {
+    const s = try render(.warn_status, "Stale lock", "PID 1234 abandoned", .{ .color = false, .emoji = true });
+    defer testing.allocator.free(s);
+    try testing.expectEqualStrings("  ⚠ Stale lock — PID 1234 abandoned\n", s);
+}
+
+test "emoji no color: err uses ✗ glyph" {
+    const s = try render(.err_status, "SQLite integrity", "Database may be corrupt", .{ .color = false, .emoji = true });
+    defer testing.allocator.free(s);
+    try testing.expectEqualStrings("  ✗ SQLite integrity — Database may be corrupt\n", s);
+}
+
+// ── full color ───────────────────────────────────────────────────────
+
+test "color: ok wraps glyph in green and detail in dim" {
+    const s = try render(.ok, "Name", "Detail", .{ .color = true, .emoji = true });
+    defer testing.allocator.free(s);
+    // Green glyph + reset, plain name, then dim em-dash + detail + reset
+    try testing.expectEqualStrings(
+        "  \x1b[32m✓\x1b[0m Name \x1b[2m— Detail\x1b[0m\n",
+        s,
+    );
+}
+
+test "color: warn glyph is yellow" {
+    const s = try render(.warn_status, "X", null, .{ .color = true, .emoji = true });
+    defer testing.allocator.free(s);
+    try testing.expectEqualStrings("  \x1b[33m⚠\x1b[0m X\n", s);
+}
+
+test "color: err glyph is red" {
+    const s = try render(.err_status, "X", null, .{ .color = true, .emoji = true });
+    defer testing.allocator.free(s);
+    try testing.expectEqualStrings("  \x1b[31m✗\x1b[0m X\n", s);
+}
+
+test "color off + emoji on: no ANSI codes leak through" {
+    const s = try render(.ok, "Z", "d", .{ .color = false, .emoji = true });
+    defer testing.allocator.free(s);
+    // No \x1b anywhere — the emoji glyph is fine (multibyte but not ANSI).
+    try testing.expect(std.mem.indexOf(u8, s, "\x1b") == null);
+    try testing.expectEqualStrings("  ✓ Z — d\n", s);
+}
+
+// ── invariants ───────────────────────────────────────────────────────
+
+test "row always ends with newline" {
+    const cases = [_]struct { st: doctor.CheckStatus, name: []const u8, det: ?[]const u8 }{
+        .{ .st = .ok, .name = "a", .det = null },
+        .{ .st = .warn_status, .name = "b", .det = "x" },
+        .{ .st = .err_status, .name = "c", .det = "y" },
+    };
+    for (cases) |cs| {
+        const s = try render(cs.st, cs.name, cs.det, .{ .color = true, .emoji = true });
+        defer testing.allocator.free(s);
+        try testing.expect(std.mem.endsWith(u8, s, "\n"));
+    }
+}
+
+test "row always starts with two-space indent" {
+    const cases = [_]doctor.CheckStatus{ .ok, .warn_status, .err_status };
+    for (cases) |st| {
+        const s = try render(st, "n", null, .{ .color = false, .emoji = false });
+        defer testing.allocator.free(s);
+        try testing.expect(std.mem.startsWith(u8, s, "  "));
+    }
+}
+
+test "empty detail string still renders (edge case)" {
+    // A non-null but empty detail shows the em-dash with nothing after.
+    // Intentionally preserved so callers don't get a silent skip.
+    const s = try render(.ok, "N", "", .{ .color = false, .emoji = false });
+    defer testing.allocator.free(s);
+    try testing.expectEqualStrings("  * N — \n", s);
+}
+
+test "null detail omits the em-dash entirely" {
+    const s = try render(.ok, "N", null, .{ .color = false, .emoji = false });
+    defer testing.allocator.free(s);
+    try testing.expect(std.mem.indexOf(u8, s, "—") == null);
+    try testing.expect(std.mem.indexOf(u8, s, "-") == null);
+}


### PR DESCRIPTION
## Summary

`mt doctor` was the odd one out - it used `[OK]`/`[WARN]`/`[ERROR]` bracketed prefixes while every other command in malt leads lines with `✓`/`⚠`/`✗` icons. 

Now they match.