### PR TITLE
refactor(list): scope mt list to a single tap with --tap filter

### DIFF
--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -144,7 +144,7 @@ pub const bash_script =
     \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --pinned --force -f" ;;
     \\        outdated)         cmd_flags="--json --formula --cask --pinned-only --refresh --quiet -q" ;;
     \\        update)           cmd_flags="--check --quiet -q" ;;
-    \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --json --quiet -q" ;;
+    \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --tap --json --quiet -q" ;;
     \\        info)             cmd_flags="--formula --cask --json" ;;
     \\        search)           cmd_flags="--formula --cask --json" ;;
     \\        uses)             cmd_flags="--recursive -r --json --quiet -q" ;;
@@ -301,6 +301,7 @@ pub const zsh_script =
     \\                        '--formula[Formulas only]' \
     \\                        '--cask[Casks only]' \
     \\                        '--pinned[Pinned packages only]' \
+    \\                        '--tap[Only packages from <label> (e.g. user/repo)]:tap label:' \
     \\                        '--json[Output as JSON]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Names only]'
     \\                    ;;
@@ -521,6 +522,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l formula  -d 'Formulas only'
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l cask     -d 'Casks only'
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l pinned   -d 'Pinned only'
+    \\    complete -c $__malt_bin -n '__malt_using_command list' -l tap      -x -d 'Only packages from <label>'
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l json     -d 'JSON output'
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l versions -d 'Show version numbers'
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l formula  -d 'Formulas only'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -147,6 +147,10 @@ const list_help =
     \\  --formula      Formulas only
     \\  --cask         Casks only
     \\  --pinned       Pinned packages only
+    \\  --tap <label>  Only packages from <label> (e.g. `user/repo`).
+    \\                 Strict equality: legacy v6-era casks with no
+    \\                 recorded tap won't match — run `mt upgrade <token>`
+    \\                 to trigger attribution, or omit the filter.
     \\  --json         Output as JSON
     \\  --quiet, -q    Names only, one per line
     \\

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -158,18 +158,29 @@ pub fn writeHumanOutput(
     }
 }
 
+/// Flag combinations for the kegs/casks list SELECT. Used as the switch
+/// key in `formulaListSql` / `caskListSql` so the compiler enforces
+/// exhaustive handling of every (pinned × tap) variant.
+const ListSqlVariant = enum { plain, tap, pinned, pinned_tap };
+
+fn listSqlVariant(show_pinned: bool, tap_filter: bool) ListSqlVariant {
+    if (show_pinned and tap_filter) return .pinned_tap;
+    if (show_pinned) return .pinned;
+    if (tap_filter) return .tap;
+    return .plain;
+}
+
 /// Compose the kegs SELECT with optional pinned + tap filters. The
-/// `?1` placeholder is bound by the caller when `tap_filter = true`.
-/// Strict equality means NULL-tap rows never match — kegs are always
-/// attributed at install time, so this is purely future-proofing.
+/// `?1` placeholder is bound by the caller for the `.tap` / `.pinned_tap`
+/// variants. Strict equality means NULL-tap rows never match — kegs are
+/// always attributed at install time, so this is purely future-proofing.
 fn formulaListSql(show_pinned: bool, tap_filter: bool) [:0]const u8 {
-    if (show_pinned and tap_filter)
-        return "SELECT name, version, pinned FROM kegs WHERE pinned = 1 AND tap = ?1 ORDER BY name;";
-    if (show_pinned)
-        return "SELECT name, version, pinned FROM kegs WHERE pinned = 1 ORDER BY name;";
-    if (tap_filter)
-        return "SELECT name, version, pinned FROM kegs WHERE tap = ?1 ORDER BY name;";
-    return "SELECT name, version, pinned FROM kegs ORDER BY name;";
+    return switch (listSqlVariant(show_pinned, tap_filter)) {
+        .plain => "SELECT name, version, pinned FROM kegs ORDER BY name;",
+        .tap => "SELECT name, version, pinned FROM kegs WHERE tap = ?1 ORDER BY name;",
+        .pinned => "SELECT name, version, pinned FROM kegs WHERE pinned = 1 ORDER BY name;",
+        .pinned_tap => "SELECT name, version, pinned FROM kegs WHERE pinned = 1 AND tap = ?1 ORDER BY name;",
+    };
 }
 
 /// Cask counterpart to `formulaListSql`. NULL tap means "unattributed"
@@ -177,13 +188,12 @@ fn formulaListSql(show_pinned: bool, tap_filter: bool) [:0]const u8 {
 /// honest. The user-facing workaround (`mt upgrade <token>`) is in the
 /// help string.
 fn caskListSql(show_pinned: bool, tap_filter: bool) [:0]const u8 {
-    if (show_pinned and tap_filter)
-        return "SELECT token, version FROM casks WHERE pinned = 1 AND tap = ?1 ORDER BY token;";
-    if (show_pinned)
-        return "SELECT token, version FROM casks WHERE pinned = 1 ORDER BY token;";
-    if (tap_filter)
-        return "SELECT token, version FROM casks WHERE tap = ?1 ORDER BY token;";
-    return "SELECT token, version FROM casks ORDER BY token;";
+    return switch (listSqlVariant(show_pinned, tap_filter)) {
+        .plain => "SELECT token, version FROM casks ORDER BY token;",
+        .tap => "SELECT token, version FROM casks WHERE tap = ?1 ORDER BY token;",
+        .pinned => "SELECT token, version FROM casks WHERE pinned = 1 ORDER BY token;",
+        .pinned_tap => "SELECT token, version FROM casks WHERE pinned = 1 AND tap = ?1 ORDER BY token;",
+    };
 }
 
 /// `--pinned` walks formulas + casks together so the output is a single
@@ -230,30 +240,43 @@ fn writePinnedHuman(
     }
 }
 
+/// Which kinds participate in the `--pinned` view. `.neither` short-circuits
+/// the caller (no SELECT to run); the other three pick a UNION shape.
+const PinnedUnionKind = enum { neither, formula_only, cask_only, both };
+
+fn pinnedUnionKind(show_formula: bool, show_cask: bool) PinnedUnionKind {
+    if (show_formula and show_cask) return .both;
+    if (show_formula) return .formula_only;
+    if (show_cask) return .cask_only;
+    return .neither;
+}
+
 /// Build the SQL that drives the `--pinned` view. The 'formula' / 'cask'
 /// literal column tags each row so the caller can render the right marker.
 /// `?1` is bound once and reused across both UNION branches when
 /// `tap_filter` is set — sqlite parameter reuse is well-defined.
 fn pinnedUnionSql(show_formula: bool, show_cask: bool, tap_filter: bool) ?[:0]const u8 {
-    if (show_formula and show_cask) {
-        if (tap_filter) return "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 AND tap = ?1 " ++
-            "UNION ALL " ++
-            "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 AND tap = ?1 " ++
-            "ORDER BY name;";
-        return "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 " ++
-            "UNION ALL " ++
-            "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 " ++
-            "ORDER BY name;";
-    }
-    if (show_formula) {
-        if (tap_filter) return "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 AND tap = ?1 ORDER BY name;";
-        return "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 ORDER BY name;";
-    }
-    if (show_cask) {
-        if (tap_filter) return "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 AND tap = ?1 ORDER BY name;";
-        return "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 ORDER BY name;";
-    }
-    return null;
+    return switch (pinnedUnionKind(show_formula, show_cask)) {
+        .neither => null,
+        .both => if (tap_filter)
+            "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 AND tap = ?1 " ++
+                "UNION ALL " ++
+                "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 AND tap = ?1 " ++
+                "ORDER BY name;"
+        else
+            "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 " ++
+                "UNION ALL " ++
+                "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 " ++
+                "ORDER BY name;",
+        .formula_only => if (tap_filter)
+            "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 AND tap = ?1 ORDER BY name;"
+        else
+            "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 ORDER BY name;",
+        .cask_only => if (tap_filter)
+            "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 AND tap = ?1 ORDER BY name;"
+        else
+            "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 ORDER BY name;",
+    };
 }
 
 /// Emit the leading cyan bullet + space, honouring `NO_COLOR`.

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -20,8 +20,11 @@ pub fn execute(ctx: *const AppCtx, args: []const []const u8) !void {
     var show_cask = false;
     var show_versions = false;
     var show_pinned = false;
+    var tap_filter: ?[]const u8 = null;
 
-    for (args) |arg| {
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
         if (std.mem.eql(u8, arg, "--formula") or std.mem.eql(u8, arg, "--formulae")) {
             show_formula = true;
         } else if (std.mem.eql(u8, arg, "--cask") or std.mem.eql(u8, arg, "--casks")) {
@@ -30,6 +33,15 @@ pub fn execute(ctx: *const AppCtx, args: []const []const u8) !void {
             show_versions = true;
         } else if (std.mem.eql(u8, arg, "--pinned")) {
             show_pinned = true;
+        } else if (std.mem.eql(u8, arg, "--tap")) {
+            if (i + 1 >= args.len) {
+                output.err("--tap requires a label (e.g. `--tap user/repo`)", .{});
+                return error.Aborted;
+            }
+            i += 1;
+            tap_filter = args[i];
+        } else if (std.mem.startsWith(u8, arg, "--tap=")) {
+            tap_filter = arg["--tap=".len..];
         }
     }
     const json_mode = output.isJson();
@@ -59,9 +71,9 @@ pub fn execute(ctx: *const AppCtx, args: []const []const u8) !void {
     defer stdout.flush() catch {};
 
     if (json_mode) {
-        try writeJsonOutput(ctx, &db, show_formula, show_cask, show_pinned, stdout);
+        try writeJsonOutput(ctx, &db, show_formula, show_cask, show_pinned, tap_filter, stdout);
     } else {
-        try writeHumanOutput(&db, show_formula, show_cask, show_versions, show_pinned, stdout);
+        try writeHumanOutput(&db, show_formula, show_cask, show_versions, show_pinned, tap_filter, stdout);
     }
 }
 
@@ -77,18 +89,21 @@ pub fn writeHumanOutput(
     show_cask: bool,
     show_versions: bool,
     show_pinned: bool,
+    tap_filter: ?[]const u8,
     stdout: *std.Io.Writer,
 ) !void {
     const quiet = output.isQuiet();
 
     if (show_pinned) {
-        try writePinnedHuman(db, show_formula, show_cask, show_versions, quiet, stdout);
+        try writePinnedHuman(db, show_formula, show_cask, show_versions, tap_filter, quiet, stdout);
         return;
     }
 
     if (show_formula) {
-        var stmt = db.prepare("SELECT name, version, pinned FROM kegs ORDER BY name;") catch return;
+        const sql = formulaListSql(false, tap_filter != null);
+        var stmt = db.prepare(sql) catch return;
         defer stmt.finalize();
+        if (tap_filter) |t| stmt.bindText(1, t) catch return;
 
         while (stmt.step() catch false) {
             const name = stmt.columnText(0) orelse continue;
@@ -116,9 +131,10 @@ pub fn writeHumanOutput(
     }
 
     if (show_cask) {
-        const sql = "SELECT token, version FROM casks ORDER BY token;";
+        const sql = caskListSql(false, tap_filter != null);
         var stmt = db.prepare(sql) catch return;
         defer stmt.finalize();
+        if (tap_filter) |t| stmt.bindText(1, t) catch return;
 
         while (stmt.step() catch false) {
             const token = stmt.columnText(0) orelse continue;
@@ -142,6 +158,34 @@ pub fn writeHumanOutput(
     }
 }
 
+/// Compose the kegs SELECT with optional pinned + tap filters. The
+/// `?1` placeholder is bound by the caller when `tap_filter = true`.
+/// Strict equality means NULL-tap rows never match — kegs are always
+/// attributed at install time, so this is purely future-proofing.
+fn formulaListSql(show_pinned: bool, tap_filter: bool) [:0]const u8 {
+    if (show_pinned and tap_filter)
+        return "SELECT name, version, pinned FROM kegs WHERE pinned = 1 AND tap = ?1 ORDER BY name;";
+    if (show_pinned)
+        return "SELECT name, version, pinned FROM kegs WHERE pinned = 1 ORDER BY name;";
+    if (tap_filter)
+        return "SELECT name, version, pinned FROM kegs WHERE tap = ?1 ORDER BY name;";
+    return "SELECT name, version, pinned FROM kegs ORDER BY name;";
+}
+
+/// Cask counterpart to `formulaListSql`. NULL tap means "unattributed"
+/// (v5-era rows pre-`casks.tap`) — strict equality keeps the filter
+/// honest. The user-facing workaround (`mt upgrade <token>`) is in the
+/// help string.
+fn caskListSql(show_pinned: bool, tap_filter: bool) [:0]const u8 {
+    if (show_pinned and tap_filter)
+        return "SELECT token, version FROM casks WHERE pinned = 1 AND tap = ?1 ORDER BY token;";
+    if (show_pinned)
+        return "SELECT token, version FROM casks WHERE pinned = 1 ORDER BY token;";
+    if (tap_filter)
+        return "SELECT token, version FROM casks WHERE tap = ?1 ORDER BY token;";
+    return "SELECT token, version FROM casks ORDER BY token;";
+}
+
 /// `--pinned` walks formulas + casks together so the output is a single
 /// sorted list across both kinds, with a `[cask]` tag distinguishing
 /// cask rows. The `[pinned]` tag is dropped — every row is pinned by
@@ -151,12 +195,14 @@ fn writePinnedHuman(
     show_formula: bool,
     show_cask: bool,
     show_versions: bool,
+    tap_filter: ?[]const u8,
     quiet: bool,
     stdout: *std.Io.Writer,
 ) !void {
-    const sql = pinnedUnionSql(show_formula, show_cask) orelse return;
+    const sql = pinnedUnionSql(show_formula, show_cask, tap_filter != null) orelse return;
     var stmt = db.prepare(sql) catch return;
     defer stmt.finalize();
+    if (tap_filter) |t| stmt.bindText(1, t) catch return;
 
     while (stmt.step() catch false) {
         const name = stmt.columnText(0) orelse continue;
@@ -186,16 +232,27 @@ fn writePinnedHuman(
 
 /// Build the SQL that drives the `--pinned` view. The 'formula' / 'cask'
 /// literal column tags each row so the caller can render the right marker.
-fn pinnedUnionSql(show_formula: bool, show_cask: bool) ?[:0]const u8 {
-    if (show_formula and show_cask)
+/// `?1` is bound once and reused across both UNION branches when
+/// `tap_filter` is set — sqlite parameter reuse is well-defined.
+fn pinnedUnionSql(show_formula: bool, show_cask: bool, tap_filter: bool) ?[:0]const u8 {
+    if (show_formula and show_cask) {
+        if (tap_filter) return "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 AND tap = ?1 " ++
+            "UNION ALL " ++
+            "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 AND tap = ?1 " ++
+            "ORDER BY name;";
         return "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 " ++
             "UNION ALL " ++
             "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 " ++
             "ORDER BY name;";
-    if (show_formula)
+    }
+    if (show_formula) {
+        if (tap_filter) return "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 AND tap = ?1 ORDER BY name;";
         return "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 ORDER BY name;";
-    if (show_cask)
+    }
+    if (show_cask) {
+        if (tap_filter) return "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 AND tap = ?1 ORDER BY name;";
         return "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 ORDER BY name;";
+    }
     return null;
 }
 
@@ -233,10 +290,11 @@ fn writeJsonOutput(
     show_formula: bool,
     show_cask: bool,
     show_pinned: bool,
+    tap_filter: ?[]const u8,
     stdout: *std.Io.Writer,
 ) !void {
     const start_ts = std.Io.Clock.real.now(ctx.io).toMilliseconds();
-    try buildListJson(db, stdout, show_formula, show_cask, show_pinned, start_ts);
+    try buildListJson(db, stdout, show_formula, show_cask, show_pinned, tap_filter, start_ts);
 }
 
 /// Build the `{ "installed": [...], "formulae": [...], "casks": [...], "time_ms": N }`
@@ -249,29 +307,30 @@ pub fn buildListJson(
     show_formula: bool,
     show_cask: bool,
     show_pinned: bool,
+    tap_filter: ?[]const u8,
     start_ts: i64,
 ) !void {
     try w.writeAll("{\"installed\":[");
     var first = true;
     if (show_pinned) {
-        try writePinnedInstalled(db, w, show_formula, show_cask, &first);
+        try writePinnedInstalled(db, w, show_formula, show_cask, tap_filter, &first);
     } else {
-        if (show_formula) try writeFormulaRows(db, w, false, .installed, &first);
-        if (show_cask) try writeCaskRows(db, w, false, .installed, &first);
+        if (show_formula) try writeFormulaRows(db, w, false, tap_filter, .installed, &first);
+        if (show_cask) try writeCaskRows(db, w, false, tap_filter, .installed, &first);
     }
     try w.writeAll("]");
 
     if (show_formula) {
         try w.writeAll(",\"formulae\":[");
         var legacy_first = true;
-        try writeFormulaRows(db, w, show_pinned, .legacy, &legacy_first);
+        try writeFormulaRows(db, w, show_pinned, tap_filter, .legacy, &legacy_first);
         try w.writeAll("]");
     }
 
     if (show_cask) {
         try w.writeAll(",\"casks\":[");
         var legacy_first = true;
-        try writeCaskRows(db, w, show_pinned, .legacy, &legacy_first);
+        try writeCaskRows(db, w, show_pinned, tap_filter, .legacy, &legacy_first);
         try w.writeAll("]");
     }
 
@@ -287,11 +346,13 @@ fn writePinnedInstalled(
     w: *std.Io.Writer,
     show_formula: bool,
     show_cask: bool,
+    tap_filter: ?[]const u8,
     first: *bool,
 ) !void {
-    const sql = pinnedUnionSql(show_formula, show_cask) orelse return;
+    const sql = pinnedUnionSql(show_formula, show_cask, tap_filter != null) orelse return;
     var stmt = db.prepare(sql) catch return;
     defer stmt.finalize();
+    if (tap_filter) |t| stmt.bindText(1, t) catch return;
 
     while (stmt.step() catch false) {
         const name = stmt.columnText(0) orelse continue;
@@ -319,16 +380,15 @@ fn writeFormulaRows(
     db: *sqlite.Database,
     w: *std.Io.Writer,
     show_pinned: bool,
+    tap_filter: ?[]const u8,
     shape: RowShape,
     first: *bool,
 ) !void {
-    const sql = if (show_pinned)
-        "SELECT name, version, pinned FROM kegs WHERE pinned = 1 ORDER BY name;"
-    else
-        "SELECT name, version, pinned FROM kegs ORDER BY name;";
+    const sql = formulaListSql(show_pinned, tap_filter != null);
 
     var stmt = db.prepare(sql) catch return;
     defer stmt.finalize();
+    if (tap_filter) |t| stmt.bindText(1, t) catch return;
 
     while (stmt.step() catch false) {
         const name = stmt.columnText(0) orelse continue;
@@ -359,15 +419,14 @@ fn writeCaskRows(
     db: *sqlite.Database,
     w: *std.Io.Writer,
     show_pinned: bool,
+    tap_filter: ?[]const u8,
     shape: RowShape,
     first: *bool,
 ) !void {
-    const sql: [:0]const u8 = if (show_pinned)
-        "SELECT token, version FROM casks WHERE pinned = 1 ORDER BY token;"
-    else
-        "SELECT token, version FROM casks ORDER BY token;";
+    const sql = caskListSql(show_pinned, tap_filter != null);
     var stmt = db.prepare(sql) catch return;
     defer stmt.finalize();
+    if (tap_filter) |t| stmt.bindText(1, t) catch return;
 
     while (stmt.step() catch false) {
         const token = stmt.columnText(0) orelse continue;

--- a/tests/list_test.zig
+++ b/tests/list_test.zig
@@ -43,12 +43,32 @@ fn insertKeg(db: *sqlite.Database, name: []const u8, version: []const u8, pinned
     try db.exec(sql);
 }
 
+fn insertKegTap(db: *sqlite.Database, name: []const u8, version: []const u8, tap: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &buf,
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, tap) VALUES ('{s}', '{s}', '{s}', 'deadbeef', '/opt/malt/Cellar/{s}/{s}', '{s}');",
+        .{ name, name, version, name, version, tap },
+    );
+    try db.exec(sql);
+}
+
 fn insertCask(db: *sqlite.Database, token: []const u8, version: []const u8) !void {
     var buf: [512]u8 = undefined;
     const sql = try std.fmt.bufPrintZ(
         &buf,
         "INSERT INTO casks (token, name, version, url) VALUES ('{s}', '{s}', '{s}', 'https://example.com');",
         .{ token, token, version },
+    );
+    try db.exec(sql);
+}
+
+fn insertCaskTap(db: *sqlite.Database, token: []const u8, version: []const u8, tap: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &buf,
+        "INSERT INTO casks (token, name, version, url, tap) VALUES ('{s}', '{s}', '{s}', 'https://example.com', '{s}');",
+        .{ token, token, version, tap },
     );
     try db.exec(sql);
 }
@@ -60,10 +80,21 @@ fn runBuild(
     show_cask: bool,
     show_pinned: bool,
 ) ![]u8 {
+    return runBuildTap(allocator, db, show_formula, show_cask, show_pinned, null);
+}
+
+fn runBuildTap(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    show_formula: bool,
+    show_cask: bool,
+    show_pinned: bool,
+    tap_filter: ?[]const u8,
+) ![]u8 {
     var aw: std.Io.Writer.Allocating = .init(allocator);
     errdefer aw.deinit();
     // Use a fixed start_ts so the ",\"time_ms\":N" suffix is predictable.
-    try cli_list.buildListJson(db, &aw.writer, show_formula, show_cask, show_pinned, test_io.milliTimestamp(
+    try cli_list.buildListJson(db, &aw.writer, show_formula, show_cask, show_pinned, tap_filter, test_io.milliTimestamp(
         std.Options.debug_io,
     ));
     return aw.toOwnedSlice();
@@ -89,6 +120,19 @@ fn runHuman(
     show_pinned: bool,
     quiet: bool,
 ) ![]u8 {
+    return runHumanTap(allocator, db, show_formula, show_cask, show_versions, show_pinned, quiet, null);
+}
+
+fn runHumanTap(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    show_formula: bool,
+    show_cask: bool,
+    show_versions: bool,
+    show_pinned: bool,
+    quiet: bool,
+    tap_filter: ?[]const u8,
+) ![]u8 {
     const prior_quiet = malt.output.isQuiet();
     malt.output.setQuiet(quiet);
     defer malt.output.setQuiet(prior_quiet);
@@ -99,7 +143,7 @@ fn runHuman(
 
     var aw: std.Io.Writer.Allocating = .init(allocator);
     errdefer aw.deinit();
-    try cli_list.writeHumanOutput(db, show_formula, show_cask, show_versions, show_pinned, &aw.writer);
+    try cli_list.writeHumanOutput(db, show_formula, show_cask, show_versions, show_pinned, tap_filter, &aw.writer);
     return aw.toOwnedSlice();
 }
 
@@ -372,6 +416,146 @@ test "writeHumanOutput --pinned merges pinned formulas + casks in one sorted lis
     const firefox_pos = std.mem.indexOf(u8, out, "firefox").?;
     const zsh_pos = std.mem.indexOf(u8, out, "zsh").?;
     try testing.expect(firefox_pos < zsh_pos);
+}
+
+// --- --tap filter ------------------------------------------------------
+
+test "writeHumanOutput --tap scopes formulas and casks to a single tap" {
+    var t = try TempDb.init("human_tap");
+    defer t.deinit();
+
+    try insertKegTap(&t.db, "tap-formula", "1.0", "user/repo");
+    try insertKeg(&t.db, "core-formula", "2.0", false);
+    try insertCaskTap(&t.db, "tap-cask", "3.0", "user/repo");
+    try insertCask(&t.db, "core-cask", "4.0");
+
+    const out = try runHumanTap(testing.allocator, &t.db, true, true, false, false, true, "user/repo");
+    defer testing.allocator.free(out);
+
+    try testing.expectEqualStrings("tap-formula\ntap-cask\n", out);
+}
+
+test "writeHumanOutput --tap nonexistent yields empty output (typo guard)" {
+    var t = try TempDb.init("human_tap_typo");
+    defer t.deinit();
+
+    try insertKegTap(&t.db, "alpha", "1.0", "user/repo");
+    try insertCaskTap(&t.db, "bravo", "2.0", "user/repo");
+
+    const out = try runHumanTap(testing.allocator, &t.db, true, true, false, false, true, "user/nope");
+    defer testing.allocator.free(out);
+
+    try testing.expectEqualStrings("", out);
+}
+
+test "writeHumanOutput --tap combined with --formula scopes to that tap's formulas only" {
+    var t = try TempDb.init("human_tap_formula_only");
+    defer t.deinit();
+
+    try insertKegTap(&t.db, "alpha", "1.0", "user/repo");
+    try insertCaskTap(&t.db, "bravo", "2.0", "user/repo");
+
+    const out = try runHumanTap(testing.allocator, &t.db, true, false, false, false, true, "user/repo");
+    defer testing.allocator.free(out);
+
+    try testing.expectEqualStrings("alpha\n", out);
+}
+
+test "writeHumanOutput --tap excludes NULL-tap casks (legacy rows treated as unattributed)" {
+    // v5-era casks have tap = NULL until upgrade backfills them. The
+    // --tap filter is strict equality: NULL never matches, even when
+    // the requested label is `homebrew/cask`. The workaround documented
+    // in `--help` is `mt upgrade <token>` to trigger attribution.
+    var t = try TempDb.init("human_tap_null_excluded");
+    defer t.deinit();
+
+    try insertCask(&t.db, "legacy-cask", "1.0"); // tap = NULL
+
+    const out = try runHumanTap(testing.allocator, &t.db, false, true, false, false, true, "homebrew/cask");
+    defer testing.allocator.free(out);
+
+    try testing.expectEqualStrings("", out);
+}
+
+test "writeHumanOutput --tap combined with --pinned scopes to pinned rows from that tap" {
+    var t = try TempDb.init("human_tap_pinned");
+    defer t.deinit();
+
+    try t.db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, tap, pinned)
+        \\VALUES ('pinned-alpha', 'pinned-alpha', '1.0', 'aa', '/c/pinned-alpha/1.0', 'user/repo', 1),
+        \\       ('loose-bravo',  'loose-bravo',  '2.0', 'aa', '/c/loose-bravo/2.0',  'user/repo', 0);
+    );
+
+    const out = try runHumanTap(testing.allocator, &t.db, true, true, false, true, true, "user/repo");
+    defer testing.allocator.free(out);
+
+    try testing.expectEqualStrings("pinned-alpha\n", out);
+}
+
+test "buildListJson --tap filters both installed and legacy arrays" {
+    var t = try TempDb.init("json_tap");
+    defer t.deinit();
+
+    try insertKegTap(&t.db, "tap-formula", "1.0", "user/repo");
+    try insertKeg(&t.db, "core-formula", "2.0", false);
+    try insertCaskTap(&t.db, "tap-cask", "3.0", "user/repo");
+
+    const out = try runBuildTap(testing.allocator, &t.db, true, true, false, "user/repo");
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"tap-formula\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":false}," ++
+            "{\"name\":\"tap-cask\",\"version\":\"3.0\",\"type\":\"cask\"}" ++
+            "],\"formulae\":[" ++
+            "{\"name\":\"tap-formula\",\"version\":\"1.0\",\"pinned\":false}" ++
+            "],\"casks\":[" ++
+            "{\"token\":\"tap-cask\",\"version\":\"3.0\"}" ++
+            "]",
+        body,
+    );
+}
+
+test "buildListJson --tap with no matches produces empty arrays" {
+    var t = try TempDb.init("json_tap_empty");
+    defer t.deinit();
+
+    try insertKegTap(&t.db, "alpha", "1.0", "user/repo");
+
+    const out = try runBuildTap(testing.allocator, &t.db, true, true, false, "other/tap");
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[],\"formulae\":[],\"casks\":[]",
+        body,
+    );
+}
+
+test "buildListJson --tap with --pinned cross-filters" {
+    var t = try TempDb.init("json_tap_pinned");
+    defer t.deinit();
+
+    try t.db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, tap, pinned)
+        \\VALUES ('held', 'held', '1.0', 'aa', '/c/held/1.0', 'user/repo', 1),
+        \\       ('loose', 'loose', '2.0', 'aa', '/c/loose/2.0', 'user/repo', 0);
+    );
+
+    const out = try runBuildTap(testing.allocator, &t.db, true, false, true, "user/repo");
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"held\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":true}" ++
+            "],\"formulae\":[" ++
+            "{\"name\":\"held\",\"version\":\"1.0\",\"pinned\":true}" ++
+            "]",
+        body,
+    );
 }
 
 test "buildListJson: output parses as valid JSON" {


### PR DESCRIPTION
## Description

`mt list --tap <label>` answers "what did I install from this tap?" with one command. The filter applies to both formulas and casks, composes with `--formula` / `--cask` to scope to a single kind, and composes with `--pinned` to scope to held rows.

## Related Issue

- None

## Notes for Reviewers

- None