### PR TITLE
fix(upgrade): stop re-downloading tap casks when not needed

### DIFF
--- a/scripts/regressions/backup_restore_tap_cask.sh
+++ b/scripts/regressions/backup_restore_tap_cask.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Regression: `mt backup` round-trips the owning tap on third-party
+# cask rows so `mt restore` reinstalls from the right tap.
+#
+# Pre-fix, `backup.zig` SELECTed `token, version` only. A tap cask
+# (e.g. `yuzeguitarist/deck/deckclip`) wrote out as `cask deckclip` —
+# losing the `yuzeguitarist/deck` ownership. On restore that bare
+# token went through `mt install --cask deckclip`, hit the core
+# Homebrew API, 404'd, and the package failed to re-install.
+#
+# The fix joins `casks.tap` into the SELECT and writes the qualified
+# slug form `cask <user>/<repo>/<token>` for tap casks. The shape is
+# the same one `mt install <user>/<repo>/<token>` already routes
+# through `installTapFormula`, so no restore-side changes are needed.
+#
+# This script asserts the full round-trip:
+#   1. Install a tap cask.
+#   2. Run `mt backup` and verify the line carries the slug shape.
+#   3. Uninstall the cask.
+#   4. Run `mt restore <file>` and verify the cask is re-installed
+#      from the owning tap (Caskroom directory present, casks.tap
+#      reattributed).
+#
+# Usage: scripts/regressions/backup_restore_tap_cask.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt, sqlite3
+# on PATH, network access. macOS only.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be <= 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_brt"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+skip() { printf '  - %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+SLUG="yuzeguitarist/deck/deckclip"
+TOKEN="${SLUG##*/}"
+EXPECTED_TAP="yuzeguitarist/deck"
+SNAP="$PREFIX/snap.txt"
+
+# ── Install ────────────────────────────────────────────────────────
+INSTALL_LOG="$PREFIX/install_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt install %s (logs \xe2\x86\x92 %s)\n' "$SLUG" "$INSTALL_LOG"
+if ! "$BIN" install "$SLUG" >"$INSTALL_LOG" 2>&1; then
+  if grep -qE "rate limit|Network failure|Tap formula/cask not found|Failed to (install|download)|Sha256Mismatch|DownloadFailed" "$INSTALL_LOG"; then
+    skip "${SLUG}: install hit a classified upstream condition; cannot exercise round-trip"
+    exit 0
+  fi
+  tail -30 "$INSTALL_LOG" >&2
+  fail "${SLUG}: install failed for an unclassified reason"
+fi
+pass "${SLUG}: installed"
+
+# ── Backup ─────────────────────────────────────────────────────────
+BACKUP_LOG="$PREFIX/backup.log"
+"$BIN" backup --output "$SNAP" >"$BACKUP_LOG" 2>&1 ||
+  fail "backup command failed: $(tail -5 "$BACKUP_LOG")"
+[[ -f "$SNAP" ]] || fail "backup did not produce $SNAP"
+pass "backup wrote $SNAP"
+
+# Assertion: the qualified slug shape is in the file.
+if ! grep -qE "^cask ${SLUG}\$" "$SNAP"; then
+  cat "$SNAP" >&2
+  fail "backup did not record qualified slug 'cask ${SLUG}'"
+fi
+pass "backup line carries the qualified slug 'cask ${SLUG}'"
+
+# Negative: the unqualified bare-token form must not also appear,
+# otherwise restore would attempt it and hit a core-API 404.
+if grep -qE "^cask ${TOKEN}\$" "$SNAP"; then
+  cat "$SNAP" >&2
+  fail "backup also wrote the unqualified bare-token form"
+fi
+pass "backup did not duplicate as bare-token form"
+
+# ── Uninstall + restore ────────────────────────────────────────────
+"$BIN" uninstall "$TOKEN" >>"$BACKUP_LOG" 2>&1 ||
+  fail "uninstall failed: $(tail -5 "$BACKUP_LOG")"
+[[ ! -d "$PREFIX/Caskroom/${TOKEN}" ]] ||
+  fail "Caskroom still present after uninstall"
+pass "${TOKEN}: uninstalled cleanly"
+
+RESTORE_LOG="$PREFIX/restore.log"
+printf '\xe2\x96\xb8 mt restore %s (logs \xe2\x86\x92 %s)\n' "$SNAP" "$RESTORE_LOG"
+"$BIN" restore "$SNAP" >"$RESTORE_LOG" 2>&1 || true
+
+if grep -qE "rate limit|Network failure|Could not resolve" "$RESTORE_LOG"; then
+  skip "restore hit a classified network condition; cannot assert round-trip"
+  exit 0
+fi
+
+# Assertion: restore re-installed the cask from the owning tap.
+if grep -qE "Could not fetch cask info|Cask '${TOKEN}' not found" "$RESTORE_LOG"; then
+  tail -30 "$RESTORE_LOG" >&2
+  fail "restore failed against the core API — backup never carried the tap"
+fi
+
+[[ -d "$PREFIX/Caskroom/${TOKEN}" ]] ||
+  fail "Caskroom missing after restore: ${PREFIX}/Caskroom/${TOKEN}"
+pass "${TOKEN}: restore re-installed via the tap path"
+
+# Verify the DB row also got the tap re-attributed (the recordInstall
+# path writes it; this catches a regression where restore would
+# silently install via a different code path that doesn't set tap).
+DB="$PREFIX/db/malt.db"
+restored_tap=$(sqlite3 "$DB" "SELECT IFNULL(tap, 'NULL') FROM casks WHERE token='${TOKEN}';")
+[[ "$restored_tap" == "$EXPECTED_TAP" ]] ||
+  fail "${TOKEN}: post-restore tap='${restored_tap}', expected '${EXPECTED_TAP}'"
+pass "${TOKEN}: post-restore casks.tap='${EXPECTED_TAP}'"
+
+printf '\n\xe2\x9c\x94 backup/restore tap-cask round-trip regression passed\n'

--- a/scripts/regressions/outdated_tap_cask.sh
+++ b/scripts/regressions/outdated_tap_cask.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Regression: `mt outdated` resolves a tap-installed cask's latest
+# version against the owning tap, not the core Homebrew API.
+#
+# Pre-fix, the cask side of `mt outdated` called `api.fetchCask(token)`
+# unconditionally. For a tap cask the core API 404s, the fetch fails,
+# and the row gets silently classified as up-to-date — leaving the
+# user with no audit signal that an upgrade is available. The fix
+# pre-routes via `casks.tap` the same way `upgradeCask` does, fetching
+# the tap's `Casks/<token>.rb` at fresh HEAD and parsing the version
+# field.
+#
+# This script:
+#   1. Installs a real third-party tap cask.
+#   2. Tampers the local DB to mark it as installed at `0.0.0`,
+#      well below any version the tap will ever ship.
+#   3. Runs `mt outdated` and asserts the cask appears as outdated
+#      with the tampered installed version and the tap's true latest.
+#
+# Tampering avoids depending on the upstream tap actually bumping
+# between install and audit — a controlled mismatch lets the script
+# stay deterministic against a stable tap state.
+#
+# Usage: scripts/regressions/outdated_tap_cask.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt, sqlite3
+# on PATH, network access. macOS only.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be <= 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_otap"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+skip() { printf '  - %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+SLUG="yuzeguitarist/deck/deckclip"
+TOKEN="${SLUG##*/}"
+
+INSTALL_LOG="$PREFIX/install_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt install %s (logs \xe2\x86\x92 %s)\n' "$SLUG" "$INSTALL_LOG"
+if ! "$BIN" install "$SLUG" >"$INSTALL_LOG" 2>&1; then
+  if grep -qE "rate limit|Network failure|Tap formula/cask not found|Failed to (install|download)|Sha256Mismatch|DownloadFailed" "$INSTALL_LOG"; then
+    skip "${SLUG}: install hit a classified upstream condition; cannot exercise outdated"
+    exit 0
+  fi
+  tail -30 "$INSTALL_LOG" >&2
+  fail "${SLUG}: install failed for an unclassified reason"
+fi
+pass "${SLUG}: installed"
+
+DB="$PREFIX/db/malt.db"
+[[ -f "$DB" ]] || fail "expected DB at $DB after install"
+
+# Force a version mismatch by tampering the installed version.
+sqlite3 "$DB" "UPDATE casks SET version='0.0.0' WHERE token='${TOKEN}';"
+tampered=$(sqlite3 "$DB" "SELECT version FROM casks WHERE token='${TOKEN}';")
+[[ "$tampered" == "0.0.0" ]] ||
+  fail "${TOKEN}: failed to tamper installed version (got '${tampered}')"
+pass "${TOKEN}: tampered installed version to 0.0.0"
+
+OUT_LOG="$PREFIX/outdated_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt outdated (expect tap-routed audit, logs \xe2\x86\x92 %s)\n' "$OUT_LOG"
+"$BIN" outdated >"$OUT_LOG" 2>&1 || true
+
+if grep -qE "rate limit|Network failure|Could not resolve" "$OUT_LOG"; then
+  skip "outdated hit a classified network condition; cannot assert tap routing"
+  exit 0
+fi
+
+# Assertion 1: the cask is listed.
+if ! grep -q "${TOKEN}" "$OUT_LOG"; then
+  tail -30 "$OUT_LOG" >&2
+  fail "${TOKEN}: tap-cask outdated audit did not list the cask"
+fi
+pass "${TOKEN}: outdated reported the tap cask"
+
+# Assertion 2: tampered installed version surfaces.
+if ! grep -qE "${TOKEN}.*0\.0\.0" "$OUT_LOG"; then
+  tail -30 "$OUT_LOG" >&2
+  fail "${TOKEN}: outdated did not report the tampered installed version"
+fi
+pass "${TOKEN}: outdated reported tampered installed=0.0.0"
+
+# Assertion 3: the audit must show a non-tampered upstream version.
+# The "All packages are up to date" line is the pre-fix failure mode.
+if grep -q "All packages are up to date" "$OUT_LOG"; then
+  tail -30 "$OUT_LOG" >&2
+  fail "${TOKEN}: outdated silently classified the tap cask as up to date"
+fi
+pass "${TOKEN}: outdated did not collapse to the up-to-date branch"
+
+printf '\n\xe2\x9c\x94 outdated tap-cask regression passed\n'

--- a/scripts/regressions/upgrade_tap_cask_force.sh
+++ b/scripts/regressions/upgrade_tap_cask_force.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Regression: `mt upgrade --force <tap-cask>` re-downloads the DMG
+# even when the recorded version matches the upstream version.
+#
+# Companion to `upgrade_tap_cask_idempotent.sh`: that script proves
+# the routed path skips when versions match; this one proves the
+# `--force` flag is threaded through and bypasses the skip. Easy to
+# regress — `upgradeRoutedTapCask`'s version compare is guarded by
+# `if (!force and ...)`; a missing `!force` clause would silently
+# turn `--force` into a no-op for tap casks.
+#
+# This script asserts:
+#   1. The version-match skip line does NOT surface — `--force` would
+#      be a no-op if it did.
+#   2. The forced upgrade emits the `Upgrading … -> …` line.
+#   3. The forced upgrade reaches the terminal `installed` line.
+#   4. The Caskroom directory and `.app` bundle both exist after the
+#      forced upgrade — proof the install pipeline completed end-to-end.
+#
+# The triplet (no-skip + Upgrading + installed) uniquely characterises
+# "the routed path took the proceed branch": skipping would emit the
+# skip line and never reach Upgrading; an early failure would never
+# reach `installed`. `ditto` preserves mtime from the DMG source, so
+# a bundle-mtime assertion would be unreliable.
+#
+# Usage: scripts/regressions/upgrade_tap_cask_force.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt, network
+# access to GitHub raw + the upstream release host. macOS only.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be <= 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_force"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+skip() { printf '  - %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+SLUG="yuzeguitarist/deck/deckclip"
+TOKEN="${SLUG##*/}"
+BUNDLE="Deck.app"
+APP_PATH="$PREFIX/Applications/$BUNDLE"
+
+INSTALL_LOG="$PREFIX/install_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt install %s (logs \xe2\x86\x92 %s)\n' "$SLUG" "$INSTALL_LOG"
+if ! "$BIN" install "$SLUG" >"$INSTALL_LOG" 2>&1; then
+  if grep -qE "rate limit|Network failure|Tap formula/cask not found|Failed to (install|download)|Sha256Mismatch|DownloadFailed" "$INSTALL_LOG"; then
+    skip "${SLUG}: install hit a classified upstream condition; cannot exercise --force"
+    exit 0
+  fi
+  tail -30 "$INSTALL_LOG" >&2
+  fail "${SLUG}: install failed for an unclassified reason"
+fi
+[[ -d "$APP_PATH" ]] || fail "${SLUG}: expected ${APP_PATH} after install"
+pass "${SLUG}: installed"
+
+FORCE_LOG="$PREFIX/upgrade_force_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt upgrade --force %s (logs \xe2\x86\x92 %s)\n' "$TOKEN" "$FORCE_LOG"
+"$BIN" upgrade --force "$TOKEN" >"$FORCE_LOG" 2>&1 || true
+
+if grep -qE "rate limit|Network failure|Could not resolve" "$FORCE_LOG"; then
+  skip "forced upgrade hit a classified network condition; cannot assert force-bypass"
+  exit 0
+fi
+
+# Assertion 1: the version-match skip must NOT surface — `--force`
+# would be a no-op if it did, exactly the regression we're guarding.
+if grep -q "is already at latest version" "$FORCE_LOG"; then
+  tail -30 "$FORCE_LOG" >&2
+  fail "${TOKEN}: --force was swallowed (version-match skip still emitted)"
+fi
+pass "${TOKEN}: --force suppressed the version-match skip"
+
+# Assertion 2: the routed-path proceed line surfaces. `output.info`
+# prefixes lines with `> `, so the regex tolerates the optional
+# decorator and any color/leading whitespace.
+if ! grep -qE "Upgrading ${TOKEN} " "$FORCE_LOG"; then
+  tail -30 "$FORCE_LOG" >&2
+  fail "${TOKEN}: forced upgrade did not enter the upgrade-proceed path"
+fi
+pass "${TOKEN}: forced upgrade entered the upgrade-proceed path"
+
+# Assertion 3: the terminal `installed` line — the install pipeline
+# reached completion, not just the routing setup.
+if ! grep -qE "${TOKEN} [^ ]+ installed" "$FORCE_LOG"; then
+  tail -30 "$FORCE_LOG" >&2
+  fail "${TOKEN}: forced upgrade did not complete an install"
+fi
+pass "${TOKEN}: forced upgrade reached the 'installed' completion line"
+
+# Assertion 4: bundle + Caskroom both present after the forced
+# upgrade. Either being missing means uninstall ran but the
+# subsequent install bailed silently.
+[[ -d "$APP_PATH" ]] || fail "${TOKEN}: app bundle missing after forced upgrade"
+[[ -d "$PREFIX/Caskroom/${TOKEN}" ]] || fail "${TOKEN}: Caskroom missing after forced upgrade"
+pass "${TOKEN}: app bundle and Caskroom both present after forced upgrade"
+
+printf '\n\xe2\x9c\x94 upgrade-tap-cask --force regression passed\n'

--- a/scripts/regressions/upgrade_tap_cask_idempotent.sh
+++ b/scripts/regressions/upgrade_tap_cask_idempotent.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Regression: `mt upgrade` against a tap-installed cask is idempotent —
+# a second invocation with no upstream change MUST NOT re-download the
+# DMG.
+#
+# Pre-fix, `upgradeTapCaskFallback` called `installTapFormula` with a
+# hardcoded `force = true`, bypassing every "already installed" guard
+# downstream. The user-visible effect: every `mt upgrade <tap-cask>`
+# fetched the full DMG, mounted it, and copied the app bundle, even
+# when nothing had changed.
+#
+# Root cause: the `casks` table had no `tap` column, so the upgrade
+# entry point couldn't pre-route by ownership the way `upgradeFormula`
+# does for `kegs.tap`. The fix adds the column (schema v5 → v6),
+# records the owning tap on install / on first fallback probe, and
+# pre-routes to `upgradeRoutedTapCask` whenever it's known. The routed
+# path fetches the tap's `Casks/<token>.rb`, compares versions, and
+# short-circuits with `is already at latest version` before any DMG
+# fetch starts.
+#
+# This script asserts the second consecutive upgrade:
+#   1. Emits the version-match skip line.
+#   2. Does NOT print the `Upgrading … -> …` line (that only fires
+#      when the routed path proceeds past the skip).
+#   3. Does NOT mention `Downloading` / a percentage progress marker
+#      (no DMG fetch happened).
+#   4. Leaves the installed app bundle's mtime unchanged across the
+#      two invocations.
+#
+# Usage: scripts/regressions/upgrade_tap_cask_idempotent.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt, network
+# access to GitHub raw + the upstream release host. macOS only.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be ≤ 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_upidem"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+skip() { printf '  - %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+# A third-party tap cask shipping a DMG. Same candidate as
+# tap_cask_dmg_gh136.sh — keeping the surface stable across regressions
+# minimises external flakiness.
+SLUG="yuzeguitarist/deck/deckclip"
+TOKEN="${SLUG##*/}"
+BUNDLE="Deck.app"
+APP_PATH="$PREFIX/Applications/$BUNDLE"
+
+INSTALL_LOG="$PREFIX/install_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt install %s (logs \xe2\x86\x92 %s)\n' "$SLUG" "$INSTALL_LOG"
+if ! "$BIN" install "$SLUG" >"$INSTALL_LOG" 2>&1; then
+  if grep -qE "rate limit|Network failure|Tap formula/cask not found|Failed to (install|download)|Sha256Mismatch|DownloadFailed" "$INSTALL_LOG"; then
+    skip "${SLUG}: install hit a classified upstream condition; cannot assert idempotence"
+    exit 0
+  fi
+  tail -30 "$INSTALL_LOG" >&2
+  fail "${SLUG}: install failed for an unclassified reason"
+fi
+[[ -d "$APP_PATH" ]] || fail "${SLUG}: expected ${APP_PATH} after install"
+pass "${SLUG}: installed"
+
+# Snapshot mtime before the first upgrade. macOS `stat -f %m` returns
+# the unix epoch seconds for the directory's mtime — stable across
+# read-only `mt upgrade` invocations.
+mtime_before=$(stat -f %m "$APP_PATH" 2>/dev/null || stat -c %Y "$APP_PATH")
+
+# ── First upgrade ───────────────────────────────────────────────────
+#
+# Tolerated outcomes: either the version matches (the typical case
+# since we just installed) and we get the skip line, OR the upstream
+# tap has bumped between our install and this upgrade (rare but
+# possible) and we get an actual upgrade. Both are fine — the assertion
+# we care about is the SECOND upgrade being a no-op.
+UP1_LOG="$PREFIX/upgrade1_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt upgrade %s (1st pass, logs \xe2\x86\x92 %s)\n' "$TOKEN" "$UP1_LOG"
+"$BIN" upgrade "$TOKEN" >"$UP1_LOG" 2>&1 || true
+
+if grep -qE "rate limit|Network failure|Could not resolve" "$UP1_LOG"; then
+  skip "first upgrade hit a classified network condition; cannot assert idempotence"
+  exit 0
+fi
+
+# ── Second upgrade (the idempotence assertion) ──────────────────────
+UP2_LOG="$PREFIX/upgrade2_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt upgrade %s (2nd pass, logs \xe2\x86\x92 %s)\n' "$TOKEN" "$UP2_LOG"
+"$BIN" upgrade "$TOKEN" >"$UP2_LOG" 2>&1 || true
+
+if grep -qE "rate limit|Network failure|Could not resolve" "$UP2_LOG"; then
+  skip "second upgrade hit a classified network condition; cannot assert idempotence"
+  exit 0
+fi
+
+# Assertion 1: skip line must surface.
+if ! grep -q "is already at latest version" "$UP2_LOG"; then
+  tail -30 "$UP2_LOG" >&2
+  fail "${TOKEN}: second upgrade did not emit the version-match skip"
+fi
+pass "${TOKEN}: second upgrade emits 'is already at latest version'"
+
+# Assertion 2: routed-path proceed line must NOT surface.
+if grep -qE "^Upgrading ${TOKEN} " "$UP2_LOG"; then
+  tail -30 "$UP2_LOG" >&2
+  fail "${TOKEN}: second upgrade proceeded past the skip"
+fi
+pass "${TOKEN}: second upgrade did not start an upgrade run"
+
+# Assertion 3: no DMG download markers. The progress bar prints `%`
+# lines via the bar renderer, and the cask installer also writes
+# "Downloading" before any large fetch.
+if grep -qE "Downloading|[0-9]+%" "$UP2_LOG"; then
+  tail -30 "$UP2_LOG" >&2
+  fail "${TOKEN}: second upgrade printed a download progress marker"
+fi
+pass "${TOKEN}: second upgrade did not emit download progress"
+
+# Assertion 4: the installed bundle's mtime is untouched.
+mtime_after=$(stat -f %m "$APP_PATH" 2>/dev/null || stat -c %Y "$APP_PATH")
+if [[ "$mtime_before" != "$mtime_after" ]]; then
+  printf '   before=%s after=%s\n' "$mtime_before" "$mtime_after" >&2
+  fail "${TOKEN}: app bundle mtime changed across upgrades"
+fi
+pass "${TOKEN}: app bundle mtime unchanged across two upgrades"
+
+printf '\n\xe2\x9c\x94 upgrade-tap-cask-idempotent regression passed\n'

--- a/scripts/regressions/upgrade_tap_cask_idempotent.sh
+++ b/scripts/regressions/upgrade_tap_cask_idempotent.sh
@@ -115,8 +115,11 @@ if ! grep -q "is already at latest version" "$UP2_LOG"; then
 fi
 pass "${TOKEN}: second upgrade emits 'is already at latest version'"
 
-# Assertion 2: routed-path proceed line must NOT surface.
-if grep -qE "^Upgrading ${TOKEN} " "$UP2_LOG"; then
+# Assertion 2: routed-path proceed line must NOT surface. `output.info`
+# decorates the line with a `> ` prefix; the unanchored regex catches
+# both the bare and the decorated form so a future output-format
+# tweak can't silently turn this assertion into a false-pass.
+if grep -qE "Upgrading ${TOKEN} " "$UP2_LOG"; then
   tail -30 "$UP2_LOG" >&2
   fail "${TOKEN}: second upgrade proceeded past the skip"
 fi

--- a/scripts/regressions/upgrade_tap_cask_legacy_backfill.sh
+++ b/scripts/regressions/upgrade_tap_cask_legacy_backfill.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Regression: a legacy v5-era cask row (with `tap = NULL`) gets its
+# owning tap attributed on the first `mt upgrade <token>` so subsequent
+# upgrades pre-route directly.
+#
+# Schema v6 added `casks.tap`. Fresh installs write the owning tap at
+# `recordInstall` time, but rows that pre-date v6 stay NULL until the
+# upgrade flow exercises the multi-tap fallback probe and the probe's
+# success path calls `backfillCaskTap` to attribute the row.
+#
+# This script simulates a legacy install by UPDATE-ing an existing cask
+# row's `tap` back to NULL, runs `mt upgrade`, and asserts:
+#   1. `casks.tap` is no longer NULL.
+#   2. The recorded tap label matches the install slug's owning tap.
+#   3. A second `mt upgrade` emits the version-match skip line —
+#      proving pre-routing kicked in instead of the probe loop.
+#
+# Usage: scripts/regressions/upgrade_tap_cask_legacy_backfill.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt, sqlite3
+# on PATH, network access for the seeding install + upgrade fetch.
+# macOS only (the cask installer relies on hdiutil / ditto).
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be <= 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_v5back"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+skip() { printf '  - %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+SLUG="yuzeguitarist/deck/deckclip"
+TOKEN="${SLUG##*/}"
+EXPECTED_TAP="yuzeguitarist/deck"
+
+INSTALL_LOG="$PREFIX/install_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt install %s (logs \xe2\x86\x92 %s)\n' "$SLUG" "$INSTALL_LOG"
+if ! "$BIN" install "$SLUG" >"$INSTALL_LOG" 2>&1; then
+  if grep -qE "rate limit|Network failure|Tap formula/cask not found|Failed to (install|download)|Sha256Mismatch|DownloadFailed" "$INSTALL_LOG"; then
+    skip "${SLUG}: install hit a classified upstream condition; cannot exercise backfill"
+    exit 0
+  fi
+  tail -30 "$INSTALL_LOG" >&2
+  fail "${SLUG}: install failed for an unclassified reason"
+fi
+pass "${SLUG}: installed"
+
+DB="$PREFIX/db/malt.db"
+[[ -f "$DB" ]] || fail "expected DB at $DB after install"
+
+# Verify install wrote the tap automatically (the v6 contract).
+post_install_tap=$(sqlite3 "$DB" "SELECT tap FROM casks WHERE token='${TOKEN}';")
+[[ "$post_install_tap" == "$EXPECTED_TAP" ]] ||
+  fail "${TOKEN}: fresh install should record tap='${EXPECTED_TAP}', got '${post_install_tap}'"
+pass "${TOKEN}: fresh install wrote casks.tap='${EXPECTED_TAP}'"
+
+# Simulate a legacy v5-era row: clear the tap column.
+sqlite3 "$DB" "UPDATE casks SET tap = NULL WHERE token='${TOKEN}';"
+legacy_tap=$(sqlite3 "$DB" "SELECT IFNULL(tap, 'NULL') FROM casks WHERE token='${TOKEN}';")
+[[ "$legacy_tap" == "NULL" ]] ||
+  fail "${TOKEN}: failed to simulate v5 legacy row (tap=${legacy_tap})"
+pass "${TOKEN}: simulated v5 legacy row (tap=NULL)"
+
+# First upgrade after the legacy row exists. The fallback probe must
+# find the owning tap and backfill the column.
+UP1_LOG="$PREFIX/upgrade1_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt upgrade %s (1st pass — triggers backfill, logs \xe2\x86\x92 %s)\n' "$TOKEN" "$UP1_LOG"
+"$BIN" upgrade "$TOKEN" >"$UP1_LOG" 2>&1 || true
+
+if grep -qE "rate limit|Network failure|Could not resolve" "$UP1_LOG"; then
+  skip "first upgrade hit a classified network condition; cannot assert backfill"
+  exit 0
+fi
+
+# Assertion: the tap column is now attributed.
+backfilled_tap=$(sqlite3 "$DB" "SELECT IFNULL(tap, 'NULL') FROM casks WHERE token='${TOKEN}';")
+if [[ "$backfilled_tap" == "NULL" ]]; then
+  tail -30 "$UP1_LOG" >&2
+  fail "${TOKEN}: backfill did not attribute the tap (still NULL after upgrade)"
+fi
+[[ "$backfilled_tap" == "$EXPECTED_TAP" ]] ||
+  fail "${TOKEN}: backfill wrote wrong tap (got '${backfilled_tap}', expected '${EXPECTED_TAP}')"
+pass "${TOKEN}: backfill wrote casks.tap='${EXPECTED_TAP}'"
+
+# Second upgrade — pre-routing must kick in (no fallback probe needed)
+# and the version-match path must emit the skip line.
+UP2_LOG="$PREFIX/upgrade2_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt upgrade %s (2nd pass — pre-routes via backfilled tap, logs \xe2\x86\x92 %s)\n' "$TOKEN" "$UP2_LOG"
+"$BIN" upgrade "$TOKEN" >"$UP2_LOG" 2>&1 || true
+
+if grep -qE "rate limit|Network failure|Could not resolve" "$UP2_LOG"; then
+  skip "second upgrade hit a classified network condition; cannot assert idempotence"
+  exit 0
+fi
+
+if ! grep -q "is already at latest version" "$UP2_LOG"; then
+  tail -30 "$UP2_LOG" >&2
+  fail "${TOKEN}: pre-routed second upgrade did not emit the version-match skip"
+fi
+pass "${TOKEN}: pre-routed second upgrade emits 'is already at latest version'"
+
+if grep -qE "Downloading|[0-9]+%" "$UP2_LOG"; then
+  tail -30 "$UP2_LOG" >&2
+  fail "${TOKEN}: pre-routed second upgrade emitted download progress"
+fi
+pass "${TOKEN}: pre-routed second upgrade skipped any artifact fetch"
+
+printf '\n\xe2\x9c\x94 upgrade-tap-cask legacy-backfill regression passed\n'

--- a/src/cli/backup.zig
+++ b/src/cli/backup.zig
@@ -108,15 +108,38 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         }
     }
 
-    var cstmt = db.prepare("SELECT token, version FROM casks ORDER BY token;") catch null;
+    // Tap is read alongside token + version so the line written for
+    // a third-party-tap cask carries the fully-qualified slug
+    // `<user>/<repo>/<token>`. Bare tokens 404 against the core API
+    // on restore; the qualified form routes through
+    // `installTapFormula` and re-installs from the owning tap.
+    var cstmt = db.prepare("SELECT token, version, tap FROM casks ORDER BY token;") catch null;
     if (cstmt) |*s| {
         defer s.finalize();
         while (s.step() catch false) {
             const name_ptr = s.columnText(0) orelse continue;
             const ver_ptr = s.columnText(1);
-            const name = std.mem.sliceTo(name_ptr, 0);
+            const tap_ptr = s.columnText(2);
+            const token = std.mem.sliceTo(name_ptr, 0);
             const version = if (ver_ptr) |p| std.mem.sliceTo(p, 0) else "";
-            try writeEntry(w, .cask, name, version, include_versions);
+            const tap = if (tap_ptr) |p| std.mem.sliceTo(p, 0) else "";
+
+            // Qualify only for third-party taps. `homebrew/cask` is the
+            // core API path and stays bare so legacy backups parse the
+            // same way.
+            if (tap.len > 0 and !std.mem.eql(u8, tap, "homebrew/cask")) {
+                var qual_buf: [256]u8 = undefined;
+                const qualified = std.fmt.bufPrint(&qual_buf, "{s}/{s}", .{ tap, token }) catch {
+                    // Tap label too long for the qualified-name buffer —
+                    // fall back to the bare token so the entry isn't lost.
+                    try writeEntry(w, .cask, token, version, include_versions);
+                    count += 1;
+                    continue;
+                };
+                try writeEntry(w, .cask, qualified, version, include_versions);
+            } else {
+                try writeEntry(w, .cask, token, version, include_versions);
+            }
             count += 1;
         }
     }

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -948,8 +948,8 @@ fn installCask(
     };
     bar.finish();
 
-    // Record in DB with install path
-    cask_mod.recordInstall(db, &cask, app_path) catch {
+    // Core API casks have no third-party tap origin to record.
+    cask_mod.recordInstall(db, &cask, app_path, null) catch {
         output.warn("Failed to record cask {s} in database", .{cask.token});
     };
     allocator.free(app_path);

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -111,8 +111,27 @@ const tap_archive_suffixes = [_]struct {
     .{ .suffix = ".zip", .kind = .zip },
 };
 
-/// Install a tap formula by fetching the Ruby formula from GitHub and
-/// extracting URL + SHA256 for the current platform.
+/// Selects which subdirectory of the tap the installer probes for the
+/// `.rb` file. `.formula_or_cask` (the default for `mt install`) tries
+/// `Formula/` first and falls back to `Casks/`; `.cask_only` skips the
+/// Formula/ probe entirely.
+///
+/// `.cask_only` exists because the formula branch of
+/// `materializeRubyFormula` opens its own DB transaction. Callers
+/// holding an open transaction (currently `upgradeRoutedTapCask`)
+/// would deadlock if a Formula/ probe accidentally resolved 200 — for
+/// example, on a tap that ships both `Formula/<name>.rb` and
+/// `Casks/<name>.rb` for the same token. The flag pins the resolver
+/// to the cask subdirectory so that branch is structurally
+/// unreachable.
+const TapResolveKind = enum {
+    formula_or_cask,
+    cask_only,
+};
+
+/// Install a tap formula or cask. Probes `Formula/<name>.rb` first and
+/// falls back to `Casks/<name>.rb` so a single entry point covers both
+/// shapes — the `mt install <user>/<repo>/<name>` form the user types.
 pub fn installTapFormula(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
@@ -122,6 +141,37 @@ pub fn installTapFormula(
     prefix: []const u8,
     dry_run: bool,
     force: bool,
+) !void {
+    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, .formula_or_cask);
+}
+
+/// Install a tap cask whose owning tap is already known. Skips the
+/// `Formula/` probe — safe to call from inside an open DB transaction
+/// because the formula branch of `materializeRubyFormula` (which
+/// begins its own transaction) is structurally unreachable.
+pub fn installTapCask(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    pkg_name: []const u8,
+    db: *sqlite.Database,
+    linker: *linker_mod.Linker,
+    prefix: []const u8,
+    dry_run: bool,
+    force: bool,
+) !void {
+    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, .cask_only);
+}
+
+fn installTapRb(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    pkg_name: []const u8,
+    db: *sqlite.Database,
+    linker: *linker_mod.Linker,
+    prefix: []const u8,
+    dry_run: bool,
+    force: bool,
+    kind: TapResolveKind,
 ) !void {
     const parts = args.parseTapName(pkg_name) orelse {
         output.err("Invalid tap formula format: {s}", .{pkg_name});
@@ -155,11 +205,17 @@ pub fn installTapFormula(
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
 
-    // Try Formula/ first, then Casks/
+    // First probe: Formula/ for the default mode, Casks/ when the
+    // caller has pinned the resolve to cask-only.
+    const initial_subdir: []const u8 = switch (kind) {
+        .formula_or_cask => "Formula",
+        .cask_only => "Casks",
+    };
     var url_buf: [512]u8 = undefined;
-    const rb_url = std.fmt.bufPrint(&url_buf, "{s}/{s}/Formula/{s}.rb", .{
+    const rb_url = std.fmt.bufPrint(&url_buf, "{s}/{s}/{s}/{s}.rb", .{
         urls.raw_base,
         commit_sha,
+        initial_subdir,
         parts.formula,
     }) catch return InstallError.FormulaNotFound;
 
@@ -175,7 +231,13 @@ pub fn installTapFormula(
     var cask_resp: ?client_mod.Response = null;
     defer if (cask_resp) |*c| c.deinit();
 
-    const resp: *const client_mod.Response = if (rb_resp.status == 200) &rb_resp else blk: {
+    const resp: *const client_mod.Response = blk: {
+        if (rb_resp.status == 200) break :blk &rb_resp;
+        // `.cask_only` already probed Casks/ — there is no fallback to
+        // try, and the downstream `resp.status != 200` check surfaces
+        // the not-found error.
+        if (kind == .cask_only) break :blk &rb_resp;
+
         const cask_url = std.fmt.bufPrint(&url_buf, "{s}/{s}/Casks/{s}.rb", .{
             urls.raw_base,
             commit_sha,

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -986,7 +986,10 @@ fn materializeTapCask(
     bar.finish();
     defer allocator.free(app_path);
 
-    cask_mod.recordInstall(db, &cask, app_path) catch {
+    // tap_label is the third-party tap origin (`user/repo`) — drives
+    // pre-routing in `mt upgrade` so subsequent invocations skip the
+    // multi-tap probe loop.
+    cask_mod.recordInstall(db, &cask, app_path, resolved.tap_label) catch {
         output.warn("Failed to record cask {s} in database", .{cask.token});
     };
 

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -10,6 +10,9 @@ const output = @import("../ui/output.zig");
 const api_mod = @import("../net/api.zig");
 const client_mod = @import("../net/client.zig");
 const cask_mod = @import("../core/cask.zig");
+const tap_mod = @import("../core/tap.zig");
+const install_local_mod = @import("install/local.zig");
+const install_args_mod = @import("install/args.zig");
 const color = @import("../ui/color.zig");
 const help = @import("help.zig");
 
@@ -40,9 +43,15 @@ pub const SNAPSHOT_VERSION: u32 = 1;
 pub const SNAPSHOT_FILE = "outdated.json";
 
 /// One row of the installed-package list fed to the worker pool.
+/// `tap` is the third-party tap label for tap-installed casks (drives
+/// outdated's pre-routing the same way `upgradeCask` uses
+/// `lookupInstalled.tap()`); null for kegs and for casks installed
+/// from the core Homebrew API. Owned by the same allocator as `name`
+/// and `version`; freed by `freeKegRows`.
 pub const KegRow = struct {
     name: []const u8,
     version: []const u8,
+    tap: ?[]const u8 = null,
 };
 
 /// Scope filter for `loadFormulaRows`. `--pinned-only` swaps in a
@@ -937,15 +946,17 @@ pub fn loadFormulaRows(
 
 /// Cask sibling of `loadFormulaRows`. Same lifetime contract; pinned
 /// filter swaps in `WHERE pinned = 1` so `--pinned-only` walks the
-/// pinned-cask audit path symmetrically with formulas.
+/// pinned-cask audit path symmetrically with formulas. The `tap`
+/// column comes along for the ride so `upstreamLatest` can pre-route
+/// tap casks to the owning tap's `.rb` instead of the core API.
 pub fn loadCaskRows(
     allocator: std.mem.Allocator,
     db: *sqlite.Database,
     filter: KegFilter,
 ) ![]KegRow {
     const sql: [:0]const u8 = switch (filter) {
-        .all => "SELECT token, version FROM casks ORDER BY token;",
-        .pinned_only => "SELECT token, version FROM casks WHERE pinned = 1 ORDER BY token;",
+        .all => "SELECT token, version, tap FROM casks ORDER BY token;",
+        .pinned_only => "SELECT token, version, tap FROM casks WHERE pinned = 1 ORDER BY token;",
     };
     return loadKegRows(allocator, db, sql);
 }
@@ -956,10 +967,15 @@ pub fn freeKegRows(allocator: std.mem.Allocator, rows: []KegRow) void {
     for (rows) |r| {
         allocator.free(r.name);
         allocator.free(r.version);
+        if (r.tap) |t| allocator.free(t);
     }
     allocator.free(rows);
 }
 
+/// Reads `name, version` (and optionally `tap` as column 2) into
+/// caller-owned `KegRow`s. Tap is left null when the column isn't
+/// part of the SELECT (formula loader) or when the row's value is
+/// SQL NULL (core-API cask, or a v5-era row not yet backfilled).
 fn loadKegRows(
     allocator: std.mem.Allocator,
     db: *sqlite.Database,
@@ -973,6 +989,7 @@ fn loadKegRows(
         for (rows.items) |r| {
             allocator.free(r.name);
             allocator.free(r.version);
+            if (r.tap) |t| allocator.free(t);
         }
         rows.deinit(allocator);
     }
@@ -984,7 +1001,16 @@ fn loadKegRows(
         const name_dup = try allocator.dupe(u8, name_slice);
         errdefer allocator.free(name_dup);
         const ver_dup = try allocator.dupe(u8, ver_slice);
-        try rows.append(allocator, .{ .name = name_dup, .version = ver_dup });
+        errdefer allocator.free(ver_dup);
+        // Column 2 is the `tap` field for cask loaders; formula
+        // loaders don't SELECT it, so `columnText` returns null and
+        // the row gets a null tap.
+        var tap_dup: ?[]u8 = null;
+        if (stmt.columnText(2)) |tap_ptr| {
+            const tap_slice = std.mem.sliceTo(tap_ptr, 0);
+            tap_dup = try allocator.dupe(u8, tap_slice);
+        }
+        try rows.append(allocator, .{ .name = name_dup, .version = ver_dup, .tap = tap_dup });
     }
     return rows.toOwnedSlice(allocator);
 }
@@ -1185,7 +1211,7 @@ fn collectOutdated(
 
     if (!shouldUsePool(kegs.len)) {
         for (kegs, 0..) |row, i| {
-            latest_versions[i] = try fetchLatest(allocator, api, kind, row);
+            latest_versions[i] = try fetchLatest(allocator, api, ctx.io, ctx.environ, kind, row);
         }
     } else {
         try runPool(ctx, allocator, cache_dir, kegs, workers_override, kind, latest_versions);
@@ -1229,23 +1255,37 @@ fn assembleEntries(
     return out.toOwnedSlice(allocator);
 }
 
-/// Fetch + parse the upstream latest version for `name` onto `alloc`.
+/// Fetch + parse the upstream latest version for `row` onto `alloc`.
 /// Best-effort: network or parse failures collapse to null. Shared by
 /// the serial and pool paths so the JSON-shape logic lives once.
+/// `io` and `environ` are only consumed by the tap-cask branch (which
+/// needs them for the per-tap HEAD resolve + raw `.rb` fetch); core-
+/// API formula/cask lookups go through `api` which already wraps the
+/// shared HTTP client.
 fn upstreamLatest(
     alloc: std.mem.Allocator,
     api: *api_mod.BrewApi,
+    io: std.Io,
+    environ: std.process.Environ,
     kind: Kind,
-    name: []const u8,
+    row: KegRow,
 ) ?[]u8 {
     return switch (kind) {
         .formula => blk: {
-            const json = api.fetchFormula(name) catch break :blk null;
+            const json = api.fetchFormula(row.name) catch break :blk null;
             defer alloc.free(json);
             break :blk parseFormulaLatest(alloc, json);
         },
         .cask => blk: {
-            const json = api.fetchCask(name) catch break :blk null;
+            // Pre-route to the owning tap when set: the core API 404s
+            // for third-party-tap casks, so the API path would silently
+            // drop the row from the audit. Same shape as `upgradeCask`.
+            if (row.tap) |tap_label| {
+                if (!install_args_mod.isCoreTap(tap_label)) {
+                    break :blk tapCaskLatestVersion(alloc, io, environ, tap_label, row.name);
+                }
+            }
+            const json = api.fetchCask(row.name) catch break :blk null;
             defer alloc.free(json);
             var cask = cask_mod.parseCask(alloc, json) catch break :blk null;
             defer cask.deinit();
@@ -1254,15 +1294,52 @@ fn upstreamLatest(
     };
 }
 
+/// Resolve a tap cask's upstream version by fetching the owning tap's
+/// `Casks/<token>.rb` at fresh HEAD and reading the `version` field.
+/// Best-effort: any network, parse, or URL-synth failure collapses to
+/// null and the cask is silently treated as up-to-date (the same
+/// fail-soft contract `fetchCask` follows for the core API).
+fn tapCaskLatestVersion(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    environ: std.process.Environ,
+    tap_label: []const u8,
+    token: []const u8,
+) ?[]u8 {
+    const slash = std.mem.indexOfScalar(u8, tap_label, '/') orelse return null;
+    if (slash == 0 or slash == tap_label.len - 1) return null;
+
+    const urls = tap_mod.resolveTapBaseUrls(alloc, tap_label) catch return null;
+    defer urls.deinit(alloc);
+
+    const fresh_sha = tap_mod.resolveHeadCommit(io, environ, alloc, urls.api_head_url) catch return null;
+    defer alloc.free(fresh_sha);
+
+    var http = client_mod.HttpClient.init(io, environ, alloc);
+    defer http.deinit();
+
+    var rb_url_buf: [512]u8 = undefined;
+    const rb_url = std.fmt.bufPrint(&rb_url_buf, "{s}/{s}/Casks/{s}.rb", .{ urls.raw_base, fresh_sha, token }) catch return null;
+
+    var rb_resp = http.get(rb_url) catch return null;
+    defer rb_resp.deinit();
+    if (rb_resp.status != 200) return null;
+
+    const rb_info = install_local_mod.parseRubyFormula(rb_resp.body) orelse return null;
+    return alloc.dupe(u8, rb_info.version) catch null;
+}
+
 /// Serial-path single-row check. Returns a caller-owned latest-version
 /// string if `row` is outdated, null otherwise.
 fn fetchLatest(
     allocator: std.mem.Allocator,
     api: *api_mod.BrewApi,
+    io: std.Io,
+    environ: std.process.Environ,
     kind: Kind,
     row: KegRow,
 ) std.mem.Allocator.Error!?[]u8 {
-    const v = upstreamLatest(allocator, api, kind, row.name) orelse return null;
+    const v = upstreamLatest(allocator, api, io, environ, kind, row) orelse return null;
     if (std.mem.eql(u8, row.version, v)) {
         allocator.free(v);
         return null;
@@ -1296,6 +1373,10 @@ fn parseFormulaLatest(allocator: std.mem.Allocator, json_bytes: []const u8) ?[]u
 
 const WorkerCtx = struct {
     io: std.Io,
+    /// Carried so tap-cask rows can resolve their owning tap's HEAD
+    /// through `tap_mod.resolveHeadCommit`, which reads GitHub auth
+    /// tokens from the parent process environ.
+    environ: std.process.Environ,
     arena: std.heap.ArenaAllocator,
     pool: *client_mod.HttpClientPool,
     cache_dir: []const u8,
@@ -1330,7 +1411,7 @@ fn runOne(out_alloc: std.mem.Allocator, wctx: *WorkerCtx) void {
 
     const arena_alloc = wctx.arena.allocator();
     var local_api = api_mod.BrewApi.init(wctx.io, arena_alloc, http, wctx.cache_dir);
-    const latest = upstreamLatest(arena_alloc, &local_api, wctx.kind, wctx.row.name) orelse return;
+    const latest = upstreamLatest(arena_alloc, &local_api, wctx.io, wctx.environ, wctx.kind, wctx.row) orelse return;
     if (std.mem.eql(u8, wctx.row.version, latest)) return;
 
     // Move into the caller's allocator so the result outlives `arena.deinit()`.
@@ -1362,6 +1443,7 @@ fn runPool(
     }
     for (ctxs, 0..) |*c, i| c.* = .{
         .io = ctx.io,
+        .environ = ctx.environ,
         .arena = std.heap.ArenaAllocator.init(std.heap.page_allocator),
         .pool = &http_pool,
         .cache_dir = cache_dir,

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -533,18 +533,129 @@ fn upgradeTapFormula(
     };
 }
 
+/// Distinguishes "this tap doesn't own the cask" from "the upgrade
+/// attempt failed". The probe loop in `upgradeTapCaskFallback` continues
+/// on either — the pre-routed call from `upgradeCask` continues only on
+/// the latter (a 404 against a recorded `casks.tap` is user-facing).
+const TapRouteError = error{ NotInTap, Aborted };
+
+/// Upgrade a cask whose owning tap is known. Fetches the tap's
+/// `Casks/<token>.rb` once to read the new version, short-circuits when
+/// the cask is already at that version, and otherwise drives the same
+/// uninstall + tap re-install sequence the install path uses. Centralises
+/// the version check so we never re-download the artifact for a cask
+/// whose tap hasn't bumped its version.
+fn upgradeRoutedTapCask(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    token: []const u8,
+    tap_label: []const u8,
+    installed_version: []const u8,
+    db: *sqlite.Database,
+    prefix: [:0]const u8,
+    dry_run: bool,
+    force: bool,
+) TapRouteError!void {
+    const slash = std.mem.indexOfScalar(u8, tap_label, '/') orelse return error.Aborted;
+    if (slash == 0 or slash == tap_label.len - 1) return error.Aborted;
+
+    const urls = tap_mod.resolveTapBaseUrls(allocator, tap_label) catch return error.Aborted;
+    defer urls.deinit(allocator);
+
+    // Always force-resolve HEAD: the whole point of `mt upgrade` is
+    // "give me the latest", so we ignore any cached pin here.
+    const fresh_sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url) catch return error.Aborted;
+    defer allocator.free(fresh_sha);
+
+    var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
+    defer http.deinit();
+
+    var rb_url_buf: [512]u8 = undefined;
+    const rb_url = std.fmt.bufPrint(&rb_url_buf, "{s}/{s}/Casks/{s}.rb", .{ urls.raw_base, fresh_sha, token }) catch return error.Aborted;
+
+    var rb_resp = http.get(rb_url) catch return error.Aborted;
+    defer rb_resp.deinit();
+    if (rb_resp.status != 200) return error.NotInTap;
+
+    const rb_info = install_local_mod.parseRubyFormula(rb_resp.body) orelse return error.NotInTap;
+
+    if (!force and std.mem.eql(u8, installed_version, rb_info.version)) {
+        output.skip("{s} is already at latest version {s}", .{ token, rb_info.version });
+        output.emitNdjsonEvent(.up_to_date, token, null);
+        return;
+    }
+
+    if (dry_run) {
+        output.info("Dry run: would upgrade cask {s} {s} -> {s}", .{ token, installed_version, rb_info.version });
+        output.emitNdjsonEvent(.would_install, token, null);
+        return;
+    }
+
+    // Persist the new pin BEFORE installTapFormula reads it via
+    // `tap_mod.getCommitSha`. Same pattern as `upgradeTapFormula`.
+    tap_mod.add(db, tap_label, urls.repo_url, fresh_sha) catch {
+        output.err("Could not pin {s} to {s}", .{ tap_label, fresh_sha });
+        return error.Aborted;
+    };
+
+    output.info("Upgrading {s} {s} -> {s}...", .{ token, installed_version, rb_info.version });
+
+    // Snapshot the pin so a force-upgrade preserves the user's hold.
+    const was_pinned = pin_mod.isPinned(db, token);
+
+    // Single DB transaction across uninstall + install + recordInstall.
+    // Mirrors the core-API path in `upgradeCask` so a partial failure
+    // can't leave the casks row missing once the new app is on disk.
+    var installer = cask_mod.CaskInstaller.init(ctx.io, ctx.environ, allocator, db, prefix);
+    db.beginTransaction() catch return error.Aborted;
+    errdefer db.rollback();
+
+    installer.uninstall(token) catch {
+        output.err("Failed to remove old version of {s}", .{token});
+        return error.Aborted;
+    };
+
+    const full_name = std.fmt.allocPrint(allocator, "{s}/{s}", .{ tap_label, token }) catch return error.Aborted;
+    defer allocator.free(full_name);
+
+    var linker = linker_mod.Linker.init(ctx.io, allocator, db, prefix);
+    install_local_mod.installTapFormula(ctx, allocator, full_name, db, &linker, prefix, dry_run, true) catch {
+        output.err("Failed to upgrade tap cask {s}", .{full_name});
+        return error.Aborted;
+    };
+
+    db.commit() catch return error.Aborted;
+
+    if (was_pinned) _ = pin_mod.setPinned(db, token, true) catch {};
+}
+
+/// Backfill the `casks.tap` column once we've discovered the owning tap
+/// via the probe loop. Idempotent (`WHERE tap IS NULL`); failures are
+/// non-fatal — the row stays NULL and we re-probe on the next upgrade.
+fn backfillCaskTap(db: *sqlite.Database, token: []const u8, tap_label: []const u8) void {
+    var stmt = db.prepare("UPDATE casks SET tap = ?1 WHERE token = ?2 AND tap IS NULL;") catch return;
+    defer stmt.finalize();
+    stmt.bindText(1, tap_label) catch return;
+    stmt.bindText(2, token) catch return;
+    _ = stmt.step() catch {};
+}
+
 /// Probe registered taps for a cask token whose row in `casks` has no
-/// tap origin column to consult. Returns true if a tap claimed the
-/// token and the upgrade went through; returns false if no third-party
+/// recorded tap origin (legacy v5 install, pre-schema-v6). Returns true
+/// if a tap claimed the token and the upgrade resolved (installed *or*
+/// skipped at the matching version); returns false if no third-party
 /// tap had `Casks/<token>.rb` so the caller can surface the original
-/// "removed upstream" error.
+/// "removed upstream" error. On a successful match the column is
+/// backfilled so the next upgrade pre-routes directly.
 fn upgradeTapCaskFallback(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
     token: []const u8,
+    installed_version: []const u8,
     db: *sqlite.Database,
     prefix: [:0]const u8,
     dry_run: bool,
+    force: bool,
 ) bool {
     const taps = tap_mod.list(allocator, db) catch return false;
     defer {
@@ -559,24 +670,16 @@ fn upgradeTapCaskFallback(
     for (taps) |t| {
         if (install_args_mod.isCoreTap(t.name)) continue;
 
-        const slash = std.mem.indexOfScalar(u8, t.name, '/') orelse continue;
-        if (slash == 0 or slash == t.name.len - 1) continue;
+        upgradeRoutedTapCask(ctx, allocator, token, t.name, installed_version, db, prefix, dry_run, force) catch |e| switch (e) {
+            // Either "tap doesn't own this token" or "something went
+            // wrong with this tap" — neither is fatal to the probe.
+            error.NotInTap, error.Aborted => continue,
+        };
 
-        const urls = tap_mod.resolveTapBaseUrls(allocator, t.name) catch continue;
-        defer urls.deinit(allocator);
-
-        // Resolve fresh HEAD per-tap. Failures are non-fatal — try the next.
-        const fresh_sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url) catch continue;
-        defer allocator.free(fresh_sha);
-
-        tap_mod.add(db, t.name, urls.repo_url, fresh_sha) catch continue;
-
-        const full_name = std.fmt.allocPrint(allocator, "{s}/{s}", .{ t.name, token }) catch continue;
-        defer allocator.free(full_name);
-
-        var linker = linker_mod.Linker.init(ctx.io, allocator, db, prefix);
-        install_local_mod.installTapFormula(ctx, allocator, full_name, db, &linker, prefix, dry_run, true) catch continue;
-
+        // The owning tap is now known. recordInstall sets `casks.tap`
+        // automatically for the install branch; backfillCaskTap covers
+        // the version-match-skip branch where no recordInstall ran.
+        backfillCaskTap(db, token, t.name);
         return true;
     }
 
@@ -776,11 +879,30 @@ fn upgradeCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []const 
         return error.Aborted;
     };
 
-    // Fetch latest version. Casks have no `tap` column on the table, so
-    // we can't pre-route the way the formula path does — fall back to
-    // probing every registered third-party tap if the core API 404s.
+    // Pre-route when the recorded `casks.tap` points at a third-party
+    // tap — saves the multi-tap probe loop and, more importantly, the
+    // version compare runs against the owning tap's `.rb` before any
+    // DMG download starts. Legacy rows (NULL tap, pre-v6 install) and
+    // core-API casks fall through to the API path below.
+    if (installed.tap()) |tap_label| {
+        if (!install_args_mod.isCoreTap(tap_label)) {
+            upgradeRoutedTapCask(ctx, allocator, token, tap_label, installed.version(), db, prefix, dry_run, force) catch |e| switch (e) {
+                error.NotInTap => {
+                    output.err("Cask {s} is no longer in tap {s}", .{ token, tap_label });
+                    return error.Aborted;
+                },
+                error.Aborted => return error.Aborted,
+            };
+            return;
+        }
+    }
+
+    // Fetch latest version. Casks have no `tap` column populated on
+    // legacy installs, so we still fall back to probing every registered
+    // third-party tap if the core API 404s — the probe also backfills
+    // `casks.tap` for the next invocation.
     const cask_json = api.fetchCask(token) catch {
-        if (upgradeTapCaskFallback(ctx, allocator, token, db, prefix, dry_run)) return;
+        if (upgradeTapCaskFallback(ctx, allocator, token, installed.version(), db, prefix, dry_run, force)) return;
         output.err("Could not fetch cask info for {s}", .{token});
         return error.Aborted;
     };
@@ -843,7 +965,10 @@ fn upgradeCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []const 
         return error.Aborted;
     };
 
-    cask_mod.recordInstall(db, &parsed_cask, app_path) catch |rec_err| {
+    // Reaching this point implies the core Homebrew API served the
+    // cask, so the tap origin stays NULL. Tap-installed casks pre-route
+    // to `upgradeTapCask` and never get here.
+    cask_mod.recordInstall(db, &parsed_cask, app_path, null) catch |rec_err| {
         output.err(
             "Failed to record cask {s} in database: {s} ({s})",
             .{ token, @errorName(rec_err), db.errMsg() },

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -654,7 +654,7 @@ fn upgradeRoutedTapCask(
 /// Backfill the `casks.tap` column once we've discovered the owning tap
 /// via the probe loop. Idempotent (`WHERE tap IS NULL`); failures are
 /// non-fatal — the row stays NULL and we re-probe on the next upgrade.
-fn backfillCaskTap(db: *sqlite.Database, token: []const u8, tap_label: []const u8) void {
+pub fn backfillCaskTap(db: *sqlite.Database, token: []const u8, tap_label: []const u8) void {
     var stmt = db.prepare("UPDATE casks SET tap = ?1 WHERE token = ?2 AND tap IS NULL;") catch return;
     defer stmt.finalize();
     stmt.bindText(1, tap_label) catch return;

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -632,8 +632,11 @@ fn upgradeRoutedTapCask(
     };
     defer allocator.free(full_name);
 
+    // `installTapCask` (not `installTapFormula`) so the resolver
+    // never enters the Formula/ probe that would open a nested DB
+    // transaction inside our outer one.
     var linker = linker_mod.Linker.init(ctx.io, allocator, db, prefix);
-    install_local_mod.installTapFormula(ctx, allocator, full_name, db, &linker, prefix, dry_run, true) catch |in_err| {
+    install_local_mod.installTapCask(ctx, allocator, full_name, db, &linker, prefix, dry_run, true) catch |in_err| {
         output.err("Failed to upgrade tap cask {s}: {s}", .{ full_name, @errorName(in_err) });
         db.rollback();
         return error.Aborted;

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -563,8 +563,13 @@ fn upgradeRoutedTapCask(
     defer urls.deinit(allocator);
 
     // Always force-resolve HEAD: the whole point of `mt upgrade` is
-    // "give me the latest", so we ignore any cached pin here.
-    const fresh_sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url) catch return error.Aborted;
+    // "give me the latest", so we ignore any cached pin here. Same
+    // error shape as `upgradeTapFormula` so probe-loop callers can
+    // grep for the resolve failure consistently.
+    const fresh_sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url) catch |e| {
+        output.err("Could not resolve {s} HEAD: {s}", .{ tap_label, tap_mod.describeResolveError(e) });
+        return error.Aborted;
+    };
     defer allocator.free(fresh_sha);
 
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
@@ -573,7 +578,10 @@ fn upgradeRoutedTapCask(
     var rb_url_buf: [512]u8 = undefined;
     const rb_url = std.fmt.bufPrint(&rb_url_buf, "{s}/{s}/Casks/{s}.rb", .{ urls.raw_base, fresh_sha, token }) catch return error.Aborted;
 
-    var rb_resp = http.get(rb_url) catch return error.Aborted;
+    var rb_resp = http.get(rb_url) catch |e| {
+        output.err("Could not fetch {s} from tap {s}: {s}", .{ token, tap_label, @errorName(e) });
+        return error.Aborted;
+    };
     defer rb_resp.deinit();
     if (rb_resp.status != 200) return error.NotInTap;
 
@@ -607,24 +615,35 @@ fn upgradeRoutedTapCask(
     // Mirrors the core-API path in `upgradeCask` so a partial failure
     // can't leave the casks row missing once the new app is on disk.
     var installer = cask_mod.CaskInstaller.init(ctx.io, ctx.environ, allocator, db, prefix);
-    db.beginTransaction() catch return error.Aborted;
-    errdefer db.rollback();
-
-    installer.uninstall(token) catch {
-        output.err("Failed to remove old version of {s}", .{token});
+    db.beginTransaction() catch |txn_err| {
+        output.err("Could not begin DB transaction for {s}: {s} ({s})", .{ token, @errorName(txn_err), db.errMsg() });
         return error.Aborted;
     };
 
-    const full_name = std.fmt.allocPrint(allocator, "{s}/{s}", .{ tap_label, token }) catch return error.Aborted;
+    installer.uninstall(token) catch |un_err| {
+        output.err("Failed to remove old version of {s}: {s}", .{ token, @errorName(un_err) });
+        db.rollback();
+        return error.Aborted;
+    };
+
+    const full_name = std.fmt.allocPrint(allocator, "{s}/{s}", .{ tap_label, token }) catch {
+        db.rollback();
+        return error.Aborted;
+    };
     defer allocator.free(full_name);
 
     var linker = linker_mod.Linker.init(ctx.io, allocator, db, prefix);
-    install_local_mod.installTapFormula(ctx, allocator, full_name, db, &linker, prefix, dry_run, true) catch {
-        output.err("Failed to upgrade tap cask {s}", .{full_name});
+    install_local_mod.installTapFormula(ctx, allocator, full_name, db, &linker, prefix, dry_run, true) catch |in_err| {
+        output.err("Failed to upgrade tap cask {s}: {s}", .{ full_name, @errorName(in_err) });
+        db.rollback();
         return error.Aborted;
     };
 
-    db.commit() catch return error.Aborted;
+    db.commit() catch |commit_err| {
+        output.err("Failed to commit upgrade for cask {s}: {s} ({s})", .{ token, @errorName(commit_err), db.errMsg() });
+        db.rollback();
+        return error.Aborted;
+    };
 
     if (was_pinned) _ = pin_mod.setPinned(db, token, true) catch {};
 }

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -69,11 +69,20 @@ pub fn parseCask(allocator: std.mem.Allocator, json_bytes: []const u8) !Cask {
 /// Record cask installation in database.
 /// The COALESCE subquery on `pinned` carries any existing user pin
 /// across INSERT OR REPLACE so a force-upgrade doesn't silently clear
-/// the hold; first-time installs default to 0.
-pub fn recordInstall(db: *sqlite.Database, cask: *const Cask, app_path: ?[]const u8) sqlite.SqliteError!void {
+/// the hold; first-time installs default to 0. `tap` is NULL for casks
+/// installed from the core Homebrew API and the tap label
+/// (`user/repo`) for those installed from a third-party tap — read at
+/// upgrade time so `mt upgrade <token>` can pre-route to the owning
+/// tap without probing the rest of the registered list.
+pub fn recordInstall(
+    db: *sqlite.Database,
+    cask: *const Cask,
+    app_path: ?[]const u8,
+    tap: ?[]const u8,
+) sqlite.SqliteError!void {
     var stmt = try db.prepare(
-        "INSERT OR REPLACE INTO casks (token, name, version, url, sha256, app_path, auto_updates, pinned)" ++
-            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, COALESCE((SELECT pinned FROM casks WHERE token = ?1), 0));",
+        "INSERT OR REPLACE INTO casks (token, name, version, url, sha256, app_path, auto_updates, pinned, tap)" ++
+            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, COALESCE((SELECT pinned FROM casks WHERE token = ?1), 0), ?8);",
     );
     defer stmt.finalize();
 
@@ -84,6 +93,7 @@ pub fn recordInstall(db: *sqlite.Database, cask: *const Cask, app_path: ?[]const
     if (cask.sha256) |s| try stmt.bindText(5, s) else try stmt.bindNull(5);
     if (app_path) |p| try stmt.bindText(6, p) else try stmt.bindNull(6);
     try stmt.bindInt(7, if (cask.auto_updates) 1 else 0);
+    if (tap) |t| try stmt.bindText(8, t) else try stmt.bindNull(8);
     _ = try stmt.step();
 }
 
@@ -809,6 +819,9 @@ pub const InstalledCask = struct {
     app_path_buf: [512]u8 = undefined,
     app_path_len: usize = 0,
     has_app_path: bool = false,
+    tap_buf: [128]u8 = undefined,
+    tap_len: usize = 0,
+    has_tap: bool = false,
 
     pub fn version(self: *const InstalledCask) []const u8 {
         return self.version_buf[0..self.version_len];
@@ -818,12 +831,20 @@ pub const InstalledCask = struct {
         if (!self.has_app_path) return null;
         return self.app_path_buf[0..self.app_path_len];
     }
+
+    /// Owning tap label (`user/repo`) or null when the cask was
+    /// installed from the core Homebrew API. Drives `mt upgrade`'s
+    /// pre-routing decision — non-null skips the multi-tap probe loop.
+    pub fn tap(self: *const InstalledCask) ?[]const u8 {
+        if (!self.has_tap) return null;
+        return self.tap_buf[0..self.tap_len];
+    }
 };
 
 /// Look up installed cask info from DB. Copies data to avoid dangling pointers.
 pub fn lookupInstalled(db: *sqlite.Database, token: []const u8) ?InstalledCask {
     var stmt = db.prepare(
-        "SELECT version, app_path FROM casks WHERE token = ?1 LIMIT 1;",
+        "SELECT version, app_path, tap FROM casks WHERE token = ?1 LIMIT 1;",
     ) catch return null;
     defer stmt.finalize();
     stmt.bindText(1, token) catch return null;
@@ -845,6 +866,15 @@ pub fn lookupInstalled(db: *sqlite.Database, token: []const u8) ?InstalledCask {
             @memcpy(result.app_path_buf[0..path_slice.len], path_slice);
             result.app_path_len = path_slice.len;
             result.has_app_path = true;
+        }
+    }
+
+    if (stmt.columnText(2)) |tap_ptr| {
+        const tap_slice = std.mem.sliceTo(tap_ptr, 0);
+        if (tap_slice.len <= result.tap_buf.len) {
+            @memcpy(result.tap_buf[0..tap_slice.len], tap_slice);
+            result.tap_len = tap_slice.len;
+            result.has_tap = true;
         }
     }
 

--- a/src/db/schema.zig
+++ b/src/db/schema.zig
@@ -35,7 +35,8 @@ pub fn initSchema(db: *sqlite.Database) MigrateError!void {
     try db.exec("CREATE INDEX IF NOT EXISTS idx_kegs_name ON kegs(name);");
     try db.exec("CREATE INDEX IF NOT EXISTS idx_kegs_store ON kegs(store_sha256);");
 
-    // 3. casks
+    // 3. casks. `pinned` is added by v4, `tap` by v6 — both ALTERs are
+    //    PRAGMA-guarded so fresh and upgraded DBs converge.
     try db.exec(
         \\CREATE TABLE IF NOT EXISTS casks (
         \\    id            INTEGER PRIMARY KEY,
@@ -101,7 +102,7 @@ pub fn initSchema(db: *sqlite.Database) MigrateError!void {
 /// Highest schema version this binary knows how to operate on. Bump in
 /// lockstep with the last `migrateVNtoVN+1` step so a future binary's
 /// DB doesn't get silently used against older SQL.
-pub const known_schema_version: i64 = 5;
+pub const known_schema_version: i64 = 6;
 
 pub const MigrateError = sqlite.SqliteError || error{SchemaTooNew};
 
@@ -116,6 +117,7 @@ pub fn migrate(db: *sqlite.Database) MigrateError!void {
     if (ver < 3) try migrateV2toV3(db);
     if (ver < 4) try migrateV3toV4(db);
     if (ver < 5) try migrateV4toV5(db);
+    if (ver < 6) try migrateV5toV6(db);
 }
 
 fn migrateV1toV2(db: *sqlite.Database) sqlite.SqliteError!void {
@@ -312,6 +314,35 @@ fn migrateV4toV5(db: *sqlite.Database) sqlite.SqliteError!void {
         defer stmt.finalize();
         if (try stmt.step()) return sqlite.SqliteError.ConstraintViolation;
     }
+
+    try db.commit();
+}
+
+/// v6 — record the originating tap on every cask row so `mt upgrade`
+/// can pre-route directly to the owning tap instead of probing every
+/// registered tap on each invocation. Legacy rows stay NULL until the
+/// next upgrade fills them in via the fallback probe.
+fn migrateV5toV6(db: *sqlite.Database) sqlite.SqliteError!void {
+    try db.beginTransaction();
+    errdefer db.rollback();
+
+    var have_column = false;
+    {
+        var stmt = try db.prepare("PRAGMA table_info(casks);");
+        defer stmt.finalize();
+        while (try stmt.step()) {
+            const name = stmt.columnText(1) orelse continue;
+            if (std.mem.eql(u8, std.mem.sliceTo(name, 0), "tap")) {
+                have_column = true;
+                break;
+            }
+        }
+    }
+    if (!have_column) {
+        try db.exec("ALTER TABLE casks ADD COLUMN tap TEXT;");
+    }
+
+    try db.exec("INSERT OR IGNORE INTO schema_version (version) VALUES (6);");
 
     try db.commit();
 }

--- a/tests/backup_cli_test.zig
+++ b/tests/backup_cli_test.zig
@@ -258,3 +258,54 @@ test "execute -q sets quiet mode without breaking the write" {
     defer testing.allocator.free(body);
     try testing.expect(std.mem.indexOf(u8, body, "formula wget") != null);
 }
+
+// `mt restore` re-feeds the backup file through `mt install`. For tap
+// casks, the unqualified token would 404 against the core API, so the
+// backup line must carry the `user/repo/token` slug shape that
+// `installTapFormula` resolves. The bare-token form is preserved for
+// core-API casks so backups produced before schema v6 keep working.
+fn seedTapCask(prefix: []const u8) !void {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO casks (token, name, version, url, sha256, tap)
+        \\VALUES ('flux-markdown', 'flux-markdown', '0.1.0',
+        \\        'https://example.invalid/flux.dmg', 'aa', 'xykong/tap');
+    );
+    try db.exec(
+        \\INSERT INTO casks (token, name, version, url, sha256)
+        \\VALUES ('firefox', 'Firefox', '120.0', 'https://example/firefox.dmg', 'bb');
+    );
+}
+
+test "execute writes tap casks as <user>/<repo>/<token> so restore re-routes correctly" {
+    var s = try Scratch.init(testing.allocator, "tap_cask_slug");
+    defer s.deinit(testing.allocator);
+    try seedTapCask(s.path);
+
+    const out_path = try std.fmt.allocPrint(testing.allocator, "{s}/snap.txt", .{s.path});
+    defer testing.allocator.free(out_path);
+
+    quiet();
+    defer unquiet();
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--output", out_path });
+
+    const body = try readAll(testing.allocator, out_path);
+    defer testing.allocator.free(body);
+
+    // Tap cask: fully-qualified slug so restore routes through
+    // `installTapFormula`.
+    try testing.expect(std.mem.indexOf(u8, body, "cask xykong/tap/flux-markdown") != null);
+
+    // Bare-token form preserved for the core-API cask alongside.
+    try testing.expect(std.mem.indexOf(u8, body, "cask firefox\n") != null);
+
+    // Negative: the tap cask must NOT also surface in the unqualified
+    // form, otherwise restore would attempt both and the bare-token
+    // attempt would 404 against the core API.
+    try testing.expect(std.mem.indexOf(u8, body, "cask flux-markdown\n") == null);
+}

--- a/tests/cask_extra_test.zig
+++ b/tests/cask_extra_test.zig
@@ -131,7 +131,7 @@ test "CaskInstaller.uninstall removes app_path, caskroom, cache, and the DB row"
     defer testing.allocator.free(app_path_z);
     try test_io.makeDirAbsolute(std.Options.debug_io, app_path_z);
 
-    try cask.recordInstall(&db, &c, app_path_z);
+    try cask.recordInstall(&db, &c, app_path_z, null);
     try testing.expect(cask.isInstalled(&db, "firefox"));
 
     const prefix: [:0]const u8 = "/tmp/mc-uninstall";

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -158,7 +158,7 @@ test "recordInstall preserves an existing pinned flag (force-upgrade keeps the h
     // Simulate a force-upgrade rewriting the row at version 200.
     var c2 = try cask.parseCask(std.testing.allocator, test_cask_json_v2);
     defer c2.deinit();
-    try cask.recordInstall(&t.db, &c2, "/Applications/Firefox.app");
+    try cask.recordInstall(&t.db, &c2, "/Applications/Firefox.app", null);
 
     try std.testing.expectEqual(true, try readCaskPinned(&t.db, "firefox"));
 }
@@ -172,7 +172,7 @@ test "recordInstall on a fresh cask defaults pinned to 0" {
 
     var c2 = try cask.parseCask(std.testing.allocator, test_cask_json_v2);
     defer c2.deinit();
-    try cask.recordInstall(&t.db, &c2, "/Applications/Firefox.app");
+    try cask.recordInstall(&t.db, &c2, "/Applications/Firefox.app", null);
 
     try std.testing.expectEqual(false, try readCaskPinned(&t.db, "firefox"));
 }
@@ -317,12 +317,27 @@ test "recordInstall and lookupInstalled round-trip" {
     var c = try cask.parseCask(std.testing.allocator, test_cask_json);
     defer c.deinit();
 
-    try cask.recordInstall(&db, &c, "/Applications/Firefox.app");
+    try cask.recordInstall(&db, &c, "/Applications/Firefox.app", null);
 
     const info = cask.lookupInstalled(&db, "firefox");
     try std.testing.expect(info != null);
     try std.testing.expectEqualStrings("123.0", info.?.version());
     try std.testing.expectEqualStrings("/Applications/Firefox.app", info.?.appPath().?);
+    try std.testing.expect(info.?.tap() == null);
+}
+
+test "recordInstall stores the owning tap for third-party-tap casks" {
+    var db = try openTestDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var c = try cask.parseCask(std.testing.allocator, test_cask_json);
+    defer c.deinit();
+
+    try cask.recordInstall(&db, &c, "/Applications/Firefox.app", "xykong/tap");
+
+    const info = cask.lookupInstalled(&db, "firefox").?;
+    try std.testing.expectEqualStrings("xykong/tap", info.tap().?);
 }
 
 test "isInstalled returns true after recordInstall" {
@@ -334,7 +349,7 @@ test "isInstalled returns true after recordInstall" {
     defer c.deinit();
 
     try std.testing.expect(!cask.isInstalled(&db, "firefox"));
-    try cask.recordInstall(&db, &c, "/Applications/Firefox.app");
+    try cask.recordInstall(&db, &c, "/Applications/Firefox.app", null);
     try std.testing.expect(cask.isInstalled(&db, "firefox"));
 }
 
@@ -346,7 +361,7 @@ test "removeRecord removes cask from DB" {
     var c = try cask.parseCask(std.testing.allocator, test_cask_json);
     defer c.deinit();
 
-    try cask.recordInstall(&db, &c, "/Applications/Firefox.app");
+    try cask.recordInstall(&db, &c, "/Applications/Firefox.app", null);
     try std.testing.expect(cask.isInstalled(&db, "firefox"));
 
     try cask.removeRecord(&db, "firefox");
@@ -365,7 +380,7 @@ test "recordInstall surfaces SqliteError when schema is missing" {
 
     try std.testing.expectError(
         sqlite.SqliteError.PrepareFailed,
-        cask.recordInstall(&db, &c, "/Applications/Firefox.app"),
+        cask.recordInstall(&db, &c, "/Applications/Firefox.app", null),
     );
 }
 
@@ -389,7 +404,7 @@ test "isOutdated detects version mismatch" {
     var c = try cask.parseCask(std.testing.allocator, test_cask_json);
     defer c.deinit();
 
-    try cask.recordInstall(&db, &c, "/Applications/Firefox.app");
+    try cask.recordInstall(&db, &c, "/Applications/Firefox.app", null);
 
     const prefix: [:0]const u8 = "/tmp/malt_test";
     var threaded: std.Io.Threaded = .init(std.testing.allocator, .{ .environ = malt.app_ctx.processEnviron() });

--- a/tests/db_schema_v2_test.zig
+++ b/tests/db_schema_v2_test.zig
@@ -41,7 +41,7 @@ fn tableExists(db: *sqlite.Database, name: [:0]const u8) !bool {
     return stmt.columnInt(0) == 1;
 }
 
-test "initSchema runs v1 then migrates to v5" {
+test "initSchema runs v1 then migrates to v6" {
     var tdb = try TempDb.init("init");
     defer tdb.deinit();
 
@@ -53,7 +53,7 @@ test "initSchema runs v1 then migrates to v5" {
     try testing.expect(try tableExists(&tdb.db, "bundle_members"));
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 5), ver);
+    try testing.expectEqual(@as(i64, 6), ver);
 }
 
 test "migrate is idempotent on re-run" {
@@ -65,7 +65,7 @@ test "migrate is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 5), ver);
+    try testing.expectEqual(@as(i64, 6), ver);
 }
 
 test "v4 migration adds pinned column to casks" {
@@ -95,7 +95,51 @@ test "v4 migration is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 5), ver);
+    try testing.expectEqual(@as(i64, 6), ver);
+}
+
+test "v6 migration adds tap column to casks" {
+    var tdb = try TempDb.init("v6_casks_tap");
+    defer tdb.deinit();
+
+    try schema.initSchema(&tdb.db);
+
+    // INSERT exercising the new column proves the ALTER landed.
+    try tdb.db.exec(
+        \\INSERT INTO casks(token, name, version, url, tap)
+        \\VALUES ('flux-markdown', 'flux-markdown', '0.1.0',
+        \\        'https://example.invalid/flux.dmg', 'xykong/tap');
+    );
+
+    var stmt = try tdb.db.prepare("SELECT tap FROM casks WHERE token='flux-markdown';");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    const raw = stmt.columnText(0) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings("xykong/tap", std.mem.sliceTo(raw, 0));
+}
+
+test "v6 migration leaves legacy casks with tap NULL" {
+    var tdb = try TempDb.init("v6_legacy_null");
+    defer tdb.deinit();
+
+    // Apply schema then reset version + drop column to simulate a v5 DB.
+    try schema.initSchema(&tdb.db);
+    try tdb.db.exec("DELETE FROM schema_version WHERE version >= 6;");
+
+    // Seed a row in v5-shape (no tap column awareness).
+    try tdb.db.exec(
+        \\INSERT INTO casks(token, name, version, url)
+        \\VALUES ('firefox', 'firefox', '123.0', 'https://example.invalid');
+    );
+
+    // Re-run migrate — should detect "still need v6" and re-apply
+    // idempotently without breaking the row.
+    try schema.migrate(&tdb.db);
+
+    var stmt = try tdb.db.prepare("SELECT tap FROM casks WHERE token='firefox';");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    try testing.expect(stmt.columnText(0) == null);
 }
 
 test "v3 migration adds commit_sha column to taps" {

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -310,6 +310,42 @@ test "loadCaskRows .all returns every installed cask" {
     try testing.expectEqualStrings("loose-cask", rows[1].name);
 }
 
+// Pre-routing in `mt outdated` mirrors the upgrade path: a row whose
+// `casks.tap` is non-null gets its latest version resolved against the
+// owning tap's `.rb`, so a tap-cask version bump shows up in the audit
+// instead of being silently dropped by the core-API 404 path.
+test "loadCaskRows surfaces the owning tap when set" {
+    const path = try setupPinnedPrefix("cask_tap_column");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try db.exec(
+        \\INSERT INTO casks(token, name, version, url, tap)
+        \\VALUES ('flux-markdown', 'flux-markdown', '0.1.0',
+        \\        'https://example.invalid/flux.dmg', 'xykong/tap');
+    );
+    try db.exec(
+        \\INSERT INTO casks(token, name, version, url)
+        \\VALUES ('legacy-cask', 'legacy-cask', '1.0',
+        \\        'https://example.invalid/legacy.dmg');
+    );
+
+    const rows = try outdated_mod.loadCaskRows(testing.allocator, &db, .all);
+    defer outdated_mod.freeKegRows(testing.allocator, rows);
+
+    try testing.expectEqual(@as(usize, 2), rows.len);
+    // ORDER BY token: 'flux-markdown' < 'legacy-cask' alphabetically.
+    try testing.expectEqualStrings("flux-markdown", rows[0].name);
+    try testing.expect(rows[0].tap != null);
+    try testing.expectEqualStrings("xykong/tap", rows[0].tap.?);
+
+    try testing.expectEqualStrings("legacy-cask", rows[1].name);
+    try testing.expect(rows[1].tap == null);
+}
+
 test "outdated execute --pinned-only walks pinned casks alongside formulas" {
     const path = try setupPinnedPrefix("exec_pinned_mixed");
     defer testing.allocator.free(path);

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -250,7 +250,7 @@ test "force-upgrade-cask orchestration: pin survives removeRecord + recordInstal
         \\}
     );
     defer c2.deinit();
-    try malt.cask.recordInstall(&db, &c2, "/Applications/Firefox.app");
+    try malt.cask.recordInstall(&db, &c2, "/Applications/Firefox.app", null);
 
     // Step 3: orchestration must reapply the pin.
     if (was_pinned) {

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -853,3 +853,68 @@ test "upgrade <pinned-tap-keg> short-circuits without resolving HEAD" {
     // Pinned + non-force = quiet skip on the tap branch too.
     try upgrade.execute(&ctx, testing.allocator, &.{"frozen-tap"});
 }
+
+// `backfillCaskTap` is the lazy-attribution writer the v5-row fallback
+// probe relies on: once it discovers the owning tap, subsequent
+// upgrades must pre-route directly instead of probing every registered
+// tap again. The pure SQL check sidesteps the network surface and pins
+// both the success and the WHERE-tap-IS-NULL idempotence guard.
+fn readCaskTap(db: *sqlite.Database, token: []const u8) !?[]u8 {
+    var stmt = try db.prepare("SELECT tap FROM casks WHERE token = ?1 LIMIT 1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, token);
+    _ = try stmt.step();
+    const raw = stmt.columnText(0) orelse return null;
+    const slice = std.mem.sliceTo(raw, 0);
+    return try testing.allocator.dupe(u8, slice);
+}
+
+test "backfillCaskTap writes the tap label on a NULL row" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO casks(token, name, version, url)
+        \\VALUES ('legacy', 'legacy', '1.0', 'https://example.invalid/x.dmg');
+    );
+
+    upgrade.backfillCaskTap(&db, "legacy", "xykong/tap");
+
+    const got = try readCaskTap(&db, "legacy") orelse return error.TestUnexpectedResult;
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("xykong/tap", got);
+}
+
+test "backfillCaskTap leaves an already-set row alone (WHERE tap IS NULL)" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO casks(token, name, version, url, tap)
+        \\VALUES ('claimed', 'claimed', '1.0', 'https://example.invalid/x.dmg',
+        \\        'first-owner/tap');
+    );
+
+    // Try to overwrite — the guard must keep the row's original tap.
+    upgrade.backfillCaskTap(&db, "claimed", "different-owner/tap");
+
+    const got = try readCaskTap(&db, "claimed") orelse return error.TestUnexpectedResult;
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("first-owner/tap", got);
+}
+
+test "backfillCaskTap on an absent token is a silent no-op" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    // No INSERT — the UPDATE matches zero rows, must not raise.
+    upgrade.backfillCaskTap(&db, "never-installed", "x/y");
+
+    var stmt = try db.prepare("SELECT COUNT(*) FROM casks;");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    try testing.expectEqual(@as(i64, 0), stmt.columnInt(0));
+}


### PR DESCRIPTION
## Description

Three connected fixes that share the same root cause - the `casks` table had no `tap` column, so every code path that wanted to ask "which tap owns this cask?" either probed every registered tap or silently dropped tap casks on the floor.

**1. `mt upgrade <tap-cask>` no longer re-downloads on every run.**

Schema v6 adds `casks.tap`. `upgradeCask` pre-routes via the column the same way `upgradeFormula` already uses `kegs.tap`, fetches the small `Casks/<token>.rb`, compares versions, and short-circuits with `is already at latest version` before any DMG fetch starts.

**2. `mt outdated` reports tap casks accurately.**

The cask side of `mt outdated` called `api.fetchCask(token)` unconditionally - tap casks 404'd and got silently classified as up-to-date. Now the audit pre-routes through the same tap-routed path as upgrade.

**3. `mt backup` / `mt restore` round-trip the owning tap.**

Backup wrote `cask <token>` only, so a tap cask lost its origin. Restore then 404'd against the core API. The backup line now carries the qualified slug shape `cask <user>/<repo>/<token>` for tap casks; restore routes through `installTapFormula` unchanged.

Legacy v5-era rows with `tap = NULL` go through the existing multi-tap probe loop on first touch; the probe's success path now backfills the column so subsequent commands pre-route directly.

## Related Issue

- None

## Notes for Reviewers

- None