### PR TITLE
feat(cli/services): logs --follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ mt services restart postgresql@16
 mt services status postgresql@16         # combined DB + launchctl state
 mt services logs postgresql@16 --tail 50 # last 50 lines of stdout
 mt services logs postgresql@16 --stderr  # read stderr instead
+mt services logs postgresql@16 -f        # tail and follow until SIGINT
 ```
 
 | Subcommand | Description                                                                |
@@ -512,7 +513,7 @@ mt services logs postgresql@16 --stderr  # read stderr instead
 | `stop`     | `launchctl bootout` the service                                            |
 | `restart`  | `stop` then `start`                                                        |
 | `status`   | Combined DB record + live `launchctl list` state                           |
-| `logs`     | Tail `stdout.log` (or `stderr.log` with `--stderr`); `--tail N` sets count |
+| `logs`     | Tail `stdout.log` (or `stderr.log` with `--stderr`); `--tail N` sets count, `--follow`/`-f` streams appended bytes until SIGINT |
 
 Services are registered automatically when an installed formula carries a `service` block (e.g. `postgresql@16`, `redis`). State lives at `{prefix}/var/malt/services/<name>/` (plist + log files) and in the SQLite `services` table. Currently macOS-only — Linux/Windows return `OsNotSupported`.
 

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -151,7 +151,7 @@ pub const bash_script =
     \\        which)            cmd_flags="--json" ;;
     \\        migrate|rollback) cmd_flags="--dry-run" ;;
     \\        link)             cmd_flags="--overwrite --force -f" ;;
-    \\        services)         cmd_flags="--tail --stderr --system --json" ;;
+    \\        services)         cmd_flags="--tail --stderr --follow -f --system --json" ;;
     \\        bundle)           cmd_flags="--dry-run --format --from-installed --purge" ;;
     \\    esac
     \\
@@ -570,6 +570,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command services' -f -a 'logs'    -d 'Tail a service log'
     \\    complete -c $__malt_bin -n '__malt_using_command services' -l tail   -d 'Number of trailing log lines'
     \\    complete -c $__malt_bin -n '__malt_using_command services' -l stderr -d 'Read stderr instead of stdout'
+    \\    complete -c $__malt_bin -n '__malt_using_command services' -l follow -s f -d 'Tail appended bytes until SIGINT'
     \\
     \\    # bundle — sub-subcommands
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -f -a 'install' -d 'Install Brewfile/Maltfile.json members'

--- a/src/cli/services.zig
+++ b/src/cli/services.zig
@@ -119,6 +119,7 @@ fn cmdLogs(allocator: std.mem.Allocator, rest: []const []const u8) !void {
     const name = rest[0];
     var tail_n: usize = 50;
     var stream: enum { stdout, stderr } = .stdout;
+    var follow = false;
     var i: usize = 1;
     while (i < rest.len) : (i += 1) {
         const a = rest[i];
@@ -127,6 +128,8 @@ fn cmdLogs(allocator: std.mem.Allocator, rest: []const []const u8) !void {
             tail_n = std.fmt.parseInt(usize, rest[i], 10) catch 50;
         } else if (std.mem.eql(u8, a, "--stderr")) {
             stream = .stderr;
+        } else if (std.mem.eql(u8, a, "--follow") or std.mem.eql(u8, a, "-f")) {
+            follow = true;
         }
     }
     const path = try supervisor.logPath(allocator, name, if (stream == .stdout) .stdout else .stderr);
@@ -135,7 +138,12 @@ fn cmdLogs(allocator: std.mem.Allocator, rest: []const []const u8) !void {
     var write_buf: [4096]u8 = undefined;
     var stdout_writer = stdout.writer(&write_buf);
     const w = &stdout_writer.interface;
-    try supervisor.tailLog(allocator, path, tail_n, w);
+    if (follow) {
+        const main_mod = @import("../main.zig");
+        try supervisor.followLog(allocator, path, tail_n, w, main_mod.isInterrupted);
+    } else {
+        try supervisor.tailLog(allocator, path, tail_n, w);
+    }
     try w.flush();
 }
 
@@ -162,8 +170,9 @@ fn printHelp() !void {
         \\  stop <name>       Boot the service out of launchd.
         \\  restart <name>    stop then start.
         \\  status [name]     Show registered state (falls back to list).
-        \\  logs <name> [--tail N] [--stderr]
+        \\  logs <name> [--tail N] [--stderr] [--follow|-f]
         \\                    Print the last N lines of the service log.
+        \\                    --follow / -f tails appended bytes until SIGINT.
         \\
     ;
     const f = fs_compat.stderrFile();

--- a/src/core/services/supervisor.zig
+++ b/src/core/services/supervisor.zig
@@ -384,3 +384,118 @@ pub fn tailLog(allocator: std.mem.Allocator, path: []const u8, n: usize, writer:
     }
     writer.writeAll(slice[start_at..]) catch return SupervisorError.IoFailed;
 }
+
+/// Tail `path` and stream appended bytes until `interrupted()` returns true.
+/// `interrupted` is the caller's seam onto SIGINT (or any other stop signal);
+/// keeping it as a callback keeps this module free of CLI/main coupling.
+pub fn followLog(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    tail_n: usize,
+    writer: *std.Io.Writer,
+    interrupted: *const fn () bool,
+) SupervisorError!void {
+    try tailLog(allocator, path, tail_n, writer);
+    writer.flush() catch return SupervisorError.IoFailed;
+
+    const f = fs_compat.openFileAbsolute(path, .{}) catch return SupervisorError.IoFailed;
+    defer f.close();
+    var offset: u64 = (f.stat() catch return SupervisorError.IoFailed).size;
+
+    var buf: [4096]u8 = undefined;
+    // 200 ms cadence is plenty for human-scale tails.
+    const poll_ns: u64 = 200 * std.time.ns_per_ms;
+    while (!interrupted()) {
+        const n = f.readAllAt(&buf, offset) catch return SupervisorError.IoFailed;
+        if (n == 0) {
+            fs_compat.sleepNanos(poll_ns);
+            continue;
+        }
+        writer.writeAll(buf[0..n]) catch return SupervisorError.IoFailed;
+        writer.flush() catch return SupervisorError.IoFailed;
+        offset += n;
+    }
+}
+
+const testing = std.testing;
+
+// Static state lets the interrupt callback drive a deterministic follow-loop
+// scenario in tests without spawning a real thread or signal.
+const FollowProbe = struct {
+    var calls: usize = 0;
+    var stop_at: usize = 1;
+    var append_at: usize = 0;
+    var append_path: []const u8 = "";
+    var append_bytes: []const u8 = "";
+
+    fn reset() void {
+        calls = 0;
+        stop_at = 1;
+        append_at = 0;
+        append_path = "";
+        append_bytes = "";
+    }
+
+    fn cb() bool {
+        calls += 1;
+        if (append_at != 0 and calls == append_at) {
+            const f = fs_compat.openFileAbsolute(append_path, .{ .mode = .read_write }) catch return true;
+            defer f.close();
+            const st = f.stat() catch return true;
+            f.writeAllAt(append_bytes, st.size) catch {};
+        }
+        return calls >= stop_at;
+    }
+};
+
+test "followLog prints initial tail and exits when interrupt is set before first poll" {
+    const dir = "/tmp/malt_supervisor_follow_interrupt";
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    try fs_compat.makeDirAbsolute(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    const log_path = dir ++ "/sample.log";
+    {
+        const f = try fs_compat.createFileAbsolute(log_path, .{ .truncate = true });
+        defer f.close();
+        try f.writeAll("first\nsecond\n");
+    }
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    FollowProbe.reset();
+    FollowProbe.stop_at = 1;
+    try followLog(testing.allocator, log_path, 2, &aw.writer, FollowProbe.cb);
+
+    try testing.expectEqualStrings("first\nsecond\n", aw.written());
+    try testing.expectEqual(@as(usize, 1), FollowProbe.calls);
+}
+
+test "followLog flushes appended bytes between polls" {
+    const dir = "/tmp/malt_supervisor_follow_poll";
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    try fs_compat.makeDirAbsolute(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    const log_path = dir ++ "/sample.log";
+    {
+        const f = try fs_compat.createFileAbsolute(log_path, .{ .truncate = true });
+        defer f.close();
+        try f.writeAll("seed\n");
+    }
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    FollowProbe.reset();
+    FollowProbe.append_path = log_path;
+    FollowProbe.append_bytes = "appended\n";
+    FollowProbe.append_at = 1;
+    FollowProbe.stop_at = 3;
+
+    try followLog(testing.allocator, log_path, 0, &aw.writer, FollowProbe.cb);
+
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "appended\n") != null);
+    try testing.expectEqual(@as(usize, 3), FollowProbe.calls);
+}


### PR DESCRIPTION
## Description

`mt services logs <name> --follow` (or `-f`) prints the existing tail and then keeps streaming bytes appended to the service's log until SIGINT. Brings the command in line with every other `*tail`/`logs` tool a developer reaches for when chasing a flapping service.

## Related Issue

- None

## Notes for Reviewers

- None