### PR TITLE
fix(core/cask): return owned app name from findAppInDir

### DIFF
--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -393,9 +393,11 @@ pub const CaskInstaller = struct {
             fs_compat.deleteDirAbsolute(mount_point) catch {};
         }
 
-        // Find the .app bundle name (from JSON artifacts or by scanning mount point)
+        // Find the .app bundle name (from JSON artifacts or by scanning mount point).
+        // app_name_buf owns the fallback name past iterator teardown.
+        var app_name_buf: [256]u8 = undefined;
         const app_name = parseAppName(cask.parsed.value.object) orelse
-            self.findAppInDir(mount_point) orelse
+            findAppInDir(mount_point, &app_name_buf) orelse
             return error.InstallFailed;
 
         // Source and destination paths
@@ -443,9 +445,10 @@ pub const CaskInstaller = struct {
             else => return error.InstallFailed,
         }
 
-        // Find the .app
+        // Find the .app. app_name_buf owns the fallback past iterator teardown.
+        var app_name_buf: [256]u8 = undefined;
         const app_name = parseAppName(cask.parsed.value.object) orelse
-            self.findAppInDir(extract_dir) orelse
+            findAppInDir(extract_dir, &app_name_buf) orelse
             return error.InstallFailed;
 
         var src_buf: [512]u8 = undefined;
@@ -490,18 +493,6 @@ pub const CaskInstaller = struct {
         return isAppRunning(app_path);
     }
 
-    fn findAppInDir(_: *CaskInstaller, dir_path: []const u8) ?[]const u8 {
-        var dir = fs_compat.openDirAbsolute(dir_path, .{ .iterate = true }) catch return null;
-        defer dir.close();
-        var iter = dir.iterate();
-        while (iter.next() catch null) |entry| {
-            if (entry.kind == .directory and std.mem.endsWith(u8, entry.name, ".app")) {
-                return entry.name;
-            }
-        }
-        return null;
-    }
-
     fn recordCaskroom(self: *CaskInstaller, cask: *const Cask) !void {
         // Create Caskroom/{token}/{version}/ to match Homebrew layout
         var buf: [512]u8 = undefined;
@@ -511,6 +502,25 @@ pub const CaskInstaller = struct {
         fs_compat.cwd().makePath(caskroom_ver) catch {};
     }
 };
+
+/// Scan `dir_path` for a `.app` bundle and copy its name into `out_buf`.
+/// Returns a slice of `out_buf` (owned by the caller) — the iterator's
+/// internal entry buffer dies with the iterator, so the name must be
+/// copied out before `dir.close()` fires. Returns null if no `.app`
+/// exists, the directory can't be opened, or the name does not fit.
+pub fn findAppInDir(dir_path: []const u8, out_buf: []u8) ?[]const u8 {
+    var dir = fs_compat.openDirAbsolute(dir_path, .{ .iterate = true }) catch return null;
+    defer dir.close();
+    var iter = dir.iterate();
+    while (iter.next() catch null) |entry| {
+        if (entry.kind == .directory and std.mem.endsWith(u8, entry.name, ".app")) {
+            if (entry.name.len > out_buf.len) return null;
+            @memcpy(out_buf[0..entry.name.len], entry.name);
+            return out_buf[0..entry.name.len];
+        }
+    }
+    return null;
+}
 
 /// SHA256 buffer size — one positional read per 64 KiB.
 const sha256_read_chunk: usize = 64 * 1024;

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -398,6 +398,65 @@ test "verifyFileSha256 propagates FileNotFound rather than Sha256Mismatch" {
     );
 }
 
+// ── findAppInDir: owns the returned name past iterator teardown ─────
+
+fn scratchDir(tag: []const u8, buf: []u8) ![]const u8 {
+    const p = try std.fmt.bufPrint(buf, "/tmp/malt_cask_findapp_{s}_{d}", .{ tag, malt_fs.nanoTimestamp() });
+    try malt_fs.makeDirAbsolute(p);
+    return p;
+}
+
+test "findAppInDir returns the .app name copied into the caller buffer" {
+    // Pins the fall-through contract: when parseAppName finds no
+    // artifacts.app, the scan must hand back a name that outlives
+    // the directory iterator. Using a caller buffer makes that
+    // guarantee explicit.
+    var dir_buf: [128]u8 = undefined;
+    const dir_path = try scratchDir("ok", &dir_buf);
+    defer malt_fs.deleteTreeAbsolute(dir_path) catch {};
+
+    var app_path_buf: [256]u8 = undefined;
+    const app_path = try std.fmt.bufPrint(&app_path_buf, "{s}/Foo.app", .{dir_path});
+    try malt_fs.makeDirAbsolute(app_path);
+
+    var out: [128]u8 = undefined;
+    const name = cask.findAppInDir(dir_path, &out) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings("Foo.app", name);
+    // The slice must be backed by the caller buffer, not iterator memory.
+    try testing.expect(@intFromPtr(name.ptr) == @intFromPtr(&out));
+}
+
+test "findAppInDir returns null when no .app bundle is present" {
+    var dir_buf: [128]u8 = undefined;
+    const dir_path = try scratchDir("none", &dir_buf);
+    defer malt_fs.deleteTreeAbsolute(dir_path) catch {};
+
+    var readme_buf: [256]u8 = undefined;
+    const readme = try std.fmt.bufPrint(&readme_buf, "{s}/README", .{dir_path});
+    const f = try malt_fs.createFileAbsolute(readme, .{});
+    f.close();
+
+    var out: [64]u8 = undefined;
+    try testing.expect(cask.findAppInDir(dir_path, &out) == null);
+}
+
+test "findAppInDir returns null when the .app name exceeds the out-buffer" {
+    var dir_buf: [128]u8 = undefined;
+    const dir_path = try scratchDir("toolong", &dir_buf);
+    defer malt_fs.deleteTreeAbsolute(dir_path) catch {};
+
+    var app_path_buf: [256]u8 = undefined;
+    const app_path = try std.fmt.bufPrint(
+        &app_path_buf,
+        "{s}/AReallyLongApplicationBundleName.app",
+        .{dir_path},
+    );
+    try malt_fs.makeDirAbsolute(app_path);
+
+    var out: [8]u8 = undefined; // too small on purpose
+    try testing.expect(cask.findAppInDir(dir_path, &out) == null);
+}
+
 test "verifyFileSha256 accepts only the exact-byte payload (collision check)" {
     // Two files that differ by a single byte must produce different
     // hashes — the chunk-boundary bug could otherwise let two files


### PR DESCRIPTION
## Description

Fix a dangling-slice UAF in `findAppInDir`: `entry.name` is borrowed from the directory iterator and dies when `dir.close()` / iterator scope ends. Switch to a caller-provided buffer so the app name survives the iterator's teardown.

## Related Issue

- None

## Notes for Reviewers

Zero-alloc fix — both existing callers already own a destination buffer. New test covers the fall-through path (`artifacts.app` missing from parsed cask).

`findAppInDir` moves from an unused-self method on `CaskInstaller` to a module-level `pub` free function, removing a spurious coupling and making the helper directly testable.
