### PR TITLE
fix(macho/patcher): make text-file replacements atomic

### DIFF
--- a/src/fs/atomic.zig
+++ b/src/fs/atomic.zig
@@ -156,6 +156,31 @@ pub fn atomicWriteFile(io: std.Io, dst_path: []const u8, data: []const u8) !void
     return atomicWriteFileImpl(io, dst_path, data, default_sync_ops);
 }
 
+/// Atomic write that re-applies the existing file's permissions after
+/// the rename. Use this when overwriting a live file whose mode bits
+/// (exec on shebangs, libtool archives, pkgconfig fragments) must
+/// survive the swap — `atomicWriteFile` alone publishes the new content
+/// under the platform default and would silently drop the exec bit.
+/// A missing `dst_path` is treated as a fresh write.
+pub fn atomicReplaceFile(io: std.Io, dst_path: []const u8, data: []const u8) !void {
+    const prior_perms: ?std.Io.File.Permissions = blk: {
+        const existing = std.Io.Dir.openFileAbsolute(io, dst_path, .{}) catch break :blk null;
+        defer existing.close(io);
+        const s = existing.stat(io) catch break :blk null;
+        break :blk s.permissions;
+    };
+
+    try atomicWriteFile(io, dst_path, data);
+
+    if (prior_perms) |p| {
+        // Best-effort mode restore: content is already durable on disk;
+        // failing here would only drop us back to the platform-default mode.
+        const f = std.Io.Dir.openFileAbsolute(io, dst_path, .{}) catch return;
+        defer f.close(io);
+        f.setPermissions(io, p) catch {};
+    }
+}
+
 fn atomicWriteFileImpl(io: std.Io, dst_path: []const u8, data: []const u8, sync_ops: anytype) !void {
     var rand_bytes: [4]u8 = undefined;
     std.c.arc4random_buf(&rand_bytes, rand_bytes.len);

--- a/src/fs/atomic.zig
+++ b/src/fs/atomic.zig
@@ -153,35 +153,34 @@ const default_sync_ops: DefaultSyncOps = .{};
 /// leaves the tempfile behind; the next call writes its own and
 /// overwrites atomically.
 pub fn atomicWriteFile(io: std.Io, dst_path: []const u8, data: []const u8) !void {
-    return atomicWriteFileImpl(io, dst_path, data, default_sync_ops);
+    return atomicWriteFileImpl(io, dst_path, data, default_sync_ops, .default_file);
 }
 
-/// Atomic write that re-applies the existing file's permissions after
-/// the rename. Use this when overwriting a live file whose mode bits
-/// (exec on shebangs, libtool archives, pkgconfig fragments) must
-/// survive the swap — `atomicWriteFile` alone publishes the new content
-/// under the platform default and would silently drop the exec bit.
-/// A missing `dst_path` is treated as a fresh write.
+/// Atomic write that publishes `data` under the existing file's
+/// permissions. The tempfile is created with the snapshotted mode so
+/// the rename itself is the single observable transition — no window
+/// where the new file carries the platform default. Use this when
+/// overwriting a live file whose mode bits (exec on shebangs, libtool
+/// archives, pkgconfig fragments) must survive the swap. A missing
+/// `dst_path` falls back to the platform default, matching
+/// `atomicWriteFile`.
 pub fn atomicReplaceFile(io: std.Io, dst_path: []const u8, data: []const u8) !void {
-    const prior_perms: ?std.Io.File.Permissions = blk: {
-        const existing = std.Io.Dir.openFileAbsolute(io, dst_path, .{}) catch break :blk null;
+    const perms: std.Io.File.Permissions = blk: {
+        const existing = std.Io.Dir.openFileAbsolute(io, dst_path, .{}) catch break :blk .default_file;
         defer existing.close(io);
-        const s = existing.stat(io) catch break :blk null;
+        const s = existing.stat(io) catch break :blk .default_file;
         break :blk s.permissions;
     };
-
-    try atomicWriteFile(io, dst_path, data);
-
-    if (prior_perms) |p| {
-        // Best-effort mode restore: content is already durable on disk;
-        // failing here would only drop us back to the platform-default mode.
-        const f = std.Io.Dir.openFileAbsolute(io, dst_path, .{}) catch return;
-        defer f.close(io);
-        f.setPermissions(io, p) catch {};
-    }
+    return atomicWriteFileImpl(io, dst_path, data, default_sync_ops, perms);
 }
 
-fn atomicWriteFileImpl(io: std.Io, dst_path: []const u8, data: []const u8, sync_ops: anytype) !void {
+fn atomicWriteFileImpl(
+    io: std.Io,
+    dst_path: []const u8,
+    data: []const u8,
+    sync_ops: anytype,
+    permissions: std.Io.File.Permissions,
+) !void {
     var rand_bytes: [4]u8 = undefined;
     std.c.arc4random_buf(&rand_bytes, rand_bytes.len);
     const hex_chars = "0123456789abcdef";
@@ -196,7 +195,10 @@ fn atomicWriteFileImpl(io: std.Io, dst_path: []const u8, data: []const u8, sync_
         return error.NameTooLong;
 
     {
-        const f = try std.Io.Dir.createFileAbsolute(io, tmp_path, .{ .truncate = true });
+        const f = try std.Io.Dir.createFileAbsolute(io, tmp_path, .{
+            .truncate = true,
+            .permissions = permissions,
+        });
         defer f.close(io);
         // Drop the tempfile on any failure before rename publishes it.
         errdefer std.Io.Dir.deleteFileAbsolute(io, tmp_path) catch {};
@@ -310,7 +312,7 @@ test "atomicWriteFileImpl fsyncs the tempfile via the injected sync ops" {
     defer std.Io.Dir.cwd().deleteTree(io, base) catch {};
 
     test_sync_counters = .{};
-    try atomicWriteFileImpl(io, base ++ "/data.bin", "abc", TestSyncOps{});
+    try atomicWriteFileImpl(io, base ++ "/data.bin", "abc", TestSyncOps{}, .default_file);
     try std.testing.expectEqual(@as(usize, 1), test_sync_counters.file);
 }
 
@@ -322,7 +324,7 @@ test "atomicWriteFileImpl fsyncs the parent directory via the injected sync ops"
     defer std.Io.Dir.cwd().deleteTree(io, base) catch {};
 
     test_sync_counters = .{};
-    try atomicWriteFileImpl(io, base ++ "/data.bin", "abc", TestSyncOps{});
+    try atomicWriteFileImpl(io, base ++ "/data.bin", "abc", TestSyncOps{}, .default_file);
     try std.testing.expectEqual(@as(usize, 1), test_sync_counters.dir);
 }
 
@@ -336,7 +338,7 @@ test "atomicWriteFileImpl propagates syncFile errors and removes the tempfile" {
     const dst = base ++ "/data.bin";
     try std.testing.expectError(
         error.AccessDenied,
-        atomicWriteFileImpl(io, dst, "abc", TestSyncOps{ .fail_file = true }),
+        atomicWriteFileImpl(io, dst, "abc", TestSyncOps{ .fail_file = true }, .default_file),
     );
 
     // dst was never renamed in; tempfiles must not accumulate either.
@@ -357,7 +359,7 @@ test "atomicWriteFileImpl propagates syncDir errors but leaves the renamed file 
     const dst = base ++ "/data.bin";
     try std.testing.expectError(
         error.AccessDenied,
-        atomicWriteFileImpl(io, dst, "abc", TestSyncOps{ .fail_dir = true }),
+        atomicWriteFileImpl(io, dst, "abc", TestSyncOps{ .fail_dir = true }, .default_file),
     );
 
     // syncDir runs after rename, so dst_path must hold the durable bytes.

--- a/src/macho/patcher.zig
+++ b/src/macho/patcher.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 const parser = @import("parser.zig");
 const text_replace = @import("../text_replace.zig");
+const atomic = @import("../fs/atomic.zig");
 
 pub const PatchError = error{
     PathTooLong,
@@ -462,11 +463,12 @@ pub fn patchTextFiles(
 
         if (modified) {
             defer if (current.ptr != content.ptr) allocator.free(current);
-            // Write back
-            file.writePositionalAll(io, current, 0) catch continue;
-            // Truncate if new content is shorter; trailing bytes are harmless if truncate fails
-            // (Mach-O loader stops at size recorded in header, not file size).
-            file.setLength(io, current.len) catch {};
+            // Atomic rename keeps the file old-or-new on a mid-write
+            // failure; `Replace` (not `Write`) also preserves the exec
+            // bit on shebanged scripts and shell wrappers.
+            var abs_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const abs_path = std.fmt.bufPrint(&abs_buf, "{s}/{s}", .{ dir_path, entry.path }) catch continue;
+            atomic.atomicReplaceFile(io, abs_path, current) catch continue;
             count += 1;
         }
     }

--- a/src/macho/patcher.zig
+++ b/src/macho/patcher.zig
@@ -420,8 +420,10 @@ pub fn patchTextFiles(
     while (try walker.next(io)) |entry| {
         if (entry.kind != .file) continue;
 
-        // Read file
-        const file = dir.openFile(io, entry.path, .{ .mode = .read_write }) catch continue;
+        // Read-only: the rewrite is published by the atomic helper, not
+        // through this handle, so a 0o444 read-only config is still
+        // patchable.
+        const file = dir.openFile(io, entry.path, .{ .mode = .read_only }) catch continue;
         defer file.close(io);
 
         const stat = file.stat(io) catch continue;

--- a/tests/atomic_test.zig
+++ b/tests/atomic_test.zig
@@ -383,6 +383,103 @@ test "atomicWriteFile surfaces FileNotFound when the parent dir is missing" {
     try testing.expectError(error.FileNotFound, err);
 }
 
+// atomicReplaceFile: the rename publishes new content under the prior
+// mode bits. Direct coverage so the helper's contract is pinned even
+// when its only caller (the macho/patcher) is refactored.
+
+test "atomicReplaceFile preserves the existing file's mode" {
+    const base = "/tmp/malt_atomic_replace_preserve";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    try test_io.makeDirAbsolute(std.Options.debug_io, base);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+
+    const dst = base ++ "/wrapper";
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, dst, .{});
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "OLD");
+        // 0o750 = unusual triple so a default-mode regression is unambiguous.
+        try f.setPermissions(std.Options.debug_io, std.Io.File.Permissions.fromMode(0o750));
+    }
+
+    try atomic.atomicReplaceFile(std.Options.debug_io, dst, "NEW");
+
+    const f = try test_io.openFileAbsolute(std.Options.debug_io, dst, .{});
+    defer f.close(std.Options.debug_io);
+    var buf: [8]u8 = undefined;
+    const n = try f.readPositionalAll(std.Options.debug_io, &buf, 0);
+    try testing.expectEqualStrings("NEW", buf[0..n]);
+
+    const s = try f.stat(std.Options.debug_io);
+    try testing.expectEqual(@as(std.posix.mode_t, 0o750), s.permissions.toMode() & 0o7777);
+}
+
+test "atomicReplaceFile writes a fresh file when dst is missing" {
+    const base = "/tmp/malt_atomic_replace_fresh";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    try test_io.makeDirAbsolute(std.Options.debug_io, base);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+
+    const dst = base ++ "/new.txt";
+    try atomic.atomicReplaceFile(std.Options.debug_io, dst, "hello");
+
+    const f = try test_io.openFileAbsolute(std.Options.debug_io, dst, .{});
+    defer f.close(std.Options.debug_io);
+    var buf: [16]u8 = undefined;
+    const n = try f.readPositionalAll(std.Options.debug_io, &buf, 0);
+    try testing.expectEqualStrings("hello", buf[0..n]);
+}
+
+test "atomicReplaceFile leaves the original intact when staging fails" {
+    // Root would bypass the 0o555 the test relies on to fail the rename.
+    if (std.c.geteuid() == 0) return error.SkipZigTest;
+
+    const base = "/tmp/malt_atomic_replace_intact";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    try test_io.makeDirAbsolute(std.Options.debug_io, base);
+
+    const dst = base ++ "/wrapper";
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, dst, .{});
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "ORIGINAL");
+    }
+
+    // Lock the parent so the helper cannot stage a sibling tempfile.
+    {
+        var d = try test_io.openDirAbsolute(std.Options.debug_io, base, .{});
+        defer d.close(std.Options.debug_io);
+        const handle: std.Io.File = .{ .handle = d.handle, .flags = .{ .nonblocking = false } };
+        handle.setPermissions(std.Options.debug_io, std.Io.File.Permissions.fromMode(0o555)) catch return error.SkipZigTest;
+    }
+    defer {
+        unlock: {
+            var d = test_io.openDirAbsolute(std.Options.debug_io, base, .{}) catch break :unlock;
+            defer d.close(std.Options.debug_io);
+            const handle: std.Io.File = .{ .handle = d.handle, .flags = .{ .nonblocking = false } };
+            handle.setPermissions(std.Options.debug_io, std.Io.File.Permissions.fromMode(0o755)) catch {};
+        }
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    }
+
+    // Whatever error the helper surfaces, the load-bearing invariant is
+    // that the path still holds the original bytes afterwards.
+    _ = atomic.atomicReplaceFile(std.Options.debug_io, dst, "NEW") catch {};
+
+    {
+        var d = try test_io.openDirAbsolute(std.Options.debug_io, base, .{});
+        defer d.close(std.Options.debug_io);
+        const handle: std.Io.File = .{ .handle = d.handle, .flags = .{ .nonblocking = false } };
+        try handle.setPermissions(std.Options.debug_io, std.Io.File.Permissions.fromMode(0o755));
+    }
+
+    const f = try test_io.openFileAbsolute(std.Options.debug_io, dst, .{});
+    defer f.close(std.Options.debug_io);
+    var buf: [16]u8 = undefined;
+    const n = try f.readPositionalAll(std.Options.debug_io, &buf, 0);
+    try testing.expectEqualStrings("ORIGINAL", buf[0..n]);
+}
+
 test "atomicRename moves a directory tree within the same filesystem" {
     const base = "/tmp/malt_atomic_rename_dir";
     test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};

--- a/tests/patcher_test.zig
+++ b/tests/patcher_test.zig
@@ -366,6 +366,23 @@ test "flushOverflow on an empty list does nothing and returns ok" {
 // patchTextFiles — atomicity and mode-preservation invariants
 // ---------------------------------------------------------------------------
 
+/// Goes through `std.Io.File.setPermissions` (matching the dir-as-file
+/// pattern used by `src/fs/atomic.zig`) so the new tests never reach for
+/// `std.c.chmod`. `geteuid` has no portable Zig peer in 0.16 and stays
+/// on `std.c` — same call shape as `tests/swap_test.zig`.
+fn chmodDir(io: std.Io, path: []const u8, mode: std.posix.mode_t) !void {
+    var d = try std.Io.Dir.openDirAbsolute(io, path, .{});
+    defer d.close(io);
+    const handle: std.Io.File = .{ .handle = d.handle, .flags = .{ .nonblocking = false } };
+    try handle.setPermissions(io, std.Io.File.Permissions.fromMode(mode));
+}
+
+fn chmodFile(io: std.Io, path: []const u8, mode: std.posix.mode_t) !void {
+    const f = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer f.close(io);
+    try f.setPermissions(io, std.Io.File.Permissions.fromMode(mode));
+}
+
 test "patchTextFiles leaves the original file intact when atomic staging fails" {
     // Root bypasses POSIX mode bits, so the EACCES path the test relies
     // on cannot fire — skip rather than mis-pass.
@@ -379,12 +396,9 @@ test "patchTextFiles leaves the original file intact when atomic staging fails" 
     const sub = try std.fmt.allocPrint(testing.allocator, "{s}/sub", .{root});
     defer testing.allocator.free(sub);
     try std.Io.Dir.createDirAbsolute(io, sub, .default_dir);
-
-    const sub_z = try testing.allocator.dupeZ(u8, sub);
-    defer testing.allocator.free(sub_z);
     defer {
         // Re-enable write perm so deleteTree can clean up the locked subdir.
-        _ = std.c.chmod(sub_z.ptr, 0o755);
+        chmodDir(io, sub, 0o755) catch {};
         std.Io.Dir.cwd().deleteTree(io, root) catch {};
         testing.allocator.free(root);
     }
@@ -403,7 +417,7 @@ test "patchTextFiles leaves the original file intact when atomic staging fails" 
     // sibling tempfile that an atomic rename stages. The in-place
     // writePositionalAll path the patcher is moving away from would
     // rewrite the file here and corrupt the assertion below.
-    if (std.c.chmod(sub_z.ptr, 0o555) != 0) return error.SkipZigTest;
+    chmodDir(io, sub, 0o555) catch return error.SkipZigTest;
 
     const replacements = [_]patcher.Replacement{
         .{ .old = "@@HOMEBREW_PREFIX@@", .new = "/opt/malt" },
@@ -411,7 +425,7 @@ test "patchTextFiles leaves the original file intact when atomic staging fails" 
     // Error is irrelevant — the load-bearing invariant is the file's bytes.
     _ = patcher.patchTextFiles(io, testing.allocator, root, &replacements) catch {};
 
-    _ = std.c.chmod(sub_z.ptr, 0o755);
+    chmodDir(io, sub, 0o755) catch {};
 
     const f = try std.Io.Dir.openFileAbsolute(io, file_path, .{});
     defer f.close(io);
@@ -445,9 +459,7 @@ test "patchTextFiles preserves the original file mode across the rewrite" {
     // 0o755 is the canonical mode for a Python or shell wrapper inside a
     // relocated keg; losing the exec bit would silently break `mt install`
     // on any formula that ships shebang scripts.
-    const fp_z = try testing.allocator.dupeZ(u8, file_path);
-    defer testing.allocator.free(fp_z);
-    if (std.c.chmod(fp_z.ptr, 0o755) != 0) return error.SkipZigTest;
+    chmodFile(io, file_path, 0o755) catch return error.SkipZigTest;
 
     const replacements = [_]patcher.Replacement{
         .{ .old = "@@HOMEBREW_PREFIX@@", .new = "/opt/malt" },
@@ -461,6 +473,48 @@ test "patchTextFiles preserves the original file mode across the rewrite" {
     defer f.close(io);
     const s = try f.stat(io);
     try testing.expectEqual(@as(std.posix.mode_t, 0o755), s.permissions.toMode() & 0o7777);
+}
+
+test "patchTextFiles rewrites a 0o444 read-only text file" {
+    // Old in-place path opened files with `.read_write`, so 0o444 configs
+    // were silently skipped. The atomic helper publishes a fresh inode
+    // with the prior mode, so read-only-on-disk text files can now be
+    // relocated without losing the original `0o444` afterwards.
+    if (std.c.geteuid() == 0) return error.SkipZigTest;
+
+    var threaded: std.Io.Threaded = undefined;
+    const io = testIo(&threaded);
+    defer threaded.deinit();
+
+    const dir = try tmpSubdir(io, "readonly_input");
+    const file_path = try std.fmt.allocPrint(testing.allocator, "{s}/conf.pc", .{dir});
+    defer {
+        // Restore write perm so deleteTree can unlink the 0o444 file.
+        chmodFile(io, file_path, 0o644) catch {};
+        std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+        testing.allocator.free(file_path);
+        testing.allocator.free(dir);
+    }
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, file_path, .{});
+        try f.writeStreamingAll(io, "prefix=@@HOMEBREW_PREFIX@@\n");
+        f.close(io);
+    }
+    chmodFile(io, file_path, 0o444) catch return error.SkipZigTest;
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "@@HOMEBREW_PREFIX@@", .new = "/opt/malt" },
+    };
+    const count = try patcher.patchTextFiles(io, testing.allocator, dir, &replacements);
+    try testing.expectEqual(@as(u32, 1), count);
+
+    const f = try std.Io.Dir.openFileAbsolute(io, file_path, .{});
+    defer f.close(io);
+    var buf: [64]u8 = undefined;
+    const n = try f.readPositionalAll(io, &buf, 0);
+    try testing.expectEqualStrings("prefix=/opt/malt\n", buf[0..n]);
+    const s = try f.stat(io);
+    try testing.expectEqual(@as(std.posix.mode_t, 0o444), s.permissions.toMode() & 0o7777);
 }
 
 /// Build a Mach-O 64 binary carrying one LC_SEGMENT_64 (__TEXT) with a

--- a/tests/patcher_test.zig
+++ b/tests/patcher_test.zig
@@ -362,6 +362,107 @@ test "flushOverflow on an empty list does nothing and returns ok" {
     try patcher.flushOverflow(threaded.io(), testing.allocator, "/tmp/whatever", &.{});
 }
 
+// ---------------------------------------------------------------------------
+// patchTextFiles — atomicity and mode-preservation invariants
+// ---------------------------------------------------------------------------
+
+test "patchTextFiles leaves the original file intact when atomic staging fails" {
+    // Root bypasses POSIX mode bits, so the EACCES path the test relies
+    // on cannot fire — skip rather than mis-pass.
+    if (std.c.geteuid() == 0) return error.SkipZigTest;
+
+    var threaded: std.Io.Threaded = undefined;
+    const io = testIo(&threaded);
+    defer threaded.deinit();
+
+    const root = try tmpSubdir(io, "atomic_intact");
+    const sub = try std.fmt.allocPrint(testing.allocator, "{s}/sub", .{root});
+    defer testing.allocator.free(sub);
+    try std.Io.Dir.createDirAbsolute(io, sub, .default_dir);
+
+    const sub_z = try testing.allocator.dupeZ(u8, sub);
+    defer testing.allocator.free(sub_z);
+    defer {
+        // Re-enable write perm so deleteTree can clean up the locked subdir.
+        _ = std.c.chmod(sub_z.ptr, 0o755);
+        std.Io.Dir.cwd().deleteTree(io, root) catch {};
+        testing.allocator.free(root);
+    }
+
+    const file_path = try std.fmt.allocPrint(testing.allocator, "{s}/wrapper.txt", .{sub});
+    defer testing.allocator.free(file_path);
+    const original = "exec @@HOMEBREW_PREFIX@@/bin/foo\n";
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, file_path, .{});
+        try f.writeStreamingAll(io, original);
+        f.close(io);
+    }
+
+    // 0o555 lets the walker enter and openFile read the existing file
+    // (POSIX needs write on the file, not the parent) but blocks the
+    // sibling tempfile that an atomic rename stages. The in-place
+    // writePositionalAll path the patcher is moving away from would
+    // rewrite the file here and corrupt the assertion below.
+    if (std.c.chmod(sub_z.ptr, 0o555) != 0) return error.SkipZigTest;
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "@@HOMEBREW_PREFIX@@", .new = "/opt/malt" },
+    };
+    // Error is irrelevant — the load-bearing invariant is the file's bytes.
+    _ = patcher.patchTextFiles(io, testing.allocator, root, &replacements) catch {};
+
+    _ = std.c.chmod(sub_z.ptr, 0o755);
+
+    const f = try std.Io.Dir.openFileAbsolute(io, file_path, .{});
+    defer f.close(io);
+    var buf: [128]u8 = undefined;
+    const n = try f.readPositionalAll(io, &buf, 0);
+    try testing.expectEqualStrings(original, buf[0..n]);
+}
+
+test "patchTextFiles preserves the original file mode across the rewrite" {
+    // Root would override the 0o755 the test pins against.
+    if (std.c.geteuid() == 0) return error.SkipZigTest;
+
+    var threaded: std.Io.Threaded = undefined;
+    const io = testIo(&threaded);
+    defer threaded.deinit();
+
+    const dir = try tmpSubdir(io, "preserve_mode");
+    defer {
+        std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+        testing.allocator.free(dir);
+    }
+
+    const file_path = try std.fmt.allocPrint(testing.allocator, "{s}/wrapper", .{dir});
+    defer testing.allocator.free(file_path);
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, file_path, .{});
+        try f.writeStreamingAll(io, "#!/bin/sh\nexec @@HOMEBREW_PREFIX@@/bin/foo\n");
+        f.close(io);
+    }
+
+    // 0o755 is the canonical mode for a Python or shell wrapper inside a
+    // relocated keg; losing the exec bit would silently break `mt install`
+    // on any formula that ships shebang scripts.
+    const fp_z = try testing.allocator.dupeZ(u8, file_path);
+    defer testing.allocator.free(fp_z);
+    if (std.c.chmod(fp_z.ptr, 0o755) != 0) return error.SkipZigTest;
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "@@HOMEBREW_PREFIX@@", .new = "/opt/malt" },
+    };
+    const count = try patcher.patchTextFiles(io, testing.allocator, dir, &replacements);
+    // Without an actual patch the rename never runs; the mode check
+    // below would pass trivially and stop guarding the regression.
+    try testing.expectEqual(@as(u32, 1), count);
+
+    const f = try std.Io.Dir.openFileAbsolute(io, file_path, .{});
+    defer f.close(io);
+    const s = try f.stat(io);
+    try testing.expectEqual(@as(std.posix.mode_t, 0o755), s.permissions.toMode() & 0o7777);
+}
+
 /// Build a Mach-O 64 binary carrying one LC_SEGMENT_64 (__TEXT) with a
 /// single __cstring section holding `blob`. The section's file offset is
 /// placed immediately after the load commands so the on-disk layout is


### PR DESCRIPTION
## Description

Routes text-file replacements in the Mach-O patcher through the project's atomic write helper. A failure mid-rewrite now leaves either the original or the new content, never a half-written mix. The fix removes a latent corruption mode for `.pc`, Python shebangs, shell wrappers, and `.la` libtool archives.

A new `atomicReplaceFile` helper in `fs/atomic` snapshots the existing file's mode and creates the tempfile under that mode so the rename itself is the single observable transition - shebanged scripts and other exec-bit-bearing wrappers survive relocation under the same permissions they were installed at. The patcher's file handle is now read-only too, so 0o444 configs inside a keg are reachable for relocation under their original mode.

## Related Issue

- None

## Notes for Reviewers

- None
