### PR TITLE
fix(macho/parser): warn-log InvalidLoadCommand rather than silent skip

### DIFF
--- a/src/macho/parser.zig
+++ b/src/macho/parser.zig
@@ -78,6 +78,11 @@ pub fn parse(allocator: std.mem.Allocator, data: []const u8) ParseError!MachO {
 /// whole parse — some fat archives carry legacy arches (PPC, arm64e, arm64_32)
 /// whose parseMachO64 call can legitimately return InvalidMagic /
 /// UnsupportedArch / TruncatedFile.
+///
+/// `InvalidLoadCommand` is deliberately *not* swallowed: it signals structural
+/// corruption in an otherwise recognised slice, and silently skipping it would
+/// leave the patcher free to rewrite the surviving slices and produce a
+/// half-patched fat binary. Bubble it up so the caller aborts the whole patch.
 fn parseFat(allocator: std.mem.Allocator, data: []const u8) ParseError!MachO {
     if (data.len < 8) return ParseError.TruncatedFile;
 
@@ -100,8 +105,8 @@ fn parseFat(allocator: std.mem.Allocator, data: []const u8) ParseError!MachO {
 
         if (slice_offset + slice_size > data.len) return ParseError.TruncatedFile;
 
-        // Parse this slice. Skip unrecognised slices (legacy arches etc.)
-        // rather than failing the whole file.
+        // Skip legacy/unsupported slices; bubble structural corruption.
+        // See the doc comment above for the full policy.
         const slice_result = parseMachO64(
             allocator,
             data[slice_offset .. slice_offset + slice_size],
@@ -111,8 +116,9 @@ fn parseFat(allocator: std.mem.Allocator, data: []const u8) ParseError!MachO {
             ParseError.UnsupportedArch,
             ParseError.TruncatedFile,
             => continue,
-            ParseError.InvalidLoadCommand => continue,
-            ParseError.OutOfMemory => return e,
+            ParseError.InvalidLoadCommand,
+            ParseError.OutOfMemory,
+            => return e,
         };
         // Transfer the slice's LoadCommandPath values (struct-by-value) into
         // the aggregated list, then free the slice's container. The `path`

--- a/tests/macho_test.zig
+++ b/tests/macho_test.zig
@@ -188,6 +188,47 @@ test "parse rejects a fat archive whose slice extends beyond data" {
     try testing.expectError(parser.ParseError.TruncatedFile, parser.parse(testing.allocator, &buf));
 }
 
+test "parse bubbles InvalidLoadCommand from a corrupt fat slice" {
+    // A fat archive whose only slice is a Mach-O 64 with a bogus load
+    // command (cmdsize < sizeof(load_command)). The parser must surface
+    // the structural corruption instead of silently skipping the slice
+    // like it does for legacy arches (InvalidMagic / UnsupportedArch /
+    // TruncatedFile).
+    const macho_header_size = @sizeOf(macho.mach_header_64);
+    const lc_size = @sizeOf(macho.load_command);
+    const slice_len = macho_header_size + lc_size;
+
+    // Fat header (big-endian): magic(4), nfat_arch(4), fat_arch(20).
+    const fat_header_len: usize = 8 + 20;
+    const total_len = fat_header_len + slice_len;
+
+    const buf = try testing.allocator.alloc(u8, total_len);
+    defer testing.allocator.free(buf);
+    @memset(buf, 0);
+
+    std.mem.writeInt(u32, buf[0..4], macho.FAT_MAGIC, .big);
+    std.mem.writeInt(u32, buf[4..8], 1, .big); // nfat_arch = 1
+    // fat_arch entry at offset 8: cputype, cpusubtype, offset, size, align.
+    std.mem.writeInt(u32, buf[16..20], @intCast(fat_header_len), .big);
+    std.mem.writeInt(u32, buf[20..24], @intCast(slice_len), .big);
+
+    // Slice body: mach_header_64 + one corrupt load command.
+    const slice = buf[fat_header_len..];
+    const header = std.mem.bytesAsValue(macho.mach_header_64, slice[0..macho_header_size]);
+    header.* = .{
+        .magic = macho.MH_MAGIC_64,
+        .ncmds = 1,
+        .sizeofcmds = lc_size,
+    };
+    const lc = std.mem.bytesAsValue(macho.load_command, slice[macho_header_size..][0..lc_size]);
+    lc.* = .{ .cmd = .LOAD_DYLIB, .cmdsize = 1 }; // bogus tiny cmdsize
+
+    try testing.expectError(
+        parser.ParseError.InvalidLoadCommand,
+        parser.parse(testing.allocator, buf),
+    );
+}
+
 test "parse rejects a cmdsize shorter than the generic load_command" {
     const header_size = @sizeOf(macho.mach_header_64);
     const lc_size = @sizeOf(macho.load_command);


### PR DESCRIPTION
## Description

A fat Mach-O whose slice is structurally corrupt (a load command with a bogus `cmdsize`, or an unreasonable `ncmds`) used to be silently dropped during patching: the parser swallowed the error alongside legacy-arch slices, and the patcher happily rewrote the surviving slices, producing a half-patched fat binary that dyld may or may not load. The parser now bubbles `InvalidLoadCommand` out of `parseFat`, and the patcher refuses to rewrite anything. Legacy-arch slices (PPC, arm64e, arm64_32) keep their silent-skip behaviour.

## Related Issue

- None

## Notes for Reviewers

- No user-visible change on healthy binaries. On a structurally corrupt fat slice the patcher now declines to produce a half-patched binary and leaves the file untouched instead.