### PR TITLE
chore(scripts,justfile): path-aware install smoke on pre-push

### DIFF
--- a/justfile
+++ b/justfile
@@ -99,10 +99,33 @@ pre-commit:
     git add "${files[@]}"
     echo "Auto-formatted ${#files[@]} staged .zig file(s)."
 
-# Pre-push hook: everything that CI checks, plus shell-lint.
+# Pre-push hook: everything that CI checks, plus shell-lint. When the
+# diff vs origin/main touches the install/extract/download surface,
+# additionally runs the heavy install smoke (~7-10 min, ~750 MB).
+# Set MALT_SKIP_SMOKE=1 to bypass the smoke check (e.g. for a doc-only
+# follow-up push you've already verified).
 [group('hooks')]
 pre-push: fmt-check test shell-lint
-    @echo "All pre-push checks passed."
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "${MALT_SKIP_SMOKE:-0}" = "1" ]; then
+        echo "▸ MALT_SKIP_SMOKE=1 — skipping install smoke"
+    elif git rev-parse --verify origin/main >/dev/null 2>&1 \
+        && git diff --name-only origin/main...HEAD 2>/dev/null \
+        | grep -qE '^(src/cli/install\.zig|src/core/bottle\.zig|src/core/cask\.zig|src/fs/archive\.zig|src/fs/atomic\.zig|src/net/client\.zig|src/net/ghcr\.zig|scripts/local-smoke-install\.sh)$'; then
+        echo "▸ Install/extract/download surface touched — running install smoke"
+        ./scripts/local-smoke-install.sh
+    else
+        echo "▸ Install/extract/download surface untouched — skipping install smoke"
+    fi
+    echo "All pre-push checks passed."
+
+# Local-only install smoke. Heavy: ~7-10 min, downloads ~750 MB.
+# Sandboxes into a temp MALT_PREFIX/MALT_CACHE; never touches /opt/malt.
+# Auto-runs from `pre-push` when install/extract/download paths change.
+[group('test')]
+smoke-install: build
+    @./scripts/local-smoke-install.sh
 
 # Install git hooks (pre-commit + pre-push)
 [group('hooks')]

--- a/scripts/local-smoke-install.sh
+++ b/scripts/local-smoke-install.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# scripts/local-smoke-install.sh — heavy install regression guard
+#
+# Runs real installs against an isolated MALT_PREFIX/MALT_CACHE to catch
+# regressions in the bottle download → SHA verify → extract pipeline that
+# CI's smoke_test.sh skips for time and bandwidth reasons. Designed for
+# pre-push gating (path-aware, in justfile) and pre-release validation.
+#
+# Cases (each from a fresh sandbox state, so failures isolate cleanly):
+#   • mt install node           — large dependency graph (24 packages),
+#                                 exercises parallel download + post_install.
+#   • mt install zig            — formula bottle path with intra-bundle
+#                                 relative symlinks (the .xctoolchain layout
+#                                 that broke in T-004 and was fixed in T-004a).
+#   • mt install --cask raycast — cask DMG path. Exercises headResolved
+#                                 redirect-follow + DMG mount/install
+#                                 (the path covered by T-006).
+#
+# Time/bandwidth: ~10–15 min, ~1.5 GB downloaded fresh.
+#
+# Cleanup: on success (FAIL=0), every cask installed by this run is
+# `mt uninstall`-ed and every formula too — so /Applications and any
+# other system-touching state malt knows about is reverted before the
+# EXIT trap wipes the temp PREFIX/CACHE/LOGDIR. On failure, artifacts
+# stay around for triage (matches scripts/local-bench.sh behavior).
+#
+# Cask installs are SKIPPED when the target /Applications/<App>.app
+# already exists — we never trample the user's pre-existing apps.
+#
+# Usage:
+#   ./scripts/local-smoke-install.sh
+#   MT_BIN=./zig-out/bin/mt ./scripts/local-smoke-install.sh
+
+set -uo pipefail
+
+MT_BIN="${MT_BIN:-./zig-out/bin/malt}"
+
+if [[ ! -x "$MT_BIN" ]]; then
+  echo "smoke-install: $MT_BIN not found or not executable" >&2
+  echo "smoke-install: run 'zig build' first (or set MT_BIN)" >&2
+  exit 2
+fi
+MT_BIN="$(cd "$(dirname "$MT_BIN")" && pwd)/$(basename "$MT_BIN")"
+
+# Short prefix template — the Mach-O in-place patcher caps at 13 bytes
+# because Homebrew bottles hard-code `/opt/homebrew` (13 bytes) in
+# LC_LOAD_DYLIB entries. `/tmp/mt.XXX` keeps us at 11 bytes with room.
+PREFIX=$(mktemp -d /tmp/mt.XXX)
+CACHE=$(mktemp -d /tmp/mc.XXX)
+LOGDIR=$(mktemp -d /tmp/ml.XXX)
+trap 'rm -rf "$PREFIX" "$CACHE" "$LOGDIR"' EXIT
+
+export MALT_PREFIX="$PREFIX"
+export MALT_CACHE="$CACHE"
+# Deterministic, machine-parseable output.
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+
+PASS=0
+FAIL=0
+SKIP=0
+FAILURES=()
+SKIPS=()
+INSTALLED_FORMULAS=()
+INSTALLED_CASKS=()
+
+# Run a command; log to LOGDIR; print PASS/FAIL; return its exit status
+# so callers can branch on success (e.g. to track what was installed).
+run() {
+  local tag="$1"
+  shift
+  local log
+  log="$LOGDIR/$(printf '%s' "$tag" | tr -c 'A-Za-z0-9' _).log"
+  printf '  RUN   [%s] %s\n' "$tag" "$*"
+  if "$@" >"$log" 2>&1; then
+    printf '  PASS  [%s]\n' "$tag"
+    PASS=$((PASS + 1))
+    return 0
+  fi
+  local rc=$?
+  printf '  FAIL  [%s] rc=%s log=%s\n' "$tag" "$rc" "$log"
+  sed -n '1,30p' "$log" | sed 's/^/        | /'
+  printf '        --- tail ---\n'
+  tail -30 "$log" | sed 's/^/        | /'
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$tag")
+  return "$rc"
+}
+
+# Install a formula and remember it for success-time cleanup.
+install_formula() {
+  local tag="$1" name="$2"
+  if run "$tag" "$MT_BIN" install "$name"; then
+    INSTALLED_FORMULAS+=("$name")
+  fi
+}
+
+# Install a cask, but only if its /Applications/<App>.app slot is empty.
+# Refusing to overwrite a pre-existing user install means uninstall on
+# success can never remove something the user wants to keep.
+install_cask() {
+  local tag="$1" cask="$2" app_name="$3"
+  local app_path="/Applications/$app_name"
+  if [ -e "$app_path" ]; then
+    printf '  SKIP  [%s] %s pre-exists; cask install would overwrite a user app\n' "$tag" "$app_path"
+    SKIP=$((SKIP + 1))
+    SKIPS+=("$tag")
+    return
+  fi
+  if run "$tag" "$MT_BIN" install --cask "$cask"; then
+    INSTALLED_CASKS+=("$cask")
+  fi
+}
+
+# Reverse what we installed. Casks first because they touch /Applications;
+# formulas second (they live entirely under MALT_PREFIX, but uninstalling
+# also exercises the uninstall path). Best-effort: a stuck uninstall must
+# not block the script from completing.
+cleanup_installs() {
+  printf '\n── Cleanup ───────────────────────────────────────\n'
+  local item
+  for item in "${INSTALLED_CASKS[@]}"; do
+    printf '  uninstall cask %s\n' "$item"
+    "$MT_BIN" uninstall --cask "$item" >/dev/null 2>&1 ||
+      printf '  WARN: uninstall --cask %s exited non-zero (continuing)\n' "$item"
+  done
+  for item in "${INSTALLED_FORMULAS[@]}"; do
+    printf '  uninstall formula %s\n' "$item"
+    "$MT_BIN" uninstall "$item" >/dev/null 2>&1 ||
+      printf '  WARN: uninstall %s exited non-zero (continuing)\n' "$item"
+  done
+}
+
+printf '── Local install smoke ───────────────────────────\n'
+printf '  PREFIX=%s (%d bytes)\n' "$PREFIX" "${#PREFIX}"
+printf '  CACHE=%s\n' "$CACHE"
+printf '  MT_BIN=%s\n\n' "$MT_BIN"
+
+run smoke.update "$MT_BIN" update
+install_formula smoke.install.node node
+install_formula smoke.install.zig zig
+install_cask smoke.install.cask.raycast raycast Raycast.app
+
+printf '\n── Summary ───────────────────────────────────────\n'
+printf '  passed: %d\n' "$PASS"
+printf '  failed: %d\n' "$FAIL"
+printf '  skipped: %d\n' "$SKIP"
+if ((SKIP > 0)); then
+  printf '  skips: %s\n' "${SKIPS[*]}"
+fi
+if ((FAIL > 0)); then
+  printf '  failures: %s\n' "${FAILURES[*]}"
+  printf '\n  triage state preserved in:\n'
+  printf '    PREFIX=%s\n' "$PREFIX"
+  printf '    LOGDIR=%s\n' "$LOGDIR"
+  # Drop the EXIT trap so artifacts survive for triage.
+  trap - EXIT
+  exit 1
+fi
+
+cleanup_installs
+exit 0


### PR DESCRIPTION
## Description

Catches install/extract/download regressions before they hit the remote. Adds `scripts/local-smoke-install.sh` (heavy install smoke against an isolated `MALT_PREFIX`) and wires it into `just pre-push` only when the diff vs `origin/main` touches the install/extract/download surface.

## Related Issue

- None

## What runs

`scripts/local-smoke-install.sh` (idempotent, sandboxed):
- `mt update`
- `mt install node` — large dep graph (24 packages); parallel download + post_install.
- `mt install zig` — formula bottle path with intra-bundle relative symlinks.
- `mt install --cask raycast` — cask DMG path (headResolved + DMG mount).

## Path-aware trigger

`just pre-push` only runs the smoke when `git diff --name-only origin/main...HEAD` touches one of:

```
src/cli/install.zig
src/core/bottle.zig
src/core/cask.zig
src/fs/archive.zig
src/fs/atomic.zig
src/net/client.zig
src/net/ghcr.zig
scripts/local-smoke-install.sh
```

Other pushes (UI, docs, refactors elsewhere) stay fast — the existing `fmt-check + test + shell-lint` chain is unchanged.

## Cleanup model

- **On success (FAIL=0):** every cask and formula installed by the run is `mt uninstall`-ed before the EXIT trap wipes the temp PREFIX/CACHE/LOGDIR. `/Applications` is restored to its pre-run state.
- **On failure:** the EXIT trap is dropped; the temp PREFIX and LOGDIR survive for triage (matches `scripts/local-bench.sh` behavior).

## Escape hatch

`MALT_SKIP_SMOKE=1 git push` bypasses the smoke check (e.g. doc-only follow-up push you've already verified). Pre-push prints a banner so the bypass is visible.
