### PR TITLE
refactor(core/hash): host constantTimeEql, guard core→cli boundary

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -175,6 +175,7 @@ pub fn build(b: *std.Build) void {
         "tests/no_readall_in_loop_test.zig",
         "tests/test_io_primitives_test.zig",
         "tests/no_io_mod_in_src_test.zig",
+        "tests/no_cli_in_core_test.zig",
         "tests/ui_color_theme_test.zig",
         "tests/install_local_test.zig",
         "tests/cask_extra_test.zig",
@@ -308,7 +309,7 @@ pub fn build(b: *std.Build) void {
     });
     test_io_mod.addImport("malt", malt_lib);
 
-    @setEvalBranchQuota(16000);
+    @setEvalBranchQuota(20000);
     inline for (test_modules) |test_file| {
         // e.g. "tests/formula_test.zig" → "formula_test" (so each test binary
         // has a unique install name, which `test-bin` / kcov need).

--- a/src/cli/install/record.zig
+++ b/src/cli/install/record.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
 const sqlite = @import("../../db/sqlite.zig");
 const formula_mod = @import("../../core/formula.zig");
+const hash = @import("../../core/hash.zig");
 const output = @import("../../ui/output.zig");
 
 pub const InstallError = error{
@@ -199,13 +200,7 @@ pub fn ensureDirs(ctx: *const AppCtx, prefix: []const u8) !void {
     }
 }
 
-/// Constant-time equality for byte slices. Used on the SHA256
-/// comparison so a network-positioned attacker cannot mount a byte-by-
-/// byte timing oracle against the expected hash. Returns false
-/// immediately on length mismatch (the length itself is not a secret).
-pub fn constantTimeEql(comptime T: type, a: []const T, b: []const T) bool {
-    if (a.len != b.len) return false;
-    var diff: T = 0;
-    for (a, b) |x, y| diff |= x ^ y;
-    return diff == 0;
-}
+/// Back-compat alias: callers reach `constantTimeEql` via
+/// `install.zig` and `record.zig`. Canonical home is `core/hash`.
+/// Drop once the install facade settles.
+pub const constantTimeEql = hash.constantTimeEql;

--- a/src/core/bottle.zig
+++ b/src/core/bottle.zig
@@ -7,7 +7,6 @@ const archive = @import("../fs/archive.zig");
 const client_mod = @import("../net/client.zig");
 const ghcr_mod = @import("../net/ghcr.zig");
 const hash_mod = @import("hash.zig");
-const install_cmd = @import("../cli/install.zig");
 
 pub const BottleError = error{
     DownloadFailed,
@@ -53,7 +52,7 @@ pub fn checkBottleSha(expected: []const u8, body: []const u8) ?MismatchInfo {
 
     // Constant-time compare — deny a byte-by-byte timing oracle against
     // the expected hash.
-    if (install_cmd.constantTimeEql(u8, &computed_hex, expected)) return null;
+    if (hash_mod.constantTimeEql(u8, &computed_hex, expected)) return null;
 
     var info: MismatchInfo = .{
         .expected = undefined,
@@ -150,7 +149,7 @@ pub fn verify(io: std.Io, file_path: []const u8, expected_sha256: []const u8) !b
 
     // Constant-time SHA compare — denies a byte-by-byte timing oracle on
     // re-verify-on-disk paths reachable with a remote-controllable hash.
-    return install_cmd.constantTimeEql(u8, &computed_hex, expected_sha256);
+    return hash_mod.constantTimeEql(u8, &computed_hex, expected_sha256);
 }
 
 test "verify returns true when sha256 matches on-disk content" {

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -5,7 +5,6 @@ const std = @import("std");
 
 const sqlite = @import("../db/sqlite.zig");
 const client_mod = @import("../net/client.zig");
-const install_cmd = @import("../cli/install.zig");
 const archive_mod = @import("../fs/archive.zig");
 const hash_mod = @import("hash.zig");
 const child_mod = @import("child.zig");
@@ -1001,9 +1000,9 @@ pub fn verifyFileSha256(io: std.Io, file_path: []const u8, expected: ?[]const u8
     if (std.mem.eql(u8, expected_hash, "no_check")) return;
 
     const got = try hashFileSha256(io, file_path);
-    // Constant-time SHA compare — mirrors install.zig to close the
-    // byte-by-byte timing oracle on the expected hash.
-    if (!install_cmd.constantTimeEql(u8, &got, expected_hash)) return error.Sha256Mismatch;
+    // Constant-time SHA compare closes the byte-by-byte timing oracle
+    // on the expected hash.
+    if (!hash_mod.constantTimeEql(u8, &got, expected_hash)) return error.Sha256Mismatch;
 }
 
 /// Check if an application is currently running by its path.

--- a/src/core/hash.zig
+++ b/src/core/hash.zig
@@ -40,3 +40,63 @@ pub fn hashFileSha256Hex(io: std.Io, file_path: []const u8) ![64]u8 {
     const raw = try hashFileSha256Raw(io, file_path);
     return std.fmt.bytesToHex(raw, .lower);
 }
+
+/// Constant-time slice equality. Closes the per-byte timing oracle on
+/// hex-SHA compares: stops only after looking at every byte, so an
+/// adaptive attacker cannot iterate one byte at a time.
+pub fn constantTimeEql(comptime T: type, a: []const T, b: []const T) bool {
+    if (a.len != b.len) return false;
+    var diff: T = 0;
+    for (a, b) |x, y| diff |= x ^ y;
+    return diff == 0;
+}
+
+test "constantTimeEql returns true for equal byte slices" {
+    try std.testing.expect(constantTimeEql(u8, "deadbeef", "deadbeef"));
+}
+
+test "constantTimeEql returns false on length mismatch" {
+    try std.testing.expect(!constantTimeEql(u8, "abc", "abcd"));
+}
+
+test "constantTimeEql returns false on different content" {
+    try std.testing.expect(!constantTimeEql(u8, "abcd", "abce"));
+}
+
+test "constantTimeEql returns true for empty equal slices" {
+    try std.testing.expect(constantTimeEql(u8, "", ""));
+}
+
+// Regression guards: the SHA path mixes byte positions, so a wrong
+// implementation that early-outs on the first byte or that masks late
+// bytes would still pass the smoke matrix above. These pin each
+// position end-to-end so an accidental refactor cannot slip past.
+
+test "constantTimeEql distinguishes inputs that differ only at first byte" {
+    const a = "0deadbeef" ** 8;
+    var b: [a.len]u8 = undefined;
+    @memcpy(&b, a);
+    b[0] = '1';
+    try std.testing.expect(!constantTimeEql(u8, a, &b));
+}
+
+test "constantTimeEql distinguishes inputs that differ only at last byte" {
+    const a = "deadbeef0" ** 8;
+    var b: [a.len]u8 = undefined;
+    @memcpy(&b, a);
+    b[b.len - 1] = '1';
+    try std.testing.expect(!constantTimeEql(u8, a, &b));
+}
+
+test "constantTimeEql handles single-byte slices" {
+    try std.testing.expect(constantTimeEql(u8, "a", "a"));
+    try std.testing.expect(!constantTimeEql(u8, "a", "b"));
+}
+
+test "constantTimeEql works on non-u8 elements (generic over T)" {
+    const a = [_]u32{ 1, 2, 3, 4 };
+    const b = [_]u32{ 1, 2, 3, 4 };
+    const c = [_]u32{ 1, 2, 3, 5 };
+    try std.testing.expect(constantTimeEql(u32, &a, &b));
+    try std.testing.expect(!constantTimeEql(u32, &a, &c));
+}

--- a/tests/no_cli_in_core_test.zig
+++ b/tests/no_cli_in_core_test.zig
@@ -1,0 +1,82 @@
+//! Pin test: no `core/*` file may import `cli/*`.
+
+const std = @import("std");
+const testing = std.testing;
+
+const test_io = @import("test_io");
+
+const scanned_root = "src/core";
+const import_prefix = "@import(\"";
+
+test "core/* files do not import cli/*" {
+    const io = std.Options.debug_io;
+
+    var failures: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (failures.items) |s| testing.allocator.free(s);
+        failures.deinit(testing.allocator);
+    }
+
+    try scanRoot(io, scanned_root, &failures);
+
+    if (failures.items.len != 0) {
+        for (failures.items) |f| std.debug.print("{s}\n", .{f});
+        return error.CoreImportsCli;
+    }
+}
+
+fn scanRoot(io: std.Io, root: []const u8, failures: *std.ArrayList([]const u8)) !void {
+    var dir = try test_io.cwd().openDir(io, root, .{ .iterate = true });
+    defer dir.close(io);
+
+    var walker = try dir.walk(testing.allocator);
+    defer walker.deinit();
+
+    while (try walker.next(io)) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.path, ".zig")) continue;
+
+        const file = try dir.openFile(io, entry.path, .{});
+        defer file.close(io);
+        const stat = try file.stat(io);
+        const content = try testing.allocator.alloc(u8, @intCast(stat.size));
+        defer testing.allocator.free(content);
+        _ = try file.readPositionalAll(io, content, 0);
+
+        try scanContent(root, entry.path, content, failures);
+    }
+}
+
+fn scanContent(
+    root: []const u8,
+    rel_path: []const u8,
+    content: []const u8,
+    failures: *std.ArrayList([]const u8),
+) !void {
+    var cursor: usize = 0;
+    while (std.mem.indexOfPos(u8, content, cursor, import_prefix)) |start| {
+        const path_start = start + import_prefix.len;
+        const end = std.mem.indexOfScalarPos(u8, content, path_start, '"') orelse break;
+        const import_path = content[path_start..end];
+        cursor = end + 1;
+
+        if (resolvesIntoCli(import_path)) {
+            const msg = try std.fmt.allocPrint(
+                testing.allocator,
+                "{s}/{s} imports {s}",
+                .{ root, rel_path, import_path },
+            );
+            try failures.append(testing.allocator, msg);
+        }
+    }
+}
+
+/// True when a relative `@import` path crosses out of `core` and
+/// resolves into `cli/`. Strip every leading `../` segment and
+/// inspect whatever the import actually targets.
+fn resolvesIntoCli(path: []const u8) bool {
+    var rest = path;
+    while (std.mem.startsWith(u8, rest, "../")) rest = rest[3..];
+    return std.mem.startsWith(u8, rest, "cli/") or
+        std.mem.eql(u8, rest, "cli.zig");
+}


### PR DESCRIPTION
## Description

Closes the `core -> cli` layering reversal that re-appeared when `core/bottle` and `core/cask` started importing `cli/install` for a generic byte comparator. The comparator now lives under `core/hash`, both modules import it directly, and a new static-invariant test fails the build if any `core/*` file imports `cli/*` again.

## Related Issue

- None

## Notes for Reviewers

- None