### PR TITLE
refactor(core/patch): expose text-file patching via the facade

### DIFF
--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -5,12 +5,8 @@ const std = @import("std");
 const clonefile = @import("../fs/clonefile.zig");
 // Binary-format-agnostic relocation facade. The Linux task plugs in
 // an ELF backend behind the same surface, so cellar never reaches past
-// it into `macho/patcher.zig` for load-command work.
+// it into `macho/patcher.zig` for either load-command or text-file work.
 const patch = @import("patch.zig");
-// `patchTextFiles` is byte-level text substitution, not a format
-// concern, so it still lives on the Mach-O module — safe to import
-// directly without widening the facade.
-const text_patcher = @import("../macho/patcher.zig");
 const codesign = @import("../macho/codesign.zig");
 const atomic = @import("../fs/atomic.zig");
 const relocated_store = @import("relocated_store.zig");
@@ -360,13 +356,13 @@ fn relocateKegTree(
         else => return CellarError.PatchFailed,
     };
 
-    const text_replacements = [_]text_patcher.Replacement{
+    const text_replacements = [_]patch.Replacement{
         .{ .old = "@@HOMEBREW_PREFIX@@", .new = new_prefix },
         .{ .old = "@@HOMEBREW_CELLAR@@", .new = new_cellar },
         .{ .old = "/opt/homebrew", .new = new_prefix },
         .{ .old = "/usr/local", .new = new_prefix },
     };
-    _ = text_patcher.patchTextFiles(io, allocator, cellar_path, &text_replacements) catch |e| {
+    _ = patch.patchTextFiles(io, allocator, cellar_path, &text_replacements) catch |e| {
         std.log.warn("text patching failed for {s}: {s}", .{ cellar_path, @errorName(e) });
     };
 

--- a/src/core/patch.zig
+++ b/src/core/patch.zig
@@ -23,6 +23,7 @@ pub const OverflowEntry = backend.OverflowEntry;
 pub const PatchError = backend.PatchError;
 pub const FallbackError = backend.FallbackError;
 pub const patchPathsCollecting = backend.patchPathsCollecting;
+pub const patchTextFiles = backend.patchTextFiles;
 pub const flushOverflow = backend.flushOverflow;
 pub const external_tool_name = backend.external_tool_name;
 
@@ -33,6 +34,7 @@ test "facade re-exports the patcher surface cellar / doctor rely on" {
     _ = PatchError;
     _ = FallbackError;
     _ = patchPathsCollecting;
+    _ = patchTextFiles;
     _ = flushOverflow;
     _ = external_tool_name;
 }
@@ -42,7 +44,8 @@ test "facade external_tool_name matches the macOS backend" {
     try std.testing.expectEqualStrings(backend.external_tool_name, external_tool_name);
 }
 
-test "facade OverflowEntry / PatchOutcome are identical to the backend's" {
+test "facade Replacement / OverflowEntry / PatchOutcome are identical to the backend's" {
+    try std.testing.expect(Replacement == backend.Replacement);
     try std.testing.expect(OverflowEntry == backend.OverflowEntry);
     try std.testing.expect(PatchOutcome == backend.PatchOutcome);
 }


### PR DESCRIPTION
## Description

Routes `core/cellar.zig`'s text-file patching through `core/patch.zig` instead of importing `macho/patcher.zig` directly. The facade is now complete: every patch concern goes through one OS-dispatch seam.

## Related Issue

- None

## Notes for Reviewers

- Pure structural move; the test suite is the contract.
