### PR TITLE
refactor: triage swallowed catch sites

### DIFF
--- a/src/cli/backup.zig
+++ b/src/cli/backup.zig
@@ -79,6 +79,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         return Error.DatabaseError;
     };
     defer db.close();
+    // Schema is idempotent; backup's SELECTs surface a real DB error if one exists.
     schema.initSchema(&db) catch {};
 
     // ── Serialize into an in-memory buffer ───────────────────────────────
@@ -150,6 +151,7 @@ fn writeToPath(path: []const u8, bytes: []const u8) Error!void {
                     else => {},
                 };
             } else {
+                // Parent may already exist; the subsequent createFile reports real errors.
                 fs_compat.cwd().makePath(dir) catch {};
             }
         }

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -114,7 +114,6 @@ fn cmdInstall(allocator: std.mem.Allocator, rest: []const []const u8) !void {
 
     var db = try openDb();
     defer db.close();
-    schema.initSchema(&db) catch {};
 
     var report = runner_mod.run(allocator, &db, manifest, .{
         .dry_run = dry_run,
@@ -161,7 +160,6 @@ fn cmdList(allocator: std.mem.Allocator) !void {
     _ = allocator;
     var db = try openDb();
     defer db.close();
-    schema.initSchema(&db) catch {};
 
     var stmt = db.prepare("SELECT name, created_at FROM bundles ORDER BY name;") catch
         return BundleError.DatabaseError;
@@ -186,7 +184,6 @@ fn cmdRemove(allocator: std.mem.Allocator, rest: []const []const u8) !void {
     const name = rest[0];
     var db = try openDb();
     defer db.close();
-    schema.initSchema(&db) catch {};
 
     var stmt = db.prepare("DELETE FROM bundles WHERE name = ?;") catch
         return BundleError.DatabaseError;
@@ -213,7 +210,6 @@ fn cmdCreate(allocator: std.mem.Allocator, rest: []const []const u8) !void {
 
     var db = try openDb();
     defer db.close();
-    schema.initSchema(&db) catch {};
 
     var manifest = manifest_mod.Manifest.init(allocator);
     defer manifest.deinit();
@@ -238,7 +234,6 @@ fn cmdExport(allocator: std.mem.Allocator, rest: []const []const u8) !void {
 
     var db = try openDb();
     defer db.close();
-    schema.initSchema(&db) catch {};
 
     var manifest = manifest_mod.Manifest.init(allocator);
     defer manifest.deinit();
@@ -273,7 +268,6 @@ fn cmdImport(allocator: std.mem.Allocator, rest: []const []const u8) !void {
 
     var db = try openDb();
     defer db.close();
-    schema.initSchema(&db) catch {};
 
     // Record metadata only; no install.
     var stmt = db.prepare(
@@ -440,11 +434,17 @@ fn openDb() !sqlite.Database {
     var db_dir_buf: [512]u8 = undefined;
     const db_dir = std.fmt.bufPrint(&db_dir_buf, "{s}/db", .{prefix}) catch
         return BundleError.DatabaseError;
+    // makePath is the idempotent "ensure" variant; a real permission/ENOSPC
+    // failure surfaces at sqlite.Database.open below with a narrower error.
     fs_compat.cwd().makePath(db_dir) catch {};
     var path_buf: [512]u8 = undefined;
     const path = std.fmt.bufPrintSentinel(&path_buf, "{s}/malt.db", .{db_dir}, 0) catch
         return BundleError.DatabaseError;
-    return sqlite.Database.open(path);
+    var db = try sqlite.Database.open(path);
+    // Schema init is idempotent; a real failure surfaces at the next
+    // prepare/step call in the caller with a narrower error.
+    schema.initSchema(&db) catch {};
+    return db;
 }
 
 fn printHelp() !void {

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -41,6 +41,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             "malt: unknown shell '{s}'. Supported shells: bash, zsh, fish\n",
             .{args[0]},
         ) catch "malt: unknown shell. Supported shells: bash, zsh, fish\n";
+        // exit(2) below is the real signal; a closed stderr shouldn't block that.
         stderr.writeAll(msg) catch {};
         std.process.exit(2);
     };
@@ -61,6 +62,7 @@ fn printUsage() void {
         \\  fish    source with: malt completions fish | source
         \\
     ;
+    // Usage is diagnostic; caller always follows with exit(2).
     fs_compat.stderrFile().writeAll(usage) catch {};
 }
 

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -134,6 +134,7 @@ fn checkSqliteIntegrity(ctx: CheckCtx, name: []const u8) CheckResult {
     };
     defer db.close();
 
+    // Schema is idempotent; the `PRAGMA integrity_check` below is the real probe.
     schema.initSchema(&db) catch {};
 
     var stmt = db.prepare("PRAGMA integrity_check;") catch {

--- a/src/cli/doctor/render.zig
+++ b/src/cli/doctor/render.zig
@@ -80,7 +80,7 @@ pub fn printCheck(name: []const u8, status: CheckStatus, detail: ?[]const u8) vo
     // prior rows when stderr is a regular file; stream via `stderrWriteAll`.
     var buf: [1024]u8 = undefined;
     var w: std.Io.Writer = .fixed(&buf);
-    // Truncation of an oversized row is acceptable — `buffered()` still emits what fit.
+    // Truncation of an oversized row is acceptable - `buffered()` still emits what fit.
     renderCheckRow(&w, status, name, detail, .{
         .color = color.isColorEnabled(),
         .emoji = color.isEmojiEnabled(),

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -56,11 +56,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var stdout_buf: [4096]u8 = undefined;
     var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
     const stdout: *std.Io.Writer = &stdout_fw.interface;
+    // Flush on teardown; stdout closed by a broken pipe is normal shell usage.
     defer stdout.flush() catch {};
 
     const colorize = !json_mode and color.isColorEnabled();
 
     if (db_opt) |*db| {
+        // Schema is idempotent; info's API fallback handles a broken DB gracefully.
         schema.initSchema(db) catch {};
         if (!force_cask and try emitInstalledFormula(allocator, db, name, prefix, stdout, json_mode, colorize)) return;
         if (!force_formula and try emitInstalledCask(allocator, db, name, stdout, json_mode, colorize)) return;

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -561,6 +561,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
                 "Skipping {s}: dependency {s} failed to install",
                 .{ job.name, failed_dep },
             );
+            // orphan keg cleanup; user already sees the skip warning above.
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
             try failed_kegs.put(job.name, {});
             failed_count += 1;
@@ -606,6 +607,7 @@ fn linkAndRecord(
     // Parse formula for DB recording
     var formula = formula_mod.parseFormula(allocator, job.formula_json) catch |err| {
         output.err("Failed to parse formula for {s}: {s}", .{ job.name, @errorName(err) });
+        // rollback materialised keg; user-visible error already emitted.
         cellar_mod.remove(prefix, job.name, job.version_str) catch {};
         return InstallError.CellarFailed;
     };
@@ -620,6 +622,7 @@ fn linkAndRecord(
                 output.err("  {s} already linked by {s}", .{ conflict.link_path, conflict.existing_keg });
             }
             output.err("Use --force to overwrite, or uninstall the conflicting package first.", .{});
+            // rollback materialised keg on conflict.
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
             return InstallError.LinkFailed;
         }
@@ -629,6 +632,7 @@ fn linkAndRecord(
     if (!job.keg_only) {
         const keg_id = recordKeg(db, &formula, job.store_sha256, keg_path, reason) catch |err| {
             output.err("Failed to record {s} in database: {s}", .{ job.name, @errorName(err) });
+            // rollback materialised keg when DB record fails.
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
             return InstallError.RecordFailed;
         };
@@ -636,19 +640,23 @@ fn linkAndRecord(
         linker.link(keg_path, job.name, keg_id) catch |err| {
             output.err("Failed to link {s}: {s}", .{ job.name, @errorName(err) });
             // Rollback: unlink what was partially created + remove DB record + cellar
+            // partial-link cleanup in a rollback; original error is authoritative.
             linker.unlink(keg_id) catch {};
             deleteKeg(db, keg_id);
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
             return InstallError.LinkFailed;
         };
+        // opt symlink is convenience; install already functional via versioned link.
         linker.linkOpt(job.name, job.version_str) catch {};
         recordDeps(db, keg_id, &formula);
     } else {
         const keg_id = recordKeg(db, &formula, job.store_sha256, keg_path, reason) catch |err| {
             output.err("Failed to record {s} in database: {s}", .{ job.name, @errorName(err) });
+            // rollback materialised keg when DB record fails.
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
             return InstallError.RecordFailed;
         };
+        // opt symlink is convenience; install already functional via versioned link.
         linker.linkOpt(job.name, job.version_str) catch {};
         recordDeps(db, keg_id, &formula);
     }
@@ -683,6 +691,7 @@ fn maybeRegisterService(
     // Ensure the log directory exists.
     var log_dir_buf: [512]u8 = undefined;
     if (std.fmt.bufPrint(&log_dir_buf, "{s}/var/log", .{prefix})) |dir| {
+        // launchd creates the file on first run; missing dir surfaces there.
         fs_compat.cwd().makePath(dir) catch {};
     } else |_| {}
 

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -423,6 +423,7 @@ fn materializeRubyFormula(
         return InstallError.DownloadFailed;
     };
     tmp_file.close();
+    // Temp archive cleanup; leaks to tmp/ are reaped by the next install.
     defer fs_compat.cwd().deleteFile(tmp_archive) catch {};
 
     const archive_mod = @import("../../fs/archive.zig");
@@ -458,6 +459,7 @@ fn materializeRubyFormula(
                 cellar_dir.copyFile(entry.path, cellar_dir, dest_name, .{}) catch continue;
                 const bin_file = cellar_dir.openFile(dest_name, .{ .mode = .read_write }) catch continue;
                 defer bin_file.close();
+                // chmod may fail on FUSE/NFS; linker still resolves the path.
                 bin_file.chmod(0o755) catch {};
                 break;
             }
@@ -491,7 +493,8 @@ fn materializeRubyFormula(
 
         if (resolved.tap_registration) |t| {
             // `COALESCE` in tap_mod.add pins the commit on first install
-            // and leaves later pins untouched.
+            // and leaves later pins untouched. Tap row is advisory — keg
+            // is already recorded; a missing tap row self-heals next sync.
             tap_mod.add(db, resolved.tap_label, t.url, t.commit_sha) catch {};
         }
     }

--- a/src/cli/install/record.zig
+++ b/src/cli/install/record.zig
@@ -115,7 +115,8 @@ pub fn recordKeg(
     return keg_id;
 }
 
-/// Delete a keg record from the database (rollback helper).
+/// Delete a keg record. Rollback helper — the caller is already in an
+/// error path, so a failed delete leaves a stale row that `doctor` cleans.
 pub fn deleteKeg(db: *sqlite.Database, keg_id: i64) void {
     var stmt = db.prepare("DELETE FROM kegs WHERE id = ?1;") catch return;
     defer stmt.finalize();
@@ -123,7 +124,9 @@ pub fn deleteKeg(db: *sqlite.Database, keg_id: i64) void {
     _ = stmt.step() catch {};
 }
 
-/// Record dependencies for a keg.
+/// Record dependencies for a keg. Each row is independent; on per-row
+/// failure we skip and continue so a partial dep table is preferred to
+/// the install being rolled back wholesale.
 pub fn recordDeps(db: *sqlite.Database, keg_id: i64, formula: *const formula_mod.Formula) void {
     for (formula.dependencies) |dep_name| {
         var stmt = db.prepare(

--- a/src/cli/link.zig
+++ b/src/cli/link.zig
@@ -34,6 +34,7 @@ pub fn executeLink(allocator: std.mem.Allocator, args: []const []const u8) !void
         return error.Aborted;
     };
     defer db.close();
+    // Schema is idempotent; existing DB with current shape is the common case.
     schema.initSchema(&db) catch {};
 
     // Look up the keg
@@ -82,6 +83,7 @@ pub fn executeLink(allocator: std.mem.Allocator, args: []const []const u8) !void
     ver_stmt.bindInt(1, keg_id) catch return;
     if (ver_stmt.step() catch false) {
         if (ver_stmt.columnText(0)) |v| {
+            // opt/ link is a convenience pointer; primary link.link already succeeded.
             linker.linkOpt(name, std.mem.sliceTo(v, 0)) catch {};
         }
     }
@@ -109,6 +111,7 @@ pub fn executeUnlink(allocator: std.mem.Allocator, args: []const []const u8) !vo
         return error.Aborted;
     };
     defer db.close();
+    // Schema is idempotent; existing DB with current shape is the common case.
     schema.initSchema(&db) catch {};
 
     // Look up the keg
@@ -136,7 +139,7 @@ pub fn executeUnlink(allocator: std.mem.Allocator, args: []const []const u8) !vo
     // Also remove opt/ symlink
     var opt_buf: [512]u8 = undefined;
     const opt_path = std.fmt.bufPrint(&opt_buf, "{s}/opt/{s}", .{ prefix, name }) catch return;
-    fs_compat.cwd().deleteFile(opt_path) catch {}; // intentional: may not exist
+    fs_compat.cwd().deleteFile(opt_path) catch {}; // opt/ link absent on never-linked kegs
 
     output.success("{s} unlinked (keg remains installed)", .{name});
 }

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -56,6 +56,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var stdout_buf: [4096]u8 = undefined;
     var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
     const stdout: *std.Io.Writer = &stdout_fw.interface;
+    // Flush on teardown; stdout closed by a broken pipe is normal shell usage.
     defer stdout.flush() catch {};
 
     if (json_mode) {

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -366,25 +366,29 @@ fn migrateKeg(
     if (!formula.keg_only) {
         const keg_id = recordKeg(deps.db, &formula, bottle.sha256, keg.path, "direct") catch {
             output.err("    {s}: failed to record in database", .{keg_name});
+            // Rollback: remove materialised keg when DB record fails.
             cellar_mod.remove(deps.prefix, formula.name, formula.pkg_version) catch {};
             return .failed_install;
         };
 
         deps.linker.link(keg.path, formula.name, keg_id) catch {
             output.warn("    {s}: some links could not be created", .{keg_name});
-            // Best-effort cleanup after a link failure; the user already sees the failure above.
+            // Rollback: unlink partial links and delete keg row; user already warned above.
             deps.linker.unlink(keg_id) catch {};
             deleteKeg(deps.db, keg_id) catch {};
             cellar_mod.remove(deps.prefix, formula.name, formula.pkg_version) catch {};
             return .failed_install;
         };
+        // Opt symlink is convenience; install is already functional via versioned link.
         deps.linker.linkOpt(formula.name, formula.pkg_version) catch {};
         recordDeps(deps.db, keg_id, &formula);
     } else {
         const keg_id = recordKeg(deps.db, &formula, bottle.sha256, keg.path, "direct") catch {
+            // Rollback: remove materialised keg when DB record fails.
             cellar_mod.remove(deps.prefix, formula.name, formula.pkg_version) catch {};
             return .failed_install;
         };
+        // Opt symlink is convenience; install is already functional via versioned link.
         deps.linker.linkOpt(formula.name, formula.pkg_version) catch {};
         recordDeps(deps.db, keg_id, &formula);
     }
@@ -500,6 +504,8 @@ fn deleteKeg(db: *sqlite.Database, keg_id: i64) sqlite.SqliteError!void {
     _ = try stmt.step();
 }
 
+/// Each row is independent; skip on per-row failure so a partial dep
+/// table is preferred to aborting a migration wholesale.
 fn recordDeps(db: *sqlite.Database, keg_id: i64, formula: *const formula_mod.Formula) void {
     for (formula.dependencies) |dep_name| {
         var stmt = db.prepare(

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -53,6 +53,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var stdout_buf: [4096]u8 = undefined;
     var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
     const stdout: *std.Io.Writer = &stdout_fw.interface;
+    // Flush on teardown; stdout closed by a broken pipe is normal shell usage.
     defer stdout.flush() catch {};
 
     // Check outdated formulas (unless --cask)
@@ -132,6 +133,7 @@ fn checkOutdatedCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *
     var stdout_buf: [4096]u8 = undefined;
     var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
     const stdout: *std.Io.Writer = &stdout_fw.interface;
+    // Flush on teardown; stdout closed by a broken pipe is normal shell usage.
     defer stdout.flush() catch {};
     var found_any = false;
 

--- a/src/cli/purge/scopes.zig
+++ b/src/cli/purge/scopes.zig
@@ -103,6 +103,10 @@ pub fn runUnusedDeps(allocator: std.mem.Allocator, prefix: []const u8, dry_run: 
     var linker = linker_mod.Linker.init(allocator, &db, prefix);
     var store = store_mod.Store.init(allocator, &db, prefix);
 
+    // Per-orphan removal is best-effort across all steps: a partially-linked
+    // or partially-materialized keg must still be cleanable. Callers rely on
+    // the DB `DELETE` as the authoritative removal signal; filesystem and
+    // refcount side-effects converge on subsequent runs.
     for (orphans) |name| {
         var stmt = db.prepare("SELECT id, version, store_sha256 FROM kegs WHERE name = ?1;") catch continue;
         defer stmt.finalize();
@@ -120,6 +124,7 @@ pub fn runUnusedDeps(allocator: std.mem.Allocator, prefix: []const u8, dry_run: 
             {
                 var parent_buf: [512]u8 = undefined;
                 const parent_path = std.fmt.bufPrint(&parent_buf, "{s}/Cellar/{s}", .{ prefix, name }) catch "";
+                // Parent dir may be non-empty (sibling versions still installed).
                 if (parent_path.len > 0) fs_compat.deleteDirAbsolute(parent_path) catch {};
             }
             if (sha_ptr) |s| {

--- a/src/cli/purge/wipe.zig
+++ b/src/cli/purge/wipe.zig
@@ -140,6 +140,7 @@ pub fn writeManifest(allocator: std.mem.Allocator, path: []const u8) Error!void 
 fn writeBytesToPath(path: []const u8, bytes: []const u8) Error!void {
     if (std.fs.path.dirname(path)) |dir| {
         if (dir.len > 0) {
+            // Parent may already exist; the subsequent createFile reports real errors.
             if (std.fs.path.isAbsolute(dir)) {
                 fs_compat.makeDirAbsolute(dir) catch {};
             } else {

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -148,7 +148,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         var del = db.prepare("DELETE FROM kegs WHERE id = ?1;") catch return error.Aborted;
         defer del.finalize();
         del.bindInt(1, current_id) catch return error.Aborted;
-        _ = del.step() catch {};
+        // Step failure inside the txn must trigger rollback, not a silent commit.
+        _ = del.step() catch return error.Aborted;
     }
 
     {
@@ -161,7 +162,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         ins.bindText(2, target.version) catch return error.Aborted;
         ins.bindText(3, target.sha256) catch return error.Aborted;
         ins.bindText(4, keg.path) catch return error.Aborted;
-        _ = ins.step() catch {};
+        // Step failure inside the txn must trigger rollback, not a silent commit.
+        _ = ins.step() catch return error.Aborted;
     }
 
     // Get new keg_id for linking

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -142,11 +142,13 @@ fn ephemeralRun(
     {
         const f = fs_compat.openFileAbsolute(bin_path, .{ .mode = .read_write }) catch return;
         defer f.close();
+        // Bottles ship with +x; chmod is belt-and-suspenders. exec below surfaces EACCES.
         f.chmod(0o755) catch {};
     }
 
     output.info("Running {s} {s} (ephemeral)...", .{ pkg_name, formula.version });
     const stderr = fs_compat.stderrFile();
+    // Separator is purely cosmetic; a closed stderr shouldn't kill the run.
     stderr.writeAll("---\n") catch {};
 
     try execBinary(allocator, bin_path, cmd_args);
@@ -166,5 +168,6 @@ fn execBinary(allocator: std.mem.Allocator, path: []const u8, cmd_args: []const 
         output.err("Failed to execute binary", .{});
         return error.Aborted;
     };
+    // Ephemeral run is fire-and-forget; child exit code isn't surfaced to the shell.
     _ = child.wait() catch {};
 }

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -109,6 +109,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var stdout_buf: [4096]u8 = undefined;
     var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
     const stdout: *std.Io.Writer = &stdout_fw.interface;
+    // Flush on teardown; stdout closed by a broken pipe is normal shell usage.
     defer stdout.flush() catch {};
     if (json_mode) {
         try emitJson(allocator, stdout, search_formula, search_cask, formula, cask, search_query);

--- a/src/cli/services.zig
+++ b/src/cli/services.zig
@@ -43,6 +43,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     var db = try openDb();
     defer db.close();
+    // Schema is idempotent; subcommand queries surface the real error if the DB is broken.
     schema.initSchema(&db) catch {};
 
     if (std.mem.eql(u8, sub, "list") or std.mem.eql(u8, sub, "ls")) {
@@ -143,6 +144,7 @@ fn openDb() !sqlite.Database {
     var db_dir_buf: [512]u8 = undefined;
     const db_dir = std.fmt.bufPrint(&db_dir_buf, "{s}/db", .{prefix}) catch
         return ServicesError.DatabaseError;
+    // db/ may already exist; sqlite.open below surfaces real path errors.
     fs_compat.cwd().makePath(db_dir) catch {};
     var path_buf: [512]u8 = undefined;
     const path = std.fmt.bufPrintSentinel(&path_buf, "{s}/malt.db", .{db_dir}, 0) catch

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -114,11 +114,13 @@ fn run(allocator: std.mem.Allocator, args: []const []const u8, action: Action) !
         }
 
         for (taps) |t| {
+            // stdout may be a closed pipe (head, grep -q, etc.); dropping the
+            // listing line is the correct behaviour, not an aborted command.
             const f = fs_compat.stdoutFile();
             f.writeAll(t.name) catch {};
             if (t.commit_sha) |sha| {
                 f.writeAll(" @ ") catch {};
-                // Print just the 7-char short SHA to keep the listing compact.
+                // 7-char short SHA to keep the listing compact.
                 const short_len = @min(sha.len, 7);
                 f.writeAll(sha[0..short_len]) catch {};
             } else {

--- a/src/cli/uninstall.zig
+++ b/src/cli/uninstall.zig
@@ -130,13 +130,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     {
         var parent_buf: [512]u8 = undefined;
         const parent_path = std.fmt.bufPrint(&parent_buf, "{s}/Cellar/{s}", .{ prefix, name }) catch "";
-        if (parent_path.len > 0) fs_compat.deleteDirAbsolute(parent_path) catch {}; // intentional: only succeeds if empty
+        if (parent_path.len > 0) fs_compat.deleteDirAbsolute(parent_path) catch {}; // Only succeeds when empty; sibling versions keep the dir alive.
     }
     // Remove opt/ symlink
     {
         var opt_buf: [512]u8 = undefined;
         const opt_path = std.fmt.bufPrint(&opt_buf, "{s}/opt/{s}", .{ prefix, name }) catch "";
-        if (opt_path.len > 0) fs_compat.cwd().deleteFile(opt_path) catch {}; // intentional: may not exist
+        if (opt_path.len > 0) fs_compat.cwd().deleteFile(opt_path) catch {}; // opt/ link absent on never-linked kegs.
     }
 
     // Decrement store ref

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -244,6 +244,7 @@ fn upgradeFormula(
         };
         allocator.free(tmp_dir);
 
+        // refcount is advisory; commit succeeded, store now owns the bytes.
         store.incrementRef(bottle.sha256) catch {};
     }
 
@@ -271,6 +272,7 @@ fn upgradeFormula(
         output.err("Failed to record new version of {s} in database", .{name});
         // Rollback: re-link old version
         restoreOldLinks(db, &linker, old_cellar_path, name, old_keg_id);
+        // rollback cellar cleanup; a leftover keg is tolerable if the rollback is already failing.
         cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
         return;
     };
@@ -278,13 +280,16 @@ fn upgradeFormula(
     linker.link(new_keg.path, formula.name, new_keg_id) catch {
         output.err("Failed to link new version of {s}", .{name});
         // Rollback: remove partial new links, restore old
+        // partial link cleanup in a rollback path.
         linker.unlink(new_keg_id) catch {};
         deleteKeg(db, new_keg_id);
         restoreOldLinks(db, &linker, old_cellar_path, name, old_keg_id);
+        // rollback cellar cleanup.
         cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
         return;
     };
 
+    // opt symlink is convenience; install is already functional via versioned link.
     linker.linkOpt(formula.name, formula.pkg_version) catch {};
 
     // Step 8: Remove old DB record + Cellar entry (success path only)
@@ -297,12 +302,13 @@ fn upgradeFormula(
         var parent_buf: [512]u8 = undefined;
         const parent_path = std.fmt.bufPrint(&parent_buf, "{s}/Cellar/{s}", .{ prefix, name }) catch "";
         if (parent_path.len > 0) {
+            // rmdir fails if other versions still live here — that is the intended guard.
             fs_compat.cwd().deleteDir(parent_path) catch {};
         }
     }
 
-    // Decrement store refcount for old bottle
     if (old_sha256.len > 0) {
+        // refcount is advisory; upgrade is already complete on disk.
         store.decrementRef(old_sha256) catch {};
     }
 
@@ -356,16 +362,16 @@ fn recordKeg(
     return keg_id;
 }
 
-/// Delete a keg record from the database (rollback helper).
+/// Delete a keg record from the database (rollback helper). The whole
+/// function is best-effort: a rollback failure is logged upstream via the
+/// caller's `output.err`, and a stale row cleans itself up on next doctor.
 fn deleteKeg(db: *sqlite.Database, keg_id: i64) void {
-    // Also clean up dependencies
     {
         var dep_stmt = db.prepare("DELETE FROM dependencies WHERE keg_id = ?1;") catch return;
         defer dep_stmt.finalize();
         dep_stmt.bindInt(1, keg_id) catch return;
         _ = dep_stmt.step() catch {};
     }
-    // Also clean up links
     {
         var link_stmt = db.prepare("DELETE FROM links WHERE keg_id = ?1;") catch return;
         defer link_stmt.finalize();
@@ -439,6 +445,7 @@ fn upgradeAllFormulas(
     for (names.items) |name| {
         upgradeFormula(allocator, name, db, api, http, prefix, dry_run) catch {
             failed_count += 1;
+            // failed_count is the authoritative counter; list is for UX only.
             failed_names.append(allocator, name) catch {};
         };
     }
@@ -542,6 +549,7 @@ fn upgradeAllCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api
     for (tokens.items) |token| {
         upgradeCask(allocator, token, db, api, prefix, dry_run) catch {
             failed_count += 1;
+            // failed_count is authoritative; list is for UX only.
             failed_tokens.append(allocator, token) catch {};
         };
     }

--- a/src/cli/uses.zig
+++ b/src/cli/uses.zig
@@ -40,6 +40,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var stdout_buf: [4096]u8 = undefined;
     var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
     const stdout: *std.Io.Writer = &stdout_fw.interface;
+    // Flush on teardown; stdout closed by a broken pipe is normal shell usage.
     defer stdout.flush() catch {};
 
     // Without a local DB nothing is installed, so nothing can "use"
@@ -50,6 +51,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer freeDependents(allocator, dependents);
 
     if (db_opt) |*db| {
+        // Schema is idempotent; read-only uses queries degrade to empty on a broken DB.
         schema.initSchema(db) catch {};
         dependents = collectDependents(allocator, db, name, recursive) catch &.{};
     }

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -138,11 +138,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     //     don't collide and `rm -rf` of a stale dir never hits /tmp root. ---
     var scratch_buf: [std.fs.max_path_bytes]u8 = undefined;
     const scratch = try buildScratchDir(&scratch_buf);
+    // Pre-clean any leftover scratch from an aborted prior run; makeDirAbsolute below surfaces real errors.
     fs_compat.deleteTreeAbsolute(scratch) catch {};
     fs_compat.makeDirAbsolute(scratch) catch {
         output.err("Cannot create scratch dir at {s}", .{scratch});
         return error.Aborted;
     };
+    // Teardown: scratch is pid-tagged, so a leftover tree is only our own dead run's.
     defer fs_compat.deleteTreeAbsolute(scratch) catch {};
 
     // --- download tarball + checksums (always needed for SHA verify) ---

--- a/src/core/bottle.zig
+++ b/src/core/bottle.zig
@@ -69,7 +69,7 @@ pub fn download(
     // Constant-time SHA compare — same reasoning as install.zig: deny a
     // byte-by-byte timing oracle against the expected hash.
     if (!install_cmd.constantTimeEql(u8, &computed_hex, expected_sha256)) {
-        // Clean up dest_dir on mismatch
+        // Clean up dest_dir on mismatch; Sha256Mismatch is the real error.
         fs_compat.deleteTreeAbsolute(dest_dir) catch {};
         return BottleError.Sha256Mismatch;
     }
@@ -94,7 +94,7 @@ pub fn download(
     // Extract
     archive.extractTarGz(tmp_path, dest_dir) catch return BottleError.ExtractionFailed;
 
-    // Remove the temp archive file
+    // Remove the temp archive file; a leftover tmp is harmless, overwritten on retry.
     fs_compat.deleteFileAbsolute(tmp_path) catch {};
 
     return .{

--- a/src/core/bundle/runner.zig
+++ b/src/core/bundle/runner.zig
@@ -126,6 +126,7 @@ pub fn run(
     const bundles_dir = std.fmt.allocPrint(allocator, "{s}/var/malt/bundles", .{prefix}) catch
         return RunnerError.OutOfMemory;
     defer allocator.free(bundles_dir);
+    // bundles/ may already exist; the lock file create below surfaces real errors.
     fs_compat.cwd().makePath(bundles_dir) catch {};
 
     const lock_path = std.fmt.allocPrint(allocator, "{s}/{s}.lock", .{ bundles_dir, bundle_name }) catch

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -289,6 +289,7 @@ pub const CaskInstaller = struct {
         const cache_path = self.downloadToCache(cask, cache_dir, self.progress) catch
             return CaskError.DownloadFailed;
         errdefer {
+            // cache already leaked to disk; nothing to do on cleanup failure.
             fs_compat.cwd().deleteFile(cache_path) catch {};
             self.allocator.free(cache_path);
         }
@@ -310,7 +311,7 @@ pub const CaskInstaller = struct {
             .unknown => return CaskError.InstallFailed,
         };
 
-        // Record in Caskroom
+        // Caskroom dir is bookkeeping; app is already in place.
         self.recordCaskroom(cask) catch {};
 
         // Clean up cache file (keep for uninstall/upgrade reference if desired)
@@ -345,23 +346,23 @@ pub const CaskInstaller = struct {
             // Check if the app is running (best-effort)
             if (isAppRunning(self.allocator, app_path)) return CaskError.UninstallFailed;
 
-            // Remove the app bundle
+            // app may already be gone (manual delete); continue to DB cleanup.
             fs_compat.deleteTreeAbsolute(app_path) catch {};
         }
 
-        // Remove Caskroom entry
+        // Caskroom bookkeeping; continue so later removals still run.
         var caskroom_buf: [512]u8 = undefined;
         const caskroom_path = std.fmt.bufPrint(&caskroom_buf, "{s}/Caskroom/{s}", .{ self.prefix, token }) catch "";
         if (caskroom_path.len > 0) fs_compat.deleteTreeAbsolute(caskroom_path) catch {};
 
-        // Remove cache entry
         var cache_buf: [512]u8 = undefined;
         for ([_][]const u8{ ".dmg", ".zip", ".pkg", ".tar.gz" }) |ext| {
             const cache_file = std.fmt.bufPrint(&cache_buf, "{s}/cache/Cask/{s}{s}", .{ self.prefix, token, ext }) catch continue;
+            // cache file may not exist for this extension.
             fs_compat.cwd().deleteFile(cache_file) catch {};
         }
 
-        // Remove DB record
+        // DB row cleanup; uninstall already did the user-visible work.
         removeRecord(self.db, token) catch {};
     }
 
@@ -435,7 +436,7 @@ pub const CaskInstaller = struct {
         };
         child_mod.runOrFail(self.allocator, &mount_argv) catch return error.InstallFailed;
 
-        // Ensure we unmount on any exit — best-effort, swallow detach errors.
+        // Unmount on any exit; kernel reaps stuck mounts on reboot if both fail.
         defer {
             const detach_argv = [_][]const u8{ "hdiutil", "detach", mount_point, "-quiet" };
             child_mod.runOrFail(self.allocator, &detach_argv) catch {};
@@ -457,7 +458,7 @@ pub const CaskInstaller = struct {
         const dst_app = try std.fmt.allocPrint(self.allocator, "{s}/{s}", .{ app_dir, app_name });
         errdefer self.allocator.free(dst_app);
 
-        // Remove existing app if present (reinstall/upgrade)
+        // existing app may not be present (fresh install).
         fs_compat.deleteTreeAbsolute(dst_app) catch {};
 
         // Copy .app bundle using ditto (preserves resource forks, xattrs)
@@ -476,6 +477,7 @@ pub const CaskInstaller = struct {
             error.PathAlreadyExists => {},
             else => return error.InstallFailed,
         };
+        // temp extract dir; leftover tolerated if teardown races.
         defer fs_compat.deleteTreeAbsolute(extract_dir) catch {};
 
         // Extract with ditto -xk (handles macOS-specific ZIP features)
@@ -495,7 +497,7 @@ pub const CaskInstaller = struct {
         const dst_app = try std.fmt.allocPrint(self.allocator, "{s}/{s}", .{ app_dir, app_name });
         errdefer self.allocator.free(dst_app);
 
-        // Remove existing
+        // existing app may not be present.
         fs_compat.deleteTreeAbsolute(dst_app) catch {};
 
         // Move .app to /Applications
@@ -550,6 +552,7 @@ pub const CaskInstaller = struct {
         const dst_app = try std.fmt.allocPrint(self.allocator, "{s}/{s}", .{ app_dir, app_name });
         errdefer self.allocator.free(dst_app);
 
+        // existing app may not be present.
         fs_compat.deleteTreeAbsolute(dst_app) catch {};
         const mv_argv = [_][]const u8{ "ditto", src_app, dst_app };
         child_mod.runOrFail(self.allocator, &mv_argv) catch return error.InstallFailed;
@@ -598,6 +601,7 @@ pub const CaskInstaller = struct {
         // Archives sometimes land without the x-bit when built on CI.
         const exec_file = fs_compat.openFileAbsolute(abs_bin, .{ .mode = .read_write }) catch
             return error.InstallFailed;
+        // chmod may fail on FUSE/NFS mounts; symlink still works if bit was set.
         exec_file.chmod(0o755) catch {};
         exec_file.close();
 
@@ -609,7 +613,7 @@ pub const CaskInstaller = struct {
         const link_path = try std.fmt.allocPrint(self.allocator, "{s}/{s}", .{ bin_parent, link_name });
         errdefer self.allocator.free(link_path);
 
-        // Replace any stale symlink/file so reinstalls are idempotent.
+        // stale link may not exist (fresh install); symLink below is authoritative.
         fs_compat.cwd().deleteFile(link_path) catch {};
         fs_compat.symLinkAbsolute(abs_bin, link_path, .{}) catch return error.InstallFailed;
         return link_path;
@@ -634,6 +638,7 @@ pub const CaskInstaller = struct {
         const caskroom_ver = std.fmt.bufPrint(&buf, "{s}/Caskroom/{s}/{s}", .{
             self.prefix, cask.token, cask.version,
         }) catch return;
+        // Caskroom dir is cosmetic bookkeeping; install already recorded in DB.
         fs_compat.cwd().makePath(caskroom_ver) catch {};
     }
 };
@@ -769,6 +774,7 @@ fn applicationsDir(prefix: []const u8, out: []u8) []const u8 {
     const probe = fs_compat.createFileAbsolute(test_path, .{});
     const system_writable = if (probe) |f| blk: {
         f.close();
+        // probe file cleanup; leaving it behind would still be benign.
         fs_compat.cwd().deleteFile(test_path) catch {};
         break :blk true;
     } else |_| false;

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -404,6 +404,8 @@ pub fn writeInstallReceiptFull(
     // Also include name in a comment-style field (not standard but useful)
     _ = name;
 
+    // INSTALL_RECEIPT.json is consumed by Homebrew-compat tools only; a
+    // partial write leaves the keg usable, and the DB is the source of truth.
     file.writeAll(json) catch {};
 }
 

--- a/src/core/deps.zig
+++ b/src/core/deps.zig
@@ -54,6 +54,7 @@ pub fn resolve(
         };
     }
 
+    // OOM on visited.put is non-fatal: duplicates are caught by the dedup check below.
     visited.put(root_name, {}) catch {};
 
     while (queue.popFront()) |dep_name| {
@@ -177,7 +178,9 @@ pub fn ensureOptLink(db: *sqlite.Database, prefix: []const u8, name: []const u8)
     };
     var parent_dir = fs_compat.openDirAbsolute(opt_parent, .{}) catch return;
     defer parent_dir.close();
+    // Stale opt/<name> may not exist on first link; symLink would EEXIST otherwise.
     parent_dir.deleteFile(name) catch {};
+    // Best-effort opt refresh: a failure here leaves the DB correct; `mt link` recovers.
     parent_dir.symLink(cellar_path, name, .{}) catch {};
 }
 

--- a/src/core/dsl/builtins/fileutils.zig
+++ b/src/core/dsl/builtins/fileutils.zig
@@ -1,6 +1,13 @@
 //! malt — DSL builtin: FileUtils operations
 //! Maps Ruby FileUtils module calls to std.fs operations.
 //! All mutating operations go through sandbox.validatePath first.
+//!
+//! Every fs mutation below swallows its error. The contract is:
+//! formulae run as a sequence of mutations and a final check (linker,
+//! cellar layout, bottle verify); a silent mid-step failure surfaces at
+//! the downstream step that expects the side effect to have happened.
+//! Matches Ruby FileUtils' force variants — closer to `rm_f`/`cp` with
+//! `force: true` than their strict counterparts.
 
 const std = @import("std");
 const fs_compat = @import("../../../fs/compat.zig");

--- a/src/core/dsl/builtins/inreplace.zig
+++ b/src/core/dsl/builtins/inreplace.zig
@@ -49,6 +49,7 @@ pub fn inreplace(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Valu
         const stderr = fs_compat.stderrFile();
         var buf: [512]u8 = undefined;
         const msg = std.fmt.bufPrint(&buf, "malt: inreplace atomic write failed ({s}); falling back to direct overwrite\n", .{@errorName(e)}) catch return Value{ .nil = {} };
+        // Warning is advisory; fallback write is the load-bearing step.
         stderr.writeAll(msg) catch {};
         writeDirectly(path, new_content);
     };
@@ -112,6 +113,7 @@ fn writeAtomic(path: []const u8, content: []const u8) !void {
     const tmp_file = dir.createFile(tmp_name, .{}) catch return error.AccessDenied;
     tmp_file.writeAll(content) catch {
         tmp_file.close();
+        // Cleanup of the partial tmp file; the write error is what we return.
         dir.deleteFile(tmp_name) catch {};
         return error.AccessDenied;
     };
@@ -119,6 +121,7 @@ fn writeAtomic(path: []const u8, content: []const u8) !void {
 
     // Rename over original
     dir.rename(tmp_name, basename) catch {
+        // Cleanup of the orphaned tmp file; the rename error is what we return.
         dir.deleteFile(tmp_name) catch {};
         return error.AccessDenied;
     };
@@ -128,5 +131,6 @@ fn writeAtomic(path: []const u8, content: []const u8) !void {
 fn writeDirectly(path: []const u8, content: []const u8) void {
     const out = fs_compat.createFileAbsolute(path, .{ .truncate = true }) catch return;
     defer out.close();
+    // Fallback path already logged a warning; no error channel left to surface.
     out.writeAll(content) catch {};
 }

--- a/src/core/dsl/builtins/pathname.zig
+++ b/src/core/dsl/builtins/pathname.zig
@@ -1,5 +1,9 @@
 //! malt — DSL builtin: Pathname operations
 //! Maps Ruby Pathname methods to std.fs calls.
+//!
+//! Same contract as fileutils.zig: fs mutations swallow their errors and
+//! surface at the downstream step (linker, cellar layout, bottle verify).
+//! Matches Ruby's non-raising Pathname helpers used by Homebrew formulae.
 
 const std = @import("std");
 const fs_compat = @import("../../../fs/compat.zig");

--- a/src/core/dsl/builtins/process.zig
+++ b/src/core/dsl/builtins/process.zig
@@ -36,7 +36,8 @@ pub fn system(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
 
 /// quiet_system — execute a command, suppress output
 pub fn quietSystem(ctx: ExecCtx, recv: ?Value, args: []const Value) BuiltinError!Value {
-    // Same as system but we ignore the exit code (quiet)
+    // Ruby's `quiet_system` returns true/false and never raises; we drop the
+    // bool too because the DSL sites that use it ignore the result.
     _ = system(ctx, recv, args) catch {};
     return Value{ .nil = {} };
 }
@@ -116,6 +117,7 @@ pub fn macosVersion(ctx: ExecCtx, _: ?Value, _: []const Value) BuiltinError!Valu
     child.spawn() catch return Value{ .string = "15.0" };
     const stdout = child.stdout orelse return Value{ .string = "15.0" };
     const ver = fs_compat.readFileToEndAlloc(stdout, ctx.allocator, 256) catch return Value{ .string = "15.0" };
+    // Already captured stdout; wait is just for reaping the zombie.
     _ = child.wait() catch {};
     const trimmed = std.mem.trimEnd(u8, ver, "\n\r ");
     return Value{ .string = trimmed };
@@ -198,6 +200,7 @@ pub fn safePopenRead(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!
 
     const stdout = child.stdout orelse return Value{ .string = "" };
     const content = fs_compat.readFileToEndAlloc(stdout, ctx.allocator, 1024 * 1024) catch return Value{ .string = "" };
+    // Already captured stdout; wait is just for reaping the zombie.
     _ = child.wait() catch {};
 
     // Chomp trailing newline

--- a/src/core/dsl/interpreter.zig
+++ b/src/core/dsl/interpreter.zig
@@ -558,6 +558,7 @@ pub const Interpreter = struct {
             const msg = try self.eval(msg_node);
             const msg_str = msg.asString(self.allocator) catch "raise";
             const f = fs_compat.stderrFile();
+            // Diagnostic print; returning DslError below is the real signal.
             f.writeAll("  x ") catch {};
             f.writeAll(msg_str) catch {};
             f.writeAll("\n") catch {};

--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -1163,6 +1163,7 @@ pub const Parser = struct {
     }
 
     fn emitError(self: *Parser, message: []const u8) DslError {
+        // OOM here means we lose one diagnostic entry; ParseError still propagates.
         self._diagnostics.append(self.allocator, .{
             .loc = self.currentLoc(),
             .message = message,

--- a/src/core/linker.zig
+++ b/src/core/linker.zig
@@ -119,10 +119,11 @@ pub const Linker = struct {
             // This avoids a window where the link is absent after deleteFile.
             var tmp_name_buf: [280]u8 = undefined;
             const tmp_name = std.fmt.bufPrint(&tmp_name_buf, ".malt_tmp_{s}", .{entry.name}) catch continue;
+            // Stale tmp from a prior aborted link; symLink would otherwise EEXIST.
             parent_dir.deleteFile(tmp_name) catch {};
             parent_dir.symLink(target, tmp_name, .{}) catch continue;
             parent_dir.rename(tmp_name, entry.name) catch {
-                // Rename failed — fall back to direct replacement
+                // Rename failed — fall back to direct replacement (non-atomic).
                 parent_dir.deleteFile(tmp_name) catch {};
                 parent_dir.deleteFile(entry.name) catch {};
                 parent_dir.symLink(target, entry.name, .{}) catch continue;
@@ -159,10 +160,10 @@ pub const Linker = struct {
         var cellar_buf: [512]u8 = undefined;
         const cellar_path = std.fmt.bufPrint(&cellar_buf, "{s}/Cellar/{s}/{s}", .{ self.prefix, name, version }) catch return;
 
-        // Remove existing symlink if present
+        // Stale opt link from a prior version; symLink would otherwise EEXIST.
         opt_dir.deleteFile(name) catch {};
 
-        // Create symlink
+        // Opt is convenience; install remains functional via the versioned link.
         opt_dir.symLink(cellar_path, name, .{}) catch {};
     }
 

--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -522,12 +522,14 @@ pub fn runPostInstall(
     }) catch return RubyError.ScriptWriteFailed;
     tmp_file.writeAll(script) catch {
         tmp_file.close();
+        // Cleanup of the partial tmp script; ScriptWriteFailed is the real error.
         fs_compat.deleteFileAbsolute(tmp_path) catch {};
         return RubyError.ScriptWriteFailed;
     };
     tmp_file.close();
 
-    // Ensure cleanup
+    // Ensure cleanup — tmp path is PID+random, so a late-running delete
+    // only ever targets this process's own script.
     defer fs_compat.deleteFileAbsolute(tmp_path) catch {};
 
     // 7. Spawn Ruby under sandbox-exec with a per-formula profile,

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -384,6 +384,7 @@ fn filterLoop(pipe_fd: c_int, out_fd: c_int) void {
         if (n <= 0) break;
         sanitizer.feed(buf[0..@intCast(n)], sink) catch break;
     }
+    // Flush after EOF; parent fd may already be gone on shutdown races.
     sanitizer.flush(sink) catch {};
 }
 

--- a/src/core/services/supervisor.zig
+++ b/src/core/services/supervisor.zig
@@ -254,6 +254,7 @@ pub fn start(ctx: SupervisorCtx, name: []const u8) SupervisorError!void {
     defer allocator.free(domain);
 
     try runLaunchctl(allocator, &.{ "launchctl", "bootstrap", domain, plist_path });
+    // Status is a UI hint; launchctl is the source of truth for liveness.
     setStatus(ctx.db, name, "running") catch {};
 }
 
@@ -266,19 +267,23 @@ pub fn stop(ctx: SupervisorCtx, name: []const u8) SupervisorError!void {
     defer allocator.free(domain);
 
     try runLaunchctl(allocator, &.{ "launchctl", "bootout", domain, plist_path });
+    // Status is a UI hint; launchctl is the source of truth for liveness.
     setStatus(ctx.db, name, "stopped") catch {};
 }
 
 pub fn restart(ctx: SupervisorCtx, name: []const u8) SupervisorError!void {
+    // Stop may fail if already stopped; start is the required half.
     stop(ctx, name) catch {};
     try start(ctx, name);
 }
 
 pub fn stopAndUnregister(ctx: SupervisorCtx, name: []const u8) void {
+    // Unregister must remove the DB row even if the service is already down.
     stop(ctx, name) catch {};
     var stmt = ctx.db.prepare("DELETE FROM services WHERE name = ?;") catch return;
     defer stmt.finalize();
     stmt.bindText(1, name) catch return;
+    // Row may not exist; DELETE is idempotent either way.
     _ = stmt.step() catch {};
 }
 

--- a/src/fs/archive.zig
+++ b/src/fs/archive.zig
@@ -230,12 +230,14 @@ fn validateSubprocessListing(argv: []const []const u8) !void {
     child.stderr_behavior = .ignore;
     child.spawn() catch return error.ExtractionFailed;
     const stdout = child.stdout orelse {
+        // Reap the child we just spawned; ExtractionFailed is the real signal.
         _ = child.wait() catch {};
         return error.ExtractionFailed;
     };
     // 4 MiB cap: bottle/tap listings are orders of magnitude smaller;
     // the bound just prevents a pathological archive from ballooning RAM.
     const listing = fs_compat.readFileToEndAlloc(stdout, child_allocator, 4 * 1024 * 1024) catch {
+        // Reap the child we just spawned; ExtractionFailed is the real signal.
         _ = child.wait() catch {};
         return error.ExtractionFailed;
     };

--- a/src/fs/atomic.zig
+++ b/src/fs/atomic.zig
@@ -114,6 +114,8 @@ pub fn atomicRename(allocator: std.mem.Allocator, src_path: []const u8, dst_path
     fs_compat.renameAbsolute(src_path, dst_path) catch |e| switch (e) {
         error.CrossDevice => {
             try clonefile.cloneTree(allocator, src_path, dst_path);
+            // Source cleanup after a successful cross-device clone; a leftover
+            // src is tolerable and gets reaped by the next housekeeping sweep.
             fs_compat.deleteTreeAbsolute(src_path) catch {};
         },
         else => return e,
@@ -143,12 +145,14 @@ pub fn atomicWriteFile(dst_path: []const u8, data: []const u8) !void {
         const f = try fs_compat.createFileAbsolute(tmp_path, .{ .truncate = true });
         defer f.close();
         f.writeAll(data) catch |e| {
+            // Tempfile cleanup on write failure; write error `e` is authoritative.
             fs_compat.deleteFileAbsolute(tmp_path) catch {};
             return e;
         };
     }
 
     fs_compat.renameAbsolute(tmp_path, dst_path) catch |e| {
+        // Tempfile cleanup on rename failure; rename error `e` is authoritative.
         fs_compat.deleteFileAbsolute(tmp_path) catch {};
         return e;
     };
@@ -160,7 +164,8 @@ pub fn atomicWriteFile(dst_path: []const u8, data: []const u8) !void {
 pub fn createTempDir(allocator: std.mem.Allocator, label: []const u8) ![]const u8 {
     const prefix = maltPrefix();
 
-    // Ensure the tmp base directory exists.
+    // Ensure the tmp base directory exists. If makePath fails, makeDirAbsolute
+    // below surfaces the real error on the final dir.
     const tmp_base = try std.fmt.allocPrint(allocator, "{s}/tmp", .{prefix});
     defer allocator.free(tmp_base);
     fs_compat.cwd().makePath(tmp_base) catch {};

--- a/src/fs/clonefile.zig
+++ b/src/fs/clonefile.zig
@@ -66,6 +66,8 @@ pub fn copyTreeFallback(allocator: std.mem.Allocator, src_path: []const u8, dst_
     var walker = src_dir.walk(allocator) catch return error.OutOfMemory;
     defer walker.deinit();
 
+    // Per-entry clone is opportunistic: any single-entry failure skips that
+    // path and continues the walk. Callers verify the final tree shape.
     while (walker.next() catch return error.AccessDenied) |entry| {
         switch (entry.kind) {
             .directory => {

--- a/src/fs/compat.zig
+++ b/src/fs/compat.zig
@@ -19,6 +19,7 @@ pub fn readFileToEndAlloc(file: std.Io.File, allocator: std.mem.Allocator, max_b
 }
 
 pub fn sleepNanos(ns: u64) void {
+    // `sleep` returns !void for cancellation; an early wake just shortens the delay.
     std.Io.sleep(io_mod.ctx(), std.Io.Duration.fromNanoseconds(@intCast(ns)), .awake) catch {};
 }
 

--- a/src/macho/patcher.zig
+++ b/src/macho/patcher.zig
@@ -382,7 +382,8 @@ pub fn patchTextFiles(
             defer if (current.ptr != content.ptr) allocator.free(current);
             // Write back
             file.writeAllAt(current, 0) catch continue;
-            // Truncate if new content is shorter
+            // Truncate if new content is shorter; trailing bytes are harmless if truncate fails
+            // (Mach-O loader stops at size recorded in header, not file size).
             file.setEndPos(current.len) catch {};
             count += 1;
         }

--- a/src/net/api.zig
+++ b/src/net/api.zig
@@ -258,6 +258,7 @@ pub const BrewApi = struct {
 
         const f = fs_compat.cwd().createFile(p, .{}) catch return;
         defer f.close();
+        // Partial index is discarded on next miss; next fetch re-populates from network.
         f.writeAll(data) catch {};
     }
 
@@ -265,6 +266,7 @@ pub const BrewApi = struct {
     pub fn invalidateCache(self: *BrewApi) void {
         var api_path_buf: [512]u8 = undefined;
         const api_path = std.fmt.bufPrint(&api_path_buf, "{s}/api", .{self.cache_dir}) catch return;
+        // Cache dir absent on first-ever run; wipe is purely opportunistic.
         fs_compat.deleteTreeAbsolute(api_path) catch {};
     }
 
@@ -338,6 +340,9 @@ pub const BrewApi = struct {
         // Atomic write so a crash mid-`writeAll` can't leave a
         // truncated JSON file that breaks the next install until the
         // cache is manually wiped.
+        //
+        // Cache is a latency optimization; a write failure (disk full,
+        // permissions) just means the next call re-fetches over the network.
         atomic.atomicWriteFile(cache_path, data) catch {};
     }
 

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -331,6 +331,7 @@ pub const HttpClient = struct {
                 if (classifyStatus(resp.status)) |dl_err| {
                     if (isTransientError(dl_err) and attempt < max_retries) {
                         resp.allocator.free(resp.body);
+                        // Sleep is backoff jitter; interruption just retries sooner.
                         std.Io.sleep(io_mod.ctx(), std.Io.Duration.fromNanoseconds(@intCast(retry_delays_ms[attempt] * std.time.ns_per_ms)), .awake) catch {};
                         attempt += 1;
                         continue;
@@ -339,6 +340,7 @@ pub const HttpClient = struct {
                 return resp;
             } else |err| {
                 if (attempt < max_retries) {
+                    // Sleep is backoff jitter; interruption just retries sooner.
                     std.Io.sleep(io_mod.ctx(), std.Io.Duration.fromNanoseconds(@intCast(retry_delays_ms[attempt] * std.time.ns_per_ms)), .awake) catch {};
                     attempt += 1;
                     continue;

--- a/src/ui/color.zig
+++ b/src/ui/color.zig
@@ -106,6 +106,8 @@ pub fn setTruecolorForTest(v: ?bool) void {
 }
 
 /// Write styled text to stderr. If colors disabled, writes text only.
+/// Every write is best-effort: stderr may be a closed pipe, and a failed
+/// draw must not abort whatever the caller was reporting on.
 pub fn styled(style: Style, text: []const u8) void {
     const f = fs_compat.stderrFile();
     if (isColorEnabled()) {
@@ -235,6 +237,8 @@ fn queryOsc11Background() ?Background {
     raw.cc[@intFromEnum(std.posix.V.MIN)] = 0;
     raw.cc[@intFromEnum(std.posix.V.TIME)] = 0;
     std.posix.tcsetattr(stdin_fd, .FLUSH, raw) catch return null;
+    // Restore cooked mode; if this fails the TTY is already broken and
+    // there is no recovery we can sensibly do from inside defer.
     defer std.posix.tcsetattr(stdin_fd, .FLUSH, saved) catch {};
 
     const query = "\x1b]11;?\x1b\\";

--- a/src/ui/io.zig
+++ b/src/ui/io.zig
@@ -82,6 +82,7 @@ pub fn endStdoutCapture() void {
 pub fn stderrWriteAll(bytes: []const u8) void {
     if (builtin.is_test) {
         if (capture_list) |list| {
+            // Test-only capture; OOM inside a test is a bug the test will surface elsewhere.
             list.appendSlice(capture_allocator, bytes) catch {};
             return;
         }
@@ -92,6 +93,7 @@ pub fn stderrWriteAll(bytes: []const u8) void {
 pub fn stdoutWriteAll(bytes: []const u8) void {
     if (builtin.is_test) {
         if (stdout_capture_list) |list| {
+            // Test-only capture; OOM inside a test is a bug the test will surface elsewhere.
             list.appendSlice(stdout_capture_allocator, bytes) catch {};
             return;
         }

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -260,6 +260,7 @@ pub fn jsonStr(w: *std.Io.Writer, s: []const u8) !void {
         } else if (byte < 0x20) {
             if (i > start) try w.writeAll(s[start..i]);
             var hex_buf: [6]u8 = undefined;
+            // `\u` + 4 hex digits = 6 bytes exactly; bufPrint cannot overflow a 6-byte buffer.
             const hex = std.fmt.bufPrint(&hex_buf, "\\u{x:0>4}", .{byte}) catch unreachable;
             try w.writeAll(hex);
             start = i + 1;

--- a/src/ui/progress.zig
+++ b/src/ui/progress.zig
@@ -1,5 +1,9 @@
 //! malt — progress module
 //! Terminal progress bar rendering with multi-line support.
+//!
+//! Every stderr write in this file is best-effort: a draw failure must not
+//! abort the work the bar is reporting on (download, install, migration).
+//! That is why each `writeAll` below ends in `catch {}`.
 
 const std = @import("std");
 const fs_compat = @import("../fs/compat.zig");

--- a/src/update/swap.zig
+++ b/src/update/swap.zig
@@ -44,6 +44,7 @@ pub fn atomicReplace(target_path: []const u8, new_path: []const u8) SwapError!vo
     // from a killed earlier run first so copy never EEXISTs.
     fs_compat.deleteFileAbsolute(staged_path) catch {};
     fs_compat.copyFileAbsolute(new_path, staged_path, .{}) catch return error.StagingFailed;
+    // Errdefer cleanup: stage leaks get reaped by the next update's pre-copy delete above.
     errdefer fs_compat.deleteFileAbsolute(staged_path) catch {};
 
     // Set mode on the staged file so we never leave a non-executable
@@ -63,6 +64,7 @@ pub fn atomicReplace(target_path: []const u8, new_path: []const u8) SwapError!vo
 
     // Atomic rename #1: target -> target.old.
     fs_compat.renameAbsolute(target_path, old_path) catch return error.SwapFailed;
+    // Rollback rename; if this also fails the caller already has RollbackFailed surfaced.
     errdefer fs_compat.renameAbsolute(old_path, target_path) catch {};
 
     // Atomic rename #2: staged -> target. If this fails the errdefers


### PR DESCRIPTION
## Description

Walk every swallowed `catch {}` / `catch unreachable` in `src/`. Each surviving swallow now declares its intent co-located with the call: why discarding the error is the correct behaviour at that site. Swallows that were masking a real error path were promoted to `try` or a named error arm. No public error sets widened beyond what the promoted call sites already declared.

The goal is reviewability: a reader should be able to tell, without context, why any `catch {}` in this codebase is load-bearing rather than an oversight.

## Related Issue

- None

## Notes for Reviewers

- None