### PR TITLE
test(coverage): skip subprocess tests under kcov

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -28,6 +28,13 @@ src_dir="$(pwd)/src"
 # block on `read(STDIN_FILENO)` when kcov inherits the user's terminal.
 # Redirecting from /dev/null forces isTty()=false so those paths take the
 # unattended-abort branch the tests are written against.
+#
+# kcov's Mach-port instrumentation collides with sandbox-exec / posix_spawn
+# children on macOS (vm_write / thread_get_state failures), turning a
+# coverage run into an unbounded hang on tests that actually fork. The
+# affected tests gate on `MALT_SKIP_SUBPROCESS_TESTS` and stay live under
+# `zig build test`; only this loop opts out of them.
+export MALT_SKIP_SUBPROCESS_TESTS=1
 for bin in zig-out/test-bin/*; do
   # Skip .dSYM debug bundles and any non-regular files
   [ -f "$bin" ] || continue

--- a/tests/dsl_builtins_test.zig
+++ b/tests/dsl_builtins_test.zig
@@ -558,6 +558,7 @@ fn arenaCtxLive(arena: *std.heap.ArenaAllocator, lio: *LiveIo, root: []const u8)
 }
 
 test "system runs /bin/true and returns true" {
+    try test_io.skipIfNoSubprocess();
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     var lio = LiveIo.init();
@@ -567,6 +568,7 @@ test "system runs /bin/true and returns true" {
 }
 
 test "system runs /bin/false and returns false" {
+    try test_io.skipIfNoSubprocess();
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     var lio = LiveIo.init();
@@ -583,6 +585,7 @@ test "system with no args returns nil" {
 }
 
 test "quietSystem always returns nil regardless of exit code" {
+    try test_io.skipIfNoSubprocess();
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     var lio = LiveIo.init();
@@ -634,6 +637,7 @@ test "osMac is true, osLinux is false, cpuArch is arm64 or x86_64" {
 }
 
 test "macosVersion returns a non-empty string" {
+    try test_io.skipIfNoSubprocess();
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     var lio = LiveIo.init();
@@ -690,6 +694,7 @@ test "formulaLookup returns MALT_PREFIX/opt/<name>" {
 }
 
 test "safePopenRead captures stdout and chomps trailing newline" {
+    try test_io.skipIfNoSubprocess();
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     var lio = LiveIo.init();

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -579,6 +579,7 @@ test "routePostInstallOutcome: non-fatal entry surfaces the --use-system-ruby hi
 }
 
 test "routePostInstallOutcome: --use-system-ruby=NAME in scope triggers the Ruby fallback banner" {
+    try test_io.skipIfNoSubprocess();
     var flog = dsl.FallbackLog.init(testing.allocator);
     defer flog.deinit();
     flog.log(.{
@@ -627,6 +628,7 @@ test "routePostInstallOutcome: fatal entry wins over hasErrors heuristic" {
 // ruby@N) are auto-included in the system-Ruby allow-list so the
 // hook routes to the same fallback path with no flag from the user.
 test "routePostInstallOutcome: ruby keg auto-routes to system Ruby with no flag" {
+    try test_io.skipIfNoSubprocess();
     var flog = dsl.FallbackLog.init(testing.allocator);
     defer flog.deinit();
     flog.log(.{
@@ -645,6 +647,7 @@ test "routePostInstallOutcome: ruby keg auto-routes to system Ruby with no flag"
 }
 
 test "routePostInstallOutcome: ruby@N keg also auto-routes to system Ruby" {
+    try test_io.skipIfNoSubprocess();
     var flog = dsl.FallbackLog.init(testing.allocator);
     defer flog.deinit();
     flog.log(.{
@@ -719,6 +722,7 @@ test "routePostInstallOutcome: auto-included ruby keg skips re-run when DSL did 
 // the auto-include must still fall back so a fresh `mt migrate ruby`
 // (or any zero-coverage scenario) still runs the hook via system Ruby.
 test "routePostInstallOutcome: auto-included ruby keg falls back when DSL did nothing" {
+    try test_io.skipIfNoSubprocess();
     var flog = dsl.FallbackLog.init(testing.allocator);
     defer flog.deinit();
     flog.log(.{

--- a/tests/sandbox_macos_test.zig
+++ b/tests/sandbox_macos_test.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const testing = std.testing;
 const sandbox = @import("malt").sandbox_macos;
+const test_io = @import("test_io");
 
 test "validatePathForProfile accepts clean absolute paths" {
     try sandbox.validatePathForProfile("/opt/malt");
@@ -107,6 +108,7 @@ const ReapObserver = struct {
 
 test "spawnFilteredWithHooks reaps child when first reader-thread spawn fails" {
     if (builtin.os.tag != .macos) return error.SkipZigTest;
+    try test_io.skipIfNoSubprocess();
 
     const argv = [_][]const u8{"/usr/bin/true"};
     const argv_z = try sandbox.buildArgv(testing.allocator, argv[0..]);
@@ -134,6 +136,7 @@ test "spawnFilteredWithHooks reaps child when first reader-thread spawn fails" {
 
 test "spawnFilteredWithHooks reaps child and joins out-thread when second spawn fails" {
     if (builtin.os.tag != .macos) return error.SkipZigTest;
+    try test_io.skipIfNoSubprocess();
 
     const argv = [_][]const u8{"/usr/bin/true"};
     const argv_z = try sandbox.buildArgv(testing.allocator, argv[0..]);
@@ -166,6 +169,7 @@ test "spawnFilteredWithHooks reaps child and joins out-thread when second spawn 
 // `failed command:` against a passing test).
 test "spawnFilteredWithHooks routes child stderr to the configured fd" {
     if (builtin.os.tag != .macos) return error.SkipZigTest;
+    try test_io.skipIfNoSubprocess();
 
     const argv = [_][]const u8{ "/bin/sh", "-c", "printf %s err-via-fd >&2" };
     const argv_z = try sandbox.buildArgv(testing.allocator, argv[0..]);

--- a/tests/test_io.zig
+++ b/tests/test_io.zig
@@ -66,6 +66,14 @@ pub fn getenv(name: []const u8) ?[:0]const u8 {
     return std.process.Environ.getPosix(malt.app_ctx.processEnviron(), name);
 }
 
+/// Skip when the harness asks us not to fork external processes.
+/// kcov's Mach-port instrumentation collides with sandbox-exec children
+/// on macOS (vm_write / thread_get_state failures), turning a coverage
+/// run into an unbounded hang.
+pub fn skipIfNoSubprocess() !void {
+    if (getenv("MALT_SKIP_SUBPROCESS_TESTS") != null) return error.SkipZigTest;
+}
+
 pub fn copyFileAbsolute(io: std.Io, source_path: []const u8, dest_path: []const u8, options: std.Io.Dir.CopyFileOptions) !void {
     const cwd_dir: std.Io.Dir = .cwd();
     return std.Io.Dir.copyFile(cwd_dir, source_path, cwd_dir, dest_path, io, options);


### PR DESCRIPTION
## Description

kcov's Mach-port instrumentation hangs on sandbox-exec / posix_spawn children. Gate the affected tests on MALT_SKIP_SUBPROCESS_TESTS so`just coverage` finishes; `just test` is unaffected.

## Related Issue

- None

## Notes for Reviewers

- None
