### PR TITLE
feat(cli): emit --json on tap, services, backup

### DIFF
--- a/src/cli/backup.zig
+++ b/src/cli/backup.zig
@@ -86,6 +86,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     defer aw.deinit();
     const w = &aw.writer;
 
+    if (output.isJson()) return executeJson(ctx, allocator, &db, output_path);
+
     try writeHeader(w);
     var count: usize = 0;
 
@@ -163,6 +165,76 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     output.success("Backup written to {s} ({d} packages)", .{ default_path, count });
 }
 
+/// `--json` path: gather direct formulas + casks (with their `tap`
+/// field) and emit `{formulas:[...],casks:[...]}` to stdout, or to
+/// `--output <path>`. Plain-text contract is untouched so `mt restore`
+/// keeps parsing the human form.
+fn executeJson(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    output_path: ?[]const u8,
+) Error!void {
+    // Arena owns every per-row dupe — one `deinit` reclaims them all and
+    // keeps the gather loop free of per-field errdefer plumbing.
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var formulas: std.ArrayList(JsonFormula) = .empty;
+    var casks: std.ArrayList(JsonCask) = .empty;
+
+    var fstmt = db.prepare(
+        "SELECT name, version FROM kegs " ++
+            "WHERE install_reason = 'direct' " ++
+            "ORDER BY name;",
+    ) catch null;
+    if (fstmt) |*s| {
+        defer s.finalize();
+        while (s.step() catch false) {
+            const name_ptr = s.columnText(0) orelse continue;
+            const ver_ptr = s.columnText(1);
+            const name = a.dupe(u8, std.mem.sliceTo(name_ptr, 0)) catch return Error.WriteFailed;
+            const version = a.dupe(u8, if (ver_ptr) |p| std.mem.sliceTo(p, 0) else "") catch
+                return Error.WriteFailed;
+            formulas.append(a, .{ .name = name, .version = version }) catch
+                return Error.WriteFailed;
+        }
+    }
+
+    var cstmt = db.prepare("SELECT token, version, tap FROM casks ORDER BY token;") catch null;
+    if (cstmt) |*s| {
+        defer s.finalize();
+        while (s.step() catch false) {
+            const name_ptr = s.columnText(0) orelse continue;
+            const ver_ptr = s.columnText(1);
+            const tap_ptr = s.columnText(2);
+            const name = a.dupe(u8, std.mem.sliceTo(name_ptr, 0)) catch return Error.WriteFailed;
+            const version = a.dupe(u8, if (ver_ptr) |p| std.mem.sliceTo(p, 0) else "") catch
+                return Error.WriteFailed;
+            const tap = a.dupe(u8, if (tap_ptr) |p| std.mem.sliceTo(p, 0) else "") catch
+                return Error.WriteFailed;
+            casks.append(a, .{ .name = name, .version = version, .tap = tap }) catch
+                return Error.WriteFailed;
+        }
+    }
+
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    writeBackupJson(&aw.writer, formulas.items, casks.items) catch return Error.WriteFailed;
+    const bytes = aw.written();
+
+    if (output_path) |p| {
+        if (std.mem.eql(u8, p, "-")) {
+            output.writeStdoutAll(bytes);
+            return;
+        }
+        try writeToPath(ctx, p, bytes);
+        return;
+    }
+    output.writeStdoutAll(bytes);
+}
+
 fn writeToPath(ctx: *const AppCtx, path: []const u8, bytes: []const u8) Error!void {
     // Create parent directories when the user supplied a nested path.
     if (std.fs.path.dirname(path)) |dir| {
@@ -191,6 +263,52 @@ fn writeToPath(ctx: *const AppCtx, path: []const u8, bytes: []const u8) Error!vo
         };
     defer file.close(ctx.io);
     file.writeStreamingAll(ctx.io, bytes) catch return Error.WriteFailed;
+}
+
+/// Plain-data view of one formula row for the `--json` writer.
+pub const JsonFormula = struct {
+    name: []const u8,
+    version: []const u8,
+};
+
+/// Plain-data view of one cask row for the `--json` writer. `tap` is the
+/// owning tap label (`""` for a core-API cask). The bare token stays in
+/// `name` — consumers can re-qualify themselves; the plain-text writer
+/// keeps doing the qualification because `mt restore` parses bare names.
+pub const JsonCask = struct {
+    name: []const u8,
+    version: []const u8,
+    tap: []const u8,
+};
+
+/// Emit `{ "formulas":[...], "casks":[...] }\n` for `mt backup --json`.
+/// Both arrays are always present so consumers don't branch on absence.
+pub fn writeBackupJson(
+    w: *std.Io.Writer,
+    formulas: []const JsonFormula,
+    casks: []const JsonCask,
+) !void {
+    try w.writeAll("{\"formulas\":[");
+    for (formulas, 0..) |f, i| {
+        if (i != 0) try w.writeAll(",");
+        try w.writeAll("{\"name\":");
+        try output.jsonStr(w, f.name);
+        try w.writeAll(",\"version\":");
+        try output.jsonStr(w, f.version);
+        try w.writeAll("}");
+    }
+    try w.writeAll("],\"casks\":[");
+    for (casks, 0..) |c, i| {
+        if (i != 0) try w.writeAll(",");
+        try w.writeAll("{\"name\":");
+        try output.jsonStr(w, c.name);
+        try w.writeAll(",\"version\":");
+        try output.jsonStr(w, c.version);
+        try w.writeAll(",\"tap\":");
+        try output.jsonStr(w, c.tap);
+        try w.writeAll("}");
+    }
+    try w.writeAll("]}\n");
 }
 
 /// Write the canonical header block at the top of a backup file.

--- a/src/cli/services.zig
+++ b/src/cli/services.zig
@@ -14,6 +14,35 @@ pub const ServicesError = error{
     SupervisorError,
 };
 
+/// One row in the `--json` listing; mirrors what the human path already
+/// renders (`name`, runtime state, auto-start hint, owning keg). Kept
+/// `pub` so tests can pin the exact bytes without staging a DB.
+pub const JsonRow = struct {
+    name: []const u8,
+    state: []const u8,
+    auto_start: bool,
+    keg_name: []const u8,
+};
+
+/// Emit `[{name,state,auto_start,keg_name},...]\n` for
+/// `mt services list --json` and `mt services status <name> --json`.
+pub fn writeServicesJson(w: *std.Io.Writer, rows: []const JsonRow) !void {
+    try w.writeAll("[");
+    for (rows, 0..) |row, i| {
+        if (i != 0) try w.writeAll(",");
+        try w.writeAll("{\"name\":");
+        try output.jsonStr(w, row.name);
+        try w.writeAll(",\"state\":");
+        try output.jsonStr(w, row.state);
+        try w.writeAll(",\"auto_start\":");
+        try w.writeAll(if (row.auto_start) "true" else "false");
+        try w.writeAll(",\"keg_name\":");
+        try output.jsonStr(w, row.keg_name);
+        try w.writeAll("}");
+    }
+    try w.writeAll("]\n");
+}
+
 pub fn describeError(err: ServicesError) []const u8 {
     return switch (err) {
         ServicesError.InvalidArgs => "invalid argument to `services`",
@@ -84,6 +113,9 @@ fn cmdOne(io: std.Io, allocator: std.mem.Allocator, db: *sqlite.Database, rest: 
 fn cmdList(io: std.Io, allocator: std.mem.Allocator, db: *sqlite.Database) !void {
     const items = try supervisor.list(.{ .allocator = allocator, .io = io, .db = db });
     defer supervisor.freeServiceInfos(allocator, items);
+
+    if (output.isJson()) return emitJson(io, allocator, items);
+
     if (items.len == 0) {
         output.info("no services registered", .{});
         return;
@@ -107,8 +139,40 @@ fn cmdStatus(io: std.Io, allocator: std.mem.Allocator, db: *sqlite.Database, res
         output.err("no such service: {s}", .{name});
         return ServicesError.SupervisorError;
     }
+    if (output.isJson()) {
+        // Reuse `supervisor.list` filtered down to `name`, so the JSON shape
+        // matches `list --json` (single-element array, identical fields).
+        const items = try supervisor.list(.{ .allocator = allocator, .io = io, .db = db });
+        defer supervisor.freeServiceInfos(allocator, items);
+        var picked: std.ArrayList(supervisor.ServiceInfo) = .empty;
+        defer picked.deinit(allocator);
+        for (items) |s| if (std.mem.eql(u8, s.name, name)) try picked.append(allocator, s);
+        return emitJson(io, allocator, picked.items);
+    }
     const runtime = supervisor.queryRuntime(io, allocator, name);
     output.info("service {s}: {s}", .{ name, supervisor.runtimeStateName(runtime) });
+}
+
+/// Render the supervisor's list of services as `--json`. Runtime state
+/// is probed per row; `queryRuntime` returns `.not_loaded` on launchctl
+/// errors so the field is always a textual tag, never a numeric code.
+fn emitJson(io: std.Io, allocator: std.mem.Allocator, items: []const supervisor.ServiceInfo) !void {
+    var rows: std.ArrayList(JsonRow) = .empty;
+    defer rows.deinit(allocator);
+    try rows.ensureTotalCapacityPrecise(allocator, items.len);
+    for (items) |s| {
+        const state = supervisor.runtimeStateName(supervisor.queryRuntime(io, allocator, s.name));
+        rows.appendAssumeCapacity(.{
+            .name = s.name,
+            .state = state,
+            .auto_start = s.auto_start,
+            .keg_name = s.keg_name,
+        });
+    }
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try writeServicesJson(&aw.writer, rows.items);
+    output.writeStdoutAll(aw.written());
 }
 
 fn cmdLogs(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []const u8) !void {
@@ -158,6 +222,30 @@ fn openDb(ctx: *const AppCtx) !sqlite.Database {
     const path = std.fmt.bufPrintSentinel(&path_buf, "{s}/malt.db", .{db_dir}, 0) catch
         return ServicesError.DatabaseError;
     return sqlite.Database.open(path);
+}
+
+test "writeServicesJson: empty input emits `[]\\n`" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeServicesJson(&aw.writer, &.{});
+    try std.testing.expectEqualStrings("[]\n", aw.written());
+}
+
+test "writeServicesJson: emits name, state, auto_start, keg_name per row" {
+    const rows = [_]JsonRow{
+        .{ .name = "redis", .state = "running", .auto_start = true, .keg_name = "redis" },
+        .{ .name = "postgres", .state = "not-loaded", .auto_start = false, .keg_name = "postgresql@16" },
+    };
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeServicesJson(&aw.writer, &rows);
+    try std.testing.expectEqualStrings(
+        "[" ++
+            "{\"name\":\"redis\",\"state\":\"running\",\"auto_start\":true,\"keg_name\":\"redis\"}," ++
+            "{\"name\":\"postgres\",\"state\":\"not-loaded\",\"auto_start\":false,\"keg_name\":\"postgresql@16\"}" ++
+            "]\n",
+        aw.written(),
+    );
 }
 
 fn printHelp(ctx: *const AppCtx) !void {

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -82,6 +82,24 @@ fn writeRefreshRowText(w: *std.Io.Writer, row: RefreshRow) !void {
     }
 }
 
+/// Emit `[{ "name", "url", "commit_sha" }, ...]\n` for `mt tap --json`.
+/// `commit_sha` is `null` when the tap is unpinned. Kept `pub` so tests can
+/// pin the exact bytes without staging a DB or running the dispatcher.
+pub fn writeTapListJson(w: *std.Io.Writer, taps: []const tap_mod.TapInfo) !void {
+    try w.writeAll("[");
+    for (taps, 0..) |t, i| {
+        if (i != 0) try w.writeAll(",");
+        try w.writeAll("{\"name\":");
+        try output.jsonStr(w, t.name);
+        try w.writeAll(",\"url\":");
+        try output.jsonStr(w, t.url);
+        try w.writeAll(",\"commit_sha\":");
+        if (t.commit_sha) |sha| try output.jsonStr(w, sha) else try w.writeAll("null");
+        try w.writeAll("}");
+    }
+    try w.writeAll("]\n");
+}
+
 fn writeRefreshRowsJson(w: *std.Io.Writer, rows: []const RefreshRow) !void {
     try w.writeAll("{\"taps\":[");
     for (rows, 0..) |row, i| {
@@ -256,6 +274,43 @@ test "writeRefreshRowsJson: emits `{taps:[{tap,old_sha,new_sha,status},...]}`" {
     );
 }
 
+test "writeTapListJson: empty input emits `[]\\n`" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeTapListJson(&aw.writer, &.{});
+    try std.testing.expectEqualStrings("[]\n", aw.written());
+}
+
+test "writeTapListJson: escapes embedded quotes/backslashes in url so output is valid JSON" {
+    const rows = [_]tap_mod.TapInfo{
+        .{ .name = "user/repo", .url = "https://x/\"weird\\path\"", .commit_sha = null },
+    };
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeTapListJson(&aw.writer, &rows);
+    try std.testing.expectEqualStrings(
+        "[{\"name\":\"user/repo\",\"url\":\"https://x/\\\"weird\\\\path\\\"\",\"commit_sha\":null}]\n",
+        aw.written(),
+    );
+}
+
+test "writeTapListJson: emits `name`, `url`, `commit_sha` per tap; null when unpinned" {
+    const rows = [_]tap_mod.TapInfo{
+        .{ .name = "user/repo", .url = "https://github.com/user/homebrew-repo", .commit_sha = sha_old },
+        .{ .name = "x/y", .url = "https://github.com/x/homebrew-y", .commit_sha = null },
+    };
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeTapListJson(&aw.writer, &rows);
+    try std.testing.expectEqualStrings(
+        "[" ++
+            "{\"name\":\"user/repo\",\"url\":\"https://github.com/user/homebrew-repo\",\"commit_sha\":\"" ++ sha_old ++ "\"}," ++
+            "{\"name\":\"x/y\",\"url\":\"https://github.com/x/homebrew-y\",\"commit_sha\":null}" ++
+            "]\n",
+        aw.written(),
+    );
+}
+
 test "writeRefreshRowsJson: empty input emits `{\"taps\":[]}`" {
     var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
@@ -325,10 +380,17 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
 
     const prefix = atomic.maltPrefixOrAbort();
 
+    // Listing-intent under `--json` needs a parseable empty array even on a
+    // fresh prefix where `db/` doesn't exist — otherwise `jq` chokes on
+    // silently-empty stdout. Detect intent from already-parsed argv.
+    const is_listing = positional == null and pin_slug == null and
+        refresh_target == null and !refresh_all;
+
     var db_path_buf: [512]u8 = undefined;
     const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
     var db = sqlite.Database.open(db_path) catch {
         // Fresh prefix with no `db/` yet = no taps registered.
+        if (is_listing and output.isJson()) output.writeStdoutAll("[]\n");
         return;
     };
     defer db.close();
@@ -367,7 +429,24 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
             output.err("Failed to list taps", .{});
             return error.Aborted;
         };
-        defer allocator.free(taps);
+        defer {
+            for (taps) |t| {
+                allocator.free(t.name);
+                allocator.free(t.url);
+                if (t.commit_sha) |sha| allocator.free(sha);
+            }
+            allocator.free(taps);
+        }
+
+        if (output.isJson()) {
+            // Route through `output.writeStdoutAll` so tests can capture the
+            // payload; one writeAll keeps a closed pipe from tearing the doc.
+            var aw: std.Io.Writer.Allocating = .init(allocator);
+            defer aw.deinit();
+            try writeTapListJson(&aw.writer, taps);
+            output.writeStdoutAll(aw.written());
+            return;
+        }
 
         if (taps.len == 0) {
             output.info("No taps registered", .{});
@@ -381,9 +460,6 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
             const line = formatTapLine(allocator, t) catch "";
             defer if (line.len != 0) allocator.free(line);
             ctx.stdout.writeStreamingAll(ctx.io, line) catch {};
-            allocator.free(t.name);
-            allocator.free(t.url);
-            if (t.commit_sha) |sha| allocator.free(sha);
         }
         return;
     }

--- a/tests/backup_cli_test.zig
+++ b/tests/backup_cli_test.zig
@@ -264,6 +264,196 @@ test "execute -q sets quiet mode without breaking the write" {
 // backup line must carry the `user/repo/token` slug shape that
 // `installTapFormula` resolves. The bare-token form is preserved for
 // core-API casks so backups produced before schema v6 keep working.
+// --- --json dispatch -------------------------------------------------
+//
+// Under `--json` the default path emits to stdout (no default file), so
+// CI pipelines that already use `jq` don't have to clean up a stale
+// `malt-backup-*.txt` after each call. The plain-text path stays
+// unchanged to preserve `mt restore` parity.
+
+fn withJson() bool {
+    const prior = output.isJson();
+    output.setMode(.json);
+    return prior;
+}
+
+fn restoreJson(prior: bool) void {
+    output.setMode(if (prior) .json else .human);
+}
+
+test "execute --json on an empty DB emits `{formulas:[],casks:[]}`" {
+    var s = try Scratch.init(testing.allocator, "json_empty");
+    defer s.deinit(testing.allocator);
+
+    const prior = withJson();
+    defer restoreJson(prior);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    quiet();
+    defer unquiet();
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{});
+
+    try testing.expectEqualStrings("{\"formulas\":[],\"casks\":[]}\n", stdout_buf.items);
+}
+
+test "execute --json on a populated DB emits direct formulas + casks with tap" {
+    var s = try Scratch.init(testing.allocator, "json_populated");
+    defer s.deinit(testing.allocator);
+    try seedRows(s.path);
+
+    const prior = withJson();
+    defer restoreJson(prior);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    quiet();
+    defer unquiet();
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{});
+
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"name\":\"wget\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"name\":\"jq\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"name\":\"firefox\"") != null);
+    // Dep-only row excluded — `mt restore` pulls deps transitively.
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"name\":\"zlib\"") == null);
+    try testing.expect(std.mem.startsWith(u8, stdout_buf.items, "{\"formulas\":["));
+    try testing.expect(std.mem.endsWith(u8, stdout_buf.items, "]}\n"));
+}
+
+test "execute --json output is a parseable JSON document" {
+    var s = try Scratch.init(testing.allocator, "json_valid_parse");
+    defer s.deinit(testing.allocator);
+    try seedRows(s.path);
+
+    const prior = withJson();
+    defer restoreJson(prior);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    quiet();
+    defer unquiet();
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{});
+
+    // Hand the captured bytes to the standard JSON parser; anything other
+    // than a clean parse means we shipped malformed output.
+    const trimmed = std.mem.trim(u8, stdout_buf.items, " \t\r\n");
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, trimmed, .{});
+    defer parsed.deinit();
+
+    const root = parsed.value.object;
+    try testing.expect(root.contains("formulas"));
+    try testing.expect(root.contains("casks"));
+    try testing.expectEqual(@as(usize, 2), root.get("formulas").?.array.items.len);
+    try testing.expectEqual(@as(usize, 1), root.get("casks").?.array.items.len);
+}
+
+test "execute --json keeps the cask `tap` field separate (no token qualification)" {
+    var s = try Scratch.init(testing.allocator, "json_tap");
+    defer s.deinit(testing.allocator);
+    try seedTapCask(s.path);
+
+    const prior = withJson();
+    defer restoreJson(prior);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    quiet();
+    defer unquiet();
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{});
+
+    // Bare token + separate `tap` field — consumers re-qualify themselves.
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"name\":\"flux-markdown\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"tap\":\"xykong/tap\"") != null);
+    // The slash-qualified shape belongs to plain-text only — must not leak in.
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "xykong/tap/flux-markdown") == null);
+    // Core-API cask: empty `tap` field.
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"name\":\"firefox\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"name\":\"firefox\",\"version\":\"120.0\",\"tap\":\"\"") != null);
+}
+
+test "execute --json --versions is a no-op (version is already a field, not a suffix)" {
+    var s = try Scratch.init(testing.allocator, "json_versions");
+    defer s.deinit(testing.allocator);
+    try seedRows(s.path);
+
+    const prior = withJson();
+    defer restoreJson(prior);
+
+    var with_buf: std.ArrayList(u8) = .empty;
+    defer with_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &with_buf);
+    quiet();
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{"--versions"});
+    output.endStdoutCapture();
+
+    var without_buf: std.ArrayList(u8) = .empty;
+    defer without_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &without_buf);
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{});
+    output.endStdoutCapture();
+    unquiet();
+
+    try testing.expectEqualStrings(with_buf.items, without_buf.items);
+    // No `name@version` suffix may bleed in from the plain-text writer.
+    try testing.expect(std.mem.indexOf(u8, with_buf.items, "wget@") == null);
+    try testing.expect(std.mem.indexOf(u8, with_buf.items, "firefox@") == null);
+}
+
+test "execute --json --output - emits to stdout instead of a default file" {
+    var s = try Scratch.init(testing.allocator, "json_stdout");
+    defer s.deinit(testing.allocator);
+    try seedRows(s.path);
+
+    const prior = withJson();
+    defer restoreJson(prior);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    quiet();
+    defer unquiet();
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--output", "-" });
+
+    try testing.expect(std.mem.startsWith(u8, stdout_buf.items, "{\"formulas\":["));
+    try testing.expect(std.mem.endsWith(u8, stdout_buf.items, "]}\n"));
+}
+
+test "execute --json with --output <path> writes JSON to the file" {
+    var s = try Scratch.init(testing.allocator, "json_to_path");
+    defer s.deinit(testing.allocator);
+    try seedRows(s.path);
+
+    const out_path = try std.fmt.allocPrint(testing.allocator, "{s}/snap.json", .{s.path});
+    defer testing.allocator.free(out_path);
+
+    const prior = withJson();
+    defer restoreJson(prior);
+
+    quiet();
+    defer unquiet();
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--output", out_path });
+
+    const body = try readAll(testing.allocator, out_path);
+    defer testing.allocator.free(body);
+    try testing.expect(std.mem.startsWith(u8, body, "{\"formulas\":["));
+    try testing.expect(std.mem.endsWith(u8, body, "]}\n"));
+    try testing.expect(std.mem.indexOf(u8, body, "\"name\":\"wget\"") != null);
+}
+
 fn seedTapCask(prefix: []const u8) !void {
     var db_path_buf: [512]u8 = undefined;
     const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);

--- a/tests/backup_test.zig
+++ b/tests/backup_test.zig
@@ -215,6 +215,37 @@ test "writeEntry + parseBackup round-trip preserves every entry" {
 
 // ── defaultBackupPath ────────────────────────────────────────────────────
 
+test "writeBackupJson: empty inputs emit `{formulas:[],casks:[]}\\n`" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try backup.writeBackupJson(&aw.writer, &.{}, &.{});
+    try testing.expectEqualStrings("{\"formulas\":[],\"casks\":[]}\n", aw.written());
+}
+
+test "writeBackupJson: emits `name`/`version` for formulas and `name`/`version`/`tap` for casks" {
+    const formulas = [_]backup.JsonFormula{
+        .{ .name = "wget", .version = "1.21" },
+        .{ .name = "jq", .version = "1.7" },
+    };
+    const casks = [_]backup.JsonCask{
+        .{ .name = "firefox", .version = "120.0", .tap = "" },
+        .{ .name = "flux-markdown", .version = "0.1.0", .tap = "xykong/tap" },
+    };
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try backup.writeBackupJson(&aw.writer, &formulas, &casks);
+    try testing.expectEqualStrings(
+        "{\"formulas\":[" ++
+            "{\"name\":\"wget\",\"version\":\"1.21\"}," ++
+            "{\"name\":\"jq\",\"version\":\"1.7\"}" ++
+            "],\"casks\":[" ++
+            "{\"name\":\"firefox\",\"version\":\"120.0\",\"tap\":\"\"}," ++
+            "{\"name\":\"flux-markdown\",\"version\":\"0.1.0\",\"tap\":\"xykong/tap\"}" ++
+            "]}\n",
+        aw.written(),
+    );
+}
+
 test "defaultBackupPath has the expected shape" {
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();

--- a/tests/cli_services_test.zig
+++ b/tests/cli_services_test.zig
@@ -116,6 +116,194 @@ test "execute start/stop/restart with wrong arity returns InvalidArgs" {
     }
 }
 
+test "execute list --json on a prefix with no db/ directory emits `[]`" {
+    // `openDb` auto-creates `db/` and the sqlite file. CI consumers piping
+    // through `jq` need a parseable empty array on first run.
+    const path = "/tmp/malt_cli_services_fresh_no_db";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    _ = c.setenv("MALT_PREFIX", path, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const prior_json = malt.output.isJson();
+    malt.output.setMode(.json);
+    defer malt.output.setMode(if (prior_json) .json else .human);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    malt.output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer malt.output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try services_cli.execute(&ctx, testing.allocator, &.{"list"});
+    try testing.expectEqualStrings("[]\n", stdout_buf.items);
+}
+
+test "execute list --json on an empty DB emits `[]`" {
+    const prefix = try setupPrefix("list_empty_json");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const prior_json = malt.output.isJson();
+    malt.output.setMode(.json);
+    defer malt.output.setMode(if (prior_json) .json else .human);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    malt.output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer malt.output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try services_cli.execute(&ctx, testing.allocator, &.{"list"});
+    try testing.expectEqualStrings("[]\n", stdout_buf.items);
+
+    // `status` with no name routes through cmdList; under --json it must
+    // emit the same empty array so consumers can rely on a single shape.
+    stdout_buf.clearRetainingCapacity();
+    try services_cli.execute(&ctx, testing.allocator, &.{"status"});
+    try testing.expectEqualStrings("[]\n", stdout_buf.items);
+}
+
+fn seedService(prefix: []const u8, name: []const u8, keg: []const u8, auto_start: bool) !void {
+    var path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+
+    var stmt = try db.prepare(
+        \\INSERT INTO services(name, keg_name, plist_path, auto_start, last_status)
+        \\VALUES (?, ?, '/dev/null', ?, 'registered');
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    try stmt.bindText(2, keg);
+    try stmt.bindInt(3, if (auto_start) 1 else 0);
+    _ = try stmt.step();
+}
+
+test "execute list --json on a populated DB emits one object per row" {
+    const prefix = try setupPrefix("list_populated_json");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+    try seedService(prefix, "redis", "redis", true);
+    try seedService(prefix, "postgres", "postgresql@16", false);
+
+    const prior_json = malt.output.isJson();
+    malt.output.setMode(.json);
+    defer malt.output.setMode(if (prior_json) .json else .human);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    malt.output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer malt.output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try services_cli.execute(&ctx, testing.allocator, &.{"list"});
+
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"name\":\"redis\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"keg_name\":\"redis\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"auto_start\":true") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"name\":\"postgres\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"keg_name\":\"postgresql@16\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"auto_start\":false") != null);
+    // Runtime probe is best-effort on non-macOS / when launchctl misses;
+    // it still must surface a textual state, never a numeric code.
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"state\":\"") != null);
+    try testing.expect(std.mem.startsWith(u8, stdout_buf.items, "["));
+    try testing.expect(std.mem.endsWith(u8, stdout_buf.items, "]\n"));
+}
+
+test "execute list --json output is a parseable JSON array" {
+    const prefix = try setupPrefix("list_json_parse");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+    try seedService(prefix, "redis", "redis", true);
+
+    const prior_json = malt.output.isJson();
+    malt.output.setMode(.json);
+    defer malt.output.setMode(if (prior_json) .json else .human);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    malt.output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer malt.output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try services_cli.execute(&ctx, testing.allocator, &.{"list"});
+
+    const trimmed = std.mem.trim(u8, stdout_buf.items, " \t\r\n");
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, trimmed, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(usize, 1), parsed.value.array.items.len);
+    const row = parsed.value.array.items[0].object;
+    try testing.expectEqualStrings("redis", row.get("name").?.string);
+    try testing.expectEqualStrings("redis", row.get("keg_name").?.string);
+    try testing.expectEqual(true, row.get("auto_start").?.bool);
+    // `state` is whatever launchctl reports — must be a string, not int.
+    try testing.expect(row.get("state").? == .string);
+}
+
+test "execute status <name> --json emits a single-element array" {
+    const prefix = try setupPrefix("status_populated_json");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+    try seedService(prefix, "redis", "redis", true);
+
+    const prior_json = malt.output.isJson();
+    malt.output.setMode(.json);
+    defer malt.output.setMode(if (prior_json) .json else .human);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    malt.output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer malt.output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try services_cli.execute(&ctx, testing.allocator, &.{ "status", "redis" });
+
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"name\":\"redis\"") != null);
+    // Only one row in the array — pin the bracketing so `postgres` (not
+    // seeded here) can't sneak in via a typo in the filter SQL.
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "postgres") == null);
+    try testing.expect(std.mem.startsWith(u8, stdout_buf.items, "[{"));
+    try testing.expect(std.mem.endsWith(u8, stdout_buf.items, "}]\n"));
+}
+
+test "execute status <missing> --json still surfaces SupervisorError" {
+    const prefix = try setupPrefix("status_missing_json");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const prior_json = malt.output.isJson();
+    malt.output.setMode(.json);
+    defer malt.output.setMode(if (prior_json) .json else .human);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try testing.expectError(
+        error.SupervisorError,
+        services_cli.execute(&ctx, testing.allocator, &.{ "status", "nope" }),
+    );
+}
+
 test "execute logs with no args returns InvalidArgs" {
     const prefix = try setupPrefix("logs_noargs");
     defer testing.allocator.free(prefix);

--- a/tests/cli_tap_test.zig
+++ b/tests/cli_tap_test.zig
@@ -43,6 +43,150 @@ test "execute with no args prints an empty list (no taps registered)" {
     try tap_cli.execute(&ctx, testing.allocator, &.{});
 }
 
+test "execute with --json on a prefix with no db/ directory still emits `[]`" {
+    // Fresh MALT_PREFIX where the `db/` dir doesn't exist yet: `sqlite.open`
+    // fails. CI consumers piping through `jq` need a parseable empty array,
+    // not silently-empty stdout.
+    const path = "/tmp/malt_cli_tap_fresh_no_db";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    _ = c.setenv("MALT_PREFIX", path, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const prior_json = malt.output.isJson();
+    malt.output.setMode(.json);
+    defer malt.output.setMode(if (prior_json) .json else .human);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    malt.output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer malt.output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try tap_cli.execute(&ctx, testing.allocator, &.{});
+    try testing.expectEqualStrings("[]\n", stdout_buf.items);
+}
+
+test "execute with --json on an empty DB emits `[]`" {
+    const prefix = try setupPrefix("list_empty_json");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const prior_json = malt.output.isJson();
+    malt.output.setMode(.json);
+    defer malt.output.setMode(if (prior_json) .json else .human);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    malt.output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer malt.output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try tap_cli.execute(&ctx, testing.allocator, &.{});
+    try testing.expectEqualStrings("[]\n", stdout_buf.items);
+}
+
+test "execute with --json output is a parseable JSON array" {
+    const prefix = try setupPrefix("list_json_parse");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const db_path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "{s}/db/malt.db",
+        .{prefix},
+        0,
+    );
+    defer testing.allocator.free(db_path);
+    {
+        var db = try malt.sqlite.Database.open(db_path);
+        defer db.close();
+        try malt.schema.initSchema(&db);
+        try malt.tap.add(
+            &db,
+            "user/repo",
+            "https://github.com/user/homebrew-repo",
+            "0123456789abcdef0123456789abcdef01234567",
+        );
+    }
+
+    const prior_json = malt.output.isJson();
+    malt.output.setMode(.json);
+    defer malt.output.setMode(if (prior_json) .json else .human);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    malt.output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer malt.output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try tap_cli.execute(&ctx, testing.allocator, &.{});
+
+    const trimmed = std.mem.trim(u8, stdout_buf.items, " \t\r\n");
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, trimmed, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(usize, 1), parsed.value.array.items.len);
+    try testing.expectEqualStrings("user/repo", parsed.value.array.items[0].object.get("name").?.string);
+}
+
+test "execute with --json on a populated DB emits one object per tap" {
+    const prefix = try setupPrefix("list_populated_json");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const db_path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "{s}/db/malt.db",
+        .{prefix},
+        0,
+    );
+    defer testing.allocator.free(db_path);
+    {
+        var db = try malt.sqlite.Database.open(db_path);
+        defer db.close();
+        try malt.schema.initSchema(&db);
+        try malt.tap.add(
+            &db,
+            "user/repo",
+            "https://github.com/user/homebrew-repo",
+            "0123456789abcdef0123456789abcdef01234567",
+        );
+        try malt.tap.add(&db, "x/y", "https://github.com/x/homebrew-y", null);
+    }
+
+    const prior_json = malt.output.isJson();
+    malt.output.setMode(.json);
+    defer malt.output.setMode(if (prior_json) .json else .human);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    malt.output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer malt.output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try tap_cli.execute(&ctx, testing.allocator, &.{});
+
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"name\":\"user/repo\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"url\":\"https://github.com/user/homebrew-repo\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"commit_sha\":\"0123456789abcdef0123456789abcdef01234567\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"name\":\"x/y\"") != null);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"commit_sha\":null") != null);
+    try testing.expect(std.mem.startsWith(u8, stdout_buf.items, "["));
+    try testing.expect(std.mem.endsWith(u8, stdout_buf.items, "]\n"));
+}
+
 test "execute with unresolvable user/repo aborts (no network pin = no add)" {
     const prefix = try setupPrefix("unresolvable");
     defer testing.allocator.free(prefix);


### PR DESCRIPTION
## Description

Finishes the "every read path is scriptable" contract by extending `--json` to `mt tap`, `mt services list`, `mt services status`, and
`mt backup`. CI pipelines that pipe malt output through `jq` no longer hit a wall on these three commands.

## Related Issue

- None

## Notes for Reviewers

- None