### PR TITLE
chore(github): add issue forms and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,105 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in malt
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below.
+
+  - type: input
+    id: version
+    attributes:
+      label: malt version
+      description: What version of malt are you running? (`mt version`)
+      placeholder: "e.g., 0.7.0"
+    validations:
+      required: true
+
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version
+      description: Output of `sw_vers -productVersion`.
+      placeholder: "e.g., 14.5"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: arch
+    attributes:
+      label: Architecture
+      options:
+        - Apple Silicon (arm64)
+        - Intel (x86_64)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install_method
+    attributes:
+      label: Install method
+      options:
+        - install.sh (one-liner)
+        - Homebrew (brew install indaco/tap/malt)
+        - Built from source
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Run `mt install jq`
+        2. Run `mt upgrade`
+        3. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Error Output
+      description: If applicable, paste any error messages or logs. Re-running with `--debug` surfaces every DSL diagnostic and is the most useful output for triage.
+      render: shell
+
+  - type: textarea
+    id: doctor
+    attributes:
+      label: `mt doctor` output
+      description: Output of `mt doctor`, if relevant.
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,64 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for malt
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please fill out the form below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: A clear description of what the problem is. Ex. I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+      placeholder: A clear description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or features you've considered.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Feature Area
+      description: What part of malt does this feature relate to?
+      options:
+        - Install / uninstall / upgrade
+        - Self-update (`mt version update`)
+        - Services (launchd)
+        - Bundles (Brewfile)
+        - Taps
+        - Rollback
+        - Ephemeral run (`mt run`)
+        - Post-install DSL interpreter
+        - Content-addressable store / caching
+        - Download pipeline / performance
+        - Homebrew fallback
+        - JSON output / scripting
+        - Security / cosign verification
+        - Migration / backup / restore
+        - Shell completions
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context, mockups, or examples about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,48 @@
+name: Question
+description: Ask a question about using malt
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question about malt? We're here to help!
+
+        Before asking, please check:
+        - [README](https://github.com/indaco/malt#readme)
+        - [Existing issues](https://github.com/indaco/malt/issues)
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your Question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: topic
+    attributes:
+      label: Topic
+      description: What area does your question relate to?
+      options:
+        - Getting started / Installation
+        - Install / uninstall / upgrade
+        - Self-update (`mt version update`)
+        - Services (launchd)
+        - Bundles (Brewfile)
+        - Taps
+        - Rollback
+        - Ephemeral run (`mt run`)
+        - Post-install DSL interpreter
+        - Homebrew fallback
+        - Security / cosign verification
+        - Migration / backup / restore
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any additional context that might help us answer your question.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Description
+
+<!-- What does this PR do? -->
+
+## Related Issue
+
+<!-- Link to related issue if any, e.g., "Fixes #123" -->
+
+## Notes for Reviewers
+
+<!-- Anything specific you'd like feedback on? -->


### PR DESCRIPTION
## Description

Adds structured issue forms and a minimal PR template so inbound triage starts from the same baseline every time.

- Bug reports ask for `mt version`, macOS version + arch, install method, reproduction, and `--debug` output - the fields that actually unblock triage.
- Feature requests and questions expose malt-specific areas (post-install DSL, services, bundles, taps, rollback, `mt run`, cosign, Homebrew fallback) so issues land in the right mental bucket.
- Blank issues are disabled; the PR template gives a three-section skeleton (description, related issue, reviewer notes).

## Related Issue

- None

## Notes for Reviewers

- None