### PR TITLE
chore(scripts): group smoke tests under scripts/smokes/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,14 @@ jobs:
       - name: CLI smoke (offline tiers)
         env:
           SMOKE_SKIP_NETWORK: "1"
-        run: ./scripts/e2e/smoke_test.sh
+        run: ./scripts/smokes/smoke_test.sh
 
       # Security smoke: flag-scope enforcement, argv-only lint,
       # pins-manifest shape, install.sh fail-closed regression suite.
       # Subsumes the individual install.sh step that used to live in
       # the Lint job.
       - name: Security smoke
-        run: ./scripts/e2e/smoke_security.sh
+        run: ./scripts/smokes/smoke_security.sh
 
       - name: Build universal binary
         run: zig build universal -Doptimize=ReleaseSafe
@@ -86,8 +86,8 @@ jobs:
 
       - name: Lint shell scripts (shellcheck + shfmt)
         run: |
-          shellcheck scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh
-          shfmt -i 2 -d scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh
+          shellcheck scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/smokes/*.sh
+          shfmt -i 2 -d scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/smokes/*.sh
 
   # Drift guard: re-run gen-pins.sh against the committed pin on every PR
   # and fail on any diff. Catches "bumped pins.zig, forgot to regenerate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,4 +350,4 @@ jobs:
           MALT_SMOKE_API_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           # Tag being released drives the propagation wait. See RELEASING.md.
           EXPECTED_TAG: ${{ github.ref_name }}
-        run: ./scripts/e2e/smoke_install_release.sh
+        run: ./scripts/smokes/smoke_install_release.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ zig build test                                   # unit tests
 ```
 
 > [!IMPORTANT]
-> If your change touches anything in [Security invariants](#security-invariants) below - sandbox, pins, plist validator, `install.sh`, `--use-system-ruby`, or argv-only spawn - also run `./scripts/e2e/smoke_security.sh` (~10 seconds, fully offline) before opening the PR. This is the single entry point that exercises every protection end-to-end - flag scoping, argv-only lint, pins-manifest shape, `install.sh` fail-closed suite - and it's the gate that catches regressions before they reach CI.
+> If your change touches anything in [Security invariants](#security-invariants) below - sandbox, pins, plist validator, `install.sh`, `--use-system-ruby`, or argv-only spawn - also run `./scripts/smokes/smoke_security.sh` (~10 seconds, fully offline) before opening the PR. This is the single entry point that exercises every protection end-to-end - flag scoping, argv-only lint, pins-manifest shape, `install.sh` fail-closed suite - and it's the gate that catches regressions before they reach CI.
 
 If your change touches `scripts/install.sh` specifically, also run `./scripts/test/install_sh_test.sh`.
 
@@ -84,8 +84,8 @@ zig build test                                   # unit tests
 ./scripts/lint-spawn-invariants.sh               # argv-only lint
 ./scripts/test/install_sh_test.sh                # install.sh regression
 ./scripts/local-bench.sh                         # full bench suite (slow)
-./scripts/e2e/smoke_test.sh                      # CLI smoke coverage
-./scripts/e2e/smoke_security.sh                  # security-surface smoke
+./scripts/smokes/smoke_test.sh                   # CLI smoke coverage
+./scripts/smokes/smoke_security.sh               # security-surface smoke
 ```
 
 For the pre-PR subset, see [Before you submit](#before-you-submit).

--- a/justfile
+++ b/justfile
@@ -66,13 +66,13 @@ fmt:
 # Lint shell scripts with shellcheck + shfmt.
 [group('lint')]
 shell-lint:
-    shellcheck scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh
-    shfmt -i 2 -d scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh
+    shellcheck scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh scripts/smokes/*.sh
+    shfmt -i 2 -d scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh scripts/smokes/*.sh
 
 # Apply shfmt formatting in place. Run after a failing `shell-lint`.
 [group('lint')]
 shell-fmt:
-    shfmt -i 2 -w scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh
+    shfmt -i 2 -w scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh scripts/smokes/*.sh
 
 # Lint: format check + build + test
 [group('lint')]
@@ -129,9 +129,9 @@ pre-push: fmt-check test shell-lint
         echo "▸ MALT_SKIP_SMOKE=1 — skipping install smoke"
     elif git rev-parse --verify origin/main >/dev/null 2>&1 \
         && git diff --name-only origin/main...HEAD 2>/dev/null \
-        | grep -qE '^(src/cli/install\.zig|src/core/bottle\.zig|src/core/cask\.zig|src/fs/archive\.zig|src/fs/atomic\.zig|src/net/client\.zig|src/net/ghcr\.zig|scripts/local-smoke-install\.sh)$'; then
+        | grep -qE '^(src/cli/install\.zig|src/core/bottle\.zig|src/core/cask\.zig|src/fs/archive\.zig|src/fs/atomic\.zig|src/net/client\.zig|src/net/ghcr\.zig|scripts/smokes/local-smoke-install\.sh)$'; then
         echo "▸ Install/extract/download surface touched — running install smoke"
-        ./scripts/local-smoke-install.sh
+        ./scripts/smokes/local-smoke-install.sh
     else
         echo "▸ Install/extract/download surface untouched — skipping install smoke"
     fi
@@ -143,7 +143,7 @@ pre-push: fmt-check test shell-lint
 # Auto-runs from `pre-push` when install/extract/download paths change.
 [group('test')]
 smoke-install: build
-    @./scripts/local-smoke-install.sh
+    @./scripts/smokes/local-smoke-install.sh
 
 # Install git hooks (pre-commit + pre-push)
 [group('hooks')]

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -30,7 +30,7 @@ if [[ ! -x zig-out/bin/malt ]]; then
 fi
 
 # Throwaway prefix. 7 bytes, safely under malt's 13-byte Mach-O patch budget
-# (see src/cli/install.zig:24 and scripts/e2e/test_smoke_install.sh).
+# (see src/cli/install.zig:24 and scripts/smokes/test_smoke_install.sh).
 PREFIX=/tmp/mt
 
 export MALT_PREFIX="$PREFIX"

--- a/scripts/smokes/local-smoke-install.sh
+++ b/scripts/smokes/local-smoke-install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/local-smoke-install.sh — heavy install regression guard
+# scripts/smokes/local-smoke-install.sh — heavy install regression guard
 #
 # Runs real installs against an isolated MALT_PREFIX/MALT_CACHE to catch
 # regressions in the bottle download → SHA verify → extract pipeline that
@@ -52,8 +52,8 @@
 # Binary casks land under $MALT_PREFIX/bin so they never need that guard.
 #
 # Usage:
-#   ./scripts/local-smoke-install.sh
-#   MT_BIN=./zig-out/bin/mt ./scripts/local-smoke-install.sh
+#   ./scripts/smokes/local-smoke-install.sh
+#   MT_BIN=./zig-out/bin/mt ./scripts/smokes/local-smoke-install.sh
 
 set -uo pipefail
 

--- a/scripts/smokes/smoke_install_local.sh
+++ b/scripts/smokes/smoke_install_local.sh
@@ -6,12 +6,12 @@
 # dry-run, autodetection, and negative paths. Hermetic — every run
 # uses a throwaway MALT_PREFIX and no download ever executes.
 #
-# Usage: scripts/smoke_install_local.sh
+# Usage: scripts/smokes/smoke_install_local.sh
 # Requirements: built `malt` binary at $MALT_BIN or zig-out/bin/malt.
 
 set -euo pipefail
 
-ROOT=$(cd "$(dirname "$0")/.." && pwd)
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
 [[ -x "$BIN" ]] || {
   echo "build malt first: zig build" >&2

--- a/scripts/smokes/smoke_install_release.sh
+++ b/scripts/smokes/smoke_install_release.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/e2e/smoke_install_release.sh
+# scripts/smokes/smoke_install_release.sh
 #
 # Post-release smoke: runs the README's one-liner against the live
 # GitHub release and exercises the full trust path end-to-end.
@@ -19,7 +19,7 @@
 # wire into a release-verification workflow.
 #
 # Usage:
-#   ./scripts/e2e/smoke_install_release.sh
+#   ./scripts/smokes/smoke_install_release.sh
 #
 # Requirements:
 #   - curl, bash, tar

--- a/scripts/smokes/smoke_migrate_parallel.sh
+++ b/scripts/smokes/smoke_migrate_parallel.sh
@@ -14,11 +14,11 @@
 # `just clean` (clean.sh /tmp/mt_* + /tmp/mt-* globs) reaps them.
 #
 # Usage:
-#   scripts/smoke_migrate_parallel.sh
-#   MALT_BIN=zig-out/bin/malt scripts/smoke_migrate_parallel.sh
-#   MIGRATE_KEGS="hello jq tree" scripts/smoke_migrate_parallel.sh
-#   MALT_MIGRATE_PARALLEL_WORKERS=8 scripts/smoke_migrate_parallel.sh
-#   SKIP_NDJSON_PASS=1 scripts/smoke_migrate_parallel.sh
+#   scripts/smokes/smoke_migrate_parallel.sh
+#   MALT_BIN=zig-out/bin/malt scripts/smokes/smoke_migrate_parallel.sh
+#   MIGRATE_KEGS="hello jq tree" scripts/smokes/smoke_migrate_parallel.sh
+#   MALT_MIGRATE_PARALLEL_WORKERS=8 scripts/smokes/smoke_migrate_parallel.sh
+#   SKIP_NDJSON_PASS=1 scripts/smokes/smoke_migrate_parallel.sh
 #
 # Requires: built malt binary, jq, network access to formulae.brew.sh
 # and ghcr.io. Not for CI - touches the user's brew Cellar (read-only)
@@ -26,7 +26,7 @@
 
 set -uo pipefail
 
-ROOT=$(cd "$(dirname "$0")/.." && pwd)
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
 # Always invoke `zig build` so a smoke run after a code edit picks up
 # the latest binary - the previous "skip if exists" gate left stale

--- a/scripts/smokes/smoke_search.sh
+++ b/scripts/smokes/smoke_search.sh
@@ -7,12 +7,12 @@
 # API, so it requires network; safe to run locally (no install side
 # effects).
 #
-# Usage: scripts/smoke_search.sh
+# Usage: scripts/smokes/smoke_search.sh
 # Requirements: built `malt` binary in zig-out/bin or $MALT_BIN.
 
 set -euo pipefail
 
-ROOT=$(cd "$(dirname "$0")/.." && pwd)
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
 [[ -x "$BIN" ]] || {
   echo "build malt first: zig build" >&2

--- a/scripts/smokes/smoke_security.sh
+++ b/scripts/smokes/smoke_security.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/e2e/smoke_security.sh
+# scripts/smokes/smoke_security.sh
 #
 # End-to-end smoke coverage for malt's security-critical surfaces.
 # Each check is a thin exercise of one protection added in the
@@ -16,8 +16,8 @@
 # Cleans up its tmp prefix on exit.
 #
 # Usage:
-#   ./scripts/e2e/smoke_security.sh
-#   MT_BIN=./zig-out/bin/mt ./scripts/e2e/smoke_security.sh
+#   ./scripts/smokes/smoke_security.sh
+#   MT_BIN=./zig-out/bin/mt ./scripts/smokes/smoke_security.sh
 
 set -uo pipefail
 

--- a/scripts/smokes/smoke_services.sh
+++ b/scripts/smokes/smoke_services.sh
@@ -6,7 +6,7 @@
 # touch the real installation. Safe to run on a developer machine; do not
 # run in CI (touches the user's launchd domain).
 #
-# Usage: scripts/smoke_services.sh
+# Usage: scripts/smokes/smoke_services.sh
 # Requirements: built `malt` binary in zig-out/bin, macOS.
 
 set -euo pipefail
@@ -16,7 +16,7 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
   exit 2
 fi
 
-ROOT=$(cd "$(dirname "$0")/.." && pwd)
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 BIN="$ROOT/zig-out/bin/malt"
 [[ -x "$BIN" ]] || {
   echo "build malt first: zig build" >&2

--- a/scripts/smokes/smoke_test.sh
+++ b/scripts/smokes/smoke_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/e2e/smoke_test.sh
+# scripts/smokes/smoke_test.sh
 #
 # Comprehensive CLI smoke test for malt. Exercises every command and subcommand
 # documented in README.md under an isolated MALT_PREFIX / MALT_CACHE, so the
@@ -15,9 +15,9 @@
 # summary is emitted. Exit code 0 iff every test passes.
 #
 # Usage:
-#   ./scripts/e2e/smoke_test.sh                      # full run
-#   SMOKE_SKIP_NETWORK=1 ./scripts/e2e/smoke_test.sh # tiers 1+2 only
-#   MT_BIN=./zig-out/bin/mt ./scripts/e2e/smoke_test.sh
+#   ./scripts/smokes/smoke_test.sh                      # full run
+#   SMOKE_SKIP_NETWORK=1 ./scripts/smokes/smoke_test.sh # tiers 1+2 only
+#   MT_BIN=./zig-out/bin/mt ./scripts/smokes/smoke_test.sh
 
 set -uo pipefail
 

--- a/scripts/smokes/test_smoke_install.sh
+++ b/scripts/smokes/test_smoke_install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/e2e/test_smoke_install.sh
+# scripts/smokes/test_smoke_install.sh
 #
 # End-to-end smoke test for `mt install`. Runs an isolated install of the
 # three packages that P1 regressed (zig, curl, rust), each of which ships as
@@ -18,9 +18,9 @@
 #   4. otool -L on each binary shows no remaining `@@HOMEBREW_` tokens.
 #
 # Usage:
-#   ./scripts/e2e/test_smoke_install.sh           # default
-#   MT_BIN=./zig-out/bin/malt ./scripts/e2e/test_smoke_install.sh
-#   SKIP_BUILD=1 ./scripts/e2e/test_smoke_install.sh   # reuse an existing build
+#   ./scripts/smokes/test_smoke_install.sh           # default
+#   MT_BIN=./zig-out/bin/malt ./scripts/smokes/test_smoke_install.sh
+#   SKIP_BUILD=1 ./scripts/smokes/test_smoke_install.sh   # reuse an existing build
 #
 # Exit codes:
 #   0 — all assertions passed


### PR DESCRIPTION
## Description

Smoke tests are scattered between `scripts/` (top-level `smoke_*.sh`, `local-smoke-install.sh`) and `scripts/e2e/` (`smoke_*.sh`, `test_smoke_install.sh`). This makes the suite harder to find and inconsistent with the existing `scripts/regressions/` convention.

This PR consolidates all 9 smoke scripts under `scripts/smokes/`, mirroring the regressions layout. `scripts/e2e/migrate_dry_run_check.sh` stays put — it's a manual QA dev check, not a smoke. CI workflows, justfile recipes, `CONTRIBUTING.md`, the pre-push install-surface gate and internal cross-references all point at the new home; file history is preserved via `git mv`.

## Related Issue

- None

## Notes for Reviewers

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)