### PR TITLE
fix(cask): suppress subprocess noise on success, surface it on failure

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -161,6 +161,7 @@ pub fn build(b: *std.Build) void {
         "tests/sandbox_macos_test.zig",
         "tests/services_validate_test.zig",
         "tests/spawn_invariant_test.zig",
+        "tests/child_test.zig",
         "tests/net_client_test.zig",
         "tests/term_sanitize_test.zig",
         "tests/perms_test.zig",

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -439,12 +439,12 @@ pub const CaskInstaller = struct {
             "-mountpoint", mount_point,
             dmg_path,
         };
-        child_mod.runOrFail(self.io, &mount_argv) catch return error.InstallFailed;
+        child_mod.runOrFail(self.io, self.allocator, &mount_argv) catch return error.InstallFailed;
 
         // Unmount on any exit; kernel reaps stuck mounts on reboot if both fail.
         defer {
             const detach_argv = [_][]const u8{ "hdiutil", "detach", mount_point, "-quiet" };
-            child_mod.runOrFail(self.io, &detach_argv) catch {};
+            child_mod.runOrFail(self.io, self.allocator, &detach_argv) catch {};
             std.Io.Dir.deleteDirAbsolute(self.io, mount_point) catch {};
         }
 
@@ -468,7 +468,7 @@ pub const CaskInstaller = struct {
 
         // Copy .app bundle using ditto (preserves resource forks, xattrs)
         const ditto_argv = [_][]const u8{ "ditto", src_app, dst_app };
-        child_mod.runOrFail(self.io, &ditto_argv) catch return error.InstallFailed;
+        child_mod.runOrFail(self.io, self.allocator, &ditto_argv) catch return error.InstallFailed;
 
         return dst_app;
     }
@@ -487,7 +487,7 @@ pub const CaskInstaller = struct {
 
         // Extract with ditto -xk (handles macOS-specific ZIP features)
         const ditto_argv = [_][]const u8{ "ditto", "-xk", zip_path, extract_dir };
-        child_mod.runOrFail(self.io, &ditto_argv) catch return error.InstallFailed;
+        child_mod.runOrFail(self.io, self.allocator, &ditto_argv) catch return error.InstallFailed;
 
         // Find the .app. app_name_buf owns the fallback past iterator teardown.
         var app_name_buf: [256]u8 = undefined;
@@ -507,7 +507,7 @@ pub const CaskInstaller = struct {
 
         // Move .app to /Applications
         const mv_argv = [_][]const u8{ "ditto", src_app, dst_app };
-        child_mod.runOrFail(self.io, &mv_argv) catch return error.InstallFailed;
+        child_mod.runOrFail(self.io, self.allocator, &mv_argv) catch return error.InstallFailed;
 
         return dst_app;
     }
@@ -560,7 +560,7 @@ pub const CaskInstaller = struct {
         // existing app may not be present.
         std.Io.Dir.cwd().deleteTree(self.io, dst_app) catch {};
         const mv_argv = [_][]const u8{ "ditto", src_app, dst_app };
-        child_mod.runOrFail(self.io, &mv_argv) catch return error.InstallFailed;
+        child_mod.runOrFail(self.io, self.allocator, &mv_argv) catch return error.InstallFailed;
         return dst_app;
     }
 
@@ -627,7 +627,7 @@ pub const CaskInstaller = struct {
     fn installPkg(self: *CaskInstaller, pkg_path: []const u8) ![]const u8 {
         // PKG installs require sudo — the caller must confirm
         const argv = [_][]const u8{ "sudo", "installer", "-pkg", pkg_path, "-target", "/" };
-        child_mod.runOrFail(self.io, &argv) catch return error.InstallFailed;
+        child_mod.runOrFail(self.io, self.allocator, &argv) catch return error.InstallFailed;
         // PKG installs don't have a single app path — record the pkg location
         return std.fmt.allocPrint(self.allocator, "{s}", .{pkg_path}) catch return error.OutOfMemory;
     }

--- a/src/core/child.zig
+++ b/src/core/child.zig
@@ -1,7 +1,8 @@
 //! malt — shared spawn+wait helper for one-shot external commands.
-//! Consolidates the Child.init/spawn/wait/switch shape that every
-//! cask-install step used to duplicate, so the caller's allocator is
-//! the single source of memory for every spawn.
+//! Captures stdout+stderr so successful runs stay silent and failures
+//! surface the child's own diagnostics. Replaces the
+//! inherited-stdio shape that let hdiutil/ditto verbose output bleed
+//! onto the user's progress bar.
 
 const std = @import("std");
 
@@ -11,40 +12,123 @@ pub const ChildError = error{
     /// Child did not exit cleanly with code 0 — covers non-zero exits,
     /// signal kills, stops, and the "unknown" termination path.
     NonZeroExit,
+    OutOfMemory,
+    IoError,
 };
 
-/// Spawn `argv`, wait for it, and collapse the outcome into a narrow
-/// error set. `io` carries the parent `Environ` so PATH lookups for
-/// programs like `hdiutil` resolve.
+/// Per-stream cap on captured bytes. Sized to fit a typical
+/// `hdiutil attach` verbose dump (a few KB) plus headroom; the pure
+/// failure-path information density does not justify holding more.
+const max_capture_bytes: usize = 256 * 1024;
+
+/// Captured outcome of a child process. `stdout` / `stderr` are owned
+/// by the caller via `deinit`.
+pub const RunReport = struct {
+    /// Exit code on `.exited`; `255` sentinel for signal/stopped/unknown.
+    code: u8,
+    stdout: []u8,
+    stderr: []u8,
+
+    pub fn deinit(self: RunReport, allocator: std.mem.Allocator) void {
+        allocator.free(self.stdout);
+        allocator.free(self.stderr);
+    }
+};
+
+/// Spawn `argv` with stdout + stderr piped, wait, and return the
+/// captured output alongside the exit code. Caller frees the buffers
+/// via `RunReport.deinit`. Reads stdout then stderr; both pipes are
+/// drained before `wait` so the child can't block on a full pipe.
+pub fn run(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+) ChildError!RunReport {
+    var child = std.process.spawn(io, .{
+        .argv = argv,
+        .stdout = .pipe,
+        .stderr = .pipe,
+    }) catch return error.SpawnFailed;
+
+    const stdout_bytes = drainPipe(io, allocator, child.stdout) catch |e| {
+        // Best-effort cleanup — kill the child so wait doesn't hang on
+        // a half-drained pipe, then surface the read failure.
+        child.kill(io);
+        return e;
+    };
+    errdefer allocator.free(stdout_bytes);
+
+    const stderr_bytes = drainPipe(io, allocator, child.stderr) catch |e| {
+        child.kill(io);
+        return e;
+    };
+    errdefer allocator.free(stderr_bytes);
+
+    const term = child.wait(io) catch return error.WaitFailed;
+    const code: u8 = switch (term) {
+        .exited => |c| c,
+        .signal, .stopped, .unknown => 255,
+    };
+
+    return .{ .code = code, .stdout = stdout_bytes, .stderr = stderr_bytes };
+}
+
+/// Spawn and wait. Silent on success; on non-zero exit, replays the
+/// child's captured stderr (then stdout) to the parent's stderr so the
+/// user sees the underlying tool's diagnostics, then returns
+/// `error.NonZeroExit`.
 pub fn runOrFail(
     io: std.Io,
+    allocator: std.mem.Allocator,
     argv: []const []const u8,
 ) ChildError!void {
-    var child = std.process.spawn(io, .{ .argv = argv }) catch return error.SpawnFailed;
-    const term = child.wait(io) catch return error.WaitFailed;
-    switch (term) {
-        .exited => |code| if (code != 0) return error.NonZeroExit,
-        .signal, .stopped, .unknown => return error.NonZeroExit,
-    }
+    const report = try run(io, allocator, argv);
+    defer report.deinit(allocator);
+    if (report.code == 0) return;
+
+    const stderr_file = std.Io.File.stderr();
+    if (report.stderr.len > 0) stderr_file.writeStreamingAll(io, report.stderr) catch {};
+    if (report.stdout.len > 0) stderr_file.writeStreamingAll(io, report.stdout) catch {};
+    return error.NonZeroExit;
+}
+
+fn drainPipe(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    pipe: ?std.Io.File,
+) ChildError![]u8 {
+    const file = pipe orelse return allocator.alloc(u8, 0) catch error.OutOfMemory;
+    var read_buf: [4096]u8 = undefined;
+    var reader = file.readerStreaming(io, &read_buf);
+    return reader.interface.allocRemaining(allocator, std.Io.Limit.limited(max_capture_bytes)) catch |e| switch (e) {
+        error.OutOfMemory => error.OutOfMemory,
+        else => error.IoError,
+    };
 }
 
 test "runOrFail returns void on exit code 0" {
     var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
     defer threaded.deinit();
     const argv = [_][]const u8{"/usr/bin/true"};
-    try runOrFail(threaded.io(), &argv);
+    try runOrFail(threaded.io(), std.testing.allocator, &argv);
 }
 
 test "runOrFail returns NonZeroExit on a non-zero exit" {
     var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
     defer threaded.deinit();
     const argv = [_][]const u8{"/usr/bin/false"};
-    try std.testing.expectError(ChildError.NonZeroExit, runOrFail(threaded.io(), &argv));
+    try std.testing.expectError(ChildError.NonZeroExit, runOrFail(threaded.io(), std.testing.allocator, &argv));
 }
 
 test "runOrFail returns SpawnFailed when program does not exist" {
     var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
     defer threaded.deinit();
     const argv = [_][]const u8{"/nonexistent/binary/malt_child_test"};
-    try std.testing.expectError(ChildError.SpawnFailed, runOrFail(threaded.io(), &argv));
+    try std.testing.expectError(ChildError.SpawnFailed, runOrFail(threaded.io(), std.testing.allocator, &argv));
 }
+
+// Capture-content tests (dual-stream, non-zero exit) live in
+// `tests/child_test.zig`. They need a shell to drive stdout+stderr in
+// one command, which the argv-only spawn invariant forbids under
+// `src/**` — the invariant only scans src/, so the integration file
+// is exempt.

--- a/tests/child_test.zig
+++ b/tests/child_test.zig
@@ -1,0 +1,40 @@
+//! malt — child module tests
+//! Capture-and-replay contract for `core/child.zig`: success is silent,
+//! failure replays the child's own stdout+stderr. Lives here because
+//! the dual-stream driver argv embeds `/bin/sh -c`, which the
+//! argv-only spawn invariant (tests/spawn_invariant_test.zig) bans
+//! anywhere under `src/`.
+
+const std = @import("std");
+const malt = @import("malt");
+const child = malt.child;
+
+test "run captures the child's stderr and surfaces a non-zero exit code" {
+    // Guards the "quiet on success, verbose on failure" contract.
+    // The point: a subprocess whose stderr is noisy on the success path
+    // (hdiutil, ditto, …) must not leak that noise into the user's
+    // terminal — runOrFail() now consumes it. On failure the captured
+    // bytes are the only diagnostic the user gets, so they must survive
+    // intact through the wait+collect.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const argv = [_][]const u8{ "/bin/sh", "-c", "echo OUT; echo ERR-MSG >&2; exit 7" };
+    var report = try child.run(threaded.io(), std.testing.allocator, &argv);
+    defer report.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u8, 7), report.code);
+    try std.testing.expect(std.mem.indexOf(u8, report.stderr, "ERR-MSG") != null);
+    try std.testing.expect(std.mem.indexOf(u8, report.stdout, "OUT") != null);
+}
+
+test "run on a successful child still returns the captured stdout" {
+    // Belt-and-suspenders: even though runOrFail drops these on success,
+    // the underlying `run` must expose what was emitted so we can wire
+    // it into richer diagnostics later without rebuilding the seam.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const argv = [_][]const u8{ "/bin/sh", "-c", "echo silent-but-recorded" };
+    var report = try child.run(threaded.io(), std.testing.allocator, &argv);
+    defer report.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u8, 0), report.code);
+    try std.testing.expect(std.mem.indexOf(u8, report.stdout, "silent-but-recorded") != null);
+}


### PR DESCRIPTION
## Description

`mt install/upgrade <cask>` for DMG casks shows hdiutil's verbose checksumming output stomping over the download progress bar:

```
⠧ flux-markdown ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━─  99% (10.3/10.4 MB ...)Checksumming Protective Master Boot Record（MBR：0）…
Protective Master Boot Record（MBR：0）: verified CRC32 $C19A8C54
Checksumming GPT Header（Primary GPT Header：1）…
...
```

Root cause: `runOrFail` in `src/core/child.zig` inherited the parent's stdout/stderr, so every subprocess malt spawns (hdiutil, ditto, sudo installer, …) wrote directly to the user's terminal - including while the progress bar's cursor was still parked on its line.

Side benefit: every shell-out malt does (cask install pipeline, future migrate/install subprocess work) gets the same UX - quiet on success, verbose when it matters.

## Related Issue

- None

## Notes for Reviewers

- None