### PR TITLE
fix(migrate): defer post_install hooks until every keg is linked

### DIFF
--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -21,6 +21,7 @@ const help = @import("help.zig");
 const keg_mod = @import("migrate/keg.zig");
 const manifest_mod = @import("migrate/manifest.zig");
 const parallel_mod = @import("migrate/parallel.zig");
+const post_install_queue_mod = @import("migrate/post_install_queue.zig");
 
 const KegResult = keg_mod.KegResult;
 const MigrateDeps = keg_mod.MigrateDeps;
@@ -276,6 +277,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         return;
     }
 
+    // Defer every keg's post_install until all kegs are materialised
+    // and `linkOpt`'d, so a hook subprocess (e.g. fc-cache) can
+    // resolve dep dylibs through `opt/<dep>` without racing the
+    // worker that links them.
+    var post_install_queue = post_install_queue_mod.Queue.init(allocator);
+    defer post_install_queue.deinit();
+
     if (parallel_flag) {
         last_run_parallel = true;
 
@@ -318,6 +326,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             .manifest_mu = &manifest_mu,
             .manifest_path = manifest_path,
             .manifest_allocator = allocator,
+            .post_install_queue = &post_install_queue,
         };
         try parallel_mod.run(allocator, &pool, worker_count);
         // Mirror the serial loop's interrupt UX so users running with
@@ -360,6 +369,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             .prefix = prefix,
             .homebrew_prefix = brew_prefix,
             .use_system_ruby_scope = use_system_ruby_scope.items,
+            .post_install_queue = &post_install_queue,
         });
 
         // OOM on per-category bookkeeping must not be swallowed: the summary
@@ -400,6 +410,11 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             output.warn("Resume manifest self-heal write failed: {s}", .{@errorName(e)});
         };
     }
+
+    // Run post_install in enqueue order now that every dep is on disk
+    // and linked under `opt/`, so dyld in any spawned subprocess sees a
+    // complete tree.
+    post_install_queue.drain(ctx, prefix, use_system_ruby_scope.items);
 
     // ── Step 5: Report ──────────────────────────────────────────────
     if (json_mode) {

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -17,6 +17,7 @@ const api_mod = @import("../../net/api.zig");
 const atomic = @import("../../fs/atomic.zig");
 const output = @import("../../ui/output.zig");
 const post_install_mod = @import("../install/post_install.zig");
+const post_install_queue_mod = @import("post_install_queue.zig");
 const install_receipt_mod = @import("../../core/install_receipt.zig");
 
 /// Result of migrating a single keg.
@@ -49,6 +50,10 @@ pub const MigrateDeps = struct {
     /// Set by the parallel runner; null on the serial path so the
     /// default flow pays no lock cost.
     db_mu: ?*std.Io.Mutex = null,
+    /// Defer post_install hooks here so they all run after every keg
+    /// is materialised and linked under `opt/`; null falls back to
+    /// inline drive (legacy / single-keg paths).
+    post_install_queue: ?*post_install_queue_mod.Queue = null,
 };
 
 /// Migrate a single keg from Homebrew into malt.
@@ -162,15 +167,32 @@ pub fn migrateKeg(
     }
 
     if (formula.post_install_defined) {
-        post_install_mod.drive(
-            ctx,
-            allocator,
-            formula.name,
-            formula.pkg_version,
-            formula_json,
-            deps.prefix,
-            deps.use_system_ruby_scope,
-        );
+        if (deps.post_install_queue) |q| {
+            // Queue dupes the strings so the worker's per-iteration
+            // arena is free to die before drain runs.
+            q.add(ctx.io, formula.name, formula.pkg_version, formula_json) catch |e| {
+                output.warn("    {s}: failed to queue post_install ({s}); running inline", .{ formula.name, @errorName(e) });
+                post_install_mod.drive(
+                    ctx,
+                    allocator,
+                    formula.name,
+                    formula.pkg_version,
+                    formula_json,
+                    deps.prefix,
+                    deps.use_system_ruby_scope,
+                );
+            };
+        } else {
+            post_install_mod.drive(
+                ctx,
+                allocator,
+                formula.name,
+                formula.pkg_version,
+                formula_json,
+                deps.prefix,
+                deps.use_system_ruby_scope,
+            );
+        }
     }
 
     const keg_only_suffix: []const u8 = if (formula.keg_only) " (keg-only — dependency only)" else "";

--- a/src/cli/migrate/parallel.zig
+++ b/src/cli/migrate/parallel.zig
@@ -14,6 +14,7 @@ const output = @import("../../ui/output.zig");
 const main_mod = @import("../../main.zig");
 const keg_mod = @import("keg.zig");
 const manifest_mod = @import("manifest.zig");
+const post_install_queue_mod = @import("post_install_queue.zig");
 
 /// 4 matches the install-side HTTP client pool; higher just queues on TLS contexts.
 pub const default_workers: u32 = 4;
@@ -74,6 +75,8 @@ pub const Pool = struct {
     manifest_mu: *std.Io.Mutex,
     manifest_path: []const u8,
     manifest_allocator: std.mem.Allocator,
+
+    post_install_queue: *post_install_queue_mod.Queue,
 };
 
 /// Per-iteration arena + borrowed http client matches the per-worker
@@ -122,6 +125,7 @@ fn worker(pool: *Pool) void {
             .homebrew_prefix = pool.homebrew_prefix,
             .use_system_ruby_scope = pool.use_system_ruby_scope,
             .db_mu = pool.db_mu,
+            .post_install_queue = pool.post_install_queue,
         });
         pool.outcomes[idx] = .{ .name = keg_name, .result = result };
 

--- a/src/cli/migrate/post_install_queue.zig
+++ b/src/cli/migrate/post_install_queue.zig
@@ -1,0 +1,164 @@
+//! malt — deferred post_install queue for `mt migrate`.
+//!
+//! Per-keg `post_install` hooks must not fire until *all* kegs in the
+//! migration have been materialised AND linked into the prefix's
+//! `opt/<name>/` runtime tree. fc-cache (fontconfig) loads
+//! `opt/gettext/lib/libintl.8.dylib`; under `--parallel`, fontconfig's
+//! own keg can finish before gettext's worker links its `opt/gettext/`
+//! symlink, which produces a dyld load failure that fc-cache silently
+//! swallows (exit 0) — leaving the user with a `post_install completed`
+//! line but no regenerated cache.
+//!
+//! The queue collects post_install requests during migration and the
+//! orchestrator drains it after every keg's migration (and `linkOpt`)
+//! has completed. Drain order is enqueue order; since all `opt/`
+//! symlinks are in place by drain time, dependency-order doesn't
+//! matter for correctness.
+
+const std = @import("std");
+const post_install_mod = @import("../install/post_install.zig");
+const AppCtx = @import("../../app_ctx.zig").AppCtx;
+
+pub const Task = struct {
+    name: []u8,
+    pkg_version: []u8,
+    formula_json: []u8,
+};
+
+/// Thread-safe queue: parallel workers `add`, the main thread `drain`s
+/// once all workers have joined. Strings are owned by the queue's
+/// allocator so they outlive per-worker arenas.
+pub const Queue = struct {
+    tasks: std.ArrayList(Task) = .empty,
+    mu: std.Io.Mutex = .init,
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator) Queue {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *Queue) void {
+        for (self.tasks.items) |t| {
+            self.allocator.free(t.name);
+            self.allocator.free(t.pkg_version);
+            self.allocator.free(t.formula_json);
+        }
+        self.tasks.deinit(self.allocator);
+    }
+
+    /// Enqueue a post_install request. Dupes inputs into the queue's
+    /// allocator so the caller's arena is free to die. Thread-safe.
+    pub fn add(
+        self: *Queue,
+        io: std.Io,
+        name: []const u8,
+        pkg_version: []const u8,
+        formula_json: []const u8,
+    ) !void {
+        self.mu.lockUncancelable(io);
+        defer self.mu.unlock(io);
+
+        const owned_name = try self.allocator.dupe(u8, name);
+        errdefer self.allocator.free(owned_name);
+        const owned_ver = try self.allocator.dupe(u8, pkg_version);
+        errdefer self.allocator.free(owned_ver);
+        const owned_json = try self.allocator.dupe(u8, formula_json);
+        errdefer self.allocator.free(owned_json);
+
+        try self.tasks.append(self.allocator, .{
+            .name = owned_name,
+            .pkg_version = owned_ver,
+            .formula_json = owned_json,
+        });
+    }
+
+    /// Run every queued post_install through the install module's
+    /// `drive`. Single-threaded; called once after migration finishes.
+    pub fn drain(
+        self: *Queue,
+        ctx: *const AppCtx,
+        prefix: []const u8,
+        use_system_ruby_scope: []const []const u8,
+    ) void {
+        for (self.tasks.items) |t| {
+            post_install_mod.drive(
+                ctx,
+                self.allocator,
+                t.name,
+                t.pkg_version,
+                t.formula_json,
+                prefix,
+                use_system_ruby_scope,
+            );
+        }
+    }
+
+    /// Snapshot of queued task count — `pub` so tests can pin enqueue
+    /// behaviour without reaching into private fields.
+    pub fn len(self: *Queue) usize {
+        return self.tasks.items.len;
+    }
+};
+
+test "Queue.add dupes inputs and survives caller-arena destruction" {
+    const a = std.testing.allocator;
+    var q = Queue.init(a);
+    defer q.deinit();
+
+    {
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const aa = arena.allocator();
+        const name = try aa.dupe(u8, "fontconfig");
+        const ver = try aa.dupe(u8, "2.17.1");
+        const json = try aa.dupe(u8, "{\"name\":\"fontconfig\"}");
+        try q.add(std.Options.debug_io, name, ver, json);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), q.len());
+    try std.testing.expectEqualStrings("fontconfig", q.tasks.items[0].name);
+    try std.testing.expectEqualStrings("2.17.1", q.tasks.items[0].pkg_version);
+    try std.testing.expectEqualStrings("{\"name\":\"fontconfig\"}", q.tasks.items[0].formula_json);
+}
+
+test "Queue.add preserves enqueue order across multiple tasks" {
+    const a = std.testing.allocator;
+    var q = Queue.init(a);
+    defer q.deinit();
+
+    try q.add(std.Options.debug_io, "first", "1.0", "{}");
+    try q.add(std.Options.debug_io, "second", "2.0", "{}");
+    try q.add(std.Options.debug_io, "third", "3.0", "{}");
+
+    try std.testing.expectEqual(@as(usize, 3), q.len());
+    try std.testing.expectEqualStrings("first", q.tasks.items[0].name);
+    try std.testing.expectEqualStrings("second", q.tasks.items[1].name);
+    try std.testing.expectEqualStrings("third", q.tasks.items[2].name);
+}
+
+test "Queue.add serialises concurrent producers without losing tasks" {
+    const a = std.testing.allocator;
+    var q = Queue.init(a);
+    defer q.deinit();
+
+    const Worker = struct {
+        const tasks_per_thread: usize = 32;
+        fn run(queue: *Queue, thread_id: usize) void {
+            var buf: [64]u8 = undefined;
+            var i: usize = 0;
+            while (i < tasks_per_thread) : (i += 1) {
+                const name = std.fmt.bufPrint(&buf, "t{d}-{d}", .{ thread_id, i }) catch return;
+                queue.add(std.Options.debug_io, name, "0", "{}") catch return;
+            }
+        }
+    };
+
+    const thread_count: usize = 4;
+    var threads: [4]std.Thread = undefined;
+    for (&threads, 0..) |*th, idx| {
+        th.* = try std.Thread.spawn(.{}, Worker.run, .{ &q, idx });
+    }
+    for (&threads) |th| th.join();
+
+    try std.testing.expectEqual(thread_count * Worker.tasks_per_thread, q.len());
+}

--- a/src/core/dsl/builtins/process.zig
+++ b/src/core/dsl/builtins/process.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 const values = @import("../values.zig");
 const pathname = @import("pathname.zig");
+const output = @import("../../../ui/output.zig");
 
 const Value = values.Value;
 const BuiltinError = pathname.BuiltinError;
@@ -23,7 +24,15 @@ pub fn system(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
 
     if (argv_slice.len == 0) return Value{ .nil = {} };
 
-    var child = std.process.spawn(ctx.io, .{ .argv = argv_slice }) catch return BuiltinError.SystemCommandFailed;
+    // Subprocess stdout shares the FD with malt's `--json` / `--ndjson`
+    // document, so verbose tools like fc-cache would corrupt it. Stderr
+    // stays inherited so warnings still surface for the user.
+    const child_stdout: std.process.SpawnOptions.StdIo =
+        if (output.isJson() or output.isNdjson()) .ignore else .inherit;
+    var child = std.process.spawn(ctx.io, .{
+        .argv = argv_slice,
+        .stdout = child_stdout,
+    }) catch return BuiltinError.SystemCommandFailed;
     const term = child.wait(ctx.io) catch return BuiltinError.SystemCommandFailed;
 
     return switch (term) {


### PR DESCRIPTION
## Description

- Per-keg `post_install` is now queued during migration and drained after every keg is materialised and linked under `opt/`.
- Removes a parallel-mode race where a hook subprocess (e.g. `fc-cache`) would dyld-fail because a dep's worker hadn't dropped its `opt/<dep>` symlink yet - fontconfig silently exit-0'd in that state, leaving the font cache stale.
- Fixes an adjacent stdout-pollution bug in the DSL `system` builtin: verbose subprocess output was corrupting `--json` / `--ndjson` documents. Stderr stays inherited so warnings still surface.

## Related issue

- None

## Notes for Reviewers

- None