### PR TITLE
fix(fs/compat): honor allocator contract on short reads

### DIFF
--- a/src/fs/compat.zig
+++ b/src/fs/compat.zig
@@ -330,7 +330,14 @@ pub const File = struct {
         const buf = try allocator.alloc(u8, @intCast(size));
         errdefer allocator.free(buf);
         const n = try self.inner.readPositionalAll(io, buf, 0);
-        return buf[0..n];
+        if (n == buf.len) return buf;
+        // Short read: shrink in place so caller-side `free` matches what
+        // we hand back — GPA traps on length mismatch, others leak the tail.
+        if (allocator.resize(buf, n)) return buf[0..n];
+        const shrunk = try allocator.alloc(u8, n);
+        @memcpy(shrunk, buf[0..n]);
+        allocator.free(buf);
+        return shrunk;
     }
 };
 

--- a/tests/fs_compat_stream_test.zig
+++ b/tests/fs_compat_stream_test.zig
@@ -163,3 +163,72 @@ test "streamFile rejects a zero-length buffer" {
         fs.streamFile(f, &empty, .{ .context = @ptrCast(&ctx), .func = &AbortCtx.callback }),
     );
 }
+
+// ── readToEndAlloc: allocator-contract safety on short reads ─────────
+
+const TruncRacer = struct {
+    path: []const u8,
+    payload: []const u8,
+    stop: std.atomic.Value(bool),
+
+    fn run(self: *TruncRacer) void {
+        // Bounce the file between "full payload" and "empty" as fast as
+        // the kernel will let us. Any reader that stats BEFORE a truncate
+        // and reads AFTER it observes stat.size > bytes-available — the
+        // exact short-read race the fix has to survive.
+        while (!self.stop.load(.acquire)) {
+            const ft = fs.openFileAbsolute(self.path, .{ .mode = .read_write }) catch continue;
+            _ = ft.setEndPos(0) catch {};
+            ft.writeAll(self.payload) catch {};
+            ft.close();
+        }
+    }
+};
+
+test "readToEndAlloc honors allocator contract when the file shrinks between stat and read" {
+    // Racy truncate reproduces BUG-002: the old code returned `buf[0..n]`
+    // of an allocation sized to `stat.size`, so any short read (sparse
+    // file, concurrent truncate, fs size drift) tripped testing.allocator's
+    // length-mismatch trap on `free`. The fix informs the allocator via
+    // `resize` before returning the trimmed slice.
+    const alloc = testing.allocator;
+
+    var path_buf: [128]u8 = undefined;
+    const p = try tempFilePath("shortread", &path_buf);
+    defer fs.cwd().deleteFile(p) catch {};
+
+    const BIG: usize = 256 * 1024;
+    const payload = try alloc.alloc(u8, BIG);
+    defer alloc.free(payload);
+    @memset(payload, 'A');
+
+    try writeFile(p, payload);
+
+    var racer = TruncRacer{
+        .path = p,
+        .payload = payload,
+        .stop = std.atomic.Value(bool).init(false),
+    };
+    const thread = try std.Thread.spawn(.{}, TruncRacer.run, .{&racer});
+    defer {
+        racer.stop.store(true, .release);
+        thread.join();
+    }
+
+    // Many iterations so the race has ample chance to interleave stat
+    // before read. Under the buggy code a single short-read free traps
+    // the whole process; under the fix every free is contract-safe.
+    var iter: usize = 0;
+    while (iter < 128) : (iter += 1) {
+        const f = fs.openFileAbsolute(p, .{}) catch continue;
+        const got = f.readToEndAlloc(alloc, BIG * 2) catch {
+            f.close();
+            continue;
+        };
+        f.close();
+        // The canary: if the slice length disagrees with the tracked
+        // allocation length, testing.allocator's DebugAllocator will
+        // abort here.
+        alloc.free(got);
+    }
+}


### PR DESCRIPTION
## Description

Fix `readToEndAlloc` and `readFileAbsoluteAlloc` in `src/fs/compat.zig` to honour Zig's allocator contract on short reads. The prior code returned a shortened slice of a larger allocation, tripping `GeneralPurposeAllocator` safety mode on `free` and silently leaking the tail under other allocators.

The fix shrinks the buffer in place via `std.mem.Allocator.resize` and falls back to alloc+memcpy for allocators that refuse to shrink, so every caller receives a slice the allocator actually tracks.

## Related Issue

- None

## Notes for Reviewers

- None