### PR TITLE
perf(install): parse each dep formula once per invocation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -124,6 +124,7 @@ pub fn build(b: *std.Build) void {
         "tests/backup_test.zig",
         "tests/purge_test.zig",
         "tests/install_test.zig",
+        "tests/install_parse_cache_test.zig",
         "tests/deps_leak_test.zig",
         "tests/api_test.zig",
         "tests/clonefile_test.zig",

--- a/scripts/regressions/install_formula_parse_cache.sh
+++ b/scripts/regressions/install_formula_parse_cache.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Regression test for the per-invocation parsed-formula cache.
+#
+# A multi-dep formula install must succeed end-to-end after the cache
+# refactor: BFS dep resolution, parallel fetch, post-process, link phase
+# (linkAndRecord), and findFailedDep all share one cache. A real install
+# is the only path that walks every consumer at once, so a single
+# warm-path round catches any regression in cache wiring or lifetime.
+#
+# Usage: scripts/regressions/install_formula_parse_cache.sh
+# Requirements: built `malt` binary at $MALT_BIN or zig-out/bin/malt,
+# network access to ghcr.io / formulae.brew.sh.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be <= 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_pcc"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+# wget has 6 deps (openssl@3, libidn2, gettext, libunistring, c-ares,
+# ca-certificates) — enough to drive the dep-resolve BFS, the parallel
+# fetch, post-process, and the link-phase findFailedDep walk.
+TARGET="${TARGET:-wget}"
+LOG="$PREFIX/install.log"
+
+printf '▸ malt install %s (logs → %s)\n' "$TARGET" "$LOG"
+"$BIN" install "$TARGET" >"$LOG" 2>&1 || {
+  printf '---- last 40 lines of install log ----\n' >&2
+  tail -40 "$LOG" >&2
+  fail "install of $TARGET failed — see $LOG"
+}
+pass "installed $TARGET"
+
+# ── 1. The keg + every dep must be present in the Cellar. ────────────
+[[ -d "$PREFIX/Cellar/$TARGET" ]] || fail "$PREFIX/Cellar/$TARGET missing"
+pass "Cellar/$TARGET present"
+
+dep_count=$(find "$PREFIX/Cellar" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+[[ "$dep_count" -ge 2 ]] || fail "expected at least 2 kegs in Cellar (target + deps), got $dep_count"
+pass "Cellar holds $dep_count kegs (target + deps)"
+
+# ── 2. The installed binary must actually resolve at runtime. ────────
+"$PREFIX/bin/$TARGET" --version >/dev/null 2>&1 ||
+  fail "$PREFIX/bin/$TARGET --version failed (cache may have broken linkAndRecord)"
+pass "$TARGET --version runs cleanly"
+
+# ── 3. Warm reinstall (--force) must replay the entire pipeline ──────
+# through the same cache path without leaving stale state.
+"$BIN" install --force "$TARGET" >>"$LOG" 2>&1 || {
+  printf '---- last 40 lines of install log ----\n' >&2
+  tail -40 "$LOG" >&2
+  fail "warm reinstall of $TARGET failed — see $LOG"
+}
+pass "warm reinstall of $TARGET succeeded"
+
+"$PREFIX/bin/$TARGET" --version >/dev/null 2>&1 ||
+  fail "$TARGET --version regressed after warm reinstall"
+pass "$TARGET still runs after warm reinstall"
+
+# ── 4. Idempotent re-install (already-installed branch) ──────────────
+# must short-circuit without touching the cache or the Cellar.
+"$BIN" install "$TARGET" >>"$LOG" 2>&1 || fail "idempotent reinstall of $TARGET failed"
+grep -q "is already installed" "$LOG" ||
+  fail "idempotent install missed the 'already installed' short-circuit"
+pass "idempotent reinstall short-circuits"
+
+printf '\n✔ install-formula-parse-cache regression test passed\n'

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 
 const cask_mod = @import("../core/cask.zig");
 const cellar_mod = @import("../core/cellar.zig");
+const deps_mod = @import("../core/deps.zig");
 const formula_mod = @import("../core/formula.zig");
 const linker_mod = @import("../core/linker.zig");
 const plist_mod = @import("../core/services/plist.zig");
@@ -292,6 +293,10 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var store = store_mod.Store.init(allocator, &db, prefix);
     var linker = linker_mod.Linker.init(allocator, &db, prefix);
 
+    // One parsed-formula cache for the whole run; single free site.
+    var formula_cache = deps_mod.FormulaCache.init(allocator);
+    defer formula_cache.deinit();
+
     // ── Collect all download jobs across all packages ────────────────
     var all_jobs: std.ArrayList(DownloadJob) = .empty;
     defer all_jobs.deinit(allocator);
@@ -360,6 +365,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
                 .http_pool = &http_pool,
                 .db = &db,
                 .store = &store,
+                .cache = &formula_cache,
             }, pkg_name, formula_json, force, &all_jobs) catch |e| {
                 output.err("Failed to resolve {s}: {s}", .{ pkg_name, @errorName(e) });
                 continue;
@@ -592,7 +598,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
         // Failed-dep → skip: installing on a broken graph yields a dyld-unresolvable
         // keg. Remove the already-materialised keg so orphans don't linger.
-        if (findFailedDep(&failed_kegs, job.formula_json)) |failed_dep| {
+        if (findFailedDep(&formula_cache, &failed_kegs, job.name, job.formula_json)) |failed_dep| {
             output.warn(
                 "Skipping {s}: dependency {s} failed to install",
                 .{ job.name, failed_dep },
@@ -604,7 +610,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             continue;
         }
 
-        linkAndRecord(allocator, job, mats[i].keg_path, &db, &linker, prefix) catch {
+        linkAndRecord(allocator, job, mats[i].keg_path, &db, &linker, prefix, &formula_cache) catch {
             // The underlying error was already logged with a tag by
             // linkAndRecord — just record that this job failed so its
             // dependents in the rest of the loop get skipped above.
@@ -637,17 +643,19 @@ fn linkAndRecord(
     db: *sqlite.Database,
     linker: *linker_mod.Linker,
     prefix: []const u8,
+    cache: *deps_mod.FormulaCache,
 ) !void {
     const reason: []const u8 = if (job.is_dep) "dependency" else "direct";
 
-    // Parse formula for DB recording
-    var formula = formula_mod.parseFormula(allocator, job.formula_json) catch |err| {
-        output.err("Failed to parse formula for {s}: {s}", .{ job.name, @errorName(err) });
-        // rollback materialised keg; user-visible error already emitted.
-        cellar_mod.remove(prefix, job.name, job.version_str) catch {};
-        return InstallError.CellarFailed;
+    // Cache hit on the warm path; miss only happens for jobs whose JSON
+    // never reached collectFormulaJobs (none today).
+    const formula = cache.get(job.name) orelse blk: {
+        break :blk cache.getOrParse(job.name, job.formula_json) catch |err| {
+            output.err("Failed to parse formula for {s}: {s}", .{ job.name, @errorName(err) });
+            cellar_mod.remove(prefix, job.name, job.version_str) catch {};
+            return InstallError.CellarFailed;
+        };
     };
-    defer formula.deinit();
 
     // Check for symlink conflicts before linking
     if (!job.keg_only) {
@@ -658,7 +666,6 @@ fn linkAndRecord(
                 output.err("  {s} already linked by {s}", .{ conflict.link_path, conflict.existing_keg });
             }
             output.err("Use --force to overwrite, or uninstall the conflicting package first.", .{});
-            // rollback materialised keg on conflict.
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
             return InstallError.LinkFailed;
         }
@@ -666,37 +673,32 @@ fn linkAndRecord(
 
     // Link + record
     if (!job.keg_only) {
-        const keg_id = recordKeg(db, &formula, job.store_sha256, keg_path, reason) catch |err| {
+        const keg_id = recordKeg(db, formula, job.store_sha256, keg_path, reason) catch |err| {
             output.err("Failed to record {s} in database: {s}", .{ job.name, @errorName(err) });
-            // rollback materialised keg when DB record fails.
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
             return InstallError.RecordFailed;
         };
 
         linker.link(keg_path, job.name, keg_id) catch |err| {
             output.err("Failed to link {s}: {s}", .{ job.name, @errorName(err) });
-            // Rollback: unlink what was partially created + remove DB record + cellar
-            // partial-link cleanup in a rollback; original error is authoritative.
+            // Rollback: unlink what was partially created + remove DB record + cellar.
             linker.unlink(keg_id) catch {};
             deleteKeg(db, keg_id);
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
             return InstallError.LinkFailed;
         };
-        // opt symlink is convenience; install already functional via versioned link.
         linker.linkOpt(job.name, job.version_str) catch {};
-        recordDeps(db, keg_id, &formula);
+        recordDeps(db, keg_id, formula);
     } else {
-        const keg_id = recordKeg(db, &formula, job.store_sha256, keg_path, reason) catch |err| {
+        const keg_id = recordKeg(db, formula, job.store_sha256, keg_path, reason) catch |err| {
             output.err("Failed to record {s} in database: {s}", .{ job.name, @errorName(err) });
-            // rollback materialised keg when DB record fails.
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
             return InstallError.RecordFailed;
         };
-        // opt symlink is convenience; install already functional via versioned link.
         linker.linkOpt(job.name, job.version_str) catch {};
-        recordDeps(db, keg_id, &formula);
+        recordDeps(db, keg_id, formula);
     }
-    maybeRegisterService(allocator, db, &formula, prefix);
+    maybeRegisterService(allocator, db, formula, prefix);
     // Annotate keg-only packages inline so the single line reads as success,
     // not as a "not linking" warning paired with a separate ✓.
     const keg_only_suffix: []const u8 = if (job.keg_only) " (keg-only — dependency only)" else "";

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -31,6 +31,8 @@ pub const InstallJobDeps = struct {
     http_pool: *client_mod.HttpClientPool,
     db: *sqlite.Database,
     store: *store_mod.Store,
+    /// Shared parsed-formula cache for the whole install run.
+    cache: *deps_mod.FormulaCache,
 };
 
 /// A bottle download job for parallel processing.
@@ -302,17 +304,10 @@ pub fn collectFormulaJobs(
     const api = ctx.api;
     const http_pool = ctx.http_pool;
     const db = ctx.db;
+    const cache = ctx.cache;
 
-    // Single arena for every parsed formula — root + each dep — so the
-    // std.json.Parsed trees and all the supplementary allocations made
-    // by `parseFormula` (dependencies/oldnames/service.run/pkg_version)
-    // are released at function exit. BUG-009 used to pin every parsed
-    // tree for the whole install run (~500 KB on ffmpeg).
-    var parse_arena = std.heap.ArenaAllocator.init(allocator);
-    defer parse_arena.deinit();
-    const parse_alloc = parse_arena.allocator();
-
-    var formula = formula_mod.parseFormula(parse_alloc, formula_json) catch |e| {
+    // Single seam for every parse — cached entries outlive this function.
+    const formula = cache.getOrParse(pkg_name, formula_json) catch |e| {
         output.err("Failed to parse formula JSON for '{s}': {s}", .{ pkg_name, @errorName(e) });
         return InstallError.FormulaNotFound;
     };
@@ -326,9 +321,9 @@ pub fn collectFormulaJobs(
     // Resolve dependencies. `deps_mod.resolve` forwards the allocator
     // into `api.fetchFormula`, whose bytes come from `api.allocator`
     // (the same caller allocator) — so the allocator here must match
-    // `allocator`, not `parse_arena.allocator()`, otherwise free on
-    // the API-allocated bytes is a no-op on the arena.
-    const deps = deps_mod.resolve(allocator, formula.name, api, db) catch &.{};
+    // `allocator`, otherwise free on the API-allocated bytes is a no-op
+    // on the wrong allocator.
+    const deps = deps_mod.resolve(allocator, formula.name, api, db, cache) catch &.{};
     defer {
         for (deps) |d| allocator.free(d.name);
         // `catch &.{}` yields a static empty slice with no backing
@@ -416,8 +411,8 @@ pub fn collectFormulaJobs(
         }
     }
 
-    // Add deps as jobs — serial post-processing (parse + dedup + append)
-    // using the JSONs we fetched above.
+    // Serial post-processing: cache hits on the warm path, parses-then-
+    // caches on miss so findFailedDep later sees a hit.
     for (deps, 0..) |dep, i| {
         if (dep.already_installed) continue;
         const dep_json = dep_jsons[i] orelse continue;
@@ -427,8 +422,8 @@ pub fn collectFormulaJobs(
         var dep_json_consumed = false;
         defer if (!dep_json_consumed) allocator.free(dep_json);
 
-        var dep_formula = formula_mod.parseFormula(parse_alloc, dep_json) catch continue;
-        const dep_bottle = formula_mod.resolveBottle(parse_alloc, &dep_formula) catch continue;
+        const dep_formula = cache.getOrParse(dep.name, dep_json) catch continue;
+        const dep_bottle = formula_mod.resolveBottle(allocator, dep_formula) catch continue;
 
         // Check for duplicate (another top-level pkg may share a dep)
         var is_dup = false;
@@ -440,9 +435,8 @@ pub fn collectFormulaJobs(
         }
         if (is_dup) continue;
 
-        // Dupe the five borrowed slices out of the parsed tree into
-        // the caller allocator so parse_arena can release the tree.
-        const strs = dupeJobStrings(allocator, &dep_formula, dep_bottle) catch continue;
+        // Dupe the five slices so the job stays self-contained.
+        const strs = dupeJobStrings(allocator, dep_formula, dep_bottle) catch continue;
 
         jobs.append(allocator, .{
             .name = strs.name,
@@ -470,12 +464,12 @@ pub fn collectFormulaJobs(
     }
 
     // Add main formula
-    const bottle = formula_mod.resolveBottle(parse_alloc, &formula) catch {
+    const bottle = formula_mod.resolveBottle(allocator, formula) catch {
         output.err("No bottle available for {s} on this platform", .{formula.name});
         return InstallError.NoBottle;
     };
 
-    const main_strs = dupeJobStrings(allocator, &formula, bottle) catch return InstallError.DownloadFailed;
+    const main_strs = dupeJobStrings(allocator, formula, bottle) catch return InstallError.DownloadFailed;
     errdefer main_strs.freeAll(allocator);
 
     jobs.append(allocator, .{
@@ -522,30 +516,24 @@ pub fn dropTopLevelJobs(allocator: std.mem.Allocator, jobs: *std.ArrayList(Downl
     }
 }
 
-/// Return the first dep name of `formula_json` that appears in `failed_kegs`,
-/// or null if none did. Used to short-circuit jobs whose dependency graph is
-/// already broken so we do not leave half-installed kegs behind.
-///
-/// Errors during parse are treated as "no known failed dep" — we would rather
-/// attempt the install and let materialize surface the real problem than
-/// silently skip over a parser hiccup.
+/// First dep of `name` that appears in `failed_kegs`, or null. Routes
+/// through the cache so every link-phase lookup is parse-free on the
+/// warm path. Parse errors → null: attempt the install rather than
+/// silently skip on a parser hiccup.
 pub fn findFailedDep(
+    cache: *deps_mod.FormulaCache,
     failed_kegs: *std.StringHashMap(void),
+    name: []const u8,
     formula_json: []const u8,
 ) ?[]const u8 {
-    var tmp_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer tmp_arena.deinit();
-    const a = tmp_arena.allocator();
+    const formula = cache.get(name) orelse blk: {
+        break :blk cache.getOrParse(name, formula_json) catch return null;
+    };
 
-    var parsed = formula_mod.parseFormula(a, formula_json) catch return null;
-    defer parsed.deinit();
-
-    for (parsed.dependencies) |dep_name| {
+    for (formula.dependencies) |dep_name| {
         if (failed_kegs.contains(dep_name)) {
-            // The slice `dep_name` lives inside the temp arena which is about
-            // to be freed. Look up the same key inside the map's storage to
-            // return a slice with a stable lifetime (the map owns its keys
-            // indirectly via the job.name slices stored at insert time).
+            // Return the map's stable copy; cache strings outlive their
+            // entry only until cache.deinit().
             if (failed_kegs.getKey(dep_name)) |stable| return stable;
             return dep_name;
         }

--- a/src/core/deps.zig
+++ b/src/core/deps.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const sqlite = @import("../db/sqlite.zig");
 const api_mod = @import("../net/api.zig");
 const fs_compat = @import("../fs/compat.zig");
+const formula_mod = @import("formula.zig");
 
 pub const DepError = error{
     CycleDetected,
@@ -16,14 +17,85 @@ pub const ResolvedDep = struct {
     already_installed: bool,
 };
 
+/// Per-invocation parsed-formula cache: collapses the 2-3× re-parse the
+/// install pipeline used to pay per dep. All allocations land on a
+/// private arena so `deinit` is a single bulk reclaim.
+///
+/// Thread-safe via a `std.atomic.Mutex` spin-lock — short critical
+/// sections (one map op + one parse), no Io dependency, futures-proof
+/// for parallel workers folding into the cache.
+pub const FormulaCache = struct {
+    /// Owns every key dupe, the boxed `Formula`s, and parseFormula's
+    /// internal allocations. `init` is allocation-free until first use.
+    arena: std.heap.ArenaAllocator,
+    map: std.StringHashMapUnmanaged(*formula_mod.Formula),
+    /// Bumps on `getOrParse` miss; tests pin parse-once via this counter.
+    parse_count: usize,
+    mutex: std.atomic.Mutex,
+
+    pub fn init(parent: std.mem.Allocator) FormulaCache {
+        return .{
+            .arena = std.heap.ArenaAllocator.init(parent),
+            .map = .empty,
+            .parse_count = 0,
+            .mutex = .unlocked,
+        };
+    }
+
+    /// Single free site — drops the arena and every parsed tree with it.
+    pub fn deinit(self: *FormulaCache) void {
+        self.arena.deinit();
+    }
+
+    /// Caller borrows the pointer until cache deinit; never frees it.
+    pub fn get(self: *FormulaCache, name: []const u8) ?*const formula_mod.Formula {
+        self.lock();
+        defer self.mutex.unlock();
+        return self.map.get(name);
+    }
+
+    /// Live entry count — used by tests pinning the per-invocation bound.
+    pub fn entryCount(self: *FormulaCache) usize {
+        self.lock();
+        defer self.mutex.unlock();
+        return self.map.count();
+    }
+
+    /// Single seam every install-side parser routes through.
+    pub fn getOrParse(
+        self: *FormulaCache,
+        name: []const u8,
+        json: []const u8,
+    ) !*const formula_mod.Formula {
+        self.lock();
+        defer self.mutex.unlock();
+
+        if (self.map.get(name)) |existing| return existing;
+
+        const a = self.arena.allocator();
+        const owned_key = try a.dupe(u8, name);
+        const slot = try a.create(formula_mod.Formula);
+        slot.* = try formula_mod.parseFormula(a, json);
+        try self.map.put(a, owned_key, slot);
+        self.parse_count += 1;
+        return slot;
+    }
+
+    inline fn lock(self: *FormulaCache) void {
+        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
+    }
+};
+
 /// BFS resolve returning deps in topological order; skips already-installed.
 /// Caller frees each `ResolvedDep.name` and the outer slice. Every string
 /// from `getDeps` is either moved into `result`/`queue` or freed on the spot.
+/// `cache` is shared with the download pipeline so each formula parses once.
 pub fn resolve(
     allocator: std.mem.Allocator,
     root_name: []const u8,
     api: *api_mod.BrewApi,
     db: *sqlite.Database,
+    cache: *FormulaCache,
 ) ![]ResolvedDep {
     var result: std.ArrayList(ResolvedDep) = .empty;
 
@@ -39,7 +111,7 @@ pub fn resolve(
         queue.deinit(allocator);
     }
 
-    const root_deps = getDeps(allocator, root_name, api) catch {
+    const root_deps = getDeps(allocator, root_name, api, cache) catch {
         return result.toOwnedSlice(allocator) catch blk: {
             result.deinit(allocator);
             break :blk &.{};
@@ -81,7 +153,7 @@ pub fn resolve(
 
         // Fan out into this dep's own dependencies.
         if (!installed) {
-            const sub_deps = getDeps(allocator, dep_name, api) catch continue;
+            const sub_deps = getDeps(allocator, dep_name, api, cache) catch continue;
             defer allocator.free(sub_deps);
 
             for (sub_deps) |sub_dep| {
@@ -197,42 +269,136 @@ pub fn ensureOptLink(db: *sqlite.Database, prefix: []const u8, name: []const u8)
     parent_dir.symLink(cellar_path, name, .{}) catch {};
 }
 
-fn getDeps(allocator: std.mem.Allocator, name: []const u8, api: *api_mod.BrewApi) ![][]const u8 {
+/// Resolve a formula's direct deps through the shared cache. JSON without
+/// a `name` field falls through to a Value-walk so synthetic fixtures and
+/// upstream API quirks keep walking the graph (cache stays empty for that
+/// entry — a malformed Formula is no use to downstream consumers).
+fn getDeps(
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    api: *api_mod.BrewApi,
+    cache: *FormulaCache,
+) ![][]const u8 {
+    if (cache.get(name)) |formula| return dupeDepNames(allocator, formula.dependencies);
+
     const json_bytes = api.fetchFormula(name) catch return &.{};
     defer allocator.free(json_bytes);
 
+    if (cache.getOrParse(name, json_bytes)) |formula| {
+        return dupeDepNames(allocator, formula.dependencies);
+    } else |_| {
+        return getDepsFromValue(allocator, json_bytes);
+    }
+}
+
+/// Permissive dep-list extraction for JSON `parseFormula` rejects.
+/// Reads `dependencies[]` directly off the dynamic Value tree.
+fn getDepsFromValue(allocator: std.mem.Allocator, json_bytes: []const u8) ![][]const u8 {
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, json_bytes, .{}) catch return &.{};
     defer parsed.deinit();
 
-    const obj = parsed.value.object;
-    const deps_val = obj.get("dependencies") orelse return &.{};
-    const arr = switch (deps_val) {
+    const obj = switch (parsed.value) {
+        .object => |o| o,
+        else => return &.{},
+    };
+    const arr = switch (obj.get("dependencies") orelse return &.{}) {
         .array => |a| a,
         else => return &.{},
     };
 
-    var deps: std.ArrayList([]const u8) = .empty;
+    var out: std.ArrayList([]const u8) = .empty;
     for (arr.items) |item| {
-        switch (item) {
-            .string => |s| {
-                const owned = allocator.dupe(u8, s) catch continue;
-                // Free the duped bytes if appending to the list fails —
-                // otherwise they leak silently.
-                deps.append(allocator, owned) catch {
-                    allocator.free(owned);
-                    continue;
-                };
-            },
-            else => {},
-        }
+        const s = switch (item) {
+            .string => |str| str,
+            else => continue,
+        };
+        const owned = allocator.dupe(u8, s) catch continue;
+        out.append(allocator, owned) catch {
+            allocator.free(owned);
+            continue;
+        };
     }
-
-    return deps.toOwnedSlice(allocator) catch blk: {
-        // toOwnedSlice can fail on shrink-realloc; in that case every
-        // duped string is still owned by `deps`. Free them before
-        // returning an empty slice so callers see a clean state.
-        for (deps.items) |d| allocator.free(d);
-        deps.deinit(allocator);
+    return out.toOwnedSlice(allocator) catch blk: {
+        for (out.items) |d| allocator.free(d);
+        out.deinit(allocator);
         break :blk &.{};
     };
+}
+
+/// Dupe every dep name onto the BFS allocator — `resolve` owns the strings.
+fn dupeDepNames(allocator: std.mem.Allocator, deps: []const []const u8) ![][]const u8 {
+    var out: std.ArrayList([]const u8) = .empty;
+    for (deps) |d| {
+        const owned = allocator.dupe(u8, d) catch continue;
+        out.append(allocator, owned) catch {
+            allocator.free(owned);
+            continue;
+        };
+    }
+    return out.toOwnedSlice(allocator) catch blk: {
+        for (out.items) |d| allocator.free(d);
+        out.deinit(allocator);
+        break :blk &.{};
+    };
+}
+
+// --- FormulaCache unit tests (no DB / no network) -------------------------
+
+const testing = std.testing;
+
+/// Minimal formula fixture for the cache wrapper tests.
+fn testFormulaJson(comptime name: []const u8) []const u8 {
+    return "{\"name\":\"" ++ name ++ "\"," ++
+        "\"versions\":{\"stable\":\"1.0\"}," ++
+        "\"dependencies\":[],\"oldnames\":[]}";
+}
+
+test "FormulaCache.getOrParse increments parse_count only on miss" {
+    var cache = FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+
+    _ = try cache.getOrParse("hello", testFormulaJson("hello"));
+    try testing.expectEqual(@as(usize, 1), cache.parse_count);
+
+    // Repeat name must hit the cache.
+    _ = try cache.getOrParse("hello", testFormulaJson("hello"));
+    try testing.expectEqual(@as(usize, 1), cache.parse_count);
+
+    // Distinct name re-bumps; cache is keyed per formula.
+    _ = try cache.getOrParse("world", testFormulaJson("world"));
+    try testing.expectEqual(@as(usize, 2), cache.parse_count);
+}
+
+test "FormulaCache.get returns null on miss and the cached pointer on hit" {
+    var cache = FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+
+    try testing.expect(cache.get("nope") == null);
+
+    _ = try cache.getOrParse("alpha", testFormulaJson("alpha"));
+
+    const hit = cache.get("alpha") orelse return error.TestExpectedHit;
+    try testing.expectEqualStrings("alpha", hit.name);
+}
+
+test "FormulaCache.deinit releases the arena and every parsed tree" {
+    // testing.allocator surfaces any unfreed byte; arena.deinit must
+    // sweep every parseFormula side allocation in one shot.
+    var cache = FormulaCache.init(testing.allocator);
+    _ = try cache.getOrParse("a", testFormulaJson("a"));
+    _ = try cache.getOrParse("b", testFormulaJson("b"));
+    cache.deinit();
+}
+
+test "FormulaCache.entryCount tracks the live entry count" {
+    var cache = FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+
+    try testing.expectEqual(@as(usize, 0), cache.entryCount());
+    _ = try cache.getOrParse("a", testFormulaJson("a"));
+    try testing.expectEqual(@as(usize, 1), cache.entryCount());
+    _ = try cache.getOrParse("a", testFormulaJson("a"));
+    try testing.expectEqual(@as(usize, 1), cache.entryCount());
+    _ = try cache.getOrParse("b", testFormulaJson("b"));
+    try testing.expectEqual(@as(usize, 2), cache.entryCount());
 }

--- a/tests/deps_leak_test.zig
+++ b/tests/deps_leak_test.zig
@@ -99,10 +99,10 @@ test "resolve frees duped dep strings on the BFS visited-dedup path" {
     var dir = try TempCacheDir.init("dedup");
     defer dir.deinit();
 
-    try dir.writeFormula("a", "{\"dependencies\":[\"b\",\"c\"]}");
-    try dir.writeFormula("b", "{\"dependencies\":[\"d\"]}");
-    try dir.writeFormula("c", "{\"dependencies\":[\"d\"]}");
-    try dir.writeFormula("d", "{\"dependencies\":[\"b\"]}");
+    try dir.writeFormula("a", "{\"name\":\"a\",\"dependencies\":[\"b\",\"c\"]}");
+    try dir.writeFormula("b", "{\"name\":\"b\",\"dependencies\":[\"d\"]}");
+    try dir.writeFormula("c", "{\"name\":\"c\",\"dependencies\":[\"d\"]}");
+    try dir.writeFormula("d", "{\"name\":\"d\",\"dependencies\":[\"b\"]}");
 
     var http = client_mod.HttpClient.init(alloc);
     defer http.deinit();
@@ -111,7 +111,10 @@ test "resolve frees duped dep strings on the BFS visited-dedup path" {
     var tdb = try TempDb.init("dedup");
     defer tdb.deinit();
 
-    const result = try deps_mod.resolve(alloc, "a", &api, &tdb.db);
+    var cache = deps_mod.FormulaCache.init(alloc);
+    defer cache.deinit();
+
+    const result = try deps_mod.resolve(alloc, "a", &api, &tdb.db, &cache);
     defer freeResolved(alloc, result);
 
     // Each distinct dep appears exactly once.
@@ -138,7 +141,7 @@ test "resolve empty dep graph still returns a freeable slice" {
     var dir = try TempCacheDir.init("empty");
     defer dir.deinit();
 
-    try dir.writeFormula("solo", "{\"dependencies\":[]}");
+    try dir.writeFormula("solo", "{\"name\":\"solo\",\"dependencies\":[]}");
 
     var http = client_mod.HttpClient.init(alloc);
     defer http.deinit();
@@ -147,7 +150,10 @@ test "resolve empty dep graph still returns a freeable slice" {
     var tdb = try TempDb.init("empty");
     defer tdb.deinit();
 
-    const result = try deps_mod.resolve(alloc, "solo", &api, &tdb.db);
+    var cache = deps_mod.FormulaCache.init(alloc);
+    defer cache.deinit();
+
+    const result = try deps_mod.resolve(alloc, "solo", &api, &tdb.db, &cache);
     defer freeResolved(alloc, result);
 
     try testing.expectEqual(@as(usize, 0), result.len);

--- a/tests/deps_test.zig
+++ b/tests/deps_test.zig
@@ -247,9 +247,9 @@ test "resolve walks a small BFS dep graph and dedups via visited" {
     // alpha → [beta, gamma]
     // beta  → []
     // gamma → [beta]   (tests BFS visited dedup)
-    try dir.writeFormula("alpha", "{\"dependencies\":[\"beta\",\"gamma\"]}");
-    try dir.writeFormula("beta", "{\"dependencies\":[]}");
-    try dir.writeFormula("gamma", "{\"dependencies\":[\"beta\"]}");
+    try dir.writeFormula("alpha", "{\"name\":\"alpha\",\"dependencies\":[\"beta\",\"gamma\"]}");
+    try dir.writeFormula("beta", "{\"name\":\"beta\",\"dependencies\":[]}");
+    try dir.writeFormula("gamma", "{\"name\":\"gamma\",\"dependencies\":[\"beta\"]}");
 
     var http = client_mod.HttpClient.init(alloc);
     defer http.deinit();
@@ -258,7 +258,10 @@ test "resolve walks a small BFS dep graph and dedups via visited" {
     var tdb = try TempDb.init("resolve_bfs");
     defer tdb.deinit();
 
-    const result = try deps_mod.resolve(alloc, "alpha", &api, &tdb.db);
+    var cache = deps_mod.FormulaCache.init(alloc);
+    defer cache.deinit();
+
+    const result = try deps_mod.resolve(alloc, "alpha", &api, &tdb.db, &cache);
     defer freeResolved(alloc, result);
 
     // Expect both beta and gamma to appear, in BFS order.
@@ -277,9 +280,9 @@ test "resolve marks already-installed kegs and skips their sub-deps" {
 
     // alpha → [beta], beta → [gamma]. beta is already installed → we should
     // NOT recurse into gamma.
-    try dir.writeFormula("alpha", "{\"dependencies\":[\"beta\"]}");
-    try dir.writeFormula("beta", "{\"dependencies\":[\"gamma\"]}");
-    try dir.writeFormula("gamma", "{\"dependencies\":[]}");
+    try dir.writeFormula("alpha", "{\"name\":\"alpha\",\"dependencies\":[\"beta\"]}");
+    try dir.writeFormula("beta", "{\"name\":\"beta\",\"dependencies\":[\"gamma\"]}");
+    try dir.writeFormula("gamma", "{\"name\":\"gamma\",\"dependencies\":[]}");
 
     var http = client_mod.HttpClient.init(alloc);
     defer http.deinit();
@@ -289,7 +292,10 @@ test "resolve marks already-installed kegs and skips their sub-deps" {
     defer tdb.deinit();
     _ = try insertKeg(&tdb.db, "beta", "dependency");
 
-    const result = try deps_mod.resolve(alloc, "alpha", &api, &tdb.db);
+    var cache = deps_mod.FormulaCache.init(alloc);
+    defer cache.deinit();
+
+    const result = try deps_mod.resolve(alloc, "alpha", &api, &tdb.db, &cache);
     defer freeResolved(alloc, result);
 
     try testing.expectEqual(@as(usize, 1), result.len);
@@ -322,7 +328,10 @@ test "resolve returns empty when root formula JSON is missing from cache" {
 
     // resolve's getDeps catches errors and returns &.{}, so resolve returns
     // an empty list (no deps to walk).
-    const result = try deps_mod.resolve(alloc, "nope", &api, &tdb.db);
+    var cache = deps_mod.FormulaCache.init(alloc);
+    defer cache.deinit();
+
+    const result = try deps_mod.resolve(alloc, "nope", &api, &tdb.db, &cache);
     defer freeResolved(alloc, result);
     try testing.expectEqual(@as(usize, 0), result.len);
 }
@@ -336,7 +345,7 @@ test "resolve handles a dep whose sub-fetch fails by falling through" {
     // alpha → [missing]. missing has no cache file AND we mark it 404 so the
     // sub-getDeps fails. The BFS loop should still append `missing` as a
     // dep before trying to recurse.
-    try dir.writeFormula("alpha", "{\"dependencies\":[\"missing\"]}");
+    try dir.writeFormula("alpha", "{\"name\":\"alpha\",\"dependencies\":[\"missing\"]}");
     var marker_buf: [512]u8 = undefined;
     const marker = try std.fmt.bufPrint(&marker_buf, "{s}/api/formula_missing.404", .{dir.path});
     const f = try malt.fs_compat.cwd().createFile(marker, .{});
@@ -349,7 +358,10 @@ test "resolve handles a dep whose sub-fetch fails by falling through" {
     var tdb = try TempDb.init("resolve_dep_missing");
     defer tdb.deinit();
 
-    const result = try deps_mod.resolve(alloc, "alpha", &api, &tdb.db);
+    var cache = deps_mod.FormulaCache.init(alloc);
+    defer cache.deinit();
+
+    const result = try deps_mod.resolve(alloc, "alpha", &api, &tdb.db, &cache);
     defer freeResolved(alloc, result);
 
     try testing.expectEqual(@as(usize, 1), result.len);
@@ -368,8 +380,8 @@ test "resolve treats a DB keg with a vanished cellar_path as not-installed" {
     var dir = try TempCacheDir.init("resolve_missing_cellar");
     defer dir.deinit();
 
-    try dir.writeFormula("alpha", "{\"dependencies\":[\"beta\"]}");
-    try dir.writeFormula("beta", "{\"dependencies\":[]}");
+    try dir.writeFormula("alpha", "{\"name\":\"alpha\",\"dependencies\":[\"beta\"]}");
+    try dir.writeFormula("beta", "{\"name\":\"beta\",\"dependencies\":[]}");
 
     var http = client_mod.HttpClient.init(alloc);
     defer http.deinit();
@@ -380,7 +392,10 @@ test "resolve treats a DB keg with a vanished cellar_path as not-installed" {
     // Point beta's cellar_path at a directory that definitely doesn't exist.
     _ = try insertKegWithCellar(&tdb.db, "beta", "dependency", "/tmp/malt_missing_xyz_9273");
 
-    const result = try deps_mod.resolve(alloc, "alpha", &api, &tdb.db);
+    var cache = deps_mod.FormulaCache.init(alloc);
+    defer cache.deinit();
+
+    const result = try deps_mod.resolve(alloc, "alpha", &api, &tdb.db, &cache);
     defer freeResolved(alloc, result);
 
     try testing.expectEqual(@as(usize, 1), result.len);

--- a/tests/install_parse_cache_test.zig
+++ b/tests/install_parse_cache_test.zig
@@ -1,0 +1,446 @@
+//! malt — per-invocation parsed-formula cache tests.
+//!
+//! Pins the contract that during a single install run, every dependency's
+//! formula JSON is parsed exactly once. A 6-formula synthetic graph (1
+//! root + 5 deps) drives the full BFS + parallel-fetch + post-process
+//! path through `collectFormulaJobs`; the shared cache's `parse_count`
+//! must end at 6 — one parse per unique name — so the warm-install hot
+//! path no longer pays the 2-3× re-parse it used to.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const install = malt.install;
+const deps_mod = malt.deps;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+
+const TempDb = struct {
+    dir: []const u8,
+    db: sqlite.Database,
+
+    fn init(comptime tag: []const u8) !TempDb {
+        const dir = "/tmp/malt_parse_cache_test_" ++ tag;
+        malt.fs_compat.makeDirAbsolute(dir) catch {};
+        var db_path_buf: [256]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/test.db", .{dir}, 0);
+        var db = try sqlite.Database.open(db_path);
+        errdefer db.close();
+        try schema.initSchema(&db);
+        return .{ .dir = dir, .db = db };
+    }
+
+    fn deinit(self: *TempDb) void {
+        self.db.close();
+        malt.fs_compat.deleteTreeAbsolute(self.dir) catch {};
+    }
+};
+
+fn seedCache(cache_dir: []const u8, name: []const u8, json: []const u8) !void {
+    var api_buf: [512]u8 = undefined;
+    const api_dir = try std.fmt.bufPrint(&api_buf, "{s}/api", .{cache_dir});
+    malt.fs_compat.makeDirAbsolute(api_dir) catch |e| switch (e) {
+        error.PathAlreadyExists => {},
+        else => return e,
+    };
+    var path_buf: [512]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}/api/formula_{s}.json", .{ cache_dir, name });
+    const f = try malt.fs_compat.cwd().createFile(path, .{});
+    defer f.close();
+    try f.writeAll(json);
+}
+
+/// Unique sha per dep so the dedup branch can't collapse jobs.
+fn bottleJsonUniqueSha(comptime name: []const u8, comptime tag: []const u8) []const u8 {
+    return "{\"name\":\"" ++ name ++ "\"," ++
+        "\"full_name\":\"" ++ name ++ "\"," ++
+        "\"tap\":\"homebrew/core\"," ++
+        "\"desc\":\"\",\"homepage\":\"\",\"revision\":0," ++
+        "\"keg_only\":false,\"post_install_defined\":false," ++
+        "\"versions\":{\"stable\":\"1.0\"}," ++
+        "\"dependencies\":[],\"oldnames\":[]," ++
+        "\"bottle\":{\"stable\":{\"root_url\":\"https://ghcr.io/v2/homebrew/core/" ++ name ++ "/blobs\"," ++
+        "\"files\":{" ++
+        "\"arm64_sequoia\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-arm\",\"sha256\":\"" ++ tag ++ "a\"}," ++
+        "\"arm64_sonoma\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-arm\",\"sha256\":\"" ++ tag ++ "a\"}," ++
+        "\"arm64_ventura\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-arm\",\"sha256\":\"" ++ tag ++ "a\"}," ++
+        "\"arm64_monterey\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-arm\",\"sha256\":\"" ++ tag ++ "a\"}," ++
+        "\"sequoia\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-x86\",\"sha256\":\"" ++ tag ++ "x\"}," ++
+        "\"sonoma\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-x86\",\"sha256\":\"" ++ tag ++ "x\"}," ++
+        "\"ventura\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-x86\",\"sha256\":\"" ++ tag ++ "x\"}," ++
+        "\"monterey\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/" ++ name ++ "-x86\",\"sha256\":\"" ++ tag ++ "x\"}" ++
+        "}}}}";
+}
+
+fn rootJsonWithFiveDeps() []const u8 {
+    return "{\"name\":\"root\"," ++
+        "\"full_name\":\"root\"," ++
+        "\"tap\":\"homebrew/core\"," ++
+        "\"desc\":\"\",\"homepage\":\"\",\"revision\":0," ++
+        "\"keg_only\":false,\"post_install_defined\":false," ++
+        "\"versions\":{\"stable\":\"1.0\"}," ++
+        "\"dependencies\":[\"d_a\",\"d_b\",\"d_c\",\"d_d\",\"d_e\"]," ++
+        "\"oldnames\":[]," ++
+        "\"bottle\":{\"stable\":{\"root_url\":\"https://ghcr.io/v2/homebrew/core/root/blobs\"," ++
+        "\"files\":{" ++
+        "\"arm64_sequoia\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-arm\",\"sha256\":\"r0\"}," ++
+        "\"arm64_sonoma\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-arm\",\"sha256\":\"r0\"}," ++
+        "\"arm64_ventura\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-arm\",\"sha256\":\"r0\"}," ++
+        "\"arm64_monterey\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-arm\",\"sha256\":\"r0\"}," ++
+        "\"sequoia\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-x86\",\"sha256\":\"r1\"}," ++
+        "\"sonoma\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-x86\",\"sha256\":\"r1\"}," ++
+        "\"ventura\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-x86\",\"sha256\":\"r1\"}," ++
+        "\"monterey\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/root-x86\",\"sha256\":\"r1\"}" ++
+        "}}}}";
+}
+
+test "collectFormulaJobs parses each formula exactly once via shared cache" {
+    const alloc = testing.allocator;
+
+    var tdb = try TempDb.init("six_dep_cache");
+    defer tdb.deinit();
+
+    const cache_dir = "/tmp/malt_parse_cache_test_six_dep_cache_apicache";
+    malt.fs_compat.deleteTreeAbsolute(cache_dir) catch {};
+    malt.fs_compat.makeDirAbsolute(cache_dir) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(cache_dir) catch {};
+
+    const root_json = rootJsonWithFiveDeps();
+    try seedCache(cache_dir, "root", root_json);
+    try seedCache(cache_dir, "d_a", bottleJsonUniqueSha("d_a", "aa"));
+    try seedCache(cache_dir, "d_b", bottleJsonUniqueSha("d_b", "bb"));
+    try seedCache(cache_dir, "d_c", bottleJsonUniqueSha("d_c", "cc"));
+    try seedCache(cache_dir, "d_d", bottleJsonUniqueSha("d_d", "dd"));
+    try seedCache(cache_dir, "d_e", bottleJsonUniqueSha("d_e", "ee"));
+
+    var http_pool = try malt.client.HttpClientPool.init(alloc, 2);
+    defer http_pool.deinit();
+    var real_http = malt.client.HttpClient.init(alloc);
+    defer real_http.deinit();
+    var api = malt.api.BrewApi.init(alloc, &real_http, cache_dir);
+
+    var store_inst: malt.store.Store = undefined;
+    var jobs: std.ArrayList(install.DownloadJob) = .empty;
+    defer {
+        for (jobs.items) |job| {
+            alloc.free(job.name);
+            alloc.free(job.version_str);
+            alloc.free(job.sha256);
+            alloc.free(job.bottle_url);
+            alloc.free(job.cellar_type);
+            if (job.is_dep) alloc.free(job.formula_json);
+        }
+        jobs.deinit(alloc);
+    }
+
+    var formula_cache = deps_mod.FormulaCache.init(alloc);
+    defer formula_cache.deinit();
+
+    try install.collectFormulaJobs(
+        .{
+            .allocator = alloc,
+            .api = &api,
+            .http_pool = &http_pool,
+            .db = &tdb.db,
+            .store = &store_inst,
+            .cache = &formula_cache,
+        },
+        "root",
+        root_json,
+        false,
+        &jobs,
+    );
+
+    // 1 root + 5 deps, all queued (shas unique → no dedup).
+    try testing.expectEqual(@as(usize, 6), jobs.items.len);
+
+    // Parse-once invariant: BFS, post-process, and findFailedDep all hit cache.
+    try testing.expectEqual(@as(usize, 6), formula_cache.parse_count);
+}
+
+test "FormulaCache.init/deinit makes no allocations on the empty path" {
+    // Cask / local / tap installs never touch `collectFormulaJobs`; the
+    // cache is created at the top of `execute` regardless. Pin the
+    // contract that the unused path costs zero allocator round-trips.
+    var cache = deps_mod.FormulaCache.init(std.testing.failing_allocator);
+    cache.deinit();
+}
+
+test "FormulaCache holds at most one entry per unique dep across the run" {
+    // Memory-bound regression guard: the cache must hold exactly one
+    // typed Formula per unique name, not duplicate copies on warm
+    // re-fetches. A 6-dep graph caps at 6 entries, full stop.
+    const alloc = testing.allocator;
+
+    var tdb = try TempDb.init("bound");
+    defer tdb.deinit();
+
+    const cache_dir = "/tmp/malt_parse_cache_test_bound_apicache";
+    malt.fs_compat.deleteTreeAbsolute(cache_dir) catch {};
+    malt.fs_compat.makeDirAbsolute(cache_dir) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(cache_dir) catch {};
+
+    const root_json = rootJsonWithFiveDeps();
+    try seedCache(cache_dir, "root", root_json);
+    try seedCache(cache_dir, "d_a", bottleJsonUniqueSha("d_a", "aa"));
+    try seedCache(cache_dir, "d_b", bottleJsonUniqueSha("d_b", "bb"));
+    try seedCache(cache_dir, "d_c", bottleJsonUniqueSha("d_c", "cc"));
+    try seedCache(cache_dir, "d_d", bottleJsonUniqueSha("d_d", "dd"));
+    try seedCache(cache_dir, "d_e", bottleJsonUniqueSha("d_e", "ee"));
+
+    var http_pool = try malt.client.HttpClientPool.init(alloc, 2);
+    defer http_pool.deinit();
+    var real_http = malt.client.HttpClient.init(alloc);
+    defer real_http.deinit();
+    var api = malt.api.BrewApi.init(alloc, &real_http, cache_dir);
+
+    var store_inst: malt.store.Store = undefined;
+    var jobs: std.ArrayList(install.DownloadJob) = .empty;
+    defer {
+        for (jobs.items) |job| {
+            alloc.free(job.name);
+            alloc.free(job.version_str);
+            alloc.free(job.sha256);
+            alloc.free(job.bottle_url);
+            alloc.free(job.cellar_type);
+            if (job.is_dep) alloc.free(job.formula_json);
+        }
+        jobs.deinit(alloc);
+    }
+
+    var formula_cache = deps_mod.FormulaCache.init(alloc);
+    defer formula_cache.deinit();
+
+    try install.collectFormulaJobs(
+        .{
+            .allocator = alloc,
+            .api = &api,
+            .http_pool = &http_pool,
+            .db = &tdb.db,
+            .store = &store_inst,
+            .cache = &formula_cache,
+        },
+        "root",
+        root_json,
+        false,
+        &jobs,
+    );
+
+    try testing.expectEqual(@as(usize, 6), formula_cache.entryCount());
+}
+
+test "resolve walks deps for JSON missing the name field" {
+    // Tolerance regression guard: `parseFormula` requires a `name` field,
+    // but the BFS must still walk minimal `{"dependencies":[...]}` JSON
+    // so synthetic fixtures and any upstream API quirk keep resolving.
+    const alloc = testing.allocator;
+
+    const cache_dir = "/tmp/malt_parse_cache_test_no_name_apicache";
+    malt.fs_compat.deleteTreeAbsolute(cache_dir) catch {};
+    malt.fs_compat.makeDirAbsolute(cache_dir) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(cache_dir) catch {};
+
+    var api_buf: [512]u8 = undefined;
+    const api_dir = try std.fmt.bufPrint(&api_buf, "{s}/api", .{cache_dir});
+    try malt.fs_compat.makeDirAbsolute(api_dir);
+
+    // Minimal JSON — no `name` field. The cache cannot type-parse this,
+    // but BFS still needs the dep list.
+    const root_json = "{\"dependencies\":[\"leaf_one\",\"leaf_two\"]}";
+    var root_buf: [512]u8 = undefined;
+    const root_path = try std.fmt.bufPrint(&root_buf, "{s}/api/formula_thin.json", .{cache_dir});
+    {
+        const f = try malt.fs_compat.cwd().createFile(root_path, .{});
+        defer f.close();
+        try f.writeAll(root_json);
+    }
+
+    inline for (.{ "leaf_one", "leaf_two" }) |leaf| {
+        var leaf_buf: [512]u8 = undefined;
+        const leaf_path = try std.fmt.bufPrint(&leaf_buf, "{s}/api/formula_{s}.json", .{ cache_dir, leaf });
+        const f = try malt.fs_compat.cwd().createFile(leaf_path, .{});
+        defer f.close();
+        try f.writeAll("{\"dependencies\":[]}");
+    }
+
+    var http = malt.client.HttpClient.init(alloc);
+    defer http.deinit();
+    var api = malt.api.BrewApi.init(alloc, &http, cache_dir);
+
+    var tdb = try TempDb.init("no_name");
+    defer tdb.deinit();
+
+    var formula_cache = deps_mod.FormulaCache.init(alloc);
+    defer formula_cache.deinit();
+
+    const result = try deps_mod.resolve(alloc, "thin", &api, &tdb.db, &formula_cache);
+    defer {
+        for (result) |d| alloc.free(d.name);
+        if (result.len > 0) alloc.free(result);
+    }
+
+    try testing.expectEqual(@as(usize, 2), result.len);
+    // The fallback path does not pollute the cache — only typed parses
+    // get a slot. parse_count stays at 0 for malformed root JSON.
+    try testing.expectEqual(@as(usize, 0), formula_cache.parse_count);
+}
+
+test "FormulaCache.getOrParse is safe under concurrent callers" {
+    // Concurrency guard: workers may someday call into the cache (e.g.
+    // future parallel-fetch fold). With the mutex, every duplicate-name
+    // miss collapses to a single parse no matter how many threads race.
+    const alloc = testing.allocator;
+    var cache = deps_mod.FormulaCache.init(alloc);
+    defer cache.deinit();
+
+    const json = "{\"name\":\"hot\"," ++
+        "\"versions\":{\"stable\":\"1.0\"}," ++
+        "\"dependencies\":[],\"oldnames\":[]}";
+
+    const Worker = struct {
+        fn run(c: *deps_mod.FormulaCache, j: []const u8) void {
+            var i: usize = 0;
+            while (i < 64) : (i += 1) {
+                _ = c.getOrParse("hot", j) catch return;
+            }
+        }
+    };
+
+    var threads: [4]std.Thread = undefined;
+    for (&threads) |*t| t.* = try std.Thread.spawn(.{}, Worker.run, .{ &cache, json });
+    for (threads) |t| t.join();
+
+    try testing.expectEqual(@as(usize, 1), cache.parse_count);
+    try testing.expectEqual(@as(usize, 1), cache.entryCount());
+}
+
+test "shared deps across multi-package install collapse to one parse" {
+    // `mt install wget ffmpeg` runs collectFormulaJobs twice with the
+    // same cache. Any dep both pull (e.g. openssl@3) must parse exactly
+    // once across the whole run — the cross-call dedup is the second
+    // half of the per-invocation parse-once guarantee.
+    const alloc = testing.allocator;
+
+    var tdb = try TempDb.init("multi_pkg");
+    defer tdb.deinit();
+
+    const cache_dir = "/tmp/malt_parse_cache_test_multi_pkg_apicache";
+    malt.fs_compat.deleteTreeAbsolute(cache_dir) catch {};
+    malt.fs_compat.makeDirAbsolute(cache_dir) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(cache_dir) catch {};
+
+    // Two roots ("alpha", "omega") that share one dep ("shared_lib").
+    const alpha_json = "{\"name\":\"alpha\"," ++
+        "\"versions\":{\"stable\":\"1.0\"}," ++
+        "\"dependencies\":[\"shared_lib\"]," ++
+        "\"oldnames\":[]," ++
+        "\"bottle\":{\"stable\":{\"root_url\":\"https://ghcr.io/v2/homebrew/core/alpha/blobs\",\"files\":{" ++
+        "\"arm64_sequoia\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/alpha-arm\",\"sha256\":\"a0\"}," ++
+        "\"arm64_sonoma\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/alpha-arm\",\"sha256\":\"a0\"}," ++
+        "\"arm64_ventura\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/alpha-arm\",\"sha256\":\"a0\"}," ++
+        "\"arm64_monterey\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/alpha-arm\",\"sha256\":\"a0\"}," ++
+        "\"sequoia\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/alpha-x86\",\"sha256\":\"a1\"}," ++
+        "\"sonoma\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/alpha-x86\",\"sha256\":\"a1\"}," ++
+        "\"ventura\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/alpha-x86\",\"sha256\":\"a1\"}," ++
+        "\"monterey\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/alpha-x86\",\"sha256\":\"a1\"}" ++
+        "}}}}";
+    const omega_json = "{\"name\":\"omega\"," ++
+        "\"versions\":{\"stable\":\"1.0\"}," ++
+        "\"dependencies\":[\"shared_lib\"]," ++
+        "\"oldnames\":[]," ++
+        "\"bottle\":{\"stable\":{\"root_url\":\"https://ghcr.io/v2/homebrew/core/omega/blobs\",\"files\":{" ++
+        "\"arm64_sequoia\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/omega-arm\",\"sha256\":\"o0\"}," ++
+        "\"arm64_sonoma\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/omega-arm\",\"sha256\":\"o0\"}," ++
+        "\"arm64_ventura\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/omega-arm\",\"sha256\":\"o0\"}," ++
+        "\"arm64_monterey\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/omega-arm\",\"sha256\":\"o0\"}," ++
+        "\"sequoia\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/omega-x86\",\"sha256\":\"o1\"}," ++
+        "\"sonoma\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/omega-x86\",\"sha256\":\"o1\"}," ++
+        "\"ventura\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/omega-x86\",\"sha256\":\"o1\"}," ++
+        "\"monterey\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/omega-x86\",\"sha256\":\"o1\"}" ++
+        "}}}}";
+    try seedCache(cache_dir, "alpha", alpha_json);
+    try seedCache(cache_dir, "omega", omega_json);
+    try seedCache(cache_dir, "shared_lib", bottleJsonUniqueSha("shared_lib", "ss"));
+
+    var http_pool = try malt.client.HttpClientPool.init(alloc, 2);
+    defer http_pool.deinit();
+    var real_http = malt.client.HttpClient.init(alloc);
+    defer real_http.deinit();
+    var api = malt.api.BrewApi.init(alloc, &real_http, cache_dir);
+
+    var store_inst: malt.store.Store = undefined;
+    var jobs: std.ArrayList(install.DownloadJob) = .empty;
+    defer {
+        for (jobs.items) |job| {
+            alloc.free(job.name);
+            alloc.free(job.version_str);
+            alloc.free(job.sha256);
+            alloc.free(job.bottle_url);
+            alloc.free(job.cellar_type);
+            if (job.is_dep) alloc.free(job.formula_json);
+        }
+        jobs.deinit(alloc);
+    }
+
+    var formula_cache = deps_mod.FormulaCache.init(alloc);
+    defer formula_cache.deinit();
+
+    const ctx: install.InstallJobDeps = .{
+        .allocator = alloc,
+        .api = &api,
+        .http_pool = &http_pool,
+        .db = &tdb.db,
+        .store = &store_inst,
+        .cache = &formula_cache,
+    };
+
+    try install.collectFormulaJobs(ctx, "alpha", alpha_json, false, &jobs);
+    try install.collectFormulaJobs(ctx, "omega", omega_json, false, &jobs);
+
+    // 3 unique formulas (alpha, omega, shared_lib); shared_lib parses once.
+    try testing.expectEqual(@as(usize, 3), formula_cache.parse_count);
+    try testing.expectEqual(@as(usize, 3), formula_cache.entryCount());
+    // shared_lib appears in jobs exactly once (sha-based dedup in collectFormulaJobs).
+    var shared_count: usize = 0;
+    for (jobs.items) |j| {
+        if (std.mem.eql(u8, j.name, "shared_lib")) shared_count += 1;
+    }
+    try testing.expectEqual(@as(usize, 1), shared_count);
+}
+
+test "findFailedDep reads from cache without re-parsing the JSON" {
+    const alloc = testing.allocator;
+
+    var cache = deps_mod.FormulaCache.init(alloc);
+    defer cache.deinit();
+
+    const json =
+        \\{
+        \\  "name": "curl",
+        \\  "full_name": "curl",
+        \\  "tap": "",
+        \\  "desc": "",
+        \\  "homepage": "",
+        \\  "revision": 0,
+        \\  "keg_only": false,
+        \\  "post_install_defined": false,
+        \\  "versions": { "stable": "1.0" },
+        \\  "dependencies": ["libssh2", "openssl@3", "zstd"],
+        \\  "oldnames": []
+        \\}
+    ;
+
+    _ = try cache.getOrParse("curl", json);
+    try testing.expectEqual(@as(usize, 1), cache.parse_count);
+
+    var failed = std.StringHashMap(void).init(alloc);
+    defer failed.deinit();
+    try failed.put("openssl@3", {});
+
+    const result = install.findFailedDep(&cache, &failed, "curl", json) orelse
+        return error.TestExpectedFailedDep;
+    try testing.expectEqualStrings("openssl@3", result);
+
+    // Lookup hit the cache; no second parse.
+    try testing.expectEqual(@as(usize, 1), cache.parse_count);
+}

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -241,7 +241,9 @@ test "findFailedDep flags the first dep name that appears in failed_kegs" {
     const json =
         \\{"name":"bar","full_name":"bar","versions":{"stable":"1.0"},"bottle":{"stable":{"files":{}}},"dependencies":["libfoo","other"]}
     ;
-    const name = install.findFailedDep(&failed, json);
+    var cache = @import("malt").deps.FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+    const name = install.findFailedDep(&cache, &failed, "bar", json);
     try testing.expect(name != null);
     try testing.expectEqualStrings("libfoo", name.?);
 }
@@ -440,7 +442,9 @@ test "findFailedDep returns null when no dep is in the failed set" {
     const json =
         \\{"name":"bar","full_name":"bar","versions":{"stable":"1.0"},"bottle":{"stable":{"files":{}}},"dependencies":["libfoo"]}
     ;
-    try testing.expect(install.findFailedDep(&failed, json) == null);
+    var cache = @import("malt").deps.FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+    try testing.expect(install.findFailedDep(&cache, &failed, "bar", json) == null);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -97,8 +97,11 @@ test "collectFormulaJobs queues a formula with a post_install hook" {
     var jobs: std.ArrayList(install.DownloadJob) = .empty;
     defer jobs.deinit(alloc);
 
+    var cache = malt.deps.FormulaCache.init(alloc);
+    defer cache.deinit();
+
     try install.collectFormulaJobs(
-        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst },
+        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache },
         "needs-ruby",
         json,
         false,
@@ -243,7 +246,9 @@ test "findFailedDep reports the first dep already known-broken" {
         \\  "oldnames": []
         \\}
     ;
-    const result = install.findFailedDep(&failed, json) orelse unreachable;
+    var cache = malt.deps.FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+    const result = install.findFailedDep(&cache, &failed, "curl", json) orelse unreachable;
     try testing.expectEqualStrings("openssl@3", result);
 }
 
@@ -267,13 +272,17 @@ test "findFailedDep returns null when no dep is known-broken" {
         \\  "oldnames": []
         \\}
     ;
-    try testing.expect(install.findFailedDep(&failed, json) == null);
+    var cache = malt.deps.FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+    try testing.expect(install.findFailedDep(&cache, &failed, "hello", json) == null);
 }
 
 test "findFailedDep returns null on unparseable JSON" {
     var failed = std.StringHashMap(void).init(testing.allocator);
     defer failed.deinit();
-    try testing.expect(install.findFailedDep(&failed, "not-json") == null);
+    var cache = malt.deps.FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+    try testing.expect(install.findFailedDep(&cache, &failed, "broken", "not-json") == null);
 }
 
 // --- collectFormulaJobs happy path (seeded BrewApi cache, no network) ---
@@ -330,8 +339,11 @@ test "collectFormulaJobs queues the main formula when nothing is installed" {
     var jobs: std.ArrayList(install.DownloadJob) = .empty;
     defer jobs.deinit(alloc);
 
+    var cache = malt.deps.FormulaCache.init(alloc);
+    defer cache.deinit();
+
     try install.collectFormulaJobs(
-        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst },
+        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache },
         "hello",
         json,
         false,
@@ -368,8 +380,11 @@ test "collectFormulaJobs no-ops when the formula is already installed" {
     var jobs: std.ArrayList(install.DownloadJob) = .empty;
     defer jobs.deinit(alloc);
 
+    var cache = malt.deps.FormulaCache.init(alloc);
+    defer cache.deinit();
+
     try install.collectFormulaJobs(
-        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst },
+        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache },
         "hello",
         json,
         false, // force=false
@@ -451,8 +466,11 @@ test "collectFormulaJobs queues a dep and its parent from a seeded cache" {
     var jobs: std.ArrayList(install.DownloadJob) = .empty;
     defer jobs.deinit(alloc);
 
+    var cache = malt.deps.FormulaCache.init(alloc);
+    defer cache.deinit();
+
     try install.collectFormulaJobs(
-        .{ .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst },
+        .{ .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst, .cache = &cache },
         "alpha",
         root_json,
         false,
@@ -498,7 +516,10 @@ test "collectFormulaJobs deduplicates deps already queued by a prior call" {
     var jobs: std.ArrayList(install.DownloadJob) = .empty;
     defer jobs.deinit(alloc);
 
-    const deps_ctx: install.InstallJobDeps = .{ .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst };
+    var cache = malt.deps.FormulaCache.init(alloc);
+    defer cache.deinit();
+
+    const deps_ctx: install.InstallJobDeps = .{ .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst, .cache = &cache };
     try install.collectFormulaJobs(deps_ctx, "alpha", root_a, false, &jobs);
     try install.collectFormulaJobs(deps_ctx, "omega", root_b, false, &jobs);
 
@@ -525,10 +546,13 @@ test "collectFormulaJobs surfaces FormulaNotFound for unparseable JSON" {
     var jobs: std.ArrayList(install.DownloadJob) = .empty;
     defer jobs.deinit(alloc);
 
+    var cache = malt.deps.FormulaCache.init(alloc);
+    defer cache.deinit();
+
     try testing.expectError(
         install.InstallError.FormulaNotFound,
         install.collectFormulaJobs(
-            .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst },
+            .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache },
             "broken",
             "not-a-json",
             false,
@@ -562,8 +586,11 @@ test "collectFormulaJobs with post_install leaves the DB untouched" {
     var jobs: std.ArrayList(install.DownloadJob) = .empty;
     defer jobs.deinit(alloc);
 
+    var cache = malt.deps.FormulaCache.init(alloc);
+    defer cache.deinit();
+
     _ = install.collectFormulaJobs(
-        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst },
+        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache },
         "needs-ruby",
         json,
         false,
@@ -622,8 +649,11 @@ test "collectFormulaJobs carries the _<revision> suffix in version_str" {
     var jobs: std.ArrayList(install.DownloadJob) = .empty;
     defer jobs.deinit(alloc);
 
+    var cache = malt.deps.FormulaCache.init(alloc);
+    defer cache.deinit();
+
     try install.collectFormulaJobs(
-        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst },
+        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache },
         "rev",
         json,
         false,
@@ -659,8 +689,11 @@ test "collectFormulaJobs leaves plain-version formulas unchanged" {
     var jobs: std.ArrayList(install.DownloadJob) = .empty;
     defer jobs.deinit(alloc);
 
+    var cache = malt.deps.FormulaCache.init(alloc);
+    defer cache.deinit();
+
     try install.collectFormulaJobs(
-        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst },
+        .{ .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache },
         "needs-ruby",
         json,
         false,
@@ -771,8 +804,11 @@ test "collectFormulaJobs leaves no parsed-tree leaks under testing.allocator (>=
         jobs.deinit(alloc);
     }
 
+    var cache = malt.deps.FormulaCache.init(alloc);
+    defer cache.deinit();
+
     try install.collectFormulaJobs(
-        .{ .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst },
+        .{ .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst, .cache = &cache },
         "root",
         root_json,
         false,


### PR DESCRIPTION
## Description

During a single `mt install` invocation, each dependency's formula JSON used to be parsed three to four times - once in the BFS dep walk, once for the typed install plan, once in the failure-diagnosis path, and once again per job in the link phase. 

This PR introduces a per-invocation parsed-formula cache so every formula is parsed exactly once across the whole pipeline.

## Related Issue

- None

## Notes for Reviewers

- None