### PR TITLE
feat(cli/bundle): cleanup removes packages absent from Brewfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,10 +269,10 @@ mt update                                # wipe API cache + drop snapshot (fast)
 mt update --check                        # write a fresh outdated snapshot only
 ```
 
-| Flag            | Description                                                      |
-| --------------- | ---------------------------------------------------------------- |
+| Flag            | Description                                                       |
+| --------------- | ----------------------------------------------------------------- |
 | `--check`       | Write a fresh `cache/outdated.json` snapshot; skip API cache wipe |
-| `--quiet`, `-q` | Suppress status messages                                         |
+| `--quiet`, `-q` | Suppress status messages                                          |
 
 Default `mt update` invalidates the API cache so the next `install`, `search`, or `info` fetches fresh data, and drops any cached `outdated.json` so the next `mt outdated` recomputes against the new world. `--check` is the explicit "warm the snapshot" path for shell-prompt integrations.
 
@@ -289,14 +289,14 @@ mt outdated --pinned-only                # CVE watch on held-back versions
 mt outdated --refresh                    # bypass the cached snapshot
 ```
 
-| Flag            | Description                                                       |
-| --------------- | ----------------------------------------------------------------- |
-| `--json`        | Output as JSON                                                    |
-| `--formula`     | Show outdated formulas only                                       |
-| `--cask`        | Show outdated casks only                                          |
-| `--pinned-only` | Audit pinned formulas + casks only                                |
-| `--refresh`     | Force live recompute, bypassing the cached snapshot               |
-| `--quiet`, `-q` | Suppress status messages                                          |
+| Flag            | Description                                         |
+| --------------- | --------------------------------------------------- |
+| `--json`        | Output as JSON                                      |
+| `--formula`     | Show outdated formulas only                         |
+| `--cask`        | Show outdated casks only                            |
+| `--pinned-only` | Audit pinned formulas + casks only                  |
+| `--refresh`     | Force live recompute, bypassing the cached snapshot |
+| `--quiet`, `-q` | Suppress status messages                            |
 
 Compares installed versions against the latest from the Homebrew API. Checks both formulas and casks by default. `--pinned-only` narrows the scan to pinned packages (formulas + casks) so you can see when an upstream release supersedes the version you've held back — pair with `mt upgrade --pinned --dry-run` for the full audit/preview pair.
 
@@ -539,6 +539,9 @@ Group-install and export sets of packages. Drop-in for `brew bundle`: reads exis
 mt bundle install                            # ./Brewfile or ./Maltfile.json
 mt bundle install path/to/Brewfile           # explicit file
 mt bundle install --dry-run                  # print what would happen
+mt bundle cleanup                            # uninstall packages absent from Brewfile (prompt)
+mt bundle cleanup --dry-run                  # print the removal plan, no changes
+mt bundle cleanup --yes                      # skip the typed confirmation
 mt bundle create                             # snapshot installed -> ./Brewfile
 mt bundle create --format json my.json       # JSON output
 mt bundle export                             # print current install to stdout
@@ -548,18 +551,20 @@ mt bundle remove devtools                    # unregister (does not uninstall)
 mt bundle import path/to/Brewfile            # register without installing
 ```
 
-| Subcommand | Description                                                                |
-| ---------- | -------------------------------------------------------------------------- |
-| `install`  | Install every member; idempotent — already-installed members are skipped   |
-| `create`   | Write the currently-installed set to a bundle file                         |
-| `list`     | List bundles registered in the database                                    |
-| `remove`   | Unregister a bundle (use `--purge` to also uninstall its members)          |
-| `export`   | Print bundle (or current install) to stdout in `brewfile` or `json` format |
-| `import`   | Register a bundle definition without installing                            |
+| Subcommand | Description                                                                                                                       |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `install`  | Install every member; idempotent — already-installed members are skipped                                                          |
+| `cleanup`  | Uninstall direct formulas/casks present on disk but absent from the Brewfile; indirect deps stay managed by `purge --unused-deps` |
+| `create`   | Write the currently-installed set to a bundle file                                                                                |
+| `list`     | List bundles registered in the database                                                                                           |
+| `remove`   | Unregister a bundle (use `--purge` to also uninstall its members)                                                                 |
+| `export`   | Print bundle (or current install) to stdout in `brewfile` or `json` format                                                        |
+| `import`   | Register a bundle definition without installing                                                                                   |
 
 | Flag               | Description                                           |
 | ------------------ | ----------------------------------------------------- |
-| `--dry-run`        | Print every member action without forking             |
+| `--dry-run`, `-n`  | Print every member action without forking             |
+| `--yes`, `-y`      | (`cleanup`) skip the typed removal confirmation       |
 | `--format <fmt>`   | `brewfile` (default) or `json`                        |
 | `--from-installed` | (`create`) populate from currently-installed packages |
 | `--purge`          | (`remove`) also uninstall each member                 |

--- a/build.zig
+++ b/build.zig
@@ -136,6 +136,7 @@ pub fn build(b: *std.Build) void {
         "tests/services_plist_test.zig",
         "tests/services_test.zig",
         "tests/bundle_test.zig",
+        "tests/bundle_cleanup_test.zig",
         "tests/atomic_test.zig",
         "tests/lock_test.zig",
         "tests/tap_test.zig",

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -272,6 +272,9 @@ else
   run_ok t3.bundle.create -- "$MT_BIN" bundle create --format json "$LOGDIR/Maltfile.json"
   run_ok t3.bundle.list -- "$MT_BIN" bundle list
   run_ok t3.bundle.install.dry -- "$MT_BIN" bundle install --dry-run "$LOGDIR/Maltfile.json"
+  # cleanup against a manifest covering everything installed: the plan must
+  # be empty and the command must short-circuit cleanly without prompting.
+  run_ok t3.bundle.cleanup.dry -- "$MT_BIN" bundle cleanup --dry-run "$LOGDIR/Maltfile.json"
 
   # run: already-installed path (no re-download).
   run_ok t3.run.tree -- "$MT_BIN" run tree -- --version

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -11,7 +11,9 @@ const manifest_mod = @import("../core/bundle/manifest.zig");
 const brewfile_mod = @import("../core/bundle/brewfile.zig");
 const brewfile_emit = @import("../core/bundle/brewfile_emit.zig");
 const runner_mod = @import("../core/bundle/runner.zig");
+const cleanup_mod = @import("../core/bundle/cleanup.zig");
 const install_cmd = @import("install.zig");
+const uninstall_cmd = @import("uninstall.zig");
 const tap_cmd = @import("tap.zig");
 const services_cmd = @import("services.zig");
 
@@ -43,6 +45,21 @@ const default_dispatcher = runner_mod.Dispatcher{
     .installCask = cliInstallCask,
     .tapAdd = cliTapAdd,
     .serviceStart = cliServiceStart,
+};
+
+fn cliUninstallFormula(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+    _ = ctx;
+    return uninstall_cmd.execute(allocator, &.{name});
+}
+
+fn cliUninstallCask(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+    _ = ctx;
+    return uninstall_cmd.execute(allocator, &.{ "--cask", name });
+}
+
+const default_cleanup_dispatcher = cleanup_mod.Dispatcher{
+    .uninstallFormula = cliUninstallFormula,
+    .uninstallCask = cliUninstallCask,
 };
 
 pub const BundleError = error{
@@ -78,6 +95,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     const rest = args[1..];
 
     if (std.mem.eql(u8, sub, "install")) return cmdInstall(allocator, rest);
+    if (std.mem.eql(u8, sub, "cleanup")) return cmdCleanup(allocator, rest);
     if (std.mem.eql(u8, sub, "create")) return cmdCreate(allocator, rest);
     if (std.mem.eql(u8, sub, "list")) return cmdList(allocator);
     if (std.mem.eql(u8, sub, "remove")) return cmdRemove(allocator, rest);
@@ -154,6 +172,93 @@ fn cmdInstall(allocator: std.mem.Allocator, rest: []const []const u8) !void {
 
     if (any_hard) return BundleError.RunnerFailed;
     output.success("bundle install complete", .{});
+}
+
+fn cmdCleanup(allocator: std.mem.Allocator, rest: []const []const u8) !void {
+    // main.zig strips the global `--dry-run` from argv; reading the
+    // module-global keeps cleanup aligned with `bundle install`.
+    var dry_run = output.isDryRun();
+    var yes = false;
+    var explicit_path: ?[]const u8 = null;
+    for (rest) |a| {
+        if (std.mem.eql(u8, a, "--dry-run") or std.mem.eql(u8, a, "-n")) {
+            dry_run = true;
+        } else if (std.mem.eql(u8, a, "--yes") or std.mem.eql(u8, a, "-y")) {
+            yes = true;
+        } else if (std.mem.startsWith(u8, a, "-")) {
+            output.warn("ignored flag: {s}", .{a});
+        } else {
+            explicit_path = a;
+        }
+    }
+
+    const path = try resolveBundlefile(allocator, explicit_path);
+    defer allocator.free(path);
+    output.info("using bundle file: {s}", .{path});
+
+    var diag = brewfile_mod.Diagnostics.init(allocator);
+    defer diag.deinit();
+    var manifest = try readManifest(allocator, path, &diag);
+    defer manifest.deinit();
+    for (diag.warnings.items) |w| output.warn("{s}", .{w});
+
+    // Tight DB scope: the connection's only job is the read-then-plan
+    // phase, so the per-member uninstalls below run against a freshly
+    // opened handle each.
+    var plan: cleanup_mod.Plan = blk: {
+        var db = try openDb();
+        defer db.close();
+        var installed = cleanup_mod.collectInstalled(allocator, &db) catch
+            return BundleError.DatabaseError;
+        defer installed.deinit();
+        var p = cleanup_mod.diff(
+            allocator,
+            manifest,
+            installed.formulas,
+            installed.casks,
+        ) catch return BundleError.RunnerFailed;
+        errdefer p.deinit();
+        cleanup_mod.orderForRemoval(allocator, &db, &p) catch
+            return BundleError.DatabaseError;
+        break :blk p;
+    };
+    defer plan.deinit();
+
+    if (plan.isEmpty()) {
+        output.success("nothing to clean up", .{});
+        return;
+    }
+
+    output.info("cleanup plan:", .{});
+    for (plan.formulas) |n| output.plain("  - {s}", .{n});
+    for (plan.casks) |n| output.plain("  - {s} (cask)", .{n});
+
+    if (dry_run) {
+        output.info("dry-run: skipping uninstall", .{});
+        return;
+    }
+
+    if (!yes and !output.confirmTyped("yes", "Type 'yes' to remove these packages: ")) {
+        output.warn("aborted", .{});
+        return;
+    }
+
+    var report = cleanup_mod.run(allocator, plan, .{
+        .dry_run = false,
+        .dispatcher = &default_cleanup_dispatcher,
+    }) catch |e| {
+        output.err("bundle cleanup failed: {s}", .{@errorName(e)});
+        return BundleError.RunnerFailed;
+    };
+    defer report.deinit();
+
+    // The uninstall pipeline already prints rich per-member diagnostics;
+    // surface only the count here so users see a single summary line.
+    if (report.hasFailure()) {
+        output.err("bundle cleanup completed with {d} failure(s)", .{report.failures.len});
+        return BundleError.RunnerFailed;
+    }
+    output.success("bundle cleanup complete", .{});
 }
 
 fn cmdList(allocator: std.mem.Allocator) !void {
@@ -453,6 +558,8 @@ fn printHelp() !void {
         \\
         \\Subcommands:
         \\  install [file]              Install formulae/casks/taps/services from a Brewfile or Maltfile.json.
+        \\  cleanup [--yes] [--dry-run] [file]
+        \\                              Uninstall packages present on disk but absent from the Brewfile.
         \\  create  [--format brewfile|json] [path]
         \\                              Write currently-installed set to a bundle file.
         \\  list                        List bundles registered in the database.

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -129,7 +129,7 @@ pub const bash_script =
     \\            ;;
     \\        bundle)
     \\            if [[ "$cur" != -* ]]; then
-    \\                COMPREPLY=( $(compgen -W "install create list remove export import" -- "$cur") )
+    \\                COMPREPLY=( $(compgen -W "install cleanup create list remove export import" -- "$cur") )
     \\                return 0
     \\            fi
     \\            ;;
@@ -153,7 +153,7 @@ pub const bash_script =
     \\        migrate|rollback) cmd_flags="--dry-run" ;;
     \\        link)             cmd_flags="--overwrite --force -f" ;;
     \\        services)         cmd_flags="--tail --stderr --follow -f --system --json" ;;
-    \\        bundle)           cmd_flags="--dry-run --format --from-installed --purge" ;;
+    \\        bundle)           cmd_flags="--dry-run -n --format --from-installed --purge --yes -y" ;;
     \\        run)              cmd_flags="--keep" ;;
     \\    esac
     \\
@@ -374,6 +374,7 @@ pub const zsh_script =
     \\                bundle)
     \\                    _values 'subcommand' \
     \\                        'install[Install members of a Brewfile/Maltfile.json]' \
+    \\                        'cleanup[Uninstall packages absent from the Brewfile]' \
     \\                        'create[Write currently-installed set to a bundle file]' \
     \\                        'list[List bundles registered in the database]' \
     \\                        'remove[Unregister a bundle]' \
@@ -598,12 +599,14 @@ pub const fish_script =
     \\
     \\    # bundle — sub-subcommands
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -f -a 'install' -d 'Install Brewfile/Maltfile.json members'
+    \\    complete -c $__malt_bin -n '__malt_using_command bundle' -f -a 'cleanup' -d 'Uninstall packages absent from the Brewfile'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -f -a 'create'  -d 'Write installed set to a bundle file'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -f -a 'list'    -d 'List registered bundles'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -f -a 'remove'  -d 'Unregister a bundle'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -f -a 'export'  -d 'Print bundle to stdout'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -f -a 'import'  -d 'Register a bundle without installing'
-    \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l dry-run        -d 'Preview without installing'
+    \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l dry-run -s n  -d 'Preview without installing/uninstalling'
+    \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l yes     -s y  -d 'Skip the cleanup confirmation prompt'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l format -r -a 'brewfile json' -d 'Output format'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l from-installed -d 'Populate from installed packages'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l purge          -d 'Also uninstall members on remove'

--- a/src/core/bundle/cleanup.zig
+++ b/src/core/bundle/cleanup.zig
@@ -1,0 +1,775 @@
+//! malt — bundle cleanup
+//!
+//! `mt bundle cleanup` removes packages on disk that the Brewfile no longer
+//! lists. This module owns the pure diff helper; the CLI layer wires the
+//! database query and the uninstall pipeline around it.
+
+const std = @import("std");
+const manifest_mod = @import("manifest.zig");
+const sqlite = @import("../../db/sqlite.zig");
+
+pub const CleanupError = error{
+    OutOfMemory,
+    NoDispatcher,
+    DatabaseError,
+};
+
+pub const MemberKind = enum { formula, cask };
+
+pub const MemberPreview = struct {
+    kind: MemberKind,
+    name: []const u8,
+};
+
+pub const MemberError = struct {
+    kind: MemberKind,
+    name: []const u8,
+    err: anyerror,
+};
+
+/// Layering seam: the CLI wires `cli/uninstall` behind this. Keeping the
+/// dispatcher injected keeps `core/bundle/cleanup.zig` free of `cli/*`
+/// imports, mirroring the existing bundle runner.
+pub const Dispatcher = struct {
+    ctx: ?*anyopaque = null,
+    uninstallFormula: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void,
+    uninstallCask: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void,
+};
+
+pub const Options = struct {
+    dry_run: bool = false,
+    dispatcher: ?*const Dispatcher = null,
+};
+
+/// Outcome of `run`. `previews` is populated on dry-run, `failures` on
+/// real runs that hit per-member errors. Names are borrowed from the
+/// caller's `Plan`, which must outlive the report.
+pub const Report = struct {
+    allocator: std.mem.Allocator,
+    failures: []MemberError,
+    previews: []MemberPreview,
+
+    pub fn hasFailure(self: Report) bool {
+        return self.failures.len > 0;
+    }
+
+    pub fn deinit(self: *Report) void {
+        self.allocator.free(self.failures);
+        self.allocator.free(self.previews);
+        self.* = undefined;
+    }
+};
+
+/// Names that are installed today but absent from the Brewfile and so are
+/// candidates for removal. Strings are owned by the plan; `deinit` frees
+/// both slices and every name in them.
+pub const Plan = struct {
+    allocator: std.mem.Allocator,
+    formulas: [][]const u8,
+    casks: [][]const u8,
+
+    pub fn isEmpty(self: Plan) bool {
+        return self.formulas.len == 0 and self.casks.len == 0;
+    }
+
+    pub fn deinit(self: *Plan) void {
+        for (self.formulas) |n| self.allocator.free(n);
+        for (self.casks) |n| self.allocator.free(n);
+        self.allocator.free(self.formulas);
+        self.allocator.free(self.casks);
+        self.* = undefined;
+    }
+};
+
+/// Direct formulas plus every cask currently installed, queried from the
+/// malt database. Strings are owned; `deinit` frees them.
+pub const InstalledLists = struct {
+    allocator: std.mem.Allocator,
+    formulas: [][]const u8,
+    casks: [][]const u8,
+
+    pub fn deinit(self: *InstalledLists) void {
+        for (self.formulas) |n| self.allocator.free(n);
+        for (self.casks) |n| self.allocator.free(n);
+        self.allocator.free(self.formulas);
+        self.allocator.free(self.casks);
+        self.* = undefined;
+    }
+};
+
+/// Pull the cleanup-relevant rows from the database. Only direct installs
+/// are candidates — indirect deps stay managed by `purge --unused-deps`.
+pub fn collectInstalled(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+) CleanupError!InstalledLists {
+    var formulas: std.ArrayList([]const u8) = .empty;
+    errdefer freeOwnedNames(allocator, &formulas);
+    var casks: std.ArrayList([]const u8) = .empty;
+    errdefer freeOwnedNames(allocator, &casks);
+
+    {
+        var stmt = db.prepare(
+            "SELECT name FROM kegs WHERE install_reason='direct' ORDER BY name;",
+        ) catch return CleanupError.DatabaseError;
+        defer stmt.finalize();
+        while (stmt.step() catch return CleanupError.DatabaseError) {
+            const n = stmt.columnText(0) orelse continue;
+            const owned = allocator.dupe(u8, std.mem.sliceTo(n, 0)) catch
+                return CleanupError.OutOfMemory;
+            formulas.append(allocator, owned) catch {
+                allocator.free(owned);
+                return CleanupError.OutOfMemory;
+            };
+        }
+    }
+
+    {
+        var stmt = db.prepare("SELECT token FROM casks ORDER BY token;") catch
+            return CleanupError.DatabaseError;
+        defer stmt.finalize();
+        while (stmt.step() catch return CleanupError.DatabaseError) {
+            const n = stmt.columnText(0) orelse continue;
+            const owned = allocator.dupe(u8, std.mem.sliceTo(n, 0)) catch
+                return CleanupError.OutOfMemory;
+            casks.append(allocator, owned) catch {
+                allocator.free(owned);
+                return CleanupError.OutOfMemory;
+            };
+        }
+    }
+
+    const owned_formulas = formulas.toOwnedSlice(allocator) catch return CleanupError.OutOfMemory;
+    errdefer allocator.free(owned_formulas);
+    const owned_casks = casks.toOwnedSlice(allocator) catch return CleanupError.OutOfMemory;
+
+    return .{
+        .allocator = allocator,
+        .formulas = owned_formulas,
+        .casks = owned_casks,
+    };
+}
+
+/// Compute the cleanup plan: every installed name not present in the
+/// manifest, returned sorted by name. Only direct installs are candidates —
+/// indirect deps are managed by `purge --unused-deps`.
+pub fn diff(
+    allocator: std.mem.Allocator,
+    manifest: manifest_mod.Manifest,
+    installed_formulas: []const []const u8,
+    installed_casks: []const []const u8,
+) CleanupError!Plan {
+    var formulas: std.ArrayList([]const u8) = .empty;
+    errdefer freeOwnedNames(allocator, &formulas);
+    var casks: std.ArrayList([]const u8) = .empty;
+    errdefer freeOwnedNames(allocator, &casks);
+
+    for (installed_formulas) |name| {
+        if (manifestHasFormula(manifest, name)) continue;
+        const owned = allocator.dupe(u8, name) catch return CleanupError.OutOfMemory;
+        formulas.append(allocator, owned) catch {
+            allocator.free(owned);
+            return CleanupError.OutOfMemory;
+        };
+    }
+    for (installed_casks) |name| {
+        if (manifestHasCask(manifest, name)) continue;
+        const owned = allocator.dupe(u8, name) catch return CleanupError.OutOfMemory;
+        casks.append(allocator, owned) catch {
+            allocator.free(owned);
+            return CleanupError.OutOfMemory;
+        };
+    }
+
+    sortNames(formulas.items);
+    sortNames(casks.items);
+
+    const owned_formulas = formulas.toOwnedSlice(allocator) catch return CleanupError.OutOfMemory;
+    errdefer allocator.free(owned_formulas);
+    const owned_casks = casks.toOwnedSlice(allocator) catch return CleanupError.OutOfMemory;
+
+    return .{
+        .allocator = allocator,
+        .formulas = owned_formulas,
+        .casks = owned_casks,
+    };
+}
+
+/// Reorder `plan.formulas` so that, for any in-plan A that depends on an
+/// in-plan B, A appears before B. Casks have no dep graph and stay alphabetical.
+/// Walks the `dependencies` table once; falls back to alphabetical for any
+/// nodes left in a cycle.
+pub fn orderForRemoval(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    plan: *Plan,
+) CleanupError!void {
+    if (plan.formulas.len < 2) return;
+
+    const n = plan.formulas.len;
+    const deps = allocator.alloc(std.ArrayList(u32), n) catch return CleanupError.OutOfMemory;
+    defer {
+        for (deps) |*l| l.deinit(allocator);
+        allocator.free(deps);
+    }
+    for (deps) |*l| l.* = .empty;
+
+    const dependents_count = allocator.alloc(u32, n) catch return CleanupError.OutOfMemory;
+    defer allocator.free(dependents_count);
+    @memset(dependents_count, 0);
+
+    var stmt = db.prepare(
+        \\SELECT k.name, d.dep_name FROM kegs k
+        \\JOIN dependencies d ON d.keg_id = k.id;
+    ) catch return CleanupError.DatabaseError;
+    defer stmt.finalize();
+    while (stmt.step() catch return CleanupError.DatabaseError) {
+        const k_ptr = stmt.columnText(0) orelse continue;
+        const d_ptr = stmt.columnText(1) orelse continue;
+        const k_idx = indexOf(plan.formulas, std.mem.sliceTo(k_ptr, 0)) orelse continue;
+        const d_idx = indexOf(plan.formulas, std.mem.sliceTo(d_ptr, 0)) orelse continue;
+        deps[k_idx].append(allocator, d_idx) catch return CleanupError.OutOfMemory;
+        dependents_count[d_idx] += 1;
+    }
+
+    var ordered = allocator.alloc([]const u8, n) catch return CleanupError.OutOfMemory;
+    errdefer allocator.free(ordered);
+    var write_idx: usize = 0;
+
+    var queue: std.ArrayList(u32) = .empty;
+    defer queue.deinit(allocator);
+    for (dependents_count, 0..) |c, i| {
+        if (c == 0) queue.append(allocator, @intCast(i)) catch return CleanupError.OutOfMemory;
+    }
+
+    var head: usize = 0;
+    while (head < queue.items.len) : (head += 1) {
+        const idx = queue.items[head];
+        ordered[write_idx] = plan.formulas[idx];
+        write_idx += 1;
+        for (deps[idx].items) |dep_idx| {
+            dependents_count[dep_idx] -= 1;
+            if (dependents_count[dep_idx] == 0) {
+                queue.append(allocator, dep_idx) catch return CleanupError.OutOfMemory;
+            }
+        }
+    }
+
+    // Cycle fallback: copy any unreached candidates in alphabetical order
+    // (plan.formulas is already sorted) so the output stays deterministic.
+    if (write_idx < n) {
+        var placed = allocator.alloc(bool, n) catch return CleanupError.OutOfMemory;
+        defer allocator.free(placed);
+        @memset(placed, false);
+        for (queue.items) |idx| placed[idx] = true;
+        for (plan.formulas, 0..) |name, i| {
+            if (placed[i]) continue;
+            ordered[write_idx] = name;
+            write_idx += 1;
+        }
+    }
+
+    allocator.free(plan.formulas);
+    plan.formulas = ordered;
+}
+
+fn indexOf(haystack: []const []const u8, needle: []const u8) ?u32 {
+    for (haystack, 0..) |s, i| if (std.mem.eql(u8, s, needle)) return @intCast(i);
+    return null;
+}
+
+/// Execute the cleanup plan. Dry-runs collect previews and never touch
+/// the dispatcher; live runs route each candidate through it and collect
+/// per-member failures so the CLI can render a single summary.
+pub fn run(
+    allocator: std.mem.Allocator,
+    plan: Plan,
+    opts: Options,
+) CleanupError!Report {
+    var failures: std.ArrayList(MemberError) = .empty;
+    errdefer failures.deinit(allocator);
+    var previews: std.ArrayList(MemberPreview) = .empty;
+    errdefer previews.deinit(allocator);
+
+    if (opts.dry_run) {
+        for (plan.formulas) |n| previews.append(allocator, .{ .kind = .formula, .name = n }) catch
+            return CleanupError.OutOfMemory;
+        for (plan.casks) |n| previews.append(allocator, .{ .kind = .cask, .name = n }) catch
+            return CleanupError.OutOfMemory;
+    } else {
+        const d = opts.dispatcher orelse return CleanupError.NoDispatcher;
+        for (plan.formulas) |n| {
+            d.uninstallFormula(d.ctx, allocator, n) catch |e| {
+                failures.append(allocator, .{ .kind = .formula, .name = n, .err = e }) catch
+                    return CleanupError.OutOfMemory;
+            };
+        }
+        for (plan.casks) |n| {
+            d.uninstallCask(d.ctx, allocator, n) catch |e| {
+                failures.append(allocator, .{ .kind = .cask, .name = n, .err = e }) catch
+                    return CleanupError.OutOfMemory;
+            };
+        }
+    }
+
+    const owned_failures = failures.toOwnedSlice(allocator) catch return CleanupError.OutOfMemory;
+    errdefer allocator.free(owned_failures);
+    const owned_previews = previews.toOwnedSlice(allocator) catch return CleanupError.OutOfMemory;
+
+    return .{
+        .allocator = allocator,
+        .failures = owned_failures,
+        .previews = owned_previews,
+    };
+}
+
+fn manifestHasFormula(manifest: manifest_mod.Manifest, name: []const u8) bool {
+    for (manifest.formulas) |f| if (std.mem.eql(u8, f.name, name)) return true;
+    return false;
+}
+
+fn manifestHasCask(manifest: manifest_mod.Manifest, name: []const u8) bool {
+    for (manifest.casks) |c| if (std.mem.eql(u8, c.name, name)) return true;
+    return false;
+}
+
+fn sortNames(items: [][]const u8) void {
+    std.mem.sort([]const u8, items, {}, struct {
+        fn lt(_: void, a: []const u8, b: []const u8) bool {
+            return std.mem.lessThan(u8, a, b);
+        }
+    }.lt);
+}
+
+fn freeOwnedNames(allocator: std.mem.Allocator, list: *std.ArrayList([]const u8)) void {
+    for (list.items) |n| allocator.free(n);
+    list.deinit(allocator);
+}
+
+// -------- inline tests --------
+
+const testing = std.testing;
+const schema = @import("../../db/schema.zig");
+
+fn testManifest(
+    parent: std.mem.Allocator,
+    formulas: []const []const u8,
+    casks: []const []const u8,
+) !manifest_mod.Manifest {
+    var m = manifest_mod.Manifest.init(parent);
+    errdefer m.deinit();
+    const a = m.allocator();
+
+    if (formulas.len > 0) {
+        const dst = try a.alloc(manifest_mod.FormulaEntry, formulas.len);
+        for (formulas, 0..) |name, i| dst[i] = .{ .name = try a.dupe(u8, name) };
+        m.formulas = dst;
+    }
+    if (casks.len > 0) {
+        const dst = try a.alloc(manifest_mod.CaskEntry, casks.len);
+        for (casks, 0..) |name, i| dst[i] = .{ .name = try a.dupe(u8, name) };
+        m.casks = dst;
+    }
+    return m;
+}
+
+test "diff returns formulas installed but missing from manifest" {
+    var m = try testManifest(testing.allocator, &.{ "wget", "jq" }, &.{});
+    defer m.deinit();
+
+    var plan = try diff(
+        testing.allocator,
+        m,
+        &[_][]const u8{ "wget", "ripgrep", "jq", "fzf" },
+        &[_][]const u8{},
+    );
+    defer plan.deinit();
+
+    try testing.expectEqual(@as(usize, 2), plan.formulas.len);
+    try testing.expectEqualStrings("fzf", plan.formulas[0]);
+    try testing.expectEqualStrings("ripgrep", plan.formulas[1]);
+    try testing.expectEqual(@as(usize, 0), plan.casks.len);
+}
+
+test "diff returns casks installed but missing from manifest" {
+    var m = try testManifest(testing.allocator, &.{}, &.{"ghostty"});
+    defer m.deinit();
+
+    var plan = try diff(
+        testing.allocator,
+        m,
+        &[_][]const u8{},
+        &[_][]const u8{ "ghostty", "visual-studio-code", "iterm2" },
+    );
+    defer plan.deinit();
+
+    try testing.expectEqual(@as(usize, 0), plan.formulas.len);
+    try testing.expectEqual(@as(usize, 2), plan.casks.len);
+    try testing.expectEqualStrings("iterm2", plan.casks[0]);
+    try testing.expectEqualStrings("visual-studio-code", plan.casks[1]);
+}
+
+test "diff is empty when manifest covers every installed entry" {
+    var m = try testManifest(testing.allocator, &.{ "wget", "jq" }, &.{"ghostty"});
+    defer m.deinit();
+
+    var plan = try diff(
+        testing.allocator,
+        m,
+        &[_][]const u8{ "wget", "jq" },
+        &[_][]const u8{"ghostty"},
+    );
+    defer plan.deinit();
+
+    try testing.expect(plan.isEmpty());
+}
+
+test "diff entries are sorted alphabetically" {
+    var m = try testManifest(testing.allocator, &.{}, &.{});
+    defer m.deinit();
+
+    var plan = try diff(
+        testing.allocator,
+        m,
+        &[_][]const u8{ "zsh", "abc", "midline" },
+        &[_][]const u8{},
+    );
+    defer plan.deinit();
+
+    try testing.expectEqualStrings("abc", plan.formulas[0]);
+    try testing.expectEqualStrings("midline", plan.formulas[1]);
+    try testing.expectEqualStrings("zsh", plan.formulas[2]);
+}
+
+const TestDispatcher = struct {
+    allocator: std.mem.Allocator,
+    formulas: std.ArrayList([]const u8),
+    casks: std.ArrayList([]const u8),
+
+    fn init(allocator: std.mem.Allocator) TestDispatcher {
+        return .{ .allocator = allocator, .formulas = .empty, .casks = .empty };
+    }
+
+    fn deinit(self: *TestDispatcher) void {
+        self.formulas.deinit(self.allocator);
+        self.casks.deinit(self.allocator);
+    }
+
+    fn unwrap(ctx: ?*anyopaque) *TestDispatcher {
+        return @ptrCast(@alignCast(ctx.?));
+    }
+
+    fn uninstallFormulaFn(ctx: ?*anyopaque, _: std.mem.Allocator, name: []const u8) anyerror!void {
+        const self = unwrap(ctx);
+        try self.formulas.append(self.allocator, name);
+    }
+
+    fn uninstallCaskFn(ctx: ?*anyopaque, _: std.mem.Allocator, name: []const u8) anyerror!void {
+        const self = unwrap(ctx);
+        try self.casks.append(self.allocator, name);
+    }
+};
+
+test "run with dry_run does not invoke the dispatcher" {
+    var fake = TestDispatcher.init(testing.allocator);
+    defer fake.deinit();
+
+    var m = try testManifest(testing.allocator, &.{}, &.{});
+    defer m.deinit();
+    var plan = try diff(
+        testing.allocator,
+        m,
+        &[_][]const u8{ "wget", "jq" },
+        &[_][]const u8{"ghostty"},
+    );
+    defer plan.deinit();
+
+    const dispatcher = Dispatcher{
+        .ctx = &fake,
+        .uninstallFormula = TestDispatcher.uninstallFormulaFn,
+        .uninstallCask = TestDispatcher.uninstallCaskFn,
+    };
+
+    var report = try run(testing.allocator, plan, .{ .dry_run = true, .dispatcher = &dispatcher });
+    defer report.deinit();
+
+    try testing.expectEqual(@as(usize, 0), fake.formulas.items.len);
+    try testing.expectEqual(@as(usize, 0), fake.casks.items.len);
+    try testing.expectEqual(@as(usize, 3), report.previews.len);
+    try testing.expectEqual(@as(usize, 0), report.failures.len);
+}
+
+test "run executes uninstall via dispatcher in formula-then-cask order" {
+    var fake = TestDispatcher.init(testing.allocator);
+    defer fake.deinit();
+
+    var m = try testManifest(testing.allocator, &.{}, &.{});
+    defer m.deinit();
+    var plan = try diff(
+        testing.allocator,
+        m,
+        &[_][]const u8{ "jq", "wget" },
+        &[_][]const u8{"ghostty"},
+    );
+    defer plan.deinit();
+
+    const dispatcher = Dispatcher{
+        .ctx = &fake,
+        .uninstallFormula = TestDispatcher.uninstallFormulaFn,
+        .uninstallCask = TestDispatcher.uninstallCaskFn,
+    };
+
+    var report = try run(testing.allocator, plan, .{ .dry_run = false, .dispatcher = &dispatcher });
+    defer report.deinit();
+
+    try testing.expectEqual(@as(usize, 2), fake.formulas.items.len);
+    try testing.expectEqualStrings("jq", fake.formulas.items[0]);
+    try testing.expectEqualStrings("wget", fake.formulas.items[1]);
+    try testing.expectEqual(@as(usize, 1), fake.casks.items.len);
+    try testing.expectEqualStrings("ghostty", fake.casks.items[0]);
+    try testing.expectEqual(@as(usize, 0), report.failures.len);
+}
+
+test "run records per-member failures and keeps going" {
+    var m = try testManifest(testing.allocator, &.{}, &.{});
+    defer m.deinit();
+    var plan = try diff(
+        testing.allocator,
+        m,
+        &[_][]const u8{ "jq", "wget" },
+        &[_][]const u8{"ghostty"},
+    );
+    defer plan.deinit();
+
+    const Failer = struct {
+        fn alwaysFails(_: ?*anyopaque, _: std.mem.Allocator, _: []const u8) anyerror!void {
+            return error.MemberFailed;
+        }
+    };
+    const dispatcher = Dispatcher{
+        .uninstallFormula = Failer.alwaysFails,
+        .uninstallCask = Failer.alwaysFails,
+    };
+
+    var report = try run(testing.allocator, plan, .{ .dry_run = false, .dispatcher = &dispatcher });
+    defer report.deinit();
+
+    try testing.expectEqual(@as(usize, 3), report.failures.len);
+    try testing.expectEqual(MemberKind.formula, report.failures[0].kind);
+    try testing.expectEqualStrings("jq", report.failures[0].name);
+    try testing.expectEqual(MemberKind.cask, report.failures[2].kind);
+    try testing.expectEqualStrings("ghostty", report.failures[2].name);
+}
+
+test "orderForRemoval reorders formulas so dependents land before their deps" {
+    const fs_compat = @import("../../fs/compat.zig");
+    const dir = "/tmp/malt_bundle_cleanup_topo_inline";
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    try fs_compat.makeDirAbsolute(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    var db_path_buf: [256]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/test.db", .{dir}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    // Z depends on A; both are direct installs and both will land in the
+    // cleanup plan when the manifest drops them. Alphabetical order would
+    // try A first and fail (Z still depends on it). Topological order
+    // must surface Z first.
+    {
+        var ins = try db.prepare(
+            \\INSERT INTO kegs(name, full_name, version, store_sha256, cellar_path, install_reason)
+            \\VALUES (?, ?, '1.0', '', '', 'direct');
+        );
+        defer ins.finalize();
+        for ([_][]const u8{ "A", "Z" }) |n| {
+            try ins.reset();
+            try ins.bindText(1, n);
+            try ins.bindText(2, n);
+            _ = try ins.step();
+        }
+    }
+    {
+        var dep = try db.prepare(
+            \\INSERT INTO dependencies(keg_id, dep_name, dep_type)
+            \\SELECT id, 'A', 'runtime' FROM kegs WHERE name = 'Z';
+        );
+        defer dep.finalize();
+        _ = try dep.step();
+    }
+
+    var m = try testManifest(testing.allocator, &.{}, &.{});
+    defer m.deinit();
+    var plan = try diff(
+        testing.allocator,
+        m,
+        &[_][]const u8{ "A", "Z" },
+        &[_][]const u8{},
+    );
+    defer plan.deinit();
+
+    // Pre-condition: diff produced alphabetical order.
+    try testing.expectEqualStrings("A", plan.formulas[0]);
+    try testing.expectEqualStrings("Z", plan.formulas[1]);
+
+    try orderForRemoval(testing.allocator, &db, &plan);
+
+    try testing.expectEqualStrings("Z", plan.formulas[0]);
+    try testing.expectEqualStrings("A", plan.formulas[1]);
+}
+
+test "orderForRemoval falls back to alphabetical when the dep graph cycles" {
+    const fs_compat = @import("../../fs/compat.zig");
+    const dir = "/tmp/malt_bundle_cleanup_topo_cycle";
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    try fs_compat.makeDirAbsolute(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    var db_path_buf: [256]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/test.db", .{dir}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    // Pathological data: A <-> B. Real Homebrew rejects cycles, but the
+    // helper must terminate and produce deterministic output anyway.
+    {
+        var ins = try db.prepare(
+            \\INSERT INTO kegs(name, full_name, version, store_sha256, cellar_path, install_reason)
+            \\VALUES (?, ?, '1.0', '', '', 'direct');
+        );
+        defer ins.finalize();
+        for ([_][]const u8{ "A", "B" }) |n| {
+            try ins.reset();
+            try ins.bindText(1, n);
+            try ins.bindText(2, n);
+            _ = try ins.step();
+        }
+    }
+    {
+        var dep = try db.prepare(
+            \\INSERT INTO dependencies(keg_id, dep_name, dep_type)
+            \\SELECT id, ?, 'runtime' FROM kegs WHERE name = ?;
+        );
+        defer dep.finalize();
+        const edges = [_]struct { from: []const u8, to: []const u8 }{
+            .{ .from = "A", .to = "B" },
+            .{ .from = "B", .to = "A" },
+        };
+        for (edges) |e| {
+            try dep.reset();
+            try dep.bindText(1, e.to);
+            try dep.bindText(2, e.from);
+            _ = try dep.step();
+        }
+    }
+
+    var m = try testManifest(testing.allocator, &.{}, &.{});
+    defer m.deinit();
+    var plan = try diff(
+        testing.allocator,
+        m,
+        &[_][]const u8{ "A", "B" },
+        &[_][]const u8{},
+    );
+    defer plan.deinit();
+
+    try orderForRemoval(testing.allocator, &db, &plan);
+
+    // Cycle fallback preserves the alphabetical input order.
+    try testing.expectEqual(@as(usize, 2), plan.formulas.len);
+    try testing.expectEqualStrings("A", plan.formulas[0]);
+    try testing.expectEqualStrings("B", plan.formulas[1]);
+}
+
+test "orderForRemoval is a no-op when no in-plan deps exist" {
+    const fs_compat = @import("../../fs/compat.zig");
+    const dir = "/tmp/malt_bundle_cleanup_topo_noop";
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    try fs_compat.makeDirAbsolute(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    var db_path_buf: [256]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/test.db", .{dir}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var m = try testManifest(testing.allocator, &.{}, &.{});
+    defer m.deinit();
+    var plan = try diff(
+        testing.allocator,
+        m,
+        &[_][]const u8{ "abc", "midline", "zsh" },
+        &[_][]const u8{},
+    );
+    defer plan.deinit();
+
+    try orderForRemoval(testing.allocator, &db, &plan);
+
+    // Independent kegs stay in alphabetical order — Kahn's frontier
+    // pops in plan-index order, which is alphabetical from `diff`.
+    try testing.expectEqualStrings("abc", plan.formulas[0]);
+    try testing.expectEqualStrings("midline", plan.formulas[1]);
+    try testing.expectEqualStrings("zsh", plan.formulas[2]);
+}
+
+test "collectInstalled returns direct formulas and every cask, sorted" {
+    const fs_compat = @import("../../fs/compat.zig");
+    const dir = "/tmp/malt_bundle_cleanup_collect_inline";
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    try fs_compat.makeDirAbsolute(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    var db_path_buf: [256]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/test.db", .{dir}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    {
+        // Indirect kegs are out of scope: cleanup must never list them, since
+        // they belong to `purge --unused-deps`.
+        var stmt = try db.prepare(
+            \\INSERT INTO kegs(name, full_name, version, store_sha256, cellar_path, install_reason)
+            \\VALUES (?, ?, '1.0', '', '', ?);
+        );
+        defer stmt.finalize();
+        const rows = [_]struct { name: []const u8, reason: []const u8 }{
+            .{ .name = "ripgrep", .reason = "direct" },
+            .{ .name = "openssl@3", .reason = "dependency" },
+            .{ .name = "wget", .reason = "direct" },
+        };
+        for (rows) |r| {
+            try stmt.reset();
+            try stmt.bindText(1, r.name);
+            try stmt.bindText(2, r.name);
+            try stmt.bindText(3, r.reason);
+            _ = try stmt.step();
+        }
+    }
+    {
+        var stmt = try db.prepare(
+            \\INSERT INTO casks(token, name, version, url) VALUES (?, ?, '1.0', '');
+        );
+        defer stmt.finalize();
+        for ([_][]const u8{ "ghostty", "iterm2" }) |n| {
+            try stmt.reset();
+            try stmt.bindText(1, n);
+            try stmt.bindText(2, n);
+            _ = try stmt.step();
+        }
+    }
+
+    var lists = try collectInstalled(testing.allocator, &db);
+    defer lists.deinit();
+
+    try testing.expectEqual(@as(usize, 2), lists.formulas.len);
+    try testing.expectEqualStrings("ripgrep", lists.formulas[0]);
+    try testing.expectEqualStrings("wget", lists.formulas[1]);
+    try testing.expectEqual(@as(usize, 2), lists.casks.len);
+    try testing.expectEqualStrings("ghostty", lists.casks[0]);
+    try testing.expectEqualStrings("iterm2", lists.casks[1]);
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -41,6 +41,7 @@ pub const bundle_brewfile_emit = @import("core/bundle/brewfile_emit.zig");
 pub const services_plist = @import("core/services/plist.zig");
 pub const services_supervisor = @import("core/services/supervisor.zig");
 pub const bundle_runner = @import("core/bundle/runner.zig");
+pub const bundle_cleanup = @import("core/bundle/cleanup.zig");
 pub const cli_services = @import("cli/services.zig");
 pub const cli_bundle = @import("cli/bundle.zig");
 pub const cli_help = @import("cli/help.zig");

--- a/tests/bundle_cleanup_test.zig
+++ b/tests/bundle_cleanup_test.zig
@@ -1,0 +1,85 @@
+//! malt — bundle cleanup CLI integration tests
+//!
+//! Pure unit tests for `core/bundle/cleanup.zig` live inline next to the
+//! module. This file pins the cross-module CLI wiring: `cli/bundle.zig`
+//! parsing, MALT_PREFIX-driven DB lookup, brewfile parsing, and the
+//! dry-run skip-uninstall contract.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+
+test "cli bundle cleanup --dry-run plans removal without dispatching" {
+    // We can't inject a fake dispatcher through `cli_bundle.execute`, so
+    // dry-run is the proof — any uninstall would mutate the database, and
+    // we assert it stays intact.
+    const dir_z: [:0]const u8 = "/tmp/malt_bundle_cleanup_cli_dry_run";
+    malt.fs_compat.deleteTreeAbsolute(dir_z) catch {};
+    try malt.fs_compat.cwd().makePath(dir_z);
+    defer malt.fs_compat.deleteTreeAbsolute(dir_z) catch {};
+
+    _ = c.setenv("MALT_PREFIX", dir_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{dir_z});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/malt.db", .{db_dir}, 0);
+    defer testing.allocator.free(db_path);
+    {
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+        var ins_keg = try db.prepare(
+            \\INSERT INTO kegs(name, full_name, version, store_sha256, cellar_path, install_reason)
+            \\VALUES (?, ?, '1.0', '', '', 'direct');
+        );
+        defer ins_keg.finalize();
+        for ([_][]const u8{ "wget", "ripgrep", "jq" }) |n| {
+            try ins_keg.reset();
+            try ins_keg.bindText(1, n);
+            try ins_keg.bindText(2, n);
+            _ = try ins_keg.step();
+        }
+        var ins_cask = try db.prepare(
+            \\INSERT INTO casks(token, name, version, url) VALUES (?, ?, '1.0', '');
+        );
+        defer ins_cask.finalize();
+        for ([_][]const u8{ "ghostty", "iterm2" }) |n| {
+            try ins_cask.reset();
+            try ins_cask.bindText(1, n);
+            try ins_cask.bindText(2, n);
+            _ = try ins_cask.step();
+        }
+    }
+
+    // Brewfile keeps wget + ghostty; cleanup must propose ripgrep, jq, iterm2.
+    const bf_path = try std.fmt.allocPrint(testing.allocator, "{s}/Brewfile", .{dir_z});
+    defer testing.allocator.free(bf_path);
+    {
+        const f = try malt.fs_compat.cwd().createFile(bf_path, .{});
+        defer f.close();
+        try f.writeAll("brew \"wget\"\ncask \"ghostty\"\n");
+    }
+
+    try malt.cli_bundle.execute(testing.allocator, &.{ "cleanup", "--dry-run", bf_path });
+
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    var stmt = try db.prepare("SELECT COUNT(*) FROM kegs;");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    try testing.expectEqual(@as(i64, 3), stmt.columnInt(0));
+
+    var stmt2 = try db.prepare("SELECT COUNT(*) FROM casks;");
+    defer stmt2.finalize();
+    _ = try stmt2.step();
+    try testing.expectEqual(@as(i64, 2), stmt2.columnInt(0));
+}
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -113,3 +113,15 @@ test "all update completions expose --check" {
     try expectContains(completions.zsh_script, "--check");
     try expectContains(completions.fish_script, "-l check");
 }
+
+test "all bundle completions expose the cleanup subcommand and its flags" {
+    for ([_][]const u8{
+        completions.bash_script,
+        completions.zsh_script,
+        completions.fish_script,
+    }) |script| try expectContains(script, "cleanup");
+    // --yes belongs to cleanup; --dry-run is shared with install.
+    try expectContains(completions.bash_script, "--yes");
+    try expectContains(completions.zsh_script, "cleanup[");
+    try expectContains(completions.fish_script, "-l yes");
+}


### PR DESCRIPTION
## Description

`mt bundle cleanup` closes the round-trip gap in `mt bundle`: now you can declare your dev environment in a Brewfile and have malt remove anything you stopped listing, just like `brew bundle cleanup`. The plan is ordered so dependents are removed before their dependencies, so dropping a chain of related packages from the Brewfile no longer needs a second pass. Pass `--dry-run` to preview the plan or `--yes` to skip the typed confirmation. Indirect dependencies stay out of scope - they remain managed by `purge --unused-deps`.

## Related Issue

- None

## Notes for Reviewers

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)