### PR TITLE
refactor(info): surface owning tap for casks in mt info

### DIFF
--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -470,39 +470,86 @@ fn writeJsonInfo(
     try stdout.writeAll("}\n");
 }
 
+/// One installed cask row as the info-render path consumes it. Slices
+/// borrow from a live `sqlite.Statement` — populate via `readInstalledCaskRow`
+/// and hand straight to an encoder; do not retain past `stmt.step`/`finalize`.
+pub const InstalledCaskRow = struct {
+    token: []const u8,
+    name: []const u8,
+    version: ?[]const u8 = null,
+    url: ?[]const u8 = null,
+    app_path: ?[]const u8 = null,
+    auto_updates: bool = false,
+    installed_at: ?[]const u8 = null,
+};
+
+/// Resolved column count is encoded in the `WHERE`-ordered SELECT below.
+const installed_cask_select =
+    "SELECT token, name, version, url, app_path, auto_updates, installed_at " ++
+    "FROM casks WHERE token = ?1 LIMIT 1;";
+
+fn readInstalledCaskRow(stmt: *sqlite.Statement, fallback_name: []const u8) InstalledCaskRow {
+    return .{
+        .token = if (stmt.columnText(0)) |t| std.mem.sliceTo(t, 0) else fallback_name,
+        .name = if (stmt.columnText(1)) |n| std.mem.sliceTo(n, 0) else fallback_name,
+        .version = if (stmt.columnText(2)) |v| std.mem.sliceTo(v, 0) else null,
+        .url = if (stmt.columnText(3)) |u| std.mem.sliceTo(u, 0) else null,
+        .app_path = if (stmt.columnText(4)) |p| std.mem.sliceTo(p, 0) else null,
+        .auto_updates = stmt.columnBool(5),
+        .installed_at = if (stmt.columnText(6)) |d| std.mem.sliceTo(d, 0) else null,
+    };
+}
+
+pub fn encodeInstalledCaskHuman(
+    w: *std.Io.Writer,
+    scratch: []u8,
+    row: *const InstalledCaskRow,
+    colorize: bool,
+) !void {
+    // "Auto-updates:" is the longest key (13 chars incl. colon), value at col 14.
+    const col: usize = 14;
+    try encodeHeader(w, colorize, row.token, "", row.version orelse "unknown", "(cask)");
+    try output.writeField(w, scratch, colorize, col, "Name", "{s}", .{row.name});
+    try output.writeField(w, scratch, colorize, col, "URL", "{s}", .{row.url orelse "N/A"});
+    try output.writeField(w, scratch, colorize, col, "App", "{s}", .{row.app_path orelse "N/A"});
+    if (row.auto_updates) try output.writeField(w, scratch, colorize, col, "Auto-updates", "yes", .{});
+    try output.writeField(w, scratch, colorize, col, "Installed", "{s}", .{row.installed_at orelse "N/A"});
+}
+
+pub fn encodeInstalledCaskJson(w: *std.Io.Writer, row: *const InstalledCaskRow) !void {
+    try w.writeAll("{\"name\":");
+    try output.jsonStr(w, row.token);
+    try w.writeAll(",\"type\":\"cask\",\"installed\":true,\"version\":");
+    try output.jsonStr(w, row.version orelse "");
+    try w.writeAll(",\"full_name\":");
+    try output.jsonStr(w, row.name);
+    try w.writeAll(",\"url\":");
+    try output.jsonStr(w, row.url orelse "");
+    try w.writeAll(",\"app_path\":");
+    try output.jsonStr(w, row.app_path orelse "");
+    try w.writeAll(",\"auto_updates\":");
+    try w.writeAll(if (row.auto_updates) "true" else "false");
+    try w.writeAll(",\"installed_at\":");
+    try output.jsonStr(w, row.installed_at orelse "");
+    try w.writeAll("}\n");
+}
+
 fn writeHumanCaskInfo(
     db: *sqlite.Database,
     name: []const u8,
     stdout: *std.Io.Writer,
     colorize: bool,
 ) !void {
-    var stmt = db.prepare(
-        "SELECT token, name, version, url, sha256, app_path, auto_updates, installed_at FROM casks WHERE token = ?1 LIMIT 1;",
-    ) catch return;
+    var stmt = db.prepare(installed_cask_select) catch return;
     defer stmt.finalize();
     stmt.bindText(1, name) catch return;
 
     const found = stmt.step() catch false;
     if (!found) return;
 
+    const row = readInstalledCaskRow(&stmt, name);
     var buf: [4096]u8 = undefined;
-    // "Auto-updates:" is the longest key (13 chars incl. colon), value at col 14.
-    const col: usize = 14;
-
-    const token = if (stmt.columnText(0)) |t| std.mem.sliceTo(t, 0) else name;
-    const cask_name = if (stmt.columnText(1)) |n| std.mem.sliceTo(n, 0) else name;
-    const ver = if (stmt.columnText(2)) |v| std.mem.sliceTo(v, 0) else "unknown";
-    const url = if (stmt.columnText(3)) |u| std.mem.sliceTo(u, 0) else "N/A";
-    const app_path = if (stmt.columnText(5)) |p| std.mem.sliceTo(p, 0) else "N/A";
-    const auto_updates = stmt.columnBool(6);
-    const installed_at = if (stmt.columnText(7)) |d| std.mem.sliceTo(d, 0) else "N/A";
-
-    try encodeHeader(stdout, colorize, token, "", ver, "(cask)");
-    try output.writeField(stdout, &buf, colorize, col, "Name", "{s}", .{cask_name});
-    try output.writeField(stdout, &buf, colorize, col, "URL", "{s}", .{url});
-    try output.writeField(stdout, &buf, colorize, col, "App", "{s}", .{app_path});
-    if (auto_updates) try output.writeField(stdout, &buf, colorize, col, "Auto-updates", "yes", .{});
-    try output.writeField(stdout, &buf, colorize, col, "Installed", "{s}", .{installed_at});
+    try encodeInstalledCaskHuman(stdout, &buf, &row, colorize);
 }
 
 fn writeJsonCaskInfo(
@@ -510,36 +557,13 @@ fn writeJsonCaskInfo(
     name: []const u8,
     stdout: *std.Io.Writer,
 ) !void {
-    var stmt = db.prepare(
-        "SELECT token, name, version, url, sha256, app_path, auto_updates, installed_at FROM casks WHERE token = ?1 LIMIT 1;",
-    ) catch return;
+    var stmt = db.prepare(installed_cask_select) catch return;
     defer stmt.finalize();
     stmt.bindText(1, name) catch return;
 
     const found = stmt.step() catch false;
     if (!found) return;
 
-    const token = if (stmt.columnText(0)) |t| std.mem.sliceTo(t, 0) else name;
-    const cask_name = if (stmt.columnText(1)) |n| std.mem.sliceTo(n, 0) else name;
-    const ver = if (stmt.columnText(2)) |v| std.mem.sliceTo(v, 0) else "";
-    const url = if (stmt.columnText(3)) |u| std.mem.sliceTo(u, 0) else "";
-    const app_path = if (stmt.columnText(5)) |p| std.mem.sliceTo(p, 0) else "";
-    const auto_updates = stmt.columnBool(6);
-    const installed_at = if (stmt.columnText(7)) |d| std.mem.sliceTo(d, 0) else "";
-
-    try stdout.writeAll("{\"name\":");
-    try output.jsonStr(stdout, token);
-    try stdout.writeAll(",\"type\":\"cask\",\"installed\":true,\"version\":");
-    try output.jsonStr(stdout, ver);
-    try stdout.writeAll(",\"full_name\":");
-    try output.jsonStr(stdout, cask_name);
-    try stdout.writeAll(",\"url\":");
-    try output.jsonStr(stdout, url);
-    try stdout.writeAll(",\"app_path\":");
-    try output.jsonStr(stdout, app_path);
-    try stdout.writeAll(",\"auto_updates\":");
-    try stdout.writeAll(if (auto_updates) "true" else "false");
-    try stdout.writeAll(",\"installed_at\":");
-    try output.jsonStr(stdout, installed_at);
-    try stdout.writeAll("}\n");
+    const row = readInstalledCaskRow(&stmt, name);
+    try encodeInstalledCaskJson(stdout, &row);
 }

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -481,11 +481,15 @@ pub const InstalledCaskRow = struct {
     app_path: ?[]const u8 = null,
     auto_updates: bool = false,
     installed_at: ?[]const u8 = null,
+    /// Null for casks installed from the core Homebrew API (the default
+    /// `homebrew/cask` tap) and for v5-era rows that pre-date `casks.tap`
+    /// and haven't been backfilled yet — they get attributed on the next
+    /// `mt upgrade <token>`.
+    tap: ?[]const u8 = null,
 };
 
-/// Resolved column count is encoded in the `WHERE`-ordered SELECT below.
 const installed_cask_select =
-    "SELECT token, name, version, url, app_path, auto_updates, installed_at " ++
+    "SELECT token, name, version, url, app_path, auto_updates, installed_at, tap " ++
     "FROM casks WHERE token = ?1 LIMIT 1;";
 
 fn readInstalledCaskRow(stmt: *sqlite.Statement, fallback_name: []const u8) InstalledCaskRow {
@@ -497,6 +501,7 @@ fn readInstalledCaskRow(stmt: *sqlite.Statement, fallback_name: []const u8) Inst
         .app_path = if (stmt.columnText(4)) |p| std.mem.sliceTo(p, 0) else null,
         .auto_updates = stmt.columnBool(5),
         .installed_at = if (stmt.columnText(6)) |d| std.mem.sliceTo(d, 0) else null,
+        .tap = if (stmt.columnText(7)) |t| std.mem.sliceTo(t, 0) else null,
     };
 }
 
@@ -510,6 +515,9 @@ pub fn encodeInstalledCaskHuman(
     const col: usize = 14;
     try encodeHeader(w, colorize, row.token, "", row.version orelse "unknown", "(cask)");
     try output.writeField(w, scratch, colorize, col, "Name", "{s}", .{row.name});
+    // Omit the Tap line for core-API casks — `homebrew/cask` is the
+    // default and printing it adds noise without information.
+    if (row.tap) |t| try output.writeField(w, scratch, colorize, col, "Tap", "{s}", .{t});
     try output.writeField(w, scratch, colorize, col, "URL", "{s}", .{row.url orelse "N/A"});
     try output.writeField(w, scratch, colorize, col, "App", "{s}", .{row.app_path orelse "N/A"});
     if (row.auto_updates) try output.writeField(w, scratch, colorize, col, "Auto-updates", "yes", .{});
@@ -531,6 +539,10 @@ pub fn encodeInstalledCaskJson(w: *std.Io.Writer, row: *const InstalledCaskRow) 
     try w.writeAll(if (row.auto_updates) "true" else "false");
     try w.writeAll(",\"installed_at\":");
     try output.jsonStr(w, row.installed_at orelse "");
+    // Matches the formula JSON's tap field — always present, empty
+    // string when unattributed so consumers can branch on truthiness.
+    try w.writeAll(",\"tap\":");
+    try output.jsonStr(w, row.tap orelse "");
     try w.writeAll("}\n");
 }
 

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -488,8 +488,11 @@ pub const InstalledCaskRow = struct {
     tap: ?[]const u8 = null,
 };
 
+/// SELECT shape kept byte-for-byte compatible with the pre-refactor query.
+/// `sha256` is unused by the renderers but stays in the column list so the
+/// extraction commit is a true mechanical refactor — only `tap` is new.
 const installed_cask_select =
-    "SELECT token, name, version, url, app_path, auto_updates, installed_at, tap " ++
+    "SELECT token, name, version, url, sha256, app_path, auto_updates, installed_at, tap " ++
     "FROM casks WHERE token = ?1 LIMIT 1;";
 
 fn readInstalledCaskRow(stmt: *sqlite.Statement, fallback_name: []const u8) InstalledCaskRow {
@@ -498,10 +501,11 @@ fn readInstalledCaskRow(stmt: *sqlite.Statement, fallback_name: []const u8) Inst
         .name = if (stmt.columnText(1)) |n| std.mem.sliceTo(n, 0) else fallback_name,
         .version = if (stmt.columnText(2)) |v| std.mem.sliceTo(v, 0) else null,
         .url = if (stmt.columnText(3)) |u| std.mem.sliceTo(u, 0) else null,
-        .app_path = if (stmt.columnText(4)) |p| std.mem.sliceTo(p, 0) else null,
-        .auto_updates = stmt.columnBool(5),
-        .installed_at = if (stmt.columnText(6)) |d| std.mem.sliceTo(d, 0) else null,
-        .tap = if (stmt.columnText(7)) |t| std.mem.sliceTo(t, 0) else null,
+        // column 4 is sha256 — intentionally unread.
+        .app_path = if (stmt.columnText(5)) |p| std.mem.sliceTo(p, 0) else null,
+        .auto_updates = stmt.columnBool(6),
+        .installed_at = if (stmt.columnText(7)) |d| std.mem.sliceTo(d, 0) else null,
+        .tap = if (stmt.columnText(8)) |t| std.mem.sliceTo(t, 0) else null,
     };
 }
 
@@ -515,13 +519,13 @@ pub fn encodeInstalledCaskHuman(
     const col: usize = 14;
     try encodeHeader(w, colorize, row.token, "", row.version orelse "unknown", "(cask)");
     try output.writeField(w, scratch, colorize, col, "Name", "{s}", .{row.name});
-    // Omit the Tap line for core-API casks — `homebrew/cask` is the
-    // default and printing it adds noise without information.
-    if (row.tap) |t| try output.writeField(w, scratch, colorize, col, "Tap", "{s}", .{t});
     try output.writeField(w, scratch, colorize, col, "URL", "{s}", .{row.url orelse "N/A"});
     try output.writeField(w, scratch, colorize, col, "App", "{s}", .{row.app_path orelse "N/A"});
     if (row.auto_updates) try output.writeField(w, scratch, colorize, col, "Auto-updates", "yes", .{});
     try output.writeField(w, scratch, colorize, col, "Installed", "{s}", .{row.installed_at orelse "N/A"});
+    // Trailing position keeps the top of the dump stable for scripts that
+    // grep the first N lines. Omitted for core-API casks (NULL tap).
+    if (row.tap) |t| try output.writeField(w, scratch, colorize, col, "Tap", "{s}", .{t});
 }
 
 pub fn encodeInstalledCaskJson(w: *std.Io.Writer, row: *const InstalledCaskRow) !void {

--- a/tests/info_cli_test.zig
+++ b/tests/info_cli_test.zig
@@ -92,6 +92,55 @@ fn seedCaskRow(prefix: []const u8) !void {
     _ = try stmt.step();
 }
 
+fn seedTapCaskRow(prefix: []const u8) !void {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var stmt = try db.prepare(
+        \\INSERT INTO casks (token, name, version, url, sha256, app_path, tap)
+        \\VALUES ('deckclip', 'deckclip', '1.4.5', 'https://example/deckclip.dmg', 'bb', '/Applications/Deck.app', 'yuzeguitarist/deck');
+    );
+    defer stmt.finalize();
+    _ = try stmt.step();
+}
+
+/// End-to-end stdout capture. Backs `ctx.stdout` with a real fd to a
+/// scratch file so the encoder's writes survive past `execute` and can
+/// be re-read for assertions. Caller owns the returned slice.
+fn captureExecute(
+    allocator: std.mem.Allocator,
+    args: []const []const u8,
+    tag: []const u8,
+) ![]u8 {
+    const ts = test_io.nanoTimestamp(std.Options.debug_io);
+    const cap_path = try std.fmt.allocPrintSentinel(
+        allocator,
+        "/tmp/malt_info_cap_{s}_{d}",
+        .{ tag, ts },
+        0,
+    );
+    defer allocator.free(cap_path);
+    defer test_io.deleteFileAbsolute(std.Options.debug_io, cap_path) catch {};
+
+    var file = try test_io.createFileAbsolute(std.Options.debug_io, cap_path, .{ .truncate = true });
+    errdefer file.close(std.Options.debug_io);
+
+    const ctx: malt.app_ctx.AppCtx = .{
+        .io = std.Options.debug_io,
+        .environ = .empty,
+        .stdout = file,
+        .stderr = test_io.testSink(),
+    };
+
+    try info.execute(&ctx, allocator, args);
+    file.close(std.Options.debug_io);
+
+    return try test_io.readFileAbsoluteAlloc(std.Options.debug_io, allocator, cap_path, 64 * 1024);
+}
+
 // --- early-return + arg parsing ---------------------------------------
 
 test "execute --help short-circuits without touching the database" {
@@ -248,4 +297,78 @@ test "execute falls back to cached API formula metadata for a not-locally-instal
     defer unquiet();
 
     try info.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{"jq"});
+}
+
+// --- end-to-end stdout capture: tap surfacing -------------------------
+//
+// WHY a separate block: the tests above prove `execute` doesn't crash on
+// the cask path, but `debug_ctx.stdout = -1` means they assert nothing
+// about the bytes. These tests back stdout with a real file so the full
+// DB → SELECT → readInstalledCaskRow → encoder → writer chain is
+// observable — catching column-index regressions, SELECT shape drift,
+// and tap-surfacing bugs that the pure encoder tests cannot see.
+
+test "execute on a tap-cask emits a Tap: line at the bottom of the human dump" {
+    var s = try Scratch.init(testing.allocator, "tap_cask_human");
+    defer s.deinit(testing.allocator);
+    try seedTapCaskRow(s.path);
+
+    const out = try captureExecute(testing.allocator, &.{"deckclip"}, "tap_cask_human");
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "deckclip: 1.4.5 (cask)") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Tap:          yuzeguitarist/deck") != null);
+    const installed_idx = std.mem.indexOf(u8, out, "Installed:") orelse return error.NoInstalledLine;
+    const tap_idx = std.mem.indexOf(u8, out, "Tap:") orelse return error.NoTapLine;
+    try testing.expect(installed_idx < tap_idx);
+}
+
+test "execute on a NULL-tap cask omits the Tap: line entirely" {
+    var s = try Scratch.init(testing.allocator, "null_tap_human");
+    defer s.deinit(testing.allocator);
+    try seedCaskRow(s.path);
+
+    const out = try captureExecute(testing.allocator, &.{"firefox"}, "null_tap_human");
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "firefox: 120.0 (cask)") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Tap:") == null);
+}
+
+test "execute --json on a tap-cask exposes the tap field" {
+    var s = try Scratch.init(testing.allocator, "tap_cask_json");
+    defer s.deinit(testing.allocator);
+    try seedTapCaskRow(s.path);
+
+    const prior_mode: output.OutputMode = if (output.isJson()) .json else .human;
+    output.setMode(.json);
+    defer output.setMode(prior_mode);
+
+    const out = try captureExecute(testing.allocator, &.{"deckclip"}, "tap_cask_json");
+    defer testing.allocator.free(out);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, out, .{});
+    defer parsed.deinit();
+
+    const tap_val = parsed.value.object.get("tap") orelse return error.MissingTapKey;
+    try testing.expectEqualStrings("yuzeguitarist/deck", tap_val.string);
+}
+
+test "execute --json on a NULL-tap cask still emits tap as an empty string" {
+    var s = try Scratch.init(testing.allocator, "null_tap_json");
+    defer s.deinit(testing.allocator);
+    try seedCaskRow(s.path);
+
+    const prior_mode: output.OutputMode = if (output.isJson()) .json else .human;
+    output.setMode(.json);
+    defer output.setMode(prior_mode);
+
+    const out = try captureExecute(testing.allocator, &.{"firefox"}, "null_tap_json");
+    defer testing.allocator.free(out);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, out, .{});
+    defer parsed.deinit();
+
+    const tap_val = parsed.value.object.get("tap") orelse return error.MissingTapKey;
+    try testing.expectEqualStrings("", tap_val.string);
 }

--- a/tests/info_test.zig
+++ b/tests/info_test.zig
@@ -283,6 +283,7 @@ test "encodeInstalledCaskHuman surfaces the owning tap when set" {
         .token = "deckclip",
         .name = "deckclip",
         .version = "1.4.5",
+        .installed_at = "2026-05-13 10:40:56",
         .tap = "yuzeguitarist/deck",
     };
 
@@ -293,12 +294,11 @@ test "encodeInstalledCaskHuman surfaces the owning tap when set" {
 
     const out = aw.written();
     try testing.expect(std.mem.indexOf(u8, out, "Tap:          yuzeguitarist/deck") != null);
-    // Tap line sits between Name and URL — same position as `From:` for formulas.
-    const name_idx = std.mem.indexOf(u8, out, "Name:") orelse return error.NoNameLine;
+    // Tap is appended after Installed so the top of the dump stays
+    // stable for scripts that grep the first N lines of `mt info`.
+    const installed_idx = std.mem.indexOf(u8, out, "Installed:") orelse return error.NoInstalledLine;
     const tap_idx = std.mem.indexOf(u8, out, "Tap:") orelse return error.NoTapLine;
-    const url_idx = std.mem.indexOf(u8, out, "URL:") orelse return error.NoUrlLine;
-    try testing.expect(name_idx < tap_idx);
-    try testing.expect(tap_idx < url_idx);
+    try testing.expect(installed_idx < tap_idx);
 }
 
 test "encodeInstalledCaskHuman omits the Tap line when null (core-API cask)" {
@@ -329,4 +329,30 @@ test "encodeInstalledCaskJson includes tap as an empty string for null and the l
     try info.encodeInstalledCaskJson(&aw.writer, &tapped);
 
     try testing.expect(std.mem.indexOf(u8, aw.written(), "\"tap\":\"yuzeguitarist/deck\"") != null);
+}
+
+test "encodeInstalledCaskJson output parses as JSON with .tap reachable" {
+    // Loose shape guard: catches future reorderings or sibling-field
+    // additions that the exact-bytes test would also catch, but keeps
+    // working even if a later refactor reorders the object keys. WHY
+    // this matters: downstream consumers branch on `.tap`, not on byte
+    // position — a parses-as test pins the contract they actually rely on.
+    const row: info.InstalledCaskRow = .{
+        .token = "deckclip",
+        .name = "deckclip",
+        .version = "1.4.5",
+        .tap = "yuzeguitarist/deck",
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try info.encodeInstalledCaskJson(&aw.writer, &row);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+
+    const tap_val = parsed.value.object.get("tap") orelse return error.MissingTapKey;
+    try testing.expectEqualStrings("yuzeguitarist/deck", tap_val.string);
+    const type_val = parsed.value.object.get("type") orelse return error.MissingTypeKey;
+    try testing.expectEqualStrings("cask", type_val.string);
 }

--- a/tests/info_test.zig
+++ b/tests/info_test.zig
@@ -188,3 +188,92 @@ test "encodeApiCaskJson produces the documented shape" {
         aw.written(),
     );
 }
+
+// --- installed-cask encoders -------------------------------------------
+
+test "encodeInstalledCaskHuman renders every populated field" {
+    const row: info.InstalledCaskRow = .{
+        .token = "firefox",
+        .name = "Firefox",
+        .version = "120.0",
+        .url = "https://example.com/firefox.dmg",
+        .app_path = "/Applications/Firefox.app",
+        .auto_updates = true,
+        .installed_at = "2026-05-13 10:40:56",
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, false);
+
+    const out = aw.written();
+    try testing.expect(std.mem.indexOf(u8, out, "firefox: 120.0 (cask)\n") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Name:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Firefox") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "URL:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "https://example.com/firefox.dmg") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "App:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "/Applications/Firefox.app") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Auto-updates:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Installed:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "2026-05-13 10:40:56") != null);
+}
+
+test "encodeInstalledCaskHuman omits Auto-updates when false and uses fallbacks for nulls" {
+    const row: info.InstalledCaskRow = .{
+        .token = "ghost",
+        .name = "ghost",
+        // version/url/app_path/installed_at null → human fallbacks ("unknown"/"N/A")
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, false);
+
+    const out = aw.written();
+    try testing.expect(std.mem.indexOf(u8, out, "ghost: unknown (cask)\n") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Auto-updates:") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "URL:          N/A") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "App:          N/A") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Installed:    N/A") != null);
+}
+
+test "encodeInstalledCaskJson produces the documented shape" {
+    const row: info.InstalledCaskRow = .{
+        .token = "firefox",
+        .name = "Firefox",
+        .version = "120.0",
+        .url = "https://example.com/firefox.dmg",
+        .app_path = "/Applications/Firefox.app",
+        .auto_updates = false,
+        .installed_at = "2026-05-13 10:40:56",
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try info.encodeInstalledCaskJson(&aw.writer, &row);
+
+    try testing.expectEqualStrings(
+        "{\"name\":\"firefox\",\"type\":\"cask\",\"installed\":true,\"version\":\"120.0\",\"full_name\":\"Firefox\",\"url\":\"https://example.com/firefox.dmg\",\"app_path\":\"/Applications/Firefox.app\",\"auto_updates\":false,\"installed_at\":\"2026-05-13 10:40:56\"}\n",
+        aw.written(),
+    );
+}
+
+test "encodeInstalledCaskJson emits empty strings for null fields" {
+    const row: info.InstalledCaskRow = .{
+        .token = "ghost",
+        .name = "ghost",
+        .auto_updates = true,
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try info.encodeInstalledCaskJson(&aw.writer, &row);
+
+    try testing.expectEqualStrings(
+        "{\"name\":\"ghost\",\"type\":\"cask\",\"installed\":true,\"version\":\"\",\"full_name\":\"ghost\",\"url\":\"\",\"app_path\":\"\",\"auto_updates\":true,\"installed_at\":\"\"}\n",
+        aw.written(),
+    );
+}

--- a/tests/info_test.zig
+++ b/tests/info_test.zig
@@ -256,7 +256,7 @@ test "encodeInstalledCaskJson produces the documented shape" {
     try info.encodeInstalledCaskJson(&aw.writer, &row);
 
     try testing.expectEqualStrings(
-        "{\"name\":\"firefox\",\"type\":\"cask\",\"installed\":true,\"version\":\"120.0\",\"full_name\":\"Firefox\",\"url\":\"https://example.com/firefox.dmg\",\"app_path\":\"/Applications/Firefox.app\",\"auto_updates\":false,\"installed_at\":\"2026-05-13 10:40:56\"}\n",
+        "{\"name\":\"firefox\",\"type\":\"cask\",\"installed\":true,\"version\":\"120.0\",\"full_name\":\"Firefox\",\"url\":\"https://example.com/firefox.dmg\",\"app_path\":\"/Applications/Firefox.app\",\"auto_updates\":false,\"installed_at\":\"2026-05-13 10:40:56\",\"tap\":\"\"}\n",
         aw.written(),
     );
 }
@@ -273,7 +273,60 @@ test "encodeInstalledCaskJson emits empty strings for null fields" {
     try info.encodeInstalledCaskJson(&aw.writer, &row);
 
     try testing.expectEqualStrings(
-        "{\"name\":\"ghost\",\"type\":\"cask\",\"installed\":true,\"version\":\"\",\"full_name\":\"ghost\",\"url\":\"\",\"app_path\":\"\",\"auto_updates\":true,\"installed_at\":\"\"}\n",
+        "{\"name\":\"ghost\",\"type\":\"cask\",\"installed\":true,\"version\":\"\",\"full_name\":\"ghost\",\"url\":\"\",\"app_path\":\"\",\"auto_updates\":true,\"installed_at\":\"\",\"tap\":\"\"}\n",
         aw.written(),
     );
+}
+
+test "encodeInstalledCaskHuman surfaces the owning tap when set" {
+    const row: info.InstalledCaskRow = .{
+        .token = "deckclip",
+        .name = "deckclip",
+        .version = "1.4.5",
+        .tap = "yuzeguitarist/deck",
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, false);
+
+    const out = aw.written();
+    try testing.expect(std.mem.indexOf(u8, out, "Tap:          yuzeguitarist/deck") != null);
+    // Tap line sits between Name and URL — same position as `From:` for formulas.
+    const name_idx = std.mem.indexOf(u8, out, "Name:") orelse return error.NoNameLine;
+    const tap_idx = std.mem.indexOf(u8, out, "Tap:") orelse return error.NoTapLine;
+    const url_idx = std.mem.indexOf(u8, out, "URL:") orelse return error.NoUrlLine;
+    try testing.expect(name_idx < tap_idx);
+    try testing.expect(tap_idx < url_idx);
+}
+
+test "encodeInstalledCaskHuman omits the Tap line when null (core-API cask)" {
+    const row: info.InstalledCaskRow = .{
+        .token = "firefox",
+        .name = "Firefox",
+        .version = "120.0",
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, false);
+
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "Tap:") == null);
+}
+
+test "encodeInstalledCaskJson includes tap as an empty string for null and the label for tap casks" {
+    const tapped: info.InstalledCaskRow = .{
+        .token = "deckclip",
+        .name = "deckclip",
+        .version = "1.4.5",
+        .tap = "yuzeguitarist/deck",
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try info.encodeInstalledCaskJson(&aw.writer, &tapped);
+
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "\"tap\":\"yuzeguitarist/deck\"") != null);
 }


### PR DESCRIPTION
## Description

`mt info <cask>` now reports the owning tap so a user inspecting a cask installed from a third-party tap can immediately answer "do I need this tap to upgrade?". For core-API casks the line is suppressed - `homebrew/cask` is the default and printing it adds noise without information.

The JSON shape gains a `"tap"` field, mirroring the existing formula shape so downstream consumers can branch on a single key across both kinds.

## Related Issue

- None

## Notes for Reviewers

- None
