### PR TITLE
fix(upgrade): atomic DB updates and actionable failure messages

### DIFF
--- a/scripts/regressions/upgrade_atomic_db_rollback.sh
+++ b/scripts/regressions/upgrade_atomic_db_rollback.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Regression: `mt upgrade` rolls the DB back atomically when its kegs
+# INSERT fails mid-flight, and surfaces the underlying SQLite category
+# and message in the failure output.
+#
+# Pre-fix, the upgrade flow ran linker.unlink (DELETE FROM links) and
+# recordKeg (INSERT INTO kegs) as separate implicit transactions with
+# no outer wrapper. A failure of either produced a half-mutated DB
+# (links gone, kegs row missing/wrong, or both) and a cryptic message:
+#
+#   ⚠ Could not remove old symlinks for <name>
+#   ✗ Failed to record new version of <name> in database
+#
+# Cause: no atomic envelope; both call sites swallowed the typed
+# `sqlite.SqliteError` so the user could not tell whether the failure
+# was Busy, ExecFailed, ConstraintViolation, or something else.
+#
+# The fix wraps unlink → recordKeg → link → deleteKeg in a single
+# `BEGIN IMMEDIATE`/`COMMIT`. On any failure inside, the txn rolls back
+# (DB returns to pre-upgrade state) and the existing FS rollback
+# rebuilds old symlinks + drops the new cellar dir. recordKeg now
+# propagates the typed SqliteError, and the upgrade-side `output.err`
+# calls include `@errorName(err)` and `db.errMsg()`.
+#
+# This script reproduces that contract end-to-end against three real
+# zero-dep formulas. For each:
+#   1. Install it via real `mt install`.
+#   2. Rename its cellar dir to `<v>_99` and update kegs.revision +
+#      cellar_path + links.target to match. This forces the upgrade
+#      walker into a real attempt (revision 99 ≠ upstream 0) AND keeps
+#      the old cellar dir at a path the rollback's `cellar_mod.remove`
+#      will not target (which removes `<name>/<new_pkg_version>`).
+#   3. Install a BEFORE INSERT trigger on `kegs` so recordKeg's INSERT
+#      raises a deterministic SQLITE_CONSTRAINT_TRIGGER mapped to
+#      ConstraintViolation. Trigger payload doubles as the errMsg
+#      assertion target.
+#   4. Run `mt upgrade <name>` and assert it exits non-zero with both
+#      `ConstraintViolation` and the trigger message in stderr.
+#   5. Drop the trigger and assert post-state: keg row + links count +
+#      old cellar dir all bit-identical to the post-tamper snapshot.
+#
+# Usage: scripts/regressions/upgrade_atomic_db_rollback.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt,
+# `sqlite3` on PATH, network access for the seeding install + the
+# upgrade fetch (bottle download).
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be ≤ 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_atom"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+DB="$PREFIX/db/malt.db"
+
+# Three zero-dep formulas — keeps the seed install in the seconds range
+# while exercising the upgrade DB path on independent rows.
+PACKAGES=(tree xz pkgconf)
+
+INSTALL_LOG="$PREFIX/install.log"
+printf '\xe2\x96\xb8 mt install %s (logs \xe2\x86\x92 %s)\n' "${PACKAGES[*]}" "$INSTALL_LOG"
+"$BIN" install "${PACKAGES[@]}" >"$INSTALL_LOG" 2>&1 ||
+  fail "seed install failed; see $INSTALL_LOG"
+for P in "${PACKAGES[@]}"; do
+  [[ -d "$PREFIX/Cellar/$P" ]] || fail "$P not in cellar after seed install"
+done
+pass "seeded ${#PACKAGES[@]} formulas"
+
+# --- Per-package: tamper, force-fail, assert rollback ------------------
+for P in "${PACKAGES[@]}"; do
+  printf '\xe2\x96\xb8 %s\n' "$P"
+
+  # 1. Sniff the actual installed version (whatever Homebrew shipped on
+  #    the day this CI runs) and stash the cellar at `<v>_99`. The 99
+  #    revision suffix decouples old_pkg_version from formula.pkg_version
+  #    so the rollback's `cellar_mod.remove` (`<name>/<new_pkg_version>`)
+  #    never targets the dir we want preserved.
+  INSTALLED_DIR=$(find "$PREFIX/Cellar/$P" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -1)
+  [[ -n "$INSTALLED_DIR" ]] || fail "no version dir under $PREFIX/Cellar/$P"
+  INSTALLED_VER=$(basename "$INSTALLED_DIR")
+  STALE_VER="${INSTALLED_VER}_99"
+  STALE_DIR="$PREFIX/Cellar/$P/$STALE_VER"
+  mv "$INSTALLED_DIR" "$STALE_DIR" || fail "could not rename cellar dir for $P"
+
+  # Drag the DB into agreement: bump revision to 99, repoint
+  # cellar_path, and rewrite links.target so unlink and link both walk
+  # the new dir. Use literal-substring REPLACE (the trailing slash
+  # anchors the match) to avoid clobbering unrelated paths.
+  sqlite3 "$DB" <<SQL || fail "could not retarget DB rows for $P"
+UPDATE kegs
+   SET revision=99,
+       cellar_path='$STALE_DIR'
+ WHERE name='$P';
+UPDATE links
+   SET target=REPLACE(target,
+                      '/Cellar/$P/$INSTALLED_VER/',
+                      '/Cellar/$P/$STALE_VER/')
+ WHERE keg_id IN (SELECT id FROM kegs WHERE name='$P');
+SQL
+
+  # 2. Snapshot the post-tamper state. The rollback contract says
+  #    these values must be bit-identical after the failed upgrade.
+  PRE_KEG_ROW=$(sqlite3 -separator '|' "$DB" \
+    "SELECT id, version, revision, store_sha256, cellar_path FROM kegs WHERE name='$P';")
+  PRE_LINK_COUNT=$(sqlite3 "$DB" \
+    "SELECT COUNT(*) FROM links l JOIN kegs k ON l.keg_id=k.id WHERE k.name='$P';")
+  [[ -n "$PRE_KEG_ROW" ]] || fail "$P keg row vanished after tamper"
+
+  # 3. Install a deterministic recordKeg-failure trigger. Scoped by
+  #    `NEW.name` so unrelated INSERTs (none expected for these
+  #    formulas, but cheap insurance) keep working.
+  TRIG="block_${P//[^A-Za-z0-9]/_}_insert"
+  TRIG_MSG="regression: forced recordKeg failure for $P"
+  sqlite3 "$DB" "CREATE TRIGGER $TRIG BEFORE INSERT ON kegs WHEN NEW.name = '$P'
+    BEGIN SELECT RAISE(ABORT, '$TRIG_MSG'); END;" ||
+    fail "could not install $TRIG"
+
+  # 4. Drive the upgrade. Must fail; stderr must name both the typed
+  #    SqliteError category and the trigger message (the latter
+  #    arrives via `db.errMsg()`).
+  UPGRADE_LOG="$PREFIX/upgrade_$P.log"
+  if "$BIN" upgrade "$P" >"$UPGRADE_LOG" 2>&1; then
+    sqlite3 "$DB" "DROP TRIGGER IF EXISTS $TRIG;"
+    fail "$P upgrade unexpectedly succeeded with trigger active; see $UPGRADE_LOG"
+  fi
+
+  grep -q "ConstraintViolation" "$UPGRADE_LOG" ||
+    fail "$P upgrade error did not name ConstraintViolation; see $UPGRADE_LOG"
+  grep -qF "$TRIG_MSG" "$UPGRADE_LOG" ||
+    fail "$P upgrade error did not surface db.errMsg() trigger payload; see $UPGRADE_LOG"
+  pass "$P upgrade error names SQLite category + message"
+
+  # 5. Drop the trigger before the post-check so the eventual cleanup
+  #    DELETEs don't trip an unrelated fire path.
+  sqlite3 "$DB" "DROP TRIGGER IF EXISTS $TRIG;"
+
+  POST_KEG_ROW=$(sqlite3 -separator '|' "$DB" \
+    "SELECT id, version, revision, store_sha256, cellar_path FROM kegs WHERE name='$P';")
+  POST_LINK_COUNT=$(sqlite3 "$DB" \
+    "SELECT COUNT(*) FROM links l JOIN kegs k ON l.keg_id=k.id WHERE k.name='$P';")
+
+  [[ "$POST_KEG_ROW" == "$PRE_KEG_ROW" ]] ||
+    fail "$P keg row drifted across rollback:
+       pre:  $PRE_KEG_ROW
+       post: $POST_KEG_ROW"
+  [[ "$POST_LINK_COUNT" == "$PRE_LINK_COUNT" ]] ||
+    fail "$P link count drifted across rollback: $PRE_LINK_COUNT -> $POST_LINK_COUNT"
+
+  # The recorded cellar_path must still exist on disk — the FS-side
+  # rollback complement to the DB rollback proves the user-visible
+  # state is fully consistent (old keg still resolvable).
+  [[ -d "$STALE_DIR" ]] ||
+    fail "$P old cellar dir missing after rollback: $STALE_DIR"
+  pass "$P kegs+links+cellar preserved after rolled-back upgrade"
+done
+
+printf '\n\xe2\x9c\x94 upgrade-atomic-db-rollback regression passed\n'

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -367,44 +367,58 @@ fn upgradeFormula(
     };
     output.emitNdjsonEvent(.materialized, name, "ok");
 
-    // Step 6: Unlink old symlinks
+    // Steps 6–8 (DB part): atomic. unlink-old → recordKeg → link-new →
+    // deleteKeg-old run inside a single SQLite transaction so a partial
+    // failure cannot leave kegs/links half-mutated. On any error inside
+    // the txn we ROLLBACK first, then run filesystem rollback (re-link
+    // old version, remove the new cellar dir) so the user can retry the
+    // upgrade against a consistent on-disk + DB state.
     var linker = linker_mod.Linker.init(ctx.io, allocator, db, prefix);
-    linker.unlink(old_keg_id) catch {
-        output.warn("Could not remove old symlinks for {s}", .{name});
-    };
-
-    // Step 7: Create new symlinks — rollback on failure
-    const new_keg_id = recordKeg(db, &formula, bottle.sha256, new_keg.path) catch {
-        output.err("Failed to record new version of {s} in database", .{name});
-        // Rollback: re-link old version
-        restoreOldLinks(db, &linker, old_cellar_path, name, old_keg_id);
-        // rollback cellar cleanup; a leftover keg is tolerable if the rollback is already failing.
+    db.beginTransaction() catch |txn_err| {
+        output.err(
+            "Could not begin DB transaction for {s}: {s} ({s})",
+            .{ name, @errorName(txn_err), db.errMsg() },
+        );
         cellar_mod.remove(ctx.io, prefix, formula.name, formula.pkg_version) catch {};
-        return;
+        return error.Aborted;
     };
 
-    linker.link(new_keg.path, formula.name, new_keg_id) catch {
-        output.err("Failed to link new version of {s}", .{name});
-        output.emitNdjsonEvent(.linked, name, "failed");
-        // Rollback: remove partial new links, restore old
-        // partial link cleanup in a rollback path.
+    const new_keg_id = upgradeDbAtomic(db, &linker, old_keg_id, &formula, bottle.sha256, new_keg.path) catch |db_err| {
+        output.err(
+            "Failed to record new version of {s} in database: {s} ({s})",
+            .{ name, @errorName(db_err), db.errMsg() },
+        );
+        db.rollback();
+        // FS rollback: the txn restored old keg/links rows; we still
+        // need to recreate the old symlinks (FS isn't transactional)
+        // and drop the freshly-materialized new cellar dir.
+        restoreOldLinks(db, &linker, old_cellar_path, name, old_keg_id);
+        cellar_mod.remove(ctx.io, prefix, formula.name, formula.pkg_version) catch {};
+        return error.Aborted;
+    };
+
+    db.commit() catch |commit_err| {
+        output.err(
+            "Failed to commit upgrade for {s}: {s} ({s})",
+            .{ name, @errorName(commit_err), db.errMsg() },
+        );
+        db.rollback();
+        // best-effort FS cleanup before falling back to the old version.
         linker.unlink(new_keg_id) catch {};
-        deleteKeg(db, new_keg_id);
         restoreOldLinks(db, &linker, old_cellar_path, name, old_keg_id);
-        // rollback cellar cleanup.
         cellar_mod.remove(ctx.io, prefix, formula.name, formula.pkg_version) catch {};
-        return;
+        return error.Aborted;
     };
-    // `recorded` after both succeed — link rollback above undoes the
-    // keg row, so an early emit would lie if `linked:failed` follows.
+
+    // emit only after the txn commits — earlier emits would lie if a
+    // later step inside the txn rolled the recorded/linked state back.
     output.emitNdjsonEvent(.linked, name, "ok");
     output.emitNdjsonEvent(.recorded, name, "ok");
 
     // opt symlink is convenience; install is already functional via versioned link.
     linker.linkOpt(formula.name, formula.pkg_version) catch {};
 
-    // Step 8: Remove old DB record + Cellar entry (success path only)
-    deleteKeg(db, old_keg_id);
+    // Step 8 (FS-only tail): drop the now-replaced cellar entry.
     cellar_mod.remove(ctx.io, prefix, name, old_pkg_version) catch {
         output.warn("Could not remove old cellar entry for {s} {s}", .{ name, old_pkg_version });
     };
@@ -556,6 +570,28 @@ fn upgradeTapCaskFallback(
     return false;
 }
 
+/// Run the DB-mutating steps of a formula upgrade — caller owns the
+/// surrounding transaction. Order is load-bearing: old links must be
+/// DELETEd before the new keg is INSERTed so the new symlinks can take
+/// over the same `link_path`s without tripping the UNIQUE index, and
+/// the old keg row stays alive until last so the FS rollback path can
+/// still find its `cellar_path`. On error the caller rolls back and
+/// runs `restoreOldLinks` + cellar cleanup.
+pub fn upgradeDbAtomic(
+    db: *sqlite.Database,
+    linker: *linker_mod.Linker,
+    old_keg_id: i64,
+    formula: *const formula_mod.Formula,
+    store_sha256: []const u8,
+    new_cellar_path: []const u8,
+) !i64 {
+    try linker.unlink(old_keg_id);
+    const new_keg_id = try recordKeg(db, formula, store_sha256, new_cellar_path);
+    try linker.link(new_cellar_path, formula.name, new_keg_id);
+    deleteKeg(db, old_keg_id);
+    return new_keg_id;
+}
+
 /// Re-link old version during rollback.
 fn restoreOldLinks(
     _: *sqlite.Database,
@@ -574,36 +610,36 @@ fn restoreOldLinks(
 /// The COALESCE on `pinned` inherits any existing user pin from the
 /// row(s) being replaced so a force-upgrade preserves the hold rather
 /// than silently clearing it. Fresh installs (no prior row) default to 0.
+///
+/// Inherits the caller's transaction (no internal BEGIN/COMMIT) so
+/// upgradeFormula can wrap unlink → recordKeg → link in a single txn:
+/// nesting `BEGIN IMMEDIATE` would error out as "cannot start a
+/// transaction within a transaction" and leave the upgrade half-mutated.
+/// A standalone caller still gets atomicity from SQLite's implicit
+/// per-statement transaction.
 pub fn recordKeg(
     db: *sqlite.Database,
     formula: *const formula_mod.Formula,
     store_sha256: []const u8,
     cellar_path: []const u8,
-) !i64 {
-    db.beginTransaction() catch return error.RecordFailed;
-    errdefer db.rollback();
-
-    var stmt = db.prepare(
+) sqlite.SqliteError!i64 {
+    var stmt = try db.prepare(
         "INSERT INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason, pinned)" ++
             " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'direct', COALESCE((SELECT MAX(pinned) FROM kegs WHERE name = ?1), 0));",
-    ) catch return error.RecordFailed;
+    );
     defer stmt.finalize();
 
-    stmt.bindText(1, formula.name) catch return error.RecordFailed;
-    stmt.bindText(2, formula.full_name) catch return error.RecordFailed;
-    stmt.bindText(3, formula.version) catch return error.RecordFailed;
-    stmt.bindInt(4, formula.revision) catch return error.RecordFailed;
-    stmt.bindText(5, formula.tap) catch return error.RecordFailed;
-    stmt.bindText(6, store_sha256) catch return error.RecordFailed;
-    stmt.bindText(7, cellar_path) catch return error.RecordFailed;
+    try stmt.bindText(1, formula.name);
+    try stmt.bindText(2, formula.full_name);
+    try stmt.bindText(3, formula.version);
+    try stmt.bindInt(4, formula.revision);
+    try stmt.bindText(5, formula.tap);
+    try stmt.bindText(6, store_sha256);
+    try stmt.bindText(7, cellar_path);
 
-    _ = stmt.step() catch return error.RecordFailed;
+    _ = try stmt.step();
 
-    const keg_id = getLastInsertId(db) catch return error.RecordFailed;
-
-    db.commit() catch return error.RecordFailed;
-
-    return keg_id;
+    return try getLastInsertId(db);
 }
 
 /// Delete a keg record from the database (rollback helper). The whole
@@ -628,12 +664,13 @@ fn deleteKeg(db: *sqlite.Database, keg_id: i64) void {
     _ = stmt.step() catch {};
 }
 
-/// Get the last inserted row id from SQLite.
-fn getLastInsertId(db: *sqlite.Database) !i64 {
-    var stmt = db.prepare("SELECT last_insert_rowid();") catch return error.RecordFailed;
+/// Get the last inserted row id from SQLite. Propagates the typed
+/// SqliteError so callers can route it through `db.errMsg()`.
+fn getLastInsertId(db: *sqlite.Database) sqlite.SqliteError!i64 {
+    var stmt = try db.prepare("SELECT last_insert_rowid();");
     defer stmt.finalize();
-    const has_row = stmt.step() catch return error.RecordFailed;
-    if (!has_row) return error.RecordFailed;
+    const has_row = try stmt.step();
+    if (!has_row) return sqlite.SqliteError.StepFailed;
     return stmt.columnInt(0);
 }
 
@@ -761,23 +798,57 @@ fn upgradeCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []const 
     // after recordInstall so a `--force` upgrade preserves the user's hold.
     const was_pinned = pin_mod.isPinned(db, token);
 
-    // Uninstall old version
+    // Atomic DB section (uninstall's DELETE + recordInstall's INSERT OR
+    // REPLACE) so a partial failure can't leave the casks row missing
+    // when the new app is already on disk. The malt.lock fileguards
+    // against other malt writers, so holding the SQLite txn across the
+    // (potentially slow) install is harmless to other connections.
     var installer = cask_mod.CaskInstaller.init(ctx.io, ctx.environ, allocator, db, prefix);
-    installer.uninstall(token) catch {
-        output.err("Failed to remove old version of {s}", .{token});
+    db.beginTransaction() catch |txn_err| {
+        output.err(
+            "Could not begin DB transaction for {s}: {s} ({s})",
+            .{ token, @errorName(txn_err), db.errMsg() },
+        );
         return error.Aborted;
     };
 
-    // Install new version
-    const app_path = installer.install(&parsed_cask) catch {
-        output.err("Failed to install new version of {s}", .{token});
+    installer.uninstall(token) catch |un_err| {
+        output.err(
+            "Failed to remove old version of {s}: {s}",
+            .{ token, @errorName(un_err) },
+        );
+        db.rollback();
         return error.Aborted;
     };
 
-    cask_mod.recordInstall(db, &parsed_cask, app_path) catch {
-        output.warn("Failed to record cask {s} in database", .{token});
+    const app_path = installer.install(&parsed_cask) catch |in_err| {
+        output.err(
+            "Failed to install new version of {s}: {s}",
+            .{ token, @errorName(in_err) },
+        );
+        db.rollback();
+        return error.Aborted;
+    };
+
+    cask_mod.recordInstall(db, &parsed_cask, app_path) catch |rec_err| {
+        output.err(
+            "Failed to record cask {s} in database: {s} ({s})",
+            .{ token, @errorName(rec_err), db.errMsg() },
+        );
+        db.rollback();
+        allocator.free(app_path);
+        return error.Aborted;
     };
     allocator.free(app_path);
+
+    db.commit() catch |commit_err| {
+        output.err(
+            "Failed to commit upgrade for cask {s}: {s} ({s})",
+            .{ token, @errorName(commit_err), db.errMsg() },
+        );
+        db.rollback();
+        return error.Aborted;
+    };
 
     if (was_pinned) {
         // Best-effort: a missing pin restore is a UX regression, not data

--- a/src/db/sqlite.zig
+++ b/src/db/sqlite.zig
@@ -133,6 +133,16 @@ pub const Database = struct {
         _ = c.sqlite3_close(self._handle);
     }
 
+    /// Last error message from this connection. Returns the SQLite-owned
+    /// UTF-8 buffer (`sqlite3_errmsg`); the slice is valid only until the
+    /// next call on this handle, so use it inline (e.g. directly in an
+    /// `output.err` format) and never store it past the next op.
+    pub fn errMsg(self: *Database) []const u8 {
+        const ptr = c.sqlite3_errmsg(self._handle);
+        if (ptr == null) return "";
+        return std.mem.sliceTo(ptr, 0);
+    }
+
     /// Execute one or more SQL statements that return no result rows.
     /// String literals and `bufPrintZ` output coerce to `[:0]const u8`; dynamic
     /// SQL should be built with `bufPrintZ` or an ArrayList plus a trailing 0.
@@ -167,3 +177,34 @@ pub const Database = struct {
         _ = c.sqlite3_exec(self._handle, "ROLLBACK;", null, null, null);
     }
 };
+
+const testing = std.testing;
+
+test "errMsg returns the underlying SQLite error string after a failed exec" {
+    var db = try Database.open(":memory:");
+    defer db.close();
+
+    // Forces a parse error, populating the connection's last-error slot.
+    try testing.expectError(SqliteError.ExecFailed, db.exec("NOT VALID SQL;"));
+    const msg = db.errMsg();
+    try testing.expect(msg.len > 0);
+    // SQLite's parse error includes the offending token; assert on a stable
+    // substring rather than the full message.
+    try testing.expect(std.mem.indexOf(u8, msg, "syntax error") != null or
+        std.mem.indexOf(u8, msg, "near \"NOT\"") != null);
+}
+
+test "errMsg surfaces a UNIQUE constraint violation message" {
+    var db = try Database.open(":memory:");
+    defer db.close();
+
+    try db.exec("CREATE TABLE t(name TEXT UNIQUE);");
+    try db.exec("INSERT INTO t(name) VALUES('a');");
+
+    var stmt = try db.prepare("INSERT INTO t(name) VALUES(?1);");
+    defer stmt.finalize();
+    try stmt.bindText(1, "a");
+    try testing.expectError(SqliteError.ConstraintViolation, stmt.step());
+    const msg = db.errMsg();
+    try testing.expect(std.mem.indexOf(u8, msg, "UNIQUE") != null);
+}

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -291,6 +291,158 @@ test "recordKeg defaults pinned=0 when no prior keg of that name exists" {
     try testing.expectEqual(false, stmt.columnBool(0));
 }
 
+// Atomicity contract: recordKeg participates in an enclosing transaction
+// rather than starting its own. Without this, upgradeFormula cannot wrap
+// unlink+recordKeg+link in a single txn — the inner BEGIN IMMEDIATE
+// would error with "cannot start a transaction within a transaction"
+// and leave the DB half-mutated on partial failure.
+test "recordKeg runs inside an outer beginTransaction without nesting errors" {
+    const path = try setupPrefix("recordkeg_inside_outer_txn");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const formula_json =
+        \\{
+        \\  "name": "inside-txn",
+        \\  "full_name": "inside-txn",
+        \\  "tap": "homebrew/core",
+        \\  "versions": {"stable": "2.0"}
+        \\}
+    ;
+    var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
+    defer formula.deinit();
+
+    try db.beginTransaction();
+    const new_keg_id = try upgrade.recordKeg(&db, &formula, "sha-inner", "/cellar/inside-txn/2.0");
+    try db.commit();
+
+    var stmt = try db.prepare("SELECT name, version FROM kegs WHERE id = ?1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, new_keg_id);
+    _ = try stmt.step();
+    try testing.expectEqualStrings("inside-txn", std.mem.sliceTo(stmt.columnText(0).?, 0));
+    try testing.expectEqualStrings("2.0", std.mem.sliceTo(stmt.columnText(1).?, 0));
+}
+
+// Diagnostics contract: a UNIQUE collision must propagate the typed
+// SqliteError so the call site can surface `db.errMsg()` and the user
+// sees what actually failed. Pre-fix this collapsed into the opaque
+// `error.RecordFailed`.
+test "recordKeg propagates ConstraintViolation on UNIQUE collision" {
+    const path = try setupPrefix("recordkeg_constraint_propagates");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+
+    // Pre-existing row that the recordKeg INSERT will collide with on
+    // (name, version, revision).
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+        \\VALUES ('collide', 'collide', '1.0', 0, 'sha-old', '/cellar/collide/1.0');
+    );
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const formula_json =
+        \\{
+        \\  "name": "collide",
+        \\  "full_name": "collide",
+        \\  "tap": "homebrew/core",
+        \\  "versions": {"stable": "1.0"}
+        \\}
+    ;
+    var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
+    defer formula.deinit();
+
+    try testing.expectError(
+        sqlite.SqliteError.ConstraintViolation,
+        upgrade.recordKeg(&db, &formula, "sha-new", "/cellar/collide/1.0"),
+    );
+    // The connection's last-error slot carries the SQLite text — that's
+    // what the upgrade path will log to the user.
+    try testing.expect(std.mem.indexOf(u8, db.errMsg(), "UNIQUE") != null);
+}
+
+// Atomic-txn contract: when `recordKeg` fails inside the outer
+// transaction (e.g. UNIQUE collision), a ROLLBACK leaves both `kegs`
+// and `links` exactly as they were before the upgrade started.
+// This is the load-bearing guarantee that keeps the user out of the
+// "unlink warned + record failed → DB half-mutated" state from the
+// original report.
+test "upgradeDbAtomic rolls back kegs+links on recordKeg failure" {
+    const path = try setupPrefix("upgradedbatomic_rollback");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+
+    // Seed: an installed keg + two links rows simulating
+    // `bin/foo` and `lib/foo.dylib` already linked.
+    try db.exec(
+        \\INSERT INTO kegs (id, name, full_name, version, revision, store_sha256, cellar_path)
+        \\VALUES (42, 'foo', 'foo', '1.0', 0, 'sha-old', '/cellar/foo/1.0');
+    );
+    try db.exec(
+        \\INSERT INTO links (keg_id, link_path, target)
+        \\VALUES (42, '/p/bin/foo', '/cellar/foo/1.0/bin/foo'),
+        \\       (42, '/p/lib/foo.dylib', '/cellar/foo/1.0/lib/foo.dylib');
+    );
+    // Pre-existing collision row that recordKeg's INSERT will hit.
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+        \\VALUES ('foo', 'foo', '2.0', 0, 'sha-collide', '/cellar/foo/2.0');
+    );
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const formula_json =
+        \\{
+        \\  "name": "foo",
+        \\  "full_name": "foo",
+        \\  "tap": "homebrew/core",
+        \\  "versions": {"stable": "2.0"}
+        \\}
+    ;
+    var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
+    defer formula.deinit();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var linker = malt.linker.Linker.init(io, testing.allocator, &db, path);
+
+    try db.beginTransaction();
+    try testing.expectError(
+        sqlite.SqliteError.ConstraintViolation,
+        upgrade.upgradeDbAtomic(&db, &linker, 42, &formula, "sha-new", "/cellar/foo/2.0_new"),
+    );
+    db.rollback();
+
+    // Old keg row survives.
+    var keg_stmt = try db.prepare("SELECT version, revision FROM kegs WHERE id = 42;");
+    defer keg_stmt.finalize();
+    try testing.expect(try keg_stmt.step());
+    try testing.expectEqualStrings("1.0", std.mem.sliceTo(keg_stmt.columnText(0).?, 0));
+    try testing.expectEqual(@as(i64, 0), keg_stmt.columnInt(1));
+
+    // Both links rows survive.
+    var links_stmt = try db.prepare("SELECT COUNT(*) FROM links WHERE keg_id = 42;");
+    defer links_stmt.finalize();
+    _ = try links_stmt.step();
+    try testing.expectEqual(@as(i64, 2), links_stmt.columnInt(0));
+}
+
 test "pinSkip honours --force and audit_mode for casks too" {
     const path = try setupPrefix("pinskip_cask");
     defer testing.allocator.free(path);


### PR DESCRIPTION
## Description

`mt upgrade` now runs its DB mutations inside a single SQLite transaction, so a failure mid-flight cannot leave kegs/links half-mutated - the txn rolls back, the existing FS rollback restores the old keg, and the user can simply retry against a consistent on-disk + DB state. Failure output now names the underlying SQLite error category and message instead of a generic "Failed to record new version of <name> in database", turning previously-opaque incidents into self-diagnosing ones.

The same atomic-txn pattern is applied to the cask upgrade path so a partial failure between `uninstall` and `recordInstall` cannot drop the casks row while the new app is on disk.

## Related Issue

- None

## Notes for Reviewers

- None