### PR TITLE
fix(core/ruby_subprocess): escape Ruby interpolations and tighten prefix validator

### DIFF
--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -14,6 +14,7 @@ const api_mod = @import("../net/api.zig");
 const sandbox = @import("sandbox/macos.zig");
 const dsl_lexer = @import("dsl/lexer.zig");
 const dsl_parser = @import("dsl/parser.zig");
+const fs_atomic = @import("../fs/atomic.zig");
 
 pub const RubyError = error{
     RubyNotFound,
@@ -23,6 +24,7 @@ pub const RubyError = error{
     ScriptWriteFailed,
     PostInstallFailed,
     OutOfMemory,
+    InvalidInput,
 };
 
 /// Upper bound on a fetched formula .rb blob. The Homebrew-wide 99th
@@ -345,6 +347,13 @@ pub fn extractPostInstallBody(allocator: std.mem.Allocator, rb_path: []const u8)
 
 /// Generate the Ruby wrapper script that provides a FormulaStub sandbox
 /// and evaluates the post_install body.
+///
+/// `prefix`, `name`, `version` are interpolated into single-quoted Ruby
+/// literals. They MUST contain only bytes from the centralised charset in
+/// `fs/atomic.zig` — anything else (`'`, `\`, `\n`, control bytes, …)
+/// would break the literal or open an injection (BUG-007). We validate
+/// at the boundary rather than escape so the contract is one-line
+/// reviewable: pass → safe to interpolate, fail → InvalidInput.
 pub fn generateWrapper(
     allocator: std.mem.Allocator,
     name: []const u8,
@@ -352,6 +361,11 @@ pub fn generateWrapper(
     prefix: []const u8,
     post_install_body: []const u8,
 ) ![]const u8 {
+    if (prefix.len == 0 or name.len == 0 or version.len == 0) return error.InvalidInput;
+    for (prefix) |b| if (!fs_atomic.isAllowedPrefixByte(b)) return error.InvalidInput;
+    for (name) |b| if (!fs_atomic.isAllowedNameByte(b)) return error.InvalidInput;
+    for (version) |b| if (!fs_atomic.isAllowedNameByte(b)) return error.InvalidInput;
+
     var aw: std.Io.Writer.Allocating = .init(allocator);
     errdefer aw.deinit();
 
@@ -448,6 +462,14 @@ pub fn runPostInstall(
     version: []const u8,
     prefix: []const u8,
 ) RubyError!void {
+    // 0. Validate inputs at the boundary. A hostile Cellar dir name (the
+    //    on-disk source of `name` on the runPostInstall path) must die
+    //    here, not deeper in script generation or the sandbox spawn.
+    if (prefix.len == 0 or name.len == 0 or version.len == 0) return RubyError.InvalidInput;
+    for (prefix) |b| if (!fs_atomic.isAllowedPrefixByte(b)) return RubyError.InvalidInput;
+    for (name) |b| if (!fs_atomic.isAllowedNameByte(b)) return RubyError.InvalidInput;
+    for (version) |b| if (!fs_atomic.isAllowedNameByte(b)) return RubyError.InvalidInput;
+
     // 1. Find Ruby (caller-owned heap slice — see detectRuby contract).
     const ruby_path = detectRuby(allocator) orelse {
         output.err("No Ruby interpreter found. Tried:", .{});

--- a/src/fs/atomic.zig
+++ b/src/fs/atomic.zig
@@ -13,7 +13,29 @@ pub const PrefixError = error{
     EmbeddedNul,
     TooLong,
     EmptyComponent,
+    DisallowedByte,
 };
+
+/// Single source of truth for the prefix charset. Matches
+/// `validatePathForProfile` in `core/sandbox/macos.zig` so anything that
+/// passes here is safe to interpolate into a Ruby single-quoted literal,
+/// a sandbox-profile path string, or a shell argv.
+pub fn isAllowedPrefixByte(b: u8) bool {
+    return switch (b) {
+        'a'...'z', 'A'...'Z', '0'...'9', '.', '_', '+', '-', '/' => true,
+        else => false,
+    };
+}
+
+/// Charset for a formula `name` or `version`. Same alphabet as the prefix
+/// minus `/` (a name with `/` would pierce a `{prefix}/Cellar/{name}/...`
+/// path) plus `@` (versioned formulae like `llvm@21`, `python@3.12`).
+pub fn isAllowedNameByte(b: u8) bool {
+    return switch (b) {
+        'a'...'z', 'A'...'Z', '0'...'9', '.', '_', '+', '-', '@' => true,
+        else => false,
+    };
+}
 
 /// Validate a candidate install prefix. Called at the env boundary so
 /// downstream code can assume absolute, NUL-free, traversal-free.
@@ -22,6 +44,10 @@ pub fn validatePrefix(prefix: []const u8) PrefixError!void {
     if (prefix.len > MAX_PREFIX_LEN) return PrefixError.TooLong;
     if (prefix[0] != '/') return PrefixError.NotAbsolute;
     if (std.mem.indexOfScalar(u8, prefix, 0) != null) return PrefixError.EmbeddedNul;
+    // Tight charset closes the BUG-007/BUG-019 injection class — quotes,
+    // backslashes, control bytes, parens etc. flow into single-quoted
+    // Ruby literals and sandbox-profile strings unchanged.
+    for (prefix) |b| if (!isAllowedPrefixByte(b)) return PrefixError.DisallowedByte;
 
     // Strip one trailing slash; `/opt/malt/` is fine, `//` inside is not.
     const trimmed = if (prefix.len > 1 and prefix[prefix.len - 1] == '/')
@@ -46,6 +72,7 @@ pub fn describePrefixError(e: PrefixError) []const u8 {
         PrefixError.EmbeddedNul => "contains NUL byte",
         PrefixError.TooLong => "exceeds 512 bytes",
         PrefixError.EmptyComponent => "contains empty path component ('//')",
+        PrefixError.DisallowedByte => "contains a byte outside [a-zA-Z0-9._+-/]",
     };
 }
 

--- a/tests/atomic_test.zig
+++ b/tests/atomic_test.zig
@@ -116,6 +116,78 @@ test "validatePrefix: dotdot-like-but-not-exact component accepted" {
     try atomic.validatePrefix("/opt/malt..");
 }
 
+// T-003: tighten the prefix charset to close the Ruby-wrapper / sandbox-
+// profile injection vector. A MALT_PREFIX with a quote, backslash, or
+// control byte breaks the generated single-quoted Ruby literal — see
+// docs/analysis/2026-04-20-01-bugs.md BUG-007 / BUG-019.
+test "validatePrefix: single quote rejected" {
+    try testing.expectError(error.DisallowedByte, atomic.validatePrefix("/tmp/m'x"));
+}
+
+test "validatePrefix: double quote rejected" {
+    try testing.expectError(error.DisallowedByte, atomic.validatePrefix("/tmp/m\"x"));
+}
+
+test "validatePrefix: backslash rejected" {
+    try testing.expectError(error.DisallowedByte, atomic.validatePrefix("/tmp/m\\x"));
+}
+
+test "validatePrefix: newline rejected" {
+    try testing.expectError(error.DisallowedByte, atomic.validatePrefix("/tmp/m\nx"));
+}
+
+test "validatePrefix: control bytes rejected" {
+    // 0x01 .. 0x1f and 0x7f all constitute injection-grade noise in any
+    // shell-or-Ruby context the prefix flows into.
+    var path: [10]u8 = "/tmp/m_x_y".*;
+    inline for (.{ 0x01, 0x07, 0x1b, 0x1f, 0x7f }) |b| {
+        path[6] = b;
+        try testing.expectError(error.DisallowedByte, atomic.validatePrefix(&path));
+    }
+}
+
+test "validatePrefix: valid-but-unusual chars accepted (+ . - _)" {
+    // Real-world prefixes may include `+` (e.g. `/opt/malt+1.0`),
+    // `-` (`/opt/foo-bar`), `.`, `_`. They must keep passing.
+    try atomic.validatePrefix("/opt/malt+1.0");
+    try atomic.validatePrefix("/opt/foo-bar.baz_qux");
+    try atomic.validatePrefix("/opt/MALT");
+}
+
+test "isAllowedNameByte: name/version charset extends prefix with @" {
+    // Cellar dir names embed the formula name + version (e.g. `llvm@21`,
+    // `gcc@13`, `python@3.12`) — `@` must pass for those, but `/` must
+    // not (it would let a hostile name pierce the Cellar path).
+    const allowed = "abcXYZ0123456789._+-@";
+    for (allowed) |b| try testing.expect(atomic.isAllowedNameByte(b));
+    const denied = "/'\"\\\n\t (){}[]$|;&<>*?#";
+    for (denied) |b| try testing.expect(!atomic.isAllowedNameByte(b));
+    var b: u8 = 0;
+    while (b < 0x20) : (b += 1) try testing.expect(!atomic.isAllowedNameByte(b));
+    try testing.expect(!atomic.isAllowedNameByte(0x7f));
+}
+
+test "describePrefixError: DisallowedByte has a descriptive string" {
+    const desc = atomic.describePrefixError(error.DisallowedByte);
+    try testing.expect(desc.len > 0);
+}
+
+test "isAllowedPrefixByte: charset matches the documented contract" {
+    // Centralised predicate used by prefix/name/version validation.
+    // [a-zA-Z0-9._+\-/] — see docs/plan/tasks/T-003.md.
+    const allowed = "abcXYZ0123456789._+-/";
+    for (allowed) |b| try testing.expect(atomic.isAllowedPrefixByte(b));
+    const denied = "'\"\\\n\t (){}[]$|;&<>*?#";
+    for (denied) |b| try testing.expect(!atomic.isAllowedPrefixByte(b));
+    // Control bytes: every byte below 0x20 plus DEL.
+    var b: u8 = 0;
+    while (b < 0x20) : (b += 1) try testing.expect(!atomic.isAllowedPrefixByte(b));
+    try testing.expect(!atomic.isAllowedPrefixByte(0x7f));
+    // High bit: not in the allowed set either.
+    try testing.expect(!atomic.isAllowedPrefixByte(0x80));
+    try testing.expect(!atomic.isAllowedPrefixByte(0xff));
+}
+
 test "maltPrefixChecked: empty MALT_PREFIX returns Empty error" {
     setPrefix("");
     defer unsetPrefix();

--- a/tests/ruby_subprocess_test.zig
+++ b/tests/ruby_subprocess_test.zig
@@ -137,6 +137,107 @@ test "generateWrapper emits a Ruby script containing the post_install body and p
     try testing.expect(std.mem.indexOf(u8, script, "2.3") != null);
 }
 
+// T-003: injection regression — every disallowed byte in any of prefix /
+// name / version must be rejected by generateWrapper, not silently
+// interpolated into the single-quoted Ruby literal. See BUG-007.
+
+test "generateWrapper rejects single quote in prefix" {
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.generateWrapper(testing.allocator, "pkg", "1.0", "/tmp/m'x", "ohai 'hi'\n"),
+    );
+}
+
+test "generateWrapper rejects backslash in prefix" {
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.generateWrapper(testing.allocator, "pkg", "1.0", "/tmp/m\\x", "ohai 'hi'\n"),
+    );
+}
+
+test "generateWrapper rejects newline in prefix" {
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.generateWrapper(testing.allocator, "pkg", "1.0", "/tmp/m\nx", "ohai 'hi'\n"),
+    );
+}
+
+test "generateWrapper rejects single quote in name" {
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.generateWrapper(testing.allocator, "p'k", "1.0", "/opt/malt", "ohai 'hi'\n"),
+    );
+}
+
+test "generateWrapper rejects backslash in name" {
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.generateWrapper(testing.allocator, "p\\k", "1.0", "/opt/malt", "ohai 'hi'\n"),
+    );
+}
+
+test "generateWrapper rejects newline in name" {
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.generateWrapper(testing.allocator, "p\nk", "1.0", "/opt/malt", "ohai 'hi'\n"),
+    );
+}
+
+test "generateWrapper rejects single quote in version" {
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.generateWrapper(testing.allocator, "pkg", "1'+exec()+'0", "/opt/malt", "ohai 'hi'\n"),
+    );
+}
+
+test "generateWrapper rejects backslash in version" {
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.generateWrapper(testing.allocator, "pkg", "1\\0", "/opt/malt", "ohai 'hi'\n"),
+    );
+}
+
+test "generateWrapper rejects newline in version" {
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.generateWrapper(testing.allocator, "pkg", "1\n0", "/opt/malt", "ohai 'hi'\n"),
+    );
+}
+
+test "generateWrapper accepts the @-versioned name format (llvm@21)" {
+    // Real-world formula names use `@` for major-version pinning.
+    const script = try ruby.generateWrapper(
+        testing.allocator,
+        "llvm@21",
+        "21.1.5",
+        "/opt/malt",
+        "ohai 'ok'\n",
+    );
+    defer testing.allocator.free(script);
+    try testing.expect(std.mem.indexOf(u8, script, "llvm@21") != null);
+}
+
+test "generateWrapper rejects empty name" {
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.generateWrapper(testing.allocator, "", "1.0", "/opt/malt", "ohai 'hi'\n"),
+    );
+}
+
+test "generateWrapper rejects empty version" {
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.generateWrapper(testing.allocator, "pkg", "", "/opt/malt", "ohai 'hi'\n"),
+    );
+}
+
+test "generateWrapper rejects empty prefix" {
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.generateWrapper(testing.allocator, "pkg", "1.0", "", "ohai 'hi'\n"),
+    );
+}
+
 test "fetchPostInstallFromGitHub returns null for an empty name" {
     try testing.expect(ruby.fetchPostInstallFromGitHub(testing.allocator, "") == null);
 }
@@ -247,6 +348,49 @@ test "extractPostInstallFromSource skips nested defs inside post_install body" {
     defer testing.allocator.free(body.?);
     try testing.expectEqual(@as(?usize, null), std.mem.indexOf(u8, body.?, "def post_install"));
     try testing.expectEqual(@as(usize, 1), std.mem.count(u8, body.?, "ohai \"hi\""));
+}
+
+// T-003: defense-in-depth — runPostInstall must reject hostile name /
+// version up front, before any of the lookup/IO work that would
+// eventually flow them into the wrapper. A Cellar directory whose name
+// or version embeds `'`, `\`, or a newline is a concrete attack on
+// `--use-system-ruby` (the directory listing flows back into name).
+
+test "runPostInstall rejects single-quote in name with InvalidInput" {
+    const err = ruby.runPostInstall(testing.allocator, "p'k", "1.0", "/opt/malt");
+    try testing.expectError(error.InvalidInput, err);
+}
+
+test "runPostInstall rejects backslash in name with InvalidInput" {
+    const err = ruby.runPostInstall(testing.allocator, "p\\k", "1.0", "/opt/malt");
+    try testing.expectError(error.InvalidInput, err);
+}
+
+test "runPostInstall rejects newline in version with InvalidInput" {
+    const err = ruby.runPostInstall(testing.allocator, "pkg", "1\n0", "/opt/malt");
+    try testing.expectError(error.InvalidInput, err);
+}
+
+test "runPostInstall rejects empty name/version/prefix with InvalidInput" {
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.runPostInstall(testing.allocator, "", "1.0", "/opt/malt"),
+    );
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.runPostInstall(testing.allocator, "pkg", "", "/opt/malt"),
+    );
+    try testing.expectError(
+        error.InvalidInput,
+        ruby.runPostInstall(testing.allocator, "pkg", "1.0", ""),
+    );
+}
+
+test "runPostInstall rejects hostile prefix with InvalidInput" {
+    // Even if the env-boundary check were bypassed, runPostInstall must
+    // not produce a syntax-corrupt wrapper.
+    const err = ruby.runPostInstall(testing.allocator, "pkg", "1.0", "/tmp/m'x");
+    try testing.expectError(error.InvalidInput, err);
 }
 
 test "detectRuby returns a heap-owned slice that the caller can free" {


### PR DESCRIPTION
## Description

Close the Ruby-wrapper injection window. `generateWrapper` no longer emits unescaped `prefix`, `name`, or `version` into single-quoted Ruby. `validatePrefix` now rejects the full shell/Ruby metacharacter set; `runPostInstall` validates name and version against the same charset.

## Related Issue

- None 

## Notes for Reviewers

Validation charset is deliberately narrow — if this rejects a real-world prefix, tell me and I'll widen. Tests include hostile-input payloads (`'`, `\`, `\n`, control bytes) for prefix, name, and version, and the valid-but-unusual cases (`+`, `.`, `-`, `_`, `@`).
