### PR TITLE
feat(cli/rollback): support --to <version> and --list

### DIFF
--- a/scripts/regressions/rollback_list_and_to.sh
+++ b/scripts/regressions/rollback_list_and_to.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Regression: `mt rollback --list` and `--to <version>` surface the malt
+# store's multi-version history without touching disk state.
+#
+# Pre-this-feature, rollback only landed on "the most recent previous"
+# entry; users keeping three versions could not step back two and had no
+# way to ask "what versions are available?" short of `ls`-ing the store.
+# This regression seeds three on-disk store entries and asserts:
+#
+#   1. `mt rollback --list <pkg>` prints every non-current entry.
+#   2. `mt rollback --list --json <pkg>` emits a parseable JSON object
+#      with `name` + `entries[]` carrying `sha256`, `version`, `mtime`.
+#   3. `mt rollback --to <missing> <pkg>` refuses with the listing.
+#
+# Sandbox-only: no network, no installs, no real bottles. The seeded
+# store entries are bare directories with placeholder receipts — enough
+# for `collectEntries` to discover them. The `--to` happy path requires
+# a real bottle to materialize and is covered by the unit tests.
+#
+# Usage: scripts/regressions/rollback_list_and_to.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt,
+# `sqlite3` on PATH.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+PREFIX="/tmp/mt_rb_reg"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX/db"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+DB="$PREFIX/db/malt.db"
+
+# Bootstrap the schema by letting malt open the DB once. `list --quiet`
+# does no network work and exits 0 on an empty store.
+"$BIN" list --quiet >/dev/null 2>&1 || true
+[[ -f "$DB" ]] || fail "DB was not initialised by mt list"
+
+# Seed: a currently-installed wget@1.22 keg plus three on-disk store
+# entries (1.20 / 1.21 / 1.22). 1.22 matches the current version so
+# `--list` must omit it; 1.20 and 1.21 are the available rollback
+# targets.
+sqlite3 "$DB" <<SQL
+INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason)
+VALUES ('wget', 'wget', '1.22', 0, 'sha_cur', '/cellar/wget/1.22', 'direct');
+SQL
+
+mkdir -p "$PREFIX/store/sha_a/wget/1.20"
+touch "$PREFIX/store/sha_a/wget/1.20/INSTALL_RECEIPT.json"
+sleep 1.1
+mkdir -p "$PREFIX/store/sha_b/wget/1.21"
+touch "$PREFIX/store/sha_b/wget/1.21/INSTALL_RECEIPT.json"
+sleep 1.1
+mkdir -p "$PREFIX/store/sha_cur/wget/1.22"
+touch "$PREFIX/store/sha_cur/wget/1.22/INSTALL_RECEIPT.json"
+
+# --- 1. --list happy path -------------------------------------------------
+LIST_OUT="$PREFIX/list.out"
+"$BIN" rollback --list wget >"$LIST_OUT" 2>&1 ||
+  fail "mt rollback --list wget exited non-zero — see $LIST_OUT"
+
+grep -q '1.20' "$LIST_OUT" ||
+  fail "--list missing 1.20 (see $LIST_OUT)"
+grep -q '1.21' "$LIST_OUT" ||
+  fail "--list missing 1.21 (see $LIST_OUT)"
+if grep -q '1.22' "$LIST_OUT"; then
+  fail "--list must NOT include the current version 1.22 (see $LIST_OUT)"
+fi
+pass "mt rollback --list lists only non-current entries"
+
+# Newest-first ordering: 1.21 (newer mtime) before 1.20.
+POS_21=$(grep -n '1.21' "$LIST_OUT" | head -1 | cut -d: -f1)
+POS_20=$(grep -n '1.20' "$LIST_OUT" | head -1 | cut -d: -f1)
+[[ -n "$POS_21" && -n "$POS_20" && "$POS_21" -lt "$POS_20" ]] ||
+  fail "--list order: 1.21 must appear before 1.20 (1.21@$POS_21, 1.20@$POS_20)"
+pass "mt rollback --list orders entries newest-first"
+
+# --- 2. --list --json shape ----------------------------------------------
+JSON_OUT="$PREFIX/list.json"
+"$BIN" --json rollback --list wget >"$JSON_OUT" 2>&1 ||
+  fail "mt --json rollback --list wget exited non-zero — see $JSON_OUT"
+
+JSON=$(cat "$JSON_OUT")
+case "$JSON" in
+*'"name":"wget"'*) ;;
+*) fail "--list --json missing name=wget (see $JSON_OUT)" ;;
+esac
+case "$JSON" in
+*'"version":"1.21"'*'"version":"1.20"'*) ;;
+*) fail "--list --json: expected 1.21 then 1.20 in document order (see $JSON_OUT)" ;;
+esac
+case "$JSON" in
+*'"version":"1.22"'*)
+  fail "--list --json must not include the current version (see $JSON_OUT)"
+  ;;
+esac
+# Sha + mtime presence; mtime is an integer literal so the digit class suffices.
+case "$JSON" in
+*'"sha256":"sha_a"'*) ;;
+*) fail "--list --json missing sha_a entry (see $JSON_OUT)" ;;
+esac
+case "$JSON" in
+*'"sha256":"sha_b"'*) ;;
+*) fail "--list --json missing sha_b entry (see $JSON_OUT)" ;;
+esac
+echo "$JSON" | grep -Eq '"mtime":[0-9]+' ||
+  fail "--list --json: mtime is not an integer (see $JSON_OUT)"
+pass "mt rollback --list --json emits the documented shape"
+
+# --- 3. --to <missing> refusal -------------------------------------------
+MISS_OUT="$PREFIX/miss.out"
+if "$BIN" rollback --to 9.9.9 wget >"$MISS_OUT" 2>&1; then
+  fail "mt rollback --to 9.9.9 wget should have exited non-zero"
+fi
+grep -q '1.20' "$MISS_OUT" || fail "--to missing-version did not print the listing (see $MISS_OUT)"
+grep -q '1.21' "$MISS_OUT" || fail "--to missing-version did not print the listing (see $MISS_OUT)"
+pass "mt rollback --to <missing> refuses and prints the available entries"
+
+printf '\n\xe2\x9c\x94 rollback-list-and-to regression passed\n'

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -149,7 +149,8 @@ pub const bash_script =
     \\        search)           cmd_flags="--formula --cask --json" ;;
     \\        uses)             cmd_flags="--recursive -r --json --quiet -q" ;;
     \\        which)            cmd_flags="--json" ;;
-    \\        migrate|rollback) cmd_flags="--dry-run" ;;
+    \\        migrate)          cmd_flags="--dry-run" ;;
+    \\        rollback)         cmd_flags="--dry-run --list --to --json" ;;
     \\        link)             cmd_flags="--overwrite --force -f" ;;
     \\        services)         cmd_flags="--tail --stderr --follow -f --system --json" ;;
     \\        bundle)           cmd_flags="--dry-run -n --format --from-installed --purge --yes -y" ;;
@@ -319,8 +320,16 @@ pub const zsh_script =
     \\                        '--json[Output as JSON]' \
     \\                        '*::query:'
     \\                    ;;
-    \\                migrate|rollback)
+    \\                migrate)
     \\                    _arguments '--dry-run[Preview without executing]'
+    \\                    ;;
+    \\                rollback)
+    \\                    _arguments \
+    \\                        '--dry-run[Preview without executing]' \
+    \\                        '--list[List every reachable store entry for <package>]' \
+    \\                        '--to[Roll back to a specific store entry]:version:' \
+    \\                        '--json[Emit --list output as JSON]' \
+    \\                        '*::package:'
     \\                    ;;
     \\                link)
     \\                    _arguments \
@@ -551,6 +560,9 @@ pub const fish_script =
     \\    # migrate / rollback
     \\    complete -c $__malt_bin -n '__malt_using_command migrate'    -l dry-run -d 'Preview'
     \\    complete -c $__malt_bin -n '__malt_using_command rollback'   -l dry-run -d 'Preview'
+    \\    complete -c $__malt_bin -n '__malt_using_command rollback'   -l list    -d 'List every reachable store entry'
+    \\    complete -c $__malt_bin -n '__malt_using_command rollback'   -l to    -x -d 'Roll back to a specific store entry (pass <version>)'
+    \\    complete -c $__malt_bin -n '__malt_using_command rollback'   -l json    -d 'Emit --list output as JSON'
     \\
     \\    # link
     \\    complete -c $__malt_bin -n '__malt_using_command link' -l overwrite -d 'Replace existing symlinks'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -237,12 +237,21 @@ const migrate_help =
 
 const rollback_help =
     \\Usage: malt rollback <package> [flags]
+    \\       malt rollback --list <package>
+    \\       malt rollback --to <version> <package>
     \\
     \\Revert a package to its previous version using the
     \\content-addressable store. No re-download needed.
     \\
+    \\Without --to, lands on the most recent previous entry.
+    \\
     \\Flags:
-    \\  --dry-run      Show what would happen
+    \\  --list             Print every reachable store entry for <package>
+    \\                     (sha, version, timestamp) and exit without changes
+    \\  --to <version>     Roll back to the exact <pkg_version> if present
+    \\                     in the store; otherwise refuse and print --list
+    \\  --json             Emit --list output as JSON (scriptable)
+    \\  --dry-run          Show what would happen
     \\
 ;
 

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -10,6 +10,7 @@ const cellar = @import("../core/cellar.zig");
 const linker_mod = @import("../core/linker.zig");
 const store_mod = @import("../core/store.zig");
 const atomic = @import("../fs/atomic.zig");
+const color = @import("../ui/color.zig");
 const output = @import("../ui/output.zig");
 const help = @import("help.zig");
 const formula_mod = @import("../core/formula.zig");
@@ -17,19 +18,55 @@ const formula_mod = @import("../core/formula.zig");
 /// `error.Aborted` is returned on every user-facing failure. The caller has
 /// already emitted a message via `output.err`; main.zig catches it and exits
 /// non-zero without printing a stack trace.
+const ParsedArgs = struct {
+    name: ?[]const u8 = null,
+    dry_run: bool = false,
+    list_mode: bool = false,
+    to_version: ?[]const u8 = null,
+};
+
+/// Parse rollback argv. The first non-flag positional is the package name;
+/// flags (`--list`, `--dry-run`, `--to <ver>` / `--to=<ver>`) can appear in
+/// any order. Returns `error.Aborted` for unknown flags or a missing value
+/// after `--to` so the dispatcher surfaces the same exit code as other
+/// usage errors.
+fn parseArgs(args: []const []const u8) error{Aborted}!ParsedArgs {
+    var p: ParsedArgs = .{ .dry_run = output.isDryRun() };
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const a = args[i];
+        if (std.mem.eql(u8, a, "--dry-run")) {
+            p.dry_run = true;
+        } else if (std.mem.eql(u8, a, "--list")) {
+            p.list_mode = true;
+        } else if (std.mem.eql(u8, a, "--to")) {
+            if (i + 1 >= args.len) {
+                output.err("--to requires a version argument", .{});
+                return error.Aborted;
+            }
+            i += 1;
+            p.to_version = args[i];
+        } else if (std.mem.startsWith(u8, a, "--to=")) {
+            p.to_version = a["--to=".len..];
+        } else if (a.len > 0 and a[0] == '-') {
+            output.err("Unknown flag: {s}", .{a});
+            return error.Aborted;
+        } else if (p.name == null) {
+            p.name = a;
+        }
+    }
+    return p;
+}
+
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(ctx, args, "rollback")) return;
 
-    if (args.len == 0) {
-        output.err("Usage: mt rollback <package>", .{});
+    const parsed = try parseArgs(args);
+    const name = parsed.name orelse {
+        output.err("Usage: mt rollback <package> [--list] [--to <version>]", .{});
         return error.Aborted;
-    }
-
-    const name = args[0];
-    var dry_run = output.isDryRun();
-    for (args[1..]) |arg| {
-        if (std.mem.eql(u8, arg, "--dry-run")) dry_run = true;
-    }
+    };
+    const dry_run = parsed.dry_run;
 
     const prefix = atomic.maltPrefixOrAbort();
 
@@ -73,46 +110,28 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     var current_pkgver_buf: [128]u8 = undefined;
     const current_pkg_version = formula_mod.pkgVersion(&current_pkgver_buf, current_ver, current_revision) catch current_ver;
 
-    // Look for other store entries that contain this formula
-    // by scanning the store directory for entries that have {name}/ subdirectory
-    var store_buf: [512]u8 = undefined;
-    const store_dir_path = std.fmt.bufPrint(&store_buf, "{s}/store", .{prefix}) catch return error.Aborted;
-
-    var store_dir = std.Io.Dir.openDirAbsolute(ctx.io, store_dir_path, .{ .iterate = true }) catch {
-        output.err("Cannot read store directory", .{});
-        return error.Aborted;
-    };
-    defer store_dir.close(ctx.io);
-
-    // Collect available versions from store entries
-    const Entry = struct { sha256: []const u8, version: []const u8 };
-    var entries: std.ArrayList(Entry) = .empty;
-    defer entries.deinit(allocator);
-
-    var iter = store_dir.iterate();
-    while (iter.next(ctx.io) catch null) |entry| {
-        if (entry.kind != .directory) continue;
-
-        // Check if this store entry contains {name}/ subdirectory
-        var check_buf: [512]u8 = undefined;
-        const check_path = std.fmt.bufPrint(&check_buf, "{s}/{s}/{s}", .{ store_dir_path, entry.name, name }) catch continue;
-
-        var keg_dir = std.Io.Dir.openDirAbsolute(ctx.io, check_path, .{ .iterate = true }) catch continue;
-        defer keg_dir.close(ctx.io);
-
-        // The first subdirectory is the version
-        var keg_iter = keg_dir.iterate();
-        while (keg_iter.next(ctx.io) catch null) |ver_entry| {
-            if (ver_entry.kind != .directory) continue;
-            // Compare against the on-disk pkg_version label so a
-            // revision-bumped current keg is skipped correctly.
-            if (std.mem.eql(u8, ver_entry.name, current_pkg_version)) continue;
-
-            const sha = allocator.dupe(u8, entry.name) catch continue;
-            const ver = allocator.dupe(u8, ver_entry.name) catch continue;
-            entries.append(allocator, .{ .sha256 = sha, .version = ver }) catch continue;
-            break;
+    // `--to <current>` is an idempotent no-op: the user is asking to
+    // land on the version they're already on, so do nothing rather than
+    // surface "not in the store" against a listing that omits the
+    // current entry by design.
+    if (parsed.to_version) |req| {
+        if (std.mem.eql(u8, req, current_pkg_version) or std.mem.eql(u8, req, current_ver)) {
+            output.info("{s} is already at {s}", .{ name, current_ver });
+            return;
         }
+    }
+
+    var entries = collectEntries(ctx.io, allocator, prefix, name, current_pkg_version) catch |e| switch (e) {
+        CollectError.StoreUnreadable => {
+            output.err("Cannot read store directory", .{});
+            return error.Aborted;
+        },
+        CollectError.OutOfMemory => return error.Aborted,
+    };
+    defer freeEntries(allocator, &entries);
+
+    if (parsed.list_mode) {
+        return printListing(allocator, name, entries.items);
     }
 
     if (entries.items.len == 0) {
@@ -121,13 +140,18 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         return error.Aborted;
     }
 
-    // Use the most recent previous version (last entry)
-    const target = entries.items[entries.items.len - 1];
+    const target_idx = selectTargetIndex(entries.items, parsed.to_version) catch {
+        // --to NotFound — refuse and print the listing so the user can pick.
+        output.err("{s} {s} is not in the store", .{ name, parsed.to_version orelse "" });
+        try printListing(allocator, name, entries.items);
+        return error.Aborted;
+    };
+    const target = entries.items[target_idx];
 
-    output.info("Rolling back {s}: {s} -> {s}", .{ name, current_ver, target.version });
+    output.info("Rolling back {s}: {s} -> {s}", .{ name, current_ver, target.pkg_version });
 
     if (dry_run) {
-        output.info("Dry run: would rollback {s} from {s} to {s}", .{ name, current_ver, target.version });
+        output.info("Dry run: would rollback {s} from {s} to {s}", .{ name, current_ver, target.pkg_version });
         return;
     }
 
@@ -153,8 +177,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     };
 
     // Materialize the old version from store
-    const keg = cellar.materialize(ctx.io, allocator, prefix, target.sha256, name, target.version) catch {
-        output.err("Failed to materialize {s} {s} from store", .{ name, target.version });
+    const keg = cellar.materialize(ctx.io, allocator, prefix, target.sha256, name, target.pkg_version) catch {
+        output.err("Failed to materialize {s} {s} from store", .{ name, target.pkg_version });
         return error.Aborted;
     };
 
@@ -166,14 +190,14 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     db.beginTransaction() catch return error.Aborted;
     errdefer db.rollback();
 
-    // target.version carries the on-disk pkg_version label (the store
+    // target.pkg_version carries the on-disk pkg_version label (the store
     // dir name), so replaceKegRow can split it back into version +
     // revision and persist the rolled-back keg's true revision.
     const keg_id = replaceKegRow(
         &db,
         current_id,
         name,
-        target.version,
+        target.pkg_version,
         target.sha256,
         keg.path,
         old_pinned,
@@ -183,13 +207,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     linker.link(keg.path, name, keg_id) catch {
         output.warn("Could not link restored {s} — try: mt link {s}", .{ name, name });
     };
-    linker.linkOpt(name, target.version) catch {
+    linker.linkOpt(name, target.pkg_version) catch {
         output.warn("Could not create opt link for {s}", .{name});
     };
 
     db.commit() catch return error.Aborted;
 
-    output.info("{s} rolled back to {s}", .{ name, target.version });
+    output.info("{s} rolled back to {s}", .{ name, target.pkg_version });
 }
 
 /// Best-effort lookup: is `token` registered as an installed cask? Used to
@@ -275,7 +299,583 @@ pub fn replaceKegRow(
     return id_stmt.columnInt(0);
 }
 
+/// A single rolled-back-to candidate discovered in the malt store.
+/// Slices are allocator-owned; `freeEntries` releases them.
+pub const Entry = struct {
+    sha256: []const u8,
+    pkg_version: []const u8,
+    mtime_ns: i128,
+};
+
+pub const CollectError = error{StoreUnreadable} || std.mem.Allocator.Error;
+
+/// Scan `<prefix>/store/<sha>/<name>/<pkg_version>/` and collect every
+/// rollback candidate for `name`. `skip_pkg_version`, when non-null,
+/// drops the entry whose pkg_version matches it (typically the currently
+/// installed version). Returned list is sorted newest-first by mtime.
+/// Caller owns the inner slices and the list; release via `freeEntries`.
+pub fn collectEntries(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    prefix: []const u8,
+    name: []const u8,
+    skip_pkg_version: ?[]const u8,
+) CollectError!std.ArrayList(Entry) {
+    var store_buf: [512]u8 = undefined;
+    const store_dir_path = std.fmt.bufPrint(&store_buf, "{s}/store", .{prefix}) catch
+        return CollectError.StoreUnreadable;
+
+    var store_dir = std.Io.Dir.openDirAbsolute(io, store_dir_path, .{ .iterate = true }) catch
+        return CollectError.StoreUnreadable;
+    defer store_dir.close(io);
+
+    var entries: std.ArrayList(Entry) = .empty;
+    errdefer freeEntries(allocator, &entries);
+
+    var iter = store_dir.iterate();
+    while (iter.next(io) catch null) |sha_entry| {
+        if (sha_entry.kind != .directory) continue;
+
+        // Each <sha> may carry a <sha>/<name>/<pkg_version>/ pair; skip when the
+        // package isn't represented here.
+        var name_buf: [512]u8 = undefined;
+        const name_path = std.fmt.bufPrint(&name_buf, "{s}/{s}/{s}", .{ store_dir_path, sha_entry.name, name }) catch continue;
+
+        var name_dir = std.Io.Dir.openDirAbsolute(io, name_path, .{ .iterate = true }) catch continue;
+        defer name_dir.close(io);
+
+        var ver_iter = name_dir.iterate();
+        while (ver_iter.next(io) catch null) |ver_entry| {
+            if (ver_entry.kind != .directory) continue;
+            if (skip_pkg_version) |skip| {
+                if (std.mem.eql(u8, ver_entry.name, skip)) continue;
+            }
+
+            const stat = name_dir.statFile(io, ver_entry.name, .{}) catch continue;
+            const sha_dup = allocator.dupe(u8, sha_entry.name) catch return CollectError.OutOfMemory;
+            errdefer allocator.free(sha_dup);
+            const ver_dup = allocator.dupe(u8, ver_entry.name) catch return CollectError.OutOfMemory;
+            errdefer allocator.free(ver_dup);
+            try entries.append(allocator, .{
+                .sha256 = sha_dup,
+                .pkg_version = ver_dup,
+                .mtime_ns = stat.mtime.nanoseconds,
+            });
+        }
+    }
+
+    std.mem.sort(Entry, entries.items, {}, struct {
+        fn cmp(_: void, a: Entry, b: Entry) bool {
+            return a.mtime_ns > b.mtime_ns;
+        }
+    }.cmp);
+    return entries;
+}
+
+/// Flush `entries` to stdout in the format selected by `output.isJson()`.
+/// Routes through `output.writeStdoutAll` so test captures see the bytes.
+fn printListing(
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    entries: []const Entry,
+) !void {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    if (output.isJson()) {
+        try writeListJson(&aw.writer, name, entries);
+    } else {
+        try writeListHuman(&aw.writer, name, entries, color.isColorEnabled());
+    }
+    output.writeStdoutAll(aw.written());
+}
+
+/// Release every owned slice in `entries.items`, then deinit the list itself.
+pub fn freeEntries(allocator: std.mem.Allocator, entries: *std.ArrayList(Entry)) void {
+    for (entries.items) |e| {
+        allocator.free(e.sha256);
+        allocator.free(e.pkg_version);
+    }
+    entries.deinit(allocator);
+}
+
+pub const SelectError = error{NotFound};
+
+/// Pick the rollback target. With `requested_version == null` returns the
+/// newest entry (index 0 of a list pre-sorted newest-first). With a
+/// requested version, returns the first entry whose `pkg_version`
+/// matches exactly. `NotFound` covers both the empty-list-default case
+/// and a requested version that is absent from the store.
+pub fn selectTargetIndex(entries: []const Entry, requested_version: ?[]const u8) SelectError!usize {
+    if (requested_version) |v| {
+        for (entries, 0..) |e, i| {
+            if (std.mem.eql(u8, e.pkg_version, v)) return i;
+        }
+        return SelectError.NotFound;
+    }
+    if (entries.len == 0) return SelectError.NotFound;
+    return 0;
+}
+
+/// `--list` human format: header + one bulleted row per entry, matching
+/// the `mt list --versions` shape. Caller supplies entries already sorted
+/// newest-first. With `colorize=false` the output stays plain ASCII (no
+/// ANSI) so test golden checks are stable.
+pub fn writeListHuman(
+    w: *std.Io.Writer,
+    name: []const u8,
+    entries: []const Entry,
+    colorize: bool,
+) !void {
+    try w.writeAll("Available rollback versions for ");
+    if (colorize) try w.writeAll(color.Style.bold.code());
+    try w.writeAll(name);
+    if (colorize) try w.writeAll(color.Style.reset.code());
+    if (entries.len == 0) {
+        try w.writeAll(": none\n");
+        return;
+    }
+    try w.writeAll(" (newest first):\n");
+
+    var scratch: [32]u8 = undefined;
+    for (entries) |e| {
+        // Bullet prefix mirrors `mt list`'s row marker for visual parity.
+        if (colorize) try w.writeAll(color.SemanticStyle.info.code());
+        try w.writeAll("  ▸ ");
+        if (colorize) try w.writeAll(color.Style.reset.code());
+
+        try w.writeAll(e.pkg_version);
+
+        if (colorize) try w.writeAll(color.SemanticStyle.detail.code());
+        try w.writeAll(" (");
+        try w.writeAll(e.sha256);
+        try w.writeAll(")  ");
+        const iso = try formatIso8601(&scratch, e.mtime_ns);
+        try w.writeAll(iso);
+        if (colorize) try w.writeAll(color.Style.reset.code());
+        try w.writeAll("\n");
+    }
+}
+
+/// Render `mtime_ns` (unix nanoseconds) as `YYYY-MM-DDTHH:MM:SSZ` into `buf`.
+/// Negative values clamp to the epoch so a missing/bogus mtime renders as
+/// `1970-01-01T00:00:00Z` instead of corrupting the listing.
+fn formatIso8601(buf: []u8, mtime_ns: i128) ![]const u8 {
+    const secs: i64 = @intCast(@max(@divTrunc(mtime_ns, std.time.ns_per_s), 0));
+    const epoch_seconds: std.time.epoch.EpochSeconds = .{ .secs = @intCast(secs) };
+    const epoch_day = epoch_seconds.getEpochDay();
+    const day_seconds = epoch_seconds.getDaySeconds();
+    const year_day = epoch_day.calculateYearDay();
+    const month_day = year_day.calculateMonthDay();
+    const day_of_month: u16 = @as(u16, month_day.day_index) + 1;
+    return std.fmt.bufPrint(
+        buf,
+        "{d:0>4}-{d:0>2}-{d:0>2}T{d:0>2}:{d:0>2}:{d:0>2}Z",
+        .{
+            year_day.year,
+            month_day.month.numeric(),
+            day_of_month,
+            day_seconds.getHoursIntoDay(),
+            day_seconds.getMinutesIntoHour(),
+            day_seconds.getSecondsIntoMinute(),
+        },
+    );
+}
+
+/// `--list` JSON shape: `{"name":"<pkg>","entries":[{"sha256":..,"version":..,"mtime":..},...]}`.
+/// `mtime` is unix seconds (integer) so consumers don't have to parse ns precision.
+pub fn writeListJson(w: *std.Io.Writer, name: []const u8, entries: []const Entry) !void {
+    try w.writeAll("{\"name\":");
+    try output.jsonStr(w, name);
+    try w.writeAll(",\"entries\":[");
+    for (entries, 0..) |e, i| {
+        if (i != 0) try w.writeAll(",");
+        try w.writeAll("{\"sha256\":");
+        try output.jsonStr(w, e.sha256);
+        try w.writeAll(",\"version\":");
+        try output.jsonStr(w, e.pkg_version);
+        const secs: i64 = @intCast(@divTrunc(e.mtime_ns, std.time.ns_per_s));
+        var buf: [32]u8 = undefined;
+        const s = try std.fmt.bufPrint(&buf, ",\"mtime\":{d}", .{secs});
+        try w.writeAll(s);
+        try w.writeAll("}");
+    }
+    try w.writeAll("]}\n");
+}
+
 const testing = std.testing;
+
+// --- parseArgs ----------------------------------------------------------
+
+test "parseArgs accepts a bare package name" {
+    const p = try parseArgs(&.{"wget"});
+    try testing.expect(p.name != null);
+    try testing.expectEqualStrings("wget", p.name.?);
+    try testing.expect(!p.list_mode);
+    try testing.expect(p.to_version == null);
+}
+
+test "parseArgs recognises --list anywhere in argv" {
+    const p_pre = try parseArgs(&.{ "--list", "wget" });
+    try testing.expect(p_pre.list_mode);
+    try testing.expectEqualStrings("wget", p_pre.name.?);
+
+    const p_post = try parseArgs(&.{ "wget", "--list" });
+    try testing.expect(p_post.list_mode);
+    try testing.expectEqualStrings("wget", p_post.name.?);
+}
+
+test "parseArgs reads --to <version> as a separated pair" {
+    const p = try parseArgs(&.{ "--to", "1.23", "wget" });
+    try testing.expect(p.to_version != null);
+    try testing.expectEqualStrings("1.23", p.to_version.?);
+    try testing.expectEqualStrings("wget", p.name.?);
+}
+
+test "parseArgs reads --to=<version> as a joined pair" {
+    const p = try parseArgs(&.{ "--to=1.23", "wget" });
+    try testing.expectEqualStrings("1.23", p.to_version.?);
+    try testing.expectEqualStrings("wget", p.name.?);
+}
+
+test "parseArgs rejects --to without a value" {
+    try testing.expectError(error.Aborted, parseArgs(&.{ "wget", "--to" }));
+}
+
+test "parseArgs rejects unknown flags" {
+    try testing.expectError(error.Aborted, parseArgs(&.{ "wget", "--nope" }));
+}
+
+test "parseArgs picks the first non-flag arg as the package name" {
+    // Belt-and-braces guard for the "--to <ver> <pkg>" shape: the version
+    // value must not be reused as the package name on the next loop pass.
+    const p = try parseArgs(&.{ "--to", "1.23", "wget", "extra" });
+    try testing.expectEqualStrings("1.23", p.to_version.?);
+    try testing.expectEqualStrings("wget", p.name.?);
+}
+
+test "parseArgs picks up --dry-run regardless of position" {
+    const p = try parseArgs(&.{ "--dry-run", "wget" });
+    try testing.expect(p.dry_run);
+}
+
+// --- formatIso8601 -------------------------------------------------------
+
+test "formatIso8601 renders the unix epoch as 1970-01-01T00:00:00Z" {
+    var buf: [32]u8 = undefined;
+    const s = try formatIso8601(&buf, 0);
+    try testing.expectEqualStrings("1970-01-01T00:00:00Z", s);
+}
+
+test "formatIso8601 clamps negative mtimes to the epoch" {
+    // A pathological store entry with a pre-epoch mtime must not corrupt
+    // the listing — the worst case is a noisy "1970-..." row.
+    var buf: [32]u8 = undefined;
+    const s = try formatIso8601(&buf, -1);
+    try testing.expectEqualStrings("1970-01-01T00:00:00Z", s);
+}
+
+test "formatIso8601 zero-pads single-digit fields" {
+    var buf: [32]u8 = undefined;
+    // 2009-02-13T23:31:30Z
+    const s = try formatIso8601(&buf, 1_234_567_890 * @as(i128, std.time.ns_per_s));
+    try testing.expectEqualStrings("2009-02-13T23:31:30Z", s);
+}
+
+// --- writeListJson ------------------------------------------------------
+
+test "writeListJson emits the documented shape" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    const ns_per_s: i128 = std.time.ns_per_s;
+    const entries = [_]Entry{
+        .{ .sha256 = "aaa", .pkg_version = "1.24", .mtime_ns = 1_700_000_000 * ns_per_s },
+        .{ .sha256 = "bbb", .pkg_version = "1.23", .mtime_ns = 1_699_000_000 * ns_per_s },
+    };
+
+    try writeListJson(&aw.writer, "wget", &entries);
+    try testing.expectEqualStrings(
+        "{\"name\":\"wget\",\"entries\":[" ++
+            "{\"sha256\":\"aaa\",\"version\":\"1.24\",\"mtime\":1700000000}," ++
+            "{\"sha256\":\"bbb\",\"version\":\"1.23\",\"mtime\":1699000000}" ++
+            "]}\n",
+        aw.written(),
+    );
+}
+
+test "writeListJson with no entries emits an empty array" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    try writeListJson(&aw.writer, "wget", &.{});
+    try testing.expectEqualStrings("{\"name\":\"wget\",\"entries\":[]}\n", aw.written());
+}
+
+/// Seed a `<prefix>/store/<sha>/<name>/<pkg_version>/INSTALL_RECEIPT.json`
+/// tree. `delay_ms_after` lets the caller force monotonically increasing
+/// mtimes across calls without depending on filesystem timer resolution
+/// (HFS+/APFS round to seconds).
+fn seedStoreEntry(
+    io: std.Io,
+    prefix: []const u8,
+    sha: []const u8,
+    name: []const u8,
+    pkg_version: []const u8,
+    delay_ms_after: u64,
+) !void {
+    var buf: [512]u8 = undefined;
+    const dir = try std.fmt.bufPrint(&buf, "{s}/store/{s}/{s}/{s}", .{ prefix, sha, name, pkg_version });
+    try std.Io.Dir.cwd().createDirPath(io, dir);
+
+    var f_buf: [600]u8 = undefined;
+    const file_path = try std.fmt.bufPrint(&f_buf, "{s}/INSTALL_RECEIPT.json", .{dir});
+    const f = try std.Io.Dir.createFileAbsolute(io, file_path, .{});
+    defer f.close(io);
+    try f.writeStreamingAll(io, "{}");
+
+    if (delay_ms_after > 0) {
+        std.Io.sleep(io, std.Io.Duration.fromNanoseconds(@intCast(delay_ms_after * std.time.ns_per_ms)), .awake) catch {};
+    }
+}
+
+test "collectEntries returns an empty list when the store has no matching package" {
+    const io = std.Options.debug_io;
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try std.fmt.bufPrint(
+        &prefix_buf,
+        "/tmp/malt_rb_collect_none_{d}",
+        .{std.Io.Clock.real.now(io).toNanoseconds()},
+    );
+    std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(io, prefix);
+
+    // Seed only `jq` so a search for `wget` returns no rows.
+    try seedStoreEntry(io, prefix, "sha_x", "jq", "1.7", 0);
+
+    var entries = try collectEntries(io, testing.allocator, prefix, "wget", null);
+    defer freeEntries(testing.allocator, &entries);
+    try testing.expectEqual(@as(usize, 0), entries.items.len);
+}
+
+test "collectEntries surfaces StoreUnreadable when {prefix}/store does not exist" {
+    const io = std.Options.debug_io;
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try std.fmt.bufPrint(
+        &prefix_buf,
+        "/tmp/malt_rb_collect_missing_{d}",
+        .{std.Io.Clock.real.now(io).toNanoseconds()},
+    );
+    std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(io, prefix);
+
+    // Deliberately do NOT create `<prefix>/store`. The error must be the
+    // typed StoreUnreadable so the dispatcher can map it to a specific
+    // user-facing message — collapsing it to OutOfMemory would lie.
+    try testing.expectError(
+        CollectError.StoreUnreadable,
+        collectEntries(io, testing.allocator, prefix, "wget", null),
+    );
+}
+
+test "collectEntries does not leak when allocator runs out mid-collection" {
+    const io = std.Options.debug_io;
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try std.fmt.bufPrint(
+        &prefix_buf,
+        "/tmp/malt_rb_collect_oom_{d}",
+        .{std.Io.Clock.real.now(io).toNanoseconds()},
+    );
+    std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(io, prefix);
+
+    try seedStoreEntry(io, prefix, "sha_a", "wget", "1.20", 0);
+    try seedStoreEntry(io, prefix, "sha_b", "wget", "1.21", 0);
+
+    // checkAllAllocationFailures injects an allocator-failure at every
+    // possible allocation point; if any path leaks or double-frees the
+    // testing allocator catches it.
+    const wrap = struct {
+        fn run(allocator: std.mem.Allocator, pfx: []const u8, igio: std.Io) !void {
+            var entries = collectEntries(igio, allocator, pfx, "wget", null) catch |e| switch (e) {
+                CollectError.OutOfMemory => return error.OutOfMemory,
+                CollectError.StoreUnreadable => return,
+            };
+            defer freeEntries(allocator, &entries);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(testing.allocator, wrap.run, .{ prefix, io });
+}
+
+test "collectEntries returns store entries sorted newest-first by mtime" {
+    const io = std.Options.debug_io;
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try std.fmt.bufPrint(
+        &prefix_buf,
+        "/tmp/malt_rb_collect_{d}",
+        .{std.Io.Clock.real.now(io).toNanoseconds()},
+    );
+    std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(io, prefix);
+
+    // Seed three versions with monotonically increasing mtimes. APFS rounds
+    // mtimes to second precision on some FS configs, so a >=1.1s gap is
+    // the cheapest reliable way to order them.
+    try seedStoreEntry(io, prefix, "sha_old", "wget", "1.20", 1100);
+    try seedStoreEntry(io, prefix, "sha_mid", "wget", "1.21", 1100);
+    try seedStoreEntry(io, prefix, "sha_new", "wget", "1.22", 0);
+
+    var entries = try collectEntries(io, testing.allocator, prefix, "wget", null);
+    defer freeEntries(testing.allocator, &entries);
+
+    try testing.expectEqual(@as(usize, 3), entries.items.len);
+    try testing.expectEqualStrings("1.22", entries.items[0].pkg_version);
+    try testing.expectEqualStrings("1.21", entries.items[1].pkg_version);
+    try testing.expectEqualStrings("1.20", entries.items[2].pkg_version);
+}
+
+test "collectEntries skips the entry that matches skip_pkg_version" {
+    const io = std.Options.debug_io;
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try std.fmt.bufPrint(
+        &prefix_buf,
+        "/tmp/malt_rb_collect_skip_{d}",
+        .{std.Io.Clock.real.now(io).toNanoseconds()},
+    );
+    std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(io, prefix);
+
+    try seedStoreEntry(io, prefix, "sha_a", "wget", "1.20", 1100);
+    try seedStoreEntry(io, prefix, "sha_b", "wget", "1.21", 1100);
+    try seedStoreEntry(io, prefix, "sha_c", "wget", "1.22", 0);
+
+    var entries = try collectEntries(io, testing.allocator, prefix, "wget", "1.22");
+    defer freeEntries(testing.allocator, &entries);
+
+    try testing.expectEqual(@as(usize, 2), entries.items.len);
+    try testing.expect(!std.mem.eql(u8, entries.items[0].pkg_version, "1.22"));
+    try testing.expect(!std.mem.eql(u8, entries.items[1].pkg_version, "1.22"));
+}
+
+test "collectEntries ignores store entries that don't contain the named package" {
+    const io = std.Options.debug_io;
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try std.fmt.bufPrint(
+        &prefix_buf,
+        "/tmp/malt_rb_collect_other_{d}",
+        .{std.Io.Clock.real.now(io).toNanoseconds()},
+    );
+    std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(io, prefix);
+
+    // Two `wget` entries plus an unrelated `jq` entry that must be filtered out.
+    try seedStoreEntry(io, prefix, "sha_a", "wget", "1.20", 1100);
+    try seedStoreEntry(io, prefix, "sha_b", "jq", "1.7", 1100);
+    try seedStoreEntry(io, prefix, "sha_c", "wget", "1.21", 0);
+
+    var entries = try collectEntries(io, testing.allocator, prefix, "wget", null);
+    defer freeEntries(testing.allocator, &entries);
+
+    try testing.expectEqual(@as(usize, 2), entries.items.len);
+}
+
+test "selectTargetIndex returns 0 (newest) when no version is requested" {
+    const entries = [_]Entry{
+        .{ .sha256 = "aaa", .pkg_version = "1.24", .mtime_ns = 0 },
+        .{ .sha256 = "bbb", .pkg_version = "1.23", .mtime_ns = 0 },
+    };
+    try testing.expectEqual(@as(usize, 0), try selectTargetIndex(&entries, null));
+}
+
+test "selectTargetIndex with a requested version returns the matching index" {
+    const entries = [_]Entry{
+        .{ .sha256 = "aaa", .pkg_version = "1.24", .mtime_ns = 0 },
+        .{ .sha256 = "bbb", .pkg_version = "1.23", .mtime_ns = 0 },
+        .{ .sha256 = "ccc", .pkg_version = "1.22", .mtime_ns = 0 },
+    };
+    try testing.expectEqual(@as(usize, 1), try selectTargetIndex(&entries, "1.23"));
+    try testing.expectEqual(@as(usize, 2), try selectTargetIndex(&entries, "1.22"));
+}
+
+test "selectTargetIndex returns NotFound when no entry matches the requested version" {
+    const entries = [_]Entry{
+        .{ .sha256 = "aaa", .pkg_version = "1.24", .mtime_ns = 0 },
+    };
+    try testing.expectError(SelectError.NotFound, selectTargetIndex(&entries, "9.9.9"));
+}
+
+test "selectTargetIndex returns NotFound on an empty list with no version" {
+    try testing.expectError(SelectError.NotFound, selectTargetIndex(&.{}, null));
+}
+
+test "writeListHuman prints a header and one row per entry with ISO timestamps" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    const ns_per_s: i128 = std.time.ns_per_s;
+    const entries = [_]Entry{
+        // 1_700_000_000 = 2023-11-14T22:13:20Z; 1_699_000_000 = 2023-11-03T08:26:40Z.
+        .{ .sha256 = "aaa111", .pkg_version = "1.24", .mtime_ns = 1_700_000_000 * ns_per_s },
+        .{ .sha256 = "bbb222", .pkg_version = "1.23", .mtime_ns = 1_699_000_000 * ns_per_s },
+    };
+
+    try writeListHuman(&aw.writer, "wget", &entries, false);
+
+    const out = aw.written();
+    try testing.expect(std.mem.indexOf(u8, out, "wget") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "aaa111") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.24") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "2023-11-14T22:13:20Z") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "bbb222") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.23") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "2023-11-03T08:26:40Z") != null);
+    // Each row carries the bullet prefix used by `mt list --versions`.
+    try testing.expect(std.mem.indexOf(u8, out, "  ▸ ") != null);
+
+    // The newest row (aaa111) appears before the older row (bbb222) — caller is
+    // expected to pass entries already sorted newest-first.
+    const aaa_idx = std.mem.indexOf(u8, out, "aaa111").?;
+    const bbb_idx = std.mem.indexOf(u8, out, "bbb222").?;
+    try testing.expect(aaa_idx < bbb_idx);
+}
+
+test "writeListHuman with no entries still prints a header so users know the listing ran" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    try writeListHuman(&aw.writer, "wget", &.{}, false);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "wget") != null);
+}
+
+test "writeListHuman with colorize=true wraps the package name in bold ANSI codes" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    try writeListHuman(&aw.writer, "wget", &.{}, true);
+    // Bold opens the package name; reset closes it. Both must appear.
+    try testing.expect(std.mem.indexOf(u8, aw.written(), color.Style.bold.code()) != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), color.Style.reset.code()) != null);
+}
+
+test "writeListJson escapes embedded quotes in the package name" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    try writeListJson(&aw.writer, "weird\"name", &.{});
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        std.mem.trimEnd(u8, aw.written(), "\n"),
+        .{},
+    );
+    defer parsed.deinit();
+    try testing.expectEqualStrings("weird\"name", parsed.value.object.get("name").?.string);
+}
 
 test "replaceKegRow splits pkg_version into version + revision" {
     var db = try sqlite.Database.open(":memory:");

--- a/tests/rollback_test.zig
+++ b/tests/rollback_test.zig
@@ -198,3 +198,195 @@ test "schema version table exists" {
     const has_row = try stmt.step();
     try testing.expect(has_row);
 }
+
+// --- `--list` / `--to` integration ----------------------------------------
+
+const output = malt.output;
+
+/// Insert a current-keg row for `name` at `version` into the sandbox DB
+/// so `execute` clears its "package not installed" guard.
+fn insertCurrentKeg(prefix: [:0]const u8, name: []const u8, version: []const u8) !void {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintZ(&db_path_buf, "{s}/db/malt.db", .{prefix});
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+
+    var stmt = try db.prepare(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason)
+        \\VALUES (?1, ?1, ?2, 0, 'cur-sha', '/cellar/x', 'direct');
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    try stmt.bindText(2, version);
+    _ = try stmt.step();
+}
+
+/// Seed a store entry tree `<prefix>/store/<sha>/<name>/<pkg_version>/` and
+/// optionally sleep afterwards so two seeds get distinct mtimes on
+/// second-resolution filesystems.
+fn seedStoreEntry(
+    prefix: [:0]const u8,
+    sha: []const u8,
+    name: []const u8,
+    pkg_version: []const u8,
+    delay_ms_after: u64,
+) !void {
+    const io = std.Options.debug_io;
+    var buf: [512]u8 = undefined;
+    const dir = try std.fmt.bufPrint(&buf, "{s}/store/{s}/{s}/{s}", .{ prefix, sha, name, pkg_version });
+    try test_io.cwd().createDirPath(io, dir);
+
+    var f_buf: [600]u8 = undefined;
+    const file_path = try std.fmt.bufPrint(&f_buf, "{s}/INSTALL_RECEIPT.json", .{dir});
+    const f = try test_io.createFileAbsolute(io, file_path, .{});
+    defer f.close(io);
+    try f.writeStreamingAll(io, "{}");
+
+    if (delay_ms_after > 0) {
+        test_io.sleepNanos(io, delay_ms_after * std.time.ns_per_ms);
+    }
+}
+
+test "rollback --list prints every store entry available for the package" {
+    const prefix: [:0]const u8 = "/tmp/malt_rb_list_happy";
+    try makeSandbox(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try insertCurrentKeg(prefix, "wget", "1.22");
+    try seedStoreEntry(prefix, "sha_a", "wget", "1.20", 1100);
+    try seedStoreEntry(prefix, "sha_b", "wget", "1.21", 1100);
+    try seedStoreEntry(prefix, "sha_c", "wget", "1.22", 0); // current — must be excluded
+
+    setPrefix(prefix);
+    defer unsetPrefix();
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try rollback.execute(&ctx, testing.allocator, &.{ "--list", "wget" });
+
+    const out = stdout_buf.items;
+    try testing.expect(std.mem.indexOf(u8, out, "wget") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.20") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.21") != null);
+    // Current version is excluded from the listing.
+    try testing.expect(std.mem.indexOf(u8, out, "1.22") == null);
+
+    // Newest entry (sha_b/1.21) precedes the older one (sha_a/1.20).
+    const v21 = std.mem.indexOf(u8, out, "1.21").?;
+    const v20 = std.mem.indexOf(u8, out, "1.20").?;
+    try testing.expect(v21 < v20);
+}
+
+test "rollback --list --json emits the documented JSON shape" {
+    const prefix: [:0]const u8 = "/tmp/malt_rb_list_json";
+    try makeSandbox(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try insertCurrentKeg(prefix, "wget", "1.22");
+    try seedStoreEntry(prefix, "sha_a", "wget", "1.20", 1100);
+    try seedStoreEntry(prefix, "sha_b", "wget", "1.21", 0);
+
+    setPrefix(prefix);
+    defer unsetPrefix();
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    const prior = output.isJson();
+    defer output.setMode(if (prior) .json else .human);
+    output.setMode(.json);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try rollback.execute(&ctx, testing.allocator, &.{ "--list", "wget" });
+
+    // Parseable JSON with the documented shape.
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        std.mem.trimEnd(u8, stdout_buf.items, "\n"),
+        .{},
+    );
+    defer parsed.deinit();
+
+    try testing.expectEqualStrings("wget", parsed.value.object.get("name").?.string);
+    const arr = parsed.value.object.get("entries").?.array;
+    try testing.expectEqual(@as(usize, 2), arr.items.len);
+    // Sorted newest-first.
+    try testing.expectEqualStrings("1.21", arr.items[0].object.get("version").?.string);
+    try testing.expectEqualStrings("1.20", arr.items[1].object.get("version").?.string);
+    // mtime is an integer (unix seconds), not a string.
+    try testing.expect(arr.items[0].object.get("mtime").? == .integer);
+}
+
+test "rollback --to <current_version> is a clean no-op, not a confusing refusal" {
+    const prefix: [:0]const u8 = "/tmp/malt_rb_to_current";
+    try makeSandbox(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try insertCurrentKeg(prefix, "wget", "1.22");
+    try seedStoreEntry(prefix, "sha_a", "wget", "1.20", 1100);
+    try seedStoreEntry(prefix, "sha_cur", "wget", "1.22", 0);
+
+    setPrefix(prefix);
+    defer unsetPrefix();
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(testing.allocator);
+    output.beginStderrCapture(testing.allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    // Asking to roll back to the version we're already on must succeed
+    // (no mutation, no Aborted) so users can re-run the same command
+    // idempotently inside scripts.
+    try rollback.execute(&ctx, testing.allocator, &.{ "--to", "1.22", "wget" });
+
+    // The "not in the store" refusal must NOT fire — that line is what we
+    // explicitly do not want surfacing in this case.
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "is not in the store") == null);
+}
+
+test "rollback --to <version> refuses with the listing when the version is absent" {
+    const prefix: [:0]const u8 = "/tmp/malt_rb_to_missing";
+    try makeSandbox(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try insertCurrentKeg(prefix, "wget", "1.22");
+    try seedStoreEntry(prefix, "sha_a", "wget", "1.20", 1100);
+    try seedStoreEntry(prefix, "sha_b", "wget", "1.21", 0);
+
+    setPrefix(prefix);
+    defer unsetPrefix();
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    const err = rollback.execute(&ctx, testing.allocator, &.{ "--to", "9.9.9", "wget" });
+    try testing.expectError(error.Aborted, err);
+
+    const out = stdout_buf.items;
+    // The refusal must surface the actual available versions so the user can pick one.
+    try testing.expect(std.mem.indexOf(u8, out, "1.20") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.21") != null);
+}


### PR DESCRIPTION
## Description

Surfaces the multi-version history of the malt store through `mt rollback`. New flags:

- `--list <pkg>` prints every reachable store entry (sha, pkg_version, timestamp), sorted newest-first, and exits without changes. Output matches `mt list --versions`
- `--to <version> <pkg>` rolls to the exact match if present; refuses with the listing if the version is absent; treats `--to <current>` as an idempotent no-op so scripts can re-run the command safely.
- `--json` makes `--list` scriptable. Shape: `{name, entries:[{sha256, version, mtime}]}` - `mtime` is unix seconds.

Default `mt rollback <pkg>` selects the newest non-current entry by mtime (was: last in filesystem iteration order - undefined). All existing rollback semantics are preserved.

## Related Issue

- None

## Notes for Reviewers

- None