### PR TITLE
fix(db/schema): broaden kegs UNIQUE to (name, version, revision)

### DIFF
--- a/scripts/regressions/upgrade_revision_bump.sh
+++ b/scripts/regressions/upgrade_revision_bump.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Regression: `mt upgrade` on a same-version revision-bump.
+#
+# Up to v0.10.1, an upgrade where Homebrew bumped only the formula's
+# revision suffix (e.g. libgit2 1.9.2 → 1.9.2_2, python@3.14 3.14.4 →
+# 3.14.4_1) failed inside recordKeg with:
+#
+#   ✗ Failed to record new version of <name> in database
+#
+# Cause: the kegs table carried `UNIQUE(name, version)`, and
+# upgradeFormula INSERTs the new keg row before deleting the old, so
+# two rows with the same upstream `version` collided. The old row
+# stayed put, the upgrade silently rolled back, and the same two
+# packages re-appeared as outdated on every subsequent `mt upgrade`.
+#
+# The fix is schema migration v4 → v5, which broadens the UNIQUE to
+# `UNIQUE(name, version, revision)`. This script verifies the migration
+# landed AND that the new constraint accepts the bug's exact data
+# pattern while still rejecting genuine duplicates.
+#
+# Usage: scripts/regressions/upgrade_revision_bump.sh
+# Requirements: built `malt` binary at $MALT_BIN or zig-out/bin/malt,
+# `sqlite3` on PATH, network access for the seeding install.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+PREFIX="/tmp/mt_revb"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+# Light formula: pulls no deps, lands fast, just enough to materialise
+# a malt prefix with an initialised DB so the migration ladder runs.
+SEED="${SEED:-tree}"
+DB="$PREFIX/db/malt.db"
+
+# --- 1. Seed a real malt install so the DB exists and migrations ran ---
+printf '\xe2\x96\xb8 seeding prefix with mt install %s\n' "$SEED"
+"$BIN" install "$SEED" >"$PREFIX/install.log" 2>&1 ||
+  fail "seed install of $SEED failed — see $PREFIX/install.log"
+pass "$SEED installed"
+
+[[ -f "$DB" ]] || fail "expected DB at $DB after install"
+
+# --- 2. schema_version reached v5 -------------------------------------
+SCHEMA_VER=$(sqlite3 "$DB" "SELECT MAX(version) FROM schema_version;")
+[[ "$SCHEMA_VER" == "5" ]] ||
+  fail "schema_version is $SCHEMA_VER, expected 5 (v4→v5 migration did not run)"
+pass "schema_version = 5"
+
+# --- 3. kegs table carries the broadened UNIQUE -----------------------
+# The UNIQUE shape is preserved verbatim in sqlite_master.sql by SQLite,
+# so a substring probe is exact.
+KEGS_SQL=$(sqlite3 "$DB" "SELECT sql FROM sqlite_master WHERE type='table' AND name='kegs';")
+echo "$KEGS_SQL" | grep -q "UNIQUE(name, version, revision)" ||
+  fail "kegs UNIQUE shape is not (name, version, revision); got:\n$KEGS_SQL"
+pass "kegs UNIQUE = (name, version, revision)"
+
+# Negative: the old (name, version) two-column shape must NOT linger.
+# The trailing `[^,]` rules out a substring match against the new
+# three-column shape `UNIQUE(name, version, revision)`.
+if echo "$KEGS_SQL" | grep -qE "UNIQUE\(name, version\)[^,]"; then
+  fail "kegs still carries old UNIQUE(name, version); migration was a no-op"
+fi
+pass "old UNIQUE(name, version) is gone"
+
+# --- 4. The exact bug pattern now succeeds -----------------------------
+# Replay the libgit2 1.9.2 → 1.9.2_2 case directly: two rows with the
+# same upstream version, different revisions, must coexist briefly
+# (this is what upgradeFormula's "INSERT new, then DELETE old" needs).
+sqlite3 "$DB" <<'SQL' || fail "INSERT pair for revision-bump rejected"
+INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+VALUES ('regtest_libgit2', 'regtest_libgit2', '1.9.2', 0, 'sha-old', '/tmp/c/regtest_libgit2/1.9.2');
+INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+VALUES ('regtest_libgit2', 'regtest_libgit2', '1.9.2', 2, 'sha-new', '/tmp/c/regtest_libgit2/1.9.2_2');
+SQL
+pass "two rows with same name+version, different revisions, coexist"
+
+# --- 5. Exact (name, version, revision) duplicate is still rejected ---
+DUP_OUT=$(
+  sqlite3 "$DB" <<'SQL' 2>&1 || true
+INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+VALUES ('regtest_libgit2', 'regtest_libgit2', '1.9.2', 2, 'sha-dup', '/tmp/c/regtest_libgit2/dup');
+SQL
+)
+echo "$DUP_OUT" | grep -qi "UNIQUE constraint failed" ||
+  fail "exact (name, version, revision) duplicate slipped through; got: $DUP_OUT"
+pass "exact (name, version, revision) duplicate rejected"
+
+# Cleanup the synthetic rows so a subsequent `mt list` doesn't surface them.
+sqlite3 "$DB" "DELETE FROM kegs WHERE name='regtest_libgit2';"
+
+printf '\n\xe2\x9c\x94 upgrade-revision-bump regression passed\n'

--- a/src/db/schema.zig
+++ b/src/db/schema.zig
@@ -104,6 +104,7 @@ pub fn migrate(db: *sqlite.Database) sqlite.SqliteError!void {
     if (ver < 2) try migrateV1toV2(db);
     if (ver < 3) try migrateV2toV3(db);
     if (ver < 4) try migrateV3toV4(db);
+    if (ver < 5) try migrateV4toV5(db);
 }
 
 fn migrateV1toV2(db: *sqlite.Database) sqlite.SqliteError!void {
@@ -205,6 +206,82 @@ fn migrateV3toV4(db: *sqlite.Database) sqlite.SqliteError!void {
     try db.commit();
 }
 
+/// v5 — broaden the kegs UNIQUE from `(name, version)` to
+/// `(name, version, revision)` so a Homebrew revision-bump upgrade
+/// (`1.9.2` → `1.9.2_2`) can transiently coexist with the old row
+/// during `recordKeg`'s "INSERT new, then DELETE old" sequence.
+/// SQLite has no `ALTER TABLE DROP CONSTRAINT`, so the table is
+/// rebuilt per the official recipe.
+fn migrateV4toV5(db: *sqlite.Database) sqlite.SqliteError!void {
+    // Substring-probe the stored CREATE statement: cheaper than a
+    // structural scan, and unique to v5 since this migration is the
+    // only writer of the new UNIQUE shape.
+    var already_migrated = false;
+    {
+        var stmt = try db.prepare(
+            \\SELECT sql FROM sqlite_master
+            \\WHERE type='table' AND name='kegs';
+        );
+        defer stmt.finalize();
+        if (try stmt.step()) {
+            const sql_ptr = stmt.columnText(0) orelse "";
+            const sql = std.mem.sliceTo(sql_ptr, 0);
+            if (std.mem.indexOf(u8, sql, "UNIQUE(name, version, revision)") != null) {
+                already_migrated = true;
+            }
+        }
+    }
+
+    if (already_migrated) {
+        // Schema is current; just bump the version marker for fixtures
+        // that pre-applied the table then reset schema_version.
+        try db.exec("INSERT OR IGNORE INTO schema_version (version) VALUES (5);");
+        return;
+    }
+
+    // FK toggle must live outside any transaction. Disabling lets us
+    // DROP `kegs` without tripping `dependencies.keg_id` / `links.keg_id`;
+    // the RENAME then rewrites those references at the new table.
+    try db.exec("PRAGMA foreign_keys=OFF;");
+    defer db.exec("PRAGMA foreign_keys=ON;") catch {};
+
+    try db.beginTransaction();
+    errdefer db.rollback();
+
+    try db.exec(
+        \\CREATE TABLE kegs_new (
+        \\    id            INTEGER PRIMARY KEY,
+        \\    name          TEXT NOT NULL,
+        \\    full_name     TEXT NOT NULL,
+        \\    version       TEXT NOT NULL,
+        \\    revision      INTEGER NOT NULL DEFAULT 0,
+        \\    tap           TEXT,
+        \\    store_sha256  TEXT NOT NULL,
+        \\    cellar_path   TEXT NOT NULL,
+        \\    installed_at  TEXT NOT NULL DEFAULT (datetime('now')),
+        \\    pinned        INTEGER NOT NULL DEFAULT 0,
+        \\    install_reason TEXT NOT NULL DEFAULT 'direct',
+        \\    UNIQUE(name, version, revision)
+        \\);
+    );
+    try db.exec(
+        \\INSERT INTO kegs_new
+        \\    (id, name, full_name, version, revision, tap, store_sha256,
+        \\     cellar_path, installed_at, pinned, install_reason)
+        \\SELECT id, name, full_name, version, revision, tap, store_sha256,
+        \\       cellar_path, installed_at, pinned, install_reason
+        \\FROM kegs;
+    );
+    try db.exec("DROP TABLE kegs;");
+    try db.exec("ALTER TABLE kegs_new RENAME TO kegs;");
+    try db.exec("CREATE INDEX IF NOT EXISTS idx_kegs_name ON kegs(name);");
+    try db.exec("CREATE INDEX IF NOT EXISTS idx_kegs_store ON kegs(store_sha256);");
+
+    try db.exec("INSERT OR IGNORE INTO schema_version (version) VALUES (5);");
+
+    try db.commit();
+}
+
 /// Query the current schema version.
 pub fn currentVersion(db: *sqlite.Database) sqlite.SqliteError!i64 {
     var stmt = try db.prepare("SELECT MAX(version) FROM schema_version;");
@@ -214,4 +291,35 @@ pub fn currentVersion(db: *sqlite.Database) sqlite.SqliteError!i64 {
     if (!has_row) return 0;
 
     return stmt.columnInt(0);
+}
+
+const testing = std.testing;
+
+// Regression: a Homebrew revision-bump upgrade ("1.9.2" → "1.9.2_2")
+// transiently coexists with the old row inside upgradeFormula's
+// "INSERT new, DELETE old" sequence. The kegs UNIQUE shape must
+// permit that pair; only an exact (name, version, revision) duplicate
+// should violate.
+test "kegs UNIQUE permits same name+version across revisions" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+        \\VALUES ('libgit2', 'libgit2', '1.9.2', 0, 'sha-old', '/c/libgit2/1.9.2');
+    );
+
+    // Same upstream version, bumped revision: must succeed.
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+        \\VALUES ('libgit2', 'libgit2', '1.9.2', 2, 'sha-new', '/c/libgit2/1.9.2_2');
+    );
+
+    // Exact (name, version, revision) duplicate: still rejected.
+    const dup = db.exec(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+        \\VALUES ('libgit2', 'libgit2', '1.9.2', 2, 'sha-dup', '/c/libgit2/dup');
+    );
+    try testing.expectError(sqlite.SqliteError.ConstraintViolation, dup);
 }

--- a/tests/db_schema_v2_test.zig
+++ b/tests/db_schema_v2_test.zig
@@ -40,7 +40,7 @@ fn tableExists(db: *sqlite.Database, name: [:0]const u8) !bool {
     return stmt.columnInt(0) == 1;
 }
 
-test "initSchema runs v1 then migrates to v3" {
+test "initSchema runs v1 then migrates to v5" {
     var tdb = try TempDb.init("init");
     defer tdb.deinit();
 
@@ -52,7 +52,7 @@ test "initSchema runs v1 then migrates to v3" {
     try testing.expect(try tableExists(&tdb.db, "bundle_members"));
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 4), ver);
+    try testing.expectEqual(@as(i64, 5), ver);
 }
 
 test "migrate is idempotent on re-run" {
@@ -64,7 +64,7 @@ test "migrate is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 4), ver);
+    try testing.expectEqual(@as(i64, 5), ver);
 }
 
 test "v4 migration adds pinned column to casks" {
@@ -94,7 +94,7 @@ test "v4 migration is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 4), ver);
+    try testing.expectEqual(@as(i64, 5), ver);
 }
 
 test "v3 migration adds commit_sha column to taps" {

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -327,3 +327,56 @@ test "pinSkip honours --force and audit_mode: pinned + override = no skip" {
     // unknown name: not pinned, not skipped
     try testing.expect(!upgrade.pinSkip(&db, "ghost", false, false));
 }
+
+// Regression: a Homebrew revision-bump upgrade leaves the old keg row
+// in place until step 8 of upgradeFormula, so recordKeg's INSERT must
+// not collide with it on (name, version) when only `revision` differs.
+// Pre-fix this aborted with SQLITE_CONSTRAINT_UNIQUE → "Failed to
+// record new version of <name> in database" — the bug from the user
+// report on libgit2 1.9.2 → 1.9.2_2 and python@3.14 3.14.4 → 3.14.4_1.
+test "recordKeg succeeds on a same-version revision-bump upgrade" {
+    const path = try setupPrefix("recordkeg_revision_bump");
+    defer testing.allocator.free(path);
+    defer malt.fs_compat.deleteTreeAbsolute(path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+
+    // Old row matches what `mt install libgit2` writes for revision 0:
+    // version='1.9.2', revision unset → defaults to 0.
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES ('libgit2', 'libgit2', '1.9.2', 'sha-old', '/cellar/libgit2/1.9.2');
+    );
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    // revision: 2 → pkg_version "1.9.2_2"; upstream `version` stays "1.9.2".
+    const formula_json =
+        \\{
+        \\  "name": "libgit2",
+        \\  "full_name": "libgit2",
+        \\  "tap": "homebrew/core",
+        \\  "revision": 2,
+        \\  "versions": {"stable": "1.9.2"}
+        \\}
+    ;
+    var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
+    defer formula.deinit();
+
+    const new_keg_id = try upgrade.recordKeg(&db, &formula, "sha-new", "/cellar/libgit2/1.9.2_2");
+
+    // Both rows must coexist briefly — upgradeFormula deletes the old
+    // one in step 8, after symlinks flip to the new keg.
+    var stmt = try db.prepare("SELECT COUNT(*) FROM kegs WHERE name='libgit2';");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    try testing.expectEqual(@as(i64, 2), stmt.columnInt(0));
+
+    var rev_stmt = try db.prepare("SELECT revision FROM kegs WHERE id = ?1;");
+    defer rev_stmt.finalize();
+    try rev_stmt.bindInt(1, new_keg_id);
+    _ = try rev_stmt.step();
+    try testing.expectEqual(@as(i64, 2), rev_stmt.columnInt(0));
+}


### PR DESCRIPTION
## Description

`mt upgrade` aborts with `Failed to record new version of <name> in database` whenever Homebrew bumps only the formula's revision suffix (e.g. `libgit2 1.9.2 → 1.9.2_2`, `python@3.14 3.14.4 → 3.14.4_1`). `upgradeFormula` INSERTs the new keg row before deleting the old, so two rows share the same `(name, version)` and hit the existing UNIQUE constraint. The old row stays put and the same packages reappear as outdated on every subsequent run.

Migration v4 → v5 rebuilds `kegs` with `UNIQUE(name, version, revision)` so the brief two-row window is legal; an exact `(name, version, revision)` duplicate is still rejected.

## Related Issue

- None

## Notes for Reviewers

- None

🤖 Generated with [claude-flow](https://github.com/ruvnet/ruflo)