### PR TITLE
fix(cli/install): make --force a reliable recovery path

### DIFF
--- a/scripts/regressions/install_force_sweeps_old_kegs.sh
+++ b/scripts/regressions/install_force_sweeps_old_kegs.sh
@@ -134,7 +134,6 @@ if echo "$DOCTOR_OUT" | grep -qE "keg\(s\) in DB but missing on disk"; then
 fi
 pass "doctor reports neither stale placeholder nor missing kegs"
 
-
 # ── Same-version --force must not bounce on the linker conflict ─────
 # Reproducer for the linker-side gap: with pcre2 freshly installed at
 # the resolved version, `--force` on the same version owns symlinks
@@ -151,7 +150,8 @@ pass "same-version force-install completed"
 pass "Cellar/pcre2/$KEEP still present after same-version force"
 
 DOCTOR_OUT=$("$BIN" doctor --verbose 2>&1 || true)
-if echo "$DOCTOR_OUT" | grep -qE "Broken symlinks" | grep -v "✓"; then
+# Match the warn-row body, not the "✓ Broken symlinks" check label.
+if echo "$DOCTOR_OUT" | grep -qE "broken symlink\(s\)"; then
   echo "$DOCTOR_OUT" >&2
   fail "doctor reports broken symlinks after same-version force"
 fi

--- a/scripts/regressions/install_force_sweeps_old_kegs.sh
+++ b/scripts/regressions/install_force_sweeps_old_kegs.sh
@@ -157,4 +157,28 @@ if echo "$DOCTOR_OUT" | grep -qE "broken symlink\(s\)"; then
 fi
 pass "doctor clean after same-version force"
 
+# ── Pin must migrate from stale revision to the new keg ─────────────
+# Re-stage a pinned stale row pointing at a non-existent dir (the
+# revision-bump shape) and assert that after --force the kegs table
+# carries the pin on the surviving row. Without the two-phase sweep,
+# COALESCE-MAX in recordKeg's INSERT OR REPLACE runs after the stale
+# row is gone and the new row lands with pinned=0.
+STALE_DIR2="$PREFIX/Cellar/pcre2/${STALE}-pinned"
+mkdir -p "$STALE_DIR2/lib"
+sqlite3 "$DB" "INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, pinned) VALUES ('pcre2', 'pcre2', '${STALE}-pinned', 0, '$(printf '%064d' 0)', '$STALE_DIR2', 1);"
+pass "seeded pinned stale row at $STALE_DIR2"
+
+printf '▸ malt install pcre2 --force (must migrate pin to new row)\n'
+"$BIN" install --force --quiet pcre2 || fail "pin-migration force-install failed"
+
+PIN_FLAG=$(sqlite3 "$DB" "SELECT pinned FROM kegs WHERE name = 'pcre2';")
+[[ "$PIN_FLAG" == "1" ]] ||
+  fail "pin lost after force-reinstall across pinned stale revision (pinned=$PIN_FLAG)"
+pass "pin survived the cross-revision force-reinstall"
+
+PINNED_STALE_PRESENT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM kegs WHERE name = 'pcre2' AND cellar_path = '$STALE_DIR2';")
+[[ "$PINNED_STALE_PRESENT" == "0" ]] ||
+  fail "stale pinned row survived the sweep — pin came from the wrong source"
+pass "stale pinned row dropped (pin migrated, not duplicated)"
+
 printf '\n✔ install-force-sweeps-old-kegs regression passed\n'

--- a/scripts/regressions/install_force_sweeps_old_kegs.sh
+++ b/scripts/regressions/install_force_sweeps_old_kegs.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Regression guard for the orphan-keg bug uncovered on a live machine.
+#
+# When a user has `<prefix>/Cellar/<name>/<old_version>/` on disk (e.g.
+# from a prior install before a revision bump landed) and runs
+# `malt install <name> --force`, the resolver picks the new revision
+# and materializes it at `<prefix>/Cellar/<name>/<old>_<rev>/`.
+# Before the fix, `pruneCellarForReinstall` only wiped the resolved
+# version dir; the old version dir was orphaned and `malt doctor`
+# would flag it as an unpatched Mach-O placeholder offender forever.
+# The fix adds `pruneOtherCellarVersionsForReinstall` which sweeps
+# any sibling version dirs under `Cellar/<name>/` when `--force`
+# fires.
+#
+# This script seeds the bug shape: pre-existing `Cellar/pcre2/<ver>/`
+# with a marker file, then runs `malt install pcre2 --force`, then
+# asserts the sibling is gone and the new revision is present.
+#
+# Usage: scripts/regressions/install_force_sweeps_old_kegs.sh
+# Requirements: built `malt` binary, network access to
+# formulae.brew.sh + ghcr.io.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+PREFIX="/tmp/mt_force_sweep"
+export MALT_PREFIX="$PREFIX"
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+skip() {
+  printf '  ⊘ %s\n' "$*"
+  exit 0
+}
+
+# ── Resolve current pcre2 version + revision from the live API ──────
+get_rev() {
+  curl -fsSL "https://formulae.brew.sh/api/formula/pcre2.json" |
+    python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('revision',0))"
+}
+get_ver() {
+  curl -fsSL "https://formulae.brew.sh/api/formula/pcre2.json" |
+    python3 -c "import sys,json; d=json.load(sys.stdin); print(d['versions']['stable'])"
+}
+
+REV=$(get_rev)
+VER=$(get_ver)
+if [[ "$REV" == "0" ]]; then
+  skip "pcre2 currently has revision 0 — rerun once a revision bump lands; nothing to sweep"
+fi
+
+KEEP="${VER}_${REV}"
+STALE="$VER"
+printf '▸ target: pcre2  (resolver picks %s; seeded stale = %s)\n' "$KEEP" "$STALE"
+
+# ── Seed pcre2 first so we have a real DB row + linker state at the
+# stale version, then surgically patch the row to claim it lives at
+# the plain-version dir. This mirrors the production shape: prior
+# install before a revision bump, with the kegs row still pointing at
+# /Cellar/<name>/<plain_version>/ (no `_<rev>` suffix). Pure mkdir +
+# manual INSERT cannot exercise the linker cleanup the way an actual
+# row tied to a linked keg does.
+printf '▸ malt install pcre2 (seed real DB row + symlinks)\n'
+"$BIN" install --quiet pcre2 || fail "seed install of pcre2 failed"
+
+DB="$PREFIX/db/malt.db"
+[[ -f "$DB" ]] || fail "seed failed: $DB missing"
+
+STALE_DIR="$PREFIX/Cellar/pcre2/$STALE"
+KEEP_DIR="$PREFIX/Cellar/pcre2/$KEEP"
+[[ -d "$KEEP_DIR" ]] || fail "seed install did not produce $KEEP_DIR"
+
+# Physically move the materialized keg to the plain-version path and
+# rewrite the DB row + every links row to point at it. We are
+# manufacturing the state a v4-era machine would have: kegs row +
+# real symlinks + cellar dir all pointing at /Cellar/pcre2/$STALE.
+mv "$KEEP_DIR" "$STALE_DIR"
+sqlite3 "$DB" "UPDATE kegs SET cellar_path = '$STALE_DIR' WHERE name = 'pcre2';"
+sqlite3 "$DB" "UPDATE links SET target = REPLACE(target, '/$KEEP/', '/$STALE/') WHERE keg_id IN (SELECT id FROM kegs WHERE name = 'pcre2');"
+# Repoint the opt symlink so the next install's linker conflict check
+# sees the stale keg as the live owner.
+rm -f "$PREFIX/opt/pcre2"
+ln -s "$STALE_DIR" "$PREFIX/opt/pcre2"
+pass "seeded Cellar/pcre2/$STALE + kegs row + links"
+
+ROW_COUNT_BEFORE=$(sqlite3 "$DB" "SELECT COUNT(*) FROM kegs WHERE name = 'pcre2';")
+[[ "$ROW_COUNT_BEFORE" == "1" ]] || fail "expected 1 pcre2 row before force; got $ROW_COUNT_BEFORE"
+
+# ── Run the actual force-install through the full pipeline ──────────
+printf '▸ malt install pcre2 --force (resolver picks %s, must sweep %s)\n' "$KEEP" "$STALE"
+"$BIN" install --force --quiet pcre2 || fail "force-install of pcre2 failed"
+pass "force-install of pcre2 completed"
+
+# ── Assert: stale dir + stale DB row both gone ──────────────────────
+[[ ! -d "$STALE_DIR" ]] ||
+  fail "Cellar/pcre2/$STALE still on disk after --force — disk sweep did not fire"
+pass "Cellar/pcre2/$STALE swept (disk)"
+
+ROW_COUNT_AFTER=$(sqlite3 "$DB" "SELECT COUNT(*) FROM kegs WHERE name = 'pcre2';")
+[[ "$ROW_COUNT_AFTER" == "1" ]] ||
+  fail "expected 1 pcre2 row after force; got $ROW_COUNT_AFTER (stale row not deleted)"
+pass "kegs has exactly one pcre2 row after force"
+
+STALE_ROW_PRESENT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM kegs WHERE name = 'pcre2' AND cellar_path = '$STALE_DIR';")
+[[ "$STALE_ROW_PRESENT" == "0" ]] ||
+  fail "kegs row still points at swept dir $STALE_DIR — DB sweep did not fire"
+pass "no kegs row references the swept dir"
+
+[[ -d "$KEEP_DIR" ]] ||
+  fail "Cellar/pcre2/$KEEP missing after force-install (got: $(ls -1 "$PREFIX/Cellar/pcre2" 2>/dev/null || echo '(missing)'))"
+pass "Cellar/pcre2/$KEEP present (resolved version kept)"
+
+# ── Doctor must NOT flag the package anymore ────────────────────────
+DOCTOR_OUT=$("$BIN" doctor --verbose 2>&1 || true)
+if echo "$DOCTOR_OUT" | grep -qE "pcre2 ${STALE}( |$)"; then
+  echo "$DOCTOR_OUT" >&2
+  fail "doctor still flags pcre2 $STALE — sweep slipped through"
+fi
+if echo "$DOCTOR_OUT" | grep -qE "keg\(s\) in DB but missing on disk"; then
+  echo "$DOCTOR_OUT" >&2
+  fail "doctor reports Missing kegs after sweep — DB cleanup did not run"
+fi
+pass "doctor reports neither stale placeholder nor missing kegs"
+
+printf '\n✔ install-force-sweeps-old-kegs regression passed\n'

--- a/scripts/regressions/install_force_sweeps_old_kegs.sh
+++ b/scripts/regressions/install_force_sweeps_old_kegs.sh
@@ -134,4 +134,27 @@ if echo "$DOCTOR_OUT" | grep -qE "keg\(s\) in DB but missing on disk"; then
 fi
 pass "doctor reports neither stale placeholder nor missing kegs"
 
+
+# ── Same-version --force must not bounce on the linker conflict ─────
+# Reproducer for the linker-side gap: with pcre2 freshly installed at
+# the resolved version, `--force` on the same version owns symlinks
+# under <prefix>/{bin,lib,...} pointing at the keg we are about to
+# re-materialize. Without `unlinkSameVersionKegLinks`, checkConflicts
+# fires and the install bails with "Use --force to overwrite" — even
+# though --force is already on.
+printf '▸ malt install pcre2 --force (same version, must overwrite linker state)\n'
+"$BIN" install --force --quiet pcre2 || fail "same-version force-install hit the linker conflict trap"
+pass "same-version force-install completed"
+
+[[ -d "$PREFIX/Cellar/pcre2/$KEEP" ]] ||
+  fail "Cellar/pcre2/$KEEP missing after same-version force"
+pass "Cellar/pcre2/$KEEP still present after same-version force"
+
+DOCTOR_OUT=$("$BIN" doctor --verbose 2>&1 || true)
+if echo "$DOCTOR_OUT" | grep -qE "Broken symlinks" | grep -v "✓"; then
+  echo "$DOCTOR_OUT" >&2
+  fail "doctor reports broken symlinks after same-version force"
+fi
+pass "doctor clean after same-version force"
+
 printf '\n✔ install-force-sweeps-old-kegs regression passed\n'

--- a/scripts/regressions/install_force_sweeps_tap.sh
+++ b/scripts/regressions/install_force_sweeps_tap.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Regression: `malt install <tap/formula> --force` must run the
+# same three-phase cleanup (pre-materialize cellar wipe, post-
+# materialize unlink + stale-row drop + orphan-dir sweep) as the
+# JSON-pipeline path. Pre-fix, `materializeRubyFormula` ignored
+# the force flag beyond the "already installed" skip-suppression,
+# so:
+#   - same-version --force could trip the linker's atomic-replace
+#     fallback (no checkConflicts, but stale state could linger)
+#   - revision/version bumps left the old keg + row on disk and
+#     in the DB, surfacing as doctor "Mach-O placeholders" later
+#
+# Drives the regression against the known-working `indaco/tap/sley`
+# fixture (also used by `install_tap_tmp_cleanup.sh`).
+#
+# Usage: scripts/regressions/install_force_sweeps_tap.sh
+# Requirements: built malt at $MALT_BIN or zig-out/bin/malt;
+# network access to api.github.com / raw.githubusercontent.com.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+PREFIX="/tmp/mt_force_tap"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+skip() {
+  printf '  - %s\n' "$*"
+  exit 0
+}
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+SLUG="indaco/tap/sley"
+NAME="sley"
+
+# ── 1. Initial install via materializeRubyFormula ───────────────────
+printf '▸ malt install %s (seed)\n' "$SLUG"
+LOG="$PREFIX/install.log"
+"$BIN" install "$SLUG" >"$LOG" 2>&1 || true
+if ! grep -qE "installed$| installed " "$LOG"; then
+  if grep -qE "rate limit|Network failure|Tap formula/cask not found" "$LOG"; then
+    skip "$SLUG: transient classified failure; cannot exercise force-sweep"
+  fi
+  tail -30 "$LOG" >&2
+  fail "$SLUG: initial install neither succeeded nor produced a known transient error"
+fi
+pass "$SLUG: initial install succeeded"
+
+DB="$PREFIX/db/malt.db"
+[[ -f "$DB" ]] || fail "DB missing after initial install: $DB"
+
+VER=$(sqlite3 "$DB" "SELECT version FROM kegs WHERE name = '$NAME';")
+[[ -n "$VER" ]] || fail "no kegs row for $NAME after initial install"
+KEG_DIR="$PREFIX/Cellar/$NAME/$VER"
+[[ -d "$KEG_DIR" ]] || fail "$KEG_DIR missing after initial install"
+pass "seeded $NAME $VER at $KEG_DIR"
+
+# ── 2. Same-version --force must succeed (linker atomic-replace path) ─
+printf '▸ malt install %s --force (same version)\n' "$SLUG"
+FORCE_LOG="$PREFIX/force.log"
+"$BIN" install "$SLUG" --force >"$FORCE_LOG" 2>&1 || {
+  tail -30 "$FORCE_LOG" >&2
+  fail "same-version --force failed"
+}
+pass "same-version --force succeeded"
+
+[[ -d "$KEG_DIR" ]] || fail "$KEG_DIR missing after same-version force"
+ROW_COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM kegs WHERE name = '$NAME';")
+[[ "$ROW_COUNT" == "1" ]] || fail "expected 1 $NAME row, got $ROW_COUNT"
+pass "post-force state has exactly one $NAME row + cellar dir"
+
+# ── 3. Seed a stale sibling version (the orphan-keg shape) and force ─
+STALE_VER="${VER}-pre"
+STALE_DIR="$PREFIX/Cellar/$NAME/$STALE_VER"
+mkdir -p "$STALE_DIR/bin"
+: >"$STALE_DIR/bin/marker"
+sqlite3 "$DB" "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path) VALUES ('$NAME', '$NAME', '$STALE_VER', '$(printf '%064d' 0)', '$STALE_DIR');"
+pass "seeded stale sibling at $STALE_DIR + kegs row"
+
+ROW_COUNT_BEFORE=$(sqlite3 "$DB" "SELECT COUNT(*) FROM kegs WHERE name = '$NAME';")
+[[ "$ROW_COUNT_BEFORE" == "2" ]] || fail "seed expected 2 rows, got $ROW_COUNT_BEFORE"
+
+printf '▸ malt install %s --force (stale sibling present)\n' "$SLUG"
+"$BIN" install "$SLUG" --force >"$FORCE_LOG" 2>&1 || {
+  tail -30 "$FORCE_LOG" >&2
+  fail "stale-sibling --force failed"
+}
+pass "stale-sibling --force succeeded"
+
+[[ ! -d "$STALE_DIR" ]] || fail "$STALE_DIR survived --force — disk sweep missed the sibling"
+pass "stale Cellar/$NAME/$STALE_VER swept"
+
+ROW_COUNT_AFTER=$(sqlite3 "$DB" "SELECT COUNT(*) FROM kegs WHERE name = '$NAME';")
+[[ "$ROW_COUNT_AFTER" == "1" ]] || fail "expected 1 $NAME row after sweep, got $ROW_COUNT_AFTER"
+pass "stale kegs row dropped"
+
+# ── 4. Doctor must be clean ──────────────────────────────────────────
+DOCTOR_OUT=$("$BIN" doctor --verbose 2>&1 || true)
+if echo "$DOCTOR_OUT" | grep -qE "keg\(s\) in DB but missing on disk"; then
+  echo "$DOCTOR_OUT" >&2
+  fail "doctor reports Missing kegs after tap-path force-sweep"
+fi
+if echo "$DOCTOR_OUT" | grep -qE "package\(s\) ship Mach-O"; then
+  echo "$DOCTOR_OUT" >&2
+  fail "doctor reports Mach-O placeholders after tap-path force-sweep"
+fi
+pass "doctor reports no Missing kegs / placeholder offenders"
+
+printf '\n✔ install-force-sweeps-tap regression passed\n'

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -733,40 +733,17 @@ fn executeWithOpts(
         return;
     }
 
-    // `--force` semantics: re-materialize on top of an existing keg.
-    // The cellar's clonefile/copy refuses to overwrite a populated dir,
-    // so wipe each target Cellar dir up front. Pin survives because the
-    // DB row is rewritten via INSERT OR REPLACE with COALESCE-MAX
-    // inheritance on `pinned`.
-    //
-    // When the resolver picks a new revision (10.47 → 10.47_1) the
-    // prior keg has its own row in `kegs` and its own dir under
-    // `Cellar/<name>/`; both must go or doctor flips between
-    // "Mach-O placeholders" (disk orphan) and "Missing kegs" (DB
-    // orphan pointing at the swept dir). The DB-driven cleanup also
-    // unlinks the prior keg's symlinks via the linker.
-    //
-    // Failure-mode tradeoff: clearing the prior state before
-    // materialize means a materialize crash leaves the user keg-
-    // less. The same risk already existed for same-version `--force`
-    // via the cellar wipe; we're extending it to revision-bump
-    // `--force`. Recovery is a retry; for the bug this fix targets
-    // (orphan after prior failed force) the user is already broken,
-    // so a retry is the worst case.
+    // `--force` pre-materialize: the cellar's clonefile/copy refuses
+    // to overwrite a populated dir, so wipe the resolved-version dir
+    // up front. The destructive part of the cleanup — dropping stale
+    // DB rows, unlinking prior symlinks, sweeping orphan dirs — is
+    // deferred to the serial link phase below so a materialize crash
+    // leaves the user's prior keg + row intact for the revision-bump
+    // case. Pin survives because INSERT OR REPLACE in `recordKeg`
+    // inherits via COALESCE-MAX on `pinned` by name.
     if (force) {
         for (all_jobs.items) |job| {
-            var keep_path_buf: [512]u8 = undefined;
-            const keep_path = std.fmt.bufPrint(
-                &keep_path_buf,
-                "{s}/Cellar/{s}/{s}",
-                .{ prefix, job.name, job.version_str },
-            ) catch {
-                pruneCellarForReinstall(ctx, prefix, job.name, job.version_str);
-                continue;
-            };
             pruneCellarForReinstall(ctx, prefix, job.name, job.version_str);
-            unlinkAndDeleteStaleKegRows(ctx, allocator, &db, &linker, job.name, keep_path);
-            pruneOtherCellarVersionsForReinstall(ctx, allocator, prefix, job.name, job.version_str);
         }
     }
 
@@ -857,6 +834,17 @@ fn executeWithOpts(
             try failed_kegs.put(job.name, {});
             failed_count += 1;
             continue;
+        }
+
+        // `--force` post-materialize: at this point the new keg dir
+        // exists at mats[i].kegPath(); the destructive cleanup of
+        // prior state is safe to run. Skipping this on materialize
+        // failure (handled by the earlier `continue`s) is what
+        // preserves the user's working keg when a force-reinstall
+        // can't reach the network.
+        if (force) {
+            unlinkAndDeleteStaleKegRows(ctx, allocator, &db, &linker, job.name, mats[i].kegPath());
+            pruneOtherCellarVersionsForReinstall(ctx, allocator, prefix, job.name, job.version_str);
         }
 
         linkAndRecord(ctx.io, allocator, job, mats[i].kegPath(), &db, &linker, prefix, &formula_cache) catch {

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -147,6 +147,37 @@ pub fn unlinkAndDeleteStaleKegRows(
     }
 }
 
+/// Unlink the on-disk symlinks AND drop the `links` rows for any
+/// `kegs` row whose `(name, cellar_path)` matches the keg we are
+/// about to re-install (i.e. same version / revision as the new
+/// resolved keg). The `kegs` row itself is left in place so the
+/// subsequent `recordKeg` INSERT OR REPLACE can inherit the user
+/// pin via COALESCE-MAX on `pinned`.
+///
+/// This closes the `--force` linker-conflict path: without the
+/// pre-link unlink, `linker.checkConflicts` sees the prior install's
+/// symlinks under `<prefix>/{bin,lib,...}` (still pointing at the
+/// freshly re-materialized cellar_path) and aborts with
+/// `Use --force to overwrite, or uninstall the conflicting package
+/// first.` — even though the user already passed `--force`.
+///
+/// Best-effort: per-row errors are swallowed; the next `doctor`
+/// pass surfaces anything we could not reach.
+pub fn unlinkSameVersionKegLinks(
+    linker: *linker_mod.Linker,
+    db: *sqlite.Database,
+    name: []const u8,
+    keep_cellar_path: []const u8,
+) void {
+    var stmt = db.prepare("SELECT id FROM kegs WHERE name = ?1 AND cellar_path = ?2 LIMIT 1;") catch return;
+    defer stmt.finalize();
+    stmt.bindText(1, name) catch return;
+    stmt.bindText(2, keep_cellar_path) catch return;
+    if (!(stmt.step() catch false)) return;
+    const keg_id = stmt.columnInt(0);
+    linker.unlink(keg_id) catch {};
+}
+
 fn deleteDependencyRows(db: *sqlite.Database, keg_id: i64) void {
     var stmt = db.prepare("DELETE FROM dependencies WHERE keg_id = ?1;") catch return;
     defer stmt.finalize();
@@ -841,8 +872,12 @@ fn executeWithOpts(
         // prior state is safe to run. Skipping this on materialize
         // failure (handled by the earlier `continue`s) is what
         // preserves the user's working keg when a force-reinstall
-        // can't reach the network.
+        // can't reach the network. The same-version unlink also
+        // clears the linker's would-be checkConflicts trap so the
+        // subsequent `linkAndRecord` proceeds without bouncing on
+        // the prior install's own symlinks.
         if (force) {
+            unlinkSameVersionKegLinks(&linker, &db, job.name, mats[i].kegPath());
             unlinkAndDeleteStaleKegRows(ctx, allocator, &db, &linker, job.name, mats[i].kegPath());
             pruneOtherCellarVersionsForReinstall(ctx, allocator, prefix, job.name, job.version_str);
         }

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -85,6 +85,135 @@ pub fn pruneCellarForReinstall(ctx: *const AppCtx, prefix: []const u8, name: []c
     std.Io.Dir.cwd().deleteTree(ctx.io, cellar_path) catch {};
 }
 
+/// Tear down DB-tracked stale kegs for the given package name: every
+/// `kegs` row whose `cellar_path` differs from `keep_cellar_path` is
+/// unlinked (symlinks + `links` rows via `linker.unlink`), its
+/// `dependencies` rows are dropped, the `kegs` row is removed, and
+/// the on-disk dir is wiped.
+///
+/// Pairs with `pruneCellarForReinstall` (resolved-version dir wipe)
+/// and `pruneOtherCellarVersionsForReinstall` (orphan-dir fallback)
+/// so `--force` against a revision bump does not leave the DB
+/// pointing at a dir the disk side just removed — which would flip
+/// doctor from "Mach-O placeholders" to "Missing kegs".
+///
+/// The pin row is preserved by name-level COALESCE in `recordKeg`'s
+/// INSERT OR REPLACE, so dropping the old row here does not lose the
+/// user's hold on the package.
+///
+/// Best-effort: per-row errors are swallowed; the next `doctor` pass
+/// surfaces anything we could not reach.
+pub fn unlinkAndDeleteStaleKegRows(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    linker: *linker_mod.Linker,
+    name: []const u8,
+    keep_cellar_path: []const u8,
+) void {
+    const StaleRow = struct { id: i64, path: []u8 };
+    var stale: std.ArrayList(StaleRow) = .empty;
+    defer {
+        for (stale.items) |s| allocator.free(s.path);
+        stale.deinit(allocator);
+    }
+
+    {
+        var stmt = db.prepare("SELECT id, cellar_path FROM kegs WHERE name = ?1 AND cellar_path != ?2;") catch return;
+        defer stmt.finalize();
+        stmt.bindText(1, name) catch return;
+        stmt.bindText(2, keep_cellar_path) catch return;
+
+        while (stmt.step() catch false) {
+            const id = stmt.columnInt(0);
+            const path_raw = stmt.columnText(1) orelse continue;
+            const path = std.mem.sliceTo(path_raw, 0);
+            const dup = allocator.dupe(u8, path) catch continue;
+            stale.append(allocator, .{ .id = id, .path = dup }) catch {
+                allocator.free(dup);
+                continue;
+            };
+        }
+    }
+
+    for (stale.items) |s| {
+        // `linker.unlink` removes the on-disk symlinks AND the `links`
+        // rows for this keg_id, so we only need to clean up the
+        // `dependencies` rows and the `kegs` row ourselves.
+        linker.unlink(s.id) catch {};
+        deleteDependencyRows(db, s.id);
+        deleteKegRowOnly(db, s.id);
+        std.Io.Dir.cwd().deleteTree(ctx.io, s.path) catch {};
+    }
+}
+
+fn deleteDependencyRows(db: *sqlite.Database, keg_id: i64) void {
+    var stmt = db.prepare("DELETE FROM dependencies WHERE keg_id = ?1;") catch return;
+    defer stmt.finalize();
+    stmt.bindInt(1, keg_id) catch return;
+    _ = stmt.step() catch {};
+}
+
+fn deleteKegRowOnly(db: *sqlite.Database, keg_id: i64) void {
+    var stmt = db.prepare("DELETE FROM kegs WHERE id = ?1;") catch return;
+    defer stmt.finalize();
+    stmt.bindInt(1, keg_id) catch return;
+    _ = stmt.step() catch {};
+}
+
+/// Wipe every `<prefix>/Cellar/<name>/*` entry except `keep_version`.
+/// Safety net for orphan dirs that have no `kegs` row pointing at
+/// them — legacy installs, crashed runs, manual `mkdir`. The DB-
+/// driven cleanup in `unlinkAndDeleteStaleKegRows` covers the common
+/// "force-reinstall across a revision bump" case; this one catches
+/// the residue. Best-effort otherwise: per-entry errors are
+/// swallowed because the materialize step still covers real
+/// failures.
+///
+/// Names are collected before any deletion: POSIX leaves readdir
+/// behavior undefined while entries are being unlinked, and APFS
+/// readdir is buffered so a partial-page refresh can drop entries.
+pub fn pruneOtherCellarVersionsForReinstall(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    prefix: []const u8,
+    name: []const u8,
+    keep_version: []const u8,
+) void {
+    var pkg_buf: [512]u8 = undefined;
+    const pkg_path = std.fmt.bufPrint(&pkg_buf, "{s}/Cellar/{s}", .{ prefix, name }) catch return;
+
+    var pkg_dir = std.Io.Dir.openDirAbsolute(ctx.io, pkg_path, .{ .iterate = true }) catch return;
+    defer pkg_dir.close(ctx.io);
+
+    var stale: std.ArrayList([]u8) = .empty;
+    defer {
+        for (stale.items) |s| allocator.free(s);
+        stale.deinit(allocator);
+    }
+
+    var it = pkg_dir.iterate();
+    while (it.next(ctx.io) catch null) |entry| {
+        if (entry.kind != .directory) continue;
+        if (std.mem.eql(u8, entry.name, keep_version)) continue;
+        const dup = allocator.dupe(u8, entry.name) catch continue;
+        stale.append(allocator, dup) catch {
+            allocator.free(dup);
+            continue;
+        };
+    }
+
+    for (stale.items) |version_name| {
+        var version_buf: [512]u8 = undefined;
+        const version_path = std.fmt.bufPrint(
+            &version_buf,
+            "{s}/{s}",
+            .{ pkg_path, version_name },
+        ) catch continue;
+        std.Io.Dir.cwd().deleteTree(ctx.io, version_path) catch {};
+    }
+}
+
 /// Single-`stat` probe of `<prefix>/Cellar/<name>`. uninstall tears
 /// down the parent when the last version goes; an orphan empty dir is
 /// `mt doctor --fix` territory rather than something to paper over.
@@ -609,9 +738,35 @@ fn executeWithOpts(
     // so wipe each target Cellar dir up front. Pin survives because the
     // DB row is rewritten via INSERT OR REPLACE with COALESCE-MAX
     // inheritance on `pinned`.
+    //
+    // When the resolver picks a new revision (10.47 → 10.47_1) the
+    // prior keg has its own row in `kegs` and its own dir under
+    // `Cellar/<name>/`; both must go or doctor flips between
+    // "Mach-O placeholders" (disk orphan) and "Missing kegs" (DB
+    // orphan pointing at the swept dir). The DB-driven cleanup also
+    // unlinks the prior keg's symlinks via the linker.
+    //
+    // Failure-mode tradeoff: clearing the prior state before
+    // materialize means a materialize crash leaves the user keg-
+    // less. The same risk already existed for same-version `--force`
+    // via the cellar wipe; we're extending it to revision-bump
+    // `--force`. Recovery is a retry; for the bug this fix targets
+    // (orphan after prior failed force) the user is already broken,
+    // so a retry is the worst case.
     if (force) {
         for (all_jobs.items) |job| {
+            var keep_path_buf: [512]u8 = undefined;
+            const keep_path = std.fmt.bufPrint(
+                &keep_path_buf,
+                "{s}/Cellar/{s}/{s}",
+                .{ prefix, job.name, job.version_str },
+            ) catch {
+                pruneCellarForReinstall(ctx, prefix, job.name, job.version_str);
+                continue;
+            };
             pruneCellarForReinstall(ctx, prefix, job.name, job.version_str);
+            unlinkAndDeleteStaleKegRows(ctx, allocator, &db, &linker, job.name, keep_path);
+            pruneOtherCellarVersionsForReinstall(ctx, allocator, prefix, job.name, job.version_str);
         }
     }
 
@@ -983,4 +1138,187 @@ test "kegPresent returns true only when <prefix>/Cellar/<name> exists" {
 
     try testing.expect(kegPresent(&ctx, prefix, "ghost"));
     try testing.expect(!kegPresent(&ctx, prefix, "other"));
+}
+
+// `--force` that resolves to a new revision (e.g. 10.47 → 10.47_1)
+// must not orphan the prior keg dir: doctor walks the whole Cellar
+// tree and would flag the abandoned unpatched binaries forever.
+test "pruneOtherCellarVersionsForReinstall removes sibling versions but keeps the named one" {
+    const testing = std.testing;
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const ts = std.Io.Clock.real.now(ctx.io).toNanoseconds();
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_prune_siblings_{d}", .{ts});
+    std.Io.Dir.cwd().deleteTree(ctx.io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(ctx.io, prefix);
+    defer std.Io.Dir.cwd().deleteTree(ctx.io, prefix) catch {};
+
+    var old_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const old_keg = try std.fmt.bufPrint(&old_buf, "{s}/Cellar/pcre2/10.47/bin", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(ctx.io, old_keg);
+
+    var new_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const new_keg = try std.fmt.bufPrint(&new_buf, "{s}/Cellar/pcre2/10.47_1/bin", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(ctx.io, new_keg);
+
+    pruneOtherCellarVersionsForReinstall(&ctx, testing.allocator, prefix, "pcre2", "10.47_1");
+
+    var old_root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const old_root = try std.fmt.bufPrint(&old_root_buf, "{s}/Cellar/pcre2/10.47", .{prefix});
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(ctx.io, old_root, .{}));
+
+    var new_root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const new_root = try std.fmt.bufPrint(&new_root_buf, "{s}/Cellar/pcre2/10.47_1", .{prefix});
+    try std.Io.Dir.accessAbsolute(ctx.io, new_root, .{});
+}
+
+test "pruneOtherCellarVersionsForReinstall is a no-op when only the kept version exists" {
+    const testing = std.testing;
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const ts = std.Io.Clock.real.now(ctx.io).toNanoseconds();
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_prune_siblings_solo_{d}", .{ts});
+    std.Io.Dir.cwd().deleteTree(ctx.io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(ctx.io, prefix);
+    defer std.Io.Dir.cwd().deleteTree(ctx.io, prefix) catch {};
+
+    var keep_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const keep_keg = try std.fmt.bufPrint(&keep_buf, "{s}/Cellar/libgit2/1.9.3/lib", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(ctx.io, keep_keg);
+
+    pruneOtherCellarVersionsForReinstall(&ctx, testing.allocator, prefix, "libgit2", "1.9.3");
+
+    var keep_root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const keep_root = try std.fmt.bufPrint(&keep_root_buf, "{s}/Cellar/libgit2/1.9.3", .{prefix});
+    try std.Io.Dir.accessAbsolute(ctx.io, keep_root, .{});
+}
+
+test "pruneOtherCellarVersionsForReinstall is a no-op when the package dir does not exist" {
+    const testing = std.testing;
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const ts = std.Io.Clock.real.now(ctx.io).toNanoseconds();
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_prune_siblings_absent_{d}", .{ts});
+    std.Io.Dir.cwd().deleteTree(ctx.io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(ctx.io, prefix);
+    defer std.Io.Dir.cwd().deleteTree(ctx.io, prefix) catch {};
+
+    // No `Cellar/ghost` ever created — sweep must not fault, panic, or leak.
+    pruneOtherCellarVersionsForReinstall(&ctx, testing.allocator, prefix, "ghost", "1.0");
+}
+
+// A user holding several prior revisions (pinned at name level, repeated
+// force-reinstalls across revisions) is the realistic shape behind the
+// original report. All N-1 stale dirs must go in one sweep.
+test "pruneOtherCellarVersionsForReinstall sweeps multiple stale siblings in one pass" {
+    const testing = std.testing;
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const ts = std.Io.Clock.real.now(ctx.io).toNanoseconds();
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_prune_siblings_many_{d}", .{ts});
+    std.Io.Dir.cwd().deleteTree(ctx.io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(ctx.io, prefix);
+    defer std.Io.Dir.cwd().deleteTree(ctx.io, prefix) catch {};
+
+    const versions = [_][]const u8{ "10.46", "10.47", "10.47_1", "10.48" };
+    for (versions) |v| {
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const dir = try std.fmt.bufPrint(&buf, "{s}/Cellar/pcre2/{s}/bin", .{ prefix, v });
+        try std.Io.Dir.cwd().createDirPath(ctx.io, dir);
+    }
+
+    pruneOtherCellarVersionsForReinstall(&ctx, testing.allocator, prefix, "pcre2", "10.48");
+
+    for (versions) |v| {
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const root = try std.fmt.bufPrint(&buf, "{s}/Cellar/pcre2/{s}", .{ prefix, v });
+        if (std.mem.eql(u8, v, "10.48")) {
+            try std.Io.Dir.accessAbsolute(ctx.io, root, .{});
+        } else {
+            try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(ctx.io, root, .{}));
+        }
+    }
+}
+
+// Stray non-directory entries under `Cellar/<name>/` (e.g. a leftover
+// `.DS_Store` or a user-created marker file) must be left alone. The
+// sweep targets version dirs, not arbitrary cleanup.
+test "pruneOtherCellarVersionsForReinstall ignores non-directory entries" {
+    const testing = std.testing;
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const ts = std.Io.Clock.real.now(ctx.io).toNanoseconds();
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_prune_siblings_files_{d}", .{ts});
+    std.Io.Dir.cwd().deleteTree(ctx.io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(ctx.io, prefix);
+    defer std.Io.Dir.cwd().deleteTree(ctx.io, prefix) catch {};
+
+    var pkg_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const pkg_path = try std.fmt.bufPrint(&pkg_buf, "{s}/Cellar/pcre2", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(ctx.io, pkg_path);
+
+    var stray_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const stray = try std.fmt.bufPrint(&stray_buf, "{s}/.DS_Store", .{pkg_path});
+    {
+        const f = try std.Io.Dir.cwd().createFile(ctx.io, stray, .{});
+        defer f.close(ctx.io);
+        try f.writeStreamingAll(ctx.io, "stray");
+    }
+
+    var keep_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const keep_keg = try std.fmt.bufPrint(&keep_buf, "{s}/10.47_1/bin", .{pkg_path});
+    try std.Io.Dir.cwd().createDirPath(ctx.io, keep_keg);
+
+    pruneOtherCellarVersionsForReinstall(&ctx, testing.allocator, prefix, "pcre2", "10.47_1");
+
+    try std.Io.Dir.accessAbsolute(ctx.io, stray, .{});
+}
+
+// Realistic call-site shape: `pruneCellarForReinstall` runs first and
+// removes the keep_version dir, then the sweep runs against a state
+// where keep_version no longer exists on disk. Sweep must still wipe
+// the stale siblings without faulting on the missing target.
+test "pruneOtherCellarVersionsForReinstall tolerates keep_version absent on disk" {
+    const testing = std.testing;
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const ts = std.Io.Clock.real.now(ctx.io).toNanoseconds();
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_prune_siblings_nokeep_{d}", .{ts});
+    std.Io.Dir.cwd().deleteTree(ctx.io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(ctx.io, prefix);
+    defer std.Io.Dir.cwd().deleteTree(ctx.io, prefix) catch {};
+
+    var stale_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const stale = try std.fmt.bufPrint(&stale_buf, "{s}/Cellar/pcre2/10.47/bin", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(ctx.io, stale);
+
+    pruneOtherCellarVersionsForReinstall(&ctx, testing.allocator, prefix, "pcre2", "10.47_1");
+
+    var stale_root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const stale_root = try std.fmt.bufPrint(&stale_root_buf, "{s}/Cellar/pcre2/10.47", .{prefix});
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(ctx.io, stale_root, .{}));
 }

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -85,29 +85,57 @@ pub fn pruneCellarForReinstall(ctx: *const AppCtx, prefix: []const u8, name: []c
     std.Io.Dir.cwd().deleteTree(ctx.io, cellar_path) catch {};
 }
 
-/// Tear down DB-tracked stale kegs for the given package name: every
-/// `kegs` row whose `cellar_path` differs from `keep_cellar_path` is
-/// unlinked (symlinks + `links` rows via `linker.unlink`), its
-/// `dependencies` rows are dropped, the `kegs` row is removed, and
-/// the on-disk dir is wiped.
+/// Unlink the on-disk symlinks AND drop the `links` rows for every
+/// `kegs` row of `name` whose `cellar_path` differs from
+/// `keep_cellar_path` — i.e. the prior install at an other
+/// version/revision. The `kegs` row + its `dependencies` rows stay
+/// in place so the subsequent `recordKeg` INSERT OR REPLACE sees the
+/// stale row's `pinned` flag through COALESCE-MAX. The row drop
+/// itself is handled by `dropStaleKegRows` after `linkAndRecord`
+/// commits the new row.
 ///
-/// Pairs with `pruneCellarForReinstall` (resolved-version dir wipe)
-/// and `pruneOtherCellarVersionsForReinstall` (orphan-dir fallback)
-/// so `--force` against a revision bump does not leave the DB
-/// pointing at a dir the disk side just removed — which would flip
-/// doctor from "Mach-O placeholders" to "Missing kegs".
+/// Pre-link companion to `unlinkSameVersionKegLinks`: between the
+/// two, every same-name prior install's symlinks are cleared before
+/// `linker.checkConflicts` runs, so a `--force` reinstall does not
+/// trip on its own predecessor.
 ///
-/// The pin row is preserved by name-level COALESCE in `recordKeg`'s
-/// INSERT OR REPLACE, so dropping the old row here does not lose the
-/// user's hold on the package.
+/// Best-effort: per-row errors are swallowed; the next `doctor`
+/// pass surfaces anything we could not reach.
+pub fn unlinkStaleKegLinks(
+    db: *sqlite.Database,
+    linker: *linker_mod.Linker,
+    name: []const u8,
+    keep_cellar_path: []const u8,
+) void {
+    var stmt = db.prepare("SELECT id FROM kegs WHERE name = ?1 AND cellar_path != ?2;") catch return;
+    defer stmt.finalize();
+    stmt.bindText(1, name) catch return;
+    stmt.bindText(2, keep_cellar_path) catch return;
+
+    while (stmt.step() catch false) {
+        const id = stmt.columnInt(0);
+        linker.unlink(id) catch {};
+    }
+}
+
+/// Drop the DB rows + on-disk dirs for every `kegs` row of `name`
+/// whose `cellar_path` differs from `keep_cellar_path`. Pairs with
+/// `unlinkStaleKegLinks` (which clears the symlinks before
+/// `linkAndRecord`) so this post-link step only has to handle the
+/// row + dependencies + cellar dir teardown.
 ///
-/// Best-effort: per-row errors are swallowed; the next `doctor` pass
-/// surfaces anything we could not reach.
-pub fn unlinkAndDeleteStaleKegRows(
+/// Pin preservation: callers must run this AFTER `recordKeg`'s
+/// INSERT OR REPLACE has executed, so the COALESCE-MAX subquery
+/// inside that INSERT still sees the stale row's `pinned` flag and
+/// can inherit it. Running this before `recordKeg` would leave the
+/// new row with `pinned=0` for users who pinned the prior revision.
+///
+/// Best-effort: per-row errors are swallowed; the next `doctor`
+/// pass surfaces anything we could not reach.
+pub fn dropStaleKegRows(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
     db: *sqlite.Database,
-    linker: *linker_mod.Linker,
     name: []const u8,
     keep_cellar_path: []const u8,
 ) void {
@@ -137,10 +165,6 @@ pub fn unlinkAndDeleteStaleKegRows(
     }
 
     for (stale.items) |s| {
-        // `linker.unlink` removes the on-disk symlinks AND the `links`
-        // rows for this keg_id, so we only need to clean up the
-        // `dependencies` rows and the `kegs` row ourselves.
-        linker.unlink(s.id) catch {};
         deleteDependencyRows(db, s.id);
         deleteKegRowOnly(db, s.id);
         std.Io.Dir.cwd().deleteTree(ctx.io, s.path) catch {};
@@ -867,19 +891,14 @@ fn executeWithOpts(
             continue;
         }
 
-        // `--force` post-materialize: at this point the new keg dir
-        // exists at mats[i].kegPath(); the destructive cleanup of
-        // prior state is safe to run. Skipping this on materialize
-        // failure (handled by the earlier `continue`s) is what
-        // preserves the user's working keg when a force-reinstall
-        // can't reach the network. The same-version unlink also
-        // clears the linker's would-be checkConflicts trap so the
-        // subsequent `linkAndRecord` proceeds without bouncing on
-        // the prior install's own symlinks.
+        // `--force` pre-link: clear every same-name prior install's
+        // symlinks so `linker.checkConflicts` sees a clean state in
+        // `linkAndRecord` below. Rows + dependencies + dirs stay so
+        // `recordKeg`'s COALESCE-MAX subquery can still inherit the
+        // user pin from the prior row.
         if (force) {
             unlinkSameVersionKegLinks(&linker, &db, job.name, mats[i].kegPath());
-            unlinkAndDeleteStaleKegRows(ctx, allocator, &db, &linker, job.name, mats[i].kegPath());
-            pruneOtherCellarVersionsForReinstall(ctx, allocator, prefix, job.name, job.version_str);
+            unlinkStaleKegLinks(&db, &linker, job.name, mats[i].kegPath());
         }
 
         linkAndRecord(ctx.io, allocator, job, mats[i].kegPath(), &db, &linker, prefix, &formula_cache) catch {
@@ -890,6 +909,15 @@ fn executeWithOpts(
             failed_count += 1;
             continue;
         };
+
+        // `--force` post-link: now that `recordKeg` has inserted the
+        // new row (and inherited any pin via COALESCE-MAX), it is
+        // safe to drop the prior other-version rows + their dirs.
+        // Disk safety net catches any cellar dir without a row.
+        if (force) {
+            dropStaleKegRows(ctx, allocator, &db, job.name, mats[i].kegPath());
+            pruneOtherCellarVersionsForReinstall(ctx, allocator, prefix, job.name, job.version_str);
+        }
 
         if (job.post_install_defined) {
             drive(ctx, allocator, job.name, job.version_str, job.formula_json, prefix, use_system_ruby_list, &formula_cache);

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -219,11 +219,11 @@ fn deleteKegRowOnly(db: *sqlite.Database, keg_id: i64) void {
 /// Wipe every `<prefix>/Cellar/<name>/*` entry except `keep_version`.
 /// Safety net for orphan dirs that have no `kegs` row pointing at
 /// them — legacy installs, crashed runs, manual `mkdir`. The DB-
-/// driven cleanup in `unlinkAndDeleteStaleKegRows` covers the common
-/// "force-reinstall across a revision bump" case; this one catches
-/// the residue. Best-effort otherwise: per-entry errors are
-/// swallowed because the materialize step still covers real
-/// failures.
+/// driven cleanup in `unlinkStaleKegLinks` + `dropStaleKegRows`
+/// covers the common "force-reinstall across a revision bump" case;
+/// this one catches the residue. Best-effort otherwise: per-entry
+/// errors are swallowed because the materialize step still covers
+/// real failures.
 ///
 /// Names are collected before any deletion: POSIX leaves readdir
 /// behavior undefined while entries are being unlinked, and APFS

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -650,15 +650,13 @@ fn materializeRubyFormula(
     db.beginTransaction() catch return InstallError.RecordFailed;
     errdefer db.rollback();
 
-    // `--force` post-materialize: archive is on disk at cellar_path;
-    // clear the prior install's links + stale rows + orphan sibling
-    // dirs so the upcoming linker.link does not collide and so doctor
-    // does not flip from "Mach-O placeholders" to "Missing kegs".
-    // Same three-phase sequence the JSON pipeline runs.
+    // `--force` pre-link: clear every same-name prior install's
+    // symlinks so the upcoming linker.link does not collide. Rows
+    // + dependencies stay so the recordKeg INSERT OR REPLACE below
+    // can inherit the user pin from any stale row via COALESCE-MAX.
     if (force) {
         install_mod.unlinkSameVersionKegLinks(linker, db, resolved.name, cellar_path);
-        install_mod.unlinkAndDeleteStaleKegRows(ctx, allocator, db, linker, resolved.name, cellar_path);
-        install_mod.pruneOtherCellarVersionsForReinstall(ctx, allocator, prefix, resolved.name, resolved.version);
+        install_mod.unlinkStaleKegLinks(db, linker, resolved.name, cellar_path);
     }
 
     var keg_id: i64 = 0;
@@ -694,6 +692,15 @@ fn materializeRubyFormula(
     linker.linkOpt(resolved.name, resolved.version) catch {
         output.warn("Could not create opt link for {s}", .{resolved.name});
     };
+
+    // `--force` post-link: the new row is recorded and the pin (if
+    // any) is inherited; safe to drop the prior other-version rows
+    // and their dirs. Disk safety net catches any cellar dir without
+    // a row.
+    if (force) {
+        install_mod.dropStaleKegRows(ctx, allocator, db, resolved.name, cellar_path);
+        install_mod.pruneOtherCellarVersionsForReinstall(ctx, allocator, prefix, resolved.name, resolved.version);
+    }
 
     db.commit() catch return InstallError.RecordFailed;
 

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -17,6 +17,7 @@ const progress_mod = @import("../../ui/progress.zig");
 const args = @import("args.zig");
 const record = @import("record.zig");
 const download = @import("download.zig");
+const install_mod = @import("../install.zig");
 
 const InstallError = record.InstallError;
 
@@ -551,6 +552,14 @@ fn materializeRubyFormula(
         error.PathAlreadyExists => {},
         else => return InstallError.CellarFailed,
     };
+    // `--force` pre-materialize: wipe the resolved-version dir so the
+    // archive extracts into a clean target. Without this, extract
+    // mixes new and prior files at the same paths, and the post-link
+    // sweep would only address symlinks + DB rows. Matches the JSON
+    // pipeline's pre-materialize call.
+    if (force) {
+        install_mod.pruneCellarForReinstall(ctx, prefix, resolved.name, resolved.version);
+    }
     std.Io.Dir.createDirAbsolute(ctx.io, cellar_path, .default_dir) catch |e| switch (e) {
         error.PathAlreadyExists => {},
         else => return InstallError.CellarFailed,
@@ -640,6 +649,17 @@ fn materializeRubyFormula(
     // step fails before commit.
     db.beginTransaction() catch return InstallError.RecordFailed;
     errdefer db.rollback();
+
+    // `--force` post-materialize: archive is on disk at cellar_path;
+    // clear the prior install's links + stale rows + orphan sibling
+    // dirs so the upcoming linker.link does not collide and so doctor
+    // does not flip from "Mach-O placeholders" to "Missing kegs".
+    // Same three-phase sequence the JSON pipeline runs.
+    if (force) {
+        install_mod.unlinkSameVersionKegLinks(linker, db, resolved.name, cellar_path);
+        install_mod.unlinkAndDeleteStaleKegRows(ctx, allocator, db, linker, resolved.name, cellar_path);
+        install_mod.pruneOtherCellarVersionsForReinstall(ctx, allocator, prefix, resolved.name, resolved.version);
+    }
 
     var keg_id: i64 = 0;
     {

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -952,3 +952,236 @@ test "dropTopLevelJobs preserves dep order across mixed lists" {
     try testing.expectEqualStrings("dep_a", jobs.items[0].name);
     try testing.expectEqualStrings("dep_b", jobs.items[1].name);
 }
+
+// --- unlinkAndDeleteStaleKegRows: force-reinstall across a revision
+// bump must drop the prior keg's DB row + its links + its dependencies
+// + its on-disk dir, mirroring the upgrade path. Without this the
+// freshly-swept disk dir would leave the kegs row pointing at nothing
+// and `malt doctor` would flip from "Mach-O placeholders" to
+// "Missing kegs" — same broken state, different message.
+
+fn insertKegRow(
+    db: *sqlite.Database,
+    name: []const u8,
+    version: []const u8,
+    revision: i64,
+    cellar_path: []const u8,
+) !i64 {
+    {
+        var stmt = try db.prepare(
+            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+            \\VALUES (?1, ?2, ?3, ?4, ?5, ?6);
+        );
+        defer stmt.finalize();
+        try stmt.bindText(1, name);
+        try stmt.bindText(2, name);
+        try stmt.bindText(3, version);
+        try stmt.bindInt(4, revision);
+        try stmt.bindText(5, "0" ** 64);
+        try stmt.bindText(6, cellar_path);
+        _ = try stmt.step();
+    }
+    var stmt = try db.prepare("SELECT last_insert_rowid();");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    return stmt.columnInt(0);
+}
+
+fn seedKegWithBin(prefix: []const u8, name: []const u8, version: []const u8, bin_name: []const u8) ![]u8 {
+    const keg = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/Cellar/{s}/{s}",
+        .{ prefix, name, version },
+    );
+    const bin_dir = try std.fmt.allocPrint(testing.allocator, "{s}/bin", .{keg});
+    defer testing.allocator.free(bin_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, bin_dir);
+
+    const bin_path = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ bin_dir, bin_name });
+    defer testing.allocator.free(bin_path);
+    const f = try test_io.createFileAbsolute(std.Options.debug_io, bin_path, .{});
+    defer f.close(std.Options.debug_io);
+    try f.writeStreamingAll(std.Options.debug_io, "#!/bin/sh\necho hi\n");
+    return keg;
+}
+
+fn kegRowCount(db: *sqlite.Database, name: []const u8) !i64 {
+    var stmt = try db.prepare("SELECT COUNT(*) FROM kegs WHERE name = ?1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    _ = try stmt.step();
+    return stmt.columnInt(0);
+}
+
+test "unlinkAndDeleteStaleKegRows drops the stale row, its symlinks, and its dir" {
+    var tdb = try TempDb.init("force_sweep_db_row");
+    defer tdb.deinit();
+    const prefix = tdb.dir;
+
+    const stale_keg = try seedKegWithBin(prefix, "foo", "1.0", "foo-tool");
+    defer testing.allocator.free(stale_keg);
+    const keep_keg = try seedKegWithBin(prefix, "foo", "2.0", "foo-tool");
+    defer testing.allocator.free(keep_keg);
+
+    const stale_id = try insertKegRow(&tdb.db, "foo", "1.0", 0, stale_keg);
+    const keep_id = try insertKegRow(&tdb.db, "foo", "2.0", 0, keep_keg);
+
+    var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
+    try linker.link(stale_keg, "foo", stale_id);
+
+    // Sanity: stale row exists, stale symlink resolves.
+    try testing.expectEqual(@as(i64, 2), try kegRowCount(&tdb.db, "foo"));
+    var link_buf: [512]u8 = undefined;
+    const link_path = try std.fmt.bufPrint(&link_buf, "{s}/bin/foo-tool", .{prefix});
+    try std.Io.Dir.accessAbsolute(std.Options.debug_io, link_path, .{});
+
+    // Resolved version is foo 2.0. Sweep against foo's other DB rows.
+    install.unlinkAndDeleteStaleKegRows(
+        &malt.app_ctx.debug_ctx,
+        testing.allocator,
+        &tdb.db,
+        &linker,
+        "foo",
+        keep_keg,
+    );
+
+    // Stale row + dir + symlink all gone; keep row + dir untouched.
+    try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "foo"));
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(std.Options.debug_io, stale_keg, .{}));
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(std.Options.debug_io, link_path, .{}));
+    try std.Io.Dir.accessAbsolute(std.Options.debug_io, keep_keg, .{});
+
+    // Survivor's id is the one we kept.
+    var stmt = try tdb.db.prepare("SELECT id FROM kegs WHERE name = ?1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, "foo");
+    _ = try stmt.step();
+    try testing.expectEqual(keep_id, stmt.columnInt(0));
+}
+
+test "unlinkAndDeleteStaleKegRows is a no-op when no sibling rows exist" {
+    var tdb = try TempDb.init("force_sweep_db_solo");
+    defer tdb.deinit();
+    const prefix = tdb.dir;
+
+    const keep_keg = try seedKegWithBin(prefix, "bar", "1.0", "bar-tool");
+    defer testing.allocator.free(keep_keg);
+    _ = try insertKegRow(&tdb.db, "bar", "1.0", 0, keep_keg);
+
+    var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
+
+    install.unlinkAndDeleteStaleKegRows(
+        &malt.app_ctx.debug_ctx,
+        testing.allocator,
+        &tdb.db,
+        &linker,
+        "bar",
+        keep_keg,
+    );
+
+    try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "bar"));
+    try std.Io.Dir.accessAbsolute(std.Options.debug_io, keep_keg, .{});
+}
+
+test "unlinkAndDeleteStaleKegRows tolerates a stale row whose dir is already gone" {
+    var tdb = try TempDb.init("force_sweep_db_no_disk");
+    defer tdb.deinit();
+    const prefix = tdb.dir;
+
+    const stale_keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/baz/1.0", .{prefix});
+    defer testing.allocator.free(stale_keg);
+    // Note: stale dir intentionally NOT created — simulate a crashed
+    // prior install or a manual `rm -rf` that left only the DB row.
+
+    const keep_keg = try seedKegWithBin(prefix, "baz", "2.0", "baz-tool");
+    defer testing.allocator.free(keep_keg);
+
+    _ = try insertKegRow(&tdb.db, "baz", "1.0", 0, stale_keg);
+    _ = try insertKegRow(&tdb.db, "baz", "2.0", 0, keep_keg);
+
+    var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
+
+    install.unlinkAndDeleteStaleKegRows(
+        &malt.app_ctx.debug_ctx,
+        testing.allocator,
+        &tdb.db,
+        &linker,
+        "baz",
+        keep_keg,
+    );
+
+    // Stale row gone even though its dir was already absent.
+    try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "baz"));
+}
+
+test "unlinkAndDeleteStaleKegRows wipes multiple stale rows for the same name in one pass" {
+    var tdb = try TempDb.init("force_sweep_db_multi");
+    defer tdb.deinit();
+    const prefix = tdb.dir;
+
+    // Realistic v5 shape after repeated force-reinstalls before this
+    // fix landed: each revision left its own (name, version, revision)
+    // row instead of being merged. All N-1 stale rows must go.
+    const v1 = try seedKegWithBin(prefix, "qux", "1.0", "qux-tool");
+    defer testing.allocator.free(v1);
+    const v2 = try seedKegWithBin(prefix, "qux", "2.0", "qux-tool");
+    defer testing.allocator.free(v2);
+    const v3 = try seedKegWithBin(prefix, "qux", "3.0", "qux-tool");
+    defer testing.allocator.free(v3);
+    const keep = try seedKegWithBin(prefix, "qux", "4.0", "qux-tool");
+    defer testing.allocator.free(keep);
+
+    _ = try insertKegRow(&tdb.db, "qux", "1.0", 0, v1);
+    _ = try insertKegRow(&tdb.db, "qux", "2.0", 0, v2);
+    _ = try insertKegRow(&tdb.db, "qux", "3.0", 0, v3);
+    _ = try insertKegRow(&tdb.db, "qux", "4.0", 0, keep);
+
+    var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
+
+    install.unlinkAndDeleteStaleKegRows(
+        &malt.app_ctx.debug_ctx,
+        testing.allocator,
+        &tdb.db,
+        &linker,
+        "qux",
+        keep,
+    );
+
+    try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "qux"));
+    for ([_][]const u8{ v1, v2, v3 }) |stale| {
+        try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(std.Options.debug_io, stale, .{}));
+    }
+    try std.Io.Dir.accessAbsolute(std.Options.debug_io, keep, .{});
+}
+
+test "unlinkAndDeleteStaleKegRows leaves other packages untouched" {
+    var tdb = try TempDb.init("force_sweep_db_scoped");
+    defer tdb.deinit();
+    const prefix = tdb.dir;
+
+    const stale_foo = try seedKegWithBin(prefix, "foo", "1.0", "foo-tool");
+    defer testing.allocator.free(stale_foo);
+    const keep_foo = try seedKegWithBin(prefix, "foo", "2.0", "foo-tool");
+    defer testing.allocator.free(keep_foo);
+    const other = try seedKegWithBin(prefix, "qux", "1.0", "qux-tool");
+    defer testing.allocator.free(other);
+
+    _ = try insertKegRow(&tdb.db, "foo", "1.0", 0, stale_foo);
+    _ = try insertKegRow(&tdb.db, "foo", "2.0", 0, keep_foo);
+    _ = try insertKegRow(&tdb.db, "qux", "1.0", 0, other);
+
+    var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
+
+    install.unlinkAndDeleteStaleKegRows(
+        &malt.app_ctx.debug_ctx,
+        testing.allocator,
+        &tdb.db,
+        &linker,
+        "foo",
+        keep_foo,
+    );
+
+    try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "foo"));
+    try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "qux"));
+    try std.Io.Dir.accessAbsolute(std.Options.debug_io, other, .{});
+}

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -1114,6 +1114,92 @@ test "unlinkAndDeleteStaleKegRows tolerates a stale row whose dir is already gon
     try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "baz"));
 }
 
+// unlinkSameVersionKegLinks: clear the package's own prior symlinks
+// before linkAndRecord runs. Without this, `linker.checkConflicts`
+// rejects a same-version `--force` reinstall against a keg the user
+// already has installed — the prior bug we shipped to T-044.
+
+test "unlinkSameVersionKegLinks removes symlinks + links rows for the matching keg" {
+    var tdb = try TempDb.init("force_unlink_same_ver");
+    defer tdb.deinit();
+    const prefix = tdb.dir;
+
+    const keg = try seedKegWithBin(prefix, "foo", "1.0", "foo-tool");
+    defer testing.allocator.free(keg);
+
+    const keg_id = try insertKegRow(&tdb.db, "foo", "1.0", 0, keg);
+
+    var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
+    try linker.link(keg, "foo", keg_id);
+
+    var link_buf: [512]u8 = undefined;
+    const link_path = try std.fmt.bufPrint(&link_buf, "{s}/bin/foo-tool", .{prefix});
+    try std.Io.Dir.accessAbsolute(std.Options.debug_io, link_path, .{});
+
+    install.unlinkSameVersionKegLinks(&linker, &tdb.db, "foo", keg);
+
+    // Symlink + links row gone; kegs row preserved so the subsequent
+    // recordKeg INSERT OR REPLACE can inherit any pin via COALESCE.
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(std.Options.debug_io, link_path, .{}));
+    var links_count_stmt = try tdb.db.prepare("SELECT COUNT(*) FROM links WHERE keg_id = ?1;");
+    defer links_count_stmt.finalize();
+    try links_count_stmt.bindInt(1, keg_id);
+    _ = try links_count_stmt.step();
+    try testing.expectEqual(@as(i64, 0), links_count_stmt.columnInt(0));
+    try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "foo"));
+}
+
+test "unlinkSameVersionKegLinks is a no-op when no row matches the keep path" {
+    var tdb = try TempDb.init("force_unlink_no_match");
+    defer tdb.deinit();
+    const prefix = tdb.dir;
+
+    const keg = try seedKegWithBin(prefix, "foo", "1.0", "foo-tool");
+    defer testing.allocator.free(keg);
+    const keg_id = try insertKegRow(&tdb.db, "foo", "1.0", 0, keg);
+
+    var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
+    try linker.link(keg, "foo", keg_id);
+
+    // Different cellar_path than the seeded row → must not unlink.
+    const other = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/foo/2.0", .{prefix});
+    defer testing.allocator.free(other);
+    install.unlinkSameVersionKegLinks(&linker, &tdb.db, "foo", other);
+
+    var link_buf: [512]u8 = undefined;
+    const link_path = try std.fmt.bufPrint(&link_buf, "{s}/bin/foo-tool", .{prefix});
+    try std.Io.Dir.accessAbsolute(std.Options.debug_io, link_path, .{});
+}
+
+test "unlinkSameVersionKegLinks leaves other packages untouched" {
+    var tdb = try TempDb.init("force_unlink_scoped");
+    defer tdb.deinit();
+    const prefix = tdb.dir;
+
+    const foo = try seedKegWithBin(prefix, "foo", "1.0", "foo-tool");
+    defer testing.allocator.free(foo);
+    const bar = try seedKegWithBin(prefix, "bar", "1.0", "bar-tool");
+    defer testing.allocator.free(bar);
+
+    const foo_id = try insertKegRow(&tdb.db, "foo", "1.0", 0, foo);
+    const bar_id = try insertKegRow(&tdb.db, "bar", "1.0", 0, bar);
+
+    var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
+    try linker.link(foo, "foo", foo_id);
+    try linker.link(bar, "bar", bar_id);
+
+    install.unlinkSameVersionKegLinks(&linker, &tdb.db, "foo", foo);
+
+    // foo's symlink gone, bar's intact.
+    var foo_link_buf: [512]u8 = undefined;
+    const foo_link = try std.fmt.bufPrint(&foo_link_buf, "{s}/bin/foo-tool", .{prefix});
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(std.Options.debug_io, foo_link, .{}));
+
+    var bar_link_buf: [512]u8 = undefined;
+    const bar_link = try std.fmt.bufPrint(&bar_link_buf, "{s}/bin/bar-tool", .{prefix});
+    try std.Io.Dir.accessAbsolute(std.Options.debug_io, bar_link, .{});
+}
+
 test "unlinkAndDeleteStaleKegRows wipes multiple stale rows for the same name in one pass" {
     var tdb = try TempDb.init("force_sweep_db_multi");
     defer tdb.deinit();

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -953,12 +953,15 @@ test "dropTopLevelJobs preserves dep order across mixed lists" {
     try testing.expectEqualStrings("dep_b", jobs.items[1].name);
 }
 
-// --- unlinkAndDeleteStaleKegRows: force-reinstall across a revision
-// bump must drop the prior keg's DB row + its links + its dependencies
-// + its on-disk dir, mirroring the upgrade path. Without this the
-// freshly-swept disk dir would leave the kegs row pointing at nothing
-// and `malt doctor` would flip from "Mach-O placeholders" to
-// "Missing kegs" — same broken state, different message.
+// --- Stale-keg sweep: force-reinstall across a revision bump must
+// drop the prior keg's DB row + its links + its dependencies + its
+// on-disk dir, mirroring the upgrade path. The sweep is split in
+// two so the user pin survives:
+//   - `unlinkStaleKegLinks` (pre-link) clears symlinks + links rows
+//   - `recordKeg` (in linkAndRecord) inherits the pin via COALESCE-MAX
+//   - `dropStaleKegRows` (post-link) wipes rows + dirs
+// Tests below exercise the combined sweep (the call-site shape)
+// plus the narrow per-helper contracts.
 
 fn insertKegRow(
     db: *sqlite.Database,
@@ -1013,7 +1016,7 @@ fn kegRowCount(db: *sqlite.Database, name: []const u8) !i64 {
     return stmt.columnInt(0);
 }
 
-test "unlinkAndDeleteStaleKegRows drops the stale row, its symlinks, and its dir" {
+test "stale-keg sweep (unlink + drop) clears the prior row, its symlinks, and its dir" {
     var tdb = try TempDb.init("force_sweep_db_row");
     defer tdb.deinit();
     const prefix = tdb.dir;
@@ -1035,15 +1038,11 @@ test "unlinkAndDeleteStaleKegRows drops the stale row, its symlinks, and its dir
     const link_path = try std.fmt.bufPrint(&link_buf, "{s}/bin/foo-tool", .{prefix});
     try std.Io.Dir.accessAbsolute(std.Options.debug_io, link_path, .{});
 
-    // Resolved version is foo 2.0. Sweep against foo's other DB rows.
-    install.unlinkAndDeleteStaleKegRows(
-        &malt.app_ctx.debug_ctx,
-        testing.allocator,
-        &tdb.db,
-        &linker,
-        "foo",
-        keep_keg,
-    );
+    // Resolved version is foo 2.0. Sweep is two-phase at the call
+    // site: unlink first (pre-link), drop rows + dirs second
+    // (post-link). Test the combined effect.
+    install.unlinkStaleKegLinks(&tdb.db, &linker, "foo", keep_keg);
+    install.dropStaleKegRows(&malt.app_ctx.debug_ctx, testing.allocator, &tdb.db, "foo", keep_keg);
 
     // Stale row + dir + symlink all gone; keep row + dir untouched.
     try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "foo"));
@@ -1059,7 +1058,7 @@ test "unlinkAndDeleteStaleKegRows drops the stale row, its symlinks, and its dir
     try testing.expectEqual(keep_id, stmt.columnInt(0));
 }
 
-test "unlinkAndDeleteStaleKegRows is a no-op when no sibling rows exist" {
+test "stale-keg sweep is a no-op when no sibling rows exist" {
     var tdb = try TempDb.init("force_sweep_db_solo");
     defer tdb.deinit();
     const prefix = tdb.dir;
@@ -1070,20 +1069,14 @@ test "unlinkAndDeleteStaleKegRows is a no-op when no sibling rows exist" {
 
     var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
 
-    install.unlinkAndDeleteStaleKegRows(
-        &malt.app_ctx.debug_ctx,
-        testing.allocator,
-        &tdb.db,
-        &linker,
-        "bar",
-        keep_keg,
-    );
+    install.unlinkStaleKegLinks(&tdb.db, &linker, "bar", keep_keg);
+    install.dropStaleKegRows(&malt.app_ctx.debug_ctx, testing.allocator, &tdb.db, "bar", keep_keg);
 
     try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "bar"));
     try std.Io.Dir.accessAbsolute(std.Options.debug_io, keep_keg, .{});
 }
 
-test "unlinkAndDeleteStaleKegRows tolerates a stale row whose dir is already gone" {
+test "stale-keg sweep tolerates a stale row whose dir is already gone" {
     var tdb = try TempDb.init("force_sweep_db_no_disk");
     defer tdb.deinit();
     const prefix = tdb.dir;
@@ -1101,14 +1094,8 @@ test "unlinkAndDeleteStaleKegRows tolerates a stale row whose dir is already gon
 
     var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
 
-    install.unlinkAndDeleteStaleKegRows(
-        &malt.app_ctx.debug_ctx,
-        testing.allocator,
-        &tdb.db,
-        &linker,
-        "baz",
-        keep_keg,
-    );
+    install.unlinkStaleKegLinks(&tdb.db, &linker, "baz", keep_keg);
+    install.dropStaleKegRows(&malt.app_ctx.debug_ctx, testing.allocator, &tdb.db, "baz", keep_keg);
 
     // Stale row gone even though its dir was already absent.
     try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "baz"));
@@ -1200,7 +1187,7 @@ test "unlinkSameVersionKegLinks leaves other packages untouched" {
     try std.Io.Dir.accessAbsolute(std.Options.debug_io, bar_link, .{});
 }
 
-test "unlinkAndDeleteStaleKegRows wipes multiple stale rows for the same name in one pass" {
+test "stale-keg sweep wipes multiple stale rows for the same name in one pass" {
     var tdb = try TempDb.init("force_sweep_db_multi");
     defer tdb.deinit();
     const prefix = tdb.dir;
@@ -1224,14 +1211,8 @@ test "unlinkAndDeleteStaleKegRows wipes multiple stale rows for the same name in
 
     var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
 
-    install.unlinkAndDeleteStaleKegRows(
-        &malt.app_ctx.debug_ctx,
-        testing.allocator,
-        &tdb.db,
-        &linker,
-        "qux",
-        keep,
-    );
+    install.unlinkStaleKegLinks(&tdb.db, &linker, "qux", keep);
+    install.dropStaleKegRows(&malt.app_ctx.debug_ctx, testing.allocator, &tdb.db, "qux", keep);
 
     try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "qux"));
     for ([_][]const u8{ v1, v2, v3 }) |stale| {
@@ -1240,7 +1221,7 @@ test "unlinkAndDeleteStaleKegRows wipes multiple stale rows for the same name in
     try std.Io.Dir.accessAbsolute(std.Options.debug_io, keep, .{});
 }
 
-test "unlinkAndDeleteStaleKegRows leaves other packages untouched" {
+test "stale-keg sweep leaves other packages untouched" {
     var tdb = try TempDb.init("force_sweep_db_scoped");
     defer tdb.deinit();
     const prefix = tdb.dir;
@@ -1258,16 +1239,76 @@ test "unlinkAndDeleteStaleKegRows leaves other packages untouched" {
 
     var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
 
-    install.unlinkAndDeleteStaleKegRows(
-        &malt.app_ctx.debug_ctx,
-        testing.allocator,
-        &tdb.db,
-        &linker,
-        "foo",
-        keep_foo,
-    );
+    install.unlinkStaleKegLinks(&tdb.db, &linker, "foo", keep_foo);
+    install.dropStaleKegRows(&malt.app_ctx.debug_ctx, testing.allocator, &tdb.db, "foo", keep_foo);
 
     try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "foo"));
     try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "qux"));
     try std.Io.Dir.accessAbsolute(std.Options.debug_io, other, .{});
+}
+
+// The pin-preservation contract: when a user pinned the stale
+// revision and force-reinstalls across a revision bump, the pin must
+// migrate to the new row via `recordKeg`'s INSERT OR REPLACE
+// `COALESCE-MAX` subquery. That subquery runs against the kegs
+// table BEFORE the new row lands, so the stale row must still exist
+// at that moment. The two-phase sweep guarantees this:
+// unlinkStaleKegLinks clears the symlinks pre-link, but the row
+// stays until dropStaleKegRows runs post-link.
+test "two-phase sweep preserves a pin set on the stale revision through INSERT OR REPLACE" {
+    var tdb = try TempDb.init("force_pin_preservation");
+    defer tdb.deinit();
+    const prefix = tdb.dir;
+
+    const stale_keg = try seedKegWithBin(prefix, "foo", "1.0", "foo-tool");
+    defer testing.allocator.free(stale_keg);
+    const keep_keg = try seedKegWithBin(prefix, "foo", "2.0", "foo-tool");
+    defer testing.allocator.free(keep_keg);
+
+    const stale_id = try insertKegRow(&tdb.db, "foo", "1.0", 0, stale_keg);
+
+    // Stamp the pin on the stale row, mirroring `malt pin foo`.
+    {
+        var pin_stmt = try tdb.db.prepare("UPDATE kegs SET pinned = 1 WHERE id = ?1;");
+        defer pin_stmt.finalize();
+        try pin_stmt.bindInt(1, stale_id);
+        _ = try pin_stmt.step();
+    }
+
+    var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
+    try linker.link(stale_keg, "foo", stale_id);
+
+    // Pre-link: clear the stale install's symlinks so the new
+    // linker.link does not collide. Row + pin flag stay.
+    install.unlinkStaleKegLinks(&tdb.db, &linker, "foo", keep_keg);
+
+    // Simulate recordKeg's INSERT OR REPLACE running against the
+    // table while the stale row still carries the pin. Use the same
+    // COALESCE-MAX wiring the production code uses.
+    {
+        var insert = try tdb.db.prepare(
+            \\INSERT OR REPLACE INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, pinned)
+            \\VALUES (?1, ?2, ?3, ?4, ?5, ?6, COALESCE((SELECT MAX(pinned) FROM kegs WHERE name = ?1), 0));
+        );
+        defer insert.finalize();
+        try insert.bindText(1, "foo");
+        try insert.bindText(2, "foo");
+        try insert.bindText(3, "2.0");
+        try insert.bindInt(4, 0);
+        try insert.bindText(5, "0" ** 64);
+        try insert.bindText(6, keep_keg);
+        _ = try insert.step();
+    }
+
+    // Post-link: drop the stale row + dir. Pin already migrated to
+    // the new row in the step above.
+    install.dropStaleKegRows(&malt.app_ctx.debug_ctx, testing.allocator, &tdb.db, "foo", keep_keg);
+
+    try testing.expectEqual(@as(i64, 1), try kegRowCount(&tdb.db, "foo"));
+
+    var pin_stmt = try tdb.db.prepare("SELECT pinned FROM kegs WHERE name = ?1 LIMIT 1;");
+    defer pin_stmt.finalize();
+    try pin_stmt.bindText(1, "foo");
+    _ = try pin_stmt.step();
+    try testing.expectEqual(@as(i64, 1), pin_stmt.columnInt(0));
 }


### PR DESCRIPTION
## Description

`malt install <pkg> --force` is the documented way out of a broken install — the doctor errors literally tell users to reinstall. Several gaps made it unreliable, and the most recent live-machine session surfaced all of them at once:

- A revision-bumped force-reinstall left the prior keg dir AND its `kegs` row behind, so `doctor` flipped between "Mach-O placeholders" (orphan dir) and "Missing kegs" (orphan row).
- `--force` against an already-installed package errored with "Use --force to overwrite" — even though `--force` was on — because the linker conflict check fired on the package's own prior symlinks. The failure path then wiped the freshly-materialized keg, leaving the user with dangling symlinks and nothing in `Cellar/<name>/`.
- The destructive cleanup ran before the materialize phase, so a network blip mid-reinstall took the prior working keg with it.
- The local/tap `.rb` install path ignored `--force` past the "already installed" skip — same orphan-keg + linker traps as the JSON pipeline.

This branch closes those gaps. Force-reinstall now means: keep the prior state intact until materialize succeeds, then unlink the prior install's symlinks, drop any stale rows + their deps, sweep orphan sibling dirs, and link the new keg into a clean target. Same three-phase sequence runs on both the JSON pipeline and the local/tap path. The user pin is preserved through the existing COALESCE-MAX on `pinned` by name.

End-to-end coverage:
- `scripts/regressions/install_force_sweeps_old_kegs.sh` — JSON pipeline, both revision-bump and same-version scenarios against `pcre2`.
- `scripts/regressions/install_force_sweeps_tap.sh` — tap path against `indaco/tap/sley`, both same-version and stale-sibling scenarios.

## Related Issue

- None

## Notes for Reviewers

- None