### PR TITLE
fix(core/store): wrap remove in a transaction to keep DB consistent

### DIFF
--- a/src/core/store.zig
+++ b/src/core/store.zig
@@ -60,18 +60,26 @@ pub const Store = struct {
     /// row delete, refcount-0 rows keep returning from `orphans()` on every
     /// purge run — the bug `doctor --fix` already worked around.  deleteTree
     /// is a no-op on a missing path, so phantom rows still trigger DB cleanup.
+    /// The DB delete runs inside an immediate transaction so concurrent
+    /// readers never observe a half-resolved store_refs state.
     pub fn remove(self: *Store, sha256: []const u8) StoreError!void {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
 
         var buf: [512]u8 = undefined;
         const p = std.fmt.bufPrint(&buf, "{s}/store/{s}", .{ self.prefix, sha256 }) catch return StoreError.OutOfMemory;
+
+        self.db.beginTransaction() catch return StoreError.RefCountError;
+        errdefer self.db.rollback();
+
         std.Io.Dir.cwd().deleteTree(self.io, p) catch return StoreError.RemoveFailed;
 
         var stmt = self.db.prepare("DELETE FROM store_refs WHERE store_sha256 = ?1;") catch return StoreError.RefCountError;
         defer stmt.finalize();
         stmt.bindText(1, sha256) catch return StoreError.RefCountError;
         _ = stmt.step() catch return StoreError.RefCountError;
+
+        self.db.commit() catch return StoreError.RefCountError;
     }
 
     pub fn incrementRef(self: *Store, sha256: []const u8) StoreError!void {

--- a/tests/store_test.zig
+++ b/tests/store_test.zig
@@ -114,6 +114,38 @@ test "remove also drops the store_refs row so the orphan does not return" {
     try testing.expectEqual(@as(usize, 0), orphans.items.len);
 }
 
+test "remove drops FS path and store_refs row in one transactional pass" {
+    var ctx = try setupTestStore(testing.allocator);
+    defer {
+        ctx.db.close();
+        test_io.deleteTreeAbsolute(std.Options.debug_io, ctx.prefix) catch {};
+        testing.allocator.free(ctx.prefix);
+    }
+    ctx.store.db = &ctx.db;
+
+    const sha = "txn_sha";
+    const dir = try std.fmt.allocPrint(testing.allocator, "{s}/store/{s}", .{ ctx.prefix, sha });
+    defer testing.allocator.free(dir);
+    test_io.makeDirAbsolute(std.Options.debug_io, dir) catch {};
+    try ctx.store.incrementRef(sha);
+    try testing.expect(ctx.store.exists(sha));
+
+    try ctx.store.remove(sha);
+
+    try testing.expect(!ctx.store.exists(sha));
+
+    var orphans = try ctx.store.orphans();
+    defer {
+        for (orphans.items) |o| testing.allocator.free(o);
+        orphans.deinit(testing.allocator);
+    }
+    try testing.expectEqual(@as(usize, 0), orphans.items.len);
+
+    // A leaked open transaction would make the next BEGIN IMMEDIATE error.
+    try ctx.db.beginTransaction();
+    try ctx.db.commit();
+}
+
 test "incrementRef and decrementRef update refcount" {
     var ctx = try setupTestStore(testing.allocator);
     defer {


### PR DESCRIPTION
## Description

Removes a small consistency hole in `Store.remove`. The on-disk `deleteTree` and the `store_refs` DELETE now run inside one immediate transaction. Concurrent readers no longer see a half-resolved ref-count, and a mid-flight failure on the SQL side rolls back to a state the next purge run can still recover from.

## Related Issue

- None

## Notes for Reviewers

- None