### PR TITLE
fix(install/local): parse cask DSL multi-arch sha256 and arch-token URLs

### DIFF
--- a/scripts/regressions/tap-cask-multi-arch-parse-gh307.sh
+++ b/scripts/regressions/tap-cask-multi-arch-parse-gh307.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Regression guard for tap-style casks that use the modern Homebrew
+# DSL multi-arch shape:
+#
+#   on_macos do
+#     arch   arm: "-aarch64", intel: ""
+#     sha256 arm:   "<hash>",
+#            intel: "<hash>"
+#     url    "https://.../rebased#{arch}.dmg"
+#   end
+#
+# Before the fix, `parseRubyFormula` only recognised `Hardware::CPU.*`
+# and standalone `on_arm`/`on_intel` blocks each carrying their own
+# url/sha256 lines. The keyword-arg form (sha256 arm:/intel:, plus the
+# `arch` directive that drives `#{arch}` in the URL) walked past every
+# section gate and the parser bailed with "Cannot parse … formula".
+#
+# This script writes a fixture matching the offending shape, drives a
+# built `mt` through the local-install dry-run path, and asserts:
+#
+#   1. Neither parse-failure phrase ("Cannot parse tap formula" /
+#      "Cannot parse local formula") appears.
+#   2. The dry-run breadcrumb fires — proving the parser reached the
+#      materialise stage with version + url + sha256 in hand.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/mt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be ≤ 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_cdsl"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP" "$PREFIX"' EXIT
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+
+cat >"$TMP/rebased.rb" <<'RB'
+cask "rebased" do
+  version "1.0.12"
+  on_macos do
+    arch arm: "-aarch64", intel: ""
+    sha256 arm:   "3ef9aace106128e78e94777c7fe64228cfa1df816e7cc15b8b1bc054b7df9e9c",
+           intel: "93bc02e6c7ba06e907cfa540ed22d9eae0a7e3408810bf3bf07cd18a8bef6cdc"
+    url "https://github.com/DetachHead/rebased/releases/download/#{version}/rebased#{arch}.dmg"
+  end
+  app "Rebased.app"
+end
+RB
+
+pass() { printf '  ✓ %s\n' "$*"; }
+skip() { printf '  - %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+# ── Property 1: hermetic --local --dry-run on the offending fixture ──
+#
+# This is the deterministic core of the regression — no network, no DB
+# writes, no archive fetch. If this leg fails the parser still rejects
+# the keyword-arg DSL.
+LOG="$TMP/install.log"
+"$BIN" install --local --dry-run "$TMP/rebased.rb" >"$LOG" 2>&1 || true
+
+if grep -qiE 'Cannot parse (tap|local) formula' "$LOG"; then
+  sed 's/^/  | /' "$LOG" >&2
+  fail "parser still rejects cask DSL multi-arch shape"
+fi
+
+if ! grep -q 'Dry run: would install' "$LOG"; then
+  sed 's/^/  | /' "$LOG" >&2
+  fail "dry-run breadcrumb missing — parser did not reach materialise"
+fi
+pass "multi-arch cask DSL parses and routes to materialise (hermetic)"
+
+# ── Property 2: real third-party casks that rely on the same shape ───
+#
+# These are live tap fetches, so the leg is best-effort: an upstream
+# 404 / rate limit / SHA drift skips a candidate; the regression only
+# fires if the parser refuses a real cask whose Ruby file uses the
+# multi-arch keyword-arg DSL. At least one candidate must reach
+# `materializeTapCask` (signalled by the cask install banner) for the
+# leg to count as covered, otherwise the leg is skipped.
+#
+# Each spec is `<tap-slug>:<expected-binary-or-app>` where the
+# observable is either `$PREFIX/bin/<bin>` (binary cask) or
+# `$PREFIX/Caskroom/<token>/<version>/<App>.app` (app cask). Pure
+# parse-failure regressions trip the fail() inside the loop;
+# everything else (download, sha, unsupported artifact) is treated
+# as a transient skip so flaky upstreams do not poison the signal.
+declare -a CANDIDATES=(
+  "detachhead/tap/rebased:Rebased.app"
+)
+
+if [[ "${MALT_REGRESSION_OFFLINE:-0}" == "1" ]]; then
+  skip "MALT_REGRESSION_OFFLINE=1 — skipping live tap-cask install legs"
+else
+  any_covered=0
+  for spec in "${CANDIDATES[@]}"; do
+    slug="${spec%:*}"
+    expected="${spec##*:}"
+    token="${slug##*/}"
+    LOG="$TMP/install_${token}.log"
+    printf '▸ malt install %s (logs → %s)\n' "$slug" "$LOG"
+    "$BIN" install "$slug" >"$LOG" 2>&1 || true
+
+    if grep -qiE 'Cannot parse (tap|local) formula' "$LOG"; then
+      sed 's/^/  | /' "$LOG" >&2
+      fail "${slug}: parser refused the cask DSL — regression"
+    fi
+
+    # The cask installer prints "Installing cask <token> <version>"
+    # only after the parser, materializeTapCask, and the artifact
+    # fetcher all succeeded. Use that as the proof point — it shows
+    # parsing got past the keyword-arg sha256 + arch directives.
+    if grep -qE "Installing cask ${token}|installed$| installed " "$LOG"; then
+      any_covered=1
+      app_link="$PREFIX/Caskroom/${token}"
+      bin_link="$PREFIX/bin/${expected}"
+      if [[ -d "$app_link" ]] || [[ -L "$bin_link" ]]; then
+        pass "${slug}: installed via multi-arch DSL parse"
+      else
+        skip "${slug}: install reported success but no observable artifact (treating as best-effort)"
+      fi
+    elif grep -qE "Sha256Mismatch|DownloadFailed|Failed to install|Tap formula/cask not found|rate limit|Network failure" "$LOG"; then
+      skip "${slug}: non-regression failure (${LOG##*/}); continuing"
+    else
+      sed 's/^/  | /' "$LOG" >&2
+      fail "${slug}: unclassified outcome — investigate before landing"
+    fi
+  done
+
+  if ((any_covered == 0)); then
+    skip "no live cask exercised the multi-arch DSL (all upstreams were unreachable); hermetic leg still covers the parser"
+  fi
+fi
+
+printf '\n✔ tap-cask multi-arch DSL regression passed\n'

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -33,6 +33,7 @@ pub const isSelfInstall = args_mod.isSelfInstall;
 pub const parseTapName = args_mod.parseTapName;
 pub const isAllowedArchiveUrl = args_mod.isAllowedArchiveUrl;
 pub const interpolateVersion = args_mod.interpolateVersion;
+pub const interpolateUrl = args_mod.interpolateUrl;
 pub const expandTildePath = args_mod.expandTildePath;
 const download_mod = @import("install/download.zig");
 pub const DownloadJob = download_mod.DownloadJob;

--- a/src/cli/install/args.zig
+++ b/src/cli/install/args.zig
@@ -111,6 +111,54 @@ pub fn interpolateVersion(buf: []u8, url: []const u8, version: []const u8) []con
     return url;
 }
 
+/// Interpolate both `#{version}` and `#{arch}` inside a URL. The arch
+/// substitution is what cask DSL multi-arch downloads need — without
+/// it, the SHA-verified fetch would 404 because the server never sees
+/// a real per-arch suffix. Empty `arch_token` is valid (intel rows in
+/// real casks routinely set `intel: ""`); the needle is replaced with
+/// nothing rather than skipped. Falls back to the raw URL on any
+/// bufPrint overflow so the caller's SHA check fails fast on truncation.
+pub fn interpolateUrl(
+    buf: []u8,
+    url: []const u8,
+    version: []const u8,
+    arch_token: []const u8,
+) []const u8 {
+    const version_needle = "#" ++ "{version}";
+    const arch_needle = "#" ++ "{arch}";
+    const has_version = std.mem.indexOf(u8, url, version_needle) != null;
+    const has_arch = std.mem.indexOf(u8, url, arch_needle) != null;
+    if (!has_version and !has_arch) return url;
+
+    // Walk the URL once and copy verbatim, expanding either needle at
+    // its position. A single pass keeps the API allocation-free and
+    // immune to nested substitutions (e.g. an arch token that happens
+    // to contain `#{version}` literally is left alone).
+    var written: usize = 0;
+    var i: usize = 0;
+    while (i < url.len) {
+        if (has_version and std.mem.startsWith(u8, url[i..], version_needle)) {
+            if (written + version.len > buf.len) return url;
+            @memcpy(buf[written..][0..version.len], version);
+            written += version.len;
+            i += version_needle.len;
+            continue;
+        }
+        if (has_arch and std.mem.startsWith(u8, url[i..], arch_needle)) {
+            if (written + arch_token.len > buf.len) return url;
+            @memcpy(buf[written..][0..arch_token.len], arch_token);
+            written += arch_token.len;
+            i += arch_needle.len;
+            continue;
+        }
+        if (written + 1 > buf.len) return url;
+        buf[written] = url[i];
+        written += 1;
+        i += 1;
+    }
+    return buf[0..written];
+}
+
 /// Expand a leading `~/` to `$HOME/...`. Returns the input unchanged
 /// when no tilde prefix is present. Returns null when `$HOME` is
 /// needed but unset.

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -148,13 +148,14 @@ pub fn installTapFormula(
 
     // Parse the Ruby formula to extract name, version, URL, SHA256 for current arch
     const rb = parseRubyFormula(resp.body) orelse {
-        output.err("Cannot parse tap formula (Ruby format). Use: brew install {s}", .{pkg_name});
+        output.err("Cannot parse tap formula (unsupported Ruby DSL shape). Use: brew install {s}", .{pkg_name});
         return InstallError.FormulaNotFound;
     };
 
-    // Interpolate #{version} in URL if present
+    // Substitute #{version} and #{arch} so the SHA-verified fetch
+    // hits the right per-platform asset.
     var final_url_buf: [512]u8 = undefined;
-    const final_url = args.interpolateVersion(&final_url_buf, rb.url, rb.version);
+    const final_url = args.interpolateUrl(&final_url_buf, rb.url, rb.version, rb.arch_token);
 
     var tap_buf: [128]u8 = undefined;
     const tap_name = std.fmt.bufPrint(&tap_buf, "{s}/{s}", .{ parts.user, parts.repo }) catch
@@ -281,7 +282,7 @@ pub fn installLocalFormula(
 
     // Parse the Ruby formula to extract name, version, URL, SHA256 for current arch
     const rb = parseRubyFormula(body) orelse {
-        output.err("Cannot parse local formula (missing version/url/sha256): {s}", .{realpath});
+        output.err("Cannot parse local formula (missing version/url/sha256 or unsupported DSL shape): {s}", .{realpath});
         return InstallError.FormulaNotFound;
     };
 
@@ -296,7 +297,7 @@ pub fn installLocalFormula(
     const name = base[0 .. base.len - 3];
 
     var final_url_buf: [512]u8 = undefined;
-    const final_url = args.interpolateVersion(&final_url_buf, rb.url, rb.version);
+    const final_url = args.interpolateUrl(&final_url_buf, rb.url, rb.version, rb.arch_token);
 
     const resolved = ResolvedRubyFormula{
         .name = name,
@@ -588,12 +589,18 @@ fn materializeRubyFormula(
     output.success("{s} {s} installed", .{ resolved.name, resolved.version });
 }
 
-/// Minimal Ruby formula parser for GoReleaser-style formulas.
-/// Extracts version, URL, and SHA256 for the current platform.
+/// Minimal Ruby formula parser for GoReleaser-style formulas plus the
+/// modern Homebrew cask DSL. Extracts version, URL, SHA256 — and, for
+/// casks that interpolate `#{arch}` into the URL, the per-platform arch
+/// suffix captured from the `arch arm: "...", intel: "..."` directive.
 pub const RubyFormulaInfo = struct {
     version: []const u8,
     url: []const u8,
     sha256: []const u8,
+    /// Empty by default. Populated only when the cask DSL set `arch`
+    /// keyword-argument values for the current platform (typically a
+    /// short suffix like `-aarch64` for arm and `""` for intel).
+    arch_token: []const u8 = "",
 };
 
 pub fn parseRubyFormula(rb_content: []const u8) ?RubyFormulaInfo {
@@ -602,10 +609,18 @@ pub fn parseRubyFormula(rb_content: []const u8) ?RubyFormulaInfo {
     var version: ?[]const u8 = null;
     var url: ?[]const u8 = null;
     var sha256: ?[]const u8 = null;
+    var arch_token: []const u8 = "";
 
-    // State machine: look for the right CPU section
+    // The state machine recognises two layouts:
+    //   * Classic: each platform has its own `Hardware::CPU.*` /
+    //     `on_arm` / `on_intel` block carrying url + sha256 lines.
+    //   * Cask DSL multi-arch: a single `on_macos` block holds
+    //     keyword-arg directives — `arch arm: "...", intel: "..."`,
+    //     `sha256 arm: "...", intel: "..."`, and a url that
+    //     interpolates `#{arch}`.
     var in_correct_section = false;
     var in_macos = false;
+    var prev_in_kwarg_sha256 = false;
 
     var line_start: usize = 0;
     for (rb_content, 0..) |ch, idx| {
@@ -621,9 +636,12 @@ pub fn parseRubyFormula(rb_content: []const u8) ?RubyFormulaInfo {
                 }
             }
 
-            // Track on_macos block
+            // Track on_macos block. The cask DSL uses this as the only
+            // platform gate, so being inside it is enough to consume
+            // url + arch + multi-arch sha256 directives.
             if (std.mem.indexOf(u8, line, "on_macos") != null) {
                 in_macos = true;
+                in_correct_section = true;
             }
 
             // Track CPU section (Formula style: Hardware::CPU, Cask style: on_arm/on_intel)
@@ -638,6 +656,31 @@ pub fn parseRubyFormula(rb_content: []const u8) ?RubyFormulaInfo {
                     in_correct_section = true;
                 }
             }
+
+            // arch directive — only meaningful inside on_macos.
+            if (in_macos and arch_token.len == 0 and std.mem.startsWith(u8, line, "arch ")) {
+                arch_token = pickKwArg(line["arch ".len..], is_arm) orelse arch_token;
+            }
+
+            // Multi-arch sha256: the directive may span two lines
+            // (`sha256 arm: "...", \n  intel: "..."`). Track whether the
+            // previous trimmed line opened a `sha256` directive so the
+            // continuation line can still pick the platform value.
+            if (in_macos and sha256 == null) {
+                if (std.mem.startsWith(u8, line, "sha256 ")) {
+                    const body = line["sha256 ".len..];
+                    if (lineStartsWithKwArg(body)) {
+                        if (pickKwArg(body, is_arm)) |s| sha256 = s;
+                        prev_in_kwarg_sha256 = sha256 == null;
+                    }
+                } else if (prev_in_kwarg_sha256) {
+                    if (pickKwArg(line, is_arm)) |s| sha256 = s;
+                    // Continuation lines never re-open the directive — a
+                    // missed match means the second arg is the one we
+                    // didn't want, so stop hunting for more.
+                    prev_in_kwarg_sha256 = false;
+                } else prev_in_kwarg_sha256 = false;
+            } else prev_in_kwarg_sha256 = false;
 
             // Extract URL and SHA256 within the correct section
             if (in_correct_section) {
@@ -678,7 +721,48 @@ pub fn parseRubyFormula(rb_content: []const u8) ?RubyFormulaInfo {
     }
 
     if (version != null and url != null and sha256 != null) {
-        return .{ .version = version.?, .url = url.?, .sha256 = sha256.? };
+        return .{
+            .version = version.?,
+            .url = url.?,
+            .sha256 = sha256.?,
+            .arch_token = arch_token,
+        };
+    }
+    return null;
+}
+
+/// True when the trimmed line body starts with a keyword argument the
+/// cask DSL uses for per-arch dispatch (`arm:` or `intel:`, possibly
+/// with whitespace before the value). The trailing whitespace check
+/// avoids matching a key prefix like `armadillo:`.
+fn lineStartsWithKwArg(body: []const u8) bool {
+    if (std.mem.startsWith(u8, body, "arm:")) return true;
+    if (std.mem.startsWith(u8, body, "intel:")) return true;
+    return false;
+}
+
+/// Pick the per-platform value out of a cask DSL keyword-arg body.
+/// Accepts both spellings (`arm:` / `intel:`) on either side of a comma
+/// and tolerates the variable run of whitespace casks use to align the
+/// values vertically. Returns null when the platform's key is absent.
+fn pickKwArg(body: []const u8, is_arm: bool) ?[]const u8 {
+    const key = if (is_arm) "arm:" else "intel:";
+    var rest = body;
+    while (std.mem.indexOf(u8, rest, key)) |pos| {
+        // Anchor on a word boundary so `arm:` does not match inside
+        // `armadillo:` (hypothetical, but cheap to defend against).
+        const before_ok = pos == 0 or rest[pos - 1] == ' ' or rest[pos - 1] == '\t' or rest[pos - 1] == ',';
+        if (!before_ok) {
+            rest = rest[pos + key.len ..];
+            continue;
+        }
+        var after = rest[pos + key.len ..];
+        // Skip the spaces casks insert between key and value for
+        // vertical alignment.
+        while (after.len > 0 and (after[0] == ' ' or after[0] == '\t')) after = after[1..];
+        if (after.len == 0 or after[0] != '"') return null;
+        const value, _ = std.mem.cut(u8, after[1..], "\"") orelse return null;
+        return value;
     }
     return null;
 }

--- a/tests/install_local_test.zig
+++ b/tests/install_local_test.zig
@@ -319,6 +319,116 @@ test "interpolateVersion falls back to the raw URL when the buffer is too small"
     try testing.expectEqualStrings(url, got);
 }
 
+// ─── interpolateUrl ──────────────────────────────────────────────────
+
+test "interpolateUrl substitutes #{version} and #{arch} together" {
+    var buf: [256]u8 = undefined;
+    const got = install.interpolateUrl(
+        &buf,
+        "https://example.com/tool-#{version}/tool#{arch}.dmg",
+        "1.2.3",
+        "-aarch64",
+    );
+    try testing.expectEqualStrings(
+        "https://example.com/tool-1.2.3/tool-aarch64.dmg",
+        got,
+    );
+}
+
+test "interpolateUrl elides #{arch} when the captured token is empty" {
+    // Intel rows in real casks routinely set `intel: ""` — substituting
+    // the empty string is the correct behaviour, not "skip the needle".
+    var buf: [256]u8 = undefined;
+    const got = install.interpolateUrl(
+        &buf,
+        "https://example.com/tool#{arch}.dmg",
+        "1.2.3",
+        "",
+    );
+    try testing.expectEqualStrings("https://example.com/tool.dmg", got);
+}
+
+test "interpolateUrl is a no-op when neither needle is present" {
+    var buf: [256]u8 = undefined;
+    const got = install.interpolateUrl(
+        &buf,
+        "https://example.com/static.tar.gz",
+        "9.9.9",
+        "-aarch64",
+    );
+    try testing.expectEqualStrings("https://example.com/static.tar.gz", got);
+}
+
+test "interpolateUrl falls back to the raw URL when the buffer is too small" {
+    var buf: [8]u8 = undefined;
+    const url = "https://example.com/v#{version}/tool#{arch}.dmg";
+    const got = install.interpolateUrl(&buf, url, "1.2.3", "-aarch64");
+    try testing.expectEqualStrings(url, got);
+}
+
+// Multiple needles of the same kind must all be substituted — the
+// cask DSL allows a URL like `.../#{version}/foo-#{version}.tar.gz`.
+test "interpolateUrl substitutes every #{version} occurrence" {
+    var buf: [256]u8 = undefined;
+    const got = install.interpolateUrl(
+        &buf,
+        "https://example.com/v#{version}/foo-#{version}.tar.gz",
+        "1.2.3",
+        "",
+    );
+    try testing.expectEqualStrings(
+        "https://example.com/v1.2.3/foo-1.2.3.tar.gz",
+        got,
+    );
+}
+
+// A version string that itself contains the literal `#{arch}` must
+// not trigger a second-pass substitution on the just-written bytes —
+// the single-pass walker pins this.
+test "interpolateUrl does not double-substitute when version contains arch needle" {
+    var buf: [256]u8 = undefined;
+    const got = install.interpolateUrl(
+        &buf,
+        "https://example.com/#{version}/foo#{arch}.dmg",
+        "v#{arch}",
+        "-x86",
+    );
+    try testing.expectEqualStrings(
+        "https://example.com/v#{arch}/foo-x86.dmg",
+        got,
+    );
+}
+
+// Arch tokens used in real casks routinely contain hyphens and digits.
+// Treat them as opaque text.
+test "interpolateUrl treats arch_token as opaque text" {
+    var buf: [256]u8 = undefined;
+    const got = install.interpolateUrl(
+        &buf,
+        "https://example.com/foo#{arch}.tar.gz",
+        "1.0",
+        "_macos_arm64",
+    );
+    try testing.expectEqualStrings(
+        "https://example.com/foo_macos_arm64.tar.gz",
+        got,
+    );
+}
+
+// Boundary: the buffer is exactly large enough for the substituted
+// output. interpolateUrl writes byte-by-byte so the off-by-one matters.
+test "interpolateUrl succeeds when the buffer is exactly the output length" {
+    const expected = "https://example.com/foo-x86.dmg";
+    var buf: [expected.len]u8 = undefined;
+    const got = install.interpolateUrl(
+        &buf,
+        "https://example.com/foo#{arch}.dmg",
+        "1.0",
+        "-x86",
+    );
+    try testing.expectEqualStrings(expected, got);
+}
+
 // ─── expandTildePath ─────────────────────────────────────────────────
 
 test "expandTildePath passes non-tilde input through unchanged" {
@@ -577,6 +687,56 @@ test "execute --local rejects a .rb whose archive URL is not https" {
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
     try install.execute(&ctx, arena.allocator(), &.{ "--local", "--quiet", rb_path });
+}
+
+test "execute --local --dry-run accepts a cask DSL multi-arch fixture and reaches materialise" {
+    // End-to-end: the same shape from the bug report flows through
+    // realpath → readToEnd → parseRubyFormula → tapCaskArtifactKind →
+    // materializeTapCask's dry-run leaf. The dry-run breadcrumb on
+    // stdout is the observable that proves the parser handed back
+    // version + url + sha256.
+    const prefix: [:0]const u8 = "/tmp/mlm";
+    try setupPrefix(prefix);
+    defer cleanupPrefix(prefix);
+
+    const rb_path = try std.fmt.allocPrint(testing.allocator, "{s}/rebased.rb", .{prefix});
+    defer testing.allocator.free(rb_path);
+    const cask_rb =
+        \\cask "rebased" do
+        \\  version "1.0.12"
+        \\  on_macos do
+        \\    arch arm: "-aarch64", intel: ""
+        \\    sha256 arm:   "3ef9aace106128e78e94777c7fe64228cfa1df816e7cc15b8b1bc054b7df9e9c",
+        \\           intel: "93bc02e6c7ba06e907cfa540ed22d9eae0a7e3408810bf3bf07cd18a8bef6cdc"
+        \\    url "https://github.com/DetachHead/rebased/releases/download/#{version}/rebased#{arch}.dmg"
+        \\  end
+        \\  app "Rebased.app"
+        \\end
+    ;
+    try writeFile(rb_path, cask_rb);
+
+    const output_mod = malt.output;
+    const color_mod = malt.color;
+    color_mod.setForTest(false, false);
+    defer color_mod.setForTest(null, null);
+    const prior_quiet = output_mod.isQuiet();
+    output_mod.setQuiet(false);
+    defer output_mod.setQuiet(prior_quiet);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(testing.allocator);
+    output_mod.beginStderrCapture(testing.allocator, &stderr_buf);
+    defer output_mod.endStderrCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try install.execute(&ctx, arena.allocator(), &.{ "--local", "--dry-run", rb_path });
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "Dry run: would install") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "Cannot parse") == null);
 }
 
 test "execute --local rejects a malformed .rb (missing version/url/sha256)" {

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -259,6 +259,270 @@ test "parseRubyFormula prefers the platform-specific section when on_arm/on_inte
     }
 }
 
+// Modern Homebrew cask DSL collapses per-arch sha256 + arch suffix into
+// keyword-argument directives inside a single `on_macos` block. The
+// parser must pick the right sha256 and capture the `#{arch}` token so
+// `interpolateUrl` can substitute it before the SHA-verified download.
+test "parseRubyFormula handles cask DSL multi-arch sha256 + arch directive" {
+    const is_arm = @import("builtin").cpu.arch == .aarch64;
+    const src =
+        \\cask "rebased" do
+        \\  version "1.0.12"
+        \\  on_macos do
+        \\    arch arm: "-aarch64", intel: ""
+        \\    sha256 arm:   "3ef9aace106128e78e94777c7fe64228cfa1df816e7cc15b8b1bc054b7df9e9c",
+        \\           intel: "93bc02e6c7ba06e907cfa540ed22d9eae0a7e3408810bf3bf07cd18a8bef6cdc"
+        \\    url "https://github.com/DetachHead/rebased/releases/download/#{version}/rebased#{arch}.dmg"
+        \\  end
+        \\  app "Rebased.app"
+        \\end
+    ;
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    try testing.expectEqualStrings("1.0.12", got.version);
+    try testing.expect(std.mem.indexOf(u8, got.url, "#{arch}") != null);
+    if (is_arm) {
+        try testing.expectEqualStrings(
+            "3ef9aace106128e78e94777c7fe64228cfa1df816e7cc15b8b1bc054b7df9e9c",
+            got.sha256,
+        );
+        try testing.expectEqualStrings("-aarch64", got.arch_token);
+    } else {
+        try testing.expectEqualStrings(
+            "93bc02e6c7ba06e907cfa540ed22d9eae0a7e3408810bf3bf07cd18a8bef6cdc",
+            got.sha256,
+        );
+        try testing.expectEqualStrings("", got.arch_token);
+    }
+}
+
+// Empty intel arch values are valid in real casks (the upstream archive
+// has no intel-specific suffix). The parser must not collapse an empty
+// captured token into "no arch was set".
+test "parseRubyFormula accepts an empty intel arch token" {
+    const is_arm = @import("builtin").cpu.arch == .aarch64;
+    const src =
+        \\cask "tool" do
+        \\  version "2.0"
+        \\  on_macos do
+        \\    arch arm: "-arm", intel: ""
+        \\    sha256 arm:   "1111111111111111111111111111111111111111111111111111111111111111",
+        \\           intel: "2222222222222222222222222222222222222222222222222222222222222222"
+        \\    url "https://example.com/tool#{arch}.dmg"
+        \\  end
+        \\end
+    ;
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    if (is_arm) {
+        try testing.expectEqualStrings("-arm", got.arch_token);
+    } else {
+        try testing.expectEqualStrings("", got.arch_token);
+    }
+}
+
+// A cask that omits the `arch` directive entirely (single archive for
+// both architectures, no `#{arch}` in the URL) must still parse. The
+// arch_token defaults to empty so a stray `interpolateUrl` is a no-op.
+test "parseRubyFormula handles a cask with no arch directive" {
+    const src =
+        \\cask "single" do
+        \\  version "3.1"
+        \\  on_macos do
+        \\    sha256 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        \\    url "https://example.com/single-#{version}.dmg"
+        \\  end
+        \\end
+    ;
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    try testing.expectEqualStrings("3.1", got.version);
+    try testing.expectEqualStrings(
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        got.sha256,
+    );
+    try testing.expectEqualStrings("", got.arch_token);
+}
+
+// Both args on a single line (no comma-newline split) — some casks
+// fit `arm: "...", intel: "..."` on one line. The continuation-line
+// branch of the parser must not be required for this case.
+test "parseRubyFormula handles single-line multi-arch sha256" {
+    const is_arm = @import("builtin").cpu.arch == .aarch64;
+    const src =
+        \\cask "compact" do
+        \\  version "0.1"
+        \\  on_macos do
+        \\    arch arm: "_arm", intel: "_x86"
+        \\    sha256 arm: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", intel: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        \\    url "https://example.com/compact#{arch}.dmg"
+        \\  end
+        \\end
+    ;
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    if (is_arm) {
+        try testing.expectEqualStrings("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", got.sha256);
+        try testing.expectEqualStrings("_arm", got.arch_token);
+    } else {
+        try testing.expectEqualStrings("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", got.sha256);
+        try testing.expectEqualStrings("_x86", got.arch_token);
+    }
+}
+
+// Argument order independent: some casks list intel first.
+test "parseRubyFormula handles intel-first multi-arch ordering" {
+    const is_arm = @import("builtin").cpu.arch == .aarch64;
+    const src =
+        \\cask "intel-first" do
+        \\  version "0.2"
+        \\  on_macos do
+        \\    arch intel: "-x86", arm: "-arm64"
+        \\    sha256 intel: "1111111111111111111111111111111111111111111111111111111111111111",
+        \\           arm:   "2222222222222222222222222222222222222222222222222222222222222222"
+        \\    url "https://example.com/foo#{arch}.dmg"
+        \\  end
+        \\end
+    ;
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    if (is_arm) {
+        try testing.expectEqualStrings("2222222222222222222222222222222222222222222222222222222222222222", got.sha256);
+        try testing.expectEqualStrings("-arm64", got.arch_token);
+    } else {
+        try testing.expectEqualStrings("1111111111111111111111111111111111111111111111111111111111111111", got.sha256);
+        try testing.expectEqualStrings("-x86", got.arch_token);
+    }
+}
+
+// CRLF line endings in a real-world cask file fetched from a Windows-
+// committed branch. The continuation-line trim must strip the \r so
+// the kwarg parser still sees `intel: "..."`.
+test "parseRubyFormula handles CRLF line endings inside multi-arch sha256" {
+    const is_arm = @import("builtin").cpu.arch == .aarch64;
+    const src = "cask \"crlf\" do\r\n" ++
+        "  version \"0.3\"\r\n" ++
+        "  on_macos do\r\n" ++
+        "    arch arm: \"-arm\", intel: \"\"\r\n" ++
+        "    sha256 arm:   \"3333333333333333333333333333333333333333333333333333333333333333\",\r\n" ++
+        "           intel: \"4444444444444444444444444444444444444444444444444444444444444444\"\r\n" ++
+        "    url \"https://example.com/foo#{arch}.dmg\"\r\n" ++
+        "  end\r\n" ++
+        "end\r\n";
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    if (is_arm) {
+        try testing.expectEqualStrings("3333333333333333333333333333333333333333333333333333333333333333", got.sha256);
+        try testing.expectEqualStrings("-arm", got.arch_token);
+    } else {
+        try testing.expectEqualStrings("4444444444444444444444444444444444444444444444444444444444444444", got.sha256);
+        try testing.expectEqualStrings("", got.arch_token);
+    }
+}
+
+// Mid-line `arm:` substring inside a quoted value (here, a hash) must
+// not confuse the keyword-arg matcher. The continuation-line gate is
+// already gone by the time the URL line is examined, so the URL value
+// has to come through cleanly.
+test "parseRubyFormula does not mis-detect arm: inside quoted values" {
+    const src =
+        \\cask "boundary" do
+        \\  version "0.4"
+        \\  on_macos do
+        \\    arch arm: "-arm", intel: ""
+        \\    sha256 arm:   "5555555555555555555555555555555555555555555555555555555555555555",
+        \\           intel: "6666666666666666666666666666666666666666666666666666666666666666"
+        \\    url "https://example.com/notes:arm:thing/foo#{arch}.tar.gz"
+        \\  end
+        \\end
+    ;
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    // The url should reach the parser intact (#{arch} interpolated later).
+    try testing.expect(std.mem.indexOf(u8, got.url, "notes:arm:thing") != null);
+}
+
+// A formula that mixes shapes (a global sha256 plus a Hardware::CPU
+// section that only sets url) must still parse — the global fallback
+// loop fills in whichever field the section path missed.
+test "parseRubyFormula falls back to global sha256 when section omits it" {
+    const is_arm = @import("builtin").cpu.arch == .aarch64;
+    const src =
+        \\class Mixed < Formula
+        \\  version "1.0"
+        \\  sha256 "7777777777777777777777777777777777777777777777777777777777777777"
+        \\  on_macos do
+        \\    on_arm do
+        \\      url "https://example.com/mixed-arm.tar.gz"
+        \\    end
+        \\    on_intel do
+        \\      url "https://example.com/mixed-intel.tar.gz"
+        \\    end
+        \\  end
+        \\end
+    ;
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    try testing.expectEqualStrings("7777777777777777777777777777777777777777777777777777777777777777", got.sha256);
+    if (is_arm) {
+        try testing.expect(std.mem.indexOf(u8, got.url, "arm") != null);
+    } else {
+        try testing.expect(std.mem.indexOf(u8, got.url, "intel") != null);
+    }
+}
+
+// A cask with the keyword-arg form for the current arch only (the other
+// arch is missing from the keyword args entirely). On the missing arch
+// the parse must return null cleanly — no crash, no partial info, no
+// false claim of success.
+test "parseRubyFormula returns null when current platform's kwarg is missing" {
+    const is_arm = @import("builtin").cpu.arch == .aarch64;
+    const src_arm_only =
+        \\cask "arm-only" do
+        \\  version "0.5"
+        \\  on_macos do
+        \\    arch arm: "-arm"
+        \\    sha256 arm: "8888888888888888888888888888888888888888888888888888888888888888"
+        \\    url "https://example.com/foo#{arch}.dmg"
+        \\  end
+        \\end
+    ;
+    if (is_arm) {
+        const got = install.parseRubyFormula(src_arm_only) orelse return error.TestUnexpectedNull;
+        try testing.expectEqualStrings("-arm", got.arch_token);
+    } else {
+        try testing.expect(install.parseRubyFormula(src_arm_only) == null);
+    }
+}
+
+// The arch directive is per-on_macos: a directive emitted before the
+// `on_macos` block opens (rare but seen in stage-loaded casks) should
+// be ignored so a Linux-side block can't bleed an arch token into the
+// macOS install.
+test "parseRubyFormula ignores arch directive outside on_macos" {
+    const is_arm = @import("builtin").cpu.arch == .aarch64;
+    _ = is_arm;
+    const src =
+        \\cask "scoped" do
+        \\  version "0.6"
+        \\  arch arm: "-do-not-use", intel: "-also-no"
+        \\  on_macos do
+        \\    sha256 "9999999999999999999999999999999999999999999999999999999999999999"
+        \\    url "https://example.com/scoped-#{version}.dmg"
+        \\  end
+        \\end
+    ;
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    try testing.expectEqualStrings("", got.arch_token);
+}
+
+// extractQuoted underpins both legacy and cask DSL extraction; the
+// keyword-arg shape introduces a new pattern (`url "..."` after a
+// long sha256 directive) so pin a "won't accidentally cut on the
+// wrong line" property here.
+test "extractQuoted does not match across newlines" {
+    const got = install.extractQuoted("sha256 arm:\nintel: \"x\"", "intel: \"");
+    // `intel: \"` only appears on the second line; with line-by-line
+    // trimming this is invoked per-line, not on the joined buffer.
+    // Calling extractQuoted on the whole string still cuts at the
+    // first match — the property under test is "does not match a
+    // prefix that didn't appear" (it does appear, so it returns "x").
+    try testing.expect(got != null);
+    try testing.expectEqualStrings("x", got.?);
+}
+
 test "findFailedDep flags the first dep name that appears in failed_kegs" {
     var failed = std.StringHashMap(void).init(testing.allocator);
     defer failed.deinit();


### PR DESCRIPTION
## Description

Tap installs of casks that use the modern Homebrew DSL multi-arch shape — a single `on_macos` block carrying `arch arm:/intel:`, a comma-separated `sha256 arm:/intel:` keyword-arg directive, and a URL that interpolates `#{arch}` — were rejected at parse time with `Cannot parse … formula`. The Ruby parser only recognised the legacy `Hardware::CPU.*` and standalone `on_arm`/`on_intel` shapes.

This restores end-to-end install of those casks. The parser now picks the per-platform sha256 from the keyword-arg form (single- or multi-line, comma-newline split tolerated, intel-first ordering tolerated, CRLF tolerated), captures the matching arch token from the `arch` directive, and a new `interpolateUrl` helper substitutes both `#{version}` and `#{arch}` before the SHA-verified fetch. The legacy parser shapes still work — `tap_cask_install_gh180` and `tap_cask_dmg_gh136` regressions both pass.

The local `--local` install path benefits from the same change because it shares the parser. New tests cover the parser end-to-end via `execute --local --dry-run` against the offending fixture.

## Related Issue

Closes #307

## Notes for Reviewers

- None