### PR TITLE
refactor(install): defer-release the token-prefetch HTTP client

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -521,10 +521,10 @@ fn executeWithOpts(
             var it = repo_set.keyIterator();
             while (it.next()) |k| try repos.append(allocator, k.*);
             const pre_http = http_pool.acquire();
+            defer http_pool.release(pre_http);
             // Best-effort cache warm — any failure (OOM or network) is
             // absorbed so workers fall back to per-repo fetchToken calls.
             ghcr.prefetchTokens(pre_http, repos.items) catch {};
-            http_pool.release(pre_http);
         }
 
         // Set up multi-progress: assign line indices and create coordinator


### PR DESCRIPTION
## Description

Hardens the token-prefetch path in `mt install` so the shared HTTP pool slot is released even if `prefetchTokens` ever evolves into a panicking or returning shape. Today the call swallows its errors, so the explicit release is enough; the moment that contract changes, every subsequent worker would block forever on `acquire`. A `defer` makes the slot lifetime independent of the call's future error shape, matching the discipline already used by `downloadWorker` and the migrate parallel pool.

## Related Issue

- None

## Notes for Reviewers

- None