### PR TITLE
refactor(migrate): match install's progress bar TUI in serial and parallel

### DIFF
--- a/src/cli/doctor/post_install.zig
+++ b/src/cli/doctor/post_install.zig
@@ -98,7 +98,7 @@ pub fn checkPostInstallStatus(ctx: *const AppCtx, allocator: std.mem.Allocator, 
         }
     }
 
-    output.info("", .{});
+    output.plain("", .{});
     output.info("Installed: {d} total, {d} without post_install, {d} with post_install", .{ total, no_pi_count, native_count + partial_count });
     if (native_count + partial_count > 0) {
         output.info("DSL parseable: {d}/{d} ({d}%)", .{ native_count, native_count + partial_count, if (native_count + partial_count > 0) 100 * native_count / (native_count + partial_count) else 0 });

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -55,7 +55,7 @@ pub const DownloadJob = struct {
     /// Alignment width for progress bar labels (max name length across all jobs).
     label_width: u8,
     /// Line index within the multi-progress group.
-    line_index: u8,
+    line_index: u16,
     /// Shared multi-progress state for coordinated rendering.
     multi: ?*progress_mod.MultiProgress,
     /// Progress bar owned by the main thread. Created before workers are spawned

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -15,7 +15,9 @@ const client_mod = @import("../net/client.zig");
 const ghcr_mod = @import("../net/ghcr.zig");
 const api_mod = @import("../net/api.zig");
 const atomic = @import("../fs/atomic.zig");
+const color = @import("../ui/color.zig");
 const output = @import("../ui/output.zig");
+const progress_mod = @import("../ui/progress.zig");
 const codesign = @import("../macho/codesign.zig");
 const help = @import("help.zig");
 const keg_mod = @import("migrate/keg.zig");
@@ -308,6 +310,47 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         // Pre-populated so an interrupted/short-circuited slot still has a defined outcome.
         for (outcomes, 0..) |*o, i| o.* = .{ .name = keg_names.items[i], .result = .skipped_installed };
 
+        // Pre-filter manifest+DB-confirmed skips so the multi-progress
+        // line count matches actual work — drawing a "✓" for kegs that
+        // never ran would be misleading. The serial path already does
+        // this inline; for parallel we hoist it ahead of bar allocation.
+        const bar_for_keg = try allocator.alloc(?*progress_mod.ProgressBar, keg_names.items.len);
+        defer allocator.free(bar_for_keg);
+        @memset(bar_for_keg, null);
+
+        var work_indices: std.ArrayList(usize) = .empty;
+        defer work_indices.deinit(allocator);
+        try work_indices.ensureTotalCapacity(allocator, keg_names.items.len);
+        var max_name_len: u8 = 0;
+        for (keg_names.items, 0..) |name, i| {
+            if (manifest.contains(name) and keg_mod.isInstalled(&db, name)) {
+                outcomes[i] = .{ .name = name, .result = .skipped_installed };
+                continue;
+            }
+            work_indices.appendAssumeCapacity(i);
+            const len: u8 = @intCast(@min(name.len, 255));
+            if (len > max_name_len) max_name_len = len;
+        }
+
+        const work_count: u16 = @intCast(@min(work_indices.items.len, std.math.maxInt(u16)));
+        var multi = progress_mod.MultiProgress.init(work_count);
+        defer multi.finish();
+
+        const bars = try allocator.alloc(progress_mod.ProgressBar, work_count);
+        defer allocator.free(bars);
+
+        for (work_indices.items[0..work_count], 0..) |keg_idx, slot| {
+            const slot_u16: u16 = @intCast(slot);
+            bars[slot] = progress_mod.ProgressBar.init(keg_names.items[keg_idx], 0);
+            bars[slot].label_width = max_name_len;
+            bars[slot].line_index = slot_u16;
+            bars[slot].multi = &multi;
+            // Initial frame so each reserved row has visible content
+            // before its worker is scheduled.
+            bars[slot].update(0);
+            bar_for_keg[keg_idx] = &bars[slot];
+        }
+
         var pool: parallel_mod.Pool = .{
             .app_ctx = ctx,
             .next_idx = std.atomic.Value(usize).init(0),
@@ -327,6 +370,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             .manifest_path = manifest_path,
             .manifest_allocator = allocator,
             .post_install_queue = &post_install_queue,
+            .bar_for_keg = bar_for_keg,
         };
         try parallel_mod.run(allocator, &pool, worker_count);
         // Mirror the serial loop's interrupt UX so users running with
@@ -344,53 +388,73 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
                 .failed_api, .failed_download, .failed_install => try failed_names.append(allocator, o.name),
             }
         }
-    } else for (keg_names.items) |keg_name| {
-        // Stop at the next keg boundary when the user hits Ctrl-C.
-        if (main_mod.isInterrupted()) {
-            output.warn("Interrupted — skipping remaining kegs.", .{});
-            break;
+    } else {
+        // Width of the widest keg name so per-keg bars line up vertically
+        // with each other (and with `install`'s download phase).
+        var max_name_len: u8 = 0;
+        for (keg_names.items) |n| {
+            const len: u8 = @intCast(@min(n.len, 255));
+            if (len > max_name_len) max_name_len = len;
         }
-        // Resume short-circuit before any API/network work — bounds
-        // re-runs by the remaining kegs, not the full set. The DB
-        // cross-check guards against a stale manifest after `mt
-        // uninstall`: manifest=yes / DB=no falls through to a real
-        // re-migrate instead of silently skipping a missing keg.
-        if (manifest.contains(keg_name) and keg_mod.isInstalled(&db, keg_name)) {
-            try skipped_installed_names.append(allocator, keg_name);
-            continue;
-        }
-        const result = migrateKeg(ctx, allocator, keg_name, .{
-            .api = &api,
-            .ghcr = &ghcr,
-            .http = &http,
-            .store = &store,
-            .linker = &linker,
-            .db = &db,
-            .prefix = prefix,
-            .homebrew_prefix = brew_prefix,
-            .use_system_ruby_scope = use_system_ruby_scope.items,
-            .post_install_queue = &post_install_queue,
-        });
 
-        // OOM on per-category bookkeeping must not be swallowed: the summary
-        // counts and JSON arrays come from these lists, and a silent drop
-        // reports fewer failures than actually occurred.
-        switch (result) {
-            .migrated => {
-                try migrated_names.append(allocator, keg_name);
-                // Persist after each success so a crash leaves the next
-                // run with the smallest possible to-do list.
-                manifest.add(keg_name) catch |e| {
-                    output.warn("Resume manifest update failed for {s}: {s}", .{ keg_name, @errorName(e) });
-                };
-                manifest.writeAtomic(ctx.io, allocator, manifest_path) catch |e| {
-                    output.warn("Resume manifest write failed: {s}", .{@errorName(e)});
-                };
-            },
-            .skipped_installed => try skipped_installed_names.append(allocator, keg_name),
-            .skipped_post_install => try skipped_post_install_names.append(allocator, keg_name),
-            .skipped_no_bottle => try skipped_no_bottle_names.append(allocator, keg_name),
-            .failed_api, .failed_download, .failed_install => try failed_names.append(allocator, keg_name),
+        for (keg_names.items) |keg_name| {
+            // Stop at the next keg boundary when the user hits Ctrl-C.
+            if (main_mod.isInterrupted()) {
+                output.warn("Interrupted — skipping remaining kegs.", .{});
+                break;
+            }
+            // Resume short-circuit before any API/network work — bounds
+            // re-runs by the remaining kegs, not the full set. The DB
+            // cross-check guards against a stale manifest after `mt
+            // uninstall`: manifest=yes / DB=no falls through to a real
+            // re-migrate instead of silently skipping a missing keg.
+            if (manifest.contains(keg_name) and keg_mod.isInstalled(&db, keg_name)) {
+                try skipped_installed_names.append(allocator, keg_name);
+                continue;
+            }
+
+            // Standalone bar (no MultiProgress) — same shape as install.zig's
+            // cask path. Initial frame so the row isn't blank before the
+            // first progress callback fires.
+            var bar = progress_mod.ProgressBar.init(keg_name, 0);
+            bar.label_width = max_name_len;
+            bar.update(0);
+
+            const result = migrateKeg(ctx, allocator, keg_name, .{
+                .api = &api,
+                .ghcr = &ghcr,
+                .http = &http,
+                .store = &store,
+                .linker = &linker,
+                .db = &db,
+                .prefix = prefix,
+                .homebrew_prefix = brew_prefix,
+                .use_system_ruby_scope = use_system_ruby_scope.items,
+                .post_install_queue = &post_install_queue,
+                .bar = &bar,
+            });
+            bar.finish();
+
+            // OOM on per-category bookkeeping must not be swallowed: the summary
+            // counts and JSON arrays come from these lists, and a silent drop
+            // reports fewer failures than actually occurred.
+            switch (result) {
+                .migrated => {
+                    try migrated_names.append(allocator, keg_name);
+                    // Persist after each success so a crash leaves the next
+                    // run with the smallest possible to-do list.
+                    manifest.add(keg_name) catch |e| {
+                        output.warn("Resume manifest update failed for {s}: {s}", .{ keg_name, @errorName(e) });
+                    };
+                    manifest.writeAtomic(ctx.io, allocator, manifest_path) catch |e| {
+                        output.warn("Resume manifest write failed: {s}", .{@errorName(e)});
+                    };
+                },
+                .skipped_installed => try skipped_installed_names.append(allocator, keg_name),
+                .skipped_post_install => try skipped_post_install_names.append(allocator, keg_name),
+                .skipped_no_bottle => try skipped_no_bottle_names.append(allocator, keg_name),
+                .failed_api, .failed_download, .failed_install => try failed_names.append(allocator, keg_name),
+            }
         }
     }
 
@@ -437,27 +501,66 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     const skipped_post_install: u32 = @intCast(skipped_post_install_names.items.len);
     const failed: u32 = @intCast(failed_names.items.len);
 
-    output.info("", .{});
-    output.info("Migration complete:", .{});
-    output.info("  Migrated:              {d}", .{migrated});
+    output.plain("", .{});
+    if (failed == 0) {
+        output.success("Migration completed.", .{});
+    } else {
+        output.info("Migration completed.", .{});
+    }
+    output.info("Migrated: {d}", .{migrated});
     if (skipped > 0)
-        output.info("  Skipped (installed):   {d}", .{skipped});
+        output.info("Skipped (installed): {d}", .{skipped});
     if (skipped_post_install > 0) {
-        output.warn("  Skipped (post_install): {d}", .{skipped_post_install});
+        output.warn("Skipped (post_install): {d}", .{skipped_post_install});
         for (skipped_post_install_names.items) |name| {
-            output.warn("    - {s} (needs post_install — use: brew install {s})", .{ name, name });
+            output.warn("  - {s} (needs post_install — use: brew install {s})", .{ name, name });
         }
         // Preserved legacy: no-bottle entries printed under the post_install warning.
         for (skipped_no_bottle_names.items) |name| {
-            output.warn("    - {s} (needs post_install — use: brew install {s})", .{ name, name });
+            output.warn("  - {s} (needs post_install — use: brew install {s})", .{ name, name });
         }
     }
     if (failed > 0) {
-        output.err("  Failed:                {d}", .{failed});
+        output.err("Failed: {d}", .{failed});
         for (failed_names.items) |name| {
-            output.err("    - {s}", .{name});
+            output.err("  - {s}", .{name});
         }
     }
+
+    if (migrated > 0 and !output.isQuiet()) {
+        try emitBrewUninstallHint(allocator, migrated_names.items);
+    }
+}
+
+/// Emit a follow-up hint listing every successfully migrated keg as a
+/// single `brew uninstall …` line. Both lines use the same `  ▸ `
+/// prefix + dim color as the version notifier so the trailing block
+/// reads as one consistent footer. The body is built manually because
+/// the joined name list can exceed `output.dim`'s 4 KiB internal
+/// buffer on installs with hundreds of kegs.
+fn emitBrewUninstallHint(
+    allocator: std.mem.Allocator,
+    migrated_names: []const []const u8,
+) !void {
+    output.plain("", .{});
+    output.dim("You can remove the migrated packages from Homebrew with:", .{});
+
+    var line: std.ArrayList(u8) = .empty;
+    defer line.deinit(allocator);
+
+    const use_color = color.isColorEnabled();
+    const prefix: []const u8 = if (color.isEmojiEnabled()) "  ▸ " else "  > ";
+    if (use_color) try line.appendSlice(allocator, color.SemanticStyle.detail.code());
+    try line.appendSlice(allocator, prefix);
+    try line.appendSlice(allocator, "brew uninstall");
+    for (migrated_names) |name| {
+        try line.append(allocator, ' ');
+        try line.appendSlice(allocator, name);
+    }
+    if (use_color) try line.appendSlice(allocator, color.Style.reset.code());
+    try line.append(allocator, '\n');
+
+    output.writeStderrAll(line.items);
 }
 
 // ── JSON output ─────────────────────────────────────────────────────

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -16,6 +16,7 @@ const ghcr_mod = @import("../../net/ghcr.zig");
 const api_mod = @import("../../net/api.zig");
 const atomic = @import("../../fs/atomic.zig");
 const output = @import("../../ui/output.zig");
+const progress_mod = @import("../../ui/progress.zig");
 const post_install_mod = @import("../install/post_install.zig");
 const post_install_queue_mod = @import("post_install_queue.zig");
 const install_receipt_mod = @import("../../core/install_receipt.zig");
@@ -54,7 +55,26 @@ pub const MigrateDeps = struct {
     /// is materialised and linked under `opt/`; null falls back to
     /// inline drive (legacy / single-keg paths).
     post_install_queue: ?*post_install_queue_mod.Queue = null,
+    /// When non-null, download progress streams into this bar (matching
+    /// the install-side TUI) and the per-keg "Migrating…"/"migrated"
+    /// info/success lines are suppressed so the bar isn't mangled by
+    /// interleaved stderr writes. Caller owns lifetime + finish().
+    bar: ?*progress_mod.ProgressBar = null,
 };
+
+/// `progressBridge`-compatible callback for `bottle_mod.download`. Same
+/// shape as the install-side bridge in `cli/install/download.zig`: first
+/// report seeds `total` from Content-Length, subsequent reports clamp
+/// `current` so a compressed-vs-uncompressed length drift doesn't push
+/// the bar past 100%.
+fn migrateBarBridge(ctx: *anyopaque, bytes_so_far: u64, content_length: ?u64) void {
+    const bar: *progress_mod.ProgressBar = @ptrCast(@alignCast(ctx));
+    if (content_length) |total| {
+        if (bar.total == 0) bar.total = total;
+    }
+    const clamped = if (bar.total > 0) @min(bytes_so_far, bar.total) else bytes_so_far;
+    bar.update(clamped);
+}
 
 /// Migrate a single keg from Homebrew into malt.
 pub fn migrateKeg(
@@ -63,8 +83,14 @@ pub fn migrateKeg(
     keg_name: []const u8,
     deps: MigrateDeps,
 ) KegResult {
+    // Suppress per-keg info/success only when the bar is *actually*
+    // drawing (TTY) — otherwise CI / piped-output users would lose
+    // every per-keg signal between the initial scan and the final
+    // summary. `is_tty` is captured at bar init via `supportsAnsi`.
+    const has_bar = if (deps.bar) |b| b.is_tty else false;
+
     if (isInstalled(deps.db, keg_name)) {
-        output.info("  {s}: already installed, skipping", .{keg_name});
+        if (!has_bar) output.info("  {s}: already installed, skipping", .{keg_name});
         return .skipped_installed;
     }
 
@@ -96,13 +122,13 @@ pub fn migrateKeg(
     };
     output.emitNdjsonEvent(allocator, .resolved, keg_name, null);
 
-    output.info("  Migrating {s} {s}...", .{ formula.name, formula.version });
+    if (!has_bar) output.info("  Migrating {s} {s}...", .{ formula.name, formula.version });
 
     if (!deps.store.exists(bottle.sha256)) {
-        if (!downloadBottle(ctx, allocator, deps.ghcr, deps.http, deps.store, bottle.url, bottle.sha256, keg_name)) {
+        if (!downloadBottle(ctx, allocator, deps.ghcr, deps.http, deps.store, bottle.url, bottle.sha256, keg_name, deps.bar)) {
             return .failed_download;
         }
-    } else {
+    } else if (!has_bar) {
         output.info("    {s} (cached in store)", .{keg_name});
     }
     if (output.isNdjson()) {
@@ -195,8 +221,10 @@ pub fn migrateKeg(
         }
     }
 
-    const keg_only_suffix: []const u8 = if (formula.keg_only) " (keg-only — dependency only)" else "";
-    output.success("  {s} {s} migrated{s}", .{ formula.name, formula.version, keg_only_suffix });
+    if (!has_bar) {
+        const keg_only_suffix: []const u8 = if (formula.keg_only) " (keg-only — dependency only)" else "";
+        output.success("  {s} {s} migrated{s}", .{ formula.name, formula.version, keg_only_suffix });
+    }
     return .migrated;
 }
 
@@ -216,6 +244,7 @@ fn migrateFromLocalCellar(
     keg_name: []const u8,
     deps: MigrateDeps,
 ) KegResult {
+    const has_bar = if (deps.bar) |b| b.is_tty else false;
     const src_keg_path = findInstalledKegPath(ctx.io, allocator, deps.homebrew_prefix, keg_name) catch null orelse {
         output.err("  {s}: not found in Homebrew API and no local Cellar copy available", .{keg_name});
         return .failed_api;
@@ -243,7 +272,7 @@ fn migrateFromLocalCellar(
         return .failed_api;
     }
 
-    output.info("  Migrating {s} {s} (from {s} tap)...", .{ keg_name, receipt.version, receipt.tap });
+    if (!has_bar) output.info("  Migrating {s} {s} (from {s} tap)...", .{ keg_name, receipt.version, receipt.tap });
 
     const keg = cellar_mod.materializeFromLocalCellar(
         ctx.io,
@@ -293,7 +322,7 @@ fn migrateFromLocalCellar(
     deps.linker.linkOpt(keg_name, receipt.version) catch {};
     recordDepsFromList(deps.db, keg_id, receipt.runtime_deps);
 
-    output.success("  {s} {s} migrated (from {s} tap)", .{ keg_name, receipt.version, receipt.tap });
+    if (!has_bar) output.success("  {s} {s} migrated (from {s} tap)", .{ keg_name, receipt.version, receipt.tap });
     return .migrated;
 }
 
@@ -368,6 +397,7 @@ fn downloadBottle(
     bottle_url: []const u8,
     sha256: []const u8,
     name: []const u8,
+    bar: ?*progress_mod.ProgressBar,
 ) bool {
     const ghcr_prefix_str = "https://ghcr.io/v2/";
     var repo_buf: [256]u8 = undefined;
@@ -389,9 +419,14 @@ fn downloadBottle(
 
     const tmp_dir = atomic.createTempDir(ctx.io, allocator, name) catch return false;
 
-    output.info("    Downloading {s}...", .{name});
+    if (bar == null) output.info("    Downloading {s}...", .{name});
 
-    _ = bottle_mod.download(ctx.io, allocator, ghcr, http, repo, digest, sha256, tmp_dir, null) catch {
+    const progress_cb: ?client_mod.ProgressCallback = if (bar) |b| .{
+        .context = @ptrCast(b),
+        .func = &migrateBarBridge,
+    } else null;
+
+    _ = bottle_mod.download(ctx.io, allocator, ghcr, http, repo, digest, sha256, tmp_dir, progress_cb) catch {
         output.err("    Download failed: {s}", .{name});
         atomic.cleanupTempDir(ctx.io, tmp_dir);
         allocator.free(tmp_dir);

--- a/src/cli/migrate/parallel.zig
+++ b/src/cli/migrate/parallel.zig
@@ -11,6 +11,7 @@ const client_mod = @import("../../net/client.zig");
 const ghcr_mod = @import("../../net/ghcr.zig");
 const api_mod = @import("../../net/api.zig");
 const output = @import("../../ui/output.zig");
+const progress_mod = @import("../../ui/progress.zig");
 const main_mod = @import("../../main.zig");
 const keg_mod = @import("keg.zig");
 const manifest_mod = @import("manifest.zig");
@@ -77,6 +78,13 @@ pub const Pool = struct {
     manifest_allocator: std.mem.Allocator,
 
     post_install_queue: *post_install_queue_mod.Queue,
+
+    /// Per-keg bar pointer. Length matches `keg_names`; an entry is null
+    /// when the orchestrator pre-filtered that keg (already installed
+    /// per manifest+DB at run start) and didn't reserve a multi-progress
+    /// line for it. Non-null entries point into a bars slice owned by
+    /// the orchestrator; that slice outlives every worker.
+    bar_for_keg: []const ?*progress_mod.ProgressBar = &.{},
 };
 
 /// Per-iteration arena + borrowed http client matches the per-worker
@@ -88,6 +96,11 @@ fn worker(pool: *Pool) void {
         const idx = pool.next_idx.fetchAdd(1, .acq_rel);
         if (idx >= pool.keg_names.len) return;
         const keg_name = pool.keg_names[idx];
+
+        const bar: ?*progress_mod.ProgressBar = if (idx < pool.bar_for_keg.len)
+            pool.bar_for_keg[idx]
+        else
+            null;
 
         if (main_mod.isInterrupted()) {
             pool.outcomes[idx] = .{ .name = keg_name, .result = .skipped_installed };
@@ -126,7 +139,9 @@ fn worker(pool: *Pool) void {
             .use_system_ruby_scope = pool.use_system_ruby_scope,
             .db_mu = pool.db_mu,
             .post_install_queue = pool.post_install_queue,
+            .bar = bar,
         });
+        if (bar) |b| b.finish();
         pool.outcomes[idx] = .{ .name = keg_name, .result = result };
 
         if (result == .migrated) {

--- a/src/ui/progress.zig
+++ b/src/ui/progress.zig
@@ -50,22 +50,27 @@ const spinner_chars = [_][]const u8{ "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "
 /// Reserves N lines upfront, then uses ANSI cursor movement so each
 /// bar updates its own line without interfering with others.
 pub const MultiProgress = struct {
-    total_lines: u8,
+    total_lines: u16,
     mutex: std.Io.Mutex,
     is_tty: bool,
 
-    pub fn init(count: u8) MultiProgress {
+    pub fn init(count: u16) MultiProgress {
         const tty = supportsAnsi();
 
         // Hide cursor, disable autowrap, reserve lines by printing empty placeholders.
         // Autowrap disabled so an over-width bar clips instead of wrapping —
         // wrapping would break the ESC[NA cursor-up math each bar relies on.
         if (tty and !output.isQuiet()) {
-            var buf: [multi_init_max_bytes]u8 = undefined;
-            const prefix = "\x1b[?25l\x1b[?7l"; // hide cursor + disable autowrap
-            @memcpy(buf[0..prefix.len], prefix);
-            @memset(buf[prefix.len .. prefix.len + count], '\n');
-            writeStderrAll(buf[0 .. prefix.len + count]);
+            // 11-byte prefix; newlines emitted in 256-byte chunks so a u16-max
+            // line count doesn't blow the stack frame.
+            writeStderrAll("\x1b[?25l\x1b[?7l");
+            const newline_chunk: [256]u8 = @splat('\n');
+            var remaining: u16 = count;
+            while (remaining > 0) {
+                const n = @min(remaining, newline_chunk.len);
+                writeStderrAll(newline_chunk[0..n]);
+                remaining -= n;
+            }
         }
 
         return .{
@@ -83,9 +88,6 @@ pub const MultiProgress = struct {
             writeStderrAll("\x1b[?7h\x1b[?25h\r");
         }
     }
-
-    /// "\x1b[?25l" (6) + "\x1b[?7l" (5) + up to u8-max newlines.
-    const multi_init_max_bytes: usize = 6 + 5 + std.math.maxInt(u8);
 };
 
 pub const ProgressBar = struct {
@@ -99,7 +101,7 @@ pub const ProgressBar = struct {
     /// Minimum label column width for alignment across multiple bars.
     label_width: u8,
     /// Line index within a MultiProgress group (0 = topmost bar).
-    line_index: u8,
+    line_index: u16,
     /// Shared multi-progress state (null for standalone bars).
     multi: ?*MultiProgress,
 
@@ -242,14 +244,14 @@ pub const ProgressBar = struct {
     }
 
     /// Write ANSI escape to move cursor up `n` lines.
-    fn writeCursorUp(buf: []u8, pos: usize, n: u8) usize {
+    fn writeCursorUp(buf: []u8, pos: usize, n: u16) usize {
         if (n == 0) return pos;
         const seq = std.fmt.bufPrint(buf[pos..], "\x1b[{d}A", .{n}) catch return pos;
         return pos + seq.len;
     }
 
     /// Write ANSI escape to move cursor down `n` lines.
-    fn writeCursorDown(buf: []u8, pos: usize, n: u8) usize {
+    fn writeCursorDown(buf: []u8, pos: usize, n: u16) usize {
         if (n == 0) return pos;
         const seq = std.fmt.bufPrint(buf[pos..], "\x1b[{d}B", .{n}) catch return pos;
         return pos + seq.len;
@@ -268,7 +270,7 @@ pub const ProgressBar = struct {
         var pos: usize = 0;
 
         // For multi-progress: move cursor up to our line
-        const move_up: u8 = if (self.multi) |mp| mp.total_lines - self.line_index else 0;
+        const move_up: u16 = if (self.multi) |mp| mp.total_lines - self.line_index else 0;
         pos = writeCursorUp(&buf, pos, move_up);
 
         // Carriage return
@@ -395,7 +397,7 @@ pub const ProgressBar = struct {
         var buf: [512]u8 = undefined;
         var pos: usize = 0;
 
-        const move_up: u8 = if (self.multi) |mp| mp.total_lines - self.line_index else 0;
+        const move_up: u16 = if (self.multi) |mp| mp.total_lines - self.line_index else 0;
         pos = writeCursorUp(&buf, pos, move_up);
 
         buf[pos] = '\r';
@@ -606,3 +608,31 @@ pub const Spinner = struct {
         writeStderrAll(buf[0..pos]);
     }
 };
+
+test "MultiProgress accepts a line count beyond u8 without truncation" {
+    output.setQuiet(true);
+    defer output.setQuiet(false);
+
+    const big: u16 = 300;
+    var mp = MultiProgress.init(big);
+    defer mp.finish();
+    try std.testing.expectEqual(big, mp.total_lines);
+}
+
+test "ProgressBar.line_index past u8 round-trips through MultiProgress render" {
+    output.setQuiet(true);
+    defer output.setQuiet(false);
+
+    var mp = MultiProgress.init(400);
+    defer mp.finish();
+    mp.is_tty = true;
+
+    var bar = ProgressBar.init("late", 100);
+    bar.is_tty = true;
+    bar.multi = &mp;
+    bar.line_index = 350; // would silently wrap to 94 under u8
+    bar.update(50);
+    bar.finish();
+
+    try std.testing.expectEqual(@as(u16, 350), bar.line_index);
+}

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -829,7 +829,7 @@ test "pre-set SIGINT flag short-circuits the per-keg loop before any API call" {
     try testing.expect(containsLine(buf.items, "Interrupted before migration"));
     // Early-return must skip both per-keg success and final summary block.
     try testing.expect(!containsLine(buf.items, "willbeskipped migrated"));
-    try testing.expect(!containsLine(buf.items, "Migration complete:"));
+    try testing.expect(!containsLine(buf.items, "Migration completed."));
 }
 
 // ── Cellar-entry filter ─────────────────────────────────────────────────
@@ -1097,7 +1097,7 @@ test "lock contention returns error.Aborted when db/malt.lock is already held" {
     );
 }
 
-test "already-installed stderr pins the 'Migration complete' + 'Skipped (installed): 1' lines" {
+test "already-installed stderr pins the 'Migration completed.' + 'Skipped (installed): 1' lines" {
     resetOutput();
     color.setForTest(false, false);
     defer color.setForTest(null, null);
@@ -1153,9 +1153,9 @@ test "already-installed stderr pins the 'Migration complete' + 'Skipped (install
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = malt.app_ctx.processEnviron() };
     try migrate.execute(&ctx, arena.allocator(), &.{});
 
-    try testing.expect(containsLine(buf.items, "Migration complete:"));
-    try testing.expect(containsLine(buf.items, "Migrated:              0"));
-    try testing.expect(containsLine(buf.items, "Skipped (installed):   1"));
+    try testing.expect(containsLine(buf.items, "Migration completed."));
+    try testing.expect(containsLine(buf.items, "Migrated: 0"));
+    try testing.expect(containsLine(buf.items, "Skipped (installed): 1"));
 }
 
 // ── Parsed-formula lifecycle pinning ────────────────────────────────────


### PR DESCRIPTION
## Description

`mt migrate` and `mt migrate --parallel` now render per-keg progress bars as `mt install`'s download phase. 

The summary closes with a copy-pasteable dim `brew uninstall <names>` hint so a successful migration converges with a clean Homebrew-side teardown.

Non-TTY runs (CI, piped stderr) keep the existing per-keg `Migrating X…`/`X migrated` log lines so log collection still has signal - the bars are visual-only.

## Related Issue

- None

## Notes for Reviewers

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)