### PR TITLE
fix(install/local): stop tap installs leaking their staging archive

### DIFF
--- a/scripts/regressions/install_tap_tmp_cleanup.sh
+++ b/scripts/regressions/install_tap_tmp_cleanup.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Regression: a successful third-party tap install must leave
+# $PREFIX/tmp/ empty — no `tap_download*` archive should survive.
+#
+# A previous build aliased the same 512-byte buffer for both the
+# staging-archive path and the per-binary `bin/<name>` path inside
+# the post-extract walker. The deferred cleanup ran against an
+# overwritten slice, so every successful tap install leaked an
+# archive into $PREFIX/tmp until the user ran `mt doctor --fix`.
+#
+# Usage: scripts/regressions/install_tap_tmp_cleanup.sh
+# Requirements: built malt at $MALT_BIN or zig-out/bin/malt, network
+# access to api.github.com / raw.githubusercontent.com.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be <= 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_tmpc"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+skip() { printf '  - %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+# Real binary tap that ships a single executable through the
+# materializeRubyFormula path (the surface the leak lived on).
+SLUG="indaco/tap/sley"
+LOG="$PREFIX/install.log"
+printf '▸ malt install %s\n' "$SLUG"
+"$BIN" install "$SLUG" >"$LOG" 2>&1 || true
+
+if ! grep -qE "installed$| installed " "$LOG"; then
+  if grep -qE "rate limit|Network failure|Tap formula/cask not found" "$LOG"; then
+    skip "$SLUG: transient classified failure; cannot assert tmp/ cleanup"
+    exit 0
+  fi
+  tail -30 "$LOG" >&2
+  fail "$SLUG: install neither succeeded nor produced a known transient error"
+fi
+pass "$SLUG: install succeeded"
+
+LEFTOVER=$(find "$PREFIX/tmp" -maxdepth 1 -name 'tap_download*' 2>/dev/null || true)
+if [[ -n "$LEFTOVER" ]]; then
+  printf '%s\n' "$LEFTOVER" >&2
+  fail "stale tap archive(s) survived a successful install"
+fi
+pass "$PREFIX/tmp is clean after successful install"
+
+printf '\n✔ tap tmp/ cleanup regression passed\n'

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -337,6 +337,19 @@ fn fstatRisk(f: std.Io.File) ?LocalPermissionRisk {
     return describeLocalPermissionRisk(@intCast(raw.mode), @intCast(raw.uid), @intCast(effective));
 }
 
+/// Compose the staging-archive path used by the tap/local install
+/// flow. The pid suffix prevents two concurrent invocations from
+/// racing on a shared `tap_download.<ext>` filename — without it,
+/// one install would overwrite the other's in-flight download.
+pub fn formatTapDownloadName(
+    buf: []u8,
+    prefix: []const u8,
+    ext: []const u8,
+    pid: i32,
+) ![]const u8 {
+    return std.fmt.bufPrint(buf, "{s}/tmp/tap_download.{d}{s}", .{ prefix, pid, ext });
+}
+
 /// Shared "from parsed `.rb` to linked keg" path, used by the tap and
 /// local installers. Does the network fetch for the archive, SHA256
 /// verification, cellar materialisation, and DB + linker commit.
@@ -462,7 +475,7 @@ fn materializeRubyFormula(
         .zip => ".zip",
     };
     var tmp_buf: [512]u8 = undefined;
-    const tmp_archive = std.fmt.bufPrint(&tmp_buf, "{s}/tmp/tap_download{s}", .{ prefix, ext }) catch
+    const tmp_archive = formatTapDownloadName(&tmp_buf, prefix, ext, std.c.getpid()) catch
         return InstallError.DownloadFailed;
 
     const tmp_file = std.Io.Dir.createFileAbsolute(ctx.io, tmp_archive, .{}) catch return InstallError.DownloadFailed;
@@ -471,7 +484,8 @@ fn materializeRubyFormula(
         return InstallError.DownloadFailed;
     };
     tmp_file.close(ctx.io);
-    // Temp archive cleanup; leaks to tmp/ are reaped by the next install.
+    // Best-effort cleanup; the per-pid name keeps a leak (panic / SIGKILL)
+    // from colliding with the next install's archive.
     defer std.Io.Dir.cwd().deleteFile(ctx.io, tmp_archive) catch {};
 
     const archive_mod = @import("../../fs/archive.zig");
@@ -504,11 +518,14 @@ fn materializeRubyFormula(
         var walker = cellar_dir.walk(allocator) catch return InstallError.CellarFailed;
         defer walker.deinit();
 
+        // Separate buffer: writing into `tmp_buf` here would corrupt the
+        // `tmp_archive` slice that the deferred cleanup still holds.
+        var dest_buf: [512]u8 = undefined;
         while (walker.next(ctx.io) catch null) |entry| {
             if (entry.kind != .file) continue;
             const basename = std.fs.path.basename(entry.path);
             if (std.mem.eql(u8, basename, target_binary)) {
-                const dest_name = std.fmt.bufPrint(&tmp_buf, "bin/{s}", .{basename}) catch continue;
+                const dest_name = std.fmt.bufPrint(&dest_buf, "bin/{s}", .{basename}) catch continue;
                 std.Io.Dir.copyFile(cellar_dir, entry.path, cellar_dir, dest_name, ctx.io, .{}) catch continue;
                 const bin_file = cellar_dir.openFile(ctx.io, dest_name, .{ .mode = .read_write }) catch continue;
                 defer bin_file.close(ctx.io);
@@ -847,4 +864,26 @@ fn writeJsonString(allocator: std.mem.Allocator, out: *std.ArrayList(u8), s: []c
         }
     }
     try out.append(allocator, '"');
+}
+
+test "formatTapDownloadName encodes pid + extension into tmp/ path" {
+    var buf: [128]u8 = undefined;
+    const got = try formatTapDownloadName(&buf, "/opt/h", ".tar.gz", 4242);
+    try std.testing.expectEqualStrings("/opt/h/tmp/tap_download.4242.tar.gz", got);
+}
+
+test "formatTapDownloadName distinct pids produce distinct paths" {
+    // Two concurrent `mt install <user>/<tap>/<formula>` invocations
+    // must not race on a shared filename — the returned path carries
+    // the live process id so each install streams into its own archive.
+    var a: [128]u8 = undefined;
+    var b: [128]u8 = undefined;
+    const path_a = try formatTapDownloadName(&a, "/opt/h", ".zip", 1);
+    const path_b = try formatTapDownloadName(&b, "/opt/h", ".zip", 2);
+    try std.testing.expect(!std.mem.eql(u8, path_a, path_b));
+}
+
+test "formatTapDownloadName surfaces NoSpaceLeft instead of truncating" {
+    var buf: [4]u8 = undefined;
+    try std.testing.expectError(error.NoSpaceLeft, formatTapDownloadName(&buf, "/opt/h", ".tar.gz", 4242));
 }


### PR DESCRIPTION
## Description

Every successful `mt install <user>/<tap>/<formula>` was leaving a stale `tap_download.tar.gz` (or `.tar.xz` / `.zip`) in `$PREFIX/tmp/`, and two concurrent tap installs raced on that shared filename - one would silently read a partial download from the other.

The staging-archive path now carries the live process id, so concurrent invocations stream into separate files. The post-extract walker also writes its `bin/<name>` rename slice into a separate buffer, so the deferred cleanup sees an intact path and actually removes the archive on the way out.

## Related Issue

- None

## Notes for Reviewers

- None