### PR TITLE
refactor(core/bottle): distinguish PathTooLong from OutOfMemory

### DIFF
--- a/src/core/bottle.zig
+++ b/src/core/bottle.zig
@@ -15,8 +15,16 @@ pub const BottleError = error{
     Sha256Mismatch,
     ExtractionFailed,
     OutOfMemory,
+    PathTooLong,
     IoError,
 };
+
+/// Formats `<dest_dir>/bottle.tar.gz` into `buf`; distinguishes path overflow
+/// from allocation failure so callers can surface a precise message.
+pub fn buildTmpArchivePath(buf: []u8, dest_dir: []const u8) BottleError![]const u8 {
+    return std.fmt.bufPrint(buf, "{s}/bottle.tar.gz", .{dest_dir}) catch
+        return BottleError.PathTooLong;
+}
 
 pub const BottleResult = struct {
     sha256: []const u8,
@@ -66,8 +74,7 @@ pub fn download(
 
     // Write bottle to temp file for extraction
     var tmp_path_buf: [512]u8 = undefined;
-    const tmp_path = std.fmt.bufPrint(&tmp_path_buf, "{s}/bottle.tar.gz", .{dest_dir}) catch
-        return BottleError.OutOfMemory;
+    const tmp_path = try buildTmpArchivePath(&tmp_path_buf, dest_dir);
 
     const tmp_file = fs_compat.createFileAbsolute(tmp_path, .{}) catch return BottleError.IoError;
     tmp_file.writeAll(body.items) catch {

--- a/tests/bottle_verify_test.zig
+++ b/tests/bottle_verify_test.zig
@@ -39,3 +39,17 @@ test "verify returns false for a mismatching sha256" {
 test "verify returns false when the file does not exist" {
     try testing.expect(!try bottle.verify(testing.allocator, "/tmp/malt_bottle_verify_missing_xyz", "00" ** 32));
 }
+
+test "buildTmpArchivePath returns PathTooLong for an oversized dest_dir" {
+    // 500-char dest_dir overflows the fixed tmp-path buffer; the distinct
+    // tag prevents users from seeing "out of memory" for a path problem.
+    var buf: [512]u8 = undefined;
+    const long_dest = "/" ++ ("a" ** 499);
+    try testing.expectError(bottle.BottleError.PathTooLong, bottle.buildTmpArchivePath(&buf, long_dest));
+}
+
+test "buildTmpArchivePath joins a normal dest_dir with the archive name" {
+    var buf: [512]u8 = undefined;
+    const path = try bottle.buildTmpArchivePath(&buf, "/tmp/malt_bottle_buildpath_ok");
+    try testing.expectEqualStrings("/tmp/malt_bottle_buildpath_ok/bottle.tar.gz", path);
+}


### PR DESCRIPTION
## Description

A bottle download whose `dest_dir` exceeds the 512-byte tmp-path buffer used to fail with `error.OutOfMemory`, so users saw "out of memory" for what was really an oversized path. This PR returns a distinct `error.PathTooLong` from the `bufPrint` path so the error message matches the real cause.

Scoped narrowly to `core/bottle.zig`. Other `bufPrint catch return error.OutOfMemory` sites elsewhere in the tree are intentionally untouched.

## Related Issue

- None

## Notes for Reviewers

- None
