### PR TITLE
fix(cli/install): refuse to install malt itself

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -28,6 +28,7 @@ pub const PrefixError = args_mod.PrefixError;
 pub const checkPrefixSane = args_mod.checkPrefixSane;
 pub const isTapFormula = args_mod.isTapFormula;
 pub const isLocalFormulaPath = args_mod.isLocalFormulaPath;
+pub const isSelfInstall = args_mod.isSelfInstall;
 pub const parseTapName = args_mod.parseTapName;
 pub const isAllowedArchiveUrl = args_mod.isAllowedArchiveUrl;
 pub const interpolateVersion = args_mod.interpolateVersion;
@@ -219,6 +220,17 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     if (packages.items.len == 0) {
         output.err("No package names specified", .{});
         return InstallError.NoPackages;
+    }
+
+    // Refuse self-install in every shape the dispatcher accepts.
+    // `mt version update` is the supported upgrade channel; letting
+    // install proceed would relink `<prefix>/bin/malt` outside its
+    // rev/origin tracking.
+    for (packages.items) |pkg| {
+        if (isSelfInstall(pkg)) {
+            output.err("Refusing to install malt itself ('{s}'). Use 'mt version update' to upgrade.", .{pkg});
+            return error.Aborted;
+        }
     }
 
     // Bare `--use-system-ruby` only valid for a single formula; otherwise

--- a/src/cli/install/args.zig
+++ b/src/cli/install/args.zig
@@ -21,6 +21,16 @@ pub fn checkPrefixSane(prefix: []const u8) PrefixError!void {
     if (prefix.len > max_prefix_sane_len) return error.PrefixAbsurd;
 }
 
+/// True when `arg` resolves to malt itself in any dispatcher-accepted
+/// shape: `malt`/`mt`, `<user>/<repo>/malt`, or `*/malt.rb`. The last
+/// path segment (with optional `.rb` stripped) is matched against the
+/// binary names. `mt update` is the supported upgrade channel.
+pub fn isSelfInstall(arg: []const u8) bool {
+    const tail = if (std.mem.lastIndexOfScalar(u8, arg, '/')) |i| arg[i + 1 ..] else arg;
+    const stem = if (std.mem.endsWith(u8, tail, ".rb")) tail[0 .. tail.len - 3] else tail;
+    return std.mem.eql(u8, stem, "malt") or std.mem.eql(u8, stem, "mt");
+}
+
 /// Check if a package name is a tap formula (user/repo/formula format).
 pub fn isTapFormula(name: []const u8) bool {
     var slash_count: u32 = 0;

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -63,6 +63,32 @@ test "parseGhcrUrl returns null for non-GHCR and malformed URLs" {
     try testing.expect(install.parseGhcrUrl("") == null);
 }
 
+test "isSelfInstall catches every shape that would relink malt" {
+    // bare names
+    try testing.expect(install.isSelfInstall("malt"));
+    try testing.expect(install.isSelfInstall("mt"));
+    // tap slugs
+    try testing.expect(install.isSelfInstall("indaco/tap/malt"));
+    try testing.expect(install.isSelfInstall("indaco/homebrew-tap/mt"));
+    // local .rb paths (relative, absolute, tilde)
+    try testing.expect(install.isSelfInstall("./malt.rb"));
+    try testing.expect(install.isSelfInstall("/tmp/malt.rb"));
+    try testing.expect(install.isSelfInstall("~/f/mt.rb"));
+}
+
+test "isSelfInstall lets unrelated names through" {
+    try testing.expect(!install.isSelfInstall("wget"));
+    try testing.expect(!install.isSelfInstall("homebrew/core/wget"));
+    try testing.expect(!install.isSelfInstall("./wget.rb"));
+    // Substring matches must not trip the guard.
+    try testing.expect(!install.isSelfInstall("malted"));
+    try testing.expect(!install.isSelfInstall("mtr"));
+    try testing.expect(!install.isSelfInstall("user/tap/malted"));
+    // Empty and slash-only inputs.
+    try testing.expect(!install.isSelfInstall(""));
+    try testing.expect(!install.isSelfInstall("/"));
+}
+
 test "isTapFormula recognises the 'user/repo/formula' shape" {
     try testing.expect(install.isTapFormula("homebrew/core/wget"));
     try testing.expect(install.isTapFormula("user/tap/myformula"));


### PR DESCRIPTION
## Description

Closes a footgun where `mt install malt` (or `mt install indaco/tap/malt`, or `mt install ./malt.rb`) would resolve, fetch, materialize, and silently relink `<prefix>/bin/malt` outside the `mt version update` channel - bypassing rev/origin tracking and shadowing the running binary.

The install path now refuses any package that would land at malt's binary name in every accepted shape (bare, tap slug, local `.rb`), with a short message redirecting users to `mt version update`.

## Related Issue

- None

## Notes for Reviewers

- A few intentional consequences worth confirming:
  - A third-party tap formula literally named `malt`/`mt` is also refused. That's the intended effect - anything that would land at `<prefix>/bin/malt` is the thing we're protecting against.
  - `--only-dependencies indaco/tap/malt` is refused too. Malt has zero formula deps today; if that ever changes the guard can be relaxed for that flag.
