### PR TITLE
test(smoke): keep network smokes honest

### DIFF
--- a/scripts/smokes/smoke_migrate_parallel.sh
+++ b/scripts/smokes/smoke_migrate_parallel.sh
@@ -439,7 +439,11 @@ SKIPPED_INSTALLED=$(jq -r '.counts.skipped_installed // 0' "$SUMMARY_JSON")
 SKIPPED_POST=$(jq -r '.counts.skipped_post_install // 0' "$SUMMARY_JSON")
 SKIPPED_NB=$(jq -r '.counts.skipped_no_bottle // 0' "$SUMMARY_JSON")
 TOTAL=$((MIGRATED + SKIPPED_INSTALLED + SKIPPED_POST + SKIPPED_NB + FAILED))
-BROKEN=$(grep -c '^BIN_BROKEN' "$USABILITY_TSV" 2>/dev/null || echo 0)
+# grep -c writes "0" to stdout on no-match AND exits 1, so `|| echo 0` would
+# concatenate to "0\n0" and trip `[[ -gt 0 ]]`. Swallow the exit only and
+# default to 0 when the file is missing entirely (no stdout at all).
+BROKEN=$(grep -c '^BIN_BROKEN' "$USABILITY_TSV" 2>/dev/null || true)
+BROKEN=${BROKEN:-0}
 
 if [[ "$EXIT" -ne 0 ]]; then
   printf '\n✗ malt migrate --parallel exited %d - see %s\n' "$EXIT" "$REPORT" >&2

--- a/scripts/smokes/smoke_test.sh
+++ b/scripts/smokes/smoke_test.sh
@@ -303,7 +303,7 @@ else
   # on jq because not every smoke environment ships it.
   if command -v jq >/dev/null 2>&1; then
     out=$("$MT_BIN" --json --quiet purge --housekeeping --dry-run 2>/dev/null)
-    if printf '%s\n' "$out" | jq -e '.version == 1 and .dry_run == true and (.scopes | type == "array")' >/dev/null 2>&1; then
+    if printf '%s\n' "$out" | jq -e '.version == 2 and .dry_run == true and (.scopes | type == "array")' >/dev/null 2>&1; then
       printf '  PASS  [t3.purge.house.json.dry] mt --json purge --housekeeping --dry-run\n'
       PASS=$((PASS + 1))
     else


### PR DESCRIPTION
## Description

Both smokes now go end-to-end clean, and the migrate guard fires for real on a `BIN_BROKEN` row.

## Related Issue

- None

## Notes for Reviewers

- None