### PR TITLE
refactor(core/pins): store commit SHA as fixed array

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Regenerate against committed pin
         run: |
-          PINNED=$(grep -E 'HOMEBREW_CORE_COMMIT_SHA.*=.*"' src/core/pins.zig \
+          PINNED=$(grep -E 'homebrew_core_commit_sha.*=.*"' src/core/pins.zig \
             | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
           echo "committed pin: $PINNED"
           ./scripts/gen-pins.sh "$PINNED"

--- a/.github/workflows/pins-bump.yml
+++ b/.github/workflows/pins-bump.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Compute short SHA for PR metadata
         id: pin
         run: |
-          SHA=$(grep -E 'HOMEBREW_CORE_COMMIT_SHA.*=.*"' src/core/pins.zig \
+          SHA=$(grep -E 'homebrew_core_commit_sha.*=.*"' src/core/pins.zig \
             | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
           echo "sha=$SHA" >>"$GITHUB_OUTPUT"
           echo "short=${SHA:0:12}" >>"$GITHUB_OUTPUT"

--- a/scripts/e2e/smoke_security.sh
+++ b/scripts/e2e/smoke_security.sh
@@ -178,11 +178,11 @@ fi
 
 # The pinned commit constant should be a 40-char lowercase hex SHA.
 PINS_ZIG="$ROOT/src/core/pins.zig"
-sha=$(grep -E 'HOMEBREW_CORE_COMMIT_SHA.*=.*"' "$PINS_ZIG" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+sha=$(grep -E 'homebrew_core_commit_sha.*=.*"' "$PINS_ZIG" | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
 if [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
   manual_pass s2.pins.commit-sha "pinned commit: $sha"
 else
-  manual_fail s2.pins.commit-sha "HOMEBREW_CORE_COMMIT_SHA is not 40-char hex: '$sha'"
+  manual_fail s2.pins.commit-sha "homebrew_core_commit_sha is not 40-char hex: '$sha'"
 fi
 
 # ── Tier 3 — install.sh fail-closed regression harness ────────────────

--- a/scripts/gen-pins.sh
+++ b/scripts/gen-pins.sh
@@ -126,7 +126,7 @@ else
   SED_INPLACE=(sed -i '')
 fi
 "${SED_INPLACE[@]}" \
-  "s|^pub const HOMEBREW_CORE_COMMIT_SHA: \\[\\]const u8 = .*|pub const HOMEBREW_CORE_COMMIT_SHA: []const u8 = \"${COMMIT}\";|" \
+  "s|^pub const homebrew_core_commit_sha: \\[40\\]u8 = .*|pub const homebrew_core_commit_sha: [40]u8 = \"${COMMIT}\".*;|" \
   src/core/pins.zig
 
 # Regenerate the manifest.
@@ -144,7 +144,7 @@ cat >"$TMP" <<'HEADER'
 # entry are refused — the code path is fail-closed.
 #
 # Regenerate with: scripts/gen-pins.sh
-# Pinned commit lives in src/core/pins.zig (HOMEBREW_CORE_COMMIT_SHA).
+# Pinned commit lives in src/core/pins.zig (homebrew_core_commit_sha).
 #
 # Lines starting with '#' and blank lines are ignored.
 HEADER

--- a/src/core/pins.zig
+++ b/src/core/pins.zig
@@ -16,8 +16,11 @@ const std = @import("std");
 /// TOFU window against a silent upstream rewrite; this constant nails
 /// the fetch URL to a single tree an auditor can reproduce.
 ///
+/// Fixed-array type: the 40-char length is a comptime property, so no
+/// slice header is emitted at use sites.
+///
 /// Bump at release time via `scripts/gen-pins.sh`.
-pub const HOMEBREW_CORE_COMMIT_SHA: []const u8 = "5d3790f92c7873f1fd8e5e2ecd6fbc689a78a96f";
+pub const homebrew_core_commit_sha: [40]u8 = "5d3790f92c7873f1fd8e5e2ecd6fbc689a78a96f".*;
 
 const MANIFEST_TEXT: []const u8 = @embedFile("pins_manifest.txt");
 

--- a/src/core/pins_manifest.txt
+++ b/src/core/pins_manifest.txt
@@ -7,7 +7,7 @@
 # entry are refused — the code path is fail-closed.
 #
 # Regenerate with: scripts/gen-pins.sh
-# Pinned commit lives in src/core/pins.zig (HOMEBREW_CORE_COMMIT_SHA).
+# Pinned commit lives in src/core/pins.zig (homebrew_core_commit_sha).
 #
 # Lines starting with '#' and blank lines are ignored.
 

--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -155,7 +155,7 @@ pub fn fetchPostInstallFromGitHub(allocator: std.mem.Allocator, name: []const u8
     const url = std.fmt.bufPrint(
         &url_buf,
         "https://raw.githubusercontent.com/Homebrew/homebrew-core/{s}/Formula/{c}/{s}.rb",
-        .{ pins.HOMEBREW_CORE_COMMIT_SHA, name[0], name },
+        .{ &pins.homebrew_core_commit_sha, name[0], name },
     ) catch return null;
 
     var http = http_client.HttpClient.init(allocator);

--- a/tests/pins_test.zig
+++ b/tests/pins_test.zig
@@ -9,10 +9,12 @@ const std = @import("std");
 const testing = std.testing;
 const pins = @import("malt").pins;
 
-test "HOMEBREW_CORE_COMMIT_SHA is a 40-char lowercase hex digest" {
-    const sha = pins.HOMEBREW_CORE_COMMIT_SHA;
-    try testing.expectEqual(@as(usize, 40), sha.len);
-    for (sha) |c| switch (c) {
+test "homebrew_core_commit_sha is a [40]u8 lowercase hex digest" {
+    // Fixed-array typing: the length is a property of the type, not a
+    // runtime field. Asserting the type itself catches accidental
+    // regressions to `[]const u8`.
+    comptime std.debug.assert(@TypeOf(pins.homebrew_core_commit_sha) == [40]u8);
+    for (pins.homebrew_core_commit_sha) |c| switch (c) {
         '0'...'9', 'a'...'f' => {},
         else => return error.TestUnexpectedResult,
     };


### PR DESCRIPTION
## Description

Store the pinned homebrew-core commit SHA as `[40]u8` instead of `[]const u8`. The 40-char length becomes a comptime property of the type, dropping the slice header at every use site.

## Related Issue

- None

## Notes for Reviewers

- None