### PR TITLE
feat(cli/bundle): include taps and services in dump

### DIFF
--- a/src/cli/backup.zig
+++ b/src/cli/backup.zig
@@ -44,6 +44,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     var output_path: ?[]const u8 = null;
     var include_versions = false;
+    var include_services = false;
 
     var i: usize = 0;
     while (i < args.len) : (i += 1) {
@@ -59,6 +60,9 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             output_path = arg["--output=".len..];
         } else if (std.mem.eql(u8, arg, "--versions")) {
             include_versions = true;
+        } else if (std.mem.eql(u8, arg, "--services")) {
+            // Honoured by the JSON writer below; plain-text has no service line.
+            include_services = true;
         } else if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
             output.setQuiet(true);
         } else {
@@ -86,7 +90,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     defer aw.deinit();
     const w = &aw.writer;
 
-    if (output.isJson()) return executeJson(ctx, allocator, &db, output_path);
+    if (output.isJson()) return executeJson(ctx, allocator, &db, output_path, include_services);
 
     try writeHeader(w);
     var count: usize = 0;
@@ -174,6 +178,7 @@ fn executeJson(
     allocator: std.mem.Allocator,
     db: *sqlite.Database,
     output_path: ?[]const u8,
+    include_services: bool,
 ) Error!void {
     // Arena owns every per-row dupe — one `deinit` reclaims them all and
     // keeps the gather loop free of per-field errdefer plumbing.
@@ -183,6 +188,7 @@ fn executeJson(
 
     var formulas: std.ArrayList(JsonFormula) = .empty;
     var casks: std.ArrayList(JsonCask) = .empty;
+    var services: std.ArrayList(JsonService) = .empty;
 
     var fstmt = db.prepare(
         "SELECT name, version FROM kegs " ++
@@ -219,9 +225,24 @@ fn executeJson(
         }
     }
 
+    if (include_services) {
+        var sstmt = db.prepare("SELECT name FROM services WHERE auto_start = 1 ORDER BY name;") catch null;
+        if (sstmt) |*st| {
+            defer st.finalize();
+            while (st.step() catch false) {
+                const name_ptr = st.columnText(0) orelse continue;
+                const name = a.dupe(u8, std.mem.sliceTo(name_ptr, 0)) catch return Error.WriteFailed;
+                services.append(a, .{ .name = name, .auto_start = true }) catch
+                    return Error.WriteFailed;
+            }
+        }
+    }
+
     var aw: std.Io.Writer.Allocating = .init(allocator);
     defer aw.deinit();
-    writeBackupJson(&aw.writer, formulas.items, casks.items) catch return Error.WriteFailed;
+    const services_opt: ?[]const JsonService = if (include_services) services.items else null;
+    writeBackupJson(&aw.writer, formulas.items, casks.items, services_opt) catch
+        return Error.WriteFailed;
     const bytes = aw.written();
 
     if (output_path) |p| {
@@ -281,12 +302,23 @@ pub const JsonCask = struct {
     tap: []const u8,
 };
 
+/// Plain-data view of one service row for the `--json` writer. Only
+/// emitted when `--services` is passed; consumers reproduce auto-start
+/// state on restore.
+pub const JsonService = struct {
+    name: []const u8,
+    auto_start: bool,
+};
+
 /// Emit `{ "formulas":[...], "casks":[...] }\n` for `mt backup --json`.
-/// Both arrays are always present so consumers don't branch on absence.
+/// `formulas` and `casks` are always present so consumers don't branch
+/// on absence; `services` is added only when the caller opts in, which
+/// keeps default payloads byte-identical to pre-`--services` malt.
 pub fn writeBackupJson(
     w: *std.Io.Writer,
     formulas: []const JsonFormula,
     casks: []const JsonCask,
+    services: ?[]const JsonService,
 ) !void {
     try w.writeAll("{\"formulas\":[");
     for (formulas, 0..) |f, i| {
@@ -308,7 +340,20 @@ pub fn writeBackupJson(
         try output.jsonStr(w, c.tap);
         try w.writeAll("}");
     }
-    try w.writeAll("]}\n");
+    try w.writeAll("]");
+    if (services) |list| {
+        try w.writeAll(",\"services\":[");
+        for (list, 0..) |sv, i| {
+            if (i != 0) try w.writeAll(",");
+            try w.writeAll("{\"name\":");
+            try output.jsonStr(w, sv.name);
+            try w.writeAll(",\"auto_start\":");
+            try w.writeAll(if (sv.auto_start) "true" else "false");
+            try w.writeAll("}");
+        }
+        try w.writeAll("]");
+    }
+    try w.writeAll("}\n");
 }
 
 /// Write the canonical header block at the top of a backup file.

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -317,6 +317,7 @@ fn cmdRemove(ctx: *const AppCtx, rest: []const []const u8) !void {
 fn cmdCreate(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []const u8) !void {
     var format: Format = .brewfile;
     var out_path: []const u8 = "Brewfile";
+    var include_services = false;
     var i: usize = 0;
     while (i < rest.len) : (i += 1) {
         const a = rest[i];
@@ -324,6 +325,8 @@ fn cmdCreate(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []c
             i += 1;
             format = parseFormat(rest[i]) orelse return BundleError.InvalidArgs;
             if (format == .json) out_path = "Maltfile.json";
+        } else if (std.mem.eql(u8, a, "--services")) {
+            include_services = true;
         } else if (!std.mem.startsWith(u8, a, "-")) {
             out_path = a;
         }
@@ -334,7 +337,7 @@ fn cmdCreate(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []c
 
     var manifest = manifest_mod.Manifest.init(allocator);
     defer manifest.deinit();
-    try populateFromInstalled(&manifest, &db);
+    try populateFromInstalled(&manifest, &db, .{ .include_services = include_services });
     try writeManifest(ctx, manifest, out_path, format);
     output.success("wrote {s}", .{out_path});
 }
@@ -342,12 +345,15 @@ fn cmdCreate(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []c
 fn cmdExport(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []const u8) !void {
     var format: Format = .brewfile;
     var bundle_name: ?[]const u8 = null;
+    var include_services = false;
     var i: usize = 0;
     while (i < rest.len) : (i += 1) {
         const a = rest[i];
         if (std.mem.eql(u8, a, "--format") and i + 1 < rest.len) {
             i += 1;
             format = parseFormat(rest[i]) orelse return BundleError.InvalidArgs;
+        } else if (std.mem.eql(u8, a, "--services")) {
+            include_services = true;
         } else if (!std.mem.startsWith(u8, a, "-")) {
             bundle_name = a;
         }
@@ -361,7 +367,7 @@ fn cmdExport(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []c
     if (bundle_name) |n| {
         try populateFromBundle(&manifest, &db, n);
     } else {
-        try populateFromInstalled(&manifest, &db);
+        try populateFromInstalled(&manifest, &db, .{ .include_services = include_services });
     }
 
     var write_buf: [4096]u8 = undefined;
@@ -486,10 +492,32 @@ fn writeManifest(
     w.flush() catch return BundleError.WriteFailed;
 }
 
-fn populateFromInstalled(manifest: *manifest_mod.Manifest, db: *sqlite.Database) !void {
+/// Options for `populateFromInstalled`. Taps round-trip unconditionally
+/// (Brewfile carries them and a missing tap silently breaks restore);
+/// services opt in via `--services` because they encode runtime state.
+const PopulateOpts = struct {
+    include_services: bool = false,
+};
+
+fn populateFromInstalled(
+    manifest: *manifest_mod.Manifest,
+    db: *sqlite.Database,
+    opts: PopulateOpts,
+) !void {
     const a = manifest.allocator();
+    var taps: std.ArrayList([]const u8) = .empty;
     var formulas: std.ArrayList(manifest_mod.FormulaEntry) = .empty;
     var casks: std.ArrayList(manifest_mod.CaskEntry) = .empty;
+    var services: std.ArrayList(manifest_mod.ServiceEntry) = .empty;
+
+    var t = db.prepare("SELECT name FROM taps ORDER BY name;") catch
+        return BundleError.DatabaseError;
+    defer t.finalize();
+    while (t.step() catch false) {
+        const n = t.columnText(0) orelse continue;
+        const name = a.dupe(u8, std.mem.sliceTo(n, 0)) catch return BundleError.DatabaseError;
+        taps.append(a, name) catch return BundleError.DatabaseError;
+    }
 
     var f = db.prepare("SELECT name FROM kegs WHERE install_reason='direct' ORDER BY name;") catch
         return BundleError.DatabaseError;
@@ -509,8 +537,22 @@ fn populateFromInstalled(manifest: *manifest_mod.Manifest, db: *sqlite.Database)
         casks.append(a, .{ .name = name }) catch return BundleError.DatabaseError;
     }
 
+    if (opts.include_services) {
+        var s = db.prepare("SELECT name FROM services WHERE auto_start = 1 ORDER BY name;") catch
+            return BundleError.DatabaseError;
+        defer s.finalize();
+        while (s.step() catch false) {
+            const n = s.columnText(0) orelse continue;
+            const name = a.dupe(u8, std.mem.sliceTo(n, 0)) catch return BundleError.DatabaseError;
+            services.append(a, .{ .name = name, .auto_start = true }) catch
+                return BundleError.DatabaseError;
+        }
+    }
+
+    manifest.taps = taps.toOwnedSlice(a) catch return BundleError.DatabaseError;
     manifest.formulas = formulas.toOwnedSlice(a) catch return BundleError.DatabaseError;
     manifest.casks = casks.toOwnedSlice(a) catch return BundleError.DatabaseError;
+    manifest.services = services.toOwnedSlice(a) catch return BundleError.DatabaseError;
     manifest.version = manifest_mod.schema_version;
 }
 
@@ -575,12 +617,14 @@ fn printHelp(ctx: *const AppCtx) !void {
         \\  install [file]              Install formulae/casks/taps/services from a Brewfile or Maltfile.json.
         \\  cleanup [--yes] [--dry-run] [file]
         \\                              Uninstall packages present on disk but absent from the Brewfile.
-        \\  create  [--format brewfile|json] [path]
+        \\  create  [--format brewfile|json] [--services] [path]
         \\                              Write currently-installed set to a bundle file.
+        \\                              --services also emits auto-start services (JSON only).
         \\  list                        List bundles registered in the database.
         \\  remove <name>               Unregister a bundle (does NOT uninstall members).
-        \\  export  [--format brewfile|json] [name]
+        \\  export  [--format brewfile|json] [--services] [name]
         \\                              Print bundle (or current install) to stdout.
+        \\                              --services also emits auto-start services (JSON only).
         \\  import  <file>              Register a bundle definition without installing.
         \\
         \\Lookup order for install/export without an explicit path:

--- a/tests/backup_cli_test.zig
+++ b/tests/backup_cli_test.zig
@@ -432,6 +432,160 @@ test "execute --json --output - emits to stdout instead of a default file" {
     try testing.expect(std.mem.endsWith(u8, stdout_buf.items, "]}\n"));
 }
 
+// --- --services round-trip -------------------------------------------
+//
+// `mt bundle export` populates services into the manifest; the JSON
+// surface of `mt backup` mirrors the behaviour so dotfiles workflows
+// can capture launchd state in one shot. Plain-text backups stay
+// untouched — the canonical file format has no `service` line.
+
+fn seedServices(prefix: []const u8) !void {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO services (name, keg_name, plist_path, auto_start, last_status)
+        \\VALUES ('postgresql@16', 'postgresql@16', '/tmp/p.plist', 1, 'running'),
+        \\       ('redis',         'redis',         '/tmp/r.plist', 0, 'stopped');
+    );
+}
+
+test "execute --json --services emits auto_start services only" {
+    var s = try Scratch.init(testing.allocator, "json_services");
+    defer s.deinit(testing.allocator);
+    try seedServices(s.path);
+
+    const prior = withJson();
+    defer restoreJson(prior);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    quiet();
+    defer unquiet();
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{"--services"});
+
+    const trimmed = std.mem.trim(u8, stdout_buf.items, " \t\r\n");
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, trimmed, .{});
+    defer parsed.deinit();
+    const services = parsed.value.object.get("services") orelse return error.MissingServices;
+    try testing.expectEqual(@as(usize, 1), services.array.items.len);
+    try testing.expectEqualStrings("postgresql@16", services.array.items[0].object.get("name").?.string);
+    try testing.expect(services.array.items[0].object.get("auto_start").?.bool);
+}
+
+test "execute --json without --services omits the services array" {
+    var s = try Scratch.init(testing.allocator, "json_no_services");
+    defer s.deinit(testing.allocator);
+    try seedServices(s.path);
+
+    const prior = withJson();
+    defer restoreJson(prior);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    quiet();
+    defer unquiet();
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{});
+
+    const trimmed = std.mem.trim(u8, stdout_buf.items, " \t\r\n");
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, trimmed, .{});
+    defer parsed.deinit();
+    try testing.expect(parsed.value.object.get("services") == null);
+}
+
+test "execute --json --services on an empty services table emits `services:[]`" {
+    // Pins the explicit-empty contract: when the user asks for
+    // services and there are none, the array still appears so a
+    // downstream consumer can branch on `services` length, not on
+    // its absence.
+    var s = try Scratch.init(testing.allocator, "json_services_empty");
+    defer s.deinit(testing.allocator);
+    // schema init only; no services seeded.
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+    }
+
+    const prior = withJson();
+    defer restoreJson(prior);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    quiet();
+    defer unquiet();
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{"--services"});
+
+    try testing.expectEqualStrings(
+        "{\"formulas\":[],\"casks\":[],\"services\":[]}\n",
+        stdout_buf.items,
+    );
+}
+
+test "execute --json --services composes with --versions and --output -" {
+    // Combined-flag smoke: arg parser is order-independent and the
+    // services payload still rides on stdout-mode output.
+    var s = try Scratch.init(testing.allocator, "json_services_combined");
+    defer s.deinit(testing.allocator);
+    try seedServices(s.path);
+    try seedRows(s.path);
+
+    const prior = withJson();
+    defer restoreJson(prior);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    quiet();
+    defer unquiet();
+    try backup.execute(
+        &malt.app_ctx.debug_ctx,
+        testing.allocator,
+        &.{ "--versions", "--services", "--output", "-" },
+    );
+
+    const trimmed = std.mem.trim(u8, stdout_buf.items, " \t\r\n");
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, trimmed, .{});
+    defer parsed.deinit();
+    try testing.expect(parsed.value.object.get("services") != null);
+    try testing.expect(parsed.value.object.get("formulas") != null);
+    try testing.expect(parsed.value.object.get("casks") != null);
+}
+
+test "execute --services on plain-text backup is a silent no-op (no `service` line)" {
+    var s = try Scratch.init(testing.allocator, "text_services_noop");
+    defer s.deinit(testing.allocator);
+    try seedServices(s.path);
+
+    const out_path = try std.fmt.allocPrint(testing.allocator, "{s}/snap.txt", .{s.path});
+    defer testing.allocator.free(out_path);
+
+    quiet();
+    defer unquiet();
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--services", "--output", out_path });
+
+    const body = try readAll(testing.allocator, out_path);
+    defer testing.allocator.free(body);
+    try testing.expect(std.mem.indexOf(u8, body, "service ") == null);
+    try testing.expect(std.mem.indexOf(u8, body, "postgresql@16") == null);
+}
+
 test "execute --json with --output <path> writes JSON to the file" {
     var s = try Scratch.init(testing.allocator, "json_to_path");
     defer s.deinit(testing.allocator);

--- a/tests/backup_test.zig
+++ b/tests/backup_test.zig
@@ -218,7 +218,7 @@ test "writeEntry + parseBackup round-trip preserves every entry" {
 test "writeBackupJson: empty inputs emit `{formulas:[],casks:[]}\\n`" {
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
-    try backup.writeBackupJson(&aw.writer, &.{}, &.{});
+    try backup.writeBackupJson(&aw.writer, &.{}, &.{}, null);
     try testing.expectEqualStrings("{\"formulas\":[],\"casks\":[]}\n", aw.written());
 }
 
@@ -233,7 +233,7 @@ test "writeBackupJson: emits `name`/`version` for formulas and `name`/`version`/
     };
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
-    try backup.writeBackupJson(&aw.writer, &formulas, &casks);
+    try backup.writeBackupJson(&aw.writer, &formulas, &casks, null);
     try testing.expectEqualStrings(
         "{\"formulas\":[" ++
             "{\"name\":\"wget\",\"version\":\"1.21\"}," ++
@@ -242,6 +242,20 @@ test "writeBackupJson: emits `name`/`version` for formulas and `name`/`version`/
             "{\"name\":\"firefox\",\"version\":\"120.0\",\"tap\":\"\"}," ++
             "{\"name\":\"flux-markdown\",\"version\":\"0.1.0\",\"tap\":\"xykong/tap\"}" ++
             "]}\n",
+        aw.written(),
+    );
+}
+
+test "writeBackupJson: appends services array only when caller opts in" {
+    const services = [_]backup.JsonService{
+        .{ .name = "postgresql@16", .auto_start = true },
+    };
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try backup.writeBackupJson(&aw.writer, &.{}, &.{}, &services);
+    try testing.expectEqualStrings(
+        "{\"formulas\":[],\"casks\":[]," ++
+            "\"services\":[{\"name\":\"postgresql@16\",\"auto_start\":true}]}\n",
         aw.written(),
     );
 }

--- a/tests/bundle_cli_test.zig
+++ b/tests/bundle_cli_test.zig
@@ -340,3 +340,164 @@ test "export --format json with no installed packages emits a JSON body" {
 
     try bundle.execute(&ctx, testing.allocator, &.{ "export", "--format", "json" });
 }
+
+// --- round-trip: taps + services in `bundle create` -------------------
+//
+// `bundle export → bundle install` previously dropped taps and auto-
+// start services silently. These pin the population path in
+// `populateFromInstalled`. `create` writes the manifest to a file we
+// can read back; `export` shares the same helper.
+
+fn seedTapsAndServices(prefix: []const u8) !void {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO taps (name, url)
+        \\VALUES ('homebrew/cask-fonts', 'https://github.com/Homebrew/homebrew-cask-fonts'),
+        \\       ('xykong/tap',          'https://github.com/xykong/homebrew-tap');
+    );
+    try db.exec(
+        \\INSERT INTO services (name, keg_name, plist_path, auto_start, last_status)
+        \\VALUES ('postgresql@16', 'postgresql@16', '/tmp/p.plist', 1, 'running'),
+        \\       ('redis',         'redis',         '/tmp/r.plist', 0, 'stopped');
+    );
+}
+
+test "bundle create --format json emits registered taps in the manifest" {
+    var s = try Scratch.init(testing.allocator, "create_taps");
+    defer s.deinit(testing.allocator);
+    try seedTapsAndServices(s.path);
+
+    const out_path = try std.fmt.allocPrint(testing.allocator, "{s}/Maltfile.json", .{s.path});
+    defer testing.allocator.free(out_path);
+
+    quiet();
+    defer unquiet();
+    try bundle.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "create", "--format", "json", out_path });
+
+    const f = try test_io.openFileAbsolute(std.Options.debug_io, out_path, .{});
+    defer f.close(std.Options.debug_io);
+    const stat = try f.stat(std.Options.debug_io);
+    const body = try testing.allocator.alloc(u8, stat.size);
+    defer testing.allocator.free(body);
+    _ = try f.readPositionalAll(std.Options.debug_io, body, 0);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, body, .{});
+    defer parsed.deinit();
+    const taps = parsed.value.object.get("taps") orelse return error.MissingTaps;
+    try testing.expectEqual(@as(usize, 2), taps.array.items.len);
+    try testing.expectEqualStrings("homebrew/cask-fonts", taps.array.items[0].string);
+    try testing.expectEqualStrings("xykong/tap", taps.array.items[1].string);
+}
+
+test "bundle create --format json --services emits auto_start services only" {
+    var s = try Scratch.init(testing.allocator, "create_services");
+    defer s.deinit(testing.allocator);
+    try seedTapsAndServices(s.path);
+
+    const out_path = try std.fmt.allocPrint(testing.allocator, "{s}/Maltfile.json", .{s.path});
+    defer testing.allocator.free(out_path);
+
+    quiet();
+    defer unquiet();
+    try bundle.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "create", "--format", "json", "--services", out_path });
+
+    const f = try test_io.openFileAbsolute(std.Options.debug_io, out_path, .{});
+    defer f.close(std.Options.debug_io);
+    const stat = try f.stat(std.Options.debug_io);
+    const body = try testing.allocator.alloc(u8, stat.size);
+    defer testing.allocator.free(body);
+    _ = try f.readPositionalAll(std.Options.debug_io, body, 0);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, body, .{});
+    defer parsed.deinit();
+    const services = parsed.value.object.get("services") orelse return error.MissingServices;
+    try testing.expectEqual(@as(usize, 1), services.array.items.len);
+    const svc = services.array.items[0].object;
+    try testing.expectEqualStrings("postgresql@16", svc.get("name").?.string);
+    try testing.expect(svc.get("auto_start").?.bool);
+}
+
+test "bundle create --format json without --services omits services" {
+    var s = try Scratch.init(testing.allocator, "create_no_services");
+    defer s.deinit(testing.allocator);
+    try seedTapsAndServices(s.path);
+
+    const out_path = try std.fmt.allocPrint(testing.allocator, "{s}/Maltfile.json", .{s.path});
+    defer testing.allocator.free(out_path);
+
+    quiet();
+    defer unquiet();
+    try bundle.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "create", "--format", "json", out_path });
+
+    const f = try test_io.openFileAbsolute(std.Options.debug_io, out_path, .{});
+    defer f.close(std.Options.debug_io);
+    const stat = try f.stat(std.Options.debug_io);
+    const body = try testing.allocator.alloc(u8, stat.size);
+    defer testing.allocator.free(body);
+    _ = try f.readPositionalAll(std.Options.debug_io, body, 0);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, body, .{});
+    defer parsed.deinit();
+    try testing.expect(parsed.value.object.get("services") == null);
+}
+
+test "bundle create --format brewfile --services accepts the flag but emits no service line" {
+    // Brewfile grammar has no `service` directive; the help text says
+    // services are JSON-only. Pin that the flag is accepted (no
+    // InvalidArgs) and silently drops services from the textual output.
+    var s = try Scratch.init(testing.allocator, "create_brewfile_services");
+    defer s.deinit(testing.allocator);
+    try seedTapsAndServices(s.path);
+
+    const out_path = try std.fmt.allocPrint(testing.allocator, "{s}/Brewfile", .{s.path});
+    defer testing.allocator.free(out_path);
+
+    quiet();
+    defer unquiet();
+    try bundle.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "create", "--format", "brewfile", "--services", out_path });
+
+    const f = try test_io.openFileAbsolute(std.Options.debug_io, out_path, .{});
+    defer f.close(std.Options.debug_io);
+    const stat = try f.stat(std.Options.debug_io);
+    const body = try testing.allocator.alloc(u8, stat.size);
+    defer testing.allocator.free(body);
+    _ = try f.readPositionalAll(std.Options.debug_io, body, 0);
+
+    // Taps still land (Brewfile grammar has `tap`); services do not.
+    try testing.expect(std.mem.indexOf(u8, body, "tap \"homebrew/cask-fonts\"") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "postgresql@16") == null);
+    try testing.expect(std.mem.indexOf(u8, body, "service ") == null);
+}
+
+test "bundle create round-trip: emitted JSON re-parses with taps preserved" {
+    var s = try Scratch.init(testing.allocator, "create_roundtrip");
+    defer s.deinit(testing.allocator);
+    try seedTapsAndServices(s.path);
+
+    const out_path = try std.fmt.allocPrint(testing.allocator, "{s}/Maltfile.json", .{s.path});
+    defer testing.allocator.free(out_path);
+
+    quiet();
+    defer unquiet();
+    try bundle.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "create", "--format", "json", "--services", out_path });
+
+    const f = try test_io.openFileAbsolute(std.Options.debug_io, out_path, .{});
+    defer f.close(std.Options.debug_io);
+    const stat = try f.stat(std.Options.debug_io);
+    const body = try testing.allocator.alloc(u8, stat.size);
+    defer testing.allocator.free(body);
+    _ = try f.readPositionalAll(std.Options.debug_io, body, 0);
+
+    var m = try malt.bundle_manifest.parseJson(testing.allocator, body);
+    defer m.deinit();
+    try testing.expectEqual(@as(usize, 2), m.taps.len);
+    try testing.expectEqualStrings("homebrew/cask-fonts", m.taps[0]);
+    try testing.expectEqual(@as(usize, 1), m.services.len);
+    try testing.expectEqualStrings("postgresql@16", m.services[0].name);
+    try testing.expect(m.services[0].auto_start);
+}


### PR DESCRIPTION
## Description

Closes the bundle round-trip gap: `mt bundle export`, `mt bundle create`, and `mt backup --json` now populate the manifest's `taps[]` and `services[]` fields from the live install. A user's dotfiles workflow no longer silently drops third-party taps or auto-start services.

Taps round-trip unconditionally (Brewfile already carries them and a missing tap silently breaks restore). Services are opt-in via a new `--services` flag - matches `brew bundle dump --services`, avoids flipping launchd state on a user who only wanted a package snapshot, and keeps default output byte-identical to pre-change malt.

## Related Issue

- None

## Notes for Reviewers

- None