### PR TITLE
fix(cli/uninstall): decrement store ref atomically with DB delete

### DIFF
--- a/src/cli/uninstall.zig
+++ b/src/cli/uninstall.zig
@@ -10,7 +10,6 @@ const output = @import("../ui/output.zig");
 const lock_mod = @import("../db/lock.zig");
 const linker = @import("../core/linker.zig");
 const cellar = @import("../core/cellar.zig");
-const store = @import("../core/store.zig");
 const cask_mod = @import("../core/cask.zig");
 const formula_mod = @import("../core/formula.zig");
 const supervisor_mod = @import("../core/services/supervisor.zig");
@@ -121,6 +120,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         output.warn("Could not remove all symlinks for {s}", .{name});
     };
 
+    // Land the DB writes before any Cellar teardown so a SIGKILL
+    // between filesystem and database steps can't strand a refcount
+    // above the on-disk reality. CASCADE drops deps/links rows.
+    finalizeDbRemoval(&db, sha256, keg_id) catch {
+        output.warn("Could not finalize uninstall for {s}", .{name});
+    };
+
     // Remove Cellar directory (dir name carries the _<revision> suffix
     // when the keg was installed with revision > 0).
     cellar.remove(ctx.io, prefix, name, pkg_version) catch {
@@ -139,23 +145,109 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         if (opt_path.len > 0) std.Io.Dir.cwd().deleteFile(ctx.io, opt_path) catch {}; // opt/ link absent on never-linked kegs.
     }
 
-    // Decrement store ref
+    output.success("{s} uninstalled", .{name});
+}
+
+// Atomic DB-side teardown for an uninstall: the store-ref decrement and
+// the kegs delete must commit together so a SIGKILL between them can't
+// leave a refcount bumped above the on-disk Cellar reality.
+fn finalizeDbRemoval(db: *sqlite.Database, sha256: []const u8, keg_id: i64) sqlite.SqliteError!void {
+    try db.beginTransaction();
+    errdefer db.rollback();
+
     if (sha256.len > 0) {
-        var st = store.Store.init(ctx.io, allocator, &db, prefix);
-        st.decrementRef(sha256) catch {
-            output.warn("Could not decrement store ref for {s}", .{name});
-        };
+        var dec = try db.prepare(
+            "UPDATE store_refs SET refcount = refcount - 1 WHERE store_sha256 = ?1 AND refcount > 0;",
+        );
+        defer dec.finalize();
+        try dec.bindText(1, sha256);
+        _ = try dec.step();
     }
 
-    // Delete from DB (CASCADE handles deps/links)
-    var del_stmt = db.prepare("DELETE FROM kegs WHERE id = ?1;") catch return;
-    defer del_stmt.finalize();
-    del_stmt.bindInt(1, keg_id) catch return;
-    _ = del_stmt.step() catch {
-        output.warn("Could not delete DB record for {s}", .{name});
-    };
+    var del = try db.prepare("DELETE FROM kegs WHERE id = ?1;");
+    defer del.finalize();
+    try del.bindInt(1, keg_id);
+    _ = try del.step();
 
-    output.success("{s} uninstalled", .{name});
+    try db.commit();
+}
+
+const testing = std.testing;
+
+fn testSeedKeg(db: *sqlite.Database, name: []const u8, sha256: []const u8) !i64 {
+    var ins = try db.prepare(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+        \\VALUES (?1, ?1, '1.0', 0, ?2, 'Cellar/x/1.0');
+    );
+    defer ins.finalize();
+    try ins.bindText(1, name);
+    try ins.bindText(2, sha256);
+    _ = try ins.step();
+
+    var sel = try db.prepare("SELECT id FROM kegs WHERE name = ?1;");
+    defer sel.finalize();
+    try sel.bindText(1, name);
+    _ = try sel.step();
+    return sel.columnInt(0);
+}
+
+fn testRefcount(db: *sqlite.Database, sha256: []const u8) !?i64 {
+    var sel = try db.prepare("SELECT refcount FROM store_refs WHERE store_sha256 = ?1;");
+    defer sel.finalize();
+    try sel.bindText(1, sha256);
+    if (!try sel.step()) return null;
+    return sel.columnInt(0);
+}
+
+fn testKegPresent(db: *sqlite.Database, keg_id: i64) !bool {
+    var sel = try db.prepare("SELECT 1 FROM kegs WHERE id = ?1;");
+    defer sel.finalize();
+    try sel.bindInt(1, keg_id);
+    return try sel.step();
+}
+
+test "finalizeDbRemoval bundles the ref decrement with the kegs delete" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    const sha = "abc123";
+    var ins_ref = try db.prepare("INSERT INTO store_refs (store_sha256, refcount) VALUES (?1, 2);");
+    try ins_ref.bindText(1, sha);
+    _ = try ins_ref.step();
+    ins_ref.finalize();
+
+    const keg_id = try testSeedKeg(&db, "foo", sha);
+    try finalizeDbRemoval(&db, sha, keg_id);
+
+    try testing.expect(!try testKegPresent(&db, keg_id));
+    try testing.expectEqual(@as(?i64, 1), try testRefcount(&db, sha));
+}
+
+test "finalizeDbRemoval rolls the ref decrement back when the delete is blocked" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    const sha = "abc123";
+    var ins_ref = try db.prepare("INSERT INTO store_refs (store_sha256, refcount) VALUES (?1, 2);");
+    try ins_ref.bindText(1, sha);
+    _ = try ins_ref.step();
+    ins_ref.finalize();
+
+    const keg_id = try testSeedKeg(&db, "foo", sha);
+
+    // Trip the DELETE so atomicity is observable: after the failure,
+    // refcount must be untouched and the kegs row must still be there.
+    try db.exec(
+        \\CREATE TRIGGER block_keg_delete BEFORE DELETE ON kegs
+        \\BEGIN SELECT RAISE(ABORT, 'blocked'); END;
+    );
+
+    try testing.expectError(sqlite.SqliteError.ConstraintViolation, finalizeDbRemoval(&db, sha, keg_id));
+
+    try testing.expect(try testKegPresent(&db, keg_id));
+    try testing.expectEqual(@as(?i64, 2), try testRefcount(&db, sha));
 }
 
 /// Uninstall a cask by token.

--- a/tests/uninstall_test.zig
+++ b/tests/uninstall_test.zig
@@ -98,6 +98,60 @@ fn kegRowExists(prefix: []const u8, name: []const u8) !bool {
     return stmt.step() catch false;
 }
 
+// Seed a keg whose store_sha256 is populated and a matching store_refs row.
+// Lets the test inspect the post-uninstall refcount, which seedKeg above
+// deliberately sidesteps by leaving sha empty.
+fn seedKegWithStoreRef(
+    allocator: std.mem.Allocator,
+    prefix: []const u8,
+    name: []const u8,
+    version: []const u8,
+    sha256: []const u8,
+    refcount: i64,
+) !void {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    const cellar_rel = try std.fmt.allocPrint(allocator, "Cellar/{s}/{s}", .{ name, version });
+    defer allocator.free(cellar_rel);
+
+    var ins_keg = try db.prepare(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+        \\VALUES (?1, ?1, ?2, 0, ?3, ?4);
+    );
+    defer ins_keg.finalize();
+    try ins_keg.bindText(1, name);
+    try ins_keg.bindText(2, version);
+    try ins_keg.bindText(3, sha256);
+    try ins_keg.bindText(4, cellar_rel);
+    _ = try ins_keg.step();
+
+    var ins_ref = try db.prepare("INSERT INTO store_refs (store_sha256, refcount) VALUES (?1, ?2);");
+    defer ins_ref.finalize();
+    try ins_ref.bindText(1, sha256);
+    try ins_ref.bindInt(2, refcount);
+    _ = try ins_ref.step();
+
+    const cellar_dir = try std.fmt.allocPrint(allocator, "{s}/Cellar/{s}/{s}", .{ prefix, name, version });
+    defer allocator.free(cellar_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cellar_dir);
+}
+
+fn refcountFor(prefix: []const u8, sha256: []const u8) !?i64 {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    var stmt = try db.prepare("SELECT refcount FROM store_refs WHERE store_sha256 = ?1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, sha256);
+    if (!try stmt.step()) return null;
+    return stmt.columnInt(0);
+}
+
 // --- early-return branches ----------------------------------------------
 
 test "execute --help short-circuits before opening the database" {
@@ -231,4 +285,23 @@ test "execute --force bypasses the dependents check" {
     // --force breaks through the guard.
     try uninstall.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--force", "foo" });
     try testing.expect(!try kegRowExists(prefix.path, "foo"));
+}
+
+test "execute drops the kegs row and decrements the store ref together" {
+    // Pre-fix the FS teardown ran before the ref decrement, so a SIGKILL
+    // mid-uninstall could leave the store row inflated above the on-disk
+    // state. Asserting both writes land guards the bundled-transaction shape.
+    var prefix = try ScratchPrefix.init(testing.allocator, "storeref");
+    defer prefix.deinit(testing.allocator);
+
+    const sha = "abc123";
+    try seedKegWithStoreRef(testing.allocator, prefix.path, "foo", "1.0", sha, 2);
+
+    quiet();
+    defer unquiet();
+
+    try uninstall.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{"foo"});
+
+    try testing.expect(!try kegRowExists(prefix.path, "foo"));
+    try testing.expectEqual(@as(?i64, 1), try refcountFor(prefix.path, sha));
 }


### PR DESCRIPTION
## Description

Closes a small disk-leak window in `mt uninstall`. The store-ref decrement and the `kegs` delete now commit together, ahead of the Cellar teardown, so a SIGKILL between filesystem and database steps can no longer leave a refcount inflated above the on-disk reality. Without this, `mt purge --store-orphans` would refuse to reap the leaked store entry because the bumped refcount made it look live.

## Related Issue

- None

## Notes for Reviewers

- None