### PR TITLE
refactor(fs/compat): close std.Io/std.posix migration shim

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -165,6 +165,7 @@ pub fn build(b: *std.Build) void {
         "tests/fs_compat_stream_test.zig",
         "tests/fs_compat_lint_test.zig",
         "tests/fs_compat_sync_test.zig",
+        "tests/fs_compat_primitives_test.zig",
         "tests/ui_color_theme_test.zig",
         "tests/install_local_test.zig",
         "tests/cask_extra_test.zig",

--- a/src/fs/compat.zig
+++ b/src/fs/compat.zig
@@ -34,11 +34,7 @@ pub fn readFileToEndAlloc(file: std.Io.File, allocator: std.mem.Allocator, max_b
 }
 
 pub fn sleepNanos(ns: u64) void {
-    const ts: std.c.timespec = .{
-        .sec = @intCast(ns / std.time.ns_per_s),
-        .nsec = @intCast(ns % std.time.ns_per_s),
-    };
-    _ = std.c.nanosleep(&ts, null);
+    std.Io.sleep(io_mod.ctx(), std.Io.Duration.fromNanoseconds(@intCast(ns)), .awake) catch {};
 }
 
 pub fn randomBytes(buf: []u8) void {
@@ -68,21 +64,15 @@ pub fn readLinkAbsolute(absolute_path: []const u8, buffer: []u8) ![]u8 {
 }
 
 pub fn timestamp() i64 {
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.REALTIME, &ts);
-    return ts.sec;
+    return std.Io.Clock.real.now(io_mod.ctx()).toSeconds();
 }
 
 pub fn nanoTimestamp() i128 {
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.REALTIME, &ts);
-    return @as(i128, ts.sec) * std.time.ns_per_s + ts.nsec;
+    return std.Io.Clock.real.now(io_mod.ctx()).toNanoseconds();
 }
 
 pub fn milliTimestamp() i64 {
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.REALTIME, &ts);
-    return @as(i64, ts.sec) * std.time.ms_per_s + @divTrunc(ts.nsec, std.time.ns_per_ms);
+    return std.Io.Clock.real.now(io_mod.ctx()).toMilliseconds();
 }
 
 /// Closed error set surfaced by `StreamCallback.func`. Keeps callers
@@ -116,20 +106,12 @@ pub fn streamFile(file: File, buf: []u8, cb: StreamCallback) !void {
 }
 
 pub fn isatty(fd: std.posix.fd_t) bool {
-    return std.c.isatty(fd) != 0;
+    const file: std.Io.File = .{ .handle = fd, .flags = .{ .nonblocking = false } };
+    return file.isTty(io_mod.ctx()) catch false;
 }
 
 pub fn getenv(name: []const u8) ?[:0]const u8 {
-    var i: usize = 0;
-    while (std.c.environ[i]) |entry| : (i += 1) {
-        const entry_slice = std.mem.sliceTo(entry, 0);
-        if (entry_slice.len <= name.len) continue;
-        if (entry_slice[name.len] != '=') continue;
-        if (!std.mem.eql(u8, entry_slice[0..name.len], name)) continue;
-        const val_ptr: [*:0]const u8 = @ptrCast(entry + name.len + 1);
-        return std.mem.sliceTo(val_ptr, 0);
-    }
-    return null;
+    return std.process.Environ.getPosix(processEnviron(), name);
 }
 
 pub fn makeDirAbsolute(absolute_path: []const u8) !void {
@@ -205,6 +187,11 @@ pub fn stdinFile() File {
 /// `/usr/local/bin:/bin/:/usr/bin` (see
 /// `std.Io.Threaded.default_PATH`) — that fallback misses `/opt/homebrew/bin`
 /// on Apple Silicon, so `cosign` installed by Homebrew can't be found.
+///
+/// `std.c.environ` is the POSIX stable ABI for the process's environ block;
+/// there is no `std.posix`/`std.Io` equivalent that does not ultimately read
+/// this same pointer. Threading `std.process.Init.Minimal.environ` through
+/// every caller would retire this helper - tracked separately.
 pub fn processEnviron() std.process.Environ {
     var n: usize = 0;
     while (std.c.environ[n] != null) : (n += 1) {}
@@ -287,9 +274,7 @@ pub const File = struct {
 
     /// Partial write (at most one syscall). Returns bytes written.
     pub fn write(self: File, bytes: []const u8) !usize {
-        const rc = std.c.write(self.inner.handle, bytes.ptr, bytes.len);
-        if (rc < 0) return error.WriteFailed;
-        return @intCast(rc);
+        return self.inner.writeStreaming(io_mod.ctx(), &.{}, &.{bytes}, 1);
     }
 
     pub fn updateTimes(self: File, atime_ns: i128, mtime_ns: i128) !void {
@@ -418,13 +403,8 @@ pub const Dir = struct {
     /// Resolve symlinks in `pathname` against `self`, writing the absolute
     /// result into `out_buffer`. Mirrors the 0.15 `Dir.realpath` contract.
     pub fn realpath(self: Dir, pathname: []const u8, out_buffer: []u8) ![]u8 {
-        _ = self;
-        const fd = std.c.open(&(try std.posix.toPosixPath(pathname)), .{ .ACCMODE = .RDONLY }, @as(std.c.mode_t, 0));
-        if (fd < 0) return error.FileNotFound;
-        defer _ = std.c.close(fd);
-        if (std.c.fcntl(fd, std.c.F.GETPATH, out_buffer.ptr) == -1) return error.NameTooLong;
-        const resolved = std.mem.sliceTo(@as([*:0]const u8, @ptrCast(out_buffer.ptr)), 0);
-        return out_buffer[0..resolved.len];
+        const n = try self.inner.realPathFile(io_mod.ctx(), pathname, out_buffer);
+        return out_buffer[0..n];
     }
 
     pub fn readLink(self: Dir, sub_path: []const u8, buffer: []u8) ![]u8 {
@@ -440,11 +420,12 @@ pub const Dir = struct {
         return self.inner.rename(old_sub_path, self.inner, new_sub_path, io_mod.ctx());
     }
 
-    /// Flush directory metadata. `std.Io.Dir` has no sync vtable entry, so
-    /// drop to POSIX `fsync(2)` on the underlying fd — same primitive the
-    /// lock release path uses.
+    /// Flush directory metadata. `std.Io.Dir` has no sync vtable entry,
+    /// so wrap the dir fd as a File and go through the File sync path -
+    /// fsync(2) on a dir fd is what POSIX defines for metadata flush.
     pub fn sync(self: Dir) !void {
-        if (std.c.fsync(self.inner.handle) != 0) return error.SyncFailed;
+        const file: std.Io.File = .{ .handle = self.inner.handle, .flags = .{ .nonblocking = false } };
+        try file.sync(io_mod.ctx());
     }
 
     pub fn openDir(self: Dir, sub_path: []const u8, options: OpenOptions) !Dir {

--- a/tests/fs_compat_primitives_test.zig
+++ b/tests/fs_compat_primitives_test.zig
@@ -1,0 +1,95 @@
+//! malt - fs_compat primitive-helper pinning tests.
+//!
+//! These helpers wrap clock / sleep / tty / env primitives. They're
+//! trivial on the surface but a silent regression (zero clock, noop
+//! sleep, wrong PATH lookup) would corrupt cache timestamps, child
+//! spawn, and color detection. Pin the observable contract so the
+//! std.Io / std.posix migration is provably behavior-preserving.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const fs = malt.fs_compat;
+
+// ── timestamps ───────────────────────────────────────────────────────
+
+test "timestamp returns a positive seconds-since-epoch value" {
+    const t = fs.timestamp();
+    try testing.expect(t > 1_700_000_000); // after 2023-11-14, the project is post-this
+}
+
+test "nanoTimestamp and milliTimestamp stay in lockstep with timestamp" {
+    // Allow 5ms of drift across the three calls - they're independent
+    // reads of CLOCK_REALTIME but should land within the same second
+    // for a sane host clock.
+    const s = fs.timestamp();
+    const ms = fs.milliTimestamp();
+    const ns = fs.nanoTimestamp();
+
+    const ms_from_s = @as(i64, s) * std.time.ms_per_s;
+    try testing.expect(@abs(ms - ms_from_s) < 1_000);
+
+    const ns_from_ms = @as(i128, ms) * std.time.ns_per_ms;
+    try testing.expect(@abs(ns - ns_from_ms) < std.time.ns_per_s);
+}
+
+test "milliTimestamp advances across a short sleep" {
+    const before = fs.milliTimestamp();
+    fs.sleepNanos(5 * std.time.ns_per_ms);
+    const after = fs.milliTimestamp();
+    try testing.expect(after >= before);
+}
+
+// ── sleepNanos ───────────────────────────────────────────────────────
+
+test "sleepNanos returns without error for a tiny duration" {
+    // Smoke: the wrapper must not panic or deadlock on small values.
+    fs.sleepNanos(1_000);
+}
+
+test "sleepNanos waits at least the requested duration" {
+    const want_ns: u64 = 2 * std.time.ns_per_ms;
+    const before = fs.nanoTimestamp();
+    fs.sleepNanos(want_ns);
+    const elapsed: u64 = @intCast(fs.nanoTimestamp() - before);
+    // Generous lower bound - scheduler jitter under CI load can trim a
+    // few hundred microseconds, so accept anything >= half the target.
+    try testing.expect(elapsed >= want_ns / 2);
+}
+
+// ── isatty ───────────────────────────────────────────────────────────
+//
+// Can't assert a specific answer - under `zig build test` stdin/stdout
+// may be pipes, ttys, or nothing depending on CI. Pin the shape: call
+// returns a bool for every std fd without trapping.
+
+test "isatty returns a bool for the three standard fds" {
+    _ = fs.isatty(std.posix.STDIN_FILENO);
+    _ = fs.isatty(std.posix.STDOUT_FILENO);
+    _ = fs.isatty(std.posix.STDERR_FILENO);
+}
+
+test "isatty returns false for a closed / invalid fd" {
+    // fd 999 is almost certainly not open in the test runner.
+    try testing.expect(!fs.isatty(999));
+}
+
+// ── getenv ───────────────────────────────────────────────────────────
+
+test "getenv returns null for an unset variable" {
+    try testing.expect(fs.getenv("MALT_DEFINITELY_UNSET_XYZ_9f3a2") == null);
+}
+
+test "getenv returns the value for a set variable" {
+    // PATH is set in every sane shell env; fall back to HOME if not.
+    const v = fs.getenv("PATH") orelse fs.getenv("HOME") orelse return error.SkipZigTest;
+    try testing.expect(v.len > 0);
+}
+
+test "getenv does not match a prefix-only name" {
+    // A classic environ-walk bug: matching "PAT" against "PATH=...".
+    // Pin that prefix matches do NOT leak through.
+    if (fs.getenv("PATH") == null) return error.SkipZigTest;
+    try testing.expect(fs.getenv("PAT") == null);
+    try testing.expect(fs.getenv("PATH_") == null);
+}


### PR DESCRIPTION
## Description

Retire the libc helpers from `src/fs/compat.zig` - `sleepNanos`, `timestamp` / `nanoTimestamp` / `milliTimestamp`, `isatty`, `Dir.sync`, `File.write`, `Dir.realpath`, and `getenv` now call `std.Io` / `std.process.Environ` / `std.Io.File` primitives rather than `std.c.nanosleep` / `clock_gettime` / `isatty` / `fsync` / `write` / `fcntl(F_GETPATH)` / a hand-rolled `environ` walk.

The only `std.c.*` reference left in the file is the read of `std.c.environ` inside `processEnviron()`. That pointer is the POSIX stable ABI for the process environ block; there is no `std.posix` / `std.Io` equivalent that does not ultimately alias it. Threading `std.process.Init.Minimal.environ` through every caller would retire it; that is a structural follow-up, not a libc-bypass.

## Related Issue

- None

## Notes for Reviewers

- None