### PR TITLE
refactor: use @tagName for trivial enum label switches

### DIFF
--- a/src/cli/purge/args.zig
+++ b/src/cli/purge/args.zig
@@ -62,17 +62,13 @@ pub const Category = enum {
     binary, // /usr/local/bin/{mt,malt} — opt-in via --remove-binary
 
     pub fn label(self: Category) []const u8 {
+        // @tagName covers the trivial tags so a rename can't desync label from source.
         return switch (self) {
             .linked_dir => "linked",
-            .opt => "opt",
             .cellar => "Cellar",
             .caskroom => "Caskroom",
-            .store => "store",
-            .cache => "cache",
-            .tmp => "tmp",
-            .db => "db",
             .prefix_root => "prefix",
-            .binary => "binary",
+            .opt, .store, .cache, .tmp, .db, .binary => @tagName(self),
         };
     }
 };

--- a/tests/purge_test.zig
+++ b/tests/purge_test.zig
@@ -126,6 +126,24 @@ test "parseArgs rejects positional arguments" {
     try testing.expectError(purge.Error.InvalidArgs, purge.parseArgs(&argv));
 }
 
+// ── Category.label ───────────────────────────────────────────────────────
+
+test "Category.label pins every tag to its user-facing string" {
+    // Guards the @tagName collapse: non-trivial mappings (linked_dir,
+    // Cellar/Caskroom capitalisation, prefix_root) must stay; trivial
+    // ones must match the tag name byte-for-byte.
+    try testing.expectEqualStrings("linked", purge.Category.label(.linked_dir));
+    try testing.expectEqualStrings("opt", purge.Category.label(.opt));
+    try testing.expectEqualStrings("Cellar", purge.Category.label(.cellar));
+    try testing.expectEqualStrings("Caskroom", purge.Category.label(.caskroom));
+    try testing.expectEqualStrings("store", purge.Category.label(.store));
+    try testing.expectEqualStrings("cache", purge.Category.label(.cache));
+    try testing.expectEqualStrings("tmp", purge.Category.label(.tmp));
+    try testing.expectEqualStrings("db", purge.Category.label(.db));
+    try testing.expectEqualStrings("prefix", purge.Category.label(.prefix_root));
+    try testing.expectEqualStrings("binary", purge.Category.label(.binary));
+}
+
 // ── buildPlan ────────────────────────────────────────────────────────────
 
 fn findCategory(plan: []const purge.Target, cat: purge.Category) ?usize {


### PR DESCRIPTION
## Description

Collapse the trivial arms of `purge.Category.label` to `@tagName(self)` so the switch only lists the four tags whose user-facing string actually diverges from the tag name (`linked_dir -> "linked"`, `cellar -> "Cellar"`, `caskroom -> "Caskroom"`, `prefix_root -> "prefix"`). `cellar.describeError` is untouched because every variant maps to a distinct prose message, not the tag name.

## Related Issue

- None

## Notes for Reviewers

- None
