### PR TITLE
fix(core): route post_install subprocess stdio via AppCtx

### DIFF
--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -10,6 +10,7 @@ const deps_mod = @import("../../core/deps.zig");
 const formula_mod = @import("../../core/formula.zig");
 const dsl = @import("../../core/dsl/root.zig");
 const ruby_sub = @import("../../core/ruby_subprocess.zig");
+const sandbox = @import("../../core/sandbox/macos.zig");
 const output = @import("../../ui/output.zig");
 
 const download = @import("download.zig");
@@ -140,10 +141,11 @@ pub fn routePostInstallOutcomeWithBody(
             output.warn("post_install DSL incomplete for {s}, falling back to system Ruby...", .{name});
             if (output.isVerbose()) flog.printUnknown(name);
             if (output.isDebug()) flog.printFatal(name);
+            const ruby_stdio: sandbox.Stdio = .{ .out = ctx.stdout.handle, .err = ctx.stderr.handle };
             const ruby_result: anyerror!void = if (pre_resolved_body) |body|
-                ruby_sub.runPostInstallWithBody(ctx.io, ctx.environ, allocator, name, version_str, prefix, body)
+                ruby_sub.runPostInstallWithBody(ctx.io, ctx.environ, allocator, name, version_str, prefix, body, ruby_stdio)
             else
-                ruby_sub.runPostInstall(ctx.io, ctx.environ, allocator, name, version_str, prefix);
+                ruby_sub.runPostInstall(ctx.io, ctx.environ, allocator, name, version_str, prefix, ruby_stdio);
             ruby_result catch |e| {
                 const err: ruby_sub.RubyError = @errorCast(e);
                 output.warn("post_install subprocess failed for {s}: {s}", .{ name, ruby_sub.describeError(err) });
@@ -389,7 +391,8 @@ pub fn drive(
 
     if (useSystemRubyForFormula(use_system_ruby_list, name) or isSelfHostingRubyKeg(name)) {
         output.warn("Running post_install for {s} via system Ruby...", .{name});
-        ruby_sub.runPostInstall(ctx.io, ctx.environ, allocator, name, version_str, prefix) catch |e| {
+        const ruby_stdio: sandbox.Stdio = .{ .out = ctx.stdout.handle, .err = ctx.stderr.handle };
+        ruby_sub.runPostInstall(ctx.io, ctx.environ, allocator, name, version_str, prefix, ruby_stdio) catch |e| {
             output.warn("post_install failed for {s}: {s}", .{ name, ruby_sub.describeError(e) });
         };
     } else {

--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -512,6 +512,7 @@ pub fn runPostInstall(
     name: []const u8,
     version: []const u8,
     prefix: []const u8,
+    stdio: sandbox.Stdio,
 ) RubyError!void {
     // 0. Boundary validation — must run before body resolution so a
     //    hostile name can't reach `fetchPostInstallFromGitHub` (which
@@ -524,7 +525,7 @@ pub fn runPostInstall(
     const body = resolvePostInstallBody(io, environ, allocator, name) orelse
         return RubyError.TapNotFound;
     defer allocator.free(body);
-    return runPostInstallWithBody(io, environ, allocator, name, version, prefix, body);
+    return runPostInstallWithBody(io, environ, allocator, name, version, prefix, body, stdio);
 }
 
 fn validateRunPostInstallInputs(name: []const u8, version: []const u8, prefix: []const u8) RubyError!void {
@@ -547,6 +548,7 @@ pub fn runPostInstallWithBody(
     version: []const u8,
     prefix: []const u8,
     body: []const u8,
+    stdio: sandbox.Stdio,
 ) RubyError!void {
     // 0. Validate inputs at the boundary. A hostile Cellar dir name (the
     //    on-disk source of `name` on the runPostInstall path) must die
@@ -626,6 +628,7 @@ pub fn runPostInstallWithBody(
         prefix,
         env,
         .{},
+        stdio,
     ) catch return RubyError.PostInstallFailed;
     if (exit_code != 0) return RubyError.PostInstallFailed;
 }

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -39,6 +39,16 @@ pub const ScrubbedEnv = struct {
 /// Minimal PATH — keeps a hostile formula off user-owned bin prefixes.
 pub const SANDBOX_PATH: []const u8 = "/usr/bin:/bin:/usr/sbin:/sbin";
 
+/// Where the sandboxed child's stdout/stderr land. Production passes the
+/// process's real fd 1/2; tests redirect to `/dev/null` so subprocess
+/// chatter doesn't leak past `output.beginStderrCapture` into the build
+/// runner's `result_error_msgs` (which would print a misleading
+/// `failed command:` against a passing test).
+pub const Stdio = struct {
+    out: c_int = std.posix.STDOUT_FILENO,
+    err: c_int = std.posix.STDERR_FILENO,
+};
+
 /// Reject any byte that could break out of a `(subpath "...")` token.
 pub fn validatePathForProfile(p: []const u8) SandboxError!void {
     if (p.len == 0 or p[0] != '/') return SandboxError.UnsafePath;
@@ -183,7 +193,9 @@ pub fn freeArgv(allocator: std.mem.Allocator, argv: [:null]?[*:0]u8) void {
 
 /// Spawn `ruby tmp_script` under `sandbox-exec` with scrubbed env and limits.
 /// Child stdout/stderr are run through `term_sanitize` to strip OSC/DCS/cursor
-/// escapes before forwarding; `MALT_ALLOW_RAW_POST_INSTALL=1` bypasses.
+/// escapes before forwarding to `stdio.out`/`stdio.err`;
+/// `MALT_ALLOW_RAW_POST_INSTALL=1` bypasses the sanitizer but still honours
+/// the configured fds.
 pub fn runRubySandboxed(
     allocator: std.mem.Allocator,
     environ: std.process.Environ,
@@ -193,6 +205,7 @@ pub fn runRubySandboxed(
     malt_prefix: []const u8,
     env: ScrubbedEnv,
     limits: Limits,
+    stdio: Stdio,
 ) SandboxError!u8 {
     if (builtin.os.tag != .macos) return SandboxError.SandboxUnsupported;
 
@@ -209,9 +222,9 @@ pub fn runRubySandboxed(
     defer freeEnvp(allocator, envp);
 
     if (rawPassthroughEnabled(environ)) {
-        return spawnInherit(argv_z, envp, limits);
+        return spawnInherit(argv_z, envp, limits, stdio);
     }
-    return spawnFiltered(argv_z, envp, limits);
+    return spawnFiltered(argv_z, envp, limits, stdio);
 }
 
 fn rawPassthroughEnabled(environ: std.process.Environ) bool {
@@ -223,10 +236,16 @@ fn spawnInherit(
     argv_z: [:null]?[*:0]u8,
     envp: [:null]?[*:0]u8,
     limits: Limits,
+    stdio: Stdio,
 ) SandboxError!u8 {
     const pid = std.c.fork();
     if (pid < 0) return SandboxError.ForkFailed;
     if (pid == 0) {
+        // dup2 is a no-op when source equals destination, so unconditional
+        // redirection keeps the production path identical to the old
+        // inherited-stdio behaviour while letting tests sink to /dev/null.
+        _ = std.c.dup2(stdio.out, std.posix.STDOUT_FILENO);
+        _ = std.c.dup2(stdio.err, std.posix.STDERR_FILENO);
         applyRlimits(limits) catch std.c._exit(127);
         _ = std.c.execve(argv_z[0].?, argv_z.ptr, envp.ptr);
         std.c._exit(127);
@@ -272,8 +291,9 @@ fn spawnFiltered(
     argv_z: [:null]?[*:0]u8,
     envp: [:null]?[*:0]u8,
     limits: Limits,
+    stdio: Stdio,
 ) SandboxError!u8 {
-    return spawnFilteredWithHooks(argv_z, envp, limits, .{});
+    return spawnFilteredWithHooks(argv_z, envp, limits, stdio, .{});
 }
 
 fn maybeSpawnFilter(
@@ -298,6 +318,7 @@ pub fn spawnFilteredWithHooks(
     argv_z: [:null]?[*:0]u8,
     envp: [:null]?[*:0]u8,
     limits: Limits,
+    stdio: Stdio,
     hooks: SpawnHooks,
 ) SandboxError!u8 {
     var out_r: Fd = .{};
@@ -345,12 +366,12 @@ pub fn spawnFilteredWithHooks(
         if (err_thread) |t| t.join();
     }
 
-    out_thread = maybeSpawnFilter(hooks, 0, out_r.value, 1) catch
+    out_thread = maybeSpawnFilter(hooks, 0, out_r.value, stdio.out) catch
         return SandboxError.ForkFailed;
     // Thread owns the read end now; its own `defer close` releases it.
     out_r.value = -1;
 
-    err_thread = maybeSpawnFilter(hooks, 1, err_r.value, 2) catch
+    err_thread = maybeSpawnFilter(hooks, 1, err_r.value, stdio.err) catch
         return SandboxError.ForkFailed;
     err_r.value = -1;
 

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -492,6 +492,32 @@ const io_mod = @import("malt").output;
 const color_mod = @import("malt").color;
 const output_mod = @import("malt").output;
 
+/// Construct an `AppCtx` whose `stdout`/`stderr` point at `/dev/null`.
+/// The `routePostInstallOutcome` Ruby fallback path forwards the
+/// sandboxed child's fd 1/2 to `ctx.stdout.handle`/`ctx.stderr.handle`;
+/// without this redirect, child stderr lands on the test runner's real
+/// fd 2 and the build-runner promotes the bytes to `result_error_msgs`,
+/// printing a misleading `failed command:` against a passing test.
+/// Caller closes the returned fd via `closeDevnullCtx`.
+fn devnullCtx() !struct { ctx: malt.app_ctx.AppCtx, fd: std.c.fd_t } {
+    const fd = std.c.open("/dev/null", .{ .ACCMODE = .RDWR }, @as(std.c.mode_t, 0));
+    if (fd < 0) return error.DevnullOpenFailed;
+    const file: std.Io.File = .{ .handle = fd, .flags = .{ .nonblocking = false } };
+    return .{
+        .ctx = .{
+            .io = malt.app_ctx.debug_ctx.io,
+            .environ = malt.app_ctx.debug_ctx.environ,
+            .stdout = file,
+            .stderr = file,
+        },
+        .fd = fd,
+    };
+}
+
+fn closeDevnullCtx(fd: std.c.fd_t) void {
+    _ = std.c.close(fd);
+}
+
 /// Capture stderr output from a single router call and return the raw
 /// bytes. Caller owns the buffer. Deterministic state (no color / no
 /// emoji / not quiet) so the assertions pin plain ASCII prefixes.
@@ -512,7 +538,10 @@ fn runRoute(
     io_mod.beginStderrCapture(testing.allocator, &buf);
     defer io_mod.endStderrCapture();
 
-    install.routePostInstallOutcome(&malt.app_ctx.debug_ctx, testing.allocator, name, "1.0", "/tmp/irrelevant", flog, scope);
+    const dn = try devnullCtx();
+    defer closeDevnullCtx(dn.fd);
+
+    install.routePostInstallOutcome(&dn.ctx, testing.allocator, name, "1.0", "/tmp/irrelevant", flog, scope);
 
     return buf.toOwnedSlice(testing.allocator);
 }
@@ -818,7 +847,10 @@ fn runRouteCaptureStdout(
     io_mod.beginStderrCapture(testing.allocator, &stderr_buf);
     defer io_mod.endStderrCapture();
 
-    install.routePostInstallOutcome(&malt.app_ctx.debug_ctx, testing.allocator, name, "1.0", "/tmp/irrelevant", flog, scope);
+    const dn = try devnullCtx();
+    defer closeDevnullCtx(dn.fd);
+
+    install.routePostInstallOutcome(&dn.ctx, testing.allocator, name, "1.0", "/tmp/irrelevant", flog, scope);
     return stdout_buf.toOwnedSlice(testing.allocator);
 }
 

--- a/tests/ruby_subprocess_test.zig
+++ b/tests/ruby_subprocess_test.zig
@@ -461,7 +461,7 @@ test "ca-certificates-shape: dispatcher with unparseable siblings leaves flog cl
 fn runPostInstallTest(name: []const u8, version: []const u8, prefix: []const u8) ruby.RubyError!void {
     var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
     defer threaded.deinit();
-    return ruby.runPostInstall(threaded.io(), testEnviron(), testing.allocator, name, version, prefix);
+    return ruby.runPostInstall(threaded.io(), testEnviron(), testing.allocator, name, version, prefix, .{});
 }
 
 test "runPostInstall rejects single-quote in name with InvalidInput" {

--- a/tests/sandbox_macos_test.zig
+++ b/tests/sandbox_macos_test.zig
@@ -121,7 +121,7 @@ test "spawnFilteredWithHooks reaps child when first reader-thread spawn fails" {
     defer sandbox.freeEnvp(testing.allocator, envp);
 
     var obs: ReapObserver = .{};
-    const result = sandbox.spawnFilteredWithHooks(argv_z, envp, .{}, .{
+    const result = sandbox.spawnFilteredWithHooks(argv_z, envp, .{}, .{}, .{
         .fail_thread_spawn_on = 0,
         .on_child_reaped = ReapObserver.cb,
         .ctx = &obs,
@@ -148,7 +148,7 @@ test "spawnFilteredWithHooks reaps child and joins out-thread when second spawn 
     defer sandbox.freeEnvp(testing.allocator, envp);
 
     var obs: ReapObserver = .{};
-    const result = sandbox.spawnFilteredWithHooks(argv_z, envp, .{}, .{
+    const result = sandbox.spawnFilteredWithHooks(argv_z, envp, .{}, .{}, .{
         .fail_thread_spawn_on = 1,
         .on_child_reaped = ReapObserver.cb,
         .ctx = &obs,
@@ -157,4 +157,46 @@ test "spawnFilteredWithHooks reaps child and joins out-thread when second spawn 
     try testing.expectError(error.ForkFailed, result);
     try testing.expectEqual(@as(u32, 1), obs.call_count);
     try testing.expect(obs.reaped_pid > 0);
+}
+
+// Pin the Stdio seam: the filter loop must route child stderr to
+// `stdio.err` rather than the parent's hardcoded fd 2 — tests rely on
+// that to keep subprocess chatter out of the build runner's
+// `result_error_msgs` (which would otherwise print a misleading
+// `failed command:` against a passing test).
+test "spawnFilteredWithHooks routes child stderr to the configured fd" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+
+    const argv = [_][]const u8{ "/bin/sh", "-c", "printf %s err-via-fd >&2" };
+    const argv_z = try sandbox.buildArgv(testing.allocator, argv[0..]);
+    defer sandbox.freeArgv(testing.allocator, argv_z);
+
+    const envp = try sandbox.buildEnvp(testing.allocator, .{
+        .home = "/tmp",
+        .path = sandbox.SANDBOX_PATH,
+        .malt_prefix = "/tmp",
+        .tmpdir = "/tmp",
+    });
+    defer sandbox.freeEnvp(testing.allocator, envp);
+
+    var pipe_fds: [2]std.c.fd_t = undefined;
+    if (std.c.pipe(&pipe_fds) != 0) return error.PipeFailed;
+    defer _ = std.c.close(pipe_fds[0]);
+
+    const exit = try sandbox.spawnFilteredWithHooks(
+        argv_z,
+        envp,
+        .{},
+        .{ .out = std.posix.STDOUT_FILENO, .err = pipe_fds[1] },
+        .{},
+    );
+    // Drop the parent's write end so the read end sees EOF after the
+    // filter thread closes its dup'd copy.
+    _ = std.c.close(pipe_fds[1]);
+    try testing.expectEqual(@as(u8, 0), exit);
+
+    var buf: [128]u8 = undefined;
+    const n = std.c.read(pipe_fds[0], &buf, buf.len);
+    try testing.expect(n > 0);
+    try testing.expectEqualStrings("err-via-fd", buf[0..@intCast(n)]);
 }


### PR DESCRIPTION
## Description

`zig build test` and CI runs printed a misleading `failed command:` line for `install_pure_test` even though every test passed and the suite returned exit 0. The four `routePostInstallOutcome` tests that exercise the system-Ruby fallback spawn a real Ruby subprocess; the sandbox's filter loop forwarded child stderr straight to the parent's hardcoded fd 2, where Zig's build runner promoted any non-empty stderr to `result_error_msgs` and rendered the false alarm.

This change routes post_install subprocess stdio through `AppCtx.stdout`/`AppCtx.stderr`. Production callers keep inheriting the real fd 1/2; tests construct an `AppCtx` whose stdio points at `/dev/null` so subprocess chatter stays out of the build runner's view. The result is clean test output locally and on CI without softening any production path or deepening the existing `core/ → ui/output` coupling.

## Related Issue

- None

## Notes for Reviewers

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)