### PR TITLE
feat(update): classify install origin so self-update can respect brew

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -111,6 +111,7 @@ pub fn build(b: *std.Build) void {
         "tests/rollback_test.zig",
         "tests/run_test.zig",
         "tests/version_update_test.zig",
+        "tests/origin_test.zig",
         "tests/cask_test.zig",
         "tests/cellar_test.zig",
         "tests/progress_test.zig",

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -155,6 +155,9 @@ run_ok t2.info.json -- "$MT_BIN" info jq --json
 run_ok t2.outdated -- "$MT_BIN" outdated
 run_ok t2.outdated.json -- "$MT_BIN" outdated --json
 run_ok t2.update -- "$MT_BIN" update
+# --check must not touch the binary; guards the self-update path as it
+# grows cosign verification.
+run_ok t2.version.update.check -- "$MT_BIN" version update --check
 run_ok t2.tap.list -- "$MT_BIN" tap
 
 # doctor: README documents exit 0/1/2 as valid semantics — accept all three on a

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -42,6 +42,7 @@ pub const cli_help = @import("cli/help.zig");
 pub const cli_info = @import("cli/info.zig");
 pub const cli_uses = @import("cli/uses.zig");
 pub const cli_version_update = @import("cli/version_update.zig");
+pub const update_origin = @import("update/origin.zig");
 pub const cli_list = @import("cli/list.zig");
 pub const cli_tap = @import("cli/tap.zig");
 pub const cli_rollback = @import("cli/rollback.zig");

--- a/src/update/origin.zig
+++ b/src/update/origin.zig
@@ -1,0 +1,24 @@
+//! malt — update origin detection.
+//!
+//! Self-update must not overwrite a brew-managed binary. Classify by
+//! resolved path so the updater can defer to `brew upgrade` instead of
+//! fighting the Cellar/Caskroom.
+
+const std = @import("std");
+
+pub const Origin = enum { direct, homebrew };
+
+/// Pure classification of a *resolved* (realpath-ed) binary path.
+///
+/// Caller must resolve symlinks first — `std.process.executablePath` on
+/// darwin returns the argv[0] shape, which for brew installs is a shim
+/// at `$(brew --prefix)/bin/malt`. Classifying the shim directly would
+/// misreport a brew install as `direct`.
+pub fn classify(resolved_path: []const u8) Origin {
+    // Match both formula (`/Cellar/`) and cask (`/Caskroom/`) layouts.
+    // Stable across Intel, Apple Silicon, linuxbrew, and custom
+    // HOMEBREW_PREFIX — only the prefix changes, the component names don't.
+    if (std.mem.indexOf(u8, resolved_path, "/Cellar/") != null) return .homebrew;
+    if (std.mem.indexOf(u8, resolved_path, "/Caskroom/") != null) return .homebrew;
+    return .direct;
+}

--- a/tests/origin_test.zig
+++ b/tests/origin_test.zig
@@ -1,0 +1,53 @@
+//! malt — update origin detection tests.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const origin = malt.update_origin;
+
+const Case = struct {
+    path: []const u8,
+    want: origin.Origin,
+};
+
+test "classify covers every install shape the updater must distinguish" {
+    const cases = [_]Case{
+        // Direct: install.sh, manual copy, build output.
+        .{ .path = "/usr/local/bin/malt", .want = .direct },
+        .{ .path = "/opt/malt/bin/malt", .want = .direct },
+        .{ .path = "/Users/alice/bin/malt", .want = .direct },
+        .{ .path = "/tmp/malt-bench-main/build/malt", .want = .direct },
+        // Unresolved brew shim — by contract, callers resolve first.
+        .{ .path = "/opt/homebrew/bin/malt", .want = .direct },
+        // Defensive: empty must not classify as homebrew.
+        .{ .path = "", .want = .direct },
+        // Brew formula (Cellar) — Apple Silicon, Intel, linuxbrew.
+        .{ .path = "/opt/homebrew/Cellar/malt/0.6.0/bin/malt", .want = .homebrew },
+        .{ .path = "/usr/local/Cellar/malt/0.6.0/bin/malt", .want = .homebrew },
+        .{ .path = "/home/linuxbrew/.linuxbrew/Cellar/malt/0.6.0/bin/malt", .want = .homebrew },
+        // Brew cask (Caskroom).
+        .{ .path = "/opt/homebrew/Caskroom/malt/0.6.0/malt", .want = .homebrew },
+        .{ .path = "/usr/local/Caskroom/malt/0.6.0/malt", .want = .homebrew },
+    };
+
+    for (cases) |c| {
+        const got = origin.classify(c.path);
+        testing.expectEqual(c.want, got) catch |err| {
+            std.debug.print("classify({s}) = .{s}, want .{s}\n", .{
+                c.path, @tagName(got), @tagName(c.want),
+            });
+            return err;
+        };
+    }
+}
+
+test "classify is pure — repeated calls agree" {
+    const p = "/opt/homebrew/Cellar/malt/0.6.0/bin/malt";
+    try testing.expectEqual(origin.Origin.homebrew, origin.classify(p));
+    try testing.expectEqual(origin.Origin.homebrew, origin.classify(p));
+}
+
+test "classify is slash-anchored — no false positives on 'cellar' substrings" {
+    try testing.expectEqual(origin.Origin.direct, origin.classify("/Users/alice/wine-cellar/malt"));
+    try testing.expectEqual(origin.Origin.direct, origin.classify("/tmp/cellarish/malt"));
+}


### PR DESCRIPTION
## Why

`malt version update` currently downloads and overwrites the running binary with zero verification -worse than the cosign-verified `install.sh`. Closing that gap requires, first, knowing whether we even own the binary we're about to replace: a brew-managed install must defer to `brew upgrade`, not get clobbered.

## What this adds

A pure `update_origin.classify(resolved_path)` that returns `.direct` or `.homebrew` based on `Cellar` or `Caskroom` markers. Stable across Intel, Apple Silicon, and custom `HOMEBREW_PREFIX`.

Zero behavior change - the classifier isn't called yet. 