### PR TITLE
refactor(core/cask,cli/run): thread caller allocator to Child.init

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -181,6 +181,7 @@ pub fn build(b: *std.Build) void {
         "tests/hash_test.zig",
         "tests/patcher_test.zig",
         "tests/patch_facade_test.zig",
+        "tests/child_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -437,13 +437,13 @@ fn populateFromBundle(manifest: *manifest_mod.Manifest, db: *sqlite.Database, na
 
 fn openDb() !sqlite.Database {
     const prefix = atomic.maltPrefix();
-    var buf: [512]u8 = undefined;
-    const path = std.fmt.bufPrint(&buf, "{s}/db/malt.db", .{prefix}) catch
+    var db_dir_buf: [512]u8 = undefined;
+    const db_dir = std.fmt.bufPrint(&db_dir_buf, "{s}/db", .{prefix}) catch
         return BundleError.DatabaseError;
-    const db_dir = std.fmt.allocPrint(std.heap.page_allocator, "{s}/db", .{prefix}) catch
-        return BundleError.DatabaseError;
-    defer std.heap.page_allocator.free(db_dir);
     fs_compat.cwd().makePath(db_dir) catch {};
+    var path_buf: [512]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/malt.db", .{db_dir}) catch
+        return BundleError.DatabaseError;
     return sqlite.Database.open(path);
 }
 

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -49,7 +49,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
         // Already installed — just exec it
         output.info("Running installed {s}...", .{pkg_name});
-        return try execBinary(bin_path, cmd_args);
+        return try execBinary(allocator, bin_path, cmd_args);
     }
 }
 
@@ -149,10 +149,10 @@ fn ephemeralRun(
     const stderr = fs_compat.stderrFile();
     stderr.writeAll("---\n") catch {};
 
-    try execBinary(bin_path, cmd_args);
+    try execBinary(allocator, bin_path, cmd_args);
 }
 
-fn execBinary(path: []const u8, cmd_args: []const []const u8) !void {
+fn execBinary(allocator: std.mem.Allocator, path: []const u8, cmd_args: []const []const u8) !void {
     // Build argv: [path] ++ cmd_args
     var argv_buf: [64][]const u8 = undefined;
     argv_buf[0] = path;
@@ -161,7 +161,7 @@ fn execBinary(path: []const u8, cmd_args: []const []const u8) !void {
         argv_buf[i] = arg;
     }
 
-    var child = fs_compat.Child.init(argv_buf[0 .. argc + 1], std.heap.c_allocator);
+    var child = fs_compat.Child.init(argv_buf[0 .. argc + 1], allocator);
     child.spawn() catch {
         output.err("Failed to execute binary", .{});
         return error.Aborted;

--- a/src/cli/services.zig
+++ b/src/cli/services.zig
@@ -140,13 +140,13 @@ fn cmdLogs(allocator: std.mem.Allocator, rest: []const []const u8) !void {
 
 fn openDb() !sqlite.Database {
     const prefix = atomic.maltPrefix();
-    var buf: [512]u8 = undefined;
-    const path = std.fmt.bufPrint(&buf, "{s}/db/malt.db", .{prefix}) catch
+    var db_dir_buf: [512]u8 = undefined;
+    const db_dir = std.fmt.bufPrint(&db_dir_buf, "{s}/db", .{prefix}) catch
         return ServicesError.DatabaseError;
-    const db_dir = std.fmt.allocPrint(std.heap.page_allocator, "{s}/db", .{prefix}) catch
-        return ServicesError.DatabaseError;
-    defer std.heap.page_allocator.free(db_dir);
     fs_compat.cwd().makePath(db_dir) catch {};
+    var path_buf: [512]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/malt.db", .{db_dir}) catch
+        return ServicesError.DatabaseError;
     return sqlite.Database.open(path);
 }
 

--- a/src/cli/uninstall.zig
+++ b/src/cli/uninstall.zig
@@ -168,7 +168,7 @@ fn uninstallCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Da
     // Check if running (unless --force)
     if (!force) {
         if (info.appPath()) |app_path| {
-            if (cask_mod.CaskInstaller.isAppRunningPub(app_path)) {
+            if (cask_mod.CaskInstaller.isAppRunningPub(allocator, app_path)) {
                 output.err("{s} appears to be running. Quit the app first, or use --force.", .{token});
                 return error.Aborted;
             }

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -9,6 +9,7 @@ const client_mod = @import("../net/client.zig");
 const install_cmd = @import("../cli/install.zig");
 const archive_mod = @import("../fs/archive.zig");
 const hash_mod = @import("hash.zig");
+const child_mod = @import("child.zig");
 
 pub const CaskError = error{
     ParseFailed,
@@ -342,7 +343,7 @@ pub const CaskInstaller = struct {
             const app_path = std.mem.sliceTo(p, 0);
 
             // Check if the app is running (best-effort)
-            if (isAppRunning(app_path)) return CaskError.UninstallFailed;
+            if (isAppRunning(self.allocator, app_path)) return CaskError.UninstallFailed;
 
             // Remove the app bundle
             fs_compat.deleteTreeAbsolute(app_path) catch {};
@@ -432,20 +433,12 @@ pub const CaskInstaller = struct {
             "-mountpoint", mount_point,
             dmg_path,
         };
-        var mount_child = fs_compat.Child.init(&mount_argv, std.heap.c_allocator);
-        mount_child.spawn() catch return error.InstallFailed;
-        const mount_term = mount_child.wait() catch return error.InstallFailed;
-        switch (mount_term) {
-            .exited => |code| if (code != 0) return error.InstallFailed,
-            else => return error.InstallFailed,
-        }
+        child_mod.runOrFail(self.allocator, &mount_argv) catch return error.InstallFailed;
 
-        // Ensure we unmount on any exit
+        // Ensure we unmount on any exit — best-effort, swallow detach errors.
         defer {
             const detach_argv = [_][]const u8{ "hdiutil", "detach", mount_point, "-quiet" };
-            var detach = fs_compat.Child.init(&detach_argv, std.heap.c_allocator);
-            detach.spawn() catch {};
-            _ = detach.wait() catch {};
+            child_mod.runOrFail(self.allocator, &detach_argv) catch {};
             fs_compat.deleteDirAbsolute(mount_point) catch {};
         }
 
@@ -469,13 +462,7 @@ pub const CaskInstaller = struct {
 
         // Copy .app bundle using ditto (preserves resource forks, xattrs)
         const ditto_argv = [_][]const u8{ "ditto", src_app, dst_app };
-        var ditto_child = fs_compat.Child.init(&ditto_argv, std.heap.c_allocator);
-        ditto_child.spawn() catch return error.InstallFailed;
-        const ditto_term = ditto_child.wait() catch return error.InstallFailed;
-        switch (ditto_term) {
-            .exited => |code| if (code != 0) return error.InstallFailed,
-            else => return error.InstallFailed,
-        }
+        child_mod.runOrFail(self.allocator, &ditto_argv) catch return error.InstallFailed;
 
         return dst_app;
     }
@@ -493,13 +480,7 @@ pub const CaskInstaller = struct {
 
         // Extract with ditto -xk (handles macOS-specific ZIP features)
         const ditto_argv = [_][]const u8{ "ditto", "-xk", zip_path, extract_dir };
-        var ditto_child = fs_compat.Child.init(&ditto_argv, std.heap.c_allocator);
-        ditto_child.spawn() catch return error.InstallFailed;
-        const ditto_term = ditto_child.wait() catch return error.InstallFailed;
-        switch (ditto_term) {
-            .exited => |code| if (code != 0) return error.InstallFailed,
-            else => return error.InstallFailed,
-        }
+        child_mod.runOrFail(self.allocator, &ditto_argv) catch return error.InstallFailed;
 
         // Find the .app. app_name_buf owns the fallback past iterator teardown.
         var app_name_buf: [256]u8 = undefined;
@@ -519,13 +500,7 @@ pub const CaskInstaller = struct {
 
         // Move .app to /Applications
         const mv_argv = [_][]const u8{ "ditto", src_app, dst_app };
-        var mv_child = fs_compat.Child.init(&mv_argv, std.heap.c_allocator);
-        mv_child.spawn() catch return error.InstallFailed;
-        const mv_term = mv_child.wait() catch return error.InstallFailed;
-        switch (mv_term) {
-            .exited => |code| if (code != 0) return error.InstallFailed,
-            else => return error.InstallFailed,
-        }
+        child_mod.runOrFail(self.allocator, &mv_argv) catch return error.InstallFailed;
 
         return dst_app;
     }
@@ -577,13 +552,7 @@ pub const CaskInstaller = struct {
 
         fs_compat.deleteTreeAbsolute(dst_app) catch {};
         const mv_argv = [_][]const u8{ "ditto", src_app, dst_app };
-        var mv_child = fs_compat.Child.init(&mv_argv, std.heap.c_allocator);
-        mv_child.spawn() catch return error.InstallFailed;
-        const mv_term = mv_child.wait() catch return error.InstallFailed;
-        switch (mv_term) {
-            .exited => |code| if (code != 0) return error.InstallFailed,
-            else => return error.InstallFailed,
-        }
+        child_mod.runOrFail(self.allocator, &mv_argv) catch return error.InstallFailed;
         return dst_app;
     }
 
@@ -649,20 +618,14 @@ pub const CaskInstaller = struct {
     fn installPkg(self: *CaskInstaller, pkg_path: []const u8) ![]const u8 {
         // PKG installs require sudo — the caller must confirm
         const argv = [_][]const u8{ "sudo", "installer", "-pkg", pkg_path, "-target", "/" };
-        var child = fs_compat.Child.init(&argv, std.heap.c_allocator);
-        child.spawn() catch return error.InstallFailed;
-        const term = child.wait() catch return error.InstallFailed;
-        switch (term) {
-            .exited => |code| if (code != 0) return error.InstallFailed,
-            else => return error.InstallFailed,
-        }
+        child_mod.runOrFail(self.allocator, &argv) catch return error.InstallFailed;
         // PKG installs don't have a single app path — record the pkg location
         return std.fmt.allocPrint(self.allocator, "{s}", .{pkg_path}) catch return error.OutOfMemory;
     }
 
     /// Public wrapper for isAppRunning (used by uninstall.zig).
-    pub fn isAppRunningPub(app_path: []const u8) bool {
-        return isAppRunning(app_path);
+    pub fn isAppRunningPub(allocator: std.mem.Allocator, app_path: []const u8) bool {
+        return isAppRunning(allocator, app_path);
     }
 
     fn recordCaskroom(self: *CaskInstaller, cask: *const Cask) !void {
@@ -739,14 +702,14 @@ pub fn verifyFileSha256(file_path: []const u8, expected: ?[]const u8) !void {
 }
 
 /// Check if an application is currently running by its path.
-fn isAppRunning(app_path: []const u8) bool {
+fn isAppRunning(allocator: std.mem.Allocator, app_path: []const u8) bool {
     const argv = [_][]const u8{ "pgrep", "-f", app_path };
-    var child = fs_compat.Child.init(&argv, std.heap.c_allocator);
+    var child = fs_compat.Child.init(&argv, allocator);
     child.spawn() catch return false;
     const term = child.wait() catch return false;
     return switch (term) {
         .exited => |code| code == 0, // pgrep exits 0 if match found
-        else => false,
+        .signal, .stopped, .unknown => false,
     };
 }
 

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -154,7 +154,7 @@ pub fn materializeWithCellar(
     }
 
     // Clone from store to Cellar
-    clonefile.cloneTree(src, cellar_path) catch return CellarError.CloneFailed;
+    clonefile.cloneTree(allocator, src, cellar_path) catch return CellarError.CloneFailed;
 
     const new_prefix = atomic.maltPrefix();
 

--- a/src/core/child.zig
+++ b/src/core/child.zig
@@ -1,0 +1,30 @@
+//! malt — shared spawn+wait helper for one-shot external commands.
+//! Consolidates the Child.init/spawn/wait/switch shape that every
+//! cask-install step used to duplicate, so the caller's allocator is
+//! the single source of memory for every spawn.
+
+const std = @import("std");
+const fs_compat = @import("../fs/compat.zig");
+
+pub const ChildError = error{
+    SpawnFailed,
+    WaitFailed,
+    /// Child did not exit cleanly with code 0 — covers non-zero exits,
+    /// signal kills, stops, and the "unknown" termination path.
+    NonZeroExit,
+};
+
+/// Spawn `argv`, wait for it, and collapse the outcome into a narrow
+/// error set. `allocator` backs argv/env dup and any pipe reads.
+pub fn runOrFail(
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+) ChildError!void {
+    var child = fs_compat.Child.init(argv, allocator);
+    child.spawn() catch return error.SpawnFailed;
+    const term = child.wait() catch return error.WaitFailed;
+    switch (term) {
+        .exited => |code| if (code != 0) return error.NonZeroExit,
+        .signal, .stopped, .unknown => return error.NonZeroExit,
+    }
+}

--- a/src/core/store.zig
+++ b/src/core/store.zig
@@ -41,7 +41,7 @@ pub const Store = struct {
         // Check if already committed (idempotent)
         fs_compat.cwd().access(dst, .{}) catch {
             // Not exists — do the rename
-            atomic.atomicRename(src, dst) catch return StoreError.CommitFailed;
+            atomic.atomicRename(self.allocator, src, dst) catch return StoreError.CommitFailed;
             return;
         };
         // Already exists — idempotent success

--- a/src/fs/atomic.zig
+++ b/src/fs/atomic.zig
@@ -110,10 +110,10 @@ pub fn maltPrefix() [:0]const u8 {
 /// from a crash standpoint, but the end state (dst present, src absent)
 /// matches `rename` semantics; a crash mid-way leaves the tmp source
 /// intact for the next housekeeping sweep to clean up.
-pub fn atomicRename(src_path: []const u8, dst_path: []const u8) !void {
+pub fn atomicRename(allocator: std.mem.Allocator, src_path: []const u8, dst_path: []const u8) !void {
     fs_compat.renameAbsolute(src_path, dst_path) catch |e| switch (e) {
         error.CrossDevice => {
-            try clonefile.cloneTree(src_path, dst_path);
+            try clonefile.cloneTree(allocator, src_path, dst_path);
             fs_compat.deleteTreeAbsolute(src_path) catch {};
         },
         else => return e,

--- a/src/fs/clonefile.zig
+++ b/src/fs/clonefile.zig
@@ -13,8 +13,10 @@ pub const CloneError = error{
 
 /// Clone a directory tree using the macOS APFS clonefile(2) syscall.
 /// Falls back to a recursive copy when the filesystem does not support
-/// copy-on-write clones (ENOTSUP).
-pub fn cloneTree(src_path: []const u8, dst_path: []const u8) CloneError!void {
+/// copy-on-write clones (ENOTSUP). `allocator` only participates in the
+/// fallback path (for the directory walker); APFS-native clones are a
+/// single syscall and do not allocate.
+pub fn cloneTree(allocator: std.mem.Allocator, src_path: []const u8, dst_path: []const u8) CloneError!void {
     const src_z = std.posix.toPosixPath(src_path) catch return error.IoError;
     const dst_z = std.posix.toPosixPath(dst_path) catch return error.IoError;
 
@@ -26,7 +28,7 @@ pub fn cloneTree(src_path: []const u8, dst_path: []const u8) CloneError!void {
     const e: std.c.E = @enumFromInt(std.c._errno().*);
     switch (e) {
         .OPNOTSUPP => {
-            copyTreeFallback(src_path, dst_path) catch return error.IoError;
+            copyTreeFallback(allocator, src_path, dst_path) catch return error.IoError;
         },
         .EXIST => return error.AlreadyExists,
         .ACCES, .PERM => return error.PermissionDenied,
@@ -46,7 +48,7 @@ pub fn isApfs(path: []const u8) bool {
     return std.mem.eql(u8, fs_name, "apfs");
 }
 
-pub fn copyTreeFallback(src_path: []const u8, dst_path: []const u8) !void {
+pub fn copyTreeFallback(allocator: std.mem.Allocator, src_path: []const u8, dst_path: []const u8) !void {
     // Open source directory.
     var src_dir = fs_compat.openDirAbsolute(src_path, .{ .iterate = true }) catch return error.FileNotFound;
     defer src_dir.close();
@@ -61,7 +63,7 @@ pub fn copyTreeFallback(src_path: []const u8, dst_path: []const u8) !void {
     defer dst_dir.close();
 
     // Walk the source tree.
-    var walker = src_dir.walk(std.heap.c_allocator) catch return error.OutOfMemory;
+    var walker = src_dir.walk(allocator) catch return error.OutOfMemory;
     defer walker.deinit();
 
     while (walker.next() catch return error.AccessDenied) |entry| {

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2,6 +2,7 @@
 //! Re-exports all modules that tests need to access.
 
 pub const cask = @import("core/cask.zig");
+pub const child = @import("core/child.zig");
 pub const hash = @import("core/hash.zig");
 pub const cellar = @import("core/cellar.zig");
 pub const deps = @import("core/deps.zig");

--- a/tests/atomic_test.zig
+++ b/tests/atomic_test.zig
@@ -293,7 +293,7 @@ test "atomicRename moves a file within the same filesystem" {
     try f.writeAll("payload");
     f.close();
 
-    try atomic.atomicRename(src, dst);
+    try atomic.atomicRename(testing.allocator, src, dst);
     try testing.expectError(error.FileNotFound, malt.fs_compat.openFileAbsolute(src, .{}));
 
     const moved = try malt.fs_compat.openFileAbsolute(dst, .{});
@@ -401,7 +401,7 @@ test "atomicRename moves a directory tree within the same filesystem" {
         try f.writeAll("payload");
     }
 
-    try atomic.atomicRename(src, dst);
+    try atomic.atomicRename(testing.allocator, src, dst);
     try testing.expectError(error.FileNotFound, malt.fs_compat.openDirAbsolute(src, .{}));
 
     var moved = try malt.fs_compat.openDirAbsolute(dst, .{});

--- a/tests/cask_extra_test.zig
+++ b/tests/cask_extra_test.zig
@@ -12,7 +12,7 @@ const schema = malt.schema;
 test "isAppRunningPub returns false for a path no pgrep match can cover" {
     // An impossible sentinel path — pgrep will not match, so isAppRunning
     // exits non-zero and the wrapper returns false.
-    try testing.expect(!cask.CaskInstaller.isAppRunningPub("/nonexistent/Sentinel-path-never-running.app"));
+    try testing.expect(!cask.CaskInstaller.isAppRunningPub(testing.allocator, "/nonexistent/Sentinel-path-never-running.app"));
 }
 
 test "CaskInstaller.uninstall on a missing token returns UninstallFailed" {

--- a/tests/child_test.zig
+++ b/tests/child_test.zig
@@ -1,0 +1,26 @@
+//! malt — core/child runOrFail helper tests.
+
+const std = @import("std");
+const malt = @import("malt");
+const child_mod = malt.child;
+
+test "runOrFail returns void on exit code 0" {
+    const argv = [_][]const u8{ "/bin/sh", "-c", "exit 0" };
+    try child_mod.runOrFail(std.testing.allocator, &argv);
+}
+
+test "runOrFail returns NonZeroExit on exit code 42" {
+    const argv = [_][]const u8{ "/bin/sh", "-c", "exit 42" };
+    try std.testing.expectError(
+        child_mod.ChildError.NonZeroExit,
+        child_mod.runOrFail(std.testing.allocator, &argv),
+    );
+}
+
+test "runOrFail returns SpawnFailed when program does not exist" {
+    const argv = [_][]const u8{"/nonexistent/binary/malt_child_test"};
+    try std.testing.expectError(
+        child_mod.ChildError.SpawnFailed,
+        child_mod.runOrFail(std.testing.allocator, &argv),
+    );
+}

--- a/tests/clonefile_test.zig
+++ b/tests/clonefile_test.zig
@@ -62,7 +62,7 @@ test "cloneTree duplicates a small directory tree" {
     var dst_buf: [512]u8 = undefined;
     const dst = try std.fmt.bufPrint(&dst_buf, "{s}/dst", .{root});
 
-    try clonefile.cloneTree(src, dst);
+    try clonefile.cloneTree(testing.allocator, src, dst);
 
     // Verify the cloned top-level file exists with the same contents.
     var verify_buf: [512]u8 = undefined;
@@ -97,7 +97,7 @@ test "cloneTree fails with AlreadyExists when dst already exists" {
     // On non-APFS filesystems the fallback may overwrite gracefully, so we
     // only assert the error on APFS.
     try malt.fs_compat.makeDirAbsolute(dst);
-    const result = clonefile.cloneTree(src, dst);
+    const result = clonefile.cloneTree(testing.allocator, src, dst);
     if (clonefile.isApfs("/tmp")) {
         try testing.expectError(clonefile.CloneError.AlreadyExists, result);
     } else {
@@ -111,6 +111,7 @@ test "cloneTree errors on a missing source when the fallback path is taken" {
     // not exist. clonefile(2) will fail with ENOENT → IoError. We also
     // cover the non-APFS fallback with a missing src below.
     const result = clonefile.cloneTree(
+        testing.allocator,
         "/definitely/not/a/real/path",
         "/tmp/malt_clonefile_test_missing_dst",
     );
@@ -134,7 +135,7 @@ test "copyTreeFallback duplicates files, subdirs, and symlinks" {
     const link_path = try std.fmt.bufPrint(&link_path_buf, "{s}/link.txt", .{src});
     malt.fs_compat.cwd().symLink("hello.txt", link_path, .{}) catch {};
 
-    try clonefile.copyTreeFallback(src, dst);
+    try clonefile.copyTreeFallback(testing.allocator, src, dst);
 
     // Verify the top-level file is present.
     var check_buf: [512]u8 = undefined;
@@ -163,7 +164,7 @@ test "copyTreeFallback is idempotent when the destination already exists" {
     const dst = try std.fmt.bufPrint(&dst_buf, "{s}/dst_idem", .{root});
 
     try malt.fs_compat.makeDirAbsolute(dst);
-    try clonefile.copyTreeFallback(src, dst);
+    try clonefile.copyTreeFallback(testing.allocator, src, dst);
 
     // Verify the nested file was still copied.
     var check_buf: [512]u8 = undefined;
@@ -175,7 +176,7 @@ test "copyTreeFallback is idempotent when the destination already exists" {
 test "copyTreeFallback errors when source directory does not exist" {
     try testing.expectError(
         error.FileNotFound,
-        clonefile.copyTreeFallback("/not/a/real/source/dir", "/tmp/malt_clonefile_nowhere"),
+        clonefile.copyTreeFallback(testing.allocator, "/not/a/real/source/dir", "/tmp/malt_clonefile_nowhere"),
     );
 }
 
@@ -220,7 +221,7 @@ test "cloneTree falls back to copyTree on a non-APFS volume" {
     defer malt.fs_compat.deleteTreeAbsolute(dst) catch {};
 
     // Without the fix, OPNOTSUPP is misclassified and this returns IoError.
-    try clonefile.cloneTree(src, dst);
+    try clonefile.cloneTree(testing.allocator, src, dst);
 
     var verify_buf: [512]u8 = undefined;
     const copied = try std.fmt.bufPrint(&verify_buf, "{s}/hello.txt", .{dst});


### PR DESCRIPTION
## Description

Make external-command spawns in `core/cask` and `cli/run` honour the
caller's allocator instead of reaching for `std.heap.c_allocator`. Adds a
single `runOrFail(allocator, argv)` helper in `core/child.zig` and
replaces seven near-identical spawn+wait+switch blocks in `cask.zig`
with one-line calls.

Net effect: every cask install step is traceable to a single allocator,
the cask installer's spawn surface is 32 LOC lighter, and no module
under `core/` or `cli/` pulls a hidden global allocator for process
spawn or throwaway formatting.

## Related Issue

- None

## Notes for Reviewers

- None