### PR TITLE
Polish version update UX: aligned confirm prompt and sudo auto-escalation

### DIFF
--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -213,10 +213,15 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     output.info("Replacing {s}...", .{self_exe});
-    swap.atomicReplace(self_exe, new_binary) catch |e| switch (e) {
+    const mode_after_self = replaceBinary(allocator, new_binary, self_exe, .user) catch |e| switch (e) {
+        error.SudoSpawnFailed, error.SudoFailed => {
+            output.err("sudo elevation failed for {s}.", .{self_exe});
+            output.info("Manual update: sudo install -m 0755 -b -B .old {s} {s}", .{ new_binary, self_exe });
+            return error.Aborted;
+        },
         error.StagingFailed, error.SwapFailed => {
-            output.err("Failed to replace {s}. You may need sudo.", .{self_exe});
-            output.info("Manual update: sudo cp {s} {s}", .{ new_binary, self_exe });
+            output.err("Failed to replace {s}.", .{self_exe});
+            output.info("Manual update: sudo install -m 0755 -b -B .old {s} {s}", .{ new_binary, self_exe });
             return;
         },
         error.RollbackFailed => {
@@ -228,17 +233,20 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             output.info("  sudo mv {s}.old {s}", .{ self_exe, self_exe });
             return error.Aborted;
         },
+        else => return e,
     };
 
     if (twin_path) |tp| {
         output.info("Replacing {s}...", .{tp});
-        swap.atomicReplace(tp, new_binary) catch |e| {
+        // Pass the post-self mode so the twin re-uses the elevation
+        // decision instead of paying a second sudo prompt.
+        _ = replaceBinary(allocator, new_binary, tp, mode_after_self) catch |e| {
             // Don't roll back self: one updated binary beats a forced
             // downgrade on the one the user just invoked. Surface the
             // manual fix so they can close the gap.
             output.err("Failed to replace {s}: {s}", .{ tp, @errorName(e) });
             output.warn("{s} is now {s} but {s} is still the previous version.", .{ self_exe, latest, tp });
-            output.info("Finish manually: sudo cp {s} {s}", .{ new_binary, tp });
+            output.info("Finish manually: sudo install -m 0755 -b -B .old {s} {s}", .{ new_binary, tp });
             output.info("Updated to {s} (previous {s} kept at {s}.old)", .{ latest, std.fs.path.basename(self_exe), self_exe });
             return;
         };
@@ -247,6 +255,56 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     output.info("Updated to {s} (previous kept at {s}.old)", .{ latest, self_exe });
+}
+
+/// How the previous swap was carried out. Threaded through twin handling
+/// so a single sudo prompt covers both binaries.
+pub const ReplaceMode = enum { user, sudo };
+
+/// Replace `target` with `new_binary`. In `.user` mode, attempt an
+/// unprivileged atomic swap; on EACCES, escalate via `sudo install`.
+/// In `.sudo` mode, skip the unprivileged attempt entirely so callers
+/// can short-circuit a known-unwritable directory after the first prompt.
+fn replaceBinary(
+    allocator: std.mem.Allocator,
+    new_binary: []const u8,
+    target: []const u8,
+    mode: ReplaceMode,
+) !ReplaceMode {
+    if (mode == .sudo) {
+        try installBinaryViaSudo(allocator, new_binary, target);
+        return .sudo;
+    }
+    swap.atomicReplace(target, new_binary) catch |e| switch (e) {
+        error.PermissionDenied => {
+            output.warn("Cannot write to {s}; escalating with sudo.", .{std.fs.path.dirname(target) orelse target});
+            try installBinaryViaSudo(allocator, new_binary, target);
+            return .sudo;
+        },
+        else => return e,
+    };
+    return .user;
+}
+
+/// Build the argv passed to `sudo install` for the elevation fallback.
+/// `-b -B .old` keeps the same `.old` rollback shape `atomicReplace`
+/// emits, so cleanup paths see one layout regardless of how the swap
+/// happened. macOS BSD-install spelling: GNU's `-S .old` is wrong here.
+pub fn buildSudoInstallArgv(new_binary: []const u8, target: []const u8) [9][]const u8 {
+    return .{ "sudo", "install", "-m", "0755", "-b", "-B", ".old", new_binary, target };
+}
+
+/// Spawn `sudo install` with the user's TTY inherited. Sudo prompts for
+/// the password on its own; we just propagate the exit status.
+fn installBinaryViaSudo(allocator: std.mem.Allocator, new_binary: []const u8, target: []const u8) !void {
+    const argv = buildSudoInstallArgv(new_binary, target);
+    var child = fs_compat.Child.init(&argv, allocator);
+    child.spawn() catch return error.SudoSpawnFailed;
+    const term = child.wait() catch return error.SudoSpawnFailed;
+    switch (term) {
+        .exited => |code| if (code != 0) return error.SudoFailed,
+        else => return error.SudoFailed,
+    }
 }
 
 /// Return the sibling binary path (`malt` ↔ `mt`) next to `self_exe`, but

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -100,6 +100,26 @@ pub fn err(comptime fmt: []const u8, args: anytype) void {
     writePrefixedLine(msg, .err, "  ✗ ", "  x ");
 }
 
+/// Print a confirmation prompt: info-coloured `?` icon, bold message,
+/// no trailing newline so the user's typed answer continues the line.
+/// Bypasses `--quiet` — a silent prompt would deadlock interactive flows.
+pub fn question(comptime fmt: []const u8, args: anytype) void {
+    var buf: [4096]u8 = undefined;
+    const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
+    const prefix: []const u8 = if (color.isEmojiEnabled()) "  ? " else "  ? ";
+    if (color.isColorEnabled()) {
+        io_mod.stderrWriteAll(color.SemanticStyle.info.code());
+        io_mod.stderrWriteAll(prefix);
+        io_mod.stderrWriteAll(color.Style.reset.code());
+        io_mod.stderrWriteAll(color.Style.bold.code());
+        io_mod.stderrWriteAll(msg);
+        io_mod.stderrWriteAll(color.Style.reset.code());
+    } else {
+        io_mod.stderrWriteAll(prefix);
+        io_mod.stderrWriteAll(msg);
+    }
+}
+
 /// Write a single styled line (no icon prefix). Pass null `style_code`
 /// for plain text. Respects `--quiet`.
 fn lineStyled(style_code: ?[]const u8, comptime fmt: []const u8, args: anytype) void {
@@ -178,20 +198,14 @@ pub fn skip(comptime fmt: []const u8, args: anytype) void {
 }
 
 /// Read a single line from stdin and return true iff the trimmed input
-/// matches `expected` exactly.  Prints `prompt` to stderr first.
+/// matches `expected` exactly. Prints `prompt` via `question` first.
 ///
 /// Returns false when stdin is not a TTY so that destructive commands
 /// refuse to run unattended without an explicit `--yes` opt-in.
 pub fn confirmTyped(expected: []const u8, prompt: []const u8) bool {
     if (!fs_compat.isatty(std.posix.STDIN_FILENO)) return false;
 
-    if (color.isColorEnabled()) {
-        io_mod.stderrWriteAll(color.Style.bold.code());
-        io_mod.stderrWriteAll(prompt);
-        io_mod.stderrWriteAll(color.Style.reset.code());
-    } else {
-        io_mod.stderrWriteAll(prompt);
-    }
+    question("{s}", .{prompt});
 
     var buf: [128]u8 = undefined;
     const n = std.posix.read(std.posix.STDIN_FILENO, &buf) catch return false;

--- a/src/update/swap.zig
+++ b/src/update/swap.zig
@@ -11,7 +11,7 @@ const fs_compat = @import("../fs/compat.zig");
 
 pub const SwapError = error{
     /// Could not stage the new binary next to the target (disk full,
-    /// permission, parent-dir unwritable). No file has moved yet.
+    /// non-permission failure). No file has moved yet.
     StagingFailed,
     /// The target→.old rename failed. Target is untouched.
     SwapFailed,
@@ -19,6 +19,10 @@ pub const SwapError = error{
     /// also failed). `<target>.old` may be the live binary; the real
     /// target path may not exist. Caller surfaces the situation loudly.
     RollbackFailed,
+    /// EACCES/EPERM on the staging copy or the target rename. Distinct
+    /// from `StagingFailed`/`SwapFailed` so the updater can elevate via
+    /// sudo instead of dumping a manual recovery hint.
+    PermissionDenied,
 };
 
 /// Replace `target_path` with the contents of `new_path`. On success,
@@ -41,9 +45,14 @@ pub fn atomicReplace(target_path: []const u8, new_path: []const u8) SwapError!vo
         return error.StagingFailed;
 
     // Stage the new binary next to the target. Cleans any stale file
-    // from a killed earlier run first so copy never EEXISTs.
+    // from a killed earlier run first so copy never EEXISTs. EACCES on
+    // the staging copy means the target dir is unwritable — the updater
+    // catches `PermissionDenied` and re-runs the swap under sudo.
     fs_compat.deleteFileAbsolute(staged_path) catch {};
-    fs_compat.copyFileAbsolute(new_path, staged_path, .{}) catch return error.StagingFailed;
+    fs_compat.copyFileAbsolute(new_path, staged_path, .{}) catch |e| switch (e) {
+        error.AccessDenied => return error.PermissionDenied,
+        else => return error.StagingFailed,
+    };
     // Errdefer cleanup: stage leaks get reaped by the next update's pre-copy delete above.
     errdefer fs_compat.deleteFileAbsolute(staged_path) catch {};
 
@@ -52,8 +61,10 @@ pub fn atomicReplace(target_path: []const u8, new_path: []const u8) SwapError!vo
     // close: a rename is not durable without a prior fsync, so a power
     // loss after rename could otherwise expose a partial binary.
     {
-        const f = fs_compat.openFileAbsolute(staged_path, .{ .mode = .read_write }) catch
-            return error.StagingFailed;
+        const f = fs_compat.openFileAbsolute(staged_path, .{ .mode = .read_write }) catch |e| switch (e) {
+            error.AccessDenied => return error.PermissionDenied,
+            else => return error.StagingFailed,
+        };
         defer f.close();
         f.chmod(0o755) catch return error.StagingFailed;
         f.sync() catch return error.StagingFailed;
@@ -62,8 +73,12 @@ pub fn atomicReplace(target_path: []const u8, new_path: []const u8) SwapError!vo
     // Clear any .old left by a crashed prior run before we overwrite it.
     fs_compat.deleteFileAbsolute(old_path) catch {};
 
-    // Atomic rename #1: target -> target.old.
-    fs_compat.renameAbsolute(target_path, old_path) catch return error.SwapFailed;
+    // Atomic rename #1: target -> target.old. EACCES/EPERM here means
+    // the dir is unwritable — same sudo-fallback path as the staging copy.
+    fs_compat.renameAbsolute(target_path, old_path) catch |e| switch (e) {
+        error.AccessDenied, error.PermissionDenied => return error.PermissionDenied,
+        else => return error.SwapFailed,
+    };
     // Rollback rename; if this also fails the caller already has RollbackFailed surfaced.
     errdefer fs_compat.renameAbsolute(old_path, target_path) catch {};
 

--- a/tests/output_test.zig
+++ b/tests/output_test.zig
@@ -271,6 +271,44 @@ test "err wraps the red prefix and uses the cross glyph" {
     try testing.expectEqualStrings("\x1b[31m  ✗ \x1b[0mnope\n", buf.items);
 }
 
+// `question` prints a confirmation-style prompt: cyan `?` icon, bold msg,
+// no trailing newline so the user types directly after the colon.
+test "question wraps the cyan prefix and bold msg without a newline" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, true, true, false);
+    defer cap.deinit();
+
+    output.question("Replace {s}? ", .{"foo"});
+    try testing.expectEqualStrings(
+        "\x1b[36m  ? \x1b[0m\x1b[1mReplace foo? \x1b[0m",
+        buf.items,
+    );
+}
+
+test "question falls back to ASCII prefix without color or emoji" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, false, false, false);
+    defer cap.deinit();
+
+    output.question("Continue? ", .{});
+    try testing.expectEqualStrings("  ? Continue? ", buf.items);
+}
+
+// Prompts must always render; --quiet only silences informational chatter.
+// If `quiet` ever swallowed `question`, confirmTyped would block on a
+// hidden prompt and the user would think malt hung.
+test "question is NOT suppressed by --quiet" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, false, false, true);
+    defer cap.deinit();
+
+    output.question("Confirm? ", .{});
+    try testing.expectEqualStrings("  ? Confirm? ", buf.items);
+}
+
 // Contract: errors always print, even under `--quiet`. If this ever flips,
 // users will stop seeing failure reasons when they pass `-q` to scripts.
 test "err is NOT suppressed by --quiet" {

--- a/tests/swap_test.zig
+++ b/tests/swap_test.zig
@@ -198,3 +198,30 @@ test "atomicReplace returns SwapFailed when target does not exist" {
 
     try testing.expectError(error.SwapFailed, swap.atomicReplace(p.target, p.new));
 }
+
+test "atomicReplace returns PermissionDenied when target dir is read-only" {
+    // root bypasses POSIX mode bits, so the EACCES path under test cannot
+    // fire — skip rather than mis-pass.
+    if (std.c.geteuid() == 0) return error.SkipZigTest;
+
+    var p = try Paths.init(testing.allocator, "readonly_dir");
+    defer p.deinit(testing.allocator);
+    try writeFile(p.target, "old");
+    try writeFile(p.new, "new");
+
+    // Drop write access on the parent directory; staging the new binary
+    // next to the target must fail with EACCES, which the swap surfaces
+    // as PermissionDenied for the updater's sudo-fallback path.
+    const dir_z = try testing.allocator.dupeZ(u8, p.dir);
+    defer testing.allocator.free(dir_z);
+    if (std.c.chmod(dir_z.ptr, 0o555) != 0) return error.SkipZigTest;
+    defer _ = std.c.chmod(dir_z.ptr, 0o755);
+
+    try testing.expectError(error.PermissionDenied, swap.atomicReplace(p.target, p.new));
+
+    // Target must still be intact after a permission-denied staging.
+    _ = std.c.chmod(dir_z.ptr, 0o755);
+    const target_contents = try readFile(testing.allocator, p.target);
+    defer testing.allocator.free(target_contents);
+    try testing.expectEqualStrings("old", target_contents);
+}

--- a/tests/version_update_test.zig
+++ b/tests/version_update_test.zig
@@ -212,3 +212,24 @@ test "resolveTwinRegularFile: returns null for unrelated basenames" {
     var buf: [fs_compat.max_path_bytes]u8 = undefined;
     try testing.expect(updater.resolveTwinRegularFile(other_path, &buf) == null);
 }
+
+// --- buildSudoInstallArgv ------------------------------------------------
+//
+// `install -m 0755 -b -B .old` is the sudo fallback when the user lacks
+// write access to the install directory (e.g. /usr/local/bin without
+// admin group). One BSD-install invocation gives us atomic copy +
+// `.old` backup + executable bit in a single sudo prompt — the same
+// rollback contract `atomicReplace` provides for the unprivileged path.
+test "buildSudoInstallArgv: shape matches BSD install with .old backup suffix" {
+    const argv = updater.buildSudoInstallArgv("/tmp/new-malt", "/usr/local/bin/malt");
+    try testing.expectEqual(@as(usize, 9), argv.len);
+    try testing.expectEqualStrings("sudo", argv[0]);
+    try testing.expectEqualStrings("install", argv[1]);
+    try testing.expectEqualStrings("-m", argv[2]);
+    try testing.expectEqualStrings("0755", argv[3]);
+    try testing.expectEqualStrings("-b", argv[4]);
+    try testing.expectEqualStrings("-B", argv[5]);
+    try testing.expectEqualStrings(".old", argv[6]);
+    try testing.expectEqualStrings("/tmp/new-malt", argv[7]);
+    try testing.expectEqualStrings("/usr/local/bin/malt", argv[8]);
+}


### PR DESCRIPTION
## Description

Two UX papercuts in `mt version update` removed:

- The "Replace … with X? Type 'yes' to confirm:" prompt now lines up with the rest of the run. It shares the indented icon shape used by every other status line, instead of being a bare bold paragraph in the middle of the flow.
- Running the command without `sudo` no longer fails when the install directory is owned by root. The updater detects the permission case the moment it happens, asks `sudo` for the password right there, and finishes the swap. No more downloading the tarball, typing `yes`, watching it abort, and rerunning the whole command with `sudo` prefixed.

The `.old` rollback file the unprivileged path leaves behind is preserved on the elevated path too, so cleanup and downgrade behave identically regardless of who owned the install directory. When two binaries are installed side by side (`malt` and `mt`), the password prompt appears once and covers both.

## Related Issue

- None

## Notes for Reviewers

- None