### PR TITLE
fix(macho): relocate path literals embedded in cstring sections

### DIFF
--- a/src/macho/parser.zig
+++ b/src/macho/parser.zig
@@ -25,13 +25,26 @@ pub const LoadCommandPath = struct {
     path: []const u8,
 };
 
+/// A `__TEXT,__cstring` (or any S_CSTRING_LITERALS) section located in
+/// the binary. Holds the absolute file offset + byte size of the packed
+/// NUL-separated string blob so the patcher can rewrite path literals
+/// (e.g. ImageMagick's compiled-in `MAGICKCORE_CODER_PATH`) that the
+/// load-command walker never sees.
+pub const CstringRegion = struct {
+    file_offset: usize,
+    size: usize,
+};
+
 pub const MachO = struct {
     /// All load command paths found in the binary
     paths: []LoadCommandPath,
+    /// Every S_CSTRING_LITERALS section across all arch slices.
+    cstrings: []CstringRegion,
     allocator: std.mem.Allocator,
 
     pub fn deinit(self: *MachO) void {
         self.allocator.free(self.paths);
+        self.allocator.free(self.cstrings);
     }
 };
 
@@ -91,6 +104,8 @@ fn parseFat(allocator: std.mem.Allocator, data: []const u8) ParseError!MachO {
 
     var all_paths: std.ArrayList(LoadCommandPath) = .empty;
     errdefer all_paths.deinit(allocator);
+    var all_cstrings: std.ArrayList(CstringRegion) = .empty;
+    errdefer all_cstrings.deinit(allocator);
 
     var offset: usize = 8;
     var i: u32 = 0;
@@ -107,7 +122,7 @@ fn parseFat(allocator: std.mem.Allocator, data: []const u8) ParseError!MachO {
 
         // Skip legacy/unsupported slices; bubble structural corruption.
         // See the doc comment above for the full policy.
-        const slice_result = parseMachO64(
+        var slice_result = parseMachO64(
             allocator,
             data[slice_offset .. slice_offset + slice_size],
             slice_offset,
@@ -120,16 +135,18 @@ fn parseFat(allocator: std.mem.Allocator, data: []const u8) ParseError!MachO {
             ParseError.OutOfMemory,
             => return e,
         };
-        // Transfer the slice's LoadCommandPath values (struct-by-value) into
-        // the aggregated list, then free the slice's container. The `path`
-        // byte slices inside each LoadCommandPath still reference the outer
-        // `data` buffer which outlives this call.
-        defer allocator.free(slice_result.paths);
+        // Transfer the slice's results (struct-by-value) into the aggregated
+        // lists, then release the per-slice containers. The byte slices
+        // inside each LoadCommandPath still reference the outer `data`
+        // buffer which outlives this call.
+        defer slice_result.deinit();
         all_paths.appendSlice(allocator, slice_result.paths) catch return ParseError.OutOfMemory;
+        all_cstrings.appendSlice(allocator, slice_result.cstrings) catch return ParseError.OutOfMemory;
     }
 
     return .{
         .paths = all_paths.toOwnedSlice(allocator) catch return ParseError.OutOfMemory,
+        .cstrings = all_cstrings.toOwnedSlice(allocator) catch return ParseError.OutOfMemory,
         .allocator = allocator,
     };
 }
@@ -143,6 +160,8 @@ fn parseMachO64(allocator: std.mem.Allocator, data: []const u8, base_offset: usi
 
     var paths: std.ArrayList(LoadCommandPath) = .empty;
     errdefer paths.deinit(allocator);
+    var cstrings: std.ArrayList(CstringRegion) = .empty;
+    errdefer cstrings.deinit(allocator);
 
     // Sanity check: reject obviously corrupt headers (ncmds > 10,000 is unreasonable)
     if (header.ncmds > 10_000) return ParseError.InvalidLoadCommand;
@@ -231,6 +250,14 @@ fn parseMachO64(allocator: std.mem.Allocator, data: []const u8, base_offset: usi
                     .path = path,
                 }) catch return ParseError.OutOfMemory;
             },
+            .SEGMENT_64 => {
+                // Bottle dylibs (ImageMagick, …) bake their install prefix
+                // into compile-time `#define`d C strings that live in
+                // `__TEXT,__cstring`, separately from any LC_LOAD_DYLIB
+                // path. Collect every S_CSTRING_LITERALS section so the
+                // patcher can rewrite those literals too.
+                try collectCstringSections(allocator, data, cmd_offset, cmdsize, base_offset, &cstrings);
+            },
             else => {},
         }
 
@@ -239,6 +266,67 @@ fn parseMachO64(allocator: std.mem.Allocator, data: []const u8, base_offset: usi
 
     return .{
         .paths = paths.toOwnedSlice(allocator) catch return ParseError.OutOfMemory,
+        .cstrings = cstrings.toOwnedSlice(allocator) catch return ParseError.OutOfMemory,
         .allocator = allocator,
     };
+}
+
+/// Walk every `section_64` inside one LC_SEGMENT_64 and append the C-string
+/// regions to `out`. Mach-O permits multiple S_CSTRING_LITERALS sections per
+/// segment, so we don't short-circuit on the first match.
+///
+/// Bounds and overflow checks mirror the rest of `parseMachO64`: any field
+/// that would point past the slice's `data` buffer is treated as corruption
+/// and bubbled via `ParseError.InvalidLoadCommand`. A section whose
+/// declared file offset + size lands beyond the slice is dropped (legacy
+/// stripped binaries do this for zerofill-like layouts and are not corrupt
+/// per se), keeping the parse resilient.
+fn collectCstringSections(
+    allocator: std.mem.Allocator,
+    data: []const u8,
+    cmd_offset: usize,
+    cmdsize: u32,
+    base_offset: usize,
+    out: *std.ArrayList(CstringRegion),
+) ParseError!void {
+    const seg_size = @sizeOf(macho.segment_command_64);
+    const sect_size = @sizeOf(macho.section_64);
+    if (cmdsize < seg_size) return;
+
+    const seg = std.mem.bytesAsValue(
+        macho.segment_command_64,
+        data[cmd_offset..][0..seg_size],
+    );
+    const nsects = seg.nsects;
+
+    const sects_total = @as(usize, nsects) * sect_size;
+    const sects_end = @addWithOverflow(seg_size, sects_total);
+    if (sects_end[1] != 0 or sects_end[0] > cmdsize) return ParseError.InvalidLoadCommand;
+
+    var sect_idx: u32 = 0;
+    while (sect_idx < nsects) : (sect_idx += 1) {
+        const sect_off = cmd_offset + seg_size + @as(usize, sect_idx) * sect_size;
+        const sect = std.mem.bytesAsValue(
+            macho.section_64,
+            data[sect_off..][0..sect_size],
+        );
+
+        if (sect.type() != macho.S_CSTRING_LITERALS) continue;
+
+        const sect_file_off: usize = sect.offset;
+        const sect_size_bytes: usize = @intCast(sect.size);
+        if (sect_size_bytes == 0) continue;
+
+        // Drop sections that land outside the current slice — legacy /
+        // pre-stripped binaries occasionally claim offsets they don't
+        // actually carry, and a malformed section_64 must not let the
+        // patcher walk off the buffer.
+        const end = @addWithOverflow(sect_file_off, sect_size_bytes);
+        if (end[1] != 0 or end[0] > data.len) continue;
+
+        out.append(allocator, .{
+            .file_offset = base_offset + sect_file_off,
+            .size = sect_size_bytes,
+        }) catch return ParseError.OutOfMemory;
+    }
 }

--- a/src/macho/patcher.zig
+++ b/src/macho/patcher.zig
@@ -145,6 +145,12 @@ pub fn patchPathsCollecting(
         patched += 1;
     }
 
+    for (macho.cstrings) |region| {
+        const counts = patchCstringRegion(data, region, replacements);
+        patched += counts.patched;
+        skipped += counts.skipped;
+    }
+
     if (patched > 0) {
         file.writePositionalAll(io, data, 0) catch return PatchError.IoError;
     }
@@ -159,6 +165,75 @@ pub fn patchPathsCollecting(
 fn pickReplacement(path: []const u8, replacements: []const Replacement) ?Replacement {
     for (replacements) |r| if (hasPrefix(path, r.old)) return r;
     return null;
+}
+
+const CstringPatchCounts = struct { patched: u32, skipped: u32 };
+
+/// Rewrite NUL-terminated strings inside one `__cstring` region whose
+/// content begins with any configured old prefix. In-place only — the
+/// section's file offset cannot grow without rewriting every fixup in
+/// the binary, which `install_name_tool` does not do for cstring data.
+///
+/// Each slot's original length (from its NUL terminator) becomes the
+/// hard budget. When the replacement fits, the slot is overwritten and
+/// the tail up to the original NUL is zero-padded so no fragment of the
+/// old path remains. When it doesn't fit, the string is left intact and
+/// counted as skipped — fundamental constraint, not a recoverable
+/// error.
+///
+/// Pointer safety: clang+ld64 with the default `-fmerge-constants`
+/// behaviour deduplicate identical strings but do not tail-merge
+/// substrings, so every in-binary pointer references the head of its
+/// string. Zero-padding the tail after the new NUL cannot break any
+/// such pointer.
+fn patchCstringRegion(
+    data: []u8,
+    region: parser.CstringRegion,
+    replacements: []const Replacement,
+) CstringPatchCounts {
+    var counts: CstringPatchCounts = .{ .patched = 0, .skipped = 0 };
+
+    const end = std.math.add(usize, region.file_offset, region.size) catch return counts;
+    if (end > data.len) return counts;
+    const blob = data[region.file_offset..end];
+
+    var i: usize = 0;
+    while (i < blob.len) {
+        const nul = std.mem.indexOfScalarPos(u8, blob, i, 0) orelse break;
+        const old_len = nul - i;
+        if (old_len == 0) {
+            i = nul + 1;
+            continue;
+        }
+
+        const current = blob[i..nul];
+        if (pickReplacement(current, replacements)) |r| {
+            const new_len = r.new.len + (old_len - r.old.len);
+            if (new_len <= old_len) {
+                // Stage in a stack buffer because the suffix aliases bytes
+                // we are about to overwrite.
+                var staging: [1024]u8 = undefined;
+                if (new_len <= staging.len) {
+                    @memcpy(staging[0..r.new.len], r.new);
+                    @memcpy(
+                        staging[r.new.len..new_len],
+                        current[r.old.len..],
+                    );
+                    @memcpy(blob[i..][0..new_len], staging[0..new_len]);
+                    @memset(blob[i + new_len .. nul], 0);
+                    counts.patched += 1;
+                } else {
+                    counts.skipped += 1;
+                }
+            } else {
+                counts.skipped += 1;
+            }
+        }
+
+        i = nul + 1;
+    }
+
+    return counts;
 }
 
 /// Dupe both old/new strings into the caller's allocator and append.

--- a/tests/macho_test.zig
+++ b/tests/macho_test.zig
@@ -336,3 +336,133 @@ test "patchPaths preserves trailing NUL at max_path_len-1 boundary" {
     try testing.expectEqualStrings("/bin/aaaaaaaaaa", slot[0 .. max_path_len - 1]);
     try testing.expectEqual(@as(u8, 0), slot[max_path_len - 1]);
 }
+
+/// Build a Mach-O 64 with one LC_SEGMENT_64 (__TEXT) carrying `nsects`
+/// sections. The caller fills each `section_64` via `sections` before the
+/// returned buffer is parsed. C-string data lives at `[cstring_offset, end)`.
+fn buildSegmentFixture(
+    allocator: std.mem.Allocator,
+    sections: []const macho.section_64,
+    cstring_blob: []const u8,
+) ![]u8 {
+    const header_size = @sizeOf(macho.mach_header_64);
+    const seg_size = @sizeOf(macho.segment_command_64);
+    const sect_size = @sizeOf(macho.section_64);
+    const cmdsize: u32 = @intCast(seg_size + sections.len * sect_size);
+    const cstring_offset = header_size + cmdsize;
+    const total = cstring_offset + cstring_blob.len;
+
+    const buf = try allocator.alloc(u8, total);
+    @memset(buf, 0);
+
+    const hdr = std.mem.bytesAsValue(macho.mach_header_64, buf[0..header_size]);
+    hdr.* = .{
+        .magic = macho.MH_MAGIC_64,
+        .ncmds = 1,
+        .sizeofcmds = cmdsize,
+    };
+
+    const seg = std.mem.bytesAsValue(macho.segment_command_64, buf[header_size..][0..seg_size]);
+    seg.* = .{
+        .cmd = .SEGMENT_64,
+        .cmdsize = cmdsize,
+        .segname = [_]u8{0} ** 16,
+        .nsects = @intCast(sections.len),
+    };
+    @memcpy(seg.segname[0.."__TEXT".len], "__TEXT");
+
+    for (sections, 0..) |s, idx| {
+        const sect_off = header_size + seg_size + idx * sect_size;
+        const sect = std.mem.bytesAsValue(macho.section_64, buf[sect_off..][0..sect_size]);
+        sect.* = s;
+    }
+
+    @memcpy(buf[cstring_offset..][0..cstring_blob.len], cstring_blob);
+
+    return buf;
+}
+
+test "parse a Mach-O 64 with __TEXT,__cstring captures the section region" {
+    const blob = "/opt/homebrew/x\x00next\x00";
+    const cstring_offset = @sizeOf(macho.mach_header_64) + @sizeOf(macho.segment_command_64) + @sizeOf(macho.section_64);
+
+    var sect: macho.section_64 = .{
+        .sectname = [_]u8{0} ** 16,
+        .segname = [_]u8{0} ** 16,
+        .offset = @intCast(cstring_offset),
+        .size = blob.len,
+        .flags = macho.S_CSTRING_LITERALS,
+    };
+    @memcpy(sect.sectname[0.."__cstring".len], "__cstring");
+    @memcpy(sect.segname[0.."__TEXT".len], "__TEXT");
+
+    const buf = try buildSegmentFixture(testing.allocator, &.{sect}, blob);
+    defer testing.allocator.free(buf);
+
+    var m = try parser.parse(testing.allocator, buf);
+    defer m.deinit();
+
+    try testing.expectEqual(@as(usize, 1), m.cstrings.len);
+    try testing.expectEqual(@as(usize, cstring_offset), m.cstrings[0].file_offset);
+    try testing.expectEqual(@as(usize, blob.len), m.cstrings[0].size);
+}
+
+test "parse a Mach-O 64 ignores non-cstring sections in the same segment" {
+    const blob = "anything\x00";
+    const cstring_offset = @sizeOf(macho.mach_header_64) + @sizeOf(macho.segment_command_64) + 2 * @sizeOf(macho.section_64);
+
+    var text_sect: macho.section_64 = .{
+        .sectname = [_]u8{0} ** 16,
+        .segname = [_]u8{0} ** 16,
+        .offset = @intCast(cstring_offset),
+        .size = blob.len,
+        .flags = macho.S_REGULAR | macho.S_ATTR_PURE_INSTRUCTIONS,
+    };
+    @memcpy(text_sect.sectname[0.."__text".len], "__text");
+    @memcpy(text_sect.segname[0.."__TEXT".len], "__TEXT");
+
+    var cstring_sect: macho.section_64 = .{
+        .sectname = [_]u8{0} ** 16,
+        .segname = [_]u8{0} ** 16,
+        .offset = @intCast(cstring_offset),
+        .size = blob.len,
+        .flags = macho.S_CSTRING_LITERALS,
+    };
+    @memcpy(cstring_sect.sectname[0.."__cstring".len], "__cstring");
+    @memcpy(cstring_sect.segname[0.."__TEXT".len], "__TEXT");
+
+    const buf = try buildSegmentFixture(testing.allocator, &.{ text_sect, cstring_sect }, blob);
+    defer testing.allocator.free(buf);
+
+    var m = try parser.parse(testing.allocator, buf);
+    defer m.deinit();
+
+    // Only the cstring section should land in the result.
+    try testing.expectEqual(@as(usize, 1), m.cstrings.len);
+    try testing.expectEqual(@as(usize, cstring_offset), m.cstrings[0].file_offset);
+}
+
+test "parse a Mach-O 64 drops cstring sections pointing outside the slice" {
+    // Section claims it lives at a file offset past the buffer end.
+    const blob = "/opt/homebrew/x\x00";
+    const cstring_offset = @sizeOf(macho.mach_header_64) + @sizeOf(macho.segment_command_64) + @sizeOf(macho.section_64);
+
+    var sect: macho.section_64 = .{
+        .sectname = [_]u8{0} ** 16,
+        .segname = [_]u8{0} ** 16,
+        .offset = 0xFFFFFFFF, // far past EOF
+        .size = blob.len,
+        .flags = macho.S_CSTRING_LITERALS,
+    };
+    @memcpy(sect.sectname[0.."__cstring".len], "__cstring");
+    @memcpy(sect.segname[0.."__TEXT".len], "__TEXT");
+    _ = cstring_offset;
+
+    const buf = try buildSegmentFixture(testing.allocator, &.{sect}, blob);
+    defer testing.allocator.free(buf);
+
+    var m = try parser.parse(testing.allocator, buf);
+    defer m.deinit();
+
+    try testing.expectEqual(@as(usize, 0), m.cstrings.len);
+}

--- a/tests/patcher_test.zig
+++ b/tests/patcher_test.zig
@@ -361,3 +361,198 @@ test "flushOverflow on an empty list does nothing and returns ok" {
     // (no-overflow bottle); the driver must not spawn anything.
     try patcher.flushOverflow(threaded.io(), testing.allocator, "/tmp/whatever", &.{});
 }
+
+/// Build a Mach-O 64 binary carrying one LC_SEGMENT_64 (__TEXT) with a
+/// single __cstring section holding `blob`. The section's file offset is
+/// placed immediately after the load commands so the on-disk layout is
+/// trivially predictable for byte-level assertions.
+///
+/// Returns the buffer and the absolute file offset of `blob[0]`.
+const CstringFixture = struct {
+    bytes: []u8,
+    cstring_offset: usize,
+};
+
+fn buildCstringFixture(
+    allocator: std.mem.Allocator,
+    blob: []const u8,
+) !CstringFixture {
+    const header_size = @sizeOf(macho.mach_header_64);
+    const seg_size = @sizeOf(macho.segment_command_64);
+    const sect_size = @sizeOf(macho.section_64);
+    const cmdsize: u32 = @intCast(seg_size + sect_size);
+    const cstring_offset = header_size + cmdsize;
+    const total = cstring_offset + blob.len;
+
+    const buf = try allocator.alloc(u8, total);
+    @memset(buf, 0);
+
+    const hdr = std.mem.bytesAsValue(macho.mach_header_64, buf[0..header_size]);
+    hdr.* = .{
+        .magic = macho.MH_MAGIC_64,
+        .ncmds = 1,
+        .sizeofcmds = cmdsize,
+    };
+
+    const seg = std.mem.bytesAsValue(macho.segment_command_64, buf[header_size..][0..seg_size]);
+    seg.* = .{
+        .cmd = .SEGMENT_64,
+        .cmdsize = cmdsize,
+        .segname = [_]u8{0} ** 16,
+        .nsects = 1,
+    };
+    @memcpy(seg.segname[0.."__TEXT".len], "__TEXT");
+
+    const sect = std.mem.bytesAsValue(macho.section_64, buf[header_size + seg_size ..][0..sect_size]);
+    sect.* = .{
+        .sectname = [_]u8{0} ** 16,
+        .segname = [_]u8{0} ** 16,
+        .offset = @intCast(cstring_offset),
+        .size = blob.len,
+        .flags = macho.S_CSTRING_LITERALS,
+    };
+    @memcpy(sect.sectname[0.."__cstring".len], "__cstring");
+    @memcpy(sect.segname[0.."__TEXT".len], "__TEXT");
+
+    @memcpy(buf[cstring_offset..][0..blob.len], blob);
+
+    return .{ .bytes = buf, .cstring_offset = cstring_offset };
+}
+
+test "patchPathsCollecting rewrites __cstring strings that match an old prefix" {
+    var threaded: std.Io.Threaded = undefined;
+    const io = testIo(&threaded);
+    defer threaded.deinit();
+
+    // Two prefix-matching strings and one untouched neighbour, all NUL-
+    // terminated and packed back-to-back as ld64 emits them.
+    const a = "/opt/homebrew/foo\x00";
+    const b = "/opt/homebrew/Cellar/imagemagick\x00";
+    const c = "unchanged\x00";
+    const blob = a ++ b ++ c;
+
+    const fix = try buildCstringFixture(testing.allocator, blob);
+    defer testing.allocator.free(fix.bytes);
+
+    const dir = try tmpSubdir(io, "cstr_basic");
+    defer {
+        std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(io, dir, "bin", fix.bytes);
+    defer testing.allocator.free(path);
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "/opt/homebrew", .new = "/M" },
+    };
+    var outcome = try patcher.patchPathsCollecting(io, testing.allocator, path, &replacements);
+    defer outcome.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u32, 2), outcome.patched_count);
+    try testing.expectEqual(@as(usize, 0), outcome.overflow.len);
+
+    // Re-read and inspect the cstring region byte-for-byte.
+    const file = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer file.close(io);
+    const got = try testing.allocator.alloc(u8, fix.bytes.len);
+    defer testing.allocator.free(got);
+    _ = try file.readPositionalAll(io, got, 0);
+
+    const region = got[fix.cstring_offset..][0..blob.len];
+
+    // First string: "/opt/homebrew/foo" → "/M/foo", NUL-padded to original 17B slot.
+    const slot_a_len = a.len; // includes trailing NUL
+    try testing.expectEqualStrings("/M/foo", std.mem.sliceTo(region[0..slot_a_len], 0));
+    for (region[("/M/foo".len + 1)..slot_a_len]) |byte| try testing.expectEqual(@as(u8, 0), byte);
+
+    // Second string: "/opt/homebrew/Cellar/imagemagick" → "/M/Cellar/imagemagick".
+    const slot_b_off = slot_a_len;
+    const slot_b_len = b.len;
+    try testing.expectEqualStrings(
+        "/M/Cellar/imagemagick",
+        std.mem.sliceTo(region[slot_b_off..][0..slot_b_len], 0),
+    );
+
+    // Third string left intact.
+    const slot_c_off = slot_a_len + slot_b_len;
+    try testing.expectEqualStrings("unchanged", std.mem.sliceTo(region[slot_c_off..][0..c.len], 0));
+}
+
+test "patchPathsCollecting leaves __cstring strings whose replacement does not fit" {
+    var threaded: std.Io.Threaded = undefined;
+    const io = testIo(&threaded);
+    defer threaded.deinit();
+
+    // Replacement "/opt/homebrew/much-longer-prefix" > "/x" (old) for any cstring
+    // beginning with "/x". Cstring slots can't grow in place — the patcher
+    // must leave the byte untouched and not error.
+    const blob = "/x/short\x00";
+    const fix = try buildCstringFixture(testing.allocator, blob);
+    defer testing.allocator.free(fix.bytes);
+
+    const dir = try tmpSubdir(io, "cstr_overflow");
+    defer {
+        std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(io, dir, "bin", fix.bytes);
+    defer testing.allocator.free(path);
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "/x", .new = "/much-longer-prefix" },
+    };
+    var outcome = try patcher.patchPathsCollecting(io, testing.allocator, path, &replacements);
+    defer outcome.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u32, 0), outcome.patched_count);
+    try testing.expectEqual(@as(usize, 0), outcome.overflow.len);
+
+    const file = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer file.close(io);
+    const got = try testing.allocator.alloc(u8, fix.bytes.len);
+    defer testing.allocator.free(got);
+    _ = try file.readPositionalAll(io, got, 0);
+    try testing.expectEqualStrings(
+        "/x/short",
+        std.mem.sliceTo(got[fix.cstring_offset..][0..blob.len], 0),
+    );
+}
+
+test "patchPathsCollecting picks the first matching prefix for cstrings" {
+    var threaded: std.Io.Threaded = undefined;
+    const io = testIo(&threaded);
+    defer threaded.deinit();
+
+    // Two replacement candidates with overlapping prefixes — first match wins
+    // (same semantics as the load-command path; documented at pickReplacement).
+    const blob = "/opt/homebrew/lib/x\x00";
+    const fix = try buildCstringFixture(testing.allocator, blob);
+    defer testing.allocator.free(fix.bytes);
+
+    const dir = try tmpSubdir(io, "cstr_firstmatch");
+    defer {
+        std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(io, dir, "bin", fix.bytes);
+    defer testing.allocator.free(path);
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "/opt/homebrew", .new = "/A" },
+        .{ .old = "/opt", .new = "/B" },
+    };
+    var outcome = try patcher.patchPathsCollecting(io, testing.allocator, path, &replacements);
+    defer outcome.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u32, 1), outcome.patched_count);
+
+    const file = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer file.close(io);
+    const got = try testing.allocator.alloc(u8, fix.bytes.len);
+    defer testing.allocator.free(got);
+    _ = try file.readPositionalAll(io, got, 0);
+    try testing.expectEqualStrings(
+        "/A/lib/x",
+        std.mem.sliceTo(got[fix.cstring_offset..][0..blob.len], 0),
+    );
+}


### PR DESCRIPTION
## Description

Mach-O bottles can bake their install prefix into compile-time C-string literals — runtime config-lookup paths, doc URLs, plugin module roots — which live in `__TEXT,__cstring` rather than in any load command. The patcher walked load commands only, so those literals survived relocation: a relocated binary still tried to read its configuration and load its plugins from the build-time prefix at runtime. On a host that also carried Homebrew, the lookup quietly resolved against
`/opt/homebrew` and the breakage stayed invisible; on every other host it failed outright.

The Mach-O parser now surfaces every `S_CSTRING_LITERALS` section
across all arch slices. The patcher rewrites each NUL-terminated entry whose head matches a configured old prefix and zero-pads the tail of the original slot — no leaked fragment of the build-time path remains.
Cstrings cannot grow in place, so over-budget replacements are silently skipped: the same hard limit that already applies to the
in-place fast path, except `install_name_tool` is not a fallback here (the slow path does not touch data sections).

## Related Issue

- None

## Notes for Reviewers

- None