### PR TITLE
refactor(db/sqlite): raise path and SQL caps

### DIFF
--- a/src/db/sqlite.zig
+++ b/src/db/sqlite.zig
@@ -33,6 +33,14 @@ fn mapError(rc: c_int, comptime default: SqliteError) SqliteError {
 /// This is safe because all bound text outlives the statement step.
 const SQLITE_STATIC: c.sqlite3_destructor_type = null;
 
+/// Maximum DB path length accepted by `Database.open`. Stack-buffered null
+/// copy; deeply nested test prefixes and custom MALT_PREFIX values fit.
+pub const MAX_PATH_LEN: usize = 2048;
+
+/// Maximum SQL length accepted by `Database.exec`. Migration bundles with
+/// many inline statements fit without forcing callers to split.
+pub const MAX_SQL_LEN: usize = 16384;
+
 pub const Statement = struct {
     stmt: *c.sqlite3_stmt,
 
@@ -106,7 +114,7 @@ pub const Database = struct {
     pub fn open(path: []const u8) SqliteError!Database {
         // SQLite requires a null-terminated path. Copy into a stack buffer
         // and add the sentinel, since callers may pass bufPrint output.
-        var path_buf: [512]u8 = undefined;
+        var path_buf: [MAX_PATH_LEN]u8 = undefined;
         if (path.len >= path_buf.len) return SqliteError.PathTooLong;
         @memcpy(path_buf[0..path.len], path);
         path_buf[path.len] = 0;
@@ -146,7 +154,7 @@ pub const Database = struct {
     /// through unchanged. `sqlite3_exec` itself is C-string-only, so we copy
     /// into a stack buffer and append the sentinel.
     pub fn exec(self: *Database, sql: []const u8) SqliteError!void {
-        var buf: [4096]u8 = undefined;
+        var buf: [MAX_SQL_LEN]u8 = undefined;
         if (sql.len >= buf.len) return SqliteError.ExecFailed;
         @memcpy(buf[0..sql.len], sql);
         buf[sql.len] = 0;

--- a/tests/db_schema_v2_test.zig
+++ b/tests/db_schema_v2_test.zig
@@ -108,6 +108,41 @@ test "services table accepts inserts and enforces PK" {
     try testing.expectError(sqlite.SqliteError.ConstraintViolation, dup_result);
 }
 
+test "Database.open accepts a 1 KB path" {
+    // Synthetic 1 KB path: we don't need sqlite to actually open it,
+    // just to confirm the internal cap no longer rejects ~1 KB inputs.
+    var buf: [1024]u8 = undefined;
+    @memset(&buf, 'a');
+    buf[0] = '/';
+    const path: []const u8 = buf[0..1024];
+
+    if (sqlite.Database.open(path)) |db_val| {
+        var db = db_val;
+        db.close();
+    } else |err| {
+        try testing.expect(err != sqlite.SqliteError.PathTooLong);
+    }
+}
+
+test "Database.exec accepts 12 KB SQL" {
+    var tdb = try TempDb.init("exec_12kb");
+    defer tdb.deinit();
+
+    try tdb.db.exec("CREATE TABLE big(v TEXT);");
+
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(testing.allocator);
+    try list.appendSlice(testing.allocator, "INSERT INTO big(v) VALUES");
+    const row = "('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'),";
+    while (list.items.len < 12 * 1024) {
+        try list.appendSlice(testing.allocator, row);
+    }
+    list.items[list.items.len - 1] = ';';
+    try testing.expect(list.items.len >= 12 * 1024);
+
+    try tdb.db.exec(list.items);
+}
+
 test "bundle_members cascade-deletes with bundle" {
     var tdb = try TempDb.init("cascade");
     defer tdb.deinit();


### PR DESCRIPTION
## Description

Raise the sqlite path and SQL caps to 2 KB / 16 KB via named `MAX_PATH_LEN` and `MAX_SQL_LEN` constants. Deeply nested test prefixes and migration bundles no longer trip the old 512 B / 4 KB limits.

## Related Issue

- None

## Notes for Reviewers

- None