### PR TITLE
fix(core/cask): install .tar.gz casks with binary artifacts

### DIFF
--- a/scripts/regressions/cask_targz_gh136.sh
+++ b/scripts/regressions/cask_targz_gh136.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Smoke test for issue #136 — `.tar.gz` and `.tgz` casks were rejected
+# with "Unsupported cask format for '<token>'" across the board,
+# covering thousands of casks (most GoReleaser-packaged CLIs ship
+# their macOS builds this way: copilot-cli, fly, codex, …).
+#
+# The fix teaches `core/cask.zig` about `tar_gz` containers and the
+# `artifacts[].binary` shape — an extracted binary gets symlinked into
+# `$MALT_PREFIX/bin/` so it lands on the user's `$PATH` the same way
+# a formula's keg does.
+#
+# The script walks a handful of real tar.gz casks, tolerates individual
+# upstream outages (network/release churn), but fails hard on the
+# original rejection symptom. A small formula install (`hello`) runs
+# afterwards to prove the formula tar.gz/bottle path — which has always
+# worked — was not collaterally broken by this change.
+#
+# Usage: scripts/regressions/cask_targz_gh136.sh
+# Requirements: built `malt` binary at $MALT_BIN or zig-out/bin/malt,
+# network access to github.com / formulae.brew.sh / upstream release hosts.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be ≤ 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_gh136"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+skip() { printf '  - %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+# ── Candidate tar.gz binary casks ──────────────────────────────────────
+#
+# Mixed `.tar.gz` and `.tgz` URL shapes, each paired with the binary
+# name it ships. The symlink at $PREFIX/bin/<bin> pointing into
+# Caskroom/<token>/<version>/ is the observable we assert on.
+#
+# Individual casks may disappear or change upstream — we require at
+# least one of the candidates to install cleanly; the rest are best
+# effort. Extend this list when adding canonical examples.
+declare -a CASKS=(
+  "copilot-cli:copilot" # .tar.gz, bare binary at archive root
+  "fly:fly"             # .tgz variant — exercises the second suffix
+  "codex:codex"         # .tar.gz, `binary [src, {target: alias}]` rename
+  "dda:dda"             # .tar.gz, different upstream (DataDog)
+  "filemon:filemon"     # .tgz, small binary from newosxbook.com
+)
+
+installed_any=0
+for spec in "${CASKS[@]}"; do
+  token="${spec%%:*}"
+  bin="${spec##*:}"
+  LOG="$PREFIX/install_${token}.log"
+  printf '▸ malt install %s (logs → %s)\n' "$token" "$LOG"
+
+  "$BIN" install "$token" >"$LOG" 2>&1 || true
+
+  # The blanket rejection is the regression we're guarding — it must
+  # never surface, even if another part of the install fails.
+  if grep -q "Unsupported cask format for '${token}'" "$LOG"; then
+    tail -20 "$LOG" >&2
+    fail "'${token}': regression — tar.gz cask still rejected"
+  fi
+
+  # Tolerate unrelated transient failures (upstream 404, sha256 drift,
+  # TLS hiccups) so one flaky cask does not mask the fix for the rest.
+  if grep -qE "Failed to install (cask )?${token}|Sha256Mismatch|DownloadFailed" "$LOG"; then
+    skip "${token}: install reported a non-regression failure; continuing"
+    continue
+  fi
+
+  link="$PREFIX/bin/$bin"
+  if [[ ! -L "$link" ]]; then
+    tail -20 "$LOG" >&2
+    fail "'${token}': expected symlink at $link"
+  fi
+
+  target=$(readlink "$link")
+  if [[ "$target" != *"/Caskroom/${token}/"* ]]; then
+    fail "'${token}': symlink points at '$target' (expected Caskroom/${token}/…)"
+  fi
+
+  if [[ ! -x "$target" ]]; then
+    fail "'${token}': symlink target '$target' is not executable"
+  fi
+
+  pass "${token}: tar.gz cask installed → \$PREFIX/bin/${bin} → ${target##*/Caskroom/}"
+  installed_any=1
+done
+
+((installed_any == 1)) || fail "no tar.gz cask installed — check network and candidate list"
+
+# ── Formula sanity: tap/bottle tar.gz paths are unaffected. ────────────
+#
+# Homebrew formula bottles are also `.tar.gz`, but flow through an
+# entirely separate install path (bottle materialisation, not the cask
+# installer). This step guards against accidentally regressing the
+# formula side when touching cask's tar.gz detection. `hello` is the
+# smallest published formula with a real binary payload.
+
+FORMULA_TARGET="${FORMULA_TARGET:-hello}"
+FLOG="$PREFIX/install_${FORMULA_TARGET}.log"
+printf '▸ malt install %s (formula sanity, logs → %s)\n' "$FORMULA_TARGET" "$FLOG"
+if ! "$BIN" install "$FORMULA_TARGET" >"$FLOG" 2>&1; then
+  skip "${FORMULA_TARGET} install failed (likely network); skipping formula sanity"
+else
+  grep -qE "${FORMULA_TARGET} [^ ]+ installed|✓ ${FORMULA_TARGET}.* installed" "$FLOG" ||
+    fail "${FORMULA_TARGET}: formula install line missing in log"
+  [[ -x "$PREFIX/bin/$FORMULA_TARGET" ]] ||
+    fail "${FORMULA_TARGET}: expected executable at \$PREFIX/bin/${FORMULA_TARGET}"
+  pass "${FORMULA_TARGET}: formula install path still works (tar.gz bottle)"
+fi
+
+printf '\n✔ gh136 tar.gz cask regression passed\n'

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -1,5 +1,5 @@
 //! malt — cask module
-//! Cask JSON parsing and installation (DMG, PKG, ZIP).
+//! Cask JSON parsing and installation (DMG, PKG, ZIP, tar.gz).
 
 const std = @import("std");
 const fs_compat = @import("../fs/compat.zig");
@@ -7,6 +7,7 @@ const fs_compat = @import("../fs/compat.zig");
 const sqlite = @import("../db/sqlite.zig");
 const client_mod = @import("../net/client.zig");
 const install_cmd = @import("../cli/install.zig");
+const archive_mod = @import("../fs/archive.zig");
 
 pub const CaskError = error{
     ParseFailed,
@@ -81,16 +82,22 @@ pub fn removeRecord(db: *sqlite.Database, token: []const u8) sqlite.SqliteError!
 }
 
 /// Determine the artifact type from the cask download URL.
-pub const ArtifactType = enum { dmg, zip, pkg, unknown };
+/// `tar_gz` covers both `.tar.gz` and `.tgz` — the two spellings are
+/// treated as a single container format here; the extractor is the same.
+pub const ArtifactType = enum { dmg, zip, pkg, tar_gz, unknown };
 
 pub fn artifactTypeFromUrl(url: []const u8) ArtifactType {
     if (std.mem.endsWith(u8, url, ".dmg")) return .dmg;
     if (std.mem.endsWith(u8, url, ".zip")) return .zip;
     if (std.mem.endsWith(u8, url, ".pkg")) return .pkg;
+    if (std.mem.endsWith(u8, url, ".tar.gz")) return .tar_gz;
+    if (std.mem.endsWith(u8, url, ".tgz")) return .tar_gz;
     // Some URLs have query params after extension
     if (std.mem.indexOf(u8, url, ".dmg?") != null or std.mem.indexOf(u8, url, ".dmg#") != null) return .dmg;
     if (std.mem.indexOf(u8, url, ".zip?") != null or std.mem.indexOf(u8, url, ".zip#") != null) return .zip;
     if (std.mem.indexOf(u8, url, ".pkg?") != null or std.mem.indexOf(u8, url, ".pkg#") != null) return .pkg;
+    if (std.mem.indexOf(u8, url, ".tar.gz?") != null or std.mem.indexOf(u8, url, ".tar.gz#") != null) return .tar_gz;
+    if (std.mem.indexOf(u8, url, ".tgz?") != null or std.mem.indexOf(u8, url, ".tgz#") != null) return .tar_gz;
     return .unknown;
 }
 
@@ -175,6 +182,49 @@ fn extractFilename(header: []const u8) ?[]const u8 {
 /// Extract the .app bundle name from cask JSON artifacts array.
 /// Homebrew cask JSON: "artifacts": [{"app": ["Firefox.app"]}, ...]
 pub fn parseAppName(obj: std.json.ObjectMap) ?[]const u8 {
+    const arr = firstArtifactArray(obj, "app") orelse return null;
+    if (arr.items.len == 0) return null;
+    return switch (arr.items[0]) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+/// Source name of the first `binary` artifact — the file to locate
+/// inside the extracted archive. Homebrew JSON shape:
+///   "artifacts": [{"binary": ["<source>"]}, ...]
+///   "artifacts": [{"binary": ["<source>", {"target": "<alias>"}]}, ...]
+pub fn parseBinaryName(obj: std.json.ObjectMap) ?[]const u8 {
+    const arr = firstArtifactArray(obj, "binary") orelse return null;
+    if (arr.items.len == 0) return null;
+    return switch (arr.items[0]) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+/// Rename hint for a `binary` artifact, e.g. the symlink should be
+/// `codex` while the file on disk is `codex-aarch64-apple-darwin`.
+/// Null when no target override is present.
+pub fn parseBinaryTarget(obj: std.json.ObjectMap) ?[]const u8 {
+    const arr = firstArtifactArray(obj, "binary") orelse return null;
+    for (arr.items[1..]) |item| {
+        switch (item) {
+            .object => |o| {
+                if (o.get("target")) |tv| {
+                    return switch (tv) {
+                        .string => |s| s,
+                        else => null,
+                    };
+                }
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn firstArtifactArray(obj: std.json.ObjectMap, key: []const u8) ?std.json.Array {
     const artifacts_val = obj.get("artifacts") orelse return null;
     const artifacts = switch (artifacts_val) {
         .array => |a| a,
@@ -183,16 +233,9 @@ pub fn parseAppName(obj: std.json.ObjectMap) ?[]const u8 {
     for (artifacts.items) |item| {
         switch (item) {
             .object => |art_obj| {
-                if (art_obj.get("app")) |app_val| {
-                    switch (app_val) {
-                        .array => |app_arr| {
-                            if (app_arr.items.len > 0) {
-                                return switch (app_arr.items[0]) {
-                                    .string => |s| s,
-                                    else => null,
-                                };
-                            }
-                        },
+                if (art_obj.get(key)) |val| {
+                    switch (val) {
+                        .array => |arr| return arr,
                         else => {},
                     }
                 }
@@ -252,6 +295,7 @@ pub const CaskInstaller = struct {
             .dmg => self.installDmg(cache_path, app_dir, cask) catch return CaskError.InstallFailed,
             .zip => self.installZip(cache_path, app_dir, cask) catch return CaskError.InstallFailed,
             .pkg => self.installPkg(cache_path) catch return CaskError.InstallFailed,
+            .tar_gz => self.installTarGz(cache_path, app_dir, cask) catch return CaskError.InstallFailed,
             .unknown => return CaskError.InstallFailed,
         };
 
@@ -301,7 +345,7 @@ pub const CaskInstaller = struct {
 
         // Remove cache entry
         var cache_buf: [512]u8 = undefined;
-        for ([_][]const u8{ ".dmg", ".zip", ".pkg" }) |ext| {
+        for ([_][]const u8{ ".dmg", ".zip", ".pkg", ".tar.gz" }) |ext| {
             const cache_file = std.fmt.bufPrint(&cache_buf, "{s}/cache/Cask/{s}{s}", .{ self.prefix, token, ext }) catch continue;
             fs_compat.cwd().deleteFile(cache_file) catch {};
         }
@@ -334,6 +378,7 @@ pub const CaskInstaller = struct {
             .dmg => ".dmg",
             .zip => ".zip",
             .pkg => ".pkg",
+            .tar_gz => ".tar.gz",
             .unknown => ".bin",
         };
         const dest = try std.fmt.allocPrint(self.allocator, "{s}/{s}{s}", .{ cache_dir, cask.token, ext_str });
@@ -475,6 +520,122 @@ pub const CaskInstaller = struct {
         return dst_app;
     }
 
+    /// Install a `.tar.gz` cask. Two shapes are supported:
+    ///   1. `binary` artifacts — extract into `Caskroom/<token>/<version>/`
+    ///      and symlink the first `binary` entry into `<prefix>/bin/`.
+    ///   2. `app` artifacts — extract and promote the `.app` to `app_dir`,
+    ///      mirroring the zip path for the rare tar.gz-wrapped bundle.
+    ///
+    /// Returns the bin symlink for binary casks, the `.app` path for app
+    /// casks — whichever the uninstaller needs to remove later.
+    fn installTarGz(
+        self: *CaskInstaller,
+        archive_path: []const u8,
+        app_dir: []const u8,
+        cask: *const Cask,
+    ) ![]const u8 {
+        // Caskroom/<token>/<version>/ doubles as the extraction root so
+        // the extracted payload is already at its final home — binaries
+        // then just need a stable symlink off `<prefix>/bin/`.
+        var caskroom_buf: [512]u8 = undefined;
+        const caskroom_ver = std.fmt.bufPrint(&caskroom_buf, "{s}/Caskroom/{s}/{s}", .{
+            self.prefix, cask.token, cask.version,
+        }) catch return error.InstallFailed;
+        fs_compat.cwd().makePath(caskroom_ver) catch return error.InstallFailed;
+
+        archive_mod.extractTarGz(archive_path, caskroom_ver) catch return error.InstallFailed;
+
+        if (parseBinaryName(cask.parsed.value.object)) |src_name| {
+            const link_name = parseBinaryTarget(cask.parsed.value.object) orelse
+                std.fs.path.basename(src_name);
+            return try self.linkCaskBinary(caskroom_ver, src_name, link_name);
+        }
+
+        // Fallback: .app inside a tar.gz (uncommon but valid). Reuse the
+        // zip path's "promote .app to app_dir" shape.
+        var app_name_buf: [256]u8 = undefined;
+        const app_name = parseAppName(cask.parsed.value.object) orelse
+            findAppInDir(caskroom_ver, &app_name_buf) orelse
+            return error.InstallFailed;
+
+        var src_buf: [512]u8 = undefined;
+        const src_app = std.fmt.bufPrint(&src_buf, "{s}/{s}", .{ caskroom_ver, app_name }) catch
+            return error.InstallFailed;
+
+        const dst_app = try std.fmt.allocPrint(self.allocator, "{s}/{s}", .{ app_dir, app_name });
+        errdefer self.allocator.free(dst_app);
+
+        fs_compat.deleteTreeAbsolute(dst_app) catch {};
+        const mv_argv = [_][]const u8{ "ditto", src_app, dst_app };
+        var mv_child = fs_compat.Child.init(&mv_argv, std.heap.c_allocator);
+        mv_child.spawn() catch return error.InstallFailed;
+        const mv_term = mv_child.wait() catch return error.InstallFailed;
+        switch (mv_term) {
+            .exited => |code| if (code != 0) return error.InstallFailed,
+            else => return error.InstallFailed,
+        }
+        return dst_app;
+    }
+
+    /// Resolve the source path of a `binary` artifact. Three shapes
+    /// appear in the wild:
+    ///   - Bare name (`copilot`) — walk the extraction tree.
+    ///   - Relative path (`darwin-arm64/btp`) — join to the extraction
+    ///     root; matches the `Caskroom/<token>/<version>/` layout.
+    ///   - Homebrew `$HOMEBREW_PREFIX/...` absolute path — rewrite the
+    ///     prefix to malt's active one; the tail already points at the
+    ///     extracted file since Caskroom lives under the prefix.
+    /// Returned slice is owned by the caller.
+    fn resolveCaskBinaryPath(self: *CaskInstaller, root: []const u8, src: []const u8) ![]u8 {
+        const env_prefix = "$HOMEBREW_PREFIX/";
+        if (std.mem.startsWith(u8, src, env_prefix)) {
+            return try std.fmt.allocPrint(
+                self.allocator,
+                "{s}/{s}",
+                .{ self.prefix, src[env_prefix.len..] },
+            );
+        }
+        if (std.mem.indexOfScalar(u8, src, '/') != null) {
+            return try std.fmt.allocPrint(self.allocator, "{s}/{s}", .{ root, src });
+        }
+        return (findFileInTree(self.allocator, root, src) catch null) orelse
+            error.InstallFailed;
+    }
+
+    /// Resolve `src_name` inside `caskroom_ver`, chmod +x, and symlink
+    /// it at `<prefix>/bin/<link_name>`. `src_name` and `link_name`
+    /// diverge when the cask uses the `binary [..., {target: ...}]`
+    /// rename form. Returns the symlink path — stored as `app_path` so
+    /// `uninstall` knows what to remove.
+    fn linkCaskBinary(
+        self: *CaskInstaller,
+        caskroom_ver: []const u8,
+        src_name: []const u8,
+        link_name: []const u8,
+    ) ![]const u8 {
+        const abs_bin = try self.resolveCaskBinaryPath(caskroom_ver, src_name);
+        defer self.allocator.free(abs_bin);
+
+        // Archives sometimes land without the x-bit when built on CI.
+        const exec_file = fs_compat.openFileAbsolute(abs_bin, .{ .mode = .read_write }) catch
+            return error.InstallFailed;
+        exec_file.chmod(0o755) catch {};
+        exec_file.close();
+
+        var bin_parent_buf: [512]u8 = undefined;
+        const bin_parent = std.fmt.bufPrint(&bin_parent_buf, "{s}/bin", .{self.prefix}) catch
+            return error.InstallFailed;
+        fs_compat.cwd().makePath(bin_parent) catch return error.InstallFailed;
+
+        const link_path = try std.fmt.allocPrint(self.allocator, "{s}/{s}", .{ bin_parent, link_name });
+        errdefer self.allocator.free(link_path);
+
+        // Replace any stale symlink/file so reinstalls are idempotent.
+        fs_compat.cwd().deleteFile(link_path) catch {};
+        fs_compat.symLinkAbsolute(abs_bin, link_path, .{}) catch return error.InstallFailed;
+        return link_path;
+    }
+
     fn installPkg(self: *CaskInstaller, pkg_path: []const u8) ![]const u8 {
         // PKG installs require sudo — the caller must confirm
         const argv = [_][]const u8{ "sudo", "installer", "-pkg", pkg_path, "-target", "/" };
@@ -503,6 +664,29 @@ pub const CaskInstaller = struct {
         fs_compat.cwd().makePath(caskroom_ver) catch {};
     }
 };
+
+/// Walk `root` looking for a regular file whose basename equals `name`
+/// and return its absolute path (owned by the caller). tar.gz archives
+/// often nest the binary one or two levels deep, so the installer can't
+/// assume it sits at the extraction root. Returns null on no match.
+pub fn findFileInTree(
+    allocator: std.mem.Allocator,
+    root: []const u8,
+    name: []const u8,
+) !?[]u8 {
+    var dir = fs_compat.openDirAbsolute(root, .{ .iterate = true }) catch return null;
+    defer dir.close();
+
+    var walker = dir.walk(allocator) catch return null;
+    defer walker.deinit();
+
+    while (walker.next() catch null) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.eql(u8, std.fs.path.basename(entry.path), name)) continue;
+        return try std.fmt.allocPrint(allocator, "{s}/{s}", .{ root, entry.path });
+    }
+    return null;
+}
 
 /// Scan `dir_path` for a `.app` bundle and copy its name into `out_buf`.
 /// Returns a slice of `out_buf` (owned by the caller) — the iterator's

--- a/tests/cask_resolve_test.zig
+++ b/tests/cask_resolve_test.zig
@@ -84,7 +84,24 @@ test "Content-Disposition: returns unknown for no filename" {
 test "Content-Disposition: returns unknown for non-matching extension" {
     try testing.expectEqual(
         cask.ArtifactType.unknown,
-        cask.artifactTypeFromContentDisposition("attachment; filename=\"archive.tar.gz\""),
+        cask.artifactTypeFromContentDisposition("attachment; filename=\"archive.bin\""),
+    );
+}
+
+// A `.tar.gz` filename surfaced through Content-Disposition must resolve
+// to tar_gz — download endpoints that 302 to a versioned release URL
+// sometimes expose the extension only via the header.
+test "Content-Disposition: extracts .tar.gz from filename" {
+    try testing.expectEqual(
+        cask.ArtifactType.tar_gz,
+        cask.artifactTypeFromContentDisposition("attachment; filename=\"release.tar.gz\""),
+    );
+}
+
+test "Content-Disposition: extracts .tgz from filename" {
+    try testing.expectEqual(
+        cask.ArtifactType.tar_gz,
+        cask.artifactTypeFromContentDisposition("attachment; filename=\"release.tgz\""),
     );
 }
 
@@ -147,7 +164,19 @@ test "resolveArtifactType handles Content-Disposition with unknown ext" {
     const result = cask.resolveArtifactType(
         testing.allocator,
         "https://example.com/download",
-        "attachment; filename=\"archive.tar.gz\"",
+        "attachment; filename=\"archive.bin\"",
     );
     try testing.expectEqual(cask.ArtifactType.unknown, result);
+}
+
+// The HEAD fallback must surface tar.gz for extensionless release URLs
+// (e.g. `releases/latest/download`) when the filename only appears in
+// the Content-Disposition header.
+test "resolveArtifactType falls back to Content-Disposition for .tar.gz" {
+    const result = cask.resolveArtifactType(
+        testing.allocator,
+        "https://releases.example.com/v1.0/download?build=arm",
+        "attachment; filename=\"tool.tar.gz\"",
+    );
+    try testing.expectEqual(cask.ArtifactType.tar_gz, result);
 }

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -30,7 +30,25 @@ test "artifactTypeFromUrl handles query params after .zip" {
 }
 
 test "artifactTypeFromUrl returns unknown for unsupported" {
-    try std.testing.expectEqual(cask.ArtifactType.unknown, cask.artifactTypeFromUrl("https://example.com/App.tar.gz"));
+    try std.testing.expectEqual(cask.ArtifactType.unknown, cask.artifactTypeFromUrl("https://example.com/App.bin"));
+}
+
+// `.tar.gz` and `.tgz` must map to the same tar_gz container, including
+// the query/fragment variants CDNs like to append.
+test "artifactTypeFromUrl detects .tar.gz" {
+    try std.testing.expectEqual(cask.ArtifactType.tar_gz, cask.artifactTypeFromUrl("https://example.com/app.tar.gz"));
+}
+
+test "artifactTypeFromUrl detects .tgz" {
+    try std.testing.expectEqual(cask.ArtifactType.tar_gz, cask.artifactTypeFromUrl("https://example.com/app.tgz"));
+}
+
+test "artifactTypeFromUrl handles query params after .tar.gz" {
+    try std.testing.expectEqual(cask.ArtifactType.tar_gz, cask.artifactTypeFromUrl("https://cdn.example.com/app.tar.gz?v=1"));
+}
+
+test "artifactTypeFromUrl handles fragment after .tgz" {
+    try std.testing.expectEqual(cask.ArtifactType.tar_gz, cask.artifactTypeFromUrl("https://cdn.example.com/app.tgz#sha=abc"));
 }
 
 // --- parseCask ---
@@ -101,6 +119,110 @@ test "parseAppName returns null for no artifacts" {
 
     const app_name = cask.parseAppName(c.parsed.value.object);
     try std.testing.expect(app_name == null);
+}
+
+// --- parseBinaryName ---
+//
+// tar.gz casks ship a CLI: the installable is the first entry of an
+// `artifacts[].binary` array, not an `app` bundle. parseBinaryName must
+// skip past unrelated artifact blocks (`zap`, `uninstall`, …) and return
+// the binary's basename.
+
+const binary_cask_json =
+    \\{
+    \\  "token": "tool",
+    \\  "name": ["Tool"],
+    \\  "version": "1.0.0",
+    \\  "desc": "Example CLI",
+    \\  "homepage": "https://example.com",
+    \\  "url": "https://example.com/tool-darwin-arm64.tar.gz",
+    \\  "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    \\  "auto_updates": true,
+    \\  "artifacts": [
+    \\    {"binary": ["tool"]},
+    \\    {"zap": [{"trash": "~/.tool"}]}
+    \\  ]
+    \\}
+;
+
+test "parseBinaryName extracts binary from artifacts" {
+    var c = try cask.parseCask(std.testing.allocator, binary_cask_json);
+    defer c.deinit();
+
+    const name = cask.parseBinaryName(c.parsed.value.object);
+    try std.testing.expect(name != null);
+    try std.testing.expectEqualStrings("tool", name.?);
+}
+
+test "parseBinaryName returns null for an app-only cask" {
+    // An app cask (Firefox) has no `binary` artifact — parseBinaryName
+    // must not mistakenly return the `app` entry.
+    var c = try cask.parseCask(std.testing.allocator, test_cask_json);
+    defer c.deinit();
+
+    try std.testing.expect(cask.parseBinaryName(c.parsed.value.object) == null);
+}
+
+test "parseAppName returns null for a binary-only cask" {
+    // Symmetric guard: the binary cask must not trip parseAppName.
+    var c = try cask.parseCask(std.testing.allocator, binary_cask_json);
+    defer c.deinit();
+
+    try std.testing.expect(cask.parseAppName(c.parsed.value.object) == null);
+}
+
+// Some casks ship a binary whose on-disk name differs from the command
+// users type — e.g. `codex` published as `codex-aarch64-apple-darwin`.
+// The Homebrew shape is `"binary": ["<src>", {"target": "<alias>"}]`.
+test "parseBinaryTarget extracts the rename target" {
+    const json =
+        \\{"token":"t","name":["T"],"version":"1","url":"https://x.com/a.tar.gz",
+        \\ "sha256":"no_check","homepage":"","desc":"","auto_updates":false,
+        \\ "artifacts":[{"binary":["tool-aarch64-apple-darwin",{"target":"tool"}]}]}
+    ;
+    var c = try cask.parseCask(std.testing.allocator, json);
+    defer c.deinit();
+
+    try std.testing.expectEqualStrings("tool-aarch64-apple-darwin", cask.parseBinaryName(c.parsed.value.object).?);
+    try std.testing.expectEqualStrings("tool", cask.parseBinaryTarget(c.parsed.value.object).?);
+}
+
+test "parseBinaryTarget returns null when no rename is present" {
+    var c = try cask.parseCask(std.testing.allocator, binary_cask_json);
+    defer c.deinit();
+
+    try std.testing.expect(cask.parseBinaryTarget(c.parsed.value.object) == null);
+}
+
+// Some casks encode the binary source as a relative path inside the
+// archive (e.g. `darwin-arm64/btp`). parseBinaryName must return the
+// raw source — path resolution is the installer's job.
+test "parseBinaryName preserves a path-qualified source" {
+    const json =
+        \\{"token":"t","name":["T"],"version":"1","url":"https://x.com/a.tar.gz",
+        \\ "sha256":"no_check","homepage":"","desc":"","auto_updates":false,
+        \\ "artifacts":[{"binary":["darwin-arm64/tool"]}]}
+    ;
+    var c = try cask.parseCask(std.testing.allocator, json);
+    defer c.deinit();
+
+    try std.testing.expectEqualStrings("darwin-arm64/tool", cask.parseBinaryName(c.parsed.value.object).?);
+}
+
+test "parseBinaryName skips non-binary artifact entries" {
+    // Order-insensitive: the binary can sit behind uninstall/zap blocks.
+    const json =
+        \\{"token":"t","name":["T"],"version":"1","url":"https://x.com/a.tar.gz",
+        \\ "sha256":"no_check","homepage":"","desc":"","auto_updates":false,
+        \\ "artifacts":[
+        \\   {"uninstall":[{"delete":"/tmp/x"}]},
+        \\   {"binary":["cli"]}
+        \\ ]}
+    ;
+    var c = try cask.parseCask(std.testing.allocator, json);
+    defer c.deinit();
+
+    try std.testing.expectEqualStrings("cli", cask.parseBinaryName(c.parsed.value.object).?);
 }
 
 // --- DB operations ---
@@ -464,6 +586,68 @@ test "findAppInDir returns null when no .app bundle is present" {
 
     var out: [64]u8 = undefined;
     try testing.expect(cask.findAppInDir(dir_path, &out) == null);
+}
+
+// ── findFileInTree: locates the binary inside a nested archive ──────
+
+test "findFileInTree returns absolute path for a file at the root" {
+    var dir_buf: [128]u8 = undefined;
+    const dir_path = try scratchDir("flat", &dir_buf);
+    defer malt_fs.deleteTreeAbsolute(dir_path) catch {};
+
+    var file_buf: [256]u8 = undefined;
+    const file_path = try std.fmt.bufPrint(&file_buf, "{s}/tool", .{dir_path});
+    const f = try malt_fs.createFileAbsolute(file_path, .{});
+    f.close();
+
+    const got = (try cask.findFileInTree(testing.allocator, dir_path, "tool")) orelse
+        return error.TestUnexpectedResult;
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings(file_path, got);
+}
+
+test "findFileInTree finds a binary nested one level deep" {
+    // Archives often wrap the binary in a versioned dir (e.g.
+    // `tool-darwin-arm64/tool`). The installer must walk past that
+    // wrapper to link the binary.
+    var dir_buf: [128]u8 = undefined;
+    const dir_path = try scratchDir("nested", &dir_buf);
+    defer malt_fs.deleteTreeAbsolute(dir_path) catch {};
+
+    var sub_buf: [256]u8 = undefined;
+    const sub = try std.fmt.bufPrint(&sub_buf, "{s}/tool-darwin-arm64", .{dir_path});
+    try malt_fs.makeDirAbsolute(sub);
+
+    var file_buf: [384]u8 = undefined;
+    const file_path = try std.fmt.bufPrint(&file_buf, "{s}/tool", .{sub});
+    const f = try malt_fs.createFileAbsolute(file_path, .{});
+    f.close();
+
+    const got = (try cask.findFileInTree(testing.allocator, dir_path, "tool")) orelse
+        return error.TestUnexpectedResult;
+    defer testing.allocator.free(got);
+    try testing.expect(std.mem.endsWith(u8, got, "/tool-darwin-arm64/tool"));
+}
+
+test "findFileInTree returns null when the file is absent" {
+    var dir_buf: [128]u8 = undefined;
+    const dir_path = try scratchDir("absent", &dir_buf);
+    defer malt_fs.deleteTreeAbsolute(dir_path) catch {};
+
+    try testing.expect((try cask.findFileInTree(testing.allocator, dir_path, "tool")) == null);
+}
+
+test "findFileInTree ignores directories sharing the basename" {
+    // A directory matching `name` must not masquerade as the binary.
+    var dir_buf: [128]u8 = undefined;
+    const dir_path = try scratchDir("dironly", &dir_buf);
+    defer malt_fs.deleteTreeAbsolute(dir_path) catch {};
+
+    var sub_buf: [256]u8 = undefined;
+    const sub = try std.fmt.bufPrint(&sub_buf, "{s}/tool", .{dir_path});
+    try malt_fs.makeDirAbsolute(sub);
+
+    try testing.expect((try cask.findFileInTree(testing.allocator, dir_path, "tool")) == null);
 }
 
 test "findAppInDir returns null when the .app name exceeds the out-buffer" {


### PR DESCRIPTION
## Description

`mt install <token>` now handles `.tar.gz` and `.tgz` casks - the shape a majority of GoReleaser-packaged macOS CLIs ship on (copilot-cli, fly, codex, dda, filemon, ...). The binary is extracted into `Caskroom/<token>/<version>/` and symlinked onto `$MALT_PREFIX/bin`, so these tools land on `$PATH` the same way a formula's keg does.

Before, every tar.gz cask bounced at the format gate with "Unsupported cask format".

## Related Issue

Fixes #136

## Notes for Reviewers

- None