### PR TITLE
refactor(core/dsl/parser): split parsePrimary into form-specific helpers

### DIFF
--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -339,79 +339,114 @@ pub const Parser = struct {
         var args: std.ArrayList(*const Node) = .empty;
         var block_pass: ?*const Node = null;
         if (self.current.kind == .lparen) {
-            self.advanceToken();
-            while (self.current.kind != .rparen and self.current.kind != .eof) {
-                self.skipNewlines();
-                if (self.current.kind == .rparen) break;
-                switch (try self.parseOneArg()) {
-                    .arg => |a| args.append(self.allocator, a) catch return DslError.OutOfMemory,
-                    .block_pass => |bp| {
-                        block_pass = bp;
-                        break;
-                    },
-                }
-                self.skipNewlines();
-                if (self.current.kind == .comma) {
-                    self.advanceToken();
-                    self.skipNewlines();
-                }
-            }
-            if (self.current.kind == .rparen) self.advanceToken();
-        } else if (isExprStart(self.current.kind) and
-            self.current.kind != .newline and
-            self.current.kind != .kw_if and
-            self.current.kind != .kw_unless and
-            self.current.kind != .kw_do and
-            self.current.kind != .kw_end and
-            self.current.kind != .dot)
-        {
+            try self.parseParenArgList(&args, &block_pass);
+        } else if (self.currentLooksLikeBareArg()) {
             // Bare arguments (no parens) — common for ohai, system, etc.
-            const arg = try self.parseExpression();
-            args.append(self.allocator, arg) catch return DslError.OutOfMemory;
-            while (self.current.kind == .comma) {
+            try self.parseBareArgList(&args, &block_pass);
+        }
+
+        return self.finishCallWithBlock(loc, receiver, method, &args, block_pass);
+    }
+
+    /// Shared bare-argument guard: the current token could start an
+    /// expression AND is not one of the keywords that signal statement
+    /// boundaries (if/unless/end/do/dot/newline). Used by every call
+    /// form that accepts paren-less arguments.
+    fn currentLooksLikeBareArg(self: *const Parser) bool {
+        const k = self.current.kind;
+        return isExprStart(k) and k != .newline and k != .kw_if and
+            k != .kw_unless and k != .kw_end and k != .kw_do and k != .dot;
+    }
+
+    /// Collect a paren-delimited argument list; stops at the matching
+    /// `)` or on a block-pass `&<primary>`. Consumes the closing paren.
+    fn parseParenArgList(
+        self: *Parser,
+        args: *std.ArrayList(*const Node),
+        block_pass_out: *?*const Node,
+    ) DslError!void {
+        self.advanceToken(); // consume '('
+        while (self.current.kind != .rparen and self.current.kind != .eof) {
+            self.skipNewlines();
+            if (self.current.kind == .rparen) break;
+            switch (try self.parseOneArg()) {
+                .arg => |a| args.append(self.allocator, a) catch return DslError.OutOfMemory,
+                .block_pass => |bp| {
+                    block_pass_out.* = bp;
+                    break;
+                },
+            }
+            self.skipNewlines();
+            if (self.current.kind == .comma) {
                 self.advanceToken();
                 self.skipNewlines();
-                switch (try self.parseOneArg()) {
-                    .arg => |a| args.append(self.allocator, a) catch return DslError.OutOfMemory,
-                    .block_pass => |bp| {
-                        block_pass = bp;
-                        break;
-                    },
-                }
             }
         }
+        if (self.current.kind == .rparen) self.advanceToken();
+    }
 
-        // Parse optional block
-        var blk: ?*const Node = null;
-        var block_params: std.ArrayList([]const u8) = .empty;
-        if (self.current.kind == .kw_do) {
+    /// Collect a paren-less bare argument list (`method a, b, &:sym`).
+    /// The caller has already verified `currentLooksLikeBareArg()`.
+    fn parseBareArgList(
+        self: *Parser,
+        args: *std.ArrayList(*const Node),
+        block_pass_out: *?*const Node,
+    ) DslError!void {
+        const first = try self.parseExpression();
+        args.append(self.allocator, first) catch return DslError.OutOfMemory;
+        while (self.current.kind == .comma) {
             self.advanceToken();
-            try self.parseBlockParams(&block_params);
-            const body = try self.parseBlock();
-            if (self.current.kind == .kw_end) self.advanceToken();
-            blk = try self.allocNode(.{
-                .loc = loc,
-                .kind = .{ .block = body },
-            });
-        } else if (self.current.kind == .lbrace) {
-            self.advanceToken();
-            try self.parseBlockParams(&block_params);
-            const body = try self.parseBlock();
-            if (self.current.kind == .rbrace) self.advanceToken();
-            blk = try self.allocNode(.{
-                .loc = loc,
-                .kind = .{ .block = body },
-            });
+            self.skipNewlines();
+            switch (try self.parseOneArg()) {
+                .arg => |a| args.append(self.allocator, a) catch return DslError.OutOfMemory,
+                .block_pass => |bp| {
+                    block_pass_out.* = bp;
+                    break;
+                },
+            }
         }
+    }
 
+    /// Consume an optional `do |params| … end` or `{ |params| … }` tail
+    /// and return the resulting block node, or null if neither is
+    /// present. Block params are appended into `params_out`.
+    fn parseOptionalBlock(
+        self: *Parser,
+        loc: SourceLoc,
+        params_out: *std.ArrayList([]const u8),
+    ) DslError!?*const Node {
+        const close: TokenKind = switch (self.current.kind) {
+            .kw_do => .kw_end,
+            .lbrace => .rbrace,
+            else => return null,
+        };
+        self.advanceToken();
+        try self.parseBlockParams(params_out);
+        const body = try self.parseBlock();
+        if (self.current.kind == close) self.advanceToken();
+        return try self.allocNode(.{ .loc = loc, .kind = .{ .block = body } });
+    }
+
+    /// Finalise a method_call node: handle the optional block tail and
+    /// own the args / block_params slices. Shared between every call
+    /// form so the ownership/cleanup pattern lives in one place.
+    fn finishCallWithBlock(
+        self: *Parser,
+        loc: SourceLoc,
+        receiver: ?*const Node,
+        name: []const u8,
+        args: *std.ArrayList(*const Node),
+        block_pass: ?*const Node,
+    ) DslError!*const Node {
+        var block_params: std.ArrayList([]const u8) = .empty;
+        const blk = try self.parseOptionalBlock(loc, &block_params);
         const args_slice = args.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
         const params_slice = block_params.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
-
         return self.allocNode(.{
             .loc = loc,
             .kind = .{ .method_call = .{
                 .receiver = receiver,
-                .method = method,
+                .method = name,
                 .args = args_slice,
                 .blk = blk,
                 .block_params = params_slice,
@@ -420,551 +455,345 @@ pub const Parser = struct {
         });
     }
 
+    /// Dispatches one primary production to its form-specific helper.
+    /// Each helper captures its own `loc`, advances past its tokens,
+    /// and returns a fully-constructed Node. No shared mutation here.
     fn parsePrimary(self: *Parser) DslError!*const Node {
+        return switch (self.current.kind) {
+            .string_double => self.parseDoubleQuotedString(),
+            .string_single => self.parseSingleQuotedString(),
+            .percent_w => self.parsePercentWArray(),
+            .heredoc_start => self.parseHeredocStart(),
+            .heredoc_body => self.parseHeredocBody(),
+            .integer => self.parseIntegerLit(),
+            .float_lit => self.parseFloatLit(),
+            .kw_true => self.parseBoolLit(true),
+            .kw_false => self.parseBoolLit(false),
+            .kw_nil => self.parseNilLit(),
+            .symbol => self.parseSymbolLit(),
+            .regex => self.parseRegexLit(),
+            .identifier => self.parseIdentifierForm(),
+            .lbracket => self.parseArrayLit(),
+            .lbrace => self.parseHashLit(),
+            .lparen => self.parseParenExpr(),
+            else => self.emitError("unexpected token in expression"),
+        };
+    }
+
+    fn parseDoubleQuotedString(self: *Parser) DslError!*const Node {
         const loc = self.currentLoc();
+        const raw = self.current.lexeme;
+        self.advanceToken();
+        // Strip surrounding `"..."`, then lower `#{...}` into interpolation parts.
+        const content = if (raw.len >= 2) raw[1 .. raw.len - 1] else raw;
+        const parts = try self.parseStringInterpolation(content, loc);
+        return self.allocNode(.{
+            .loc = loc,
+            .kind = .{ .string_literal = .{ .parts = parts } },
+        });
+    }
 
-        switch (self.current.kind) {
-            .string_double => {
-                const raw = self.current.lexeme;
+    fn parseSingleQuotedString(self: *Parser) DslError!*const Node {
+        const loc = self.currentLoc();
+        const raw = self.current.lexeme;
+        self.advanceToken();
+        // Single-quoted strings have no interpolation — one literal part.
+        const content = if (raw.len >= 2) raw[1 .. raw.len - 1] else raw;
+        const parts = self.allocator.alloc(ast.StringPart, 1) catch return DslError.OutOfMemory;
+        parts[0] = .{ .literal = content };
+        return self.allocNode(.{
+            .loc = loc,
+            .kind = .{ .string_literal = .{ .parts = parts } },
+        });
+    }
+
+    fn parseHeredocStart(self: *Parser) DslError!*const Node {
+        const loc = self.currentLoc();
+        self.advanceToken();
+        const body = if (self.current.kind == .heredoc_body) self.current.lexeme else "";
+        if (self.current.kind == .heredoc_body) self.advanceToken();
+        return self.allocNode(.{ .loc = loc, .kind = .{ .heredoc_literal = body } });
+    }
+
+    fn parseHeredocBody(self: *Parser) DslError!*const Node {
+        const loc = self.currentLoc();
+        const body = self.current.lexeme;
+        self.advanceToken();
+        return self.allocNode(.{ .loc = loc, .kind = .{ .heredoc_literal = body } });
+    }
+
+    fn parseIntegerLit(self: *Parser) DslError!*const Node {
+        const loc = self.currentLoc();
+        const val = parseIntValue(self.current.lexeme);
+        self.advanceToken();
+        return self.allocNode(.{ .loc = loc, .kind = .{ .int_literal = val } });
+    }
+
+    fn parseFloatLit(self: *Parser) DslError!*const Node {
+        const loc = self.currentLoc();
+        const val = std.fmt.parseFloat(f64, self.current.lexeme) catch 0.0;
+        self.advanceToken();
+        return self.allocNode(.{ .loc = loc, .kind = .{ .float_literal = val } });
+    }
+
+    fn parseBoolLit(self: *Parser, v: bool) DslError!*const Node {
+        const loc = self.currentLoc();
+        self.advanceToken();
+        return self.allocNode(.{ .loc = loc, .kind = .{ .bool_literal = v } });
+    }
+
+    fn parseNilLit(self: *Parser) DslError!*const Node {
+        const loc = self.currentLoc();
+        self.advanceToken();
+        return self.allocNode(.{ .loc = loc, .kind = .{ .nil_literal = {} } });
+    }
+
+    fn parseSymbolLit(self: *Parser) DslError!*const Node {
+        const loc = self.currentLoc();
+        const raw = self.current.lexeme;
+        self.advanceToken();
+        // Strip the leading `:`; the lexeme is `:name`.
+        const name = if (raw.len > 1) raw[1..] else raw;
+        return self.allocNode(.{ .loc = loc, .kind = .{ .symbol_literal = name } });
+    }
+
+    /// Regex literals are stored as a single-part string literal until
+    /// a real regex engine is added; keeps the interpreter path uniform.
+    fn parseRegexLit(self: *Parser) DslError!*const Node {
+        const loc = self.currentLoc();
+        const raw = self.current.lexeme;
+        self.advanceToken();
+        const parts = self.allocator.alloc(ast.StringPart, 1) catch return DslError.OutOfMemory;
+        parts[0] = .{ .literal = raw };
+        return self.allocNode(.{
+            .loc = loc,
+            .kind = .{ .string_literal = .{ .parts = parts } },
+        });
+    }
+
+    fn parsePercentWArray(self: *Parser) DslError!*const Node {
+        const loc = self.currentLoc();
+        // %w[word1 word2 ...] — split by whitespace into a string array.
+        // Pre-count and bulk-allocate so a typical %w[...] costs three
+        // allocs (StringParts, Nodes, *Node slice) instead of 1+2*N.
+        const content = self.current.lexeme;
+        self.advanceToken();
+
+        var counter = std.mem.tokenizeAny(u8, content, " \t\n\r");
+        var n: usize = 0;
+        while (counter.next()) |_| n += 1;
+        if (n == 0) {
+            const empty: []const *const Node = &.{};
+            return self.allocNode(.{ .loc = loc, .kind = .{ .array_literal = empty } });
+        }
+
+        const parts = self.allocator.alloc(ast.StringPart, n) catch return DslError.OutOfMemory;
+        const nodes = self.allocator.alloc(Node, n) catch return DslError.OutOfMemory;
+        const elems = self.allocator.alloc(*const Node, n) catch return DslError.OutOfMemory;
+
+        var it = std.mem.tokenizeAny(u8, content, " \t\n\r");
+        var i: usize = 0;
+        while (it.next()) |word| : (i += 1) {
+            parts[i] = .{ .literal = word };
+            nodes[i] = .{
+                .loc = loc,
+                .kind = .{ .string_literal = .{ .parts = parts[i .. i + 1] } },
+            };
+            elems[i] = &nodes[i];
+        }
+        return self.allocNode(.{ .loc = loc, .kind = .{ .array_literal = elems } });
+    }
+
+    fn parseArrayLit(self: *Parser) DslError!*const Node {
+        const loc = self.currentLoc();
+        self.advanceToken(); // '['
+        var elems: std.ArrayList(*const Node) = .empty;
+        while (self.current.kind != .rbracket and self.current.kind != .eof) {
+            self.skipNewlines();
+            if (self.current.kind == .rbracket) break;
+            const elem = try self.parseExpression();
+            elems.append(self.allocator, elem) catch return DslError.OutOfMemory;
+            self.skipNewlines();
+            if (self.current.kind == .comma) self.advanceToken();
+        }
+        if (self.current.kind == .rbracket) self.advanceToken();
+        const slice = elems.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
+        return self.allocNode(.{ .loc = loc, .kind = .{ .array_literal = slice } });
+    }
+
+    fn parseHashLit(self: *Parser) DslError!*const Node {
+        const loc = self.currentLoc();
+        self.advanceToken(); // '{'
+        var entries: std.ArrayList(ast.HashEntry) = .empty;
+        while (self.current.kind != .rbrace and self.current.kind != .eof) {
+            self.skipNewlines();
+            if (self.current.kind == .rbrace) break;
+
+            // Ruby's `{ name: value }` shorthand lowers to a symbol key —
+            // recognise `identifier:` (single colon, not `::`) so the
+            // identifier does not resolve as a method at eval time.
+            const key_loc = self.currentLoc();
+            var key: *const Node = undefined;
+            if (self.current.kind == .identifier) {
+                const lex_before = self.lexer.*;
+                const ident_lexeme = self.current.lexeme;
                 self.advanceToken();
-                // Strip quotes
-                const content = if (raw.len >= 2) raw[1 .. raw.len - 1] else raw;
-                // Parse interpolation segments #{...}
-                const parts = try self.parseStringInterpolation(content, loc);
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .string_literal = .{ .parts = parts } },
-                });
-            },
-            .string_single => {
-                const raw = self.current.lexeme;
-                self.advanceToken();
-                // Strip quotes — single-quoted strings have no interpolation
-                const content = if (raw.len >= 2) raw[1 .. raw.len - 1] else raw;
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .string_literal = .{
-                        .parts = blk: {
-                            const parts = self.allocator.alloc(ast.StringPart, 1) catch return DslError.OutOfMemory;
-                            parts[0] = .{ .literal = content };
-                            break :blk parts;
-                        },
-                    } },
-                });
-            },
-            .percent_w => {
-                // %w[word1 word2 ...] — split by whitespace into a string
-                // array. Pre-count and bulk-allocate so a typical %w[...]
-                // costs three allocs (StringParts, Nodes, *Node slice)
-                // instead of 1+2*N from the previous per-word loop.
-                const content = self.current.lexeme;
-                self.advanceToken();
-
-                var counter = std.mem.tokenizeAny(u8, content, " \t\n\r");
-                var n: usize = 0;
-                while (counter.next()) |_| n += 1;
-                if (n == 0) {
-                    const empty: []const *const Node = &.{};
-                    return self.allocNode(.{
-                        .loc = loc,
-                        .kind = .{ .array_literal = empty },
-                    });
-                }
-
-                const parts = self.allocator.alloc(ast.StringPart, n) catch return DslError.OutOfMemory;
-                const nodes = self.allocator.alloc(Node, n) catch return DslError.OutOfMemory;
-                const elems = self.allocator.alloc(*const Node, n) catch return DslError.OutOfMemory;
-
-                var it = std.mem.tokenizeAny(u8, content, " \t\n\r");
-                var i: usize = 0;
-                while (it.next()) |word| : (i += 1) {
-                    parts[i] = .{ .literal = word };
-                    nodes[i] = .{
-                        .loc = loc,
-                        .kind = .{ .string_literal = .{ .parts = parts[i .. i + 1] } },
-                    };
-                    elems[i] = &nodes[i];
-                }
-
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .array_literal = elems },
-                });
-            },
-            .heredoc_start => {
-                // Advance past start, next token should be heredoc_body
-                self.advanceToken();
-                const body_lexeme = if (self.current.kind == .heredoc_body) self.current.lexeme else "";
-                if (self.current.kind == .heredoc_body) self.advanceToken();
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .heredoc_literal = body_lexeme },
-                });
-            },
-            .heredoc_body => {
-                const body_lexeme = self.current.lexeme;
-                self.advanceToken();
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .heredoc_literal = body_lexeme },
-                });
-            },
-            .integer => {
-                const val = parseIntValue(self.current.lexeme);
-                self.advanceToken();
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .int_literal = val },
-                });
-            },
-            .float_lit => {
-                const val = std.fmt.parseFloat(f64, self.current.lexeme) catch 0.0;
-                self.advanceToken();
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .float_literal = val },
-                });
-            },
-            .kw_true => {
-                self.advanceToken();
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .bool_literal = true },
-                });
-            },
-            .kw_false => {
-                self.advanceToken();
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .bool_literal = false },
-                });
-            },
-            .kw_nil => {
-                self.advanceToken();
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .nil_literal = {} },
-                });
-            },
-            .symbol => {
-                const raw = self.current.lexeme;
-                self.advanceToken();
-                // Strip leading :
-                const name = if (raw.len > 1) raw[1..] else raw;
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .symbol_literal = name },
-                });
-            },
-            .regex => {
-                // Store regex as a string for now
-                const raw = self.current.lexeme;
-                self.advanceToken();
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .string_literal = .{
-                        .parts = blk: {
-                            const parts = self.allocator.alloc(ast.StringPart, 1) catch return DslError.OutOfMemory;
-                            parts[0] = .{ .literal = raw };
-                            break :blk parts;
-                        },
-                    } },
-                });
-            },
-            .identifier => {
-                const name = self.current.lexeme;
-
-                // --- Dir[expr] → Dir.glob(expr) ---
-                if (std.mem.eql(u8, name, "Dir")) {
-                    // `lexer.peek()` saves *every* field `next()` may
-                    // mutate — including the heredoc state — so a
-                    // `Dir<<~EOS` peek restores cleanly instead of
-                    // leaving the lexer mid-collection.
-                    const peek_tok = self.lexer.peek();
-                    if (peek_tok.kind == .lbracket) {
-                        self.advanceToken(); // consume "Dir"
-                        self.advanceToken(); // consume "["
-                        var args: std.ArrayList(*const Node) = .empty;
-                        while (self.current.kind != .rbracket and self.current.kind != .eof) {
-                            const arg = try self.parseExpression();
-                            args.append(self.allocator, arg) catch return DslError.OutOfMemory;
-                            if (self.current.kind == .comma) {
-                                self.advanceToken();
-                                self.skipNewlines();
-                            }
-                        }
-                        if (self.current.kind == .rbracket) self.advanceToken();
-                        const args_slice = args.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
-                        return self.allocNode(.{
-                            .loc = loc,
-                            .kind = .{ .method_call = .{
-                                .receiver = null,
-                                .method = "Dir.glob",
-                                .args = args_slice,
-                                .blk = null,
-                                .block_params = &.{},
-                            } },
-                        });
-                    }
-                }
-
-                // --- Formula["name"] → Formula.lookup(name) ---
-                if (std.mem.eql(u8, name, "Formula")) {
-                    // Same reasoning as the `Dir` peek above: only
-                    // `lexer.peek()` saves the heredoc state.
-                    const peek_tok3 = self.lexer.peek();
-                    if (peek_tok3.kind == .lbracket) {
-                        self.advanceToken(); // consume "Formula"
-                        self.advanceToken(); // consume "["
-                        const name_expr = try self.parseExpression();
-                        if (self.current.kind == .rbracket) self.advanceToken();
-                        const args = self.allocator.alloc(*const Node, 1) catch return DslError.OutOfMemory;
-                        args[0] = name_expr;
-                        return self.allocNode(.{
-                            .loc = loc,
-                            .kind = .{ .method_call = .{
-                                .receiver = null,
-                                .method = "Formula.lookup",
-                                .args = args,
-                                .blk = null,
-                                .block_params = &.{},
-                            } },
-                        });
-                    }
-                }
-
-                // --- ENV["key"] read / ENV["key"] = value write ---
-                if (std.mem.eql(u8, name, "ENV")) {
-                    // Same reasoning as the `Dir` peek above: only
-                    // `lexer.peek()` saves the heredoc state.
-                    const peek_tok2 = self.lexer.peek();
-                    if (peek_tok2.kind == .lbracket) {
-                        self.advanceToken(); // consume "ENV"
-                        self.advanceToken(); // consume "["
-                        const key_expr = try self.parseExpression();
-                        if (self.current.kind == .rbracket) self.advanceToken();
-
-                        // Check for assignment: ENV["key"] = value
-                        if (self.current.kind == .equals) {
-                            self.advanceToken(); // consume =
-                            const val_expr = try self.parseExpression();
-                            // Emit as method_call to "ENV.set" with key and value args
-                            var args: std.ArrayList(*const Node) = .empty;
-                            args.append(self.allocator, key_expr) catch return DslError.OutOfMemory;
-                            args.append(self.allocator, val_expr) catch return DslError.OutOfMemory;
-                            const args_slice = args.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
-                            return self.allocNode(.{
-                                .loc = loc,
-                                .kind = .{ .method_call = .{
-                                    .receiver = null,
-                                    .method = "ENV.set",
-                                    .args = args_slice,
-                                    .blk = null,
-                                    .block_params = &.{},
-                                } },
-                            });
-                        }
-
-                        // Read form: ENV["key"]
-                        var args: std.ArrayList(*const Node) = .empty;
-                        args.append(self.allocator, key_expr) catch return DslError.OutOfMemory;
-                        const args_slice = args.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
-                        return self.allocNode(.{
-                            .loc = loc,
-                            .kind = .{ .method_call = .{
-                                .receiver = null,
-                                .method = "ENV.get",
-                                .args = args_slice,
-                                .blk = null,
-                                .block_params = &.{},
-                            } },
-                        });
-                    }
-                }
-
-                self.advanceToken();
-
-                // For methods that are ALWAYS bare-call (never use parens),
-                // parse args as expressions — `cp (expr).method, dest`
-                // needs `(expr)` parsed as grouped expression, not arg-list delimiters.
-                if (isAlwaysBareMethod(name) and isExprStart(self.current.kind) and
-                    self.current.kind != .newline and
-                    self.current.kind != .kw_if and
-                    self.current.kind != .kw_unless and
-                    self.current.kind != .kw_end and
-                    self.current.kind != .kw_do and
-                    self.current.kind != .dot)
-                {
-                    var args: std.ArrayList(*const Node) = .empty;
-                    var block_pass: ?*const Node = null;
-                    const arg = try self.parseExpression();
-                    args.append(self.allocator, arg) catch return DslError.OutOfMemory;
-                    while (self.current.kind == .comma) {
-                        self.advanceToken();
-                        self.skipNewlines();
-                        switch (try self.parseOneArg()) {
-                            .arg => |a| args.append(self.allocator, a) catch return DslError.OutOfMemory,
-                            .block_pass => |bp| {
-                                block_pass = bp;
-                                break;
-                            },
-                        }
-                    }
-
-                    // Parse optional block
-                    var blk: ?*const Node = null;
-                    var block_params: std.ArrayList([]const u8) = .empty;
-                    if (self.current.kind == .kw_do) {
-                        self.advanceToken();
-                        try self.parseBlockParams(&block_params);
-                        const body = try self.parseBlock();
-                        if (self.current.kind == .kw_end) self.advanceToken();
-                        blk = try self.allocNode(.{
-                            .loc = loc,
-                            .kind = .{ .block = body },
-                        });
-                    } else if (self.current.kind == .lbrace) {
-                        self.advanceToken();
-                        try self.parseBlockParams(&block_params);
-                        const body = try self.parseBlock();
-                        if (self.current.kind == .rbrace) self.advanceToken();
-                        blk = try self.allocNode(.{
-                            .loc = loc,
-                            .kind = .{ .block = body },
-                        });
-                    }
-
-                    const args_slice = args.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
-                    const params_slice = block_params.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
-
-                    return self.allocNode(.{
-                        .loc = loc,
-                        .kind = .{ .method_call = .{
-                            .receiver = null,
-                            .method = name,
-                            .args = args_slice,
-                            .blk = blk,
-                            .block_params = params_slice,
-                            .block_pass = block_pass,
-                        } },
-                    });
-                }
-
-                // Non-bare method call with parens: method(args)
-                if (self.current.kind == .lparen) {
-                    // method(args) — may end with `&<primary>` block-pass.
+                if (self.current.kind == .colon) {
                     self.advanceToken();
-                    var args: std.ArrayList(*const Node) = .empty;
-                    var block_pass: ?*const Node = null;
-                    while (self.current.kind != .rparen and self.current.kind != .eof) {
-                        switch (try self.parseOneArg()) {
-                            .arg => |a| args.append(self.allocator, a) catch return DslError.OutOfMemory,
-                            .block_pass => |bp| {
-                                block_pass = bp;
-                                break;
-                            },
-                        }
-                        if (self.current.kind == .comma) {
-                            self.advanceToken();
-                            self.skipNewlines();
-                        }
-                    }
-                    if (self.current.kind == .rparen) self.advanceToken();
-
-                    // Parse optional block
-                    var blk: ?*const Node = null;
-                    var block_params: std.ArrayList([]const u8) = .empty;
-                    if (self.current.kind == .kw_do) {
-                        self.advanceToken();
-                        try self.parseBlockParams(&block_params);
-                        const body = try self.parseBlock();
-                        if (self.current.kind == .kw_end) self.advanceToken();
-                        blk = try self.allocNode(.{
-                            .loc = loc,
-                            .kind = .{ .block = body },
-                        });
-                    } else if (self.current.kind == .lbrace) {
-                        self.advanceToken();
-                        try self.parseBlockParams(&block_params);
-                        const body = try self.parseBlock();
-                        if (self.current.kind == .rbrace) self.advanceToken();
-                        blk = try self.allocNode(.{
-                            .loc = loc,
-                            .kind = .{ .block = body },
-                        });
-                    }
-
-                    const args_slice = args.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
-                    const params_slice = block_params.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
-
-                    return self.allocNode(.{
-                        .loc = loc,
-                        .kind = .{ .method_call = .{
-                            .receiver = null,
-                            .method = name,
-                            .args = args_slice,
-                            .blk = blk,
-                            .block_params = params_slice,
-                            .block_pass = block_pass,
-                        } },
+                    key = try self.allocNode(.{
+                        .loc = key_loc,
+                        .kind = .{ .symbol_literal = ident_lexeme },
                     });
-                }
-
-                // Check if this is a bare method call with arguments (no parens)
-                // Only for known methods that take bare args
-                if (isBareCallMethod(name) and isExprStart(self.current.kind) and
-                    self.current.kind != .newline and
-                    self.current.kind != .kw_if and
-                    self.current.kind != .kw_unless and
-                    self.current.kind != .kw_end and
-                    self.current.kind != .kw_do and
-                    self.current.kind != .dot)
-                {
-                    var args: std.ArrayList(*const Node) = .empty;
-                    var block_pass: ?*const Node = null;
-                    const arg = try self.parseExpression();
-                    args.append(self.allocator, arg) catch return DslError.OutOfMemory;
-                    while (self.current.kind == .comma) {
-                        self.advanceToken();
-                        self.skipNewlines();
-                        switch (try self.parseOneArg()) {
-                            .arg => |a| args.append(self.allocator, a) catch return DslError.OutOfMemory,
-                            .block_pass => |bp| {
-                                block_pass = bp;
-                                break;
-                            },
-                        }
-                    }
-
-                    // Parse optional block
-                    var blk: ?*const Node = null;
-                    var block_params: std.ArrayList([]const u8) = .empty;
-                    if (self.current.kind == .kw_do) {
-                        self.advanceToken();
-                        try self.parseBlockParams(&block_params);
-                        const body = try self.parseBlock();
-                        if (self.current.kind == .kw_end) self.advanceToken();
-                        blk = try self.allocNode(.{
-                            .loc = loc,
-                            .kind = .{ .block = body },
-                        });
-                    } else if (self.current.kind == .lbrace) {
-                        self.advanceToken();
-                        try self.parseBlockParams(&block_params);
-                        const body = try self.parseBlock();
-                        if (self.current.kind == .rbrace) self.advanceToken();
-                        blk = try self.allocNode(.{
-                            .loc = loc,
-                            .kind = .{ .block = body },
-                        });
-                    }
-
-                    const args_slice = args.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
-                    const params_slice = block_params.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
-
-                    return self.allocNode(.{
-                        .loc = loc,
-                        .kind = .{ .method_call = .{
-                            .receiver = null,
-                            .method = name,
-                            .args = args_slice,
-                            .blk = blk,
-                            .block_params = params_slice,
-                            .block_pass = block_pass,
-                        } },
-                    });
-                }
-
-                // Plain identifier
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .identifier = name },
-                });
-            },
-            .lbracket => {
-                // Array literal
-                self.advanceToken();
-                var elems: std.ArrayList(*const Node) = .empty;
-                while (self.current.kind != .rbracket and self.current.kind != .eof) {
-                    self.skipNewlines();
-                    if (self.current.kind == .rbracket) break;
-                    const elem = try self.parseExpression();
-                    elems.append(self.allocator, elem) catch return DslError.OutOfMemory;
-                    self.skipNewlines();
-                    if (self.current.kind == .comma) self.advanceToken();
-                }
-                if (self.current.kind == .rbracket) self.advanceToken();
-                const slice = elems.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .array_literal = slice },
-                });
-            },
-            .lbrace => {
-                // Hash literal. Ruby's shorthand `{ name: value }` lowers
-                // to a symbol key — recognise the `identifier:` case so
-                // it doesn't get resolved as an unknown method/identifier
-                // at interpret time.
-                self.advanceToken();
-                var entries: std.ArrayList(ast.HashEntry) = .empty;
-                while (self.current.kind != .rbrace and self.current.kind != .eof) {
-                    self.skipNewlines();
-                    if (self.current.kind == .rbrace) break;
-
-                    const key_loc = self.currentLoc();
-                    var key: *const Node = undefined;
-                    // Peek: if we see `identifier : ...` (single colon, not `::`),
-                    // treat the identifier as a symbol literal.
-                    if (self.current.kind == .identifier) {
-                        const lex_before = self.lexer.*;
-                        const ident_lexeme = self.current.lexeme;
-                        self.advanceToken();
-                        if (self.current.kind == .colon) {
-                            self.advanceToken();
-                            key = try self.allocNode(.{
-                                .loc = key_loc,
-                                .kind = .{ .symbol_literal = ident_lexeme },
-                            });
-                            const value = try self.parseExpression();
-                            entries.append(self.allocator, .{ .key = key, .value = value }) catch return DslError.OutOfMemory;
-                            self.skipNewlines();
-                            if (self.current.kind == .comma) self.advanceToken();
-                            continue;
-                        }
-                        // Not shorthand — rewind and parse as a full expression.
-                        self.lexer.* = lex_before;
-                        self.current = self.lexer.next();
-                    }
-
-                    key = try self.parseExpression();
-                    if (self.current.kind == .fat_arrow) {
-                        self.advanceToken();
-                    } else if (self.current.kind == .colon) {
-                        self.advanceToken();
-                    }
-
                     const value = try self.parseExpression();
                     entries.append(self.allocator, .{ .key = key, .value = value }) catch return DslError.OutOfMemory;
                     self.skipNewlines();
                     if (self.current.kind == .comma) self.advanceToken();
+                    continue;
                 }
-                if (self.current.kind == .rbrace) self.advanceToken();
-                const slice = entries.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
-                return self.allocNode(.{
-                    .loc = loc,
-                    .kind = .{ .hash_literal = slice },
-                });
-            },
-            .lparen => {
+                // Not shorthand — rewind and re-parse as a full expression.
+                self.lexer.* = lex_before;
+                self.current = self.lexer.next();
+            }
+
+            key = try self.parseExpression();
+            if (self.current.kind == .fat_arrow or self.current.kind == .colon) {
                 self.advanceToken();
-                const inner = try self.parseExpression();
-                if (self.current.kind == .rparen) self.advanceToken();
-                return inner;
-            },
-            else => {
-                return self.emitError("unexpected token in expression");
-            },
+            }
+
+            const value = try self.parseExpression();
+            entries.append(self.allocator, .{ .key = key, .value = value }) catch return DslError.OutOfMemory;
+            self.skipNewlines();
+            if (self.current.kind == .comma) self.advanceToken();
         }
+        if (self.current.kind == .rbrace) self.advanceToken();
+        const slice = entries.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
+        return self.allocNode(.{ .loc = loc, .kind = .{ .hash_literal = slice } });
+    }
+
+    fn parseParenExpr(self: *Parser) DslError!*const Node {
+        self.advanceToken(); // '('
+        const inner = try self.parseExpression();
+        if (self.current.kind == .rparen) self.advanceToken();
+        return inner;
+    }
+
+    /// An identifier at expression position can be a plain reference,
+    /// a call (bare, paren, or always-bare), or an `X[...]` index form
+    /// for the built-in pseudo-modules `Dir`, `Formula`, `ENV`.
+    fn parseIdentifierForm(self: *Parser) DslError!*const Node {
+        const loc = self.currentLoc();
+        const name = self.current.lexeme;
+
+        // `lexer.peek()` saves every field `next()` may mutate —
+        // including heredoc state — so a `Dir<<~EOS` peek restores
+        // cleanly instead of leaving the lexer mid-collection.
+        if (std.mem.eql(u8, name, "Dir") and self.lexer.peek().kind == .lbracket)
+            return self.parseDirIndex(loc);
+        if (std.mem.eql(u8, name, "Formula") and self.lexer.peek().kind == .lbracket)
+            return self.parseFormulaIndex(loc);
+        if (std.mem.eql(u8, name, "ENV") and self.lexer.peek().kind == .lbracket)
+            return self.parseEnvIndex(loc);
+
+        self.advanceToken(); // consume identifier
+
+        // Always-bare methods (`cp`, `cp_r`) must be checked before the
+        // lparen arm so `cp (expr).method, dest` keeps `(expr)` grouped
+        // instead of consuming `(...)` as a paren-arg list.
+        const starts_bare = self.currentLooksLikeBareArg();
+        if (isAlwaysBareMethod(name) and starts_bare) return self.parseBareMethodCall(loc, name);
+        if (self.current.kind == .lparen) return self.parseParenCall(loc, name);
+        if (isBareCallMethod(name) and starts_bare) return self.parseBareMethodCall(loc, name);
+
+        return self.allocNode(.{ .loc = loc, .kind = .{ .identifier = name } });
+    }
+
+    /// Build a bare (no receiver, no block) method_call node — shared
+    /// by the Dir/Formula/ENV index rewrites.
+    fn makeStaticMethodCall(
+        self: *Parser,
+        loc: SourceLoc,
+        name: []const u8,
+        args: []const *const Node,
+    ) DslError!*const Node {
+        return self.allocNode(.{
+            .loc = loc,
+            .kind = .{ .method_call = .{
+                .receiver = null,
+                .method = name,
+                .args = args,
+                .blk = null,
+                .block_params = &.{},
+            } },
+        });
+    }
+
+    /// `Dir[expr, expr, ...]` → `Dir.glob(expr, expr, ...)`.
+    fn parseDirIndex(self: *Parser, loc: SourceLoc) DslError!*const Node {
+        self.advanceToken(); // 'Dir'
+        self.advanceToken(); // '['
+        var args: std.ArrayList(*const Node) = .empty;
+        while (self.current.kind != .rbracket and self.current.kind != .eof) {
+            const arg = try self.parseExpression();
+            args.append(self.allocator, arg) catch return DslError.OutOfMemory;
+            if (self.current.kind == .comma) {
+                self.advanceToken();
+                self.skipNewlines();
+            }
+        }
+        if (self.current.kind == .rbracket) self.advanceToken();
+        const args_slice = args.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
+        return self.makeStaticMethodCall(loc, "Dir.glob", args_slice);
+    }
+
+    /// `Formula[name]` → `Formula.lookup(name)`.
+    fn parseFormulaIndex(self: *Parser, loc: SourceLoc) DslError!*const Node {
+        self.advanceToken(); // 'Formula'
+        self.advanceToken(); // '['
+        const name_expr = try self.parseExpression();
+        if (self.current.kind == .rbracket) self.advanceToken();
+        const args = self.allocator.alloc(*const Node, 1) catch return DslError.OutOfMemory;
+        args[0] = name_expr;
+        return self.makeStaticMethodCall(loc, "Formula.lookup", args);
+    }
+
+    /// `ENV[key]` reads → `ENV.get(key)`; `ENV[key] = value` writes
+    /// → `ENV.set(key, value)`.
+    fn parseEnvIndex(self: *Parser, loc: SourceLoc) DslError!*const Node {
+        self.advanceToken(); // 'ENV'
+        self.advanceToken(); // '['
+        const key_expr = try self.parseExpression();
+        if (self.current.kind == .rbracket) self.advanceToken();
+
+        if (self.current.kind == .equals) {
+            self.advanceToken();
+            const val_expr = try self.parseExpression();
+            const args = self.allocator.alloc(*const Node, 2) catch return DslError.OutOfMemory;
+            args[0] = key_expr;
+            args[1] = val_expr;
+            return self.makeStaticMethodCall(loc, "ENV.set", args);
+        }
+
+        const args = self.allocator.alloc(*const Node, 1) catch return DslError.OutOfMemory;
+        args[0] = key_expr;
+        return self.makeStaticMethodCall(loc, "ENV.get", args);
+    }
+
+    /// Paren-delimited call: `name(args)`.
+    fn parseParenCall(self: *Parser, loc: SourceLoc, name: []const u8) DslError!*const Node {
+        var args: std.ArrayList(*const Node) = .empty;
+        var block_pass: ?*const Node = null;
+        try self.parseParenArgList(&args, &block_pass);
+        return self.finishCallWithBlock(loc, null, name, &args, block_pass);
+    }
+
+    /// Bare (paren-less) call: `name a, b [&:sym] [do |x| … end]`.
+    /// Used for both always-bare methods (cp, cp_r) and bare-capable
+    /// methods (system, ohai, …).
+    fn parseBareMethodCall(self: *Parser, loc: SourceLoc, name: []const u8) DslError!*const Node {
+        var args: std.ArrayList(*const Node) = .empty;
+        var block_pass: ?*const Node = null;
+        try self.parseBareArgList(&args, &block_pass);
+        return self.finishCallWithBlock(loc, null, name, &args, block_pass);
     }
 
     fn parseIf(self: *Parser) DslError!*const Node {

--- a/tests/dsl_parser_test.zig
+++ b/tests/dsl_parser_test.zig
@@ -950,3 +950,312 @@ test "parser: llvm@21 post_install snippet parses with block-pass" {
     try testing.expectEqualStrings("all?", cond_mc.method);
     try testing.expect(cond_mc.block_pass != null);
 }
+
+// ---------------------------------------------------------------------------
+// Per-helper coverage for parsePrimary arms
+// ---------------------------------------------------------------------------
+//
+// One focused test per parsePrimary arm that the broader suite did not
+// already exercise directly. Keeps each new helper under its own
+// regression guard so a future bug lands with a pinpoint failure.
+
+test "parser: float literal" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "x = 1.5");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+    const asg = nodes[0].kind.assignment;
+    try testing.expectEqualStrings("x", asg.name);
+    try testing.expectEqual(@as(f64, 1.5), asg.value.kind.float_literal);
+}
+
+test "parser: symbol literal strips leading colon" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, ":ok");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+    try testing.expectEqualStrings("ok", nodes[0].kind.symbol_literal);
+}
+
+test "parser: regex literal stored as single-part string" {
+    // parseRegexLit keeps the full `/re/` lexeme so the interpreter can
+    // treat it as a string until a real regex engine is wired up.
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "/abc/");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+    const sl = nodes[0].kind.string_literal;
+    try testing.expectEqual(@as(usize, 1), sl.parts.len);
+    try testing.expectEqualStrings("/abc/", sl.parts[0].literal);
+}
+
+test "parser: single-quoted string has no interpolation" {
+    // A `#{…}` sequence inside single quotes must survive as literal
+    // text, never as an interpolation part.
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "'hello #{name}'");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+    const sl = nodes[0].kind.string_literal;
+    try testing.expectEqual(@as(usize, 1), sl.parts.len);
+    try testing.expectEqualStrings("hello #{name}", sl.parts[0].literal);
+}
+
+test "parser: heredoc body lowers to heredoc_literal" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "<<~EOS\n  body\nEOS\n");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+    try testing.expectEqualStrings("  body\n", nodes[0].kind.heredoc_literal);
+}
+
+test "parser: paren expression returns inner node verbatim" {
+    // parseParenExpr must unwrap to the inner expression; no
+    // paren-wrapper node is introduced.
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "(42)");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+    try testing.expectEqual(@as(i64, 42), nodes[0].kind.int_literal);
+}
+
+test "parser: Formula lookup rewrites to method_call" {
+    // Formula["name"] → Formula.lookup(name). Pinned so the identifier
+    // arm's peek/rewrite stays stable even without the heredoc edge.
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "Formula[\"openssl\"]");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+    const mc = nodes[0].kind.method_call;
+    try testing.expectEqualStrings("Formula.lookup", mc.method);
+    try testing.expectEqual(@as(usize, 1), mc.args.len);
+    try testing.expectEqualStrings("openssl", mc.args[0].kind.string_literal.parts[0].literal);
+}
+
+test "parser: always-bare cp keeps (expr) as grouped primary" {
+    // cp / cp_r are always-bare; a leading `(` must be parsed as the
+    // grouped-expression primary, not as a paren-delimited arg list.
+    // Regression guard for the `cp (lib/"libfoo.so").parent, dst` shape.
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "cp (lib/\"libfoo.so\").parent, dst");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+    const mc = nodes[0].kind.method_call;
+    try testing.expectEqualStrings("cp", mc.method);
+    try testing.expectEqual(@as(usize, 2), mc.args.len);
+    try testing.expectEqualStrings("parent", mc.args[0].kind.method_call.method);
+    try testing.expectEqualStrings("dst", mc.args[1].kind.identifier);
+}
+
+// ---------------------------------------------------------------------------
+// parsePrimary corpus snapshot
+// ---------------------------------------------------------------------------
+//
+// Pins the AST shape across every primary form in one shot. Any future
+// change in parsePrimary (or its helpers) that perturbs the tree -
+// node order, method name, literal value, block-pass wiring - will
+// flip this test red. Keeps the corpus-level byte-identity invariant
+// the T-024a refactor requires.
+
+fn dumpNode(w: *std.Io.Writer, node: *const Node) !void {
+    try w.writeByte('(');
+    try w.writeAll(@tagName(node.kind));
+    switch (node.kind) {
+        .int_literal => |v| try w.print(" {d}", .{v}),
+        .float_literal => |v| try w.print(" {d}", .{v}),
+        .bool_literal => |v| try w.print(" {}", .{v}),
+        .nil_literal => {},
+        .symbol_literal => |name| try w.print(" :{s}", .{name}),
+        .identifier => |name| try w.print(" {s}", .{name}),
+        .heredoc_literal => |body| try w.print(" {d}b", .{body.len}),
+        .string_literal => |sl| {
+            try w.writeByte(' ');
+            for (sl.parts) |p| switch (p) {
+                .literal => |lit| try w.print("L\"{s}\"", .{lit}),
+                .interpolation => |inner| {
+                    try w.writeAll("I");
+                    try dumpNode(w, inner);
+                },
+            };
+        },
+        .interpolation => |parts| {
+            for (parts) |p| {
+                try w.writeByte(' ');
+                try dumpNode(w, p);
+            }
+        },
+        .path_join => |pj| {
+            try w.writeByte(' ');
+            try dumpNode(w, pj.left);
+            try w.writeByte(' ');
+            try dumpNode(w, pj.right);
+        },
+        .assignment => |asg| {
+            try w.print(" {s}=", .{asg.name});
+            try dumpNode(w, asg.value);
+        },
+        .array_literal => |elems| for (elems) |e| {
+            try w.writeByte(' ');
+            try dumpNode(w, e);
+        },
+        .hash_literal => |entries| for (entries) |he| {
+            try w.writeAll(" {");
+            try dumpNode(w, he.key);
+            try w.writeAll("=>");
+            try dumpNode(w, he.value);
+            try w.writeByte('}');
+        },
+        .method_call => |mc| {
+            try w.print(" m={s}", .{mc.method});
+            if (mc.receiver) |recv| {
+                try w.writeAll(" r=");
+                try dumpNode(w, recv);
+            }
+            for (mc.args) |a| {
+                try w.writeByte(' ');
+                try dumpNode(w, a);
+            }
+            if (mc.block_pass) |bp| {
+                try w.writeAll(" &");
+                try dumpNode(w, bp);
+            }
+            if (mc.blk) |b| {
+                try w.writeAll(" [|");
+                for (mc.block_params, 0..) |p, i| {
+                    if (i > 0) try w.writeByte(',');
+                    try w.writeAll(p);
+                }
+                try w.writeAll("|");
+                try dumpNode(w, b);
+                try w.writeByte(']');
+            }
+        },
+        .block => |stmts| for (stmts) |s| {
+            try w.writeByte(' ');
+            try dumpNode(w, s);
+        },
+        .postfix_if => |pi| {
+            try w.writeAll(" body=");
+            try dumpNode(w, pi.body);
+            try w.writeAll(" cond=");
+            try dumpNode(w, pi.condition);
+        },
+        .postfix_unless => |pu| {
+            try w.writeAll(" body=");
+            try dumpNode(w, pu.body);
+            try w.writeAll(" cond=");
+            try dumpNode(w, pu.condition);
+        },
+        .if_else, .unless_statement, .each_loop, .begin_rescue, .method_def, .return_statement => {},
+        .raise_statement => |rs| if (rs.message) |m| {
+            try w.writeByte(' ');
+            try dumpNode(w, m);
+        },
+        .logical_and, .logical_or => |lb| {
+            try w.writeByte(' ');
+            try dumpNode(w, lb.left);
+            try w.writeByte(' ');
+            try dumpNode(w, lb.right);
+        },
+        .logical_not => |inner| {
+            try w.writeByte(' ');
+            try dumpNode(w, inner);
+        },
+    }
+    try w.writeByte(')');
+}
+
+fn dumpNodes(w: *std.Io.Writer, nodes: []const *const Node) !void {
+    for (nodes, 0..) |n, i| {
+        if (i > 0) try w.writeByte('\n');
+        try dumpNode(w, n);
+    }
+}
+
+test "parser: corpus AST snapshot pins every primary form" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    // One source that covers every arm of parsePrimary: literals (int,
+    // hex, octal, float, bool, nil, symbol, regex), strings (single,
+    // double with interpolation), %w, heredoc, Dir[..], Formula[..],
+    // ENV[..] read+write, paren expression, array and hash literals,
+    // plain identifier, bare call, paren call, always-bare call,
+    // and a block-pass.
+    const Case = struct { src: []const u8, want: []const u8 };
+    const cases = [_]Case{
+        .{ .src = "n = 42", .want = "(assignment n=(int_literal 42))" },
+        .{ .src = "p = 0x10", .want = "(assignment p=(int_literal 16))" },
+        .{ .src = "o = 0o17", .want = "(assignment o=(int_literal 15))" },
+        .{ .src = "f = 1.5", .want = "(assignment f=(float_literal 1.5))" },
+        .{ .src = "t = true", .want = "(assignment t=(bool_literal true))" },
+        .{ .src = "u = false", .want = "(assignment u=(bool_literal false))" },
+        .{ .src = "z = nil", .want = "(assignment z=(nil_literal))" },
+        .{ .src = "sym = :ok", .want = "(assignment sym=(symbol_literal :ok))" },
+        .{ .src = "r = /re/", .want = "(assignment r=(string_literal L\"/re/\"))" },
+        .{
+            .src = "s1 = \"hello #{name}\"",
+            .want = "(assignment s1=(string_literal L\"hello \"I(identifier name)))",
+        },
+        .{ .src = "s2 = 'single'", .want = "(assignment s2=(string_literal L\"single\"))" },
+        .{
+            .src = "w = %w[a b c]",
+            .want = "(assignment w=(array_literal (string_literal L\"a\") (string_literal L\"b\") (string_literal L\"c\")))",
+        },
+        .{
+            .src = "arr = [1, 2, 3]",
+            .want = "(assignment arr=(array_literal (int_literal 1) (int_literal 2) (int_literal 3)))",
+        },
+        .{
+            .src = "h = { name: \"n\", \"age\" => 1 }",
+            .want = "(assignment h=(hash_literal {(symbol_literal :name)=>(string_literal L\"n\")} {(string_literal L\"age\")=>(int_literal 1)}))",
+        },
+        .{ .src = "grp = (42)", .want = "(assignment grp=(int_literal 42))" },
+        .{
+            .src = "d = Dir[\"*.rb\"]",
+            .want = "(assignment d=(method_call m=Dir.glob (string_literal L\"*.rb\")))",
+        },
+        .{
+            .src = "fx = Formula[\"openssl\"]",
+            .want = "(assignment fx=(method_call m=Formula.lookup (string_literal L\"openssl\")))",
+        },
+        .{
+            .src = "e = ENV[\"X\"]",
+            .want = "(assignment e=(method_call m=ENV.get (string_literal L\"X\")))",
+        },
+        .{
+            .src = "ENV[\"Y\"] = \"y\"",
+            .want = "(method_call m=ENV.set (string_literal L\"Y\") (string_literal L\"y\"))",
+        },
+        .{
+            .src = "cp a, b",
+            .want = "(method_call m=cp (identifier a) (identifier b))",
+        },
+        .{
+            .src = "system \"make\", \"install\"",
+            .want = "(method_call m=system (string_literal L\"make\") (string_literal L\"install\"))",
+        },
+        .{ .src = "puts(a)", .want = "(method_call m=puts (identifier a))" },
+        .{
+            .src = "xs.all?(&:exist?)",
+            .want = "(method_call m=all? r=(identifier xs) &(symbol_literal :exist?))",
+        },
+        .{ .src = "name", .want = "(identifier name)" },
+    };
+
+    var buf: [2 * 1024]u8 = undefined;
+    for (cases) |c| {
+        const nodes = try parseSource(&arena, c.src);
+        var aw: std.Io.Writer = .fixed(&buf);
+        try dumpNodes(&aw, nodes);
+        try testing.expectEqualStrings(c.want, aw.buffered());
+    }
+}


### PR DESCRIPTION
## Description

Breaks the 547-LOC parsePrimary in the DSL parser into one small helper per primary form so the parser reads top-down as a dispatch table instead of one wall of nested switches. Future parse-rule additions become local and review-friendly. Public parser surface and parse output are unchanged.

## Related Issue

- None

## Notes for Reviewers

Refactor-only: no grammar change, no new errors, no AST shape change. Every DSL corpus and lexer test stays green; parsed AST is byte-identical for the corpus.