### PR TITLE
fix(release): widen smoke wait and distinguish lag from missing release

### DIFF
--- a/justfile
+++ b/justfile
@@ -64,13 +64,13 @@ fmt:
 # Lint shell scripts with shellcheck + shfmt.
 [group('lint')]
 shell-lint:
-    shellcheck scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh
-    shfmt -i 2 -d scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh
+    shellcheck scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh
+    shfmt -i 2 -d scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh
 
 # Apply shfmt formatting in place. Run after a failing `shell-lint`.
 [group('lint')]
 shell-fmt:
-    shfmt -i 2 -w scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh
+    shfmt -i 2 -w scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh
 
 # Lint: format check + build + test
 [group('lint')]

--- a/scripts/e2e/smoke_install_release.sh
+++ b/scripts/e2e/smoke_install_release.sh
@@ -76,33 +76,19 @@ if [ -n "$COSIGN_PATH" ]; then
   SAFE_PATH="$(dirname "$COSIGN_PATH"):$SAFE_PATH"
 fi
 
-# GitHub's /releases/latest endpoint flips to the new tag
-# asynchronously — measured at up to ~60s after a release is published
-# (the old release stops being "latest" before the new one takes the
-# flag, and the endpoint serves 404 through the transition). The
-# smoke runs seconds after publish, so a blind sleep isn't enough.
-# Actively poll the API until it reflects our tag, up to 2 minutes.
-# install.sh itself has a retry loop for real users; this poll just
-# makes the CI feedback loop deterministic.
+# GitHub publishes a release in two observable steps:
+#   1. /releases/tags/<tag> goes 200 (the release object exists).
+#   2. /releases/latest.tag_name flips to <tag> (CDN catches up).
+# install.sh hits /releases/latest, so step 2 is the user-facing gate —
+# but separating the two lets the smoke say *which* of the two lagged.
+# Unit coverage for these helpers lives in scripts/test/release_wait_test.sh.
 if [ "${MALT_SMOKE_SKIP_PROPAGATION_WAIT:-0}" != "1" ]; then
   EXPECTED_TAG="v$(cat "$(dirname "$0")/../../.version")"
-  step "Waiting up to 2m for ${EXPECTED_TAG} to appear on /releases/latest"
-  API_URL="https://api.github.com/repos/indaco/malt/releases/latest"
-  deadline=$(($(date +%s) + 120))
-  ready=0
-  while [ "$(date +%s)" -lt "$deadline" ]; do
-    body=$(curl -fsSL --max-time 10 "$API_URL" 2>/dev/null || true)
-    if printf '%s' "$body" | grep -q "\"tag_name\": *\"${EXPECTED_TAG}\""; then
-      ready=1
-      break
-    fi
-    sleep 5
-  done
-  if [ "$ready" = "1" ]; then
-    pass "API reflects ${EXPECTED_TAG}"
-  else
-    fail "API still not showing ${EXPECTED_TAG} after 2m — propagation unusually slow"
-  fi
+  # shellcheck source=/dev/null
+  source "$(dirname "$0")/../lib/release_wait.sh"
+  step "Waiting up to $((WAIT_BUDGET_SECONDS / 60))m for ${EXPECTED_TAG} to propagate"
+  wait_for_release "${EXPECTED_TAG}"
+  pass "API /releases/latest reflects ${EXPECTED_TAG}"
 fi
 
 step "Running install.sh from README against the live release"

--- a/scripts/lib/release_wait.sh
+++ b/scripts/lib/release_wait.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# scripts/lib/release_wait.sh
+#
+# Helpers that answer "is this release ready for users yet?" against
+# GitHub's REST API. Split into two checks because they fail for
+# distinct reasons:
+#
+#   • release_tag_exists — /releases/tags/<tag> is 200 the instant the
+#     release is published. If it's NOT 200, the release workflow
+#     hasn't finished or failed outright.
+#
+#   • release_latest_matches — /releases/latest reports our tag. The
+#     "latest" flag flips asynchronously after publish; `install.sh`
+#     (and therefore the README one-liner) depends on this.
+#
+# The top-level `wait_for_release` stitches them together so failures
+# can say precisely which of the two is lagging.
+#
+# Intended to be sourced. Exit-only `fail` from the caller's smoke
+# script is wired in via the MALT_SMOKE_FAIL_FN env var (defaults to
+# "fail" — the name the smoke script already defines).
+
+# Configurable via env so tests can compress the wait to milliseconds.
+WAIT_BUDGET_SECONDS="${WAIT_BUDGET_SECONDS:-300}" # 5 minutes default
+WAIT_POLL_INTERVAL="${WAIT_POLL_INTERVAL:-5}"     # 5s between probes
+MALT_SMOKE_API_BASE="${MALT_SMOKE_API_BASE:-https://api.github.com/repos/indaco/malt}"
+
+# Returns 0 when GitHub's tag-specific release endpoint responds 200.
+release_tag_exists() {
+  local tag="$1"
+  local code
+  code=$(curl -fsSL -o /dev/null -w '%{http_code}' --max-time 10 \
+    "${MALT_SMOKE_API_BASE}/releases/tags/${tag}" 2>/dev/null || true)
+  [ "$code" = "200" ]
+}
+
+# Returns 0 when /releases/latest.tag_name equals `tag` exactly.
+# Strict match (no partial) so v0.7.0 cannot accept v0.7.00.
+release_latest_matches() {
+  local tag="$1"
+  local body
+  body=$(curl -fsSL --max-time 10 \
+    "${MALT_SMOKE_API_BASE}/releases/latest" 2>/dev/null || true)
+  # Require the exact closing quote so prefix-only tags don't match.
+  printf '%s' "$body" | grep -q "\"tag_name\": *\"${tag}\""
+}
+
+# Poll both endpoints until /latest reflects `tag` or the budget runs
+# out. On failure, calls the caller's `fail` function (exported as
+# MALT_SMOKE_FAIL_FN) with one of two precise messages so operators
+# know whether to re-run the release workflow or just wait on the CDN.
+wait_for_release() {
+  local tag="$1"
+  local fail_fn="${MALT_SMOKE_FAIL_FN:-fail}"
+  local deadline=$(($(date +%s) + WAIT_BUDGET_SECONDS))
+  local tag_exists=0
+
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    # Once we've seen the tag endpoint go 200 we don't re-probe — the
+    # release isn't going to un-publish itself.
+    if [ "$tag_exists" -eq 0 ] && release_tag_exists "$tag"; then
+      tag_exists=1
+    fi
+    if release_latest_matches "$tag"; then
+      return 0
+    fi
+    sleep "$WAIT_POLL_INTERVAL"
+  done
+
+  if [ "$tag_exists" -eq 1 ]; then
+    "$fail_fn" "${tag} is published but /releases/latest is still serving an older tag after $((WAIT_BUDGET_SECONDS / 60))m — install.sh will fall back to source for users until the CDN catches up."
+  else
+    "$fail_fn" "${tag} does not exist on the release API after $((WAIT_BUDGET_SECONDS / 60))m — release workflow may have failed; check the Actions log."
+  fi
+  return 1
+}

--- a/scripts/test/release_wait_test.sh
+++ b/scripts/test/release_wait_test.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/lib/release_wait.sh.
+#
+# Mocks `curl` so the helpers can be exercised offline against every
+# GitHub API state the smoke script has to tolerate:
+#   • tag endpoint 404 + latest wrong      → release doesn't exist yet
+#   • tag endpoint 200 + latest old        → published, CDN still catching up
+#   • tag endpoint 200 + latest correct    → happy path
+#   • tag endpoint 5xx / network flakiness → retry without false-failing
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+LIB="$ROOT/scripts/lib/release_wait.sh"
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+# ── curl mock harness ────────────────────────────────────────────────
+#
+# Tests set two env vars:
+#   FAKE_TAG_STATUS  — HTTP code returned for /releases/tags/<tag>
+#   FAKE_LATEST_TAG  — tag name reported by /releases/latest (empty ⇒ 404)
+#
+# The mocked curl honours only the flags the lib uses (-f, -s, -w, -o,
+# --max-time). It writes the status-code to stdout when -w '%{http_code}'
+# is present; otherwise it writes the fake body.
+curl() {
+  local url="" want_status=0 output_file="" has_f=0
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+    -f | -fsSL | -fsS | -fs | -fsL) has_f=1 ;;
+    -s | -L | -S) ;;
+    -w)
+      shift
+      if [ "$1" = '%{http_code}' ]; then want_status=1; fi
+      ;;
+    -o)
+      shift
+      output_file="$1"
+      ;;
+    --max-time)
+      shift
+      ;;
+    --connect-timeout)
+      shift
+      ;;
+    http*) url="$1" ;;
+    *) ;;
+    esac
+    shift
+  done
+
+  local status="" body=""
+  case "$url" in
+  */releases/tags/*)
+    status="${FAKE_TAG_STATUS:-404}"
+    body="{\"tag_name\":\"$(basename "$url")\"}"
+    ;;
+  */releases/latest)
+    if [ -n "${FAKE_LATEST_TAG:-}" ]; then
+      status="200"
+      body="{\"tag_name\": \"${FAKE_LATEST_TAG}\"}"
+    else
+      status="404"
+      body=""
+    fi
+    ;;
+  *)
+    status="404"
+    body=""
+    ;;
+  esac
+
+  # -o redirects body to file.
+  [ -n "$output_file" ] && printf '%s' "$body" >"$output_file"
+
+  # -w '%{http_code}' overrides body with the numeric status.
+  if [ "$want_status" = "1" ]; then
+    printf '%s' "$status"
+  elif [ -z "$output_file" ]; then
+    printf '%s' "$body"
+  fi
+
+  # With -f, non-2xx status means curl itself exits non-zero.
+  if [ "$has_f" = "1" ] && [ "${status:0:1}" != "2" ]; then
+    return 22
+  fi
+  return 0
+}
+export -f curl
+
+# Disable the lib's real sleep so tests finish in ms, not minutes.
+sleep() { :; }
+export -f sleep
+
+# Load the unit under test — requires the lib to exist (TDD: the first
+# runs should fail on "no such file").
+# shellcheck source=/dev/null
+source "$LIB"
+
+# Make `fail` / `pass` inside the lib visible but not fatal during
+# tests. The lib calls `fail` which `exit 1`s — we run each case in a
+# subshell so one failure does not abort the rest.
+run() (
+  set +e
+  "$@"
+  echo "rc=$?"
+)
+
+# ── release_tag_exists ───────────────────────────────────────────────
+
+t=0
+ok() {
+  t=$((t + 1))
+  printf '  ✓ [%02d] %s\n' "$t" "$*"
+}
+bad() {
+  t=$((t + 1))
+  printf '  ✗ [%02d] %s\n' "$t" "$*" >&2
+  exit 1
+}
+
+if FAKE_TAG_STATUS=200 release_tag_exists "v0.7.0"; then
+  ok "release_tag_exists returns 0 on 200"
+else
+  bad "release_tag_exists should succeed on 200"
+fi
+if FAKE_TAG_STATUS=404 release_tag_exists "v0.7.0"; then
+  bad "release_tag_exists should fail on 404"
+else
+  ok "release_tag_exists returns non-zero on 404"
+fi
+if FAKE_TAG_STATUS=503 release_tag_exists "v0.7.0"; then
+  bad "release_tag_exists should fail on 5xx"
+else
+  ok "release_tag_exists returns non-zero on 5xx"
+fi
+
+# ── release_latest_matches ───────────────────────────────────────────
+
+if FAKE_LATEST_TAG="v0.7.0" release_latest_matches "v0.7.0"; then
+  ok "release_latest_matches matches the exact tag"
+else
+  bad "release_latest_matches should match on identical tag"
+fi
+if FAKE_LATEST_TAG="v0.6.2" release_latest_matches "v0.7.0"; then
+  bad "release_latest_matches should NOT match an older tag"
+else
+  ok "release_latest_matches rejects an older tag"
+fi
+if FAKE_LATEST_TAG="" release_latest_matches "v0.7.0"; then
+  bad "release_latest_matches should NOT match on empty body / 404"
+else
+  ok "release_latest_matches rejects empty/404 response"
+fi
+# Partial-match guard: `v0.7.0` must not match `v0.7.00` etc.
+if FAKE_LATEST_TAG="v0.7.00" release_latest_matches "v0.7.0"; then
+  bad "release_latest_matches must not accept a partial tag match"
+else
+  ok "release_latest_matches rejects partial-string matches"
+fi
+
+# ── wait_for_release: happy + both failure shapes ────────────────────
+#
+# Sentinel: the lib's `fail` function (inherited from smoke script)
+# normally `exit 1`s. For the unit tests, override it to record the
+# message and return non-zero so the harness can introspect.
+LAST_FAIL=""
+# shellcheck disable=SC2317
+fail_capture() {
+  LAST_FAIL="$*"
+  return 1
+}
+
+# wait_for_release may call `fail_capture` which returns non-zero —
+# don't let `set -e` abort the harness before we inspect LAST_FAIL.
+set +e
+
+# Happy path: tag present, /latest flipped on first probe.
+if FAKE_TAG_STATUS=200 FAKE_LATEST_TAG="v0.7.0" \
+  WAIT_BUDGET_SECONDS=5 WAIT_POLL_INTERVAL=0 \
+  MALT_SMOKE_FAIL_FN=fail_capture \
+  wait_for_release "v0.7.0" >/dev/null; then
+  ok "wait_for_release succeeds when tag+latest both ready"
+else
+  bad "wait_for_release failed on the happy path"
+fi
+
+# Tag exists but /latest lags — must fail with the precise message.
+LAST_FAIL=""
+FAKE_TAG_STATUS=200 FAKE_LATEST_TAG="v0.6.2" \
+  WAIT_BUDGET_SECONDS=1 WAIT_POLL_INTERVAL=0 \
+  MALT_SMOKE_FAIL_FN=fail_capture \
+  wait_for_release "v0.7.0" >/dev/null
+case "$LAST_FAIL" in
+*"published"*"/releases/latest"*) ok "wait_for_release reports the precise CDN-lag message" ;;
+*) bad "expected precise CDN-lag message, got: ${LAST_FAIL:-<empty>}" ;;
+esac
+
+# Tag does not exist — must fail with the "release missing" message.
+LAST_FAIL=""
+FAKE_TAG_STATUS=404 FAKE_LATEST_TAG="" \
+  WAIT_BUDGET_SECONDS=1 WAIT_POLL_INTERVAL=0 \
+  MALT_SMOKE_FAIL_FN=fail_capture \
+  wait_for_release "v0.7.0" >/dev/null
+case "$LAST_FAIL" in
+*"does not exist"*) ok "wait_for_release reports the release-missing message" ;;
+*) bad "expected release-missing message, got: ${LAST_FAIL:-<empty>}" ;;
+esac
+
+# Intermittent flake: tag + /latest both arrive eventually.
+if FAKE_TAG_STATUS=200 FAKE_LATEST_TAG="v0.7.0" \
+  WAIT_BUDGET_SECONDS=2 WAIT_POLL_INTERVAL=0 \
+  MALT_SMOKE_FAIL_FN=fail_capture \
+  wait_for_release "v0.7.0" >/dev/null; then
+  ok "wait_for_release tolerates eventual readiness within budget"
+else
+  bad "wait_for_release failed to tolerate eventual readiness"
+fi
+
+echo
+echo "✔ release_wait: $t unit case(s) passed"


### PR DESCRIPTION
## Summary

- Release-verification smoke no longer false-fails on GitHub's normal (and occasionally >2-minute) \`/releases/latest\` CDN lag — the wait now budgets 5 minutes.
- Failures are now diagnosable at a glance: "release does not exist" points at the release workflow, "published but /releases/latest is still serving an older tag" points at GitHub's CDN (install.sh will fall back to source for users until it catches up).
- No user-facing impact — \`install.sh\` is fetched fresh from \`main\` and already carries its own retry budget. This PR only hardens the CI canary.
