### PR TITLE
fix(net/client,net/ghcr): surface real cause of bottle download failures

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -335,21 +335,29 @@ fn downloadWorker(
     const http = http_pool.acquire();
     defer http_pool.release(http);
 
-    // Download with transient-failure retry.
-    // GHCR CDN occasionally returns truncated responses or drops connections
-    // under parallel load (21-dep installs like `node` can trigger this).
-    // Retry up to 3 times with exponential backoff (100ms, 400ms) before giving up.
     const max_attempts: u8 = 3;
     const retry_delays_ms = [_]u64{ 100, 400 };
     var dl_attempt: u8 = 0;
     var dl_ok = false;
+    var last_err: bottle_mod.BottleError = bottle_mod.BottleError.DownloadFailed;
     while (dl_attempt < max_attempts) : (dl_attempt += 1) {
         if (bottle_mod.download(allocator, ghcr, http, repo, digest, job.sha256, tmp_dir, progress_cb)) |_| {
             dl_ok = true;
             break;
-        } else |_| {
-            // Wipe the partial tmp and retry
+        } else |dl_err| {
+            last_err = dl_err;
             atomic.cleanupTempDir(tmp_dir);
+            if (dl_err == bottle_mod.BottleError.DownloadPermanent) {
+                output.err("  {s}: permanent HTTP error (404/410), not retrying", .{job.name});
+                break;
+            }
+            if (dl_err == bottle_mod.BottleError.ExtractionFailed or
+                dl_err == bottle_mod.BottleError.Sha256Mismatch or
+                dl_err == bottle_mod.BottleError.PathTooLong)
+            {
+                output.err("  {s}: {s}", .{ job.name, @errorName(dl_err) });
+                break;
+            }
             if (dl_attempt + 1 < max_attempts) {
                 fs_compat.sleepNanos(retry_delays_ms[dl_attempt] * std.time.ns_per_ms);
             }
@@ -357,10 +365,10 @@ fn downloadWorker(
     }
     if (!dl_ok) {
         bar.finish();
-        output.err("  Download failed: {s} (after {d} attempts)", .{ job.name, max_attempts });
+        if (dl_attempt >= max_attempts) {
+            output.err("  {s}: {s} (after {d} attempts)", .{ job.name, @errorName(last_err), max_attempts });
+        }
         allocator.free(tmp_dir);
-        // Thread worker: caller inspects DownloadJob.success rather than
-        // receiving an error — exit the worker, let the coordinator abort.
         return;
     }
     bar.finish();

--- a/src/core/bottle.zig
+++ b/src/core/bottle.zig
@@ -12,6 +12,8 @@ const install_cmd = @import("../cli/install.zig");
 
 pub const BottleError = error{
     DownloadFailed,
+    DownloadPermanent,
+    DownloadRateLimited,
     Sha256Mismatch,
     ExtractionFailed,
     OutOfMemory,
@@ -51,7 +53,13 @@ pub fn download(
     var body: std.ArrayList(u8) = .empty;
     defer body.deinit(allocator);
 
-    ghcr.downloadBlob(allocator, http, repo, digest, &body, progress) catch return BottleError.DownloadFailed;
+    ghcr.downloadBlob(allocator, http, repo, digest, &body, progress) catch |e| {
+        return switch (e) {
+            ghcr_mod.GhcrError.DownloadHttpClientError => BottleError.DownloadPermanent,
+            ghcr_mod.GhcrError.DownloadRateLimited => BottleError.DownloadRateLimited,
+            else => BottleError.DownloadFailed,
+        };
+    };
 
     // Compute SHA256 of downloaded data
     var hash: [32]u8 = undefined;

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -2,6 +2,60 @@ const std = @import("std");
 const fs_compat = @import("../fs/compat.zig");
 const io_mod = @import("../ui/io.zig");
 
+pub const DownloadError = error{
+    Timeout,
+    ConnectionReset,
+    HttpClientError,
+    HttpServerError,
+    RateLimited,
+    TlsDowngradeRefused,
+    ResponseTooLarge,
+    ReadFailed,
+};
+
+pub const DownloadDiagnostic = struct {
+    status: ?u16,
+    url: []const u8,
+    bytes_read: u64,
+    err: DownloadError,
+
+    pub fn isPermanent(self: DownloadDiagnostic) bool {
+        return switch (self.err) {
+            error.HttpClientError => blk: {
+                const s = self.status orelse break :blk false;
+                break :blk s == 404 or s == 410;
+            },
+            error.TlsDowngradeRefused, error.ResponseTooLarge => true,
+            else => false,
+        };
+    }
+};
+
+pub fn classifyStatus(status: u16) ?DownloadError {
+    if (status >= 200 and status < 400) return null;
+    if (status == 429) return error.RateLimited;
+    if (status >= 400 and status < 500) return error.HttpClientError;
+    if (status >= 500) return error.HttpServerError;
+    return null;
+}
+
+pub fn isTransientError(err: DownloadError) bool {
+    return switch (err) {
+        error.Timeout, error.ConnectionReset, error.HttpServerError, error.RateLimited, error.ReadFailed => true,
+        error.HttpClientError, error.TlsDowngradeRefused, error.ResponseTooLarge => false,
+    };
+}
+
+/// Compute read-timeout in nanoseconds scaled by Content-Length.
+/// Floor: 30 s. Scale: content_length / min_bandwidth (64 KiB/s).
+pub fn scaledTimeoutNs(content_length: ?u64) u64 {
+    const floor_ns: u64 = 30 * std.time.ns_per_s;
+    const cl = content_length orelse return floor_ns;
+    const min_bandwidth: u64 = 64 * 1024; // 64 KiB/s
+    const transfer_ns = (cl / min_bandwidth) * std.time.ns_per_s;
+    return @max(floor_ns, transfer_ns);
+}
+
 /// Optional progress reporting for long downloads.
 /// `bytes_so_far`: total bytes received so far (after decompression).
 /// `content_length`: total expected bytes from HTTP header, or null if unknown.
@@ -297,10 +351,9 @@ pub const HttpClient = struct {
         while (true) {
             const result = self.doGetLimited(url, extra_headers, max_bytes, progress);
             if (result) |resp| {
-                // Retry on transient server errors
-                if (resp.status == 429 or resp.status == 503 or resp.status == 504) {
-                    resp.allocator.free(resp.body);
-                    if (attempt < MAX_RETRIES) {
+                if (classifyStatus(resp.status)) |dl_err| {
+                    if (isTransientError(dl_err) and attempt < MAX_RETRIES) {
+                        resp.allocator.free(resp.body);
                         std.Io.sleep(io_mod.ctx(), std.Io.Duration.fromNanoseconds(@intCast(RETRY_DELAYS_MS[attempt] * std.time.ns_per_ms)), .awake) catch {};
                         attempt += 1;
                         continue;
@@ -308,7 +361,6 @@ pub const HttpClient = struct {
                 }
                 return resp;
             } else |err| {
-                // Retry on connection errors
                 if (attempt < MAX_RETRIES) {
                     std.Io.sleep(io_mod.ctx(), std.Io.Duration.fromNanoseconds(@intCast(RETRY_DELAYS_MS[attempt] * std.time.ns_per_ms)), .awake) catch {};
                     attempt += 1;
@@ -383,7 +435,10 @@ pub const HttpClient = struct {
         // implementation slept in 1 s ticks and could stall `join()` by
         // up to a full second per request — that was the entire warm
         // install floor (see docs/perf/results.md).
-        const effective_timeout = if (max_bytes > MAX_METADATA_BYTES) BLOB_TIMEOUT_NS else self.timeout_ns;
+        const effective_timeout = if (max_bytes > MAX_METADATA_BYTES)
+            @max(BLOB_TIMEOUT_NS, scaledTimeoutNs(content_length))
+        else
+            self.timeout_ns;
         var request_done: std.Io.Event = .unset;
         const watchdog = std.Thread.spawn(.{}, watchdogFn, .{
             &request_done,

--- a/src/net/ghcr.zig
+++ b/src/net/ghcr.zig
@@ -10,6 +10,11 @@ const io_mod = @import("../ui/io.zig");
 pub const GhcrError = error{
     TokenFetchFailed,
     DownloadFailed,
+    DownloadTimeout,
+    DownloadConnectionReset,
+    DownloadHttpClientError,
+    DownloadHttpServerError,
+    DownloadRateLimited,
     Unauthorized,
     InvalidResponse,
     OutOfMemory,
@@ -211,17 +216,13 @@ pub const GhcrClient = struct {
         body_out: *std.ArrayList(u8),
         progress: ?client_mod.ProgressCallback,
     ) GhcrError!void {
-        // Get token through the mutex-protected cache (avoids redundant fetches).
-        // `fetchToken` returns an owned dupe — free before leaving.
         const token = self.fetchToken(http, repo) catch return GhcrError.TokenFetchFailed;
         defer self.allocator.free(token);
 
-        // Build URL: https://ghcr.io/v2/{repo}/blobs/{digest}
         var url_buf: [512]u8 = undefined;
         const url = std.fmt.bufPrint(&url_buf, "https://ghcr.io/v2/{s}/blobs/{s}", .{ repo, digest }) catch
             return GhcrError.OutOfMemory;
 
-        // Download with cached token
         var auth_buf: [2048]u8 = undefined;
         const auth_value = std.fmt.bufPrint(&auth_buf, "Bearer {s}", .{token}) catch
             return GhcrError.OutOfMemory;
@@ -234,9 +235,26 @@ pub const GhcrClient = struct {
             return GhcrError.DownloadFailed;
         defer resp.deinit();
 
-        if (resp.status != 200) return GhcrError.DownloadFailed;
+        if (resp.status == 401) return GhcrError.Unauthorized;
+        if (resp.status != 200) {
+            return classifyGhcrStatus(resp.status);
+        }
 
         body_out.appendSlice(allocator, resp.body) catch return GhcrError.OutOfMemory;
+    }
+
+    pub fn classifyGhcrStatus(status: u16) GhcrError {
+        if (client_mod.classifyStatus(status)) |dl_err| {
+            return switch (dl_err) {
+                error.RateLimited => GhcrError.DownloadRateLimited,
+                error.HttpClientError => GhcrError.DownloadHttpClientError,
+                error.HttpServerError => GhcrError.DownloadHttpServerError,
+                error.Timeout => GhcrError.DownloadTimeout,
+                error.ConnectionReset => GhcrError.DownloadConnectionReset,
+                else => GhcrError.DownloadFailed,
+            };
+        }
+        return GhcrError.DownloadFailed;
     }
 };
 

--- a/tests/ghcr_test.zig
+++ b/tests/ghcr_test.zig
@@ -111,6 +111,28 @@ test "hasTokenFor is false before any fetch and true after a direct cache seed" 
     try testing.expect(!g.hasTokenFor("homebrew/core/tree"));
 }
 
+// ── GHCR error classification ──────────────────────────────────────
+
+test "classifyGhcrStatus: 404 maps to DownloadHttpClientError" {
+    try testing.expectEqual(ghcr.GhcrError.DownloadHttpClientError, ghcr.GhcrClient.classifyGhcrStatus(404));
+}
+
+test "classifyGhcrStatus: 410 maps to DownloadHttpClientError" {
+    try testing.expectEqual(ghcr.GhcrError.DownloadHttpClientError, ghcr.GhcrClient.classifyGhcrStatus(410));
+}
+
+test "classifyGhcrStatus: 429 maps to DownloadRateLimited" {
+    try testing.expectEqual(ghcr.GhcrError.DownloadRateLimited, ghcr.GhcrClient.classifyGhcrStatus(429));
+}
+
+test "classifyGhcrStatus: 500 maps to DownloadHttpServerError" {
+    try testing.expectEqual(ghcr.GhcrError.DownloadHttpServerError, ghcr.GhcrClient.classifyGhcrStatus(500));
+}
+
+test "classifyGhcrStatus: 503 maps to DownloadHttpServerError" {
+    try testing.expectEqual(ghcr.GhcrError.DownloadHttpServerError, ghcr.GhcrClient.classifyGhcrStatus(503));
+}
+
 test "hasTokenFor treats expired tokens as cache-miss" {
     var pool = try client_mod.HttpClientPool.init(testing.allocator, 1);
     defer pool.deinit();

--- a/tests/net_client_test.zig
+++ b/tests/net_client_test.zig
@@ -106,3 +106,160 @@ test "HttpClient.headResolved: returns OOM with no leak when initial url dupe fa
 
     try testing.expectError(error.OutOfMemory, http.headResolved("https://example.com/"));
 }
+
+// ── Download error classification ──────────────────────────────────
+
+test "classifyStatus: 200 is not an error" {
+    try testing.expectEqual(@as(?client.DownloadError, null), client.classifyStatus(200));
+}
+
+test "classifyStatus: 301 redirect is not an error" {
+    try testing.expectEqual(@as(?client.DownloadError, null), client.classifyStatus(301));
+}
+
+test "classifyStatus: 404 is HttpClientError" {
+    try testing.expectEqual(@as(?client.DownloadError, error.HttpClientError), client.classifyStatus(404));
+}
+
+test "classifyStatus: 410 is HttpClientError" {
+    try testing.expectEqual(@as(?client.DownloadError, error.HttpClientError), client.classifyStatus(410));
+}
+
+test "classifyStatus: 429 is RateLimited" {
+    try testing.expectEqual(@as(?client.DownloadError, error.RateLimited), client.classifyStatus(429));
+}
+
+test "classifyStatus: 500 is HttpServerError" {
+    try testing.expectEqual(@as(?client.DownloadError, error.HttpServerError), client.classifyStatus(500));
+}
+
+test "classifyStatus: 503 is HttpServerError" {
+    try testing.expectEqual(@as(?client.DownloadError, error.HttpServerError), client.classifyStatus(503));
+}
+
+test "isTransientError: Timeout is transient" {
+    try testing.expect(client.isTransientError(error.Timeout));
+}
+
+test "isTransientError: ConnectionReset is transient" {
+    try testing.expect(client.isTransientError(error.ConnectionReset));
+}
+
+test "isTransientError: HttpServerError is transient" {
+    try testing.expect(client.isTransientError(error.HttpServerError));
+}
+
+test "isTransientError: RateLimited is transient" {
+    try testing.expect(client.isTransientError(error.RateLimited));
+}
+
+test "isTransientError: HttpClientError is permanent" {
+    try testing.expect(!client.isTransientError(error.HttpClientError));
+}
+
+test "isTransientError: TlsDowngradeRefused is permanent" {
+    try testing.expect(!client.isTransientError(error.TlsDowngradeRefused));
+}
+
+test "DownloadDiagnostic.isPermanent: 404 is permanent" {
+    const d = client.DownloadDiagnostic{
+        .status = 404,
+        .url = "https://ghcr.io/v2/homebrew/core/rust/blobs/sha256:abc",
+        .bytes_read = 0,
+        .err = error.HttpClientError,
+    };
+    try testing.expect(d.isPermanent());
+}
+
+test "DownloadDiagnostic.isPermanent: 410 is permanent" {
+    const d = client.DownloadDiagnostic{
+        .status = 410,
+        .url = "https://ghcr.io/v2/homebrew/core/rust/blobs/sha256:abc",
+        .bytes_read = 0,
+        .err = error.HttpClientError,
+    };
+    try testing.expect(d.isPermanent());
+}
+
+test "DownloadDiagnostic.isPermanent: 403 is not permanent" {
+    const d = client.DownloadDiagnostic{
+        .status = 403,
+        .url = "https://ghcr.io/v2/homebrew/core/rust/blobs/sha256:abc",
+        .bytes_read = 0,
+        .err = error.HttpClientError,
+    };
+    try testing.expect(!d.isPermanent());
+}
+
+test "DownloadDiagnostic.isPermanent: 500 is not permanent" {
+    const d = client.DownloadDiagnostic{
+        .status = 500,
+        .url = "https://ghcr.io/v2/homebrew/core/rust/blobs/sha256:abc",
+        .bytes_read = 42,
+        .err = error.HttpServerError,
+    };
+    try testing.expect(!d.isPermanent());
+}
+
+test "DownloadDiagnostic.isPermanent: TlsDowngradeRefused is permanent" {
+    const d = client.DownloadDiagnostic{
+        .status = null,
+        .url = "https://ghcr.io/...",
+        .bytes_read = 0,
+        .err = error.TlsDowngradeRefused,
+    };
+    try testing.expect(d.isPermanent());
+}
+
+// ── Scaled timeout ─────────────────────────────────────────────────
+
+test "scaledTimeoutNs: null content_length returns floor (30s)" {
+    try testing.expectEqual(@as(u64, 30 * std.time.ns_per_s), client.scaledTimeoutNs(null));
+}
+
+test "scaledTimeoutNs: small file returns floor" {
+    // 1 MiB at 64 KiB/s = 16 s, below 30 s floor
+    try testing.expectEqual(@as(u64, 30 * std.time.ns_per_s), client.scaledTimeoutNs(1024 * 1024));
+}
+
+test "scaledTimeoutNs: 500 MiB file gets generous timeout" {
+    const cl: u64 = 500 * 1024 * 1024;
+    const result = client.scaledTimeoutNs(cl);
+    // 500 MiB / 64 KiB/s = 8000 s
+    try testing.expectEqual(@as(u64, 8000 * std.time.ns_per_s), result);
+}
+
+test "scaledTimeoutNs: 0-length file returns floor" {
+    try testing.expectEqual(@as(u64, 30 * std.time.ns_per_s), client.scaledTimeoutNs(0));
+}
+
+test "scaledTimeoutNs: null combined with BLOB_TIMEOUT_NS keeps 10-min minimum" {
+    // Blob downloads use @max(BLOB_TIMEOUT_NS, scaledTimeoutNs(cl)).
+    // When Content-Length is null (chunked), scaledTimeoutNs returns 30s,
+    // but the blob floor must dominate.
+    const blob_timeout = 600 * std.time.ns_per_s;
+    const scaled = client.scaledTimeoutNs(null);
+    try testing.expect(@max(blob_timeout, scaled) == blob_timeout);
+}
+
+// ── Retry short-circuit: permanent errors must not retry ───────────
+
+test "classifyStatus + isTransientError: 404 is not retried" {
+    const err = client.classifyStatus(404).?;
+    try testing.expect(!client.isTransientError(err));
+}
+
+test "classifyStatus + isTransientError: 410 is not retried" {
+    const err = client.classifyStatus(410).?;
+    try testing.expect(!client.isTransientError(err));
+}
+
+test "classifyStatus + isTransientError: 500 is retried" {
+    const err = client.classifyStatus(500).?;
+    try testing.expect(client.isTransientError(err));
+}
+
+test "classifyStatus + isTransientError: 429 is retried" {
+    const err = client.classifyStatus(429).?;
+    try testing.expect(client.isTransientError(err));
+}


### PR DESCRIPTION
## Description

Replaces the opaque "Download failed" message with the actual failure cause - ExtractionFailed, Sha256Mismatch, PathTooLong, or the specific HTTP error class (4xx permanent, 5xx transient, 429 rate-limited). The retry loop now short-circuits on non-transient errors instead of burning the full backoff budget. Read-timeout scales with Content-Length so very large bottles are not aborted on a slow link.

## Related Issue

- None

## Notes for Reviewers

Installs that used to print a wall of "Download failed" now surface the real cause. Permanent HTTP errors (404/410) and non-download failures (extraction, SHA mismatch) exit immediately; transient errors (5xx, resets, rate-limits) still retry with adaptive timeouts.