### PR TITLE
refactor: snake_case value constants

### DIFF
--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -397,13 +397,13 @@ fn populateFromInstalled(manifest: *manifest_mod.Manifest, db: *sqlite.Database)
 
     manifest.formulas = formulas.toOwnedSlice(a) catch return BundleError.DatabaseError;
     manifest.casks = casks.toOwnedSlice(a) catch return BundleError.DatabaseError;
-    manifest.version = manifest_mod.SCHEMA_VERSION;
+    manifest.version = manifest_mod.schema_version;
 }
 
 fn populateFromBundle(manifest: *manifest_mod.Manifest, db: *sqlite.Database, name: []const u8) !void {
     const a = manifest.allocator();
     manifest.name = a.dupe(u8, name) catch return BundleError.DatabaseError;
-    manifest.version = manifest_mod.SCHEMA_VERSION;
+    manifest.version = manifest_mod.schema_version;
 
     var taps: std.ArrayList([]const u8) = .empty;
     var formulas: std.ArrayList(manifest_mod.FormulaEntry) = .empty;

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -20,14 +20,14 @@ const release = @import("../update/release.zig");
 const verify = @import("../update/verify.zig");
 const swap = @import("../update/swap.zig");
 
-const CURRENT_VERSION = @import("../version.zig").value;
-const RELEASES_API = "https://api.github.com/repos/indaco/malt/releases/latest";
-const CHECKSUMS_NAME = "checksums.txt";
-const SIGSTORE_NAME = "checksums.txt.sigstore.json";
+const current_version = @import("../version.zig").value;
+const releases_api = "https://api.github.com/repos/indaco/malt/releases/latest";
+const checksums_name = "checksums.txt";
+const sigstore_name = "checksums.txt.sigstore.json";
 // Pins the signature to the exact workflow that produced the release.
 // A token able to upload a replacement checksums.txt cannot forge this.
-const CERT_IDENTITY_REGEX = "^https://github.com/indaco/malt/\\.github/workflows/release\\.yml@";
-const OIDC_ISSUER = "https://token.actions.githubusercontent.com";
+const cert_identity_regex = "^https://github.com/indaco/malt/\\.github/workflows/release\\.yml@";
+const oidc_issuer = "https://token.actions.githubusercontent.com";
 
 pub const Opts = struct {
     check: bool = false,
@@ -61,13 +61,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         return;
     }
 
-    output.info("Current version: {s}", .{CURRENT_VERSION});
+    output.info("Current version: {s}", .{current_version});
     output.info("Checking for updates...", .{});
 
     var http = client_mod.HttpClient.init(allocator);
     defer http.deinit();
 
-    var resp = http.get(RELEASES_API) catch {
+    var resp = http.get(releases_api) catch {
         output.err("Cannot reach GitHub API", .{});
         return error.Aborted;
     };
@@ -97,11 +97,11 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     };
     const latest = if (tag.len > 0 and tag[0] == 'v') tag[1..] else tag;
 
-    if (std.mem.eql(u8, latest, CURRENT_VERSION)) {
-        output.info("Already up to date ({s})", .{CURRENT_VERSION});
+    if (std.mem.eql(u8, latest, current_version)) {
+        output.info("Already up to date ({s})", .{current_version});
         return;
     }
-    output.info("New version available: {s} (current: {s})", .{ latest, CURRENT_VERSION });
+    output.info("New version available: {s} (current: {s})", .{ latest, current_version });
 
     if (opts.check) {
         output.info("Run 'mt version update' to install", .{});
@@ -128,8 +128,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         output.err("No matching binary found for darwin {s}", .{arch_str});
         return error.Aborted;
     };
-    const checksums_url = release.pickAssetUrlByName(assets, CHECKSUMS_NAME) orelse {
-        output.err("Release is missing {s}", .{CHECKSUMS_NAME});
+    const checksums_url = release.pickAssetUrlByName(assets, checksums_name) orelse {
+        output.err("Release is missing {s}", .{checksums_name});
         return error.Aborted;
     };
     const archive_name = std.fs.path.basename(tarball_url);
@@ -149,7 +149,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     output.info("Downloading {s}...", .{archive_name});
     const tarball_path = try writeDownload(allocator, &http, tarball_url, scratch, archive_name);
     defer allocator.free(tarball_path);
-    const checksums_path = try writeDownload(allocator, &http, checksums_url, scratch, CHECKSUMS_NAME);
+    const checksums_path = try writeDownload(allocator, &http, checksums_url, scratch, checksums_name);
     defer allocator.free(checksums_path);
 
     // --- verification phase ---
@@ -345,11 +345,11 @@ fn runVerification(rv: RunVerification) !void {
         return;
     }
 
-    const sigstore_url = release.pickAssetUrlByName(rv.assets, SIGSTORE_NAME) orelse {
-        output.err("Release is missing {s}", .{SIGSTORE_NAME});
+    const sigstore_url = release.pickAssetUrlByName(rv.assets, sigstore_name) orelse {
+        output.err("Release is missing {s}", .{sigstore_name});
         return error.Aborted;
     };
-    const sigstore_path = try writeDownload(rv.allocator, rv.http, sigstore_url, rv.scratch, SIGSTORE_NAME);
+    const sigstore_path = try writeDownload(rv.allocator, rv.http, sigstore_url, rv.scratch, sigstore_name);
     defer rv.allocator.free(sigstore_path);
 
     output.info("Verifying cosign signature + SHA256 checksum...", .{});
@@ -358,8 +358,8 @@ fn runVerification(rv: RunVerification) !void {
         .checksums_path = rv.checksums_path,
         .sigstore_path = sigstore_path,
         .archive_name = rv.archive_name,
-        .cert_identity_regex = CERT_IDENTITY_REGEX,
-        .oidc_issuer = OIDC_ISSUER,
+        .cert_identity_regex = cert_identity_regex,
+        .oidc_issuer = oidc_issuer,
     }) catch |e| switch (e) {
         error.CosignNotFound => {
             output.err("cosign is required to verify the release signature.", .{});
@@ -368,11 +368,11 @@ fn runVerification(rv: RunVerification) !void {
             return error.Aborted;
         },
         error.CosignVerifyFailed => {
-            output.err("cosign signature verification failed for {s}", .{CHECKSUMS_NAME});
+            output.err("cosign signature verification failed for {s}", .{checksums_name});
             return error.Aborted;
         },
         error.ChecksumMissing => {
-            output.err("Checksum for {s} not listed in {s}", .{ rv.archive_name, CHECKSUMS_NAME });
+            output.err("Checksum for {s} not listed in {s}", .{ rv.archive_name, checksums_name });
             return error.Aborted;
         },
         error.ChecksumMismatch => {

--- a/src/core/bundle/brewfile.zig
+++ b/src/core/bundle/brewfile.zig
@@ -97,7 +97,7 @@ pub fn parse(
     m.formulas = formulas.toOwnedSlice(a) catch return BrewfileError.OutOfMemory;
     m.casks = casks.toOwnedSlice(a) catch return BrewfileError.OutOfMemory;
     m.services = services.toOwnedSlice(a) catch return BrewfileError.OutOfMemory;
-    m.version = manifest_mod.SCHEMA_VERSION;
+    m.version = manifest_mod.schema_version;
     return m;
 }
 

--- a/src/core/bundle/manifest.zig
+++ b/src/core/bundle/manifest.zig
@@ -6,7 +6,7 @@
 
 const std = @import("std");
 
-pub const SCHEMA_VERSION: u32 = 1;
+pub const schema_version: u32 = 1;
 
 pub const ManifestError = error{
     UnsupportedVersion,
@@ -42,7 +42,7 @@ pub const ServiceEntry = struct {
 pub const Manifest = struct {
     arena: std.heap.ArenaAllocator,
     name: []const u8 = "",
-    version: u32 = SCHEMA_VERSION,
+    version: u32 = schema_version,
     formulas: []FormulaEntry = &.{},
     casks: []CaskEntry = &.{},
     taps: [][]const u8 = &.{},
@@ -76,8 +76,8 @@ pub fn parseJson(parent: std.mem.Allocator, json_text: []const u8) ManifestError
 
     if (obj.get("version")) |v| {
         if (v != .integer) return ManifestError.MalformedJson;
-        if (v.integer != @as(i64, SCHEMA_VERSION)) return ManifestError.UnsupportedVersion;
-        manifest.version = SCHEMA_VERSION;
+        if (v.integer != @as(i64, schema_version)) return ManifestError.UnsupportedVersion;
+        manifest.version = schema_version;
     }
 
     if (obj.get("name")) |v| {

--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -44,7 +44,7 @@ pub fn describeError(err: RubyError) []const u8 {
 /// Upper bound on a fetched formula .rb blob. The Homebrew-wide 99th
 /// percentile is ~40 KiB; 1 MiB is orders of magnitude of headroom
 /// without giving a hostile response room to grow.
-const MAX_FORMULA_RB_BYTES: usize = 1024 * 1024;
+const max_formula_rb_bytes: usize = 1024 * 1024;
 
 /// Detect a usable Ruby interpreter. Returns a caller-owned absolute path
 /// or null. Caller must free the returned slice with `allocator.free`.
@@ -164,7 +164,7 @@ pub fn fetchPostInstallFromGitHub(allocator: std.mem.Allocator, name: []const u8
     var resp = http.get(url) catch return null;
     defer resp.deinit();
     if (resp.status != 200) return null;
-    if (resp.body.len == 0 or resp.body.len > MAX_FORMULA_RB_BYTES) return null;
+    if (resp.body.len == 0 or resp.body.len > max_formula_rb_bytes) return null;
 
     var actual_hex: [pins.SHA256_HEX_LEN]u8 = undefined;
     pins.sha256Hex(resp.body, &actual_hex);

--- a/src/core/services/plist.zig
+++ b/src/core/services/plist.zig
@@ -48,15 +48,15 @@ pub const ValidationError = error{
 };
 
 /// Cap on argv count. Real launchd services carry fewer than a dozen.
-pub const MAX_PROGRAM_ARGS: usize = 64;
+pub const max_program_args: usize = 64;
 /// Cap on a single argv or path string.
-pub const MAX_ARG_LEN: usize = 4096;
+pub const max_arg_len: usize = 4096;
 
 /// Reject launchd interpreters as the leading executable. If a formula
 /// actually ships its own cellar-local `sh` it must invoke it via its
 /// cellar path — not `/bin/sh`, which launchd would happily run with
 /// whatever argv follows.
-const FORBIDDEN_HEADS = [_][]const u8{
+const forbidden_heads = [_][]const u8{
     "/bin/sh",      "/bin/bash",     "/bin/zsh",        "/bin/ksh",
     "/usr/bin/sh",  "/usr/bin/bash", "/usr/bin/zsh",    "/usr/bin/env",
     "/usr/bin/ksh", "/usr/bin/tcsh", "/usr/bin/python", "/usr/bin/perl",
@@ -78,7 +78,7 @@ pub fn validate(
     malt_prefix: []const u8,
 ) ValidationError!void {
     if (spec.program_args.len == 0) return ValidationError.Empty;
-    if (spec.program_args.len > MAX_PROGRAM_ARGS) return ValidationError.TooManyArgs;
+    if (spec.program_args.len > max_program_args) return ValidationError.TooManyArgs;
 
     for (spec.program_args) |a| try checkString(a);
     try checkString(spec.label);
@@ -92,7 +92,7 @@ pub fn validate(
 
     const head = spec.program_args[0];
     if (head.len == 0 or head[0] != '/') return ValidationError.RelativeExecutable;
-    for (FORBIDDEN_HEADS) |h| {
+    for (forbidden_heads) |h| {
         if (std.mem.eql(u8, head, h)) return ValidationError.InterpreterBait;
     }
 
@@ -120,7 +120,7 @@ pub fn validate(
 }
 
 fn checkString(s: []const u8) ValidationError!void {
-    if (s.len > MAX_ARG_LEN) return ValidationError.ArgTooLong;
+    if (s.len > max_arg_len) return ValidationError.ArgTooLong;
     if (std.mem.indexOfScalar(u8, s, 0) != null) return ValidationError.EmbeddedNul;
 }
 

--- a/src/fs/atomic.zig
+++ b/src/fs/atomic.zig
@@ -4,7 +4,7 @@ const clonefile = @import("clonefile.zig");
 
 /// 512 bytes: ~4× real Homebrew prefix length, still small enough that
 /// anything past it is either a bug or overflow bait.
-pub const MAX_PREFIX_LEN: usize = 512;
+pub const max_prefix_len: usize = 512;
 
 pub const PrefixError = error{
     Empty,
@@ -41,7 +41,7 @@ pub fn isAllowedNameByte(b: u8) bool {
 /// downstream code can assume absolute, NUL-free, traversal-free.
 pub fn validatePrefix(prefix: []const u8) PrefixError!void {
     if (prefix.len == 0) return PrefixError.Empty;
-    if (prefix.len > MAX_PREFIX_LEN) return PrefixError.TooLong;
+    if (prefix.len > max_prefix_len) return PrefixError.TooLong;
     if (prefix[0] != '/') return PrefixError.NotAbsolute;
     if (std.mem.indexOfScalar(u8, prefix, 0) != null) return PrefixError.EmbeddedNul;
     // Tight charset closes the BUG-007/BUG-019 injection class — quotes,

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,19 +13,19 @@ else
     std.debug.simple_panic;
 
 /// Global interrupt flag — set by SIGINT handler, checked at install step boundaries.
-var g_interrupted: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+var interrupted: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 
 pub fn isInterrupted() bool {
-    return g_interrupted.load(.acquire);
+    return interrupted.load(.acquire);
 }
 
 /// Test-only flag override — raising real SIGINT would race the test runner.
 pub fn setInterruptedForTest(v: bool) void {
-    g_interrupted.store(v, .release);
+    interrupted.store(v, .release);
 }
 
 fn sigintHandler(_: std.c.SIG) callconv(.c) void {
-    g_interrupted.store(true, .release);
+    interrupted.store(true, .release);
 }
 
 // CLI command modules
@@ -131,7 +131,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
         }
     };
 
-    // Register SIGINT handler so Ctrl-C sets g_interrupted instead of
+    // Register SIGINT handler so Ctrl-C sets interrupted instead of
     // immediately killing the process. Install commands check the flag at
     // step boundaries and clean up before exiting.
     const act = std.posix.Sigaction{

--- a/src/net/api.zig
+++ b/src/net/api.zig
@@ -6,13 +6,13 @@ const fs_compat = @import("../fs/compat.zig");
 const atomic = @import("../fs/atomic.zig");
 const client_mod = @import("client.zig");
 
-const BASE_URL = "https://formulae.brew.sh/api";
-const CACHE_TTL_SECS: i64 = 300; // 5 minutes
+const base_url = "https://formulae.brew.sh/api";
+const cache_ttl_secs: i64 = 300; // 5 minutes
 
 /// Names-index TTL. The full Homebrew name list changes on the order of days
 /// (new formulae merged, tokens renamed), so a 24 h window avoids burning
 /// ~40 MiB of fetch per search while still picking up changes within a day.
-pub const INDEX_TTL_SECS: i64 = 24 * 60 * 60;
+pub const index_ttl_secs: i64 = 24 * 60 * 60;
 
 pub const ApiError = error{
     NotFound,
@@ -136,7 +136,7 @@ pub const BrewApi = struct {
     pub fn fetchFormula(self: *BrewApi, name: []const u8) ApiError![]const u8 {
         try validateName(name);
         var url_buf: [512]u8 = undefined;
-        const url = std.fmt.bufPrint(&url_buf, BASE_URL ++ "/formula/{s}.json", .{name}) catch
+        const url = std.fmt.bufPrint(&url_buf, base_url ++ "/formula/{s}.json", .{name}) catch
             return ApiError.OutOfMemory;
         return self.fetchCached(name, url, "formula_");
     }
@@ -145,7 +145,7 @@ pub const BrewApi = struct {
     pub fn fetchCask(self: *BrewApi, token: []const u8) ApiError![]const u8 {
         try validateName(token);
         var url_buf: [512]u8 = undefined;
-        const url = std.fmt.bufPrint(&url_buf, BASE_URL ++ "/cask/{s}.json", .{token}) catch
+        const url = std.fmt.bufPrint(&url_buf, base_url ++ "/cask/{s}.json", .{token}) catch
             return ApiError.OutOfMemory;
         return self.fetchCached(token, url, "cask_");
     }
@@ -189,7 +189,7 @@ pub const BrewApi = struct {
         const stat = fs_compat.cwd().statFile(cache_path) catch return false;
         const now = fs_compat.timestamp();
         const mtime_secs: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_s));
-        return now - mtime_secs <= CACHE_TTL_SECS;
+        return now - mtime_secs <= cache_ttl_secs;
     }
 
     /// Fetch the newline-delimited names index for all formulae or casks.
@@ -205,8 +205,8 @@ pub const BrewApi = struct {
         if (self.readNamesIndex(key)) |cached| return cached;
 
         const url: []const u8 = switch (kind) {
-            .formula => BASE_URL ++ "/formula.json",
-            .cask => BASE_URL ++ "/cask.json",
+            .formula => base_url ++ "/formula.json",
+            .cask => base_url ++ "/cask.json",
         };
         var resp = self.http.get(url) catch return ApiError.ApiUnreachable;
         defer resp.deinit();
@@ -228,7 +228,7 @@ pub const BrewApi = struct {
         const stat = fs_compat.cwd().statFile(p) catch return null;
         const now = fs_compat.timestamp();
         const mtime_secs: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_s));
-        if (now - mtime_secs > INDEX_TTL_SECS) return null;
+        if (now - mtime_secs > index_ttl_secs) return null;
 
         const file = fs_compat.cwd().openFile(p, .{}) catch return null;
         defer file.close();
@@ -306,7 +306,7 @@ pub const BrewApi = struct {
         const stat = fs_compat.cwd().statFile(cache_path) catch return null;
         const now = fs_compat.timestamp();
         const mtime_secs: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_s));
-        if (now - mtime_secs > CACHE_TTL_SECS) return null;
+        if (now - mtime_secs > cache_ttl_secs) return null;
 
         // Read file
         const file = fs_compat.cwd().openFile(cache_path, .{}) catch return null;
@@ -353,13 +353,13 @@ pub const BrewApi = struct {
         const stat = fs_compat.cwd().statFile(cache_path) catch return false;
         const now = fs_compat.timestamp();
         const mtime_secs: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_s));
-        if (now - mtime_secs > CACHE_TTL_SECS) return false;
+        if (now - mtime_secs > cache_ttl_secs) return false;
         return true;
     }
 
     /// Write a zero-byte marker file to record that this key 404s. The
     /// file's mtime is the TTL anchor — `readNotFoundCache` checks it
-    /// against `CACHE_TTL_SECS`. Best-effort; failures are silent so a
+    /// against `cache_ttl_secs`. Best-effort; failures are silent so a
     /// missing cache dir never breaks an install.
     pub fn writeNotFoundCache(self: *const BrewApi, key: []const u8, prefix: []const u8) void {
         var dir_buf: [512]u8 = undefined;
@@ -377,9 +377,9 @@ pub const BrewApi = struct {
     }
 
     /// Maximum cache size (200 MB). Entries are evicted by age (oldest first).
-    const MAX_CACHE_BYTES: u64 = 200 * 1024 * 1024;
+    const max_cache_bytes: u64 = 200 * 1024 * 1024;
 
-    /// Evict oldest cache entries until total size is under MAX_CACHE_BYTES.
+    /// Evict oldest cache entries until total size is under max_cache_bytes.
     /// Called by `malt cleanup` and `malt doctor`.
     pub fn evictCache(self: *BrewApi) u32 {
         var dir_buf: [512]u8 = undefined;
@@ -405,7 +405,7 @@ pub const BrewApi = struct {
             total_size += stat.size;
         }
 
-        if (total_size <= MAX_CACHE_BYTES) return 0;
+        if (total_size <= max_cache_bytes) return 0;
 
         // Sort by mtime ascending (oldest first)
         std.mem.sort(Entry, entries.items, {}, struct {
@@ -416,7 +416,7 @@ pub const BrewApi = struct {
 
         var evicted: u32 = 0;
         for (entries.items) |entry| {
-            if (total_size <= MAX_CACHE_BYTES) break;
+            if (total_size <= max_cache_bytes) break;
             const name = entry.name_buf[0..entry.name_len];
             dir.deleteFile(name) catch continue;
             total_size -|= entry.size;

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -89,7 +89,7 @@ pub const HttpClient = struct {
     client: std.http.Client,
 
     /// Per-request timeout in nanoseconds. Default: 30 seconds.
-    timeout_ns: u64 = DEFAULT_TIMEOUT_NS,
+    timeout_ns: u64 = default_timeout_ns,
 
     /// Lazily-allocated decompression windows, reused across requests. These
     /// are sized for the worst case per encoding (zstd ~128 KiB, flate
@@ -100,9 +100,9 @@ pub const HttpClient = struct {
     zstd_window: ?[]u8 = null,
     flate_window: ?[]u8 = null,
 
-    const DEFAULT_TIMEOUT_NS: u64 = 30 * std.time.ns_per_s;
+    const default_timeout_ns: u64 = 30 * std.time.ns_per_s;
     /// Blob downloads (bottles, cask DMGs) get a much longer timeout.
-    const BLOB_TIMEOUT_NS: u64 = 600 * std.time.ns_per_s; // 10 minutes
+    const blob_timeout_ns: u64 = 600 * std.time.ns_per_s; // 10 minutes
 
     pub fn init(allocator: std.mem.Allocator) HttpClient {
         return .{
@@ -155,7 +155,7 @@ pub const HttpClient = struct {
     }
 
     /// Perform a GET request with extra headers (e.g. Authorization for blob downloads).
-    /// Uses the larger MAX_BLOB_BYTES limit since this is typically used for bottle downloads.
+    /// Uses the larger max_blob_bytes limit since this is typically used for bottle downloads.
     /// The caller owns the returned `Response` and must call `deinit` on it.
     pub fn getWithHeaders(
         self: *HttpClient,
@@ -163,7 +163,7 @@ pub const HttpClient = struct {
         extra_headers: []const std.http.Header,
         progress: ?ProgressCallback,
     ) !Response {
-        return self.doGetWithRetry(url, extra_headers, MAX_BLOB_BYTES, progress);
+        return self.doGetWithRetry(url, extra_headers, max_blob_bytes, progress);
     }
 
     /// Perform a HEAD request and return only the HTTP status code.
@@ -207,7 +207,7 @@ pub const HttpClient = struct {
         }
     };
 
-    const MAX_HEAD_REDIRECTS = 5;
+    const max_head_redirects = 5;
 
     /// HEAD request that manually follows redirects, returning the
     /// final URL and Content-Disposition. The stdlib skips redirect
@@ -222,7 +222,7 @@ pub const HttpClient = struct {
         };
         errdefer resolved.deinit();
 
-        for (0..MAX_HEAD_REDIRECTS) |_| {
+        for (0..max_head_redirects) |_| {
             const uri = std.Uri.parse(resolved.final_url) catch break;
 
             var req = self.client.request(.HEAD, uri, .{
@@ -257,15 +257,15 @@ pub const HttpClient = struct {
     /// Default maximum response body size for metadata (API JSON, tokens, etc.).
     /// The full Homebrew formula.json index is ~25 MB; 50 MB gives headroom.
     /// Bottle downloads bypass this via getWithHeaders (which sets no limit).
-    const MAX_METADATA_BYTES: usize = 50 * 1024 * 1024;
+    const max_metadata_bytes: usize = 50 * 1024 * 1024;
 
     /// Bottle responses can be 500+ MB. We cap at 2 GB to prevent true OOM.
-    const MAX_BLOB_BYTES: usize = 2 * 1024 * 1024 * 1024;
+    const max_blob_bytes: usize = 2 * 1024 * 1024 * 1024;
 
     // ---- internal helper ----
 
-    const MAX_RETRIES = 3;
-    const RETRY_DELAYS_MS = [_]u64{ 1000, 2000, 4000 };
+    const max_retries = 3;
+    const retry_delays_ms = [_]u64{ 1000, 2000, 4000 };
 
     /// Writer wrapper that counts bytes written, enforces an upper bound, and
     /// optionally fires a progress callback. The bound is checked on every
@@ -337,7 +337,7 @@ pub const HttpClient = struct {
         url: []const u8,
         extra_headers: []const std.http.Header,
     ) !Response {
-        return self.doGetWithRetry(url, extra_headers, MAX_METADATA_BYTES, null);
+        return self.doGetWithRetry(url, extra_headers, max_metadata_bytes, null);
     }
 
     fn doGetWithRetry(
@@ -352,17 +352,17 @@ pub const HttpClient = struct {
             const result = self.doGetLimited(url, extra_headers, max_bytes, progress);
             if (result) |resp| {
                 if (classifyStatus(resp.status)) |dl_err| {
-                    if (isTransientError(dl_err) and attempt < MAX_RETRIES) {
+                    if (isTransientError(dl_err) and attempt < max_retries) {
                         resp.allocator.free(resp.body);
-                        std.Io.sleep(io_mod.ctx(), std.Io.Duration.fromNanoseconds(@intCast(RETRY_DELAYS_MS[attempt] * std.time.ns_per_ms)), .awake) catch {};
+                        std.Io.sleep(io_mod.ctx(), std.Io.Duration.fromNanoseconds(@intCast(retry_delays_ms[attempt] * std.time.ns_per_ms)), .awake) catch {};
                         attempt += 1;
                         continue;
                     }
                 }
                 return resp;
             } else |err| {
-                if (attempt < MAX_RETRIES) {
-                    std.Io.sleep(io_mod.ctx(), std.Io.Duration.fromNanoseconds(@intCast(RETRY_DELAYS_MS[attempt] * std.time.ns_per_ms)), .awake) catch {};
+                if (attempt < max_retries) {
+                    std.Io.sleep(io_mod.ctx(), std.Io.Duration.fromNanoseconds(@intCast(retry_delays_ms[attempt] * std.time.ns_per_ms)), .awake) catch {};
                     attempt += 1;
                     continue;
                 }
@@ -435,8 +435,8 @@ pub const HttpClient = struct {
         // implementation slept in 1 s ticks and could stall `join()` by
         // up to a full second per request — that was the entire warm
         // install floor (see docs/perf/results.md).
-        const effective_timeout = if (max_bytes > MAX_METADATA_BYTES)
-            @max(BLOB_TIMEOUT_NS, scaledTimeoutNs(content_length))
+        const effective_timeout = if (max_bytes > max_metadata_bytes)
+            @max(blob_timeout_ns, scaledTimeoutNs(content_length))
         else
             self.timeout_ns;
         var request_done: std.Io.Event = .unset;

--- a/src/ui/term_sanitize.zig
+++ b/src/ui/term_sanitize.zig
@@ -32,15 +32,15 @@ pub const Sink = struct {
 /// CSI parameter buffer cap. Real SGR/cursor sequences rarely exceed
 /// a handful of bytes; an attacker can still overflow, in which case
 /// we drop the whole sequence at its final byte.
-pub const CSI_PARAM_MAX: usize = 32;
-pub const OUT_BUF: usize = 256;
+pub const csi_param_max: usize = 32;
+pub const out_buf: usize = 256;
 
 pub const Sanitizer = struct {
     state: State = .normal,
-    csi_buf: [CSI_PARAM_MAX]u8 = undefined,
+    csi_buf: [csi_param_max]u8 = undefined,
     csi_len: usize = 0,
     csi_overflow: bool = false,
-    out_buf: [OUT_BUF]u8 = undefined,
+    out_buf: [out_buf]u8 = undefined,
     out_len: usize = 0,
 
     const State = enum {

--- a/tests/atomic_test.zig
+++ b/tests/atomic_test.zig
@@ -82,15 +82,15 @@ test "validatePrefix: NUL byte rejected" {
     try testing.expectError(error.EmbeddedNul, atomic.validatePrefix("/opt/malt\x00"));
 }
 
-test "validatePrefix: length > MAX_PREFIX_LEN rejected" {
-    var buf: [atomic.MAX_PREFIX_LEN + 1]u8 = undefined;
+test "validatePrefix: length > max_prefix_len rejected" {
+    var buf: [atomic.max_prefix_len + 1]u8 = undefined;
     @memset(&buf, 'a');
     buf[0] = '/';
     try testing.expectError(error.TooLong, atomic.validatePrefix(&buf));
 }
 
-test "validatePrefix: length == MAX_PREFIX_LEN accepted" {
-    var buf: [atomic.MAX_PREFIX_LEN]u8 = undefined;
+test "validatePrefix: length == max_prefix_len accepted" {
+    var buf: [atomic.max_prefix_len]u8 = undefined;
     @memset(&buf, 'a');
     buf[0] = '/';
     try atomic.validatePrefix(&buf);

--- a/tests/bundle_test.zig
+++ b/tests/bundle_test.zig
@@ -37,7 +37,7 @@ fn buildManifest(parent: std.mem.Allocator) !manifest_mod.Manifest {
     var m = manifest_mod.Manifest.init(parent);
     const a = m.allocator();
     m.name = try a.dupe(u8, "devtools");
-    m.version = manifest_mod.SCHEMA_VERSION;
+    m.version = manifest_mod.schema_version;
 
     const taps = try a.alloc([]const u8, 1);
     taps[0] = try a.dupe(u8, "homebrew/cask-fonts");

--- a/tests/net_client_test.zig
+++ b/tests/net_client_test.zig
@@ -233,8 +233,8 @@ test "scaledTimeoutNs: 0-length file returns floor" {
     try testing.expectEqual(@as(u64, 30 * std.time.ns_per_s), client.scaledTimeoutNs(0));
 }
 
-test "scaledTimeoutNs: null combined with BLOB_TIMEOUT_NS keeps 10-min minimum" {
-    // Blob downloads use @max(BLOB_TIMEOUT_NS, scaledTimeoutNs(cl)).
+test "scaledTimeoutNs: null combined with blob_timeout_ns keeps 10-min minimum" {
+    // Blob downloads use @max(blob_timeout_ns, scaledTimeoutNs(cl)).
     // When Content-Length is null (chunked), scaledTimeoutNs returns 30s,
     // but the blob floor must dominate.
     const blob_timeout = 600 * std.time.ns_per_s;

--- a/tests/services_validate_test.zig
+++ b/tests/services_validate_test.zig
@@ -86,7 +86,7 @@ test "validate: embedded NUL in arg rejected" {
 }
 
 test "validate: oversize arg rejected" {
-    var big: [plist.MAX_ARG_LEN + 1]u8 = undefined;
+    var big: [plist.max_arg_len + 1]u8 = undefined;
     @memset(&big, 'a');
     const args = [_][]const u8{ "/opt/malt/Cellar/foo/1.0/bin/foo", big[0..] };
     try testing.expectError(error.ArgTooLong, plist.validate(.{
@@ -98,7 +98,7 @@ test "validate: oversize arg rejected" {
 }
 
 test "validate: too many args rejected" {
-    var args: [plist.MAX_PROGRAM_ARGS + 1][]const u8 = undefined;
+    var args: [plist.max_program_args + 1][]const u8 = undefined;
     args[0] = "/opt/malt/Cellar/foo/1.0/bin/foo";
     for (args[1..]) |*a| a.* = "x";
     try testing.expectError(error.TooManyArgs, plist.validate(.{

--- a/tests/spawn_invariant_test.zig
+++ b/tests/spawn_invariant_test.zig
@@ -34,13 +34,13 @@ fn stripLineComment(line: []const u8) []const u8 {
 }
 
 // Files in src/core/services/plist.zig legitimately name the forbidden
-// interpreter paths in FORBIDDEN_HEADS — they're the *rejection list*
+// interpreter paths in forbidden_heads — they're the *rejection list*
 // for formula-declared services. Exempt that exact context.
 fn allowedContext(path: []const u8, line: []const u8) bool {
     if (std.mem.endsWith(u8, path, "core/services/plist.zig")) {
-        // FORBIDDEN_HEADS declaration + error docstrings — both live in
+        // forbidden_heads declaration + error docstrings — both live in
         // that file by design. Any other usage still has to pass.
-        if (std.mem.indexOf(u8, line, "FORBIDDEN_HEADS") != null) return true;
+        if (std.mem.indexOf(u8, line, "forbidden_heads") != null) return true;
         // Quoted-string list entries: `"/bin/sh",`
         if (std.mem.indexOf(u8, line, "\"/bin/") != null) return true;
         if (std.mem.indexOf(u8, line, "\"/usr/bin/") != null) return true;

--- a/tests/term_sanitize_test.zig
+++ b/tests/term_sanitize_test.zig
@@ -158,7 +158,7 @@ test "SOS always dropped" {
 // ── CSI overflow fails closed ───────────────────────────────────────
 
 test "CSI with oversized params fails closed" {
-    var big: [ts.CSI_PARAM_MAX + 10]u8 = undefined;
+    var big: [ts.csi_param_max + 10]u8 = undefined;
     @memset(&big, '1');
     var input: std.ArrayList(u8) = .empty;
     defer input.deinit(testing.allocator);


### PR DESCRIPTION
## Description

Rename value constants to `snake_case` matching Zig stdlib convention; 

## Related Issue

- None

## Notes for Reviewers

- Mechanical rename; no behaviour change. 