### PR TITLE
fix(github): restore bug report template in issue picker

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -94,7 +94,7 @@ body:
   - type: textarea
     id: doctor
     attributes:
-      label: `mt doctor` output
+      label: Doctor output
       description: Output of `mt doctor`, if relevant.
       render: shell
 


### PR DESCRIPTION
## Description

The bug report form stopped appearing in the "New issue" picker. The cause is a label value that starts with a backtick (`` `mt doctor` output ``);

Switch the label to plain text ("Doctor output"). The backticks stay in the description line, which renders as Markdown, so the `mt doctor` reference is preserved.

## Related Issue

- None

## Notes for Reviewers

- None