### PR TITLE
fix(cli/install): free per-dep parsed formulas in collectFormulaJobs

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -983,6 +983,52 @@ const FetchFormulaCtx = struct {
     }
 };
 
+/// Job-owned strings duped out of a parsed formula so its
+/// `std.json.Parsed` arena can be released as soon as
+/// `collectFormulaJobs` is done reading it. Lifetime matches the
+/// `DownloadJob` — freed by the install flow after the job completes.
+const JobStrings = struct {
+    name: []u8,
+    version_str: []u8,
+    sha256: []u8,
+    bottle_url: []u8,
+    cellar_type: []u8,
+
+    fn freeAll(self: JobStrings, a: std.mem.Allocator) void {
+        a.free(self.name);
+        a.free(self.version_str);
+        a.free(self.sha256);
+        a.free(self.bottle_url);
+        a.free(self.cellar_type);
+    }
+};
+
+/// Dupe the five borrowed slices that a `DownloadJob` needs from a
+/// parsed formula, so the parsed tree can be deinited immediately.
+/// Rolls back on partial failure via errdefer chain.
+fn dupeJobStrings(
+    a: std.mem.Allocator,
+    f: *const formula_mod.Formula,
+    b: formula_mod.BottleFile,
+) !JobStrings {
+    const name = try a.dupe(u8, f.name);
+    errdefer a.free(name);
+    const version_str = try a.dupe(u8, f.pkg_version);
+    errdefer a.free(version_str);
+    const sha256 = try a.dupe(u8, b.sha256);
+    errdefer a.free(sha256);
+    const bottle_url = try a.dupe(u8, b.url);
+    errdefer a.free(bottle_url);
+    const cellar_type = try a.dupe(u8, b.cellar);
+    return .{
+        .name = name,
+        .version_str = version_str,
+        .sha256 = sha256,
+        .bottle_url = bottle_url,
+        .cellar_type = cellar_type,
+    };
+}
+
 /// Collect download jobs for a formula and all its dependencies.
 /// Appends to the shared jobs list for parallel download.
 ///
@@ -1001,7 +1047,17 @@ pub fn collectFormulaJobs(
     jobs: *std.ArrayList(DownloadJob),
 ) !void {
     _ = store;
-    var formula = formula_mod.parseFormula(allocator, formula_json) catch |e| {
+
+    // Single arena for every parsed formula — root + each dep — so the
+    // std.json.Parsed trees and all the supplementary allocations made
+    // by `parseFormula` (dependencies/oldnames/service.run/pkg_version)
+    // are released at function exit. BUG-009 used to pin every parsed
+    // tree for the whole install run (~500 KB on ffmpeg).
+    var parse_arena = std.heap.ArenaAllocator.init(allocator);
+    defer parse_arena.deinit();
+    const parse_alloc = parse_arena.allocator();
+
+    var formula = formula_mod.parseFormula(parse_alloc, formula_json) catch |e| {
         output.err("Failed to parse formula JSON for '{s}': {s}", .{ pkg_name, @errorName(e) });
         return InstallError.FormulaNotFound;
     };
@@ -1009,12 +1065,22 @@ pub fn collectFormulaJobs(
     // Check if already installed
     if (!force and isInstalled(db, formula.name)) {
         output.info("{s} is already installed", .{formula.name});
-        formula.deinit();
         return;
     }
 
-    // Resolve dependencies
+    // Resolve dependencies. `deps_mod.resolve` forwards the allocator
+    // into `api.fetchFormula`, whose bytes come from `api.allocator`
+    // (the same caller allocator) — so the allocator here must match
+    // `allocator`, not `parse_arena.allocator()`, otherwise free on
+    // the API-allocated bytes is a no-op on the arena.
     const deps = deps_mod.resolve(allocator, formula.name, api, db) catch &.{};
+    defer {
+        for (deps) |d| allocator.free(d.name);
+        // `catch &.{}` yields a static empty slice with no backing
+        // allocation — freeing it would be "invalid free" on safe
+        // allocators.
+        if (deps.len > 0) allocator.free(deps);
+    }
 
     // Keep each already-installed dep's opt/ symlink pointing at its Cellar.
     const heal_prefix = atomic.maltPrefix();
@@ -1083,15 +1149,13 @@ pub fn collectFormulaJobs(
         if (dep.already_installed) continue;
         const dep_json = dep_jsons[i] orelse continue;
 
-        var dep_formula = formula_mod.parseFormula(allocator, dep_json) catch {
-            allocator.free(dep_json);
-            continue;
-        };
-        const dep_bottle = formula_mod.resolveBottle(allocator, &dep_formula) catch {
-            dep_formula.deinit();
-            allocator.free(dep_json);
-            continue;
-        };
+        // dep_json is moved into the job on success; any continue path
+        // before that transfer must free the bytes.
+        var dep_json_consumed = false;
+        defer if (!dep_json_consumed) allocator.free(dep_json);
+
+        var dep_formula = formula_mod.parseFormula(parse_alloc, dep_json) catch continue;
+        const dep_bottle = formula_mod.resolveBottle(parse_alloc, &dep_formula) catch continue;
 
         // Check for duplicate (another top-level pkg may share a dep)
         var is_dup = false;
@@ -1101,51 +1165,58 @@ pub fn collectFormulaJobs(
                 break;
             }
         }
-        if (is_dup) {
-            dep_formula.deinit();
-            allocator.free(dep_json);
-            continue;
-        }
+        if (is_dup) continue;
+
+        // Dupe the five borrowed slices out of the parsed tree into
+        // the caller allocator so parse_arena can release the tree.
+        const strs = dupeJobStrings(allocator, &dep_formula, dep_bottle) catch continue;
 
         jobs.append(allocator, .{
-            .name = dep_formula.name,
+            .name = strs.name,
             // pkg_version folds in the `_N` revision suffix so cellar
             // paths match the bottle's baked-in LC_LOAD_DYLIB entries.
-            .version_str = dep_formula.pkg_version,
-            .sha256 = dep_bottle.sha256,
-            .bottle_url = dep_bottle.url,
+            .version_str = strs.version_str,
+            .sha256 = strs.sha256,
+            .bottle_url = strs.bottle_url,
             .is_dep = true,
             .keg_only = dep_formula.keg_only,
             .post_install_defined = dep_formula.post_install_defined,
             .formula_json = dep_json,
-            .cellar_type = dep_bottle.cellar,
+            .cellar_type = strs.cellar_type,
             .label_width = 0,
             .line_index = 0,
             .multi = null,
             .bar = null,
             .store_sha256 = "",
             .succeeded = false,
-        }) catch continue;
+        }) catch {
+            strs.freeAll(allocator);
+            continue;
+        };
+        dep_json_consumed = true;
     }
 
     // Add main formula
-    const bottle = formula_mod.resolveBottle(allocator, &formula) catch {
+    const bottle = formula_mod.resolveBottle(parse_alloc, &formula) catch {
         output.err("No bottle available for {s} on this platform", .{formula.name});
         return InstallError.NoBottle;
     };
 
+    const main_strs = dupeJobStrings(allocator, &formula, bottle) catch return InstallError.DownloadFailed;
+    errdefer main_strs.freeAll(allocator);
+
     jobs.append(allocator, .{
-        .name = formula.name,
+        .name = main_strs.name,
         // Same reason as the dep branch above: the cellar dir name
         // must carry the `_N` suffix when revision > 0.
-        .version_str = formula.pkg_version,
-        .sha256 = bottle.sha256,
-        .bottle_url = bottle.url,
+        .version_str = main_strs.version_str,
+        .sha256 = main_strs.sha256,
+        .bottle_url = main_strs.bottle_url,
         .is_dep = false,
         .keg_only = formula.keg_only,
         .post_install_defined = formula.post_install_defined,
         .formula_json = formula_json,
-        .cellar_type = bottle.cellar,
+        .cellar_type = main_strs.cellar_type,
         .label_width = 0,
         .line_index = 0,
         .multi = null,

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -684,3 +684,120 @@ test "collectFormulaJobs leaves plain-version formulas unchanged" {
     try testing.expectEqualStrings("1.0", jobs.items[0].version_str);
     try testing.expect(std.mem.indexOf(u8, jobs.items[0].version_str, "_") == null);
 }
+
+/// Three-dep fixture with unique per-dep sha so the dep-dedup path inside
+/// `collectFormulaJobs` cannot collapse the dependencies into a single job.
+fn formulaJsonWithThreeDeps(
+    comptime name: []const u8,
+    comptime a: []const u8,
+    comptime b: []const u8,
+    comptime c: []const u8,
+) []const u8 {
+    return "{\"name\":\"" ++ name ++ "\"," ++
+        "\"full_name\":\"" ++ name ++ "\"," ++
+        "\"tap\":\"homebrew/core\"," ++
+        "\"desc\":\"\",\"homepage\":\"\",\"revision\":0," ++
+        "\"keg_only\":false,\"post_install_defined\":false," ++
+        "\"versions\":{\"stable\":\"1.0\"}," ++
+        "\"dependencies\":[\"" ++ a ++ "\",\"" ++ b ++ "\",\"" ++ c ++ "\"]," ++
+        "\"oldnames\":[]," ++
+        "\"bottle\":{\"stable\":{\"root_url\":\"https://ghcr.io/v2/homebrew/core/" ++ name ++ "/blobs\"," ++
+        "\"files\":{" ++
+        "\"arm64_sequoia\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-arm\",\"sha256\":\"r0\"}," ++
+        "\"arm64_sonoma\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-arm\",\"sha256\":\"r0\"}," ++
+        "\"arm64_ventura\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-arm\",\"sha256\":\"r0\"}," ++
+        "\"arm64_monterey\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-arm\",\"sha256\":\"r0\"}," ++
+        "\"sequoia\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-x86\",\"sha256\":\"r1\"}," ++
+        "\"sonoma\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-x86\",\"sha256\":\"r1\"}," ++
+        "\"ventura\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-x86\",\"sha256\":\"r1\"}," ++
+        "\"monterey\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-x86\",\"sha256\":\"r1\"}" ++
+        "}}}}";
+}
+
+/// Dep fixture with a caller-supplied unique sha prefix so each dep's
+/// bottle is distinguishable from its siblings.
+fn bottleJsonUniqueSha(comptime name: []const u8, comptime tag: []const u8) []const u8 {
+    return "{\"name\":\"" ++ name ++ "\"," ++
+        "\"full_name\":\"" ++ name ++ "\"," ++
+        "\"tap\":\"homebrew/core\"," ++
+        "\"desc\":\"\",\"homepage\":\"\",\"revision\":0," ++
+        "\"keg_only\":false,\"post_install_defined\":false," ++
+        "\"versions\":{\"stable\":\"1.0\"}," ++
+        "\"dependencies\":[],\"oldnames\":[]," ++
+        "\"bottle\":{\"stable\":{\"root_url\":\"https://ghcr.io/v2/homebrew/core/" ++ name ++ "/blobs\"," ++
+        "\"files\":{" ++
+        "\"arm64_sequoia\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-arm\",\"sha256\":\"" ++ tag ++ "a\"}," ++
+        "\"arm64_sonoma\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-arm\",\"sha256\":\"" ++ tag ++ "a\"}," ++
+        "\"arm64_ventura\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-arm\",\"sha256\":\"" ++ tag ++ "a\"}," ++
+        "\"arm64_monterey\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-arm\",\"sha256\":\"" ++ tag ++ "a\"}," ++
+        "\"sequoia\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-x86\",\"sha256\":\"" ++ tag ++ "x\"}," ++
+        "\"sonoma\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-x86\",\"sha256\":\"" ++ tag ++ "x\"}," ++
+        "\"ventura\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-x86\",\"sha256\":\"" ++ tag ++ "x\"}," ++
+        "\"monterey\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-x86\",\"sha256\":\"" ++ tag ++ "x\"}" ++
+        "}}}}";
+}
+
+test "collectFormulaJobs leaves no parsed-tree leaks under testing.allocator (>=3 deps)" {
+    // BUG-009 regression guard: every per-dep std.json.Parsed (and the
+    // root's) used to stay pinned for the whole install run. Here we
+    // run the full 3-dep resolve path under testing.allocator and
+    // free only the strings the caller knows it owns — anything else
+    // that survives is a parsed-tree leak and trips the allocator.
+    const alloc = testing.allocator;
+
+    var tdb = try TempDb.init("parsed_tree_leak");
+    defer tdb.deinit();
+
+    const cache_dir = "/tmp/malt_install_test_parsed_tree_leak_cache";
+    malt.fs_compat.deleteTreeAbsolute(cache_dir) catch {};
+    malt.fs_compat.makeDirAbsolute(cache_dir) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(cache_dir) catch {};
+
+    try seedCache(cache_dir, "dep_a", bottleJsonUniqueSha("dep_a", "aa"));
+    try seedCache(cache_dir, "dep_b", bottleJsonUniqueSha("dep_b", "bb"));
+    try seedCache(cache_dir, "dep_c", bottleJsonUniqueSha("dep_c", "cc"));
+
+    const root_json = formulaJsonWithThreeDeps("root", "dep_a", "dep_b", "dep_c");
+    try seedCache(cache_dir, "root", root_json);
+
+    var http_pool = try malt.client.HttpClientPool.init(alloc, 2);
+    defer http_pool.deinit();
+    var real_http = malt.client.HttpClient.init(alloc);
+    defer real_http.deinit();
+    var api = malt.api.BrewApi.init(alloc, &real_http, cache_dir);
+
+    var store_inst: malt.store.Store = undefined;
+    var jobs: std.ArrayList(install.DownloadJob) = .empty;
+    defer {
+        // Caller-owned job strings: name/version/sha/url/cellar are duped
+        // into `alloc` so collectFormulaJobs can drop the parsed tree.
+        // `formula_json` is duped only for dep jobs; the main job borrows
+        // the caller-supplied input literal.
+        for (jobs.items) |job| {
+            alloc.free(job.name);
+            alloc.free(job.version_str);
+            alloc.free(job.sha256);
+            alloc.free(job.bottle_url);
+            alloc.free(job.cellar_type);
+            if (job.is_dep) alloc.free(job.formula_json);
+        }
+        jobs.deinit(alloc);
+    }
+
+    try install.collectFormulaJobs(
+        alloc,
+        "root",
+        root_json,
+        &api,
+        &http_pool,
+        &tdb.db,
+        &store_inst,
+        false,
+        &jobs,
+    );
+
+    // Three deps plus the root must all be queued (no dedup: every sha unique).
+    try testing.expectEqual(@as(usize, 4), jobs.items.len);
+    try testing.expectEqualStrings("root", jobs.items[3].name);
+    try testing.expect(!jobs.items[3].is_dep);
+}


### PR DESCRIPTION
## Description

Free each per-dep `std.json.Parsed` formula immediately after `collectFormulaJobs` copies the five strings it needs into the job. Prior code kept every parsed tree alive for the entire install run — ~500 KB on ffmpeg, worse on big toolchains. The root formula had the same shape of leak and is folded into the same fix by parking both parses on a single function-scoped `ArenaAllocator`.

## Related Issue

- None

## Notes for Reviewers

- None