### PR TITLE
refactor: ship single binary; mt is a symlink to malt

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,13 +18,11 @@ builds:
 universal_binaries:
   - replace: true
     name_template: malt
-    # Drop the `mt` alias next to the universal binary so it ends up
-    # inside the release tarball. Matches what `zig build` produces,
-    # what install.sh creates via symlink, and what the homebrew_casks
-    # stanza below already declares.
+    # `mt` ships as a symlink to `malt` — relative target stays valid
+    # wherever the tarball is extracted. Matches `zig build` + install.sh.
     hooks:
       post:
-        - cmd: cp "{{ .Path }}" "{{ dir .Path }}/mt"
+        - cmd: ln -sfn malt "{{ dir .Path }}/mt"
 
 archives:
   - formats: ["tar.gz"]
@@ -85,7 +83,6 @@ homebrew_casks:
         install: |
           if OS.mac?
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/malt"]
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/mt"]
           end
 
 release:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ cd malt
 ./scripts/install.sh
 ```
 
-Building requires [Zig 0.16.x](https://ziglang.org/download/) and produces both `malt` and `mt` (a built-in alias) in `zig-out/bin/`. For development builds (debug, tests, universal binary), see [Development builds](#development-builds).
+Building requires [Zig 0.16.x](https://ziglang.org/download/) and produces `malt` in `zig-out/bin/` with `mt` next to it as a symlink to `malt`. For development builds (debug, tests, universal binary), see [Development builds](#development-builds).
 
 ### First commands
 
@@ -129,7 +129,7 @@ mt outdated                       # what has updates available
 mt upgrade ripgrep                # atomic; old version is restored on failure
 ```
 
-`mt` and `malt` are the same binary; both names ship with every install method. Additional aliases: `remove` for `uninstall`, `ls` for `list`. Anywhere a flag accepts `--formula` or `--cask`, it also accepts `--formulae` or `--casks` - pick whichever reads more naturally.
+`mt` and `malt` are the same binary — `mt` is a symlink to `malt` and ships with every install method. Additional aliases: `remove` for `uninstall`, `ls` for `list`. Anywhere a flag accepts `--formula` or `--cask`, it also accepts `--formulae` or `--casks` - pick whichever reads more naturally.
 
 If you typed something malt doesn't implement, malt checks for `brew` and silently delegates. If `brew` isn't installed:
 
@@ -193,7 +193,8 @@ Commands grouped by what you're doing. Every command works with `malt` or `mt`, 
 At a glance - `malt -h`:
 
 ```text
-malt - a fast macOS package manager (Homebrew-compatible)
+malt — a fast, drop-in Homebrew alternative for macOS.
+Warm installs in milliseconds. post_install scripts that actually run.
 
 Usage: malt <command> [options] [arguments]
        mt <command> [options] [arguments]    (alias)

--- a/build.zig
+++ b/build.zig
@@ -86,11 +86,14 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addIncludePath(b.path("vendor/"));
     exe.root_module.addIncludePath(b.path("c/"));
 
-    b.installArtifact(exe);
+    const malt_install = b.addInstallArtifact(exe, .{});
+    b.getInstallStep().dependOn(&malt_install.step);
 
-    // Install "mt" as a copy of "malt" so both names work out of the box
-    const mt_copy = b.addInstallBinFile(exe.getEmittedBin(), "mt");
-    b.getInstallStep().dependOn(&mt_copy.step);
+    // `mt` is a symlink to `malt` — half the disk, one binary to update.
+    const mt_symlink = b.addSystemCommand(&.{ "ln", "-sfn", "malt", "mt" });
+    mt_symlink.setCwd(.{ .cwd_relative = b.getInstallPath(.bin, "") });
+    mt_symlink.step.dependOn(&malt_install.step);
+    b.getInstallStep().dependOn(&mt_symlink.step);
 
     // --- Run step ---
     const run_cmd = b.addRunArtifact(exe);
@@ -374,9 +377,9 @@ pub fn build(b: *std.Build) void {
     const install_universal = b.addInstallBinFile(universal_output, "malt");
     universal_step.dependOn(&install_universal.step);
 
-    // Ship the `mt` alias alongside the universal binary so the
-    // release tarball contains both names — matches the default
-    // `zig build` install layout and what the README promises.
-    const install_universal_mt = b.addInstallBinFile(universal_output, "mt");
-    universal_step.dependOn(&install_universal_mt.step);
+    // Mirror the default install layout: `mt` is a symlink to `malt`.
+    const universal_mt_symlink = b.addSystemCommand(&.{ "ln", "-sfn", "malt", "mt" });
+    universal_mt_symlink.setCwd(.{ .cwd_relative = b.getInstallPath(.bin, "") });
+    universal_mt_symlink.step.dependOn(&install_universal.step);
+    universal_step.dependOn(&universal_mt_symlink.step);
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -184,13 +184,8 @@ if [ -z "$LATEST" ]; then
   info "Installing to ${INSTALL_DIR}..."
   $SUDO install -m 755 "$BINARY_PATH" "${INSTALL_DIR}/${BINARY}"
 
-  # `zig build` produces both `malt` and `mt`. Install the real `mt`
-  # if it's there; otherwise fall back to a symlink.
-  if [ -f "${BUILD_BIN_DIR}/mt" ]; then
-    $SUDO install -m 755 "${BUILD_BIN_DIR}/mt" "${INSTALL_DIR}/mt"
-  else
-    $SUDO ln -sf "${INSTALL_DIR}/${BINARY}" "${INSTALL_DIR}/mt"
-  fi
+  # `mt` is a symlink to `malt`. Relative target survives prefix moves.
+  $SUDO ln -sfn "${BINARY}" "${INSTALL_DIR}/mt"
 
 else
   VERSION="${LATEST#v}"
@@ -266,24 +261,18 @@ else
   info "Extracting..."
   tar -xzf "$TMPDIR/$ARCHIVE_NAME" -C "$TMPDIR"
 
-  # Find the binaries (may be in a subdirectory). `-perm -u+x` is
+  # Find the binary (may be in a subdirectory). `-perm -u+x` is
   # portable across BSD and GNU find; the old `+111` form is
   # deprecated BSD syntax.
   BINARY_PATH=$(find "$TMPDIR" -name "$BINARY" -type f -perm -u+x | head -1)
   [ -n "$BINARY_PATH" ] || error "Binary '${BINARY}' not found in archive"
-  MT_PATH=$(find "$TMPDIR" -name mt -type f -perm -u+x | head -1)
 
   # ── Install binary ──────────────────────────────────────────────
   info "Installing to ${INSTALL_DIR}..."
   $SUDO install -m 755 "$BINARY_PATH" "${INSTALL_DIR}/${BINARY}"
 
-  # Install `mt` — prefer the real binary shipped in the archive,
-  # fall back to a symlink if it isn't there.
-  if [ -n "$MT_PATH" ]; then
-    $SUDO install -m 755 "$MT_PATH" "${INSTALL_DIR}/mt"
-  else
-    $SUDO ln -sf "${INSTALL_DIR}/${BINARY}" "${INSTALL_DIR}/mt"
-  fi
+  # `mt` is a symlink to `malt`. Relative target survives prefix moves.
+  $SUDO ln -sfn "${BINARY}" "${INSTALL_DIR}/mt"
 fi
 
 # ── Create prefix directory ─────────────────────────────────────────

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -190,11 +190,16 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         output.err("Cannot determine current binary path", .{});
         return error.Aborted;
     };
-    const self_exe = self_exe_buf[0..n];
+    // `mt` is a symlink to `malt`; resolve through it so atomicReplace
+    // rewrites the real binary instead of clobbering the symlink.
+    var resolved_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const self_exe = if (std.Io.Dir.cwd().realPathFile(ctx.io, self_exe_buf[0..n], &resolved_buf)) |m|
+        resolved_buf[0..m]
+    else |_|
+        self_exe_buf[0..n];
 
-    // install.sh ships two independent binaries (`malt` and `mt`) side by
-    // side; swapping only the invoked one leaves the other on the old
-    // version. Detect the twin so we can update both in lockstep.
+    // Legacy installs shipped both names as regular files; the sibling
+    // still needs its own swap. Symlink layouts return null here.
     var twin_buf: [std.fs.max_path_bytes]u8 = undefined;
     const twin_path: ?[]const u8 = resolveTwinRegularFile(ctx.io, self_exe, &twin_buf);
 
@@ -252,6 +257,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             notifier.markUpdatedTo(ctx, tag, latest);
             return;
         };
+        // Collapse the legacy dual-binary layout into the symlink layout
+        // (`mt` → `malt`). Best-effort: a failure here leaves both binaries
+        // up-to-date, just without the disk savings.
+        migrateTwinToSymlink(ctx, self_exe, mode_after_self) catch |e| {
+            output.warn("Could not migrate {s} to a symlink ({s}); both binaries are on {s}.", .{ tp, @errorName(e), latest });
+        };
+
         output.info("Updated {s} and {s} to {s} (previous kept at *.old)", .{ self_exe, tp, latest });
         notifier.markUpdatedTo(ctx, tag, latest);
         return;
@@ -309,6 +321,34 @@ fn installBinaryViaSudo(ctx: *const AppCtx, allocator: std.mem.Allocator, new_bi
     switch (term) {
         .exited => |code| if (code != 0) return error.SudoFailed,
         else => return error.SudoFailed,
+    }
+}
+
+/// Replace the legacy `mt` regular file with a symlink to `malt` so the
+/// install converges on the new layout after a self-update from a
+/// pre-symlink release. `ln -sfn` removes any existing file at the path
+/// (regular or symlink) before relinking, so this is idempotent.
+fn migrateTwinToSymlink(
+    ctx: *const AppCtx,
+    self_exe: []const u8,
+    mode: ReplaceMode,
+) !void {
+    // `mt` is always the symlink, `malt` is always the real binary —
+    // pick the right path regardless of which name the user invoked.
+    const dir = std.fs.path.dirname(self_exe) orelse return error.NoInstallDir;
+    var mt_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const mt_path = try std.fmt.bufPrint(&mt_buf, "{s}/mt", .{dir});
+
+    const argv: []const []const u8 = if (mode == .sudo)
+        &.{ "sudo", "ln", "-sfn", "malt", mt_path }
+    else
+        &.{ "ln", "-sfn", "malt", mt_path };
+
+    var child = std.process.spawn(ctx.io, .{ .argv = argv }) catch return error.SpawnFailed;
+    const term = child.wait(ctx.io) catch return error.SpawnFailed;
+    switch (term) {
+        .exited => |code| if (code != 0) return error.LinkFailed,
+        else => return error.LinkFailed,
     }
 }
 

--- a/tests/version_update_test.zig
+++ b/tests/version_update_test.zig
@@ -110,9 +110,10 @@ test "writeResponseBody: createFileAbsolute failure leaves zero leaked allocatio
 
 // --- resolveTwinRegularFile ---------------------------------------------
 //
-// install.sh ships two independent binaries (`malt` and `mt`). The updater
-// has to swap both in lockstep, otherwise `malt --version` and `mt --version`
-// drift apart. These tests pin the twin-detection contract.
+// `mt` is a symlink to `malt` on fresh installs, but pre-symlink releases
+// shipped both as independent regular files. The updater has to detect
+// that legacy layout and swap both in lockstep — these tests pin the
+// twin-detection contract for back-compat.
 
 fn writeFile(path: []const u8, content: []const u8) !void {
     const f = try fs_compat.createFileAbsolute(std.Options.debug_io, path, .{});


### PR DESCRIPTION
## Description

The `mt` alias used to be a copy of `malt` across every install path —
`zig build`, the goreleaser universal-binary hook, `install.sh`, and the
Homebrew cask. Every install carried two identical 3.5 MB binaries.

This PR collapses each path to a single binary plus a relative-target
symlink (`mt → malt`):

| Path | Before | After |
|---|---|---|
| `zig build` (default + universal) | `b.addInstallBinFile(..., "mt")` | `ln -sfn malt mt` step |
| `.goreleaser.yaml` (universal hook) | `cp` | `ln -sfn malt` + dropped redundant `xattr` on the alias |
| `scripts/install.sh` (build path + release path) | install both, fallback to symlink | always symlink, dropped the `MT_PATH` find |
| Release tarball | ~6.8 MB | **~3.5 MB** (verified via `goreleaser release --snapshot`) |

`mt` argv-dispatch was already a no-op (`src/main.zig:319` skips
`argv[0]`), so the binary was always name-agnostic — the symlink swap is
purely a packaging refactor.

### Updater changes for the new layout

`src/cli/version_update.zig`:

- **realpath the running binary** before swap. `executablePath` returns
  the path the user invoked; if it's a symlink (`mt`), `atomicReplace`
  would clobber the symlink with a regular file and leave the real
  binary stale. Resolving through it ensures the swap rewrites `malt`
  and the symlink keeps tracking.
- **Legacy → symlink migration.** After a successful dual-binary swap
  on a pre-symlink install, replace `mt` with `ln -sfn malt mt` so old
  installs converge on the new layout. Best-effort: any failure here
  leaves both binaries on the new version, just without the disk
  savings.

The existing `resolveTwinRegularFile` contract is preserved as the
back-compat path for legacy installs (still tested by
`tests/version_update_test.zig`).

## Related Issue

None.

## Notes for Reviewers

**End-user behaviour:** unchanged. Both names still work, `--version`
output is identical, and `mt version update` from any install layout (new symlink, legacy dual-binary, or invoked via either name) lands on the new version cleanly.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)