### PR TITLE
ci(release): run goreleaser before publishing release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,36 +7,9 @@ on:
 permissions: {}
 
 jobs:
-  create-release-notes:
-    name: release-notes
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    environment:
-      name: Release
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Update release with notes
-        env:
-          TAG_NAME: ${{ github.event.release.tag_name }}
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: |
-          gh release edit "$TAG_NAME" \
-            --title "$TAG_NAME" \
-            --draft=false \
-            --prerelease=false \
-            --latest \
-            --notes-file "${{ github.workspace }}/.changes/${TAG_NAME}.md"
-
   goreleaser:
     name: goreleaser
     runs-on: macos-14
-    needs: create-release-notes
     # id-token: write is the minimum for cosign keyless - it lets the
     # job mint a GitHub OIDC token that Sigstore exchanges for a
     # short-lived signing certificate. Nothing else is widened.
@@ -78,3 +51,30 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
+
+  create-release-notes:
+    name: release-notes
+    runs-on: ubuntu-latest
+    needs: goreleaser
+    permissions:
+      contents: write
+    environment:
+      name: Release
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Update release with notes
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          gh release edit "$TAG_NAME" \
+            --title "$TAG_NAME" \
+            --draft=false \
+            --prerelease=false \
+            --latest \
+            --notes-file "${{ github.workspace }}/.changes/${TAG_NAME}.md"


### PR DESCRIPTION
## Summary

Reorders the release workflow so goreleaser runs first, and only on success does the release flip out of draft and get marked as `latest`.