### PR TITLE
feat(cli): mt shellenv for bash, zsh, fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,21 @@ malt completions fish > ~/.config/fish/completions/malt.fish
 
 Completes subcommands (for both `malt` and `mt`), per-command flags, global flags, and the positional shell name for `completions` itself. Unknown shell names exit non-zero with an error.
 
+### `mt shellenv`
+
+Drop-in for `eval "$(brew shellenv)"`. Prints `bash`/`zsh`/`fish` init lines that export `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR`, `HOMEBREW_REPOSITORY` (so brew-aware scripts keep sniffing) and prepend malt's `bin`, `sbin`, `share/man`, `share/info` onto `PATH`, `MANPATH`, `INFOPATH`. With no argument the shell is detected from `$SHELL`.
+
+```bash
+# Bash / zsh — POSIX export form, safe to eval from rc files
+eval "$(mt shellenv)"          # auto-detect from $SHELL
+eval "$(mt shellenv bash)"
+
+# Fish — uses set -gx, since `export` is a syntax error in fish
+mt shellenv fish | source
+```
+
+Add the `eval`/`source` line to `~/.zshrc`, `~/.bashrc`, or `~/.config/fish/config.fish` to make malt's binaries discoverable in every new shell. Unknown shell names exit non-zero with an error; an unrecognised `$SHELL` fails closed and asks for an explicit argument.
+
 ### Global Flags
 
 | Flag              | Description                                                                     |

--- a/build.zig
+++ b/build.zig
@@ -178,6 +178,7 @@ pub fn build(b: *std.Build) void {
         "tests/hash_test.zig",
         "tests/patcher_test.zig",
         "tests/pin_test.zig",
+        "tests/shellenv_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -125,10 +125,38 @@ else
   FAILURES+=("t1.completions.bad")
 fi
 
+run_grep t1.shellenv.bash 'export HOMEBREW_PREFIX=' -- "$MT_BIN" shellenv bash
+run_grep t1.shellenv.zsh 'export HOMEBREW_PREFIX=' -- "$MT_BIN" shellenv zsh
+run_grep t1.shellenv.fish 'set -gx HOMEBREW_PREFIX' -- "$MT_BIN" shellenv fish
+
+# Eval-safety: bash must accept the output as a sequence of statements.
+eval "$("$MT_BIN" shellenv bash)" >/dev/null 2>&1
+rc=$?
+if [[ "$rc" == 0 ]]; then
+  printf '  PASS  [t1.shellenv.eval-bash] exit=0\n'
+  PASS=$((PASS + 1))
+else
+  printf '  FAIL  [t1.shellenv.eval-bash] eval rc=%s\n' "$rc"
+  FAIL=$((FAIL + 1))
+  FAILURES+=("t1.shellenv.eval-bash")
+fi
+
+# Unknown shell must exit non-zero, mirroring `completions tcsh`.
+"$MT_BIN" shellenv tcsh >/dev/null 2>&1
+rc=$?
+if [[ "$rc" != 0 ]]; then
+  printf '  PASS  [t1.shellenv.bad] exit=%s (non-zero)\n' "$rc"
+  PASS=$((PASS + 1))
+else
+  printf '  FAIL  [t1.shellenv.bad] expected non-zero, got %s\n' "$rc"
+  FAIL=$((FAIL + 1))
+  FAILURES+=("t1.shellenv.bad")
+fi
+
 # Per-command --help on everything documented.
 for cmd in install uninstall upgrade update outdated list info search uses \
   doctor purge tap untap migrate backup restore services bundle \
-  rollback run link unlink pin unpin version completions; do
+  rollback run link unlink pin unpin version completions shellenv; do
   run_ok "t1.help.$cmd" -- "$MT_BIN" "$cmd" --help
 done
 

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -87,7 +87,7 @@ pub const bash_script =
     \\    words=("${COMP_WORDS[@]}")
     \\    cword=$COMP_CWORD
     \\
-    \\    local commands="install uninstall remove upgrade update outdated list ls info search uses doctor tap untap migrate rollback link unlink pin unpin run version completions backup restore purge services bundle help"
+    \\    local commands="install uninstall remove upgrade update outdated list ls info search uses doctor tap untap migrate rollback link unlink pin unpin run version completions shellenv backup restore purge services bundle help"
     \\    local global_flags="--verbose -v --quiet -q --json --dry-run --help -h --version"
     \\
     \\    # Find the first non-flag word after the program — that's the subcommand.
@@ -109,7 +109,7 @@ pub const bash_script =
     \\    fi
     \\
     \\    case "$cmd" in
-    \\        completions)
+    \\        completions|shellenv)
     \\            if [[ "$cur" != -* ]]; then
     \\                COMPREPLY=( $(compgen -W "bash zsh fish" -- "$cur") )
     \\                return 0
@@ -210,6 +210,7 @@ pub const zsh_script =
     \\        'run:Run a package binary without installing'
     \\        'version:Show version or self-update'
     \\        'completions:Generate shell completion scripts'
+    \\        'shellenv:Print PATH/MANPATH/HOMEBREW_PREFIX exports for shell init'
     \\        'backup:Dump installed packages to a restorable text file'
     \\        'restore:Reinstall every package listed in a backup file'
     \\        'purge:Housekeeping or full wipe (requires a scope flag)'
@@ -303,7 +304,7 @@ pub const zsh_script =
     \\                        '(--force -f)'{--force,-f}'[Same as --overwrite]' \
     \\                        '*::formula:'
     \\                    ;;
-    \\                completions)
+    \\                completions|shellenv)
     \\                    _values 'shell' bash zsh fish
     \\                    ;;
     \\                backup)
@@ -444,6 +445,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n __malt_needs_command -a run         -d 'Run package binary without installing'
     \\    complete -c $__malt_bin -n __malt_needs_command -a version     -d 'Show version or self-update'
     \\    complete -c $__malt_bin -n __malt_needs_command -a completions -d 'Generate shell completion scripts'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a shellenv    -d 'Print shell init exports (PATH, MANPATH, HOMEBREW_PREFIX)'
     \\    complete -c $__malt_bin -n __malt_needs_command -a backup      -d 'Dump installed packages to a text file'
     \\    complete -c $__malt_bin -n __malt_needs_command -a restore     -d 'Reinstall every package in a backup file'
     \\    complete -c $__malt_bin -n __malt_needs_command -a purge       -d 'Housekeeping or full wipe (requires a scope)'
@@ -516,6 +518,9 @@ pub const fish_script =
     \\
     \\    # completions — shell name as positional
     \\    complete -c $__malt_bin -n '__malt_using_command completions' -f -a 'bash zsh fish'
+    \\
+    \\    # shellenv — shell name as positional
+    \\    complete -c $__malt_bin -n '__malt_using_command shellenv' -f -a 'bash zsh fish'
     \\
     \\    # backup
     \\    complete -c $__malt_bin -n '__malt_using_command backup' -s o -l output   -r -d 'Output file (use - for stdout)'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -36,6 +36,7 @@ pub fn helpFor(command: []const u8) []const u8 {
         .{ "link", link_help },
         .{ "unlink", unlink_help2 },
         .{ "completions", completions_help },
+        .{ "shellenv", shellenv_help },
         .{ "backup", backup_help },
         .{ "restore", restore_help },
         .{ "purge", purge_help },
@@ -259,6 +260,19 @@ const completions_help =
     \\  bash    malt completions bash > /usr/local/etc/bash_completion.d/malt
     \\  zsh     malt completions zsh  > "${fpath[1]}/_malt"
     \\  fish    malt completions fish > ~/.config/fish/completions/malt.fish
+    \\
+;
+
+const shellenv_help =
+    \\Usage: malt shellenv [bash|zsh|fish]
+    \\
+    \\Print shell-init lines that export HOMEBREW_PREFIX and prepend
+    \\malt's bin/sbin/man/info dirs onto PATH/MANPATH/INFOPATH. With no
+    \\argument the shell is detected from $SHELL.
+    \\
+    \\Source from your rc file:
+    \\  bash/zsh   eval "$(malt shellenv)"
+    \\  fish       malt shellenv fish | source
     \\
 ;
 

--- a/src/cli/shellenv.zig
+++ b/src/cli/shellenv.zig
@@ -1,0 +1,91 @@
+//! malt — shellenv command
+//! Match brew's shellenv contract so `eval "$(mt shellenv)"` works in place
+//! of the brew form during onboarding.
+
+const std = @import("std");
+const fs_compat = @import("../fs/compat.zig");
+const atomic = @import("../fs/atomic.zig");
+const io_mod = @import("../ui/io.zig");
+const help = @import("help.zig");
+
+pub const Shell = enum { bash, zsh, fish };
+
+pub fn parseShell(name: []const u8) ?Shell {
+    if (std.mem.eql(u8, name, "bash")) return .bash;
+    if (std.mem.eql(u8, name, "zsh")) return .zsh;
+    if (std.mem.eql(u8, name, "fish")) return .fish;
+    return null;
+}
+
+pub fn detectFromShellPath(value: ?[]const u8) ?Shell {
+    const path = value orelse return null;
+    if (path.len == 0) return null;
+    const slash = std.mem.lastIndexOfScalar(u8, path, '/');
+    const base = if (slash) |i| path[i + 1 ..] else path;
+    return parseShell(base);
+}
+
+/// Caller owns the returned slice.
+pub fn render(
+    allocator: std.mem.Allocator,
+    shell: Shell,
+    prefix: []const u8,
+) std.mem.Allocator.Error![]u8 {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    errdefer aw.deinit();
+    // The writer is allocator-backed, so its `WriteFailed` is always OOM.
+    writeShellEnv(&aw.writer, shell, prefix) catch return error.OutOfMemory;
+    return aw.toOwnedSlice();
+}
+
+fn writeShellEnv(w: *std.Io.Writer, shell: Shell, prefix: []const u8) std.Io.Writer.Error!void {
+    // Fish uses `set -gx` because `export` is a syntax error in fish;
+    // bash/zsh share the POSIX form.
+    switch (shell) {
+        .bash, .zsh => {
+            try w.print("export HOMEBREW_PREFIX=\"{s}\";\n", .{prefix});
+            try w.print("export HOMEBREW_CELLAR=\"{s}/Cellar\";\n", .{prefix});
+            try w.print("export HOMEBREW_REPOSITORY=\"{s}\";\n", .{prefix});
+            try w.print("export PATH=\"{s}/bin:{s}/sbin${{PATH+:$PATH}}\";\n", .{ prefix, prefix });
+            try w.print("export MANPATH=\"{s}/share/man${{MANPATH+:$MANPATH}}:\";\n", .{prefix});
+            try w.print("export INFOPATH=\"{s}/share/info:${{INFOPATH:-}}\";\n", .{prefix});
+        },
+        .fish => {
+            try w.print("set -gx HOMEBREW_PREFIX \"{s}\";\n", .{prefix});
+            try w.print("set -gx HOMEBREW_CELLAR \"{s}/Cellar\";\n", .{prefix});
+            try w.print("set -gx HOMEBREW_REPOSITORY \"{s}\";\n", .{prefix});
+            try w.print("set -gx PATH \"{s}/bin\" \"{s}/sbin\" $PATH;\n", .{ prefix, prefix });
+            try w.print("set -gx MANPATH \"{s}/share/man\" $MANPATH;\n", .{prefix});
+            try w.print("set -gx INFOPATH \"{s}/share/info\" $INFOPATH;\n", .{prefix});
+        },
+    }
+}
+
+pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
+    if (help.showIfRequested(args, "shellenv")) return;
+
+    const shell = resolveShell(args) orelse std.process.exit(2);
+
+    const out = try render(allocator, shell, atomic.maltPrefix());
+    defer allocator.free(out);
+    io_mod.stdoutWriteAll(out);
+}
+
+fn resolveShell(args: []const []const u8) ?Shell {
+    if (args.len > 0) {
+        if (parseShell(args[0])) |s| return s;
+        var buf: [128]u8 = undefined;
+        const msg = std.fmt.bufPrint(
+            &buf,
+            "malt: unknown shell '{s}'. Supported: bash, zsh, fish\n",
+            .{args[0]},
+        ) catch "malt: unknown shell. Supported: bash, zsh, fish\n";
+        io_mod.stderrWriteAll(msg);
+        return null;
+    }
+    if (detectFromShellPath(fs_compat.getenv("SHELL"))) |s| return s;
+    io_mod.stderrWriteAll(
+        "malt: could not detect shell from $SHELL. Pass bash, zsh, or fish explicitly.\n",
+    );
+    return null;
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -28,6 +28,7 @@ pub const term_sanitize = @import("ui/term_sanitize.zig");
 pub const progress = @import("ui/progress.zig");
 pub const version = @import("version.zig");
 pub const completions = @import("cli/completions.zig");
+pub const shellenv = @import("cli/shellenv.zig");
 pub const backup = @import("cli/backup.zig");
 pub const purge = @import("cli/purge.zig");
 pub const install = @import("cli/install.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -46,6 +46,7 @@ const pin_cmd = @import("cli/pin.zig");
 const run_cmd = @import("cli/run.zig");
 const version_update = @import("cli/version_update.zig");
 const completions = @import("cli/completions.zig");
+const shellenv = @import("cli/shellenv.zig");
 const backup = @import("cli/backup.zig");
 const restore = @import("cli/restore.zig");
 const purge = @import("cli/purge.zig");
@@ -77,6 +78,7 @@ const Command = enum {
     run,
     version_cmd,
     completions,
+    shellenv,
     backup,
     restore,
     purge,
@@ -113,6 +115,7 @@ const command_names = [_]struct {
     .{ .tag = .run, .names = &.{"run"} },
     .{ .tag = .version_cmd, .names = &.{"version"} },
     .{ .tag = .completions, .names = &.{"completions"} },
+    .{ .tag = .shellenv, .names = &.{"shellenv"} },
     .{ .tag = .backup, .names = &.{"backup"} },
     .{ .tag = .restore, .names = &.{"restore"} },
     .{ .tag = .purge, .names = &.{"purge"} },
@@ -265,6 +268,7 @@ fn dispatch(allocator: std.mem.Allocator, cmd: Command, cmd_args: []const []cons
         .unpin => try pin_cmd.executeUnpin(allocator, cmd_args),
         .run => try run_cmd.execute(allocator, cmd_args),
         .completions => try completions.execute(allocator, cmd_args),
+        .shellenv => try shellenv.execute(allocator, cmd_args),
         .backup => try backup.execute(allocator, cmd_args),
         .restore => try restore.execute(allocator, cmd_args),
         .purge => try purge.execute(allocator, cmd_args),
@@ -311,6 +315,7 @@ fn printUsage() void {
         \\  unpin         Lift the pin so `upgrade` resumes touching it
         \\  run           Run a package binary without installing
         \\  completions   Generate shell completion scripts (bash, zsh, fish)
+        \\  shellenv      Print PATH/MANPATH/HOMEBREW_PREFIX exports for shell init
         \\  backup        Dump installed packages to a restorable text file
         \\  restore       Reinstall every package listed in a backup file
         \\  purge         Housekeeping or full wipe (--store-orphans, --unused-deps,

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -40,8 +40,8 @@ const all_commands = [_][]const u8{
     "info",    "search",      "doctor",   "tap",
     "untap",   "migrate",     "rollback", "link",
     "unlink",  "pin",         "unpin",    "run",
-    "version", "completions", "backup",   "restore",
-    "purge",   "services",    "bundle",
+    "version", "completions", "shellenv", "backup",
+    "restore", "purge",       "services", "bundle",
 };
 
 fn expectContains(haystack: []const u8, needle: []const u8) !void {

--- a/tests/shellenv_test.zig
+++ b/tests/shellenv_test.zig
@@ -1,0 +1,130 @@
+//! malt — shellenv command tests
+
+const std = @import("std");
+const testing = std.testing;
+const shellenv = @import("malt").shellenv;
+
+test "parseShell recognises the three supported shells" {
+    try testing.expectEqual(shellenv.Shell.bash, shellenv.parseShell("bash").?);
+    try testing.expectEqual(shellenv.Shell.zsh, shellenv.parseShell("zsh").?);
+    try testing.expectEqual(shellenv.Shell.fish, shellenv.parseShell("fish").?);
+}
+
+test "parseShell returns null for unknown shells" {
+    try testing.expect(shellenv.parseShell("tcsh") == null);
+    try testing.expect(shellenv.parseShell("ksh") == null);
+    try testing.expect(shellenv.parseShell("") == null);
+    try testing.expect(shellenv.parseShell("Bash") == null);
+}
+
+test "detectFromShellPath maps common $SHELL values to a shell" {
+    try testing.expectEqual(shellenv.Shell.bash, shellenv.detectFromShellPath("/bin/bash").?);
+    try testing.expectEqual(shellenv.Shell.zsh, shellenv.detectFromShellPath("/bin/zsh").?);
+    try testing.expectEqual(shellenv.Shell.fish, shellenv.detectFromShellPath("/usr/local/bin/fish").?);
+    try testing.expectEqual(shellenv.Shell.fish, shellenv.detectFromShellPath("/opt/homebrew/bin/fish").?);
+}
+
+test "detectFromShellPath returns null for missing or unknown shells" {
+    try testing.expect(shellenv.detectFromShellPath(null) == null);
+    try testing.expect(shellenv.detectFromShellPath("") == null);
+    try testing.expect(shellenv.detectFromShellPath("/bin/tcsh") == null);
+    try testing.expect(shellenv.detectFromShellPath("/usr/bin/sh") == null);
+}
+
+fn expectContains(haystack: []const u8, needle: []const u8) !void {
+    if (std.mem.indexOf(u8, haystack, needle) == null) {
+        std.debug.print("expected output to contain '{s}', got:\n{s}\n", .{ needle, haystack });
+        return error.MissingSubstring;
+    }
+}
+
+test "render bash exports brew-compatible env so third-party scripts keep working" {
+    const out = try shellenv.render(testing.allocator, .bash, "/opt/malt");
+    defer testing.allocator.free(out);
+
+    try expectContains(out, "export HOMEBREW_PREFIX=\"/opt/malt\"");
+    try expectContains(out, "export HOMEBREW_CELLAR=\"/opt/malt/Cellar\"");
+    try expectContains(out, "export HOMEBREW_REPOSITORY=\"/opt/malt\"");
+    try expectContains(out, "export PATH=");
+    try expectContains(out, "/opt/malt/bin");
+    try expectContains(out, "/opt/malt/sbin");
+    try expectContains(out, "export MANPATH=");
+    try expectContains(out, "/opt/malt/share/man");
+    try expectContains(out, "export INFOPATH=");
+    try expectContains(out, "/opt/malt/share/info");
+}
+
+test "render bash and zsh emit byte-identical output (single shared arm)" {
+    const bash = try shellenv.render(testing.allocator, .bash, "/opt/malt");
+    defer testing.allocator.free(bash);
+    const zsh = try shellenv.render(testing.allocator, .zsh, "/opt/malt");
+    defer testing.allocator.free(zsh);
+    try testing.expectEqualStrings(bash, zsh);
+}
+
+test "render bash prepends malt's bin before \\$PATH so its binaries win" {
+    const out = try shellenv.render(testing.allocator, .bash, "/opt/malt");
+    defer testing.allocator.free(out);
+    // Binary order matters: an `append` would let the existing PATH shadow
+    // malt-installed tools.
+    try expectContains(out, "PATH=\"/opt/malt/bin:/opt/malt/sbin");
+    // POSIX-safe expansion: empty PATH must stay empty, not become ":".
+    try expectContains(out, "${PATH+:$PATH}");
+}
+
+test "render bash terminates every line with `;\\n` so eval sees full statements" {
+    const out = try shellenv.render(testing.allocator, .bash, "/opt/malt");
+    defer testing.allocator.free(out);
+    try testing.expect(out.len > 0);
+    try testing.expect(std.mem.endsWith(u8, out, ";\n"));
+    var it = std.mem.splitScalar(u8, out, '\n');
+    while (it.next()) |line| {
+        if (line.len == 0) continue;
+        try testing.expect(std.mem.endsWith(u8, line, ";"));
+    }
+}
+
+test "render fish uses set -gx and avoids POSIX export syntax" {
+    const out = try shellenv.render(testing.allocator, .fish, "/opt/malt");
+    defer testing.allocator.free(out);
+
+    try expectContains(out, "set -gx HOMEBREW_PREFIX \"/opt/malt\"");
+    try expectContains(out, "set -gx HOMEBREW_CELLAR \"/opt/malt/Cellar\"");
+    try expectContains(out, "set -gx HOMEBREW_REPOSITORY \"/opt/malt\"");
+    try expectContains(out, "set -gx PATH \"/opt/malt/bin\" \"/opt/malt/sbin\" $PATH");
+    try expectContains(out, "set -gx MANPATH \"/opt/malt/share/man\" $MANPATH");
+    try expectContains(out, "set -gx INFOPATH \"/opt/malt/share/info\" $INFOPATH");
+    // POSIX `export` and bash brace-expansion are syntax errors in fish.
+    try testing.expect(std.mem.indexOf(u8, out, "export ") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "${") == null);
+}
+
+test "render honors a non-default prefix" {
+    const out = try shellenv.render(testing.allocator, .bash, "/usr/local");
+    defer testing.allocator.free(out);
+
+    try expectContains(out, "export HOMEBREW_PREFIX=\"/usr/local\"");
+    try expectContains(out, "/usr/local/bin");
+    try testing.expect(std.mem.indexOf(u8, out, "/opt/malt") == null);
+}
+
+test "render surfaces allocator failure rather than swallowing it" {
+    try testing.expectError(
+        error.OutOfMemory,
+        shellenv.render(testing.failing_allocator, .bash, "/opt/malt"),
+    );
+}
+
+test "render with a tiny budget eventually returns OutOfMemory, not corruption" {
+    // Exercises every partial-write path through `Writer.Allocating`.
+    try testing.checkAllAllocationFailures(
+        testing.allocator,
+        struct {
+            fn run(a: std.mem.Allocator) !void {
+                const out = try shellenv.render(a, .fish, "/opt/malt");
+                a.free(out);
+            }
+        }.run,
+        .{},
+    );
+}


### PR DESCRIPTION
## Description

New `mt shellenv [bash|zsh|fish]` prints shell-init lines that export
HOMEBREW_PREFIX/CELLAR/REPOSITORY and prepend malt's bin/sbin/man/info dirs
onto PATH/MANPATH/INFOPATH. Drops in for `eval "$(brew shellenv)"` so
existing onboarding muscle memory works against malt without hand-editing
PATH. With no argument the shell is detected from \$SHELL.

Bash and zsh share the POSIX `export` form (with `\${PATH+:\$PATH}` so an
unset PATH stays unset rather than gaining a stray colon). Fish uses the
native `set -gx` since `export` is a syntax error there.

## Related Issue

- None

## Notes for Reviewers

- None