### PR TITLE
refactor(core): return structured outcomes rather than emitting UI

### DIFF
--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -107,20 +107,54 @@ fn cmdInstall(allocator: std.mem.Allocator, rest: []const []const u8) !void {
     defer allocator.free(path);
     output.info("using bundle file: {s}", .{path});
 
-    var manifest = try readManifest(allocator, path);
+    var diag = brewfile_mod.Diagnostics.init(allocator);
+    defer diag.deinit();
+    var manifest = try readManifest(allocator, path, &diag);
     defer manifest.deinit();
+    for (diag.warnings.items) |w| output.warn("{s}", .{w});
 
     var db = try openDb();
     defer db.close();
     schema.initSchema(&db) catch {};
 
-    runner_mod.run(allocator, &db, manifest, .{
+    var report = runner_mod.run(allocator, &db, manifest, .{
         .dry_run = dry_run,
         .dispatcher = &default_dispatcher,
     }) catch |e| {
         output.err("bundle install failed: {s}", .{@errorName(e)});
         return BundleError.RunnerFailed;
     };
+    defer report.deinit();
+
+    for (report.previews) |p| switch (p.kind) {
+        .tap => output.info("would run: malt tap {s}", .{p.name}),
+        .formula => output.info("would run: malt install {s}", .{p.name}),
+        .cask => output.info("would run: malt install --cask {s}", .{p.name}),
+        .service_start => output.info("would run: malt services start {s}", .{p.name}),
+    };
+    var any_hard = false;
+    for (report.failures) |f| switch (f.kind) {
+        .tap => {
+            output.err("tap failed: {s}", .{f.name});
+            any_hard = true;
+        },
+        .formula => {
+            output.err("install failed: {s}", .{f.name});
+            any_hard = true;
+        },
+        .cask => {
+            output.err("cask install failed: {s}", .{f.name});
+            any_hard = true;
+        },
+        // Service auto-start is best-effort; warn but don't fail the bundle.
+        .service_start => output.warn("could not auto-start service: {s}", .{f.name}),
+    };
+    if (report.db_record_error) |name| {
+        output.err("could not record bundle in database: {s}", .{name});
+        any_hard = true;
+    }
+
+    if (any_hard) return BundleError.RunnerFailed;
     output.success("bundle install complete", .{});
 }
 
@@ -232,8 +266,11 @@ fn cmdImport(allocator: std.mem.Allocator, rest: []const []const u8) !void {
         return BundleError.InvalidArgs;
     }
     const path = rest[0];
-    var manifest = try readManifest(allocator, path);
+    var diag = brewfile_mod.Diagnostics.init(allocator);
+    defer diag.deinit();
+    var manifest = try readManifest(allocator, path, &diag);
     defer manifest.deinit();
+    for (diag.warnings.items) |w| output.warn("{s}", .{w});
 
     var db = try openDb();
     defer db.close();
@@ -291,7 +328,11 @@ fn resolveBundlefile(allocator: std.mem.Allocator, explicit: ?[]const u8) ![]con
     return BundleError.BundlefileNotFound;
 }
 
-fn readManifest(allocator: std.mem.Allocator, path: []const u8) !manifest_mod.Manifest {
+fn readManifest(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    diag: ?*brewfile_mod.Diagnostics,
+) !manifest_mod.Manifest {
     const file = if (std.fs.path.isAbsolute(path))
         fs_compat.openFileAbsolute(path, .{}) catch return BundleError.BundlefileNotFound
     else
@@ -307,7 +348,7 @@ fn readManifest(allocator: std.mem.Allocator, path: []const u8) !manifest_mod.Ma
     if (std.mem.endsWith(u8, path, ".json")) {
         return manifest_mod.parseJson(allocator, body) catch return BundleError.BundlefileParse;
     }
-    return brewfile_mod.parse(allocator, body) catch return BundleError.BundlefileParse;
+    return brewfile_mod.parse(allocator, body, diag) catch return BundleError.BundlefileParse;
 }
 
 fn writeManifest(

--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -71,7 +71,7 @@ pub fn routePostInstallOutcome(
             if (output.isVerbose()) flog.printUnknown(name);
             if (output.isDebug()) flog.printFatal(name);
             ruby_sub.runPostInstall(allocator, name, version_str, prefix) catch |e| {
-                output.warn("post_install subprocess failed for {s}: {s}", .{ name, @errorName(e) });
+                output.warn("post_install subprocess failed for {s}: {s}", .{ name, ruby_sub.describeError(e) });
                 break :blk .ruby_fallback_failed;
             };
             // Symmetric with the native "completed" info so scripted users
@@ -200,7 +200,7 @@ pub fn drive(
     if (useSystemRubyForFormula(use_system_ruby_list, name)) {
         output.warn("Running post_install for {s} via system Ruby...", .{name});
         ruby_sub.runPostInstall(allocator, name, version_str, prefix) catch |e| {
-            output.warn("post_install failed for {s}: {s}", .{ name, @errorName(e) });
+            output.warn("post_install failed for {s}: {s}", .{ name, ruby_sub.describeError(e) });
         };
     } else {
         output.warn("{s}: post_install skipped (use --use-system-ruby={s} or brew install {s})", .{ name, name, name });

--- a/src/core/bundle/brewfile.zig
+++ b/src/core/bundle/brewfile.zig
@@ -11,7 +11,6 @@
 
 const std = @import("std");
 const manifest_mod = @import("manifest.zig");
-const output = @import("../../ui/output.zig");
 
 pub const BrewfileError = error{
     UnexpectedToken,
@@ -44,7 +43,29 @@ const Line = struct {
     num: usize,
 };
 
-pub fn parse(parent: std.mem.Allocator, brewfile_text: []const u8) BrewfileError!manifest_mod.Manifest {
+/// Caller-owned out-bag for non-fatal parser warnings (currently: unknown
+/// directives we skip). Core returns outcomes; UI renders at the
+/// boundary — `cli/bundle.zig` drains this into `output.warn`.
+pub const Diagnostics = struct {
+    allocator: std.mem.Allocator,
+    warnings: std.ArrayList([]const u8),
+
+    pub fn init(allocator: std.mem.Allocator) Diagnostics {
+        return .{ .allocator = allocator, .warnings = .empty };
+    }
+
+    pub fn deinit(self: *Diagnostics) void {
+        for (self.warnings.items) |w| self.allocator.free(w);
+        self.warnings.deinit(self.allocator);
+        self.* = undefined;
+    }
+};
+
+pub fn parse(
+    parent: std.mem.Allocator,
+    brewfile_text: []const u8,
+    diag: ?*Diagnostics,
+) BrewfileError!manifest_mod.Manifest {
     var m = manifest_mod.Manifest.init(parent);
     errdefer m.deinit();
     const a = m.allocator();
@@ -69,7 +90,7 @@ pub fn parse(parent: std.mem.Allocator, brewfile_text: []const u8) BrewfileError
             return BrewfileError.BlocksUnsupported;
         }
 
-        try parseLine(a, trimmed, line_no, &taps, &formulas, &casks, &services);
+        try parseLine(a, trimmed, line_no, &taps, &formulas, &casks, &services, diag);
     }
 
     m.taps = taps.toOwnedSlice(a) catch return BrewfileError.OutOfMemory;
@@ -88,6 +109,7 @@ fn parseLine(
     formulas: *std.ArrayList(manifest_mod.FormulaEntry),
     casks: *std.ArrayList(manifest_mod.CaskEntry),
     services: *std.ArrayList(manifest_mod.ServiceEntry),
+    diag: ?*Diagnostics,
 ) BrewfileError!void {
     _ = line_no;
 
@@ -147,8 +169,14 @@ fn parseLine(
         // Recognised but not yet installable by malt — record as formulas w/ a
         // synthetic prefix so users see them round-tripped.
         formulas.append(a, .{ .name = first }) catch return BrewfileError.OutOfMemory;
-    } else {
-        output.warn("skipping unknown Brewfile directive: {s}", .{directive});
+    } else if (diag) |d| {
+        const msg = std.fmt.allocPrint(
+            d.allocator,
+            "skipping unknown Brewfile directive: {s}",
+            .{directive},
+        ) catch return BrewfileError.OutOfMemory;
+        errdefer d.allocator.free(msg);
+        d.warnings.append(d.allocator, msg) catch return BrewfileError.OutOfMemory;
     }
 }
 

--- a/src/core/bundle/runner.zig
+++ b/src/core/bundle/runner.zig
@@ -8,6 +8,9 @@
 //! depends on no `cli/*` module, so bundle tests link without dragging in
 //! the whole CLI surface.
 //!
+//! core returns outcomes; UI renders at the boundary — `run()` produces a
+//! `Report` that the caller (`cli/bundle.zig`) renders via `ui/output.*`.
+//!
 //! Each underlying primitive (install, tap, services start) is already
 //! idempotent, so running a bundle twice is a no-op for already-installed
 //! members.
@@ -19,11 +22,9 @@ const sqlite = @import("../../db/sqlite.zig");
 const schema = @import("../../db/schema.zig");
 const lock_mod = @import("../../db/lock.zig");
 const atomic = @import("../../fs/atomic.zig");
-const output = @import("../../ui/output.zig");
 const manifest_mod = @import("manifest.zig");
 
 pub const RunnerError = error{
-    MemberFailed,
     DatabaseError,
     LockFailed,
     IoFailed,
@@ -36,7 +37,6 @@ pub const RunnerError = error{
 
 pub fn describeError(err: RunnerError) []const u8 {
     return switch (err) {
-        RunnerError.MemberFailed => "at least one bundle member failed to install",
         RunnerError.DatabaseError => "database error during bundle install",
         RunnerError.LockFailed => "could not acquire bundle lock",
         RunnerError.IoFailed => "filesystem error during bundle install",
@@ -44,6 +44,45 @@ pub fn describeError(err: RunnerError) []const u8 {
         RunnerError.NoDispatcher => "bundle runner called without a dispatcher and without malt_bin",
     };
 }
+
+pub const MemberKind = enum { tap, formula, cask, service_start };
+
+/// One member whose install call returned a non-null error. `name` is
+/// borrowed from the caller's `Manifest`; the caller must keep the
+/// manifest alive until `Report.deinit`.
+pub const MemberError = struct {
+    kind: MemberKind,
+    name: []const u8,
+    err: anyerror,
+};
+
+/// Entry in the dry-run preview list — what the CLI would render as
+/// "would run: malt …" without actually forking.
+pub const MemberPreview = struct {
+    kind: MemberKind,
+    name: []const u8,
+};
+
+/// Structured outcome of a `run()` call. The runner emits no UI; the
+/// CLI renders this report via `ui/output.*`.
+pub const Report = struct {
+    allocator: std.mem.Allocator,
+    failures: []MemberError,
+    previews: []MemberPreview,
+    /// When `recordBundle` failed (non-dry-run only), the `@errorName`
+    /// of the cause. Borrowed from `@errorName`, so no free needed.
+    db_record_error: ?[]const u8 = null,
+
+    pub fn hasFailure(self: Report) bool {
+        return self.failures.len > 0 or self.db_record_error != null;
+    }
+
+    pub fn deinit(self: *Report) void {
+        self.allocator.free(self.failures);
+        self.allocator.free(self.previews);
+        self.* = undefined;
+    }
+};
 
 /// Layering seam: the CLI wires up a concrete implementation that forwards
 /// to `cli/install`, `cli/tap`, `cli/services`. Keeping this as an injected
@@ -70,7 +109,7 @@ pub const Options = struct {
     prefix: ?[]const u8 = null,
     /// In-process dispatcher injected from the CLI layer. Null is legal
     /// for `dry_run` and subprocess (`malt_bin`) paths; otherwise the
-    /// runner returns `RunnerError.NoDispatcher`.
+    /// runner records `NoDispatcher` as each member's failure.
     dispatcher: ?*const Dispatcher = null,
 };
 
@@ -79,7 +118,7 @@ pub fn run(
     db: *sqlite.Database,
     manifest: manifest_mod.Manifest,
     opts: Options,
-) RunnerError!void {
+) RunnerError!Report {
     const bundle_name = if (manifest.name.len > 0) manifest.name else "unnamed";
 
     // Bundles directory + advisory lock for idempotency.
@@ -99,46 +138,51 @@ pub fn run(
         null;
     defer if (lock) |*l| l.release();
 
-    var any_failed = false;
+    var failures: std.ArrayList(MemberError) = .empty;
+    errdefer failures.deinit(allocator);
+    var previews: std.ArrayList(MemberPreview) = .empty;
+    errdefer previews.deinit(allocator);
 
     // 1. taps
     for (manifest.taps) |t| {
-        callMember(allocator, .{ .tap = t }, opts) catch {
-            output.err("tap failed: {s}", .{t});
-            any_failed = true;
-        };
+        try recordMember(allocator, .{ .tap = t }, opts, &failures, &previews);
     }
 
     // 2. formulas
     for (manifest.formulas) |f| {
-        callMember(allocator, .{ .formula = f.name }, opts) catch {
-            output.err("install failed: {s}", .{f.name});
-            any_failed = true;
-        };
+        try recordMember(allocator, .{ .formula = f.name }, opts, &failures, &previews);
     }
 
     // 3. casks
     for (manifest.casks) |c| {
-        callMember(allocator, .{ .cask = c.name }, opts) catch {
-            output.err("cask install failed: {s}", .{c.name});
-            any_failed = true;
-        };
+        try recordMember(allocator, .{ .cask = c.name }, opts, &failures, &previews);
     }
 
     // 4. services start (auto_start only). Best-effort.
     for (manifest.services) |s| {
         if (!s.auto_start) continue;
-        callMember(allocator, .{ .service_start = s.name }, opts) catch {
-            output.warn("could not auto-start service: {s}", .{s.name});
-        };
+        try recordMember(allocator, .{ .service_start = s.name }, opts, &failures, &previews);
     }
 
-    // 5. Record bundle and members in DB (even in dry-run skip).
+    var db_record_error: ?[]const u8 = null;
+    // 5. Record bundle and members in DB (even on partial failure). Skipped
+    //    in dry-run so the preview path stays read-only.
     if (!opts.dry_run) recordBundle(allocator, db, manifest) catch |e| {
-        output.err("could not record bundle in database: {s}", .{@errorName(e)});
+        db_record_error = @errorName(e);
     };
 
-    if (any_failed) return RunnerError.MemberFailed;
+    // Own each slice before composing the return so an OOM on the second
+    // toOwnedSlice cannot orphan the first.
+    const owned_failures = failures.toOwnedSlice(allocator) catch return RunnerError.OutOfMemory;
+    errdefer allocator.free(owned_failures);
+    const owned_previews = previews.toOwnedSlice(allocator) catch return RunnerError.OutOfMemory;
+
+    return .{
+        .allocator = allocator,
+        .failures = owned_failures,
+        .previews = owned_previews,
+        .db_record_error = db_record_error,
+    };
 }
 
 const MemberCall = union(enum) {
@@ -146,19 +190,49 @@ const MemberCall = union(enum) {
     formula: []const u8,
     cask: []const u8,
     service_start: []const u8,
+
+    fn kind(self: MemberCall) MemberKind {
+        return switch (self) {
+            .tap => .tap,
+            .formula => .formula,
+            .cask => .cask,
+            .service_start => .service_start,
+        };
+    }
+
+    fn name(self: MemberCall) []const u8 {
+        return switch (self) {
+            .tap => |n| n,
+            .formula => |n| n,
+            .cask => |n| n,
+            .service_start => |n| n,
+        };
+    }
 };
 
-fn callMember(allocator: std.mem.Allocator, call: MemberCall, opts: Options) !void {
+fn recordMember(
+    allocator: std.mem.Allocator,
+    call: MemberCall,
+    opts: Options,
+    failures: *std.ArrayList(MemberError),
+    previews: *std.ArrayList(MemberPreview),
+) RunnerError!void {
     if (opts.dry_run) {
-        switch (call) {
-            .tap => |n| output.info("would run: malt tap {s}", .{n}),
-            .formula => |n| output.info("would run: malt install {s}", .{n}),
-            .cask => |n| output.info("would run: malt install --cask {s}", .{n}),
-            .service_start => |n| output.info("would run: malt services start {s}", .{n}),
-        }
+        previews.append(allocator, .{ .kind = call.kind(), .name = call.name() }) catch
+            return RunnerError.OutOfMemory;
         return;
     }
 
+    callMember(allocator, call, opts) catch |e| {
+        failures.append(allocator, .{
+            .kind = call.kind(),
+            .name = call.name(),
+            .err = e,
+        }) catch return RunnerError.OutOfMemory;
+    };
+}
+
+fn callMember(allocator: std.mem.Allocator, call: MemberCall, opts: Options) !void {
     // Test escape hatch: when malt_bin is set, fall back to subprocess so
     // tests can substitute /usr/bin/false to assert exit-code propagation.
     if (opts.malt_bin) |bin| return runSubprocess(allocator, bin, call);

--- a/src/core/dsl/builtins/ui.zig
+++ b/src/core/dsl/builtins/ui.zig
@@ -1,8 +1,9 @@
 //! malt — DSL builtin: UI operations
-//! Maps ohai/opoo/odie to src/ui/output.zig
+//! Maps ohai/opoo/odie to src/ui/output.zig — the sole UI channel the
+//! DSL is allowed. Direct stderr writes were removed per the "core
+//! returns outcomes" layering (R3).
 
 const std = @import("std");
-const fs_compat = @import("../../../fs/compat.zig");
 const output = @import("../../../ui/output.zig");
 const values = @import("../values.zig");
 const pathname = @import("pathname.zig");
@@ -15,12 +16,7 @@ const ExecCtx = pathname.ExecCtx;
 pub fn ohai(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     if (args.len == 0) return Value{ .nil = {} };
     const msg = args[0].asString(ctx.allocator) catch return Value{ .nil = {} };
-    var buf: [4096]u8 = undefined;
-    const formatted = std.fmt.bufPrint(&buf, "{s}", .{msg}) catch return Value{ .nil = {} };
-    const f = fs_compat.stderrFile();
-    f.writeAll("  > ") catch {};
-    f.writeAll(formatted) catch {};
-    f.writeAll("\n") catch {};
+    output.info("{s}", .{msg});
     return Value{ .nil = {} };
 }
 
@@ -28,12 +24,7 @@ pub fn ohai(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
 pub fn opoo(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     if (args.len == 0) return Value{ .nil = {} };
     const msg = args[0].asString(ctx.allocator) catch return Value{ .nil = {} };
-    var buf: [4096]u8 = undefined;
-    const formatted = std.fmt.bufPrint(&buf, "{s}", .{msg}) catch return Value{ .nil = {} };
-    const f = fs_compat.stderrFile();
-    f.writeAll("  ! ") catch {};
-    f.writeAll(formatted) catch {};
-    f.writeAll("\n") catch {};
+    output.warn("{s}", .{msg});
     return Value{ .nil = {} };
 }
 
@@ -41,11 +32,6 @@ pub fn opoo(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
 pub fn odie(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     if (args.len == 0) return BuiltinError.PostInstallFailed;
     const msg = args[0].asString(ctx.allocator) catch return BuiltinError.PostInstallFailed;
-    var buf: [4096]u8 = undefined;
-    const formatted = std.fmt.bufPrint(&buf, "{s}", .{msg}) catch return BuiltinError.PostInstallFailed;
-    const f = fs_compat.stderrFile();
-    f.writeAll("  x ") catch {};
-    f.writeAll(formatted) catch {};
-    f.writeAll("\n") catch {};
+    output.err("{s}", .{msg});
     return BuiltinError.PostInstallFailed;
 }

--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -6,7 +6,6 @@
 const std = @import("std");
 const fs_compat = @import("../fs/compat.zig");
 const builtin = @import("builtin");
-const output = @import("../ui/output.zig");
 const codesign = @import("../macho/codesign.zig");
 const pins = @import("pins.zig");
 const http_client = @import("../net/client.zig");
@@ -26,6 +25,21 @@ pub const RubyError = error{
     OutOfMemory,
     InvalidInput,
 };
+
+/// Human-readable hint for each RubyError variant. CLI renders these so
+/// core/* itself emits no UI.
+pub fn describeError(err: RubyError) []const u8 {
+    return switch (err) {
+        RubyError.RubyNotFound => "no Ruby interpreter found (tried /opt/homebrew, /usr/local, rbenv, asdf, PATH)",
+        RubyError.TapNotFound => "homebrew-core tap not found; run `brew tap --force homebrew/core`",
+        RubyError.FormulaSourceNotFound => "formula .rb source not found in the homebrew-core tap",
+        RubyError.PostInstallBodyNotFound => "could not extract post_install body from formula source",
+        RubyError.ScriptWriteFailed => "could not write the temporary Ruby wrapper script",
+        RubyError.PostInstallFailed => "post_install script failed to run or exited non-zero",
+        RubyError.OutOfMemory => "out of memory running post_install",
+        RubyError.InvalidInput => "invalid formula name, version, or prefix",
+    };
+}
 
 /// Upper bound on a fetched formula .rb blob. The Homebrew-wide 99th
 /// percentile is ~40 KiB; 1 MiB is orders of magnitude of headroom
@@ -133,16 +147,9 @@ pub fn fetchPostInstallFromGitHub(allocator: std.mem.Allocator, name: []const u8
     // ([a-z0-9@._+-]) — the URL path substitutes the name directly.
     api_mod.validateName(name) catch return null;
 
-    const expected_hash = pins.expectedSha256(name) orelse {
-        // Fail-closed: no manifest entry, no fetch. Logged so users
-        // hitting this path know *why* rather than guessing that the
-        // network is down.
-        output.warn(
-            "post_install fetch refused for {s}: no entry in pins_manifest.txt (run scripts/gen-pins.sh)",
-            .{name},
-        );
-        return null;
-    };
+    // Fail-closed: no manifest entry, no fetch. The caller decides whether
+    // to warn — core stays headless.
+    const expected_hash = pins.expectedSha256(name) orelse return null;
 
     var url_buf: [512]u8 = undefined;
     const url = std.fmt.bufPrint(
@@ -161,13 +168,7 @@ pub fn fetchPostInstallFromGitHub(allocator: std.mem.Allocator, name: []const u8
 
     var actual_hex: [pins.SHA256_HEX_LEN]u8 = undefined;
     pins.sha256Hex(resp.body, &actual_hex);
-    if (!std.mem.eql(u8, actual_hex[0..], expected_hash)) {
-        output.err(
-            "post_install fetch refused for {s}: SHA256 mismatch at pinned commit (expected {s}, got {s})",
-            .{ name, expected_hash, actual_hex[0..] },
-        );
-        return null;
-    }
+    if (!std.mem.eql(u8, actual_hex[0..], expected_hash)) return null;
 
     return extractPostInstallFromSource(allocator, resp.body);
 }
@@ -475,38 +476,24 @@ pub fn runPostInstall(
     for (name) |b| if (!fs_atomic.isAllowedNameByte(b)) return RubyError.InvalidInput;
     for (version) |b| if (!fs_atomic.isAllowedNameByte(b)) return RubyError.InvalidInput;
 
+    // Core returns outcomes; UI renders at the boundary — the CLI caller
+    // maps each RubyError variant to user-facing text.
+
     // 1. Find Ruby (caller-owned heap slice — see detectRuby contract).
-    const ruby_path = detectRuby(allocator) orelse {
-        output.err("No Ruby interpreter found. Tried:", .{});
-        output.err("  /opt/homebrew/opt/ruby/bin/ruby", .{});
-        output.err("  /usr/local/opt/ruby/bin/ruby", .{});
-        output.err("  ~/.rbenv/shims/ruby, ~/.asdf/shims/ruby", .{});
-        output.err("  /usr/bin/ruby", .{});
-        output.err("  PATH search", .{});
-        return RubyError.RubyNotFound;
-    };
+    const ruby_path = detectRuby(allocator) orelse return RubyError.RubyNotFound;
     defer allocator.free(ruby_path);
 
     // 2. Find homebrew-core tap
-    const tap_path = findHomebrewCoreTap() orelse {
-        output.err("homebrew-core tap not found. Required for --use-system-ruby.", .{});
-        output.err("Run: brew tap --force homebrew/core", .{});
-        return RubyError.TapNotFound;
-    };
+    const tap_path = findHomebrewCoreTap() orelse return RubyError.TapNotFound;
 
     // 3. Resolve .rb source file
     var rb_buf: [1024]u8 = undefined;
-    const rb_path = resolveFormulaRbPath(&rb_buf, tap_path, name) orelse {
-        output.err("Formula source not found: {s}", .{name});
-        output.err("Expected at: {s}/Formula/{c}/{s}.rb", .{ tap_path, name[0], name });
+    const rb_path = resolveFormulaRbPath(&rb_buf, tap_path, name) orelse
         return RubyError.FormulaSourceNotFound;
-    };
 
     // 4. Extract post_install body
-    const body = extractPostInstallBody(allocator, rb_path) orelse {
-        output.err("Could not extract post_install body from {s}", .{rb_path});
+    const body = extractPostInstallBody(allocator, rb_path) orelse
         return RubyError.PostInstallBodyNotFound;
-    };
     defer allocator.free(body);
 
     // 5. Generate wrapper script
@@ -572,12 +559,6 @@ pub fn runPostInstall(
         prefix,
         env,
         .{},
-    ) catch |e| {
-        output.err("post_install sandbox spawn failed: {s}", .{@errorName(e)});
-        return RubyError.PostInstallFailed;
-    };
-    if (exit_code != 0) {
-        output.err("post_install script exited with code {d}", .{exit_code});
-        return RubyError.PostInstallFailed;
-    }
+    ) catch return RubyError.PostInstallFailed;
+    if (exit_code != 0) return RubyError.PostInstallFailed;
 }

--- a/src/core/services/supervisor.zig
+++ b/src/core/services/supervisor.zig
@@ -28,12 +28,10 @@
 
 const std = @import("std");
 const fs_compat = @import("../../fs/compat.zig");
-const io_mod = @import("../../ui/io.zig");
 const builtin = @import("builtin");
 const sqlite = @import("../../db/sqlite.zig");
 const plist_mod = @import("plist.zig");
 const atomic = @import("../../fs/atomic.zig");
-const output = @import("../../ui/output.zig");
 
 pub const SupervisorError = error{
     OsNotSupported,

--- a/tests/bundle_brewfile_test.zig
+++ b/tests/bundle_brewfile_test.zig
@@ -8,7 +8,7 @@ const brewfile_emit = malt.bundle_brewfile_emit;
 
 test "parse minimal Brewfile" {
     const txt = "brew \"wget\"\n";
-    var m = try brewfile.parse(testing.allocator, txt);
+    var m = try brewfile.parse(testing.allocator, txt, null);
     defer m.deinit();
 
     try testing.expectEqual(@as(usize, 1), m.formulas.len);
@@ -23,7 +23,7 @@ test "parse with hash options" {
         \\cask "ghostty"
         \\brew "postgresql@16", restart_service: true
     ;
-    var m = try brewfile.parse(testing.allocator, txt);
+    var m = try brewfile.parse(testing.allocator, txt, null);
     defer m.deinit();
 
     try testing.expectEqual(@as(usize, 1), m.taps.len);
@@ -44,7 +44,7 @@ test "parse with comments and blank lines" {
         \\# another comment
         \\cask "ghostty"
     ;
-    var m = try brewfile.parse(testing.allocator, txt);
+    var m = try brewfile.parse(testing.allocator, txt, null);
     defer m.deinit();
 
     try testing.expectEqual(@as(usize, 1), m.formulas.len);
@@ -53,7 +53,7 @@ test "parse with comments and blank lines" {
 
 test "unknown directive warns but does not fail" {
     const txt = "brew \"wget\"\nwhalebrew \"foo/bar\"\nbrew \"jq\"\n";
-    var m = try brewfile.parse(testing.allocator, txt);
+    var m = try brewfile.parse(testing.allocator, txt, null);
     defer m.deinit();
 
     try testing.expectEqual(@as(usize, 2), m.formulas.len);
@@ -61,11 +61,25 @@ test "unknown directive warns but does not fail" {
     try testing.expectEqualStrings("jq", m.formulas[1].name);
 }
 
+test "unknown directive records a warning in diagnostics" {
+    // Core routes the skipped directive through the caller's diagnostics
+    // rather than the UI layer, so the parser stays headless.
+    const txt = "brew \"wget\"\nwhalebrew \"foo/bar\"\n";
+    var diag = brewfile.Diagnostics.init(testing.allocator);
+    defer diag.deinit();
+
+    var m = try brewfile.parse(testing.allocator, txt, &diag);
+    defer m.deinit();
+
+    try testing.expectEqual(@as(usize, 1), diag.warnings.items.len);
+    try testing.expect(std.mem.indexOf(u8, diag.warnings.items[0], "whalebrew") != null);
+}
+
 test "conditionals rejected" {
     const txt = "brew \"wget\" if OS.mac?\n";
     try testing.expectError(
         brewfile.BrewfileError.ConditionalsUnsupported,
-        brewfile.parse(testing.allocator, txt),
+        brewfile.parse(testing.allocator, txt, null),
     );
 }
 
@@ -73,7 +87,7 @@ test "blocks rejected" {
     const txt = "brew \"wget\" do\n  link\nend\n";
     try testing.expectError(
         brewfile.BrewfileError.BlocksUnsupported,
-        brewfile.parse(testing.allocator, txt),
+        brewfile.parse(testing.allocator, txt, null),
     );
 }
 
@@ -84,14 +98,14 @@ test "round trip emit then parse" {
         \\brew "jq", version: "1.7"
         \\cask "ghostty"
     ;
-    var m1 = try brewfile.parse(testing.allocator, original);
+    var m1 = try brewfile.parse(testing.allocator, original, null);
     defer m1.deinit();
 
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
     try brewfile_emit.emit(m1, &aw.writer);
 
-    var m2 = try brewfile.parse(testing.allocator, aw.written());
+    var m2 = try brewfile.parse(testing.allocator, aw.written(), null);
     defer m2.deinit();
 
     try testing.expectEqual(m1.taps.len, m2.taps.len);

--- a/tests/bundle_test.zig
+++ b/tests/bundle_test.zig
@@ -62,7 +62,8 @@ test "dry-run runner does not fork and skips DB write" {
     var m = try buildManifest(testing.allocator);
     defer m.deinit();
 
-    try runner.run(testing.allocator, &t.db, m, .{ .dry_run = true, .prefix = t.dir });
+    var report = try runner.run(testing.allocator, &t.db, m, .{ .dry_run = true, .prefix = t.dir });
+    defer report.deinit();
 
     var stmt = try t.db.prepare("SELECT COUNT(*) FROM bundles;");
     defer stmt.finalize();
@@ -78,14 +79,16 @@ test "non-dry runner with mocked malt_bin records bundle even on member failure"
     defer m.deinit();
 
     // Use /usr/bin/false: spawns succeed but each call exits non-zero.
-    // The runner should still record the bundle row before returning the
-    // aggregate MemberFailed error.
-    const result = runner.run(testing.allocator, &t.db, m, .{
+    // The runner should still record the bundle row despite every member
+    // landing in the failures list.
+    var report = try runner.run(testing.allocator, &t.db, m, .{
         .dry_run = false,
         .malt_bin = "/usr/bin/false",
         .prefix = t.dir,
     });
-    try testing.expectError(runner.RunnerError.MemberFailed, result);
+    defer report.deinit();
+    try testing.expect(report.hasFailure());
+    try testing.expectEqual(@as(usize, 4), report.failures.len);
 
     var stmt = try t.db.prepare("SELECT COUNT(*) FROM bundles WHERE name='devtools';");
     defer stmt.finalize();
@@ -119,11 +122,13 @@ test "runner routes members through the provided dispatcher" {
     var m = try buildManifest(testing.allocator);
     defer m.deinit();
 
-    try runner.run(testing.allocator, &t.db, m, .{
+    var report = try runner.run(testing.allocator, &t.db, m, .{
         .dry_run = false,
         .prefix = t.dir,
         .dispatcher = &dispatcher,
     });
+    defer report.deinit();
+    try testing.expect(!report.hasFailure());
 
     try testing.expectEqual(@as(usize, 1), calls.taps.items.len);
     try testing.expectEqualStrings("homebrew/cask-fonts", calls.taps.items[0]);
@@ -187,6 +192,57 @@ const Calls = struct {
     }
 };
 
+test "runner returns Report with per-member failures, not a bool" {
+    // Pins the contract: the runner collects structured failures so the
+    // CLI layer can render; core/* itself emits no UI.
+    var t = try TempDb.init("report_failures");
+    defer t.deinit();
+
+    var m = try buildManifest(testing.allocator);
+    defer m.deinit();
+
+    var report = try runner.run(testing.allocator, &t.db, m, .{
+        .dry_run = false,
+        .malt_bin = "/usr/bin/false",
+        .prefix = t.dir,
+    });
+    defer report.deinit();
+
+    try testing.expect(report.hasFailure());
+    // 1 tap + 2 formulas + 1 cask all exit non-zero under /usr/bin/false.
+    try testing.expectEqual(@as(usize, 4), report.failures.len);
+    try testing.expectEqual(runner.MemberKind.tap, report.failures[0].kind);
+    try testing.expectEqualStrings("homebrew/cask-fonts", report.failures[0].name);
+    try testing.expectEqual(runner.MemberKind.formula, report.failures[1].kind);
+    try testing.expectEqualStrings("wget", report.failures[1].name);
+    try testing.expectEqual(runner.MemberKind.formula, report.failures[2].kind);
+    try testing.expectEqualStrings("jq", report.failures[2].name);
+    try testing.expectEqual(runner.MemberKind.cask, report.failures[3].kind);
+    try testing.expectEqualStrings("ghostty", report.failures[3].name);
+    try testing.expectEqual(@as(usize, 0), report.previews.len);
+}
+
+test "dry-run report captures previews, no failures, no DB write" {
+    var t = try TempDb.init("report_previews");
+    defer t.deinit();
+
+    var m = try buildManifest(testing.allocator);
+    defer m.deinit();
+
+    var report = try runner.run(testing.allocator, &t.db, m, .{
+        .dry_run = true,
+        .prefix = t.dir,
+    });
+    defer report.deinit();
+
+    try testing.expect(!report.hasFailure());
+    try testing.expectEqual(@as(usize, 0), report.failures.len);
+    // 1 tap + 2 formulas + 1 cask = 4 previews.
+    try testing.expectEqual(@as(usize, 4), report.previews.len);
+    try testing.expectEqual(runner.MemberKind.tap, report.previews[0].kind);
+    try testing.expectEqualStrings("homebrew/cask-fonts", report.previews[0].name);
+}
+
 test "runner refuses in-process bundle install with no dispatcher and no malt_bin" {
     var t = try TempDb.init("no_dispatcher");
     defer t.deinit();
@@ -194,14 +250,16 @@ test "runner refuses in-process bundle install with no dispatcher and no malt_bi
     var m = try buildManifest(testing.allocator);
     defer m.deinit();
 
-    const result = runner.run(testing.allocator, &t.db, m, .{
+    var report = try runner.run(testing.allocator, &t.db, m, .{
         .dry_run = false,
         .prefix = t.dir,
     });
-    try testing.expectError(runner.RunnerError.MemberFailed, result);
+    defer report.deinit();
+    try testing.expect(report.hasFailure());
+    try testing.expectEqual(@as(usize, 4), report.failures.len);
+    // Each member's err is RunnerError.NoDispatcher on this path.
+    for (report.failures) |f| try testing.expectEqual(anyerror.NoDispatcher, f.err);
 
-    // The bundle row must NOT exist when the very first member bombed out
-    // with NoDispatcher — we only record after attempting all members.
     var stmt = try t.db.prepare("SELECT COUNT(*) FROM bundles WHERE name='devtools';");
     defer stmt.finalize();
     _ = try stmt.step();
@@ -222,10 +280,11 @@ test "round-trip: parse Brewfile fixture, run dry, no panic" {
         \\# real-world dotfiles often have these:
         \\whalebrew "foo/bar"
     ;
-    var m = try malt.bundle_brewfile.parse(testing.allocator, fixture);
+    var m = try malt.bundle_brewfile.parse(testing.allocator, fixture, null);
     defer m.deinit();
 
-    try runner.run(testing.allocator, &t.db, m, .{ .dry_run = true, .prefix = t.dir });
+    var report = try runner.run(testing.allocator, &t.db, m, .{ .dry_run = true, .prefix = t.dir });
+    defer report.deinit();
 }
 
 test "real-world Brewfile shapes parse without error" {
@@ -269,12 +328,13 @@ test "real-world Brewfile shapes parse without error" {
     var t = try TempDb.init("realworld");
     defer t.deinit();
 
-    var m = try malt.bundle_brewfile.parse(testing.allocator, fixture);
+    var m = try malt.bundle_brewfile.parse(testing.allocator, fixture, null);
     defer m.deinit();
 
     try testing.expect(m.taps.len >= 3);
     try testing.expect(m.formulas.len >= 8);
     try testing.expect(m.casks.len >= 3);
 
-    try runner.run(testing.allocator, &t.db, m, .{ .dry_run = true, .prefix = t.dir });
+    var report = try runner.run(testing.allocator, &t.db, m, .{ .dry_run = true, .prefix = t.dir });
+    defer report.deinit();
 }

--- a/tests/ruby_subprocess_test.zig
+++ b/tests/ruby_subprocess_test.zig
@@ -458,6 +458,16 @@ test "runPostInstall rejects hostile prefix with InvalidInput" {
     try testing.expectError(error.InvalidInput, err);
 }
 
+test "describeError covers every RubyError variant with a user hint" {
+    // Core returns outcomes; UI renders at the boundary — this helper is
+    // the single source of truth for the user-facing text per variant.
+    inline for (comptime @typeInfo(ruby.RubyError).error_set.?) |v| {
+        const err = @field(ruby.RubyError, v.name);
+        const msg = ruby.describeError(err);
+        try testing.expect(msg.len > 0);
+    }
+}
+
 test "detectRuby returns a heap-owned slice that the caller can free" {
     // On any machine that has Ruby available, the contract requires the
     // returned slice to be allocator-owned so the call site can pair it


### PR DESCRIPTION
## Description

Stop emitting UI from `core/*`. `core/bundle/runner.zig`, `core/bundle/brewfile.zig`, `core/ruby_subprocess.zig`, and `core/services/supervisor.zig` now return structured outcomes (or no longer import UI at all). The CLI layer renders. `core/dsl/builtins/ui.zig` keeps its DSL-facing `ohai`/`opoo`/`odie` but routes them exclusively through `ui/output.*`, dropping the duplicate direct-stderr path.

## Related Issue

- None

## Notes for Reviewers

- None