### PR TITLE
fix(core/store): drop the store_refs row when removing an orphan

### DIFF
--- a/src/core/store.zig
+++ b/src/core/store.zig
@@ -56,10 +56,22 @@ pub const Store = struct {
         return std.fmt.allocPrint(self.allocator, "{s}/store/{s}", .{ self.prefix, sha256 }) catch return StoreError.OutOfMemory;
     }
 
+    /// Removes both the on-disk path AND the store_refs row.  Without the
+    /// row delete, refcount-0 rows keep returning from `orphans()` on every
+    /// purge run — the bug `doctor --fix` already worked around.  deleteTree
+    /// is a no-op on a missing path, so phantom rows still trigger DB cleanup.
     pub fn remove(self: *Store, sha256: []const u8) StoreError!void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+
         var buf: [512]u8 = undefined;
         const p = std.fmt.bufPrint(&buf, "{s}/store/{s}", .{ self.prefix, sha256 }) catch return StoreError.OutOfMemory;
         std.Io.Dir.cwd().deleteTree(self.io, p) catch return StoreError.RemoveFailed;
+
+        var stmt = self.db.prepare("DELETE FROM store_refs WHERE store_sha256 = ?1;") catch return StoreError.RefCountError;
+        defer stmt.finalize();
+        stmt.bindText(1, sha256) catch return StoreError.RefCountError;
+        _ = stmt.step() catch return StoreError.RefCountError;
     }
 
     pub fn incrementRef(self: *Store, sha256: []const u8) StoreError!void {

--- a/tests/store_test.zig
+++ b/tests/store_test.zig
@@ -80,6 +80,40 @@ test "duplicate commit is idempotent" {
     try testing.expect(ctx.store.exists("dup_sha"));
 }
 
+test "remove also drops the store_refs row so the orphan does not return" {
+    var ctx = try setupTestStore(testing.allocator);
+    defer {
+        ctx.db.close();
+        test_io.deleteTreeAbsolute(std.Options.debug_io, ctx.prefix) catch {};
+        testing.allocator.free(ctx.prefix);
+    }
+    ctx.store.db = &ctx.db;
+
+    try ctx.store.incrementRef("orphan_sha");
+    try ctx.store.decrementRef("orphan_sha"); // refcount → 0
+
+    // Pre-condition: enumerate sees the orphan.
+    {
+        var orphans = try ctx.store.orphans();
+        defer {
+            for (orphans.items) |o| testing.allocator.free(o);
+            orphans.deinit(testing.allocator);
+        }
+        try testing.expectEqual(@as(usize, 1), orphans.items.len);
+    }
+
+    // remove() with no on-disk path must still clear the DB row — otherwise
+    // the same row keeps reappearing on every purge run.
+    try ctx.store.remove("orphan_sha");
+
+    var orphans = try ctx.store.orphans();
+    defer {
+        for (orphans.items) |o| testing.allocator.free(o);
+        orphans.deinit(testing.allocator);
+    }
+    try testing.expectEqual(@as(usize, 0), orphans.items.len);
+}
+
 test "incrementRef and decrementRef update refcount" {
     var ctx = try setupTestStore(testing.allocator);
     defer {


### PR DESCRIPTION
## Description

`Store.remove()` only deleted the on-disk path; the refcount-0 row stayed in `store_refs`, so `Store.orphans()` kept returning the same SHA forever. After the first run, `mt purge --store-orphans` reclaimed nothing on disk but happily reported the same orphan count again - confusing for users and the reason the freed-bytes counter looked broken.

`remove()` now does the disk delete and the row delete under the existing mutex, in that order. `deleteTree` is a no-op on a missing path, so phantom rows (where the disk was already gone from a previous half-fix) still trigger DB cleanup and stop reappearing. Inline test in `tests/store_test.zig` proves the orphan does not return after a `remove()` that found no on-disk path.

## Related Issue

- None.

## Notes for Reviewers

- Stacked on #232.