### PR TITLE
fix(install): widen API retry budget for cold-release propagation

### DIFF
--- a/scripts/e2e/smoke_install_release.sh
+++ b/scripts/e2e/smoke_install_release.sh
@@ -76,13 +76,33 @@ if [ -n "$COSIGN_PATH" ]; then
   SAFE_PATH="$(dirname "$COSIGN_PATH"):$SAFE_PATH"
 fi
 
-# GitHub's /releases/latest is CDN-cached and lags a freshly-published
-# release by up to a minute. install.sh has its own retry loop, but a
-# short pre-wait here shortens the feedback loop when the smoke runs
-# seconds after the release is flipped to published.
+# GitHub's /releases/latest endpoint flips to the new tag
+# asynchronously — measured at up to ~60s after a release is published
+# (the old release stops being "latest" before the new one takes the
+# flag, and the endpoint serves 404 through the transition). The
+# smoke runs seconds after publish, so a blind sleep isn't enough.
+# Actively poll the API until it reflects our tag, up to 2 minutes.
+# install.sh itself has a retry loop for real users; this poll just
+# makes the CI feedback loop deterministic.
 if [ "${MALT_SMOKE_SKIP_PROPAGATION_WAIT:-0}" != "1" ]; then
-  step "Waiting 15s for release to propagate to the API"
-  sleep 15
+  EXPECTED_TAG="v$(cat "$(dirname "$0")/../../.version")"
+  step "Waiting up to 2m for ${EXPECTED_TAG} to appear on /releases/latest"
+  API_URL="https://api.github.com/repos/indaco/malt/releases/latest"
+  deadline=$(($(date +%s) + 120))
+  ready=0
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    body=$(curl -fsSL --max-time 10 "$API_URL" 2>/dev/null || true)
+    if printf '%s' "$body" | grep -q "\"tag_name\": *\"${EXPECTED_TAG}\""; then
+      ready=1
+      break
+    fi
+    sleep 5
+  done
+  if [ "$ready" = "1" ]; then
+    pass "API reflects ${EXPECTED_TAG}"
+  else
+    fail "API still not showing ${EXPECTED_TAG} after 2m — propagation unusually slow"
+  fi
 fi
 
 step "Running install.sh from README against the live release"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -91,18 +91,26 @@ else
   # ── Find latest release ──────────────────────────────────────────
   info "Fetching latest release..."
   # Retry any curl failure — GitHub's /releases/latest endpoint can
-  # return 404 (CDN cache not yet warm on a freshly published release),
-  # 5xx, rate-limit responses, or just time out. Curl's built-in --retry
-  # only covers 408/429/5xx and needs 7.71+ for --retry-all-errors, so
-  # we do it in bash for portability across macOS and older Linux.
+  # return 404 while the "latest" flag is in transition right after a
+  # release is published, plus the usual 5xx/rate-limit/timeout.
+  # Measured: transition can take 30-60s after publish, so the retry
+  # budget has to be at least ~45s to cover it. Exponential backoff
+  # across 5 attempts (3, 6, 12, 24) gives ~45s plus the fast-fail
+  # per-attempt time — still bounded, and benefits every one-liner
+  # user hitting a freshly-cut release, not just the CI smoke. Plain
+  # --retry (no --retry-all-errors) needs 7.71+, so we do it in bash
+  # for portability across macOS and older Linux.
   API_RESPONSE=""
-  for attempt in 1 2 3; do
+  backoffs="3 6 12 24"
+  attempt=0
+  for delay in $backoffs end; do
+    attempt=$((attempt + 1))
     if API_RESPONSE=$(curl -fsSL --connect-timeout 10 --max-time 30 \
       "$API_LATEST_URL" 2>/dev/null); then
       break
     fi
     API_RESPONSE=""
-    [ "$attempt" -lt 3 ] && sleep $((attempt * 3))
+    [ "$delay" != "end" ] && sleep "$delay"
   done
   if [ -n "$API_RESPONSE" ]; then
     LATEST=$(printf '%s' "$API_RESPONSE" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//')


### PR DESCRIPTION
## Summary

The v0.6.2 release smoke failed because `/releases/latest` was still 404-ing when `install.sh` gave up — GitHub's "latest" flag transition after publish can take up to ~60s (old release loses the flag before the new one picks it up), but our combined budget was only ~25s.

Two paired fixes:

- **install.sh**: retry budget extended from 3 attempts / ~13s to 5 attempts / ~45s (exponential backoff 3+6+12+24). Benefits every user hitting the one-liner in the minute after a release publishes, not just CI.
- **smoke**: the blind 15s sleep is replaced with an active poll that reads `.version`, prepends `v`, and waits up to 2 minutes for `/releases/latest` to reflect that exact tag. The install-smoke now runs on a known-good API state, so any remaining failure is really about install.sh — not about GitHub still catching up.

Security regression test (`scripts/test/install_sh_test.sh`) stays green at 7/7.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)