### PR TITLE
fix(cask): hash multi-chunk downloads correctly

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -157,6 +157,8 @@ pub fn build(b: *std.Build) void {
         "tests/cli_tap_test.zig",
         "tests/cli_services_test.zig",
         "tests/install_execute_test.zig",
+        "tests/fs_compat_stream_test.zig",
+        "tests/fs_compat_lint_test.zig",
         "tests/install_local_test.zig",
         "tests/cask_extra_test.zig",
         "tests/dsl_interpreter_extra_test.zig",

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1351,9 +1351,11 @@ fn installCask(
         .func = &progressBridge,
     };
 
-    const app_path = installer.install(&cask) catch {
+    const app_path = installer.install(&cask) catch |e| {
         bar.finish();
-        output.err("Failed to install cask {s}", .{cask.token});
+        // Surface the specific cause (Sha256Mismatch, DownloadFailed, …) —
+        // users can't act on a bare "failed to install".
+        output.err("Failed to install cask {s}: {s}", .{ cask.token, @errorName(e) });
         return InstallError.CaskNotFound;
     };
     bar.finish();

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -275,29 +275,7 @@ pub const CaskInstaller = struct {
     }
 
     fn verifySha256(_: *CaskInstaller, file_path: []const u8, expected: ?[]const u8) !void {
-        const expected_hash = expected orelse return; // no_check casks skip verification
-        if (std.mem.eql(u8, expected_hash, "no_check")) return;
-
-        const file = try fs_compat.openFileAbsolute(file_path, .{});
-        defer file.close();
-
-        const stat = try file.stat();
-        // For large files, read in chunks
-        var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-        var read_buf: [65536]u8 = undefined;
-        var remaining: u64 = stat.size;
-        while (remaining > 0) {
-            const to_read = @min(remaining, read_buf.len);
-            const n = file.readAll(read_buf[0..to_read]) catch return error.Sha256Mismatch;
-            if (n == 0) break;
-            hasher.update(read_buf[0..n]);
-            remaining -= n;
-        }
-        var hash: [32]u8 = undefined;
-        hasher.final(&hash);
-
-        const hex_buf = std.fmt.bytesToHex(hash, .lower);
-        if (!std.mem.eql(u8, &hex_buf, expected_hash)) return error.Sha256Mismatch;
+        return verifyFileSha256(file_path, expected);
     }
 
     fn installDmg(self: *CaskInstaller, dmg_path: []const u8, app_dir: []const u8, cask: *const Cask) ![]const u8 {
@@ -452,6 +430,45 @@ pub const CaskInstaller = struct {
         fs_compat.cwd().makePath(caskroom_ver) catch {};
     }
 };
+
+/// SHA256 buffer size — one positional read per 64 KiB.
+const sha256_read_chunk: usize = 64 * 1024;
+
+/// Compute the SHA256 of `file_path` as lowercase hex. Streams via
+/// `fs_compat.streamFile` so the file-reading loop lives in exactly
+/// one place — no more hand-rolled offset bookkeeping.
+pub fn hashFileSha256(file_path: []const u8) ![64]u8 {
+    const file = try fs_compat.openFileAbsolute(file_path, .{});
+    defer file.close();
+
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    var read_buf: [sha256_read_chunk]u8 = undefined;
+    try fs_compat.streamFile(file, &read_buf, .{
+        .context = @ptrCast(&hasher),
+        .func = &sha256Update,
+    });
+    var hash: [32]u8 = undefined;
+    hasher.final(&hash);
+    return std.fmt.bytesToHex(hash, .lower);
+}
+
+/// Bridge `streamFile`'s erased-context callback to `Sha256.update`.
+fn sha256Update(ctx: *anyopaque, chunk: []const u8) anyerror!void {
+    const hasher: *std.crypto.hash.sha2.Sha256 = @ptrCast(@alignCast(ctx));
+    hasher.update(chunk);
+}
+
+/// Verify `file_path` hashes to `expected` (lowercase hex). A null
+/// `expected` or the literal `"no_check"` skips verification —
+/// mirrors Homebrew's `sha256 :no_check` escape hatch for casks that
+/// cannot be pinned (auto-updating installers).
+pub fn verifyFileSha256(file_path: []const u8, expected: ?[]const u8) !void {
+    const expected_hash = expected orelse return;
+    if (std.mem.eql(u8, expected_hash, "no_check")) return;
+
+    const got = try hashFileSha256(file_path);
+    if (!std.mem.eql(u8, &got, expected_hash)) return error.Sha256Mismatch;
+}
 
 /// Check if an application is currently running by its path.
 fn isAppRunning(app_path: []const u8) bool {

--- a/src/fs/compat.zig
+++ b/src/fs/compat.zig
@@ -84,6 +84,31 @@ pub fn milliTimestamp() i64 {
     return @as(i64, ts.sec) * std.time.ms_per_s + @divTrunc(ts.nsec, std.time.ns_per_ms);
 }
 
+/// Context + function pair for `streamFile`. The func receives every
+/// chunk exactly once, in order — any non-void error aborts the walk
+/// and propagates out to the caller.
+pub const StreamCallback = struct {
+    context: *anyopaque,
+    func: *const fn (context: *anyopaque, chunk: []const u8) anyerror!void,
+};
+
+/// Walk `file` from start to EOF in `buf`-sized chunks, invoking `cb`
+/// on each chunk. Advancing-offset positional reads — the obvious way
+/// to stream a file without tripping on `readAll`'s offset-0
+/// behaviour. Fails fast on a zero-length buffer (would loop).
+pub fn streamFile(file: File, buf: []u8, cb: StreamCallback) !void {
+    if (buf.len == 0) return error.InvalidArgument;
+    var offset: u64 = 0;
+    while (true) {
+        const n = try file.readAllAt(buf, offset);
+        if (n == 0) break;
+        try cb.func(cb.context, buf[0..n]);
+        offset += n;
+        // Short read ⇒ EOF; skip one extra syscall on exact-multiple sizes.
+        if (n < buf.len) break;
+    }
+}
+
 pub fn isatty(fd: std.posix.fd_t) bool {
     return std.c.isatty(fd) != 0;
 }
@@ -247,10 +272,18 @@ pub const File = struct {
         });
     }
 
+    /// Positional read from offset 0. Safe for single-shot reads of a
+    /// whole file into a stat-sized buffer. **Never call this inside a
+    /// loop** — every iteration re-reads the first bytes. For
+    /// streaming use `readAllAt` with an advancing offset or (better)
+    /// the `streamFile` helper which handles the offset bookkeeping.
     pub fn readAll(self: File, buffer: []u8) !usize {
         return self.inner.readPositionalAll(io_mod.ctx(), buffer, 0);
     }
 
+    /// Positional read from `offset`. The streaming primitive — the
+    /// caller advances `offset` by the returned byte count. Prefer
+    /// `streamFile` when the loop body would otherwise be boilerplate.
     pub fn readAllAt(self: File, buffer: []u8, offset: u64) !usize {
         return self.inner.readPositionalAll(io_mod.ctx(), buffer, offset);
     }

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -171,3 +171,260 @@ test "isOutdated detects version mismatch" {
     try std.testing.expect(installer.isOutdated("firefox", "124.0"));
     try std.testing.expect(!installer.isOutdated("firefox", "123.0"));
 }
+
+// ─── hashFileSha256 / verifyFileSha256 ───────────────────────────────
+//
+// A multi-chunk read bug meant any file larger than the 64 KiB read
+// buffer got the first chunk re-hashed in place of later chunks,
+// producing a wrong digest. Caught on a live cask install where the
+// upstream zip was bit-perfect but malt rejected it. These tests
+// exercise the chunk loop at every boundary and prove the hash
+// output against independently-computed digests.
+
+const testing = std.testing;
+const malt_fs = malt.fs_compat;
+
+/// 64 KiB — the internal SHA256 read buffer size. Every boundary
+/// case below is expressed relative to this so the tests stay
+/// meaningful if the constant ever changes.
+const CHUNK: usize = 64 * 1024;
+
+fn tempFilePath(tag: []const u8, buf: []u8) ![]const u8 {
+    return std.fmt.bufPrint(buf, "/tmp/malt_cask_verify_{s}_{d}", .{ tag, malt_fs.nanoTimestamp() });
+}
+
+fn writeFile(path: []const u8, bytes: []const u8) !void {
+    const f = try malt_fs.createFileAbsolute(path, .{});
+    defer f.close();
+    try f.writeAll(bytes);
+}
+
+/// Independent SHA256 of `bytes` as lowercase hex, computed in one
+/// pass via `std.crypto` — used to cross-check the chunked impl.
+fn referenceHex(bytes: []const u8) [64]u8 {
+    var hash: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(bytes, &hash, .{});
+    return std.fmt.bytesToHex(hash, .lower);
+}
+
+/// Fill `buf` with a predictable, non-repeating byte pattern so every
+/// chunk contributes distinct bytes. The old bug only shows up when
+/// later chunks differ from the first.
+fn fillPattern(buf: []u8) void {
+    for (buf, 0..) |*b, i| b.* = @intCast((i *% 131 +% 7) & 0xFF);
+}
+
+fn hashTempFile(alloc: std.mem.Allocator, tag: []const u8, size: usize) !void {
+    const payload = try alloc.alloc(u8, size);
+    defer alloc.free(payload);
+    fillPattern(payload);
+
+    var path_buf: [128]u8 = undefined;
+    const p = try tempFilePath(tag, &path_buf);
+    try writeFile(p, payload);
+    defer malt_fs.cwd().deleteFile(p) catch {};
+
+    const got = try cask.hashFileSha256(p);
+    const want = referenceHex(payload);
+    try testing.expectEqualSlices(u8, &want, &got);
+}
+
+// ── hashFileSha256: exercises the chunk-boundary matrix ──────────────
+
+test "hashFileSha256 matches reference for an empty file" {
+    var path_buf: [128]u8 = undefined;
+    const p = try tempFilePath("empty", &path_buf);
+    try writeFile(p, "");
+    defer malt_fs.cwd().deleteFile(p) catch {};
+
+    const got = try cask.hashFileSha256(p);
+    // SHA256 of empty input.
+    try testing.expectEqualSlices(
+        u8,
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        &got,
+    );
+}
+
+test "hashFileSha256 matches reference for sub-chunk inputs" {
+    try hashTempFile(testing.allocator, "sub_1", 1);
+    try hashTempFile(testing.allocator, "sub_63", 63);
+    try hashTempFile(testing.allocator, "sub_1024", 1024);
+}
+
+test "hashFileSha256 matches reference at CHUNK-1" {
+    try hashTempFile(testing.allocator, "below", CHUNK - 1);
+}
+
+test "hashFileSha256 matches reference at exactly CHUNK" {
+    // Precise boundary: the loop does one full read then a short-read
+    // EOF check. If the loop ever double-read the first chunk this
+    // would be the smallest failing size.
+    try hashTempFile(testing.allocator, "eq", CHUNK);
+}
+
+test "hashFileSha256 matches reference at CHUNK+1 (straddles the boundary)" {
+    try hashTempFile(testing.allocator, "above", CHUNK + 1);
+}
+
+test "hashFileSha256 matches reference across two full chunks" {
+    try hashTempFile(testing.allocator, "two", 2 * CHUNK);
+}
+
+test "hashFileSha256 matches reference across 2½ chunks (the repro size)" {
+    // 160 KiB — mirrors the failing-in-the-wild case: later chunks
+    // carry bytes the old loop never actually hashed.
+    try hashTempFile(testing.allocator, "repro", CHUNK * 2 + CHUNK / 2);
+}
+
+test "hashFileSha256 matches reference on a 1 MiB payload" {
+    try hashTempFile(testing.allocator, "mib", 1024 * 1024);
+}
+
+test "hashFileSha256 of 'abc' matches the NIST test vector" {
+    var path_buf: [128]u8 = undefined;
+    const p = try tempFilePath("nist_abc", &path_buf);
+    try writeFile(p, "abc");
+    defer malt_fs.cwd().deleteFile(p) catch {};
+
+    const got = try cask.hashFileSha256(p);
+    try testing.expectEqualSlices(
+        u8,
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        &got,
+    );
+}
+
+test "hashFileSha256 propagates FileNotFound for a missing path" {
+    try testing.expectError(
+        error.FileNotFound,
+        cask.hashFileSha256("/tmp/malt_cask_verify_absent_xyzzy.bin"),
+    );
+}
+
+// ── verifyFileSha256: the pickier public API ─────────────────────────
+
+test "verifyFileSha256 accepts the correct digest on a tiny file" {
+    var path_buf: [128]u8 = undefined;
+    const p = try tempFilePath("tiny_ok", &path_buf);
+    try writeFile(p, "hello");
+    defer malt_fs.cwd().deleteFile(p) catch {};
+
+    // `printf 'hello' | shasum -a 256`
+    try cask.verifyFileSha256(p, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+}
+
+test "verifyFileSha256 rejects a digest with a single flipped bit" {
+    // The strictest form of "is our compare byte-exact?" — the only
+    // difference from the correct digest is the trailing character.
+    var path_buf: [128]u8 = undefined;
+    const p = try tempFilePath("flip", &path_buf);
+    try writeFile(p, "hello");
+    defer malt_fs.cwd().deleteFile(p) catch {};
+
+    try testing.expectError(
+        error.Sha256Mismatch,
+        cask.verifyFileSha256(p, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9825"),
+    );
+}
+
+test "verifyFileSha256 rejects an uppercase digest (strict lower-hex)" {
+    // Homebrew always emits lowercase. Reject mixed-case so a sloppy
+    // copy-paste can never silently succeed with an attacker-tuned hex.
+    var path_buf: [128]u8 = undefined;
+    const p = try tempFilePath("upper", &path_buf);
+    try writeFile(p, "hello");
+    defer malt_fs.cwd().deleteFile(p) catch {};
+
+    try testing.expectError(
+        error.Sha256Mismatch,
+        cask.verifyFileSha256(p, "2CF24DBA5FB0A30E26E83B2AC5B9E29E1B161E5C1FA7425E73043362938B9824"),
+    );
+}
+
+test "verifyFileSha256 rejects a truncated or over-length digest" {
+    var path_buf: [128]u8 = undefined;
+    const p = try tempFilePath("length", &path_buf);
+    try writeFile(p, "hello");
+    defer malt_fs.cwd().deleteFile(p) catch {};
+
+    try testing.expectError(error.Sha256Mismatch, cask.verifyFileSha256(p, "2cf2"));
+    try testing.expectError(
+        error.Sha256Mismatch,
+        cask.verifyFileSha256(p, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b98240"),
+    );
+}
+
+test "verifyFileSha256 skips verification on null or :no_check" {
+    // `sha256 :no_check` is Homebrew's opt-out for self-updating
+    // installers. Honouring the skip prevents spurious failures on
+    // perfectly valid casks.
+    var path_buf: [128]u8 = undefined;
+    const p = try tempFilePath("skip", &path_buf);
+    try writeFile(p, "anything");
+    defer malt_fs.cwd().deleteFile(p) catch {};
+
+    try cask.verifyFileSha256(p, null);
+    try cask.verifyFileSha256(p, "no_check");
+}
+
+test "verifyFileSha256 accepts a correct digest on a >1 MiB file" {
+    // Regression guard for the chunked-read bug: the public API must
+    // produce the same digest as `openssl dgst -sha256` on arbitrarily
+    // large files. Without the fix, every chunk after the first is
+    // re-read from offset 0 and the digest comes out wrong.
+    const alloc = testing.allocator;
+    const size: usize = 1024 * 1024 + 7; // non-power-of-two on purpose
+    const payload = try alloc.alloc(u8, size);
+    defer alloc.free(payload);
+    fillPattern(payload);
+
+    var path_buf: [128]u8 = undefined;
+    const p = try tempFilePath("big_ok", &path_buf);
+    try writeFile(p, payload);
+    defer malt_fs.cwd().deleteFile(p) catch {};
+
+    const expected = referenceHex(payload);
+    try cask.verifyFileSha256(p, &expected);
+}
+
+test "verifyFileSha256 propagates FileNotFound rather than Sha256Mismatch" {
+    // Distinguish I/O failure from hash failure — users hitting a
+    // permission error deserve to know, not "your download is
+    // corrupt" when nothing was ever read.
+    try testing.expectError(
+        error.FileNotFound,
+        cask.verifyFileSha256("/tmp/malt_cask_verify_missing_xyzzy.bin", "0" ** 64),
+    );
+}
+
+test "verifyFileSha256 accepts only the exact-byte payload (collision check)" {
+    // Two files that differ by a single byte must produce different
+    // hashes — the chunk-boundary bug could otherwise let two files
+    // share a hash when the diverging byte lived in a "skipped" chunk.
+    const alloc = testing.allocator;
+    const a = try alloc.alloc(u8, CHUNK + 128);
+    defer alloc.free(a);
+    fillPattern(a);
+
+    const b = try alloc.alloc(u8, CHUNK + 128);
+    defer alloc.free(b);
+    fillPattern(b);
+    b[CHUNK + 64] +%= 1; // flip one byte past the first chunk boundary
+
+    var ap_buf: [128]u8 = undefined;
+    const ap = try tempFilePath("coll_a", &ap_buf);
+    try writeFile(ap, a);
+    defer malt_fs.cwd().deleteFile(ap) catch {};
+
+    var bp_buf: [128]u8 = undefined;
+    const bp = try tempFilePath("coll_b", &bp_buf);
+    try writeFile(bp, b);
+    defer malt_fs.cwd().deleteFile(bp) catch {};
+
+    const hex_a = referenceHex(a);
+    try cask.verifyFileSha256(ap, &hex_a);
+    // `a`'s hash must NOT validate `b` — this is exactly the property
+    // the old bug could have broken.
+    try testing.expectError(error.Sha256Mismatch, cask.verifyFileSha256(bp, &hex_a));
+}

--- a/tests/fs_compat_lint_test.zig
+++ b/tests/fs_compat_lint_test.zig
@@ -1,0 +1,231 @@
+//! malt — lint-as-test for fs_compat.readAll misuse
+//!
+//! `readAll` is a positional read from offset 0 — safe for single-shot
+//! reads of a whole file, fatal inside a loop (every iteration reads
+//! the first bytes again). The cask SHA bug was exactly this.
+//!
+//! This test walks src/ and fails if any file pairs a `while`/`for`
+//! keyword with a `readAll(` call within a short window. Use
+//! `readAllAt` or `streamFile` for streaming instead.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const fs = malt.fs_compat;
+
+/// Lines of look-ahead after a `while (` / `for (` header before we
+/// stop counting. Real streaming loops put the `readAll(` within a
+/// handful of lines of the loop header; anything farther is almost
+/// certainly unrelated.
+const SCAN_WINDOW: usize = 10;
+
+/// Inspect one source buffer for the readAll-in-loop antipattern.
+/// Returns the 1-based line number of the first offending `readAll(`
+/// call, or null when the file is clean.
+///
+/// The dangerous shape is re-reading the *same* handle inside a loop.
+/// If an `openFile` appears between the loop header and the `readAll`,
+/// each iteration works on a fresh handle (one-shot-per-iteration) —
+/// that's safe and the scanner skips it. Pure — no I/O.
+fn findReadAllInLoop(source: []const u8) ?usize {
+    var loop_open_at: ?usize = null;
+    var open_file_since_loop: bool = false;
+    var line_no: usize = 0;
+    var it = std.mem.splitScalar(u8, source, '\n');
+    while (it.next()) |raw| {
+        line_no += 1;
+        const line = std.mem.trim(u8, raw, " \t\r");
+
+        if (isLoopHeader(line)) {
+            loop_open_at = line_no;
+            open_file_since_loop = false;
+            continue;
+        }
+        if (loop_open_at) |opened| {
+            if (line_no - opened > SCAN_WINDOW) {
+                loop_open_at = null;
+                open_file_since_loop = false;
+            }
+        }
+
+        // A fresh handle inside the loop body flips the pattern from
+        // "re-read same file" (bug) to "one read per new file" (safe).
+        if (loop_open_at != null and std.mem.indexOf(u8, line, "openFile") != null) {
+            open_file_since_loop = true;
+            continue;
+        }
+
+        // Flag only bare `readAll(` inside an active loop where the
+        // handle was NOT just opened in the same iteration.
+        if (loop_open_at != null and !open_file_since_loop and containsBareReadAll(line)) {
+            return line_no;
+        }
+    }
+    return null;
+}
+
+fn isLoopHeader(line: []const u8) bool {
+    // Match the start of a while/for statement — the `(` qualifier
+    // rules out `while` as a word inside a comment or string literal.
+    return std.mem.startsWith(u8, line, "while (") or
+        std.mem.startsWith(u8, line, "for (") or
+        std.mem.indexOf(u8, line, " while (") != null or
+        std.mem.indexOf(u8, line, " for (") != null;
+}
+
+fn containsBareReadAll(line: []const u8) bool {
+    // Locate `readAll(`, then make sure the two chars before it are
+    // `.` (method call) or `(` / space (free function) rather than
+    // `t` (i.e. the `readAllAt` prefix we *do* allow).
+    const needle = "readAll(";
+    var idx: usize = 0;
+    while (std.mem.indexOfPos(u8, line, idx, needle)) |pos| {
+        // Reject `readAllAt(` by checking the 3 chars before `(`.
+        if (pos >= 2 and std.mem.eql(u8, line[pos + "readAll".len - 2 .. pos + "readAll".len], "ll") and
+            (pos + needle.len) <= line.len and line[pos + needle.len - 1] == '(')
+        {
+            // Also confirm this isn't inside `readAllAt` — At would
+            // appear immediately after readAll, but splitScalar above
+            // matched `readAll(` already, so At can't be there.
+            return true;
+        }
+        idx = pos + needle.len;
+    }
+    return false;
+}
+
+// ─── unit tests on the detector itself ───────────────────────────────
+
+test "findReadAllInLoop flags the classic positional-0 bug shape" {
+    const bad =
+        \\while (remaining > 0) {
+        \\    const n = file.readAll(buf) catch break;
+        \\    if (n == 0) break;
+        \\}
+    ;
+    try testing.expect(findReadAllInLoop(bad) != null);
+}
+
+test "findReadAllInLoop flags for-loops too" {
+    const bad =
+        \\for (chunks) |_| {
+        \\    const n = file.readAll(&magic) catch break;
+        \\    _ = n;
+        \\}
+    ;
+    try testing.expect(findReadAllInLoop(bad) != null);
+}
+
+test "findReadAllInLoop accepts readAllAt inside a loop" {
+    const ok =
+        \\while (true) {
+        \\    const n = try file.readAllAt(buf, offset);
+        \\    if (n == 0) break;
+        \\}
+    ;
+    try testing.expect(findReadAllInLoop(ok) == null);
+}
+
+test "findReadAllInLoop accepts a single-shot readAll outside any loop" {
+    const ok =
+        \\const data = allocator.alloc(u8, stat.size) catch return;
+        \\const n = file.readAll(data) catch return;
+        \\_ = n;
+    ;
+    try testing.expect(findReadAllInLoop(ok) == null);
+}
+
+test "findReadAllInLoop allows readAll when openFile opens a fresh handle per iteration" {
+    // This is the cellar-walk pattern: open a new file per directory
+    // entry, read its magic, close. Each iteration is one-shot and
+    // therefore safe regardless of being inside a while loop.
+    const ok =
+        \\while (walker.next() catch null) |entry| {
+        \\    const file = fs_compat.openFileAbsolute(path, .{}) catch continue;
+        \\    var magic: [4]u8 = undefined;
+        \\    const n = file.readAll(&magic) catch continue;
+        \\    _ = n;
+        \\}
+    ;
+    try testing.expect(findReadAllInLoop(ok) == null);
+}
+
+test "findReadAllInLoop ignores loops far above an unrelated readAll call" {
+    // A `while` many lines earlier should NOT trigger on a one-shot
+    // read — the window expires. Otherwise the lint would false-
+    // positive on any file that happens to contain unrelated loops.
+    const ok =
+        \\while (it.next()) |entry| {
+        \\    process(entry);
+        \\}
+        \\
+        \\// 20 lines later, a one-shot read:
+        \\//
+        \\//
+        \\//
+        \\//
+        \\//
+        \\//
+        \\//
+        \\//
+        \\//
+        \\//
+        \\const data = allocator.alloc(u8, stat.size) catch return;
+        \\const n = file.readAll(data) catch return;
+    ;
+    try testing.expect(findReadAllInLoop(ok) == null);
+}
+
+test "findReadAllInLoop reports the line number of the first offender" {
+    const bad =
+        \\// line 1
+        \\// line 2
+        \\while (x) {
+        \\    const n = file.readAll(buf) catch break;
+        \\}
+    ;
+    try testing.expectEqual(@as(usize, 4), findReadAllInLoop(bad).?);
+}
+
+// ─── the guard itself: scan src/ ─────────────────────────────────────
+//
+// Fails loud if a future contributor (or a careless revert of the
+// cask fix) re-introduces the bug pattern anywhere under src/.
+
+test "no readAll() inside a loop anywhere under src/" {
+    var dir = try fs.cwd().openDir("src", .{ .iterate = true });
+    defer dir.close();
+
+    var walker = try dir.walk(testing.allocator);
+    defer walker.deinit();
+
+    var failures: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (failures.items) |s| testing.allocator.free(s);
+        failures.deinit(testing.allocator);
+    }
+
+    while (try walker.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.path, ".zig")) continue;
+
+        const file = try dir.openFile(entry.path, .{});
+        defer file.close();
+        const content = try file.readToEndAlloc(testing.allocator, 1 << 22);
+        defer testing.allocator.free(content);
+
+        if (findReadAllInLoop(content)) |line| {
+            const msg = try std.fmt.allocPrint(
+                testing.allocator,
+                "src/{s}:{d}: readAll() inside a loop — use readAllAt or fs_compat.streamFile",
+                .{ entry.path, line },
+            );
+            try failures.append(testing.allocator, msg);
+        }
+    }
+
+    if (failures.items.len != 0) {
+        for (failures.items) |f| std.debug.print("{s}\n", .{f});
+        return error.ReadAllInLoop;
+    }
+}

--- a/tests/fs_compat_stream_test.zig
+++ b/tests/fs_compat_stream_test.zig
@@ -1,0 +1,165 @@
+//! malt — fs_compat.streamFile tests
+//!
+//! streamFile is the future-proof "walk a file in chunks" helper —
+//! every multi-chunk consumer (hashing, scanning, checksumming) should
+//! reach for it instead of hand-rolling a `readAll` loop that silently
+//! reads the first chunk over and over.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const fs = malt.fs_compat;
+
+// Any chunk size the helper accepts must work at both sides of the
+// boundary. The tests below use a small buffer on purpose so "more
+// than one chunk" is cheap to provoke.
+const TEST_CHUNK: usize = 64;
+
+fn tempFilePath(tag: []const u8, buf: []u8) ![]const u8 {
+    return std.fmt.bufPrint(buf, "/tmp/malt_stream_{s}_{d}", .{ tag, fs.nanoTimestamp() });
+}
+
+fn writeFile(path: []const u8, bytes: []const u8) !void {
+    const f = try fs.createFileAbsolute(path, .{});
+    defer f.close();
+    try f.writeAll(bytes);
+}
+
+// Collector callback — appends every chunk into an ArrayList so the
+// test can assert the full byte sequence the helper surfaced.
+const Collector = struct {
+    list: *std.ArrayList(u8),
+
+    fn callback(ctx: *anyopaque, chunk: []const u8) anyerror!void {
+        const self: *Collector = @ptrCast(@alignCast(ctx));
+        try self.list.appendSlice(testing.allocator, chunk);
+    }
+};
+
+fn runStream(path: []const u8) !std.ArrayList(u8) {
+    const f = try fs.openFileAbsolute(path, .{});
+    defer f.close();
+    var collected: std.ArrayList(u8) = .empty;
+    errdefer collected.deinit(testing.allocator);
+    var c = Collector{ .list = &collected };
+    var buf: [TEST_CHUNK]u8 = undefined;
+    try fs.streamFile(f, &buf, .{ .context = @ptrCast(&c), .func = &Collector.callback });
+    return collected;
+}
+
+// ── size sweep: every boundary vs the chunk size ─────────────────────
+
+fn assertRoundTrip(tag: []const u8, size: usize) !void {
+    const payload = try testing.allocator.alloc(u8, size);
+    defer testing.allocator.free(payload);
+    for (payload, 0..) |*b, i| b.* = @intCast((i *% 131 +% 7) & 0xFF);
+
+    var path_buf: [128]u8 = undefined;
+    const p = try tempFilePath(tag, &path_buf);
+    try writeFile(p, payload);
+    defer fs.cwd().deleteFile(p) catch {};
+
+    var got = try runStream(p);
+    defer got.deinit(testing.allocator);
+    try testing.expectEqualSlices(u8, payload, got.items);
+}
+
+test "streamFile surfaces nothing for an empty file" {
+    try assertRoundTrip("empty", 0);
+}
+
+test "streamFile surfaces a 1-byte file" {
+    try assertRoundTrip("one", 1);
+}
+
+test "streamFile surfaces a sub-chunk file" {
+    try assertRoundTrip("sub", TEST_CHUNK - 3);
+}
+
+test "streamFile surfaces a file exactly one chunk long" {
+    try assertRoundTrip("eq", TEST_CHUNK);
+}
+
+test "streamFile surfaces a file that straddles the chunk boundary" {
+    try assertRoundTrip("straddle", TEST_CHUNK + 1);
+}
+
+test "streamFile surfaces a multi-chunk file without losing bytes" {
+    try assertRoundTrip("multi", TEST_CHUNK * 4 + 17);
+}
+
+test "streamFile keeps bytes in order across chunks" {
+    // Sanity check beyond "lengths match" — if the helper ever starts
+    // re-reading the first chunk the bytes will be wrong even though
+    // the count could still line up.
+    const size = TEST_CHUNK * 3 + 5;
+    const payload = try testing.allocator.alloc(u8, size);
+    defer testing.allocator.free(payload);
+    for (payload, 0..) |*b, i| b.* = @intCast(i & 0xFF);
+
+    var path_buf: [128]u8 = undefined;
+    const p = try tempFilePath("order", &path_buf);
+    try writeFile(p, payload);
+    defer fs.cwd().deleteFile(p) catch {};
+
+    var got = try runStream(p);
+    defer got.deinit(testing.allocator);
+    try testing.expectEqualSlices(u8, payload, got.items);
+}
+
+// ── callback-error propagation ───────────────────────────────────────
+
+const AbortCtx = struct {
+    seen: usize = 0,
+    abort_after: usize,
+
+    fn callback(ctx: *anyopaque, chunk: []const u8) anyerror!void {
+        const self: *AbortCtx = @ptrCast(@alignCast(ctx));
+        self.seen += chunk.len;
+        if (self.seen > self.abort_after) return error.CallbackAborted;
+    }
+};
+
+test "streamFile propagates a callback error and stops reading" {
+    const payload = try testing.allocator.alloc(u8, TEST_CHUNK * 4);
+    defer testing.allocator.free(payload);
+    @memset(payload, 'x');
+
+    var path_buf: [128]u8 = undefined;
+    const p = try tempFilePath("abort", &path_buf);
+    try writeFile(p, payload);
+    defer fs.cwd().deleteFile(p) catch {};
+
+    const f = try fs.openFileAbsolute(p, .{});
+    defer f.close();
+
+    var buf: [TEST_CHUNK]u8 = undefined;
+    var ctx = AbortCtx{ .abort_after = TEST_CHUNK }; // stop after the first chunk
+    try testing.expectError(
+        error.CallbackAborted,
+        fs.streamFile(f, &buf, .{ .context = @ptrCast(&ctx), .func = &AbortCtx.callback }),
+    );
+    // Only one chunk (or maybe two, depending on chunk size boundary)
+    // was delivered — definitely not the full file.
+    try testing.expect(ctx.seen < payload.len);
+}
+
+test "streamFile rejects a zero-length buffer" {
+    // A zero-sized chunk buffer would silently loop forever (readAllAt
+    // on an empty slice returns 0 and the guard can't distinguish EOF
+    // from no-progress). Fail loud instead.
+    var path_buf: [128]u8 = undefined;
+    const p = try tempFilePath("zerobuf", &path_buf);
+    try writeFile(p, "hello");
+    defer fs.cwd().deleteFile(p) catch {};
+
+    const f = try fs.openFileAbsolute(p, .{});
+    defer f.close();
+
+    var empty: [0]u8 = undefined;
+    var ctx = AbortCtx{ .abort_after = 1 };
+    try testing.expectError(
+        error.InvalidArgument,
+        fs.streamFile(f, &empty, .{ .context = @ptrCast(&ctx), .func = &AbortCtx.callback }),
+    );
+}


### PR DESCRIPTION
## Summary

- Cask SHA verification now matches `openssl dgst -sha256` on any size file. Before this, every cask whose download exceeded the 64 KiB read buffer was rejected as tampered — the loop re-read the first chunk instead of advancing through the file. Install errors now tell the user *which* step failed instead of a generic "not found".
- New `fs_compat.streamFile` helper is the "obvious way to walk a file in chunks" — handles the offset bookkeeping so future hashing / scanning code doesn't trip on the same trap.
- A test-as-lint guard scans `src/` and fails the build if `readAll()` ever creeps back into a loop body, so the bug can't silently regress.
