### PR TITLE
fix(net/client): plug leaks in redirect-follow HEAD state machine

### DIFF
--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -142,6 +142,15 @@ pub const HttpClient = struct {
             self.allocator.free(self.final_url);
             if (self.content_disposition) |cd| self.allocator.free(cd);
         }
+
+        /// Swap `final_url` to a fresh dupe of `new_url`. The old slice is
+        /// only freed after the new dupe succeeds, so an OOM here leaves
+        /// the struct's invariants intact for `deinit`.
+        pub fn replaceFinalUrl(self: *HeadResolved, new_url: []const u8) !void {
+            const next = try self.allocator.dupe(u8, new_url);
+            self.allocator.free(self.final_url);
+            self.final_url = next;
+        }
     };
 
     const MAX_HEAD_REDIRECTS = 5;
@@ -150,13 +159,17 @@ pub const HttpClient = struct {
     /// final URL and Content-Disposition. The stdlib skips redirect
     /// handling for HEAD, so we follow Location headers ourselves.
     pub fn headResolved(self: *HttpClient, url: []const u8) !HeadResolved {
-        var current_url = try self.allocator.dupe(u8, url);
-        var cd_result: ?[]const u8 = null;
+        // Build the result eagerly so a single errdefer covers every dupe
+        // inside the redirect loop; on success the caller takes ownership.
+        var resolved: HeadResolved = .{
+            .final_url = try self.allocator.dupe(u8, url),
+            .content_disposition = null,
+            .allocator = self.allocator,
+        };
+        errdefer resolved.deinit();
 
         for (0..MAX_HEAD_REDIRECTS) |_| {
-            const uri = std.Uri.parse(current_url) catch {
-                break;
-            };
+            const uri = std.Uri.parse(resolved.final_url) catch break;
 
             var req = self.client.request(.HEAD, uri, .{
                 .extra_headers = &.{},
@@ -168,29 +181,23 @@ pub const HttpClient = struct {
             var redirect_buf: [32 * 1024]u8 = undefined;
             const response = req.receiveHead(&redirect_buf) catch break;
 
-            if (cd_result == null) {
+            if (resolved.content_disposition == null) {
                 if (response.head.content_disposition) |cd| {
-                    cd_result = try self.allocator.dupe(u8, cd);
+                    resolved.content_disposition = try self.allocator.dupe(u8, cd);
                 }
             }
 
             const status: u16 = @intFromEnum(response.head.status);
             if (status >= 301 and status <= 308) {
                 if (response.head.location) |loc| {
-                    const next = try self.allocator.dupe(u8, loc);
-                    self.allocator.free(current_url);
-                    current_url = next;
+                    try resolved.replaceFinalUrl(loc);
                     continue;
                 }
             }
             break;
         }
 
-        return .{
-            .final_url = current_url,
-            .content_disposition = cd_result,
-            .allocator = self.allocator,
-        };
+        return resolved;
     }
 
     /// Default maximum response body size for metadata (API JSON, tokens, etc.).

--- a/tests/net_client_test.zig
+++ b/tests/net_client_test.zig
@@ -35,3 +35,74 @@ test "schemeIsHttps: substring traps rejected" {
     try testing.expect(!client.schemeIsHttps("httpsx"));
     try testing.expect(!client.schemeIsHttps("xhttps"));
 }
+
+test "HeadResolved.deinit: frees final_url and content_disposition when both set" {
+    var head: client.HttpClient.HeadResolved = .{
+        .final_url = try testing.allocator.dupe(u8, "https://a.example/x"),
+        .content_disposition = try testing.allocator.dupe(u8, "attachment; filename=x"),
+        .allocator = testing.allocator,
+    };
+    head.deinit();
+}
+
+test "HeadResolved.deinit: handles null content_disposition" {
+    var head: client.HttpClient.HeadResolved = .{
+        .final_url = try testing.allocator.dupe(u8, "https://a.example/x"),
+        .content_disposition = null,
+        .allocator = testing.allocator,
+    };
+    head.deinit();
+}
+
+test "HeadResolved.replaceFinalUrl: swaps to new dupe and frees the old" {
+    var head: client.HttpClient.HeadResolved = .{
+        .final_url = try testing.allocator.dupe(u8, "https://a.example/x"),
+        .content_disposition = null,
+        .allocator = testing.allocator,
+    };
+    defer head.deinit();
+
+    try head.replaceFinalUrl("https://b.example/y");
+    try testing.expectEqualStrings("https://b.example/y", head.final_url);
+}
+
+test "HeadResolved.replaceFinalUrl: dupe failure preserves original and leaks nothing" {
+    // Mirrors the redirect-loop rotation: if the new dupe fails, the old
+    // url stays owned and the caller's errdefer head.deinit() reclaims it.
+    // fail_index=1 lets the initial dupe succeed and trips replaceFinalUrl's.
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 1 });
+    var head: client.HttpClient.HeadResolved = .{
+        .final_url = try failing.allocator().dupe(u8, "https://a.example/x"),
+        .content_disposition = null,
+        .allocator = failing.allocator(),
+    };
+    defer head.deinit();
+
+    try testing.expectError(error.OutOfMemory, head.replaceFinalUrl("https://b.example/y"));
+    try testing.expectEqualStrings("https://a.example/x", head.final_url);
+}
+
+test "HeadResolved.replaceFinalUrl: dupe failure with content_disposition set leaks nothing" {
+    // The CD-set branch is the second leak path called out in the bug:
+    // a redirect that fails to dupe its location must not strand cd_result.
+    // Indices: 0 = url dupe, 1 = cd dupe, 2 = replaceFinalUrl dupe (fails).
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 2 });
+    var head: client.HttpClient.HeadResolved = .{
+        .final_url = try failing.allocator().dupe(u8, "https://a.example/x"),
+        .content_disposition = try failing.allocator().dupe(u8, "attachment; filename=x"),
+        .allocator = failing.allocator(),
+    };
+    defer head.deinit();
+
+    try testing.expectError(error.OutOfMemory, head.replaceFinalUrl("https://b.example/y"));
+    try testing.expectEqualStrings("https://a.example/x", head.final_url);
+    try testing.expectEqualStrings("attachment; filename=x", head.content_disposition.?);
+}
+
+test "HttpClient.headResolved: returns OOM with no leak when initial url dupe fails" {
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    var http = client.HttpClient.init(failing.allocator());
+    defer http.deinit();
+
+    try testing.expectError(error.OutOfMemory, http.headResolved("https://example.com/"));
+}


### PR DESCRIPTION
## Description

Plug two allocation leaks in `net/client.zig`'s redirect-follow HEAD state machine. `current_url` (the initial dupe of the target URL) and `cd_result` (the in-flight Content-Disposition) were both unowned by anyone on the error path: a dupe failure inside the redirect loop bubbled out without freeing either. Now the function builds a `HeadResolved` immediately and a single `errdefer head.deinit()` covers every dupe in the loop. URL rotation goes through a small `replaceFinalUrl` helper that dupes the new target before freeing the old one, so an OOM mid-rotation leaves the struct's invariants intact for `deinit`.

## Related Issue

- None

## Notes for Reviewers

- None

