### PR TITLE
chore(release): amend v0.6.1 notes with release workflow fixes

### DIFF
--- a/.changes/v0.6.1.md
+++ b/.changes/v0.6.1.md
@@ -19,6 +19,11 @@ introduced were correctly wired, but silently empty in practice. Plus a rough ed
 
 - **release:** smoke the live release install end-to-end ([116f817](https://github.com/indaco/malt/commit/116f817)) ([#68](https://github.com/indaco/malt/pull/68))
 
+### 🤖 CI
+
+- **release:** disable zig-cache so poisoned entries can't block a release ([54192e0](https://github.com/indaco/malt/commit/54192e0)) ([#72](https://github.com/indaco/malt/pull/72))
+- **release:** run the live-install smoke in-sequence, not on a parallel trigger ([65922e0](https://github.com/indaco/malt/commit/65922e0)) ([#71](https://github.com/indaco/malt/pull/71))
+
 ### ❤️ Contributors
 
 - [@indaco](https://github.com/indaco)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ introduced were correctly wired, but silently empty in practice. Plus a rough ed
 
 - **release:** smoke the live release install end-to-end ([116f817](https://github.com/indaco/malt/commit/116f817)) ([#68](https://github.com/indaco/malt/pull/68))
 
+### 🤖 CI
+
+- **release:** disable zig-cache so poisoned entries can't block a release ([54192e0](https://github.com/indaco/malt/commit/54192e0)) ([#72](https://github.com/indaco/malt/pull/72))
+- **release:** run the live-install smoke in-sequence, not on a parallel trigger ([65922e0](https://github.com/indaco/malt/commit/65922e0)) ([#71](https://github.com/indaco/malt/pull/71))
+
 ### ❤️ Contributors
 
 - [@indaco](https://github.com/indaco)


### PR DESCRIPTION
## Summary

The `chore(release): v0.6.1` commit landed before the smoke-race fix (#71) and the cache-poison fix (#72) — both are genuine v0.6.1 material but sit on top of the original release commit, so the shipped notes lied. This PR brings `.changes/v0.6.1.md` and `CHANGELOG.md` back in sync with the commit range the tag will actually cover.

Tag v0.6.1 at the HEAD that results from merging this PR - users get the documented release.