### PR TITLE
fix(install/post_install): only fall back to Ruby when the DSL actually skipped work

### DIFF
--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -66,6 +66,13 @@ pub const PostInstallStatus = enum {
 /// `--use-system-ruby` suggestion we show on execute-time failures so
 /// users never see "completed" when statements were silently skipped.
 ///
+/// Auto-included Ruby-interpreter kegs (`ruby`, `ruby@N`) only fall
+/// through to the system-Ruby re-run when the DSL handled none of the
+/// body. Their effects often already landed at brew-install time, so a
+/// blanket re-run would double-stamp non-idempotent steps (counters,
+/// timestamps, version caches). Explicit `--use-system-ruby=NAME` is
+/// a user opt-in and falls through unconditionally.
+///
 /// Under `--verbose`, the skipped entries are dumped so users can tell
 /// WHICH helpers fell through. Under `--json`, a single status line is
 /// emitted to stdout for scripted pipelines.
@@ -121,7 +128,15 @@ pub fn routePostInstallOutcomeWithBody(
             output.info("post_install completed for {s}", .{name});
             break :blk .completed;
         }
-        if (useSystemRubyForFormula(use_system_ruby_list, name) or isSelfHostingRubyKeg(name)) {
+        // Auto-included Ruby-interpreter kegs (`ruby`, `ruby@N`) skip the
+        // re-run when the DSL handled any top-level statement: their
+        // post_install effects often already landed (e.g. `mt migrate ruby`
+        // after brew installed it), so a Ruby-side re-run would double-stamp
+        // non-idempotent steps. Explicit `--use-system-ruby=NAME` honors the
+        // user's opt-in unconditionally.
+        const explicit_opt_in = useSystemRubyForFormula(use_system_ruby_list, name);
+        const auto_self_hosting = isSelfHostingRubyKeg(name);
+        if (explicit_opt_in or (auto_self_hosting and !flog.dslDidWork())) {
             output.warn("post_install DSL incomplete for {s}, falling back to system Ruby...", .{name});
             if (output.isVerbose()) flog.printUnknown(name);
             if (output.isDebug()) flog.printFatal(name);

--- a/src/core/dsl/fallback_log.zig
+++ b/src/core/dsl/fallback_log.zig
@@ -25,6 +25,16 @@ pub const FallbackEntry = struct {
 pub const FallbackLog = struct {
     entries: std.ArrayList(FallbackEntry),
     allocator: std.mem.Allocator,
+    /// Top-level statements the interpreter attempted to evaluate. Bumped
+    /// per-node by `Interpreter.execute`; tests construct synthetic logs by
+    /// setting this directly.
+    total_top_level: usize = 0,
+    /// Top-level statements that completed without logging any new entry.
+    /// `dslDidWork()` reads this so the post_install router can tell
+    /// "DSL handled the body and warned" from "DSL handled none of it" —
+    /// re-running a partially-applied body via Ruby double-stamps any
+    /// non-idempotent side effect (counters, timestamps, version caches).
+    handled_top_level: usize = 0,
 
     pub fn init(allocator: std.mem.Allocator) FallbackLog {
         return .{
@@ -46,6 +56,15 @@ pub const FallbackLog = struct {
 
     pub fn hasErrors(self: *const FallbackLog) bool {
         return self.entries.items.len > 0;
+    }
+
+    /// True when at least one top-level statement evaluated without a new
+    /// fall-through being logged during it. The router uses this to gate
+    /// the system-Ruby re-run: re-executing a body whose effects already
+    /// landed double-stamps non-idempotent steps (counters, timestamps,
+    /// version-stamped caches), so we accept the partial result instead.
+    pub fn dslDidWork(self: *const FallbackLog) bool {
+        return self.handled_top_level > 0;
     }
 
     pub fn hasFatal(self: *const FallbackLog) bool {
@@ -133,3 +152,30 @@ pub const FallbackLog = struct {
         return aw.toOwnedSlice();
     }
 };
+
+test "dslDidWork: empty log reports no work done" {
+    var flog = FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+    try std.testing.expect(!flog.dslDidWork());
+}
+
+test "dslDidWork: entries alone do not imply work was done" {
+    // A synthetic log with only logged entries (no successful statement
+    // counted) reflects "DSL handled none of the body" — the router must
+    // still treat this as a fall-back-eligible state.
+    var flog = FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+    flog.log(.{ .formula = "x", .reason = .unknown_method, .detail = "h", .loc = null });
+    try std.testing.expect(flog.hasErrors());
+    try std.testing.expect(!flog.dslDidWork());
+}
+
+test "dslDidWork: at least one handled statement flips the signal" {
+    var flog = FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+    flog.total_top_level = 5;
+    flog.handled_top_level = 4;
+    flog.log(.{ .formula = "x", .reason = .unknown_method, .detail = "h", .loc = null });
+    try std.testing.expect(flog.hasErrors());
+    try std.testing.expect(flog.dslDidWork());
+}

--- a/src/core/dsl/interpreter.zig
+++ b/src/core/dsl/interpreter.zig
@@ -60,6 +60,11 @@ pub const Interpreter = struct {
 
     pub fn execute(self: *Interpreter, nodes: []const *const Node) DslError!void {
         for (nodes) |node| {
+            self.ctx.fallback_log_writer.total_top_level += 1;
+            // A statement counts as "handled" only if its eval threw nothing
+            // and logged nothing — the router uses that signal to gate the
+            // system-Ruby fallback away from already-applied bodies.
+            const before_entries = self.ctx.fallback_log_writer.entries.items.len;
             // Exhaustive: new DslError tags must be classified, not dropped.
             _ = self.eval(node) catch |e| switch (e) {
                 DslError.PostInstallFailed => return e,
@@ -77,6 +82,9 @@ pub const Interpreter = struct {
                 // value is discarded because there's no caller.
                 DslError.ReturnSignal => {
                     self.ctx.return_value = Value{ .nil = {} };
+                    if (self.ctx.fallback_log_writer.entries.items.len == before_entries) {
+                        self.ctx.fallback_log_writer.handled_top_level += 1;
+                    }
                     return;
                 },
                 // Per-statement diagnostics — log upstream, keep going.
@@ -87,6 +95,9 @@ pub const Interpreter = struct {
                 DslError.OutOfMemory,
                 => continue,
             };
+            if (self.ctx.fallback_log_writer.entries.items.len == before_entries) {
+                self.ctx.fallback_log_writer.handled_top_level += 1;
+            }
         }
     }
 

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -2661,3 +2661,85 @@ test "executePostInstall accepts FormulaRef and binds formula_name" {
     );
     try testing.expect(!flog.hasErrors());
 }
+
+// The router gates the system-Ruby re-run on this counter pair: a clean
+// run must leave `handled_top_level == total_top_level` so `dslDidWork()`
+// matches reality, otherwise a fully-applied body could be re-executed
+// and double-stamp non-idempotent steps.
+test "executePostInstall: clean body bumps handled and total top-level counters" {
+    var arena = testArena();
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var flog = dsl.FallbackLog.init(a);
+    defer flog.deinit();
+
+    try dsl.executePostInstall(
+        std.Options.debug_io,
+        malt.app_ctx.processEnviron(),
+        a,
+        .{ .name = "acme", .version = "9.9.9", .pkg_version = "9.9.9" },
+        "_ = pkgshare\n_ = bin\n",
+        "/opt/testmalt",
+        &flog,
+    );
+    try testing.expect(!flog.hasErrors());
+    try testing.expectEqual(@as(usize, 2), flog.total_top_level);
+    try testing.expectEqual(@as(usize, 2), flog.handled_top_level);
+    try testing.expect(flog.dslDidWork());
+}
+
+// A statement whose evaluation logs a fall-through (unknown helper) must
+// NOT count as handled — `dslDidWork()` would be a lie. With a mix of
+// clean + skipped statements, only the clean ones bump `handled`.
+test "executePostInstall: per-statement fall-through suppresses the handled bump" {
+    var arena = testArena();
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var flog = dsl.FallbackLog.init(a);
+    defer flog.deinit();
+
+    // First statement is a pure binding read (handled). Second invokes an
+    // unknown identifier, which logs `unknown_method` — this top-level
+    // statement must NOT be counted as handled.
+    try dsl.executePostInstall(
+        std.Options.debug_io,
+        malt.app_ctx.processEnviron(),
+        a,
+        .{ .name = "acme", .version = "9.9.9", .pkg_version = "9.9.9" },
+        "_ = pkgshare\nunknown_helper_xyz\n",
+        "/opt/testmalt",
+        &flog,
+    );
+    try testing.expect(flog.hasErrors());
+    try testing.expectEqual(@as(usize, 2), flog.total_top_level);
+    try testing.expectEqual(@as(usize, 1), flog.handled_top_level);
+    try testing.expect(flog.dslDidWork());
+}
+
+// All-unhandled body: every top-level statement logs a fall-through. The
+// counter signals "DSL did nothing useful" so the router still falls back
+// to system Ruby for users who opted in.
+test "executePostInstall: all-unhandled body leaves dslDidWork false" {
+    var arena = testArena();
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var flog = dsl.FallbackLog.init(a);
+    defer flog.deinit();
+
+    try dsl.executePostInstall(
+        std.Options.debug_io,
+        malt.app_ctx.processEnviron(),
+        a,
+        .{ .name = "acme", .version = "9.9.9", .pkg_version = "9.9.9" },
+        "first_unknown\nsecond_unknown\n",
+        "/opt/testmalt",
+        &flog,
+    );
+    try testing.expect(flog.hasErrors());
+    try testing.expectEqual(@as(usize, 2), flog.total_top_level);
+    try testing.expectEqual(@as(usize, 0), flog.handled_top_level);
+    try testing.expect(!flog.dslDidWork());
+}

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -661,6 +661,69 @@ test "routePostInstallOutcome: scope with unrelated names is ignored" {
     try testing.expect(std.mem.indexOf(u8, out, "partially skipped (use --use-system-ruby=foo") != null);
 }
 
+// Auto-included Ruby-interpreter kegs (`ruby`, `ruby@N`) gate the re-run
+// on whether the DSL handled anything: their effects often land at brew
+// install time, so re-running the hook end-to-end via Ruby would double-
+// stamp non-idempotent steps (counters, timestamps, version caches).
+// Explicit `--use-system-ruby=NAME` is a user opt-in and unaffected.
+test "routePostInstallOutcome: auto-included ruby keg skips re-run when DSL did work" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.log(.{
+        .formula = "ruby@3.4",
+        .reason = .unsupported_node,
+        .detail = "default_args",
+        .loc = null,
+    });
+    flog.total_top_level = 3;
+    flog.handled_top_level = 2;
+
+    const out = try runRoute(&flog, "ruby@3.4", &.{});
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "falling back to system Ruby") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "(via system Ruby)") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "partially skipped") != null);
+}
+
+// Negative pin on the same axis: when the DSL handled none of the body,
+// the auto-include must still fall back so a fresh `mt migrate ruby`
+// (or any zero-coverage scenario) still runs the hook via system Ruby.
+test "routePostInstallOutcome: auto-included ruby keg falls back when DSL did nothing" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.log(.{
+        .formula = "ruby@3.4",
+        .reason = .unsupported_node,
+        .detail = "default_args",
+        .loc = null,
+    });
+    flog.total_top_level = 3;
+    flog.handled_top_level = 0;
+
+    const out = try runRoute(&flog, "ruby@3.4", &.{});
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "falling back to system Ruby") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "partially skipped") == null);
+}
+
+// JSON mirror for the auto-include skip path: status is partially_skipped,
+// never ran_via_ruby, when the DSL handled some work.
+test "routePostInstallOutcome: --json reports partially_skipped for ruby keg with work" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.log(.{ .formula = "ruby@3.4", .reason = .unknown_method, .detail = "h", .loc = null });
+    flog.total_top_level = 4;
+    flog.handled_top_level = 3;
+
+    const out = try runRouteCaptureStdout(&flog, "ruby@3.4", &.{});
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "\"status\":\"partially_skipped\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"status\":\"ran_via_ruby\"") == null);
+}
+
 // ---------------------------------------------------------------------------
 // routePostInstallOutcome under --verbose / --debug — the diagnostic dump
 // is what lets users (and bug reports) see WHICH helpers the DSL skipped.


### PR DESCRIPTION
## Description

The system-Ruby fallback in `routePostInstallOutcome` fired any time the DSL fallback log was non-empty, even when the DSL had already executed most of the post_install body. For auto-included Ruby-interpreter kegs (`ruby`, `ruby@N`), whose effects often already landed at brew-install time, that meant `mt migrate ruby` would re-run the entire hook through a Ruby subprocess and double-stamp non-idempotent steps - counters, timestamp files, version-stamped caches.

The router now tracks DSL coverage at the top-level statement granularity and skips the auto-include re-run when the DSL handled at least one statement cleanly. Explicit `--use-system-ruby=NAME` is a user opt-in and falls through unconditionally, preserving the gh85 contract where `--use-system-ruby=llvm@21` still drives `write_config_files` to completion.

## Related Issue

- None

## Notes for Reviewers

- None