### PR TITLE
perf(install): skip cask-ambiguity probe on unambiguous warm path

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -163,6 +163,7 @@ pub fn build(b: *std.Build) void {
         "tests/cli_tap_test.zig",
         "tests/cli_services_test.zig",
         "tests/install_execute_test.zig",
+        "tests/install_ambiguity_test.zig",
         "tests/fs_compat_stream_test.zig",
         "tests/fs_compat_lint_test.zig",
         "tests/fs_compat_primitives_test.zig",

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -350,8 +350,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
                 continue;
             };
 
-            // Check if name also exists as a cask — warn about ambiguity
-            if (!force_formula) {
+            // Skip the cask read+parse when no cask is cached — single stat.
+            if (!force_formula and api.cachedExists(pkg_name, .cask)) {
                 if (api.fetchCask(pkg_name)) |cask_json| {
                     allocator.free(cask_json);
                     output.info("{s} exists as both a formula and a cask. Installing formula. Use --cask to install the cask instead.", .{pkg_name});

--- a/src/net/api.zig
+++ b/src/net/api.zig
@@ -152,6 +152,15 @@ pub const BrewApi = struct {
 
     pub const Kind = enum { formula, cask };
 
+    /// Cache filename prefix for each `Kind`. Centralised so probe and
+    /// fetch helpers can't drift out of sync over which name they stat.
+    fn prefixForKind(kind: Kind) []const u8 {
+        return switch (kind) {
+            .formula => "formula_",
+            .cask => "cask_",
+        };
+    }
+
     /// Existence probe that reuses the same cache layout as `fetchFormula` /
     /// `fetchCask` without ever reading the cached body. On a warm 5-minute
     /// cache this is a single `statFile` call; on a miss it falls through to
@@ -160,10 +169,7 @@ pub const BrewApi = struct {
     /// `ApiUnreachable` are propagated.
     pub fn exists(self: *BrewApi, name: []const u8, kind: Kind) ApiError!bool {
         try validateName(name);
-        const prefix: []const u8 = switch (kind) {
-            .formula => "formula_",
-            .cask => "cask_",
-        };
+        const prefix = prefixForKind(kind);
 
         if (self.readNotFoundCache(name, prefix)) return false;
         if (self.cachedFresh(name, prefix)) return true;
@@ -178,6 +184,17 @@ pub const BrewApi = struct {
             else => return e,
         };
         self.allocator.free(body);
+        return true;
+    }
+
+    /// Single-stat presence probe — no body read, no parse, no TTL gate
+    /// (freshness is `fetchCached`'s problem). Used to skip the cask-
+    /// ambiguity warning when no cask of that name has ever been cached.
+    pub fn cachedExists(self: *BrewApi, name: []const u8, kind: Kind) bool {
+        const prefix = prefixForKind(kind);
+        var path_buf: [512]u8 = undefined;
+        const cache_path = std.fmt.bufPrint(&path_buf, "{s}/api/{s}{s}.json", .{ self.cache_dir, prefix, name }) catch return false;
+        _ = fs_compat.cwd().statFile(cache_path) catch return false;
         return true;
     }
 

--- a/tests/api_test.zig
+++ b/tests/api_test.zig
@@ -271,6 +271,61 @@ test "exists rejects invalid names before any cache lookup" {
     try testing.expectError(api_mod.ApiError.InvalidName, api.exists("..", .formula));
 }
 
+test "cachedExists returns true when a cask cache file is present" {
+    var http = client_mod.HttpClient.init(testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("cached_exists_hit");
+    defer dir.deinit();
+
+    try dir.writeCacheFile("cask_firefox.json", "{\"token\":\"firefox\"}");
+
+    var api = api_mod.BrewApi.init(testing.allocator, &http, dir.path);
+    try testing.expect(api.cachedExists("firefox", .cask));
+}
+
+test "cachedExists returns false when no cache file is present" {
+    var http = client_mod.HttpClient.init(testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("cached_exists_miss");
+    defer dir.deinit();
+
+    var api = api_mod.BrewApi.init(testing.allocator, &http, dir.path);
+    try testing.expect(!api.cachedExists("ghost", .cask));
+}
+
+test "cachedExists ignores stale mtime — existence is the only check" {
+    // Skipping the parse runs once the file is gone; for a present file
+    // we hand off to fetchCask, which owns freshness. cachedExists must
+    // not duplicate the TTL gate.
+    var http = client_mod.HttpClient.init(testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("cached_exists_stale");
+    defer dir.deinit();
+
+    try dir.writeCacheFile("cask_old.json", "{}");
+    var path_buf: [512]u8 = undefined;
+    const full = try std.fmt.bufPrint(&path_buf, "{s}/api/cask_old.json", .{dir.path});
+    const file = try malt.fs_compat.cwd().openFile(full, .{ .mode = .write_only });
+    defer file.close();
+    try file.updateTimes(0, 0);
+
+    var api = api_mod.BrewApi.init(testing.allocator, &http, dir.path);
+    try testing.expect(api.cachedExists("old", .cask));
+}
+
+test "cachedExists discriminates formula vs cask cache files" {
+    var http = client_mod.HttpClient.init(testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("cached_exists_kind");
+    defer dir.deinit();
+
+    try dir.writeCacheFile("formula_node.json", "{\"name\":\"node\"}");
+
+    var api = api_mod.BrewApi.init(testing.allocator, &http, dir.path);
+    try testing.expect(api.cachedExists("node", .formula));
+    try testing.expect(!api.cachedExists("node", .cask));
+}
+
 test "readNotFoundCache returns false for stale marker" {
     var http = client_mod.HttpClient.init(testing.allocator);
     defer http.deinit();

--- a/tests/install_ambiguity_test.zig
+++ b/tests/install_ambiguity_test.zig
@@ -1,0 +1,106 @@
+//! malt — formula/cask ambiguity-warning regression test.
+//! Pins two observable contracts around the cask-ambiguity probe in
+//! `install.execute`:
+//!   1. When both a formula and a cask of the same name are cached
+//!      locally, the "exists as both …" warning is emitted on stderr.
+//!   2. When only the formula is cached, no warning is emitted —
+//!      the probe must not invent a cask out of thin air.
+
+const std = @import("std");
+const malt = @import("malt");
+const testing = std.testing;
+const install = @import("malt").install;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+const ambiguity_marker: []const u8 = "exists as both a formula and a cask";
+
+const formula_wget_json =
+    \\{"name":"wget","full_name":"wget","tap":"homebrew/core","desc":"","homepage":"",
+    \\ "versions":{"stable":"1.0"},"revision":0,"dependencies":[],"oldnames":[],
+    \\ "keg_only":false,"post_install_defined":false,
+    \\ "bottle":{"stable":{"root_url":"https://ghcr.io/v2/homebrew/core/wget/blobs",
+    \\   "files":{
+    \\     "arm64_sequoia":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+    \\     "arm64_sonoma":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+    \\     "arm64_ventura":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+    \\     "arm64_monterey":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+    \\     "sequoia":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+    \\     "sonoma":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+    \\     "ventura":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+    \\     "monterey":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"}
+    \\   }}}}
+;
+
+fn seedCacheFile(prefix: []const u8, rel: []const u8, body: []const u8) !void {
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{prefix});
+    defer testing.allocator.free(cache_api);
+    try malt.fs_compat.cwd().makePath(cache_api);
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ cache_api, rel });
+    defer testing.allocator.free(path);
+    const f = try malt.fs_compat.cwd().createFile(path, .{});
+    defer f.close();
+    try f.writeAll(body);
+}
+
+test "ambiguity warning fires when both formula and cask are cached" {
+    const prefix_z: [:0]const u8 = "/tmp/mamb_b";
+    malt.fs_compat.deleteTreeAbsolute(prefix_z) catch {};
+    try malt.fs_compat.cwd().makePath(prefix_z);
+    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    defer malt.fs_compat.deleteTreeAbsolute(prefix_z) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    try seedCacheFile(prefix_z, "formula_wget.json", formula_wget_json);
+    try seedCacheFile(
+        prefix_z,
+        "cask_wget.json",
+        "{\"token\":\"wget\",\"url\":\"https://example.com/x.dmg\",\"version\":\"1\"}",
+    );
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.io_mod.beginStderrCapture(testing.allocator, &captured);
+    defer malt.io_mod.endStderrCapture();
+
+    try install.execute(arena.allocator(), &.{ "--dry-run", "wget" });
+
+    try testing.expect(std.mem.indexOf(u8, captured.items, ambiguity_marker) != null);
+}
+
+test "ambiguity warning is silent when no cask cache is present" {
+    const prefix_z: [:0]const u8 = "/tmp/mamb_n";
+    malt.fs_compat.deleteTreeAbsolute(prefix_z) catch {};
+    try malt.fs_compat.cwd().makePath(prefix_z);
+    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    defer malt.fs_compat.deleteTreeAbsolute(prefix_z) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    try seedCacheFile(prefix_z, "formula_wget.json", formula_wget_json);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.io_mod.beginStderrCapture(testing.allocator, &captured);
+    defer malt.io_mod.endStderrCapture();
+
+    try install.execute(arena.allocator(), &.{ "--dry-run", "wget" });
+
+    try testing.expect(std.mem.indexOf(u8, captured.items, ambiguity_marker) == null);
+}


### PR DESCRIPTION
## Description

`mt install <formula>` used to call `fetchCask` after every successful formula resolve to drive the "exists as both a formula and a cask" warning. The pre-existing `.404` marker already collapsed the warm-warm case to one `stat`, so the win shows up where it actually hurt: first installs and post-TTL probes, where the old path did a full HTTP round-trip just to learn there is no cask.

After this change, that path is one `stat` of the on-disk `cask_<name>.json` and an early skip when it isn't there. The warning still fires verbatim for names that legitimately collide with a cask.

## Related Issue

- None

## Notes for Reviewers

- None