### PR TITLE
refactor(core/bundle): invert runner -> cli direction

### DIFF
--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -11,6 +11,39 @@ const manifest_mod = @import("../core/bundle/manifest.zig");
 const brewfile_mod = @import("../core/bundle/brewfile.zig");
 const brewfile_emit = @import("../core/bundle/brewfile_emit.zig");
 const runner_mod = @import("../core/bundle/runner.zig");
+const install_cmd = @import("install.zig");
+const tap_cmd = @import("tap.zig");
+const services_cmd = @import("services.zig");
+
+// Default in-process dispatcher: the CLI layer supplies this so the
+// runner can stay ignorant of cli/* while still calling into the real
+// install/tap/services primitives.
+fn cliInstallFormula(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+    _ = ctx;
+    return install_cmd.installAll(allocator, &.{name}, .{});
+}
+
+fn cliInstallCask(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+    _ = ctx;
+    return install_cmd.installAll(allocator, &.{name}, .{ .cask = true });
+}
+
+fn cliTapAdd(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+    _ = ctx;
+    return tap_cmd.tapAdd(allocator, name);
+}
+
+fn cliServiceStart(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+    _ = ctx;
+    return services_cmd.servicesStart(allocator, name);
+}
+
+const default_dispatcher = runner_mod.Dispatcher{
+    .installFormula = cliInstallFormula,
+    .installCask = cliInstallCask,
+    .tapAdd = cliTapAdd,
+    .serviceStart = cliServiceStart,
+};
 
 pub const BundleError = error{
     InvalidArgs,
@@ -81,7 +114,10 @@ fn cmdInstall(allocator: std.mem.Allocator, rest: []const []const u8) !void {
     defer db.close();
     schema.initSchema(&db) catch {};
 
-    runner_mod.run(allocator, &db, manifest, .{ .dry_run = dry_run }) catch |e| {
+    runner_mod.run(allocator, &db, manifest, .{
+        .dry_run = dry_run,
+        .dispatcher = &default_dispatcher,
+    }) catch |e| {
         output.err("bundle install failed: {s}", .{@errorName(e)});
         return BundleError.RunnerFailed;
     };

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -385,6 +385,26 @@ fn downloadWorker(
     job.succeeded = true;
 }
 
+pub const InstallAllOpts = struct {
+    /// Treat every package as a cask; equivalent to `--cask`.
+    cask: bool = false,
+};
+
+/// Non-argv primitive used by `core/bundle/runner.zig` via its injected
+/// `Dispatcher`. Argv parsing stays in `execute`; this seam is what lets
+/// core/bundle share orchestration without importing `cli/*`.
+pub fn installAll(
+    allocator: std.mem.Allocator,
+    packages: []const []const u8,
+    opts: InstallAllOpts,
+) !void {
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(allocator);
+    if (opts.cask) try argv.append(allocator, "--cask");
+    for (packages) |p| try argv.append(allocator, p);
+    return execute(allocator, argv.items);
+}
+
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "install")) return;
 

--- a/src/cli/services.zig
+++ b/src/cli/services.zig
@@ -22,6 +22,13 @@ pub fn describeError(err: ServicesError) []const u8 {
     };
 }
 
+/// Primitive entry point for core/bundle's dispatcher: start a single
+/// service. Argv parsing stays in `execute`; this is the non-argv seam.
+pub fn servicesStart(allocator: std.mem.Allocator, name: []const u8) !void {
+    const argv = [_][]const u8{ "start", name };
+    return execute(allocator, &argv);
+}
+
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (args.len == 0 or
         std.mem.eql(u8, args[0], "-h") or

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -42,6 +42,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     return run(allocator, args, .add);
 }
 
+/// Primitive entry point for core/bundle's dispatcher: add a single tap by
+/// name. Argv parsing stays in `execute`; this is the non-argv seam.
+pub fn tapAdd(allocator: std.mem.Allocator, name: []const u8) !void {
+    const argv = [_][]const u8{name};
+    return run(allocator, &argv, .add);
+}
+
 pub fn executeUntap(allocator: std.mem.Allocator, args: []const []const u8) !void {
     return run(allocator, args, .remove);
 }

--- a/src/core/bundle/runner.zig
+++ b/src/core/bundle/runner.zig
@@ -1,15 +1,16 @@
 //! malt — bundle runner
 //!
-//! Installs every member of a `Manifest` by calling the matching command
-//! module's `execute` function in-process. Each underlying primitive
-//! (`install`, `tap`, `services start`) is already idempotent, so running a
-//! bundle twice is a no-op for already-installed members. Avoiding a
-//! subprocess per member keeps SQLite warm and removes per-fork output noise.
+//! Installs every member of a `Manifest` by routing each item through a
+//! caller-supplied `Dispatcher` (in-process) or a fallback `malt` subprocess
+//! (when `Options.malt_bin` is set — tests use that to assert exit-code
+//! propagation via `/usr/bin/false`). In-process is the production default:
+//! it keeps SQLite warm and avoids per-fork output noise. The runner itself
+//! depends on no `cli/*` module, so bundle tests link without dragging in
+//! the whole CLI surface.
 //!
-//! `Options.malt_bin` is honoured only by the legacy subprocess fallback,
-//! which the test suite still uses when it wants to assert exit-code
-//! propagation against a fake binary like `/usr/bin/false`. Production
-//! callers leave it null.
+//! Each underlying primitive (install, tap, services start) is already
+//! idempotent, so running a bundle twice is a no-op for already-installed
+//! members.
 
 const std = @import("std");
 const fs_compat = @import("../../fs/compat.zig");
@@ -20,9 +21,6 @@ const lock_mod = @import("../../db/lock.zig");
 const atomic = @import("../../fs/atomic.zig");
 const output = @import("../../ui/output.zig");
 const manifest_mod = @import("manifest.zig");
-const install_cmd = @import("../../cli/install.zig");
-const tap_cmd = @import("../../cli/tap.zig");
-const services_cmd = @import("../../cli/services.zig");
 
 pub const RunnerError = error{
     MemberFailed,
@@ -30,6 +28,10 @@ pub const RunnerError = error{
     LockFailed,
     IoFailed,
     OutOfMemory,
+    /// Production builds need a `Dispatcher` wired from the CLI layer;
+    /// absence means the caller forgot to provide one and we refuse to
+    /// silently do nothing.
+    NoDispatcher,
 };
 
 pub fn describeError(err: RunnerError) []const u8 {
@@ -39,19 +41,37 @@ pub fn describeError(err: RunnerError) []const u8 {
         RunnerError.LockFailed => "could not acquire bundle lock",
         RunnerError.IoFailed => "filesystem error during bundle install",
         RunnerError.OutOfMemory => "out of memory during bundle install",
+        RunnerError.NoDispatcher => "bundle runner called without a dispatcher and without malt_bin",
     };
 }
+
+/// Layering seam: the CLI wires up a concrete implementation that forwards
+/// to `cli/install`, `cli/tap`, `cli/services`. Keeping this as an injected
+/// interface is what lets `core/bundle/runner.zig` avoid a `cli/*` import.
+pub const Dispatcher = struct {
+    ctx: ?*anyopaque = null,
+    installFormula: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void,
+    installCask: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void,
+    tapAdd: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void,
+    serviceStart: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void,
+};
 
 pub const Options = struct {
     /// When true, report what would be installed without forking subprocesses.
     dry_run: bool = false,
-    /// Override the binary used for member installs. When null, `malt` from
-    /// $PATH is used.
+    /// Override the binary used for member installs. When set, each member
+    /// is run via subprocess — test suites use this to substitute
+    /// `/usr/bin/false` and assert exit-code propagation. Production
+    /// callers leave it null and provide a `dispatcher` instead.
     malt_bin: ?[]const u8 = null,
     /// Override the install prefix used for the bundle lockfile. Tests use
     /// this to keep the lock under their per-test temp directory; production
     /// callers leave it null (which falls back to `MALT_PREFIX`).
     prefix: ?[]const u8 = null,
+    /// In-process dispatcher injected from the CLI layer. Null is legal
+    /// for `dry_run` and subprocess (`malt_bin`) paths; otherwise the
+    /// runner returns `RunnerError.NoDispatcher`.
+    dispatcher: ?*const Dispatcher = null,
 };
 
 pub fn run(
@@ -143,11 +163,12 @@ fn callMember(allocator: std.mem.Allocator, call: MemberCall, opts: Options) !vo
     // tests can substitute /usr/bin/false to assert exit-code propagation.
     if (opts.malt_bin) |bin| return runSubprocess(allocator, bin, call);
 
+    const d = opts.dispatcher orelse return RunnerError.NoDispatcher;
     switch (call) {
-        .tap => |n| try tap_cmd.execute(allocator, &.{n}),
-        .formula => |n| try install_cmd.execute(allocator, &.{n}),
-        .cask => |n| try install_cmd.execute(allocator, &.{ "--cask", n }),
-        .service_start => |n| try services_cmd.execute(allocator, &.{ "start", n }),
+        .tap => |n| try d.tapAdd(d.ctx, allocator, n),
+        .formula => |n| try d.installFormula(d.ctx, allocator, n),
+        .cask => |n| try d.installCask(d.ctx, allocator, n),
+        .service_start => |n| try d.serviceStart(d.ctx, allocator, n),
     }
 }
 

--- a/tests/bundle_test.zig
+++ b/tests/bundle_test.zig
@@ -99,6 +99,117 @@ test "non-dry runner with mocked malt_bin records bundle even on member failure"
     try testing.expectEqual(@as(i64, 4), ms.columnInt(0));
 }
 
+test "runner routes members through the provided dispatcher" {
+    var t = try TempDb.init("dispatcher");
+    defer t.deinit();
+
+    // Capture which primitive each member hit so we can prove runner.zig
+    // no longer reaches into cli/* via argv.
+    var calls = Calls.init(testing.allocator);
+    defer calls.deinit();
+
+    const dispatcher = runner.Dispatcher{
+        .ctx = &calls,
+        .installFormula = Calls.installFormulaFn,
+        .installCask = Calls.installCaskFn,
+        .tapAdd = Calls.tapAddFn,
+        .serviceStart = Calls.serviceStartFn,
+    };
+
+    var m = try buildManifest(testing.allocator);
+    defer m.deinit();
+
+    try runner.run(testing.allocator, &t.db, m, .{
+        .dry_run = false,
+        .prefix = t.dir,
+        .dispatcher = &dispatcher,
+    });
+
+    try testing.expectEqual(@as(usize, 1), calls.taps.items.len);
+    try testing.expectEqualStrings("homebrew/cask-fonts", calls.taps.items[0]);
+    try testing.expectEqual(@as(usize, 2), calls.formulas.items.len);
+    try testing.expectEqualStrings("wget", calls.formulas.items[0]);
+    try testing.expectEqualStrings("jq", calls.formulas.items[1]);
+    try testing.expectEqual(@as(usize, 1), calls.casks.items.len);
+    try testing.expectEqualStrings("ghostty", calls.casks.items[0]);
+    try testing.expectEqual(@as(usize, 0), calls.services.items.len);
+}
+
+const Calls = struct {
+    allocator: std.mem.Allocator,
+    taps: std.ArrayList([]const u8),
+    formulas: std.ArrayList([]const u8),
+    casks: std.ArrayList([]const u8),
+    services: std.ArrayList([]const u8),
+
+    fn init(allocator: std.mem.Allocator) Calls {
+        return .{
+            .allocator = allocator,
+            .taps = .empty,
+            .formulas = .empty,
+            .casks = .empty,
+            .services = .empty,
+        };
+    }
+
+    fn deinit(self: *Calls) void {
+        self.taps.deinit(self.allocator);
+        self.formulas.deinit(self.allocator);
+        self.casks.deinit(self.allocator);
+        self.services.deinit(self.allocator);
+    }
+
+    fn record(list: *std.ArrayList([]const u8), allocator: std.mem.Allocator, name: []const u8) !void {
+        try list.append(allocator, name);
+    }
+
+    // ctx round-trips through the Dispatcher vtable as *anyopaque; these
+    // casts restore the concrete type the test injected.
+    fn unwrap(ctx: ?*anyopaque) *Calls {
+        return @ptrCast(@alignCast(ctx.?));
+    }
+
+    fn tapAddFn(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+        const self = unwrap(ctx);
+        try record(&self.taps, allocator, name);
+    }
+    fn installFormulaFn(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+        const self = unwrap(ctx);
+        try record(&self.formulas, allocator, name);
+    }
+    fn installCaskFn(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+        const self = unwrap(ctx);
+        try record(&self.casks, allocator, name);
+    }
+    fn serviceStartFn(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+        const self = unwrap(ctx);
+        try record(&self.services, allocator, name);
+    }
+};
+
+test "runner refuses in-process bundle install with no dispatcher and no malt_bin" {
+    var t = try TempDb.init("no_dispatcher");
+    defer t.deinit();
+
+    var m = try buildManifest(testing.allocator);
+    defer m.deinit();
+
+    const result = runner.run(testing.allocator, &t.db, m, .{
+        .dry_run = false,
+        .prefix = t.dir,
+    });
+    try testing.expectError(runner.RunnerError.MemberFailed, result);
+
+    // The bundle row must NOT exist when the very first member bombed out
+    // with NoDispatcher — we only record after attempting all members.
+    var stmt = try t.db.prepare("SELECT COUNT(*) FROM bundles WHERE name='devtools';");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    // recordBundle still runs even on partial failure, matching the
+    // existing `/usr/bin/false` test — this pins that invariant.
+    try testing.expectEqual(@as(i64, 1), stmt.columnInt(0));
+}
+
 test "round-trip: parse Brewfile fixture, run dry, no panic" {
     var t = try TempDb.init("smoke");
     defer t.deinit();


### PR DESCRIPTION
## Description

Invert the `core/bundle/runner.zig -> cli/*` direction. The runner now routes each bundle member through an injected `Dispatcher` (function-pointer vtable with `installFormula` / `installCask` / `tapAdd` / `serviceStart`). The CLI layer (`cli/bundle.zig`) supplies a default dispatcher that forwards to new non-argv primitives in `cli/install.zig::installAll`, `cli/tap.zig::tapAdd`, `cli/services.zig::servicesStart`. The argv-taking `execute` functions stay put as the interactive CLI entry point.

## Related Issue

- None

## Notes for Reviewers

- New `RunnerError.NoDispatcher` is raised when the runner is invoked
  in-process without a dispatcher and without `malt_bin`; existing tests
  either use `dry_run` or `malt_bin = "/usr/bin/false"` so they don't hit
  this path. `cli/bundle.zig::cmdInstall` always supplies the default.