### PR TITLE
fix(cli/install): resolve third-party tap HEAD commit reliably

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,6 +752,7 @@ Every install follows a strict 9-step protocol. Failure at any step triggers cle
 | `MALT_NO_EMOJI`                | Disable emoji in output                                                           | unset            |
 | `MALT_THEME`                   | Force the output palette: `light`, `dark`, or `auto` (detects via OSC 11)         | `auto`           |
 | `HOMEBREW_GITHUB_API_TOKEN`    | GitHub token for higher API rate limits                                           | unset            |
+| `MALT_GITHUB_TOKEN`            | GitHub token sent as `Authorization: Bearer` on tap `/commits/HEAD` calls only    | unset            |
 | `MALT_ALLOW_UNVERIFIED`        | Skip cosign signature check in `install.sh` (use only when cosign is unavailable) | unset            |
 | `MALT_ALLOW_UNVERIFIED_SOURCE` | Allow `install.sh` to clone `main` when no release tag resolves                   | unset            |
 | `MALT_ALLOW_RAW_POST_INSTALL`  | Disable terminal escape filter on ruby `post_install` output                      | unset            |
@@ -788,33 +789,39 @@ zig build universal                      # universal binary (arm64 + x86_64 via 
 Install times on macOS 14 (Apple Silicon), comparing malt against other Homebrew-compatible package managers.
 
 <!-- BENCH:SIZE:START -->
+
 ### Binary Size
 
-| Tool | Size |
-| ---- | ---- |
+| Tool     | Size   |
+| -------- | ------ |
 | **malt** | 3.1 MB |
 | nanobrew | 1.7 MB |
 | zerobrew | 8.6 MB |
+
 <!-- BENCH:SIZE:END -->
 
 <!-- BENCH:COLD:START -->
+
 ### Cold Install (median ±σ)
 
-| Package | malt | nanobrew | zerobrew | Homebrew |
-| ------- | ---- | -------- | -------- | -------- |
-| **tree** (0 deps) | 0.630±0.237s | 0.644±0.029s | 1.232±0.071s | 3.323±0.287s |
-| **wget** (6 deps) | 3.408±0.263s | 5.753±1.347s | 8.484±1.862s | 5.109±1.243s |
+| Package              | malt         | nanobrew     | zerobrew     | Homebrew      |
+| -------------------- | ------------ | ------------ | ------------ | ------------- |
+| **tree** (0 deps)    | 0.630±0.237s | 0.644±0.029s | 1.232±0.071s | 3.323±0.287s  |
+| **wget** (6 deps)    | 3.408±0.263s | 5.753±1.347s | 8.484±1.862s | 5.109±1.243s  |
 | **ffmpeg** (11 deps) | 3.055±0.468s | 3.779±0.191s | 7.375±0.456s | 17.314±0.814s |
+
 <!-- BENCH:COLD:END -->
 
 <!-- BENCH:WARM:START -->
+
 ### Warm Install
 
-| Package | malt | nanobrew | zerobrew |
-| ------- | ---- | -------- | -------- |
-| **tree** (0 deps) | 0.007s | 0.014s | 0.226s |
-| **wget** (6 deps) | 0.092s | 2.976s | 1.013s |
-| **ffmpeg** (11 deps) | 0.297s | 1.547s | 3.026s |
+| Package              | malt   | nanobrew | zerobrew |
+| -------------------- | ------ | -------- | -------- |
+| **tree** (0 deps)    | 0.007s | 0.014s   | 0.226s   |
+| **wget** (6 deps)    | 0.092s | 2.976s   | 1.013s   |
+| **ffmpeg** (11 deps) | 0.297s | 1.547s   | 3.026s   |
+
 <!-- BENCH:WARM:END -->
 
 > [!IMPORTANT]

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -225,6 +225,11 @@ else
   # exercise it via a full smoke run before shipping.
   run_ok t3.version.update.check -- "$MT_BIN" version update --check
 
+  # Third-party tap install — guards against the blanket "floating
+  # HEAD" regression. Uses a small GoReleaser-packaged tap formula.
+  run_ok t3.install.tap -- "$MT_BIN" install indaco/tap/sley
+  run_ok t3.uninstall.tap -- "$MT_BIN" uninstall sley
+
   # Issue #85 regression: zig pulls llvm@21 whose post_install uses Ruby's
   # `&:sym` block-pass shorthand. If the DSL parser or fatal-classification
   # ever regresses, the install prints "post_install DSL failed for llvm@21"

--- a/scripts/regressions/tap_cask_install_gh180.sh
+++ b/scripts/regressions/tap_cask_install_gh180.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Regression guard for third-party tap cask installs.
+#
+# Before the fix, `mt install <user>/<tap>/<cask>` collapsed every
+# `resolveHeadCommit` failure — rate limit, 404, network, malformed
+# JSON — into a blanket "refusing to install from a floating HEAD"
+# message. The real cause was invisible without --debug.
+#
+# The fix widens `TapError` so each failure mode has its own tag, and
+# honors `MALT_GITHUB_TOKEN` as a Bearer header on the `/commits/HEAD`
+# call (lifting the 60/hr anonymous cap). The user-facing error now
+# names the cause and the remediation.
+#
+# This script asserts two properties:
+#   1. A known-404 tap input never surfaces the blanket message — it
+#      must emit the new classified message naming the 'homebrew-'
+#      prefix rule. This distinguishes a fixed binary from a pre-fix
+#      one regardless of the runner's GitHub rate-limit state.
+#   2. A real third-party tap install either succeeds or fails with a
+#      classified error (rate limit, 404, network). The blanket string
+#      must never resurface.
+#
+# Usage: scripts/regressions/tap_cask_install_gh180.sh
+# Requirements: built malt at $MALT_BIN or zig-out/bin/malt, network
+# access to api.github.com / raw.githubusercontent.com.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be <= 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_gh180"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+skip() { printf '  - %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+# The original regression symptom. If this phrase appears in *any*
+# install log below, we've re-introduced the opaque error surface.
+BLANKET="refusing to install from a floating HEAD"
+
+# ── Property 1: bogus tap produces a classified message ──────────────
+#
+# The distinguishing signal between fixed and pre-fix binaries. On
+# a pre-fix binary this prints the blanket message; on a fixed binary
+# it names the homebrew- prefix rule (the 404 branch of the classifier).
+BOGUS_LOG="$PREFIX/install_bogus.log"
+printf '▸ malt install malt-nobody-test/nope/nothing (expected: classified 404 message)\n'
+"$BIN" install "malt-nobody-test/nope/nothing" >"$BOGUS_LOG" 2>&1 || true
+if grep -q "$BLANKET" "$BOGUS_LOG"; then
+  tail -30 "$BOGUS_LOG" >&2
+  fail "bogus-tap: regression — opaque 'floating HEAD' error on 404"
+fi
+if ! grep -qE "homebrew-|rate limit|Network failure" "$BOGUS_LOG"; then
+  tail -30 "$BOGUS_LOG" >&2
+  fail "bogus-tap: expected a classified error message, got none"
+fi
+pass "bogus-tap: classified error emitted (no blanket message)"
+
+# ── Property 2: real third-party tap candidates ──────────────────────
+#
+# Each spec is `<tap-slug>`. We accept either a successful install
+# line or a classified error; only the blanket string is a regression.
+#
+# Each spec is `<tap-slug>:<expected-binary>`. The binary basename is
+# what the install must symlink into $PREFIX/bin/. The longbridge cask
+# is the original gh#180 reproduction — its archive ships a
+# `longbridge` binary while the cask token is `longbridge-terminal`,
+# so the cask DSL `binary "longbridge"` directive must be honoured.
+declare -a CANDIDATES=(
+  "longbridge/tap/longbridge-terminal:longbridge"
+  "goreleaser/tap/goreleaser:goreleaser"
+  "indaco/tap/sley:sley"
+)
+
+for spec in "${CANDIDATES[@]}"; do
+  slug="${spec%:*}"
+  bin="${spec##*:}"
+  token="${slug##*/}"
+  LOG="$PREFIX/install_${token}.log"
+  printf '▸ malt install %s (logs → %s)\n' "$slug" "$LOG"
+  "$BIN" install "$slug" >"$LOG" 2>&1 || true
+
+  if grep -q "$BLANKET" "$LOG"; then
+    tail -30 "$LOG" >&2
+    fail "${slug}: regression — opaque 'floating HEAD' error returned"
+  fi
+
+  if grep -qE "installed$| installed " "$LOG"; then
+    link="$PREFIX/bin/$bin"
+    if [[ ! -L "$link" ]]; then
+      tail -30 "$LOG" >&2
+      fail "${slug}: install reported success but \$PREFIX/bin/${bin} is missing"
+    fi
+    target=$(readlink -f "$link" 2>/dev/null || readlink "$link")
+    if [[ ! -x "$target" ]]; then
+      fail "${slug}: \$PREFIX/bin/${bin} resolves to a non-executable target"
+    fi
+    pass "${slug}: installed → \$PREFIX/bin/${bin}"
+  elif grep -qE "homebrew-|rate limit|Network failure|Tap formula/cask not found" "$LOG"; then
+    skip "${slug}: reported a classified non-blanket error; continuing"
+  else
+    tail -30 "$LOG" >&2
+    fail "${slug}: neither installed nor emitted a classified error"
+  fi
+done
+
+printf '\n✔ gh180 third-party tap regression passed\n'

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -53,6 +53,7 @@ pub const LocalPermissionRisk = local_mod.LocalPermissionRisk;
 pub const describeLocalPermissionRisk = local_mod.describeLocalPermissionRisk;
 pub const RubyFormulaInfo = local_mod.RubyFormulaInfo;
 pub const parseRubyFormula = local_mod.parseRubyFormula;
+pub const parseCaskBinary = local_mod.parseCaskBinary;
 pub const extractQuoted = local_mod.extractQuoted;
 const installTapFormula = local_mod.installTapFormula;
 const installLocalFormula = local_mod.installLocalFormula;

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -42,6 +42,11 @@ const ResolvedRubyFormula = struct {
     /// Archive URL post `#{version}` interpolation.
     url: []const u8,
     sha256: []const u8,
+    /// Cask DSL `binary "<x>"` override. Set when the archive's
+    /// top-level executable does not match `name` (e.g. the
+    /// `longbridge-terminal` cask ships a `longbridge` binary). Null
+    /// for formulas and for casks that omit the directive.
+    binary_name: ?[]const u8 = null,
     /// When set, the tap is registered in the DB (mirrors the original
     /// tap install behaviour). Local installs leave this null so they
     /// never pollute the tap list.
@@ -82,8 +87,8 @@ pub fn installTapFormula(
         if ((tap_mod.getCommitSha(allocator, db, tap_slug) catch null)) |cached| {
             break :blk cached;
         }
-        break :blk tap_mod.resolveHeadCommit(allocator, parts.user, parts.repo) catch {
-            output.err("Could not resolve {s}'s HEAD commit — refusing to install from a floating HEAD.", .{tap_slug});
+        break :blk tap_mod.resolveHeadCommit(allocator, parts.user, parts.repo) catch |e| {
+            output.err("Could not resolve {s}'s HEAD commit: {s}", .{ tap_slug, tap_mod.describeResolveError(e) });
             return InstallError.FormulaNotFound;
         };
     };
@@ -152,6 +157,7 @@ pub fn installTapFormula(
         .version = rb.version,
         .url = final_url,
         .sha256 = rb.sha256,
+        .binary_name = parseCaskBinary(resp.body),
         .tap_registration = .{ .url = tap_url, .commit_sha = commit_sha },
     };
     try materializeRubyFormula(allocator, resolved, &http, db, linker, prefix, dry_run, force);
@@ -443,7 +449,12 @@ fn materializeRubyFormula(
     }
 
     // Promote the binary to bin/ (GoReleaser may extract directly or
-    // into a subdirectory — walk to handle both).
+    // into a subdirectory — walk to handle both). For casks that
+    // declare `binary "<x>"`, the archive file is named `<x>` while
+    // the keg is named by the cask token; match on the declared
+    // binary so a tap cask like `longbridge-terminal` lands its
+    // `longbridge` executable.
+    const target_binary = resolved.binary_name orelse resolved.name;
     {
         var cellar_dir = fs_compat.openDirAbsolute(cellar_path, .{ .iterate = true }) catch return InstallError.CellarFailed;
         defer cellar_dir.close();
@@ -454,7 +465,7 @@ fn materializeRubyFormula(
         while (walker.next() catch null) |entry| {
             if (entry.kind != .file) continue;
             const basename = std.fs.path.basename(entry.path);
-            if (std.mem.eql(u8, basename, resolved.name)) {
+            if (std.mem.eql(u8, basename, target_binary)) {
                 const dest_name = std.fmt.bufPrint(&tmp_buf, "bin/{s}", .{basename}) catch continue;
                 cellar_dir.copyFile(entry.path, cellar_dir, dest_name, .{}) catch continue;
                 const bin_file = cellar_dir.openFile(dest_name, .{ .mode = .read_write }) catch continue;
@@ -610,4 +621,24 @@ pub fn extractQuoted(line: []const u8, prefix: []const u8) ?[]const u8 {
     _, const after = std.mem.cut(u8, line, prefix) orelse return null;
     const body, _ = std.mem.cut(u8, after, "\"") orelse return null;
     return body;
+}
+
+/// Pull the first argument of a cask `binary "<name>"` directive.
+/// Homebrew's cask DSL promotes that file to `$PREFIX/bin/<name>`, so
+/// tap casks whose archive binary does not match the cask token
+/// (e.g. `longbridge-terminal` ships a `longbridge` binary) need this
+/// override to land a working symlink. Returns null for formulas or
+/// casks that omit the directive. Anchored to the trimmed line start
+/// so a stray mention in a comment or `desc` string does not match.
+pub fn parseCaskBinary(rb_content: []const u8) ?[]const u8 {
+    var line_start: usize = 0;
+    for (rb_content, 0..) |ch, idx| {
+        if (ch != '\n' and idx != rb_content.len - 1) continue;
+        const line_end = if (ch == '\n') idx else idx + 1;
+        const line = std.mem.trim(u8, rb_content[line_start..line_end], " \t\r");
+        line_start = idx + 1;
+        if (!std.mem.startsWith(u8, line, "binary \"")) continue;
+        if (extractQuoted(line, "binary \"")) |b| return b;
+    }
+    return null;
 }

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -179,8 +179,8 @@ fn run(allocator: std.mem.Allocator, args: []const []const u8, action: Action) !
             const repo = name[slash + 1 ..];
             // Resolve HEAD so the tap is pinned from day one. Failing
             // here beats silently registering an unpinned tap.
-            const sha = tap_mod.resolveHeadCommit(allocator, user, repo) catch {
-                output.err("Could not resolve {s}'s HEAD commit. Network down?", .{name});
+            const sha = tap_mod.resolveHeadCommit(allocator, user, repo) catch |e| {
+                output.err("Could not resolve {s}'s HEAD commit: {s}", .{ name, tap_mod.describeResolveError(e) });
                 return error.Aborted;
             };
             defer allocator.free(sha);
@@ -210,8 +210,8 @@ fn refreshTap(allocator: std.mem.Allocator, db: *sqlite.Database, name: []const 
     const slash = std.mem.findScalar(u8, name, '/').?;
     const user = name[0..slash];
     const repo = name[slash + 1 ..];
-    const sha = tap_mod.resolveHeadCommit(allocator, user, repo) catch {
-        output.err("Could not resolve {s}'s HEAD commit. Network down?", .{name});
+    const sha = tap_mod.resolveHeadCommit(allocator, user, repo) catch |e| {
+        output.err("Could not resolve {s}'s HEAD commit: {s}", .{ name, tap_mod.describeResolveError(e) });
         return error.Aborted;
     };
     defer allocator.free(sha);

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const sqlite = @import("../db/sqlite.zig");
 const client_mod = @import("../net/client.zig");
+const fs_compat = @import("../fs/compat.zig");
 
 pub const TapInfo = struct {
     name: []const u8,
@@ -12,11 +13,58 @@ pub const TapInfo = struct {
 };
 
 pub const TapError = error{
+    /// Catch-all for causes we could not classify (5xx, unknown status, etc.).
     ResolveFailed,
     InvalidSha,
+    /// GitHub answered 404 — the tap repo is not at `homebrew-<repo>`.
     NotFound,
+    /// GitHub answered 403 — public cap is 60/hr per IP.
+    RateLimited,
+    /// `/commits/HEAD` returned 200 but the body did not contain a valid SHA.
+    MalformedJson,
+    /// Network layer failure before a status could be read.
+    NetworkError,
     OutOfMemory,
 };
+
+/// Map a non-200 GitHub response status onto the narrowest `TapError` tag
+/// we can name. Callers use the tag to pick the user-facing message —
+/// see `src/cli/install/local.zig` and `src/cli/tap.zig`.
+pub fn classifyResolveStatus(status: u16) TapError {
+    return switch (status) {
+        403 => TapError.RateLimited,
+        404 => TapError.NotFound,
+        else => TapError.ResolveFailed,
+    };
+}
+
+/// Build a `Authorization: Bearer <token>` header into `buf` from
+/// `MALT_GITHUB_TOKEN`, or return null when the env var is unset or
+/// empty. Exclusive to `resolveHeadCommit` — no other codepath picks up
+/// this env var, so users who set it only affect tap-resolution calls.
+pub fn githubAuthHeader(buf: []u8) ?std.http.Header {
+    const raw = fs_compat.getenv("MALT_GITHUB_TOKEN") orelse return null;
+    const token = std.mem.sliceTo(raw, 0);
+    if (token.len == 0) return null;
+    const value = std.fmt.bufPrint(buf, "Bearer {s}", .{token}) catch return null;
+    return .{ .name = "Authorization", .value = value };
+}
+
+/// Short remediation hint for each `TapError` variant. Keeping the
+/// strings here (not at the call site) means `cli/install/local.zig`
+/// and `cli/tap.zig` cannot drift out of sync, and unit tests can pin
+/// every tag without touching the network or the UI layer.
+pub fn describeResolveError(err: TapError) []const u8 {
+    return switch (err) {
+        error.RateLimited => "GitHub API rate limit reached. Set MALT_GITHUB_TOKEN to an authorized GitHub token to lift the 60/hr anonymous cap.",
+        error.NotFound => "GitHub returned 404 for the tap repo. Third-party taps must live at github.com/<user>/homebrew-<repo>; taps that drop the 'homebrew-' prefix are not yet supported.",
+        error.NetworkError => "Network failure while reaching api.github.com — check connectivity and retry.",
+        error.MalformedJson => "Unexpected response shape from GitHub — rerun with --debug and attach the log when filing an issue.",
+        error.InvalidSha => "GitHub returned a commit SHA that failed validation (not 40-char lowercase hex).",
+        error.ResolveFailed => "GitHub returned an unexpected status while resolving HEAD — retry, or set MALT_GITHUB_TOKEN if this persists.",
+        error.OutOfMemory => "Out of memory while resolving HEAD commit.",
+    };
+}
 
 pub fn add(
     db: *sqlite.Database,
@@ -157,8 +205,9 @@ pub fn parseCommitShaFromJson(body: []const u8) ?[]const u8 {
 }
 
 /// Ask GitHub for the current HEAD commit of a tap's repo. Returns
-/// the 40-char lowercase hex SHA or an error on network / malformed
-/// response. Caller owns the returned slice.
+/// the 40-char lowercase hex SHA or a classified `TapError` so callers
+/// can surface the actual cause (rate limit, 404, network, JSON). Caller
+/// owns the returned slice.
 pub fn resolveHeadCommit(
     allocator: std.mem.Allocator,
     user: []const u8,
@@ -174,10 +223,17 @@ pub fn resolveHeadCommit(
     var http = client_mod.HttpClient.init(allocator);
     defer http.deinit();
 
-    var resp = http.get(url) catch return TapError.ResolveFailed;
+    // MALT_GITHUB_TOKEN takes precedence; otherwise `http.get` falls
+    // back to the HOMEBREW_GITHUB_API_TOKEN auto-inject in net/client.
+    var auth_buf: [256]u8 = undefined;
+    var resp = if (githubAuthHeader(&auth_buf)) |header| blk: {
+        const headers = [_]std.http.Header{header};
+        break :blk http.getWithHeaders(url, &headers, null) catch return TapError.NetworkError;
+    } else http.get(url) catch return TapError.NetworkError;
     defer resp.deinit();
-    if (resp.status != 200) return TapError.ResolveFailed;
 
-    const sha = parseCommitShaFromJson(resp.body) orelse return TapError.ResolveFailed;
+    if (resp.status != 200) return classifyResolveStatus(resp.status);
+
+    const sha = parseCommitShaFromJson(resp.body) orelse return TapError.MalformedJson;
     return allocator.dupe(u8, sha) catch TapError.OutOfMemory;
 }

--- a/tests/install_local_test.zig
+++ b/tests/install_local_test.zig
@@ -176,6 +176,57 @@ test "constantTimeEql handles empty slices" {
     try testing.expect(install.constantTimeEql(u8, "", ""));
 }
 
+// ─── parseCaskBinary ─────────────────────────────────────────────────
+
+test "parseCaskBinary: extracts the basic binary directive" {
+    const rb =
+        \\cask "longbridge-terminal" do
+        \\  version "0.17.4"
+        \\  binary "longbridge"
+        \\end
+    ;
+    try testing.expectEqualStrings("longbridge", install.parseCaskBinary(rb).?);
+}
+
+test "parseCaskBinary: tolerates extra arguments on the directive" {
+    // Homebrew cask DSL permits `binary "src", target: "alias"`. The
+    // first quoted value is the archive-side basename — that's what we
+    // care about for bin/ promotion.
+    const rb =
+        \\cask "foo" do
+        \\  binary "longbridge", target: "lb"
+        \\end
+    ;
+    try testing.expectEqualStrings("longbridge", install.parseCaskBinary(rb).?);
+}
+
+test "parseCaskBinary: returns null on formulas with no binary directive" {
+    const rb =
+        \\class Wget < Formula
+        \\  version "1.0"
+        \\  url "https://x"
+        \\  sha256 "deadbeef"
+        \\end
+    ;
+    try testing.expect(install.parseCaskBinary(rb) == null);
+}
+
+test "parseCaskBinary: ignores mid-line 'binary' substrings" {
+    // Must anchor at the trimmed line start so a stray mention in a
+    // comment or a variable name does not resolve to a bogus binary.
+    const rb =
+        \\cask "foo" do
+        \\  desc "binary \"fake\" is just a comment"
+        \\end
+    ;
+    try testing.expect(install.parseCaskBinary(rb) == null);
+}
+
+test "parseCaskBinary: indented directive still matches" {
+    const rb = "  binary \"sley\"\n";
+    try testing.expectEqualStrings("sley", install.parseCaskBinary(rb).?);
+}
+
 // ─── interpolateVersion ──────────────────────────────────────────────
 
 test "interpolateVersion substitutes #{version} once in the URL" {

--- a/tests/tap_test.zig
+++ b/tests/tap_test.zig
@@ -336,3 +336,99 @@ test "parseCommitShaFromJson: uppercase hex in value is rejected" {
     ;
     try testing.expectEqual(@as(?[]const u8, null), tap.parseCommitShaFromJson(body));
 }
+
+// ────────────────────────────────────────────────────────────────────
+// classifyResolveStatus — callers rely on distinct tags to map each
+// GitHub failure mode to a user-facing message. A blanket
+// `ResolveFailed` would re-introduce the opaque "floating HEAD" error.
+// ────────────────────────────────────────────────────────────────────
+
+test "classifyResolveStatus: 403 is the rate-limit signal" {
+    // Unauthenticated `/commits/HEAD` caps at 60/hr per IP. Past the
+    // cap, the API answers 403 with a rate-limit body.
+    try testing.expectEqual(tap.TapError.RateLimited, tap.classifyResolveStatus(403));
+}
+
+test "classifyResolveStatus: 404 maps to NotFound" {
+    try testing.expectEqual(tap.TapError.NotFound, tap.classifyResolveStatus(404));
+}
+
+test "classifyResolveStatus: unexpected 5xx falls back to ResolveFailed" {
+    try testing.expectEqual(tap.TapError.ResolveFailed, tap.classifyResolveStatus(500));
+    try testing.expectEqual(tap.TapError.ResolveFailed, tap.classifyResolveStatus(502));
+}
+
+test "classifyResolveStatus: 401 (bad auth) is distinct from rate limit" {
+    try testing.expectEqual(tap.TapError.ResolveFailed, tap.classifyResolveStatus(401));
+}
+
+// ────────────────────────────────────────────────────────────────────
+// githubAuthHeader — only the `/commits/HEAD` call picks up
+// MALT_GITHUB_TOKEN; everything else keeps the existing HOMEBREW token
+// plumbing. Bearer header format must match GitHub's contract.
+// ────────────────────────────────────────────────────────────────────
+
+const c_env = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+test "githubAuthHeader: returns null when MALT_GITHUB_TOKEN unset" {
+    _ = c_env.unsetenv("MALT_GITHUB_TOKEN");
+    var buf: [256]u8 = undefined;
+    try testing.expect(tap.githubAuthHeader(&buf) == null);
+}
+
+test "githubAuthHeader: returns Bearer header when MALT_GITHUB_TOKEN set" {
+    _ = c_env.setenv("MALT_GITHUB_TOKEN", "ghp_testtoken", 1);
+    defer _ = c_env.unsetenv("MALT_GITHUB_TOKEN");
+
+    var buf: [256]u8 = undefined;
+    const h = tap.githubAuthHeader(&buf) orelse return error.TestUnexpectedNull;
+    try testing.expectEqualStrings("Authorization", h.name);
+    try testing.expectEqualStrings("Bearer ghp_testtoken", h.value);
+}
+
+test "githubAuthHeader: empty-string token behaves as unset" {
+    _ = c_env.setenv("MALT_GITHUB_TOKEN", "", 1);
+    defer _ = c_env.unsetenv("MALT_GITHUB_TOKEN");
+    var buf: [256]u8 = undefined;
+    try testing.expect(tap.githubAuthHeader(&buf) == null);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// describeResolveError — load-bearing user-facing change: each tap
+// failure mode gets a distinct remediation hint instead of the old
+// blanket "floating HEAD" message.
+// ────────────────────────────────────────────────────────────────────
+
+test "describeResolveError: RateLimited names MALT_GITHUB_TOKEN" {
+    const msg = tap.describeResolveError(tap.TapError.RateLimited);
+    try testing.expect(std.mem.indexOf(u8, msg, "MALT_GITHUB_TOKEN") != null);
+    try testing.expect(std.mem.indexOf(u8, msg, "rate limit") != null);
+}
+
+test "describeResolveError: NotFound explains the homebrew- prefix rule" {
+    const msg = tap.describeResolveError(tap.TapError.NotFound);
+    try testing.expect(std.mem.indexOf(u8, msg, "homebrew-") != null);
+}
+
+test "describeResolveError: NetworkError mentions connectivity" {
+    const msg = tap.describeResolveError(tap.TapError.NetworkError);
+    try testing.expect(std.mem.indexOf(u8, msg, "etwork") != null or
+        std.mem.indexOf(u8, msg, "onnect") != null);
+}
+
+test "describeResolveError: MalformedJson is distinct from ResolveFailed" {
+    const malformed = tap.describeResolveError(tap.TapError.MalformedJson);
+    const generic = tap.describeResolveError(tap.TapError.ResolveFailed);
+    try testing.expect(!std.mem.eql(u8, malformed, generic));
+}
+
+test "describeResolveError: every TapError variant gets a non-empty hint" {
+    inline for (@typeInfo(tap.TapError).error_set.?) |e| {
+        const err = @field(tap.TapError, e.name);
+        const msg = tap.describeResolveError(err);
+        try testing.expect(msg.len > 0);
+    }
+}


### PR DESCRIPTION
## Description

Installing a third-party tap cask or formula used to fail with one opaque line - "refusing to install from a floating HEAD" - hiding the real cause (most often an exhausted anonymous GitHub API quota). Once past that, casks whose archive binary did not match the cask token (the [gh#180](https://github.com/indaco/malt/issues/180) report: `longbridge-terminal` ships a `longbridge` executable) installed silently but left the user without a working command.

After this change:

- Each failure mode gets its own user-facing message (rate limit, 404, network, malformed JSON) with the remediation named inline.
- Setting `MALT_GITHUB_TOKEN` lifts the 60/hr anonymous cap on tap HEAD resolution. The token is scoped to this one call, never logged, never reflected in error messages.
- Cask `binary "<name>"` directives are honored, so `mt install longbridge/tap/longbridge-terminal` lands a working `longbridge` in `$PREFIX/bin/`.

## Related Issue

- Fixes #180.

## Notes for Reviewers

- None