### PR TITLE
feat(cli/info): include retained version history per package

### DIFF
--- a/scripts/regressions/info_rollback_history.sh
+++ b/scripts/regressions/info_rollback_history.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Regression: `mt info <pkg>` surfaces the retained rollback history that
+# `mt rollback <pkg> --list` already exposes — one mental model across
+# both verbs. Without this guard the two views could drift, leaving
+# users guessing which one is authoritative.
+#
+# The seeded state mirrors the rollback_list_and_to regression: a
+# currently-installed wget@1.22 keg with two prior on-disk store
+# entries (1.20, 1.21), and a flux-markdown cask at 1.32.427 with two
+# prior cask_versions rows (1.30.0, 1.31.0).
+#
+# Sandbox-only: no network, no installs, no bottles. The store entries
+# are bare directories with placeholder receipts; the rollback writer
+# never reaches for the bottle contents in `--list` / `info`.
+#
+# Usage: scripts/regressions/info_rollback_history.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt,
+# `sqlite3` on PATH.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+PREFIX="/tmp/mt_info_hist_reg"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX/db"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+DB="$PREFIX/db/malt.db"
+
+# Bootstrap schema by letting malt open the DB once.
+"$BIN" list --quiet >/dev/null 2>&1 || true
+[[ -f "$DB" ]] || fail "DB was not initialised by mt list"
+
+# --- formula side: keg row + two prior store versions ---------------------
+sqlite3 "$DB" <<SQL
+INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason)
+VALUES ('wget', 'wget', '1.22', 0, 'sha_cur', '$PREFIX/Cellar/wget/1.22', 'direct');
+SQL
+
+mkdir -p "$PREFIX/Cellar/wget/1.22"
+mkdir -p "$PREFIX/store/sha_a/wget/1.20"
+touch "$PREFIX/store/sha_a/wget/1.20/INSTALL_RECEIPT.json"
+sleep 1.1
+mkdir -p "$PREFIX/store/sha_b/wget/1.21"
+touch "$PREFIX/store/sha_b/wget/1.21/INSTALL_RECEIPT.json"
+sleep 1.1
+mkdir -p "$PREFIX/store/sha_cur/wget/1.22"
+touch "$PREFIX/store/sha_cur/wget/1.22/INSTALL_RECEIPT.json"
+
+# 1. Formula human: section appears with both prior versions.
+INFO_OUT="$PREFIX/info.out"
+"$BIN" info wget >"$INFO_OUT" 2>&1 ||
+  fail "mt info wget exited non-zero (see $INFO_OUT)"
+
+grep -q 'Available rollback versions for wget' "$INFO_OUT" ||
+  fail "mt info wget did not emit the rollback section (see $INFO_OUT)"
+grep -q '1.20' "$INFO_OUT" || fail "mt info wget missing 1.20 (see $INFO_OUT)"
+grep -q '1.21' "$INFO_OUT" || fail "mt info wget missing 1.21 (see $INFO_OUT)"
+# Section must skip the current version.
+SECTION_LINE=$(grep -n 'Available rollback versions' "$INFO_OUT" | head -1 | cut -d: -f1)
+tail -n +"$SECTION_LINE" "$INFO_OUT" | grep -q '1.22' &&
+  fail "mt info wget should not list the current version in its own history"
+pass "mt info <formula> appends the rollback section (skipping the current version)"
+
+# 2. Formula --json: available_rollback_versions populated with the same shape.
+JSON_OUT="$PREFIX/info.json"
+"$BIN" --json info wget >"$JSON_OUT" 2>&1 ||
+  fail "mt --json info wget exited non-zero (see $JSON_OUT)"
+
+JSON=$(cat "$JSON_OUT")
+case "$JSON" in
+*'"available_rollback_versions":'*) ;;
+*) fail "mt --json info wget missing available_rollback_versions key (see $JSON_OUT)" ;;
+esac
+case "$JSON" in
+*'"version":"1.21"'*'"version":"1.20"'*) ;;
+*) fail "mt --json info wget: expected 1.21 then 1.20 in document order (see $JSON_OUT)" ;;
+esac
+case "$JSON" in
+*'"sha256":"sha_a"'*) ;;
+*) fail "mt --json info wget missing sha_a (see $JSON_OUT)" ;;
+esac
+echo "$JSON" | grep -Eq '"mtime":[0-9]+' ||
+  fail "mt --json info wget: mtime is not an integer (see $JSON_OUT)"
+pass "mt info <formula> --json carries the rollback entries[] shape"
+
+# --- cask side: installed row + two prior cask_versions ------------------
+sqlite3 "$DB" <<SQL
+INSERT INTO casks (token, name, version, url, sha256)
+VALUES ('flux-markdown', 'flux-markdown', '1.32.427',
+        'https://example.invalid/flux.dmg', 'aa');
+INSERT INTO cask_versions (token, version, url, sha256, artifact_type, installed_at)
+VALUES ('flux-markdown','1.30.0','https://example.invalid/old.dmg','dd','dmg','2026-01-01T00:00:00'),
+       ('flux-markdown','1.31.0','https://example.invalid/mid.dmg','ee','dmg','2026-02-01T00:00:00'),
+       ('flux-markdown','1.32.427','https://example.invalid/cur.dmg','aa','dmg','2026-03-01T00:00:00');
+SQL
+
+# 3. Cask human: section appears with both prior cask versions.
+CASK_OUT="$PREFIX/cask.out"
+"$BIN" info flux-markdown >"$CASK_OUT" 2>&1 ||
+  fail "mt info flux-markdown exited non-zero (see $CASK_OUT)"
+grep -q 'Available rollback versions for flux-markdown' "$CASK_OUT" ||
+  fail "mt info <cask> did not emit the rollback section (see $CASK_OUT)"
+grep -q '1.30.0' "$CASK_OUT" || fail "mt info <cask> missing 1.30.0 (see $CASK_OUT)"
+grep -q '1.31.0' "$CASK_OUT" || fail "mt info <cask> missing 1.31.0 (see $CASK_OUT)"
+SECTION_LINE=$(grep -n 'Available rollback versions' "$CASK_OUT" | head -1 | cut -d: -f1)
+tail -n +"$SECTION_LINE" "$CASK_OUT" | grep -q '1.32.427' &&
+  fail "mt info <cask> should not list the current version in its own history"
+pass "mt info <cask> appends the rollback section (skipping the current version)"
+
+# 4. Cask --json: parses cleanly, available_rollback_versions has the entries.
+CASK_JSON_OUT="$PREFIX/cask.json"
+"$BIN" --json info flux-markdown >"$CASK_JSON_OUT" 2>&1 ||
+  fail "mt --json info flux-markdown exited non-zero (see $CASK_JSON_OUT)"
+CASK_JSON=$(cat "$CASK_JSON_OUT")
+case "$CASK_JSON" in
+*'"available_rollback_versions":'*) ;;
+*) fail "mt --json info <cask> missing available_rollback_versions key (see $CASK_JSON_OUT)" ;;
+esac
+case "$CASK_JSON" in
+*'"version":"1.31.0"'*'"version":"1.30.0"'*) ;;
+*) fail "mt --json info <cask>: expected 1.31.0 before 1.30.0 (see $CASK_JSON_OUT)" ;;
+esac
+pass "mt info <cask> --json carries the rollback entries[] shape"
+
+# --- empty-history case: no section in human, [] in JSON ------------------
+sqlite3 "$DB" <<SQL
+INSERT INTO casks (token, name, version, url, sha256)
+VALUES ('firefox', 'Firefox', '120.0',
+        'https://example.invalid/ff.dmg', 'bb');
+SQL
+
+EMPTY_OUT="$PREFIX/empty.out"
+"$BIN" info firefox >"$EMPTY_OUT" 2>&1 ||
+  fail "mt info firefox exited non-zero (see $EMPTY_OUT)"
+if grep -q 'Available rollback versions' "$EMPTY_OUT"; then
+  fail "mt info <cask> with no history should not emit the section (see $EMPTY_OUT)"
+fi
+pass "mt info <pkg> with empty history suppresses the section"
+
+EMPTY_JSON_OUT="$PREFIX/empty.json"
+"$BIN" --json info firefox >"$EMPTY_JSON_OUT" 2>&1 ||
+  fail "mt --json info firefox exited non-zero (see $EMPTY_JSON_OUT)"
+case "$(cat "$EMPTY_JSON_OUT")" in
+*'"available_rollback_versions":[]'*) ;;
+*) fail "mt --json info <cask> with no history: expected available_rollback_versions:[] (see $EMPTY_JSON_OUT)" ;;
+esac
+pass "mt info <pkg> --json with empty history emits available_rollback_versions:[]"
+
+printf '\n\xe2\x9c\x94 info-rollback-history regression passed\n'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -159,7 +159,12 @@ const list_help =
 const info_help =
     \\Usage: malt info <package> [flags]
     \\
-    \\Show detailed information about a formula or cask.
+    \\Show detailed information about a formula or cask. If the package
+    \\has retained rollback versions (multi-version store entries for
+    \\formulas, cask_versions history for casks), they are listed under
+    \\an "Available rollback versions" section so `mt rollback <pkg>`
+    \\and `mt info <pkg>` agree on what's retrievable. The same listing
+    \\is exposed in `--json` as the `available_rollback_versions` array.
     \\
     \\Flags:
     \\  --formula      Show formula info only

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -13,6 +13,12 @@ const client_mod = @import("../net/client.zig");
 const formula_mod = @import("../core/formula.zig");
 const cask_mod = @import("../core/cask.zig");
 const help = @import("help.zig");
+const rollback = @import("rollback.zig");
+
+/// Empty history sentinel for encoder callers that don't have a DB /
+/// store handy (tests, the API-fallback path). Keeps the signature
+/// uniform without forcing every caller to allocate an empty slice.
+pub const no_history: []const rollback.Entry = &.{};
 
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(ctx, args, "info")) return;
@@ -64,8 +70,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     if (db_opt) |*db| {
         // Schema is idempotent; info's API fallback handles a broken DB gracefully.
         schema.initSchema(db) catch {};
-        if (!force_cask and try emitInstalledFormula(db, name, prefix, stdout, json_mode, colorize)) return;
-        if (!force_formula and try emitInstalledCask(db, name, stdout, json_mode, colorize)) return;
+        if (!force_cask and try emitInstalledFormula(ctx, allocator, db, name, prefix, stdout, json_mode, colorize)) return;
+        if (!force_formula and try emitInstalledCask(allocator, db, name, stdout, json_mode, colorize)) return;
     }
 
     // Not locally installed — fall back to Homebrew API metadata so
@@ -82,6 +88,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 /// true (caller stops). Returns false when the lookup misses so the
 /// caller can try the cask path.
 fn emitInstalledFormula(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
     db: *sqlite.Database,
     name: []const u8,
     prefix: []const u8,
@@ -90,7 +98,7 @@ fn emitInstalledFormula(
     colorize: bool,
 ) !bool {
     var stmt = db.prepare(
-        "SELECT name, version, tap, cellar_path, pinned, installed_at FROM kegs WHERE name = ?1 LIMIT 1;",
+        "SELECT name, version, tap, cellar_path, pinned, installed_at, revision FROM kegs WHERE name = ?1 LIMIT 1;",
     ) catch return false;
     defer stmt.finalize();
     stmt.bindText(1, name) catch return false;
@@ -98,16 +106,35 @@ fn emitInstalledFormula(
     const installed = stmt.step() catch false;
     if (!installed) return false;
 
+    const ver_ptr = stmt.columnText(1);
+    const ver_slice = if (ver_ptr) |v| std.mem.sliceTo(v, 0) else "unknown";
+    const revision = stmt.columnInt(6);
+
+    // The store walker keys on the on-disk pkg_version (`1.9.2_2`), not
+    // the bare upstream version — without the suffix a revision-bumped
+    // current keg would re-appear in its own rollback listing.
+    var pkgver_buf: [128]u8 = undefined;
+    const current_pkg_version = formula_mod.pkgVersion(&pkgver_buf, ver_slice, revision) catch ver_slice;
+
+    var history = rollback.collectEntries(ctx.io, allocator, prefix, name, current_pkg_version) catch |e| switch (e) {
+        // Missing store / OOM during the listing must not break the
+        // primary info dump — fall through with an empty history so
+        // the user still sees the installed-row fields.
+        rollback.CollectError.StoreUnreadable, rollback.CollectError.OutOfMemory => @as(std.ArrayList(rollback.Entry), .empty),
+    };
+    defer rollback.freeEntries(allocator, &history);
+
     if (json_mode) {
-        try writeJsonInfo(name, true, &stmt, stdout);
+        try writeJsonInfo(name, &stmt, history.items, stdout);
     } else {
-        try writeHumanInfo(name, true, &stmt, prefix, stdout, colorize);
+        try writeHumanInfo(name, &stmt, history.items, stdout, colorize);
     }
     return true;
 }
 
 /// Cask counterpart to `emitInstalledFormula`.
 fn emitInstalledCask(
+    allocator: std.mem.Allocator,
     db: *sqlite.Database,
     name: []const u8,
     stdout: *std.Io.Writer,
@@ -115,10 +142,19 @@ fn emitInstalledCask(
     colorize: bool,
 ) !bool {
     if (cask_mod.lookupInstalled(db, name) == null) return false;
+
+    const cur_ver_opt = rollback.currentCaskVersion(allocator, db, name);
+    defer if (cur_ver_opt) |v| allocator.free(v);
+
+    var history = rollback.collectCaskEntries(allocator, db, name, cur_ver_opt) catch |e| switch (e) {
+        rollback.CollectError.StoreUnreadable, rollback.CollectError.OutOfMemory => @as(std.ArrayList(rollback.Entry), .empty),
+    };
+    defer rollback.freeEntries(allocator, &history);
+
     if (json_mode) {
-        try writeJsonCaskInfo(db, name, stdout);
+        try writeJsonCaskInfo(db, name, history.items, stdout);
     } else {
-        try writeHumanCaskInfo(db, name, stdout, colorize);
+        try writeHumanCaskInfo(db, name, history.items, stdout, colorize);
     }
     return true;
 }
@@ -405,69 +441,115 @@ fn writeJsonNotInstalled(
 
 fn writeHumanInfo(
     name: []const u8,
-    installed: bool,
     stmt: *sqlite.Statement,
-    prefix: []const u8,
+    history: []const rollback.Entry,
     stdout: *std.Io.Writer,
     colorize: bool,
 ) !void {
-    var buf: [4096]u8 = undefined;
+    const ver = stmt.columnText(1);
+    const tap = stmt.columnText(2);
+    const cellar_path = stmt.columnText(3);
+    const pinned = stmt.columnBool(4);
+    const installed_at = stmt.columnText(5);
 
-    if (installed) {
-        // "Installed:" is the longest key (10 chars incl. colon), value at col 11.
-        const col: usize = 11;
-        const ver = stmt.columnText(1);
-        const tap = stmt.columnText(2);
-        const cellar_path = stmt.columnText(3);
-        const pinned = stmt.columnBool(4);
-        const installed_at = stmt.columnText(5);
+    const ver_slice = if (ver) |v| std.mem.sliceTo(v, 0) else "unknown";
+    const tap_slice = if (tap) |t| std.mem.sliceTo(t, 0) else "N/A";
+    const path_slice = if (cellar_path) |p| std.mem.sliceTo(p, 0) else "N/A";
+    const date_slice = if (installed_at) |d| std.mem.sliceTo(d, 0) else "N/A";
 
-        const ver_slice = if (ver) |v| std.mem.sliceTo(v, 0) else "unknown";
-        const tap_slice = if (tap) |t| std.mem.sliceTo(t, 0) else "N/A";
-        const path_slice = if (cellar_path) |p| std.mem.sliceTo(p, 0) else "N/A";
-        const date_slice = if (installed_at) |d| std.mem.sliceTo(d, 0) else "N/A";
-
-        try encodeHeader(stdout, colorize, name, "stable", ver_slice, "");
-        try output.writeField(stdout, &buf, colorize, col, "From", "{s}", .{tap_slice});
-        // Use the recorded cellar_path directly — it carries the
-        // correct `_<revision>` suffix for revisioned formulas.
-        _ = prefix;
-        try output.writeField(stdout, &buf, colorize, col, "Path", "{s}", .{path_slice});
-        if (pinned) try output.writeField(stdout, &buf, colorize, col, "Pinned", "yes", .{});
-        try output.writeField(stdout, &buf, colorize, col, "Installed", "{s}", .{date_slice});
-    } else {
-        try writeLine(stdout, &buf, "{s}: not installed\n", .{name});
-    }
+    var scratch: [4096]u8 = undefined;
+    try encodeInstalledFormulaHuman(
+        stdout,
+        &scratch,
+        name,
+        ver_slice,
+        tap_slice,
+        path_slice,
+        pinned,
+        date_slice,
+        history,
+        colorize,
+    );
 }
 
 fn writeJsonInfo(
     name: []const u8,
-    installed: bool,
     stmt: *sqlite.Statement,
+    history: []const rollback.Entry,
     stdout: *std.Io.Writer,
 ) !void {
-    try stdout.writeAll("{\"name\":");
-    try output.jsonStr(stdout, name);
-    try stdout.writeAll(",\"type\":\"formula\",\"installed\":");
-    try stdout.writeAll(if (installed) "true" else "false");
+    const ver = stmt.columnText(1);
+    const tap = stmt.columnText(2);
+    const pinned = stmt.columnBool(4);
+    const installed_at = stmt.columnText(5);
 
-    if (installed) {
-        const ver = stmt.columnText(1);
-        const tap = stmt.columnText(2);
-        const pinned = stmt.columnBool(4);
-        const installed_at = stmt.columnText(5);
+    try encodeInstalledFormulaJson(
+        stdout,
+        name,
+        if (ver) |v| std.mem.sliceTo(v, 0) else "",
+        if (tap) |t| std.mem.sliceTo(t, 0) else "",
+        pinned,
+        if (installed_at) |d| std.mem.sliceTo(d, 0) else "",
+        history,
+    );
+}
 
-        try stdout.writeAll(",\"version\":");
-        try output.jsonStr(stdout, if (ver) |v| std.mem.sliceTo(v, 0) else "");
-        try stdout.writeAll(",\"tap\":");
-        try output.jsonStr(stdout, if (tap) |t| std.mem.sliceTo(t, 0) else "");
-        try stdout.writeAll(",\"pinned\":");
-        try stdout.writeAll(if (pinned) "true" else "false");
-        try stdout.writeAll(",\"installed_at\":");
-        try output.jsonStr(stdout, if (installed_at) |d| std.mem.sliceTo(d, 0) else "");
+/// Installed-formula human encoder. Mirrors today's `mt info <formula>`
+/// field block byte-for-byte when `history` is empty so a fresh
+/// single-version install looks unchanged. When non-empty, appends a
+/// blank line + the same listing `mt rollback <pkg> --list` emits so
+/// users see one mental model across both commands.
+pub fn encodeInstalledFormulaHuman(
+    w: *std.Io.Writer,
+    scratch: []u8,
+    name: []const u8,
+    version: []const u8,
+    tap: []const u8,
+    cellar_path: []const u8,
+    pinned: bool,
+    installed_at: []const u8,
+    history: []const rollback.Entry,
+    colorize: bool,
+) !void {
+    // "Installed:" is the longest key (10 chars incl. colon), value at col 11.
+    const col: usize = 11;
+    try encodeHeader(w, colorize, name, "stable", version, "");
+    try output.writeField(w, scratch, colorize, col, "From", "{s}", .{tap});
+    try output.writeField(w, scratch, colorize, col, "Path", "{s}", .{cellar_path});
+    if (pinned) try output.writeField(w, scratch, colorize, col, "Pinned", "yes", .{});
+    try output.writeField(w, scratch, colorize, col, "Installed", "{s}", .{installed_at});
+    if (history.len != 0) {
+        try w.writeAll("\n");
+        try rollback.writeListHuman(w, name, history, colorize);
     }
+}
 
-    try stdout.writeAll("}\n");
+/// Installed-formula JSON encoder. Always emits
+/// `available_rollback_versions` (empty array when no retained store
+/// entries exist) so downstream consumers can branch on length without
+/// guarding for an absent key.
+pub fn encodeInstalledFormulaJson(
+    w: *std.Io.Writer,
+    name: []const u8,
+    version: []const u8,
+    tap: []const u8,
+    pinned: bool,
+    installed_at: []const u8,
+    history: []const rollback.Entry,
+) !void {
+    try w.writeAll("{\"name\":");
+    try output.jsonStr(w, name);
+    try w.writeAll(",\"type\":\"formula\",\"installed\":true,\"version\":");
+    try output.jsonStr(w, version);
+    try w.writeAll(",\"tap\":");
+    try output.jsonStr(w, tap);
+    try w.writeAll(",\"pinned\":");
+    try w.writeAll(if (pinned) "true" else "false");
+    try w.writeAll(",\"installed_at\":");
+    try output.jsonStr(w, installed_at);
+    try w.writeAll(",\"available_rollback_versions\":");
+    try rollback.writeEntriesJsonArray(w, history);
+    try w.writeAll("}\n");
 }
 
 /// One installed cask row as the info-render path consumes it. Slices
@@ -513,6 +595,7 @@ pub fn encodeInstalledCaskHuman(
     w: *std.Io.Writer,
     scratch: []u8,
     row: *const InstalledCaskRow,
+    history: []const rollback.Entry,
     colorize: bool,
 ) !void {
     // "Auto-updates:" is the longest key (13 chars incl. colon), value at col 14.
@@ -526,9 +609,17 @@ pub fn encodeInstalledCaskHuman(
     // Trailing position keeps the top of the dump stable for scripts that
     // grep the first N lines. Omitted for core-API casks (NULL tap).
     if (row.tap) |t| try output.writeField(w, scratch, colorize, col, "Tap", "{s}", .{t});
+    if (history.len != 0) {
+        try w.writeAll("\n");
+        try rollback.writeListHuman(w, row.token, history, colorize);
+    }
 }
 
-pub fn encodeInstalledCaskJson(w: *std.Io.Writer, row: *const InstalledCaskRow) !void {
+pub fn encodeInstalledCaskJson(
+    w: *std.Io.Writer,
+    row: *const InstalledCaskRow,
+    history: []const rollback.Entry,
+) !void {
     try w.writeAll("{\"name\":");
     try output.jsonStr(w, row.token);
     try w.writeAll(",\"type\":\"cask\",\"installed\":true,\"version\":");
@@ -547,12 +638,15 @@ pub fn encodeInstalledCaskJson(w: *std.Io.Writer, row: *const InstalledCaskRow) 
     // string when unattributed so consumers can branch on truthiness.
     try w.writeAll(",\"tap\":");
     try output.jsonStr(w, row.tap orelse "");
+    try w.writeAll(",\"available_rollback_versions\":");
+    try rollback.writeEntriesJsonArray(w, history);
     try w.writeAll("}\n");
 }
 
 fn writeHumanCaskInfo(
     db: *sqlite.Database,
     name: []const u8,
+    history: []const rollback.Entry,
     stdout: *std.Io.Writer,
     colorize: bool,
 ) !void {
@@ -565,12 +659,13 @@ fn writeHumanCaskInfo(
 
     const row = readInstalledCaskRow(&stmt, name);
     var buf: [4096]u8 = undefined;
-    try encodeInstalledCaskHuman(stdout, &buf, &row, colorize);
+    try encodeInstalledCaskHuman(stdout, &buf, &row, history, colorize);
 }
 
 fn writeJsonCaskInfo(
     db: *sqlite.Database,
     name: []const u8,
+    history: []const rollback.Entry,
     stdout: *std.Io.Writer,
 ) !void {
     var stmt = db.prepare(installed_cask_select) catch return;
@@ -581,5 +676,5 @@ fn writeJsonCaskInfo(
     if (!found) return;
 
     const row = readInstalledCaskRow(&stmt, name);
-    try encodeInstalledCaskJson(stdout, &row);
+    try encodeInstalledCaskJson(stdout, &row, history);
 }

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -620,7 +620,17 @@ fn formatIso8601(buf: []u8, mtime_ns: i128) ![]const u8 {
 pub fn writeListJson(w: *std.Io.Writer, name: []const u8, entries: []const Entry) !void {
     try w.writeAll("{\"name\":");
     try output.jsonStr(w, name);
-    try w.writeAll(",\"entries\":[");
+    try w.writeAll(",\"entries\":");
+    try writeEntriesJsonArray(w, entries);
+    try w.writeAll("}\n");
+}
+
+/// Just the `[{sha256,version,mtime}, ...]` array. Shared so `mt info`
+/// can splice the rollback-list shape into its installed-package JSON
+/// without rewriting the encoder — one source of truth for downstream
+/// consumers that already parse `mt rollback --list --json`.
+pub fn writeEntriesJsonArray(w: *std.Io.Writer, entries: []const Entry) !void {
+    try w.writeAll("[");
     for (entries, 0..) |e, i| {
         if (i != 0) try w.writeAll(",");
         try w.writeAll("{\"sha256\":");
@@ -633,7 +643,7 @@ pub fn writeListJson(w: *std.Io.Writer, name: []const u8, entries: []const Entry
         try w.writeAll(s);
         try w.writeAll("}");
     }
-    try w.writeAll("]}\n");
+    try w.writeAll("]");
 }
 
 const testing = std.testing;
@@ -743,6 +753,32 @@ test "writeListJson with no entries emits an empty array" {
 
     try writeListJson(&aw.writer, "wget", &.{});
     try testing.expectEqualStrings("{\"name\":\"wget\",\"entries\":[]}\n", aw.written());
+}
+
+test "writeEntriesJsonArray emits a bare array compatible with rollback-list entries[]" {
+    // The array is the splice point: `mt info` reuses it inside its own
+    // object so downstream consumers can parse one shape across both
+    // commands. Pinning the bytes here prevents drift between the
+    // splice site and `writeListJson`'s consumers.
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    const ns_per_s: i128 = std.time.ns_per_s;
+    const entries = [_]Entry{
+        .{ .sha256 = "aaa", .pkg_version = "1.24", .mtime_ns = 1_700_000_000 * ns_per_s },
+    };
+    try writeEntriesJsonArray(&aw.writer, &entries);
+    try testing.expectEqualStrings(
+        "[{\"sha256\":\"aaa\",\"version\":\"1.24\",\"mtime\":1700000000}]",
+        aw.written(),
+    );
+}
+
+test "writeEntriesJsonArray emits [] when empty" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try writeEntriesJsonArray(&aw.writer, &.{});
+    try testing.expectEqualStrings("[]", aw.written());
 }
 
 /// Seed a `<prefix>/store/<sha>/<name>/<pkg_version>/INSTALL_RECEIPT.json`

--- a/tests/info_cli_test.zig
+++ b/tests/info_cli_test.zig
@@ -372,3 +372,174 @@ test "execute --json on a NULL-tap cask still emits tap as an empty string" {
     const tap_val = parsed.value.object.get("tap") orelse return error.MissingTapKey;
     try testing.expectEqualStrings("", tap_val.string);
 }
+
+// --- retained rollback history under `mt info` -------------------------
+//
+// WHY end-to-end: the pure encoder tests cover the bytes, but only an
+// `execute` capture exercises the SQL SELECTs, the store walker, and
+// the skip_pkg_version wiring. Regressing those silently is the failure
+// mode that bit T-037 — pinning here keeps both halves honest.
+
+/// Seed `<prefix>/store/<sha>/<name>/<pkg_version>/INSTALL_RECEIPT.json`
+/// so `rollback.collectEntries` sees a real retained version for `name`.
+fn seedStoreVersion(prefix: []const u8, sha: []const u8, name: []const u8, pkg_version: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const dir = try std.fmt.bufPrint(&buf, "{s}/store/{s}/{s}/{s}", .{ prefix, sha, name, pkg_version });
+    try test_io.cwd().createDirPath(std.Options.debug_io, dir);
+
+    var f_buf: [600]u8 = undefined;
+    const file_path = try std.fmt.bufPrint(&f_buf, "{s}/INSTALL_RECEIPT.json", .{dir});
+    const f = try test_io.createFileAbsolute(std.Options.debug_io, file_path, .{ .truncate = true });
+    defer f.close(std.Options.debug_io);
+    try f.writeStreamingAll(std.Options.debug_io, "{}");
+}
+
+fn seedCaskVersionsHistory(prefix: []const u8) !void {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO cask_versions (token, version, url, sha256, installed_at)
+        \\VALUES ('flux-markdown', '1.30.0', 'https://x/a.dmg', 'aa', '2026-01-01T00:00:00'),
+        \\       ('flux-markdown', '1.31.0', 'https://x/b.dmg', 'bb', '2026-02-01T00:00:00');
+    );
+    try db.exec(
+        \\INSERT INTO casks (token, name, version, url, sha256, app_path)
+        \\VALUES ('flux-markdown', 'flux-markdown', '1.32.0', 'https://x/c.dmg', 'cc', '/Applications/Flux.app');
+    );
+}
+
+test "execute on a formula with retained store versions appends the rollback section" {
+    var s = try Scratch.init(testing.allocator, "fmla_hist_human");
+    defer s.deinit(testing.allocator);
+    try seedFormulaKeg(testing.allocator, s.path);
+    // Two prior versions in the store; current (1.21) excluded by the
+    // skip_pkg_version handoff so it doesn't appear in its own listing.
+    try seedStoreVersion(s.path, "sha_old", "wget", "1.19");
+    try seedStoreVersion(s.path, "sha_mid", "wget", "1.20");
+
+    const out = try captureExecute(testing.allocator, &.{"wget"}, "fmla_hist_human");
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "Available rollback versions for wget") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.19") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.20") != null);
+    // Current version must be filtered out of its own listing.
+    const section_idx = std.mem.indexOf(u8, out, "Available rollback versions").?;
+    try testing.expect(std.mem.indexOf(u8, out[section_idx..], "1.21") == null);
+}
+
+test "execute --json on a formula with retained store versions populates available_rollback_versions" {
+    var s = try Scratch.init(testing.allocator, "fmla_hist_json");
+    defer s.deinit(testing.allocator);
+    try seedFormulaKeg(testing.allocator, s.path);
+    try seedStoreVersion(s.path, "sha_old", "wget", "1.19");
+
+    const prior_mode: output.OutputMode = if (output.isJson()) .json else .human;
+    output.setMode(.json);
+    defer output.setMode(prior_mode);
+
+    const out = try captureExecute(testing.allocator, &.{"wget"}, "fmla_hist_json");
+    defer testing.allocator.free(out);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, out, .{});
+    defer parsed.deinit();
+
+    const arr = parsed.value.object.get("available_rollback_versions") orelse return error.MissingKey;
+    try testing.expectEqual(@as(usize, 1), arr.array.items.len);
+    try testing.expectEqualStrings("1.19", arr.array.items[0].object.get("version").?.string);
+}
+
+test "execute --json on a formula with no retained versions emits available_rollback_versions:[]" {
+    var s = try Scratch.init(testing.allocator, "fmla_empty_json");
+    defer s.deinit(testing.allocator);
+    try seedFormulaKeg(testing.allocator, s.path);
+
+    const prior_mode: output.OutputMode = if (output.isJson()) .json else .human;
+    output.setMode(.json);
+    defer output.setMode(prior_mode);
+
+    const out = try captureExecute(testing.allocator, &.{"wget"}, "fmla_empty_json");
+    defer testing.allocator.free(out);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, out, .{});
+    defer parsed.deinit();
+
+    const arr = parsed.value.object.get("available_rollback_versions") orelse return error.MissingKey;
+    try testing.expectEqual(@as(usize, 0), arr.array.items.len);
+}
+
+test "execute on a formula with no retained versions omits the section in human output" {
+    var s = try Scratch.init(testing.allocator, "fmla_empty_human");
+    defer s.deinit(testing.allocator);
+    try seedFormulaKeg(testing.allocator, s.path);
+
+    const out = try captureExecute(testing.allocator, &.{"wget"}, "fmla_empty_human");
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "Available rollback versions") == null);
+    // Existing field block stays byte-identical for the empty-history case.
+    try testing.expect(std.mem.indexOf(u8, out, "wget: stable 1.21\n") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "From:      homebrew/core\n") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Installed:") != null);
+}
+
+test "execute on a cask with retained cask_versions rows appends the rollback section" {
+    var s = try Scratch.init(testing.allocator, "cask_hist_human");
+    defer s.deinit(testing.allocator);
+    try seedCaskVersionsHistory(s.path);
+
+    const out = try captureExecute(testing.allocator, &.{"flux-markdown"}, "cask_hist_human");
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "Available rollback versions for flux-markdown") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.31.0") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.30.0") != null);
+    // Current cask version must not appear in its own rollback listing.
+    const section_idx = std.mem.indexOf(u8, out, "Available rollback versions").?;
+    try testing.expect(std.mem.indexOf(u8, out[section_idx..], "1.32.0") == null);
+}
+
+test "execute --json on a cask with history populates available_rollback_versions" {
+    var s = try Scratch.init(testing.allocator, "cask_hist_json");
+    defer s.deinit(testing.allocator);
+    try seedCaskVersionsHistory(s.path);
+
+    const prior_mode: output.OutputMode = if (output.isJson()) .json else .human;
+    output.setMode(.json);
+    defer output.setMode(prior_mode);
+
+    const out = try captureExecute(testing.allocator, &.{"flux-markdown"}, "cask_hist_json");
+    defer testing.allocator.free(out);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, out, .{});
+    defer parsed.deinit();
+
+    const arr = parsed.value.object.get("available_rollback_versions") orelse return error.MissingKey;
+    try testing.expectEqual(@as(usize, 2), arr.array.items.len);
+    // Newest-first ordering matches `mt rollback --list` exactly.
+    try testing.expectEqualStrings("1.31.0", arr.array.items[0].object.get("version").?.string);
+    try testing.expectEqualStrings("1.30.0", arr.array.items[1].object.get("version").?.string);
+}
+
+test "execute --json on a cask with no history emits available_rollback_versions:[]" {
+    var s = try Scratch.init(testing.allocator, "cask_empty_json");
+    defer s.deinit(testing.allocator);
+    try seedCaskRow(s.path);
+
+    const prior_mode: output.OutputMode = if (output.isJson()) .json else .human;
+    output.setMode(.json);
+    defer output.setMode(prior_mode);
+
+    const out = try captureExecute(testing.allocator, &.{"firefox"}, "cask_empty_json");
+    defer testing.allocator.free(out);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, out, .{});
+    defer parsed.deinit();
+
+    const arr = parsed.value.object.get("available_rollback_versions") orelse return error.MissingKey;
+    try testing.expectEqual(@as(usize, 0), arr.array.items.len);
+}

--- a/tests/info_test.zig
+++ b/tests/info_test.zig
@@ -72,6 +72,7 @@ test "encodeInstallHint collapses to a bare line in quiet mode" {
 
 const malt_formula = @import("malt").formula;
 const malt_cask = @import("malt").cask;
+const rollback = @import("malt").cli_rollback;
 
 const FORMULA_FIXTURE =
     \\{
@@ -205,7 +206,7 @@ test "encodeInstalledCaskHuman renders every populated field" {
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
     var scratch: [4096]u8 = undefined;
-    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, false);
+    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, info.no_history, false);
 
     const out = aw.written();
     try testing.expect(std.mem.indexOf(u8, out, "firefox: 120.0 (cask)\n") != null);
@@ -230,7 +231,7 @@ test "encodeInstalledCaskHuman omits Auto-updates when false and uses fallbacks 
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
     var scratch: [4096]u8 = undefined;
-    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, false);
+    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, info.no_history, false);
 
     const out = aw.written();
     try testing.expect(std.mem.indexOf(u8, out, "ghost: unknown (cask)\n") != null);
@@ -253,10 +254,10 @@ test "encodeInstalledCaskJson produces the documented shape" {
 
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
-    try info.encodeInstalledCaskJson(&aw.writer, &row);
+    try info.encodeInstalledCaskJson(&aw.writer, &row, info.no_history);
 
     try testing.expectEqualStrings(
-        "{\"name\":\"firefox\",\"type\":\"cask\",\"installed\":true,\"version\":\"120.0\",\"full_name\":\"Firefox\",\"url\":\"https://example.com/firefox.dmg\",\"app_path\":\"/Applications/Firefox.app\",\"auto_updates\":false,\"installed_at\":\"2026-05-13 10:40:56\",\"tap\":\"\"}\n",
+        "{\"name\":\"firefox\",\"type\":\"cask\",\"installed\":true,\"version\":\"120.0\",\"full_name\":\"Firefox\",\"url\":\"https://example.com/firefox.dmg\",\"app_path\":\"/Applications/Firefox.app\",\"auto_updates\":false,\"installed_at\":\"2026-05-13 10:40:56\",\"tap\":\"\",\"available_rollback_versions\":[]}\n",
         aw.written(),
     );
 }
@@ -270,10 +271,10 @@ test "encodeInstalledCaskJson emits empty strings for null fields" {
 
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
-    try info.encodeInstalledCaskJson(&aw.writer, &row);
+    try info.encodeInstalledCaskJson(&aw.writer, &row, info.no_history);
 
     try testing.expectEqualStrings(
-        "{\"name\":\"ghost\",\"type\":\"cask\",\"installed\":true,\"version\":\"\",\"full_name\":\"ghost\",\"url\":\"\",\"app_path\":\"\",\"auto_updates\":true,\"installed_at\":\"\",\"tap\":\"\"}\n",
+        "{\"name\":\"ghost\",\"type\":\"cask\",\"installed\":true,\"version\":\"\",\"full_name\":\"ghost\",\"url\":\"\",\"app_path\":\"\",\"auto_updates\":true,\"installed_at\":\"\",\"tap\":\"\",\"available_rollback_versions\":[]}\n",
         aw.written(),
     );
 }
@@ -290,7 +291,7 @@ test "encodeInstalledCaskHuman surfaces the owning tap when set" {
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
     var scratch: [4096]u8 = undefined;
-    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, false);
+    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, info.no_history, false);
 
     const out = aw.written();
     try testing.expect(std.mem.indexOf(u8, out, "Tap:          yuzeguitarist/deck") != null);
@@ -311,7 +312,7 @@ test "encodeInstalledCaskHuman omits the Tap line when null (core-API cask)" {
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
     var scratch: [4096]u8 = undefined;
-    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, false);
+    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, info.no_history, false);
 
     try testing.expect(std.mem.indexOf(u8, aw.written(), "Tap:") == null);
 }
@@ -326,9 +327,213 @@ test "encodeInstalledCaskJson includes tap as an empty string for null and the l
 
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
-    try info.encodeInstalledCaskJson(&aw.writer, &tapped);
+    try info.encodeInstalledCaskJson(&aw.writer, &tapped, info.no_history);
 
     try testing.expect(std.mem.indexOf(u8, aw.written(), "\"tap\":\"yuzeguitarist/deck\"") != null);
+}
+
+// --- rollback history surfaces ------------------------------------------
+//
+// `mt info` reuses `mt rollback <pkg> --list`'s listing so users see one
+// shape across both verbs. These tests pin: (a) empty history is invisible
+// in human output but stable as `[]` in JSON, (b) non-empty history emits
+// the `mt rollback --list` section under both formula and cask paths.
+
+const ns_per_s: i128 = std.time.ns_per_s;
+
+const two_entries = [_]rollback.Entry{
+    .{ .sha256 = "aaa111", .pkg_version = "1.24", .mtime_ns = 1_700_000_000 * ns_per_s },
+    .{ .sha256 = "bbb222", .pkg_version = "1.23", .mtime_ns = 1_699_000_000 * ns_per_s },
+};
+
+test "encodeInstalledFormulaHuman omits the rollback section when history is empty" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try info.encodeInstalledFormulaHuman(
+        &aw.writer,
+        &scratch,
+        "wget",
+        "1.24.5",
+        "homebrew/core",
+        "/opt/malt/Cellar/wget/1.24.5",
+        false,
+        "2026-05-13 10:40:56",
+        info.no_history,
+        false,
+    );
+    // Byte-identical to the pre-T-040 shape — adding history must not
+    // alter the dump for a fresh single-version install.
+    try testing.expectEqualStrings(
+        "wget: stable 1.24.5\n" ++
+            "From:      homebrew/core\n" ++
+            "Path:      /opt/malt/Cellar/wget/1.24.5\n" ++
+            "Installed: 2026-05-13 10:40:56\n",
+        aw.written(),
+    );
+}
+
+test "encodeInstalledFormulaHuman appends the rollback listing when history is non-empty" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try info.encodeInstalledFormulaHuman(
+        &aw.writer,
+        &scratch,
+        "wget",
+        "1.24.5",
+        "homebrew/core",
+        "/opt/malt/Cellar/wget/1.24.5",
+        false,
+        "2026-05-13 10:40:56",
+        &two_entries,
+        false,
+    );
+    const out = aw.written();
+    try testing.expect(std.mem.indexOf(u8, out, "Available rollback versions for wget") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.24") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.23") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "aaa111") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "bbb222") != null);
+    // Section sits below the field block so the top of the dump stays
+    // stable for greppers reading the first N lines.
+    const installed_idx = std.mem.indexOf(u8, out, "Installed:").?;
+    const section_idx = std.mem.indexOf(u8, out, "Available rollback versions").?;
+    try testing.expect(installed_idx < section_idx);
+}
+
+test "encodeInstalledFormulaJson emits available_rollback_versions:[] for an empty history" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try info.encodeInstalledFormulaJson(
+        &aw.writer,
+        "wget",
+        "1.24.5",
+        "homebrew/core",
+        false,
+        "2026-05-13 10:40:56",
+        info.no_history,
+    );
+    try testing.expectEqualStrings(
+        "{\"name\":\"wget\",\"type\":\"formula\",\"installed\":true,\"version\":\"1.24.5\"," ++
+            "\"tap\":\"homebrew/core\",\"pinned\":false,\"installed_at\":\"2026-05-13 10:40:56\"," ++
+            "\"available_rollback_versions\":[]}\n",
+        aw.written(),
+    );
+}
+
+test "encodeInstalledFormulaJson splices the same entries[] shape mt rollback --list emits" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try info.encodeInstalledFormulaJson(
+        &aw.writer,
+        "wget",
+        "1.24.5",
+        "homebrew/core",
+        true,
+        "2026-05-13 10:40:56",
+        &two_entries,
+    );
+    // Pinning the entries-array bytes here is the splice contract:
+    // downstream consumers already parse `mt rollback --list --json`'s
+    // `entries[]`, and the info payload must hand them the same shape.
+    try testing.expectEqualStrings(
+        "{\"name\":\"wget\",\"type\":\"formula\",\"installed\":true,\"version\":\"1.24.5\"," ++
+            "\"tap\":\"homebrew/core\",\"pinned\":true,\"installed_at\":\"2026-05-13 10:40:56\"," ++
+            "\"available_rollback_versions\":[" ++
+            "{\"sha256\":\"aaa111\",\"version\":\"1.24\",\"mtime\":1700000000}," ++
+            "{\"sha256\":\"bbb222\",\"version\":\"1.23\",\"mtime\":1699000000}" ++
+            "]}\n",
+        aw.written(),
+    );
+}
+
+test "encodeInstalledFormulaJson output parses as JSON with available_rollback_versions reachable" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try info.encodeInstalledFormulaJson(
+        &aw.writer,
+        "wget",
+        "1.24.5",
+        "homebrew/core",
+        false,
+        "2026-05-13 10:40:56",
+        &two_entries,
+    );
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+
+    const arr = parsed.value.object.get("available_rollback_versions") orelse return error.MissingKey;
+    try testing.expectEqual(@as(usize, 2), arr.array.items.len);
+    try testing.expectEqualStrings("1.24", arr.array.items[0].object.get("version").?.string);
+    try testing.expectEqualStrings("aaa111", arr.array.items[0].object.get("sha256").?.string);
+    try testing.expectEqual(@as(i64, 1_700_000_000), arr.array.items[0].object.get("mtime").?.integer);
+}
+
+test "encodeInstalledCaskHuman omits the rollback section when history is empty" {
+    const row: info.InstalledCaskRow = .{
+        .token = "firefox",
+        .name = "Firefox",
+        .version = "120.0",
+        .url = "https://example.com/firefox.dmg",
+        .app_path = "/Applications/Firefox.app",
+        .auto_updates = false,
+        .installed_at = "2026-05-13 10:40:56",
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, info.no_history, false);
+
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "Available rollback versions") == null);
+}
+
+test "encodeInstalledCaskHuman appends the rollback listing when history is non-empty" {
+    const row: info.InstalledCaskRow = .{
+        .token = "flux-markdown",
+        .name = "flux-markdown",
+        .version = "1.32.0",
+    };
+    const cask_history = [_]rollback.Entry{
+        .{ .sha256 = "aa", .pkg_version = "1.31.0", .mtime_ns = 1_700_000_000 * ns_per_s },
+        .{ .sha256 = "bb", .pkg_version = "1.30.0", .mtime_ns = 1_699_000_000 * ns_per_s },
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, &cask_history, false);
+
+    const out = aw.written();
+    try testing.expect(std.mem.indexOf(u8, out, "Available rollback versions for flux-markdown") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.31.0") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.30.0") != null);
+}
+
+test "encodeInstalledCaskJson splices history entries into the installed-cask object" {
+    const row: info.InstalledCaskRow = .{
+        .token = "flux-markdown",
+        .name = "flux-markdown",
+        .version = "1.32.0",
+        .auto_updates = false,
+        .installed_at = "2026-05-13 10:40:56",
+    };
+    const cask_history = [_]rollback.Entry{
+        .{ .sha256 = "aa", .pkg_version = "1.31.0", .mtime_ns = 1_700_000_000 * ns_per_s },
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try info.encodeInstalledCaskJson(&aw.writer, &row, &cask_history);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+
+    const arr = parsed.value.object.get("available_rollback_versions") orelse return error.MissingKey;
+    try testing.expectEqual(@as(usize, 1), arr.array.items.len);
+    try testing.expectEqualStrings("1.31.0", arr.array.items[0].object.get("version").?.string);
+    try testing.expectEqual(@as(i64, 1_700_000_000), arr.array.items[0].object.get("mtime").?.integer);
 }
 
 test "encodeInstalledCaskJson output parses as JSON with .tap reachable" {
@@ -346,7 +551,7 @@ test "encodeInstalledCaskJson output parses as JSON with .tap reachable" {
 
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
-    try info.encodeInstalledCaskJson(&aw.writer, &row);
+    try info.encodeInstalledCaskJson(&aw.writer, &row, info.no_history);
 
     const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
     defer parsed.deinit();


### PR DESCRIPTION
## Description

`mt info <package>` now surfaces the retained version history that `mt rollback <pkg> --list` already exposed. For formulas the multi-version malt store is walked (skipping the current pkg_version); for casks the `cask_versions` history table is read (skipping the current cask version). 

`--json` gains an `available_rollback_versions` array on the installed-formula and installed-cask branches, carrying the same `{sha256,version,mtime}` shape as `mt rollback --list --json`'s `entries[]`. 


## Related Issue

- None

## Notes for Reviewers

- None