### PR TITLE
test: quiet just coverage noise on macOS

### DIFF
--- a/tests/install_idempotent_test.zig
+++ b/tests/install_idempotent_test.zig
@@ -27,6 +27,30 @@ fn seedCellarKeg(prefix: []const u8, name: []const u8, version: []const u8) !voi
     try malt.fs_compat.cwd().makePath(dir);
 }
 
+/// Redirect fd 2 to /dev/null and return a saved dup. Subprocess stderr
+/// (e.g. `ditto` complaining about a deliberately-broken cask path)
+/// bypasses `io_mod.beginStderrCapture` since that only catches Zig
+/// writes — silencing fd 2 itself is the only way to keep `just coverage`
+/// output tidy.
+fn silenceStderr() std.c.fd_t {
+    const saved = std.c.dup(2);
+    if (saved < 0) return -1;
+    const dn = std.c.open("/dev/null", .{ .ACCMODE = .WRONLY }, @as(std.c.mode_t, 0));
+    if (dn < 0) {
+        _ = std.c.close(saved);
+        return -1;
+    }
+    _ = std.c.dup2(dn, 2);
+    _ = std.c.close(dn);
+    return saved;
+}
+
+fn restoreStderr(saved: std.c.fd_t) void {
+    if (saved < 0) return;
+    _ = std.c.dup2(saved, 2);
+    _ = std.c.close(saved);
+}
+
 fn setupPrefix(suffix: []const u8) ![:0]u8 {
     const path = try std.fmt.allocPrintSentinel(
         testing.allocator,
@@ -112,6 +136,10 @@ test "execute falls through when one of several args is missing from the Cellar"
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
+    // The fall-through pipeline reaches a deliberately-broken cask
+    // extract; ditto writes its complaint straight to fd 2 — gate it.
+    const saved_stderr = silenceStderr();
+    defer restoreStderr(saved_stderr);
     install.execute(arena.allocator(), &.{ "--quiet", "alpha", "missing" }) catch {};
 
     try testing.expect(pathExists(db_file));

--- a/tests/sandbox_macos_test.zig
+++ b/tests/sandbox_macos_test.zig
@@ -105,12 +105,6 @@ const ReapObserver = struct {
     }
 };
 
-fn childProcessExists(pid: std.c.pid_t) bool {
-    // `kill(pid, 0)` returns 0 while the pid still names a live or
-    // zombie process we own; -1/ESRCH once it has been reaped.
-    return std.c.kill(pid, @enumFromInt(0)) == 0;
-}
-
 test "spawnFilteredWithHooks reaps child when first reader-thread spawn fails" {
     if (builtin.os.tag != .macos) return error.SkipZigTest;
 
@@ -136,8 +130,6 @@ test "spawnFilteredWithHooks reaps child when first reader-thread spawn fails" {
     try testing.expectError(error.ForkFailed, result);
     try testing.expectEqual(@as(u32, 1), obs.call_count);
     try testing.expect(obs.reaped_pid > 0);
-    // Process must be gone — the reap fix waited on it before returning.
-    try testing.expect(!childProcessExists(obs.reaped_pid));
 }
 
 test "spawnFilteredWithHooks reaps child and joins out-thread when second spawn fails" {
@@ -165,5 +157,4 @@ test "spawnFilteredWithHooks reaps child and joins out-thread when second spawn 
     try testing.expectError(error.ForkFailed, result);
     try testing.expectEqual(@as(u32, 1), obs.call_count);
     try testing.expect(obs.reaped_pid > 0);
-    try testing.expect(!childProcessExists(obs.reaped_pid));
 }


### PR DESCRIPTION
## Description

`just coverage` was producing two kinds of noise on macOS that made the output hard to scan:

- A flaky assertion in the sandbox reap tests - the post-`waitpid``kill(pid, 0)` probe raced PID reuse under kcov's heavy process churn.
- A `ditto` complaint leaking from the partial-Cellar install test, where the fall-through pipeline reaches a deliberately-broken cask extract and the subprocess writes straight to fd 2.

Both are test-only fixes; no production behaviour changes. The reap tests still prove the child was waited on via the existing `on_child_reaped` callback, and the partial-Cellar test still pins that the fast path was skipped.

## Related Issue

- None

## Notes for Reviewers

- None
