### PR TITLE
feat(cli): instant mt outdated via cached snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,10 +265,16 @@ A pinned package is held at its current version: `mt upgrade <name>` skips it wi
 Refresh the local formula/cask metadata cache.
 
 ```bash
-mt update
+mt update                                # wipe API cache + drop snapshot (fast)
+mt update --check                        # write a fresh outdated snapshot only
 ```
 
-Invalidates all entries in the API cache. The next `install`, `search`, or `info` command fetches fresh data from the Homebrew API.
+| Flag            | Description                                                      |
+| --------------- | ---------------------------------------------------------------- |
+| `--check`       | Write a fresh `cache/outdated.json` snapshot; skip API cache wipe |
+| `--quiet`, `-q` | Suppress status messages                                         |
+
+Default `mt update` invalidates the API cache so the next `install`, `search`, or `info` fetches fresh data, and drops any cached `outdated.json` so the next `mt outdated` recomputes against the new world. `--check` is the explicit "warm the snapshot" path for shell-prompt integrations.
 
 ### `mt outdated`
 
@@ -280,17 +286,21 @@ mt outdated --json
 mt outdated --cask
 mt outdated --formula
 mt outdated --pinned-only                # CVE watch on held-back versions
+mt outdated --refresh                    # bypass the cached snapshot
 ```
 
-| Flag            | Description                        |
-| --------------- | ---------------------------------- |
-| `--json`        | Output as JSON                     |
-| `--formula`     | Show outdated formulas only        |
-| `--cask`        | Show outdated casks only           |
-| `--pinned-only` | Audit pinned formulas + casks only |
-| `--quiet`, `-q` | Suppress status messages           |
+| Flag            | Description                                                       |
+| --------------- | ----------------------------------------------------------------- |
+| `--json`        | Output as JSON                                                    |
+| `--formula`     | Show outdated formulas only                                       |
+| `--cask`        | Show outdated casks only                                          |
+| `--pinned-only` | Audit pinned formulas + casks only                                |
+| `--refresh`     | Force live recompute, bypassing the cached snapshot               |
+| `--quiet`, `-q` | Suppress status messages                                          |
 
 Compares installed versions against the latest from the Homebrew API. Checks both formulas and casks by default. `--pinned-only` narrows the scan to pinned packages (formulas + casks) so you can see when an upstream release supersedes the version you've held back — pair with `mt upgrade --pinned --dry-run` for the full audit/preview pair.
+
+**Snapshot cache.** When a fresh `cache/outdated.json` is present, `mt outdated` reads it instead of round-tripping the Homebrew API — making it usable in shell prompts and instant-feedback integrations. The snapshot is filtered through the live DB at read time so an uninstalled or manually-upgraded keg can never appear. The threshold is 24 h by default; override with `MALT_OUTDATED_MAX_AGE=<hours>` (set to `0` to mark every snapshot stale). A stale read warns and recommends `mt update --check`. Snapshots are auto-refreshed after any full live recompute.
 
 ```text
 wget (1.24.5) < 1.25.0

--- a/bench/snapshot_bench.zig
+++ b/bench/snapshot_bench.zig
@@ -1,0 +1,210 @@
+//! Microbench for the outdated-snapshot hot path.
+//!
+//! Times the three operations on the snapshot read path —
+//! `renderSnapshot`, `parseSnapshot`, `intersectWithDb` — across a
+//! synthetic dataset sized to match a heavily-installed machine.
+//!
+//! Run via `just bench-snapshot`. Asserts a hard per-op budget so a
+//! regression breaks the bench rather than slipping into a release.
+
+const std = @import("std");
+const malt = @import("malt");
+const outdated = malt.cli_outdated;
+const fs_compat = malt.fs_compat;
+
+fn nowNs() u64 {
+    return @intCast(fs_compat.nanoTimestamp());
+}
+
+/// Realistic upper bound for an active developer machine.
+const N_FORMULAS: usize = 500;
+/// 10% outdated is a generous worst case; most prefixes have far fewer.
+const N_OUTDATED: usize = 50;
+const N_CASKS: usize = 100;
+const N_OUTDATED_CASKS: usize = 10;
+
+/// Iterations per phase. Picked so each phase runs well past 100 ms on
+/// the slowest realistic hardware, so the median + p95 are meaningful.
+const ITERS: usize = 200;
+
+/// Hard budgets — anything above these on a quiet macOS machine is a
+/// regression worth investigating. Generous enough to absorb CI noise.
+const BUDGET_RENDER_NS: u64 = 5 * std.time.ns_per_ms;
+const BUDGET_PARSE_NS: u64 = 10 * std.time.ns_per_ms;
+const BUDGET_INTERSECT_NS: u64 = 1 * std.time.ns_per_ms;
+
+const Stat = struct {
+    median_ns: u64,
+    p95_ns: u64,
+    min_ns: u64,
+    max_ns: u64,
+};
+
+fn computeStat(samples: []u64) Stat {
+    std.mem.sort(u64, samples, {}, std.sort.asc(u64));
+    const median = samples[samples.len / 2];
+    const p95_idx = (samples.len * 95) / 100;
+    return .{
+        .median_ns = median,
+        .p95_ns = samples[p95_idx],
+        .min_ns = samples[0],
+        .max_ns = samples[samples.len - 1],
+    };
+}
+
+fn printStat(name: []const u8, s: Stat, budget_ns: u64) void {
+    const ok = if (s.median_ns <= budget_ns) "OK" else "OVER";
+    std.debug.print(
+        "  {s:<14}  median={d:>7}us  p95={d:>7}us  min={d:>7}us  max={d:>7}us  budget={d:>5}us [{s}]\n",
+        .{
+            name,
+            s.median_ns / std.time.ns_per_us,
+            s.p95_ns / std.time.ns_per_us,
+            s.min_ns / std.time.ns_per_us,
+            s.max_ns / std.time.ns_per_us,
+            budget_ns / std.time.ns_per_us,
+            ok,
+        },
+    );
+}
+
+fn buildSyntheticEntries(
+    arena: std.mem.Allocator,
+    count: usize,
+    name_prefix: []const u8,
+) ![]outdated.OutdatedEntry {
+    const out = try arena.alloc(outdated.OutdatedEntry, count);
+    for (out, 0..) |*e, i| {
+        e.* = .{
+            .name = try std.fmt.allocPrint(arena, "{s}{d:0>4}", .{ name_prefix, i }),
+            .installed = try arena.dupe(u8, "1.0.0"),
+            .latest = try arena.dupe(u8, "2.0.0"),
+        };
+    }
+    return out;
+}
+
+fn buildDbRows(
+    arena: std.mem.Allocator,
+    total: usize,
+    name_prefix: []const u8,
+) ![]outdated.KegRow {
+    const out = try arena.alloc(outdated.KegRow, total);
+    for (out, 0..) |*r, i| {
+        r.* = .{
+            .name = try std.fmt.allocPrint(arena, "{s}{d:0>4}", .{ name_prefix, i }),
+            .version = "1.0.0",
+        };
+    }
+    return out;
+}
+
+pub fn main() !void {
+    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    std.debug.print(
+        "snapshot_bench: N_FORMULAS={d} (outdated={d}), N_CASKS={d} (outdated={d}), iters={d}\n\n",
+        .{ N_FORMULAS, N_OUTDATED, N_CASKS, N_OUTDATED_CASKS, ITERS },
+    );
+
+    const formulas = try buildSyntheticEntries(arena, N_OUTDATED, "f");
+    const casks = try buildSyntheticEntries(arena, N_OUTDATED_CASKS, "c");
+    const db_formula_rows = try buildDbRows(arena, N_FORMULAS, "f");
+    const db_cask_rows = try buildDbRows(arena, N_CASKS, "c");
+
+    const snap: outdated.Snapshot = .{
+        .generated_at_ms = 0,
+        .formulas = formulas,
+        .casks = casks,
+    };
+
+    // Warm the page cache + branch predictors.
+    {
+        const j = try outdated.renderSnapshot(alloc, snap);
+        defer alloc.free(j);
+        const p = try outdated.parseSnapshot(alloc, j);
+        defer outdated.freeSnapshot(alloc, p);
+        const f = try outdated.intersectWithDb(alloc, db_formula_rows, p.formulas);
+        defer freeEntrySlice(alloc, f);
+    }
+
+    const samples = try arena.alloc(u64, ITERS);
+
+    // --- renderSnapshot ---
+    for (samples) |*s| {
+        const t0 = nowNs();
+        const j = try outdated.renderSnapshot(alloc, snap);
+        s.* = nowNs() - t0;
+        alloc.free(j);
+    }
+    const render_stat = computeStat(samples);
+
+    // Render once for the parse + intersect phases.
+    const json = try outdated.renderSnapshot(alloc, snap);
+    defer alloc.free(json);
+
+    // --- parseSnapshot ---
+    for (samples) |*s| {
+        const t0 = nowNs();
+        const p = try outdated.parseSnapshot(alloc, json);
+        s.* = nowNs() - t0;
+        outdated.freeSnapshot(alloc, p);
+    }
+    const parse_stat = computeStat(samples);
+
+    // Parse once for the intersect phase.
+    const parsed = try outdated.parseSnapshot(alloc, json);
+    defer outdated.freeSnapshot(alloc, parsed);
+
+    // --- intersectWithDb (formulas: 500 DB rows × 50 snapshot entries) ---
+    for (samples) |*s| {
+        const t0 = nowNs();
+        const f = try outdated.intersectWithDb(alloc, db_formula_rows, parsed.formulas);
+        s.* = nowNs() - t0;
+        freeEntrySlice(alloc, f);
+    }
+    const intersect_stat = computeStat(samples);
+
+    // --- intersectWithDb (casks) ---
+    for (samples) |*s| {
+        const t0 = nowNs();
+        const c = try outdated.intersectWithDb(alloc, db_cask_rows, parsed.casks);
+        s.* = nowNs() - t0;
+        freeEntrySlice(alloc, c);
+    }
+    const intersect_cask_stat = computeStat(samples);
+
+    std.debug.print("phase            median       p95         min         max         budget   status\n", .{});
+    std.debug.print("---------------  ----------  ----------  ----------  ----------  -------  ------\n", .{});
+    printStat("render", render_stat, BUDGET_RENDER_NS);
+    printStat("parse", parse_stat, BUDGET_PARSE_NS);
+    printStat("intersect.f", intersect_stat, BUDGET_INTERSECT_NS);
+    printStat("intersect.c", intersect_cask_stat, BUDGET_INTERSECT_NS);
+
+    var over_budget = false;
+    if (render_stat.median_ns > BUDGET_RENDER_NS) over_budget = true;
+    if (parse_stat.median_ns > BUDGET_PARSE_NS) over_budget = true;
+    if (intersect_stat.median_ns > BUDGET_INTERSECT_NS) over_budget = true;
+    if (intersect_cask_stat.median_ns > BUDGET_INTERSECT_NS) over_budget = true;
+
+    if (over_budget) {
+        std.debug.print("\nFAIL: at least one phase exceeded its budget.\n", .{});
+        std.process.exit(1);
+    }
+    std.debug.print("\nOK: all phases within budget.\n", .{});
+}
+
+fn freeEntrySlice(allocator: std.mem.Allocator, slice: []outdated.OutdatedEntry) void {
+    for (slice) |e| {
+        allocator.free(e.name);
+        allocator.free(e.installed);
+        allocator.free(e.latest);
+    }
+    allocator.free(slice);
+}

--- a/build.zig
+++ b/build.zig
@@ -209,6 +209,24 @@ pub fn build(b: *std.Build) void {
     malt_lib.addImport("c_clonefile", host_c_mods.c_clonefile);
     malt_lib.addImport("c_mount", host_c_mods.c_mount);
 
+    // --- Snapshot microbench ---
+    // Standalone ReleaseSafe executable that imports the malt lib so it
+    // measures the snapshot helpers without process-spawn overhead.
+    const bench_mod = b.createModule(.{
+        .root_source_file = b.path("bench/snapshot_bench.zig"),
+        .target = target,
+        .optimize = .ReleaseSafe,
+        .link_libc = true,
+    });
+    bench_mod.addImport("malt", malt_lib);
+    const bench_exe = b.addExecutable(.{
+        .name = "snapshot_bench",
+        .root_module = bench_mod,
+    });
+    const run_bench = b.addRunArtifact(bench_exe);
+    const bench_step = b.step("bench-snapshot", "Run the outdated-snapshot microbench");
+    bench_step.dependOn(&run_bench.step);
+
     // Inline `test` blocks inside src/*.zig only run when their file is in
     // the same module as the test root — crossing `addImport("malt", ...)`
     // drops them. This target uses src/lib.zig as the test root so every

--- a/justfile
+++ b/justfile
@@ -172,6 +172,13 @@ hooks-uninstall:
 bench *args:
     ./scripts/bench.sh {{ args }}
 
+# Microbench for the outdated-snapshot read path. Asserts a hard
+# per-phase budget so a regression on render/parse/intersect breaks
+# the bench rather than silently slipping through CI.
+[group('bench')]
+bench-snapshot:
+    zig build bench-snapshot
+
 # ---------------------------------------------------------------------------
 # Cleanup
 # ---------------------------------------------------------------------------

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -190,9 +190,9 @@ run_ok t2.outdated -- "$MT_BIN" outdated
 run_ok t2.outdated.json -- "$MT_BIN" outdated --json
 run_ok t2.outdated.refresh -- "$MT_BIN" outdated --refresh
 run_ok t2.update -- "$MT_BIN" update
-# `update` (no flag) must not leave a snapshot behind.
+# Default mt update must not leave a snapshot behind.
 if [[ -e "$CACHE/outdated.json" ]]; then
-  printf '  FAIL  [t2.update.no-snapshot] cache/outdated.json should be absent after `mt update`\n'
+  printf '  FAIL  [t2.update.no-snapshot] cache/outdated.json should be absent after mt update\n'
   FAIL=$((FAIL + 1))
   FAILURES+=("t2.update.no-snapshot")
 else
@@ -200,7 +200,7 @@ else
   PASS=$((PASS + 1))
 fi
 run_ok t2.update.check -- "$MT_BIN" update --check
-# `update --check` must write a parseable snapshot at the documented path.
+# mt update --check must write a parseable snapshot at the documented path.
 if [[ -s "$CACHE/outdated.json" ]] && grep -q '"version":1' "$CACHE/outdated.json"; then
   printf '  PASS  [t2.update.check.writes-snapshot] cache/outdated.json present\n'
   PASS=$((PASS + 1))

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -188,7 +188,27 @@ run_grep t2.info.jq "jq" -- "$MT_BIN" info jq
 run_ok t2.info.json -- "$MT_BIN" info jq --json
 run_ok t2.outdated -- "$MT_BIN" outdated
 run_ok t2.outdated.json -- "$MT_BIN" outdated --json
+run_ok t2.outdated.refresh -- "$MT_BIN" outdated --refresh
 run_ok t2.update -- "$MT_BIN" update
+# `update` (no flag) must not leave a snapshot behind.
+if [[ -e "$CACHE/outdated.json" ]]; then
+  printf '  FAIL  [t2.update.no-snapshot] cache/outdated.json should be absent after `mt update`\n'
+  FAIL=$((FAIL + 1))
+  FAILURES+=("t2.update.no-snapshot")
+else
+  printf '  PASS  [t2.update.no-snapshot] cache/outdated.json absent\n'
+  PASS=$((PASS + 1))
+fi
+run_ok t2.update.check -- "$MT_BIN" update --check
+# `update --check` must write a parseable snapshot at the documented path.
+if [[ -s "$CACHE/outdated.json" ]] && grep -q '"version":1' "$CACHE/outdated.json"; then
+  printf '  PASS  [t2.update.check.writes-snapshot] cache/outdated.json present\n'
+  PASS=$((PASS + 1))
+else
+  printf '  FAIL  [t2.update.check.writes-snapshot] cache/outdated.json missing or malformed\n'
+  FAIL=$((FAIL + 1))
+  FAILURES+=("t2.update.check.writes-snapshot")
+fi
 run_ok t2.tap.list -- "$MT_BIN" tap
 
 # doctor: README documents exit 0/1/2 as valid semantics — accept all three on a

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -143,7 +143,8 @@ pub const bash_script =
     \\        purge)            cmd_flags="--store-orphans --unused-deps --cache --cache= --downloads --stale-casks --old-versions --housekeeping --wipe --backup -b --keep-cache --remove-binary --yes -y --dry-run -n" ;;
     \\        uninstall|remove) cmd_flags="--force --zap --dry-run" ;;
     \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --pinned --force -f" ;;
-    \\        outdated)         cmd_flags="--json --formula --cask --pinned-only --quiet -q" ;;
+    \\        outdated)         cmd_flags="--json --formula --cask --pinned-only --refresh --quiet -q" ;;
+    \\        update)           cmd_flags="--check --quiet -q" ;;
     \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --json --quiet -q" ;;
     \\        info)             cmd_flags="--formula --cask --json" ;;
     \\        search)           cmd_flags="--formula --cask --json" ;;
@@ -285,6 +286,12 @@ pub const zsh_script =
     \\                        '--formula[Show outdated formulas only]' \
     \\                        '--cask[Show outdated casks only]' \
     \\                        '--pinned-only[Audit pinned formulas + casks only]' \
+    \\                        '--refresh[Force live recompute, bypass the cached snapshot]' \
+    \\                        '(--quiet -q)'{--quiet,-q}'[Suppress status messages]'
+    \\                    ;;
+    \\                update)
+    \\                    _arguments \
+    \\                        '--check[Refresh only the outdated snapshot, skip API cache wipe]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress status messages]'
     \\                    ;;
     \\                list|ls)
@@ -498,6 +505,10 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l formula     -d 'Formulas only'
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l cask        -d 'Casks only'
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l pinned-only -d 'Pinned formulas + casks only'
+    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l refresh     -d 'Force live recompute, bypass the cached snapshot'
+    \\
+    \\    # update
+    \\    complete -c $__malt_bin -n '__malt_using_command update' -l check -d 'Refresh only the outdated snapshot, skip API cache wipe'
     \\
     \\    # list / ls
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l versions -d 'Show version numbers'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -108,9 +108,13 @@ const upgrade_help =
 ;
 
 const update_help =
-    \\Usage: malt update
+    \\Usage: malt update [flags]
     \\
-    \\Refresh the local formula/cask metadata cache.
+    \\Refresh the local formula/cask metadata cache and the outdated snapshot.
+    \\
+    \\Flags:
+    \\  --check     Refresh only the outdated snapshot (skip API cache wipe)
+    \\  --quiet, -q Suppress status messages
     \\
 ;
 
@@ -124,7 +128,12 @@ const outdated_help =
     \\  --formula      Show outdated formulas only
     \\  --cask         Show outdated casks only
     \\  --pinned-only  Audit pinned formulas + casks only (CVE watch)
+    \\  --refresh      Force live recompute, bypassing the cached snapshot
     \\  --quiet, -q    Suppress status messages
+    \\
+    \\Reads the cached snapshot at {cache}/outdated.json when fresh
+    \\(<= MALT_OUTDATED_MAX_AGE hours, default 24); falls back to a live
+    \\recompute on miss or --refresh.
     \\
 ;
 

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -24,6 +24,22 @@ pub const OUTDATED_DEFAULT_WORKERS: usize = 8;
 /// uplink, or lower it to one to reproduce serial behaviour).
 pub const OUTDATED_WORKERS_ENV = "MALT_OUTDATED_WORKERS";
 
+/// Default max age (hours) for the cached `outdated.json` snapshot. Picked
+/// to match the analysis doc: "shell-prompt integrations want instant
+/// startup; ~daily refresh is plenty for security awareness".
+pub const SNAPSHOT_DEFAULT_MAX_AGE_HOURS: u64 = 24;
+
+/// Env var override for `SNAPSHOT_DEFAULT_MAX_AGE_HOURS`. Same lenient
+/// parsing rules as `OUTDATED_WORKERS_ENV`.
+pub const SNAPSHOT_MAX_AGE_ENV = "MALT_OUTDATED_MAX_AGE";
+
+/// On-disk snapshot version. Mismatched snapshots are treated as misses
+/// so a downgrade never tries to read a future shape.
+pub const SNAPSHOT_VERSION: u32 = 1;
+
+/// Snapshot filename under `{cache}/`.
+pub const SNAPSHOT_FILE = "outdated.json";
+
 /// One row of the installed-package list fed to the worker pool.
 pub const KegRow = struct {
     name: []const u8,
@@ -43,6 +59,17 @@ pub const OutdatedEntry = struct {
     latest: []u8,
 };
 
+/// Cached `mt outdated` result. Snapshot trades freshness for instant
+/// startup so shell-prompt integrations don't pay an API round-trip per
+/// shell. All slices are owned by the parser's allocator (or by the
+/// caller, when assembling an in-memory snapshot from `OutdatedEntry`).
+pub const Snapshot = struct {
+    /// `std.time.milliTimestamp()` at the moment the snapshot was generated.
+    generated_at_ms: i64,
+    formulas: []const OutdatedEntry,
+    casks: []const OutdatedEntry,
+};
+
 /// Parse the worker-count override env var. Anything non-positive or
 /// non-numeric falls back to the default — matches the lenient style
 /// the rest of the CLI uses for tuning knobs.
@@ -52,6 +79,331 @@ pub fn parseWorkersEnv(s: ?[]const u8) ?usize {
     const n = std.fmt.parseInt(usize, raw, 10) catch return null;
     if (n == 0) return null;
     return n;
+}
+
+/// Resolve the snapshot max-age threshold (in hours) from an env value.
+/// Returns `null` for unset / empty / non-numeric so the caller can apply
+/// `SNAPSHOT_DEFAULT_MAX_AGE_HOURS`; preserves an explicit `"0"` as `0`
+/// so users who set the env to 0 actually get "always stale".
+pub fn parseMaxAgeHoursEnv(s: ?[]const u8) ?u64 {
+    const raw = s orelse return null;
+    if (raw.len == 0) return null;
+    return std.fmt.parseInt(u64, raw, 10) catch null;
+}
+
+/// True when `now_ms - generated_at_ms` exceeds the threshold. Future-
+/// dated snapshots (clock skew) are treated as fresh — better than
+/// surprising the user with a "stale" warning right after `mt update`.
+pub fn isStale(generated_at_ms: i64, now_ms: i64, max_age_hours: u64) bool {
+    if (now_ms <= generated_at_ms) return false;
+    const age_ms: u64 = @intCast(now_ms - generated_at_ms);
+    // Saturating multiply: a pathological env value (e.g. u64 max) folds
+    // to "never stale" rather than wrapping to 0 and reporting fresh
+    // snapshots as stale.
+    const max_ms = std.math.mul(u64, max_age_hours, 60 * 60 * 1000) catch std.math.maxInt(u64);
+    return age_ms > max_ms;
+}
+
+pub const RenderError = error{ OutOfMemory, WriteFailed };
+
+/// Render `snap` as a UTF-8 JSON document. Caller owns the returned
+/// slice. Shape: `{ "version": N, "generated_at_ms": ms, "formulas":
+/// [...], "casks": [...] }` — small enough to stream, stable enough to
+/// parse on a downgrade.
+pub fn renderSnapshot(allocator: std.mem.Allocator, snap: Snapshot) RenderError![]u8 {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
+
+    try w.print("{{\"version\":{d},\"generated_at_ms\":{d},\"formulas\":[", .{ SNAPSHOT_VERSION, snap.generated_at_ms });
+    for (snap.formulas, 0..) |e, i| {
+        if (i != 0) try w.writeAll(",");
+        try writeEntryJson(w, e);
+    }
+    try w.writeAll("],\"casks\":[");
+    for (snap.casks, 0..) |e, i| {
+        if (i != 0) try w.writeAll(",");
+        try writeEntryJson(w, e);
+    }
+    try w.writeAll("]}");
+
+    return aw.toOwnedSlice();
+}
+
+fn writeEntryJson(w: *std.Io.Writer, e: OutdatedEntry) !void {
+    try w.writeAll("{\"name\":");
+    try output.jsonStr(w, e.name);
+    try w.writeAll(",\"installed\":");
+    try output.jsonStr(w, e.installed);
+    try w.writeAll(",\"latest\":");
+    try output.jsonStr(w, e.latest);
+    try w.writeAll("}");
+}
+
+/// Owned snapshot returned by `parseSnapshot`. Free with `freeSnapshot`.
+/// Holds its own copy of every string so it outlives the parser arena.
+pub const OwnedSnapshot = struct {
+    generated_at_ms: i64,
+    formulas: []OutdatedEntry,
+    casks: []OutdatedEntry,
+};
+
+/// Per-string cap so a tampered snapshot can't push `std.json` into
+/// an N-MiB allocation. Real names/versions are well under 256 bytes.
+const snapshot_max_value_len: usize = 4 * 1024;
+
+/// Typed schema avoids the `std.json.Value` tree; allocation is bounded
+/// by the input size + the per-string cap above.
+const SnapshotDoc = struct {
+    version: u32,
+    generated_at_ms: i64,
+    formulas: []const EntryDoc,
+    casks: []const EntryDoc,
+};
+
+const EntryDoc = struct {
+    name: []const u8,
+    installed: []const u8,
+    latest: []const u8,
+};
+
+pub const SnapshotParseError = error{ InvalidSnapshot, OutOfMemory };
+
+pub fn parseSnapshot(allocator: std.mem.Allocator, bytes: []const u8) SnapshotParseError!OwnedSnapshot {
+    const opts: std.json.ParseOptions = .{
+        .ignore_unknown_fields = true,
+        .max_value_len = snapshot_max_value_len,
+        // Force allocation so `max_value_len` applies to every string;
+        // the default `.alloc_if_needed` borrows un-escaped values from
+        // the input buffer and bypasses the cap.
+        .allocate = .alloc_always,
+    };
+    const parsed = std.json.parseFromSlice(SnapshotDoc, allocator, bytes, opts) catch |e| switch (e) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidSnapshot,
+    };
+    defer parsed.deinit();
+
+    if (parsed.value.version != SNAPSHOT_VERSION) return error.InvalidSnapshot;
+
+    const formulas = try dupEntryDocs(allocator, parsed.value.formulas);
+    errdefer freeEntrySlice(allocator, formulas);
+    const casks = try dupEntryDocs(allocator, parsed.value.casks);
+
+    return .{
+        .generated_at_ms = parsed.value.generated_at_ms,
+        .formulas = formulas,
+        .casks = casks,
+    };
+}
+
+fn dupEntryDocs(
+    allocator: std.mem.Allocator,
+    docs: []const EntryDoc,
+) std.mem.Allocator.Error![]OutdatedEntry {
+    const out = try allocator.alloc(OutdatedEntry, docs.len);
+    var filled: usize = 0;
+    errdefer {
+        for (out[0..filled]) |e| {
+            allocator.free(e.name);
+            allocator.free(e.installed);
+            allocator.free(e.latest);
+        }
+        allocator.free(out);
+    }
+    for (docs) |d| {
+        const name = try allocator.dupe(u8, d.name);
+        errdefer allocator.free(name);
+        const installed = try allocator.dupe(u8, d.installed);
+        errdefer allocator.free(installed);
+        const latest = try allocator.dupe(u8, d.latest);
+        out[filled] = .{ .name = name, .installed = installed, .latest = latest };
+        filled += 1;
+    }
+    return out;
+}
+
+fn freeEntrySlice(allocator: std.mem.Allocator, slice: []OutdatedEntry) void {
+    for (slice) |e| {
+        allocator.free(e.name);
+        allocator.free(e.installed);
+        allocator.free(e.latest);
+    }
+    allocator.free(slice);
+}
+
+/// Resolve the absolute snapshot path under `cache_dir`. Caller frees.
+pub fn snapshotPath(allocator: std.mem.Allocator, cache_dir: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ cache_dir, SNAPSHOT_FILE });
+}
+
+/// Atomically write `snap` to `{cache_dir}/outdated.json`. Creates the
+/// cache dir if missing — `mt update --check` may run before any other
+/// command has touched the cache.
+pub fn writeSnapshot(
+    allocator: std.mem.Allocator,
+    cache_dir: []const u8,
+    snap: Snapshot,
+) !void {
+    // Best-effort: a real error here gets surfaced by atomicWriteFile below.
+    fs_compat.cwd().makePath(cache_dir) catch {};
+
+    const path = try snapshotPath(allocator, cache_dir);
+    defer allocator.free(path);
+    const json = try renderSnapshot(allocator, snap);
+    defer allocator.free(json);
+    try atomic.atomicWriteFile(path, json);
+}
+
+/// Realistic snapshots are tens of KiB; 1 MiB refuses any inflated file
+/// before bytes reach `std.json`.
+const snapshot_read_cap: usize = 1 * 1024 * 1024;
+
+/// Read the snapshot at `{cache_dir}/outdated.json`. Snapshot trades
+/// freshness for instant startup; on any read or parse failure we
+/// return null so callers fall back to a live recompute.
+pub fn readSnapshot(allocator: std.mem.Allocator, cache_dir: []const u8) ?OwnedSnapshot {
+    const path = snapshotPath(allocator, cache_dir) catch return null;
+    defer allocator.free(path);
+    const bytes = fs_compat.readFileAbsoluteAlloc(allocator, path, snapshot_read_cap) catch return null;
+    defer allocator.free(bytes);
+    return parseSnapshot(allocator, bytes) catch null;
+}
+
+/// Filter `snap_entries` against the current DB so a stale snapshot
+/// never names an uninstalled or already-upgraded keg. Match key is
+/// `(name, installed)`; a name-only match would let a manual upgrade
+/// past `installed` still report the keg as outdated. Returns a
+/// caller-owned slice; free with `freeEntrySlice` semantics.
+pub fn intersectWithDb(
+    allocator: std.mem.Allocator,
+    db_rows: []const KegRow,
+    snap_entries: []const OutdatedEntry,
+) std.mem.Allocator.Error![]OutdatedEntry {
+    if (snap_entries.len == 0 or db_rows.len == 0) {
+        return allocator.alloc(OutdatedEntry, 0);
+    }
+
+    // O(N+M): index the snapshot by name once, then walk the DB rows
+    // (which already arrive in `ORDER BY name` so emit order is stable).
+    var by_name: std.StringHashMap(*const OutdatedEntry) = .init(allocator);
+    defer by_name.deinit();
+    try by_name.ensureTotalCapacity(@intCast(snap_entries.len));
+    for (snap_entries) |*e| {
+        // Names are unique per scope; a duplicate is a corrupted file,
+        // so we favour the first entry rather than rejecting the read.
+        const gop = by_name.getOrPutAssumeCapacity(e.name);
+        if (!gop.found_existing) gop.value_ptr.* = e;
+    }
+
+    var out: std.ArrayList(OutdatedEntry) = try .initCapacity(allocator, db_rows.len);
+    errdefer {
+        for (out.items) |e| {
+            allocator.free(e.name);
+            allocator.free(e.installed);
+            allocator.free(e.latest);
+        }
+        out.deinit(allocator);
+    }
+
+    for (db_rows) |row| {
+        const e_ptr = by_name.get(row.name) orelse continue;
+        const e = e_ptr.*;
+        if (!std.mem.eql(u8, e.installed, row.version)) continue;
+        const dup = try dupEntry(allocator, e);
+        out.appendAssumeCapacity(dup);
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn dupEntry(allocator: std.mem.Allocator, e: OutdatedEntry) std.mem.Allocator.Error!OutdatedEntry {
+    const name = try allocator.dupe(u8, e.name);
+    errdefer allocator.free(name);
+    const installed = try allocator.dupe(u8, e.installed);
+    errdefer allocator.free(installed);
+    const latest = try allocator.dupe(u8, e.latest);
+    return .{ .name = name, .installed = installed, .latest = latest };
+}
+
+/// What `mt outdated` should do for the current invocation. Picked once,
+/// up front, so the dispatch is testable and the rest of `execute`
+/// stays linear.
+pub const EmitPlan = enum {
+    /// Snapshot exists, fresh enough — read silently.
+    use_snapshot_fresh,
+    /// Snapshot exists, age past threshold — read but warn.
+    use_snapshot_stale,
+    /// Recompute live: missing snapshot, `--refresh`, or filter (e.g.
+    /// `--pinned-only`) the snapshot can't satisfy.
+    recompute,
+};
+
+/// Recompute every outdated entry (formulas + casks) and overwrite the
+/// snapshot at `{cache_dir}/outdated.json`. Best-effort: failures are
+/// folded into the caller's `catch {}` so a snapshot write never blocks
+/// the user-facing output that already succeeded.
+pub fn refreshSnapshot(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    api: *api_mod.BrewApi,
+    cache_dir: []const u8,
+    workers_override: ?usize,
+) !void {
+    const formula_rows = try loadFormulaRows(allocator, db, .all);
+    defer freeKegRows(allocator, formula_rows);
+    const cask_rows = try loadCaskRows(allocator, db, .all);
+    defer freeKegRows(allocator, cask_rows);
+
+    const formulas = try collectOutdatedFormulas(allocator, api, cache_dir, formula_rows, workers_override);
+    defer {
+        for (formulas) |e| {
+            allocator.free(e.name);
+            allocator.free(e.installed);
+            allocator.free(e.latest);
+        }
+        allocator.free(formulas);
+    }
+    const casks = try collectOutdatedCasks(allocator, api, cache_dir, cask_rows, workers_override);
+    defer {
+        for (casks) |e| {
+            allocator.free(e.name);
+            allocator.free(e.installed);
+            allocator.free(e.latest);
+        }
+        allocator.free(casks);
+    }
+
+    try writeSnapshot(allocator, cache_dir, .{
+        .generated_at_ms = fs_compat.milliTimestamp(),
+        .formulas = formulas,
+        .casks = casks,
+    });
+}
+
+/// Decide whether to read the snapshot or recompute. Pure; tested.
+pub fn planEmit(
+    args: []const []const u8,
+    snap_present: bool,
+    snap_generated_at_ms: i64,
+    now_ms: i64,
+    max_age_hours: u64,
+) EmitPlan {
+    for (args) |a| {
+        if (std.mem.eql(u8, a, "--refresh")) return .recompute;
+        // The cached snapshot is "all-installed" by construction; pinned
+        // membership lives in the DB. Anything that filters by it has to
+        // round-trip the DB, which means a recompute.
+        if (std.mem.eql(u8, a, "--pinned-only")) return .recompute;
+    }
+    if (!snap_present) return .recompute;
+    if (isStale(snap_generated_at_ms, now_ms, max_age_hours)) return .use_snapshot_stale;
+    return .use_snapshot_fresh;
+}
+
+/// Free both arrays + every duped string in `snap`.
+pub fn freeSnapshot(allocator: std.mem.Allocator, snap: OwnedSnapshot) void {
+    freeEntrySlice(allocator, snap.formulas);
+    freeEntrySlice(allocator, snap.casks);
 }
 
 /// Resolve the actual worker count for `jobs`. Capped at `jobs` so we
@@ -117,6 +469,259 @@ test "parseWorkersEnv rejects null, empty, zero, and non-numeric values" {
     try std.testing.expectEqual(@as(?usize, null), parseWorkersEnv("-3"));
 }
 
+test "parseMaxAgeHoursEnv yields null for null/empty/garbage so callers default" {
+    try std.testing.expectEqual(@as(?u64, null), parseMaxAgeHoursEnv(null));
+    try std.testing.expectEqual(@as(?u64, null), parseMaxAgeHoursEnv(""));
+    try std.testing.expectEqual(@as(?u64, null), parseMaxAgeHoursEnv("nope"));
+    try std.testing.expectEqual(@as(?u64, null), parseMaxAgeHoursEnv("-3"));
+}
+
+test "parseMaxAgeHoursEnv preserves explicit 0 as 'always stale'" {
+    // The user reaches for 0 to opt out of caching; treating it as
+    // 'fall back to default' would silently re-enable the snapshot.
+    try std.testing.expectEqual(@as(?u64, 0), parseMaxAgeHoursEnv("0"));
+}
+
+test "parseMaxAgeHoursEnv parses positive integers verbatim" {
+    try std.testing.expectEqual(@as(?u64, 1), parseMaxAgeHoursEnv("1"));
+    try std.testing.expectEqual(@as(?u64, 12), parseMaxAgeHoursEnv("12"));
+    try std.testing.expectEqual(@as(?u64, 168), parseMaxAgeHoursEnv("168"));
+}
+
+test "renderSnapshot emits the canonical JSON shape" {
+    const formulas = [_]OutdatedEntry{
+        .{ .name = @constCast("alpha"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
+    };
+    const casks = [_]OutdatedEntry{
+        .{ .name = @constCast("beta"), .installed = @constCast("3.0"), .latest = @constCast("3.5") },
+    };
+    const snap: Snapshot = .{
+        .generated_at_ms = 1_700_000_000_000,
+        .formulas = &formulas,
+        .casks = &casks,
+    };
+    const json = try renderSnapshot(std.testing.allocator, snap);
+    defer std.testing.allocator.free(json);
+
+    const want =
+        \\{"version":1,"generated_at_ms":1700000000000,"formulas":[{"name":"alpha","installed":"1.0","latest":"2.0"}],"casks":[{"name":"beta","installed":"3.0","latest":"3.5"}]}
+    ;
+    try std.testing.expectEqualStrings(want, json);
+}
+
+test "parseSnapshot round-trips a rendered snapshot" {
+    const formulas = [_]OutdatedEntry{
+        .{ .name = @constCast("alpha"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
+        .{ .name = @constCast("bravo"), .installed = @constCast("3.0"), .latest = @constCast("3.5") },
+    };
+    const casks = [_]OutdatedEntry{
+        .{ .name = @constCast("charlie"), .installed = @constCast("9.0"), .latest = @constCast("9.5") },
+    };
+    const snap: Snapshot = .{
+        .generated_at_ms = 1_700_000_000_000,
+        .formulas = &formulas,
+        .casks = &casks,
+    };
+    const json = try renderSnapshot(std.testing.allocator, snap);
+    defer std.testing.allocator.free(json);
+
+    const parsed = try parseSnapshot(std.testing.allocator, json);
+    defer freeSnapshot(std.testing.allocator, parsed);
+
+    try std.testing.expectEqual(@as(i64, 1_700_000_000_000), parsed.generated_at_ms);
+    try std.testing.expectEqual(@as(usize, 2), parsed.formulas.len);
+    try std.testing.expectEqualStrings("alpha", parsed.formulas[0].name);
+    try std.testing.expectEqualStrings("1.0", parsed.formulas[0].installed);
+    try std.testing.expectEqualStrings("2.0", parsed.formulas[0].latest);
+    try std.testing.expectEqualStrings("bravo", parsed.formulas[1].name);
+    try std.testing.expectEqual(@as(usize, 1), parsed.casks.len);
+    try std.testing.expectEqualStrings("charlie", parsed.casks[0].name);
+    try std.testing.expectEqualStrings("9.5", parsed.casks[0].latest);
+}
+
+test "parseSnapshot rejects mismatched version, missing fields, garbage" {
+    try std.testing.expectError(error.InvalidSnapshot, parseSnapshot(std.testing.allocator, ""));
+    try std.testing.expectError(error.InvalidSnapshot, parseSnapshot(std.testing.allocator, "not-json"));
+    // Future schema version: refuse rather than guess.
+    try std.testing.expectError(
+        error.InvalidSnapshot,
+        parseSnapshot(std.testing.allocator, "{\"version\":99,\"generated_at_ms\":0,\"formulas\":[],\"casks\":[]}"),
+    );
+    // Missing required field.
+    try std.testing.expectError(
+        error.InvalidSnapshot,
+        parseSnapshot(std.testing.allocator, "{\"version\":1,\"formulas\":[],\"casks\":[]}"),
+    );
+    // Wrong type for formulas.
+    try std.testing.expectError(
+        error.InvalidSnapshot,
+        parseSnapshot(std.testing.allocator, "{\"version\":1,\"generated_at_ms\":0,\"formulas\":\"x\",\"casks\":[]}"),
+    );
+}
+
+test "parseSnapshot bounds per-string allocation against tampered input" {
+    // Build a JSON document with a single name field exceeding the
+    // per-value cap. The typed parser must reject it without inflating
+    // memory to the size of the malicious string.
+    const oversized_len = snapshot_max_value_len + 1;
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    try buf.appendSlice(std.testing.allocator, "{\"version\":1,\"generated_at_ms\":0,\"formulas\":[{\"name\":\"");
+    try buf.appendNTimes(std.testing.allocator, 'a', oversized_len);
+    try buf.appendSlice(std.testing.allocator, "\",\"installed\":\"1\",\"latest\":\"2\"}],\"casks\":[]}");
+
+    try std.testing.expectError(
+        error.InvalidSnapshot,
+        parseSnapshot(std.testing.allocator, buf.items),
+    );
+}
+
+test "parseSnapshot tolerates unknown forward-compatible fields" {
+    // Adding a field server-side shouldn't invalidate existing snapshots.
+    const json =
+        \\{"version":1,"generated_at_ms":0,"formulas":[],"casks":[],"future":42}
+    ;
+    const parsed = try parseSnapshot(std.testing.allocator, json);
+    defer freeSnapshot(std.testing.allocator, parsed);
+    try std.testing.expectEqual(@as(usize, 0), parsed.formulas.len);
+}
+
+test "renderSnapshot handles empty formula and cask lists" {
+    const snap: Snapshot = .{
+        .generated_at_ms = 0,
+        .formulas = &[_]OutdatedEntry{},
+        .casks = &[_]OutdatedEntry{},
+    };
+    const json = try renderSnapshot(std.testing.allocator, snap);
+    defer std.testing.allocator.free(json);
+
+    const want =
+        \\{"version":1,"generated_at_ms":0,"formulas":[],"casks":[]}
+    ;
+    try std.testing.expectEqualStrings(want, json);
+}
+
+test "intersectWithDb drops snapshot entries whose keg is no longer installed" {
+    const snap = [_]OutdatedEntry{
+        .{ .name = @constCast("alpha"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
+        .{ .name = @constCast("ghost"), .installed = @constCast("0.5"), .latest = @constCast("1.0") },
+        .{ .name = @constCast("zulu"), .installed = @constCast("3.0"), .latest = @constCast("3.5") },
+    };
+    const db = [_]KegRow{
+        .{ .name = "alpha", .version = "1.0" },
+        // ghost was uninstalled since the snapshot was taken
+        .{ .name = "zulu", .version = "3.0" },
+    };
+    const out = try intersectWithDb(std.testing.allocator, &db, &snap);
+    defer freeEntrySlice(std.testing.allocator, out);
+    try std.testing.expectEqual(@as(usize, 2), out.len);
+    try std.testing.expectEqualStrings("alpha", out[0].name);
+    try std.testing.expectEqualStrings("zulu", out[1].name);
+}
+
+test "intersectWithDb drops entries whose installed version no longer matches" {
+    const snap = [_]OutdatedEntry{
+        .{ .name = @constCast("alpha"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
+    };
+    const db = [_]KegRow{
+        // user upgraded alpha 1.0 -> 1.5 manually; we don't know if 1.5 is
+        // outdated until the snapshot is refreshed, so we drop it.
+        .{ .name = "alpha", .version = "1.5" },
+    };
+    const out = try intersectWithDb(std.testing.allocator, &db, &snap);
+    defer freeEntrySlice(std.testing.allocator, out);
+    try std.testing.expectEqual(@as(usize, 0), out.len);
+}
+
+test "intersectWithDb preserves DB ordering and ignores newly-installed kegs" {
+    const snap = [_]OutdatedEntry{
+        .{ .name = @constCast("bravo"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
+    };
+    const db = [_]KegRow{
+        .{ .name = "alpha", .version = "9.9" }, // installed since snapshot, ignored
+        .{ .name = "bravo", .version = "1.0" },
+    };
+    const out = try intersectWithDb(std.testing.allocator, &db, &snap);
+    defer freeEntrySlice(std.testing.allocator, out);
+    try std.testing.expectEqual(@as(usize, 1), out.len);
+    try std.testing.expectEqualStrings("bravo", out[0].name);
+}
+
+test "intersectWithDb returns empty for empty inputs" {
+    const empty_snap: []const OutdatedEntry = &.{};
+    const empty_db: []const KegRow = &.{};
+    const both = try intersectWithDb(std.testing.allocator, empty_db, empty_snap);
+    defer freeEntrySlice(std.testing.allocator, both);
+    try std.testing.expectEqual(@as(usize, 0), both.len);
+
+    const some_snap = [_]OutdatedEntry{
+        .{ .name = @constCast("alpha"), .installed = @constCast("1"), .latest = @constCast("2") },
+    };
+    const left = try intersectWithDb(std.testing.allocator, empty_db, &some_snap);
+    defer freeEntrySlice(std.testing.allocator, left);
+    try std.testing.expectEqual(@as(usize, 0), left.len);
+
+    const some_db = [_]KegRow{.{ .name = "alpha", .version = "1" }};
+    const right = try intersectWithDb(std.testing.allocator, &some_db, empty_snap);
+    defer freeEntrySlice(std.testing.allocator, right);
+    try std.testing.expectEqual(@as(usize, 0), right.len);
+}
+
+test "planEmit picks a fresh snapshot when one exists and age is below threshold" {
+    const args = [_][]const u8{};
+    try std.testing.expectEqual(EmitPlan.use_snapshot_fresh, planEmit(&args, true, 0, 0, 24));
+}
+
+test "planEmit warns on stale snapshots" {
+    const hour_ms: i64 = 60 * 60 * 1000;
+    const args = [_][]const u8{};
+    try std.testing.expectEqual(
+        EmitPlan.use_snapshot_stale,
+        planEmit(&args, true, 0, 25 * hour_ms, 24),
+    );
+}
+
+test "planEmit falls back to recompute when no snapshot is present" {
+    const args = [_][]const u8{};
+    try std.testing.expectEqual(EmitPlan.recompute, planEmit(&args, false, 0, 0, 24));
+}
+
+test "planEmit recomputes on --refresh even when snapshot is fresh" {
+    const args = [_][]const u8{"--refresh"};
+    try std.testing.expectEqual(EmitPlan.recompute, planEmit(&args, true, 0, 0, 24));
+}
+
+test "planEmit recomputes when --pinned-only narrows the scope" {
+    const args = [_][]const u8{"--pinned-only"};
+    try std.testing.expectEqual(EmitPlan.recompute, planEmit(&args, true, 0, 0, 24));
+}
+
+test "isStale flips at the max-age boundary in milliseconds" {
+    const hour_ms: i64 = 60 * 60 * 1000;
+    // Same instant -> fresh.
+    try std.testing.expect(!isStale(0, 0, 24));
+    // Exactly at the boundary -> still fresh.
+    try std.testing.expect(!isStale(0, 24 * hour_ms, 24));
+    // One ms past the boundary -> stale.
+    try std.testing.expect(isStale(0, 24 * hour_ms + 1, 24));
+    // Future-dated snapshot (clock skew) -> treated as fresh.
+    try std.testing.expect(!isStale(100 * hour_ms, 0, 24));
+    // Custom threshold honoured.
+    try std.testing.expect(isStale(0, 2 * hour_ms, 1));
+    try std.testing.expect(!isStale(0, 1 * hour_ms, 2));
+}
+
+test "isStale with max_age_hours == 0 marks any non-zero age as stale" {
+    try std.testing.expect(!isStale(0, 0, 0));
+    try std.testing.expect(isStale(0, 1, 0));
+}
+
+test "isStale folds a u64-overflowing threshold to 'never stale'" {
+    // A pathological MALT_OUTDATED_MAX_AGE shouldn't wrap to 0 ms and
+    // report otherwise-fresh snapshots as stale.
+    try std.testing.expect(!isStale(0, std.math.maxInt(i64), std.math.maxInt(u64)));
+}
+
 test "summaryMessage suppresses 'all up to date' when any row was printed" {
     try std.testing.expectEqual(@as(?[]const u8, null), summaryMessage(3, 0, false, false));
     try std.testing.expectEqual(@as(?[]const u8, null), summaryMessage(0, 2, false, false));
@@ -154,13 +759,21 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             pinned_only = true;
         }
     }
-    // `--pinned-only` covers both formulas and casks now that the casks
-    // table has its own `pinned` column. The flag narrows the rows each
-    // section loads, but does not narrow the scope.
     // `--json` and `--quiet` are stripped by the global parser in main.zig.
     const json_mode = output.isJson();
 
-    // Open DB
+    const cache_dir = atomic.maltCacheDir(allocator) catch {
+        output.err("Failed to determine cache directory", .{});
+        return error.Aborted;
+    };
+    defer allocator.free(cache_dir);
+
+    var stdout_buf: [4096]u8 = undefined;
+    var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
+    const stdout: *std.Io.Writer = &stdout_fw.interface;
+    // Flush on teardown; stdout closed by a broken pipe is normal shell usage.
+    defer stdout.flush() catch {};
+
     const prefix = atomic.maltPrefix();
     var db_path_buf: [512]u8 = undefined;
     const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
@@ -171,40 +784,116 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer db.close();
     schema.initSchema(&db) catch return;
 
-    const cache_dir = atomic.maltCacheDir(allocator) catch {
-        output.err("Failed to determine cache directory", .{});
-        return error.Aborted;
-    };
-    defer allocator.free(cache_dir);
+    const max_age_hours = parseMaxAgeHoursEnv(fs_compat.getenv(SNAPSHOT_MAX_AGE_ENV)) orelse
+        SNAPSHOT_DEFAULT_MAX_AGE_HOURS;
+    const snap_opt = readSnapshot(allocator, cache_dir);
+    defer if (snap_opt) |s| freeSnapshot(allocator, s);
 
+    const plan = planEmit(
+        args,
+        snap_opt != null,
+        if (snap_opt) |s| s.generated_at_ms else 0,
+        fs_compat.milliTimestamp(),
+        max_age_hours,
+    );
+
+    switch (plan) {
+        .use_snapshot_fresh, .use_snapshot_stale => {
+            if (plan == .use_snapshot_stale) {
+                output.warn(
+                    "Outdated snapshot is older than {d}h; run `mt update --check` to refresh.",
+                    .{max_age_hours},
+                );
+            }
+            try emitFromSnapshot(allocator, &db, snap_opt.?, stdout, json_mode, .{
+                .cask_only = cask_only,
+                .formula_only = formula_only,
+            });
+        },
+        .recompute => try recomputeAndEmit(allocator, &db, cache_dir, stdout, json_mode, .{
+            .cask_only = cask_only,
+            .formula_only = formula_only,
+            .pinned_only = pinned_only,
+        }),
+    }
+}
+
+const ScopeFlags = struct {
+    cask_only: bool = false,
+    formula_only: bool = false,
+    pinned_only: bool = false,
+};
+
+/// Emit the snapshot through the live DB so an uninstalled or
+/// upgraded keg never appears in the output.
+fn emitFromSnapshot(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    snap: OwnedSnapshot,
+    stdout: *std.Io.Writer,
+    json_mode: bool,
+    scope: ScopeFlags,
+) !void {
+    var formula_count: usize = 0;
+    var cask_count: usize = 0;
+
+    if (!scope.cask_only) {
+        const rows = try loadFormulaRows(allocator, db, .all);
+        defer freeKegRows(allocator, rows);
+        const filtered = try intersectWithDb(allocator, rows, snap.formulas);
+        defer freeEntrySlice(allocator, filtered);
+        try writeFormulaEntries(allocator, stdout, filtered, json_mode);
+        formula_count = filtered.len;
+    }
+    if (!scope.formula_only) {
+        const rows = try loadCaskRows(allocator, db, .all);
+        defer freeKegRows(allocator, rows);
+        const filtered = try intersectWithDb(allocator, rows, snap.casks);
+        defer freeEntrySlice(allocator, filtered);
+        try writeCaskEntries(stdout, filtered, json_mode);
+        cask_count = filtered.len;
+    }
+
+    if (!json_mode) {
+        if (summaryMessage(formula_count, cask_count, scope.formula_only, scope.cask_only)) |msg| {
+            output.info("{s}", .{msg});
+        }
+    }
+}
+
+fn recomputeAndEmit(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    cache_dir: []const u8,
+    stdout: *std.Io.Writer,
+    json_mode: bool,
+    scope: ScopeFlags,
+) !void {
     var http = client_mod.HttpClient.init(allocator);
     defer http.deinit();
     var api = api_mod.BrewApi.init(allocator, &http, cache_dir);
 
     const workers_override = parseWorkersEnv(fs_compat.getenv(OUTDATED_WORKERS_ENV));
 
-    var stdout_buf: [4096]u8 = undefined;
-    var stdout_fw = io_mod.stdoutFile().writer(io_mod.ctx(), &stdout_buf);
-    const stdout: *std.Io.Writer = &stdout_fw.interface;
-    // Flush on teardown; stdout closed by a broken pipe is normal shell usage.
-    defer stdout.flush() catch {};
-
     var formula_count: usize = 0;
     var cask_count: usize = 0;
-    if (!cask_only) {
-        const filter: KegFilter = if (pinned_only) .pinned_only else .all;
-        formula_count = try emitOutdatedFormulas(allocator, &db, &api, cache_dir, workers_override, stdout, json_mode, filter);
+    if (!scope.cask_only) {
+        const filter: KegFilter = if (scope.pinned_only) .pinned_only else .all;
+        formula_count = try emitOutdatedFormulas(allocator, db, &api, cache_dir, workers_override, stdout, json_mode, filter);
     }
-    if (!formula_only) {
-        const filter: KegFilter = if (pinned_only) .pinned_only else .all;
-        cask_count = try emitOutdatedCasks(allocator, &db, &api, cache_dir, workers_override, stdout, json_mode, filter);
+    if (!scope.formula_only) {
+        const filter: KegFilter = if (scope.pinned_only) .pinned_only else .all;
+        cask_count = try emitOutdatedCasks(allocator, db, &api, cache_dir, workers_override, stdout, json_mode, filter);
+    }
+    // Refresh the snapshot only when we walked the full keg set; a
+    // partial recompute would mislead the next reader. Best-effort:
+    // a write failure shouldn't shadow the listing the user already saw.
+    if (!scope.pinned_only and !scope.cask_only and !scope.formula_only) {
+        refreshSnapshot(allocator, db, &api, cache_dir, workers_override) catch {};
     }
 
-    // Single end-of-run summary so we never print "All casks are up to
-    // date" next to a list of outdated formulas. Suppressed in JSON
-    // mode and under `--quiet` (handled by `output.info`).
     if (!json_mode) {
-        if (summaryMessage(formula_count, cask_count, formula_only, cask_only)) |msg| {
+        if (summaryMessage(formula_count, cask_count, scope.formula_only, scope.cask_only)) |msg| {
             output.info("{s}", .{msg});
         }
     }

--- a/src/cli/update.zig
+++ b/src/cli/update.zig
@@ -1,18 +1,28 @@
 //! malt — update command
-//! Refresh metadata cache.
+//! Wipe the metadata cache (default) or refresh the outdated snapshot (`--check`).
 
 const std = @import("std");
 const fs_compat = @import("../fs/compat.zig");
 const atomic = @import("../fs/atomic.zig");
+const sqlite = @import("../db/sqlite.zig");
+const schema = @import("../db/schema.zig");
+const api_mod = @import("../net/api.zig");
+const client_mod = @import("../net/client.zig");
+const outdated_mod = @import("outdated.zig");
 const output = @import("../ui/output.zig");
 const help = @import("help.zig");
 
-pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
+pub const UpdateError = error{Aborted} || std.mem.Allocator.Error;
+
+pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) UpdateError!void {
     if (help.showIfRequested(args, "update")) return;
 
+    var check_only = false;
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
             output.setQuiet(true);
+        } else if (std.mem.eql(u8, arg, "--check")) {
+            check_only = true;
         }
     }
 
@@ -22,13 +32,54 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     };
     defer allocator.free(cache_dir);
 
-    // Delete all files in {cache_dir}/api/
-    var api_path_buf: [512]u8 = undefined;
-    const api_path = std.fmt.bufPrint(&api_path_buf, "{s}/api", .{cache_dir}) catch return;
+    if (check_only) {
+        refreshSnapshot(allocator, cache_dir) catch |e| {
+            output.err("Failed to refresh outdated snapshot: {s}", .{@errorName(e)});
+            return error.Aborted;
+        };
+        output.info("Outdated snapshot refreshed.", .{});
+        return;
+    }
 
-    fs_compat.deleteTreeAbsolute(api_path) catch {
-        // Directory may not exist yet — that's fine
-    };
+    // Stays sub-100ms: wipe API cache + invalidate snapshot; the next
+    // `mt outdated` recomputes against the new world.
+    var api_buf: [512]u8 = undefined;
+    if (std.fmt.bufPrint(&api_buf, "{s}/api", .{cache_dir})) |api_path| {
+        fs_compat.deleteTreeAbsolute(api_path) catch {};
+    } else |_| {}
+
+    invalidateSnapshot(allocator, cache_dir);
 
     output.info("Cache cleared. Metadata will be re-fetched on next operation.", .{});
+}
+
+/// Best-effort: a leftover snapshot is harmless because the read path
+/// filters through the live DB; worst case is one extra recompute.
+fn invalidateSnapshot(allocator: std.mem.Allocator, cache_dir: []const u8) void {
+    const path = outdated_mod.snapshotPath(allocator, cache_dir) catch return;
+    defer allocator.free(path);
+    fs_compat.deleteFileAbsolute(path) catch {};
+}
+
+fn refreshSnapshot(allocator: std.mem.Allocator, cache_dir: []const u8) !void {
+    const prefix = atomic.maltPrefix();
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return error.Aborted;
+    var db = sqlite.Database.open(db_path) catch {
+        // Fresh prefix: write an empty snapshot so readers get instant "all clear".
+        try outdated_mod.writeSnapshot(allocator, cache_dir, .{
+            .generated_at_ms = fs_compat.milliTimestamp(),
+            .formulas = &.{},
+            .casks = &.{},
+        });
+        return;
+    };
+    defer db.close();
+    schema.initSchema(&db) catch return;
+
+    var http = client_mod.HttpClient.init(allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(allocator, &http, cache_dir);
+
+    try outdated_mod.refreshSnapshot(allocator, &db, &api, cache_dir, null);
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -49,6 +49,7 @@ pub const cli_info = @import("cli/info.zig");
 pub const cli_uses = @import("cli/uses.zig");
 pub const cli_which = @import("cli/which.zig");
 pub const cli_outdated = @import("cli/outdated.zig");
+pub const cli_update = @import("cli/update.zig");
 pub const cli_version_update = @import("cli/version_update.zig");
 pub const update_cleanup = @import("update/cleanup.zig");
 pub const update_origin = @import("update/origin.zig");

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -101,3 +101,15 @@ test "all install completions expose --local" {
     try expectContains(completions.zsh_script, "--local");
     try expectContains(completions.fish_script, "-l local");
 }
+
+test "all outdated completions expose --refresh" {
+    try expectContains(completions.bash_script, "--refresh");
+    try expectContains(completions.zsh_script, "--refresh");
+    try expectContains(completions.fish_script, "-l refresh");
+}
+
+test "all update completions expose --check" {
+    try expectContains(completions.bash_script, "--check");
+    try expectContains(completions.zsh_script, "--check");
+    try expectContains(completions.fish_script, "-l check");
+}

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -8,6 +8,7 @@ const std = @import("std");
 const testing = std.testing;
 const malt = @import("malt");
 const outdated_mod = malt.cli_outdated;
+const update_mod = malt.cli_update;
 const api_mod = malt.api;
 const client_mod = malt.client;
 const sqlite = malt.sqlite;
@@ -381,6 +382,376 @@ test "loadFormulaRows .pinned_only on an empty DB is a no-op" {
     defer outdated_mod.freeKegRows(testing.allocator, rows);
 
     try testing.expectEqual(@as(usize, 0), rows.len);
+}
+
+// --- Cached snapshot (write/read round-trip) ---
+
+// --- update + --check integration ---
+
+const UpdateEnv = struct {
+    prefix_path: [:0]u8,
+    cache_path: [:0]u8,
+
+    fn init(suffix: []const u8) !UpdateEnv {
+        const prefix = try std.fmt.allocPrintSentinel(
+            testing.allocator,
+            "/tmp/malt_update_test_{d}_{s}",
+            .{ malt.fs_compat.nanoTimestamp(), suffix },
+            0,
+        );
+        const cache = try std.fmt.allocPrintSentinel(
+            testing.allocator,
+            "{s}/cache",
+            .{prefix},
+            0,
+        );
+        malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+        try malt.fs_compat.cwd().makePath(prefix);
+        try malt.fs_compat.cwd().makePath(cache);
+        const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{prefix});
+        defer testing.allocator.free(db_dir);
+        try malt.fs_compat.cwd().makePath(db_dir);
+
+        _ = c.setenv("MALT_PREFIX", prefix.ptr, 1);
+        _ = c.setenv("MALT_CACHE", cache.ptr, 1);
+        return .{ .prefix_path = prefix, .cache_path = cache };
+    }
+
+    fn deinit(self: *UpdateEnv) void {
+        _ = c.unsetenv("MALT_PREFIX");
+        _ = c.unsetenv("MALT_CACHE");
+        malt.fs_compat.deleteTreeAbsolute(self.prefix_path) catch {};
+        testing.allocator.free(self.prefix_path);
+        testing.allocator.free(self.cache_path);
+    }
+
+    fn writeApiFile(self: UpdateEnv, rel: []const u8, body: []const u8) !void {
+        var dir_buf: [512]u8 = undefined;
+        const api_dir = try std.fmt.bufPrint(&dir_buf, "{s}/api", .{self.cache_path});
+        try malt.fs_compat.cwd().makePath(api_dir);
+        var path_buf: [512]u8 = undefined;
+        const path = try std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ api_dir, rel });
+        const f = try malt.fs_compat.cwd().createFile(path, .{});
+        defer f.close();
+        try f.writeAll(body);
+    }
+
+    fn apiFileExists(self: UpdateEnv, rel: []const u8) bool {
+        var path_buf: [512]u8 = undefined;
+        const path = std.fmt.bufPrint(&path_buf, "{s}/api/{s}", .{ self.cache_path, rel }) catch return false;
+        malt.fs_compat.accessAbsolute(path, .{}) catch return false;
+        return true;
+    }
+};
+
+fn openUpdateDb(prefix: [:0]const u8) !sqlite.Database {
+    var buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    errdefer db.close();
+    try schema.initSchema(&db);
+    return db;
+}
+
+fn insertKegV1(db: *sqlite.Database, name: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &buf,
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, pinned) VALUES ('{s}', '{s}', '1.0', 'deadbeef', '/cellar/{s}/1.0', 0);",
+        .{ name, name, name },
+    );
+    try db.exec(sql);
+}
+
+test "update --check writes the snapshot and leaves the API cache intact" {
+    var env = try UpdateEnv.init("check_keeps_cache");
+    defer env.deinit();
+
+    try env.writeApiFile(
+        "formula_alpha.json",
+        "{\"name\":\"alpha\",\"versions\":{\"stable\":\"2.0\"}}",
+    );
+    {
+        var db = try openUpdateDb(env.prefix_path);
+        defer db.close();
+        try insertKegV1(&db, "alpha");
+    }
+
+    try update_mod.execute(testing.allocator, &.{"--check"});
+
+    // Snapshot was written.
+    const snap_opt = outdated_mod.readSnapshot(testing.allocator, env.cache_path);
+    try testing.expect(snap_opt != null);
+    const snap = snap_opt.?;
+    defer outdated_mod.freeSnapshot(testing.allocator, snap);
+    try testing.expectEqual(@as(usize, 1), snap.formulas.len);
+    try testing.expectEqualStrings("alpha", snap.formulas[0].name);
+    try testing.expectEqualStrings("1.0", snap.formulas[0].installed);
+    try testing.expectEqualStrings("2.0", snap.formulas[0].latest);
+
+    // API cache survives.
+    try testing.expect(env.apiFileExists("formula_alpha.json"));
+}
+
+test "update without --check wipes the API cache and skips the slow snapshot write" {
+    var env = try UpdateEnv.init("default_wipes_cache");
+    defer env.deinit();
+
+    try env.writeApiFile("formula_alpha.json", "{\"name\":\"alpha\"}");
+
+    try update_mod.execute(testing.allocator, &.{});
+
+    // Cache wipe still happens.
+    try testing.expect(!env.apiFileExists("formula_alpha.json"));
+    // No snapshot is written: keeping `mt update` cheap is the contract.
+    try testing.expectEqual(
+        @as(?outdated_mod.OwnedSnapshot, null),
+        outdated_mod.readSnapshot(testing.allocator, env.cache_path),
+    );
+}
+
+test "update without --check deletes a stale snapshot to force fresh recompute next run" {
+    var env = try UpdateEnv.init("default_deletes_snapshot");
+    defer env.deinit();
+
+    // Pre-existing snapshot from a prior run: the cache wipe just
+    // dropped its data source, so the snapshot has no business surviving.
+    try outdated_mod.writeSnapshot(testing.allocator, env.cache_path, .{
+        .generated_at_ms = malt.fs_compat.milliTimestamp(),
+        .formulas = &[_]outdated_mod.OutdatedEntry{},
+        .casks = &[_]outdated_mod.OutdatedEntry{},
+    });
+    try testing.expect(outdated_mod.readSnapshot(testing.allocator, env.cache_path) != null);
+
+    try update_mod.execute(testing.allocator, &.{});
+
+    try testing.expectEqual(
+        @as(?outdated_mod.OwnedSnapshot, null),
+        outdated_mod.readSnapshot(testing.allocator, env.cache_path),
+    );
+}
+
+test "outdated execute reads a fresh snapshot and never overwrites it" {
+    var env = try UpdateEnv.init("outdated_uses_snapshot");
+    defer env.deinit();
+
+    {
+        var db = try openUpdateDb(env.prefix_path);
+        defer db.close();
+        try insertKegV1(&db, "alpha");
+    }
+
+    // Use a fixed marker timestamp on a fresh snapshot. The snapshot
+    // path must NOT rewrite the file (recompute would update the
+    // timestamp), so the marker survives across execute().
+    const marker_ts: i64 = malt.fs_compat.milliTimestamp() - 1000;
+    const formulas = [_]outdated_mod.OutdatedEntry{
+        .{ .name = @constCast("alpha"), .installed = @constCast("1.0"), .latest = @constCast("9.9") },
+    };
+    try outdated_mod.writeSnapshot(testing.allocator, env.cache_path, .{
+        .generated_at_ms = marker_ts,
+        .formulas = &formulas,
+        .casks = &[_]outdated_mod.OutdatedEntry{},
+    });
+
+    try outdated_mod.execute(testing.allocator, &.{});
+
+    // The marker timestamp survives — proof the snapshot was read and
+    // not regenerated by the recompute path.
+    const after_opt = outdated_mod.readSnapshot(testing.allocator, env.cache_path);
+    try testing.expect(after_opt != null);
+    const after = after_opt.?;
+    defer outdated_mod.freeSnapshot(testing.allocator, after);
+    try testing.expectEqual(marker_ts, after.generated_at_ms);
+    try testing.expectEqual(@as(usize, 1), after.formulas.len);
+    try testing.expectEqualStrings("alpha", after.formulas[0].name);
+    try testing.expectEqualStrings("9.9", after.formulas[0].latest);
+}
+
+test "outdated execute drops snapshot entries whose keg was uninstalled" {
+    var env = try UpdateEnv.init("outdated_filters_uninstalled");
+    defer env.deinit();
+
+    {
+        var db = try openUpdateDb(env.prefix_path);
+        defer db.close();
+        // alpha is installed; ghost was uninstalled since the snapshot.
+        try insertKegV1(&db, "alpha");
+    }
+
+    const marker_ts: i64 = malt.fs_compat.milliTimestamp() - 1000;
+    const formulas = [_]outdated_mod.OutdatedEntry{
+        .{ .name = @constCast("alpha"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
+        .{ .name = @constCast("ghost"), .installed = @constCast("0.5"), .latest = @constCast("1.0") },
+    };
+    try outdated_mod.writeSnapshot(testing.allocator, env.cache_path, .{
+        .generated_at_ms = marker_ts,
+        .formulas = &formulas,
+        .casks = &[_]outdated_mod.OutdatedEntry{},
+    });
+
+    try outdated_mod.execute(testing.allocator, &.{});
+
+    // Marker timestamp survives -> execute() took the snapshot path
+    // (recompute would have rewritten it with a fresh timestamp).
+    const after_opt = outdated_mod.readSnapshot(testing.allocator, env.cache_path);
+    try testing.expect(after_opt != null);
+    const after = after_opt.?;
+    defer outdated_mod.freeSnapshot(testing.allocator, after);
+    try testing.expectEqual(marker_ts, after.generated_at_ms);
+
+    // Filter correctness: same DB + snapshot inputs that execute() saw,
+    // run through the same helper, must yield only `alpha`.
+    var db = try openUpdateDb(env.prefix_path);
+    defer db.close();
+    const rows = try outdated_mod.loadFormulaRows(testing.allocator, &db, .all);
+    defer outdated_mod.freeKegRows(testing.allocator, rows);
+    const filtered = try outdated_mod.intersectWithDb(testing.allocator, rows, &formulas);
+    defer {
+        for (filtered) |e| {
+            testing.allocator.free(e.name);
+            testing.allocator.free(e.installed);
+            testing.allocator.free(e.latest);
+        }
+        testing.allocator.free(filtered);
+    }
+    try testing.expectEqual(@as(usize, 1), filtered.len);
+    try testing.expectEqualStrings("alpha", filtered[0].name);
+}
+
+test "outdated execute on a stale snapshot emits the cached entries (used as proof of read)" {
+    var env = try UpdateEnv.init("outdated_stale_uses_cache");
+    defer env.deinit();
+
+    {
+        var db = try openUpdateDb(env.prefix_path);
+        defer db.close();
+        try insertKegV1(&db, "alpha");
+    }
+
+    // 30-day-old snapshot — well past the 24h default threshold.
+    const month_ms: i64 = 30 * 24 * 60 * 60 * 1000;
+    const formulas = [_]outdated_mod.OutdatedEntry{
+        .{ .name = @constCast("alpha"), .installed = @constCast("1.0"), .latest = @constCast("3.0") },
+    };
+    try outdated_mod.writeSnapshot(testing.allocator, env.cache_path, .{
+        .generated_at_ms = malt.fs_compat.milliTimestamp() - month_ms,
+        .formulas = &formulas,
+        .casks = &[_]outdated_mod.OutdatedEntry{},
+    });
+
+    // Stale snapshot: emits entries (so shell prompts stay instant), warning
+    // on stderr — but should NOT overwrite the snapshot. We verify the
+    // post-execute snapshot still contains "alpha->3.0" rather than a fresh
+    // empty recompute.
+    try outdated_mod.execute(testing.allocator, &.{});
+
+    const after_opt = outdated_mod.readSnapshot(testing.allocator, env.cache_path);
+    try testing.expect(after_opt != null);
+    const after = after_opt.?;
+    defer outdated_mod.freeSnapshot(testing.allocator, after);
+    try testing.expectEqual(@as(usize, 1), after.formulas.len);
+    try testing.expectEqualStrings("alpha", after.formulas[0].name);
+    try testing.expectEqualStrings("3.0", after.formulas[0].latest);
+}
+
+test "outdated execute --refresh skips the snapshot and recomputes" {
+    var env = try UpdateEnv.init("outdated_refresh_recomputes");
+    defer env.deinit();
+
+    {
+        var db = try openUpdateDb(env.prefix_path);
+        defer db.close();
+        // No kegs => no API calls => --refresh path stays offline.
+    }
+
+    // Stamp a snapshot with a bogus latest; --refresh must not surface it.
+    const formulas = [_]outdated_mod.OutdatedEntry{
+        .{ .name = @constCast("alpha"), .installed = @constCast("1.0"), .latest = @constCast("bogus") },
+    };
+    try outdated_mod.writeSnapshot(testing.allocator, env.cache_path, .{
+        .generated_at_ms = malt.fs_compat.milliTimestamp(),
+        .formulas = &formulas,
+        .casks = &[_]outdated_mod.OutdatedEntry{},
+    });
+
+    try outdated_mod.execute(testing.allocator, &.{"--refresh"});
+
+    // After --refresh, the snapshot is regenerated to reflect actual state.
+    const fresh_opt = outdated_mod.readSnapshot(testing.allocator, env.cache_path);
+    try testing.expect(fresh_opt != null);
+    const fresh = fresh_opt.?;
+    defer outdated_mod.freeSnapshot(testing.allocator, fresh);
+    try testing.expectEqual(@as(usize, 0), fresh.formulas.len);
+    try testing.expectEqual(@as(usize, 0), fresh.casks.len);
+}
+
+test "writeSnapshot then readSnapshot round-trips entries through the cache file" {
+    var dir = try TempCacheDir.init("snapshot_round_trip");
+    defer dir.deinit();
+
+    const formulas = [_]outdated_mod.OutdatedEntry{
+        .{ .name = @constCast("alpha"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
+    };
+    const casks = [_]outdated_mod.OutdatedEntry{
+        .{ .name = @constCast("beta"), .installed = @constCast("3.0"), .latest = @constCast("3.5") },
+    };
+    const snap: outdated_mod.Snapshot = .{
+        .generated_at_ms = 1_700_000_000_000,
+        .formulas = &formulas,
+        .casks = &casks,
+    };
+    try outdated_mod.writeSnapshot(testing.allocator, dir.path, snap);
+
+    const read_opt = outdated_mod.readSnapshot(testing.allocator, dir.path);
+    try testing.expect(read_opt != null);
+    const read = read_opt.?;
+    defer outdated_mod.freeSnapshot(testing.allocator, read);
+
+    try testing.expectEqual(@as(i64, 1_700_000_000_000), read.generated_at_ms);
+    try testing.expectEqual(@as(usize, 1), read.formulas.len);
+    try testing.expectEqualStrings("alpha", read.formulas[0].name);
+    try testing.expectEqualStrings("2.0", read.formulas[0].latest);
+    try testing.expectEqual(@as(usize, 1), read.casks.len);
+    try testing.expectEqualStrings("beta", read.casks[0].name);
+}
+
+test "readSnapshot returns null when the file is missing" {
+    var dir = try TempCacheDir.init("snapshot_missing");
+    defer dir.deinit();
+    try testing.expectEqual(@as(?outdated_mod.OwnedSnapshot, null), outdated_mod.readSnapshot(testing.allocator, dir.path));
+}
+
+test "readSnapshot returns null on garbage contents" {
+    var dir = try TempCacheDir.init("snapshot_garbage");
+    defer dir.deinit();
+    const path = try outdated_mod.snapshotPath(testing.allocator, dir.path);
+    defer testing.allocator.free(path);
+    const f = try malt.fs_compat.cwd().createFile(path, .{});
+    defer f.close();
+    try f.writeAll("not-json-at-all");
+    try testing.expectEqual(@as(?outdated_mod.OwnedSnapshot, null), outdated_mod.readSnapshot(testing.allocator, dir.path));
+}
+
+test "writeSnapshot creates the cache directory if missing" {
+    const tag = "snapshot_mkdir";
+    const path = "/tmp/malt_outdated_test_" ++ tag;
+    malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+
+    const snap: outdated_mod.Snapshot = .{
+        .generated_at_ms = 0,
+        .formulas = &[_]outdated_mod.OutdatedEntry{},
+        .casks = &[_]outdated_mod.OutdatedEntry{},
+    };
+    try outdated_mod.writeSnapshot(testing.allocator, path, snap);
+
+    const read_opt = outdated_mod.readSnapshot(testing.allocator, path);
+    try testing.expect(read_opt != null);
+    const read = read_opt.?;
+    defer outdated_mod.freeSnapshot(testing.allocator, read);
+    try testing.expectEqual(@as(usize, 0), read.formulas.len);
+    try testing.expectEqual(@as(usize, 0), read.casks.len);
 }
 
 test "outdated execute --pinned-only is a quiet no-op when no kegs are pinned" {


### PR DESCRIPTION
## Description

Makes `mt outdated` usable from shell prompts (starship, p10k) by caching the answer at `cache/outdated.json`. On a warm machine the read is instant - no API round-trips, no network. The snapshot is filtered through the live DB on every read, so a keg you uninstalled or upgraded since the last refresh never shows up as outdated.

`mt update --check` warms the snapshot explicitly (the slow walk over installed kegs lives behind this flag, not the default).
Default `mt update` stays as fast as before by invalidating the snapshot instead of rewriting it - the next `mt outdated` recomputes and writes a fresh one. `mt outdated --refresh` forces a live recompute on demand.

`MALT_OUTDATED_MAX_AGE=N` overrides the 24-hour staleness threshold (set to 0 to mark every snapshot stale). Stale reads warn but stay instant; `--quiet` suppresses the warning.

A microbench at `just bench-snapshot` asserts the read path stays well under any realistic shell-prompt latency budget.

## Related issue

- None

## Notes for Reviewers

- None