### PR TITLE
fix(install): install revisioned formulas at versioned_revision dir

### DIFF
--- a/justfile
+++ b/justfile
@@ -64,13 +64,13 @@ fmt:
 # Lint shell scripts with shellcheck + shfmt.
 [group('lint')]
 shell-lint:
-    shellcheck scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh
-    shfmt -i 2 -d scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh
+    shellcheck scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh
+    shfmt -i 2 -d scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh
 
 # Apply shfmt formatting in place. Run after a failing `shell-lint`.
 [group('lint')]
 shell-fmt:
-    shfmt -i 2 -w scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh
+    shfmt -i 2 -w scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh
 
 # Lint: format check + build + test
 [group('lint')]

--- a/scripts/regressions/install_revisioned_gh77.sh
+++ b/scripts/regressions/install_revisioned_gh77.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Smoke test for revisioned formulas (issue #77).
+#
+# Revisioned formulas (Homebrew `revision: 1` onwards) must land at
+# `Cellar/<name>/<version>_<revision>` because bottles bake that path
+# into LC_LOAD_DYLIB entries. Plain `<version>` produces dyld errors
+# at runtime. This script installs one end-to-end and verifies both
+# the on-disk layout AND that the installed binary actually loads.
+#
+# Usage: scripts/smoke_install_revisioned.sh
+# Requirements: built `malt` binary at $MALT_BIN or zig-out/bin/malt,
+# network access to ghcr.io / formulae.brew.sh.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be ≤ 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_rev"
+export MALT_PREFIX="$PREFIX"
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+# ── Helper: pull revision + version straight from the live API ───────
+get_rev() {
+  local name="$1"
+  curl -fsSL "https://formulae.brew.sh/api/formula/${name//@/%40}.json" |
+    python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('revision',0))"
+}
+get_ver() {
+  local name="$1"
+  curl -fsSL "https://formulae.brew.sh/api/formula/${name//@/%40}.json" |
+    python3 -c "import sys,json; d=json.load(sys.stdin); print(d['versions']['stable'])"
+}
+
+TARGET="${TARGET:-pcre2}" # overrideable if the caller knows a better candidate
+REV=$(get_rev "$TARGET")
+VER=$(get_ver "$TARGET")
+
+if [[ "$REV" == "0" ]]; then
+  printf '▸ skipping: %s currently has revision 0 — rerun once a revision bump lands\n' "$TARGET"
+  exit 0
+fi
+
+PKGVER="${VER}_${REV}"
+printf '▸ target: %s  (version=%s  revision=%s  ⇒ Cellar dir = %s)\n' "$TARGET" "$VER" "$REV" "$PKGVER"
+
+# ── 1. Install end-to-end ────────────────────────────────────────────
+printf '▸ malt install %s\n' "$TARGET"
+"$BIN" install --quiet "$TARGET" || fail "install of $TARGET failed"
+pass "installed $TARGET"
+
+# ── 2. Cellar path carries the _<revision> suffix ────────────────────
+printf '▸ cellar dir exists at Cellar/%s/%s\n' "$TARGET" "$PKGVER"
+[[ -d "$PREFIX/Cellar/$TARGET/$PKGVER" ]] ||
+  fail "expected Cellar/$TARGET/$PKGVER to exist, got: $(ls -1 "$PREFIX/Cellar/$TARGET" 2>/dev/null || echo '(missing)')"
+pass "on-disk path is Cellar/$TARGET/$PKGVER"
+
+# Negative: the plain-version dir must NOT exist.
+[[ ! -d "$PREFIX/Cellar/$TARGET/$VER" ]] ||
+  fail "plain Cellar/$TARGET/$VER was also created — the fix did not take effect"
+pass "plain Cellar/$TARGET/$VER absent (no stale dir)"
+
+# ── 3. opt/<name> symlink resolves to the correct dir ────────────────
+if [[ -L "$PREFIX/opt/$TARGET" ]]; then
+  LINK_TARGET=$(readlink "$PREFIX/opt/$TARGET")
+  [[ "$LINK_TARGET" == *"/$PKGVER" ]] ||
+    fail "opt/$TARGET points at $LINK_TARGET (expected …/$PKGVER)"
+  pass "opt/$TARGET → …/$PKGVER"
+fi
+
+# ── 4. Installed dylib is dyld-loadable (the bug from issue #77) ─────
+# `otool -L` walks the LC_LOAD_DYLIB chain and will error if any
+# referenced library can't be located. This is the exact failure the
+# user hit when running `tig`.
+# Walk every real dylib (not symlink) and resolve its LC_LOAD_DYLIB
+# chain against the installed prefix. Any missing path = dyld would
+# abort at runtime, which is exactly the bug from issue #77.
+LIB_DIR="$PREFIX/Cellar/$TARGET/$PKGVER/lib"
+if [[ -d "$LIB_DIR" ]]; then
+  checked=0
+  while IFS= read -r dylib; do
+    # Extract every absolute LC_LOAD_DYLIB reference under $PREFIX
+    # and stat them.
+    # `otool -L`'s first line is the file itself (trailing colon);
+    # indented lines are the actual LC_LOAD_DYLIB entries. Grab only
+    # the indented ones, strip `(compat …)` suffix.
+    while IFS= read -r dep; do
+      [[ -e "$dep" ]] || fail "dyld would fail: $(basename "$dylib") references missing $dep"
+    done < <(otool -L "$dylib" | awk -v p="$PREFIX" '/^\t/ && $1 ~ p"/" { print $1 }')
+    checked=$((checked + 1))
+  done < <(find "$LIB_DIR" -name '*.dylib' -type f 2>/dev/null)
+  [[ "$checked" -gt 0 ]] && pass "all $checked dylib(s) resolve to real files under $PREFIX"
+fi
+
+# ── 5. info command shows the correct path ───────────────────────────
+printf '▸ malt info %s\n' "$TARGET"
+INFO_OUT=$("$BIN" info "$TARGET" 2>&1)
+echo "$INFO_OUT" | grep -q "Cellar/$TARGET/$PKGVER" ||
+  fail "mt info should surface the _<revision> path"
+pass "mt info reports the revisioned path"
+
+printf '\n✔ revisioned-install smoke test passed\n'

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -437,8 +437,10 @@ fn writeHumanInfo(
 
         try encodeHeader(stdout, colorize, name, "stable", ver_slice, "");
         try output.writeField(stdout, &buf, colorize, col, "From", "{s}", .{tap_slice});
-        try output.writeField(stdout, &buf, colorize, col, "Path", "{s}/Cellar/{s}/{s}", .{ prefix, name, ver_slice });
-        _ = path_slice;
+        // Use the recorded cellar_path directly — it carries the
+        // correct `_<revision>` suffix for revisioned formulas.
+        _ = prefix;
+        try output.writeField(stdout, &buf, colorize, col, "Path", "{s}", .{path_slice});
         if (pinned) try output.writeField(stdout, &buf, colorize, col, "Pinned", "yes", .{});
         try output.writeField(stdout, &buf, colorize, col, "Installed", "{s}", .{date_slice});
     } else {

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -980,7 +980,9 @@ pub fn collectFormulaJobs(
 
         jobs.append(allocator, .{
             .name = dep_formula.name,
-            .version_str = dep_formula.version,
+            // pkg_version folds in the `_N` revision suffix so cellar
+            // paths match the bottle's baked-in LC_LOAD_DYLIB entries.
+            .version_str = dep_formula.pkg_version,
             .sha256 = dep_bottle.sha256,
             .bottle_url = dep_bottle.url,
             .is_dep = true,
@@ -1005,7 +1007,9 @@ pub fn collectFormulaJobs(
 
     jobs.append(allocator, .{
         .name = formula.name,
-        .version_str = formula.version,
+        // Same reason as the dep branch above: the cellar dir name
+        // must carry the `_N` suffix when revision > 0.
+        .version_str = formula.pkg_version,
         .sha256 = bottle.sha256,
         .bottle_url = bottle.url,
         .is_dep = false,
@@ -1205,7 +1209,7 @@ fn maybeRegisterService(
     const cellar_path = std.fmt.bufPrint(
         &cellar_buf,
         "{s}/Cellar/{s}/{s}",
-        .{ prefix, formula.name, formula.version },
+        .{ prefix, formula.name, formula.pkg_version },
     ) catch return;
 
     const spec: plist_mod.ServiceSpec = .{

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -290,7 +290,7 @@ fn migrateKeg(
         prefix,
         bottle.sha256,
         formula.name,
-        formula.version,
+        formula.pkg_version,
     ) catch {
         output.err("    {s}: failed to materialize", .{keg_name});
         formula.deinit();
@@ -302,7 +302,7 @@ fn migrateKeg(
     if (!formula.keg_only) {
         const keg_id = recordKeg(db, &formula, bottle.sha256, keg.path, "direct") catch {
             output.err("    {s}: failed to record in database", .{keg_name});
-            cellar_mod.remove(prefix, formula.name, formula.version) catch {};
+            cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
             formula.deinit();
             allocator.free(formula_json);
             return .failed_install;
@@ -312,21 +312,21 @@ fn migrateKeg(
             output.warn("    {s}: some links could not be created", .{keg_name});
             linker.unlink(keg_id) catch {};
             deleteKeg(db, keg_id);
-            cellar_mod.remove(prefix, formula.name, formula.version) catch {};
+            cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
             formula.deinit();
             allocator.free(formula_json);
             return .failed_install;
         };
-        linker.linkOpt(formula.name, formula.version) catch {};
+        linker.linkOpt(formula.name, formula.pkg_version) catch {};
         recordDeps(db, keg_id, &formula);
     } else {
         const keg_id = recordKeg(db, &formula, bottle.sha256, keg.path, "direct") catch {
-            cellar_mod.remove(prefix, formula.name, formula.version) catch {};
+            cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
             formula.deinit();
             allocator.free(formula_json);
             return .failed_install;
         };
-        linker.linkOpt(formula.name, formula.version) catch {};
+        linker.linkOpt(formula.name, formula.pkg_version) catch {};
         recordDeps(db, keg_id, &formula);
     }
 
@@ -351,7 +351,7 @@ fn migrateKeg(
                         break :post_install;
                     }
                     if (inScope(use_system_ruby_scope, formula.name)) {
-                        ruby_sub.runPostInstall(allocator, formula.name, formula.version, prefix) catch |e| {
+                        ruby_sub.runPostInstall(allocator, formula.name, formula.pkg_version, prefix) catch |e| {
                             output.warn("  post_install subprocess failed for {s}: {s}", .{ formula.name, @errorName(e) });
                         };
                     } else {
@@ -378,7 +378,7 @@ fn migrateKeg(
                     break :post_install;
                 }
                 if (inScope(use_system_ruby_scope, formula.name)) {
-                    ruby_sub.runPostInstall(allocator, formula.name, formula.version, prefix) catch |e| {
+                    ruby_sub.runPostInstall(allocator, formula.name, formula.pkg_version, prefix) catch |e| {
                         output.warn("  post_install subprocess failed for {s}: {s}", .{ formula.name, @errorName(e) });
                     };
                 } else {
@@ -393,7 +393,7 @@ fn migrateKeg(
         // No source available — fall back to subprocess or skip
         if (inScope(use_system_ruby_scope, formula.name)) {
             output.warn("  Running post_install for {s} via system Ruby...", .{formula.name});
-            ruby_sub.runPostInstall(allocator, formula.name, formula.version, prefix) catch |e| {
+            ruby_sub.runPostInstall(allocator, formula.name, formula.pkg_version, prefix) catch |e| {
                 output.warn("  post_install failed for {s}: {s}", .{ formula.name, @errorName(e) });
             };
         } else {

--- a/src/cli/uninstall.zig
+++ b/src/cli/uninstall.zig
@@ -12,6 +12,7 @@ const linker = @import("../core/linker.zig");
 const cellar = @import("../core/cellar.zig");
 const store = @import("../core/store.zig");
 const cask_mod = @import("../core/cask.zig");
+const formula_mod = @import("../core/formula.zig");
 const supervisor_mod = @import("../core/services/supervisor.zig");
 const help = @import("help.zig");
 
@@ -68,7 +69,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     // Find the keg
     var find_stmt = db.prepare(
-        "SELECT id, version, store_sha256 FROM kegs WHERE name = ?1 LIMIT 1;",
+        "SELECT id, version, revision, store_sha256 FROM kegs WHERE name = ?1 LIMIT 1;",
     ) catch return;
     defer find_stmt.finalize();
     find_stmt.bindText(1, name) catch return;
@@ -81,9 +82,14 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     const keg_id = find_stmt.columnInt(0);
     const ver_ptr = find_stmt.columnText(1);
-    const sha_ptr = find_stmt.columnText(2);
+    const revision = find_stmt.columnInt(2);
+    const sha_ptr = find_stmt.columnText(3);
     const version = if (ver_ptr) |v| std.mem.sliceTo(v, 0) else "unknown";
     const sha256 = if (sha_ptr) |s| std.mem.sliceTo(s, 0) else "";
+
+    // Revision-aware dir name for the on-disk cellar entry.
+    var pkgver_buf: [128]u8 = undefined;
+    const pkg_version = formula_mod.pkgVersion(&pkgver_buf, version, revision) catch version;
 
     // Check for dependents (unless --force)
     if (!force) {
@@ -115,8 +121,9 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         output.warn("Could not remove all symlinks for {s}", .{name});
     };
 
-    // Remove Cellar directory
-    cellar.remove(prefix, name, version) catch {
+    // Remove Cellar directory (dir name carries the _<revision> suffix
+    // when the keg was installed with revision > 0).
+    cellar.remove(prefix, name, pkg_version) catch {
         output.warn("Could not remove cellar entry for {s} {s}", .{ name, version });
     };
     // Also remove parent if empty (e.g. Cellar/jq/ after removing Cellar/jq/1.8.1/)

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -118,7 +118,7 @@ fn upgradeFormula(
 ) !void {
     // Step 1: Look up installed version from DB
     var find_stmt = db.prepare(
-        "SELECT id, version, store_sha256, cellar_path FROM kegs WHERE name = ?1 LIMIT 1;",
+        "SELECT id, version, revision, store_sha256, cellar_path FROM kegs WHERE name = ?1 LIMIT 1;",
     ) catch return;
     defer find_stmt.finalize();
     find_stmt.bindText(1, name) catch return;
@@ -131,11 +131,17 @@ fn upgradeFormula(
 
     const old_keg_id = find_stmt.columnInt(0);
     const old_ver_ptr = find_stmt.columnText(1);
-    const old_sha_ptr = find_stmt.columnText(2);
-    const old_cellar_ptr = find_stmt.columnText(3);
+    const old_revision = find_stmt.columnInt(2);
+    const old_sha_ptr = find_stmt.columnText(3);
+    const old_cellar_ptr = find_stmt.columnText(4);
     const old_version = if (old_ver_ptr) |v| std.mem.sliceTo(v, 0) else "unknown";
     const old_sha256 = if (old_sha_ptr) |s| std.mem.sliceTo(s, 0) else "";
     const old_cellar_path = if (old_cellar_ptr) |c| std.mem.sliceTo(c, 0) else "";
+
+    // Reconstruct the revision-aware path label for the old keg so
+    // cellar_mod.remove / linker calls target the actual on-disk dir.
+    var old_pkgver_buf: [128]u8 = undefined;
+    const old_pkg_version = formula_mod.pkgVersion(&old_pkgver_buf, old_version, old_revision) catch old_version;
 
     // Step 2: Fetch latest formula from API
     const formula_json = api.fetchFormula(name) catch {
@@ -151,17 +157,17 @@ fn upgradeFormula(
     defer formula.deinit();
 
     // Compare versions
-    if (std.mem.eql(u8, old_version, formula.version)) {
-        output.skip("{s} is already at latest version {s}", .{ name, formula.version });
+    if (std.mem.eql(u8, old_pkg_version, formula.pkg_version)) {
+        output.skip("{s} is already at latest version {s}", .{ name, formula.pkg_version });
         return;
     }
 
     if (dry_run) {
-        output.info("Dry run: would upgrade {s} {s} -> {s}", .{ name, old_version, formula.version });
+        output.info("Dry run: would upgrade {s} {s} -> {s}", .{ name, old_version, formula.pkg_version });
         return;
     }
 
-    output.info("Upgrading {s} {s} -> {s}...", .{ name, old_version, formula.version });
+    output.info("Upgrading {s} {s} -> {s}...", .{ name, old_version, formula.pkg_version });
 
     // Step 3: Resolve bottle for new version
     const bottle = formula_mod.resolveBottle(allocator, &formula) catch {
@@ -224,7 +230,7 @@ fn upgradeFormula(
         prefix,
         bottle.sha256,
         formula.name,
-        formula.version,
+        formula.pkg_version,
     ) catch {
         output.err("Failed to materialize {s}", .{name});
         return error.Aborted;
@@ -241,7 +247,7 @@ fn upgradeFormula(
         output.err("Failed to record new version of {s} in database", .{name});
         // Rollback: re-link old version
         restoreOldLinks(db, &linker, old_cellar_path, name, old_keg_id);
-        cellar_mod.remove(prefix, formula.name, formula.version) catch {};
+        cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
         return;
     };
 
@@ -251,16 +257,16 @@ fn upgradeFormula(
         linker.unlink(new_keg_id) catch {};
         deleteKeg(db, new_keg_id);
         restoreOldLinks(db, &linker, old_cellar_path, name, old_keg_id);
-        cellar_mod.remove(prefix, formula.name, formula.version) catch {};
+        cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
         return;
     };
 
-    linker.linkOpt(formula.name, formula.version) catch {};
+    linker.linkOpt(formula.name, formula.pkg_version) catch {};
 
     // Step 8: Remove old DB record + Cellar entry (success path only)
     deleteKeg(db, old_keg_id);
-    cellar_mod.remove(prefix, name, old_version) catch {
-        output.warn("Could not remove old cellar entry for {s} {s}", .{ name, old_version });
+    cellar_mod.remove(prefix, name, old_pkg_version) catch {
+        output.warn("Could not remove old cellar entry for {s} {s}", .{ name, old_pkg_version });
     };
     // Also remove parent if empty
     {
@@ -276,7 +282,7 @@ fn upgradeFormula(
         store.decrementRef(old_sha256) catch {};
     }
 
-    output.success("{s} upgraded to {s}", .{ name, formula.version });
+    output.success("{s} upgraded to {s}", .{ name, formula.pkg_version });
 }
 
 /// Re-link old version during rollback.

--- a/src/core/formula.zig
+++ b/src/core/formula.zig
@@ -30,12 +30,29 @@ pub const ServiceDef = struct {
     run_at_load: bool = true,
 };
 
+/// Format Homebrew's canonical on-disk version label into `buf`.
+/// `revision > 0` appends `_<revision>` (matching Homebrew's
+/// `PkgVersion`); otherwise the plain `version` is returned
+/// unchanged. Revisions ≤ 0 are treated as zero — defensive against
+/// upstream JSON glitches. Used everywhere a filesystem path under
+/// `Cellar/<name>/` is assembled; getting this wrong produces
+/// `dyld: Library not loaded` errors because bottles hard-code the
+/// full path in LC_LOAD_DYLIB entries.
+pub fn pkgVersion(buf: []u8, version: []const u8, revision: i64) ![]const u8 {
+    if (revision <= 0) return std.fmt.bufPrint(buf, "{s}", .{version});
+    return std.fmt.bufPrint(buf, "{s}_{d}", .{ version, revision });
+}
+
 pub const Formula = struct {
     name: []const u8,
     full_name: []const u8,
     tap: []const u8,
     desc: []const u8,
     version: []const u8,
+    /// Canonical on-disk version name: equals `version` when
+    /// `revision == 0`, else `<version>_<revision>`. Use this for
+    /// every Cellar/opt/receipt path — never raw `version`.
+    pkg_version: []const u8,
     revision: i64,
     license: ?[]const u8,
     homepage: []const u8,
@@ -232,12 +249,21 @@ pub fn parseFormula(allocator: std.mem.Allocator, json_data: []const u8) !Formul
         }
     }
 
+    // Pre-compute the revision-aware path label once. Single-allocator
+    // dupe into the caller's arena so every downstream consumer can
+    // borrow a stable slice instead of re-formatting per call site.
+    const pkg_version_str = blk: {
+        if (revision <= 0) break :blk version_str;
+        break :blk try std.fmt.allocPrint(allocator, "{s}_{d}", .{ version_str, revision });
+    };
+
     return Formula{
         .name = name,
         .full_name = full_name,
         .tap = tap,
         .desc = desc,
         .version = version_str,
+        .pkg_version = pkg_version_str,
         .revision = revision,
         .license = license,
         .homepage = homepage,

--- a/tests/formula_test.zig
+++ b/tests/formula_test.zig
@@ -188,3 +188,74 @@ test "formula without service block has null service" {
     defer formula.deinit();
     try testing.expect(formula.service == null);
 }
+
+// ─── pkgVersion / Formula.pkg_version ────────────────────────────────
+//
+// Homebrew's canonical on-disk name for a keg is `<version>_<revision>`
+// when revision > 0, else `<version>`. Bottles are built against that
+// path and their Mach-O LC_LOAD_DYLIB entries bake it in, so dropping
+// the `_N` suffix breaks dyld at runtime (see issue #77: pcre2 10.47_1
+// installed as `pcre2/10.47` → `dyld: Library not loaded`).
+
+test "pkgVersion returns the plain version when revision is zero" {
+    var buf: [64]u8 = undefined;
+    const got = try formula_mod.pkgVersion(&buf, "1.24.5", 0);
+    try testing.expectEqualStrings("1.24.5", got);
+}
+
+test "pkgVersion appends _<revision> when revision > 0" {
+    var buf: [64]u8 = undefined;
+    const got = try formula_mod.pkgVersion(&buf, "10.47", 1);
+    try testing.expectEqualStrings("10.47_1", got);
+    const got2 = try formula_mod.pkgVersion(&buf, "3.6.2", 3);
+    try testing.expectEqualStrings("3.6.2_3", got2);
+}
+
+test "pkgVersion treats negative revision as zero (defensive)" {
+    // Homebrew never ships negative revisions; be safe rather than
+    // emitting `10.47_-1` if upstream JSON ever goes wrong.
+    var buf: [64]u8 = undefined;
+    const got = try formula_mod.pkgVersion(&buf, "10.47", -1);
+    try testing.expectEqualStrings("10.47", got);
+}
+
+test "pkgVersion returns NoSpaceLeft on a buffer too small to hold the result" {
+    // bufPrint-style contract: overflow surfaces as NoSpaceLeft so
+    // callers handle it the same way they handle every other path
+    // formatter in malt.
+    var small: [4]u8 = undefined;
+    try testing.expectError(error.NoSpaceLeft, formula_mod.pkgVersion(&small, "10.47", 1));
+}
+
+test "parseFormula populates pkg_version with the _<revision> suffix" {
+    var arena = testArena();
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const json =
+        \\{
+        \\  "name": "pcre2", "full_name": "pcre2", "tap": "homebrew/core",
+        \\  "desc": "", "homepage": "", "revision": 1,
+        \\  "versions": {"stable": "10.47"},
+        \\  "dependencies": [], "oldnames": [],
+        \\  "keg_only": false, "post_install_defined": false,
+        \\  "bottle": {"stable": {"root_url": "", "files": {}}}
+        \\}
+    ;
+    var f = try formula_mod.parseFormula(alloc, json);
+    defer f.deinit();
+    try testing.expectEqualStrings("10.47", f.version);
+    try testing.expectEqual(@as(i64, 1), f.revision);
+    try testing.expectEqualStrings("10.47_1", f.pkg_version);
+}
+
+test "parseFormula's pkg_version equals version when revision is zero" {
+    var arena = testArena();
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var f = try formula_mod.parseFormula(alloc, minimal_json);
+    defer f.deinit();
+    try testing.expectEqualStrings("1.24.5", f.version);
+    try testing.expectEqualStrings("1.24.5", f.pkg_version);
+}

--- a/tests/install_execute_test.zig
+++ b/tests/install_execute_test.zig
@@ -176,3 +176,47 @@ test "execute refuses to run when MALT_PREFIX exceeds the Mach-O budget" {
         install.execute(testing.allocator, &.{"wget"}),
     );
 }
+
+// ─── Revisioned formula handling (issue #77) ─────────────────────────
+//
+// Revisioned formulas (Homebrew `revision: 1` onwards) must land in
+// `Cellar/<name>/<version>_<revision>`, because bottles are built
+// against that path and bake it into LC_LOAD_DYLIB entries. A plain
+// `Cellar/<name>/<version>` install produces "dyld: Library not
+// loaded" at runtime (see issue #77 with pcre2 10.47_1).
+
+test "execute --dry-run routes a revisioned formula through the install pipeline" {
+    // The dry-run path flows: ensureDirs → DB open → lock → cache hit
+    // → collectFormulaJobs → print plan → return. A revisioned formula
+    // exercises every call site that reads `formula.pkg_version` in
+    // place of the plain `version`.
+    const prefix_z: [:0]const u8 = "/tmp/mr";
+    malt.fs_compat.deleteTreeAbsolute(prefix_z) catch {};
+    try malt.fs_compat.cwd().makePath(prefix_z);
+    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    defer malt.fs_compat.deleteTreeAbsolute(prefix_z) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // revision=1 → the keg dir under Cellar must be "10.47_1", not "10.47".
+    const json =
+        \\{"name":"rev1","full_name":"rev1","tap":"homebrew/core","desc":"","homepage":"",
+        \\ "versions":{"stable":"10.47"},"revision":1,"dependencies":[],"oldnames":[],
+        \\ "keg_only":false,"post_install_defined":false,
+        \\ "bottle":{"stable":{"root_url":"https://ghcr.io/v2/homebrew/core/rev1/blobs",
+        \\   "files":{
+        \\     "arm64_sequoia":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_sonoma":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_ventura":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_monterey":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "sequoia":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+        \\     "sonoma":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+        \\     "ventura":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+        \\     "monterey":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"}
+        \\   }}}}
+    ;
+    try seedFormulaCache(prefix_z, "rev1", json);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try install.execute(arena.allocator(), &.{ "--dry-run", "--quiet", "rev1" });
+}

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -603,3 +603,84 @@ test "collectFormulaJobs with post_install leaves the DB untouched" {
     try testing.expect(has_row);
     try testing.expectEqual(@as(i64, 0), stmt.columnInt(0));
 }
+
+test "collectFormulaJobs carries the _<revision> suffix in version_str" {
+    // Direct coverage for issue #77: a revisioned formula must reach
+    // the DownloadJob with its pkg_version (e.g. "10.47_1"), not the
+    // plain `versions.stable` (e.g. "10.47"). materializeAndLink reads
+    // `job.version_str` to form the Cellar dir name, so any drift
+    // there re-introduces the dyld breakage.
+    var arena = testArena();
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tdb = try TempDb.init("rev_jobs");
+    defer tdb.deinit();
+
+    const json =
+        \\{"name":"rev","full_name":"rev","tap":"homebrew/core","desc":"","homepage":"",
+        \\ "versions":{"stable":"10.47"},"revision":1,"dependencies":[],"oldnames":[],
+        \\ "keg_only":false,"post_install_defined":false,
+        \\ "bottle":{"stable":{"root_url":"https://ghcr.io/v2/homebrew/core/rev/blobs","files":{
+        \\   "arm64_sequoia":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"a"},
+        \\   "arm64_sonoma":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"a"},
+        \\   "arm64_ventura":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"a"},
+        \\   "arm64_monterey":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"a"},
+        \\   "sequoia":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"b"},
+        \\   "sonoma":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"b"},
+        \\   "ventura":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"b"},
+        \\   "monterey":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"b"}
+        \\ }}}}
+    ;
+
+    const cache_dir = "/tmp/malt_install_test_rev_jobs_cache";
+    malt.fs_compat.makeDirAbsolute(cache_dir) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(cache_dir) catch {};
+
+    var http = try malt.client.HttpClientPool.init(alloc, 1);
+    defer http.deinit();
+    var real_http = malt.client.HttpClient.init(alloc);
+    defer real_http.deinit();
+    var api = malt.api.BrewApi.init(alloc, &real_http, cache_dir);
+
+    var store_inst: malt.store.Store = undefined;
+    var jobs: std.ArrayList(install.DownloadJob) = .empty;
+    defer jobs.deinit(alloc);
+
+    try install.collectFormulaJobs(alloc, "rev", json, &api, &http, &tdb.db, &store_inst, false, &jobs);
+
+    try testing.expectEqual(@as(usize, 1), jobs.items.len);
+    try testing.expectEqualStrings("10.47_1", jobs.items[0].version_str);
+}
+
+test "collectFormulaJobs leaves plain-version formulas unchanged" {
+    // Regression guard: revision == 0 must NOT sprout an `_0` suffix.
+    var arena = testArena();
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tdb = try TempDb.init("norev_jobs");
+    defer tdb.deinit();
+
+    const json = postInstallFormulaJson(); // revision: 0 fixture.
+
+    const cache_dir = "/tmp/malt_install_test_norev_jobs_cache";
+    malt.fs_compat.makeDirAbsolute(cache_dir) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(cache_dir) catch {};
+
+    var http = try malt.client.HttpClientPool.init(alloc, 1);
+    defer http.deinit();
+    var real_http = malt.client.HttpClient.init(alloc);
+    defer real_http.deinit();
+    var api = malt.api.BrewApi.init(alloc, &real_http, cache_dir);
+
+    var store_inst: malt.store.Store = undefined;
+    var jobs: std.ArrayList(install.DownloadJob) = .empty;
+    defer jobs.deinit(alloc);
+
+    try install.collectFormulaJobs(alloc, "needs-ruby", json, &api, &http, &tdb.db, &store_inst, false, &jobs);
+
+    try testing.expectEqual(@as(usize, 1), jobs.items.len);
+    try testing.expectEqualStrings("1.0", jobs.items[0].version_str);
+    try testing.expect(std.mem.indexOf(u8, jobs.items[0].version_str, "_") == null);
+}


### PR DESCRIPTION
## Summary

This PR Fixes #77: running a Homebrew-revisioned formula (e.g. `tig`, which pulls `pcre2` 10.47_1) aborted at startup with `dyld: Library not loaded: /opt/malt/Cellar/pcre2/10.47_1/lib/libpcre2-8.0.dylib`.


**Root cause** 

Every filesystem-path construction used the bare `version` (`10.47`) while bottles bake `<version>_<revision>` (`10.47_1`) into `LC_LOAD_DYLIB` entries.

**Solution**

Every place malt builds a cellar path (install, uninstall, upgrade, migrate, info) now uses Homebrew's canonical `PkgVersion` label. The DB schema is unchanged — `version` and `revision` stay as separate columns.

- New regression script under `scripts/regressions/install_revisioned_gh77.sh` installs pcre2 from the live API and walks every dylib's load-command chain to catch future drift.

## Test plan

- [x] `zig build test`
- [x] `scripts/regressions/install_revisioned_gh77.sh` — pcre2 lands at `Cellar/pcre2/10.47_1`, all 4 dylibs resolve
- [x] `malt install tig && tig --version` — the original reproducer runs cleanly