### PR TITLE
feat(cli): mt which to resolve prefix binaries to kegs

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,18 @@ mt uses --recursive <formula>
 mt uses <formula> --json
 ```
 
+### `mt which`
+
+Resolve a prefix binary to the keg that owns it - the reverse lookup pairs with `mt uses`. Accepts a bare name (resolved through `{prefix}/bin/<name>`) or an absolute path to a malt-managed symlink.
+
+```bash
+mt which jq
+mt which /opt/malt/bin/jq
+mt --json which jq
+```
+
+Human output: `<name> <version> <keg-path>`. JSON output: `{"name", "version", "keg"}`. Read-only and offline; exits non-zero with a clear message when the binary is not owned by malt.
+
 ### `mt doctor`
 
 System health check.

--- a/build.zig
+++ b/build.zig
@@ -171,6 +171,7 @@ pub fn build(b: *std.Build) void {
         "tests/search_test.zig",
         "tests/info_test.zig",
         "tests/uses_test.zig",
+        "tests/which_test.zig",
         "tests/output_test.zig",
         "tests/worker_arena_test.zig",
         "tests/migrate_smoke_test.zig",

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -154,7 +154,7 @@ else
 fi
 
 # Per-command --help on everything documented.
-for cmd in install uninstall upgrade update outdated list info search uses \
+for cmd in install uninstall upgrade update outdated list info search uses which \
   doctor purge tap untap migrate backup restore services bundle \
   rollback run link unlink pin unpin version completions shellenv; do
   run_ok "t1.help.$cmd" -- "$MT_BIN" "$cmd" --help
@@ -216,6 +216,8 @@ else
   run_grep t3.info.tree "tree" -- "$MT_BIN" info tree
   run_ok t3.uses.tree -- "$MT_BIN" uses tree
   run_ok t3.uses.recursive -- "$MT_BIN" uses --recursive tree
+  run_ok t3.which.tree -- "$MT_BIN" which tree
+  run_ok t3.which.json -- "$MT_BIN" --json which tree
 
   # link is already done by install; unlink + re-link exercises the code path.
   run_ok t3.unlink -- "$MT_BIN" unlink tree

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -87,7 +87,7 @@ pub const bash_script =
     \\    words=("${COMP_WORDS[@]}")
     \\    cword=$COMP_CWORD
     \\
-    \\    local commands="install uninstall remove upgrade update outdated list ls info search uses doctor tap untap migrate rollback link unlink pin unpin run version completions shellenv backup restore purge services bundle help"
+    \\    local commands="install uninstall remove upgrade update outdated list ls info search uses which doctor tap untap migrate rollback link unlink pin unpin run version completions shellenv backup restore purge services bundle help"
     \\    local global_flags="--verbose -v --quiet -q --json --dry-run --help -h --version"
     \\
     \\    # Find the first non-flag word after the program — that's the subcommand.
@@ -148,6 +148,7 @@ pub const bash_script =
     \\        info)             cmd_flags="--formula --cask --json" ;;
     \\        search)           cmd_flags="--formula --cask --json" ;;
     \\        uses)             cmd_flags="--recursive -r --json --quiet -q" ;;
+    \\        which)            cmd_flags="--json" ;;
     \\        migrate|rollback) cmd_flags="--dry-run" ;;
     \\        link)             cmd_flags="--overwrite --force -f" ;;
     \\        services)         cmd_flags="--tail --stderr --system --json" ;;
@@ -198,6 +199,7 @@ pub const zsh_script =
     \\        'info:Show detailed package information'
     \\        'search:Search formulas and casks'
     \\        'uses:Show installed packages that depend on a formula'
+    \\        'which:Resolve a prefix binary to its owning keg'
     \\        'doctor:System health check'
     \\        'tap:Manage taps'
     \\        'untap:Remove a tap'
@@ -264,6 +266,11 @@ pub const zsh_script =
     \\                    ;;
     \\                pin|unpin)
     \\                    _arguments '*::keg:'
+    \\                    ;;
+    \\                which)
+    \\                    _arguments \
+    \\                        '--json[Output as JSON]' \
+    \\                        '*::name-or-path:'
     \\                    ;;
     \\                outdated)
     \\                    _arguments \
@@ -433,6 +440,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n __malt_needs_command -a info        -d 'Show detailed package information'
     \\    complete -c $__malt_bin -n __malt_needs_command -a search      -d 'Search formulas and casks'
     \\    complete -c $__malt_bin -n __malt_needs_command -a uses        -d 'Show packages that depend on a formula'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a which       -d 'Resolve a prefix binary to its owning keg'
     \\    complete -c $__malt_bin -n __malt_needs_command -a doctor      -d 'System health check'
     \\    complete -c $__malt_bin -n __malt_needs_command -a tap         -d 'Manage taps'
     \\    complete -c $__malt_bin -n __malt_needs_command -a untap       -d 'Remove a tap'
@@ -507,6 +515,9 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command uses' -l recursive -s r -d 'Include transitive dependents'
     \\    complete -c $__malt_bin -n '__malt_using_command uses' -l json               -d 'JSON output'
     \\    complete -c $__malt_bin -n '__malt_using_command uses' -l quiet     -s q    -d 'Suppress status messages'
+    \\
+    \\    # which
+    \\    complete -c $__malt_bin -n '__malt_using_command which' -l json -d 'JSON output'
     \\
     \\    # migrate / rollback
     \\    complete -c $__malt_bin -n '__malt_using_command migrate'    -l dry-run -d 'Preview'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -41,6 +41,7 @@ pub fn helpFor(command: []const u8) []const u8 {
         .{ "restore", restore_help },
         .{ "purge", purge_help },
         .{ "uses", uses_help },
+        .{ "which", which_help },
         .{ "pin", pin_help },
         .{ "unpin", unpin_help },
     });
@@ -386,5 +387,23 @@ const uses_help =
     \\  malt uses openssl@3
     \\  malt uses --recursive icu4c@78
     \\  malt --json uses node@20
+    \\
+;
+
+const which_help =
+    \\Usage: malt which <name|path>
+    \\
+    \\Resolve a prefix binary to the keg that owns it. Accepts a bare
+    \\name (resolved through `{prefix}/bin/<name>`) or an absolute path
+    \\to a malt-managed symlink. Pairs with `mt uses` as the
+    \\forward/reverse lookup pair.
+    \\
+    \\Flags:
+    \\  --json   Emit `{"name", "version", "keg"}` as JSON
+    \\
+    \\Examples:
+    \\  malt which jq
+    \\  malt which /opt/malt/bin/jq
+    \\  malt --json which jq
     \\
 ;

--- a/src/cli/which.zig
+++ b/src/cli/which.zig
@@ -1,0 +1,245 @@
+//! malt — which command
+//! Resolve a prefix binary (or absolute path) to the keg that owns it.
+
+const std = @import("std");
+const atomic = @import("../fs/atomic.zig");
+const fs_compat = @import("../fs/compat.zig");
+const color = @import("../ui/color.zig");
+const io_mod = @import("../ui/io.zig");
+const output = @import("../ui/output.zig");
+const help = @import("help.zig");
+
+pub const ResolveError = error{
+    NotACellarPath,
+    MalformedCellarPath,
+};
+
+/// All three fields are borrowed slices into the input target —
+/// the caller must keep that buffer alive for the lifetime of the
+/// `Resolution`. `keg` is `<...>/Cellar/<name>/<version>`.
+pub const Resolution = struct {
+    name: []const u8,
+    version: []const u8,
+    keg: []const u8,
+};
+
+/// Parse a symlink target like `<...>/Cellar/<name>/<version>/<rest>` into
+/// its keg coordinates. Prefix-agnostic: anchors on `/Cellar/` so any
+/// `MALT_PREFIX` works.
+pub fn resolveFromTarget(target: []const u8) ResolveError!Resolution {
+    const cellar_marker = "/Cellar/";
+    const idx = std.mem.indexOf(u8, target, cellar_marker) orelse
+        return ResolveError.NotACellarPath;
+    const after = target[idx + cellar_marker.len ..];
+    const name_end = std.mem.indexOfScalar(u8, after, '/') orelse
+        return ResolveError.MalformedCellarPath;
+    const name = after[0..name_end];
+    if (name.len == 0) return ResolveError.MalformedCellarPath;
+
+    const ver_and_rest = after[name_end + 1 ..];
+    const ver_end = std.mem.indexOfScalar(u8, ver_and_rest, '/') orelse ver_and_rest.len;
+    const version = ver_and_rest[0..ver_end];
+    if (version.len == 0) return ResolveError.MalformedCellarPath;
+
+    const keg_end = idx + cellar_marker.len + name_end + 1 + ver_end;
+    return .{
+        .name = name,
+        .version = version,
+        .keg = target[0..keg_end],
+    };
+}
+
+pub fn encodeJson(w: *std.Io.Writer, res: Resolution) !void {
+    try w.writeAll("{\"name\":");
+    try output.jsonStr(w, res.name);
+    try w.writeAll(",\"version\":");
+    try output.jsonStr(w, res.version);
+    try w.writeAll(",\"keg\":");
+    try output.jsonStr(w, res.keg);
+    try w.writeAll("}\n");
+}
+
+/// Mirror `mt info`'s installed-keg layout: bold `<name>: <version>` header
+/// followed by an aligned `Keg:` field row.
+pub fn encodeHuman(w: *std.Io.Writer, res: Resolution, colorize: bool) !void {
+    if (colorize) try w.writeAll(color.Style.bold.code());
+    try w.writeAll(res.name);
+    if (colorize) try w.writeAll(color.Style.reset.code());
+    try w.writeAll(": ");
+    if (colorize) try w.writeAll(color.Style.bold.code());
+    try w.writeAll(res.version);
+    if (colorize) try w.writeAll(color.Style.reset.code());
+    try w.writeAll("\n");
+
+    // "Keg:" (4 chars + colon = 5) is the only field; widen if more land later.
+    const col: usize = 5;
+    var scratch: [1024]u8 = undefined;
+    try output.writeField(w, &scratch, colorize, col, "Keg", "{s}", .{res.keg});
+}
+
+pub fn execute(_: std.mem.Allocator, args: []const []const u8) !void {
+    if (help.showIfRequested(args, "which")) return;
+
+    var arg: ?[]const u8 = null;
+    for (args) |a| {
+        if (a.len > 0 and a[0] != '-') {
+            arg = a;
+            break;
+        }
+    }
+    const target_arg = arg orelse {
+        output.err("Usage: mt which <name|path>", .{});
+        return error.Aborted;
+    };
+
+    const prefix = atomic.maltPrefix();
+
+    // Bare name -> {prefix}/bin/<name>; absolute path -> as-is. The
+    // readlink result is the source of truth: the cellar path encodes
+    // keg identity, so we resolve everything through it.
+    var link_buf: [fs_compat.max_path_bytes]u8 = undefined;
+    const link_path = if (target_arg[0] == '/')
+        target_arg
+    else
+        std.fmt.bufPrint(&link_buf, "{s}/bin/{s}", .{ prefix, target_arg }) catch {
+            // Only triggers on a name that overflows max_path_bytes; the underlying error is OOM-ish, not informative.
+            output.err("name too long: {s}", .{target_arg});
+            return error.Aborted;
+        };
+
+    var target_buf: [fs_compat.max_path_bytes]u8 = undefined;
+    const link_target = fs_compat.readLinkAbsolute(link_path, &target_buf) catch {
+        // Missing entry, plain file, or unreadable — all surface the same way: not owned by malt.
+        output.err("{s}: not owned by malt (no symlink under {s}/bin)", .{ target_arg, prefix });
+        return error.Aborted;
+    };
+
+    const res = resolveFromTarget(link_target) catch {
+        // Symlink resolves but does not point into a Cellar keg — both NotACellarPath and MalformedCellarPath read the same to a user.
+        output.err("{s}: symlink target {s} is not in {s}/Cellar", .{ target_arg, link_target, prefix });
+        return error.Aborted;
+    };
+
+    var stdout_buf: [1024]u8 = undefined;
+    var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
+    const stdout: *std.Io.Writer = &stdout_fw.interface;
+    // Flush on teardown; stdout closed by a broken pipe is normal shell usage.
+    defer stdout.flush() catch {};
+
+    if (output.isJson()) {
+        try encodeJson(stdout, res);
+    } else {
+        try encodeHuman(stdout, res, color.isColorEnabled());
+    }
+}
+
+// --- inline unit tests --------------------------------------------------
+
+const testing = std.testing;
+
+test "resolveFromTarget extracts name, version, and keg from a typical target" {
+    const res = try resolveFromTarget("/opt/malt/Cellar/jq/1.7.1/bin/jq");
+    try testing.expectEqualStrings("jq", res.name);
+    try testing.expectEqualStrings("1.7.1", res.version);
+    try testing.expectEqualStrings("/opt/malt/Cellar/jq/1.7.1", res.keg);
+}
+
+test "resolveFromTarget handles versioned formula names with @" {
+    const res = try resolveFromTarget("/opt/malt/Cellar/openssl@3/3.4.0/lib/libssl.dylib");
+    try testing.expectEqualStrings("openssl@3", res.name);
+    try testing.expectEqualStrings("3.4.0", res.version);
+    try testing.expectEqualStrings("/opt/malt/Cellar/openssl@3/3.4.0", res.keg);
+}
+
+test "resolveFromTarget honors any prefix (anchors on /Cellar/)" {
+    const res = try resolveFromTarget("/tmp/mt.sandbox/Cellar/wget/1.25.0/bin/wget");
+    try testing.expectEqualStrings("wget", res.name);
+    try testing.expectEqualStrings("1.25.0", res.version);
+    try testing.expectEqualStrings("/tmp/mt.sandbox/Cellar/wget/1.25.0", res.keg);
+}
+
+test "resolveFromTarget handles a target ending exactly at the version dir" {
+    const res = try resolveFromTarget("/opt/malt/Cellar/tree/2.2.1");
+    try testing.expectEqualStrings("tree", res.name);
+    try testing.expectEqualStrings("2.2.1", res.version);
+    try testing.expectEqualStrings("/opt/malt/Cellar/tree/2.2.1", res.keg);
+}
+
+test "resolveFromTarget rejects paths without /Cellar/" {
+    try testing.expectError(ResolveError.NotACellarPath, resolveFromTarget("/usr/local/bin/jq"));
+}
+
+test "resolveFromTarget rejects a Cellar path missing the version segment" {
+    try testing.expectError(ResolveError.MalformedCellarPath, resolveFromTarget("/opt/malt/Cellar/jq"));
+}
+
+test "resolveFromTarget rejects a Cellar path with empty name segment" {
+    try testing.expectError(ResolveError.MalformedCellarPath, resolveFromTarget("/opt/malt/Cellar//1.0/bin/x"));
+}
+
+test "encodeJson emits {name, version, keg} in stable order" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeJson(&aw.writer, .{
+        .name = "jq",
+        .version = "1.7.1",
+        .keg = "/opt/malt/Cellar/jq/1.7.1",
+    });
+    try testing.expectEqualStrings(
+        "{\"name\":\"jq\",\"version\":\"1.7.1\",\"keg\":\"/opt/malt/Cellar/jq/1.7.1\"}\n",
+        aw.written(),
+    );
+}
+
+test "encodeJson escapes special characters so output stays valid JSON" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeJson(&aw.writer, .{
+        .name = "weird\"name",
+        .version = "1.0\\beta",
+        .keg = "/odd\npath",
+    });
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        std.mem.trimEnd(u8, aw.written(), "\n"),
+        .{},
+    );
+    defer parsed.deinit();
+    try testing.expectEqualStrings("weird\"name", parsed.value.object.get("name").?.string);
+    try testing.expectEqualStrings("1.0\\beta", parsed.value.object.get("version").?.string);
+    try testing.expectEqualStrings("/odd\npath", parsed.value.object.get("keg").?.string);
+}
+
+test "encodeHuman matches mt info's header+field shape" {
+    // Layout: bold header `<name>: <version>`, then a `Keg:` field row
+    // aligned the same way info aligns its installed-keg fields.
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeHuman(&aw.writer, .{
+        .name = "jq",
+        .version = "1.7.1",
+        .keg = "/opt/malt/Cellar/jq/1.7.1",
+    }, false);
+    try testing.expectEqualStrings(
+        \\jq: 1.7.1
+        \\Keg: /opt/malt/Cellar/jq/1.7.1
+        \\
+    ,
+        aw.written(),
+    );
+}
+
+test "encodeHuman in colorize mode wraps name and version in bold codes" {
+    // Just check the bold ANSI prefix shows up — the exact byte layout
+    // matches what `output.writeFieldKey` and info's encodeHeader emit.
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeHuman(&aw.writer, .{
+        .name = "jq",
+        .version = "1.7.1",
+        .keg = "/opt/malt/Cellar/jq/1.7.1",
+    }, true);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "\x1b[1m") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "Keg:") != null);
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -47,6 +47,7 @@ pub const cli_help = @import("cli/help.zig");
 pub const cli_migrate = @import("cli/migrate.zig");
 pub const cli_info = @import("cli/info.zig");
 pub const cli_uses = @import("cli/uses.zig");
+pub const cli_which = @import("cli/which.zig");
 pub const cli_version_update = @import("cli/version_update.zig");
 pub const update_cleanup = @import("update/cleanup.zig");
 pub const update_origin = @import("update/origin.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -53,6 +53,7 @@ const purge = @import("cli/purge.zig");
 const services = @import("cli/services.zig");
 const bundle = @import("cli/bundle.zig");
 const uses = @import("cli/uses.zig");
+const which_cmd = @import("cli/which.zig");
 
 const version_mod = @import("version.zig");
 const version = version_mod.value;
@@ -85,6 +86,7 @@ const Command = enum {
     services,
     bundle,
     uses,
+    which,
     help,
     version,
 };
@@ -122,6 +124,7 @@ const command_names = [_]struct {
     .{ .tag = .services, .names = &.{"services"} },
     .{ .tag = .bundle, .names = &.{"bundle"} },
     .{ .tag = .uses, .names = &.{"uses"} },
+    .{ .tag = .which, .names = &.{"which"} },
     .{ .tag = .help, .names = &.{ "help", "--help", "-h" } },
     .{ .tag = .version, .names = &.{"--version"} },
 };
@@ -275,6 +278,7 @@ fn dispatch(allocator: std.mem.Allocator, cmd: Command, cmd_args: []const []cons
         .services => try services.execute(allocator, cmd_args),
         .bundle => try bundle.execute(allocator, cmd_args),
         .uses => try uses.execute(allocator, cmd_args),
+        .which => try which_cmd.execute(allocator, cmd_args),
         .version_cmd => {
             // "mt version" — check for "mt version update" subcommand
             if (cmd_args.len > 0 and std.mem.eql(u8, cmd_args[0], "update")) {
@@ -305,6 +309,7 @@ fn printUsage() void {
         \\  info          Show detailed package information
         \\  search        Search formulas and casks
         \\  uses          Show installed packages that depend on a formula
+        \\  which         Resolve a prefix binary (or path) to its keg
         \\  doctor        System health check
         \\  tap/untap     Manage taps
         \\  migrate       Import existing Homebrew installation

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -42,6 +42,7 @@ const all_commands = [_][]const u8{
     "unlink",  "pin",         "unpin",    "run",
     "version", "completions", "shellenv", "backup",
     "restore", "purge",       "services", "bundle",
+    "which",
 };
 
 fn expectContains(haystack: []const u8, needle: []const u8) !void {

--- a/tests/which_test.zig
+++ b/tests/which_test.zig
@@ -1,0 +1,107 @@
+//! malt — which command integration tests
+//!
+//! Pure resolver and encoder tests live inline in `src/cli/which.zig`
+//! (see T-052). This file covers the end-to-end `execute` path that
+//! needs a real prefix on disk: directory layout, symlink readlink,
+//! and the abort-on-miss surface.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const which = malt.cli_which;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+/// Build a fake malt prefix with `Cellar/<name>/<ver>/bin/<name>` and a
+/// `bin/<name>` symlink pointing at it. Returns the prefix path; caller
+/// frees + deletes it.
+fn makePrefixWithKeg(suffix: []const u8, name: []const u8, version: []const u8) ![:0]u8 {
+    const prefix = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "/tmp/malt_which_{d}_{s}",
+        .{ malt.fs_compat.nanoTimestamp(), suffix },
+        0,
+    );
+    malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+
+    const keg_bin = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/Cellar/{s}/{s}/bin",
+        .{ prefix, name, version },
+    );
+    defer testing.allocator.free(keg_bin);
+    try malt.fs_compat.cwd().makePath(keg_bin);
+
+    const real_bin = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ keg_bin, name });
+    defer testing.allocator.free(real_bin);
+    {
+        const f = try malt.fs_compat.createFileAbsolute(real_bin, .{ .truncate = true });
+        defer f.close();
+    }
+
+    const prefix_bin = try std.fmt.allocPrint(testing.allocator, "{s}/bin", .{prefix});
+    defer testing.allocator.free(prefix_bin);
+    try malt.fs_compat.cwd().makePath(prefix_bin);
+
+    const link_path = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ prefix_bin, name });
+    defer testing.allocator.free(link_path);
+    try malt.fs_compat.symLinkAbsolute(real_bin, link_path, .{});
+
+    return prefix;
+}
+
+test "execute resolves a bare binary name through the prefix bin symlink" {
+    const prefix = try makePrefixWithKeg("bare", "jq", "1.7.1");
+    defer testing.allocator.free(prefix);
+    defer malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+    _ = c.setenv("MALT_PREFIX", prefix.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    try which.execute(testing.allocator, &.{"jq"});
+}
+
+test "execute accepts an absolute path under the prefix" {
+    const prefix = try makePrefixWithKeg("abs", "wget", "1.25.0");
+    defer testing.allocator.free(prefix);
+    defer malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+    _ = c.setenv("MALT_PREFIX", prefix.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const abs = try std.fmt.allocPrint(testing.allocator, "{s}/bin/wget", .{prefix});
+    defer testing.allocator.free(abs);
+
+    try which.execute(testing.allocator, &.{abs});
+}
+
+test "execute on an unknown name returns Aborted" {
+    const prefix = try makePrefixWithKeg("unknown", "wget", "1.25.0");
+    defer testing.allocator.free(prefix);
+    defer malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+    _ = c.setenv("MALT_PREFIX", prefix.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    try testing.expectError(error.Aborted, which.execute(testing.allocator, &.{"does-not-exist"}));
+}
+
+test "execute with no positional arg returns Aborted with usage" {
+    try testing.expectError(error.Aborted, which.execute(testing.allocator, &.{}));
+}
+
+test "execute on an absolute path that is not a symlink returns Aborted" {
+    const prefix = try makePrefixWithKeg("plain", "tree", "2.2.1");
+    defer testing.allocator.free(prefix);
+    defer malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+    _ = c.setenv("MALT_PREFIX", prefix.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const plain = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/Cellar/tree/2.2.1/bin/tree",
+        .{prefix},
+    );
+    defer testing.allocator.free(plain);
+    try testing.expectError(error.Aborted, which.execute(testing.allocator, &.{plain}));
+}


### PR DESCRIPTION
## Description

New `mt which <name|path>` resolves a malt-managed binary back to the keg that owns it - the reverse lookup pairs with `mt uses`. Bare names resolve through `{prefix}/bin/<name>`; absolute paths to a prefix symlink are accepted directly. Read-only and offline.

- `--json` emits `{name, version, keg}` for scripting. 
- Unknown binaries exit non-zero with a clear "not owned by malt" message rather than falling through to a confusing readlink failure.

## Related Issue

- None

## Notes for Reviewers

- None