### PR TITLE
fix(cask): handle extensionless download URLs via HEAD redirect resolution

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -167,6 +167,7 @@ pub fn build(b: *std.Build) void {
         "tests/ui_color_theme_test.zig",
         "tests/install_local_test.zig",
         "tests/cask_extra_test.zig",
+        "tests/cask_resolve_test.zig",
         "tests/dsl_interpreter_extra_test.zig",
         "tests/list_test.zig",
         "tests/search_test.zig",

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1356,6 +1356,18 @@ fn maybeRegisterService(
     };
 }
 
+/// HEAD-based fallback for extensionless cask URLs.
+/// Follows redirects to discover the real file extension.
+fn resolveCaskArtifactViaHead(allocator: std.mem.Allocator, url: []const u8) cask_mod.ArtifactType {
+    var http = client_mod.HttpClient.init(allocator);
+    defer http.deinit();
+
+    var resolved = http.headResolved(url) catch return .unknown;
+    defer resolved.deinit();
+
+    return cask_mod.resolveArtifactType(allocator, resolved.final_url, resolved.content_disposition);
+}
+
 /// Install a cask (DMG, ZIP, or PKG).
 fn installCask(
     allocator: std.mem.Allocator,
@@ -1382,7 +1394,13 @@ fn installCask(
         return;
     }
 
-    const artifact_type = cask_mod.artifactTypeFromUrl(cask.url);
+    var artifact_type = cask_mod.artifactTypeFromUrl(cask.url);
+
+    // Extensionless URLs (e.g. download APIs that 302 to the real file):
+    // resolve via HEAD to discover the final URL and Content-Disposition.
+    if (artifact_type == .unknown) {
+        artifact_type = resolveCaskArtifactViaHead(allocator, cask.url);
+    }
 
     if (dry_run) {
         output.info("Dry run: would install cask {s} {s} ({s})", .{
@@ -1408,6 +1426,7 @@ fn installCask(
 
     const prefix = atomic.maltPrefix();
     var installer = cask_mod.CaskInstaller.init(allocator, db, prefix);
+    installer.artifact_type_override = artifact_type;
 
     // Progress bar for cask download
     var bar = progress_mod.ProgressBar.init(cask.token, 0);

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -93,6 +93,84 @@ pub fn artifactTypeFromUrl(url: []const u8) ArtifactType {
     return .unknown;
 }
 
+/// Detect artifact type from a Content-Disposition header value.
+/// Handles both `filename="X.dmg"` and `filename*=UTF-8''X.dmg`.
+pub fn artifactTypeFromContentDisposition(header: []const u8) ArtifactType {
+    const filename = extractFilename(header) orelse return .unknown;
+    return artifactTypeFromUrl(filename);
+}
+
+/// Combined resolution: URL extension first, then Content-Disposition.
+/// `content_disposition` is nullable — pass the header from a HEAD
+/// response when the URL alone is ambiguous.
+pub fn resolveArtifactType(
+    _: std.mem.Allocator,
+    url: []const u8,
+    content_disposition: ?[]const u8,
+) ArtifactType {
+    const from_url = artifactTypeFromUrl(url);
+    if (from_url != .unknown) return from_url;
+
+    if (content_disposition) |cd| {
+        const from_cd = artifactTypeFromContentDisposition(cd);
+        if (from_cd != .unknown) return from_cd;
+    }
+
+    return .unknown;
+}
+
+fn extractFilename(header: []const u8) ?[]const u8 {
+    // Try filename*= first (RFC 5987), then filename=
+    for ([_][]const u8{ "filename*=", "filename=" }) |key| {
+        var pos: usize = 0;
+        while (pos < header.len) {
+            if (std.mem.indexOfPos(u8, header, pos, key)) |start| {
+                var val_start = start + key.len;
+                // Skip whitespace after '='
+                while (val_start < header.len and header[val_start] == ' ') val_start += 1;
+
+                if (std.mem.eql(u8, key, "filename*=")) {
+                    // Skip charset and language: e.g. UTF-8''
+                    if (std.mem.indexOfPos(u8, header, val_start, "''")) |ticks| {
+                        val_start = ticks + 2;
+                    }
+                }
+
+                // Strip optional quotes
+                if (val_start < header.len and header[val_start] == '"') {
+                    val_start += 1;
+                    if (std.mem.indexOfPos(u8, header, val_start, "\"")) |end| {
+                        return header[val_start..end];
+                    }
+                }
+                // Unquoted: run until semicolon, space, or end
+                const end = blk: {
+                    for (header[val_start..], val_start..) |ch, i| {
+                        if (ch == ';' or ch == ' ') break :blk i;
+                    }
+                    break :blk header.len;
+                };
+                if (end > val_start) return header[val_start..end];
+                pos = val_start;
+            } else break;
+        }
+    }
+
+    // Also handle `filename =` (space before equals)
+    if (std.mem.indexOf(u8, header, "filename")) |fn_start| {
+        var i = fn_start + "filename".len;
+        while (i < header.len and (header[i] == ' ' or header[i] == '=')) i += 1;
+        if (i < header.len and header[i] == '"') {
+            i += 1;
+            if (std.mem.indexOfPos(u8, header, i, "\"")) |end| {
+                return header[i..end];
+            }
+        }
+    }
+
+    return null;
+}
+
 /// Extract the .app bundle name from cask JSON artifacts array.
 /// Homebrew cask JSON: "artifacts": [{"app": ["Firefox.app"]}, ...]
 pub fn parseAppName(obj: std.json.ObjectMap) ?[]const u8 {
@@ -130,6 +208,8 @@ pub const CaskInstaller = struct {
     prefix: [:0]const u8,
     db: *sqlite.Database,
     progress: ?client_mod.ProgressCallback,
+    /// Pre-resolved type for extensionless URLs (HEAD fallback).
+    artifact_type_override: ?ArtifactType = null,
 
     pub fn init(allocator: std.mem.Allocator, db: *sqlite.Database, prefix: [:0]const u8) CaskInstaller {
         return .{ .allocator = allocator, .db = db, .prefix = prefix, .progress = null };
@@ -138,7 +218,7 @@ pub const CaskInstaller = struct {
     /// Install a cask. Downloads, verifies SHA256, and installs based on artifact type.
     /// Returns the installed app path on success.
     pub fn install(self: *CaskInstaller, cask: *const Cask) CaskError![]const u8 {
-        const artifact_type = artifactTypeFromUrl(cask.url);
+        const artifact_type = self.artifact_type_override orelse artifactTypeFromUrl(cask.url);
         if (artifact_type == .unknown) return CaskError.InstallFailed;
 
         // Ensure cache/Cask/ directory exists
@@ -248,7 +328,8 @@ pub const CaskInstaller = struct {
     // --- Private helpers ---
 
     fn downloadToCache(self: *CaskInstaller, cask: *const Cask, cache_dir: []const u8, progress: ?client_mod.ProgressCallback) ![]const u8 {
-        const ext_str = switch (artifactTypeFromUrl(cask.url)) {
+        const resolved = self.artifact_type_override orelse artifactTypeFromUrl(cask.url);
+        const ext_str = switch (resolved) {
             .dmg => ".dmg",
             .zip => ".zip",
             .pkg => ".pkg",

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -133,6 +133,66 @@ pub const HttpClient = struct {
         return @intFromEnum(response.head.status);
     }
 
+    pub const HeadResolved = struct {
+        final_url: []const u8,
+        content_disposition: ?[]const u8,
+        allocator: std.mem.Allocator,
+
+        pub fn deinit(self: *HeadResolved) void {
+            self.allocator.free(self.final_url);
+            if (self.content_disposition) |cd| self.allocator.free(cd);
+        }
+    };
+
+    const MAX_HEAD_REDIRECTS = 5;
+
+    /// HEAD request that manually follows redirects, returning the
+    /// final URL and Content-Disposition. The stdlib skips redirect
+    /// handling for HEAD, so we follow Location headers ourselves.
+    pub fn headResolved(self: *HttpClient, url: []const u8) !HeadResolved {
+        var current_url = try self.allocator.dupe(u8, url);
+        var cd_result: ?[]const u8 = null;
+
+        for (0..MAX_HEAD_REDIRECTS) |_| {
+            const uri = std.Uri.parse(current_url) catch {
+                break;
+            };
+
+            var req = self.client.request(.HEAD, uri, .{
+                .extra_headers = &.{},
+            }) catch break;
+            defer req.deinit();
+
+            req.sendBodiless() catch break;
+
+            var redirect_buf: [32 * 1024]u8 = undefined;
+            const response = req.receiveHead(&redirect_buf) catch break;
+
+            if (cd_result == null) {
+                if (response.head.content_disposition) |cd| {
+                    cd_result = try self.allocator.dupe(u8, cd);
+                }
+            }
+
+            const status: u16 = @intFromEnum(response.head.status);
+            if (status >= 301 and status <= 308) {
+                if (response.head.location) |loc| {
+                    const next = try self.allocator.dupe(u8, loc);
+                    self.allocator.free(current_url);
+                    current_url = next;
+                    continue;
+                }
+            }
+            break;
+        }
+
+        return .{
+            .final_url = current_url,
+            .content_disposition = cd_result,
+            .allocator = self.allocator,
+        };
+    }
+
     /// Default maximum response body size for metadata (API JSON, tokens, etc.).
     /// The full Homebrew formula.json index is ~25 MB; 50 MB gives headroom.
     /// Bottle downloads bypass this via getWithHeaders (which sets no limit).
@@ -404,6 +464,37 @@ pub const HttpClient = struct {
         };
     }
 };
+
+fn formatUri(allocator: std.mem.Allocator, uri: std.Uri) ![]const u8 {
+    const scheme = uri.scheme;
+    const host = if (uri.host) |h| switch (h) {
+        .raw => |r| r,
+        .percent_encoded => |p| p,
+    } else "";
+    const path = switch (uri.path) {
+        .raw => |r| r,
+        .percent_encoded => |p| p,
+    };
+    const query = if (uri.query) |q| switch (q) {
+        .raw => |r| r,
+        .percent_encoded => |p| p,
+    } else null;
+    const fragment = if (uri.fragment) |f| switch (f) {
+        .raw => |r| r,
+        .percent_encoded => |p| p,
+    } else null;
+
+    if (fragment) |frag| {
+        if (query) |q| {
+            return std.fmt.allocPrint(allocator, "{s}://{s}{s}?{s}#{s}", .{ scheme, host, path, q, frag });
+        }
+        return std.fmt.allocPrint(allocator, "{s}://{s}{s}#{s}", .{ scheme, host, path, frag });
+    }
+    if (query) |q| {
+        return std.fmt.allocPrint(allocator, "{s}://{s}{s}?{s}", .{ scheme, host, path, q });
+    }
+    return std.fmt.allocPrint(allocator, "{s}://{s}{s}", .{ scheme, host, path });
+}
 
 /// Thread-safe pool of `HttpClient` instances with borrow/return
 /// semantics. Workers call `acquire()` to get exclusive access to an

--- a/tests/cask_extra_test.zig
+++ b/tests/cask_extra_test.zig
@@ -53,6 +53,36 @@ test "CaskInstaller.install rejects a cask with an unknown artifact URL extensio
     try testing.expectError(cask.CaskError.InstallFailed, installer.install(&c));
 }
 
+test "artifact_type_override bypasses URL detection" {
+    // Extensionless URL would normally fail; override lets it proceed
+    // past the type gate (install still fails later, but not at the gate).
+    const extensionless_json =
+        \\{"token":"noext","name":["NoExt"],"version":"1.0",
+        \\ "url":"https://example.com/download?build=arm",
+        \\ "sha256":"no_check","homepage":"","desc":"","auto_updates":false,"artifacts":[]}
+    ;
+    var c = try cask.parseCask(testing.allocator, extensionless_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    const prefix: [:0]const u8 = "/tmp/mc4";
+    var installer = cask.CaskInstaller.init(testing.allocator, &db, prefix);
+
+    // Without override: fails at the type gate with InstallFailed
+    try testing.expectError(cask.CaskError.InstallFailed, installer.install(&c));
+
+    // With override: passes the type gate (gets further before failing)
+    installer.artifact_type_override = .dmg;
+    malt.fs_compat.cwd().makePath(prefix ++ "/cache/Cask") catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+    const result = installer.install(&c);
+    // Should fail on download, not on the type gate
+    try testing.expectError(cask.CaskError.DownloadFailed, result);
+}
+
 test "CaskInstaller.uninstall removes app_path, caskroom, cache, and the DB row" {
     const test_cask_json =
         \\{"token":"firefox","name":["Firefox"],"version":"123.0","desc":"","homepage":"",

--- a/tests/cask_resolve_test.zig
+++ b/tests/cask_resolve_test.zig
@@ -1,0 +1,153 @@
+//! malt — cask artifact resolution tests
+//! Covers Content-Disposition parsing and the HEAD-based redirect
+//! fallback for extensionless cask URLs.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const cask = malt.cask;
+
+// --- artifactTypeFromUrl: extensionless / edge-case URLs ---
+
+test "artifactTypeFromUrl returns unknown for extensionless path with query" {
+    try testing.expectEqual(
+        cask.ArtifactType.unknown,
+        cask.artifactTypeFromUrl("https://releases.example.com/v1.0/download?build=arm"),
+    );
+}
+
+test "artifactTypeFromUrl returns unknown for bare path" {
+    try testing.expectEqual(
+        cask.ArtifactType.unknown,
+        cask.artifactTypeFromUrl("https://example.com/releases/latest/download"),
+    );
+}
+
+test "artifactTypeFromUrl detects .dmg with fragment" {
+    try testing.expectEqual(
+        cask.ArtifactType.dmg,
+        cask.artifactTypeFromUrl("https://example.com/App.dmg#anchor"),
+    );
+}
+
+test "artifactTypeFromUrl detects .pkg with query" {
+    try testing.expectEqual(
+        cask.ArtifactType.pkg,
+        cask.artifactTypeFromUrl("https://cdn.example.com/Install.pkg?v=2"),
+    );
+}
+
+// --- artifactTypeFromContentDisposition ---
+
+test "Content-Disposition: extracts .dmg from filename" {
+    try testing.expectEqual(
+        cask.ArtifactType.dmg,
+        cask.artifactTypeFromContentDisposition("attachment; filename=\"App.dmg\""),
+    );
+}
+
+test "Content-Disposition: extracts .zip from filename" {
+    try testing.expectEqual(
+        cask.ArtifactType.zip,
+        cask.artifactTypeFromContentDisposition("attachment; filename=\"App.zip\""),
+    );
+}
+
+test "Content-Disposition: extracts .pkg from filename" {
+    try testing.expectEqual(
+        cask.ArtifactType.pkg,
+        cask.artifactTypeFromContentDisposition("attachment; filename=\"Installer.pkg\""),
+    );
+}
+
+test "Content-Disposition: handles filename* (RFC 5987 extended)" {
+    try testing.expectEqual(
+        cask.ArtifactType.dmg,
+        cask.artifactTypeFromContentDisposition("attachment; filename*=UTF-8''My%20App.dmg"),
+    );
+}
+
+test "Content-Disposition: handles unquoted filename" {
+    try testing.expectEqual(
+        cask.ArtifactType.zip,
+        cask.artifactTypeFromContentDisposition("attachment; filename=release.zip"),
+    );
+}
+
+test "Content-Disposition: returns unknown for no filename" {
+    try testing.expectEqual(
+        cask.ArtifactType.unknown,
+        cask.artifactTypeFromContentDisposition("attachment"),
+    );
+}
+
+test "Content-Disposition: returns unknown for non-matching extension" {
+    try testing.expectEqual(
+        cask.ArtifactType.unknown,
+        cask.artifactTypeFromContentDisposition("attachment; filename=\"archive.tar.gz\""),
+    );
+}
+
+test "Content-Disposition: returns unknown for empty string" {
+    try testing.expectEqual(
+        cask.ArtifactType.unknown,
+        cask.artifactTypeFromContentDisposition(""),
+    );
+}
+
+test "Content-Disposition: handles case with spaces around equals" {
+    try testing.expectEqual(
+        cask.ArtifactType.dmg,
+        cask.artifactTypeFromContentDisposition("attachment; filename = \"App.dmg\""),
+    );
+}
+
+// --- resolveArtifactType: combined resolution logic ---
+
+test "resolveArtifactType returns url-detected type without network" {
+    const result = cask.resolveArtifactType(
+        testing.allocator,
+        "https://example.com/App.dmg",
+        null,
+    );
+    try testing.expectEqual(cask.ArtifactType.dmg, result);
+}
+
+test "resolveArtifactType falls back to Content-Disposition" {
+    // Simulates a HEAD response that returned a Content-Disposition header.
+    // When the URL has no extension, Content-Disposition is the next signal.
+    const result = cask.resolveArtifactType(
+        testing.allocator,
+        "https://releases.example.com/v1.0/download?build=arm",
+        "attachment; filename=\"Raycast.dmg\"",
+    );
+    try testing.expectEqual(cask.ArtifactType.dmg, result);
+}
+
+test "resolveArtifactType returns unknown when all signals fail" {
+    const result = cask.resolveArtifactType(
+        testing.allocator,
+        "https://releases.example.com/download",
+        null,
+    );
+    try testing.expectEqual(cask.ArtifactType.unknown, result);
+}
+
+test "resolveArtifactType prefers url over Content-Disposition" {
+    // URL says .zip, Content-Disposition says .dmg — trust the URL
+    const result = cask.resolveArtifactType(
+        testing.allocator,
+        "https://example.com/App.zip",
+        "attachment; filename=\"wrong.dmg\"",
+    );
+    try testing.expectEqual(cask.ArtifactType.zip, result);
+}
+
+test "resolveArtifactType handles Content-Disposition with unknown ext" {
+    const result = cask.resolveArtifactType(
+        testing.allocator,
+        "https://example.com/download",
+        "attachment; filename=\"archive.tar.gz\"",
+    );
+    try testing.expectEqual(cask.ArtifactType.unknown, result);
+}


### PR DESCRIPTION
## Description

Casks whose download URL has no file extension (e.g. download APIs that
302-redirect to the real `.dmg`) were rejected with "Unsupported cask format".

- When `artifactTypeFromUrl` returns unknown, a lightweight HEAD request
  follows the redirect chain to discover the final URL and its extension
- Content-Disposition header parsing provides a secondary signal
- The resolved type is passed through to `CaskInstaller` so the download
  cache also gets the correct file extension

## Related Issue

- None

## Notes for Reviewers

- None

Generated with [Claude Code](https://claude.ai/code)