### PR TITLE
feat(cli): --pinned-only audit and upgrade --pinned dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,17 +235,19 @@ mt upgrade <package>                     # upgrade a specific formula or cask
 mt upgrade --cask                        # upgrade all outdated casks
 mt upgrade --formula                     # upgrade all outdated formulas
 mt upgrade --dry-run                     # show what would be upgraded
+mt upgrade --pinned --dry-run            # audit pinned kegs for drift (no mutation)
 mt upgrade --force <package>             # bypass pin protection
 ```
 
-| Flag            | Description                       |
-| --------------- | --------------------------------- |
-| `--cask`        | Upgrade casks only                |
-| `--formula`     | Upgrade formulas only             |
-| `--dry-run`     | Preview without upgrading         |
-| `--force`, `-f` | Bypass pin protection (dangerous) |
+| Flag            | Description                                          |
+| --------------- | ---------------------------------------------------- |
+| `--cask`        | Upgrade casks only                                   |
+| `--formula`     | Upgrade formulas only                                |
+| `--dry-run`     | Preview without upgrading                            |
+| `--pinned`      | Audit pinned kegs only (needs `--dry-run`/`--force`) |
+| `--force`, `-f` | Bypass pin protection (dangerous)                    |
 
-Pinned kegs (`mt pin <name>`) are skipped with a dim "pinned, skipped" line; pass `--force` to override the pin for a single run. Formula upgrades install the new version, verify it, switch symlinks atomically, and only remove the old version after success. On failure, the old version is restored automatically.
+Pinned kegs (`mt pin <name>`) are skipped with a dim "pinned, skipped" line; pass `--force` to override the pin for a single run. `--pinned --dry-run` walks pinned kegs end-to-end so you can see the upstream drift without mutating anything — useful for CVE watch on held-back versions. Formula upgrades install the new version, verify it, switch symlinks atomically, and only remove the old version after success. On failure, the old version is restored automatically.
 
 ### `mt pin` / `mt unpin`
 
@@ -277,16 +279,18 @@ mt outdated
 mt outdated --json
 mt outdated --cask
 mt outdated --formula
+mt outdated --pinned-only                # CVE watch on held-back versions
 ```
 
-| Flag            | Description                 |
-| --------------- | --------------------------- |
-| `--json`        | Output as JSON              |
-| `--formula`     | Show outdated formulas only |
-| `--cask`        | Show outdated casks only    |
-| `--quiet`, `-q` | Suppress status messages    |
+| Flag            | Description                             |
+| --------------- | --------------------------------------- |
+| `--json`        | Output as JSON                          |
+| `--formula`     | Show outdated formulas only             |
+| `--cask`        | Show outdated casks only                |
+| `--pinned-only` | Audit pinned kegs only (formula-scoped) |
+| `--quiet`, `-q` | Suppress status messages                |
 
-Compares installed versions against the latest from the Homebrew API. Checks both formulas and casks by default.
+Compares installed versions against the latest from the Homebrew API. Checks both formulas and casks by default. `--pinned-only` narrows the scan to pinned kegs so you can see when an upstream release supersedes the version you've held back — pair with `mt upgrade --pinned --dry-run` for the full audit/preview pair.
 
 ```text
 wget (1.24.5) < 1.25.0

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -142,8 +142,8 @@ pub const bash_script =
     \\        restore)          cmd_flags="--dry-run --force --quiet -q" ;;
     \\        purge)            cmd_flags="--store-orphans --unused-deps --cache --cache= --downloads --stale-casks --old-versions --housekeeping --wipe --backup -b --keep-cache --remove-binary --yes -y --dry-run -n" ;;
     \\        uninstall|remove) cmd_flags="--force --zap --dry-run" ;;
-    \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --force -f" ;;
-    \\        outdated)         cmd_flags="--json --formula --cask --quiet -q" ;;
+    \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --pinned --force -f" ;;
+    \\        outdated)         cmd_flags="--json --formula --cask --pinned-only --quiet -q" ;;
     \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --json --quiet -q" ;;
     \\        info)             cmd_flags="--formula --cask --json" ;;
     \\        search)           cmd_flags="--formula --cask --json" ;;
@@ -262,6 +262,7 @@ pub const zsh_script =
     \\                        '--cask[Upgrade casks only]' \
     \\                        '--formula[Upgrade formulas only]' \
     \\                        '--dry-run[Show what would be upgraded]' \
+    \\                        '--pinned[Audit pinned kegs (requires --dry-run or --force)]' \
     \\                        '(--force -f)'{--force,-f}'[Bypass pin protection]' \
     \\                        '*::package:'
     \\                    ;;
@@ -283,6 +284,7 @@ pub const zsh_script =
     \\                        '--json[Output as JSON]' \
     \\                        '--formula[Show outdated formulas only]' \
     \\                        '--cask[Show outdated casks only]' \
+    \\                        '--pinned-only[Audit pinned kegs only]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress status messages]'
     \\                    ;;
     \\                list|ls)
@@ -488,12 +490,14 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l cask    -d 'Casks only'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l formula -d 'Formulas only'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l dry-run -d 'Preview'
+    \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l pinned  -d 'Audit pinned kegs (needs --dry-run or --force)'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -s f -l force -d 'Bypass pin protection'
     \\
     \\    # outdated
-    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l json    -d 'JSON output'
-    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l formula -d 'Formulas only'
-    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l cask    -d 'Casks only'
+    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l json        -d 'JSON output'
+    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l formula     -d 'Formulas only'
+    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l cask        -d 'Casks only'
+    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l pinned-only -d 'Pinned kegs only'
     \\
     \\    # list / ls
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l versions -d 'Show version numbers'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -101,6 +101,7 @@ const upgrade_help =
     \\  --cask         Upgrade casks only
     \\  --formula      Upgrade formulas only
     \\  --dry-run      Show what would be upgraded
+    \\  --pinned       Audit pinned kegs (requires --dry-run or --force)
     \\  --force, -f    Bypass pin protection (dangerous; user-initiated)
     \\
 ;
@@ -121,6 +122,7 @@ const outdated_help =
     \\  --json         Output as JSON
     \\  --formula      Show outdated formulas only
     \\  --cask         Show outdated casks only
+    \\  --pinned-only  Audit pinned kegs only (formulas; CVE watch)
     \\  --quiet, -q    Suppress status messages
     \\
 ;

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -30,6 +30,11 @@ pub const KegRow = struct {
     version: []const u8,
 };
 
+/// Scope filter for `loadFormulaRows`. `--pinned-only` swaps in a
+/// pinned-row SQL so the audit path never round-trips the API for kegs
+/// that aren't being protected from upgrade.
+pub const KegFilter = enum { all, pinned_only };
+
 /// Result row for a single outdated package. All slices are owned by
 /// the caller's allocator.
 pub const OutdatedEntry = struct {
@@ -138,13 +143,22 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     var cask_only = false;
     var formula_only = false;
+    var pinned_only = false;
 
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "--cask")) {
             cask_only = true;
         } else if (std.mem.eql(u8, arg, "--formula") or std.mem.eql(u8, arg, "--formulae")) {
             formula_only = true;
+        } else if (std.mem.eql(u8, arg, "--pinned-only")) {
+            pinned_only = true;
         }
+    }
+    // `--pinned-only` is formula-scoped: the casks table has no `pinned`
+    // column, so any cask scan would be vacuous. Force the formula scope.
+    if (pinned_only) {
+        cask_only = false;
+        formula_only = true;
     }
     // `--json` and `--quiet` are stripped by the global parser in main.zig.
     const json_mode = output.isJson();
@@ -181,7 +195,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var formula_count: usize = 0;
     var cask_count: usize = 0;
     if (!cask_only) {
-        formula_count = try emitOutdatedFormulas(allocator, &db, &api, cache_dir, workers_override, stdout, json_mode);
+        const filter: KegFilter = if (pinned_only) .pinned_only else .all;
+        formula_count = try emitOutdatedFormulas(allocator, &db, &api, cache_dir, workers_override, stdout, json_mode, filter);
     }
     if (!formula_only) {
         cask_count = try emitOutdatedCasks(allocator, &db, &api, cache_dir, workers_override, stdout, json_mode);
@@ -195,6 +210,31 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             output.info("{s}", .{msg});
         }
     }
+}
+
+/// Load installed formula rows, optionally narrowed to pinned-only.
+/// Caller frees with `freeKegRows`. Exposed for tests + the audit path
+/// in `cli/upgrade`; both want the same SQL choice.
+pub fn loadFormulaRows(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    filter: KegFilter,
+) ![]KegRow {
+    const sql: [:0]const u8 = switch (filter) {
+        .all => "SELECT name, version FROM kegs ORDER BY name;",
+        .pinned_only => "SELECT name, version FROM kegs WHERE pinned = 1 ORDER BY name;",
+    };
+    return loadKegRows(allocator, db, sql);
+}
+
+/// Caller-side free for any rows returned by `loadFormulaRows` (or the
+/// internal cask query). Pairs with the allocator passed in.
+pub fn freeKegRows(allocator: std.mem.Allocator, rows: []KegRow) void {
+    for (rows) |r| {
+        allocator.free(r.name);
+        allocator.free(r.version);
+    }
+    allocator.free(rows);
 }
 
 fn loadKegRows(
@@ -226,14 +266,6 @@ fn loadKegRows(
     return rows.toOwnedSlice(allocator);
 }
 
-fn freeKegRows(allocator: std.mem.Allocator, rows: []KegRow) void {
-    for (rows) |r| {
-        allocator.free(r.name);
-        allocator.free(r.version);
-    }
-    allocator.free(rows);
-}
-
 fn emitOutdatedFormulas(
     allocator: std.mem.Allocator,
     db: *sqlite.Database,
@@ -242,8 +274,9 @@ fn emitOutdatedFormulas(
     workers_override: ?usize,
     stdout: *std.Io.Writer,
     json_mode: bool,
+    filter: KegFilter,
 ) !usize {
-    const rows = try loadKegRows(allocator, db, "SELECT name, version FROM kegs ORDER BY name;");
+    const rows = try loadFormulaRows(allocator, db, filter);
     defer freeKegRows(allocator, rows);
 
     const entries = try collectOutdatedFormulas(allocator, api, cache_dir, rows, workers_override);

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -20,7 +20,7 @@ const ghcr_mod = @import("../net/ghcr.zig");
 const help = @import("help.zig");
 const pin_mod = @import("pin.zig");
 
-const UpgradeFlag = enum { quiet, cask, formula, dry_run, force };
+const UpgradeFlag = enum { quiet, cask, formula, dry_run, force, pinned };
 
 const upgrade_flag_map = std.StaticStringMap(UpgradeFlag).initComptime(.{
     .{ "-q", .quiet },
@@ -30,12 +30,16 @@ const upgrade_flag_map = std.StaticStringMap(UpgradeFlag).initComptime(.{
     .{ "--dry-run", .dry_run },
     .{ "--force", .force },
     .{ "-f", .force },
+    .{ "--pinned", .pinned },
 });
 
 /// True when this name should be skipped due to a user pin. Pure gate so
 /// the `--force` semantics are testable without dragging in the API.
-pub fn pinSkip(db: *sqlite.Database, name: []const u8, force: bool) bool {
-    if (force) return false;
+/// `audit_mode` lets `--pinned --dry-run` walk pinned kegs end-to-end so
+/// the user can see the drift; without that escape, every row would
+/// short-circuit before the API check.
+pub fn pinSkip(db: *sqlite.Database, name: []const u8, force: bool, audit_mode: bool) bool {
+    if (force or audit_mode) return false;
     return pin_mod.isPinned(db, name);
 }
 
@@ -46,6 +50,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var formula_only = false;
     var dry_run = output.isDryRun();
     var force = false;
+    var pinned_only = false;
     var pkg_name: ?[]const u8 = null;
 
     // StaticStringMap + exhaustive switch: every flag routes to a handler.
@@ -56,8 +61,21 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             .formula => formula_only = true,
             .dry_run => dry_run = true,
             .force => force = true,
+            .pinned => pinned_only = true,
         } else if (arg.len > 0 and arg[0] != '-') {
             if (pkg_name == null) pkg_name = arg;
+        }
+    }
+
+    if (pinned_only) {
+        // Casks lack a `pinned` column; the audit is formula-scoped.
+        cask_only = false;
+        formula_only = true;
+        // Without --dry-run or --force the audit would just print
+        // "pinned, skipped" for every row - refuse rather than waste cycles.
+        if (!dry_run and !force) {
+            output.err("--pinned requires --dry-run (audit) or --force (override)", .{});
+            return error.Aborted;
         }
     }
 
@@ -102,7 +120,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         // Upgrade a specific package — try formula first, then cask
         if (!cask_only) {
             if (isFormulaInstalled(&db, name)) {
-                upgradeFormula(allocator, name, &db, &api, &http, prefix, dry_run, force) catch {
+                upgradeFormula(allocator, name, &db, &api, &http, prefix, dry_run, force, pinned_only) catch {
                     any_failed = true;
                 };
                 if (any_failed) return error.Aborted;
@@ -110,13 +128,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             }
         }
         // Not a formula (or --cask): try cask
-        upgradeCask(allocator, name, &db, &api, prefix, dry_run, force) catch {
+        upgradeCask(allocator, name, &db, &api, prefix, dry_run, force, pinned_only) catch {
             any_failed = true;
         };
     } else {
         // Upgrade all
         if (!cask_only) {
-            upgradeAllFormulas(allocator, &db, &api, &http, prefix, dry_run, force) catch {
+            upgradeAllFormulas(allocator, &db, &api, &http, prefix, dry_run, force, pinned_only) catch {
                 any_failed = true;
             };
         }
@@ -152,10 +170,13 @@ fn upgradeFormula(
     prefix: [:0]const u8,
     dry_run: bool,
     force: bool,
+    audit_mode: bool,
 ) !void {
     // Honor pins before any network or filesystem work — the whole
-    // point is that a pinned keg never gets touched.
-    if (pinSkip(db, name, force)) {
+    // point is that a pinned keg never gets touched. Audit mode
+    // (`--pinned --dry-run`) walks pinned kegs end-to-end so the user
+    // sees the drift, but the dry-run gate still blocks any mutation.
+    if (pinSkip(db, name, force, audit_mode)) {
         output.dim("{s} is pinned, skipped", .{name});
         return;
     }
@@ -431,8 +452,13 @@ fn upgradeAllFormulas(
     prefix: [:0]const u8,
     dry_run: bool,
     force: bool,
+    pinned_only: bool,
 ) !void {
-    var stmt = db.prepare("SELECT name, version FROM kegs ORDER BY name;") catch return;
+    const sql: [:0]const u8 = if (pinned_only)
+        "SELECT name, version FROM kegs WHERE pinned = 1 ORDER BY name;"
+    else
+        "SELECT name, version FROM kegs ORDER BY name;";
+    var stmt = db.prepare(sql) catch return;
     defer stmt.finalize();
 
     // Collect names first to avoid holding the statement open during upgrade
@@ -453,7 +479,8 @@ fn upgradeAllFormulas(
     }
 
     if (names.items.len == 0) {
-        output.info("No formulas installed.", .{});
+        // Quiet on the audit path: "no pinned kegs" is the normal idle state.
+        if (!pinned_only) output.info("No formulas installed.", .{});
         return;
     }
 
@@ -464,7 +491,7 @@ fn upgradeAllFormulas(
     defer failed_names.deinit(allocator);
 
     for (names.items) |name| {
-        upgradeFormula(allocator, name, db, api, http, prefix, dry_run, force) catch {
+        upgradeFormula(allocator, name, db, api, http, prefix, dry_run, force, pinned_only) catch {
             failed_count += 1;
             // failed_count is the authoritative counter; list is for UX only.
             failed_names.append(allocator, name) catch {};
@@ -483,8 +510,8 @@ fn upgradeAllFormulas(
 // Cask upgrade
 // ---------------------------------------------------------------------------
 
-fn upgradeCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Database, api: *api_mod.BrewApi, prefix: [:0]const u8, dry_run: bool, force: bool) !void {
-    if (pinSkip(db, token, force)) {
+fn upgradeCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Database, api: *api_mod.BrewApi, prefix: [:0]const u8, dry_run: bool, force: bool, audit_mode: bool) !void {
+    if (pinSkip(db, token, force, audit_mode)) {
         output.dim("{s} is pinned, skipped", .{token});
         return;
     }
@@ -573,7 +600,8 @@ fn upgradeAllCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api
     defer failed_tokens.deinit(allocator);
 
     for (tokens.items) |token| {
-        upgradeCask(allocator, token, db, api, prefix, dry_run, force) catch {
+        // Cask scope never enters audit mode (no `pinned` column).
+        upgradeCask(allocator, token, db, api, prefix, dry_run, force, false) catch {
             failed_count += 1;
             // failed_count is authoritative; list is for UX only.
             failed_tokens.append(allocator, token) catch {};

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -10,6 +10,13 @@ const malt = @import("malt");
 const outdated_mod = malt.cli_outdated;
 const api_mod = malt.api;
 const client_mod = malt.client;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
 
 // --- Integration: collectOutdatedFormulas / collectOutdatedCasks ---
 
@@ -211,4 +218,113 @@ test "collectOutdatedCasks (large-N, pool path) preserves sorted order" {
         try testing.expectEqualStrings("1.0", entry.installed);
         try testing.expectEqualStrings("2.0", entry.latest);
     }
+}
+
+// --- --pinned-only filter ---
+
+fn setupPinnedPrefix(suffix: []const u8) ![:0]u8 {
+    const path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "/tmp/malt_outdated_pinned_{d}_{s}",
+        .{ malt.fs_compat.nanoTimestamp(), suffix },
+        0,
+    );
+    malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    try malt.fs_compat.cwd().makePath(path);
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{path});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+    _ = c.setenv("MALT_PREFIX", path.ptr, 1);
+    return path;
+}
+
+fn openSeededDb(prefix: [:0]const u8) !sqlite.Database {
+    var buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    errdefer db.close();
+    try schema.initSchema(&db);
+    return db;
+}
+
+fn insertKeg(db: *sqlite.Database, name: []const u8, pinned: bool) !void {
+    var buf: [512]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &buf,
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, pinned) VALUES ('{s}', '{s}', '1.0', 'deadbeef', '/cellar/{s}/1.0', {d});",
+        .{ name, name, name, @intFromBool(pinned) },
+    );
+    try db.exec(sql);
+}
+
+test "loadFormulaRows .pinned_only returns only pinned rows" {
+    const path = try setupPinnedPrefix("filter_pinned");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertKeg(&db, "alpha", false);
+    try insertKeg(&db, "bravo", true);
+    try insertKeg(&db, "charlie", true);
+
+    const rows = try outdated_mod.loadFormulaRows(testing.allocator, &db, .pinned_only);
+    defer outdated_mod.freeKegRows(testing.allocator, rows);
+
+    try testing.expectEqual(@as(usize, 2), rows.len);
+    try testing.expectEqualStrings("bravo", rows[0].name);
+    try testing.expectEqualStrings("charlie", rows[1].name);
+}
+
+test "loadFormulaRows .all returns every installed row" {
+    const path = try setupPinnedPrefix("filter_all");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertKeg(&db, "alpha", false);
+    try insertKeg(&db, "bravo", true);
+
+    const rows = try outdated_mod.loadFormulaRows(testing.allocator, &db, .all);
+    defer outdated_mod.freeKegRows(testing.allocator, rows);
+
+    try testing.expectEqual(@as(usize, 2), rows.len);
+    try testing.expectEqualStrings("alpha", rows[0].name);
+    try testing.expectEqualStrings("bravo", rows[1].name);
+}
+
+test "loadFormulaRows .pinned_only on an empty DB is a no-op" {
+    const path = try setupPinnedPrefix("filter_empty");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertKeg(&db, "alpha", false);
+    try insertKeg(&db, "bravo", false);
+
+    const rows = try outdated_mod.loadFormulaRows(testing.allocator, &db, .pinned_only);
+    defer outdated_mod.freeKegRows(testing.allocator, rows);
+
+    try testing.expectEqual(@as(usize, 0), rows.len);
+}
+
+test "outdated execute --pinned-only is a quiet no-op when no kegs are pinned" {
+    const path = try setupPinnedPrefix("exec_no_pins");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        try insertKeg(&db, "alpha", false);
+    }
+
+    // No pinned kegs => no API calls => quiet success even with no cache.
+    try outdated_mod.execute(testing.allocator, &.{"--pinned-only"});
 }

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -103,7 +103,39 @@ test "mt upgrade (no args) skips pinned kegs without aggregating failures" {
     try upgrade.execute(testing.allocator, &.{});
 }
 
-test "pinSkip honours --force: pinned + force = false (no skip)" {
+test "mt upgrade --pinned --dry-run with no pinned kegs is a quiet no-op" {
+    const path = try setupPrefix("pinned_audit_empty");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        // Unpinned keg — the --pinned filter excludes it, no API call.
+        try db.exec("INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path) VALUES ('loose', 'loose', '1.0', 'sha', '/cellar/loose/1.0');");
+    }
+
+    try upgrade.execute(testing.allocator, &.{ "--pinned", "--dry-run" });
+}
+
+test "mt upgrade --pinned without --dry-run or --force errors with usage" {
+    const path = try setupPrefix("pinned_requires_audit");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{path});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+
+    try testing.expectError(
+        error.Aborted,
+        upgrade.execute(testing.allocator, &.{"--pinned"}),
+    );
+}
+
+test "pinSkip honours --force and audit_mode: pinned + override = no skip" {
     const path = try setupPrefix("pinskip_helper");
     defer testing.allocator.free(path);
     defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
@@ -114,13 +146,15 @@ test "pinSkip honours --force: pinned + force = false (no skip)" {
     try insertPinnedKeg(&db, "forced");
     try db.exec("INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path) VALUES ('loose', 'loose', '1.0', 'sha', '/cellar/loose/1.0');");
 
-    // pinned + !force = skip
-    try testing.expect(upgrade.pinSkip(&db, "forced", false));
+    // pinned + neither override = skip
+    try testing.expect(upgrade.pinSkip(&db, "forced", false, false));
     // pinned + force = no skip (the whole point of --force)
-    try testing.expect(!upgrade.pinSkip(&db, "forced", true));
-    // unpinned: never skipped, force or not
-    try testing.expect(!upgrade.pinSkip(&db, "loose", false));
-    try testing.expect(!upgrade.pinSkip(&db, "loose", true));
+    try testing.expect(!upgrade.pinSkip(&db, "forced", true, false));
+    // pinned + audit = no skip (so `--pinned --dry-run` walks the row)
+    try testing.expect(!upgrade.pinSkip(&db, "forced", false, true));
+    // unpinned: never skipped, force/audit or not
+    try testing.expect(!upgrade.pinSkip(&db, "loose", false, false));
+    try testing.expect(!upgrade.pinSkip(&db, "loose", true, false));
     // unknown name: not pinned, not skipped
-    try testing.expect(!upgrade.pinSkip(&db, "ghost", false));
+    try testing.expect(!upgrade.pinSkip(&db, "ghost", false, false));
 }


### PR DESCRIPTION
## Description

`mt outdated --pinned-only` and `mt upgrade --pinned --dry-run` turn the `pinned` column into a first-class CVE-watch surface: list which held-back kegs have drifted upstream, or preview what pinning is currently blocking, without touching disk.

- `mt outdated --pinned-only` swaps in `WHERE pinned = 1` and skips the cask scan entirely (casks have no `pinned` column). Sort order, JSON shape, and human-mode rendering are inherited from the existing path.

- `mt upgrade --pinned` filters the bulk-upgrade SQL the same way and threads a new `audit_mode` flag into `pinSkip` so the per-row pin guard steps aside, letting the `--dry-run` preview ("Dry run: would upgrade X v1 -> v2") fire on every pinned keg. Audit mode requires either `--dry-run` (preview) or `--force` (override) - bare `--pinned` exits non-zero with a usage hint rather than silently no-opping.

## Related Issue

- None

## Notes for Reviewers

- Casks deliberately stay out of scope: any `--pinned-only` / `--pinned` cask scan would always be empty, so `cask_only` flips off and the cask emit/upgrade path is skipped. README and `--help` call this out.