### PR TITLE
feat(cli/tap): add --pin <sha> and --refresh --all

### DIFF
--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -158,6 +158,7 @@ pub const bash_script =
     \\        bundle)           cmd_flags="--dry-run -n --format --from-installed --purge --yes -y" ;;
     \\        run)              cmd_flags="--keep" ;;
     \\        doctor)           cmd_flags="--fix --dry-run" ;;
+    \\        tap)              cmd_flags="--refresh --all --pin --yes -y --json" ;;
     \\    esac
     \\
     \\    if [[ "$cur" == -* ]]; then
@@ -402,6 +403,15 @@ pub const zsh_script =
     \\                        'export[Print bundle to stdout]' \
     \\                        'import[Register a bundle definition without installing]'
     \\                    ;;
+    \\                tap)
+    \\                    _arguments \
+    \\                        '--refresh[Advance the pin to current HEAD]' \
+    \\                        '--all[With --refresh: walk every registered tap]' \
+    \\                        '--pin[Explicitly pin <slug> to <sha>]' \
+    \\                        '(--yes -y)'{--yes,-y}'[Confirm --refresh --all apply]' \
+    \\                        '--json[Emit refresh-all diff as JSON]' \
+    \\                        '*::slug:'
+    \\                    ;;
     \\            esac
     \\            ;;
     \\    esac
@@ -588,6 +598,13 @@ pub const fish_script =
     \\
     \\    # run
     \\    complete -c $__malt_bin -n '__malt_using_command run' -l keep -d 'Cache extracted bottle under {cache}/run/<sha256>/'
+    \\
+    \\    # tap
+    \\    complete -c $__malt_bin -n '__malt_using_command tap' -l refresh -d 'Advance the pin to current HEAD'
+    \\    complete -c $__malt_bin -n '__malt_using_command tap' -l all     -d 'With --refresh: walk every registered tap'
+    \\    complete -c $__malt_bin -n '__malt_using_command tap' -l pin     -d 'Explicitly pin <slug> to <sha>'
+    \\    complete -c $__malt_bin -n '__malt_using_command tap' -s y -l yes -d 'Confirm --refresh --all apply'
+    \\    complete -c $__malt_bin -n '__malt_using_command tap' -l json    -d 'Emit refresh-all diff as JSON'
     \\
     \\    # completions — shell name as positional
     \\    complete -c $__malt_bin -n '__malt_using_command completions' -f -a 'bash zsh fish'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -232,13 +232,29 @@ const doctor_help =
 const tap_help =
     \\Usage: malt tap [<user>/<repo>]
     \\       malt tap --refresh <user>/<repo>
+    \\       malt tap --refresh --all [--yes] [--json]
+    \\       malt tap --pin <user>/<repo> <sha>
     \\       malt untap <user>/<repo>
     \\
     \\Manage taps. Without arguments, lists registered taps + their
     \\pinned commit. `tap <slug>` resolves the repo's HEAD commit at
     \\that moment and stores it; subsequent installs from the tap fetch
     \\against the pin, not whatever HEAD happens to point to later.
-    \\`--refresh` explicitly advances the pin to the current HEAD.
+    \\
+    \\Flags:
+    \\  --refresh [<slug>]   Advance the pin to the current HEAD. With a
+    \\                       slug, refreshes that one tap; with --all,
+    \\                       walks every registered tap.
+    \\  --all                Pairs with --refresh: batch every tap, print
+    \\                       a per-row `old_sha[..7] -> new_sha[..7]` diff,
+    \\                       and refuse to apply without --yes when any
+    \\                       tap moved.
+    \\  --pin <slug> <sha>   Explicitly pin <slug> to <sha>. The SHA is
+    \\                       validated for reachability through GitHub's
+    \\                       commits/<sha> endpoint before the pin lands.
+    \\  --yes, -y            Confirm the apply step of --refresh --all.
+    \\  --json               Emit the --refresh --all diff as
+    \\                       `{"taps":[{"tap","old_sha","new_sha","status"}]}`.
     \\
     \\Taps are auto-resolved during install, so explicit `tap` is
     \\usually unnecessary — the auto-tap also pins the SHA on first use.

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -38,6 +38,67 @@ fn validateComponent(part: []const u8) TapNameError!void {
     }
 }
 
+/// One row in the `--refresh --all` listing. Fields point at slices owned
+/// by the surrounding `tap.list` result or the per-tap resolve buffer; the
+/// row itself does not own memory.
+const RefreshRow = struct {
+    name: []const u8,
+    old_sha: ?[]const u8,
+    new_sha: ?[]const u8,
+    status: RefreshStatus,
+};
+
+const RefreshStatus = enum { unchanged, moved, failed };
+
+/// Classify a single tap row by its (old, new) SHA pair. `null` `new`
+/// means the network lookup failed; the row is surfaced as `failed` so
+/// users still see what would have moved had the resolve succeeded.
+fn classifyRefresh(old: ?[]const u8, new: ?[]const u8) RefreshStatus {
+    const new_sha = new orelse return .failed;
+    if (old) |o| {
+        if (std.mem.eql(u8, o, new_sha)) return .unchanged;
+        return .moved;
+    }
+    return .moved;
+}
+
+/// True if any row would write a new SHA on apply. Failures alone do not
+/// gate — there's nothing to apply for a row we couldn't resolve.
+fn anyMoved(rows: []const RefreshRow) bool {
+    for (rows) |r| if (r.status == .moved) return true;
+    return false;
+}
+
+fn shortSha(sha: ?[]const u8) []const u8 {
+    if (sha) |s| return s[0..@min(s.len, 7)];
+    return "<unpinned>";
+}
+
+fn writeRefreshRowText(w: *std.Io.Writer, row: RefreshRow) !void {
+    switch (row.status) {
+        .unchanged => try w.print("  {s}: {s} (unchanged)\n", .{ row.name, shortSha(row.old_sha) }),
+        .moved => try w.print("  {s}: {s} -> {s}\n", .{ row.name, shortSha(row.old_sha), shortSha(row.new_sha) }),
+        .failed => try w.print("  {s}: {s} -> ??? (failed)\n", .{ row.name, shortSha(row.old_sha) }),
+    }
+}
+
+fn writeRefreshRowsJson(w: *std.Io.Writer, rows: []const RefreshRow) !void {
+    try w.writeAll("{\"taps\":[");
+    for (rows, 0..) |row, i| {
+        if (i != 0) try w.writeAll(",");
+        try w.writeAll("{\"tap\":");
+        try output.jsonStr(w, row.name);
+        try w.writeAll(",\"old_sha\":");
+        if (row.old_sha) |s| try output.jsonStr(w, s) else try w.writeAll("null");
+        try w.writeAll(",\"new_sha\":");
+        if (row.new_sha) |s| try output.jsonStr(w, s) else try w.writeAll("null");
+        try w.writeAll(",\"status\":");
+        try output.jsonStr(w, @tagName(row.status));
+        try w.writeAll("}");
+    }
+    try w.writeAll("]}\n");
+}
+
 /// Render one listing row: `name @ {7-char sha}` when pinned, or
 /// `name (unpinned — run \`mt tap --refresh name\`)` when not. Caller owns
 /// the returned slice. Kept in one place so the refresh hint stays in
@@ -77,6 +138,131 @@ test "formatTapLine renders refresh hint for an unpinned tap" {
     );
 }
 
+// ───────────────────────────────────────────────────────────────────
+// refresh-all row classifier + formatters. Pure data shaping so the
+// `--yes` gate and the `{tap, old_sha, new_sha, status}` JSON contract
+// can be pinned byte-for-byte without staging a real DB or network.
+// ───────────────────────────────────────────────────────────────────
+
+const sha_old = "0123456789abcdef0123456789abcdef01234567";
+const sha_new = "abcdef0123456789abcdef0123456789abcdef01";
+
+test "classifyRefresh: identical old/new → unchanged" {
+    try std.testing.expectEqual(RefreshStatus.unchanged, classifyRefresh(sha_old, sha_old));
+}
+
+test "classifyRefresh: differing old/new → moved" {
+    try std.testing.expectEqual(RefreshStatus.moved, classifyRefresh(sha_old, sha_new));
+}
+
+test "classifyRefresh: null new (failed resolve) → failed" {
+    try std.testing.expectEqual(RefreshStatus.failed, classifyRefresh(sha_old, null));
+    try std.testing.expectEqual(RefreshStatus.failed, classifyRefresh(null, null));
+}
+
+test "classifyRefresh: null old + new SHA → moved (newly pinned counts as a write)" {
+    try std.testing.expectEqual(RefreshStatus.moved, classifyRefresh(null, sha_new));
+}
+
+test "anyMoved: empty list returns false" {
+    try std.testing.expect(!anyMoved(&.{}));
+}
+
+test "anyMoved: all unchanged returns false" {
+    const rows = [_]RefreshRow{
+        .{ .name = "a/b", .old_sha = sha_old, .new_sha = sha_old, .status = .unchanged },
+        .{ .name = "c/d", .old_sha = sha_old, .new_sha = sha_old, .status = .unchanged },
+    };
+    try std.testing.expect(!anyMoved(&rows));
+}
+
+test "anyMoved: any moved row returns true (failures alone do not gate)" {
+    const only_failed = [_]RefreshRow{
+        .{ .name = "a/b", .old_sha = sha_old, .new_sha = null, .status = .failed },
+    };
+    try std.testing.expect(!anyMoved(&only_failed));
+
+    const with_moved = [_]RefreshRow{
+        .{ .name = "a/b", .old_sha = sha_old, .new_sha = sha_old, .status = .unchanged },
+        .{ .name = "c/d", .old_sha = sha_old, .new_sha = sha_new, .status = .moved },
+    };
+    try std.testing.expect(anyMoved(&with_moved));
+}
+
+test "writeRefreshRowText: moved row renders `old[..7] -> new[..7]`" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeRefreshRowText(&aw.writer, .{
+        .name = "user/repo",
+        .old_sha = sha_old,
+        .new_sha = sha_new,
+        .status = .moved,
+    });
+    try std.testing.expectEqualStrings("  user/repo: 0123456 -> abcdef0\n", aw.written());
+}
+
+test "writeRefreshRowText: unchanged row marks the row as unchanged" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeRefreshRowText(&aw.writer, .{
+        .name = "user/repo",
+        .old_sha = sha_old,
+        .new_sha = sha_old,
+        .status = .unchanged,
+    });
+    try std.testing.expectEqualStrings("  user/repo: 0123456 (unchanged)\n", aw.written());
+}
+
+test "writeRefreshRowText: failed row keeps the old SHA visible" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeRefreshRowText(&aw.writer, .{
+        .name = "user/repo",
+        .old_sha = sha_old,
+        .new_sha = null,
+        .status = .failed,
+    });
+    try std.testing.expectEqualStrings("  user/repo: 0123456 -> ??? (failed)\n", aw.written());
+}
+
+test "writeRefreshRowText: unpinned old SHA is surfaced explicitly" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeRefreshRowText(&aw.writer, .{
+        .name = "user/repo",
+        .old_sha = null,
+        .new_sha = sha_new,
+        .status = .moved,
+    });
+    try std.testing.expectEqualStrings("  user/repo: <unpinned> -> abcdef0\n", aw.written());
+}
+
+test "writeRefreshRowsJson: emits `{taps:[{tap,old_sha,new_sha,status},...]}`" {
+    const rows = [_]RefreshRow{
+        .{ .name = "a/b", .old_sha = sha_old, .new_sha = sha_new, .status = .moved },
+        .{ .name = "c/d", .old_sha = sha_old, .new_sha = sha_old, .status = .unchanged },
+        .{ .name = "e/f", .old_sha = null, .new_sha = null, .status = .failed },
+    };
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeRefreshRowsJson(&aw.writer, &rows);
+    try std.testing.expectEqualStrings(
+        "{\"taps\":[" ++
+            "{\"tap\":\"a/b\",\"old_sha\":\"" ++ sha_old ++ "\",\"new_sha\":\"" ++ sha_new ++ "\",\"status\":\"moved\"}," ++
+            "{\"tap\":\"c/d\",\"old_sha\":\"" ++ sha_old ++ "\",\"new_sha\":\"" ++ sha_old ++ "\",\"status\":\"unchanged\"}," ++
+            "{\"tap\":\"e/f\",\"old_sha\":null,\"new_sha\":null,\"status\":\"failed\"}" ++
+            "]}\n",
+        aw.written(),
+    );
+}
+
+test "writeRefreshRowsJson: empty input emits `{\"taps\":[]}`" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeRefreshRowsJson(&aw.writer, &.{});
+    try std.testing.expectEqualStrings("{\"taps\":[]}\n", aw.written());
+}
+
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
     return run(ctx, allocator, args, .add);
 }
@@ -98,15 +284,37 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
     if (help.showIfRequested(ctx, args, if (action == .add) "tap" else "untap")) return;
 
     // --refresh <name>: update the stored commit pin to current HEAD.
+    // --pin <user/repo> <sha>: explicit pin; consumes the next two argv slots.
+    // --refresh --all: walk every registered tap and refresh in batch.
     var refresh_target: ?[]const u8 = null;
+    var refresh_all = false;
+    var pin_slug: ?[]const u8 = null;
+    var pin_sha: ?[]const u8 = null;
+    var yes = false;
     var positional: ?[]const u8 = null;
-    for (args) |arg| {
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
         if (std.mem.eql(u8, arg, "--refresh")) {
-            // `--refresh` without a name refreshes the positional,
-            // resolved below. We just flag the mode here.
             refresh_target = "";
         } else if (std.mem.startsWith(u8, arg, "--refresh=")) {
             refresh_target = arg["--refresh=".len..];
+        } else if (std.mem.eql(u8, arg, "--all")) {
+            refresh_all = true;
+        } else if (std.mem.eql(u8, arg, "--yes") or std.mem.eql(u8, arg, "-y")) {
+            yes = true;
+        } else if (std.mem.eql(u8, arg, "--pin")) {
+            if (action != .add) {
+                output.err("--pin is only valid with `mt tap`", .{});
+                return error.Aborted;
+            }
+            if (i + 2 >= args.len) {
+                output.err("Usage: mt tap --pin user/repo <sha>", .{});
+                return error.Aborted;
+            }
+            pin_slug = args[i + 1];
+            pin_sha = args[i + 2];
+            i += 2;
         } else if (!std.mem.startsWith(u8, arg, "-")) {
             if (positional == null) positional = arg;
         }
@@ -125,6 +333,20 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
     };
     defer db.close();
     schema.initSchema(&db) catch return;
+
+    if (pin_slug) |slug| {
+        try pinTap(ctx, allocator, &db, slug, pin_sha.?);
+        return;
+    }
+
+    if (refresh_all) {
+        if (action != .add) {
+            output.err("--refresh is only valid with `mt tap`", .{});
+            return error.Aborted;
+        }
+        try refreshAll(ctx, allocator, &db, yes);
+        return;
+    }
 
     if (refresh_target) |target| {
         if (action != .add) {
@@ -198,6 +420,143 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
             output.info("Untapped {s}", .{name});
         },
     }
+}
+
+fn pinTap(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    slug: []const u8,
+    sha: []const u8,
+) !void {
+    validateTapName(slug) catch {
+        output.err("Invalid tap '{s}'. Expected: user/repo with [A-Za-z0-9._-]", .{slug});
+        return error.Aborted;
+    };
+    tap_mod.validateCommitSha(sha) catch {
+        output.err("Invalid SHA '{s}'. Expected a 40-char lowercase hex commit SHA.", .{sha});
+        return error.Aborted;
+    };
+
+    // Route reachability through the same HTTP path as HEAD resolution so a
+    // 200 here proves the SHA is fetchable from the exact repo subsequent
+    // installs will use. A 404 means GitHub has no such commit on this repo.
+    const commit_url = try tap_mod.resolveCommitUrl(allocator, slug, sha);
+    defer allocator.free(commit_url);
+    const echoed = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, commit_url) catch |e| {
+        if (e == error.NotFound) {
+            output.err("Cannot pin {s} @ {s}: GitHub has no such commit on this tap.", .{ slug, sha[0..@min(sha.len, 7)] });
+        } else {
+            output.err("Could not verify {s} @ {s}: {s}", .{ slug, sha[0..@min(sha.len, 7)], tap_mod.describeResolveError(e) });
+        }
+        return error.Aborted;
+    };
+    defer allocator.free(echoed);
+
+    // Defensive: GitHub's `commits/<sha>` echoes the resolved full SHA. If
+    // it differs, treat as unreachable rather than store a mismatched pin.
+    if (!std.mem.eql(u8, echoed, sha)) {
+        output.err("Cannot pin {s} @ {s}: GitHub returned a different SHA.", .{ slug, sha[0..@min(sha.len, 7)] });
+        return error.Aborted;
+    }
+
+    const urls = try tap_mod.resolveTapBaseUrls(allocator, slug);
+    defer urls.deinit(allocator);
+    tap_mod.add(db, slug, urls.repo_url, sha) catch {
+        output.err("Failed to pin {s}", .{slug});
+        return error.Aborted;
+    };
+    output.info("Pinned {s} @ {s}", .{ slug, sha[0..@min(sha.len, 7)] });
+}
+
+/// Walk every registered tap, resolve current HEAD, emit a diff, and only
+/// apply writes when `yes` is set. JSON consumers still see the full diff;
+/// the `--yes` gate is independent of the output format.
+fn refreshAll(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    yes: bool,
+) !void {
+    const taps = tap_mod.list(allocator, db) catch {
+        output.err("Failed to list taps", .{});
+        return error.Aborted;
+    };
+    defer {
+        for (taps) |t| {
+            allocator.free(t.name);
+            allocator.free(t.url);
+            if (t.commit_sha) |sha| allocator.free(sha);
+        }
+        allocator.free(taps);
+    }
+
+    // Resolve each tap's HEAD up-front so the diff display reflects the
+    // full plan before any write happens — including the case where the
+    // user immediately passes `--yes`.
+    var new_shas: std.ArrayList(?[]const u8) = .empty;
+    defer {
+        for (new_shas.items) |maybe_sha| if (maybe_sha) |sha| allocator.free(sha);
+        new_shas.deinit(allocator);
+    }
+    try new_shas.ensureTotalCapacityPrecise(allocator, taps.len);
+
+    var rows: std.ArrayList(RefreshRow) = .empty;
+    defer rows.deinit(allocator);
+    try rows.ensureTotalCapacityPrecise(allocator, taps.len);
+
+    for (taps) |t| {
+        const new_sha = resolveOneHead(ctx, allocator, t.name) catch null;
+        new_shas.appendAssumeCapacity(new_sha);
+        rows.appendAssumeCapacity(.{
+            .name = t.name,
+            .old_sha = t.commit_sha,
+            .new_sha = new_sha,
+            .status = classifyRefresh(t.commit_sha, new_sha),
+        });
+    }
+
+    try emitRefreshAll(ctx, rows.items);
+
+    if (anyMoved(rows.items) and !yes) {
+        output.err("Taps moved. Re-run with --yes to apply.", .{});
+        return error.Aborted;
+    }
+
+    // Apply only the rows that actually moved; unchanged is a no-op and
+    // failed has no SHA to write.
+    for (rows.items) |row| {
+        if (row.status != .moved) continue;
+        const new_sha = row.new_sha orelse continue;
+        tap_mod.updateCommit(db, row.name, new_sha) catch {
+            output.err("Failed to update commit pin for {s}", .{row.name});
+            return error.Aborted;
+        };
+    }
+}
+
+fn resolveOneHead(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    slug: []const u8,
+) ![]const u8 {
+    const urls = try tap_mod.resolveTapBaseUrls(allocator, slug);
+    defer urls.deinit(allocator);
+    return tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url);
+}
+
+fn emitRefreshAll(ctx: *const AppCtx, rows: []const RefreshRow) !void {
+    var stdout_buf: [4096]u8 = undefined;
+    var stdout_fw = ctx.stdout.writer(ctx.io, &stdout_buf);
+    const stdout: *std.Io.Writer = &stdout_fw.interface;
+    defer stdout.flush() catch {};
+
+    if (output.isJson()) {
+        try writeRefreshRowsJson(stdout, rows);
+        return;
+    }
+    if (rows.len == 0) return;
+    for (rows) |row| try writeRefreshRowText(stdout, row);
 }
 
 fn refreshTap(ctx: *const AppCtx, allocator: std.mem.Allocator, db: *sqlite.Database, name: []const u8) !void {

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -253,6 +253,45 @@ test "resolveTapBaseUrls synthesises homebrew- prefix once per field" {
     );
 }
 
+/// Build the `commits/<sha>` URL siblings of `api_head_url`. Routed
+/// through the same `homebrew-<repo>` synthesis so `mt tap --pin` and the
+/// HEAD path can't drift apart — a 200 here means the SHA is reachable
+/// against the exact repo subsequent installs will fetch from.
+pub fn resolveCommitUrl(
+    allocator: std.mem.Allocator,
+    slug: []const u8,
+    sha: []const u8,
+) std.mem.Allocator.Error![]const u8 {
+    const slash = std.mem.indexOfScalar(u8, slug, '/') orelse unreachable;
+    const user = slug[0..slash];
+    const repo = slug[slash + 1 ..];
+    return std.fmt.allocPrint(
+        allocator,
+        "https://api.github.com/repos/{s}/homebrew-{s}/commits/{s}",
+        .{ user, repo, sha },
+    );
+}
+
+test "resolveCommitUrl builds the homebrew- prefixed commits/<sha> URL" {
+    const sha = "0123456789abcdef0123456789abcdef01234567";
+    const url = try resolveCommitUrl(std.testing.allocator, "user/repo", sha);
+    defer std.testing.allocator.free(url);
+    try std.testing.expectEqualStrings(
+        "https://api.github.com/repos/user/homebrew-repo/commits/" ++ sha,
+        url,
+    );
+}
+
+test "resolveCommitUrl preserves hyphens and digits in repo names" {
+    const sha = "0123456789abcdef0123456789abcdef01234567";
+    const url = try resolveCommitUrl(std.testing.allocator, "user-1/some-tap.v2", sha);
+    defer std.testing.allocator.free(url);
+    try std.testing.expectEqualStrings(
+        "https://api.github.com/repos/user-1/homebrew-some-tap.v2/commits/" ++ sha,
+        url,
+    );
+}
+
 test "resolveTapBaseUrls preserves repo names containing hyphens and digits" {
     const urls = try resolveTapBaseUrls(std.testing.allocator, "user-1/some-tap.v2");
     defer urls.deinit(std.testing.allocator);

--- a/tests/cli_tap_test.zig
+++ b/tests/cli_tap_test.zig
@@ -166,3 +166,174 @@ test "execute with a bare name (no slash) surfaces error.Aborted" {
         tap_cli.execute(&ctx, testing.allocator, &.{"no_slash_here"}),
     );
 }
+
+// ---------------------------------------------------------------------------
+// --pin <user/repo> <sha>
+// ---------------------------------------------------------------------------
+
+test "execute --pin without two operands aborts" {
+    const prefix = try setupPrefix("pin_missing_operand");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(&ctx, testing.allocator, &.{"--pin"}),
+    );
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(&ctx, testing.allocator, &.{ "--pin", "user/repo" }),
+    );
+}
+
+test "execute --pin with malformed SHA aborts before any network call" {
+    const prefix = try setupPrefix("pin_bad_sha");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    // Empty environ guarantees no live network configuration is in play;
+    // if the implementation routes to HTTP this will hang or error noisily.
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(&ctx, testing.allocator, &.{ "--pin", "user/repo", "deadbeef" }),
+    );
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(&ctx, testing.allocator, &.{ "--pin", "user/repo", "GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG" }),
+    );
+}
+
+test "execute --pin with malformed tap name aborts" {
+    const prefix = try setupPrefix("pin_bad_tap");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(&ctx, testing.allocator, &.{
+            "--pin", "no_slash_here", "0123456789abcdef0123456789abcdef01234567",
+        }),
+    );
+}
+
+test "execute --pin under `mt untap` is rejected" {
+    const prefix = try setupPrefix("pin_under_untap");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.executeUntap(&ctx, testing.allocator, &.{
+            "--pin", "user/repo", "0123456789abcdef0123456789abcdef01234567",
+        }),
+    );
+}
+
+test "execute --pin with unresolvable repo surfaces error.Aborted" {
+    const prefix = try setupPrefix("pin_unresolvable");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // `user/repo` is not a real homebrew tap — the commits/<sha> endpoint
+    // 404s and the pin must be refused, mirroring the `mt tap` add path.
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{
+        .io = threaded.io(),
+        .environ = malt.app_ctx.processEnviron(),
+    };
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(&ctx, testing.allocator, &.{
+            "--pin", "user/repo", "0123456789abcdef0123456789abcdef01234567",
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// --refresh --all
+// ---------------------------------------------------------------------------
+
+test "execute --refresh --all on an empty DB is a clean no-op" {
+    const prefix = try setupPrefix("refresh_all_empty");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    // No taps registered → no diff, no apply, exit 0.
+    try tap_cli.execute(&ctx, testing.allocator, &.{ "--refresh", "--all" });
+    try tap_cli.execute(&ctx, testing.allocator, &.{ "--refresh", "--all", "--yes" });
+}
+
+test "execute --refresh --all under `mt untap` is rejected" {
+    const prefix = try setupPrefix("refresh_all_under_untap");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.executeUntap(&ctx, testing.allocator, &.{ "--refresh", "--all" }),
+    );
+}
+
+test "execute --refresh --all with only failed rows does not gate the apply" {
+    // Pre-seed a row whose remote 404s. `--all` walks it, surfaces the
+    // failure, but the no-moved-rows path still exits cleanly without
+    // requiring `--yes`. Confirms the `anyMoved` gate is failure-tolerant.
+    const prefix = try setupPrefix("refresh_all_failed_only");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const db_path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "{s}/db/malt.db",
+        .{prefix},
+        0,
+    );
+    defer testing.allocator.free(db_path);
+    {
+        var db = try malt.sqlite.Database.open(db_path);
+        defer db.close();
+        try malt.schema.initSchema(&db);
+        try malt.tap.add(
+            &db,
+            "user/repo",
+            "https://github.com/user/homebrew-repo",
+            "0123456789abcdef0123456789abcdef01234567",
+        );
+    }
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{
+        .io = threaded.io(),
+        .environ = malt.app_ctx.processEnviron(),
+    };
+    // The remote 404s → row is `failed` → not gated → exit clean.
+    try tap_cli.execute(&ctx, testing.allocator, &.{ "--refresh", "--all" });
+}


### PR DESCRIPTION
## Description

Complete the tap-security story:

- `mt tap --pin <user/repo> <sha>` pins to a specific audited SHA; refuses unreachable SHAs by routing through GitHub's `commits/<sha>` endpoint (same `homebrew-<repo>` synthesis as install).
- `mt tap --refresh --all` walks every registered tap, prints a `old_sha[..7] -> new_sha[..7]` diff (or `--json` for scriptable audits), and refuses to apply without `--yes` when any tap moved. Per-row resolve failures are surfaced as `failed` and do not gate the apply step — there is nothing to write for a row we could not resolve.

`--json` emits the per-row shape `{"taps":[{"tap","old_sha","new_sha","status"}]}` for scriptable audits; `status` is one of `unchanged`, `moved`, or `failed`.

## Related Issue

- None

## Notes for Reviewers

- None