### PR TITLE
fix(install/post_install): auto-include ruby keg in system-Ruby fallback

### DIFF
--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -22,6 +22,22 @@ pub fn useSystemRubyForFormula(scope: []const []const u8, formula_name: []const 
     return false;
 }
 
+/// `ruby` and its versioned aliases (`ruby@3`, `ruby@3.4`, ...) carry their
+/// own `post_install` hook. Without auto-inclusion the user has to write
+/// `--use-system-ruby=ruby` to install ruby — recursive nonsense, since
+/// the trust boundary is whatever `mt migrate ruby` already implies.
+pub fn isSelfHostingRubyKeg(name: []const u8) bool {
+    if (std.mem.eql(u8, name, "ruby")) return true;
+    if (!std.mem.startsWith(u8, name, "ruby@")) return false;
+    const tail = name["ruby@".len..];
+    if (tail.len == 0) return false;
+    for (tail) |c| switch (c) {
+        '0'...'9', '.' => {},
+        else => return false,
+    };
+    return true;
+}
+
 /// Post_install outcome status — surfaced to users as human text and
 /// to scripted consumers as JSON when `--json` is set.
 pub const PostInstallStatus = enum {
@@ -67,7 +83,7 @@ pub fn routePostInstallOutcome(
             output.info("post_install completed for {s}", .{name});
             break :blk .completed;
         }
-        if (useSystemRubyForFormula(use_system_ruby_list, name)) {
+        if (useSystemRubyForFormula(use_system_ruby_list, name) or isSelfHostingRubyKeg(name)) {
             output.warn("post_install DSL incomplete for {s}, falling back to system Ruby...", .{name});
             if (output.isVerbose()) flog.printUnknown(name);
             if (output.isDebug()) flog.printFatal(name);
@@ -250,7 +266,7 @@ pub fn drive(
         }
     }
 
-    if (useSystemRubyForFormula(use_system_ruby_list, name)) {
+    if (useSystemRubyForFormula(use_system_ruby_list, name) or isSelfHostingRubyKeg(name)) {
         output.warn("Running post_install for {s} via system Ruby...", .{name});
         ruby_sub.runPostInstall(ctx.io, ctx.environ, allocator, name, version_str, prefix) catch |e| {
             output.warn("post_install failed for {s}: {s}", .{ name, ruby_sub.describeError(e) });
@@ -258,4 +274,24 @@ pub fn drive(
     } else {
         output.warn("{s}: post_install skipped (use --use-system-ruby={s} or brew install {s})", .{ name, name, name });
     }
+}
+
+test "isSelfHostingRubyKeg: bare ruby and versioned aliases match" {
+    try std.testing.expect(isSelfHostingRubyKeg("ruby"));
+    try std.testing.expect(isSelfHostingRubyKeg("ruby@3"));
+    try std.testing.expect(isSelfHostingRubyKeg("ruby@3.4"));
+    try std.testing.expect(isSelfHostingRubyKeg("ruby@4.0.3"));
+}
+
+test "isSelfHostingRubyKeg: non-ruby kegs and lookalikes are rejected" {
+    try std.testing.expect(!isSelfHostingRubyKeg(""));
+    try std.testing.expect(!isSelfHostingRubyKeg("rubygems"));
+    try std.testing.expect(!isSelfHostingRubyKeg("iruby"));
+    try std.testing.expect(!isSelfHostingRubyKeg("jruby"));
+    try std.testing.expect(!isSelfHostingRubyKeg("ruby-build"));
+    // Empty/garbage version tail must not auto-include — keeps the
+    // pattern tight to canonical Homebrew interpreter kegs.
+    try std.testing.expect(!isSelfHostingRubyKeg("ruby@"));
+    try std.testing.expect(!isSelfHostingRubyKeg("ruby@stable"));
+    try std.testing.expect(!isSelfHostingRubyKeg("ruby@3-rc1"));
 }

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -590,6 +590,60 @@ test "routePostInstallOutcome: fatal entry wins over hasErrors heuristic" {
     try testing.expect(std.mem.indexOf(u8, out, "post_install completed") == null);
 }
 
+// `mt migrate ruby` shouldn't require `--use-system-ruby=ruby` — the
+// recursion is nonsensical. Self-hosting interpreter kegs (ruby,
+// ruby@N) are auto-included in the system-Ruby allow-list so the
+// hook routes to the same fallback path with no flag from the user.
+test "routePostInstallOutcome: ruby keg auto-routes to system Ruby with no flag" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.log(.{
+        .formula = "ruby",
+        .reason = .unknown_method,
+        .detail = "rubygems_helper",
+        .loc = null,
+    });
+
+    const out = try runRoute(&flog, "ruby", &.{});
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "falling back to system Ruby") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "partially skipped") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "use --use-system-ruby=ruby") == null);
+}
+
+test "routePostInstallOutcome: ruby@N keg also auto-routes to system Ruby" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.log(.{
+        .formula = "ruby@3.4",
+        .reason = .unsupported_node,
+        .detail = "default_args",
+        .loc = null,
+    });
+
+    const out = try runRoute(&flog, "ruby@3.4", &.{});
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "falling back to system Ruby") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "partially skipped") == null);
+}
+
+// Negative: lookalikes must NOT inherit the auto-include — only the
+// canonical interpreter kegs. Regression guard against widening the
+// trust boundary by accident.
+test "routePostInstallOutcome: ruby-lookalike kegs still need the explicit flag" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.log(.{ .formula = "rubygems", .reason = .unknown_method, .detail = "x", .loc = null });
+
+    const out = try runRoute(&flog, "rubygems", &.{});
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "falling back to system Ruby") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "partially skipped (use --use-system-ruby=rubygems") != null);
+}
+
 test "routePostInstallOutcome: scope with unrelated names is ignored" {
     var flog = dsl.FallbackLog.init(testing.allocator);
     defer flog.deinit();


### PR DESCRIPTION
## Description

`mt migrate ruby` previously surfaced the recursive suggestion `use --use-system-ruby=ruby to attempt via Ruby` and reported the keg as `partially_skipped`. The trust boundary the flag controls is whatever `mt migrate ruby` already implies, so asking the user to opt back into Ruby for the Ruby keg itself is nonsensical.

This PR auto-includes canonical Ruby interpreter kegs (`ruby`, `ruby@3`, `ruby@3.4`, ...) in the system-Ruby fallback path. The `--use-system-ruby=<list>` flag keeps its v0.4.0 semantics for every other keg.

Stacks on #244.

### What changed

- New `isSelfHostingRubyKeg(name)` matches `ruby` and `ruby@<digits>(.<digits>)*` only — lookalikes (`rubygems`, `iruby`, `jruby`, `ruby-build`, `ruby@stable`) stay outside the auto-include.
- `routePostInstallOutcome` and `drive` OR the helper into the existing scope check; both gates land on the same fallback banner and downstream subprocess.

## Related issue

- None

## Notes for Reviewers

Subset smoke (`hello jq tree libdeflate ruby`) green on this machine: 5/5 migrated, 0 failed, 5 usable, concurrency interleaved. The recursive `--use-system-ruby=ruby` suggestion no longer appears; ruby migrates and is usable (`/tmp/mt_mp/Cellar/ruby/4.0.3/bin/rdbg --help` exits 0).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)