### PR TITLE
fix(fs/archive): allow intra-bundle relative symlink targets

### DIFF
--- a/src/fs/archive.zig
+++ b/src/fs/archive.zig
@@ -24,6 +24,42 @@ pub fn isSafeEntryPath(name: []const u8) bool {
     return true;
 }
 
+/// Symlink targets may legitimately use `..` to point at a sibling within
+/// the extracted bundle (e.g. Apple `.xctoolchain`'s `usr/bin -> ../../../bin`).
+/// Resolve `link_name` lexically against `dirname(entry_name)` and reject
+/// only when the result would escape the extraction root, or when the
+/// target is absolute, empty, or NUL-bearing. `entry_name` is assumed to
+/// have already passed `isSafeEntryPath`.
+pub fn isSafeSymlinkTarget(entry_name: []const u8, link_name: []const u8) bool {
+    if (link_name.len == 0) return false;
+    if (link_name[0] == '/') return false;
+    if (std.mem.indexOfScalar(u8, link_name, 0) != null) return false;
+
+    // Parent depth: components in entry_name minus the symlink's own slot.
+    var parent_depth: usize = 0;
+    var name_it = std.mem.splitScalar(u8, entry_name, '/');
+    while (name_it.next()) |comp| {
+        if (comp.len == 0 or std.mem.eql(u8, comp, ".")) continue;
+        if (std.mem.eql(u8, comp, "..")) return false;
+        parent_depth += 1;
+    }
+    if (parent_depth == 0) return false;
+    parent_depth -= 1;
+
+    var depth = parent_depth;
+    var link_it = std.mem.splitScalar(u8, link_name, '/');
+    while (link_it.next()) |comp| {
+        if (comp.len == 0 or std.mem.eql(u8, comp, ".")) continue;
+        if (std.mem.eql(u8, comp, "..")) {
+            if (depth == 0) return false;
+            depth -= 1;
+        } else {
+            depth += 1;
+        }
+    }
+    return true;
+}
+
 /// Read up to `out.len` bytes from the file at `absolute_path`, returning how
 /// many were actually read. Used for the magic-byte sniff before handing a
 /// downloaded archive off to an external extractor.
@@ -106,7 +142,7 @@ fn validateTarGz(archive_path: []const u8) !void {
 
     while (it.next() catch return error.ExtractionFailed) |entry| {
         if (!isSafeEntryPath(entry.name)) return error.ExtractionFailed;
-        if (entry.kind == .sym_link and !isSafeEntryPath(entry.link_name)) {
+        if (entry.kind == .sym_link and !isSafeSymlinkTarget(entry.name, entry.link_name)) {
             return error.ExtractionFailed;
         }
     }

--- a/tests/archive_test.zig
+++ b/tests/archive_test.zig
@@ -361,3 +361,81 @@ test "isSafeEntryPath rejects escape paths" {
     try testing.expect(!archive.isSafeEntryPath("..\x00"));
     try testing.expect(!archive.isSafeEntryPath("ok\x00evil"));
 }
+
+test "isSafeSymlinkTarget: accepts intra-bundle relative targets" {
+    // The llvm@21 / .xctoolchain shape: ../../../bin from a 5-deep dir
+    // resolves to a sibling at depth 2 — safely inside the extraction root.
+    try testing.expect(archive.isSafeSymlinkTarget(
+        "llvm@21/21.1.8/Toolchains/LLVM21.1.8.xctoolchain/usr/bin",
+        "../../../bin",
+    ));
+    // Sibling next to the symlink (the common bottle shape).
+    try testing.expect(archive.isSafeSymlinkTarget("a/b/link", "sibling"));
+    // Up one level into a sibling subtree.
+    try testing.expect(archive.isSafeSymlinkTarget("a/b/c/link", "../d"));
+    // `.` and empty components are no-ops.
+    try testing.expect(archive.isSafeSymlinkTarget("a/b/link", "./c/./d"));
+}
+
+test "isSafeSymlinkTarget: rejects targets that escape the root" {
+    // One `..` too many — entry sits at depth 1 (parent depth 0).
+    try testing.expect(!archive.isSafeSymlinkTarget("link", "../escape"));
+    // 4 `..` from a 3-deep parent overshoots.
+    try testing.expect(!archive.isSafeSymlinkTarget("a/b/c/link", "../../../../etc"));
+    // Mid-path overshoot: pops to root then climbs back — still escaped at the pop.
+    try testing.expect(!archive.isSafeSymlinkTarget("a/link", "../../oops/back"));
+}
+
+test "isSafeSymlinkTarget: rejects absolute, empty, and NUL-bearing targets" {
+    try testing.expect(!archive.isSafeSymlinkTarget("a/b/link", "/etc/passwd"));
+    try testing.expect(!archive.isSafeSymlinkTarget("a/b/link", ""));
+    try testing.expect(!archive.isSafeSymlinkTarget("a/b/link", "ok\x00evil"));
+}
+
+test "extractTarGz accepts a symlink whose relative target stays inside dest" {
+    // Mirrors the llvm@21 bottle layout that broke after T-004:
+    // a deep symlink whose `..`-only target resolves to a sibling within
+    // the extracted tree. Pre-fix this errored out as `ExtractionFailed`.
+    const base = "/tmp/malt_archive_targz_intra_symlink";
+    malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    try malt.fs_compat.makeDirAbsolute(base);
+    defer malt.fs_compat.deleteTreeAbsolute(base) catch {};
+
+    const src_root = base ++ "/src";
+    try malt.fs_compat.makeDirAbsolute(src_root);
+    var src_dir = try malt.fs_compat.openDirAbsolute(src_root, .{});
+    defer {
+        var sd = src_dir;
+        sd.close();
+    }
+    try src_dir.makePath("bin");
+    try src_dir.makePath("Toolchains/x.xctoolchain/usr");
+    {
+        const f = try src_dir.createFile("bin/llvm-tool", .{});
+        try f.writeAll("#!/bin/sh\n");
+        f.close();
+    }
+    // Symlink target uses `..` to point at the sibling `bin` dir — exactly
+    // the shape Apple .xctoolchain bundles ship with.
+    var usr_dir = try src_dir.openDir("Toolchains/x.xctoolchain/usr", .{});
+    defer {
+        var ud = usr_dir;
+        ud.close();
+    }
+    try usr_dir.symLink("../../../bin", "bin", .{});
+
+    const archive_path = base ++ "/payload.tar.gz";
+    try runTar(&.{ "tar", "czf", archive_path, "-C", base, "src" });
+    try malt.fs_compat.deleteTreeAbsolute(src_root);
+
+    try archive.extractTarGz(archive_path, base);
+
+    var link_buf: [64]u8 = undefined;
+    var dest_dir = try malt.fs_compat.openDirAbsolute(base, .{});
+    defer {
+        var dd = dest_dir;
+        dd.close();
+    }
+    const target = try dest_dir.readLink("src/Toolchains/x.xctoolchain/usr/bin", &link_buf);
+    try testing.expectEqualStrings("../../../bin", target);
+}


### PR DESCRIPTION
## Description

`validateTarGz` rejected legitimate intra-bundle relative symlink targets — any `..` in a symlink's `link_name` was treated the same as a tar-slip escape. That's wrong: a target like `../../../bin` from `Toolchains/X.xctoolchain/usr/bin` resolves inside the extracted root and is the canonical `.xctoolchain` layout. As a result, `mt install zig` (and anything depending on `llvm@21` or any LLVM toolchain) failed 3× with `ExtractionFailed` after a clean SHA-verified download.

This PR adds an `isSafeSymlinkTarget` predicate that lexically resolves the link target against its parent directory and rejects only paths that escape the extraction root. `isSafeEntryPath` keeps its strict no-`..` rule for entry names.

## Related Issue

- None

## Notes for Reviewers

- None
