### PR TITLE
refactor(core/dsl): split interpreter context and decouple from formula

### DIFF
--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -145,7 +145,11 @@ pub fn executeDslPostInstall(
 
     // DSL errors reflect in `flog`; the router reads the log as the source
     // of truth so silent skips downgrade the same as hard failures.
-    dsl.executePostInstall(allocator, &formula, post_install_src, prefix, &flog) catch {};
+    dsl.executePostInstall(allocator, .{
+        .name = formula.name,
+        .version = formula.version,
+        .pkg_version = formula.pkg_version,
+    }, post_install_src, prefix, &flog) catch {};
     routePostInstallOutcome(allocator, name, version_str, prefix, &flog, use_system_ruby_list);
     return .handled;
 }

--- a/src/core/dsl/context.zig
+++ b/src/core/dsl/context.zig
@@ -1,0 +1,221 @@
+//! malt — DSL execution context
+//! Holds the runtime state (scopes, path bindings, method table, fallback
+//! log) the tree-walker operates against. Split out of `interpreter.zig`
+//! so the DSL is free of the formula domain — callers hand in a narrow
+//! `FormulaRef` projection.
+
+const std = @import("std");
+const ast = @import("ast.zig");
+const values = @import("values.zig");
+const fallback_log = @import("fallback_log.zig");
+
+const Value = values.Value;
+const FallbackLog = fallback_log.FallbackLog;
+
+pub const DslError = error{
+    ParseError,
+    UnknownMethod,
+    UnsupportedNode,
+    PathSandboxViolation,
+    PostInstallFailed,
+    SystemCommandFailed,
+    OutOfMemory,
+    /// Control-flow signal raised by `return`. Callers that bound the
+    /// unwind (a def call frame, the post_install top-level) catch it;
+    /// block iterators propagate it so `return` inside `.each` exits the
+    /// enclosing method instead of the iteration.
+    ReturnSignal,
+};
+
+/// Scopes are arena-backed — no deinit; the post_install arena frees locals.
+pub const Scope = struct {
+    locals: std.StringHashMap(Value),
+    /// Marks a def-call frame. Binding lookup stops here so a called
+    /// method cannot see the caller's locals — matches Ruby's lexical
+    /// scoping for `def`.
+    is_method_frame: bool = false,
+
+    pub fn init(arena: std.mem.Allocator) Scope {
+        return .{ .locals = std.StringHashMap(Value).init(arena) };
+    }
+};
+
+/// Formula path binding slots. Storage order mirrors EnumArray indexing;
+/// `binding_map` translates DSL identifiers to these tags.
+pub const PathBinding = enum {
+    prefix,
+    bin,
+    sbin,
+    lib,
+    libexec,
+    include,
+    share,
+    pkgshare,
+    etc,
+    pkgetc,
+    var_dir,
+    opt_prefix,
+    homebrew_prefix,
+    homebrew_cellar,
+};
+
+const binding_map = std.StaticStringMap(PathBinding).initComptime(.{
+    .{ "prefix", PathBinding.prefix },
+    .{ "bin", PathBinding.bin },
+    .{ "sbin", PathBinding.sbin },
+    .{ "lib", PathBinding.lib },
+    .{ "libexec", PathBinding.libexec },
+    .{ "include", PathBinding.include },
+    .{ "share", PathBinding.share },
+    .{ "pkgshare", PathBinding.pkgshare },
+    .{ "etc", PathBinding.etc },
+    .{ "pkgetc", PathBinding.pkgetc },
+    .{ "var", PathBinding.var_dir },
+    .{ "opt_prefix", PathBinding.opt_prefix },
+    .{ "HOMEBREW_PREFIX", PathBinding.homebrew_prefix },
+    .{ "HOMEBREW_CELLAR", PathBinding.homebrew_cellar },
+});
+
+/// Narrow projection; keeps DSL free of formula types.
+pub const FormulaRef = struct {
+    name: []const u8,
+    version: []const u8,
+    pkg_version: []const u8,
+};
+
+pub const ExecContext = struct {
+    /// Caller-owned arena. Owns every path string, scope map, and the
+    /// methods table; deinit is a no-op because the caller tears it down.
+    arena: std.mem.Allocator,
+
+    /// Cellar path for the current formula — also stored in `paths[.prefix]`,
+    /// kept as a direct field so builtins (sandbox validation) can read it
+    /// without a lookup.
+    cellar_path: []const u8,
+    malt_prefix: []const u8,
+
+    /// All formula path bindings, indexed by `PathBinding`.
+    paths: std.EnumArray(PathBinding, []const u8),
+
+    /// Local-variable scope stack for nested blocks. Mutated by
+    /// `pushScope`/`popScope`/`setLocal`; do not touch from builtins.
+    _scopes: std.ArrayList(Scope),
+
+    // Sandbox root for path validation
+    sandbox_root: []const u8,
+
+    // Fallback log writer
+    fallback_log_writer: *FallbackLog,
+
+    // Formula name for fallback log entries
+    formula_name: []const u8,
+
+    /// User-defined methods from `def ... end`. Entries borrow the parser
+    /// arena; the map itself lives on `arena`.
+    methods: std.StringHashMap(ast.MethodDef),
+
+    // Value threaded through a `return` statement. The call-frame (or
+    // top-level executor) reads + resets this when it catches ReturnSignal.
+    return_value: Value,
+
+    pub fn init(
+        arena: std.mem.Allocator,
+        ref: FormulaRef,
+        malt_prefix: []const u8,
+        flog: *FallbackLog,
+    ) DslError!ExecContext {
+        const cellar_path = std.fmt.allocPrint(arena, "{s}/Cellar/{s}/{s}", .{
+            malt_prefix, ref.name, ref.version,
+        }) catch malt_prefix;
+
+        var paths = std.EnumArray(PathBinding, []const u8).initUndefined();
+        paths.set(.prefix, cellar_path);
+        paths.set(.bin, joinPath(arena, cellar_path, "bin"));
+        paths.set(.sbin, joinPath(arena, cellar_path, "sbin"));
+        paths.set(.lib, joinPath(arena, cellar_path, "lib"));
+        paths.set(.libexec, joinPath(arena, cellar_path, "libexec"));
+        paths.set(.include, joinPath(arena, cellar_path, "include"));
+        paths.set(.share, joinPath(arena, cellar_path, "share"));
+        paths.set(.pkgshare, std.fmt.allocPrint(arena, "{s}/share/{s}", .{ cellar_path, ref.name }) catch cellar_path);
+        paths.set(.etc, joinPath(arena, malt_prefix, "etc"));
+        // pkgetc: bare identifier in homebrew core (gnutls, openssl@3 …).
+        paths.set(.pkgetc, std.fmt.allocPrint(arena, "{s}/etc/{s}", .{ malt_prefix, ref.name }) catch malt_prefix);
+        paths.set(.var_dir, joinPath(arena, malt_prefix, "var"));
+        paths.set(.opt_prefix, std.fmt.allocPrint(arena, "{s}/opt/{s}", .{ malt_prefix, ref.name }) catch malt_prefix);
+        paths.set(.homebrew_prefix, malt_prefix);
+        paths.set(.homebrew_cellar, joinPath(arena, malt_prefix, "Cellar"));
+
+        var ctx = ExecContext{
+            .arena = arena,
+            .cellar_path = cellar_path,
+            .malt_prefix = malt_prefix,
+            .paths = paths,
+            ._scopes = .empty,
+            .sandbox_root = malt_prefix,
+            .fallback_log_writer = flog,
+            .formula_name = ref.name,
+            .methods = std.StringHashMap(ast.MethodDef).init(arena),
+            .return_value = Value{ .nil = {} },
+        };
+
+        // OOM here would leave callers with a zero-depth stack; surface it.
+        try ctx.pushScope();
+        return ctx;
+    }
+
+    /// Arena owns every allocation — caller tears it down. No per-field free.
+    pub fn deinit(_: *ExecContext) void {}
+
+    pub fn resolveBinding(self: *ExecContext, name: []const u8) ?Value {
+        // Check local scopes (innermost first). Stop at the first
+        // is_method_frame scope so a def doesn't leak through caller
+        // locals (Ruby lexical-scope behaviour for `def`).
+        var i = self._scopes.items.len;
+        while (i > 0) {
+            i -= 1;
+            const scope = &self._scopes.items[i];
+            if (scope.locals.get(name)) |val| {
+                return val;
+            }
+            if (scope.is_method_frame) break;
+        }
+
+        if (binding_map.get(name)) |tag| {
+            return Value{ .pathname = self.paths.get(tag) };
+        }
+        return null;
+    }
+
+    // OOM on a scope push must not be swallowed: a silent drop leaves the
+    // matching popScope tearing down the caller's scope, so outer locals
+    // vanish and subsequent lookups return stale/nil under memory pressure.
+    pub fn pushScope(self: *ExecContext) DslError!void {
+        self._scopes.append(self.arena, Scope.init(self.arena)) catch return DslError.OutOfMemory;
+    }
+
+    pub fn pushMethodScope(self: *ExecContext) DslError!void {
+        self._scopes.append(self.arena, .{
+            .locals = std.StringHashMap(Value).init(self.arena),
+            .is_method_frame = true,
+        }) catch return DslError.OutOfMemory;
+    }
+
+    pub fn popScope(self: *ExecContext) void {
+        // Arena owns the scope's locals — dropping the stack slot is enough.
+        _ = self._scopes.pop();
+    }
+
+    pub fn setLocal(self: *ExecContext, name: []const u8, value: Value) DslError!void {
+        if (self._scopes.items.len == 0) return;
+        self._scopes.items[self._scopes.items.len - 1].locals.put(name, value) catch return DslError.OutOfMemory;
+    }
+
+    /// Current scope-stack depth. Tests use this to pin push/pop invariants.
+    pub fn scopeDepth(self: *const ExecContext) usize {
+        return self._scopes.items.len;
+    }
+};
+
+pub fn joinPath(allocator: std.mem.Allocator, base: []const u8, sub: []const u8) []const u8 {
+    return std.fs.path.join(allocator, &.{ base, sub }) catch base;
+}

--- a/src/core/dsl/interpreter.zig
+++ b/src/core/dsl/interpreter.zig
@@ -1,5 +1,5 @@
 //! malt — DSL interpreter
-//! Tree-walking evaluator with ExecContext for formula path bindings.
+//! Tree-walking evaluator; runtime state lives in `context.zig`.
 
 const std = @import("std");
 const fs_compat = @import("../../fs/compat.zig");
@@ -10,212 +10,16 @@ const parser_mod = @import("parser.zig");
 const sandbox = @import("sandbox.zig");
 const fallback_log = @import("fallback_log.zig");
 const builtins_root = @import("builtins/root.zig");
-const formula_mod = @import("../formula.zig");
+const context = @import("context.zig");
 
 const Node = ast.Node;
 const SourceLoc = ast.SourceLoc;
 const Value = values.Value;
 const FallbackLog = fallback_log.FallbackLog;
-const FallbackEntry = fallback_log.FallbackEntry;
-const FallbackReason = fallback_log.FallbackReason;
-const Formula = formula_mod.Formula;
 
-pub const DslError = error{
-    ParseError,
-    UnknownMethod,
-    UnsupportedNode,
-    PathSandboxViolation,
-    PostInstallFailed,
-    SystemCommandFailed,
-    OutOfMemory,
-    /// Control-flow signal raised by `return`. Callers that bound the
-    /// unwind (a def call frame, the post_install top-level) catch it;
-    /// block iterators propagate it so `return` inside `.each` exits the
-    /// enclosing method instead of the iteration.
-    ReturnSignal,
-};
-
-/// Scopes are arena-backed — no deinit; the post_install arena frees locals.
-pub const Scope = struct {
-    locals: std.StringHashMap(Value),
-    /// Marks a def-call frame. Binding lookup stops here so a called
-    /// method cannot see the caller's locals — matches Ruby's lexical
-    /// scoping for `def`.
-    is_method_frame: bool = false,
-
-    pub fn init(arena: std.mem.Allocator) Scope {
-        return .{ .locals = std.StringHashMap(Value).init(arena) };
-    }
-};
-
-/// Formula path binding slots. Storage order mirrors EnumArray indexing;
-/// `binding_map` translates DSL identifiers to these tags.
-pub const PathBinding = enum {
-    prefix,
-    bin,
-    sbin,
-    lib,
-    libexec,
-    include,
-    share,
-    pkgshare,
-    etc,
-    pkgetc,
-    var_dir,
-    opt_prefix,
-    homebrew_prefix,
-    homebrew_cellar,
-};
-
-const binding_map = std.StaticStringMap(PathBinding).initComptime(.{
-    .{ "prefix", PathBinding.prefix },
-    .{ "bin", PathBinding.bin },
-    .{ "sbin", PathBinding.sbin },
-    .{ "lib", PathBinding.lib },
-    .{ "libexec", PathBinding.libexec },
-    .{ "include", PathBinding.include },
-    .{ "share", PathBinding.share },
-    .{ "pkgshare", PathBinding.pkgshare },
-    .{ "etc", PathBinding.etc },
-    .{ "pkgetc", PathBinding.pkgetc },
-    .{ "var", PathBinding.var_dir },
-    .{ "opt_prefix", PathBinding.opt_prefix },
-    .{ "HOMEBREW_PREFIX", PathBinding.homebrew_prefix },
-    .{ "HOMEBREW_CELLAR", PathBinding.homebrew_cellar },
-});
-
-pub const ExecContext = struct {
-    /// Caller-owned arena. Owns every path string, scope map, and the
-    /// methods table; deinit is a no-op because the caller tears it down.
-    arena: std.mem.Allocator,
-
-    /// Cellar path for the current formula — also stored in `paths[.prefix]`,
-    /// kept as a direct field so builtins (sandbox validation) can read it
-    /// without a lookup.
-    cellar_path: []const u8,
-    malt_prefix: []const u8,
-
-    /// All formula path bindings, indexed by `PathBinding`.
-    paths: std.EnumArray(PathBinding, []const u8),
-
-    /// Local-variable scope stack for nested blocks. Mutated by
-    /// `pushScope`/`popScope`/`setLocal`; do not touch from builtins.
-    _scopes: std.ArrayList(Scope),
-
-    // Sandbox root for path validation
-    sandbox_root: []const u8,
-
-    // Fallback log writer
-    fallback_log_writer: *FallbackLog,
-
-    // Formula name for fallback log entries
-    formula_name: []const u8,
-
-    /// User-defined methods from `def ... end`. Entries borrow the parser
-    /// arena; the map itself lives on `arena`.
-    methods: std.StringHashMap(ast.MethodDef),
-
-    // Value threaded through a `return` statement. The call-frame (or
-    // top-level executor) reads + resets this when it catches ReturnSignal.
-    return_value: Value,
-
-    pub fn init(
-        arena: std.mem.Allocator,
-        formula: *const Formula,
-        malt_prefix: []const u8,
-        flog: *FallbackLog,
-    ) DslError!ExecContext {
-        const cellar_path = std.fmt.allocPrint(arena, "{s}/Cellar/{s}/{s}", .{
-            malt_prefix, formula.name, formula.version,
-        }) catch malt_prefix;
-
-        var paths = std.EnumArray(PathBinding, []const u8).initUndefined();
-        paths.set(.prefix, cellar_path);
-        paths.set(.bin, joinPath(arena, cellar_path, "bin"));
-        paths.set(.sbin, joinPath(arena, cellar_path, "sbin"));
-        paths.set(.lib, joinPath(arena, cellar_path, "lib"));
-        paths.set(.libexec, joinPath(arena, cellar_path, "libexec"));
-        paths.set(.include, joinPath(arena, cellar_path, "include"));
-        paths.set(.share, joinPath(arena, cellar_path, "share"));
-        paths.set(.pkgshare, std.fmt.allocPrint(arena, "{s}/share/{s}", .{ cellar_path, formula.name }) catch cellar_path);
-        paths.set(.etc, joinPath(arena, malt_prefix, "etc"));
-        // pkgetc: bare identifier in homebrew core (gnutls, openssl@3 …).
-        paths.set(.pkgetc, std.fmt.allocPrint(arena, "{s}/etc/{s}", .{ malt_prefix, formula.name }) catch malt_prefix);
-        paths.set(.var_dir, joinPath(arena, malt_prefix, "var"));
-        paths.set(.opt_prefix, std.fmt.allocPrint(arena, "{s}/opt/{s}", .{ malt_prefix, formula.name }) catch malt_prefix);
-        paths.set(.homebrew_prefix, malt_prefix);
-        paths.set(.homebrew_cellar, joinPath(arena, malt_prefix, "Cellar"));
-
-        var ctx = ExecContext{
-            .arena = arena,
-            .cellar_path = cellar_path,
-            .malt_prefix = malt_prefix,
-            .paths = paths,
-            ._scopes = .empty,
-            .sandbox_root = malt_prefix,
-            .fallback_log_writer = flog,
-            .formula_name = formula.name,
-            .methods = std.StringHashMap(ast.MethodDef).init(arena),
-            .return_value = Value{ .nil = {} },
-        };
-
-        // OOM here would leave callers with a zero-depth stack; surface it.
-        try ctx.pushScope();
-        return ctx;
-    }
-
-    /// Arena owns every allocation — caller tears it down. No per-field free.
-    pub fn deinit(_: *ExecContext) void {}
-
-    pub fn resolveBinding(self: *ExecContext, name: []const u8) ?Value {
-        // Check local scopes (innermost first). Stop at the first
-        // is_method_frame scope so a def doesn't leak through caller
-        // locals (Ruby lexical-scope behaviour for `def`).
-        var i = self._scopes.items.len;
-        while (i > 0) {
-            i -= 1;
-            const scope = &self._scopes.items[i];
-            if (scope.locals.get(name)) |val| {
-                return val;
-            }
-            if (scope.is_method_frame) break;
-        }
-
-        if (binding_map.get(name)) |tag| {
-            return Value{ .pathname = self.paths.get(tag) };
-        }
-        return null;
-    }
-
-    // OOM on a scope push must not be swallowed: a silent drop leaves the
-    // matching popScope tearing down the caller's scope, so outer locals
-    // vanish and subsequent lookups return stale/nil under memory pressure.
-    pub fn pushScope(self: *ExecContext) DslError!void {
-        self._scopes.append(self.arena, Scope.init(self.arena)) catch return DslError.OutOfMemory;
-    }
-
-    pub fn pushMethodScope(self: *ExecContext) DslError!void {
-        self._scopes.append(self.arena, .{
-            .locals = std.StringHashMap(Value).init(self.arena),
-            .is_method_frame = true,
-        }) catch return DslError.OutOfMemory;
-    }
-
-    pub fn popScope(self: *ExecContext) void {
-        // Arena owns the scope's locals — dropping the stack slot is enough.
-        _ = self._scopes.pop();
-    }
-
-    pub fn setLocal(self: *ExecContext, name: []const u8, value: Value) DslError!void {
-        if (self._scopes.items.len == 0) return;
-        self._scopes.items[self._scopes.items.len - 1].locals.put(name, value) catch return DslError.OutOfMemory;
-    }
-
-    /// Current scope-stack depth. Tests use this to pin push/pop invariants.
-    pub fn scopeDepth(self: *const ExecContext) usize {
-        return self._scopes.items.len;
-    }
-};
+const DslError = context.DslError;
+const ExecContext = context.ExecContext;
+const FormulaRef = context.FormulaRef;
 
 /// Per-element error policy for `.each`-style iteration blocks. Hard
 /// errors (formula aborts, sandbox breach, control-flow signals, OOM)
@@ -1089,7 +893,7 @@ fn compare(left: Value, op: []const u8, right: Value) bool {
 /// Execute a formula's post_install block.
 pub fn executePostInstall(
     allocator: std.mem.Allocator,
-    formula: *const Formula,
+    ref: FormulaRef,
     ruby_source: []const u8,
     malt_prefix: []const u8,
     flog: *FallbackLog,
@@ -1106,7 +910,7 @@ pub fn executePostInstall(
         // the diagnostics ArrayList was filled and then dropped on return.
         for (parser.diagnostics()) |d| {
             flog.log(.{
-                .formula = formula.name,
+                .formula = ref.name,
                 .reason = .parse_error,
                 .detail = d.message,
                 .loc = d.loc,
@@ -1115,12 +919,8 @@ pub fn executePostInstall(
         return e;
     };
 
-    var ctx = try ExecContext.init(a, formula, malt_prefix, flog);
+    var ctx = try ExecContext.init(a, ref, malt_prefix, flog);
     defer ctx.deinit();
     var interp = Interpreter.init(&ctx);
     try interp.execute(nodes);
-}
-
-fn joinPath(allocator: std.mem.Allocator, base: []const u8, sub: []const u8) []const u8 {
-    return std.fs.path.join(allocator, &.{ base, sub }) catch base;
 }

--- a/src/core/dsl/root.zig
+++ b/src/core/dsl/root.zig
@@ -4,6 +4,7 @@
 pub const ast = @import("ast.zig");
 pub const lexer = @import("lexer.zig");
 pub const parser = @import("parser.zig");
+pub const context = @import("context.zig");
 pub const interpreter = @import("interpreter.zig");
 pub const values = @import("values.zig");
 pub const sandbox = @import("sandbox.zig");
@@ -12,8 +13,9 @@ pub const builtins = @import("builtins/root.zig");
 
 // Public API re-exports
 pub const executePostInstall = interpreter.executePostInstall;
-pub const DslError = interpreter.DslError;
-pub const ExecContext = interpreter.ExecContext;
+pub const DslError = context.DslError;
+pub const ExecContext = context.ExecContext;
+pub const FormulaRef = context.FormulaRef;
 pub const FallbackLog = fallback_log.FallbackLog;
 pub const FallbackEntry = fallback_log.FallbackEntry;
 pub const FallbackReason = fallback_log.FallbackReason;

--- a/tests/dsl_interpreter_extra_test.zig
+++ b/tests/dsl_interpreter_extra_test.zig
@@ -58,7 +58,11 @@ fn run(ruby_src: []const u8) !void {
     var flog = dsl.FallbackLog.init(alloc);
     defer flog.deinit();
 
-    try dsl.executePostInstall(alloc, &f, ruby_src, prefix, &flog);
+    try dsl.executePostInstall(alloc, .{
+        .name = f.name,
+        .version = f.version,
+        .pkg_version = f.pkg_version,
+    }, ruby_src, prefix, &flog);
 }
 
 test "string interpolation inside post_install" {

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -57,7 +57,11 @@ fn runSnippet(
     var flog = dsl.FallbackLog.init(alloc);
     defer flog.deinit();
 
-    dsl.executePostInstall(alloc, &f, ruby_src, malt_prefix, &flog) catch |e| {
+    dsl.executePostInstall(alloc, .{
+        .name = f.name,
+        .version = f.version,
+        .pkg_version = f.pkg_version,
+    }, ruby_src, malt_prefix, &flog) catch |e| {
         return @as(?dsl.DslError, e);
     };
     return null;
@@ -820,7 +824,11 @@ test "interpreter: unknown method is logged in fallback log" {
     var flog = dsl.FallbackLog.init(alloc);
     defer flog.deinit();
 
-    dsl.executePostInstall(alloc, &f, "unknown_method_xyz", prefix, &flog) catch {};
+    dsl.executePostInstall(alloc, .{
+        .name = f.name,
+        .version = f.version,
+        .pkg_version = f.pkg_version,
+    }, "unknown_method_xyz", prefix, &flog) catch {};
 
     // Verify fallback log has at least one entry
     try testing.expect(flog.hasErrors());
@@ -1516,7 +1524,11 @@ test "parse_error: malformed source populates fallback log with location" {
     defer flog.deinit();
 
     // Stray `]` with no matching open — a guaranteed parser error.
-    const result = dsl.executePostInstall(alloc, &f, "ohai \"hi\"\n]\n", prefix, &flog);
+    const result = dsl.executePostInstall(alloc, .{
+        .name = f.name,
+        .version = f.version,
+        .pkg_version = f.pkg_version,
+    }, "ohai \"hi\"\n]\n", prefix, &flog);
     try testing.expectError(dsl.DslError.ParseError, result);
 
     // The diagnostics from Parser.diagnostics should now be on the log
@@ -2508,7 +2520,11 @@ test "interpreter: arena-owned path bindings leak-clean under testing.allocator"
         \\_a = HOMEBREW_PREFIX
         \\_a = HOMEBREW_CELLAR
     ;
-    try dsl.executePostInstall(testing.allocator, &f, src, prefix, &flog);
+    try dsl.executePostInstall(testing.allocator, .{
+        .name = f.name,
+        .version = f.version,
+        .pkg_version = f.pkg_version,
+    }, src, prefix, &flog);
 }
 
 // pushScope must propagate OOM instead of swallowing it. A silent failure
@@ -2526,7 +2542,7 @@ test "ExecContext.pushScope propagates OOM from the arena" {
         .arena = failing.allocator(),
         .cellar_path = "",
         .malt_prefix = "",
-        .paths = std.EnumArray(malt.dsl.interpreter.PathBinding, []const u8).initFill(""),
+        .paths = std.EnumArray(malt.dsl.context.PathBinding, []const u8).initFill(""),
         ._scopes = .empty,
         .sandbox_root = "",
         .fallback_log_writer = &flog,
@@ -2551,7 +2567,7 @@ test "ExecContext.pushMethodScope propagates OOM from the arena" {
         .arena = failing.allocator(),
         .cellar_path = "",
         .malt_prefix = "",
-        .paths = std.EnumArray(malt.dsl.interpreter.PathBinding, []const u8).initFill(""),
+        .paths = std.EnumArray(malt.dsl.context.PathBinding, []const u8).initFill(""),
         ._scopes = .empty,
         .sandbox_root = "",
         .fallback_log_writer = &flog,

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -2579,3 +2579,53 @@ test "ExecContext.pushMethodScope propagates OOM from the arena" {
     try testing.expectError(error.OutOfMemory, ctx.pushMethodScope());
     try testing.expectEqual(@as(usize, 0), ctx.scopeDepth());
 }
+
+// Pins the decoupled `FormulaRef` entrypoint: ExecContext must build its
+// path table from the narrow projection (name, version, pkg_version)
+// without importing the formula domain. Asserting paths rather than
+// construction proves both the API shape and the interpolation contract.
+test "ExecContext.init with FormulaRef projects cellar + pkgshare paths" {
+    var arena = testArena();
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var flog = dsl.FallbackLog.init(a);
+    defer flog.deinit();
+
+    const prefix = "/opt/testmalt";
+    var ctx = try dsl.ExecContext.init(a, .{
+        .name = "ffmpeg",
+        .version = "7.1.2",
+        .pkg_version = "7.1.2",
+    }, prefix, &flog);
+    defer ctx.deinit();
+
+    try testing.expectEqualStrings("/opt/testmalt/Cellar/ffmpeg/7.1.2", ctx.cellar_path);
+    try testing.expectEqualStrings("/opt/testmalt/Cellar/ffmpeg/7.1.2/bin", ctx.paths.get(.bin));
+    try testing.expectEqualStrings("/opt/testmalt/Cellar/ffmpeg/7.1.2/share/ffmpeg", ctx.paths.get(.pkgshare));
+    try testing.expectEqualStrings("/opt/testmalt/etc/ffmpeg", ctx.paths.get(.pkgetc));
+    try testing.expectEqualStrings("/opt/testmalt/opt/ffmpeg", ctx.paths.get(.opt_prefix));
+    try testing.expectEqualStrings("ffmpeg", ctx.formula_name);
+}
+
+// Pins the full entrypoint on FormulaRef: callers construct the narrow
+// projection and the DSL module never sees `Formula`. The snippet
+// exercises a binding so the interpolated `share/<name>` path name
+// is observable through the fallback log.
+test "executePostInstall accepts FormulaRef and binds formula_name" {
+    var arena = testArena();
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var flog = dsl.FallbackLog.init(a);
+    defer flog.deinit();
+
+    try dsl.executePostInstall(
+        a,
+        .{ .name = "acme", .version = "9.9.9", .pkg_version = "9.9.9" },
+        "_ = pkgshare\n",
+        "/opt/testmalt",
+        &flog,
+    );
+    try testing.expect(!flog.hasErrors());
+}

--- a/tests/ruby_subprocess_test.zig
+++ b/tests/ruby_subprocess_test.zig
@@ -409,7 +409,11 @@ test "ca-certificates-shape: dispatcher with unparseable siblings leaves flog cl
     var flog = malt.dsl.FallbackLog.init(alloc);
     defer flog.deinit();
 
-    try malt.dsl.executePostInstall(alloc, &f, body, "/tmp/malt_cacerts_test", &flog);
+    try malt.dsl.executePostInstall(alloc, .{
+        .name = f.name,
+        .version = f.version,
+        .pkg_version = f.pkg_version,
+    }, body, "/tmp/malt_cacerts_test", &flog);
 
     try testing.expect(!flog.hasFatal());
     try testing.expectEqual(@as(usize, 0), flog.entries.items.len);


### PR DESCRIPTION
## Description

Split `core/dsl/interpreter.zig` into `context.zig` (Scope + ExecContext + path bindings + joinPath) and `interpreter.zig` (tree-walker + `executePostInstall`). `ExecContext.init` and `executePostInstall` now take a narrow `FormulaRef { name, version, pkg_version }` projection, so `core/dsl` no longer imports `core/formula.zig`.

## Related Issue

- None

## Notes for Reviewers

- None

Generated with [Claude Code](https://claude.com/claude-code)