### PR TITLE
fix(db/lock): retry on EINTR and handle WouldBlock

### DIFF
--- a/src/db/lock.zig
+++ b/src/db/lock.zig
@@ -4,7 +4,58 @@ pub const LockError = error{
     Timeout,
     OpenFailed,
     WriteFailed,
+    /// ENOLCK: kernel advisory-lock slots exhausted — not contention, so surface distinctly.
+    LockResourceExhausted,
 };
+
+/// Cap on EINTR retries so a signal storm can't spin the acquire loop forever.
+pub const MAX_EINTR_RETRIES: u32 = 5;
+
+/// Mapping of a non-zero `flock` errno to a loop action. Pure so it's unit-testable.
+pub const FlockOutcome = enum {
+    retry_later, // EAGAIN — sleep and try again within the deadline.
+    interrupted, // EINTR — retry immediately (bounded).
+    resource_exhausted, // ENOLCK — kernel lock table full.
+    open_failed, // EBADF / EINVAL / … — treat as a hard failure.
+};
+
+pub fn classifyFlockErrno(errno: std.c.E) FlockOutcome {
+    return switch (errno) {
+        .AGAIN => .retry_later,
+        .INTR => .interrupted,
+        .NOLCK => .resource_exhausted,
+        else => .open_failed,
+    };
+}
+
+/// Next action for the acquire loop, from the current `flock` probe plus loop state.
+pub const AcquireStep = enum {
+    acquired,
+    sleep_and_retry,
+    timeout,
+    retry_interrupted,
+    interrupted_exhausted,
+    resource_exhausted,
+    open_failed,
+};
+
+pub const AcquireProbe = struct {
+    rc: c_int,
+    errno: std.c.E,
+    elapsed_ns: u128,
+    deadline_ns: u128,
+    eintr_retries: u32,
+};
+
+pub fn nextAcquireStep(p: AcquireProbe) AcquireStep {
+    if (p.rc == 0) return .acquired;
+    return switch (classifyFlockErrno(p.errno)) {
+        .retry_later => if (p.elapsed_ns >= p.deadline_ns) .timeout else .sleep_and_retry,
+        .interrupted => if (p.eintr_retries >= MAX_EINTR_RETRIES) .interrupted_exhausted else .retry_interrupted,
+        .resource_exhausted => .resource_exhausted,
+        .open_failed => .open_failed,
+    };
+}
 
 pub const LockFile = struct {
     fd: std.posix.fd_t,
@@ -20,22 +71,26 @@ pub const LockFile = struct {
             .CREAT = true,
         }, @as(std.c.mode_t, 0o644));
         if (fd < 0) return error.OpenFailed;
+        errdefer _ = std.c.close(fd);
 
         const deadline_ns: u128 = @as(u128, @intCast(timeout_ms)) * std.time.ns_per_ms;
         var elapsed_ns: u128 = 0;
+        var eintr_retries: u32 = 0;
         const sleep_ns: u64 = 100 * std.time.ns_per_ms;
 
-        while (true) {
-            // Try non-blocking exclusive lock.
+        acquire_loop: while (true) {
             const rc = std.c.flock(fd, std.c.LOCK.EX | std.c.LOCK.NB);
-            if (rc == 0) break;
-            const errno = std.posix.errno(rc);
-            switch (errno) {
-                .AGAIN => {
-                    if (elapsed_ns >= deadline_ns) {
-                        _ = std.c.close(fd);
-                        return error.Timeout;
-                    }
+            // errno is read unconditionally; ignored on rc==0 inside nextAcquireStep.
+            const step = nextAcquireStep(.{
+                .rc = rc,
+                .errno = std.posix.errno(rc),
+                .elapsed_ns = elapsed_ns,
+                .deadline_ns = deadline_ns,
+                .eintr_retries = eintr_retries,
+            });
+            switch (step) {
+                .acquired => break :acquire_loop,
+                .sleep_and_retry => {
                     const ts: std.c.timespec = .{
                         .sec = @intCast(sleep_ns / std.time.ns_per_s),
                         .nsec = @intCast(sleep_ns % std.time.ns_per_s),
@@ -43,10 +98,11 @@ pub const LockFile = struct {
                     _ = std.c.nanosleep(&ts, null);
                     elapsed_ns += sleep_ns;
                 },
-                else => {
-                    _ = std.c.close(fd);
-                    return error.OpenFailed;
-                },
+                .retry_interrupted => eintr_retries += 1,
+                .timeout => return error.Timeout,
+                .resource_exhausted => return error.LockResourceExhausted,
+                // Exhausted EINTR retries collapse into OpenFailed — no new tag in scope.
+                .interrupted_exhausted, .open_failed => return error.OpenFailed,
             }
         }
 
@@ -78,6 +134,18 @@ pub const LockFile = struct {
         };
     }
 
+    /// Bounded retry on WouldBlock so a future O_NONBLOCK flip can't silently hide a held lock.
+    fn readHolderBytes(fd: std.posix.fd_t, buf: []u8) ?usize {
+        var attempts: u2 = 0;
+        while (attempts < 2) : (attempts += 1) {
+            return std.posix.read(fd, buf) catch |err| switch (err) {
+                error.WouldBlock => continue,
+                else => return null,
+            };
+        }
+        return null;
+    }
+
     /// Release the advisory lock and close the file descriptor.
     ///
     /// Truncates the file to 0 bytes before unlocking so subsequent
@@ -104,7 +172,7 @@ pub const LockFile = struct {
         defer _ = std.c.close(fd);
 
         var buf: [32]u8 = undefined;
-        const n = std.posix.read(fd, &buf) catch return null;
+        const n = readHolderBytes(fd, &buf) orelse return null;
         if (n == 0) return null;
 
         const trimmed = std.mem.trimEnd(u8, buf[0..n], &[_]u8{ '\n', '\r', ' ' });

--- a/tests/lock_test.zig
+++ b/tests/lock_test.zig
@@ -58,3 +58,100 @@ test "holderPid returns null on an empty file (vacated after release)" {
 
     try testing.expect(lock.LockFile.holderPid(path) == null);
 }
+
+test "classifyFlockErrno: EAGAIN retries later" {
+    try testing.expectEqual(lock.FlockOutcome.retry_later, lock.classifyFlockErrno(.AGAIN));
+}
+
+test "classifyFlockErrno: EINTR signals interruption" {
+    try testing.expectEqual(lock.FlockOutcome.interrupted, lock.classifyFlockErrno(.INTR));
+}
+
+test "classifyFlockErrno: ENOLCK is a distinct resource-exhausted outcome" {
+    try testing.expectEqual(lock.FlockOutcome.resource_exhausted, lock.classifyFlockErrno(.NOLCK));
+}
+
+test "classifyFlockErrno: unrelated errno falls through to open_failed" {
+    try testing.expectEqual(lock.FlockOutcome.open_failed, lock.classifyFlockErrno(.BADF));
+    try testing.expectEqual(lock.FlockOutcome.open_failed, lock.classifyFlockErrno(.INVAL));
+}
+
+test "LockError exposes a distinct LockResourceExhausted tag" {
+    const err: lock.LockError = error.LockResourceExhausted;
+    try testing.expect(err == error.LockResourceExhausted);
+}
+
+test "MAX_EINTR_RETRIES is bounded" {
+    try testing.expect(lock.MAX_EINTR_RETRIES > 0);
+    try testing.expect(lock.MAX_EINTR_RETRIES <= 16);
+}
+
+test "nextAcquireStep: rc == 0 means acquired regardless of other state" {
+    try testing.expectEqual(lock.AcquireStep.acquired, lock.nextAcquireStep(.{
+        .rc = 0,
+        .errno = .SUCCESS,
+        .elapsed_ns = 0,
+        .deadline_ns = 1_000,
+        .eintr_retries = 0,
+    }));
+}
+
+test "nextAcquireStep: EAGAIN within the deadline sleeps and retries" {
+    try testing.expectEqual(lock.AcquireStep.sleep_and_retry, lock.nextAcquireStep(.{
+        .rc = -1,
+        .errno = .AGAIN,
+        .elapsed_ns = 100,
+        .deadline_ns = 1_000,
+        .eintr_retries = 0,
+    }));
+}
+
+test "nextAcquireStep: EAGAIN past the deadline is a Timeout" {
+    try testing.expectEqual(lock.AcquireStep.timeout, lock.nextAcquireStep(.{
+        .rc = -1,
+        .errno = .AGAIN,
+        .elapsed_ns = 1_000,
+        .deadline_ns = 1_000,
+        .eintr_retries = 0,
+    }));
+}
+
+test "nextAcquireStep: EINTR under the cap retries immediately" {
+    try testing.expectEqual(lock.AcquireStep.retry_interrupted, lock.nextAcquireStep(.{
+        .rc = -1,
+        .errno = .INTR,
+        .elapsed_ns = 0,
+        .deadline_ns = 1_000,
+        .eintr_retries = lock.MAX_EINTR_RETRIES - 1,
+    }));
+}
+
+test "nextAcquireStep: EINTR at the cap gives up" {
+    try testing.expectEqual(lock.AcquireStep.interrupted_exhausted, lock.nextAcquireStep(.{
+        .rc = -1,
+        .errno = .INTR,
+        .elapsed_ns = 0,
+        .deadline_ns = 1_000,
+        .eintr_retries = lock.MAX_EINTR_RETRIES,
+    }));
+}
+
+test "nextAcquireStep: ENOLCK surfaces resource exhaustion" {
+    try testing.expectEqual(lock.AcquireStep.resource_exhausted, lock.nextAcquireStep(.{
+        .rc = -1,
+        .errno = .NOLCK,
+        .elapsed_ns = 0,
+        .deadline_ns = 1_000,
+        .eintr_retries = 0,
+    }));
+}
+
+test "nextAcquireStep: unclassified errno is a hard open failure" {
+    try testing.expectEqual(lock.AcquireStep.open_failed, lock.nextAcquireStep(.{
+        .rc = -1,
+        .errno = .BADF,
+        .elapsed_ns = 0,
+        .deadline_ns = 1_000,
+        .eintr_retries = 0,
+    }));
+}


### PR DESCRIPTION
## Description

A signal (SIGWINCH, SIGCHLD, anything the main process ignores) landing inside `mt install`'s lock acquisition used to fail the whole command with "Another mt process is running." Now `flock` retries on EINTR up to a bounded cap, ENOLCK surfaces as a distinct error instead of hiding behind "open failed", and `holderPid` handles `WouldBlock` explicitly so a future non-blocking open can't silently misreport a held lock as vacated.

## Related Issue

- None

## Notes for Reviewers

- None