### PR TITLE
fix(ui): keep notice and warn distinguishable in NO_COLOR / no-emoji mode

### DIFF
--- a/src/ui/color.zig
+++ b/src/ui/color.zig
@@ -320,15 +320,15 @@ const dark_basic: Palette = .{
 // yellow→magenta. Detail reuses the dark-basic faint code so both basic
 // palettes render meta info identically — dropping into the default
 // foreground on terminals that ignore SGR 2.
-// Notice collides with warn here (both magenta); the two never co-appear
-// and truecolor terminals (the common case) carry the visual distinction.
+// Notice picks cyan so it stays distinct from warn's magenta on the one
+// palette where the same hue would otherwise collapse the two roles.
 const light_basic: Palette = .{
     .info = "\x1b[34m",
     .warn = "\x1b[35m",
     .success = "\x1b[32m",
     .err = "\x1b[31m",
     .detail = "\x1b[2m",
-    .notice = "\x1b[35m",
+    .notice = "\x1b[36m",
 };
 
 /// Pure palette lookup. Exposed so tests pin every cell.
@@ -383,9 +383,14 @@ test "paletteCode: notice — dark + basic is magenta (distinct from yellow warn
     try std.testing.expectEqualStrings("\x1b[35m", paletteCode(.notice, .dark, false));
 }
 
-// Light + basic shares the magenta escape with warn — the two never
-// co-appear and truecolor terminals carry the visual distinction via
-// violet-700. Pinned so the choice stays a deliberate, reviewable diff.
-test "paletteCode: notice — light + basic reuses magenta (intentional warn collision)" {
-    try std.testing.expectEqualStrings("\x1b[35m", paletteCode(.notice, .light, false));
+// Light + basic must avoid warn's magenta — on a NO_COLOR-y / no-emoji
+// terminal the glyph alone already carries the distinction, but as soon
+// as basic colour is on the two lines have to land on different hues.
+test "paletteCode: notice — light + basic uses cyan, distinct from warn-magenta" {
+    try std.testing.expectEqualStrings("\x1b[36m", paletteCode(.notice, .light, false));
+    try std.testing.expect(!std.mem.eql(
+        u8,
+        paletteCode(.notice, .light, false),
+        paletteCode(.warn, .light, false),
+    ));
 }

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -263,13 +263,14 @@ pub fn err(comptime fmt: []const u8, args: anytype) void {
 }
 
 /// "FYI / explanation" line — a passive heads-up that is neither a warning
-/// nor a failure. Plain mode picks `i` (info-glyph) so a NO_COLOR /
-/// MALT_NO_EMOJI line reads distinctly from `warn`'s `!`.
+/// nor a failure. Each tier picks an info-shaped glyph (`ⓘ` / `i`) so the
+/// line reads distinctly from `warn`'s `⚠`/`!` on every (color, emoji)
+/// combination, including NO_COLOR + MALT_NO_EMOJI.
 pub fn notice(comptime fmt: []const u8, args: anytype) void {
     if (quiet) return;
     var buf: [4096]u8 = undefined;
     const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
-    writePrefixedLine(msg, .notice, "  ! ", "  i ");
+    writePrefixedLine(msg, .notice, "  ⓘ ", "  i ");
 }
 
 /// Print a confirmation prompt: info-coloured `?` icon, bold message,
@@ -546,7 +547,7 @@ pub fn emitNdjsonEvent(
 // Sister tests for the other prefix-line helpers live alongside the public
 // API surface in tests/output_test.zig; these are kept inline because the
 // helper is a thin wrapper over the already-tested writePrefixedLine.
-test "notice wraps the magenta prefix and uses the bang glyph (dark + basic)" {
+test "notice wraps the magenta prefix and uses the circled-i glyph (dark + basic)" {
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
     const prior_quiet = isQuiet();
@@ -564,7 +565,7 @@ test "notice wraps the magenta prefix and uses the bang glyph (dark + basic)" {
     }
 
     notice("heads up", .{});
-    try std.testing.expectEqualStrings("\x1b[35m  ! \x1b[0mheads up\n", buf.items);
+    try std.testing.expectEqualStrings("\x1b[35m  ⓘ \x1b[0mheads up\n", buf.items);
 }
 
 test "notice falls back to an info-style ASCII glyph when emoji and color are off" {

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -263,12 +263,13 @@ pub fn err(comptime fmt: []const u8, args: anytype) void {
 }
 
 /// "FYI / explanation" line — a passive heads-up that is neither a warning
-/// nor a failure. Purple/violet glyph so it reads distinctly from `warn`.
+/// nor a failure. Plain mode picks `i` (info-glyph) so a NO_COLOR /
+/// MALT_NO_EMOJI line reads distinctly from `warn`'s `!`.
 pub fn notice(comptime fmt: []const u8, args: anytype) void {
     if (quiet) return;
     var buf: [4096]u8 = undefined;
     const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
-    writePrefixedLine(msg, .notice, "  ! ", "  ! ");
+    writePrefixedLine(msg, .notice, "  ! ", "  i ");
 }
 
 /// Print a confirmation prompt: info-coloured `?` icon, bold message,
@@ -566,7 +567,7 @@ test "notice wraps the magenta prefix and uses the bang glyph (dark + basic)" {
     try std.testing.expectEqualStrings("\x1b[35m  ! \x1b[0mheads up\n", buf.items);
 }
 
-test "notice falls back to ASCII bang prefix when emoji and color are off" {
+test "notice falls back to an info-style ASCII glyph when emoji and color are off" {
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
     const prior_quiet = isQuiet();
@@ -580,7 +581,34 @@ test "notice falls back to ASCII bang prefix when emoji and color are off" {
     }
 
     notice("plain notice", .{});
-    try std.testing.expectEqualStrings("  ! plain notice\n", buf.items);
+    try std.testing.expectEqualStrings("  i plain notice\n", buf.items);
+}
+
+// Regression: with NO_COLOR + MALT_NO_EMOJI both lines used to render
+// bytewise-identical `  ! <msg>` — pinning the divergence keeps CI logs
+// and minimalist terminals able to tell a passive notice from a warning.
+test "notice and warn render bytewise-distinct lines with color and emoji off" {
+    const prior_quiet = isQuiet();
+    color.setForTest(false, false);
+    setQuiet(false);
+    defer {
+        color.setForTest(null, null);
+        setQuiet(prior_quiet);
+    }
+
+    var notice_buf: std.ArrayList(u8) = .empty;
+    defer notice_buf.deinit(std.testing.allocator);
+    beginStderrCapture(std.testing.allocator, &notice_buf);
+    notice("same message", .{});
+    endStderrCapture();
+
+    var warn_buf: std.ArrayList(u8) = .empty;
+    defer warn_buf.deinit(std.testing.allocator);
+    beginStderrCapture(std.testing.allocator, &warn_buf);
+    warn("same message", .{});
+    endStderrCapture();
+
+    try std.testing.expect(!std.mem.eql(u8, notice_buf.items, warn_buf.items));
 }
 
 test "notice is suppressed by --quiet" {


### PR DESCRIPTION
## Description

The "update available" notice and a real warning rendered as the exact same line on `NO_COLOR=1` or with emoji disabled, so CI logs and minimalist setups could not tell them apart - the visual distinction the previous release added was undone in the most-shipped output form. Notice now uses an info-style ASCII glyph in plain mode and a non-magenta hue on the light-basic palette, so the two roles stay readable on every (color, emoji) combination.

## Related Issue

- None

## Notes for Reviewers

- None