### PR TITLE
chore(update): tighten idioms, fill test gaps, add --cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,9 +572,10 @@ mt version                           # show current version
 mt version update                    # install latest (interactive confirm)
 mt version update --check            # check only, no download
 mt version update --yes              # non-interactive (CI / scripts)
+mt version update --cleanup          # remove stale .old + orphaned staging files
 ```
 
-`update` queries the GitHub releases API, verifies the release with cosign and SHA256 against the same trust anchor as `install.sh`, and atomically replaces the running binary. The previous binary is preserved at `<target>.old` for manual rollback.
+`update` queries the GitHub releases API, verifies the release with cosign and SHA256 against the same trust anchor as `install.sh`, and atomically replaces the running binary. The previous binary is preserved at `<target>.old` for manual rollback; accumulated `.old` files (and any orphaned `.malt-update-<pid>` staging files from killed updates) can be removed with `mt version update --cleanup`, which runs locally and makes no network calls.
 
 **Homebrew installs.** If malt was installed via `brew install --cask malt`, the updater detects this and prints a hint pointing you at `brew upgrade --cask malt` — overwriting a brew-managed file from underneath would corrupt its install receipt and break the next `brew upgrade`.
 

--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ mt version update --yes              # non-interactive (CI / scripts)
 MALT_ALLOW_UNVERIFIED=1 mt version update --no-verify
 ```
 
+> [!NOTE]
 > `install.sh` accepts `MALT_ALLOW_UNVERIFIED=1` alone as the bypass; `mt version update` requires both the env var and `--no-verify`. Update is the command that runs repeatedly — the extra guard is deliberate.
 
 ### `mt completions`

--- a/build.zig
+++ b/build.zig
@@ -115,6 +115,7 @@ pub fn build(b: *std.Build) void {
         "tests/release_test.zig",
         "tests/verify_test.zig",
         "tests/swap_test.zig",
+        "tests/cleanup_test.zig",
         "tests/cask_test.zig",
         "tests/cellar_test.zig",
         "tests/progress_test.zig",

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -134,6 +134,8 @@ done
 
 # Alias dispatch (`mt` and `malt` both installed in zig-out/bin).
 run_ok t1.alias.mt -- "$(dirname "$MT_BIN")/mt" version
+# --cleanup is a local-only operation; no network, safe in tier 1.
+run_ok t1.version.update.cleanup -- "$MT_BIN" version update --cleanup
 
 # `purge` with no scope must error per README.
 run t1.purge.no-scope 1 -- "$MT_BIN" purge

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -14,6 +14,7 @@ const builtin = @import("builtin");
 const client_mod = @import("../net/client.zig");
 const archive = @import("../fs/archive.zig");
 const output = @import("../ui/output.zig");
+const cleanup = @import("../update/cleanup.zig");
 const origin = @import("../update/origin.zig");
 const release = @import("../update/release.zig");
 const verify = @import("../update/verify.zig");
@@ -28,24 +29,28 @@ const SIGSTORE_NAME = "checksums.txt.sigstore.json";
 const CERT_IDENTITY_REGEX = "^https://github.com/indaco/malt/\\.github/workflows/release\\.yml@";
 const OIDC_ISSUER = "https://token.actions.githubusercontent.com";
 
-const Opts = struct {
+pub const Opts = struct {
     check: bool = false,
     yes: bool = false,
     no_verify: bool = false,
+    cleanup: bool = false,
 };
 
-fn parseArgs(args: []const []const u8) Opts {
+pub fn parseArgs(args: []const []const u8) Opts {
     var opts = Opts{};
     for (args) |a| {
         if (std.mem.eql(u8, a, "--check")) opts.check = true;
         if (std.mem.eql(u8, a, "--yes") or std.mem.eql(u8, a, "-y")) opts.yes = true;
         if (std.mem.eql(u8, a, "--no-verify")) opts.no_verify = true;
+        if (std.mem.eql(u8, a, "--cleanup")) opts.cleanup = true;
     }
     return opts;
 }
 
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     const opts = parseArgs(args);
+
+    if (opts.cleanup) return runCleanup();
 
     // Brew-managed installs must be upgraded via `brew`, otherwise the
     // Cellar/Caskroom metadata drifts from the file on disk. Route these
@@ -86,7 +91,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         },
     };
 
-    const tag = strField(obj, "tag_name") orelse {
+    const tag = release.strField(obj, "tag_name") orelse {
         output.err("No tag_name in release", .{});
         return error.Aborted;
     };
@@ -146,7 +151,16 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     const checksums_path = try writeDownload(allocator, &http, checksums_url, scratch, CHECKSUMS_NAME);
 
     // --- verification phase ---
-    try runVerification(allocator, &http, assets, scratch, tarball_path, checksums_path, archive_name, opts);
+    try runVerification(.{
+        .allocator = allocator,
+        .http = &http,
+        .assets = assets,
+        .scratch = scratch,
+        .tarball_path = tarball_path,
+        .checksums_path = checksums_path,
+        .archive_name = archive_name,
+        .opts = opts,
+    });
 
     // --- extract + find binary ---
     const extract_dir_buf = try std.fmt.allocPrint(allocator, "{s}/extract", .{scratch});
@@ -246,10 +260,7 @@ fn writeDownload(
     return path;
 }
 
-/// Run cosign + SHA256 verification, or print a loud bypass warning
-/// when the user has opted out of both with `--no-verify` and
-/// `MALT_ALLOW_UNVERIFIED=1`. Fails the update on any verify error.
-fn runVerification(
+const RunVerification = struct {
     allocator: std.mem.Allocator,
     http: *client_mod.HttpClient,
     assets: std.json.Array,
@@ -258,23 +269,30 @@ fn runVerification(
     checksums_path: []const u8,
     archive_name: []const u8,
     opts: Opts,
-) !void {
-    if (opts.no_verify and unverifiedAllowed()) {
+};
+
+/// Run cosign + SHA256 verification, or print a loud bypass warning
+/// when the user has opted out of both with `--no-verify` and
+/// `MALT_ALLOW_UNVERIFIED=1`. Fails the update on any verify error.
+fn runVerification(rv: RunVerification) !void {
+    if (rv.opts.no_verify and unverifiedAllowed()) {
         output.warn("MALT_ALLOW_UNVERIFIED=1 and --no-verify - skipping signature and checksum verification", .{});
         output.warn("This update will not be cryptographically verified. Install cosign to enable verification.", .{});
         return;
     }
 
-    const sigstore_url = release.pickAssetUrlByName(assets, SIGSTORE_NAME) orelse {
+    const sigstore_url = release.pickAssetUrlByName(rv.assets, SIGSTORE_NAME) orelse {
         output.err("Release is missing {s}", .{SIGSTORE_NAME});
         return error.Aborted;
     };
-    const sigstore_path = try writeDownload(allocator, http, sigstore_url, scratch, SIGSTORE_NAME);
+    const sigstore_path = try writeDownload(rv.allocator, rv.http, sigstore_url, rv.scratch, SIGSTORE_NAME);
 
-    output.info("Verifying cosign signature...", .{});
-    verify.verifyCosignBlob(allocator, .{
-        .blob_path = checksums_path,
-        .bundle_path = sigstore_path,
+    output.info("Verifying cosign signature + SHA256 checksum...", .{});
+    verify.verifyAll(rv.allocator, .{
+        .tarball_path = rv.tarball_path,
+        .checksums_path = rv.checksums_path,
+        .sigstore_path = sigstore_path,
+        .archive_name = rv.archive_name,
         .cert_identity_regex = CERT_IDENTITY_REGEX,
         .oidc_issuer = OIDC_ISSUER,
     }) catch |e| switch (e) {
@@ -288,33 +306,43 @@ fn runVerification(
             output.err("cosign signature verification failed for {s}", .{CHECKSUMS_NAME});
             return error.Aborted;
         },
-    };
-
-    output.info("Verifying SHA256 checksum...", .{});
-    const checksums_bytes = fs_compat.readFileAbsoluteAlloc(allocator, checksums_path, 1 << 20) catch {
-        output.err("Cannot read {s}", .{CHECKSUMS_NAME});
-        return error.Aborted;
-    };
-    defer allocator.free(checksums_bytes);
-    const expected = verify.lookupSha256(checksums_bytes, archive_name) orelse {
-        output.err("Checksum for {s} not listed in {s}", .{ archive_name, CHECKSUMS_NAME });
-        return error.Aborted;
-    };
-    const tarball_bytes = fs_compat.readFileAbsoluteAlloc(allocator, tarball_path, 1 << 28) catch {
-        output.err("Cannot read {s}", .{tarball_path});
-        return error.Aborted;
-    };
-    defer allocator.free(tarball_bytes);
-    verify.verifySha256(tarball_bytes, expected) catch |e| switch (e) {
+        error.ChecksumMissing => {
+            output.err("Checksum for {s} not listed in {s}", .{ rv.archive_name, CHECKSUMS_NAME });
+            return error.Aborted;
+        },
         error.ChecksumMismatch => {
-            output.err("SHA256 mismatch for {s}", .{archive_name});
+            output.err("SHA256 mismatch for {s}", .{rv.archive_name});
             return error.Aborted;
         },
         error.InvalidHex => {
-            output.err("Malformed checksum for {s}", .{archive_name});
+            output.err("Malformed checksum for {s}", .{rv.archive_name});
             return error.Aborted;
         },
+        error.ReadFailed => {
+            output.err("Cannot read verification files in {s}", .{rv.scratch});
+            return error.Aborted;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
     };
+}
+
+/// Remove `<self_exe>.old` and any orphaned `.malt-update-*` staging
+/// files next to the running binary. Idempotent - a clean tree exits 0.
+fn runCleanup() !void {
+    var exe_buf: [fs_compat.max_path_bytes]u8 = undefined;
+    const n = std.process.executablePath(io_mod.ctx(), &exe_buf) catch {
+        output.err("Cannot determine current binary path", .{});
+        return error.Aborted;
+    };
+    const cleaned = cleanup.cleanUpdateArtefacts(exe_buf[0..n]) catch {
+        output.err("Cleanup failed", .{});
+        return error.Aborted;
+    };
+    if (cleaned.total() == 0) {
+        output.info("Nothing to clean up.", .{});
+    } else {
+        output.info("Removed {d} .old binary, {d} staging file(s).", .{ cleaned.old, cleaned.staging });
+    }
 }
 
 /// Resolve the running binary via `executablePath` + `realpath` and
@@ -330,12 +358,4 @@ fn detectOrigin() origin.Origin {
 fn unverifiedAllowed() bool {
     const v = fs_compat.getenv("MALT_ALLOW_UNVERIFIED") orelse return false;
     return std.mem.eql(u8, v, "1");
-}
-
-fn strField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
-    const v = obj.get(key) orelse return null;
-    return switch (v) {
-        .string => |s| s,
-        else => null,
-    };
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -42,6 +42,7 @@ pub const cli_help = @import("cli/help.zig");
 pub const cli_info = @import("cli/info.zig");
 pub const cli_uses = @import("cli/uses.zig");
 pub const cli_version_update = @import("cli/version_update.zig");
+pub const update_cleanup = @import("update/cleanup.zig");
 pub const update_origin = @import("update/origin.zig");
 pub const update_release = @import("update/release.zig");
 pub const update_verify = @import("update/verify.zig");

--- a/src/update/cleanup.zig
+++ b/src/update/cleanup.zig
@@ -1,0 +1,47 @@
+//! malt - cleanup of self-update artefacts.
+//!
+//! `<target>.old` is kept for manual rollback after each update.
+//! Over time these accumulate, and killed updates may leave
+//! `.malt-update-<pid>` staging files behind. `cleanUpdateArtefacts`
+//! removes both from the target's directory.
+
+const std = @import("std");
+const fs_compat = @import("../fs/compat.zig");
+const io_mod = @import("../ui/io.zig");
+
+pub const Cleaned = struct {
+    /// Number of `<target>.old` files removed (0 or 1).
+    old: u32 = 0,
+    /// Number of `.malt-update-<pid>` staging files removed.
+    staging: u32 = 0,
+
+    pub fn total(self: Cleaned) u32 {
+        return self.old + self.staging;
+    }
+};
+
+/// Remove `<target>.old` and any `.malt-update-*` staging files in
+/// `target`'s directory. Silent on missing files - "already clean" is
+/// a success state, not an error.
+pub fn cleanUpdateArtefacts(target_path: []const u8) !Cleaned {
+    var cleaned = Cleaned{};
+
+    var old_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const old_path = try std.fmt.bufPrint(&old_buf, "{s}.old", .{target_path});
+    if (fs_compat.deleteFileAbsolute(old_path)) |_| {
+        cleaned.old += 1;
+    } else |_| {}
+
+    const target_dir = std.fs.path.dirname(target_path) orelse return cleaned;
+    var dir = fs_compat.openDirAbsolute(target_dir, .{ .iterate = true }) catch return cleaned;
+    defer dir.close();
+
+    var it = dir.inner.iterate();
+    while (it.next(io_mod.ctx()) catch null) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.startsWith(u8, entry.name, ".malt-update-")) continue;
+        dir.inner.deleteFile(io_mod.ctx(), entry.name) catch continue;
+        cleaned.staging += 1;
+    }
+    return cleaned;
+}

--- a/src/update/release.zig
+++ b/src/update/release.zig
@@ -87,7 +87,9 @@ pub fn findReleaseBinary(
     return null;
 }
 
-fn strField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+/// Return `obj[key]` when it is a JSON string, else `null`. Pub'd so
+/// the updater's `tag_name` extraction can reuse it.
+pub fn strField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
     const v = obj.get(key) orelse return null;
     return switch (v) {
         .string => |s| s,

--- a/src/update/verify.zig
+++ b/src/update/verify.zig
@@ -70,6 +70,56 @@ pub const CosignBlob = struct {
     oidc_issuer: []const u8,
 };
 
+pub const VerifyError = error{
+    CosignNotFound,
+    CosignVerifyFailed,
+    /// `archive_name` has no matching line in `checksums.txt`.
+    ChecksumMissing,
+    ChecksumMismatch,
+    InvalidHex,
+    /// A required input file could not be read (OS error, permissions).
+    ReadFailed,
+    OutOfMemory,
+};
+
+pub const VerifyInputs = struct {
+    /// `"cosign"` for PATH lookup, or an absolute path (tests).
+    cosign_bin: []const u8 = "cosign",
+    tarball_path: []const u8,
+    checksums_path: []const u8,
+    sigstore_path: []const u8,
+    /// Filename as it appears in `checksums.txt`, e.g. `malt_0.7.0_darwin_all.tar.gz`.
+    archive_name: []const u8,
+    cert_identity_regex: []const u8,
+    oidc_issuer: []const u8,
+};
+
+/// Verify a downloaded release end-to-end: cosign-verify the checksums
+/// file, then SHA256-verify the tarball against the now-trusted list.
+/// Pure file I/O + subprocess — the caller is responsible for placing
+/// the three input files on disk. Testable without HTTP.
+pub fn verifyAll(allocator: std.mem.Allocator, in: VerifyInputs) VerifyError!void {
+    verifyCosignBlob(allocator, .{
+        .cosign_bin = in.cosign_bin,
+        .blob_path = in.checksums_path,
+        .bundle_path = in.sigstore_path,
+        .cert_identity_regex = in.cert_identity_regex,
+        .oidc_issuer = in.oidc_issuer,
+    }) catch |e| return e;
+
+    const checksums = fs_compat.readFileAbsoluteAlloc(allocator, in.checksums_path, 1 << 20) catch
+        return error.ReadFailed;
+    defer allocator.free(checksums);
+
+    const expected = lookupSha256(checksums, in.archive_name) orelse return error.ChecksumMissing;
+
+    const tarball = fs_compat.readFileAbsoluteAlloc(allocator, in.tarball_path, 1 << 28) catch
+        return error.ReadFailed;
+    defer allocator.free(tarball);
+
+    return verifySha256(tarball, expected);
+}
+
 /// Shell out to `cosign verify-blob` with the same flags `install.sh` uses.
 /// Exit 0 = verified. Any other outcome maps to a CosignError.
 pub fn verifyCosignBlob(allocator: std.mem.Allocator, args: CosignBlob) CosignError!void {

--- a/tests/cleanup_test.zig
+++ b/tests/cleanup_test.zig
@@ -1,0 +1,106 @@
+//! malt - cleanup of self-update artefacts tests.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const cleanup = malt.update_cleanup;
+const fs_compat = malt.fs_compat;
+
+fn resetScratch(allocator: std.mem.Allocator, tag: []const u8) ![]u8 {
+    const dir = try std.fmt.allocPrint(allocator, "/tmp/malt_cleanup_test_{s}", .{tag});
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    try fs_compat.makeDirAbsolute(dir);
+    return dir;
+}
+
+fn writeFile(path: []const u8, content: []const u8) !void {
+    const f = try fs_compat.createFileAbsolute(path, .{});
+    defer f.close();
+    try f.writeAll(content);
+}
+
+fn exists(path: []const u8) bool {
+    fs_compat.accessAbsolute(path, .{}) catch return false;
+    return true;
+}
+
+test "cleanUpdateArtefacts removes the .old sibling" {
+    const dir = try resetScratch(testing.allocator, "old_only");
+    defer testing.allocator.free(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    const target = try std.fmt.allocPrint(testing.allocator, "{s}/malt", .{dir});
+    defer testing.allocator.free(target);
+    const old = try std.fmt.allocPrint(testing.allocator, "{s}/malt.old", .{dir});
+    defer testing.allocator.free(old);
+
+    try writeFile(target, "live");
+    try writeFile(old, "previous");
+
+    const cleaned = try cleanup.cleanUpdateArtefacts(target);
+    try testing.expectEqual(@as(u32, 1), cleaned.old);
+    try testing.expectEqual(@as(u32, 0), cleaned.staging);
+    try testing.expect(!exists(old));
+    try testing.expect(exists(target)); // live binary must survive
+}
+
+test "cleanUpdateArtefacts removes all .malt-update-* staging files" {
+    const dir = try resetScratch(testing.allocator, "staging_only");
+    defer testing.allocator.free(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    const target = try std.fmt.allocPrint(testing.allocator, "{s}/malt", .{dir});
+    defer testing.allocator.free(target);
+    try writeFile(target, "live");
+
+    const s1 = try std.fmt.allocPrint(testing.allocator, "{s}/.malt-update-111", .{dir});
+    defer testing.allocator.free(s1);
+    const s2 = try std.fmt.allocPrint(testing.allocator, "{s}/.malt-update-222", .{dir});
+    defer testing.allocator.free(s2);
+    try writeFile(s1, "orphan-1");
+    try writeFile(s2, "orphan-2");
+
+    const cleaned = try cleanup.cleanUpdateArtefacts(target);
+    try testing.expectEqual(@as(u32, 2), cleaned.staging);
+    try testing.expect(!exists(s1));
+    try testing.expect(!exists(s2));
+    try testing.expect(exists(target));
+}
+
+test "cleanUpdateArtefacts on an already-clean tree is a no-op" {
+    const dir = try resetScratch(testing.allocator, "nothing");
+    defer testing.allocator.free(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    const target = try std.fmt.allocPrint(testing.allocator, "{s}/malt", .{dir});
+    defer testing.allocator.free(target);
+    try writeFile(target, "live");
+
+    const cleaned = try cleanup.cleanUpdateArtefacts(target);
+    try testing.expectEqual(@as(u32, 0), cleaned.total());
+    try testing.expect(exists(target));
+}
+
+test "cleanUpdateArtefacts does not touch unrelated hidden files" {
+    // Defence against an over-broad glob - only files starting with the
+    // exact prefix `.malt-update-` should be removed.
+    const dir = try resetScratch(testing.allocator, "unrelated");
+    defer testing.allocator.free(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    const target = try std.fmt.allocPrint(testing.allocator, "{s}/malt", .{dir});
+    defer testing.allocator.free(target);
+    try writeFile(target, "live");
+
+    const bystander = try std.fmt.allocPrint(testing.allocator, "{s}/.malt-config", .{dir});
+    defer testing.allocator.free(bystander);
+    const also = try std.fmt.allocPrint(testing.allocator, "{s}/.DS_Store", .{dir});
+    defer testing.allocator.free(also);
+    try writeFile(bystander, "user");
+    try writeFile(also, "mac");
+
+    const cleaned = try cleanup.cleanUpdateArtefacts(target);
+    try testing.expectEqual(@as(u32, 0), cleaned.total());
+    try testing.expect(exists(bystander));
+    try testing.expect(exists(also));
+}

--- a/tests/release_test.zig
+++ b/tests/release_test.zig
@@ -38,6 +38,17 @@ test "matchesAssetName rejects the wrong arch on a per-arch build" {
     try testing.expect(!release.matchesAssetName("malt_0.3.1_darwin_arm64.tar.gz", "x86_64"));
 }
 
+test "matchesAssetName rejects names longer than the internal lowercase buffer" {
+    // The matcher uses a 256-byte stack buffer for the lowercase copy.
+    // Names exceeding it must return false (not silently truncate and
+    // match). Documents the boundary so a future GoReleaser template
+    // change that produces longer names surfaces a clear fix.
+    var buf: [300]u8 = undefined;
+    @memset(&buf, 'a');
+    std.mem.copyForwards(u8, buf[buf.len - 22 ..], "_darwin_all.tar.gz.zip");
+    try testing.expect(!release.matchesAssetName(buf[0..buf.len], "arm64"));
+}
+
 test "matchesAssetName rejects the non-tarball sibling assets" {
     // Release set also contains checksums + signature files; only the
     // tarball is ever a valid pick.

--- a/tests/verify_test.zig
+++ b/tests/verify_test.zig
@@ -131,6 +131,114 @@ test "verifyCosignBlob accepts a cosign that exits 0" {
     try verify.verifyCosignBlob(testing.allocator, args);
 }
 
+// --- verifyAll (end-to-end, local fixtures) ------------------------------
+//
+// Exercises the composed trust chain without HTTP: caller stages three
+// files on disk, verifyAll runs cosign + SHA256 and either succeeds or
+// refuses. Covers every failure mode the updater must catch.
+
+const HELLO_WORLD_HEX_LINE = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9  malt_0.7.0_darwin_all.tar.gz\n";
+const ARCHIVE_NAME = "malt_0.7.0_darwin_all.tar.gz";
+
+const Fixture = struct {
+    dir: []const u8,
+    tarball: []const u8,
+    checksums: []const u8,
+    sigstore: []const u8,
+    cosign_bin: []const u8,
+
+    fn setup(allocator: std.mem.Allocator, tag: []const u8, tarball_bytes: []const u8, checksums_bytes: []const u8, cosign_exit: u8) !Fixture {
+        const dir = try std.fmt.allocPrint(allocator, "/tmp/malt_verifyall_{s}", .{tag});
+        fs_compat.deleteTreeAbsolute(dir) catch {};
+        try fs_compat.makeDirAbsolute(dir);
+
+        const tarball = try std.fmt.allocPrint(allocator, "{s}/malt.tgz", .{dir});
+        const checksums = try std.fmt.allocPrint(allocator, "{s}/checksums.txt", .{dir});
+        const sigstore = try std.fmt.allocPrint(allocator, "{s}/checksums.txt.sigstore.json", .{dir});
+        const cosign_bin = try std.fmt.allocPrint(allocator, "{s}/fake_cosign", .{dir});
+
+        try writeFile(tarball, tarball_bytes);
+        try writeFile(checksums, checksums_bytes);
+        try writeFile(sigstore, "{}"); // content doesn't matter; fake cosign ignores it
+        try writeFakeCosign(cosign_bin, cosign_exit);
+
+        return .{
+            .dir = dir,
+            .tarball = tarball,
+            .checksums = checksums,
+            .sigstore = sigstore,
+            .cosign_bin = cosign_bin,
+        };
+    }
+
+    fn deinit(self: *const Fixture, allocator: std.mem.Allocator) void {
+        fs_compat.deleteTreeAbsolute(self.dir) catch {};
+        allocator.free(self.dir);
+        allocator.free(self.tarball);
+        allocator.free(self.checksums);
+        allocator.free(self.sigstore);
+        allocator.free(self.cosign_bin);
+    }
+
+    fn inputs(self: *const Fixture) verify.VerifyInputs {
+        return .{
+            .cosign_bin = self.cosign_bin,
+            .tarball_path = self.tarball,
+            .checksums_path = self.checksums,
+            .sigstore_path = self.sigstore,
+            .archive_name = ARCHIVE_NAME,
+            .cert_identity_regex = "^https://example\\.com/",
+            .oidc_issuer = "https://example.com",
+        };
+    }
+};
+
+fn writeFile(path: []const u8, content: []const u8) !void {
+    const f = try fs_compat.createFileAbsolute(path, .{});
+    defer f.close();
+    try f.writeAll(content);
+}
+
+test "verifyAll accepts a valid tarball + matching checksum + good cosign" {
+    var fx = try Fixture.setup(testing.allocator, "happy", "hello world", HELLO_WORLD_HEX_LINE, 0);
+    defer fx.deinit(testing.allocator);
+    try verify.verifyAll(testing.allocator, fx.inputs());
+}
+
+test "verifyAll rejects a tampered tarball (SHA256 mismatch)" {
+    var fx = try Fixture.setup(testing.allocator, "sha_mismatch", "hello WORLD", HELLO_WORLD_HEX_LINE, 0);
+    defer fx.deinit(testing.allocator);
+    try testing.expectError(error.ChecksumMismatch, verify.verifyAll(testing.allocator, fx.inputs()));
+}
+
+test "verifyAll rejects when checksums.txt omits the archive" {
+    const unrelated = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  other.tar.gz\n";
+    var fx = try Fixture.setup(testing.allocator, "missing_entry", "hello world", unrelated, 0);
+    defer fx.deinit(testing.allocator);
+    try testing.expectError(error.ChecksumMissing, verify.verifyAll(testing.allocator, fx.inputs()));
+}
+
+test "verifyAll rejects when cosign exits non-zero (signature tampered)" {
+    var fx = try Fixture.setup(testing.allocator, "cosign_fail", "hello world", HELLO_WORLD_HEX_LINE, 1);
+    defer fx.deinit(testing.allocator);
+    try testing.expectError(error.CosignVerifyFailed, verify.verifyAll(testing.allocator, fx.inputs()));
+}
+
+test "verifyAll reports CosignNotFound when the binary is missing" {
+    var fx = try Fixture.setup(testing.allocator, "no_cosign", "hello world", HELLO_WORLD_HEX_LINE, 0);
+    defer fx.deinit(testing.allocator);
+    var inputs = fx.inputs();
+    inputs.cosign_bin = "/tmp/malt_verifyall_absent_cosign_xyz";
+    try testing.expectError(error.CosignNotFound, verify.verifyAll(testing.allocator, inputs));
+}
+
+test "verifyAll reports ReadFailed when the tarball cannot be read" {
+    var fx = try Fixture.setup(testing.allocator, "missing_tarball", "hello world", HELLO_WORLD_HEX_LINE, 0);
+    defer fx.deinit(testing.allocator);
+    try fs_compat.deleteFileAbsolute(fx.tarball);
+    try testing.expectError(error.ReadFailed, verify.verifyAll(testing.allocator, fx.inputs()));
+}
+
 test "verifyCosignBlob errors when cosign exits non-zero" {
     const path = "/tmp/malt_fake_cosign_fail";
     try writeFakeCosign(path, 1);

--- a/tests/version_update_test.zig
+++ b/tests/version_update_test.zig
@@ -8,9 +8,48 @@ const std = @import("std");
 const testing = std.testing;
 const malt = @import("malt");
 const version_mod = malt.version;
+const updater = malt.cli_version_update;
 
 test "version value is non-empty and trimmed" {
     try testing.expect(version_mod.value.len > 0);
     try testing.expect(version_mod.value[version_mod.value.len - 1] != '\n');
     try testing.expect(version_mod.value[version_mod.value.len - 1] != ' ');
+}
+
+// --- parseArgs ------------------------------------------------------------
+//
+// Flag parsing is the tiniest possible target for drift: a typo or
+// refactor that silently disables `--yes` in CI could leave the updater
+// prompting forever. Pin each flag's recognised forms.
+
+test "parseArgs: no flags yields all-false" {
+    const opts = updater.parseArgs(&.{});
+    try testing.expect(!opts.check);
+    try testing.expect(!opts.yes);
+    try testing.expect(!opts.no_verify);
+    try testing.expect(!opts.cleanup);
+}
+
+test "parseArgs: --check sets check" {
+    try testing.expect(updater.parseArgs(&.{"--check"}).check);
+}
+
+test "parseArgs: both long and short forms of --yes" {
+    try testing.expect(updater.parseArgs(&.{"--yes"}).yes);
+    try testing.expect(updater.parseArgs(&.{"-y"}).yes);
+}
+
+test "parseArgs: --no-verify and --cleanup are independent" {
+    const opts = updater.parseArgs(&.{ "--no-verify", "--cleanup" });
+    try testing.expect(opts.no_verify);
+    try testing.expect(opts.cleanup);
+    try testing.expect(!opts.yes);
+}
+
+test "parseArgs: unrecognised flags are ignored (do not crash)" {
+    // Forward-compat: a user passing a flag from a newer version of
+    // malt to an older binary should not crash the updater.
+    const opts = updater.parseArgs(&.{ "--check", "--nonsense", "--yes" });
+    try testing.expect(opts.check);
+    try testing.expect(opts.yes);
 }


### PR DESCRIPTION
## Why

1. The end-to-end trust chain (cosign verify + SHA256 verify + "refuse to swap on failure") had **no test** - each primitive was covered in isolation, the composition was not. A regression that swallowed a verify error one level up would have gone unnoticed.
2. Flag parsing in `mt version update` had no test. `--yes`, `--check`, `--no-verify` could silently stop working after a refactor.
3. After every update the previous binary stays at `<target>.old` for rollback. These **accumulate over time** and there was no way to clean them up short of `rm`.
4. `matchesAssetName` has a hardcoded 256-byte buffer for the lowercase copy. Over-long names returned false silently, with no test pinning the boundary.

## What this changes

**New pure pipeline in the verify module.** `verify.verifyAll(allocator, inputs)` composes cosign + SHA256 + checksum-lookup over file paths, so the full trust chain can be exercised end-to-end without HTTP. `runVerification` in the CLI is now a thin download-then-delegate wrapper, and all user-facing error messages live in one place.

**New `mt version update --cleanup`.** Local-only operation that removes `<target>.old` and any orphaned `.malt-update-<pid>` staging files next to the running binary. Runs without network, safe in offline smoke.

## Behavioural delta

- `mt version update --cleanup` is the only new surface. All other commands behave identically.
- The verification flow is semantically unchanged - same cosign flags, same SHA256 check, same bypass rules. Refactor is structural.