### PR TITLE
feat(cli): --output-format=ndjson for mutating commands

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -179,6 +179,7 @@ pub fn build(b: *std.Build) void {
         "tests/uses_test.zig",
         "tests/which_test.zig",
         "tests/output_test.zig",
+        "tests/ndjson_test.zig",
         "tests/worker_arena_test.zig",
         "tests/migrate_smoke_test.zig",
         "tests/upgrade_test.zig",

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -236,6 +236,18 @@ else
 
   run_ok t3.install.dry -- "$MT_BIN" install --dry-run tree
   run_ok t3.install.tree -- "$MT_BIN" install tree
+
+  # ndjson stream contract — fast-path emits `already_installed` once
+  # tree is on disk; upgrade brackets every run with lock_acquired +
+  # install_complete; --json + --output-format=ndjson must be orthogonal
+  # (per-step ndjson events, existing --json blob still works).
+  run_grep t3.install.ndjson.fastpath '"event":"already_installed".*"name":"tree"' -- \
+    "$MT_BIN" --output-format=ndjson --quiet install tree
+  run_grep t3.upgrade.ndjson.up_to_date '"event":"up_to_date".*"name":"tree"' -- \
+    "$MT_BIN" --output-format=ndjson --quiet upgrade tree
+  run_grep t3.upgrade.ndjson.bracket '"event":"install_complete"' -- \
+    "$MT_BIN" --json --output-format=ndjson --quiet upgrade tree
+
   run_grep t3.list.has-tree "tree" -- "$MT_BIN" list
   run_grep t3.info.tree "tree" -- "$MT_BIN" info tree
   run_ok t3.uses.tree -- "$MT_BIN" uses tree

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -88,7 +88,7 @@ pub const bash_script =
     \\    cword=$COMP_CWORD
     \\
     \\    local commands="install uninstall remove upgrade update outdated list ls info search uses which doctor tap untap migrate rollback link unlink pin unpin run version completions shellenv backup restore purge services bundle help"
-    \\    local global_flags="--verbose -v --quiet -q --json --dry-run --help -h --version"
+    \\    local global_flags="--verbose -v --quiet -q --json --output-format=ndjson --dry-run --help -h --version"
     \\
     \\    # Find the first non-flag word after the program — that's the subcommand.
     \\    local cmd="" i
@@ -228,6 +228,7 @@ pub const zsh_script =
     \\        '(--verbose -v)'{--verbose,-v}'[Verbose output]' \
     \\        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
     \\        '--json[JSON output]' \
+    \\        '--output-format=ndjson[Stream one JSON event per state transition]' \
     \\        '--dry-run[Preview without executing]' \
     \\        '(- : *)'{--help,-h}'[Show help]' \
     \\        '(- : *)--version[Show version]' \
@@ -441,6 +442,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -s v -l verbose -d 'Verbose output'
     \\    complete -c $__malt_bin -s q -l quiet   -d 'Suppress non-error output'
     \\    complete -c $__malt_bin      -l json    -d 'JSON output'
+    \\    complete -c $__malt_bin      -l output-format=ndjson -d 'Stream one JSON event per state transition'
     \\    complete -c $__malt_bin      -l dry-run -d 'Preview without executing'
     \\    complete -c $__malt_bin -s h -l help    -d 'Show help'
     \\    complete -c $__malt_bin      -l version -d 'Show version'

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -262,7 +262,12 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             if (isTapFormula(pkg) or isLocalFormulaPath(pkg)) break :fast;
             if (!kegPresent(prefix, pkg)) break :fast;
         }
-        for (packages.items) |pkg| output.info("{s} is already installed", .{pkg});
+        for (packages.items) |pkg| {
+            output.info("{s} is already installed", .{pkg});
+            // Fast-path skips the protocol; positive signal so consumers
+            // can tell idempotent success from "command never ran".
+            output.emitNdjsonEvent(allocator, .already_installed, pkg, null);
+        }
         return;
     }
 
@@ -294,6 +299,10 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         return InstallError.LockError;
     };
     defer lk.release();
+    // LIFO: install_complete fires before lk.release. Inline gate keeps
+    // the deferred call out of the default paths.
+    defer if (output.isNdjson()) output.emitNdjsonEvent(allocator, .install_complete, "", null);
+    output.emitNdjsonEvent(allocator, .lock_acquired, "", null);
 
     // Main-thread HTTP client; workers borrow from `http_pool` instead.
     var http = client_mod.HttpClient.init(allocator);
@@ -397,6 +406,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
                 output.err("Failed to resolve {s}: {s}", .{ pkg_name, @errorName(e) });
                 continue;
             };
+            output.emitNdjsonEvent(allocator, .resolved, pkg_name, null);
         } else {
             installCask(allocator, pkg_name, &db, &api, dry_run) catch |e| {
                 output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
@@ -416,6 +426,8 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         for (all_jobs.items) |job| {
             const tag: []const u8 = if (job.is_dep) " (dependency)" else "";
             output.info("  {s} {s}{s}", .{ job.name, job.version_str, tag });
+            // No transition outcome to report on a plan-only run.
+            output.emitNdjsonEvent(allocator, .would_install, job.name, null);
         }
         return;
     }
@@ -530,6 +542,17 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         multi.finish();
     }
 
+    // Emit from the main thread so ndjson order is deterministic
+    // regardless of worker interleaving.
+    if (output.isNdjson()) {
+        for (all_jobs.items) |job| {
+            if (!job.succeeded) continue;
+            output.emitNdjsonEvent(allocator, .downloaded, job.name, "ok");
+            output.emitNdjsonEvent(allocator, .extracted, job.name, "ok");
+            output.emitNdjsonEvent(allocator, .stored, job.name, "ok");
+        }
+    }
+
     // Check for Ctrl-C between download and materialize phases
     if (main_mod.isInterrupted()) {
         output.warn("Interrupted. Cleaning up...", .{});
@@ -618,10 +641,12 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
                 "Failed to materialize {s}: {s} ({s})",
                 .{ job.name, @errorName(err), cellar_mod.describeError(err) },
             );
+            output.emitNdjsonEvent(allocator, .materialized, job.name, "failed");
             try failed_kegs.put(job.name, {});
             failed_count += 1;
             continue;
         }
+        output.emitNdjsonEvent(allocator, .materialized, job.name, "ok");
 
         // Failed-dep → skip: installing on a broken graph yields a dyld-unresolvable
         // keg. Remove the already-materialised keg so orphans don't linger.
@@ -708,12 +733,17 @@ fn linkAndRecord(
 
         linker.link(keg_path, job.name, keg_id) catch |err| {
             output.err("Failed to link {s}: {s}", .{ job.name, @errorName(err) });
+            output.emitNdjsonEvent(allocator, .linked, job.name, "failed");
             // Rollback: unlink what was partially created + remove DB record + cellar.
             linker.unlink(keg_id) catch {};
             deleteKeg(db, keg_id);
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
             return InstallError.LinkFailed;
         };
+        // `recorded` after both succeed — link rollback undoes the keg
+        // row, so an early emit would lie if `linked:failed` follows.
+        output.emitNdjsonEvent(allocator, .linked, job.name, "ok");
+        output.emitNdjsonEvent(allocator, .recorded, job.name, "ok");
         linker.linkOpt(job.name, job.version_str) catch {};
         recordDeps(db, keg_id, formula);
     } else {
@@ -722,6 +752,8 @@ fn linkAndRecord(
             cellar_mod.remove(prefix, job.name, job.version_str) catch {};
             return InstallError.RecordFailed;
         };
+        // keg-only has no public link phase to roll back.
+        output.emitNdjsonEvent(allocator, .recorded, job.name, "ok");
         linker.linkOpt(job.name, job.version_str) catch {};
         recordDeps(db, keg_id, formula);
     }

--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -85,7 +85,9 @@ pub fn routePostInstallOutcome(
         break :blk .partially_skipped;
     };
 
-    if (output.isJson()) emitPostInstallJson(allocator, name, status, flog);
+    // post_install belongs to the 9-step protocol stream, so ndjson
+    // consumers need it even without `--json`.
+    if (output.isJson() or output.isNdjson()) emitPostInstallJson(allocator, name, status, flog);
 }
 
 /// Write one JSON line per post_install routing decision to stdout. One
@@ -99,7 +101,10 @@ fn emitPostInstallJson(
     var aw: std.Io.Writer.Allocating = .init(allocator);
     defer aw.deinit();
     const w = &aw.writer;
-    w.writeAll("{\"event\":\"post_install\",\"name\":") catch return;
+    // Sourced from NdjsonEvent so renames propagate, no stale literal.
+    w.writeAll("{\"event\":\"") catch return;
+    w.writeAll(@tagName(output.NdjsonEvent.post_install)) catch return;
+    w.writeAll("\",\"name\":") catch return;
     output.jsonStr(w, name) catch return;
     w.writeAll(",\"status\":\"") catch return;
     w.writeAll(@tagName(status)) catch return;

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -166,6 +166,13 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             output.info("Would migrate {d} packages from Homebrew", .{keg_names.items.len});
             output.warn("Run without --dry-run to perform migration", .{});
         }
+        // Per-keg plan event — consumers don't need to parse the
+        // human/--json blob to pre-flight a migration.
+        if (output.isNdjson()) {
+            for (keg_names.items) |kn| {
+                output.emitNdjsonEvent(allocator, .would_install, kn, null);
+            }
+        }
         return;
     }
 
@@ -195,6 +202,10 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         return error.Aborted;
     };
     defer lk.release();
+    // LIFO: install_complete fires before lk.release. Inline gate keeps
+    // the deferred call out of the default paths.
+    defer if (output.isNdjson()) output.emitNdjsonEvent(allocator, .install_complete, "", null);
+    output.emitNdjsonEvent(allocator, .lock_acquired, "", null);
 
     // Set up HTTP + API + GHCR + store + linker
     var http = client_mod.HttpClient.init(allocator);
@@ -333,6 +344,7 @@ fn migrateKeg(
         output.warn("  {s}: no bottle available for this platform", .{keg_name});
         return .skipped_no_bottle;
     };
+    output.emitNdjsonEvent(allocator, .resolved, keg_name, null);
 
     output.info("  Migrating {s} {s}...", .{ formula.name, formula.version });
 
@@ -343,6 +355,11 @@ fn migrateKeg(
         }
     } else {
         output.info("    {s} (cached in store)", .{keg_name});
+    }
+    if (output.isNdjson()) {
+        output.emitNdjsonEvent(allocator, .downloaded, keg_name, "ok");
+        output.emitNdjsonEvent(allocator, .extracted, keg_name, "ok");
+        output.emitNdjsonEvent(allocator, .stored, keg_name, "ok");
     }
 
     // Increment store refcount
@@ -359,8 +376,10 @@ fn migrateKeg(
         formula.pkg_version,
     ) catch {
         output.err("    {s}: failed to materialize", .{keg_name});
+        output.emitNdjsonEvent(allocator, .materialized, keg_name, "failed");
         return .failed_install;
     };
+    output.emitNdjsonEvent(allocator, .materialized, keg_name, "ok");
 
     // 7. Record in DB + link
     if (!formula.keg_only) {
@@ -373,12 +392,17 @@ fn migrateKeg(
 
         deps.linker.link(keg.path, formula.name, keg_id) catch {
             output.warn("    {s}: some links could not be created", .{keg_name});
+            output.emitNdjsonEvent(allocator, .linked, keg_name, "failed");
             // Rollback: unlink partial links and delete keg row; user already warned above.
             deps.linker.unlink(keg_id) catch {};
             deleteKeg(deps.db, keg_id) catch {};
             cellar_mod.remove(deps.prefix, formula.name, formula.pkg_version) catch {};
             return .failed_install;
         };
+        // `recorded` after both succeed — link rollback above undoes
+        // the keg row, so an early emit would lie if link fails.
+        output.emitNdjsonEvent(allocator, .linked, keg_name, "ok");
+        output.emitNdjsonEvent(allocator, .recorded, keg_name, "ok");
         // Opt symlink is convenience; install is already functional via versioned link.
         deps.linker.linkOpt(formula.name, formula.pkg_version) catch {};
         recordDeps(deps.db, keg_id, &formula);
@@ -388,6 +412,7 @@ fn migrateKeg(
             cellar_mod.remove(deps.prefix, formula.name, formula.pkg_version) catch {};
             return .failed_install;
         };
+        output.emitNdjsonEvent(allocator, .recorded, keg_name, "ok");
         // Opt symlink is convenience; install is already functional via versioned link.
         deps.linker.linkOpt(formula.name, formula.pkg_version) catch {};
         recordDeps(deps.db, keg_id, &formula);

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -90,6 +90,10 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         return error.Aborted;
     };
     defer lk.release();
+    // LIFO: install_complete fires before lk.release. Inline gate keeps
+    // the deferred call out of the default paths.
+    defer if (output.isNdjson()) output.emitNdjsonEvent(allocator, .install_complete, "", null);
+    output.emitNdjsonEvent(allocator, .lock_acquired, "", null);
 
     var db_path_buf: [512]u8 = undefined;
     const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
@@ -175,6 +179,8 @@ fn upgradeFormula(
     // sees the drift, but the dry-run gate still blocks any mutation.
     if (pinSkip(db, name, force, audit_mode)) {
         output.dim("{s} is pinned, skipped", .{name});
+        // Distinguishes "skipped by policy" from "command never ran".
+        output.emitNdjsonEvent(allocator, .pinned, name, null);
         return;
     }
 
@@ -221,15 +227,19 @@ fn upgradeFormula(
     // Compare versions
     if (std.mem.eql(u8, old_pkg_version, formula.pkg_version)) {
         output.skip("{s} is already at latest version {s}", .{ name, formula.pkg_version });
+        output.emitNdjsonEvent(allocator, .up_to_date, name, null);
         return;
     }
 
     if (dry_run) {
         output.info("Dry run: would upgrade {s} {s} -> {s}", .{ name, old_version, formula.pkg_version });
+        // Same vocabulary across install/upgrade/migrate — one parser fits all.
+        output.emitNdjsonEvent(allocator, .would_install, name, null);
         return;
     }
 
     output.info("Upgrading {s} {s} -> {s}...", .{ name, old_version, formula.pkg_version });
+    output.emitNdjsonEvent(allocator, .resolved, name, null);
 
     // Step 3: Resolve bottle for new version
     const bottle = formula_mod.resolveBottle(allocator, &formula) catch {
@@ -285,6 +295,12 @@ fn upgradeFormula(
         // refcount is advisory; commit succeeded, store now owns the bytes.
         store.incrementRef(bottle.sha256) catch {};
     }
+    // Emit even on warm-cache so the cold/warm event sequence matches.
+    if (output.isNdjson()) {
+        output.emitNdjsonEvent(allocator, .downloaded, name, "ok");
+        output.emitNdjsonEvent(allocator, .extracted, name, "ok");
+        output.emitNdjsonEvent(allocator, .stored, name, "ok");
+    }
 
     // Step 5: Materialize new version to Cellar
     output.dim("Materializing {s} to cellar...", .{name});
@@ -296,8 +312,10 @@ fn upgradeFormula(
         formula.pkg_version,
     ) catch {
         output.err("Failed to materialize {s}", .{name});
+        output.emitNdjsonEvent(allocator, .materialized, name, "failed");
         return error.Aborted;
     };
+    output.emitNdjsonEvent(allocator, .materialized, name, "ok");
 
     // Step 6: Unlink old symlinks
     var linker = linker_mod.Linker.init(allocator, db, prefix);
@@ -317,6 +335,7 @@ fn upgradeFormula(
 
     linker.link(new_keg.path, formula.name, new_keg_id) catch {
         output.err("Failed to link new version of {s}", .{name});
+        output.emitNdjsonEvent(allocator, .linked, name, "failed");
         // Rollback: remove partial new links, restore old
         // partial link cleanup in a rollback path.
         linker.unlink(new_keg_id) catch {};
@@ -326,6 +345,10 @@ fn upgradeFormula(
         cellar_mod.remove(prefix, formula.name, formula.pkg_version) catch {};
         return;
     };
+    // `recorded` after both succeed — link rollback above undoes the
+    // keg row, so an early emit would lie if `linked:failed` follows.
+    output.emitNdjsonEvent(allocator, .linked, name, "ok");
+    output.emitNdjsonEvent(allocator, .recorded, name, "ok");
 
     // opt symlink is convenience; install is already functional via versioned link.
     linker.linkOpt(formula.name, formula.pkg_version) catch {};
@@ -513,6 +536,7 @@ fn upgradeAllFormulas(
 fn upgradeCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Database, api: *api_mod.BrewApi, prefix: [:0]const u8, dry_run: bool, force: bool, audit_mode: bool) !void {
     if (pinSkip(db, token, force, audit_mode)) {
         output.dim("{s} is pinned, skipped", .{token});
+        output.emitNdjsonEvent(allocator, .pinned, token, null);
         return;
     }
 
@@ -537,11 +561,13 @@ fn upgradeCask(allocator: std.mem.Allocator, token: []const u8, db: *sqlite.Data
     const installed_version = installed.version();
     if (std.mem.eql(u8, installed_version, parsed_cask.version)) {
         output.skip("{s} is already at latest version {s}", .{ token, parsed_cask.version });
+        output.emitNdjsonEvent(allocator, .up_to_date, token, null);
         return;
     }
 
     if (dry_run) {
         output.info("Dry run: would upgrade cask {s} {s} -> {s}", .{ token, installed_version, parsed_cask.version });
+        output.emitNdjsonEvent(allocator, .would_install, token, null);
         return;
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -144,6 +144,101 @@ const command_map = blk: {
     break :blk std.StaticStringMap(Command).initComptime(pairs);
 };
 
+/// Set of process-wide flags consumed before subcommand dispatch.
+/// StaticStringMap + exhaustive switch matches the install/upgrade
+/// flag parsers and gives the compiler ownership of "every flag has a
+/// handler" so adding a tag without wiring it fails to build.
+const GlobalFlag = enum {
+    verbose,
+    debug,
+    quiet,
+    json,
+    ndjson,
+    dry_run,
+};
+
+const global_flag_map = std.StaticStringMap(GlobalFlag).initComptime(.{
+    .{ "--verbose", .verbose },
+    .{ "-v", .verbose },
+    .{ "--debug", .debug },
+    .{ "--quiet", .quiet },
+    .{ "-q", .quiet },
+    .{ "--json", .json },
+    .{ "--output-format=ndjson", .ndjson },
+    .{ "--dry-run", .dry_run },
+});
+
+/// Apply a global flag to the process-wide `output.*` state and report
+/// whether it was consumed. Pulled out of `main` so the dispatch loop
+/// stays a one-liner and the flag set is testable without spawning a
+/// child process. Returns `false` for anything that should reach the
+/// subcommand's argv.
+pub fn applyGlobalFlag(arg: []const u8) bool {
+    const output = @import("ui/output.zig");
+    const flag = global_flag_map.get(arg) orelse return false;
+    switch (flag) {
+        .verbose => output.setVerbose(true),
+        .debug => output.setDebug(true),
+        .quiet => output.setQuiet(true),
+        .json => output.setMode(.json),
+        .ndjson => output.setNdjson(true),
+        .dry_run => output.setDryRun(true),
+    }
+    return true;
+}
+
+test "applyGlobalFlag --output-format=ndjson toggles ndjson mode" {
+    const output = @import("ui/output.zig");
+    const prior = output.isNdjson();
+    defer output.setNdjson(prior);
+    output.setNdjson(false);
+
+    try std.testing.expect(applyGlobalFlag("--output-format=ndjson"));
+    try std.testing.expect(output.isNdjson());
+}
+
+test "applyGlobalFlag is orthogonal to --json" {
+    const output = @import("ui/output.zig");
+    const prior_ndjson = output.isNdjson();
+    const prior_mode = output.isJson();
+    defer {
+        output.setNdjson(prior_ndjson);
+        output.setMode(if (prior_mode) .json else .human);
+    }
+    output.setNdjson(false);
+    output.setMode(.human);
+
+    _ = applyGlobalFlag("--json");
+    _ = applyGlobalFlag("--output-format=ndjson");
+    try std.testing.expect(output.isJson());
+    try std.testing.expect(output.isNdjson());
+}
+
+test "applyGlobalFlag returns false for unrecognised flags" {
+    try std.testing.expect(!applyGlobalFlag("--cask"));
+    try std.testing.expect(!applyGlobalFlag("--output-format=junk"));
+    try std.testing.expect(!applyGlobalFlag("wget"));
+}
+
+test "applyGlobalFlag --output-format=ndjson does not flip --quiet" {
+    // Compose with --quiet explicitly when needed; the streams are
+    // already split (ndjson on stdout, human on stderr), so users
+    // pipeline-redirect rather than have malt couple two concerns.
+    const output = @import("ui/output.zig");
+    const prior_ndjson = output.isNdjson();
+    const prior_quiet = output.isQuiet();
+    defer {
+        output.setNdjson(prior_ndjson);
+        output.setQuiet(prior_quiet);
+    }
+    output.setNdjson(false);
+    output.setQuiet(false);
+
+    _ = applyGlobalFlag("--output-format=ndjson");
+    try std.testing.expect(output.isNdjson());
+    try std.testing.expect(!output.isQuiet());
+}
+
 pub fn main(init: std.process.Init.Minimal) !void {
     // In debug builds, use GeneralPurposeAllocator as the backing
     // allocator for leak detection and use-after-free checks.
@@ -194,7 +289,6 @@ pub fn main(init: std.process.Init.Minimal) !void {
 
     // Parse global flags before dispatch — strip them from the args
     // passed to subcommands so they don't need to parse them individually.
-    const output = @import("ui/output.zig");
     var filtered: std.ArrayList([]const u8) = .empty;
     defer filtered.deinit(allocator);
     var cmd_str: []const u8 = "";
@@ -214,19 +308,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
             found_cmd = true;
             continue;
         }
-        if (std.mem.eql(u8, arg, "--verbose") or std.mem.eql(u8, arg, "-v")) {
-            output.setVerbose(true);
-        } else if (std.mem.eql(u8, arg, "--debug")) {
-            output.setDebug(true);
-        } else if (std.mem.eql(u8, arg, "--quiet") or std.mem.eql(u8, arg, "-q")) {
-            output.setQuiet(true);
-        } else if (std.mem.eql(u8, arg, "--json")) {
-            output.setMode(.json);
-        } else if (std.mem.eql(u8, arg, "--dry-run")) {
-            output.setDryRun(true);
-        } else {
-            try filtered.append(allocator, arg);
-        }
+        if (!applyGlobalFlag(arg)) try filtered.append(allocator, arg);
     }
 
     if (!found_cmd) {
@@ -337,6 +419,9 @@ fn printUsage() void {
         \\                  pair with issue reports for full context
         \\  --quiet, -q     Suppress non-error output
         \\  --json          JSON output (read commands)
+        \\  --output-format=ndjson
+        \\                  Stream one JSON event per state transition for
+        \\                  install/upgrade/migrate (orthogonal to --json)
         \\  --dry-run       Preview without executing
         \\  --help, -h      Show help
         \\  --version       Show version

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -16,6 +16,9 @@ var verbose: bool = false;
 var debug: bool = false;
 var dry_run: bool = false;
 var mode: OutputMode = .human;
+/// Orthogonal to `mode`/`--json` so CI can stream per-step events
+/// without losing the final summary.
+var ndjson: bool = false;
 
 pub fn setQuiet(q: bool) void {
     quiet = q;
@@ -50,6 +53,12 @@ pub fn isDryRun() bool {
 }
 pub fn isJson() bool {
     return mode == .json;
+}
+pub fn setNdjson(b: bool) void {
+    ndjson = b;
+}
+pub fn isNdjson() bool {
+    return ndjson;
 }
 
 /// Shared implementation for info/warn/success/err. One concrete
@@ -309,4 +318,69 @@ pub fn jsonOutput(allocator: std.mem.Allocator, value: anytype) !void {
     try std.json.Stringify.value(value, .{}, &aw.writer);
     try aw.writer.writeByte('\n');
     io_mod.stdoutWriteAll(aw.written());
+}
+
+/// Closed vocabulary so call-site typos fail to compile. `@tagName` is
+/// the wire-format string; `snake_case` matches the existing post_install
+/// line so consumers can reuse one parser.
+pub const NdjsonEvent = enum {
+    // 9-step protocol on the bottle install path.
+    lock_acquired,
+    resolved,
+    downloaded,
+    extracted,
+    stored,
+    materialized,
+    linked,
+    recorded,
+    install_complete,
+    // Shared with --json's existing post_install summary line.
+    post_install,
+    // No-transition outcomes.
+    would_install,
+    already_installed,
+    up_to_date,
+    pinned,
+};
+
+/// Write one `{"event":...}\n` per state transition. No-op when ndjson
+/// is off so the default and `--json` paths pay nothing.
+///
+/// `name` is omitted when empty (lock_acquired et al. are command-level);
+/// `status` is omitted when null so consumers skip a `null` vs `missing`
+/// branch. Overflowing events drop silently rather than fail the install.
+/// `allocator` is unused — kept for parity with the other JSON helpers.
+pub fn emitNdjsonEvent(
+    allocator: std.mem.Allocator,
+    event: NdjsonEvent,
+    name: []const u8,
+    status: ?[]const u8,
+) void {
+    _ = allocator;
+    if (!ndjson) return;
+    // Worst-case adversarial-escape name still fits in 1 KiB.
+    var buf: [1024]u8 = undefined;
+    var w = std.Io.Writer.fixed(buf[0..]);
+    w.writeAll("{\"event\":") catch return;
+    jsonStr(&w, @tagName(event)) catch return;
+    if (name.len > 0) {
+        w.writeAll(",\"name\":") catch return;
+        jsonStr(&w, name) catch return;
+    }
+    if (status) |s| {
+        w.writeAll(",\"status\":") catch return;
+        jsonStr(&w, s) catch return;
+    }
+    w.writeAll("}\n") catch return;
+    io_mod.stdoutWriteAll(w.buffered());
+}
+
+test "isNdjson defaults to false and setNdjson toggles it" {
+    const prior = isNdjson();
+    defer setNdjson(prior);
+
+    setNdjson(false);
+    try std.testing.expect(!isNdjson());
+    setNdjson(true);
+    try std.testing.expect(isNdjson());
 }

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -114,6 +114,15 @@ test "all update completions expose --check" {
     try expectContains(completions.fish_script, "-l check");
 }
 
+test "all global-flag completions expose --output-format=ndjson" {
+    // Regression guard: ndjson is a global flag, so every shell's
+    // top-level flag list must include it. Tab-completion on the
+    // mutating commands is a primary user surface.
+    try expectContains(completions.bash_script, "--output-format=ndjson");
+    try expectContains(completions.zsh_script, "--output-format=ndjson");
+    try expectContains(completions.fish_script, "output-format=ndjson");
+}
+
 test "all bundle completions expose the cleanup subcommand and its flags" {
     for ([_][]const u8{
         completions.bash_script,

--- a/tests/ndjson_test.zig
+++ b/tests/ndjson_test.zig
@@ -1,0 +1,224 @@
+//! malt — `--output-format=ndjson` integration tests
+//!
+//! Pins the event vocabulary for the 9-step install protocol and the
+//! bracketing protocol events that wrap upgrade and migrate. The test
+//! drives the public emit helper directly to keep the integration surface
+//! small — the real install/upgrade/migrate flows funnel every transition
+//! through the same `output.emitNdjsonEvent` call site, so vocabulary
+//! coverage here pins the contract every command must honour.
+
+const std = @import("std");
+const malt = @import("malt");
+const testing = std.testing;
+const output = malt.output;
+const io_mod = malt.io_mod;
+const upgrade = malt.upgrade;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+/// One stable name per step in the 9-step install protocol described in
+/// the README. Locking these in a slice forces a compile-time review when
+/// a new step (or rename) lands; consumers parse by event name, so churn
+/// here is a breaking change for them.
+///
+/// Two ordering notes for consumers:
+///   - For a single-package install, events arrive in this exact order.
+///   - For a multi-package install (e.g. `mt install wget` with deps),
+///     download-class events (downloaded/extracted/stored) emit for
+///     every job before the first materialized event, because the
+///     protocol downloads in parallel and materialises serially.
+///     Each per-package event carries `name` so consumers group by it
+///     instead of relying on strict per-package linearity.
+const install_step_events = [_]output.NdjsonEvent{
+    .lock_acquired,
+    .resolved,
+    .downloaded,
+    .extracted,
+    .stored,
+    .materialized,
+    .linked,
+    .recorded,
+    .install_complete,
+};
+
+fn setNdjsonOn() bool {
+    const prior = output.isNdjson();
+    output.setNdjson(true);
+    return prior;
+}
+
+fn restoreNdjson(prior: bool) void {
+    output.setNdjson(prior);
+}
+
+test "9-step install protocol emits one ndjson line per step" {
+    const prior = setNdjsonOn();
+    defer restoreNdjson(prior);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    // Drive each protocol step through the same helper the real
+    // commands use so the line shape is the one consumers will see.
+    output.emitNdjsonEvent(testing.allocator, .lock_acquired, "", null);
+    output.emitNdjsonEvent(testing.allocator, .resolved, "wget", null);
+    output.emitNdjsonEvent(testing.allocator, .downloaded, "wget", "ok");
+    output.emitNdjsonEvent(testing.allocator, .extracted, "wget", "ok");
+    output.emitNdjsonEvent(testing.allocator, .stored, "wget", "ok");
+    output.emitNdjsonEvent(testing.allocator, .materialized, "wget", "ok");
+    output.emitNdjsonEvent(testing.allocator, .linked, "wget", "ok");
+    output.emitNdjsonEvent(testing.allocator, .recorded, "wget", "ok");
+    output.emitNdjsonEvent(testing.allocator, .install_complete, "", null);
+
+    // Exactly one line per step — no fan-out, no dropped events.
+    try testing.expectEqual(install_step_events.len, std.mem.count(u8, buf.items, "\n"));
+
+    var lines = std.mem.splitScalar(u8, std.mem.trimEnd(u8, buf.items, "\n"), '\n');
+    var idx: usize = 0;
+    while (lines.next()) |line| : (idx += 1) {
+        const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line, .{});
+        defer parsed.deinit();
+        try testing.expectEqualStrings(
+            @tagName(install_step_events[idx]),
+            parsed.value.object.get("event").?.string,
+        );
+    }
+    try testing.expectEqual(install_step_events.len, idx);
+}
+
+test "ndjson off emits zero events for the same call sequence" {
+    const prior = output.isNdjson();
+    defer restoreNdjson(prior);
+    output.setNdjson(false);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    for (install_step_events) |ev| {
+        output.emitNdjsonEvent(testing.allocator, ev, "wget", "ok");
+    }
+    try testing.expectEqualStrings("", buf.items);
+}
+
+test "every NdjsonEvent variant emits a parser-clean line" {
+    // Walk the enum exhaustively so adding a variant without testing it
+    // surfaces here rather than as a missed event in production.
+    const prior = setNdjsonOn();
+    defer restoreNdjson(prior);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    inline for (std.meta.tags(output.NdjsonEvent)) |ev| {
+        output.emitNdjsonEvent(testing.allocator, ev, "wget", null);
+    }
+
+    const total: usize = std.meta.tags(output.NdjsonEvent).len;
+    try testing.expectEqual(total, std.mem.count(u8, buf.items, "\n"));
+}
+
+test "no-op skip event names are stable across mutating commands" {
+    // Pin every "no transition happened" event variant. These emit on
+    // idempotent / refused paths so consumers can tell "skipped by policy"
+    // from "command never ran".
+    const skip_events = [_]output.NdjsonEvent{
+        .already_installed, // install fast-path
+        .would_install, // dry-run install / upgrade / migrate
+        .up_to_date, // upgrade detects no version drift
+        .pinned, // upgrade refuses a pinned package
+    };
+    const prior = setNdjsonOn();
+    defer restoreNdjson(prior);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    for (skip_events) |ev| output.emitNdjsonEvent(testing.allocator, ev, "wget", null);
+
+    try testing.expectEqual(skip_events.len, std.mem.count(u8, buf.items, "\n"));
+    // No status field on any of them — these are no-transition events.
+    try testing.expect(std.mem.indexOf(u8, buf.items, "\"status\"") == null);
+    for (skip_events) |ev| {
+        var needle_buf: [64]u8 = undefined;
+        const needle = try std.fmt.bufPrint(&needle_buf, "\"event\":\"{s}\"", .{@tagName(ev)});
+        try testing.expect(std.mem.indexOf(u8, buf.items, needle) != null);
+    }
+}
+
+test "would_install and already_installed are stable side-channel event names" {
+    // Pin the two non-protocol event names so changes here surface as
+    // a compile-test diff. `would_install` is the dry-run signal,
+    // `already_installed` is the idempotent fast-path signal — each
+    // intentionally omits `status` because no transition outcome
+    // exists.
+    const prior = setNdjsonOn();
+    defer restoreNdjson(prior);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    output.emitNdjsonEvent(testing.allocator, .would_install, "wget", null);
+    output.emitNdjsonEvent(testing.allocator, .already_installed, "tree", null);
+
+    try testing.expectEqual(@as(usize, 2), std.mem.count(u8, buf.items, "\n"));
+    try testing.expect(std.mem.indexOf(u8, buf.items, "\"event\":\"would_install\"") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"wget\"") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "\"event\":\"already_installed\"") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"tree\"") != null);
+    // No status field on either event.
+    try testing.expect(std.mem.indexOf(u8, buf.items, "\"status\"") == null);
+}
+
+test "upgrade emits bracketing lock_acquired + install_complete under ndjson" {
+    // A fake MALT_PREFIX with an empty DB lets `upgrade.execute` run
+    // through lock acquire → "no formulas installed" → release without
+    // touching the network. The test pins the bracketing events so the
+    // ndjson stream stays well-formed even when no work is done.
+    const path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "/tmp/malt_ndjson_upgrade_{d}",
+        .{malt.fs_compat.nanoTimestamp()},
+        0,
+    );
+    defer testing.allocator.free(path);
+    malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    try malt.fs_compat.cwd().makePath(path);
+    _ = c.setenv("MALT_PREFIX", path.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{path});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+
+    const prior = setNdjsonOn();
+    defer restoreNdjson(prior);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    try upgrade.execute(testing.allocator, &.{});
+
+    try testing.expect(std.mem.indexOf(u8, buf.items, "\"event\":\"lock_acquired\"") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "\"event\":\"install_complete\"") != null);
+    // install_complete must trail lock_acquired so consumers can rely on
+    // a strict open/close bracket.
+    const open_pos = std.mem.indexOf(u8, buf.items, "\"event\":\"lock_acquired\"").?;
+    const close_pos = std.mem.indexOf(u8, buf.items, "\"event\":\"install_complete\"").?;
+    try testing.expect(close_pos > open_pos);
+}

--- a/tests/output_test.zig
+++ b/tests/output_test.zig
@@ -398,3 +398,120 @@ test "jsonStr output round-trips through std.json parser" {
         try testing.expectEqualStrings(s, parsed.value.string);
     }
 }
+
+// ── ndjson streaming for mutating commands ─────────────────────────────
+// `--output-format=ndjson` is orthogonal to `--json`: it gates per-state
+// transition events on stdout while leaving the existing summary output
+// untouched. Tests pin the silent-by-default behaviour and the
+// parser-clean line shape consumers will jq-pipe.
+
+/// Capture stdout for an ndjson event emit. Pairs scope-style with `defer`
+/// so each test stays free of capture/teardown boilerplate.
+const NdjsonCapture = struct {
+    buf: *std.ArrayList(u8),
+    prior_ndjson: bool,
+
+    fn init(buf: *std.ArrayList(u8), enabled: bool) NdjsonCapture {
+        const prior = output.isNdjson();
+        output.setNdjson(enabled);
+        io_mod.beginStdoutCapture(testing.allocator, buf);
+        return .{ .buf = buf, .prior_ndjson = prior };
+    }
+
+    fn deinit(self: NdjsonCapture) void {
+        io_mod.endStdoutCapture();
+        output.setNdjson(self.prior_ndjson);
+    }
+};
+
+test "emitNdjsonEvent writes nothing when ndjson is off" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = NdjsonCapture.init(&buf, false);
+    defer cap.deinit();
+
+    output.emitNdjsonEvent(testing.allocator, .downloaded, "wget", null);
+    try testing.expectEqualStrings("", buf.items);
+}
+
+test "emitNdjsonEvent writes one parser-clean line when ndjson is on" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = NdjsonCapture.init(&buf, true);
+    defer cap.deinit();
+
+    output.emitNdjsonEvent(testing.allocator, .downloaded, "wget", "ok");
+    try testing.expect(std.mem.endsWith(u8, buf.items, "\n"));
+    // Single line, no embedded newlines except the trailing one.
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, buf.items, "\n"));
+
+    const trimmed = std.mem.trimEnd(u8, buf.items, "\n");
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, trimmed, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("downloaded", parsed.value.object.get("event").?.string);
+    try testing.expectEqualStrings("wget", parsed.value.object.get("name").?.string);
+    try testing.expectEqualStrings("ok", parsed.value.object.get("status").?.string);
+}
+
+test "emitNdjsonEvent omits status field when null" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = NdjsonCapture.init(&buf, true);
+    defer cap.deinit();
+
+    output.emitNdjsonEvent(testing.allocator, .lock_acquired, "", null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "\"status\"") == null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "\"event\":\"lock_acquired\"") != null);
+}
+
+test "emitNdjsonEvent escapes adversarial name and status fields" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = NdjsonCapture.init(&buf, true);
+    defer cap.deinit();
+
+    output.emitNdjsonEvent(testing.allocator, .linked, "needs\"quote", "fa\nil");
+
+    const trimmed = std.mem.trimEnd(u8, buf.items, "\n");
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, trimmed, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("needs\"quote", parsed.value.object.get("name").?.string);
+    try testing.expectEqualStrings("fa\nil", parsed.value.object.get("status").?.string);
+}
+
+test "emitNdjsonEvent silently drops events that overflow the stack buffer" {
+    // The stack buffer is 1 KiB. A pathologically long name should drop
+    // the event rather than write a partial / unparseable line — that's
+    // the contract real consumers depend on (every line is well-formed
+    // JSON or absent).
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const cap = NdjsonCapture.init(&buf, true);
+    defer cap.deinit();
+
+    var huge: [4096]u8 = undefined;
+    @memset(&huge, 'x');
+    output.emitNdjsonEvent(testing.allocator, .downloaded, &huge, "ok");
+
+    // No partial bytes; either the full line landed or nothing did.
+    if (buf.items.len > 0) {
+        try testing.expect(std.mem.endsWith(u8, buf.items, "\n"));
+    }
+    // Specifically: this size must overflow, so we expect *no* output.
+    try testing.expectEqualStrings("", buf.items);
+}
+
+test "emitNdjsonEvent fires under ndjson regardless of --json mode" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+
+    const prior_mode = output.isJson();
+    defer output.setMode(if (prior_mode) .json else .human);
+    output.setMode(.human);
+
+    const cap = NdjsonCapture.init(&buf, true);
+    defer cap.deinit();
+
+    output.emitNdjsonEvent(testing.allocator, .resolved, "tree", null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "\"event\":\"resolved\"") != null);
+}


### PR DESCRIPTION
## Description

`--output-format=ndjson` streams a line-delimited JSON object per state transition in `mt install`, `mt upgrade`, and `mt migrate`. CI and dashboards now get a structured event feed - `lock_acquired`, `resolved`, `downloaded`, `extracted`, `stored`, `materialized`, `linked`, `recorded`, `install_complete` - without parsing mixed human/JSON output. Skip-state outcomes are also covered: `would_install` for dry-run, `already_installed` for the idempotent fast-path, `up_to_date` and `pinned` for upgrade refusals.

The flag is orthogonal to `--json`; both can run together. Default and `--json` paths are byte-identical to today.

## Related Issue

- None

## Notes for Reviewers

- None