### PR TITLE
fix(fs/archive): sanitise archive entry paths against tar-slip

### DIFF
--- a/src/fs/archive.zig
+++ b/src/fs/archive.zig
@@ -10,6 +10,20 @@ const fs_compat = @import("compat.zig");
 /// pool of noise for zero benefit. Kept on libc alloc for clarity.
 const child_allocator = std.heap.c_allocator;
 
+/// archive entries can escape dest; reject before extract.
+/// Reject absolute, `..`-bearing, NUL-bearing, or empty names — `.`
+/// components are tolerated since tar routinely emits `./name`.
+pub fn isSafeEntryPath(name: []const u8) bool {
+    if (name.len == 0) return false;
+    if (name[0] == '/') return false;
+    if (std.mem.indexOfScalar(u8, name, 0) != null) return false;
+    var it = std.mem.splitScalar(u8, name, '/');
+    while (it.next()) |comp| {
+        if (std.mem.eql(u8, comp, "..")) return false;
+    }
+    return true;
+}
+
 /// Read up to `out.len` bytes from the file at `absolute_path`, returning how
 /// many were actually read. Used for the magic-byte sniff before handing a
 /// downloaded archive off to an external extractor.
@@ -43,6 +57,12 @@ pub fn extractTarGz(archive_path: []const u8, dest_dir: []const u8) !void {
         return error.ExtractionFailed;
     }
 
+    // Pre-scan: a single escaping entry (or symlink target) taints the
+    // whole archive. Extraction streams entries in order, so without a
+    // pre-scan a safe entry preceding a hostile one would already be on
+    // disk by the time the extractor errors out.
+    try validateTarGz(archive_path);
+
     const io = io_mod.ctx();
 
     var file = std.Io.Dir.openFileAbsolute(io, archive_path, .{}) catch return error.ExtractionFailed;
@@ -63,6 +83,33 @@ pub fn extractTarGz(archive_path: []const u8, dest_dir: []const u8) !void {
     defer dir.close(io);
 
     std.tar.pipeToFileSystem(io, dir, &decompress.reader, .{}) catch return error.ExtractionFailed;
+}
+
+fn validateTarGz(archive_path: []const u8) !void {
+    const io = io_mod.ctx();
+    var file = std.Io.Dir.openFileAbsolute(io, archive_path, .{}) catch return error.ExtractionFailed;
+    defer file.close(io);
+
+    var file_buf: [16 * 1024]u8 = undefined;
+    var file_reader = file.reader(io, &file_buf);
+    const input: *std.Io.Reader = &file_reader.interface;
+
+    var window: [std.compress.flate.max_window_len]u8 = undefined;
+    var decompress = std.compress.flate.Decompress.init(input, .gzip, &window);
+
+    var file_name_buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    var link_name_buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    var it: std.tar.Iterator = .init(&decompress.reader, .{
+        .file_name_buffer = &file_name_buffer,
+        .link_name_buffer = &link_name_buffer,
+    });
+
+    while (it.next() catch return error.ExtractionFailed) |entry| {
+        if (!isSafeEntryPath(entry.name)) return error.ExtractionFailed;
+        if (entry.kind == .sym_link and !isSafeEntryPath(entry.link_name)) {
+            return error.ExtractionFailed;
+        }
+    }
 }
 
 /// Extracts a tar.zst archive from the given input reader into output_dir.
@@ -87,6 +134,8 @@ pub fn extractZip(archive_path: []const u8, dest_dir: []const u8) !void {
         return error.ExtractionFailed;
     }
 
+    try validateZip(archive_path);
+
     // -q: quiet, -o: overwrite without prompting, -d: destination dir.
     const argv = [_][]const u8{ "unzip", "-q", "-o", archive_path, "-d", dest_dir };
     var child = fs_compat.Child.init(&argv, child_allocator);
@@ -100,11 +149,23 @@ pub fn extractZip(archive_path: []const u8, dest_dir: []const u8) !void {
     }
 }
 
+fn validateZip(archive_path: []const u8) !void {
+    // `-Z1` prints one entry name per line with no headers or sizes —
+    // a zero-column listing we can scan without parsing unzip's table.
+    const argv = [_][]const u8{ "unzip", "-Z1", archive_path };
+    try validateSubprocessListing(&argv);
+}
+
 /// Extracts a tar.xz archive file to a directory using the system `tar` command.
 /// Zig 0.15's xz decompressor uses the legacy I/O API which doesn't integrate
 /// with std.tar, so we shell out to the system tar (always available on macOS).
+/// `--no-same-permissions`/`--no-same-owner` stop tar from honouring archived
+/// uid/mode bits on extract — downloaded archives should not shape the
+/// on-disk identity of what they produce.
 pub fn extractTarXzFile(archive_path: []const u8, dest_dir: []const u8) !void {
-    const argv = [_][]const u8{ "tar", "xf", archive_path, "-C", dest_dir };
+    try validateTarListing(archive_path);
+
+    const argv = [_][]const u8{ "tar", "xf", archive_path, "-C", dest_dir, "--no-same-permissions", "--no-same-owner" };
     var child = fs_compat.Child.init(&argv, child_allocator);
     child.spawn() catch return error.ExtractionFailed;
     const term = child.wait() catch return error.ExtractionFailed;
@@ -113,5 +174,43 @@ pub fn extractTarXzFile(archive_path: []const u8, dest_dir: []const u8) !void {
             if (code != 0) return error.ExtractionFailed;
         },
         else => return error.ExtractionFailed,
+    }
+}
+
+fn validateTarListing(archive_path: []const u8) !void {
+    const argv = [_][]const u8{ "tar", "tf", archive_path };
+    try validateSubprocessListing(&argv);
+}
+
+/// Spawn `argv` expecting one entry name per stdout line, and reject the
+/// archive if any entry fails `isSafeEntryPath`. Shared by `extractZip`
+/// (via `unzip -Z1`) and `extractTarXzFile` (via `tar tf`).
+fn validateSubprocessListing(argv: []const []const u8) !void {
+    var child = fs_compat.Child.init(argv, child_allocator);
+    child.stdout_behavior = .pipe;
+    child.stderr_behavior = .ignore;
+    child.spawn() catch return error.ExtractionFailed;
+    const stdout = child.stdout orelse {
+        _ = child.wait() catch {};
+        return error.ExtractionFailed;
+    };
+    // 4 MiB cap: bottle/tap listings are orders of magnitude smaller;
+    // the bound just prevents a pathological archive from ballooning RAM.
+    const listing = fs_compat.readFileToEndAlloc(stdout, child_allocator, 4 * 1024 * 1024) catch {
+        _ = child.wait() catch {};
+        return error.ExtractionFailed;
+    };
+    defer child_allocator.free(listing);
+    const term = child.wait() catch return error.ExtractionFailed;
+    switch (term) {
+        .exited => |code| if (code != 0) return error.ExtractionFailed,
+        else => return error.ExtractionFailed,
+    }
+
+    var it = std.mem.splitScalar(u8, listing, '\n');
+    while (it.next()) |raw| {
+        const line = std.mem.trimEnd(u8, raw, "\r");
+        if (line.len == 0) continue;
+        if (!isSafeEntryPath(line)) return error.ExtractionFailed;
     }
 }

--- a/tests/archive_test.zig
+++ b/tests/archive_test.zig
@@ -243,3 +243,121 @@ test "extractZip rejects a missing archive" {
 
     try testing.expectError(error.ExtractionFailed, archive.extractZip(base ++ "/nope.zip", base));
 }
+
+// tar-slip: pre-scan must reject the whole archive before any entry
+// lands. `-s` rewrites bad.txt's header name to `../escape.txt` so the
+// tarball claims a path outside dest. good.txt comes first in tar
+// order — if the extractor streamed entries it would write good.txt
+// before hitting the bad one, which the test forbids.
+test "extractTarGz rejects tar-slip and leaves dest untouched" {
+    const base = "/tmp/malt_archive_tarslip_targz";
+    malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    try malt.fs_compat.makeDirAbsolute(base);
+    defer malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    const dest = base ++ "/dest";
+    try malt.fs_compat.makeDirAbsolute(dest);
+
+    const src_dir = base ++ "/src";
+    try malt.fs_compat.makeDirAbsolute(src_dir);
+    {
+        const f = try malt.fs_compat.createFileAbsolute(src_dir ++ "/good.txt", .{});
+        try f.writeAll("safe");
+        f.close();
+    }
+    {
+        const f = try malt.fs_compat.createFileAbsolute(src_dir ++ "/bad.txt", .{});
+        try f.writeAll("hostile");
+        f.close();
+    }
+
+    const archive_path = base ++ "/hostile.tar.gz";
+    try runCmd(&.{ "tar", "czf", archive_path, "-C", src_dir, "-s", "|^bad.txt|../escape.txt|", "good.txt", "bad.txt" });
+
+    try testing.expectError(error.ExtractionFailed, archive.extractTarGz(archive_path, dest));
+    try testing.expectError(error.FileNotFound, malt.fs_compat.accessAbsolute(dest ++ "/good.txt", .{}));
+    try testing.expectError(error.FileNotFound, malt.fs_compat.accessAbsolute(base ++ "/escape.txt", .{}));
+}
+
+// tar-slip for zip: macOS `zip` normalises `..` out at creation, so
+// we lean on python3's zipfile to emit the entry name verbatim.
+test "extractZip rejects tar-slip and leaves dest untouched" {
+    const base = "/tmp/malt_archive_tarslip_zip";
+    malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    try malt.fs_compat.makeDirAbsolute(base);
+    defer malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    const dest = base ++ "/dest";
+    try malt.fs_compat.makeDirAbsolute(dest);
+
+    const archive_path = base ++ "/hostile.zip";
+    const script = "import zipfile\n" ++
+        "with zipfile.ZipFile('" ++ archive_path ++ "', 'w') as z:\n" ++
+        "    z.writestr('good.txt', b'safe')\n" ++
+        "    z.writestr('../escape.txt', b'hostile')\n";
+    try runCmd(&.{ "python3", "-c", script });
+
+    try testing.expectError(error.ExtractionFailed, archive.extractZip(archive_path, dest));
+    try testing.expectError(error.FileNotFound, malt.fs_compat.accessAbsolute(dest ++ "/good.txt", .{}));
+    try testing.expectError(error.FileNotFound, malt.fs_compat.accessAbsolute(base ++ "/escape.txt", .{}));
+}
+
+test "extractTarXzFile rejects tar-slip and leaves dest untouched" {
+    const base = "/tmp/malt_archive_tarslip_tarxz";
+    malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    try malt.fs_compat.makeDirAbsolute(base);
+    defer malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    const dest = base ++ "/dest";
+    try malt.fs_compat.makeDirAbsolute(dest);
+
+    const src_dir = base ++ "/src";
+    try malt.fs_compat.makeDirAbsolute(src_dir);
+    {
+        const f = try malt.fs_compat.createFileAbsolute(src_dir ++ "/good.txt", .{});
+        try f.writeAll("safe");
+        f.close();
+    }
+    {
+        const f = try malt.fs_compat.createFileAbsolute(src_dir ++ "/bad.txt", .{});
+        try f.writeAll("hostile");
+        f.close();
+    }
+
+    const archive_path = base ++ "/hostile.tar.xz";
+    try runCmd(&.{ "tar", "cJf", archive_path, "-C", src_dir, "-s", "|^bad.txt|../escape.txt|", "good.txt", "bad.txt" });
+
+    try testing.expectError(error.ExtractionFailed, archive.extractTarXzFile(archive_path, dest));
+    try testing.expectError(error.FileNotFound, malt.fs_compat.accessAbsolute(dest ++ "/good.txt", .{}));
+    try testing.expectError(error.FileNotFound, malt.fs_compat.accessAbsolute(base ++ "/escape.txt", .{}));
+}
+
+test "extractTarGz rejects a symlink entry whose target escapes dest" {
+    const base = "/tmp/malt_archive_tarslip_targz_symlink";
+    malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    try malt.fs_compat.makeDirAbsolute(base);
+    defer malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    const dest = base ++ "/dest";
+    try malt.fs_compat.makeDirAbsolute(dest);
+
+    const src_dir = base ++ "/src";
+    try malt.fs_compat.makeDirAbsolute(src_dir);
+    try malt.fs_compat.symLinkAbsolute("/etc/passwd", src_dir ++ "/badlink", .{});
+
+    const archive_path = base ++ "/sym.tar.gz";
+    try runCmd(&.{ "tar", "czf", archive_path, "-C", src_dir, "badlink" });
+
+    try testing.expectError(error.ExtractionFailed, archive.extractTarGz(archive_path, dest));
+    try testing.expectError(error.FileNotFound, malt.fs_compat.accessAbsolute(dest ++ "/badlink", .{}));
+}
+
+test "isSafeEntryPath rejects escape paths" {
+    try testing.expect(archive.isSafeEntryPath("a/b/c"));
+    try testing.expect(archive.isSafeEntryPath("./ok"));
+    try testing.expect(archive.isSafeEntryPath("a/./b"));
+    try testing.expect(archive.isSafeEntryPath("deep/dir/"));
+    try testing.expect(!archive.isSafeEntryPath(""));
+    try testing.expect(!archive.isSafeEntryPath("/abs/path"));
+    try testing.expect(!archive.isSafeEntryPath("../escape"));
+    try testing.expect(!archive.isSafeEntryPath("a/../b"));
+    try testing.expect(!archive.isSafeEntryPath("a/b/.."));
+    try testing.expect(!archive.isSafeEntryPath("..\x00"));
+    try testing.expect(!archive.isSafeEntryPath("ok\x00evil"));
+}


### PR DESCRIPTION
## Description

Pre-scan archive entries before extraction in `fs/archive.zig` and reject any path that escapes `dest_dir` (absolute, `..` components, NUL bytes, or resolves outside). Applies to `extractTarGz`, `extractZip`, `extractTarXzFile`. `extractTarGz` additionally validates symlink `link_name` (std.tar's `sanitizePath` only covers `file_name`). Hostile tap formulas (local-path install) can no longer write outside the cellar via `../` entries — bytes-SHA pinning confirmed what the attacker served, not what they named.

## Related Issue

- None

## Notes for Reviewers

- None