### PR TITLE
fix(migrate): run post_install for tap kegs migrated from the Cellar fallback

### DIFF
--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -13,6 +13,17 @@ const output = @import("../../ui/output.zig");
 
 const download = @import("download.zig");
 
+/// Extract the post_install body from a tap's `<name>.rb`. Tap kegs
+/// aren't reachable from the bottle DSL pipeline (the locator only
+/// knows homebrew-core), so the migrate fallback resolves the body
+/// here and feeds it to `driveTap`. Returns null when no `def
+/// post_install` block is present, the file is missing, or the parser
+/// can't extract a clean body — caller's contract is "run iff
+/// non-null."
+pub fn extractRbPostInstallBody(io: std.Io, allocator: std.mem.Allocator, rb_path: []const u8) ?[]const u8 {
+    return ruby_sub.extractPostInstallBody(io, allocator, rb_path);
+}
+
 pub const DownloadJob = download.DownloadJob;
 
 /// Whether --use-system-ruby opts the named formula into the Ruby
@@ -69,6 +80,32 @@ pub fn routePostInstallOutcome(
     flog: *const dsl.FallbackLog,
     use_system_ruby_list: []const []const u8,
 ) void {
+    routePostInstallOutcomeWithBody(
+        ctx,
+        allocator,
+        name,
+        version_str,
+        prefix,
+        flog,
+        use_system_ruby_list,
+        null,
+    );
+}
+
+/// Variant that takes a pre-resolved post_install body so the system-
+/// Ruby fallback works for tap kegs (whose `.rb` source isn't reachable
+/// through homebrew-core's locator). When `pre_resolved_body` is null
+/// the routing matches the bottle path byte-for-byte.
+pub fn routePostInstallOutcomeWithBody(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    version_str: []const u8,
+    prefix: []const u8,
+    flog: *const dsl.FallbackLog,
+    use_system_ruby_list: []const []const u8,
+    pre_resolved_body: ?[]const u8,
+) void {
     const status: PostInstallStatus = blk: {
         if (flog.hasFatal()) {
             output.warn("post_install DSL failed for {s} (fatal)", .{name});
@@ -87,8 +124,13 @@ pub fn routePostInstallOutcome(
             output.warn("post_install DSL incomplete for {s}, falling back to system Ruby...", .{name});
             if (output.isVerbose()) flog.printUnknown(name);
             if (output.isDebug()) flog.printFatal(name);
-            ruby_sub.runPostInstall(ctx.io, ctx.environ, allocator, name, version_str, prefix) catch |e| {
-                output.warn("post_install subprocess failed for {s}: {s}", .{ name, ruby_sub.describeError(e) });
+            const ruby_result: anyerror!void = if (pre_resolved_body) |body|
+                ruby_sub.runPostInstallWithBody(ctx.io, ctx.environ, allocator, name, version_str, prefix, body)
+            else
+                ruby_sub.runPostInstall(ctx.io, ctx.environ, allocator, name, version_str, prefix);
+            ruby_result catch |e| {
+                const err: ruby_sub.RubyError = @errorCast(e);
+                output.warn("post_install subprocess failed for {s}: {s}", .{ name, ruby_sub.describeError(err) });
                 break :blk .ruby_fallback_failed;
             };
             // Symmetric with the native "completed" info so scripted users
@@ -202,19 +244,57 @@ pub fn executeDslPostInstall(
         return .parse_failed;
     };
     defer formula.deinit();
+    executeDslPostInstallFields(
+        ctx,
+        allocator,
+        name,
+        version_str,
+        formula.version,
+        formula.pkg_version,
+        post_install_src,
+        prefix,
+        use_system_ruby_list,
+    );
+    return .handled;
+}
 
+/// Fields-based variant: bypass formula JSON entirely. Used by the
+/// migrate tap-fallback path where we already have name/version from
+/// the receipt and the post_install body extracted from the tap's .rb.
+/// Forwards the body through to the router so a `--use-system-ruby`
+/// fallback for a tap keg targets the same body the DSL was run with —
+/// homebrew-core's locator can't reach non-core taps.
+pub fn executeDslPostInstallFields(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    version_str: []const u8,
+    dsl_version: []const u8,
+    pkg_version: []const u8,
+    post_install_src: []const u8,
+    prefix: []const u8,
+    use_system_ruby_list: []const []const u8,
+) void {
     var flog = dsl.FallbackLog.init(allocator);
     defer flog.deinit();
 
     // DSL errors reflect in `flog`; the router reads the log as the source
     // of truth so silent skips downgrade the same as hard failures.
     dsl.executePostInstall(ctx.io, ctx.environ, allocator, .{
-        .name = formula.name,
-        .version = formula.version,
-        .pkg_version = formula.pkg_version,
+        .name = name,
+        .version = dsl_version,
+        .pkg_version = pkg_version,
     }, post_install_src, prefix, &flog) catch {};
-    routePostInstallOutcome(ctx, allocator, name, version_str, prefix, &flog, use_system_ruby_list);
-    return .handled;
+    routePostInstallOutcomeWithBody(
+        ctx,
+        allocator,
+        name,
+        version_str,
+        prefix,
+        &flog,
+        use_system_ruby_list,
+        post_install_src,
+    );
 }
 
 /// Locate a DSL post_install body for `name`: prefer a locally cloned
@@ -274,6 +354,90 @@ pub fn drive(
     } else {
         output.warn("{s}: post_install skipped (use --use-system-ruby={s} or brew install {s})", .{ name, name, name });
     }
+}
+
+/// Tap-fallback analog of `drive`: the post_install body has already
+/// been resolved off the tap's `<name>.rb`, so we skip the homebrew-core
+/// locator and feed it straight to the DSL. The router still emits the
+/// same `completed` / `partially skipped` / `--use-system-ruby` lines —
+/// this is the install path's user-facing contract, just sourced from
+/// a tap receipt instead of a parsed formula.
+///
+/// Tap kegs migrated through the fallback carry no revision suffix
+/// (the receipt's `source.versions.stable` is the whole version), so a
+/// single `version` string covers both the user-facing message and the
+/// DSL's `formula.version` / `formula.pkg_version` slots.
+pub fn driveTap(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    version: []const u8,
+    post_install_src: []const u8,
+    prefix: []const u8,
+    use_system_ruby_list: []const []const u8,
+) void {
+    executeDslPostInstallFields(
+        ctx,
+        allocator,
+        name,
+        version,
+        version,
+        version,
+        post_install_src,
+        prefix,
+        use_system_ruby_list,
+    );
+}
+
+test "extractRbPostInstallBody: returns the body when the .rb defines post_install" {
+    const dir = "/tmp/malt_pi_decl_yes";
+    std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
+    try std.Io.Dir.createDirAbsolute(std.Options.debug_io, dir, .default_dir);
+    defer std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
+
+    const rb = dir ++ "/glow.rb";
+    const f = try std.Io.Dir.createFileAbsolute(std.Options.debug_io, rb, .{ .truncate = true });
+    try f.writeStreamingAll(std.Options.debug_io,
+        \\class Glow < Formula
+        \\  def post_install
+        \\    bin.install "glow"
+        \\  end
+        \\end
+        \\
+    );
+    f.close(std.Options.debug_io);
+
+    const body = extractRbPostInstallBody(std.Options.debug_io, std.testing.allocator, rb);
+    try std.testing.expect(body != null);
+    defer std.testing.allocator.free(body.?);
+    try std.testing.expect(std.mem.indexOf(u8, body.?, "bin.install") != null);
+}
+
+test "extractRbPostInstallBody: null when the .rb has no post_install block" {
+    const dir = "/tmp/malt_pi_decl_no";
+    std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
+    try std.Io.Dir.createDirAbsolute(std.Options.debug_io, dir, .default_dir);
+    defer std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
+
+    const rb = dir ++ "/quiet.rb";
+    const f = try std.Io.Dir.createFileAbsolute(std.Options.debug_io, rb, .{ .truncate = true });
+    try f.writeStreamingAll(std.Options.debug_io,
+        \\class Quiet < Formula
+        \\  url "x"
+        \\end
+        \\
+    );
+    f.close(std.Options.debug_io);
+
+    try std.testing.expect(extractRbPostInstallBody(std.Options.debug_io, std.testing.allocator, rb) == null);
+}
+
+test "extractRbPostInstallBody: null when the .rb is missing entirely" {
+    try std.testing.expect(extractRbPostInstallBody(
+        std.Options.debug_io,
+        std.testing.allocator,
+        "/tmp/malt_pi_decl_missing/never.rb",
+    ) == null);
 }
 
 test "isSelfHostingRubyKeg: bare ruby and versioned aliases match" {

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -322,8 +322,120 @@ fn migrateFromLocalCellar(
     deps.linker.linkOpt(keg_name, receipt.version) catch {};
     recordDepsFromList(deps.db, keg_id, receipt.runtime_deps);
 
+    // Tap kegs aren't reachable from the bottle DSL pipeline (its body
+    // locator only knows homebrew-core), so a `def post_install` in the
+    // tap's .rb is resolved here and either deferred onto the queue
+    // (parallel path, drained after every keg's `linkOpt`) or driven
+    // inline. Outcome routing matches the install path byte-for-byte:
+    // "completed" / "partially skipped — use --use-system-ruby" / fatal.
+    runTapPostInstallIfDefined(
+        ctx,
+        allocator,
+        deps,
+        keg_name,
+        receipt.tap,
+        receipt.version,
+        receipt.source_path,
+    );
+
     if (!has_bar) output.success("  {s} {s} migrated (from {s} tap)", .{ keg_name, receipt.version, receipt.tap });
     return .migrated;
+}
+
+/// Resolve the tap's post_install body and either queue it (so it
+/// runs after every keg's `opt/<name>/` symlink is in place) or drive
+/// it inline on the legacy single-keg path. Silent when no body is
+/// found — the formula simply has no hook.
+fn runTapPostInstallIfDefined(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    deps: MigrateDeps,
+    name: []const u8,
+    tap: []const u8,
+    version_str: []const u8,
+    receipt_source_path: []const u8,
+) void {
+    const rb_path = findTapFormulaRb(ctx.io, allocator, deps.homebrew_prefix, tap, name, receipt_source_path) orelse return;
+    defer allocator.free(rb_path);
+    const body = post_install_mod.extractRbPostInstallBody(ctx.io, allocator, rb_path) orelse return;
+    defer allocator.free(body);
+
+    if (deps.post_install_queue) |q| {
+        q.addTap(ctx.io, name, version_str, body) catch |e| {
+            output.warn("    {s}: failed to queue post_install ({s}); running inline", .{ name, @errorName(e) });
+            post_install_mod.driveTap(
+                ctx,
+                allocator,
+                name,
+                version_str,
+                body,
+                deps.prefix,
+                deps.use_system_ruby_scope,
+            );
+        };
+    } else {
+        post_install_mod.driveTap(
+            ctx,
+            allocator,
+            name,
+            version_str,
+            body,
+            deps.prefix,
+            deps.use_system_ruby_scope,
+        );
+    }
+}
+
+/// Resolve the `<name>.rb` source for a tap keg. Prefers the receipt's
+/// `source.path` (modern brew populates it for tap formulae), falling
+/// back to the canonical `Library/Taps/<user>/homebrew-<repo>/Formula/`
+/// layout — sharded first, then flat — so older receipts still hit a
+/// real file. Returns a caller-owned absolute path or null.
+pub fn findTapFormulaRb(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    homebrew_prefix: []const u8,
+    tap: []const u8,
+    name: []const u8,
+    receipt_source_path: []const u8,
+) ?[]const u8 {
+    if (receipt_source_path.len > 0 and std.mem.endsWith(u8, receipt_source_path, ".rb")) {
+        if (std.Io.Dir.accessAbsolute(io, receipt_source_path, .{})) |_| {
+            return allocator.dupe(u8, receipt_source_path) catch null;
+        } else |_| {
+            // Receipt path stale (tap moved/uninstalled) — fall through.
+        }
+    }
+
+    const slash = std.mem.indexOfScalar(u8, tap, '/') orelse return null;
+    const user = tap[0..slash];
+    const raw_repo = tap[slash + 1 ..];
+    if (user.len == 0 or raw_repo.len == 0) return null;
+    const repo = if (std.mem.startsWith(u8, raw_repo, "homebrew-"))
+        raw_repo["homebrew-".len..]
+    else
+        raw_repo;
+    if (repo.len == 0) return null;
+
+    var tap_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const tap_path = std.fmt.bufPrint(&tap_buf, "{s}/Library/Taps/{s}/homebrew-{s}", .{
+        homebrew_prefix, user, repo,
+    }) catch return null;
+
+    var rb_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const sharded = std.fmt.bufPrint(&rb_buf, "{s}/Formula/{c}/{s}.rb", .{
+        tap_path, name[0], name,
+    }) catch return null;
+    if (std.Io.Dir.accessAbsolute(io, sharded, .{})) |_| {
+        return allocator.dupe(u8, sharded) catch null;
+    } else |_| {}
+
+    const flat = std.fmt.bufPrint(&rb_buf, "{s}/Formula/{s}.rb", .{ tap_path, name }) catch return null;
+    if (std.Io.Dir.accessAbsolute(io, flat, .{})) |_| {
+        return allocator.dupe(u8, flat) catch null;
+    } else |_| {}
+
+    return null;
 }
 
 /// Locate the most recently-installed version subdir for `name` under
@@ -550,4 +662,127 @@ pub fn isInstalled(db: *sqlite.Database, name: []const u8) bool {
     defer stmt.finalize();
     stmt.bindText(1, name) catch return false;
     return stmt.step() catch false;
+}
+
+test "findTapFormulaRb prefers the receipt's source.path when it exists and ends in .rb" {
+    const dir = "/tmp/malt_taprb_src";
+    std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
+    try std.Io.Dir.createDirAbsolute(std.Options.debug_io, dir, .default_dir);
+    defer std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
+
+    const rb = dir ++ "/glow.rb";
+    const f = try std.Io.Dir.createFileAbsolute(std.Options.debug_io, rb, .{ .truncate = true });
+    f.close(std.Options.debug_io);
+
+    const got = findTapFormulaRb(
+        std.Options.debug_io,
+        std.testing.allocator,
+        "/nonexistent/brew",
+        "charmbracelet/tap",
+        "glow",
+        rb,
+    );
+    try std.testing.expect(got != null);
+    defer std.testing.allocator.free(got.?);
+    try std.testing.expectEqualStrings(rb, got.?);
+}
+
+test "findTapFormulaRb falls back to the canonical sharded tap layout when source.path is stale" {
+    const dir = "/tmp/malt_taprb_sharded";
+    std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
+
+    const formula_dir = dir ++ "/Library/Taps/charmbracelet/homebrew-tap/Formula/g";
+    try std.Io.Dir.cwd().createDirPath(std.Options.debug_io, formula_dir);
+    const rb = formula_dir ++ "/glow.rb";
+    (try std.Io.Dir.createFileAbsolute(std.Options.debug_io, rb, .{ .truncate = true }))
+        .close(std.Options.debug_io);
+
+    const got = findTapFormulaRb(
+        std.Options.debug_io,
+        std.testing.allocator,
+        dir,
+        "charmbracelet/tap",
+        "glow",
+        "/missing/path.rb",
+    );
+    try std.testing.expect(got != null);
+    defer std.testing.allocator.free(got.?);
+    try std.testing.expect(std.mem.endsWith(u8, got.?, "/Formula/g/glow.rb"));
+}
+
+test "findTapFormulaRb falls back to the flat tap layout when sharded is absent" {
+    const dir = "/tmp/malt_taprb_flat";
+    std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
+
+    const formula_dir = dir ++ "/Library/Taps/user/homebrew-private/Formula";
+    try std.Io.Dir.cwd().createDirPath(std.Options.debug_io, formula_dir);
+    const rb = formula_dir ++ "/widget.rb";
+    (try std.Io.Dir.createFileAbsolute(std.Options.debug_io, rb, .{ .truncate = true }))
+        .close(std.Options.debug_io);
+
+    const got = findTapFormulaRb(
+        std.Options.debug_io,
+        std.testing.allocator,
+        dir,
+        "user/private",
+        "widget",
+        "",
+    );
+    try std.testing.expect(got != null);
+    defer std.testing.allocator.free(got.?);
+    try std.testing.expect(std.mem.endsWith(u8, got.?, "/Formula/widget.rb"));
+}
+
+test "findTapFormulaRb does not double-prefix when the tap repo already starts with homebrew-" {
+    const dir = "/tmp/malt_taprb_no_double";
+    std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
+
+    const formula_dir = dir ++ "/Library/Taps/user/homebrew-foo/Formula/w";
+    try std.Io.Dir.cwd().createDirPath(std.Options.debug_io, formula_dir);
+    const rb = formula_dir ++ "/widget.rb";
+    (try std.Io.Dir.createFileAbsolute(std.Options.debug_io, rb, .{ .truncate = true }))
+        .close(std.Options.debug_io);
+
+    const got = findTapFormulaRb(
+        std.Options.debug_io,
+        std.testing.allocator,
+        dir,
+        "user/homebrew-foo",
+        "widget",
+        "",
+    );
+    try std.testing.expect(got != null);
+    defer std.testing.allocator.free(got.?);
+    try std.testing.expect(std.mem.indexOf(u8, got.?, "/homebrew-foo/") != null);
+    try std.testing.expect(std.mem.indexOf(u8, got.?, "/homebrew-homebrew-") == null);
+}
+
+test "findTapFormulaRb returns null when neither the receipt path nor the canonical layout exists" {
+    const dir = "/tmp/malt_taprb_none";
+    std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
+    try std.Io.Dir.createDirAbsolute(std.Options.debug_io, dir, .default_dir);
+    defer std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
+
+    try std.testing.expect(findTapFormulaRb(
+        std.Options.debug_io,
+        std.testing.allocator,
+        dir,
+        "charmbracelet/tap",
+        "glow",
+        "",
+    ) == null);
+}
+
+test "findTapFormulaRb refuses a malformed tap (missing slash) instead of guessing a path" {
+    try std.testing.expect(findTapFormulaRb(
+        std.Options.debug_io,
+        std.testing.allocator,
+        "/tmp/malt_taprb_bad",
+        "noslash",
+        "glow",
+        "",
+    ) == null);
 }

--- a/src/cli/migrate/post_install_queue.zig
+++ b/src/cli/migrate/post_install_queue.zig
@@ -19,10 +19,26 @@ const std = @import("std");
 const post_install_mod = @import("../install/post_install.zig");
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
 
-pub const Task = struct {
+/// Two queueable shapes share the same FIFO and drain so order across
+/// bottle and tap kegs is preserved (fc-cache races care about
+/// link-time order, not source-of-truth shape).
+pub const Task = union(enum) {
+    bottle: BottlePayload,
+    tap: TapPayload,
+};
+
+pub const BottlePayload = struct {
     name: []u8,
     pkg_version: []u8,
     formula_json: []u8,
+};
+
+pub const TapPayload = struct {
+    name: []u8,
+    pkg_version: []u8,
+    /// Body extracted from the tap's `<name>.rb`; the homebrew-core
+    /// locator never sees this path, so we resolve at queue time.
+    post_install_src: []u8,
 };
 
 /// Thread-safe queue: parallel workers `add`, the main thread `drain`s
@@ -38,16 +54,23 @@ pub const Queue = struct {
     }
 
     pub fn deinit(self: *Queue) void {
-        for (self.tasks.items) |t| {
-            self.allocator.free(t.name);
-            self.allocator.free(t.pkg_version);
-            self.allocator.free(t.formula_json);
-        }
+        for (self.tasks.items) |t| switch (t) {
+            .bottle => |b| {
+                self.allocator.free(b.name);
+                self.allocator.free(b.pkg_version);
+                self.allocator.free(b.formula_json);
+            },
+            .tap => |tp| {
+                self.allocator.free(tp.name);
+                self.allocator.free(tp.pkg_version);
+                self.allocator.free(tp.post_install_src);
+            },
+        };
         self.tasks.deinit(self.allocator);
     }
 
-    /// Enqueue a post_install request. Dupes inputs into the queue's
-    /// allocator so the caller's arena is free to die. Thread-safe.
+    /// Enqueue a bottle-path post_install request. Dupes inputs into
+    /// the queue's allocator so the caller's arena is free to die.
     pub fn add(
         self: *Queue,
         io: std.Io,
@@ -65,32 +88,69 @@ pub const Queue = struct {
         const owned_json = try self.allocator.dupe(u8, formula_json);
         errdefer self.allocator.free(owned_json);
 
-        try self.tasks.append(self.allocator, .{
+        try self.tasks.append(self.allocator, .{ .bottle = .{
             .name = owned_name,
             .pkg_version = owned_ver,
             .formula_json = owned_json,
-        });
+        } });
+    }
+
+    /// Enqueue a tap-fallback post_install request. Caller owns the
+    /// pre-extracted body until this returns; the queue dupes it.
+    pub fn addTap(
+        self: *Queue,
+        io: std.Io,
+        name: []const u8,
+        pkg_version: []const u8,
+        post_install_src: []const u8,
+    ) !void {
+        self.mu.lockUncancelable(io);
+        defer self.mu.unlock(io);
+
+        const owned_name = try self.allocator.dupe(u8, name);
+        errdefer self.allocator.free(owned_name);
+        const owned_ver = try self.allocator.dupe(u8, pkg_version);
+        errdefer self.allocator.free(owned_ver);
+        const owned_src = try self.allocator.dupe(u8, post_install_src);
+        errdefer self.allocator.free(owned_src);
+
+        try self.tasks.append(self.allocator, .{ .tap = .{
+            .name = owned_name,
+            .pkg_version = owned_ver,
+            .post_install_src = owned_src,
+        } });
     }
 
     /// Run every queued post_install through the install module's
-    /// `drive`. Single-threaded; called once after migration finishes.
+    /// `drive`/`driveTap`. Single-threaded; called once after migration
+    /// finishes so every `opt/<name>/` symlink is in place before any
+    /// hook fires.
     pub fn drain(
         self: *Queue,
         ctx: *const AppCtx,
         prefix: []const u8,
         use_system_ruby_scope: []const []const u8,
     ) void {
-        for (self.tasks.items) |t| {
-            post_install_mod.drive(
+        for (self.tasks.items) |t| switch (t) {
+            .bottle => |b| post_install_mod.drive(
                 ctx,
                 self.allocator,
-                t.name,
-                t.pkg_version,
-                t.formula_json,
+                b.name,
+                b.pkg_version,
+                b.formula_json,
                 prefix,
                 use_system_ruby_scope,
-            );
-        }
+            ),
+            .tap => |tp| post_install_mod.driveTap(
+                ctx,
+                self.allocator,
+                tp.name,
+                tp.pkg_version,
+                tp.post_install_src,
+                prefix,
+                use_system_ruby_scope,
+            ),
+        };
     }
 
     /// Snapshot of queued task count — `pub` so tests can pin enqueue
@@ -116,9 +176,24 @@ test "Queue.add dupes inputs and survives caller-arena destruction" {
     }
 
     try std.testing.expectEqual(@as(usize, 1), q.len());
-    try std.testing.expectEqualStrings("fontconfig", q.tasks.items[0].name);
-    try std.testing.expectEqualStrings("2.17.1", q.tasks.items[0].pkg_version);
-    try std.testing.expectEqualStrings("{\"name\":\"fontconfig\"}", q.tasks.items[0].formula_json);
+    const t = q.tasks.items[0].bottle;
+    try std.testing.expectEqualStrings("fontconfig", t.name);
+    try std.testing.expectEqualStrings("2.17.1", t.pkg_version);
+    try std.testing.expectEqualStrings("{\"name\":\"fontconfig\"}", t.formula_json);
+}
+
+test "Queue.addTap dupes inputs and tags the task as tap-sourced" {
+    const a = std.testing.allocator;
+    var q = Queue.init(a);
+    defer q.deinit();
+
+    try q.addTap(std.Options.debug_io, "glow", "0.2.2", "bin.install \"glow\"\n");
+
+    try std.testing.expectEqual(@as(usize, 1), q.len());
+    const t = q.tasks.items[0].tap;
+    try std.testing.expectEqualStrings("glow", t.name);
+    try std.testing.expectEqualStrings("0.2.2", t.pkg_version);
+    try std.testing.expectEqualStrings("bin.install \"glow\"\n", t.post_install_src);
 }
 
 test "Queue.add preserves enqueue order across multiple tasks" {
@@ -131,9 +206,24 @@ test "Queue.add preserves enqueue order across multiple tasks" {
     try q.add(std.Options.debug_io, "third", "3.0", "{}");
 
     try std.testing.expectEqual(@as(usize, 3), q.len());
-    try std.testing.expectEqualStrings("first", q.tasks.items[0].name);
-    try std.testing.expectEqualStrings("second", q.tasks.items[1].name);
-    try std.testing.expectEqualStrings("third", q.tasks.items[2].name);
+    try std.testing.expectEqualStrings("first", q.tasks.items[0].bottle.name);
+    try std.testing.expectEqualStrings("second", q.tasks.items[1].bottle.name);
+    try std.testing.expectEqualStrings("third", q.tasks.items[2].bottle.name);
+}
+
+test "Queue interleaves bottle and tap tasks in enqueue order" {
+    const a = std.testing.allocator;
+    var q = Queue.init(a);
+    defer q.deinit();
+
+    try q.add(std.Options.debug_io, "first", "1.0", "{}");
+    try q.addTap(std.Options.debug_io, "second", "2.0", "src");
+    try q.add(std.Options.debug_io, "third", "3.0", "{}");
+
+    try std.testing.expectEqual(@as(usize, 3), q.len());
+    try std.testing.expectEqualStrings("first", q.tasks.items[0].bottle.name);
+    try std.testing.expectEqualStrings("second", q.tasks.items[1].tap.name);
+    try std.testing.expectEqualStrings("third", q.tasks.items[2].bottle.name);
 }
 
 test "Queue.add serialises concurrent producers without losing tasks" {

--- a/src/core/install_receipt.zig
+++ b/src/core/install_receipt.zig
@@ -15,6 +15,10 @@ pub const Receipt = struct {
     /// `source.versions.stable`. Authoritative version for routing
     /// + DB recording. Empty when absent.
     version: []const u8,
+    /// `source.path` — for tap formulae this is the absolute on-disk
+    /// path to the `<name>.rb` source; for `homebrew/core` modern brew
+    /// stores the API JWS cache path here instead. Empty when absent.
+    source_path: []const u8,
     /// `runtime_dependencies[*].full_name`. Order preserved.
     runtime_deps: []const []const u8,
 
@@ -85,6 +89,16 @@ pub fn parseInstallReceipt(parent: std.mem.Allocator, json_text: []const u8) Par
         }
     };
 
+    const source_path = blk: {
+        const src = source_obj orelse break :blk "";
+        const v = src.get("path") orelse break :blk "";
+        switch (v) {
+            .string => |s| break :blk a.dupe(u8, s) catch return ParseError.OutOfMemory,
+            .null => break :blk "",
+            else => break :blk "",
+        }
+    };
+
     const deps = blk: {
         const v = root.get("runtime_dependencies") orelse break :blk &[_][]const u8{};
         const arr = switch (v) {
@@ -111,6 +125,7 @@ pub fn parseInstallReceipt(parent: std.mem.Allocator, json_text: []const u8) Par
     return .{
         .tap = tap,
         .version = version,
+        .source_path = source_path,
         .runtime_deps = deps,
         .arena = arena,
     };
@@ -159,12 +174,31 @@ test "parseInstallReceipt extracts tap, stable version, and runtime_dependencies
     try std.testing.expectEqualStrings("zlib", r.runtime_deps[1]);
 }
 
+test "parseInstallReceipt extracts source.path so the migrate fallback can find the tap's .rb" {
+    const src =
+        \\{
+        \\  "source": {
+        \\    "tap": "charmbracelet/tap",
+        \\    "path": "/opt/homebrew/Library/Taps/charmbracelet/homebrew-tap/Formula/glow.rb",
+        \\    "versions": {"stable": "0.2.2"}
+        \\  }
+        \\}
+    ;
+    var r = try parseInstallReceipt(std.testing.allocator, src);
+    defer r.deinit();
+    try std.testing.expectEqualStrings(
+        "/opt/homebrew/Library/Taps/charmbracelet/homebrew-tap/Formula/glow.rb",
+        r.source_path,
+    );
+}
+
 test "parseInstallReceipt tolerates missing optional fields" {
     const src = "{\"source\": {}}";
     var r = try parseInstallReceipt(std.testing.allocator, src);
     defer r.deinit();
     try std.testing.expectEqualStrings("", r.tap);
     try std.testing.expectEqualStrings("", r.version);
+    try std.testing.expectEqualStrings("", r.source_path);
     try std.testing.expectEqual(@as(usize, 0), r.runtime_deps.len);
 }
 

--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -513,20 +513,10 @@ pub fn runPostInstall(
     version: []const u8,
     prefix: []const u8,
 ) RubyError!void {
-    // 0. Validate inputs at the boundary. A hostile Cellar dir name (the
-    //    on-disk source of `name` on the runPostInstall path) must die
-    //    here, not deeper in script generation or the sandbox spawn.
-    if (prefix.len == 0 or name.len == 0 or version.len == 0) return RubyError.InvalidInput;
-    for (prefix) |b| if (!fs_atomic.isAllowedPrefixByte(b)) return RubyError.InvalidInput;
-    for (name) |b| if (!fs_atomic.isAllowedNameByte(b)) return RubyError.InvalidInput;
-    for (version) |b| if (!fs_atomic.isAllowedNameByte(b)) return RubyError.InvalidInput;
-
-    // Core returns outcomes; UI renders at the boundary — the CLI caller
-    // maps each RubyError variant to user-facing text.
-
-    // 1. Find Ruby (caller-owned heap slice — see detectRuby contract).
-    const ruby_path = detectRuby(io, environ, allocator) orelse return RubyError.RubyNotFound;
-    defer allocator.free(ruby_path);
+    // 0. Boundary validation — must run before body resolution so a
+    //    hostile name can't reach `fetchPostInstallFromGitHub` (which
+    //    performs its own check but only after a network round-trip).
+    try validateRunPostInstallInputs(name, version, prefix);
 
     // 2-4. Resolve the post_install body. Local homebrew-core tap is
     //      preferred; hash-pinned GitHub fetch is the fallback so
@@ -534,6 +524,41 @@ pub fn runPostInstall(
     const body = resolvePostInstallBody(io, environ, allocator, name) orelse
         return RubyError.TapNotFound;
     defer allocator.free(body);
+    return runPostInstallWithBody(io, environ, allocator, name, version, prefix, body);
+}
+
+fn validateRunPostInstallInputs(name: []const u8, version: []const u8, prefix: []const u8) RubyError!void {
+    if (prefix.len == 0 or name.len == 0 or version.len == 0) return RubyError.InvalidInput;
+    for (prefix) |b| if (!fs_atomic.isAllowedPrefixByte(b)) return RubyError.InvalidInput;
+    for (name) |b| if (!fs_atomic.isAllowedNameByte(b)) return RubyError.InvalidInput;
+    for (version) |b| if (!fs_atomic.isAllowedNameByte(b)) return RubyError.InvalidInput;
+}
+
+/// Tap-aware variant: caller has already extracted the post_install
+/// body from the tap's `<name>.rb` (homebrew-core's locator can't reach
+/// non-core taps). Skips body resolution; everything else mirrors
+/// `runPostInstall` exactly so the sandbox + script-write contract
+/// stays a single source of truth.
+pub fn runPostInstallWithBody(
+    io: std.Io,
+    environ: std.process.Environ,
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    version: []const u8,
+    prefix: []const u8,
+    body: []const u8,
+) RubyError!void {
+    // 0. Validate inputs at the boundary. A hostile Cellar dir name (the
+    //    on-disk source of `name` on the runPostInstall path) must die
+    //    here, not deeper in script generation or the sandbox spawn.
+    try validateRunPostInstallInputs(name, version, prefix);
+
+    // Core returns outcomes; UI renders at the boundary — the CLI caller
+    // maps each RubyError variant to user-facing text.
+
+    // 1. Find Ruby (caller-owned heap slice — see detectRuby contract).
+    const ruby_path = detectRuby(io, environ, allocator) orelse return RubyError.RubyNotFound;
+    defer allocator.free(ruby_path);
 
     // 5. Generate wrapper script
     const script = generateWrapper(allocator, name, version, prefix, body) catch

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -2080,3 +2080,268 @@ test "dry-run with 4 kegs under testing.allocator shows zero leaks" {
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = malt.app_ctx.processEnviron() };
     try migrate.execute(&ctx, testing.allocator, &.{ "--dry-run", "--quiet" });
 }
+
+// ── Tap-fallback post_install execution ─────────────────────────────────
+//
+// migrateFromLocalCellar runs when the brew API has no record of a keg
+// (private/third-party tap). Tap kegs aren't reachable from the bottle
+// DSL pipeline's locator, so the fallback resolves the body straight
+// off the tap's `<name>.rb` and feeds it to the same DSL +
+// FallbackLog → outcome routing the install path uses. A trivially-
+// empty body should land on the "completed" branch.
+
+test "tap fallback runs the DSL post_install body and reports completion" {
+    resetOutput();
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    const brew = try scratchDir("brew_tap_pi");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, brew) catch {};
+        testing.allocator.free(brew);
+    }
+
+    // ≤13 bytes — same Mach-O patching budget the sister tests rely on.
+    const mt_z: [:0]const u8 = "/tmp/mt_tpi";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, mt_z) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, mt_z);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, mt_z) catch {};
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Source Cellar keg dir + receipt with non-core tap so the fallback
+    // accepts the local copy and source.path so we exercise the receipt
+    // branch in findTapFormulaRb. Body is a no-op so the DSL run lands
+    // cleanly on the "completed" branch.
+    const tap_rb = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/Library/Taps/owner/homebrew-tap/Formula/g/glow.rb",
+        .{brew},
+    );
+    defer testing.allocator.free(tap_rb);
+    const tap_dir = std.fs.path.dirname(tap_rb).?;
+    try test_io.cwd().createDirPath(std.Options.debug_io, tap_dir);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, tap_rb, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io,
+            \\class Glow < Formula
+            \\  url "x"
+            \\  def post_install
+            \\    # no-op; pins the completed-DSL outcome path
+            \\  end
+            \\end
+            \\
+        );
+    }
+
+    const keg_dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/glow/0.2.2", .{brew});
+    defer testing.allocator.free(keg_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, keg_dir);
+    const receipt_path = try std.fmt.allocPrint(testing.allocator, "{s}/INSTALL_RECEIPT.json", .{keg_dir});
+    defer testing.allocator.free(receipt_path);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, receipt_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        const body = try std.fmt.allocPrint(
+            testing.allocator,
+            "{{\"source\":{{\"tap\":\"owner/tap\",\"path\":\"{s}\",\"versions\":{{\"stable\":\"0.2.2\"}}}}}}",
+            .{tap_rb},
+        );
+        defer testing.allocator.free(body);
+        try f.writeStreamingAll(std.Options.debug_io, body);
+    }
+
+    // 404 marker forces fetchFormula → error.NotFound, routing the keg
+    // into the local-Cellar fallback offline.
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{mt_z});
+    defer testing.allocator.free(cache_api);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_api);
+    const marker = try std.fmt.allocPrint(testing.allocator, "{s}/formula_glow.404", .{cache_api});
+    defer testing.allocator.free(marker);
+    (try test_io.createFileAbsolute(std.Options.debug_io, marker, .{})).close(std.Options.debug_io);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &stderr_buf);
+    defer io_mod.endStderrCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = malt.app_ctx.processEnviron() };
+    try migrate.execute(&ctx, arena.allocator(), &.{});
+
+    try testing.expect(containsLine(stderr_buf.items, "post_install completed for glow"));
+    try testing.expect(!containsLine(stderr_buf.items, "post_install partially skipped"));
+}
+
+test "tap fallback partial-DSL emits the --use-system-ruby hint same as install" {
+    resetOutput();
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    const brew = try scratchDir("brew_tap_partial");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, brew) catch {};
+        testing.allocator.free(brew);
+    }
+
+    const mt_z: [:0]const u8 = "/tmp/mt_tpp";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, mt_z) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, mt_z);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, mt_z) catch {};
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Body calls a helper the DSL doesn't speak — FallbackLog records
+    // unknown_method, router downgrades to "partially skipped".
+    const tap_rb = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/Library/Taps/owner/homebrew-tap/Formula/g/gizmo.rb",
+        .{brew},
+    );
+    defer testing.allocator.free(tap_rb);
+    const tap_dir = std.fs.path.dirname(tap_rb).?;
+    try test_io.cwd().createDirPath(std.Options.debug_io, tap_dir);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, tap_rb, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io,
+            \\class Gizmo < Formula
+            \\  url "x"
+            \\  def post_install
+            \\    not_a_dsl_helper(prefix)
+            \\  end
+            \\end
+            \\
+        );
+    }
+
+    const keg_dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/gizmo/1.0", .{brew});
+    defer testing.allocator.free(keg_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, keg_dir);
+    const receipt_path = try std.fmt.allocPrint(testing.allocator, "{s}/INSTALL_RECEIPT.json", .{keg_dir});
+    defer testing.allocator.free(receipt_path);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, receipt_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        const body = try std.fmt.allocPrint(
+            testing.allocator,
+            "{{\"source\":{{\"tap\":\"owner/tap\",\"path\":\"{s}\",\"versions\":{{\"stable\":\"1.0\"}}}}}}",
+            .{tap_rb},
+        );
+        defer testing.allocator.free(body);
+        try f.writeStreamingAll(std.Options.debug_io, body);
+    }
+
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{mt_z});
+    defer testing.allocator.free(cache_api);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_api);
+    const marker = try std.fmt.allocPrint(testing.allocator, "{s}/formula_gizmo.404", .{cache_api});
+    defer testing.allocator.free(marker);
+    (try test_io.createFileAbsolute(std.Options.debug_io, marker, .{})).close(std.Options.debug_io);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &stderr_buf);
+    defer io_mod.endStderrCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = malt.app_ctx.processEnviron() };
+    try migrate.execute(&ctx, arena.allocator(), &.{});
+
+    try testing.expect(containsLine(stderr_buf.items, "post_install partially skipped"));
+    try testing.expect(containsLine(stderr_buf.items, "use --use-system-ruby=gizmo"));
+}
+
+test "tap fallback stays silent when the tap formula has no post_install" {
+    resetOutput();
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    const brew = try scratchDir("brew_tap_no_pi");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, brew) catch {};
+        testing.allocator.free(brew);
+    }
+
+    const mt_z: [:0]const u8 = "/tmp/mt_tnp";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, mt_z) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, mt_z);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, mt_z) catch {};
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const tap_rb = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/Library/Taps/owner/homebrew-tap/Formula/q/quiet.rb",
+        .{brew},
+    );
+    defer testing.allocator.free(tap_rb);
+    const tap_dir = std.fs.path.dirname(tap_rb).?;
+    try test_io.cwd().createDirPath(std.Options.debug_io, tap_dir);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, tap_rb, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io,
+            \\class Quiet < Formula
+            \\  url "x"
+            \\end
+            \\
+        );
+    }
+
+    const keg_dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/quiet/1.0", .{brew});
+    defer testing.allocator.free(keg_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, keg_dir);
+    const receipt_path = try std.fmt.allocPrint(testing.allocator, "{s}/INSTALL_RECEIPT.json", .{keg_dir});
+    defer testing.allocator.free(receipt_path);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, receipt_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        const body = try std.fmt.allocPrint(
+            testing.allocator,
+            "{{\"source\":{{\"tap\":\"owner/tap\",\"path\":\"{s}\",\"versions\":{{\"stable\":\"1.0\"}}}}}}",
+            .{tap_rb},
+        );
+        defer testing.allocator.free(body);
+        try f.writeStreamingAll(std.Options.debug_io, body);
+    }
+
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{mt_z});
+    defer testing.allocator.free(cache_api);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_api);
+    const marker = try std.fmt.allocPrint(testing.allocator, "{s}/formula_quiet.404", .{cache_api});
+    defer testing.allocator.free(marker);
+    (try test_io.createFileAbsolute(std.Options.debug_io, marker, .{})).close(std.Options.debug_io);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &stderr_buf);
+    defer io_mod.endStderrCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = malt.app_ctx.processEnviron() };
+    try migrate.execute(&ctx, arena.allocator(), &.{});
+
+    // No body in the .rb means no DSL run and no router output for this
+    // keg — the absence of every post_install line is the contract.
+    try testing.expect(!containsLine(stderr_buf.items, "post_install"));
+}


### PR DESCRIPTION
## Description

Tap kegs migrated through the copy-from-Cellar fallback were silently skipping their `post_install` hook even when the formula declared one - the keg looked migrated but font caches, GIO modules, ruby gems and friends never got regenerated. The fallback now runs the hook on the same DSL pipeline the install path uses, so users get the familiar `post_install completed for <name>` line on success and the same `--use-system-ruby=<name>` hint when malt's interpreter trips on a helper it doesn't speak yet. `--use-system-ruby` works end-to-end against tap kegs too: the Ruby subprocess is fed the body extracted from the tap's local `.rb` instead of the homebrew-core-only locator that previously refused them. Bottle path behaviour is unchanged.

## Related Issue

- None

## Notes for Reviewers

- None