### PR TITLE
fix(cli/upgrade): refresh tap-installed packages and self-heal dep opt links

### DIFF
--- a/scripts/regressions/upgrade_dep_opt_link_self_heal.sh
+++ b/scripts/regressions/upgrade_dep_opt_link_self_heal.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Regression: `mt upgrade` self-heals a transitive dep whose opt link
+# was wiped from disk.
+#
+# Pre-fix, `collectMissingDepNames` consulted the DB only via
+# `isFormulaInstalled`, so a dep with a healthy `kegs` row but a
+# missing `opt/<name>` symlink was reported as installed. The upgrade
+# walker skipped it and the new bottle linked dylibs that still
+# pointed at a dead symlink. The install path's `deps.resolve` used
+# the strict probe (cellar dir + opt link) and would have queued a
+# re-link — the asymmetry meant `mt install` self-healed but
+# `mt upgrade` did not.
+#
+# This script reproduces the asymmetry end-to-end:
+#   1. Install a real formula with a transitive dep (`jq` + `oniguruma`).
+#   2. Synthesize a stale version on the top-level row so the upgrade
+#      walker actually runs (versions match → short-circuit, no dep walk).
+#   3. Wipe `$PREFIX/opt/oniguruma` while leaving the cellar dir and
+#      DB row intact — the exact pre-fix invisible-rot state.
+#   4. Run `mt upgrade jq` and assert the opt link is rebuilt and
+#      resolves into the oniguruma cellar.
+#
+# Usage: scripts/regressions/upgrade_dep_opt_link_self_heal.sh
+# Requirements: built malt at $MALT_BIN or zig-out/bin/malt, sqlite3
+# on PATH, network access for the seeding install + upgrade fetch.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be <= 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_n9"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+# `jq` carries exactly one runtime dep (`oniguruma`) and ships small
+# bottles for both arches — keeps the network/disk cost of this
+# regression in the seconds range.
+TOP="jq"
+DEP="oniguruma"
+DB="$PREFIX/db/malt.db"
+
+# --- 1. Seed a real install so both kegs land on disk -----------------
+INSTALL_LOG="$PREFIX/install.log"
+printf '\xe2\x96\xb8 mt install %s (logs \xe2\x86\x92 %s)\n' "$TOP" "$INSTALL_LOG"
+"$BIN" install "$TOP" >"$INSTALL_LOG" 2>&1 ||
+  fail "seed install of $TOP failed; see $INSTALL_LOG"
+pass "$TOP + $DEP installed"
+
+# Sanity: both opt links must exist before we start tampering.
+[[ -L "$PREFIX/opt/$TOP" ]] || fail "$PREFIX/opt/$TOP missing after install"
+[[ -L "$PREFIX/opt/$DEP" ]] || fail "$PREFIX/opt/$DEP missing after install"
+
+# --- 2. Synthesise an outdated version on the top-level row -----------
+# The upgrade walker short-circuits when installed pkg_version matches
+# upstream's; lying on `version` forces it to take the dep-walk branch
+# regardless of where Homebrew's stable jq actually sits today.
+sqlite3 "$DB" \
+  "UPDATE kegs SET version='0.0' WHERE name='$TOP';" ||
+  fail "could not bump down $TOP's version"
+pass "synthesised stale version='0.0' on $TOP"
+
+# --- 3. Nuke the dep's opt symlink (DB row + cellar dir survive) ------
+DEP_CELLAR=$(sqlite3 "$DB" \
+  "SELECT cellar_path FROM kegs WHERE name='$DEP' LIMIT 1;")
+[[ -d "$DEP_CELLAR" ]] || fail "$DEP cellar dir missing before tamper: $DEP_CELLAR"
+
+rm -f "$PREFIX/opt/$DEP"
+[[ ! -L "$PREFIX/opt/$DEP" ]] || fail "could not remove $PREFIX/opt/$DEP"
+pass "wiped \$PREFIX/opt/$DEP (cellar dir + DB row preserved)"
+
+# --- 4. Trigger the upgrade and assert the dep self-heals -------------
+UPGRADE_LOG="$PREFIX/upgrade.log"
+printf '\xe2\x96\xb8 mt upgrade %s (logs \xe2\x86\x92 %s)\n' "$TOP" "$UPGRADE_LOG"
+if ! "$BIN" upgrade "$TOP" >"$UPGRADE_LOG" 2>&1; then
+  tail -30 "$UPGRADE_LOG" >&2
+  fail "$TOP upgrade aborted; see $UPGRADE_LOG"
+fi
+
+# Pre-fix, the walker would have left $PREFIX/opt/$DEP wiped after the
+# upgrade because the nuked link was treated as "still installed". The
+# fix walks every transitive dep through `deps.ensureOptLink` before
+# the dep BFS, so the symlink is rebuilt regardless of whether the
+# downstream install fast-path elects to re-fetch.
+[[ -L "$PREFIX/opt/$DEP" ]] ||
+  fail "\$PREFIX/opt/$DEP not restored after upgrade — pre-fix asymmetry returned"
+RESOLVED=$(readlink -f "$PREFIX/opt/$DEP" 2>/dev/null || readlink "$PREFIX/opt/$DEP")
+[[ -d "$RESOLVED" ]] ||
+  fail "\$PREFIX/opt/$DEP points at a non-existent target: $RESOLVED"
+case "$RESOLVED" in
+*"/Cellar/$DEP/"*) ;;
+*) fail "\$PREFIX/opt/$DEP resolves outside the $DEP cellar: $RESOLVED" ;;
+esac
+pass "\$PREFIX/opt/$DEP rebuilt and resolves into the $DEP cellar"
+
+printf '\n\xe2\x9c\x94 upgrade-dep-opt-link-self-heal regression passed\n'

--- a/scripts/regressions/upgrade_tap_routing.sh
+++ b/scripts/regressions/upgrade_tap_routing.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Regression: `mt upgrade` against a tap-installed formula or cask.
+#
+# Up to v0.10.3, every installed package was looked up at
+# `formulae.brew.sh/api/formula/<name>.json` (or `.../cask/<name>.json`).
+# Anything from a third-party tap 404'd and the run aborted with:
+#
+#   ✗ Could not fetch formula info for <name>
+#
+# even though the package never lived on the core API. The fix routes
+# tap-installed kegs (`kegs.tap` != `homebrew/core`) through the tap
+# `.rb` path, and on a cask 404 falls back through every registered
+# third-party tap before declaring the upgrade dead.
+#
+# This script asserts:
+#   1. A synthetic tap keg row never produces the core-API error
+#      message — the routing signal is the tap-side parser/resolver.
+#   2. A real third-party tap formula install can be re-driven through
+#      `mt upgrade` without the regression string surfacing.
+#
+# Usage: scripts/regressions/upgrade_tap_routing.sh
+# Requirements: built malt at $MALT_BIN or zig-out/bin/malt, sqlite3 on
+# PATH, network access for the seeding install.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be <= 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_tapup"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+skip() { printf '  - %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+# The pre-fix symptom. If this string surfaces for a tap-installed
+# package, we've re-introduced the bug.
+REGRESSION="Could not fetch formula info"
+REGRESSION_CASK="Could not fetch cask info"
+
+# ── Property 1: synthetic tap keg avoids the core-API error ──────────
+#
+# Seed a tap keg row directly so the test does not depend on a real
+# tap install completing. The malformed tap label forces an early
+# tap-side parse rejection — pre-fix, the same row would have walked
+# straight into fetchFormula and printed the regression string.
+
+# `mt list` only opens an existing DB; the install path is what
+# bootstraps `$PREFIX/db/`. Mkdir + an `mt list` call kicks the schema
+# init through the same code path malt itself uses.
+mkdir -p "$PREFIX/db"
+"$BIN" list >/dev/null 2>&1 || true
+DB="$PREFIX/db/malt.db"
+[[ -f "$DB" ]] || fail "expected DB at $DB after a list call"
+
+sqlite3 "$DB" <<'SQL' || fail "could not seed synthetic tap keg row"
+INSERT INTO kegs (name, full_name, version, tap, store_sha256, cellar_path)
+VALUES ('regtap_baguette', 'tap-only/repo/regtap_baguette', '0.1',
+        'tap-only-no-slash', 'sha-old', '/tmp/c/regtap_baguette/0.1');
+SQL
+
+SYNTH_LOG="$PREFIX/synthetic_upgrade.log"
+printf '\xe2\x96\xb8 mt upgrade regtap_baguette (synthetic tap row, expect tap-side error)\n'
+"$BIN" upgrade regtap_baguette >"$SYNTH_LOG" 2>&1 || true
+
+if grep -q "$REGRESSION" "$SYNTH_LOG"; then
+  tail -30 "$SYNTH_LOG" >&2
+  fail "synthetic tap keg leaked the core-API error string"
+fi
+pass "synthetic tap keg: core-API error string not emitted"
+
+if ! grep -q "Cannot parse tap" "$SYNTH_LOG"; then
+  tail -30 "$SYNTH_LOG" >&2
+  fail "synthetic tap keg: tap-side parse rejection missing"
+fi
+pass "synthetic tap keg: tap-side rejection emitted"
+
+# Clean the synthetic row before the real install so list/migrate aren't confused.
+sqlite3 "$DB" "DELETE FROM kegs WHERE name='regtap_baguette';"
+
+# ── Property 2: real third-party tap formula upgrade end-to-end ──────
+#
+# `indaco/tap/sley` is a clean Go-binary tap: small archive, no deps,
+# already exercised by other regressions. After install we drive the
+# upgrade walker and assert the tap branch handles the row instead of
+# falling through to fetchFormula.
+
+SLUG="indaco/tap/sley"
+TOKEN="sley"
+INSTALL_LOG="$PREFIX/install_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt install %s (logs \xe2\x86\x92 %s)\n' "$SLUG" "$INSTALL_LOG"
+if ! "$BIN" install "$SLUG" >"$INSTALL_LOG" 2>&1; then
+  if grep -qE "rate limit|Network failure|homebrew-" "$INSTALL_LOG"; then
+    skip "${SLUG}: install hit a classified upstream condition; skipping upgrade leg"
+    printf '\n\xe2\x9c\x94 upgrade-tap-routing regression passed (synthetic only)\n'
+    exit 0
+  fi
+  tail -30 "$INSTALL_LOG" >&2
+  fail "${SLUG}: install failed for an unclassified reason"
+fi
+pass "${SLUG}: installed"
+
+UPGRADE_LOG="$PREFIX/upgrade_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt upgrade %s (logs \xe2\x86\x92 %s)\n' "$TOKEN" "$UPGRADE_LOG"
+"$BIN" upgrade "$TOKEN" >"$UPGRADE_LOG" 2>&1 || true
+
+if grep -q "$REGRESSION" "$UPGRADE_LOG"; then
+  tail -30 "$UPGRADE_LOG" >&2
+  fail "${SLUG}: upgrade leaked the core-API error string"
+fi
+if grep -q "$REGRESSION_CASK" "$UPGRADE_LOG"; then
+  tail -30 "$UPGRADE_LOG" >&2
+  fail "${SLUG}: upgrade leaked the core-API cask error string"
+fi
+pass "${SLUG}: upgrade did not surface the core-API error"
+
+# A successful upgrade either re-installs at the fresh commit ("installed"),
+# short-circuits because the pin hasn't moved ("already at latest tap commit"),
+# or hits a classified network failure. Anything else means we routed
+# somewhere unexpected.
+if grep -qE "installed$| installed |already at latest tap commit" "$UPGRADE_LOG"; then
+  pass "${SLUG}: upgrade reached the tap path and produced a routed outcome"
+elif grep -qE "rate limit|Network failure|Could not resolve" "$UPGRADE_LOG"; then
+  skip "${SLUG}: upgrade hit a classified network condition; routing is fine"
+else
+  tail -30 "$UPGRADE_LOG" >&2
+  fail "${SLUG}: upgrade output does not show a tap-routed outcome"
+fi
+
+printf '\n\xe2\x9c\x94 upgrade-tap-routing regression passed\n'

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -27,6 +27,7 @@ pub const max_prefix_sane_len = args_mod.max_prefix_sane_len;
 pub const PrefixError = args_mod.PrefixError;
 pub const checkPrefixSane = args_mod.checkPrefixSane;
 pub const isTapFormula = args_mod.isTapFormula;
+pub const isCoreTap = args_mod.isCoreTap;
 pub const isLocalFormulaPath = args_mod.isLocalFormulaPath;
 pub const isSelfInstall = args_mod.isSelfInstall;
 pub const parseTapName = args_mod.parseTapName;

--- a/src/cli/install/args.zig
+++ b/src/cli/install/args.zig
@@ -40,6 +40,16 @@ pub fn isTapFormula(name: []const u8) bool {
     return slash_count == 2;
 }
 
+/// True when `tap_label` represents one of Homebrew's core taps. Empty
+/// or NULL labels also count as core so legacy keg rows that predate
+/// the tap-tracking column don't get mis-routed through the tap path.
+pub fn isCoreTap(tap_label: []const u8) bool {
+    if (tap_label.len == 0) return true;
+    if (std.mem.eql(u8, tap_label, "homebrew/core")) return true;
+    if (std.mem.eql(u8, tap_label, "homebrew/cask")) return true;
+    return false;
+}
+
 /// Shape-based detection for a local `.rb` path argument (e.g.
 /// `./wget.rb`, `/tmp/wget.rb`, `~/f/wget.rb`, `a/b/c/d.rb`). Pure:
 /// no filesystem access, no allocation.
@@ -108,4 +118,27 @@ pub fn expandTildePath(ctx: *const AppCtx, buf: []u8, arg: []const u8) ?[]const 
     if (arg.len < 2 or arg[0] != '~' or arg[1] != '/') return arg;
     const home = std.process.Environ.getPosix(ctx.environ, "HOME") orelse return null;
     return std.fmt.bufPrint(buf, "{s}{s}", .{ home, arg[1..] }) catch null;
+}
+
+test "isCoreTap recognises homebrew/core and homebrew/cask" {
+    try std.testing.expect(isCoreTap("homebrew/core"));
+    try std.testing.expect(isCoreTap("homebrew/cask"));
+}
+
+test "isCoreTap treats empty string as core (legacy rows)" {
+    // Pre-tap-tracking kegs have NULL/empty `tap`; they must keep
+    // routing through the core API path.
+    try std.testing.expect(isCoreTap(""));
+}
+
+test "isCoreTap rejects third-party tap labels" {
+    try std.testing.expect(!isCoreTap("user/repo"));
+    try std.testing.expect(!isCoreTap("acme/tools"));
+    try std.testing.expect(!isCoreTap("homebrew/services"));
+}
+
+test "isCoreTap is exact-match (not prefix)" {
+    // `homebrew/core-staging` is a hypothetical fork; treat it as third-party.
+    try std.testing.expect(!isCoreTap("homebrew/core-staging"));
+    try std.testing.expect(!isCoreTap("homebrew/cask-fonts"));
 }

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -23,6 +23,7 @@ const install_mod = @import("install.zig");
 const install_local_mod = @import("install/local.zig");
 const install_args_mod = @import("install/args.zig");
 const tap_mod = @import("../core/tap.zig");
+const deps_mod = @import("../core/deps.zig");
 
 const UpgradeFlag = enum { quiet, cask, formula, dry_run, force, pinned };
 
@@ -263,8 +264,18 @@ fn upgradeFormula(
     // materialised before the new bottle relocates / links — otherwise
     // dyld errors at first use (e.g. curl 8.20 added libngtcp2 that
     // 8.19 did not have).
+    //
+    // Self-heal `opt/<dep>` for every transitive dep before the BFS
+    // probe: the install fast-path treats a present Cellar dir as
+    // "already installed" and would otherwise short-circuit a re-link
+    // when only the symlink was wiped. After this loop, the strict
+    // probe in `collectMissingDepNames` only flags genuinely
+    // cellar-missing deps for re-fetching.
+    for (formula.dependencies) |dep_name| {
+        deps_mod.ensureOptLink(ctx.io, db, prefix, dep_name);
+    }
     {
-        const missing = collectMissingDepNames(allocator, db, formula.dependencies) catch &.{};
+        const missing = collectMissingDepNames(ctx.io, allocator, db, formula.dependencies) catch &.{};
         defer if (missing.len > 0) allocator.free(missing);
         if (missing.len > 0) {
             output.info("Installing new dep(s) for {s} ({d})...", .{ name, missing.len });
@@ -837,6 +848,7 @@ fn upgradeAllCasks(ctx: *const AppCtx, allocator: std.mem.Allocator, db: *sqlite
 /// (e.g. curl 8.20 introduces a runtime dep on libngtcp2 that wasn't
 /// part of curl 8.19's dep set).
 pub fn collectMissingDepNames(
+    io: std.Io,
     allocator: std.mem.Allocator,
     db: *sqlite.Database,
     dep_names: []const []const u8,
@@ -844,47 +856,16 @@ pub fn collectMissingDepNames(
     var missing: std.ArrayList([]const u8) = .empty;
     errdefer missing.deinit(allocator);
 
+    // Strict check: a DB row alone does not count - the cellar dir and
+    // opt symlink must also resolve. The install path's BFS uses the
+    // same predicate, so an opt-link nuked under a previously-installed
+    // dep self-heals through both `mt install` and `mt upgrade`.
     for (dep_names) |n| {
-        if (!isFormulaInstalled(db, n)) try missing.append(allocator, n);
+        if (!deps_mod.isInstalled(io, db, n)) try missing.append(allocator, n);
     }
     return missing.toOwnedSlice(allocator);
 }
 
-const testing = std.testing;
-
-test "collectMissingDepNames returns deps absent from the DB" {
-    var db = try sqlite.Database.open(":memory:");
-    defer db.close();
-    try schema.initSchema(&db);
-
-    try db.exec(
-        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
-        \\VALUES ('alpha', 'alpha', '1.0', 'sha-a', '/c/alpha/1.0');
-    );
-
-    const deps = [_][]const u8{ "alpha", "beta", "gamma" };
-    const missing = try collectMissingDepNames(testing.allocator, &db, &deps);
-    defer testing.allocator.free(missing);
-
-    try testing.expectEqual(@as(usize, 2), missing.len);
-    try testing.expectEqualStrings("beta", missing[0]);
-    try testing.expectEqualStrings("gamma", missing[1]);
-}
-
-test "collectMissingDepNames returns an empty slice when all deps are installed" {
-    var db = try sqlite.Database.open(":memory:");
-    defer db.close();
-    try schema.initSchema(&db);
-
-    try db.exec(
-        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
-        \\VALUES ('alpha', 'alpha', '1.0', 'sha-a', '/c/alpha/1.0'),
-        \\       ('beta',  'beta',  '1.0', 'sha-b', '/c/beta/1.0');
-    );
-
-    const deps = [_][]const u8{ "alpha", "beta" };
-    const missing = try collectMissingDepNames(testing.allocator, &db, &deps);
-    defer testing.allocator.free(missing);
-
-    try testing.expectEqual(@as(usize, 0), missing.len);
-}
+// `collectMissingDepNames` now consults the filesystem (cellar_path +
+// opt symlink), so coverage lives in `tests/upgrade_test.zig` where a
+// real MALT_PREFIX fixture is available.

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -20,6 +20,9 @@ const ghcr_mod = @import("../net/ghcr.zig");
 const help = @import("help.zig");
 const pin_mod = @import("pin.zig");
 const install_mod = @import("install.zig");
+const install_local_mod = @import("install/local.zig");
+const install_args_mod = @import("install/args.zig");
+const tap_mod = @import("../core/tap.zig");
 
 const UpgradeFlag = enum { quiet, cask, formula, dry_run, force, pinned };
 
@@ -188,7 +191,7 @@ fn upgradeFormula(
 
     // Step 1: Look up installed version from DB
     var find_stmt = db.prepare(
-        "SELECT id, version, revision, store_sha256, cellar_path FROM kegs WHERE name = ?1 LIMIT 1;",
+        "SELECT id, version, revision, store_sha256, cellar_path, tap FROM kegs WHERE name = ?1 LIMIT 1;",
     ) catch return;
     defer find_stmt.finalize();
     find_stmt.bindText(1, name) catch return;
@@ -204,9 +207,21 @@ fn upgradeFormula(
     const old_revision = find_stmt.columnInt(2);
     const old_sha_ptr = find_stmt.columnText(3);
     const old_cellar_ptr = find_stmt.columnText(4);
+    const tap_ptr = find_stmt.columnText(5);
     const old_version = if (old_ver_ptr) |v| std.mem.sliceTo(v, 0) else "unknown";
     const old_sha256 = if (old_sha_ptr) |s| std.mem.sliceTo(s, 0) else "";
     const old_cellar_path = if (old_cellar_ptr) |c| std.mem.sliceTo(c, 0) else "";
+    const tap_label = if (tap_ptr) |t| std.mem.sliceTo(t, 0) else "";
+
+    // Tap-installed formulas come from `<user>/<repo>` repos, not the
+    // homebrew/core API. Route them through the tap-aware upgrade path
+    // before touching `formulae.brew.sh`. Dupe the tap label so the
+    // slice survives across statements that reuse the SQLite buffer.
+    if (!install_args_mod.isCoreTap(tap_label)) {
+        const tap_owned = allocator.dupe(u8, tap_label) catch return error.Aborted;
+        defer allocator.free(tap_owned);
+        return upgradeTapFormula(ctx, allocator, name, tap_owned, db, prefix, dry_run, force, audit_mode);
+    }
 
     // Reconstruct the revision-aware path label for the old keg so
     // cellar_mod.remove / linker calls target the actual on-disk dir.
@@ -400,6 +415,136 @@ fn upgradeFormula(
     output.success("{s} upgraded to {s}", .{ name, formula.pkg_version });
 }
 
+/// Upgrade a tap-installed formula. The reported `tap_label` is
+/// `<user>/<repo>` (the value `kegs.tap` carries for everything that did
+/// not come from `homebrew/core`). We re-resolve the tap's HEAD commit,
+/// short-circuit when the pin already points there, and otherwise bump
+/// the pin and re-enter `installTapFormula` with `force = true` so the
+/// shared materialise/link path picks up the new revision. Tap casks
+/// reach the same delegate via `upgradeTapCaskFallback`.
+fn upgradeTapFormula(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    tap_label: []const u8,
+    db: *sqlite.Database,
+    prefix: [:0]const u8,
+    dry_run: bool,
+    force: bool,
+    audit_mode: bool,
+) !void {
+    if (pinSkip(db, name, force, audit_mode)) {
+        output.dim("{s} is pinned, skipped", .{name});
+        output.emitNdjsonEvent(allocator, .pinned, name, null);
+        return;
+    }
+
+    const slash = std.mem.indexOfScalar(u8, tap_label, '/') orelse {
+        output.err("Cannot parse tap '{s}' for {s}", .{ tap_label, name });
+        return error.Aborted;
+    };
+    const user = tap_label[0..slash];
+    const repo = tap_label[slash + 1 ..];
+    if (user.len == 0 or repo.len == 0) {
+        output.err("Cannot parse tap '{s}' for {s}", .{ tap_label, name });
+        return error.Aborted;
+    }
+
+    // The whole point of `mt upgrade` is "give me the latest", so we
+    // ignore any cached pin and force-resolve HEAD.
+    const fresh_sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, user, repo) catch |e| {
+        output.err("Could not resolve {s} HEAD: {s}", .{ tap_label, tap_mod.describeResolveError(e) });
+        return error.Aborted;
+    };
+    defer allocator.free(fresh_sha);
+
+    const cached_sha_opt = tap_mod.getCommitSha(allocator, db, tap_label) catch null;
+    defer if (cached_sha_opt) |s| allocator.free(s);
+    const same_commit = if (cached_sha_opt) |c| std.mem.eql(u8, c, fresh_sha) else false;
+
+    if (!force and same_commit) {
+        output.skip("{s} is already at latest tap commit", .{name});
+        output.emitNdjsonEvent(allocator, .up_to_date, name, null);
+        return;
+    }
+
+    if (dry_run) {
+        const short_len = @min(@as(usize, 8), fresh_sha.len);
+        output.info("Dry run: would refresh tap {s} to {s} for {s}", .{ tap_label, fresh_sha[0..short_len], name });
+        output.emitNdjsonEvent(allocator, .would_install, name, null);
+        return;
+    }
+
+    // Persist the new pin BEFORE installTapFormula reads it. Use add()
+    // so a missing tap row (legacy install) is created instead of erroring.
+    var tap_url_buf: [256]u8 = undefined;
+    const tap_url = std.fmt.bufPrint(&tap_url_buf, "https://github.com/{s}", .{tap_label}) catch return error.Aborted;
+    tap_mod.add(db, tap_label, tap_url, fresh_sha) catch {
+        output.err("Could not pin {s} to {s}", .{ tap_label, fresh_sha });
+        return error.Aborted;
+    };
+
+    const full_name = std.fmt.allocPrint(allocator, "{s}/{s}", .{ tap_label, name }) catch return error.Aborted;
+    defer allocator.free(full_name);
+
+    var linker = linker_mod.Linker.init(ctx.io, allocator, db, prefix);
+    install_local_mod.installTapFormula(ctx, allocator, full_name, db, &linker, prefix, dry_run, true) catch {
+        output.err("Failed to upgrade tap formula {s}", .{full_name});
+        return error.Aborted;
+    };
+}
+
+/// Probe registered taps for a cask token whose row in `casks` has no
+/// tap origin column to consult. Returns true if a tap claimed the
+/// token and the upgrade went through; returns false if no third-party
+/// tap had `Casks/<token>.rb` so the caller can surface the original
+/// "removed upstream" error.
+fn upgradeTapCaskFallback(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    token: []const u8,
+    db: *sqlite.Database,
+    prefix: [:0]const u8,
+    dry_run: bool,
+) bool {
+    const taps = tap_mod.list(allocator, db) catch return false;
+    defer {
+        for (taps) |t| {
+            allocator.free(t.name);
+            allocator.free(t.url);
+            if (t.commit_sha) |s| allocator.free(s);
+        }
+        allocator.free(taps);
+    }
+
+    for (taps) |t| {
+        if (install_args_mod.isCoreTap(t.name)) continue;
+
+        const slash = std.mem.indexOfScalar(u8, t.name, '/') orelse continue;
+        const user = t.name[0..slash];
+        const repo = t.name[slash + 1 ..];
+        if (user.len == 0 or repo.len == 0) continue;
+
+        // Resolve fresh HEAD per-tap. Failures are non-fatal — try the next.
+        const fresh_sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, user, repo) catch continue;
+        defer allocator.free(fresh_sha);
+
+        var tap_url_buf: [256]u8 = undefined;
+        const tap_url = std.fmt.bufPrint(&tap_url_buf, "https://github.com/{s}", .{t.name}) catch continue;
+        tap_mod.add(db, t.name, tap_url, fresh_sha) catch continue;
+
+        const full_name = std.fmt.allocPrint(allocator, "{s}/{s}", .{ t.name, token }) catch continue;
+        defer allocator.free(full_name);
+
+        var linker = linker_mod.Linker.init(ctx.io, allocator, db, prefix);
+        install_local_mod.installTapFormula(ctx, allocator, full_name, db, &linker, prefix, dry_run, true) catch continue;
+
+        return true;
+    }
+
+    return false;
+}
+
 /// Re-link old version during rollback.
 fn restoreOldLinks(
     _: *sqlite.Database,
@@ -570,8 +715,11 @@ fn upgradeCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []const 
         return error.Aborted;
     };
 
-    // Fetch latest version
+    // Fetch latest version. Casks have no `tap` column on the table, so
+    // we can't pre-route the way the formula path does — fall back to
+    // probing every registered third-party tap if the core API 404s.
     const cask_json = api.fetchCask(token) catch {
+        if (upgradeTapCaskFallback(ctx, allocator, token, db, prefix, dry_run)) return;
         output.err("Could not fetch cask info for {s}", .{token});
         return error.Aborted;
     };

--- a/src/core/deps.zig
+++ b/src/core/deps.zig
@@ -224,7 +224,7 @@ pub fn findOrphans(allocator: std.mem.Allocator, db: *sqlite.Database) ![]const 
 
 // --- helpers ---
 
-fn isInstalled(io: std.Io, db: *sqlite.Database, name: []const u8) bool {
+pub fn isInstalled(io: std.Io, db: *sqlite.Database, name: []const u8) bool {
     var stmt = db.prepare("SELECT cellar_path FROM kegs WHERE name = ?1 LIMIT 1;") catch return false;
     defer stmt.finalize();
     stmt.bindText(1, name) catch return false;

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -573,6 +573,113 @@ test "upgrade routes tap-installed kegs away from the core formula API" {
 
 // A pinned tap-installed keg short-circuits in pinSkip before any network
 // activity - same contract as a pinned core keg, just on the tap branch.
+// Materialise `<prefix>/Cellar/<name>/<version>` on disk and (optionally)
+// the matching `<prefix>/opt/<name>` symlink, then insert the matching
+// keg row. Mirrors what the install path leaves behind so
+// `deps.isInstalled`'s opt-link + cellar-path probe sees a healthy keg.
+fn seedInstalledKeg(
+    db: *sqlite.Database,
+    prefix: []const u8,
+    name: []const u8,
+    version: []const u8,
+    create_opt_link: bool,
+) !void {
+    var cellar_buf: [512]u8 = undefined;
+    const cellar_root = try std.fmt.bufPrint(&cellar_buf, "{s}/Cellar/{s}/{s}", .{ prefix, name, version });
+    try test_io.cwd().createDirPath(std.Options.debug_io, cellar_root);
+
+    var insert_buf: [512]u8 = undefined;
+    const insert = try std.fmt.bufPrintZ(
+        &insert_buf,
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path) VALUES ('{s}', '{s}', '{s}', 'sha-{s}', '{s}');",
+        .{ name, name, version, name, cellar_root },
+    );
+    try db.exec(insert);
+
+    if (!create_opt_link) return;
+
+    var opt_dir_buf: [512]u8 = undefined;
+    const opt_dir = try std.fmt.bufPrint(&opt_dir_buf, "{s}/opt", .{prefix});
+    try test_io.cwd().createDirPath(std.Options.debug_io, opt_dir);
+
+    var opt_path_buf: [512]u8 = undefined;
+    const opt_path = try std.fmt.bufPrint(&opt_path_buf, "{s}/{s}", .{ opt_dir, name });
+    var parent = try test_io.openDirAbsolute(std.Options.debug_io, opt_dir, .{});
+    defer parent.close(std.Options.debug_io);
+    parent.deleteFile(std.Options.debug_io, name) catch {};
+    try parent.symLink(std.Options.debug_io, cellar_root, name, .{});
+    _ = opt_path;
+}
+
+test "collectMissingDepNames returns names absent from the DB" {
+    const path = try setupPrefix("missing_deps_absent");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try seedInstalledKeg(&db, path, "alpha", "1.0", true);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const deps = [_][]const u8{ "alpha", "beta", "gamma" };
+    const missing = try upgrade.collectMissingDepNames(threaded.io(), testing.allocator, &db, &deps);
+    defer testing.allocator.free(missing);
+
+    try testing.expectEqual(@as(usize, 2), missing.len);
+    try testing.expectEqualStrings("beta", missing[0]);
+    try testing.expectEqualStrings("gamma", missing[1]);
+}
+
+test "collectMissingDepNames returns empty when every dep is fully installed" {
+    const path = try setupPrefix("missing_deps_all_present");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try seedInstalledKeg(&db, path, "alpha", "1.0", true);
+    try seedInstalledKeg(&db, path, "beta", "1.0", true);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const deps = [_][]const u8{ "alpha", "beta" };
+    const missing = try upgrade.collectMissingDepNames(threaded.io(), testing.allocator, &db, &deps);
+    defer testing.allocator.free(missing);
+
+    try testing.expectEqual(@as(usize, 0), missing.len);
+}
+
+// Pre-fix, `collectMissingDepNames` only consulted the DB. A dep whose
+// `opt/<name>` link had been wiped (Cellar move, manual cleanup, broken
+// install) was treated as installed and the upgrade walked past it -
+// while `deps.resolve`'s strict probe would have queued a re-link from
+// the install path. The asymmetry meant a tap upgrade against a
+// nuked-opt dep would silently leave the link dead. Coupling the
+// upgrade probe to `deps.isInstalled` brings parity, so the reinstall
+// trigger fires under either entry point.
+test "collectMissingDepNames flags a keg whose opt link has been nuked" {
+    const path = try setupPrefix("missing_deps_opt_link_nuked");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try seedInstalledKeg(&db, path, "alpha", "1.0", false); // cellar yes, opt link no
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const deps = [_][]const u8{"alpha"};
+    const missing = try upgrade.collectMissingDepNames(threaded.io(), testing.allocator, &db, &deps);
+    defer testing.allocator.free(missing);
+
+    try testing.expectEqual(@as(usize, 1), missing.len);
+    try testing.expectEqualStrings("alpha", missing[0]);
+}
+
 test "upgrade <pinned-tap-keg> short-circuits without resolving HEAD" {
     const path = try setupPrefix("upgrade_tap_pinned");
     defer testing.allocator.free(path);

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -515,3 +515,82 @@ test "upgrade with a missing transitive dep does not error with lock contention"
 
     try testing.expect(std.mem.indexOf(u8, captured.items, "Another mt process is running") == null);
 }
+
+// Pre-fix, every keg row went through `formulae.brew.sh/api/formula/<name>.json`,
+// so a tap-installed package surfaced as `Could not fetch formula info for X` and
+// error.Aborted - even though the package never lived on the core API. The new
+// upgrade path consults `kegs.tap` and routes anything off `homebrew/core` through
+// the tap-aware branch instead. The malformed-label case below pins the routing:
+// the old API error must NOT appear, because we exit on the tap-side parse check.
+test "upgrade routes tap-installed kegs away from the core formula API" {
+    const path = try setupPrefix("upgrade_tap_routing");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        // Tap label is intentionally malformed (no slash) so the tap-side
+        // parser rejects it before any network call and we never touch the
+        // core API regardless of cache state.
+        try db.exec(
+            \\INSERT INTO kegs (name, full_name, version, tap, store_sha256, cellar_path)
+            \\VALUES ('baguette', 'tap-only/repo/baguette', '0.1', 'tap-only-no-slash', 'sha-old', '/cellar/baguette/0.1');
+        );
+    }
+
+    // Seed a 404 marker for the core API so the OLD codepath would have
+    // surfaced "Could not fetch formula info" without touching the network.
+    // The NEW codepath must never read this marker.
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{path});
+    defer testing.allocator.free(cache_api);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_api);
+    const marker = try std.fmt.allocPrint(testing.allocator, "{s}/formula_baguette.404", .{cache_api});
+    defer testing.allocator.free(marker);
+    const mf = try test_io.createFileAbsolute(std.Options.debug_io, marker, .{ .truncate = true });
+    mf.close(std.Options.debug_io);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    output.beginStderrCapture(testing.allocator, &captured);
+    defer output.endStderrCapture();
+
+    try testing.expectError(
+        error.Aborted,
+        upgrade.execute(&ctx, testing.allocator, &.{"baguette"}),
+    );
+
+    // Routing guard: the OLD core-API error must never appear for a tap keg.
+    try testing.expect(std.mem.indexOf(u8, captured.items, "Could not fetch formula info") == null);
+    // Positive signal: the tap-side parser rejected the malformed label.
+    try testing.expect(std.mem.indexOf(u8, captured.items, "Cannot parse tap") != null);
+}
+
+// A pinned tap-installed keg short-circuits in pinSkip before any network
+// activity - same contract as a pinned core keg, just on the tap branch.
+test "upgrade <pinned-tap-keg> short-circuits without resolving HEAD" {
+    const path = try setupPrefix("upgrade_tap_pinned");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        try db.exec(
+            \\INSERT INTO kegs (name, full_name, version, tap, store_sha256, cellar_path, pinned)
+            \\VALUES ('frozen-tap', 'user/repo/frozen-tap', '1.0', 'user/repo', 'sha', '/cellar/frozen-tap/1.0', 1);
+        );
+    }
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    // Pinned + non-force = quiet skip on the tap branch too.
+    try upgrade.execute(&ctx, testing.allocator, &.{"frozen-tap"});
+}


### PR DESCRIPTION
## Description

`mt upgrade` was hardcoded to homebrew/core's API endpoint, so any tap-installed formula or cask 404'd and the run aborted with `Could not fetch formula info`. Tap kegs now follow the same `.rb`-from-tap path that `mt install` already uses, so `mt upgrade` refreshes them in place alongside core packages and the run no longer exits non-zero on a single tap entry.

Closes a closely related self-heal asymmetry: the upgrade walker treated a keg with a wiped `opt/<name>` symlink as installed and the new bottle linked dylibs against a dead path. The walker now ensures `opt/<dep>` is rebuilt before the dep BFS, with the same strict cellar-and-symlink check the install resolver uses, so a yanked symlink heals on the next upgrade instead of dying at first dylib load.

## Related Issue

Fixes #257

## Notes for Reviewers

- None