### PR TITLE
fix(cli/version_update): errdefer path in writeDownload

### DIFF
--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -148,7 +148,9 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // --- download tarball + checksums (always needed for SHA verify) ---
     output.info("Downloading {s}...", .{archive_name});
     const tarball_path = try writeDownload(allocator, &http, tarball_url, scratch, archive_name);
+    defer allocator.free(tarball_path);
     const checksums_path = try writeDownload(allocator, &http, checksums_url, scratch, CHECKSUMS_NAME);
+    defer allocator.free(checksums_path);
 
     // --- verification phase ---
     try runVerification(.{
@@ -230,6 +232,7 @@ fn buildScratchDir(buf: []u8) ![]const u8 {
 }
 
 /// Download `url` into `dir/name`, return the absolute path.
+/// Caller owns the returned slice.
 fn writeDownload(
     allocator: std.mem.Allocator,
     http: *client_mod.HttpClient,
@@ -246,14 +249,26 @@ fn writeDownload(
         output.err("Download returned status {d} for {s}", .{ resp.status, url });
         return error.Aborted;
     }
+    return writeResponseBody(allocator, dir, name, resp.body);
+}
 
+/// Write `body` to `dir/name`, return the caller-owned absolute path.
+/// Split from `writeDownload` so the file-write half is reachable under
+/// `testing.allocator` without a live HTTP client (BUG-012 regression guard).
+pub fn writeResponseBody(
+    allocator: std.mem.Allocator,
+    dir: []const u8,
+    name: []const u8,
+    body: []const u8,
+) ![]const u8 {
     const path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir, name });
+    errdefer allocator.free(path);
     const f = fs_compat.createFileAbsolute(path, .{}) catch {
         output.err("Cannot create {s}", .{path});
         return error.Aborted;
     };
     defer f.close();
-    f.writeAll(resp.body) catch {
+    f.writeAll(body) catch {
         output.err("Failed to write {s}", .{path});
         return error.Aborted;
     };
@@ -286,6 +301,7 @@ fn runVerification(rv: RunVerification) !void {
         return error.Aborted;
     };
     const sigstore_path = try writeDownload(rv.allocator, rv.http, sigstore_url, rv.scratch, SIGSTORE_NAME);
+    defer rv.allocator.free(sigstore_path);
 
     output.info("Verifying cosign signature + SHA256 checksum...", .{});
     verify.verifyAll(rv.allocator, .{

--- a/tests/version_update_test.zig
+++ b/tests/version_update_test.zig
@@ -9,6 +9,9 @@ const testing = std.testing;
 const malt = @import("malt");
 const version_mod = malt.version;
 const updater = malt.cli_version_update;
+const output_mod = malt.output;
+const fs_compat = malt.fs_compat;
+const io_mod = malt.io_mod;
 
 test "version value is non-empty and trimmed" {
     try testing.expect(version_mod.value.len > 0);
@@ -52,4 +55,53 @@ test "parseArgs: unrecognised flags are ignored (do not crash)" {
     const opts = updater.parseArgs(&.{ "--check", "--nonsense", "--yes" });
     try testing.expect(opts.check);
     try testing.expect(opts.yes);
+}
+
+// --- writeResponseBody ---------------------------------------------------
+//
+// BUG-012 regression guard: the old `writeDownload` allocated `path` and
+// returned early on `createFileAbsolute` / `writeAll` errors without freeing
+// it. Exercising the helper under `testing.allocator` proves the ownership
+// contract — happy path returns an owned slice, failure path leaves zero
+// allocations behind.
+
+fn tmpDirAbsolute(tmp: *std.testing.TmpDir, buf: []u8) ![]const u8 {
+    const n = try std.Io.Dir.realPath(tmp.dir, io_mod.ctx(), buf);
+    return buf[0..n];
+}
+
+test "writeResponseBody: writes body and returns caller-owned path" {
+    output_mod.setQuiet(true);
+    defer output_mod.setQuiet(false);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [fs_compat.max_path_bytes]u8 = undefined;
+    const dir_abs = try tmpDirAbsolute(&tmp, &buf);
+
+    const path = try updater.writeResponseBody(testing.allocator, dir_abs, "payload.bin", "hello-T011");
+    defer testing.allocator.free(path);
+
+    const expected_suffix = "/payload.bin";
+    try testing.expect(std.mem.endsWith(u8, path, expected_suffix));
+
+    const contents = try fs_compat.readFileAbsoluteAlloc(testing.allocator, path, 1024);
+    defer testing.allocator.free(contents);
+    try testing.expectEqualStrings("hello-T011", contents);
+}
+
+test "writeResponseBody: createFileAbsolute failure leaves zero leaked allocations" {
+    // testing.allocator leak-detects; without `errdefer` on the allocPrint
+    // the freshly-allocated `path` would escape unfreed here.
+    output_mod.setQuiet(true);
+    defer output_mod.setQuiet(false);
+
+    const result = updater.writeResponseBody(
+        testing.allocator,
+        "/nonexistent/malt-T011-guardrail",
+        "payload.bin",
+        "x",
+    );
+    try testing.expectError(error.Aborted, result);
 }


### PR DESCRIPTION
## Description

Add `errdefer` for the `path` allocation in `writeDownload` and free the three download paths in `execute` / `runVerification`. The file-write half is split into `writeResponseBody` so it can be exercised under `testing.allocator` without a live HTTP client. Previously the paths lived until process exit, which hid the leak for the CLI but would bite any future in-process embedding of the updater.

## Related Issue

-None

## Notes for Reviewers

- None