### PR TITLE
feat(cli/run): --keep for cached ephemeral runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,13 +506,13 @@ mt services logs postgresql@16 --stderr  # read stderr instead
 mt services logs postgresql@16 -f        # tail and follow until SIGINT
 ```
 
-| Subcommand | Description                                                                |
-| ---------- | -------------------------------------------------------------------------- |
-| `list`     | Show every registered service with `running` / `loaded` / `stopped`        |
-| `start`    | Generate and `launchctl bootstrap` the service into `gui/<uid>`            |
-| `stop`     | `launchctl bootout` the service                                            |
-| `restart`  | `stop` then `start`                                                        |
-| `status`   | Combined DB record + live `launchctl list` state                           |
+| Subcommand | Description                                                                                                                     |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `list`     | Show every registered service with `running` / `loaded` / `stopped`                                                             |
+| `start`    | Generate and `launchctl bootstrap` the service into `gui/<uid>`                                                                 |
+| `stop`     | `launchctl bootout` the service                                                                                                 |
+| `restart`  | `stop` then `start`                                                                                                             |
+| `status`   | Combined DB record + live `launchctl list` state                                                                                |
 | `logs`     | Tail `stdout.log` (or `stderr.log` with `--stderr`); `--tail N` sets count, `--follow`/`-f` streams appended bytes until SIGINT |
 
 Services are registered automatically when an installed formula carries a `service` block (e.g. `postgresql@16`, `redis`). State lives at `{prefix}/var/malt/services/<name>/` (plist + log files) and in the SQLite `services` table. Currently macOS-only — Linux/Windows return `OsNotSupported`.
@@ -573,9 +573,12 @@ Run a package binary without installing it.
 mt run <package> -- <args...>
 mt run jq -- --version
 mt run ripgrep -- --help
+mt run --keep jq -- --version          # cache the bottle for next run
 ```
 
 Downloads the bottle to a temp directory, extracts the binary, executes it with the provided arguments, and cleans up. If the package is already installed, runs the installed binary directly.
+
+Pass `--keep` to extract under `{cache}/run/<sha256>/` instead of the temp dir; subsequent `mt run` calls for the same bottle skip the download and start instantly. The cache is wiped by `mt purge --cache`.
 
 ### `mt link` / `mt unlink`
 

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -162,6 +162,10 @@ done
 
 # Alias dispatch (`mt` and `malt` both installed in zig-out/bin).
 run_ok t1.alias.mt -- "$(dirname "$MT_BIN")/mt" version
+
+# Help surfaces every documented flag — fast guard against a flag silently
+# disappearing from the help text when its impl gets refactored.
+run_grep t1.help.run.keep '\-\-keep' -- "$MT_BIN" run --help
 # --cleanup is a local-only operation; no network, safe in tier 1.
 run_ok t1.version.update.cleanup -- "$MT_BIN" version update --cleanup
 
@@ -244,11 +248,22 @@ else
 
   # run: already-installed path (no re-download).
   run_ok t3.run.tree -- "$MT_BIN" run tree -- --version
+  # --keep flag must parse on the installed path even though caching
+  # only kicks in for the ephemeral download branch.
+  run_ok t3.run.keep.tree -- "$MT_BIN" run --keep tree -- --version
 
   # purge dry-runs only — never destructive here.
   run_ok t3.purge.store.dry -- "$MT_BIN" purge --store-orphans --dry-run
   run_ok t3.purge.house.dry -- "$MT_BIN" purge --housekeeping --dry-run
   run_ok t3.purge.cache.dry -- "$MT_BIN" purge --cache=7 --dry-run
+
+  # T-060 AC: --keep populates {cache}/run/<sha>/ and a sibling .lock file;
+  # `mt purge --cache` must reach both. Pre-populate a stale slot so the
+  # mtime-based pruner picks it up, then assert the dry-run sees it.
+  mkdir -p "$CACHE/run/maltsmokeslot/jq/1.0/bin"
+  touch -t 202001010000 "$CACHE/run/maltsmokeslot/jq/1.0/bin/jq"
+  touch -t 202001010000 "$CACHE/run/maltsmokeslot.lock"
+  run_grep t3.purge.cache.run-slot 'maltsmokeslot' -- "$MT_BIN" purge --cache=1 --dry-run
 
   # uninstall — removes from sandbox.
   run_ok t3.uninstall -- "$MT_BIN" uninstall tree

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -153,6 +153,7 @@ pub const bash_script =
     \\        link)             cmd_flags="--overwrite --force -f" ;;
     \\        services)         cmd_flags="--tail --stderr --follow -f --system --json" ;;
     \\        bundle)           cmd_flags="--dry-run --format --from-installed --purge" ;;
+    \\        run)              cmd_flags="--keep" ;;
     \\    esac
     \\
     \\    if [[ "$cur" == -* ]]; then
@@ -266,6 +267,11 @@ pub const zsh_script =
     \\                    ;;
     \\                pin|unpin)
     \\                    _arguments '*::keg:'
+    \\                    ;;
+    \\                run)
+    \\                    _arguments \
+    \\                        '--keep[Cache extracted bottle under {cache}/run/<sha256>/]' \
+    \\                        '*::package:'
     \\                    ;;
     \\                which)
     \\                    _arguments \
@@ -526,6 +532,9 @@ pub const fish_script =
     \\    # link
     \\    complete -c $__malt_bin -n '__malt_using_command link' -l overwrite -d 'Replace existing symlinks'
     \\    complete -c $__malt_bin -n '__malt_using_command link' -s f -l force -d 'Same as --overwrite'
+    \\
+    \\    # run
+    \\    complete -c $__malt_bin -n '__malt_using_command run' -l keep -d 'Cache extracted bottle under {cache}/run/<sha256>/'
     \\
     \\    # completions — shell name as positional
     \\    complete -c $__malt_bin -n '__malt_using_command completions' -f -a 'bash zsh fish'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -219,14 +219,20 @@ const rollback_help =
 ;
 
 const run_help =
-    \\Usage: malt run <package> [-- <args...>]
+    \\Usage: malt run [--keep] <package> [-- <args...>]
     \\
     \\Run a package binary without installing it. Downloads to a
     \\temp directory, executes, and cleans up. If the package is
     \\already installed, runs the installed binary directly.
     \\
+    \\Flags:
+    \\  --keep    Cache the extracted bottle under {cache}/run/<sha256>/
+    \\            so subsequent runs skip download. Wipe with
+    \\            `mt purge --cache`.
+    \\
     \\Example:
     \\  malt run jq -- --version
+    \\  malt run --keep jq -- --version
     \\
 ;
 

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -1,67 +1,126 @@
 //! malt — run command
 //! Run a package binary without installing — download to temp, execute, clean up.
+//! `--keep` extracts under {cache}/run/<sha256>/ so subsequent runs skip download.
 
 const std = @import("std");
 const fs_compat = @import("../fs/compat.zig");
-const sqlite = @import("../db/sqlite.zig");
-const schema = @import("../db/schema.zig");
 const formula_mod = @import("../core/formula.zig");
 const bottle_mod = @import("../core/bottle.zig");
-const cellar = @import("../core/cellar.zig");
 const client_mod = @import("../net/client.zig");
 const ghcr_mod = @import("../net/ghcr.zig");
 const api_mod = @import("../net/api.zig");
 const atomic = @import("../fs/atomic.zig");
+const lock_mod = @import("../db/lock.zig");
 const output = @import("../ui/output.zig");
 const help = @import("help.zig");
+
+/// Cap on how long a peer holding `{cache}/run/<sha>.lock` can keep us
+/// waiting before we surface the contention as a hard error. Tunable
+/// via `MALT_RUN_KEEP_LOCK_TIMEOUT_MS` so CI / slow-link users can raise it.
+const default_keep_lock_timeout_ms: u32 = 300_000;
+
+fn keepLockTimeoutMs() u32 {
+    if (fs_compat.getenv("MALT_RUN_KEEP_LOCK_TIMEOUT_MS")) |v| {
+        return std.fmt.parseInt(u32, std.mem.sliceTo(v, 0), 10) catch default_keep_lock_timeout_ms;
+    }
+    return default_keep_lock_timeout_ms;
+}
+
+/// Release-and-clear: scattered call sites would otherwise drift on the
+/// release/null pairing and silently leak the lock fd into exec.
+fn releaseKeepLock(slot: *?lock_mod.LockFile) void {
+    if (slot.*) |*lk| lk.release();
+    slot.* = null;
+}
+
+pub const ParsedArgs = struct {
+    pkg_name: []const u8,
+    keep: bool,
+    cmd_args: []const []const u8,
+};
+
+/// Parse `mt run` argv into package name, --keep flag, and command args after `--`.
+/// Accepts `--keep` in any position before the `--` separator. Returns null when
+/// no package name is present so callers can surface usage.
+pub fn parseArgs(args: []const []const u8) ?ParsedArgs {
+    var keep = false;
+    var pkg_name: ?[]const u8 = null;
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        if (std.mem.eql(u8, arg, "--")) {
+            const cmd_args = if (i + 1 < args.len) args[i + 1 ..] else &[_][]const u8{};
+            if (pkg_name) |name| return .{ .pkg_name = name, .keep = keep, .cmd_args = cmd_args };
+            return null;
+        }
+        if (std.mem.eql(u8, arg, "--keep")) {
+            keep = true;
+            continue;
+        }
+        if (pkg_name == null) pkg_name = arg;
+    }
+    if (pkg_name) |name| return .{ .pkg_name = name, .keep = keep, .cmd_args = &[_][]const u8{} };
+    return null;
+}
+
+/// Format `{cache_dir}/run/<sha256>` into `buf`. PathTooLong distinguishes
+/// overflow from allocation failure for callers that surface the cause.
+pub fn buildKeepCachePath(buf: []u8, cache_dir: []const u8, sha256: []const u8) error{PathTooLong}![]const u8 {
+    return std.fmt.bufPrint(buf, "{s}/run/{s}", .{ cache_dir, sha256 }) catch error.PathTooLong;
+}
+
+/// Sibling lock file for the cache slot. Lives next to (not inside) the
+/// slot so wiping the slot on a re-extract leaves the lock file intact.
+pub fn buildKeepLockPath(buf: []u8, cache_dir: []const u8, sha256: []const u8) error{PathTooLong}![]const u8 {
+    return std.fmt.bufPrint(buf, "{s}/run/{s}.lock", .{ cache_dir, sha256 }) catch error.PathTooLong;
+}
+
+/// Probe `{cache_dir}/run/<sha>/<pkg>/<ver>/bin/<pkg>`. Returns the path
+/// (borrowed from `buf`) on hit, null on miss.
+pub fn findCachedBinary(
+    buf: []u8,
+    cache_dir: []const u8,
+    sha256: []const u8,
+    pkg_name: []const u8,
+    version: []const u8,
+) error{PathTooLong}!?[]const u8 {
+    const bin_path = std.fmt.bufPrint(buf, "{s}/run/{s}/{s}/{s}/bin/{s}", .{
+        cache_dir, sha256, pkg_name, version, pkg_name,
+    }) catch return error.PathTooLong;
+    fs_compat.accessAbsolute(bin_path, .{}) catch return null;
+    return bin_path;
+}
 
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "run")) return;
 
-    if (args.len == 0) {
-        output.err("Usage: mt run <package> [-- <args...>]", .{});
+    const parsed = parseArgs(args) orelse {
+        output.err("Usage: mt run [--keep] <package> [-- <args...>]", .{});
         output.info("Example: mt run jq -- --version", .{});
         return error.Aborted;
-    }
-
-    const pkg_name = args[0];
-
-    // Split args at "--" into package args and command args
-    var cmd_args_start: usize = args.len;
-    for (args[1..], 1..) |arg, i| {
-        if (std.mem.eql(u8, arg, "--")) {
-            cmd_args_start = i + 1;
-            break;
-        }
-    }
-    const cmd_args = if (cmd_args_start < args.len) args[cmd_args_start..] else &[_][]const u8{};
+    };
 
     const prefix = atomic.maltPrefix();
 
-    // Check if already installed — if so, just run it
-    {
-        var bin_buf: [512]u8 = undefined;
-        const bin_path = std.fmt.bufPrint(&bin_buf, "{s}/bin/{s}", .{ prefix, pkg_name }) catch return;
-        fs_compat.accessAbsolute(bin_path, .{}) catch {
-            // Not installed — proceed with ephemeral run
-            return ephemeralRun(allocator, pkg_name, cmd_args, prefix);
-        };
+    var bin_buf: [512]u8 = undefined;
+    const installed_bin = std.fmt.bufPrint(&bin_buf, "{s}/bin/{s}", .{ prefix, parsed.pkg_name }) catch return;
+    fs_compat.accessAbsolute(installed_bin, .{}) catch {
+        return ephemeralRun(allocator, parsed.pkg_name, parsed.cmd_args, parsed.keep, prefix);
+    };
 
-        // Already installed — just exec it
-        output.info("Running installed {s}...", .{pkg_name});
-        return try execBinary(allocator, bin_path, cmd_args);
-    }
+    output.info("Running installed {s}...", .{parsed.pkg_name});
+    return try execBinary(allocator, installed_bin, parsed.cmd_args);
 }
 
 fn ephemeralRun(
     allocator: std.mem.Allocator,
     pkg_name: []const u8,
     cmd_args: []const []const u8,
+    keep: bool,
     prefix: []const u8,
 ) !void {
     output.info("Fetching {s} for ephemeral run...", .{pkg_name});
 
-    // Set up HTTP + API
     var http = client_mod.HttpClient.init(allocator);
     defer http.deinit();
 
@@ -69,7 +128,6 @@ fn ephemeralRun(
     const cache_dir = std.fmt.bufPrint(&cache_buf, "{s}/cache", .{prefix}) catch return;
     var api = api_mod.BrewApi.init(allocator, &http, cache_dir);
 
-    // Fetch formula
     const formula_json = api.fetchFormula(pkg_name) catch {
         output.err("Formula '{s}' not found", .{pkg_name});
         return error.Aborted;
@@ -82,27 +140,90 @@ fn ephemeralRun(
     };
     defer formula.deinit();
 
-    // Select bottle
     const bottle = formula_mod.resolveBottle(allocator, &formula) catch {
         output.err("No bottle available for {s} on this platform", .{pkg_name});
         return error.Aborted;
     };
 
-    // Set up GHCR
+    // Per-slot lock serializes parallel `mt run --keep <pkg>` so two
+    // peers don't truncate one another's bottle.tar.gz mid-extract.
+    var keep_lock: ?lock_mod.LockFile = null;
+    errdefer releaseKeepLock(&keep_lock);
+
+    if (keep) {
+        var run_root_buf: [512]u8 = undefined;
+        const run_root = std.fmt.bufPrint(&run_root_buf, "{s}/run", .{cache_dir}) catch {
+            output.err("Cache root path too long for {s}", .{pkg_name});
+            return error.Aborted;
+        };
+        // Lock file needs the run/ root to exist before open(O_CREAT).
+        fs_compat.cwd().makePath(run_root) catch {
+            output.err("Failed to create run cache root", .{});
+            return error.Aborted;
+        };
+
+        var lock_buf: [512]u8 = undefined;
+        const lock_path = buildKeepLockPath(&lock_buf, cache_dir, bottle.sha256) catch {
+            output.err("Cache lock path too long for {s}", .{pkg_name});
+            return error.Aborted;
+        };
+        keep_lock = lock_mod.LockFile.acquire(lock_path, keepLockTimeoutMs()) catch |e| {
+            if (e == error.Timeout) {
+                if (lock_mod.LockFile.holderPid(lock_path)) |pid| {
+                    output.err("Another `mt run --keep` for {s} is in progress (pid {d})", .{ pkg_name, pid });
+                } else {
+                    output.err("Another `mt run --keep` for {s} is in progress", .{pkg_name});
+                }
+            } else {
+                output.err("Failed to acquire run cache lock for {s}", .{pkg_name});
+            }
+            return error.Aborted;
+        };
+
+        // Probe under the lock — a peer that just released may have populated the slot.
+        var hit_buf: [512]u8 = undefined;
+        if (findCachedBinary(&hit_buf, cache_dir, bottle.sha256, pkg_name, formula.version) catch null) |cached_bin| {
+            // Drop the lock before exec so peers can run the cached binary unblocked.
+            releaseKeepLock(&keep_lock);
+            output.info("Running cached {s} {s}...", .{ pkg_name, formula.version });
+            return try execBinary(allocator, cached_bin, cmd_args);
+        }
+    }
+
     var ghcr = ghcr_mod.GhcrClient.init(allocator, &http);
     defer ghcr.deinit();
 
-    // Create temp dir
-    const tmp_dir = atomic.createTempDir(allocator, "run") catch {
-        output.err("Failed to create temp directory", .{});
-        return error.Aborted;
+    // Cache slot under {cache} so `mt purge --cache` wipes it; a tmp dir otherwise.
+    var keep_dest_buf: [512]u8 = undefined;
+    var dest_dir: []const u8 = undefined;
+    var owned_tmp: ?[]const u8 = null;
+    defer if (owned_tmp) |p| {
+        atomic.cleanupTempDir(p);
+        allocator.free(p);
     };
-    defer {
-        atomic.cleanupTempDir(tmp_dir);
-        allocator.free(tmp_dir);
-    }
 
-    // Extract repo + digest from bottle URL
+    if (keep) {
+        dest_dir = buildKeepCachePath(&keep_dest_buf, cache_dir, bottle.sha256) catch {
+            output.err("Cache path too long for {s}", .{pkg_name});
+            return error.Aborted;
+        };
+        // Wipe stale partial state from a prior aborted run so the
+        // tar extractor never trips on pre-existing entries.
+        fs_compat.deleteTreeAbsolute(dest_dir) catch {};
+        fs_compat.cwd().makePath(dest_dir) catch {
+            output.err("Failed to create run cache directory", .{});
+            return error.Aborted;
+        };
+    } else {
+        owned_tmp = atomic.createTempDir(allocator, "run") catch {
+            output.err("Failed to create temp directory", .{});
+            return error.Aborted;
+        };
+        dest_dir = owned_tmp.?;
+    }
+    // Half-extracted cache slot is poison for the next --keep run; wipe on failure.
+    errdefer if (keep) fs_compat.deleteTreeAbsolute(dest_dir) catch {};
+
     const ghcr_prefix = "https://ghcr.io/v2/";
     var repo_buf: [256]u8 = undefined;
     var digest_buf: [128]u8 = undefined;
@@ -117,17 +238,15 @@ fn ephemeralRun(
         } else return;
     } else return;
 
-    // Download
     output.info("Downloading {s} {s}...", .{ pkg_name, formula.version });
-    _ = bottle_mod.download(allocator, &ghcr, &http, repo, digest, bottle.sha256, tmp_dir, null) catch {
+    _ = bottle_mod.download(allocator, &ghcr, &http, repo, digest, bottle.sha256, dest_dir, null) catch {
         output.err("Failed to download {s}", .{pkg_name});
         return error.Aborted;
     };
 
-    // Find the binary in the extracted contents
     var bin_path_buf: [512]u8 = undefined;
     const bin_path = std.fmt.bufPrint(&bin_path_buf, "{s}/{s}/{s}/bin/{s}", .{
-        tmp_dir,
+        dest_dir,
         pkg_name,
         formula.version,
         pkg_name,
@@ -138,7 +257,6 @@ fn ephemeralRun(
         return error.Aborted;
     };
 
-    // Make executable
     {
         const f = fs_compat.openFileAbsolute(bin_path, .{ .mode = .read_write }) catch return;
         defer f.close();
@@ -146,7 +264,15 @@ fn ephemeralRun(
         f.chmod(0o755) catch {};
     }
 
-    output.info("Running {s} {s} (ephemeral)...", .{ pkg_name, formula.version });
+    // Slot fully populated; let waiting peers in before we hand off to exec.
+    if (keep_lock) |*lk| lk.release();
+    keep_lock = null;
+
+    if (keep) {
+        output.info("Running {s} {s} (cached)...", .{ pkg_name, formula.version });
+    } else {
+        output.info("Running {s} {s} (ephemeral)...", .{ pkg_name, formula.version });
+    }
     const stderr = fs_compat.stderrFile();
     // Separator is purely cosmetic; a closed stderr shouldn't kill the run.
     stderr.writeAll("---\n") catch {};
@@ -170,4 +296,75 @@ fn execBinary(allocator: std.mem.Allocator, path: []const u8, cmd_args: []const 
     };
     // Ephemeral run is fire-and-forget; child exit code isn't surfaced to the shell.
     _ = child.wait() catch {};
+}
+
+test "parseArgs splits at double dash" {
+    const args = [_][]const u8{ "jq", "--arg", "--", "--version", "-r" };
+    const parsed = parseArgs(&args).?;
+    try std.testing.expectEqualStrings("jq", parsed.pkg_name);
+    try std.testing.expect(!parsed.keep);
+    try std.testing.expectEqual(@as(usize, 2), parsed.cmd_args.len);
+    try std.testing.expectEqualStrings("--version", parsed.cmd_args[0]);
+    try std.testing.expectEqualStrings("-r", parsed.cmd_args[1]);
+}
+
+test "parseArgs without double dash has no command args" {
+    const args = [_][]const u8{"jq"};
+    const parsed = parseArgs(&args).?;
+    try std.testing.expectEqualStrings("jq", parsed.pkg_name);
+    try std.testing.expect(!parsed.keep);
+    try std.testing.expectEqual(@as(usize, 0), parsed.cmd_args.len);
+}
+
+test "parseArgs detects --keep before package name" {
+    const args = [_][]const u8{ "--keep", "jq", "--", "--version" };
+    const parsed = parseArgs(&args).?;
+    try std.testing.expectEqualStrings("jq", parsed.pkg_name);
+    try std.testing.expect(parsed.keep);
+    try std.testing.expectEqual(@as(usize, 1), parsed.cmd_args.len);
+    try std.testing.expectEqualStrings("--version", parsed.cmd_args[0]);
+}
+
+test "parseArgs detects --keep after package name" {
+    const args = [_][]const u8{ "jq", "--keep", "--", "--version" };
+    const parsed = parseArgs(&args).?;
+    try std.testing.expectEqualStrings("jq", parsed.pkg_name);
+    try std.testing.expect(parsed.keep);
+    try std.testing.expectEqual(@as(usize, 1), parsed.cmd_args.len);
+}
+
+test "parseArgs returns null for empty args" {
+    try std.testing.expect(parseArgs(&[_][]const u8{}) == null);
+}
+
+test "parseArgs returns null when only --keep is given" {
+    try std.testing.expect(parseArgs(&[_][]const u8{"--keep"}) == null);
+}
+
+test "buildKeepCachePath joins cache_dir, sha256, and run subpath" {
+    var buf: [512]u8 = undefined;
+    const path = try buildKeepCachePath(&buf, "/opt/malt/cache", "deadbeef");
+    try std.testing.expectEqualStrings("/opt/malt/cache/run/deadbeef", path);
+}
+
+test "buildKeepCachePath surfaces PathTooLong on overflow" {
+    var buf: [16]u8 = undefined;
+    try std.testing.expectError(
+        error.PathTooLong,
+        buildKeepCachePath(&buf, "/opt/malt/cache", "deadbeef"),
+    );
+}
+
+test "buildKeepLockPath sits next to the slot, not inside it" {
+    var buf: [512]u8 = undefined;
+    const path = try buildKeepLockPath(&buf, "/opt/malt/cache", "deadbeef");
+    try std.testing.expectEqualStrings("/opt/malt/cache/run/deadbeef.lock", path);
+}
+
+test "buildKeepLockPath surfaces PathTooLong on overflow" {
+    var buf: [16]u8 = undefined;
+    try std.testing.expectError(
+        error.PathTooLong,
+        buildKeepLockPath(&buf, "/opt/malt/cache", "deadbeef"),
+    );
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -56,6 +56,7 @@ pub const update_verify = @import("update/verify.zig");
 pub const update_swap = @import("update/swap.zig");
 pub const cli_list = @import("cli/list.zig");
 pub const cli_pin = @import("cli/pin.zig");
+pub const cli_run = @import("cli/run.zig");
 pub const cli_tap = @import("cli/tap.zig");
 pub const cli_rollback = @import("cli/rollback.zig");
 pub const tap = @import("core/tap.zig");

--- a/tests/run_test.zig
+++ b/tests/run_test.zig
@@ -1,34 +1,111 @@
-//! malt — run (ephemeral execution) tests
-//! Network-dependent tests are deferred; unit tests cover argument parsing.
+//! malt — run command integration tests
+//!
+//! Pure parsing and path-formatting tests live inline in `src/cli/run.zig`.
+//! This file covers the `--keep` cache lookup against a real on-disk layout.
 
 const std = @import("std");
+const malt = @import("malt");
 const testing = std.testing;
+const cli_run = malt.cli_run;
 
-test "argument split at double dash" {
-    const args = [_][]const u8{ "jq", "--arg", "--", "--version", "-r" };
-    var cmd_args_start: usize = args.len;
-    for (args[1..], 1..) |arg, i| {
-        if (std.mem.eql(u8, arg, "--")) {
-            cmd_args_start = i + 1;
-            break;
-        }
-    }
-    const cmd_args = if (cmd_args_start < args.len) args[cmd_args_start..] else &[_][]const u8{};
+test "findCachedBinary returns the path when the cached binary exists" {
+    const base = "/tmp/malt_run_keep_hit";
+    malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(base) catch {};
 
-    try testing.expectEqual(@as(usize, 2), cmd_args.len);
-    try testing.expectEqualStrings("--version", cmd_args[0]);
-    try testing.expectEqualStrings("-r", cmd_args[1]);
+    const sha = "abc123";
+    const pkg = "jq";
+    const ver = "1.7.1";
+
+    const bin_dir = try std.fmt.allocPrint(testing.allocator, "{s}/run/{s}/{s}/{s}/bin", .{ base, sha, pkg, ver });
+    defer testing.allocator.free(bin_dir);
+    try malt.fs_compat.cwd().makePath(bin_dir);
+
+    const expected_bin = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ bin_dir, pkg });
+    defer testing.allocator.free(expected_bin);
+    const f = try malt.fs_compat.createFileAbsolute(expected_bin, .{});
+    f.close();
+
+    var probe_buf: [512]u8 = undefined;
+    const cached = try cli_run.findCachedBinary(&probe_buf, base, sha, pkg, ver);
+    try testing.expect(cached != null);
+    try testing.expectEqualStrings(expected_bin, cached.?);
 }
 
-test "no double dash means no command args" {
-    const args = [_][]const u8{"jq"};
-    var cmd_args_start: usize = args.len;
-    for (args[1..], 1..) |arg, i| {
-        if (std.mem.eql(u8, arg, "--")) {
-            cmd_args_start = i + 1;
-            break;
-        }
-    }
-    const cmd_args = if (cmd_args_start < args.len) args[cmd_args_start..] else &[_][]const u8{};
-    try testing.expectEqual(@as(usize, 0), cmd_args.len);
+test "findCachedBinary reports miss when the cache is empty" {
+    const base = "/tmp/malt_run_keep_miss";
+    malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(base) catch {};
+
+    var probe_buf: [512]u8 = undefined;
+    const cached = try cli_run.findCachedBinary(&probe_buf, base, "abc", "jq", "1.0");
+    try testing.expect(cached == null);
+}
+
+// Locks down the property that a cached bottle for one SHA does NOT satisfy
+// a probe for another SHA — guards against accidental cross-version reuse
+// when an upstream rebuilds with the same `version` string.
+test "findCachedBinary keys cache slot on sha256, not just pkg+version" {
+    const base = "/tmp/malt_run_keep_sha_isolation";
+    malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(base) catch {};
+
+    const sha_a = "aaa111";
+    const sha_b = "bbb222";
+    const pkg = "jq";
+    const ver = "1.7.1";
+
+    const bin_dir = try std.fmt.allocPrint(testing.allocator, "{s}/run/{s}/{s}/{s}/bin", .{ base, sha_a, pkg, ver });
+    defer testing.allocator.free(bin_dir);
+    try malt.fs_compat.cwd().makePath(bin_dir);
+    const bin_path = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ bin_dir, pkg });
+    defer testing.allocator.free(bin_path);
+    const f = try malt.fs_compat.createFileAbsolute(bin_path, .{});
+    f.close();
+
+    var probe_buf: [512]u8 = undefined;
+    const same_sha = try cli_run.findCachedBinary(&probe_buf, base, sha_a, pkg, ver);
+    try testing.expect(same_sha != null);
+
+    const other_sha = try cli_run.findCachedBinary(&probe_buf, base, sha_b, pkg, ver);
+    try testing.expect(other_sha == null);
+}
+
+test "findCachedBinary requires the version directory to match" {
+    const base = "/tmp/malt_run_keep_ver_isolation";
+    malt.fs_compat.deleteTreeAbsolute(base) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(base) catch {};
+
+    const sha = "abc";
+    const pkg = "jq";
+
+    const bin_dir = try std.fmt.allocPrint(testing.allocator, "{s}/run/{s}/{s}/1.7.1/bin", .{ base, sha, pkg });
+    defer testing.allocator.free(bin_dir);
+    try malt.fs_compat.cwd().makePath(bin_dir);
+    const bin_path = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ bin_dir, pkg });
+    defer testing.allocator.free(bin_path);
+    const f = try malt.fs_compat.createFileAbsolute(bin_path, .{});
+    f.close();
+
+    var probe_buf: [512]u8 = undefined;
+    const wrong_ver = try cli_run.findCachedBinary(&probe_buf, base, sha, pkg, "2.0");
+    try testing.expect(wrong_ver == null);
+}
+
+// Acquiring the same lock from a second handle within one process must
+// time out (flock is per-process on the SAME fd path here, but separate
+// LockFile.acquire calls open new fds, which on macOS/Linux contend).
+test "LockFile blocks a second acquire on the same path" {
+    const lock_path = "/tmp/malt_run_keep_lock_test.lock";
+    malt.fs_compat.deleteFileAbsolute(lock_path) catch {};
+    defer malt.fs_compat.deleteFileAbsolute(lock_path) catch {};
+
+    var first = try malt.lock.LockFile.acquire(lock_path, 1_000);
+    defer first.release();
+
+    // Second acquire must time out within 200 ms while the first is held.
+    try testing.expectError(
+        error.Timeout,
+        malt.lock.LockFile.acquire(lock_path, 200),
+    );
 }


### PR DESCRIPTION
## Description

`mt run --keep` caches the extracted bottle under `{cache}/run/<sha256>/` so subsequent runs skip download and extraction. Without `--keep` the behaviour is unchanged: ephemeral tmp dir, cleaned up on exit. Cached runs are still wiped by `mt purge --cache`.

## Related Issue

- None

## Notes for Reviewers

The flag is parsed in any position before `--` so `mt run --keep jq -- --version` and `mt run jq --keep -- --version` both work. Cache key is the bottle's expected SHA256, so distinct platforms or revisions don't collide.