### PR TITLE
chore: silence environmental noise from `zig build test`

### DIFF
--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -257,8 +257,12 @@ pub fn materializeWithCellar(
     // homebrew path references (tree, etc.), the modified list is empty
     // and the ~15 ms codesign subprocess is skipped entirely.
     if (codesign.isArm64() and modified_macho_paths.items.len > 0) {
-        codesign.adHocSignAll(io, allocator, modified_macho_paths.items) catch |e| {
-            std.log.warn("codesigning failed for {s}: {s}", .{ cellar_path, @errorName(e) });
+        codesign.adHocSignAll(io, allocator, modified_macho_paths.items) catch |e| switch (e) {
+            // Spawn failure means the io can't run subprocesses (the
+            // debug_io used by tests). Real codesign(1) errors land in
+            // CodesignFailed / CodesignNotFound and still get warned.
+            error.SpawnFailed => {},
+            else => std.log.warn("codesigning failed for {s}: {s}", .{ cellar_path, @errorName(e) }),
         };
     }
 

--- a/src/core/dsl/interpreter.zig
+++ b/src/core/dsl/interpreter.zig
@@ -10,6 +10,10 @@ const sandbox = @import("sandbox.zig");
 const fallback_log = @import("fallback_log.zig");
 const builtins_root = @import("builtins/root.zig");
 const context = @import("context.zig");
+// Same UI seam used by `odie` and the fallback log; routing through
+// the output module keeps test stderr capture working instead of
+// punching directly to fd 2.
+const output = @import("../../ui/output.zig");
 
 const Node = ast.Node;
 const SourceLoc = ast.SourceLoc;
@@ -563,8 +567,7 @@ pub const Interpreter = struct {
             // assembly OOM and the stream failure are tolerated.
             if (std.fmt.allocPrint(self.allocator, "  x {s}\n", .{msg_str})) |line| {
                 defer self.allocator.free(line);
-                const stderr: std.Io.File = .{ .handle = std.posix.STDERR_FILENO, .flags = .{ .nonblocking = false } };
-                stderr.writeStreamingAll(self.ctx.io, line) catch {};
+                output.writeStderrAll(line);
             } else |_| {}
         }
         return DslError.PostInstallFailed;

--- a/tests/clonefile_test.zig
+++ b/tests/clonefile_test.zig
@@ -189,15 +189,18 @@ test "copyTreeFallback errors when source directory does not exist" {
 // MALT_TEST_NON_APFS_DIR. On the common macOS dev box every visible mount
 // is APFS, so we skip with a clear message instead of inventing one.
 test "cloneTree falls back to copyTree on a non-APFS volume" {
+    // Skip notes use std.log.debug so default `zig build test` output stays
+    // quiet; run with `-Dlog-level=debug` (or set MALT_TEST_NON_APFS_DIR)
+    // when actively wiring up the non-APFS path.
     const non_apfs_dir = test_io.getenv("MALT_TEST_NON_APFS_DIR") orelse {
-        std.log.warn(
+        std.log.debug(
             "skipping non-APFS fallback test: set MALT_TEST_NON_APFS_DIR to a writable non-APFS mount to enable",
             .{},
         );
         return error.SkipZigTest;
     };
     if (clonefile.isApfs(non_apfs_dir)) {
-        std.log.warn(
+        std.log.debug(
             "skipping non-APFS fallback test: MALT_TEST_NON_APFS_DIR={s} is APFS",
             .{non_apfs_dir},
         );

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -286,6 +286,27 @@ test "interpreter: raise causes PostInstallFailed" {
     try testing.expectEqual(dsl.DslError.PostInstallFailed, err.?);
 }
 
+test "interpreter: raise message is captured by the output module seam" {
+    // Pins the routing fix: `raise` emits via output.writeStderrAll so
+    // beginStderrCapture intercepts the line and `zig build test` stays
+    // quiet. A regression to direct fd-2 writes would let the message
+    // leak past the capture and the assertion below would fail.
+    var arena = testArena();
+    defer arena.deinit();
+
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &buf);
+    defer malt.output.endStderrCapture();
+
+    const err = try runSnippet(&arena, "raise \"boom\"", prefix);
+    try testing.expect(err != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "boom") != null);
+}
+
 test "interpreter: begin rescue handles error" {
     var arena = testArena();
     defer arena.deinit();


### PR DESCRIPTION
## Description

`zig build test --summary all` was leaking three classes of stderr noise on every CI run despite the suite passing:

- DSL `raise "msg"` punched directly to fd 2, bypassing `output.beginStderrCapture` and printing `x boom / x oops / x stop` lines.
- `cellar_test` hit `SpawnFailed` because `std.Options.debug_io` can't run subprocesses, then `cellar.zig` warn-logged the codesign failure for each fake bottle.
- The non-APFS clonefile test warn-logged its own skip even though `SkipZigTest` already accounts for it.

After this PR `zig build test` is silent unless something actually goes wrong. Real codesign failures (`CodesignFailed`, `CodesignNotFound`) still warn so production diagnostics are unaffected.

## Related issue

- None

## Notes for Reviewers

- None