### PR TITLE
refactor(core): extract signals module from main

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -176,6 +176,7 @@ pub fn build(b: *std.Build) void {
         "tests/test_io_primitives_test.zig",
         "tests/no_io_mod_in_src_test.zig",
         "tests/no_cli_in_core_test.zig",
+        "tests/no_main_reach_in_cli_test.zig",
         "tests/ui_color_theme_test.zig",
         "tests/install_local_test.zig",
         "tests/cask_extra_test.zig",

--- a/src/app_ctx.zig
+++ b/src/app_ctx.zig
@@ -1,6 +1,12 @@
 //! Single source of `std.Io`, stdio sinks, and `Environ` for the process.
 //! Built in `main` from `std.process.Init.Minimal` and threaded down so
 //! subcommands stop reaching for module-level globals.
+//!
+//! Boundary policy: `AppCtx` is a CLI-layer aggregate. `cli/*` and `update/*`
+//! take `*const AppCtx`; `core/*` takes raw `std.Io` and
+//! `std.process.Environ` parameters by design — no stdio, no AppCtx.
+//! Keeping core library-shaped lets unit tests drive it with `debug_io`
+//! and an empty environ without ever staging a process context.
 
 const std = @import("std");
 const builtin = @import("builtin");

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -11,6 +11,7 @@ const formula_mod = @import("../core/formula.zig");
 const linker_mod = @import("../core/linker.zig");
 const plist_mod = @import("../core/services/plist.zig");
 const supervisor_mod = @import("../core/services/supervisor.zig");
+const signals = @import("../core/signals.zig");
 const store_mod = @import("../core/store.zig");
 const lock_mod = @import("../db/lock.zig");
 const schema = @import("../db/schema.zig");
@@ -570,15 +571,14 @@ fn executeWithOpts(
     defer all_jobs.deinit(allocator);
 
     // Check for Ctrl-C before resolution phase
-    const main_mod = @import("../main.zig");
-    if (main_mod.isInterrupted()) {
+    if (signals.isInterrupted()) {
         output.warn("Interrupted before resolution.", .{});
         return;
     }
 
     for (packages.items) |pkg_name| {
         // Check for Ctrl-C between packages during resolution
-        if (main_mod.isInterrupted()) {
+        if (signals.isInterrupted()) {
             output.warn("Interrupted during resolution.", .{});
             return;
         }
@@ -783,7 +783,7 @@ fn executeWithOpts(
     }
 
     // Check for Ctrl-C between download and materialize phases
-    if (main_mod.isInterrupted()) {
+    if (signals.isInterrupted()) {
         output.warn("Interrupted. Cleaning up...", .{});
         return;
     }
@@ -849,7 +849,7 @@ fn executeWithOpts(
     var failed_count: usize = 0;
 
     for (all_jobs.items, 0..) |*job, i| {
-        if (main_mod.isInterrupted()) {
+        if (signals.isInterrupted()) {
             output.warn("Interrupted. Stopping install.", .{});
             break;
         }

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -9,6 +9,7 @@ const AppCtx = @import("../app_ctx.zig").AppCtx;
 const sqlite = @import("../db/sqlite.zig");
 const schema = @import("../db/schema.zig");
 const lock_mod = @import("../db/lock.zig");
+const signals = @import("../core/signals.zig");
 const store_mod = @import("../core/store.zig");
 const linker_mod = @import("../core/linker.zig");
 const client_mod = @import("../net/client.zig");
@@ -276,8 +277,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     defer cancelled_names.deinit(allocator);
 
     // Honour Ctrl-C raised during setup, before any network work starts.
-    const main_mod = @import("../main.zig");
-    if (main_mod.isInterrupted()) {
+    if (signals.isInterrupted()) {
         output.warn("Interrupted before migration.", .{});
         return;
     }
@@ -382,7 +382,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         try parallel_mod.run(allocator, &pool, worker_count);
         // Mirror the serial loop's interrupt UX so users running with
         // --parallel still see "Interrupted" instead of silent skips.
-        if (main_mod.isInterrupted()) {
+        if (signals.isInterrupted()) {
             output.warn("Interrupted — skipping remaining kegs.", .{});
         }
 
@@ -407,7 +407,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
         for (keg_names.items) |keg_name| {
             // Stop at the next keg boundary when the user hits Ctrl-C.
-            if (main_mod.isInterrupted()) {
+            if (signals.isInterrupted()) {
                 output.warn("Interrupted — skipping remaining kegs.", .{});
                 break;
             }

--- a/src/cli/migrate/parallel.zig
+++ b/src/cli/migrate/parallel.zig
@@ -12,7 +12,7 @@ const ghcr_mod = @import("../../net/ghcr.zig");
 const api_mod = @import("../../net/api.zig");
 const output = @import("../../ui/output.zig");
 const progress_mod = @import("../../ui/progress.zig");
-const main_mod = @import("../../main.zig");
+const signals = @import("../../core/signals.zig");
 const keg_mod = @import("keg.zig");
 const manifest_mod = @import("manifest.zig");
 const post_install_queue_mod = @import("post_install_queue.zig");
@@ -119,7 +119,7 @@ fn worker(pool: *Pool) void {
             continue;
         }
 
-        if (main_mod.isInterrupted()) {
+        if (signals.isInterrupted()) {
             pool.outcomes[idx] = .{ .name = keg_name, .result = .cancelled };
             continue;
         }
@@ -230,8 +230,8 @@ test "boundWorkerCount caps by job count" {
 // already." The DB pointer stays `undefined` because the empty manifest
 // short-circuits the `and` before any DB query runs.
 test "worker interrupt branch routes untouched kegs to .cancelled" {
-    main_mod.setInterruptedForTest(true);
-    defer main_mod.setInterruptedForTest(false);
+    signals.setInterruptedForTest(true);
+    defer signals.setInterruptedForTest(false);
 
     const app_ctx_mod = @import("../../app_ctx.zig");
     const names = [_][]const u8{ "a", "b", "c" };

--- a/src/cli/services.zig
+++ b/src/cli/services.zig
@@ -6,6 +6,7 @@ const sqlite = @import("../db/sqlite.zig");
 const schema = @import("../db/schema.zig");
 const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
+const signals = @import("../core/signals.zig");
 const supervisor = @import("../core/services/supervisor.zig");
 
 pub const ServicesError = error{
@@ -203,8 +204,7 @@ fn cmdLogs(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []con
     var stdout_writer = stdout.writer(ctx.io, &write_buf);
     const w = &stdout_writer.interface;
     if (follow) {
-        const main_mod = @import("../main.zig");
-        try supervisor.followLog(ctx.io, allocator, path, tail_n, w, main_mod.isInterrupted);
+        try supervisor.followLog(ctx.io, allocator, path, tail_n, w, signals.isInterrupted);
     } else {
         try supervisor.tailLog(ctx.io, allocator, path, tail_n, w);
     }

--- a/src/core/signals.zig
+++ b/src/core/signals.zig
@@ -1,0 +1,96 @@
+//! Process-wide interrupt flag + SIGINT handler.
+//!
+//! Long-running CLI ops poll `isInterrupted()` between step boundaries so
+//! Ctrl-C cleans up instead of killing mid-write. Pulled out of `main.zig`
+//! so 12 sites in `cli/*` and `update/*` stop reaching up across the
+//! CLI/core boundary for a single atomic bool.
+
+const std = @import("std");
+
+/// Raised by `sigintHandler`, polled at step boundaries.
+var interrupted: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+
+/// Tracks whether `installHandler` has wired SIGINT. Lets dispatch
+/// distinguish a real production run (preserve any flag the handler set)
+/// from a test runner re-entering with stale state from a prior case.
+var handler_installed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+
+pub fn isInterrupted() bool {
+    return interrupted.load(.acquire);
+}
+
+/// Test-only override — raising real SIGINT would race the test runner.
+pub fn setInterruptedForTest(v: bool) void {
+    interrupted.store(v, .release);
+}
+
+/// Test-only override so the production-mode preservation branch is
+/// reachable from inline tests without actually installing a process-wide
+/// signal handler.
+pub fn setSignalHandlerInstalledForTest(v: bool) void {
+    handler_installed.store(v, .release);
+}
+
+pub fn signalHandlerInstalled() bool {
+    return handler_installed.load(.acquire);
+}
+
+fn sigintHandler(_: std.posix.SIG) callconv(.c) void {
+    interrupted.store(true, .release);
+}
+
+/// Wire SIGINT to flip the interrupt flag. Idempotent so repeated CLI
+/// invocations inside a test process do not double-register and do not
+/// clobber a flag the prior handler already set.
+pub fn installHandler() void {
+    if (handler_installed.load(.acquire)) return;
+    const act = std.posix.Sigaction{
+        .handler = .{ .handler = &sigintHandler },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    };
+    std.posix.sigaction(std.posix.SIG.INT, &act, null);
+    handler_installed.store(true, .release);
+}
+
+test "setInterruptedForTest round-trips through isInterrupted" {
+    setInterruptedForTest(true);
+    defer setInterruptedForTest(false);
+    try std.testing.expect(isInterrupted());
+
+    setInterruptedForTest(false);
+    try std.testing.expect(!isInterrupted());
+}
+
+test "setSignalHandlerInstalledForTest round-trips through signalHandlerInstalled" {
+    const prior = signalHandlerInstalled();
+    defer setSignalHandlerInstalledForTest(prior);
+
+    setSignalHandlerInstalledForTest(true);
+    try std.testing.expect(signalHandlerInstalled());
+
+    setSignalHandlerInstalledForTest(false);
+    try std.testing.expect(!signalHandlerInstalled());
+}
+
+// Idempotency matters because tests re-enter `main`-shaped code paths in
+// the same process. A naive second `sigaction` would still work at the
+// kernel level, but the worry is the interrupt flag: if the handler
+// already fired between two installs, the second call must not clobber it.
+test "installHandler does not clobber a raised interrupt flag" {
+    const prior_installed = signalHandlerInstalled();
+    const prior_interrupted = isInterrupted();
+    defer setSignalHandlerInstalledForTest(prior_installed);
+    defer setInterruptedForTest(prior_interrupted);
+
+    setSignalHandlerInstalledForTest(false);
+    setInterruptedForTest(false);
+
+    installHandler();
+    try std.testing.expect(signalHandlerInstalled());
+
+    // Simulate the handler firing between two install attempts.
+    setInterruptedForTest(true);
+    installHandler();
+    try std.testing.expect(isInterrupted());
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -58,6 +58,7 @@ pub const ruby_subprocess = @import("core/ruby_subprocess.zig");
 pub const sandbox_macos = @import("core/sandbox/macos.zig");
 pub const services_plist = @import("core/services/plist.zig");
 pub const services_supervisor = @import("core/services/supervisor.zig");
+pub const signals = @import("core/signals.zig");
 pub const store = @import("core/store.zig");
 pub const tap = @import("core/tap.zig");
 pub const lock = @import("db/lock.zig");
@@ -69,7 +70,6 @@ pub const clonefile = @import("fs/clonefile.zig");
 pub const codesign = @import("macho/codesign.zig");
 pub const parser = @import("macho/parser.zig");
 pub const patcher = @import("macho/patcher.zig");
-pub const main_mod = @import("main.zig");
 pub const api = @import("net/api.zig");
 pub const client = @import("net/client.zig");
 pub const ghcr = @import("net/ghcr.zig");
@@ -88,4 +88,8 @@ pub const version = @import("version.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());
+    // main.zig is not re-exported (it's the binary's entry point, not a
+    // library surface), but its inline tests still need to be discovered
+    // by the lib_tests target.
+    _ = @import("main.zig");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -30,6 +30,7 @@ const upgrade = @import("cli/upgrade.zig");
 const uses = @import("cli/uses.zig");
 const version_update = @import("cli/version_update.zig");
 const which_cmd = @import("cli/which.zig");
+const signals = @import("core/signals.zig");
 const color_mod = @import("ui/color.zig");
 const progress_mod = @import("ui/progress.zig");
 const notifier = @import("update/notifier.zig");
@@ -71,33 +72,6 @@ fn maltLogFn(
     const output = @import("ui/output.zig");
     if (level == .debug and !output.isDebug()) return;
     std.log.defaultLog(level, scope, fmt, args);
-}
-
-/// Global interrupt flag — set by SIGINT handler, checked at install step boundaries.
-var interrupted: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
-
-/// Tracks whether `main` has wired SIGINT to `sigintHandler`. Lets `dispatch`
-/// distinguish a real production run (preserve any flag the handler set) from
-/// a test runner re-entering with stale state from a prior case.
-var signal_handler_installed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
-
-pub fn isInterrupted() bool {
-    return interrupted.load(.acquire);
-}
-
-/// Test-only flag override — raising real SIGINT would race the test runner.
-pub fn setInterruptedForTest(v: bool) void {
-    interrupted.store(v, .release);
-}
-
-/// Test-only override so the production-mode preservation branch is reachable
-/// from inline tests without actually installing a process-wide signal handler.
-pub fn setSignalHandlerInstalledForTest(v: bool) void {
-    signal_handler_installed.store(v, .release);
-}
-
-fn sigintHandler(_: std.posix.SIG) callconv(.c) void {
-    interrupted.store(true, .release);
 }
 
 // CLI command modules
@@ -279,25 +253,25 @@ test "command_map resolves cleanup to the cleanup tag" {
 }
 
 test "dispatch clears stale interrupt under the test runner" {
-    setInterruptedForTest(true);
-    defer setInterruptedForTest(false);
+    signals.setInterruptedForTest(true);
+    defer signals.setInterruptedForTest(false);
 
     const ctx: AppCtx = .{ .io = std.Options.debug_io, .environ = .empty };
     try dispatch(std.testing.allocator, &ctx, .help, &.{});
 
-    try std.testing.expect(!isInterrupted());
+    try std.testing.expect(!signals.isInterrupted());
 }
 
 test "dispatch preserves interrupt once the signal handler is installed" {
-    setSignalHandlerInstalledForTest(true);
-    defer setSignalHandlerInstalledForTest(false);
-    setInterruptedForTest(true);
-    defer setInterruptedForTest(false);
+    signals.setSignalHandlerInstalledForTest(true);
+    defer signals.setSignalHandlerInstalledForTest(false);
+    signals.setInterruptedForTest(true);
+    defer signals.setInterruptedForTest(false);
 
     const ctx: AppCtx = .{ .io = std.Options.debug_io, .environ = .empty };
     try dispatch(std.testing.allocator, &ctx, .help, &.{});
 
-    try std.testing.expect(isInterrupted());
+    try std.testing.expect(signals.isInterrupted());
 }
 
 test "applyGlobalFlag --output-format=ndjson does not flip --quiet" {
@@ -333,16 +307,10 @@ pub fn main(init: std.process.Init.Minimal) !void {
         }
     };
 
-    // Register SIGINT handler so Ctrl-C sets interrupted instead of
+    // Register SIGINT handler so Ctrl-C sets the interrupt flag instead of
     // immediately killing the process. Install commands check the flag at
     // step boundaries and clean up before exiting.
-    const act = std.posix.Sigaction{
-        .handler = .{ .handler = &sigintHandler },
-        .mask = std.posix.sigemptyset(),
-        .flags = 0,
-    };
-    std.posix.sigaction(std.posix.SIG.INT, &act, null);
-    signal_handler_installed.store(true, .release);
+    signals.installHandler();
 
     // Run terminal-background detection once, up front, before any
     // output.* call can trigger a lazy OSC 11 probe mid-stream (the
@@ -441,8 +409,8 @@ fn dispatch(allocator: std.mem.Allocator, ctx: *const AppCtx, cmd: Command, cmd_
     // No SIGINT handler means we're under the test runner (or some other
     // non-`main` entry); clear any flag a prior test left behind so it
     // can't bleed into this dispatch.
-    if (!signal_handler_installed.load(.acquire)) {
-        interrupted.store(false, .release);
+    if (!signals.signalHandlerInstalled()) {
+        signals.setInterruptedForTest(false);
     }
     switch (cmd) {
         .install => try install.execute(ctx, allocator, cmd_args),

--- a/src/update/notifier.zig
+++ b/src/update/notifier.zig
@@ -9,6 +9,7 @@ const std = @import("std");
 const output = @import("../ui/output.zig");
 const color = @import("../ui/color.zig");
 const client_mod = @import("../net/client.zig");
+const signals = @import("../core/signals.zig");
 const atomic = @import("../fs/atomic.zig");
 const release = @import("release.zig");
 const origin_mod = @import("origin.zig");
@@ -239,8 +240,7 @@ fn fetchLatestTag(ctx: *const AppCtx, allocator: std.mem.Allocator) ![]u8 {
     http.timeout_ns = network_timeout_ns;
     // SIGINT on the prompt-after-success window collapses the probe
     // instead of stalling the user behind the 1.5 s deadline.
-    const main_mod = @import("../main.zig");
-    http.cancel = main_mod.isInterrupted;
+    http.cancel = signals.isInterrupted;
     defer http.deinit();
     var resp = try http.get(release.releases_latest_url);
     defer resp.deinit();
@@ -401,8 +401,7 @@ fn runNotify(ctx: *const AppCtx, allocator: std.mem.Allocator, current_version: 
     if (need_refresh) {
         // Don't make the user wait out a 1.5s HTTP timeout after Ctrl-C.
         // Same convention as `cli/install.zig` and `cli/migrate.zig`.
-        const main_mod = @import("../main.zig");
-        if (main_mod.isInterrupted()) return;
+        if (signals.isInterrupted()) return;
         refreshOnce(ctx, allocator, path, &state, now, current_version) catch {};
     }
 

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -817,8 +817,8 @@ test "pre-set SIGINT flag short-circuits the per-keg loop before any API call" {
     defer _ = c.unsetenv("MALT_PREFIX");
 
     // Pre-set the flag so the pre-loop check fires before any API hit.
-    malt.main_mod.setInterruptedForTest(true);
-    defer malt.main_mod.setInterruptedForTest(false);
+    malt.signals.setInterruptedForTest(true);
+    defer malt.signals.setInterruptedForTest(false);
 
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(testing.allocator);

--- a/tests/no_main_reach_in_cli_test.zig
+++ b/tests/no_main_reach_in_cli_test.zig
@@ -1,0 +1,83 @@
+//! Pin test: no `cli/*` or `update/*` file may reach up into `main.zig`.
+//! The interrupt flag now lives in `core/signals.zig`; consumers import it
+//! directly. Catches the lazy-import smell before it spreads again.
+
+const std = @import("std");
+const testing = std.testing;
+
+const test_io = @import("test_io");
+
+const scanned_roots = [_][]const u8{ "src/cli", "src/update" };
+const import_prefix = "@import(\"";
+
+test "no cli/* or update/* file imports main.zig" {
+    const io = std.Options.debug_io;
+
+    var failures: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (failures.items) |s| testing.allocator.free(s);
+        failures.deinit(testing.allocator);
+    }
+
+    for (scanned_roots) |root| try scanRoot(io, root, &failures);
+
+    if (failures.items.len != 0) {
+        for (failures.items) |f| std.debug.print("{s}\n", .{f});
+        return error.CliOrUpdateImportsMain;
+    }
+}
+
+fn scanRoot(io: std.Io, root: []const u8, failures: *std.ArrayList([]const u8)) !void {
+    var dir = try test_io.cwd().openDir(io, root, .{ .iterate = true });
+    defer dir.close(io);
+
+    var walker = try dir.walk(testing.allocator);
+    defer walker.deinit();
+
+    while (try walker.next(io)) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.path, ".zig")) continue;
+
+        const file = try dir.openFile(io, entry.path, .{});
+        defer file.close(io);
+        const stat = try file.stat(io);
+        const content = try testing.allocator.alloc(u8, @intCast(stat.size));
+        defer testing.allocator.free(content);
+        _ = try file.readPositionalAll(io, content, 0);
+
+        try scanContent(root, entry.path, content, failures);
+    }
+}
+
+fn scanContent(
+    root: []const u8,
+    rel_path: []const u8,
+    content: []const u8,
+    failures: *std.ArrayList([]const u8),
+) !void {
+    var cursor: usize = 0;
+    while (std.mem.indexOfPos(u8, content, cursor, import_prefix)) |start| {
+        const path_start = start + import_prefix.len;
+        const end = std.mem.indexOfScalarPos(u8, content, path_start, '"') orelse break;
+        const import_path = content[path_start..end];
+        cursor = end + 1;
+
+        if (resolvesIntoMain(import_path)) {
+            const msg = try std.fmt.allocPrint(
+                testing.allocator,
+                "{s}/{s} imports {s}",
+                .{ root, rel_path, import_path },
+            );
+            try failures.append(testing.allocator, msg);
+        }
+    }
+}
+
+/// True when a relative `@import` path crosses out of the CLI/update tree
+/// and lands on `main.zig`. Strip every leading `../` segment and compare
+/// the tail — covers both `../main.zig` and `../../main.zig`.
+fn resolvesIntoMain(path: []const u8) bool {
+    var rest = path;
+    while (std.mem.startsWith(u8, rest, "../")) rest = rest[3..];
+    return std.mem.eql(u8, rest, "main.zig");
+}


### PR DESCRIPTION
## Description

Lifts the interrupt flag and signal handler out of `main.zig` into `core/signals.zig`. Every long-running command now imports the flag from the new home; no caller reaches up to `main` anymore, and no module uses the lazy `@import("../main.zig")` pattern. Also pins the AppCtx boundary convention (AppCtx is CLI; core takes raw `std.Io`) in the struct's doc-comment so future commits do not drift it.

## Related Issue

- None

## Notes for Reviewers

- None