### PR TITLE
refactor(cli/install): narrow localErrorIsAnnounced to InstallError

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1857,7 +1857,7 @@ fn installLocalFormula(
     prefix: []const u8,
     dry_run: bool,
     force: bool,
-) !void {
+) InstallError!void {
     // Expand a leading `~/` to `$HOME` so the common "drop it in
     // your dotfiles" path works without requiring shell expansion.
     var home_buf: [fs_compat.max_path_bytes]u8 = undefined;
@@ -1971,9 +1971,10 @@ pub fn isAllowedArchiveUrl(url: []const u8) bool {
 /// True when the given error has already surfaced a specific,
 /// user-facing `output.err` line from inside the install helpers, so
 /// the dispatch-loop shouldn't add a generic "Failed to install X: E"
-/// summary on top. Kept next to the helpers it mirrors so adding a new
-/// announced error type can't forget this call site.
-pub fn localErrorIsAnnounced(e: anyerror) bool {
+/// summary on top. Narrowed to `InstallError` so a new tag forces a
+/// compile error on unhandled paths instead of silently falling through
+/// the old `else =>` prong.
+pub fn localErrorIsAnnounced(e: InstallError) bool {
     return switch (e) {
         InstallError.LocalFormulaNotReadable,
         InstallError.InsecureArchiveUrl,
@@ -1981,7 +1982,20 @@ pub fn localErrorIsAnnounced(e: anyerror) bool {
         InstallError.DownloadFailed,
         InstallError.CellarFailed,
         => true,
-        else => false,
+
+        InstallError.NoPackages,
+        InstallError.DatabaseError,
+        InstallError.LockError,
+        InstallError.CaskNotFound,
+        InstallError.NoBottle,
+        InstallError.StoreFailed,
+        InstallError.LinkFailed,
+        InstallError.RecordFailed,
+        InstallError.PartialFailure,
+        InstallError.PrefixTooLong,
+        InstallError.PostInstallUnsupported,
+        InstallError.AmbiguousSystemRubyScope,
+        => false,
     };
 }
 
@@ -2059,7 +2073,7 @@ fn materializeRubyFormula(
     prefix: []const u8,
     dry_run: bool,
     force: bool,
-) !void {
+) InstallError!void {
     output.info("Found {s} {s}", .{ resolved.name, resolved.version });
 
     if (dry_run) {

--- a/tests/install_local_test.zig
+++ b/tests/install_local_test.zig
@@ -102,12 +102,28 @@ test "localErrorIsAnnounced covers errors with specific user-facing messages" {
 }
 
 test "localErrorIsAnnounced returns false for unexpected errors" {
-    // Genuinely surprising errors (e.g. OOM, DB failures without a
-    // prior message) keep the generic summary so the user sees
-    // *something* rather than silent failure.
-    try testing.expect(!install.localErrorIsAnnounced(error.OutOfMemory));
+    // DB/record failures reach the dispatch loop without a dedicated
+    // user-facing line, so the generic summary stays on for them.
     try testing.expect(!install.localErrorIsAnnounced(install.InstallError.RecordFailed));
     try testing.expect(!install.localErrorIsAnnounced(install.InstallError.LockError));
+}
+
+test "localErrorIsAnnounced parameter is narrowed to InstallError" {
+    // A widened `anyerror` makes the inner switch meaningless — any new
+    // InstallError tag compiles without a handler. Pin the narrowing.
+    const info = @typeInfo(@TypeOf(install.localErrorIsAnnounced)).@"fn";
+    try testing.expect(info.params[0].type.? == install.InstallError);
+}
+
+test "localErrorIsAnnounced handles every InstallError tag" {
+    // Comptime sweep: if a future tag is added without a switch arm,
+    // the exhaustive check in `localErrorIsAnnounced` already fails to
+    // compile. This test also fails the whole module to compile, making
+    // the missing coverage visible from `zig build test` output.
+    inline for (@typeInfo(install.InstallError).error_set.?) |err| {
+        const tag = @field(install.InstallError, err.name);
+        _ = install.localErrorIsAnnounced(tag);
+    }
 }
 
 // ─── describeLocalPermissionRisk ─────────────────────────────────────


### PR DESCRIPTION
## Description

Narrow `localErrorIsAnnounced` to accept `InstallError` rather than `anyerror`. The inner switch is now exhaustive over every `InstallError` variant (no `else =>` prong), so adding a new tag without updating the handler fails at compile time. `installLocalFormula` and `materializeRubyFormula` also declare `InstallError!void` return types so the narrowed error flows to the dispatch-loop `catch |e|` site without `@errorCast`.

## Related Issue

- None

## Notes for Reviewers

- None
