### PR TITLE
ci(release): disable zig-cache so poisoned entries can't block a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,14 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.16.0
+          # Release runs rarely; a fresh compile takes a few extra
+          # minutes but is worth it. A cancelled or crashed release
+          # job (e.g. the one we killed while debugging the smoke
+          # race) leaves a half-written .zig-cache entry, which the
+          # next release picks up and tries to exec — producing an
+          # InvalidExe failure on a "cached 102ms" binary. Releases
+          # are a trust boundary; always rebuild from scratch.
+          use-cache: false
 
       - name: Run unit tests
         run: zig build test --summary all


### PR DESCRIPTION
## Summary

Releases are a trust boundary and run rarely. A few extra minutes of compile time is a fair price for never shipping an artifact that happened to load from a stale cache. `use-cache: false` on `mlugg/setup-zig` forces every release to rebuild from scratch.

The poisoned cache entry has already been deleted by hand, so the next release would have worked anyway — this PR keeps it from happening again.