### PR TITLE
refactor: adopt constantTimeEql at remaining sha-compare sites

### DIFF
--- a/src/core/bottle.zig
+++ b/src/core/bottle.zig
@@ -8,6 +8,7 @@ const archive = @import("../fs/archive.zig");
 const atomic = @import("../fs/atomic.zig");
 const client_mod = @import("../net/client.zig");
 const ghcr_mod = @import("../net/ghcr.zig");
+const install_cmd = @import("../cli/install.zig");
 
 pub const BottleError = error{
     DownloadFailed,
@@ -49,8 +50,9 @@ pub fn download(
     std.crypto.hash.sha2.Sha256.hash(body.items, &hash, .{});
     const computed_hex = std.fmt.bytesToHex(hash, .lower);
 
-    // Verify SHA256
-    if (!std.mem.eql(u8, &computed_hex, expected_sha256)) {
+    // Constant-time SHA compare — same reasoning as install.zig: deny a
+    // byte-by-byte timing oracle against the expected hash.
+    if (!install_cmd.constantTimeEql(u8, &computed_hex, expected_sha256)) {
         // Clean up dest_dir on mismatch
         fs_compat.deleteTreeAbsolute(dest_dir) catch {};
         return BottleError.Sha256Mismatch;

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -6,6 +6,7 @@ const fs_compat = @import("../fs/compat.zig");
 
 const sqlite = @import("../db/sqlite.zig");
 const client_mod = @import("../net/client.zig");
+const install_cmd = @import("../cli/install.zig");
 
 pub const CaskError = error{
     ParseFailed,
@@ -558,7 +559,9 @@ pub fn verifyFileSha256(file_path: []const u8, expected: ?[]const u8) !void {
     if (std.mem.eql(u8, expected_hash, "no_check")) return;
 
     const got = try hashFileSha256(file_path);
-    if (!std.mem.eql(u8, &got, expected_hash)) return error.Sha256Mismatch;
+    // Constant-time SHA compare — mirrors install.zig to close the
+    // byte-by-byte timing oracle on the expected hash.
+    if (!install_cmd.constantTimeEql(u8, &got, expected_hash)) return error.Sha256Mismatch;
 }
 
 /// Check if an application is currently running by its path.

--- a/src/update/verify.zig
+++ b/src/update/verify.zig
@@ -11,6 +11,7 @@
 
 const std = @import("std");
 const fs_compat = @import("../fs/compat.zig");
+const install_cmd = @import("../cli/install.zig");
 
 pub const ChecksumError = error{
     /// `bytes` did not hash to the value named in `expected_hex`.
@@ -28,7 +29,9 @@ pub fn verifySha256(bytes: []const u8, expected_hex: []const u8) ChecksumError!v
     var actual: [32]u8 = undefined;
     std.crypto.hash.sha2.Sha256.hash(bytes, &actual, .{});
 
-    if (!std.mem.eql(u8, &expected, &actual)) return error.ChecksumMismatch;
+    // Constant-time SHA compare — mirrors install.zig to close the
+    // byte-by-byte timing oracle on the expected hash.
+    if (!install_cmd.constantTimeEql(u8, &expected, &actual)) return error.ChecksumMismatch;
 }
 
 /// Find the SHA256 hex for `archive_name` in a GoReleaser-style


### PR DESCRIPTION
## Description

SHA256 comparisons in bottle downloads, cask verification, and self-update checksum verification now run in constant time, matching the approach already used by the formula install path. A network-positioned attacker can no longer learn bytes of an expected hash by timing how fast `malt` rejects a mismatched asset.

## Related Issue

- None

## Notes for Reviewers

Hygiene fix; no user-visible behaviour change. The existing helper is reused as-is via a single import per site - no new utility module, no duplicated code.