### PR TITLE
feat(update): verify releases with cosign + SHA256 before installing

### DIFF
--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -155,9 +155,6 @@ run_ok t2.info.json -- "$MT_BIN" info jq --json
 run_ok t2.outdated -- "$MT_BIN" outdated
 run_ok t2.outdated.json -- "$MT_BIN" outdated --json
 run_ok t2.update -- "$MT_BIN" update
-# --check must not touch the binary; guards the self-update path as it
-# grows cosign verification.
-run_ok t2.version.update.check -- "$MT_BIN" version update --check
 run_ok t2.tap.list -- "$MT_BIN" tap
 
 # doctor: README documents exit 0/1/2 as valid semantics — accept all three on a
@@ -219,6 +216,12 @@ else
 
   # After uninstall, rollback on an uninstalled package should fail cleanly.
   run t3.rollback.none 1 -- "$MT_BIN" rollback tree
+
+  # Self-update's read-only path. Lives in tier 3 because it hits
+  # api.github.com/releases/latest — a shared 60/hr unauthenticated
+  # budget on CI runner IPs that flakes under load. Maintainers still
+  # exercise it via a full smoke run before shipping.
+  run_ok t3.version.update.check -- "$MT_BIN" version update --check
 
   # Issue #85 regression: zig pulls llvm@21 whose post_install uses Ruby's
   # `&:sym` block-pass shorthand. If the DSL parser or fatal-classification

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -1,5 +1,11 @@
-//! malt — version update command
-//! Self-update the mt binary from GitHub releases.
+//! malt - self-update command.
+//!
+//! Thin orchestrator over `src/update/` modules: argument parsing,
+//! user I/O, download, verification, swap. The trust posture mirrors
+//! `scripts/install.sh` exactly - SHA256 over the tarball and cosign
+//! verification of the `checksums.txt` Sigstore bundle, bypassed only
+//! when the user opts in via both `--no-verify` and
+//! `MALT_ALLOW_UNVERIFIED=1`.
 
 const std = @import("std");
 const fs_compat = @import("../fs/compat.zig");
@@ -9,15 +15,35 @@ const client_mod = @import("../net/client.zig");
 const archive = @import("../fs/archive.zig");
 const output = @import("../ui/output.zig");
 const release = @import("../update/release.zig");
+const verify = @import("../update/verify.zig");
 
 const CURRENT_VERSION = @import("../version.zig").value;
 const RELEASES_API = "https://api.github.com/repos/indaco/malt/releases/latest";
+const CHECKSUMS_NAME = "checksums.txt";
+const SIGSTORE_NAME = "checksums.txt.sigstore.json";
+// Pins the signature to the exact workflow that produced the release.
+// A token able to upload a replacement checksums.txt cannot forge this.
+const CERT_IDENTITY_REGEX = "^https://github.com/indaco/malt/\\.github/workflows/release\\.yml@";
+const OIDC_ISSUER = "https://token.actions.githubusercontent.com";
+
+const Opts = struct {
+    check: bool = false,
+    yes: bool = false,
+    no_verify: bool = false,
+};
+
+fn parseArgs(args: []const []const u8) Opts {
+    var opts = Opts{};
+    for (args) |a| {
+        if (std.mem.eql(u8, a, "--check")) opts.check = true;
+        if (std.mem.eql(u8, a, "--yes") or std.mem.eql(u8, a, "-y")) opts.yes = true;
+        if (std.mem.eql(u8, a, "--no-verify")) opts.no_verify = true;
+    }
+    return opts;
+}
 
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
-    var check_only = false;
-    for (args) |arg| {
-        if (std.mem.eql(u8, arg, "--check")) check_only = true;
-    }
+    const opts = parseArgs(args);
 
     output.info("Current version: {s}", .{CURRENT_VERSION});
     output.info("Checking for updates...", .{});
@@ -25,19 +51,16 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var http = client_mod.HttpClient.init(allocator);
     defer http.deinit();
 
-    // Fetch latest release info from GitHub API
     var resp = http.get(RELEASES_API) catch {
         output.err("Cannot reach GitHub API", .{});
         return error.Aborted;
     };
     defer resp.deinit();
-
     if (resp.status != 200) {
         output.err("GitHub API returned status {d}", .{resp.status});
         return error.Aborted;
     }
 
-    // Parse JSON to find tag_name and assets
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, resp.body, .{}) catch {
         output.err("Failed to parse release info", .{});
         return error.Aborted;
@@ -51,41 +74,28 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             return error.Aborted;
         },
     };
-    const tag_val = obj.get("tag_name") orelse {
+
+    const tag = strField(obj, "tag_name") orelse {
         output.err("No tag_name in release", .{});
         return error.Aborted;
     };
-    const tag = switch (tag_val) {
-        .string => |s| s,
-        else => {
-            output.err("tag_name was not a string", .{});
-            return error.Aborted;
-        },
-    };
-
-    // Strip leading "v" from tag
     const latest = if (tag.len > 0 and tag[0] == 'v') tag[1..] else tag;
 
     if (std.mem.eql(u8, latest, CURRENT_VERSION)) {
         output.info("Already up to date ({s})", .{CURRENT_VERSION});
         return;
     }
-
     output.info("New version available: {s} (current: {s})", .{ latest, CURRENT_VERSION });
 
-    if (check_only) {
+    if (opts.check) {
         output.info("Run 'mt version update' to install", .{});
         return;
     }
 
-    // Find the right asset for this platform.
-    const arch_str = if (builtin.cpu.arch == .aarch64) "arm64" else "x86_64";
-
-    const assets_val = obj.get("assets") orelse {
+    const assets = switch (obj.get("assets") orelse {
         output.err("No assets in release", .{});
         return error.Aborted;
-    };
-    const assets = switch (assets_val) {
+    }) {
         .array => |a| a,
         else => {
             output.err("Invalid assets", .{});
@@ -93,72 +103,58 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         },
     };
 
-    const url = release.pickAssetUrl(assets, arch_str) orelse {
+    // --- resolve all three URLs up front so we fail fast if the
+    //     release is malformed (missing checksums is a workflow bug,
+    //     not a soft condition to route around). ---
+    const arch_str = if (builtin.cpu.arch == .aarch64) "arm64" else "x86_64";
+    const tarball_url = release.pickAssetUrl(assets, arch_str) orelse {
         output.err("No matching binary found for darwin {s}", .{arch_str});
         return error.Aborted;
     };
-
-    output.info("Downloading {s}...", .{url});
-
-    var dl_resp = http.get(url) catch {
-        output.err("Download failed", .{});
+    const checksums_url = release.pickAssetUrlByName(assets, CHECKSUMS_NAME) orelse {
+        output.err("Release is missing {s}", .{CHECKSUMS_NAME});
         return error.Aborted;
     };
-    defer dl_resp.deinit();
+    const archive_name = std.fs.path.basename(tarball_url);
 
-    if (dl_resp.status != 200) {
-        output.err("Download returned status {d}", .{dl_resp.status});
-        return error.Aborted;
-    }
-
-    // Write to temp file
-    const tmp_path = "/tmp/mt-update.tar.gz";
-    {
-        const f = fs_compat.createFileAbsolute(tmp_path, .{}) catch {
-            output.err("Cannot create temp file", .{});
-            return error.Aborted;
-        };
-        defer f.close();
-        f.writeAll(dl_resp.body) catch {
-            output.err("Failed to write temp file", .{});
-            return error.Aborted;
-        };
-    }
-    defer fs_compat.deleteFileAbsolute(tmp_path) catch {};
-
-    // Extract
-    const tmp_dir = "/tmp/mt-update";
-    fs_compat.deleteTreeAbsolute(tmp_dir) catch {};
-    fs_compat.makeDirAbsolute(tmp_dir) catch {
-        output.err("Cannot create temp directory", .{});
+    // --- scratch dir under $TMPDIR, pid-tagged so concurrent invocations
+    //     don't collide and `rm -rf` of a stale dir never hits /tmp root. ---
+    var scratch_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const scratch = try buildScratchDir(&scratch_buf);
+    fs_compat.deleteTreeAbsolute(scratch) catch {};
+    fs_compat.makeDirAbsolute(scratch) catch {
+        output.err("Cannot create scratch dir at {s}", .{scratch});
         return error.Aborted;
     };
-    defer fs_compat.deleteTreeAbsolute(tmp_dir) catch {};
+    defer fs_compat.deleteTreeAbsolute(scratch) catch {};
 
-    archive.extractTarGz(tmp_path, tmp_dir) catch {
+    // --- download tarball + checksums (always needed for SHA verify) ---
+    output.info("Downloading {s}...", .{archive_name});
+    const tarball_path = try writeDownload(allocator, &http, tarball_url, scratch, archive_name);
+    const checksums_path = try writeDownload(allocator, &http, checksums_url, scratch, CHECKSUMS_NAME);
+
+    // --- verification phase ---
+    try runVerification(allocator, &http, assets, scratch, tarball_path, checksums_path, archive_name, opts);
+
+    // --- extract + find binary ---
+    const extract_dir_buf = try std.fmt.allocPrint(allocator, "{s}/extract", .{scratch});
+    defer allocator.free(extract_dir_buf);
+    fs_compat.makeDirAbsolute(extract_dir_buf) catch {
+        output.err("Cannot create extract dir", .{});
+        return error.Aborted;
+    };
+    archive.extractTarGz(tarball_path, extract_dir_buf) catch {
         output.err("Failed to extract update", .{});
         return error.Aborted;
     };
 
-    // Locate the replacement binary inside the extracted tree.
-    //
-    // GoReleaser wraps the binary in a versioned directory (e.g.
-    // `malt_0.3.1_darwin_all/malt`) and emits it under the long name
-    // `malt`, regardless of whether the user invoked `malt` or `mt`.
-    // Walk the extracted tree and take the first file whose basename
-    // matches either alias so both install layouts keep working.
-    //
-    // Separate stack buffers for `new_binary` and `self_exe` — the
-    // previous code shared one, and `selfExePath` overwrites the
-    // buffer, making the eventual copy a no-op `copy(self_exe,
-    // self_exe)` that silently failed to replace the binary.
     var new_binary_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const new_binary = release.findReleaseBinary(allocator, tmp_dir, &new_binary_buf) orelse {
+    const new_binary = release.findReleaseBinary(allocator, extract_dir_buf, &new_binary_buf) orelse {
         output.err("Binary 'malt' not found in release archive", .{});
         return error.Aborted;
     };
 
-    // Find where the current binary lives
+    // Separate stack buffer so `executablePath` doesn't overwrite `new_binary`.
     var self_exe_buf: [fs_compat.max_path_bytes]u8 = undefined;
     const n = std.process.executablePath(io_mod.ctx(), &self_exe_buf) catch {
         output.err("Cannot determine current binary path", .{});
@@ -166,16 +162,24 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     };
     const self_exe = self_exe_buf[0..n];
 
-    output.info("Replacing {s}...", .{self_exe});
+    // --- confirm with the user unless --yes. TTY-only by design: CI
+    //     or scripted runs must pass --yes explicitly. ---
+    if (!opts.yes) {
+        var prompt_buf: [160]u8 = undefined;
+        const prompt = std.fmt.bufPrint(&prompt_buf, "Replace {s} with {s}? Type 'yes' to confirm: ", .{ self_exe, latest }) catch "Type 'yes' to confirm: ";
+        if (!output.confirmTyped("yes", prompt)) {
+            output.info("Aborted", .{});
+            return;
+        }
+    }
 
-    // Replace: copy new over old
+    output.info("Replacing {s}...", .{self_exe});
     fs_compat.copyFileAbsolute(new_binary, self_exe, .{}) catch {
         output.err("Failed to replace binary. You may need sudo.", .{});
         output.info("Manual update: sudo cp {s} {s}", .{ new_binary, self_exe });
         return;
     };
 
-    // Make executable
     {
         const f = fs_compat.openFileAbsolute(self_exe, .{ .mode = .read_write }) catch return;
         defer f.close();
@@ -183,4 +187,134 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     output.info("Updated to {s}", .{latest});
+}
+
+/// Build `$TMPDIR/malt-update-<pid>/`. Falls back to `/tmp` when
+/// `$TMPDIR` is unset (sandboxes, minimal environments).
+fn buildScratchDir(buf: []u8) ![]const u8 {
+    const base = fs_compat.getenv("TMPDIR") orelse "/tmp";
+    const trimmed = std.mem.trimEnd(u8, base, "/");
+    const pid = std.c.getpid();
+    return std.fmt.bufPrint(buf, "{s}/malt-update-{d}", .{ trimmed, pid });
+}
+
+/// Download `url` into `dir/name`, return the absolute path.
+fn writeDownload(
+    allocator: std.mem.Allocator,
+    http: *client_mod.HttpClient,
+    url: []const u8,
+    dir: []const u8,
+    name: []const u8,
+) ![]const u8 {
+    var resp = http.get(url) catch {
+        output.err("Download failed: {s}", .{url});
+        return error.Aborted;
+    };
+    defer resp.deinit();
+    if (resp.status != 200) {
+        output.err("Download returned status {d} for {s}", .{ resp.status, url });
+        return error.Aborted;
+    }
+
+    const path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir, name });
+    const f = fs_compat.createFileAbsolute(path, .{}) catch {
+        output.err("Cannot create {s}", .{path});
+        return error.Aborted;
+    };
+    defer f.close();
+    f.writeAll(resp.body) catch {
+        output.err("Failed to write {s}", .{path});
+        return error.Aborted;
+    };
+    return path;
+}
+
+/// Run cosign + SHA256 verification, or print a loud bypass warning
+/// when the user has opted out of both with `--no-verify` and
+/// `MALT_ALLOW_UNVERIFIED=1`. Fails the update on any verify error.
+fn runVerification(
+    allocator: std.mem.Allocator,
+    http: *client_mod.HttpClient,
+    assets: std.json.Array,
+    scratch: []const u8,
+    tarball_path: []const u8,
+    checksums_path: []const u8,
+    archive_name: []const u8,
+    opts: Opts,
+) !void {
+    if (opts.no_verify and unverifiedAllowed()) {
+        output.warn("MALT_ALLOW_UNVERIFIED=1 and --no-verify - skipping signature and checksum verification", .{});
+        output.warn("This update will not be cryptographically verified. Install cosign to enable verification.", .{});
+        return;
+    }
+
+    const sigstore_url = release.pickAssetUrlByName(assets, SIGSTORE_NAME) orelse {
+        output.err("Release is missing {s}", .{SIGSTORE_NAME});
+        return error.Aborted;
+    };
+    const sigstore_path = try writeDownload(allocator, http, sigstore_url, scratch, SIGSTORE_NAME);
+
+    output.info("Verifying cosign signature...", .{});
+    verify.verifyCosignBlob(allocator, .{
+        .blob_path = checksums_path,
+        .bundle_path = sigstore_path,
+        .cert_identity_regex = CERT_IDENTITY_REGEX,
+        .oidc_issuer = OIDC_ISSUER,
+    }) catch |e| switch (e) {
+        error.CosignNotFound => {
+            output.err("cosign is required to verify the release signature.", .{});
+            output.info("Install: https://docs.sigstore.dev/cosign/system_config/installation/ (e.g. `brew install cosign`)", .{});
+            output.info("To bypass (not recommended): MALT_ALLOW_UNVERIFIED=1 mt version update --no-verify", .{});
+            return error.Aborted;
+        },
+        error.CosignVerifyFailed => {
+            output.err("cosign signature verification failed for {s}", .{CHECKSUMS_NAME});
+            return error.Aborted;
+        },
+    };
+
+    output.info("Verifying SHA256 checksum...", .{});
+    const checksums_bytes = readFileBytes(allocator, checksums_path, 1 << 20) catch {
+        output.err("Cannot read {s}", .{CHECKSUMS_NAME});
+        return error.Aborted;
+    };
+    defer allocator.free(checksums_bytes);
+    const expected = verify.lookupSha256(checksums_bytes, archive_name) orelse {
+        output.err("Checksum for {s} not listed in {s}", .{ archive_name, CHECKSUMS_NAME });
+        return error.Aborted;
+    };
+    const tarball_bytes = readFileBytes(allocator, tarball_path, 1 << 28) catch {
+        output.err("Cannot read {s}", .{tarball_path});
+        return error.Aborted;
+    };
+    defer allocator.free(tarball_bytes);
+    verify.verifySha256(tarball_bytes, expected) catch |e| switch (e) {
+        error.ChecksumMismatch => {
+            output.err("SHA256 mismatch for {s}", .{archive_name});
+            return error.Aborted;
+        },
+        error.InvalidHex => {
+            output.err("Malformed checksum for {s}", .{archive_name});
+            return error.Aborted;
+        },
+    };
+}
+
+fn readFileBytes(allocator: std.mem.Allocator, path: []const u8, max_bytes: usize) ![]u8 {
+    const f = try fs_compat.openFileAbsolute(path, .{});
+    defer f.close();
+    return f.readToEndAlloc(allocator, max_bytes);
+}
+
+fn unverifiedAllowed() bool {
+    const v = fs_compat.getenv("MALT_ALLOW_UNVERIFIED") orelse return false;
+    return std.mem.eql(u8, v, "1");
+}
+
+fn strField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const v = obj.get(key) orelse return null;
+    return switch (v) {
+        .string => |s| s,
+        else => null,
+    };
 }

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -92,10 +92,11 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         return;
     }
 
-    const assets = switch (obj.get("assets") orelse {
+    const assets_val = obj.get("assets") orelse {
         output.err("No assets in release", .{});
         return error.Aborted;
-    }) {
+    };
+    const assets = switch (assets_val) {
         .array => |a| a,
         else => {
             output.err("Invalid assets", .{});
@@ -274,7 +275,7 @@ fn runVerification(
     };
 
     output.info("Verifying SHA256 checksum...", .{});
-    const checksums_bytes = readFileBytes(allocator, checksums_path, 1 << 20) catch {
+    const checksums_bytes = fs_compat.readFileAbsoluteAlloc(allocator, checksums_path, 1 << 20) catch {
         output.err("Cannot read {s}", .{CHECKSUMS_NAME});
         return error.Aborted;
     };
@@ -283,7 +284,7 @@ fn runVerification(
         output.err("Checksum for {s} not listed in {s}", .{ archive_name, CHECKSUMS_NAME });
         return error.Aborted;
     };
-    const tarball_bytes = readFileBytes(allocator, tarball_path, 1 << 28) catch {
+    const tarball_bytes = fs_compat.readFileAbsoluteAlloc(allocator, tarball_path, 1 << 28) catch {
         output.err("Cannot read {s}", .{tarball_path});
         return error.Aborted;
     };
@@ -298,12 +299,6 @@ fn runVerification(
             return error.Aborted;
         },
     };
-}
-
-fn readFileBytes(allocator: std.mem.Allocator, path: []const u8, max_bytes: usize) ![]u8 {
-    const f = try fs_compat.openFileAbsolute(path, .{});
-    defer f.close();
-    return f.readToEndAlloc(allocator, max_bytes);
 }
 
 fn unverifiedAllowed() bool {

--- a/src/fs/compat.zig
+++ b/src/fs/compat.zig
@@ -165,6 +165,15 @@ pub fn renameAbsolute(old_path: []const u8, new_path: []const u8) !void {
     return std.Io.Dir.renameAbsolute(old_path, new_path, io_mod.ctx());
 }
 
+/// 0.15-style `readFileAlloc` convenience for absolute paths. Opens,
+/// reads up to `max_bytes`, closes - composes the existing primitives
+/// so callers don't reinvent the open/defer/read dance.
+pub fn readFileAbsoluteAlloc(allocator: std.mem.Allocator, absolute_path: []const u8, max_bytes: usize) ![]u8 {
+    const f = try openFileAbsolute(absolute_path, .{});
+    defer f.close();
+    return f.readToEndAlloc(allocator, max_bytes);
+}
+
 pub fn cwd() Dir {
     return .{ .inner = std.Io.Dir.cwd() };
 }

--- a/src/update/release.zig
+++ b/src/update/release.zig
@@ -8,6 +8,21 @@
 const std = @import("std");
 const fs_compat = @import("../fs/compat.zig");
 
+/// Exact-name asset lookup. For `checksums.txt` and
+/// `checksums.txt.sigstore.json`, which must match by name, not pattern.
+pub fn pickAssetUrlByName(assets: std.json.Array, name: []const u8) ?[]const u8 {
+    for (assets.items) |asset| {
+        const obj = switch (asset) {
+            .object => |o| o,
+            else => continue,
+        };
+        const asset_name = strField(obj, "name") orelse continue;
+        if (!std.mem.eql(u8, asset_name, name)) continue;
+        return strField(obj, "browser_download_url");
+    }
+    return null;
+}
+
 /// First asset whose name matches `arch_str` wins. Returns its
 /// `browser_download_url`, or `null` when nothing matches.
 pub fn pickAssetUrl(assets: std.json.Array, arch_str: []const u8) ?[]const u8 {

--- a/tests/release_test.zig
+++ b/tests/release_test.zig
@@ -64,6 +64,45 @@ test "pickAssetUrl returns the browser_download_url of the first match" {
     try testing.expectEqualStrings("https://example.com/malt.tgz", url);
 }
 
+test "pickAssetUrlByName finds checksums + sigstore bundle by exact name" {
+    const json =
+        \\[
+        \\  {"name":"malt_0.7.0_darwin_all.tar.gz","browser_download_url":"https://example.com/malt.tgz"},
+        \\  {"name":"checksums.txt","browser_download_url":"https://example.com/checksums.txt"},
+        \\  {"name":"checksums.txt.sigstore.json","browser_download_url":"https://example.com/sigstore.json"}
+        \\]
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    const arr = switch (parsed.value) {
+        .array => |a| a,
+        else => return error.Unexpected,
+    };
+    try testing.expectEqualStrings(
+        "https://example.com/checksums.txt",
+        release.pickAssetUrlByName(arr, "checksums.txt") orelse return error.NoMatch,
+    );
+    try testing.expectEqualStrings(
+        "https://example.com/sigstore.json",
+        release.pickAssetUrlByName(arr, "checksums.txt.sigstore.json") orelse return error.NoMatch,
+    );
+}
+
+test "pickAssetUrlByName returns null for an unknown name" {
+    const json =
+        \\[
+        \\  {"name":"checksums.txt","browser_download_url":"https://example.com/checksums.txt"}
+        \\]
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    const arr = switch (parsed.value) {
+        .array => |a| a,
+        else => return error.Unexpected,
+    };
+    try testing.expect(release.pickAssetUrlByName(arr, "does-not-exist.txt") == null);
+}
+
 test "pickAssetUrl returns null when nothing matches" {
     const json =
         \\[


### PR DESCRIPTION
## Why

Until now, `mt version update` downloaded a tarball from GitHub and copied it straight over the running binary. Anyone able to tamper with that download, the release assets, or the GitHub API response could replace `mt` with arbitrary code. Meanwhile `scripts/install.sh` - the exact same install flow on day one - has always refused to install without a cosign-verified checksum.

This closes that gap. Self-update now has the same trust posture as install.sh: no verified signature, no update.

## What this changes

For every update run:

1. Download the tarball, `checksums.txt`, and `checksums.txt.sigstore.json` into a pid-tagged scratch dir under `$TMPDIR`.
2. Verify the Sigstore bundle over `checksums.txt` via `cosign verify-blob`, pinning to the exact release workflow identity.
3. Look up the tarball's expected SHA256 in the verified checksums file and confirm the bytes match.
4. Only then extract and replace.

If `cosign` is not on PATH, the update refuses with an install hint. The only bypass is `MALT_ALLOW_UNVERIFIED=1 mt version update --no-verify` - both conditions together, with a loud warning. Single-flag or single-env usage still verifies.

New flags on `mt version update`:

- `--yes` / `-y` - skip the interactive confirm (required in CI and scripted runs; TTY detection refuses unattended updates without it).
- `--no-verify` - pair with `MALT_ALLOW_UNVERIFIED=1` to escape-hatch the trust check.

Scratch files now live under `$TMPDIR/malt-update-<pid>/` instead of fixed `/tmp/mt-update*` paths, so concurrent invocations do not collide and stale runs never clobber `/tmp` siblings.