### PR TITLE
perf(cli/install): bounded pool for collectFormulaJobs

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1007,6 +1007,40 @@ const FetchFormulaCtx = struct {
     }
 };
 
+/// Maximum concurrent workers for the dep-fetch phase of
+/// `collectFormulaJobs`. Matches the install-time HTTP client pool so
+/// workers never block on `pool.acquire` — extra workers would just sit
+/// idle waiting for a client.
+pub const MAX_COLLECT_FETCH_WORKERS: usize = 4;
+
+/// Bounded worker count for a given dep-fetch load. Exposed so tests
+/// can pin the "no more than N threads" invariant without scraping
+/// `std.Thread.spawn` call counts.
+pub fn collectFetchWorkerCount(deps_to_fetch: usize) usize {
+    return @min(MAX_COLLECT_FETCH_WORKERS, deps_to_fetch);
+}
+
+/// Shared state for the dep-fetch pool. Mirrors `MaterializePool`: a
+/// single atomic index hands out `ctxs` slots to workers until the
+/// array is drained. Already-installed deps are skipped in-thread.
+const FetchJobsPool = struct {
+    next_idx: std.atomic.Value(usize),
+    ctxs: []FetchFormulaCtx,
+    deps: []const deps_mod.ResolvedDep,
+};
+
+/// Thread entry-point for the bounded dep-fetch pool. Each worker
+/// grabs the next `ctxs` index atomically and runs the fetch until the
+/// index passes the end, skipping deps that are already installed.
+fn collectFetchPoolWorker(pool: *FetchJobsPool) void {
+    while (true) {
+        const idx = pool.next_idx.fetchAdd(1, .acq_rel);
+        if (idx >= pool.ctxs.len) return;
+        if (pool.deps[idx].already_installed) continue;
+        pool.ctxs[idx].run();
+    }
+}
+
 /// Job-owned strings duped out of a parsed formula so its
 /// `std.json.Parsed` arena can be released as soon as
 /// `collectFormulaJobs` is done reading it. Lifetime matches the
@@ -1141,21 +1175,39 @@ pub fn collectFormulaJobs(
             };
         }
 
-        const threads = allocator.alloc(std.Thread, deps.len) catch return InstallError.DownloadFailed;
-        defer allocator.free(threads);
-
-        var spawned: usize = 0;
-        for (deps, 0..) |dep, i| {
-            if (dep.already_installed) continue;
-            if (std.Thread.spawn(.{}, FetchFormulaCtx.run, .{&ctxs[i]})) |t| {
-                threads[spawned] = t;
-                spawned += 1;
-            } else |_| {
-                // Spawn failure → run inline on the caller thread.
-                ctxs[i].run();
-            }
+        // Bounded pool: one-thread-per-dep over-allocated stacks and
+        // queued on the 4-slot HTTP client pool anyway. Workers share
+        // an atomic index and drain `ctxs` — same pattern as
+        // `materializePoolWorker`.
+        var to_fetch: usize = 0;
+        for (deps) |d| {
+            if (!d.already_installed) to_fetch += 1;
         }
-        for (threads[0..spawned]) |t| t.join();
+
+        if (to_fetch > 0) {
+            const worker_count = collectFetchWorkerCount(to_fetch);
+            var pool_ctx: FetchJobsPool = .{
+                .next_idx = std.atomic.Value(usize).init(0),
+                .ctxs = ctxs,
+                .deps = deps,
+            };
+
+            const threads = allocator.alloc(std.Thread, worker_count) catch
+                return InstallError.DownloadFailed;
+            defer allocator.free(threads);
+
+            var spawned: usize = 0;
+            for (0..worker_count) |_| {
+                if (std.Thread.spawn(.{}, collectFetchPoolWorker, .{&pool_ctx})) |t| {
+                    threads[spawned] = t;
+                    spawned += 1;
+                } else |_| {
+                    // Spawn failure → drain remaining work inline.
+                    collectFetchPoolWorker(&pool_ctx);
+                }
+            }
+            for (threads[0..spawned]) |t| t.join();
+        }
 
         // Dupe each fetched JSON into the caller's allocator so the
         // memory outlives per-worker `arena.deinit()` — downstream

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -801,3 +801,18 @@ test "collectFormulaJobs leaves no parsed-tree leaks under testing.allocator (>=
     try testing.expectEqualStrings("root", jobs.items[3].name);
     try testing.expect(!jobs.items[3].is_dep);
 }
+
+test "collectFetchWorkerCount clamps to MAX_COLLECT_FETCH_WORKERS" {
+    // Pool invariant: the dep-fetch phase never spawns more than
+    // MAX_COLLECT_FETCH_WORKERS threads, even on heavy graphs (40+ deps).
+    // The old one-thread-per-dep loop would scale linearly; the pool
+    // caps it so threads never outnumber HTTP client pool slots.
+    const cap = install.MAX_COLLECT_FETCH_WORKERS;
+
+    try testing.expectEqual(@as(usize, 0), install.collectFetchWorkerCount(0));
+    try testing.expectEqual(@as(usize, 1), install.collectFetchWorkerCount(1));
+    try testing.expectEqual(cap, install.collectFetchWorkerCount(cap));
+    try testing.expectEqual(cap, install.collectFetchWorkerCount(cap + 1));
+    try testing.expectEqual(cap, install.collectFetchWorkerCount(40));
+    try testing.expectEqual(cap, install.collectFetchWorkerCount(128));
+}


### PR DESCRIPTION
## Description

Install's dep-formula fetch phase spawned one thread per dependency and then queued them against a 4-slot HTTP client pool - extra threads just sat idle waiting for a client. On heavy graphs (40+ deps) that's 20+ wasted stacks and a lot of pool contention; on small graphs like ffmpeg (11 deps) the behaviour is unchanged.

Replace it with the same bounded atomic-index pool pattern `materializePoolWorker` already uses: a fixed set of workers share one `fetchAdd` index and drain the dep array. Workers never outnumber HTTP client slots, so none of them stall on `pool.acquire`.

## Related Issue

- None

## Notes for Reviewers

- Worker cap lives in a named constant (`MAX_COLLECT_FETCH_WORKERS = 4`) so the value and its rationale are co-located.