### PR TITLE
test(install-parse-cache): wipe TempDb dir before reopen

### DIFF
--- a/tests/install_parse_cache_test.zig
+++ b/tests/install_parse_cache_test.zig
@@ -22,6 +22,9 @@ const TempDb = struct {
 
     fn init(comptime tag: []const u8) !TempDb {
         const dir = "/tmp/malt_parse_cache_test_" ++ tag;
+        // Wipe leftover test.db / test.db-wal / test.db-shm from a prior
+        // run; a stale SHM makes the WAL pragma flake on re-open.
+        test_io.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
         test_io.makeDirAbsolute(std.Options.debug_io, dir) catch {};
         var db_path_buf: [256]u8 = undefined;
         const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/test.db", .{dir}, 0);


### PR DESCRIPTION
## Description

Stops `tests/install_parse_cache_test.zig` from flaking on the WAL open inside `TempDb.init`. The fixed `/tmp/malt_parse_cache_test_<tag>` path was reused across runs without a pre-wipe, so a prior aborted run could leave a `test.db-shm` behind that made `PRAGMA journal_mode=WAL` transiently return BUSY and surface as `OpenFailed`. Now the dir is deleted before being recreated, matching the pattern the rest of the file already uses for `cache_dir`.

## Related Issue

- None

## Notes for Reviewers

- None
