### PR TITLE
refactor(tap): consolidate tap-fetch URL synthesis behind one seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,13 +81,19 @@ jobs:
       - name: Check Zig formatting
         run: zig fmt --check src/ tests/
 
+      # Static structural guard: every tap fetch URL, writeback URL,
+      # and MALT_GITHUB_TOKEN reach stays inside src/core/tap.zig.
+      # No build, no network — fast enough to live in lint.
+      - name: Tap-resolution contract guard
+        run: ./scripts/regressions/tap-resolution-contract.sh
+
       - name: Install shell-lint tools
         run: brew install shellcheck shfmt
 
       - name: Lint shell scripts (shellcheck + shfmt)
         run: |
-          shellcheck scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/smokes/*.sh
-          shfmt -i 2 -d scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/smokes/*.sh
+          shellcheck scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh scripts/smokes/*.sh
+          shfmt -i 2 -d scripts/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh scripts/smokes/*.sh
 
   # Drift guard: re-run gen-pins.sh against the committed pin on every PR
   # and fail on any diff. Catches "bumped pins.zig, forgot to regenerate

--- a/justfile
+++ b/justfile
@@ -32,9 +32,14 @@ install:
 # Test & coverage
 # ---------------------------------------------------------------------------
 
-# Run unit tests
+# Static regression guards — cheap, no network, no build.
 [group('test')]
-test:
+regressions-static:
+    @./scripts/regressions/tap-resolution-contract.sh
+
+# Run unit tests + cheap static regression guards.
+[group('test')]
+test: regressions-static
     zig build test --summary all
 
 # Run tests under kcov, print line-coverage percentage, and refresh

--- a/scripts/regressions/tap-resolution-contract.sh
+++ b/scripts/regressions/tap-resolution-contract.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Lock the tap-resolution contract to a single seam in src/core/tap.zig.
+#
+# Every fetch URL, every writeback URL, and the `MALT_GITHUB_TOKEN`
+# auth reach are co-located in one file so a future URL-shape change
+# (prefixless taps, non-GitHub hosts) or auth-policy change lands in
+# exactly one place. Drift here is the refresh-regression mode the
+# tap-resolution refactor was designed to structurally prevent.
+#
+# Three anti-patterns are flagged:
+#   1. `homebrew-{` — duplicated `homebrew-<repo>` synthesis (API/raw URLs)
+#   2. `https://github.com/{s}"` — decorative writeback that lied about
+#      the actually-resolvable repo URL
+#   3. `MALT_GITHUB_TOKEN` / `githubAuthHeader` outside the helper —
+#      the token reaches exactly the GitHub API HEAD call and never
+#      the raw Formula/Cask fetches. Widening (or narrowing) the reach
+#      without explicit intent is a contract change.
+#
+# Allowed sites:
+#   - src/core/tap.zig          the helper itself
+#   - src/cli/migrate/keg.zig   on-disk Cellar path
+#                                 (<prefix>/Library/Taps/<user>/homebrew-<repo>) —
+#                                 Homebrew's filesystem layout, not a URL
+#
+# Usage: scripts/regressions/tap-resolution-contract.sh
+# Requirements: POSIX grep — no network, no build.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+hits_prefix=$(grep -rn --include='*.zig' -F 'homebrew-{' src/ || true)
+hits_bare_slug=$(grep -rn --include='*.zig' -F 'https://github.com/{s}"' src/ || true)
+hits_token=$(grep -rn --include='*.zig' -F 'MALT_GITHUB_TOKEN' src/ || true)
+hits_auth_helper=$(grep -rn --include='*.zig' -F 'githubAuthHeader' src/ || true)
+
+all=$(printf '%s\n%s\n%s\n%s\n' \
+  "$hits_prefix" "$hits_bare_slug" "$hits_token" "$hits_auth_helper")
+
+filtered=$(printf '%s\n' "$all" |
+  grep -v '^src/core/tap\.zig:' |
+  grep -v '^src/cli/migrate/keg\.zig:' |
+  grep -v '^$' || true)
+
+if [[ -n "$filtered" ]]; then
+  printf "FAIL: tap-resolution contract violation outside src/core/tap.zig:\n\n" >&2
+  printf '%s\n\n' "$filtered" >&2
+  printf 'Route URLs through resolveTapBaseUrls; keep MALT_GITHUB_TOKEN reach\n' >&2
+  printf 'inside resolveHeadCommit via githubAuthHeader.\n' >&2
+  exit 1
+fi
+
+echo "OK: tap-resolution contract holds — all fetches and auth go through src/core/tap.zig"

--- a/scripts/regressions/tap-resolution-contract.sh
+++ b/scripts/regressions/tap-resolution-contract.sh
@@ -30,10 +30,13 @@ set -euo pipefail
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 cd "$ROOT"
 
-hits_prefix=$(grep -rn --include='*.zig' -F 'homebrew-{' src/ || true)
-hits_bare_slug=$(grep -rn --include='*.zig' -F 'https://github.com/{s}"' src/ || true)
-hits_token=$(grep -rn --include='*.zig' -F 'MALT_GITHUB_TOKEN' src/ || true)
-hits_auth_helper=$(grep -rn --include='*.zig' -F 'githubAuthHeader' src/ || true)
+# Search root is `src` (no trailing slash) so grep outputs `src/path:N:…`
+# uniformly across BSD and GNU; a trailing slash makes some grep
+# versions emit `src//path` and the allowlist regex below would miss.
+hits_prefix=$(grep -rn --include='*.zig' -F 'homebrew-{' src || true)
+hits_bare_slug=$(grep -rn --include='*.zig' -F 'https://github.com/{s}"' src || true)
+hits_token=$(grep -rn --include='*.zig' -F 'MALT_GITHUB_TOKEN' src || true)
+hits_auth_helper=$(grep -rn --include='*.zig' -F 'githubAuthHeader' src || true)
 
 all=$(printf '%s\n%s\n%s\n%s\n' \
   "$hits_prefix" "$hits_bare_slug" "$hits_token" "$hits_auth_helper")

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -91,11 +91,14 @@ pub fn installTapFormula(
     const tap_slug = std.fmt.bufPrint(&tap_slug_buf, "{s}/{s}", .{ parts.user, parts.repo }) catch
         return InstallError.FormulaNotFound;
 
+    const urls = try tap_mod.resolveTapBaseUrls(allocator, tap_slug);
+    defer urls.deinit(allocator);
+
     const commit_sha = blk: {
         if ((tap_mod.getCommitSha(allocator, db, tap_slug) catch null)) |cached| {
             break :blk cached;
         }
-        break :blk tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, parts.user, parts.repo) catch |e| {
+        break :blk tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url) catch |e| {
             output.err("Could not resolve {s}'s HEAD commit: {s}", .{ tap_slug, tap_mod.describeResolveError(e) });
             return InstallError.FormulaNotFound;
         };
@@ -107,9 +110,8 @@ pub fn installTapFormula(
 
     // Try Formula/ first, then Casks/
     var url_buf: [512]u8 = undefined;
-    const rb_url = std.fmt.bufPrint(&url_buf, "https://raw.githubusercontent.com/{s}/homebrew-{s}/{s}/Formula/{s}.rb", .{
-        parts.user,
-        parts.repo,
+    const rb_url = std.fmt.bufPrint(&url_buf, "{s}/{s}/Formula/{s}.rb", .{
+        urls.raw_base,
         commit_sha,
         parts.formula,
     }) catch return InstallError.FormulaNotFound;
@@ -127,9 +129,8 @@ pub fn installTapFormula(
     defer if (cask_resp) |*c| c.deinit();
 
     const resp: *const client_mod.Response = if (rb_resp.status == 200) &rb_resp else blk: {
-        const cask_url = std.fmt.bufPrint(&url_buf, "https://raw.githubusercontent.com/{s}/homebrew-{s}/{s}/Casks/{s}.rb", .{
-            parts.user,
-            parts.repo,
+        const cask_url = std.fmt.bufPrint(&url_buf, "{s}/{s}/Casks/{s}.rb", .{
+            urls.raw_base,
             commit_sha,
             parts.formula,
         }) catch return InstallError.FormulaNotFound;
@@ -157,23 +158,16 @@ pub fn installTapFormula(
     var final_url_buf: [512]u8 = undefined;
     const final_url = args.interpolateUrl(&final_url_buf, rb.url, rb.version, rb.arch_token);
 
-    var tap_buf: [128]u8 = undefined;
-    const tap_name = std.fmt.bufPrint(&tap_buf, "{s}/{s}", .{ parts.user, parts.repo }) catch
-        return InstallError.FormulaNotFound;
-    var tap_url_buf: [256]u8 = undefined;
-    const tap_url = std.fmt.bufPrint(&tap_url_buf, "https://github.com/{s}", .{tap_name}) catch
-        return InstallError.FormulaNotFound;
-
     const resolved = ResolvedRubyFormula{
         .name = parts.formula,
         .full_name = pkg_name,
-        .tap_label = tap_name,
+        .tap_label = tap_slug,
         .version = rb.version,
         .url = final_url,
         .sha256 = rb.sha256,
         .binary_name = parseCaskBinary(resp.body),
         .app_name = parseCaskApp(resp.body),
-        .tap_registration = .{ .url = tap_url, .commit_sha = commit_sha },
+        .tap_registration = .{ .url = urls.repo_url, .commit_sha = commit_sha },
     };
     try materializeRubyFormula(ctx, allocator, resolved, &http, db, linker, prefix, dry_run, force);
 }

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -174,19 +174,17 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
 
     switch (action) {
         .add => {
-            const slash = std.mem.findScalar(u8, name, '/').?;
-            const user = name[0..slash];
-            const repo = name[slash + 1 ..];
+            const urls = try tap_mod.resolveTapBaseUrls(allocator, name);
+            defer urls.deinit(allocator);
+
             // Resolve HEAD so the tap is pinned from day one. Failing
             // here beats silently registering an unpinned tap.
-            const sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, user, repo) catch |e| {
+            const sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url) catch |e| {
                 output.err("Could not resolve {s}'s HEAD commit: {s}", .{ name, tap_mod.describeResolveError(e) });
                 return error.Aborted;
             };
             defer allocator.free(sha);
-            var url_buf: [256]u8 = undefined;
-            const url = std.fmt.bufPrint(&url_buf, "https://github.com/{s}", .{name}) catch return;
-            tap_mod.add(&db, name, url, sha) catch {
+            tap_mod.add(&db, name, urls.repo_url, sha) catch {
                 output.err("Failed to add tap {s}", .{name});
                 return error.Aborted;
             };
@@ -207,10 +205,9 @@ fn refreshTap(ctx: *const AppCtx, allocator: std.mem.Allocator, db: *sqlite.Data
         output.err("Invalid tap '{s}'. Expected: user/repo with [A-Za-z0-9._-]", .{name});
         return error.Aborted;
     };
-    const slash = std.mem.findScalar(u8, name, '/').?;
-    const user = name[0..slash];
-    const repo = name[slash + 1 ..];
-    const sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, user, repo) catch |e| {
+    const urls = try tap_mod.resolveTapBaseUrls(allocator, name);
+    defer urls.deinit(allocator);
+    const sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url) catch |e| {
         output.err("Could not resolve {s}'s HEAD commit: {s}", .{ name, tap_mod.describeResolveError(e) });
         return error.Aborted;
     };

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -468,16 +468,17 @@ fn upgradeTapFormula(
         output.err("Cannot parse tap '{s}' for {s}", .{ tap_label, name });
         return error.Aborted;
     };
-    const user = tap_label[0..slash];
-    const repo = tap_label[slash + 1 ..];
-    if (user.len == 0 or repo.len == 0) {
+    if (slash == 0 or slash == tap_label.len - 1) {
         output.err("Cannot parse tap '{s}' for {s}", .{ tap_label, name });
         return error.Aborted;
     }
 
+    const urls = try tap_mod.resolveTapBaseUrls(allocator, tap_label);
+    defer urls.deinit(allocator);
+
     // The whole point of `mt upgrade` is "give me the latest", so we
     // ignore any cached pin and force-resolve HEAD.
-    const fresh_sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, user, repo) catch |e| {
+    const fresh_sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url) catch |e| {
         output.err("Could not resolve {s} HEAD: {s}", .{ tap_label, tap_mod.describeResolveError(e) });
         return error.Aborted;
     };
@@ -502,9 +503,7 @@ fn upgradeTapFormula(
 
     // Persist the new pin BEFORE installTapFormula reads it. Use add()
     // so a missing tap row (legacy install) is created instead of erroring.
-    var tap_url_buf: [256]u8 = undefined;
-    const tap_url = std.fmt.bufPrint(&tap_url_buf, "https://github.com/{s}", .{tap_label}) catch return error.Aborted;
-    tap_mod.add(db, tap_label, tap_url, fresh_sha) catch {
+    tap_mod.add(db, tap_label, urls.repo_url, fresh_sha) catch {
         output.err("Could not pin {s} to {s}", .{ tap_label, fresh_sha });
         return error.Aborted;
     };
@@ -546,17 +545,16 @@ fn upgradeTapCaskFallback(
         if (install_args_mod.isCoreTap(t.name)) continue;
 
         const slash = std.mem.indexOfScalar(u8, t.name, '/') orelse continue;
-        const user = t.name[0..slash];
-        const repo = t.name[slash + 1 ..];
-        if (user.len == 0 or repo.len == 0) continue;
+        if (slash == 0 or slash == t.name.len - 1) continue;
+
+        const urls = tap_mod.resolveTapBaseUrls(allocator, t.name) catch continue;
+        defer urls.deinit(allocator);
 
         // Resolve fresh HEAD per-tap. Failures are non-fatal — try the next.
-        const fresh_sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, user, repo) catch continue;
+        const fresh_sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url) catch continue;
         defer allocator.free(fresh_sha);
 
-        var tap_url_buf: [256]u8 = undefined;
-        const tap_url = std.fmt.bufPrint(&tap_url_buf, "https://github.com/{s}", .{t.name}) catch continue;
-        tap_mod.add(db, t.name, tap_url, fresh_sha) catch continue;
+        tap_mod.add(db, t.name, urls.repo_url, fresh_sha) catch continue;
 
         const full_name = std.fmt.allocPrint(allocator, "{s}/{s}", .{ t.name, token }) catch continue;
         defer allocator.free(full_name);

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -172,6 +172,105 @@ pub fn resolveFormula(allocator: std.mem.Allocator, user: []const u8, repo: []co
     return std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{ user, repo, formula });
 }
 
+/// URLs every tap fetch site needs, derived from one slug parse so the
+/// `homebrew-<repo>` synthesis lives in exactly one place. For raw
+/// fetches callers append `/<sha>/Formula/<name>.rb` (or `Casks/`) to
+/// `raw_base` — keeping the sha out of the helper means the API URL
+/// (queried before any sha exists) shares the same synthesis path.
+pub const TapBaseUrls = struct {
+    /// `https://api.github.com/repos/<user>/homebrew-<repo>/commits/HEAD`
+    api_head_url: []const u8,
+    /// `https://github.com/<user>/homebrew-<repo>` — the URL that actually
+    /// resolves; written to `taps.url`.
+    repo_url: []const u8,
+    /// `https://raw.githubusercontent.com/<user>/homebrew-<repo>` — caller
+    /// appends `/<sha>/Formula/<name>.rb` or `/<sha>/Casks/<name>.rb`.
+    raw_base: []const u8,
+
+    pub fn deinit(self: TapBaseUrls, allocator: std.mem.Allocator) void {
+        allocator.free(self.api_head_url);
+        allocator.free(self.repo_url);
+        allocator.free(self.raw_base);
+    }
+};
+
+/// Build every URL needed to talk to a tap repo from its `user/repo` slug.
+/// Single seam for `homebrew-<repo>` prefix synthesis — a future change
+/// to the URL shape (prefixless taps, non-GitHub hosts) lands in one
+/// file. `slug` must be a validated `user/repo` form (see
+/// `cli/tap.zig:validateTapName`); a missing `/` trips `unreachable`.
+pub fn resolveTapBaseUrls(
+    allocator: std.mem.Allocator,
+    slug: []const u8,
+) std.mem.Allocator.Error!TapBaseUrls {
+    const slash = std.mem.indexOfScalar(u8, slug, '/') orelse unreachable;
+    const user = slug[0..slash];
+    const repo = slug[slash + 1 ..];
+
+    const api_head_url = try std.fmt.allocPrint(
+        allocator,
+        "https://api.github.com/repos/{s}/homebrew-{s}/commits/HEAD",
+        .{ user, repo },
+    );
+    errdefer allocator.free(api_head_url);
+
+    const repo_url = try std.fmt.allocPrint(
+        allocator,
+        "https://github.com/{s}/homebrew-{s}",
+        .{ user, repo },
+    );
+    errdefer allocator.free(repo_url);
+
+    const raw_base = try std.fmt.allocPrint(
+        allocator,
+        "https://raw.githubusercontent.com/{s}/homebrew-{s}",
+        .{ user, repo },
+    );
+    errdefer allocator.free(raw_base);
+
+    return .{
+        .api_head_url = api_head_url,
+        .repo_url = repo_url,
+        .raw_base = raw_base,
+    };
+}
+
+test "resolveTapBaseUrls synthesises homebrew- prefix once per field" {
+    const urls = try resolveTapBaseUrls(std.testing.allocator, "aeroxy/tap");
+    defer urls.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(
+        "https://api.github.com/repos/aeroxy/homebrew-tap/commits/HEAD",
+        urls.api_head_url,
+    );
+    try std.testing.expectEqualStrings(
+        "https://github.com/aeroxy/homebrew-tap",
+        urls.repo_url,
+    );
+    try std.testing.expectEqualStrings(
+        "https://raw.githubusercontent.com/aeroxy/homebrew-tap",
+        urls.raw_base,
+    );
+}
+
+test "resolveTapBaseUrls preserves repo names containing hyphens and digits" {
+    const urls = try resolveTapBaseUrls(std.testing.allocator, "user-1/some-tap.v2");
+    defer urls.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(
+        "https://api.github.com/repos/user-1/homebrew-some-tap.v2/commits/HEAD",
+        urls.api_head_url,
+    );
+    try std.testing.expectEqualStrings(
+        "https://github.com/user-1/homebrew-some-tap.v2",
+        urls.repo_url,
+    );
+    try std.testing.expectEqualStrings(
+        "https://raw.githubusercontent.com/user-1/homebrew-some-tap.v2",
+        urls.raw_base,
+    );
+}
+
 /// A 40-char lowercase hex commit SHA — matches git's printable form.
 pub fn validateCommitSha(sha: []const u8) TapError!void {
     if (sha.len != 40) return TapError.InvalidSha;
@@ -206,20 +305,17 @@ pub fn parseCommitShaFromJson(body: []const u8) ?[]const u8 {
 /// the 40-char lowercase hex SHA or a classified `TapError` so callers
 /// can surface the actual cause (rate limit, 404, network, JSON). Caller
 /// owns the returned slice.
+///
+/// `api_head_url` must come from `resolveTapBaseUrls` — that single seam
+/// owns the `homebrew-<repo>` synthesis. A bare-args overload that
+/// re-synthesised the URL inline is exactly the refresh-regression mode
+/// we structurally prevent by routing every fetch site through the helper.
 pub fn resolveHeadCommit(
     io: std.Io,
     environ: std.process.Environ,
     allocator: std.mem.Allocator,
-    user: []const u8,
-    repo_bare: []const u8,
+    api_head_url: []const u8,
 ) TapError![]const u8 {
-    var url_buf: [512]u8 = undefined;
-    const url = std.fmt.bufPrint(
-        &url_buf,
-        "https://api.github.com/repos/{s}/homebrew-{s}/commits/HEAD",
-        .{ user, repo_bare },
-    ) catch return TapError.ResolveFailed;
-
     var http = client_mod.HttpClient.init(io, environ, allocator);
     defer http.deinit();
 
@@ -228,8 +324,8 @@ pub fn resolveHeadCommit(
     var auth_buf: [256]u8 = undefined;
     var resp = if (githubAuthHeader(environ, &auth_buf)) |header| blk: {
         const headers = [_]std.http.Header{header};
-        break :blk http.getWithHeaders(url, &headers, null) catch return TapError.NetworkError;
-    } else http.get(url) catch return TapError.NetworkError;
+        break :blk http.getWithHeaders(api_head_url, &headers, null) catch return TapError.NetworkError;
+    } else http.get(api_head_url) catch return TapError.NetworkError;
     defer resp.deinit();
 
     if (resp.status != 200) return classifyResolveStatus(resp.status);


### PR DESCRIPTION
## Description

The tap-resolution surface previously duplicated `homebrew-<repo>` URL synthesis across five fetch sites and wrote a decorative `https://github.com/<slug>` URL into `taps.url` that didn't resolve to the repo malt was actually fetching from. This refactor consolidates every fetch URL, writeback URL, and the `MALT_GITHUB_TOKEN` auth reach into one helper (`resolveTapBaseUrls`) in `src/core/tap.zig`. A future URL-shape change - prefixless taps, non-GitHub hosts - now lands in one file instead of five, and the stored `taps.url` row matches the actually-resolvable repo.

A new regression guard (`scripts/regressions/tap-resolution-contract.sh`, wired into both `just test` and CI's lint job) catches inline `homebrew-{` syntheses, bare-slug `https://github.com/{s}"` writebacks, and unauthorized `MALT_GITHUB_TOKEN` reach outside the helper — drift now fails CI rather than silently rotting.

No user-visible change.

## Related Issue

- None

## Notes for Reviewers

- None