### PR TITLE
feat(cli/doctor): enumerate offenders under --verbose

### DIFF
--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -191,14 +191,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     }
 }
 
-/// Emit one dim/faint detail line indented under a check row. Routes
-/// through `output.writeStderrAll` so doctor's stderr-capture tests
-/// see the bytes; `std.debug.print` would bypass the capture buffer.
-/// 4-space indent keeps the row visually nested under the parent
-/// without crowding the message text on the line above.
+/// Emit one dim/faint detail line indented under a check row, with a
+/// `-` bullet so multiple rows read as a list. Routes through
+/// `output.writeStderrAll` so doctor's stderr-capture tests see the
+/// bytes; `std.debug.print` would bypass the capture buffer.
 fn writeStyledDetail(text: []const u8) void {
     var line_buf: [1024]u8 = undefined;
-    const line = std.fmt.bufPrint(&line_buf, "    {s}\n", .{text}) catch return;
+    const line = std.fmt.bufPrint(&line_buf, "    - {s}\n", .{text}) catch return;
     if (color.isColorEnabled()) {
         output.writeStderrAll(color.SemanticStyle.detail.code());
         output.writeStderrAll(line);

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -582,15 +582,13 @@ fn checkMachOPlaceholders(ctx: CheckCtx, name: []const u8) CheckResult {
     };
     defer walker.deinit();
 
-    var bad_count: u32 = 0;
-    var first_bad_buf: [256]u8 = undefined;
-    var first_bad_len: usize = 0;
-    // Group by `<package> <version>` so the verbose list reports the
-    // reinstall target the user actually cares about. A single keg
-    // can bundle hundreds of placeholder-bearing files (Python
-    // site-packages, llvm tools, …) and a per-file enumeration buries
-    // the actionable name in noise.
-    var groups: std.StringArrayHashMapUnmanaged(u32) = .empty;
+    // Group by `<package> <version>` so the headline reports the
+    // reinstall target — the user reinstalls the keg, not the file.
+    // A single keg can bundle hundreds of placeholder-bearing files
+    // (Python site-packages inside a meta-package, LLVM tools);
+    // counting files there inflates the number without adding
+    // actionable information.
+    var groups: std.StringArrayHashMapUnmanaged(void) = .empty;
     defer {
         var it = groups.iterator();
         while (it.next()) |kv| ctx.allocator.free(kv.key_ptr.*);
@@ -600,50 +598,41 @@ fn checkMachOPlaceholders(ctx: CheckCtx, name: []const u8) CheckResult {
     while (walker.next(ctx.io) catch null) |entry| {
         if (entry.kind != .file) continue;
         if (hasUnpatchedPlaceholder(ctx.io, ctx.allocator, &cellar_dir, entry.path) catch false) {
-            bad_count += 1;
-            if (first_bad_len == 0) {
-                const s = std.fmt.bufPrint(&first_bad_buf, "{s}", .{entry.path}) catch continue;
-                first_bad_len = s.len;
-            }
-            // Verbose-grouping is best-effort: an allocator failure
-            // here drops the group entry, never the count.
+            // Grouping is best-effort: an allocator failure here
+            // drops the group entry, never silently triggers an
+            // .ok outcome — the headline is still right because
+            // it's derived from `groups.count()` which only grows
+            // when the entry actually lands.
             const key = caskCellarKegKey(ctx.allocator, entry.path) orelse continue;
             const gop = groups.getOrPut(ctx.allocator, key) catch {
                 ctx.allocator.free(key);
                 continue;
             };
-            if (gop.found_existing) {
-                ctx.allocator.free(key);
-            } else {
-                gop.value_ptr.* = 0;
-            }
-            gop.value_ptr.* += 1;
+            if (gop.found_existing) ctx.allocator.free(key);
         }
     }
 
-    if (bad_count == 0) {
+    if (groups.count() == 0) {
         printCheck(name, .ok, null);
         return .ok;
     }
+    const first_key = blk: {
+        var it = groups.iterator();
+        break :blk if (it.next()) |kv| kv.key_ptr.* else "";
+    };
     var msg_buf: [512]u8 = undefined;
     const msg = std.fmt.bufPrint(
         &msg_buf,
-        "{d} Mach-O file(s) with unpatched @@HOMEBREW_* placeholders (first: {s}). Reinstall the affected packages.",
-        .{ bad_count, first_bad_buf[0..first_bad_len] },
+        "{d} package(s) ship Mach-O file(s) with unpatched @@HOMEBREW_* placeholders (first: {s}). Reinstall the affected packages.",
+        .{ groups.count(), first_key },
     ) catch "Mach-O files with unpatched @@HOMEBREW_* placeholders found.";
     printCheck(name, .err_status, msg);
 
     if (output.isVerbose()) {
-        var lines: std.ArrayList([]u8) = .empty;
-        defer freeOwnedStringList(ctx.allocator, &lines);
+        var lines: std.ArrayList([]const u8) = .empty;
+        defer lines.deinit(ctx.allocator);
         var it = groups.iterator();
-        while (it.next()) |kv| {
-            const row = std.fmt.allocPrint(ctx.allocator, "{s} ({d} file(s))", .{ kv.key_ptr.*, kv.value_ptr.* }) catch continue;
-            lines.append(ctx.allocator, row) catch {
-                ctx.allocator.free(row);
-                continue;
-            };
-        }
+        while (it.next()) |kv| lines.append(ctx.allocator, kv.key_ptr.*) catch continue;
         writeVerboseList(lines.items);
     }
     return .err_status;

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -9,6 +9,7 @@ const lock_mod = @import("../db/lock.zig");
 const atomic = @import("../fs/atomic.zig");
 const clonefile = @import("../fs/clonefile.zig");
 const output = @import("../ui/output.zig");
+const color = @import("../ui/color.zig");
 const help = @import("help.zig");
 const parser = @import("../macho/parser.zig");
 const patch = @import("../core/patch.zig");
@@ -188,6 +189,45 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     } else {
         output.success("Your malt installation is healthy", .{});
     }
+}
+
+/// Stream the entries (one per indented line, 8-space prefix matching
+/// the detail-row pattern `checkPrefixPermissions` uses) to stderr
+/// when `--verbose` is active. Lines are wrapped in the detail
+/// (dim/faint) colour so they visually recede next to the check row
+/// they belong to. Routes through `output.writeStderrAll` so doctor's
+/// stderr-capture tests see the bytes; `std.debug.print` would bypass
+/// the capture buffer.
+fn writeVerboseList(entries: []const []const u8) void {
+    if (!output.isVerbose()) return;
+    const colorize = color.isColorEnabled();
+    var line_buf: [1024]u8 = undefined;
+    for (entries) |e| {
+        const text = std.fmt.bufPrint(&line_buf, "        {s}\n", .{e}) catch continue;
+        if (colorize) {
+            output.writeStderrAll(color.SemanticStyle.detail.code());
+            output.writeStderrAll(text);
+            output.writeStderrAll(color.Style.reset.code());
+        } else {
+            output.writeStderrAll(text);
+        }
+    }
+}
+
+fn freeOwnedStringList(allocator: std.mem.Allocator, list: *std.ArrayList([]u8)) void {
+    for (list.items) |s| allocator.free(s);
+    list.deinit(allocator);
+}
+
+/// Extract the keg identifier (`<package> <version>`) from a
+/// Cellar-relative file path of the form `<package>/<version>/<rest>`.
+/// Returns null when the path has fewer than two slash-delimited
+/// segments — those are walker artefacts we ignore here.
+fn caskCellarKegKey(allocator: std.mem.Allocator, path: []const u8) ?[]u8 {
+    const first_slash = std.mem.indexOfScalar(u8, path, '/') orelse return null;
+    const rest = path[first_slash + 1 ..];
+    const second_slash = std.mem.indexOfScalar(u8, rest, '/') orelse rest.len;
+    return std.fmt.allocPrint(allocator, "{s} {s}", .{ path[0..first_slash], rest[0..second_slash] }) catch null;
 }
 
 // ── individual checks ────────────────────────────────────────────────
@@ -447,16 +487,26 @@ fn checkMissingKegs(ctx: CheckCtx, name: []const u8) CheckResult {
     };
     defer stmt.finalize();
 
-    var missing_count: u32 = 0;
+    // Collect missing kegs so `--verbose` can name each one; under
+    // default mode the list is just sized for the count.
+    var offenders: std.ArrayList([]u8) = .empty;
+    defer freeOwnedStringList(ctx.allocator, &offenders);
+
     while (stmt.step() catch false) {
         const cellar_raw = stmt.columnText(2) orelse continue;
         const cellar_path = std.mem.sliceTo(cellar_raw, 0);
         std.Io.Dir.accessAbsolute(ctx.io, cellar_path, .{}) catch {
-            missing_count += 1;
+            const k_name = std.mem.sliceTo(stmt.columnText(0) orelse continue, 0);
+            const k_ver = std.mem.sliceTo(stmt.columnText(1) orelse continue, 0);
+            const row = std.fmt.allocPrint(ctx.allocator, "{s} {s}", .{ k_name, k_ver }) catch continue;
+            offenders.append(ctx.allocator, row) catch {
+                ctx.allocator.free(row);
+                continue;
+            };
         };
     }
 
-    if (missing_count == 0) {
+    if (offenders.items.len == 0) {
         printCheck(name, .ok, null);
         return .ok;
     }
@@ -464,15 +514,17 @@ fn checkMissingKegs(ctx: CheckCtx, name: []const u8) CheckResult {
     const msg = std.fmt.bufPrint(
         &msg_buf,
         "{d} keg(s) in DB but missing on disk. Reinstall affected packages",
-        .{missing_count},
+        .{offenders.items.len},
     ) catch "Missing keg directories detected. Reinstall affected packages";
     printCheck(name, .err_status, msg);
+    writeVerboseList(offenders.items);
     return .err_status;
 }
 
 fn checkBrokenSymlinks(ctx: CheckCtx, name: []const u8) CheckResult {
     const link_dirs = [_][]const u8{ "bin", "lib", "include", "share", "sbin" };
-    var broken_count: u32 = 0;
+    var offenders: std.ArrayList([]u8) = .empty;
+    defer freeOwnedStringList(ctx.allocator, &offenders);
 
     for (link_dirs) |subdir| {
         var dir_buf: [512]u8 = undefined;
@@ -484,14 +536,18 @@ fn checkBrokenSymlinks(ctx: CheckCtx, name: []const u8) CheckResult {
         while (dir_iter.next(ctx.io) catch null) |entry| {
             if (entry.kind == .sym_link) {
                 _ = dir.statFile(ctx.io, entry.name, .{}) catch {
-                    broken_count += 1;
+                    const path = std.fmt.allocPrint(ctx.allocator, "{s}/{s}", .{ subdir, entry.name }) catch continue;
+                    offenders.append(ctx.allocator, path) catch {
+                        ctx.allocator.free(path);
+                        continue;
+                    };
                     continue;
                 };
             }
         }
     }
 
-    if (broken_count == 0) {
+    if (offenders.items.len == 0) {
         printCheck(name, .ok, null);
         return .ok;
     }
@@ -499,9 +555,10 @@ fn checkBrokenSymlinks(ctx: CheckCtx, name: []const u8) CheckResult {
     const msg = std.fmt.bufPrint(
         &msg_buf,
         "{d} broken symlink(s). Run: mt purge --housekeeping",
-        .{broken_count},
+        .{offenders.items.len},
     ) catch "Broken symlinks found. Run: mt purge --housekeeping";
     printCheck(name, .warn_status, msg);
+    writeVerboseList(offenders.items);
     return .warn_status;
 }
 
@@ -528,6 +585,17 @@ fn checkMachOPlaceholders(ctx: CheckCtx, name: []const u8) CheckResult {
     var bad_count: u32 = 0;
     var first_bad_buf: [256]u8 = undefined;
     var first_bad_len: usize = 0;
+    // Group by `<package> <version>` so the verbose list reports the
+    // reinstall target the user actually cares about. A single keg
+    // can bundle hundreds of placeholder-bearing files (Python
+    // site-packages, llvm tools, …) and a per-file enumeration buries
+    // the actionable name in noise.
+    var groups: std.StringArrayHashMapUnmanaged(u32) = .empty;
+    defer {
+        var it = groups.iterator();
+        while (it.next()) |kv| ctx.allocator.free(kv.key_ptr.*);
+        groups.deinit(ctx.allocator);
+    }
 
     while (walker.next(ctx.io) catch null) |entry| {
         if (entry.kind != .file) continue;
@@ -537,6 +605,19 @@ fn checkMachOPlaceholders(ctx: CheckCtx, name: []const u8) CheckResult {
                 const s = std.fmt.bufPrint(&first_bad_buf, "{s}", .{entry.path}) catch continue;
                 first_bad_len = s.len;
             }
+            // Verbose-grouping is best-effort: an allocator failure
+            // here drops the group entry, never the count.
+            const key = caskCellarKegKey(ctx.allocator, entry.path) orelse continue;
+            const gop = groups.getOrPut(ctx.allocator, key) catch {
+                ctx.allocator.free(key);
+                continue;
+            };
+            if (gop.found_existing) {
+                ctx.allocator.free(key);
+            } else {
+                gop.value_ptr.* = 0;
+            }
+            gop.value_ptr.* += 1;
         }
     }
 
@@ -551,6 +632,20 @@ fn checkMachOPlaceholders(ctx: CheckCtx, name: []const u8) CheckResult {
         .{ bad_count, first_bad_buf[0..first_bad_len] },
     ) catch "Mach-O files with unpatched @@HOMEBREW_* placeholders found.";
     printCheck(name, .err_status, msg);
+
+    if (output.isVerbose()) {
+        var lines: std.ArrayList([]u8) = .empty;
+        defer freeOwnedStringList(ctx.allocator, &lines);
+        var it = groups.iterator();
+        while (it.next()) |kv| {
+            const row = std.fmt.allocPrint(ctx.allocator, "{s} ({d} file(s))", .{ kv.key_ptr.*, kv.value_ptr.* }) catch continue;
+            lines.append(ctx.allocator, row) catch {
+                ctx.allocator.free(row);
+                continue;
+            };
+        }
+        writeVerboseList(lines.items);
+    }
     return .err_status;
 }
 

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -191,27 +191,30 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     }
 }
 
-/// Stream the entries (one per indented line, 8-space prefix matching
-/// the detail-row pattern `checkPrefixPermissions` uses) to stderr
-/// when `--verbose` is active. Lines are wrapped in the detail
-/// (dim/faint) colour so they visually recede next to the check row
-/// they belong to. Routes through `output.writeStderrAll` so doctor's
-/// stderr-capture tests see the bytes; `std.debug.print` would bypass
-/// the capture buffer.
+/// Emit one dim/faint detail line indented under a check row. Routes
+/// through `output.writeStderrAll` so doctor's stderr-capture tests
+/// see the bytes; `std.debug.print` would bypass the capture buffer.
+/// 4-space indent keeps the row visually nested under the parent
+/// without crowding the message text on the line above.
+fn writeStyledDetail(text: []const u8) void {
+    var line_buf: [1024]u8 = undefined;
+    const line = std.fmt.bufPrint(&line_buf, "    {s}\n", .{text}) catch return;
+    if (color.isColorEnabled()) {
+        output.writeStderrAll(color.SemanticStyle.detail.code());
+        output.writeStderrAll(line);
+        output.writeStderrAll(color.Style.reset.code());
+    } else {
+        output.writeStderrAll(line);
+    }
+}
+
+/// Stream the verbose-only entry list. Gated on `--verbose`; the
+/// always-on first-3 hint lines (`checkPrefixPermissions`) call
+/// `writeStyledDetail` directly so they share the styling without
+/// the verbose gate.
 fn writeVerboseList(entries: []const []const u8) void {
     if (!output.isVerbose()) return;
-    const colorize = color.isColorEnabled();
-    var line_buf: [1024]u8 = undefined;
-    for (entries) |e| {
-        const text = std.fmt.bufPrint(&line_buf, "        {s}\n", .{e}) catch continue;
-        if (colorize) {
-            output.writeStderrAll(color.SemanticStyle.detail.code());
-            output.writeStderrAll(text);
-            output.writeStderrAll(color.Style.reset.code());
-        } else {
-            output.writeStderrAll(text);
-        }
-    }
+    for (entries) |e| writeStyledDetail(e);
 }
 
 fn freeOwnedStringList(allocator: std.mem.Allocator, list: *std.ArrayList([]u8)) void {
@@ -384,7 +387,10 @@ fn checkPrefixPermissions(ctx: CheckCtx, name: []const u8) CheckResult {
         .{ findings.len, ctx.prefix },
     ) catch "Weak-permission paths under prefix";
     printCheck(name, .warn_status, pm_msg);
-    // First few as a hint so the user knows where to look.
+    // First few as a hint so the user knows where to look. Routes
+    // through the shared styled-detail writer for parity with the
+    // verbose lists below — capture-aware (so tests see the bytes)
+    // and dim/faint on a tty.
     for (findings[0..@min(findings.len, 3)]) |f| {
         var line_buf: [1024]u8 = undefined;
         const reason = if (f.report.other_writable)
@@ -393,8 +399,8 @@ fn checkPrefixPermissions(ctx: CheckCtx, name: []const u8) CheckResult {
             "group-writable"
         else
             "wrong owner";
-        const line = std.fmt.bufPrint(&line_buf, "        {s} ({s})", .{ f.path, reason }) catch continue;
-        std.debug.print("{s}\n", .{line});
+        const line = std.fmt.bufPrint(&line_buf, "{s} ({s})", .{ f.path, reason }) catch continue;
+        writeStyledDetail(line);
     }
     return .warn_status;
 }
@@ -616,16 +622,27 @@ fn checkMachOPlaceholders(ctx: CheckCtx, name: []const u8) CheckResult {
         printCheck(name, .ok, null);
         return .ok;
     }
-    const first_key = blk: {
-        var it = groups.iterator();
-        break :blk if (it.next()) |kv| kv.key_ptr.* else "";
-    };
     var msg_buf: [512]u8 = undefined;
-    const msg = std.fmt.bufPrint(
-        &msg_buf,
-        "{d} package(s) ship Mach-O file(s) with unpatched @@HOMEBREW_* placeholders (first: {s}). Reinstall the affected packages.",
-        .{ groups.count(), first_key },
-    ) catch "Mach-O files with unpatched @@HOMEBREW_* placeholders found.";
+    const msg = blk: {
+        if (output.isVerbose()) {
+            // Verbose lists every package below; the (first: …) hint
+            // would just duplicate the first row of that list.
+            break :blk std.fmt.bufPrint(
+                &msg_buf,
+                "{d} package(s) ship Mach-O file(s) with unpatched @@HOMEBREW_* placeholders. Reinstall the affected packages.",
+                .{groups.count()},
+            ) catch "Mach-O files with unpatched @@HOMEBREW_* placeholders found.";
+        }
+        const first_key = first_key: {
+            var it = groups.iterator();
+            break :first_key if (it.next()) |kv| kv.key_ptr.* else "";
+        };
+        break :blk std.fmt.bufPrint(
+            &msg_buf,
+            "{d} package(s) ship Mach-O file(s) with unpatched @@HOMEBREW_* placeholders (first: {s}). Reinstall the affected packages.",
+            .{ groups.count(), first_key },
+        ) catch "Mach-O files with unpatched @@HOMEBREW_* placeholders found.";
+    };
     printCheck(name, .err_status, msg);
 
     if (output.isVerbose()) {

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -2,36 +2,38 @@
 //! System health check.
 
 const std = @import("std");
-const AppCtx = @import("../app_ctx.zig").AppCtx;
-const sqlite = @import("../db/sqlite.zig");
-const schema = @import("../db/schema.zig");
-const lock_mod = @import("../db/lock.zig");
-const atomic = @import("../fs/atomic.zig");
-const clonefile = @import("../fs/clonefile.zig");
-const output = @import("../ui/output.zig");
-const color = @import("../ui/color.zig");
-const help = @import("help.zig");
-const parser = @import("../macho/parser.zig");
-const patch = @import("../core/patch.zig");
-const perms_mod = @import("../core/perms.zig");
-const client_mod = @import("../net/client.zig");
+
 const mount_c = @import("c_mount");
 
-const render = @import("doctor/render.zig");
-const post_install = @import("doctor/post_install.zig");
-const fix_mod = @import("doctor/fix.zig");
+const AppCtx = @import("../app_ctx.zig").AppCtx;
+const patch = @import("../core/patch.zig");
+const perms_mod = @import("../core/perms.zig");
+const lock_mod = @import("../db/lock.zig");
+const schema = @import("../db/schema.zig");
+const sqlite = @import("../db/sqlite.zig");
+const atomic = @import("../fs/atomic.zig");
+const clonefile = @import("../fs/clonefile.zig");
+const parser = @import("../macho/parser.zig");
+const client_mod = @import("../net/client.zig");
+const color = @import("../ui/color.zig");
+const output = @import("../ui/output.zig");
 pub const cask_history = @import("doctor/cask_history.zig");
-
+const fix_mod = @import("doctor/fix.zig");
 pub const FixKind = fix_mod.FixKind;
 pub const ManualKind = fix_mod.ManualKind;
 pub const FixConditions = fix_mod.Conditions;
 pub const FixPlan = fix_mod.Plan;
 pub const planFixes = fix_mod.planFixes;
-
+const post_install = @import("doctor/post_install.zig");
+const render = @import("doctor/render.zig");
 pub const CheckStatus = render.CheckStatus;
 pub const CheckStyle = render.CheckStyle;
 pub const renderCheckRow = render.renderCheckRow;
 pub const printCheck = render.printCheck;
+/// Per-check outcome; same tags the row renderer uses so the walker
+/// can tally without re-translating.
+pub const CheckResult = render.CheckStatus;
+const help = @import("help.zig");
 
 /// Shared context passed to every check.
 pub const CheckCtx = struct {
@@ -40,10 +42,6 @@ pub const CheckCtx = struct {
     io: std.Io,
     environ: std.process.Environ,
 };
-
-/// Per-check outcome; same tags the row renderer uses so the walker
-/// can tally without re-translating.
-pub const CheckResult = render.CheckStatus;
 
 /// One entry in the health walk. `run` prints its row(s) and returns
 /// the walker's tally tag.
@@ -135,6 +133,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     const fix_requested = fix_mod.wantsFix(args);
 
+    resetVerboseHint();
     output.info("Running health checks...", .{});
     const tally = runChecks(.{
         .allocator = allocator,
@@ -180,6 +179,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     }
 
     output.plain("", .{});
+    emitVerboseHintIfNeeded();
     if (tally.errors > 0) {
         output.err("{d} error(s), {d} warning(s)", .{ tally.errors, tally.warnings });
         std.process.exit(2);
@@ -189,6 +189,37 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     } else {
         output.success("Your malt installation is healthy", .{});
     }
+}
+
+/// Armed by any check that surfaces offenders the user could see
+/// listed under `--verbose` (Mach-O placeholders, broken symlinks,
+/// missing kegs, prefix-permissions). `execute` reads it after the
+/// check loop to emit a dim "run with --verbose for the full list"
+/// nudge. Reset by `resetVerboseHint` so re-entering the dispatcher
+/// from tests starts clean.
+var verbose_hint_armed: bool = false;
+
+/// Test hook + production reset: clear the verbose-hint flag at the
+/// top of every `execute` so a previous run on the same process
+/// doesn't leak its state.
+pub fn resetVerboseHint() void {
+    verbose_hint_armed = false;
+}
+
+/// Internal arm — called by enumerable checks whenever they have
+/// offenders, regardless of the verbose flag. `emitVerboseHintIfNeeded`
+/// decides whether to surface the nudge.
+fn armVerboseHint() void {
+    verbose_hint_armed = true;
+}
+
+/// Emit a "run with --verbose for the full list" nudge after the
+/// check loop when an enumerable check surfaced offenders AND
+/// `--verbose` is off.
+pub fn emitVerboseHintIfNeeded() void {
+    if (output.isVerbose()) return;
+    if (!verbose_hint_armed) return;
+    output.dim("run with --verbose for the full list", .{});
 }
 
 /// Emit one dim/faint detail line indented under a check row, with a
@@ -386,6 +417,7 @@ fn checkPrefixPermissions(ctx: CheckCtx, name: []const u8) CheckResult {
         .{ findings.len, ctx.prefix },
     ) catch "Weak-permission paths under prefix";
     printCheck(name, .warn_status, pm_msg);
+    armVerboseHint();
     // First few as a hint so the user knows where to look. Routes
     // through the shared styled-detail writer for parity with the
     // verbose lists below — capture-aware (so tests see the bytes)
@@ -522,6 +554,7 @@ fn checkMissingKegs(ctx: CheckCtx, name: []const u8) CheckResult {
         .{offenders.items.len},
     ) catch "Missing keg directories detected. Reinstall affected packages";
     printCheck(name, .err_status, msg);
+    armVerboseHint();
     writeVerboseList(offenders.items);
     return .err_status;
 }
@@ -563,6 +596,7 @@ fn checkBrokenSymlinks(ctx: CheckCtx, name: []const u8) CheckResult {
         .{offenders.items.len},
     ) catch "Broken symlinks found. Run: mt purge --housekeeping";
     printCheck(name, .warn_status, msg);
+    armVerboseHint();
     writeVerboseList(offenders.items);
     return .warn_status;
 }
@@ -643,6 +677,7 @@ fn checkMachOPlaceholders(ctx: CheckCtx, name: []const u8) CheckResult {
         ) catch "Mach-O files with unpatched @@HOMEBREW_* placeholders found.";
     };
     printCheck(name, .err_status, msg);
+    armVerboseHint();
 
     if (output.isVerbose()) {
         var lines: std.ArrayList([]const u8) = .empty;

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -199,8 +199,11 @@ const doctor_help =
     \\                 Pair with --dry-run to preview the plan.
     \\                 Dangerous classes (corrupt DB, missing kegs)
     \\                 still print a manual remediation command.
-    \\  --verbose      Include per-(token version) entries under the
-    \\                 retained-cask-versions summary.
+    \\  --verbose      List every offender under the count-only
+    \\                 checks (Mach-O placeholders, broken symlinks,
+    \\                 missing kegs) on its own indented line, and
+    \\                 include the per-(token version) breakdown
+    \\                 under the retained-cask-versions summary.
     \\  --json         Emit the retained-cask-versions report as a
     \\                 stable `{cask_history: {retained_versions,
     \\                 bytes}}` payload on stdout. Empty state still

--- a/tests/doctor_dispatch_test.zig
+++ b/tests/doctor_dispatch_test.zig
@@ -291,17 +291,20 @@ fn captureStderrAround(
     op();
 }
 
-test "checkMachOPlaceholders under --verbose groups offenders by (package version)" {
+test "checkMachOPlaceholders under --verbose lists each affected (package version)" {
     // The verbose list is keyed by the keg the user would reinstall —
     // package + version — not per file, because a single keg can
     // ship hundreds of bundled Mach-O files (Python site-packages
     // inside a meta-package, for example) and a flat enumeration
-    // buries the actionable name in noise.
+    // buries the actionable name in noise. The per-package file
+    // count is also dropped: the user reinstalls the keg either way,
+    // and a "(N file(s))" suffix turns out to be implementation
+    // noise that distracts from the action.
     const allocator = testing.allocator;
     var s = try Scratch.init(allocator, "macho_verbose");
     defer s.deinit(allocator);
 
-    // alpha 1.0: two bad files → "alpha 1.0 (2 file(s))".
+    // alpha 1.0: two bad files — should appear ONCE in the list.
     const dir1 = try std.fmt.allocPrint(allocator, "{s}/Cellar/alpha/1.0/lib", .{s.path});
     defer allocator.free(dir1);
     try test_io.cwd().createDirPath(std.Options.debug_io, dir1);
@@ -312,7 +315,7 @@ test "checkMachOPlaceholders under --verbose groups offenders by (package versio
     defer allocator.free(bin1b);
     try writeMachOWithPath(allocator, bin1b, "@@HOMEBREW_PREFIX@@/lib/libalpha-extra.dylib");
 
-    // beta 2.0: one bad file → "beta 2.0 (1 file(s))".
+    // beta 2.0: one bad file.
     const dir2 = try std.fmt.allocPrint(allocator, "{s}/Cellar/beta/2.0/bin", .{s.path});
     defer allocator.free(dir2);
     try test_io.cwd().createDirPath(std.Options.debug_io, dir2);
@@ -335,11 +338,12 @@ test "checkMachOPlaceholders under --verbose groups offenders by (package versio
         .environ = .empty,
     }, &doctor.checks);
 
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha 1.0 (2 file(s))") != null);
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        beta 2.0 (1 file(s))") != null);
-    // Flat per-file rows must NOT appear — that is what the user
-    // explicitly asked to stop seeing on real systems where one
-    // affected keg can contribute 100+ files.
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha 1.0\n") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        beta 2.0\n") != null);
+    // Each package appears exactly once — no per-file rows leaking
+    // back in via the grouping.
+    const alpha_idx = std.mem.indexOf(u8, stderr_buf.items, "        alpha 1.0\n").?;
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items[alpha_idx + 1 ..], "        alpha 1.0\n") == null);
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha/1.0/lib/libalpha.dylib") == null);
 }
 
@@ -409,12 +413,20 @@ test "checkMachOPlaceholders without --verbose keeps the count + first-hint summ
         .environ = .empty,
     }, &doctor.checks);
 
-    // Both files contribute to the count, but only one shows as the
-    // (first: …) example in default mode. The verbose-only indented
-    // lines must be absent.
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "2 Mach-O file(s)") != null);
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha/1.0/lib/libalpha.dylib") == null);
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        beta/2.0/bin/beta") == null);
+    // Headline counts PACKAGES, not files: the user reinstalls the
+    // keg either way, so the package count is the actionable number.
+    // First-package hint stays (helps users who don't want to re-run
+    // with --verbose). No detail rows in default mode.
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "2 package(s)") != null);
+    // FS walk order isn't guaranteed to be alphabetical on every
+    // host, so accept either of the two seeded kegs as the first
+    // example — the contract is "name a real package", not "name
+    // this specific package".
+    const has_alpha_first = std.mem.indexOf(u8, stderr_buf.items, "(first: alpha 1.0)") != null;
+    const has_beta_first = std.mem.indexOf(u8, stderr_buf.items, "(first: beta 2.0)") != null;
+    try testing.expect(has_alpha_first or has_beta_first);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha 1.0\n") == null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        beta 2.0\n") == null);
 }
 
 test "checkBrokenSymlinks under --verbose lists every broken symlink path" {

--- a/tests/doctor_dispatch_test.zig
+++ b/tests/doctor_dispatch_test.zig
@@ -338,12 +338,12 @@ test "checkMachOPlaceholders under --verbose lists each affected (package versio
         .environ = .empty,
     }, &doctor.checks);
 
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    alpha 1.0\n") != null);
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    beta 2.0\n") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    - alpha 1.0\n") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    - beta 2.0\n") != null);
     // Each package appears exactly once — no per-file rows leaking
     // back in via the grouping.
-    const alpha_idx = std.mem.indexOf(u8, stderr_buf.items, "    alpha 1.0\n").?;
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items[alpha_idx + 1 ..], "    alpha 1.0\n") == null);
+    const alpha_idx = std.mem.indexOf(u8, stderr_buf.items, "    - alpha 1.0\n").?;
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items[alpha_idx + 1 ..], "    - alpha 1.0\n") == null);
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha/1.0/lib/libalpha.dylib") == null);
     // Verbose redundantly shows every package below the headline,
     // so the (first: …) hint must drop out — the row above is
@@ -377,7 +377,7 @@ test "checkBrokenSymlinks without --verbose keeps the count summary only" {
     }, &doctor.checks);
 
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "1 broken symlink(s)") != null);
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    bin/ghost-default") == null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    - bin/ghost-default") == null);
 }
 
 test "checkMachOPlaceholders without --verbose keeps the count + first-hint summary only" {
@@ -429,8 +429,8 @@ test "checkMachOPlaceholders without --verbose keeps the count + first-hint summ
     const has_alpha_first = std.mem.indexOf(u8, stderr_buf.items, "(first: alpha 1.0)") != null;
     const has_beta_first = std.mem.indexOf(u8, stderr_buf.items, "(first: beta 2.0)") != null;
     try testing.expect(has_alpha_first or has_beta_first);
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    alpha 1.0\n") == null);
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    beta 2.0\n") == null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    - alpha 1.0\n") == null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    - beta 2.0\n") == null);
 }
 
 test "checkBrokenSymlinks under --verbose lists every broken symlink path" {

--- a/tests/doctor_dispatch_test.zig
+++ b/tests/doctor_dispatch_test.zig
@@ -338,13 +338,17 @@ test "checkMachOPlaceholders under --verbose lists each affected (package versio
         .environ = .empty,
     }, &doctor.checks);
 
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha 1.0\n") != null);
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        beta 2.0\n") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    alpha 1.0\n") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    beta 2.0\n") != null);
     // Each package appears exactly once — no per-file rows leaking
     // back in via the grouping.
-    const alpha_idx = std.mem.indexOf(u8, stderr_buf.items, "        alpha 1.0\n").?;
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items[alpha_idx + 1 ..], "        alpha 1.0\n") == null);
+    const alpha_idx = std.mem.indexOf(u8, stderr_buf.items, "    alpha 1.0\n").?;
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items[alpha_idx + 1 ..], "    alpha 1.0\n") == null);
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha/1.0/lib/libalpha.dylib") == null);
+    // Verbose redundantly shows every package below the headline,
+    // so the (first: …) hint must drop out — the row above is
+    // shorter without it.
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "(first:") == null);
 }
 
 test "checkBrokenSymlinks without --verbose keeps the count summary only" {
@@ -373,7 +377,7 @@ test "checkBrokenSymlinks without --verbose keeps the count summary only" {
     }, &doctor.checks);
 
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "1 broken symlink(s)") != null);
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        bin/ghost-default") == null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    bin/ghost-default") == null);
 }
 
 test "checkMachOPlaceholders without --verbose keeps the count + first-hint summary only" {
@@ -425,8 +429,8 @@ test "checkMachOPlaceholders without --verbose keeps the count + first-hint summ
     const has_alpha_first = std.mem.indexOf(u8, stderr_buf.items, "(first: alpha 1.0)") != null;
     const has_beta_first = std.mem.indexOf(u8, stderr_buf.items, "(first: beta 2.0)") != null;
     try testing.expect(has_alpha_first or has_beta_first);
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha 1.0\n") == null);
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        beta 2.0\n") == null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    alpha 1.0\n") == null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    beta 2.0\n") == null);
 }
 
 test "checkBrokenSymlinks under --verbose lists every broken symlink path" {
@@ -463,6 +467,51 @@ test "checkBrokenSymlinks under --verbose lists every broken symlink path" {
 
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "bin/ghost-a") != null);
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "lib/ghost-b") != null);
+}
+
+test "checkPrefixPermissions hint lines flow through stderr capture so they share the verbose-list look" {
+    // Pre-this PR, the first-3 hint rows used `std.debug.print` and
+    // bypassed the output capture, so tests couldn't pin them and
+    // they were styled differently from every other detail line.
+    // Both should now route through `output.writeStderrAll` (the
+    // same path used by Mach-O / symlinks / kegs verbose lists),
+    // putting the bytes into the capture buffer.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "perms_hints");
+    defer s.deinit(allocator);
+
+    // Plant a path with a group-writable bit so the perms walker
+    // reports it. Bit 0o020 == group-write. UID match keeps the
+    // walker focused on the perms axis.
+    const weak = try std.fmt.allocPrint(allocator, "{s}/Cellar/weak", .{s.path});
+    defer allocator.free(weak);
+    const f = try test_io.createFileAbsolute(std.Options.debug_io, weak, .{ .truncate = true });
+    f.close(std.Options.debug_io);
+    _ = std.c.chmod(@ptrCast(weak.ptr), 0o664);
+
+    output.setVerbose(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+
+    // Either the path landed in the capture (new behaviour) or the
+    // perms walker on this host didn't trip (CI without group bits);
+    // accept both, but if the row appears it must have flowed
+    // through the capture, not the bypass.
+    if (std.mem.indexOf(u8, stderr_buf.items, "Prefix permissions") != null and
+        std.mem.indexOf(u8, stderr_buf.items, "weak permissions") != null)
+    {
+        try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "Cellar/weak") != null);
+    }
 }
 
 test "checkMissingKegs under --verbose lists each missing (name version) pair" {

--- a/tests/doctor_dispatch_test.zig
+++ b/tests/doctor_dispatch_test.zig
@@ -469,6 +469,105 @@ test "checkBrokenSymlinks under --verbose lists every broken symlink path" {
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "lib/ghost-b") != null);
 }
 
+test "after the check loop, a dim --verbose hint fires when offenders exist and --verbose is off" {
+    // Mach-O placeholder seeded so the check has at least one
+    // offender to enumerate; with --verbose OFF the user only sees
+    // the count + first hint. The new tail-of-output nudge points
+    // them at --verbose so they can find the rest without having
+    // to know about the flag.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "verbose_hint");
+    defer s.deinit(allocator);
+
+    const dir1 = try std.fmt.allocPrint(allocator, "{s}/Cellar/alpha/1.0/lib", .{s.path});
+    defer allocator.free(dir1);
+    try test_io.cwd().createDirPath(std.Options.debug_io, dir1);
+    const bin1 = try std.fmt.allocPrint(allocator, "{s}/libalpha.dylib", .{dir1});
+    defer allocator.free(bin1);
+    try writeMachOWithPath(allocator, bin1, "@@HOMEBREW_PREFIX@@/lib/libalpha.dylib");
+
+    output.setVerbose(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.resetVerboseHint();
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+    doctor.emitVerboseHintIfNeeded();
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "--verbose") != null);
+}
+
+test "emitVerboseHintIfNeeded stays silent when --verbose is already active" {
+    // Re-running with --verbose surfaces the list directly, so the
+    // nudge would be redundant. Pin it as silent in that case.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "verbose_hint_on");
+    defer s.deinit(allocator);
+
+    const dir1 = try std.fmt.allocPrint(allocator, "{s}/Cellar/alpha/1.0/lib", .{s.path});
+    defer allocator.free(dir1);
+    try test_io.cwd().createDirPath(std.Options.debug_io, dir1);
+    const bin1 = try std.fmt.allocPrint(allocator, "{s}/libalpha.dylib", .{dir1});
+    defer allocator.free(bin1);
+    try writeMachOWithPath(allocator, bin1, "@@HOMEBREW_PREFIX@@/lib/libalpha.dylib");
+
+    output.setVerbose(true);
+    defer output.setVerbose(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.resetVerboseHint();
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+    doctor.emitVerboseHintIfNeeded();
+
+    // The "Run …" prefix on the existing fix hint (e.g.
+    // `Run: mt purge --housekeeping`) is unrelated; assert the
+    // nudge-specific phrase is absent.
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "for the full list") == null);
+}
+
+test "emitVerboseHintIfNeeded stays silent on a clean prefix" {
+    // No enumerable offenders → no nudge. Otherwise we'd train
+    // users to ignore it as noise on healthy systems.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "verbose_hint_clean");
+    defer s.deinit(allocator);
+
+    output.setVerbose(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.resetVerboseHint();
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+    doctor.emitVerboseHintIfNeeded();
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "for the full list") == null);
+}
+
 test "checkPrefixPermissions hint lines flow through stderr capture so they share the verbose-list look" {
     // Pre-this PR, the first-3 hint rows used `std.debug.print` and
     // bypassed the output capture, so tests couldn't pin them and

--- a/tests/doctor_dispatch_test.zig
+++ b/tests/doctor_dispatch_test.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 const malt = @import("malt");
 const test_io = @import("test_io");
 const testing = std.testing;
+const macho = std.macho;
 const doctor = malt.doctor;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
@@ -226,4 +227,269 @@ test "countMissingLocalSources tallies missing source paths against tap='local' 
     const census = doctor.countMissingLocalSources(std.Options.debug_io, &db);
     try testing.expectEqual(@as(u32, 2), census.total);
     try testing.expectEqual(@as(u32, 1), census.stale);
+}
+
+// --- --verbose enumeration for count-only checks -----------------------
+
+fn writeMachOWithPath(
+    allocator: std.mem.Allocator,
+    file_path: []const u8,
+    embedded_path: []const u8,
+) !void {
+    // Mach-O 64 with a single LC_LOAD_DYLIB whose dylib name is
+    // `embedded_path`. `doctor.checkMachOPlaceholders` parses load
+    // command paths and flags any that still contain
+    // `@@HOMEBREW_PREFIX@@` / `@@HOMEBREW_CELLAR@@`, so this fixture is
+    // the minimum that exercises the check end-to-end.
+    const lc_size = @sizeOf(macho.dylib_command);
+    const name_offset: u32 = @intCast(lc_size);
+    const path_len = embedded_path.len + 1; // NUL terminator
+    const cmdsize: u32 = @intCast(lc_size + path_len);
+    const cmdsize_aligned: u32 = (cmdsize + 7) & ~@as(u32, 7);
+
+    const header_size = @sizeOf(macho.mach_header_64);
+    const total_len = header_size + cmdsize_aligned;
+
+    const buf = try allocator.alloc(u8, total_len);
+    defer allocator.free(buf);
+    @memset(buf, 0);
+
+    const header = std.mem.bytesAsValue(macho.mach_header_64, buf[0..header_size]);
+    header.* = .{
+        .magic = macho.MH_MAGIC_64,
+        .ncmds = 1,
+        .sizeofcmds = cmdsize_aligned,
+    };
+
+    const dy = std.mem.bytesAsValue(macho.dylib_command, buf[header_size..][0..lc_size]);
+    dy.* = .{
+        .cmd = .LOAD_DYLIB,
+        .cmdsize = cmdsize_aligned,
+        .dylib = .{
+            .name = name_offset,
+            .timestamp = 0,
+            .current_version = 0,
+            .compatibility_version = 0,
+        },
+    };
+    @memcpy(buf[header_size + lc_size ..][0..embedded_path.len], embedded_path);
+    // Trailing NUL is already zero from @memset; the +1 ensures
+    // parser sees a terminated string.
+
+    const f = try test_io.createFileAbsolute(std.Options.debug_io, file_path, .{ .truncate = true });
+    defer f.close(std.Options.debug_io);
+    try f.writeStreamingAll(std.Options.debug_io, buf);
+}
+
+fn captureStderrAround(
+    allocator: std.mem.Allocator,
+    buf: *std.ArrayList(u8),
+    op: anytype,
+) void {
+    output.beginStderrCapture(allocator, buf);
+    defer output.endStderrCapture();
+    op();
+}
+
+test "checkMachOPlaceholders under --verbose groups offenders by (package version)" {
+    // The verbose list is keyed by the keg the user would reinstall —
+    // package + version — not per file, because a single keg can
+    // ship hundreds of bundled Mach-O files (Python site-packages
+    // inside a meta-package, for example) and a flat enumeration
+    // buries the actionable name in noise.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "macho_verbose");
+    defer s.deinit(allocator);
+
+    // alpha 1.0: two bad files → "alpha 1.0 (2 file(s))".
+    const dir1 = try std.fmt.allocPrint(allocator, "{s}/Cellar/alpha/1.0/lib", .{s.path});
+    defer allocator.free(dir1);
+    try test_io.cwd().createDirPath(std.Options.debug_io, dir1);
+    const bin1a = try std.fmt.allocPrint(allocator, "{s}/libalpha.dylib", .{dir1});
+    defer allocator.free(bin1a);
+    try writeMachOWithPath(allocator, bin1a, "@@HOMEBREW_PREFIX@@/lib/libalpha.dylib");
+    const bin1b = try std.fmt.allocPrint(allocator, "{s}/libalpha-extra.dylib", .{dir1});
+    defer allocator.free(bin1b);
+    try writeMachOWithPath(allocator, bin1b, "@@HOMEBREW_PREFIX@@/lib/libalpha-extra.dylib");
+
+    // beta 2.0: one bad file → "beta 2.0 (1 file(s))".
+    const dir2 = try std.fmt.allocPrint(allocator, "{s}/Cellar/beta/2.0/bin", .{s.path});
+    defer allocator.free(dir2);
+    try test_io.cwd().createDirPath(std.Options.debug_io, dir2);
+    const bin2 = try std.fmt.allocPrint(allocator, "{s}/beta", .{dir2});
+    defer allocator.free(bin2);
+    try writeMachOWithPath(allocator, bin2, "@@HOMEBREW_CELLAR@@/beta/2.0/bin/beta");
+
+    output.setVerbose(true);
+    defer output.setVerbose(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha 1.0 (2 file(s))") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        beta 2.0 (1 file(s))") != null);
+    // Flat per-file rows must NOT appear — that is what the user
+    // explicitly asked to stop seeing on real systems where one
+    // affected keg can contribute 100+ files.
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha/1.0/lib/libalpha.dylib") == null);
+}
+
+test "checkBrokenSymlinks without --verbose keeps the count summary only" {
+    // Default-mode pinning so the verbose branch cannot leak detail
+    // rows when the user did not ask for them.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "symlinks_default");
+    defer s.deinit(allocator);
+
+    const link_path = try std.fmt.allocPrint(allocator, "{s}/bin/ghost-default", .{s.path});
+    defer allocator.free(link_path);
+    try std.Io.Dir.symLinkAbsolute(std.Options.debug_io, "/tmp/malt_doctor_disp_default_symlink_target_dne", link_path, .{});
+
+    output.setVerbose(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "1 broken symlink(s)") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        bin/ghost-default") == null);
+}
+
+test "checkMachOPlaceholders without --verbose keeps the count + first-hint summary only" {
+    // Pin the default-mode output so the verbose branch does not
+    // accidentally leak detail lines into non-verbose runs.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "macho_default");
+    defer s.deinit(allocator);
+
+    const dir1 = try std.fmt.allocPrint(allocator, "{s}/Cellar/alpha/1.0/lib", .{s.path});
+    defer allocator.free(dir1);
+    try test_io.cwd().createDirPath(std.Options.debug_io, dir1);
+    const bin1 = try std.fmt.allocPrint(allocator, "{s}/libalpha.dylib", .{dir1});
+    defer allocator.free(bin1);
+    try writeMachOWithPath(allocator, bin1, "@@HOMEBREW_PREFIX@@/lib/libalpha.dylib");
+
+    const dir2 = try std.fmt.allocPrint(allocator, "{s}/Cellar/beta/2.0/bin", .{s.path});
+    defer allocator.free(dir2);
+    try test_io.cwd().createDirPath(std.Options.debug_io, dir2);
+    const bin2 = try std.fmt.allocPrint(allocator, "{s}/beta", .{dir2});
+    defer allocator.free(bin2);
+    try writeMachOWithPath(allocator, bin2, "@@HOMEBREW_CELLAR@@/beta/2.0/bin/beta");
+
+    // Explicit reset so a leaky test earlier in the run does not
+    // poison this one.
+    output.setVerbose(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+
+    // Both files contribute to the count, but only one shows as the
+    // (first: …) example in default mode. The verbose-only indented
+    // lines must be absent.
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "2 Mach-O file(s)") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha/1.0/lib/libalpha.dylib") == null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        beta/2.0/bin/beta") == null);
+}
+
+test "checkBrokenSymlinks under --verbose lists every broken symlink path" {
+    // Two link-dir entries (bin/ and lib/) each pointing at targets
+    // that do not exist. The check counts both today; verbose must
+    // surface the symlink paths so the user can `ls -l` them
+    // directly.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "symlinks_verbose");
+    defer s.deinit(allocator);
+
+    const link_a_path = try std.fmt.allocPrint(allocator, "{s}/bin/ghost-a", .{s.path});
+    defer allocator.free(link_a_path);
+    try std.Io.Dir.symLinkAbsolute(std.Options.debug_io, "/tmp/malt_doctor_disp_ghost_target_does_not_exist_a", link_a_path, .{});
+
+    const link_b_path = try std.fmt.allocPrint(allocator, "{s}/lib/ghost-b", .{s.path});
+    defer allocator.free(link_b_path);
+    try std.Io.Dir.symLinkAbsolute(std.Options.debug_io, "/tmp/malt_doctor_disp_ghost_target_does_not_exist_b", link_b_path, .{});
+
+    output.setVerbose(true);
+    defer output.setVerbose(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "bin/ghost-a") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "lib/ghost-b") != null);
+}
+
+test "checkMissingKegs under --verbose lists each missing (name version) pair" {
+    // Two keg rows pointing at Cellar paths that don't exist. The
+    // user needs the names to decide which packages to reinstall —
+    // count alone forces them to inspect the DB by hand.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "missing_keg_verbose");
+    defer s.deinit(allocator);
+
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+        try db.exec(
+            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+            \\VALUES
+            \\  ('phantom-a', 'phantom-a', '9.9', 0, '', '/tmp/malt_doctor_disp_phantom_a_dne'),
+            \\  ('phantom-b', 'phantom-b', '1.0', 0, '', '/tmp/malt_doctor_disp_phantom_b_dne');
+        );
+    }
+
+    output.setVerbose(true);
+    defer output.setVerbose(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "phantom-a 9.9") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "phantom-b 1.0") != null);
 }


### PR DESCRIPTION
## Description

`mt doctor` today reports a count for `Mach-O placeholders`, `Broken symlinks`, and `Missing kegs` and discards every offender beyond (at most) one example. On a real system that's 100+ Mach-O files behind a single `(first: …)` hint with no way to ask "which packages?" short of grepping the Cellar.

This PR adds `--verbose` enumeration to all three checks, plus a trailing nudge so users know the flag exists:

## Related Issue

- None

## Notes for Reviewers

- None