### PR TITLE
refactor(core/sandbox): use std.posix.rlimit_resource tags

### DIFF
--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -130,25 +130,18 @@ pub fn renderRubyProfile(
     return aw.toOwnedSlice() catch SandboxError.ProfileBuildFailed;
 }
 
-/// RLIMIT constants. Zig's `std.posix.rlimit_resource` is an enum on
-/// macOS whose integer values match the platform headers; we name
-/// them here so the call sites below stay readable.
-const RLIMIT = struct {
-    const CPU: std.posix.rlimit_resource = @enumFromInt(0);
-    const FSIZE: std.posix.rlimit_resource = @enumFromInt(1);
-    const AS: std.posix.rlimit_resource = @enumFromInt(5);
-};
-
 fn applyRlimits(limits: Limits) SandboxError!void {
     const as_max: std.posix.rlim_t = @intCast(limits.address_space_bytes);
     const fs_max: std.posix.rlim_t = @intCast(limits.file_size_bytes);
     const cpu_max: std.posix.rlim_t = @intCast(limits.cpu_seconds);
 
-    std.posix.setrlimit(RLIMIT.CPU, .{ .cur = cpu_max, .max = cpu_max }) catch
+    // On macOS `.AS` is a `pub const` alias for `.RSS` inside the
+    // rlimit_resource namespace — same BSD lineage as RLIMIT_AS == RLIMIT_RSS.
+    std.posix.setrlimit(.CPU, .{ .cur = cpu_max, .max = cpu_max }) catch
         return SandboxError.RlimitFailed;
-    std.posix.setrlimit(RLIMIT.FSIZE, .{ .cur = fs_max, .max = fs_max }) catch
+    std.posix.setrlimit(.FSIZE, .{ .cur = fs_max, .max = fs_max }) catch
         return SandboxError.RlimitFailed;
-    std.posix.setrlimit(RLIMIT.AS, .{ .cur = as_max, .max = as_max }) catch
+    std.posix.setrlimit(.AS, .{ .cur = as_max, .max = as_max }) catch
         return SandboxError.RlimitFailed;
 }
 

--- a/tests/sandbox_macos_test.zig
+++ b/tests/sandbox_macos_test.zig
@@ -79,6 +79,16 @@ test "SANDBOX_PATH restricts to system directories only" {
     try testing.expectEqualStrings("/usr/bin:/bin:/usr/sbin:/sbin", sandbox.SANDBOX_PATH);
 }
 
+test "std.posix.rlimit_resource tags resolve on macOS for CPU/FSIZE/AS" {
+    // Pin: the three rlimit tags applyRlimits relies on must round-trip
+    // through the kernel on macOS. If a stdlib rename ever loses one of
+    // these, this test fails before fork/exec tests do.
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    _ = try std.posix.getrlimit(.CPU);
+    _ = try std.posix.getrlimit(.FSIZE);
+    _ = try std.posix.getrlimit(.AS);
+}
+
 // Reap-on-error tests: drive the thread-spawn-failure path via the
 // `SpawnHooks` injector and assert the parent reaped the child before
 // returning. /usr/bin/true is a stable short-lived child on macOS — the


### PR DESCRIPTION
## Description

Swap the open-coded `RLIMIT` struct in `core/sandbox/macos.zig` for `std.posix.rlimit_resource` tags. `applyRlimits` now calls `setrlimit(.CPU, ...)`, `.FSIZE`, `.AS` directly - no local wrapper, no `@enumFromInt`.

## Related Issue

- None

## Notes for Reviewers

- On macOS stdlib, `.CPU = 0`, `.FSIZE = 1`, and `.AS` aliases `.RSS = 5` - exactly the integers the old `@enumFromInt(0/1/5)` produced.
