### PR TITLE
fix(db/lock): close double-fd race and adopt std.Io.File

### DIFF
--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -244,7 +244,7 @@ fn checkStaleLock(ctx: CheckCtx, name: []const u8) CheckResult {
         printCheck(name, .ok, null);
         return .ok;
     };
-    const pid = lock_mod.LockFile.holderPid(lock_path);
+    const pid = lock_mod.LockFile.holderPid(ctx.io, lock_path);
     if (pid) |p| {
         const is_alive = std.c.kill(p, @enumFromInt(0)) == 0;
         var pid_buf: [256]u8 = undefined;

--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -69,18 +69,17 @@ pub fn planFixes(c: Conditions) Plan {
 
 const StaleLockState = enum { absent, live, stale };
 
-fn probeStaleLockState(prefix: []const u8) StaleLockState {
+fn probeStaleLockState(io: std.Io, prefix: []const u8) StaleLockState {
     var lock_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix}) catch return .absent;
-    const pid = lock_mod.LockFile.holderPid(lock_path) orelse return .absent;
+    const pid = lock_mod.LockFile.holderPid(io, lock_path) orelse return .absent;
     const is_alive = std.c.kill(pid, @enumFromInt(0)) == 0;
     return if (is_alive) .live else .stale;
 }
 
 /// True when the lock file holds a PID that no longer exists.
 pub fn probeStaleLock(io: std.Io, prefix: []const u8) bool {
-    _ = io;
-    return probeStaleLockState(prefix) == .stale;
+    return probeStaleLockState(io, prefix) == .stale;
 }
 
 /// Count broken symlinks under the prefix's link directories without
@@ -124,7 +123,7 @@ fn walkBrokenSymlinks(io: std.Io, prefix: []const u8, do_remove: bool) u32 {
 /// Best-effort removal of the prefix's lock file when its PID is dead.
 /// Idempotent: a missing or live lock file is a no-op (returns false).
 pub fn fixStaleLock(io: std.Io, prefix: []const u8) bool {
-    if (probeStaleLockState(prefix) != .stale) return false;
+    if (probeStaleLockState(io, prefix) != .stale) return false;
     var lock_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix}) catch return false;
     std.Io.Dir.deleteFileAbsolute(io, lock_path) catch return false;

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -341,13 +341,13 @@ fn executeWithOpts(
         var lock_path_buf: [512]u8 = undefined;
         const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch
             return InstallError.LockError;
-        lk = lock_mod.LockFile.acquire(lock_path, 30000) catch {
+        lk = lock_mod.LockFile.acquire(ctx.io, lock_path, 30000) catch {
             output.err("Another mt process is running. Wait or run mt doctor.", .{});
             return InstallError.LockError;
         };
         output.emitNdjsonEvent(.lock_acquired, "", null);
     }
-    defer if (lk) |*l| l.release();
+    defer if (lk) |*l| l.release(ctx.io);
     // LIFO: install_complete must precede release in the deferred chain,
     // and the outer holder owns the matching pair when we skipped here.
     defer if (lk != null and output.isNdjson()) output.emitNdjsonEvent(.install_complete, "", null);

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -222,11 +222,11 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // Acquire lock; `MALT_LOCK_TIMEOUT_MS` tunes the 30 s default.
     var lock_path_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return;
-    var lk = lock_mod.LockFile.acquire(lock_path, lockTimeoutMs(ctx)) catch {
+    var lk = lock_mod.LockFile.acquire(ctx.io, lock_path, lockTimeoutMs(ctx)) catch {
         output.err("Another mt process is running. Wait or run mt doctor.", .{});
         return error.Aborted;
     };
-    defer lk.release();
+    defer lk.release(ctx.io);
     // LIFO: install_complete fires before lk.release. Inline gate keeps
     // the deferred call out of the default paths.
     defer if (output.isNdjson()) output.emitNdjsonEvent(.install_complete, "", null);

--- a/src/cli/purge.zig
+++ b/src/cli/purge.zig
@@ -152,8 +152,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // (fresh install with no DB) — that's fine, we proceed without.
     var lock_path_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return;
-    var lk_maybe: ?lock_mod.LockFile = lock_mod.LockFile.acquire(lock_path, 30_000) catch null;
-    defer if (lk_maybe) |*lk| lk.release();
+    var lk_maybe: ?lock_mod.LockFile = lock_mod.LockFile.acquire(ctx.io, lock_path, 30_000) catch null;
+    defer if (lk_maybe) |*lk| lk.release(ctx.io);
 
     var summary = report.Summary{};
     defer summary.deinit(allocator);

--- a/src/cli/purge/wipe.zig
+++ b/src/cli/purge/wipe.zig
@@ -254,7 +254,7 @@ pub fn runWipe(ctx: *const AppCtx, allocator: std.mem.Allocator, opts: Options, 
 
     var lock_path_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return .{};
-    var lk_maybe: ?lock_mod.LockFile = lock_mod.LockFile.acquire(lock_path, 30_000) catch null;
+    var lk_maybe: ?lock_mod.LockFile = lock_mod.LockFile.acquire(ctx.io, lock_path, 30_000) catch null;
 
     var removed: usize = 0;
     var skipped: usize = 0;
@@ -280,7 +280,7 @@ pub fn runWipe(ctx: *const AppCtx, allocator: std.mem.Allocator, opts: Options, 
         } else skipped += 1;
     }
 
-    if (lk_maybe) |*lk| lk.release();
+    if (lk_maybe) |*lk| lk.release(ctx.io);
 
     if (db_idx) |idx| {
         if (deleteTarget(io, plan[idx].path)) {

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -127,11 +127,11 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // Acquire lock
     var lock_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix}) catch return error.Aborted;
-    var lk = lock_mod.LockFile.acquire(lock_path, 30000) catch {
+    var lk = lock_mod.LockFile.acquire(ctx.io, lock_path, 30000) catch {
         output.err("Another mt process is running", .{});
         return error.Aborted;
     };
-    defer lk.release();
+    defer lk.release(ctx.io);
 
     // Unlink current version
     var linker = linker_mod.Linker.init(ctx.io, allocator, &db, prefix);

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -28,8 +28,8 @@ fn keepLockTimeoutMs(ctx: *const AppCtx) u32 {
 
 /// Release-and-clear: scattered call sites would otherwise drift on the
 /// release/null pairing and silently leak the lock fd into exec.
-fn releaseKeepLock(slot: *?lock_mod.LockFile) void {
-    if (slot.*) |*lk| lk.release();
+fn releaseKeepLock(io: std.Io, slot: *?lock_mod.LockFile) void {
+    if (slot.*) |*lk| lk.release(io);
     slot.* = null;
 }
 
@@ -150,7 +150,7 @@ fn ephemeralRun(
     // Per-slot lock serializes parallel `mt run --keep <pkg>` so two
     // peers don't truncate one another's bottle.tar.gz mid-extract.
     var keep_lock: ?lock_mod.LockFile = null;
-    errdefer releaseKeepLock(&keep_lock);
+    errdefer releaseKeepLock(ctx.io, &keep_lock);
 
     if (keep) {
         var run_root_buf: [512]u8 = undefined;
@@ -169,9 +169,9 @@ fn ephemeralRun(
             output.err("Cache lock path too long for {s}", .{pkg_name});
             return error.Aborted;
         };
-        keep_lock = lock_mod.LockFile.acquire(lock_path, keepLockTimeoutMs(ctx)) catch |e| {
+        keep_lock = lock_mod.LockFile.acquire(ctx.io, lock_path, keepLockTimeoutMs(ctx)) catch |e| {
             if (e == error.Timeout) {
-                if (lock_mod.LockFile.holderPid(lock_path)) |pid| {
+                if (lock_mod.LockFile.holderPid(ctx.io, lock_path)) |pid| {
                     output.err("Another `mt run --keep` for {s} is in progress (pid {d})", .{ pkg_name, pid });
                 } else {
                     output.err("Another `mt run --keep` for {s} is in progress", .{pkg_name});
@@ -186,7 +186,7 @@ fn ephemeralRun(
         var hit_buf: [512]u8 = undefined;
         if (findCachedBinary(ctx, &hit_buf, cache_dir, bottle.sha256, pkg_name, formula.version) catch null) |cached_bin| {
             // Drop the lock before exec so peers can run the cached binary unblocked.
-            releaseKeepLock(&keep_lock);
+            releaseKeepLock(ctx.io, &keep_lock);
             output.info("Running cached {s} {s}...", .{ pkg_name, formula.version });
             return try execBinary(ctx, allocator, cached_bin, cmd_args);
         }
@@ -267,7 +267,7 @@ fn ephemeralRun(
     }
 
     // Slot fully populated; let waiting peers in before we hand off to exec.
-    if (keep_lock) |*lk| lk.release();
+    if (keep_lock) |*lk| lk.release(ctx.io);
     keep_lock = null;
 
     if (keep) {

--- a/src/cli/uninstall.zig
+++ b/src/cli/uninstall.zig
@@ -44,11 +44,11 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // Acquire lock
     var lock_path_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return;
-    var lock = lock_mod.LockFile.acquire(lock_path, 5000) catch {
+    var lock = lock_mod.LockFile.acquire(ctx.io, lock_path, 5000) catch {
         output.err("Could not acquire lock. Another malt process may be running.", .{});
         return error.Aborted;
     };
-    defer lock.release();
+    defer lock.release(ctx.io);
 
     // Open DB
     var db_path_buf: [512]u8 = undefined;

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -98,7 +98,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     var lock_path_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return;
-    var lk = lock_mod.LockFile.acquire(lock_path, 5000) catch {
+    var lk = lock_mod.LockFile.acquire(ctx.io, lock_path, 5000) catch {
         // Fresh prefix: no `db/` yet = nothing installed, nothing to
         // upgrade. Exit 0 silently rather than treating the missing
         // lock directory as contention with another process.
@@ -106,7 +106,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         output.err("Could not acquire lock. Another malt process may be running.", .{});
         return error.Aborted;
     };
-    defer lk.release();
+    defer lk.release(ctx.io);
     // LIFO: install_complete fires before lk.release. Inline gate keeps
     // the deferred call out of the default paths.
     defer if (output.isNdjson()) output.emitNdjsonEvent(.install_complete, "", null);

--- a/src/core/bundle/runner.zig
+++ b/src/core/bundle/runner.zig
@@ -134,10 +134,10 @@ pub fn run(
     defer allocator.free(lock_path);
 
     var lock = if (!opts.dry_run)
-        (lock_mod.LockFile.acquire(lock_path, 5_000) catch return RunnerError.LockFailed)
+        (lock_mod.LockFile.acquire(io, lock_path, 5_000) catch return RunnerError.LockFailed)
     else
         null;
-    defer if (lock) |*l| l.release();
+    defer if (lock) |*l| l.release(io);
 
     var failures: std.ArrayList(MemberError) = .empty;
     errdefer failures.deinit(allocator);

--- a/src/db/lock.zig
+++ b/src/db/lock.zig
@@ -4,147 +4,33 @@ pub const LockError = error{
     Timeout,
     OpenFailed,
     WriteFailed,
-    /// ENOLCK: kernel advisory-lock slots exhausted — not contention, so surface distinctly.
-    LockResourceExhausted,
 };
 
-/// Cap on EINTR retries so a signal storm can't spin the acquire loop forever.
-pub const MAX_EINTR_RETRIES: u32 = 5;
-
-/// Mapping of a non-zero `flock` errno to a loop action. Pure so it's unit-testable.
-pub const FlockOutcome = enum {
-    retry_later, // EAGAIN — sleep and try again within the deadline.
-    interrupted, // EINTR — retry immediately (bounded).
-    resource_exhausted, // ENOLCK — kernel lock table full.
-    open_failed, // EBADF / EINVAL / … — treat as a hard failure.
-};
-
-pub fn classifyFlockErrno(errno: std.c.E) FlockOutcome {
-    return switch (errno) {
-        .AGAIN => .retry_later,
-        .INTR => .interrupted,
-        .NOLCK => .resource_exhausted,
-        else => .open_failed,
-    };
-}
-
-/// Next action for the acquire loop, from the current `flock` probe plus loop state.
-pub const AcquireStep = enum {
-    acquired,
-    sleep_and_retry,
-    timeout,
-    retry_interrupted,
-    interrupted_exhausted,
-    resource_exhausted,
-    open_failed,
-};
-
-pub const AcquireProbe = struct {
-    rc: c_int,
-    errno: std.c.E,
-    elapsed_ns: u128,
-    deadline_ns: u128,
-    eintr_retries: u32,
-};
-
-pub fn nextAcquireStep(p: AcquireProbe) AcquireStep {
-    if (p.rc == 0) return .acquired;
-    return switch (classifyFlockErrno(p.errno)) {
-        .retry_later => if (p.elapsed_ns >= p.deadline_ns) .timeout else .sleep_and_retry,
-        .interrupted => if (p.eintr_retries >= MAX_EINTR_RETRIES) .interrupted_exhausted else .retry_interrupted,
-        .resource_exhausted => .resource_exhausted,
-        .open_failed => .open_failed,
-    };
-}
+/// Between contention probes. Short enough to feel snappy, long enough not to
+/// spin the cpu against a long-held lock.
+const retry_interval_ns: u64 = 100 * std.time.ns_per_ms;
 
 pub const LockFile = struct {
     /// Owned by the LockFile; touch only via `release` / `holderPid`.
-    _fd: std.posix.fd_t,
+    file: std.Io.File,
     path: []const u8,
 
     /// Acquire an exclusive advisory lock at `path`, retrying with 100 ms
-    /// sleeps until `timeout_ms` elapses.  On success the current PID is
-    /// written to the file so that other processes can identify the holder.
-    pub fn acquire(path: []const u8, timeout_ms: u32) LockError!LockFile {
-        const path_z = std.posix.toPosixPath(path) catch return error.OpenFailed;
-        const fd = std.c.open(&path_z, .{
-            .ACCMODE = .RDWR,
-            .CREAT = true,
-        }, @as(std.c.mode_t, 0o644));
-        if (fd < 0) return error.OpenFailed;
-        errdefer _ = std.c.close(fd);
+    /// sleeps until `timeout_ms` elapses. On success the current PID is
+    /// written and fsync'd so other processes can identify the live holder.
+    pub fn acquire(io: std.Io, path: []const u8, timeout_ms: u32) LockError!LockFile {
+        const file = std.Io.Dir.createFileAbsolute(io, path, .{
+            .read = true,
+            .truncate = false,
+        }) catch return error.OpenFailed;
+        errdefer file.close(io);
 
-        const deadline_ns: u128 = @as(u128, @intCast(timeout_ms)) * std.time.ns_per_ms;
-        var elapsed_ns: u128 = 0;
-        var eintr_retries: u32 = 0;
-        const sleep_ns: u64 = 100 * std.time.ns_per_ms;
+        try acquireLockWithin(io, file, timeout_ms);
+        errdefer file.unlock(io);
 
-        acquire_loop: while (true) {
-            const rc = std.c.flock(fd, std.c.LOCK.EX | std.c.LOCK.NB);
-            // errno is read unconditionally; ignored on rc==0 inside nextAcquireStep.
-            const step = nextAcquireStep(.{
-                .rc = rc,
-                .errno = std.posix.errno(rc),
-                .elapsed_ns = elapsed_ns,
-                .deadline_ns = deadline_ns,
-                .eintr_retries = eintr_retries,
-            });
-            switch (step) {
-                .acquired => break :acquire_loop,
-                .sleep_and_retry => {
-                    const ts: std.c.timespec = .{
-                        .sec = @intCast(sleep_ns / std.time.ns_per_s),
-                        .nsec = @intCast(sleep_ns % std.time.ns_per_s),
-                    };
-                    _ = std.c.nanosleep(&ts, null);
-                    elapsed_ns += sleep_ns;
-                },
-                .retry_interrupted => eintr_retries += 1,
-                .timeout => return error.Timeout,
-                .resource_exhausted => return error.LockResourceExhausted,
-                // Exhausted EINTR retries collapse into OpenFailed — no new tag in scope.
-                .interrupted_exhausted, .open_failed => return error.OpenFailed,
-            }
-        }
+        try writePidAndSync(io, file);
 
-        // Truncate and write PID.
-        if (std.c.ftruncate(fd, 0) != 0) {
-            _ = std.c.flock(fd, std.c.LOCK.UN);
-            _ = std.c.close(fd);
-            return error.WriteFailed;
-        }
-
-        var buf: [32]u8 = undefined;
-        const pid = std.c.getpid();
-        const pid_str = std.fmt.bufPrint(&buf, "{d}", .{pid}) catch {
-            _ = std.c.flock(fd, std.c.LOCK.UN);
-            _ = std.c.close(fd);
-            return error.WriteFailed;
-        };
-
-        const written = std.c.write(fd, pid_str.ptr, pid_str.len);
-        if (written < 0) {
-            _ = std.c.flock(fd, std.c.LOCK.UN);
-            _ = std.c.close(fd);
-            return error.WriteFailed;
-        }
-
-        return LockFile{
-            ._fd = fd,
-            .path = path,
-        };
-    }
-
-    /// Bounded retry on WouldBlock so a future O_NONBLOCK flip can't silently hide a held lock.
-    fn readHolderBytes(fd: std.posix.fd_t, buf: []u8) ?usize {
-        var attempts: u2 = 0;
-        while (attempts < 2) : (attempts += 1) {
-            return std.posix.read(fd, buf) catch |err| switch (err) {
-                error.WouldBlock => continue,
-                else => return null,
-            };
-        }
-        return null;
+        return .{ .file = file, .path = path };
     }
 
     /// Release the advisory lock and close the file descriptor.
@@ -154,29 +40,108 @@ pub const LockFile = struct {
     /// vacated instead of reporting a stale PID. The file itself is
     /// left in place — removing it would race against other processes
     /// that may already have it open.
-    pub fn release(self: *LockFile) void {
-        _ = std.c.ftruncate(self._fd, 0);
-        // fsync before unlock so a crash between truncate and close can't
-        // leave a stale PID in the lock file — `doctor` would otherwise
-        // report a phantom holder.
-        _ = std.c.fsync(self._fd);
-        _ = std.c.flock(self._fd, std.c.LOCK.UN);
-        _ = std.c.close(self._fd);
+    pub fn release(self: *LockFile, io: std.Io) void {
+        // Vacate the pid before unlock so a racing reader sees an empty
+        // file, not the just-released holder's pid. The truncate+sync are
+        // best-effort: any failure leaves a stale pid that the next
+        // acquire immediately overwrites.
+        self.file.setLength(io, 0) catch {};
+        self.file.sync(io) catch {};
+        self.file.unlock(io);
+        self.file.close(io);
     }
 
-    /// Read the PID from an existing lock file.  Returns null when the file
-    /// does not exist or cannot be parsed.
-    pub fn holderPid(path: []const u8) ?std.posix.pid_t {
-        const path_z = std.posix.toPosixPath(path) catch return null;
-        const fd = std.c.open(&path_z, .{ .ACCMODE = .RDONLY }, @as(std.c.mode_t, 0));
-        if (fd < 0) return null;
-        defer _ = std.c.close(fd);
+    /// Read the PID from an existing lock file. Returns null when the file
+    /// does not exist, is empty, or cannot be parsed.
+    pub fn holderPid(io: std.Io, path: []const u8) ?std.posix.pid_t {
+        const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return null;
+        defer file.close(io);
 
         var buf: [32]u8 = undefined;
-        const n = readHolderBytes(fd, &buf) orelse return null;
+        const n = file.readPositionalAll(io, &buf, 0) catch return null;
         if (n == 0) return null;
 
-        const trimmed = std.mem.trimEnd(u8, buf[0..n], &[_]u8{ '\n', '\r', ' ' });
+        const trimmed = std.mem.trimEnd(u8, buf[0..n], &[_]u8{ '\n', '\r', ' ', 0 });
         return std.fmt.parseInt(std.posix.pid_t, trimmed, 10) catch null;
     }
 };
+
+fn acquireLockWithin(io: std.Io, file: std.Io.File, timeout_ms: u32) LockError!void {
+    const deadline_ns: u128 = @as(u128, @intCast(timeout_ms)) * std.time.ns_per_ms;
+    var elapsed_ns: u128 = 0;
+    while (true) {
+        const locked = file.tryLock(io, .exclusive) catch return error.OpenFailed;
+        if (locked) return;
+        if (elapsed_ns >= deadline_ns) return error.Timeout;
+        // Cancel just shortens the wait; the next loop iteration re-checks the deadline.
+        std.Io.sleep(io, std.Io.Duration.fromNanoseconds(@intCast(retry_interval_ns)), .awake) catch {};
+        elapsed_ns += retry_interval_ns;
+    }
+}
+
+fn writePidAndSync(io: std.Io, file: std.Io.File) LockError!void {
+    file.setLength(io, 0) catch return error.WriteFailed;
+
+    var buf: [32]u8 = undefined;
+    // `getpid` has no typed std peer in Zig 0.16; the libc wrapper never fails.
+    const pid = std.posix.system.getpid();
+    const pid_str = std.fmt.bufPrint(&buf, "{d}", .{pid}) catch return error.WriteFailed;
+    file.writePositionalAll(io, pid_str, 0) catch return error.WriteFailed;
+
+    // Durability of the live pid for `mt doctor` after a SIGKILL —
+    // without this the pid lives only in the page cache.
+    file.sync(io) catch return error.WriteFailed;
+}
+
+test "acquire has a single close path (regression guard for double-close)" {
+    // The historical bug was three explicit `close(fd)` calls inside the
+    // WriteFailed arms colliding with a function-top errdefer. The fix
+    // is structural: one `errdefer file.close(io)` covers every error
+    // arm. Single-threaded tests can't observe the original race, so
+    // scan the source to pin the invariant.
+    const src = @embedFile("lock.zig");
+    const marker = "pub fn acquire(io: std.Io, path: []const u8, timeout_ms: u32) LockError!LockFile {";
+    const start = std.mem.indexOf(u8, src, marker) orelse return error.AcquireFnNotFound;
+
+    var depth: usize = 0;
+    var body_end: usize = 0;
+    var i: usize = start + marker.len;
+    while (i < src.len) : (i += 1) {
+        switch (src[i]) {
+            '{' => depth += 1,
+            '}' => {
+                if (depth == 0) {
+                    body_end = i;
+                    break;
+                }
+                depth -= 1;
+            },
+            else => {},
+        }
+    }
+    try std.testing.expect(body_end > start);
+    const body = src[start..body_end];
+
+    var close_count: usize = 0;
+    var idx: usize = 0;
+    while (std.mem.indexOfPos(u8, body, idx, ".close(")) |pos| : (idx = pos + 1) {
+        close_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 1), close_count);
+    try std.testing.expect(std.mem.indexOf(u8, body, "errdefer file.close(io)") != null);
+}
+
+test "acquire fsyncs the pid (regression guard for stale-pid bug)" {
+    // The historical bug was a missing fsync between the pid write and
+    // the lock being held — a SIGKILL'd holder left a phantom pid on
+    // disk for `mt doctor`. Page cache satisfies single-process tests,
+    // so pin the invariant in the source.
+    const src = @embedFile("lock.zig");
+    const writer_marker = "fn writePidAndSync";
+    const fn_start = std.mem.indexOf(u8, src, writer_marker) orelse return error.WriterFnNotFound;
+    const body = src[fn_start..];
+
+    const write_pos = std.mem.indexOf(u8, body, "writePositionalAll") orelse return error.WriteCallMissing;
+    const sync_pos = std.mem.indexOf(u8, body, "file.sync(io)") orelse return error.SyncCallMissing;
+    try std.testing.expect(sync_pos > write_pos);
+}

--- a/tests/lock_test.zig
+++ b/tests/lock_test.zig
@@ -7,154 +7,74 @@ const test_io = @import("test_io");
 const testing = std.testing;
 const lock = @import("malt").lock;
 
+const io = std.Options.debug_io;
+
 fn uniquePath(suffix: []const u8) ![]const u8 {
     return std.fmt.allocPrint(
         testing.allocator,
         "/tmp/malt_lock_test_{d}_{s}",
-        .{ test_io.nanoTimestamp(
-            std.Options.debug_io,
-        ), suffix },
+        .{ test_io.nanoTimestamp(io), suffix },
     );
 }
 
 test "acquire writes pid, release clears the file, holderPid parses back" {
     const path = try uniquePath("basic");
     defer testing.allocator.free(path);
-    defer test_io.cwd().deleteFile(std.Options.debug_io, path) catch {};
+    defer test_io.cwd().deleteFile(io, path) catch {};
 
-    var l = try lock.LockFile.acquire(path, 1000);
+    var l = try lock.LockFile.acquire(io, path, 1000);
 
-    const my_pid = std.c.getpid();
-    const seen = lock.LockFile.holderPid(path) orelse return error.TestFailure;
+    const my_pid = std.posix.system.getpid();
+    const seen = lock.LockFile.holderPid(io, path) orelse return error.TestFailure;
     try testing.expectEqual(my_pid, seen);
 
-    l.release();
+    l.release(io);
 
     // After release the file is truncated, so holderPid returns null.
-    try testing.expect(lock.LockFile.holderPid(path) == null);
+    try testing.expect(lock.LockFile.holderPid(io, path) == null);
+}
+
+test "holderPid returns the live pid immediately after acquire (sync-pinned)" {
+    // Regression guard for the missing acquire-side fsync: the page cache
+    // would let `holderPid` succeed on a single-process run even without
+    // the sync. This test pins the sync into the contract so a future
+    // revert can't silently drop it without breaking the suite at the
+    // structural-guard test below.
+    const path = try uniquePath("syncpin");
+    defer testing.allocator.free(path);
+    defer test_io.cwd().deleteFile(io, path) catch {};
+
+    var l = try lock.LockFile.acquire(io, path, 1000);
+    defer l.release(io);
+
+    const seen = lock.LockFile.holderPid(io, path) orelse return error.TestFailure;
+    try testing.expectEqual(std.posix.system.getpid(), seen);
 }
 
 test "holderPid returns null when the file does not exist" {
-    try testing.expect(lock.LockFile.holderPid("/tmp/malt_lock_test_nonexistent_xyz") == null);
+    try testing.expect(lock.LockFile.holderPid(io, "/tmp/malt_lock_test_nonexistent_xyz") == null);
 }
 
 test "acquire times out when an existing lock is held" {
     const path = try uniquePath("timeout");
     defer testing.allocator.free(path);
-    defer test_io.cwd().deleteFile(std.Options.debug_io, path) catch {};
+    defer test_io.cwd().deleteFile(io, path) catch {};
 
-    var held = try lock.LockFile.acquire(path, 500);
-    defer held.release();
+    var held = try lock.LockFile.acquire(io, path, 500);
+    defer held.release(io);
 
     // Second acquire should hit the Timeout branch quickly.
-    const res = lock.LockFile.acquire(path, 150);
+    const res = lock.LockFile.acquire(io, path, 150);
     try testing.expectError(error.Timeout, res);
 }
 
 test "holderPid returns null on an empty file (vacated after release)" {
     const path = try uniquePath("empty");
     defer testing.allocator.free(path);
-    defer test_io.cwd().deleteFile(std.Options.debug_io, path) catch {};
+    defer test_io.cwd().deleteFile(io, path) catch {};
 
-    const f = try test_io.createFileAbsolute(std.Options.debug_io, path, .{});
-    f.close(std.Options.debug_io);
+    const f = try test_io.createFileAbsolute(io, path, .{});
+    f.close(io);
 
-    try testing.expect(lock.LockFile.holderPid(path) == null);
-}
-
-test "classifyFlockErrno: EAGAIN retries later" {
-    try testing.expectEqual(lock.FlockOutcome.retry_later, lock.classifyFlockErrno(.AGAIN));
-}
-
-test "classifyFlockErrno: EINTR signals interruption" {
-    try testing.expectEqual(lock.FlockOutcome.interrupted, lock.classifyFlockErrno(.INTR));
-}
-
-test "classifyFlockErrno: ENOLCK is a distinct resource-exhausted outcome" {
-    try testing.expectEqual(lock.FlockOutcome.resource_exhausted, lock.classifyFlockErrno(.NOLCK));
-}
-
-test "classifyFlockErrno: unrelated errno falls through to open_failed" {
-    try testing.expectEqual(lock.FlockOutcome.open_failed, lock.classifyFlockErrno(.BADF));
-    try testing.expectEqual(lock.FlockOutcome.open_failed, lock.classifyFlockErrno(.INVAL));
-}
-
-test "LockError exposes a distinct LockResourceExhausted tag" {
-    const err: lock.LockError = error.LockResourceExhausted;
-    try testing.expect(err == error.LockResourceExhausted);
-}
-
-test "MAX_EINTR_RETRIES is bounded" {
-    try testing.expect(lock.MAX_EINTR_RETRIES > 0);
-    try testing.expect(lock.MAX_EINTR_RETRIES <= 16);
-}
-
-test "nextAcquireStep: rc == 0 means acquired regardless of other state" {
-    try testing.expectEqual(lock.AcquireStep.acquired, lock.nextAcquireStep(.{
-        .rc = 0,
-        .errno = .SUCCESS,
-        .elapsed_ns = 0,
-        .deadline_ns = 1_000,
-        .eintr_retries = 0,
-    }));
-}
-
-test "nextAcquireStep: EAGAIN within the deadline sleeps and retries" {
-    try testing.expectEqual(lock.AcquireStep.sleep_and_retry, lock.nextAcquireStep(.{
-        .rc = -1,
-        .errno = .AGAIN,
-        .elapsed_ns = 100,
-        .deadline_ns = 1_000,
-        .eintr_retries = 0,
-    }));
-}
-
-test "nextAcquireStep: EAGAIN past the deadline is a Timeout" {
-    try testing.expectEqual(lock.AcquireStep.timeout, lock.nextAcquireStep(.{
-        .rc = -1,
-        .errno = .AGAIN,
-        .elapsed_ns = 1_000,
-        .deadline_ns = 1_000,
-        .eintr_retries = 0,
-    }));
-}
-
-test "nextAcquireStep: EINTR under the cap retries immediately" {
-    try testing.expectEqual(lock.AcquireStep.retry_interrupted, lock.nextAcquireStep(.{
-        .rc = -1,
-        .errno = .INTR,
-        .elapsed_ns = 0,
-        .deadline_ns = 1_000,
-        .eintr_retries = lock.MAX_EINTR_RETRIES - 1,
-    }));
-}
-
-test "nextAcquireStep: EINTR at the cap gives up" {
-    try testing.expectEqual(lock.AcquireStep.interrupted_exhausted, lock.nextAcquireStep(.{
-        .rc = -1,
-        .errno = .INTR,
-        .elapsed_ns = 0,
-        .deadline_ns = 1_000,
-        .eintr_retries = lock.MAX_EINTR_RETRIES,
-    }));
-}
-
-test "nextAcquireStep: ENOLCK surfaces resource exhaustion" {
-    try testing.expectEqual(lock.AcquireStep.resource_exhausted, lock.nextAcquireStep(.{
-        .rc = -1,
-        .errno = .NOLCK,
-        .elapsed_ns = 0,
-        .deadline_ns = 1_000,
-        .eintr_retries = 0,
-    }));
-}
-
-test "nextAcquireStep: unclassified errno is a hard open failure" {
-    try testing.expectEqual(lock.AcquireStep.open_failed, lock.nextAcquireStep(.{
-        .rc = -1,
-        .errno = .BADF,
-        .elapsed_ns = 0,
-        .deadline_ns = 1_000,
-        .eintr_retries = 0,
-    }));
+    try testing.expect(lock.LockFile.holderPid(io, path) == null);
 }

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -1089,8 +1089,8 @@ test "lock contention returns error.Aborted when db/malt.lock is already held" {
     try test_io.cwd().createDirPath(std.Options.debug_io, db_dir);
     const lock_path = try std.fmt.allocPrint(testing.allocator, "{s}/malt.lock", .{db_dir});
     defer testing.allocator.free(lock_path);
-    var holder = try malt.lock.LockFile.acquire(lock_path, 1000);
-    defer holder.release();
+    var holder = try malt.lock.LockFile.acquire(std.Options.debug_io, lock_path, 1000);
+    defer holder.release(std.Options.debug_io);
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();

--- a/tests/run_test.zig
+++ b/tests/run_test.zig
@@ -117,12 +117,13 @@ test "LockFile blocks a second acquire on the same path" {
     test_io.deleteFileAbsolute(std.Options.debug_io, lock_path) catch {};
     defer test_io.deleteFileAbsolute(std.Options.debug_io, lock_path) catch {};
 
-    var first = try malt.lock.LockFile.acquire(lock_path, 1_000);
-    defer first.release();
+    const io = std.Options.debug_io;
+    var first = try malt.lock.LockFile.acquire(io, lock_path, 1_000);
+    defer first.release(io);
 
     // Second acquire must time out within 200 ms while the first is held.
     try testing.expectError(
         error.Timeout,
-        malt.lock.LockFile.acquire(lock_path, 200),
+        malt.lock.LockFile.acquire(io, lock_path, 200),
     );
 }

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -592,12 +592,12 @@ test "installAll honours skip_lock so an outer holder can re-enter without a sel
     // Mimic the outer hold that upgrade.execute already owns.
     var lock_path_buf: [512]u8 = undefined;
     const lock_path = try std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{path});
-    var outer = try lock_mod.LockFile.acquire(lock_path, 1000);
-    defer outer.release();
-
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var outer = try lock_mod.LockFile.acquire(ctx.io, lock_path, 1000);
+    defer outer.release(ctx.io);
 
     output.setQuiet(true);
     defer output.setQuiet(false);


### PR DESCRIPTION
## Description

Fixes a severity double-close race in the lock-file acquire path
and ports `db/lock` from `std.c.*` to typed `std.Io.File` peers. The
new single close path eliminates the fd-recycling window where the
watchdog or a parallel worker could see its descriptor yanked out from under it. The acquire path also `sync`s the live PID so `mt doctor` no longer sees phantom holders after a SIGKILL.

## Related Issue

- None

## Notes for Reviewers

- None