### PR TITLE
feat(update): add SHA256 and cosign verification primitives

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -113,6 +113,7 @@ pub fn build(b: *std.Build) void {
         "tests/version_update_test.zig",
         "tests/origin_test.zig",
         "tests/release_test.zig",
+        "tests/verify_test.zig",
         "tests/cask_test.zig",
         "tests/cellar_test.zig",
         "tests/progress_test.zig",

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -44,6 +44,7 @@ pub const cli_uses = @import("cli/uses.zig");
 pub const cli_version_update = @import("cli/version_update.zig");
 pub const update_origin = @import("update/origin.zig");
 pub const update_release = @import("update/release.zig");
+pub const update_verify = @import("update/verify.zig");
 pub const cli_list = @import("cli/list.zig");
 pub const cli_tap = @import("cli/tap.zig");
 pub const cli_rollback = @import("cli/rollback.zig");

--- a/src/update/verify.zig
+++ b/src/update/verify.zig
@@ -1,0 +1,97 @@
+//! malt - trust layer for self-update.
+//!
+//! Two independent primitives the updater composes:
+//!   1. `verifySha256` / `lookupSha256` — integrity against a
+//!      GoReleaser-style `checksums.txt`.
+//!   2. `verifyCosignBlob` — Sigstore signature of that checksums file,
+//!      mirroring `scripts/install.sh` exactly.
+//!
+//! Pure string/bytes in, errors out. No network, no filesystem (except
+//! the cosign subprocess, which is injected via `cosign_bin`).
+
+const std = @import("std");
+const fs_compat = @import("../fs/compat.zig");
+
+pub const ChecksumError = error{
+    /// `bytes` did not hash to the value named in `expected_hex`.
+    ChecksumMismatch,
+    /// `expected_hex` was not 64 hex digits.
+    InvalidHex,
+};
+
+/// Verify that SHA256(bytes) equals `expected_hex`. Case-insensitive.
+pub fn verifySha256(bytes: []const u8, expected_hex: []const u8) ChecksumError!void {
+    if (expected_hex.len != 64) return error.InvalidHex;
+    var expected: [32]u8 = undefined;
+    _ = std.fmt.hexToBytes(&expected, expected_hex) catch return error.InvalidHex;
+
+    var actual: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(bytes, &actual, .{});
+
+    if (!std.mem.eql(u8, &expected, &actual)) return error.ChecksumMismatch;
+}
+
+/// Find the SHA256 hex for `archive_name` in a GoReleaser-style
+/// `checksums.txt`. Line format: `<64-hex>  <filename>\n`.
+/// Returns null if the archive is not listed.
+pub fn lookupSha256(checksums_txt: []const u8, archive_name: []const u8) ?[]const u8 {
+    var it = std.mem.splitScalar(u8, checksums_txt, '\n');
+    while (it.next()) |raw| {
+        // Tolerate CRLF endings from Windows-edited fixtures.
+        const line = std.mem.trimEnd(u8, raw, "\r");
+        if (line.len < 66) continue; // 64 hex + 2 spaces + >=1 name char
+        // GoReleaser writes `<hex>  <name>` with two spaces.
+        const sep = std.mem.indexOf(u8, line, "  ") orelse continue;
+        if (sep != 64) continue;
+        const name = line[sep + 2 ..];
+        if (!std.mem.eql(u8, name, archive_name)) continue;
+        return line[0..64];
+    }
+    return null;
+}
+
+pub const CosignError = error{
+    /// `cosign_bin` could not be spawned (not installed, not executable).
+    CosignNotFound,
+    /// `cosign verify-blob` exited non-zero - signature did not verify.
+    CosignVerifyFailed,
+};
+
+pub const CosignBlob = struct {
+    /// Either `"cosign"` to resolve via PATH, or an absolute path (tests).
+    cosign_bin: []const u8 = "cosign",
+    /// The blob whose signature is being checked (usually checksums.txt).
+    blob_path: []const u8,
+    /// Sigstore `.sigstore.json` bundle (cert + signature + rekor entry).
+    bundle_path: []const u8,
+    /// Regex the Sigstore cert's identity must match - pins the workflow.
+    cert_identity_regex: []const u8,
+    /// OIDC issuer that signed the cert, e.g. GitHub Actions token issuer.
+    oidc_issuer: []const u8,
+};
+
+/// Shell out to `cosign verify-blob` with the same flags `install.sh` uses.
+/// Exit 0 = verified. Any other outcome maps to a CosignError.
+pub fn verifyCosignBlob(allocator: std.mem.Allocator, args: CosignBlob) CosignError!void {
+    const argv = [_][]const u8{
+        args.cosign_bin,
+        "verify-blob",
+        "--bundle",
+        args.bundle_path,
+        "--certificate-identity-regexp",
+        args.cert_identity_regex,
+        "--certificate-oidc-issuer",
+        args.oidc_issuer,
+        args.blob_path,
+    };
+
+    var child = fs_compat.Child.init(&argv, allocator);
+    child.stdout_behavior = .ignore;
+    child.stderr_behavior = .ignore;
+    child.spawn() catch return error.CosignNotFound;
+    const term = child.wait() catch return error.CosignVerifyFailed;
+    switch (term) {
+        .exited => |code| if (code != 0) return error.CosignVerifyFailed,
+        else => return error.CosignVerifyFailed,
+    }
+}

--- a/tests/verify_test.zig
+++ b/tests/verify_test.zig
@@ -1,0 +1,142 @@
+//! malt - trust layer tests.
+//!
+//! SHA256 + checksums.txt parsing are pure. Cosign verification is
+//! exercised with a fake `cosign_bin` (a shell script we write to a
+//! tmp path) so the test suite has no hard dep on cosign being installed.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const verify = malt.update_verify;
+const fs_compat = malt.fs_compat;
+
+// SHA256("hello world")
+const HELLO_WORLD_HEX = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+// SHA256("")
+const EMPTY_HEX = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+// --- verifySha256 ---------------------------------------------------------
+
+test "verifySha256 accepts the correct hex for a known input" {
+    try verify.verifySha256("hello world", HELLO_WORLD_HEX);
+}
+
+test "verifySha256 is case-insensitive on the expected hex" {
+    const upper = "B94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9";
+    try verify.verifySha256("hello world", upper);
+}
+
+test "verifySha256 rejects a single-bit flip in the expected hex" {
+    // Last char: 9 -> 8. One byte differs, mismatch is required.
+    const flipped = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde8";
+    try testing.expectError(error.ChecksumMismatch, verify.verifySha256("hello world", flipped));
+}
+
+test "verifySha256 rejects a tampered input byte" {
+    try testing.expectError(error.ChecksumMismatch, verify.verifySha256("hello world!", HELLO_WORLD_HEX));
+}
+
+test "verifySha256 rejects wrong hex length" {
+    try testing.expectError(error.InvalidHex, verify.verifySha256("hello world", "deadbeef"));
+    // 63 chars - one short
+    try testing.expectError(
+        error.InvalidHex,
+        verify.verifySha256("hello world", "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde"),
+    );
+}
+
+test "verifySha256 rejects non-hex characters" {
+    // Same length, but 'z' is not hex.
+    const bad = "z94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+    try testing.expectError(error.InvalidHex, verify.verifySha256("hello world", bad));
+}
+
+test "verifySha256 accepts the empty-bytes digest" {
+    try verify.verifySha256("", EMPTY_HEX);
+}
+
+// --- lookupSha256 ---------------------------------------------------------
+
+test "lookupSha256 finds a single-line archive" {
+    const txt = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  malt_0.7.0_darwin_all.tar.gz\n";
+    const got = verify.lookupSha256(txt, "malt_0.7.0_darwin_all.tar.gz") orelse return error.Missing;
+    try testing.expectEqualStrings(HELLO_WORLD_HEX, got);
+}
+
+test "lookupSha256 picks the right line among many" {
+    const txt =
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  other.tar.gz\n" ++
+        "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  malt_0.7.0_darwin_all.tar.gz\n" ++
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  third.tar.gz\n";
+    const got = verify.lookupSha256(txt, "malt_0.7.0_darwin_all.tar.gz") orelse return error.Missing;
+    try testing.expectEqualStrings(HELLO_WORLD_HEX, got);
+}
+
+test "lookupSha256 tolerates CRLF line endings" {
+    const txt = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  malt_0.7.0_darwin_all.tar.gz\r\n";
+    const got = verify.lookupSha256(txt, "malt_0.7.0_darwin_all.tar.gz") orelse return error.Missing;
+    try testing.expectEqualStrings(HELLO_WORLD_HEX, got);
+}
+
+test "lookupSha256 returns null when the archive is absent" {
+    const txt = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  other.tar.gz\n";
+    try testing.expect(verify.lookupSha256(txt, "malt_0.7.0_darwin_all.tar.gz") == null);
+}
+
+test "lookupSha256 ignores malformed lines without crashing" {
+    // First line is garbage; second line is a valid match. The matcher
+    // must skip the broken line, not bail the whole scan.
+    const txt =
+        "not-even-hex\n" ++
+        "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  malt_0.7.0_darwin_all.tar.gz\n";
+    const got = verify.lookupSha256(txt, "malt_0.7.0_darwin_all.tar.gz") orelse return error.Missing;
+    try testing.expectEqualStrings(HELLO_WORLD_HEX, got);
+}
+
+// --- verifyCosignBlob -----------------------------------------------------
+
+/// Write a shell script to `path` that exits with `exit_code` when run,
+/// and chmod it executable. Used as a drop-in `cosign_bin` so tests can
+/// exercise the subprocess path without depending on real cosign.
+fn writeFakeCosign(path: []const u8, exit_code: u8) !void {
+    fs_compat.deleteFileAbsolute(path) catch {};
+    const f = try fs_compat.createFileAbsolute(path, .{});
+    defer f.close();
+    var buf: [64]u8 = undefined;
+    const script = try std.fmt.bufPrint(&buf, "#!/bin/sh\nexit {d}\n", .{exit_code});
+    try f.writeAll(script);
+    try f.chmod(0o755);
+}
+
+const fake_args = verify.CosignBlob{
+    .blob_path = "/tmp/does-not-need-to-exist",
+    .bundle_path = "/tmp/does-not-need-to-exist.sigstore.json",
+    .cert_identity_regex = "^https://example\\.com/",
+    .oidc_issuer = "https://example.com",
+};
+
+test "verifyCosignBlob returns CosignNotFound when the binary is missing" {
+    var args = fake_args;
+    args.cosign_bin = "/tmp/malt_nonexistent_cosign_xyz_99";
+    try testing.expectError(error.CosignNotFound, verify.verifyCosignBlob(testing.allocator, args));
+}
+
+test "verifyCosignBlob accepts a cosign that exits 0" {
+    const path = "/tmp/malt_fake_cosign_ok";
+    try writeFakeCosign(path, 0);
+    defer fs_compat.deleteFileAbsolute(path) catch {};
+
+    var args = fake_args;
+    args.cosign_bin = path;
+    try verify.verifyCosignBlob(testing.allocator, args);
+}
+
+test "verifyCosignBlob errors when cosign exits non-zero" {
+    const path = "/tmp/malt_fake_cosign_fail";
+    try writeFakeCosign(path, 1);
+    defer fs_compat.deleteFileAbsolute(path) catch {};
+
+    var args = fake_args;
+    args.cosign_bin = path;
+    try testing.expectError(error.CosignVerifyFailed, verify.verifyCosignBlob(testing.allocator, args));
+}


### PR DESCRIPTION
## Why

`install.sh` verifies releases with SHA256 + cosign before copying bytes over `/usr/local/bin/malt`. The self-update path does not. Closing that gap needs trust primitives that can be tested in isolation and map 1:1 to the install.sh flow.

## What this adds

`src/update/verify.zig`:

- `verifySha256(bytes, hex)` - raw integrity check, case-insensitive hex, explicit `InvalidHex` vs `ChecksumMismatch`.
- `lookupSha256(checksums_txt, archive_name)` - parses the GoReleaser `<hex>  <name>` format, tolerates CRLF and malformed lines.
- `verifyCosignBlob(args)` - spawns `cosign verify-blob` with the exact flags install.sh uses; returns `CosignNotFound` or `CosignVerifyFailed`.

The cosign wrapper accepts a `cosign_bin` override so tests drive the subprocess path with a fake script and carry no dependency on real cosign being installed in CI.