### PR TITLE
refactor: unify post_install routing between install and migrate

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -8,7 +8,6 @@ const cask_mod = @import("../core/cask.zig");
 const cellar_mod = @import("../core/cellar.zig");
 const formula_mod = @import("../core/formula.zig");
 const linker_mod = @import("../core/linker.zig");
-const ruby_sub = @import("../core/ruby_subprocess.zig");
 const plist_mod = @import("../core/services/plist.zig");
 const supervisor_mod = @import("../core/services/supervisor.zig");
 const store_mod = @import("../core/store.zig");
@@ -62,7 +61,7 @@ pub const PostInstallStatus = post_install_mod.PostInstallStatus;
 pub const routePostInstallOutcome = post_install_mod.routePostInstallOutcome;
 pub const DslPostInstallOutcome = post_install_mod.DslPostInstallOutcome;
 pub const executeDslPostInstall = post_install_mod.executeDslPostInstall;
-const useSystemRubyForFormula = post_install_mod.useSystemRubyForFormula;
+pub const drive = post_install_mod.drive;
 const record_mod = @import("install/record.zig");
 pub const InstallError = record_mod.InstallError;
 pub const localErrorIsAnnounced = record_mod.localErrorIsAnnounced;
@@ -609,42 +608,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             continue;
         };
 
-        // Execute post_install: try DSL interpreter first, fall back to
-        // system Ruby subprocess when --use-system-ruby is set.
-        if (job.post_install_defined) post_install: {
-            // Locate a DSL source: local tap first, GitHub fetch second.
-            const dsl_src: ?[]const u8 = blk: {
-                const tap_path = ruby_sub.findHomebrewCoreTap();
-                var rb_buf: [1024]u8 = undefined;
-                const rb_path = if (tap_path) |tp|
-                    ruby_sub.resolveFormulaRbPath(&rb_buf, tp, job.name)
-                else
-                    null;
-                if (rb_path) |sp| {
-                    if (ruby_sub.extractPostInstallBody(allocator, sp)) |s| break :blk s;
-                }
-                break :blk ruby_sub.fetchPostInstallFromGitHub(allocator, job.name);
-            };
-
-            if (dsl_src) |src| {
-                defer allocator.free(src);
-                switch (executeDslPostInstall(allocator, job, src, prefix, use_system_ruby_list)) {
-                    .handled => break :post_install,
-                    // parse_failed leaves the DSL path unusable — fall through
-                    // so the system-Ruby fallback still has a chance to run.
-                    .parse_failed => {},
-                }
-            }
-
-            // No usable DSL source — fall back to subprocess or skip.
-            if (useSystemRubyForFormula(use_system_ruby_list, job.name)) {
-                output.warn("Running post_install for {s} via system Ruby...", .{job.name});
-                ruby_sub.runPostInstall(allocator, job.name, job.version_str, prefix) catch |e| {
-                    output.warn("post_install failed for {s}: {s}", .{ job.name, @errorName(e) });
-                };
-            } else {
-                output.warn("{s}: post_install skipped (use --use-system-ruby={s} or brew install {s})", .{ job.name, job.name, job.name });
-            }
+        if (job.post_install_defined) {
+            drive(allocator, job.name, job.version_str, job.formula_json, prefix, use_system_ruby_list);
         }
     }
 

--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -1,6 +1,8 @@
 //! Post-install routing for formulas that declare a Ruby hook.
 //! Prefers the native DSL interpreter and, when a per-formula scope
-//! opts in, falls back to a sandboxed `ruby` subprocess.
+//! opts in, falls back to a sandboxed `ruby` subprocess. Single source
+//! of truth for both `install` and `migrate` so users see byte-identical
+//! human + JSON envelopes regardless of which command did the work.
 
 const std = @import("std");
 const formula_mod = @import("../../core/formula.zig");
@@ -117,20 +119,23 @@ pub const DslPostInstallOutcome = enum {
     parse_failed,
 };
 
-/// Run one DSL post_install attempt against `job`. Owns the formula +
-/// FallbackLog lifetimes so callers don't have to replicate the cleanup
-/// chain across every candidate source (local .rb, GitHub fetch).
+/// Run one DSL post_install attempt for a formula. Owns the parsed
+/// formula + FallbackLog lifetimes so callers don't have to replicate
+/// the cleanup chain across every candidate source (local .rb, GitHub).
 ///
-/// Pub so install-pure tests can pin the outcome contract directly.
+/// Narrow inputs (name + version + json bytes) keep migrate decoupled
+/// from install's `DownloadJob` shape.
 pub fn executeDslPostInstall(
     allocator: std.mem.Allocator,
-    job: *const DownloadJob,
+    name: []const u8,
+    version_str: []const u8,
+    formula_json: []const u8,
     post_install_src: []const u8,
     prefix: []const u8,
     use_system_ruby_list: []const []const u8,
 ) DslPostInstallOutcome {
-    var formula = formula_mod.parseFormula(allocator, job.formula_json) catch {
-        output.warn("post_install: failed to parse formula for {s}", .{job.name});
+    var formula = formula_mod.parseFormula(allocator, formula_json) catch {
+        output.warn("post_install: failed to parse formula for {s}", .{name});
         return .parse_failed;
     };
     defer formula.deinit();
@@ -141,6 +146,63 @@ pub fn executeDslPostInstall(
     // DSL errors reflect in `flog`; the router reads the log as the source
     // of truth so silent skips downgrade the same as hard failures.
     dsl.executePostInstall(allocator, &formula, post_install_src, prefix, &flog) catch {};
-    routePostInstallOutcome(allocator, job.name, job.version_str, prefix, &flog, use_system_ruby_list);
+    routePostInstallOutcome(allocator, name, version_str, prefix, &flog, use_system_ruby_list);
     return .handled;
+}
+
+/// Locate a DSL post_install body for `name`: prefer a locally cloned
+/// homebrew-core tap, fall back to the pinned GitHub fetch. Returned
+/// slice (when non-null) is owned by the caller.
+fn locateDslSource(allocator: std.mem.Allocator, name: []const u8) ?[]const u8 {
+    const tap_path = ruby_sub.findHomebrewCoreTap();
+    var rb_buf: [1024]u8 = undefined;
+    const rb_path = if (tap_path) |tp|
+        ruby_sub.resolveFormulaRbPath(&rb_buf, tp, name)
+    else
+        null;
+    if (rb_path) |sp| {
+        if (ruby_sub.extractPostInstallBody(allocator, sp)) |s| return s;
+    }
+    return ruby_sub.fetchPostInstallFromGitHub(allocator, name);
+}
+
+/// End-to-end post_install dispatch shared by `install` and `migrate`:
+/// locate a DSL source, run it through the interpreter and route the
+/// outcome, or fall back to a system-Ruby subprocess (when the formula
+/// is in `--use-system-ruby` scope) or the unified skip hint. Both
+/// commands route through here so human + JSON envelopes match exactly.
+pub fn drive(
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    version_str: []const u8,
+    formula_json: []const u8,
+    prefix: []const u8,
+    use_system_ruby_list: []const []const u8,
+) void {
+    if (locateDslSource(allocator, name)) |src| {
+        defer allocator.free(src);
+        switch (executeDslPostInstall(
+            allocator,
+            name,
+            version_str,
+            formula_json,
+            src,
+            prefix,
+            use_system_ruby_list,
+        )) {
+            .handled => return,
+            // parse_failed leaves the DSL path unusable — fall through so
+            // the system-Ruby fallback still has a chance to run.
+            .parse_failed => {},
+        }
+    }
+
+    if (useSystemRubyForFormula(use_system_ruby_list, name)) {
+        output.warn("Running post_install for {s} via system Ruby...", .{name});
+        ruby_sub.runPostInstall(allocator, name, version_str, prefix) catch |e| {
+            output.warn("post_install failed for {s}: {s}", .{ name, @errorName(e) });
+        };
+    } else {
+        output.warn("{s}: post_install skipped (use --use-system-ruby={s} or brew install {s})", .{ name, name, name });
+    }
 }

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -21,14 +21,8 @@ const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
 const io_mod = @import("../ui/io.zig");
 const codesign = @import("../macho/codesign.zig");
-const ruby_sub = @import("../core/ruby_subprocess.zig");
-const dsl = @import("../core/dsl/root.zig");
+const post_install_mod = @import("install/post_install.zig");
 const help = @import("help.zig");
-
-fn inScope(scope: []const []const u8, name: []const u8) bool {
-    for (scope) |n| if (std.mem.eql(u8, n, name)) return true;
-    return false;
-}
 
 /// Resolve the Homebrew install prefix. Respects `HOMEBREW_PREFIX` (set
 /// by `brew shellenv` and by users with a non-standard install), falls
@@ -391,75 +385,15 @@ fn migrateKeg(
         recordDeps(db, keg_id, &formula);
     }
 
-    // Execute post_install: try DSL interpreter first, fall back to
-    // system Ruby subprocess when --use-system-ruby is set.
-    if (formula.post_install_defined) post_install: {
-        const tap_path = ruby_sub.findHomebrewCoreTap();
-        var rb_buf: [1024]u8 = undefined;
-        const rb_path = if (tap_path) |tp| ruby_sub.resolveFormulaRbPath(&rb_buf, tp, formula.name) else null;
-
-        if (rb_path) |src_path| {
-            if (ruby_sub.extractPostInstallBody(allocator, src_path)) |post_install_src| {
-                defer allocator.free(post_install_src);
-
-                var flog = dsl.FallbackLog.init(allocator);
-                defer flog.deinit();
-
-                dsl.executePostInstall(allocator, &formula, post_install_src, prefix, &flog) catch {
-                    if (flog.hasFatal()) {
-                        output.warn("  post_install DSL failed for {s} (fatal)", .{formula.name});
-                        flog.printFatal(formula.name);
-                        break :post_install;
-                    }
-                    if (inScope(use_system_ruby_scope, formula.name)) {
-                        ruby_sub.runPostInstall(allocator, formula.name, formula.pkg_version, prefix) catch |e| {
-                            output.warn("  post_install subprocess failed for {s}: {s}", .{ formula.name, @errorName(e) });
-                        };
-                    } else {
-                        output.warn("  {s}: post_install partially skipped (use --use-system-ruby={s} to attempt via Ruby)", .{ formula.name, formula.name });
-                    }
-                    break :post_install;
-                };
-                output.info("  post_install completed for {s}", .{formula.name});
-                break :post_install;
-            }
-        }
-
-        // No local .rb source — try fetching from GitHub
-        if (ruby_sub.fetchPostInstallFromGitHub(allocator, formula.name)) |post_install_src| {
-            defer allocator.free(post_install_src);
-
-            var flog2 = dsl.FallbackLog.init(allocator);
-            defer flog2.deinit();
-
-            dsl.executePostInstall(allocator, &formula, post_install_src, prefix, &flog2) catch {
-                if (flog2.hasFatal()) {
-                    output.warn("  post_install DSL failed for {s} (fatal)", .{formula.name});
-                    flog2.printFatal(formula.name);
-                    break :post_install;
-                }
-                if (inScope(use_system_ruby_scope, formula.name)) {
-                    ruby_sub.runPostInstall(allocator, formula.name, formula.pkg_version, prefix) catch |e| {
-                        output.warn("  post_install subprocess failed for {s}: {s}", .{ formula.name, @errorName(e) });
-                    };
-                } else {
-                    output.warn("  {s}: post_install partially skipped (use --use-system-ruby={s} to attempt via Ruby)", .{ formula.name, formula.name });
-                }
-                break :post_install;
-            };
-            output.info("  post_install completed for {s}", .{formula.name});
-            break :post_install;
-        }
-
-        // No source available — fall back to subprocess or skip
-        if (inScope(use_system_ruby_scope, formula.name)) {
-            output.warn("  Running post_install for {s} via system Ruby...", .{formula.name});
-            ruby_sub.runPostInstall(allocator, formula.name, formula.pkg_version, prefix) catch |e| {
-                output.warn("  post_install failed for {s}: {s}", .{ formula.name, @errorName(e) });
-            };
-        } else {
-            output.warn("  {s}: post_install skipped (use --use-system-ruby={s} or brew install {s})", .{ formula.name, formula.name, formula.name });
-        }
+    if (formula.post_install_defined) {
+        post_install_mod.drive(
+            allocator,
+            formula.name,
+            formula.pkg_version,
+            formula_json,
+            prefix,
+            use_system_ruby_scope,
+        );
     }
 
     const keg_only_suffix: []const u8 = if (formula.keg_only) " (keg-only — dependency only)" else "";

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -621,29 +621,11 @@ test "routePostInstallOutcome: --json status=fatal on sandbox violation" {
 }
 
 // ---------------------------------------------------------------------------
-// executeDslPostInstall — owns one DSL attempt against a job. The outcome
-// decides whether the caller falls through to the system-Ruby fallback.
+// executeDslPostInstall — owns one DSL attempt against a parsed formula.
+// The outcome decides whether the caller falls through to the system-Ruby
+// fallback. Narrow inputs (name + version + json bytes) so install and
+// migrate share the same entry without forging a DownloadJob.
 // ---------------------------------------------------------------------------
-
-fn stubJob(name: []const u8, formula_json: []const u8) install.DownloadJob {
-    return .{
-        .name = name,
-        .version_str = "1.0",
-        .sha256 = "aa",
-        .bottle_url = "",
-        .is_dep = false,
-        .keg_only = false,
-        .post_install_defined = true,
-        .formula_json = formula_json,
-        .cellar_type = ":any",
-        .label_width = 0,
-        .line_index = 0,
-        .multi = null,
-        .bar = null,
-        .store_sha256 = "",
-        .succeeded = true,
-    };
-}
 
 test "executeDslPostInstall returns .parse_failed when formula JSON is unparseable" {
     // The parse-failure path must surface as a distinct outcome so the
@@ -653,10 +635,11 @@ test "executeDslPostInstall returns .parse_failed when formula JSON is unparseab
     output_mod.setQuiet(true);
     defer output_mod.setQuiet(prior_quiet);
 
-    const job = stubJob("bad-json", "not-a-json");
     const outcome = install.executeDslPostInstall(
         testing.allocator,
-        &job,
+        "bad-json",
+        "1.0",
+        "not-a-json",
         "# empty body",
         "/tmp/irrelevant",
         &.{},
@@ -676,15 +659,57 @@ test "executeDslPostInstall returns .handled when DSL executes against a valid f
     const json =
         \\{"name":"hello","full_name":"hello","versions":{"stable":"1.0"},"dependencies":[],"oldnames":[]}
     ;
-    const job = stubJob("hello", json);
     const outcome = install.executeDslPostInstall(
         testing.allocator,
-        &job,
+        "hello",
+        "1.0",
+        json,
         "# empty",
         "/tmp/irrelevant",
         &.{},
     );
     try testing.expectEqual(install.DslPostInstallOutcome.handled, outcome);
+}
+
+// ---------------------------------------------------------------------------
+// drive — full post_install flow shared by install + migrate. Locates a
+// DSL source, runs it through executeDslPostInstall, or falls back to the
+// system-Ruby subprocess. Tested via the no-source / no-scope leaf so both
+// commands route the "user must opt in" hint through one code path.
+// ---------------------------------------------------------------------------
+
+test "drive: no DSL source and no scope match emits the unified skip hint" {
+    color_mod.setForTest(false, false);
+    defer color_mod.setForTest(null, null);
+    const prior_quiet = output_mod.isQuiet();
+    output_mod.setQuiet(false);
+    defer output_mod.setQuiet(prior_quiet);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &buf);
+    defer io_mod.endStderrCapture();
+
+    // A name guaranteed to miss every DSL source: not a real formula, no
+    // .rb on disk, no pin manifest entry → fetchPostInstallFromGitHub
+    // returns null, so drive lands on the skip leaf.
+    install.drive(
+        testing.allocator,
+        "__nonexistent_test_formula_xyz__",
+        "1.0",
+        "{}",
+        "/tmp/irrelevant",
+        &.{},
+    );
+
+    // The skip hint is the byte-for-byte string both install and migrate
+    // must print so scripted users see the same "opt in" message.
+    try testing.expect(std.mem.indexOf(
+        u8,
+        buf.items,
+        "post_install skipped (use --use-system-ruby=__nonexistent_test_formula_xyz__ or brew install __nonexistent_test_formula_xyz__)",
+    ) != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "Running post_install") == null);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Migrate now calls the shared `post_install.drive` helper instead of carrying its own copy of the locate -> execute -> route -> fall back decision tree. Both commands route through one entry point, so users see byte-identical human and JSON envelopes for every post_install outcome regardless of which command did the work.

## Related Issue

- None

## Notes for Reviewers

- None