### PR TITLE
fix(install/tap): install third-party tap formulas with version-in-URL

### DIFF
--- a/scripts/regressions/tap_formula_url_version.sh
+++ b/scripts/regressions/tap_formula_url_version.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Regression guard for tap formulas that omit `version "..."` and
+# embed the tag in the URL.
+#
+# Homebrew treats `version` as optional: when the URL path encodes
+# the tag (`/releases/download/<X>/...`, `/archive/refs/tags/<X>.<ext>`,
+# `/archive/<X>.<ext>`), the version is derived. malt's tap parser
+# previously rejected this shape as "unsupported Ruby DSL shape",
+# blocking a large slice of third-party single-platform formulas
+# (the `aeroxy/tap/ast-outline` shape).
+#
+# This script asserts the end-to-end install against a live tap whose
+# formula has no `version` directive:
+#   1. `malt install aeroxy/tap/ast-outline` exits 0.
+#   2. The install log surfaces the derived version (`Found ast-outline 2.0.0`),
+#      proving the parser took the URL-derivation branch rather than an
+#      explicit-version branch.
+#   3. The keg is materialised at `$PREFIX/Cellar/ast-outline/2.0.0/...`
+#      and `$PREFIX/bin/ast-outline` symlinks into it.
+#   4. The installed binary runs `--version` and reports `2.0.0`.
+#
+# Usage: scripts/regressions/tap_formula_url_version.sh
+# Requirements: built malt at $MALT_BIN or zig-out/bin/malt, network
+# access to api.github.com / raw.githubusercontent.com /
+# github.com/aeroxy/ast-outline release assets.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be <= 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_urlv"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+SLUG="aeroxy/tap/ast-outline"
+TOKEN="ast-outline"
+EXPECTED_VERSION="2.0.0"
+LOG="$PREFIX/install.log"
+
+printf '▸ malt install %s (logs → %s)\n' "$SLUG" "$LOG"
+"$BIN" install "$SLUG" >"$LOG" 2>&1 || {
+  tail -30 "$LOG" >&2
+  fail "${SLUG}: install exited non-zero"
+}
+
+# The diagnostic line proves the URL-derivation branch fired: a
+# pre-fix binary returned `Cannot parse tap formula (unsupported
+# Ruby DSL shape)` and never reached the "Found …" line.
+if ! grep -qE "Found ${TOKEN} ${EXPECTED_VERSION}" "$LOG"; then
+  tail -30 "$LOG" >&2
+  fail "${SLUG}: install log missing the derived 'Found ${TOKEN} ${EXPECTED_VERSION}' line"
+fi
+pass "${SLUG}: parser derived version ${EXPECTED_VERSION} from URL"
+
+CELLAR="$PREFIX/Cellar/${TOKEN}/${EXPECTED_VERSION}"
+if [[ ! -d "$CELLAR" ]]; then
+  fail "${SLUG}: expected keg directory ${CELLAR} is missing"
+fi
+pass "${SLUG}: keg materialised at \$PREFIX/Cellar/${TOKEN}/${EXPECTED_VERSION}"
+
+LINK="$PREFIX/bin/${TOKEN}"
+if [[ ! -L "$LINK" ]]; then
+  fail "${SLUG}: \$PREFIX/bin/${TOKEN} symlink is missing"
+fi
+TARGET=$(readlink -f "$LINK" 2>/dev/null || readlink "$LINK")
+if [[ ! -x "$TARGET" ]]; then
+  fail "${SLUG}: \$PREFIX/bin/${TOKEN} resolves to a non-executable target"
+fi
+pass "${SLUG}: \$PREFIX/bin/${TOKEN} → ${TARGET#"$PREFIX/"}"
+
+# Run the installed binary. Any exit-zero with the expected version
+# string proves the cellar layout and the binary's interpreter are
+# both sound (codesign-friendly, no dyld breakage).
+VERSION_OUT=$("$LINK" --version 2>&1) || {
+  printf '%s\n' "$VERSION_OUT" >&2
+  fail "${SLUG}: installed binary failed to run --version"
+}
+if ! grep -qE "${EXPECTED_VERSION}\$|${EXPECTED_VERSION} " <<<"$VERSION_OUT"; then
+  printf '%s\n' "$VERSION_OUT" >&2
+  fail "${SLUG}: --version output did not include ${EXPECTED_VERSION}"
+fi
+pass "${SLUG}: binary runs and reports ${EXPECTED_VERSION}"
+
+printf '\n✔ tap-formula URL-derived version regression passed\n'

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -64,6 +64,53 @@ const TapRegistration = struct {
     commit_sha: []const u8,
 };
 
+/// Archive container formats the tap/local install path extracts.
+/// `tar_gz` collapses `.tar.gz` and `.tgz` URLs into the same
+/// extractor — the variant names match the `archive_mod.extract*`
+/// functions called by `materializeRubyFormula`.
+const TapArchiveKind = enum {
+    tar_gz,
+    tar_xz,
+    zip,
+
+    /// Canonical suffix used when staging the downloaded archive on
+    /// disk. The `.tgz` alias is accepted on input via `fromUrl` but
+    /// the staged file always carries `.tar.gz` so a stray inspection
+    /// (or the `defer deleteFile`) finds a predictable name.
+    fn extension(self: TapArchiveKind) []const u8 {
+        return switch (self) {
+            .tar_gz => ".tar.gz",
+            .tar_xz => ".tar.xz",
+            .zip => ".zip",
+        };
+    }
+
+    /// Classify a tap URL by suffix. Returns null for any extension
+    /// the tap installer does not extract — the caller surfaces an
+    /// "unsupported archive format" error to the user.
+    fn fromUrl(url: []const u8) ?TapArchiveKind {
+        for (tap_archive_suffixes) |row| {
+            if (std.mem.endsWith(u8, url, row.suffix)) return row.kind;
+        }
+        return null;
+    }
+};
+
+/// Single source of truth for the `(suffix, TapArchiveKind)` pairs the
+/// tap/local install path accepts. Drives both `TapArchiveKind.fromUrl`
+/// (URL → enum) and `deriveVersionFromUrl` (which iterates the
+/// suffixes to strip a version token from a tag-in-URL formula).
+/// Adding a new format requires one edit here.
+const tap_archive_suffixes = [_]struct {
+    suffix: []const u8,
+    kind: TapArchiveKind,
+}{
+    .{ .suffix = ".tar.gz", .kind = .tar_gz },
+    .{ .suffix = ".tgz", .kind = .tar_gz },
+    .{ .suffix = ".tar.xz", .kind = .tar_xz },
+    .{ .suffix = ".zip", .kind = .zip },
+};
+
 /// Install a tap formula by fetching the Ruby formula from GitHub and
 /// extracting URL + SHA256 for the current platform.
 pub fn installTapFormula(
@@ -457,25 +504,13 @@ fn materializeRubyFormula(
 
     // Pick archive kind from the URL suffix; reject unknown formats
     // rather than feeding them to tar and printing a generic "failed".
-    const TapArchive = enum { tar_gz, tar_xz, zip };
-    const kind: ?TapArchive = blk: {
-        if (std.mem.endsWith(u8, resolved.url, ".tar.gz") or std.mem.endsWith(u8, resolved.url, ".tgz")) break :blk .tar_gz;
-        if (std.mem.endsWith(u8, resolved.url, ".tar.xz")) break :blk .tar_xz;
-        if (std.mem.endsWith(u8, resolved.url, ".zip")) break :blk .zip;
-        break :blk null;
-    };
-    const archive_kind = kind orelse {
+    const archive_kind = TapArchiveKind.fromUrl(resolved.url) orelse {
         output.err("Unsupported archive format for {s}: {s}", .{ resolved.name, resolved.url });
         output.err("Supported formats: .tar.gz, .tar.xz, .zip.", .{});
         return InstallError.DownloadFailed;
     };
-    const ext: []const u8 = switch (archive_kind) {
-        .tar_gz => ".tar.gz",
-        .tar_xz => ".tar.xz",
-        .zip => ".zip",
-    };
     var tmp_buf: [512]u8 = undefined;
-    const tmp_archive = formatTapDownloadName(&tmp_buf, prefix, ext, std.c.getpid()) catch
+    const tmp_archive = formatTapDownloadName(&tmp_buf, prefix, archive_kind.extension(), std.c.getpid()) catch
         return InstallError.DownloadFailed;
 
     const tmp_file = std.Io.Dir.createFileAbsolute(ctx.io, tmp_archive, .{}) catch return InstallError.DownloadFailed;
@@ -741,8 +776,6 @@ pub fn parseRubyFormula(rb_content: []const u8) ?RubyFormulaInfo {
 /// single `v`/`V`). The strict check stops malt from inventing a
 /// version like `latest` or `nightly` for a floating-tag URL.
 fn deriveVersionFromUrl(url: []const u8) ?[]const u8 {
-    const archive_exts = [_][]const u8{ ".tar.gz", ".tar.xz", ".tgz", ".zip" };
-
     if (std.mem.indexOf(u8, url, "/releases/download/")) |pos| {
         const after = url[pos + "/releases/download/".len ..];
         const slash = std.mem.indexOfScalar(u8, after, '/') orelse return null;
@@ -751,12 +784,7 @@ fn deriveVersionFromUrl(url: []const u8) ?[]const u8 {
 
     if (std.mem.indexOf(u8, url, "/archive/refs/tags/")) |pos| {
         const after = url[pos + "/archive/refs/tags/".len ..];
-        for (archive_exts) |ext| {
-            if (std.mem.endsWith(u8, after, ext)) {
-                return validateVersionToken(after[0 .. after.len - ext.len]);
-            }
-        }
-        return null;
+        return stripArchiveSuffixThenValidate(after);
     }
 
     if (std.mem.indexOf(u8, url, "/archive/")) |pos| {
@@ -765,14 +793,23 @@ fn deriveVersionFromUrl(url: []const u8) ?[]const u8 {
         // would already have matched above — anything still containing
         // a slash here is not a version token.
         if (std.mem.indexOfScalar(u8, after, '/') != null) return null;
-        for (archive_exts) |ext| {
-            if (std.mem.endsWith(u8, after, ext)) {
-                return validateVersionToken(after[0 .. after.len - ext.len]);
-            }
-        }
-        return null;
+        return stripArchiveSuffixThenValidate(after);
     }
 
+    return null;
+}
+
+/// Strip any accepted tap-archive suffix from `tail` and run the
+/// result through `validateVersionToken`. Returns null when no
+/// recognised suffix matches — keeps the suffix list in lockstep with
+/// `tap_archive_suffixes` so adding a format wires up version
+/// derivation automatically.
+fn stripArchiveSuffixThenValidate(tail: []const u8) ?[]const u8 {
+    for (tap_archive_suffixes) |row| {
+        if (std.mem.endsWith(u8, tail, row.suffix)) {
+            return validateVersionToken(tail[0 .. tail.len - row.suffix.len]);
+        }
+    }
     return null;
 }
 

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -714,15 +714,80 @@ pub fn parseRubyFormula(rb_content: []const u8) ?RubyFormulaInfo {
         }
     }
 
-    if (version != null and url != null and sha256 != null) {
+    if (url != null and sha256 != null) {
+        // Homebrew treats `version` as optional when the tag is encoded
+        // in the URL. Mirror that: derive it from the release-asset or
+        // archive-tag path so common tap shapes (top-level url+sha256,
+        // no `version` line) still install.
+        const final_version = version orelse deriveVersionFromUrl(url.?) orelse return null;
         return .{
-            .version = version.?,
+            .version = final_version,
             .url = url.?,
             .sha256 = sha256.?,
             .arch_token = arch_token,
         };
     }
     return null;
+}
+
+/// Pull a version token out of a Homebrew-style URL when the formula
+/// omits `version "..."`. Covers the three shapes Homebrew itself
+/// derives from:
+///   * `…/releases/download/<X>/…`              — release asset
+///   * `…/archive/refs/tags/<X>.<archive-ext>`  — git tag tarball
+///   * `…/archive/<X>.<archive-ext>`            — short-form tag tarball
+/// Returns null when no pattern matches or the captured token does not
+/// look like a version (must start with a digit, optionally after a
+/// single `v`/`V`). The strict check stops malt from inventing a
+/// version like `latest` or `nightly` for a floating-tag URL.
+fn deriveVersionFromUrl(url: []const u8) ?[]const u8 {
+    const archive_exts = [_][]const u8{ ".tar.gz", ".tar.xz", ".tgz", ".zip" };
+
+    if (std.mem.indexOf(u8, url, "/releases/download/")) |pos| {
+        const after = url[pos + "/releases/download/".len ..];
+        const slash = std.mem.indexOfScalar(u8, after, '/') orelse return null;
+        return validateVersionToken(after[0..slash]);
+    }
+
+    if (std.mem.indexOf(u8, url, "/archive/refs/tags/")) |pos| {
+        const after = url[pos + "/archive/refs/tags/".len ..];
+        for (archive_exts) |ext| {
+            if (std.mem.endsWith(u8, after, ext)) {
+                return validateVersionToken(after[0 .. after.len - ext.len]);
+            }
+        }
+        return null;
+    }
+
+    if (std.mem.indexOf(u8, url, "/archive/")) |pos| {
+        const after = url[pos + "/archive/".len ..];
+        // Nested paths belong to the `/archive/refs/tags/` shape, which
+        // would already have matched above — anything still containing
+        // a slash here is not a version token.
+        if (std.mem.indexOfScalar(u8, after, '/') != null) return null;
+        for (archive_exts) |ext| {
+            if (std.mem.endsWith(u8, after, ext)) {
+                return validateVersionToken(after[0 .. after.len - ext.len]);
+            }
+        }
+        return null;
+    }
+
+    return null;
+}
+
+/// Strip an optional leading `v`/`V` and confirm the next byte is a
+/// digit. Reject anything else so a tag like `latest`, `nightly`, or
+/// `release-2.0.0` never becomes a malt `Cellar/<name>/<version>`
+/// path. Returns the trimmed slice or null on rejection.
+fn validateVersionToken(s: []const u8) ?[]const u8 {
+    if (s.len == 0) return null;
+    if (s[0] == 'v' or s[0] == 'V') {
+        if (s.len < 2 or !std.ascii.isDigit(s[1])) return null;
+        return s[1..];
+    }
+    if (!std.ascii.isDigit(s[0])) return null;
+    return s;
 }
 
 /// True when the trimmed line body starts with a keyword argument the

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -508,6 +508,139 @@ test "parseRubyFormula ignores arch directive outside on_macos" {
     try testing.expectEqualStrings("", got.arch_token);
 }
 
+// `version` is optional in Homebrew formulas — when the tag is encoded
+// in the URL path, the parser must derive it so common tap shapes like
+// `aeroxy/tap/ast-outline` (top-level url + sha256, no version line,
+// release-asset URL) install instead of failing as "unsupported DSL".
+test "parseRubyFormula derives version from /releases/download/<X>/ when version directive is absent" {
+    const src =
+        \\class AstOutline < Formula
+        \\  desc "test"
+        \\  url "https://github.com/aeroxy/ast-outline/releases/download/2.0.0/ast-outline-macos-arm64.zip"
+        \\  sha256 "a76c4e384a0dd155a42b6dc7b2fe4f125de7c5ede04ddb8e7ee8fbab51fc0f34"
+        \\end
+    ;
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    try testing.expectEqualStrings("2.0.0", got.version);
+    try testing.expectEqualStrings(
+        "https://github.com/aeroxy/ast-outline/releases/download/2.0.0/ast-outline-macos-arm64.zip",
+        got.url,
+    );
+    try testing.expectEqualStrings(
+        "a76c4e384a0dd155a42b6dc7b2fe4f125de7c5ede04ddb8e7ee8fbab51fc0f34",
+        got.sha256,
+    );
+}
+
+// A leading `v` on the captured token is stripped — `v3.1.4` → `3.1.4`.
+// Every release-tag URL we sampled in the wild used this convention,
+// and `Cellar/<name>/v3.1.4` paths would be ugly and inconsistent with
+// the bottle path Homebrew installs to.
+test "parseRubyFormula derives version stripping a leading v from a release tag" {
+    const src =
+        \\class Tool < Formula
+        \\  url "https://github.com/example/tool/releases/download/v3.1.4/tool.tar.gz"
+        \\  sha256 "1111111111111111111111111111111111111111111111111111111111111111"
+        \\end
+    ;
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    try testing.expectEqualStrings("3.1.4", got.version);
+}
+
+// `archive/refs/tags/v<X>.tar.gz` is the dominant source-archive shape
+// for taps like FelixKratz/sketchybar — pinning it keeps the parser
+// useful for the broader "version-in-URL" population, not just for
+// release-asset binaries.
+test "parseRubyFormula derives version from archive/refs/tags/<X>.tar.gz" {
+    const src =
+        \\class Sketchybar < Formula
+        \\  url "https://github.com/FelixKratz/SketchyBar/archive/refs/tags/v2.23.0.tar.gz"
+        \\  sha256 "2222222222222222222222222222222222222222222222222222222222222222"
+        \\end
+    ;
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    try testing.expectEqualStrings("2.23.0", got.version);
+}
+
+// .zip variant of the same shape — extension matching is exhaustive
+// across the four archive formats we extract, so .zip must work too.
+test "parseRubyFormula derives version from archive/refs/tags/<X>.zip" {
+    const src =
+        \\class Tool < Formula
+        \\  url "https://github.com/example/tool/archive/refs/tags/1.0.0.zip"
+        \\  sha256 "3333333333333333333333333333333333333333333333333333333333333333"
+        \\end
+    ;
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    try testing.expectEqualStrings("1.0.0", got.version);
+}
+
+// Short-form `/archive/<X>.tar.gz` — GitHub serves the same tarball
+// for this and the long form, and a non-trivial slice of older
+// formulas still use the short URL.
+test "parseRubyFormula derives version from archive/<X>.tar.gz" {
+    const src =
+        \\class Tool < Formula
+        \\  url "https://github.com/example/tool/archive/v1.0.0.tar.gz"
+        \\  sha256 "4444444444444444444444444444444444444444444444444444444444444444"
+        \\end
+    ;
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    try testing.expectEqualStrings("1.0.0", got.version);
+}
+
+// An explicit `version "..."` always wins over what could be derived
+// from the URL — the formula author's intent is authoritative.
+test "parseRubyFormula prefers explicit version over a derivable URL token" {
+    const src =
+        \\class Tool < Formula
+        \\  version "9.9.9"
+        \\  url "https://github.com/example/tool/releases/download/2.0.0/tool.zip"
+        \\  sha256 "5555555555555555555555555555555555555555555555555555555555555555"
+        \\end
+    ;
+    const got = install.parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    try testing.expectEqualStrings("9.9.9", got.version);
+}
+
+// Floating-tag URLs (`latest`, `nightly`, …) are common but must not
+// silently become a malt keg directory named `latest`. The token must
+// start with a digit; anything else returns null so the user sees the
+// "unsupported DSL shape" error and adds an explicit `version`.
+test "parseRubyFormula rejects floating-tag URLs that are not version-shaped" {
+    const src =
+        \\class Tool < Formula
+        \\  url "https://github.com/example/tool/releases/download/latest/tool.zip"
+        \\  sha256 "6666666666666666666666666666666666666666666666666666666666666666"
+        \\end
+    ;
+    try testing.expect(install.parseRubyFormula(src) == null);
+}
+
+// URL with none of the three recognised path shapes — the parser does
+// not invent a version from the filename basename.
+test "parseRubyFormula returns null when URL matches no derivation pattern" {
+    const src =
+        \\class Tool < Formula
+        \\  url "https://example.com/foo.tar.gz"
+        \\  sha256 "7777777777777777777777777777777777777777777777777777777777777777"
+        \\end
+    ;
+    try testing.expect(install.parseRubyFormula(src) == null);
+}
+
+// A leading `v` must be followed by a digit — otherwise `vendor-build`,
+// `v0lume`'s typo, or a tag like `vN` would all parse as versions.
+test "parseRubyFormula rejects a v-prefix that is not followed by a digit" {
+    const src =
+        \\class Tool < Formula
+        \\  url "https://github.com/example/tool/releases/download/vendor-build/tool.zip"
+        \\  sha256 "8888888888888888888888888888888888888888888888888888888888888888"
+        \\end
+    ;
+    try testing.expect(install.parseRubyFormula(src) == null);
+}
+
 // extractQuoted underpins both legacy and cask DSL extraction; the
 // keyword-arg shape introduces a new pattern (`url "..."` after a
 // long sha256 directive) so pin a "won't accidentally cut on the


### PR DESCRIPTION
## Description

`mt install <user>/<tap>/<formula>` now works for third-party taps whose `.rb` ships a top-level `url` + `sha256` with no `version "..."` directive - the dominant shape Homebrew uses for prebuilt single-platform release assets. Before this PR the install died at `parseRubyFormula` with "unsupported Ruby DSL shape" even though the tap was reachable and the formula was structurally valid.

The parser now derives the version from the URL path when the formula omits the directive, covering the three Homebrew-standard shapes (`/releases/download/<X>/...`, `/archive/refs/tags/<X>.<ext>`, `/archive/<X>.<ext>`). Floating-tag URLs (`latest`, `nightly`, non-version-shaped strings) are still rejected so a missing version never produces a nonsense keg path.

## Related Issue

- None

## Notes for Reviewers

- None