### PR TITLE
perf(install): short-circuit when keg already present

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -164,6 +164,7 @@ pub fn build(b: *std.Build) void {
         "tests/cli_services_test.zig",
         "tests/install_execute_test.zig",
         "tests/install_ambiguity_test.zig",
+        "tests/install_idempotent_test.zig",
         "tests/fs_compat_stream_test.zig",
         "tests/fs_compat_lint_test.zig",
         "tests/fs_compat_primitives_test.zig",

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -79,6 +79,17 @@ pub fn pruneCellarForReinstall(prefix: []const u8, name: []const u8, version: []
     const cellar_path = std.fmt.bufPrint(&cellar_buf, "{s}/Cellar/{s}/{s}", .{ prefix, name, version }) catch return;
     fs_compat.deleteTreeAbsolute(cellar_path) catch {};
 }
+
+/// Single-`stat` probe of `<prefix>/Cellar/<name>`. uninstall tears
+/// down the parent when the last version goes; an orphan empty dir is
+/// `mt doctor --fix` territory rather than something to paper over.
+fn kegPresent(prefix: []const u8, name: []const u8) bool {
+    var buf: [512]u8 = undefined;
+    const cellar_path = std.fmt.bufPrint(&buf, "{s}/Cellar/{s}", .{ prefix, name }) catch return false;
+    fs_compat.accessAbsolute(cellar_path, .{}) catch return false;
+    return true;
+}
+
 pub const localErrorIsAnnounced = record_mod.localErrorIsAnnounced;
 pub const recordKeg = record_mod.recordKeg;
 pub const deleteKeg = record_mod.deleteKeg;
@@ -238,6 +249,22 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             return InstallError.PrefixAbsurd;
         },
     };
+
+    // Idempotent fast path — skip DB / lock / HTTP setup when every named
+    // arg already has a Cellar entry. Flags that change semantics
+    // (--force / --cask / --local / --dry-run / --only-dependencies) and
+    // tap-form / .rb-path args route to the regular flow. All-or-nothing
+    // on multi-arg keeps the gate state-free.
+    const fastpath_eligible = !force and !force_cask and !local_only and
+        !dry_run and !only_dependencies;
+    if (fastpath_eligible) fast: {
+        for (packages.items) |pkg| {
+            if (isTapFormula(pkg) or isLocalFormulaPath(pkg)) break :fast;
+            if (!kegPresent(prefix, pkg)) break :fast;
+        }
+        for (packages.items) |pkg| output.info("{s} is already installed", .{pkg});
+        return;
+    }
 
     // Ensure required directories exist (Step 0)
     ensureDirs(prefix) catch return error.Aborted;
@@ -850,4 +877,27 @@ fn installCask(
     allocator.free(app_path);
 
     output.success("{s} {s} installed", .{ cask.token, cask.version });
+}
+
+test "kegPresent returns true only when <prefix>/Cellar/<name> exists" {
+    const testing = std.testing;
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = try std.fmt.bufPrint(
+        &path_buf,
+        "/tmp/malt_kegpresent_{d}",
+        .{fs_compat.nanoTimestamp()},
+    );
+    fs_compat.deleteTreeAbsolute(prefix) catch {};
+    try fs_compat.cwd().makePath(prefix);
+    defer fs_compat.deleteTreeAbsolute(prefix) catch {};
+
+    try testing.expect(!kegPresent(prefix, "ghost"));
+
+    var keg_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const keg = try std.fmt.bufPrint(&keg_buf, "{s}/Cellar/ghost", .{prefix});
+    try fs_compat.cwd().makePath(keg);
+
+    try testing.expect(kegPresent(prefix, "ghost"));
+    try testing.expect(!kegPresent(prefix, "other"));
 }

--- a/tests/install_idempotent_test.zig
+++ b/tests/install_idempotent_test.zig
@@ -1,0 +1,138 @@
+//! malt — idempotent-install fast-path integration tests.
+//!
+//! When every named package already has a populated Cellar entry and no
+//! upgrade-forcing flag is in play, `install.execute` must short-circuit
+//! before opening SQLite, acquiring the install lock, or initialising
+//! the HTTP pool. Asserting "no DB file created" is the cheapest way to
+//! pin that the fast path actually skipped the heavy setup.
+
+const std = @import("std");
+const malt = @import("malt");
+const testing = std.testing;
+const install = malt.install;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+fn pathExists(path: []const u8) bool {
+    malt.fs_compat.accessAbsolute(path, .{}) catch return false;
+    return true;
+}
+
+fn seedCellarKeg(prefix: []const u8, name: []const u8, version: []const u8) !void {
+    const dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/{s}/{s}", .{ prefix, name, version });
+    defer testing.allocator.free(dir);
+    try malt.fs_compat.cwd().makePath(dir);
+}
+
+fn setupPrefix(suffix: []const u8) ![:0]u8 {
+    const path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "/tmp/malt_install_idem_{d}_{s}",
+        .{ malt.fs_compat.nanoTimestamp(), suffix },
+        0,
+    );
+    malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    try malt.fs_compat.cwd().makePath(path);
+    _ = c.setenv("MALT_PREFIX", path.ptr, 1);
+    return path;
+}
+
+test "execute short-circuits without opening the DB when the keg already exists" {
+    const prefix = try setupPrefix("hit");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    try seedCellarKeg(prefix, "seedpkg", "1.0");
+
+    const db_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.db", .{prefix});
+    defer testing.allocator.free(db_file);
+    const lock_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.lock", .{prefix});
+    defer testing.allocator.free(lock_file);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.io_mod.beginStderrCapture(testing.allocator, &captured);
+    defer malt.io_mod.endStderrCapture();
+
+    try install.execute(arena.allocator(), &.{"seedpkg"});
+
+    // No SQLite open ⇒ no malt.db file. No lock acquire ⇒ no malt.lock.
+    try testing.expect(!pathExists(db_file));
+    try testing.expect(!pathExists(lock_file));
+    try testing.expect(std.mem.indexOf(u8, captured.items, "seedpkg is already installed") != null);
+}
+
+test "execute --force falls through to the existing path even when the keg exists" {
+    const prefix = try setupPrefix("force");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    try seedCellarKeg(prefix, "seedpkg", "1.0");
+
+    const db_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.db", .{prefix});
+    defer testing.allocator.free(db_file);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    // `--force` drives the full pipeline; we don't care about the eventual
+    // outcome for an unresolvable name, only that the DB was opened.
+    install.execute(arena.allocator(), &.{ "--force", "--quiet", "seedpkg" }) catch {};
+
+    try testing.expect(pathExists(db_file));
+}
+
+test "execute falls through when one of several args is missing from the Cellar" {
+    const prefix = try setupPrefix("partial");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    try seedCellarKeg(prefix, "alpha", "1.0");
+
+    const db_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.db", .{prefix});
+    defer testing.allocator.free(db_file);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    install.execute(arena.allocator(), &.{ "--quiet", "alpha", "missing" }) catch {};
+
+    try testing.expect(pathExists(db_file));
+}
+
+test "execute --dry-run skips the fast path so the plan still reaches the user" {
+    const prefix = try setupPrefix("dryrun");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    try seedCellarKeg(prefix, "seedpkg", "1.0");
+
+    const db_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.db", .{prefix});
+    defer testing.allocator.free(db_file);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    install.execute(arena.allocator(), &.{ "--dry-run", "--quiet", "seedpkg" }) catch {};
+
+    try testing.expect(pathExists(db_file));
+}


### PR DESCRIPTION
## Description

`mt install <pkg>` for a package that is already installed now short-circuits before opening SQLite, acquiring the install lock, or initialising the HTTP pool. A single stat on `<MALT_PREFIX>/Cellar/<name>` decides the fast path; on multi-arg invocations it only fires when every named package is present, otherwise the existing flow handles the whole batch.

User-visible: idempotent `mt install` calls feel instantaneous. No change to `--force` / `--cask` / `--local` / `--dry-run` / `--only-dependencies`, or to tap-form / `.rb`-path inputs - they all route to the existing pipeline.

## Related Issue

- None

## Notes for Reviewers

- None