### PR TITLE
fix(cli/rollback): stop mislabelling installed casks as missing

### DIFF
--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -50,7 +50,14 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     cur_stmt.bindText(1, name) catch return error.Aborted;
 
     if (!(cur_stmt.step() catch false)) {
-        output.err("{s} is not installed", .{name});
+        // A cask installed under the same token reads as "not installed"
+        // by the kegs query alone — split the diagnostic so the user
+        // isn't told their installed app is missing.
+        if (isCaskInstalled(&db, name)) {
+            output.err("{s} is a cask; mt rollback does not support casks yet", .{name});
+        } else {
+            output.err("{s} is not installed", .{name});
+        }
         return error.Aborted;
     }
 
@@ -183,6 +190,18 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     db.commit() catch return error.Aborted;
 
     output.info("{s} rolled back to {s}", .{ name, target.version });
+}
+
+/// Best-effort lookup: is `token` registered as an installed cask? Used to
+/// split the rollback "not installed" diagnostic so a cask token doesn't
+/// read as a missing package. Any SQL failure collapses to `false` — the
+/// caller falls back to the original message rather than masking the
+/// underlying error.
+fn isCaskInstalled(db: *sqlite.Database, token: []const u8) bool {
+    var stmt = db.prepare("SELECT 1 FROM casks WHERE token = ?1 LIMIT 1;") catch return false;
+    defer stmt.finalize();
+    stmt.bindText(1, token) catch return false;
+    return stmt.step() catch false;
 }
 
 /// Wipe the on-disk Cellar dir for a keg currently at `version`/`revision`.

--- a/tests/rollback_test.zig
+++ b/tests/rollback_test.zig
@@ -144,6 +144,46 @@ test "capturePinnedById reads the pinned column for a given keg id" {
     try testing.expect(!rollback.capturePinnedById(&db, 999_999));
 }
 
+test "rollback distinguishes a cask token from a truly missing package" {
+    const prefix: [:0]const u8 = "/tmp/malt_rb_cask_diag";
+    try makeSandbox(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    // Seed a cask row only — no matching keg. Pre-fix, the kegs-only
+    // check claimed the cask was "not installed", which lied: it IS
+    // installed, just not as a formula. This test pins the corrected
+    // diagnostic so the lie doesn't quietly come back.
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintZ(&db_path_buf, "{s}/db/malt.db", .{prefix});
+    var db = try sqlite.Database.open(db_path);
+    try db.exec(
+        \\INSERT INTO casks (token, name, version, url, sha256)
+        \\VALUES ('flux-markdown', 'flux-markdown', '1.32.427',
+        \\        'https://example.invalid/flux.dmg', 'aa');
+    );
+    db.close();
+
+    setPrefix(prefix);
+    defer unsetPrefix();
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &stderr_buf);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    const err = rollback.execute(&ctx, testing.allocator, &.{"flux-markdown"});
+    try testing.expectError(error.Aborted, err);
+
+    // The corrected diagnostic names the cask shape and steers the user
+    // away from the "package is missing" mental model.
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "cask") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "is not installed") == null);
+}
+
 test "schema version table exists" {
     const prefix = "/tmp/malt_sv_test";
     test_io.makeDirAbsolute(std.Options.debug_io, prefix) catch {};


### PR DESCRIPTION
## Description

`mt rollback <cask-token>` printed `<token> is not installed` even when the cask was present in the DB - the kegs-only lookup couldn't see it.
Split the diagnostic: an installed cask now reads as a cask, the genuine "package is absent" line is preserved when neither shape exists.

Before:

```
$ mt rollback flux-markdown
  ✗ flux-markdown is not installed   # lie: it IS installed (as a cask)
```

After:

```
$ mt rollback flux-markdown
  ✗ flux-markdown is a cask; mt rollback does not support casks yet
$ mt rollback no-such-pkg
  ✗ no-such-pkg is not installed     # unchanged for the genuine miss
```

## Related Issue

- None

## Notes for Reviewers

- None