### PR TITLE
refactor: privatise raw sqlite/lock handles; document borrowed slices

### DIFF
--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -19,13 +19,22 @@ pub const CaskError = error{
     OutOfMemory,
 };
 
+/// Parsed Homebrew cask. Every `[]const u8` borrows from `parsed`; valid
+/// only until `deinit()`. Callers holding strings past that point must dupe.
 pub const Cask = struct {
+    /// Borrowed from `parsed`.
     token: []const u8,
+    /// Borrowed from `parsed`.
     name: []const u8,
+    /// Borrowed from `parsed`.
     version: []const u8,
+    /// Borrowed from `parsed`.
     desc: []const u8,
+    /// Borrowed from `parsed`.
     homepage: []const u8,
+    /// Borrowed from `parsed`.
     url: []const u8,
+    /// Borrowed from `parsed` when present.
     sha256: ?[]const u8,
     auto_updates: bool,
 

--- a/src/core/dsl/fallback_log.zig
+++ b/src/core/dsl/fallback_log.zig
@@ -10,7 +10,7 @@ pub const FallbackReason = enum {
     unsupported_node,
     sandbox_violation,
     system_command_failed,
-    /// Parser diagnostic propagated from `Parser.diagnostics` after a
+    /// Parser diagnostic propagated from `Parser.diagnostics()` after a
     /// `parseBlock` failure. Carries the offending line/col in `loc`.
     parse_error,
 };

--- a/src/core/dsl/interpreter.zig
+++ b/src/core/dsl/interpreter.zig
@@ -98,8 +98,9 @@ pub const ExecContext = struct {
     /// All formula path bindings, indexed by `PathBinding`.
     paths: std.EnumArray(PathBinding, []const u8),
 
-    // Local variable scope (stack for nested blocks)
-    scopes: std.ArrayList(Scope),
+    /// Local-variable scope stack for nested blocks. Mutated by
+    /// `pushScope`/`popScope`/`setLocal`; do not touch from builtins.
+    _scopes: std.ArrayList(Scope),
 
     // Sandbox root for path validation
     sandbox_root: []const u8,
@@ -150,7 +151,7 @@ pub const ExecContext = struct {
             .cellar_path = cellar_path,
             .malt_prefix = malt_prefix,
             .paths = paths,
-            .scopes = .empty,
+            ._scopes = .empty,
             .sandbox_root = malt_prefix,
             .fallback_log_writer = flog,
             .formula_name = formula.name,
@@ -170,10 +171,10 @@ pub const ExecContext = struct {
         // Check local scopes (innermost first). Stop at the first
         // is_method_frame scope so a def doesn't leak through caller
         // locals (Ruby lexical-scope behaviour for `def`).
-        var i = self.scopes.items.len;
+        var i = self._scopes.items.len;
         while (i > 0) {
             i -= 1;
-            const scope = &self.scopes.items[i];
+            const scope = &self._scopes.items[i];
             if (scope.locals.get(name)) |val| {
                 return val;
             }
@@ -190,11 +191,11 @@ pub const ExecContext = struct {
     // matching popScope tearing down the caller's scope, so outer locals
     // vanish and subsequent lookups return stale/nil under memory pressure.
     pub fn pushScope(self: *ExecContext) DslError!void {
-        self.scopes.append(self.arena, Scope.init(self.arena)) catch return DslError.OutOfMemory;
+        self._scopes.append(self.arena, Scope.init(self.arena)) catch return DslError.OutOfMemory;
     }
 
     pub fn pushMethodScope(self: *ExecContext) DslError!void {
-        self.scopes.append(self.arena, .{
+        self._scopes.append(self.arena, .{
             .locals = std.StringHashMap(Value).init(self.arena),
             .is_method_frame = true,
         }) catch return DslError.OutOfMemory;
@@ -202,12 +203,17 @@ pub const ExecContext = struct {
 
     pub fn popScope(self: *ExecContext) void {
         // Arena owns the scope's locals — dropping the stack slot is enough.
-        _ = self.scopes.pop();
+        _ = self._scopes.pop();
     }
 
     pub fn setLocal(self: *ExecContext, name: []const u8, value: Value) DslError!void {
-        if (self.scopes.items.len == 0) return;
-        self.scopes.items[self.scopes.items.len - 1].locals.put(name, value) catch return DslError.OutOfMemory;
+        if (self._scopes.items.len == 0) return;
+        self._scopes.items[self._scopes.items.len - 1].locals.put(name, value) catch return DslError.OutOfMemory;
+    }
+
+    /// Current scope-stack depth. Tests use this to pin push/pop invariants.
+    pub fn scopeDepth(self: *const ExecContext) usize {
+        return self._scopes.items.len;
     }
 };
 
@@ -1098,7 +1104,7 @@ pub fn executePostInstall(
         // Surface accumulated parse diagnostics through the fallback log
         // so the CLI can print them with file:line context. Without this
         // the diagnostics ArrayList was filled and then dropped on return.
-        for (parser.diagnostics.items) |d| {
+        for (parser.diagnostics()) |d| {
             flog.log(.{
                 .formula = formula.name,
                 .reason = .parse_error,

--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -27,7 +27,8 @@ pub const Diagnostic = struct {
 pub const Parser = struct {
     lexer: *Lexer,
     allocator: std.mem.Allocator,
-    diagnostics: std.ArrayList(Diagnostic),
+    /// Use `diagnostics()` from outside; the list is append-only internal state.
+    _diagnostics: std.ArrayList(Diagnostic),
     current: Token,
 
     pub fn init(allocator: std.mem.Allocator, lex: *Lexer) Parser {
@@ -35,9 +36,14 @@ pub const Parser = struct {
         return .{
             .lexer = lex,
             .allocator = allocator,
-            .diagnostics = .empty,
+            ._diagnostics = .empty,
             .current = first,
         };
+    }
+
+    /// Read-only view of the accumulated parse diagnostics.
+    pub fn diagnostics(self: *const Parser) []const Diagnostic {
+        return self._diagnostics.items;
     }
 
     /// Parse a complete post_install block body (sequence of statements).
@@ -1173,7 +1179,7 @@ pub const Parser = struct {
     }
 
     fn emitError(self: *Parser, message: []const u8) DslError {
-        self.diagnostics.append(self.allocator, .{
+        self._diagnostics.append(self.allocator, .{
             .loc = self.currentLoc(),
             .message = message,
             .severity = .err,

--- a/src/core/formula.zig
+++ b/src/core/formula.zig
@@ -11,6 +11,9 @@ pub const FormulaError = error{
     NoBottleAvailable,
 };
 
+/// Bottle descriptor for one platform. All three strings borrow from the
+/// JSON source that backs the parent `Formula._parsed`; callers that hold
+/// a `BottleFile` beyond `Formula.deinit()` must dupe first.
 pub const BottleFile = struct {
     cellar: []const u8,
     url: []const u8,
@@ -43,27 +46,47 @@ pub fn pkgVersion(buf: []u8, version: []const u8, revision: i64) ![]const u8 {
     return std.fmt.bufPrint(buf, "{s}_{d}", .{ version, revision });
 }
 
+/// Parsed Homebrew formula. Unless otherwise noted, every `[]const u8` and
+/// `[]const []const u8` field borrows from `_parsed`; valid only until
+/// `deinit()`. The exception is `pkg_version`, which is allocated on the
+/// caller's allocator so it can outlive revision-zero callers that reuse
+/// `version`.
 pub const Formula = struct {
+    /// Borrowed from `_parsed`.
     name: []const u8,
+    /// Borrowed from `_parsed`.
     full_name: []const u8,
+    /// Borrowed from `_parsed`.
     tap: []const u8,
+    /// Borrowed from `_parsed`.
     desc: []const u8,
+    /// Borrowed from `_parsed`.
     version: []const u8,
     /// Canonical on-disk version name: equals `version` when
-    /// `revision == 0`, else `<version>_<revision>`. Use this for
-    /// every Cellar/opt/receipt path — never raw `version`.
+    /// `revision == 0` (borrowed from `_parsed`), else
+    /// `<version>_<revision>` allocated on the caller's allocator.
+    /// Use this for every Cellar/opt/receipt path — never raw `version`.
     pkg_version: []const u8,
     revision: i64,
+    /// Borrowed from `_parsed` when present.
     license: ?[]const u8,
+    /// Borrowed from `_parsed`.
     homepage: []const u8,
+    /// Outer slice allocated on the caller's allocator; element strings
+    /// borrow from `_parsed`.
     dependencies: []const []const u8,
     keg_only: bool,
     post_install_defined: bool,
+    /// Map keys and `BottleFile` string fields borrow from `_parsed`.
     bottle_files: ?std.json.ArrayHashMap(BottleFile),
+    /// Borrowed from `_parsed`.
     bottle_root_url: ?[]const u8,
+    /// Outer slice allocated on the caller's allocator; element strings
+    /// borrow from `_parsed`.
     oldnames: []const []const u8,
     /// Optional launchd service block. Populated when the upstream formula
     /// JSON contains a `service` object with at least a `run` array.
+    /// All string fields inside borrow from `_parsed`.
     service: ?ServiceDef = null,
 
     /// Holds the parsed JSON tree. Must stay alive as long as the Formula

--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -220,7 +220,7 @@ fn canParseBlock(allocator: std.mem.Allocator, src: []const u8) bool {
     var lex = dsl_lexer.Lexer.init(src);
     var p = dsl_parser.Parser.init(arena.allocator(), &lex);
     _ = p.parseBlock() catch return false;
-    return p.diagnostics.items.len == 0;
+    return p.diagnostics().len == 0;
 }
 
 /// Span describing a single `def NAME ... end` block at a known indent.

--- a/src/db/lock.zig
+++ b/src/db/lock.zig
@@ -58,7 +58,8 @@ pub fn nextAcquireStep(p: AcquireProbe) AcquireStep {
 }
 
 pub const LockFile = struct {
-    fd: std.posix.fd_t,
+    /// Owned by the LockFile; touch only via `release` / `holderPid`.
+    _fd: std.posix.fd_t,
     path: []const u8,
 
     /// Acquire an exclusive advisory lock at `path`, retrying with 100 ms
@@ -129,7 +130,7 @@ pub const LockFile = struct {
         }
 
         return LockFile{
-            .fd = fd,
+            ._fd = fd,
             .path = path,
         };
     }
@@ -154,13 +155,13 @@ pub const LockFile = struct {
     /// left in place — removing it would race against other processes
     /// that may already have it open.
     pub fn release(self: *LockFile) void {
-        _ = std.c.ftruncate(self.fd, 0);
+        _ = std.c.ftruncate(self._fd, 0);
         // fsync before unlock so a crash between truncate and close can't
         // leave a stale PID in the lock file — `doctor` would otherwise
         // report a phantom holder.
-        _ = std.c.fsync(self.fd);
-        _ = std.c.flock(self.fd, std.c.LOCK.UN);
-        _ = std.c.close(self.fd);
+        _ = std.c.fsync(self._fd);
+        _ = std.c.flock(self._fd, std.c.LOCK.UN);
+        _ = std.c.close(self._fd);
     }
 
     /// Read the PID from an existing lock file.  Returns null when the file

--- a/src/db/sqlite.zig
+++ b/src/db/sqlite.zig
@@ -42,12 +42,13 @@ pub const MAX_PATH_LEN: usize = 2048;
 pub const MAX_SQL_LEN: usize = 16384;
 
 pub const Statement = struct {
-    stmt: *c.sqlite3_stmt,
+    /// Raw sqlite handle; touch only via the methods below.
+    _stmt: *c.sqlite3_stmt,
 
     /// Advance the statement. Returns true when a data row is available (SQLITE_ROW),
     /// false when execution is complete (SQLITE_DONE).
     pub fn step(self: *Statement) SqliteError!bool {
-        const rc = c.sqlite3_step(self.stmt);
+        const rc = c.sqlite3_step(self._stmt);
         if (rc == c.SQLITE_ROW) return true;
         if (rc == c.SQLITE_DONE) return false;
         return mapError(rc, SqliteError.StepFailed);
@@ -55,19 +56,19 @@ pub const Statement = struct {
 
     /// Finalize (destroy) the prepared statement, releasing all resources.
     pub fn finalize(self: *Statement) void {
-        _ = c.sqlite3_finalize(self.stmt);
+        _ = c.sqlite3_finalize(self._stmt);
     }
 
     /// Reset the statement so it can be re-executed with new bindings.
     pub fn reset(self: *Statement) SqliteError!void {
-        const rc = c.sqlite3_reset(self.stmt);
+        const rc = c.sqlite3_reset(self._stmt);
         if (rc != c.SQLITE_OK) return mapError(rc, SqliteError.StepFailed);
     }
 
     /// Bind a text value to the 1-indexed parameter at `idx`.
     pub fn bindText(self: *Statement, idx: u32, text: []const u8) SqliteError!void {
         const rc = c.sqlite3_bind_text(
-            self.stmt,
+            self._stmt,
             @intCast(idx),
             @ptrCast(text.ptr),
             @intCast(text.len),
@@ -78,36 +79,37 @@ pub const Statement = struct {
 
     /// Bind a 64-bit integer value to the 1-indexed parameter at `idx`.
     pub fn bindInt(self: *Statement, idx: u32, val: i64) SqliteError!void {
-        const rc = c.sqlite3_bind_int64(self.stmt, @intCast(idx), val);
+        const rc = c.sqlite3_bind_int64(self._stmt, @intCast(idx), val);
         if (rc != c.SQLITE_OK) return mapError(rc, SqliteError.BindFailed);
     }
 
     /// Bind NULL to the 1-indexed parameter at `idx`.
     pub fn bindNull(self: *Statement, idx: u32) SqliteError!void {
-        const rc = c.sqlite3_bind_null(self.stmt, @intCast(idx));
+        const rc = c.sqlite3_bind_null(self._stmt, @intCast(idx));
         if (rc != c.SQLITE_OK) return mapError(rc, SqliteError.BindFailed);
     }
 
     /// Return the text value of column `idx` (0-indexed), or null if the column is SQL NULL.
     pub fn columnText(self: *Statement, idx: u32) ?[*:0]const u8 {
-        const ptr = c.sqlite3_column_text(self.stmt, @intCast(idx));
+        const ptr = c.sqlite3_column_text(self._stmt, @intCast(idx));
         if (ptr == null) return null;
         return ptr;
     }
 
     /// Return the 64-bit integer value of column `idx` (0-indexed).
     pub fn columnInt(self: *Statement, idx: u32) i64 {
-        return c.sqlite3_column_int64(self.stmt, @intCast(idx));
+        return c.sqlite3_column_int64(self._stmt, @intCast(idx));
     }
 
     /// Return the boolean interpretation of column `idx` (0-indexed): true when non-zero.
     pub fn columnBool(self: *Statement, idx: u32) bool {
-        return c.sqlite3_column_int64(self.stmt, @intCast(idx)) != 0;
+        return c.sqlite3_column_int64(self._stmt, @intCast(idx)) != 0;
     }
 };
 
 pub const Database = struct {
-    handle: *c.sqlite3,
+    /// Raw sqlite handle; touch only via the methods below.
+    _handle: *c.sqlite3,
 
     /// Open (or create) a database file at `path`.
     /// Configures pragmas: journal_mode=WAL, foreign_keys=ON, busy_timeout=5000.
@@ -133,7 +135,7 @@ pub const Database = struct {
             return SqliteError.OpenFailed;
         }
 
-        var self = Database{ .handle = db.? };
+        var self = Database{ ._handle = db.? };
 
         // Set recommended pragmas.
         self.exec("PRAGMA journal_mode=WAL;") catch return SqliteError.OpenFailed;
@@ -145,7 +147,7 @@ pub const Database = struct {
 
     /// Close the database connection and release resources.
     pub fn close(self: *Database) void {
-        _ = c.sqlite3_close(self.handle);
+        _ = c.sqlite3_close(self._handle);
     }
 
     /// Execute one or more SQL statements that return no result rows.
@@ -159,7 +161,7 @@ pub const Database = struct {
         @memcpy(buf[0..sql.len], sql);
         buf[sql.len] = 0;
         const c_sql: [*:0]const u8 = buf[0..sql.len :0];
-        const rc = c.sqlite3_exec(self.handle, c_sql, null, null, null);
+        const rc = c.sqlite3_exec(self._handle, c_sql, null, null, null);
         if (rc != c.SQLITE_OK) return mapError(rc, SqliteError.ExecFailed);
     }
 
@@ -168,9 +170,9 @@ pub const Database = struct {
     /// no copy needed.
     pub fn prepare(self: *Database, sql: []const u8) SqliteError!Statement {
         var stmt: ?*c.sqlite3_stmt = null;
-        const rc = c.sqlite3_prepare_v2(self.handle, sql.ptr, @intCast(sql.len), &stmt, null);
+        const rc = c.sqlite3_prepare_v2(self._handle, sql.ptr, @intCast(sql.len), &stmt, null);
         if (rc != c.SQLITE_OK) return mapError(rc, SqliteError.PrepareFailed);
-        return Statement{ .stmt = stmt.? };
+        return Statement{ ._stmt = stmt.? };
     }
 
     /// Begin an immediate transaction.
@@ -186,6 +188,6 @@ pub const Database = struct {
     /// Roll back the current transaction.  Errors are intentionally ignored
     /// because this is typically called from an errdefer path.
     pub fn rollback(self: *Database) void {
-        _ = c.sqlite3_exec(self.handle, "ROLLBACK;", null, null, null);
+        _ = c.sqlite3_exec(self._handle, "ROLLBACK;", null, null, null);
     }
 };

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -2527,7 +2527,7 @@ test "ExecContext.pushScope propagates OOM from the arena" {
         .cellar_path = "",
         .malt_prefix = "",
         .paths = std.EnumArray(malt.dsl.interpreter.PathBinding, []const u8).initFill(""),
-        .scopes = .empty,
+        ._scopes = .empty,
         .sandbox_root = "",
         .fallback_log_writer = &flog,
         .formula_name = "test",
@@ -2536,7 +2536,7 @@ test "ExecContext.pushScope propagates OOM from the arena" {
     };
 
     try testing.expectError(error.OutOfMemory, ctx.pushScope());
-    try testing.expectEqual(@as(usize, 0), ctx.scopes.items.len);
+    try testing.expectEqual(@as(usize, 0), ctx.scopeDepth());
 }
 
 test "ExecContext.pushMethodScope propagates OOM from the arena" {
@@ -2552,7 +2552,7 @@ test "ExecContext.pushMethodScope propagates OOM from the arena" {
         .cellar_path = "",
         .malt_prefix = "",
         .paths = std.EnumArray(malt.dsl.interpreter.PathBinding, []const u8).initFill(""),
-        .scopes = .empty,
+        ._scopes = .empty,
         .sandbox_root = "",
         .fallback_log_writer = &flog,
         .formula_name = "test",
@@ -2561,5 +2561,5 @@ test "ExecContext.pushMethodScope propagates OOM from the arena" {
     };
 
     try testing.expectError(error.OutOfMemory, ctx.pushMethodScope());
-    try testing.expectEqual(@as(usize, 0), ctx.scopes.items.len);
+    try testing.expectEqual(@as(usize, 0), ctx.scopeDepth());
 }

--- a/tests/dsl_parser_test.zig
+++ b/tests/dsl_parser_test.zig
@@ -24,6 +24,20 @@ fn parseSource(arena: *std.heap.ArenaAllocator, src: []const u8) ![]const *const
     return p.parseBlock();
 }
 
+// Accessor pins the read-only diagnostics surface: callers borrow a slice,
+// never mutate the backing list.
+test "parser: diagnostics() accessor returns accumulated entries" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    var lex = Lexer.init(")");
+    var p = Parser.init(arena.allocator(), &lex);
+    _ = p.parseBlock() catch {};
+
+    const diags = p.diagnostics();
+    try testing.expect(diags.len >= 1);
+}
+
 // ---------------------------------------------------------------------------
 // Simple method calls
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Narrow the public surface around the database and DSL primitives so the ownership contract is enforced by the names, not just convention. 

## Related Issue

- None

## Note for Reviewers

No runtime change; only struct-field names and one accessor method
move.

Generated with [Claude Code](https://claude.com/claude-code).