### PR TITLE
feat(cli/purge): include cask per-version cache + Caskroom in --old-versions

### DIFF
--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -361,7 +361,7 @@ pub const zsh_script =
     \\                        '--cache[Prune cache files older than 30 days]' \
     \\                        '--downloads[Wipe the downloads cache]' \
     \\                        '--stale-casks[Remove cache + Caskroom for uninstalled casks]' \
-    \\                        '--old-versions[Remove non-latest Cellar versions]' \
+    \\                        '--old-versions[Remove non-latest Cellar versions + retained cask history]' \
     \\                        '--housekeeping[All safe scopes at once]' \
     \\                        '--wipe[Nuclear: remove every malt artefact]' \
     \\                        '(--backup -b)'{--backup,-b}'[Write a restorable manifest before deleting]:path:_files' \
@@ -592,7 +592,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l cache            -d 'Prune cache files older than 30 days (or N via --cache=N)'
     \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l downloads        -d 'Wipe the downloads cache (typed confirm)'
     \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l stale-casks      -d 'Cask cache + Caskroom for uninstalled casks'
-    \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l old-versions     -d 'Non-latest Cellar versions (typed confirm)'
+    \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l old-versions     -d 'Non-latest Cellar versions + retained cask history (typed confirm)'
     \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l housekeeping     -d 'All safe scopes at once'
     \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l wipe             -d 'Nuclear: every malt artefact (typed confirm)'
     \\    # purge — shared / wipe-only flags

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -361,7 +361,7 @@ const purge_help =
     \\  --cache[=DAYS]       Cache files older than DAYS (default 30)
     \\  --downloads          Wipe {cache}/downloads entirely        (typed confirm)
     \\  --stale-casks        Cask cache + Caskroom for uninstalled casks
-    \\  --old-versions       Non-latest versions in {prefix}/Cellar (typed confirm)
+    \\  --old-versions       Non-latest Cellar versions + retained cask history (typed confirm)
     \\  --housekeeping       = --store-orphans --unused-deps --cache --stale-casks
     \\  --wipe               Nuclear: every malt artefact on disk    (typed confirm)
     \\

--- a/src/cli/purge/scopes.zig
+++ b/src/cli/purge/scopes.zig
@@ -13,6 +13,7 @@ const store_mod = @import("../../core/store.zig");
 const deps_mod = @import("../../core/deps.zig");
 const linker_mod = @import("../../core/linker.zig");
 const cellar_mod = @import("../../core/cellar.zig");
+const cask_mod = @import("../../core/cask.zig");
 const util = @import("util.zig");
 const report = @import("report.zig");
 
@@ -439,36 +440,92 @@ pub fn runStaleCasks(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
 
 // ── Tier: --old-versions ────────────────────────────────────────────────────
 
+// Single shape for both `old-versions` passes. `kind` distinguishes
+// keg dirs in `Cellar/<formula>/<version>` from cask history rows in
+// `cask_versions` — they share the same report row but route through
+// different sweep paths.
+const OldVersionCandidate = struct {
+    kind: enum { cellar, cask },
+    name: []u8, // owned: formula name (cellar) or cask token
+    version: []u8, // owned
+    size: u64,
+};
+
 pub fn runOldVersions(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: []const u8, dry_run: bool) !TierResult {
     var result: TierResult = .{};
     const io = ctx.io;
 
     var rep = report.Reporter.init("old-versions", dry_run);
 
-    var cellar_buf: [512]u8 = undefined;
-    const cellar_path = std.fmt.bufPrint(&cellar_buf, "{s}/Cellar", .{prefix}) catch return result;
-
-    var cellar_dir = std.Io.Dir.openDirAbsolute(io, cellar_path, .{ .iterate = true }) catch {
-        rep.empty("no Cellar directory");
-        return result;
-    };
-    defer cellar_dir.close(io);
-
-    // Two-pass: collect candidates first so the header count matches what
-    // the user is about to see scrolled past.
-    const Candidate = struct {
-        formula: []u8, // owned
-        version: []u8, // owned
-        size: u64,
-    };
-    var candidates: std.ArrayList(Candidate) = .empty;
+    var candidates: std.ArrayList(OldVersionCandidate) = .empty;
     defer {
         for (candidates.items) |c| {
-            allocator.free(c.formula);
+            allocator.free(c.name);
             allocator.free(c.version);
         }
         candidates.deinit(allocator);
     }
+
+    try collectCellarOldVersions(io, allocator, prefix, &candidates);
+    collectCaskOldVersions(io, allocator, prefix, &candidates, &result);
+
+    if (candidates.items.len == 0) {
+        rep.empty("nothing to remove");
+        return result;
+    }
+
+    rep.header(candidates.items.len, "version", "versions");
+
+    // Reopen the DB only when the cask pass actually found rows — the
+    // cellar-only case stays DB-free, matching the pre-T-038 shape.
+    var db_opt: ?sqlite.Database = blk: {
+        for (candidates.items) |c| {
+            if (c.kind == .cask) break :blk reopenDbForRowDeletes(io, prefix, &result);
+        }
+        break :blk null;
+    };
+    defer if (db_opt) |*db| db.close();
+
+    var label_buf: [256]u8 = undefined;
+    for (candidates.items) |c| {
+        const label = std.fmt.bufPrint(&label_buf, "{s}/{s}", .{ c.name, c.version }) catch c.name;
+        switch (c.kind) {
+            .cellar => {
+                if (!dry_run) {
+                    var path_buf: [512]u8 = undefined;
+                    const full = std.fmt.bufPrint(&path_buf, "{s}/Cellar/{s}/{s}", .{ prefix, c.name, c.version }) catch continue;
+                    std.Io.Dir.cwd().deleteTree(io, full) catch continue;
+                }
+                rep.item(label);
+                result.bytes += c.size;
+                result.removed += 1;
+            },
+            .cask => {
+                if (!dry_run) {
+                    if (!sweepCaskOldVersion(io, prefix, c.name, c.version)) continue;
+                    if (db_opt) |*db| deleteCaskVersionRow(db, c.name, c.version);
+                }
+                rep.item(label);
+                result.bytes += c.size;
+                result.removed += 1;
+            },
+        }
+    }
+    rep.done(candidates.items.len);
+    return result;
+}
+
+fn collectCellarOldVersions(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    prefix: []const u8,
+    candidates: *std.ArrayList(OldVersionCandidate),
+) !void {
+    var cellar_buf: [512]u8 = undefined;
+    const cellar_path = std.fmt.bufPrint(&cellar_buf, "{s}/Cellar", .{prefix}) catch return;
+
+    var cellar_dir = std.Io.Dir.openDirAbsolute(io, cellar_path, .{ .iterate = true }) catch return;
+    defer cellar_dir.close(io);
 
     var iter = cellar_dir.iterate();
     while (iter.next(io) catch null) |formula_entry| {
@@ -515,35 +572,134 @@ pub fn runOldVersions(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: 
                 allocator.free(fdup);
                 continue;
             };
-            candidates.append(allocator, .{ .formula = fdup, .version = vdup, .size = sz }) catch {
+            candidates.append(allocator, .{ .kind = .cellar, .name = fdup, .version = vdup, .size = sz }) catch {
                 allocator.free(fdup);
                 allocator.free(vdup);
                 continue;
             };
         }
     }
+}
 
-    if (candidates.items.len == 0) {
-        rep.empty("nothing to remove");
-        return result;
+// Walk `cask_versions` for rows whose version isn't the currently-
+// installed cask. Best-effort: an absent DB (fresh prefix, no install
+// yet) is a clean skip, not a fault.
+fn collectCaskOldVersions(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    prefix: []const u8,
+    candidates: *std.ArrayList(OldVersionCandidate),
+    result: *TierResult,
+) void {
+    var db = switch (util.openDbTri(io, prefix)) {
+        .absent => return,
+        .unreadable => |e| {
+            output.warn("old-versions: cannot open database for cask history ({s})", .{@errorName(e)});
+            result.status = .err;
+            result.error_kind = "db_unreadable";
+            return;
+        },
+        .opened => |db_val| db_val,
+    };
+    defer db.close();
+    schema.initSchema(&db) catch |e| {
+        output.warn("old-versions: cannot init schema for cask history ({s})", .{@errorName(e)});
+        result.status = .err;
+        result.error_kind = "schema_init";
+        return;
+    };
+
+    // INNER JOIN drops tokens that have history rows but no current
+    // install (uninstall already wiped that case); != selects every
+    // history row whose version no longer matches the live one.
+    var stmt = db.prepare(
+        \\SELECT cv.token, cv.version
+        \\FROM cask_versions cv
+        \\JOIN casks c ON c.token = cv.token
+        \\WHERE cv.version != c.version;
+    ) catch |e| {
+        output.warn("old-versions: cannot prepare cask history query ({s})", .{@errorName(e)});
+        result.status = .err;
+        result.error_kind = "db_prepare";
+        return;
+    };
+    defer stmt.finalize();
+
+    while (stmt.step() catch false) {
+        const token_ptr = stmt.columnText(0) orelse continue;
+        const version_ptr = stmt.columnText(1) orelse continue;
+        const token = std.mem.sliceTo(token_ptr, 0);
+        const version = std.mem.sliceTo(version_ptr, 0);
+
+        // Size the on-disk footprint: Caskroom dir + every per-version
+        // cache file we'd remove. Computed up front so the report's
+        // freed-bytes counter is accurate even on dry-run.
+        const sz = caskVersionFootprint(io, allocator, prefix, token, version);
+
+        const tdup = allocator.dupe(u8, token) catch continue;
+        const vdup = allocator.dupe(u8, version) catch {
+            allocator.free(tdup);
+            continue;
+        };
+        candidates.append(allocator, .{ .kind = .cask, .name = tdup, .version = vdup, .size = sz }) catch {
+            allocator.free(tdup);
+            allocator.free(vdup);
+            continue;
+        };
     }
+}
 
-    rep.header(candidates.items.len, "version", "versions");
+fn reopenDbForRowDeletes(io: std.Io, prefix: []const u8, result: *TierResult) ?sqlite.Database {
+    return switch (util.openDbTri(io, prefix)) {
+        .absent => null,
+        .unreadable => |e| blk: {
+            output.warn("old-versions: cannot reopen database for history rows ({s})", .{@errorName(e)});
+            result.status = .err;
+            result.error_kind = "db_unreadable";
+            break :blk null;
+        },
+        .opened => |db_val| db_val,
+    };
+}
 
-    var label_buf: [256]u8 = undefined;
-    for (candidates.items) |c| {
-        if (!dry_run) {
-            var path_buf: [512]u8 = undefined;
-            const full = std.fmt.bufPrint(&path_buf, "{s}/Cellar/{s}/{s}", .{ prefix, c.formula, c.version }) catch continue;
-            std.Io.Dir.cwd().deleteTree(io, full) catch continue;
-        }
-        const label = std.fmt.bufPrint(&label_buf, "{s}/{s}", .{ c.formula, c.version }) catch c.formula;
-        rep.item(label);
-        result.bytes += c.size;
-        result.removed += 1;
+fn caskVersionFootprint(io: std.Io, allocator: std.mem.Allocator, prefix: []const u8, token: []const u8, version: []const u8) u64 {
+    var total: u64 = 0;
+    var path_buf: [512]u8 = undefined;
+    if (std.fmt.bufPrint(&path_buf, "{s}/Caskroom/{s}/{s}", .{ prefix, token, version })) |caskroom_path| {
+        total += util.pathSize(io, allocator, caskroom_path);
+    } else |_| {}
+
+    for ([_][]const u8{ ".dmg", ".zip", ".pkg", ".tar.gz" }) |ext| {
+        const cache_path = std.fmt.bufPrint(&path_buf, "{s}/cache/Cask/{s}-{s}{s}", .{ prefix, token, version, ext }) catch continue;
+        if (std.Io.Dir.cwd().statFile(io, cache_path, .{})) |st| {
+            total += st.size;
+        } else |_| {}
     }
-    rep.done(candidates.items.len);
-    return result;
+    return total;
+}
+
+// Try the filesystem-side removal first; the history row delete is
+// only safe after we've actually cleared disk. Returns true when both
+// the Caskroom dir and every per-version cache file are gone (either
+// removed here or already absent). A live file we cannot remove (e.g.
+// read-only mount) gates the row so a future writable run can finish.
+fn sweepCaskOldVersion(io: std.Io, prefix: []const u8, token: []const u8, version: []const u8) bool {
+    var path_buf: [512]u8 = undefined;
+    if (std.fmt.bufPrint(&path_buf, "{s}/Caskroom/{s}/{s}", .{ prefix, token, version })) |caskroom_path| {
+        if (std.Io.Dir.accessAbsolute(io, caskroom_path, .{})) |_| {
+            std.Io.Dir.cwd().deleteTree(io, caskroom_path) catch return false;
+        } else |_| {}
+    } else |_| {}
+
+    return cask_mod.deletePerVersionCacheFile(io, prefix, token, version);
+}
+
+fn deleteCaskVersionRow(db: *sqlite.Database, token: []const u8, version: []const u8) void {
+    var stmt = db.prepare("DELETE FROM cask_versions WHERE token = ?1 AND version = ?2;") catch return;
+    defer stmt.finalize();
+    stmt.bindText(1, token) catch return;
+    stmt.bindText(2, version) catch return;
+    _ = stmt.step() catch {};
 }
 
 // ── inline unit tests ──────────────────────────────────────────────────────
@@ -617,4 +773,228 @@ test "runStaleCasks self-heals a schema-less db rather than reporting it as a fa
     try testing.expectEqual(util.ScopeStatus.ok, result.status);
     try testing.expect(result.error_kind == null);
     try testing.expectEqual(@as(u32, 0), result.removed);
+}
+
+// ── runOldVersions cask history sweep ──────────────────────────────────────
+//
+// T-038 extends the Cellar-only walker so cask per-version artefacts
+// (`cache/Cask/<token>-<version>.<ext>`, `Caskroom/<token>/<version>/`)
+// and the matching `cask_versions` rows get the same "non-current wins,
+// older versions go" treatment. Pinning the contract here so a future
+// refactor cannot silently drop the cask branch.
+
+fn seedCaskVersionRow(
+    db: *sqlite.Database,
+    token: []const u8,
+    version: []const u8,
+    artifact_type: []const u8,
+) !void {
+    var stmt = try db.prepare(
+        \\INSERT INTO cask_versions (token, version, url, sha256, artifact_type, cache_path)
+        \\VALUES (?1, ?2, ?3, ?4, ?5, ?6);
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, token);
+    try stmt.bindText(2, version);
+    try stmt.bindText(3, "https://example.invalid/dummy");
+    try stmt.bindNull(4);
+    try stmt.bindText(5, artifact_type);
+    try stmt.bindNull(6);
+    _ = try stmt.step();
+}
+
+fn seedCurrentCask(db: *sqlite.Database, token: []const u8, version: []const u8) !void {
+    var stmt = try db.prepare(
+        \\INSERT INTO casks (token, name, version, url, sha256, app_path, auto_updates)
+        \\VALUES (?1, ?1, ?2, 'https://example.invalid/dummy', NULL, NULL, 0);
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, token);
+    try stmt.bindText(2, version);
+    _ = try stmt.step();
+}
+
+fn touchFile(io: std.Io, path: []const u8) !void {
+    if (std.fs.path.dirname(path)) |dir| {
+        try std.Io.Dir.cwd().createDirPath(io, dir);
+    }
+    const f = try std.Io.Dir.createFileAbsolute(io, path, .{ .truncate = true });
+    defer f.close(io);
+    try f.writeStreamingAll(io, "x");
+}
+
+fn rowCount(db: *sqlite.Database, token: []const u8) !i64 {
+    var stmt = try db.prepare("SELECT COUNT(*) FROM cask_versions WHERE token = ?1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, token);
+    _ = try stmt.step();
+    return stmt.columnInt(0);
+}
+
+test "runOldVersions sweeps non-current cask per-version cache + caskroom + history" {
+    // Two history rows for `flux`: one current (v2), one stale (v1).
+    // After a live run the stale cache file and Caskroom version dir
+    // must be gone, the stale history row deleted, and counters must
+    // reflect at least the cask removal.
+    const allocator = testing.allocator;
+
+    const prefix = "/tmp/malt_runOldVersions_cask_sweep";
+    std.Io.Dir.cwd().deleteTree(fs_test_io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(fs_test_io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix);
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix ++ "/db");
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix ++ "/cache/Cask");
+
+    {
+        var db = try sqlite.Database.open(prefix ++ "/db/malt.db");
+        defer db.close();
+        try schema.initSchema(&db);
+        try seedCurrentCask(&db, "flux", "2.0");
+        try seedCaskVersionRow(&db, "flux", "2.0", "dmg");
+        try seedCaskVersionRow(&db, "flux", "1.0", "dmg");
+    }
+
+    try touchFile(fs_test_io, prefix ++ "/cache/Cask/flux-2.0.dmg");
+    try touchFile(fs_test_io, prefix ++ "/cache/Cask/flux-1.0.dmg");
+    try touchFile(fs_test_io, prefix ++ "/Caskroom/flux/2.0/.metadata");
+    try touchFile(fs_test_io, prefix ++ "/Caskroom/flux/1.0/.metadata");
+
+    const ctx = AppCtx{ .io = fs_test_io, .environ = .empty };
+    const result = try runOldVersions(&ctx, allocator, prefix, false);
+
+    try testing.expectEqual(util.ScopeStatus.ok, result.status);
+    try testing.expect(result.removed >= 1);
+
+    // Current artefacts survive.
+    try std.Io.Dir.accessAbsolute(fs_test_io, prefix ++ "/cache/Cask/flux-2.0.dmg", .{});
+    try std.Io.Dir.accessAbsolute(fs_test_io, prefix ++ "/Caskroom/flux/2.0", .{});
+
+    // Stale artefacts gone.
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(fs_test_io, prefix ++ "/cache/Cask/flux-1.0.dmg", .{}),
+    );
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(fs_test_io, prefix ++ "/Caskroom/flux/1.0", .{}),
+    );
+
+    // History row deleted; current row preserved.
+    {
+        var db = try sqlite.Database.open(prefix ++ "/db/malt.db");
+        defer db.close();
+        try testing.expectEqual(@as(i64, 1), try rowCount(&db, "flux"));
+    }
+}
+
+test "runOldVersions --dry-run reports cask candidates without touching disk or db" {
+    const allocator = testing.allocator;
+
+    const prefix = "/tmp/malt_runOldVersions_cask_dry_run";
+    std.Io.Dir.cwd().deleteTree(fs_test_io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(fs_test_io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix);
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix ++ "/db");
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix ++ "/cache/Cask");
+
+    {
+        var db = try sqlite.Database.open(prefix ++ "/db/malt.db");
+        defer db.close();
+        try schema.initSchema(&db);
+        try seedCurrentCask(&db, "flux", "2.0");
+        try seedCaskVersionRow(&db, "flux", "2.0", "dmg");
+        try seedCaskVersionRow(&db, "flux", "1.0", "dmg");
+    }
+
+    try touchFile(fs_test_io, prefix ++ "/cache/Cask/flux-1.0.dmg");
+    try touchFile(fs_test_io, prefix ++ "/Caskroom/flux/1.0/.metadata");
+
+    const ctx = AppCtx{ .io = fs_test_io, .environ = .empty };
+    const result = try runOldVersions(&ctx, allocator, prefix, true);
+
+    try testing.expectEqual(util.ScopeStatus.ok, result.status);
+    try testing.expect(result.removed >= 1);
+
+    // Dry-run preserves everything.
+    try std.Io.Dir.accessAbsolute(fs_test_io, prefix ++ "/cache/Cask/flux-1.0.dmg", .{});
+    try std.Io.Dir.accessAbsolute(fs_test_io, prefix ++ "/Caskroom/flux/1.0", .{});
+
+    var db = try sqlite.Database.open(prefix ++ "/db/malt.db");
+    defer db.close();
+    try testing.expectEqual(@as(i64, 2), try rowCount(&db, "flux"));
+}
+
+test "runOldVersions on already-swept cask state is a clean no-op" {
+    // After a successful live run the second invocation must report
+    // zero removals — no missing-row warnings, no errored status. Pins
+    // the idempotence acceptance criterion.
+    const allocator = testing.allocator;
+
+    const prefix = "/tmp/malt_runOldVersions_cask_noop";
+    std.Io.Dir.cwd().deleteTree(fs_test_io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(fs_test_io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix);
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix ++ "/db");
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix ++ "/cache/Cask");
+
+    {
+        var db = try sqlite.Database.open(prefix ++ "/db/malt.db");
+        defer db.close();
+        try schema.initSchema(&db);
+        try seedCurrentCask(&db, "flux", "2.0");
+        try seedCaskVersionRow(&db, "flux", "2.0", "dmg");
+        try seedCaskVersionRow(&db, "flux", "1.0", "dmg");
+    }
+    try touchFile(fs_test_io, prefix ++ "/cache/Cask/flux-1.0.dmg");
+    try touchFile(fs_test_io, prefix ++ "/Caskroom/flux/1.0/.metadata");
+
+    const ctx = AppCtx{ .io = fs_test_io, .environ = .empty };
+    _ = try runOldVersions(&ctx, allocator, prefix, false);
+    const second = try runOldVersions(&ctx, allocator, prefix, false);
+
+    try testing.expectEqual(util.ScopeStatus.ok, second.status);
+    try testing.expectEqual(@as(u32, 0), second.removed);
+}
+
+test "runOldVersions ignores pin status when sweeping old cask versions" {
+    // Pinned cask: current row stays in `casks`. Pin must not bleed
+    // into the history sweep — old versions are still eligible for
+    // removal, matching the Cellar-side policy.
+    const allocator = testing.allocator;
+
+    const prefix = "/tmp/malt_runOldVersions_cask_pinned";
+    std.Io.Dir.cwd().deleteTree(fs_test_io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(fs_test_io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix);
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix ++ "/db");
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix ++ "/cache/Cask");
+
+    {
+        var db = try sqlite.Database.open(prefix ++ "/db/malt.db");
+        defer db.close();
+        try schema.initSchema(&db);
+        // Insert with auto_updates=1 to simulate a held cask; the cask
+        // schema does not carry a `pinned` column itself, so the proxy
+        // here is "user-flagged-as-managed" via auto_updates.
+        var stmt = try db.prepare(
+            \\INSERT INTO casks (token, name, version, url, sha256, app_path, auto_updates)
+            \\VALUES ('flux', 'flux', '2.0', 'https://example.invalid/dummy', NULL, NULL, 1);
+        );
+        defer stmt.finalize();
+        _ = try stmt.step();
+        try seedCaskVersionRow(&db, "flux", "2.0", "dmg");
+        try seedCaskVersionRow(&db, "flux", "1.0", "dmg");
+    }
+    try touchFile(fs_test_io, prefix ++ "/cache/Cask/flux-1.0.dmg");
+    try touchFile(fs_test_io, prefix ++ "/Caskroom/flux/1.0/.metadata");
+
+    const ctx = AppCtx{ .io = fs_test_io, .environ = .empty };
+    const result = try runOldVersions(&ctx, allocator, prefix, false);
+
+    try testing.expectEqual(util.ScopeStatus.ok, result.status);
+    try testing.expect(result.removed >= 1);
+    try testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(fs_test_io, prefix ++ "/cache/Cask/flux-1.0.dmg", .{}),
+    );
 }

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -249,6 +249,26 @@ pub fn artifactTypeTag(t: ArtifactType) []const u8 {
     };
 }
 
+/// Delete the per-version cache file for one `(token, version)` pair.
+/// Mirrors the `<prefix>/cache/Cask/<token>-<version>.<ext>` naming
+/// `sweepPerVersionCache` matches by prefix, but stays surgical so
+/// `purge --old-versions` can drop a stale version without touching
+/// the current one. Iterates every known extension because
+/// `cask_versions.artifact_type` is nullable on rows backfilled
+/// before v7. Returns true when every file that existed was removed
+/// (or none existed); false when an existing file could not be
+/// deleted — the caller uses that signal to gate the DB row delete
+/// so a read-only mount doesn't orphan history.
+pub fn deletePerVersionCacheFile(io: std.Io, prefix: []const u8, token: []const u8, version: []const u8) bool {
+    for ([_][]const u8{ ".dmg", ".zip", ".pkg", ".tar.gz" }) |ext| {
+        var path_buf: [512]u8 = undefined;
+        const path = std.fmt.bufPrint(&path_buf, "{s}/cache/Cask/{s}-{s}{s}", .{ prefix, token, version, ext }) catch continue;
+        std.Io.Dir.accessAbsolute(io, path, .{}) catch continue;
+        std.Io.Dir.cwd().deleteFile(io, path) catch return false;
+    }
+    return true;
+}
+
 /// Iterate `{prefix}/cache/Cask/` and delete any file whose basename
 /// starts with `{token}-` — the per-version cache shape this binary
 /// writes. Used by uninstall + purge so per-version artefacts don't

--- a/tests/purge_scopes_test.zig
+++ b/tests/purge_scopes_test.zig
@@ -157,6 +157,85 @@ test "--stale-casks --dry-run iterates orphaned cache/Cask files and Caskroom di
 
 // --- --old-versions ------------------------------------------------------
 
+test "--old-versions --yes sweeps cask per-version cache + caskroom + history row" {
+    // End-to-end integration: drives `purge.execute` (not the scope
+    // function directly) so the JSON summary path and locking flow are
+    // exercised alongside the cask sweep. Mirrors the keg-side
+    // destructive test pattern.
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "old_versions_cask");
+    defer prefix.deinit(allocator);
+
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+
+        var cask_stmt = try db.prepare(
+            \\INSERT INTO casks (token, name, version, url, sha256, app_path, auto_updates)
+            \\VALUES ('flux', 'flux', '2.0', 'https://example.invalid/dummy', NULL, NULL, 0);
+        );
+        defer cask_stmt.finalize();
+        _ = try cask_stmt.step();
+
+        for ([_][]const u8{ "1.0", "2.0" }) |ver| {
+            var v_stmt = try db.prepare(
+                \\INSERT INTO cask_versions (token, version, url, sha256, artifact_type, cache_path)
+                \\VALUES ('flux', ?1, 'https://example.invalid/dummy', NULL, 'dmg', NULL);
+            );
+            defer v_stmt.finalize();
+            try v_stmt.bindText(1, ver);
+            _ = try v_stmt.step();
+        }
+    }
+
+    try writeFileAt(allocator, &.{ prefix.path, "cache", "Cask", "flux-1.0.dmg" }, "stale");
+    try writeFileAt(allocator, &.{ prefix.path, "cache", "Cask", "flux-2.0.dmg" }, "current");
+    try writeFileAt(allocator, &.{ prefix.path, "Caskroom", "flux", "1.0", ".meta" }, "x");
+    try writeFileAt(allocator, &.{ prefix.path, "Caskroom", "flux", "2.0", ".meta" }, "x");
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(false);
+    output.setNdjson(false);
+    output.setQuiet(true);
+
+    const ctx = malt.app_ctx.debug_ctx;
+    try purge.execute(&ctx, allocator, &.{ "--old-versions", "--yes" });
+
+    // Stale artefacts gone.
+    const stale_cache = try std.fmt.allocPrint(allocator, "{s}/cache/Cask/flux-1.0.dmg", .{prefix.path});
+    defer allocator.free(stale_cache);
+    try testing.expectError(
+        error.FileNotFound,
+        test_io.accessAbsolute(std.Options.debug_io, stale_cache, .{}),
+    );
+    const stale_room = try std.fmt.allocPrint(allocator, "{s}/Caskroom/flux/1.0", .{prefix.path});
+    defer allocator.free(stale_room);
+    try testing.expectError(
+        error.FileNotFound,
+        test_io.accessAbsolute(std.Options.debug_io, stale_room, .{}),
+    );
+
+    // Current artefacts survive.
+    const current_cache = try std.fmt.allocPrint(allocator, "{s}/cache/Cask/flux-2.0.dmg", .{prefix.path});
+    defer allocator.free(current_cache);
+    try test_io.accessAbsolute(std.Options.debug_io, current_cache, .{});
+
+    // History rows: only the current row remains.
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix.path}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    var count_stmt = try db.prepare("SELECT COUNT(*) FROM cask_versions WHERE token = 'flux';");
+    defer count_stmt.finalize();
+    _ = try count_stmt.step();
+    try testing.expectEqual(@as(i64, 1), count_stmt.columnInt(0));
+}
+
 test "--old-versions --dry-run iterates Cellar dirs that hold multiple versions" {
     const allocator = testing.allocator;
     var prefix = try ScratchPrefix.init(allocator, "old_versions");


### PR DESCRIPTION
## Description

Closes the housekeeping loop opened by the per-version cask retention work: `mt purge --old-versions` now sweeps retained cask per-version cache files and Caskroom version directories whose version is not the currently-installed one, plus the matching `cask_versions` rows. Cellar-side behaviour is unchanged. `--dry-run`, `--json`, and `--output-format=ndjson` all cover the new pass; the help text and zsh/fish completions reflect the broader scope.

## Related Issue

- None

## Notes for Reviewers

- None