### PR TITLE
feat(dsl): Enumerable methods on hash receivers (.map/.each/.select/.reject)

### DIFF
--- a/src/core/dsl/interpreter.zig
+++ b/src/core/dsl/interpreter.zig
@@ -463,6 +463,21 @@ pub const Interpreter = struct {
                 }
             }
 
+            // Enumerable methods on hash receivers — same shape as arrays
+            // but the block is yielded (key, value) pairs. Covers llvm@21's
+            // `{ darwin: ..., macosx: ... }.map do |system, version| ... end`.
+            if (receiver_val == .hash and mc.blk != null) {
+                if (std.mem.eql(u8, mc.method, "map")) {
+                    return self.evalHashMap(receiver_val.hash, mc.block_params, mc.blk.?);
+                } else if (std.mem.eql(u8, mc.method, "each")) {
+                    return self.evalHashEach(receiver_val.hash, mc.block_params, mc.blk.?);
+                } else if (std.mem.eql(u8, mc.method, "select")) {
+                    return self.evalHashSelect(receiver_val.hash, mc.block_params, mc.blk.?);
+                } else if (std.mem.eql(u8, mc.method, "reject")) {
+                    return self.evalHashReject(receiver_val.hash, mc.block_params, mc.blk.?);
+                }
+            }
+
             // `&:sym` block-pass on the common Enumerable methods. The symbol
             // names a receiver builtin invoked per element — same effect as
             // `{ |x| x.sym }` without the block allocation.
@@ -487,6 +502,23 @@ pub const Interpreter = struct {
                 } else if (std.mem.eql(u8, mc.method, "any?")) {
                     for (receiver_val.array) |it| if (it.isTruthy()) return Value{ .bool = true };
                     return Value{ .bool = false };
+                }
+            }
+
+            // `hash.any?` / `hash.all?` without a block. Ruby's default is
+            // non-empty / empty check for `any?` and "every value truthy"
+            // for `all?` (treating pairs as `[k, v]` truthy-by-default, so
+            // `all?` reduces to "no entries are nil/false values").
+            if (receiver_val == .hash and mc.blk == null and mc.block_pass == null) {
+                if (std.mem.eql(u8, mc.method, "any?")) {
+                    return Value{ .bool = receiver_val.hash.len > 0 };
+                } else if (std.mem.eql(u8, mc.method, "all?")) {
+                    for (receiver_val.hash) |pair| if (!pair.value.isTruthy()) return Value{ .bool = false };
+                    return Value{ .bool = true };
+                } else if (std.mem.eql(u8, mc.method, "empty?")) {
+                    return Value{ .bool = receiver_val.hash.len == 0 };
+                } else if (std.mem.eql(u8, mc.method, "length") or std.mem.eql(u8, mc.method, "size")) {
+                    return Value{ .int = @as(i64, @intCast(receiver_val.hash.len)) };
                 }
             }
 
@@ -621,23 +653,28 @@ pub const Interpreter = struct {
 
     fn evalEachLoop(self: *Interpreter, el: *const ast.EachLoop) DslError!Value {
         const iterable = try self.eval(el.iterable);
-        const items = switch (iterable) {
-            .array => |a| a,
+        switch (iterable) {
+            .array => |items| for (items) |item| {
+                self.ctx.pushScope();
+                defer self.ctx.popScope();
+                if (el.params.len > 0) self.ctx.setLocal(el.params[0], item);
+                _ = self.evalBlockSlice(el.body) catch |e| switch (e) {
+                    DslError.PostInstallFailed, DslError.PathSandboxViolation, DslError.ReturnSignal => return e,
+                    else => continue,
+                };
+            },
+            .hash => |pairs| for (pairs) |pair| {
+                // Hash iteration yields (key, value) — matches Ruby's
+                // `hash.each do |k, v|` and the llvm@21 post_install shape.
+                self.ctx.pushScope();
+                defer self.ctx.popScope();
+                self.bindHashPair(el.params, pair);
+                _ = self.evalBlockSlice(el.body) catch |e| switch (e) {
+                    DslError.PostInstallFailed, DslError.PathSandboxViolation, DslError.ReturnSignal => return e,
+                    else => continue,
+                };
+            },
             else => return Value{ .nil = {} },
-        };
-
-        for (items) |item| {
-            self.ctx.pushScope();
-            defer self.ctx.popScope();
-
-            if (el.params.len > 0) {
-                self.ctx.setLocal(el.params[0], item);
-            }
-
-            _ = self.evalBlockSlice(el.body) catch |e| switch (e) {
-                DslError.PostInstallFailed, DslError.PathSandboxViolation, DslError.ReturnSignal => return e,
-                else => continue,
-            };
         }
         return Value{ .nil = {} };
     }
@@ -722,6 +759,75 @@ pub const Interpreter = struct {
             };
         }
         return Value{ .nil = {} };
+    }
+
+    /// Bind a hash pair into the current scope for block evaluation. Two
+    /// positional params → classic `|k, v|`; one param → the pair is
+    /// bound to it (same shape as Ruby's `|kv|` destructuring). Zero
+    /// params is legal but useless — nothing to reference.
+    fn bindHashPair(self: *Interpreter, params: []const []const u8, pair: Value.HashPair) void {
+        if (params.len == 0) return;
+        if (params.len == 1) {
+            const arr = self.allocator.alloc(Value, 2) catch return;
+            arr[0] = pair.key;
+            arr[1] = pair.value;
+            self.ctx.setLocal(params[0], Value{ .array = arr });
+            return;
+        }
+        self.ctx.setLocal(params[0], pair.key);
+        self.ctx.setLocal(params[1], pair.value);
+    }
+
+    fn evalHashEach(self: *Interpreter, pairs: []const Value.HashPair, params: []const []const u8, blk: *const Node) DslError!Value {
+        for (pairs) |pair| {
+            self.ctx.pushScope();
+            defer self.ctx.popScope();
+            self.bindHashPair(params, pair);
+            _ = self.eval(blk) catch |e| switch (e) {
+                DslError.PostInstallFailed, DslError.PathSandboxViolation, DslError.ReturnSignal => return e,
+                else => continue,
+            };
+        }
+        return Value{ .nil = {} };
+    }
+
+    fn evalHashMap(self: *Interpreter, pairs: []const Value.HashPair, params: []const []const u8, blk: *const Node) DslError!Value {
+        var out: std.ArrayList(Value) = .empty;
+        for (pairs) |pair| {
+            self.ctx.pushScope();
+            defer self.ctx.popScope();
+            self.bindHashPair(params, pair);
+            const v = try self.eval(blk);
+            out.append(self.allocator, v) catch return DslError.OutOfMemory;
+        }
+        const slice = out.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
+        return Value{ .array = slice };
+    }
+
+    fn evalHashSelect(self: *Interpreter, pairs: []const Value.HashPair, params: []const []const u8, blk: *const Node) DslError!Value {
+        var out: std.ArrayList(Value.HashPair) = .empty;
+        for (pairs) |pair| {
+            self.ctx.pushScope();
+            defer self.ctx.popScope();
+            self.bindHashPair(params, pair);
+            const v = try self.eval(blk);
+            if (v.isTruthy()) out.append(self.allocator, pair) catch return DslError.OutOfMemory;
+        }
+        const slice = out.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
+        return Value{ .hash = slice };
+    }
+
+    fn evalHashReject(self: *Interpreter, pairs: []const Value.HashPair, params: []const []const u8, blk: *const Node) DslError!Value {
+        var out: std.ArrayList(Value.HashPair) = .empty;
+        for (pairs) |pair| {
+            self.ctx.pushScope();
+            defer self.ctx.popScope();
+            self.bindHashPair(params, pair);
+            const v = try self.eval(blk);
+            if (!v.isTruthy()) out.append(self.allocator, pair) catch return DslError.OutOfMemory;
+        }
+        const slice = out.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
+        return Value{ .hash = slice };
     }
 
     /// Dispatch an Enumerable method whose block is `&:sym` shorthand. The

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -1914,3 +1914,179 @@ test "interpreter: chained .major on an OS.kernel_version result stays an intege
     const err = try runSnippet(&arena, src, prefix);
     try testing.expect(err == null);
 }
+
+// ---------------------------------------------------------------------------
+// Enumerable methods on hash receivers — .each / .map / .select / .reject
+// with two-param blocks (|key, value|). Needed by llvm@21's post_install
+// which does `{ darwin: ..., macosx: ... }.map do |system, version| ... end`.
+// ---------------------------------------------------------------------------
+
+test "interpreter: hash.map yields (key, value) and returns an array" {
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    // Map each entry to `share/<key>` and write the value as its body. The
+    // .map result is an array of pathnames that .all?(&:exist?) confirms.
+    const src =
+        \\share.mkpath
+        \\paths = { a: "alpha", b: "beta" }.map do |name, body|
+        \\  (share/name).write body
+        \\  share/name
+        \\end
+        \\odie "hash.map lost entries" unless paths.all?(&:exist?)
+        \\odie "a missing" unless (share/"a").exist?
+        \\odie "b missing" unless (share/"b").exist?
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
+}
+
+test "interpreter: hash.each yields (key, value) and returns nil" {
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    const src =
+        \\share.mkpath
+        \\{ one: "1", two: "2" }.each do |name, body|
+        \\  (share/name).write body
+        \\end
+        \\odie "one missing" unless (share/"one").exist?
+        \\odie "two missing" unless (share/"two").exist?
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
+}
+
+test "interpreter: hash.select filters entries by the 2-arg block" {
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    // Keep only entries whose value `.exist?` is true. Pre-create one of
+    // the two target files so the filter has a real decision to make.
+    const src =
+        \\share.mkpath
+        \\(share/"here").write "x"
+        \\subset = { a: share/"here", b: share/"missing" }.select do |_k, path|
+        \\  path.exist?
+        \\end
+        \\odie "expected 1 entry after select" unless subset.any?
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
+}
+
+test "interpreter: llvm@21 shape — hash.map + array.all?(&:exist?) chains cleanly" {
+    // Exact shape from llvm@21 post_install. Only `write_config_files`
+    // (blocked on the `<<` shovel operator) should remain unknown after
+    // this PR — tracked in the next follow-up.
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    const src =
+        \\share.mkpath
+        \\(share/"a.cfg").write "x"
+        \\(share/"b.cfg").write "x"
+        \\paths = { a: share/"a.cfg", b: share/"b.cfg" }.map do |_k, p|
+        \\  p
+        \\end
+        \\odie "chain lost entries" unless paths.all?(&:exist?)
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
+}
+
+test "interpreter: hash.reject is the dual of select" {
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    // Reject entries whose value is already present; we expect the
+    // remaining entry's side effect (write) to run.
+    const src =
+        \\share.mkpath
+        \\(share/"kept_k").write "already"
+        \\{ a: share/"kept_k", b: share/"new_k" }.reject do |_k, p|
+        \\  p.exist?
+        \\end.each do |_k, p|
+        \\  p.write "fresh"
+        \\end
+        \\odie "new_k should have been written" unless (share/"new_k").exist?
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
+}
+
+test "interpreter: block-less hash.any?/all?/empty?/length" {
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    // `.any?` on non-empty → truthy; `.empty?` → false; `.length` > 0.
+    // `.all?` is true unless a value is literally false/nil.
+    const src =
+        \\h = { a: 1, b: 2 }
+        \\odie "any? should be true" unless h.any?
+        \\odie "empty? should be false" if h.empty?
+        \\odie "all? should be true for truthy values" unless h.all?
+        \\odie "length should be positive" unless h.length
+        \\empty = {}
+        \\odie "empty.any? should be false" if empty.any?
+        \\odie "empty.empty? should be true" unless empty.empty?
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
+}
+
+test "interpreter: hash.each with single-param block destructures the pair" {
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    // Ruby allows `hash.each { |kv| ... }` where `kv` is `[key, value]`.
+    // The DSL binds the pair as a 2-element array — assert one element
+    // came through by writing its value to disk under its key.
+    const src =
+        \\share.mkpath
+        \\{ single: "yes" }.each do |kv|
+        \\  (share/kv[0]).write kv[1]
+        \\end
+        \\odie "single missing" unless (share/"single").exist?
+    ;
+    _ = try runSnippet(&arena, src, prefix);
+    // We don't insist on success — `kv[0]` indexing isn't implemented
+    // yet, so the only invariant enforced here is: no parse_error / no
+    // panic when destructuring a 1-arg block over a hash.
+}
+
+test "interpreter: empty hash.map/each returns quickly without side effects" {
+    var arena = testArena();
+    defer arena.deinit();
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    // Guard against a spurious block invocation on an empty hash — would
+    // have shown up as the odie firing despite no entries.
+    const src =
+        \\share.mkpath
+        \\empty = {}
+        \\empty.map do |_k, _v|
+        \\  odie "map should not run on empty hash"
+        \\end
+        \\empty.each do |_k, _v|
+        \\  odie "each should not run on empty hash"
+        \\end
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
+}


### PR DESCRIPTION
## Summary

Second of three follow-ups to #86. Before this, `mt install --debug zig` surfaced three remaining unknowns on llvm@21's post_install:

```tezt
llvm@21:14:7:  [unknown_method] map
llvm@21:17:28: [unknown_method] all?
llvm@21:19:5:  [unknown_method] write_config_files
```

The first two were downstream of the same gap: `{ darwin: ..., macosx: ... }.map` on a hash receiver logged as unknown, so `config_files` was nil and the follow-on `.all?(&:exist?)` on nil also logged. After this PR both are
resolved; only `write_config_files` remains (blocked on the `<<` shovel operator — next PR).

What's covered:

- `.each` / `.map` / `.select` / `.reject` on hash receivers yield `|key, value|` pairs; `|kv|` single-param destructures to a 2-element array to match Ruby's contract.
- `.any?` / `.all?` / `.empty?` / `.length` / `.size` block-less forms follow Ruby hash semantics (non-empty / truthy-values / zero-entry).
- `each_loop` (parser's implicit form for `.each do ... end`) gains a hash branch so both call shapes reach the same handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code) is