### PR TITLE
fix(core/dsl/parser): save full heredoc state on identifier[ peeks

### DIFF
--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -576,17 +576,11 @@ pub const Parser = struct {
 
                 // --- Dir[expr] → Dir.glob(expr) ---
                 if (std.mem.eql(u8, name, "Dir")) {
-                    // Peek to see if next token is [
-                    const saved_pos2 = self.lexer.pos;
-                    const saved_line2 = self.lexer.line;
-                    const saved_col2 = self.lexer.col;
-                    const saved_lwv2 = self.lexer.last_was_value;
-                    const peek_tok = self.lexer.next();
-                    self.lexer.pos = saved_pos2;
-                    self.lexer.line = saved_line2;
-                    self.lexer.col = saved_col2;
-                    self.lexer.last_was_value = saved_lwv2;
-
+                    // `lexer.peek()` saves *every* field `next()` may
+                    // mutate — including the heredoc state — so a
+                    // `Dir<<~EOS` peek restores cleanly instead of
+                    // leaving the lexer mid-collection.
+                    const peek_tok = self.lexer.peek();
                     if (peek_tok.kind == .lbracket) {
                         self.advanceToken(); // consume "Dir"
                         self.advanceToken(); // consume "["
@@ -616,16 +610,9 @@ pub const Parser = struct {
 
                 // --- Formula["name"] → Formula.lookup(name) ---
                 if (std.mem.eql(u8, name, "Formula")) {
-                    const saved_pos4 = self.lexer.pos;
-                    const saved_line4 = self.lexer.line;
-                    const saved_col4 = self.lexer.col;
-                    const saved_lwv4 = self.lexer.last_was_value;
-                    const peek_tok3 = self.lexer.next();
-                    self.lexer.pos = saved_pos4;
-                    self.lexer.line = saved_line4;
-                    self.lexer.col = saved_col4;
-                    self.lexer.last_was_value = saved_lwv4;
-
+                    // Same reasoning as the `Dir` peek above: only
+                    // `lexer.peek()` saves the heredoc state.
+                    const peek_tok3 = self.lexer.peek();
                     if (peek_tok3.kind == .lbracket) {
                         self.advanceToken(); // consume "Formula"
                         self.advanceToken(); // consume "["
@@ -648,16 +635,9 @@ pub const Parser = struct {
 
                 // --- ENV["key"] read / ENV["key"] = value write ---
                 if (std.mem.eql(u8, name, "ENV")) {
-                    const saved_pos3 = self.lexer.pos;
-                    const saved_line3 = self.lexer.line;
-                    const saved_col3 = self.lexer.col;
-                    const saved_lwv3 = self.lexer.last_was_value;
-                    const peek_tok2 = self.lexer.next();
-                    self.lexer.pos = saved_pos3;
-                    self.lexer.line = saved_line3;
-                    self.lexer.col = saved_col3;
-                    self.lexer.last_was_value = saved_lwv3;
-
+                    // Same reasoning as the `Dir` peek above: only
+                    // `lexer.peek()` saves the heredoc state.
+                    const peek_tok2 = self.lexer.peek();
                     if (peek_tok2.kind == .lbracket) {
                         self.advanceToken(); // consume "ENV"
                         self.advanceToken(); // consume "["

--- a/tests/dsl_parser_test.zig
+++ b/tests/dsl_parser_test.zig
@@ -584,6 +584,58 @@ test "parser: Dir glob pattern" {
     try testing.expectEqual(@as(usize, 1), mc.args.len);
 }
 
+test "parser: Dir peek preserves heredoc lexer state" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    // When `Dir` is immediately followed by `<<~EOS`, parsePrimary's peek
+    // for `[` calls lexer.next() which starts a heredoc and mutates
+    // heredoc_terminator / heredoc_collecting. A correct peek restores
+    // that state; a buggy one leaves the lexer mid-collection, so the
+    // subsequent advanceToken() collects from the wrong position and
+    // swallows the `<<~EOS` start marker into the body.
+    const nodes = try parseSource(&arena, "Dir<<~EOS\n  body\nEOS\n");
+
+    try testing.expectEqual(@as(usize, 2), nodes.len);
+    try testing.expectEqualStrings("Dir", nodes[0].kind.identifier);
+
+    const body = nodes[1].kind.heredoc_literal;
+    try testing.expect(std.mem.indexOf(u8, body, "<<~") == null);
+    try testing.expectEqualStrings("  body\n", body);
+}
+
+test "parser: Formula peek preserves heredoc lexer state" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    // Same invariant as the Dir peek: the `Formula[` lookahead must not
+    // leak heredoc state if the peek consumes a `<<~EOS` start marker.
+    const nodes = try parseSource(&arena, "Formula<<~EOS\n  body\nEOS\n");
+
+    try testing.expectEqual(@as(usize, 2), nodes.len);
+    try testing.expectEqualStrings("Formula", nodes[0].kind.identifier);
+
+    const body = nodes[1].kind.heredoc_literal;
+    try testing.expect(std.mem.indexOf(u8, body, "<<~") == null);
+    try testing.expectEqualStrings("  body\n", body);
+}
+
+test "parser: ENV peek preserves heredoc lexer state" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    // Same invariant as the Dir peek: the `ENV[` lookahead must not
+    // leak heredoc state if the peek consumes a `<<~EOS` start marker.
+    const nodes = try parseSource(&arena, "ENV<<~EOS\n  body\nEOS\n");
+
+    try testing.expectEqual(@as(usize, 2), nodes.len);
+    try testing.expectEqualStrings("ENV", nodes[0].kind.identifier);
+
+    const body = nodes[1].kind.heredoc_literal;
+    try testing.expect(std.mem.indexOf(u8, body, "<<~") == null);
+    try testing.expectEqualStrings("  body\n", body);
+}
+
 test "parser: ENV read" {
     var arena = testArena();
     defer arena.deinit();


### PR DESCRIPTION
## Description

The DSL parser's `Dir[`, `Formula[`, and `ENV[` peeks now delegate to `lexer.peek()`, which saves and restores every field `next()` may mutate - including the heredoc state. Previously each peek only saved `pos`/`line`/`col`/`last_was_value`, so a sequence like `Dir<<~EOS` (or the `Formula`/`ENV` equivalents) left the lexer mid-heredoc-collection after the peek. The next token fetch then swallowed the `<<~EOS` start marker as if it were heredoc body, corrupting the parse.

## Related Issue

- None

## Notes for Reviewers

`Lexer.peek()` already implements the full save/restore - replacing each hand-rolled block with a call to it is both the minimum fix and the idiomatic one. All three identifier-lookahead sites in `parsePrimary` now share this helper; the earlier `parseExpression` peek (identifier-followed-by-`=`) already saved all six fields and stays as-is.