### PR TITLE
feat(cli/doctor): report retained cask version count + size

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -202,6 +202,7 @@ pub fn build(b: *std.Build) void {
         "tests/restore_cli_test.zig",
         "tests/search_cli_test.zig",
         "tests/doctor_dispatch_test.zig",
+        "tests/doctor_cask_history_test.zig",
         "tests/info_cli_test.zig",
         "tests/backup_cli_test.zig",
         "tests/run_cli_test.zig",

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -19,6 +19,7 @@ const mount_c = @import("c_mount");
 const render = @import("doctor/render.zig");
 const post_install = @import("doctor/post_install.zig");
 const fix_mod = @import("doctor/fix.zig");
+pub const cask_history = @import("doctor/cask_history.zig");
 
 pub const FixKind = fix_mod.FixKind;
 pub const ManualKind = fix_mod.ManualKind;
@@ -89,6 +90,36 @@ pub fn runChecks(ctx: CheckCtx, table: []const Check) Tally {
     return tally;
 }
 
+/// Walk retained cask versions and emit the report doctor surfaces
+/// after the check rows. Pure read-only: routes to stdout (JSON) or
+/// stderr (human + optional verbose entry list) by reading
+/// `output.isJson()` and `output.isVerbose()`. Held public so the
+/// integration test can drive the same path `execute` uses.
+pub fn emitCaskHistoryReport(allocator: std.mem.Allocator, io: std.Io, prefix: []const u8) void {
+    var census = cask_history.collectCensus(allocator, io, prefix);
+    defer census.deinit(allocator);
+
+    if (output.isJson()) {
+        var aw: std.Io.Writer.Allocating = .init(allocator);
+        defer aw.deinit();
+        cask_history.writeJson(&aw.writer, census) catch return;
+        output.writeStdoutAll(aw.written());
+        return;
+    }
+
+    if (census.entries.len == 0) return;
+
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    cask_history.writeHumanSummary(&aw.writer, census) catch return;
+    if (output.isVerbose()) {
+        // Best-effort: a writer error here loses the entry rows but
+        // the summary line is already in `aw` and worth flushing.
+        cask_history.writeHumanEntries(&aw.writer, census) catch {};
+    }
+    output.writeStderrAll(aw.written());
+}
+
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(ctx, args, "doctor")) return;
 
@@ -110,6 +141,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         .io = ctx.io,
         .environ = ctx.environ,
     }, &checks);
+
+    emitCaskHistoryReport(allocator, ctx.io, prefix);
 
     if (fix_requested) {
         output.plain("", .{});

--- a/src/cli/doctor/cask_history.zig
+++ b/src/cli/doctor/cask_history.zig
@@ -1,0 +1,461 @@
+//! malt — doctor cask history walker.
+//!
+//! Counts every `cask_versions` row whose `version` no longer matches
+//! the live `casks.version` row, plus the on-disk footprint (Caskroom
+//! dir + per-version cache file). Read-only: doctor surfaces the number
+//! so the user knows what `mt purge --old-versions` would reclaim;
+//! mutation lives in purge, not here.
+
+const std = @import("std");
+const sqlite = @import("../../db/sqlite.zig");
+
+pub const Entry = struct {
+    token: []const u8,
+    version: []const u8,
+    bytes: u64,
+};
+
+pub const Census = struct {
+    entries: []Entry,
+    total_bytes: u64,
+
+    pub fn deinit(self: *Census, allocator: std.mem.Allocator) void {
+        for (self.entries) |e| {
+            allocator.free(e.token);
+            allocator.free(e.version);
+        }
+        allocator.free(self.entries);
+        self.* = .{ .entries = &.{}, .total_bytes = 0 };
+    }
+};
+
+/// Walk `cask_versions JOIN casks` and return every row whose version
+/// isn't the currently-installed one, plus its disk footprint. Always
+/// returns a valid census — a missing/unopenable DB or an absent
+/// schema is "nothing retained", not a failure: doctor reports here,
+/// it does not enforce.
+pub fn collectCensus(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    prefix: []const u8,
+) Census {
+    const empty: Census = .{ .entries = &.{}, .total_bytes = 0 };
+
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return empty;
+    var db = sqlite.Database.open(db_path) catch return empty;
+    defer db.close();
+
+    // INNER JOIN drops tokens that have history but no current install
+    // (uninstall already cleared that case); `!=` selects every history
+    // row whose version no longer matches the live one — same set
+    // `mt purge --old-versions` would sweep.
+    var stmt = db.prepare(
+        \\SELECT cv.token, cv.version
+        \\FROM cask_versions cv
+        \\JOIN casks c ON c.token = cv.token
+        \\WHERE cv.version != c.version
+        \\ORDER BY cv.token, cv.version;
+    ) catch return empty;
+    defer stmt.finalize();
+
+    var list: std.ArrayList(Entry) = .empty;
+    errdefer {
+        for (list.items) |e| {
+            allocator.free(e.token);
+            allocator.free(e.version);
+        }
+        list.deinit(allocator);
+    }
+
+    var total_bytes: u64 = 0;
+    while (stmt.step() catch false) {
+        const tok_ptr = stmt.columnText(0) orelse continue;
+        const ver_ptr = stmt.columnText(1) orelse continue;
+        const tok = std.mem.sliceTo(tok_ptr, 0);
+        const ver = std.mem.sliceTo(ver_ptr, 0);
+
+        const bytes = perVersionFootprint(io, allocator, prefix, tok, ver);
+        const tok_dup = allocator.dupe(u8, tok) catch continue;
+        const ver_dup = allocator.dupe(u8, ver) catch {
+            allocator.free(tok_dup);
+            continue;
+        };
+        list.append(allocator, .{ .token = tok_dup, .version = ver_dup, .bytes = bytes }) catch {
+            allocator.free(tok_dup);
+            allocator.free(ver_dup);
+            continue;
+        };
+        total_bytes += bytes;
+    }
+
+    const slice = list.toOwnedSlice(allocator) catch return empty;
+    return .{ .entries = slice, .total_bytes = total_bytes };
+}
+
+/// Caskroom dir total + every per-version cache file. Mirrors the
+/// extension list and stat/walk shape of
+/// `cli/purge/scopes.zig::caskVersionFootprint` so doctor's reported
+/// bytes match the bytes `mt purge --old-versions` actually frees.
+fn perVersionFootprint(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    prefix: []const u8,
+    token: []const u8,
+    version: []const u8,
+) u64 {
+    var total: u64 = 0;
+    var path_buf: [512]u8 = undefined;
+
+    if (std.fmt.bufPrint(&path_buf, "{s}/Caskroom/{s}/{s}", .{ prefix, token, version })) |caskroom_path| {
+        total += pathSize(io, allocator, caskroom_path);
+    } else |_| {}
+
+    for ([_][]const u8{ ".dmg", ".zip", ".pkg", ".tar.gz" }) |ext| {
+        const cache_path = std.fmt.bufPrint(&path_buf, "{s}/cache/Cask/{s}-{s}{s}", .{ prefix, token, version, ext }) catch continue;
+        if (std.Io.Dir.cwd().statFile(io, cache_path, .{})) |st| {
+            total += st.size;
+        } else |_| {}
+    }
+    return total;
+}
+
+/// Size of a regular file (single stat) or the recursive sum of every
+/// regular file under a directory. Mirrors `cli/purge/util.zig::pathSize`
+/// — doctor can't cross the sibling-CLI boundary into `cli/purge`, so
+/// the shape is duplicated here. Best-effort throughout: any I/O
+/// failure contributes zero, not an error.
+fn pathSize(io: std.Io, allocator: std.mem.Allocator, path: []const u8) u64 {
+    if (std.Io.Dir.cwd().statFile(io, path, .{})) |st| {
+        if (st.kind != .directory) return st.size;
+    } else |_| return 0;
+
+    var dir = std.Io.Dir.openDirAbsolute(io, path, .{ .iterate = true }) catch return 0;
+    defer dir.close(io);
+
+    var walker = dir.walk(allocator) catch return 0;
+    defer walker.deinit();
+
+    var total: u64 = 0;
+    while (walker.next(io) catch null) |entry| {
+        if (entry.kind == .file) {
+            const s = std.Io.Dir.statFile(entry.dir, io, entry.basename, .{}) catch continue;
+            total += s.size;
+        }
+    }
+    return total;
+}
+
+/// Render the human one-liner doctor surfaces after the check rows.
+/// Empty census writes nothing — the empty case must not add noise to
+/// the default human output. Pure (writer-driven) so tests pin the
+/// exact bytes.
+pub fn writeHumanSummary(w: *std.Io.Writer, census: Census) !void {
+    if (census.entries.len == 0) return;
+    var buf: [32]u8 = undefined;
+    const size = formatBytes(census.total_bytes, &buf);
+    try w.print(
+        "  > Retained cask versions: {d} ({s}). Run: mt purge --old-versions\n",
+        .{ census.entries.len, size },
+    );
+}
+
+/// Emit one indented `<token> <version> (<size>)` line per retained
+/// entry — what `--verbose` prints under doctor's summary row. Empty
+/// census writes nothing so the verbose path stays silent in the
+/// clean case. Pure for byte-pinning tests.
+pub fn writeHumanEntries(w: *std.Io.Writer, census: Census) !void {
+    if (census.entries.len == 0) return;
+    var size_buf: [32]u8 = undefined;
+    for (census.entries) |e| {
+        const size = formatBytes(e.bytes, &size_buf);
+        try w.print("        {s} {s} ({s})\n", .{ e.token, e.version, size });
+    }
+}
+
+/// Emit doctor's `--json` payload as a single line. The schema stays
+/// stable across the empty case (zero values, not omission) so
+/// scripted consumers can always read `cask_history.retained_versions`
+/// and `cask_history.bytes`. Pure for byte-pinning tests.
+pub fn writeJson(w: *std.Io.Writer, census: Census) !void {
+    try w.print(
+        "{{\"cask_history\":{{\"retained_versions\":{d},\"bytes\":{d}}}}}\n",
+        .{ census.entries.len, census.total_bytes },
+    );
+}
+
+/// Format a byte count as `{d:.1} {unit}` (B/KB/MB/GB/TB). Local mirror
+/// of `cli/purge/util.zig::formatBytes` — same shape, but doctor can't
+/// pull `cli/purge` across the sibling-CLI boundary.
+fn formatBytes(bytes: u64, buf: []u8) []const u8 {
+    const units = [_][]const u8{ "B", "KB", "MB", "GB", "TB" };
+    var value: f64 = @floatFromInt(bytes);
+    var unit: usize = 0;
+    while (value >= 1024.0 and unit + 1 < units.len) {
+        value /= 1024.0;
+        unit += 1;
+    }
+    return std.fmt.bufPrint(buf, "{d:.1} {s}", .{ value, units[unit] }) catch "?";
+}
+
+// ── inline unit tests ──────────────────────────────────────────────────────
+
+const testing = std.testing;
+const fs_test_io = std.Options.debug_io;
+const schema = @import("../../db/schema.zig");
+
+fn rmrf(path: []const u8) void {
+    std.Io.Dir.cwd().deleteTree(fs_test_io, path) catch {};
+}
+
+/// Build a unique scratch prefix with the dir skeleton doctor's walker
+/// expects (`db/`, `cache/Cask/`, `Caskroom/`). Caller frees the slice.
+fn seedScratch(allocator: std.mem.Allocator, tag: []const u8) ![:0]u8 {
+    const ts: u32 = @intCast(std.Io.Clock.real.now(fs_test_io).toMilliseconds() & 0xffff_ffff);
+    const prefix = try std.fmt.allocPrintSentinel(
+        allocator,
+        "/tmp/malt_doctor_cask_history_{s}_{x}",
+        .{ tag, ts },
+        0,
+    );
+    rmrf(prefix);
+    inline for ([_][]const u8{ "/db", "/cache/Cask", "/Caskroom" }) |sub| {
+        var sub_buf: [600]u8 = undefined;
+        const sub_path = try std.fmt.bufPrint(&sub_buf, "{s}{s}", .{ prefix, sub });
+        try std.Io.Dir.cwd().createDirPath(fs_test_io, sub_path);
+    }
+    return prefix;
+}
+
+fn writeFile(path: []const u8, body: []const u8) !void {
+    const f = try std.Io.Dir.createFileAbsolute(fs_test_io, path, .{ .truncate = true });
+    defer f.close(fs_test_io);
+    try f.writeStreamingAll(fs_test_io, body);
+}
+
+test "collectCensus reports retained versions plus on-disk bytes" {
+    // Two history rows differ from the live cask; one row matches and
+    // must not appear. Disk artefacts are planted only for the retained
+    // versions so the byte total can be lower-bounded against the
+    // exact bytes we wrote.
+    const allocator = testing.allocator;
+    const prefix = try seedScratch(allocator, "two_retained");
+    defer {
+        rmrf(prefix);
+        allocator.free(prefix);
+    }
+
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+        try db.exec(
+            \\INSERT INTO casks (token, name, version, url)
+            \\VALUES ('alpha', 'Alpha', '2.0', 'https://x.invalid/a.dmg');
+        );
+        try db.exec(
+            \\INSERT INTO cask_versions (token, version, url, artifact_type)
+            \\VALUES ('alpha', '1.0', 'https://x.invalid/a-1.0.dmg', 'dmg'),
+            \\       ('alpha', '1.5', 'https://x.invalid/a-1.5.dmg', 'dmg'),
+            \\       ('alpha', '2.0', 'https://x.invalid/a-2.0.dmg', 'dmg');
+        );
+    }
+
+    const cask_1_0 = try std.fmt.allocPrint(allocator, "{s}/Caskroom/alpha/1.0", .{prefix});
+    defer allocator.free(cask_1_0);
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, cask_1_0);
+    const app_1_0 = try std.fmt.allocPrint(allocator, "{s}/Caskroom/alpha/1.0/Alpha.app", .{prefix});
+    defer allocator.free(app_1_0);
+    try writeFile(app_1_0, "x" ** 64);
+
+    const cache_1_5 = try std.fmt.allocPrint(allocator, "{s}/cache/Cask/alpha-1.5.dmg", .{prefix});
+    defer allocator.free(cache_1_5);
+    try writeFile(cache_1_5, "y" ** 128);
+
+    var census = collectCensus(allocator, fs_test_io, prefix);
+    defer census.deinit(allocator);
+
+    try testing.expectEqual(@as(usize, 2), census.entries.len);
+    try testing.expect(census.total_bytes >= 64 + 128);
+}
+
+test "writeHumanSummary emits a one-liner with count + scaled bytes when non-empty" {
+    // Pin the exact bytes doctor's human path appends after the check
+    // rows. The byte total is `formatBytes`-shaped (matches purge's
+    // freed-bytes reporter) so users see one consistent size format
+    // across `doctor` and `purge --old-versions`.
+    var entries = [_]Entry{
+        .{ .token = "alpha", .version = "1.0", .bytes = 64 },
+        .{ .token = "alpha", .version = "1.5", .bytes = 128 },
+    };
+    const census: Census = .{ .entries = entries[0..], .total_bytes = 192 };
+
+    var buf: [256]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try writeHumanSummary(&w, census);
+    try testing.expectEqualStrings(
+        "  > Retained cask versions: 2 (192.0 B). Run: mt purge --old-versions\n",
+        w.buffered(),
+    );
+}
+
+test "writeHumanEntries emits one indented (token version size) line per entry" {
+    // `--verbose` lets the user see exactly which retained version
+    // accounts for each byte. The indent matches doctor's existing
+    // detail-row pattern (see `checkPrefixPermissions`).
+    var entries = [_]Entry{
+        .{ .token = "alpha", .version = "1.0", .bytes = 64 },
+        .{ .token = "alpha", .version = "1.5", .bytes = 128 },
+    };
+    const census: Census = .{ .entries = entries[0..], .total_bytes = 192 };
+
+    var buf: [256]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try writeHumanEntries(&w, census);
+    try testing.expectEqualStrings(
+        "        alpha 1.0 (64.0 B)\n        alpha 1.5 (128.0 B)\n",
+        w.buffered(),
+    );
+}
+
+test "writeHumanEntries writes nothing when the census is empty" {
+    // Symmetric with the summary writer — empty case stays silent so
+    // `--verbose` on a clean prefix adds no rows.
+    const census: Census = .{ .entries = &.{}, .total_bytes = 0 };
+
+    var buf: [64]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try writeHumanEntries(&w, census);
+    try testing.expectEqual(@as(usize, 0), w.buffered().len);
+}
+
+test "writeHumanSummary writes nothing when the census is empty" {
+    // The empty branch must not append a row — the task forbids extra
+    // human noise when nothing is retained. JSON callers still see the
+    // section with zero values; that's a separate writer.
+    const census: Census = .{ .entries = &.{}, .total_bytes = 0 };
+
+    var buf: [64]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try writeHumanSummary(&w, census);
+    try testing.expectEqual(@as(usize, 0), w.buffered().len);
+}
+
+test "writeJson emits the cask_history object with retained_versions + bytes" {
+    // Stable JSON shape for `mt doctor --json`: a `cask_history` key
+    // mapping to `{retained_versions, bytes}`. Compact form (no
+    // indent) matches the rollback / list JSON writers so existing
+    // CLI consumers do not have to special-case doctor.
+    var entries = [_]Entry{
+        .{ .token = "alpha", .version = "1.0", .bytes = 64 },
+        .{ .token = "alpha", .version = "1.5", .bytes = 128 },
+    };
+    const census: Census = .{ .entries = entries[0..], .total_bytes = 192 };
+
+    var buf: [256]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try writeJson(&w, census);
+    try testing.expectEqualStrings(
+        "{\"cask_history\":{\"retained_versions\":2,\"bytes\":192}}\n",
+        w.buffered(),
+    );
+}
+
+test "writeJson keeps the cask_history section present when the census is empty" {
+    // Stable shape: the section MUST exist with zero values so callers
+    // can rely on the schema even when nothing is retained.
+    const census: Census = .{ .entries = &.{}, .total_bytes = 0 };
+
+    var buf: [128]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try writeJson(&w, census);
+    try testing.expectEqualStrings(
+        "{\"cask_history\":{\"retained_versions\":0,\"bytes\":0}}\n",
+        w.buffered(),
+    );
+}
+
+test "collectCensus ignores orphan history rows that have no live casks entry" {
+    // Mirrors purge's INNER JOIN contract: a token uninstalled from
+    // `casks` but still carrying `cask_versions` history is purge's
+    // stale-casks scope, not old-versions. Doctor must not double-
+    // report it here.
+    const allocator = testing.allocator;
+    const prefix = try seedScratch(allocator, "orphan");
+    defer {
+        rmrf(prefix);
+        allocator.free(prefix);
+    }
+
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+        // History present, NO row in `casks` for this token.
+        try db.exec(
+            \\INSERT INTO cask_versions (token, version, url, artifact_type)
+            \\VALUES ('orphan', '0.9', 'https://x.invalid/o-0.9.dmg', 'dmg');
+        );
+    }
+
+    var census = collectCensus(allocator, fs_test_io, prefix);
+    defer census.deinit(allocator);
+
+    try testing.expectEqual(@as(usize, 0), census.entries.len);
+    try testing.expectEqual(@as(u64, 0), census.total_bytes);
+}
+
+test "collectCensus omits the token whose history matches the live version exactly" {
+    // History row with the same version as the live install is the
+    // "current" pointer used for resume after a crash — it must not
+    // count as retained, otherwise purge would re-delete what the
+    // user is actively running.
+    const allocator = testing.allocator;
+    const prefix = try seedScratch(allocator, "match");
+    defer {
+        rmrf(prefix);
+        allocator.free(prefix);
+    }
+
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+        try db.exec(
+            \\INSERT INTO casks (token, name, version, url)
+            \\VALUES ('beta', 'Beta', '3.0', 'https://x.invalid/b.dmg');
+        );
+        try db.exec(
+            \\INSERT INTO cask_versions (token, version, url, artifact_type)
+            \\VALUES ('beta', '3.0', 'https://x.invalid/b-3.0.dmg', 'dmg');
+        );
+    }
+
+    var census = collectCensus(allocator, fs_test_io, prefix);
+    defer census.deinit(allocator);
+
+    try testing.expectEqual(@as(usize, 0), census.entries.len);
+}
+
+test "collectCensus on a fresh prefix returns an empty census" {
+    // No DB on disk → walker reports zero entries / zero bytes. Empty
+    // is the silent default; doctor's human path skips its summary
+    // line when this branch is taken.
+    const allocator = testing.allocator;
+    const prefix = "/tmp/malt_doctor_cask_history_fresh";
+    rmrf(prefix);
+    defer rmrf(prefix);
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix);
+
+    var census = collectCensus(allocator, fs_test_io, prefix);
+    defer census.deinit(allocator);
+
+    try testing.expectEqual(@as(usize, 0), census.entries.len);
+    try testing.expectEqual(@as(u64, 0), census.total_bytes);
+}

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -186,12 +186,25 @@ const doctor_help =
     \\Run system health checks: database integrity, orphaned store
     \\entries, broken symlinks, disk space, API reachability, and more.
     \\
+    \\Trailing report:
+    \\  Retained cask versions — for every cask token whose
+    \\  `cask_versions` history has rows that are not the live
+    \\  install, the count + on-disk bytes are summarised. Empty
+    \\  state stays silent. Read-only: `mt purge --old-versions`
+    \\  is what actually reclaims the space.
+    \\
     \\Options:
     \\  --fix          Apply the safe-class fixers (stale lock,
     \\                 orphaned store entries, broken symlinks).
     \\                 Pair with --dry-run to preview the plan.
     \\                 Dangerous classes (corrupt DB, missing kegs)
     \\                 still print a manual remediation command.
+    \\  --verbose      Include per-(token version) entries under the
+    \\                 retained-cask-versions summary.
+    \\  --json         Emit the retained-cask-versions report as a
+    \\                 stable `{cask_history: {retained_versions,
+    \\                 bytes}}` payload on stdout. Empty state still
+    \\                 surfaces with zero values.
     \\
 ;
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -37,6 +37,7 @@ pub const install = @import("cli/install.zig");
 pub const upgrade = @import("cli/upgrade.zig");
 pub const doctor = @import("cli/doctor.zig");
 pub const doctor_fix = @import("cli/doctor/fix.zig");
+pub const doctor_cask_history = @import("cli/doctor/cask_history.zig");
 pub const dsl = @import("core/dsl/root.zig");
 pub const bundle_manifest = @import("core/bundle/manifest.zig");
 pub const bundle_brewfile = @import("core/bundle/brewfile.zig");

--- a/tests/doctor_cask_history_test.zig
+++ b/tests/doctor_cask_history_test.zig
@@ -1,0 +1,256 @@
+//! malt — doctor cask history report integration tests.
+//!
+//! Drives `doctor.emitCaskHistoryReport` against a real seeded prefix
+//! and asserts the bytes that land on stderr (human) or stdout (JSON).
+//! The pure rendering functions are exercised in
+//! `src/cli/doctor/cask_history.zig`'s inline tests; this file pins
+//! the wiring through `output.*`.
+
+const std = @import("std");
+const malt = @import("malt");
+const test_io = @import("test_io");
+const testing = std.testing;
+const doctor = malt.doctor;
+const cask_history = malt.doctor_cask_history;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+const output = malt.output;
+
+const Scratch = struct {
+    path: [:0]u8,
+
+    fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
+        const ts = test_io.nanoTimestamp(std.Options.debug_io);
+        const path = try std.fmt.allocPrintSentinel(
+            allocator,
+            "/tmp/malt_doctor_cask_history_{s}_{d}",
+            .{ tag, ts },
+            0,
+        );
+        test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, path);
+        const subs = [_][]const u8{ "db", "cache/Cask", "Caskroom" };
+        for (subs) |sd| {
+            const dir = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ path, sd });
+            defer allocator.free(dir);
+            try test_io.cwd().createDirPath(std.Options.debug_io, dir);
+        }
+        return .{ .path = path };
+    }
+
+    fn deinit(self: *Scratch, allocator: std.mem.Allocator) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.path) catch {};
+        allocator.free(self.path);
+    }
+
+    /// Plant a current cask + two retained history rows + matching
+    /// disk artefacts so the walker reports a deterministic byte total.
+    fn seedTwoRetainedAlphaVersions(self: *Scratch, allocator: std.mem.Allocator) !void {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{self.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+        try db.exec(
+            \\INSERT INTO casks (token, name, version, url)
+            \\VALUES ('alpha', 'Alpha', '2.0', 'https://x.invalid/a.dmg');
+        );
+        try db.exec(
+            \\INSERT INTO cask_versions (token, version, url, artifact_type)
+            \\VALUES ('alpha', '1.0', 'https://x.invalid/a-1.0.dmg', 'dmg'),
+            \\       ('alpha', '1.5', 'https://x.invalid/a-1.5.dmg', 'dmg'),
+            \\       ('alpha', '2.0', 'https://x.invalid/a-2.0.dmg', 'dmg');
+        );
+
+        const app_1_0 = try std.fmt.allocPrint(allocator, "{s}/Caskroom/alpha/1.0/Alpha.app", .{self.path});
+        defer allocator.free(app_1_0);
+        try test_io.cwd().createDirPath(std.Options.debug_io, std.fs.path.dirname(app_1_0).?);
+        const f1 = try test_io.createFileAbsolute(std.Options.debug_io, app_1_0, .{ .truncate = true });
+        defer f1.close(std.Options.debug_io);
+        try f1.writeStreamingAll(std.Options.debug_io, "x" ** 64);
+
+        const cache_1_5 = try std.fmt.allocPrint(allocator, "{s}/cache/Cask/alpha-1.5.dmg", .{self.path});
+        defer allocator.free(cache_1_5);
+        const f2 = try test_io.createFileAbsolute(std.Options.debug_io, cache_1_5, .{ .truncate = true });
+        defer f2.close(std.Options.debug_io);
+        try f2.writeStreamingAll(std.Options.debug_io, "y" ** 128);
+    }
+};
+
+fn resetOutputFlags() void {
+    output.setQuiet(false);
+    output.setVerbose(false);
+    output.setMode(.human);
+}
+
+test "emitCaskHistoryReport: default mode prints a one-line summary on stderr" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "default");
+    defer s.deinit(allocator);
+    try s.seedTwoRetainedAlphaVersions(allocator);
+
+    resetOutputFlags();
+    defer resetOutputFlags();
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.emitCaskHistoryReport(allocator, std.Options.debug_io, s.path);
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "Retained cask versions: 2") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "mt purge --old-versions") != null);
+    // Default mode must not list per-entry rows — those belong to --verbose.
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha 1.0") == null);
+}
+
+test "emitCaskHistoryReport: empty case stays silent on stderr in human mode" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "empty");
+    defer s.deinit(allocator);
+
+    resetOutputFlags();
+    defer resetOutputFlags();
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.emitCaskHistoryReport(allocator, std.Options.debug_io, s.path);
+
+    try testing.expectEqual(@as(usize, 0), stderr_buf.items.len);
+}
+
+test "emitCaskHistoryReport: --verbose lists every retained (token version) under the summary" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "verbose");
+    defer s.deinit(allocator);
+    try s.seedTwoRetainedAlphaVersions(allocator);
+
+    resetOutputFlags();
+    defer resetOutputFlags();
+    output.setVerbose(true);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.emitCaskHistoryReport(allocator, std.Options.debug_io, s.path);
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "Retained cask versions: 2") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha 1.0") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha 1.5") != null);
+}
+
+test "emitCaskHistoryReport: --json emits the cask_history payload on stdout" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "json");
+    defer s.deinit(allocator);
+    try s.seedTwoRetainedAlphaVersions(allocator);
+
+    resetOutputFlags();
+    defer resetOutputFlags();
+    output.setMode(.json);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.emitCaskHistoryReport(allocator, std.Options.debug_io, s.path);
+
+    // Stable JSON shape — same byte sequence the inline `writeJson`
+    // test pins, so a refactor that changes either path catches both.
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"cask_history\":") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"retained_versions\":2") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"bytes\":") != null);
+    // JSON mode routes the report away from stderr — no human summary
+    // line should appear there.
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "Retained cask versions") == null);
+}
+
+test "emitCaskHistoryReport: --json stays stable when nothing is retained" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "json_empty");
+    defer s.deinit(allocator);
+
+    resetOutputFlags();
+    defer resetOutputFlags();
+    output.setMode(.json);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    doctor.emitCaskHistoryReport(allocator, std.Options.debug_io, s.path);
+
+    // Schema contract: the section is always present, even when empty.
+    try testing.expectEqualStrings(
+        "{\"cask_history\":{\"retained_versions\":0,\"bytes\":0}}\n",
+        stdout_buf.items,
+    );
+}
+
+test "emitCaskHistoryReport: read-only — cask_versions rows survive the walk" {
+    // Doctor reports without `--fix` must never mutate. Pin the row
+    // count before and after so a future regression that wires a
+    // delete into this code path trips here.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "ro");
+    defer s.deinit(allocator);
+    try s.seedTwoRetainedAlphaVersions(allocator);
+
+    const before = try countCaskVersionRows(allocator, s.path);
+
+    resetOutputFlags();
+    defer resetOutputFlags();
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.emitCaskHistoryReport(allocator, std.Options.debug_io, s.path);
+
+    const after = try countCaskVersionRows(allocator, s.path);
+    try testing.expectEqual(before, after);
+    try testing.expectEqual(@as(i64, 3), after);
+}
+
+fn countCaskVersionRows(allocator: std.mem.Allocator, prefix: []const u8) !i64 {
+    _ = allocator;
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    var stmt = try db.prepare("SELECT COUNT(*) FROM cask_versions;");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    return stmt.columnInt(0);
+}
+
+test "writeJson exposed via lib alias matches the inline test bytes" {
+    // Smoke check that the public symbol path in `malt.doctor_cask_history`
+    // resolves to the same writer the unit tests exercise.
+    var entries = [_]cask_history.Entry{
+        .{ .token = "alpha", .version = "1.0", .bytes = 64 },
+    };
+    const census: cask_history.Census = .{ .entries = entries[0..], .total_bytes = 64 };
+
+    var buf: [128]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try cask_history.writeJson(&w, census);
+    try testing.expectEqualStrings(
+        "{\"cask_history\":{\"retained_versions\":1,\"bytes\":64}}\n",
+        w.buffered(),
+    );
+}


### PR DESCRIPTION
## Description

`mt doctor` now points the user at retained cask version state that `mt purge --old-versions` could reclaim. After the existing check rows, the command reports:

- `Retained cask versions: N (X.Y B). Run: mt purge --old-versions` as a one-liner in default human mode (silent when nothing is retained, so the empty case adds no noise);
- the per-`(token, version)` breakdown under `--verbose`;
- a stable `{"cask_history": {"retained_versions": N, "bytes": B}}` payload on stdout under `--json` — the section is always present, even when empty, so scripted consumers can rely on the shape.

`doctor` and `purge` always agree on the number. `--fix` does not touch this report.

## Related Issue

- None

## Notes for Reviewers

- None