### PR TITLE
fix(cli/upgrade): share malt.lock with installAll to avoid self-deadlock

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -102,6 +102,11 @@ pub const constantTimeEql = record_mod.constantTimeEql;
 pub const InstallAllOpts = struct {
     /// Treat every package as a cask; equivalent to `--cask`.
     cask: bool = false,
+    /// Caller already owns `malt.lock` on a separate fd. BSD `flock` is
+    /// per-fd, so re-entering `execute` from the same process would
+    /// otherwise EAGAIN-loop against its own hold and 30 s-timeout with
+    /// the misleading "another mt process is running" error.
+    skip_lock: bool = false,
 };
 
 /// Non-argv primitive used by `core/bundle/runner.zig` via its injected
@@ -117,8 +122,15 @@ pub fn installAll(
     defer argv.deinit(allocator);
     if (opts.cask) try argv.append(allocator, "--cask");
     for (packages) |p| try argv.append(allocator, p);
-    return execute(ctx, allocator, argv.items);
+    return executeWithOpts(ctx, allocator, argv.items, .{ .skip_lock = opts.skip_lock });
 }
+
+/// Internal options that don't have an argv form. Kept private so the
+/// non-argv flags (currently just lock ownership) stay an in-process
+/// contract instead of leaking into the user-visible flag surface.
+const ExecuteOpts = struct {
+    skip_lock: bool = false,
+};
 
 const InstallFlag = enum {
     cask,
@@ -146,6 +158,15 @@ const install_flag_map = std.StaticStringMap(InstallFlag).initComptime(.{
 });
 
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
+    return executeWithOpts(ctx, allocator, args, .{});
+}
+
+fn executeWithOpts(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    args: []const []const u8,
+    exec_opts: ExecuteOpts,
+) !void {
     if (help.showIfRequested(ctx, args, "install")) return;
 
     // Parse flags
@@ -303,19 +324,25 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         return InstallError.DatabaseError;
     };
 
-    // Acquire lock (Step 1)
-    var lock_path_buf: [512]u8 = undefined;
-    const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch
-        return InstallError.LockError;
-    var lk = lock_mod.LockFile.acquire(lock_path, 30000) catch {
-        output.err("Another mt process is running. Wait or run mt doctor.", .{});
-        return InstallError.LockError;
-    };
-    defer lk.release();
-    // LIFO: install_complete fires before lk.release. Inline gate keeps
-    // the deferred call out of the default paths.
-    defer if (output.isNdjson()) output.emitNdjsonEvent(allocator, .install_complete, "", null);
-    output.emitNdjsonEvent(allocator, .lock_acquired, "", null);
+    // Acquire lock (Step 1) — skipped when the caller already owns it.
+    // BSD `flock` is per-fd, so a re-entry from the same process (e.g.
+    // upgrade -> installAll for missing transitive deps) would
+    // EAGAIN-loop against its own hold and time out as fake contention.
+    var lk: ?lock_mod.LockFile = null;
+    if (!exec_opts.skip_lock) {
+        var lock_path_buf: [512]u8 = undefined;
+        const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch
+            return InstallError.LockError;
+        lk = lock_mod.LockFile.acquire(lock_path, 30000) catch {
+            output.err("Another mt process is running. Wait or run mt doctor.", .{});
+            return InstallError.LockError;
+        };
+        output.emitNdjsonEvent(allocator, .lock_acquired, "", null);
+    }
+    defer if (lk) |*l| l.release();
+    // LIFO: install_complete must precede release in the deferred chain,
+    // and the outer holder owns the matching pair when we skipped here.
+    defer if (lk != null and output.isNdjson()) output.emitNdjsonEvent(allocator, .install_complete, "", null);
 
     // Main-thread HTTP client; workers borrow from `http_pool` instead.
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -253,7 +253,11 @@ fn upgradeFormula(
         defer if (missing.len > 0) allocator.free(missing);
         if (missing.len > 0) {
             output.info("Installing new dep(s) for {s} ({d})...", .{ name, missing.len });
-            install_mod.installAll(ctx, allocator, missing, .{}) catch {
+            // Re-enter installAll while we already own malt.lock above:
+            // BSD flock is per-fd, so without skip_lock the inner acquire
+            // would EAGAIN-loop on our own hold and 30 s-timeout as
+            // misleading "Another mt process is running" contention.
+            install_mod.installAll(ctx, allocator, missing, .{ .skip_lock = true }) catch {
                 output.err("Could not install new dep(s) for {s}", .{name});
                 return error.Aborted;
             };

--- a/src/core/pins_manifest.txt
+++ b/src/core/pins_manifest.txt
@@ -12,7 +12,6 @@
 # Lines starting with '#' and blank lines are ignored.
 
 abricate 4dc614ecc38fde228a23e1b7931abe8dca961eaeb9e032baf98f31362533a23e
-apache-archiva a93e103e695c1bef68ad4565762ec0cd1ad806a9afd5ddecaac51698307861f1
 aravis 4bb2aa92b0674e1992b707c36b5f69a50aa73c77e91975b8302dc4e5e1914744
 arcadedb bd3a83f0511926c2cb2851a37bf61887666c38dfb16de550ebaa9e368b8c2242
 baobab a4a026f49ace311c15343bdb6fcf17bbdad568dbd428b50e02cadd04fca0a057

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -9,9 +9,12 @@ const malt = @import("malt");
 const test_io = @import("test_io");
 const testing = std.testing;
 const upgrade = malt.upgrade;
+const install = malt.install;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
 const formula_mod = malt.formula;
+const lock_mod = malt.lock;
+const output = malt.output;
 
 const c = struct {
     extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
@@ -403,4 +406,112 @@ test "recordKeg succeeds on a same-version revision-bump upgrade" {
     try rev_stmt.bindInt(1, new_keg_id);
     _ = try rev_stmt.step();
     try testing.expectEqual(@as(i64, 2), rev_stmt.columnInt(0));
+}
+
+// Regression: upgrade.execute holds malt.lock on its own fd, then re-enters
+// install.execute via installAll for missing transitive deps. BSD flock is
+// per-fd, so the inner acquire EAGAIN-loops 30 s on the outer process's own
+// hold and aborts with the misleading "Another mt process is running" error.
+// installAll exposes `skip_lock = true` for callers that already own the
+// lock; this test pins that contract from the install side and the upgrade
+// side asserts the same path completes without a lock-contention message.
+test "installAll honours skip_lock so an outer holder can re-enter without a self-deadlock" {
+    const path = try setupPrefix("installall_skip_lock");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{path});
+    defer testing.allocator.free(db_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, db_dir);
+
+    // Plant 404 markers for both formula and cask kinds so resolution
+    // exits before the network is reached and no jobs queue up.
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{path});
+    defer testing.allocator.free(cache_api);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_api);
+    inline for (.{ "formula_zzghost.404", "cask_zzghost.404" }) |name| {
+        const p = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ cache_api, name });
+        defer testing.allocator.free(p);
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, p, .{ .truncate = true });
+        f.close(std.Options.debug_io);
+    }
+
+    // Mimic the outer hold that upgrade.execute already owns.
+    var lock_path_buf: [512]u8 = undefined;
+    const lock_path = try std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{path});
+    var outer = try lock_mod.LockFile.acquire(lock_path, 1000);
+    defer outer.release();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    output.setQuiet(true);
+    defer output.setQuiet(false);
+
+    // skip_lock=true must bypass the per-fd flock entirely. The 404
+    // markers drain the resolution queue, so a clean return proves we
+    // never blocked on the lock.
+    try install.installAll(&ctx, testing.allocator, &.{"zzghost"}, .{ .skip_lock = true });
+}
+
+// Regression: when the new bottle of an installed formula introduces a dep
+// that isn't on disk yet, upgrade.execute reaches into installAll to fetch
+// the missing dep. The path used to deadlock against its own malt.lock and
+// surface as "Another mt process is running"; the user-facing fix is that
+// the dep install branch exits via its own diagnostic instead.
+test "upgrade with a missing transitive dep does not error with lock contention" {
+    const path = try setupPrefix("upgrade_missing_dep");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        try db.exec(
+            \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+            \\VALUES ('curl', 'curl', '8.19', 'sha-old', '/cellar/curl/8.19');
+        );
+    }
+
+    // Cache-seed the new curl JSON with a dep on a name that 404s, so the
+    // dep installAll exits via "fetchFormula failed" rather than network.
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{path});
+    defer testing.allocator.free(cache_api);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_api);
+
+    const cache_json = try std.fmt.allocPrint(testing.allocator, "{s}/formula_curl.json", .{cache_api});
+    defer testing.allocator.free(cache_json);
+    const cf = try test_io.createFileAbsolute(std.Options.debug_io, cache_json, .{ .truncate = true });
+    const body =
+        \\{"name":"curl","full_name":"curl","tap":"homebrew/core","desc":"","homepage":"","license":null,"revision":0,"keg_only":false,"post_install_defined":false,"versions":{"stable":"8.20"},"dependencies":["zzngtcp2"],"oldnames":[],"bottle":{"stable":{"root_url":"","files":{}}}}
+    ;
+    try cf.writeStreamingAll(std.Options.debug_io, body);
+    cf.close(std.Options.debug_io);
+
+    inline for (.{ "formula_zzngtcp2.404", "cask_zzngtcp2.404" }) |name| {
+        const p = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ cache_api, name });
+        defer testing.allocator.free(p);
+        const m = try test_io.createFileAbsolute(std.Options.debug_io, p, .{ .truncate = true });
+        m.close(std.Options.debug_io);
+    }
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    output.beginStderrCapture(testing.allocator, &captured);
+    defer output.endStderrCapture();
+
+    // The bottle slot is empty so resolveBottle aborts after the dep
+    // install path runs — both branches surface error.Aborted today, but
+    // the load-bearing observation is the *reason*: the error must not be
+    // the lock-contention message that masks the real cause.
+    upgrade.execute(&ctx, testing.allocator, &.{"curl"}) catch {};
+
+    try testing.expect(std.mem.indexOf(u8, captured.items, "Another mt process is running") == null);
 }


### PR DESCRIPTION
## Description

`mt upgrade <foo>` would stall 30 s and abort with "Another mt process is running" whenever the new bottle pulled in a transitive dep that wasn't already on disk. Upgrade and install each tried to take the same per-fd flock on `malt.lock` from inside the same process, so the inner acquire EAGAIN-looped against the outer hold until the timeout. Now the upgrade keeps its lock and threads it through to the dep-install path instead of re-acquiring, and the misleading contention message is gone for this case.

## Related Issue

- None

## Notes for Reviewers

- None