### PR TITLE
refactor(update/notifier): make heads-up sit cleanly under any subcommand

### DIFF
--- a/src/update/notifier.zig
+++ b/src/update/notifier.zig
@@ -7,6 +7,7 @@
 
 const std = @import("std");
 const output = @import("../ui/output.zig");
+const color = @import("../ui/color.zig");
 const client_mod = @import("../net/client.zig");
 const atomic = @import("../fs/atomic.zig");
 const release = @import("release.zig");
@@ -303,13 +304,52 @@ fn suppressed(io: std.Io, environ: std.process.Environ, cmd_str: []const u8) boo
     return false;
 }
 
-/// Headline goes through `notice` (violet `!`) so an available update reads
-/// as a heads-up, not a warning. The action hint stays dim — it's reference
-/// material, not the message.
+/// Headline keeps the violet `notice` palette so an available update reads
+/// as a heads-up, not a warning; the action hint stays dim — reference
+/// material, not the message. Rendered inline (rather than via
+/// `output.notice`/`output.dim`) so the layout can sit flush-left under a
+/// blank-line separator, which reads better at the tail of any subcommand.
 fn printNotice(latest_tag: []const u8, current_version: []const u8) void {
     const latest_no_v = release.stripVPrefix(latest_tag);
-    output.notice("A newer malt is available: {s} (you're on {s}).", .{ latest_no_v, current_version });
-    output.dim("Run 'mt version update' to upgrade, or set MALT_NO_VERSION_NOTIFIER=1 to silence this.", .{});
+
+    var notice_buf: [4096]u8 = undefined;
+    const notice_msg = std.fmt.bufPrint(
+        &notice_buf,
+        "A newer malt is available: {s} (you're on {s}).",
+        .{ latest_no_v, current_version },
+    ) catch return;
+    const dim_msg = "Run 'mt version update' to upgrade, or set MALT_NO_VERSION_NOTIFIER=1 to silence this.";
+
+    const colorize = color.isColorEnabled();
+    const emoji = color.isEmojiEnabled();
+    const notice_prefix: []const u8 = if (emoji) "ⓘ " else "i ";
+    const dim_prefix: []const u8 = if (emoji) "▸ " else "> ";
+
+    // Blank line separates the heads-up from whatever the subcommand
+    // printed last. Safe: notifier fires post-dispatch, no other worker
+    // is writing concurrently here.
+    output.writeStderrAll("\n");
+
+    if (colorize) {
+        output.writeStderrAll(color.SemanticStyle.notice.code());
+        output.writeStderrAll(notice_prefix);
+        output.writeStderrAll(color.Style.reset.code());
+    } else {
+        output.writeStderrAll(notice_prefix);
+    }
+    output.writeStderrAll(notice_msg);
+    output.writeStderrAll("\n");
+
+    if (colorize) {
+        output.writeStderrAll(color.SemanticStyle.detail.code());
+        output.writeStderrAll(dim_prefix);
+        output.writeStderrAll(dim_msg);
+        output.writeStderrAll(color.Style.reset.code());
+    } else {
+        output.writeStderrAll(dim_prefix);
+        output.writeStderrAll(dim_msg);
+    }
+    output.writeStderrAll("\n");
 }
 
 /// Best-effort cache write so a successful self-update silences the
@@ -707,4 +747,48 @@ test "readCache: missing file is null, not an error" {
     std.Io.Dir.deleteFileAbsolute(io, path) catch {};
     const got = try readCache(io, std.testing.allocator, path);
     try std.testing.expect(got == null);
+}
+
+// Pins the heads-up layout: blank-line separator + flush-left prefixes
+// in both palettes. The blank line keeps the notice from sticking to a
+// subcommand's last line of output; the flush margin keeps the glyphs
+// aligned with the user's prompt regardless of which subcommand ran.
+test "printNotice: blank-line + flush-left layout, color + emoji on (dark + basic)" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    color.setForTest(true, true);
+    color.setBackgroundForTest(color.Background.dark);
+    color.setTruecolorForTest(false);
+    output.beginStderrCapture(std.testing.allocator, &buf);
+    defer {
+        output.endStderrCapture();
+        color.setForTest(null, null);
+        color.setBackgroundForTest(null);
+        color.setTruecolorForTest(null);
+    }
+
+    printNotice("v0.11.6", "0.11.0");
+
+    const want = "\n" ++
+        "\x1b[35mⓘ \x1b[0mA newer malt is available: 0.11.6 (you're on 0.11.0).\n" ++
+        "\x1b[2m▸ Run 'mt version update' to upgrade, or set MALT_NO_VERSION_NOTIFIER=1 to silence this.\x1b[0m\n";
+    try std.testing.expectEqualStrings(want, buf.items);
+}
+
+test "printNotice: no color, no emoji → flush-left ASCII layout" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    color.setForTest(false, false);
+    output.beginStderrCapture(std.testing.allocator, &buf);
+    defer {
+        output.endStderrCapture();
+        color.setForTest(null, null);
+    }
+
+    printNotice("v0.11.6", "0.11.0");
+
+    const want = "\n" ++
+        "i A newer malt is available: 0.11.6 (you're on 0.11.0).\n" ++
+        "> Run 'mt version update' to upgrade, or set MALT_NO_VERSION_NOTIFIER=1 to silence this.\n";
+    try std.testing.expectEqualStrings(want, buf.items);
 }


### PR DESCRIPTION
## Description

Lead the update heads-up with a blank line and drop the left padding on both rows so the notice sits flush under any subcommand's tail, instead of clashing with the surrounding TUI margins.

## Related Issue

- None

## Notes for Reviewers

- None