### PR TITLE
feat(cli/purge): emit structured JSON and NDJSON for purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ mt purge --wipe --backup ~/snapshot.txt --remove-binary --yes
 
 Shared flags: `--dry-run`/`-n` (preview), `--yes`/`-y` (skip typed-confirm), `--quiet`/`-q`, `--backup`/`-b <path>` (write a `mt restore`-compatible manifest before any deletion). `--wipe`-only flags: `--keep-cache` (preserve downloaded bottles), `--remove-binary` (also unlink `/usr/local/bin/{mt,malt}`).
 
+Structured output for scripts: `mt --json purge --<scope>...` emits a single summary object on stdout (`version`, `dry_run`, `scopes`, `totals`, `time_ms`); `mt --output-format=ndjson purge ...` streams `scope_started` / `scope_completed` / `purge_complete` events, one per line. Stderr stays the human surface in either mode.
+
 `--wipe` cannot combine with any other scope. Every other scope can run together under one lock acquisition. `mt purge` honours `MALT_PREFIX` and `MALT_CACHE`, so pointing those at a throwaway path is the safe way to test the command end-to-end. For per-package removal, use `mt uninstall`.
 
 `mt link <formula>` and `mt unlink <formula>` manage the prefix symlinks. `link` reports conflicts and aborts unless `--overwrite`/`--force`/`-f` is passed. `unlink` removes symlinks from `bin/`, `lib/`, etc. and the `opt/` symlink, but leaves the keg installed.

--- a/build.zig
+++ b/build.zig
@@ -128,6 +128,7 @@ pub fn build(b: *std.Build) void {
         "tests/backup_test.zig",
         "tests/purge_test.zig",
         "tests/purge_output_test.zig",
+        "tests/purge_json_test.zig",
         "tests/install_test.zig",
         "tests/install_parse_cache_test.zig",
         "tests/deps_leak_test.zig",

--- a/scripts/e2e/smoke_test.sh
+++ b/scripts/e2e/smoke_test.sh
@@ -299,6 +299,34 @@ else
   run_ok t3.purge.house.dry -- "$MT_BIN" purge --housekeeping --dry-run
   run_ok t3.purge.cache.dry -- "$MT_BIN" purge --cache=7 --dry-run
 
+  # Structured-output probes: prove the v1 wire format is parseable. Gated
+  # on jq because not every smoke environment ships it.
+  if command -v jq >/dev/null 2>&1; then
+    out=$("$MT_BIN" --json --quiet purge --housekeeping --dry-run 2>/dev/null)
+    if printf '%s\n' "$out" | jq -e '.version == 1 and .dry_run == true and (.scopes | type == "array")' >/dev/null 2>&1; then
+      printf '  PASS  [t3.purge.house.json.dry] mt --json purge --housekeeping --dry-run\n'
+      PASS=$((PASS + 1))
+    else
+      printf '  FAIL  [t3.purge.house.json.dry] payload not parseable / missing keys\n'
+      printf '%s\n' "$out" | sed 's/^/        | /'
+      FAIL=$((FAIL + 1))
+      FAILURES+=("t3.purge.house.json.dry")
+    fi
+
+    if "$MT_BIN" --output-format=ndjson --quiet purge --housekeeping --dry-run 2>/dev/null |
+      jq -e 'select(.event=="purge_complete") | .dry_run == true' >/dev/null 2>&1; then
+      printf '  PASS  [t3.purge.house.ndjson.dry] mt --output-format=ndjson purge --housekeeping --dry-run\n'
+      PASS=$((PASS + 1))
+    else
+      printf '  FAIL  [t3.purge.house.ndjson.dry] event stream missing purge_complete\n'
+      FAIL=$((FAIL + 1))
+      FAILURES+=("t3.purge.house.ndjson.dry")
+    fi
+  else
+    printf '  SKIP  [t3.purge.house.json.dry] (jq not on PATH)\n'
+    printf '  SKIP  [t3.purge.house.ndjson.dry] (jq not on PATH)\n'
+  fi
+
   # T-060 AC: --keep populates {cache}/run/<sha>/ and a sibling .lock file;
   # `mt purge --cache` must reach both. Pre-populate a stale slot so the
   # mtime-based pruner picks it up, then assert the dry-run sees it.

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -360,7 +360,9 @@ pub const zsh_script =
     \\                        '--remove-binary[--wipe only: also unlink /usr/local/bin/{mt,malt}]' \
     \\                        '(--yes -y)'{--yes,-y}'[Skip every typed confirmation]' \
     \\                        '(--dry-run -n)'{--dry-run,-n}'[Preview without removing]' \
-    \\                        '(--verbose -v)'{--verbose,-v}'[Show every per-scope item; no truncation, full SHAs]'
+    \\                        '(--verbose -v)'{--verbose,-v}'[Show every per-scope item; no truncation, full SHAs]' \
+    \\                        '--json[Single summary object on stdout for scripts]' \
+    \\                        '--output-format=ndjson[Stream one event per scope start/complete + purge_complete]'
     \\                    ;;
     \\                version)
     \\                    _values 'subcommand' 'update[Self-update the binary]'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -355,6 +355,12 @@ const purge_help =
     \\  --verbose, -v        Show every per-scope item (no truncation, full SHAs)
     \\  --backup, -b <path>  Write a `mt restore`-compatible manifest first
     \\
+    \\Structured output (stdout; stderr stays the human surface):
+    \\  --json                  Single summary object: version, dry_run, scopes,
+    \\                          totals, time_ms.
+    \\  --output-format=ndjson  One {"event":...} line per state transition
+    \\                          (scope_started, scope_completed, purge_complete).
+    \\
     \\--wipe-only flags:
     \\  --keep-cache         Do not delete the cache directory
     \\  --remove-binary      Also unlink /usr/local/bin/{mt,malt}

--- a/src/cli/purge.zig
+++ b/src/cli/purge.zig
@@ -13,6 +13,7 @@ const wipe_mod = @import("purge/wipe.zig");
 const scopes_mod = @import("purge/scopes.zig");
 const util = @import("purge/util.zig");
 const report = @import("purge/report.zig");
+const purge_json = @import("purge/json.zig");
 
 pub const Error = args_mod.Error;
 pub const Scope = args_mod.Scope;
@@ -27,6 +28,41 @@ pub const freePlan = wipe_mod.freePlan;
 pub const formatBytes = util.formatBytes;
 
 const TierResult = util.TierResult;
+
+/// Closed enum of non-wipe scopes. Field names match `Scope` so
+/// `@field(opts.scope, @tagName(k))` checks selection without a
+/// hand-maintained dispatch table.
+const ScopeKey = enum {
+    unused_deps,
+    store_orphans,
+    cache,
+    downloads,
+    stale_casks,
+    old_versions,
+
+    fn label(k: ScopeKey) []const u8 {
+        return switch (k) {
+            .unused_deps => "unused-deps",
+            .store_orphans => "store-orphans",
+            .cache => "cache",
+            .downloads => "downloads",
+            .stale_casks => "stale-casks",
+            .old_versions => "old-versions",
+        };
+    }
+};
+
+/// Run order matters: unused-deps must precede store-orphans because
+/// removing a keg decrements its store ref to 0, and those fresh
+/// orphans only get swept on the second pass.
+const scope_run_order = [_]ScopeKey{
+    .unused_deps,
+    .store_orphans,
+    .cache,
+    .downloads,
+    .stale_casks,
+    .old_versions,
+};
 
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(ctx, args, "purge")) return;
@@ -50,8 +86,34 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     };
     defer allocator.free(cache_dir);
 
+    const start_ts = std.Io.Clock.real.now(ctx.io).toMilliseconds();
+
     if (opts.scope.wipe) {
-        try wipe_mod.runWipe(ctx, allocator, opts, prefix, cache_dir, dry_run);
+        purge_json.emitScopeStarted("wipe", dry_run);
+        var wipe_result: util.TierResult = .{};
+        // Declare in reverse-of-fire order: LIFO defer flushes
+        // scope_completed → purge_complete → summary even if runWipe
+        // errors (e.g. UserAborted), so consumers can rely on a strict
+        // open/close bracket per command invocation.
+        defer if (output.isJson()) {
+            const elapsed = std.Io.Clock.real.now(ctx.io).toMilliseconds() - start_ts;
+            const wipe_rows = [_]report.SummaryRow{.{
+                .name = "wipe",
+                .removed = @intCast(wipe_result.removed),
+                .bytes = wipe_result.bytes,
+            }};
+            purge_json.emitSummary(
+                allocator,
+                dry_run,
+                &wipe_rows,
+                wipe_result.removed,
+                wipe_result.bytes,
+                elapsed,
+            ) catch {};
+        };
+        defer purge_json.emitPurgeComplete(wipe_result.removed, wipe_result.bytes, dry_run);
+        defer purge_json.emitScopeCompleted("wipe", wipe_result.removed, wipe_result.bytes, dry_run);
+        wipe_result = try wipe_mod.runWipe(ctx, allocator, opts, prefix, cache_dir, dry_run);
         return;
     }
 
@@ -83,44 +145,42 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     defer summary.deinit(allocator);
     var grand_total: TierResult = .{};
 
-    // unused-deps must run before store-orphans: removing a keg decrements
-    // its store ref to 0, and those fresh orphans only get swept on the
-    // second pass.
-    if (opts.scope.unused_deps) {
-        const r = try scopes_mod.runUnusedDeps(ctx, allocator, prefix, dry_run);
-        try summary.add(allocator, .{ .name = "unused-deps", .removed = r.removed, .bytes = r.bytes });
-        grand_total.removed += r.removed;
-        grand_total.bytes += r.bytes;
-    }
-    if (opts.scope.store_orphans) {
-        const r = try scopes_mod.runStoreOrphans(ctx, allocator, prefix, dry_run);
-        try summary.add(allocator, .{ .name = "store-orphans", .removed = r.removed, .bytes = r.bytes });
-        grand_total.removed += r.removed;
-        grand_total.bytes += r.bytes;
-    }
-    if (opts.scope.cache) {
-        const r = try scopes_mod.runCache(ctx, allocator, cache_dir, opts.cache_days, dry_run);
-        try summary.add(allocator, .{ .name = "cache", .removed = r.removed, .bytes = r.bytes });
-        grand_total.removed += r.removed;
-        grand_total.bytes += r.bytes;
-    }
-    if (opts.scope.downloads) {
-        const r = try scopes_mod.runDownloads(ctx, allocator, cache_dir, dry_run);
-        try summary.add(allocator, .{ .name = "downloads", .removed = r.removed, .bytes = r.bytes });
-        grand_total.removed += r.removed;
-        grand_total.bytes += r.bytes;
-    }
-    if (opts.scope.stale_casks) {
-        const r = try scopes_mod.runStaleCasks(ctx, allocator, prefix, dry_run);
-        try summary.add(allocator, .{ .name = "stale-casks", .removed = r.removed, .bytes = r.bytes });
-        grand_total.removed += r.removed;
-        grand_total.bytes += r.bytes;
-    }
-    if (opts.scope.old_versions) {
-        const r = try scopes_mod.runOldVersions(ctx, allocator, prefix, dry_run);
-        try summary.add(allocator, .{ .name = "old-versions", .removed = r.removed, .bytes = r.bytes });
-        grand_total.removed += r.removed;
-        grand_total.bytes += r.bytes;
+    // Strict ndjson bracketing: scope_started lines always pair with a
+    // scope_completed (handled per scope below) and purge_complete /
+    // summary always close the stream, even if a scope errors mid-flight.
+    // Declare in reverse-of-fire order: LIFO drains purge_complete first,
+    // then summary.
+    defer if (output.isJson()) {
+        const elapsed = std.Io.Clock.real.now(ctx.io).toMilliseconds() - start_ts;
+        purge_json.emitSummary(
+            allocator,
+            dry_run,
+            summary.rows.items,
+            grand_total.removed,
+            grand_total.bytes,
+            elapsed,
+        ) catch {};
+    };
+    defer purge_json.emitPurgeComplete(grand_total.removed, grand_total.bytes, dry_run);
+
+    inline for (scope_run_order) |k| {
+        if (@field(opts.scope, @tagName(k))) {
+            const name = comptime k.label();
+            purge_json.emitScopeStarted(name, dry_run);
+            var r: TierResult = .{};
+            defer purge_json.emitScopeCompleted(name, r.removed, r.bytes, dry_run);
+            r = try switch (k) {
+                .unused_deps => scopes_mod.runUnusedDeps(ctx, allocator, prefix, dry_run),
+                .store_orphans => scopes_mod.runStoreOrphans(ctx, allocator, prefix, dry_run),
+                .cache => scopes_mod.runCache(ctx, allocator, cache_dir, opts.cache_days, dry_run),
+                .downloads => scopes_mod.runDownloads(ctx, allocator, cache_dir, dry_run),
+                .stale_casks => scopes_mod.runStaleCasks(ctx, allocator, prefix, dry_run),
+                .old_versions => scopes_mod.runOldVersions(ctx, allocator, prefix, dry_run),
+            };
+            try summary.add(allocator, .{ .name = name, .removed = r.removed, .bytes = r.bytes });
+            grand_total.removed += r.removed;
+            grand_total.bytes += r.bytes;
+        }
     }
 
     // Skip the table when only one scope ran — the per-scope footer is

--- a/src/cli/purge/json.zig
+++ b/src/cli/purge/json.zig
@@ -1,0 +1,293 @@
+//! malt — purge JSON / NDJSON output sink.
+//!
+//! Two complementary modes that scripts can drive without parsing the
+//! human stderr surface. Both are gated by global flags applied before
+//! dispatch — `--json` for the single-summary mode, `--output-format=
+//! ndjson` for the streaming mode. Stderr remains the human path in
+//! either mode so interactive runs keep their existing TTY layout.
+//!
+//! ## Wire format (v1)
+//!
+//! ### `--json` summary (one object on stdout, trailing `\n`)
+//!
+//! ```json
+//! {
+//!   "version": 1,
+//!   "dry_run": false,
+//!   "scopes": [
+//!     {"name": "store-orphans", "removed": 5, "bytes": 4096},
+//!     {"name": "unused-deps",   "removed": 1, "bytes": 0}
+//!   ],
+//!   "totals": {"removed": 6, "bytes": 4096},
+//!   "time_ms": 12
+//! }
+//! ```
+//!
+//! ### `--output-format=ndjson` event stream (one object per line)
+//!
+//! ```ndjson
+//! {"event":"scope_started","scope":"store-orphans","dry_run":false}
+//! {"event":"scope_completed","scope":"store-orphans","removed":5,"bytes":4096,"dry_run":false}
+//! {"event":"purge_complete","removed":5,"bytes":4096,"dry_run":false}
+//! ```
+//!
+//! Field guarantees:
+//! - `version` is the schema version. Bumped only on a breaking change;
+//!   a `version` field is always present so consumers can branch.
+//! - `dry_run` is a boolean on every event and on the summary. Purge
+//!   uses a field rather than a `would_*` verb (the install/upgrade
+//!   convention) because dry-run still walks every scope; events are
+//!   semantically the same, only the side-effect is suppressed.
+//! - Scope names match the long-form CLI flags minus the `--` prefix
+//!   (`store-orphans`, `unused-deps`, `cache`, `downloads`,
+//!   `stale-casks`, `old-versions`, `wipe`).
+//! - `scope_started` always pairs with a `scope_completed`, even on
+//!   error paths (UserAborted, OOM). `purge_complete` always closes
+//!   the stream. Consumers can rely on strict open/close brackets.
+
+const std = @import("std");
+const output = @import("../../ui/output.zig");
+const report = @import("report.zig");
+
+pub const schema_version: u32 = 1;
+
+/// Wire-format event names. Mirrors the closed-vocabulary pattern in
+/// `output.NdjsonEvent`: a typo at a call site fails to compile rather
+/// than emitting a malformed line.
+pub const PurgeEvent = enum {
+    scope_started,
+    scope_completed,
+    purge_complete,
+};
+
+/// Build the `--json` summary document. Pure: writes only to `w`, takes
+/// no allocator, no IO. The orchestrator pre-aggregates `rows` and
+/// `totals` so this stays a serialiser.
+pub fn buildSummary(
+    w: *std.Io.Writer,
+    dry_run: bool,
+    rows: []const report.SummaryRow,
+    total_removed: u64,
+    total_bytes: u64,
+    time_ms: i64,
+) !void {
+    try w.print(
+        "{{\"version\":{d},\"dry_run\":{s},\"scopes\":[",
+        .{ schema_version, if (dry_run) "true" else "false" },
+    );
+    for (rows, 0..) |row, i| {
+        if (i != 0) try w.writeAll(",");
+        try w.writeAll("{\"name\":");
+        try output.jsonStr(w, row.name);
+        try w.print(",\"removed\":{d},\"bytes\":{d}}}", .{ row.removed, row.bytes });
+    }
+    try w.print(
+        "],\"totals\":{{\"removed\":{d},\"bytes\":{d}}},\"time_ms\":{d}}}\n",
+        .{ total_removed, total_bytes, time_ms },
+    );
+}
+
+/// Shared ndjson event emitter for purge events. Mirrors the silent-drop
+/// semantics of `output.emitNdjsonEvent`: an event that would overflow
+/// the fixed buffer (adversarial scope name, pathological counts) is
+/// dropped rather than failing the command — the human stderr path is
+/// still authoritative.
+fn emitEvent(event: PurgeEvent, scope: ?[]const u8, removed: ?u64, bytes: ?u64, dry_run: bool) void {
+    if (!output.isNdjson()) return;
+    var buf: [512]u8 = undefined;
+    var w = std.Io.Writer.fixed(buf[0..]);
+    w.writeAll("{\"event\":") catch return;
+    output.jsonStr(&w, @tagName(event)) catch return;
+    if (scope) |s| {
+        w.writeAll(",\"scope\":") catch return;
+        output.jsonStr(&w, s) catch return;
+    }
+    if (removed) |r| w.print(",\"removed\":{d}", .{r}) catch return;
+    if (bytes) |b| w.print(",\"bytes\":{d}", .{b}) catch return;
+    w.writeAll(",\"dry_run\":") catch return;
+    w.writeAll(if (dry_run) "true" else "false") catch return;
+    w.writeAll("}\n") catch return;
+    output.writeStdoutAll(w.buffered());
+}
+
+/// Emit `{"event":"scope_started","scope":"<name>","dry_run":<bool>}\n`
+/// when ndjson mode is on; no-op otherwise. Per-scope ndjson is one
+/// summary line, not one line per item — call sites stay unchanged.
+pub fn emitScopeStarted(scope: []const u8, dry_run: bool) void {
+    emitEvent(.scope_started, scope, null, null, dry_run);
+}
+
+/// Emit `{"event":"scope_completed","scope":...,"removed":N,"bytes":B,"dry_run":<bool>}\n`.
+pub fn emitScopeCompleted(scope: []const u8, removed: u64, bytes: u64, dry_run: bool) void {
+    emitEvent(.scope_completed, scope, removed, bytes, dry_run);
+}
+
+/// Emit `{"event":"purge_complete","removed":N,"bytes":B,"dry_run":<bool>}\n`.
+pub fn emitPurgeComplete(removed: u64, bytes: u64, dry_run: bool) void {
+    emitEvent(.purge_complete, null, removed, bytes, dry_run);
+}
+
+/// Build + flush the `--json` summary to stdout. Allocates a transient
+/// buffer because the document is unbounded in `rows.len`.
+pub fn emitSummary(
+    allocator: std.mem.Allocator,
+    dry_run: bool,
+    rows: []const report.SummaryRow,
+    total_removed: u64,
+    total_bytes: u64,
+    time_ms: i64,
+) !void {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try buildSummary(&aw.writer, dry_run, rows, total_removed, total_bytes, time_ms);
+    output.writeStdoutAll(aw.written());
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "buildSummary emits a parseable object with required top-level keys" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    const rows = [_]report.SummaryRow{
+        .{ .name = "store-orphans", .removed = 5, .bytes = 4096 },
+        .{ .name = "unused-deps", .removed = 1, .bytes = 0 },
+    };
+    try buildSummary(&aw.writer, false, &rows, 6, 4096, 12);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    try testing.expectEqual(@as(i64, schema_version), obj.get("version").?.integer);
+    try testing.expectEqual(false, obj.get("dry_run").?.bool);
+    try testing.expectEqual(@as(usize, 2), obj.get("scopes").?.array.items.len);
+    const totals = obj.get("totals").?.object;
+    try testing.expectEqual(@as(i64, 6), totals.get("removed").?.integer);
+    try testing.expectEqual(@as(i64, 4096), totals.get("bytes").?.integer);
+    try testing.expectEqual(@as(i64, 12), obj.get("time_ms").?.integer);
+}
+
+test "buildSummary marks dry-run runs with dry_run:true" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try buildSummary(&aw.writer, true, &.{}, 0, 0, 0);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+    try testing.expectEqual(true, parsed.value.object.get("dry_run").?.bool);
+}
+
+test "buildSummary scope rows pin name/removed/bytes shape" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    const rows = [_]report.SummaryRow{
+        .{ .name = "cache", .removed = 3, .bytes = 1024 },
+    };
+    try buildSummary(&aw.writer, false, &rows, 3, 1024, 0);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+    const scope = parsed.value.object.get("scopes").?.array.items[0].object;
+    try testing.expectEqualStrings("cache", scope.get("name").?.string);
+    try testing.expectEqual(@as(i64, 3), scope.get("removed").?.integer);
+    try testing.expectEqual(@as(i64, 1024), scope.get("bytes").?.integer);
+}
+
+test "buildSummary escapes special characters in scope names" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    const rows = [_]report.SummaryRow{
+        .{ .name = "weird\"name", .removed = 0, .bytes = 0 },
+    };
+    try buildSummary(&aw.writer, false, &rows, 0, 0, 0);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+    const scope = parsed.value.object.get("scopes").?.array.items[0].object;
+    try testing.expectEqualStrings("weird\"name", scope.get("name").?.string);
+}
+
+test "emit helpers no-op when ndjson mode is off" {
+    const prior = output.isNdjson();
+    defer output.setNdjson(prior);
+    output.setNdjson(false);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &buf);
+    defer output.endStdoutCapture();
+
+    emitScopeStarted("cache", false);
+    emitScopeCompleted("cache", 1, 2, false);
+    emitPurgeComplete(1, 2, false);
+
+    try testing.expectEqual(@as(usize, 0), buf.items.len);
+}
+
+test "emitScopeStarted writes one parseable line" {
+    const prior = output.isNdjson();
+    defer output.setNdjson(prior);
+    output.setNdjson(true);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &buf);
+    defer output.endStdoutCapture();
+
+    emitScopeStarted("store-orphans", true);
+
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, buf.items, "\n"));
+    const line = std.mem.trimEnd(u8, buf.items, "\n");
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("scope_started", parsed.value.object.get("event").?.string);
+    try testing.expectEqualStrings("store-orphans", parsed.value.object.get("scope").?.string);
+    try testing.expectEqual(true, parsed.value.object.get("dry_run").?.bool);
+}
+
+test "emitScopeCompleted carries removed/bytes counters" {
+    const prior = output.isNdjson();
+    defer output.setNdjson(prior);
+    output.setNdjson(true);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &buf);
+    defer output.endStdoutCapture();
+
+    emitScopeCompleted("cache", 7, 8192, false);
+
+    const line = std.mem.trimEnd(u8, buf.items, "\n");
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line, .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    try testing.expectEqualStrings("scope_completed", obj.get("event").?.string);
+    try testing.expectEqualStrings("cache", obj.get("scope").?.string);
+    try testing.expectEqual(@as(i64, 7), obj.get("removed").?.integer);
+    try testing.expectEqual(@as(i64, 8192), obj.get("bytes").?.integer);
+    try testing.expectEqual(false, obj.get("dry_run").?.bool);
+}
+
+test "emitPurgeComplete brackets the stream" {
+    const prior = output.isNdjson();
+    defer output.setNdjson(prior);
+    output.setNdjson(true);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &buf);
+    defer output.endStdoutCapture();
+
+    emitPurgeComplete(42, 1_048_576, false);
+
+    const line = std.mem.trimEnd(u8, buf.items, "\n");
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line, .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    try testing.expectEqualStrings("purge_complete", obj.get("event").?.string);
+    try testing.expectEqual(@as(i64, 42), obj.get("removed").?.integer);
+    try testing.expectEqual(@as(i64, 1_048_576), obj.get("bytes").?.integer);
+}

--- a/src/cli/purge/scopes.zig
+++ b/src/cli/purge/scopes.zig
@@ -21,15 +21,26 @@ const TierResult = util.TierResult;
 
 pub fn runStoreOrphans(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: []const u8, dry_run: bool) !TierResult {
     var result: TierResult = .{};
-
-    var db = util.openDb(prefix) orelse {
-        output.err("store-orphans: failed to open database", .{});
-        return result;
-    };
-    defer db.close();
-    schema.initSchema(&db) catch return result;
+    var rep = report.Reporter.init("store-orphans", dry_run);
+    rep.fmt = .short_hash;
 
     const io = ctx.io;
+    var db = switch (util.openDbTri(io, prefix)) {
+        .absent => {
+            rep.empty("no database — nothing to inspect");
+            return result;
+        },
+        .unreadable => |e| {
+            output.err("store-orphans: cannot open database ({s})", .{@errorName(e)});
+            return result;
+        },
+        .opened => |db_val| db_val,
+    };
+    defer db.close();
+    schema.initSchema(&db) catch |e| {
+        output.err("store-orphans: cannot init schema ({s})", .{@errorName(e)});
+        return result;
+    };
 
     var store = store_mod.Store.init(io, allocator, &db, prefix);
     var orphans_list = store.orphans() catch {
@@ -40,9 +51,6 @@ pub fn runStoreOrphans(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix:
         for (orphans_list.items) |item| allocator.free(item);
         orphans_list.deinit(allocator);
     }
-
-    var rep = report.Reporter.init("store-orphans", dry_run);
-    rep.fmt = .short_hash;
 
     if (orphans_list.items.len == 0) {
         rep.empty("no orphaned store entries");
@@ -73,13 +81,24 @@ pub fn runStoreOrphans(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix:
 
 pub fn runUnusedDeps(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: []const u8, dry_run: bool) !TierResult {
     var result: TierResult = .{};
+    var rep = report.Reporter.init("unused-deps", dry_run);
 
-    var db = util.openDb(prefix) orelse {
-        output.err("unused-deps: failed to open database", .{});
-        return result;
+    var db = switch (util.openDbTri(ctx.io, prefix)) {
+        .absent => {
+            rep.empty("no database — nothing to inspect");
+            return result;
+        },
+        .unreadable => |e| {
+            output.err("unused-deps: cannot open database ({s})", .{@errorName(e)});
+            return result;
+        },
+        .opened => |db_val| db_val,
     };
     defer db.close();
-    schema.initSchema(&db) catch return result;
+    schema.initSchema(&db) catch |e| {
+        output.err("unused-deps: cannot init schema ({s})", .{@errorName(e)});
+        return result;
+    };
 
     const orphans = deps_mod.findOrphans(allocator, &db) catch {
         output.err("unused-deps: failed to find orphans", .{});
@@ -89,8 +108,6 @@ pub fn runUnusedDeps(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
         for (orphans) |o| allocator.free(o);
         allocator.free(orphans);
     }
-
-    var rep = report.Reporter.init("unused-deps", dry_run);
 
     if (orphans.len == 0) {
         rep.empty("no orphaned dependencies");
@@ -260,9 +277,16 @@ pub fn runStaleCasks(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
 
     var rep = report.Reporter.init("stale-casks", dry_run);
 
-    var db = util.openDb(prefix) orelse {
-        rep.empty("no database — nothing to inspect");
-        return result;
+    var db = switch (util.openDbTri(io, prefix)) {
+        .absent => {
+            rep.empty("no database — nothing to inspect");
+            return result;
+        },
+        .unreadable => |e| {
+            output.err("stale-casks: cannot open database ({s})", .{@errorName(e)});
+            return result;
+        },
+        .opened => |db_val| db_val,
     };
     defer db.close();
 

--- a/src/cli/purge/util.zig
+++ b/src/cli/purge/util.zig
@@ -51,6 +51,31 @@ pub fn openDb(prefix: []const u8) ?sqlite.Database {
     return sqlite.Database.open(db_path) catch null;
 }
 
+/// Tri-state DB open: distinguishes "fresh prefix, nothing yet" from
+/// "the file is there but cannot be opened" (corruption, permissions).
+/// Callers route the two to different UX paths — soft skip vs loud err.
+pub const DbOutcome = union(enum) {
+    absent,
+    unreadable: sqlite.SqliteError,
+    opened: sqlite.Database,
+};
+
+pub fn openDbTri(io: std.Io, prefix: []const u8) DbOutcome {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return .absent;
+    // Probe for prior existence: SQLite's OPEN_CREATE flag would mask
+    // the difference between "no DB yet" and "file is there but dead".
+    const pre_existed = blk: {
+        std.Io.Dir.accessAbsolute(io, db_path, .{}) catch break :blk false;
+        break :blk true;
+    };
+    if (sqlite.Database.open(db_path)) |db| {
+        return .{ .opened = db };
+    } else |e| {
+        return if (pre_existed) .{ .unreadable = e } else .absent;
+    }
+}
+
 pub fn confirmScope(yes: bool, expected: []const u8, scope_label: []const u8) Error!void {
     if (yes) return;
     var prompt_buf: [128]u8 = undefined;

--- a/src/cli/purge/wipe.zig
+++ b/src/cli/purge/wipe.zig
@@ -193,7 +193,14 @@ pub fn verifyWipe(io: std.Io, plan: []const Target) void {
     }
 }
 
-pub fn runWipe(ctx: *const AppCtx, allocator: std.mem.Allocator, opts: Options, prefix: []const u8, cache_dir: []const u8, dry_run: bool) !void {
+/// Same idempotency contract as `accessAbsolute`: a missing path is not
+/// an error, just absent.
+fn pathExists(io: std.Io, path: []const u8) bool {
+    std.Io.Dir.accessAbsolute(io, path, .{}) catch return false;
+    return true;
+}
+
+pub fn runWipe(ctx: *const AppCtx, allocator: std.mem.Allocator, opts: Options, prefix: []const u8, cache_dir: []const u8, dry_run: bool) !util.TierResult {
     warnBanner();
     output.dimPlain("prefix:  {s}", .{prefix});
     output.dimPlain("cache:   {s}", .{cache_dir});
@@ -205,10 +212,20 @@ pub fn runWipe(ctx: *const AppCtx, allocator: std.mem.Allocator, opts: Options, 
 
     const io = ctx.io;
 
+    // Pre-flight stat: track which plan entries already hold data so the
+    // JSON `removed` counter reflects paths that would actually be freed.
+    // Without this, deleteTree's idempotent success on missing paths
+    // would inflate the count to plan.len on a half-installed prefix.
+    const existed = try allocator.alloc(bool, plan.len);
+    defer allocator.free(existed);
+
     var total_bytes: u64 = 0;
-    for (plan) |t| {
-        const size = util.pathSize(io, allocator, t.path);
+    var existing_count: u32 = 0;
+    for (plan, 0..) |t, idx| {
+        existed[idx] = pathExists(io, t.path);
+        const size = if (existed[idx]) util.pathSize(io, allocator, t.path) else 0;
         total_bytes += size;
+        if (existed[idx]) existing_count += 1;
         var sz_buf: [32]u8 = undefined;
         const sz = util.formatBytes(size, &sz_buf);
         output.plain("  [{s:<8}] {s} ({s})", .{ t.category.label(), t.path, sz });
@@ -230,17 +247,18 @@ pub fn runWipe(ctx: *const AppCtx, allocator: std.mem.Allocator, opts: Options, 
 
     if (dry_run) {
         output.info("dry run — nothing was removed", .{});
-        return;
+        return .{ .removed = existing_count, .bytes = total_bytes };
     }
 
     try util.confirmScope(opts.yes, "purge", "wipe");
 
     var lock_path_buf: [512]u8 = undefined;
-    const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return;
+    const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return .{};
     var lk_maybe: ?lock_mod.LockFile = lock_mod.LockFile.acquire(lock_path, 30_000) catch null;
 
     var removed: usize = 0;
     var skipped: usize = 0;
+    var freed_paths: u32 = 0;
     var db_idx: ?usize = null;
     var prefix_idx: ?usize = null;
 
@@ -256,16 +274,25 @@ pub fn runWipe(ctx: *const AppCtx, allocator: std.mem.Allocator, opts: Options, 
             },
             else => {},
         }
-        if (deleteTarget(io, t.path)) removed += 1 else skipped += 1;
+        if (deleteTarget(io, t.path)) {
+            removed += 1;
+            if (existed[idx]) freed_paths += 1;
+        } else skipped += 1;
     }
 
     if (lk_maybe) |*lk| lk.release();
 
     if (db_idx) |idx| {
-        if (deleteTarget(io, plan[idx].path)) removed += 1 else skipped += 1;
+        if (deleteTarget(io, plan[idx].path)) {
+            removed += 1;
+            if (existed[idx]) freed_paths += 1;
+        } else skipped += 1;
     }
     if (prefix_idx) |idx| {
-        if (deletePrefixRoot(io, plan[idx].path)) removed += 1 else skipped += 1;
+        if (deletePrefixRoot(io, plan[idx].path)) {
+            removed += 1;
+            if (existed[idx]) freed_paths += 1;
+        } else skipped += 1;
     }
 
     verifyWipe(io, plan);
@@ -273,4 +300,5 @@ pub fn runWipe(ctx: *const AppCtx, allocator: std.mem.Allocator, opts: Options, 
     var sum_buf: [128]u8 = undefined;
     const sum = std.fmt.bufPrint(&sum_buf, "removed {d} target(s), skipped {d}", .{ removed, skipped }) catch "";
     output.success("{s}", .{sum});
+    return .{ .removed = freed_paths, .bytes = total_bytes };
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -31,6 +31,7 @@ pub const shellenv = @import("cli/shellenv.zig");
 pub const backup = @import("cli/backup.zig");
 pub const purge = @import("cli/purge.zig");
 pub const purge_report = @import("cli/purge/report.zig");
+pub const purge_json = @import("cli/purge/json.zig");
 pub const install = @import("cli/install.zig");
 pub const upgrade = @import("cli/upgrade.zig");
 pub const doctor = @import("cli/doctor.zig");

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -132,6 +132,20 @@ test "purge completions expose --verbose with command-specific semantics" {
     try expectContains(completions.zsh_script, "Show every per-scope item");
 }
 
+test "purge completions surface --json and --output-format=ndjson" {
+    // Same shape as --verbose: bash and fish merge global flags into the
+    // per-subcommand list automatically; zsh's per-command _arguments
+    // block has to declare them locally or `mt purge --<TAB>` won't
+    // discover them.
+    try expectContains(completions.zsh_script, "Single summary object on stdout for scripts");
+    try expectContains(completions.zsh_script, "Stream one event per scope start/complete");
+    // Bash global_flags list and fish unconditional completes already
+    // cover both flags; pin them here so a regression in the global slot
+    // surfaces as a purge-specific failure.
+    try expectContains(completions.bash_script, "--output-format=ndjson");
+    try expectContains(completions.fish_script, "output-format=ndjson");
+}
+
 test "all bundle completions expose the cleanup subcommand and its flags" {
     for ([_][]const u8{
         completions.bash_script,

--- a/tests/help_test.zig
+++ b/tests/help_test.zig
@@ -65,6 +65,15 @@ test "purge help documents --verbose for full per-scope listings" {
     try testing.expect(std.mem.indexOf(u8, text, "no truncation") != null);
 }
 
+test "purge help documents structured output for scripts" {
+    // Discoverability guard: the JSON / NDJSON contract is silent on
+    // stdout by default, so users only know to script against it if
+    // --help advertises both modes.
+    const text = help.helpFor("purge");
+    try testing.expect(std.mem.indexOf(u8, text, "--json") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "--output-format=ndjson") != null);
+}
+
 test "install help documents --local and its code-exec warning" {
     // Discoverability guard: the flag only meaningfully exists if the
     // help output tells the user about it.

--- a/tests/purge_json_test.zig
+++ b/tests/purge_json_test.zig
@@ -314,6 +314,44 @@ test "wipe dry-run removed count matches the live freed-path semantic" {
     try testing.expect(removed < 14);
 }
 
+test "corrupt database surfaces a real error, not the soft no-db skip" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "corrupt_db");
+    defer prefix.deinit(allocator);
+
+    // Pre-populate {prefix}/db/malt.db with random bytes so SQLite's
+    // header check rejects it. This must take the .unreadable branch
+    // and log a loud err, not the soft "no database" path.
+    const db_path = try std.fmt.allocPrint(allocator, "{s}/db/malt.db", .{prefix.path});
+    defer allocator.free(db_path);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, db_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "this is not a valid sqlite header, just garbage to trip the open path");
+    }
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(true);
+    output.setNdjson(false);
+    output.setQuiet(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    const ctx = makeCtx();
+    try purge.execute(&ctx, allocator, &[_][]const u8{"--store-orphans"});
+
+    // Must NOT take the soft skip path.
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "no database — nothing to inspect") == null);
+    // Must surface the real error so the user can investigate.
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "cannot open database") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "store-orphans") != null);
+}
+
 test "ndjson scope_completed carries removed/bytes counters" {
     const allocator = testing.allocator;
     var prefix = try ScratchPrefix.init(allocator, "counters");

--- a/tests/purge_json_test.zig
+++ b/tests/purge_json_test.zig
@@ -1,0 +1,351 @@
+//! malt — purge --json / --output-format=ndjson integration tests.
+//!
+//! Drives `purge.execute` against a throwaway MALT_PREFIX and asserts the
+//! stdout payload shape (keys + value types) without pinning exact
+//! stringification — keeps the wire format flexible to field-order
+//! changes while pinning the v1 schema fields every consumer depends on.
+
+const std = @import("std");
+const malt = @import("malt");
+const test_io = @import("test_io");
+const testing = std.testing;
+const output = malt.output;
+const purge = malt.purge;
+const purge_json = malt.purge_json;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+const ScratchPrefix = struct {
+    path: [:0]u8,
+
+    fn init(allocator: std.mem.Allocator, tag: []const u8) !ScratchPrefix {
+        const ts = test_io.nanoTimestamp(std.Options.debug_io);
+        const path = try std.fmt.allocPrintSentinel(
+            allocator,
+            "/tmp/malt_purge_json_{s}_{d}",
+            .{ tag, ts },
+            0,
+        );
+        test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, path);
+        const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});
+        defer allocator.free(db_dir);
+        try test_io.cwd().createDirPath(std.Options.debug_io, db_dir);
+        const cache_dir = try std.fmt.allocPrint(allocator, "{s}/cache", .{path});
+        defer allocator.free(cache_dir);
+        try test_io.cwd().createDirPath(std.Options.debug_io, cache_dir);
+        _ = c.setenv("MALT_PREFIX", path.ptr, 1);
+        return .{ .path = path };
+    }
+
+    fn deinit(self: *ScratchPrefix, allocator: std.mem.Allocator) void {
+        _ = c.unsetenv("MALT_PREFIX");
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.path) catch {};
+        allocator.free(self.path);
+    }
+};
+
+const OutputState = struct {
+    prior_mode: output.OutputMode,
+    prior_ndjson: bool,
+    prior_dry: bool,
+    prior_quiet: bool,
+
+    fn save() OutputState {
+        return .{
+            .prior_mode = if (output.isJson()) .json else .human,
+            .prior_ndjson = output.isNdjson(),
+            .prior_dry = output.isDryRun(),
+            .prior_quiet = output.isQuiet(),
+        };
+    }
+
+    fn restore(self: OutputState) void {
+        output.setMode(self.prior_mode);
+        output.setNdjson(self.prior_ndjson);
+        output.setDryRun(self.prior_dry);
+        output.setQuiet(self.prior_quiet);
+    }
+};
+
+fn makeCtx() malt.app_ctx.AppCtx {
+    return .{ .io = std.Options.debug_io, .environ = .empty };
+}
+
+// ── --json summary tests ───────────────────────────────────────────────────
+
+test "--json --housekeeping --dry-run emits a parseable v1 summary on stdout" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "house_dry");
+    defer prefix.deinit(allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.json);
+    output.setDryRun(true);
+    output.setNdjson(false);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    const ctx = makeCtx();
+    try purge.execute(&ctx, allocator, &[_][]const u8{"--housekeeping"});
+
+    // Find the JSON object on stdout — leading lines may exist if
+    // intermediate ndjson is off. The summary is a single object.
+    const trimmed = std.mem.trim(u8, stdout_buf.items, " \r\n\t");
+    try testing.expect(trimmed.len > 0);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+
+    try testing.expectEqual(@as(i64, purge_json.schema_version), obj.get("version").?.integer);
+    try testing.expectEqual(true, obj.get("dry_run").?.bool);
+    try testing.expect(obj.get("scopes").? == .array);
+    try testing.expect(obj.get("totals").? == .object);
+    const totals = obj.get("totals").?.object;
+    try testing.expect(totals.get("removed") != null);
+    try testing.expect(totals.get("bytes") != null);
+    try testing.expect(obj.get("time_ms") != null);
+}
+
+test "--json --wipe --dry-run emits a parseable summary with the wipe scope" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "wipe_dry");
+    defer prefix.deinit(allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.json);
+    output.setDryRun(true);
+    output.setNdjson(false);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    const ctx = makeCtx();
+    try purge.execute(&ctx, allocator, &[_][]const u8{ "--wipe", "--yes" });
+
+    const trimmed = std.mem.trim(u8, stdout_buf.items, " \r\n\t");
+    try testing.expect(trimmed.len > 0);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    try testing.expectEqual(true, obj.get("dry_run").?.bool);
+
+    const scopes = obj.get("scopes").?.array;
+    try testing.expectEqual(@as(usize, 1), scopes.items.len);
+    try testing.expectEqualStrings("wipe", scopes.items[0].object.get("name").?.string);
+}
+
+test "--json --quiet --housekeeping keeps stdout populated, stderr silent" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "quiet");
+    defer prefix.deinit(allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.json);
+    output.setDryRun(true);
+    output.setQuiet(true);
+    output.setNdjson(false);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    const ctx = makeCtx();
+    try purge.execute(&ctx, allocator, &[_][]const u8{"--housekeeping"});
+
+    try testing.expect(stdout_buf.items.len > 0);
+    try testing.expectEqual(@as(usize, 0), stderr_buf.items.len);
+
+    const trimmed = std.mem.trim(u8, stdout_buf.items, " \r\n\t");
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(true, parsed.value.object.get("dry_run").?.bool);
+}
+
+// ── --output-format=ndjson tests ───────────────────────────────────────────
+
+test "--output-format=ndjson --housekeeping emits scope events bracketed by purge_complete" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "house_ndjson");
+    defer prefix.deinit(allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(true);
+    output.setNdjson(true);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    const ctx = makeCtx();
+    try purge.execute(&ctx, allocator, &[_][]const u8{"--housekeeping"});
+
+    // Every line must parse as JSON; vocabulary stays inside the
+    // PurgeEvent enum so any rename surfaces in the parser.
+    var lines = std.mem.splitScalar(u8, std.mem.trimEnd(u8, stdout_buf.items, "\n"), '\n');
+    var scope_started: usize = 0;
+    var scope_completed: usize = 0;
+    var purge_complete_seen: bool = false;
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+        defer parsed.deinit();
+        const event = parsed.value.object.get("event").?.string;
+        if (std.mem.eql(u8, event, "scope_started")) scope_started += 1;
+        if (std.mem.eql(u8, event, "scope_completed")) scope_completed += 1;
+        if (std.mem.eql(u8, event, "purge_complete")) purge_complete_seen = true;
+    }
+    try testing.expect(scope_started > 0);
+    try testing.expectEqual(scope_started, scope_completed);
+    try testing.expect(purge_complete_seen);
+
+    // purge_complete must be the closing line so consumers can rely on
+    // a strict bracket — find its byte offset and check it trails
+    // every scope_completed event.
+    const close_pos = std.mem.indexOf(u8, stdout_buf.items, "\"event\":\"purge_complete\"").?;
+    var search_start: usize = 0;
+    while (std.mem.indexOfPos(u8, stdout_buf.items, search_start, "\"event\":\"scope_completed\"")) |pos| {
+        try testing.expect(pos < close_pos);
+        search_start = pos + 1;
+    }
+}
+
+test "--output-format=ndjson --wipe emits a wipe scope event" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "wipe_ndjson");
+    defer prefix.deinit(allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(true);
+    output.setNdjson(true);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    const ctx = makeCtx();
+    try purge.execute(&ctx, allocator, &[_][]const u8{ "--wipe", "--yes" });
+
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"scope\":\"wipe\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"event\":\"purge_complete\"") != null);
+}
+
+test "ndjson stream stays bracketed when --wipe is aborted at confirm" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "wipe_abort");
+    defer prefix.deinit(allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(false);
+    output.setNdjson(true);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    // No --yes, stdin not a TTY → confirmScope returns Error.UserAborted.
+    // The ndjson stream must still close out with scope_completed +
+    // purge_complete so consumers can rely on strict bracketing.
+    const ctx = makeCtx();
+    const rc = purge.execute(&ctx, allocator, &[_][]const u8{"--wipe"});
+    try testing.expectError(purge.Error.UserAborted, rc);
+
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"event\":\"scope_started\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"event\":\"scope_completed\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"event\":\"purge_complete\"") != null);
+}
+
+test "wipe dry-run removed count matches the live freed-path semantic" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "wipe_count");
+    defer prefix.deinit(allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.json);
+    output.setDryRun(true);
+    output.setNdjson(false);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    // Fresh prefix has only `db/` and `cache/` (created by ScratchPrefix);
+    // every other plan target is missing on disk, so `removed` reports
+    // only the targets that pre-existed — not plan.len.
+    const ctx = makeCtx();
+    try purge.execute(&ctx, allocator, &[_][]const u8{ "--wipe", "--yes" });
+
+    const trimmed = std.mem.trim(u8, stdout_buf.items, " \r\n\t");
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{});
+    defer parsed.deinit();
+    const removed = parsed.value.object.get("totals").?.object.get("removed").?.integer;
+    // Two pre-existing targets: db, cache (and the prefix root itself).
+    try testing.expect(removed >= 2);
+    try testing.expect(removed < 14);
+}
+
+test "ndjson scope_completed carries removed/bytes counters" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "counters");
+    defer prefix.deinit(allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(true);
+    output.setNdjson(true);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    const ctx = makeCtx();
+    try purge.execute(&ctx, allocator, &[_][]const u8{"--housekeeping"});
+
+    // At least one scope_completed line must contain both counters,
+    // even if the values are zero — the keys are part of the contract.
+    var lines = std.mem.splitScalar(u8, std.mem.trimEnd(u8, stdout_buf.items, "\n"), '\n');
+    var saw_completed_with_counters = false;
+    while (lines.next()) |line| {
+        if (std.mem.indexOf(u8, line, "\"event\":\"scope_completed\"") == null) continue;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+        defer parsed.deinit();
+        const obj = parsed.value.object;
+        try testing.expect(obj.get("removed") != null);
+        try testing.expect(obj.get("bytes") != null);
+        try testing.expect(obj.get("dry_run") != null);
+        saw_completed_with_counters = true;
+    }
+    try testing.expect(saw_completed_with_counters);
+}


### PR DESCRIPTION
## Description

`mt purge` now honours `--json` (single summary object on stdout) and `--output-format=ndjson` (one event per state transition) so scripts can consume purge results without parsing the human stderr surface. Stderr behaviour is unchanged from the default human mode.

## Related issue

- None

## Notes for Reviewers

- None