### PR TITLE
fix(net/ghcr): return owned token from fetchToken

### DIFF
--- a/src/net/ghcr.zig
+++ b/src/net/ghcr.zig
@@ -147,6 +147,11 @@ pub const GhcrClient = struct {
     ///
     /// `http` is a caller-owned client — typically borrowed from a
     /// `HttpClientPool` so the TLS context is reused across requests.
+    ///
+    /// **Ownership.** The returned slice is an owned dupe allocated
+    /// from `self.allocator`; the caller must `defer self.allocator.free(token)`.
+    /// A borrowed return would race `clearCache` between mutex release
+    /// and the caller's use.
     pub fn fetchToken(
         self: *GhcrClient,
         http: *client_mod.HttpClient,
@@ -158,7 +163,9 @@ pub const GhcrClient = struct {
 
         const now = fs_compat.timestamp();
         if (self.cached_token) |t| {
-            if (now < self.token_expiry and self.cached_scopes.contains(repo)) return t;
+            if (now < self.token_expiry and self.cached_scopes.contains(repo)) {
+                return self.allocator.dupe(u8, t) catch GhcrError.OutOfMemory;
+            }
             self.clearCache();
         }
 
@@ -176,11 +183,16 @@ pub const GhcrClient = struct {
             return GhcrError.InvalidResponse;
         errdefer self.allocator.free(token);
 
+        // Keep the caller's copy independent from the cache so a later
+        // `clearCache` can't free memory still in flight.
+        const cached_copy = self.allocator.dupe(u8, token) catch return GhcrError.OutOfMemory;
+        errdefer self.allocator.free(cached_copy);
+
         const repo_dup = self.allocator.dupe(u8, repo) catch return GhcrError.OutOfMemory;
         errdefer self.allocator.free(repo_dup);
         try self.cached_scopes.put(self.allocator, repo_dup, {});
 
-        self.cached_token = token;
+        self.cached_token = cached_copy;
         self.token_expiry = now + 270; // 4.5 min buffer before 5 min expiry
         return token;
     }
@@ -199,8 +211,10 @@ pub const GhcrClient = struct {
         body_out: *std.ArrayList(u8),
         progress: ?client_mod.ProgressCallback,
     ) GhcrError!void {
-        // Get token through the mutex-protected cache (avoids redundant fetches)
+        // Get token through the mutex-protected cache (avoids redundant fetches).
+        // `fetchToken` returns an owned dupe — free before leaving.
         const token = self.fetchToken(http, repo) catch return GhcrError.TokenFetchFailed;
+        defer self.allocator.free(token);
 
         // Build URL: https://ghcr.io/v2/{repo}/blobs/{digest}
         var url_buf: [512]u8 = undefined;

--- a/tests/ghcr_test.zig
+++ b/tests/ghcr_test.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 const testing = std.testing;
 const client_mod = @import("malt").client;
 const ghcr = @import("malt").ghcr;
+const io_mod = @import("malt").io_mod;
 
 test "extractTokenField parses {\"token\":\"...\"} responses" {
     const json = "{\"token\":\"abc123\",\"expires_in\":300}";
@@ -126,4 +127,125 @@ test "hasTokenFor treats expired tokens as cache-miss" {
     g.token_expiry = 0; // far in the past
 
     try testing.expect(!g.hasTokenFor("homebrew/core/wget"));
+}
+
+test "fetchToken on cache hit returns an owned dupe the caller must free" {
+    // Pin the owned-return contract: the slice handed back is a fresh
+    // allocation, distinct from `cached_token`. If fetchToken ever
+    // reverts to a borrow, this test double-frees the cached buffer
+    // and the testing allocator aborts the run.
+    var pool = try client_mod.HttpClientPool.init(testing.allocator, 1);
+    defer pool.deinit();
+    const http = pool.acquire();
+    defer pool.release(http);
+
+    var g = ghcr.GhcrClient.init(testing.allocator, http);
+    defer g.deinit();
+
+    const seeded_token = try testing.allocator.dupe(u8, "fake-token");
+    const seeded_repo = try testing.allocator.dupe(u8, "homebrew/core/wget");
+    g.cached_token = seeded_token;
+    try g.cached_scopes.put(testing.allocator, seeded_repo, {});
+    g.token_expiry = std.math.maxInt(i64);
+
+    const token = try g.fetchToken(http, "homebrew/core/wget");
+    defer testing.allocator.free(token);
+
+    try testing.expectEqualStrings("fake-token", token);
+    try testing.expect(token.ptr != seeded_token.ptr);
+}
+
+// Concurrent stress: one churner replaces the cached token in a tight
+// loop (the mutex-protected half of `prefetchTokens`) while four
+// fetchers call fetchToken on the same repo. With a borrowed return
+// the churner's free would race the fetchers' use — `testing.allocator`
+// catches the resulting double-free or leak. Owned-dupe returns give
+// every fetcher an independent allocation, so the loop stays clean.
+test "fetchToken is safe against concurrent cache churn" {
+    const fetchers: usize = 4;
+    const iterations: usize = 2000;
+
+    var pool = try client_mod.HttpClientPool.init(testing.allocator, 1);
+    defer pool.deinit();
+    const http = pool.acquire();
+    defer pool.release(http);
+
+    var g = ghcr.GhcrClient.init(testing.allocator, http);
+    defer g.deinit();
+
+    // Initial seed so fetchers never miss and reach the network path.
+    g.cached_token = try testing.allocator.dupe(u8, "tok-0");
+    try g.cached_scopes.put(
+        testing.allocator,
+        try testing.allocator.dupe(u8, "homebrew/core/wget"),
+        {},
+    );
+    g.token_expiry = std.math.maxInt(i64);
+
+    const stop = std.atomic.Value(bool);
+    var done: stop = .init(false);
+
+    const Churn = struct {
+        fn run(gc: *ghcr.GhcrClient, flag: *stop, iters: usize) void {
+            const io = io_mod.ctx();
+            var i: usize = 0;
+            while (i < iters) : (i += 1) {
+                gc.mutex.lockUncancelable(io);
+                // Clear + reseed atomically under the mutex; mirrors
+                // the prefetchTokens window where cached_token is
+                // replaced with a fresh allocation.
+                if (gc.cached_token) |t| testing.allocator.free(t);
+                var it = gc.cached_scopes.keyIterator();
+                while (it.next()) |k| testing.allocator.free(k.*);
+                gc.cached_scopes.clearRetainingCapacity();
+
+                const fresh_tok = testing.allocator.dupe(u8, "tok-n") catch {
+                    gc.cached_token = null;
+                    gc.token_expiry = 0;
+                    gc.mutex.unlock(io);
+                    return;
+                };
+                const fresh_repo = testing.allocator.dupe(u8, "homebrew/core/wget") catch {
+                    testing.allocator.free(fresh_tok);
+                    gc.cached_token = null;
+                    gc.token_expiry = 0;
+                    gc.mutex.unlock(io);
+                    return;
+                };
+                gc.cached_scopes.put(testing.allocator, fresh_repo, {}) catch {
+                    testing.allocator.free(fresh_tok);
+                    testing.allocator.free(fresh_repo);
+                    gc.cached_token = null;
+                    gc.token_expiry = 0;
+                    gc.mutex.unlock(io);
+                    return;
+                };
+                gc.cached_token = fresh_tok;
+                gc.token_expiry = std.math.maxInt(i64);
+                gc.mutex.unlock(io);
+            }
+            flag.store(true, .release);
+        }
+    };
+
+    const Fetch = struct {
+        fn run(gc: *ghcr.GhcrClient, cli: *client_mod.HttpClient, flag: *stop) void {
+            while (!flag.load(.acquire)) {
+                const tok = gc.fetchToken(cli, "homebrew/core/wget") catch continue;
+                // Touch the bytes so the read races the churner's free
+                // under the old borrowed-return behaviour.
+                var sum: usize = 0;
+                for (tok) |b| sum +%= b;
+                std.mem.doNotOptimizeAway(sum);
+                testing.allocator.free(tok);
+            }
+        }
+    };
+
+    const threads = try testing.allocator.alloc(std.Thread, fetchers + 1);
+    defer testing.allocator.free(threads);
+
+    threads[0] = try std.Thread.spawn(.{}, Churn.run, .{ &g, &done, iterations });
+    for (threads[1..]) |*t| t.* = try std.Thread.spawn(.{}, Fetch.run, .{ &g, http, &done });
+    for (threads) |t| t.join();
 }


### PR DESCRIPTION
## Description

`fetchToken` now returns an owned token; callers `defer free`. Eliminates the mutex-release UAF window where another thread's `prefetchTokens`/`clearCache` could free the cached allocation while the caller still held the returned slice.

## Related Issue

- None

## Notes for Reviewers

One small dupe per request - acceptable cost for correctness.