### PR TITLE
feat(cli/doctor): nudge users toward --fix when conditions are auto-fixable

### DIFF
--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -134,6 +134,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     const fix_requested = fix_mod.wantsFix(args);
 
     resetVerboseHint();
+    resetFixHint();
     output.info("Running health checks...", .{});
     const tally = runChecks(.{
         .allocator = allocator,
@@ -182,9 +183,11 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     emitVerboseHintIfNeeded();
     if (tally.errors > 0) {
         output.err("{d} error(s), {d} warning(s)", .{ tally.errors, tally.warnings });
+        emitFixHintIfNeeded(fix_requested);
         std.process.exit(2);
     } else if (tally.warnings > 0) {
         output.warn("{d} warning(s)", .{tally.warnings});
+        emitFixHintIfNeeded(fix_requested);
         std.process.exit(1);
     } else {
         output.success("Your malt installation is healthy", .{});
@@ -220,6 +223,37 @@ pub fn emitVerboseHintIfNeeded() void {
     if (output.isVerbose()) return;
     if (!verbose_hint_armed) return;
     output.dim("run with --verbose for the full list", .{});
+}
+
+/// Armed by any check that surfaces a condition `--fix` can act on
+/// (stale lock with dead PID, orphan store entries, broken symlinks).
+/// Manual-class issues do not arm: their inline rows already carry
+/// the same remediation hint `--fix` would print, so the nudge would
+/// be pure noise. `execute` reads it after the check loop to emit a
+/// dim "run with --fix" suggestion.
+var fix_hint_armed: bool = false;
+
+/// Test hook + production reset: clear the fix-hint flag at the top
+/// of every `execute` so a previous run on the same process doesn't
+/// leak its state.
+pub fn resetFixHint() void {
+    fix_hint_armed = false;
+}
+
+/// Internal arm — called by checks that detect a safe-class
+/// condition `--fix` can resolve. `emitFixHintIfNeeded` decides
+/// whether to surface the nudge.
+fn armFixHint() void {
+    fix_hint_armed = true;
+}
+
+/// Emit a "run with --fix to apply safe-class fixes" nudge after the
+/// check loop when a fixable condition was detected and `--fix` was
+/// not already on the command line.
+pub fn emitFixHintIfNeeded(fix_requested: bool) void {
+    if (fix_requested) return;
+    if (!fix_hint_armed) return;
+    output.dim("run with --fix to apply safe-class fixes", .{});
 }
 
 /// Emit one dim/faint detail line indented under a check row, with a
@@ -360,6 +394,7 @@ fn checkStaleLock(ctx: CheckCtx, name: []const u8) CheckResult {
         } else {
             const s = std.fmt.bufPrint(&pid_buf, "Stale lock from dead PID {d}. Run: rm {s}", .{ p, lock_path }) catch "Stale lock detected";
             printCheck(name, .warn_status, s);
+            armFixHint();
         }
         return .warn_status;
     }
@@ -503,6 +538,7 @@ fn checkOrphanedStore(ctx: CheckCtx, name: []const u8) CheckResult {
         .{orphan_count},
     ) catch "Orphaned store entries found. Run: mt purge --store-orphans";
     printCheck(name, .warn_status, msg);
+    armFixHint();
     return .warn_status;
 }
 
@@ -597,6 +633,7 @@ fn checkBrokenSymlinks(ctx: CheckCtx, name: []const u8) CheckResult {
     ) catch "Broken symlinks found. Run: mt cleanup";
     printCheck(name, .warn_status, msg);
     armVerboseHint();
+    armFixHint();
     writeVerboseList(offenders.items);
     return .warn_status;
 }
@@ -837,4 +874,58 @@ pub fn countMissingLocalSources(
         };
     }
     return census;
+}
+
+// ── inline unit tests ───────────────────────────────────────────────
+//
+// Pure state-machine coverage for the fix-hint flag. Production walker
+// coverage (which check arms the flag) lives in
+// `tests/doctor_dispatch_test.zig` as integration; here we only pin
+// the gating contract of the emit helper.
+
+const testing = std.testing;
+
+fn fixHintEmitted(buf: []const u8) bool {
+    return std.mem.indexOf(u8, buf, "safe-class fixes") != null;
+}
+
+fn captureFixEmit(allocator: std.mem.Allocator, fix_requested: bool) !std.ArrayList(u8) {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &buf);
+    defer output.endStderrCapture();
+    emitFixHintIfNeeded(fix_requested);
+    return buf;
+}
+
+test "emitFixHintIfNeeded: silent without arming" {
+    resetFixHint();
+    var captured = try captureFixEmit(testing.allocator, false);
+    defer captured.deinit(testing.allocator);
+    try testing.expect(!fixHintEmitted(captured.items));
+}
+
+test "emitFixHintIfNeeded: emits when armed and --fix is off" {
+    resetFixHint();
+    armFixHint();
+    var captured = try captureFixEmit(testing.allocator, false);
+    defer captured.deinit(testing.allocator);
+    try testing.expect(fixHintEmitted(captured.items));
+}
+
+test "emitFixHintIfNeeded: silent when --fix was already passed" {
+    resetFixHint();
+    armFixHint();
+    var captured = try captureFixEmit(testing.allocator, true);
+    defer captured.deinit(testing.allocator);
+    try testing.expect(!fixHintEmitted(captured.items));
+}
+
+test "resetFixHint: clears a previously-armed flag" {
+    resetFixHint();
+    armFixHint();
+    resetFixHint();
+    var captured = try captureFixEmit(testing.allocator, false);
+    defer captured.deinit(testing.allocator);
+    try testing.expect(!fixHintEmitted(captured.items));
 }

--- a/tests/doctor_dispatch_test.zig
+++ b/tests/doctor_dispatch_test.zig
@@ -655,3 +655,232 @@ test "checkMissingKegs under --verbose lists each missing (name version) pair" {
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "phantom-a 9.9") != null);
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "phantom-b 1.0") != null);
 }
+
+// --- --fix hint emission ----------------------------------------------
+
+test "fix hint fires when a broken symlink is present and --fix is off" {
+    // Broken symlink is a safe-class condition `--fix` can remove,
+    // so the dim nudge after the summary helps a user who doesn't
+    // know the flag exists.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "fix_hint_symlink");
+    defer s.deinit(allocator);
+
+    const link_path = try std.fmt.allocPrint(allocator, "{s}/bin/ghost-fix-hint", .{s.path});
+    defer allocator.free(link_path);
+    try std.Io.Dir.symLinkAbsolute(
+        std.Options.debug_io,
+        "/tmp/malt_doctor_disp_fix_hint_ghost_target_dne",
+        link_path,
+        .{},
+    );
+
+    output.setVerbose(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.resetFixHint();
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+    doctor.emitFixHintIfNeeded(false);
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "--fix") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "safe-class fixes") != null);
+}
+
+test "fix hint fires when an orphaned store entry is present" {
+    // Plant a store/<sha> directory with no matching store_refs row;
+    // checkOrphanedStore counts it and must arm the hint.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "fix_hint_orphan");
+    defer s.deinit(allocator);
+
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+    }
+
+    const orphan = try std.fmt.allocPrint(
+        allocator,
+        "{s}/store/0000000000000000000000000000000000000000000000000000000000000000",
+        .{s.path},
+    );
+    defer allocator.free(orphan);
+    try test_io.cwd().createDirPath(std.Options.debug_io, orphan);
+
+    output.setVerbose(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.resetFixHint();
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+    doctor.emitFixHintIfNeeded(false);
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "--fix") != null);
+}
+
+test "fix hint stays silent when --fix was already passed" {
+    // The user already knows about the flag; re-suggesting it after
+    // the summary is noise.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "fix_hint_already_on");
+    defer s.deinit(allocator);
+
+    const link_path = try std.fmt.allocPrint(allocator, "{s}/bin/ghost-fix-already", .{s.path});
+    defer allocator.free(link_path);
+    try std.Io.Dir.symLinkAbsolute(
+        std.Options.debug_io,
+        "/tmp/malt_doctor_disp_fix_already_ghost_target_dne",
+        link_path,
+        .{},
+    );
+
+    output.setVerbose(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.resetFixHint();
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+    doctor.emitFixHintIfNeeded(true);
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "safe-class fixes") == null);
+}
+
+test "fix hint stays silent on a clean prefix" {
+    // No fixable conditions → no nudge. Otherwise we'd train users
+    // to ignore it as noise on healthy systems.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "fix_hint_clean");
+    defer s.deinit(allocator);
+
+    output.setVerbose(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.resetFixHint();
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+    doctor.emitFixHintIfNeeded(false);
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "safe-class fixes") == null);
+}
+
+test "fix hint stays silent when only manual-class issues are present" {
+    // A missing keg is manual-class (reinstall); the inline check
+    // row already says so. Suggesting --fix would just route the
+    // user to a near-duplicate hint.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "fix_hint_manual_only");
+    defer s.deinit(allocator);
+
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+        try db.exec(
+            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+            \\VALUES ('phantom-fix-hint', 'phantom-fix-hint', '9.9', 0, '', '/tmp/malt_doctor_disp_phantom_fix_hint_dne');
+        );
+    }
+
+    output.setVerbose(false);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.resetFixHint();
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+    doctor.emitFixHintIfNeeded(false);
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "safe-class fixes") == null);
+}
+
+test "resetFixHint clears state between runs so a clean walker stays silent" {
+    // Without the reset, an armed flag from a prior run on the same
+    // process would leak into the next call. Pin the contract here.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "fix_hint_reset");
+    defer s.deinit(allocator);
+
+    const link_path = try std.fmt.allocPrint(allocator, "{s}/bin/ghost-fix-reset", .{s.path});
+    defer allocator.free(link_path);
+    try std.Io.Dir.symLinkAbsolute(
+        std.Options.debug_io,
+        "/tmp/malt_doctor_disp_fix_reset_ghost_target_dne",
+        link_path,
+        .{},
+    );
+
+    output.setVerbose(false);
+
+    // First walk arms the flag.
+    doctor.resetFixHint();
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+
+    // Now remove the offender and reset; the next walk has nothing
+    // to find, and the hint must not fire.
+    try test_io.cwd().deleteFile(std.Options.debug_io, link_path);
+    doctor.resetFixHint();
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    _ = doctor.runChecks(.{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks);
+    doctor.emitFixHintIfNeeded(false);
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "safe-class fixes") == null);
+}


### PR DESCRIPTION
## Description

After the summary line, `mt doctor` now emits a dim hint whenever it surfaced a stale lock (dead PID), orphaned store entries, or broken symlinks - and the user did not already pass `--fix`. The same discoverability pattern the `--verbose` hint already uses, applied to the auto-fix surface so users learn the flag without having to read the README first.

When `--fix` is already on the command line, the hint is silent.

## Related Issue

- None

## Notes for Reviewers

- None