### PR TITLE
fix(core/cellar): grow overflowing Mach-O slots via install_name_tool

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -178,6 +178,8 @@ pub fn build(b: *std.Build) void {
         "tests/migrate_smoke_test.zig",
         "tests/upgrade_test.zig",
         "tests/hash_test.zig",
+        "tests/patcher_test.zig",
+        "tests/patch_facade_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/scripts/local-smoke-install.sh
+++ b/scripts/local-smoke-install.sh
@@ -66,7 +66,10 @@ MT_BIN="$(cd "$(dirname "$MT_BIN")" && pwd)/$(basename "$MT_BIN")"
 PREFIX=$(mktemp -d /tmp/mt.XXX)
 CACHE=$(mktemp -d /tmp/mc.XXX)
 LOGDIR=$(mktemp -d /tmp/ml.XXX)
-trap 'rm -rf "$PREFIX" "$CACHE" "$LOGDIR"' EXIT
+# /tmp/mt_tahoe + /tmp/mc_tahoe are the python overflow-fallback case's
+# fixed sandbox paths; sweep them too so an early abort never strands
+# them on disk.
+trap 'rm -rf "$PREFIX" "$CACHE" "$LOGDIR" /tmp/mt_tahoe /tmp/mc_tahoe' EXIT
 
 export MALT_PREFIX="$PREFIX"
 export MALT_CACHE="$CACHE"
@@ -149,10 +152,12 @@ install_binary_cask() {
 # under dyld). Self-contained: own prefix/cache, own cleanup.
 install_python_overflow_fallback() {
   local tag="smoke.install.python_overflow_fallback"
+  # Fixed paths so the global EXIT trap below can reach them by literal
+  # name without inheriting the function's locals (which are unset
+  # under `set -u` once the function returns).
   local long_prefix=/tmp/mt_tahoe # 13 bytes — just over the placeholder
   local long_cache=/tmp/mc_tahoe
   rm -rf "$long_prefix" "$long_cache"
-  trap 'rm -rf "$PREFIX" "$CACHE" "$LOGDIR" "$long_prefix" "$long_cache"' EXIT
 
   if MALT_PREFIX="$long_prefix" MALT_CACHE="$long_cache" \
     run "$tag" "$MT_BIN" install python@3.14; then

--- a/scripts/local-smoke-install.sh
+++ b/scripts/local-smoke-install.sh
@@ -21,8 +21,17 @@
 #   • mt install --cask copilot-cli — cask `binary` artifact (symlinks a CLI
 #                                 into $PREFIX/bin). Exercises the
 #                                 non-/Applications cask codepath.
+#   • mt install python@3.14 (long prefix) — install_name_tool overflow
+#                                 fallback. python@3.14 has the tightest
+#                                 @@HOMEBREW_CELLAR@@ slots in homebrew/core;
+#                                 under any prefix > 12 bytes the in-place
+#                                 patcher overflows by one byte and the
+#                                 fallback grows the slot via subprocess.
+#                                 The case verifies otool sees the long
+#                                 path AND python3.14 actually loads at
+#                                 runtime under the long prefix.
 #
-# Time/bandwidth: ~15–25 min, ~3 GB downloaded fresh.
+# Time/bandwidth: ~20-30 min, ~3.5 GB downloaded fresh.
 #
 # Cleanup: on success (FAIL=0), every cask installed by this run is
 # `mt uninstall`-ed and every formula too — so /Applications and any
@@ -49,9 +58,11 @@ if [[ ! -x "$MT_BIN" ]]; then
 fi
 MT_BIN="$(cd "$(dirname "$MT_BIN")" && pwd)/$(basename "$MT_BIN")"
 
-# Short prefix template — the Mach-O in-place patcher caps at 13 bytes
-# because Homebrew bottles hard-code `/opt/homebrew` (13 bytes) in
-# LC_LOAD_DYLIB entries. `/tmp/mt.XXX` keeps us at 11 bytes with room.
+# Short prefix for the main loop. Most bottles' load-command slots fit
+# any reasonable prefix in-place; using 11 bytes keeps the fast path
+# in scope for the bulk of the run. The python@3.14 case below uses
+# its own 13-byte prefix to actively exercise the install_name_tool
+# overflow fallback.
 PREFIX=$(mktemp -d /tmp/mt.XXX)
 CACHE=$(mktemp -d /tmp/mc.XXX)
 LOGDIR=$(mktemp -d /tmp/ml.XXX)
@@ -130,6 +141,45 @@ install_binary_cask() {
   fi
 }
 
+# python@3.14 + a >12-byte MALT_PREFIX is the canonical install_name_tool
+# overflow case: tight @@HOMEBREW_CELLAR@@ slots overflow by one byte
+# and the in-place patcher hands them to install_name_tool. We pin both
+# the patched-binary shape (otool sees the long path) and the runtime
+# (python3.14 imports ssl, proving the rewritten LC_LOAD_DYLIBs resolve
+# under dyld). Self-contained: own prefix/cache, own cleanup.
+install_python_overflow_fallback() {
+  local tag="smoke.install.python_overflow_fallback"
+  local long_prefix=/tmp/mt_tahoe # 13 bytes — just over the placeholder
+  local long_cache=/tmp/mc_tahoe
+  rm -rf "$long_prefix" "$long_cache"
+  trap 'rm -rf "$PREFIX" "$CACHE" "$LOGDIR" "$long_prefix" "$long_cache"' EXIT
+
+  if MALT_PREFIX="$long_prefix" MALT_CACHE="$long_cache" \
+    run "$tag" "$MT_BIN" install python@3.14; then
+    local libpath
+    libpath=$(find "$long_prefix/Cellar/python@3.14" -name 'libpython3.14.dylib' 2>/dev/null | head -1)
+    if [[ -n "$libpath" ]] && otool -L "$libpath" 2>/dev/null | grep -q "$long_prefix"; then
+      printf '  PASS  [%s.otool] long prefix in LC_LOAD_DYLIB\n' "$tag"
+      PASS=$((PASS + 1))
+    else
+      printf '  FAIL  [%s.otool] %s missing from LC_LOAD_DYLIB\n' "$tag" "$long_prefix"
+      FAIL=$((FAIL + 1))
+      FAILURES+=("$tag.otool")
+    fi
+    if MALT_PREFIX="$long_prefix" "$long_prefix/bin/python3.14" \
+      -c 'import ssl' >/dev/null 2>&1; then
+      printf '  PASS  [%s.runtime] python3.14 imports ssl under long prefix\n' "$tag"
+      PASS=$((PASS + 1))
+    else
+      printf '  FAIL  [%s.runtime] python3.14 dyld broken under long prefix\n' "$tag"
+      FAIL=$((FAIL + 1))
+      FAILURES+=("$tag.runtime")
+    fi
+    MALT_PREFIX="$long_prefix" "$MT_BIN" uninstall python@3.14 >/dev/null 2>&1 || true
+  fi
+  rm -rf "$long_prefix" "$long_cache"
+}
+
 # Reverse what we installed. Casks first because they touch /Applications;
 # formulas second (they live entirely under MALT_PREFIX, but uninstalling
 # also exercises the uninstall path). Best-effort: a stuck uninstall must
@@ -161,6 +211,7 @@ install_formula smoke.install.rust rust
 install_formula smoke.install.go go
 install_cask smoke.install.cask.raycast raycast Raycast.app
 install_binary_cask smoke.install.cask.copilot-cli copilot-cli
+install_python_overflow_fallback
 
 printf '\n── Summary ───────────────────────────────────────\n'
 printf '  passed: %d\n' "$PASS"

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -14,6 +14,7 @@ const color = @import("../ui/color.zig");
 const help = @import("help.zig");
 const install_mod = @import("install.zig");
 const parser = @import("../macho/parser.zig");
+const patch = @import("../core/patch.zig");
 const perms_mod = @import("../core/perms.zig");
 
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
@@ -124,21 +125,25 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         }
     }
 
-    // 3b. Prefix length — Mach-O in-place patching budget.
-    //     A long MALT_PREFIX cannot fit inside the load-command slot and will
-    //     silently break every bottle that hard-codes /opt/homebrew paths.
-    install_mod.checkPrefixLength(prefix) catch {
-        var pl_buf: [256]u8 = undefined;
-        const pl_msg = std.fmt.bufPrint(
-            &pl_buf,
-            "MALT_PREFIX '{s}' is {d} bytes, exceeds {d}-byte Mach-O patch budget. Set MALT_PREFIX to a shorter path.",
-            .{ prefix, prefix.len, install_mod.max_prefix_len },
-        ) catch "MALT_PREFIX exceeds the Mach-O patch budget. Set MALT_PREFIX to a shorter path.";
-        printCheck("Prefix length", .err_status, pl_msg);
-        errors += 1;
-    };
-    if (prefix.len <= install_mod.max_prefix_len) {
-        printCheck("Prefix length", .ok, null);
+    // 3b. External relocation tool — required by the Mach-O overflow
+    //     fallback. Bottles whose load-command slots don't fit the new
+    //     prefix get grown via this binary; without it, installs of
+    //     those bottles fail. Realistic prefixes fit in-place for most
+    //     bottles, so this is a warning (not an error) when absent.
+    {
+        const tool = patch.external_tool_name;
+        if (externalToolAvailable(tool)) {
+            printCheck(tool, .ok, null);
+        } else {
+            var et_buf: [256]u8 = undefined;
+            const et_msg = std.fmt.bufPrint(
+                &et_buf,
+                "`{s}` not found on PATH. Install Xcode Command Line Tools: xcode-select --install",
+                .{tool},
+            ) catch "External relocation tool missing. Install Xcode Command Line Tools.";
+            printCheck(tool, .warn_status, et_msg);
+            warnings += 1;
+        }
     }
 
     // 4. APFS volume
@@ -564,6 +569,30 @@ fn hasUnpatchedPlaceholder(
     for (macho.paths) |lcp| {
         if (std.mem.indexOf(u8, lcp.path, "@@HOMEBREW_PREFIX@@") != null) return true;
         if (std.mem.indexOf(u8, lcp.path, "@@HOMEBREW_CELLAR@@") != null) return true;
+    }
+    return false;
+}
+
+/// Fast existence check for a platform relocation tool on PATH.
+/// Tries `/usr/bin/<tool>` first (where Xcode Command Line Tools land
+/// install_name_tool) and then walks `PATH` entry-by-entry. `pub` so
+/// the doctor render test can exercise both branches.
+pub fn externalToolAvailable(tool: []const u8) bool {
+    // Fast path for the common macOS case — avoids allocating a PATH
+    // walk on every `mt doctor` invocation.
+    var fast_buf: [64]u8 = undefined;
+    const fast_path = std.fmt.bufPrint(&fast_buf, "/usr/bin/{s}", .{tool}) catch null;
+    if (fast_path) |p| {
+        if (fs_compat.accessAbsolute(p, .{})) |_| return true else |_| {}
+    }
+
+    const path_env = fs_compat.getenv("PATH") orelse return false;
+    var it = std.mem.splitScalar(u8, path_env, ':');
+    while (it.next()) |dir| {
+        if (dir.len == 0) continue;
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const full = std.fmt.bufPrint(&buf, "{s}/{s}", .{ dir, tool }) catch continue;
+        if (fs_compat.accessAbsolute(full, .{})) |_| return true else |_| {}
     }
     return false;
 }

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -28,22 +28,18 @@ const supervisor_mod = @import("../core/services/supervisor.zig");
 const plist_mod = @import("../core/services/plist.zig");
 const help = @import("help.zig");
 
-/// Maximum safe byte length for MALT_PREFIX.
-///
-/// Homebrew bottles hard-code `/opt/homebrew` (13 bytes) in LC_LOAD_DYLIB
-/// load-command paths. `malt` rewrites that prefix in place during
-/// materialize, and the replacement path must not be longer than the
-/// original or the load command will not fit its pre-allocated slot and
-/// dyld will refuse to load the binary.
-///
-/// Keeping MALT_PREFIX ≤ 13 bytes guarantees the rewrite always fits,
-/// matching the rationale called out in README.md (§"Directory Layout").
-pub const max_prefix_len: usize = "/opt/homebrew".len;
+/// Upper bound on MALT_PREFIX byte length. This is a sanity cap, not a
+/// correctness gate: the Mach-O relocation pipeline (see
+/// `src/core/patch.zig`) grows overflowing load-command slots via
+/// `install_name_tool`, so realistic prefixes of any practical length
+/// work without preflight rejection. The cap just keeps pathological
+/// values from reaching the subprocess.
+pub const max_prefix_sane_len: usize = 256;
 
-pub const PrefixError = error{PrefixTooLong};
+pub const PrefixError = error{PrefixAbsurd};
 
-/// Refuse to proceed when MALT_PREFIX exceeds `max_prefix_len`. Exposed so
-/// `mt doctor` can reuse the same rule.
+/// Reject MALT_PREFIX values past the sanity cap. Exposed so `mt doctor`
+/// can reuse the same rule.
 /// Parsed `<repo>@<digest>` reference from a GHCR blob URL.
 /// Both fields are slices into the input URL — no allocation; valid
 /// for the lifetime of the caller's string.
@@ -68,8 +64,8 @@ pub fn parseGhcrUrl(url: []const u8) ?GhcrRef {
     };
 }
 
-pub fn checkPrefixLength(prefix: []const u8) PrefixError!void {
-    if (prefix.len > max_prefix_len) return error.PrefixTooLong;
+pub fn checkPrefixSane(prefix: []const u8) PrefixError!void {
+    if (prefix.len > max_prefix_sane_len) return error.PrefixAbsurd;
 }
 
 pub const InstallError = error{
@@ -88,10 +84,10 @@ pub const InstallError = error{
     /// or was skipped because an ancestor dep failed. Returned from `execute`
     /// so `main` exits non-zero.
     PartialFailure,
-    /// MALT_PREFIX is longer than the Mach-O in-place patching budget. Set
-    /// before any network activity so the user can fix it without waiting on
-    /// a multi-gigabyte download that will inevitably fail.
-    PrefixTooLong,
+    /// MALT_PREFIX is absurdly long (exceeds the 256-byte sanity cap).
+    /// Raised before any network activity so pathological values never
+    /// reach the relocation subprocess.
+    PrefixAbsurd,
     /// Formula defines a Ruby `post_install` hook that malt cannot execute.
     /// Raised before any dep resolution or job queueing so nothing is
     /// downloaded, materialised, or linked for the affected package.
@@ -496,21 +492,18 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // Initialize infrastructure
     const prefix = atomic.maltPrefix();
 
-    // Pre-flight: refuse the install if MALT_PREFIX is longer than the
-    // Mach-O in-place patching budget. We catch this BEFORE any network
-    // activity so users do not spend minutes downloading bottles that are
-    // guaranteed to fail at patch time.
-    checkPrefixLength(prefix) catch |err| switch (err) {
-        error.PrefixTooLong => {
+    // Sanity cap: refuse absurdly long prefixes before any network
+    // activity. Realistic values sail through — install_name_tool grows
+    // overflowing load-command slots into the bottle's __LINKEDIT
+    // padding.
+    checkPrefixSane(prefix) catch |err| switch (err) {
+        error.PrefixAbsurd => {
             output.err(
-                "MALT_PREFIX '{s}' is {d} bytes, which exceeds the {d}-byte budget for Mach-O in-place patching.",
-                .{ prefix, prefix.len, max_prefix_len },
+                "MALT_PREFIX '{s}' is {d} bytes, beyond the {d}-byte sanity cap.",
+                .{ prefix, prefix.len, max_prefix_sane_len },
             );
-            output.err("Homebrew bottles hard-code `/opt/homebrew` (13 bytes) in LC_LOAD_DYLIB", .{});
-            output.err("entries, and malt replaces that prefix in place — the replacement must", .{});
-            output.err("not be longer or dyld will fail to load the binaries at runtime.", .{});
-            output.err("Set MALT_PREFIX to a shorter path (e.g. /opt/malt or /tmp/mt) and retry.", .{});
-            return InstallError.PrefixTooLong;
+            output.err("Set MALT_PREFIX to a reasonable path and retry.", .{});
+            return InstallError.PrefixAbsurd;
         },
     };
 
@@ -2068,7 +2061,7 @@ pub fn localErrorIsAnnounced(e: InstallError) bool {
         InstallError.LinkFailed,
         InstallError.RecordFailed,
         InstallError.PartialFailure,
-        InstallError.PrefixTooLong,
+        InstallError.PrefixAbsurd,
         InstallError.PostInstallUnsupported,
         InstallError.AmbiguousSystemRubyScope,
         => false,

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -4,7 +4,14 @@
 const std = @import("std");
 const fs_compat = @import("../fs/compat.zig");
 const clonefile = @import("../fs/clonefile.zig");
-const patcher = @import("../macho/patcher.zig");
+// Binary-format-agnostic relocation facade. The Linux task plugs in
+// an ELF backend behind the same surface, so cellar never reaches past
+// it into `macho/patcher.zig` for load-command work.
+const patch = @import("patch.zig");
+// `patchTextFiles` is byte-level text substitution, not a format
+// concern, so it still lives on the Mach-O module — safe to import
+// directly without widening the facade.
+const text_patcher = @import("../macho/patcher.zig");
 const codesign = @import("../macho/codesign.zig");
 const atomic = @import("../fs/atomic.zig");
 
@@ -12,6 +19,15 @@ pub const CellarError = error{
     CloneFailed,
     PatchFailed,
     PathTooLong,
+    /// A bottle's load-command slot overflowed AND the install_name_tool
+    /// fallback reported that the binary's __LINKEDIT padding is
+    /// exhausted. Only actionable by shortening MALT_PREFIX or
+    /// rebuilding the bottle with `-headerpad_max_install_names`.
+    InsufficientHeaderPad,
+    /// `install_name_tool` is not on PATH. Surfaced separately so
+    /// `mt doctor` / user messaging can point at Xcode Command Line
+    /// Tools as the remediation.
+    InstallNameToolMissing,
     CodesignFailed,
     RemoveFailed,
     OutOfMemory,
@@ -24,6 +40,8 @@ pub fn describeError(err: CellarError) []const u8 {
         CellarError.CloneFailed => "APFS clonefile or copy failed",
         CellarError.PatchFailed => "Mach-O or text-file path patching failed",
         CellarError.PathTooLong => "new prefix path is longer than the bottle was built with",
+        CellarError.InsufficientHeaderPad => "install_name_tool: bottle built without -headerpad_max_install_names",
+        CellarError.InstallNameToolMissing => "install_name_tool not found on PATH (install Xcode Command Line Tools)",
         CellarError.CodesignFailed => "codesign re-signing failed",
         CellarError.RemoveFailed => "cellar directory removal failed",
         CellarError.OutOfMemory => "out of memory",
@@ -187,6 +205,8 @@ pub fn materializeWithCellar(
         &modified_macho_paths,
     ) catch |e| switch (e) {
         CellarError.PathTooLong => return CellarError.PathTooLong,
+        CellarError.InsufficientHeaderPad => return CellarError.InsufficientHeaderPad,
+        CellarError.InstallNameToolMissing => return CellarError.InstallNameToolMissing,
         else => return CellarError.PatchFailed,
     };
 
@@ -194,13 +214,13 @@ pub fn materializeWithCellar(
     // placeholders appear in scripts, .pc files, and configs regardless of
     // whether the bottle is relocatable. Text files don't carry code
     // signatures so they don't feed back into the codesign list.
-    const text_replacements = [_]patcher.Replacement{
+    const text_replacements = [_]text_patcher.Replacement{
         .{ .old = "@@HOMEBREW_PREFIX@@", .new = new_prefix },
         .{ .old = "@@HOMEBREW_CELLAR@@", .new = new_cellar },
         .{ .old = "/opt/homebrew", .new = new_prefix },
         .{ .old = "/usr/local", .new = new_prefix },
     };
-    _ = patcher.patchTextFiles(allocator, cellar_path, &text_replacements) catch |e| {
+    _ = text_patcher.patchTextFiles(allocator, cellar_path, &text_replacements) catch |e| {
         std.log.warn("text patching failed for {s}: {s}", .{ cellar_path, @errorName(e) });
     };
 
@@ -244,9 +264,14 @@ const Replacement = struct {
 /// are *not* added to the list — their ad-hoc signature is still valid
 /// and they don't need re-signing.
 ///
-/// `PathTooLong` is surfaced as a real error (MALT_PREFIX exceeded the
-/// in-place patching budget); other per-file errors are skipped so a
-/// single bad binary does not fail the whole materialize.
+/// Slots that overflow their load-command region are deferred to
+/// `install_name_tool` — Homebrew bottles ship ~4 KiB of `__LINKEDIT`
+/// padding for that exact purpose, which the slow path uses to grow
+/// the slot. A non-zero subprocess exit that reports padding
+/// exhaustion surfaces `InsufficientHeaderPad` so the user can
+/// shorten MALT_PREFIX or rebuild the bottle; anything else falls
+/// through to the generic `PatchFailed`. Per-file I/O errors are
+/// skipped so a single bad binary does not abort the whole materialize.
 fn walkMachOAndPatch(
     allocator: std.mem.Allocator,
     dir_path: []const u8,
@@ -260,6 +285,13 @@ fn walkMachOAndPatch(
     defer walker.deinit();
 
     const parser_mod = @import("../macho/parser.zig");
+
+    // `cellar.Replacement` is its own type alias; convert once for
+    // the facade's shape.
+    var patch_reps_buf: [8]patch.Replacement = undefined;
+    std.debug.assert(replacements.len <= patch_reps_buf.len);
+    for (replacements, 0..) |r, i| patch_reps_buf[i] = .{ .old = r.old, .new = r.new };
+    const patch_reps = patch_reps_buf[0..replacements.len];
 
     while (walker.next() catch null) |entry| {
         if (entry.kind != .file) continue;
@@ -280,15 +312,23 @@ fn walkMachOAndPatch(
 
         if (!parser_mod.isMachO(&magic_buf)) continue;
 
-        var any_modified = false;
-        for (replacements) |r| {
-            const result = patcher.patchPaths(allocator, full_path, r.old, r.new) catch |e| switch (e) {
-                error.PathTooLong => return CellarError.PathTooLong,
-                else => continue,
+        // One read/write per file for all replacements. Slots that fit
+        // are rewritten in process; slots that overflow are queued for
+        // the install_name_tool fallback below.
+        var outcome = patch.patchPathsCollecting(allocator, full_path, patch_reps) catch
+            continue;
+        defer outcome.deinit(allocator);
+
+        if (outcome.overflow.len > 0) {
+            patch.flushOverflow(allocator, full_path, outcome.overflow) catch |e| switch (e) {
+                patch.FallbackError.InsufficientHeaderPad => return CellarError.InsufficientHeaderPad,
+                patch.FallbackError.InstallNameToolMissing => return CellarError.InstallNameToolMissing,
+                patch.FallbackError.OutOfMemory => return CellarError.OutOfMemory,
+                else => return CellarError.PatchFailed,
             };
-            if (result.patched_count > 0) any_modified = true;
         }
 
+        const any_modified = outcome.patched_count > 0 or outcome.overflow.len > 0;
         if (any_modified) {
             // Transfer ownership of `full_path` into the modified list.
             // On append failure, let the defer free it and carry on —

--- a/src/core/patch.zig
+++ b/src/core/patch.zig
@@ -1,0 +1,27 @@
+//! Cross-platform path-relocation facade. Re-exports the active
+//! backend's symbols under format-agnostic names so cellar / doctor
+//! never import a macOS- or ELF-specific module directly.
+//!
+//! Dispatch is a `comptime` switch on the target OS — there is no
+//! runtime indirection and no binary-size cost beyond the one active
+//! backend. Adding Linux support is additive: drop
+//! `src/elf/patcher.zig` in place with the same public surface and
+//! uncomment the `.linux` arm below.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const backend = switch (builtin.target.os.tag) {
+    .macos => @import("../macho/patcher.zig"),
+    // .linux => @import("../elf/patcher.zig"),  // future task
+    else => @compileError("unsupported target for patch relocation facade"),
+};
+
+pub const Replacement = backend.Replacement;
+pub const PatchOutcome = backend.PatchOutcome;
+pub const OverflowEntry = backend.OverflowEntry;
+pub const PatchError = backend.PatchError;
+pub const FallbackError = backend.FallbackError;
+pub const patchPathsCollecting = backend.patchPathsCollecting;
+pub const flushOverflow = backend.flushOverflow;
+pub const external_tool_name = backend.external_tool_name;

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -19,6 +19,7 @@ pub const io_mod = @import("ui/io.zig");
 pub const codesign = @import("macho/codesign.zig");
 pub const parser = @import("macho/parser.zig");
 pub const patcher = @import("macho/patcher.zig");
+pub const patch = @import("core/patch.zig");
 pub const api = @import("net/api.zig");
 pub const client = @import("net/client.zig");
 pub const output = @import("ui/output.zig");

--- a/src/macho/patcher.zig
+++ b/src/macho/patcher.zig
@@ -18,16 +18,62 @@ pub const PatchResult = struct {
     skipped_count: u32,
 };
 
-/// Patch all Mach-O load command paths in a binary file.
-/// Replaces occurrences of old_prefix with new_prefix, null-padding to maintain size.
-/// The binary is modified in-place (read, modify, write back).
+/// One load-command path that did not fit its slot. The caller flushes
+/// these via the slow path (`flushOverflow` → `install_name_tool`).
+/// Strings are caller-owned; release through `PatchOutcome.deinit`.
+pub const OverflowEntry = struct {
+    /// Raw load-command type (`@intFromEnum(LC.LOAD_DYLIB)` etc.).
+    /// Drives the `-change` vs `-rpath` vs `-id` argv shape downstream.
+    cmd: u32,
+    /// Original path embedded in the slot (the `install_name_tool -change`
+    /// "old" argument).
+    old_path: []const u8,
+    /// Replacement path the in-place patcher could not fit.
+    new_path: []const u8,
+};
+
+pub const PatchOutcome = struct {
+    patched_count: u32,
+    skipped_count: u32,
+    /// Slots that exceeded their cmd slot. Empty for the fast path.
+    overflow: []OverflowEntry,
+
+    pub fn deinit(self: *PatchOutcome, allocator: std.mem.Allocator) void {
+        for (self.overflow) |e| {
+            allocator.free(e.old_path);
+            allocator.free(e.new_path);
+        }
+        allocator.free(self.overflow);
+    }
+};
+
+/// Legacy single-replacement entry kept for callers that want the
+/// all-or-nothing semantics. Bubbles `PathTooLong` if any slot does not
+/// fit; new code should call `patchPathsCollecting` instead and flush
+/// the overflow list via `flushOverflow`.
 pub fn patchPaths(
     allocator: std.mem.Allocator,
     file_path: []const u8,
     old_prefix: []const u8,
     new_prefix: []const u8,
 ) PatchError!PatchResult {
-    // Read the entire file
+    const reps = [_]Replacement{.{ .old = old_prefix, .new = new_prefix }};
+    var outcome = try patchPathsCollecting(allocator, file_path, &reps);
+    defer outcome.deinit(allocator);
+    if (outcome.overflow.len > 0) return PatchError.PathTooLong;
+    return .{ .patched_count = outcome.patched_count, .skipped_count = outcome.skipped_count };
+}
+
+/// Patch every load-command path that fits its slot in place; collect
+/// any slot that overflowed into `overflow` for the caller to flush via
+/// `install_name_tool`. A single Mach-O walk applies all replacements
+/// (first match wins per load command), so the file is opened, read,
+/// and rewritten at most once regardless of replacement count.
+pub fn patchPathsCollecting(
+    allocator: std.mem.Allocator,
+    file_path: []const u8,
+    replacements: []const Replacement,
+) PatchError!PatchOutcome {
     const file = fs_compat.cwd().openFile(file_path, .{ .mode = .read_write }) catch
         return PatchError.OpenFailed;
     defer file.close();
@@ -39,32 +85,38 @@ pub fn patchPaths(
     const bytes_read = file.readAll(data) catch return PatchError.IoError;
     if (bytes_read < data.len) return PatchError.IoError;
 
-    // Parse Mach-O to find load command paths
     var macho = parser.parse(allocator, data) catch return PatchError.ParseFailed;
     defer macho.deinit();
+
+    // Each appended entry owns two heap strings; the outer errdefer hands
+    // them back if a later allocation in the loop fails.
+    var overflow: std.ArrayList(OverflowEntry) = .empty;
+    errdefer {
+        for (overflow.items) |e| {
+            allocator.free(e.old_path);
+            allocator.free(e.new_path);
+        }
+        overflow.deinit(allocator);
+    }
 
     var patched: u32 = 0;
     var skipped: u32 = 0;
 
     for (macho.paths) |lcp| {
-        // Check if path contains old_prefix
-        if (!hasPrefix(lcp.path, old_prefix)) {
+        const r = pickReplacement(lcp.path, replacements) orelse {
             skipped += 1;
+            continue;
+        };
+
+        const suffix = lcp.path[r.old.len..];
+        const new_path_len = r.new.len + suffix.len;
+
+        // +1 budgets the NUL terminator so the slot keeps a trailing zero.
+        if (new_path_len + 1 > lcp.max_path_len) {
+            try recordOverflow(allocator, &overflow, lcp, r);
             continue;
         }
 
-        // Build replacement path
-        const suffix = lcp.path[old_prefix.len..];
-        const new_path_len = new_prefix.len + suffix.len;
-
-        // +1 budgets the NUL terminator so the memset below writes at least one zero.
-        if (new_path_len + 1 > lcp.max_path_len) {
-            return PatchError.PathTooLong;
-        }
-
-        // Write replacement at the offset. The addition is done with
-        // overflow checking so a malformed Mach-O with an offset near
-        // `usize.max` can't wrap around and pass the in-bounds check.
         const offset = lcp.path_offset;
         const end = std.math.add(usize, offset, lcp.max_path_len) catch {
             skipped += 1;
@@ -75,17 +127,16 @@ pub fn patchPaths(
             continue;
         }
 
-        // Build the new path in a temp buffer to avoid aliasing issues
-        // (suffix points into data which we're about to overwrite)
+        // Stage the new path in a stack buffer first because `suffix`
+        // aliases the same `data` we're about to overwrite.
         var new_path_buf: [1024]u8 = undefined;
         if (new_path_len > new_path_buf.len) {
             skipped += 1;
             continue;
         }
-        @memcpy(new_path_buf[0..new_prefix.len], new_prefix);
-        @memcpy(new_path_buf[new_prefix.len..new_path_len], suffix);
+        @memcpy(new_path_buf[0..r.new.len], r.new);
+        @memcpy(new_path_buf[r.new.len..new_path_len], suffix);
 
-        // Write replacement + null padding
         @memcpy(data[offset .. offset + new_path_len], new_path_buf[0..new_path_len]);
         @memset(data[offset + new_path_len .. offset + lcp.max_path_len], 0);
 
@@ -93,11 +144,43 @@ pub fn patchPaths(
     }
 
     if (patched > 0) {
-        // Write modified data back to file
         file.writeAllAt(data, 0) catch return PatchError.IoError;
     }
 
-    return .{ .patched_count = patched, .skipped_count = skipped };
+    return .{
+        .patched_count = patched,
+        .skipped_count = skipped,
+        .overflow = overflow.toOwnedSlice(allocator) catch return PatchError.OutOfMemory,
+    };
+}
+
+fn pickReplacement(path: []const u8, replacements: []const Replacement) ?Replacement {
+    for (replacements) |r| if (hasPrefix(path, r.old)) return r;
+    return null;
+}
+
+/// Dupe both old/new strings into the caller's allocator and append.
+/// On any allocation failure the partial duplicates are freed so the
+/// list never observes a half-built entry; previously appended entries
+/// remain owned by the list (the outer errdefer in
+/// `patchPathsCollecting` releases them on a final failure).
+fn recordOverflow(
+    allocator: std.mem.Allocator,
+    list: *std.ArrayList(OverflowEntry),
+    lcp: parser.LoadCommandPath,
+    rep: Replacement,
+) PatchError!void {
+    const old_dup = allocator.dupe(u8, lcp.path) catch return PatchError.OutOfMemory;
+    errdefer allocator.free(old_dup);
+    const suffix = lcp.path[rep.old.len..];
+    const new_dup = std.mem.concat(allocator, u8, &.{ rep.new, suffix }) catch
+        return PatchError.OutOfMemory;
+    errdefer allocator.free(new_dup);
+    list.append(allocator, .{
+        .cmd = lcp.cmd,
+        .old_path = old_dup,
+        .new_path = new_dup,
+    }) catch return PatchError.OutOfMemory;
 }
 
 /// A single (needle → replacement) pair for `patchTextFiles`.
@@ -105,6 +188,128 @@ pub const Replacement = struct {
     old: []const u8,
     new: []const u8,
 };
+
+/// Errors surfaced by the `install_name_tool` fallback driver. The
+/// generic fail / missing variants are subprocess plumbing problems;
+/// `InsufficientHeaderPad` is the actionable user-facing one (rebuild
+/// the bottle with `-headerpad_max_install_names`, or shorten
+/// MALT_PREFIX).
+pub const FallbackError = error{
+    InstallNameToolMissing,
+    InstallNameToolFailed,
+    InsufficientHeaderPad,
+    IoError,
+    OutOfMemory,
+};
+
+/// Name of the platform tool that owns the slow-path slot growing.
+/// `comptime` so the doctor check renders the right name without a
+/// runtime branch; the future Linux backend swaps this for `"patchelf"`.
+pub const external_tool_name: []const u8 = "install_name_tool";
+
+/// Build the `install_name_tool` argv for one binary's overflow batch.
+/// Caller owns the returned slice (`allocator.free`); the strings inside
+/// are borrowed from the `entries` and `file_path` arguments.
+pub fn buildInstallNameToolArgv(
+    allocator: std.mem.Allocator,
+    file_path: []const u8,
+    entries: []const OverflowEntry,
+) std.mem.Allocator.Error![][]const u8 {
+    // Worst case: one binary path plus three argv slots per entry.
+    var argv: std.ArrayList([]const u8) = try .initCapacity(allocator, 1 + entries.len * 3 + 1);
+    errdefer argv.deinit(allocator);
+
+    argv.appendAssumeCapacity(external_tool_name);
+    for (entries) |e| switch (installNameToolForm(e.cmd)) {
+        .change => {
+            argv.appendAssumeCapacity("-change");
+            argv.appendAssumeCapacity(e.old_path);
+            argv.appendAssumeCapacity(e.new_path);
+        },
+        .rpath => {
+            argv.appendAssumeCapacity("-rpath");
+            argv.appendAssumeCapacity(e.old_path);
+            argv.appendAssumeCapacity(e.new_path);
+        },
+        .id => {
+            // -id takes only the new install name; the old one is
+            // implicit (LC_ID_DYLIB carries a single name).
+            argv.appendAssumeCapacity("-id");
+            argv.appendAssumeCapacity(e.new_path);
+        },
+    };
+    argv.appendAssumeCapacity(file_path);
+    return argv.toOwnedSlice(allocator);
+}
+
+const InstallNameToolForm = enum { change, rpath, id };
+
+fn installNameToolForm(cmd: u32) InstallNameToolForm {
+    const lc = std.macho.LC;
+    return switch (cmd) {
+        @intFromEnum(lc.ID_DYLIB) => .id,
+        @intFromEnum(lc.RPATH) => .rpath,
+        // LOAD_DYLIB / LOAD_WEAK_DYLIB / LAZY_LOAD_DYLIB / REEXPORT_DYLIB
+        // all use `-change`. Default to `-change` for any other dylib-ish
+        // load command rather than refusing the flush.
+        else => .change,
+    };
+}
+
+/// Translate `install_name_tool`'s stderr into a structured fallback
+/// error. Apple's wording for the headerpad-exhaustion case is stable
+/// across Xcode releases and is the only one users have a remediation
+/// for, so it gets its own variant; everything else collapses to a
+/// generic failure that surfaces the raw stderr to the user upstream.
+pub fn classifyInstallNameToolStderr(stderr: []const u8) FallbackError {
+    if (std.mem.indexOf(u8, stderr, "larger updated load commands do not fit") != null)
+        return FallbackError.InsufficientHeaderPad;
+    if (std.mem.indexOf(u8, stderr, "no room for new load commands") != null)
+        return FallbackError.InsufficientHeaderPad;
+    return FallbackError.InstallNameToolFailed;
+}
+
+/// Flush one binary's overflow list via a single `install_name_tool`
+/// invocation. All overflowing slots for the binary share one spawn so
+/// cost scales with affected binaries, not load commands. A non-zero
+/// exit is mapped through `classifyInstallNameToolStderr` so the
+/// user-facing remediation is specific.
+pub fn flushOverflow(
+    allocator: std.mem.Allocator,
+    file_path: []const u8,
+    entries: []const OverflowEntry,
+) FallbackError!void {
+    if (entries.len == 0) return;
+
+    const argv = buildInstallNameToolArgv(allocator, file_path, entries) catch
+        return FallbackError.OutOfMemory;
+    defer allocator.free(argv);
+
+    var child = fs_compat.Child.init(argv, allocator);
+    child.stdout_behavior = .ignore;
+    child.stderr_behavior = .pipe;
+    child.spawn() catch |e| switch (e) {
+        // `FileNotFound` is what `std.process.spawn` returns when the
+        // binary is not on PATH — caller's doctor check should have
+        // surfaced this already, but bottle installs may run before
+        // doctor on a fresh box.
+        error.FileNotFound => return FallbackError.InstallNameToolMissing,
+        else => return FallbackError.IoError,
+    };
+
+    const stderr_file = child.stderr orelse return FallbackError.IoError;
+    const stderr_bytes = fs_compat.readFileToEndAlloc(stderr_file, allocator, 64 * 1024) catch
+        return FallbackError.IoError;
+    defer allocator.free(stderr_bytes);
+
+    const term = child.wait() catch return FallbackError.InstallNameToolFailed;
+    switch (term) {
+        .exited => |code| {
+            if (code != 0) return classifyInstallNameToolStderr(stderr_bytes);
+        },
+        else => return FallbackError.InstallNameToolFailed,
+    }
+}
 
 /// Patch text files in a directory tree with a batch of replacements.
 ///

--- a/tests/cellar_test.zig
+++ b/tests/cellar_test.zig
@@ -334,32 +334,24 @@ test "binary files are skipped by text patching without error" {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// P4 — Pre-flight MALT_PREFIX length check
+// Prefix sanity cap (upper guardrail, no longer a Mach-O in-place budget)
 // ---------------------------------------------------------------------------
 
-test "checkPrefixLength accepts prefixes within the Mach-O patch budget" {
-    try install_mod.checkPrefixLength("/opt/malt");
-    try install_mod.checkPrefixLength("/opt/homebrew"); // exactly 13 bytes — boundary
-    try install_mod.checkPrefixLength("/tmp/mt");
+test "checkPrefixSane accepts realistic MALT_PREFIX values" {
+    try install_mod.checkPrefixSane("/opt/malt");
+    try install_mod.checkPrefixSane("/opt/homebrew");
+    try install_mod.checkPrefixSane("/tmp/mt");
+    try install_mod.checkPrefixSane("/tmp/mt_tahoe"); // 13 bytes — formerly rejected
+    try install_mod.checkPrefixSane("/var/folders/abc/def/ghi/jkl/mno/prefix");
 }
 
-test "checkPrefixLength rejects prefixes that overflow the budget" {
-    try testing.expectError(
-        error.PrefixTooLong,
-        install_mod.checkPrefixLength("/var/folders/abc/def/ghi/jkl/mno/prefix"),
-    );
-    try testing.expectError(
-        error.PrefixTooLong,
-        install_mod.checkPrefixLength("/opt/homebrew/"), // 14 bytes — just over
-    );
-}
-
-test "max_prefix_len matches the /opt/homebrew budget" {
-    try testing.expectEqual(@as(usize, "/opt/homebrew".len), install_mod.max_prefix_len);
+test "checkPrefixSane rejects absurd prefixes at the 256-byte cap" {
+    const huge = "/" ++ "x" ** 512;
+    try testing.expectError(error.PrefixAbsurd, install_mod.checkPrefixSane(huge));
 }
 
 // ---------------------------------------------------------------------------
-// P5 — CellarError.describeError covers every tag
+// CellarError.describeError covers every tag
 // ---------------------------------------------------------------------------
 
 test "describeError returns a non-empty, distinct message for every CellarError" {
@@ -367,6 +359,8 @@ test "describeError returns a non-empty, distinct message for every CellarError"
         cellar_mod.CellarError.CloneFailed,
         cellar_mod.CellarError.PatchFailed,
         cellar_mod.CellarError.PathTooLong,
+        cellar_mod.CellarError.InsufficientHeaderPad,
+        cellar_mod.CellarError.InstallNameToolMissing,
         cellar_mod.CellarError.CodesignFailed,
         cellar_mod.CellarError.RemoveFailed,
         cellar_mod.CellarError.OutOfMemory,

--- a/tests/doctor_render_test.zig
+++ b/tests/doctor_render_test.zig
@@ -164,6 +164,24 @@ test "null detail omits the em-dash entirely" {
 const malt = @import("malt");
 const sqlite = malt.sqlite;
 const schema = malt.schema;
+const patch = malt.patch;
+
+// ── external-tool availability check ─────────────────────────────────
+//
+// Guards the doctor row that surfaces `install_name_tool` (today) or
+// `patchelf` (after the Linux backend lands). The tool name is read
+// from the facade so the check is platform-agnostic at the call site.
+
+test "doctor.externalToolAvailable returns true when the tool is on PATH" {
+    // `install_name_tool` is part of Xcode Command Line Tools and is
+    // always installed in the repo's dev environment — any bot that
+    // can build malt can find it.
+    try testing.expect(malt.doctor.externalToolAvailable(patch.external_tool_name));
+}
+
+test "doctor.externalToolAvailable returns false for a clearly-missing binary" {
+    try testing.expect(!malt.doctor.externalToolAvailable("mt_no_such_binary_ever_xyz"));
+}
 
 fn seedKeg(db: *sqlite.Database, name: []const u8, tap: []const u8, full_name: []const u8) !void {
     var stmt = try db.prepare(

--- a/tests/install_execute_test.zig
+++ b/tests/install_execute_test.zig
@@ -56,8 +56,6 @@ fn seedFormulaCache(prefix: []const u8, name: []const u8, json: []const u8) !voi
 }
 
 test "execute --dry-run prints a plan for a cached formula" {
-    // The Mach-O in-place patching budget is "/opt/homebrew".len (13 bytes),
-    // so the test prefix must be short enough to pass checkPrefixLength.
     const prefix_z: [:0]const u8 = "/tmp/mm";
     malt.fs_compat.deleteTreeAbsolute(prefix_z) catch {};
     try malt.fs_compat.cwd().makePath(prefix_z);
@@ -167,12 +165,15 @@ test "execute --dry-run with an already-installed package short-circuits" {
     try install.execute(arena.allocator(), &.{ "--dry-run", "--quiet", "seeded" });
 }
 
-test "execute refuses to run when MALT_PREFIX exceeds the Mach-O budget" {
-    const too_long = "/tmp/malt_install_exec_too_long_" ++ "x" ** 64;
+test "execute refuses to run when MALT_PREFIX is absurdly long (> 256 bytes)" {
+    // The former 12-byte Mach-O ceiling is gone — install_name_tool
+    // grows overflowing slots into __LINKEDIT padding. What remains is
+    // a cheap upper bound on pathological values.
+    const too_long = "/tmp/malt_install_exec_absurdly_long_" ++ "x" ** 400;
     defer _ = c.unsetenv("MALT_PREFIX");
     _ = c.setenv("MALT_PREFIX", too_long, 1);
     try testing.expectError(
-        install.InstallError.PrefixTooLong,
+        install.InstallError.PrefixAbsurd,
         install.execute(testing.allocator, &.{"wget"}),
     );
 }

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -87,15 +87,20 @@ test "parseTapName returns null on an incomplete string" {
     try testing.expect(install.parseTapName("user/repo") == null);
 }
 
-test "checkPrefixLength rejects a prefix longer than the Mach-O budget" {
-    const too_long = "/" ++ "x" ** 64;
-    try testing.expectError(error.PrefixTooLong, install.checkPrefixLength(too_long));
+test "checkPrefixSane accepts realistic prefixes (up to the 256-byte sanity cap)" {
+    try install.checkPrefixSane("/opt/malt");
+    try install.checkPrefixSane("/usr/local");
+    try install.checkPrefixSane("/opt/homebrew");
+    try install.checkPrefixSane("/tmp/mt_tahoe");
+    try install.checkPrefixSane("/Users/someuser/malt");
+    // Nothing special about 13 bytes any more — install_name_tool's
+    // headerpad fallback absorbs the overflow.
+    try install.checkPrefixSane("/var/folders/qp/mt_prefix_under_128_bytes_long_enough_to_matter");
 }
 
-test "checkPrefixLength accepts prefixes up to the Mach-O budget" {
-    try install.checkPrefixLength("/opt/malt");
-    try install.checkPrefixLength("/usr/local");
-    try install.checkPrefixLength("/opt/homebrew");
+test "checkPrefixSane rejects absurdly long prefixes at the 256-byte cap" {
+    const huge = "/" ++ "x" ** 512;
+    try testing.expectError(error.PrefixAbsurd, install.checkPrefixSane(huge));
 }
 
 test "parseRubyFormula extracts version/url/sha256 from a flat formula body" {

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -118,19 +118,17 @@ test "collectFormulaJobs queues a formula with a post_install hook" {
 
 // --- Pure helper tests (no DB / network) ---
 
-test "checkPrefixLength accepts prefix at the limit" {
-    try install.checkPrefixLength("/opt/homebrew");
+test "checkPrefixSane accepts a realistic developer-length prefix" {
+    try install.checkPrefixSane("/Users/somebody/malt");
 }
 
-test "checkPrefixLength accepts a short prefix" {
-    try install.checkPrefixLength("/opt/m");
+test "checkPrefixSane accepts a short prefix" {
+    try install.checkPrefixSane("/opt/m");
 }
 
-test "checkPrefixLength rejects a too-long prefix" {
-    try testing.expectError(
-        install.PrefixError.PrefixTooLong,
-        install.checkPrefixLength("/opt/homebrew-longer"),
-    );
+test "checkPrefixSane rejects an absurdly long prefix" {
+    const huge = "/" ++ "a" ** 300;
+    try testing.expectError(install.PrefixError.PrefixAbsurd, install.checkPrefixSane(huge));
 }
 
 test "isTapFormula detects three-part user/repo/formula names" {

--- a/tests/patch_facade_test.zig
+++ b/tests/patch_facade_test.zig
@@ -1,0 +1,43 @@
+//! malt — patch facade tests
+//!
+//! Guards the cross-platform relocation seam. Today the only backend is
+//! macOS (`install_name_tool`); a future Linux task drops into the
+//! `.linux` arm of the comptime switch with `patchelf`, at which point
+//! `external_tool_name` changes and this test is the first thing that
+//! fails loud.
+//!
+//! These tests deliberately reference the facade (`malt.patch`) rather
+//! than `malt.patcher` so cellar / doctor callers that do the same keep
+//! a honest single-seam rule.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const patch = malt.patch;
+const patcher = malt.patcher;
+
+test "facade re-exports the patcher surface cellar / doctor rely on" {
+    // If any of these go missing the swap-to-Linux diff is suddenly
+    // non-trivial; holding the shape explicit documents what any
+    // future backend must provide.
+    _ = patch.Replacement;
+    _ = patch.PatchOutcome;
+    _ = patch.OverflowEntry;
+    _ = patch.PatchError;
+    _ = patch.FallbackError;
+    _ = patch.patchPathsCollecting;
+    _ = patch.flushOverflow;
+    _ = patch.external_tool_name;
+}
+
+test "facade external_tool_name matches the macOS backend" {
+    try testing.expectEqualStrings("install_name_tool", patch.external_tool_name);
+    try testing.expectEqualStrings(patcher.external_tool_name, patch.external_tool_name);
+}
+
+test "facade OverflowEntry / PatchOutcome are identical to the backend's" {
+    // Same type-identity means callers can hand outcomes between the
+    // facade and the backend without a conversion step.
+    try testing.expect(patch.OverflowEntry == patcher.OverflowEntry);
+    try testing.expect(patch.PatchOutcome == patcher.PatchOutcome);
+}

--- a/tests/patcher_test.zig
+++ b/tests/patcher_test.zig
@@ -1,0 +1,329 @@
+//! malt — patcher overflow-collection tests
+//!
+//! Covers `patchPathsCollecting`: the new entry point that replaces the
+//! all-or-nothing `PathTooLong` behaviour of `patchPaths` with an outcome
+//! that separates in-place rewrites from slots that need the fallback
+//! path (install_name_tool). The same walk must keep the fast in-place
+//! rewrite for any slot that still fits.
+
+const std = @import("std");
+const testing = std.testing;
+const macho = std.macho;
+const malt = @import("malt");
+const patcher = malt.patcher;
+const parser = malt.parser;
+
+/// Build a Mach-O 64 binary with two LC_LOAD_DYLIB load commands.
+/// Each command has `cmdsize` bytes; its path region begins at the
+/// `sizeof(dylib_command)` offset and carries the caller-supplied path
+/// (null-terminated by the zero-fill).
+fn buildTwoDylibFixture(
+    allocator: std.mem.Allocator,
+    path1: []const u8,
+    cmdsize1: u32,
+    path2: []const u8,
+    cmdsize2: u32,
+) ![]u8 {
+    const header_size = @sizeOf(macho.mach_header_64);
+    const name_offset: u32 = @sizeOf(macho.dylib_command);
+    const total = header_size + cmdsize1 + cmdsize2;
+
+    const buf = try allocator.alloc(u8, total);
+    @memset(buf, 0);
+
+    const hdr = std.mem.bytesAsValue(macho.mach_header_64, buf[0..header_size]);
+    hdr.* = .{
+        .magic = macho.MH_MAGIC_64,
+        .ncmds = 2,
+        .sizeofcmds = cmdsize1 + cmdsize2,
+    };
+
+    const lc1_off = header_size;
+    const dy1 = std.mem.bytesAsValue(macho.dylib_command, buf[lc1_off..][0..name_offset]);
+    dy1.* = .{
+        .cmd = .LOAD_DYLIB,
+        .cmdsize = cmdsize1,
+        .dylib = .{ .name = name_offset, .timestamp = 0, .current_version = 0, .compatibility_version = 0 },
+    };
+    std.debug.assert(path1.len + 1 <= cmdsize1 - name_offset);
+    @memcpy(buf[lc1_off + name_offset ..][0..path1.len], path1);
+
+    const lc2_off = header_size + cmdsize1;
+    const dy2 = std.mem.bytesAsValue(macho.dylib_command, buf[lc2_off..][0..name_offset]);
+    dy2.* = .{
+        .cmd = .LOAD_DYLIB,
+        .cmdsize = cmdsize2,
+        .dylib = .{ .name = name_offset, .timestamp = 0, .current_version = 0, .compatibility_version = 0 },
+    };
+    std.debug.assert(path2.len + 1 <= cmdsize2 - name_offset);
+    @memcpy(buf[lc2_off + name_offset ..][0..path2.len], path2);
+
+    return buf;
+}
+
+fn writeFixture(dir: []const u8, filename: []const u8, bytes: []const u8) ![]u8 {
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ dir, filename });
+    const f = try malt.fs_compat.createFileAbsolute(path, .{});
+    defer f.close();
+    try f.writeAll(bytes);
+    return path;
+}
+
+fn tmpSubdir(tag: []const u8) ![]u8 {
+    const path = try std.fmt.allocPrint(
+        testing.allocator,
+        "/tmp/malt_patcher_test_{s}_{x}",
+        .{ tag, malt.fs_compat.randomInt(u64) },
+    );
+    try malt.fs_compat.cwd().makePath(path);
+    return path;
+}
+
+test "patchPathsCollecting mixes in-place rewrite with overflow entries" {
+    // LC1: cmdsize 48, slot 24B, path "/O/short" — fits any /new-prefix/short replacement.
+    // LC2: cmdsize 32, slot  8B, path "/O/x"     — replacement overflows the slot.
+    const bytes = try buildTwoDylibFixture(
+        testing.allocator,
+        "/O/short",
+        48,
+        "/O/x",
+        32,
+    );
+    defer testing.allocator.free(bytes);
+
+    const dir = try tmpSubdir("mixed");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(dir, "bin", bytes);
+    defer testing.allocator.free(path);
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "/O", .new = "/new-prefix" },
+    };
+    var outcome = try patcher.patchPathsCollecting(testing.allocator, path, &replacements);
+    defer outcome.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u32, 1), outcome.patched_count);
+    try testing.expectEqual(@as(usize, 1), outcome.overflow.len);
+    try testing.expectEqualStrings("/O/x", outcome.overflow[0].old_path);
+    try testing.expectEqualStrings("/new-prefix/x", outcome.overflow[0].new_path);
+}
+
+test "patchPathsCollecting does not error when a slot overflows" {
+    // The whole point: `patchPaths` returns PathTooLong on overflow;
+    // `patchPathsCollecting` must carry on and hand the overflow back.
+    const bytes = try buildTwoDylibFixture(
+        testing.allocator,
+        "/O/short",
+        48,
+        "/O/x",
+        32,
+    );
+    defer testing.allocator.free(bytes);
+
+    const dir = try tmpSubdir("no_error");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(dir, "bin", bytes);
+    defer testing.allocator.free(path);
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "/O", .new = "/new-prefix" },
+    };
+    // Must not surface PathTooLong: the per-slot failure is absorbed into
+    // `outcome.overflow` so the caller can flush it via install_name_tool.
+    var outcome = try patcher.patchPathsCollecting(testing.allocator, path, &replacements);
+    outcome.deinit(testing.allocator);
+}
+
+test "patchPathsCollecting on a no-overflow fixture returns an empty overflow list" {
+    // Both slots easily fit a short replacement.
+    const bytes = try buildTwoDylibFixture(
+        testing.allocator,
+        "/O/a",
+        48,
+        "/O/b",
+        48,
+    );
+    defer testing.allocator.free(bytes);
+
+    const dir = try tmpSubdir("no_overflow");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(dir, "bin", bytes);
+    defer testing.allocator.free(path);
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "/O", .new = "/N" },
+    };
+    var outcome = try patcher.patchPathsCollecting(testing.allocator, path, &replacements);
+    defer outcome.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u32, 2), outcome.patched_count);
+    try testing.expectEqual(@as(usize, 0), outcome.overflow.len);
+}
+
+test "patchPathsCollecting with only-overflow fixture reports zero in-place patches" {
+    // Both slots too small to take the long replacement.
+    const bytes = try buildTwoDylibFixture(
+        testing.allocator,
+        "/O/x",
+        32,
+        "/O/y",
+        32,
+    );
+    defer testing.allocator.free(bytes);
+
+    const dir = try tmpSubdir("only_overflow");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(dir, "bin", bytes);
+    defer testing.allocator.free(path);
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "/O", .new = "/a-long-replacement-prefix" },
+    };
+    var outcome = try patcher.patchPathsCollecting(testing.allocator, path, &replacements);
+    defer outcome.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u32, 0), outcome.patched_count);
+    try testing.expectEqual(@as(usize, 2), outcome.overflow.len);
+}
+
+test "patchPathsCollecting persists in-place rewrites to disk" {
+    // After the call, re-parsing the file must show the rewritten slot for
+    // the LC that fit, while the overflow slot stays untouched (fallback
+    // will own it).
+    const bytes = try buildTwoDylibFixture(
+        testing.allocator,
+        "/O/short",
+        48,
+        "/O/x",
+        32,
+    );
+    defer testing.allocator.free(bytes);
+
+    const dir = try tmpSubdir("persist");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(dir, "bin", bytes);
+    defer testing.allocator.free(path);
+
+    const replacements = [_]patcher.Replacement{
+        // Length picked so LC1's 24B slot fits "/medium-prefix/short" (21B
+        // incl NUL) but LC2's 8B slot can't take "/medium-prefix/x" (17B).
+        .{ .old = "/O", .new = "/medium-prefix" },
+    };
+    var outcome = try patcher.patchPathsCollecting(testing.allocator, path, &replacements);
+    outcome.deinit(testing.allocator);
+
+    const data = try malt.fs_compat.readFileAbsoluteAlloc(testing.allocator, path, 4096);
+    defer testing.allocator.free(data);
+
+    var re = try parser.parse(testing.allocator, data);
+    defer re.deinit();
+    try testing.expectEqual(@as(usize, 2), re.paths.len);
+    try testing.expectEqualStrings("/medium-prefix/short", re.paths[0].path);
+    // Overflow slot stayed as-is — fallback flushes it later.
+    try testing.expectEqualStrings("/O/x", re.paths[1].path);
+}
+
+// ---------------------------------------------------------------------------
+// flushOverflow / install_name_tool driver
+// ---------------------------------------------------------------------------
+
+test "external_tool_name is install_name_tool on macOS" {
+    try testing.expectEqualStrings("install_name_tool", patcher.external_tool_name);
+}
+
+test "buildInstallNameToolArgv batches -change pairs into a single invocation" {
+    const entries = [_]patcher.OverflowEntry{
+        .{
+            .cmd = @intFromEnum(macho.LC.LOAD_DYLIB),
+            .old_path = "@@HOMEBREW_CELLAR@@/openssl/3.0/lib/libssl.dylib",
+            .new_path = "/tmp/mt_tahoe/Cellar/openssl/3.0/lib/libssl.dylib",
+        },
+        .{
+            .cmd = @intFromEnum(macho.LC.LOAD_DYLIB),
+            .old_path = "@@HOMEBREW_CELLAR@@/openssl/3.0/lib/libcrypto.dylib",
+            .new_path = "/tmp/mt_tahoe/Cellar/openssl/3.0/lib/libcrypto.dylib",
+        },
+    };
+    const argv = try patcher.buildInstallNameToolArgv(testing.allocator, "/tmp/binary", &entries);
+    defer testing.allocator.free(argv);
+
+    try testing.expectEqual(@as(usize, 8), argv.len);
+    try testing.expectEqualStrings("install_name_tool", argv[0]);
+    try testing.expectEqualStrings("-change", argv[1]);
+    try testing.expectEqualStrings(entries[0].old_path, argv[2]);
+    try testing.expectEqualStrings(entries[0].new_path, argv[3]);
+    try testing.expectEqualStrings("-change", argv[4]);
+    try testing.expectEqualStrings(entries[1].old_path, argv[5]);
+    try testing.expectEqualStrings(entries[1].new_path, argv[6]);
+    try testing.expectEqualStrings("/tmp/binary", argv[7]);
+}
+
+test "buildInstallNameToolArgv routes LC_RPATH through -rpath" {
+    const entries = [_]patcher.OverflowEntry{
+        .{
+            .cmd = @intFromEnum(macho.LC.RPATH),
+            .old_path = "@@HOMEBREW_PREFIX@@/lib",
+            .new_path = "/tmp/mt_tahoe/lib",
+        },
+    };
+    const argv = try patcher.buildInstallNameToolArgv(testing.allocator, "/tmp/binary", &entries);
+    defer testing.allocator.free(argv);
+
+    try testing.expectEqualStrings("-rpath", argv[1]);
+    try testing.expectEqualStrings(entries[0].old_path, argv[2]);
+    try testing.expectEqualStrings(entries[0].new_path, argv[3]);
+}
+
+test "buildInstallNameToolArgv routes LC_ID_DYLIB through -id (no old arg)" {
+    const entries = [_]patcher.OverflowEntry{
+        .{
+            .cmd = @intFromEnum(macho.LC.ID_DYLIB),
+            .old_path = "@@HOMEBREW_CELLAR@@/foo.dylib",
+            .new_path = "/tmp/mt_tahoe/foo.dylib",
+        },
+    };
+    const argv = try patcher.buildInstallNameToolArgv(testing.allocator, "/tmp/binary", &entries);
+    defer testing.allocator.free(argv);
+
+    // -id <new> <binary>: the "old" path is implicit.
+    try testing.expectEqual(@as(usize, 4), argv.len);
+    try testing.expectEqualStrings("-id", argv[1]);
+    try testing.expectEqualStrings(entries[0].new_path, argv[2]);
+    try testing.expectEqualStrings("/tmp/binary", argv[3]);
+}
+
+test "classifyInstallNameToolStderr maps headerpad text to InsufficientHeaderPad" {
+    const stderr =
+        "install_name_tool: changing install names or rpaths can't be redone for: " ++
+        "/tmp/binary because larger updated load commands do not fit (the program must be relinked, " ++
+        "and you may need to use -headerpad or -headerpad_max_install_names)\n";
+    const got = patcher.classifyInstallNameToolStderr(stderr);
+    try testing.expectEqual(patcher.FallbackError.InsufficientHeaderPad, got);
+}
+
+test "classifyInstallNameToolStderr falls back to InstallNameToolFailed for other text" {
+    const stderr = "install_name_tool: some other failure\n";
+    const got = patcher.classifyInstallNameToolStderr(stderr);
+    try testing.expectEqual(patcher.FallbackError.InstallNameToolFailed, got);
+}
+
+test "flushOverflow on an empty list does nothing and returns ok" {
+    // Defensive cheap path: callers can pass an empty overflow list
+    // (no-overflow bottle); the driver must not spawn anything.
+    try patcher.flushOverflow(testing.allocator, "/tmp/whatever", &.{});
+}


### PR DESCRIPTION
## Description

Adds an install_name_tool fallback for Mach-O load commands that overflow their slot during bottle relocation. The fast in-place byte patcher is unchanged for load commands that fit (the vast majority); overflowing entries are collected during the walk and flushed per binary via a single batched `install_name_tool -change` subprocess, then re-signed by the existing ad-hoc codesign step. The 12-byte MALT_PREFIX ceiling becomes history.

## Related Issue

- None

## Notes for Reviewers

Platform seam: a new `src/core/patch.zig` is a comptime-dispatch facade that re-exports the active backend's symbols (Mach-O today) under format-agnostic names, matching malt's existing `src/fs/compat.zig` pattern. A future Linux/ELF backend drops into the `.linux` branch of the same switch - cellar and doctor already import through the facade.