### PR TITLE
refactor(cli/doctor): point broken-symlink hint at mt cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ mt doctor --post-install-status          # check DSL support per installed formu
 | API reachable       | HEAD to `formulae.brew.sh` returns 2xx        | Warn: offline                            |
 | Orphaned store      | All store entries referenced by a keg         | Warn: suggest `mt purge --store-orphans` |
 | Missing kegs        | All DB keg paths exist on disk                | Error: suggest reinstall                 |
-| Broken symlinks     | All symlinks in bin/, lib/ etc. resolve       | Warn: suggest `mt purge --housekeeping`  |
+| Broken symlinks     | All symlinks in bin/, lib/ etc. resolve       | Warn: suggest `mt cleanup`               |
 | Disk space          | > 1 GB free on prefix volume                  | Warn: low disk space                     |
 | Post-install DSL    | All installed post_install formulae parseable | Warn: unsupported construct              |
 

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -592,9 +592,9 @@ fn checkBrokenSymlinks(ctx: CheckCtx, name: []const u8) CheckResult {
     var msg_buf: [256]u8 = undefined;
     const msg = std.fmt.bufPrint(
         &msg_buf,
-        "{d} broken symlink(s). Run: mt purge --housekeeping",
+        "{d} broken symlink(s). Run: mt cleanup",
         .{offenders.items.len},
-    ) catch "Broken symlinks found. Run: mt purge --housekeeping";
+    ) catch "Broken symlinks found. Run: mt cleanup";
     printCheck(name, .warn_status, msg);
     armVerboseHint();
     writeVerboseList(offenders.items);

--- a/tests/doctor_dispatch_test.zig
+++ b/tests/doctor_dispatch_test.zig
@@ -378,6 +378,8 @@ test "checkBrokenSymlinks without --verbose keeps the count summary only" {
 
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "1 broken symlink(s)") != null);
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "    - bin/ghost-default") == null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "Run: mt cleanup") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "purge --housekeeping") == null);
 }
 
 test "checkMachOPlaceholders without --verbose keeps the count + first-hint summary only" {
@@ -537,8 +539,8 @@ test "emitVerboseHintIfNeeded stays silent when --verbose is already active" {
     doctor.emitVerboseHintIfNeeded();
 
     // The "Run …" prefix on the existing fix hint (e.g.
-    // `Run: mt purge --housekeeping`) is unrelated; assert the
-    // nudge-specific phrase is absent.
+    // `Run: mt cleanup`) is unrelated; assert the nudge-specific
+    // phrase is absent.
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "for the full list") == null);
 }
 


### PR DESCRIPTION
## Description

Migrates `mt doctor`'s broken-symlink remediation hint from `Run: mt purge --housekeeping` to the Homebrew-shaped alias `Run: mt cleanup`. 

## Related Issue

- None

## Notes for Reviewers

- None