### PR TITLE
fix(migrate/parallel): distinguish cancelled kegs from already-installed ones

### DIFF
--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -168,6 +168,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
                     &.{},
                     &.{},
                     &.{},
+                    &.{},
                     start_ts,
                 );
             }
@@ -271,6 +272,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     defer skipped_no_bottle_names.deinit(allocator);
     var failed_names: std.ArrayList([]const u8) = .empty;
     defer failed_names.deinit(allocator);
+    var cancelled_names: std.ArrayList([]const u8) = .empty;
+    defer cancelled_names.deinit(allocator);
 
     // Honour Ctrl-C raised during setup, before any network work starts.
     const main_mod = @import("../main.zig");
@@ -307,8 +310,10 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
         const outcomes = try allocator.alloc(parallel_mod.KegOutcome, keg_names.items.len);
         defer allocator.free(outcomes);
-        // Pre-populated so an interrupted/short-circuited slot still has a defined outcome.
-        for (outcomes, 0..) |*o, i| o.* = .{ .name = keg_names.items[i], .result = .skipped_installed };
+        // Pre-populated so an interrupted/short-circuited slot still has a
+        // defined outcome — `.cancelled` so untouched kegs surface as
+        // "you cancelled before I touched it" rather than "I had it already".
+        for (outcomes, 0..) |*o, i| o.* = .{ .name = keg_names.items[i], .result = .cancelled };
 
         // Pre-filter manifest+DB-confirmed skips so the multi-progress
         // line count matches actual work — drawing a "✓" for kegs that
@@ -386,6 +391,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
                 .skipped_post_install => try skipped_post_install_names.append(allocator, o.name),
                 .skipped_no_bottle => try skipped_no_bottle_names.append(allocator, o.name),
                 .failed_api, .failed_download, .failed_install => try failed_names.append(allocator, o.name),
+                .cancelled => try cancelled_names.append(allocator, o.name),
             }
         }
     } else {
@@ -454,6 +460,9 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
                 .skipped_post_install => try skipped_post_install_names.append(allocator, keg_name),
                 .skipped_no_bottle => try skipped_no_bottle_names.append(allocator, keg_name),
                 .failed_api, .failed_download, .failed_install => try failed_names.append(allocator, keg_name),
+                // The serial loop exits on Ctrl-C before migrateKeg ever
+                // returns; this arm exists only so the switch stays exhaustive.
+                .cancelled => try cancelled_names.append(allocator, keg_name),
             }
         }
     }
@@ -490,6 +499,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             skipped_post_install_names.items,
             skipped_no_bottle_names.items,
             failed_names.items,
+            cancelled_names.items,
             start_ts,
         );
         return;
@@ -500,6 +510,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     const skipped: u32 = @intCast(skipped_installed_names.items.len + skipped_no_bottle_names.items.len);
     const skipped_post_install: u32 = @intCast(skipped_post_install_names.items.len);
     const failed: u32 = @intCast(failed_names.items.len);
+    const cancelled: u32 = @intCast(cancelled_names.items.len);
 
     output.plain("", .{});
     if (failed == 0) {
@@ -510,6 +521,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     output.info("Migrated: {d}", .{migrated});
     if (skipped > 0)
         output.info("Skipped (installed): {d}", .{skipped});
+    if (cancelled > 0)
+        output.info("Cancelled: {d}", .{cancelled});
     if (skipped_post_install > 0) {
         output.warn("Skipped (post_install): {d}", .{skipped_post_install});
         for (skipped_post_install_names.items) |name| {
@@ -589,6 +602,7 @@ fn emitSummaryJson(
     skipped_post_install_names: []const []const u8,
     skipped_no_bottle_names: []const []const u8,
     failed_names: []const []const u8,
+    cancelled_names: []const []const u8,
     start_ts: i64,
 ) !void {
     var aw: std.Io.Writer.Allocating = .init(allocator);
@@ -601,6 +615,7 @@ fn emitSummaryJson(
         skipped_post_install_names,
         skipped_no_bottle_names,
         failed_names,
+        cancelled_names,
         output.drainPostInstallEvents(),
         start_ts,
     );
@@ -640,6 +655,7 @@ pub fn buildSummaryJson(
     skipped_post_install_names: []const []const u8,
     skipped_no_bottle_names: []const []const u8,
     failed_names: []const []const u8,
+    cancelled_names: []const []const u8,
     post_install_events: []const []const u8,
     start_ts: i64,
 ) !void {
@@ -655,22 +671,25 @@ pub fn buildSummaryJson(
     try output.jsonStringArray(w, skipped_no_bottle_names);
     try w.writeAll(",\"failed\":");
     try output.jsonStringArray(w, failed_names);
+    try w.writeAll(",\"cancelled\":");
+    try output.jsonStringArray(w, cancelled_names);
     try w.writeAll(",\"post_install_events\":[");
     for (post_install_events, 0..) |entry, i| {
         if (i > 0) try w.writeAll(",");
         try w.writeAll(entry);
     }
     try w.writeAll("]");
-    var counts_buf: [256]u8 = undefined;
+    var counts_buf: [320]u8 = undefined;
     const counts = try std.fmt.bufPrint(
         &counts_buf,
-        ",\"counts\":{{\"migrated\":{d},\"skipped_installed\":{d},\"skipped_post_install\":{d},\"skipped_no_bottle\":{d},\"failed\":{d}}}",
+        ",\"counts\":{{\"migrated\":{d},\"skipped_installed\":{d},\"skipped_post_install\":{d},\"skipped_no_bottle\":{d},\"failed\":{d},\"cancelled\":{d}}}",
         .{
             migrated_names.len,
             skipped_installed_names.len,
             skipped_post_install_names.len,
             skipped_no_bottle_names.len,
             failed_names.len,
+            cancelled_names.len,
         },
     );
     try w.writeAll(counts);

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -21,7 +21,9 @@ const post_install_mod = @import("../install/post_install.zig");
 const post_install_queue_mod = @import("post_install_queue.zig");
 const install_receipt_mod = @import("../../core/install_receipt.zig");
 
-/// Result of migrating a single keg.
+/// Result of migrating a single keg. `cancelled` marks slots a worker
+/// never reached because SIGINT raced ahead — distinct from
+/// `skipped_installed` (the keg was already migrated).
 pub const KegResult = enum {
     migrated,
     skipped_installed,
@@ -30,6 +32,7 @@ pub const KegResult = enum {
     failed_api,
     failed_download,
     failed_install,
+    cancelled,
 };
 
 /// Named-field bundle for the shared state `migrateKeg` threads across

--- a/src/cli/migrate/parallel.zig
+++ b/src/cli/migrate/parallel.zig
@@ -102,11 +102,10 @@ fn worker(pool: *Pool) void {
         else
             null;
 
-        if (main_mod.isInterrupted()) {
-            pool.outcomes[idx] = .{ .name = keg_name, .result = .skipped_installed };
-            continue;
-        }
-
+        // Manifest+DB check runs before the interrupt check so a keg that
+        // was already installed surfaces as `.skipped_installed` even when
+        // Ctrl-C fires mid-run; reversing the order would demote real
+        // skips to `.cancelled` and lie about on-disk state.
         pool.manifest_mu.lockUncancelable(io);
         const in_manifest = pool.manifest.contains(keg_name);
         pool.manifest_mu.unlock(io);
@@ -114,6 +113,11 @@ fn worker(pool: *Pool) void {
         // uninstall` — see the matching note in cli/migrate.zig.
         if (in_manifest and keg_mod.isInstalled(pool.db, keg_name)) {
             pool.outcomes[idx] = .{ .name = keg_name, .result = .skipped_installed };
+            continue;
+        }
+
+        if (main_mod.isInterrupted()) {
+            pool.outcomes[idx] = .{ .name = keg_name, .result = .cancelled };
             continue;
         }
 
@@ -215,4 +219,48 @@ test "boundWorkerCount caps by job count" {
     try std.testing.expectEqual(@as(u32, 2), boundWorkerCount(4, 2));
     try std.testing.expectEqual(@as(u32, 4), boundWorkerCount(4, 10));
     try std.testing.expectEqual(@as(u32, 0), boundWorkerCount(4, 0));
+}
+
+// Pre-set SIGINT with an empty manifest: every slot falls through the
+// manifest+DB short-circuit and lands on the interrupt arm, so the
+// summary can tell "you cancelled before I touched it" from "I had it
+// already." The DB pointer stays `undefined` because the empty manifest
+// short-circuits the `and` before any DB query runs.
+test "worker interrupt branch routes untouched kegs to .cancelled" {
+    main_mod.setInterruptedForTest(true);
+    defer main_mod.setInterruptedForTest(false);
+
+    const app_ctx_mod = @import("../../app_ctx.zig");
+    const names = [_][]const u8{ "a", "b", "c" };
+    var outcomes: [names.len]KegOutcome = undefined;
+    for (&outcomes, 0..) |*o, i| o.* = .{ .name = names[i], .result = .cancelled };
+
+    var manifest = manifest_mod.Manifest.init(std.testing.allocator);
+    defer manifest.deinit();
+    var manifest_mu: std.Io.Mutex = .init;
+    var db_mu: std.Io.Mutex = .init;
+
+    var pool: Pool = .{
+        .app_ctx = &app_ctx_mod.debug_ctx,
+        .next_idx = std.atomic.Value(usize).init(0),
+        .keg_names = &names,
+        .outcomes = &outcomes,
+        .cache_dir = "",
+        .prefix = "",
+        .homebrew_prefix = "",
+        .use_system_ruby_scope = &.{},
+        .http_pool = undefined,
+        .store = undefined,
+        .linker = undefined,
+        .db = undefined,
+        .db_mu = &db_mu,
+        .manifest = &manifest,
+        .manifest_mu = &manifest_mu,
+        .manifest_path = "",
+        .manifest_allocator = std.testing.allocator,
+        .post_install_queue = undefined,
+    };
+    try run(std.testing.allocator, &pool, 2);
+
+    for (outcomes) |o| try std.testing.expectEqual(keg_mod.KegResult.cancelled, o.result);
 }

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -431,6 +431,7 @@ test "buildSummaryJson emits per-category arrays + counts object" {
         &.{"fancy-keg"},
         &.{},
         &.{"brokenpkg"},
+        &.{"untouched"},
         &.{},
         0,
     );
@@ -447,6 +448,8 @@ test "buildSummaryJson emits per-category arrays + counts object" {
     try testing.expectEqual(@as(usize, 0), root.get("skipped_no_bottle").?.array.items.len);
     try testing.expectEqual(@as(usize, 1), root.get("failed").?.array.items.len);
     try testing.expectEqualStrings("brokenpkg", root.get("failed").?.array.items[0].string);
+    try testing.expectEqual(@as(usize, 1), root.get("cancelled").?.array.items.len);
+    try testing.expectEqualStrings("untouched", root.get("cancelled").?.array.items[0].string);
 
     const counts = root.get("counts").?.object;
     try testing.expectEqual(@as(i64, 2), counts.get("migrated").?.integer);
@@ -454,6 +457,7 @@ test "buildSummaryJson emits per-category arrays + counts object" {
     try testing.expectEqual(@as(i64, 1), counts.get("skipped_post_install").?.integer);
     try testing.expectEqual(@as(i64, 0), counts.get("skipped_no_bottle").?.integer);
     try testing.expectEqual(@as(i64, 1), counts.get("failed").?.integer);
+    try testing.expectEqual(@as(i64, 1), counts.get("cancelled").?.integer);
 }
 
 // Under `--json`, post_install events land inside the summary doc
@@ -472,6 +476,7 @@ test "buildSummaryJson embeds post_install_events when buffer has entries" {
         &aw.writer,
         "/opt/homebrew",
         &.{ "ca-certificates", "openssl@3" },
+        &.{},
         &.{},
         &.{},
         &.{},
@@ -507,6 +512,7 @@ test "buildSummaryJson emits an empty post_install_events array when buffer is e
         &.{},
         &.{},
         &.{},
+        &.{},
         0,
     );
 
@@ -520,7 +526,7 @@ test "buildSummaryJson escapes adversarial keg names per RFC 8259" {
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
     const names = [_][]const u8{"weird\"\\keg"};
-    try migrate.buildSummaryJson(&aw.writer, "/opt/homebrew", &names, &.{}, &.{}, &.{}, &.{}, &.{}, 0);
+    try migrate.buildSummaryJson(&aw.writer, "/opt/homebrew", &names, &.{}, &.{}, &.{}, &.{}, &.{}, &.{}, 0);
 
     const parsed = try parseAndCheck(aw.written());
     defer parsed.deinit();


### PR DESCRIPTION
## Description

When `mt migrate --parallel` is interrupted with Ctrl-C, every keg the workers had not yet touched was being reported as `Skipped (installed)` in the human summary and `skipped_installed[]` in the JSON document - the JSON contract could not tell scripts whether a keg was ignored because it was already up-to-date or because the user cancelled the run.

A new `cancelled` outcome bucket captures that distinction, surfaced as a `Cancelled: N` line in the human summary and a `cancelled[]` array (plus matching `counts.cancelled`) in the JSON summary. The worker now resolves manifest+DB-installed kegs before checking the interrupt flag, so a genuinely-installed keg still reports as `skipped_installed` even when the run is cancelled mid-flight.

## Related Issue

- None

## Notes for Reviewers

- None