### PR TITLE
refactor: parameter-object multi-arg entrypoints

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -37,6 +37,7 @@ pub const DownloadJob = download_mod.DownloadJob;
 pub const MAX_COLLECT_FETCH_WORKERS = download_mod.MAX_COLLECT_FETCH_WORKERS;
 pub const collectFetchWorkerCount = download_mod.collectFetchWorkerCount;
 pub const collectFormulaJobs = download_mod.collectFormulaJobs;
+pub const InstallJobDeps = download_mod.InstallJobDeps;
 pub const findFailedDep = download_mod.findFailedDep;
 const progressBridge = download_mod.progressBridge;
 const downloadWorker = download_mod.downloadWorker;
@@ -342,7 +343,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             }
 
             // Collect jobs for this formula + its deps
-            collectFormulaJobs(allocator, pkg_name, formula_json, &api, &http_pool, &db, &store, force, &all_jobs) catch |e| {
+            collectFormulaJobs(.{
+                .allocator = allocator,
+                .api = &api,
+                .http_pool = &http_pool,
+                .db = &db,
+                .store = &store,
+            }, pkg_name, formula_json, force, &all_jobs) catch |e| {
                 output.err("Failed to resolve {s}: {s}", .{ pkg_name, @errorName(e) });
                 continue;
             };

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -743,7 +743,7 @@ fn maybeRegisterService(
         .keep_alive = def.keep_alive,
     };
 
-    supervisor_mod.register(allocator, db, spec, formula.name, false, cellar_path, prefix) catch |err| {
+    supervisor_mod.register(.{ .allocator = allocator, .db = db }, spec, formula.name, false, cellar_path, prefix) catch |err| {
         output.warn("could not register service for {s}: {s}", .{ formula.name, @errorName(err) });
     };
 }

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -22,6 +22,17 @@ const record = @import("record.zig");
 
 const InstallError = record.InstallError;
 
+/// Named-field bundle for `collectFormulaJobs` so callers stop threading
+/// six pointers through every call. Opens a DI seam for tests to swap in
+/// fakes by replacing fields.
+pub const InstallJobDeps = struct {
+    allocator: std.mem.Allocator,
+    api: *api_mod.BrewApi,
+    http_pool: *client_mod.HttpClientPool,
+    db: *sqlite.Database,
+    store: *store_mod.Store,
+};
+
 /// A bottle download job for parallel processing.
 ///
 /// Public so integration tests can construct an empty jobs list and assert
@@ -281,17 +292,16 @@ fn dupeJobStrings(
 /// (already-installed, post_install_defined) with a real SQLite DB and
 /// without a live Homebrew API connection.
 pub fn collectFormulaJobs(
-    allocator: std.mem.Allocator,
+    ctx: InstallJobDeps,
     pkg_name: []const u8,
     formula_json: []const u8,
-    api: *api_mod.BrewApi,
-    http_pool: *client_mod.HttpClientPool,
-    db: *sqlite.Database,
-    store: *store_mod.Store,
     force: bool,
     jobs: *std.ArrayList(DownloadJob),
 ) !void {
-    _ = store;
+    const allocator = ctx.allocator;
+    const api = ctx.api;
+    const http_pool = ctx.http_pool;
+    const db = ctx.db;
 
     // Single arena for every parsed formula — root + each dep — so the
     // std.json.Parsed trees and all the supplementary allocations made

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -72,6 +72,19 @@ const KegResult = enum {
     failed_install,
 };
 
+/// Named-field bundle for the shared state `migrateKeg` threads across
+/// every keg in the loop. Opens a DI seam for tests to swap in fakes.
+const MigrateDeps = struct {
+    api: *api_mod.BrewApi,
+    ghcr: *ghcr_mod.GhcrClient,
+    http: *client_mod.HttpClient,
+    store: *store_mod.Store,
+    linker: *linker_mod.Linker,
+    db: *sqlite.Database,
+    prefix: []const u8,
+    use_system_ruby_scope: []const []const u8,
+};
+
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "migrate")) return;
 
@@ -223,18 +236,16 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             output.warn("Interrupted — skipping remaining kegs.", .{});
             break;
         }
-        const result = migrateKeg(
-            allocator,
-            keg_name,
-            &api,
-            &ghcr,
-            &http,
-            &store,
-            &linker,
-            &db,
-            prefix,
-            use_system_ruby_scope.items,
-        );
+        const result = migrateKeg(allocator, keg_name, .{
+            .api = &api,
+            .ghcr = &ghcr,
+            .http = &http,
+            .store = &store,
+            .linker = &linker,
+            .db = &db,
+            .prefix = prefix,
+            .use_system_ruby_scope = use_system_ruby_scope.items,
+        });
 
         // OOM on per-category bookkeeping must not be swallowed: the summary
         // counts and JSON arrays come from these lists, and a silent drop
@@ -296,23 +307,16 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 fn migrateKeg(
     allocator: std.mem.Allocator,
     keg_name: []const u8,
-    api: *api_mod.BrewApi,
-    ghcr: *ghcr_mod.GhcrClient,
-    http: *client_mod.HttpClient,
-    store: *store_mod.Store,
-    linker: *linker_mod.Linker,
-    db: *sqlite.Database,
-    prefix: []const u8,
-    use_system_ruby_scope: []const []const u8,
+    deps: MigrateDeps,
 ) KegResult {
     // 1. Check if already installed in malt
-    if (isInstalled(db, keg_name)) {
+    if (isInstalled(deps.db, keg_name)) {
         output.info("  {s}: already installed, skipping", .{keg_name});
         return .skipped_installed;
     }
 
     // Two `defer`s below collapse six per-branch cleanups.
-    const formula_json = api.fetchFormula(keg_name) catch {
+    const formula_json = deps.api.fetchFormula(keg_name) catch {
         output.err("  {s}: not found in Homebrew API", .{keg_name});
         return .failed_api;
     };
@@ -333,8 +337,8 @@ fn migrateKeg(
     output.info("  Migrating {s} {s}...", .{ formula.name, formula.version });
 
     // 5. Download bottle via GHCR (skip if already in store)
-    if (!store.exists(bottle.sha256)) {
-        if (!downloadBottle(allocator, ghcr, http, store, bottle.url, bottle.sha256, keg_name)) {
+    if (!deps.store.exists(bottle.sha256)) {
+        if (!downloadBottle(allocator, deps.ghcr, deps.http, deps.store, bottle.url, bottle.sha256, keg_name)) {
             return .failed_download;
         }
     } else {
@@ -342,14 +346,14 @@ fn migrateKeg(
     }
 
     // Increment store refcount
-    store.incrementRef(bottle.sha256) catch |e| {
+    deps.store.incrementRef(bottle.sha256) catch |e| {
         std.log.warn("refcount increment failed for {s}: {s}", .{ keg_name, @errorName(e) });
     };
 
     // 6. Materialize to cellar
     const keg = cellar_mod.materialize(
         allocator,
-        prefix,
+        deps.prefix,
         bottle.sha256,
         formula.name,
         formula.pkg_version,
@@ -360,29 +364,29 @@ fn migrateKeg(
 
     // 7. Record in DB + link
     if (!formula.keg_only) {
-        const keg_id = recordKeg(db, &formula, bottle.sha256, keg.path, "direct") catch {
+        const keg_id = recordKeg(deps.db, &formula, bottle.sha256, keg.path, "direct") catch {
             output.err("    {s}: failed to record in database", .{keg_name});
-            cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
+            cellar_mod.remove(deps.prefix, formula.name, formula.pkg_version) catch {};
             return .failed_install;
         };
 
-        linker.link(keg.path, formula.name, keg_id) catch {
+        deps.linker.link(keg.path, formula.name, keg_id) catch {
             output.warn("    {s}: some links could not be created", .{keg_name});
             // Best-effort cleanup after a link failure; the user already sees the failure above.
-            linker.unlink(keg_id) catch {};
-            deleteKeg(db, keg_id) catch {};
-            cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
+            deps.linker.unlink(keg_id) catch {};
+            deleteKeg(deps.db, keg_id) catch {};
+            cellar_mod.remove(deps.prefix, formula.name, formula.pkg_version) catch {};
             return .failed_install;
         };
-        linker.linkOpt(formula.name, formula.pkg_version) catch {};
-        recordDeps(db, keg_id, &formula);
+        deps.linker.linkOpt(formula.name, formula.pkg_version) catch {};
+        recordDeps(deps.db, keg_id, &formula);
     } else {
-        const keg_id = recordKeg(db, &formula, bottle.sha256, keg.path, "direct") catch {
-            cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
+        const keg_id = recordKeg(deps.db, &formula, bottle.sha256, keg.path, "direct") catch {
+            cellar_mod.remove(deps.prefix, formula.name, formula.pkg_version) catch {};
             return .failed_install;
         };
-        linker.linkOpt(formula.name, formula.pkg_version) catch {};
-        recordDeps(db, keg_id, &formula);
+        deps.linker.linkOpt(formula.name, formula.pkg_version) catch {};
+        recordDeps(deps.db, keg_id, &formula);
     }
 
     if (formula.post_install_defined) {
@@ -391,8 +395,8 @@ fn migrateKeg(
             formula.name,
             formula.pkg_version,
             formula_json,
-            prefix,
-            use_system_ruby_scope,
+            deps.prefix,
+            deps.use_system_ruby_scope,
         );
     }
 

--- a/src/cli/services.zig
+++ b/src/cli/services.zig
@@ -71,16 +71,17 @@ fn cmdOne(allocator: std.mem.Allocator, db: *sqlite.Database, rest: []const []co
         return ServicesError.InvalidArgs;
     }
     const name = rest[0];
+    const ctx: supervisor.SupervisorCtx = .{ .allocator = allocator, .db = db };
     switch (op) {
-        .start => try supervisor.start(allocator, db, name),
-        .stop => try supervisor.stop(allocator, db, name),
-        .restart => try supervisor.restart(allocator, db, name),
+        .start => try supervisor.start(ctx, name),
+        .stop => try supervisor.stop(ctx, name),
+        .restart => try supervisor.restart(ctx, name),
     }
     output.success("services {s}: {s}", .{ @tagName(op), name });
 }
 
 fn cmdList(allocator: std.mem.Allocator, db: *sqlite.Database) !void {
-    const items = try supervisor.list(allocator, db);
+    const items = try supervisor.list(.{ .allocator = allocator, .db = db });
     defer supervisor.freeServiceInfos(allocator, items);
     if (items.len == 0) {
         output.info("no services registered", .{});

--- a/src/cli/uninstall.zig
+++ b/src/cli/uninstall.zig
@@ -113,7 +113,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     // Stop and unregister any associated launchd service before tearing down
     // files. The service name we register matches the formula name.
-    supervisor_mod.stopAndUnregister(allocator, &db, name);
+    supervisor_mod.stopAndUnregister(.{ .allocator = allocator, .db = &db }, name);
 
     // Unlink symlinks
     var lnk = linker.Linker.init(allocator, &db, prefix);

--- a/src/core/services/supervisor.zig
+++ b/src/core/services/supervisor.zig
@@ -58,6 +58,14 @@ pub fn describeError(err: SupervisorError) []const u8 {
     };
 }
 
+/// Named-field bundle for supervisor entrypoints that would otherwise
+/// thread `(allocator, db)` through every call. Opens a DI seam for
+/// tests to swap in fakes by replacing fields.
+pub const SupervisorCtx = struct {
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+};
+
 pub const ServiceInfo = struct {
     name: []const u8,
     keg_name: []const u8,
@@ -91,8 +99,9 @@ pub fn logPath(allocator: std.mem.Allocator, name: []const u8, stream: enum { st
 }
 
 /// List services from the `services` table.
-pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) SupervisorError![]ServiceInfo {
-    var stmt = db.prepare("SELECT name, keg_name, plist_path, auto_start, last_status FROM services ORDER BY name;") catch
+pub fn list(ctx: SupervisorCtx) SupervisorError![]ServiceInfo {
+    const allocator = ctx.allocator;
+    var stmt = ctx.db.prepare("SELECT name, keg_name, plist_path, auto_start, last_status FROM services ORDER BY name;") catch
         return SupervisorError.DatabaseError;
     defer stmt.finalize();
 
@@ -159,8 +168,7 @@ pub fn freeServiceInfos(allocator: std.mem.Allocator, services: []ServiceInfo) v
 /// before the plist lands on disk or launchctl sees it. See
 /// `plist_mod.validate`.
 pub fn register(
-    allocator: std.mem.Allocator,
-    db: *sqlite.Database,
+    ctx: SupervisorCtx,
     spec: plist_mod.ServiceSpec,
     keg_name: []const u8,
     auto_start: bool,
@@ -169,6 +177,7 @@ pub fn register(
 ) SupervisorError!void {
     if (builtin.os.tag != .macos) return SupervisorError.OsNotSupported;
 
+    const allocator = ctx.allocator;
     plist_mod.validate(spec, cellar_path, malt_prefix) catch return SupervisorError.InvalidService;
 
     const dir = try serviceDir(allocator, spec.label);
@@ -195,7 +204,7 @@ pub fn register(
     plist_mod.render(spec, &aw.writer) catch return SupervisorError.IoFailed;
     file.writeAll(aw.written()) catch return SupervisorError.IoFailed;
 
-    var stmt = db.prepare(
+    var stmt = ctx.db.prepare(
         \\INSERT OR REPLACE INTO services(name, keg_name, plist_path, auto_start, last_status)
         \\VALUES (?, ?, ?, ?, 'registered');
     ) catch return SupervisorError.DatabaseError;
@@ -236,36 +245,38 @@ fn lookupPlistPath(allocator: std.mem.Allocator, db: *sqlite.Database, name: []c
     return allocator.dupe(u8, std.mem.sliceTo(p, 0)) catch return SupervisorError.OutOfMemory;
 }
 
-pub fn start(allocator: std.mem.Allocator, db: *sqlite.Database, name: []const u8) SupervisorError!void {
+pub fn start(ctx: SupervisorCtx, name: []const u8) SupervisorError!void {
     if (builtin.os.tag != .macos) return SupervisorError.OsNotSupported;
-    const plist_path = try lookupPlistPath(allocator, db, name);
+    const allocator = ctx.allocator;
+    const plist_path = try lookupPlistPath(allocator, ctx.db, name);
     defer allocator.free(plist_path);
     const domain = userDomain(allocator) catch return SupervisorError.OutOfMemory;
     defer allocator.free(domain);
 
     try runLaunchctl(allocator, &.{ "launchctl", "bootstrap", domain, plist_path });
-    setStatus(db, name, "running") catch {};
+    setStatus(ctx.db, name, "running") catch {};
 }
 
-pub fn stop(allocator: std.mem.Allocator, db: *sqlite.Database, name: []const u8) SupervisorError!void {
+pub fn stop(ctx: SupervisorCtx, name: []const u8) SupervisorError!void {
     if (builtin.os.tag != .macos) return SupervisorError.OsNotSupported;
-    const plist_path = try lookupPlistPath(allocator, db, name);
+    const allocator = ctx.allocator;
+    const plist_path = try lookupPlistPath(allocator, ctx.db, name);
     defer allocator.free(plist_path);
     const domain = userDomain(allocator) catch return SupervisorError.OutOfMemory;
     defer allocator.free(domain);
 
     try runLaunchctl(allocator, &.{ "launchctl", "bootout", domain, plist_path });
-    setStatus(db, name, "stopped") catch {};
+    setStatus(ctx.db, name, "stopped") catch {};
 }
 
-pub fn restart(allocator: std.mem.Allocator, db: *sqlite.Database, name: []const u8) SupervisorError!void {
-    stop(allocator, db, name) catch {};
-    try start(allocator, db, name);
+pub fn restart(ctx: SupervisorCtx, name: []const u8) SupervisorError!void {
+    stop(ctx, name) catch {};
+    try start(ctx, name);
 }
 
-pub fn stopAndUnregister(allocator: std.mem.Allocator, db: *sqlite.Database, name: []const u8) void {
-    stop(allocator, db, name) catch {};
-    var stmt = db.prepare("DELETE FROM services WHERE name = ?;") catch return;
+pub fn stopAndUnregister(ctx: SupervisorCtx, name: []const u8) void {
+    stop(ctx, name) catch {};
+    var stmt = ctx.db.prepare("DELETE FROM services WHERE name = ?;") catch return;
     defer stmt.finalize();
     stmt.bindText(1, name) catch return;
     _ = stmt.step() catch {};

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -98,13 +98,9 @@ test "collectFormulaJobs queues a formula with a post_install hook" {
     defer jobs.deinit(alloc);
 
     try install.collectFormulaJobs(
-        alloc,
+        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst },
         "needs-ruby",
         json,
-        &api,
-        &http,
-        &tdb.db,
-        &store_inst,
         false,
         &jobs,
     );
@@ -335,13 +331,9 @@ test "collectFormulaJobs queues the main formula when nothing is installed" {
     defer jobs.deinit(alloc);
 
     try install.collectFormulaJobs(
-        alloc,
+        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst },
         "hello",
         json,
-        &api,
-        &http,
-        &tdb.db,
-        &store_inst,
         false,
         &jobs,
     );
@@ -377,13 +369,9 @@ test "collectFormulaJobs no-ops when the formula is already installed" {
     defer jobs.deinit(alloc);
 
     try install.collectFormulaJobs(
-        alloc,
+        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst },
         "hello",
         json,
-        &api,
-        &http,
-        &tdb.db,
-        &store_inst,
         false, // force=false
         &jobs,
     );
@@ -464,13 +452,9 @@ test "collectFormulaJobs queues a dep and its parent from a seeded cache" {
     defer jobs.deinit(alloc);
 
     try install.collectFormulaJobs(
-        alloc,
+        .{ .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst },
         "alpha",
         root_json,
-        &api,
-        &http_pool,
-        &tdb.db,
-        &store_inst,
         false,
         &jobs,
     );
@@ -514,8 +498,9 @@ test "collectFormulaJobs deduplicates deps already queued by a prior call" {
     var jobs: std.ArrayList(install.DownloadJob) = .empty;
     defer jobs.deinit(alloc);
 
-    try install.collectFormulaJobs(alloc, "alpha", root_a, &api, &http_pool, &tdb.db, &store_inst, false, &jobs);
-    try install.collectFormulaJobs(alloc, "omega", root_b, &api, &http_pool, &tdb.db, &store_inst, false, &jobs);
+    const deps_ctx: install.InstallJobDeps = .{ .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst };
+    try install.collectFormulaJobs(deps_ctx, "alpha", root_a, false, &jobs);
+    try install.collectFormulaJobs(deps_ctx, "omega", root_b, false, &jobs);
 
     // beta should appear exactly once. jobs: [beta, alpha, omega]
     var beta_count: usize = 0;
@@ -543,13 +528,9 @@ test "collectFormulaJobs surfaces FormulaNotFound for unparseable JSON" {
     try testing.expectError(
         install.InstallError.FormulaNotFound,
         install.collectFormulaJobs(
-            alloc,
+            .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst },
             "broken",
             "not-a-json",
-            &api,
-            &http,
-            &tdb.db,
-            &store_inst,
             false,
             &jobs,
         ),
@@ -582,13 +563,9 @@ test "collectFormulaJobs with post_install leaves the DB untouched" {
     defer jobs.deinit(alloc);
 
     _ = install.collectFormulaJobs(
-        alloc,
+        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst },
         "needs-ruby",
         json,
-        &api,
-        &http,
-        &tdb.db,
-        &store_inst,
         false,
         &jobs,
     ) catch {};
@@ -645,7 +622,13 @@ test "collectFormulaJobs carries the _<revision> suffix in version_str" {
     var jobs: std.ArrayList(install.DownloadJob) = .empty;
     defer jobs.deinit(alloc);
 
-    try install.collectFormulaJobs(alloc, "rev", json, &api, &http, &tdb.db, &store_inst, false, &jobs);
+    try install.collectFormulaJobs(
+        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst },
+        "rev",
+        json,
+        false,
+        &jobs,
+    );
 
     try testing.expectEqual(@as(usize, 1), jobs.items.len);
     try testing.expectEqualStrings("10.47_1", jobs.items[0].version_str);
@@ -676,7 +659,13 @@ test "collectFormulaJobs leaves plain-version formulas unchanged" {
     var jobs: std.ArrayList(install.DownloadJob) = .empty;
     defer jobs.deinit(alloc);
 
-    try install.collectFormulaJobs(alloc, "needs-ruby", json, &api, &http, &tdb.db, &store_inst, false, &jobs);
+    try install.collectFormulaJobs(
+        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst },
+        "needs-ruby",
+        json,
+        false,
+        &jobs,
+    );
 
     try testing.expectEqual(@as(usize, 1), jobs.items.len);
     try testing.expectEqualStrings("1.0", jobs.items[0].version_str);
@@ -783,13 +772,9 @@ test "collectFormulaJobs leaves no parsed-tree leaks under testing.allocator (>=
     }
 
     try install.collectFormulaJobs(
-        alloc,
+        .{ .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst },
         "root",
         root_json,
-        &api,
-        &http_pool,
-        &tdb.db,
-        &store_inst,
         false,
         &jobs,
     );

--- a/tests/services_test.zig
+++ b/tests/services_test.zig
@@ -37,7 +37,7 @@ test "list returns empty initially" {
     var t = try TempDb.init("empty");
     defer t.deinit();
 
-    const items = try supervisor.list(testing.allocator, &t.db);
+    const items = try supervisor.list(.{ .allocator = testing.allocator, .db = &t.db });
     defer supervisor.freeServiceInfos(testing.allocator, items);
     try testing.expectEqual(@as(usize, 0), items.len);
 }
@@ -54,7 +54,7 @@ test "raw services row insert is reflected by list and hasService" {
     try testing.expect(supervisor.hasService(&t.db, "redis"));
     try testing.expect(!supervisor.hasService(&t.db, "missing"));
 
-    const items = try supervisor.list(testing.allocator, &t.db);
+    const items = try supervisor.list(.{ .allocator = testing.allocator, .db = &t.db });
     defer supervisor.freeServiceInfos(testing.allocator, items);
     try testing.expectEqual(@as(usize, 1), items.len);
     try testing.expectEqualStrings("redis", items[0].name);
@@ -62,7 +62,7 @@ test "raw services row insert is reflected by list and hasService" {
 }
 
 fn listAndFree(alloc: std.mem.Allocator, db: *sqlite.Database) !void {
-    const items = try supervisor.list(alloc, db);
+    const items = try supervisor.list(.{ .allocator = alloc, .db = db });
     supervisor.freeServiceInfos(alloc, items);
 }
 

--- a/tests/supervisor_pure_test.zig
+++ b/tests/supervisor_pure_test.zig
@@ -16,6 +16,17 @@ const c = struct {
     extern "c" fn unsetenv(name: [*:0]const u8) c_int;
 };
 
+test "SupervisorCtx bundles allocator and db into one param" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    const ctx: supervisor.SupervisorCtx = .{ .allocator = testing.allocator, .db = &db };
+    try testing.expectError(error.ServiceNotFound, supervisor.start(ctx, "absent"));
+    try testing.expectError(error.ServiceNotFound, supervisor.stop(ctx, "absent"));
+    try testing.expectError(error.ServiceNotFound, supervisor.restart(ctx, "absent"));
+}
+
 test "describeError returns a distinct message per tag" {
     const msgs = [_][]const u8{
         supervisor.describeError(error.OsNotSupported),
@@ -69,7 +80,7 @@ test "list is empty on a fresh database and hasService returns false" {
     defer db.close();
     try schema.initSchema(&db);
 
-    const list = try supervisor.list(testing.allocator, &db);
+    const list = try supervisor.list(.{ .allocator = testing.allocator, .db = &db });
     defer supervisor.freeServiceInfos(testing.allocator, list);
     try testing.expectEqual(@as(usize, 0), list.len);
     try testing.expect(!supervisor.hasService(&db, "anything"));
@@ -99,11 +110,12 @@ test "register writes a plist and a DB row that list reports back" {
         .stdout_path = "/tmp/malt_sup_register/out.log",
         .stderr_path = "/tmp/malt_sup_register/err.log",
     };
-    try supervisor.register(testing.allocator, &db, spec, "testkeg", true, cellar, prefix);
+    const ctx: supervisor.SupervisorCtx = .{ .allocator = testing.allocator, .db = &db };
+    try supervisor.register(ctx, spec, "testkeg", true, cellar, prefix);
 
     try testing.expect(supervisor.hasService(&db, "com.malt.test.svc"));
 
-    const list = try supervisor.list(testing.allocator, &db);
+    const list = try supervisor.list(ctx);
     defer supervisor.freeServiceInfos(testing.allocator, list);
     try testing.expectEqual(@as(usize, 1), list.len);
     try testing.expectEqualStrings("com.malt.test.svc", list[0].name);
@@ -139,9 +151,10 @@ test "start/stop/restart return ServiceNotFound when no DB row exists" {
     defer db.close();
     try schema.initSchema(&db);
 
-    try testing.expectError(error.ServiceNotFound, supervisor.start(testing.allocator, &db, "absent"));
-    try testing.expectError(error.ServiceNotFound, supervisor.stop(testing.allocator, &db, "absent"));
-    try testing.expectError(error.ServiceNotFound, supervisor.restart(testing.allocator, &db, "absent"));
+    const ctx: supervisor.SupervisorCtx = .{ .allocator = testing.allocator, .db = &db };
+    try testing.expectError(error.ServiceNotFound, supervisor.start(ctx, "absent"));
+    try testing.expectError(error.ServiceNotFound, supervisor.stop(ctx, "absent"));
+    try testing.expectError(error.ServiceNotFound, supervisor.restart(ctx, "absent"));
 }
 
 test "stopAndUnregister is a no-op on an absent service and still wipes the row" {
@@ -162,7 +175,7 @@ test "stopAndUnregister is a no-op on an absent service and still wipes the row"
     stmt.finalize();
 
     try testing.expect(supervisor.hasService(&db, "ghost"));
-    supervisor.stopAndUnregister(testing.allocator, &db, "ghost");
+    supervisor.stopAndUnregister(.{ .allocator = testing.allocator, .db = &db }, "ghost");
     try testing.expect(!supervisor.hasService(&db, "ghost"));
 }
 


### PR DESCRIPTION
## Description

Three param-objects replace 9/8/2-argument entrypoints: `MigrateDeps`, `InstallJobDeps`, `SupervisorCtx`. Callers build a struct literal; tests can swap in fakes by replacing fields.

## Related Issue

- None

## Notes for Reviewers

No behaviour change; pure signature tidy-up.