### PR TITLE
fix(core): cleanup duped row strings on partial-dupe failure

### DIFF
--- a/src/core/services/supervisor.zig
+++ b/src/core/services/supervisor.zig
@@ -99,7 +99,11 @@ pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) SupervisorError!
     defer stmt.finalize();
 
     var buf: std.ArrayList(ServiceInfo) = .empty;
-    errdefer buf.deinit(allocator);
+    // ArrayList.deinit doesn't reach row sub-allocations; walk them too.
+    errdefer {
+        for (buf.items) |s| freeServiceInfoFields(allocator, s);
+        buf.deinit(allocator);
+    }
 
     while (stmt.step() catch return SupervisorError.DatabaseError) {
         const name_p = stmt.columnText(0) orelse continue;
@@ -107,26 +111,45 @@ pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) SupervisorError!
         const plist_p = stmt.columnText(2) orelse continue;
         const status_p = stmt.columnText(4);
 
-        const info: ServiceInfo = .{
-            .name = allocator.dupe(u8, std.mem.sliceTo(name_p, 0)) catch return SupervisorError.OutOfMemory,
-            .keg_name = allocator.dupe(u8, std.mem.sliceTo(keg_p, 0)) catch return SupervisorError.OutOfMemory,
-            .plist_path = allocator.dupe(u8, std.mem.sliceTo(plist_p, 0)) catch return SupervisorError.OutOfMemory,
+        // Build the row in locals so a later dupe failure can't strand an earlier one.
+        const name_owned = allocator.dupe(u8, std.mem.sliceTo(name_p, 0)) catch
+            return SupervisorError.OutOfMemory;
+        errdefer allocator.free(name_owned);
+        const keg_owned = allocator.dupe(u8, std.mem.sliceTo(keg_p, 0)) catch
+            return SupervisorError.OutOfMemory;
+        errdefer allocator.free(keg_owned);
+        const plist_owned = allocator.dupe(u8, std.mem.sliceTo(plist_p, 0)) catch
+            return SupervisorError.OutOfMemory;
+        errdefer allocator.free(plist_owned);
+        const status_owned = if (status_p) |p|
+            allocator.dupe(u8, std.mem.sliceTo(p, 0)) catch
+                return SupervisorError.OutOfMemory
+        else
+            allocator.dupe(u8, "unknown") catch
+                return SupervisorError.OutOfMemory;
+        errdefer allocator.free(status_owned);
+
+        buf.append(allocator, .{
+            .name = name_owned,
+            .keg_name = keg_owned,
+            .plist_path = plist_owned,
             .auto_start = stmt.columnBool(3),
-            .last_status = if (status_p) |p| allocator.dupe(u8, std.mem.sliceTo(p, 0)) catch return SupervisorError.OutOfMemory else allocator.dupe(u8, "unknown") catch return SupervisorError.OutOfMemory,
-        };
-        buf.append(allocator, info) catch return SupervisorError.OutOfMemory;
+            .last_status = status_owned,
+        }) catch return SupervisorError.OutOfMemory;
     }
 
     return buf.toOwnedSlice(allocator) catch return SupervisorError.OutOfMemory;
 }
 
+fn freeServiceInfoFields(allocator: std.mem.Allocator, info: ServiceInfo) void {
+    allocator.free(info.name);
+    allocator.free(info.keg_name);
+    allocator.free(info.plist_path);
+    allocator.free(info.last_status);
+}
+
 pub fn freeServiceInfos(allocator: std.mem.Allocator, services: []ServiceInfo) void {
-    for (services) |s| {
-        allocator.free(s.name);
-        allocator.free(s.keg_name);
-        allocator.free(s.plist_path);
-        allocator.free(s.last_status);
-    }
+    for (services) |s| freeServiceInfoFields(allocator, s);
     allocator.free(services);
 }
 

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -80,7 +80,11 @@ pub fn getCommitSha(
 
 pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) ![]TapInfo {
     var taps: std.ArrayList(TapInfo) = .empty;
-    errdefer taps.deinit(allocator);
+    // ArrayList.deinit doesn't reach row sub-allocations; walk them too.
+    errdefer {
+        for (taps.items) |t| freeTapInfoFields(allocator, t);
+        taps.deinit(allocator);
+    }
 
     var stmt = try db.prepare("SELECT name, url, commit_sha FROM taps;");
     defer stmt.finalize();
@@ -88,13 +92,19 @@ pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) ![]TapInfo {
     while (try stmt.step()) {
         const n = stmt.columnText(0) orelse continue;
         const u = stmt.columnText(1) orelse continue;
+
+        // Build the row in locals so a later dupe failure can't strand an earlier one.
         const name_owned = try allocator.dupe(u8, std.mem.sliceTo(n, 0));
+        errdefer allocator.free(name_owned);
         const url_owned = try allocator.dupe(u8, std.mem.sliceTo(u, 0));
-        const sha_owned = if (stmt.columnText(2)) |s| blk: {
+        errdefer allocator.free(url_owned);
+        const sha_owned: ?[]const u8 = if (stmt.columnText(2)) |s| blk: {
             const trimmed = std.mem.sliceTo(s, 0);
             if (trimmed.len == 0) break :blk null;
             break :blk try allocator.dupe(u8, trimmed);
         } else null;
+        errdefer if (sha_owned) |sha| allocator.free(sha);
+
         try taps.append(allocator, .{
             .name = name_owned,
             .url = url_owned,
@@ -103,6 +113,12 @@ pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) ![]TapInfo {
     }
 
     return taps.toOwnedSlice(allocator);
+}
+
+fn freeTapInfoFields(allocator: std.mem.Allocator, info: TapInfo) void {
+    allocator.free(info.name);
+    allocator.free(info.url);
+    if (info.commit_sha) |sha| allocator.free(sha);
 }
 
 /// Resolve a tap formula — builds the full tap formula name.

--- a/tests/services_test.zig
+++ b/tests/services_test.zig
@@ -61,6 +61,30 @@ test "raw services row insert is reflected by list and hasService" {
     try testing.expect(items[0].auto_start);
 }
 
+fn listAndFree(alloc: std.mem.Allocator, db: *sqlite.Database) !void {
+    const items = try supervisor.list(alloc, db);
+    supervisor.freeServiceInfos(alloc, items);
+}
+
+test "list: partial-dupe failure on any allocation leaves zero leaks" {
+    // BUG-010 regression guard: earlier row dupes used to leak when a later
+    // dupe or append failed, and already-populated rows were never walked.
+    var t = try TempDb.init("partial_dupe");
+    defer t.deinit();
+
+    // Two rows so the errdefer has to walk both completed and partial state.
+    try t.db.exec(
+        \\INSERT INTO services(name, keg_name, plist_path, auto_start, last_status)
+        \\VALUES ('alpha', 'alpha-keg', '/tmp/a.plist', 1, 'registered');
+    );
+    try t.db.exec(
+        \\INSERT INTO services(name, keg_name, plist_path, auto_start, last_status)
+        \\VALUES ('beta', 'beta-keg', '/tmp/b.plist', 0, 'stopped');
+    );
+
+    try testing.checkAllAllocationFailures(testing.allocator, listAndFree, .{&t.db});
+}
+
 test "tailLog returns last N lines of a small file" {
     var t = try TempDb.init("tail");
     defer t.deinit();

--- a/tests/tap_test.zig
+++ b/tests/tap_test.zig
@@ -208,6 +208,30 @@ test "remove deletes a tap" {
     try testing.expectEqualStrings("c/d", taps[0].name);
 }
 
+fn listAndFree(alloc: std.mem.Allocator, db: *sqlite.Database) !void {
+    const taps = try tap.list(alloc, db);
+    for (taps) |t| {
+        alloc.free(t.name);
+        alloc.free(t.url);
+        if (t.commit_sha) |sha| alloc.free(sha);
+    }
+    alloc.free(taps);
+}
+
+test "list: partial-dupe failure on any allocation leaves zero leaks" {
+    // BUG-011 regression guard: per-row dupes used to leak when a later
+    // dupe or append failed, and completed rows were never walked.
+    // Mix a pinned row with an unpinned one to exercise the optional-SHA branch.
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "alpha/one", "https://github.com/alpha/one", valid_sha);
+    try tap.add(&db, "beta/two", "https://github.com/beta/two", null);
+
+    try testing.checkAllAllocationFailures(testing.allocator, listAndFree, .{&db});
+}
+
 test "resolveFormula joins user/repo/formula with slashes" {
     const s = try tap.resolveFormula(testing.allocator, "u", "r", "f");
     defer testing.allocator.free(s);


### PR DESCRIPTION
## Description
Fix partial-dupe leaks in `supervisor.list()` and `tap.list()`. Earlier per-row string dupes leaked when a later dupe failed, and the outer `errdefer` only released the accumulator array. Now rows build into locals with nested errdefers, append only after full population, and an outer walker frees any rows already in the list on error.

## Related Issue

- None

## Notes for Reviewers

- None