### PR TITLE
feat(cli): extend pinning to casks

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,30 +235,30 @@ mt upgrade <package>                     # upgrade a specific formula or cask
 mt upgrade --cask                        # upgrade all outdated casks
 mt upgrade --formula                     # upgrade all outdated formulas
 mt upgrade --dry-run                     # show what would be upgraded
-mt upgrade --pinned --dry-run            # audit pinned kegs for drift (no mutation)
+mt upgrade --pinned --dry-run            # audit pinned formulas + casks for drift (no mutation)
 mt upgrade --force <package>             # bypass pin protection
 ```
 
-| Flag            | Description                                          |
-| --------------- | ---------------------------------------------------- |
-| `--cask`        | Upgrade casks only                                   |
-| `--formula`     | Upgrade formulas only                                |
-| `--dry-run`     | Preview without upgrading                            |
-| `--pinned`      | Audit pinned kegs only (needs `--dry-run`/`--force`) |
-| `--force`, `-f` | Bypass pin protection (dangerous)                    |
+| Flag            | Description                                                 |
+| --------------- | ----------------------------------------------------------- |
+| `--cask`        | Upgrade casks only                                          |
+| `--formula`     | Upgrade formulas only                                       |
+| `--dry-run`     | Preview without upgrading                                   |
+| `--pinned`      | Audit pinned formulas + casks (needs `--dry-run`/`--force`) |
+| `--force`, `-f` | Bypass pin protection (dangerous)                           |
 
-Pinned kegs (`mt pin <name>`) are skipped with a dim "pinned, skipped" line; pass `--force` to override the pin for a single run. `--pinned --dry-run` walks pinned kegs end-to-end so you can see the upstream drift without mutating anything — useful for CVE watch on held-back versions. Formula upgrades install the new version, verify it, switch symlinks atomically, and only remove the old version after success. On failure, the old version is restored automatically.
+Pinned formulas and casks (`mt pin <name>`) are skipped with a dim "pinned, skipped" line; pass `--force` to override the pin for a single run. `--pinned --dry-run` walks every pinned package end-to-end so you can see the upstream drift without mutating anything — useful for CVE watch on held-back versions. Formula upgrades install the new version, verify it, switch symlinks atomically, and only remove the old version after success. On failure, the old version is restored automatically.
 
 ### `mt pin` / `mt unpin`
 
-Protect an installed keg from `mt upgrade` (or lift the protection).
+Protect an installed formula or cask from `mt upgrade` (or lift the protection).
 
 ```bash
-mt pin <name>                            # mark as pinned
+mt pin <name>                            # mark a formula or cask as pinned
 mt unpin <name>                          # lift the pin
 ```
 
-A pinned keg is held at its current version: `mt upgrade <name>` skips it with a dim "pinned, skipped" line, and bulk `mt upgrade` does the same per-keg. Use `mt list --pinned` to inspect; pass `mt upgrade --force` to override once without removing the pin.
+A pinned package is held at its current version: `mt upgrade <name>` skips it with a dim "pinned, skipped" line, and bulk `mt upgrade` does the same per-package. Use `mt list --pinned` to inspect; pass `mt upgrade --force` to override once without removing the pin.
 
 ### `mt update`
 
@@ -282,15 +282,15 @@ mt outdated --formula
 mt outdated --pinned-only                # CVE watch on held-back versions
 ```
 
-| Flag            | Description                             |
-| --------------- | --------------------------------------- |
-| `--json`        | Output as JSON                          |
-| `--formula`     | Show outdated formulas only             |
-| `--cask`        | Show outdated casks only                |
-| `--pinned-only` | Audit pinned kegs only (formula-scoped) |
-| `--quiet`, `-q` | Suppress status messages                |
+| Flag            | Description                        |
+| --------------- | ---------------------------------- |
+| `--json`        | Output as JSON                     |
+| `--formula`     | Show outdated formulas only        |
+| `--cask`        | Show outdated casks only           |
+| `--pinned-only` | Audit pinned formulas + casks only |
+| `--quiet`, `-q` | Suppress status messages           |
 
-Compares installed versions against the latest from the Homebrew API. Checks both formulas and casks by default. `--pinned-only` narrows the scan to pinned kegs so you can see when an upstream release supersedes the version you've held back — pair with `mt upgrade --pinned --dry-run` for the full audit/preview pair.
+Compares installed versions against the latest from the Homebrew API. Checks both formulas and casks by default. `--pinned-only` narrows the scan to pinned packages (formulas + casks) so you can see when an upstream release supersedes the version you've held back — pair with `mt upgrade --pinned --dry-run` for the full audit/preview pair.
 
 ```text
 wget (1.24.5) < 1.25.0

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -229,10 +229,14 @@ else
   run_ok t3.link.overwrite -- "$MT_BIN" link tree --overwrite
 
   # pin / unpin / upgrade-skip round-trip: pin tree, verify upgrade is a no-op,
-  # then unpin so the rest of the smoke run is unaffected.
+  # exercise the audit flags (`outdated --pinned-only`, `upgrade --pinned
+  # --dry-run`) — both walk pinned formulas + casks symmetrically — then
+  # unpin so the rest of the smoke run is unaffected.
   run_ok t3.pin -- "$MT_BIN" pin tree
   run_grep t3.list.pinned-tree "tree" -- "$MT_BIN" list --pinned
   run_ok t3.upgrade.pinned -- "$MT_BIN" upgrade tree
+  run_ok t3.outdated.pinned-only -- "$MT_BIN" outdated --pinned-only
+  run_ok t3.upgrade.pinned-dry -- "$MT_BIN" upgrade --pinned --dry-run
   run_ok t3.unpin -- "$MT_BIN" unpin tree
 
   # backup / restore round-trip.

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -231,12 +231,15 @@ else
   # pin / unpin / upgrade-skip round-trip: pin tree, verify upgrade is a no-op,
   # exercise the audit flags (`outdated --pinned-only`, `upgrade --pinned
   # --dry-run`) — both walk pinned formulas + casks symmetrically — then
-  # unpin so the rest of the smoke run is unaffected.
+  # confirm a force-reinstall keeps the pin alive (INSERT OR REPLACE
+  # inherits the prior `pinned` via COALESCE-MAX), and finally unpin.
   run_ok t3.pin -- "$MT_BIN" pin tree
   run_grep t3.list.pinned-tree "tree" -- "$MT_BIN" list --pinned
   run_ok t3.upgrade.pinned -- "$MT_BIN" upgrade tree
   run_ok t3.outdated.pinned-only -- "$MT_BIN" outdated --pinned-only
   run_ok t3.upgrade.pinned-dry -- "$MT_BIN" upgrade --pinned --dry-run
+  run_ok t3.install.force.reinstall -- "$MT_BIN" install --force tree
+  run_grep t3.list.pinned.after-reinstall "tree" -- "$MT_BIN" list --pinned
   run_ok t3.unpin -- "$MT_BIN" unpin tree
 
   # backup / restore round-trip.

--- a/scripts/local-smoke-install.sh
+++ b/scripts/local-smoke-install.sh
@@ -20,7 +20,11 @@
 #                                 + DMG mount/install.
 #   • mt install --cask copilot-cli — cask `binary` artifact (symlinks a CLI
 #                                 into $PREFIX/bin). Exercises the
-#                                 non-/Applications cask codepath.
+#                                 non-/Applications cask codepath. The
+#                                 same cask also drives the cask-side
+#                                 pin/unpin round-trip (mt pin / unpin /
+#                                 list --pinned / upgrade --pinned --dry-run /
+#                                 upgrade <pinned-cask> no-op).
 #   • mt install python@3.14 (long prefix) — install_name_tool overflow
 #                                 fallback. python@3.14 has the tightest
 #                                 @@HOMEBREW_CELLAR@@ slots in homebrew/core;
@@ -154,6 +158,46 @@ install_binary_cask() {
 # the patched-binary shape (otool sees the long path) and the runtime
 # (python3.14 imports ssl, proving the rewritten LC_LOAD_DYLIBs resolve
 # under dyld). Self-contained: own prefix/cache, own cleanup.
+# Cask pin/unpin round-trip end-to-end against an installed cask. Pins
+# the cask, asserts `mt list --pinned` surfaces it, asserts a follow-up
+# `mt upgrade <token>` is a quiet no-op (pinned skip), exercises the
+# audit flag pair, then unpins so the cleanup pass can uninstall cleanly.
+pin_cask_round_trip() {
+  local tag="smoke.install.cask.pin"
+  local cask="$1"
+
+  if ! "$MT_BIN" list --cask -q 2>/dev/null | grep -qx "$cask"; then
+    printf '  SKIP  [%s] %s not installed; pin round-trip needs a live cask\n' "$tag" "$cask"
+    SKIP=$((SKIP + 1))
+    SKIPS+=("$tag")
+    return
+  fi
+
+  if ! run "$tag.pin" "$MT_BIN" pin "$cask"; then return; fi
+
+  if "$MT_BIN" list --pinned -q 2>/dev/null | grep -qx "$cask"; then
+    printf '  PASS  [%s.list] %s visible in mt list --pinned\n' "$tag" "$cask"
+    PASS=$((PASS + 1))
+  else
+    printf '  FAIL  [%s.list] %s missing from mt list --pinned\n' "$tag" "$cask"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$tag.list")
+  fi
+
+  # `mt upgrade <pinned-cask>` must short-circuit before fetchCask — exit 0,
+  # no error. The dim "pinned, skipped" line lives on stderr/stdout; we only
+  # assert the exit code here so terminal styling never flakes the test.
+  run "$tag.upgrade.skipped" "$MT_BIN" upgrade "$cask"
+
+  # The audit flag pair must reach the cask path now (T-062a). Both run
+  # against the live API; a network blip is tolerated as long as the
+  # binary itself doesn't crash.
+  run "$tag.outdated.pinned-only" "$MT_BIN" outdated --pinned-only
+  run "$tag.upgrade.pinned-dry" "$MT_BIN" upgrade --pinned --dry-run
+
+  run "$tag.unpin" "$MT_BIN" unpin "$cask"
+}
+
 install_python_overflow_fallback() {
   local tag="smoke.install.python_overflow_fallback"
   # Fixed paths so the global EXIT trap below can reach them by literal
@@ -270,6 +314,7 @@ install_formula smoke.install.rust rust
 install_formula smoke.install.go go
 install_cask smoke.install.cask.raycast raycast Raycast.app
 install_binary_cask smoke.install.cask.copilot-cli copilot-cli
+pin_cask_round_trip copilot-cli
 install_python_overflow_fallback
 install_only_deps_wget
 

--- a/scripts/regressions/pin_preservation.sh
+++ b/scripts/regressions/pin_preservation.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Pin preservation across reinstall paths.
+#
+# A user-pinned formula or cask must keep its hold across every non-
+# uninstall lifecycle event. This script exercises the in-place row
+# replacements that previously cleared the pinned column:
+#
+#   1. `mt install --force <pinned-formula>`  — INSERT OR REPLACE on kegs
+#   2. `mt install --cask --force <pinned-cask>` — INSERT OR REPLACE on casks
+#
+# Asserts after each step that `mt list --pinned` still names the
+# package and that `mt upgrade <name>` is a quiet no-op (the
+# "pinned, skipped" short-circuit only fires when the row is still
+# pinned in DB).
+#
+# Rollback / migrate paths are covered by unit tests; they require a
+# multi-version store / a Homebrew installation to drive end-to-end and
+# would balloon this script's runtime. The two install --force paths
+# above share the same SQL pattern (`COALESCE((SELECT MAX(pinned) ...))`)
+# so a green run here implies the pattern is wired correctly.
+#
+# Usage: scripts/regressions/pin_preservation.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt, network.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+PREFIX="/tmp/mt_pin"
+CACHE="/tmp/mc_pin"
+export MALT_PREFIX="$PREFIX"
+export MALT_CACHE="$CACHE"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX" "$CACHE"
+mkdir -p "$PREFIX" "$CACHE"
+trap 'rm -rf "$PREFIX" "$CACHE"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+# Formula side: tree is small, has no post_install, and lives entirely
+# under MALT_PREFIX. Override with FORMULA=name.
+FORMULA="${FORMULA:-tree}"
+# Binary cask: no /Applications dependency, lands under $PREFIX/bin.
+# Override with CASK=token.
+CASK="${CASK:-copilot-cli}"
+
+assert_pinned() {
+  local kind="$1" name="$2"
+  if "$BIN" list --pinned --quiet 2>/dev/null | grep -qx "$name"; then
+    pass "$kind $name still appears in mt list --pinned"
+  else
+    "$BIN" list --pinned 2>&1 | sed 's|^|        | |' >&2
+    fail "$kind $name missing from mt list --pinned (pin was clobbered)"
+  fi
+}
+
+assert_upgrade_skips() {
+  local kind="$1" name="$2"
+  local log
+  log="$PREFIX/upgrade_${name//\//_}.log"
+  if "$BIN" upgrade "$name" >"$log" 2>&1; then
+    if grep -q 'pinned, skipped' "$log"; then
+      pass "$kind $name: mt upgrade prints 'pinned, skipped'"
+    else
+      pass "$kind $name: mt upgrade exits 0 (already at latest is also fine)"
+    fi
+  else
+    sed -n '1,30p' "$log" >&2
+    fail "$kind $name: mt upgrade returned non-zero"
+  fi
+}
+
+# --- Formula round-trip: install -> pin -> install --force ---
+printf '\xe2\x96\xb8 formula round-trip on %s\n' "$FORMULA"
+"$BIN" install "$FORMULA" >"$PREFIX/install_$FORMULA.log" 2>&1 ||
+  fail "initial install of $FORMULA failed — see $PREFIX/install_$FORMULA.log"
+pass "$FORMULA installed"
+
+"$BIN" pin "$FORMULA" >/dev/null 2>&1 ||
+  fail "mt pin $FORMULA failed"
+assert_pinned formula "$FORMULA"
+
+# install --force on an already-installed formula must preserve the pin.
+"$BIN" install --force "$FORMULA" >"$PREFIX/install_force_$FORMULA.log" 2>&1 ||
+  fail "mt install --force $FORMULA failed — see $PREFIX/install_force_$FORMULA.log"
+assert_pinned formula "$FORMULA"
+assert_upgrade_skips formula "$FORMULA"
+
+"$BIN" unpin "$FORMULA" >/dev/null 2>&1 || true
+"$BIN" uninstall "$FORMULA" >/dev/null 2>&1 || true
+
+# --- Cask round-trip: install -> pin -> install --cask --force ---
+printf '\xe2\x96\xb8 cask round-trip on %s\n' "$CASK"
+if ! "$BIN" install --cask "$CASK" >"$PREFIX/install_$CASK.log" 2>&1; then
+  printf '  - SKIP cask leg: install --cask %s failed (network/upstream)\n' "$CASK"
+  printf '\n\xe2\x9c\x94 pin-preservation regression passed (cask leg skipped)\n'
+  exit 0
+fi
+pass "$CASK installed"
+
+"$BIN" pin "$CASK" >/dev/null 2>&1 ||
+  fail "mt pin $CASK failed"
+assert_pinned cask "$CASK"
+
+"$BIN" install --cask --force "$CASK" >"$PREFIX/install_force_$CASK.log" 2>&1 ||
+  fail "mt install --cask --force $CASK failed — see $PREFIX/install_force_$CASK.log"
+assert_pinned cask "$CASK"
+assert_upgrade_skips cask "$CASK"
+
+"$BIN" unpin "$CASK" >/dev/null 2>&1 || true
+"$BIN" uninstall --cask "$CASK" >/dev/null 2>&1 || true
+
+printf '\n\xe2\x9c\x94 pin-preservation regression passed\n'

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -208,8 +208,8 @@ pub const zsh_script =
     \\        'rollback:Revert a package to its previous version'
     \\        'link:Create symlinks for an installed keg'
     \\        'unlink:Remove symlinks (keg stays installed)'
-    \\        'pin:Protect an installed keg from upgrade'
-    \\        'unpin:Lift the pin on an installed keg'
+    \\        'pin:Protect an installed formula or cask from upgrade'
+    \\        'unpin:Lift the pin on an installed formula or cask'
     \\        'run:Run a package binary without installing'
     \\        'version:Show version or self-update'
     \\        'completions:Generate shell completion scripts'
@@ -262,7 +262,7 @@ pub const zsh_script =
     \\                        '--cask[Upgrade casks only]' \
     \\                        '--formula[Upgrade formulas only]' \
     \\                        '--dry-run[Show what would be upgraded]' \
-    \\                        '--pinned[Audit pinned kegs (requires --dry-run or --force)]' \
+    \\                        '--pinned[Audit pinned formulas + casks (requires --dry-run or --force)]' \
     \\                        '(--force -f)'{--force,-f}'[Bypass pin protection]' \
     \\                        '*::package:'
     \\                    ;;
@@ -284,7 +284,7 @@ pub const zsh_script =
     \\                        '--json[Output as JSON]' \
     \\                        '--formula[Show outdated formulas only]' \
     \\                        '--cask[Show outdated casks only]' \
-    \\                        '--pinned-only[Audit pinned kegs only]' \
+    \\                        '--pinned-only[Audit pinned formulas + casks only]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress status messages]'
     \\                    ;;
     \\                list|ls)
@@ -456,8 +456,8 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n __malt_needs_command -a rollback    -d 'Revert package to previous version'
     \\    complete -c $__malt_bin -n __malt_needs_command -a link        -d 'Create symlinks for a keg'
     \\    complete -c $__malt_bin -n __malt_needs_command -a unlink      -d 'Remove symlinks (keg stays)'
-    \\    complete -c $__malt_bin -n __malt_needs_command -a pin         -d 'Protect an installed keg from upgrade'
-    \\    complete -c $__malt_bin -n __malt_needs_command -a unpin       -d 'Lift the pin on an installed keg'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a pin         -d 'Protect an installed formula or cask from upgrade'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a unpin       -d 'Lift the pin on an installed formula or cask'
     \\    complete -c $__malt_bin -n __malt_needs_command -a run         -d 'Run package binary without installing'
     \\    complete -c $__malt_bin -n __malt_needs_command -a version     -d 'Show version or self-update'
     \\    complete -c $__malt_bin -n __malt_needs_command -a completions -d 'Generate shell completion scripts'
@@ -490,14 +490,14 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l cask    -d 'Casks only'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l formula -d 'Formulas only'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l dry-run -d 'Preview'
-    \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l pinned  -d 'Audit pinned kegs (needs --dry-run or --force)'
+    \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l pinned  -d 'Audit pinned formulas + casks (needs --dry-run or --force)'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -s f -l force -d 'Bypass pin protection'
     \\
     \\    # outdated
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l json        -d 'JSON output'
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l formula     -d 'Formulas only'
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l cask        -d 'Casks only'
-    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l pinned-only -d 'Pinned kegs only'
+    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l pinned-only -d 'Pinned formulas + casks only'
     \\
     \\    # list / ls
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l versions -d 'Show version numbers'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -93,15 +93,16 @@ const uninstall_help =
 const upgrade_help =
     \\Usage: malt upgrade [<package>] [flags]
     \\
-    \\Upgrade installed packages to latest versions. Pinned kegs are
-    \\skipped with a "pinned, skipped" line; pass --force to override.
+    \\Upgrade installed packages to latest versions. Pinned kegs and
+    \\casks are skipped with a "pinned, skipped" line; pass --force to
+    \\override.
     \\
     \\Flags:
     \\  --all          Upgrade everything (formulas + casks)
     \\  --cask         Upgrade casks only
     \\  --formula      Upgrade formulas only
     \\  --dry-run      Show what would be upgraded
-    \\  --pinned       Audit pinned kegs (requires --dry-run or --force)
+    \\  --pinned       Audit pinned formulas + casks (requires --dry-run or --force)
     \\  --force, -f    Bypass pin protection (dangerous; user-initiated)
     \\
 ;
@@ -122,7 +123,7 @@ const outdated_help =
     \\  --json         Output as JSON
     \\  --formula      Show outdated formulas only
     \\  --cask         Show outdated casks only
-    \\  --pinned-only  Audit pinned kegs only (formulas; CVE watch)
+    \\  --pinned-only  Audit pinned formulas + casks only (CVE watch)
     \\  --quiet, -q    Suppress status messages
     \\
 ;
@@ -367,18 +368,18 @@ const restore_help =
 const pin_help =
     \\Usage: malt pin <name>
     \\
-    \\Mark an installed keg as pinned so `malt upgrade` skips it. The pin
-    \\survives across upgrades and is visible in `mt list --pinned`.
-    \\Use `mt unpin <name>` to lift the pin, or `mt upgrade --force <name>`
-    \\to override it once.
+    \\Mark an installed formula or cask as pinned so `malt upgrade` skips
+    \\it. The pin survives across upgrades and is visible in
+    \\`mt list --pinned`. Use `mt unpin <name>` to lift it, or
+    \\`mt upgrade --force <name>` to override the pin once.
     \\
 ;
 
 const unpin_help =
     \\Usage: malt unpin <name>
     \\
-    \\Lift the pin on an installed keg so subsequent `malt upgrade` runs
-    \\touch it again.
+    \\Lift the pin on an installed formula or cask so subsequent
+    \\`malt upgrade` runs touch it again.
     \\
 ;
 

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -66,6 +66,16 @@ pub const executeDslPostInstall = post_install_mod.executeDslPostInstall;
 pub const drive = post_install_mod.drive;
 const record_mod = @import("install/record.zig");
 pub const InstallError = record_mod.InstallError;
+
+/// Wipe `<prefix>/Cellar/<name>/<version>` so a `--force` reinstall can
+/// re-materialize on top of it. No-op when the dir is missing or the
+/// path overflows the buffer; failures are best-effort because the
+/// follow-up materialize step surfaces real errors with full context.
+pub fn pruneCellarForReinstall(prefix: []const u8, name: []const u8, version: []const u8) void {
+    var cellar_buf: [512]u8 = undefined;
+    const cellar_path = std.fmt.bufPrint(&cellar_buf, "{s}/Cellar/{s}/{s}", .{ prefix, name, version }) catch return;
+    fs_compat.deleteTreeAbsolute(cellar_path) catch {};
+}
 pub const localErrorIsAnnounced = record_mod.localErrorIsAnnounced;
 pub const recordKeg = record_mod.recordKeg;
 pub const deleteKeg = record_mod.deleteKeg;
@@ -489,6 +499,17 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (main_mod.isInterrupted()) {
         output.warn("Interrupted. Cleaning up...", .{});
         return;
+    }
+
+    // `--force` semantics: re-materialize on top of an existing keg.
+    // The cellar's clonefile/copy refuses to overwrite a populated dir,
+    // so wipe each target Cellar dir up front. Pin survives because the
+    // DB row is rewritten via INSERT OR REPLACE with COALESCE-MAX
+    // inheritance on `pinned`.
+    if (force) {
+        for (all_jobs.items) |job| {
+            pruneCellarForReinstall(prefix, job.name, job.version_str);
+        }
     }
 
     // ── Parallel materialize phase ──────────────────────────────────

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -487,9 +487,11 @@ fn materializeRubyFormula(
 
     var keg_id: i64 = 0;
     {
+        // The COALESCE on `pinned` carries any existing user pin across
+        // INSERT OR REPLACE so a force-reinstall preserves the hold.
         var stmt = db.prepare(
-            "INSERT OR REPLACE INTO kegs (name, full_name, version, tap, store_sha256, cellar_path, install_reason)" ++
-                " VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'direct');",
+            "INSERT OR REPLACE INTO kegs (name, full_name, version, tap, store_sha256, cellar_path, install_reason, pinned)" ++
+                " VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'direct', COALESCE((SELECT MAX(pinned) FROM kegs WHERE name = ?1), 0));",
         ) catch return InstallError.RecordFailed;
         defer stmt.finalize();
         stmt.bindText(1, resolved.name) catch return InstallError.RecordFailed;

--- a/src/cli/install/record.zig
+++ b/src/cli/install/record.zig
@@ -90,9 +90,12 @@ pub fn recordKeg(
     db.beginTransaction() catch return InstallError.RecordFailed;
     errdefer db.rollback();
 
+    // The COALESCE on `pinned` carries any existing user pin across
+    // INSERT OR REPLACE so a force-reinstall preserves the hold; fresh
+    // installs default to 0.
     var stmt = db.prepare(
-        "INSERT OR REPLACE INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason)" ++
-            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8);",
+        "INSERT OR REPLACE INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason, pinned)" ++
+            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, COALESCE((SELECT MAX(pinned) FROM kegs WHERE name = ?1), 0));",
     ) catch return InstallError.RecordFailed;
     defer stmt.finalize();
 

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -82,13 +82,13 @@ pub fn writeHumanOutput(
 ) !void {
     const quiet = output.isQuiet();
 
-    if (show_formula) {
-        const sql = if (show_pinned)
-            "SELECT name, version, pinned FROM kegs WHERE pinned = 1 ORDER BY name;"
-        else
-            "SELECT name, version, pinned FROM kegs ORDER BY name;";
+    if (show_pinned) {
+        try writePinnedHuman(db, show_formula, show_cask, show_versions, quiet, stdout);
+        return;
+    }
 
-        var stmt = db.prepare(sql) catch return;
+    if (show_formula) {
+        var stmt = db.prepare("SELECT name, version, pinned FROM kegs ORDER BY name;") catch return;
         defer stmt.finalize();
 
         while (stmt.step() catch false) {
@@ -141,6 +141,63 @@ pub fn writeHumanOutput(
             stdout.writeAll("\n") catch return;
         }
     }
+}
+
+/// `--pinned` walks formulas + casks together so the output is a single
+/// sorted list across both kinds, with a `[cask]` tag distinguishing
+/// cask rows. The `[pinned]` tag is dropped — every row is pinned by
+/// definition, so repeating it is noise.
+fn writePinnedHuman(
+    db: *sqlite.Database,
+    show_formula: bool,
+    show_cask: bool,
+    show_versions: bool,
+    quiet: bool,
+    stdout: *std.Io.Writer,
+) !void {
+    const sql = pinnedUnionSql(show_formula, show_cask) orelse return;
+    var stmt = db.prepare(sql) catch return;
+    defer stmt.finalize();
+
+    while (stmt.step() catch false) {
+        const name = stmt.columnText(0) orelse continue;
+        const ver = stmt.columnText(1);
+        const kind = stmt.columnText(2);
+        const name_slice = std.mem.sliceTo(name, 0);
+        const is_cask = if (kind) |k| std.mem.eql(u8, std.mem.sliceTo(k, 0), "cask") else false;
+
+        if (quiet) {
+            stdout.writeAll(name_slice) catch return;
+            stdout.writeAll("\n") catch return;
+            continue;
+        }
+
+        writeBulletPrefix(stdout);
+        stdout.writeAll(name_slice) catch return;
+        if (show_versions) {
+            const ver_slice = if (ver) |v| std.mem.sliceTo(v, 0) else "?";
+            writeStyledSpan(stdout, color.SemanticStyle.detail.code(), " (", ver_slice, ")");
+        }
+        if (is_cask) {
+            writeStyledSpan(stdout, color.SemanticStyle.detail.code(), " [", "cask", "]");
+        }
+        stdout.writeAll("\n") catch return;
+    }
+}
+
+/// Build the SQL that drives the `--pinned` view. The 'formula' / 'cask'
+/// literal column tags each row so the caller can render the right marker.
+fn pinnedUnionSql(show_formula: bool, show_cask: bool) ?[:0]const u8 {
+    if (show_formula and show_cask)
+        return "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 " ++
+            "UNION ALL " ++
+            "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 " ++
+            "ORDER BY name;";
+    if (show_formula)
+        return "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 ORDER BY name;";
+    if (show_cask)
+        return "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 ORDER BY name;";
+    return null;
 }
 
 /// Emit the leading cyan bullet + space, honouring `NO_COLOR`.
@@ -198,8 +255,12 @@ pub fn buildListJson(
 ) !void {
     try w.writeAll("{\"installed\":[");
     var first = true;
-    if (show_formula) try writeFormulaRows(db, w, show_pinned, .installed, &first);
-    if (show_cask) try writeCaskRows(db, w, .installed, &first);
+    if (show_pinned) {
+        try writePinnedInstalled(db, w, show_formula, show_cask, &first);
+    } else {
+        if (show_formula) try writeFormulaRows(db, w, false, .installed, &first);
+        if (show_cask) try writeCaskRows(db, w, false, .installed, &first);
+    }
     try w.writeAll("]");
 
     if (show_formula) {
@@ -212,12 +273,46 @@ pub fn buildListJson(
     if (show_cask) {
         try w.writeAll(",\"casks\":[");
         var legacy_first = true;
-        try writeCaskRows(db, w, .legacy, &legacy_first);
+        try writeCaskRows(db, w, show_pinned, .legacy, &legacy_first);
         try w.writeAll("]");
     }
 
     try output.jsonTimeSuffix(w, start_ts);
     try w.writeAll("}\n");
+}
+
+/// `installed` array under `--pinned`: one sorted run across formulas
+/// and casks, each row carrying the `pinned: true` flag for parity with
+/// the formula-only shape callers already consume.
+fn writePinnedInstalled(
+    db: *sqlite.Database,
+    w: *std.Io.Writer,
+    show_formula: bool,
+    show_cask: bool,
+    first: *bool,
+) !void {
+    const sql = pinnedUnionSql(show_formula, show_cask) orelse return;
+    var stmt = db.prepare(sql) catch return;
+    defer stmt.finalize();
+
+    while (stmt.step() catch false) {
+        const name = stmt.columnText(0) orelse continue;
+        const ver = stmt.columnText(1);
+        const kind = stmt.columnText(2);
+        const is_cask = if (kind) |k| std.mem.eql(u8, std.mem.sliceTo(k, 0), "cask") else false;
+
+        if (!first.*) try w.writeAll(",");
+        first.* = false;
+        try w.writeAll("{\"name\":");
+        try output.jsonStr(w, std.mem.sliceTo(name, 0));
+        try w.writeAll(",\"version\":");
+        try output.jsonStr(w, if (ver) |v| std.mem.sliceTo(v, 0) else "");
+        if (is_cask) {
+            try w.writeAll(",\"type\":\"cask\",\"pinned\":true}");
+        } else {
+            try w.writeAll(",\"type\":\"formula\",\"pinned\":true}");
+        }
+    }
 }
 
 const RowShape = enum { installed, legacy };
@@ -265,10 +360,15 @@ fn writeFormulaRows(
 fn writeCaskRows(
     db: *sqlite.Database,
     w: *std.Io.Writer,
+    show_pinned: bool,
     shape: RowShape,
     first: *bool,
 ) !void {
-    var stmt = db.prepare("SELECT token, version FROM casks ORDER BY token;") catch return;
+    const sql: [:0]const u8 = if (show_pinned)
+        "SELECT token, version FROM casks WHERE pinned = 1 ORDER BY token;"
+    else
+        "SELECT token, version FROM casks ORDER BY token;";
+    var stmt = db.prepare(sql) catch return;
     defer stmt.finalize();
 
     while (stmt.step() catch false) {

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -474,9 +474,11 @@ fn recordKeg(
     db.beginTransaction() catch return error.RecordFailed;
     errdefer db.rollback();
 
+    // The COALESCE on `pinned` carries any existing user pin across
+    // INSERT OR REPLACE so re-migrating doesn't silently drop holds.
     var stmt = db.prepare(
-        "INSERT OR REPLACE INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason)" ++
-            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8);",
+        "INSERT OR REPLACE INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason, pinned)" ++
+            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, COALESCE((SELECT MAX(pinned) FROM kegs WHERE name = ?1), 0));",
     ) catch return error.RecordFailed;
     defer stmt.finalize();
 

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -154,12 +154,9 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             pinned_only = true;
         }
     }
-    // `--pinned-only` is formula-scoped: the casks table has no `pinned`
-    // column, so any cask scan would be vacuous. Force the formula scope.
-    if (pinned_only) {
-        cask_only = false;
-        formula_only = true;
-    }
+    // `--pinned-only` covers both formulas and casks now that the casks
+    // table has its own `pinned` column. The flag narrows the rows each
+    // section loads, but does not narrow the scope.
     // `--json` and `--quiet` are stripped by the global parser in main.zig.
     const json_mode = output.isJson();
 
@@ -199,7 +196,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         formula_count = try emitOutdatedFormulas(allocator, &db, &api, cache_dir, workers_override, stdout, json_mode, filter);
     }
     if (!formula_only) {
-        cask_count = try emitOutdatedCasks(allocator, &db, &api, cache_dir, workers_override, stdout, json_mode);
+        const filter: KegFilter = if (pinned_only) .pinned_only else .all;
+        cask_count = try emitOutdatedCasks(allocator, &db, &api, cache_dir, workers_override, stdout, json_mode, filter);
     }
 
     // Single end-of-run summary so we never print "All casks are up to
@@ -227,8 +225,23 @@ pub fn loadFormulaRows(
     return loadKegRows(allocator, db, sql);
 }
 
-/// Caller-side free for any rows returned by `loadFormulaRows` (or the
-/// internal cask query). Pairs with the allocator passed in.
+/// Cask sibling of `loadFormulaRows`. Same lifetime contract; pinned
+/// filter swaps in `WHERE pinned = 1` so `--pinned-only` walks the
+/// pinned-cask audit path symmetrically with formulas.
+pub fn loadCaskRows(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    filter: KegFilter,
+) ![]KegRow {
+    const sql: [:0]const u8 = switch (filter) {
+        .all => "SELECT token, version FROM casks ORDER BY token;",
+        .pinned_only => "SELECT token, version FROM casks WHERE pinned = 1 ORDER BY token;",
+    };
+    return loadKegRows(allocator, db, sql);
+}
+
+/// Caller-side free for any rows returned by `loadFormulaRows` /
+/// `loadCaskRows`. Pairs with the allocator passed in.
 pub fn freeKegRows(allocator: std.mem.Allocator, rows: []KegRow) void {
     for (rows) |r| {
         allocator.free(r.name);
@@ -294,8 +307,9 @@ fn emitOutdatedCasks(
     workers_override: ?usize,
     stdout: *std.Io.Writer,
     json_mode: bool,
+    filter: KegFilter,
 ) !usize {
-    const rows = try loadKegRows(allocator, db, "SELECT token, version FROM casks ORDER BY token;");
+    const rows = try loadCaskRows(allocator, db, filter);
     defer freeKegRows(allocator, rows);
 
     const entries = try collectOutdatedCasks(allocator, api, cache_dir, rows, workers_override);

--- a/src/cli/pin.zig
+++ b/src/cli/pin.zig
@@ -71,9 +71,20 @@ fn run(args: []const []const u8, action: Action) !void {
 
 /// Set the `pinned` column on `name`. Returns true when a row was matched
 /// (idempotent re-pins still report true). False means no installed keg
-/// of that name exists, which the caller should surface as a usage error.
+/// or cask of that name exists, which the caller surfaces as a usage error.
 pub fn setPinned(db: *sqlite.Database, name: []const u8, value: bool) sqlite.SqliteError!bool {
-    var stmt = try db.prepare("UPDATE kegs SET pinned = ?1 WHERE name = ?2;");
+    if (try setPinnedOn(db, "UPDATE kegs SET pinned = ?1 WHERE name = ?2;", name, value)) return true;
+    // Fall through to casks so `mt pin firefox` works on an installed cask.
+    return setPinnedOn(db, "UPDATE casks SET pinned = ?1 WHERE token = ?2;", name, value);
+}
+
+fn setPinnedOn(
+    db: *sqlite.Database,
+    sql: [:0]const u8,
+    name: []const u8,
+    value: bool,
+) sqlite.SqliteError!bool {
+    var stmt = try db.prepare(sql);
     defer stmt.finalize();
     try stmt.bindInt(1, @intFromBool(value));
     try stmt.bindText(2, name);
@@ -81,15 +92,20 @@ pub fn setPinned(db: *sqlite.Database, name: []const u8, value: bool) sqlite.Sql
     return changes(db) > 0;
 }
 
-/// Returns true iff an installed keg named `name` has `pinned=1`.
+/// Returns true iff an installed keg or cask named `name` has `pinned=1`.
 /// Missing rows are reported as not pinned — callers treat the absence
 /// of a row as "nothing to skip".
 pub fn isPinned(db: *sqlite.Database, name: []const u8) bool {
-    var stmt = db.prepare("SELECT pinned FROM kegs WHERE name = ?1 LIMIT 1;") catch return false;
+    if (lookupPinned(db, "SELECT pinned FROM kegs WHERE name = ?1 LIMIT 1;", name)) |p| return p;
+    return lookupPinned(db, "SELECT pinned FROM casks WHERE token = ?1 LIMIT 1;", name) orelse false;
+}
+
+fn lookupPinned(db: *sqlite.Database, sql: [:0]const u8, name: []const u8) ?bool {
+    var stmt = db.prepare(sql) catch return null;
     defer stmt.finalize();
-    stmt.bindText(1, name) catch return false;
-    const has = stmt.step() catch return false;
-    if (!has) return false;
+    stmt.bindText(1, name) catch return null;
+    const has = stmt.step() catch return null;
+    if (!has) return null;
     return stmt.columnBool(0);
 }
 

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -140,7 +140,11 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         return error.Aborted;
     };
 
-    // Update DB: delete old record, insert new one
+    // Update DB: delete old record, insert new one. Capture the old
+    // pin BEFORE the delete so the new row can inherit it — rolling
+    // back a held formula must not silently clear the user's hold.
+    const old_pinned = capturePinnedById(&db, current_id);
+
     db.beginTransaction() catch return error.Aborted;
     errdefer db.rollback();
 
@@ -154,14 +158,15 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     {
         var ins = db.prepare(
-            "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, install_reason)" ++
-                " VALUES (?1, ?1, ?2, ?3, ?4, 'direct');",
+            "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, install_reason, pinned)" ++
+                " VALUES (?1, ?1, ?2, ?3, ?4, 'direct', ?5);",
         ) catch return error.Aborted;
         defer ins.finalize();
         ins.bindText(1, name) catch return error.Aborted;
         ins.bindText(2, target.version) catch return error.Aborted;
         ins.bindText(3, target.sha256) catch return error.Aborted;
         ins.bindText(4, keg.path) catch return error.Aborted;
+        ins.bindInt(5, @intFromBool(old_pinned)) catch return error.Aborted;
         // Step failure inside the txn must trigger rollback, not a silent commit.
         _ = ins.step() catch return error.Aborted;
     }
@@ -182,4 +187,15 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     db.commit() catch return error.Aborted;
 
     output.info("{s} rolled back to {s}", .{ name, target.version });
+}
+
+/// Returns the `pinned` flag of the keg row identified by `keg_id`, or
+/// false if the row is missing or the read fails. Pub for tests; used
+/// inside `execute` to snapshot the hold across a DELETE/INSERT swap.
+pub fn capturePinnedById(db: *sqlite.Database, keg_id: i64) bool {
+    var stmt = db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;") catch return false;
+    defer stmt.finalize();
+    stmt.bindInt(1, keg_id) catch return false;
+    if (!(stmt.step() catch false)) return false;
+    return stmt.columnBool(0);
 }

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -68,9 +68,6 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     if (pinned_only) {
-        // Casks lack a `pinned` column; the audit is formula-scoped.
-        cask_only = false;
-        formula_only = true;
         // Without --dry-run or --force the audit would just print
         // "pinned, skipped" for every row - refuse rather than waste cycles.
         if (!dry_run and !force) {
@@ -139,7 +136,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             };
         }
         if (!formula_only) {
-            upgradeAllCasks(allocator, &db, &api, prefix, dry_run, force) catch {
+            upgradeAllCasks(allocator, &db, &api, prefix, dry_run, force, pinned_only) catch {
                 any_failed = true;
             };
         }
@@ -371,7 +368,10 @@ fn restoreOldLinks(
 }
 
 /// Record a keg in the database for upgrade. Returns the keg_id.
-fn recordKeg(
+/// The COALESCE on `pinned` inherits any existing user pin from the
+/// row(s) being replaced so a force-upgrade preserves the hold rather
+/// than silently clearing it. Fresh installs (no prior row) default to 0.
+pub fn recordKeg(
     db: *sqlite.Database,
     formula: *const formula_mod.Formula,
     store_sha256: []const u8,
@@ -381,8 +381,8 @@ fn recordKeg(
     errdefer db.rollback();
 
     var stmt = db.prepare(
-        "INSERT INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason)" ++
-            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'direct');",
+        "INSERT INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason, pinned)" ++
+            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'direct', COALESCE((SELECT MAX(pinned) FROM kegs WHERE name = ?1), 0));",
     ) catch return error.RecordFailed;
     defer stmt.finalize();
 
@@ -547,6 +547,10 @@ fn upgradeCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Data
 
     output.info("Upgrading {s} {s} -> {s}...", .{ token, installed_version, parsed_cask.version });
 
+    // Snapshot the pin BEFORE uninstall removes the cask row; re-apply
+    // after recordInstall so a `--force` upgrade preserves the user's hold.
+    const was_pinned = pin_mod.isPinned(db, token);
+
     // Uninstall old version
     var installer = cask_mod.CaskInstaller.init(allocator, db, prefix);
     installer.uninstall(token) catch {
@@ -565,11 +569,21 @@ fn upgradeCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Data
     };
     allocator.free(app_path);
 
+    if (was_pinned) {
+        // Best-effort: a missing pin restore is a UX regression, not data
+        // loss — the cask itself is upgraded and recorded.
+        _ = pin_mod.setPinned(db, token, true) catch {};
+    }
+
     output.success("{s} upgraded to {s}", .{ token, parsed_cask.version });
 }
 
-fn upgradeAllCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api_mod.BrewApi, prefix: [:0]const u8, dry_run: bool, force: bool) !void {
-    var stmt = db.prepare("SELECT token, version FROM casks ORDER BY token;") catch return;
+fn upgradeAllCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api_mod.BrewApi, prefix: [:0]const u8, dry_run: bool, force: bool, pinned_only: bool) !void {
+    const sql: [:0]const u8 = if (pinned_only)
+        "SELECT token, version FROM casks WHERE pinned = 1 ORDER BY token;"
+    else
+        "SELECT token, version FROM casks ORDER BY token;";
+    var stmt = db.prepare(sql) catch return;
     defer stmt.finalize();
 
     // Collect tokens first so we can free the statement before driving
@@ -591,7 +605,8 @@ fn upgradeAllCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api
     }
 
     if (tokens.items.len == 0) {
-        output.info("All casks are up to date.", .{});
+        // Quiet on the audit path: "no pinned casks" is the normal idle state.
+        if (!pinned_only) output.info("All casks are up to date.", .{});
         return;
     }
 
@@ -600,8 +615,7 @@ fn upgradeAllCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api
     defer failed_tokens.deinit(allocator);
 
     for (tokens.items) |token| {
-        // Cask scope never enters audit mode (no `pinned` column).
-        upgradeCask(allocator, token, db, api, prefix, dry_run, force, false) catch {
+        upgradeCask(allocator, token, db, api, prefix, dry_run, force, pinned_only) catch {
             failed_count += 1;
             // failed_count is authoritative; list is for UX only.
             failed_tokens.append(allocator, token) catch {};

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -68,9 +68,13 @@ pub fn parseCask(allocator: std.mem.Allocator, json_bytes: []const u8) !Cask {
 }
 
 /// Record cask installation in database.
+/// The COALESCE subquery on `pinned` carries any existing user pin
+/// across INSERT OR REPLACE so a force-upgrade doesn't silently clear
+/// the hold; first-time installs default to 0.
 pub fn recordInstall(db: *sqlite.Database, cask: *const Cask, app_path: ?[]const u8) sqlite.SqliteError!void {
     var stmt = try db.prepare(
-        "INSERT OR REPLACE INTO casks (token, name, version, url, sha256, app_path, auto_updates) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7);",
+        "INSERT OR REPLACE INTO casks (token, name, version, url, sha256, app_path, auto_updates, pinned)" ++
+            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, COALESCE((SELECT pinned FROM casks WHERE token = ?1), 0));",
     );
     defer stmt.finalize();
 

--- a/src/db/schema.zig
+++ b/src/db/schema.zig
@@ -103,6 +103,7 @@ pub fn migrate(db: *sqlite.Database) sqlite.SqliteError!void {
     const ver = try currentVersion(db);
     if (ver < 2) try migrateV1toV2(db);
     if (ver < 3) try migrateV2toV3(db);
+    if (ver < 4) try migrateV3toV4(db);
 }
 
 fn migrateV1toV2(db: *sqlite.Database) sqlite.SqliteError!void {
@@ -170,6 +171,36 @@ fn migrateV2toV3(db: *sqlite.Database) sqlite.SqliteError!void {
     }
 
     try db.exec("INSERT OR IGNORE INTO schema_version (version) VALUES (3);");
+
+    try db.commit();
+}
+
+/// v4 — extend `pinned` to casks so `mt pin <cask>` and the
+/// `--pinned-only` / `--pinned` audit surface are symmetric across
+/// formulas and casks.
+fn migrateV3toV4(db: *sqlite.Database) sqlite.SqliteError!void {
+    try db.beginTransaction();
+    errdefer db.rollback();
+
+    // PRAGMA-guarded ALTER so the migration is idempotent on a DB that
+    // already carries the column (re-runs against fresh fixtures).
+    var have_column = false;
+    {
+        var stmt = try db.prepare("PRAGMA table_info(casks);");
+        defer stmt.finalize();
+        while (try stmt.step()) {
+            const name = stmt.columnText(1) orelse continue;
+            if (std.mem.eql(u8, std.mem.sliceTo(name, 0), "pinned")) {
+                have_column = true;
+                break;
+            }
+        }
+    }
+    if (!have_column) {
+        try db.exec("ALTER TABLE casks ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0;");
+    }
+
+    try db.exec("INSERT OR IGNORE INTO schema_version (version) VALUES (4);");
 
     try db.commit();
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -316,7 +316,7 @@ fn printUsage() void {
         \\  rollback      Revert a package to its previous version
         \\  link          Create symlinks for an installed keg
         \\  unlink        Remove symlinks (keg stays installed)
-        \\  pin           Protect an installed keg from `upgrade`
+        \\  pin           Protect an installed formula or cask from `upgrade`
         \\  unpin         Lift the pin so `upgrade` resumes touching it
         \\  run           Run a package binary without installing
         \\  completions   Generate shell completion scripts (bash, zsh, fish)

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -99,6 +99,79 @@ test "parseCask rejects missing token" {
     try std.testing.expectError(cask.CaskError.ParseFailed, result);
 }
 
+// --- recordInstall pin preservation ---
+
+const test_cask_json_v2 =
+    \\{
+    \\  "token": "firefox",
+    \\  "name": ["Firefox"],
+    \\  "version": "200.0",
+    \\  "desc": "Web browser",
+    \\  "homepage": "https://www.mozilla.org/firefox/",
+    \\  "url": "https://download.mozilla.org/firefox-200.0.dmg",
+    \\  "sha256": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    \\  "auto_updates": true,
+    \\  "artifacts": [{"app": ["Firefox.app"]}]
+    \\}
+;
+
+fn openTempCaskDb(comptime tag: []const u8) !struct { dir: []const u8, db: sqlite.Database } {
+    const dir = "/tmp/malt_cask_recordinstall_" ++ tag;
+    malt.fs_compat.deleteTreeAbsolute(dir) catch {};
+    try malt.fs_compat.makeDirAbsolute(dir);
+    var buf: [256]u8 = undefined;
+    const path = try std.fmt.bufPrintSentinel(&buf, "{s}/test.db", .{dir}, 0);
+    var db = try sqlite.Database.open(path);
+    errdefer db.close();
+    try schema.initSchema(&db);
+    return .{ .dir = dir, .db = db };
+}
+
+fn readCaskPinned(db: *sqlite.Database, token: []const u8) !bool {
+    var stmt = try db.prepare("SELECT pinned FROM casks WHERE token = ?1 LIMIT 1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, token);
+    const has = try stmt.step();
+    if (!has) return error.NotFound;
+    return stmt.columnBool(0);
+}
+
+test "recordInstall preserves an existing pinned flag (force-upgrade keeps the hold)" {
+    var t = try openTempCaskDb("preserve_pin");
+    defer {
+        t.db.close();
+        malt.fs_compat.deleteTreeAbsolute(t.dir) catch {};
+    }
+
+    // Seed firefox at version 1 with pinned = 1.
+    try t.db.exec(
+        \\INSERT INTO casks (token, name, version, url, pinned)
+        \\VALUES ('firefox', 'Firefox', '123.0', 'https://example.invalid', 1);
+    );
+    try std.testing.expectEqual(true, try readCaskPinned(&t.db, "firefox"));
+
+    // Simulate a force-upgrade rewriting the row at version 200.
+    var c2 = try cask.parseCask(std.testing.allocator, test_cask_json_v2);
+    defer c2.deinit();
+    try cask.recordInstall(&t.db, &c2, "/Applications/Firefox.app");
+
+    try std.testing.expectEqual(true, try readCaskPinned(&t.db, "firefox"));
+}
+
+test "recordInstall on a fresh cask defaults pinned to 0" {
+    var t = try openTempCaskDb("fresh_pin");
+    defer {
+        t.db.close();
+        malt.fs_compat.deleteTreeAbsolute(t.dir) catch {};
+    }
+
+    var c2 = try cask.parseCask(std.testing.allocator, test_cask_json_v2);
+    defer c2.deinit();
+    try cask.recordInstall(&t.db, &c2, "/Applications/Firefox.app");
+
+    try std.testing.expectEqual(false, try readCaskPinned(&t.db, "firefox"));
+}
+
 // --- parseAppName ---
 
 test "parseAppName extracts app from artifacts" {

--- a/tests/db_schema_v2_test.zig
+++ b/tests/db_schema_v2_test.zig
@@ -52,7 +52,7 @@ test "initSchema runs v1 then migrates to v3" {
     try testing.expect(try tableExists(&tdb.db, "bundle_members"));
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 3), ver);
+    try testing.expectEqual(@as(i64, 4), ver);
 }
 
 test "migrate is idempotent on re-run" {
@@ -64,7 +64,37 @@ test "migrate is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 3), ver);
+    try testing.expectEqual(@as(i64, 4), ver);
+}
+
+test "v4 migration adds pinned column to casks" {
+    var tdb = try TempDb.init("v4_casks_pinned");
+    defer tdb.deinit();
+
+    try schema.initSchema(&tdb.db);
+
+    // INSERT exercising the new column proves the ALTER landed.
+    try tdb.db.exec(
+        \\INSERT INTO casks(token, name, version, url, pinned)
+        \\VALUES ('firefox', 'firefox', '120.0', 'https://example.invalid', 1);
+    );
+
+    var stmt = try tdb.db.prepare("SELECT pinned FROM casks WHERE token='firefox';");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    try testing.expectEqual(@as(i64, 1), stmt.columnInt(0));
+}
+
+test "v4 migration is idempotent on re-run" {
+    var tdb = try TempDb.init("v4_idempotent");
+    defer tdb.deinit();
+
+    try schema.initSchema(&tdb.db);
+    try schema.migrate(&tdb.db);
+    try schema.migrate(&tdb.db);
+
+    const ver = try schema.currentVersion(&tdb.db);
+    try testing.expectEqual(@as(i64, 4), ver);
 }
 
 test "v3 migration adds commit_sha column to taps" {

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -292,6 +292,49 @@ test "isInstalled is false before recordKeg, true after" {
     try testing.expect(install.isInstalled(&db, "foo"));
 }
 
+test "install.recordKeg preserves a prior pinned flag on REPLACE (force-reinstall keeps the hold)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    // Seed a pinned keg row at version 1.0 so the upcoming INSERT OR REPLACE
+    // for the same (name, version) hits the conflict path.
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, pinned)
+        \\VALUES ('foo', 'foo', '1.0', 'deadbeef', '/opt/malt/Cellar/foo/1.0', 1);
+    );
+
+    var f = try parseFake(arena.allocator());
+    defer f.deinit();
+    const keg_id = try install.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct");
+
+    var stmt = try db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, keg_id);
+    _ = try stmt.step();
+    try testing.expectEqual(true, stmt.columnBool(0));
+}
+
+test "install.recordKeg defaults pinned=0 when no prior keg of that name exists" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var f = try parseFake(arena.allocator());
+    defer f.deinit();
+    const keg_id = try install.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct");
+
+    var stmt = try db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, keg_id);
+    _ = try stmt.step();
+    try testing.expectEqual(false, stmt.columnBool(0));
+}
+
 test "recordDeps inserts one row per dependency in the dependencies table" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -292,6 +292,49 @@ test "isInstalled is false before recordKeg, true after" {
     try testing.expect(install.isInstalled(&db, "foo"));
 }
 
+test "pruneCellarForReinstall wipes an existing Cellar dir so --force can re-materialize" {
+    const prefix = try std.fmt.allocPrint(
+        testing.allocator,
+        "/tmp/malt_prune_cellar_{d}",
+        .{malt.fs_compat.nanoTimestamp()},
+    );
+    defer testing.allocator.free(prefix);
+    malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+
+    const keg_dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/foo/1.0/bin", .{prefix});
+    defer testing.allocator.free(keg_dir);
+    try malt.fs_compat.cwd().makePath(keg_dir);
+
+    const file = try std.fmt.allocPrint(testing.allocator, "{s}/foo", .{keg_dir});
+    defer testing.allocator.free(file);
+    {
+        const f = try malt.fs_compat.cwd().createFile(file, .{});
+        defer f.close();
+        try f.writeAll("payload");
+    }
+
+    install.pruneCellarForReinstall(prefix, "foo", "1.0");
+
+    const cellar_dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/foo/1.0", .{prefix});
+    defer testing.allocator.free(cellar_dir);
+    try testing.expectError(error.FileNotFound, malt.fs_compat.accessAbsolute(cellar_dir, .{}));
+}
+
+test "pruneCellarForReinstall is a no-op when the destination is missing" {
+    const prefix = try std.fmt.allocPrint(
+        testing.allocator,
+        "/tmp/malt_prune_cellar_missing_{d}",
+        .{malt.fs_compat.nanoTimestamp()},
+    );
+    defer testing.allocator.free(prefix);
+    malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+
+    // Never created — pruning must not fault, panic, or leak.
+    install.pruneCellarForReinstall(prefix, "ghost", "1.0");
+}
+
 test "install.recordKeg preserves a prior pinned flag on REPLACE (force-reinstall keeps the hold)" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();

--- a/tests/list_test.zig
+++ b/tests/list_test.zig
@@ -236,6 +236,141 @@ test "buildListJson: --pinned filters formulae to pinned only" {
     );
 }
 
+test "buildListJson: --pinned UNIONs pinned formulas and casks sorted by name" {
+    var t = try TempDb.init("pinned_mixed");
+    defer t.deinit();
+
+    // 'zsh' is the only pinned formula; 'firefox' is the only pinned cask.
+    // 'loose' (formula) and 'slack' (cask) must be excluded by the pinned filter.
+    try insertKeg(&t.db, "loose", "1.0", false);
+    try insertKeg(&t.db, "zsh", "5.9", true);
+    try insertCask(&t.db, "slack", "4.0");
+    try t.db.exec(
+        \\INSERT INTO casks (token, name, version, url, pinned)
+        \\VALUES ('firefox', 'firefox', '120.0', 'https://example.invalid', 1);
+    );
+
+    const out = try runBuild(testing.allocator, &t.db, true, true, true);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"firefox\",\"version\":\"120.0\",\"type\":\"cask\",\"pinned\":true}," ++
+            "{\"name\":\"zsh\",\"version\":\"5.9\",\"type\":\"formula\",\"pinned\":true}" ++
+            "],\"formulae\":[" ++
+            "{\"name\":\"zsh\",\"version\":\"5.9\",\"pinned\":true}" ++
+            "],\"casks\":[" ++
+            "{\"token\":\"firefox\",\"version\":\"120.0\"}" ++
+            "]",
+        body,
+    );
+}
+
+test "buildListJson: --pinned installed array interleaves formulas and casks by name" {
+    var t = try TempDb.init("pinned_interleave");
+    defer t.deinit();
+
+    // Names chosen so any en-bloc emit (formulas-then-casks or vice versa)
+    // would visibly mis-sort against the cross-kind name order.
+    try insertKeg(&t.db, "alpha", "1.0", true);
+    try insertKeg(&t.db, "charlie", "3.0", true);
+    try t.db.exec(
+        \\INSERT INTO casks (token, name, version, url, pinned)
+        \\VALUES ('bravo', 'bravo', '2.0', 'https://example.invalid', 1),
+        \\       ('delta', 'delta', '4.0', 'https://example.invalid', 1);
+    );
+
+    const out = try runBuild(testing.allocator, &t.db, true, true, true);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"alpha\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":true}," ++
+            "{\"name\":\"bravo\",\"version\":\"2.0\",\"type\":\"cask\",\"pinned\":true}," ++
+            "{\"name\":\"charlie\",\"version\":\"3.0\",\"type\":\"formula\",\"pinned\":true}," ++
+            "{\"name\":\"delta\",\"version\":\"4.0\",\"type\":\"cask\",\"pinned\":true}" ++
+            "],\"formulae\":[" ++
+            "{\"name\":\"alpha\",\"version\":\"1.0\",\"pinned\":true}," ++
+            "{\"name\":\"charlie\",\"version\":\"3.0\",\"pinned\":true}" ++
+            "],\"casks\":[" ++
+            "{\"token\":\"bravo\",\"version\":\"2.0\"}," ++
+            "{\"token\":\"delta\",\"version\":\"4.0\"}" ++
+            "]",
+        body,
+    );
+}
+
+test "buildListJson: --pinned legacy casks array excludes unpinned casks" {
+    var t = try TempDb.init("pinned_casks_legacy");
+    defer t.deinit();
+
+    try insertCask(&t.db, "loose-cask", "1.0"); // unpinned: must NOT appear
+    try t.db.exec(
+        \\INSERT INTO casks (token, name, version, url, pinned)
+        \\VALUES ('held-cask', 'held-cask', '2.0', 'https://example.invalid', 1);
+    );
+
+    const out = try runBuild(testing.allocator, &t.db, false, true, true);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"held-cask\",\"version\":\"2.0\",\"type\":\"cask\",\"pinned\":true}" ++
+            "],\"casks\":[" ++
+            "{\"token\":\"held-cask\",\"version\":\"2.0\"}" ++
+            "]",
+        body,
+    );
+}
+
+test "writeHumanOutput --pinned drops the [pinned] tag (every row is pinned by definition)" {
+    var t = try TempDb.init("human_pinned_no_tag");
+    defer t.deinit();
+    try insertKeg(&t.db, "alpha", "1.0", true);
+    try t.db.exec(
+        \\INSERT INTO casks (token, name, version, url, pinned)
+        \\VALUES ('bravo', 'bravo', '2.0', 'https://example.invalid', 1);
+    );
+
+    const out = try runHuman(testing.allocator, &t.db, true, true, false, true, false);
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "[pinned]") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "alpha") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "bravo") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "[cask]") != null);
+}
+
+test "writeHumanOutput --pinned merges pinned formulas + casks in one sorted list" {
+    var t = try TempDb.init("human_pinned_mixed");
+    defer t.deinit();
+
+    try insertKeg(&t.db, "loose", "1.0", false);
+    try insertKeg(&t.db, "zsh", "5.9", true);
+    try t.db.exec(
+        \\INSERT INTO casks (token, name, version, url, pinned)
+        \\VALUES ('firefox', 'firefox', '120.0', 'https://example.invalid', 1);
+    );
+    try insertCask(&t.db, "slack", "4.0"); // unpinned, must not appear
+
+    const out = try runHuman(testing.allocator, &t.db, true, true, false, true, false);
+    defer testing.allocator.free(out);
+
+    // Single sorted output: firefox (cask) then zsh (formula). 'loose' and
+    // 'slack' excluded by the pinned filter.
+    try testing.expect(std.mem.indexOf(u8, out, "  ▸ firefox") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "  ▸ zsh") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "loose") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "slack") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "[cask]") != null);
+    const firefox_pos = std.mem.indexOf(u8, out, "firefox").?;
+    const zsh_pos = std.mem.indexOf(u8, out, "zsh").?;
+    try testing.expect(firefox_pos < zsh_pos);
+}
+
 test "buildListJson: output parses as valid JSON" {
     var t = try TempDb.init("valid_json");
     defer t.deinit();

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -257,6 +257,76 @@ fn insertKeg(db: *sqlite.Database, name: []const u8, pinned: bool) !void {
     try db.exec(sql);
 }
 
+fn insertCask(db: *sqlite.Database, token: []const u8, pinned: bool) !void {
+    var buf: [512]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &buf,
+        "INSERT INTO casks (token, name, version, url, pinned) VALUES ('{s}', '{s}', '120.0', 'https://example.invalid', {d});",
+        .{ token, token, @intFromBool(pinned) },
+    );
+    try db.exec(sql);
+}
+
+test "loadCaskRows .pinned_only returns only pinned casks" {
+    const path = try setupPinnedPrefix("filter_pinned_casks");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertCask(&db, "loose-cask", false);
+    try insertCask(&db, "held-one", true);
+    try insertCask(&db, "held-two", true);
+
+    const rows = try outdated_mod.loadCaskRows(testing.allocator, &db, .pinned_only);
+    defer outdated_mod.freeKegRows(testing.allocator, rows);
+
+    try testing.expectEqual(@as(usize, 2), rows.len);
+    try testing.expectEqualStrings("held-one", rows[0].name);
+    try testing.expectEqualStrings("held-two", rows[1].name);
+}
+
+test "loadCaskRows .all returns every installed cask" {
+    const path = try setupPinnedPrefix("filter_all_casks");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertCask(&db, "loose-cask", false);
+    try insertCask(&db, "held-cask", true);
+
+    const rows = try outdated_mod.loadCaskRows(testing.allocator, &db, .all);
+    defer outdated_mod.freeKegRows(testing.allocator, rows);
+
+    try testing.expectEqual(@as(usize, 2), rows.len);
+    try testing.expectEqualStrings("held-cask", rows[0].name);
+    try testing.expectEqualStrings("loose-cask", rows[1].name);
+}
+
+test "outdated execute --pinned-only walks pinned casks alongside formulas" {
+    const path = try setupPinnedPrefix("exec_pinned_mixed");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        try insertKeg(&db, "loose", false);
+        try insertCask(&db, "free-cask", false);
+        try insertCask(&db, "held-cask", true);
+    }
+
+    // Cask-side row exists and is pinned: the audit must visit it instead of
+    // short-circuiting to formula-only scope. With no API cache the row drops
+    // out of the result silently — the success contract is "no error, no
+    // formula-only override".
+    try outdated_mod.execute(testing.allocator, &.{"--pinned-only"});
+}
+
 test "loadFormulaRows .pinned_only returns only pinned rows" {
     const path = try setupPinnedPrefix("filter_pinned");
     defer testing.allocator.free(path);

--- a/tests/pin_test.zig
+++ b/tests/pin_test.zig
@@ -165,6 +165,97 @@ test "isPinned reflects DB column" {
     try testing.expect(!cli_pin.isPinned(&db, "missing"));
 }
 
+fn insertCask(db: *sqlite.Database, token: []const u8, pinned: bool) !void {
+    var buf: [512]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &buf,
+        "INSERT INTO casks (token, name, version, url, pinned) VALUES ('{s}', '{s}', '120.0', 'https://example.invalid', {d});",
+        .{ token, token, @intFromBool(pinned) },
+    );
+    try db.exec(sql);
+}
+
+fn readCaskPinned(db: *sqlite.Database, token: []const u8) !bool {
+    var stmt = try db.prepare("SELECT pinned FROM casks WHERE token = ?1 LIMIT 1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, token);
+    const has = try stmt.step();
+    if (!has) return error.NotFound;
+    return stmt.columnBool(0);
+}
+
+test "mt pin <cask-token> falls through kegs and sets casks.pinned" {
+    const path = try setupPrefix("pin_cask_set");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openDb(path);
+        defer db.close();
+        try insertCask(&db, "firefox", false);
+    }
+
+    try cli_pin.execute(testing.allocator, &.{"firefox"});
+
+    var db = try openDb(path);
+    defer db.close();
+    try testing.expectEqual(true, try readCaskPinned(&db, "firefox"));
+}
+
+test "mt unpin <cask-token> clears casks.pinned" {
+    const path = try setupPrefix("unpin_cask_clear");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openDb(path);
+        defer db.close();
+        try insertCask(&db, "slack", true);
+    }
+
+    try cli_pin.executeUnpin(testing.allocator, &.{"slack"});
+
+    var db = try openDb(path);
+    defer db.close();
+    try testing.expectEqual(false, try readCaskPinned(&db, "slack"));
+}
+
+test "mt pin <cask> is idempotent — re-pinning a cask still succeeds" {
+    const path = try setupPrefix("pin_cask_idempotent");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openDb(path);
+        defer db.close();
+        try insertCask(&db, "obsidian", true);
+    }
+
+    try cli_pin.execute(testing.allocator, &.{"obsidian"});
+
+    var db = try openDb(path);
+    defer db.close();
+    try testing.expectEqual(true, try readCaskPinned(&db, "obsidian"));
+}
+
+test "isPinned reflects casks.pinned via fall-through" {
+    const path = try setupPrefix("ispinned_cask");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openDb(path);
+    defer db.close();
+    try insertCask(&db, "loose-cask", false);
+    try insertCask(&db, "held-cask", true);
+
+    try testing.expect(!cli_pin.isPinned(&db, "loose-cask"));
+    try testing.expect(cli_pin.isPinned(&db, "held-cask"));
+}
+
 test "mt pin is idempotent — re-pinning is a no-op success" {
     const path = try setupPrefix("pin_idempotent");
     defer testing.allocator.free(path);

--- a/tests/rollback_test.zig
+++ b/tests/rollback_test.zig
@@ -100,6 +100,41 @@ test "rollback returns error.Aborted when no previous version exists in store" {
     try testing.expectError(error.Aborted, err);
 }
 
+test "capturePinnedById reads the pinned column for a given keg id" {
+    const prefix = "/tmp/malt_rb_capture_pin";
+    malt.fs_compat.makeDirAbsolute(prefix) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+
+    var db = try sqlite.Database.open("/tmp/malt_rb_capture_pin/db.db");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, pinned)
+        \\VALUES ('held', 'held', '1.0', 'sha', '/cellar/held/1.0', 1),
+        \\       ('loose', 'loose', '1.0', 'sha2', '/cellar/loose/1.0', 0);
+    );
+
+    const held_id = blk: {
+        var s = try db.prepare("SELECT id FROM kegs WHERE name = 'held';");
+        defer s.finalize();
+        _ = try s.step();
+        break :blk s.columnInt(0);
+    };
+    const loose_id = blk: {
+        var s = try db.prepare("SELECT id FROM kegs WHERE name = 'loose';");
+        defer s.finalize();
+        _ = try s.step();
+        break :blk s.columnInt(0);
+    };
+
+    try testing.expect(rollback.capturePinnedById(&db, held_id));
+    try testing.expect(!rollback.capturePinnedById(&db, loose_id));
+    // Unknown id collapses to false rather than erroring — matches the
+    // "best-effort, never lose data" stance the rollback flow needs.
+    try testing.expect(!rollback.capturePinnedById(&db, 999_999));
+}
+
 test "schema version table exists" {
     const prefix = "/tmp/malt_sv_test";
     malt.fs_compat.makeDirAbsolute(prefix) catch {};

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -10,6 +10,7 @@ const testing = std.testing;
 const upgrade = malt.upgrade;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
+const formula_mod = malt.formula;
 
 const c = struct {
     extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
@@ -132,6 +133,174 @@ test "mt upgrade --pinned without --dry-run or --force errors with usage" {
     try testing.expectError(
         error.Aborted,
         upgrade.execute(testing.allocator, &.{"--pinned"}),
+    );
+}
+
+fn insertPinnedCask(db: *sqlite.Database, token: []const u8, version: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &buf,
+        "INSERT INTO casks (token, name, version, url, pinned) VALUES ('{s}', '{s}', '{s}', 'https://example.invalid', 1);",
+        .{ token, token, version },
+    );
+    try db.exec(sql);
+}
+
+test "mt upgrade <pinned-cask> is a quiet no-op (no API call)" {
+    const path = try setupPrefix("pinned_skip_named_cask");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        try insertPinnedCask(&db, "firefox", "120.0");
+    }
+
+    // Pinned cask short-circuits in upgradeCask before fetchCask — must NOT error.
+    try upgrade.execute(testing.allocator, &.{"firefox"});
+}
+
+test "recordKeg inherits pinned=1 from an existing keg of the same name" {
+    const path = try setupPrefix("recordkeg_inherit_pin");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertPinnedKeg(&db, "alpha");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const formula_json =
+        \\{
+        \\  "name": "alpha",
+        \\  "full_name": "alpha",
+        \\  "tap": "homebrew/core",
+        \\  "versions": {"stable": "2.0"}
+        \\}
+    ;
+    var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
+    defer formula.deinit();
+
+    const new_keg_id = try upgrade.recordKeg(&db, &formula, "deadbeef2", "/cellar/alpha/2.0");
+
+    var stmt = try db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, new_keg_id);
+    _ = try stmt.step();
+    try testing.expectEqual(true, stmt.columnBool(0));
+}
+
+test "force-upgrade-cask orchestration: pin survives removeRecord + recordInstall" {
+    // Simulates the DB side of upgradeCask under --force: the existing
+    // pinned cask row is removed (uninstall.removeRecord), a new row is
+    // inserted (recordInstall), and the orchestration must reapply the
+    // pin so the user's hold survives.
+    const path = try setupPrefix("force_upgrade_cask_pin");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertPinnedCask(&db, "firefox", "1.0");
+
+    const was_pinned = malt.cli_pin.isPinned(&db, "firefox");
+    try testing.expect(was_pinned);
+
+    // Step 1: uninstall side — DB row removed by removeRecord.
+    try malt.cask.removeRecord(&db, "firefox");
+
+    // Step 2: install side — recordInstall on a fresh row defaults pinned=0.
+    var c2 = try malt.cask.parseCask(testing.allocator,
+        \\{
+        \\  "token": "firefox",
+        \\  "name": ["Firefox"],
+        \\  "version": "200.0",
+        \\  "url": "https://example.invalid/firefox.dmg",
+        \\  "auto_updates": true,
+        \\  "artifacts": [{"app": ["Firefox.app"]}]
+        \\}
+    );
+    defer c2.deinit();
+    try malt.cask.recordInstall(&db, &c2, "/Applications/Firefox.app");
+
+    // Step 3: orchestration must reapply the pin.
+    if (was_pinned) {
+        _ = try malt.cli_pin.setPinned(&db, "firefox", true);
+    }
+
+    try testing.expect(malt.cli_pin.isPinned(&db, "firefox"));
+}
+
+test "recordKeg defaults pinned=0 when no prior keg of that name exists" {
+    const path = try setupPrefix("recordkeg_fresh_pin");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const formula_json =
+        \\{
+        \\  "name": "fresh",
+        \\  "full_name": "fresh",
+        \\  "tap": "homebrew/core",
+        \\  "versions": {"stable": "1.0"}
+        \\}
+    ;
+    var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
+    defer formula.deinit();
+
+    const new_keg_id = try upgrade.recordKeg(&db, &formula, "deadbeef0", "/cellar/fresh/1.0");
+
+    var stmt = try db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, new_keg_id);
+    _ = try stmt.step();
+    try testing.expectEqual(false, stmt.columnBool(0));
+}
+
+test "pinSkip honours --force and audit_mode for casks too" {
+    const path = try setupPrefix("pinskip_cask");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertPinnedCask(&db, "held-cask", "1.0");
+
+    try testing.expect(upgrade.pinSkip(&db, "held-cask", false, false));
+    try testing.expect(!upgrade.pinSkip(&db, "held-cask", true, false));
+    try testing.expect(!upgrade.pinSkip(&db, "held-cask", false, true));
+}
+
+test "mt upgrade --pinned --dry-run reaches the cask path (no formula-only override)" {
+    const path = try setupPrefix("pinned_audit_cask");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        try insertPinnedCask(&db, "pinned-cask", "1.0");
+    }
+
+    // No cache seeded: if the walker reaches the cask, fetchCask fails and
+    // aborts; if the formula-only override is still in place, the cask
+    // path is silently skipped and execute() returns OK. The audit must
+    // walk the row, so this run aborts.
+    try testing.expectError(
+        error.Aborted,
+        upgrade.execute(testing.allocator, &.{ "--pinned", "--dry-run" }),
     );
 }
 


### PR DESCRIPTION
## Description

`mt pin` / `mt unpin` now work on casks too, and `mt list --pinned`, `mt outdated --pinned-only`, `mt upgrade --pinned --dry-run` all surface formulas and casks together. Closes the asymmetry where the pin column and the audit flags both existed but only on the formula side.

The same pass extends pin durability to every keg/cask write path: `mt upgrade --force`, `mt install --force`, `mt rollback`, and `mt migrate` re-runs all preserve a user's pin across the row swap instead of silently clearing it. A pinned package stays pinned through any non-uninstall lifecycle event, formulas and casks alike.

## Related Issue

- None

## Notes for Reviewers

- Migration mirrors the v2 -> v3 `taps.commit_sha` add: ALTER guarded by a PRAGMA probe, schema_version bump inside the same transaction.
