### PR TITLE
feat(migrate): --json output, SIGINT check, lock-timeout env

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -175,6 +175,7 @@ pub fn build(b: *std.Build) void {
         "tests/uses_test.zig",
         "tests/output_test.zig",
         "tests/worker_arena_test.zig",
+        "tests/migrate_smoke_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/scripts/e2e/migrate_dry_run_check.sh
+++ b/scripts/e2e/migrate_dry_run_check.sh
@@ -36,20 +36,20 @@ TMP=$(mktemp -d /tmp/mt_migcheck.XXX)
 trap 'rm -rf "$TMP"' EXIT
 
 # 1. What `brew` thinks is installed.
-brew list --formulae | sort -u > "$TMP/brew.txt"
+brew list --formulae | sort -u >"$TMP/brew.txt"
 
 # 2. What `mt migrate --dry-run` discovers in the same Cellar. JSON
 #    output is stable + parseable; the keg list lives at `.kegs`.
-"$MT_BIN" migrate --dry-run --json | jq -r '.kegs[]' | sort -u > "$TMP/mt.txt"
+"$MT_BIN" migrate --dry-run --json | jq -r '.kegs[]' | sort -u >"$TMP/mt.txt"
 
-BREW_N=$(wc -l < "$TMP/brew.txt" | tr -d ' ')
-MT_N=$(wc -l < "$TMP/mt.txt" | tr -d ' ')
+BREW_N=$(wc -l <"$TMP/brew.txt" | tr -d ' ')
+MT_N=$(wc -l <"$TMP/mt.txt" | tr -d ' ')
 
 echo "brew list --formulae : $BREW_N"
 echo "mt migrate --dry-run : $MT_N"
 echo
 
-if diff -u "$TMP/brew.txt" "$TMP/mt.txt" > "$TMP/diff.txt"; then
+if diff -u "$TMP/brew.txt" "$TMP/mt.txt" >"$TMP/diff.txt"; then
   echo "migrate-check: OK — keg sets match"
   exit 0
 fi

--- a/scripts/e2e/migrate_dry_run_check.sh
+++ b/scripts/e2e/migrate_dry_run_check.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# scripts/e2e/migrate_dry_run_check.sh
+#
+# Manual QA check: runs `mt migrate --dry-run --json` against the user's
+# real Homebrew install and diffs the reported keg set against
+# `brew list --formulae`. Meant for a dev machine with brew already set
+# up — never runs in CI.
+#
+# Read-only: --dry-run never touches MALT_PREFIX, never hits GHCR, never
+# writes to the Homebrew Cellar.
+#
+# Usage:
+#   ./scripts/e2e/migrate_dry_run_check.sh                # default brew
+#   HOMEBREW_PREFIX=/custom/brew ./scripts/e2e/migrate_dry_run_check.sh
+#   MT_BIN=./zig-out/bin/malt ./scripts/e2e/migrate_dry_run_check.sh
+
+set -uo pipefail
+
+MT_BIN="${MT_BIN:-./zig-out/bin/malt}"
+
+if [[ ! -x "$MT_BIN" ]]; then
+  echo "migrate-check: $MT_BIN not found or not executable" >&2
+  echo "migrate-check: run 'zig build' first (or set MT_BIN)" >&2
+  exit 2
+fi
+if ! command -v brew >/dev/null 2>&1; then
+  echo "migrate-check: brew not on PATH — nothing to compare against" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "migrate-check: jq is required to parse --json output" >&2
+  exit 2
+fi
+
+TMP=$(mktemp -d /tmp/mt_migcheck.XXX)
+trap 'rm -rf "$TMP"' EXIT
+
+# 1. What `brew` thinks is installed.
+brew list --formulae | sort -u > "$TMP/brew.txt"
+
+# 2. What `mt migrate --dry-run` discovers in the same Cellar. JSON
+#    output is stable + parseable; the keg list lives at `.kegs`.
+"$MT_BIN" migrate --dry-run --json | jq -r '.kegs[]' | sort -u > "$TMP/mt.txt"
+
+BREW_N=$(wc -l < "$TMP/brew.txt" | tr -d ' ')
+MT_N=$(wc -l < "$TMP/mt.txt" | tr -d ' ')
+
+echo "brew list --formulae : $BREW_N"
+echo "mt migrate --dry-run : $MT_N"
+echo
+
+if diff -u "$TMP/brew.txt" "$TMP/mt.txt" > "$TMP/diff.txt"; then
+  echo "migrate-check: OK — keg sets match"
+  exit 0
+fi
+
+echo "migrate-check: MISMATCH — diff (< brew, > malt):"
+cat "$TMP/diff.txt"
+exit 1

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -187,6 +187,10 @@ const migrate_help =
     \\
     \\Flags:
     \\  --dry-run          Show what would be migrated
+    \\  --json             Emit a machine-readable summary on stdout (pairs with
+    \\                     --dry-run to list kegs, or with a real run to report
+    \\                     per-category names + counts for migrated / skipped /
+    \\                     failed).
     \\  --use-system-ruby=<name>,...  Run post_install via the system Ruby interpreter
     \\                     (experimental, sandboxed) for the named kegs only. A bare
     \\                     `--use-system-ruby` is not allowed here — it would widen

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -274,4 +274,3 @@ fn writeCaskRows(
         }
     }
 }
-

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -195,7 +195,7 @@ pub fn buildListJson(
         try w.writeAll("]");
     }
 
-    try writeTimeSuffix(w, start_ts);
+    try output.jsonTimeSuffix(w, start_ts);
     try w.writeAll("}\n");
 }
 
@@ -275,10 +275,3 @@ fn writeCaskRows(
     }
 }
 
-/// Write the ,"time_ms":N suffix for JSON output.
-fn writeTimeSuffix(w: anytype, start_ts: i64) !void {
-    const elapsed = fs_compat.milliTimestamp() - start_ts;
-    var time_buf: [32]u8 = undefined;
-    const time_str = std.fmt.bufPrint(&time_buf, ",\"time_ms\":{d}", .{elapsed}) catch return;
-    try w.writeAll(time_str);
-}

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -19,6 +19,7 @@ const ghcr_mod = @import("../net/ghcr.zig");
 const api_mod = @import("../net/api.zig");
 const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
+const io_mod = @import("../ui/io.zig");
 const codesign = @import("../macho/codesign.zig");
 const ruby_sub = @import("../core/ruby_subprocess.zig");
 const dsl = @import("../core/dsl/root.zig");
@@ -40,6 +41,14 @@ pub fn detectBrewPrefix() []const u8 {
     return if (codesign.isArm64()) "/opt/homebrew" else "/usr/local";
 }
 
+/// Lock-acquire timeout. `MALT_LOCK_TIMEOUT_MS` overrides the 30 s default.
+fn lockTimeoutMs() u32 {
+    if (fs_compat.getenv("MALT_LOCK_TIMEOUT_MS")) |v| {
+        return std.fmt.parseInt(u32, v, 10) catch 30_000;
+    }
+    return 30_000;
+}
+
 /// Result of migrating a single keg.
 const KegResult = enum {
     migrated,
@@ -54,6 +63,8 @@ const KegResult = enum {
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "migrate")) return;
 
+    const start_ts = fs_compat.milliTimestamp();
+    const json_mode = output.isJson();
     var dry_run = output.isDryRun();
     // Ruby is opt-in per keg only. A bare --use-system-ruby across a
     // whole `migrate` would widen the trust boundary to every
@@ -114,7 +125,11 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     if (keg_names.items.len == 0) {
-        output.info("No kegs found in Homebrew Cellar", .{});
+        if (json_mode) {
+            try emitDryRunJson(allocator, brew_prefix, &.{}, dry_run, start_ts);
+        } else {
+            output.info("No kegs found in Homebrew Cellar", .{});
+        }
         return;
     }
 
@@ -122,11 +137,15 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     // ── Dry-run mode: list and exit ─────────────────────────────────
     if (dry_run) {
-        for (keg_names.items) |name| {
-            output.info("  Would migrate: {s}", .{name});
+        if (json_mode) {
+            try emitDryRunJson(allocator, brew_prefix, keg_names.items, true, start_ts);
+        } else {
+            for (keg_names.items) |name| {
+                output.info("  Would migrate: {s}", .{name});
+            }
+            output.info("Would migrate {d} packages from Homebrew", .{keg_names.items.len});
+            output.warn("Run without --dry-run to perform migration", .{});
         }
-        output.info("Would migrate {d} packages from Homebrew", .{keg_names.items.len});
-        output.warn("Run without --dry-run to perform migration", .{});
         return;
     }
 
@@ -148,10 +167,10 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         return error.Aborted;
     };
 
-    // Acquire lock
+    // Acquire lock; `MALT_LOCK_TIMEOUT_MS` tunes the 30 s default.
     var lock_path_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return;
-    var lk = lock_mod.LockFile.acquire(lock_path, 30000) catch {
+    var lk = lock_mod.LockFile.acquire(lock_path, lockTimeoutMs()) catch {
         output.err("Another mt process is running. Wait or run mt doctor.", .{});
         return error.Aborted;
     };
@@ -172,17 +191,31 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var linker = linker_mod.Linker.init(allocator, &db, prefix);
 
     // ── Step 4: Migrate each keg ────────────────────────────────────
-    var migrated: u32 = 0;
-    var skipped: u32 = 0;
-    var skipped_post_install: u32 = 0;
-    var failed: u32 = 0;
-
-    var skipped_names: std.ArrayList([]const u8) = .empty;
-    defer skipped_names.deinit(allocator);
+    // Per-category name lists: counts are derived lengths; JSON emits arrays verbatim.
+    var migrated_names: std.ArrayList([]const u8) = .empty;
+    defer migrated_names.deinit(allocator);
+    var skipped_installed_names: std.ArrayList([]const u8) = .empty;
+    defer skipped_installed_names.deinit(allocator);
+    var skipped_post_install_names: std.ArrayList([]const u8) = .empty;
+    defer skipped_post_install_names.deinit(allocator);
+    var skipped_no_bottle_names: std.ArrayList([]const u8) = .empty;
+    defer skipped_no_bottle_names.deinit(allocator);
     var failed_names: std.ArrayList([]const u8) = .empty;
     defer failed_names.deinit(allocator);
 
+    // Honour Ctrl-C raised during setup, before any network work starts.
+    const main_mod = @import("../main.zig");
+    if (main_mod.isInterrupted()) {
+        output.warn("Interrupted before migration.", .{});
+        return;
+    }
+
     for (keg_names.items) |keg_name| {
+        // Stop at the next keg boundary when the user hits Ctrl-C.
+        if (main_mod.isInterrupted()) {
+            output.warn("Interrupted — skipping remaining kegs.", .{});
+            break;
+        }
         const result = migrateKeg(
             allocator,
             keg_name,
@@ -197,28 +230,35 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         );
 
         switch (result) {
-            .migrated => {
-                migrated += 1;
-            },
-            .skipped_installed => {
-                skipped += 1;
-            },
-            .skipped_post_install => {
-                skipped_post_install += 1;
-                skipped_names.append(allocator, keg_name) catch {};
-            },
-            .skipped_no_bottle => {
-                skipped += 1;
-                skipped_names.append(allocator, keg_name) catch {};
-            },
-            .failed_api, .failed_download, .failed_install => {
-                failed += 1;
-                failed_names.append(allocator, keg_name) catch {};
-            },
+            .migrated => migrated_names.append(allocator, keg_name) catch {},
+            .skipped_installed => skipped_installed_names.append(allocator, keg_name) catch {},
+            .skipped_post_install => skipped_post_install_names.append(allocator, keg_name) catch {},
+            .skipped_no_bottle => skipped_no_bottle_names.append(allocator, keg_name) catch {},
+            .failed_api, .failed_download, .failed_install => failed_names.append(allocator, keg_name) catch {},
         }
     }
 
     // ── Step 5: Report ──────────────────────────────────────────────
+    if (json_mode) {
+        try emitSummaryJson(
+            allocator,
+            brew_prefix,
+            migrated_names.items,
+            skipped_installed_names.items,
+            skipped_post_install_names.items,
+            skipped_no_bottle_names.items,
+            failed_names.items,
+            start_ts,
+        );
+        return;
+    }
+
+    const migrated: u32 = @intCast(migrated_names.items.len);
+    // Preserve legacy lumping: human summary merges installed + no-bottle under "Skipped (installed)".
+    const skipped: u32 = @intCast(skipped_installed_names.items.len + skipped_no_bottle_names.items.len);
+    const skipped_post_install: u32 = @intCast(skipped_post_install_names.items.len);
+    const failed: u32 = @intCast(failed_names.items.len);
+
     output.info("", .{});
     output.info("Migration complete:", .{});
     output.info("  Migrated:              {d}", .{migrated});
@@ -226,7 +266,11 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         output.info("  Skipped (installed):   {d}", .{skipped});
     if (skipped_post_install > 0) {
         output.warn("  Skipped (post_install): {d}", .{skipped_post_install});
-        for (skipped_names.items) |name| {
+        for (skipped_post_install_names.items) |name| {
+            output.warn("    - {s} (needs post_install — use: brew install {s})", .{ name, name });
+        }
+        // Preserved legacy: no-bottle entries printed under the post_install warning.
+        for (skipped_no_bottle_names.items) |name| {
             output.warn("    - {s} (needs post_install — use: brew install {s})", .{ name, name });
         }
     }
@@ -538,6 +582,109 @@ fn isInstalled(db: *sqlite.Database, name: []const u8) bool {
     defer stmt.finalize();
     stmt.bindText(1, name) catch return false;
     return stmt.step() catch false;
+}
+
+// ── JSON output ─────────────────────────────────────────────────────
+
+/// Build + flush the dry-run (or empty-Cellar) JSON document to stdout.
+fn emitDryRunJson(
+    allocator: std.mem.Allocator,
+    brew_prefix: []const u8,
+    keg_names: []const []const u8,
+    dry_run: bool,
+    start_ts: i64,
+) !void {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try buildDryRunJson(&aw.writer, brew_prefix, keg_names, dry_run, start_ts);
+    io_mod.stdoutWriteAll(aw.written());
+}
+
+/// Build + flush the final-summary JSON document to stdout.
+fn emitSummaryJson(
+    allocator: std.mem.Allocator,
+    brew_prefix: []const u8,
+    migrated_names: []const []const u8,
+    skipped_installed_names: []const []const u8,
+    skipped_post_install_names: []const []const u8,
+    skipped_no_bottle_names: []const []const u8,
+    failed_names: []const []const u8,
+    start_ts: i64,
+) !void {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try buildSummaryJson(
+        &aw.writer,
+        brew_prefix,
+        migrated_names,
+        skipped_installed_names,
+        skipped_post_install_names,
+        skipped_no_bottle_names,
+        failed_names,
+        start_ts,
+    );
+    io_mod.stdoutWriteAll(aw.written());
+}
+
+/// Dry-run JSON `{dry_run, brew_prefix, kegs, count, time_ms}`; `pub` for direct test assertions.
+pub fn buildDryRunJson(
+    w: anytype,
+    brew_prefix: []const u8,
+    keg_names: []const []const u8,
+    dry_run: bool,
+    start_ts: i64,
+) !void {
+    try w.writeAll("{\"dry_run\":");
+    try w.writeAll(if (dry_run) "true" else "false");
+    try w.writeAll(",\"brew_prefix\":");
+    try output.jsonStr(w, brew_prefix);
+    try w.writeAll(",\"kegs\":");
+    try output.jsonStringArray(w, keg_names);
+    var tail: [64]u8 = undefined;
+    const tail_str = try std.fmt.bufPrint(&tail, ",\"count\":{d}", .{keg_names.len});
+    try w.writeAll(tail_str);
+    try output.jsonTimeSuffix(w, start_ts);
+    try w.writeAll("}\n");
+}
+
+/// Final-summary JSON: per-category arrays + counts + time_ms; `pub` for direct test assertions.
+pub fn buildSummaryJson(
+    w: anytype,
+    brew_prefix: []const u8,
+    migrated_names: []const []const u8,
+    skipped_installed_names: []const []const u8,
+    skipped_post_install_names: []const []const u8,
+    skipped_no_bottle_names: []const []const u8,
+    failed_names: []const []const u8,
+    start_ts: i64,
+) !void {
+    try w.writeAll("{\"dry_run\":false,\"brew_prefix\":");
+    try output.jsonStr(w, brew_prefix);
+    try w.writeAll(",\"migrated\":");
+    try output.jsonStringArray(w, migrated_names);
+    try w.writeAll(",\"skipped_installed\":");
+    try output.jsonStringArray(w, skipped_installed_names);
+    try w.writeAll(",\"skipped_post_install\":");
+    try output.jsonStringArray(w, skipped_post_install_names);
+    try w.writeAll(",\"skipped_no_bottle\":");
+    try output.jsonStringArray(w, skipped_no_bottle_names);
+    try w.writeAll(",\"failed\":");
+    try output.jsonStringArray(w, failed_names);
+    var counts_buf: [256]u8 = undefined;
+    const counts = try std.fmt.bufPrint(
+        &counts_buf,
+        ",\"counts\":{{\"migrated\":{d},\"skipped_installed\":{d},\"skipped_post_install\":{d},\"skipped_no_bottle\":{d},\"failed\":{d}}}",
+        .{
+            migrated_names.len,
+            skipped_installed_names.len,
+            skipped_post_install_names.len,
+            skipped_no_bottle_names.len,
+            failed_names.len,
+        },
+    );
+    try w.writeAll(counts);
+    try output.jsonTimeSuffix(w, start_ts);
+    try w.writeAll("}\n");
 }
 
 /// Ensure all required directories under prefix exist.

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -29,6 +29,17 @@ fn inScope(scope: []const []const u8, name: []const u8) bool {
     return false;
 }
 
+/// Resolve the Homebrew install prefix. Respects `HOMEBREW_PREFIX` (set
+/// by `brew shellenv` and by users with a non-standard install), falls
+/// back to the arch-based default. Exposed so smoke tests can point the
+/// command at a fake Cellar under a scratch path.
+pub fn detectBrewPrefix() []const u8 {
+    if (fs_compat.getenv("HOMEBREW_PREFIX")) |p| {
+        if (p.len > 0) return p;
+    }
+    return if (codesign.isArm64()) "/opt/homebrew" else "/usr/local";
+}
+
 /// Result of migrating a single keg.
 const KegResult = enum {
     migrated,
@@ -71,7 +82,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     // ── Step 1: Detect Homebrew prefix ──────────────────────────────
-    const brew_prefix = if (codesign.isArm64()) "/opt/homebrew" else "/usr/local";
+    const brew_prefix = detectBrewPrefix();
     var cellar_buf: [256]u8 = undefined;
     const brew_cellar = std.fmt.bufPrint(&cellar_buf, "{s}/Cellar", .{brew_prefix}) catch return;
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -39,6 +39,7 @@ pub const bundle_runner = @import("core/bundle/runner.zig");
 pub const cli_services = @import("cli/services.zig");
 pub const cli_bundle = @import("cli/bundle.zig");
 pub const cli_help = @import("cli/help.zig");
+pub const cli_migrate = @import("cli/migrate.zig");
 pub const cli_info = @import("cli/info.zig");
 pub const cli_uses = @import("cli/uses.zig");
 pub const cli_version_update = @import("cli/version_update.zig");

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -59,3 +59,4 @@ pub const ruby_subprocess = @import("core/ruby_subprocess.zig");
 pub const pins = @import("core/pins.zig");
 pub const perms = @import("core/perms.zig");
 pub const sandbox_macos = @import("core/sandbox/macos.zig");
+pub const main_mod = @import("main.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -19,6 +19,11 @@ pub fn isInterrupted() bool {
     return g_interrupted.load(.acquire);
 }
 
+/// Test-only flag override — raising real SIGINT would race the test runner.
+pub fn setInterruptedForTest(v: bool) void {
+    g_interrupted.store(v, .release);
+}
+
 fn sigintHandler(_: std.c.SIG) callconv(.c) void {
     g_interrupted.store(true, .release);
 }

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -272,6 +272,24 @@ pub fn jsonStr(w: anytype, s: []const u8) !void {
     try w.writeAll("\"");
 }
 
+/// Write a `["a","b",...]` JSON array of RFC-8259-escaped strings to `w`.
+pub fn jsonStringArray(w: anytype, items: []const []const u8) !void {
+    try w.writeAll("[");
+    for (items, 0..) |item, i| {
+        if (i != 0) try w.writeAll(",");
+        try jsonStr(w, item);
+    }
+    try w.writeAll("]");
+}
+
+/// Write the `,"time_ms":N` suffix used by `--json` commands; `start_ts` is a `milliTimestamp()`.
+pub fn jsonTimeSuffix(w: anytype, start_ts: i64) !void {
+    const elapsed = fs_compat.milliTimestamp() - start_ts;
+    var buf: [32]u8 = undefined;
+    const s = std.fmt.bufPrint(&buf, ",\"time_ms\":{d}", .{elapsed}) catch return;
+    try w.writeAll(s);
+}
+
 /// Write JSON to stdout
 pub fn jsonOutput(allocator: std.mem.Allocator, value: anytype) !void {
     var aw: std.Io.Writer.Allocating = .init(allocator);

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -11,18 +11,20 @@ const malt = @import("malt");
 const testing = std.testing;
 const migrate = malt.cli_migrate;
 const output = malt.output;
+const io_mod = malt.io_mod;
+const color = malt.color;
 
 const c = struct {
     extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
     extern "c" fn unsetenv(name: [*:0]const u8) c_int;
 };
 
-// Reset the global output flags that prior tests may have flipped — migrate
-// reads `output.isDryRun()` to seed its local `dry_run` and calls
-// `output.setQuiet` when it sees `-q`/`--quiet`.
+// Reset globals other tests may have flipped. `setMode(.human)` matters for the
+// --json assertions below — JSON mode is sticky across tests otherwise.
 fn resetOutput() void {
     output.setQuiet(false);
     output.setDryRun(false);
+    output.setMode(.human);
 }
 
 fn scratchDir(suffix: []const u8) ![:0]u8 {
@@ -346,4 +348,553 @@ test "already-installed kegs are skipped without touching the network" {
     defer count_stmt.finalize();
     try testing.expect(try count_stmt.step());
     try testing.expectEqual(@as(i64, 1), count_stmt.columnInt(0));
+}
+
+// ── JSON builders: pure unit tests (no globals, no filesystem) ──────────
+
+fn parseAndCheck(bytes: []const u8) !std.json.Parsed(std.json.Value) {
+    return try std.json.parseFromSlice(std.json.Value, testing.allocator, bytes, .{});
+}
+
+test "buildDryRunJson emits a well-formed document with kegs + count" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    const kegs = [_][]const u8{ "tree", "wget", "jq" };
+    try migrate.buildDryRunJson(&aw.writer, "/opt/homebrew", &kegs, true, 0);
+
+    const bytes = aw.written();
+    try testing.expect(std.mem.endsWith(u8, bytes, "}\n"));
+
+    const parsed = try parseAndCheck(bytes);
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try testing.expect(root.get("dry_run").?.bool);
+    try testing.expectEqualStrings("/opt/homebrew", root.get("brew_prefix").?.string);
+    try testing.expectEqual(@as(i64, 3), root.get("count").?.integer);
+    const arr = root.get("kegs").?.array;
+    try testing.expectEqual(@as(usize, 3), arr.items.len);
+    try testing.expectEqualStrings("tree", arr.items[0].string);
+    try testing.expectEqualStrings("wget", arr.items[1].string);
+    try testing.expectEqualStrings("jq", arr.items[2].string);
+    try testing.expect(root.get("time_ms") != null);
+}
+
+test "buildDryRunJson emits empty-kegs shape for an empty Cellar" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try migrate.buildDryRunJson(&aw.writer, "/usr/local", &.{}, false, 0);
+
+    const parsed = try parseAndCheck(aw.written());
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try testing.expect(!root.get("dry_run").?.bool);
+    try testing.expectEqualStrings("/usr/local", root.get("brew_prefix").?.string);
+    try testing.expectEqual(@as(i64, 0), root.get("count").?.integer);
+    try testing.expectEqual(@as(usize, 0), root.get("kegs").?.array.items.len);
+}
+
+test "buildSummaryJson emits per-category arrays + counts object" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try migrate.buildSummaryJson(
+        &aw.writer,
+        "/opt/homebrew",
+        &.{ "tree", "wget" },
+        &.{"seeded"},
+        &.{"fancy-keg"},
+        &.{},
+        &.{"brokenpkg"},
+        0,
+    );
+
+    const parsed = try parseAndCheck(aw.written());
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try testing.expect(!root.get("dry_run").?.bool);
+    try testing.expectEqual(@as(usize, 2), root.get("migrated").?.array.items.len);
+    try testing.expectEqualStrings("tree", root.get("migrated").?.array.items[0].string);
+    try testing.expectEqual(@as(usize, 1), root.get("skipped_installed").?.array.items.len);
+    try testing.expectEqualStrings("seeded", root.get("skipped_installed").?.array.items[0].string);
+    try testing.expectEqual(@as(usize, 1), root.get("skipped_post_install").?.array.items.len);
+    try testing.expectEqual(@as(usize, 0), root.get("skipped_no_bottle").?.array.items.len);
+    try testing.expectEqual(@as(usize, 1), root.get("failed").?.array.items.len);
+    try testing.expectEqualStrings("brokenpkg", root.get("failed").?.array.items[0].string);
+
+    const counts = root.get("counts").?.object;
+    try testing.expectEqual(@as(i64, 2), counts.get("migrated").?.integer);
+    try testing.expectEqual(@as(i64, 1), counts.get("skipped_installed").?.integer);
+    try testing.expectEqual(@as(i64, 1), counts.get("skipped_post_install").?.integer);
+    try testing.expectEqual(@as(i64, 0), counts.get("skipped_no_bottle").?.integer);
+    try testing.expectEqual(@as(i64, 1), counts.get("failed").?.integer);
+}
+
+test "buildSummaryJson escapes adversarial keg names per RFC 8259" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    const names = [_][]const u8{"weird\"\\keg"};
+    try migrate.buildSummaryJson(&aw.writer, "/opt/homebrew", &names, &.{}, &.{}, &.{}, &.{}, 0);
+
+    const parsed = try parseAndCheck(aw.written());
+    defer parsed.deinit();
+    try testing.expectEqualStrings("weird\"\\keg", parsed.value.object.get("migrated").?.array.items[0].string);
+}
+
+// ── End-to-end: capture stdout under --json, parse the payload ──────────
+
+test "dry-run with --json emits a parseable document on stdout" {
+    resetOutput();
+    const brew = try scratchDir("brew_json_dry");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt = try scratchDir("mt_json_dry");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(mt) catch {};
+        testing.allocator.free(mt);
+    }
+    try seedFakeBrew(brew, &.{ "tree", "wget" });
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    output.setMode(.json);
+    defer resetOutput();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{"--dry-run"});
+
+    const parsed = try parseAndCheck(buf.items);
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try testing.expect(root.get("dry_run").?.bool);
+    try testing.expectEqual(@as(i64, 2), root.get("count").?.integer);
+    try testing.expectEqual(@as(usize, 2), root.get("kegs").?.array.items.len);
+}
+
+test "--json with empty Cellar emits an empty-kegs document (no human 'No kegs' line)" {
+    resetOutput();
+    const brew = try scratchDir("brew_json_empty");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt = try scratchDir("mt_json_empty");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(mt) catch {};
+        testing.allocator.free(mt);
+    }
+    try seedFakeBrew(brew, &.{});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    output.setMode(.json);
+    defer resetOutput();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{});
+
+    const parsed = try parseAndCheck(buf.items);
+    defer parsed.deinit();
+    try testing.expectEqual(@as(i64, 0), parsed.value.object.get("count").?.integer);
+}
+
+test "--json on an already-installed keg records it under skipped_installed" {
+    resetOutput();
+    const brew = try scratchDir("brew_json_inst");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+
+    // ≤13-byte MALT_PREFIX — same Mach-O cap rationale as the sister test above.
+    const mt_z: [:0]const u8 = "/tmp/mt_mj";
+    malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+    try malt.fs_compat.cwd().makePath(mt_z);
+    defer malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+
+    try seedFakeBrew(brew, &.{"seeded"});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt_z});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+    const db_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt.db", .{db_dir});
+    defer testing.allocator.free(db_path);
+
+    var db = try malt.sqlite.Database.open(db_path);
+    try malt.schema.initSchema(&db);
+    var stmt = try db.prepare(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (?, ?, ?, ?, ?);
+    );
+    try stmt.bindText(1, "seeded");
+    try stmt.bindText(2, "seeded");
+    try stmt.bindText(3, "1.0");
+    try stmt.bindText(4, "0" ** 64);
+    try stmt.bindText(5, "/tmp/mt_mj/Cellar/seeded/1.0");
+    _ = try stmt.step();
+    stmt.finalize();
+    db.close();
+
+    output.setMode(.json);
+    defer resetOutput();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{});
+
+    const parsed = try parseAndCheck(buf.items);
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try testing.expectEqual(@as(usize, 0), root.get("migrated").?.array.items.len);
+    try testing.expectEqual(@as(usize, 1), root.get("skipped_installed").?.array.items.len);
+    try testing.expectEqualStrings("seeded", root.get("skipped_installed").?.array.items[0].string);
+    try testing.expectEqual(@as(i64, 1), root.get("counts").?.object.get("skipped_installed").?.integer);
+}
+
+// ── Human summary: stderr capture pins specific lines ───────────────────
+
+fn containsLine(haystack: []const u8, needle: []const u8) bool {
+    return std.mem.indexOf(u8, haystack, needle) != null;
+}
+
+test "dry-run stderr pins the 'Found N packages' and 'Would migrate N' lines" {
+    resetOutput();
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    const brew = try scratchDir("brew_stderr_dry");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt = try scratchDir("mt_stderr_dry");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(mt) catch {};
+        testing.allocator.free(mt);
+    }
+    try seedFakeBrew(brew, &.{ "tree", "wget", "jq" });
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &buf);
+    defer io_mod.endStderrCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{"--dry-run"});
+
+    try testing.expect(containsLine(buf.items, "Found 3 package(s) in Homebrew Cellar"));
+    try testing.expect(containsLine(buf.items, "Would migrate: tree"));
+    try testing.expect(containsLine(buf.items, "Would migrate: wget"));
+    try testing.expect(containsLine(buf.items, "Would migrate: jq"));
+    try testing.expect(containsLine(buf.items, "Would migrate 3 packages from Homebrew"));
+}
+
+// ── SIGINT handling ─────────────────────────────────────────────────────
+
+test "pre-set SIGINT flag short-circuits the per-keg loop before any API call" {
+    resetOutput();
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    const brew = try scratchDir("brew_sigint");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt_z: [:0]const u8 = "/tmp/mt_si";
+    malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+    try malt.fs_compat.cwd().makePath(mt_z);
+    defer malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+
+    try seedFakeBrew(brew, &.{"willbeskipped"});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Pre-set the flag so the pre-loop check fires before any API hit.
+    malt.main_mod.setInterruptedForTest(true);
+    defer malt.main_mod.setInterruptedForTest(false);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &buf);
+    defer io_mod.endStderrCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{});
+
+    try testing.expect(containsLine(buf.items, "Interrupted before migration"));
+    // Early-return must skip both per-keg success and final summary block.
+    try testing.expect(!containsLine(buf.items, "willbeskipped migrated"));
+    try testing.expect(!containsLine(buf.items, "Migration complete:"));
+}
+
+// ── Cellar-entry filter ─────────────────────────────────────────────────
+
+test "cellar scan ignores stray files and symlinks alongside keg directories" {
+    resetOutput();
+    const brew = try scratchDir("brew_filter");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt = try scratchDir("mt_filter");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(mt) catch {};
+        testing.allocator.free(mt);
+    }
+    try seedFakeBrew(brew, &.{"tree"});
+
+    // Plant a stray regular file + a dangling symlink in the Cellar root.
+    const cellar = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar", .{brew});
+    defer testing.allocator.free(cellar);
+    const stray_file = try std.fmt.allocPrint(testing.allocator, "{s}/.DS_Store", .{cellar});
+    defer testing.allocator.free(stray_file);
+    const stray_link = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/dangling", .{cellar}, 0);
+    defer testing.allocator.free(stray_link);
+
+    const f = try malt.fs_compat.cwd().createFile(stray_file, .{});
+    f.close();
+    _ = std.c.symlink("/tmp/nonexistent_migrate_smoke_target", stray_link.ptr);
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    output.setMode(.json);
+    defer resetOutput();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{"--dry-run"});
+
+    const parsed = try parseAndCheck(buf.items);
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try testing.expectEqual(@as(i64, 1), root.get("count").?.integer);
+    const kegs = root.get("kegs").?.array;
+    try testing.expectEqual(@as(usize, 1), kegs.items.len);
+    try testing.expectEqualStrings("tree", kegs.items[0].string);
+}
+
+// ── Multi-keg mixed outcomes (skipped_installed + failed_api, offline) ──
+
+test "mixed outcomes: installed keg is skipped and unknown keg fails at API (404-cached)" {
+    resetOutput();
+    const brew = try scratchDir("brew_mixed");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+
+    const mt_z: [:0]const u8 = "/tmp/mt_mx";
+    malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+    try malt.fs_compat.cwd().makePath(mt_z);
+    defer malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+
+    try seedFakeBrew(brew, &.{ "seeded", "unknownpkg" });
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Seed malt DB: one keg already "installed" to exercise the skip path.
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt_z});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+    const db_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt.db", .{db_dir});
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    try malt.schema.initSchema(&db);
+    var stmt = try db.prepare(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (?, ?, ?, ?, ?);
+    );
+    try stmt.bindText(1, "seeded");
+    try stmt.bindText(2, "seeded");
+    try stmt.bindText(3, "1.0");
+    try stmt.bindText(4, "0" ** 64);
+    try stmt.bindText(5, "/tmp/mt_mx/Cellar/seeded/1.0");
+    _ = try stmt.step();
+    stmt.finalize();
+    db.close();
+
+    // Pre-seed a 404 marker so fetchFormula fails offline (audit-documented pattern).
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{mt_z});
+    defer testing.allocator.free(cache_api);
+    try malt.fs_compat.cwd().makePath(cache_api);
+    const marker = try std.fmt.allocPrint(testing.allocator, "{s}/formula_unknownpkg.404", .{cache_api});
+    defer testing.allocator.free(marker);
+    const mf = try malt.fs_compat.cwd().createFile(marker, .{});
+    mf.close();
+
+    output.setMode(.json);
+    defer resetOutput();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{});
+
+    const parsed = try parseAndCheck(buf.items);
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try testing.expectEqual(@as(usize, 0), root.get("migrated").?.array.items.len);
+    try testing.expectEqual(@as(usize, 1), root.get("skipped_installed").?.array.items.len);
+    try testing.expectEqualStrings("seeded", root.get("skipped_installed").?.array.items[0].string);
+    try testing.expectEqual(@as(usize, 1), root.get("failed").?.array.items.len);
+    try testing.expectEqualStrings("unknownpkg", root.get("failed").?.array.items[0].string);
+
+    const counts = root.get("counts").?.object;
+    try testing.expectEqual(@as(i64, 0), counts.get("migrated").?.integer);
+    try testing.expectEqual(@as(i64, 1), counts.get("skipped_installed").?.integer);
+    try testing.expectEqual(@as(i64, 1), counts.get("failed").?.integer);
+}
+
+// ── Lock contention ─────────────────────────────────────────────────────
+
+test "lock contention returns error.Aborted when db/malt.lock is already held" {
+    resetOutput();
+    const brew = try scratchDir("brew_lock");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+
+    const mt_z: [:0]const u8 = "/tmp/mt_lk";
+    malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+    try malt.fs_compat.cwd().makePath(mt_z);
+    defer malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+
+    try seedFakeBrew(brew, &.{"willnotreach"});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+    // Short timeout so contention fails fast instead of the 30 s default.
+    _ = c.setenv("MALT_LOCK_TIMEOUT_MS", "50", 1);
+    defer _ = c.unsetenv("MALT_LOCK_TIMEOUT_MS");
+
+    // Pre-acquire the lock externally so migrate's acquire hits timeout.
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt_z});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+    const lock_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt.lock", .{db_dir});
+    defer testing.allocator.free(lock_path);
+    var holder = try malt.lock.LockFile.acquire(lock_path, 1000);
+    defer holder.release();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try testing.expectError(
+        error.Aborted,
+        migrate.execute(arena.allocator(), &.{}),
+    );
+}
+
+test "already-installed stderr pins the 'Migration complete' + 'Skipped (installed): 1' lines" {
+    resetOutput();
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    const brew = try scratchDir("brew_stderr_inst");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+
+    const mt_z: [:0]const u8 = "/tmp/mt_ms";
+    malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+    try malt.fs_compat.cwd().makePath(mt_z);
+    defer malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+
+    try seedFakeBrew(brew, &.{"seeded"});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt_z});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+    const db_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt.db", .{db_dir});
+    defer testing.allocator.free(db_path);
+
+    var db = try malt.sqlite.Database.open(db_path);
+    try malt.schema.initSchema(&db);
+    var stmt = try db.prepare(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (?, ?, ?, ?, ?);
+    );
+    try stmt.bindText(1, "seeded");
+    try stmt.bindText(2, "seeded");
+    try stmt.bindText(3, "1.0");
+    try stmt.bindText(4, "0" ** 64);
+    try stmt.bindText(5, "/tmp/mt_ms/Cellar/seeded/1.0");
+    _ = try stmt.step();
+    stmt.finalize();
+    db.close();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &buf);
+    defer io_mod.endStderrCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{});
+
+    try testing.expect(containsLine(buf.items, "Migration complete:"));
+    try testing.expect(containsLine(buf.items, "Migrated:              0"));
+    try testing.expect(containsLine(buf.items, "Skipped (installed):   1"));
 }

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -1,0 +1,349 @@
+//! Smoke tests for `malt migrate` — drives `migrate.execute` end-to-end
+//! against a fake Homebrew Cellar (via HOMEBREW_PREFIX) and a scratch
+//! MALT_PREFIX, so the whole command pipeline is exercised without
+//! touching the user's real Homebrew or malt installs, and without
+//! network access. Dry-run is the primary vehicle: it reaches every
+//! input-validation and cellar-scan path, then returns before any
+//! bottle download would happen.
+
+const std = @import("std");
+const malt = @import("malt");
+const testing = std.testing;
+const migrate = malt.cli_migrate;
+const output = malt.output;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+// Reset the global output flags that prior tests may have flipped — migrate
+// reads `output.isDryRun()` to seed its local `dry_run` and calls
+// `output.setQuiet` when it sees `-q`/`--quiet`.
+fn resetOutput() void {
+    output.setQuiet(false);
+    output.setDryRun(false);
+}
+
+fn scratchDir(suffix: []const u8) ![:0]u8 {
+    const p = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "/tmp/mt_mig_{d}_{s}",
+        .{ malt.fs_compat.nanoTimestamp(), suffix },
+        0,
+    );
+    malt.fs_compat.deleteTreeAbsolute(p) catch {};
+    try malt.fs_compat.cwd().makePath(p);
+    return p;
+}
+
+fn setenvZ(key: [*:0]const u8, value: []const u8) !void {
+    const sz = try testing.allocator.dupeZ(u8, value);
+    defer testing.allocator.free(sz);
+    _ = c.setenv(key, sz.ptr, 1);
+}
+
+// Seed `prefix/Cellar/<name>/1.0` for each keg name. Empty directories are
+// enough — migrate's cellar iterator only looks at `entry.kind == .directory`.
+fn seedFakeBrew(prefix: []const u8, kegs: []const []const u8) !void {
+    const cellar = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar", .{prefix});
+    defer testing.allocator.free(cellar);
+    try malt.fs_compat.cwd().makePath(cellar);
+    for (kegs) |name| {
+        const keg_dir = try std.fmt.allocPrint(testing.allocator, "{s}/{s}/1.0", .{ cellar, name });
+        defer testing.allocator.free(keg_dir);
+        try malt.fs_compat.cwd().makePath(keg_dir);
+    }
+}
+
+fn pathExists(path: []const u8) bool {
+    malt.fs_compat.accessAbsolute(path, .{}) catch return false;
+    return true;
+}
+
+// ── Flag parsing / input validation ─────────────────────────────────────
+
+test "migrate --help short-circuits before touching the filesystem" {
+    resetOutput();
+    // No HOMEBREW_PREFIX set, no MALT_PREFIX set — help must not care.
+    _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.unsetenv("MALT_PREFIX");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{"--help"});
+    try migrate.execute(arena.allocator(), &.{"-h"});
+}
+
+test "bare --use-system-ruby is refused (would widen trust boundary to every keg)" {
+    resetOutput();
+    _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.unsetenv("MALT_PREFIX");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try testing.expectError(
+        error.Aborted,
+        migrate.execute(arena.allocator(), &.{"--use-system-ruby"}),
+    );
+    // The rejection fires before brew detection, so --dry-run can't rescue it.
+    try testing.expectError(
+        error.Aborted,
+        migrate.execute(arena.allocator(), &.{ "--dry-run", "--use-system-ruby" }),
+    );
+}
+
+// ── detectBrewPrefix env override ───────────────────────────────────────
+
+test "detectBrewPrefix honors HOMEBREW_PREFIX when set" {
+    _ = c.setenv("HOMEBREW_PREFIX", "/tmp/brew_fake_prefix", 1);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    try testing.expectEqualStrings("/tmp/brew_fake_prefix", migrate.detectBrewPrefix());
+}
+
+test "detectBrewPrefix falls back to arch default when unset" {
+    _ = c.unsetenv("HOMEBREW_PREFIX");
+    const got = migrate.detectBrewPrefix();
+    // Either /opt/homebrew (arm64) or /usr/local (x86) — never empty,
+    // always absolute. Exact value depends on the host arch.
+    try testing.expect(got.len > 0);
+    try testing.expectEqual(@as(u8, '/'), got[0]);
+}
+
+test "empty HOMEBREW_PREFIX falls through to arch default" {
+    _ = c.setenv("HOMEBREW_PREFIX", "", 1);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    const got = migrate.detectBrewPrefix();
+    try testing.expect(got.len > 0);
+    try testing.expectEqual(@as(u8, '/'), got[0]);
+}
+
+// ── Cellar discovery ────────────────────────────────────────────────────
+
+test "missing Homebrew installation yields error.Aborted" {
+    resetOutput();
+    const bogus = "/tmp/mt_mig_no_such_brew_dir_12345";
+    malt.fs_compat.deleteTreeAbsolute(bogus) catch {};
+    _ = c.setenv("HOMEBREW_PREFIX", bogus, 1);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try testing.expectError(
+        error.Aborted,
+        migrate.execute(arena.allocator(), &.{"--dry-run"}),
+    );
+}
+
+test "empty Cellar exits cleanly with no malt state created" {
+    resetOutput();
+    const brew = try scratchDir("brew_empty");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt = try scratchDir("mt_empty");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(mt) catch {};
+        testing.allocator.free(mt);
+    }
+    try seedFakeBrew(brew, &.{});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{});
+
+    // Empty-Cellar branch returns before ensureDirs runs, so the malt
+    // prefix must not have been seeded with store/db/Cellar subtrees.
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt});
+    defer testing.allocator.free(db_dir);
+    try testing.expect(!pathExists(db_dir));
+}
+
+// ── Dry-run happy paths ─────────────────────────────────────────────────
+
+test "dry-run with kegs lists them and never initializes malt state" {
+    resetOutput();
+    const brew = try scratchDir("brew_dry");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt = try scratchDir("mt_dry");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(mt) catch {};
+        testing.allocator.free(mt);
+    }
+    try seedFakeBrew(brew, &.{ "tree", "wget", "jq" });
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{ "--dry-run", "--quiet" });
+
+    // Dry-run returns before ensureDirs — no DB, no lock, no Cellar
+    // in the malt prefix.
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt});
+    defer testing.allocator.free(db_dir);
+    try testing.expect(!pathExists(db_dir));
+}
+
+test "dry-run is idempotent: back-to-back runs both succeed with no state change" {
+    resetOutput();
+    const brew = try scratchDir("brew_idem");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt = try scratchDir("mt_idem");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(mt) catch {};
+        testing.allocator.free(mt);
+    }
+    try seedFakeBrew(brew, &.{ "openssl", "ca-certificates" });
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{ "--dry-run", "--quiet" });
+    try migrate.execute(arena.allocator(), &.{ "--dry-run", "--quiet" });
+
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt});
+    defer testing.allocator.free(db_dir);
+    try testing.expect(!pathExists(db_dir));
+}
+
+test "dry-run with scoped --use-system-ruby=foo,bar is accepted (scope parsed, no trust-boundary error)" {
+    resetOutput();
+    const brew = try scratchDir("brew_scope");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt = try scratchDir("mt_scope");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(mt) catch {};
+        testing.allocator.free(mt);
+    }
+    try seedFakeBrew(brew, &.{"foo"});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    // Scoped form is the *only* way to opt in for migrate; empty names in the
+    // list (e.g. "foo,,bar") must be tolerated, and dry-run must still win.
+    try migrate.execute(arena.allocator(), &.{ "--dry-run", "--quiet", "--use-system-ruby=foo,,bar" });
+}
+
+// ── Quiet flag ──────────────────────────────────────────────────────────
+
+test "--quiet alone (no dry-run) with empty Cellar still returns cleanly" {
+    resetOutput();
+    const brew = try scratchDir("brew_quiet");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt = try scratchDir("mt_quiet");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(mt) catch {};
+        testing.allocator.free(mt);
+    }
+    try seedFakeBrew(brew, &.{});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{"-q"});
+    // Reset so downstream tests don't inherit quiet=true from this one.
+    resetOutput();
+}
+
+// ── Already-installed skip path ─────────────────────────────────────────
+//
+// This test exercises the full non-dry-run pipeline up to the per-keg
+// dispatch: ensureDirs creates the malt tree, the SQLite DB is opened,
+// schema initialised, lock acquired, and then migrateKeg's `isInstalled`
+// check short-circuits the API call because the keg is already recorded.
+// No network hit, no bottle download, no Cellar materialization.
+
+test "already-installed kegs are skipped without touching the network" {
+    resetOutput();
+    const brew = try scratchDir("brew_inst");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+
+    // MALT_PREFIX must be ≤13 bytes (Mach-O path-patching budget). Using a
+    // short prefix keeps us safely under the cap even though migrate's
+    // skip-installed path doesn't actually patch any binaries.
+    const mt_z: [:0]const u8 = "/tmp/mt_mi";
+    malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+    try malt.fs_compat.cwd().makePath(mt_z);
+    defer malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+
+    try seedFakeBrew(brew, &.{"seeded"});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Pre-seed the malt DB with a keg named "seeded" so migrate's
+    // `isInstalled` returns true and the API call is bypassed.
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt_z});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+    const db_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt.db", .{db_dir});
+    defer testing.allocator.free(db_path);
+
+    var db = try malt.sqlite.Database.open(db_path);
+    try malt.schema.initSchema(&db);
+    var stmt = try db.prepare(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (?, ?, ?, ?, ?);
+    );
+    try stmt.bindText(1, "seeded");
+    try stmt.bindText(2, "seeded");
+    try stmt.bindText(3, "1.0");
+    try stmt.bindText(4, "0" ** 64);
+    try stmt.bindText(5, "/tmp/mt_mi/Cellar/seeded/1.0");
+    _ = try stmt.step();
+    stmt.finalize();
+    db.close();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{"--quiet"});
+    resetOutput();
+
+    // Verify the skip branch did not insert a duplicate or clobber the seed.
+    var db2 = try malt.sqlite.Database.open(db_path);
+    defer db2.close();
+    var count_stmt = try db2.prepare("SELECT COUNT(*) FROM kegs WHERE name = 'seeded';");
+    defer count_stmt.finalize();
+    try testing.expect(try count_stmt.step());
+    try testing.expectEqual(@as(i64, 1), count_stmt.columnInt(0));
+}

--- a/tests/output_test.zig
+++ b/tests/output_test.zig
@@ -6,9 +6,10 @@
 
 const std = @import("std");
 const testing = std.testing;
-const output = @import("malt").output;
-const io_mod = @import("malt").io_mod;
-const color = @import("malt").color;
+const malt = @import("malt");
+const output = malt.output;
+const io_mod = malt.io_mod;
+const color = malt.color;
 
 /// Set up stderr capture with an explicit color/emoji state. Returns a
 /// guard the caller defers to tear down both the capture and the state
@@ -75,6 +76,111 @@ test "jsonStr passes UTF-8 bytes through unchanged" {
     const got = try encode("café 🍺");
     defer testing.allocator.free(got);
     try testing.expectEqualStrings("\"café 🍺\"", got);
+}
+
+// ── jsonStringArray: shared `["a","b",...]` writer ─────────────────────
+
+fn encodeArray(items: []const []const u8) ![]u8 {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    errdefer aw.deinit();
+    try output.jsonStringArray(&aw.writer, items);
+    return aw.toOwnedSlice();
+}
+
+test "jsonStringArray writes [] for an empty slice" {
+    const got = try encodeArray(&.{});
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("[]", got);
+}
+
+test "jsonStringArray writes a single-quoted element with no separator" {
+    const got = try encodeArray(&.{"tree"});
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("[\"tree\"]", got);
+}
+
+test "jsonStringArray comma-separates multiple elements without trailing comma" {
+    const got = try encodeArray(&.{ "tree", "wget", "jq" });
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("[\"tree\",\"wget\",\"jq\"]", got);
+}
+
+test "jsonStringArray delegates per-element escaping to jsonStr" {
+    const got = try encodeArray(&.{ "a\"b", "c\\d", "e\nf" });
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("[\"a\\\"b\",\"c\\\\d\",\"e\\nf\"]", got);
+}
+
+test "jsonStringArray round-trips through std.json" {
+    const got = try encodeArray(&.{ "tree", "café 🍺", "weird\"name" });
+    defer testing.allocator.free(got);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, got, .{});
+    defer parsed.deinit();
+    const arr = parsed.value.array;
+    try testing.expectEqual(@as(usize, 3), arr.items.len);
+    try testing.expectEqualStrings("tree", arr.items[0].string);
+    try testing.expectEqualStrings("café 🍺", arr.items[1].string);
+    try testing.expectEqualStrings("weird\"name", arr.items[2].string);
+}
+
+test "jsonStringArray handles an element containing every short-form escape" {
+    const got = try encodeArray(&.{"a\"b\\c\nd\re\tf\x08g\x0ch"});
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("[\"a\\\"b\\\\c\\nd\\re\\tf\\bg\\fh\"]", got);
+}
+
+// ── jsonTimeSuffix: shared `,"time_ms":N` tail ─────────────────────────
+
+fn encodeTimeSuffix(start_ts: i64) ![]u8 {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    errdefer aw.deinit();
+    try output.jsonTimeSuffix(&aw.writer, start_ts);
+    return aw.toOwnedSlice();
+}
+
+test "jsonTimeSuffix starts with the literal key prefix" {
+    const got = try encodeTimeSuffix(0);
+    defer testing.allocator.free(got);
+    try testing.expect(std.mem.startsWith(u8, got, ",\"time_ms\":"));
+}
+
+test "jsonTimeSuffix emits a non-negative integer for a past start_ts" {
+    // A milliTimestamp() captured just above is by definition ≤ the one
+    // fetched inside the helper, so the diff cannot be negative.
+    const start = malt.fs_compat.milliTimestamp();
+    const got = try encodeTimeSuffix(start);
+    defer testing.allocator.free(got);
+
+    const colon = std.mem.indexOfScalar(u8, got, ':').?;
+    const num_str = got[colon + 1 ..];
+    const n = try std.fmt.parseInt(i64, num_str, 10);
+    try testing.expect(n >= 0);
+}
+
+test "jsonTimeSuffix produces a large elapsed value for a far-past start_ts" {
+    const now = malt.fs_compat.milliTimestamp();
+    const got = try encodeTimeSuffix(now - 1_000_000);
+    defer testing.allocator.free(got);
+
+    const colon = std.mem.indexOfScalar(u8, got, ':').?;
+    const n = try std.fmt.parseInt(i64, got[colon + 1 ..], 10);
+    try testing.expect(n >= 1_000_000);
+}
+
+test "jsonTimeSuffix composes onto an open object to yield valid JSON" {
+    // Real callers concatenate the suffix onto a partial `{...` payload;
+    // exercise that assembly here to prove a consumer can parse the join.
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try aw.writer.writeAll("{\"ok\":true");
+    try output.jsonTimeSuffix(&aw.writer, 0);
+    try aw.writer.writeAll("}");
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+    try testing.expect(parsed.value.object.get("ok").?.bool);
+    try testing.expect(parsed.value.object.get("time_ms").?.integer >= 0);
 }
 
 // Regression: under the test runner, `io_mod.stdoutFile()` must not


### PR DESCRIPTION
## Description

- **Scriptable migrations.** `--json` now returns the same contract as `list` and `outdated`: a structured summary on stdout (keg set for `--dry-run`, per-category migrated / skipped / failed arrays for a real run) that CI and post-migration dashboards can consume without regex-scraping.
- **Graceful shutdown.** Hitting Ctrl-C mid-migration stops at the next keg boundary instead of plowing ahead — matching the behaviour users already expect from `install`.
- **Fail-fast on contention.** `MALT_LOCK_TIMEOUT_MS` replaces the hard-coded 30-second wait so a second `mt` process (or a stuck one) surfaces quickly on slow filesystems and in CI.
- **Safety net for the scanner.** The Cellar iteration, the already-installed skip path, the empty-Cellar early return, and the dry-run planner all now have dedicated smoke tests. A manual QA script (`scripts/e2e/migrate_dry_run_check.sh`) diffs the discovered keg set against `brew list --formulae` on a real machine as a gut-check before cutting a release.

Human output is unchanged; this is additive.

## Related Issue

- None

## Notes for Reviewers

- None