### PR TITLE
fix: edge-case hardening

### DIFF
--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -52,7 +52,7 @@ fn lockTimeoutMs(ctx: *const AppCtx) u32 {
     return 30_000;
 }
 
-/// Arena-own Cellar names and log iterator errors instead of silently
+/// Arena-own Cellar names and log + skip iterator errors instead of
 /// truncating the scan — `iter.next() catch null` used to hide every
 /// later keg behind the first bad entry. `anytype` for mock iterators
 /// and a duck-typed `dir` so symlink-target lookups go through the same
@@ -66,8 +66,8 @@ pub fn scanCellarKegs(
 ) !void {
     while (true) {
         const entry = iter.next(io) catch |err| {
-            output.warn("Cellar scan error: {s}; keeping {d} entries already found", .{ @errorName(err), names.items.len });
-            break;
+            output.warn("Cellar scan error: {s}; skipping entry, kept {d} so far", .{ @errorName(err), names.items.len });
+            continue;
         } orelse break;
         const accept = switch (entry.kind) {
             .directory => true,

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -97,6 +97,10 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     const latest = release.stripVPrefix(tag);
 
     if (std.mem.eql(u8, latest, current_version)) {
+        // Freshen the passive notifier cache so a manual `--check` that
+        // confirms the running version stops the next invocation from
+        // nagging about an already-installed release.
+        notifier.markUpdatedTo(ctx, tag, current_version);
         output.info("Already up to date ({s})", .{current_version});
         return;
     }

--- a/src/db/schema.zig
+++ b/src/db/schema.zig
@@ -3,7 +3,7 @@ const sqlite = @import("sqlite.zig");
 
 /// Initialize the database schema (CREATE TABLE IF NOT EXISTS).
 /// Idempotent — safe to call on an existing database.
-pub fn initSchema(db: *sqlite.Database) sqlite.SqliteError!void {
+pub fn initSchema(db: *sqlite.Database) MigrateError!void {
     try db.beginTransaction();
     errdefer db.rollback();
 
@@ -98,9 +98,20 @@ pub fn initSchema(db: *sqlite.Database) sqlite.SqliteError!void {
     try migrate(db);
 }
 
-/// Run any pending schema migrations.
-pub fn migrate(db: *sqlite.Database) sqlite.SqliteError!void {
+/// Highest schema version this binary knows how to operate on. Bump in
+/// lockstep with the last `migrateVNtoVN+1` step so a future binary's
+/// DB doesn't get silently used against older SQL.
+pub const known_schema_version: i64 = 5;
+
+pub const MigrateError = sqlite.SqliteError || error{SchemaTooNew};
+
+/// Run any pending schema migrations. Refuses to operate on a DB whose
+/// schema version exceeds `known_schema_version` — running an older
+/// binary against a newer DB (e.g. multi-host shared `$MALT_PREFIX/db`)
+/// would otherwise execute current SQL against a future shape.
+pub fn migrate(db: *sqlite.Database) MigrateError!void {
     const ver = try currentVersion(db);
+    if (ver > known_schema_version) return error.SchemaTooNew;
     if (ver < 2) try migrateV1toV2(db);
     if (ver < 3) try migrateV2toV3(db);
     if (ver < 4) try migrateV3toV4(db);
@@ -399,4 +410,23 @@ test "v4→v5 migration aborts when foreign_key_check finds a violation" {
 
     // Rollback must leave the schema at v4 so a future run can retry.
     try testing.expectEqual(@as(i64, 4), try currentVersion(&db));
+}
+
+test "migrate refuses a DB whose schema_version exceeds the known max" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+
+    // Minimal v1 shape — a `schema_version` table with one future row is
+    // enough to reach the version probe in `migrate`.
+    try db.exec(
+        \\CREATE TABLE schema_version (
+        \\    version INTEGER PRIMARY KEY,
+        \\    applied TEXT NOT NULL DEFAULT (datetime('now'))
+        \\);
+    );
+    try db.exec("INSERT INTO schema_version (version) VALUES (999);");
+
+    try testing.expectError(error.SchemaTooNew, migrate(&db));
+    // Untouched: refusal must not silently bump the version.
+    try testing.expectEqual(@as(i64, 999), try currentVersion(&db));
 }

--- a/src/update/notifier.zig
+++ b/src/update/notifier.zig
@@ -18,6 +18,11 @@ const cache_filename = "version-notify.json";
 /// Match gh, npm, pnpm — smaller TTLs nag, larger lose freshness.
 pub const cache_ttl_secs: i64 = 24 * 60 * 60;
 
+/// Cooldown after a failed probe so a GitHub outage does not re-fire the
+/// 1.5 s timeout on every malt invocation. Short enough that a recovered
+/// network is picked up the next time the user runs anything.
+pub const failure_backoff_secs: i64 = 5 * 60;
+
 /// Bounded so a cache miss can't drag the user's hot path. Fires after
 /// dispatch, so the command's output is already on screen.
 pub const network_timeout_ns: u64 = 1_500 * std.time.ns_per_ms;
@@ -30,6 +35,10 @@ pub const State = struct {
     latest_tag: []const u8,
     /// Lets a fresh cache skip notices for users who've just updated.
     current_seen: []const u8,
+    /// Wall-clock of the most recent probe attempt (success or failure).
+    /// `last_attempt > checked_at` is the failure-marker shape: the next
+    /// invocation backs off until `failure_backoff_secs` has elapsed.
+    last_attempt: i64 = 0,
 };
 
 /// The `current == seen == latest_no_v` clause silences the notice for
@@ -46,6 +55,15 @@ pub fn cacheStale(now_secs: i64, checked_at: i64, ttl: i64) bool {
     // Cache from the future (clock skew) — treat as fresh, never re-fetch.
     if (now_secs <= checked_at) return false;
     return (now_secs - checked_at) >= ttl;
+}
+
+/// True when the previous probe failed recently and the caller should
+/// skip the network. `last_attempt > checked_at` is the failure shape:
+/// success bumps both fields together so they stay equal.
+pub fn inFailureBackoff(now_secs: i64, last_attempt: i64, checked_at: i64, backoff: i64) bool {
+    if (last_attempt <= checked_at) return false;
+    if (now_secs <= last_attempt) return false; // clock skew
+    return (now_secs - last_attempt) < backoff;
 }
 
 const ci_env_vars = [_][]const u8{
@@ -128,6 +146,9 @@ pub fn encodeState(buf: []u8, state: State) ![]u8 {
     try output.jsonStr(&w, state.latest_tag);
     try w.writeAll(",\"current_seen\":");
     try output.jsonStr(&w, state.current_seen);
+    try w.writeAll(",\"last_attempt\":");
+    const att = try std.fmt.bufPrint(&num_buf, "{d}", .{state.last_attempt});
+    try w.writeAll(att);
     try w.writeAll("}\n");
     return w.buffered();
 }
@@ -163,7 +184,17 @@ pub fn decodeState(allocator: std.mem.Allocator, bytes: []const u8) !?State {
     const tag_dup = try allocator.dupe(u8, latest_tag_s);
     errdefer allocator.free(tag_dup);
     const seen_dup = try allocator.dupe(u8, current_seen_s);
-    return .{ .checked_at = checked_at_i, .latest_tag = tag_dup, .current_seen = seen_dup };
+    // Optional, default 0 so caches written by older malt still decode.
+    const last_attempt_i: i64 = if (obj.get("last_attempt")) |v| switch (v) {
+        .integer => |i| i,
+        else => 0,
+    } else 0;
+    return .{
+        .checked_at = checked_at_i,
+        .latest_tag = tag_dup,
+        .current_seen = seen_dup,
+        .last_attempt = last_attempt_i,
+    };
 }
 
 pub fn freeState(allocator: std.mem.Allocator, state: State) void {
@@ -308,7 +339,10 @@ fn runNotify(ctx: *const AppCtx, allocator: std.mem.Allocator, current_version: 
     defer if (state) |s| freeState(allocator, s);
 
     const now = std.Io.Clock.real.now(ctx.io).toSeconds();
-    const need_refresh = if (state) |s| cacheStale(now, s.checked_at, cache_ttl_secs) else true;
+    const need_refresh = if (state) |s| blk: {
+        if (!cacheStale(now, s.checked_at, cache_ttl_secs)) break :blk false;
+        break :blk !inFailureBackoff(now, s.last_attempt, s.checked_at, failure_backoff_secs);
+    } else true;
 
     // The 33%-savings clause: cache fresh + no notice due → return without
     // touching `executablePath`/`realpath`. The dominant path on a healthy
@@ -338,7 +372,9 @@ fn runNotify(ctx: *const AppCtx, allocator: std.mem.Allocator, current_version: 
 }
 
 /// On network failure `state` is left untouched so the caller's old
-/// cache view survives a flaky GitHub API.
+/// cache view survives a flaky GitHub API. The failure path persists a
+/// `last_attempt` marker so the next invocation skips the probe until
+/// `failure_backoff_secs` has elapsed.
 fn refreshOnce(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
@@ -347,7 +383,10 @@ fn refreshOnce(
     now: i64,
     current_version: []const u8,
 ) !void {
-    const tag = try fetchLatestTag(ctx, allocator);
+    const tag = fetchLatestTag(ctx, allocator) catch |err| {
+        writeFailureMarker(ctx.io, path, state.*, now, current_version);
+        return err;
+    };
     errdefer allocator.free(tag);
 
     // Preserve a previously-recorded `current_seen` if any; else start at
@@ -356,9 +395,34 @@ fn refreshOnce(
     const seen_dup = try allocator.dupe(u8, prior_seen);
     errdefer allocator.free(seen_dup);
 
-    writeCache(ctx.io, path, .{ .checked_at = now, .latest_tag = tag, .current_seen = prior_seen }) catch {};
+    writeCache(ctx.io, path, .{
+        .checked_at = now,
+        .latest_tag = tag,
+        .current_seen = prior_seen,
+        .last_attempt = now,
+    }) catch {};
 
-    replaceState(state, allocator, .{ .checked_at = now, .latest_tag = tag, .current_seen = seen_dup });
+    replaceState(state, allocator, .{
+        .checked_at = now,
+        .latest_tag = tag,
+        .current_seen = seen_dup,
+        .last_attempt = now,
+    });
+}
+
+/// Persist a failure marker so the next invocation backs off instead of
+/// re-probing through a network outage. Best-effort: a write error here
+/// just defers to the next probe, which is the same as today.
+pub fn writeFailureMarker(io: std.Io, path: []const u8, prior: ?State, now: i64, current_version: []const u8) void {
+    const checked_at: i64 = if (prior) |p| p.checked_at else 0;
+    const tag: []const u8 = if (prior) |p| p.latest_tag else "";
+    const seen: []const u8 = if (prior) |p| p.current_seen else current_version;
+    writeCache(io, path, .{
+        .checked_at = checked_at,
+        .latest_tag = tag,
+        .current_seen = seen,
+        .last_attempt = now,
+    }) catch {};
 }
 
 /// Read the entire contents of an absolute file path into a caller-owned slice.

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -1320,6 +1320,41 @@ test "scanCellarKegs warns and preserves prior names when iterator errors" {
     try testing.expect(containsLine(buf.items, "AccessDenied"));
 }
 
+test "scanCellarKegs continues past a mid-scan iterator error" {
+    resetOutput();
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var names: std.ArrayList([]const u8) = .empty;
+    // Bad entry sits between two good ones; the loop must skip the bad
+    // index and still surface the trailing keg instead of truncating.
+    var mock = MockIter{
+        .entries = &.{
+            .{ .name = "tree", .kind = .directory },
+            .{ .name = "wget", .kind = .directory },
+            .{ .name = "ffmpeg", .kind = .directory },
+        },
+        .fail_after = 1,
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &buf);
+    defer io_mod.endStderrCapture();
+
+    try migrate.scanCellarKegs(std.Options.debug_io, arena.allocator(), &mock, MockDir{}, &names);
+
+    // tree precedes the error; ffmpeg follows it. The middle index that
+    // returned `error.AccessDenied` is the only one missing.
+    try testing.expectEqual(@as(usize, 2), names.items.len);
+    try testing.expectEqualStrings("tree", names.items[0]);
+    try testing.expectEqualStrings("ffmpeg", names.items[1]);
+    try testing.expect(containsLine(buf.items, "Cellar scan error"));
+}
+
 // ── Resume manifest ────────────────────────────────────────────────
 //
 // Pre-seed `{cache}/migrate.progress.json` with one keg name. Run migrate
@@ -1975,8 +2010,11 @@ test "scanCellarKegs skips non-directory entries and survives fail-first iterato
     io_mod.beginStderrCapture(testing.allocator, &buf);
     defer io_mod.endStderrCapture();
 
+    // Error swallows the .DS_Store slot (idx 0); the loop must keep
+    // going so the trailing keg "tree" still lands in the result.
     try migrate.scanCellarKegs(std.Options.debug_io, arena.allocator(), &mock, MockDir{}, &names);
-    try testing.expectEqual(@as(usize, 0), names.items.len);
+    try testing.expectEqual(@as(usize, 1), names.items.len);
+    try testing.expectEqualStrings("tree", names.items[0]);
     try testing.expect(containsLine(buf.items, "Cellar scan error"));
 }
 

--- a/tests/version_notify_test.zig
+++ b/tests/version_notify_test.zig
@@ -143,12 +143,94 @@ test "encodeState/decodeState round-trip preserves every field" {
         .checked_at = 1714400000,
         .latest_tag = "v0.10.1",
         .current_seen = "0.10.0",
+        .last_attempt = 1714400500,
     });
     const got = (try notifier.decodeState(allocator, encoded)) orelse
         return error.TestExpectedNonNull;
     defer notifier.freeState(allocator, got);
     try testing.expectEqual(@as(i64, 1714400000), got.checked_at);
     try testing.expectEqualStrings("v0.10.1", got.latest_tag);
+    try testing.expectEqualStrings("0.10.0", got.current_seen);
+    try testing.expectEqual(@as(i64, 1714400500), got.last_attempt);
+}
+
+test "decodeState: caches written before last_attempt existed default to 0" {
+    // Old cache files lack the `last_attempt` key; tolerant decode keeps
+    // them readable so a downgrade-then-upgrade round-trip is safe.
+    const legacy = "{\"checked_at\":42,\"latest_tag\":\"v0.10.0\",\"current_seen\":\"0.9.0\"}";
+    const got = (try notifier.decodeState(testing.allocator, legacy)) orelse
+        return error.TestExpectedNonNull;
+    defer notifier.freeState(testing.allocator, got);
+    try testing.expectEqual(@as(i64, 0), got.last_attempt);
+}
+
+test "inFailureBackoff: only fires when last_attempt > checked_at" {
+    // Equal pair = success shape; never a backoff.
+    try testing.expect(!notifier.inFailureBackoff(1000, 500, 500, 60));
+    // last_attempt newer than checked_at + within window → back off.
+    try testing.expect(notifier.inFailureBackoff(550, 500, 100, 60));
+    // Window elapsed → no longer backing off.
+    try testing.expect(!notifier.inFailureBackoff(600, 500, 100, 60));
+    // Clock skew (now < last_attempt) — never back off, never crash.
+    try testing.expect(!notifier.inFailureBackoff(400, 500, 100, 60));
+}
+
+test "writeFailureMarker preserves prior cache and bumps last_attempt" {
+    const allocator = testing.allocator;
+    const io = std.Options.debug_io;
+
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notify_fail_{d}", .{fs_compat.nanoTimestamp(
+        std.Options.debug_io,
+    )});
+    fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
+
+    // Seed a successful cache, then simulate a probe failure.
+    try notifier.writeCache(io, path, .{
+        .checked_at = 100,
+        .latest_tag = "v0.10.1",
+        .current_seen = "0.10.0",
+        .last_attempt = 100,
+    });
+    const prior = (try notifier.readCache(io, allocator, path)) orelse return error.TestExpectedNonNull;
+    defer notifier.freeState(allocator, prior);
+
+    notifier.writeFailureMarker(io, path, prior, 250, "0.10.0");
+
+    const after = (try notifier.readCache(io, allocator, path)) orelse return error.TestExpectedNonNull;
+    defer notifier.freeState(allocator, after);
+    // checked_at stays at the last successful probe; only last_attempt moves.
+    try testing.expectEqual(@as(i64, 100), after.checked_at);
+    try testing.expectEqual(@as(i64, 250), after.last_attempt);
+    try testing.expectEqualStrings("v0.10.1", after.latest_tag);
+    try testing.expectEqualStrings("0.10.0", after.current_seen);
+}
+
+test "writeFailureMarker on a first-ever run records only the failed attempt" {
+    const allocator = testing.allocator;
+    const io = std.Options.debug_io;
+
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notify_first_{d}", .{fs_compat.nanoTimestamp(
+        std.Options.debug_io,
+    )});
+    fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
+
+    notifier.writeFailureMarker(io, path, null, 500, "0.10.0");
+
+    const got = (try notifier.readCache(io, allocator, path)) orelse return error.TestExpectedNonNull;
+    defer notifier.freeState(allocator, got);
+    try testing.expectEqual(@as(i64, 0), got.checked_at);
+    try testing.expectEqual(@as(i64, 500), got.last_attempt);
+    try testing.expectEqualStrings("", got.latest_tag);
     try testing.expectEqualStrings("0.10.0", got.current_seen);
 }
 
@@ -179,6 +261,7 @@ test "writeCache + readCache full round-trip on disk" {
         .checked_at = 42,
         .latest_tag = "v0.99.0",
         .current_seen = "0.10.0",
+        .last_attempt = 42,
     });
 
     const got = (try notifier.readCache(io, allocator, path)) orelse return error.TestExpectedNonNull;
@@ -187,6 +270,7 @@ test "writeCache + readCache full round-trip on disk" {
     try testing.expectEqual(@as(i64, 42), got.checked_at);
     try testing.expectEqualStrings("v0.99.0", got.latest_tag);
     try testing.expectEqualStrings("0.10.0", got.current_seen);
+    try testing.expectEqual(@as(i64, 42), got.last_attempt);
 }
 
 test "writeCache creates the parent directory when absent" {

--- a/tests/version_notify_test.zig
+++ b/tests/version_notify_test.zig
@@ -10,7 +10,13 @@ const testing = std.testing;
 const malt = @import("malt");
 const test_io = @import("test_io");
 const notifier = malt.update_notifier;
+const app_ctx = malt.app_ctx;
 const fs_compat = test_io;
+
+const c_env = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
 
 test "shouldNotify: full table — equal/newer/post-update" {
     const Case = struct {
@@ -208,6 +214,47 @@ test "writeFailureMarker preserves prior cache and bumps last_attempt" {
     try testing.expectEqual(@as(i64, 250), after.last_attempt);
     try testing.expectEqualStrings("v0.10.1", after.latest_tag);
     try testing.expectEqualStrings("0.10.0", after.current_seen);
+}
+
+test "markUpdatedTo bumps current_seen so a manual --check stops the nag" {
+    // Pin the N-10 contract: a manual `mt version update --check` that
+    // confirms `latest == current` must update `current_seen` so
+    // `shouldNotify` flips to false on the next invocation.
+    const allocator = testing.allocator;
+    const io = std.Options.debug_io;
+
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = try std.fmt.bufPrintZ(&dir_buf, "/tmp/malt_notify_check_{d}", .{fs_compat.nanoTimestamp(
+        std.Options.debug_io,
+    )});
+    fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, dir);
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
+
+    _ = c_env.setenv("MALT_CACHE", dir.ptr, 1);
+    defer _ = c_env.unsetenv("MALT_CACHE");
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
+
+    // Pre-seed a stale cache: notifier observed v0.10.1 long ago and the
+    // user has since installed it elsewhere, so current_seen drifted.
+    try notifier.writeCache(io, path, .{
+        .checked_at = 1,
+        .latest_tag = "v0.10.1",
+        .current_seen = "0.10.0",
+        .last_attempt = 1,
+    });
+
+    // Snapshot the live env so cachePath sees MALT_CACHE.
+    const ctx: app_ctx.AppCtx = .{ .io = io, .environ = app_ctx.processEnviron() };
+    notifier.markUpdatedTo(&ctx, "v0.10.1", "0.10.1");
+
+    const got = (try notifier.readCache(io, allocator, path)) orelse return error.TestExpectedNonNull;
+    defer notifier.freeState(allocator, got);
+    try testing.expectEqualStrings("v0.10.1", got.latest_tag);
+    try testing.expectEqualStrings("0.10.1", got.current_seen);
+    try testing.expect(!notifier.shouldNotify("0.10.1", got.latest_tag, got.current_seen));
 }
 
 test "writeFailureMarker on a first-ever run records only the failed attempt" {


### PR DESCRIPTION
## Description

Four small defensive fixes flagged in the pre-v0.11:

- **migrate / Cellar scan**: a single bad directory entry no longer truncates the rest of the scan. The loop logs the entry, skips it, and keeps walking the Cellar so trailing kegs are still surfaced.
- **notifier / network outage**: the passive update notifier now persists a `last_attempt` marker on probe failure and backs off for 5 minutes before re-probing. A 24 h GitHub outage stops re-running the 1.5 s timeout on every malt invocation.
- **notifier / manual --check**: `mt version update --check` now bumps `current_seen` when it confirms the running binary already matches the released version. The next invocation's passive notifier no longer nags about a release the user already has.
- **db/schema**: `migrate` refuses to operate on a DB whose `schema_version` exceeds the highest migration this binary knows about. Running an older malt against a DB written by a newer one (shared `$MALT_PREFIX` across hosts) used to silently execute current SQL against a future shape; now it returns a typed `SchemaTooNew` error instead.

The `version-notify.json` decoder is tolerant of caches written before `last_attempt` existed, so a downgrade-then-upgrade round-trip stays safe.

## Related Issue

- None

## Notes for Reviewers

- None