### PR TITLE
feat(cli): add mt cleanup shim for purge --housekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Commands:
   purge         Housekeeping or full wipe (--store-orphans, --unused-deps,
                 --cache, --downloads, --stale-casks, --old-versions,
                 --housekeeping, --wipe)
+  cleanup       Shorthand for `purge --housekeeping`
   services      Manage long-running launchd services (start/stop/status/logs)
   bundle        Install or export a Brewfile/Maltfile.json set of packages
   version       Show version (use 'version update' to self-update)
@@ -383,6 +384,8 @@ Shared flags: `--dry-run`/`-n` (preview), `--yes`/`-y` (skip typed-confirm), `--
 Structured output for scripts: `mt --json purge --<scope>...` emits a single summary object on stdout (`version`, `dry_run`, `scopes`, `totals`, `time_ms`); `mt --output-format=ndjson purge ...` streams `scope_started` / `scope_completed` / `purge_complete` events, one per line. Stderr stays the human surface in either mode.
 
 `--wipe` cannot combine with any other scope. Every other scope can run together under one lock acquisition. `mt purge` honours `MALT_PREFIX` and `MALT_CACHE`, so pointing those at a throwaway path is the safe way to test the command end-to-end. For per-package removal, use `mt uninstall`.
+
+`mt cleanup` is a Homebrew-shaped alias for `mt purge --housekeeping`: the safe daily-driver scope (`--store-orphans --unused-deps --cache --stale-casks`). Trailing flags pass through unchanged (`mt cleanup --dry-run`, `mt cleanup --cache=7 --yes`), so weekly muscle memory works while the full scope menu stays under `mt purge`.
 
 `mt link <formula>` and `mt unlink <formula>` manage the prefix symlinks. `link` reports conflicts and aborts unless `--overwrite`/`--force`/`-f` is passed. `unlink` removes symlinks from `bin/`, `lib/`, etc. and the `opt/` symlink, but leaves the keg installed.
 

--- a/build.zig
+++ b/build.zig
@@ -215,6 +215,7 @@ pub fn build(b: *std.Build) void {
         "tests/deps_cli_exec_test.zig",
         "tests/text_replace_test.zig",
         "tests/bottle_test.zig",
+        "tests/cleanup_cli_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/scripts/smokes/smoke_test.sh
+++ b/scripts/smokes/smoke_test.sh
@@ -155,7 +155,7 @@ fi
 
 # Per-command --help on everything documented.
 for cmd in install uninstall upgrade update outdated list info search uses deps which \
-  doctor purge tap untap migrate backup restore services bundle \
+  doctor purge cleanup tap untap migrate backup restore services bundle \
   rollback run link unlink pin unpin version completions shellenv; do
   run_ok "t1.help.$cmd" -- "$MT_BIN" "$cmd" --help
 done
@@ -301,6 +301,9 @@ else
   run_ok t3.purge.store.dry -- "$MT_BIN" purge --store-orphans --dry-run
   run_ok t3.purge.house.dry -- "$MT_BIN" purge --housekeeping --dry-run
   run_ok t3.purge.cache.dry -- "$MT_BIN" purge --cache=7 --dry-run
+  # `mt cleanup` shim — forwards to `purge --housekeeping`.
+  run_ok t3.cleanup.dry -- "$MT_BIN" cleanup --dry-run
+  run_ok t3.cleanup.cache.dry -- "$MT_BIN" cleanup --cache=7 --dry-run
 
   # Structured-output probes: prove the v1 wire format is parseable. Gated
   # on jq because not every smoke environment ships it.

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -87,7 +87,7 @@ pub const bash_script =
     \\    words=("${COMP_WORDS[@]}")
     \\    cword=$COMP_CWORD
     \\
-    \\    local commands="install uninstall remove upgrade update outdated list ls info search uses deps which doctor tap untap migrate rollback link unlink pin unpin run version completions shellenv backup restore purge services bundle help"
+    \\    local commands="install uninstall remove upgrade update outdated list ls info search uses deps which doctor tap untap migrate rollback link unlink pin unpin run version completions shellenv backup restore purge cleanup services bundle help"
     \\    local global_flags="--verbose -v --quiet -q --json --output-format=ndjson --dry-run --help -h --version"
     \\
     \\    # Find the first non-flag word after the program — that's the subcommand.
@@ -223,6 +223,7 @@ pub const zsh_script =
     \\        'backup:Dump installed packages to a restorable text file'
     \\        'restore:Reinstall every package listed in a backup file'
     \\        'purge:Housekeeping or full wipe (requires a scope flag)'
+    \\        'cleanup:Shorthand for purge --housekeeping (safe daily-driver)'
     \\        'services:Manage long-running launchd services'
     \\        'bundle:Install or export a Brewfile/Maltfile.json bundle'
     \\        'help:Show help'
@@ -506,6 +507,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n __malt_needs_command -a backup      -d 'Dump installed packages to a text file'
     \\    complete -c $__malt_bin -n __malt_needs_command -a restore     -d 'Reinstall every package in a backup file'
     \\    complete -c $__malt_bin -n __malt_needs_command -a purge       -d 'Housekeeping or full wipe (requires a scope)'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a cleanup     -d 'Shorthand for purge --housekeeping (safe daily-driver)'
     \\    complete -c $__malt_bin -n __malt_needs_command -a services    -d 'Manage long-running launchd services'
     \\    complete -c $__malt_bin -n __malt_needs_command -a bundle      -d 'Install or export a Brewfile/Maltfile.json'
     \\    complete -c $__malt_bin -n __malt_needs_command -a help        -d 'Show help'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -41,6 +41,7 @@ pub fn helpFor(command: []const u8) []const u8 {
         .{ "backup", backup_help },
         .{ "restore", restore_help },
         .{ "purge", purge_help },
+        .{ "cleanup", cleanup_help },
         .{ "uses", uses_help },
         .{ "deps", deps_help },
         .{ "which", which_help },
@@ -440,6 +441,31 @@ const purge_help =
     \\  malt purge --wipe --backup ~/malt-snapshot.txt --remove-binary --yes
     \\
     \\For per-package removal use `mt uninstall <name>`.
+    \\
+;
+
+const cleanup_help =
+    \\Usage: malt cleanup [flags]
+    \\
+    \\Shorthand for `malt purge --housekeeping` — the safe daily-driver
+    \\scope (store-orphans + unused-deps + cache + stale-casks). For the
+    \\full menu (downloads scrub, old-versions, wipe) use `mt purge`.
+    \\
+    \\Flags pass through to `purge`; the common ones:
+    \\  --dry-run, -n        Preview only
+    \\  --yes, -y            Skip every typed confirmation
+    \\  --quiet, -q          Suppress per-item output
+    \\  --verbose, -v        Show every per-scope item, full SHAs
+    \\  --cache=<DAYS>       Override the 30-day cache cutoff
+    \\  --backup, -b <path>  Write a `mt restore`-compatible manifest first
+    \\  --json               Single summary object on stdout
+    \\  --output-format=ndjson
+    \\                       One event per scope start/complete
+    \\
+    \\Examples:
+    \\  malt cleanup
+    \\  malt cleanup --dry-run
+    \\  malt cleanup --cache=7 --yes
     \\
 ;
 

--- a/src/cli/purge.zig
+++ b/src/cli/purge.zig
@@ -234,3 +234,17 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         output.success("removed {d} {s}, freed ~{s}", .{ grand_total.removed, item_noun, sz });
     }
 }
+
+/// `mt cleanup` shim — Homebrew-shaped verb that forwards to the safe
+/// daily-driver scope. Prepends `--housekeeping` so trailing flags
+/// (`--dry-run`, `--json`, ...) pass through unchanged. Intercepts
+/// `--help` first so users see the cleanup banner, not purge's.
+pub fn executeCleanup(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
+    if (help.showIfRequested(ctx, args, "cleanup")) return;
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(allocator);
+    try argv.ensureTotalCapacity(allocator, args.len + 1);
+    argv.appendAssumeCapacity("--housekeeping");
+    argv.appendSliceAssumeCapacity(args);
+    return execute(ctx, allocator, argv.items);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -126,6 +126,7 @@ const Command = enum {
     backup,
     restore,
     purge,
+    cleanup,
     services,
     bundle,
     uses,
@@ -165,6 +166,7 @@ const command_names = [_]struct {
     .{ .tag = .backup, .names = &.{"backup"} },
     .{ .tag = .restore, .names = &.{"restore"} },
     .{ .tag = .purge, .names = &.{"purge"} },
+    .{ .tag = .cleanup, .names = &.{"cleanup"} },
     .{ .tag = .services, .names = &.{"services"} },
     .{ .tag = .bundle, .names = &.{"bundle"} },
     .{ .tag = .uses, .names = &.{"uses"} },
@@ -268,6 +270,12 @@ test "applyGlobalFlag returns false for unrecognised flags" {
 test "dispatch accepts AppCtx and routes help without panic" {
     const ctx: AppCtx = .{ .io = std.Options.debug_io, .environ = .empty };
     try dispatch(std.testing.allocator, &ctx, .help, &.{});
+}
+
+test "command_map resolves cleanup to the cleanup tag" {
+    // `mt cleanup` is the Homebrew-shaped alias for `mt purge --housekeeping`.
+    // Pin the tag so a rename can't silently break the dispatch arm.
+    try std.testing.expectEqual(@as(?Command, .cleanup), command_map.get("cleanup"));
 }
 
 test "dispatch clears stale interrupt under the test runner" {
@@ -457,6 +465,7 @@ fn dispatch(allocator: std.mem.Allocator, ctx: *const AppCtx, cmd: Command, cmd_
         .backup => try backup.execute(ctx, allocator, cmd_args),
         .restore => try restore.execute(ctx, allocator, cmd_args),
         .purge => try purge.execute(ctx, allocator, cmd_args),
+        .cleanup => try purge.executeCleanup(ctx, allocator, cmd_args),
         .services => try services.execute(ctx, allocator, cmd_args),
         .bundle => try bundle.execute(ctx, allocator, cmd_args),
         .uses => try uses.execute(ctx, allocator, cmd_args),
@@ -511,6 +520,7 @@ fn printUsage(ctx: *const AppCtx) void {
         \\  purge         Housekeeping or full wipe (--store-orphans, --unused-deps,
         \\                --cache, --downloads, --stale-casks, --old-versions,
         \\                --housekeeping, --wipe)
+        \\  cleanup       Shorthand for `purge --housekeeping`
         \\  services      Manage long-running launchd services (start/stop/status/logs)
         \\  bundle        Install or export a Brewfile/Maltfile.json set of packages
         \\  version       Show version (use 'version update' to self-update)

--- a/tests/cleanup_cli_test.zig
+++ b/tests/cleanup_cli_test.zig
@@ -1,0 +1,243 @@
+//! malt — `mt cleanup` shim tests.
+//!
+//! `mt cleanup` is a one-line alias for `mt purge --housekeeping`. The
+//! contract is byte-identical output: every line the alias produces on
+//! stderr (the human surface) must match what the canonical invocation
+//! produces against the same scratch prefix.
+
+const std = @import("std");
+const malt = @import("malt");
+const test_io = @import("test_io");
+const testing = std.testing;
+const purge = malt.purge;
+const output = malt.output;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+const ScratchPrefix = struct {
+    path: [:0]u8,
+
+    fn init(allocator: std.mem.Allocator, tag: []const u8) !ScratchPrefix {
+        const ts = test_io.nanoTimestamp(std.Options.debug_io);
+        const path = try std.fmt.allocPrintSentinel(
+            allocator,
+            "/tmp/malt_cleanup_cli_{s}_{d}",
+            .{ tag, ts },
+            0,
+        );
+        test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, path);
+        const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});
+        defer allocator.free(db_dir);
+        try test_io.cwd().createDirPath(std.Options.debug_io, db_dir);
+        const cache_dir = try std.fmt.allocPrint(allocator, "{s}/cache", .{path});
+        defer allocator.free(cache_dir);
+        try test_io.cwd().createDirPath(std.Options.debug_io, cache_dir);
+
+        // Schema must exist — every housekeeping scope opens the DB.
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+
+        _ = c.setenv("MALT_PREFIX", path.ptr, 1);
+        return .{ .path = path };
+    }
+
+    fn deinit(self: *ScratchPrefix, allocator: std.mem.Allocator) void {
+        _ = c.unsetenv("MALT_PREFIX");
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.path) catch {};
+        allocator.free(self.path);
+    }
+};
+
+const OutputState = struct {
+    prior_mode: output.OutputMode,
+    prior_ndjson: bool,
+    prior_dry: bool,
+    prior_quiet: bool,
+
+    fn save() OutputState {
+        return .{
+            .prior_mode = if (output.isJson()) .json else .human,
+            .prior_ndjson = output.isNdjson(),
+            .prior_dry = output.isDryRun(),
+            .prior_quiet = output.isQuiet(),
+        };
+    }
+
+    fn restore(self: OutputState) void {
+        output.setMode(self.prior_mode);
+        output.setNdjson(self.prior_ndjson);
+        output.setDryRun(self.prior_dry);
+        output.setQuiet(self.prior_quiet);
+    }
+};
+
+// `mt cleanup` and `mt purge --housekeeping` must produce identical
+// stderr against an empty seeded prefix. Running both back-to-back in
+// dry-run keeps the prefix unchanged between calls.
+test "cleanup with no extra args matches purge --housekeeping byte-for-byte" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "noargs");
+    defer prefix.deinit(allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(true);
+    output.setNdjson(false);
+    output.setQuiet(false);
+
+    const ctx = malt.app_ctx.debug_ctx;
+
+    var ref_buf: std.ArrayList(u8) = .empty;
+    defer ref_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &ref_buf);
+    try purge.execute(&ctx, allocator, &.{"--housekeeping"});
+    output.endStderrCapture();
+
+    var shim_buf: std.ArrayList(u8) = .empty;
+    defer shim_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &shim_buf);
+    try purge.executeCleanup(&ctx, allocator, &.{});
+    output.endStderrCapture();
+
+    try testing.expectEqualStrings(ref_buf.items, shim_buf.items);
+}
+
+// `mt cleanup --help` must show cleanup's own help, not purge's. The
+// shim intercepts before forwarding so the verb the user typed is the
+// verb the help text names. Captures via a real fd so the byte stream
+// from `ctx.stdout.writeStreamingAll` lands somewhere readable.
+test "cleanup --help shows cleanup's help, not purge's" {
+    const allocator = testing.allocator;
+
+    const ts = test_io.nanoTimestamp(std.Options.debug_io);
+    const path = try std.fmt.allocPrintSentinel(
+        allocator,
+        "/tmp/malt_cleanup_help_{d}",
+        .{ts},
+        0,
+    );
+    defer allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+
+    const fd = std.c.open(path.ptr, .{ .ACCMODE = .RDWR, .CREAT = true, .TRUNC = true }, @as(std.c.mode_t, 0o644));
+    try testing.expect(fd >= 0);
+    defer _ = std.c.close(fd);
+
+    const ctx: malt.app_ctx.AppCtx = .{
+        .io = std.Options.debug_io,
+        .environ = .empty,
+        .stdout = .{ .handle = fd, .flags = .{ .nonblocking = false } },
+        .stderr = test_io.testSink(),
+    };
+
+    try purge.executeCleanup(&ctx, allocator, &.{"--help"});
+
+    // Read back from the start of the file.
+    _ = std.c.lseek(fd, 0, std.c.SEEK.SET);
+    var buf: [4096]u8 = undefined;
+    const n = std.c.read(fd, &buf, buf.len);
+    try testing.expect(n > 0);
+    const stdout = buf[0..@intCast(n)];
+
+    try testing.expect(std.mem.indexOf(u8, stdout, "malt cleanup") != null);
+    // Negative guard: purge's usage banner must not leak through.
+    try testing.expect(std.mem.indexOf(u8, stdout, "Usage: malt purge") == null);
+}
+
+// Defence against the alias quietly widening scope: `mt cleanup --wipe`
+// must be rejected the same way `mt purge --housekeeping --wipe` is, so
+// users can't accidentally promote the daily-driver verb to the nuclear
+// one by appending a flag.
+test "cleanup rejects --wipe (mutually exclusive scopes)" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "wipe_combo");
+    defer prefix.deinit(allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(true);
+    output.setQuiet(true);
+
+    const ctx = malt.app_ctx.debug_ctx;
+    try testing.expectError(
+        purge.Error.InvalidArgs,
+        purge.executeCleanup(&ctx, allocator, &.{"--wipe"}),
+    );
+}
+
+// A second `--housekeeping` on the alias must be idempotent — the args
+// parser tolerates duplicate scope flags and the resulting plan is the
+// same as a single `--housekeeping`. Pinned so a future "reject
+// duplicates" refactor doesn't break the alias.
+test "cleanup tolerates a redundant --housekeeping forwarded by users" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "double_house");
+    defer prefix.deinit(allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(true);
+    output.setQuiet(false);
+
+    const ctx = malt.app_ctx.debug_ctx;
+
+    var ref_buf: std.ArrayList(u8) = .empty;
+    defer ref_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &ref_buf);
+    try purge.executeCleanup(&ctx, allocator, &.{});
+    output.endStderrCapture();
+
+    var dup_buf: std.ArrayList(u8) = .empty;
+    defer dup_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &dup_buf);
+    try purge.executeCleanup(&ctx, allocator, &.{"--housekeeping"});
+    output.endStderrCapture();
+
+    try testing.expectEqualStrings(ref_buf.items, dup_buf.items);
+}
+
+// Passthrough check: trailing per-command flags after `cleanup` must
+// reach purge in the same order as if they followed `--housekeeping`
+// directly. `--cache=7` is a real per-command override (the global
+// `--dry-run` would be stripped upstream by `main`, so it can't ride
+// in via cmd_args).
+test "cleanup forwards --cache=N identically to purge --housekeeping --cache=N" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "cache_pass");
+    defer prefix.deinit(allocator);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(true);
+    output.setNdjson(false);
+    output.setQuiet(false);
+
+    const ctx = malt.app_ctx.debug_ctx;
+
+    var ref_buf: std.ArrayList(u8) = .empty;
+    defer ref_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &ref_buf);
+    try purge.execute(&ctx, allocator, &.{ "--housekeeping", "--cache=7" });
+    output.endStderrCapture();
+
+    var shim_buf: std.ArrayList(u8) = .empty;
+    defer shim_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &shim_buf);
+    try purge.executeCleanup(&ctx, allocator, &.{"--cache=7"});
+    output.endStderrCapture();
+
+    try testing.expectEqualStrings(ref_buf.items, shim_buf.items);
+}

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -42,8 +42,8 @@ const all_commands = [_][]const u8{
     "untap",   "migrate",     "rollback", "link",
     "unlink",  "pin",         "unpin",    "run",
     "version", "completions", "shellenv", "backup",
-    "restore", "purge",       "services", "bundle",
-    "which",   "deps",
+    "restore", "purge",       "cleanup",  "services",
+    "bundle",  "which",       "deps",
 };
 
 fn expectContains(haystack: []const u8, needle: []const u8) !void {
@@ -145,6 +145,15 @@ test "purge completions surface --json and --output-format=ndjson" {
     // surfaces as a purge-specific failure.
     try expectContains(completions.bash_script, "--output-format=ndjson");
     try expectContains(completions.fish_script, "output-format=ndjson");
+}
+
+test "all completions expose cleanup as a top-level verb" {
+    // `cleanup` already appears in every script as a `bundle cleanup`
+    // subcommand, so substring presence isn't enough — pin the
+    // top-level token shapes each shell uses for the verbs row.
+    try expectContains(completions.bash_script, "list ls info search uses deps which doctor tap untap migrate rollback link unlink pin unpin run version completions shellenv backup restore purge cleanup");
+    try expectContains(completions.zsh_script, "'cleanup:");
+    try expectContains(completions.fish_script, "__malt_needs_command -a cleanup");
 }
 
 test "all bundle completions expose the cleanup subcommand and its flags" {

--- a/tests/help_test.zig
+++ b/tests/help_test.zig
@@ -97,6 +97,21 @@ test "helpFor falls back gracefully for unknown commands" {
     try testing.expectEqualStrings("No help available.\n", help.helpFor("not-a-real-command"));
 }
 
+test "cleanup help advertises the shorthand and points at purge" {
+    // `mt cleanup` is a thin alias; --help has to make that explicit so
+    // users discover the full scope menu lives under `mt purge`.
+    const text = help.helpFor("cleanup");
+    try testing.expect(std.mem.indexOf(u8, text, "malt cleanup") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "--housekeeping") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "mt purge") != null);
+}
+
+test "showIfRequested honours --help for cleanup" {
+    const ctx = quietCtx();
+    const args = [_][]const u8{"--help"};
+    try testing.expect(help.showIfRequested(&ctx, &args, "cleanup"));
+}
+
 // Integration: verify that `malt <cmd> --help` writes to stdout (not stderr).
 // Relies on the pre-built binary under zig-out/bin/malt; skipped if absent.
 test "--help output lands on stdout, not stderr" {


### PR DESCRIPTION
## Description

Adds `mt cleanup` as a shorthand for `mt purge --housekeeping`, the safe daily-driver scope. The full purge menu remains under `mt purge`; the alias removes the "purge sounds scary" adoption friction for first-week converts.

## Related Issue

- None

## Notes for Reviewers

- One-line dispatch in `main.zig`; the byte-identical assertion in `tests/cleanup_cli_test.zig` is the contract.
