### PR TITLE
chore: add release-branch + patch workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - "release/**"
     paths:
       - "**/*.zig"
       - "**/*.zon"
@@ -10,7 +12,9 @@ on:
       - "src/core/pins_manifest.txt"
       - ".github/workflows/ci.yml"
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - "release/**"
     paths:
       - "**/*.zig"
       - "**/*.zon"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ For anything beyond a typo or a one-line fix, **open an issue first**. A short c
 
 **Pull requests.** PRs are squash-merged into `main`, so the squash subject is what shows up in `git log` - write the PR title with that in mind (Conventional Commits header, under 70 chars). The PR description should focus on the user-visible behaviour change or the safety property added; avoid file-by-file changelogs (the diff already shows that).
 
+**Where PRs go.** Open every PR against `main`, including bug fixes against the latest release. malt maintains a `release/X.Y` branch as the patch line for the current minor; the maintainer cherry-picks user-visible fixes from `main` onto it. Don't target `release/*` branches directly - it makes the next minor a regression risk and bypasses the gate.
+
 > [!NOTE]
 > **AI-assisted contributions are welcome.** malt itself is human-directed AI implementation, so PRs written with Claude, Copilot, or similar tools are fine - provided you've read the diff, understand what the patch does, and stand behind it as your own work. Treat the AI as a collaborator, not a release valve.
 

--- a/justfile
+++ b/justfile
@@ -180,6 +180,70 @@ bench-snapshot:
     zig build bench-snapshot
 
 # ---------------------------------------------------------------------------
+# Release / patch
+# ---------------------------------------------------------------------------
+# Patch releases are cut from a `release/0.X` branch, never from main.
+# Workflow:
+#   1. `git checkout release/0.X && git pull`
+#   2. `just backport <sha>`   - cherry-pick the squashed fix from main
+#                                  (repeat per fix; resolve conflicts inline)
+#   3. `just patch`            - bumps .version, regenerates changelog,
+#                                  pushes branch, creates + pushes the tag
+# The tag push triggers .github/workflows/release.yml exactly like a
+# minor release - goreleaser builds + signs, the Homebrew tap formula
+# bumps, install.sh starts serving the patch on next run.
+
+# Cherry-pick a commit (or range) from main onto the current release
+# branch and run the test gate before you push.
+#   just backport <sha>            single squashed PR commit
+#   just backport <sha1>..<sha2>   range
+[group('release')]
+backport ref:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    branch="$(git rev-parse --abbrev-ref HEAD)"
+    case "$branch" in
+        release/*) ;;
+        *) echo "error: not on a release branch (current: $branch)" >&2; exit 1 ;;
+    esac
+
+    git cherry-pick -x {{ ref }}
+    just fmt-check test
+    echo "▸ Cherry-picked {{ ref }} onto $branch — review, then 'just patch'."
+
+# Prepare a patch on the current release branch: gate -> sley bump ->
+# sley changelog merge. Refuses to run from main or a dirty tree. The
+# push + tag steps are intentionally manual; the recipe prints the
+# exact commands to run after you've inspected the result.
+[group('release')]
+patch:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    branch="$(git rev-parse --abbrev-ref HEAD)"
+    case "$branch" in
+        release/*) ;;
+        *) echo "error: refuse to patch from '$branch' — checkout release/0.X first" >&2; exit 1 ;;
+    esac
+
+    if ! git diff-index --quiet HEAD --; then
+        echo "error: working tree dirty — commit or stash first" >&2
+        exit 1
+    fi
+
+    just fmt-check test
+    sley bump patch
+    sley changelog merge
+
+    # Push + tag are kept manual until the workflow is battle-tested.
+    # Review `git log` and `.changes/v*.md` first, then run:
+    #   git push origin "$branch"
+    #   sley tag create --push
+    echo "▸ Bump + changelog ready on $branch."
+    echo "▸ Review, then run: git push origin $branch && sley tag create --push"
+
+# ---------------------------------------------------------------------------
 # Cleanup
 # ---------------------------------------------------------------------------
 # Remove Zig build artifacts (.zig-cache, zig-out, coverage) and test


### PR DESCRIPTION
## Description

Introduces a `release/X.Y` patch line so user-facing fixes can ship as `vX.Y.Z` patches without pulling in unmerged features from `main`. Two new `just` recipes wrap the cherry-pick + gate + bump + changelog flow, and CI is extended to gate `release/**` alongside `main`. 

Contributors are unaffected - PRs still target `main`, and the maintainer cherry-picks fixes onto the active patch line. The rule is documented in `CONTRIBUTING.md` so new contributors don't open PRs against `release/*`.

## Related Issue

- None

## Notes for Reviewers

- `just patch` intentionally stops after `sley changelog merge`. The `git push` and `sley tag create --push` steps are kept manual until the recipe has been exercised on a real fix - the lines are commented inside the recipe and the follow-up commands are echoed to stdout. Uncomment once trusted.
