### PR TITLE
perf(update/verify): stream SHA for self-update tarball

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -177,6 +177,7 @@ pub fn build(b: *std.Build) void {
         "tests/worker_arena_test.zig",
         "tests/migrate_smoke_test.zig",
         "tests/upgrade_test.zig",
+        "tests/hash_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -8,6 +8,7 @@ const sqlite = @import("../db/sqlite.zig");
 const client_mod = @import("../net/client.zig");
 const install_cmd = @import("../cli/install.zig");
 const archive_mod = @import("../fs/archive.zig");
+const hash_mod = @import("hash.zig");
 
 pub const CaskError = error{
     ParseFailed,
@@ -707,31 +708,11 @@ pub fn findAppInDir(dir_path: []const u8, out_buf: []u8) ?[]const u8 {
     return null;
 }
 
-/// SHA256 buffer size — one positional read per 64 KiB.
-const sha256_read_chunk: usize = 64 * 1024;
-
-/// Compute the SHA256 of `file_path` as lowercase hex. Streams via
-/// `fs_compat.streamFile` so the file-reading loop lives in exactly
-/// one place — no more hand-rolled offset bookkeeping.
+/// Compute the SHA256 of `file_path` as lowercase hex. Delegates to
+/// the shared streaming helper so the chunk loop and buffer size are
+/// defined in exactly one place.
 pub fn hashFileSha256(file_path: []const u8) ![64]u8 {
-    const file = try fs_compat.openFileAbsolute(file_path, .{});
-    defer file.close();
-
-    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-    var read_buf: [sha256_read_chunk]u8 = undefined;
-    try fs_compat.streamFile(file, &read_buf, .{
-        .context = @ptrCast(&hasher),
-        .func = &sha256Update,
-    });
-    var hash: [32]u8 = undefined;
-    hasher.final(&hash);
-    return std.fmt.bytesToHex(hash, .lower);
-}
-
-/// Bridge `streamFile`'s erased-context callback to `Sha256.update`.
-fn sha256Update(ctx: *anyopaque, chunk: []const u8) fs_compat.StreamError!void {
-    const hasher: *std.crypto.hash.sha2.Sha256 = @ptrCast(@alignCast(ctx));
-    hasher.update(chunk);
+    return hash_mod.hashFileSha256Hex(file_path);
 }
 
 /// Verify `file_path` hashes to `expected` (lowercase hex). A null

--- a/src/core/hash.zig
+++ b/src/core/hash.zig
@@ -1,0 +1,45 @@
+//! malt — shared streaming SHA256 for file paths.
+//!
+//! Centralises the read-in-chunks-feed-the-hasher dance so callers that
+//! hash large files (self-update tarball, cask artifacts) bound RSS to
+//! the chunk size instead of the file size. Raw and hex variants both
+//! route through the same `fs_compat.streamFile` loop.
+
+const std = @import("std");
+const fs_compat = @import("../fs/compat.zig");
+
+/// One positional read per 64 KiB — large enough to keep syscall
+/// overhead in the noise, small enough that peak RSS stays flat even
+/// on the 256 MiB self-update tarball.
+const sha256_read_chunk: usize = 64 * 1024;
+
+/// Stream `file_path` through SHA256 and return the raw 32-byte digest.
+/// Used by `update/verify.zig` so the self-update tarball is never
+/// read whole into memory.
+pub fn hashFileSha256Raw(file_path: []const u8) ![32]u8 {
+    const file = try fs_compat.openFileAbsolute(file_path, .{});
+    defer file.close();
+
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    var read_buf: [sha256_read_chunk]u8 = undefined;
+    try fs_compat.streamFile(file, &read_buf, .{
+        .context = @ptrCast(&hasher),
+        .func = &sha256Update,
+    });
+    var out: [32]u8 = undefined;
+    hasher.final(&out);
+    return out;
+}
+
+/// Lowercase-hex form of `hashFileSha256Raw` — the shape `cask` prefers
+/// for comparison with manifest strings.
+pub fn hashFileSha256Hex(file_path: []const u8) ![64]u8 {
+    const raw = try hashFileSha256Raw(file_path);
+    return std.fmt.bytesToHex(raw, .lower);
+}
+
+/// Bridge `streamFile`'s erased-context callback to `Sha256.update`.
+fn sha256Update(ctx: *anyopaque, chunk: []const u8) fs_compat.StreamError!void {
+    const hasher: *std.crypto.hash.sha2.Sha256 = @ptrCast(@alignCast(ctx));
+    hasher.update(chunk);
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2,6 +2,7 @@
 //! Re-exports all modules that tests need to access.
 
 pub const cask = @import("core/cask.zig");
+pub const hash = @import("core/hash.zig");
 pub const cellar = @import("core/cellar.zig");
 pub const deps = @import("core/deps.zig");
 pub const formula = @import("core/formula.zig");

--- a/src/update/verify.zig
+++ b/src/update/verify.zig
@@ -11,6 +11,7 @@
 
 const std = @import("std");
 const fs_compat = @import("../fs/compat.zig");
+const hash = @import("../core/hash.zig");
 const install_cmd = @import("../cli/install.zig");
 
 pub const ChecksumError = error{
@@ -114,13 +115,14 @@ pub fn verifyAll(allocator: std.mem.Allocator, in: VerifyInputs) VerifyError!voi
         return error.ReadFailed;
     defer allocator.free(checksums);
 
-    const expected = lookupSha256(checksums, in.archive_name) orelse return error.ChecksumMissing;
+    const expected_hex = lookupSha256(checksums, in.archive_name) orelse return error.ChecksumMissing;
+    if (expected_hex.len != 64) return error.InvalidHex;
+    var expected: [32]u8 = undefined;
+    _ = std.fmt.hexToBytes(&expected, expected_hex) catch return error.InvalidHex;
 
-    const tarball = fs_compat.readFileAbsoluteAlloc(allocator, in.tarball_path, 1 << 28) catch
-        return error.ReadFailed;
-    defer allocator.free(tarball);
-
-    return verifySha256(tarball, expected);
+    // Stream to bound RSS during self-update — the tarball can be 256 MiB.
+    const actual = hash.hashFileSha256Raw(in.tarball_path) catch return error.ReadFailed;
+    if (!install_cmd.constantTimeEql(u8, &expected, &actual)) return error.ChecksumMismatch;
 }
 
 /// Shell out to `cosign verify-blob` with the same flags `install.sh` uses.

--- a/tests/hash_test.zig
+++ b/tests/hash_test.zig
@@ -1,0 +1,106 @@
+//! malt - shared streaming-SHA helper tests.
+//!
+//! The helper hashes files in bounded chunks so callers that might
+//! see large payloads (self-update tarballs, casks) never need to
+//! hold the whole file in RAM. Tests cover the boundary matrix,
+//! the NIST "abc" vector, empty input, and missing-path propagation.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const hash = malt.hash;
+const fs_compat = malt.fs_compat;
+
+/// 64 KiB — internal SHA256 read chunk. Boundary cases are expressed
+/// relative to this so the tests stay meaningful if the constant moves.
+const CHUNK: usize = 64 * 1024;
+
+fn tempPath(tag: []const u8, buf: []u8) ![]const u8 {
+    return std.fmt.bufPrint(buf, "/tmp/malt_hash_test_{s}_{d}", .{ tag, fs_compat.nanoTimestamp() });
+}
+
+fn writeFile(path: []const u8, bytes: []const u8) !void {
+    const f = try fs_compat.createFileAbsolute(path, .{});
+    defer f.close();
+    try f.writeAll(bytes);
+}
+
+fn fillPattern(buf: []u8) void {
+    for (buf, 0..) |*b, i| b.* = @intCast((i *% 131 +% 7) & 0xFF);
+}
+
+fn referenceRaw(bytes: []const u8) [32]u8 {
+    var out: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(bytes, &out, .{});
+    return out;
+}
+
+test "hashFileSha256Raw returns the canonical empty digest" {
+    var buf: [128]u8 = undefined;
+    const p = try tempPath("empty_raw", &buf);
+    try writeFile(p, "");
+    defer fs_compat.deleteFileAbsolute(p) catch {};
+
+    const got = try hash.hashFileSha256Raw(p);
+    // SHA256("")
+    const want = [_]u8{
+        0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14,
+        0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
+        0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
+        0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+    };
+    try testing.expectEqualSlices(u8, &want, &got);
+}
+
+test "hashFileSha256Raw matches NIST 'abc' vector" {
+    var buf: [128]u8 = undefined;
+    const p = try tempPath("abc_raw", &buf);
+    try writeFile(p, "abc");
+    defer fs_compat.deleteFileAbsolute(p) catch {};
+
+    const got = try hash.hashFileSha256Raw(p);
+    const want = [_]u8{
+        0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
+        0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
+        0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
+        0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad,
+    };
+    try testing.expectEqualSlices(u8, &want, &got);
+}
+
+test "hashFileSha256Raw streams past the chunk boundary" {
+    // 2.5x CHUNK — the exact repro size that broke the pre-stream
+    // hash in cask. Proves later chunks reach the hasher intact.
+    const size = 2 * CHUNK + CHUNK / 2;
+    const payload = try testing.allocator.alloc(u8, size);
+    defer testing.allocator.free(payload);
+    fillPattern(payload);
+
+    var buf: [128]u8 = undefined;
+    const p = try tempPath("multi_raw", &buf);
+    try writeFile(p, payload);
+    defer fs_compat.deleteFileAbsolute(p) catch {};
+
+    const got = try hash.hashFileSha256Raw(p);
+    const want = referenceRaw(payload);
+    try testing.expectEqualSlices(u8, &want, &got);
+}
+
+test "hashFileSha256Raw propagates FileNotFound" {
+    try testing.expectError(
+        error.FileNotFound,
+        hash.hashFileSha256Raw("/tmp/malt_hash_test_absent_xyzzy.bin"),
+    );
+}
+
+test "hashFileSha256Hex is the lowercase hex of hashFileSha256Raw" {
+    var buf: [128]u8 = undefined;
+    const p = try tempPath("hex_match", &buf);
+    try writeFile(p, "hello world");
+    defer fs_compat.deleteFileAbsolute(p) catch {};
+
+    const raw = try hash.hashFileSha256Raw(p);
+    const hex = try hash.hashFileSha256Hex(p);
+    const expected_hex = std.fmt.bytesToHex(raw, .lower);
+    try testing.expectEqualSlices(u8, &expected_hex, &hex);
+}

--- a/tests/verify_test.zig
+++ b/tests/verify_test.zig
@@ -239,6 +239,132 @@ test "verifyAll reports ReadFailed when the tarball cannot be read" {
     try testing.expectError(error.ReadFailed, verify.verifyAll(testing.allocator, fx.inputs()));
 }
 
+// --- verifyAll (multi-chunk tarball) --------------------------------------
+//
+// Pins the tarball-hashing path across the switch to streaming SHA256.
+// A 160 KiB payload (2.5x the 64 KiB read chunk) forces the stream
+// loop through multiple iterations — if any later chunk ever stops
+// reaching the hasher, these tests catch it.
+
+fn patternedPayload(alloc: std.mem.Allocator, size: usize) ![]u8 {
+    const buf = try alloc.alloc(u8, size);
+    for (buf, 0..) |*b, i| b.* = @intCast((i *% 131 +% 7) & 0xFF);
+    return buf;
+}
+
+fn sha256Hex(bytes: []const u8) [64]u8 {
+    var raw: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(bytes, &raw, .{});
+    return std.fmt.bytesToHex(raw, .lower);
+}
+
+test "verifyAll streams a large tarball without loading it whole (smoke)" {
+    // Gated: MALT_VERIFY_SMOKE_MIB=N enables a realistic self-update-sized
+    // run. Measured under `/usr/bin/time -l`, peak RSS stays flat as N
+    // grows — the fixture below writes the tarball in 64 KiB chunks so
+    // the test itself never holds the whole payload in memory.
+    const env = fs_compat.getenv("MALT_VERIFY_SMOKE_MIB") orelse return error.SkipZigTest;
+    const mib = std.fmt.parseInt(usize, env, 10) catch return error.SkipZigTest;
+    if (mib == 0) return error.SkipZigTest;
+    const total: usize = mib * 1024 * 1024;
+
+    const dir = "/tmp/malt_verifyall_smoke";
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    try fs_compat.makeDirAbsolute(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    const tarball = try std.fmt.allocPrint(testing.allocator, "{s}/malt.tgz", .{dir});
+    defer testing.allocator.free(tarball);
+    const checksums = try std.fmt.allocPrint(testing.allocator, "{s}/checksums.txt", .{dir});
+    defer testing.allocator.free(checksums);
+    const sigstore = try std.fmt.allocPrint(testing.allocator, "{s}/checksums.txt.sigstore.json", .{dir});
+    defer testing.allocator.free(sigstore);
+    const cosign_bin = try std.fmt.allocPrint(testing.allocator, "{s}/fake_cosign", .{dir});
+    defer testing.allocator.free(cosign_bin);
+
+    // Stream-write the tarball while hashing the same bytes. A 64 KiB
+    // pattern buffer is the only payload-sized allocation this test makes.
+    var chunk: [64 * 1024]u8 = undefined;
+    for (&chunk, 0..) |*b, i| b.* = @intCast((i *% 131 +% 7) & 0xFF);
+
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    {
+        const tf = try fs_compat.createFileAbsolute(tarball, .{});
+        defer tf.close();
+        var remaining = total;
+        while (remaining > 0) {
+            const n = @min(remaining, chunk.len);
+            try tf.writeAll(chunk[0..n]);
+            hasher.update(chunk[0..n]);
+            remaining -= n;
+        }
+    }
+    var digest: [32]u8 = undefined;
+    hasher.final(&digest);
+    const hex = std.fmt.bytesToHex(digest, .lower);
+
+    const line = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}  {s}\n",
+        .{ hex, ARCHIVE_NAME },
+    );
+    defer testing.allocator.free(line);
+    try writeFile(checksums, line);
+
+    try writeFile(sigstore, "{}");
+    try writeFakeCosign(cosign_bin, 0);
+
+    try verify.verifyAll(testing.allocator, .{
+        .cosign_bin = cosign_bin,
+        .tarball_path = tarball,
+        .checksums_path = checksums,
+        .sigstore_path = sigstore,
+        .archive_name = ARCHIVE_NAME,
+        .cert_identity_regex = "^https://example\\.com/",
+        .oidc_issuer = "https://example.com",
+    });
+}
+
+test "verifyAll accepts a multi-chunk tarball whose hash matches" {
+    const payload = try patternedPayload(testing.allocator, 160 * 1024);
+    defer testing.allocator.free(payload);
+
+    const hex = sha256Hex(payload);
+    const line = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}  {s}\n",
+        .{ hex, ARCHIVE_NAME },
+    );
+    defer testing.allocator.free(line);
+
+    var fx = try Fixture.setup(testing.allocator, "multi_ok", payload, line, 0);
+    defer fx.deinit(testing.allocator);
+    try verify.verifyAll(testing.allocator, fx.inputs());
+}
+
+test "verifyAll rejects a multi-chunk tarball whose content was tampered" {
+    const payload = try patternedPayload(testing.allocator, 160 * 1024);
+    defer testing.allocator.free(payload);
+
+    const hex = sha256Hex(payload);
+    const line = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}  {s}\n",
+        .{ hex, ARCHIVE_NAME },
+    );
+    defer testing.allocator.free(line);
+
+    // Flip one byte deep inside the second chunk — within the range
+    // that the old chunk-0-only bug used to skip.
+    const tampered = try testing.allocator.dupe(u8, payload);
+    defer testing.allocator.free(tampered);
+    tampered[80 * 1024] ^= 0x01;
+
+    var fx = try Fixture.setup(testing.allocator, "multi_bad", tampered, line, 0);
+    defer fx.deinit(testing.allocator);
+    try testing.expectError(error.ChecksumMismatch, verify.verifyAll(testing.allocator, fx.inputs()));
+}
+
 test "verifyCosignBlob errors when cosign exits non-zero" {
     const path = "/tmp/malt_fake_cosign_fail";
     try writeFakeCosign(path, 1);


### PR DESCRIPTION
## Description

`mt version update` used to pull the entire self-update tarball into memory before hashing it, so peak RSS during an update scaled with the release size (cap: 256 MiB). The tarball now streams through `Sha256` in 64 KiB chunks, so peak RSS is bounded by the chunk buffer regardless of release size.

The streaming helper lives in `src/core/hash.zig` and is shared with `core/cask.zig`, which replaces its private copy of the same loop with a delegate call.

## Related Issue

- none

## Notes for Reviewers

- Smoke-measured under `/usr/bin/time -l`: peak RSS stays flat at ~5.8 MiB whether the tarball is 1 MiB or 256 MiB. Previously it tracked the tarball size 1:1 (256 MiB tarball -> 261 MiB peak RSS).