### PR TITLE
ci(bench): fix README date refresh in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -165,8 +165,9 @@ jobs:
             }" README.md
           done
 
-          # Update date
-          sed -i '' "s/> Benchmarks on Apple Silicon.*/> Benchmarks on Apple Silicon (GitHub Actions macos-14), $DATE. Auto-updated weekly via [benchmark workflow](.github\/workflows\/benchmark.yml)./" README.md
+          # Update date. The anchor pins to the README's actual
+          # line (no `> Benchmarks on` blockquote prefix).
+          sed -i '' "s|^Apple Silicon (GitHub Actions macos-14), .*|Apple Silicon (GitHub Actions macos-14), $DATE. Auto-updated weekly via the [benchmark workflow](.github/workflows/benchmark.yml).|" README.md
 
       - name: Open PR with benchmark results
         # Only publish the README refresh when the workflow runs against


### PR DESCRIPTION
## Description

The weekly benchmark workflow has been refreshing the install-time tables but leaving the publication date stale - readers see fresh numbers stamped with an old run date, which undermines trust in the benchmarks section.

The README sed pattern was anchored to a blockquote prefix that no longer exists on the line, so the substitution silently no-op'd. Re-anchored to the actual line and switched to a pipe delimiter to keep the workflow path readable.

## Related Issue

- None

## Notes for Reviewers

Verified locally by running the patched sed against the current README - line 626 now rewrites cleanly with the workflow's \$DATE.