### PR TITLE
feat(migrate): copy-from-Cellar fallback for kegs not in the Homebrew API

### DIFF
--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -307,6 +307,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             .outcomes = outcomes,
             .cache_dir = cache_dir,
             .prefix = prefix,
+            .homebrew_prefix = brew_prefix,
             .use_system_ruby_scope = use_system_ruby_scope.items,
             .http_pool = &http_pool,
             .store = &store,
@@ -357,6 +358,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             .linker = &linker,
             .db = &db,
             .prefix = prefix,
+            .homebrew_prefix = brew_prefix,
             .use_system_ruby_scope = use_system_ruby_scope.items,
         });
 

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -17,6 +17,7 @@ const api_mod = @import("../../net/api.zig");
 const atomic = @import("../../fs/atomic.zig");
 const output = @import("../../ui/output.zig");
 const post_install_mod = @import("../install/post_install.zig");
+const install_receipt_mod = @import("../../core/install_receipt.zig");
 
 /// Result of migrating a single keg.
 pub const KegResult = enum {
@@ -39,6 +40,11 @@ pub const MigrateDeps = struct {
     linker: *linker_mod.Linker,
     db: *sqlite.Database,
     prefix: []const u8,
+    /// Source Homebrew install root — used as the read-only fallback
+    /// when the brew API has no record of a keg (private/third-party
+    /// taps); INSTALL_RECEIPT.json under each keg supplies the version
+    /// + tap so we can copy + relocate the on-disk tree.
+    homebrew_prefix: []const u8,
     use_system_ruby_scope: []const []const u8,
     /// Set by the parallel runner; null on the serial path so the
     /// default flow pays no lock cost.
@@ -58,9 +64,18 @@ pub fn migrateKeg(
     }
 
     // Two `defer`s below collapse six per-branch cleanups.
-    const formula_json = deps.api.fetchFormula(keg_name) catch {
-        output.err("  {s}: not found in Homebrew API", .{keg_name});
-        return .failed_api;
+    const formula_json = deps.api.fetchFormula(keg_name) catch |e| switch (e) {
+        // `NotFound` is the only API outcome that triggers the
+        // private-tap copy-from-Cellar fallback: the keg simply doesn't
+        // exist in formulae.brew.sh because it lives in a third-party
+        // tap. Network / response-shape / cache failures bypass the
+        // fallback so a transient brew-api outage doesn't silently
+        // shadow the canonical bottle path.
+        error.NotFound => return migrateFromLocalCellar(ctx, allocator, keg_name, deps),
+        else => {
+            output.err("  {s}: Homebrew API fetch failed ({s})", .{ keg_name, @errorName(e) });
+            return .failed_api;
+        },
     };
     defer allocator.free(formula_json);
 
@@ -163,6 +178,164 @@ pub fn migrateKeg(
     return .migrated;
 }
 
+/// Copy-from-Cellar fallback for kegs the brew API can't resolve
+/// (private/third-party taps). Locates `<homebrew_prefix>/Cellar/<name>/`,
+/// picks the version subdir whose `INSTALL_RECEIPT.json` mtime is
+/// newest (matches brew's "current" version when multiples are present),
+/// reads the receipt, and — if the recorded tap is non-core — copies
+/// the keg tree into malt's Cellar via the same relocation pipeline
+/// the bottle path uses. A `homebrew/core` keg that's missing from
+/// the API is treated as a real API problem, not a fallback case:
+/// returning `.failed_api` keeps the user's attention on the brew side
+/// instead of papering over an upstream outage with a stale local copy.
+fn migrateFromLocalCellar(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    keg_name: []const u8,
+    deps: MigrateDeps,
+) KegResult {
+    const src_keg_path = findInstalledKegPath(ctx.io, allocator, deps.homebrew_prefix, keg_name) catch null orelse {
+        output.err("  {s}: not found in Homebrew API and no local Cellar copy available", .{keg_name});
+        return .failed_api;
+    };
+    defer allocator.free(src_keg_path);
+
+    const receipt_text = readInstallReceipt(ctx.io, allocator, src_keg_path) catch {
+        output.err("  {s}: local Cellar copy lacks a readable INSTALL_RECEIPT.json", .{keg_name});
+        return .failed_api;
+    };
+    defer allocator.free(receipt_text);
+
+    var receipt = install_receipt_mod.parseInstallReceipt(allocator, receipt_text) catch {
+        output.err("  {s}: INSTALL_RECEIPT.json malformed", .{keg_name});
+        return .failed_api;
+    };
+    defer receipt.deinit();
+
+    if (install_receipt_mod.isCoreTap(receipt.tap)) {
+        output.err("  {s}: not found in Homebrew API (homebrew/core keg — refusing local-Cellar fallback)", .{keg_name});
+        return .failed_api;
+    }
+    if (receipt.version.len == 0) {
+        output.err("  {s}: INSTALL_RECEIPT.json has no source.versions.stable", .{keg_name});
+        return .failed_api;
+    }
+
+    output.info("  Migrating {s} {s} (from {s} tap)...", .{ keg_name, receipt.version, receipt.tap });
+
+    const keg = cellar_mod.materializeFromLocalCellar(
+        ctx.io,
+        allocator,
+        deps.prefix,
+        src_keg_path,
+        keg_name,
+        receipt.version,
+        receipt.tap,
+        // Tap kegs don't carry a Homebrew bottle cellar_type tag here;
+        // pass empty so the relocation pipeline treats it as a normal
+        // bottle (full absolute-path rewrite + placeholder substitution).
+        "",
+    ) catch |e| {
+        output.err("    {s}: failed to materialize from local Cellar ({s})", .{ keg_name, @errorName(e) });
+        return .failed_install;
+    };
+
+    if (deps.db_mu) |m| m.lockUncancelable(ctx.io);
+    defer if (deps.db_mu) |m| m.unlock(ctx.io);
+
+    var full_name_buf: [256]u8 = undefined;
+    const full_name = std.fmt.bufPrint(&full_name_buf, "{s}/{s}", .{ receipt.tap, keg_name }) catch keg_name;
+
+    const keg_id = recordKegFields(deps.db, .{
+        .name = keg_name,
+        .full_name = full_name,
+        .version = receipt.version,
+        .revision = 0,
+        .tap = receipt.tap,
+        .store_sha256 = "",
+        .cellar_path = keg.path,
+        .install_reason = "direct",
+    }) catch {
+        output.err("    {s}: failed to record in database", .{keg_name});
+        cellar_mod.remove(ctx.io, deps.prefix, keg_name, receipt.version) catch {};
+        return .failed_install;
+    };
+
+    deps.linker.link(keg.path, keg_name, keg_id) catch {
+        output.warn("    {s}: some links could not be created", .{keg_name});
+        deps.linker.unlink(keg_id) catch {};
+        deleteKeg(deps.db, keg_id) catch {};
+        cellar_mod.remove(ctx.io, deps.prefix, keg_name, receipt.version) catch {};
+        return .failed_install;
+    };
+    deps.linker.linkOpt(keg_name, receipt.version) catch {};
+    recordDepsFromList(deps.db, keg_id, receipt.runtime_deps);
+
+    output.success("  {s} {s} migrated (from {s} tap)", .{ keg_name, receipt.version, receipt.tap });
+    return .migrated;
+}
+
+/// Locate the most recently-installed version subdir for `name` under
+/// the source brew Cellar. Picks the one whose INSTALL_RECEIPT.json
+/// mtime is highest so an upgrade-then-uninstall sequence still
+/// migrates the version brew currently considers active. Returns the
+/// caller-owned absolute path or null when no version dir carries a
+/// receipt.
+fn findInstalledKegPath(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    homebrew_prefix: []const u8,
+    name: []const u8,
+) !?[]const u8 {
+    var cellar_buf: [512]u8 = undefined;
+    const cellar_name_path = std.fmt.bufPrint(&cellar_buf, "{s}/Cellar/{s}", .{ homebrew_prefix, name }) catch return null;
+
+    var dir = std.Io.Dir.openDirAbsolute(io, cellar_name_path, .{ .iterate = true }) catch return null;
+    defer dir.close(io);
+
+    var best_path: ?[]const u8 = null;
+    var best_mtime_ns: i96 = std.math.minInt(i96);
+    errdefer if (best_path) |p| allocator.free(p);
+
+    var it = dir.iterate();
+    while (it.next(io) catch null) |entry| {
+        if (entry.kind != .directory) continue;
+        var receipt_buf: [512]u8 = undefined;
+        const receipt_rel = std.fmt.bufPrint(&receipt_buf, "{s}/INSTALL_RECEIPT.json", .{entry.name}) catch continue;
+        const stat = dir.statFile(io, receipt_rel, .{}) catch continue;
+        if (stat.kind != .file) continue;
+        const mtime_ns = stat.mtime.toNanoseconds();
+        if (mtime_ns > best_mtime_ns) {
+            const new_full = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ cellar_name_path, entry.name });
+            if (best_path) |old| allocator.free(old);
+            best_path = new_full;
+            best_mtime_ns = mtime_ns;
+        }
+    }
+    return best_path;
+}
+
+/// Slurp `INSTALL_RECEIPT.json` from a keg directory. Caller owns.
+/// Receipts are small (well under 1 MiB even for python with hundreds
+/// of runtime deps); cap defensively to refuse a hostile/runaway file.
+fn readInstallReceipt(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    keg_path: []const u8,
+) ![]u8 {
+    var path_buf: [512]u8 = undefined;
+    const receipt_path = try std.fmt.bufPrint(&path_buf, "{s}/INSTALL_RECEIPT.json", .{keg_path});
+    const file = try std.Io.Dir.openFileAbsolute(io, receipt_path, .{});
+    defer file.close(io);
+    const stat = try file.stat(io);
+    const max_bytes: u64 = 1024 * 1024;
+    if (stat.size > max_bytes) return error.ReceiptTooLarge;
+    const buf = try allocator.alloc(u8, stat.size);
+    errdefer allocator.free(buf);
+    const n = try file.readPositionalAll(io, buf, 0);
+    return buf[0..n];
+}
+
 /// Download a bottle from GHCR and commit to the store.
 fn downloadBottle(
     ctx: *const AppCtx,
@@ -215,6 +388,21 @@ fn downloadBottle(
 
 // ── DB helpers (same pattern as install.zig) ────────────────────────
 
+/// Field bundle accepted by both the formula path (extracted from
+/// `Formula`) and the local-Cellar fallback (extracted from
+/// `INSTALL_RECEIPT.json`). Keeping the DB write surface flat means
+/// the two callers exercise byte-identical SQL.
+const KegFields = struct {
+    name: []const u8,
+    full_name: []const u8,
+    version: []const u8,
+    revision: i64,
+    tap: []const u8,
+    store_sha256: []const u8,
+    cellar_path: []const u8,
+    install_reason: []const u8,
+};
+
 fn recordKeg(
     db: *sqlite.Database,
     formula: *const formula_mod.Formula,
@@ -222,6 +410,19 @@ fn recordKeg(
     cellar_path: []const u8,
     install_reason: []const u8,
 ) !i64 {
+    return recordKegFields(db, .{
+        .name = formula.name,
+        .full_name = formula.full_name,
+        .version = formula.version,
+        .revision = formula.revision,
+        .tap = formula.tap,
+        .store_sha256 = store_sha256,
+        .cellar_path = cellar_path,
+        .install_reason = install_reason,
+    });
+}
+
+fn recordKegFields(db: *sqlite.Database, f: KegFields) !i64 {
     db.beginTransaction() catch return error.RecordFailed;
     errdefer db.rollback();
 
@@ -233,14 +434,14 @@ fn recordKeg(
     ) catch return error.RecordFailed;
     defer stmt.finalize();
 
-    stmt.bindText(1, formula.name) catch return error.RecordFailed;
-    stmt.bindText(2, formula.full_name) catch return error.RecordFailed;
-    stmt.bindText(3, formula.version) catch return error.RecordFailed;
-    stmt.bindInt(4, formula.revision) catch return error.RecordFailed;
-    stmt.bindText(5, formula.tap) catch return error.RecordFailed;
-    stmt.bindText(6, store_sha256) catch return error.RecordFailed;
-    stmt.bindText(7, cellar_path) catch return error.RecordFailed;
-    stmt.bindText(8, install_reason) catch return error.RecordFailed;
+    stmt.bindText(1, f.name) catch return error.RecordFailed;
+    stmt.bindText(2, f.full_name) catch return error.RecordFailed;
+    stmt.bindText(3, f.version) catch return error.RecordFailed;
+    stmt.bindInt(4, f.revision) catch return error.RecordFailed;
+    stmt.bindText(5, f.tap) catch return error.RecordFailed;
+    stmt.bindText(6, f.store_sha256) catch return error.RecordFailed;
+    stmt.bindText(7, f.cellar_path) catch return error.RecordFailed;
+    stmt.bindText(8, f.install_reason) catch return error.RecordFailed;
 
     _ = stmt.step() catch return error.RecordFailed;
 
@@ -260,7 +461,14 @@ fn deleteKeg(db: *sqlite.Database, keg_id: i64) sqlite.SqliteError!void {
 /// Each row is independent; skip on per-row failure so a partial dep
 /// table is preferred to aborting a migration wholesale.
 fn recordDeps(db: *sqlite.Database, keg_id: i64, formula: *const formula_mod.Formula) void {
-    for (formula.dependencies) |dep_name| {
+    recordDepsFromList(db, keg_id, formula.dependencies);
+}
+
+/// Same SQL as `recordDeps` but takes a pre-extracted list — used by
+/// the local-Cellar fallback whose dependency names come straight off
+/// `INSTALL_RECEIPT.json` rather than a parsed Formula.
+fn recordDepsFromList(db: *sqlite.Database, keg_id: i64, dep_names: []const []const u8) void {
+    for (dep_names) |dep_name| {
         var stmt = db.prepare(
             "INSERT OR IGNORE INTO dependencies (keg_id, dep_name, dep_type) VALUES (?1, ?2, 'runtime');",
         ) catch continue;

--- a/src/cli/migrate/parallel.zig
+++ b/src/cli/migrate/parallel.zig
@@ -61,6 +61,7 @@ pub const Pool = struct {
 
     cache_dir: []const u8,
     prefix: []const u8,
+    homebrew_prefix: []const u8,
     use_system_ruby_scope: []const []const u8,
 
     http_pool: *client_mod.HttpClientPool,
@@ -118,6 +119,7 @@ fn worker(pool: *Pool) void {
             .linker = pool.linker,
             .db = pool.db,
             .prefix = pool.prefix,
+            .homebrew_prefix = pool.homebrew_prefix,
             .use_system_ruby_scope = pool.use_system_ruby_scope,
             .db_mu = pool.db_mu,
         });

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -182,89 +182,7 @@ pub fn materializeWithCellar(
         return CellarError.CloneFailed;
     };
 
-    const new_prefix = atomic.maltPrefix();
-
-    // Build cellar replacement for @@HOMEBREW_CELLAR@@
-    var new_cellar_buf: [256]u8 = undefined;
-    const new_cellar = std.fmt.bufPrint(&new_cellar_buf, "{s}/Cellar", .{new_prefix}) catch new_prefix;
-
-    // Build the full Mach-O replacement list in one shot. `@@HOMEBREW_*@@`
-    // placeholders are patched for every bottle (they appear even in `:any`
-    // bottles — zig, curl, rust, llvm@* all use them in LC_LOAD_DYLIB /
-    // LC_RPATH load commands). The absolute-path rewrites are skipped for
-    // `:any` and `:any_skip_relocation` bottles, where Homebrew guarantees
-    // only `@rpath` / `@loader_path` + placeholder tokens.
-    //
-    // Passing all the replacements in one call means the walker visits
-    // each file exactly once and opens it exactly once per active
-    // replacement, instead of walking the cellar twice.
-    const skip_absolute_rewrite = std.mem.eql(u8, cellar_type, ":any") or
-        std.mem.eql(u8, cellar_type, ":any_skip_relocation");
-
-    var macho_reps_buf: [4]Replacement = undefined;
-    macho_reps_buf[0] = .{ .old = "@@HOMEBREW_PREFIX@@", .new = new_prefix };
-    macho_reps_buf[1] = .{ .old = "@@HOMEBREW_CELLAR@@", .new = new_cellar };
-    var macho_reps_len: usize = 2;
-    if (!skip_absolute_rewrite) {
-        macho_reps_buf[2] = .{ .old = "/opt/homebrew", .new = new_prefix };
-        macho_reps_buf[3] = .{ .old = "/usr/local", .new = new_prefix };
-        macho_reps_len = 4;
-    }
-
-    // `walkMachOAndPatch` collects the full paths of every Mach-O file
-    // it actually modified (i.e. where at least one replacement rewrote
-    // bytes). Those are the only files whose ad-hoc signature got
-    // invalidated, so they are the only files we need to re-sign. For a
-    // bottle whose binaries don't reference `/opt/homebrew` at all
-    // (e.g. `tree`), this list comes back empty and the expensive
-    // codesign subprocess is skipped entirely.
-    var modified_macho_paths: std.ArrayList([]const u8) = .empty;
-    defer {
-        for (modified_macho_paths.items) |p| allocator.free(p);
-        modified_macho_paths.deinit(allocator);
-    }
-
-    walkMachOAndPatch(
-        io,
-        allocator,
-        cellar_path,
-        macho_reps_buf[0..macho_reps_len],
-        &modified_macho_paths,
-    ) catch |e| switch (e) {
-        CellarError.PathTooLong => return CellarError.PathTooLong,
-        CellarError.InsufficientHeaderPad => return CellarError.InsufficientHeaderPad,
-        CellarError.InstallNameToolMissing => return CellarError.InstallNameToolMissing,
-        else => return CellarError.PatchFailed,
-    };
-
-    // Always patch text files — @@HOMEBREW_PREFIX@@ and @@HOMEBREW_CELLAR@@
-    // placeholders appear in scripts, .pc files, and configs regardless of
-    // whether the bottle is relocatable. Text files don't carry code
-    // signatures so they don't feed back into the codesign list.
-    const text_replacements = [_]text_patcher.Replacement{
-        .{ .old = "@@HOMEBREW_PREFIX@@", .new = new_prefix },
-        .{ .old = "@@HOMEBREW_CELLAR@@", .new = new_cellar },
-        .{ .old = "/opt/homebrew", .new = new_prefix },
-        .{ .old = "/usr/local", .new = new_prefix },
-    };
-    _ = text_patcher.patchTextFiles(io, allocator, cellar_path, &text_replacements) catch |e| {
-        std.log.warn("text patching failed for {s}: {s}", .{ cellar_path, @errorName(e) });
-    };
-
-    // Ad-hoc codesign on arm64. We only sign the Mach-O files we actually
-    // modified above — unpatched binaries keep their original ad-hoc
-    // signature, so re-signing them is pure waste. For bottles without any
-    // homebrew path references (tree, etc.), the modified list is empty
-    // and the ~15 ms codesign subprocess is skipped entirely.
-    if (codesign.isArm64() and modified_macho_paths.items.len > 0) {
-        codesign.adHocSignAll(io, allocator, modified_macho_paths.items) catch |e| switch (e) {
-            // Spawn failure means the io can't run subprocesses (the
-            // debug_io used by tests). Real codesign(1) errors land in
-            // CodesignFailed / CodesignNotFound and still get warned.
-            error.SpawnFailed => {},
-            else => std.log.warn("codesigning failed for {s}: {s}", .{ cellar_path, @errorName(e) }),
-        };
-    }
+    try relocateKegTree(io, allocator, cellar_path, cellar_type);
 
     // Write INSTALL_RECEIPT.json for brew compatibility
     writeInstallReceipt(io, cellar_path, name, version, store_sha256);
@@ -382,6 +300,146 @@ fn walkMachOAndPatch(
 
 /// Write a brew-compatible INSTALL_RECEIPT.json to the keg directory.
 /// This allows Homebrew to recognize malt-installed packages.
+/// Relocate a freshly-cloned keg tree at `cellar_path` so its embedded
+/// path references point at the live malt prefix: patch Mach-O load
+/// commands, substitute `@@HOMEBREW_*@@` placeholders in text files,
+/// ad-hoc-codesign every Mach-O the patcher actually mutated. Shared
+/// by both the bottle materialize path (`materializeWithCellar`) and
+/// the local-Cellar copy fallback (`materializeFromLocalCellar`) so
+/// every keg lands on disk with byte-identical relocation regardless
+/// of whether it came from the store or a sibling brew install.
+fn relocateKegTree(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    cellar_path: []const u8,
+    cellar_type: []const u8,
+) CellarError!void {
+    const new_prefix = atomic.maltPrefix();
+
+    var new_cellar_buf: [256]u8 = undefined;
+    const new_cellar = std.fmt.bufPrint(&new_cellar_buf, "{s}/Cellar", .{new_prefix}) catch new_prefix;
+
+    // `@@HOMEBREW_*@@` placeholders are patched for every bottle (they
+    // appear even in `:any` bottles — zig, curl, rust, llvm@* all use
+    // them in LC_LOAD_DYLIB / LC_RPATH). Absolute-path rewrites are
+    // skipped for `:any` / `:any_skip_relocation`, where Homebrew
+    // guarantees only `@rpath` / `@loader_path` + placeholder tokens.
+    const skip_absolute_rewrite = std.mem.eql(u8, cellar_type, ":any") or
+        std.mem.eql(u8, cellar_type, ":any_skip_relocation");
+
+    var macho_reps_buf: [4]Replacement = undefined;
+    macho_reps_buf[0] = .{ .old = "@@HOMEBREW_PREFIX@@", .new = new_prefix };
+    macho_reps_buf[1] = .{ .old = "@@HOMEBREW_CELLAR@@", .new = new_cellar };
+    var macho_reps_len: usize = 2;
+    if (!skip_absolute_rewrite) {
+        macho_reps_buf[2] = .{ .old = "/opt/homebrew", .new = new_prefix };
+        macho_reps_buf[3] = .{ .old = "/usr/local", .new = new_prefix };
+        macho_reps_len = 4;
+    }
+
+    // `walkMachOAndPatch` collects every file it actually mutated; only
+    // those need re-signing. Bottles with no `/opt/homebrew` references
+    // (`tree`, ...) come back with an empty list and skip the codesign
+    // subprocess entirely.
+    var modified_macho_paths: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (modified_macho_paths.items) |p| allocator.free(p);
+        modified_macho_paths.deinit(allocator);
+    }
+
+    walkMachOAndPatch(
+        io,
+        allocator,
+        cellar_path,
+        macho_reps_buf[0..macho_reps_len],
+        &modified_macho_paths,
+    ) catch |e| switch (e) {
+        CellarError.PathTooLong => return CellarError.PathTooLong,
+        CellarError.InsufficientHeaderPad => return CellarError.InsufficientHeaderPad,
+        CellarError.InstallNameToolMissing => return CellarError.InstallNameToolMissing,
+        else => return CellarError.PatchFailed,
+    };
+
+    const text_replacements = [_]text_patcher.Replacement{
+        .{ .old = "@@HOMEBREW_PREFIX@@", .new = new_prefix },
+        .{ .old = "@@HOMEBREW_CELLAR@@", .new = new_cellar },
+        .{ .old = "/opt/homebrew", .new = new_prefix },
+        .{ .old = "/usr/local", .new = new_prefix },
+    };
+    _ = text_patcher.patchTextFiles(io, allocator, cellar_path, &text_replacements) catch |e| {
+        std.log.warn("text patching failed for {s}: {s}", .{ cellar_path, @errorName(e) });
+    };
+
+    if (codesign.isArm64() and modified_macho_paths.items.len > 0) {
+        codesign.adHocSignAll(io, allocator, modified_macho_paths.items) catch |e| switch (e) {
+            error.SpawnFailed => {},
+            else => std.log.warn("codesigning failed for {s}: {s}", .{ cellar_path, @errorName(e) }),
+        };
+    }
+}
+
+/// Copy a keg tree from a sibling Homebrew install at `src_keg_path`
+/// (typically `$HOMEBREW_PREFIX/Cellar/<name>/<version>/`) into malt's
+/// Cellar and run the same relocation pipeline as the bottle path.
+/// Used when a private/third-party tap keg isn't resolvable through the
+/// brew API but is already present on disk in the user's Homebrew
+/// install — the bytes have been vetted by the user, we just relocate
+/// them. The caller-supplied `tap` is recorded in the malt-side
+/// `INSTALL_RECEIPT.json`. No store entry is created (no sha256 to
+/// key on); a fresh install of the same keg will copy from the source
+/// Cellar again rather than hitting the relocated-store cache.
+pub fn materializeFromLocalCellar(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    prefix: []const u8,
+    src_keg_path: []const u8,
+    name: []const u8,
+    version: []const u8,
+    tap: []const u8,
+    cellar_type: []const u8,
+) CellarError!Keg {
+    var cellar_buf: [512]u8 = undefined;
+    const cellar_path = std.fmt.bufPrint(&cellar_buf, "{s}/Cellar/{s}/{s}", .{ prefix, name, version }) catch
+        return CellarError.OutOfMemory;
+
+    var parent_buf: [512]u8 = undefined;
+    const parent = std.fmt.bufPrint(&parent_buf, "{s}/Cellar/{s}", .{ prefix, name }) catch
+        return CellarError.OutOfMemory;
+    std.Io.Dir.createDirAbsolute(io, parent, .default_dir) catch |e| switch (e) {
+        error.PathAlreadyExists => {},
+        else => {
+            std.log.debug("cellar parent mkdir {s}: {s}", .{ parent, @errorName(e) });
+            return CellarError.CloneFailed;
+        },
+    };
+
+    // On any patching failure below, wipe the partial keg and the
+    // empty parent dir so the caller can retry without state drift.
+    errdefer {
+        std.Io.Dir.cwd().deleteTree(io, cellar_path) catch {};
+        std.Io.Dir.deleteDirAbsolute(io, parent) catch {};
+    }
+
+    // Pre-wipe matches the bottle path: clonefile(2) returns EEXIST on
+    // a populated dst, and a SIGKILLed prior run can leave stale state.
+    std.Io.Dir.cwd().deleteTree(io, cellar_path) catch {};
+
+    clonefile.cloneTree(io, allocator, src_keg_path, cellar_path) catch |e| {
+        std.log.debug("cellar clonefile {s} -> {s}: {s}", .{ src_keg_path, cellar_path, @errorName(e) });
+        return CellarError.CloneFailed;
+    };
+
+    try relocateKegTree(io, allocator, cellar_path, cellar_type);
+
+    // Tap-aware receipt: the source-of-truth tap is the sibling
+    // brew install's, not "homebrew/core". `mt list` and friends use
+    // this to surface where a keg originally came from.
+    writeInstallReceiptFull(io, cellar_path, name, version, "", tap, true);
+
+    const owned_path = allocator.dupe(u8, cellar_path) catch return CellarError.OutOfMemory;
+    return .{ .name = name, .version = version, .path = owned_path };
+}
+
 fn writeInstallReceipt(io: std.Io, cellar_path: []const u8, name: []const u8, version: []const u8, store_sha256: []const u8) void {
     writeInstallReceiptFull(io, cellar_path, name, version, store_sha256, null, true);
 }

--- a/src/core/install_receipt.zig
+++ b/src/core/install_receipt.zig
@@ -1,0 +1,202 @@
+//! malt — Homebrew INSTALL_RECEIPT.json parser
+//!
+//! Extracts the small subset of fields malt's private-tap copy-from-Cellar
+//! fallback needs from a keg's `INSTALL_RECEIPT.json`: source tap, stable
+//! version, and runtime dependency names. The parser is deliberately
+//! lenient — newer brew versions add fields we don't read, older ones
+//! omit fields we tolerate as null/absent.
+
+const std = @import("std");
+
+pub const Receipt = struct {
+    /// `"homebrew/core"` for stock formulae, `"<user>/<repo>"` for tap
+    /// formulae. Empty when the receipt omits it (very old brew).
+    tap: []const u8,
+    /// `source.versions.stable`. Authoritative version for routing
+    /// + DB recording. Empty when absent.
+    version: []const u8,
+    /// `runtime_dependencies[*].full_name`. Order preserved.
+    runtime_deps: []const []const u8,
+
+    arena: std.heap.ArenaAllocator,
+
+    pub fn deinit(self: *Receipt) void {
+        self.arena.deinit();
+    }
+};
+
+pub const ParseError = error{
+    InvalidReceipt,
+    OutOfMemory,
+};
+
+/// Parse a Homebrew `INSTALL_RECEIPT.json` body. Tolerates absent / null
+/// fields so receipts written by older brew versions don't break the
+/// fallback. Returns the small subset of fields the migrate path uses;
+/// caller owns the arena that backs every string.
+pub fn parseInstallReceipt(parent: std.mem.Allocator, json_text: []const u8) ParseError!Receipt {
+    var arena = std.heap.ArenaAllocator.init(parent);
+    errdefer arena.deinit();
+    const a = arena.allocator();
+
+    var parsed = std.json.parseFromSlice(
+        std.json.Value,
+        a,
+        json_text,
+        .{ .ignore_unknown_fields = true },
+    ) catch return ParseError.InvalidReceipt;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |o| o,
+        else => return ParseError.InvalidReceipt,
+    };
+
+    const source_obj: ?std.json.ObjectMap = blk: {
+        const v = root.get("source") orelse break :blk null;
+        switch (v) {
+            .object => |o| break :blk o,
+            else => break :blk null,
+        }
+    };
+
+    const tap = blk: {
+        const src = source_obj orelse break :blk "";
+        const v = src.get("tap") orelse break :blk "";
+        switch (v) {
+            .string => |s| break :blk a.dupe(u8, s) catch return ParseError.OutOfMemory,
+            .null => break :blk "",
+            else => break :blk "",
+        }
+    };
+
+    const version = blk: {
+        const src = source_obj orelse break :blk "";
+        const versions_v = src.get("versions") orelse break :blk "";
+        const versions = switch (versions_v) {
+            .object => |o| o,
+            else => break :blk "",
+        };
+        const stable_v = versions.get("stable") orelse break :blk "";
+        switch (stable_v) {
+            .string => |s| break :blk a.dupe(u8, s) catch return ParseError.OutOfMemory,
+            .null => break :blk "",
+            else => break :blk "",
+        }
+    };
+
+    const deps = blk: {
+        const v = root.get("runtime_dependencies") orelse break :blk &[_][]const u8{};
+        const arr = switch (v) {
+            .array => |arr| arr,
+            else => break :blk &[_][]const u8{},
+        };
+        var list: std.ArrayList([]const u8) = .empty;
+        for (arr.items) |item| {
+            const obj = switch (item) {
+                .object => |o| o,
+                else => continue,
+            };
+            const name_v = obj.get("full_name") orelse continue;
+            const name = switch (name_v) {
+                .string => |s| s,
+                else => continue,
+            };
+            const owned = a.dupe(u8, name) catch return ParseError.OutOfMemory;
+            list.append(a, owned) catch return ParseError.OutOfMemory;
+        }
+        break :blk list.toOwnedSlice(a) catch return ParseError.OutOfMemory;
+    };
+
+    return .{
+        .tap = tap,
+        .version = version,
+        .runtime_deps = deps,
+        .arena = arena,
+    };
+}
+
+/// True for `homebrew/core` (the stock tap) or an empty/missing tap.
+/// Anything else is a private/third-party tap.
+pub fn isCoreTap(tap: []const u8) bool {
+    return tap.len == 0 or std.mem.eql(u8, tap, "homebrew/core");
+}
+
+test "isCoreTap recognises the stock tap and absent values" {
+    try std.testing.expect(isCoreTap("homebrew/core"));
+    try std.testing.expect(isCoreTap(""));
+}
+
+test "isCoreTap rejects private taps" {
+    try std.testing.expect(!isCoreTap("charmbracelet/tap"));
+    try std.testing.expect(!isCoreTap("user/private"));
+    try std.testing.expect(!isCoreTap("homebrew/cask"));
+}
+
+test "parseInstallReceipt extracts tap, stable version, and runtime_dependencies" {
+    const src =
+        \\{
+        \\  "source": {
+        \\    "tap": "charmbracelet/tap",
+        \\    "spec": "stable",
+        \\    "versions": {
+        \\      "stable": "0.2.2",
+        \\      "head": null
+        \\    }
+        \\  },
+        \\  "runtime_dependencies": [
+        \\    {"full_name": "oniguruma", "version": "6.9.10"},
+        \\    {"full_name": "zlib", "version": "1.3"}
+        \\  ]
+        \\}
+    ;
+    var r = try parseInstallReceipt(std.testing.allocator, src);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("charmbracelet/tap", r.tap);
+    try std.testing.expectEqualStrings("0.2.2", r.version);
+    try std.testing.expectEqual(@as(usize, 2), r.runtime_deps.len);
+    try std.testing.expectEqualStrings("oniguruma", r.runtime_deps[0]);
+    try std.testing.expectEqualStrings("zlib", r.runtime_deps[1]);
+}
+
+test "parseInstallReceipt tolerates missing optional fields" {
+    const src = "{\"source\": {}}";
+    var r = try parseInstallReceipt(std.testing.allocator, src);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("", r.tap);
+    try std.testing.expectEqualStrings("", r.version);
+    try std.testing.expectEqual(@as(usize, 0), r.runtime_deps.len);
+}
+
+test "parseInstallReceipt tolerates a missing source object" {
+    const src = "{}";
+    var r = try parseInstallReceipt(std.testing.allocator, src);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("", r.tap);
+    try std.testing.expectEqualStrings("", r.version);
+}
+
+test "parseInstallReceipt skips runtime_dependencies entries lacking full_name" {
+    const src =
+        \\{
+        \\  "source": {"tap": "x/y", "versions": {"stable": "1.0"}},
+        \\  "runtime_dependencies": [
+        \\    {"full_name": "good"},
+        \\    {"version": "1.0"},
+        \\    "raw-string-not-an-object",
+        \\    {"full_name": "also-good"}
+        \\  ]
+        \\}
+    ;
+    var r = try parseInstallReceipt(std.testing.allocator, src);
+    defer r.deinit();
+    try std.testing.expectEqual(@as(usize, 2), r.runtime_deps.len);
+    try std.testing.expectEqualStrings("good", r.runtime_deps[0]);
+    try std.testing.expectEqualStrings("also-good", r.runtime_deps[1]);
+}
+
+test "parseInstallReceipt rejects invalid JSON with InvalidReceipt" {
+    try std.testing.expectError(ParseError.InvalidReceipt, parseInstallReceipt(std.testing.allocator, "not json"));
+    try std.testing.expectError(ParseError.InvalidReceipt, parseInstallReceipt(std.testing.allocator, "[1,2,3]"));
+    try std.testing.expectError(ParseError.InvalidReceipt, parseInstallReceipt(std.testing.allocator, ""));
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -7,6 +7,7 @@ pub const hash = @import("core/hash.zig");
 pub const cellar = @import("core/cellar.zig");
 pub const deps = @import("core/deps.zig");
 pub const formula = @import("core/formula.zig");
+pub const install_receipt = @import("core/install_receipt.zig");
 pub const linker = @import("core/linker.zig");
 pub const store = @import("core/store.zig");
 pub const relocated_store = @import("core/relocated_store.zig");


### PR DESCRIPTION
## Description

Private / third-party-tap kegs (e.g. \`charmbracelet/tap/freeze\`) don't exist in formulae.brew.sh, so \`mt migrate\` previously dropped them in \`failed\` with \`x   <name>: not found in Homebrew API\`. The bytes are already on the user's disk under the source brew install — vetted by the user when they originally \`brew install\`'d — so an end-to-end migration that fails purely because the brew API has no record is unnecessary friction.

This PR adds a copy-from-Cellar fallback that engages only on \`ApiError.NotFound\`. Network / response-shape errors stay loud.

### What changed

- New \`core/install_receipt.zig\` parses \`INSTALL_RECEIPT.json\` for the small subset the fallback needs (\`source.tap\`, \`source.versions.stable\`, \`runtime_dependencies[*].full_name\`) and tolerates absent / null fields so older brew receipts still parse. Inline tests cover the private/core tap cases, missing-field tolerance, malformed-JSON rejection, and runtime-dep entries lacking \`full_name\`.
- \`cellar.zig\`: extracts the relocation pipeline (Mach-O load-command patching + text-file placeholder substitution + ad-hoc codesign) into \`relocateKegTree\` so both the bottle path (\`materializeWithCellar\`) and the new local-Cellar path share one implementation. Adds \`materializeFromLocalCellar\` which clonefile-copies the keg tree, runs the shared relocation pipeline, and writes a tap-aware \`INSTALL_RECEIPT.json\`.
- \`cli/migrate/keg.zig\`: routes \`fetchFormula\` failures through a switch — \`error.NotFound\` triggers the fallback, every other error variant fails loudly with the specific \`@errorName\`. New \`migrateFromLocalCellar\` finds the version subdir with the newest \`INSTALL_RECEIPT.json\` mtime, reads the receipt, refuses the fallback for \`homebrew/core\` kegs (treating an API miss there as a real upstream outage rather than papering over it), and otherwise routes through \`materializeFromLocalCellar\` + record + link. The DB write surface collapses into a flat \`KegFields\` struct so the formula path and receipt path exercise byte-identical SQL. \`MigrateDeps\` and \`Pool\` gain a \`homebrew_prefix\` field threaded from \`migrate.execute\`.

## Related issue 

- None

## Notes for Reviewers

End-to-end smoke on the local 164-keg brew (full \`scripts/smoke_migrate_parallel.sh\`):

| Metric      | Pre-fix          | Post-fix       |
| ----------- | ---------------- | -------------- |
| Migrated    | 162 / 164        | **164 / 164**  |
| Failed      | 2 (private taps) | **0**          |
| Usable      | 122              | **124**        |
| Wall-clock  | 443.6 s          | 441.0 s        |

\`freeze\` and now route through the new fallback (\`Migrating freeze 0.2.2 (from charmbracelet/tap tap)...\` → \`freeze 0.2.2 migrated (from charmbracelet/tap tap)\`). Wall-clock is unchanged because the clonefile copy is cheap relative to the GHCR download the bottle path runs.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)