### PR TITLE
refactor: replace anyerror in vtable callbacks with narrow sets

### DIFF
--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -544,7 +544,7 @@ pub fn hashFileSha256(file_path: []const u8) ![64]u8 {
 }
 
 /// Bridge `streamFile`'s erased-context callback to `Sha256.update`.
-fn sha256Update(ctx: *anyopaque, chunk: []const u8) anyerror!void {
+fn sha256Update(ctx: *anyopaque, chunk: []const u8) fs_compat.StreamError!void {
     const hasher: *std.crypto.hash.sha2.Sha256 = @ptrCast(@alignCast(ctx));
     hasher.update(chunk);
 }

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -426,7 +426,7 @@ pub fn spawnFilteredWithHooks(
 
 const FdSinkCtx = struct { fd: c_int };
 
-fn fdSinkWrite(ctx: *anyopaque, bytes: []const u8) anyerror!void {
+fn fdSinkWrite(ctx: *anyopaque, bytes: []const u8) term_sanitize.SinkError!void {
     const self: *FdSinkCtx = @ptrCast(@alignCast(ctx));
     var off: usize = 0;
     while (off < bytes.len) {

--- a/src/fs/compat.zig
+++ b/src/fs/compat.zig
@@ -84,12 +84,17 @@ pub fn milliTimestamp() i64 {
     return @as(i64, ts.sec) * std.time.ms_per_s + @divTrunc(ts.nsec, std.time.ns_per_ms);
 }
 
+/// Closed error set surfaced by `StreamCallback.func`. Keeps callers
+/// exhaustive: a new callback failure mode must land here or it cannot
+/// be plumbed through the vtable.
+pub const StreamError = error{ OutOfMemory, CallbackAborted };
+
 /// Context + function pair for `streamFile`. The func receives every
 /// chunk exactly once, in order — any non-void error aborts the walk
 /// and propagates out to the caller.
 pub const StreamCallback = struct {
     context: *anyopaque,
-    func: *const fn (context: *anyopaque, chunk: []const u8) anyerror!void,
+    func: *const fn (context: *anyopaque, chunk: []const u8) StreamError!void,
 };
 
 /// Walk `file` from start to EOF in `buf`-sized chunks, invoking `cb`

--- a/src/ui/term_sanitize.zig
+++ b/src/ui/term_sanitize.zig
@@ -12,13 +12,19 @@
 
 const std = @import("std");
 
+/// Closed error set surfaced by `Sink.write_fn`. Every sink
+/// implementation must collapse its failure modes into this set so
+/// sanitizer callers can switch exhaustively instead of catching
+/// `anyerror`.
+pub const SinkError = error{WriteFailed};
+
 /// Bytes-out callback. The sink is allowed to fail; the sanitizer
 /// propagates that error to its caller.
 pub const Sink = struct {
     ctx: *anyopaque,
-    write_fn: *const fn (ctx: *anyopaque, bytes: []const u8) anyerror!void,
+    write_fn: *const fn (ctx: *anyopaque, bytes: []const u8) SinkError!void,
 
-    pub fn write(self: Sink, bytes: []const u8) anyerror!void {
+    pub fn write(self: Sink, bytes: []const u8) SinkError!void {
         return self.write_fn(self.ctx, bytes);
     }
 };

--- a/tests/fs_compat_stream_test.zig
+++ b/tests/fs_compat_stream_test.zig
@@ -30,7 +30,7 @@ fn writeFile(path: []const u8, bytes: []const u8) !void {
 const Collector = struct {
     list: *std.ArrayList(u8),
 
-    fn callback(ctx: *anyopaque, chunk: []const u8) anyerror!void {
+    fn callback(ctx: *anyopaque, chunk: []const u8) fs.StreamError!void {
         const self: *Collector = @ptrCast(@alignCast(ctx));
         try self.list.appendSlice(testing.allocator, chunk);
     }
@@ -45,6 +45,19 @@ fn runStream(path: []const u8) !std.ArrayList(u8) {
     var buf: [TEST_CHUNK]u8 = undefined;
     try fs.streamFile(f, &buf, .{ .context = @ptrCast(&c), .func = &Collector.callback });
     return collected;
+}
+
+// ── callback-signature shape ─────────────────────────────────────────
+//
+// Pin that `StreamCallback.func` returns a closed error set, not
+// `anyerror`. A closed set lets every caller switch exhaustively on the
+// concrete tags; `anyerror` would swallow new tags silently.
+test "StreamCallback.func declares a closed error set" {
+    const FuncPtr = std.meta.fieldInfo(fs.StreamCallback, .func).type;
+    const FnType = @typeInfo(FuncPtr).pointer.child;
+    const RetT = @typeInfo(FnType).@"fn".return_type.?;
+    const ErrSet = @typeInfo(RetT).error_union.error_set;
+    try testing.expect(@typeInfo(ErrSet).error_set != null);
 }
 
 // ── size sweep: every boundary vs the chunk size ─────────────────────
@@ -113,7 +126,7 @@ const AbortCtx = struct {
     seen: usize = 0,
     abort_after: usize,
 
-    fn callback(ctx: *anyopaque, chunk: []const u8) anyerror!void {
+    fn callback(ctx: *anyopaque, chunk: []const u8) fs.StreamError!void {
         const self: *AbortCtx = @ptrCast(@alignCast(ctx));
         self.seen += chunk.len;
         if (self.seen > self.abort_after) return error.CallbackAborted;

--- a/tests/term_sanitize_test.zig
+++ b/tests/term_sanitize_test.zig
@@ -16,9 +16,12 @@ const Buf = struct {
         return .{ .ctx = self, .write_fn = writeFn };
     }
 
-    fn writeFn(ctx: *anyopaque, bytes: []const u8) anyerror!void {
+    fn writeFn(ctx: *anyopaque, bytes: []const u8) ts.SinkError!void {
         const self: *Buf = @ptrCast(@alignCast(ctx));
-        try self.list.appendSlice(testing.allocator, bytes);
+        // Test buffer backed by testing.allocator: collapse an allocator
+        // failure into the sink's single failure tag so the vtable stays
+        // closed.
+        self.list.appendSlice(testing.allocator, bytes) catch return error.WriteFailed;
     }
 
     fn deinit(self: *Buf) void {
@@ -33,6 +36,17 @@ fn check(input: []const u8, expected: []const u8) !void {
     try s.feed(input, buf.sink());
     try s.flush(buf.sink());
     try testing.expectEqualSlices(u8, expected, buf.list.items);
+}
+
+// Pin that `Sink.write_fn` returns a closed error set. A bare
+// `anyerror` here would let a hostile sink raise arbitrary tags and
+// defeat exhaustive switching at every caller.
+test "Sink.write_fn declares a closed error set" {
+    const FuncPtr = std.meta.fieldInfo(ts.Sink, .write_fn).type;
+    const FnType = @typeInfo(FuncPtr).pointer.child;
+    const RetT = @typeInfo(FnType).@"fn".return_type.?;
+    const ErrSet = @typeInfo(RetT).error_union.error_set;
+    try testing.expect(@typeInfo(ErrSet).error_set != null);
 }
 
 test "plain ASCII passes through" {


### PR DESCRIPTION
## Description

Replace `anyerror` in four vtable callback signatures with narrow error sets. Callers now switch exhaustively on the concrete tags.

## Related Issue

- None

## Notes for Reviewers

Internal callbacks only.