### PR TITLE
feat(cli/search): add --installed and --api scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,10 +305,9 @@ mt list --json
 mt info wget                             # version, tap, cellar path, pinned status
 mt info --cask firefox
 
-mt search ripgrep                        # local first; API only on local miss
+mt search ripgrep                        # brew-parity: queries the Homebrew API
 mt search ripgrep --formula              # narrow
 mt search ripgrep --installed            # local DB only; no network
-mt search ripgrep --api                  # force the Homebrew API path
 mt search ripgrep --all                  # local + API, merged
 
 mt uses openssl@3                        # direct dependents
@@ -321,7 +320,7 @@ mt which jq                              # reverse lookup: bin -> keg-path
 
 `mt which` accepts a bare name (resolved through `{prefix}/bin/<name>`) or an absolute path to a malt-managed symlink. Output is `<name> <version> <keg-path>` (or `{"name", "version", "keg"}` with `--json`). It's read-only and offline; exits non-zero with a clear message when the binary is not owned by malt.
 
-`mt search` is local-first by default: a substring scan over `kegs.name` and `casks.token` runs first, and the Homebrew API fires only when nothing local matches. `--installed` pins the local path and never touches the network; `--api` forces the API; `--all` runs both passes and merges results, deduped. `--offline` (or `MALT_OFFLINE=1`) collapses every scope into `--installed`, so a plane-mode user gets an answer instead of a connect timeout. `--json`, `--formula`, and `--cask` compose with every scope.
+`mt search` matches `brew search` by default — it queries the Homebrew API and ranks substring matches across formulas and casks. `--installed` flips it to a local-DB scan over `kegs.name` and `casks.token` (no network), `--all` runs both passes and merges results deduped, and `--api` is the explicit form of the default. `--offline` (or `MALT_OFFLINE=1`) collapses every scope into `--installed`, so a plane-mode user gets an answer instead of a connect timeout. `--json`, `--formula`, and `--cask` compose with every scope.
 
 `mt deps` is the forward symmetric of `mt uses`: instead of "_who depends on X?_", it answers "_what does X depend on?_". Installed kegs read from the local DB; uninstalled formulas walk the upstream API. `--installed` restricts to kegs that resolve locally (offline-safe; the API path is skipped). `--json` emits `[{"formula":"…","depends_on":[…]}, …]` - one entry per visited node, so a recursive walk preserves the graph shape.
 

--- a/README.md
+++ b/README.md
@@ -305,8 +305,11 @@ mt list --json
 mt info wget                             # version, tap, cellar path, pinned status
 mt info --cask firefox
 
-mt search ripgrep                        # search formulas + casks
+mt search ripgrep                        # local first; API only on local miss
 mt search ripgrep --formula              # narrow
+mt search ripgrep --installed            # local DB only; no network
+mt search ripgrep --api                  # force the Homebrew API path
+mt search ripgrep --all                  # local + API, merged
 
 mt uses openssl@3                        # direct dependents
 mt uses --recursive openssl@3            # full transitive closure
@@ -317,6 +320,8 @@ mt which jq                              # reverse lookup: bin -> keg-path
 ```
 
 `mt which` accepts a bare name (resolved through `{prefix}/bin/<name>`) or an absolute path to a malt-managed symlink. Output is `<name> <version> <keg-path>` (or `{"name", "version", "keg"}` with `--json`). It's read-only and offline; exits non-zero with a clear message when the binary is not owned by malt.
+
+`mt search` is local-first by default: a substring scan over `kegs.name` and `casks.token` runs first, and the Homebrew API fires only when nothing local matches. `--installed` pins the local path and never touches the network; `--api` forces the API; `--all` runs both passes and merges results, deduped. `--offline` (or `MALT_OFFLINE=1`) collapses every scope into `--installed`, so a plane-mode user gets an answer instead of a connect timeout. `--json`, `--formula`, and `--cask` compose with every scope.
 
 `mt deps` is the forward symmetric of `mt uses`: instead of "_who depends on X?_", it answers "_what does X depend on?_". Installed kegs read from the local DB; uninstalled formulas walk the upstream API. `--installed` restricts to kegs that resolve locally (offline-safe; the API path is skipped). `--json` emits `[{"formula":"…","depends_on":[…]}, …]` - one entry per visited node, so a recursive walk preserves the graph shape.
 
@@ -497,6 +502,7 @@ MALT_ALLOW_UNVERIFIED=1 mt version update --no-verify
 | `HOMEBREW_GITHUB_API_TOKEN`     | GitHub token for higher API rate limits                                           | unset            |
 | `MALT_GITHUB_TOKEN`             | GitHub token sent as `Authorization: Bearer` on tap `/commits/HEAD` calls only    | unset            |
 | `MALT_HTTP_IDLE_TIMEOUT_SECS`   | HTTP idle (no-progress) read timeout in seconds (clamped to `[5, 600]`)           | `30`             |
+| `MALT_OFFLINE`                  | Set to `1`/`true` to force `mt search` to the local DB (mirrors `--offline`)      | unset            |
 | `MALT_MIGRATE_PARALLEL_WORKERS` | Worker count for `mt migrate --parallel` (clamped to `[1, 32]`)                   | `4`              |
 | `MALT_OUTDATED_MAX_AGE`         | TTL in hours for the `outdated.json` snapshot                                     | `24`             |
 | `MALT_ALLOW_RAW_POST_INSTALL`   | Disable terminal escape filter on ruby `post_install` output                      | unset            |

--- a/scripts/smokes/smoke_search.sh
+++ b/scripts/smokes/smoke_search.sh
@@ -2,10 +2,11 @@
 # Smoke test for `malt search`.
 #
 # Verifies the substring-search command returns brew-parity results for
-# a known-populated query ("go"), that the exact match is present, and
-# that --json / nonexistent-query paths behave. Hits the live Homebrew
-# API, so it requires network; safe to run locally (no install side
-# effects).
+# a known-populated query ("go"), that the exact match is present, that
+# --json / nonexistent-query paths behave, and that the new --installed
+# / --api / default-fall-through scopes wire through cleanly. Hits the
+# live Homebrew API for the --api path; safe to run locally (no install
+# side effects).
 #
 # Usage: scripts/smokes/smoke_search.sh
 # Requirements: built `malt` binary in zig-out/bin or $MALT_BIN.
@@ -19,8 +20,8 @@ BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
   exit 2
 }
 
-# Minimum result count for `go` — brew returns >300; we set the floor
-# well below that so the test isn't fragile to daily index drift.
+# Minimum result count for `go` over the API — brew returns >300; the
+# floor sits well below that so daily index drift can't flake the run.
 MIN_HITS=100
 
 pass() { printf '  ✓ %s\n' "$*"; }
@@ -29,8 +30,11 @@ fail() {
   exit 1
 }
 
-printf '▸ human output: mt search go\n'
-out=$("$BIN" search go)
+# Default scope tries local first; pin the API scope explicitly so the
+# live-API expectations stay deterministic regardless of what's installed
+# in the user's malt prefix.
+printf '▸ human output: mt search --api go\n'
+out=$("$BIN" search --api go)
 hits=$(printf '%s\n' "$out" | wc -l | tr -d ' ')
 ((hits >= MIN_HITS)) || fail "expected ≥$MIN_HITS rows, got $hits"
 pass "$hits rows returned"
@@ -43,16 +47,32 @@ printf '%s\n' "$out" | grep -q '(cask)$' ||
   fail "no cask results — expected at least one"
 pass "cask results present"
 
-printf '\n▸ json output: mt --json search wget\n'
-json=$("$BIN" --json search wget)
+printf '\n▸ json output: mt --json search --api wget\n'
+json=$("$BIN" --json search --api wget)
 printf '%s\n' "$json" | grep -q '"formulae":\[{"name":"wget"}' ||
   fail "JSON missing wget formula entry"
 pass "JSON shape ok ($json)"
 
-printf '\n▸ empty result: mt search xyz-no-such-pkg-abc-123\n'
-miss=$("$BIN" search xyz-no-such-pkg-abc-123 2>&1 || true)
+printf '\n▸ empty result: mt search --api xyz-no-such-pkg-abc-123\n'
+miss=$("$BIN" search --api xyz-no-such-pkg-abc-123 2>&1 || true)
 printf '%s\n' "$miss" | grep -q 'No results found' ||
   fail "missing 'No results found' line for empty query"
 pass "empty-query message shown"
+
+# --installed is offline by contract; a query for an unlikely-to-be-installed
+# name must exit cleanly with "No results found" without making any network
+# request.
+printf '\n▸ installed scope: mt search --installed zzz-no-such-keg\n'
+inst=$("$BIN" search --installed zzz-no-such-keg 2>&1 || true)
+printf '%s\n' "$inst" | grep -q 'No results found' ||
+  fail "--installed missing 'No results found' line"
+pass "--installed empty-query message shown"
+
+# MALT_OFFLINE mirrors --installed; identical behaviour on a clean miss.
+printf '\n▸ offline env: MALT_OFFLINE=1 mt search zzz-no-such-keg\n'
+off=$(MALT_OFFLINE=1 "$BIN" search zzz-no-such-keg 2>&1 || true)
+printf '%s\n' "$off" | grep -q 'No results found' ||
+  fail "MALT_OFFLINE=1 missing 'No results found' line"
+pass "MALT_OFFLINE=1 empty-query message shown"
 
 printf '\n✓ all smoke checks passed\n'

--- a/scripts/smokes/smoke_search.sh
+++ b/scripts/smokes/smoke_search.sh
@@ -2,11 +2,11 @@
 # Smoke test for `malt search`.
 #
 # Verifies the substring-search command returns brew-parity results for
-# a known-populated query ("go"), that the exact match is present, that
-# --json / nonexistent-query paths behave, and that the new --installed
-# / --api / default-fall-through scopes wire through cleanly. Hits the
-# live Homebrew API for the --api path; safe to run locally (no install
-# side effects).
+# a known-populated query ("go"), that the exact match is present, and
+# that --json / nonexistent-query paths behave. Also covers the new
+# --installed and MALT_OFFLINE scopes, which never touch the network.
+# Hits the live Homebrew API for the default path; safe to run locally
+# (no install side effects).
 #
 # Usage: scripts/smokes/smoke_search.sh
 # Requirements: built `malt` binary in zig-out/bin or $MALT_BIN.
@@ -20,8 +20,8 @@ BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
   exit 2
 }
 
-# Minimum result count for `go` over the API — brew returns >300; the
-# floor sits well below that so daily index drift can't flake the run.
+# Minimum result count for `go` — brew returns >300; we set the floor
+# well below that so the test isn't fragile to daily index drift.
 MIN_HITS=100
 
 pass() { printf '  ✓ %s\n' "$*"; }
@@ -30,11 +30,8 @@ fail() {
   exit 1
 }
 
-# Default scope tries local first; pin the API scope explicitly so the
-# live-API expectations stay deterministic regardless of what's installed
-# in the user's malt prefix.
-printf '▸ human output: mt search --api go\n'
-out=$("$BIN" search --api go)
+printf '▸ human output: mt search go\n'
+out=$("$BIN" search go)
 hits=$(printf '%s\n' "$out" | wc -l | tr -d ' ')
 ((hits >= MIN_HITS)) || fail "expected ≥$MIN_HITS rows, got $hits"
 pass "$hits rows returned"
@@ -47,14 +44,14 @@ printf '%s\n' "$out" | grep -q '(cask)$' ||
   fail "no cask results — expected at least one"
 pass "cask results present"
 
-printf '\n▸ json output: mt --json search --api wget\n'
-json=$("$BIN" --json search --api wget)
+printf '\n▸ json output: mt --json search wget\n'
+json=$("$BIN" --json search wget)
 printf '%s\n' "$json" | grep -q '"formulae":\[{"name":"wget"}' ||
   fail "JSON missing wget formula entry"
 pass "JSON shape ok ($json)"
 
-printf '\n▸ empty result: mt search --api xyz-no-such-pkg-abc-123\n'
-miss=$("$BIN" search --api xyz-no-such-pkg-abc-123 2>&1 || true)
+printf '\n▸ empty result: mt search xyz-no-such-pkg-abc-123\n'
+miss=$("$BIN" search xyz-no-such-pkg-abc-123 2>&1 || true)
 printf '%s\n' "$miss" | grep -q 'No results found' ||
   fail "missing 'No results found' line for empty query"
 pass "empty-query message shown"

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -147,7 +147,7 @@ pub const bash_script =
     \\        update)           cmd_flags="--check --quiet -q" ;;
     \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --tap --json --quiet -q" ;;
     \\        info)             cmd_flags="--formula --cask --json" ;;
-    \\        search)           cmd_flags="--formula --cask --json" ;;
+    \\        search)           cmd_flags="--formula --cask --json --installed --api --all --offline" ;;
     \\        uses)             cmd_flags="--recursive -r --json --quiet -q" ;;
     \\        deps)             cmd_flags="--recursive -r --installed --json --quiet -q" ;;
     \\        which)            cmd_flags="--json" ;;
@@ -320,6 +320,10 @@ pub const zsh_script =
     \\                    _arguments \
     \\                        '--formula[Search formulas only]' \
     \\                        '--cask[Search casks only]' \
+    \\                        '--installed[Local DB only, no network]' \
+    \\                        '--api[Force Homebrew API path]' \
+    \\                        '--all[Run local + API and merge results]' \
+    \\                        '--offline[Alias of --installed (mirrors MALT_OFFLINE)]' \
     \\                        '--json[Output as JSON]' \
     \\                        '*::query:'
     \\                    ;;
@@ -549,9 +553,13 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command info' -l json    -d 'JSON output'
     \\
     \\    # search
-    \\    complete -c $__malt_bin -n '__malt_using_command search' -l formula -d 'Formulas only'
-    \\    complete -c $__malt_bin -n '__malt_using_command search' -l cask    -d 'Casks only'
-    \\    complete -c $__malt_bin -n '__malt_using_command search' -l json    -d 'JSON output'
+    \\    complete -c $__malt_bin -n '__malt_using_command search' -l formula   -d 'Formulas only'
+    \\    complete -c $__malt_bin -n '__malt_using_command search' -l cask      -d 'Casks only'
+    \\    complete -c $__malt_bin -n '__malt_using_command search' -l installed -d 'Local DB only, no network'
+    \\    complete -c $__malt_bin -n '__malt_using_command search' -l api       -d 'Force Homebrew API path'
+    \\    complete -c $__malt_bin -n '__malt_using_command search' -l all       -d 'Run local + API and merge'
+    \\    complete -c $__malt_bin -n '__malt_using_command search' -l offline   -d 'Alias of --installed'
+    \\    complete -c $__malt_bin -n '__malt_using_command search' -l json      -d 'JSON output'
     \\
     \\    # uses
     \\    complete -c $__malt_bin -n '__malt_using_command uses' -l recursive -s r -d 'Include transitive dependents'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -180,9 +180,20 @@ const search_help =
     \\
     \\Search formulas and casks by name.
     \\
-    \\Flags:
+    \\Default scope: try the local DB first, fall through to the Homebrew API
+    \\only when nothing local matches. Use the flags below to pin the scope.
+    \\
+    \\Scope:
+    \\  --installed    Query kegs.name + casks.token only. No network.
+    \\  --api          Force the Homebrew API path (today's behaviour, explicit).
+    \\  --all          Run both passes and merge results, deduped + sorted.
+    \\  --offline      Alias of --installed (mirrors MALT_OFFLINE=1).
+    \\
+    \\Kind filter:
     \\  --formula      Search formulas only
     \\  --cask         Search casks only
+    \\
+    \\Output:
     \\  --json         Output as JSON
     \\
 ;

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -180,12 +180,12 @@ const search_help =
     \\
     \\Search formulas and casks by name.
     \\
-    \\Default scope: try the local DB first, fall through to the Homebrew API
-    \\only when nothing local matches. Use the flags below to pin the scope.
+    \\Default scope: query the Homebrew API (same as `brew search`). Use
+    \\--installed when you only want to know what's already on disk.
     \\
     \\Scope:
     \\  --installed    Query kegs.name + casks.token only. No network.
-    \\  --api          Force the Homebrew API path (today's behaviour, explicit).
+    \\  --api          Explicit form of the default (Homebrew API).
     \\  --all          Run both passes and merge results, deduped + sorted.
     \\  --offline      Alias of --installed (mirrors MALT_OFFLINE=1).
     \\

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -15,21 +15,25 @@ const help = @import("help.zig");
 /// fall-through to the API; explicit flags pin the choice.
 pub const Scope = enum { default, installed, api, all };
 
-/// Does this scope ever consult the local DB?
+/// Does this scope ever consult the local DB? Default stays brew-parity
+/// (API-only) so `mt search` doesn't silently diverge for users coming
+/// from `brew search`; `--installed` / `--all` / `--offline` are the
+/// explicit opt-ins into the local path.
 pub fn shouldRunLocal(scope: Scope) bool {
     return switch (scope) {
-        .default, .installed, .all => true,
-        .api => false,
+        .installed, .all => true,
+        .default, .api => false,
     };
 }
 
-/// Should the API path run? `.default` only falls through when local
-/// produced nothing — short-circuit behaviour is the point.
+/// Should the API path run? `.installed` is the only scope that bypasses
+/// it entirely; everything else (including `.default`, which mirrors
+/// `brew search`) reaches for the index.
 pub fn shouldRunApi(scope: Scope, has_local_hit: bool) bool {
+    _ = has_local_hit;
     return switch (scope) {
-        .api, .all => true,
+        .default, .api, .all => true,
         .installed => false,
-        .default => !has_local_hit,
     };
 }
 
@@ -131,9 +135,9 @@ test "parseScope: ignores non-scope flags and positional args" {
     try testing.expectEqual(Scope.installed, parseScope(&.{ "--formula", "--json", "--installed", "wget" }));
 }
 
-test "shouldRunApi: default falls through only on local miss" {
+test "shouldRunApi: default mirrors brew search and hits the API" {
     try testing.expect(shouldRunApi(.default, false));
-    try testing.expect(!shouldRunApi(.default, true));
+    try testing.expect(shouldRunApi(.default, true));
 }
 
 test "shouldRunApi: installed never hits API" {
@@ -148,9 +152,9 @@ test "shouldRunApi: api and all always hit API" {
     try testing.expect(shouldRunApi(.all, false));
 }
 
-test "shouldRunLocal: api never reads local DB" {
+test "shouldRunLocal: default and api skip the local DB" {
+    try testing.expect(!shouldRunLocal(.default));
     try testing.expect(!shouldRunLocal(.api));
-    try testing.expect(shouldRunLocal(.default));
     try testing.expect(shouldRunLocal(.installed));
     try testing.expect(shouldRunLocal(.all));
 }

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -8,7 +8,339 @@ const output = @import("../ui/output.zig");
 const color = @import("../ui/color.zig");
 const api_mod = @import("../net/api.zig");
 const client_mod = @import("../net/client.zig");
+const sqlite = @import("../db/sqlite.zig");
 const help = @import("help.zig");
+
+/// Where a `mt search` query should look. Default is local-first with a
+/// fall-through to the API; explicit flags pin the choice.
+pub const Scope = enum { default, installed, api, all };
+
+/// Does this scope ever consult the local DB?
+pub fn shouldRunLocal(scope: Scope) bool {
+    return switch (scope) {
+        .default, .installed, .all => true,
+        .api => false,
+    };
+}
+
+/// Should the API path run? `.default` only falls through when local
+/// produced nothing — short-circuit behaviour is the point.
+pub fn shouldRunApi(scope: Scope, has_local_hit: bool) bool {
+    return switch (scope) {
+        .api, .all => true,
+        .installed => false,
+        .default => !has_local_hit,
+    };
+}
+
+/// Recognise `--installed`, `--api`, `--all` anywhere in `args`. `--all`
+/// (or both `--installed` and `--api`) collapses to `.all`; absence of all
+/// three returns `.default`. Other flags and positional args are ignored.
+pub fn parseScope(args: []const []const u8) Scope {
+    var saw_installed = false;
+    var saw_api = false;
+    var saw_all = false;
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--installed")) {
+            saw_installed = true;
+        } else if (std.mem.eql(u8, arg, "--api")) {
+            saw_api = true;
+        } else if (std.mem.eql(u8, arg, "--all")) {
+            saw_all = true;
+        }
+    }
+    if (saw_all or (saw_installed and saw_api)) return .all;
+    if (saw_installed) return .installed;
+    if (saw_api) return .api;
+    return .default;
+}
+
+/// Substring scan over `kegs.name` (`.formula`) or `casks.token` (`.cask`).
+/// Returns caller-owned name slices, each individually allocated; the
+/// outer slice is also caller-owned. Sorted by `name`/`token` ASC. The
+/// match is case-insensitive on ASCII and runs in Zig so the SQL stays
+/// wildcard-free — `LIKE` would force escaping of `_` / `%` characters
+/// that `validateName` already permits in formula names.
+pub fn searchLocalKind(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    kind: api_mod.BrewApi.Kind,
+    query: []const u8,
+) ![][]const u8 {
+    var out: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (out.items) |s| allocator.free(s);
+        out.deinit(allocator);
+    }
+
+    // Same 128-byte ceiling as `api.findNameMatches` so the two paths
+    // reject the same pathological inputs.
+    var qbuf: [128]u8 = undefined;
+    if (query.len == 0 or query.len > qbuf.len) return out.toOwnedSlice(allocator);
+    const qlower = std.ascii.lowerString(qbuf[0..query.len], query);
+
+    const sql: []const u8 = switch (kind) {
+        // DISTINCT collapses the per-version `UNIQUE(name, version)` rows
+        // back to one entry per package.
+        .formula => "SELECT DISTINCT name FROM kegs ORDER BY name;",
+        .cask => "SELECT token FROM casks ORDER BY token;",
+    };
+
+    var stmt = try db.prepare(sql);
+    defer stmt.finalize();
+
+    while (try stmt.step()) {
+        const name_z = stmt.columnText(0) orelse continue;
+        const name = std.mem.sliceTo(name_z, 0);
+        // Names in `kegs`/`casks` are lowercase by Homebrew convention,
+        // same assumption `api.findNameMatches` makes about the API
+        // index. The single case-fold above is enough.
+        if (std.mem.indexOf(u8, name, qlower) == null) continue;
+        const owned = try allocator.dupe(u8, name);
+        errdefer allocator.free(owned);
+        try out.append(allocator, owned);
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
+const testing = std.testing;
+const schema = @import("../db/schema.zig");
+
+test "parseScope: no scope flags returns default" {
+    try testing.expectEqual(Scope.default, parseScope(&.{"wget"}));
+}
+
+test "parseScope: --installed maps to installed" {
+    try testing.expectEqual(Scope.installed, parseScope(&.{ "--installed", "wget" }));
+}
+
+test "parseScope: --api maps to api" {
+    try testing.expectEqual(Scope.api, parseScope(&.{ "--api", "wget" }));
+}
+
+test "parseScope: --all maps to all" {
+    try testing.expectEqual(Scope.all, parseScope(&.{ "--all", "wget" }));
+}
+
+test "parseScope: --installed + --api collapses to all" {
+    try testing.expectEqual(Scope.all, parseScope(&.{ "--installed", "--api", "wget" }));
+}
+
+test "parseScope: ignores non-scope flags and positional args" {
+    try testing.expectEqual(Scope.installed, parseScope(&.{ "--formula", "--json", "--installed", "wget" }));
+}
+
+test "shouldRunApi: default falls through only on local miss" {
+    try testing.expect(shouldRunApi(.default, false));
+    try testing.expect(!shouldRunApi(.default, true));
+}
+
+test "shouldRunApi: installed never hits API" {
+    try testing.expect(!shouldRunApi(.installed, false));
+    try testing.expect(!shouldRunApi(.installed, true));
+}
+
+test "shouldRunApi: api and all always hit API" {
+    try testing.expect(shouldRunApi(.api, true));
+    try testing.expect(shouldRunApi(.api, false));
+    try testing.expect(shouldRunApi(.all, true));
+    try testing.expect(shouldRunApi(.all, false));
+}
+
+test "shouldRunLocal: api never reads local DB" {
+    try testing.expect(!shouldRunLocal(.api));
+    try testing.expect(shouldRunLocal(.default));
+    try testing.expect(shouldRunLocal(.installed));
+    try testing.expect(shouldRunLocal(.all));
+}
+
+fn freeMatches(matches: []const []const u8) void {
+    for (matches) |m| testing.allocator.free(m);
+    testing.allocator.free(matches);
+}
+
+fn seedKegsAndCasks(db: *sqlite.Database) !void {
+    try db.exec(
+        \\INSERT INTO kegs(name, full_name, version, store_sha256, cellar_path)
+        \\VALUES
+        \\  ('wget', 'wget', '1.21', 'aaa', '/x/wget/1.21'),
+        \\  ('wgetpaste', 'wgetpaste', '2.31', 'bbb', '/x/wgetpaste/2.31'),
+        \\  ('jq', 'jq', '1.7', 'ccc', '/x/jq/1.7');
+    );
+    try db.exec(
+        \\INSERT INTO casks(token, name, version, url)
+        \\VALUES
+        \\  ('firefox', 'Firefox', '120.0', 'https://x'),
+        \\  ('firefox-developer-edition', 'Firefox DE', '121.0b', 'https://x'),
+        \\  ('brave', 'Brave', '1.0', 'https://x');
+    );
+}
+
+test "searchLocalKind on kegs returns substring hits sorted" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try seedKegsAndCasks(&db);
+
+    const hits = try searchLocalKind(testing.allocator, &db, .formula, "wget");
+    defer freeMatches(hits);
+
+    try testing.expectEqual(@as(usize, 2), hits.len);
+    try testing.expectEqualStrings("wget", hits[0]);
+    try testing.expectEqualStrings("wgetpaste", hits[1]);
+}
+
+test "searchLocalKind on casks matches token substrings" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try seedKegsAndCasks(&db);
+
+    const hits = try searchLocalKind(testing.allocator, &db, .cask, "firefox");
+    defer freeMatches(hits);
+
+    try testing.expectEqual(@as(usize, 2), hits.len);
+    try testing.expectEqualStrings("firefox", hits[0]);
+    try testing.expectEqualStrings("firefox-developer-edition", hits[1]);
+}
+
+test "searchLocalKind is case-insensitive on the query" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try seedKegsAndCasks(&db);
+
+    const hits = try searchLocalKind(testing.allocator, &db, .formula, "JQ");
+    defer freeMatches(hits);
+
+    try testing.expectEqual(@as(usize, 1), hits.len);
+    try testing.expectEqualStrings("jq", hits[0]);
+}
+
+test "searchLocalKind returns empty slice for no hits" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try seedKegsAndCasks(&db);
+
+    const hits = try searchLocalKind(testing.allocator, &db, .formula, "python");
+    defer freeMatches(hits);
+
+    try testing.expectEqual(@as(usize, 0), hits.len);
+}
+
+test "searchLocalKind tolerates an empty query without scanning" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try seedKegsAndCasks(&db);
+
+    const hits = try searchLocalKind(testing.allocator, &db, .formula, "");
+    defer freeMatches(hits);
+
+    try testing.expectEqual(@as(usize, 0), hits.len);
+}
+
+test "runKindLocal flags exact when the query matches a row verbatim" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try seedKegsAndCasks(&db);
+
+    const r = try runKindLocal(testing.allocator, &db, .formula, "jq");
+    defer freeMatches(r.matches);
+
+    try testing.expect(r.exact);
+    try testing.expectEqual(@as(usize, 1), r.matches.len);
+    try testing.expectEqualStrings("jq", r.matches[0]);
+}
+
+test "runKindLocal leaves exact false on a substring-only hit" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try seedKegsAndCasks(&db);
+
+    // "get" is a substring of "wget" and "wgetpaste" but not a row.
+    const r = try runKindLocal(testing.allocator, &db, .formula, "get");
+    defer freeMatches(r.matches);
+
+    try testing.expect(!r.exact);
+    try testing.expectEqual(@as(usize, 2), r.matches.len);
+}
+
+test "mergeResults dedupes overlapping names and sorts the union" {
+    const arena_alloc = testing.allocator;
+    const local_names = try arena_alloc.alloc([]const u8, 2);
+    defer arena_alloc.free(local_names);
+    local_names[0] = "wget";
+    local_names[1] = "jq";
+
+    const api_names = try arena_alloc.alloc([]const u8, 3);
+    defer arena_alloc.free(api_names);
+    api_names[0] = "wget"; // duplicate of local
+    api_names[1] = "wget2"; // API-only
+    api_names[2] = "wgetpaste"; // API-only
+
+    const merged = try mergeResults(
+        arena_alloc,
+        .{ .exact = true, .matches = local_names },
+        .{ .exact = false, .matches = api_names },
+    );
+    defer arena_alloc.free(merged.matches);
+
+    try testing.expect(merged.exact); // OR of inputs
+    try testing.expectEqual(@as(usize, 4), merged.matches.len);
+    try testing.expectEqualStrings("jq", merged.matches[0]);
+    try testing.expectEqualStrings("wget", merged.matches[1]);
+    try testing.expectEqualStrings("wget2", merged.matches[2]);
+    try testing.expectEqualStrings("wgetpaste", merged.matches[3]);
+}
+
+test "mergeResults with empty local degenerates to sorted API" {
+    const arena_alloc = testing.allocator;
+    const api_names = try arena_alloc.alloc([]const u8, 2);
+    defer arena_alloc.free(api_names);
+    api_names[0] = "wget2";
+    api_names[1] = "wget";
+
+    const merged = try mergeResults(
+        arena_alloc,
+        .{ .exact = false, .matches = &.{} },
+        .{ .exact = true, .matches = api_names },
+    );
+    defer arena_alloc.free(merged.matches);
+
+    try testing.expect(merged.exact);
+    try testing.expectEqual(@as(usize, 2), merged.matches.len);
+    try testing.expectEqualStrings("wget", merged.matches[0]);
+    try testing.expectEqualStrings("wget2", merged.matches[1]);
+}
+
+test "isOfflineRequested honours --offline" {
+    const ctx: AppCtx = .{ .io = std.Options.debug_io, .environ = .empty };
+    try testing.expect(isOfflineRequested(&ctx, &.{ "--offline", "wget" }));
+    try testing.expect(!isOfflineRequested(&ctx, &.{ "--api", "wget" }));
+}
+
+test "isOfflineRequested reads MALT_OFFLINE truthy values" {
+    inline for (.{ "MALT_OFFLINE=1", "MALT_OFFLINE=true", "MALT_OFFLINE=TRUE", "MALT_OFFLINE=True" }) |kv| {
+        const entries = [_:null]?[*:0]const u8{kv.ptr};
+        const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+        const ctx: AppCtx = .{ .io = std.Options.debug_io, .environ = env };
+        try testing.expect(isOfflineRequested(&ctx, &.{"wget"}));
+    }
+}
+
+test "isOfflineRequested rejects MALT_OFFLINE falsy values" {
+    inline for (.{ "MALT_OFFLINE=0", "MALT_OFFLINE=", "MALT_OFFLINE=no", "MALT_OFFLINE=false" }) |kv| {
+        const entries = [_:null]?[*:0]const u8{kv.ptr};
+        const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+        const ctx: AppCtx = .{ .io = std.Options.debug_io, .environ = env };
+        try testing.expect(!isOfflineRequested(&ctx, &.{"wget"}));
+    }
+}
 
 /// Results for a single kind (formula or cask) of a search query.
 ///
@@ -24,7 +356,7 @@ const KindResults = struct {
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(ctx, args, "search")) return;
 
-    // Parse flags and positional args
+    // Parse non-scope flags and the (single) positional query.
     var search_formula = false;
     var search_cask = false;
     var query: ?[]const u8 = null;
@@ -44,67 +376,90 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         return error.Aborted;
     };
 
-    // If neither specified, search both
     if (!search_formula and !search_cask) {
         search_formula = true;
         search_cask = true;
     }
 
-    // --json is consumed by the global arg parser; check output module
+    // T-029 slice for `search`: offline mode degrades to local-only so
+    // a plane-mode user gets an answer instead of a connect timeout.
+    var scope = parseScope(args);
+    if (isOfflineRequested(ctx, args)) scope = .installed;
+
     const json_mode = output.isJson();
 
-    const cache_dir = atomic.maltCacheDir(allocator) catch {
-        output.err("Failed to determine cache directory", .{});
-        return error.Aborted;
-    };
-    defer allocator.free(cache_dir);
-
-    // Each kind owns its own arena on `page_allocator` — worker-local
-    // so the formula and cask threads never share a bump-pointer.
-    // Both arenas deinit at function exit, freeing every `KindResults`
-    // field uniformly — no per-struct deinit needed. The unused arena
-    // on single-kind queries is empty; deinit is cheap.
+    // One arena per kind: the worker-thread API path keeps each `KindResults`
+    // bump-pointer disjoint, and local matches join later in the same arena.
     var f_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer f_arena.deinit();
     var c_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer c_arena.deinit();
+    const f_alloc = f_arena.allocator();
+    const c_alloc = c_arena.allocator();
 
-    // When both kinds are requested we dispatch the cask work to a
-    // worker thread so the two independent JSON index downloads
-    // (formula ~29 MiB, cask ~14 MiB) overlap. On a cold cache this
-    // roughly halves wall time; on a warm cache the thread is created
-    // and joined in under a millisecond so the overhead is noise.
-    //
-    // `std.http.Client` is not safe to share across threads, so each
-    // path owns its own `HttpClient`. The synchronous single-kind
-    // paths keep the original one-client shape to avoid pointless
-    // thread spawns.
     var formula: KindResults = .{};
     var cask: KindResults = .{};
 
-    if (search_formula and search_cask) {
-        var cask_task: KindTask = .{
-            .ctx = ctx,
-            .allocator = c_arena.allocator(),
-            .cache_dir = cache_dir,
-            .kind = .cask,
-            .query = search_query,
+    if (shouldRunLocal(scope)) {
+        if (openLocalDb(ctx)) |db_opt| {
+            if (db_opt) |db_in| {
+                var db = db_in;
+                defer db.close();
+                if (search_formula) formula = runKindLocal(f_alloc, &db, .formula, search_query) catch .{};
+                if (search_cask) cask = runKindLocal(c_alloc, &db, .cask, search_query) catch .{};
+            }
+        } else |_| {}
+    }
+
+    const has_local_hit = formula.exact or cask.exact or
+        formula.matches.len != 0 or cask.matches.len != 0;
+
+    if (shouldRunApi(scope, has_local_hit)) {
+        const cache_dir = atomic.maltCacheDir(allocator) catch {
+            output.err("Failed to determine cache directory", .{});
+            return error.Aborted;
         };
-        const worker = std.Thread.spawn(.{}, KindTask.run, .{&cask_task}) catch null;
-        formula = runKindIsolated(ctx, f_arena.allocator(), cache_dir, .formula, search_query);
-        if (worker) |w| {
-            w.join();
-            cask = cask_task.result;
-        } else {
-            // Spawn failed — fall back to running cask inline. Rare
-            // enough (only on thread-creation failure) that the
-            // sequential path is fine.
-            cask = runKindIsolated(ctx, c_arena.allocator(), cache_dir, .cask, search_query);
+        defer allocator.free(cache_dir);
+
+        // Cask + formula API indexes are ~29 MiB / ~14 MiB on first fetch;
+        // overlapping the two halves wall-clock on a cold cache, costs
+        // ~ms on a warm one. `std.http.Client` is not thread-safe so each
+        // worker owns its own `HttpClient`.
+        var api_formula: KindResults = .{};
+        var api_cask: KindResults = .{};
+        if (search_formula and search_cask) {
+            var cask_task: KindTask = .{
+                .ctx = ctx,
+                .allocator = c_alloc,
+                .cache_dir = cache_dir,
+                .kind = .cask,
+                .query = search_query,
+            };
+            const worker = std.Thread.spawn(.{}, KindTask.run, .{&cask_task}) catch null;
+            api_formula = runKindIsolated(ctx, f_alloc, cache_dir, .formula, search_query);
+            if (worker) |w| {
+                w.join();
+                api_cask = cask_task.result;
+            } else {
+                api_cask = runKindIsolated(ctx, c_alloc, cache_dir, .cask, search_query);
+            }
+        } else if (search_formula) {
+            api_formula = runKindIsolated(ctx, f_alloc, cache_dir, .formula, search_query);
+        } else if (search_cask) {
+            api_cask = runKindIsolated(ctx, c_alloc, cache_dir, .cask, search_query);
         }
-    } else if (search_formula) {
-        formula = runKindIsolated(ctx, f_arena.allocator(), cache_dir, .formula, search_query);
-    } else if (search_cask) {
-        cask = runKindIsolated(ctx, c_arena.allocator(), cache_dir, .cask, search_query);
+
+        switch (scope) {
+            .all => {
+                if (search_formula) formula = mergeResults(f_alloc, formula, api_formula) catch api_formula;
+                if (search_cask) cask = mergeResults(c_alloc, cask, api_cask) catch api_cask;
+            },
+            .default, .api => {
+                if (search_formula) formula = api_formula;
+                if (search_cask) cask = api_cask;
+            },
+            .installed => unreachable, // shouldRunApi(.installed, …) is false.
+        }
     }
 
     var stdout_buf: [4096]u8 = undefined;
@@ -117,6 +472,91 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     } else {
         emitHuman(stdout, formula, cask, search_query);
     }
+}
+
+/// `--offline` flag or `MALT_OFFLINE` env (`1` / `true`). When either
+/// is active, `mt search` cannot make sense of `--api` and degrades to
+/// `--installed` semantics.
+pub fn isOfflineRequested(ctx: *const AppCtx, args: []const []const u8) bool {
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--offline")) return true;
+    }
+    const val = std.process.Environ.getPosix(ctx.environ, "MALT_OFFLINE") orelse return false;
+    return std.mem.eql(u8, val, "1") or std.ascii.eqlIgnoreCase(val, "true");
+}
+
+/// Open `{prefix}/db/malt.db` for read-only search. Returns `null` when
+/// the file doesn't exist yet (fresh prefix) so callers can degrade to
+/// "no local matches" instead of aborting. Outer error wraps unexpected
+/// `sqlite` / `schema` failures.
+fn openLocalDb(ctx: *const AppCtx) !?sqlite.Database {
+    const prefix = atomic.maltPrefixOrAbort();
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return null;
+    _ = std.Io.Dir.cwd().statFile(ctx.io, std.mem.sliceTo(db_path, 0), .{}) catch return null;
+    var db = sqlite.Database.open(db_path) catch return null;
+    errdefer db.close();
+    try schema.initSchema(&db);
+    return db;
+}
+
+/// Local-DB counterpart to `runKindIsolated`. `exact` is set when the
+/// case-folded query matches a row verbatim — same semantics the API
+/// path's `api.exists` provides.
+fn runKindLocal(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    kind: api_mod.BrewApi.Kind,
+    query: []const u8,
+) !KindResults {
+    const matches = try searchLocalKind(allocator, db, kind, query);
+    var qbuf: [128]u8 = undefined;
+    var exact = false;
+    if (query.len > 0 and query.len <= qbuf.len) {
+        const qlower = std.ascii.lowerString(qbuf[0..query.len], query);
+        for (matches) |m| {
+            if (std.mem.eql(u8, m, qlower)) {
+                exact = true;
+                break;
+            }
+        }
+    }
+    return .{ .exact = exact, .index = null, .matches = matches };
+}
+
+/// Merge local + API matches for one kind (`--all` path). Deduplicates
+/// by exact name and sorts ASC so the combined output reads consistently.
+/// `index` is carried from the API side since the API matches still
+/// reference it.
+fn mergeResults(
+    allocator: std.mem.Allocator,
+    locals: KindResults,
+    api: KindResults,
+) !KindResults {
+    var combined: std.ArrayList([]const u8) = .empty;
+    errdefer combined.deinit(allocator);
+    try combined.appendSlice(allocator, locals.matches);
+    for (api.matches) |a| {
+        var dup = false;
+        for (locals.matches) |l| {
+            if (std.mem.eql(u8, l, a)) {
+                dup = true;
+                break;
+            }
+        }
+        if (!dup) try combined.append(allocator, a);
+    }
+    const merged = try combined.toOwnedSlice(allocator);
+    std.mem.sort([]const u8, merged, {}, lessThanStr);
+    return .{
+        .exact = locals.exact or api.exact,
+        .index = api.index,
+        .matches = merged,
+    };
+}
+
+fn lessThanStr(_: void, a: []const u8, b: []const u8) bool {
+    return std.mem.lessThan(u8, a, b);
 }
 
 /// Run the exact + substring search for one kind with a locally-owned

--- a/tests/search_cli_test.zig
+++ b/tests/search_cli_test.zig
@@ -261,24 +261,12 @@ test "execute --api still works with only the cache seeded" {
     try search.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--api", "wget" });
 }
 
-test "execute default short-circuits when local has a match" {
-    // Seed DB only — no cache. Default scope should run the local pass,
-    // find `wget`, and skip the API entirely (cache absence is harmless).
-    var s = try Scratch.init(testing.allocator, "default_local_hit");
-    defer s.deinit(testing.allocator);
-    try seedDb(testing.allocator, s.path);
-
-    const prior = OutputState.save();
-    defer prior.restore();
-    output.setQuiet(true);
-
-    try search.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{"wget"});
-}
-
-test "execute default falls through to API on local miss" {
-    // Seed DB + cache; query a name that's in the cache index but not
-    // installed locally. Default scope must reach for the API.
-    var s = try Scratch.init(testing.allocator, "default_fallthrough");
+test "execute default queries the API even when the local DB has a match" {
+    // Default mirrors `brew search`: regardless of what's installed in
+    // the local prefix, the answer comes from the Homebrew API. Seed
+    // both DB and cache, query something both know about, and verify
+    // the helper accepts the work without erroring.
+    var s = try Scratch.init(testing.allocator, "default_api_parity");
     defer s.deinit(testing.allocator);
     try seedDb(testing.allocator, s.path);
     try seedCache(testing.allocator, s.path);
@@ -287,11 +275,21 @@ test "execute default falls through to API on local miss" {
     defer prior.restore();
     output.setQuiet(true);
 
-    // "wgetpaste" matches in the API index AND locally — better to query
-    // a token that's API-only. The seeded cask index has `brave`, which
-    // is also in the local DB. Use `jq` — local has it, so this tests
-    // short-circuit. For fall-through use a token only the cache knows.
-    try search.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--cask", "firefox-developer-edition" });
+    try search.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{"wget"});
+}
+
+test "execute default tolerates a missing local DB (never reads it)" {
+    // Fresh prefix with only the API cache — default scope never opens
+    // the local DB, so absence is a no-op rather than an error path.
+    var s = try Scratch.init(testing.allocator, "default_nodb");
+    defer s.deinit(testing.allocator);
+    try seedCache(testing.allocator, s.path);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    try search.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{"wget"});
 }
 
 test "execute --all runs both passes with cache + DB seeded" {

--- a/tests/search_cli_test.zig
+++ b/tests/search_cli_test.zig
@@ -11,6 +11,8 @@ const test_io = @import("test_io");
 const testing = std.testing;
 const search = malt.cli_search;
 const output = malt.output;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
 
 const c = struct {
     extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
@@ -51,6 +53,34 @@ fn writeFile(path: []const u8, content: []const u8) !void {
     const f = try test_io.createFileAbsolute(std.Options.debug_io, path, .{ .truncate = true });
     defer f.close(std.Options.debug_io);
     try f.writeStreamingAll(std.Options.debug_io, content);
+}
+
+// Seed `{prefix}/db/malt.db` with kegs + casks so `--installed` and the
+// `default` local-first path find real rows without ever touching the API.
+fn seedDb(allocator: std.mem.Allocator, prefix: []const u8) !void {
+    const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{prefix});
+    defer allocator.free(db_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, db_dir);
+
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/malt.db", .{db_dir}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs(name, full_name, version, store_sha256, cellar_path)
+        \\VALUES
+        \\  ('wget',      'wget',      '1.21', 'aaa', '/c/wget/1.21'),
+        \\  ('wgetpaste', 'wgetpaste', '2.31', 'bbb', '/c/wgetpaste/2.31'),
+        \\  ('jq',        'jq',        '1.7',  'ccc', '/c/jq/1.7');
+    );
+    try db.exec(
+        \\INSERT INTO casks(token, name, version, url)
+        \\VALUES
+        \\  ('firefox', 'Firefox', '120.0', 'https://x'),
+        \\  ('brave',   'Brave',   '1.0',   'https://x');
+    );
 }
 
 // Seed both names indexes + a per-package json so api.exists() and
@@ -171,4 +201,157 @@ test "execute --json emits a JSON object covering both kinds" {
     // is only populated for `output.*` writes which `search` only uses
     // on the no-args branch.
     _ = stdout_buf.items;
+}
+
+// --- T-031: scope flag plumbing through `execute` ----------------------
+
+test "execute --installed reads the local DB without an API cache present" {
+    var s = try Scratch.init(testing.allocator, "installed");
+    defer s.deinit(testing.allocator);
+    try seedDb(testing.allocator, s.path);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    // No `seedCache` — if the local-only path slipped through to the API,
+    // `runKindIsolated` would still tolerate the miss (matches stays empty),
+    // so the real assertion is "no error and the helper accepted the flag".
+    try search.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--installed", "wget" });
+}
+
+test "execute --installed --formula composes scope with kind filter" {
+    var s = try Scratch.init(testing.allocator, "installed_formula");
+    defer s.deinit(testing.allocator);
+    try seedDb(testing.allocator, s.path);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    try search.execute(
+        &malt.app_ctx.debug_ctx,
+        testing.allocator,
+        &.{ "--installed", "--formula", "jq" },
+    );
+}
+
+test "execute --installed --json keeps the JSON dispatch active" {
+    var s = try Scratch.init(testing.allocator, "installed_json");
+    defer s.deinit(testing.allocator);
+    try seedDb(testing.allocator, s.path);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.json);
+    output.setQuiet(true);
+
+    try search.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--installed", "wget" });
+}
+
+test "execute --api still works with only the cache seeded" {
+    var s = try Scratch.init(testing.allocator, "api_only");
+    defer s.deinit(testing.allocator);
+    try seedCache(testing.allocator, s.path);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    try search.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--api", "wget" });
+}
+
+test "execute default short-circuits when local has a match" {
+    // Seed DB only — no cache. Default scope should run the local pass,
+    // find `wget`, and skip the API entirely (cache absence is harmless).
+    var s = try Scratch.init(testing.allocator, "default_local_hit");
+    defer s.deinit(testing.allocator);
+    try seedDb(testing.allocator, s.path);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    try search.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{"wget"});
+}
+
+test "execute default falls through to API on local miss" {
+    // Seed DB + cache; query a name that's in the cache index but not
+    // installed locally. Default scope must reach for the API.
+    var s = try Scratch.init(testing.allocator, "default_fallthrough");
+    defer s.deinit(testing.allocator);
+    try seedDb(testing.allocator, s.path);
+    try seedCache(testing.allocator, s.path);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    // "wgetpaste" matches in the API index AND locally — better to query
+    // a token that's API-only. The seeded cask index has `brave`, which
+    // is also in the local DB. Use `jq` — local has it, so this tests
+    // short-circuit. For fall-through use a token only the cache knows.
+    try search.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--cask", "firefox-developer-edition" });
+}
+
+test "execute --all runs both passes with cache + DB seeded" {
+    var s = try Scratch.init(testing.allocator, "all_scope");
+    defer s.deinit(testing.allocator);
+    try seedDb(testing.allocator, s.path);
+    try seedCache(testing.allocator, s.path);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    try search.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--all", "wget" });
+}
+
+test "execute --installed tolerates a missing local DB without crashing" {
+    // Fresh prefix with no `db/malt.db` — local lookup must degrade
+    // silently, not error out.
+    var s = try Scratch.init(testing.allocator, "installed_nodb");
+    defer s.deinit(testing.allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    try search.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--installed", "wget" });
+}
+
+test "execute --offline collapses --api into local-only" {
+    // T-029 slice: even with `--api` requested, `--offline` wins and the
+    // command must not attempt the network path.
+    var s = try Scratch.init(testing.allocator, "offline");
+    defer s.deinit(testing.allocator);
+    try seedDb(testing.allocator, s.path);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    try search.execute(
+        &malt.app_ctx.debug_ctx,
+        testing.allocator,
+        &.{ "--offline", "--api", "wget" },
+    );
+}
+
+test "execute MALT_OFFLINE=1 mirrors the --offline flag" {
+    var s = try Scratch.init(testing.allocator, "offline_env");
+    defer s.deinit(testing.allocator);
+    try seedDb(testing.allocator, s.path);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    // Build an AppCtx with a one-entry environ instead of mutating the
+    // process env — keeps the test hermetic and parallel-safe.
+    const entries = [_:null]?[*:0]const u8{"MALT_OFFLINE=1".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    const ctx: malt.app_ctx.AppCtx = .{ .io = std.Options.debug_io, .environ = env };
+
+    try search.execute(&ctx, testing.allocator, &.{"wget"});
 }


### PR DESCRIPTION
## Description

Adds `--installed`, `--api`, and `--all` scopes to `mt search`, plus `--offline` (mirroring `MALT_OFFLINE=1`) as the search-side slice of the offline-mode work. Default scope stays brew-parity — `mt search foo` keeps querying the Homebrew API exactly like `brew search foo` — so users coming from brew get no surprise. `--installed` is the local-only opt-in: a substring scan over `kegs.name` and `casks.token` with no network. `--all` runs both passes and merges results deduped + sorted.
`--offline` collapses every scope into `--installed`. `--json`, `--formula`, and `--cask` compose with every scope.

## Related Issue

- None

## Notes for Reviewers

- None