### PR TITLE
test(install): kill flaky idempotent fall-through by skipping the network

### DIFF
--- a/tests/install_idempotent_test.zig
+++ b/tests/install_idempotent_test.zig
@@ -27,30 +27,6 @@ fn seedCellarKeg(prefix: []const u8, name: []const u8, version: []const u8) !voi
     try malt.fs_compat.cwd().makePath(dir);
 }
 
-/// Redirect fd 2 to /dev/null and return a saved dup. Subprocess stderr
-/// (e.g. `ditto` complaining about a deliberately-broken cask path)
-/// bypasses `io_mod.beginStderrCapture` since that only catches Zig
-/// writes — silencing fd 2 itself is the only way to keep `just coverage`
-/// output tidy.
-fn silenceStderr() std.c.fd_t {
-    const saved = std.c.dup(2);
-    if (saved < 0) return -1;
-    const dn = std.c.open("/dev/null", .{ .ACCMODE = .WRONLY }, @as(std.c.mode_t, 0));
-    if (dn < 0) {
-        _ = std.c.close(saved);
-        return -1;
-    }
-    _ = std.c.dup2(dn, 2);
-    _ = std.c.close(dn);
-    return saved;
-}
-
-fn restoreStderr(saved: std.c.fd_t) void {
-    if (saved < 0) return;
-    _ = std.c.dup2(saved, 2);
-    _ = std.c.close(saved);
-}
-
 fn setupPrefix(suffix: []const u8) ![:0]u8 {
     const path = try std.fmt.allocPrintSentinel(
         testing.allocator,
@@ -129,18 +105,17 @@ test "execute falls through when one of several args is missing from the Cellar"
         _ = c.unsetenv("MALT_PREFIX");
     }
 
-    try seedCellarKeg(prefix, "alpha", "1.0");
+    // Uppercase names fail api.validateName synchronously — keeps the
+    // fall-through pipeline off the network. "alpha" is a real Homebrew
+    // cask, so the prior fixture downloaded Alpha.app and crashed.
+    try seedCellarKeg(prefix, "ALPHA_FIXTURE", "1.0");
 
     const db_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.db", .{prefix});
     defer testing.allocator.free(db_file);
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
-    // The fall-through pipeline reaches a deliberately-broken cask
-    // extract; ditto writes its complaint straight to fd 2 — gate it.
-    const saved_stderr = silenceStderr();
-    defer restoreStderr(saved_stderr);
-    install.execute(arena.allocator(), &.{ "--quiet", "alpha", "missing" }) catch {};
+    install.execute(arena.allocator(), &.{ "--quiet", "ALPHA_FIXTURE", "MISSING_FIXTURE" }) catch {};
 
     try testing.expect(pathExists(db_file));
 }


### PR DESCRIPTION
## Description

The install_idempotent fall-through test sat on a network-dependent code path: it seeded `alpha` and probed `missing` against `install.execute`, but `alpha` is a real Homebrew cask, so the fall-through 404'd on `fetchFormula`, hit `installCask`, downloaded Alpha.app from sourceforge, and SIGABRTed intermittently on the cask installer's progress bar / ditto path. The build orchestrator surfaced this as a 1-in-N parallel-test crash that rejected pre-push hooks.

Switching to uppercase fixture names (`ALPHA_FIXTURE` / `MISSING_FIXTURE`) makes both `fetchFormula` and `fetchCask` return `InvalidName` synchronously - no HTTP, no progress bar, no subprocess. The fall-through still opens the DB, which is the only thing the test actually asserts. The `silenceStderr` / `restoreStderr` helpers become dead code once the noisy ditto path is gone, so they're removed too.

Test now finishes in ~200ms instead of 2-5s and 7/7 stress runs are green where the prior version was ~80% flaky.

## Related Issue

- None

## Notes for Reviewers

- None