### PR TITLE
feat: passive version-notify after dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,20 +472,21 @@ MALT_ALLOW_UNVERIFIED=1 mt version update --no-verify
 
 ### Environment variables
 
-| Variable                       | Description                                                                       | Default          |
-| ------------------------------ | --------------------------------------------------------------------------------- | ---------------- |
-| `MALT_PREFIX`                  | Override install prefix                                                           | `/opt/malt`      |
-| `MALT_CACHE`                   | Override cache directory                                                          | `{prefix}/cache` |
-| `NO_COLOR`                     | Disable colored output                                                            | unset            |
-| `MALT_NO_EMOJI`                | Disable emoji in output                                                           | unset            |
-| `MALT_THEME`                   | Force the output palette: `light`, `dark`, or `auto` (detects via OSC 11)         | `auto`           |
-| `HOMEBREW_GITHUB_API_TOKEN`    | GitHub token for higher API rate limits                                           | unset            |
-| `MALT_GITHUB_TOKEN`            | GitHub token sent as `Authorization: Bearer` on tap `/commits/HEAD` calls only    | unset            |
-| `MALT_OUTDATED_MAX_AGE`        | TTL in hours for the `outdated.json` snapshot                                     | `24`             |
-| `MALT_MIGRATE_PARALLEL_WORKERS` | Worker count for `mt migrate --parallel` (clamped to `[1, 32]`)                  | `4`              |
-| `MALT_ALLOW_UNVERIFIED`        | Skip cosign signature check in `install.sh` (use only when cosign is unavailable) | unset            |
-| `MALT_ALLOW_UNVERIFIED_SOURCE` | Allow `install.sh` to clone `main` when no release tag resolves                   | unset            |
-| `MALT_ALLOW_RAW_POST_INSTALL`  | Disable terminal escape filter on ruby `post_install` output                      | unset            |
+| Variable                        | Description                                                                       | Default          |
+| ------------------------------- | --------------------------------------------------------------------------------- | ---------------- |
+| `MALT_PREFIX`                   | Override install prefix                                                           | `/opt/malt`      |
+| `MALT_CACHE`                    | Override cache directory                                                          | `{prefix}/cache` |
+| `NO_COLOR`                      | Disable colored output                                                            | unset            |
+| `MALT_NO_EMOJI`                 | Disable emoji in output                                                           | unset            |
+| `MALT_NO_VERSION_NOTIFIER`      | Set to `1` to suppress the "newer malt available" notice                          | unset            |
+| `MALT_THEME`                    | Force the output palette: `light`, `dark`, or `auto` (detects via OSC 11)         | `auto`           |
+| `HOMEBREW_GITHUB_API_TOKEN`     | GitHub token for higher API rate limits                                           | unset            |
+| `MALT_GITHUB_TOKEN`             | GitHub token sent as `Authorization: Bearer` on tap `/commits/HEAD` calls only    | unset            |
+| `MALT_MIGRATE_PARALLEL_WORKERS` | Worker count for `mt migrate --parallel` (clamped to `[1, 32]`)                   | `4`              |
+| `MALT_OUTDATED_MAX_AGE`         | TTL in hours for the `outdated.json` snapshot                                     | `24`             |
+| `MALT_ALLOW_RAW_POST_INSTALL`   | Disable terminal escape filter on ruby `post_install` output                      | unset            |
+| `MALT_ALLOW_UNVERIFIED`         | Skip cosign signature check in `install.sh` (use only when cosign is unavailable) | unset            |
+| `MALT_ALLOW_UNVERIFIED_SOURCE`  | Allow `install.sh` to clone `main` when no release tag resolves                   | unset            |
 
 ## Architecture
 

--- a/build.zig
+++ b/build.zig
@@ -111,6 +111,7 @@ pub fn build(b: *std.Build) void {
         "tests/rollback_test.zig",
         "tests/run_test.zig",
         "tests/version_update_test.zig",
+        "tests/version_notify_test.zig",
         "tests/origin_test.zig",
         "tests/release_test.zig",
         "tests/verify_test.zig",

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -19,9 +19,9 @@ const origin = @import("../update/origin.zig");
 const release = @import("../update/release.zig");
 const verify = @import("../update/verify.zig");
 const swap = @import("../update/swap.zig");
+const notifier = @import("../update/notifier.zig");
 
 const current_version = @import("../version.zig").value;
-const releases_api = "https://api.github.com/repos/indaco/malt/releases/latest";
 const checksums_name = "checksums.txt";
 const sigstore_name = "checksums.txt.sigstore.json";
 // Pins the signature to the exact workflow that produced the release.
@@ -67,7 +67,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var http = client_mod.HttpClient.init(allocator);
     defer http.deinit();
 
-    var resp = http.get(releases_api) catch {
+    var resp = http.get(release.releases_latest_url) catch {
         output.err("Cannot reach GitHub API", .{});
         return error.Aborted;
     };
@@ -95,7 +95,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         output.err("No tag_name in release", .{});
         return error.Aborted;
     };
-    const latest = if (tag.len > 0 and tag[0] == 'v') tag[1..] else tag;
+    const latest = release.stripVPrefix(tag);
 
     if (std.mem.eql(u8, latest, current_version)) {
         output.info("Already up to date ({s})", .{current_version});
@@ -248,13 +248,17 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
             output.warn("{s} is now {s} but {s} is still the previous version.", .{ self_exe, latest, tp });
             output.info("Finish manually: sudo install -m 0755 -b -B .old {s} {s}", .{ new_binary, tp });
             output.info("Updated to {s} (previous {s} kept at {s}.old)", .{ latest, std.fs.path.basename(self_exe), self_exe });
+            // Self is on the new version even though twin lagged — dismiss the nag.
+            notifier.markUpdatedTo(tag, latest);
             return;
         };
         output.info("Updated {s} and {s} to {s} (previous kept at *.old)", .{ self_exe, tp, latest });
+        notifier.markUpdatedTo(tag, latest);
         return;
     }
 
     output.info("Updated to {s} (previous kept at {s}.old)", .{ latest, self_exe });
+    notifier.markUpdatedTo(tag, latest);
 }
 
 /// How the previous swap was carried out. Threaded through twin handling

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -61,6 +61,7 @@ pub const update_origin = @import("update/origin.zig");
 pub const update_release = @import("update/release.zig");
 pub const update_verify = @import("update/verify.zig");
 pub const update_swap = @import("update/swap.zig");
+pub const update_notifier = @import("update/notifier.zig");
 pub const cli_list = @import("cli/list.zig");
 pub const cli_pin = @import("cli/pin.zig");
 pub const cli_run = @import("cli/run.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -57,6 +57,7 @@ const which_cmd = @import("cli/which.zig");
 
 const version_mod = @import("version.zig");
 const version = version_mod.value;
+const notifier = @import("update/notifier.zig");
 
 const Command = enum {
     install,
@@ -326,6 +327,10 @@ pub fn main(init: std.process.Init.Minimal) !void {
             error.Aborted => std.process.exit(1),
             else => return e,
         };
+        // Best-effort passive notice on successful subcommands. Owns its
+        // own suppression list (CI, --quiet/--json/ndjson/--dry-run, env
+        // opt-out, non-TTY, brew origin, version/help meta-commands).
+        notifier.maybeNotify(allocator, version, cmd_str);
     } else {
         // Unknown command — try transparent brew fallback
         try brewFallback(allocator, args);
@@ -431,6 +436,8 @@ fn printUsage() void {
         \\  MALT_CACHE        Override cache directory
         \\  NO_COLOR          Disable colored output
         \\  MALT_NO_EMOJI     Disable emoji in output
+        \\  MALT_NO_VERSION_NOTIFIER=1
+        \\                    Suppress the "newer malt available" stderr notice
         \\
     ;
     io_mod.stdoutWriteAll(usage);

--- a/src/update/notifier.zig
+++ b/src/update/notifier.zig
@@ -1,0 +1,520 @@
+//! malt — passive version-notify (npm/pnpm/gh-cli style).
+//!
+//! Best-effort by contract: every error path swallows so the notifier
+//! can never break a real command. Suppressed under CI, `--quiet`,
+//! `--json`, ndjson, `--dry-run`, non-TTY stderr, homebrew origin, and
+//! the `version`/`help` meta-commands.
+
+const std = @import("std");
+const fs_compat = @import("../fs/compat.zig");
+const io_mod = @import("../ui/io.zig");
+const output = @import("../ui/output.zig");
+const client_mod = @import("../net/client.zig");
+const release = @import("release.zig");
+const origin_mod = @import("origin.zig");
+
+const cache_filename = "version-notify.json";
+
+/// Match gh, npm, pnpm — smaller TTLs nag, larger lose freshness.
+pub const cache_ttl_secs: i64 = 24 * 60 * 60;
+
+/// Bounded so a cache miss can't drag the user's hot path. Fires after
+/// dispatch, so the command's output is already on screen.
+pub const network_timeout_ns: u64 = 1_500 * std.time.ns_per_ms;
+
+/// Persisted as `<cache_dir>/version-notify.json`. Decoder is tolerant
+/// so a downgraded malt doesn't strand the file.
+pub const State = struct {
+    checked_at: i64,
+    /// As returned by GitHub: with the leading `v`.
+    latest_tag: []const u8,
+    /// Lets a fresh cache skip notices for users who've just updated.
+    current_seen: []const u8,
+};
+
+/// The `current == seen == latest_no_v` clause silences the notice for
+/// users who've just updated while the cache TTL is still alive.
+pub fn shouldNotify(current: []const u8, latest_tag: []const u8, current_seen: []const u8) bool {
+    const latest_no_v = release.stripVPrefix(latest_tag);
+    if (latest_no_v.len == 0) return false;
+    if (std.mem.eql(u8, current, latest_no_v)) return false;
+    if (std.mem.eql(u8, current, current_seen) and std.mem.eql(u8, current_seen, latest_no_v)) return false;
+    return true;
+}
+
+pub fn cacheStale(now_secs: i64, checked_at: i64, ttl: i64) bool {
+    // Cache from the future (clock skew) — treat as fresh, never re-fetch.
+    if (now_secs <= checked_at) return false;
+    return (now_secs - checked_at) >= ttl;
+}
+
+const ci_env_vars = [_][]const u8{
+    "CI",
+    "GITHUB_ACTIONS",
+    "BUILDKITE",
+    "JENKINS_URL",
+    "TF_BUILD",
+    "CIRCLECI",
+    "GITLAB_CI",
+};
+
+/// Pure variant of `isCi` so tests don't mutate the host environment.
+/// `values` parallels `ci_env_vars` entry-for-entry.
+pub fn isCiFromValues(values: []const ?[]const u8) bool {
+    std.debug.assert(values.len == ci_env_vars.len);
+    for (values) |v| {
+        if (v) |s| {
+            if (s.len > 0) return true;
+        }
+    }
+    return false;
+}
+
+pub fn isCi() bool {
+    inline for (ci_env_vars) |name| {
+        if (fs_compat.getenv(name)) |v| {
+            if (v.len > 0) return true;
+        }
+    }
+    return false;
+}
+
+/// Precedence: `MALT_CACHE` > `XDG_CACHE_HOME` > `HOME`. Pulled into a
+/// struct so the rule is testable without touching the host environment.
+pub const EnvOverride = struct {
+    malt_cache: ?[]const u8 = null,
+    xdg_cache_home: ?[]const u8 = null,
+    home: ?[]const u8 = null,
+};
+
+/// Returns slice-into-`buf`, or null if no env var in the chain is set.
+pub fn cacheDirFrom(env: EnvOverride, buf: []u8) ?[]const u8 {
+    if (env.malt_cache) |v| if (v.len > 0) return std.fmt.bufPrint(buf, "{s}", .{v}) catch null;
+    if (env.xdg_cache_home) |v| if (v.len > 0) return std.fmt.bufPrint(buf, "{s}/malt", .{v}) catch null;
+    if (env.home) |v| if (v.len > 0) return std.fmt.bufPrint(buf, "{s}/.cache/malt", .{v}) catch null;
+    return null;
+}
+
+fn liveEnv() EnvOverride {
+    return .{
+        .malt_cache = fs_compat.getenv("MALT_CACHE"),
+        .xdg_cache_home = fs_compat.getenv("XDG_CACHE_HOME"),
+        .home = fs_compat.getenv("HOME"),
+    };
+}
+
+pub fn cacheDir(buf: []u8) ?[]const u8 {
+    return cacheDirFrom(liveEnv(), buf);
+}
+
+pub fn cachePathFrom(env: EnvOverride, buf: []u8) ?[]const u8 {
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = cacheDirFrom(env, &dir_buf) orelse return null;
+    return std.fmt.bufPrint(buf, "{s}/{s}", .{ dir, cache_filename }) catch null;
+}
+
+pub fn cachePath(buf: []u8) ?[]const u8 {
+    return cachePathFrom(liveEnv(), buf);
+}
+
+/// Realistic failure: `error.NoSpaceLeft` when `buf` is undersized.
+pub fn encodeState(buf: []u8, state: State) ![]u8 {
+    var w = std.Io.Writer.fixed(buf);
+    try w.writeAll("{\"checked_at\":");
+    var num_buf: [32]u8 = undefined;
+    const num = try std.fmt.bufPrint(&num_buf, "{d}", .{state.checked_at});
+    try w.writeAll(num);
+    try w.writeAll(",\"latest_tag\":");
+    try output.jsonStr(&w, state.latest_tag);
+    try w.writeAll(",\"current_seen\":");
+    try output.jsonStr(&w, state.current_seen);
+    try w.writeAll("}\n");
+    return w.buffered();
+}
+
+/// Caller frees via `freeState`. OOM propagates; every other parse
+/// error collapses to `error.InvalidPayload` so a torn cache doesn't
+/// leak a JSON parser type into best-effort callers.
+pub fn decodeState(allocator: std.mem.Allocator, bytes: []const u8) !?State {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, bytes, .{}) catch |e| switch (e) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidPayload,
+    };
+    defer parsed.deinit();
+    const obj = switch (parsed.value) {
+        .object => |o| o,
+        else => return null,
+    };
+    const checked_at_v = obj.get("checked_at") orelse return null;
+    const latest_tag_v = obj.get("latest_tag") orelse return null;
+    const current_seen_v = obj.get("current_seen") orelse return null;
+    const checked_at_i = switch (checked_at_v) {
+        .integer => |i| i,
+        else => return null,
+    };
+    const latest_tag_s = switch (latest_tag_v) {
+        .string => |s| s,
+        else => return null,
+    };
+    const current_seen_s = switch (current_seen_v) {
+        .string => |s| s,
+        else => return null,
+    };
+    const tag_dup = try allocator.dupe(u8, latest_tag_s);
+    errdefer allocator.free(tag_dup);
+    const seen_dup = try allocator.dupe(u8, current_seen_s);
+    return .{ .checked_at = checked_at_i, .latest_tag = tag_dup, .current_seen = seen_dup };
+}
+
+pub fn freeState(allocator: std.mem.Allocator, state: State) void {
+    allocator.free(state.latest_tag);
+    allocator.free(state.current_seen);
+}
+
+/// Returns null when the file is absent (a torn or first run).
+pub fn readCache(allocator: std.mem.Allocator, path: []const u8) !?State {
+    const bytes = fs_compat.readFileAbsoluteAlloc(allocator, path, 64 * 1024) catch |e| switch (e) {
+        error.FileNotFound => return null,
+        else => return e,
+    };
+    defer allocator.free(bytes);
+    return decodeState(allocator, bytes);
+}
+
+/// Creates the parent directory if missing. A torn write surfaces as
+/// `error.InvalidPayload` on the next read and is treated as no cache.
+pub fn writeCache(path: []const u8, state: State) !void {
+    if (std.fs.path.dirname(path)) |dir| {
+        var cwd = fs_compat.cwd();
+        cwd.makePath(dir) catch {};
+    }
+    var buf: [1024]u8 = undefined;
+    const encoded = try encodeState(&buf, state);
+    const f = try fs_compat.createFileAbsolute(path, .{});
+    defer f.close();
+    try f.writeAll(encoded);
+}
+
+fn fetchLatestTag(allocator: std.mem.Allocator) ![]u8 {
+    var http = client_mod.HttpClient.init(allocator);
+    http.timeout_ns = network_timeout_ns;
+    defer http.deinit();
+    var resp = try http.get(release.releases_latest_url);
+    defer resp.deinit();
+    if (resp.status != 200) return error.NetworkUnavailable;
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, resp.body, .{}) catch return error.InvalidPayload;
+    defer parsed.deinit();
+    const obj = switch (parsed.value) {
+        .object => |o| o,
+        else => return error.InvalidPayload,
+    };
+    const tag = release.strField(obj, "tag_name") orelse return error.InvalidPayload;
+    return allocator.dupe(u8, tag);
+}
+
+/// Errors degrade to `false` — a transient FS error must not silence
+/// the notifier for everyone.
+fn originIsHomebrew() bool {
+    var exe_buf: [fs_compat.max_path_bytes]u8 = undefined;
+    const n = std.process.executablePath(io_mod.ctx(), &exe_buf) catch return false;
+    var resolved_buf: [std.fs.max_path_bytes]u8 = undefined;
+    return origin_mod.classifyResolved(&resolved_buf, exe_buf[0..n]) == .homebrew;
+}
+
+/// Install-pipeline commands deliberately aren't here — `bench.sh`
+/// redirects stderr, so the non-TTY rule below already exempts them
+/// from measurement while interactive users still get the notice.
+const meta_commands = [_][]const u8{ "version", "--version", "help", "--help", "-h" };
+
+/// Public so `tests/version_notify_test.zig` can pin the skip list
+/// without going through the full `suppressed` flow.
+pub fn isSkippedCommand(cmd: []const u8) bool {
+    if (cmd.len == 0) return true;
+    for (meta_commands) |m| {
+        if (std.mem.eql(u8, cmd, m)) return true;
+    }
+    return false;
+}
+
+/// Mirrors `MALT_ALLOW_UNVERIFIED` / `MALT_ALLOW_RAW_POST_INSTALL`:
+/// the literal `"1"` is the on-state, anything else (incl. an empty
+/// value) is off, so a stray `=` doesn't accidentally silence notices.
+pub fn notifierDisabledFromValue(value: ?[]const u8) bool {
+    const v = value orelse return false;
+    return std.mem.eql(u8, v, "1");
+}
+
+fn notifierDisabled() bool {
+    return notifierDisabledFromValue(fs_compat.getenv("MALT_NO_VERSION_NOTIFIER"));
+}
+
+/// Cheapest checks first. `originIsHomebrew` is deliberately not here —
+/// the `executablePath` + `realpath` pair is deferred to `runNotify` so
+/// the cache-fresh hot path skips it entirely.
+fn suppressed(cmd_str: []const u8) bool {
+    if (isSkippedCommand(cmd_str)) return true;
+    if (output.isQuiet() or output.isJson() or output.isNdjson() or output.isDryRun()) return true;
+    if (notifierDisabled()) return true;
+    if (isCi()) return true;
+    if (!fs_compat.isatty(std.posix.STDERR_FILENO)) return true;
+    return false;
+}
+
+/// Dim so it recedes next to the command's own info/success lines.
+fn printNotice(latest_tag: []const u8, current_version: []const u8) void {
+    const latest_no_v = release.stripVPrefix(latest_tag);
+    output.dim("A newer malt is available: {s} (you're on {s}).", .{ latest_no_v, current_version });
+    output.dim("Run 'mt version update' to upgrade, or set MALT_NO_VERSION_NOTIFIER=1 to silence this.", .{});
+}
+
+/// Best-effort cache write so a successful self-update silences the
+/// nag immediately, not on the next 24h refresh.
+pub fn markUpdatedTo(latest_tag: []const u8, current_version: []const u8) void {
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = cachePath(&path_buf) orelse return;
+    writeCache(path, .{
+        .checked_at = fs_compat.timestamp(),
+        .latest_tag = latest_tag,
+        .current_seen = current_version,
+    }) catch {};
+}
+
+/// Best-effort entrypoint. `cmd_str` is the canonical subcommand name;
+/// `version`/`help` aliases bypass the notice via the suppression list.
+pub fn maybeNotify(allocator: std.mem.Allocator, current_version: []const u8, cmd_str: []const u8) void {
+    if (suppressed(cmd_str)) return;
+    runNotify(allocator, current_version) catch {};
+}
+
+fn runNotify(allocator: std.mem.Allocator, current_version: []const u8) !void {
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = cachePath(&path_buf) orelse return;
+
+    var state: ?State = readCache(allocator, path) catch null;
+    defer if (state) |s| freeState(allocator, s);
+
+    const now = fs_compat.timestamp();
+    const need_refresh = if (state) |s| cacheStale(now, s.checked_at, cache_ttl_secs) else true;
+
+    // The 33%-savings clause: cache fresh + no notice due → return without
+    // touching `executablePath`/`realpath`. The dominant path on a healthy
+    // workstation between refresh windows.
+    const wants_print = blk: {
+        const s = state orelse break :blk false;
+        break :blk shouldNotify(current_version, s.latest_tag, s.current_seen);
+    };
+    if (!need_refresh and !wants_print) return;
+
+    // Brew installs are owned by `brew upgrade --cask malt`; refresh and
+    // print both make no sense for them. Origin check is a 2-syscall
+    // executablePath + realpath, paid only on this rare-action path.
+    if (originIsHomebrew()) return;
+
+    if (need_refresh) {
+        // Don't make the user wait out a 1.5s HTTP timeout after Ctrl-C.
+        // Same convention as `cli/install.zig` and `cli/migrate.zig`.
+        const main_mod = @import("../main.zig");
+        if (main_mod.isInterrupted()) return;
+        refreshOnce(allocator, path, &state, now, current_version) catch {};
+    }
+
+    const s = state orelse return;
+    if (!shouldNotify(current_version, s.latest_tag, s.current_seen)) return;
+    printNotice(s.latest_tag, current_version);
+}
+
+/// On network failure `state` is left untouched so the caller's old
+/// cache view survives a flaky GitHub API.
+fn refreshOnce(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    state: *?State,
+    now: i64,
+    current_version: []const u8,
+) !void {
+    const tag = try fetchLatestTag(allocator);
+    errdefer allocator.free(tag);
+
+    // Preserve a previously-recorded `current_seen` if any; else start at
+    // the running version so the suppression clause works.
+    const prior_seen: []const u8 = if (state.*) |s| s.current_seen else current_version;
+    const seen_dup = try allocator.dupe(u8, prior_seen);
+    errdefer allocator.free(seen_dup);
+
+    writeCache(path, .{ .checked_at = now, .latest_tag = tag, .current_seen = prior_seen }) catch {};
+
+    if (state.*) |old| freeState(allocator, old);
+    state.* = .{ .checked_at = now, .latest_tag = tag, .current_seen = seen_dup };
+}
+
+// --- pure-logic tests ----------------------------------------------------
+
+test "shouldNotify: equal versions never notify (with or without leading v)" {
+    try std.testing.expect(!shouldNotify("0.10.0", "v0.10.0", "0.10.0"));
+    try std.testing.expect(!shouldNotify("0.10.0", "0.10.0", ""));
+}
+
+test "shouldNotify: newer latest fires notice" {
+    try std.testing.expect(shouldNotify("0.10.0", "v0.10.1", ""));
+    try std.testing.expect(shouldNotify("0.10.0", "v0.11.0", "0.9.0"));
+}
+
+test "shouldNotify: empty latest never fires" {
+    try std.testing.expect(!shouldNotify("0.10.0", "", ""));
+    try std.testing.expect(!shouldNotify("0.10.0", "v", ""));
+}
+
+test "shouldNotify: post-update suppression — current_seen matches both" {
+    // User updated to 0.10.1; cache still says latest=v0.10.1 — don't nag.
+    try std.testing.expect(!shouldNotify("0.10.1", "v0.10.1", "0.10.1"));
+}
+
+test "shouldNotify: stale cache with mismatched current_seen still fires" {
+    // Cache predates a downgrade-then-cache-rewrite; safe default is to fire.
+    try std.testing.expect(shouldNotify("0.9.0", "v0.10.0", "0.8.0"));
+}
+
+test "cacheStale: TTL boundary" {
+    try std.testing.expect(!cacheStale(100, 100, 60)); // equal ⇒ fresh (delta 0)
+    try std.testing.expect(!cacheStale(159, 100, 60)); // delta 59 < 60
+    try std.testing.expect(cacheStale(160, 100, 60)); // delta 60 ⇒ stale
+    try std.testing.expect(cacheStale(1000, 100, 60));
+}
+
+test "cacheStale: clock skew (cache from the future) is treated as fresh" {
+    try std.testing.expect(!cacheStale(50, 100, 60));
+}
+
+test "notifierDisabledFromValue: only literal \"1\" disables (matches MALT_ALLOW_UNVERIFIED)" {
+    try std.testing.expect(!notifierDisabledFromValue(null));
+    try std.testing.expect(!notifierDisabledFromValue(""));
+    try std.testing.expect(!notifierDisabledFromValue("0"));
+    try std.testing.expect(!notifierDisabledFromValue("true"));
+    try std.testing.expect(!notifierDisabledFromValue("yes"));
+    try std.testing.expect(notifierDisabledFromValue("1"));
+}
+
+test "isCiFromValues: any non-empty wins" {
+    const all_null = [_]?[]const u8{ null, null, null, null, null, null, null };
+    try std.testing.expect(!isCiFromValues(&all_null));
+
+    const empty_string_only = [_]?[]const u8{ "", null, null, null, null, null, null };
+    try std.testing.expect(!isCiFromValues(&empty_string_only));
+
+    const ci_set = [_]?[]const u8{ "true", null, null, null, null, null, null };
+    try std.testing.expect(isCiFromValues(&ci_set));
+
+    const gha_set = [_]?[]const u8{ null, "true", null, null, null, null, null };
+    try std.testing.expect(isCiFromValues(&gha_set));
+}
+
+test "cacheDirFrom: precedence is MALT_CACHE > XDG_CACHE_HOME > HOME" {
+    var buf: [256]u8 = undefined;
+    {
+        const got = cacheDirFrom(.{
+            .malt_cache = "/m",
+            .xdg_cache_home = "/x",
+            .home = "/h",
+        }, &buf) orelse return error.TestExpectedNonNull;
+        try std.testing.expectEqualStrings("/m", got);
+    }
+    {
+        const got = cacheDirFrom(.{
+            .xdg_cache_home = "/x",
+            .home = "/h",
+        }, &buf) orelse return error.TestExpectedNonNull;
+        try std.testing.expectEqualStrings("/x/malt", got);
+    }
+    {
+        const got = cacheDirFrom(.{ .home = "/h" }, &buf) orelse return error.TestExpectedNonNull;
+        try std.testing.expectEqualStrings("/h/.cache/malt", got);
+    }
+    try std.testing.expect(cacheDirFrom(.{}, &buf) == null);
+}
+
+test "cacheDirFrom: empty values fall through to the next candidate" {
+    var buf: [256]u8 = undefined;
+    const got = cacheDirFrom(.{
+        .malt_cache = "",
+        .xdg_cache_home = "",
+        .home = "/home/u",
+    }, &buf) orelse return error.TestExpectedNonNull;
+    try std.testing.expectEqualStrings("/home/u/.cache/malt", got);
+}
+
+test "encodeState/decodeState: round-trip preserves every field" {
+    const allocator = std.testing.allocator;
+    var buf: [1024]u8 = undefined;
+    const encoded = try encodeState(&buf, .{
+        .checked_at = 1714400000,
+        .latest_tag = "v0.10.1",
+        .current_seen = "0.10.0",
+    });
+
+    const got = (try decodeState(allocator, encoded)) orelse return error.TestExpectedNonNull;
+    defer freeState(allocator, got);
+
+    try std.testing.expectEqual(@as(i64, 1714400000), got.checked_at);
+    try std.testing.expectEqualStrings("v0.10.1", got.latest_tag);
+    try std.testing.expectEqualStrings("0.10.0", got.current_seen);
+}
+
+test "decodeState: malformed JSON yields error.InvalidPayload" {
+    try std.testing.expectError(error.InvalidPayload, decodeState(std.testing.allocator, "not json"));
+}
+
+test "decodeState: missing fields yield null (not an error)" {
+    const got = try decodeState(std.testing.allocator, "{\"checked_at\":1}");
+    try std.testing.expect(got == null);
+}
+
+test "decodeState: extra fields are ignored (forwards-compat)" {
+    const allocator = std.testing.allocator;
+    const json =
+        \\{"checked_at":1,"latest_tag":"v0.10.1","current_seen":"0.10.0","future_field":42}
+    ;
+    const got = (try decodeState(allocator, json)) orelse return error.TestExpectedNonNull;
+    defer freeState(allocator, got);
+    try std.testing.expectEqualStrings("v0.10.1", got.latest_tag);
+}
+
+test "encodeState: escapes JSON special characters in tag/version strings" {
+    var buf: [256]u8 = undefined;
+    const encoded = try encodeState(&buf, .{
+        .checked_at = 0,
+        .latest_tag = "v\"X",
+        .current_seen = "ok",
+    });
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\\\"") != null);
+}
+
+test "writeCache + readCache round-trip on a real file" {
+    const allocator = std.testing.allocator;
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notifier_rt_{d}", .{fs_compat.nanoTimestamp()});
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
+
+    try writeCache(path, .{
+        .checked_at = 1714400000,
+        .latest_tag = "v0.10.1",
+        .current_seen = "0.10.0",
+    });
+    const got = (try readCache(allocator, path)) orelse return error.TestExpectedNonNull;
+    defer freeState(allocator, got);
+
+    try std.testing.expectEqual(@as(i64, 1714400000), got.checked_at);
+    try std.testing.expectEqualStrings("v0.10.1", got.latest_tag);
+    try std.testing.expectEqualStrings("0.10.0", got.current_seen);
+}
+
+test "readCache: missing file is null, not an error" {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&buf, "/tmp/malt_notifier_absent_{d}.json", .{fs_compat.nanoTimestamp()});
+    fs_compat.deleteFileAbsolute(path) catch {};
+    const got = try readCache(std.testing.allocator, path);
+    try std.testing.expect(got == null);
+}

--- a/src/update/release.zig
+++ b/src/update/release.zig
@@ -8,6 +8,10 @@
 const std = @import("std");
 const fs_compat = @import("../fs/compat.zig");
 
+/// Single source of truth for the GitHub release endpoint. Shared with the
+/// passive notifier so it doesn't drift away from the authenticated updater.
+pub const releases_latest_url = "https://api.github.com/repos/indaco/malt/releases/latest";
+
 /// Exact-name asset lookup. For `checksums.txt` and
 /// `checksums.txt.sigstore.json`, which must match by name, not pattern.
 pub fn pickAssetUrlByName(assets: std.json.Array, name: []const u8) ?[]const u8 {
@@ -95,4 +99,11 @@ pub fn strField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
         .string => |s| s,
         else => null,
     };
+}
+
+/// Drop a leading `v` from a release tag. Centralised so the updater,
+/// the notifier, and any future caller agree on what `v0.10.1` vs
+/// `0.10.1` mean.
+pub fn stripVPrefix(tag: []const u8) []const u8 {
+    return if (tag.len > 0 and tag[0] == 'v') tag[1..] else tag;
 }

--- a/tests/release_test.zig
+++ b/tests/release_test.zig
@@ -225,3 +225,12 @@ test "findReleaseBinary returns null when the prefix does not exist" {
         release.findReleaseBinary(testing.allocator, "/tmp/malt_findbin_absent_xyz_99", &out_buf) == null,
     );
 }
+
+test "stripVPrefix drops a leading 'v' but leaves bare versions and edges alone" {
+    try testing.expectEqualStrings("0.10.1", release.stripVPrefix("v0.10.1"));
+    try testing.expectEqualStrings("0.10.1", release.stripVPrefix("0.10.1"));
+    try testing.expectEqualStrings("", release.stripVPrefix(""));
+    try testing.expectEqualStrings("", release.stripVPrefix("v"));
+    // Single-letter input that is not 'v' must pass through.
+    try testing.expectEqualStrings("x", release.stripVPrefix("x"));
+}

--- a/tests/version_notify_test.zig
+++ b/tests/version_notify_test.zig
@@ -1,0 +1,235 @@
+//! malt — passive version-notify tests.
+//!
+//! Pure-logic + cache-file IO. The HTTP refresh path is exercised live
+//! by the inline tests in `src/update/notifier.zig` only as far as the
+//! decode/encode shape; the network call itself is left to the existing
+//! `HttpClient` test surface.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const notifier = malt.update_notifier;
+const fs_compat = malt.fs_compat;
+
+test "shouldNotify: full table — equal/newer/post-update" {
+    const Case = struct {
+        current: []const u8,
+        latest: []const u8,
+        seen: []const u8,
+        want: bool,
+    };
+    const cases = [_]Case{
+        .{ .current = "0.10.0", .latest = "v0.10.0", .seen = "0.10.0", .want = false },
+        .{ .current = "0.10.0", .latest = "v0.10.1", .seen = "0.10.0", .want = true },
+        .{ .current = "0.10.0", .latest = "0.10.1", .seen = "", .want = true },
+        .{ .current = "0.10.1", .latest = "v0.10.1", .seen = "0.10.1", .want = false },
+        .{ .current = "0.10.0", .latest = "", .seen = "", .want = false },
+        .{ .current = "0.10.0", .latest = "v0.9.0", .seen = "", .want = true },
+    };
+    for (cases) |c| {
+        const got = notifier.shouldNotify(c.current, c.latest, c.seen);
+        testing.expectEqual(c.want, got) catch |err| {
+            std.debug.print("shouldNotify({s}, {s}, {s}) = {}, want {}\n", .{
+                c.current, c.latest, c.seen, got, c.want,
+            });
+            return err;
+        };
+    }
+}
+
+test "cacheStale: TTL boundary table" {
+    const Case = struct { now: i64, checked: i64, ttl: i64, want: bool };
+    const cases = [_]Case{
+        .{ .now = 100, .checked = 100, .ttl = 60, .want = false },
+        .{ .now = 159, .checked = 100, .ttl = 60, .want = false },
+        .{ .now = 160, .checked = 100, .ttl = 60, .want = true },
+        .{ .now = 9999, .checked = 100, .ttl = 60, .want = true },
+        // Clock skew: cache from the future is treated as fresh.
+        .{ .now = 50, .checked = 100, .ttl = 60, .want = false },
+    };
+    for (cases) |c| {
+        try testing.expectEqual(c.want, notifier.cacheStale(c.now, c.checked, c.ttl));
+    }
+}
+
+test "isSkippedCommand: meta commands skip; install-pipeline does NOT" {
+    // Meta: own their own messaging or do no work. Notice would be noise.
+    try testing.expect(notifier.isSkippedCommand("version"));
+    try testing.expect(notifier.isSkippedCommand("--version"));
+    try testing.expect(notifier.isSkippedCommand("help"));
+    try testing.expect(notifier.isSkippedCommand("--help"));
+    try testing.expect(notifier.isSkippedCommand("-h"));
+    try testing.expect(notifier.isSkippedCommand("")); // defensive
+
+    // Install-pipeline / heavy mutation commands — notice fires AFTER the
+    // pipeline. bench.sh is unaffected because it redirects stderr to a
+    // file, tripping the non-TTY suppression rule instead.
+    try testing.expect(!notifier.isSkippedCommand("install"));
+    try testing.expect(!notifier.isSkippedCommand("uninstall"));
+    try testing.expect(!notifier.isSkippedCommand("upgrade"));
+    try testing.expect(!notifier.isSkippedCommand("migrate"));
+    try testing.expect(!notifier.isSkippedCommand("bundle"));
+
+    // Read-only / fast commands clearly keep the notice.
+    try testing.expect(!notifier.isSkippedCommand("list"));
+    try testing.expect(!notifier.isSkippedCommand("info"));
+    try testing.expect(!notifier.isSkippedCommand("search"));
+    try testing.expect(!notifier.isSkippedCommand("outdated"));
+    try testing.expect(!notifier.isSkippedCommand("doctor"));
+}
+
+test "notifierDisabledFromValue: only \"1\" disables (matches MALT_ALLOW_UNVERIFIED shape)" {
+    try testing.expect(!notifier.notifierDisabledFromValue(null));
+    try testing.expect(!notifier.notifierDisabledFromValue(""));
+    try testing.expect(!notifier.notifierDisabledFromValue("0"));
+    try testing.expect(!notifier.notifierDisabledFromValue("true"));
+    try testing.expect(!notifier.notifierDisabledFromValue("yes"));
+    try testing.expect(notifier.notifierDisabledFromValue("1"));
+}
+
+test "isCiFromValues: detects any non-empty CI variable" {
+    const empty = [_]?[]const u8{ null, null, null, null, null, null, null };
+    try testing.expect(!notifier.isCiFromValues(&empty));
+
+    const all_empty_strings = [_]?[]const u8{ "", "", "", "", "", "", "" };
+    try testing.expect(!notifier.isCiFromValues(&all_empty_strings));
+
+    // Each slot in turn — proves no off-by-one in the loop.
+    var slots = [_]?[]const u8{ null, null, null, null, null, null, null };
+    var i: usize = 0;
+    while (i < slots.len) : (i += 1) {
+        slots = [_]?[]const u8{ null, null, null, null, null, null, null };
+        slots[i] = "yes";
+        try testing.expect(notifier.isCiFromValues(&slots));
+    }
+}
+
+test "cacheDirFrom: precedence MALT_CACHE > XDG_CACHE_HOME > HOME" {
+    var buf: [256]u8 = undefined;
+    {
+        const got = notifier.cacheDirFrom(.{
+            .malt_cache = "/m",
+            .xdg_cache_home = "/x",
+            .home = "/h",
+        }, &buf) orelse return error.TestExpectedNonNull;
+        try testing.expectEqualStrings("/m", got);
+    }
+    {
+        const got = notifier.cacheDirFrom(.{
+            .xdg_cache_home = "/x",
+            .home = "/h",
+        }, &buf) orelse return error.TestExpectedNonNull;
+        try testing.expectEqualStrings("/x/malt", got);
+    }
+    {
+        const got = notifier.cacheDirFrom(.{ .home = "/h" }, &buf) orelse return error.TestExpectedNonNull;
+        try testing.expectEqualStrings("/h/.cache/malt", got);
+    }
+    try testing.expect(notifier.cacheDirFrom(.{}, &buf) == null);
+}
+
+test "cachePathFrom: appends version-notify.json to the resolved dir" {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const got = notifier.cachePathFrom(.{ .malt_cache = "/cache" }, &buf) orelse
+        return error.TestExpectedNonNull;
+    try testing.expectEqualStrings("/cache/version-notify.json", got);
+}
+
+test "encodeState/decodeState round-trip preserves every field" {
+    const allocator = testing.allocator;
+    var buf: [1024]u8 = undefined;
+    const encoded = try notifier.encodeState(&buf, .{
+        .checked_at = 1714400000,
+        .latest_tag = "v0.10.1",
+        .current_seen = "0.10.0",
+    });
+    const got = (try notifier.decodeState(allocator, encoded)) orelse
+        return error.TestExpectedNonNull;
+    defer notifier.freeState(allocator, got);
+    try testing.expectEqual(@as(i64, 1714400000), got.checked_at);
+    try testing.expectEqualStrings("v0.10.1", got.latest_tag);
+    try testing.expectEqualStrings("0.10.0", got.current_seen);
+}
+
+test "decodeState: malformed JSON yields error.InvalidPayload" {
+    try testing.expectError(error.InvalidPayload, notifier.decodeState(testing.allocator, "{nope"));
+}
+
+test "decodeState: missing required field yields null (not an error)" {
+    const got = try notifier.decodeState(testing.allocator, "{\"checked_at\":1}");
+    try testing.expect(got == null);
+}
+
+test "writeCache + readCache full round-trip on disk" {
+    const allocator = testing.allocator;
+
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notify_test_{d}", .{fs_compat.nanoTimestamp()});
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
+
+    try notifier.writeCache(path, .{
+        .checked_at = 42,
+        .latest_tag = "v0.99.0",
+        .current_seen = "0.10.0",
+    });
+
+    const got = (try notifier.readCache(allocator, path)) orelse return error.TestExpectedNonNull;
+    defer notifier.freeState(allocator, got);
+
+    try testing.expectEqual(@as(i64, 42), got.checked_at);
+    try testing.expectEqualStrings("v0.99.0", got.latest_tag);
+    try testing.expectEqualStrings("0.10.0", got.current_seen);
+}
+
+test "writeCache creates the parent directory when absent" {
+    const allocator = testing.allocator;
+
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notify_mkdir_{d}", .{fs_compat.nanoTimestamp()});
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    // Three-deep path to confirm `makePath` recurses (not just the leaf).
+    const path = try std.fmt.bufPrint(&path_buf, "{s}/a/b/c/version-notify.json", .{dir});
+
+    try notifier.writeCache(path, .{
+        .checked_at = 0,
+        .latest_tag = "v1.0.0",
+        .current_seen = "0.0.0",
+    });
+
+    const got = (try notifier.readCache(allocator, path)) orelse return error.TestExpectedNonNull;
+    defer notifier.freeState(allocator, got);
+    try testing.expectEqualStrings("v1.0.0", got.latest_tag);
+}
+
+test "readCache: missing file is null, not an error" {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&buf, "/tmp/malt_notify_absent_{d}.json", .{fs_compat.nanoTimestamp()});
+    fs_compat.deleteFileAbsolute(path) catch {};
+    const got = try notifier.readCache(testing.allocator, path);
+    try testing.expect(got == null);
+}
+
+test "readCache: corrupt file surfaces InvalidPayload (caller can choose to ignore)" {
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notify_corrupt_{d}", .{fs_compat.nanoTimestamp()});
+    fs_compat.deleteTreeAbsolute(dir) catch {};
+    try fs_compat.makeDirAbsolute(dir);
+    defer fs_compat.deleteTreeAbsolute(dir) catch {};
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
+    {
+        const f = try fs_compat.createFileAbsolute(path, .{});
+        defer f.close();
+        try f.writeAll("garbage{not_json");
+    }
+
+    try testing.expectError(error.InvalidPayload, notifier.readCache(testing.allocator, path));
+}


### PR DESCRIPTION
## Description

Adds a passive "newer malt is available" nudge that fires after a command succeeds, surfacing unannounced updates to users who never run `mt version update --check`. 

The check itself never blocks the command pipeline: post-dispatch hook, 24h cache at `$MALT_CACHE/version-notify.json`, 1500ms hard network ceiling, SIGINT short-circuited.

`MALT_NO_VERSION_NOTIFIER=1` silences it for everyone else.

## Related Issue

- None

## Notes for Reviewers

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)