### PR TITLE
fix(update): cosign PATH lookup + twin 'malt'/'mt' swap

### DIFF
--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -190,11 +190,20 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     };
     const self_exe = self_exe_buf[0..n];
 
+    // install.sh ships two independent binaries (`malt` and `mt`) side by
+    // side; swapping only the invoked one leaves the other on the old
+    // version. Detect the twin so we can update both in lockstep.
+    var twin_buf: [fs_compat.max_path_bytes]u8 = undefined;
+    const twin_path: ?[]const u8 = resolveTwinRegularFile(self_exe, &twin_buf);
+
     // --- confirm with the user unless --yes. TTY-only by design: CI
     //     or scripted runs must pass --yes explicitly. ---
     if (!opts.yes) {
-        var prompt_buf: [160]u8 = undefined;
-        const prompt = std.fmt.bufPrint(&prompt_buf, "Replace {s} with {s}? Type 'yes' to confirm: ", .{ self_exe, latest }) catch "Type 'yes' to confirm: ";
+        var prompt_buf: [320]u8 = undefined;
+        const prompt = if (twin_path) |tp|
+            std.fmt.bufPrint(&prompt_buf, "Replace {s} and {s} with {s}? Type 'yes' to confirm: ", .{ self_exe, tp, latest }) catch "Type 'yes' to confirm: "
+        else
+            std.fmt.bufPrint(&prompt_buf, "Replace {s} with {s}? Type 'yes' to confirm: ", .{ self_exe, latest }) catch "Type 'yes' to confirm: ";
         if (!output.confirmTyped("yes", prompt)) {
             output.info("Aborted", .{});
             return;
@@ -219,7 +228,47 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         },
     };
 
+    if (twin_path) |tp| {
+        output.info("Replacing {s}...", .{tp});
+        swap.atomicReplace(tp, new_binary) catch |e| {
+            // Don't roll back self: one updated binary beats a forced
+            // downgrade on the one the user just invoked. Surface the
+            // manual fix so they can close the gap.
+            output.err("Failed to replace {s}: {s}", .{ tp, @errorName(e) });
+            output.warn("{s} is now {s} but {s} is still the previous version.", .{ self_exe, latest, tp });
+            output.info("Finish manually: sudo cp {s} {s}", .{ new_binary, tp });
+            output.info("Updated to {s} (previous {s} kept at {s}.old)", .{ latest, std.fs.path.basename(self_exe), self_exe });
+            return;
+        };
+        output.info("Updated {s} and {s} to {s} (previous kept at *.old)", .{ self_exe, tp, latest });
+        return;
+    }
+
     output.info("Updated to {s} (previous kept at {s}.old)", .{ latest, self_exe });
+}
+
+/// Return the sibling binary path (`malt` ↔ `mt`) next to `self_exe`, but
+/// only when it is a plain regular file that needs its own swap. Symlinks
+/// track their target automatically after a swap, so we skip those.
+/// Returned slice points into `buf`.
+pub fn resolveTwinRegularFile(self_exe: []const u8, buf: []u8) ?[]const u8 {
+    const base = std.fs.path.basename(self_exe);
+    const twin_base: []const u8 =
+        if (std.mem.eql(u8, base, "malt")) "mt" else if (std.mem.eql(u8, base, "mt")) "malt" else return null;
+    const dir = std.fs.path.dirname(self_exe) orelse return null;
+
+    const twin_path = std.fmt.bufPrint(buf, "{s}/{s}", .{ dir, twin_base }) catch return null;
+
+    // `readLinkAbsolute` is the cheapest lstat here: success = symlink
+    // (skip), `error.NotLink` = regular file to update, anything else
+    // (missing, permission) = nothing we can usefully replace.
+    var link_buf: [fs_compat.max_path_bytes]u8 = undefined;
+    if (fs_compat.readLinkAbsolute(twin_path, &link_buf)) |_| {
+        return null;
+    } else |err| switch (err) {
+        error.NotLink => return twin_path,
+        else => return null,
+    }
 }
 
 /// Build `$TMPDIR/malt-update-<pid>/`. Falls back to `/tmp` when

--- a/src/fs/compat.zig
+++ b/src/fs/compat.zig
@@ -199,6 +199,19 @@ pub fn stdinFile() File {
     return .{ .inner = std.Io.File.stdin() };
 }
 
+/// View of the parent process's `environ` as a `std.process.Environ`.
+/// `std.Io.Threaded.init(.., .{})` defaults to an empty environ, which makes
+/// child spawns inherit nothing and forces PATH lookup onto a hard-coded
+/// `/usr/local/bin:/bin/:/usr/bin` (see
+/// `std.Io.Threaded.default_PATH`) — that fallback misses `/opt/homebrew/bin`
+/// on Apple Silicon, so `cosign` installed by Homebrew can't be found.
+pub fn processEnviron() std.process.Environ {
+    var n: usize = 0;
+    while (std.c.environ[n] != null) : (n += 1) {}
+    const slice: [:null]const ?[*:0]const u8 = @ptrCast(std.c.environ[0..n :null]);
+    return .{ .block = .{ .slice = slice } };
+}
+
 /// 0.15-style `std.process.Child` shim. The 0.16 API moved spawn/wait into
 /// free functions on `std.process` that take an `Io`; this wrapper preserves
 /// the two-step `init` → `spawn` → `wait` call shape so existing callers
@@ -228,8 +241,9 @@ pub const Child = struct {
         // allocator, which is fine for write-only stderr but blows up the
         // moment `std.process.spawn` tries to dup argv / env into its
         // arena. Build a per-call `Threaded` io rooted at the caller's
-        // allocator so spawn allocations succeed.
-        var threaded: std.Io.Threaded = .init(self.allocator, .{});
+        // allocator — and seeded with the real environ so PATH resolution
+        // and the child's env match the parent (see `processEnviron`).
+        var threaded: std.Io.Threaded = .init(self.allocator, .{ .environ = processEnviron() });
         defer threaded.deinit();
         const spawned = try std.process.spawn(threaded.io(), .{
             .argv = self.argv,

--- a/tests/verify_test.zig
+++ b/tests/verify_test.zig
@@ -131,6 +131,43 @@ test "verifyCosignBlob accepts a cosign that exits 0" {
     try verify.verifyCosignBlob(testing.allocator, args);
 }
 
+// libc env mutators: Zig 0.16 has no std wrapper for these and the
+// regression test needs a scoped PATH change to prove bare-name lookup.
+extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+
+test "verifyCosignBlob finds a bare 'cosign' via PATH (regression: gh#151)" {
+    // Before: `fs_compat.Child.spawn` initialized Threaded with an empty
+    // environ, so PATH resolution fell back to Zig's hard-coded
+    // `/usr/local/bin:/bin/:/usr/bin` and missed `/opt/homebrew/bin`. Drop
+    // a fake `cosign` into a scratch dir, prepend to PATH, and assert
+    // bare-name spawn resolves it.
+    const dir = "/tmp/malt_cosign_path_lookup";
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    try fs_compat.makeDirAbsolute(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    try writeFakeCosign(dir ++ "/cosign", 0);
+
+    // Snapshot PATH before mutating: `getenv` points into libc's environ,
+    // which `setenv` may realloc, so copy into a stable sentinel buffer.
+    // PATH is a colon-joined list, so size the buffer generously.
+    var orig_buf: [8192]u8 = undefined;
+    const orig_raw = fs_compat.getenv("PATH") orelse "";
+    if (orig_raw.len >= orig_buf.len) return error.SkipZigTest;
+    @memcpy(orig_buf[0..orig_raw.len], orig_raw);
+    orig_buf[orig_raw.len] = 0;
+
+    var new_path_buf: [8192]u8 = undefined;
+    const new_path = try std.fmt.bufPrintZ(&new_path_buf, "{s}:{s}", .{ dir, orig_raw });
+    if (setenv("PATH", new_path.ptr, 1) != 0) return error.SetEnvFailed;
+    defer _ = if (orig_raw.len == 0) unsetenv("PATH") else setenv("PATH", @ptrCast(&orig_buf), 1);
+
+    var args = fake_args;
+    args.cosign_bin = "cosign";
+    try verify.verifyCosignBlob(testing.allocator, args);
+}
+
 // --- verifyAll (end-to-end, local fixtures) ------------------------------
 //
 // Exercises the composed trust chain without HTTP: caller stages three

--- a/tests/version_update_test.zig
+++ b/tests/version_update_test.zig
@@ -105,3 +105,110 @@ test "writeResponseBody: createFileAbsolute failure leaves zero leaked allocatio
     );
     try testing.expectError(error.Aborted, result);
 }
+
+// --- resolveTwinRegularFile ---------------------------------------------
+//
+// install.sh ships two independent binaries (`malt` and `mt`). The updater
+// has to swap both in lockstep, otherwise `malt --version` and `mt --version`
+// drift apart. These tests pin the twin-detection contract.
+
+fn writeFile(path: []const u8, content: []const u8) !void {
+    const f = try fs_compat.createFileAbsolute(path, .{});
+    defer f.close();
+    try f.writeAll(content);
+}
+
+fn makeScratch(allocator: std.mem.Allocator, tag: []const u8) ![]u8 {
+    const dir = try std.fmt.allocPrint(allocator, "/tmp/malt_twin_test_{s}", .{tag});
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    try fs_compat.makeDirAbsolute(dir);
+    return dir;
+}
+
+test "resolveTwinRegularFile: returns sibling mt when invoked as malt" {
+    const dir = try makeScratch(testing.allocator, "malt_to_mt");
+    defer {
+        fs_compat.deleteTreeAbsolute(dir) catch {};
+        testing.allocator.free(dir);
+    }
+
+    const malt_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt", .{dir});
+    defer testing.allocator.free(malt_path);
+    const mt_path = try std.fmt.allocPrint(testing.allocator, "{s}/mt", .{dir});
+    defer testing.allocator.free(mt_path);
+    try writeFile(malt_path, "m");
+    try writeFile(mt_path, "m");
+
+    var buf: [fs_compat.max_path_bytes]u8 = undefined;
+    const twin = updater.resolveTwinRegularFile(malt_path, &buf) orelse return error.ExpectedTwin;
+    try testing.expectEqualStrings(mt_path, twin);
+}
+
+test "resolveTwinRegularFile: returns sibling malt when invoked as mt" {
+    const dir = try makeScratch(testing.allocator, "mt_to_malt");
+    defer {
+        fs_compat.deleteTreeAbsolute(dir) catch {};
+        testing.allocator.free(dir);
+    }
+
+    const malt_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt", .{dir});
+    defer testing.allocator.free(malt_path);
+    const mt_path = try std.fmt.allocPrint(testing.allocator, "{s}/mt", .{dir});
+    defer testing.allocator.free(mt_path);
+    try writeFile(malt_path, "m");
+    try writeFile(mt_path, "m");
+
+    var buf: [fs_compat.max_path_bytes]u8 = undefined;
+    const twin = updater.resolveTwinRegularFile(mt_path, &buf) orelse return error.ExpectedTwin;
+    try testing.expectEqualStrings(malt_path, twin);
+}
+
+test "resolveTwinRegularFile: returns null when sibling is a symlink" {
+    // A symlink already tracks its target: swapping the real file is enough,
+    // no second swap required.
+    const dir = try makeScratch(testing.allocator, "symlink_twin");
+    defer {
+        fs_compat.deleteTreeAbsolute(dir) catch {};
+        testing.allocator.free(dir);
+    }
+
+    const malt_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt", .{dir});
+    defer testing.allocator.free(malt_path);
+    const mt_path = try std.fmt.allocPrint(testing.allocator, "{s}/mt", .{dir});
+    defer testing.allocator.free(mt_path);
+    try writeFile(malt_path, "m");
+    try fs_compat.symLinkAbsolute(malt_path, mt_path, .{});
+
+    var buf: [fs_compat.max_path_bytes]u8 = undefined;
+    try testing.expect(updater.resolveTwinRegularFile(malt_path, &buf) == null);
+}
+
+test "resolveTwinRegularFile: returns null when no sibling exists" {
+    const dir = try makeScratch(testing.allocator, "no_twin");
+    defer {
+        fs_compat.deleteTreeAbsolute(dir) catch {};
+        testing.allocator.free(dir);
+    }
+
+    const malt_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt", .{dir});
+    defer testing.allocator.free(malt_path);
+    try writeFile(malt_path, "m");
+
+    var buf: [fs_compat.max_path_bytes]u8 = undefined;
+    try testing.expect(updater.resolveTwinRegularFile(malt_path, &buf) == null);
+}
+
+test "resolveTwinRegularFile: returns null for unrelated basenames" {
+    const dir = try makeScratch(testing.allocator, "other_name");
+    defer {
+        fs_compat.deleteTreeAbsolute(dir) catch {};
+        testing.allocator.free(dir);
+    }
+
+    const other_path = try std.fmt.allocPrint(testing.allocator, "{s}/something-else", .{dir});
+    defer testing.allocator.free(other_path);
+    try writeFile(other_path, "x");
+
+    var buf: [fs_compat.max_path_bytes]u8 = undefined;
+    try testing.expect(updater.resolveTwinRegularFile(other_path, &buf) == null);
+}


### PR DESCRIPTION
## Description

Two independent bugs in `mt version update`, both surfaced in #151.

**Bug 1 - cosign not detected even when installed.** `fs_compat.Child.spawn` built its `std.Io.Threaded` with `.{}` defaults, which left `environ` empty. `std.Io.Threaded`'s PATH resolution then fell back to the baked-in `/usr/local/bin:/bin/:/usr/bin` and missed `/opt/homebrew/bin`, so Apple Silicon users who ran `brew install cosign` still hit `cosign is required to verify the release signature`. A new `processEnviron()` helper exposes libc's `environ` and the per-call Threaded is seeded with it, so PATH lookup and the child's inherited env both match the parent.

**Bug 2 . `--no-verify` updated only one of `malt`/`mt`.** `install.sh` drops both as independent regular files. The updater only swapped the binary behind `executablePath`, so after the update `malt --version` and `mt --version` would disagree. `resolveTwinRegularFile()` now finds the sibling next to `self_exe`; if it's a regular file we swap it in lockstep, if it's a symlink we leave it alone (symlinks track their target automatically). On a successful primary + failed twin swap, we keep the primary updated and surface a `sudo cp` recipe rather than rolling back the binary the user just invoked.

## Related Issue

Fixes #151

## Notes for Reviewers

- None
