### PR TITLE
perf(install/post_install): reuse the install path's FormulaCache

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -710,7 +710,7 @@ fn executeWithOpts(
         };
 
         if (job.post_install_defined) {
-            drive(ctx, allocator, job.name, job.version_str, job.formula_json, prefix, use_system_ruby_list);
+            drive(ctx, allocator, job.name, job.version_str, job.formula_json, prefix, use_system_ruby_list, &formula_cache);
         }
     }
 

--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -6,6 +6,7 @@
 
 const std = @import("std");
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
+const deps_mod = @import("../../core/deps.zig");
 const formula_mod = @import("../../core/formula.zig");
 const dsl = @import("../../core/dsl/root.zig");
 const ruby_sub = @import("../../core/ruby_subprocess.zig");
@@ -229,6 +230,11 @@ pub const DslPostInstallOutcome = enum {
 ///
 /// Narrow inputs (name + version + json bytes) keep migrate decoupled
 /// from install's `DownloadJob` shape.
+///
+/// `cache`, when non-null, is the install pipeline's per-run
+/// `FormulaCache`: routes through it so the parse-once invariant the
+/// dep resolver and `linkAndRecord` rely on extends to post_install.
+/// Null callers (migrate, tests) keep a private parse arena.
 pub fn executeDslPostInstall(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
@@ -238,19 +244,33 @@ pub fn executeDslPostInstall(
     post_install_src: []const u8,
     prefix: []const u8,
     use_system_ruby_list: []const []const u8,
+    cache: ?*deps_mod.FormulaCache,
 ) DslPostInstallOutcome {
-    var formula = formula_mod.parseFormula(allocator, formula_json) catch {
-        output.warn("post_install: failed to parse formula for {s}", .{name});
-        return .parse_failed;
+    var owned: ?formula_mod.Formula = null;
+    defer if (owned) |*f| f.deinit();
+
+    const dsl_version: []const u8, const pkg_version: []const u8 = blk: {
+        if (cache) |c| {
+            const f = c.getOrParse(name, formula_json) catch {
+                output.warn("post_install: failed to parse formula for {s}", .{name});
+                return .parse_failed;
+            };
+            break :blk .{ f.version, f.pkg_version };
+        }
+        owned = formula_mod.parseFormula(allocator, formula_json) catch {
+            output.warn("post_install: failed to parse formula for {s}", .{name});
+            return .parse_failed;
+        };
+        break :blk .{ owned.?.version, owned.?.pkg_version };
     };
-    defer formula.deinit();
+
     executeDslPostInstallFields(
         ctx,
         allocator,
         name,
         version_str,
-        formula.version,
-        formula.pkg_version,
+        dsl_version,
+        pkg_version,
         post_install_src,
         prefix,
         use_system_ruby_list,
@@ -318,6 +338,10 @@ fn locateDslSource(ctx: *const AppCtx, allocator: std.mem.Allocator, name: []con
 /// outcome, or fall back to a system-Ruby subprocess (when the formula
 /// is in `--use-system-ruby` scope) or the unified skip hint. Both
 /// commands route through here so human + JSON envelopes match exactly.
+///
+/// `cache` is forwarded to `executeDslPostInstall`; pass non-null from
+/// the install path to share the parse-once cache, null from migrate
+/// (its own per-keg parse already owns the lifetime).
 pub fn drive(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
@@ -326,6 +350,7 @@ pub fn drive(
     formula_json: []const u8,
     prefix: []const u8,
     use_system_ruby_list: []const []const u8,
+    cache: ?*deps_mod.FormulaCache,
 ) void {
     if (locateDslSource(ctx, allocator, name)) |src| {
         defer allocator.free(src);
@@ -338,6 +363,7 @@ pub fn drive(
             src,
             prefix,
             use_system_ruby_list,
+            cache,
         )) {
             .handled => return,
             // parse_failed leaves the DSL path unusable — fall through so

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -216,6 +216,7 @@ pub fn migrateKeg(
                     formula_json,
                     deps.prefix,
                     deps.use_system_ruby_scope,
+                    null,
                 );
             };
         } else {
@@ -227,6 +228,7 @@ pub fn migrateKeg(
                 formula_json,
                 deps.prefix,
                 deps.use_system_ruby_scope,
+                null,
             );
         }
     }

--- a/src/cli/migrate/post_install_queue.zig
+++ b/src/cli/migrate/post_install_queue.zig
@@ -140,6 +140,7 @@ pub const Queue = struct {
                 b.formula_json,
                 prefix,
                 use_system_ruby_scope,
+                null,
             ),
             .tap => |tp| post_install_mod.driveTap(
                 ctx,

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -824,6 +824,7 @@ test "executeDslPostInstall returns .parse_failed when formula JSON is unparseab
         "# empty body",
         "/tmp/irrelevant",
         &.{},
+        null,
     );
     try testing.expectEqual(install.DslPostInstallOutcome.parse_failed, outcome);
 }
@@ -849,8 +850,86 @@ test "executeDslPostInstall returns .handled when DSL executes against a valid f
         "# empty",
         "/tmp/irrelevant",
         &.{},
+        null,
     );
     try testing.expectEqual(install.DslPostInstallOutcome.handled, outcome);
+}
+
+test "executeDslPostInstall routes through the shared FormulaCache once per name" {
+    // Pins the parse-once invariant the dep resolver and linkAndRecord
+    // already enforce: with a shared cache, repeated post_install calls
+    // for the same formula across an installAll run must not re-parse.
+    color_mod.setForTest(false, false);
+    defer color_mod.setForTest(null, null);
+    const prior_quiet = output_mod.isQuiet();
+    output_mod.setQuiet(true);
+    defer output_mod.setQuiet(prior_quiet);
+
+    const json =
+        \\{"name":"hello","full_name":"hello","versions":{"stable":"1.0"},"dependencies":[],"oldnames":[]}
+    ;
+    var cache = malt.deps.FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+
+    const first = install.executeDslPostInstall(
+        &malt.app_ctx.debug_ctx,
+        testing.allocator,
+        "hello",
+        "1.0",
+        json,
+        "# empty",
+        "/tmp/irrelevant",
+        &.{},
+        &cache,
+    );
+    try testing.expectEqual(install.DslPostInstallOutcome.handled, first);
+    try testing.expectEqual(@as(usize, 1), cache.parse_count);
+
+    const second = install.executeDslPostInstall(
+        &malt.app_ctx.debug_ctx,
+        testing.allocator,
+        "hello",
+        "1.0",
+        json,
+        "# empty",
+        "/tmp/irrelevant",
+        &.{},
+        &cache,
+    );
+    try testing.expectEqual(install.DslPostInstallOutcome.handled, second);
+    try testing.expectEqual(@as(usize, 1), cache.parse_count);
+}
+
+test "executeDslPostInstall reuses an entry the install pipeline already parsed" {
+    // Mirrors the install loop's order: linkAndRecord parses + caches,
+    // then drive() runs post_install. The second parse must be a no-op.
+    color_mod.setForTest(false, false);
+    defer color_mod.setForTest(null, null);
+    const prior_quiet = output_mod.isQuiet();
+    output_mod.setQuiet(true);
+    defer output_mod.setQuiet(prior_quiet);
+
+    const json =
+        \\{"name":"hello","full_name":"hello","versions":{"stable":"1.0"},"dependencies":[],"oldnames":[]}
+    ;
+    var cache = malt.deps.FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+    _ = try cache.getOrParse("hello", json);
+    try testing.expectEqual(@as(usize, 1), cache.parse_count);
+
+    const outcome = install.executeDslPostInstall(
+        &malt.app_ctx.debug_ctx,
+        testing.allocator,
+        "hello",
+        "1.0",
+        json,
+        "# empty",
+        "/tmp/irrelevant",
+        &.{},
+        &cache,
+    );
+    try testing.expectEqual(install.DslPostInstallOutcome.handled, outcome);
+    try testing.expectEqual(@as(usize, 1), cache.parse_count);
 }
 
 // ---------------------------------------------------------------------------
@@ -883,6 +962,7 @@ test "drive: no DSL source and no scope match emits the unified skip hint" {
         "{}",
         "/tmp/irrelevant",
         &.{},
+        null,
     );
 
     // The skip hint is the byte-for-byte string both install and migrate


### PR DESCRIPTION
## Description

Each formula's post_install was re-parsing the formula JSON even though the install pipeline had already parsed and cached it. On a multi-formula install the cost added up, and the second parse arena was a quiet ownership hazard if the cache ever learned to dedupe shared deps.

The DSL post_install runner now consumes the same per-run FormulaCache the dep resolver and link/record path use, so parse cost is bounded to one per name across an installAll run. Migrate keeps its own per-keg lifetime by passing null.

## Related Issue

- None

## Notes for Reviewers

- None