### PR TITLE
fix(fs/archive): allow prefix-relative symlinks in bottle extraction

### DIFF
--- a/src/fs/archive.zig
+++ b/src/fs/archive.zig
@@ -24,19 +24,20 @@ pub fn isSafeEntryPath(name: []const u8) bool {
     return true;
 }
 
-/// Symlink targets may legitimately use `..` to point at a sibling within
-/// the extracted bundle (e.g. Apple `.xctoolchain`'s `usr/bin -> ../../../bin`).
+/// Symlink targets may climb to a sibling inside the bundle (Apple
+/// `.xctoolchain`) or one level above it — bottles reach sibling formulas
+/// via `<prefix>/opt/<name>`, resolved against the implicit Cellar parent.
 /// Resolve `link_name` lexically against `dirname(entry_name)` and reject
-/// only when the result would escape the extraction root, or when the
-/// target is absolute, empty, or NUL-bearing. `entry_name` is assumed to
-/// have already passed `isSafeEntryPath`.
+/// climbs deeper than that, plus absolute, empty, or NUL-bearing targets.
+/// `entry_name` is assumed to have passed `isSafeEntryPath`, so a later
+/// entry cannot chain through the escape beyond the prefix parent.
 pub fn isSafeSymlinkTarget(entry_name: []const u8, link_name: []const u8) bool {
     if (link_name.len == 0) return false;
     if (link_name[0] == '/') return false;
     if (std.mem.indexOfScalar(u8, link_name, 0) != null) return false;
 
     // Parent depth: components in entry_name minus the symlink's own slot.
-    var parent_depth: usize = 0;
+    var parent_depth: isize = 0;
     var name_it = std.mem.splitScalar(u8, entry_name, '/');
     while (name_it.next()) |comp| {
         if (comp.len == 0 or std.mem.eql(u8, comp, ".")) continue;
@@ -51,8 +52,10 @@ pub fn isSafeSymlinkTarget(entry_name: []const u8, link_name: []const u8) bool {
     while (link_it.next()) |comp| {
         if (comp.len == 0 or std.mem.eql(u8, comp, ".")) continue;
         if (std.mem.eql(u8, comp, "..")) {
-            if (depth == 0) return false;
             depth -= 1;
+            // -1 lands in the prefix parent (legitimate bottle shape);
+            // anything beyond is genuine escape.
+            if (depth < -1) return false;
         } else {
             depth += 1;
         }

--- a/tests/archive_test.zig
+++ b/tests/archive_test.zig
@@ -377,13 +377,32 @@ test "isSafeSymlinkTarget: accepts intra-bundle relative targets" {
     try testing.expect(archive.isSafeSymlinkTarget("a/b/link", "./c/./d"));
 }
 
-test "isSafeSymlinkTarget: rejects targets that escape the root" {
-    // One `..` too many — entry sits at depth 1 (parent depth 0).
-    try testing.expect(!archive.isSafeSymlinkTarget("link", "../escape"));
-    // 4 `..` from a 3-deep parent overshoots.
-    try testing.expect(!archive.isSafeSymlinkTarget("a/b/c/link", "../../../../etc"));
-    // Mid-path overshoot: pops to root then climbs back — still escaped at the pop.
-    try testing.expect(!archive.isSafeSymlinkTarget("a/link", "../../oops/back"));
+test "isSafeSymlinkTarget: accepts prefix-relative targets one level above root" {
+    // Rust bottle shape: 7 ../ from a 6-deep parent lands in the prefix
+    // parent and descends into the sibling formula's opt path.
+    try testing.expect(archive.isSafeSymlinkTarget(
+        "rust/1.95.0/lib/rustlib/aarch64-apple-darwin/bin/rust-objcopy",
+        "../../../../../../../opt/llvm/bin/llvm-objcopy",
+    ));
+    // Minimum case: top-level entry climbing exactly to the prefix parent.
+    try testing.expect(archive.isSafeSymlinkTarget("link", "../opt/sibling"));
+    // Deep entry whose `..` run lands at the prefix parent, then descends.
+    try testing.expect(archive.isSafeSymlinkTarget(
+        "a/b/c/link",
+        "../../../../etc/shared",
+    ));
+}
+
+test "isSafeSymlinkTarget: rejects targets that climb beyond the prefix parent" {
+    // +2 from a top-level entry — one step past the prefix parent.
+    try testing.expect(!archive.isSafeSymlinkTarget("link", "../../escape"));
+    // +2 from a deeper entry: 5 `..` from parent_depth 3 underflows by two.
+    try testing.expect(!archive.isSafeSymlinkTarget(
+        "a/b/c/link",
+        "../../../../../etc",
+    ));
+    // Mid-path overshoot: pops past the prefix parent before climbing back.
+    try testing.expect(!archive.isSafeSymlinkTarget("a/link", "../../../oops/back"));
 }
 
 test "isSafeSymlinkTarget: rejects absolute, empty, and NUL-bearing targets" {


### PR DESCRIPTION
## Description

Relaxes the bottle-extraction symlink validator by exactly one parent level so Homebrew bottles with sibling-formula references (rust -> llvm, etc.) extract cleanly. Tar-slip defences stay intact: absolute targets, NUL bytes, and over-escape beyond the prefix parent remain rejected.

## Related Issue

- None

## Notes for Reviewers

Bottles like rust and llvm ship symlinks whose target climbs one level above the tar root so they resolve, once moved into Cellar, into the sibling formula's opt path. Before this, those bottles failed extraction on every prefix. Two new unit tests pin the accepted cases (rust-style 7-deep sibling, top-level prefix-parent) and the rejections (absolute, NUL, +2 over-escape). Verified end-to-end: `MALT_PREFIX=/tmp/mt_tahoe mt install rust` materialises rust + llvm, and rustc compiles and runs a hello world.
