### PR TITLE
refactor(cli/purge): sectioned housekeeping output, summary table, --verbose

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -127,6 +127,7 @@ pub fn build(b: *std.Build) void {
         "tests/completions_test.zig",
         "tests/backup_test.zig",
         "tests/purge_test.zig",
+        "tests/purge_output_test.zig",
         "tests/install_test.zig",
         "tests/install_parse_cache_test.zig",
         "tests/deps_leak_test.zig",

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -359,7 +359,8 @@ pub const zsh_script =
     \\                        '--keep-cache[--wipe only: leave the cache directory intact]' \
     \\                        '--remove-binary[--wipe only: also unlink /usr/local/bin/{mt,malt}]' \
     \\                        '(--yes -y)'{--yes,-y}'[Skip every typed confirmation]' \
-    \\                        '(--dry-run -n)'{--dry-run,-n}'[Preview without removing]'
+    \\                        '(--dry-run -n)'{--dry-run,-n}'[Preview without removing]' \
+    \\                        '(--verbose -v)'{--verbose,-v}'[Show every per-scope item; no truncation, full SHAs]'
     \\                    ;;
     \\                version)
     \\                    _values 'subcommand' 'update[Self-update the binary]'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -352,6 +352,7 @@ const purge_help =
     \\  --dry-run, -n        Preview only
     \\  --yes, -y            Skip every typed confirmation prompt
     \\  --quiet, -q          Suppress per-item output
+    \\  --verbose, -v        Show every per-scope item (no truncation, full SHAs)
     \\  --backup, -b <path>  Write a `mt restore`-compatible manifest first
     \\
     \\--wipe-only flags:

--- a/src/cli/purge.zig
+++ b/src/cli/purge.zig
@@ -12,6 +12,7 @@ const args_mod = @import("purge/args.zig");
 const wipe_mod = @import("purge/wipe.zig");
 const scopes_mod = @import("purge/scopes.zig");
 const util = @import("purge/util.zig");
+const report = @import("purge/report.zig");
 
 pub const Error = args_mod.Error;
 pub const Scope = args_mod.Scope;
@@ -78,6 +79,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     var lk_maybe: ?lock_mod.LockFile = lock_mod.LockFile.acquire(lock_path, 30_000) catch null;
     defer if (lk_maybe) |*lk| lk.release();
 
+    var summary = report.Summary{};
+    defer summary.deinit(allocator);
     var grand_total: TierResult = .{};
 
     // unused-deps must run before store-orphans: removing a keg decrements
@@ -85,40 +88,51 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // second pass.
     if (opts.scope.unused_deps) {
         const r = try scopes_mod.runUnusedDeps(ctx, allocator, prefix, dry_run);
+        try summary.add(allocator, .{ .name = "unused-deps", .removed = r.removed, .bytes = r.bytes });
         grand_total.removed += r.removed;
         grand_total.bytes += r.bytes;
     }
     if (opts.scope.store_orphans) {
         const r = try scopes_mod.runStoreOrphans(ctx, allocator, prefix, dry_run);
+        try summary.add(allocator, .{ .name = "store-orphans", .removed = r.removed, .bytes = r.bytes });
         grand_total.removed += r.removed;
         grand_total.bytes += r.bytes;
     }
     if (opts.scope.cache) {
         const r = try scopes_mod.runCache(ctx, allocator, cache_dir, opts.cache_days, dry_run);
+        try summary.add(allocator, .{ .name = "cache", .removed = r.removed, .bytes = r.bytes });
         grand_total.removed += r.removed;
         grand_total.bytes += r.bytes;
     }
     if (opts.scope.downloads) {
         const r = try scopes_mod.runDownloads(ctx, allocator, cache_dir, dry_run);
+        try summary.add(allocator, .{ .name = "downloads", .removed = r.removed, .bytes = r.bytes });
         grand_total.removed += r.removed;
         grand_total.bytes += r.bytes;
     }
     if (opts.scope.stale_casks) {
         const r = try scopes_mod.runStaleCasks(ctx, allocator, prefix, dry_run);
+        try summary.add(allocator, .{ .name = "stale-casks", .removed = r.removed, .bytes = r.bytes });
         grand_total.removed += r.removed;
         grand_total.bytes += r.bytes;
     }
     if (opts.scope.old_versions) {
         const r = try scopes_mod.runOldVersions(ctx, allocator, prefix, dry_run);
+        try summary.add(allocator, .{ .name = "old-versions", .removed = r.removed, .bytes = r.bytes });
         grand_total.removed += r.removed;
         grand_total.bytes += r.bytes;
     }
 
+    // Skip the table when only one scope ran — the per-scope footer is
+    // already enough and the table would just repeat it.
+    if (summary.rows.items.len > 1) summary.render();
+
+    const item_noun = report.pluralize(grand_total.removed, "item", "items");
     var sz_buf: [32]u8 = undefined;
     const sz = formatBytes(grand_total.bytes, &sz_buf);
     if (dry_run) {
-        output.info("dry run: would remove {d} item(s), ~{s}", .{ grand_total.removed, sz });
+        output.info("dry run: would remove {d} {s}, ~{s}", .{ grand_total.removed, item_noun, sz });
     } else {
-        output.success("removed {d} item(s), freed ~{s}", .{ grand_total.removed, sz });
+        output.success("removed {d} {s}, freed ~{s}", .{ grand_total.removed, item_noun, sz });
     }
 }

--- a/src/cli/purge/report.zig
+++ b/src/cli/purge/report.zig
@@ -1,0 +1,236 @@
+//! malt — purge per-scope sectioned reporter.
+//! Each scope feeds: header → items → done.  The reporter caps long
+//! lists, truncates SHAs, and the orchestrator collects subtotals into
+//! a `Summary` so the final table reads at a glance.
+
+const std = @import("std");
+const output = @import("../../ui/output.zig");
+const color = @import("../../ui/color.zig");
+const util = @import("util.zig");
+
+/// Item-list cap; bypassed by `--verbose`.  Picked to fit a half-screen
+/// in a typical 24-row terminal alongside the header + footer.
+pub const default_item_cap: usize = 10;
+/// Matches git/docker/nix short-ref convention; long enough to stay
+/// unambiguous against current store sizes.
+pub const short_hash_len: usize = 12;
+
+/// `name` is borrowed from a caller-owned literal (scope label) — no
+/// allocation needed.
+pub const SummaryRow = struct {
+    name: []const u8,
+    removed: u32,
+    bytes: u64,
+};
+
+pub const Summary = struct {
+    rows: std.ArrayList(SummaryRow) = .empty,
+
+    pub fn add(self: *Summary, allocator: std.mem.Allocator, row: SummaryRow) !void {
+        try self.rows.append(allocator, row);
+    }
+
+    pub fn deinit(self: *Summary, allocator: std.mem.Allocator) void {
+        self.rows.deinit(allocator);
+    }
+
+    pub fn isEmpty(self: *const Summary) bool {
+        return self.rows.items.len == 0;
+    }
+
+    pub fn render(self: *const Summary) void {
+        renderTable(self.rows.items);
+    }
+};
+
+/// Pass both forms so irregular nouns ("entry"/"entries") stay at the
+/// call site instead of being baked into a lookup here.
+pub fn pluralize(n: usize, singular: []const u8, plural: []const u8) []const u8 {
+    return if (n == 1) singular else plural;
+}
+
+/// Returns the input slice when it already fits, so callers can route
+/// every value through this helper without a length check.
+pub fn shortHash(sha: []const u8, buf: []u8) []const u8 {
+    if (sha.len <= short_hash_len) return sha;
+    const ell = "…"; // 3 bytes UTF-8
+    std.debug.assert(buf.len >= short_hash_len + ell.len);
+    @memcpy(buf[0..short_hash_len], sha[0..short_hash_len]);
+    @memcpy(buf[short_hash_len..][0..ell.len], ell);
+    return buf[0 .. short_hash_len + ell.len];
+}
+
+pub const ItemFormat = enum { plain, short_hash };
+
+pub const Reporter = struct {
+    scope: []const u8,
+    dry_run: bool,
+    verbose: bool,
+    item_cap: usize = default_item_cap,
+    fmt: ItemFormat = .plain,
+    seen: usize = 0,
+
+    pub fn init(scope: []const u8, dry_run: bool) Reporter {
+        return .{
+            .scope = scope,
+            .dry_run = dry_run,
+            .verbose = output.isVerbose(),
+        };
+    }
+
+    /// Header reads "scope: removing N <noun>" — the dry-run/live wording
+    /// split lives here so call sites don't repeat it.
+    pub fn header(self: *const Reporter, count: usize, singular: []const u8, plural: []const u8) void {
+        const noun = pluralize(count, singular, plural);
+        if (self.dry_run) {
+            output.info("{s}: would remove {d} {s}", .{ self.scope, count, noun });
+        } else {
+            output.info("{s}: removing {d} {s}", .{ self.scope, count, noun });
+        }
+    }
+
+    /// Dim "nothing to do" line so empty scopes recede next to active ones.
+    pub fn empty(self: *const Reporter, message: []const u8) void {
+        output.skip("{s}: {s}", .{ self.scope, message });
+    }
+
+    /// Status line for sections that work without per-item trace
+    /// (cache pruning announces its window before it walks).
+    pub fn note(self: *const Reporter, comptime fmt: []const u8, args: anytype) void {
+        var buf: [320]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
+        output.info("{s}: {s}", .{ self.scope, msg });
+    }
+
+    pub fn item(self: *Reporter, label: []const u8) void {
+        defer self.seen += 1;
+        if (!self.verbose and self.seen >= self.item_cap) return;
+        var buf: [128]u8 = undefined;
+        const text: []const u8 = switch (self.fmt) {
+            .plain => label,
+            .short_hash => shortHash(label, &buf),
+        };
+        writeItem(text);
+    }
+
+    /// Emits the "… N more" hint when items were clipped.  Subtotal
+    /// bookkeeping happens in the orchestrator; the reporter is print-only.
+    pub fn done(self: *const Reporter, total_seen: usize) void {
+        if (!self.verbose and total_seen > self.item_cap) {
+            writeMore(total_seen - self.item_cap);
+        }
+    }
+};
+
+fn writeItem(text: []const u8) void {
+    const bullet: []const u8 = if (color.isEmojiEnabled()) "    • " else "    - ";
+    if (color.isColorEnabled()) {
+        output.writeStderrAll(color.SemanticStyle.detail.code());
+        output.writeStderrAll(bullet);
+        output.writeStderrAll(color.Style.reset.code());
+    } else {
+        output.writeStderrAll(bullet);
+    }
+    output.writeStderrAll(text);
+    output.writeStderrAll("\n");
+}
+
+fn writeMore(remaining: usize) void {
+    var buf: [96]u8 = undefined;
+    const msg = std.fmt.bufPrint(
+        &buf,
+        "    … {d} more (use --verbose to show all)",
+        .{remaining},
+    ) catch return;
+    if (color.isColorEnabled()) {
+        output.writeStderrAll(color.SemanticStyle.detail.code());
+        output.writeStderrAll(msg);
+        output.writeStderrAll(color.Style.reset.code());
+    } else {
+        output.writeStderrAll(msg);
+    }
+    output.writeStderrAll("\n");
+}
+
+// ── Summary table rendering ────────────────────────────────────────────────
+// Fixed widths instead of dynamic ones: the layout is more predictable and
+// the longest scope label today ("store-orphans", 13 chars) fits comfortably.
+
+const name_col: usize = 16;
+const count_col: usize = 6;
+const bytes_col: usize = 12;
+const gap: usize = 4;
+const rule_width: usize = name_col + count_col + gap + bytes_col;
+
+fn renderTable(rows: []const SummaryRow) void {
+    if (rows.len == 0) return;
+
+    output.plain("", .{});
+    output.boldPlain("  Summary", .{});
+    writeRule();
+
+    var total_count: u64 = 0;
+    var total_bytes: u64 = 0;
+    for (rows) |r| {
+        total_count += r.removed;
+        total_bytes += r.bytes;
+        writeRow(r.name, r.removed, r.bytes);
+    }
+    writeRule();
+    writeRow("total", @intCast(total_count), total_bytes);
+}
+
+fn writeRule() void {
+    var buf: [rule_width]u8 = undefined;
+    @memset(buf[0..], '-');
+    if (color.isColorEnabled()) output.writeStderrAll(color.SemanticStyle.detail.code());
+    output.writeStderrAll("  ");
+    output.writeStderrAll(buf[0..rule_width]);
+    if (color.isColorEnabled()) output.writeStderrAll(color.Style.reset.code());
+    output.writeStderrAll("\n");
+}
+
+fn writeRow(name: []const u8, count: u32, bytes: u64) void {
+    var bytes_buf: [32]u8 = undefined;
+    const bytes_str = util.formatBytes(bytes, &bytes_buf);
+
+    var line_buf: [128]u8 = undefined;
+    const line = std.fmt.bufPrint(
+        &line_buf,
+        "  {s:<16}{d:>6}    {s:>12}",
+        .{ name, count, bytes_str },
+    ) catch return;
+    output.plain("{s}", .{line});
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "pluralize picks singular for n=1, plural otherwise" {
+    try testing.expectEqualStrings("package", pluralize(1, "package", "packages"));
+    try testing.expectEqualStrings("packages", pluralize(0, "package", "packages"));
+    try testing.expectEqualStrings("packages", pluralize(2, "package", "packages"));
+    try testing.expectEqualStrings("entry", pluralize(1, "entry", "entries"));
+    try testing.expectEqualStrings("entries", pluralize(57, "entry", "entries"));
+}
+
+test "shortHash truncates a full SHA-256 to 12 chars + ellipsis" {
+    var buf: [32]u8 = undefined;
+    const sha = "f81449aaecf0d71e3679c230904eaaf746b2fc61b3186870a8c2f33e38eb8404";
+    const got = shortHash(sha, &buf);
+    try testing.expectEqualStrings("f81449aaecf0…", got);
+}
+
+test "shortHash returns the input slice when it is already short" {
+    var buf: [32]u8 = undefined;
+    const got = shortHash("abc", &buf);
+    try testing.expectEqualStrings("abc", got);
+}
+
+test "shortHash leaves a 12-char input untouched (boundary)" {
+    var buf: [32]u8 = undefined;
+    const exact = "0123456789ab";
+    const got = shortHash(exact, &buf);
+    try testing.expectEqualStrings(exact, got);
+}

--- a/src/cli/purge/report.zig
+++ b/src/cli/purge/report.zig
@@ -123,6 +123,7 @@ pub const Reporter = struct {
 };
 
 fn writeItem(text: []const u8) void {
+    if (output.isQuiet()) return; // raw stderr writes don't honour --quiet on their own
     const bullet: []const u8 = if (color.isEmojiEnabled()) "    • " else "    - ";
     if (color.isColorEnabled()) {
         output.writeStderrAll(color.SemanticStyle.detail.code());
@@ -136,6 +137,7 @@ fn writeItem(text: []const u8) void {
 }
 
 fn writeMore(remaining: usize) void {
+    if (output.isQuiet()) return;
     var buf: [96]u8 = undefined;
     const msg = std.fmt.bufPrint(
         &buf,
@@ -181,6 +183,7 @@ fn renderTable(rows: []const SummaryRow) void {
 }
 
 fn writeRule() void {
+    if (output.isQuiet()) return;
     var buf: [rule_width]u8 = undefined;
     @memset(buf[0..], '-');
     if (color.isColorEnabled()) output.writeStderrAll(color.SemanticStyle.detail.code());

--- a/src/cli/purge/scopes.zig
+++ b/src/cli/purge/scopes.zig
@@ -1,6 +1,8 @@
 //! malt — per-scope runners driven by the purge orchestrator.  Each
 //! `runX` is an independent bounded context that owns its own database
-//! handle, allocator plumbing, and dry-run branching.
+//! handle, allocator plumbing, and dry-run branching.  Output flows
+//! through a `Reporter`: header → items → footer.  The orchestrator
+//! collects the `TierResult` returned here into a summary table.
 
 const std = @import("std");
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
@@ -11,6 +13,7 @@ const deps_mod = @import("../../core/deps.zig");
 const linker_mod = @import("../../core/linker.zig");
 const cellar_mod = @import("../../core/cellar.zig");
 const util = @import("util.zig");
+const report = @import("report.zig");
 
 const TierResult = util.TierResult;
 
@@ -38,28 +41,31 @@ pub fn runStoreOrphans(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix:
         orphans_list.deinit(allocator);
     }
 
+    var rep = report.Reporter.init("store-orphans", dry_run);
+    rep.fmt = .short_hash;
+
     if (orphans_list.items.len == 0) {
-        output.info("store-orphans: no orphaned store entries", .{});
+        rep.empty("no orphaned store entries");
         return result;
     }
 
-    if (dry_run) {
-        output.info("store-orphans: would remove {d} entry(s):", .{orphans_list.items.len});
-    } else {
-        output.info("store-orphans: removing {d} entry(s):", .{orphans_list.items.len});
-    }
+    rep.header(orphans_list.items.len, "entry", "entries");
 
+    // Stat the entry before remove() so we can credit freed bytes — the
+    // path disappears as soon as `store.remove` returns.
     for (orphans_list.items) |sha| {
-        util.writeStderr("  ");
-        util.writeStderr(sha);
-        util.writeStderr("\n");
+        var path_buf: [512]u8 = undefined;
+        const store_path = std.fmt.bufPrint(&path_buf, "{s}/store/{s}", .{ prefix, sha }) catch continue;
+        const sz = util.pathSize(io, allocator, store_path);
+
+        rep.item(sha);
         if (!dry_run) {
             store.remove(sha) catch continue;
-            result.removed += 1;
-        } else {
-            result.removed += 1;
         }
+        result.removed += 1;
+        result.bytes += sz;
     }
+    rep.done(orphans_list.items.len);
     return result;
 }
 
@@ -84,26 +90,23 @@ pub fn runUnusedDeps(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
         allocator.free(orphans);
     }
 
+    var rep = report.Reporter.init("unused-deps", dry_run);
+
     if (orphans.len == 0) {
-        output.info("unused-deps: no orphaned dependencies", .{});
+        rep.empty("no orphaned dependencies");
         return result;
     }
 
+    rep.header(orphans.len, "package", "packages");
+
     if (dry_run) {
-        output.info("unused-deps: would remove {d} package(s):", .{orphans.len});
-        for (orphans) |name| {
-            util.writeStderr("  ");
-            util.writeStderr(name);
-            util.writeStderr("\n");
-        }
+        for (orphans) |name| rep.item(name);
+        rep.done(orphans.len);
         result.removed = @intCast(orphans.len);
         return result;
     }
 
-    output.info("unused-deps: removing {d} package(s):", .{orphans.len});
-
     const io = ctx.io;
-
     var linker = linker_mod.Linker.init(io, allocator, &db, prefix);
     var store = store_mod.Store.init(io, allocator, &db, prefix);
 
@@ -120,6 +123,14 @@ pub fn runUnusedDeps(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
             const keg_id = stmt.columnInt(0);
             const version_ptr = stmt.columnText(1);
             const sha_ptr = stmt.columnText(2);
+
+            // Credit cellar bytes before unlink: removing the keg deletes
+            // the directory we'd otherwise stat.
+            if (version_ptr) |v| {
+                var path_buf: [512]u8 = undefined;
+                const cellar_path = std.fmt.bufPrint(&path_buf, "{s}/Cellar/{s}/{s}", .{ prefix, name, std.mem.sliceTo(v, 0) }) catch "";
+                if (cellar_path.len > 0) result.bytes += util.pathSize(io, allocator, cellar_path);
+            }
 
             linker.unlink(keg_id) catch {};
             if (version_ptr) |v| {
@@ -139,12 +150,11 @@ pub fn runUnusedDeps(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
             del.bindInt(1, keg_id) catch continue;
             _ = del.step() catch {};
 
-            util.writeStderr("  ");
-            util.writeStderr(name);
-            util.writeStderr("\n");
+            rep.item(name);
             result.removed += 1;
         }
     }
+    rep.done(orphans.len);
     return result;
 }
 
@@ -153,12 +163,19 @@ pub fn runUnusedDeps(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
 pub fn runCache(ctx: *const AppCtx, allocator: std.mem.Allocator, cache_dir: []const u8, max_age_days: i64, dry_run: bool) !TierResult {
     _ = allocator;
     var result: TierResult = .{};
-    output.info("cache: pruning entries older than {d} day(s) under {s}", .{ max_age_days, cache_dir });
-    pruneCacheRecursive(ctx.io, cache_dir, max_age_days, dry_run, &result);
+
+    var rep = report.Reporter.init("cache", dry_run);
+    rep.note("pruning entries older than {d} {s} under {s}", .{
+        max_age_days,
+        report.pluralize(@intCast(max_age_days), "day", "days"),
+        cache_dir,
+    });
+    pruneCacheRecursive(ctx.io, cache_dir, max_age_days, dry_run, &result, &rep);
+    rep.done(result.removed);
     return result;
 }
 
-fn pruneCacheRecursive(io: std.Io, cache_dir: []const u8, max_age_days: i64, dry_run: bool, result: *TierResult) void {
+fn pruneCacheRecursive(io: std.Io, cache_dir: []const u8, max_age_days: i64, dry_run: bool, result: *TierResult, rep: *report.Reporter) void {
     var dir = std.Io.Dir.openDirAbsolute(io, cache_dir, .{ .iterate = true }) catch return;
     defer dir.close(io);
 
@@ -170,18 +187,18 @@ fn pruneCacheRecursive(io: std.Io, cache_dir: []const u8, max_age_days: i64, dry
         if (entry.kind == .directory) {
             var sub_buf: [512]u8 = undefined;
             const sub_path = std.fmt.bufPrint(&sub_buf, "{s}/{s}", .{ cache_dir, entry.name }) catch continue;
-            pruneCacheRecursive(io, sub_path, max_age_days, dry_run, result);
+            pruneCacheRecursive(io, sub_path, max_age_days, dry_run, result, rep);
             continue;
         }
         const stat = dir.statFile(io, entry.name, .{}) catch continue;
         const mtime_secs: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_s));
         if (now - mtime_secs > max_age_secs) {
-            if (dry_run) {
-                output.info("  would prune: {s}/{s}", .{ cache_dir, entry.name });
-            } else {
-                dir.deleteFile(io, entry.name) catch continue;
-                output.info("  pruned: {s}/{s}", .{ cache_dir, entry.name });
-            }
+            if (!dry_run) dir.deleteFile(io, entry.name) catch continue;
+            // Full path so users (and the smoke tests) can see WHERE the
+            // file lived; the leaf alone hides path-of-cleanup hot spots.
+            var label_buf: [768]u8 = undefined;
+            const label = std.fmt.bufPrint(&label_buf, "{s}/{s}", .{ cache_dir, entry.name }) catch entry.name;
+            rep.item(label);
             result.bytes += stat.size;
             result.removed += 1;
         }
@@ -195,34 +212,43 @@ pub fn runDownloads(ctx: *const AppCtx, allocator: std.mem.Allocator, cache_dir:
     var result: TierResult = .{};
     const io = ctx.io;
 
+    var rep = report.Reporter.init("downloads", dry_run);
+
     var path_buf: [512]u8 = undefined;
     const downloads_path = std.fmt.bufPrint(&path_buf, "{s}/downloads", .{cache_dir}) catch return result;
 
     var dir = std.Io.Dir.openDirAbsolute(io, downloads_path, .{ .iterate = true }) catch {
-        output.info("downloads: nothing to remove ({s} not present)", .{downloads_path});
+        rep.empty("nothing to remove (downloads dir not present)");
         return result;
     };
     defer dir.close(io);
 
-    if (dry_run) {
-        output.info("downloads: would wipe {s}", .{downloads_path});
-    } else {
-        output.info("downloads: wiping {s}", .{downloads_path});
+    // Two-pass: count first so the header reads accurately, then remove.
+    // Cheap because the directory is already cached after the open above.
+    var entries_seen: usize = 0;
+    var ent_iter = dir.iterate();
+    while (ent_iter.next(io) catch null) |entry| {
+        if (entry.kind == .directory) continue;
+        entries_seen += 1;
     }
+
+    if (entries_seen == 0) {
+        rep.empty("nothing to remove");
+        return result;
+    }
+
+    rep.header(entries_seen, "file", "files");
 
     var iter = dir.iterate();
     while (iter.next(io) catch null) |entry| {
         if (entry.kind == .directory) continue;
         const stat = dir.statFile(io, entry.name, .{}) catch continue;
-        if (dry_run) {
-            output.info("  would remove: {s}", .{entry.name});
-        } else {
-            dir.deleteFile(io, entry.name) catch continue;
-            output.info("  removed: {s}", .{entry.name});
-        }
+        if (!dry_run) dir.deleteFile(io, entry.name) catch continue;
+        rep.item(entry.name);
         result.bytes += stat.size;
         result.removed += 1;
     }
+    rep.done(entries_seen);
     return result;
 }
 
@@ -232,11 +258,26 @@ pub fn runStaleCasks(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
     var result: TierResult = .{};
     const io = ctx.io;
 
+    var rep = report.Reporter.init("stale-casks", dry_run);
+
     var db = util.openDb(prefix) orelse {
-        output.info("stale-casks: no database — nothing to inspect", .{});
+        rep.empty("no database — nothing to inspect");
         return result;
     };
     defer db.close();
+
+    // Collect candidates first so we can emit a single header line with
+    // an accurate count before printing the per-item bullets.
+    const Candidate = struct {
+        kind: enum { cache_file, caskroom_dir },
+        name: []u8, // owned
+        size: u64,
+    };
+    var candidates: std.ArrayList(Candidate) = .empty;
+    defer {
+        for (candidates.items) |c| allocator.free(c.name);
+        candidates.deinit(allocator);
+    }
 
     // Cask download cache
     var cask_cache_buf: [512]u8 = undefined;
@@ -264,18 +305,14 @@ pub fn runStaleCasks(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
             var stmt = db.prepare("SELECT token FROM casks WHERE token = ?1 LIMIT 1;") catch continue;
             defer stmt.finalize();
             stmt.bindText(1, token_z) catch continue;
-
             if (stmt.step() catch false) continue; // still installed
 
             const stat = dir.statFile(io, entry.name, .{}) catch continue;
-            if (dry_run) {
-                output.info("  stale-casks: would remove cache {s}", .{entry.name});
-            } else {
-                dir.deleteFile(io, entry.name) catch continue;
-                output.info("  stale-casks: removed cache {s}", .{entry.name});
-            }
-            result.bytes += stat.size;
-            result.removed += 1;
+            const dup = allocator.dupe(u8, entry.name) catch continue;
+            candidates.append(allocator, .{ .kind = .cache_file, .name = dup, .size = stat.size }) catch {
+                allocator.free(dup);
+                continue;
+            };
         }
     } else |_| {}
 
@@ -296,24 +333,49 @@ pub fn runStaleCasks(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
             var stmt = db.prepare("SELECT token FROM casks WHERE token = ?1 LIMIT 1;") catch continue;
             defer stmt.finalize();
             stmt.bindText(1, token_z) catch continue;
-
             if (stmt.step() catch false) continue;
 
             var path_buf: [512]u8 = undefined;
             const full = std.fmt.bufPrint(&path_buf, "{s}/Caskroom/{s}", .{ prefix, entry.name }) catch continue;
-            if (dry_run) {
-                output.info("  stale-casks: would remove Caskroom/{s}", .{entry.name});
-            } else {
-                std.Io.Dir.cwd().deleteTree(io, full) catch continue;
-                output.info("  stale-casks: removed Caskroom/{s}", .{entry.name});
-            }
-            result.removed += 1;
+            const sz = util.pathSize(io, allocator, full);
+            const dup = allocator.dupe(u8, entry.name) catch continue;
+            candidates.append(allocator, .{ .kind = .caskroom_dir, .name = dup, .size = sz }) catch {
+                allocator.free(dup);
+                continue;
+            };
         }
     } else |_| {}
 
-    if (result.removed == 0) {
-        output.info("stale-casks: nothing to remove", .{});
+    if (candidates.items.len == 0) {
+        rep.empty("nothing to remove");
+        return result;
     }
+
+    rep.header(candidates.items.len, "entry", "entries");
+
+    for (candidates.items) |c| {
+        switch (c.kind) {
+            .cache_file => {
+                if (!dry_run) {
+                    var dir = std.Io.Dir.openDirAbsolute(io, cask_cache_path, .{}) catch continue;
+                    defer dir.close(io);
+                    dir.deleteFile(io, c.name) catch continue;
+                }
+                rep.item(c.name);
+            },
+            .caskroom_dir => {
+                if (!dry_run) {
+                    var path_buf: [512]u8 = undefined;
+                    const full = std.fmt.bufPrint(&path_buf, "{s}/Caskroom/{s}", .{ prefix, c.name }) catch continue;
+                    std.Io.Dir.cwd().deleteTree(io, full) catch continue;
+                }
+                rep.item(c.name);
+            },
+        }
+        result.removed += 1;
+        result.bytes += c.size;
+    }
+    rep.done(candidates.items.len);
     return result;
 }
 
@@ -323,14 +385,32 @@ pub fn runOldVersions(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: 
     var result: TierResult = .{};
     const io = ctx.io;
 
+    var rep = report.Reporter.init("old-versions", dry_run);
+
     var cellar_buf: [512]u8 = undefined;
     const cellar_path = std.fmt.bufPrint(&cellar_buf, "{s}/Cellar", .{prefix}) catch return result;
 
     var cellar_dir = std.Io.Dir.openDirAbsolute(io, cellar_path, .{ .iterate = true }) catch {
-        output.info("old-versions: no Cellar directory at {s}", .{cellar_path});
+        rep.empty("no Cellar directory");
         return result;
     };
     defer cellar_dir.close(io);
+
+    // Two-pass: collect candidates first so the header count matches what
+    // the user is about to see scrolled past.
+    const Candidate = struct {
+        formula: []u8, // owned
+        version: []u8, // owned
+        size: u64,
+    };
+    var candidates: std.ArrayList(Candidate) = .empty;
+    defer {
+        for (candidates.items) |c| {
+            allocator.free(c.formula);
+            allocator.free(c.version);
+        }
+        candidates.deinit(allocator);
+    }
 
     var iter = cellar_dir.iterate();
     while (iter.next(io) catch null) |formula_entry| {
@@ -339,7 +419,6 @@ pub fn runOldVersions(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: 
         var formula_dir = cellar_dir.openDir(io, formula_entry.name, .{ .iterate = true }) catch continue;
         defer formula_dir.close(io);
 
-        // Collect (name, mtime) for every version directory.
         const Version = struct { name: []u8, mtime: i128 };
         var versions: std.ArrayList(Version) = .empty;
         defer {
@@ -372,19 +451,39 @@ pub fn runOldVersions(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: 
             var path_buf: [512]u8 = undefined;
             const full = std.fmt.bufPrint(&path_buf, "{s}/Cellar/{s}/{s}", .{ prefix, formula_entry.name, v.name }) catch continue;
             const sz = util.pathSize(io, allocator, full);
-            if (dry_run) {
-                output.info("  old-versions: would remove {s}/{s}", .{ formula_entry.name, v.name });
-            } else {
-                std.Io.Dir.cwd().deleteTree(io, full) catch continue;
-                output.info("  old-versions: removed {s}/{s}", .{ formula_entry.name, v.name });
-            }
-            result.bytes += sz;
-            result.removed += 1;
+
+            const fdup = allocator.dupe(u8, formula_entry.name) catch continue;
+            const vdup = allocator.dupe(u8, v.name) catch {
+                allocator.free(fdup);
+                continue;
+            };
+            candidates.append(allocator, .{ .formula = fdup, .version = vdup, .size = sz }) catch {
+                allocator.free(fdup);
+                allocator.free(vdup);
+                continue;
+            };
         }
     }
 
-    if (result.removed == 0) {
-        output.info("old-versions: nothing to remove", .{});
+    if (candidates.items.len == 0) {
+        rep.empty("nothing to remove");
+        return result;
     }
+
+    rep.header(candidates.items.len, "version", "versions");
+
+    var label_buf: [256]u8 = undefined;
+    for (candidates.items) |c| {
+        if (!dry_run) {
+            var path_buf: [512]u8 = undefined;
+            const full = std.fmt.bufPrint(&path_buf, "{s}/Cellar/{s}/{s}", .{ prefix, c.formula, c.version }) catch continue;
+            std.Io.Dir.cwd().deleteTree(io, full) catch continue;
+        }
+        const label = std.fmt.bufPrint(&label_buf, "{s}/{s}", .{ c.formula, c.version }) catch c.formula;
+        rep.item(label);
+        result.bytes += c.size;
+        result.removed += 1;
+    }
+    rep.done(candidates.items.len);
     return result;
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -30,6 +30,7 @@ pub const completions = @import("cli/completions.zig");
 pub const shellenv = @import("cli/shellenv.zig");
 pub const backup = @import("cli/backup.zig");
 pub const purge = @import("cli/purge.zig");
+pub const purge_report = @import("cli/purge/report.zig");
 pub const install = @import("cli/install.zig");
 pub const upgrade = @import("cli/upgrade.zig");
 pub const doctor = @import("cli/doctor.zig");

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -123,6 +123,15 @@ test "all global-flag completions expose --output-format=ndjson" {
     try expectContains(completions.fish_script, "output-format=ndjson");
 }
 
+test "purge completions expose --verbose with command-specific semantics" {
+    // --verbose is a global flag, so bash/fish pick it up automatically;
+    // zsh's per-command _arguments block has to declare it locally so the
+    // help string explains what it means inside `mt purge`.
+    try expectContains(completions.bash_script, "--verbose -v");
+    try expectContains(completions.fish_script, "-l verbose");
+    try expectContains(completions.zsh_script, "Show every per-scope item");
+}
+
 test "all bundle completions expose the cleanup subcommand and its flags" {
     for ([_][]const u8{
         completions.bash_script,

--- a/tests/help_test.zig
+++ b/tests/help_test.zig
@@ -57,6 +57,14 @@ test "helpFor returns command-specific text for known commands" {
     try testing.expect(std.mem.indexOf(u8, help.helpFor("purge"), "--housekeeping") != null);
 }
 
+test "purge help documents --verbose for full per-scope listings" {
+    // Discoverability guard: the housekeeping output truncates lists by
+    // default, so the bypass flag only exists if --help mentions it.
+    const text = help.helpFor("purge");
+    try testing.expect(std.mem.indexOf(u8, text, "--verbose") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "no truncation") != null);
+}
+
 test "install help documents --local and its code-exec warning" {
     // Discoverability guard: the flag only meaningfully exists if the
     // help output tells the user about it.

--- a/tests/purge_output_test.zig
+++ b/tests/purge_output_test.zig
@@ -20,13 +20,14 @@ const Capture = struct {
         color_on: bool = false,
         emoji_on: bool = false,
         verbose: bool = false,
+        quiet: bool = false,
     }) Capture {
         const prior_quiet = output.isQuiet();
         const prior_verbose = output.isVerbose();
         color.setForTest(opts.color_on, opts.emoji_on);
         color.setBackgroundForTest(color.Background.dark);
         color.setTruecolorForTest(false);
-        output.setQuiet(false);
+        output.setQuiet(opts.quiet);
         output.setVerbose(opts.verbose);
         output.beginStderrCapture(testing.allocator, buf);
         return .{ .buf = buf, .prior_quiet = prior_quiet, .prior_verbose = prior_verbose };
@@ -196,6 +197,37 @@ test "Summary.render emits one row per scope plus a total line" {
         if (std.mem.indexOf(u8, ln, "----------") != null) rules += 1;
     }
     try testing.expectEqual(@as(usize, 2), rules);
+}
+
+// ── --quiet propagation ─────────────────────────────────────────────────────
+
+test "quiet mode silences items, the more-hint, and the summary table" {
+    var buf = newBuf();
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, .{ .quiet = true });
+    defer cap.deinit();
+
+    var rep = report.Reporter.init("store-orphans", false);
+    rep.fmt = .short_hash;
+    var i: usize = 0;
+    while (i < 15) : (i += 1) {
+        var sha: [64]u8 = undefined;
+        @memset(&sha, '0');
+        sha[0] = 'a';
+        sha[1] = '0' + @as(u8, @intCast(i % 10));
+        rep.item(&sha);
+    }
+    rep.done(15);
+
+    var summary = report.Summary{};
+    defer summary.deinit(testing.allocator);
+    try summary.add(testing.allocator, .{ .name = "store-orphans", .removed = 15, .bytes = 1024 });
+    summary.render();
+
+    // Nothing should reach stderr under --quiet — neither the bullets
+    // (writeItem) nor the truncation hint (writeMore) nor the table rules
+    // (writeRule) may bypass the quiet flag.
+    try testing.expectEqual(@as(usize, 0), buf.items.len);
 }
 
 test "Summary.render is a no-op when no rows were added" {

--- a/tests/purge_output_test.zig
+++ b/tests/purge_output_test.zig
@@ -1,0 +1,212 @@
+//! malt — purge output tests
+//! Exercises the sectioned Reporter + Summary table via the stderr-capture
+//! seam in `ui/output.zig`. These cover behaviour that pure unit tests in
+//! `cli/purge/report.zig` cannot: header/item/footer formatting, the cap +
+//! "… N more" tail, the verbose bypass, and the aligned summary table.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const output = malt.output;
+const color = malt.color;
+const report = malt.purge_report;
+
+const Capture = struct {
+    buf: *std.ArrayList(u8),
+    prior_quiet: bool,
+    prior_verbose: bool,
+
+    fn init(buf: *std.ArrayList(u8), opts: struct {
+        color_on: bool = false,
+        emoji_on: bool = false,
+        verbose: bool = false,
+    }) Capture {
+        const prior_quiet = output.isQuiet();
+        const prior_verbose = output.isVerbose();
+        color.setForTest(opts.color_on, opts.emoji_on);
+        color.setBackgroundForTest(color.Background.dark);
+        color.setTruecolorForTest(false);
+        output.setQuiet(false);
+        output.setVerbose(opts.verbose);
+        output.beginStderrCapture(testing.allocator, buf);
+        return .{ .buf = buf, .prior_quiet = prior_quiet, .prior_verbose = prior_verbose };
+    }
+
+    fn deinit(self: Capture) void {
+        output.endStderrCapture();
+        color.setForTest(null, null);
+        color.setBackgroundForTest(null);
+        color.setTruecolorForTest(null);
+        output.setQuiet(self.prior_quiet);
+        output.setVerbose(self.prior_verbose);
+    }
+};
+
+fn newBuf() std.ArrayList(u8) {
+    return .empty;
+}
+
+// ── Reporter.header ─────────────────────────────────────────────────────────
+
+test "header singular vs plural noun is selected by count" {
+    var buf = newBuf();
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, .{});
+    defer cap.deinit();
+
+    var rep = report.Reporter.init("unused-deps", false);
+    rep.header(1, "package", "packages");
+    rep.header(10, "package", "packages");
+
+    try testing.expect(std.mem.indexOf(u8, buf.items, "removing 1 package\n") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "removing 10 packages\n") != null);
+}
+
+test "header reads 'would remove' under dry-run" {
+    var buf = newBuf();
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, .{});
+    defer cap.deinit();
+
+    var rep = report.Reporter.init("store-orphans", true);
+    rep.header(3, "entry", "entries");
+
+    try testing.expect(std.mem.indexOf(u8, buf.items, "would remove 3 entries") != null);
+    // Defensive: dry-run path must not say "removing".
+    try testing.expect(std.mem.indexOf(u8, buf.items, "removing 3") == null);
+}
+
+// ── Reporter.item + cap ─────────────────────────────────────────────────────
+
+test "item caps the listed entries at default_item_cap and prints the more line" {
+    var buf = newBuf();
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, .{});
+    defer cap.deinit();
+
+    var rep = report.Reporter.init("store-orphans", false);
+    rep.fmt = .short_hash;
+
+    const total: usize = 15;
+    var i: usize = 0;
+    while (i < total) : (i += 1) {
+        // 64-char hex, distinct first 12 nibbles per item.
+        var sha: [64]u8 = undefined;
+        @memset(&sha, '0');
+        const hexd = "0123456789abcdef";
+        sha[0] = hexd[i & 0xf];
+        sha[1] = hexd[(i >> 4) & 0xf];
+        rep.item(&sha);
+    }
+    rep.done(total);
+
+    // Every printed item line uses the bullet glyph; under emoji-off it's '-'.
+    var lines = std.mem.splitScalar(u8, buf.items, '\n');
+    var bullets: usize = 0;
+    while (lines.next()) |ln| {
+        if (std.mem.indexOf(u8, ln, "    - ") != null) bullets += 1;
+    }
+    try testing.expectEqual(@as(usize, report.default_item_cap), bullets);
+
+    // Tail line names the remaining count.
+    try testing.expect(std.mem.indexOf(u8, buf.items, "… 5 more") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "use --verbose") != null);
+}
+
+test "verbose mode bypasses the cap and prints every item" {
+    var buf = newBuf();
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, .{ .verbose = true });
+    defer cap.deinit();
+
+    var rep = report.Reporter.init("unused-deps", false);
+    const names = [_][]const u8{ "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l" };
+    for (names) |n| rep.item(n);
+    rep.done(names.len);
+
+    var lines = std.mem.splitScalar(u8, buf.items, '\n');
+    var bullets: usize = 0;
+    while (lines.next()) |ln| {
+        if (std.mem.indexOf(u8, ln, "    - ") != null) bullets += 1;
+    }
+    try testing.expectEqual(@as(usize, names.len), bullets);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "more (use --verbose") == null);
+}
+
+test "short_hash item format truncates long SHAs but leaves short labels alone" {
+    var buf = newBuf();
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, .{});
+    defer cap.deinit();
+
+    var rep = report.Reporter.init("store-orphans", false);
+    rep.fmt = .short_hash;
+    rep.item("f81449aaecf0d71e3679c230904eaaf746b2fc61b3186870a8c2f33e38eb8404");
+    rep.item("short");
+
+    try testing.expect(std.mem.indexOf(u8, buf.items, "    - f81449aaecf0…\n") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "    - short\n") != null);
+    // Full SHA must NOT leak when the format asks for short hashes.
+    try testing.expect(std.mem.indexOf(u8, buf.items, "f81449aaecf0d71e3679c230904eaaf7") == null);
+}
+
+// ── Reporter.empty / note ───────────────────────────────────────────────────
+
+test "empty emits a dim 'nothing to remove' line under the scope name" {
+    var buf = newBuf();
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, .{});
+    defer cap.deinit();
+
+    var rep = report.Reporter.init("stale-casks", false);
+    rep.empty("nothing to remove");
+
+    try testing.expect(std.mem.indexOf(u8, buf.items, "stale-casks: nothing to remove") != null);
+}
+
+// ── Summary table ──────────────────────────────────────────────────────────
+
+test "Summary.render emits one row per scope plus a total line" {
+    var buf = newBuf();
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, .{});
+    defer cap.deinit();
+
+    var summary = report.Summary{};
+    defer summary.deinit(testing.allocator);
+
+    try summary.add(testing.allocator, .{ .name = "unused-deps", .removed = 10, .bytes = 2 * 1024 * 1024 * 1024 });
+    try summary.add(testing.allocator, .{ .name = "store-orphans", .removed = 57, .bytes = 1024 * 1024 });
+    try summary.add(testing.allocator, .{ .name = "cache", .removed = 0, .bytes = 0 });
+
+    summary.render();
+
+    try testing.expect(std.mem.indexOf(u8, buf.items, "Summary") != null);
+    // Each scope name appears as a row.
+    try testing.expect(std.mem.indexOf(u8, buf.items, "unused-deps") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "store-orphans") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "cache") != null);
+    // Total row carries the summed count (10 + 57 + 0 = 67) and a bytes value.
+    try testing.expect(std.mem.indexOf(u8, buf.items, "total") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "67") != null);
+    // Two rule lines bracket the body.
+    var rules: usize = 0;
+    var lines = std.mem.splitScalar(u8, buf.items, '\n');
+    while (lines.next()) |ln| {
+        if (std.mem.indexOf(u8, ln, "----------") != null) rules += 1;
+    }
+    try testing.expectEqual(@as(usize, 2), rules);
+}
+
+test "Summary.render is a no-op when no rows were added" {
+    var buf = newBuf();
+    defer buf.deinit(testing.allocator);
+    const cap = Capture.init(&buf, .{});
+    defer cap.deinit();
+
+    var summary = report.Summary{};
+    defer summary.deinit(testing.allocator);
+    summary.render();
+
+    try testing.expectEqual(@as(usize, 0), buf.items.len);
+}


### PR DESCRIPTION
## Description

Reworks the per-scope output that `mt purge --housekeeping` emits so it's actually scannable. Each scope now reads as a header + indented item bullets + dim "nothing to do" line; long lists collapse to the first 10 + "... N more (use --verbose to show all)"; SHA labels are truncated to 12 chars; and the run ends with a Summary table when more than one scope contributed (per-scope counts, freed bytes, total).

`--verbose` bypasses both the item cap and the SHA truncation - documented in `mt purge --help` and pinned by a discoverability test.

## Related Issue

- None

## Notes for Reviewers

- None