### PR TITLE
fix(cli/migrate): close leaks and propagate iterator errors

### DIFF
--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -49,6 +49,24 @@ fn lockTimeoutMs() u32 {
     return 30_000;
 }
 
+/// Arena-own Cellar names and log iterator errors instead of silently
+/// truncating the scan — `iter.next() catch null` used to hide every
+/// later keg behind the first bad entry. `anytype` for mock iterators.
+pub fn scanCellarKegs(
+    arena: std.mem.Allocator,
+    iter: anytype,
+    names: *std.ArrayList([]const u8),
+) !void {
+    while (true) {
+        const entry = iter.next() catch |err| {
+            output.warn("Cellar scan error: {s}; keeping {d} entries already found", .{ @errorName(err), names.items.len });
+            break;
+        } orelse break;
+        if (entry.kind != .directory) continue;
+        try names.append(arena, try arena.dupe(u8, entry.name));
+    }
+}
+
 /// Result of migrating a single keg.
 const KegResult = enum {
     migrated,
@@ -111,18 +129,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     };
     defer dir.close();
 
+    // Uniform scan-lifetime dupes → one arena, no per-entry free plumbing.
+    var scan_arena = std.heap.ArenaAllocator.init(allocator);
+    defer scan_arena.deinit();
     var keg_names: std.ArrayList([]const u8) = .empty;
-    defer keg_names.deinit(allocator);
 
     var iter = dir.iterate();
-    while (iter.next() catch null) |entry| {
-        if (entry.kind != .directory) continue;
-        const owned = allocator.dupe(u8, entry.name) catch continue;
-        keg_names.append(allocator, owned) catch {
-            allocator.free(owned);
-            continue;
-        };
-    }
+    try scanCellarKegs(scan_arena.allocator(), &iter, &keg_names);
 
     if (keg_names.items.len == 0) {
         if (json_mode) {
@@ -301,23 +314,22 @@ fn migrateKeg(
         return .skipped_installed;
     }
 
-    // 2. Resolve formula via Homebrew API
+    // Two `defer`s below collapse six per-branch cleanups.
     const formula_json = api.fetchFormula(keg_name) catch {
         output.err("  {s}: not found in Homebrew API", .{keg_name});
         return .failed_api;
     };
+    defer allocator.free(formula_json);
 
     var formula = formula_mod.parseFormula(allocator, formula_json) catch {
         output.err("  {s}: failed to parse formula JSON", .{keg_name});
-        allocator.free(formula_json);
         return .failed_api;
     };
+    defer formula.deinit();
 
     // 3. Resolve bottle for this platform
     const bottle = formula_mod.resolveBottle(allocator, &formula) catch {
         output.warn("  {s}: no bottle available for this platform", .{keg_name});
-        formula.deinit();
-        allocator.free(formula_json);
         return .skipped_no_bottle;
     };
 
@@ -326,8 +338,6 @@ fn migrateKeg(
     // 5. Download bottle via GHCR (skip if already in store)
     if (!store.exists(bottle.sha256)) {
         if (!downloadBottle(allocator, ghcr, http, store, bottle.url, bottle.sha256, keg_name)) {
-            formula.deinit();
-            allocator.free(formula_json);
             return .failed_download;
         }
     } else {
@@ -348,8 +358,6 @@ fn migrateKeg(
         formula.pkg_version,
     ) catch {
         output.err("    {s}: failed to materialize", .{keg_name});
-        formula.deinit();
-        allocator.free(formula_json);
         return .failed_install;
     };
 
@@ -358,8 +366,6 @@ fn migrateKeg(
         const keg_id = recordKeg(db, &formula, bottle.sha256, keg.path, "direct") catch {
             output.err("    {s}: failed to record in database", .{keg_name});
             cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
-            formula.deinit();
-            allocator.free(formula_json);
             return .failed_install;
         };
 
@@ -368,8 +374,6 @@ fn migrateKeg(
             linker.unlink(keg_id) catch {};
             deleteKeg(db, keg_id);
             cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
-            formula.deinit();
-            allocator.free(formula_json);
             return .failed_install;
         };
         linker.linkOpt(formula.name, formula.pkg_version) catch {};
@@ -377,8 +381,6 @@ fn migrateKeg(
     } else {
         const keg_id = recordKeg(db, &formula, bottle.sha256, keg.path, "direct") catch {
             cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
-            formula.deinit();
-            allocator.free(formula_json);
             return .failed_install;
         };
         linker.linkOpt(formula.name, formula.pkg_version) catch {};

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -898,3 +898,186 @@ test "already-installed stderr pins the 'Migration complete' + 'Skipped (install
     try testing.expect(containsLine(buf.items, "Migrated:              0"));
     try testing.expect(containsLine(buf.items, "Skipped (installed):   1"));
 }
+
+// ── Parsed-formula lifecycle pinning ────────────────────────────────────
+//
+// Drive `migrateKeg` through the `.skipped_no_bottle` branch (formula JSON
+// has no bottle for this platform). Pre-T-008 this branch manually calls
+// `formula.deinit()` + `allocator.free(formula_json)`; after collapse the
+// defer/errdefer pair must free exactly once on this path too — a double
+// free of `_parsed` would crash the sqlite/arena owner in the next run.
+
+test "skipped_no_bottle: cached formula with no platform bottle is categorized correctly" {
+    resetOutput();
+
+    const brew = try scratchDir("brew_nobottle");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+
+    // ≤13-byte MALT_PREFIX — same Mach-O budget rationale as sister tests.
+    const mt_z: [:0]const u8 = "/tmp/mt_nb";
+    malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+    try malt.fs_compat.cwd().makePath(mt_z);
+    defer malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+
+    try seedFakeBrew(brew, &.{"noplatform"});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Seed a formula-cache hit with an intentionally minimal payload — no
+    // bottle_files, no dependencies, no oldnames. `resolveBottle` returns
+    // NoBottleAvailable immediately and the branch's cleanup path runs.
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{mt_z});
+    defer testing.allocator.free(cache_api);
+    try malt.fs_compat.cwd().makePath(cache_api);
+    const cache_path = try std.fmt.allocPrint(testing.allocator, "{s}/formula_noplatform.json", .{cache_api});
+    defer testing.allocator.free(cache_path);
+    const cache_file = try malt.fs_compat.cwd().createFile(cache_path, .{});
+    defer cache_file.close();
+    try cache_file.writeAll(
+        \\{"name":"noplatform","full_name":"noplatform","tap":"homebrew/core","versions":{"stable":"1.0"}}
+    );
+
+    output.setMode(.json);
+    defer resetOutput();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{});
+
+    const parsed = try parseAndCheck(buf.items);
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try testing.expectEqual(@as(usize, 1), root.get("skipped_no_bottle").?.array.items.len);
+    try testing.expectEqualStrings("noplatform", root.get("skipped_no_bottle").?.array.items[0].string);
+    try testing.expectEqual(@as(usize, 0), root.get("migrated").?.array.items.len);
+    try testing.expectEqual(@as(usize, 0), root.get("failed").?.array.items.len);
+    try testing.expectEqual(@as(i64, 1), root.get("counts").?.object.get("skipped_no_bottle").?.integer);
+}
+
+// ── Iterator-error surface: scanCellarKegs logs + preserves prior ──────
+//
+// `iter.next() catch null` silently collapsed the scan on any permission,
+// I/O, or stale-handle error — hiding every later keg behind a single bad
+// entry. A mock iterator that yields two kegs then `error.AccessDenied`
+// pins the replacement contract: prior entries survive, the failure is
+// logged, and the loop terminates without propagating the error.
+
+const MockDirEntry = struct {
+    name: []const u8,
+    kind: std.Io.File.Kind,
+};
+
+const MockIter = struct {
+    entries: []const MockDirEntry,
+    idx: usize = 0,
+    fail_after: ?usize = null,
+
+    pub fn next(self: *MockIter) !?MockDirEntry {
+        if (self.fail_after) |n| if (self.idx == n) {
+            self.idx += 1;
+            return error.AccessDenied;
+        };
+        if (self.idx >= self.entries.len) return null;
+        defer self.idx += 1;
+        return self.entries[self.idx];
+    }
+};
+
+test "scanCellarKegs warns and preserves prior names when iterator errors" {
+    resetOutput();
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var names: std.ArrayList([]const u8) = .empty;
+    var mock = MockIter{
+        .entries = &.{
+            .{ .name = "tree", .kind = .directory },
+            .{ .name = "wget", .kind = .directory },
+        },
+        .fail_after = 2,
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &buf);
+    defer io_mod.endStderrCapture();
+
+    try migrate.scanCellarKegs(arena.allocator(), &mock, &names);
+
+    try testing.expectEqual(@as(usize, 2), names.items.len);
+    try testing.expectEqualStrings("tree", names.items[0]);
+    try testing.expectEqualStrings("wget", names.items[1]);
+    try testing.expect(containsLine(buf.items, "Cellar scan error"));
+    try testing.expect(containsLine(buf.items, "AccessDenied"));
+}
+
+test "scanCellarKegs skips non-directory entries and survives fail-first iterator" {
+    resetOutput();
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var names: std.ArrayList([]const u8) = .empty;
+    var mock = MockIter{
+        .entries = &.{
+            .{ .name = ".DS_Store", .kind = .file },
+            .{ .name = "tree", .kind = .directory },
+        },
+        .fail_after = 0, // error on the very first call
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &buf);
+    defer io_mod.endStderrCapture();
+
+    try migrate.scanCellarKegs(arena.allocator(), &mock, &names);
+    try testing.expectEqual(@as(usize, 0), names.items.len);
+    try testing.expect(containsLine(buf.items, "Cellar scan error"));
+}
+
+// ── Leak discipline: execute must not leak under testing.allocator ──────
+//
+// Prior to T-008 the cellar scan duped every entry via `allocator.dupe`
+// into a plain `ArrayList([]const u8)` whose `deinit` only freed the
+// backing array — each per-entry dupe leaked. Existing tests masked this
+// by allocating through an arena; dropping the arena here turns the leak
+// into a test failure and guards the arena-scoped scan going forward.
+
+test "dry-run with 4 kegs under testing.allocator shows zero leaks" {
+    resetOutput();
+    const brew = try scratchDir("brew_noleak");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt = try scratchDir("mt_noleak");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(mt) catch {};
+        testing.allocator.free(mt);
+    }
+    try seedFakeBrew(brew, &.{ "tree", "wget", "jq", "ffmpeg" });
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    try migrate.execute(testing.allocator, &.{ "--dry-run", "--quiet" });
+}


### PR DESCRIPTION
## Description

Close three leaks in `mt migrate` and surface directory-iterator errors. Six near-identical per-branch cleanups in `migrateKeg` collapse to one `defer`/`defer` pair, and the `keg_names` scan moves to an `ArenaAllocator` so every duped entry shares a single lifetime.
Replaces `iter.next() catch null` with an explicit `warn`-and-break handler so one bad Cellar entry no longer hides every later keg.

## Related Issue

- None

## Notes for Reviewers

- None
