### PR TITLE
feat(update): defer self-update to brew for Homebrew-managed installs

### DIFF
--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -14,6 +14,7 @@ const builtin = @import("builtin");
 const client_mod = @import("../net/client.zig");
 const archive = @import("../fs/archive.zig");
 const output = @import("../ui/output.zig");
+const origin = @import("../update/origin.zig");
 const release = @import("../update/release.zig");
 const verify = @import("../update/verify.zig");
 const swap = @import("../update/swap.zig");
@@ -45,6 +46,15 @@ fn parseArgs(args: []const []const u8) Opts {
 
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     const opts = parseArgs(args);
+
+    // Brew-managed installs must be upgraded via `brew`, otherwise the
+    // Cellar/Caskroom metadata drifts from the file on disk. Route these
+    // users at the tool that owns their install.
+    if (detectOrigin() == .homebrew) {
+        output.info("This malt was installed via Homebrew.", .{});
+        output.info("Update with: brew upgrade --cask malt", .{});
+        return;
+    }
 
     output.info("Current version: {s}", .{CURRENT_VERSION});
     output.info("Checking for updates...", .{});
@@ -305,6 +315,16 @@ fn runVerification(
             return error.Aborted;
         },
     };
+}
+
+/// Resolve the running binary via `executablePath` + `realpath` and
+/// classify the install. Failure to resolve degrades to `.direct`, so
+/// a transient FS error never locks the updater out.
+fn detectOrigin() origin.Origin {
+    var exe_buf: [fs_compat.max_path_bytes]u8 = undefined;
+    const n = std.process.executablePath(io_mod.ctx(), &exe_buf) catch return .direct;
+    var resolved_buf: [std.fs.max_path_bytes]u8 = undefined;
+    return origin.classifyResolved(&resolved_buf, exe_buf[0..n]);
 }
 
 fn unverifiedAllowed() bool {

--- a/src/update/origin.zig
+++ b/src/update/origin.zig
@@ -5,6 +5,7 @@
 //! fighting the Cellar/Caskroom.
 
 const std = @import("std");
+const fs_compat = @import("../fs/compat.zig");
 
 pub const Origin = enum { direct, homebrew };
 
@@ -21,4 +22,13 @@ pub fn classify(resolved_path: []const u8) Origin {
     if (std.mem.indexOf(u8, resolved_path, "/Cellar/") != null) return .homebrew;
     if (std.mem.indexOf(u8, resolved_path, "/Caskroom/") != null) return .homebrew;
     return .direct;
+}
+
+/// Classify a possibly-symlinked path: resolve via `realpath(2)`, then
+/// `classify()` the real path. Returns `.direct` if the path cannot be
+/// resolved - a missing/unreadable binary should fall through to the
+/// normal updater rather than refusing based on a resolution error.
+pub fn classifyResolved(out_buf: []u8, path: []const u8) Origin {
+    const resolved = fs_compat.cwd().realpath(path, out_buf) catch return .direct;
+    return classify(resolved);
 }

--- a/tests/origin_test.zig
+++ b/tests/origin_test.zig
@@ -51,3 +51,71 @@ test "classify is slash-anchored — no false positives on 'cellar' substrings" 
     try testing.expectEqual(origin.Origin.direct, origin.classify("/Users/alice/wine-cellar/malt"));
     try testing.expectEqual(origin.Origin.direct, origin.classify("/tmp/cellarish/malt"));
 }
+
+// --- classifyResolved ---------------------------------------------------
+//
+// Verifies that symlink resolution happens before classification, so a
+// brew shim like `/opt/homebrew/bin/malt` pointing into `Cellar` is
+// detected as homebrew instead of being treated as a direct install.
+
+const fs_compat = malt.fs_compat;
+
+fn resetScratch(allocator: std.mem.Allocator, tag: []const u8) ![]u8 {
+    const dir = try std.fmt.allocPrint(allocator, "/tmp/malt_origin_test_{s}", .{tag});
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    try fs_compat.makeDirAbsolute(dir);
+    return dir;
+}
+
+fn touch(path: []const u8) !void {
+    const f = try fs_compat.createFileAbsolute(path, .{});
+    defer f.close();
+    try f.writeAll("");
+}
+
+test "classifyResolved reports homebrew when a shim points into /Cellar/" {
+    const dir = try resetScratch(std.testing.allocator, "shim");
+    defer std.testing.allocator.free(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    // Stand up a `Cellar/malt/0.6.0/bin/malt` real file.
+    const cellar = try std.fmt.allocPrint(std.testing.allocator, "{s}/Cellar/malt/0.6.0/bin", .{dir});
+    defer std.testing.allocator.free(cellar);
+    try fs_compat.cwd().makePath(cellar);
+    const real = try std.fmt.allocPrint(std.testing.allocator, "{s}/malt", .{cellar});
+    defer std.testing.allocator.free(real);
+    try touch(real);
+
+    // Create a `bin/malt` shim pointing at the real file.
+    const bin = try std.fmt.allocPrint(std.testing.allocator, "{s}/bin", .{dir});
+    defer std.testing.allocator.free(bin);
+    try fs_compat.cwd().makePath(bin);
+    const shim = try std.fmt.allocPrint(std.testing.allocator, "{s}/malt", .{bin});
+    defer std.testing.allocator.free(shim);
+    try fs_compat.symLinkAbsolute(real, shim, .{});
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expectEqual(origin.Origin.homebrew, origin.classifyResolved(&buf, shim));
+}
+
+test "classifyResolved reports direct for a non-symlinked direct install" {
+    const dir = try resetScratch(std.testing.allocator, "direct");
+    defer std.testing.allocator.free(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    const path = try std.fmt.allocPrint(std.testing.allocator, "{s}/malt", .{dir});
+    defer std.testing.allocator.free(path);
+    try touch(path);
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expectEqual(origin.Origin.direct, origin.classifyResolved(&buf, path));
+}
+
+test "classifyResolved falls back to direct when the path cannot be resolved" {
+    // Safer than refusing to update on a transient FS error.
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expectEqual(
+        origin.Origin.direct,
+        origin.classifyResolved(&buf, "/tmp/malt_origin_test_absent_xyz_99"),
+    );
+}


### PR DESCRIPTION
## Why

Users who installed malt via `brew install --cask malt` (or a formula) expect `brew upgrade` to own their upgrade path. When they type `mt version update`, the current behavior silently overwrites the file inside the Cellar/Caskroom, leaving Homebrew's install receipt pointing at the old version and breaking the next `brew upgrade` for them. That is the worst kind of failure: nothing obviously broken until a week later, when `brew` trips over state it no longer recognizes.

## What this changes

Before any network work, the updater now resolves the running binary's real path (following the brew shim at `$(brew --prefix)/bin/malt`) and checks whether it lives inside a Homebrew layout. If it does, `mt version update` prints:

```
This malt was installed via Homebrew.
Update with: brew upgrade --cask malt
```

and exits 0 without fetching, verifying, or touching anything. Direct installs (`install.sh`, manual copy, any non-brew layout) continue through the normal verified-download path unchanged.

Detection is substring-based on `/Cellar/` and `/Caskroom/` in the resolved path, so it handles Intel, Apple Silicon, linuxbrew, and custom `HOMEBREW_PREFIX` layouts without a prefix lookup.