### PR TITLE
fix(dsl): harden post_install DSL — block-pass, ::, diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,14 +592,15 @@ Completes subcommands (for both `malt` and `mt`), per-command flags, global flag
 
 ### Global Flags
 
-| Flag              | Description                                   |
-| ----------------- | --------------------------------------------- |
-| `--verbose`, `-v` | Verbose output (all commands)                 |
-| `--quiet`, `-q`   | Suppress non-error output (all commands)      |
-| `--json`          | JSON output (read commands)                   |
-| `--dry-run`       | Preview without executing (mutating commands) |
-| `--help`, `-h`    | Show help                                     |
-| `--version`       | Show version                                  |
+| Flag              | Description                                                                      |
+| ----------------- | -------------------------------------------------------------------------------- |
+| `--verbose`, `-v` | Verbose output (all commands)                                                    |
+| `--debug`         | Surface every DSL diagnostic (implies verbose); pair with issue reports          |
+| `--quiet`, `-q`   | Suppress non-error output (all commands)                                         |
+| `--json`          | JSON output (read commands; also emits per-package `post_install` status lines)  |
+| `--dry-run`       | Preview without executing (mutating commands)                                    |
+| `--help`, `-h`    | Show help                                                                        |
+| `--version`       | Show version                                                                     |
 
 ---
 

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -216,6 +216,18 @@ else
 
   # After uninstall, rollback on an uninstalled package should fail cleanly.
   run t3.rollback.none 1 -- "$MT_BIN" rollback tree
+
+  # Issue #85 regression: zig pulls llvm@21 whose post_install uses Ruby's
+  # `&:sym` block-pass shorthand. If the DSL parser or fatal-classification
+  # ever regresses, the install prints "post_install DSL failed for llvm@21"
+  # — the grep below will catch it. Gated on SMOKE_INSTALL_HEAVY because the
+  # llvm@21 bottle is ~350 MB and most CI runs shouldn't download it.
+  if [[ "${SMOKE_INSTALL_HEAVY:-0}" == "1" ]]; then
+    run_ok t3.install.zig -- "$MT_BIN" install zig
+    run 't3.install.zig.no_post_install_fatal' 1 -- \
+      grep -q "post_install DSL failed for llvm@21" "$LOGDIR/t3_install_zig.log"
+    run_ok t3.uninstall.zig -- "$MT_BIN" uninstall zig
+  fi
 fi
 
 # ── Summary ────────────────────────────────────────────────────────────────

--- a/scripts/regressions/post_install_block_pass_gh85.sh
+++ b/scripts/regressions/post_install_block_pass_gh85.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Smoke test for issue #85 — `post_install` DSL fails with "unexpected token"
+# on Ruby's `&:sym` block-pass shorthand.
+#
+# The reporter hit this on `mt install zig`, where `llvm@21` pulls in a
+# `post_install` that calls `config_files.all?(&:exist?)`. The native DSL
+# must parse the `&:sym` block-pass *and* not mark the (previously fatal)
+# parse error as fatal — otherwise the `--use-system-ruby` fallback is
+# silently disabled.
+#
+# Usage: scripts/regressions/post_install_block_pass_gh85.sh
+# Requirements: built `malt` binary at $MALT_BIN or zig-out/bin/malt,
+# network access to ghcr.io / formulae.brew.sh.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be ≤ 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_gh85"
+export MALT_PREFIX="$PREFIX"
+# Deterministic output so `grep` matches the real strings, not ANSI.
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+TARGET="${TARGET:-zig}" # zig pulls llvm@21, which is the formula that failed
+LOG="$PREFIX/install.log"
+
+printf '▸ malt install %s (logs → %s)\n' "$TARGET" "$LOG"
+"$BIN" install "$TARGET" >"$LOG" 2>&1 || fail "install of $TARGET failed — see $LOG"
+pass "installed $TARGET"
+
+# ── 1. The native DSL parser must not emit the old fatal. ────────────
+if grep -q "post_install DSL failed for llvm@21" "$LOG"; then
+  printf '---- last 40 lines of install log ----\n' >&2
+  tail -40 "$LOG" >&2
+  fail "regression: llvm@21 post_install fatal surfaced again"
+fi
+pass "no post_install DSL fatal for llvm@21"
+
+# ── 2. The specific `unexpected token` diagnostic must be gone. ──────
+# The fix is the parser accepting `&:sym` block-pass. Any parse_error
+# pinned to the `&` column would be the regression.
+if grep -qE "llvm@21:[0-9]+:[0-9]+: \[parse_error\]" "$LOG"; then
+  printf '---- parse_error lines ----\n' >&2
+  grep -E "llvm@21:.*parse_error" "$LOG" >&2
+  fail "regression: parse_error on llvm@21 post_install"
+fi
+pass "no parse_error on llvm@21 post_install body"
+
+# ── 3. Install finished cleanly for the top-level target. ────────────
+grep -qE "✓ ${TARGET} .* installed|${TARGET} [^ ]+ installed" "$LOG" ||
+  fail "install line for $TARGET missing in log"
+pass "$TARGET install completed"
+
+# ── 4. Follow-up commands see the keg. ───────────────────────────────
+INFO_OUT=$("$BIN" info "$TARGET" 2>&1)
+echo "$INFO_OUT" | grep -q "Cellar/$TARGET/" ||
+  fail "mt info $TARGET does not surface a Cellar path"
+pass "mt info $TARGET reports the installed keg"
+
+# ── 5. --use-system-ruby=llvm@21 drives post_install to completion. ──
+#
+# llvm@21's post_install calls a private `def write_config_files(...)`
+# that the native DSL doesn't execute (no `def` support), so the base
+# install prints "partially skipped" and does NOT create the
+# `<prefix>/etc/clang/<arch>-apple-*.cfg` files the formula ships.
+# Passing `--use-system-ruby=llvm@21` delegates that single formula's
+# post_install to the Ruby subprocess, which writes those config files
+# and unlocks `clang -cc1` defaults for keg-only LLVM users.
+#
+# This path needs system Ruby + a homebrew-core tap clone. Skip rather
+# than fail when either is absent — the fix still holds for the native
+# path we just verified above.
+TAP=""
+for cand in /opt/homebrew/Library/Taps/homebrew/homebrew-core \
+  /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core; do
+  [[ -d "$cand" ]] && TAP="$cand" && break
+done
+
+if [[ -x /usr/bin/ruby ]] && [[ -n "$TAP" ]]; then
+  # Fresh prefix so write_config_files actually has work to do; the
+  # formula's `return if config_files.all?(&:exist?)` guard would
+  # otherwise no-op after the first run.
+  rm -rf "$PREFIX"
+  mkdir -p "$PREFIX"
+
+  LOG2="$PREFIX/install_sysruby.log"
+  printf '▸ malt install --use-system-ruby=llvm@21 %s (logs → %s)\n' "$TARGET" "$LOG2"
+  "$BIN" install --use-system-ruby=llvm@21 "$TARGET" >"$LOG2" 2>&1 ||
+    fail "install with --use-system-ruby=llvm@21 failed — see $LOG2"
+  pass "installed $TARGET with --use-system-ruby=llvm@21"
+
+  # The "partially skipped" warning must be gone — the Ruby subprocess
+  # ran post_install to completion.
+  if grep -q "post_install partially skipped" "$LOG2"; then
+    tail -20 "$LOG2" >&2
+    fail "--use-system-ruby=llvm@21 did not take the Ruby fallback path"
+  fi
+  pass "no 'partially skipped' warning under --use-system-ruby=llvm@21"
+
+  # write_config_files must have written `<arch>-apple-*.cfg` files.
+  arch=$(uname -m)
+  shopt -s nullglob
+  cfg_files=("$PREFIX"/etc/clang/"${arch}"-apple-*.cfg)
+  shopt -u nullglob
+  [[ ${#cfg_files[@]} -gt 0 ]] ||
+    fail "expected ${arch}-apple-*.cfg under $PREFIX/etc/clang after --use-system-ruby run"
+  pass "clang config files written (${#cfg_files[@]} file(s) under etc/clang)"
+else
+  printf '  - skipping --use-system-ruby=llvm@21 check: tap or /usr/bin/ruby absent\n'
+fi
+
+printf '\n✔ gh85 post_install block-pass regression passed\n'

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -19,6 +19,7 @@ const ghcr_mod = @import("../net/ghcr.zig");
 const api_mod = @import("../net/api.zig");
 const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
+const io_mod = @import("../ui/io.zig");
 const progress_mod = @import("../ui/progress.zig");
 const ruby_sub = @import("../core/ruby_subprocess.zig");
 const tap_mod = @import("../core/tap.zig");
@@ -118,11 +119,25 @@ fn useSystemRubyForFormula(scope: []const []const u8, formula_name: []const u8) 
     return false;
 }
 
+/// Post_install outcome status — surfaced to users as human text and
+/// to scripted consumers as JSON when `--json` is set.
+pub const PostInstallStatus = enum {
+    completed,
+    partially_skipped,
+    ran_via_ruby,
+    ruby_fallback_failed,
+    fatal,
+};
+
 /// Route the post_install outcome using the fallback log as the single
-/// source of truth. "completed" now means exactly that — zero logged
-/// entries; any unknown_method / unsupported_node downgrades to the same
-/// `--use-system-ruby` suggestion we show on execute-time failures, so
+/// source of truth. "completed" means zero logged entries; any
+/// unknown_method / unsupported_node downgrades to the same
+/// `--use-system-ruby` suggestion we show on execute-time failures so
 /// users never see "completed" when statements were silently skipped.
+///
+/// Under `--verbose`, the skipped entries are dumped so users can tell
+/// WHICH helpers fell through. Under `--json`, a single status line is
+/// emitted to stdout for scripted pipelines.
 ///
 /// Pub so the install-pure tests can drive it with a synthetic flog and
 /// pin the exact output for every branch.
@@ -134,23 +149,63 @@ pub fn routePostInstallOutcome(
     flog: *const dsl.FallbackLog,
     use_system_ruby_list: []const []const u8,
 ) void {
-    if (flog.hasFatal()) {
-        output.warn("post_install DSL failed for {s} (fatal)", .{name});
-        flog.printFatal(name);
-        return;
-    }
-    if (!flog.hasErrors()) {
-        output.info("post_install completed for {s}", .{name});
-        return;
-    }
-    if (useSystemRubyForFormula(use_system_ruby_list, name)) {
-        output.warn("post_install DSL incomplete for {s}, falling back to system Ruby...", .{name});
-        ruby_sub.runPostInstall(allocator, name, version_str, prefix) catch |e| {
-            output.warn("post_install subprocess failed for {s}: {s}", .{ name, @errorName(e) });
-        };
-        return;
-    }
-    output.warn("{s}: post_install partially skipped (use --use-system-ruby={s} to attempt via Ruby)", .{ name, name });
+    const status: PostInstallStatus = blk: {
+        if (flog.hasFatal()) {
+            output.warn("post_install DSL failed for {s} (fatal)", .{name});
+            flog.printFatal(name);
+            // `--debug` also surfaces the non-fatal context so a bug
+            // report includes every reason the DSL logged, not just the
+            // one that aborted execution.
+            if (output.isDebug()) flog.printUnknown(name);
+            break :blk .fatal;
+        }
+        if (!flog.hasErrors()) {
+            output.info("post_install completed for {s}", .{name});
+            break :blk .completed;
+        }
+        if (useSystemRubyForFormula(use_system_ruby_list, name)) {
+            output.warn("post_install DSL incomplete for {s}, falling back to system Ruby...", .{name});
+            if (output.isVerbose()) flog.printUnknown(name);
+            if (output.isDebug()) flog.printFatal(name);
+            ruby_sub.runPostInstall(allocator, name, version_str, prefix) catch |e| {
+                output.warn("post_install subprocess failed for {s}: {s}", .{ name, @errorName(e) });
+                break :blk .ruby_fallback_failed;
+            };
+            // Symmetric with the native "completed" info so scripted users
+            // see a positive signal when the Ruby escape hatch succeeded.
+            output.info("post_install completed for {s} (via system Ruby)", .{name});
+            break :blk .ran_via_ruby;
+        }
+        output.warn("{s}: post_install partially skipped (use --use-system-ruby={s} to attempt via Ruby)", .{ name, name });
+        if (output.isVerbose()) flog.printUnknown(name);
+        if (output.isDebug()) flog.printFatal(name);
+        break :blk .partially_skipped;
+    };
+
+    if (output.isJson()) emitPostInstallJson(allocator, name, status, flog);
+}
+
+/// Write one JSON line per post_install routing decision to stdout. One
+/// line per package keeps the stream pipe-friendly (`jq -c`, line-split).
+fn emitPostInstallJson(
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    status: PostInstallStatus,
+    flog: *const dsl.FallbackLog,
+) void {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
+    w.writeAll("{\"event\":\"post_install\",\"name\":") catch return;
+    output.jsonStr(w, name) catch return;
+    w.writeAll(",\"status\":\"") catch return;
+    w.writeAll(@tagName(status)) catch return;
+    w.writeAll("\",\"entries\":") catch return;
+    const entries_json = flog.toJson(allocator) catch return;
+    defer allocator.free(entries_json);
+    w.writeAll(entries_json) catch return;
+    w.writeAll("}\n") catch return;
+    io_mod.stdoutWriteAll(aw.written());
 }
 
 /// A bottle download job for parallel processing.

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -118,6 +118,41 @@ fn useSystemRubyForFormula(scope: []const []const u8, formula_name: []const u8) 
     return false;
 }
 
+/// Route the post_install outcome using the fallback log as the single
+/// source of truth. "completed" now means exactly that — zero logged
+/// entries; any unknown_method / unsupported_node downgrades to the same
+/// `--use-system-ruby` suggestion we show on execute-time failures, so
+/// users never see "completed" when statements were silently skipped.
+///
+/// Pub so the install-pure tests can drive it with a synthetic flog and
+/// pin the exact output for every branch.
+pub fn routePostInstallOutcome(
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    version_str: []const u8,
+    prefix: []const u8,
+    flog: *const dsl.FallbackLog,
+    use_system_ruby_list: []const []const u8,
+) void {
+    if (flog.hasFatal()) {
+        output.warn("post_install DSL failed for {s} (fatal)", .{name});
+        flog.printFatal(name);
+        return;
+    }
+    if (!flog.hasErrors()) {
+        output.info("post_install completed for {s}", .{name});
+        return;
+    }
+    if (useSystemRubyForFormula(use_system_ruby_list, name)) {
+        output.warn("post_install DSL incomplete for {s}, falling back to system Ruby...", .{name});
+        ruby_sub.runPostInstall(allocator, name, version_str, prefix) catch |e| {
+            output.warn("post_install subprocess failed for {s}: {s}", .{ name, @errorName(e) });
+        };
+        return;
+    }
+    output.warn("{s}: post_install partially skipped (use --use-system-ruby={s} to attempt via Ruby)", .{ name, name });
+}
+
 /// A bottle download job for parallel processing.
 ///
 /// Public so integration tests can construct an empty jobs list and assert
@@ -785,23 +820,12 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
                     var flog = dsl.FallbackLog.init(allocator);
                     defer flog.deinit();
 
-                    dsl.executePostInstall(allocator, &formula, post_install_src, prefix, &flog) catch {
-                        if (flog.hasFatal()) {
-                            output.warn("post_install DSL failed for {s} (fatal)", .{job.name});
-                            flog.printFatal(job.name);
-                            break :post_install;
-                        }
-                        if (useSystemRubyForFormula(use_system_ruby_list, job.name)) {
-                            output.warn("post_install DSL incomplete for {s}, falling back to system Ruby...", .{job.name});
-                            ruby_sub.runPostInstall(allocator, job.name, job.version_str, prefix) catch |e| {
-                                output.warn("post_install subprocess failed for {s}: {s}", .{ job.name, @errorName(e) });
-                            };
-                        } else {
-                            output.warn("{s}: post_install partially skipped (use --use-system-ruby={s} to attempt via Ruby)", .{ job.name, job.name });
-                        }
-                        break :post_install;
-                    };
-                    output.info("post_install completed for {s}", .{job.name});
+                    // Error from execute is already reflected in `flog`;
+                    // the outcome router uses the log as the source of
+                    // truth so silent-skips downgrade the same as hard
+                    // failures instead of reading as "completed".
+                    dsl.executePostInstall(allocator, &formula, post_install_src, prefix, &flog) catch {};
+                    routePostInstallOutcome(allocator, job.name, job.version_str, prefix, &flog, use_system_ruby_list);
                     break :post_install;
                 }
             }
@@ -819,22 +843,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
                 var flog = dsl.FallbackLog.init(allocator);
                 defer flog.deinit();
 
-                dsl.executePostInstall(allocator, &formula, post_install_src, prefix, &flog) catch {
-                    if (flog.hasFatal()) {
-                        output.warn("post_install DSL failed for {s} (fatal)", .{job.name});
-                        flog.printFatal(job.name);
-                        break :post_install;
-                    }
-                    if (useSystemRubyForFormula(use_system_ruby_list, job.name)) {
-                        ruby_sub.runPostInstall(allocator, job.name, job.version_str, prefix) catch |e| {
-                            output.warn("post_install subprocess failed for {s}: {s}", .{ job.name, @errorName(e) });
-                        };
-                    } else {
-                        output.warn("{s}: post_install partially skipped (use --use-system-ruby={s} to attempt via Ruby)", .{ job.name, job.name });
-                    }
-                    break :post_install;
-                };
-                output.info("post_install completed for {s}", .{job.name});
+                dsl.executePostInstall(allocator, &formula, post_install_src, prefix, &flog) catch {};
+                routePostInstallOutcome(allocator, job.name, job.version_str, prefix, &flog, use_system_ruby_list);
                 break :post_install;
             }
 

--- a/src/core/dsl/ast.zig
+++ b/src/core/dsl/ast.zig
@@ -47,6 +47,9 @@ pub const MethodCall = struct {
     args: []const *const Node,
     blk: ?*const Node,
     block_params: []const []const u8,
+    /// Ruby's `&<expr>` block-pass arg (commonly `&:sym` for symbol-to-proc).
+    /// Exclusive with `blk`: parser accepts one form per call.
+    block_pass: ?*const Node = null,
 };
 
 pub const StringLiteral = struct {

--- a/src/core/dsl/fallback_log.zig
+++ b/src/core/dsl/fallback_log.zig
@@ -53,26 +53,24 @@ pub const FallbackLog = struct {
     pub fn hasFatal(self: *const FallbackLog) bool {
         for (self.entries.items) |entry| {
             switch (entry.reason) {
-                .sandbox_violation, .system_command_failed, .parse_error => return true,
+                .sandbox_violation, .system_command_failed => return true,
                 else => {},
             }
         }
         return false;
     }
 
-    /// Print every fatal entry to stderr in `tag:line:col: message` form so
-    /// users debugging a broken `post_install` block can jump straight to
-    /// the offending line. `tag` is typically the formula name. The
-    /// non-fatal entries (unknown_method / unsupported_node) are
-    /// intentionally skipped — those drive the `--use-system-ruby`
-    /// fallback flow and would just be noise here.
+    /// Print every fatal-or-diagnostic entry in `tag:line:col: message` form.
+    /// `parse_error` is included so users see the exact file:line:col when the
+    /// DSL falls back to `--use-system-ruby`; it is not treated as fatal by
+    /// `hasFatal`, keeping the salvage path open.
     pub fn printFatal(self: *const FallbackLog, tag: []const u8) void {
         for (self.entries.items) |entry| {
-            const fatal = switch (entry.reason) {
+            const printable = switch (entry.reason) {
                 .sandbox_violation, .system_command_failed, .parse_error => true,
                 else => false,
             };
-            if (!fatal) continue;
+            if (!printable) continue;
             var buf: [1024]u8 = undefined;
             const formatted = if (entry.loc) |loc|
                 std.fmt.bufPrint(&buf, "  {s}:{d}:{d}: [{s}] {s}\n", .{

--- a/src/core/dsl/fallback_log.zig
+++ b/src/core/dsl/fallback_log.zig
@@ -84,6 +84,31 @@ pub const FallbackLog = struct {
         }
     }
 
+    /// Print unknown_method / unsupported_node entries to stderr — the
+    /// log-only reasons that `printFatal` intentionally skips. Called by
+    /// the install CLI under `--verbose` so users can see which helpers
+    /// the DSL silently downgraded instead of only the "partially skipped"
+    /// hint.
+    pub fn printUnknown(self: *const FallbackLog, tag: []const u8) void {
+        for (self.entries.items) |entry| {
+            const unknown = switch (entry.reason) {
+                .unknown_method, .unsupported_node => true,
+                else => false,
+            };
+            if (!unknown) continue;
+            var buf: [1024]u8 = undefined;
+            const formatted = if (entry.loc) |loc|
+                std.fmt.bufPrint(&buf, "  {s}:{d}:{d}: [{s}] {s}\n", .{
+                    tag, loc.line, loc.col, @tagName(entry.reason), entry.detail,
+                }) catch continue
+            else
+                std.fmt.bufPrint(&buf, "  {s}: [{s}] {s}\n", .{
+                    tag, @tagName(entry.reason), entry.detail,
+                }) catch continue;
+            io_mod.stderrWriteAll(formatted);
+        }
+    }
+
     /// Serialize to JSON for telemetry reporting.
     pub fn toJson(self: *const FallbackLog, allocator: std.mem.Allocator) ![]const u8 {
         var aw: std.Io.Writer.Allocating = .init(allocator);

--- a/src/core/dsl/interpreter.zig
+++ b/src/core/dsl/interpreter.zig
@@ -463,6 +463,33 @@ pub const Interpreter = struct {
                 }
             }
 
+            // `&:sym` block-pass on the common Enumerable methods. The symbol
+            // names a receiver builtin invoked per element — same effect as
+            // `{ |x| x.sym }` without the block allocation.
+            if (receiver_val == .array and mc.block_pass != null) {
+                const bp_val = try self.eval(mc.block_pass.?);
+                if (bp_val == .symbol) {
+                    return self.dispatchBlockPassSym(mc.method, receiver_val.array, bp_val.symbol, loc);
+                }
+                self.ctx.fallback_log_writer.log(.{
+                    .formula = self.ctx.formula_name,
+                    .reason = .unsupported_node,
+                    .detail = "block_pass with non-symbol expression",
+                    .loc = loc,
+                });
+            }
+
+            // Block-less `all?` / `any?` — Ruby semantics: truthiness of each element.
+            if (receiver_val == .array and mc.blk == null and mc.block_pass == null) {
+                if (std.mem.eql(u8, mc.method, "all?")) {
+                    for (receiver_val.array) |it| if (!it.isTruthy()) return Value{ .bool = false };
+                    return Value{ .bool = true };
+                } else if (std.mem.eql(u8, mc.method, "any?")) {
+                    for (receiver_val.array) |it| if (it.isTruthy()) return Value{ .bool = true };
+                    return Value{ .bool = false };
+                }
+            }
+
             // Look up in receiver builtins
             if (builtins_root.receiver_builtins.get(mc.method)) |func| {
                 return func(builtin_ctx, receiver_val, args_slice) catch |e| {
@@ -691,6 +718,110 @@ pub const Interpreter = struct {
             if (params.len > 0) self.ctx.setLocal(params[0], item);
             _ = self.eval(blk) catch |e| switch (e) {
                 DslError.PostInstallFailed, DslError.PathSandboxViolation, DslError.ReturnSignal => return e,
+                else => continue,
+            };
+        }
+        return Value{ .nil = {} };
+    }
+
+    /// Dispatch an Enumerable method whose block is `&:sym` shorthand. The
+    /// per-element behavior is "invoke `sym` as a receiver method on the
+    /// item", matched against the existing receiver-builtin table.
+    fn dispatchBlockPassSym(
+        self: *Interpreter,
+        method: []const u8,
+        items: []const Value,
+        sym: []const u8,
+        loc: SourceLoc,
+    ) DslError!Value {
+        if (std.mem.eql(u8, method, "all?")) return self.evalArrayAllByName(items, sym, loc);
+        if (std.mem.eql(u8, method, "any?")) return self.evalArrayAnyByName(items, sym, loc);
+        if (std.mem.eql(u8, method, "map")) return self.evalArrayMapByName(items, sym, loc);
+        if (std.mem.eql(u8, method, "select")) return self.evalArraySelectByName(items, sym, loc);
+        if (std.mem.eql(u8, method, "reject")) return self.evalArrayRejectByName(items, sym, loc);
+        if (std.mem.eql(u8, method, "each")) return self.evalArrayEachByName(items, sym, loc);
+        // Method doesn't route through the &:sym shortcut; log and return nil
+        // so the host formula can continue.
+        self.ctx.fallback_log_writer.log(.{
+            .formula = self.ctx.formula_name,
+            .reason = .unsupported_node,
+            .detail = method,
+            .loc = loc,
+        });
+        return Value{ .nil = {} };
+    }
+
+    /// Send the zero-arg method named `sym` to `item` via the receiver-builtin
+    /// table. Unknown sym is logged non-fatally and yields nil — same policy
+    /// as regular unknown receiver methods.
+    fn sendByName(self: *Interpreter, item: Value, sym: []const u8, loc: SourceLoc) DslError!Value {
+        const builtin_ctx = builtins_root.pathname.ExecCtx{
+            .allocator = self.allocator,
+            .cellar_path = self.ctx.cellar_path,
+            .malt_prefix = self.ctx.malt_prefix,
+        };
+        if (builtins_root.receiver_builtins.get(sym)) |func| {
+            return func(builtin_ctx, item, &.{}) catch |e| mapBuiltinError(e);
+        }
+        self.ctx.fallback_log_writer.log(.{
+            .formula = self.ctx.formula_name,
+            .reason = .unknown_method,
+            .detail = sym,
+            .loc = loc,
+        });
+        return Value{ .nil = {} };
+    }
+
+    fn evalArrayAllByName(self: *Interpreter, items: []const Value, sym: []const u8, loc: SourceLoc) DslError!Value {
+        for (items) |item| {
+            const v = try self.sendByName(item, sym, loc);
+            if (!v.isTruthy()) return Value{ .bool = false };
+        }
+        return Value{ .bool = true };
+    }
+
+    fn evalArrayAnyByName(self: *Interpreter, items: []const Value, sym: []const u8, loc: SourceLoc) DslError!Value {
+        for (items) |item| {
+            const v = try self.sendByName(item, sym, loc);
+            if (v.isTruthy()) return Value{ .bool = true };
+        }
+        return Value{ .bool = false };
+    }
+
+    fn evalArrayMapByName(self: *Interpreter, items: []const Value, sym: []const u8, loc: SourceLoc) DslError!Value {
+        var out: std.ArrayList(Value) = .empty;
+        for (items) |item| {
+            const v = try self.sendByName(item, sym, loc);
+            out.append(self.allocator, v) catch return DslError.OutOfMemory;
+        }
+        const slice = out.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
+        return Value{ .array = slice };
+    }
+
+    fn evalArraySelectByName(self: *Interpreter, items: []const Value, sym: []const u8, loc: SourceLoc) DslError!Value {
+        var out: std.ArrayList(Value) = .empty;
+        for (items) |item| {
+            const v = try self.sendByName(item, sym, loc);
+            if (v.isTruthy()) out.append(self.allocator, item) catch return DslError.OutOfMemory;
+        }
+        const slice = out.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
+        return Value{ .array = slice };
+    }
+
+    fn evalArrayRejectByName(self: *Interpreter, items: []const Value, sym: []const u8, loc: SourceLoc) DslError!Value {
+        var out: std.ArrayList(Value) = .empty;
+        for (items) |item| {
+            const v = try self.sendByName(item, sym, loc);
+            if (!v.isTruthy()) out.append(self.allocator, item) catch return DslError.OutOfMemory;
+        }
+        const slice = out.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
+        return Value{ .array = slice };
+    }
+
+    fn evalArrayEachByName(self: *Interpreter, items: []const Value, sym: []const u8, loc: SourceLoc) DslError!Value {
+        for (items) |item| {
+            _ = self.sendByName(item, sym, loc) catch |e| switch (e) {
+                DslError.PostInstallFailed, DslError.PathSandboxViolation => return e,
                 else => continue,
             };
         }

--- a/src/core/dsl/lexer.zig
+++ b/src/core/dsl/lexer.zig
@@ -181,8 +181,11 @@ pub const Lexer = struct {
             }
         }
 
-        // Symbol literal :name
-        if (c == ':' and self.remaining() > 1) {
+        // `:` starts a symbol (`:name`) or the `:` side of a hash rocket;
+        // `::` is the module separator, handled by `lexOperator`. Check
+        // for `::` first so it isn't split into two colons (regression
+        // observed in `Hardware::CPU.arch` and similar Homebrew idioms).
+        if (c == ':' and self.remaining() > 1 and self.source[self.pos + 1] != ':') {
             const next_c = self.source[self.pos + 1];
             if (std.ascii.isAlphabetic(next_c) or next_c == '_') {
                 return self.lexSymbol();

--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -236,15 +236,21 @@ pub const Parser = struct {
             return self.parseEachWithReceiver(receiver, loc);
         }
 
-        // Parse arguments
+        // Parse arguments — paren list may end with `&<primary>` (block-pass).
         var args: std.ArrayList(*const Node) = .empty;
+        var block_pass: ?*const Node = null;
         if (self.current.kind == .lparen) {
             self.advanceToken();
             while (self.current.kind != .rparen and self.current.kind != .eof) {
                 self.skipNewlines();
                 if (self.current.kind == .rparen) break;
-                const arg = try self.parseExpression();
-                args.append(self.allocator, arg) catch return DslError.OutOfMemory;
+                switch (try self.parseOneArg()) {
+                    .arg => |a| args.append(self.allocator, a) catch return DslError.OutOfMemory,
+                    .block_pass => |bp| {
+                        block_pass = bp;
+                        break;
+                    },
+                }
                 self.skipNewlines();
                 if (self.current.kind == .comma) {
                     self.advanceToken();
@@ -266,8 +272,13 @@ pub const Parser = struct {
             while (self.current.kind == .comma) {
                 self.advanceToken();
                 self.skipNewlines();
-                const next_arg = try self.parseExpression();
-                args.append(self.allocator, next_arg) catch return DslError.OutOfMemory;
+                switch (try self.parseOneArg()) {
+                    .arg => |a| args.append(self.allocator, a) catch return DslError.OutOfMemory,
+                    .block_pass => |bp| {
+                        block_pass = bp;
+                        break;
+                    },
+                }
             }
         }
 
@@ -305,6 +316,7 @@ pub const Parser = struct {
                 .args = args_slice,
                 .blk = blk,
                 .block_params = params_slice,
+                .block_pass = block_pass,
             } },
         });
     }
@@ -605,13 +617,19 @@ pub const Parser = struct {
                     self.current.kind != .dot)
                 {
                     var args: std.ArrayList(*const Node) = .empty;
+                    var block_pass: ?*const Node = null;
                     const arg = try self.parseExpression();
                     args.append(self.allocator, arg) catch return DslError.OutOfMemory;
                     while (self.current.kind == .comma) {
                         self.advanceToken();
                         self.skipNewlines();
-                        const next_arg = try self.parseExpression();
-                        args.append(self.allocator, next_arg) catch return DslError.OutOfMemory;
+                        switch (try self.parseOneArg()) {
+                            .arg => |a| args.append(self.allocator, a) catch return DslError.OutOfMemory,
+                            .block_pass => |bp| {
+                                block_pass = bp;
+                                break;
+                            },
+                        }
                     }
 
                     // Parse optional block
@@ -648,18 +666,25 @@ pub const Parser = struct {
                             .args = args_slice,
                             .blk = blk,
                             .block_params = params_slice,
+                            .block_pass = block_pass,
                         } },
                     });
                 }
 
                 // Non-bare method call with parens: method(args)
                 if (self.current.kind == .lparen) {
-                    // method(args)
+                    // method(args) — may end with `&<primary>` block-pass.
                     self.advanceToken();
                     var args: std.ArrayList(*const Node) = .empty;
+                    var block_pass: ?*const Node = null;
                     while (self.current.kind != .rparen and self.current.kind != .eof) {
-                        const arg = try self.parseExpression();
-                        args.append(self.allocator, arg) catch return DslError.OutOfMemory;
+                        switch (try self.parseOneArg()) {
+                            .arg => |a| args.append(self.allocator, a) catch return DslError.OutOfMemory,
+                            .block_pass => |bp| {
+                                block_pass = bp;
+                                break;
+                            },
+                        }
                         if (self.current.kind == .comma) {
                             self.advanceToken();
                             self.skipNewlines();
@@ -701,6 +726,7 @@ pub const Parser = struct {
                             .args = args_slice,
                             .blk = blk,
                             .block_params = params_slice,
+                            .block_pass = block_pass,
                         } },
                     });
                 }
@@ -716,13 +742,19 @@ pub const Parser = struct {
                     self.current.kind != .dot)
                 {
                     var args: std.ArrayList(*const Node) = .empty;
+                    var block_pass: ?*const Node = null;
                     const arg = try self.parseExpression();
                     args.append(self.allocator, arg) catch return DslError.OutOfMemory;
                     while (self.current.kind == .comma) {
                         self.advanceToken();
                         self.skipNewlines();
-                        const next_arg = try self.parseExpression();
-                        args.append(self.allocator, next_arg) catch return DslError.OutOfMemory;
+                        switch (try self.parseOneArg()) {
+                            .arg => |a| args.append(self.allocator, a) catch return DslError.OutOfMemory,
+                            .block_pass => |bp| {
+                                block_pass = bp;
+                                break;
+                            },
+                        }
                     }
 
                     // Parse optional block
@@ -759,6 +791,7 @@ pub const Parser = struct {
                             .args = args_slice,
                             .blk = blk,
                             .block_params = params_slice,
+                            .block_pass = block_pass,
                         } },
                     });
                 }
@@ -1143,6 +1176,24 @@ pub const Parser = struct {
         }
 
         return parts_list.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
+    }
+
+    /// Parse a single arg inside a method-call arg list. Returns either a
+    /// positional expression node or a block-pass payload (`&<primary>`).
+    /// Block-pass is always the last arg per Ruby grammar; callers break
+    /// out of their arg loop when they see one.
+    const ArgOutcome = union(enum) {
+        arg: *const Node,
+        block_pass: *const Node,
+    };
+
+    fn parseOneArg(self: *Parser) DslError!ArgOutcome {
+        if (self.current.kind == .ampersand) {
+            self.advanceToken();
+            const inner = try self.parsePrimary();
+            return .{ .block_pass = inner };
+        }
+        return .{ .arg = try self.parseExpression() };
     }
 
     fn parseBlockParams(self: *Parser, params: *std.ArrayList([]const u8)) DslError!void {

--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -822,15 +822,42 @@ pub const Parser = struct {
                 });
             },
             .lbrace => {
-                // Hash literal
+                // Hash literal. Ruby's shorthand `{ name: value }` lowers
+                // to a symbol key — recognise the `identifier:` case so
+                // it doesn't get resolved as an unknown method/identifier
+                // at interpret time.
                 self.advanceToken();
                 var entries: std.ArrayList(ast.HashEntry) = .empty;
                 while (self.current.kind != .rbrace and self.current.kind != .eof) {
                     self.skipNewlines();
                     if (self.current.kind == .rbrace) break;
 
-                    const key = try self.parseExpression();
+                    const key_loc = self.currentLoc();
+                    var key: *const Node = undefined;
+                    // Peek: if we see `identifier : ...` (single colon, not `::`),
+                    // treat the identifier as a symbol literal.
+                    if (self.current.kind == .identifier) {
+                        const lex_before = self.lexer.*;
+                        const ident_lexeme = self.current.lexeme;
+                        self.advanceToken();
+                        if (self.current.kind == .colon) {
+                            self.advanceToken();
+                            key = try self.allocNode(.{
+                                .loc = key_loc,
+                                .kind = .{ .symbol_literal = ident_lexeme },
+                            });
+                            const value = try self.parseExpression();
+                            entries.append(self.allocator, .{ .key = key, .value = value }) catch return DslError.OutOfMemory;
+                            self.skipNewlines();
+                            if (self.current.kind == .comma) self.advanceToken();
+                            continue;
+                        }
+                        // Not shorthand — rewind and parse as a full expression.
+                        self.lexer.* = lex_before;
+                        self.current = self.lexer.next();
+                    }
 
+                    key = try self.parseExpression();
                     if (self.current.kind == .fat_arrow) {
                         self.advanceToken();
                     } else if (self.current.kind == .colon) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -184,6 +184,8 @@ pub fn main(init: std.process.Init.Minimal) !void {
         }
         if (std.mem.eql(u8, arg, "--verbose") or std.mem.eql(u8, arg, "-v")) {
             output.setVerbose(true);
+        } else if (std.mem.eql(u8, arg, "--debug")) {
+            output.setDebug(true);
         } else if (std.mem.eql(u8, arg, "--quiet") or std.mem.eql(u8, arg, "-q")) {
             output.setQuiet(true);
         } else if (std.mem.eql(u8, arg, "--json")) {
@@ -290,6 +292,8 @@ fn printUsage() void {
         \\
         \\Global flags:
         \\  --verbose, -v   Verbose output
+        \\  --debug         Surface every DSL diagnostic (implies verbose);
+        \\                  pair with issue reports for full context
         \\  --quiet, -q     Suppress non-error output
         \\  --json          JSON output (read commands)
         \\  --dry-run       Preview without executing

--- a/src/ui/io.zig
+++ b/src/ui/io.zig
@@ -46,10 +46,12 @@ pub fn stderrFile() std.Io.File {
     return std.Io.File.stderr();
 }
 
-/// Test-only stderr capture. Tests run sequentially in a binary, so no
-/// lock; elided from release via `builtin.is_test` guards.
+/// Test-only stderr / stdout capture. Tests run sequentially in a binary,
+/// so no lock; elided from release via `builtin.is_test` guards.
 var capture_list: ?*std.ArrayList(u8) = null;
 var capture_allocator: std.mem.Allocator = undefined;
+var stdout_capture_list: ?*std.ArrayList(u8) = null;
+var stdout_capture_allocator: std.mem.Allocator = undefined;
 
 /// Test-only: redirect `stderrWriteAll` into `buf`. Pair with `endStderrCapture`.
 pub fn beginStderrCapture(allocator: std.mem.Allocator, buf: *std.ArrayList(u8)) void {
@@ -64,6 +66,19 @@ pub fn endStderrCapture() void {
     capture_list = null;
 }
 
+/// Test-only: redirect `stdoutWriteAll` into `buf`. Pair with `endStdoutCapture`.
+/// Needed for asserting JSON-mode payloads that land on stdout.
+pub fn beginStdoutCapture(allocator: std.mem.Allocator, buf: *std.ArrayList(u8)) void {
+    if (!builtin.is_test) return;
+    stdout_capture_list = buf;
+    stdout_capture_allocator = allocator;
+}
+
+pub fn endStdoutCapture() void {
+    if (!builtin.is_test) return;
+    stdout_capture_list = null;
+}
+
 pub fn stderrWriteAll(bytes: []const u8) void {
     if (builtin.is_test) {
         if (capture_list) |list| {
@@ -75,5 +90,11 @@ pub fn stderrWriteAll(bytes: []const u8) void {
 }
 
 pub fn stdoutWriteAll(bytes: []const u8) void {
+    if (builtin.is_test) {
+        if (stdout_capture_list) |list| {
+            list.appendSlice(stdout_capture_allocator, bytes) catch {};
+            return;
+        }
+    }
     stdoutFile().writeStreamingAll(ctx(), bytes) catch return;
 }

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -13,6 +13,7 @@ pub const OutputMode = enum {
 
 var quiet: bool = false;
 var verbose: bool = false;
+var debug: bool = false;
 var dry_run: bool = false;
 var mode: OutputMode = .human;
 
@@ -21,6 +22,13 @@ pub fn setQuiet(q: bool) void {
 }
 pub fn setVerbose(v: bool) void {
     verbose = v;
+}
+/// Enable debug mode — prints every logged diagnostic the CLI collects,
+/// so users filing issues can attach a single transcript that captures
+/// what the DSL/interpreter saw. Implies verbose.
+pub fn setDebug(d: bool) void {
+    debug = d;
+    if (d) verbose = true;
 }
 pub fn setDryRun(d: bool) void {
     dry_run = d;
@@ -33,6 +41,9 @@ pub fn isQuiet() bool {
 }
 pub fn isVerbose() bool {
     return verbose;
+}
+pub fn isDebug() bool {
+    return debug;
 }
 pub fn isDryRun() bool {
     return dry_run;

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -1522,7 +1522,9 @@ test "parse_error: malformed source populates fallback log with location" {
     // The diagnostics from Parser.diagnostics should now be on the log
     // tagged as parse_error and carrying their source location, so the
     // CLI can print "<formula>:<line>:<col>: <message>" for the user.
-    try testing.expect(flog.hasFatal());
+    // parse_error is no longer fatal — it's logged with loc for the CLI
+    // but must not suppress the --use-system-ruby salvage path.
+    try testing.expect(!flog.hasFatal());
 
     var saw_parse_error = false;
     for (flog.entries.items) |entry| {
@@ -1781,4 +1783,96 @@ test "interpreter: return from inside .each exits the enclosing def" {
     // no-op and the return-if-count==2 never fires. Accept whatever
     // err comes back — the important invariant is that the snippet
     // doesn't explode when `return` crosses a block boundary.
+}
+
+// ---------------------------------------------------------------------------
+// Block-pass (&:symbol) — the llvm@21 regression.
+//
+// `config_files.all?(&:exist?)` must both parse and evaluate so that the
+// native DSL path keeps pace with real homebrew-core formulas.
+// ---------------------------------------------------------------------------
+
+test "interpreter: array.all?(&:exist?) is true when every path exists" {
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    // Both dirs exist → `all?` is true → `odie unless ...` is skipped.
+    const src =
+        \\a = share/"a"
+        \\b = share/"b"
+        \\a.mkpath
+        \\b.mkpath
+        \\odie "at least one path missing" unless [a, b].all?(&:exist?)
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
+}
+
+test "interpreter: array.all?(&:exist?) is false when any path is missing" {
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    // `b` was never created → `all?` is false → `odie` fires → PostInstallFailed.
+    const src =
+        \\a = share/"a"
+        \\b = share/"b_absent"
+        \\a.mkpath
+        \\odie "expected failure" unless [a, b].all?(&:exist?)
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expectEqual(@as(?dsl.DslError, dsl.DslError.PostInstallFailed), err);
+}
+
+test "interpreter: array.any?(&:exist?) reflects membership" {
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    // Only `a` exists → `any?` is true → `odie` is skipped.
+    const src =
+        \\a = share/"a"
+        \\b = share/"b_absent"
+        \\a.mkpath
+        \\odie "expected no failure" unless [a, b].any?(&:exist?)
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
+}
+
+test "interpreter: array.map(&:exist?) threads the sym-to-proc block" {
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    // Map yields [true, false]; all? over that is false, so odie fires.
+    const src =
+        \\a = share/"a"
+        \\b = share/"missing"
+        \\a.mkpath
+        \\odie "mapped false present" unless [a, b].map(&:exist?).all?
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expectEqual(@as(?dsl.DslError, dsl.DslError.PostInstallFailed), err);
+}
+
+test "interpreter: llvm@21 post_install shape runs to completion" {
+    // End-to-end reproduction of the #85 failure. With block-pass +
+    // parse_error non-fatal, the snippet must no longer explode on line 9.
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    const src =
+        \\config_files = [share/"a.cfg", share/"b.cfg"]
+        \\return if config_files.all?(&:exist?)
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
 }

--- a/tests/dsl_lexer_test.zig
+++ b/tests/dsl_lexer_test.zig
@@ -428,3 +428,42 @@ test "lexer: method with bang suffix" {
     try expectToken(&lex, .identifier, "gsub!");
     try expectKind(&lex, .eof);
 }
+
+// `::` is Ruby's module/constant separator. Real formulas use it heavily
+// (`Hardware::CPU.arch`, `MacOS::CLT::PKG_PATH`), so ensure the lexer emits
+// a single `double_colon` token and not two `colon` tokens — regression
+// traced to llvm@21's post_install.
+test "lexer: :: is a single double_colon token" {
+    var lex = Lexer.init("A::B");
+    try expectToken(&lex, .identifier, "A");
+    try expectKind(&lex, .double_colon);
+    try expectToken(&lex, .identifier, "B");
+    try expectKind(&lex, .eof);
+}
+
+test "lexer: nested module path A::B::C" {
+    var lex = Lexer.init("Hardware::CPU::arch");
+    try expectToken(&lex, .identifier, "Hardware");
+    try expectKind(&lex, .double_colon);
+    try expectToken(&lex, .identifier, "CPU");
+    try expectKind(&lex, .double_colon);
+    try expectToken(&lex, .identifier, "arch");
+    try expectKind(&lex, .eof);
+}
+
+test "lexer: symbol-vs-module-separator still lexes :sym correctly" {
+    // The fix for `::` must NOT break the `:sym` symbol path.
+    var lex = Lexer.init(":exist?");
+    try expectToken(&lex, .symbol, ":exist?");
+    try expectKind(&lex, .eof);
+}
+
+test "lexer: bare colon (hash rocket lhs) remains a single colon" {
+    var lex = Lexer.init("{ foo: 1 }");
+    try expectKind(&lex, .lbrace);
+    try expectToken(&lex, .identifier, "foo");
+    try expectKind(&lex, .colon);
+    try expectToken(&lex, .integer, "1");
+    try expectKind(&lex, .rbrace);
+    try expectKind(&lex, .eof);
+}

--- a/tests/dsl_parser_test.zig
+++ b/tests/dsl_parser_test.zig
@@ -830,3 +830,71 @@ test "parser: def body with return short-circuit" {
         else => return error.TestUnexpectedResult,
     }
 }
+
+// ---------------------------------------------------------------------------
+// Block-pass argument (&:symbol) — Ruby's symbol-to-proc shorthand.
+//
+// Regression: llvm@21's `post_install` uses `config_files.all?(&:exist?)`;
+// the parser must accept `&<primary>` inside any arg list and expose it on
+// `MethodCall.block_pass` instead of tripping "unexpected token".
+// ---------------------------------------------------------------------------
+
+test "parser: block-pass with symbol on receiver method call" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "xs.all?(&:exist?)");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+
+    const mc = nodes[0].kind.method_call;
+    try testing.expectEqualStrings("all?", mc.method);
+    try testing.expectEqual(@as(usize, 0), mc.args.len);
+    try testing.expect(mc.block_pass != null);
+    try testing.expectEqualStrings("exist?", mc.block_pass.?.kind.symbol_literal);
+}
+
+test "parser: block-pass mixed with regular positional arg" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "xs.inject(0, &:plus)");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+
+    const mc = nodes[0].kind.method_call;
+    try testing.expectEqualStrings("inject", mc.method);
+    try testing.expectEqual(@as(usize, 1), mc.args.len);
+    try testing.expectEqual(@as(i64, 0), mc.args[0].kind.int_literal);
+    try testing.expect(mc.block_pass != null);
+    try testing.expectEqualStrings("plus", mc.block_pass.?.kind.symbol_literal);
+}
+
+test "parser: block-pass on bare paren call" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "foo(&:bar)");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+
+    const mc = nodes[0].kind.method_call;
+    try testing.expectEqualStrings("foo", mc.method);
+    try testing.expect(mc.block_pass != null);
+    try testing.expectEqualStrings("bar", mc.block_pass.?.kind.symbol_literal);
+}
+
+test "parser: llvm@21 post_install snippet parses with block-pass" {
+    // Distilled from llvm@21.rb — reproduces the original `unexpected token`.
+    var arena = testArena();
+    defer arena.deinit();
+
+    const src =
+        \\config_files = [bin/"a", bin/"b"]
+        \\return if config_files.all?(&:exist?)
+    ;
+    const nodes = try parseSource(&arena, src);
+    try testing.expectEqual(@as(usize, 2), nodes.len);
+
+    const postfix = nodes[1].kind.postfix_if;
+    const cond_mc = postfix.condition.kind.method_call;
+    try testing.expectEqualStrings("all?", cond_mc.method);
+    try testing.expect(cond_mc.block_pass != null);
+}

--- a/tests/fallback_log_test.zig
+++ b/tests/fallback_log_test.zig
@@ -23,7 +23,7 @@ test "hasErrors is true once any entry is logged" {
     try testing.expect(!log.hasFatal()); // unknown_method is non-fatal
 }
 
-test "hasFatal picks up sandbox_violation, system_command_failed and parse_error" {
+test "hasFatal picks up sandbox_violation and system_command_failed" {
     var log_a = FallbackLog.init(testing.allocator);
     defer log_a.deinit();
     log_a.log(.{ .formula = "f", .reason = .sandbox_violation, .detail = "d", .loc = null });
@@ -38,11 +38,18 @@ test "hasFatal picks up sandbox_violation, system_command_failed and parse_error
     defer log_c.deinit();
     log_c.log(.{ .formula = "f", .reason = .unsupported_node, .detail = "d", .loc = null });
     try testing.expect(!log_c.hasFatal());
+}
 
-    var log_d = FallbackLog.init(testing.allocator);
-    defer log_d.deinit();
-    log_d.log(.{ .formula = "f", .reason = .parse_error, .detail = "expected end", .loc = .{ .line = 4, .col = 1 } });
-    try testing.expect(log_d.hasFatal());
+// parse_error used to be fatal, which also killed the --use-system-ruby
+// fallback path. Now it's logged with loc for the CLI but treated as
+// recoverable so formulas using constructs the native DSL doesn't know
+// yet can still be salvaged by the Ruby subprocess.
+test "hasFatal does NOT trip on parse_error (fallback path stays open)" {
+    var log = FallbackLog.init(testing.allocator);
+    defer log.deinit();
+    log.log(.{ .formula = "f", .reason = .parse_error, .detail = "unexpected token", .loc = .{ .line = 4, .col = 1 } });
+    try testing.expect(log.hasErrors());
+    try testing.expect(!log.hasFatal());
 }
 
 test "printFatal does not crash on empty / fatal / non-fatal mixes" {

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -475,3 +475,194 @@ test "routePostInstallOutcome: scope with unrelated names is ignored" {
     try testing.expect(std.mem.indexOf(u8, out, "falling back to system Ruby") == null);
     try testing.expect(std.mem.indexOf(u8, out, "partially skipped (use --use-system-ruby=foo") != null);
 }
+
+// ---------------------------------------------------------------------------
+// routePostInstallOutcome under --verbose / --debug — the diagnostic dump
+// is what lets users (and bug reports) see WHICH helpers the DSL skipped.
+// ---------------------------------------------------------------------------
+
+test "routePostInstallOutcome: --verbose dumps unknown_method entries after the hint" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.log(.{ .formula = "foo", .reason = .unknown_method, .detail = "quiet_system", .loc = .{ .line = 4, .col = 6 } });
+    flog.log(.{ .formula = "foo", .reason = .unsupported_node, .detail = "default_args", .loc = null });
+
+    const prior = output_mod.isVerbose();
+    output_mod.setVerbose(true);
+    defer output_mod.setVerbose(prior);
+
+    const out = try runRoute(&flog, "foo", &.{});
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "partially skipped") != null);
+    // Both reasons surface, with/without source location.
+    try testing.expect(std.mem.indexOf(u8, out, "foo:4:6: [unknown_method] quiet_system") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "foo: [unsupported_node] default_args") != null);
+}
+
+test "routePostInstallOutcome: --debug surfaces fatal entries alongside the hint" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    // Non-fatal unknown + a parse_error diagnostic — debug prints both.
+    flog.log(.{ .formula = "foo", .reason = .unknown_method, .detail = "helper", .loc = null });
+    flog.log(.{ .formula = "foo", .reason = .parse_error, .detail = "unexpected token", .loc = .{ .line = 1, .col = 1 } });
+
+    const prior_v = output_mod.isVerbose();
+    const prior_d = output_mod.isDebug();
+    output_mod.setDebug(true);
+    defer {
+        output_mod.setVerbose(prior_v);
+        // No setter to un-debug a flag — reset via setDebug(false).
+        output_mod.setDebug(prior_d);
+    }
+
+    const out = try runRoute(&flog, "foo", &.{});
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "partially skipped") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "[unknown_method] helper") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "[parse_error] unexpected token") != null);
+}
+
+test "routePostInstallOutcome: fatal + --debug also prints non-fatal context" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.log(.{ .formula = "z", .reason = .sandbox_violation, .detail = "/etc/passwd", .loc = null });
+    flog.log(.{ .formula = "z", .reason = .unknown_method, .detail = "tangential_helper", .loc = null });
+
+    const prior_d = output_mod.isDebug();
+    output_mod.setDebug(true);
+    defer output_mod.setDebug(prior_d);
+
+    const out = try runRoute(&flog, "z", &.{});
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "DSL failed for z (fatal)") != null);
+    // Sandbox violation surfaces via printFatal; tangential helper via printUnknown.
+    try testing.expect(std.mem.indexOf(u8, out, "[sandbox_violation] /etc/passwd") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "[unknown_method] tangential_helper") != null);
+}
+
+// ---------------------------------------------------------------------------
+// routePostInstallOutcome under --json — one structured line per package
+// so scripted pipelines can tell completed / partial / fatal apart.
+// ---------------------------------------------------------------------------
+
+fn runRouteCaptureStdout(
+    flog: *const dsl.FallbackLog,
+    name: []const u8,
+    scope: []const []const u8,
+) ![]u8 {
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    errdefer stdout_buf.deinit(testing.allocator);
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(testing.allocator);
+
+    color_mod.setForTest(false, false);
+    defer color_mod.setForTest(null, null);
+
+    const prior_mode_is_json = output_mod.isJson();
+    output_mod.setMode(.json);
+    defer output_mod.setMode(if (prior_mode_is_json) .json else .human);
+
+    io_mod.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer io_mod.endStdoutCapture();
+    io_mod.beginStderrCapture(testing.allocator, &stderr_buf);
+    defer io_mod.endStderrCapture();
+
+    install.routePostInstallOutcome(testing.allocator, name, "1.0", "/tmp/irrelevant", flog, scope);
+    return stdout_buf.toOwnedSlice(testing.allocator);
+}
+
+test "routePostInstallOutcome: --json emits one status line with escaped name" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.log(.{ .formula = "llvm@21", .reason = .unknown_method, .detail = "write_config_files", .loc = .{ .line = 8, .col = 3 } });
+
+    const out = try runRouteCaptureStdout(&flog, "llvm@21", &.{});
+    defer testing.allocator.free(out);
+
+    // Shape: `{"event":"post_install","name":"llvm@21","status":"partially_skipped","entries":[...]}\n`
+    try testing.expect(std.mem.endsWith(u8, out, "\n"));
+    try testing.expect(std.mem.indexOf(u8, out, "\"event\":\"post_install\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"name\":\"llvm@21\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"status\":\"partially_skipped\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"reason\":\"unknown_method\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"detail\":\"write_config_files\"") != null);
+
+    // Round-trip through std.json to confirm the line is parser-clean.
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, out, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("llvm@21", parsed.value.object.get("name").?.string);
+    try testing.expectEqualStrings("partially_skipped", parsed.value.object.get("status").?.string);
+}
+
+test "routePostInstallOutcome: --json status=completed for clean flog" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    const out = try runRouteCaptureStdout(&flog, "wget", &.{});
+    defer testing.allocator.free(out);
+    try testing.expect(std.mem.indexOf(u8, out, "\"status\":\"completed\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"entries\":[]") != null);
+}
+
+test "routePostInstallOutcome: --json status=fatal on sandbox violation" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.log(.{ .formula = "bad", .reason = .sandbox_violation, .detail = "/etc/passwd", .loc = null });
+    const out = try runRouteCaptureStdout(&flog, "bad", &.{});
+    defer testing.allocator.free(out);
+    try testing.expect(std.mem.indexOf(u8, out, "\"status\":\"fatal\"") != null);
+}
+
+// ---------------------------------------------------------------------------
+// Invariants — pinned as tests so future refactors can't drift them silently:
+//   - per-formula FallbackLog isolation
+//   - deferred cleanup fires on labelled break
+//   - multiple non-fatal entries emit a single partial-skip warning
+//   - unknown scope names can't pass as `--use-system-ruby` matches
+// ---------------------------------------------------------------------------
+
+test "invariant: two FallbackLogs stay isolated (per-formula scope)" {
+    var a = dsl.FallbackLog.init(testing.allocator);
+    defer a.deinit();
+    var b = dsl.FallbackLog.init(testing.allocator);
+    defer b.deinit();
+
+    a.log(.{ .formula = "a", .reason = .unknown_method, .detail = "a_helper", .loc = null });
+    try testing.expect(a.hasErrors());
+    try testing.expect(!b.hasErrors());
+    try testing.expectEqual(@as(usize, 1), a.entries.items.len);
+    try testing.expectEqual(@as(usize, 0), b.entries.items.len);
+}
+
+test "invariant: router emits exactly one partially-skipped warn regardless of entry count" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    // 10 entries shouldn't yield 10 warnings — the hint is per-package.
+    var i: usize = 0;
+    while (i < 10) : (i += 1) {
+        flog.log(.{ .formula = "f", .reason = .unknown_method, .detail = "x", .loc = null });
+    }
+    const out = try runRoute(&flog, "f", &.{});
+    defer testing.allocator.free(out);
+
+    // One "partially skipped" line with the package name — count occurrences.
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, out, "partially skipped"));
+}
+
+test "invariant: defer fires on labelled break (FallbackLog no-leak)" {
+    // Smokes the control-flow that the install loop uses every iteration.
+    var leaked = false;
+    outer: {
+        var list: std.ArrayList(u8) = .empty;
+        defer list.deinit(testing.allocator);
+        list.append(testing.allocator, 'x') catch {
+            leaked = true;
+            break :outer;
+        };
+        // Labelled break — the Zig runtime MUST still run the defer above.
+        break :outer;
+    }
+    try testing.expect(!leaked);
+}

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -351,3 +351,127 @@ test "findFailedDep returns null when no dep is in the failed set" {
     ;
     try testing.expect(install.findFailedDep(&failed, json) == null);
 }
+
+// ---------------------------------------------------------------------------
+// routePostInstallOutcome — branch coverage driven by a synthetic fallback
+// log. The router is where "completed" gets its real meaning (zero logged
+// entries) and where silent unknown_method entries now surface the
+// `--use-system-ruby` hint instead of passing under the radar.
+// ---------------------------------------------------------------------------
+
+const dsl = @import("malt").dsl;
+const io_mod = @import("malt").io_mod;
+const color_mod = @import("malt").color;
+const output_mod = @import("malt").output;
+
+/// Capture stderr output from a single router call and return the raw
+/// bytes. Caller owns the buffer. Deterministic state (no color / no
+/// emoji / not quiet) so the assertions pin plain ASCII prefixes.
+fn runRoute(
+    flog: *const dsl.FallbackLog,
+    name: []const u8,
+    scope: []const []const u8,
+) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(testing.allocator);
+
+    color_mod.setForTest(false, false);
+    defer color_mod.setForTest(null, null);
+    const prior_quiet = output_mod.isQuiet();
+    output_mod.setQuiet(false);
+    defer output_mod.setQuiet(prior_quiet);
+
+    io_mod.beginStderrCapture(testing.allocator, &buf);
+    defer io_mod.endStderrCapture();
+
+    install.routePostInstallOutcome(testing.allocator, name, "1.0", "/tmp/irrelevant", flog, scope);
+
+    return buf.toOwnedSlice(testing.allocator);
+}
+
+test "routePostInstallOutcome: clean flog prints a 'completed' info line" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+
+    const out = try runRoute(&flog, "wget", &.{});
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "post_install completed for wget") != null);
+    // Never suggest the Ruby fallback on clean runs.
+    try testing.expect(std.mem.indexOf(u8, out, "--use-system-ruby") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "fatal") == null);
+}
+
+test "routePostInstallOutcome: non-fatal entry surfaces the --use-system-ruby hint" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.log(.{
+        .formula = "wget",
+        .reason = .unknown_method,
+        .detail = "some_helper",
+        .loc = .{ .line = 2, .col = 3 },
+    });
+
+    const out = try runRoute(&flog, "wget", &.{});
+    defer testing.allocator.free(out);
+
+    // Downgrade: "completed" must NOT appear — silent skip ≠ success.
+    try testing.expect(std.mem.indexOf(u8, out, "post_install completed") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "partially skipped") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "--use-system-ruby=wget") != null);
+}
+
+test "routePostInstallOutcome: --use-system-ruby=NAME in scope triggers the Ruby fallback banner" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.log(.{
+        .formula = "openssl@3",
+        .reason = .unsupported_node,
+        .detail = "keyword_args",
+        .loc = null,
+    });
+
+    const scope = [_][]const u8{"openssl@3"};
+    const out = try runRoute(&flog, "openssl@3", scope[0..]);
+    defer testing.allocator.free(out);
+
+    // The fallback banner leads the warning so users know the Ruby
+    // subprocess is about to run — not the "partially skipped" hint.
+    try testing.expect(std.mem.indexOf(u8, out, "falling back to system Ruby") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "partially skipped") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "post_install completed") == null);
+}
+
+test "routePostInstallOutcome: fatal entry wins over hasErrors heuristic" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.log(.{
+        .formula = "evil",
+        .reason = .sandbox_violation,
+        .detail = "/etc/passwd",
+        .loc = .{ .line = 1, .col = 1 },
+    });
+    // A fatal entry must short-circuit even if --use-system-ruby is in
+    // scope — sandbox violations are never delegated to Ruby.
+    const scope = [_][]const u8{"evil"};
+    const out = try runRoute(&flog, "evil", scope[0..]);
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "post_install DSL failed for evil (fatal)") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "falling back to system Ruby") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "post_install completed") == null);
+}
+
+test "routePostInstallOutcome: scope with unrelated names is ignored" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.log(.{ .formula = "foo", .reason = .unknown_method, .detail = "x", .loc = null });
+
+    // `--use-system-ruby=other` shouldn't catch "foo".
+    const scope = [_][]const u8{"other"};
+    const out = try runRoute(&flog, "foo", scope[0..]);
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "falling back to system Ruby") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "partially skipped (use --use-system-ruby=foo") != null);
+}


### PR DESCRIPTION
## Summary

Real homebrew-core formulas use Ruby constructs our DSL couldn't parse — `&:sym` block-pass, `Hardware::CPU.arch` module paths, `{ name: value }` hash shorthand. Bodies using them aborted with `parse_error` and silently skipped; `llvm@21` (pulled by `mt install zig`) was the canonical case.

After this PR:

- Those shapes parse + execute natively. `mt install zig` no longer trips a `parse_error`; the body runs until it meets a builtin we haven't implemented yet.
- The fallback log is the single source of truth. `post_install completed` means exactly that — zero logged entries; any `unknown_method` / `unsupported_node` surfaces the same `--use-system-ruby=<name>` hint  the error path showed, so silent skips no longer read as success.
- New `--debug` global flag prints every DSL diagnostic so bug reports  capture *which* helpers we don't speak yet.
- `--json` emits one structured `post_install` status line per package for  scripted pipelines.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)