### PR TITLE
feat(cli/install): --only-dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ malt install --local ./wget.rb
 # Install multiple packages (downloads in parallel)
 malt install jq wget ripgrep
 
+# Install only the transitive deps of a package (e.g. before building from source)
+malt install --only-dependencies wget
+
 # List installed packages
 malt list --versions
 
@@ -164,6 +167,7 @@ mt install <package> [<package> ...]     # multiple packages
 | `--local`                      | Install from a local `.rb` path (code-exec surface — trust required) |
 | `--dry-run`                    | Show what would be installed without installing                      |
 | `--force`                      | Overwrite existing installations                                     |
+| `--only-dependencies`          | Install transitive deps but skip the requested package               |
 | `--use-system-ruby[=<name>,…]` | Run `post_install` via system Ruby (sandboxed, per-formula)          |
 | `--quiet`, `-q`                | Suppress all output except errors                                    |
 | `--json`                       | Output result as JSON                                                |

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -2,8 +2,15 @@
 # scripts/clean.sh — remove Zig build artifacts and test scratch dirs.
 #
 # Clears `.zig-cache`, `zig-out`, and `coverage/`, plus any leftover
-# test directories under `/tmp` matching the project's test prefixes
-# (`malt_*`, `mt_*`, `mt-*`, `ml.*`, `mc_*`).
+# test / e2e / smoke / bench directories under `/tmp`. Covers every
+# variant used by the project:
+#   malt_* / malt-*            Zig test scratch + bench work dir
+#   mt_* / mt-* / mt.*         CLI test dirs, bench prefix, smoke PREFIX
+#   ml_* / ml.*                LOGDIR (smoke + e2e security)
+#   mc_* / mc.*                CACHE  (smoke + e2e security)
+# and the bench peer-tool prefixes (/tmp/nb, /tmp/zb, /tmp/malt-bench),
+# honouring BENCH_WORK_DIR / MALT_BENCH_PREFIX / NB_BENCH_PREFIX /
+# ZB_BENCH_PREFIX env overrides so tweaked paths still get cleaned.
 #
 # Some integration tests mint read-only Cellar/<pkg>/1.0/bin fixtures
 # that defeat a plain `rm -rf`; this script chmods everything writable
@@ -48,18 +55,41 @@ remove_tree zig-out
 remove_tree coverage
 
 echo "▸ Test scratch under /tmp"
+# Patterns cover every mktemp/fixture prefix across tests + e2e + smoke +
+# bench. The underscore / dot / hyphen variants are intentional - smoke
+# uses `mktemp -d /tmp/mt.XXX`, e2e security uses `mt_sec.XXX`, bench
+# uses `/tmp/malt-bench`. Missing one variant leaks multi-GB Cellar or
+# cache dirs on every crashed run.
 for pattern in \
   '/tmp/malt_*' \
+  '/tmp/malt-*' \
   '/tmp/mt_*' \
   '/tmp/mt-*' \
+  '/tmp/mt.*' \
+  '/tmp/ml_*' \
   '/tmp/ml.*' \
-  '/tmp/mc_*'; do
+  '/tmp/mc_*' \
+  '/tmp/mc.*'; do
   # Unquoted on purpose so the shell glob-expands the pattern.
   # shellcheck disable=SC2086
   for path in $pattern; do
     [ -e "$path" ] || continue
     remove_tree "$path"
   done
+done
+
+echo "▸ Bench peer-tool prefixes"
+# Mirror bench.sh defaults; honour env overrides so user-tweaked paths
+# still get cleaned.
+for path in \
+  "${BENCH_WORK_DIR:-/tmp/malt-bench}" \
+  "${MALT_BENCH_PREFIX:-/tmp/mt-b}" \
+  "${NB_BENCH_PREFIX:-/tmp/nb}" \
+  "${ZB_BENCH_PREFIX:-/tmp/zb}"; do
+  case "$path" in
+  /tmp/*) [ -e "$path" ] && remove_tree "$path" ;;
+  *) printf "  ⚠ refusing to wipe path outside /tmp: %s\n" "$path" ;;
+  esac
 done
 
 echo "Done. Freed ~$(human "$total_kb")."

--- a/scripts/local-smoke-install.sh
+++ b/scripts/local-smoke-install.sh
@@ -231,7 +231,8 @@ install_only_deps_wget() {
       printf '  PASS  [%s.purge] purge --unused-deps reclaimed every dep\n' "$tag"
       PASS=$((PASS + 1))
     else
-      printf '  FAIL  [%s.purge] kegs survived purge: %s\n' "$tag" "$("$MT_BIN" list -q 2>/dev/null | tr '\n' ' ')"
+      printf '  FAIL  [%s.purge] kegs survived purge:\n' "$tag"
+      "$MT_BIN" list -q 2>/dev/null | sed 's|^|        | |'
       FAIL=$((FAIL + 1))
       FAILURES+=("$tag.purge")
     fi

--- a/scripts/local-smoke-install.sh
+++ b/scripts/local-smoke-install.sh
@@ -30,6 +30,10 @@
 #                                 The case verifies otool sees the long
 #                                 path AND python3.14 actually loads at
 #                                 runtime under the long prefix.
+#   • mt install --only-dependencies wget — brew-parity flag. Asserts the
+#                                 top-level is skipped, deps land marked
+#                                 `dependency`, and `mt purge --unused-deps`
+#                                 reclaims them with no direct retention.
 #
 # Time/bandwidth: ~20-30 min, ~3.5 GB downloaded fresh.
 #
@@ -185,6 +189,55 @@ install_python_overflow_fallback() {
   rm -rf "$long_prefix" "$long_cache"
 }
 
+# Pin the --only-dependencies contract end-to-end against a live formula.
+# wget is the canonical "warm the store before building from source" target:
+# half a dozen recognizable deps (libidn2, openssl@3, ...) and no
+# post_install drama. We also exercise `mt purge --unused-deps`, since the
+# whole point of recording deps as `dependency` is that purge can reclaim
+# them once nothing direct retains them.
+install_only_deps_wget() {
+  local tag="smoke.install.only_deps.wget"
+  local target="wget"
+  # libidn2 is wget's most stable transitive dep across recent bottles;
+  # if homebrew/core ever drops it the assertion below is the early signal.
+  local sentinel_dep="libidn2"
+
+  if ! run "$tag" "$MT_BIN" install --only-dependencies "$target"; then
+    return
+  fi
+
+  if "$MT_BIN" list -q 2>/dev/null | grep -qx "$target"; then
+    printf '  FAIL  [%s.absent] %s leaked into mt list\n' "$tag" "$target"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$tag.absent")
+  else
+    printf '  PASS  [%s.absent] top-level %s correctly skipped\n' "$tag" "$target"
+    PASS=$((PASS + 1))
+  fi
+
+  if "$MT_BIN" list -q 2>/dev/null | grep -qx "$sentinel_dep"; then
+    printf '  PASS  [%s.dep] %s installed as indirect dep\n' "$tag" "$sentinel_dep"
+    PASS=$((PASS + 1))
+  else
+    printf '  FAIL  [%s.dep] expected dep %s not installed\n' "$tag" "$sentinel_dep"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$tag.dep")
+  fi
+
+  # `purge --unused-deps` must reclaim every dep, since nothing direct
+  # retains them in this fresh sandbox.
+  if run "$tag.purge" "$MT_BIN" purge --unused-deps --yes; then
+    if [[ -z "$("$MT_BIN" list -q 2>/dev/null)" ]]; then
+      printf '  PASS  [%s.purge] purge --unused-deps reclaimed every dep\n' "$tag"
+      PASS=$((PASS + 1))
+    else
+      printf '  FAIL  [%s.purge] kegs survived purge: %s\n' "$tag" "$("$MT_BIN" list -q 2>/dev/null | tr '\n' ' ')"
+      FAIL=$((FAIL + 1))
+      FAILURES+=("$tag.purge")
+    fi
+  fi
+}
+
 # Reverse what we installed. Casks first because they touch /Applications;
 # formulas second (they live entirely under MALT_PREFIX, but uninstalling
 # also exercises the uninstall path). Best-effort: a stuck uninstall must
@@ -217,6 +270,7 @@ install_formula smoke.install.go go
 install_cask smoke.install.cask.raycast raycast Raycast.app
 install_binary_cask smoke.install.cask.copilot-cli copilot-cli
 install_python_overflow_fallback
+install_only_deps_wget
 
 printf '\n── Summary ───────────────────────────────────────\n'
 printf '  passed: %d\n' "$PASS"

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -67,6 +67,9 @@ const install_help =
     \\                     only pass files you trust)
     \\  --dry-run          Show what would be installed
     \\  --force            Overwrite existing installations
+    \\  --only-dependencies  Install transitive deps but skip the requested package
+    \\                     (deps are recorded as `dependency` so `mt purge --unused-deps`
+    \\                     can later GC them)
     \\  --use-system-ruby[=<name>,...]  Run post_install via the system Ruby interpreter
     \\                     (experimental, sandboxed). A bare flag requires a single
     \\                     package; use =<name>,... to scope when installing multiple.

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -38,6 +38,7 @@ pub const collectFetchWorkerCount = download_mod.collectFetchWorkerCount;
 pub const collectFormulaJobs = download_mod.collectFormulaJobs;
 pub const InstallJobDeps = download_mod.InstallJobDeps;
 pub const findFailedDep = download_mod.findFailedDep;
+pub const dropTopLevelJobs = download_mod.dropTopLevelJobs;
 const progressBridge = download_mod.progressBridge;
 const downloadWorker = download_mod.downloadWorker;
 const MaterializeResult = download_mod.MaterializeResult;
@@ -102,6 +103,7 @@ const InstallFlag = enum {
     use_system_ruby,
     quiet,
     json,
+    only_dependencies,
 };
 
 const install_flag_map = std.StaticStringMap(InstallFlag).initComptime(.{
@@ -114,6 +116,7 @@ const install_flag_map = std.StaticStringMap(InstallFlag).initComptime(.{
     .{ "--quiet", .quiet },
     .{ "-q", .quiet },
     .{ "--json", .json },
+    .{ "--only-dependencies", .only_dependencies },
 });
 
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
@@ -136,6 +139,9 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // `--local` forces .rb-path interpretation — explicit trust opt-in in
     // argv instead of shape-based autodetection.
     var local_only = false;
+    // brew parity: resolve the dep graph, bail before the requested package's
+    // materialise+link. Deps stay marked `dependency` for `mt purge --unused-deps`.
+    var only_dependencies = false;
 
     // StaticStringMap + exhaustive switch: the compiler checks every flag
     // has a handler, so adding a new variant without wiring it fails to build.
@@ -157,6 +163,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             .use_system_ruby => use_system_ruby_bare = true,
             .quiet => output.setQuiet(true),
             .json => output.setMode(.json),
+            .only_dependencies => only_dependencies = true,
         } else if (!std.mem.startsWith(u8, arg, "-")) {
             packages.append(allocator, arg) catch return error.OutOfMemory;
         }
@@ -351,6 +358,11 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             };
         }
     }
+
+    // top-level skipped; deps still recorded for GC. Surviving jobs keep
+    // `is_dep=true`, so `linkAndRecord` writes `install_reason='dependency'`
+    // and `mt purge --unused-deps` reclaims them once nothing direct retains them.
+    if (only_dependencies) dropTopLevelJobs(allocator, &all_jobs);
 
     if (all_jobs.items.len == 0) return;
 

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -502,6 +502,26 @@ pub fn collectFormulaJobs(
     output.info("Resolved {s} {s} ({d} {s})", .{ formula.name, formula.version, jobs.items.len, pkg_word });
 }
 
+/// Drop top-level (`is_dep == false`) jobs from `jobs` so `--only-dependencies`
+/// can bail before the requested package is materialised. Frees the same five
+/// strings `dupeJobStrings` allocated; `formula_json` on top-level jobs is
+/// borrowed from `api.fetchFormula`, so freeing it here would double-free.
+pub fn dropTopLevelJobs(allocator: std.mem.Allocator, jobs: *std.ArrayList(DownloadJob)) void {
+    var i: usize = 0;
+    while (i < jobs.items.len) {
+        if (jobs.items[i].is_dep) {
+            i += 1;
+            continue;
+        }
+        const removed = jobs.orderedRemove(i);
+        allocator.free(removed.name);
+        allocator.free(removed.version_str);
+        allocator.free(removed.sha256);
+        allocator.free(removed.bottle_url);
+        allocator.free(removed.cellar_type);
+    }
+}
+
 /// Return the first dep name of `formula_json` that appears in `failed_kegs`,
 /// or null if none did. Used to short-circuit jobs whose dependency graph is
 /// already broken so we do not leave half-installed kegs behind.

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -66,7 +66,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 }
 
-fn writeHumanOutput(
+/// Pub for tests: assert the exact bytes for the human path without
+/// staging a real DB-on-prefix + stdout-capture rig.
+///
+/// Honours `output.isQuiet()`: under `--quiet` the help text promises
+/// "Names only, one per line", so decorations (bullet, version suffix,
+/// `[pinned]` tag) are suppressed and each row is a bare name + `\n`.
+pub fn writeHumanOutput(
     db: *sqlite.Database,
     show_formula: bool,
     show_cask: bool,
@@ -74,6 +80,8 @@ fn writeHumanOutput(
     show_pinned: bool,
     stdout: *std.Io.Writer,
 ) !void {
+    const quiet = output.isQuiet();
+
     if (show_formula) {
         const sql = if (show_pinned)
             "SELECT name, version, pinned FROM kegs WHERE pinned = 1 ORDER BY name;"
@@ -88,6 +96,12 @@ fn writeHumanOutput(
             const ver = stmt.columnText(1);
             const pinned = stmt.columnBool(2);
             const name_slice = std.mem.sliceTo(name, 0);
+
+            if (quiet) {
+                stdout.writeAll(name_slice) catch return;
+                stdout.writeAll("\n") catch return;
+                continue;
+            }
 
             writeBulletPrefix(stdout);
             stdout.writeAll(name_slice) catch return;
@@ -111,6 +125,12 @@ fn writeHumanOutput(
             const token = stmt.columnText(0) orelse continue;
             const ver = stmt.columnText(1);
             const token_slice = std.mem.sliceTo(token, 0);
+
+            if (quiet) {
+                stdout.writeAll(token_slice) catch return;
+                stdout.writeAll("\n") catch return;
+                continue;
+            }
 
             writeBulletPrefix(stdout);
             stdout.writeAll(token_slice) catch return;

--- a/tests/install_execute_test.zig
+++ b/tests/install_execute_test.zig
@@ -186,6 +186,124 @@ test "execute refuses to run when MALT_PREFIX is absurdly long (> 256 bytes)" {
 // `Cellar/<name>/<version>` install produces "dyld: Library not
 // loaded" at runtime (see issue #77 with pcre2 10.47_1).
 
+test "execute --only-dependencies on a leaf formula plans nothing" {
+    // Leaf formula → after dropping top-level the queue is empty, so the
+    // "Dry run: would install ..." line never fires. Pins the early-return
+    // branch so a future refactor cannot accidentally print a 0-package plan.
+    const prefix_z: [:0]const u8 = "/tmp/mol";
+    malt.fs_compat.deleteTreeAbsolute(prefix_z) catch {};
+    try malt.fs_compat.cwd().makePath(prefix_z);
+    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    defer malt.fs_compat.deleteTreeAbsolute(prefix_z) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const json =
+        \\{"name":"leaf","full_name":"leaf","tap":"homebrew/core","desc":"","homepage":"",
+        \\ "versions":{"stable":"1.0"},"revision":0,"dependencies":[],"oldnames":[],
+        \\ "keg_only":false,"post_install_defined":false,
+        \\ "bottle":{"stable":{"root_url":"https://ghcr.io/v2/homebrew/core/leaf/blobs",
+        \\   "files":{
+        \\     "arm64_sequoia":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_sonoma":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_ventura":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_monterey":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "sequoia":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+        \\     "sonoma":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+        \\     "ventura":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+        \\     "monterey":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"}
+        \\   }}}}
+    ;
+    try seedFormulaCache(prefix_z, "leaf", json);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.io_mod.beginStderrCapture(testing.allocator, &captured);
+    defer malt.io_mod.endStderrCapture();
+
+    try install.execute(arena.allocator(), &.{ "--dry-run", "--only-dependencies", "leaf" });
+
+    try testing.expect(std.mem.indexOf(u8, captured.items, "Dry run: would install") == null);
+}
+
+test "execute --only-dependencies --dry-run plans deps but skips the requested formula" {
+    // Brew parity: --only-dependencies installs the transitive deps but
+    // never materialises or links the requested package. Captured stderr
+    // is the cheapest way to assert the plan's contents from the outside.
+    const prefix_z: [:0]const u8 = "/tmp/mod";
+    malt.fs_compat.deleteTreeAbsolute(prefix_z) catch {};
+    try malt.fs_compat.cwd().makePath(prefix_z);
+    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    defer malt.fs_compat.deleteTreeAbsolute(prefix_z) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const dep_json =
+        \\{"name":"beta","full_name":"beta","tap":"homebrew/core","desc":"","homepage":"",
+        \\ "versions":{"stable":"1.0"},"revision":0,"dependencies":[],"oldnames":[],
+        \\ "keg_only":false,"post_install_defined":false,
+        \\ "bottle":{"stable":{"root_url":"https://ghcr.io/v2/homebrew/core/beta/blobs",
+        \\   "files":{
+        \\     "arm64_sequoia":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"bb"},
+        \\     "arm64_sonoma":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"bb"},
+        \\     "arm64_ventura":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"bb"},
+        \\     "arm64_monterey":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"bb"},
+        \\     "sequoia":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"bx"},
+        \\     "sonoma":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"bx"},
+        \\     "ventura":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"bx"},
+        \\     "monterey":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"bx"}
+        \\   }}}}
+    ;
+    try seedFormulaCache(prefix_z, "beta", dep_json);
+
+    const root_json =
+        \\{"name":"alpha","full_name":"alpha","tap":"homebrew/core","desc":"","homepage":"",
+        \\ "versions":{"stable":"1.0"},"revision":0,"dependencies":["beta"],"oldnames":[],
+        \\ "keg_only":false,"post_install_defined":false,
+        \\ "bottle":{"stable":{"root_url":"https://ghcr.io/v2/homebrew/core/alpha/blobs",
+        \\   "files":{
+        \\     "arm64_sequoia":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_sonoma":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_ventura":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_monterey":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "sequoia":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"ax"},
+        \\     "sonoma":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"ax"},
+        \\     "ventura":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"ax"},
+        \\     "monterey":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"ax"}
+        \\   }}}}
+    ;
+    try seedFormulaCache(prefix_z, "alpha", root_json);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    // `output.quiet` is process-global; earlier tests in this file pass
+    // `--quiet` and leave it set. Reset so the dry-run plan reaches our capture.
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.io_mod.beginStderrCapture(testing.allocator, &captured);
+    defer malt.io_mod.endStderrCapture();
+
+    try install.execute(arena.allocator(), &.{ "--dry-run", "--only-dependencies", "alpha" });
+
+    // The dry-run plan header is the load-bearing observation: with the
+    // top-level filtered, only the single dep should land in the plan.
+    // (`alpha` still appears upstream in the "Resolved alpha …" log line
+    // emitted before the filter, so we anchor on the plan header instead.)
+    try testing.expect(std.mem.indexOf(u8, captured.items, "would install 1 package") != null);
+    try testing.expect(std.mem.indexOf(u8, captured.items, "beta 1.0 (dependency)") != null);
+    try testing.expect(std.mem.indexOf(u8, captured.items, "would install 2 packages") == null);
+}
+
 test "execute --dry-run routes a revisioned formula through the install pipeline" {
     // The dry-run path flows: ensureDirs → DB open → lock → cache hit
     // → collectFormulaJobs → print plan → return. A revisioned formula

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -799,3 +799,119 @@ test "collectFetchWorkerCount clamps to MAX_COLLECT_FETCH_WORKERS" {
     try testing.expectEqual(cap, install.collectFetchWorkerCount(40));
     try testing.expectEqual(cap, install.collectFetchWorkerCount(128));
 }
+
+// --- dropTopLevelJobs (--only-dependencies seam) ---
+
+/// Append a `DownloadJob` whose owned strings are duped into `alloc`.
+/// `formula_json` follows the production split: dep jobs own their JSON
+/// bytes (`is_dep=true`), top-level jobs borrow the caller's input
+/// (`is_dep=false`).
+fn appendOwnedJob(
+    alloc: std.mem.Allocator,
+    jobs: *std.ArrayList(install.DownloadJob),
+    name: []const u8,
+    is_dep: bool,
+    borrowed_json: []const u8,
+) !void {
+    const formula_json: []const u8 = if (is_dep) try alloc.dupe(u8, borrowed_json) else borrowed_json;
+    try jobs.append(alloc, .{
+        .name = try alloc.dupe(u8, name),
+        .version_str = try alloc.dupe(u8, "1.0"),
+        .sha256 = try alloc.dupe(u8, "aa"),
+        .bottle_url = try alloc.dupe(u8, "https://x"),
+        .is_dep = is_dep,
+        .keg_only = false,
+        .post_install_defined = false,
+        .formula_json = formula_json,
+        .cellar_type = try alloc.dupe(u8, ":any"),
+        .label_width = 0,
+        .line_index = 0,
+        .multi = null,
+        .bar = null,
+        .store_sha256 = "",
+        .succeeded = false,
+    });
+}
+
+test "dropTopLevelJobs removes the top-level job and frees its owned strings" {
+    // Under testing.allocator the helper must free the dropped job's name,
+    // version, sha, url, and cellar_type; otherwise the runner reports a leak.
+    const alloc = testing.allocator;
+    var jobs: std.ArrayList(install.DownloadJob) = .empty;
+    defer {
+        for (jobs.items) |j| {
+            alloc.free(j.name);
+            alloc.free(j.version_str);
+            alloc.free(j.sha256);
+            alloc.free(j.bottle_url);
+            alloc.free(j.cellar_type);
+            if (j.is_dep) alloc.free(j.formula_json);
+        }
+        jobs.deinit(alloc);
+    }
+
+    try appendOwnedJob(alloc, &jobs, "beta", true, "{}");
+    try appendOwnedJob(alloc, &jobs, "alpha", false, "{}");
+
+    install.dropTopLevelJobs(alloc, &jobs);
+
+    try testing.expectEqual(@as(usize, 1), jobs.items.len);
+    try testing.expectEqualStrings("beta", jobs.items[0].name);
+    try testing.expect(jobs.items[0].is_dep);
+}
+
+test "dropTopLevelJobs is a no-op when every job is a dep" {
+    const alloc = testing.allocator;
+    var jobs: std.ArrayList(install.DownloadJob) = .empty;
+    defer {
+        for (jobs.items) |j| {
+            alloc.free(j.name);
+            alloc.free(j.version_str);
+            alloc.free(j.sha256);
+            alloc.free(j.bottle_url);
+            alloc.free(j.cellar_type);
+            if (j.is_dep) alloc.free(j.formula_json);
+        }
+        jobs.deinit(alloc);
+    }
+
+    try appendOwnedJob(alloc, &jobs, "beta", true, "{}");
+    try appendOwnedJob(alloc, &jobs, "gamma", true, "{}");
+
+    install.dropTopLevelJobs(alloc, &jobs);
+
+    try testing.expectEqual(@as(usize, 2), jobs.items.len);
+    try testing.expectEqualStrings("beta", jobs.items[0].name);
+    try testing.expectEqualStrings("gamma", jobs.items[1].name);
+}
+
+test "dropTopLevelJobs preserves dep order across mixed lists" {
+    // Top-level jobs are appended *after* deps in collectFormulaJobs, but
+    // a multi-package install can interleave (alpha-deps, alpha, beta-deps,
+    // beta). Order matters because the link phase walks deps before
+    // dependents — anything out of order regresses findFailedDep.
+    const alloc = testing.allocator;
+    var jobs: std.ArrayList(install.DownloadJob) = .empty;
+    defer {
+        for (jobs.items) |j| {
+            alloc.free(j.name);
+            alloc.free(j.version_str);
+            alloc.free(j.sha256);
+            alloc.free(j.bottle_url);
+            alloc.free(j.cellar_type);
+            if (j.is_dep) alloc.free(j.formula_json);
+        }
+        jobs.deinit(alloc);
+    }
+
+    try appendOwnedJob(alloc, &jobs, "dep_a", true, "{}");
+    try appendOwnedJob(alloc, &jobs, "alpha", false, "{}");
+    try appendOwnedJob(alloc, &jobs, "dep_b", true, "{}");
+    try appendOwnedJob(alloc, &jobs, "beta", false, "{}");
+
+    install.dropTopLevelJobs(alloc, &jobs);
+
+    try testing.expectEqual(@as(usize, 2), jobs.items.len);
+    try testing.expectEqualStrings("dep_a", jobs.items[0].name);
+    try testing.expectEqualStrings("dep_b", jobs.items[1].name);
+}

--- a/tests/list_test.zig
+++ b/tests/list_test.zig
@@ -74,6 +74,63 @@ fn trimTimeSuffix(out: []const u8) []const u8 {
     return out;
 }
 
+/// Emit `writeHumanOutput` into a freshly allocated buffer with `quiet`
+/// honoured around the call so the global state mutation never leaks
+/// to neighbouring tests.
+fn runHuman(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    show_formula: bool,
+    show_cask: bool,
+    show_versions: bool,
+    show_pinned: bool,
+    quiet: bool,
+) ![]u8 {
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(quiet);
+    defer malt.output.setQuiet(prior_quiet);
+    // `writeHumanOutput` reads colour state via the global; pin to no-color
+    // so assertions below stay independent of the host terminal.
+    malt.color.setForTest(false, false);
+    defer malt.color.setForTest(null, null);
+
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    errdefer aw.deinit();
+    try cli_list.writeHumanOutput(db, show_formula, show_cask, show_versions, show_pinned, &aw.writer);
+    return aw.toOwnedSlice();
+}
+
+test "writeHumanOutput honours --quiet: names only, no bullet, no decorations" {
+    // The help text advertises `--quiet, -q  Names only, one per line`,
+    // which makes the output script-parseable. Decorations (bullet, version
+    // suffix, [pinned] tag) must all be suppressed under quiet mode.
+    var t = try TempDb.init("human_quiet");
+    defer t.deinit();
+    try insertKeg(&t.db, "alpha", "1.0", false);
+    try insertKeg(&t.db, "bravo", "2.1", true);
+    try insertCask(&t.db, "charlie", "3.0");
+
+    const out = try runHuman(testing.allocator, &t.db, true, true, true, false, true);
+    defer testing.allocator.free(out);
+
+    try testing.expectEqualStrings("alpha\nbravo\ncharlie\n", out);
+}
+
+test "writeHumanOutput non-quiet keeps the bullet prefix and decorations" {
+    // Regression guard: the quiet fix must not strip decorations from the
+    // default human output that interactive users expect.
+    var t = try TempDb.init("human_decorated");
+    defer t.deinit();
+    try insertKeg(&t.db, "alpha", "1.0", true);
+
+    const out = try runHuman(testing.allocator, &t.db, true, false, true, false, false);
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "  ▸ alpha") != null);
+    try testing.expect(std.mem.indexOf(u8, out, " (1.0)") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "[pinned]") != null);
+}
+
 test "buildListJson: empty DB, both flags" {
     var t = try TempDb.init("empty");
     defer t.deinit();


### PR DESCRIPTION
## Summary

`mt install --only-dependencies <pkg>` resolves the dep graph, installs every transitive dep, then skips the requested package's materialise + link. Brew parity for warming the store before building a package from source, or seeding a Brewfile environment without forcing the top-level binaries onto the system.

Surviving deps stay on the existing `install_reason='dependency'` rail, so `mt purge --unused-deps` reclaims them once nothing direct retains them. No schema change.

## Related issue 

- None

## Notes for Reviewers

- None