### PR TITLE
refactor(cli/install): fix post_install formula cleanup chain

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -208,6 +208,42 @@ fn emitPostInstallJson(
     io_mod.stdoutWriteAll(aw.written());
 }
 
+/// Outcome of a single DSL post_install attempt. `.parse_failed` lets
+/// the caller fall through to the system-Ruby fallback instead of
+/// silently dropping the hook.
+pub const DslPostInstallOutcome = enum {
+    handled,
+    parse_failed,
+};
+
+/// Run one DSL post_install attempt against `job`. Owns the formula +
+/// FallbackLog lifetimes so callers don't have to replicate the cleanup
+/// chain across every candidate source (local .rb, GitHub fetch).
+///
+/// Pub so install-pure tests can pin the outcome contract directly.
+pub fn executeDslPostInstall(
+    allocator: std.mem.Allocator,
+    job: *const DownloadJob,
+    post_install_src: []const u8,
+    prefix: []const u8,
+    use_system_ruby_list: []const []const u8,
+) DslPostInstallOutcome {
+    var formula = formula_mod.parseFormula(allocator, job.formula_json) catch {
+        output.warn("post_install: failed to parse formula for {s}", .{job.name});
+        return .parse_failed;
+    };
+    defer formula.deinit();
+
+    var flog = dsl.FallbackLog.init(allocator);
+    defer flog.deinit();
+
+    // DSL errors reflect in `flog`; the router reads the log as the source
+    // of truth so silent skips downgrade the same as hard failures.
+    dsl.executePostInstall(allocator, &formula, post_install_src, prefix, &flog) catch {};
+    routePostInstallOutcome(allocator, job.name, job.version_str, prefix, &flog, use_system_ruby_list);
+    return .handled;
+}
+
 /// A bottle download job for parallel processing.
 ///
 /// Public so integration tests can construct an empty jobs list and assert
@@ -764,12 +800,14 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // and subprocess wait overlap) while keeping cache pressure low.
     const mats = allocator.alloc(MaterializeResult, all_jobs.items.len) catch
         return InstallError.CellarFailed;
-    defer {
-        for (mats) |m| {
-            if (m.keg_path.len > 0) std.heap.c_allocator.free(m.keg_path);
-        }
-        allocator.free(mats);
-    }
+    // Two defers (LIFO): the keg-path loop needs `mats` alive, so free the
+    // outer slice last. Splits the two allocator contracts into distinct
+    // statements so the reader doesn't have to track which slice came from
+    // which allocator.
+    defer allocator.free(mats);
+    defer for (mats) |m| {
+        if (m.keg_path.len > 0) std.heap.c_allocator.free(m.keg_path);
+    };
     for (mats) |*m| m.* = .{ .ok = false, .keg_path = &[_]u8{}, .err = null };
 
     {
@@ -865,53 +903,31 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         // Execute post_install: try DSL interpreter first, fall back to
         // system Ruby subprocess when --use-system-ruby is set.
         if (job.post_install_defined) post_install: {
-            // Try to locate the .rb source file for DSL extraction
-            const tap_path = ruby_sub.findHomebrewCoreTap();
-            var rb_buf: [1024]u8 = undefined;
-            const rb_path = if (tap_path) |tp| ruby_sub.resolveFormulaRbPath(&rb_buf, tp, job.name) else null;
+            // Locate a DSL source: local tap first, GitHub fetch second.
+            const dsl_src: ?[]const u8 = blk: {
+                const tap_path = ruby_sub.findHomebrewCoreTap();
+                var rb_buf: [1024]u8 = undefined;
+                const rb_path = if (tap_path) |tp|
+                    ruby_sub.resolveFormulaRbPath(&rb_buf, tp, job.name)
+                else
+                    null;
+                if (rb_path) |sp| {
+                    if (ruby_sub.extractPostInstallBody(allocator, sp)) |s| break :blk s;
+                }
+                break :blk ruby_sub.fetchPostInstallFromGitHub(allocator, job.name);
+            };
 
-            if (rb_path) |src_path| {
-                if (ruby_sub.extractPostInstallBody(allocator, src_path)) |post_install_src| {
-                    defer allocator.free(post_install_src);
-
-                    var formula = formula_mod.parseFormula(allocator, job.formula_json) catch {
-                        output.warn("post_install: failed to parse formula for {s}", .{job.name});
-                        break :post_install;
-                    };
-                    defer formula.deinit();
-
-                    var flog = dsl.FallbackLog.init(allocator);
-                    defer flog.deinit();
-
-                    // Error from execute is already reflected in `flog`;
-                    // the outcome router uses the log as the source of
-                    // truth so silent-skips downgrade the same as hard
-                    // failures instead of reading as "completed".
-                    dsl.executePostInstall(allocator, &formula, post_install_src, prefix, &flog) catch {};
-                    routePostInstallOutcome(allocator, job.name, job.version_str, prefix, &flog, use_system_ruby_list);
-                    break :post_install;
+            if (dsl_src) |src| {
+                defer allocator.free(src);
+                switch (executeDslPostInstall(allocator, job, src, prefix, use_system_ruby_list)) {
+                    .handled => break :post_install,
+                    // parse_failed leaves the DSL path unusable — fall through
+                    // so the system-Ruby fallback still has a chance to run.
+                    .parse_failed => {},
                 }
             }
 
-            // No local .rb source — try fetching from GitHub
-            if (ruby_sub.fetchPostInstallFromGitHub(allocator, job.name)) |post_install_src| {
-                defer allocator.free(post_install_src);
-
-                var formula = formula_mod.parseFormula(allocator, job.formula_json) catch {
-                    output.warn("post_install: failed to parse formula for {s}", .{job.name});
-                    break :post_install;
-                };
-                defer formula.deinit();
-
-                var flog = dsl.FallbackLog.init(allocator);
-                defer flog.deinit();
-
-                dsl.executePostInstall(allocator, &formula, post_install_src, prefix, &flog) catch {};
-                routePostInstallOutcome(allocator, job.name, job.version_str, prefix, &flog, use_system_ruby_list);
-                break :post_install;
-            }
-
-            // No source available — fall back to subprocess or skip
+            // No usable DSL source — fall back to subprocess or skip.
             if (useSystemRubyForFormula(use_system_ruby_list, job.name)) {
                 output.warn("Running post_install for {s} via system Ruby...", .{job.name});
                 ruby_sub.runPostInstall(allocator, job.name, job.version_str, prefix) catch |e| {

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -616,6 +616,73 @@ test "routePostInstallOutcome: --json status=fatal on sandbox violation" {
 }
 
 // ---------------------------------------------------------------------------
+// executeDslPostInstall — owns one DSL attempt against a job. The outcome
+// decides whether the caller falls through to the system-Ruby fallback.
+// ---------------------------------------------------------------------------
+
+fn stubJob(name: []const u8, formula_json: []const u8) install.DownloadJob {
+    return .{
+        .name = name,
+        .version_str = "1.0",
+        .sha256 = "aa",
+        .bottle_url = "",
+        .is_dep = false,
+        .keg_only = false,
+        .post_install_defined = true,
+        .formula_json = formula_json,
+        .cellar_type = ":any",
+        .label_width = 0,
+        .line_index = 0,
+        .multi = null,
+        .bar = null,
+        .store_sha256 = "",
+        .succeeded = true,
+    };
+}
+
+test "executeDslPostInstall returns .parse_failed when formula JSON is unparseable" {
+    // The parse-failure path must surface as a distinct outcome so the
+    // caller can still try the system-Ruby fallback instead of silently
+    // dropping the hook.
+    const prior_quiet = output_mod.isQuiet();
+    output_mod.setQuiet(true);
+    defer output_mod.setQuiet(prior_quiet);
+
+    const job = stubJob("bad-json", "not-a-json");
+    const outcome = install.executeDslPostInstall(
+        testing.allocator,
+        &job,
+        "# empty body",
+        "/tmp/irrelevant",
+        &.{},
+    );
+    try testing.expectEqual(install.DslPostInstallOutcome.parse_failed, outcome);
+}
+
+test "executeDslPostInstall returns .handled when DSL executes against a valid formula" {
+    color_mod.setForTest(false, false);
+    defer color_mod.setForTest(null, null);
+    const prior_quiet = output_mod.isQuiet();
+    output_mod.setQuiet(true);
+    defer output_mod.setQuiet(prior_quiet);
+
+    // Minimal valid JSON: parseFormula only requires `name`; an empty Ruby
+    // body compiles to zero nodes so the interpreter runs to completion.
+    const json =
+        \\{"name":"hello","full_name":"hello","versions":{"stable":"1.0"},"dependencies":[],"oldnames":[]}
+    ;
+    const job = stubJob("hello", json);
+    const outcome = install.executeDslPostInstall(
+        testing.allocator,
+        &job,
+        "# empty",
+        "/tmp/irrelevant",
+        &.{},
+    );
+    try testing.expectEqual(install.DslPostInstallOutcome.handled, outcome);
+}
+
+// ---------------------------------------------------------------------------
 // Invariants — pinned as tests so future refactors can't drift them silently:
 //   - per-formula FallbackLog isolation
 //   - deferred cleanup fires on labelled break


### PR DESCRIPTION
## Description

Fix the cleanup chain around post_install in `cli/install.zig`. The two duplicated DSL blocks collapse into a single `executeDslPostInstall` helper returning a `DslPostInstallOutcome` enum, so the caller decides whether to fall through to the system-Ruby fallback. The parse-failure path that previously dead-ended with `break :post_install` now reports `.parse_failed` and lets the fallback run. The mixed-allocator `defer` for `mats` splits into two LIFO `defer` statements so each contract reads cleanly on its own.

## Related Issue

- None

## Notes for Reviewers

- None