### PR TITLE
docs(src): collapse multi-paragraph comments to one load-bearing line

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1,6 +1,5 @@
-//! malt — install command
-//! Install formulas, casks, or tap formulas.
-//! Implements the 9-step atomic install protocol.
+//! malt — install command.
+//! 9-step atomic install protocol for formulas, casks, and tap formulas.
 
 const std = @import("std");
 
@@ -128,19 +127,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // allowing programmatic callers to pass `--dry-run` directly in `args`.
     var dry_run = output.isDryRun();
     var force = false;
-    // `--use-system-ruby` scope: the audit flagged a session-wide flag
-    // as an auto-fallback trust widener. We keep the flag ergonomic
-    // when a single formula is installed (bare flag implies that
-    // formula) but require an explicit `--use-system-ruby=name[,name]`
-    // list when multiple formulas are queued, so a DSL parse failure
-    // on one never enables Ruby for the rest.
+    // Scoped `--use-system-ruby` — a bare flag with multiple formulas would
+    // let a DSL parse failure on one silently widen Ruby trust across the rest.
     var use_system_ruby_bare = false;
     var use_system_ruby_scope: std.ArrayList([]const u8) = .empty;
     defer use_system_ruby_scope.deinit(allocator);
-    // `--local` forces every positional argument to be interpreted as a
-    // path to a `.rb` file. The flag is the explicit opt-in that
-    // captures the "I trust this file" decision in argv, rather than
-    // leaving it to shape-based autodetection.
+    // `--local` forces .rb-path interpretation — explicit trust opt-in in
+    // argv instead of shape-based autodetection.
     var local_only = false;
 
     // StaticStringMap + exhaustive switch: the compiler checks every flag
@@ -169,18 +162,12 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     if (local_only and packages.items.len == 0) {
-        // User-facing argv error — emit the one-liner and exit clean.
-        // Returning `error.Aborted` (per the main.zig contract) avoids
-        // the "error: LocalFormulaMissingPath" stack trace that raw
-        // InstallError variants trigger.
+        // `error.Aborted` per the main.zig contract — avoids a raw stack trace.
         output.err("--local requires a path to a .rb file", .{});
         return error.Aborted;
     }
 
-    // `--local` conflicts with other mode flags. Rather than silently
-    // letting path-shape detection win, refuse ambiguous argv up front
-    // so "install --local --cask ./foo.rb" cannot quietly drop the
-    // cask pathway or vice versa.
+    // Refuse ambiguous argv so `--local` cannot silently drop another mode.
     if (local_only) {
         if (force_cask) {
             output.err("--local cannot be combined with --cask (a .rb file is never a cask)", .{});
@@ -201,9 +188,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         return InstallError.NoPackages;
     }
 
-    // Disambiguate bare `--use-system-ruby`: accept it as shorthand
-    // when exactly one formula was listed; otherwise the user must
-    // name which formulas should get the wider path.
+    // Bare `--use-system-ruby` only valid for a single formula; otherwise
+    // require an explicit scope.
     if (use_system_ruby_bare) {
         if (packages.items.len == 1) {
             try use_system_ruby_scope.append(allocator, packages.items[0]);
@@ -220,10 +206,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // Initialize infrastructure
     const prefix = atomic.maltPrefix();
 
-    // Sanity cap: refuse absurdly long prefixes before any network
-    // activity. Realistic values sail through — install_name_tool grows
-    // overflowing load-command slots into the bottle's __LINKEDIT
-    // padding.
+    // Absurdly long prefixes overflow install_name_tool's load-command slots.
     checkPrefixSane(prefix) catch |err| switch (err) {
         error.PrefixAbsurd => {
             output.err(
@@ -264,17 +247,12 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     };
     defer lk.release();
 
-    // Set up HTTP client (single-threaded main-thread use — formula
-    // lookups, cask probe, top-level `fetchFormula`). Worker threads
-    // borrow from the pool below instead of touching this instance.
+    // Main-thread HTTP client; workers borrow from `http_pool` instead.
     var http = client_mod.HttpClient.init(allocator);
     defer http.deinit();
 
-    // Shared HTTP client pool for worker threads. Each worker
-    // (download + parallel resolve) borrows an idle client for the
-    // duration of one request so TLS contexts are reused across
-    // calls. 4 slots is the same budget the P5 materialize pool uses
-    // and is enough to saturate cold installs on typical machines.
+    // 4-slot worker pool — same budget as the materialize pool; enough to
+    // saturate cold installs while reusing TLS contexts.
     var http_pool = client_mod.HttpClientPool.init(allocator, 4) catch {
         output.err("Failed to initialise HTTP client pool", .{});
         return InstallError.DownloadFailed;
@@ -312,19 +290,12 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             return;
         }
 
-        // Local .rb path (explicit via --local, or shape-detected — a
-        // leading `.`/`/`/`~` or embedded slash plus a `.rb` suffix).
-        // Path wins over tap-form when `.rb` is present so a typo like
-        // `user/repo/foo.rb` gets a clean local-file error instead of
-        // a confusing GitHub 404.
+        // Path wins over tap-form when `.rb` is present — a typo like
+        // `user/repo/foo.rb` hits local-file error, not a GitHub 404.
         if (local_only or isLocalFormulaPath(pkg_name)) {
             installLocalFormula(allocator, pkg_name, &db, &linker, prefix, dry_run, force) catch |e| {
-                // The inner function has already emitted a specific
-                // error line (missing file, insecure URL, parse
-                // failure, …). Only append the generic summary for
-                // errors whose internal message didn't cover the
-                // "what" — keeps single-package failures from printing
-                // two red lines for one problem.
+                // Skip the generic summary when the inner error line already
+                // told the user what went wrong.
                 if (!localErrorIsAnnounced(e)) {
                     output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
                 }
@@ -420,16 +391,9 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             output.info("Downloading {d} bottles...", .{to_download});
         }
 
-        // GHCR token prefetch: fold every distinct repo in the batch
-        // into a single multi-scope `/token` round-trip so each
-        // download worker hits the cache instead of racing its own
-        // token fetch. On a 12-dep install this turns 12 sequential
-        // token round-trips into 1. `prefetchTokens` is best-effort;
-        // on any error we leave the cache empty and workers fall back
-        // to per-repo fetches (the old behaviour, one round-trip each).
-        // OOM during prefetch bookkeeping must not be swallowed: subsequent
-        // install phases depend on allocator integrity. Token prefetch itself
-        // stays best-effort — a cache miss falls back to per-worker fetches.
+        // Fold every repo into one multi-scope `/token` round-trip; workers
+        // hit the cache instead of racing. Bookkeeping OOM must propagate —
+        // only the token fetch itself is best-effort.
         var repo_set: std.StringHashMapUnmanaged(void) = .empty;
         defer repo_set.deinit(allocator);
         for (all_jobs.items) |*job| {
@@ -460,11 +424,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         }
         var multi = progress_mod.MultiProgress.init(download_index);
 
-        // Allocate all progress bars in the main thread so we can render an
-        // initial frame on every reserved line BEFORE spawning workers. This
-        // avoids a blank row when a later worker thread is scheduled before
-        // an earlier one. Bars live in a stable slice so the pointers we
-        // hand to worker threads remain valid.
+        // Main-thread bar allocation — draw an initial frame on every line
+        // before workers spawn, and keep pointers stable for them.
         var bars: []progress_mod.ProgressBar = &.{};
         if (allocator.alloc(progress_mod.ProgressBar, download_index)) |s| {
             bars = s;
@@ -518,27 +479,12 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     // ── Parallel materialize phase ──────────────────────────────────
-    //
-    // Each materialize step (clonefile + Mach-O patch + codesign) is
-    // independent — workers never touch each other's keg paths. Shared
-    // state (linker conflict check, SQLite INSERTs, `failed_kegs`) is
-    // deferred to the serial link phase below.
-    //
-    // The old flow ran `materializeAndLink` serially per job, which on
-    // cold installs of large formulae like ffmpeg (11 deps) added up to
-    // ~3 s of back-to-back materialize work.
-    //
-    // **Bounded** pool — max 4 workers. Unbounded parallelism (one
-    // thread per job) turned into page-cache thrashing and codesign
-    // subprocess contention on warm ffmpeg, regressing that workload
-    // ~160 ms. Four workers preserves the cold-install speedup (I/O
-    // and subprocess wait overlap) while keeping cache pressure low.
+    // Materialize steps are per-keg independent; shared state is deferred
+    // to the serial link phase. 4-worker cap — unbounded spawn regressed
+    // warm ffmpeg via page-cache + codesign contention.
     const mats = allocator.alloc(MaterializeResult, all_jobs.items.len) catch
         return InstallError.CellarFailed;
-    // Two defers (LIFO): the keg-path loop needs `mats` alive, so free the
-    // outer slice last. Splits the two allocator contracts into distinct
-    // statements so the reader doesn't have to track which slice came from
-    // which allocator.
+    // LIFO defers: keg paths freed first (c_allocator), outer slice last.
     defer allocator.free(mats);
     defer for (mats) |m| {
         if (m.keg_path.len > 0) std.heap.c_allocator.free(m.keg_path);
@@ -575,11 +521,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     // ── Serial link + record phase ──────────────────────────────────
-    //
-    // Runs in dep order (the jobs list came out of `collectFormulaJobs`
-    // dep-sorted) so `findFailedDep` correctly propagates failures down
-    // the graph. Linker conflict checks and SQLite writes are not
-    // thread-safe, so this phase cannot be parallelised.
+    // Runs in dep order so `findFailedDep` propagates failures down the
+    // graph; linker + SQLite writes cannot be parallelised.
     var failed_kegs = std.StringHashMap(void).init(allocator);
     defer failed_kegs.deinit();
     var failed_count: usize = 0;
@@ -611,10 +554,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             continue;
         }
 
-        // Skip if any runtime dep has already failed — installing on top of a
-        // broken dep graph produces a keg that dyld cannot resolve at runtime.
-        // The keg has already been materialised into the Cellar by a worker;
-        // remove it before continuing so we do not leave orphans behind.
+        // Failed-dep → skip: installing on a broken graph yields a dyld-unresolvable
+        // keg. Remove the already-materialised keg so orphans don't linger.
         if (findFailedDep(&failed_kegs, job.formula_json)) |failed_dep| {
             output.warn(
                 "Skipping {s}: dependency {s} failed to install",
@@ -650,13 +591,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 }
 
-/// Main-thread link + record phase for a single job that already had
-/// its bottle materialised into the Cellar by a worker. Parses the
-/// formula JSON, checks symlink conflicts, creates symlinks, and
-/// writes the keg + dependency rows into the DB.
-///
-/// Must run serially — linker conflict checking reads the current
-/// symlink state and SQLite writes are not safe from multiple writers.
+/// Link + record a materialised keg. Must run serially: linker conflict
+/// checks read live symlink state and SQLite is single-writer.
 fn linkAndRecord(
     allocator: std.mem.Allocator,
     job: *DownloadJob,
@@ -724,10 +660,7 @@ fn linkAndRecord(
 }
 
 /// Register a launchd service when the formula carries a `service:` block.
-/// Best-effort: failures only emit a warning so they don't fail the install.
-/// Path validation (interpreter bait, path escape, argv caps) is run
-/// inside `supervisor.register` against the formula's cellar + the
-/// install prefix.
+/// Best-effort: failures warn but don't fail the install.
 fn maybeRegisterService(
     allocator: std.mem.Allocator,
     db: *sqlite.Database,

--- a/src/cli/purge.zig
+++ b/src/cli/purge.zig
@@ -1,34 +1,5 @@
-//! malt — purge command
-//! Unified housekeeping + nuclear-wipe command.  A scope flag selects
-//! what to remove; without one, the command refuses to run.
-//!
-//! Scopes (one or more required):
-//!   --store-orphans  Refcount-0 blobs in {prefix}/store
-//!   --unused-deps    Indirect-install kegs no other package needs
-//!   --cache[=DAYS]   Cache files older than DAYS (default 30)
-//!   --downloads      Wipe {cache}/downloads entirely
-//!   --stale-casks    Cask cache + Caskroom entries for uninstalled casks
-//!   --old-versions   Non-latest versions in {prefix}/Cellar
-//!   --housekeeping   = --store-orphans --unused-deps --cache --stale-casks
-//!   --wipe           Nuclear: remove every malt artefact from disk
-//!
-//! Shared flags:
-//!   --dry-run, -n        Preview only (also recognised as the global flag)
-//!   --yes, -y            Skip every typed confirmation prompt
-//!   --quiet, -q          Suppress per-item output
-//!   --backup, -b PATH    Write a `mt restore`-compatible manifest first
-//!
-//! --wipe-only flags:
-//!   --keep-cache         Do not remove the cache directory
-//!   --remove-binary      Also unlink /usr/local/bin/{mt,malt}
-//!
-//! Confirmation gates (skippable with --yes):
-//!   --wipe          → type "purge"
-//!   --downloads     → type "downloads"
-//!   --old-versions  → type "old-versions"
-//!
-//! Non-goals:
-//!   * Per-package removal — use `mt uninstall <name>`.
+//! malt — purge command: housekeeping and nuclear-wipe scopes.
+//! Refuses to run without a scope flag; full flag reference in `mt purge --help`.
 
 const std = @import("std");
 const atomic = @import("../fs/atomic.zig");

--- a/src/core/deps.zig
+++ b/src/core/deps.zig
@@ -1,5 +1,4 @@
-//! malt — dependency resolution
-//! BFS dependency resolution with cycle detection and orphan finding.
+//! malt — BFS dep resolution with cycle detection and orphan finding.
 
 const std = @import("std");
 const sqlite = @import("../db/sqlite.zig");
@@ -17,17 +16,9 @@ pub const ResolvedDep = struct {
     already_installed: bool,
 };
 
-/// Resolve all dependencies for a formula using BFS.
-/// Returns dependencies in topological order (deps before dependents).
-/// Skips already-installed packages.
-///
-/// Ownership: each returned `ResolvedDep.name` is heap-allocated with
-/// `allocator` and the caller must free both every `name` and the outer
-/// slice. `getDeps` already hands us duped strings, so every string we
-/// receive from it is either (a) moved into `result`, (b) moved into
-/// `queue` for later processing, or (c) freed on the spot. Nothing is
-/// allowed to escape silently — earlier versions leaked duped dep
-/// strings any time BFS skipped a name via the `visited` set.
+/// BFS resolve returning deps in topological order; skips already-installed.
+/// Caller frees each `ResolvedDep.name` and the outer slice. Every string
+/// from `getDeps` is either moved into `result`/`queue` or freed on the spot.
 pub fn resolve(
     allocator: std.mem.Allocator,
     root_name: []const u8,
@@ -72,11 +63,8 @@ pub fn resolve(
             continue;
         }
 
-        // Transfer ownership of `dep_name` into `result` BEFORE marking it
-        // in `visited`. That way `visited`'s key borrows from `result`'s
-        // stable storage — if we did it the other way round and the
-        // append failed, we'd either leak the string or leave `visited`
-        // with a dangling key.
+        // Append to `result` before marking `visited` — `visited` borrows from
+        // `result`'s stable storage, and reversing risks leak or dangle on OOM.
         const installed = isInstalled(db, dep_name);
         result.append(allocator, .{
             .name = dep_name,

--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -95,10 +95,7 @@ pub const Parser = struct {
         return self.maybeWrapPostfix(expr);
     }
 
-    /// Wrap `body` in a postfix_if/postfix_unless if the current token is
-    /// `if`/`unless`, otherwise return it unchanged. Used for both regular
-    /// expression statements and `return` — Ruby lets either form appear
-    /// with a trailing guard.
+    /// Optional `if`/`unless` postfix-guard wrap; used for exprs and `return`.
     fn maybeWrapPostfix(self: *Parser, body: *const Node) DslError!*const Node {
         if (self.current.kind == .kw_if) {
             self.advanceToken();
@@ -120,11 +117,8 @@ pub const Parser = struct {
     }
 
     fn parseExpression(self: *Parser) DslError!*const Node {
-        // `if` / `unless` on the RHS of an assignment is Ruby's
-        // expression-form. The statement-level parse already handles the
-        // standalone form; accepting them here lets
-        // `sysroot = if cond then "a" else "b" end` round-trip through
-        // parseExpression without special-casing at the call site.
+        // Expression-form `if`/`unless` on RHS of assignment — lets
+        // `x = if cond then a else b end` round-trip without call-site hacks.
         if (self.current.kind == .kw_if) return self.parseIf();
         if (self.current.kind == .kw_unless) return self.parseUnless();
 
@@ -133,11 +127,9 @@ pub const Parser = struct {
             const name = self.current.lexeme;
             const loc = self.currentLoc();
 
-            // Peek ahead to see if next non-newline token is =. All
-            // lexer state that `next()` may mutate must be saved here,
-            // including the heredoc fields — otherwise a peek that
-            // straddles a heredoc boundary would clobber the lexer's
-            // mid-collection state.
+            // Peek past newlines for `=`. All mutable lexer state — including
+            // heredoc fields — must be saved, or a peek across a heredoc
+            // boundary corrupts mid-collection state.
             const saved_pos = self.lexer.pos;
             const saved_line = self.lexer.line;
             const saved_col = self.lexer.col;
@@ -354,10 +346,7 @@ pub const Parser = struct {
         return self.finishCallWithBlock(loc, receiver, method, &args, block_pass);
     }
 
-    /// Shared bare-argument guard: the current token could start an
-    /// expression AND is not one of the keywords that signal statement
-    /// boundaries (if/unless/end/do/dot/newline). Used by every call
-    /// form that accepts paren-less arguments.
+    /// True when the current token could open a paren-less argument list.
     fn currentLooksLikeBareArg(self: *const Parser) bool {
         const k = self.current.kind;
         return isExprStart(k) and k != .newline and k != .kw_if and
@@ -1024,11 +1013,8 @@ pub const Parser = struct {
         });
     }
 
-    /// Collect a comma-separated identifier list for `def` params. Shared
-    /// between paren and bare forms; the caller consumes the paren (or
-    /// newline) that terminates the list. Unknown tokens (default args,
-    /// `*rest`, `&blk`) stop the loop — formulas using those degrade to
-    /// `--use-system-ruby` via the sibling parse-check.
+    /// Collect a comma-separated ident list for `def` params; unknown tokens
+    /// stop the loop and degrade the formula to `--use-system-ruby`.
     fn parseDefParams(
         self: *Parser,
         params: *std.ArrayList([]const u8),
@@ -1119,10 +1105,8 @@ pub const Parser = struct {
         return parts_list.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
     }
 
-    /// Parse a single arg inside a method-call arg list. Returns either a
-    /// positional expression node or a block-pass payload (`&<primary>`).
-    /// Block-pass is always the last arg per Ruby grammar; callers break
-    /// out of their arg loop when they see one.
+    /// Parse one arg; `&<primary>` yields a block-pass (always last per
+    /// Ruby grammar, callers break on it).
     const ArgOutcome = union(enum) {
         arg: *const Node,
         block_pass: *const Node,

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -1,21 +1,5 @@
-//! malt — macOS sandbox-exec profile + spawn wrapper for the Ruby
-//! post_install subprocess.
-//!
-//! This module is the OS-level containment layer for the explicit
-//! `--use-system-ruby` path. Ruby code from a hostile formula running
-//! under the user's UID is the threat; the containment goal is:
-//!
-//!   - confine writes to the formula's own cellar and a small set of
-//!     shared directories under MALT_PREFIX (etc, var, share, opt),
-//!   - block network entirely,
-//!   - strip environment vars that alter dynamic-loader or Ruby
-//!     behaviour (DYLD_*, RUBYOPT, etc.),
-//!   - clamp CPU / memory / file-size budgets so a runaway script
-//!     fails fast instead of exhausting the user's machine.
-//!
-//! The sandbox profile is rendered per formula at spawn time. Paths are
-//! validated against a conservative charset before interpolation to
-//! keep the profile string free of SCL metacharacters.
+//! malt — macOS sandbox-exec wrapper for `--use-system-ruby` post_install.
+//! Confines writes, blocks network, scrubs env, and clamps resource limits.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -35,23 +19,17 @@ pub const SandboxError = error{
     ChildExited,
 };
 
-/// Resource caps applied to the sandboxed child before `execve`.
-/// Conservative defaults — a well-behaved post_install hook never hits
-/// any of these. Operators can widen via formula-level config later if
-/// a real regression shows up.
+/// Resource caps applied before `execve`. Conservative defaults.
 pub const Limits = struct {
-    /// Wall-clock CPU seconds. macOS counts user+system.
+    /// Wall-clock CPU seconds (user+system).
     cpu_seconds: u64 = 300,
-    /// Virtual address space ceiling (RLIMIT_AS). 2 GiB is generous
-    /// for any post_install that isn't mining.
+    /// RLIMIT_AS ceiling.
     address_space_bytes: u64 = 2 * 1024 * 1024 * 1024,
-    /// Largest single file the child may create (RLIMIT_FSIZE).
+    /// RLIMIT_FSIZE per-file cap.
     file_size_bytes: u64 = 512 * 1024 * 1024,
 };
 
-/// Environment slots propagated to the sandboxed child. Everything not
-/// in this list is dropped at `execve` time — in particular the
-/// dynamic-loader knobs and Ruby's global preload hooks.
+/// Allowlist propagated to the child; DYLD_* and RUBYOPT/RUBYLIB are dropped.
 pub const ScrubbedEnv = struct {
     home: []const u8,
     path: []const u8,
@@ -59,19 +37,10 @@ pub const ScrubbedEnv = struct {
     tmpdir: []const u8,
 };
 
-/// Minimal PATH passed through to the sandboxed child. Anything more
-/// ambitious lets a hostile formula exploit whatever random binary
-/// happens to live in the user's homebrew/cargo/npm prefixes.
+/// Minimal PATH — keeps a hostile formula off user-owned bin prefixes.
 pub const SANDBOX_PATH: []const u8 = "/usr/bin:/bin:/usr/sbin:/sbin";
 
-/// Validate that a path is safe to splice into a sandbox-exec profile
-/// string. Rejects quote, backslash, parenthesis, newline, and NUL —
-/// any of which could break out of the `(subpath "...")` token.
-///
-/// malt's cellar paths are built from [a-z0-9@._+-/] formula names and
-/// version strings concatenated with a known prefix, so well-formed
-/// input passes; this guards against a malformed MALT_PREFIX or an
-/// unusual formula version slipping through.
+/// Reject any byte that could break out of a `(subpath "...")` token.
 pub fn validatePathForProfile(p: []const u8) SandboxError!void {
     if (p.len == 0 or p[0] != '/') return SandboxError.UnsafePath;
     for (p) |c| switch (c) {
@@ -80,11 +49,8 @@ pub fn validatePathForProfile(p: []const u8) SandboxError!void {
     };
 }
 
-/// Render a sandbox-exec profile SCL string for a Ruby post_install
-/// run. Deny-by-default; file-read broadly; file-write only under
-/// `cellar_path` and the four shared subtrees of `malt_prefix`.
-///
-/// Caller owns the returned slice.
+/// Render the deny-by-default SCL profile; writes limited to `cellar_path`
+/// and four subtrees of `malt_prefix`. Caller owns the slice.
 pub fn renderRubyProfile(
     allocator: std.mem.Allocator,
     cellar_path: []const u8,
@@ -145,10 +111,7 @@ fn applyRlimits(limits: Limits) SandboxError!void {
         return SandboxError.RlimitFailed;
 }
 
-/// Build a null-terminated envp array from an allowlist. Everything
-/// outside the allowlist is dropped — in particular DYLD_*, RUBYOPT,
-/// RUBYLIB, GEM_* and friends. Public so tests can feed a scrubbed env
-/// into `spawnFilteredWithHooks`.
+/// Build a null-terminated envp from the allowlist; everything else dropped.
 pub fn buildEnvp(
     allocator: std.mem.Allocator,
     env: ScrubbedEnv,
@@ -181,9 +144,7 @@ pub fn freeEnvp(allocator: std.mem.Allocator, envp: [:null]?[*:0]u8) void {
     allocator.free(envp[0 .. i + 1]);
 }
 
-/// Build a null-terminated argv array. Caller owns; free with
-/// `freeArgv`. Public so test binaries can drive `spawnFilteredWithHooks`
-/// without duplicating the sentinel-array plumbing.
+/// Build a null-terminated argv; free with `freeArgv`. Caller owns.
 pub fn buildArgv(
     allocator: std.mem.Allocator,
     argv: []const []const u8,
@@ -209,19 +170,9 @@ pub fn freeArgv(allocator: std.mem.Allocator, argv: [:null]?[*:0]u8) void {
     allocator.free(argv[0 .. i + 1]);
 }
 
-/// Spawn `ruby tmp_script` under `sandbox-exec -p <profile>`, a
-/// scrubbed env, and the resource limits. Streams stdout/stderr from
-/// the child directly to the current process's stdout/stderr.
-///
-/// Returns the child's exit code on normal exit, or a SandboxError
-/// if the child was killed by a signal / the sandbox couldn't be
-/// applied / the fork-exec itself failed.
-///
-/// The child's stdout/stderr are filtered through a terminal escape-
-/// sequence sanitizer (`term_sanitize`) before being forwarded to the
-/// parent's fds, so a hostile formula cannot emit OSC/DCS/cursor
-/// commands that rewrite scrollback or exfiltrate via terminal
-/// extensions. Set `MALT_ALLOW_RAW_POST_INSTALL=1` to bypass.
+/// Spawn `ruby tmp_script` under `sandbox-exec` with scrubbed env and limits.
+/// Child stdout/stderr are run through `term_sanitize` to strip OSC/DCS/cursor
+/// escapes before forwarding; `MALT_ALLOW_RAW_POST_INSTALL=1` bypasses.
 pub fn runRubySandboxed(
     allocator: std.mem.Allocator,
     ruby_path: []const u8,
@@ -276,9 +227,8 @@ fn spawnInherit(
     return @intCast(wexitstatus(status));
 }
 
-/// Sentinel-backed fd wrapper. `closeOnce` is idempotent and zeroes the
-/// value after close, so an errdefer registered on the same fd cannot
-/// double-close an fd that another code path already dropped explicitly.
+/// Idempotent fd wrapper — `closeOnce` zeroes the value so `errdefer`
+/// can't double-close an fd another path already dropped.
 const Fd = struct {
     value: c_int = -1,
 
@@ -297,18 +247,11 @@ fn openPipe(reader: *Fd, writer: *Fd) SandboxError!void {
     writer.value = buf[1];
 }
 
-/// Test-only hooks to drive rare error paths in `spawnFilteredWithHooks`.
-/// Production callers pass the zero-value default; only the in-module
-/// tests populate these fields, so the seam has no runtime cost in
-/// shipped builds.
+/// Test-only hooks; zero-value in production.
 pub const SpawnHooks = struct {
-    /// Force the Nth (0-indexed) `std.Thread.spawn` call to fail with
-    /// `error.SystemResources`. Exercises the thread-spawn-failure path
-    /// without inducing real OS pressure.
+    /// Force the Nth thread spawn to return `error.SystemResources`.
     fail_thread_spawn_on: ?u32 = null,
-    /// Invoked with the child's pid right after the parent `waitpid`s
-    /// it on an error path. Lets tests observe that the child was
-    /// reaped before the error propagates to the caller.
+    /// Invoked after the parent waitpid's the child on an error path.
     on_child_reaped: ?*const fn (pid: std.c.pid_t, ctx: ?*anyopaque) void = null,
     ctx: ?*anyopaque = null,
 };
@@ -331,9 +274,7 @@ fn maybeSpawnFilter(
     return std.Thread.spawn(.{}, filterLoop, .{ pipe_fd, out_fd });
 }
 
-/// Kill a running child and block until it is reaped. Safe to call when
-/// the child is already gone — SIGKILL on a missing pid is ignored, and
-/// `waitpid` tolerates the zombie/reaped states we could land in.
+/// Kill and reap; safe on already-dead pids (ESRCH/zombie are tolerated).
 fn reapChild(pid: std.c.pid_t, hooks: SpawnHooks) void {
     std.posix.kill(pid, std.posix.SIG.KILL) catch {}; // ESRCH means already dead
     var status: c_int = 0;

--- a/src/fs/compat.zig
+++ b/src/fs/compat.zig
@@ -1,13 +1,5 @@
-//! 0.15-style `std.fs` / `std.posix.getenv` shim backed by the 0.16
-//! `std.Io` APIs. Lets us carry the existing filesystem call-shape
-//! through the migration without threading an `Io` context into every
-//! caller. Long-term callers should accept `std.process.Init` and
-//! route a real `Io` through, at which point this shim can retire.
-//!
-//! Every helper pulls its `Io` from `io_mod.ctx()` (the default
-//! `std.Options.debug_io`). Behaviour matches the 0.15 APIs: absolute
-//! path operations, `cwd` rooted operations, and env-var lookup via
-//! the libc `environ` array.
+//! 0.15-style `std.fs` / `std.posix.getenv` shim over the 0.16 `std.Io` APIs.
+//! Helpers pull `Io` from `io_mod.ctx()`; retires once callers thread `Io`.
 
 const std = @import("std");
 const io_mod = @import("../ui/io.zig");
@@ -16,15 +8,8 @@ pub const path = std.fs.path;
 pub const max_path_bytes = std.Io.Dir.max_path_bytes;
 pub const max_name_bytes = std.Io.Dir.max_name_bytes;
 
-/// Look up an environment variable via the libc `environ` array. Matches
-/// the 0.15 `std.posix.getenv` contract: returns a sentinel-terminated
-/// slice that points into the global environment block, or `null` when
-/// the variable is unset.
-/// 0.15-style `File.readToEndAlloc` for callers that still receive a raw
-/// `std.Io.File` (e.g. from `child.stdout.?`). Streams the whole file
-/// through a per-call `Threaded` io into an `ArrayList`. The default
-/// `debug_io` won't work here because reading a child pipe blocks and
-/// needs the threaded io's wait/poll machinery.
+/// Read a raw `std.Io.File` to end on a per-call `Threaded` io — the default
+/// `debug_io` can't wait on blocking child pipes.
 pub fn readFileToEndAlloc(file: std.Io.File, allocator: std.mem.Allocator, max_bytes: usize) ![]u8 {
     var threaded: std.Io.Threaded = .init(allocator, .{});
     defer threaded.deinit();
@@ -75,23 +60,17 @@ pub fn milliTimestamp() i64 {
     return std.Io.Clock.real.now(io_mod.ctx()).toMilliseconds();
 }
 
-/// Closed error set surfaced by `StreamCallback.func`. Keeps callers
-/// exhaustive: a new callback failure mode must land here or it cannot
-/// be plumbed through the vtable.
+/// Closed error set for `StreamCallback.func`; forces exhaustive handling.
 pub const StreamError = error{ OutOfMemory, CallbackAborted };
 
-/// Context + function pair for `streamFile`. The func receives every
-/// chunk exactly once, in order — any non-void error aborts the walk
-/// and propagates out to the caller.
+/// Context + func for `streamFile`; a non-void error aborts the walk.
 pub const StreamCallback = struct {
     context: *anyopaque,
     func: *const fn (context: *anyopaque, chunk: []const u8) StreamError!void,
 };
 
-/// Walk `file` from start to EOF in `buf`-sized chunks, invoking `cb`
-/// on each chunk. Advancing-offset positional reads — the obvious way
-/// to stream a file without tripping on `readAll`'s offset-0
-/// behaviour. Fails fast on a zero-length buffer (would loop).
+/// Stream `file` to EOF in `buf`-sized chunks via advancing positional reads.
+/// Fails fast on a zero-length buffer (would loop).
 pub fn streamFile(file: File, buf: []u8, cb: StreamCallback) !void {
     if (buf.len == 0) return error.InvalidArgument;
     var offset: u64 = 0;
@@ -153,9 +132,7 @@ pub fn renameAbsolute(old_path: []const u8, new_path: []const u8) !void {
     return std.Io.Dir.renameAbsolute(old_path, new_path, io_mod.ctx());
 }
 
-/// 0.15-style `readFileAlloc` convenience for absolute paths. Opens,
-/// reads up to `max_bytes`, closes - composes the existing primitives
-/// so callers don't reinvent the open/defer/read dance.
+/// 0.15-style `readFileAlloc` convenience for absolute paths.
 pub fn readFileAbsoluteAlloc(allocator: std.mem.Allocator, absolute_path: []const u8, max_bytes: usize) ![]u8 {
     const f = try openFileAbsolute(absolute_path, .{});
     defer f.close();
@@ -166,9 +143,7 @@ pub fn cwd() Dir {
     return .{ .inner = std.Io.Dir.cwd() };
 }
 
-/// 0.15-style `fs_compat.stderrFile()` / `stdout()` / `stdin()` — return the
-/// shim wrapper so `.writeAll` / `.supportsAnsiEscapeCodes` etc. work
-/// without threading `io` through callers.
+/// 0.15-style std stream accessors returning the shim `File`.
 pub fn stderrFile() File {
     return .{ .inner = io_mod.stderrFile() };
 }
@@ -181,17 +156,9 @@ pub fn stdinFile() File {
     return .{ .inner = std.Io.File.stdin() };
 }
 
-/// View of the parent process's `environ` as a `std.process.Environ`.
-/// `std.Io.Threaded.init(.., .{})` defaults to an empty environ, which makes
-/// child spawns inherit nothing and forces PATH lookup onto a hard-coded
-/// `/usr/local/bin:/bin/:/usr/bin` (see
-/// `std.Io.Threaded.default_PATH`) — that fallback misses `/opt/homebrew/bin`
-/// on Apple Silicon, so `cosign` installed by Homebrew can't be found.
-///
-/// `std.c.environ` is the POSIX stable ABI for the process's environ block;
-/// there is no `std.posix`/`std.Io` equivalent that does not ultimately read
-/// this same pointer. Threading `std.process.Init.Minimal.environ` through
-/// every caller would retire this helper - tracked separately.
+/// Parent `environ` as `std.process.Environ`. `std.Io.Threaded`'s default is
+/// empty, which falls back to a PATH that misses `/opt/homebrew/bin` on Apple
+/// Silicon and hides `cosign`.
 pub fn processEnviron() std.process.Environ {
     var n: usize = 0;
     while (std.c.environ[n] != null) : (n += 1) {}
@@ -199,11 +166,7 @@ pub fn processEnviron() std.process.Environ {
     return .{ .block = .{ .slice = slice } };
 }
 
-/// 0.15-style `std.process.Child` shim. The 0.16 API moved spawn/wait into
-/// free functions on `std.process` that take an `Io`; this wrapper preserves
-/// the two-step `init` → `spawn` → `wait` call shape so existing callers
-/// don't have to be rewritten yet. `stdin_behavior` / `stdout_behavior` /
-/// `stderr_behavior` mirror the 0.15 field names.
+/// 0.15-style `std.process.Child` shim over the 0.16 `std.process` free fns.
 pub const Child = struct {
     argv: []const []const u8,
     allocator: std.mem.Allocator,
@@ -224,12 +187,8 @@ pub const Child = struct {
     }
 
     pub fn spawn(self: *Child) !void {
-        // `std.Options.debug_io` (used elsewhere) is backed by a `.failing`
-        // allocator, which is fine for write-only stderr but blows up the
-        // moment `std.process.spawn` tries to dup argv / env into its
-        // arena. Build a per-call `Threaded` io rooted at the caller's
-        // allocator — and seeded with the real environ so PATH resolution
-        // and the child's env match the parent (see `processEnviron`).
+        // `debug_io`'s failing allocator can't back argv/env dups; build a
+        // per-call `Threaded` io with the real environ so PATH matches parent.
         var threaded: std.Io.Threaded = .init(self.allocator, .{ .environ = processEnviron() });
         defer threaded.deinit();
         const spawned = try std.process.spawn(threaded.io(), .{
@@ -286,18 +245,12 @@ pub const File = struct {
         });
     }
 
-    /// Positional read from offset 0. Safe for single-shot reads of a
-    /// whole file into a stat-sized buffer. **Never call this inside a
-    /// loop** — every iteration re-reads the first bytes. For
-    /// streaming use `readAllAt` with an advancing offset or (better)
-    /// the `streamFile` helper which handles the offset bookkeeping.
+    /// Positional read from offset 0 — single-shot only; loops re-read bytes.
     pub fn readAll(self: File, buffer: []u8) !usize {
         return self.inner.readPositionalAll(io_mod.ctx(), buffer, 0);
     }
 
-    /// Positional read from `offset`. The streaming primitive — the
-    /// caller advances `offset` by the returned byte count. Prefer
-    /// `streamFile` when the loop body would otherwise be boilerplate.
+    /// Positional read; caller advances `offset`. Prefer `streamFile`.
     pub fn readAllAt(self: File, buffer: []u8, offset: u64) !usize {
         return self.inner.readPositionalAll(io_mod.ctx(), buffer, offset);
     }
@@ -306,8 +259,7 @@ pub const File = struct {
         return self.inner.stat(io_mod.ctx());
     }
 
-    /// Positional write of all bytes starting at `offset`. Replaces the 0.15
-    /// `file.seekTo(offset); file.writeAll(bytes);` idiom.
+    /// Positional write of all bytes starting at `offset`.
     pub fn writeAllAt(self: File, bytes: []const u8, offset: u64) !void {
         return self.inner.writePositionalAll(io_mod.ctx(), bytes, offset);
     }
@@ -328,8 +280,8 @@ pub const File = struct {
         return self.inner.setPermissions(io_mod.ctx(), std.Io.File.Permissions.fromMode(@intCast(mode)));
     }
 
-    /// Block until pending contents and metadata are on disk. Callers that
-    /// rename-for-atomicity must sync first — POSIX rename is not durable.
+    /// fsync; callers that rename-for-atomicity must sync first (POSIX
+    /// rename is not durable).
     pub fn sync(self: File) !void {
         return self.inner.sync(io_mod.ctx());
     }
@@ -342,8 +294,8 @@ pub const File = struct {
         errdefer allocator.free(buf);
         const n = try self.inner.readPositionalAll(io, buf, 0);
         if (n == buf.len) return buf;
-        // Short read: shrink in place so caller-side `free` matches what
-        // we hand back — GPA traps on length mismatch, others leak the tail.
+        // Short read: shrink so caller-side free matches — GPA traps on
+        // length mismatch, others leak the tail.
         if (allocator.resize(buf, n)) return buf[0..n];
         const shrunk = try allocator.alloc(u8, n);
         @memcpy(shrunk, buf[0..n]);
@@ -400,8 +352,7 @@ pub const Dir = struct {
         return self.inner.deleteTree(io_mod.ctx(), sub_path);
     }
 
-    /// Resolve symlinks in `pathname` against `self`, writing the absolute
-    /// result into `out_buffer`. Mirrors the 0.15 `Dir.realpath` contract.
+    /// 0.15-style `Dir.realpath` into `out_buffer`.
     pub fn realpath(self: Dir, pathname: []const u8, out_buffer: []u8) ![]u8 {
         const n = try self.inner.realPathFile(io_mod.ctx(), pathname, out_buffer);
         return out_buffer[0..n];
@@ -420,9 +371,7 @@ pub const Dir = struct {
         return self.inner.rename(old_sub_path, self.inner, new_sub_path, io_mod.ctx());
     }
 
-    /// Flush directory metadata. `std.Io.Dir` has no sync vtable entry,
-    /// so wrap the dir fd as a File and go through the File sync path -
-    /// fsync(2) on a dir fd is what POSIX defines for metadata flush.
+    /// Flush directory metadata via fsync(2) on the dir fd (POSIX contract).
     pub fn sync(self: Dir) !void {
         const file: std.Io.File = .{ .handle = self.inner.handle, .flags = .{ .nonblocking = false } };
         try file.sync(io_mod.ctx());

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -46,8 +46,7 @@ pub fn isTransientError(err: DownloadError) bool {
     };
 }
 
-/// Compute read-timeout in nanoseconds scaled by Content-Length.
-/// Floor: 30 s. Scale: content_length / min_bandwidth (64 KiB/s).
+/// Read-timeout in ns scaled by Content-Length; floor 30 s at 64 KiB/s.
 pub fn scaledTimeoutNs(content_length: ?u64) u64 {
     const floor_ns: u64 = 30 * std.time.ns_per_s;
     const cl = content_length orelse return floor_ns;
@@ -56,9 +55,7 @@ pub fn scaledTimeoutNs(content_length: ?u64) u64 {
     return @max(floor_ns, transfer_ns);
 }
 
-/// Optional progress reporting for long downloads.
-/// `bytes_so_far`: total bytes received so far (after decompression).
-/// `content_length`: total expected bytes from HTTP header, or null if unknown.
+/// Optional progress callback for long downloads (post-decompression bytes).
 pub const ProgressCallback = struct {
     context: *anyopaque,
     func: *const fn (context: *anyopaque, bytes_so_far: u64, content_length: ?u64) void,
@@ -79,7 +76,6 @@ pub const Response = struct {
 };
 
 /// True if the URI scheme is exactly "https" (ascii case-insensitive).
-/// Exposed for the downgrade-guard tests; inlined at the only call site.
 pub fn schemeIsHttps(scheme: []const u8) bool {
     return std.ascii.eqlIgnoreCase(scheme, "https");
 }
@@ -91,12 +87,8 @@ pub const HttpClient = struct {
     /// Per-request timeout in nanoseconds. Default: 30 seconds.
     timeout_ns: u64 = default_timeout_ns,
 
-    /// Lazily-allocated decompression windows, reused across requests. These
-    /// are sized for the worst case per encoding (zstd ~128 KiB, flate
-    /// 32 KiB); previously every request allocated a fresh buffer and freed
-    /// it on return, which cost ~160 KiB of allocator churn per API call.
-    /// A single HttpClient is borrowed from a pool per thread, so the buffer
-    /// is never accessed concurrently.
+    /// Reused across requests; each HttpClient is borrowed single-threaded
+    /// from a pool, so no concurrent access.
     zstd_window: ?[]u8 = null,
     flate_window: ?[]u8 = null,
 
@@ -131,10 +123,8 @@ pub const HttpClient = struct {
         return w;
     }
 
-    /// Perform a GET request and return the response status and body.
-    /// Automatically injects HOMEBREW_GITHUB_API_TOKEN as Authorization
-    /// header for GitHub/Homebrew API requests when the env var is set.
-    /// The caller owns the returned `Response` and must call `deinit` on it.
+    /// GET request; auto-injects HOMEBREW_GITHUB_API_TOKEN as Authorization
+    /// for GitHub/Homebrew hosts. Caller owns the returned `Response`.
     pub fn get(self: *HttpClient, url: []const u8) !Response {
         if (fs_compat.getenv("HOMEBREW_GITHUB_API_TOKEN")) |token| {
             // Apply token to GitHub and Homebrew API requests
@@ -154,9 +144,7 @@ pub const HttpClient = struct {
         return self.doGet(url, &.{});
     }
 
-    /// Perform a GET request with extra headers (e.g. Authorization for blob downloads).
-    /// Uses the larger max_blob_bytes limit since this is typically used for bottle downloads.
-    /// The caller owns the returned `Response` and must call `deinit` on it.
+    /// GET with extra headers under `max_blob_bytes`. Caller owns `Response`.
     pub fn getWithHeaders(
         self: *HttpClient,
         url: []const u8,
@@ -177,10 +165,8 @@ pub const HttpClient = struct {
 
         try req.sendBodiless();
 
-        // 32 KiB header buffer — GHCR's `/token` and blob redirects can
-        // exceed 8 KiB once cookies, signed-URL params, and multi-scope
-        // token responses stack up. 0.15 capped at 8 KiB and occasionally
-        // tripped `HeaderBufferTooSmall` on cold installs.
+        // 32 KiB — GHCR's multi-scope token + signed-URL redirects exceed
+        // the 8 KiB default and tripped `HeaderBufferTooSmall`.
         var redirect_buf: [32 * 1024]u8 = undefined;
         const response = try req.receiveHead(&redirect_buf);
 
@@ -209,9 +195,7 @@ pub const HttpClient = struct {
 
     const max_head_redirects = 5;
 
-    /// HEAD request that manually follows redirects, returning the
-    /// final URL and Content-Disposition. The stdlib skips redirect
-    /// handling for HEAD, so we follow Location headers ourselves.
+    /// HEAD with manual redirect follow — stdlib skips redirects on HEAD.
     pub fn headResolved(self: *HttpClient, url: []const u8) !HeadResolved {
         // Build the result eagerly so a single errdefer covers every dupe
         // inside the redirect loop; on success the caller takes ownership.
@@ -254,9 +238,7 @@ pub const HttpClient = struct {
         return resolved;
     }
 
-    /// Default maximum response body size for metadata (API JSON, tokens, etc.).
-    /// The full Homebrew formula.json index is ~25 MB; 50 MB gives headroom.
-    /// Bottle downloads bypass this via getWithHeaders (which sets no limit).
+    /// Metadata cap (formula.json is ~25 MB; 50 MB gives headroom).
     const max_metadata_bytes: usize = 50 * 1024 * 1024;
 
     /// Bottle responses can be 500+ MB. We cap at 2 GB to prevent true OOM.
@@ -267,14 +249,9 @@ pub const HttpClient = struct {
     const max_retries = 3;
     const retry_delays_ms = [_]u64{ 1000, 2000, 4000 };
 
-    /// Writer wrapper that counts bytes written, enforces an upper bound, and
-    /// optionally fires a progress callback. The bound is checked on every
-    /// write so oversized responses are rejected mid-stream instead of after
-    /// the full body has been buffered.
-    ///
-    /// When the limit would be exceeded, `drain`/`sendFile` return
-    /// `error.WriteFailed`; callers (`streamRemaining`) can then inspect
-    /// `bytes_written` to distinguish "too large" from a real write error.
+    /// Counts written bytes, enforces an upper bound mid-stream, and reports
+    /// progress. On overflow `drain`/`sendFile` return `error.WriteFailed`
+    /// and callers distinguish via `bytes_written` vs `limit_exceeded`.
     const CountingWriter = struct {
         inner: *std.Io.Writer.Allocating,
         bytes_written: u64,
@@ -388,18 +365,12 @@ pub const HttpClient = struct {
 
         try req.sendBodiless();
 
-        // 32 KiB header buffer — see comment in `head()`. Blob
-        // redirects from GHCR (Azure CDN signed URLs) routinely push
-        // past the old 8 KiB budget.
+        // 32 KiB header buffer — see `head()`.
         var redirect_buf: [32 * 1024]u8 = undefined;
         var response = try req.receiveHead(&redirect_buf);
 
-        // Refuse an https → http downgrade across a 3xx chain. The
-        // stdlib already strips privileged headers on scheme change,
-        // but letting the body itself come back over plaintext with
-        // no CA validation is still a metadata-substitution vector
-        // for every endpoint whose integrity check depends on what
-        // the response says.
+        // Refuse https → http downgrade across 3xx — plaintext bodies are
+        // a metadata-substitution vector even with stdlib header stripping.
         if (https_origin and !schemeIsHttps(req.uri.scheme))
             return error.TlsDowngradeRefused;
 
@@ -426,15 +397,9 @@ pub const HttpClient = struct {
         var decompress: std.http.Decompress = undefined;
         var body_reader = response.readerDecompressing(&transfer_buffer, &decompress, decompress_buffer);
 
-        // Timeout watchdog: closes the underlying connection if the read
-        // stalls beyond the deadline. This is the only reliable way to
-        // abort a blocking read call.
-        //
-        // `request_done` is a one-shot event so the main thread can wake
-        // the watchdog immediately on completion. The previous polling
-        // implementation slept in 1 s ticks and could stall `join()` by
-        // up to a full second per request — that was the entire warm
-        // install floor (see docs/perf/results.md).
+        // Watchdog closes the socket on stall; one-shot `request_done`
+        // wakes it immediately on success (previous 1 s polling stalled
+        // `join()` and dominated the warm-install floor).
         const effective_timeout = if (max_bytes > max_metadata_bytes)
             @max(blob_timeout_ns, scaledTimeoutNs(content_length))
         else
@@ -450,11 +415,8 @@ pub const HttpClient = struct {
             if (watchdog) |w| w.join();
         }
 
-        // Read the full response body through a CountingWriter that enforces
-        // `max_bytes` per-write. This rejects oversized responses mid-stream
-        // instead of after the whole body is already buffered (and the old
-        // code's only check was post-hoc, which defeats the purpose on a
-        // 2 GB/500 MB body).
+        // `CountingWriter` enforces `max_bytes` per-write so oversized bodies
+        // are rejected mid-stream, not after buffering.
         var counting = CountingWriter{
             .inner = &body_writer,
             .bytes_written = 0,
@@ -487,23 +449,9 @@ pub const HttpClient = struct {
         };
     }
 
-    /// Watchdog thread: waits until either the main thread signals
-    /// `request_done` (request finished normally) or the timeout elapses.
-    /// On timeout, marks the connection dead AND hard-shuts-down the
-    /// underlying TCP socket so any in-flight `readv` / `writev` on
-    /// the main thread returns immediately.
-    ///
-    /// **Important:** setting `conn.closing = true` alone is not
-    /// enough to interrupt a blocked read. That flag only influences
-    /// the *next* read — a `readv` already parked in the kernel
-    /// waiting on TLS bytes stays parked indefinitely. This used to
-    /// hang malt for minutes if a dep formula fetch hit a stalled
-    /// TLS connection (observed once during cold-ffmpeg bench runs).
-    /// `posix.shutdown(fd, .both)` forces the kernel to wake the
-    /// blocked syscall with an error, unblocking the main thread.
-    ///
-    /// Uses `ResetEvent.timedWait` so the main thread can wake us
-    /// immediately on successful completion — no polling overhead.
+    /// On timeout, both flag the connection and `shutdown(.both)` the fd —
+    /// setting `conn.closing` alone does not wake a `readv` already parked
+    /// in the kernel, which hung malt for minutes on stalled TLS reads.
     fn watchdogFn(
         request_done: *std.Io.Event,
         timeout_ns: u64,
@@ -558,20 +506,10 @@ fn formatUri(allocator: std.mem.Allocator, uri: std.Uri) ![]const u8 {
     return std.fmt.allocPrint(allocator, "{s}://{s}{s}", .{ scheme, host, path });
 }
 
-/// Thread-safe pool of `HttpClient` instances with borrow/return
-/// semantics. Workers call `acquire()` to get exclusive access to an
-/// idle client, use it synchronously, then call `release()` so another
-/// worker can take it.
-///
-/// Why a pool: `std.http.Client` is *not* thread-safe across
-/// concurrent calls, but creating a fresh one per request pays the
-/// TLS context + cert store + connection setup cost every time. On a
-/// cold `ffmpeg` install that was ~15 HttpClient creations back to
-/// back (formula fetches + GHCR token + 12 blob downloads), each
-/// paying its own handshake. A 4-slot pool keeps per-connection
-/// reuse for the hot phase while preserving the no-sharing invariant.
-///
-/// All methods are safe to call from multiple threads.
+/// Thread-safe borrow/return pool of `HttpClient`s. `std.http.Client` is
+/// not thread-safe, but per-request construction pays the full TLS
+/// handshake every time; pooling preserves no-sharing while reusing
+/// connections across the hot phase of an install.
 pub const HttpClientPool = struct {
     allocator: std.mem.Allocator,
     clients: []HttpClient,
@@ -601,8 +539,7 @@ pub const HttpClientPool = struct {
         self.allocator.free(self.busy);
     }
 
-    /// Block until an idle client is available, mark it busy, return
-    /// a pointer the caller can use exclusively until `release`.
+    /// Block until idle, mark busy, return exclusive pointer until `release`.
     pub fn acquire(self: *HttpClientPool) *HttpClient {
         const io = io_mod.ctx();
         self.mutex.lockUncancelable(io);
@@ -618,9 +555,7 @@ pub const HttpClientPool = struct {
         }
     }
 
-    /// Return a previously-acquired client to the pool. The pointer
-    /// must have come from `acquire` on the same pool; calling with
-    /// a foreign pointer is a programmer error.
+    /// Return an acquired client; foreign pointers are a programmer error.
     pub fn release(self: *HttpClientPool, client: *HttpClient) void {
         const io = io_mod.ctx();
         self.mutex.lockUncancelable(io);


### PR DESCRIPTION
## Description

Collapse multi-paragraph comments across the cited files to their single load-bearing sentence. File-heads collapse to <=2 lines. Private `///` docs drop to one sentence. Inline `//` prose blocks that restated rationale are pulled down to one or two lines; comments that encode a real invariant, hidden constraint, or workaround are left intact but tightened.

## Related Issue

- None

## Notes for Reviewers

- No code changes