### PR TITLE
feat(update): atomic rename-based binary swap with .old rollback

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -114,6 +114,7 @@ pub fn build(b: *std.Build) void {
         "tests/origin_test.zig",
         "tests/release_test.zig",
         "tests/verify_test.zig",
+        "tests/swap_test.zig",
         "tests/cask_test.zig",
         "tests/cellar_test.zig",
         "tests/progress_test.zig",

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -16,6 +16,7 @@ const archive = @import("../fs/archive.zig");
 const output = @import("../ui/output.zig");
 const release = @import("../update/release.zig");
 const verify = @import("../update/verify.zig");
+const swap = @import("../update/swap.zig");
 
 const CURRENT_VERSION = @import("../version.zig").value;
 const RELEASES_API = "https://api.github.com/repos/indaco/malt/releases/latest";
@@ -175,19 +176,24 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     output.info("Replacing {s}...", .{self_exe});
-    fs_compat.copyFileAbsolute(new_binary, self_exe, .{}) catch {
-        output.err("Failed to replace binary. You may need sudo.", .{});
-        output.info("Manual update: sudo cp {s} {s}", .{ new_binary, self_exe });
-        return;
+    swap.atomicReplace(self_exe, new_binary) catch |e| switch (e) {
+        error.StagingFailed, error.SwapFailed => {
+            output.err("Failed to replace {s}. You may need sudo.", .{self_exe});
+            output.info("Manual update: sudo cp {s} {s}", .{ new_binary, self_exe });
+            return;
+        },
+        error.RollbackFailed => {
+            // Two renames went one-and-a-half: target is gone, .old is still
+            // the previous binary. The next invocation the user makes
+            // cannot find `malt` on PATH, so surface the recovery path loudly.
+            output.err("Update aborted mid-swap; rollback also failed.", .{});
+            output.info("Restore the previous binary with:", .{});
+            output.info("  sudo mv {s}.old {s}", .{ self_exe, self_exe });
+            return error.Aborted;
+        },
     };
 
-    {
-        const f = fs_compat.openFileAbsolute(self_exe, .{ .mode = .read_write }) catch return;
-        defer f.close();
-        f.chmod(0o755) catch {};
-    }
-
-    output.info("Updated to {s}", .{latest});
+    output.info("Updated to {s} (previous kept at {s}.old)", .{ latest, self_exe });
 }
 
 /// Build `$TMPDIR/malt-update-<pid>/`. Falls back to `/tmp` when

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -45,6 +45,7 @@ pub const cli_version_update = @import("cli/version_update.zig");
 pub const update_origin = @import("update/origin.zig");
 pub const update_release = @import("update/release.zig");
 pub const update_verify = @import("update/verify.zig");
+pub const update_swap = @import("update/swap.zig");
 pub const cli_list = @import("cli/list.zig");
 pub const cli_tap = @import("cli/tap.zig");
 pub const cli_rollback = @import("cli/rollback.zig");

--- a/src/update/swap.zig
+++ b/src/update/swap.zig
@@ -1,0 +1,68 @@
+//! malt - atomic binary replacement for self-update.
+//!
+//! `atomicReplace(target, new)` swaps in a fresh binary using two
+//! POSIX rename(2) calls. Both operands live in the same directory
+//! as `target` at the rename step, so the rename is always within
+//! one filesystem and therefore atomic. Preserves `<target>.old` for
+//! manual rollback on success; restores it to `<target>` on failure.
+
+const std = @import("std");
+const fs_compat = @import("../fs/compat.zig");
+
+pub const SwapError = error{
+    /// Could not stage the new binary next to the target (disk full,
+    /// permission, parent-dir unwritable). No file has moved yet.
+    StagingFailed,
+    /// The target→.old rename failed. Target is untouched.
+    SwapFailed,
+    /// The swap happened but the state is inconsistent (e.g. rollback
+    /// also failed). `<target>.old` may be the live binary; the real
+    /// target path may not exist. Caller surfaces the situation loudly.
+    RollbackFailed,
+};
+
+/// Replace `target_path` with the contents of `new_path`. On success,
+/// the previous binary is kept at `<target_path>.old` for manual
+/// rollback. On failure during the swap, the previous binary is
+/// restored and no partial state is left behind.
+///
+/// `new_path` is copied - not moved - so callers can keep scratch
+/// extraction in `$TMPDIR` without caring whether it shares a volume
+/// with the target.
+pub fn atomicReplace(target_path: []const u8, new_path: []const u8) SwapError!void {
+    const target_dir = std.fs.path.dirname(target_path) orelse return error.SwapFailed;
+
+    var old_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const old_path = std.fmt.bufPrint(&old_path_buf, "{s}.old", .{target_path}) catch
+        return error.StagingFailed;
+
+    var staged_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const staged_path = std.fmt.bufPrint(&staged_path_buf, "{s}/.malt-update-{d}", .{ target_dir, std.c.getpid() }) catch
+        return error.StagingFailed;
+
+    // Stage the new binary next to the target. Cleans any stale file
+    // from a killed earlier run first so copy never EEXISTs.
+    fs_compat.deleteFileAbsolute(staged_path) catch {};
+    fs_compat.copyFileAbsolute(new_path, staged_path, .{}) catch return error.StagingFailed;
+    errdefer fs_compat.deleteFileAbsolute(staged_path) catch {};
+
+    // Set mode on the staged file so we never leave a non-executable
+    // malt in place if the rename succeeds but chmod races.
+    {
+        const f = fs_compat.openFileAbsolute(staged_path, .{ .mode = .read_write }) catch
+            return error.StagingFailed;
+        defer f.close();
+        f.chmod(0o755) catch return error.StagingFailed;
+    }
+
+    // Clear any .old left by a crashed prior run before we overwrite it.
+    fs_compat.deleteFileAbsolute(old_path) catch {};
+
+    // Atomic rename #1: target -> target.old.
+    fs_compat.renameAbsolute(target_path, old_path) catch return error.SwapFailed;
+    errdefer fs_compat.renameAbsolute(old_path, target_path) catch {};
+
+    // Atomic rename #2: staged -> target. If this fails the errdefers
+    // above restore .old to target and delete the stage.
+    fs_compat.renameAbsolute(staged_path, target_path) catch return error.RollbackFailed;
+}

--- a/tests/swap_test.zig
+++ b/tests/swap_test.zig
@@ -1,0 +1,200 @@
+//! malt - atomic swap tests.
+//!
+//! All work happens in a scratch dir under `/tmp` so target, new,
+//! staged, and .old all share a volume - the same invariant the real
+//! updater enforces. Tests are TDD-style: written from the caller's
+//! contract, not the implementation shape.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const swap = malt.update_swap;
+const fs_compat = malt.fs_compat;
+
+fn resetScratch(allocator: std.mem.Allocator, tag: []const u8) ![]u8 {
+    const dir = try std.fmt.allocPrint(allocator, "/tmp/malt_swap_test_{s}", .{tag});
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    try fs_compat.makeDirAbsolute(dir);
+    return dir;
+}
+
+fn writeFile(path: []const u8, content: []const u8) !void {
+    const f = try fs_compat.createFileAbsolute(path, .{});
+    defer f.close();
+    try f.writeAll(content);
+}
+
+fn readFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    return fs_compat.readFileAbsoluteAlloc(allocator, path, 1 << 16);
+}
+
+/// Returns the POSIX mode bits (rwxrwxrwx = 0o777) of `path`.
+fn modeBits(path: []const u8) !u32 {
+    const f = try fs_compat.openFileAbsolute(path, .{});
+    defer f.close();
+    const st = try f.stat();
+    return @intCast(st.permissions.toMode() & 0o777);
+}
+
+/// Build a scratch dir + its target/new/old/staged triple of paths.
+/// All four live in the same dir so rename-based atomicity holds.
+const Paths = struct {
+    dir: []u8,
+    target: []u8,
+    new: []u8,
+    old: []u8,
+    staged: []u8,
+
+    fn init(allocator: std.mem.Allocator, tag: []const u8) !Paths {
+        const dir = try resetScratch(allocator, tag);
+        return .{
+            .dir = dir,
+            .target = try std.fmt.allocPrint(allocator, "{s}/malt", .{dir}),
+            .new = try std.fmt.allocPrint(allocator, "{s}/malt.new", .{dir}),
+            .old = try std.fmt.allocPrint(allocator, "{s}/malt.old", .{dir}),
+            .staged = try std.fmt.allocPrint(allocator, "{s}/.malt-update-{d}", .{ dir, std.c.getpid() }),
+        };
+    }
+
+    fn deinit(self: *Paths, allocator: std.mem.Allocator) void {
+        fs_compat.deleteTreeAbsolute(self.dir) catch {};
+        allocator.free(self.dir);
+        allocator.free(self.target);
+        allocator.free(self.new);
+        allocator.free(self.old);
+        allocator.free(self.staged);
+    }
+};
+
+// --- happy path ----------------------------------------------------------
+
+test "atomicReplace swaps target and preserves original at .old" {
+    var p = try Paths.init(testing.allocator, "happy");
+    defer p.deinit(testing.allocator);
+
+    try writeFile(p.target, "version-1-bytes");
+    try writeFile(p.new, "version-2-bytes");
+
+    try swap.atomicReplace(p.target, p.new);
+
+    const target_contents = try readFile(testing.allocator, p.target);
+    defer testing.allocator.free(target_contents);
+    try testing.expectEqualStrings("version-2-bytes", target_contents);
+
+    const old_contents = try readFile(testing.allocator, p.old);
+    defer testing.allocator.free(old_contents);
+    try testing.expectEqualStrings("version-1-bytes", old_contents);
+}
+
+test "atomicReplace leaves the swapped-in target executable (owner + group + other +x)" {
+    var p = try Paths.init(testing.allocator, "exec");
+    defer p.deinit(testing.allocator);
+
+    try writeFile(p.target, "old");
+    try writeFile(p.new, "new"); // createFile defaults to non-executable
+
+    try swap.atomicReplace(p.target, p.new);
+
+    // All three execute bits must be set (0o755 = rwxr-xr-x).
+    const mode = try modeBits(p.target);
+    try testing.expectEqual(@as(u32, 0o755), mode);
+}
+
+test "atomicReplace leaves new_path untouched - it is copied, not moved" {
+    var p = try Paths.init(testing.allocator, "source_preserved");
+    defer p.deinit(testing.allocator);
+
+    try writeFile(p.target, "old");
+    try writeFile(p.new, "fresh");
+
+    try swap.atomicReplace(p.target, p.new);
+
+    // Caller still owns new_path and can inspect / re-use it.
+    const new_contents = try readFile(testing.allocator, p.new);
+    defer testing.allocator.free(new_contents);
+    try testing.expectEqualStrings("fresh", new_contents);
+}
+
+test "atomicReplace removes the staging file on success" {
+    var p = try Paths.init(testing.allocator, "stage_gone");
+    defer p.deinit(testing.allocator);
+
+    try writeFile(p.target, "old");
+    try writeFile(p.new, "new");
+
+    try swap.atomicReplace(p.target, p.new);
+
+    // Staged temp must not leak into the target directory.
+    try testing.expectError(error.FileNotFound, fs_compat.accessAbsolute(p.staged, .{}));
+}
+
+// --- prior-run cleanup ---------------------------------------------------
+
+test "atomicReplace overwrites a stale .old from a prior run" {
+    var p = try Paths.init(testing.allocator, "stale_old");
+    defer p.deinit(testing.allocator);
+
+    try writeFile(p.old, "pre-existing-old-from-crash");
+    try writeFile(p.target, "version-2");
+    try writeFile(p.new, "version-3");
+
+    try swap.atomicReplace(p.target, p.new);
+
+    // The stale .old must have been replaced with the just-swapped-out
+    // target, not preserved.
+    const old_contents = try readFile(testing.allocator, p.old);
+    defer testing.allocator.free(old_contents);
+    try testing.expectEqualStrings("version-2", old_contents);
+}
+
+test "atomicReplace overwrites a stale staged file from a killed prior run" {
+    var p = try Paths.init(testing.allocator, "stale_stage");
+    defer p.deinit(testing.allocator);
+
+    try writeFile(p.staged, "from-killed-run");
+    try writeFile(p.target, "version-1");
+    try writeFile(p.new, "version-2");
+
+    try swap.atomicReplace(p.target, p.new);
+
+    const target_contents = try readFile(testing.allocator, p.target);
+    defer testing.allocator.free(target_contents);
+    try testing.expectEqualStrings("version-2", target_contents);
+}
+
+// --- failure paths -------------------------------------------------------
+
+test "atomicReplace returns StagingFailed when target directory is missing" {
+    var p = try Paths.init(testing.allocator, "source_only");
+    defer p.deinit(testing.allocator);
+    try writeFile(p.new, "doesnt-matter");
+
+    // Target dir literally does not exist - staging must not hit rename.
+    const target = "/tmp/malt_swap_test_missing_dir_xyz_99/malt";
+    fs_compat.deleteTreeAbsolute("/tmp/malt_swap_test_missing_dir_xyz_99") catch {};
+
+    try testing.expectError(error.StagingFailed, swap.atomicReplace(target, p.new));
+}
+
+test "atomicReplace returns StagingFailed when new_path does not exist" {
+    var p = try Paths.init(testing.allocator, "missing_source");
+    defer p.deinit(testing.allocator);
+    try writeFile(p.target, "old");
+    // Deliberately do not create p.new.
+
+    try testing.expectError(error.StagingFailed, swap.atomicReplace(p.target, p.new));
+
+    // Target must be untouched when staging fails.
+    const target_contents = try readFile(testing.allocator, p.target);
+    defer testing.allocator.free(target_contents);
+    try testing.expectEqualStrings("old", target_contents);
+}
+
+test "atomicReplace returns SwapFailed when target does not exist" {
+    var p = try Paths.init(testing.allocator, "missing_target");
+    defer p.deinit(testing.allocator);
+    try writeFile(p.new, "new");
+    // Deliberately do not create p.target.
+
+    try testing.expectError(error.SwapFailed, swap.atomicReplace(p.target, p.new));
+}


### PR DESCRIPTION
## Why

Until now, `mt version update` replaced the running binary with a plain `copyFileAbsolute`. If the copy failed mid-write, the user was left with a half-written executable and no way back. If something crashed between copy and chmod, malt could survive as a non-executable file.

Swapping a running binary deserves the same rename-based atomicity that the rest of malt uses for its on-disk state.

## What this changes

New `src/update/swap.zig` exposing `atomicReplace(target, new)`:

1. Copies `new` into a pid-tagged staging file next to `target` so both live on the same volume.
2. Renames `target` to `target.old` (atomic POSIX rename).
3. Renames the staged file to `target` (atomic POSIX rename).
4. Sets `0o755` on the staged file *before* the rename, so the live binary is executable from the moment the second rename lands.

The previous binary stays at `target.old` for manual rollback. If the swap fails mid-flight, the rollback restores `target` automatically. A genuinely unrecoverable state (rollback itself fails) surfaces a loud `mv <target>.old <target>` recovery hint.

`mt version update` now prints `Updated to X (previous kept at /path/to/malt.old)` on success, so the rollback path is discoverable without reading the README.