### PR TITLE
feat(cli/purge): distinguish swallowed scope failures from clean no-ops in ndjson

### DIFF
--- a/src/cli/purge.zig
+++ b/src/cli/purge.zig
@@ -101,6 +101,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
                 .name = "wipe",
                 .removed = @intCast(wipe_result.removed),
                 .bytes = wipe_result.bytes,
+                .status = wipe_result.status,
+                .error_kind = wipe_result.error_kind,
             }};
             purge_json.emitSummary(
                 allocator,
@@ -111,8 +113,21 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
                 elapsed,
             ) catch {};
         };
-        defer purge_json.emitPurgeComplete(wipe_result.removed, wipe_result.bytes, dry_run);
-        defer purge_json.emitScopeCompleted("wipe", wipe_result.removed, wipe_result.bytes, dry_run);
+        defer purge_json.emitPurgeComplete(
+            wipe_result.removed,
+            wipe_result.bytes,
+            dry_run,
+            wipe_result.status,
+            wipe_result.error_kind,
+        );
+        defer purge_json.emitScopeCompleted(
+            "wipe",
+            wipe_result.removed,
+            wipe_result.bytes,
+            dry_run,
+            wipe_result.status,
+            wipe_result.error_kind,
+        );
         wipe_result = try wipe_mod.runWipe(ctx, allocator, opts, prefix, cache_dir, dry_run);
         return;
     }
@@ -161,14 +176,27 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             elapsed,
         ) catch {};
     };
-    defer purge_json.emitPurgeComplete(grand_total.removed, grand_total.bytes, dry_run);
+    defer purge_json.emitPurgeComplete(
+        grand_total.removed,
+        grand_total.bytes,
+        dry_run,
+        grand_total.status,
+        grand_total.error_kind,
+    );
 
     inline for (scope_run_order) |k| {
         if (@field(opts.scope, @tagName(k))) {
             const name = comptime k.label();
             purge_json.emitScopeStarted(name, dry_run);
             var r: TierResult = .{};
-            defer purge_json.emitScopeCompleted(name, r.removed, r.bytes, dry_run);
+            defer purge_json.emitScopeCompleted(
+                name,
+                r.removed,
+                r.bytes,
+                dry_run,
+                r.status,
+                r.error_kind,
+            );
             r = try switch (k) {
                 .unused_deps => scopes_mod.runUnusedDeps(ctx, allocator, prefix, dry_run),
                 .store_orphans => scopes_mod.runStoreOrphans(ctx, allocator, prefix, dry_run),
@@ -177,9 +205,21 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
                 .stale_casks => scopes_mod.runStaleCasks(ctx, allocator, prefix, dry_run),
                 .old_versions => scopes_mod.runOldVersions(ctx, allocator, prefix, dry_run),
             };
-            try summary.add(allocator, .{ .name = name, .removed = r.removed, .bytes = r.bytes });
+            try summary.add(allocator, .{
+                .name = name,
+                .removed = r.removed,
+                .bytes = r.bytes,
+                .status = r.status,
+                .error_kind = r.error_kind,
+            });
             grand_total.removed += r.removed;
             grand_total.bytes += r.bytes;
+            // First failure wins as the surfaced error_kind; subsequent
+            // scope errors still flip status and stay in their own row.
+            if (r.status == .err and grand_total.status == .ok) {
+                grand_total.status = .err;
+                grand_total.error_kind = r.error_kind;
+            }
         }
     }
 

--- a/src/cli/purge/json.zig
+++ b/src/cli/purge/json.zig
@@ -6,19 +6,20 @@
 //! ndjson` for the streaming mode. Stderr remains the human path in
 //! either mode so interactive runs keep their existing TTY layout.
 //!
-//! ## Wire format (v1)
+//! ## Wire format (v2)
 //!
 //! ### `--json` summary (one object on stdout, trailing `\n`)
 //!
 //! ```json
 //! {
-//!   "version": 1,
+//!   "version": 2,
 //!   "dry_run": false,
 //!   "scopes": [
-//!     {"name": "store-orphans", "removed": 5, "bytes": 4096},
-//!     {"name": "unused-deps",   "removed": 1, "bytes": 0}
+//!     {"name": "store-orphans", "removed": 5, "bytes": 4096, "status": "ok"},
+//!     {"name": "unused-deps",   "removed": 0, "bytes": 0,    "status": "error", "error_kind": "db_unreadable"}
 //!   ],
-//!   "totals": {"removed": 6, "bytes": 4096},
+//!   "totals": {"removed": 5, "bytes": 4096},
+//!   "status": "error",
 //!   "time_ms": 12
 //! }
 //! ```
@@ -27,8 +28,8 @@
 //!
 //! ```ndjson
 //! {"event":"scope_started","scope":"store-orphans","dry_run":false}
-//! {"event":"scope_completed","scope":"store-orphans","removed":5,"bytes":4096,"dry_run":false}
-//! {"event":"purge_complete","removed":5,"bytes":4096,"dry_run":false}
+//! {"event":"scope_completed","scope":"store-orphans","removed":5,"bytes":4096,"dry_run":false,"status":"ok"}
+//! {"event":"purge_complete","removed":5,"bytes":4096,"dry_run":false,"status":"ok"}
 //! ```
 //!
 //! Field guarantees:
@@ -44,12 +45,24 @@
 //! - `scope_started` always pairs with a `scope_completed`, even on
 //!   error paths (UserAborted, OOM). `purge_complete` always closes
 //!   the stream. Consumers can rely on strict open/close brackets.
+//! - `status` is `"ok"` or `"error"` on every `scope_completed` and
+//!   `purge_complete` event (and on every summary scope row + the
+//!   summary itself). Distinguishes a clean no-op from a swallowed
+//!   internal failure that the human stderr path already surfaced.
+//! - `error_kind` is a stable lowercase token included only when
+//!   `status == "error"` so scripts can branch without parsing
+//!   free-form errno strings.
 
 const std = @import("std");
 const output = @import("../../ui/output.zig");
 const report = @import("report.zig");
+const util = @import("util.zig");
 
-pub const schema_version: u32 = 1;
+pub const ScopeStatus = util.ScopeStatus;
+
+/// v2 added `status` (and optional `error_kind`) so consumers can tell
+/// a clean no-op apart from a swallowed scope failure.
+pub const schema_version: u32 = 2;
 
 /// Wire-format event names. Mirrors the closed-vocabulary pattern in
 /// `output.NdjsonEvent`: a typo at a call site fails to compile rather
@@ -75,16 +88,36 @@ pub fn buildSummary(
         "{{\"version\":{d},\"dry_run\":{s},\"scopes\":[",
         .{ schema_version, if (dry_run) "true" else "false" },
     );
+    var any_error = false;
     for (rows, 0..) |row, i| {
         if (i != 0) try w.writeAll(",");
         try w.writeAll("{\"name\":");
         try output.jsonStr(w, row.name);
-        try w.print(",\"removed\":{d},\"bytes\":{d}}}", .{ row.removed, row.bytes });
+        try w.print(",\"removed\":{d},\"bytes\":{d},\"status\":\"{s}\"", .{
+            row.removed,
+            row.bytes,
+            statusTag(row.status),
+        });
+        if (row.status == .err) {
+            any_error = true;
+            if (row.error_kind) |kind| {
+                try w.writeAll(",\"error_kind\":");
+                try output.jsonStr(w, kind);
+            }
+        }
+        try w.writeAll("}");
     }
     try w.print(
-        "],\"totals\":{{\"removed\":{d},\"bytes\":{d}}},\"time_ms\":{d}}}\n",
-        .{ total_removed, total_bytes, time_ms },
+        "],\"totals\":{{\"removed\":{d},\"bytes\":{d}}},\"status\":\"{s}\",\"time_ms\":{d}}}\n",
+        .{ total_removed, total_bytes, statusTag(if (any_error) .err else .ok), time_ms },
     );
+}
+
+fn statusTag(s: ScopeStatus) []const u8 {
+    return switch (s) {
+        .ok => "ok",
+        .err => "error",
+    };
 }
 
 /// Shared ndjson event emitter for purge events. Mirrors the silent-drop
@@ -92,7 +125,15 @@ pub fn buildSummary(
 /// the fixed buffer (adversarial scope name, pathological counts) is
 /// dropped rather than failing the command — the human stderr path is
 /// still authoritative.
-fn emitEvent(event: PurgeEvent, scope: ?[]const u8, removed: ?u64, bytes: ?u64, dry_run: bool) void {
+fn emitEvent(
+    event: PurgeEvent,
+    scope: ?[]const u8,
+    removed: ?u64,
+    bytes: ?u64,
+    dry_run: bool,
+    status: ?ScopeStatus,
+    error_kind: ?[]const u8,
+) void {
     if (!output.isNdjson()) return;
     var buf: [512]u8 = undefined;
     var w = std.Io.Writer.fixed(buf[0..]);
@@ -106,6 +147,15 @@ fn emitEvent(event: PurgeEvent, scope: ?[]const u8, removed: ?u64, bytes: ?u64, 
     if (bytes) |b| w.print(",\"bytes\":{d}", .{b}) catch return;
     w.writeAll(",\"dry_run\":") catch return;
     w.writeAll(if (dry_run) "true" else "false") catch return;
+    if (status) |s| {
+        w.print(",\"status\":\"{s}\"", .{statusTag(s)}) catch return;
+        if (s == .err) {
+            if (error_kind) |kind| {
+                w.writeAll(",\"error_kind\":") catch return;
+                output.jsonStr(&w, kind) catch return;
+            }
+        }
+    }
     w.writeAll("}\n") catch return;
     output.writeStdoutAll(w.buffered());
 }
@@ -114,17 +164,32 @@ fn emitEvent(event: PurgeEvent, scope: ?[]const u8, removed: ?u64, bytes: ?u64, 
 /// when ndjson mode is on; no-op otherwise. Per-scope ndjson is one
 /// summary line, not one line per item — call sites stay unchanged.
 pub fn emitScopeStarted(scope: []const u8, dry_run: bool) void {
-    emitEvent(.scope_started, scope, null, null, dry_run);
+    emitEvent(.scope_started, scope, null, null, dry_run, null, null);
 }
 
-/// Emit `{"event":"scope_completed","scope":...,"removed":N,"bytes":B,"dry_run":<bool>}\n`.
-pub fn emitScopeCompleted(scope: []const u8, removed: u64, bytes: u64, dry_run: bool) void {
-    emitEvent(.scope_completed, scope, removed, bytes, dry_run);
+/// Emit `{"event":"scope_completed","scope":...,"removed":N,"bytes":B,"dry_run":<bool>,"status":...}\n`.
+/// `error_kind` is only included on `.err` so consumers don't branch on
+/// `null` vs missing.
+pub fn emitScopeCompleted(
+    scope: []const u8,
+    removed: u64,
+    bytes: u64,
+    dry_run: bool,
+    status: ScopeStatus,
+    error_kind: ?[]const u8,
+) void {
+    emitEvent(.scope_completed, scope, removed, bytes, dry_run, status, error_kind);
 }
 
-/// Emit `{"event":"purge_complete","removed":N,"bytes":B,"dry_run":<bool>}\n`.
-pub fn emitPurgeComplete(removed: u64, bytes: u64, dry_run: bool) void {
-    emitEvent(.purge_complete, null, removed, bytes, dry_run);
+/// Emit `{"event":"purge_complete","removed":N,"bytes":B,"dry_run":<bool>,"status":...}\n`.
+pub fn emitPurgeComplete(
+    removed: u64,
+    bytes: u64,
+    dry_run: bool,
+    status: ScopeStatus,
+    error_kind: ?[]const u8,
+) void {
+    emitEvent(.purge_complete, null, removed, bytes, dry_run, status, error_kind);
 }
 
 /// Build + flush the `--json` summary to stdout. Allocates a transient
@@ -221,8 +286,8 @@ test "emit helpers no-op when ndjson mode is off" {
     defer output.endStdoutCapture();
 
     emitScopeStarted("cache", false);
-    emitScopeCompleted("cache", 1, 2, false);
-    emitPurgeComplete(1, 2, false);
+    emitScopeCompleted("cache", 1, 2, false, .ok, null);
+    emitPurgeComplete(1, 2, false, .ok, null);
 
     try testing.expectEqual(@as(usize, 0), buf.items.len);
 }
@@ -258,7 +323,7 @@ test "emitScopeCompleted carries removed/bytes counters" {
     output.beginStdoutCapture(testing.allocator, &buf);
     defer output.endStdoutCapture();
 
-    emitScopeCompleted("cache", 7, 8192, false);
+    emitScopeCompleted("cache", 7, 8192, false, .ok, null);
 
     const line = std.mem.trimEnd(u8, buf.items, "\n");
     const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line, .{});
@@ -281,7 +346,7 @@ test "emitPurgeComplete brackets the stream" {
     output.beginStdoutCapture(testing.allocator, &buf);
     defer output.endStdoutCapture();
 
-    emitPurgeComplete(42, 1_048_576, false);
+    emitPurgeComplete(42, 1_048_576, false, .ok, null);
 
     const line = std.mem.trimEnd(u8, buf.items, "\n");
     const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line, .{});
@@ -290,4 +355,44 @@ test "emitPurgeComplete brackets the stream" {
     try testing.expectEqualStrings("purge_complete", obj.get("event").?.string);
     try testing.expectEqual(@as(i64, 42), obj.get("removed").?.integer);
     try testing.expectEqual(@as(i64, 1_048_576), obj.get("bytes").?.integer);
+}
+
+test "emitScopeCompleted carries status and optional error_kind on errors" {
+    const prior = output.isNdjson();
+    defer output.setNdjson(prior);
+    output.setNdjson(true);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &buf);
+    defer output.endStdoutCapture();
+
+    emitScopeCompleted("store-orphans", 0, 0, false, .err, "open_failed");
+
+    const line = std.mem.trimEnd(u8, buf.items, "\n");
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line, .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    try testing.expectEqualStrings("error", obj.get("status").?.string);
+    try testing.expectEqualStrings("open_failed", obj.get("error_kind").?.string);
+}
+
+test "emitScopeCompleted reports status:ok and omits error_kind on success" {
+    const prior = output.isNdjson();
+    defer output.setNdjson(prior);
+    output.setNdjson(true);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &buf);
+    defer output.endStdoutCapture();
+
+    emitScopeCompleted("cache", 5, 1024, false, .ok, null);
+
+    const line = std.mem.trimEnd(u8, buf.items, "\n");
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line, .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+    try testing.expectEqualStrings("ok", obj.get("status").?.string);
+    try testing.expect(obj.get("error_kind") == null);
 }

--- a/src/cli/purge/report.zig
+++ b/src/cli/purge/report.zig
@@ -21,6 +21,8 @@ pub const SummaryRow = struct {
     name: []const u8,
     removed: u32,
     bytes: u64,
+    status: util.ScopeStatus = .ok,
+    error_kind: ?[]const u8 = null,
 };
 
 pub const Summary = struct {

--- a/src/cli/purge/scopes.zig
+++ b/src/cli/purge/scopes.zig
@@ -32,6 +32,8 @@ pub fn runStoreOrphans(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix:
         },
         .unreadable => |e| {
             output.err("store-orphans: cannot open database ({s})", .{@errorName(e)});
+            result.status = .err;
+            result.error_kind = "db_unreadable";
             return result;
         },
         .opened => |db_val| db_val,
@@ -39,12 +41,16 @@ pub fn runStoreOrphans(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix:
     defer db.close();
     schema.initSchema(&db) catch |e| {
         output.err("store-orphans: cannot init schema ({s})", .{@errorName(e)});
+        result.status = .err;
+        result.error_kind = "schema_init";
         return result;
     };
 
     var store = store_mod.Store.init(io, allocator, &db, prefix);
     var orphans_list = store.orphans() catch {
         output.err("store-orphans: failed to enumerate orphans", .{});
+        result.status = .err;
+        result.error_kind = "enumerate_orphans";
         return result;
     };
     defer {
@@ -90,6 +96,8 @@ pub fn runUnusedDeps(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
         },
         .unreadable => |e| {
             output.err("unused-deps: cannot open database ({s})", .{@errorName(e)});
+            result.status = .err;
+            result.error_kind = "db_unreadable";
             return result;
         },
         .opened => |db_val| db_val,
@@ -97,11 +105,15 @@ pub fn runUnusedDeps(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
     defer db.close();
     schema.initSchema(&db) catch |e| {
         output.err("unused-deps: cannot init schema ({s})", .{@errorName(e)});
+        result.status = .err;
+        result.error_kind = "schema_init";
         return result;
     };
 
     const orphans = deps_mod.findOrphans(allocator, &db) catch {
         output.err("unused-deps: failed to find orphans", .{});
+        result.status = .err;
+        result.error_kind = "find_orphans";
         return result;
     };
     defer {
@@ -284,6 +296,8 @@ pub fn runStaleCasks(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
         },
         .unreadable => |e| {
             output.err("stale-casks: cannot open database ({s})", .{@errorName(e)});
+            result.status = .err;
+            result.error_kind = "db_unreadable";
             return result;
         },
         .opened => |db_val| db_val,

--- a/src/cli/purge/util.zig
+++ b/src/cli/purge/util.zig
@@ -8,9 +8,18 @@ const args_mod = @import("args.zig");
 
 pub const Error = args_mod.Error;
 
+/// Outcome discriminator for a scope run. `.ok` is the silent default;
+/// `.err` signals an internal failure that the orchestrator surfaced
+/// via stderr but did not propagate as a Zig error — the wire format
+/// needs a positive marker so consumers can distinguish a clean no-op
+/// from a swallowed fault.
+pub const ScopeStatus = enum { ok, err };
+
 pub const TierResult = struct {
     removed: u32 = 0,
     bytes: u64 = 0,
+    status: ScopeStatus = .ok,
+    error_kind: ?[]const u8 = null,
 };
 
 pub fn formatBytes(bytes: u64, buf: []u8) []const u8 {

--- a/tests/purge_json_test.zig
+++ b/tests/purge_json_test.zig
@@ -387,3 +387,201 @@ test "ndjson scope_completed carries removed/bytes counters" {
     }
     try testing.expect(saw_completed_with_counters);
 }
+
+// ── status field on ndjson + --json events ─────────────────────────────────
+//
+// Without a status discriminator, scope_completed for a corrupt/locked DB
+// is bytewise indistinguishable from a clean "nothing to do" run: both
+// emit `removed:0,bytes:0`. These tests pin the contract that consumers
+// can rely on `status` to disambiguate.
+
+test "ndjson scope_completed reports status:ok on a clean no-op run" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "ok_status");
+    defer prefix.deinit(allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(true);
+    output.setNdjson(true);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    const ctx = makeCtx();
+    try purge.execute(&ctx, allocator, &[_][]const u8{"--housekeeping"});
+
+    var lines = std.mem.splitScalar(u8, std.mem.trimEnd(u8, stdout_buf.items, "\n"), '\n');
+    var saw_completed_with_status = false;
+    while (lines.next()) |line| {
+        if (std.mem.indexOf(u8, line, "\"event\":\"scope_completed\"") == null) continue;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+        defer parsed.deinit();
+        const obj = parsed.value.object;
+        try testing.expectEqualStrings("ok", obj.get("status").?.string);
+        saw_completed_with_status = true;
+    }
+    try testing.expect(saw_completed_with_status);
+}
+
+test "ndjson purge_complete carries status:ok when no scope errored" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "purge_ok_status");
+    defer prefix.deinit(allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(true);
+    output.setNdjson(true);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    const ctx = makeCtx();
+    try purge.execute(&ctx, allocator, &[_][]const u8{"--housekeeping"});
+
+    var lines = std.mem.splitScalar(u8, std.mem.trimEnd(u8, stdout_buf.items, "\n"), '\n');
+    var saw_purge_complete = false;
+    while (lines.next()) |line| {
+        if (std.mem.indexOf(u8, line, "\"event\":\"purge_complete\"") == null) continue;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+        defer parsed.deinit();
+        try testing.expectEqualStrings("ok", parsed.value.object.get("status").?.string);
+        saw_purge_complete = true;
+    }
+    try testing.expect(saw_purge_complete);
+}
+
+test "ndjson scope_completed reports status:error and error_kind on corrupt DB" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "err_status");
+    defer prefix.deinit(allocator);
+
+    const db_path = try std.fmt.allocPrint(allocator, "{s}/db/malt.db", .{prefix.path});
+    defer allocator.free(db_path);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, db_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "this is not a valid sqlite header, just garbage to trip the open path");
+    }
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(true);
+    output.setNdjson(true);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    const ctx = makeCtx();
+    try purge.execute(&ctx, allocator, &[_][]const u8{"--store-orphans"});
+
+    var lines = std.mem.splitScalar(u8, std.mem.trimEnd(u8, stdout_buf.items, "\n"), '\n');
+    var saw_error_completion = false;
+    while (lines.next()) |line| {
+        if (std.mem.indexOf(u8, line, "\"event\":\"scope_completed\"") == null) continue;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+        defer parsed.deinit();
+        const obj = parsed.value.object;
+        try testing.expectEqualStrings("store-orphans", obj.get("scope").?.string);
+        try testing.expectEqualStrings("error", obj.get("status").?.string);
+        // error_kind is a stable lowercase token so scripts can branch
+        // without parsing free-form errno strings.
+        try testing.expect(obj.get("error_kind") != null);
+        try testing.expect(obj.get("error_kind").?.string.len > 0);
+        saw_error_completion = true;
+    }
+    try testing.expect(saw_error_completion);
+}
+
+test "ndjson purge_complete carries status:error when any scope errored" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "purge_err");
+    defer prefix.deinit(allocator);
+
+    const db_path = try std.fmt.allocPrint(allocator, "{s}/db/malt.db", .{prefix.path});
+    defer allocator.free(db_path);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, db_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "garbage header");
+    }
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(true);
+    output.setNdjson(true);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    const ctx = makeCtx();
+    try purge.execute(&ctx, allocator, &[_][]const u8{"--store-orphans"});
+
+    var lines = std.mem.splitScalar(u8, std.mem.trimEnd(u8, stdout_buf.items, "\n"), '\n');
+    var saw_purge_complete_error = false;
+    while (lines.next()) |line| {
+        if (std.mem.indexOf(u8, line, "\"event\":\"purge_complete\"") == null) continue;
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+        defer parsed.deinit();
+        try testing.expectEqualStrings("error", parsed.value.object.get("status").?.string);
+        saw_purge_complete_error = true;
+    }
+    try testing.expect(saw_purge_complete_error);
+}
+
+test "--json summary marks errored scopes with status:error and bumps schema version" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "summary_err");
+    defer prefix.deinit(allocator);
+
+    const db_path = try std.fmt.allocPrint(allocator, "{s}/db/malt.db", .{prefix.path});
+    defer allocator.free(db_path);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, db_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "garbage");
+    }
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.json);
+    output.setDryRun(true);
+    output.setNdjson(false);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    const ctx = makeCtx();
+    try purge.execute(&ctx, allocator, &[_][]const u8{"--store-orphans"});
+
+    const trimmed = std.mem.trim(u8, stdout_buf.items, " \r\n\t");
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+
+    // schema_version bump signals the wire-format contract change.
+    try testing.expectEqual(@as(i64, 2), obj.get("version").?.integer);
+
+    const scopes = obj.get("scopes").?.array.items;
+    try testing.expectEqual(@as(usize, 1), scopes.len);
+    const scope_obj = scopes[0].object;
+    try testing.expectEqualStrings("store-orphans", scope_obj.get("name").?.string);
+    try testing.expectEqualStrings("error", scope_obj.get("status").?.string);
+    try testing.expect(scope_obj.get("error_kind") != null);
+    try testing.expectEqualStrings("error", obj.get("status").?.string);
+}


### PR DESCRIPTION
## Description

Scripts driving `mt purge --output-format=ndjson` could not tell whether `scope_completed` reported zero work because nothing needed cleaning or because the underlying database was unreadable - the two cases were bytewise identical on the wire. Each `scope_completed` and `purge_complete` event now carries a `status` ("ok" or "error"), and a stable `error_kind` token when status is "error", so consumers can branch without parsing free-form errno strings.

The `--json` summary picks up the same fields per scope row plus a top-level overall status, and the schema version is bumped so a consumer can detect the contract change without sniffing for keys.

## Related Issue

- None

## Notes for Reviewers

- None