### PR TITLE
refactor(ui,cli): replace long "writeAll catch {}" chains with try

### DIFF
--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -38,6 +38,45 @@ fn validateComponent(part: []const u8) TapNameError!void {
     }
 }
 
+/// Render one listing row: `name @ {7-char sha}` when pinned, or
+/// `name (unpinned — run \`mt tap --refresh name\`)` when not. Caller owns
+/// the returned slice. Kept in one place so the refresh hint stays in
+/// sync with `mt tap --refresh` and the exact byte layout is testable.
+fn formatTapLine(allocator: std.mem.Allocator, t: tap_mod.TapInfo) ![]u8 {
+    if (t.commit_sha) |sha| {
+        const short_len = @min(sha.len, 7);
+        return std.fmt.allocPrint(allocator, "{s} @ {s}\n", .{ t.name, sha[0..short_len] });
+    }
+    return std.fmt.allocPrint(
+        allocator,
+        "{s} (unpinned — run `mt tap --refresh {s}`)\n",
+        .{ t.name, t.name },
+    );
+}
+
+test "formatTapLine renders short SHA for a pinned tap" {
+    const line = try formatTapLine(std.testing.allocator, .{
+        .name = "user/repo",
+        .url = "https://x",
+        .commit_sha = "0123456789abcdef0123456789abcdef01234567",
+    });
+    defer std.testing.allocator.free(line);
+    try std.testing.expectEqualStrings("user/repo @ 0123456\n", line);
+}
+
+test "formatTapLine renders refresh hint for an unpinned tap" {
+    const line = try formatTapLine(std.testing.allocator, .{
+        .name = "user/repo",
+        .url = "https://x",
+        .commit_sha = null,
+    });
+    defer std.testing.allocator.free(line);
+    try std.testing.expectEqualStrings(
+        "user/repo (unpinned — run `mt tap --refresh user/repo`)\n",
+        line,
+    );
+}
+
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     return run(allocator, args, .add);
 }
@@ -114,21 +153,12 @@ fn run(allocator: std.mem.Allocator, args: []const []const u8, action: Action) !
         }
 
         for (taps) |t| {
-            // stdout may be a closed pipe (head, grep -q, etc.); dropping the
-            // listing line is the correct behaviour, not an aborted command.
-            const f = fs_compat.stdoutFile();
-            f.writeAll(t.name) catch {};
-            if (t.commit_sha) |sha| {
-                f.writeAll(" @ ") catch {};
-                // 7-char short SHA to keep the listing compact.
-                const short_len = @min(sha.len, 7);
-                f.writeAll(sha[0..short_len]) catch {};
-            } else {
-                f.writeAll(" (unpinned — run `mt tap --refresh ") catch {};
-                f.writeAll(t.name) catch {};
-                f.writeAll("`)") catch {};
-            }
-            f.writeAll("\n") catch {};
+            // Assemble the line once so stdout sees a single writeAll — a closed
+            // pipe (head, grep -q, etc.) drops the full line rather than leaving
+            // it half-written. Empty on OOM keeps the listing best-effort.
+            const line = formatTapLine(allocator, t) catch "";
+            defer if (line.len != 0) allocator.free(line);
+            fs_compat.stdoutFile().writeAll(line) catch {};
             allocator.free(t.name);
             allocator.free(t.url);
             if (t.commit_sha) |sha| allocator.free(sha);

--- a/src/core/dsl/interpreter.zig
+++ b/src/core/dsl/interpreter.zig
@@ -557,11 +557,13 @@ pub const Interpreter = struct {
         if (rs.message) |msg_node| {
             const msg = try self.eval(msg_node);
             const msg_str = msg.asString(self.allocator) catch "raise";
-            const f = fs_compat.stderrFile();
-            // Diagnostic print; returning DslError below is the real signal.
-            f.writeAll("  x ") catch {};
-            f.writeAll(msg_str) catch {};
-            f.writeAll("\n") catch {};
+            // Assemble once so EPIPE hits a single detectable site; the real
+            // signal is DslError.PostInstallFailed below, so both the
+            // assembly OOM and the stream failure are tolerated.
+            if (std.fmt.allocPrint(self.allocator, "  x {s}\n", .{msg_str})) |line| {
+                defer self.allocator.free(line);
+                fs_compat.stderrFile().writeAll(line) catch {};
+            } else |_| {}
         }
         return DslError.PostInstallFailed;
     }

--- a/src/ui/color.zig
+++ b/src/ui/color.zig
@@ -105,20 +105,6 @@ pub fn setTruecolorForTest(v: ?bool) void {
     truecolor_cached = v;
 }
 
-/// Write styled text to stderr. If colors disabled, writes text only.
-/// Every write is best-effort: stderr may be a closed pipe, and a failed
-/// draw must not abort whatever the caller was reporting on.
-pub fn styled(style: Style, text: []const u8) void {
-    const f = fs_compat.stderrFile();
-    if (isColorEnabled()) {
-        f.writeAll(style.code()) catch {};
-        f.writeAll(text) catch {};
-        f.writeAll(Style.reset.code()) catch {};
-    } else {
-        f.writeAll(text) catch {};
-    }
-}
-
 /// Cached background accessor. Detection runs at most once per process.
 pub fn background() Background {
     if (background_cached) |v| return v;

--- a/src/ui/progress.zig
+++ b/src/ui/progress.zig
@@ -3,7 +3,9 @@
 //!
 //! Every stderr write in this file is best-effort: a draw failure must not
 //! abort the work the bar is reporting on (download, install, migration).
-//! That is why each `writeAll` below ends in `catch {}`.
+//! Each print group assembles its bytes in a stack buffer and hits stderr
+//! once so EPIPE surfaces at a single catch site instead of corrupting
+//! mid-chain output.
 
 const std = @import("std");
 const fs_compat = @import("../fs/compat.zig");
@@ -28,17 +30,14 @@ pub const MultiProgress = struct {
         const tty = stderr.supportsAnsiEscapeCodes();
 
         // Hide cursor, disable autowrap, reserve lines by printing empty placeholders.
-        // Autowrap is disabled so that if a bar row exceeds the terminal width, the
-        // overflow is clipped at the right edge instead of flowing onto a second
-        // visual line — wrapping would break the ESC[NA cursor-up math that each
-        // bar uses to update its dedicated line.
+        // Autowrap disabled so an over-width bar clips instead of wrapping —
+        // wrapping would break the ESC[NA cursor-up math each bar relies on.
         if (tty and !output.isQuiet()) {
-            stderr.writeAll("\x1b[?25l") catch {}; // hide cursor
-            stderr.writeAll("\x1b[?7l") catch {}; // disable autowrap
-            var i: u8 = 0;
-            while (i < count) : (i += 1) {
-                stderr.writeAll("\n") catch {};
-            }
+            var buf: [multi_init_max_bytes]u8 = undefined;
+            const prefix = "\x1b[?25l\x1b[?7l"; // hide cursor + disable autowrap
+            @memcpy(buf[0..prefix.len], prefix);
+            @memset(buf[prefix.len .. prefix.len + count], '\n');
+            stderr.writeAll(buf[0 .. prefix.len + count]) catch {};
         }
 
         return .{
@@ -52,11 +51,13 @@ pub const MultiProgress = struct {
     /// Must be called after all download threads have joined.
     pub fn finish(self: *MultiProgress) void {
         if (self.is_tty and !output.isQuiet()) {
-            const stderr = fs_compat.stderrFile();
-            stderr.writeAll("\x1b[?7h") catch {}; // re-enable autowrap
-            stderr.writeAll("\x1b[?25h\r") catch {}; // show cursor + column 0
+            // Re-enable autowrap, show cursor, return to col 0.
+            fs_compat.stderrFile().writeAll("\x1b[?7h\x1b[?25h\r") catch {};
         }
     }
+
+    /// "\x1b[?25l" (6) + "\x1b[?7l" (5) + up to u8-max newlines.
+    const multi_init_max_bytes: usize = 6 + 5 + std.math.maxInt(u8);
 };
 
 pub const ProgressBar = struct {
@@ -457,14 +458,7 @@ pub const Spinner = struct {
         if (output.isQuiet()) return;
 
         if (!self.is_tty) {
-            // Non-TTY: emit a single dim info line and return. No animation.
-            const f = fs_compat.stderrFile();
-            const pfx: []const u8 = if (color.isEmojiEnabled()) "  \xe2\x96\xb8 " else "  > ";
-            if (color.isColorEnabled()) f.writeAll(color.SemanticStyle.detail.code()) catch {};
-            f.writeAll(pfx) catch {};
-            f.writeAll(self.message) catch {};
-            if (color.isColorEnabled()) f.writeAll(color.Style.reset.code()) catch {};
-            f.writeAll("\n") catch {};
+            self.writeFallbackLine();
             return;
         }
 
@@ -472,17 +466,42 @@ pub const Spinner = struct {
         f.writeAll("\x1b[?25l") catch {}; // hide cursor
         self.active = true;
         self.thread = std.Thread.spawn(.{}, spinLoop, .{self}) catch blk: {
-            // Thread spawn failed: fall back to a single static line.
+            // Thread spawn failed: restore cursor and emit the static fallback line.
             self.active = false;
             f.writeAll("\x1b[?25h") catch {};
-            const pfx: []const u8 = if (color.isEmojiEnabled()) "  \xe2\x96\xb8 " else "  > ";
-            if (color.isColorEnabled()) f.writeAll(color.SemanticStyle.detail.code()) catch {};
-            f.writeAll(pfx) catch {};
-            f.writeAll(self.message) catch {};
-            if (color.isColorEnabled()) f.writeAll(color.Style.reset.code()) catch {};
-            f.writeAll("\n") catch {};
+            self.writeFallbackLine();
             break :blk null;
         };
+    }
+
+    /// Assemble one dim info line ("<detail>pfx message<reset>\n") in a
+    /// stack buffer and write it once so EPIPE surfaces at a single site.
+    fn writeFallbackLine(self: *const Spinner) void {
+        var buf: [512]u8 = undefined;
+        var pos: usize = 0;
+        const use_color = color.isColorEnabled();
+
+        if (use_color) {
+            const detail = color.SemanticStyle.detail.code();
+            @memcpy(buf[pos .. pos + detail.len], detail);
+            pos += detail.len;
+        }
+        const pfx: []const u8 = if (color.isEmojiEnabled()) "  \xe2\x96\xb8 " else "  > ";
+        @memcpy(buf[pos .. pos + pfx.len], pfx);
+        pos += pfx.len;
+        const reset_len = if (use_color) color.Style.reset.code().len else 0;
+        const msg_len = @min(self.message.len, buf.len - pos - reset_len - 1);
+        @memcpy(buf[pos .. pos + msg_len], self.message[0..msg_len]);
+        pos += msg_len;
+        if (use_color) {
+            const reset_code = color.Style.reset.code();
+            @memcpy(buf[pos .. pos + reset_code.len], reset_code);
+            pos += reset_code.len;
+        }
+        buf[pos] = '\n';
+        pos += 1;
+
+        fs_compat.stderrFile().writeAll(buf[0..pos]) catch {};
     }
 
     /// Signal the background thread to exit, join it, then clear the line


### PR DESCRIPTION
## Description

Replace long `writeAll(...) catch {}` chains in tap/color/progress/interpreter with single-write print groups so EPIPE and mid-chain write failures surface at one detectable site instead of silently producing half-written output.

## Related Issue

- None

## Notes for Reviewers

- None