### PR TITLE
fix(cli): preserve revision on rollback + pull new transitive deps on upgrade

### DIFF
--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -12,6 +12,7 @@ const store_mod = @import("../core/store.zig");
 const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
 const help = @import("help.zig");
+const formula_mod = @import("../core/formula.zig");
 
 /// `error.Aborted` is returned on every user-facing failure. The caller has
 /// already emitted a message via `output.err`; main.zig catches it and exits
@@ -43,7 +44,7 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     // Find current installed version
     var cur_stmt = db.prepare(
-        "SELECT id, version, store_sha256 FROM kegs WHERE name = ?1 ORDER BY installed_at DESC LIMIT 1;",
+        "SELECT id, version, revision, store_sha256 FROM kegs WHERE name = ?1 ORDER BY installed_at DESC LIMIT 1;",
     ) catch return error.Aborted;
     defer cur_stmt.finalize();
     cur_stmt.bindText(1, name) catch return error.Aborted;
@@ -56,6 +57,14 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     const current_id = cur_stmt.columnInt(0);
     const current_ver_ptr = cur_stmt.columnText(1);
     const current_ver = if (current_ver_ptr) |v| std.mem.sliceTo(v, 0) else "unknown";
+    const current_revision = cur_stmt.columnInt(2);
+
+    // pkg_version is what the on-disk Cellar / store dir is named after,
+    // so the store-scan below must compare against this — not the bare
+    // upstream `version` — to correctly skip a current revision-bumped
+    // keg (e.g. version="1.9.2", revision=2 → label "1.9.2_2").
+    var current_pkgver_buf: [128]u8 = undefined;
+    const current_pkg_version = formula_mod.pkgVersion(&current_pkgver_buf, current_ver, current_revision) catch current_ver;
 
     // Look for other store entries that contain this formula
     // by scanning the store directory for entries that have {name}/ subdirectory
@@ -88,8 +97,9 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
         var keg_iter = keg_dir.iterate();
         while (keg_iter.next() catch null) |ver_entry| {
             if (ver_entry.kind != .directory) continue;
-            // Skip current version
-            if (std.mem.eql(u8, ver_entry.name, current_ver)) continue;
+            // Compare against the on-disk pkg_version label so a
+            // revision-bumped current keg is skipped correctly.
+            if (std.mem.eql(u8, ver_entry.name, current_pkg_version)) continue;
 
             const sha = allocator.dupe(u8, entry.name) catch continue;
             const ver = allocator.dupe(u8, ver_entry.name) catch continue;
@@ -148,33 +158,18 @@ pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     db.beginTransaction() catch return error.Aborted;
     errdefer db.rollback();
 
-    {
-        var del = db.prepare("DELETE FROM kegs WHERE id = ?1;") catch return error.Aborted;
-        defer del.finalize();
-        del.bindInt(1, current_id) catch return error.Aborted;
-        // Step failure inside the txn must trigger rollback, not a silent commit.
-        _ = del.step() catch return error.Aborted;
-    }
-
-    {
-        var ins = db.prepare(
-            "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, install_reason, pinned)" ++
-                " VALUES (?1, ?1, ?2, ?3, ?4, 'direct', ?5);",
-        ) catch return error.Aborted;
-        defer ins.finalize();
-        ins.bindText(1, name) catch return error.Aborted;
-        ins.bindText(2, target.version) catch return error.Aborted;
-        ins.bindText(3, target.sha256) catch return error.Aborted;
-        ins.bindText(4, keg.path) catch return error.Aborted;
-        ins.bindInt(5, @intFromBool(old_pinned)) catch return error.Aborted;
-        // Step failure inside the txn must trigger rollback, not a silent commit.
-        _ = ins.step() catch return error.Aborted;
-    }
-
-    // Get new keg_id for linking
-    var id_stmt = db.prepare("SELECT last_insert_rowid();") catch return error.Aborted;
-    defer id_stmt.finalize();
-    const keg_id = if (id_stmt.step() catch false) id_stmt.columnInt(0) else return error.Aborted;
+    // target.version carries the on-disk pkg_version label (the store
+    // dir name), so replaceKegRow can split it back into version +
+    // revision and persist the rolled-back keg's true revision.
+    const keg_id = replaceKegRow(
+        &db,
+        current_id,
+        name,
+        target.version,
+        target.sha256,
+        keg.path,
+        old_pinned,
+    ) catch return error.Aborted;
 
     // Link the old version
     linker.link(keg.path, name, keg_id) catch {
@@ -198,4 +193,113 @@ pub fn capturePinnedById(db: *sqlite.Database, keg_id: i64) bool {
     stmt.bindInt(1, keg_id) catch return false;
     if (!(stmt.step() catch false)) return false;
     return stmt.columnBool(0);
+}
+
+/// Swap the keg row identified by `old_keg_id` for a fresh row pointing
+/// at `pkg_version` (the on-disk label, e.g. "1.9.2_2"). Splits the
+/// label into `version` + `revision` so the new row reflects the
+/// rolled-back keg's true revision instead of silently writing 0.
+/// Returns the new keg row id. Caller owns the surrounding transaction.
+pub fn replaceKegRow(
+    db: *sqlite.Database,
+    old_keg_id: i64,
+    name: []const u8,
+    pkg_version: []const u8,
+    store_sha256: []const u8,
+    cellar_path: []const u8,
+    pinned: bool,
+) !i64 {
+    const parsed = formula_mod.parsePkgVersion(pkg_version);
+
+    {
+        var del = try db.prepare("DELETE FROM kegs WHERE id = ?1;");
+        defer del.finalize();
+        try del.bindInt(1, old_keg_id);
+        _ = try del.step();
+    }
+
+    {
+        var ins = try db.prepare(
+            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason, pinned)
+            \\VALUES (?1, ?1, ?2, ?3, ?4, ?5, 'direct', ?6);
+        );
+        defer ins.finalize();
+        try ins.bindText(1, name);
+        try ins.bindText(2, parsed.version);
+        try ins.bindInt(3, parsed.revision);
+        try ins.bindText(4, store_sha256);
+        try ins.bindText(5, cellar_path);
+        try ins.bindInt(6, @intFromBool(pinned));
+        _ = try ins.step();
+    }
+
+    var id_stmt = try db.prepare("SELECT last_insert_rowid();");
+    defer id_stmt.finalize();
+    if (!(try id_stmt.step())) return error.RecordFailed;
+    return id_stmt.columnInt(0);
+}
+
+const testing = std.testing;
+
+test "replaceKegRow splits pkg_version into version + revision" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    // Current keg at revision=2; rollback target is revision=0 of same upstream version.
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, pinned)
+        \\VALUES ('libgit2', 'libgit2', '1.9.2', 2, 'sha-cur', '/c/libgit2/1.9.2_2', 1);
+    );
+    const old_id = blk: {
+        var s = try db.prepare("SELECT id FROM kegs WHERE name='libgit2';");
+        defer s.finalize();
+        _ = try s.step();
+        break :blk s.columnInt(0);
+    };
+
+    const new_id = try replaceKegRow(&db, old_id, "libgit2", "1.9.2", "sha-old", "/c/libgit2/1.9.2", true);
+
+    var stmt = try db.prepare("SELECT version, revision, pinned FROM kegs WHERE id = ?1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, new_id);
+    _ = try stmt.step();
+    const ver = stmt.columnText(0) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings("1.9.2", std.mem.sliceTo(ver, 0));
+    try testing.expectEqual(@as(i64, 0), stmt.columnInt(1));
+    try testing.expect(stmt.columnBool(2));
+}
+
+test "replaceKegRow recovers a non-zero revision from pkg_version" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+        \\VALUES ('python@3.14', 'python@3.14', '3.14.4', 1, 'sha-cur', '/c/python@3.14/3.14.4_1');
+    );
+    const old_id = blk: {
+        var s = try db.prepare("SELECT id FROM kegs WHERE name='python@3.14';");
+        defer s.finalize();
+        _ = try s.step();
+        break :blk s.columnInt(0);
+    };
+
+    // Rolling back to an earlier revision-2 build.
+    const new_id = try replaceKegRow(&db, old_id, "python@3.14", "3.14.3_2", "sha-old", "/c/python@3.14/3.14.3_2", false);
+
+    var stmt = try db.prepare("SELECT version, revision FROM kegs WHERE id = ?1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, new_id);
+    _ = try stmt.step();
+    const ver = stmt.columnText(0) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings("3.14.3", std.mem.sliceTo(ver, 0));
+    try testing.expectEqual(@as(i64, 2), stmt.columnInt(1));
+
+    // Old row was deleted in the same swap.
+    var cnt = try db.prepare("SELECT COUNT(*) FROM kegs WHERE name='python@3.14';");
+    defer cnt.finalize();
+    _ = try cnt.step();
+    try testing.expectEqual(@as(i64, 1), cnt.columnInt(0));
 }

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -19,6 +19,7 @@ const linker_mod = @import("../core/linker.zig");
 const ghcr_mod = @import("../net/ghcr.zig");
 const help = @import("help.zig");
 const pin_mod = @import("pin.zig");
+const install_mod = @import("install.zig");
 
 const UpgradeFlag = enum { quiet, cask, formula, dry_run, force, pinned };
 
@@ -240,6 +241,23 @@ fn upgradeFormula(
 
     output.info("Upgrading {s} {s} -> {s}...", .{ name, old_version, formula.pkg_version });
     output.emitNdjsonEvent(allocator, .resolved, name, null);
+
+    // Bottles bake LC_LOAD_DYLIB paths against their own dep set, so a
+    // dep introduced after the previously-installed version must be
+    // materialised before the new bottle relocates / links — otherwise
+    // dyld errors at first use (e.g. curl 8.20 added libngtcp2 that
+    // 8.19 did not have).
+    {
+        const missing = collectMissingDepNames(allocator, db, formula.dependencies) catch &.{};
+        defer if (missing.len > 0) allocator.free(missing);
+        if (missing.len > 0) {
+            output.info("Installing new dep(s) for {s} ({d})...", .{ name, missing.len });
+            install_mod.installAll(allocator, missing, .{}) catch {
+                output.err("Could not install new dep(s) for {s}", .{name});
+                return error.Aborted;
+            };
+        }
+    }
 
     // Step 3: Resolve bottle for new version
     const bottle = formula_mod.resolveBottle(allocator, &formula) catch {
@@ -654,4 +672,64 @@ fn upgradeAllCasks(allocator: std.mem.Allocator, db: *sqlite.Database, api: *api
         for (failed_tokens.items) |token| output.err("  - {s}", .{token});
         return error.Aborted;
     }
+}
+
+/// Filter `dep_names` to those not yet recorded in `kegs`. Caller owns
+/// the outer slice; the entries borrow from `dep_names`.
+///
+/// This is the seam upgrade uses to catch transitive deps that the
+/// previously-installed bottle didn't have but the new bottle does
+/// (e.g. curl 8.20 introduces a runtime dep on libngtcp2 that wasn't
+/// part of curl 8.19's dep set).
+pub fn collectMissingDepNames(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    dep_names: []const []const u8,
+) ![][]const u8 {
+    var missing: std.ArrayList([]const u8) = .empty;
+    errdefer missing.deinit(allocator);
+
+    for (dep_names) |n| {
+        if (!isFormulaInstalled(db, n)) try missing.append(allocator, n);
+    }
+    return missing.toOwnedSlice(allocator);
+}
+
+const testing = std.testing;
+
+test "collectMissingDepNames returns deps absent from the DB" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES ('alpha', 'alpha', '1.0', 'sha-a', '/c/alpha/1.0');
+    );
+
+    const deps = [_][]const u8{ "alpha", "beta", "gamma" };
+    const missing = try collectMissingDepNames(testing.allocator, &db, &deps);
+    defer testing.allocator.free(missing);
+
+    try testing.expectEqual(@as(usize, 2), missing.len);
+    try testing.expectEqualStrings("beta", missing[0]);
+    try testing.expectEqualStrings("gamma", missing[1]);
+}
+
+test "collectMissingDepNames returns an empty slice when all deps are installed" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES ('alpha', 'alpha', '1.0', 'sha-a', '/c/alpha/1.0'),
+        \\       ('beta',  'beta',  '1.0', 'sha-b', '/c/beta/1.0');
+    );
+
+    const deps = [_][]const u8{ "alpha", "beta" };
+    const missing = try collectMissingDepNames(testing.allocator, &db, &deps);
+    defer testing.allocator.free(missing);
+
+    try testing.expectEqual(@as(usize, 0), missing.len);
 }

--- a/src/core/formula.zig
+++ b/src/core/formula.zig
@@ -368,3 +368,52 @@ pub fn resolveAlias(allocator: std.mem.Allocator, name: []const u8, json_data: [
 
     return null;
 }
+
+/// Inverse of `pkgVersion`. Returns the upstream version slice (borrowed
+/// from `label`) and the trailing revision integer. Anything that isn't
+/// a strict `<…>_<digits>` suffix is treated as part of the version
+/// (e.g. Homebrew-style `0.1.0_p1`), so the round-trip
+/// `pkgVersion(parsePkgVersion(s)) == s` only holds for labels this
+/// tool actually emits.
+pub const ParsedPkgVersion = struct { version: []const u8, revision: i64 };
+
+pub fn parsePkgVersion(label: []const u8) ParsedPkgVersion {
+    const us = std.mem.lastIndexOfScalar(u8, label, '_') orelse
+        return .{ .version = label, .revision = 0 };
+    const tail = label[us + 1 ..];
+    if (tail.len == 0) return .{ .version = label, .revision = 0 };
+    const rev = std.fmt.parseInt(i64, tail, 10) catch
+        return .{ .version = label, .revision = 0 };
+    if (rev < 0) return .{ .version = label, .revision = 0 };
+    return .{ .version = label[0..us], .revision = rev };
+}
+
+const testing = std.testing;
+
+test "parsePkgVersion splits revision suffix" {
+    const r = parsePkgVersion("1.9.2_2");
+    try testing.expectEqualStrings("1.9.2", r.version);
+    try testing.expectEqual(@as(i64, 2), r.revision);
+}
+
+test "parsePkgVersion treats no-suffix as revision zero" {
+    const r = parsePkgVersion("1.0.0");
+    try testing.expectEqualStrings("1.0.0", r.version);
+    try testing.expectEqual(@as(i64, 0), r.revision);
+}
+
+test "parsePkgVersion preserves non-numeric underscore tails" {
+    // Homebrew patch-level versions like `0.1.0_p1` are part of the
+    // upstream version, not a revision bump.
+    const r = parsePkgVersion("0.1.0_p1");
+    try testing.expectEqualStrings("0.1.0_p1", r.version);
+    try testing.expectEqual(@as(i64, 0), r.revision);
+}
+
+test "parsePkgVersion round-trips with pkgVersion" {
+    var buf: [64]u8 = undefined;
+    const formatted = try pkgVersion(&buf, "3.14.4", 1);
+    const r = parsePkgVersion(formatted);
+    try testing.expectEqualStrings("3.14.4", r.version);
+    try testing.expectEqual(@as(i64, 1), r.revision);
+}


### PR DESCRIPTION
## Description

Two fixes surfaced while validating [#223](https://github.com/indaco/malt/pull/223).

**`mt rollback`** wrote `revision=0` for every restored keg and compared the store-iter against the bare upstream `version`, so a revision-bumped current keg could be rolled back to itself. Adds `formula.parsePkgVersion` (inverse of `pkgVersion`) and a `replaceKegRow` seam that splits the on-disk pkg_version label back into `version + revision`.

**`mt upgrade`** materialised the new bottle without checking whether its dep set had grown — when upstream added a new direct dep (e.g. `curl 8.19 → 8.20` introduced `libngtcp2`) the new bottle linked against a missing dylib and dyld errored on first use. Adds `collectMissingDepNames` and dispatches the diff through `installAll` before the upgrade's existing materialise → patch → link path.

## Related Issue

Surfaced during smoke-testing of #223 (the user's `/opt/malt/bin/curl` was broken after `mt upgrade curl`).

## Notes for Reviewers

- None

🤖 Generated with [claude-flow](https://github.com/ruvnet/ruflo)