### PR TITLE
fix(ui): light palette — meta info recedes, basic variants align

### DIFF
--- a/justfile
+++ b/justfile
@@ -140,3 +140,33 @@ bench *args:
 [group('docs')]
 record-demo:
     ./scripts/record-demo.sh
+
+# Regenerate docs/contrast-previews/*.png for the four palette cells
+# (dark|light) × (truecolor|basic). Internal: only run after editing
+# the palette cells in src/ui/color.zig or the sample text in
+# scripts/contrast_preview.sh. Requires freeze on PATH
+# (`brew install charmbracelet/tap/freeze`).
+[group('docs')]
+[private]
+contrast-previews:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v freeze >/dev/null || {
+        echo "error: freeze not found — brew install charmbracelet/tap/freeze" >&2
+        exit 1
+    }
+    out=docs/contrast-previews
+    mkdir -p "$out"
+    # Dark variants take freeze's default charm theme + background.
+    THEME=dark  TIER=truecolor freeze -x "bash scripts/contrast_preview.sh" \
+        -o "$out/dark-truecolor.png"
+    THEME=dark  TIER=basic     freeze -x "bash scripts/contrast_preview.sh" \
+        -o "$out/dark-basic.png"
+    # Light variants force the github theme + white background so plain
+    # (uncoloured) body text renders dark on white instead of charm's
+    # light-grey default foreground.
+    THEME=light TIER=truecolor freeze -x "bash scripts/contrast_preview.sh" \
+        -t github -b '#ffffff' -o "$out/light-truecolor.png"
+    THEME=light TIER=basic     freeze -x "bash scripts/contrast_preview.sh" \
+        -t github -b '#ffffff' -o "$out/light-basic.png"
+    echo "Regenerated 4 contrast previews in $out/."

--- a/scripts/contrast_preview.sh
+++ b/scripts/contrast_preview.sh
@@ -33,7 +33,7 @@ elif [[ "$TIER" == truecolor && "$THEME" == light ]]; then
   WARN=$'\033[38;2;180;83;9m'
   SUCCESS=$'\033[38;2;21;128;61m'
   ERR=$'\033[38;2;185;28;28m'
-  DETAIL=$'\033[38;2;71;85;105m'
+  DETAIL=$'\033[38;2;148;163;184m'
 elif [[ "$TIER" == basic && "$THEME" == dark ]]; then
   INFO=$'\033[36m'
   WARN=$'\033[33m'
@@ -45,7 +45,7 @@ else # basic + light
   WARN=$'\033[35m'
   SUCCESS=$'\033[32m'
   ERR=$'\033[31m'
-  DETAIL=$'\033[90m'
+  DETAIL=$'\033[2m'
 fi
 
 PFX_INFO="  ${INFO}▸${RESET} "

--- a/src/ui/color.zig
+++ b/src/ui/color.zig
@@ -276,14 +276,16 @@ const dark_truecolor: Palette = .{
     .detail = "\x1b[38;2;148;163;184m",
 };
 
-// Light + truecolor — Tailwind sky-600 / amber-700 / green-700 / red-700 / slate-600.
+// Light + truecolor — Tailwind sky-600 / amber-700 / green-700 / red-700 / slate-400.
 // Yellow shifts to orange (amber-700) because only orange hits AA on white.
+// Detail uses slate-400 like the dark palette so meta info recedes under the
+// default-foreground body text instead of upstaging it in dark slate.
 const light_truecolor: Palette = .{
     .info = "\x1b[38;2;2;132;199m",
     .warn = "\x1b[38;2;180;83;9m",
     .success = "\x1b[38;2;21;128;61m",
     .err = "\x1b[38;2;185;28;28m",
-    .detail = "\x1b[38;2;71;85;105m",
+    .detail = "\x1b[38;2;148;163;184m",
 };
 
 // Dark + basic — legacy ANSI 8-colour palette malt has always used.
@@ -296,13 +298,15 @@ const dark_basic: Palette = .{
 };
 
 // Light + basic — swap hues that wash out on white: cyan→blue,
-// yellow→magenta, dim→bright_black. Green and red stay readable.
+// yellow→magenta. Detail reuses the dark-basic faint code so both basic
+// palettes render meta info identically — dropping into the default
+// foreground on terminals that ignore SGR 2.
 const light_basic: Palette = .{
     .info = "\x1b[34m",
     .warn = "\x1b[35m",
     .success = "\x1b[32m",
     .err = "\x1b[31m",
-    .detail = "\x1b[90m",
+    .detail = "\x1b[2m",
 };
 
 /// Pure palette lookup. Exposed so tests pin every cell.

--- a/tests/ui_color_theme_test.zig
+++ b/tests/ui_color_theme_test.zig
@@ -172,7 +172,9 @@ test "paletteCode: light + truecolor palette (orange warn for AA contrast on whi
     try testing.expectEqualStrings("\x1b[38;2;180;83;9m", c(.warn, l, true));
     try testing.expectEqualStrings("\x1b[38;2;21;128;61m", c(.success, l, true));
     try testing.expectEqualStrings("\x1b[38;2;185;28;28m", c(.err, l, true));
-    try testing.expectEqualStrings("\x1b[38;2;71;85;105m", c(.detail, l, true));
+    // Detail mirrors the dark palette's slate-400 so meta info recedes
+    // instead of out-weighting the default-foreground body text.
+    try testing.expectEqualStrings("\x1b[38;2;148;163;184m", c(.detail, l, true));
 }
 
 test "paletteCode: dark + basic falls back to today's legacy palette" {
@@ -185,14 +187,15 @@ test "paletteCode: dark + basic falls back to today's legacy palette" {
     try testing.expectEqualStrings("\x1b[2m", c(.detail, d, false));
 }
 
-test "paletteCode: light + basic swaps fade-prone hues (cyan→blue, yellow→magenta, dim→grey)" {
+test "paletteCode: light + basic swaps fade-prone hues (cyan→blue, yellow→magenta) and shares dark-basic faint" {
     const c = color.paletteCode;
     const l = color.Background.light;
     try testing.expectEqualStrings("\x1b[34m", c(.info, l, false));
     try testing.expectEqualStrings("\x1b[35m", c(.warn, l, false));
     try testing.expectEqualStrings("\x1b[32m", c(.success, l, false));
     try testing.expectEqualStrings("\x1b[31m", c(.err, l, false));
-    try testing.expectEqualStrings("\x1b[90m", c(.detail, l, false));
+    // Same faint as dark-basic: both basic palettes render detail identically.
+    try testing.expectEqualStrings("\x1b[2m", c(.detail, l, false));
 }
 
 test "paletteCode: unknown background behaves like dark" {


### PR DESCRIPTION
## Summary

**Problem**

On a light terminal, meta info in the truecolor palette was out-weighting the default-foreground body text (dark slate upstaging plain text), and the basic palette rendered detail in a distinct bright-black grey while dark-basic collapses it into the default foreground. Net effect: the visual hierarchy inverted the moment a user switched to a light theme.

**Solution**

This nudges both light cells so the four palettes share one story:

- Truecolor detail drops to slate-400, matching the dark cell, so meta info fades under the body text instead of competing with it.
- Basic detail reuses dark-basic's faint (SGR 2), so both basic cells behave identically and collapse to the default foreground on terminals that ignore faint.