### PR TITLE
refactor(cli): StaticStringMap flag parsing and command dispatch

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -93,6 +93,29 @@ pub fn installAll(
     return execute(allocator, argv.items);
 }
 
+const InstallFlag = enum {
+    cask,
+    formula,
+    dry_run,
+    force,
+    local,
+    use_system_ruby,
+    quiet,
+    json,
+};
+
+const install_flag_map = std.StaticStringMap(InstallFlag).initComptime(.{
+    .{ "--cask", .cask },
+    .{ "--formula", .formula },
+    .{ "--dry-run", .dry_run },
+    .{ "--force", .force },
+    .{ "--local", .local },
+    .{ "--use-system-ruby", .use_system_ruby },
+    .{ "--quiet", .quiet },
+    .{ "-q", .quiet },
+    .{ "--json", .json },
+});
+
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "install")) return;
 
@@ -120,29 +143,26 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // leaving it to shape-based autodetection.
     var local_only = false;
 
+    // StaticStringMap + exhaustive switch: the compiler checks every flag
+    // has a handler, so adding a new variant without wiring it fails to build.
     for (args) |arg| {
-        if (std.mem.eql(u8, arg, "--cask")) {
-            force_cask = true;
-        } else if (std.mem.eql(u8, arg, "--formula")) {
-            force_formula = true;
-        } else if (std.mem.eql(u8, arg, "--dry-run")) {
-            dry_run = true;
-        } else if (std.mem.eql(u8, arg, "--force")) {
-            force = true;
-        } else if (std.mem.eql(u8, arg, "--local")) {
-            local_only = true;
-        } else if (std.mem.eql(u8, arg, "--use-system-ruby")) {
-            use_system_ruby_bare = true;
-        } else if (std.mem.startsWith(u8, arg, "--use-system-ruby=")) {
+        if (std.mem.startsWith(u8, arg, "--use-system-ruby=")) {
             const list = arg["--use-system-ruby=".len..];
             var it = std.mem.splitScalar(u8, list, ',');
             while (it.next()) |name| {
                 if (name.len > 0) try use_system_ruby_scope.append(allocator, name);
             }
-        } else if (std.mem.eql(u8, arg, "--quiet") or std.mem.eql(u8, arg, "-q")) {
-            output.setQuiet(true);
-        } else if (std.mem.eql(u8, arg, "--json")) {
-            output.setMode(.json);
+            continue;
+        }
+        if (install_flag_map.get(arg)) |flag| switch (flag) {
+            .cask => force_cask = true,
+            .formula => force_formula = true,
+            .dry_run => dry_run = true,
+            .force => force = true,
+            .local => local_only = true,
+            .use_system_ruby => use_system_ruby_bare = true,
+            .quiet => output.setQuiet(true),
+            .json => output.setMode(.json),
         } else if (!std.mem.startsWith(u8, arg, "-")) {
             packages.append(allocator, arg) catch return error.OutOfMemory;
         }

--- a/src/cli/purge/args.zig
+++ b/src/cli/purge/args.zig
@@ -82,59 +82,80 @@ pub const Target = struct {
     category: Category,
 };
 
+const Flag = enum {
+    store_orphans,
+    unused_deps,
+    cache,
+    downloads,
+    stale_casks,
+    old_versions,
+    housekeeping,
+    wipe,
+    yes,
+    backup,
+    keep_cache,
+    remove_binary,
+};
+
+const flag_map = std.StaticStringMap(Flag).initComptime(.{
+    .{ "--store-orphans", .store_orphans },
+    .{ "--unused-deps", .unused_deps },
+    .{ "--cache", .cache },
+    .{ "--downloads", .downloads },
+    .{ "--stale-casks", .stale_casks },
+    .{ "--old-versions", .old_versions },
+    .{ "--housekeeping", .housekeeping },
+    .{ "--wipe", .wipe },
+    .{ "--yes", .yes },
+    .{ "-y", .yes },
+    .{ "--backup", .backup },
+    .{ "-b", .backup },
+    .{ "--keep-cache", .keep_cache },
+    .{ "--remove-binary", .remove_binary },
+});
+
 pub fn parseArgs(args: []const []const u8) Error!Options {
     var opts: Options = .{};
     var i: usize = 0;
+    // StaticStringMap + exhaustive switch: every flag must map to a handler.
     while (i < args.len) : (i += 1) {
         const arg = args[i];
 
-        // Scope flags
-        if (std.mem.eql(u8, arg, "--store-orphans")) {
-            opts.scope.store_orphans = true;
-        } else if (std.mem.eql(u8, arg, "--unused-deps")) {
-            opts.scope.unused_deps = true;
-        } else if (std.mem.eql(u8, arg, "--cache")) {
-            opts.scope.cache = true;
-        } else if (std.mem.startsWith(u8, arg, "--cache=")) {
+        // Prefix forms can't live in the exact-match map.
+        if (std.mem.startsWith(u8, arg, "--cache=")) {
             opts.scope.cache = true;
             opts.cache_days = std.fmt.parseInt(i64, arg["--cache=".len..], 10) catch
                 return Error.InvalidArgs;
-        } else if (std.mem.eql(u8, arg, "--downloads")) {
-            opts.scope.downloads = true;
-        } else if (std.mem.eql(u8, arg, "--stale-casks")) {
-            opts.scope.stale_casks = true;
-        } else if (std.mem.eql(u8, arg, "--old-versions")) {
-            opts.scope.old_versions = true;
-        } else if (std.mem.eql(u8, arg, "--housekeeping")) {
-            opts.scope.store_orphans = true;
-            opts.scope.unused_deps = true;
-            opts.scope.cache = true;
-            opts.scope.stale_casks = true;
-        } else if (std.mem.eql(u8, arg, "--wipe")) {
-            opts.scope.wipe = true;
+            continue;
         }
-
-        // Shared flags
-        else if (std.mem.eql(u8, arg, "--yes") or std.mem.eql(u8, arg, "-y")) {
-            opts.yes = true;
-        } else if (std.mem.eql(u8, arg, "--backup") or std.mem.eql(u8, arg, "-b")) {
-            if (i + 1 >= args.len) return Error.InvalidArgs;
-            i += 1;
-            opts.backup_path = args[i];
-        } else if (std.mem.startsWith(u8, arg, "--backup=")) {
+        if (std.mem.startsWith(u8, arg, "--backup=")) {
             opts.backup_path = arg["--backup=".len..];
+            continue;
         }
 
-        // --wipe-only flags
-        else if (std.mem.eql(u8, arg, "--keep-cache")) {
-            opts.keep_cache = true;
-        } else if (std.mem.eql(u8, arg, "--remove-binary")) {
-            opts.remove_binary = true;
-        }
-
-        // Anything else is invalid (positionals included)
-        else {
-            return Error.InvalidArgs;
+        const flag = flag_map.get(arg) orelse return Error.InvalidArgs;
+        switch (flag) {
+            .store_orphans => opts.scope.store_orphans = true,
+            .unused_deps => opts.scope.unused_deps = true,
+            .cache => opts.scope.cache = true,
+            .downloads => opts.scope.downloads = true,
+            .stale_casks => opts.scope.stale_casks = true,
+            .old_versions => opts.scope.old_versions = true,
+            .housekeeping => {
+                opts.scope.store_orphans = true;
+                opts.scope.unused_deps = true;
+                opts.scope.cache = true;
+                opts.scope.stale_casks = true;
+            },
+            .wipe => opts.scope.wipe = true,
+            .yes => opts.yes = true,
+            .backup => {
+                if (i + 1 >= args.len) return Error.InvalidArgs;
+                i += 1;
+                opts.backup_path = args[i];
+            },
+            .keep_cache => opts.keep_cache = true,
+            .remove_binary => opts.remove_binary = true,
         }
     }
 

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -19,6 +19,16 @@ const linker_mod = @import("../core/linker.zig");
 const ghcr_mod = @import("../net/ghcr.zig");
 const help = @import("help.zig");
 
+const UpgradeFlag = enum { quiet, cask, formula, dry_run };
+
+const upgrade_flag_map = std.StaticStringMap(UpgradeFlag).initComptime(.{
+    .{ "-q", .quiet },
+    .{ "--quiet", .quiet },
+    .{ "--cask", .cask },
+    .{ "--formula", .formula },
+    .{ "--dry-run", .dry_run },
+});
+
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "upgrade")) return;
 
@@ -27,15 +37,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var dry_run = output.isDryRun();
     var pkg_name: ?[]const u8 = null;
 
+    // StaticStringMap + exhaustive switch: every flag routes to a handler.
     for (args) |arg| {
-        if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
-            output.setQuiet(true);
-        } else if (std.mem.eql(u8, arg, "--cask")) {
-            cask_only = true;
-        } else if (std.mem.eql(u8, arg, "--formula")) {
-            formula_only = true;
-        } else if (std.mem.eql(u8, arg, "--dry-run")) {
-            dry_run = true;
+        if (upgrade_flag_map.get(arg)) |flag| switch (flag) {
+            .quiet => output.setQuiet(true),
+            .cask => cask_only = true,
+            .formula => formula_only = true,
+            .dry_run => dry_run = true,
         } else if (arg.len > 0 and arg[0] != '-') {
             if (pkg_name == null) pkg_name = arg;
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -84,38 +84,54 @@ const Command = enum {
     version,
 };
 
-const command_map = std.StaticStringMap(Command).initComptime(.{
-    .{ "install", .install },
-    .{ "uninstall", .uninstall },
-    .{ "remove", .uninstall },
-    .{ "upgrade", .upgrade },
-    .{ "update", .update },
-    .{ "outdated", .outdated },
-    .{ "list", .list },
-    .{ "ls", .list },
-    .{ "info", .info },
-    .{ "search", .search },
-    .{ "doctor", .doctor },
-    .{ "tap", .tap },
-    .{ "untap", .untap },
-    .{ "migrate", .migrate },
-    .{ "rollback", .rollback },
-    .{ "link", .link },
-    .{ "unlink", .unlink },
-    .{ "run", .run },
-    .{ "completions", .completions },
-    .{ "backup", .backup },
-    .{ "restore", .restore },
-    .{ "purge", .purge },
-    .{ "services", .services },
-    .{ "bundle", .bundle },
-    .{ "uses", .uses },
-    .{ "help", .help },
-    .{ "--help", .help },
-    .{ "-h", .help },
-    .{ "version", .version_cmd },
-    .{ "--version", .version },
-});
+/// Aliases live beside their canonical tag so there's one source of
+/// truth; `command_map` below is synthesised from this at comptime.
+const command_names = [_]struct {
+    tag: Command,
+    names: []const []const u8,
+}{
+    .{ .tag = .install, .names = &.{"install"} },
+    .{ .tag = .uninstall, .names = &.{ "uninstall", "remove" } },
+    .{ .tag = .upgrade, .names = &.{"upgrade"} },
+    .{ .tag = .update, .names = &.{"update"} },
+    .{ .tag = .outdated, .names = &.{"outdated"} },
+    .{ .tag = .list, .names = &.{ "list", "ls" } },
+    .{ .tag = .info, .names = &.{"info"} },
+    .{ .tag = .search, .names = &.{"search"} },
+    .{ .tag = .doctor, .names = &.{"doctor"} },
+    .{ .tag = .tap, .names = &.{"tap"} },
+    .{ .tag = .untap, .names = &.{"untap"} },
+    .{ .tag = .migrate, .names = &.{"migrate"} },
+    .{ .tag = .rollback, .names = &.{"rollback"} },
+    .{ .tag = .link, .names = &.{"link"} },
+    .{ .tag = .unlink, .names = &.{"unlink"} },
+    .{ .tag = .run, .names = &.{"run"} },
+    .{ .tag = .version_cmd, .names = &.{"version"} },
+    .{ .tag = .completions, .names = &.{"completions"} },
+    .{ .tag = .backup, .names = &.{"backup"} },
+    .{ .tag = .restore, .names = &.{"restore"} },
+    .{ .tag = .purge, .names = &.{"purge"} },
+    .{ .tag = .services, .names = &.{"services"} },
+    .{ .tag = .bundle, .names = &.{"bundle"} },
+    .{ .tag = .uses, .names = &.{"uses"} },
+    .{ .tag = .help, .names = &.{ "help", "--help", "-h" } },
+    .{ .tag = .version, .names = &.{"--version"} },
+};
+
+const command_map = blk: {
+    @setEvalBranchQuota(10_000);
+    var total: usize = 0;
+    for (command_names) |entry| total += entry.names.len;
+    var pairs: [total]struct { []const u8, Command } = undefined;
+    var i: usize = 0;
+    for (command_names) |entry| {
+        for (entry.names) |name| {
+            pairs[i] = .{ name, entry.tag };
+            i += 1;
+        }
+    }
+    break :blk std.StaticStringMap(Command).initComptime(pairs);
+};
 
 pub fn main(init: std.process.Init.Minimal) !void {
     // In debug builds, use GeneralPurposeAllocator as the backing


### PR DESCRIPTION
## Description

Replace `std.mem.eql` chains in `cli/install`, `cli/purge/args`, and `cli/upgrade` flag parsers with `std.StaticStringMap(enum)` + exhaustive `switch`. Command dispatch in `main.zig` now synthesises its map from a single table that holds aliases beside their canonical `Command` tag - `remove` sits with `uninstall`, `ls` with `list`, `--help`/`-h` with `help`.

## Related Issue

- None

## Notes for Reviewers

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)