### PR TITLE
ci: fix authenticate release install smoke API calls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,4 +125,10 @@ jobs:
         uses: sigstore/cosign-installer@v4.1.1
 
       - name: Run release-install smoke
+        env:
+          # Authenticated API calls raise the ceiling from 60/hr per
+          # runner IP (shared across the macos-14 pool) to 5000/hr,
+          # which both the propagation wait and install.sh probe rely
+          # on. Contents-read is the only scope consulted.
+          MALT_SMOKE_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/e2e/smoke_install_release.sh

--- a/scripts/e2e/smoke_install_release.sh
+++ b/scripts/e2e/smoke_install_release.sh
@@ -92,13 +92,19 @@ if [ "${MALT_SMOKE_SKIP_PROPAGATION_WAIT:-0}" != "1" ]; then
 fi
 
 step "Running install.sh from README against the live release"
+# env -i wipes GITHUB_TOKEN — forward it as MALT_INSTALLER_API_TOKEN so
+# install.sh's /releases/latest probe is authenticated (5000/hr vs the
+# 60/hr unauthenticated ceiling that shared runner IPs routinely hit).
+INSTALLER_TOKEN="${MALT_SMOKE_API_TOKEN:-${GITHUB_TOKEN:-}}"
 if [ "${MALT_SKIP_COSIGN:-0}" = "1" ]; then
   env -i HOME="$HOME" USER="$USER" PATH="$SAFE_PATH" \
     MALT_ALLOW_UNVERIFIED=1 PREFIX="$PREFIX" INSTALL_DIR="$INSTALL_DIR" \
+    MALT_INSTALLER_API_TOKEN="$INSTALLER_TOKEN" \
     bash -c "curl -fsSL \"$INSTALLER_URL\" | bash"
 else
   env -i HOME="$HOME" USER="$USER" PATH="$SAFE_PATH" \
     PREFIX="$PREFIX" INSTALL_DIR="$INSTALL_DIR" \
+    MALT_INSTALLER_API_TOKEN="$INSTALLER_TOKEN" \
     bash -c "curl -fsSL \"$INSTALLER_URL\" | bash"
 fi
 [ -x "$INSTALL_DIR/malt" ] || fail "malt binary missing at $INSTALL_DIR/malt"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -101,11 +101,19 @@ else
   # --retry (no --retry-all-errors) needs 7.71+, so we do it in bash
   # for portability across macOS and older Linux.
   API_RESPONSE=""
+  # Optional auth header — empty in normal user installs. The release
+  # smoke sets this so polls survive the unauthenticated 60/hr-per-IP
+  # ceiling on shared CI runners.
+  api_auth_args=()
+  if [ -n "${MALT_INSTALLER_API_TOKEN:-}" ]; then
+    api_auth_args=(-H "Authorization: Bearer ${MALT_INSTALLER_API_TOKEN}")
+  fi
   backoffs="3 6 12 24"
   attempt=0
   for delay in $backoffs end; do
     attempt=$((attempt + 1))
     if API_RESPONSE=$(curl -fsSL --connect-timeout 10 --max-time 30 \
+      ${api_auth_args[@]+"${api_auth_args[@]}"} \
       "$API_LATEST_URL" 2>/dev/null); then
       break
     fi

--- a/scripts/lib/release_wait.sh
+++ b/scripts/lib/release_wait.sh
@@ -21,15 +21,29 @@
 # "fail" — the name the smoke script already defines).
 
 # Configurable via env so tests can compress the wait to milliseconds.
-WAIT_BUDGET_SECONDS="${WAIT_BUDGET_SECONDS:-300}" # 5 minutes default
-WAIT_POLL_INTERVAL="${WAIT_POLL_INTERVAL:-5}"     # 5s between probes
+# Default is 10m: /releases/latest can lag the goreleaser publish by
+# several minutes on a cold release (observed > 5m in v0.9.2).
+WAIT_BUDGET_SECONDS="${WAIT_BUDGET_SECONDS:-600}"
+WAIT_POLL_INTERVAL="${WAIT_POLL_INTERVAL:-5}" # 5s between probes
 MALT_SMOKE_API_BASE="${MALT_SMOKE_API_BASE:-https://api.github.com/repos/indaco/malt}"
+
+# Optional token. Unauthenticated GitHub API is 60 req/hr per IP, and
+# macos-14 runners share IPs — a busy window plus aggressive polling
+# drops us to 403s that look identical to "tag not ready yet". The
+# smoke workflow passes the job's GITHUB_TOKEN here to lift the ceiling
+# to 5000/hr and keep polls honest.
+MALT_SMOKE_API_TOKEN="${MALT_SMOKE_API_TOKEN:-}"
 
 # Returns 0 when GitHub's tag-specific release endpoint responds 200.
 release_tag_exists() {
   local tag="$1"
-  local code
+  local code auth_args=()
+  if [ -n "$MALT_SMOKE_API_TOKEN" ]; then
+    auth_args=(-H "Authorization: Bearer ${MALT_SMOKE_API_TOKEN}")
+  fi
+  # set -u-safe array splat (bash 3.2 rejects "${arr[@]}" when empty).
   code=$(curl -fsSL -o /dev/null -w '%{http_code}' --max-time 10 \
+    ${auth_args[@]+"${auth_args[@]}"} \
     "${MALT_SMOKE_API_BASE}/releases/tags/${tag}" 2>/dev/null || true)
   [ "$code" = "200" ]
 }
@@ -38,8 +52,12 @@ release_tag_exists() {
 # Strict match (no partial) so v0.7.0 cannot accept v0.7.00.
 release_latest_matches() {
   local tag="$1"
-  local body
+  local body auth_args=()
+  if [ -n "$MALT_SMOKE_API_TOKEN" ]; then
+    auth_args=(-H "Authorization: Bearer ${MALT_SMOKE_API_TOKEN}")
+  fi
   body=$(curl -fsSL --max-time 10 \
+    ${auth_args[@]+"${auth_args[@]}"} \
     "${MALT_SMOKE_API_BASE}/releases/latest" 2>/dev/null || true)
   # Require the exact closing quote so prefix-only tags don't match.
   printf '%s' "$body" | grep -q "\"tag_name\": *\"${tag}\""


### PR DESCRIPTION
## Description

The install-smoke job on live releases was failing in two distinct ways - one timing out the 5m propagation wait, the other falling through to a source build - both rooted in unauthenticated GitHub API polling hitting the 60/hr/IP ceiling shared across macos-14 runners.

Forwards the job's implicit GITHUB_TOKEN through an opt-in Authorization header to both the wait helper and install.sh's /releases/latest probe, lifting the rate ceiling to 5000/hr. Public installer behavior is unchanged: the header is only added when MALT_INSTALLER_API_TOKEN is explicitly set.

Also widens the CDN-propagation wait from 5m to 10m, since /releases/latest can lag the goreleaser publish by more than 5 minutes on a cold release.

## Related Issue

- None 

## Notes for Reviewers

- None 