### PR TITLE
fix(cli/bundle): honor global --dry-run in bundle install

### DIFF
--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -89,14 +89,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 }
 
 fn cmdInstall(allocator: std.mem.Allocator, rest: []const []const u8) !void {
-    var dry_run = false;
+    // main.zig strips the global `--dry-run` from argv; reading the
+    // module-global here keeps bundle install aligned with every other
+    // subcommand (install, upgrade, purge, …) and with its envelope.
+    const dry_run = output.isDryRun();
     var explicit_path: ?[]const u8 = null;
-    var i: usize = 0;
-    while (i < rest.len) : (i += 1) {
-        const a = rest[i];
-        if (std.mem.eql(u8, a, "--dry-run")) {
-            dry_run = true;
-        } else if (std.mem.startsWith(u8, a, "-")) {
+    for (rest) |a| {
+        if (std.mem.startsWith(u8, a, "-")) {
             output.warn("ignored flag: {s}", .{a});
         } else {
             explicit_path = a;

--- a/tests/bundle_test.zig
+++ b/tests/bundle_test.zig
@@ -287,6 +287,50 @@ test "round-trip: parse Brewfile fixture, run dry, no panic" {
     defer report.deinit();
 }
 
+test "bundle install honors the global --dry-run flag set by main.zig" {
+    // Repro for T-034a: main.zig consumes `--dry-run` before it reaches
+    // `cmdInstall`, so the local arm never fires and the runner ran with
+    // `dry_run = false`. Pin the contract: when `output.isDryRun()` is true,
+    // the runner must skip `recordBundle`, leaving the `bundles` table empty.
+    const dir_z: [:0]const u8 = "/tmp/malt_bundle_dry_run_cli_wire";
+    malt.fs_compat.deleteTreeAbsolute(dir_z) catch {};
+    try malt.fs_compat.cwd().makePath(dir_z);
+    defer malt.fs_compat.deleteTreeAbsolute(dir_z) catch {};
+
+    _ = c.setenv("MALT_PREFIX", dir_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Empty-but-valid Brewfile: parser yields an empty manifest, so the
+    // dispatcher is never called and the only observable side-effect is
+    // the `recordBundle` insert — which dry-run must suppress.
+    const bf_path = try std.fmt.allocPrint(testing.allocator, "{s}/Brewfile", .{dir_z});
+    defer testing.allocator.free(bf_path);
+    {
+        const f = try malt.fs_compat.cwd().createFile(bf_path, .{});
+        defer f.close();
+        try f.writeAll("# empty\n");
+    }
+
+    malt.output.setDryRun(true);
+    defer malt.output.setDryRun(false);
+
+    try malt.cli_bundle.execute(testing.allocator, &.{ "install", bf_path });
+
+    const db_path = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.db", .{dir_z});
+    defer testing.allocator.free(db_path);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    var stmt = try db.prepare("SELECT COUNT(*) FROM bundles;");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    try testing.expectEqual(@as(i64, 0), stmt.columnInt(0));
+}
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
 test "real-world Brewfile shapes parse without error" {
     // Regression canary: shapes pulled from popular public dotfiles repos.
     // We assert parse + dry-run succeed; we do not assert specific counts so


### PR DESCRIPTION
## Description

`mt bundle install --dry-run` was silently invoking the real dispatcher and writing a `bundles` row to the DB. `main.zig` consumes the global `--dry-run` before it reaches `cmdInstall`, so the local arm never fired and the runner ran non-dry. Reading `output.isDryRun()` instead (the single source every other subcommand already uses) makes the dry-run envelope actually dry: the dispatcher stays quiet, and the DB is untouched.

## Related Issue

- Follow-up to #158

## Notes for Reviewers

- None