### PR TITLE
perf(cli/outdated): parallelise API fetches

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -180,6 +180,7 @@ pub fn build(b: *std.Build) void {
         "tests/patcher_test.zig",
         "tests/pin_test.zig",
         "tests/shellenv_test.zig",
+        "tests/outdated_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -5,12 +5,133 @@ const std = @import("std");
 const sqlite = @import("../db/sqlite.zig");
 const schema = @import("../db/schema.zig");
 const atomic = @import("../fs/atomic.zig");
+const fs_compat = @import("../fs/compat.zig");
 const output = @import("../ui/output.zig");
 const io_mod = @import("../ui/io.zig");
 const api_mod = @import("../net/api.zig");
 const client_mod = @import("../net/client.zig");
 const cask_mod = @import("../core/cask.zig");
+const color = @import("../ui/color.zig");
 const help = @import("help.zig");
+
+/// Default ceiling on concurrent API fetches. One round-trip per keg
+/// dominates `mt outdated` on machines with many installed packages, so
+/// we hand the work to a bounded pool the same way `cli/install` and
+/// `cli/search` do.
+pub const OUTDATED_DEFAULT_WORKERS: usize = 8;
+
+/// Env var that lets users tune the pool size (e.g. crank it on a fat
+/// uplink, or lower it to one to reproduce serial behaviour).
+pub const OUTDATED_WORKERS_ENV = "MALT_OUTDATED_WORKERS";
+
+/// One row of the installed-package list fed to the worker pool.
+pub const KegRow = struct {
+    name: []const u8,
+    version: []const u8,
+};
+
+/// Result row for a single outdated package. All slices are owned by
+/// the caller's allocator.
+pub const OutdatedEntry = struct {
+    name: []u8,
+    installed: []u8,
+    latest: []u8,
+};
+
+/// Parse the worker-count override env var. Anything non-positive or
+/// non-numeric falls back to the default — matches the lenient style
+/// the rest of the CLI uses for tuning knobs.
+pub fn parseWorkersEnv(s: ?[]const u8) ?usize {
+    const raw = s orelse return null;
+    if (raw.len == 0) return null;
+    const n = std.fmt.parseInt(usize, raw, 10) catch return null;
+    if (n == 0) return null;
+    return n;
+}
+
+/// Resolve the actual worker count for `jobs`. Capped at `jobs` so we
+/// never spawn idle workers, and at the env override (or the default
+/// ceiling) so we never starve the network.
+pub fn outdatedWorkerCount(jobs: usize, env_override: ?usize) usize {
+    const cap = env_override orelse OUTDATED_DEFAULT_WORKERS;
+    return @min(cap, jobs);
+}
+
+/// Below this we keep the single-client serial path — the pool's
+/// thread-spawn + HTTP-pool init overhead is not worth it for a
+/// handful of round-trips.
+pub fn shouldUsePool(jobs: usize) bool {
+    return jobs >= OUTDATED_DEFAULT_WORKERS;
+}
+
+/// "All clear" summary line for the current scope, or null when at
+/// least one outdated row was already emitted (so we never claim
+/// "everything's fine" alongside a list of outdated packages).
+fn summaryMessage(formula_count: usize, cask_count: usize, formula_only: bool, cask_only: bool) ?[]const u8 {
+    if (formula_count != 0 or cask_count != 0) return null;
+    if (formula_only) return "All formulas are up to date.";
+    if (cask_only) return "All casks are up to date.";
+    return "All packages are up to date.";
+}
+
+test "outdatedWorkerCount caps at the default for large N" {
+    try std.testing.expectEqual(
+        @as(usize, OUTDATED_DEFAULT_WORKERS),
+        outdatedWorkerCount(50, null),
+    );
+}
+
+test "outdatedWorkerCount returns N when N is below the default" {
+    try std.testing.expectEqual(@as(usize, 3), outdatedWorkerCount(3, null));
+    try std.testing.expectEqual(@as(usize, 0), outdatedWorkerCount(0, null));
+}
+
+test "outdatedWorkerCount respects env overrides above and below the default" {
+    try std.testing.expectEqual(@as(usize, 4), outdatedWorkerCount(50, 4));
+    // Power-user override: env wins over the default ceiling.
+    try std.testing.expectEqual(@as(usize, 16), outdatedWorkerCount(50, 16));
+}
+
+test "shouldUsePool flips at the default-worker boundary" {
+    try std.testing.expect(!shouldUsePool(0));
+    try std.testing.expect(!shouldUsePool(OUTDATED_DEFAULT_WORKERS - 1));
+    try std.testing.expect(shouldUsePool(OUTDATED_DEFAULT_WORKERS));
+    try std.testing.expect(shouldUsePool(50));
+}
+
+test "parseWorkersEnv parses a positive integer" {
+    try std.testing.expectEqual(@as(?usize, 4), parseWorkersEnv("4"));
+    try std.testing.expectEqual(@as(?usize, 16), parseWorkersEnv("16"));
+}
+
+test "parseWorkersEnv rejects null, empty, zero, and non-numeric values" {
+    try std.testing.expectEqual(@as(?usize, null), parseWorkersEnv(null));
+    try std.testing.expectEqual(@as(?usize, null), parseWorkersEnv(""));
+    try std.testing.expectEqual(@as(?usize, null), parseWorkersEnv("0"));
+    try std.testing.expectEqual(@as(?usize, null), parseWorkersEnv("abc"));
+    try std.testing.expectEqual(@as(?usize, null), parseWorkersEnv("-3"));
+}
+
+test "summaryMessage suppresses 'all up to date' when any row was printed" {
+    try std.testing.expectEqual(@as(?[]const u8, null), summaryMessage(3, 0, false, false));
+    try std.testing.expectEqual(@as(?[]const u8, null), summaryMessage(0, 2, false, false));
+    try std.testing.expectEqual(@as(?[]const u8, null), summaryMessage(1, 1, false, false));
+}
+
+test "summaryMessage picks the message that matches the active scope" {
+    try std.testing.expectEqualStrings(
+        "All packages are up to date.",
+        summaryMessage(0, 0, false, false).?,
+    );
+    try std.testing.expectEqualStrings(
+        "All formulas are up to date.",
+        summaryMessage(0, 0, true, false).?,
+    );
+    try std.testing.expectEqualStrings(
+        "All casks are up to date.",
+        summaryMessage(0, 0, false, true).?,
+    );
+}
 
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "outdated")) return;
@@ -39,7 +160,6 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer db.close();
     schema.initSchema(&db) catch return;
 
-    // Set up API client
     const cache_dir = atomic.maltCacheDir(allocator) catch {
         output.err("Failed to determine cache directory", .{});
         return error.Aborted;
@@ -50,151 +170,468 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer http.deinit();
     var api = api_mod.BrewApi.init(allocator, &http, cache_dir);
 
+    const workers_override = parseWorkersEnv(fs_compat.getenv(OUTDATED_WORKERS_ENV));
+
     var stdout_buf: [4096]u8 = undefined;
     var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
     const stdout: *std.Io.Writer = &stdout_fw.interface;
     // Flush on teardown; stdout closed by a broken pipe is normal shell usage.
     defer stdout.flush() catch {};
 
-    // Check outdated formulas (unless --cask)
+    var formula_count: usize = 0;
+    var cask_count: usize = 0;
     if (!cask_only) {
-        var stmt = db.prepare("SELECT name, version FROM kegs ORDER BY name;") catch return;
-        defer stmt.finalize();
-
-        if (json_mode) {
-            var aw: std.Io.Writer.Allocating = .init(allocator);
-            defer aw.deinit();
-            const w = &aw.writer;
-            try w.writeAll("[");
-
-            var first = true;
-            while (stmt.step() catch false) {
-                const name_ptr = stmt.columnText(0) orelse continue;
-                const ver_ptr = stmt.columnText(1);
-                const name_slice = std.mem.sliceTo(name_ptr, 0);
-                const ver_slice = if (ver_ptr) |v| std.mem.sliceTo(v, 0) else "0";
-
-                const latest = getLatestVersion(allocator, &api, name_slice) orelse continue;
-                defer allocator.free(latest);
-
-                if (!std.mem.eql(u8, ver_slice, latest)) {
-                    if (!first) try w.writeAll(",");
-                    first = false;
-                    try w.writeAll("{\"name\":");
-                    try output.jsonStr(w, name_slice);
-                    try w.writeAll(",\"installed\":");
-                    try output.jsonStr(w, ver_slice);
-                    try w.writeAll(",\"latest\":");
-                    try output.jsonStr(w, latest);
-                    try w.writeAll(",\"type\":\"formula\"}");
-                }
-            }
-
-            try w.writeAll("]\n");
-            stdout.writeAll(aw.written()) catch return;
-        } else {
-            var found_any = false;
-            while (stmt.step() catch false) {
-                const name_ptr = stmt.columnText(0) orelse continue;
-                const ver_ptr = stmt.columnText(1);
-                const name_slice = std.mem.sliceTo(name_ptr, 0);
-                const ver_slice = if (ver_ptr) |v| std.mem.sliceTo(v, 0) else "0";
-
-                const latest = getLatestVersion(allocator, &api, name_slice) orelse continue;
-                defer allocator.free(latest);
-
-                if (!std.mem.eql(u8, ver_slice, latest)) {
-                    found_any = true;
-                    var line_buf: [512]u8 = undefined;
-                    const line = std.fmt.bufPrint(&line_buf, "{s} ({s}) < {s}\n", .{ name_slice, ver_slice, latest }) catch continue;
-                    stdout.writeAll(line) catch return;
-                }
-            }
-
-            if (!found_any and !output.isQuiet()) {
-                output.info("All formulas are up to date.", .{});
-            }
-        }
+        formula_count = try emitOutdatedFormulas(allocator, &db, &api, cache_dir, workers_override, stdout, json_mode);
+    }
+    if (!formula_only) {
+        cask_count = try emitOutdatedCasks(allocator, &db, &api, cache_dir, workers_override, stdout, json_mode);
     }
 
-    // Check outdated casks (unless --formula)
-    if (!formula_only) {
-        try checkOutdatedCasks(allocator, &db, &api, json_mode);
+    // Single end-of-run summary so we never print "All casks are up to
+    // date" next to a list of outdated formulas. Suppressed in JSON
+    // mode and under `--quiet` (handled by `output.info`).
+    if (!json_mode) {
+        if (summaryMessage(formula_count, cask_count, formula_only, cask_only)) |msg| {
+            output.info("{s}", .{msg});
+        }
     }
 }
 
-fn checkOutdatedCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api_mod.BrewApi, json_mode: bool) !void {
-    var stmt = db.prepare("SELECT token, version FROM casks ORDER BY token;") catch |e| {
-        output.err("Failed to query casks: {s}", .{@errorName(e)});
-        return e;
-    };
+fn loadKegRows(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    sql: [:0]const u8,
+) ![]KegRow {
+    var stmt = db.prepare(sql) catch return &.{};
     defer stmt.finalize();
 
-    var stdout_buf: [4096]u8 = undefined;
-    var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
-    const stdout: *std.Io.Writer = &stdout_fw.interface;
-    // Flush on teardown; stdout closed by a broken pipe is normal shell usage.
-    defer stdout.flush() catch {};
-    var found_any = false;
-
-    while (stmt.step() catch false) {
-        const token_ptr = stmt.columnText(0) orelse continue;
-        const ver_ptr = stmt.columnText(1);
-        const token = std.mem.sliceTo(token_ptr, 0);
-        const installed_ver = if (ver_ptr) |v| std.mem.sliceTo(v, 0) else "0";
-
-        const cask_json = api.fetchCask(token) catch continue;
-        defer allocator.free(cask_json);
-
-        var cask = cask_mod.parseCask(allocator, cask_json) catch continue;
-        defer cask.deinit();
-
-        if (!std.mem.eql(u8, installed_ver, cask.version)) {
-            found_any = true;
-            if (json_mode) {
-                stdout.writeAll("{\"name\":") catch continue;
-                output.jsonStr(stdout, token) catch continue;
-                stdout.writeAll(",\"installed\":") catch continue;
-                output.jsonStr(stdout, installed_ver) catch continue;
-                stdout.writeAll(",\"latest\":") catch continue;
-                output.jsonStr(stdout, cask.version) catch continue;
-                stdout.writeAll(",\"type\":\"cask\"}\n") catch continue;
-            } else {
-                var buf: [512]u8 = undefined;
-                const line = std.fmt.bufPrint(&buf, "{s} ({s}) < {s} [cask]\n", .{ token, installed_ver, cask.version }) catch continue;
-                stdout.writeAll(line) catch return;
-            }
+    var rows: std.ArrayList(KegRow) = .empty;
+    errdefer {
+        for (rows.items) |r| {
+            allocator.free(r.name);
+            allocator.free(r.version);
         }
+        rows.deinit(allocator);
+    }
+    while (stmt.step() catch false) {
+        const name_ptr = stmt.columnText(0) orelse continue;
+        const ver_ptr = stmt.columnText(1);
+        const name_slice = std.mem.sliceTo(name_ptr, 0);
+        const ver_slice = if (ver_ptr) |v| std.mem.sliceTo(v, 0) else "0";
+        const name_dup = try allocator.dupe(u8, name_slice);
+        errdefer allocator.free(name_dup);
+        const ver_dup = try allocator.dupe(u8, ver_slice);
+        try rows.append(allocator, .{ .name = name_dup, .version = ver_dup });
+    }
+    return rows.toOwnedSlice(allocator);
+}
+
+fn freeKegRows(allocator: std.mem.Allocator, rows: []KegRow) void {
+    for (rows) |r| {
+        allocator.free(r.name);
+        allocator.free(r.version);
+    }
+    allocator.free(rows);
+}
+
+fn emitOutdatedFormulas(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    api: *api_mod.BrewApi,
+    cache_dir: []const u8,
+    workers_override: ?usize,
+    stdout: *std.Io.Writer,
+    json_mode: bool,
+) !usize {
+    const rows = try loadKegRows(allocator, db, "SELECT name, version FROM kegs ORDER BY name;");
+    defer freeKegRows(allocator, rows);
+
+    const entries = try collectOutdatedFormulas(allocator, api, cache_dir, rows, workers_override);
+    defer freeEntries(allocator, entries);
+
+    try writeFormulaEntries(allocator, stdout, entries, json_mode);
+    return entries.len;
+}
+
+fn emitOutdatedCasks(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    api: *api_mod.BrewApi,
+    cache_dir: []const u8,
+    workers_override: ?usize,
+    stdout: *std.Io.Writer,
+    json_mode: bool,
+) !usize {
+    const rows = try loadKegRows(allocator, db, "SELECT token, version FROM casks ORDER BY token;");
+    defer freeKegRows(allocator, rows);
+
+    const entries = try collectOutdatedCasks(allocator, api, cache_dir, rows, workers_override);
+    defer freeEntries(allocator, entries);
+
+    try writeCaskEntries(stdout, entries, json_mode);
+    return entries.len;
+}
+
+fn freeEntries(allocator: std.mem.Allocator, entries: []OutdatedEntry) void {
+    for (entries) |e| {
+        allocator.free(e.name);
+        allocator.free(e.installed);
+        allocator.free(e.latest);
+    }
+    allocator.free(entries);
+}
+
+fn writeFormulaEntries(
+    allocator: std.mem.Allocator,
+    stdout: *std.Io.Writer,
+    entries: []const OutdatedEntry,
+    json_mode: bool,
+) !void {
+    if (json_mode) {
+        var aw: std.Io.Writer.Allocating = .init(allocator);
+        defer aw.deinit();
+        const w = &aw.writer;
+        try w.writeAll("[");
+        for (entries, 0..) |e, i| {
+            if (i != 0) try w.writeAll(",");
+            try w.writeAll("{\"name\":");
+            try output.jsonStr(w, e.name);
+            try w.writeAll(",\"installed\":");
+            try output.jsonStr(w, e.installed);
+            try w.writeAll(",\"latest\":");
+            try output.jsonStr(w, e.latest);
+            try w.writeAll(",\"type\":\"formula\"}");
+        }
+        try w.writeAll("]\n");
+        stdout.writeAll(aw.written()) catch return;
+        return;
     }
 
-    if (!found_any and !output.isQuiet()) {
-        output.info("All casks are up to date.", .{});
+    for (entries) |e| writeEntry(stdout, e, null);
+}
+
+fn writeCaskEntries(
+    stdout: *std.Io.Writer,
+    entries: []const OutdatedEntry,
+    json_mode: bool,
+) !void {
+    if (json_mode) {
+        for (entries) |e| {
+            stdout.writeAll("{\"name\":") catch continue;
+            output.jsonStr(stdout, e.name) catch continue;
+            stdout.writeAll(",\"installed\":") catch continue;
+            output.jsonStr(stdout, e.installed) catch continue;
+            stdout.writeAll(",\"latest\":") catch continue;
+            output.jsonStr(stdout, e.latest) catch continue;
+            stdout.writeAll(",\"type\":\"cask\"}\n") catch continue;
+        }
+        return;
+    }
+
+    for (entries) |e| writeEntry(stdout, e, "cask");
+}
+
+/// Match the `mt list` / `mt search` row shape: cyan bullet, plain
+/// name, dimmed `(installed)`, warn-coloured `< latest`, and an
+/// optional dim `[kind]` tag for casks. Honours `NO_COLOR` / pipes
+/// automatically via `color.isColorEnabled()`.
+fn writeEntry(stdout: *std.Io.Writer, e: OutdatedEntry, kind_tag: ?[]const u8) void {
+    if (output.isQuiet()) {
+        stdout.writeAll(e.name) catch return;
+        stdout.writeAll("\n") catch return;
+        return;
+    }
+
+    writeBullet(stdout);
+    stdout.writeAll(e.name) catch return;
+    writeStyledSpan(stdout, color.SemanticStyle.detail.code(), " (", e.installed, ")");
+    writeStyledSpan(stdout, color.SemanticStyle.warn.code(), " < ", e.latest, "");
+    if (kind_tag) |t| writeStyledSpan(stdout, color.SemanticStyle.detail.code(), " [", t, "]");
+    stdout.writeAll("\n") catch return;
+}
+
+fn writeBullet(stdout: *std.Io.Writer) void {
+    if (color.isColorEnabled()) {
+        stdout.writeAll(color.SemanticStyle.info.code()) catch return;
+        stdout.writeAll("  \xe2\x96\xb8 ") catch return;
+        stdout.writeAll(color.Style.reset.code()) catch return;
+    } else {
+        stdout.writeAll("  \xe2\x96\xb8 ") catch return;
     }
 }
 
-fn getLatestVersion(allocator: std.mem.Allocator, api: *api_mod.BrewApi, name: []const u8) ?[]const u8 {
-    const json_bytes = api.fetchFormula(name) catch return null;
-    defer allocator.free(json_bytes);
+fn writeStyledSpan(
+    stdout: *std.Io.Writer,
+    style_code: []const u8,
+    open: []const u8,
+    body: []const u8,
+    close: []const u8,
+) void {
+    const use_color = color.isColorEnabled();
+    if (use_color) stdout.writeAll(style_code) catch return;
+    stdout.writeAll(open) catch return;
+    stdout.writeAll(body) catch return;
+    stdout.writeAll(close) catch return;
+    if (use_color) stdout.writeAll(color.Style.reset.code()) catch return;
+}
 
-    const parsed = std.json.parseFromSlice(std.json.Value, allocator, json_bytes, .{}) catch return null;
-    defer parsed.deinit();
+/// Compute outdated formulas for `kegs`. Sort order follows `kegs` —
+/// callers query the DB with `ORDER BY name`. Per-row API failures or
+/// 404s drop silently (matches the old serial behaviour).
+pub fn collectOutdatedFormulas(
+    allocator: std.mem.Allocator,
+    api: *api_mod.BrewApi,
+    cache_dir: []const u8,
+    kegs: []const KegRow,
+    workers_override: ?usize,
+) std.mem.Allocator.Error![]OutdatedEntry {
+    return collectOutdated(allocator, api, cache_dir, kegs, workers_override, .formula);
+}
 
-    const obj = parsed.value.object;
+/// Cask sibling of `collectOutdatedFormulas`. Same lifetime contract.
+pub fn collectOutdatedCasks(
+    allocator: std.mem.Allocator,
+    api: *api_mod.BrewApi,
+    cache_dir: []const u8,
+    kegs: []const KegRow,
+    workers_override: ?usize,
+) std.mem.Allocator.Error![]OutdatedEntry {
+    return collectOutdated(allocator, api, cache_dir, kegs, workers_override, .cask);
+}
 
-    // Try versions.stable first
-    if (obj.get("versions")) |versions_val| {
-        switch (versions_val) {
-            .object => |versions_obj| {
-                if (versions_obj.get("stable")) |stable_val| {
-                    switch (stable_val) {
-                        .string => |s| return allocator.dupe(u8, s) catch null,
-                        else => {},
-                    }
-                }
-            },
-            else => {},
+const Kind = enum { formula, cask };
+
+fn collectOutdated(
+    allocator: std.mem.Allocator,
+    api: *api_mod.BrewApi,
+    cache_dir: []const u8,
+    kegs: []const KegRow,
+    workers_override: ?usize,
+    kind: Kind,
+) std.mem.Allocator.Error![]OutdatedEntry {
+    if (kegs.len == 0) return allocator.alloc(OutdatedEntry, 0);
+
+    // Per-row latest-version slot. Workers fill `latest_versions[i]`
+    // with a caller-allocator-owned string when row `i` is outdated;
+    // null otherwise. Indexed-write keeps the pool free of locks.
+    const latest_versions = try allocator.alloc(?[]u8, kegs.len);
+    defer allocator.free(latest_versions);
+    @memset(latest_versions, null);
+    errdefer for (latest_versions) |maybe| {
+        if (maybe) |v| allocator.free(v);
+    };
+
+    if (!shouldUsePool(kegs.len)) {
+        for (kegs, 0..) |row, i| {
+            latest_versions[i] = try fetchLatest(allocator, api, kind, row);
         }
+    } else {
+        try runPool(allocator, cache_dir, kegs, workers_override, kind, latest_versions);
     }
 
-    return null;
+    return assembleEntries(allocator, kegs, latest_versions);
+}
+
+fn assembleEntries(
+    allocator: std.mem.Allocator,
+    kegs: []const KegRow,
+    latest_versions: []?[]u8,
+) std.mem.Allocator.Error![]OutdatedEntry {
+    var out: std.ArrayList(OutdatedEntry) = try .initCapacity(allocator, kegs.len);
+    errdefer {
+        for (out.items) |e| {
+            allocator.free(e.name);
+            allocator.free(e.installed);
+            allocator.free(e.latest);
+        }
+        out.deinit(allocator);
+    }
+
+    for (kegs, 0..) |row, i| {
+        const latest = latest_versions[i] orelse continue;
+        // Hand ownership of `latest` over to the entry; clear the
+        // slot so the errdefer above doesn't double-free it.
+        latest_versions[i] = null;
+        errdefer allocator.free(latest);
+
+        const name_dup = try allocator.dupe(u8, row.name);
+        errdefer allocator.free(name_dup);
+        const installed_dup = try allocator.dupe(u8, row.version);
+
+        try out.append(allocator, .{
+            .name = name_dup,
+            .installed = installed_dup,
+            .latest = latest,
+        });
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+/// Fetch + parse the upstream latest version for `name` onto `alloc`.
+/// Best-effort: network or parse failures collapse to null. Shared by
+/// the serial and pool paths so the JSON-shape logic lives once.
+fn upstreamLatest(
+    alloc: std.mem.Allocator,
+    api: *api_mod.BrewApi,
+    kind: Kind,
+    name: []const u8,
+) ?[]u8 {
+    return switch (kind) {
+        .formula => blk: {
+            const json = api.fetchFormula(name) catch break :blk null;
+            defer alloc.free(json);
+            break :blk parseFormulaLatest(alloc, json);
+        },
+        .cask => blk: {
+            const json = api.fetchCask(name) catch break :blk null;
+            defer alloc.free(json);
+            var cask = cask_mod.parseCask(alloc, json) catch break :blk null;
+            defer cask.deinit();
+            break :blk alloc.dupe(u8, cask.version) catch null;
+        },
+    };
+}
+
+/// Serial-path single-row check. Returns a caller-owned latest-version
+/// string if `row` is outdated, null otherwise.
+fn fetchLatest(
+    allocator: std.mem.Allocator,
+    api: *api_mod.BrewApi,
+    kind: Kind,
+    row: KegRow,
+) std.mem.Allocator.Error!?[]u8 {
+    const v = upstreamLatest(allocator, api, kind, row.name) orelse return null;
+    if (std.mem.eql(u8, row.version, v)) {
+        allocator.free(v);
+        return null;
+    }
+    return v;
+}
+
+/// Pull `versions.stable` out of a Homebrew formula JSON document.
+/// Returns a fresh caller-owned copy or null if the field is missing /
+/// the document is malformed.
+fn parseFormulaLatest(allocator: std.mem.Allocator, json_bytes: []const u8) ?[]u8 {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, json_bytes, .{}) catch return null;
+    defer parsed.deinit();
+    const obj = switch (parsed.value) {
+        .object => |o| o,
+        else => return null,
+    };
+    const versions_val = obj.get("versions") orelse return null;
+    const versions_obj = switch (versions_val) {
+        .object => |o| o,
+        else => return null,
+    };
+    const stable_val = versions_obj.get("stable") orelse return null;
+    return switch (stable_val) {
+        .string => |s| allocator.dupe(u8, s) catch null,
+        else => null,
+    };
+}
+
+// --- Pool path ---
+
+const WorkerCtx = struct {
+    arena: std.heap.ArenaAllocator,
+    pool: *client_mod.HttpClientPool,
+    cache_dir: []const u8,
+    row: KegRow,
+    kind: Kind,
+    /// Result allocated on the **caller** allocator so it survives
+    /// arena teardown. Null = up-to-date or fetch failed.
+    out: ?[]u8 = null,
+    /// Out-of-memory from caller-allocator dupe; surfaced after join.
+    /// Other failures stay silent to match the serial behaviour.
+    err: ?std.mem.Allocator.Error = null,
+};
+
+const PoolState = struct {
+    next_idx: std.atomic.Value(usize),
+    ctxs: []WorkerCtx,
+    out_allocator: std.mem.Allocator,
+};
+
+fn poolWorker(state: *PoolState) void {
+    while (true) {
+        const idx = state.next_idx.fetchAdd(1, .acq_rel);
+        if (idx >= state.ctxs.len) return;
+        const ctx = &state.ctxs[idx];
+        runOne(state.out_allocator, ctx);
+    }
+}
+
+fn runOne(out_alloc: std.mem.Allocator, ctx: *WorkerCtx) void {
+    const http = ctx.pool.acquire();
+    defer ctx.pool.release(http);
+
+    const arena_alloc = ctx.arena.allocator();
+    var local_api = api_mod.BrewApi.init(arena_alloc, http, ctx.cache_dir);
+    const latest = upstreamLatest(arena_alloc, &local_api, ctx.kind, ctx.row.name) orelse return;
+    if (std.mem.eql(u8, ctx.row.version, latest)) return;
+
+    // Move into the caller's allocator so the result outlives `arena.deinit()`.
+    ctx.out = out_alloc.dupe(u8, latest) catch |e| blk: {
+        ctx.err = e;
+        break :blk null;
+    };
+}
+
+fn runPool(
+    allocator: std.mem.Allocator,
+    cache_dir: []const u8,
+    kegs: []const KegRow,
+    workers_override: ?usize,
+    kind: Kind,
+    latest_versions: []?[]u8,
+) std.mem.Allocator.Error!void {
+    const worker_count = outdatedWorkerCount(kegs.len, workers_override);
+    std.debug.assert(worker_count > 0);
+
+    var http_pool = try client_mod.HttpClientPool.init(allocator, worker_count);
+    defer http_pool.deinit();
+
+    const ctxs = try allocator.alloc(WorkerCtx, kegs.len);
+    defer {
+        for (ctxs) |*c| c.arena.deinit();
+        allocator.free(ctxs);
+    }
+    for (ctxs, 0..) |*c, i| c.* = .{
+        .arena = std.heap.ArenaAllocator.init(std.heap.page_allocator),
+        .pool = &http_pool,
+        .cache_dir = cache_dir,
+        .row = kegs[i],
+        .kind = kind,
+    };
+
+    var state: PoolState = .{
+        .next_idx = std.atomic.Value(usize).init(0),
+        .ctxs = ctxs,
+        .out_allocator = allocator,
+    };
+
+    const threads = try allocator.alloc(std.Thread, worker_count);
+    defer allocator.free(threads);
+
+    var spawned: usize = 0;
+    for (0..worker_count) |_| {
+        if (std.Thread.spawn(.{}, poolWorker, .{&state})) |t| {
+            threads[spawned] = t;
+            spawned += 1;
+        } else |_| {
+            // Spawn failure: drain remaining work inline on this thread.
+            poolWorker(&state);
+        }
+    }
+    for (threads[0..spawned]) |t| t.join();
+
+    // Move every successful out into the caller's slot first so the
+    // caller's errdefer can free partial-success memory if we then
+    // surface a worker OOM.
+    for (ctxs, 0..) |c, i| {
+        latest_versions[i] = c.out;
+    }
+    for (ctxs) |c| {
+        if (c.err) |e| return e;
+    }
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -48,6 +48,7 @@ pub const cli_migrate = @import("cli/migrate.zig");
 pub const cli_info = @import("cli/info.zig");
 pub const cli_uses = @import("cli/uses.zig");
 pub const cli_which = @import("cli/which.zig");
+pub const cli_outdated = @import("cli/outdated.zig");
 pub const cli_version_update = @import("cli/version_update.zig");
 pub const update_cleanup = @import("update/cleanup.zig");
 pub const update_origin = @import("update/origin.zig");

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -1,0 +1,214 @@
+//! malt — outdated parallelisation tests
+//!
+//! Cache-seeded integration tests for `collectOutdatedFormulas` /
+//! `collectOutdatedCasks`. Pure helper assertions live next to their
+//! definitions in `src/cli/outdated.zig` as inline `test` blocks.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const outdated_mod = malt.cli_outdated;
+const api_mod = malt.api;
+const client_mod = malt.client;
+
+// --- Integration: collectOutdatedFormulas / collectOutdatedCasks ---
+
+const TempCacheDir = struct {
+    path: []const u8,
+
+    fn init(comptime tag: []const u8) !TempCacheDir {
+        const p = "/tmp/malt_outdated_test_" ++ tag;
+        malt.fs_compat.deleteTreeAbsolute(p) catch {};
+        try malt.fs_compat.makeDirAbsolute(p);
+        return .{ .path = p };
+    }
+
+    fn deinit(self: *TempCacheDir) void {
+        malt.fs_compat.deleteTreeAbsolute(self.path) catch {};
+    }
+
+    fn writeCacheFile(self: *TempCacheDir, rel: []const u8, content: []const u8) !void {
+        var api_buf: [512]u8 = undefined;
+        const api_dir = try std.fmt.bufPrint(&api_buf, "{s}/api", .{self.path});
+        malt.fs_compat.makeDirAbsolute(api_dir) catch |e| switch (e) {
+            error.PathAlreadyExists => {},
+            else => return e,
+        };
+        var path_buf: [512]u8 = undefined;
+        const full = try std.fmt.bufPrint(&path_buf, "{s}/api/{s}", .{ self.path, rel });
+        const f = try malt.fs_compat.cwd().createFile(full, .{});
+        defer f.close();
+        try f.writeAll(content);
+    }
+};
+
+fn freeEntries(allocator: std.mem.Allocator, entries: []outdated_mod.OutdatedEntry) void {
+    for (entries) |e| {
+        allocator.free(e.name);
+        allocator.free(e.installed);
+        allocator.free(e.latest);
+    }
+    allocator.free(entries);
+}
+
+fn seedFormula(dir: *TempCacheDir, name: []const u8, latest: []const u8) !void {
+    var key_buf: [128]u8 = undefined;
+    const file = try std.fmt.bufPrint(&key_buf, "formula_{s}.json", .{name});
+    var body_buf: [256]u8 = undefined;
+    const body = try std.fmt.bufPrint(&body_buf, "{{\"name\":\"{s}\",\"versions\":{{\"stable\":\"{s}\"}}}}", .{ name, latest });
+    try dir.writeCacheFile(file, body);
+}
+
+fn seedCask(dir: *TempCacheDir, token: []const u8, latest: []const u8) !void {
+    var key_buf: [128]u8 = undefined;
+    const file = try std.fmt.bufPrint(&key_buf, "cask_{s}.json", .{token});
+    var body_buf: [512]u8 = undefined;
+    // parseCask needs `url` too — minimal shape so it returns ok.
+    const body = try std.fmt.bufPrint(
+        &body_buf,
+        "{{\"token\":\"{s}\",\"name\":[\"{s}\"],\"version\":\"{s}\",\"url\":\"https://example.invalid/{s}.dmg\"}}",
+        .{ token, token, latest, token },
+    );
+    try dir.writeCacheFile(file, body);
+}
+
+test "collectOutdatedFormulas (small-N, single-client path) returns sorted outdated rows only" {
+    var http = client_mod.HttpClient.init(testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("formulas_small");
+    defer dir.deinit();
+
+    try seedFormula(&dir, "alpha", "2.0");
+    try seedFormula(&dir, "bravo", "1.0");
+    try seedFormula(&dir, "charlie", "3.5");
+
+    var api = api_mod.BrewApi.init(testing.allocator, &http, dir.path);
+
+    const kegs = [_]outdated_mod.KegRow{
+        .{ .name = "alpha", .version = "1.0" }, // outdated
+        .{ .name = "bravo", .version = "1.0" }, // up-to-date
+        .{ .name = "charlie", .version = "3.0" }, // outdated
+    };
+
+    const out = try outdated_mod.collectOutdatedFormulas(testing.allocator, &api, dir.path, &kegs, null);
+    defer freeEntries(testing.allocator, out);
+
+    try testing.expectEqual(@as(usize, 2), out.len);
+    try testing.expectEqualStrings("alpha", out[0].name);
+    try testing.expectEqualStrings("1.0", out[0].installed);
+    try testing.expectEqualStrings("2.0", out[0].latest);
+    try testing.expectEqualStrings("charlie", out[1].name);
+    try testing.expectEqualStrings("3.0", out[1].installed);
+    try testing.expectEqualStrings("3.5", out[1].latest);
+}
+
+test "collectOutdatedFormulas (large-N, pool path) preserves sorted order" {
+    var http = client_mod.HttpClient.init(testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("formulas_large");
+    defer dir.deinit();
+
+    // 10 fake formulas, all outdated (installed=1.0, latest=2.0).
+    // 10 > OUTDATED_DEFAULT_WORKERS so the pool path runs.
+    const names = [_][]const u8{
+        "f00", "f01", "f02", "f03", "f04",
+        "f05", "f06", "f07", "f08", "f09",
+    };
+    for (names) |n| try seedFormula(&dir, n, "2.0");
+
+    var rows_buf: [names.len]outdated_mod.KegRow = undefined;
+    for (names, 0..) |n, i| rows_buf[i] = .{ .name = n, .version = "1.0" };
+
+    var api = api_mod.BrewApi.init(testing.allocator, &http, dir.path);
+    const out = try outdated_mod.collectOutdatedFormulas(testing.allocator, &api, dir.path, &rows_buf, null);
+    defer freeEntries(testing.allocator, out);
+
+    try testing.expectEqual(@as(usize, names.len), out.len);
+    for (out, 0..) |entry, i| {
+        try testing.expectEqualStrings(names[i], entry.name);
+        try testing.expectEqualStrings("1.0", entry.installed);
+        try testing.expectEqualStrings("2.0", entry.latest);
+    }
+}
+
+test "collectOutdatedFormulas tolerates a missing/404 entry without aborting" {
+    // One name has no cache entry — the worker treats it as "no remote
+    // info" and the row drops out of the result rather than failing the
+    // whole command.
+    var http = client_mod.HttpClient.init(testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("formulas_partial");
+    defer dir.deinit();
+
+    try seedFormula(&dir, "alpha", "2.0");
+    // 'ghost' is intentionally not seeded; with no network it yields null.
+    try seedFormula(&dir, "zulu", "9.9");
+
+    var api = api_mod.BrewApi.init(testing.allocator, &http, dir.path);
+
+    const kegs = [_]outdated_mod.KegRow{
+        .{ .name = "alpha", .version = "1.0" },
+        .{ .name = "ghost", .version = "0.1" },
+        .{ .name = "zulu", .version = "1.0" },
+    };
+
+    const out = try outdated_mod.collectOutdatedFormulas(testing.allocator, &api, dir.path, &kegs, null);
+    defer freeEntries(testing.allocator, out);
+
+    try testing.expectEqual(@as(usize, 2), out.len);
+    try testing.expectEqualStrings("alpha", out[0].name);
+    try testing.expectEqualStrings("zulu", out[1].name);
+}
+
+test "collectOutdatedCasks (small-N) returns sorted outdated rows only" {
+    var http = client_mod.HttpClient.init(testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("casks_small");
+    defer dir.deinit();
+
+    try seedCask(&dir, "appone", "5.0");
+    try seedCask(&dir, "appthree", "1.1");
+    try seedCask(&dir, "apptwo", "2.0");
+
+    var api = api_mod.BrewApi.init(testing.allocator, &http, dir.path);
+
+    const kegs = [_]outdated_mod.KegRow{
+        .{ .name = "appone", .version = "5.0" }, // up-to-date
+        .{ .name = "appthree", .version = "1.0" }, // outdated
+        .{ .name = "apptwo", .version = "1.0" }, // outdated
+    };
+
+    const out = try outdated_mod.collectOutdatedCasks(testing.allocator, &api, dir.path, &kegs, null);
+    defer freeEntries(testing.allocator, out);
+
+    try testing.expectEqual(@as(usize, 2), out.len);
+    try testing.expectEqualStrings("appthree", out[0].name);
+    try testing.expectEqualStrings("apptwo", out[1].name);
+}
+
+test "collectOutdatedCasks (large-N, pool path) preserves sorted order" {
+    var http = client_mod.HttpClient.init(testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("casks_large");
+    defer dir.deinit();
+
+    const tokens = [_][]const u8{
+        "c00", "c01", "c02", "c03", "c04",
+        "c05", "c06", "c07", "c08", "c09",
+    };
+    for (tokens) |t| try seedCask(&dir, t, "2.0");
+
+    var rows_buf: [tokens.len]outdated_mod.KegRow = undefined;
+    for (tokens, 0..) |t, i| rows_buf[i] = .{ .name = t, .version = "1.0" };
+
+    var api = api_mod.BrewApi.init(testing.allocator, &http, dir.path);
+    const out = try outdated_mod.collectOutdatedCasks(testing.allocator, &api, dir.path, &rows_buf, null);
+    defer freeEntries(testing.allocator, out);
+
+    try testing.expectEqual(@as(usize, tokens.len), out.len);
+    for (out, 0..) |entry, i| {
+        try testing.expectEqualStrings(tokens[i], entry.name);
+        try testing.expectEqualStrings("1.0", entry.installed);
+        try testing.expectEqualStrings("2.0", entry.latest);
+    }
+}


### PR DESCRIPTION
## Description

`mt outdated` now fans the per-keg API round-trips out across a bounded worker pool (default 8, override with `MALT_OUTDATED_WORKERS`) instead of fetching one keg at a time. Pools are skipped under 8 kegs to keep the cheap path cheap; sort order and JSON shape are unchanged. Human-mode rows pick up the same `  ▸ name (installed) < latest [cask]` style `mt list` and `mt search` already use - cyan bullet, dim version, warn-coloured upgrade arrow.

## Related Issue

- None

## Notes for Reviewers

Mirrors the install-time `collectFormulaJobs` shape: per-worker `ArenaAllocator`, shared `HttpClientPool`, atomic next-index.