### PR TITLE
fix(update/swap): fsync before swap rename

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -164,6 +164,7 @@ pub fn build(b: *std.Build) void {
         "tests/install_execute_test.zig",
         "tests/fs_compat_stream_test.zig",
         "tests/fs_compat_lint_test.zig",
+        "tests/fs_compat_sync_test.zig",
         "tests/ui_color_theme_test.zig",
         "tests/install_local_test.zig",
         "tests/cask_extra_test.zig",

--- a/src/fs/compat.zig
+++ b/src/fs/compat.zig
@@ -329,6 +329,12 @@ pub const File = struct {
         return self.inner.setPermissions(io_mod.ctx(), std.Io.File.Permissions.fromMode(@intCast(mode)));
     }
 
+    /// Block until pending contents and metadata are on disk. Callers that
+    /// rename-for-atomicity must sync first — POSIX rename is not durable.
+    pub fn sync(self: File) !void {
+        return self.inner.sync(io_mod.ctx());
+    }
+
     pub fn readToEndAlloc(self: File, allocator: std.mem.Allocator, max_bytes: usize) ![]u8 {
         const io = io_mod.ctx();
         const st = try self.inner.stat(io);
@@ -418,6 +424,13 @@ pub const Dir = struct {
 
     pub fn rename(self: Dir, old_sub_path: []const u8, new_sub_path: []const u8) !void {
         return self.inner.rename(old_sub_path, self.inner, new_sub_path, io_mod.ctx());
+    }
+
+    /// Flush directory metadata. `std.Io.Dir` has no sync vtable entry, so
+    /// drop to POSIX `fsync(2)` on the underlying fd — same primitive the
+    /// lock release path uses.
+    pub fn sync(self: Dir) !void {
+        if (std.c.fsync(self.inner.handle) != 0) return error.SyncFailed;
     }
 
     pub fn openDir(self: Dir, sub_path: []const u8, options: OpenOptions) !Dir {

--- a/src/update/swap.zig
+++ b/src/update/swap.zig
@@ -47,12 +47,15 @@ pub fn atomicReplace(target_path: []const u8, new_path: []const u8) SwapError!vo
     errdefer fs_compat.deleteFileAbsolute(staged_path) catch {};
 
     // Set mode on the staged file so we never leave a non-executable
-    // malt in place if the rename succeeds but chmod races.
+    // malt in place if the rename succeeds but chmod races. Sync before
+    // close: a rename is not durable without a prior fsync, so a power
+    // loss after rename could otherwise expose a partial binary.
     {
         const f = fs_compat.openFileAbsolute(staged_path, .{ .mode = .read_write }) catch
             return error.StagingFailed;
         defer f.close();
         f.chmod(0o755) catch return error.StagingFailed;
+        f.sync() catch return error.StagingFailed;
     }
 
     // Clear any .old left by a crashed prior run before we overwrite it.
@@ -65,4 +68,12 @@ pub fn atomicReplace(target_path: []const u8, new_path: []const u8) SwapError!vo
     // Atomic rename #2: staged -> target. If this fails the errdefers
     // above restore .old to target and delete the stage.
     fs_compat.renameAbsolute(staged_path, target_path) catch return error.RollbackFailed;
+
+    // Flush the parent so both rename dirents are durable. Swallowing
+    // errors here is fine: the swap already succeeded in the page cache;
+    // only a power loss in the next few ms could lose the dirents and
+    // there is nothing to roll back to at this point.
+    var dir = fs_compat.openDirAbsolute(target_dir, .{}) catch return;
+    defer dir.close();
+    dir.sync() catch {};
 }

--- a/tests/fs_compat_sync_test.zig
+++ b/tests/fs_compat_sync_test.zig
@@ -1,0 +1,50 @@
+//! malt — fs_compat.sync tests
+//!
+//! `sync` on a File / Dir is the seam callers use to make writes
+//! and rename metadata durable. Every atomic-swap style path needs
+//! this, so keep it exercised at the compat layer — the POSIX
+//! primitive is the same whether we wrap `std.Io.File.sync` or
+//! `fsync(2)` directly for directories.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const fs = malt.fs_compat;
+
+fn scratchDir(tag: []const u8, buf: []u8) ![]const u8 {
+    return std.fmt.bufPrint(buf, "/tmp/malt_sync_{s}_{d}", .{ tag, fs.nanoTimestamp() });
+}
+
+test "File.sync flushes a freshly written file without error" {
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try scratchDir("file", &path_buf);
+    fs.deleteTreeAbsolute(dir_path) catch {};
+    try fs.makeDirAbsolute(dir_path);
+    defer fs.deleteTreeAbsolute(dir_path) catch {};
+
+    var file_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const file_path = try std.fmt.bufPrint(&file_path_buf, "{s}/data", .{dir_path});
+
+    const f = try fs.createFileAbsolute(file_path, .{});
+    defer f.close();
+    try f.writeAll("durable-bytes");
+    try f.sync();
+}
+
+test "Dir.sync flushes directory metadata without error" {
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try scratchDir("dir", &path_buf);
+    fs.deleteTreeAbsolute(dir_path) catch {};
+    try fs.makeDirAbsolute(dir_path);
+    defer fs.deleteTreeAbsolute(dir_path) catch {};
+
+    // Create a file so the directory has metadata worth flushing.
+    var child_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const child_path = try std.fmt.bufPrint(&child_buf, "{s}/child", .{dir_path});
+    const child = try fs.createFileAbsolute(child_path, .{});
+    child.close();
+
+    var dir = try fs.openDirAbsolute(dir_path, .{});
+    defer dir.close();
+    try dir.sync();
+}


### PR DESCRIPTION
## Description

Add `fsync` for the staged file and the parent directory around the swap rename in `src/update/swap.zig`. The promise of atomicity now matches the implementation: a power loss between rename and kernel flush can no longer leave `<target>` missing or holding partial content.

## Related Issue

- None

## Notes for Reviewers

- None