### PR TITLE
feat(dsl): Version-style accessors on strings (.major/.minor/.patch/.to_i)

### DIFF
--- a/src/core/dsl/builtins/root.zig
+++ b/src/core/dsl/builtins/root.zig
@@ -121,4 +121,11 @@ pub const receiver_builtins = std.StaticStringMap(BuiltinFn).initComptime(.{
     .{ "length", string.length },
     .{ "size", string.length },
     .{ "+", string.concat },
+
+    // Version-style accessors on strings — keep the dispatch keys tight
+    // to match Homebrew's shape (OS.kernel_version.major, etc.).
+    .{ "major", string.major },
+    .{ "minor", string.minor },
+    .{ "patch", string.patch },
+    .{ "to_i", string.toI },
 });

--- a/src/core/dsl/builtins/string.zig
+++ b/src/core/dsl/builtins/string.zig
@@ -226,3 +226,79 @@ pub fn concat(ctx: ExecCtx, receiver: ?Value, args: []const Value) BuiltinError!
 fn isWhitespace(c: u8) bool {
     return c == ' ' or c == '\t' or c == '\n' or c == '\r';
 }
+
+// ---------------------------------------------------------------------------
+// Version-style accessors — Homebrew routinely chains `x.major` on string
+// results from `OS.kernel_version` / `MacOS.version` / `Version.new(x)`.
+// Faithful to Ruby's Version contract: strip an optional leading `v`, split
+// on `.`, yield the Nth numeric segment as an Int, missing/non-numeric
+// segments degrade to `0` (same policy as `"".to_i`).
+// ---------------------------------------------------------------------------
+
+/// `.major` — first numeric segment of a version string.
+pub fn major(ctx: ExecCtx, receiver: ?Value, _: []const Value) BuiltinError!Value {
+    return Value{ .int = versionSegment(try receiverStr(ctx.allocator, receiver), 0) };
+}
+
+/// `.minor` — second numeric segment; 0 if absent.
+pub fn minor(ctx: ExecCtx, receiver: ?Value, _: []const Value) BuiltinError!Value {
+    return Value{ .int = versionSegment(try receiverStr(ctx.allocator, receiver), 1) };
+}
+
+/// `.patch` — third numeric segment; 0 if absent.
+pub fn patch(ctx: ExecCtx, receiver: ?Value, _: []const Value) BuiltinError!Value {
+    return Value{ .int = versionSegment(try receiverStr(ctx.allocator, receiver), 2) };
+}
+
+/// `.to_i` — Ruby's leading-integer parse: reads an optional sign then as
+/// many digits as possible; junk at the tail is ignored. Empty / no-digit
+/// input yields 0.
+pub fn toI(ctx: ExecCtx, receiver: ?Value, _: []const Value) BuiltinError!Value {
+    const s = std.mem.trim(u8, try receiverStr(ctx.allocator, receiver), " \t\r\n");
+    if (s.len == 0) return Value{ .int = 0 };
+
+    var i: usize = 0;
+    var negative = false;
+    if (s[0] == '-' or s[0] == '+') {
+        negative = s[0] == '-';
+        i = 1;
+    }
+    var n: i64 = 0;
+    var saw_digit = false;
+    while (i < s.len and std.ascii.isDigit(s[i])) : (i += 1) {
+        n = n *% 10 +% @as(i64, s[i] - '0');
+        saw_digit = true;
+    }
+    if (!saw_digit) return Value{ .int = 0 };
+    return Value{ .int = if (negative) -n else n };
+}
+
+/// Return the `index`-th numeric segment of a dotted version string, or 0
+/// when the segment is missing or non-numeric.
+fn versionSegment(raw: []const u8, index: usize) i64 {
+    const trimmed = std.mem.trim(u8, raw, " \t\r\n");
+    const stripped = if (trimmed.len > 0 and (trimmed[0] == 'v' or trimmed[0] == 'V'))
+        trimmed[1..]
+    else
+        trimmed;
+
+    var it = std.mem.splitScalar(u8, stripped, '.');
+    var seen: usize = 0;
+    while (it.next()) |segment| : (seen += 1) {
+        if (seen == index) return parseLeadingInt(segment);
+    }
+    return 0;
+}
+
+/// Read as many leading digits as possible and return them as i64. Used by
+/// both `versionSegment` and `.to_i`. Non-digit-led input yields 0.
+fn parseLeadingInt(s: []const u8) i64 {
+    var n: i64 = 0;
+    var saw_digit = false;
+    for (s) |b| {
+        if (!std.ascii.isDigit(b)) break;
+        n = n *% 10 +% @as(i64, b - '0');
+        saw_digit = true;
+    }
+    return if (saw_digit) n else 0;
+}

--- a/src/core/dsl/builtins/string.zig
+++ b/src/core/dsl/builtins/string.zig
@@ -252,7 +252,8 @@ pub fn patch(ctx: ExecCtx, receiver: ?Value, _: []const Value) BuiltinError!Valu
 
 /// `.to_i` — Ruby's leading-integer parse: reads an optional sign then as
 /// many digits as possible; junk at the tail is ignored. Empty / no-digit
-/// input yields 0.
+/// input yields 0. Unlike Ruby (which promotes to Bignum), we saturate at
+/// i64 bounds so a huge literal doesn't wrap into a bogus comparison.
 pub fn toI(ctx: ExecCtx, receiver: ?Value, _: []const Value) BuiltinError!Value {
     const s = std.mem.trim(u8, try receiverStr(ctx.allocator, receiver), " \t\r\n");
     if (s.len == 0) return Value{ .int = 0 };
@@ -266,7 +267,9 @@ pub fn toI(ctx: ExecCtx, receiver: ?Value, _: []const Value) BuiltinError!Value 
     var n: i64 = 0;
     var saw_digit = false;
     while (i < s.len and std.ascii.isDigit(s[i])) : (i += 1) {
-        n = n *% 10 +% @as(i64, s[i] - '0');
+        const digit: i64 = @as(i64, s[i] - '0');
+        n = std.math.mul(i64, n, 10) catch std.math.maxInt(i64);
+        n = std.math.add(i64, n, digit) catch std.math.maxInt(i64);
         saw_digit = true;
     }
     if (!saw_digit) return Value{ .int = 0 };
@@ -291,13 +294,15 @@ fn versionSegment(raw: []const u8, index: usize) i64 {
 }
 
 /// Read as many leading digits as possible and return them as i64. Used by
-/// both `versionSegment` and `.to_i`. Non-digit-led input yields 0.
+/// `versionSegment`; saturates at i64 max on overflow so "999...9".major
+/// can still participate in comparisons without wrapping.
 fn parseLeadingInt(s: []const u8) i64 {
     var n: i64 = 0;
     var saw_digit = false;
     for (s) |b| {
         if (!std.ascii.isDigit(b)) break;
-        n = n *% 10 +% @as(i64, b - '0');
+        n = std.math.mul(i64, n, 10) catch std.math.maxInt(i64);
+        n = std.math.add(i64, n, @as(i64, b - '0')) catch std.math.maxInt(i64);
         saw_digit = true;
     }
     return if (saw_digit) n else 0;

--- a/tests/dsl_builtins_test.zig
+++ b/tests/dsl_builtins_test.zig
@@ -10,6 +10,7 @@ const dsl = @import("malt").dsl;
 const pathname = dsl.builtins.pathname;
 const fileutils = dsl.builtins.fileutils;
 const process = dsl.builtins.process;
+const string = dsl.builtins.string;
 const Value = dsl.Value;
 const ExecCtx = pathname.ExecCtx;
 
@@ -638,4 +639,67 @@ test "safePopenRead captures stdout and chomps trailing newline" {
     defer arena.deinit();
     const v = try process.safePopenRead(arenaCtx(&arena, "/tmp/malt"), null, &.{ .{ .string = "/bin/echo" }, .{ .string = "hello" } });
     try testing.expectEqualStrings("hello", v.string);
+}
+
+// ---------------------------------------------------------------------------
+// Version-style accessors on strings — `.major`, `.minor`, `.patch`, `.to_i`
+//
+// Homebrew formulas routinely chain `OS.kernel_version.major` /
+// `Version.new(x).major`. Without these, llvm@21-style post_install bodies
+// hit `unknown_method` on each accessor and bail out early.
+// ---------------------------------------------------------------------------
+
+test "string.major returns the leading numeric segment as an integer" {
+    const v = try string.major(mkCtx("/tmp"), .{ .string = "25.4.0" }, &.{});
+    try testing.expectEqual(@as(i64, 25), v.int);
+}
+
+test "string.major handles single-segment versions" {
+    const v = try string.major(mkCtx("/tmp"), .{ .string = "15" }, &.{});
+    try testing.expectEqual(@as(i64, 15), v.int);
+}
+
+test "string.major strips a leading 'v' prefix" {
+    // Common in tag-style version strings (e.g. `v3.11.7`).
+    const v = try string.major(mkCtx("/tmp"), .{ .string = "v3.11.7" }, &.{});
+    try testing.expectEqual(@as(i64, 3), v.int);
+}
+
+test "string.major returns 0 on non-numeric / empty input" {
+    // Conservative: degrade to 0 so downstream `.major == N` comparisons
+    // don't crash on stray output. Matches Ruby `"".to_i == 0`.
+    try testing.expectEqual(@as(i64, 0), (try string.major(mkCtx("/tmp"), .{ .string = "" }, &.{})).int);
+    try testing.expectEqual(@as(i64, 0), (try string.major(mkCtx("/tmp"), .{ .string = "dev" }, &.{})).int);
+}
+
+test "string.minor returns the second numeric segment" {
+    try testing.expectEqual(@as(i64, 4), (try string.minor(mkCtx("/tmp"), .{ .string = "25.4.0" }, &.{})).int);
+    try testing.expectEqual(@as(i64, 11), (try string.minor(mkCtx("/tmp"), .{ .string = "3.11.7" }, &.{})).int);
+    // Single-segment version has no minor — fall back to 0.
+    try testing.expectEqual(@as(i64, 0), (try string.minor(mkCtx("/tmp"), .{ .string = "15" }, &.{})).int);
+}
+
+test "string.patch returns the third numeric segment" {
+    try testing.expectEqual(@as(i64, 0), (try string.patch(mkCtx("/tmp"), .{ .string = "25.4.0" }, &.{})).int);
+    try testing.expectEqual(@as(i64, 7), (try string.patch(mkCtx("/tmp"), .{ .string = "3.11.7" }, &.{})).int);
+    try testing.expectEqual(@as(i64, 0), (try string.patch(mkCtx("/tmp"), .{ .string = "25.4" }, &.{})).int);
+}
+
+test "string.to_i parses the leading integer and stops at non-digits" {
+    // Ruby-style: `"42abc".to_i == 42`, `"no_digits".to_i == 0`.
+    try testing.expectEqual(@as(i64, 42), (try string.toI(mkCtx("/tmp"), .{ .string = "42" }, &.{})).int);
+    try testing.expectEqual(@as(i64, 42), (try string.toI(mkCtx("/tmp"), .{ .string = "42abc" }, &.{})).int);
+    try testing.expectEqual(@as(i64, 0), (try string.toI(mkCtx("/tmp"), .{ .string = "abc" }, &.{})).int);
+    try testing.expectEqual(@as(i64, -5), (try string.toI(mkCtx("/tmp"), .{ .string = "-5" }, &.{})).int);
+}
+
+test "string.major routes through receiver_builtins dispatch" {
+    // Regression: the interpreter looks up `.major` in receiver_builtins;
+    // if this wiring ever drifts, `OS.kernel_version.major` silently
+    // degrades back to unknown_method. Pin both the key and the function.
+    const dispatch = @import("malt").dsl.builtins.receiver_builtins;
+    try testing.expect(dispatch.get("major") != null);
+    try testing.expect(dispatch.get("minor") != null);
+    try testing.expect(dispatch.get("patch") != null);
+    try testing.expect(dispatch.get("to_i") != null);
 }

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -1876,3 +1876,41 @@ test "interpreter: llvm@21 post_install shape runs to completion" {
     const err = try runSnippet(&arena, src, prefix);
     try testing.expect(err == null);
 }
+
+// ---------------------------------------------------------------------------
+// `.major`/`.minor`/`.patch`/`.to_i` on strings — unlocks Homebrew's
+// `OS.kernel_version.major` / `Version.new(x).major` idioms so llvm@21-style
+// post_install guards can compute without falling back.
+// ---------------------------------------------------------------------------
+
+test "interpreter: MacOS.version.major chains through string receiver builtins" {
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    // odie only fires if .major returns a non-positive value — i.e. the
+    // DSL still has the accessor wired. Works on any macOS (major ≥ 10).
+    const src =
+        \\v = MacOS.version.major
+        \\odie "major unavailable" unless v
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
+}
+
+test "interpreter: chained .major on an OS.kernel_version result stays an integer" {
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    // `.to_i` on a `.major` result is a no-op — but exercises both builtins
+    // in sequence and guards against an accidental Value-kind regression.
+    const src =
+        \\n = OS.kernel_version.major.to_i
+        \\odie "expected an int from .major.to_i" unless n
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
+}


### PR DESCRIPTION
## Summary

First of three follow-ups to #86. Before this, `mt install --debug zig` surfaced:

```text
llvm@21:12:33: [unknown_method] major
llvm@21:19:57: [unknown_method] major
```

because `OS.kernel_version` / `MacOS.version` return strings and the DSL had no `.major`/`.minor`/`.patch` accessor on the string receiver.

After this PR, those two entries are gone. The three remaining `[unknown_method]` entries on llvm@21 (`map` on hash, downstream `.all?`, and `write_config_files` blocked by `<<`) are tracked follow-ups.

Semantics match Ruby's `Version`: strip optional leading `v`, split on `.`, yield the Nth numeric segment as Int. Missing or non-numeric segments degrade to `0` — same policy as `"".to_i`. `.to_i` itself
reads leading digits and stops at non-digits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)