### PR TITLE
refactor(dsl/inreplace): route stderr warning through output module

### DIFF
--- a/src/core/dsl/builtins/inreplace.zig
+++ b/src/core/dsl/builtins/inreplace.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const values = @import("../values.zig");
 const sandbox = @import("../sandbox.zig");
 const pathname = @import("pathname.zig");
+const output = @import("../../../ui/output.zig");
 
 const Value = values.Value;
 const BuiltinError = pathname.BuiltinError;
@@ -52,12 +53,12 @@ pub fn inreplace(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Valu
     // did *not* use the atomic path.
     var underlying_name: ?[]const u8 = null;
     writeAtomic(ctx.io, path, new_content, &underlying_name) catch |e| {
-        const stderr: std.Io.File = .{ .handle = std.posix.STDERR_FILENO, .flags = .{ .nonblocking = false } };
         var buf: [512]u8 = undefined;
         const underlying = underlying_name orelse @errorName(e);
         const msg = formatAtomicWriteFailureMessage(&buf, e, underlying) catch return Value{ .nil = {} };
-        // Warning is advisory; fallback write is the load-bearing step.
-        stderr.writeStreamingAll(ctx.io, msg) catch {};
+        // Route through the capture-aware seam so tests see the warning
+        // and CI logs do not interleave with raw-fd writes.
+        output.writeStderrAll(msg);
         writeDirectly(ctx.io, path, new_content);
     };
 

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -642,6 +642,55 @@ test "interpreter: inreplace replaces content in file" {
     try testing.expectEqualStrings("setting=NEW_VALUE\n", buf[0..n]);
 }
 
+// Regression: the atomic-write fallback warning previously bypassed the
+// output module by writing to STDERR_FILENO directly, which let the line
+// leak past `beginStderrCapture` and interleave with `zig test` output.
+test "interpreter: inreplace fallback warning is captured by output stderr seam" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    const target_dir = try std.fs.path.join(
+        testing.allocator,
+        &.{ prefix, "Cellar", "testpkg", "1.0" },
+    );
+    defer testing.allocator.free(target_dir);
+
+    const config_path = try std.fs.path.join(
+        testing.allocator,
+        &.{ target_dir, "config.txt" },
+    );
+    defer testing.allocator.free(config_path);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, config_path, .{});
+        _ = try f.writeStreamingAll(std.Options.debug_io, "setting=OLD_VALUE\n");
+        f.close(std.Options.debug_io);
+    }
+
+    // Strip write on the parent so writeAtomic's tmp-file create returns
+    // EACCES, which trips the warn+fallback branch under test.
+    const target_dir_z = try testing.allocator.dupeZ(u8, target_dir);
+    defer testing.allocator.free(target_dir_z);
+    const c = struct {
+        extern "c" fn chmod(path: [*:0]const u8, mode: u16) c_int;
+    };
+    if (c.chmod(target_dir_z, 0o555) != 0) return error.TestUnexpectedResult;
+    defer _ = c.chmod(target_dir_z, 0o755);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &stderr_buf);
+    defer malt.output.endStderrCapture();
+
+    const src = "inreplace prefix/\"config.txt\", \"OLD_VALUE\", \"NEW_VALUE\"";
+    _ = try runSnippet(&arena, src, prefix);
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "inreplace atomic write failed") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "TempCreateFailed") != null);
+}
+
 // ---------------------------------------------------------------------------
 // Extended tests — Logical operators
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

The atomic-write fallback warning emitted by the `inreplace` DSL builtin now flows through the same capture-aware stderr seam every other call site uses, instead of writing directly to fd 2.

User-visible value:
- Tests that capture stderr can assert on this advisory line.
- CI logs no longer interleave a raw-fd write with `zig test`'s own reporting when a formula's atomic-write fallback ever fires.

A pinning test in `tests/dsl_interpreter_test.zig` forces the `TempCreateFailed` branch (parent dir stripped to `0o555`) and asserts the warning text reaches the capture buffer, locking the seam in place.

## Related Issue

- None

## Notes for Reviewers

- None