### PR TITLE
refactor(ui): route stdin probes and prompt reads through pkg_io

### DIFF
--- a/src/ui/color.zig
+++ b/src/ui/color.zig
@@ -259,7 +259,8 @@ fn queryOsc11Background() ?Background {
     if (ready == 0) return null;
 
     var buf: [64]u8 = undefined;
-    const n = std.posix.read(stdin_fd, &buf) catch return null;
+    const stdin_file: std.Io.File = .{ .handle = stdin_fd, .flags = .{ .nonblocking = false } };
+    const n = stdin_file.readStreaming(pkg_io, &.{buf[0..]}) catch return null;
     if (n == 0) return null;
     const rgb = parseOsc11Response(buf[0..n]) orelse return null;
     return classifyLuminance(rgb);

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -10,6 +10,10 @@ pub const OutputMode = enum {
     json,
 };
 
+/// Seeded by argv parsing in `main` before any worker thread spawns and
+/// not flipped afterwards, so plain reads/writes stay race-free. Mutators
+/// that need a runtime flip must migrate the flag (and every reader) to
+/// `@atomicLoad`/`@atomicStore`, matching `post_install_emit` below.
 var quiet: bool = false;
 var verbose: bool = false;
 var debug: bool = false;

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -416,9 +416,15 @@ pub fn confirmTyped(expected: []const u8, prompt: []const u8) bool {
     if (!is_tty) return false;
 
     question("{s}", .{prompt});
+    return readMatchingLine(stdin_file, pkg_io, expected);
+}
 
+/// Helper kept separate so tests can drive the read path against a pipe
+/// without needing a real TTY; routing the read through `io` matches the
+/// `isTty` probe and lets `AppCtx.io` redirection observe stdin.
+fn readMatchingLine(stdin_file: std.Io.File, io: std.Io, expected: []const u8) bool {
     var buf: [128]u8 = undefined;
-    const n = std.posix.read(std.posix.STDIN_FILENO, &buf) catch return false;
+    const n = stdin_file.readStreaming(io, &.{buf[0..]}) catch return false;
     if (n == 0) return false;
     const input = std.mem.trim(u8, buf[0..n], " \t\r\n");
     return std.mem.eql(u8, input, expected);
@@ -829,4 +835,47 @@ test "postInstallEmit reflects the most recent setPostInstallEmit value" {
 
     resetPostInstallEvents();
     try std.testing.expectEqual(PostInstallEmit.stream, postInstallEmit());
+}
+
+// Drives the read path through the seeded io against a pipe so the
+// `confirmTyped` accept/reject contract — including EOF — is pinned
+// without relying on a real TTY.
+fn pipeForTest() ![2]std.c.fd_t {
+    var fds: [2]std.c.fd_t = undefined;
+    if (std.c.pipe(&fds) != 0) return error.PipeFailed;
+    return fds;
+}
+
+test "readMatchingLine accepts trimmed input that matches expected" {
+    const fds = try pipeForTest();
+    defer _ = std.c.close(fds[0]);
+
+    const msg = "yes\n";
+    const written = std.c.write(fds[1], msg.ptr, msg.len);
+    try std.testing.expectEqual(@as(isize, msg.len), written);
+    _ = std.c.close(fds[1]);
+
+    const stdin_file: std.Io.File = .{ .handle = fds[0], .flags = .{ .nonblocking = false } };
+    try std.testing.expect(readMatchingLine(stdin_file, std.Options.debug_io, "yes"));
+}
+
+test "readMatchingLine rejects mismatched input" {
+    const fds = try pipeForTest();
+    defer _ = std.c.close(fds[0]);
+
+    const msg = "no\n";
+    _ = std.c.write(fds[1], msg.ptr, msg.len);
+    _ = std.c.close(fds[1]);
+
+    const stdin_file: std.Io.File = .{ .handle = fds[0], .flags = .{ .nonblocking = false } };
+    try std.testing.expect(!readMatchingLine(stdin_file, std.Options.debug_io, "yes"));
+}
+
+test "readMatchingLine returns false when stdin is at EOF" {
+    const fds = try pipeForTest();
+    defer _ = std.c.close(fds[0]);
+    _ = std.c.close(fds[1]);
+
+    const stdin_file: std.Io.File = .{ .handle = fds[0], .flags = .{ .nonblocking = false } };
+    try std.testing.expect(!readMatchingLine(stdin_file, std.Options.debug_io, "yes"));
 }


### PR DESCRIPTION
## Description

Aligns the two remaining stdin reads in `src/ui/` with the seeded `pkg_io` so `AppCtx.io` redirection observes them like every other I/O in the module:

- `confirmTyped` now reads via `std.Io.File.readStreaming(pkg_io, ...)`, matching the `isTty` probe it already routes through `pkg_io`. Behind a small extracted helper so unit tests can drive the read against a pipe instead of needing a real TTY.
- The OSC 11 background probe in `ui/color` reads its response the same way, removing the last `std.posix.read(stdin)` bypass in the UI layer.

Also pins the `quiet`/`verbose`/`debug`/`dry_run`/`mode`/`ndjson` mutation contract in a comment: these flags are configured by argv parsing before any worker thread spawns, so plain reads/writes stay race-free; future runtime mutators must migrate the flag and its readers to `@atomicLoad`/`@atomicStore` (matching `post_install_emit` next door). Promoting them eagerly cost ~3 KB of code that crossed a Mach-O page boundary into a 16 KB on-disk hit for a race no caller actually produces - a real binary-size regression for a theoretical concern.

## Related Issue

- None

## Notes for Reviewers

- None