### PR TITLE
fix(core/deps): purge --unused-deps must walk transitive closure

### DIFF
--- a/src/core/deps.zig
+++ b/src/core/deps.zig
@@ -109,19 +109,32 @@ pub fn resolve(
     };
 }
 
-/// Find orphaned dependencies (install_reason='dependency' but not needed by any direct install).
+/// Find orphaned dependencies (install_reason='dependency' and not in the
+/// transitive closure of any direct install's dependency graph).
+///
+/// The recursive CTE seeds with kegs directly listed by any `install_reason
+/// = 'direct'` keg, then walks `dependencies` rows transitively so a dep
+/// reached only through another dep (e.g. `node` → `openssl@3` →
+/// `ca-certificates`) is still classed as retained. A flat one-level
+/// query would mis-purge those grandchild deps.
 pub fn findOrphans(allocator: std.mem.Allocator, db: *sqlite.Database) ![]const []const u8 {
     var orphans: std.ArrayList([]const u8) = .empty;
 
-    // Get all dependency-installed kegs
     var stmt = db.prepare(
+        \\WITH RECURSIVE retained(name) AS (
+        \\    SELECT DISTINCT d.dep_name
+        \\    FROM dependencies d
+        \\    JOIN kegs k ON k.id = d.keg_id
+        \\    WHERE k.install_reason = 'direct'
+        \\    UNION
+        \\    SELECT d.dep_name
+        \\    FROM dependencies d
+        \\    JOIN kegs k2 ON k2.id = d.keg_id
+        \\    JOIN retained r ON r.name = k2.name
+        \\)
         \\SELECT k.name FROM kegs k
         \\WHERE k.install_reason = 'dependency'
-        \\AND k.name NOT IN (
-        \\    SELECT DISTINCT d.dep_name FROM dependencies d
-        \\    JOIN kegs k2 ON k2.id = d.keg_id
-        \\    WHERE k2.install_reason = 'direct'
-        \\);
+        \\AND k.name NOT IN (SELECT name FROM retained);
     ) catch return orphans.toOwnedSlice(allocator) catch &.{};
     defer stmt.finalize();
 

--- a/tests/deps_test.zig
+++ b/tests/deps_test.zig
@@ -145,6 +145,55 @@ test "findOrphans returns empty when every dep keg is still referenced" {
     try testing.expectEqual(@as(usize, 0), orphans.len);
 }
 
+test "findOrphans walks the transitive closure of direct kegs" {
+    // Real-world shape: `node` (direct) → `openssl@3` → `ca-certificates`.
+    // The dependencies table only carries direct edges, so a one-level
+    // query would have classed `ca-certificates` as orphan even though
+    // `openssl@3` (retained by node) still pulls it in. Plus a stranded
+    // dep nobody references — the only thing that should actually purge.
+    var tdb = try TempDb.init("orphans_transitive");
+    defer tdb.deinit();
+
+    const node_id = try insertKeg(&tdb.db, "node", "direct");
+    try insertDep(&tdb.db, node_id, "openssl@3");
+
+    const openssl_id = try insertKeg(&tdb.db, "openssl@3", "dependency");
+    try insertDep(&tdb.db, openssl_id, "ca-certificates");
+
+    _ = try insertKeg(&tdb.db, "ca-certificates", "dependency");
+    _ = try insertKeg(&tdb.db, "stranded-lib", "dependency");
+
+    const orphans = try deps_mod.findOrphans(testing.allocator, &tdb.db);
+    defer {
+        for (orphans) |o| testing.allocator.free(o);
+        testing.allocator.free(orphans);
+    }
+
+    try testing.expectEqual(@as(usize, 1), orphans.len);
+    try testing.expectEqualStrings("stranded-lib", orphans[0]);
+}
+
+test "findOrphans tolerates dependency cycles without looping forever" {
+    // Defensive: a malformed graph where two dep kegs reference each
+    // other (a → b, b → a) under no direct retainer should still
+    // classify both as orphans. The recursive CTE's UNION (not UNION
+    // ALL) collapses repeats so the walk terminates.
+    var tdb = try TempDb.init("orphans_cycle");
+    defer tdb.deinit();
+
+    const a_id = try insertKeg(&tdb.db, "a-lib", "dependency");
+    const b_id = try insertKeg(&tdb.db, "b-lib", "dependency");
+    try insertDep(&tdb.db, a_id, "b-lib");
+    try insertDep(&tdb.db, b_id, "a-lib");
+
+    const orphans = try deps_mod.findOrphans(testing.allocator, &tdb.db);
+    defer {
+        for (orphans) |o| testing.allocator.free(o);
+        testing.allocator.free(orphans);
+    }
+    try testing.expectEqual(@as(usize, 2), orphans.len);
+}
+
 test "ResolvedDep carries name and already_installed flag" {
     const d = deps_mod.ResolvedDep{ .name = "foo", .already_installed = true };
     try testing.expectEqualStrings("foo", d.name);


### PR DESCRIPTION
## Description

`mt purge --unused-deps` was reclaiming legitimate deps - things like `ca-certificates`, `xz`, `gettext` - whenever a direct keg pulled them in only via another dep (e.g. `node` → `openssl@3` → `ca-certificates`). The orphan query walked only one level: a dep was retained iff a direct keg listed it explicitly. The `dependencies` table records direct edges only, so any grandchild dep slipped through and got classed as orphan.

The query now seeds with every direct keg's deps and walks \`dependencies\` rows transitively via a recursive CTE, so anything reachable from a direct keg's graph is retained. Stranded deps (no direct retainer anywhere) still purge; cycles in malformed graphs terminate cleanly.

## Related Issue

## Notes for Reviewers

- No schema or migration changes - it is a query rewrite only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)