### PR TITLE
docs(readme): keep bug-report callout focused on the reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Reuses every formula, bottle, cask, tap, and `Brewfile` in the existing ecosyste
 > [!IMPORTANT]
 > **malt is under active development.** The CLI surface is mostly settled and significant breaking changes are unlikely - but bugs are still likely.
 >
-> If you hit one, please [open an issue](https://github.com/indaco/malt/issues/new). User-reported bugs jump ahead of everything else I'm working on and ship in patch releases per [`RELEASING.md`](RELEASING.md).
+> If you hit one, please [open an issue](https://github.com/indaco/malt/issues/new). User-reported bugs jump the queue and ship in patch releases.
 
 ## Why malt exists
 


### PR DESCRIPTION
## Description

Rephrase the "under active development" callout in `README.md` so it reassures the bug-reporter without dropping them into a maintainer's release checklist.

## Related Issue

- None

## Notes for Reviewers

- None