### PR TITLE
feat(cli/migrate): --parallel with resume manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ mt run --keep ripgrep -- --help          # cache the bottle for next run
 
 `mt uninstall` removes a package, refusing if dependents exist or, for casks, if the application is running. `--force` (`-f`) bypasses both checks. `--cask` forces cask uninstall. Store entries are preserved for `mt purge --store-orphans`.
 
-`mt migrate` imports an existing Homebrew installation by scanning the Cellar and reinstalling each package through malt. It never modifies the Homebrew install. Packages with `post_install` are executed via the native interpreter; unsupported scripts fall back to `--use-system-ruby` or are skipped with a report. `--dry-run` previews.
+`mt migrate` imports an existing Homebrew installation by scanning the Cellar and reinstalling each package through malt. It never modifies the Homebrew install. Packages with `post_install` are executed via the native interpreter; unsupported scripts fall back to `--use-system-ruby` or are skipped with a report. `--dry-run` previews. `--parallel` runs the per-keg work concurrently (4 workers by default; tune with `MALT_MIGRATE_PARALLEL_WORKERS=N`) and records each success in `{prefix}/cache/migrate.progress.json`, so a re-run after a crash or `^C` resumes where it stopped.
 
 ### Stay current
 
@@ -482,6 +482,7 @@ MALT_ALLOW_UNVERIFIED=1 mt version update --no-verify
 | `HOMEBREW_GITHUB_API_TOKEN`    | GitHub token for higher API rate limits                                           | unset            |
 | `MALT_GITHUB_TOKEN`            | GitHub token sent as `Authorization: Bearer` on tap `/commits/HEAD` calls only    | unset            |
 | `MALT_OUTDATED_MAX_AGE`        | TTL in hours for the `outdated.json` snapshot                                     | `24`             |
+| `MALT_MIGRATE_PARALLEL_WORKERS` | Worker count for `mt migrate --parallel` (clamped to `[1, 32]`)                  | `4`              |
 | `MALT_ALLOW_UNVERIFIED`        | Skip cosign signature check in `install.sh` (use only when cosign is unavailable) | unset            |
 | `MALT_ALLOW_UNVERIFIED_SOURCE` | Allow `install.sh` to clone `main` when no release tag resolves                   | unset            |
 | `MALT_ALLOW_RAW_POST_INSTALL`  | Disable terminal escape filter on ruby `post_install` output                      | unset            |

--- a/build.zig
+++ b/build.zig
@@ -182,6 +182,7 @@ pub fn build(b: *std.Build) void {
         "tests/ndjson_test.zig",
         "tests/worker_arena_test.zig",
         "tests/migrate_smoke_test.zig",
+        "tests/migrate_manifest_test.zig",
         "tests/upgrade_test.zig",
         "tests/hash_test.zig",
         "tests/patcher_test.zig",

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -215,6 +215,11 @@ const migrate_help =
     \\
     \\Flags:
     \\  --dry-run          Show what would be migrated
+    \\  --parallel         Migrate kegs concurrently with a bounded worker pool
+    \\                     (default 4 workers; override with
+    \\                     MALT_MIGRATE_PARALLEL_WORKERS=N). Successful kegs are
+    \\                     recorded in {prefix}/cache/migrate.progress.json so a
+    \\                     re-run after a crash or ^C resumes where it stopped.
     \\  --json             Emit a machine-readable summary on stdout (pairs with
     \\                     --dry-run to list kegs, or with a real run to report
     \\                     per-category names + counts for migrated / skipped /

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -9,10 +9,7 @@ const fs_compat = @import("../fs/compat.zig");
 const sqlite = @import("../db/sqlite.zig");
 const schema = @import("../db/schema.zig");
 const lock_mod = @import("../db/lock.zig");
-const formula_mod = @import("../core/formula.zig");
-const bottle_mod = @import("../core/bottle.zig");
 const store_mod = @import("../core/store.zig");
-const cellar_mod = @import("../core/cellar.zig");
 const linker_mod = @import("../core/linker.zig");
 const client_mod = @import("../net/client.zig");
 const ghcr_mod = @import("../net/ghcr.zig");
@@ -21,8 +18,12 @@ const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
 const io_mod = @import("../ui/io.zig");
 const codesign = @import("../macho/codesign.zig");
-const post_install_mod = @import("install/post_install.zig");
 const help = @import("help.zig");
+const keg_mod = @import("migrate/keg.zig");
+
+const KegResult = keg_mod.KegResult;
+const MigrateDeps = keg_mod.MigrateDeps;
+const migrateKeg = keg_mod.migrateKeg;
 
 /// Resolve the Homebrew install prefix. Respects `HOMEBREW_PREFIX` (set
 /// by `brew shellenv` and by users with a non-standard install), falls
@@ -60,30 +61,6 @@ pub fn scanCellarKegs(
         try names.append(arena, try arena.dupe(u8, entry.name));
     }
 }
-
-/// Result of migrating a single keg.
-const KegResult = enum {
-    migrated,
-    skipped_installed,
-    skipped_post_install,
-    skipped_no_bottle,
-    failed_api,
-    failed_download,
-    failed_install,
-};
-
-/// Named-field bundle for the shared state `migrateKeg` threads across
-/// every keg in the loop. Opens a DI seam for tests to swap in fakes.
-const MigrateDeps = struct {
-    api: *api_mod.BrewApi,
-    ghcr: *ghcr_mod.GhcrClient,
-    http: *client_mod.HttpClient,
-    store: *store_mod.Store,
-    linker: *linker_mod.Linker,
-    db: *sqlite.Database,
-    prefix: []const u8,
-    use_system_ruby_scope: []const []const u8,
-};
 
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "migrate")) return;
@@ -312,253 +289,6 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             output.err("    - {s}", .{name});
         }
     }
-}
-
-/// Migrate a single keg from Homebrew into malt.
-fn migrateKeg(
-    allocator: std.mem.Allocator,
-    keg_name: []const u8,
-    deps: MigrateDeps,
-) KegResult {
-    // 1. Check if already installed in malt
-    if (isInstalled(deps.db, keg_name)) {
-        output.info("  {s}: already installed, skipping", .{keg_name});
-        return .skipped_installed;
-    }
-
-    // Two `defer`s below collapse six per-branch cleanups.
-    const formula_json = deps.api.fetchFormula(keg_name) catch {
-        output.err("  {s}: not found in Homebrew API", .{keg_name});
-        return .failed_api;
-    };
-    defer allocator.free(formula_json);
-
-    var formula = formula_mod.parseFormula(allocator, formula_json) catch {
-        output.err("  {s}: failed to parse formula JSON", .{keg_name});
-        return .failed_api;
-    };
-    defer formula.deinit();
-
-    // 3. Resolve bottle for this platform
-    const bottle = formula_mod.resolveBottle(allocator, &formula) catch {
-        output.warn("  {s}: no bottle available for this platform", .{keg_name});
-        return .skipped_no_bottle;
-    };
-    output.emitNdjsonEvent(allocator, .resolved, keg_name, null);
-
-    output.info("  Migrating {s} {s}...", .{ formula.name, formula.version });
-
-    // 5. Download bottle via GHCR (skip if already in store)
-    if (!deps.store.exists(bottle.sha256)) {
-        if (!downloadBottle(allocator, deps.ghcr, deps.http, deps.store, bottle.url, bottle.sha256, keg_name)) {
-            return .failed_download;
-        }
-    } else {
-        output.info("    {s} (cached in store)", .{keg_name});
-    }
-    if (output.isNdjson()) {
-        output.emitNdjsonEvent(allocator, .downloaded, keg_name, "ok");
-        output.emitNdjsonEvent(allocator, .extracted, keg_name, "ok");
-        output.emitNdjsonEvent(allocator, .stored, keg_name, "ok");
-    }
-
-    // Increment store refcount
-    deps.store.incrementRef(bottle.sha256) catch |e| {
-        std.log.warn("refcount increment failed for {s}: {s}", .{ keg_name, @errorName(e) });
-    };
-
-    // 6. Materialize to cellar
-    const keg = cellar_mod.materialize(
-        allocator,
-        deps.prefix,
-        bottle.sha256,
-        formula.name,
-        formula.pkg_version,
-    ) catch {
-        output.err("    {s}: failed to materialize", .{keg_name});
-        output.emitNdjsonEvent(allocator, .materialized, keg_name, "failed");
-        return .failed_install;
-    };
-    output.emitNdjsonEvent(allocator, .materialized, keg_name, "ok");
-
-    // 7. Record in DB + link
-    if (!formula.keg_only) {
-        const keg_id = recordKeg(deps.db, &formula, bottle.sha256, keg.path, "direct") catch {
-            output.err("    {s}: failed to record in database", .{keg_name});
-            // Rollback: remove materialised keg when DB record fails.
-            cellar_mod.remove(deps.prefix, formula.name, formula.pkg_version) catch {};
-            return .failed_install;
-        };
-
-        deps.linker.link(keg.path, formula.name, keg_id) catch {
-            output.warn("    {s}: some links could not be created", .{keg_name});
-            output.emitNdjsonEvent(allocator, .linked, keg_name, "failed");
-            // Rollback: unlink partial links and delete keg row; user already warned above.
-            deps.linker.unlink(keg_id) catch {};
-            deleteKeg(deps.db, keg_id) catch {};
-            cellar_mod.remove(deps.prefix, formula.name, formula.pkg_version) catch {};
-            return .failed_install;
-        };
-        // `recorded` after both succeed — link rollback above undoes
-        // the keg row, so an early emit would lie if link fails.
-        output.emitNdjsonEvent(allocator, .linked, keg_name, "ok");
-        output.emitNdjsonEvent(allocator, .recorded, keg_name, "ok");
-        // Opt symlink is convenience; install is already functional via versioned link.
-        deps.linker.linkOpt(formula.name, formula.pkg_version) catch {};
-        recordDeps(deps.db, keg_id, &formula);
-    } else {
-        const keg_id = recordKeg(deps.db, &formula, bottle.sha256, keg.path, "direct") catch {
-            // Rollback: remove materialised keg when DB record fails.
-            cellar_mod.remove(deps.prefix, formula.name, formula.pkg_version) catch {};
-            return .failed_install;
-        };
-        output.emitNdjsonEvent(allocator, .recorded, keg_name, "ok");
-        // Opt symlink is convenience; install is already functional via versioned link.
-        deps.linker.linkOpt(formula.name, formula.pkg_version) catch {};
-        recordDeps(deps.db, keg_id, &formula);
-    }
-
-    if (formula.post_install_defined) {
-        post_install_mod.drive(
-            allocator,
-            formula.name,
-            formula.pkg_version,
-            formula_json,
-            deps.prefix,
-            deps.use_system_ruby_scope,
-        );
-    }
-
-    const keg_only_suffix: []const u8 = if (formula.keg_only) " (keg-only — dependency only)" else "";
-    output.success("  {s} {s} migrated{s}", .{ formula.name, formula.version, keg_only_suffix });
-    return .migrated;
-}
-
-/// Download a bottle from GHCR and commit to the store.
-fn downloadBottle(
-    allocator: std.mem.Allocator,
-    ghcr: *ghcr_mod.GhcrClient,
-    http: *client_mod.HttpClient,
-    store: *store_mod.Store,
-    bottle_url: []const u8,
-    sha256: []const u8,
-    name: []const u8,
-) bool {
-    // Extract repo + digest from bottle URL
-    const ghcr_prefix_str = "https://ghcr.io/v2/";
-    var repo_buf: [256]u8 = undefined;
-    var digest_buf: [128]u8 = undefined;
-
-    if (!std.mem.startsWith(u8, bottle_url, ghcr_prefix_str)) {
-        output.err("    {s}: unsupported bottle URL", .{name});
-        return false;
-    }
-
-    const path = bottle_url[ghcr_prefix_str.len..];
-    const blobs_pos = std.mem.indexOf(u8, path, "/blobs/") orelse {
-        output.err("    {s}: malformed bottle URL", .{name});
-        return false;
-    };
-
-    const repo = std.fmt.bufPrint(&repo_buf, "{s}", .{path[0..blobs_pos]}) catch return false;
-    const digest = std.fmt.bufPrint(&digest_buf, "{s}", .{path[blobs_pos + "/blobs/".len ..]}) catch return false;
-
-    // Create temp dir
-    const tmp_dir = atomic.createTempDir(allocator, name) catch return false;
-
-    output.info("    Downloading {s}...", .{name});
-
-    // Download
-    _ = bottle_mod.download(allocator, ghcr, http, repo, digest, sha256, tmp_dir, null) catch {
-        output.err("    Download failed: {s}", .{name});
-        atomic.cleanupTempDir(tmp_dir);
-        allocator.free(tmp_dir);
-        return false;
-    };
-
-    // Commit to store
-    store.commitFrom(sha256, tmp_dir) catch {
-        output.err("    Store commit failed: {s}", .{name});
-        atomic.cleanupTempDir(tmp_dir);
-        allocator.free(tmp_dir);
-        return false;
-    };
-    allocator.free(tmp_dir);
-    return true;
-}
-
-// ── DB helpers (same pattern as install.zig) ────────────────────────
-
-fn recordKeg(
-    db: *sqlite.Database,
-    formula: *const formula_mod.Formula,
-    store_sha256: []const u8,
-    cellar_path: []const u8,
-    install_reason: []const u8,
-) !i64 {
-    db.beginTransaction() catch return error.RecordFailed;
-    errdefer db.rollback();
-
-    // The COALESCE on `pinned` carries any existing user pin across
-    // INSERT OR REPLACE so re-migrating doesn't silently drop holds.
-    var stmt = db.prepare(
-        "INSERT OR REPLACE INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason, pinned)" ++
-            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, COALESCE((SELECT MAX(pinned) FROM kegs WHERE name = ?1), 0));",
-    ) catch return error.RecordFailed;
-    defer stmt.finalize();
-
-    stmt.bindText(1, formula.name) catch return error.RecordFailed;
-    stmt.bindText(2, formula.full_name) catch return error.RecordFailed;
-    stmt.bindText(3, formula.version) catch return error.RecordFailed;
-    stmt.bindInt(4, formula.revision) catch return error.RecordFailed;
-    stmt.bindText(5, formula.tap) catch return error.RecordFailed;
-    stmt.bindText(6, store_sha256) catch return error.RecordFailed;
-    stmt.bindText(7, cellar_path) catch return error.RecordFailed;
-    stmt.bindText(8, install_reason) catch return error.RecordFailed;
-
-    _ = stmt.step() catch return error.RecordFailed;
-
-    const keg_id = getLastInsertId(db) catch return error.RecordFailed;
-    db.commit() catch return error.RecordFailed;
-
-    return keg_id;
-}
-
-fn deleteKeg(db: *sqlite.Database, keg_id: i64) sqlite.SqliteError!void {
-    var stmt = try db.prepare("DELETE FROM kegs WHERE id = ?1;");
-    defer stmt.finalize();
-    try stmt.bindInt(1, keg_id);
-    _ = try stmt.step();
-}
-
-/// Each row is independent; skip on per-row failure so a partial dep
-/// table is preferred to aborting a migration wholesale.
-fn recordDeps(db: *sqlite.Database, keg_id: i64, formula: *const formula_mod.Formula) void {
-    for (formula.dependencies) |dep_name| {
-        var stmt = db.prepare(
-            "INSERT OR IGNORE INTO dependencies (keg_id, dep_name, dep_type) VALUES (?1, ?2, 'runtime');",
-        ) catch continue;
-        defer stmt.finalize();
-
-        stmt.bindInt(1, keg_id) catch continue;
-        stmt.bindText(2, dep_name) catch continue;
-        _ = stmt.step() catch {};
-    }
-}
-
-fn getLastInsertId(db: *sqlite.Database) !i64 {
-    var stmt = db.prepare("SELECT last_insert_rowid();") catch return error.RecordFailed;
-    defer stmt.finalize();
-    const has_row = stmt.step() catch return error.RecordFailed;
-    if (!has_row) return error.RecordFailed;
-    return stmt.columnInt(0);
-}
-
-fn isInstalled(db: *sqlite.Database, name: []const u8) bool {
-    var stmt = db.prepare("SELECT id FROM kegs WHERE name = ?1 LIMIT 1;") catch return false;
-    defer stmt.finalize();
-    stmt.bindText(1, name) catch return false;
-    return stmt.step() catch false;
 }
 
 // ── JSON output ─────────────────────────────────────────────────────

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -20,6 +20,7 @@ const io_mod = @import("../ui/io.zig");
 const codesign = @import("../macho/codesign.zig");
 const help = @import("help.zig");
 const keg_mod = @import("migrate/keg.zig");
+const manifest_mod = @import("migrate/manifest.zig");
 
 const KegResult = keg_mod.KegResult;
 const MigrateDeps = keg_mod.MigrateDeps;
@@ -198,6 +199,20 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var store = store_mod.Store.init(allocator, &db, prefix);
     var linker = linker_mod.Linker.init(allocator, &db, prefix);
 
+    // Resume manifest: a crashed/^C run resumes from where it stopped
+    // instead of redoing every keg.
+    var manifest_path_buf: [512]u8 = undefined;
+    const manifest_path = std.fmt.bufPrint(
+        &manifest_path_buf,
+        "{s}/cache/migrate.progress.json",
+        .{prefix},
+    ) catch return;
+    var manifest = manifest_mod.loadFromPath(allocator, manifest_path) catch |e| blk: {
+        output.warn("Could not read resume manifest ({s}); starting fresh", .{@errorName(e)});
+        break :blk manifest_mod.Manifest.init(allocator);
+    };
+    defer manifest.deinit();
+
     // ── Step 4: Migrate each keg ────────────────────────────────────
     // Per-category name lists: counts are derived lengths; JSON emits arrays verbatim.
     var migrated_names: std.ArrayList([]const u8) = .empty;
@@ -224,6 +239,15 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             output.warn("Interrupted — skipping remaining kegs.", .{});
             break;
         }
+        // Resume short-circuit before any API/network work — bounds
+        // re-runs by the remaining kegs, not the full set. The DB
+        // cross-check guards against a stale manifest after `mt
+        // uninstall`: manifest=yes / DB=no falls through to a real
+        // re-migrate instead of silently skipping a missing keg.
+        if (manifest.contains(keg_name) and keg_mod.isInstalled(&db, keg_name)) {
+            try skipped_installed_names.append(allocator, keg_name);
+            continue;
+        }
         const result = migrateKeg(allocator, keg_name, .{
             .api = &api,
             .ghcr = &ghcr,
@@ -239,12 +263,39 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         // counts and JSON arrays come from these lists, and a silent drop
         // reports fewer failures than actually occurred.
         switch (result) {
-            .migrated => try migrated_names.append(allocator, keg_name),
+            .migrated => {
+                try migrated_names.append(allocator, keg_name);
+                // Persist after each success so a crash leaves the next
+                // run with the smallest possible to-do list.
+                manifest.add(keg_name) catch |e| {
+                    output.warn("Resume manifest update failed for {s}: {s}", .{ keg_name, @errorName(e) });
+                };
+                manifest.writeAtomic(allocator, manifest_path) catch |e| {
+                    output.warn("Resume manifest write failed: {s}", .{@errorName(e)});
+                };
+            },
             .skipped_installed => try skipped_installed_names.append(allocator, keg_name),
             .skipped_post_install => try skipped_post_install_names.append(allocator, keg_name),
             .skipped_no_bottle => try skipped_no_bottle_names.append(allocator, keg_name),
             .failed_api, .failed_download, .failed_install => try failed_names.append(allocator, keg_name),
         }
+    }
+
+    // Self-heal the resume manifest: any DB-confirmed skip that wasn't
+    // already recorded gets added now, so a SIGKILL between "DB
+    // committed" and "manifest writeAtomic flushed" converges on the
+    // next run instead of paying the DB-lookup penalty forever.
+    var manifest_dirty = false;
+    for (skipped_installed_names.items) |name| {
+        if (!manifest.contains(name)) {
+            manifest.add(name) catch continue;
+            manifest_dirty = true;
+        }
+    }
+    if (manifest_dirty) {
+        manifest.writeAtomic(allocator, manifest_path) catch |e| {
+            output.warn("Resume manifest self-heal write failed: {s}", .{@errorName(e)});
+        };
     }
 
     // ── Step 5: Report ──────────────────────────────────────────────

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -21,10 +21,15 @@ const codesign = @import("../macho/codesign.zig");
 const help = @import("help.zig");
 const keg_mod = @import("migrate/keg.zig");
 const manifest_mod = @import("migrate/manifest.zig");
+const parallel_mod = @import("migrate/parallel.zig");
 
 const KegResult = keg_mod.KegResult;
 const MigrateDeps = keg_mod.MigrateDeps;
 const migrateKeg = keg_mod.migrateKeg;
+
+/// Test seam — pins dispatch decisions without relying on observable
+/// side-effects. Reset on every `execute` entry.
+pub var last_run_parallel: bool = false;
 
 /// Resolve the Homebrew install prefix. Respects `HOMEBREW_PREFIX` (set
 /// by `brew shellenv` and by users with a non-standard install), falls
@@ -66,6 +71,8 @@ pub fn scanCellarKegs(
 pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(args, "migrate")) return;
 
+    last_run_parallel = false;
+
     const start_ts = fs_compat.milliTimestamp();
     const json_mode = output.isJson();
     var dry_run = output.isDryRun();
@@ -73,10 +80,12 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     // whole `migrate` would widen the trust boundary to every
     // Homebrew-Cellar entry at once; refuse it and require names.
     var use_system_ruby_bare = false;
+    var parallel_flag = false;
     var use_system_ruby_scope: std.ArrayList([]const u8) = .empty;
     defer use_system_ruby_scope.deinit(allocator);
     for (args) |arg| {
         if (std.mem.eql(u8, arg, "--dry-run")) dry_run = true;
+        if (std.mem.eql(u8, arg, "--parallel")) parallel_flag = true;
         if (std.mem.eql(u8, arg, "--use-system-ruby")) use_system_ruby_bare = true;
         if (std.mem.startsWith(u8, arg, "--use-system-ruby=")) {
             const list = arg["--use-system-ruby=".len..];
@@ -233,7 +242,64 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         return;
     }
 
-    for (keg_names.items) |keg_name| {
+    if (parallel_flag) {
+        last_run_parallel = true;
+
+        const worker_count = parallel_mod.boundWorkerCount(
+            parallel_mod.workerCountFromLiveEnv(),
+            keg_names.items.len,
+        );
+
+        // Borrowed clients keep TLS contexts warm across kegs without
+        // paying a fresh handshake per worker.
+        var http_pool = client_mod.HttpClientPool.init(allocator, @intCast(@max(worker_count, 1))) catch {
+            output.err("Failed to initialise HTTP client pool", .{});
+            return error.Aborted;
+        };
+        defer http_pool.deinit();
+
+        var db_mu: std.Io.Mutex = .init;
+        var manifest_mu: std.Io.Mutex = .init;
+
+        const outcomes = try allocator.alloc(parallel_mod.KegOutcome, keg_names.items.len);
+        defer allocator.free(outcomes);
+        // Pre-populated so an interrupted/short-circuited slot still has a defined outcome.
+        for (outcomes, 0..) |*o, i| o.* = .{ .name = keg_names.items[i], .result = .skipped_installed };
+
+        var pool: parallel_mod.Pool = .{
+            .next_idx = std.atomic.Value(usize).init(0),
+            .keg_names = keg_names.items,
+            .outcomes = outcomes,
+            .cache_dir = cache_dir,
+            .prefix = prefix,
+            .use_system_ruby_scope = use_system_ruby_scope.items,
+            .http_pool = &http_pool,
+            .store = &store,
+            .linker = &linker,
+            .db = &db,
+            .db_mu = &db_mu,
+            .manifest = &manifest,
+            .manifest_mu = &manifest_mu,
+            .manifest_path = manifest_path,
+            .manifest_allocator = allocator,
+        };
+        try parallel_mod.run(allocator, &pool, worker_count);
+        // Mirror the serial loop's interrupt UX so users running with
+        // --parallel still see "Interrupted" instead of silent skips.
+        if (main_mod.isInterrupted()) {
+            output.warn("Interrupted — skipping remaining kegs.", .{});
+        }
+
+        for (outcomes) |o| {
+            switch (o.result) {
+                .migrated => try migrated_names.append(allocator, o.name),
+                .skipped_installed => try skipped_installed_names.append(allocator, o.name),
+                .skipped_post_install => try skipped_post_install_names.append(allocator, o.name),
+                .skipped_no_bottle => try skipped_no_bottle_names.append(allocator, o.name),
+                .failed_api, .failed_download, .failed_install => try failed_names.append(allocator, o.name),
+            }
+        }
+    } else for (keg_names.items) |keg_name| {
         // Stop at the next keg boundary when the user hits Ctrl-C.
         if (main_mod.isInterrupted()) {
             output.warn("Interrupted — skipping remaining kegs.", .{});

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -1,0 +1,275 @@
+//! Per-keg migrate work + supporting DB helpers. Mirrors the
+//! `cli/install/{download,record}.zig` split: keep the wide-args
+//! per-item function out of the orchestrator so the entry-point file
+//! shrinks to flag parsing, scan, and dispatch.
+
+const std = @import("std");
+const sqlite = @import("../../db/sqlite.zig");
+const formula_mod = @import("../../core/formula.zig");
+const bottle_mod = @import("../../core/bottle.zig");
+const store_mod = @import("../../core/store.zig");
+const cellar_mod = @import("../../core/cellar.zig");
+const linker_mod = @import("../../core/linker.zig");
+const client_mod = @import("../../net/client.zig");
+const ghcr_mod = @import("../../net/ghcr.zig");
+const api_mod = @import("../../net/api.zig");
+const atomic = @import("../../fs/atomic.zig");
+const output = @import("../../ui/output.zig");
+const post_install_mod = @import("../install/post_install.zig");
+
+/// Result of migrating a single keg.
+pub const KegResult = enum {
+    migrated,
+    skipped_installed,
+    skipped_post_install,
+    skipped_no_bottle,
+    failed_api,
+    failed_download,
+    failed_install,
+};
+
+/// Named-field bundle for the shared state `migrateKeg` threads across
+/// every keg in the loop. Opens a DI seam for tests to swap in fakes.
+pub const MigrateDeps = struct {
+    api: *api_mod.BrewApi,
+    ghcr: *ghcr_mod.GhcrClient,
+    http: *client_mod.HttpClient,
+    store: *store_mod.Store,
+    linker: *linker_mod.Linker,
+    db: *sqlite.Database,
+    prefix: []const u8,
+    use_system_ruby_scope: []const []const u8,
+};
+
+/// Migrate a single keg from Homebrew into malt.
+pub fn migrateKeg(
+    allocator: std.mem.Allocator,
+    keg_name: []const u8,
+    deps: MigrateDeps,
+) KegResult {
+    if (isInstalled(deps.db, keg_name)) {
+        output.info("  {s}: already installed, skipping", .{keg_name});
+        return .skipped_installed;
+    }
+
+    // Two `defer`s below collapse six per-branch cleanups.
+    const formula_json = deps.api.fetchFormula(keg_name) catch {
+        output.err("  {s}: not found in Homebrew API", .{keg_name});
+        return .failed_api;
+    };
+    defer allocator.free(formula_json);
+
+    var formula = formula_mod.parseFormula(allocator, formula_json) catch {
+        output.err("  {s}: failed to parse formula JSON", .{keg_name});
+        return .failed_api;
+    };
+    defer formula.deinit();
+
+    const bottle = formula_mod.resolveBottle(allocator, &formula) catch {
+        output.warn("  {s}: no bottle available for this platform", .{keg_name});
+        return .skipped_no_bottle;
+    };
+    output.emitNdjsonEvent(allocator, .resolved, keg_name, null);
+
+    output.info("  Migrating {s} {s}...", .{ formula.name, formula.version });
+
+    if (!deps.store.exists(bottle.sha256)) {
+        if (!downloadBottle(allocator, deps.ghcr, deps.http, deps.store, bottle.url, bottle.sha256, keg_name)) {
+            return .failed_download;
+        }
+    } else {
+        output.info("    {s} (cached in store)", .{keg_name});
+    }
+    if (output.isNdjson()) {
+        output.emitNdjsonEvent(allocator, .downloaded, keg_name, "ok");
+        output.emitNdjsonEvent(allocator, .extracted, keg_name, "ok");
+        output.emitNdjsonEvent(allocator, .stored, keg_name, "ok");
+    }
+
+    deps.store.incrementRef(bottle.sha256) catch |e| {
+        std.log.warn("refcount increment failed for {s}: {s}", .{ keg_name, @errorName(e) });
+    };
+
+    const keg = cellar_mod.materialize(
+        allocator,
+        deps.prefix,
+        bottle.sha256,
+        formula.name,
+        formula.pkg_version,
+    ) catch {
+        output.err("    {s}: failed to materialize", .{keg_name});
+        output.emitNdjsonEvent(allocator, .materialized, keg_name, "failed");
+        return .failed_install;
+    };
+    output.emitNdjsonEvent(allocator, .materialized, keg_name, "ok");
+
+    if (!formula.keg_only) {
+        const keg_id = recordKeg(deps.db, &formula, bottle.sha256, keg.path, "direct") catch {
+            output.err("    {s}: failed to record in database", .{keg_name});
+            cellar_mod.remove(deps.prefix, formula.name, formula.pkg_version) catch {};
+            return .failed_install;
+        };
+
+        deps.linker.link(keg.path, formula.name, keg_id) catch {
+            output.warn("    {s}: some links could not be created", .{keg_name});
+            output.emitNdjsonEvent(allocator, .linked, keg_name, "failed");
+            // Rollback: unlink partial links and delete keg row; user already warned above.
+            deps.linker.unlink(keg_id) catch {};
+            deleteKeg(deps.db, keg_id) catch {};
+            cellar_mod.remove(deps.prefix, formula.name, formula.pkg_version) catch {};
+            return .failed_install;
+        };
+        // `recorded` after both succeed — link rollback above undoes
+        // the keg row, so an early emit would lie if link fails.
+        output.emitNdjsonEvent(allocator, .linked, keg_name, "ok");
+        output.emitNdjsonEvent(allocator, .recorded, keg_name, "ok");
+        deps.linker.linkOpt(formula.name, formula.pkg_version) catch {};
+        recordDeps(deps.db, keg_id, &formula);
+    } else {
+        const keg_id = recordKeg(deps.db, &formula, bottle.sha256, keg.path, "direct") catch {
+            cellar_mod.remove(deps.prefix, formula.name, formula.pkg_version) catch {};
+            return .failed_install;
+        };
+        output.emitNdjsonEvent(allocator, .recorded, keg_name, "ok");
+        deps.linker.linkOpt(formula.name, formula.pkg_version) catch {};
+        recordDeps(deps.db, keg_id, &formula);
+    }
+
+    if (formula.post_install_defined) {
+        post_install_mod.drive(
+            allocator,
+            formula.name,
+            formula.pkg_version,
+            formula_json,
+            deps.prefix,
+            deps.use_system_ruby_scope,
+        );
+    }
+
+    const keg_only_suffix: []const u8 = if (formula.keg_only) " (keg-only — dependency only)" else "";
+    output.success("  {s} {s} migrated{s}", .{ formula.name, formula.version, keg_only_suffix });
+    return .migrated;
+}
+
+/// Download a bottle from GHCR and commit to the store.
+fn downloadBottle(
+    allocator: std.mem.Allocator,
+    ghcr: *ghcr_mod.GhcrClient,
+    http: *client_mod.HttpClient,
+    store: *store_mod.Store,
+    bottle_url: []const u8,
+    sha256: []const u8,
+    name: []const u8,
+) bool {
+    const ghcr_prefix_str = "https://ghcr.io/v2/";
+    var repo_buf: [256]u8 = undefined;
+    var digest_buf: [128]u8 = undefined;
+
+    if (!std.mem.startsWith(u8, bottle_url, ghcr_prefix_str)) {
+        output.err("    {s}: unsupported bottle URL", .{name});
+        return false;
+    }
+
+    const path = bottle_url[ghcr_prefix_str.len..];
+    const blobs_pos = std.mem.indexOf(u8, path, "/blobs/") orelse {
+        output.err("    {s}: malformed bottle URL", .{name});
+        return false;
+    };
+
+    const repo = std.fmt.bufPrint(&repo_buf, "{s}", .{path[0..blobs_pos]}) catch return false;
+    const digest = std.fmt.bufPrint(&digest_buf, "{s}", .{path[blobs_pos + "/blobs/".len ..]}) catch return false;
+
+    const tmp_dir = atomic.createTempDir(allocator, name) catch return false;
+
+    output.info("    Downloading {s}...", .{name});
+
+    _ = bottle_mod.download(allocator, ghcr, http, repo, digest, sha256, tmp_dir, null) catch {
+        output.err("    Download failed: {s}", .{name});
+        atomic.cleanupTempDir(tmp_dir);
+        allocator.free(tmp_dir);
+        return false;
+    };
+
+    store.commitFrom(sha256, tmp_dir) catch {
+        output.err("    Store commit failed: {s}", .{name});
+        atomic.cleanupTempDir(tmp_dir);
+        allocator.free(tmp_dir);
+        return false;
+    };
+    allocator.free(tmp_dir);
+    return true;
+}
+
+// ── DB helpers (same pattern as install.zig) ────────────────────────
+
+fn recordKeg(
+    db: *sqlite.Database,
+    formula: *const formula_mod.Formula,
+    store_sha256: []const u8,
+    cellar_path: []const u8,
+    install_reason: []const u8,
+) !i64 {
+    db.beginTransaction() catch return error.RecordFailed;
+    errdefer db.rollback();
+
+    // The COALESCE on `pinned` carries any existing user pin across
+    // INSERT OR REPLACE so re-migrating doesn't silently drop holds.
+    var stmt = db.prepare(
+        "INSERT OR REPLACE INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason, pinned)" ++
+            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, COALESCE((SELECT MAX(pinned) FROM kegs WHERE name = ?1), 0));",
+    ) catch return error.RecordFailed;
+    defer stmt.finalize();
+
+    stmt.bindText(1, formula.name) catch return error.RecordFailed;
+    stmt.bindText(2, formula.full_name) catch return error.RecordFailed;
+    stmt.bindText(3, formula.version) catch return error.RecordFailed;
+    stmt.bindInt(4, formula.revision) catch return error.RecordFailed;
+    stmt.bindText(5, formula.tap) catch return error.RecordFailed;
+    stmt.bindText(6, store_sha256) catch return error.RecordFailed;
+    stmt.bindText(7, cellar_path) catch return error.RecordFailed;
+    stmt.bindText(8, install_reason) catch return error.RecordFailed;
+
+    _ = stmt.step() catch return error.RecordFailed;
+
+    const keg_id = getLastInsertId(db) catch return error.RecordFailed;
+    db.commit() catch return error.RecordFailed;
+
+    return keg_id;
+}
+
+fn deleteKeg(db: *sqlite.Database, keg_id: i64) sqlite.SqliteError!void {
+    var stmt = try db.prepare("DELETE FROM kegs WHERE id = ?1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, keg_id);
+    _ = try stmt.step();
+}
+
+/// Each row is independent; skip on per-row failure so a partial dep
+/// table is preferred to aborting a migration wholesale.
+fn recordDeps(db: *sqlite.Database, keg_id: i64, formula: *const formula_mod.Formula) void {
+    for (formula.dependencies) |dep_name| {
+        var stmt = db.prepare(
+            "INSERT OR IGNORE INTO dependencies (keg_id, dep_name, dep_type) VALUES (?1, ?2, 'runtime');",
+        ) catch continue;
+        defer stmt.finalize();
+
+        stmt.bindInt(1, keg_id) catch continue;
+        stmt.bindText(2, dep_name) catch continue;
+        _ = stmt.step() catch {};
+    }
+}
+
+fn getLastInsertId(db: *sqlite.Database) !i64 {
+    var stmt = db.prepare("SELECT last_insert_rowid();") catch return error.RecordFailed;
+    defer stmt.finalize();
+    const has_row = stmt.step() catch return error.RecordFailed;
+    if (!has_row) return error.RecordFailed;
+    return stmt.columnInt(0);
+}
+
+fn isInstalled(db: *sqlite.Database, name: []const u8) bool {
+    var stmt = db.prepare("SELECT id FROM kegs WHERE name = ?1 LIMIT 1;") catch return false;
+    defer stmt.finalize();
+    stmt.bindText(1, name) catch return false;
+    return stmt.step() catch false;
+}

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -267,7 +267,7 @@ fn getLastInsertId(db: *sqlite.Database) !i64 {
     return stmt.columnInt(0);
 }
 
-fn isInstalled(db: *sqlite.Database, name: []const u8) bool {
+pub fn isInstalled(db: *sqlite.Database, name: []const u8) bool {
     var stmt = db.prepare("SELECT id FROM kegs WHERE name = ?1 LIMIT 1;") catch return false;
     defer stmt.finalize();
     stmt.bindText(1, name) catch return false;

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -16,6 +16,7 @@ const api_mod = @import("../../net/api.zig");
 const atomic = @import("../../fs/atomic.zig");
 const output = @import("../../ui/output.zig");
 const post_install_mod = @import("../install/post_install.zig");
+const io_mod = @import("../../ui/io.zig");
 
 /// Result of migrating a single keg.
 pub const KegResult = enum {
@@ -39,6 +40,9 @@ pub const MigrateDeps = struct {
     db: *sqlite.Database,
     prefix: []const u8,
     use_system_ruby_scope: []const []const u8,
+    /// Set by the parallel runner; null on the serial path so the
+    /// default flow pays no lock cost.
+    db_mu: ?*std.Io.Mutex = null,
 };
 
 /// Migrate a single keg from Homebrew into malt.
@@ -102,6 +106,12 @@ pub fn migrateKeg(
         return .failed_install;
     };
     output.emitNdjsonEvent(allocator, .materialized, keg_name, "ok");
+
+    // Workers serialise on `db_mu` so transactions can't interleave;
+    // serial callers leave `db_mu` null and pay no lock cost.
+    const io_ctx = io_mod.ctx();
+    if (deps.db_mu) |m| m.lockUncancelable(io_ctx);
+    defer if (deps.db_mu) |m| m.unlock(io_ctx);
 
     if (!formula.keg_only) {
         const keg_id = recordKeg(deps.db, &formula, bottle.sha256, keg.path, "direct") catch {

--- a/src/cli/migrate/manifest.zig
+++ b/src/cli/migrate/manifest.zig
@@ -1,0 +1,176 @@
+//! Resume manifest for `mt migrate`. Records successfully migrated keg
+//! names so a re-run after crash, ^C, or partial failure skips work
+//! already done. Append-on-success — durability matters more than
+//! shrinking the file when an entry is rolled back.
+
+const std = @import("std");
+const fs_compat = @import("../../fs/compat.zig");
+const atomic = @import("../../fs/atomic.zig");
+const output = @import("../../ui/output.zig");
+
+/// Bounds adversarial / corrupt files at parse time (8 MiB ≫ any real
+/// migrate manifest).
+pub const max_manifest_bytes: usize = 8 * 1024 * 1024;
+
+/// Owns its strings via the caller's allocator so lifetime is explicit.
+pub const Manifest = struct {
+    allocator: std.mem.Allocator,
+    entries: std.ArrayList([]u8) = .empty,
+
+    pub fn init(allocator: std.mem.Allocator) Manifest {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *Manifest) void {
+        for (self.entries.items) |e| self.allocator.free(e);
+        self.entries.deinit(self.allocator);
+    }
+
+    /// True iff `name` is recorded as completed.
+    pub fn contains(self: *const Manifest, name: []const u8) bool {
+        for (self.entries.items) |e| {
+            if (std.mem.eql(u8, e, name)) return true;
+        }
+        return false;
+    }
+
+    /// Add `name` to the in-memory set. Idempotent: a duplicate add is a no-op.
+    pub fn add(self: *Manifest, name: []const u8) !void {
+        if (self.contains(name)) return;
+        const owned = try self.allocator.dupe(u8, name);
+        errdefer self.allocator.free(owned);
+        try self.entries.append(self.allocator, owned);
+    }
+
+    /// Borrowed view of the completed names. Slices alias `entries`.
+    pub fn names(self: *const Manifest) []const []const u8 {
+        // ArrayList([]u8) → []const []const u8 — same layout, narrower view.
+        return @ptrCast(self.entries.items);
+    }
+
+    /// Crash-safe rewrite via tempfile + rename: readers see old or new, never partial.
+    pub fn writeAtomic(self: *const Manifest, allocator: std.mem.Allocator, path: []const u8) !void {
+        var aw: std.Io.Writer.Allocating = .init(allocator);
+        defer aw.deinit();
+        try writeJson(&aw.writer, self.names());
+        try atomic.atomicWriteFile(path, aw.written());
+    }
+};
+
+/// Bump when a future change isn't backward-readable; older binaries
+/// refuse to load rather than mis-parse.
+pub const schema_version: u32 = 1;
+
+/// Empty-file and missing-key cases both yield an empty manifest so
+/// first-run callers don't need to special-case them.
+pub fn parseJson(allocator: std.mem.Allocator, bytes: []const u8) !Manifest {
+    var m = Manifest.init(allocator);
+    errdefer m.deinit();
+
+    const trimmed = std.mem.trim(u8, bytes, " \t\r\n");
+    if (trimmed.len == 0) return m;
+
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{}) catch
+        return error.InvalidManifest;
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidManifest;
+    const root = parsed.value.object;
+
+    if (root.get("version")) |v| {
+        if (v != .integer or v.integer != schema_version) {
+            return error.UnsupportedManifestVersion;
+        }
+    }
+
+    const completed = root.get("completed") orelse return m;
+    if (completed != .array) return error.InvalidManifest;
+    for (completed.array.items) |entry| {
+        if (entry != .string) return error.InvalidManifest;
+        try m.add(entry.string);
+    }
+    return m;
+}
+
+/// Reuses `output.jsonStringArray` so manifest and migrate-summary JSON
+/// share one escape implementation and can't drift apart.
+pub fn writeJson(w: *std.Io.Writer, names: []const []const u8) !void {
+    try w.print("{{\"version\":{d},\"completed\":", .{schema_version});
+    try output.jsonStringArray(w, names);
+    try w.writeAll("}\n");
+}
+
+/// Missing file is treated as empty so first-run callers don't need
+/// to special-case it.
+pub fn loadFromPath(allocator: std.mem.Allocator, path: []const u8) !Manifest {
+    const bytes = fs_compat.readFileAbsoluteAlloc(allocator, path, max_manifest_bytes) catch |err| switch (err) {
+        error.FileNotFound => return Manifest.init(allocator),
+        else => return err,
+    };
+    defer allocator.free(bytes);
+    return parseJson(allocator, bytes);
+}
+
+// ── Pure-helper unit tests ──────────────────────────────────────────
+
+test "Manifest.contains is false before any add and true after" {
+    var m = Manifest.init(std.testing.allocator);
+    defer m.deinit();
+    try std.testing.expect(!m.contains("foo"));
+    try m.add("foo");
+    try std.testing.expect(m.contains("foo"));
+    try std.testing.expect(!m.contains("bar"));
+}
+
+test "Manifest.add is idempotent" {
+    var m = Manifest.init(std.testing.allocator);
+    defer m.deinit();
+    try m.add("foo");
+    try m.add("foo");
+    try std.testing.expectEqual(@as(usize, 1), m.entries.items.len);
+}
+
+test "writeJson emits version + completed array" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    const names = [_][]const u8{ "tree", "wget" };
+    try writeJson(&aw.writer, &names);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try std.testing.expectEqual(@as(i64, 1), root.get("version").?.integer);
+    const arr = root.get("completed").?.array;
+    try std.testing.expectEqual(@as(usize, 2), arr.items.len);
+    try std.testing.expectEqualStrings("tree", arr.items[0].string);
+    try std.testing.expectEqualStrings("wget", arr.items[1].string);
+}
+
+test "parseJson round-trips writeJson" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    const names = [_][]const u8{ "foo", "bar", "baz" };
+    try writeJson(&aw.writer, &names);
+
+    var m = try parseJson(std.testing.allocator, aw.written());
+    defer m.deinit();
+    try std.testing.expect(m.contains("foo"));
+    try std.testing.expect(m.contains("bar"));
+    try std.testing.expect(m.contains("baz"));
+    try std.testing.expect(!m.contains("missing"));
+}
+
+test "parseJson tolerates empty input as empty manifest" {
+    var m = try parseJson(std.testing.allocator, "");
+    defer m.deinit();
+    try std.testing.expect(!m.contains("anything"));
+}
+
+test "parseJson rejects future schema versions" {
+    const m_or_err = parseJson(std.testing.allocator, "{\"version\":99,\"completed\":[]}");
+    try std.testing.expectError(error.UnsupportedManifestVersion, m_or_err);
+}
+
+test "parseJson surfaces invalid JSON as an error rather than silently dropping it" {
+    const m_or_err = parseJson(std.testing.allocator, "not json");
+    try std.testing.expectError(error.InvalidManifest, m_or_err);
+}

--- a/src/cli/migrate/parallel.zig
+++ b/src/cli/migrate/parallel.zig
@@ -1,0 +1,197 @@
+//! Bounded worker pool for `mt migrate --parallel`. Workers do the
+//! per-keg migrate work concurrently; sqlite writes serialise through
+//! a shared mutex so transactions stay atomic across threads.
+
+const std = @import("std");
+const fs_compat = @import("../../fs/compat.zig");
+const sqlite = @import("../../db/sqlite.zig");
+const store_mod = @import("../../core/store.zig");
+const linker_mod = @import("../../core/linker.zig");
+const client_mod = @import("../../net/client.zig");
+const ghcr_mod = @import("../../net/ghcr.zig");
+const api_mod = @import("../../net/api.zig");
+const output = @import("../../ui/output.zig");
+const main_mod = @import("../../main.zig");
+const io_mod = @import("../../ui/io.zig");
+const keg_mod = @import("keg.zig");
+const manifest_mod = @import("manifest.zig");
+
+/// 4 matches the install-side HTTP client pool; higher just queues on TLS contexts.
+pub const default_workers: u32 = 4;
+
+/// Bound stack/FD usage under hostile env values.
+pub const max_workers: u32 = 32;
+
+/// Clamps to `[1, max_workers]` so a typo never spawns hundreds of threads.
+/// Takes the env reading via the caller so tests pin behaviour without `setenv`.
+pub fn workerCountFromEnv(env_value: ?[]const u8) u32 {
+    const raw = env_value orelse return default_workers;
+    const trimmed = std.mem.trim(u8, raw, " \t");
+    if (trimmed.len == 0) return default_workers;
+    const parsed = std.fmt.parseInt(u32, trimmed, 10) catch return default_workers;
+    return std.math.clamp(parsed, 1, max_workers);
+}
+
+/// Read `MALT_MIGRATE_PARALLEL_WORKERS` from the live environment.
+pub fn workerCountFromLiveEnv() u32 {
+    return workerCountFromEnv(fs_compat.getenv("MALT_MIGRATE_PARALLEL_WORKERS"));
+}
+
+/// Extra threads beyond the job count would just spin on an empty queue.
+pub fn boundWorkerCount(requested: u32, jobs: usize) u32 {
+    if (jobs == 0) return 0;
+    const j: u32 = if (jobs > max_workers) max_workers else @intCast(jobs);
+    return @min(requested, j);
+}
+
+/// Outcome plus name so the orchestrator can drain into the same
+/// per-category lists the serial path uses.
+pub const KegOutcome = struct {
+    name: []const u8,
+    result: keg_mod.KegResult,
+};
+
+/// Workers download+materialise lock-free; `db_mu` and `manifest_mu`
+/// serialise the post-success persistence so concurrent successes can
+/// flush without racing.
+pub const Pool = struct {
+    next_idx: std.atomic.Value(usize),
+    keg_names: []const []const u8,
+    outcomes: []KegOutcome,
+
+    cache_dir: []const u8,
+    prefix: []const u8,
+    use_system_ruby_scope: []const []const u8,
+
+    http_pool: *client_mod.HttpClientPool,
+    store: *store_mod.Store,
+    linker: *linker_mod.Linker,
+    db: *sqlite.Database,
+    db_mu: *std.Io.Mutex,
+
+    manifest: *manifest_mod.Manifest,
+    manifest_mu: *std.Io.Mutex,
+    manifest_path: []const u8,
+    manifest_allocator: std.mem.Allocator,
+};
+
+/// Per-iteration arena + borrowed http client matches the per-worker
+/// pattern in `cli/install/download.zig` so TLS contexts stay warm
+/// without sharing mutable state across threads.
+fn worker(pool: *Pool) void {
+    while (true) {
+        const idx = pool.next_idx.fetchAdd(1, .acq_rel);
+        if (idx >= pool.keg_names.len) return;
+        const keg_name = pool.keg_names[idx];
+
+        if (main_mod.isInterrupted()) {
+            pool.outcomes[idx] = .{ .name = keg_name, .result = .skipped_installed };
+            continue;
+        }
+
+        const io_ctx = io_mod.ctx();
+        pool.manifest_mu.lockUncancelable(io_ctx);
+        const in_manifest = pool.manifest.contains(keg_name);
+        pool.manifest_mu.unlock(io_ctx);
+        // DB cross-check guards against a stale manifest after `mt
+        // uninstall` — see the matching note in cli/migrate.zig.
+        if (in_manifest and keg_mod.isInstalled(pool.db, keg_name)) {
+            pool.outcomes[idx] = .{ .name = keg_name, .result = .skipped_installed };
+            continue;
+        }
+
+        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        const http = pool.http_pool.acquire();
+        defer pool.http_pool.release(http);
+        var api = api_mod.BrewApi.init(a, http, pool.cache_dir);
+        var ghcr = ghcr_mod.GhcrClient.init(a, http);
+        defer ghcr.deinit();
+
+        const result = keg_mod.migrateKeg(a, keg_name, .{
+            .api = &api,
+            .ghcr = &ghcr,
+            .http = http,
+            .store = pool.store,
+            .linker = pool.linker,
+            .db = pool.db,
+            .prefix = pool.prefix,
+            .use_system_ruby_scope = pool.use_system_ruby_scope,
+            .db_mu = pool.db_mu,
+        });
+        pool.outcomes[idx] = .{ .name = keg_name, .result = result };
+
+        if (result == .migrated) {
+            pool.manifest_mu.lockUncancelable(io_ctx);
+            pool.manifest.add(keg_name) catch |e| {
+                output.warn("Resume manifest update failed for {s}: {s}", .{ keg_name, @errorName(e) });
+            };
+            pool.manifest.writeAtomic(pool.manifest_allocator, pool.manifest_path) catch |e| {
+                output.warn("Resume manifest write failed: {s}", .{@errorName(e)});
+            };
+            pool.manifest_mu.unlock(io_ctx);
+        }
+    }
+}
+
+/// Falls back to inline drain on spawn failure so a thread-spawn refusal
+/// still completes the queue — same defensive pattern as `MaterializePool`.
+pub fn run(allocator: std.mem.Allocator, pool: *Pool, worker_count: u32) !void {
+    if (pool.keg_names.len == 0) return;
+
+    const threads = allocator.alloc(std.Thread, worker_count) catch {
+        // Fall back to inline drain — single-threaded, but correct.
+        worker(pool);
+        return;
+    };
+    defer allocator.free(threads);
+
+    var spawned: usize = 0;
+    var i: usize = 0;
+    while (i < worker_count) : (i += 1) {
+        if (std.Thread.spawn(.{}, worker, .{pool})) |t| {
+            threads[spawned] = t;
+            spawned += 1;
+        } else |_| {
+            worker(pool);
+        }
+    }
+    for (threads[0..spawned]) |t| t.join();
+}
+
+// ── Inline unit tests ──────────────────────────────────────────────
+
+test "workerCountFromEnv returns default when env is null" {
+    try std.testing.expectEqual(default_workers, workerCountFromEnv(null));
+}
+
+test "workerCountFromEnv returns default on empty / whitespace" {
+    try std.testing.expectEqual(default_workers, workerCountFromEnv(""));
+    try std.testing.expectEqual(default_workers, workerCountFromEnv("   "));
+}
+
+test "workerCountFromEnv parses a numeric value" {
+    try std.testing.expectEqual(@as(u32, 8), workerCountFromEnv("8"));
+    try std.testing.expectEqual(@as(u32, 1), workerCountFromEnv("1"));
+}
+
+test "workerCountFromEnv falls back to default on garbage" {
+    try std.testing.expectEqual(default_workers, workerCountFromEnv("not-a-number"));
+    try std.testing.expectEqual(default_workers, workerCountFromEnv("4abc"));
+}
+
+test "workerCountFromEnv clamps to max_workers ceiling" {
+    try std.testing.expectEqual(max_workers, workerCountFromEnv("9999"));
+}
+
+test "workerCountFromEnv clamps zero to one (a 0-thread pool would deadlock)" {
+    try std.testing.expectEqual(@as(u32, 1), workerCountFromEnv("0"));
+}
+
+test "boundWorkerCount caps by job count" {
+    try std.testing.expectEqual(@as(u32, 2), boundWorkerCount(4, 2));
+    try std.testing.expectEqual(@as(u32, 4), boundWorkerCount(4, 10));
+    try std.testing.expectEqual(@as(u32, 0), boundWorkerCount(4, 0));
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -48,6 +48,7 @@ pub const cli_services = @import("cli/services.zig");
 pub const cli_bundle = @import("cli/bundle.zig");
 pub const cli_help = @import("cli/help.zig");
 pub const cli_migrate = @import("cli/migrate.zig");
+pub const cli_migrate_manifest = @import("cli/migrate/manifest.zig");
 pub const cli_info = @import("cli/info.zig");
 pub const cli_uses = @import("cli/uses.zig");
 pub const cli_which = @import("cli/which.zig");

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -49,6 +49,7 @@ pub const cli_bundle = @import("cli/bundle.zig");
 pub const cli_help = @import("cli/help.zig");
 pub const cli_migrate = @import("cli/migrate.zig");
 pub const cli_migrate_manifest = @import("cli/migrate/manifest.zig");
+pub const cli_migrate_parallel = @import("cli/migrate/parallel.zig");
 pub const cli_info = @import("cli/info.zig");
 pub const cli_uses = @import("cli/uses.zig");
 pub const cli_which = @import("cli/which.zig");

--- a/tests/migrate_manifest_test.zig
+++ b/tests/migrate_manifest_test.zig
@@ -1,0 +1,68 @@
+//! File-IO tests for the `cli/migrate/manifest.zig` module — exercise
+//! the load/atomic-write loop against /tmp scratch paths. Pure parser
+//! / encoder tests live inline in the module itself; anything that
+//! touches the filesystem lives here.
+
+const std = @import("std");
+const malt = @import("malt");
+const testing = std.testing;
+const manifest = malt.cli_migrate_manifest;
+const fs_compat = malt.fs_compat;
+
+fn scratchManifestPath(suffix: []const u8) ![:0]u8 {
+    return std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "/tmp/mt_manifest_{d}_{s}.json",
+        .{ fs_compat.nanoTimestamp(), suffix },
+        0,
+    );
+}
+
+test "loadFromPath returns an empty manifest when the file does not exist" {
+    const path = try scratchManifestPath("missing");
+    defer testing.allocator.free(path);
+    fs_compat.deleteFileAbsolute(path) catch {};
+
+    var m = try manifest.loadFromPath(testing.allocator, path);
+    defer m.deinit();
+    try testing.expectEqual(@as(usize, 0), m.entries.items.len);
+}
+
+test "writeAtomic + loadFromPath round-trip the completed list" {
+    const path = try scratchManifestPath("roundtrip");
+    defer testing.allocator.free(path);
+    defer fs_compat.deleteFileAbsolute(path) catch {};
+
+    var m = manifest.Manifest.init(testing.allocator);
+    defer m.deinit();
+    try m.add("foo");
+    try m.add("bar");
+    try m.writeAtomic(testing.allocator, path);
+
+    var loaded = try manifest.loadFromPath(testing.allocator, path);
+    defer loaded.deinit();
+    try testing.expect(loaded.contains("foo"));
+    try testing.expect(loaded.contains("bar"));
+    try testing.expect(!loaded.contains("baz"));
+}
+
+test "writeAtomic over an existing file replaces its contents" {
+    const path = try scratchManifestPath("replace");
+    defer testing.allocator.free(path);
+    defer fs_compat.deleteFileAbsolute(path) catch {};
+
+    var first = manifest.Manifest.init(testing.allocator);
+    defer first.deinit();
+    try first.add("only-first");
+    try first.writeAtomic(testing.allocator, path);
+
+    var second = manifest.Manifest.init(testing.allocator);
+    defer second.deinit();
+    try second.add("only-second");
+    try second.writeAtomic(testing.allocator, path);
+
+    var loaded = try manifest.loadFromPath(testing.allocator, path);
+    defer loaded.deinit();
+    try testing.expect(!loaded.contains("only-first"));
+    try testing.expect(loaded.contains("only-second"));
+}

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -1139,6 +1139,220 @@ test "resume manifest: pre-seeded keg is skipped before any API call" {
     try testing.expectEqualStrings("unknownpkg", failed.items[0].string);
 }
 
+// ── --parallel flag ────────────────────────────────────────────────
+//
+// `--parallel` activates the bounded worker pool. The flag must:
+//   * never fail to parse (smoke for the new flag plumbing),
+//   * not break dry-run (dry-run wins regardless of --parallel),
+//   * preserve the resume contract (manifest entries still skipped),
+//   * deliver the same outcomes as serial when no real network work
+//     is needed (already-installed + manifest-skipped paths).
+
+test "--parallel --dry-run lists kegs and never starts the pool" {
+    resetOutput();
+    const brew = try scratchDir("brew_par_dry");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt = try scratchDir("mt_par_dry");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(mt) catch {};
+        testing.allocator.free(mt);
+    }
+    try seedFakeBrew(brew, &.{ "tree", "wget" });
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    output.setMode(.json);
+    defer resetOutput();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{ "--parallel", "--dry-run" });
+
+    const parsed = try parseAndCheck(buf.items);
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try testing.expect(root.get("dry_run").?.bool);
+    try testing.expectEqual(@as(i64, 2), root.get("count").?.integer);
+}
+
+test "--parallel sets the dispatch flag before falling through to skip-only paths" {
+    resetOutput();
+    defer migrate.last_run_parallel = false;
+
+    const brew = try scratchDir("brew_par_dispatch");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt_z: [:0]const u8 = "/tmp/mt_pd";
+    malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+    try malt.fs_compat.cwd().makePath(mt_z);
+    defer malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+
+    try seedFakeBrew(brew, &.{"k"});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Seed manifest so the only keg short-circuits, keeping the test offline.
+    const cache_dir = try std.fmt.allocPrint(testing.allocator, "{s}/cache", .{mt_z});
+    defer testing.allocator.free(cache_dir);
+    try malt.fs_compat.cwd().makePath(cache_dir);
+    var manifest = malt.cli_migrate_manifest.Manifest.init(testing.allocator);
+    defer manifest.deinit();
+    try manifest.add("k");
+    const manifest_path = try std.fmt.allocPrint(testing.allocator, "{s}/migrate.progress.json", .{cache_dir});
+    defer testing.allocator.free(manifest_path);
+    try manifest.writeAtomic(testing.allocator, manifest_path);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{ "--parallel", "--quiet" });
+
+    try testing.expect(migrate.last_run_parallel);
+}
+
+test "without --parallel the dispatch flag stays false" {
+    resetOutput();
+    migrate.last_run_parallel = false;
+    defer migrate.last_run_parallel = false;
+
+    const brew = try scratchDir("brew_par_serial");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt = try scratchDir("mt_par_serial");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(mt) catch {};
+        testing.allocator.free(mt);
+    }
+    try seedFakeBrew(brew, &.{});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{"--quiet"});
+
+    try testing.expect(!migrate.last_run_parallel);
+}
+
+test "--parallel honours the resume manifest the same way serial does" {
+    resetOutput();
+
+    const brew = try scratchDir("brew_par_resume");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+
+    const mt_z: [:0]const u8 = "/tmp/mt_pr";
+    malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+    try malt.fs_compat.cwd().makePath(mt_z);
+    defer malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+
+    try seedFakeBrew(brew, &.{ "k1", "k2", "k3" });
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Seed 404 markers for every keg so any reach-the-API behaviour
+    // terminates offline as failed_api rather than hanging the test.
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{mt_z});
+    defer testing.allocator.free(cache_api);
+    try malt.fs_compat.cwd().makePath(cache_api);
+    inline for (.{ "k1", "k2", "k3" }) |name| {
+        const m = try std.fmt.allocPrint(testing.allocator, "{s}/formula_{s}.404", .{ cache_api, name });
+        defer testing.allocator.free(m);
+        const f = try malt.fs_compat.cwd().createFile(m, .{});
+        f.close();
+    }
+
+    // Pre-seed all three kegs as completed in the resume manifest *and*
+    // in the DB — the skip path requires both to agree (see
+    // `cli/migrate.zig` stale-manifest note).
+    const cache_dir = try std.fmt.allocPrint(testing.allocator, "{s}/cache", .{mt_z});
+    defer testing.allocator.free(cache_dir);
+    try malt.fs_compat.cwd().makePath(cache_dir);
+    var manifest = malt.cli_migrate_manifest.Manifest.init(testing.allocator);
+    defer manifest.deinit();
+    try manifest.add("k1");
+    try manifest.add("k2");
+    try manifest.add("k3");
+    const manifest_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/migrate.progress.json",
+        .{cache_dir},
+    );
+    defer testing.allocator.free(manifest_path);
+    try manifest.writeAtomic(testing.allocator, manifest_path);
+
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt_z});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/malt.db", .{db_dir}, 0);
+    defer testing.allocator.free(db_path);
+    var db_seed = try malt.sqlite.Database.open(db_path);
+    try malt.schema.initSchema(&db_seed);
+    inline for (.{ "k1", "k2", "k3" }) |name| {
+        var s = try db_seed.prepare(
+            \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+            \\VALUES (?, ?, ?, ?, ?);
+        );
+        try s.bindText(1, name);
+        try s.bindText(2, name);
+        try s.bindText(3, "1.0");
+        try s.bindText(4, "0" ** 64);
+        try s.bindText(5, "/tmp/mt_pr/Cellar/" ++ name ++ "/1.0");
+        _ = try s.step();
+        s.finalize();
+    }
+    db_seed.close();
+
+    output.setMode(.json);
+    defer resetOutput();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    // Cap workers low so a cold/empty pool still exercises the spawn path.
+    _ = c.setenv("MALT_MIGRATE_PARALLEL_WORKERS", "2", 1);
+    defer _ = c.unsetenv("MALT_MIGRATE_PARALLEL_WORKERS");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{"--parallel"});
+
+    const parsed = try parseAndCheck(buf.items);
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    // All three kegs are recorded as already-completed via the manifest,
+    // so workers never reach the API — failed_names stays empty.
+    try testing.expectEqual(@as(usize, 3), root.get("skipped_installed").?.array.items.len);
+    try testing.expectEqual(@as(usize, 0), root.get("failed").?.array.items.len);
+}
+
 // ── Manifest contract on failure ───────────────────────────────────
 //
 // A failed keg must never end up in `migrate.progress.json`; otherwise
@@ -1246,6 +1460,10 @@ test "manifest preserves pre-existing entries across a run with new failures" {
     try testing.expect(loaded.contains("old"));
     try testing.expect(!loaded.contains("newfail"));
 }
+
+// `MALT_MIGRATE_PARALLEL_WORKERS` parses correctly in unit tests, but
+// the live-env path goes through `workerCountFromLiveEnv` — wire it
+// up here so a future refactor that broke the env name would fail.
 
 // Stale manifest (post-uninstall) must not silently skip a keg the user
 // expects to be re-migrated. Pre-seed the manifest with "ghost" but
@@ -1380,6 +1598,24 @@ test "manifest self-heals from DB-confirmed skips after a crash recovery" {
     var loaded = try malt.cli_migrate_manifest.loadFromPath(testing.allocator, manifest_path);
     defer loaded.deinit();
     try testing.expect(loaded.contains("recovered"));
+}
+
+test "MALT_MIGRATE_PARALLEL_WORKERS env wires through to the live helper" {
+    _ = c.setenv("MALT_MIGRATE_PARALLEL_WORKERS", "7", 1);
+    defer _ = c.unsetenv("MALT_MIGRATE_PARALLEL_WORKERS");
+    try testing.expectEqual(@as(u32, 7), malt.cli_migrate_parallel.workerCountFromLiveEnv());
+
+    _ = c.setenv("MALT_MIGRATE_PARALLEL_WORKERS", "9999", 1);
+    try testing.expectEqual(
+        malt.cli_migrate_parallel.max_workers,
+        malt.cli_migrate_parallel.workerCountFromLiveEnv(),
+    );
+
+    _ = c.unsetenv("MALT_MIGRATE_PARALLEL_WORKERS");
+    try testing.expectEqual(
+        malt.cli_migrate_parallel.default_workers,
+        malt.cli_migrate_parallel.workerCountFromLiveEnv(),
+    );
 }
 
 test "scanCellarKegs skips non-directory entries and survives fail-first iterator" {

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -1024,6 +1024,364 @@ test "scanCellarKegs warns and preserves prior names when iterator errors" {
     try testing.expect(containsLine(buf.items, "AccessDenied"));
 }
 
+// ── Resume manifest ────────────────────────────────────────────────
+//
+// Pre-seed `{cache}/migrate.progress.json` with one keg name. Run migrate
+// over a fake Cellar that contains that same keg and one unknown keg. The
+// pre-seeded keg must be skipped *before* any API hit (no 404 marker, so
+// reaching the API would leak as a `failed_api` outcome) — this pins the
+// resume contract end-to-end.
+
+test "resume manifest: pre-seeded keg is skipped before any API call" {
+    resetOutput();
+
+    const brew = try scratchDir("brew_resume");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+
+    const mt_z: [:0]const u8 = "/tmp/mt_rs";
+    malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+    try malt.fs_compat.cwd().makePath(mt_z);
+    defer malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+
+    try seedFakeBrew(brew, &.{ "alreadydone", "unknownpkg" });
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Pre-seed a 404 marker for the *other* keg so it fails offline. If the
+    // manifest filter ever regresses, "alreadydone" would also try the API
+    // and fail differently (FormulaNotFound → failed_api), pinning the bug.
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{mt_z});
+    defer testing.allocator.free(cache_api);
+    try malt.fs_compat.cwd().makePath(cache_api);
+    const marker = try std.fmt.allocPrint(testing.allocator, "{s}/formula_unknownpkg.404", .{cache_api});
+    defer testing.allocator.free(marker);
+    const mf = try malt.fs_compat.cwd().createFile(marker, .{});
+    mf.close();
+
+    // Pre-seed a 404 for "alreadydone" too — if the manifest filter ever
+    // breaks, the test still terminates offline (failed_api) instead of
+    // hitting the network. The assertion still pins resume because we
+    // expect skipped_installed, not failed_api.
+    const marker2 = try std.fmt.allocPrint(testing.allocator, "{s}/formula_alreadydone.404", .{cache_api});
+    defer testing.allocator.free(marker2);
+    const mf2 = try malt.fs_compat.cwd().createFile(marker2, .{});
+    mf2.close();
+
+    // Pre-seed the resume manifest with "alreadydone" *and* a matching
+    // DB row — the resume short-circuit requires both to agree so a
+    // stale manifest after `mt uninstall` doesn't silently skip a keg.
+    const cache_dir = try std.fmt.allocPrint(testing.allocator, "{s}/cache", .{mt_z});
+    defer testing.allocator.free(cache_dir);
+    try malt.fs_compat.cwd().makePath(cache_dir);
+    var manifest = malt.cli_migrate_manifest.Manifest.init(testing.allocator);
+    defer manifest.deinit();
+    try manifest.add("alreadydone");
+    const manifest_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/migrate.progress.json",
+        .{cache_dir},
+    );
+    defer testing.allocator.free(manifest_path);
+    try manifest.writeAtomic(testing.allocator, manifest_path);
+
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt_z});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/malt.db", .{db_dir}, 0);
+    defer testing.allocator.free(db_path);
+    var db_seed = try malt.sqlite.Database.open(db_path);
+    try malt.schema.initSchema(&db_seed);
+    var seed_stmt = try db_seed.prepare(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (?, ?, ?, ?, ?);
+    );
+    try seed_stmt.bindText(1, "alreadydone");
+    try seed_stmt.bindText(2, "alreadydone");
+    try seed_stmt.bindText(3, "1.0");
+    try seed_stmt.bindText(4, "0" ** 64);
+    try seed_stmt.bindText(5, "/tmp/mt_rs/Cellar/alreadydone/1.0");
+    _ = try seed_stmt.step();
+    seed_stmt.finalize();
+    db_seed.close();
+
+    output.setMode(.json);
+    defer resetOutput();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{});
+
+    const parsed = try parseAndCheck(buf.items);
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    // Pre-seeded keg is reported skipped (resume contract).
+    const skipped = root.get("skipped_installed").?.array;
+    var found_alreadydone = false;
+    for (skipped.items) |v| {
+        if (std.mem.eql(u8, v.string, "alreadydone")) found_alreadydone = true;
+    }
+    try testing.expect(found_alreadydone);
+    // The other keg still went through the API (and 404'd) — pinning that
+    // the manifest filter is *selective*, not a blanket short-circuit.
+    const failed = root.get("failed").?.array;
+    try testing.expectEqual(@as(usize, 1), failed.items.len);
+    try testing.expectEqualStrings("unknownpkg", failed.items[0].string);
+}
+
+// ── Manifest contract on failure ───────────────────────────────────
+//
+// A failed keg must never end up in `migrate.progress.json`; otherwise
+// every future run would silently skip a keg the user actually wants
+// installed. Drive a 404-failing keg through the serial path and assert
+// the on-disk manifest stays empty.
+
+test "failed migrate does not write the keg into the resume manifest" {
+    resetOutput();
+
+    const brew = try scratchDir("brew_failnomanifest");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt_z: [:0]const u8 = "/tmp/mt_fn";
+    malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+    try malt.fs_compat.cwd().makePath(mt_z);
+    defer malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+
+    try seedFakeBrew(brew, &.{"failkeg"});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{mt_z});
+    defer testing.allocator.free(cache_api);
+    try malt.fs_compat.cwd().makePath(cache_api);
+    const marker = try std.fmt.allocPrint(testing.allocator, "{s}/formula_failkeg.404", .{cache_api});
+    defer testing.allocator.free(marker);
+    const mf = try malt.fs_compat.cwd().createFile(marker, .{});
+    mf.close();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{"--quiet"});
+
+    // Manifest must either not exist or contain zero entries — the 404
+    // path returned `.failed_api`, never `.migrated`.
+    const manifest_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/cache/migrate.progress.json",
+        .{mt_z},
+    );
+    defer testing.allocator.free(manifest_path);
+    var loaded = try malt.cli_migrate_manifest.loadFromPath(testing.allocator, manifest_path);
+    defer loaded.deinit();
+    try testing.expect(!loaded.contains("failkeg"));
+    try testing.expectEqual(@as(usize, 0), loaded.entries.items.len);
+}
+
+// Pre-seeded successes must survive a later re-run that fails on
+// other kegs. `writeAtomic` rewrites the whole file each tick, so a
+// regression in the load-then-rewrite contract would silently drop
+// previously-completed entries.
+
+test "manifest preserves pre-existing entries across a run with new failures" {
+    resetOutput();
+
+    const brew = try scratchDir("brew_preserve");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt_z: [:0]const u8 = "/tmp/mt_pv";
+    malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+    try malt.fs_compat.cwd().makePath(mt_z);
+    defer malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+
+    // The Cellar contains the pre-seeded keg + a new one that 404s.
+    try seedFakeBrew(brew, &.{ "old", "newfail" });
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{mt_z});
+    defer testing.allocator.free(cache_api);
+    try malt.fs_compat.cwd().makePath(cache_api);
+    const marker = try std.fmt.allocPrint(testing.allocator, "{s}/formula_newfail.404", .{cache_api});
+    defer testing.allocator.free(marker);
+    const mf = try malt.fs_compat.cwd().createFile(marker, .{});
+    mf.close();
+
+    const cache_dir = try std.fmt.allocPrint(testing.allocator, "{s}/cache", .{mt_z});
+    defer testing.allocator.free(cache_dir);
+    try malt.fs_compat.cwd().makePath(cache_dir);
+    const manifest_path = try std.fmt.allocPrint(testing.allocator, "{s}/migrate.progress.json", .{cache_dir});
+    defer testing.allocator.free(manifest_path);
+
+    var seed = malt.cli_migrate_manifest.Manifest.init(testing.allocator);
+    defer seed.deinit();
+    try seed.add("old");
+    try seed.writeAtomic(testing.allocator, manifest_path);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{"--quiet"});
+
+    var loaded = try malt.cli_migrate_manifest.loadFromPath(testing.allocator, manifest_path);
+    defer loaded.deinit();
+    try testing.expect(loaded.contains("old"));
+    try testing.expect(!loaded.contains("newfail"));
+}
+
+// Stale manifest (post-uninstall) must not silently skip a keg the user
+// expects to be re-migrated. Pre-seed the manifest with "ghost" but
+// leave the DB empty + 404-mark the formula. Pre-PR semantics would
+// have skipped silently; the DB cross-check forces a real attempt
+// (which 404s offline → `failed`), proving we did NOT short-circuit.
+
+test "stale manifest after uninstall falls through to a real migrate" {
+    resetOutput();
+
+    const brew = try scratchDir("brew_stale");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt_z: [:0]const u8 = "/tmp/mt_st";
+    malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+    try malt.fs_compat.cwd().makePath(mt_z);
+    defer malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+
+    try seedFakeBrew(brew, &.{"ghost"});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{mt_z});
+    defer testing.allocator.free(cache_api);
+    try malt.fs_compat.cwd().makePath(cache_api);
+    const marker = try std.fmt.allocPrint(testing.allocator, "{s}/formula_ghost.404", .{cache_api});
+    defer testing.allocator.free(marker);
+    const mf = try malt.fs_compat.cwd().createFile(marker, .{});
+    mf.close();
+
+    // Manifest claims "ghost" was migrated; DB is empty (simulating uninstall).
+    const cache_dir = try std.fmt.allocPrint(testing.allocator, "{s}/cache", .{mt_z});
+    defer testing.allocator.free(cache_dir);
+    try malt.fs_compat.cwd().makePath(cache_dir);
+    var stale = malt.cli_migrate_manifest.Manifest.init(testing.allocator);
+    defer stale.deinit();
+    try stale.add("ghost");
+    const manifest_path = try std.fmt.allocPrint(testing.allocator, "{s}/migrate.progress.json", .{cache_dir});
+    defer testing.allocator.free(manifest_path);
+    try stale.writeAtomic(testing.allocator, manifest_path);
+
+    output.setMode(.json);
+    defer resetOutput();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{});
+
+    const parsed = try parseAndCheck(buf.items);
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    // Real attempt happened — keg ended up in `failed` (API 404), not
+    // `skipped_installed`. A regression to manifest-only-skip would
+    // place it in `skipped_installed` with zero failures.
+    try testing.expectEqual(@as(usize, 0), root.get("skipped_installed").?.array.items.len);
+    try testing.expectEqual(@as(usize, 1), root.get("failed").?.array.items.len);
+    try testing.expectEqualStrings("ghost", root.get("failed").?.array.items[0].string);
+}
+
+// Self-heal contract: the SIGKILL window between "DB row committed"
+// and "manifest writeAtomic flushed" leaves DB ahead of manifest. The
+// recovery run must repopulate the manifest from the DB-confirmed skip
+// so subsequent runs don't keep paying the DB-lookup penalty for the
+// same keg forever.
+
+test "manifest self-heals from DB-confirmed skips after a crash recovery" {
+    resetOutput();
+
+    const brew = try scratchDir("brew_heal");
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt_z: [:0]const u8 = "/tmp/mt_hl";
+    malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+    try malt.fs_compat.cwd().makePath(mt_z);
+    defer malt.fs_compat.deleteTreeAbsolute(mt_z) catch {};
+
+    try seedFakeBrew(brew, &.{"recovered"});
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Simulate the post-crash state: DB has the keg (previous run
+    // committed it) but the manifest file does not exist (previous
+    // run died before writeAtomic).
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{mt_z});
+    defer testing.allocator.free(db_dir);
+    try malt.fs_compat.cwd().makePath(db_dir);
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/malt.db", .{db_dir}, 0);
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    try malt.schema.initSchema(&db);
+    var stmt = try db.prepare(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (?, ?, ?, ?, ?);
+    );
+    try stmt.bindText(1, "recovered");
+    try stmt.bindText(2, "recovered");
+    try stmt.bindText(3, "1.0");
+    try stmt.bindText(4, "0" ** 64);
+    try stmt.bindText(5, "/tmp/mt_hl/Cellar/recovered/1.0");
+    _ = try stmt.step();
+    stmt.finalize();
+    db.close();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    try migrate.execute(arena.allocator(), &.{"--quiet"});
+
+    // Manifest now exists on disk and contains the keg the DB had —
+    // future runs hit the cheap manifest short-circuit instead of the
+    // DB lookup. Pin both: file load works, and the entry is there.
+    const manifest_path = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/cache/migrate.progress.json",
+        .{mt_z},
+    );
+    defer testing.allocator.free(manifest_path);
+    var loaded = try malt.cli_migrate_manifest.loadFromPath(testing.allocator, manifest_path);
+    defer loaded.deinit();
+    try testing.expect(loaded.contains("recovered"));
+}
+
 test "scanCellarKegs skips non-directory entries and survives fail-first iterator" {
     resetOutput();
     color.setForTest(false, false);


### PR DESCRIPTION
## Description

`mt migrate --parallel` runs the per-keg work concurrently with a bounded worker pool (default 4 workers; override with `MALT_MIGRATE_PARALLEL_WORKERS=N`). On success each keg is recorded in `{prefix}/cache/migrate.progress.json`, so a re-run after a crash, ^C, or partial failure resumes where it stopped instead of redoing every keg from scratch. Resume works in both serial and parallel modes, so users who don't opt into parallelism still get crash-safety.

DB writes serialise behind a mutex inside `migrateKeg`, so concurrent workers cannot interleave transactions. The download + materialise phases run lock-free, which is where the wall-clock win comes from.

## Related Issue

- None

## Notes for Reviewers

- None