### PR TITLE
refactor: replace "catch {}" with try or PartialFailure

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -176,6 +176,7 @@ pub fn build(b: *std.Build) void {
         "tests/output_test.zig",
         "tests/worker_arena_test.zig",
         "tests/migrate_smoke_test.zig",
+        "tests/upgrade_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -656,20 +656,25 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         // token round-trips into 1. `prefetchTokens` is best-effort;
         // on any error we leave the cache empty and workers fall back
         // to per-repo fetches (the old behaviour, one round-trip each).
+        // OOM during prefetch bookkeeping must not be swallowed: subsequent
+        // install phases depend on allocator integrity. Token prefetch itself
+        // stays best-effort — a cache miss falls back to per-worker fetches.
         var repo_set: std.StringHashMapUnmanaged(void) = .empty;
         defer repo_set.deinit(allocator);
         for (all_jobs.items) |*job| {
             if (job.succeeded) continue;
             const ref = parseGhcrUrl(job.bottle_url) orelse continue;
-            repo_set.put(allocator, ref.repo, {}) catch {};
+            try repo_set.put(allocator, ref.repo, {});
         }
         if (repo_set.count() > 0) {
             var repos: std.ArrayList([]const u8) = .empty;
             defer repos.deinit(allocator);
-            repos.ensureTotalCapacity(allocator, repo_set.count()) catch {};
+            try repos.ensureTotalCapacity(allocator, repo_set.count());
             var it = repo_set.keyIterator();
-            while (it.next()) |k| repos.append(allocator, k.*) catch {};
+            while (it.next()) |k| try repos.append(allocator, k.*);
             const pre_http = http_pool.acquire();
+            // Best-effort cache warm — any failure (OOM or network) is
+            // absorbed so workers fall back to per-repo fetchToken calls.
             ghcr.prefetchTokens(pre_http, repos.items) catch {};
             http_pool.release(pre_http);
         }
@@ -812,9 +817,12 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             break;
         }
 
+        // OOM on failed-keg bookkeeping must not be swallowed: the subsequent
+        // findFailedDep check relies on this map, and a silent drop would
+        // let dependents install on top of a broken graph.
         if (!job.succeeded) {
             output.err("Download failed for {s}, skipping", .{job.name});
-            failed_kegs.put(job.name, {}) catch {};
+            try failed_kegs.put(job.name, {});
             failed_count += 1;
             continue;
         }
@@ -825,7 +833,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
                 "Failed to materialize {s}: {s} ({s})",
                 .{ job.name, @errorName(err), cellar_mod.describeError(err) },
             );
-            failed_kegs.put(job.name, {}) catch {};
+            try failed_kegs.put(job.name, {});
             failed_count += 1;
             continue;
         }
@@ -840,7 +848,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
                 .{ job.name, failed_dep },
             );
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
-            failed_kegs.put(job.name, {}) catch {};
+            try failed_kegs.put(job.name, {});
             failed_count += 1;
             continue;
         }
@@ -849,7 +857,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             // The underlying error was already logged with a tag by
             // linkAndRecord — just record that this job failed so its
             // dependents in the rest of the loop get skipped above.
-            failed_kegs.put(job.name, {}) catch {};
+            try failed_kegs.put(job.name, {});
             failed_count += 1;
             continue;
         };

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -242,12 +242,15 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             use_system_ruby_scope.items,
         );
 
+        // OOM on per-category bookkeeping must not be swallowed: the summary
+        // counts and JSON arrays come from these lists, and a silent drop
+        // reports fewer failures than actually occurred.
         switch (result) {
-            .migrated => migrated_names.append(allocator, keg_name) catch {},
-            .skipped_installed => skipped_installed_names.append(allocator, keg_name) catch {},
-            .skipped_post_install => skipped_post_install_names.append(allocator, keg_name) catch {},
-            .skipped_no_bottle => skipped_no_bottle_names.append(allocator, keg_name) catch {},
-            .failed_api, .failed_download, .failed_install => failed_names.append(allocator, keg_name) catch {},
+            .migrated => try migrated_names.append(allocator, keg_name),
+            .skipped_installed => try skipped_installed_names.append(allocator, keg_name),
+            .skipped_post_install => try skipped_post_install_names.append(allocator, keg_name),
+            .skipped_no_bottle => try skipped_no_bottle_names.append(allocator, keg_name),
+            .failed_api, .failed_download, .failed_install => try failed_names.append(allocator, keg_name),
         }
     }
 

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -73,25 +73,41 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     const cache_dir = std.fmt.bufPrint(&cache_dir_buf, "{s}/cache", .{prefix}) catch return;
     var api = api_mod.BrewApi.init(allocator, &http, cache_dir);
 
+    // Per-package errors must not be swallowed: a batch that fails every
+    // item used to exit 0, hiding the failure from CI. We aggregate here
+    // and surface error.Aborted so main.zig maps it to a non-zero exit.
+    var any_failed = false;
+
     if (pkg_name) |name| {
         // Upgrade a specific package — try formula first, then cask
         if (!cask_only) {
             if (isFormulaInstalled(&db, name)) {
-                upgradeFormula(allocator, name, &db, &api, &http, prefix, dry_run) catch {};
+                upgradeFormula(allocator, name, &db, &api, &http, prefix, dry_run) catch {
+                    any_failed = true;
+                };
+                if (any_failed) return error.Aborted;
                 return;
             }
         }
         // Not a formula (or --cask): try cask
-        upgradeCask(allocator, name, &db, &api, prefix, dry_run) catch {};
+        upgradeCask(allocator, name, &db, &api, prefix, dry_run) catch {
+            any_failed = true;
+        };
     } else {
         // Upgrade all
         if (!cask_only) {
-            upgradeAllFormulas(allocator, &db, &api, &http, prefix, dry_run);
+            upgradeAllFormulas(allocator, &db, &api, &http, prefix, dry_run) catch {
+                any_failed = true;
+            };
         }
         if (!formula_only) {
-            upgradeAllCasks(allocator, &db, &api, prefix, dry_run);
+            upgradeAllCasks(allocator, &db, &api, prefix, dry_run) catch {
+                any_failed = true;
+            };
         }
     }
+
+    if (any_failed) return error.Aborted;
 }
 
 // ---------------------------------------------------------------------------
@@ -371,7 +387,8 @@ fn isFormulaInstalled(db: *sqlite.Database, name: []const u8) bool {
     return stmt.step() catch false;
 }
 
-/// Upgrade all outdated formulas.
+/// Upgrade all outdated formulas. Returns error.Aborted if any individual
+/// upgrade failed so the caller can propagate a non-zero exit.
 fn upgradeAllFormulas(
     allocator: std.mem.Allocator,
     db: *sqlite.Database,
@@ -379,7 +396,7 @@ fn upgradeAllFormulas(
     http: *client_mod.HttpClient,
     prefix: [:0]const u8,
     dry_run: bool,
-) void {
+) !void {
     var stmt = db.prepare("SELECT name, version FROM kegs ORDER BY name;") catch return;
     defer stmt.finalize();
 
@@ -405,8 +422,24 @@ fn upgradeAllFormulas(
         return;
     }
 
+    // Count separately from the name list so an OOM on the names append
+    // cannot hide a failure from the summary/exit-code contract.
+    var failed_count: usize = 0;
+    var failed_names: std.ArrayList([]const u8) = .empty;
+    defer failed_names.deinit(allocator);
+
     for (names.items) |name| {
-        upgradeFormula(allocator, name, db, api, http, prefix, dry_run) catch {};
+        upgradeFormula(allocator, name, db, api, http, prefix, dry_run) catch {
+            failed_count += 1;
+            failed_names.append(allocator, name) catch {};
+        };
+    }
+
+    if (failed_count > 0) {
+        const word: []const u8 = if (failed_count == 1) "formula" else "formulas";
+        output.err("{d} {s} failed to upgrade:", .{ failed_count, word });
+        for (failed_names.items) |name| output.err("  - {s}", .{name});
+        return error.Aborted;
     }
 }
 
@@ -467,20 +500,48 @@ fn upgradeCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Data
     output.success("{s} upgraded to {s}", .{ token, parsed_cask.version });
 }
 
-fn upgradeAllCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api_mod.BrewApi, prefix: [:0]const u8, dry_run: bool) void {
+fn upgradeAllCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api_mod.BrewApi, prefix: [:0]const u8, dry_run: bool) !void {
     var stmt = db.prepare("SELECT token, version FROM casks ORDER BY token;") catch return;
     defer stmt.finalize();
 
-    var upgraded: u32 = 0;
-    while (stmt.step() catch false) {
-        const token_ptr = stmt.columnText(0) orelse continue;
-        const token = std.mem.sliceTo(token_ptr, 0);
-
-        upgradeCask(allocator, token, db, api, prefix, dry_run) catch {};
-        upgraded += 1;
+    // Collect tokens first so we can free the statement before driving
+    // per-cask upgrades; each upgrade opens its own statements.
+    var tokens: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (tokens.items) |t| allocator.free(t);
+        tokens.deinit(allocator);
     }
 
-    if (upgraded == 0) {
+    while (stmt.step() catch false) {
+        const token_ptr = stmt.columnText(0) orelse continue;
+        const token_slice = std.mem.sliceTo(token_ptr, 0);
+        const owned = allocator.dupe(u8, token_slice) catch continue;
+        tokens.append(allocator, owned) catch {
+            allocator.free(owned);
+            continue;
+        };
+    }
+
+    if (tokens.items.len == 0) {
         output.info("All casks are up to date.", .{});
+        return;
+    }
+
+    var failed_count: usize = 0;
+    var failed_tokens: std.ArrayList([]const u8) = .empty;
+    defer failed_tokens.deinit(allocator);
+
+    for (tokens.items) |token| {
+        upgradeCask(allocator, token, db, api, prefix, dry_run) catch {
+            failed_count += 1;
+            failed_tokens.append(allocator, token) catch {};
+        };
+    }
+
+    if (failed_count > 0) {
+        const word: []const u8 = if (failed_count == 1) "cask" else "casks";
+        output.err("{d} {s} failed to upgrade:", .{ failed_count, word });
+        for (failed_tokens.items) |token| output.err("  - {s}", .{token});
+        return error.Aborted;
     }
 }

--- a/src/core/dsl/interpreter.zig
+++ b/src/core/dsl/interpreter.zig
@@ -123,7 +123,7 @@ pub const ExecContext = struct {
         formula: *const Formula,
         malt_prefix: []const u8,
         flog: *FallbackLog,
-    ) ExecContext {
+    ) DslError!ExecContext {
         const cellar_path = std.fmt.allocPrint(arena, "{s}/Cellar/{s}/{s}", .{
             malt_prefix, formula.name, formula.version,
         }) catch malt_prefix;
@@ -158,8 +158,8 @@ pub const ExecContext = struct {
             .return_value = Value{ .nil = {} },
         };
 
-        // Push initial scope
-        ctx.pushScope();
+        // OOM here would leave callers with a zero-depth stack; surface it.
+        try ctx.pushScope();
         return ctx;
     }
 
@@ -186,15 +186,18 @@ pub const ExecContext = struct {
         return null;
     }
 
-    pub fn pushScope(self: *ExecContext) void {
-        self.scopes.append(self.arena, Scope.init(self.arena)) catch {};
+    // OOM on a scope push must not be swallowed: a silent drop leaves the
+    // matching popScope tearing down the caller's scope, so outer locals
+    // vanish and subsequent lookups return stale/nil under memory pressure.
+    pub fn pushScope(self: *ExecContext) DslError!void {
+        self.scopes.append(self.arena, Scope.init(self.arena)) catch return DslError.OutOfMemory;
     }
 
-    pub fn pushMethodScope(self: *ExecContext) void {
+    pub fn pushMethodScope(self: *ExecContext) DslError!void {
         self.scopes.append(self.arena, .{
             .locals = std.StringHashMap(Value).init(self.arena),
             .is_method_frame = true,
-        }) catch {};
+        }) catch return DslError.OutOfMemory;
     }
 
     pub fn popScope(self: *ExecContext) void {
@@ -202,10 +205,9 @@ pub const ExecContext = struct {
         _ = self.scopes.pop();
     }
 
-    pub fn setLocal(self: *ExecContext, name: []const u8, value: Value) void {
-        if (self.scopes.items.len > 0) {
-            self.scopes.items[self.scopes.items.len - 1].locals.put(name, value) catch {};
-        }
+    pub fn setLocal(self: *ExecContext, name: []const u8, value: Value) DslError!void {
+        if (self.scopes.items.len == 0) return;
+        self.scopes.items[self.scopes.items.len - 1].locals.put(name, value) catch return DslError.OutOfMemory;
     }
 };
 
@@ -304,12 +306,12 @@ pub const Interpreter = struct {
         md: ast.MethodDef,
         args: []const Value,
     ) DslError!Value {
-        self.ctx.pushMethodScope();
+        try self.ctx.pushMethodScope();
         defer self.ctx.popScope();
 
         for (md.params, 0..) |pname, i| {
             const v = if (i < args.len) args[i] else Value{ .nil = {} };
-            self.ctx.setLocal(pname, v);
+            try self.ctx.setLocal(pname, v);
         }
 
         // Ruby implicit-return: the last expression's value is the method's
@@ -380,7 +382,7 @@ pub const Interpreter = struct {
 
     fn evalAssignment(self: *Interpreter, a: *const ast.Assignment) DslError!Value {
         const val = try self.eval(a.value);
-        self.ctx.setLocal(a.name, val);
+        try self.ctx.setLocal(a.name, val);
         return val;
     }
 
@@ -664,22 +666,22 @@ pub const Interpreter = struct {
         const iterable = try self.eval(el.iterable);
         switch (iterable) {
             .array => |items| for (items) |item| {
-                self.ctx.pushScope();
+                try self.ctx.pushScope();
                 defer self.ctx.popScope();
-                if (el.params.len > 0) self.ctx.setLocal(el.params[0], item);
+                if (el.params.len > 0) try self.ctx.setLocal(el.params[0], item);
                 _ = self.evalBlockSlice(el.body) catch |e| switch (e) {
-                    DslError.PostInstallFailed, DslError.PathSandboxViolation, DslError.ReturnSignal => return e,
+                    DslError.PostInstallFailed, DslError.PathSandboxViolation, DslError.ReturnSignal, DslError.OutOfMemory => return e,
                     else => continue,
                 };
             },
             .hash => |pairs| for (pairs) |pair| {
                 // Hash iteration yields (key, value) — matches Ruby's
                 // `hash.each do |k, v|` and the llvm@21 post_install shape.
-                self.ctx.pushScope();
+                try self.ctx.pushScope();
                 defer self.ctx.popScope();
-                self.bindHashPair(el.params, pair);
+                try self.bindHashPair(el.params, pair);
                 _ = self.evalBlockSlice(el.body) catch |e| switch (e) {
-                    DslError.PostInstallFailed, DslError.PathSandboxViolation, DslError.ReturnSignal => return e,
+                    DslError.PostInstallFailed, DslError.PathSandboxViolation, DslError.ReturnSignal, DslError.OutOfMemory => return e,
                     else => continue,
                 };
             },
@@ -717,9 +719,9 @@ pub const Interpreter = struct {
     fn evalArraySelect(self: *Interpreter, items: []const Value, params: []const []const u8, blk: *const Node) DslError!Value {
         var result: std.ArrayList(Value) = .empty;
         for (items) |item| {
-            self.ctx.pushScope();
+            try self.ctx.pushScope();
             defer self.ctx.popScope();
-            if (params.len > 0) self.ctx.setLocal(params[0], item);
+            if (params.len > 0) try self.ctx.setLocal(params[0], item);
             const val = try self.eval(blk);
             if (val.isTruthy()) {
                 result.append(self.allocator, item) catch return DslError.OutOfMemory;
@@ -732,9 +734,9 @@ pub const Interpreter = struct {
     fn evalArrayMap(self: *Interpreter, items: []const Value, params: []const []const u8, blk: *const Node) DslError!Value {
         var result: std.ArrayList(Value) = .empty;
         for (items) |item| {
-            self.ctx.pushScope();
+            try self.ctx.pushScope();
             defer self.ctx.popScope();
-            if (params.len > 0) self.ctx.setLocal(params[0], item);
+            if (params.len > 0) try self.ctx.setLocal(params[0], item);
             const val = try self.eval(blk);
             result.append(self.allocator, val) catch return DslError.OutOfMemory;
         }
@@ -745,9 +747,9 @@ pub const Interpreter = struct {
     fn evalArrayReject(self: *Interpreter, items: []const Value, params: []const []const u8, blk: *const Node) DslError!Value {
         var result: std.ArrayList(Value) = .empty;
         for (items) |item| {
-            self.ctx.pushScope();
+            try self.ctx.pushScope();
             defer self.ctx.popScope();
-            if (params.len > 0) self.ctx.setLocal(params[0], item);
+            if (params.len > 0) try self.ctx.setLocal(params[0], item);
             const val = try self.eval(blk);
             if (!val.isTruthy()) {
                 result.append(self.allocator, item) catch return DslError.OutOfMemory;
@@ -759,11 +761,11 @@ pub const Interpreter = struct {
 
     fn evalArrayEach(self: *Interpreter, items: []const Value, params: []const []const u8, blk: *const Node) DslError!Value {
         for (items) |item| {
-            self.ctx.pushScope();
+            try self.ctx.pushScope();
             defer self.ctx.popScope();
-            if (params.len > 0) self.ctx.setLocal(params[0], item);
+            if (params.len > 0) try self.ctx.setLocal(params[0], item);
             _ = self.eval(blk) catch |e| switch (e) {
-                DslError.PostInstallFailed, DslError.PathSandboxViolation, DslError.ReturnSignal => return e,
+                DslError.PostInstallFailed, DslError.PathSandboxViolation, DslError.ReturnSignal, DslError.OutOfMemory => return e,
                 else => continue,
             };
         }
@@ -774,26 +776,26 @@ pub const Interpreter = struct {
     /// positional params → classic `|k, v|`; one param → the pair is
     /// bound to it (same shape as Ruby's `|kv|` destructuring). Zero
     /// params is legal but useless — nothing to reference.
-    fn bindHashPair(self: *Interpreter, params: []const []const u8, pair: Value.HashPair) void {
+    fn bindHashPair(self: *Interpreter, params: []const []const u8, pair: Value.HashPair) DslError!void {
         if (params.len == 0) return;
         if (params.len == 1) {
-            const arr = self.allocator.alloc(Value, 2) catch return;
+            const arr = self.allocator.alloc(Value, 2) catch return DslError.OutOfMemory;
             arr[0] = pair.key;
             arr[1] = pair.value;
-            self.ctx.setLocal(params[0], Value{ .array = arr });
+            try self.ctx.setLocal(params[0], Value{ .array = arr });
             return;
         }
-        self.ctx.setLocal(params[0], pair.key);
-        self.ctx.setLocal(params[1], pair.value);
+        try self.ctx.setLocal(params[0], pair.key);
+        try self.ctx.setLocal(params[1], pair.value);
     }
 
     fn evalHashEach(self: *Interpreter, pairs: []const Value.HashPair, params: []const []const u8, blk: *const Node) DslError!Value {
         for (pairs) |pair| {
-            self.ctx.pushScope();
+            try self.ctx.pushScope();
             defer self.ctx.popScope();
-            self.bindHashPair(params, pair);
+            try self.bindHashPair(params, pair);
             _ = self.eval(blk) catch |e| switch (e) {
-                DslError.PostInstallFailed, DslError.PathSandboxViolation, DslError.ReturnSignal => return e,
+                DslError.PostInstallFailed, DslError.PathSandboxViolation, DslError.ReturnSignal, DslError.OutOfMemory => return e,
                 else => continue,
             };
         }
@@ -803,9 +805,9 @@ pub const Interpreter = struct {
     fn evalHashMap(self: *Interpreter, pairs: []const Value.HashPair, params: []const []const u8, blk: *const Node) DslError!Value {
         var out: std.ArrayList(Value) = .empty;
         for (pairs) |pair| {
-            self.ctx.pushScope();
+            try self.ctx.pushScope();
             defer self.ctx.popScope();
-            self.bindHashPair(params, pair);
+            try self.bindHashPair(params, pair);
             const v = try self.eval(blk);
             out.append(self.allocator, v) catch return DslError.OutOfMemory;
         }
@@ -816,9 +818,9 @@ pub const Interpreter = struct {
     fn evalHashSelect(self: *Interpreter, pairs: []const Value.HashPair, params: []const []const u8, blk: *const Node) DslError!Value {
         var out: std.ArrayList(Value.HashPair) = .empty;
         for (pairs) |pair| {
-            self.ctx.pushScope();
+            try self.ctx.pushScope();
             defer self.ctx.popScope();
-            self.bindHashPair(params, pair);
+            try self.bindHashPair(params, pair);
             const v = try self.eval(blk);
             if (v.isTruthy()) out.append(self.allocator, pair) catch return DslError.OutOfMemory;
         }
@@ -829,9 +831,9 @@ pub const Interpreter = struct {
     fn evalHashReject(self: *Interpreter, pairs: []const Value.HashPair, params: []const []const u8, blk: *const Node) DslError!Value {
         var out: std.ArrayList(Value.HashPair) = .empty;
         for (pairs) |pair| {
-            self.ctx.pushScope();
+            try self.ctx.pushScope();
             defer self.ctx.popScope();
-            self.bindHashPair(params, pair);
+            try self.bindHashPair(params, pair);
             const v = try self.eval(blk);
             if (!v.isTruthy()) out.append(self.allocator, pair) catch return DslError.OutOfMemory;
         }
@@ -1058,7 +1060,7 @@ pub fn executePostInstall(
         return e;
     };
 
-    var ctx = ExecContext.init(a, formula, malt_prefix, flog);
+    var ctx = try ExecContext.init(a, formula, malt_prefix, flog);
     defer ctx.deinit();
     var interp = Interpreter.init(&ctx);
     try interp.execute(nodes);

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -28,6 +28,7 @@ pub const completions = @import("cli/completions.zig");
 pub const backup = @import("cli/backup.zig");
 pub const purge = @import("cli/purge.zig");
 pub const install = @import("cli/install.zig");
+pub const upgrade = @import("cli/upgrade.zig");
 pub const doctor = @import("cli/doctor.zig");
 pub const dsl = @import("core/dsl/root.zig");
 pub const bundle_manifest = @import("core/bundle/manifest.zig");

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -2463,3 +2463,56 @@ test "interpreter: arena-owned path bindings leak-clean under testing.allocator"
     ;
     try dsl.executePostInstall(testing.allocator, &f, src, prefix, &flog);
 }
+
+// pushScope must propagate OOM instead of swallowing it. A silent failure
+// leaves the stack desynced: the next popScope tears down the caller's
+// scope, so outer locals disappear under memory pressure.
+test "ExecContext.pushScope propagates OOM from the arena" {
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+
+    var methods = std.StringHashMap(malt.dsl.ast.MethodDef).init(testing.allocator);
+    defer methods.deinit();
+
+    var ctx: dsl.ExecContext = .{
+        .arena = failing.allocator(),
+        .cellar_path = "",
+        .malt_prefix = "",
+        .paths = std.EnumArray(malt.dsl.interpreter.PathBinding, []const u8).initFill(""),
+        .scopes = .empty,
+        .sandbox_root = "",
+        .fallback_log_writer = &flog,
+        .formula_name = "test",
+        .methods = methods,
+        .return_value = .{ .nil = {} },
+    };
+
+    try testing.expectError(error.OutOfMemory, ctx.pushScope());
+    try testing.expectEqual(@as(usize, 0), ctx.scopes.items.len);
+}
+
+test "ExecContext.pushMethodScope propagates OOM from the arena" {
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+
+    var methods = std.StringHashMap(malt.dsl.ast.MethodDef).init(testing.allocator);
+    defer methods.deinit();
+
+    var ctx: dsl.ExecContext = .{
+        .arena = failing.allocator(),
+        .cellar_path = "",
+        .malt_prefix = "",
+        .paths = std.EnumArray(malt.dsl.interpreter.PathBinding, []const u8).initFill(""),
+        .scopes = .empty,
+        .sandbox_root = "",
+        .fallback_log_writer = &flog,
+        .formula_name = "test",
+        .methods = methods,
+        .return_value = .{ .nil = {} },
+    };
+
+    try testing.expectError(error.OutOfMemory, ctx.pushMethodScope());
+    try testing.expectEqual(@as(usize, 0), ctx.scopes.items.len);
+}

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -1,0 +1,46 @@
+//! malt — upgrade.execute behaviour tests
+//! Locks in the exit-code contract: an upgrade that touches a package we
+//! cannot upgrade (not installed, or batch item failure) must surface a
+//! non-zero exit instead of silently reporting success. Uses a scratch
+//! MALT_PREFIX so no real DB or network is hit.
+
+const std = @import("std");
+const malt = @import("malt");
+const testing = std.testing;
+const upgrade = malt.upgrade;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+fn setupPrefix(suffix: []const u8) ![:0]u8 {
+    const path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "/tmp/malt_upgrade_exec_{d}_{s}",
+        .{ malt.fs_compat.nanoTimestamp(), suffix },
+        0,
+    );
+    malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    try malt.fs_compat.cwd().makePath(path);
+    _ = c.setenv("MALT_PREFIX", path.ptr, 1);
+    return path;
+}
+
+test "mt upgrade <nonexistent> surfaces a non-zero exit" {
+    const path = try setupPrefix("nonexistent_pkg");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Seed an empty DB so the `db/` dir exists (lock acquire doesn't
+    // short-circuit to silent-return) but no packages are installed.
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{path});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+
+    try testing.expectError(
+        error.Aborted,
+        upgrade.execute(testing.allocator, &.{"definitely-not-installed"}),
+    );
+}


### PR DESCRIPTION
## Description

Stop swallowing three classes of errors with `catch {}`:

- Allocator failures in install prefetch / failed-keg bookkeeping (`cli/install.zig`) and migrate per-category bookkeeping (`cli/migrate.zig`) now propagate via `try`.
- Per-package errors in `mt upgrade` (`cli/upgrade.zig`) are aggregated into a failure count + summary and produce a non-zero exit on any failure. Single-package and batch variants share the same contract.
- OOM inside interpreter scope pushes (`core/dsl/interpreter.zig`): `pushScope` / `pushMethodScope` / `setLocal` now return `DslError!void`, and `ExecContext.init` propagates because it pushes  the initial scope. Callers use `try` throughout so the next `popScope` never tears down the caller's scope under memory pressure.

The GHCR `prefetchTokens` call stays best-effort (a network cache warm that is not load-bearing), now with a one-line justification comment instead of a bare swallow.

## Related Issue

- None

## Notes for Reviewers

**Behaviour change:** `mt upgrade foo` used to exit 0 when the upgrade failed; it now exits non-zero. Matches `install.zig`'s semantics and unbreaks CI usage.
