### PR TITLE
refactor(db/sqlite): accept sentinel-terminated paths and SQL

### DIFF
--- a/src/cli/backup.zig
+++ b/src/cli/backup.zig
@@ -71,7 +71,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // ── Open the database ────────────────────────────────────────────────
     const prefix = atomic.maltPrefix();
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch
         return Error.DatabaseError;
 
     var db = sqlite.Database.open(db_path) catch {

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -442,7 +442,7 @@ fn openDb() !sqlite.Database {
         return BundleError.DatabaseError;
     fs_compat.cwd().makePath(db_dir) catch {};
     var path_buf: [512]u8 = undefined;
-    const path = std.fmt.bufPrint(&path_buf, "{s}/malt.db", .{db_dir}) catch
+    const path = std.fmt.bufPrintSentinel(&path_buf, "{s}/malt.db", .{db_dir}, 0) catch
         return BundleError.DatabaseError;
     return sqlite.Database.open(path);
 }

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -124,7 +124,7 @@ fn checkMaltPrefix(ctx: CheckCtx, name: []const u8) CheckResult {
 
 fn checkSqliteIntegrity(ctx: CheckCtx, name: []const u8) CheckResult {
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{ctx.prefix}) catch {
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{ctx.prefix}, 0) catch {
         printCheck(name, .err_status, "Prefix path too long");
         return .err_status;
     };
@@ -290,7 +290,7 @@ fn checkApiReachable(ctx: CheckCtx, name: []const u8) CheckResult {
 
 fn checkOrphanedStore(ctx: CheckCtx, name: []const u8) CheckResult {
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{ctx.prefix}) catch {
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{ctx.prefix}, 0) catch {
         printCheck(name, .ok, null);
         return .ok;
     };
@@ -345,7 +345,7 @@ fn checkOrphanedStore(ctx: CheckCtx, name: []const u8) CheckResult {
 
 fn checkMissingKegs(ctx: CheckCtx, name: []const u8) CheckResult {
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{ctx.prefix}) catch {
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{ctx.prefix}, 0) catch {
         printCheck(name, .ok, null);
         return .ok;
     };
@@ -499,7 +499,7 @@ fn checkDiskSpace(ctx: CheckCtx, name: []const u8) CheckResult {
 
 fn checkLocalSources(ctx: CheckCtx, name: []const u8) CheckResult {
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{ctx.prefix}) catch {
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{ctx.prefix}, 0) catch {
         printCheck(name, .ok, null);
         return .ok;
     };

--- a/src/cli/doctor/post_install.zig
+++ b/src/cli/doctor/post_install.zig
@@ -19,7 +19,7 @@ pub fn checkPostInstallStatus(allocator: std.mem.Allocator, prefix: []const u8) 
     output.info("Post-install DSL status:", .{});
 
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
     var db = sqlite.Database.open(db_path) catch return;
     defer db.close();
 

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -390,7 +390,7 @@ fn writeLine(w: *std.Io.Writer, scratch: []u8, comptime fmt: []const u8, args: a
 /// caller can degrade to a stateless response instead of bailing.
 pub fn openDb(prefix: []const u8) ?sqlite.Database {
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return null;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return null;
     return sqlite.Database.open(db_path) catch null;
 }
 

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -240,7 +240,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     // Open database
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch
         return InstallError.DatabaseError;
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database at {s}", .{db_path});

--- a/src/cli/link.zig
+++ b/src/cli/link.zig
@@ -28,7 +28,7 @@ pub fn executeLink(allocator: std.mem.Allocator, args: []const []const u8) !void
     const prefix = atomic.maltPrefix();
 
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database", .{});
         return error.Aborted;
@@ -103,7 +103,7 @@ pub fn executeUnlink(allocator: std.mem.Allocator, args: []const []const u8) !vo
     const prefix = atomic.maltPrefix();
 
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database", .{});
         return error.Aborted;

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -44,7 +44,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // Open DB
     const prefix = atomic.maltPrefix();
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
     var db = sqlite.Database.open(db_path) catch {
         // Fresh prefix with no `db/` yet = nothing installed. Treat as
         // empty output (rc=0), same contract as `ls` on an empty dir.

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -175,7 +175,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     // Open database
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database at {s}", .{db_path});
         return error.Aborted;

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -31,7 +31,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // Open DB
     const prefix = atomic.maltPrefix();
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
     var db = sqlite.Database.open(db_path) catch {
         // Fresh prefix: nothing installed = nothing to be outdated.
         return;

--- a/src/cli/purge/util.zig
+++ b/src/cli/purge/util.zig
@@ -49,7 +49,7 @@ pub fn pathSize(allocator: std.mem.Allocator, path: []const u8) u64 {
 
 pub fn openDb(prefix: []const u8) ?sqlite.Database {
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return null;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return null;
     return sqlite.Database.open(db_path) catch null;
 }
 

--- a/src/cli/purge/wipe.zig
+++ b/src/cli/purge/wipe.zig
@@ -96,7 +96,7 @@ fn warnBanner() void {
 pub fn writeManifest(allocator: std.mem.Allocator, path: []const u8) Error!void {
     const prefix = atomic.maltPrefix();
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return Error.DatabaseError;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return Error.DatabaseError;
 
     var aw: std.Io.Writer.Allocating = .init(allocator);
     defer aw.deinit();

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -33,7 +33,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     const prefix = atomic.maltPrefix();
 
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return error.Aborted;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return error.Aborted;
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database", .{});
         return error.Aborted;

--- a/src/cli/services.zig
+++ b/src/cli/services.zig
@@ -145,7 +145,7 @@ fn openDb() !sqlite.Database {
         return ServicesError.DatabaseError;
     fs_compat.cwd().makePath(db_dir) catch {};
     var path_buf: [512]u8 = undefined;
-    const path = std.fmt.bufPrint(&path_buf, "{s}/malt.db", .{db_dir}) catch
+    const path = std.fmt.bufPrintSentinel(&path_buf, "{s}/malt.db", .{db_dir}, 0) catch
         return ServicesError.DatabaseError;
     return sqlite.Database.open(path);
 }

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -79,7 +79,7 @@ fn run(allocator: std.mem.Allocator, args: []const []const u8, action: Action) !
     const prefix = atomic.maltPrefix();
 
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
     var db = sqlite.Database.open(db_path) catch {
         // Fresh prefix with no `db/` yet = no taps registered.
         return;

--- a/src/cli/uninstall.zig
+++ b/src/cli/uninstall.zig
@@ -53,7 +53,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     // Open DB
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database", .{});
         return error.Aborted;

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -65,7 +65,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer lk.release();
 
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrint(&db_path_buf, "{s}/db/malt.db", .{prefix}) catch return;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
     var db = sqlite.Database.open(db_path) catch {
         // Same degradation as `list`/`outdated` — missing DB on a fresh
         // prefix is empty state, not an error.

--- a/src/db/sqlite.zig
+++ b/src/db/sqlite.zig
@@ -10,7 +10,6 @@ pub const SqliteError = error{
     ConstraintViolation,
     Busy,
     Corrupt,
-    PathTooLong,
 };
 
 /// Map a raw SQLite result code to the appropriate SqliteError.
@@ -32,14 +31,6 @@ fn mapError(rc: c_int, comptime default: SqliteError) SqliteError {
 /// Use SQLITE_STATIC (null destructor) for text bindings.
 /// This is safe because all bound text outlives the statement step.
 const SQLITE_STATIC: c.sqlite3_destructor_type = null;
-
-/// Maximum DB path length accepted by `Database.open`. Stack-buffered null
-/// copy; deeply nested test prefixes and custom MALT_PREFIX values fit.
-pub const MAX_PATH_LEN: usize = 2048;
-
-/// Maximum SQL length accepted by `Database.exec`. Migration bundles with
-/// many inline statements fit without forcing callers to split.
-pub const MAX_SQL_LEN: usize = 16384;
 
 pub const Statement = struct {
     /// Raw sqlite handle; touch only via the methods below.
@@ -113,18 +104,10 @@ pub const Database = struct {
 
     /// Open (or create) a database file at `path`.
     /// Configures pragmas: journal_mode=WAL, foreign_keys=ON, busy_timeout=5000.
-    pub fn open(path: []const u8) SqliteError!Database {
-        // SQLite requires a null-terminated path. Copy into a stack buffer
-        // and add the sentinel, since callers may pass bufPrint output.
-        var path_buf: [MAX_PATH_LEN]u8 = undefined;
-        if (path.len >= path_buf.len) return SqliteError.PathTooLong;
-        @memcpy(path_buf[0..path.len], path);
-        path_buf[path.len] = 0;
-        const c_path: [*:0]const u8 = path_buf[0..path.len :0];
-
+    pub fn open(path: [:0]const u8) SqliteError!Database {
         var db: ?*c.sqlite3 = null;
         const rc = c.sqlite3_open_v2(
-            c_path,
+            path.ptr,
             &db,
             c.SQLITE_OPEN_READWRITE | c.SQLITE_OPEN_CREATE,
             null,
@@ -151,17 +134,10 @@ pub const Database = struct {
     }
 
     /// Execute one or more SQL statements that return no result rows.
-    /// Accepts a slice so callers can pass `bufPrint` output without needing
-    /// to hand-manage a null terminator; compile-time literals still coerce
-    /// through unchanged. `sqlite3_exec` itself is C-string-only, so we copy
-    /// into a stack buffer and append the sentinel.
-    pub fn exec(self: *Database, sql: []const u8) SqliteError!void {
-        var buf: [MAX_SQL_LEN]u8 = undefined;
-        if (sql.len >= buf.len) return SqliteError.ExecFailed;
-        @memcpy(buf[0..sql.len], sql);
-        buf[sql.len] = 0;
-        const c_sql: [*:0]const u8 = buf[0..sql.len :0];
-        const rc = c.sqlite3_exec(self._handle, c_sql, null, null, null);
+    /// String literals and `bufPrintZ` output coerce to `[:0]const u8`; dynamic
+    /// SQL should be built with `bufPrintZ` or an ArrayList plus a trailing 0.
+    pub fn exec(self: *Database, sql: [:0]const u8) SqliteError!void {
+        const rc = c.sqlite3_exec(self._handle, sql.ptr, null, null, null);
         if (rc != c.SQLITE_OK) return mapError(rc, SqliteError.ExecFailed);
     }
 

--- a/tests/bundle_test.zig
+++ b/tests/bundle_test.zig
@@ -20,7 +20,7 @@ const TempDb = struct {
         malt.fs_compat.deleteTreeAbsolute(dir) catch {};
         try malt.fs_compat.makeDirAbsolute(dir);
         var db_path_buf: [256]u8 = undefined;
-        const db_path = try std.fmt.bufPrint(&db_path_buf, "{s}/test.db", .{dir});
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/test.db", .{dir}, 0);
         var db = try sqlite.Database.open(db_path);
         errdefer db.close();
         try schema.initSchema(&db);
@@ -316,7 +316,7 @@ test "bundle install honors the global --dry-run flag set by main.zig" {
 
     try malt.cli_bundle.execute(testing.allocator, &.{ "install", bf_path });
 
-    const db_path = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.db", .{dir_z});
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/db/malt.db", .{dir_z}, 0);
     defer testing.allocator.free(db_path);
     var db = try sqlite.Database.open(db_path);
     defer db.close();

--- a/tests/db_schema_v2_test.zig
+++ b/tests/db_schema_v2_test.zig
@@ -15,7 +15,7 @@ const TempDb = struct {
         malt.fs_compat.deleteTreeAbsolute(dir) catch {};
         try malt.fs_compat.makeDirAbsolute(dir);
         var db_path_buf: [256]u8 = undefined;
-        const db_path = try std.fmt.bufPrint(&db_path_buf, "{s}/test.db", .{dir});
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/test.db", .{dir}, 0);
         var db = try sqlite.Database.open(db_path);
         errdefer db.close();
         return .{ .dir = dir, .db = db };
@@ -108,22 +108,6 @@ test "services table accepts inserts and enforces PK" {
     try testing.expectError(sqlite.SqliteError.ConstraintViolation, dup_result);
 }
 
-test "Database.open accepts a 1 KB path" {
-    // Synthetic 1 KB path: we don't need sqlite to actually open it,
-    // just to confirm the internal cap no longer rejects ~1 KB inputs.
-    var buf: [1024]u8 = undefined;
-    @memset(&buf, 'a');
-    buf[0] = '/';
-    const path: []const u8 = buf[0..1024];
-
-    if (sqlite.Database.open(path)) |db_val| {
-        var db = db_val;
-        db.close();
-    } else |err| {
-        try testing.expect(err != sqlite.SqliteError.PathTooLong);
-    }
-}
-
 test "Database.exec accepts 12 KB SQL" {
     var tdb = try TempDb.init("exec_12kb");
     defer tdb.deinit();
@@ -140,7 +124,9 @@ test "Database.exec accepts 12 KB SQL" {
     list.items[list.items.len - 1] = ';';
     try testing.expect(list.items.len >= 12 * 1024);
 
-    try tdb.db.exec(list.items);
+    try list.append(testing.allocator, 0);
+    const sql: [:0]const u8 = list.items[0 .. list.items.len - 1 :0];
+    try tdb.db.exec(sql);
 }
 
 test "bundle_members cascade-deletes with bundle" {

--- a/tests/deps_leak_test.zig
+++ b/tests/deps_leak_test.zig
@@ -33,7 +33,7 @@ const TempDb = struct {
         const dir = "/tmp/malt_deps_leak_test_" ++ tag;
         malt.fs_compat.makeDirAbsolute(dir) catch {};
         var buf: [256]u8 = undefined;
-        const path = try std.fmt.bufPrint(&buf, "{s}/test.db", .{dir});
+        const path = try std.fmt.bufPrintSentinel(&buf, "{s}/test.db", .{dir}, 0);
         var db = try sqlite.Database.open(path);
         errdefer db.close();
         try schema.initSchema(&db);

--- a/tests/deps_test.zig
+++ b/tests/deps_test.zig
@@ -53,7 +53,7 @@ const TempDb = struct {
         const dir = "/tmp/malt_deps_test_" ++ tag;
         malt.fs_compat.makeDirAbsolute(dir) catch {};
         var buf: [256]u8 = undefined;
-        const path = try std.fmt.bufPrint(&buf, "{s}/test.db", .{dir});
+        const path = try std.fmt.bufPrintSentinel(&buf, "{s}/test.db", .{dir}, 0);
         var db = try sqlite.Database.open(path);
         errdefer db.close();
         try schema.initSchema(&db);
@@ -351,7 +351,7 @@ const TempPrefix = struct {
         errdefer malt.fs_compat.deleteTreeAbsolute(root) catch {};
 
         var db_buf: [256]u8 = undefined;
-        const db_path = try std.fmt.bufPrint(&db_buf, "{s}/malt.db", .{root});
+        const db_path = try std.fmt.bufPrintSentinel(&db_buf, "{s}/malt.db", .{root}, 0);
         var db = try sqlite.Database.open(db_path);
         errdefer db.close();
         try schema.initSchema(&db);

--- a/tests/install_execute_test.zig
+++ b/tests/install_execute_test.zig
@@ -135,7 +135,7 @@ test "execute --dry-run with an already-installed package short-circuits" {
     const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{prefix_z});
     defer testing.allocator.free(db_dir);
     try malt.fs_compat.cwd().makePath(db_dir);
-    const db_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt.db", .{db_dir});
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/malt.db", .{db_dir}, 0);
     defer testing.allocator.free(db_path);
 
     var db = try malt.sqlite.Database.open(db_path);

--- a/tests/install_local_test.zig
+++ b/tests/install_local_test.zig
@@ -465,7 +465,7 @@ const sqlite = malt.sqlite;
 const schema = malt.schema;
 
 fn seedLocalKeg(
-    db_path: []const u8,
+    db_path: [:0]const u8,
     prefix: []const u8,
     name: []const u8,
     version: []const u8,

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -48,7 +48,7 @@ const TempDb = struct {
         const dir = "/tmp/malt_install_test_" ++ tag;
         malt.fs_compat.makeDirAbsolute(dir) catch {};
         var db_path_buf: [256]u8 = undefined;
-        const db_path = try std.fmt.bufPrint(&db_path_buf, "{s}/test.db", .{dir});
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/test.db", .{dir}, 0);
         var db = try sqlite.Database.open(db_path);
         errdefer db.close();
         try schema.initSchema(&db);

--- a/tests/list_test.zig
+++ b/tests/list_test.zig
@@ -19,7 +19,7 @@ const TempDb = struct {
         malt.fs_compat.deleteTreeAbsolute(dir) catch {};
         try malt.fs_compat.makeDirAbsolute(dir);
         var buf: [256]u8 = undefined;
-        const path = try std.fmt.bufPrint(&buf, "{s}/test.db", .{dir});
+        const path = try std.fmt.bufPrintSentinel(&buf, "{s}/test.db", .{dir}, 0);
         var db = try sqlite.Database.open(path);
         errdefer db.close();
         try schema.initSchema(&db);

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -318,7 +318,7 @@ test "already-installed kegs are skipped without touching the network" {
     const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt_z});
     defer testing.allocator.free(db_dir);
     try malt.fs_compat.cwd().makePath(db_dir);
-    const db_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt.db", .{db_dir});
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/malt.db", .{db_dir}, 0);
     defer testing.allocator.free(db_path);
 
     var db = try malt.sqlite.Database.open(db_path);
@@ -540,7 +540,7 @@ test "--json on an already-installed keg records it under skipped_installed" {
     const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt_z});
     defer testing.allocator.free(db_dir);
     try malt.fs_compat.cwd().makePath(db_dir);
-    const db_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt.db", .{db_dir});
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/malt.db", .{db_dir}, 0);
     defer testing.allocator.free(db_path);
 
     var db = try malt.sqlite.Database.open(db_path);
@@ -746,7 +746,7 @@ test "mixed outcomes: installed keg is skipped and unknown keg fails at API (404
     const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt_z});
     defer testing.allocator.free(db_dir);
     try malt.fs_compat.cwd().makePath(db_dir);
-    const db_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt.db", .{db_dir});
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/malt.db", .{db_dir}, 0);
     defer testing.allocator.free(db_path);
     var db = try malt.sqlite.Database.open(db_path);
     try malt.schema.initSchema(&db);
@@ -867,7 +867,7 @@ test "already-installed stderr pins the 'Migration complete' + 'Skipped (install
     const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt_z});
     defer testing.allocator.free(db_dir);
     try malt.fs_compat.cwd().makePath(db_dir);
-    const db_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt.db", .{db_dir});
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/malt.db", .{db_dir}, 0);
     defer testing.allocator.free(db_path);
 
     var db = try malt.sqlite.Database.open(db_path);

--- a/tests/services_test.zig
+++ b/tests/services_test.zig
@@ -20,7 +20,7 @@ const TempDb = struct {
         malt.fs_compat.deleteTreeAbsolute(dir) catch {};
         try malt.fs_compat.makeDirAbsolute(dir);
         var db_path_buf: [256]u8 = undefined;
-        const db_path = try std.fmt.bufPrint(&db_path_buf, "{s}/test.db", .{dir});
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/test.db", .{dir}, 0);
         var db = try sqlite.Database.open(db_path);
         errdefer db.close();
         try schema.initSchema(&db);

--- a/tests/store_test.zig
+++ b/tests/store_test.zig
@@ -17,7 +17,7 @@ fn setupTestStore(allocator: std.mem.Allocator) !struct { db: sqlite.Database, s
     defer allocator.free(store_dir);
     malt.fs_compat.makeDirAbsolute(store_dir) catch {};
 
-    const db_path = try std.fmt.allocPrint(allocator, "{s}/test.db", .{prefix});
+    const db_path = try std.fmt.allocPrintSentinel(allocator, "{s}/test.db", .{prefix}, 0);
     defer allocator.free(db_path);
     var db = try sqlite.Database.open(db_path);
     try schema.initSchema(&db);

--- a/tests/uses_test.zig
+++ b/tests/uses_test.zig
@@ -14,7 +14,7 @@ const schema = malt.schema;
 
 fn makeDb(tag: []const u8) !sqlite.Database {
     var path_buf: [256]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, "/tmp/malt_uses_test_{s}.db", .{tag});
+    const path = try std.fmt.bufPrintSentinel(&path_buf, "/tmp/malt_uses_test_{s}.db", .{tag}, 0);
     malt.fs_compat.deleteFileAbsolute(path) catch {};
     var db = try sqlite.Database.open(path);
     try schema.initSchema(&db);


### PR DESCRIPTION
## Description

Replace manual null-termination at the two sqlite wrapper sites with `[:0]const u8` parameters. `Database.open` and `Database.exec` now accept sentinel-terminated slices, dropping the internal stack buffers, `@memcpy`, and explicit NUL writes. Callers construct their paths with `bufPrintSentinel` / `allocPrintSentinel` (or pass string literals, which already coerce). Dead API surface - `MAX_PATH_LEN`, `MAX_SQL_LEN`, `PathTooLong` - is removed.

## Related Issue

- None

## Notes for Reviewers

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)