### PR TITLE
feat(cli): mt pin / mt unpin and upgrade honors pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,15 +231,28 @@ mt upgrade <package>                     # upgrade a specific formula or cask
 mt upgrade --cask                        # upgrade all outdated casks
 mt upgrade --formula                     # upgrade all outdated formulas
 mt upgrade --dry-run                     # show what would be upgraded
+mt upgrade --force <package>             # bypass pin protection
 ```
 
-| Flag        | Description               |
-| ----------- | ------------------------- |
-| `--cask`    | Upgrade casks only        |
-| `--formula` | Upgrade formulas only     |
-| `--dry-run` | Preview without upgrading |
+| Flag            | Description                       |
+| --------------- | --------------------------------- |
+| `--cask`        | Upgrade casks only                |
+| `--formula`     | Upgrade formulas only             |
+| `--dry-run`     | Preview without upgrading         |
+| `--force`, `-f` | Bypass pin protection (dangerous) |
 
-Formula upgrades install the new version, verify it, switch symlinks atomically, and only remove the old version after success. On failure, the old version is restored automatically.
+Pinned kegs (`mt pin <name>`) are skipped with a dim "pinned, skipped" line; pass `--force` to override the pin for a single run. Formula upgrades install the new version, verify it, switch symlinks atomically, and only remove the old version after success. On failure, the old version is restored automatically.
+
+### `mt pin` / `mt unpin`
+
+Protect an installed keg from `mt upgrade` (or lift the protection).
+
+```bash
+mt pin <name>                            # mark as pinned
+mt unpin <name>                          # lift the pin
+```
+
+A pinned keg is held at its current version: `mt upgrade <name>` skips it with a dim "pinned, skipped" line, and bulk `mt upgrade` does the same per-keg. Use `mt list --pinned` to inspect; pass `mt upgrade --force` to override once without removing the pin.
 
 ### `mt update`
 

--- a/build.zig
+++ b/build.zig
@@ -177,6 +177,7 @@ pub fn build(b: *std.Build) void {
         "tests/upgrade_test.zig",
         "tests/hash_test.zig",
         "tests/patcher_test.zig",
+        "tests/pin_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -128,7 +128,7 @@ fi
 # Per-command --help on everything documented.
 for cmd in install uninstall upgrade update outdated list info search uses \
   doctor purge tap untap migrate backup restore services bundle \
-  rollback run link unlink version completions; do
+  rollback run link unlink pin unpin version completions; do
   run_ok "t1.help.$cmd" -- "$MT_BIN" "$cmd" --help
 done
 
@@ -193,6 +193,13 @@ else
   run_ok t3.unlink -- "$MT_BIN" unlink tree
   run_ok t3.link -- "$MT_BIN" link tree
   run_ok t3.link.overwrite -- "$MT_BIN" link tree --overwrite
+
+  # pin / unpin / upgrade-skip round-trip: pin tree, verify upgrade is a no-op,
+  # then unpin so the rest of the smoke run is unaffected.
+  run_ok t3.pin -- "$MT_BIN" pin tree
+  run_grep t3.list.pinned-tree "tree" -- "$MT_BIN" list --pinned
+  run_ok t3.upgrade.pinned -- "$MT_BIN" upgrade tree
+  run_ok t3.unpin -- "$MT_BIN" unpin tree
 
   # backup / restore round-trip.
   run_ok t3.backup -- "$MT_BIN" backup --output "$LOGDIR/backup.txt"

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -87,7 +87,7 @@ pub const bash_script =
     \\    words=("${COMP_WORDS[@]}")
     \\    cword=$COMP_CWORD
     \\
-    \\    local commands="install uninstall remove upgrade update outdated list ls info search uses doctor tap untap migrate rollback link unlink run version completions backup restore purge services bundle help"
+    \\    local commands="install uninstall remove upgrade update outdated list ls info search uses doctor tap untap migrate rollback link unlink pin unpin run version completions backup restore purge services bundle help"
     \\    local global_flags="--verbose -v --quiet -q --json --dry-run --help -h --version"
     \\
     \\    # Find the first non-flag word after the program — that's the subcommand.
@@ -142,7 +142,7 @@ pub const bash_script =
     \\        restore)          cmd_flags="--dry-run --force --quiet -q" ;;
     \\        purge)            cmd_flags="--store-orphans --unused-deps --cache --cache= --downloads --stale-casks --old-versions --housekeeping --wipe --backup -b --keep-cache --remove-binary --yes -y --dry-run -n" ;;
     \\        uninstall|remove) cmd_flags="--force --zap --dry-run" ;;
-    \\        upgrade)          cmd_flags="--all --cask --formula --dry-run" ;;
+    \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --force -f" ;;
     \\        outdated)         cmd_flags="--json --formula --cask --quiet -q" ;;
     \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --json --quiet -q" ;;
     \\        info)             cmd_flags="--formula --cask --json" ;;
@@ -205,6 +205,8 @@ pub const zsh_script =
     \\        'rollback:Revert a package to its previous version'
     \\        'link:Create symlinks for an installed keg'
     \\        'unlink:Remove symlinks (keg stays installed)'
+    \\        'pin:Protect an installed keg from upgrade'
+    \\        'unpin:Lift the pin on an installed keg'
     \\        'run:Run a package binary without installing'
     \\        'version:Show version or self-update'
     \\        'completions:Generate shell completion scripts'
@@ -256,7 +258,11 @@ pub const zsh_script =
     \\                        '--cask[Upgrade casks only]' \
     \\                        '--formula[Upgrade formulas only]' \
     \\                        '--dry-run[Show what would be upgraded]' \
+    \\                        '(--force -f)'{--force,-f}'[Bypass pin protection]' \
     \\                        '*::package:'
+    \\                    ;;
+    \\                pin|unpin)
+    \\                    _arguments '*::keg:'
     \\                    ;;
     \\                outdated)
     \\                    _arguments \
@@ -433,6 +439,8 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n __malt_needs_command -a rollback    -d 'Revert package to previous version'
     \\    complete -c $__malt_bin -n __malt_needs_command -a link        -d 'Create symlinks for a keg'
     \\    complete -c $__malt_bin -n __malt_needs_command -a unlink      -d 'Remove symlinks (keg stays)'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a pin         -d 'Protect an installed keg from upgrade'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a unpin       -d 'Lift the pin on an installed keg'
     \\    complete -c $__malt_bin -n __malt_needs_command -a run         -d 'Run package binary without installing'
     \\    complete -c $__malt_bin -n __malt_needs_command -a version     -d 'Show version or self-update'
     \\    complete -c $__malt_bin -n __malt_needs_command -a completions -d 'Generate shell completion scripts'
@@ -464,6 +472,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l cask    -d 'Casks only'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l formula -d 'Formulas only'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l dry-run -d 'Preview'
+    \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -s f -l force -d 'Bypass pin protection'
     \\
     \\    # outdated
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l json    -d 'JSON output'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -40,6 +40,8 @@ pub fn helpFor(command: []const u8) []const u8 {
         .{ "restore", restore_help },
         .{ "purge", purge_help },
         .{ "uses", uses_help },
+        .{ "pin", pin_help },
+        .{ "unpin", unpin_help },
     });
     return map.get(command) orelse "No help available.\n";
 }
@@ -86,13 +88,15 @@ const uninstall_help =
 const upgrade_help =
     \\Usage: malt upgrade [<package>] [flags]
     \\
-    \\Upgrade installed packages to latest versions.
+    \\Upgrade installed packages to latest versions. Pinned kegs are
+    \\skipped with a "pinned, skipped" line; pass --force to override.
     \\
     \\Flags:
     \\  --all          Upgrade everything (formulas + casks)
     \\  --cask         Upgrade casks only
     \\  --formula      Upgrade formulas only
     \\  --dry-run      Show what would be upgraded
+    \\  --force, -f    Bypass pin protection (dangerous; user-initiated)
     \\
 ;
 
@@ -331,6 +335,24 @@ const restore_help =
     \\
     \\Example:
     \\  malt restore malt-backup-2026-04-10T14-32-05.txt
+    \\
+;
+
+const pin_help =
+    \\Usage: malt pin <name>
+    \\
+    \\Mark an installed keg as pinned so `malt upgrade` skips it. The pin
+    \\survives across upgrades and is visible in `mt list --pinned`.
+    \\Use `mt unpin <name>` to lift the pin, or `mt upgrade --force <name>`
+    \\to override it once.
+    \\
+;
+
+const unpin_help =
+    \\Usage: malt unpin <name>
+    \\
+    \\Lift the pin on an installed keg so subsequent `malt upgrade` runs
+    \\touch it again.
     \\
 ;
 

--- a/src/cli/pin.zig
+++ b/src/cli/pin.zig
@@ -1,0 +1,102 @@
+//! malt — pin / unpin commands
+//! Toggle the `pinned` column on an installed keg. `mt upgrade` reads
+//! the column to skip protected versions; the schema and `list --pinned`
+//! already surface it.
+
+const std = @import("std");
+const sqlite = @import("../db/sqlite.zig");
+const schema = @import("../db/schema.zig");
+const atomic = @import("../fs/atomic.zig");
+const output = @import("../ui/output.zig");
+const help = @import("help.zig");
+
+pub fn execute(_: std.mem.Allocator, args: []const []const u8) !void {
+    return run(args, .pin);
+}
+
+pub fn executeUnpin(_: std.mem.Allocator, args: []const []const u8) !void {
+    return run(args, .unpin);
+}
+
+const Action = enum {
+    pin,
+    unpin,
+
+    fn flag(self: Action) bool {
+        return self == .pin;
+    }
+
+    fn cmdName(self: Action) []const u8 {
+        return @tagName(self);
+    }
+
+    fn doneVerb(self: Action) []const u8 {
+        return switch (self) {
+            .pin => "pinned",
+            .unpin => "unpinned",
+        };
+    }
+};
+
+fn run(args: []const []const u8, action: Action) !void {
+    if (help.showIfRequested(args, action.cmdName())) return;
+
+    if (args.len == 0) {
+        output.err("Usage: mt {s} <name>", .{action.cmdName()});
+        return error.Aborted;
+    }
+    const name = args[0];
+
+    const prefix = atomic.maltPrefix();
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
+    var db = sqlite.Database.open(db_path) catch {
+        output.err("Failed to open database", .{});
+        return error.Aborted;
+    };
+    defer db.close();
+    schema.initSchema(&db) catch {};
+
+    const updated = setPinned(&db, name, action.flag()) catch {
+        output.err("Database update failed for {s}", .{name});
+        return error.Aborted;
+    };
+    if (!updated) {
+        output.err("{s} is not installed", .{name});
+        return error.Aborted;
+    }
+
+    output.success("{s} {s}", .{ name, action.doneVerb() });
+}
+
+/// Set the `pinned` column on `name`. Returns true when a row was matched
+/// (idempotent re-pins still report true). False means no installed keg
+/// of that name exists, which the caller should surface as a usage error.
+pub fn setPinned(db: *sqlite.Database, name: []const u8, value: bool) sqlite.SqliteError!bool {
+    var stmt = try db.prepare("UPDATE kegs SET pinned = ?1 WHERE name = ?2;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, @intFromBool(value));
+    try stmt.bindText(2, name);
+    _ = try stmt.step();
+    return changes(db) > 0;
+}
+
+/// Returns true iff an installed keg named `name` has `pinned=1`.
+/// Missing rows are reported as not pinned — callers treat the absence
+/// of a row as "nothing to skip".
+pub fn isPinned(db: *sqlite.Database, name: []const u8) bool {
+    var stmt = db.prepare("SELECT pinned FROM kegs WHERE name = ?1 LIMIT 1;") catch return false;
+    defer stmt.finalize();
+    stmt.bindText(1, name) catch return false;
+    const has = stmt.step() catch return false;
+    if (!has) return false;
+    return stmt.columnBool(0);
+}
+
+fn changes(db: *sqlite.Database) i64 {
+    var stmt = db.prepare("SELECT changes();") catch return 0;
+    defer stmt.finalize();
+    const has = stmt.step() catch return 0;
+    if (!has) return 0;
+    return stmt.columnInt(0);
+}

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -18,8 +18,9 @@ const cellar_mod = @import("../core/cellar.zig");
 const linker_mod = @import("../core/linker.zig");
 const ghcr_mod = @import("../net/ghcr.zig");
 const help = @import("help.zig");
+const pin_mod = @import("pin.zig");
 
-const UpgradeFlag = enum { quiet, cask, formula, dry_run };
+const UpgradeFlag = enum { quiet, cask, formula, dry_run, force };
 
 const upgrade_flag_map = std.StaticStringMap(UpgradeFlag).initComptime(.{
     .{ "-q", .quiet },
@@ -27,7 +28,16 @@ const upgrade_flag_map = std.StaticStringMap(UpgradeFlag).initComptime(.{
     .{ "--cask", .cask },
     .{ "--formula", .formula },
     .{ "--dry-run", .dry_run },
+    .{ "--force", .force },
+    .{ "-f", .force },
 });
+
+/// True when this name should be skipped due to a user pin. Pure gate so
+/// the `--force` semantics are testable without dragging in the API.
+pub fn pinSkip(db: *sqlite.Database, name: []const u8, force: bool) bool {
+    if (force) return false;
+    return pin_mod.isPinned(db, name);
+}
 
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "upgrade")) return;
@@ -35,6 +45,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var cask_only = false;
     var formula_only = false;
     var dry_run = output.isDryRun();
+    var force = false;
     var pkg_name: ?[]const u8 = null;
 
     // StaticStringMap + exhaustive switch: every flag routes to a handler.
@@ -44,6 +55,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             .cask => cask_only = true,
             .formula => formula_only = true,
             .dry_run => dry_run = true,
+            .force => force = true,
         } else if (arg.len > 0 and arg[0] != '-') {
             if (pkg_name == null) pkg_name = arg;
         }
@@ -90,7 +102,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         // Upgrade a specific package — try formula first, then cask
         if (!cask_only) {
             if (isFormulaInstalled(&db, name)) {
-                upgradeFormula(allocator, name, &db, &api, &http, prefix, dry_run) catch {
+                upgradeFormula(allocator, name, &db, &api, &http, prefix, dry_run, force) catch {
                     any_failed = true;
                 };
                 if (any_failed) return error.Aborted;
@@ -98,18 +110,18 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             }
         }
         // Not a formula (or --cask): try cask
-        upgradeCask(allocator, name, &db, &api, prefix, dry_run) catch {
+        upgradeCask(allocator, name, &db, &api, prefix, dry_run, force) catch {
             any_failed = true;
         };
     } else {
         // Upgrade all
         if (!cask_only) {
-            upgradeAllFormulas(allocator, &db, &api, &http, prefix, dry_run) catch {
+            upgradeAllFormulas(allocator, &db, &api, &http, prefix, dry_run, force) catch {
                 any_failed = true;
             };
         }
         if (!formula_only) {
-            upgradeAllCasks(allocator, &db, &api, prefix, dry_run) catch {
+            upgradeAllCasks(allocator, &db, &api, prefix, dry_run, force) catch {
                 any_failed = true;
             };
         }
@@ -139,7 +151,15 @@ fn upgradeFormula(
     http: *client_mod.HttpClient,
     prefix: [:0]const u8,
     dry_run: bool,
+    force: bool,
 ) !void {
+    // Honor pins before any network or filesystem work — the whole
+    // point is that a pinned keg never gets touched.
+    if (pinSkip(db, name, force)) {
+        output.dim("{s} is pinned, skipped", .{name});
+        return;
+    }
+
     // Step 1: Look up installed version from DB
     var find_stmt = db.prepare(
         "SELECT id, version, revision, store_sha256, cellar_path FROM kegs WHERE name = ?1 LIMIT 1;",
@@ -410,6 +430,7 @@ fn upgradeAllFormulas(
     http: *client_mod.HttpClient,
     prefix: [:0]const u8,
     dry_run: bool,
+    force: bool,
 ) !void {
     var stmt = db.prepare("SELECT name, version FROM kegs ORDER BY name;") catch return;
     defer stmt.finalize();
@@ -443,7 +464,7 @@ fn upgradeAllFormulas(
     defer failed_names.deinit(allocator);
 
     for (names.items) |name| {
-        upgradeFormula(allocator, name, db, api, http, prefix, dry_run) catch {
+        upgradeFormula(allocator, name, db, api, http, prefix, dry_run, force) catch {
             failed_count += 1;
             // failed_count is the authoritative counter; list is for UX only.
             failed_names.append(allocator, name) catch {};
@@ -462,7 +483,12 @@ fn upgradeAllFormulas(
 // Cask upgrade
 // ---------------------------------------------------------------------------
 
-fn upgradeCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Database, api: *api_mod.BrewApi, prefix: [:0]const u8, dry_run: bool) !void {
+fn upgradeCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Database, api: *api_mod.BrewApi, prefix: [:0]const u8, dry_run: bool, force: bool) !void {
+    if (pinSkip(db, token, force)) {
+        output.dim("{s} is pinned, skipped", .{token});
+        return;
+    }
+
     const installed = cask_mod.lookupInstalled(db, token) orelse {
         output.err("{s} is not installed as a cask", .{token});
         return error.Aborted;
@@ -515,7 +541,7 @@ fn upgradeCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Data
     output.success("{s} upgraded to {s}", .{ token, parsed_cask.version });
 }
 
-fn upgradeAllCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api_mod.BrewApi, prefix: [:0]const u8, dry_run: bool) !void {
+fn upgradeAllCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api_mod.BrewApi, prefix: [:0]const u8, dry_run: bool, force: bool) !void {
     var stmt = db.prepare("SELECT token, version FROM casks ORDER BY token;") catch return;
     defer stmt.finalize();
 
@@ -547,7 +573,7 @@ fn upgradeAllCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api
     defer failed_tokens.deinit(allocator);
 
     for (tokens.items) |token| {
-        upgradeCask(allocator, token, db, api, prefix, dry_run) catch {
+        upgradeCask(allocator, token, db, api, prefix, dry_run, force) catch {
             failed_count += 1;
             // failed_count is authoritative; list is for UX only.
             failed_tokens.append(allocator, token) catch {};

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -53,6 +53,7 @@ pub const update_release = @import("update/release.zig");
 pub const update_verify = @import("update/verify.zig");
 pub const update_swap = @import("update/swap.zig");
 pub const cli_list = @import("cli/list.zig");
+pub const cli_pin = @import("cli/pin.zig");
 pub const cli_tap = @import("cli/tap.zig");
 pub const cli_rollback = @import("cli/rollback.zig");
 pub const tap = @import("core/tap.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,6 +42,7 @@ const tap = @import("cli/tap.zig");
 const migrate = @import("cli/migrate.zig");
 const rollback = @import("cli/rollback.zig");
 const link_cmd = @import("cli/link.zig");
+const pin_cmd = @import("cli/pin.zig");
 const run_cmd = @import("cli/run.zig");
 const version_update = @import("cli/version_update.zig");
 const completions = @import("cli/completions.zig");
@@ -71,6 +72,8 @@ const Command = enum {
     rollback,
     link,
     unlink,
+    pin,
+    unpin,
     run,
     version_cmd,
     completions,
@@ -105,6 +108,8 @@ const command_names = [_]struct {
     .{ .tag = .rollback, .names = &.{"rollback"} },
     .{ .tag = .link, .names = &.{"link"} },
     .{ .tag = .unlink, .names = &.{"unlink"} },
+    .{ .tag = .pin, .names = &.{"pin"} },
+    .{ .tag = .unpin, .names = &.{"unpin"} },
     .{ .tag = .run, .names = &.{"run"} },
     .{ .tag = .version_cmd, .names = &.{"version"} },
     .{ .tag = .completions, .names = &.{"completions"} },
@@ -256,6 +261,8 @@ fn dispatch(allocator: std.mem.Allocator, cmd: Command, cmd_args: []const []cons
         .rollback => try rollback.execute(allocator, cmd_args),
         .link => try link_cmd.executeLink(allocator, cmd_args),
         .unlink => try link_cmd.executeUnlink(allocator, cmd_args),
+        .pin => try pin_cmd.execute(allocator, cmd_args),
+        .unpin => try pin_cmd.executeUnpin(allocator, cmd_args),
         .run => try run_cmd.execute(allocator, cmd_args),
         .completions => try completions.execute(allocator, cmd_args),
         .backup => try backup.execute(allocator, cmd_args),
@@ -300,6 +307,8 @@ fn printUsage() void {
         \\  rollback      Revert a package to its previous version
         \\  link          Create symlinks for an installed keg
         \\  unlink        Remove symlinks (keg stays installed)
+        \\  pin           Protect an installed keg from `upgrade`
+        \\  unpin         Lift the pin so `upgrade` resumes touching it
         \\  run           Run a package binary without installing
         \\  completions   Generate shell completion scripts (bash, zsh, fish)
         \\  backup        Dump installed packages to a restorable text file

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -35,13 +35,13 @@ test "scriptFor routes each shell to a non-empty script" {
 }
 
 const all_commands = [_][]const u8{
-    "install", "uninstall", "remove",   "upgrade",
-    "update",  "outdated",  "list",     "ls",
-    "info",    "search",    "doctor",   "tap",
-    "untap",   "migrate",   "rollback", "link",
-    "unlink",  "run",       "version",  "completions",
-    "backup",  "restore",   "purge",    "services",
-    "bundle",
+    "install", "uninstall",   "remove",   "upgrade",
+    "update",  "outdated",    "list",     "ls",
+    "info",    "search",      "doctor",   "tap",
+    "untap",   "migrate",     "rollback", "link",
+    "unlink",  "pin",         "unpin",    "run",
+    "version", "completions", "backup",   "restore",
+    "purge",   "services",    "bundle",
 };
 
 fn expectContains(haystack: []const u8, needle: []const u8) !void {

--- a/tests/help_test.zig
+++ b/tests/help_test.zig
@@ -25,11 +25,12 @@ test "showIfRequested returns true for long --help" {
 
 test "showIfRequested covers every documented command (exercises every branch of the static map)" {
     const commands = [_][]const u8{
-        "install",  "uninstall", "upgrade", "update",
-        "outdated", "list",      "info",    "search",
-        "doctor",   "tap",       "migrate", "rollback",
-        "run",      "link",      "unlink",  "completions",
-        "backup",   "restore",   "purge",   "not-a-real-command",
+        "install",  "uninstall",          "upgrade", "update",
+        "outdated", "list",               "info",    "search",
+        "doctor",   "tap",                "migrate", "rollback",
+        "run",      "link",               "unlink",  "pin",
+        "unpin",    "completions",        "backup",  "restore",
+        "purge",    "not-a-real-command",
     };
     const args = [_][]const u8{"--help"};
     for (commands) |cmd| {

--- a/tests/pin_test.zig
+++ b/tests/pin_test.zig
@@ -1,0 +1,185 @@
+//! malt — `mt pin` / `mt unpin` behaviour tests
+//! Locks in the pin/unpin contract: setting the column on an installed
+//! keg, idempotent re-pin, error handling for missing-name and
+//! not-installed cases. Uses a scratch MALT_PREFIX so no real DB is hit.
+
+const std = @import("std");
+const malt = @import("malt");
+const testing = std.testing;
+const cli_pin = malt.cli_pin;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+fn setupPrefix(suffix: []const u8) ![:0]u8 {
+    const path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "/tmp/malt_pin_test_{d}_{s}",
+        .{ malt.fs_compat.nanoTimestamp(), suffix },
+        0,
+    );
+    malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    try malt.fs_compat.cwd().makePath(path);
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{path});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+    _ = c.setenv("MALT_PREFIX", path.ptr, 1);
+    return path;
+}
+
+fn openDb(prefix: [:0]const u8) !sqlite.Database {
+    var buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    errdefer db.close();
+    try schema.initSchema(&db);
+    return db;
+}
+
+fn insertKeg(db: *sqlite.Database, name: []const u8, pinned: bool) !void {
+    var buf: [512]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &buf,
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, pinned) VALUES ('{s}', '{s}', '1.0', 'deadbeef', '/cellar/{s}/1.0', {d});",
+        .{ name, name, name, @intFromBool(pinned) },
+    );
+    try db.exec(sql);
+}
+
+fn readPinned(db: *sqlite.Database, name: []const u8) !bool {
+    var stmt = try db.prepare("SELECT pinned FROM kegs WHERE name = ?1 LIMIT 1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    const has = try stmt.step();
+    if (!has) return error.NotFound;
+    return stmt.columnBool(0);
+}
+
+test "mt pin <name> sets pinned=1 on installed keg" {
+    const path = try setupPrefix("pin_set");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openDb(path);
+        defer db.close();
+        try insertKeg(&db, "alpha", false);
+    }
+
+    try cli_pin.execute(testing.allocator, &.{"alpha"});
+
+    var db = try openDb(path);
+    defer db.close();
+    try testing.expectEqual(true, try readPinned(&db, "alpha"));
+}
+
+test "mt unpin <name> clears pinned" {
+    const path = try setupPrefix("unpin_clear");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openDb(path);
+        defer db.close();
+        try insertKeg(&db, "bravo", true);
+    }
+
+    try cli_pin.executeUnpin(testing.allocator, &.{"bravo"});
+
+    var db = try openDb(path);
+    defer db.close();
+    try testing.expectEqual(false, try readPinned(&db, "bravo"));
+}
+
+test "mt pin with no args returns Aborted (usage)" {
+    const path = try setupPrefix("pin_noargs");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    try testing.expectError(error.Aborted, cli_pin.execute(testing.allocator, &.{}));
+}
+
+test "mt unpin with no args returns Aborted (usage)" {
+    const path = try setupPrefix("unpin_noargs");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    try testing.expectError(error.Aborted, cli_pin.executeUnpin(testing.allocator, &.{}));
+}
+
+test "mt pin <not-installed> returns Aborted" {
+    const path = try setupPrefix("pin_notinst");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openDb(path);
+        defer db.close();
+    }
+
+    try testing.expectError(
+        error.Aborted,
+        cli_pin.execute(testing.allocator, &.{"definitely-not-installed"}),
+    );
+}
+
+test "mt unpin <not-installed> returns Aborted" {
+    const path = try setupPrefix("unpin_notinst");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openDb(path);
+        defer db.close();
+    }
+
+    try testing.expectError(
+        error.Aborted,
+        cli_pin.executeUnpin(testing.allocator, &.{"definitely-not-installed"}),
+    );
+}
+
+test "isPinned reflects DB column" {
+    const path = try setupPrefix("ispinned");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openDb(path);
+    defer db.close();
+    try insertKeg(&db, "uno", false);
+    try insertKeg(&db, "due", true);
+
+    try testing.expect(!cli_pin.isPinned(&db, "uno"));
+    try testing.expect(cli_pin.isPinned(&db, "due"));
+    try testing.expect(!cli_pin.isPinned(&db, "missing"));
+}
+
+test "mt pin is idempotent — re-pinning is a no-op success" {
+    const path = try setupPrefix("pin_idempotent");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openDb(path);
+        defer db.close();
+        try insertKeg(&db, "tre", true);
+    }
+
+    try cli_pin.execute(testing.allocator, &.{"tre"});
+
+    var db = try openDb(path);
+    defer db.close();
+    try testing.expectEqual(true, try readPinned(&db, "tre"));
+}

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -8,6 +8,8 @@ const std = @import("std");
 const malt = @import("malt");
 const testing = std.testing;
 const upgrade = malt.upgrade;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
 
 const c = struct {
     extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
@@ -43,4 +45,82 @@ test "mt upgrade <nonexistent> surfaces a non-zero exit" {
         error.Aborted,
         upgrade.execute(testing.allocator, &.{"definitely-not-installed"}),
     );
+}
+
+fn openSeededDb(prefix: [:0]const u8) !sqlite.Database {
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{prefix});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+
+    var buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    errdefer db.close();
+    try schema.initSchema(&db);
+    return db;
+}
+
+fn insertPinnedKeg(db: *sqlite.Database, name: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &buf,
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, pinned) VALUES ('{s}', '{s}', '1.0', 'deadbeef', '/cellar/{s}/1.0', 1);",
+        .{ name, name, name },
+    );
+    try db.exec(sql);
+}
+
+test "mt upgrade <pinned> is a quiet no-op (no API call)" {
+    const path = try setupPrefix("pinned_skip_named");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        try insertPinnedKeg(&db, "alpha-pinned");
+    }
+
+    // Pinned name short-circuits before fetchFormula — must NOT error.
+    try upgrade.execute(testing.allocator, &.{"alpha-pinned"});
+}
+
+test "mt upgrade (no args) skips pinned kegs without aggregating failures" {
+    const path = try setupPrefix("pinned_skip_bulk");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        try insertPinnedKeg(&db, "first-pinned");
+        try insertPinnedKeg(&db, "second-pinned");
+    }
+
+    // All-pinned bulk run: every keg is skipped, no failures aggregate.
+    try upgrade.execute(testing.allocator, &.{});
+}
+
+test "pinSkip honours --force: pinned + force = false (no skip)" {
+    const path = try setupPrefix("pinskip_helper");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertPinnedKeg(&db, "forced");
+    try db.exec("INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path) VALUES ('loose', 'loose', '1.0', 'sha', '/cellar/loose/1.0');");
+
+    // pinned + !force = skip
+    try testing.expect(upgrade.pinSkip(&db, "forced", false));
+    // pinned + force = no skip (the whole point of --force)
+    try testing.expect(!upgrade.pinSkip(&db, "forced", true));
+    // unpinned: never skipped, force or not
+    try testing.expect(!upgrade.pinSkip(&db, "loose", false));
+    try testing.expect(!upgrade.pinSkip(&db, "loose", true));
+    // unknown name: not pinned, not skipped
+    try testing.expect(!upgrade.pinSkip(&db, "ghost", false));
 }


### PR DESCRIPTION
## Description

Adds `mt pin <name>` and `mt unpin <name>`; `mt upgrade` now skips `pinned=1` rows with a dim "pinned, skipped" line unless `--force`.

## Related Issue

- None

## Notes for Reviewers

Schema already had the `pinned` column and `mt list --pinned` already surfaced it; today `upgrade` silently rolled the keg anyway. This wires the user-visible verbs and honors the column in both the single-name and bulk `upgrade` paths. `--force` is the documented escape hatch (see `mt upgrade --help`). The pin gate is exposed as a pure helper (`upgrade.pinSkip`) so the `--force` semantics are unit-tested without dragging in the API.