### PR TITLE
fix(cli/install): pre-wipe cellar dst so clonefile survives stale kegs

### DIFF
--- a/scripts/regressions/install_zig_clonefail_gh85.sh
+++ b/scripts/regressions/install_zig_clonefail_gh85.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Regression: `mt install zig` against a prefix that already hosts a
+# `Cellar/<name>/<version>` directory (left over from a SIGKILLed prior run,
+# a partial warm-path failure, or a drop-in Homebrew prefix) used to
+# bubble out of v0.10.0 as:
+#
+#   ✗ Failed to materialize lld@21: CloneFailed (APFS clonefile or copy failed)
+#   ✗ Failed to materialize zstd:   CloneFailed (APFS clonefile or copy failed)
+#   ⚠ Skipping zig: dependency lld@21 failed to install
+#
+# clonefile(2) refuses to write into an existing directory (EEXIST), so the
+# cold-path materialise fails the moment any keg dir already exists at the
+# target path. The fix wipes cellar_path before clonefile, mirroring the
+# warm path's existing pre-wipe.
+#
+# Usage: scripts/regressions/install_zig_clonefail_gh85.sh
+# Requirements: built `malt` binary at $MALT_BIN or zig-out/bin/malt,
+# network access to ghcr.io / formulae.brew.sh.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+PREFIX="/tmp/mt_gh85b"
+export MALT_PREFIX="$PREFIX"
+# Deterministic output so `grep` matches plain strings, not ANSI/emoji.
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+TARGET="${TARGET:-zig}" # zig drags in lld@21 + zstd, the original bug pair
+
+# ── 1. Plant stale Cellar dirs at every DEP target. ────────────────────
+# These mimic leftovers from a SIGKILLed prior `mt install zig` or a
+# drop-in Homebrew prefix that already hosts the same kegs. We pin the
+# stale dirs at the same {name}/{version} malt is about to write — if
+# the `name` isn't on the dep list (e.g. the formula name moved), the
+# fixture is harmless and the regression simply doesn't fire.
+#
+# We deliberately leave Cellar/$TARGET/ absent so the top-level fastpath
+# (which only checks `Cellar/<top>` existence) does not short-circuit.
+STALE_DEPS=("lld@21:21.1.8_1" "llvm@21:21.1.8" "zstd:1.5.7_1" "lz4:1.10.0" "xz:5.8.3")
+for entry in "${STALE_DEPS[@]}"; do
+  dep="${entry%%:*}"
+  ver="${entry##*:}"
+  mkdir -p "$PREFIX/Cellar/$dep/$ver"
+  printf 'stale\n' >"$PREFIX/Cellar/$dep/$ver/STALE_FILE"
+done
+pass "planted stale Cellar/<dep>/<version> fixtures"
+
+# ── 2. Install — must complete cleanly and emit the success line. ──────
+LOG="$PREFIX/install.log"
+printf '▸ malt --debug install %s (logs → %s)\n' "$TARGET" "$LOG"
+"$BIN" --debug install "$TARGET" >"$LOG" 2>&1 || {
+  printf '==== last 40 lines of install log ====\n' >&2
+  tail -40 "$LOG" >&2
+  fail "install of $TARGET failed against a prefix with stale Cellar dirs"
+}
+pass "installed $TARGET"
+
+# ── 3. The exact regression markers must NOT appear. ───────────────────
+if grep -qE "Failed to materialize.*CloneFailed" "$LOG"; then
+  printf '==== materialize failures ====\n' >&2
+  grep -E "Failed to materialize" "$LOG" >&2
+  fail "regression: materialize failed with CloneFailed (gh#85)"
+fi
+pass "no CloneFailed materialise failures"
+
+if grep -qE "Skipping .*: dependency .* failed to install" "$LOG"; then
+  printf '==== dep skips ====\n' >&2
+  grep -E "Skipping " "$LOG" >&2
+  fail "regression: a dep was skipped because of a CloneFailed parent"
+fi
+pass "no dep skipped due to a failed parent"
+
+# ── 4. Stale fixtures got replaced by real keg content. ───────────────
+# clonefile would have refused to write into the planted dirs without
+# the cold-path pre-wipe; STALE_FILE absence proves the wipe happened
+# AND the real bottle landed.
+for entry in "${STALE_DEPS[@]}"; do
+  dep="${entry%%:*}"
+  ver="${entry##*:}"
+  if [[ -f "$PREFIX/Cellar/$dep/$ver/STALE_FILE" ]]; then
+    fail "STALE_FILE survived under Cellar/$dep/$ver — pre-wipe did not run"
+  fi
+  [[ -f "$PREFIX/Cellar/$dep/$ver/INSTALL_RECEIPT.json" ]] ||
+    fail "no INSTALL_RECEIPT.json under Cellar/$dep/$ver — bottle did not materialize"
+done
+pass "stale fixtures replaced; INSTALL_RECEIPT.json present for every dep"
+
+# ── 5. Re-installing on top of the just-installed keg also succeeds. ──
+# The same code path runs without warm cache for fresh installs and with
+# warm cache for the second run; pin both.
+LOG2="$PREFIX/install_warm.log"
+printf '▸ malt install %s (warm; logs → %s)\n' "$TARGET" "$LOG2"
+"$BIN" install "$TARGET" >"$LOG2" 2>&1 || {
+  printf '==== last 40 lines of warm install log ====\n' >&2
+  tail -40 "$LOG2" >&2
+  fail "warm reinstall of $TARGET failed"
+}
+pass "warm reinstall of $TARGET completed"
+
+printf '\n✔ gh85 install-zig clonefail regression passed\n'

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -126,7 +126,10 @@ pub fn materializeWithCellar(
         return CellarError.OutOfMemory;
     fs_compat.makeDirAbsolute(parent) catch |e| switch (e) {
         error.PathAlreadyExists => {},
-        else => return CellarError.CloneFailed,
+        else => {
+            std.log.debug("cellar parent mkdir {s}: {s}", .{ parent, @errorName(e) });
+            return CellarError.CloneFailed;
+        },
     };
 
     // Try keg_src first (exact version match), then scan for a revision
@@ -169,8 +172,14 @@ pub fn materializeWithCellar(
         fs_compat.deleteDirAbsolute(parent) catch {};
     }
 
-    // Clone from store to Cellar
-    clonefile.cloneTree(allocator, src, cellar_path) catch return CellarError.CloneFailed;
+    // clonefile(2) returns EEXIST on a populated dst; pre-wipe to match
+    // the warm path and survive a SIGKILLed prior run or drop-in keg.
+    fs_compat.deleteTreeAbsolute(cellar_path) catch {};
+
+    clonefile.cloneTree(allocator, src, cellar_path) catch |e| {
+        std.log.debug("cellar clonefile {s} -> {s}: {s}", .{ src, cellar_path, @errorName(e) });
+        return CellarError.CloneFailed;
+    };
 
     const new_prefix = atomic.maltPrefix();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -12,6 +12,24 @@ pub const panic = if (@import("builtin").mode == .Debug)
 else
     std.debug.simple_panic;
 
+// Gate `.debug` on the runtime --debug flag so release builds still
+// surface std.log.debug diagnostics in bug reports.
+pub const std_options: std.Options = .{
+    .log_level = .debug,
+    .logFn = maltLogFn,
+};
+
+fn maltLogFn(
+    comptime level: std.log.Level,
+    comptime scope: @EnumLiteral(),
+    comptime fmt: []const u8,
+    args: anytype,
+) void {
+    const output = @import("ui/output.zig");
+    if (level == .debug and !output.isDebug()) return;
+    std.log.defaultLog(level, scope, fmt, args);
+}
+
 /// Global interrupt flag — set by SIGINT handler, checked at install step boundaries.
 var interrupted: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 

--- a/tests/cellar_test.zig
+++ b/tests/cellar_test.zig
@@ -132,6 +132,60 @@ test "materialize handles version with revision suffix" {
     try testing.expect(!nested_exists);
 }
 
+test "materialize replaces a pre-existing Cellar/{name}/{version} directory (gh#85)" {
+    // Regression: clonefile(2) refuses to write into an existing directory
+    // (EEXIST), so a leftover keg from a SIGKILLed prior run, a partial
+    // warm-path failure, or a drop-in Homebrew prefix would surface as
+    // "CloneFailed (APFS clonefile or copy failed)" on every retry. The
+    // cold path now wipes cellar_path before the clone, mirroring the
+    // warm path's existing pre-wipe.
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        malt.fs_compat.deleteTreeAbsolute(prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+
+    try setupMaltDirs(testing.allocator, prefix);
+    try createBottleFixture(testing.allocator, prefix, "stale123", "lld@21", "21.1.8_1");
+
+    // Plant a stale keg at the exact destination malt is about to write.
+    const stale_keg = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/Cellar/lld@21/21.1.8_1",
+        .{prefix},
+    );
+    defer testing.allocator.free(stale_keg);
+    try malt.fs_compat.cwd().makePath(stale_keg);
+    const stale_file = try std.fmt.allocPrint(testing.allocator, "{s}/STALE_FILE", .{stale_keg});
+    defer testing.allocator.free(stale_file);
+    {
+        const f = try malt.fs_compat.createFileAbsolute(stale_file, .{});
+        try f.writeAll("stale\n");
+        f.close();
+    }
+
+    const old_env = setMaltPrefix(prefix);
+    defer restoreMaltPrefix(old_env);
+
+    const keg = try cellar_mod.materializeWithCellar(
+        testing.allocator,
+        prefix,
+        "stale123",
+        "lld@21",
+        "21.1.8_1",
+        ":any",
+    );
+    defer testing.allocator.free(keg.path);
+
+    // STALE_FILE must be gone: the cold path wiped the dir before clonefile.
+    try testing.expectError(error.FileNotFound, malt.fs_compat.accessAbsolute(stale_file, .{}));
+
+    // Fresh content from the bottle is in place.
+    var bin_buf: [512]u8 = undefined;
+    const bin_path = try std.fmt.bufPrint(&bin_buf, "{s}/bin/hello", .{keg.path});
+    try malt.fs_compat.accessAbsolute(bin_path, .{});
+}
+
 test "materialize handles exact version match (no revision)" {
     const prefix = try createTestDir(testing.allocator);
     defer {


### PR DESCRIPTION
## Description

`mt install <pkg>` against a prefix that already hosts a `Cellar/<name>/<version>` directory bubbled out as `CloneFailed (APFS clonefile or copy failed)` for every dep that hit the cold materialise path. clonefile(2) returns EEXIST on a populated dst, so any leftover keg from a SIGKILLed prior run, a partial warm-path failure, or a drop-in Homebrew prefix made every retry fail at exactly that step.

The cold path now wipes `cellar_path` before the clone, mirroring the warm path's existing pre-wipe. `--debug` is also wired through `std.log.debug` so future regressions in this area carry the underlying errno into bug reports without a binary rebuild.

## Related Issue

Fixes #85

## Notes for Reviewers

- None