### PR TITLE
refactor: bubble SqliteError through core helpers

### DIFF
--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -374,8 +374,9 @@ fn migrateKeg(
 
         linker.link(keg.path, formula.name, keg_id) catch {
             output.warn("    {s}: some links could not be created", .{keg_name});
+            // Best-effort cleanup after a link failure; the user already sees the failure above.
             linker.unlink(keg_id) catch {};
-            deleteKeg(db, keg_id);
+            deleteKeg(db, keg_id) catch {};
             cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
             return .failed_install;
         };
@@ -554,11 +555,11 @@ fn recordKeg(
     return keg_id;
 }
 
-fn deleteKeg(db: *sqlite.Database, keg_id: i64) void {
-    var stmt = db.prepare("DELETE FROM kegs WHERE id = ?1;") catch return;
+fn deleteKeg(db: *sqlite.Database, keg_id: i64) sqlite.SqliteError!void {
+    var stmt = try db.prepare("DELETE FROM kegs WHERE id = ?1;");
     defer stmt.finalize();
-    stmt.bindInt(1, keg_id) catch return;
-    _ = stmt.step() catch {};
+    try stmt.bindInt(1, keg_id);
+    _ = try stmt.step();
 }
 
 fn recordDeps(db: *sqlite.Database, keg_id: i64, formula: *const formula_mod.Formula) void {

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -55,28 +55,28 @@ pub fn parseCask(allocator: std.mem.Allocator, json_bytes: []const u8) !Cask {
 }
 
 /// Record cask installation in database.
-pub fn recordInstall(db: *sqlite.Database, cask: *const Cask, app_path: ?[]const u8) !void {
-    var stmt = db.prepare(
+pub fn recordInstall(db: *sqlite.Database, cask: *const Cask, app_path: ?[]const u8) sqlite.SqliteError!void {
+    var stmt = try db.prepare(
         "INSERT OR REPLACE INTO casks (token, name, version, url, sha256, app_path, auto_updates) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7);",
-    ) catch return;
+    );
     defer stmt.finalize();
 
-    stmt.bindText(1, cask.token) catch return;
-    stmt.bindText(2, cask.name) catch return;
-    stmt.bindText(3, cask.version) catch return;
-    stmt.bindText(4, cask.url) catch return;
-    if (cask.sha256) |s| stmt.bindText(5, s) catch return else stmt.bindNull(5) catch return;
-    if (app_path) |p| stmt.bindText(6, p) catch return else stmt.bindNull(6) catch return;
-    stmt.bindInt(7, if (cask.auto_updates) 1 else 0) catch return;
-    _ = stmt.step() catch {};
+    try stmt.bindText(1, cask.token);
+    try stmt.bindText(2, cask.name);
+    try stmt.bindText(3, cask.version);
+    try stmt.bindText(4, cask.url);
+    if (cask.sha256) |s| try stmt.bindText(5, s) else try stmt.bindNull(5);
+    if (app_path) |p| try stmt.bindText(6, p) else try stmt.bindNull(6);
+    try stmt.bindInt(7, if (cask.auto_updates) 1 else 0);
+    _ = try stmt.step();
 }
 
 /// Remove cask record from database.
-pub fn removeRecord(db: *sqlite.Database, token: []const u8) !void {
-    var stmt = db.prepare("DELETE FROM casks WHERE token = ?1;") catch return;
+pub fn removeRecord(db: *sqlite.Database, token: []const u8) sqlite.SqliteError!void {
+    var stmt = try db.prepare("DELETE FROM casks WHERE token = ?1;");
     defer stmt.finalize();
-    stmt.bindText(1, token) catch return;
-    _ = stmt.step() catch {};
+    try stmt.bindText(1, token);
+    _ = try stmt.step();
 }
 
 /// Determine the artifact type from the cask download URL.

--- a/src/core/linker.zig
+++ b/src/core/linker.zig
@@ -133,14 +133,14 @@ pub const Linker = struct {
             const link_path = std.fmt.bufPrint(&link_buf, "{s}/{s}/{s}", .{ self.prefix, subdir, entry.name }) catch continue;
 
             // Record in DB
-            var stmt = self.db.prepare(
+            var stmt = try self.db.prepare(
                 "INSERT OR REPLACE INTO links (keg_id, link_path, target) VALUES (?1, ?2, ?3);",
-            ) catch continue;
+            );
             defer stmt.finalize();
-            stmt.bindInt(1, keg_id) catch continue;
-            stmt.bindText(2, link_path) catch continue;
-            stmt.bindText(3, target) catch continue;
-            _ = stmt.step() catch {};
+            try stmt.bindInt(1, keg_id);
+            try stmt.bindText(2, link_path);
+            try stmt.bindText(3, target);
+            _ = try stmt.step();
         }
     }
 
@@ -167,23 +167,21 @@ pub const Linker = struct {
     }
 
     /// Remove all symlinks for a keg (from DB).
-    pub fn unlink(self: *Linker, keg_id: i64) !void {
-        // Query all links for this keg
-        var stmt = self.db.prepare("SELECT link_path FROM links WHERE keg_id = ?1;") catch return;
+    pub fn unlink(self: *Linker, keg_id: i64) sqlite.SqliteError!void {
+        var stmt = try self.db.prepare("SELECT link_path FROM links WHERE keg_id = ?1;");
         defer stmt.finalize();
-        stmt.bindInt(1, keg_id) catch return;
+        try stmt.bindInt(1, keg_id);
 
-        while (stmt.step() catch null) |has_row| {
-            if (!has_row) break;
+        while (try stmt.step()) {
             const link_path = stmt.columnText(0) orelse continue;
             const path_slice = std.mem.sliceTo(link_path, 0);
+            // Symlink may already be gone from the filesystem; DB row is the source of truth we're flushing.
             fs_compat.cwd().deleteFile(path_slice) catch {};
         }
 
-        // Delete from DB
-        var del_stmt = self.db.prepare("DELETE FROM links WHERE keg_id = ?1;") catch return;
+        var del_stmt = try self.db.prepare("DELETE FROM links WHERE keg_id = ?1;");
         defer del_stmt.finalize();
-        del_stmt.bindInt(1, keg_id) catch return;
-        _ = del_stmt.step() catch {};
+        try del_stmt.bindInt(1, keg_id);
+        _ = try del_stmt.step();
     }
 };

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -23,31 +23,31 @@ pub fn add(
     name: []const u8,
     url: []const u8,
     commit_sha: ?[]const u8,
-) !void {
+) sqlite.SqliteError!void {
     // URL is sticky on conflict (URL doesn't change once registered);
     // commit_sha is sticky unless the caller passes a new one. Refresh
     // goes through `updateCommit` which forces a replacement.
-    var stmt = db.prepare(
+    var stmt = try db.prepare(
         \\INSERT INTO taps (name, url, commit_sha) VALUES (?1, ?2, ?3)
         \\ON CONFLICT(name) DO UPDATE SET
         \\    commit_sha = COALESCE(excluded.commit_sha, taps.commit_sha);
-    ) catch return;
+    );
     defer stmt.finalize();
-    stmt.bindText(1, name) catch return;
-    stmt.bindText(2, url) catch return;
+    try stmt.bindText(1, name);
+    try stmt.bindText(2, url);
     if (commit_sha) |s| {
-        stmt.bindText(3, s) catch return;
+        try stmt.bindText(3, s);
     } else {
-        stmt.bindNull(3) catch return;
+        try stmt.bindNull(3);
     }
-    _ = stmt.step() catch {};
+    _ = try stmt.step();
 }
 
-pub fn remove(db: *sqlite.Database, name: []const u8) !void {
-    var stmt = db.prepare("DELETE FROM taps WHERE name = ?1;") catch return;
+pub fn remove(db: *sqlite.Database, name: []const u8) sqlite.SqliteError!void {
+    var stmt = try db.prepare("DELETE FROM taps WHERE name = ?1;");
     defer stmt.finalize();
-    stmt.bindText(1, name) catch return;
-    _ = stmt.step() catch {};
+    try stmt.bindText(1, name);
+    _ = try stmt.step();
 }
 
 /// Replace the stored commit SHA for an existing tap. Called by

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -153,6 +153,32 @@ test "removeRecord removes cask from DB" {
     try std.testing.expect(!cask.isInstalled(&db, "firefox"));
 }
 
+// A schema-less DB makes `prepare` fail. Bubbling the SqliteError lets
+// the caller distinguish "table missing" from "constraint violation" —
+// previously both became a silent no-op.
+test "recordInstall surfaces SqliteError when schema is missing" {
+    var db = try openTestDb();
+    defer db.close();
+
+    var c = try cask.parseCask(std.testing.allocator, test_cask_json);
+    defer c.deinit();
+
+    try std.testing.expectError(
+        sqlite.SqliteError.PrepareFailed,
+        cask.recordInstall(&db, &c, "/Applications/Firefox.app"),
+    );
+}
+
+test "removeRecord surfaces SqliteError when schema is missing" {
+    var db = try openTestDb();
+    defer db.close();
+
+    try std.testing.expectError(
+        sqlite.SqliteError.PrepareFailed,
+        cask.removeRecord(&db, "firefox"),
+    );
+}
+
 // --- CaskInstaller.isOutdated ---
 
 test "isOutdated detects version mismatch" {

--- a/tests/linker_core_test.zig
+++ b/tests/linker_core_test.zig
@@ -172,3 +172,14 @@ test "checkConflicts is empty when nothing is linked yet" {
     defer testing.allocator.free(conflicts);
     try testing.expectEqual(@as(usize, 0), conflicts.len);
 }
+
+// Without the `links` table, unlink's prepare fails. The rc used to
+// turn into a silent `return`, hiding "schema missing" from the caller.
+test "unlink surfaces SqliteError when links table is missing" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    // Intentionally no schema.initSchema — `links` does not exist.
+
+    var linker = linker_mod.Linker.init(testing.allocator, &db, "/tmp/malt_unused");
+    try testing.expectError(sqlite.SqliteError.PrepareFailed, linker.unlink(1));
+}

--- a/tests/tap_test.zig
+++ b/tests/tap_test.zig
@@ -208,6 +208,29 @@ test "remove deletes a tap" {
     try testing.expectEqualStrings("c/d", taps[0].name);
 }
 
+// A missing schema previously turned into a silent no-op; now the
+// caller sees the underlying sqlite rc and can distinguish it from a
+// constraint violation or a bind failure.
+test "add surfaces SqliteError when schema is missing" {
+    var db = try openDb();
+    defer db.close();
+
+    try testing.expectError(
+        sqlite.SqliteError.PrepareFailed,
+        tap.add(&db, "user/repo", "https://x", valid_sha),
+    );
+}
+
+test "remove surfaces SqliteError when schema is missing" {
+    var db = try openDb();
+    defer db.close();
+
+    try testing.expectError(
+        sqlite.SqliteError.PrepareFailed,
+        tap.remove(&db, "user/repo"),
+    );
+}
+
 fn listAndFree(alloc: std.mem.Allocator, db: *sqlite.Database) !void {
     const taps = try tap.list(alloc, db);
     for (taps) |t| {


### PR DESCRIPTION
## Description

Bubble `SqliteError` through cask, tap, linker, and migrate helpers instead of swallowing rc with `catch return`/`catch {}`. Domain-error mapping moves to the outer entrypoint; inner helpers `try`.

## Related Issue

- None

## Notes for Reviewers

A few callers now have slightly wider error sets. No user-visible behaviour change except clearer error text on failure.