### PR TITLE
refactor(update/notifier): split policy and cache

### DIFF
--- a/src/update/notifier.zig
+++ b/src/update/notifier.zig
@@ -6,234 +6,42 @@
 //! the `version`/`help` meta-commands.
 
 const std = @import("std");
-const output = @import("../ui/output.zig");
-const color = @import("../ui/color.zig");
-const client_mod = @import("../net/client.zig");
-const signals = @import("../core/signals.zig");
-const atomic = @import("../fs/atomic.zig");
-const release = @import("release.zig");
-const origin_mod = @import("origin.zig");
+
 const AppCtx = @import("../app_ctx.zig").AppCtx;
+const signals = @import("../core/signals.zig");
+const client_mod = @import("../net/client.zig");
+const color = @import("../ui/color.zig");
+const output = @import("../ui/output.zig");
+const origin_mod = @import("origin.zig");
+const release = @import("release.zig");
+const cache = @import("notifier/cache.zig");
+const policy = @import("notifier/policy.zig");
 
-const cache_filename = "version-notify.json";
+pub const cache_ttl_secs = policy.cache_ttl_secs;
+pub const failure_backoff_secs = policy.failure_backoff_secs;
+pub const shouldNotify = policy.shouldNotify;
+pub const cacheStale = policy.cacheStale;
+pub const inFailureBackoff = policy.inFailureBackoff;
+pub const isCi = policy.isCi;
+pub const isCiFromValues = policy.isCiFromValues;
+pub const isSkippedCommand = policy.isSkippedCommand;
+pub const notifierDisabledFromValue = policy.notifierDisabledFromValue;
 
-/// Match gh, npm, pnpm — smaller TTLs nag, larger lose freshness.
-pub const cache_ttl_secs: i64 = 24 * 60 * 60;
-
-/// Cooldown after a failed probe so a GitHub outage does not re-fire the
-/// 1.5 s timeout on every malt invocation. Short enough that a recovered
-/// network is picked up the next time the user runs anything.
-pub const failure_backoff_secs: i64 = 5 * 60;
+pub const State = cache.State;
+pub const EnvOverride = cache.EnvOverride;
+pub const cacheDirFrom = cache.cacheDirFrom;
+pub const cacheDir = cache.cacheDir;
+pub const cachePathFrom = cache.cachePathFrom;
+pub const cachePath = cache.cachePath;
+pub const encodeState = cache.encodeState;
+pub const decodeState = cache.decodeState;
+pub const freeState = cache.freeState;
+pub const readCache = cache.readCache;
+pub const writeCache = cache.writeCache;
 
 /// Bounded so a cache miss can't drag the user's hot path. Fires after
 /// dispatch, so the command's output is already on screen.
 pub const network_timeout_ns: u64 = 1_500 * std.time.ns_per_ms;
-
-/// Persisted as `<cache_dir>/version-notify.json`. Decoder is tolerant
-/// so a downgraded malt doesn't strand the file.
-pub const State = struct {
-    checked_at: i64,
-    /// As returned by GitHub: with the leading `v`.
-    latest_tag: []const u8,
-    /// Lets a fresh cache skip notices for users who've just updated.
-    current_seen: []const u8,
-    /// Wall-clock of the most recent probe attempt (success or failure).
-    /// `last_attempt > checked_at` is the failure-marker shape: the next
-    /// invocation backs off until `failure_backoff_secs` has elapsed.
-    last_attempt: i64 = 0,
-};
-
-/// The `current == seen == latest_no_v` clause silences the notice for
-/// users who've just updated while the cache TTL is still alive.
-pub fn shouldNotify(current: []const u8, latest_tag: []const u8, current_seen: []const u8) bool {
-    const latest_no_v = release.stripVPrefix(latest_tag);
-    if (latest_no_v.len == 0) return false;
-    if (std.mem.eql(u8, current, latest_no_v)) return false;
-    if (std.mem.eql(u8, current, current_seen) and std.mem.eql(u8, current_seen, latest_no_v)) return false;
-    return true;
-}
-
-pub fn cacheStale(now_secs: i64, checked_at: i64, ttl: i64) bool {
-    // Cache from the future (clock skew) — treat as fresh, never re-fetch.
-    if (now_secs <= checked_at) return false;
-    return (now_secs - checked_at) >= ttl;
-}
-
-/// True when the previous probe failed recently and the caller should
-/// skip the network. `last_attempt > checked_at` is the failure shape:
-/// success bumps both fields together so they stay equal.
-pub fn inFailureBackoff(now_secs: i64, last_attempt: i64, checked_at: i64, backoff: i64) bool {
-    if (last_attempt <= checked_at) return false;
-    if (now_secs <= last_attempt) return false; // clock skew
-    return (now_secs - last_attempt) < backoff;
-}
-
-const ci_env_vars = [_][]const u8{
-    "CI",
-    "GITHUB_ACTIONS",
-    "BUILDKITE",
-    "JENKINS_URL",
-    "TF_BUILD",
-    "CIRCLECI",
-    "GITLAB_CI",
-};
-
-/// Pure variant of `isCi` so tests don't mutate the host environment.
-/// `values` parallels `ci_env_vars` entry-for-entry.
-pub fn isCiFromValues(values: []const ?[]const u8) bool {
-    std.debug.assert(values.len == ci_env_vars.len);
-    for (values) |v| {
-        if (v) |s| {
-            if (s.len > 0) return true;
-        }
-    }
-    return false;
-}
-
-pub fn isCi(environ: std.process.Environ) bool {
-    inline for (ci_env_vars) |name| {
-        if (std.process.Environ.getPosix(environ, name)) |v| {
-            if (v.len > 0) return true;
-        }
-    }
-    return false;
-}
-
-/// Precedence: `MALT_CACHE` > `XDG_CACHE_HOME` > `HOME`. Pulled into a
-/// struct so the rule is testable without touching the host environment.
-pub const EnvOverride = struct {
-    malt_cache: ?[]const u8 = null,
-    xdg_cache_home: ?[]const u8 = null,
-    home: ?[]const u8 = null,
-};
-
-/// Returns slice-into-`buf`, or null if no env var in the chain is set.
-pub fn cacheDirFrom(env: EnvOverride, buf: []u8) ?[]const u8 {
-    if (env.malt_cache) |v| if (v.len > 0) return std.fmt.bufPrint(buf, "{s}", .{v}) catch null;
-    if (env.xdg_cache_home) |v| if (v.len > 0) return std.fmt.bufPrint(buf, "{s}/malt", .{v}) catch null;
-    if (env.home) |v| if (v.len > 0) return std.fmt.bufPrint(buf, "{s}/.cache/malt", .{v}) catch null;
-    return null;
-}
-
-fn liveEnv(environ: std.process.Environ) EnvOverride {
-    return .{
-        .malt_cache = std.process.Environ.getPosix(environ, "MALT_CACHE"),
-        .xdg_cache_home = std.process.Environ.getPosix(environ, "XDG_CACHE_HOME"),
-        .home = std.process.Environ.getPosix(environ, "HOME"),
-    };
-}
-
-pub fn cacheDir(environ: std.process.Environ, buf: []u8) ?[]const u8 {
-    return cacheDirFrom(liveEnv(environ), buf);
-}
-
-pub fn cachePathFrom(env: EnvOverride, buf: []u8) ?[]const u8 {
-    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const dir = cacheDirFrom(env, &dir_buf) orelse return null;
-    return std.fmt.bufPrint(buf, "{s}/{s}", .{ dir, cache_filename }) catch null;
-}
-
-pub fn cachePath(environ: std.process.Environ, buf: []u8) ?[]const u8 {
-    return cachePathFrom(liveEnv(environ), buf);
-}
-
-/// Realistic failure: `error.NoSpaceLeft` when `buf` is undersized.
-pub fn encodeState(buf: []u8, state: State) ![]u8 {
-    var w = std.Io.Writer.fixed(buf);
-    try w.writeAll("{\"checked_at\":");
-    var num_buf: [32]u8 = undefined;
-    const num = try std.fmt.bufPrint(&num_buf, "{d}", .{state.checked_at});
-    try w.writeAll(num);
-    try w.writeAll(",\"latest_tag\":");
-    try output.jsonStr(&w, state.latest_tag);
-    try w.writeAll(",\"current_seen\":");
-    try output.jsonStr(&w, state.current_seen);
-    try w.writeAll(",\"last_attempt\":");
-    const att = try std.fmt.bufPrint(&num_buf, "{d}", .{state.last_attempt});
-    try w.writeAll(att);
-    try w.writeAll("}\n");
-    return w.buffered();
-}
-
-/// Caller frees via `freeState`. OOM propagates; every other parse
-/// error collapses to `error.InvalidPayload` so a torn cache doesn't
-/// leak a JSON parser type into best-effort callers.
-pub fn decodeState(allocator: std.mem.Allocator, bytes: []const u8) !?State {
-    const parsed = std.json.parseFromSlice(std.json.Value, allocator, bytes, .{}) catch |e| switch (e) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return error.InvalidPayload,
-    };
-    defer parsed.deinit();
-    const obj = switch (parsed.value) {
-        .object => |o| o,
-        else => return null,
-    };
-    const checked_at_v = obj.get("checked_at") orelse return null;
-    const latest_tag_v = obj.get("latest_tag") orelse return null;
-    const current_seen_v = obj.get("current_seen") orelse return null;
-    const checked_at_i = switch (checked_at_v) {
-        .integer => |i| i,
-        else => return null,
-    };
-    const latest_tag_s = switch (latest_tag_v) {
-        .string => |s| s,
-        else => return null,
-    };
-    const current_seen_s = switch (current_seen_v) {
-        .string => |s| s,
-        else => return null,
-    };
-    const tag_dup = try allocator.dupe(u8, latest_tag_s);
-    errdefer allocator.free(tag_dup);
-    const seen_dup = try allocator.dupe(u8, current_seen_s);
-    // Optional, default 0 so caches written by older malt still decode.
-    const last_attempt_i: i64 = if (obj.get("last_attempt")) |v| switch (v) {
-        .integer => |i| i,
-        else => 0,
-    } else 0;
-    return .{
-        .checked_at = checked_at_i,
-        .latest_tag = tag_dup,
-        .current_seen = seen_dup,
-        .last_attempt = last_attempt_i,
-    };
-}
-
-pub fn freeState(allocator: std.mem.Allocator, state: State) void {
-    allocator.free(state.latest_tag);
-    allocator.free(state.current_seen);
-}
-
-/// Install `new_value` first, then free the prior — single statement so a
-/// caller's `defer if (state) |s| freeState(...)` can never observe a freed
-/// pair, even if a future edit slips a fallible call in between.
-fn replaceState(state: *?State, allocator: std.mem.Allocator, new_value: State) void {
-    const prior = state.*;
-    state.* = new_value;
-    if (prior) |p| freeState(allocator, p);
-}
-
-/// Returns null when the file is absent (a torn or first run).
-pub fn readCache(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !?State {
-    const bytes = readFileAllAbsolute(io, allocator, path, 64 * 1024) catch |e| switch (e) {
-        error.FileNotFound => return null,
-        else => return e,
-    };
-    defer allocator.free(bytes);
-    return decodeState(allocator, bytes);
-}
-
-/// Creates the parent directory if missing. Routed through
-/// `atomicWriteFile` so a SIGKILL or concurrent writer can never publish
-/// a torn JSON — readers see either the old cache or the new one.
-pub fn writeCache(io: std.Io, path: []const u8, state: State) !void {
-    if (std.fs.path.dirname(path)) |dir| {
-        std.Io.Dir.cwd().createDirPath(io, dir) catch {};
-    }
-    var buf: [1024]u8 = undefined;
-    const encoded = try encodeState(&buf, state);
-    try atomic.atomicWriteFile(io, path, encoded);
-}
 
 fn fetchLatestTag(ctx: *const AppCtx, allocator: std.mem.Allocator) ![]u8 {
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
@@ -264,41 +72,14 @@ fn originIsHomebrew(io: std.Io) bool {
     return origin_mod.classifyResolved(io, &resolved_buf, exe_buf[0..n]) == .homebrew;
 }
 
-/// Install-pipeline commands deliberately aren't here — `bench.sh`
-/// redirects stderr, so the non-TTY rule below already exempts them
-/// from measurement while interactive users still get the notice.
-const meta_commands = [_][]const u8{ "version", "--version", "help", "--help", "-h" };
-
-/// Public so `tests/version_notify_test.zig` can pin the skip list
-/// without going through the full `suppressed` flow.
-pub fn isSkippedCommand(cmd: []const u8) bool {
-    if (cmd.len == 0) return true;
-    for (meta_commands) |m| {
-        if (std.mem.eql(u8, cmd, m)) return true;
-    }
-    return false;
-}
-
-/// Mirrors `MALT_ALLOW_UNVERIFIED` / `MALT_ALLOW_RAW_POST_INSTALL`:
-/// the literal `"1"` is the on-state, anything else (incl. an empty
-/// value) is off, so a stray `=` doesn't accidentally silence notices.
-pub fn notifierDisabledFromValue(value: ?[]const u8) bool {
-    const v = value orelse return false;
-    return std.mem.eql(u8, v, "1");
-}
-
-fn notifierDisabled(environ: std.process.Environ) bool {
-    return notifierDisabledFromValue(std.process.Environ.getPosix(environ, "MALT_NO_VERSION_NOTIFIER"));
-}
-
 /// Cheapest checks first. `originIsHomebrew` is deliberately not here —
 /// the `executablePath` + `realpath` pair is deferred to `runNotify` so
 /// the cache-fresh hot path skips it entirely.
 fn suppressed(io: std.Io, environ: std.process.Environ, cmd_str: []const u8) bool {
-    if (isSkippedCommand(cmd_str)) return true;
+    if (policy.isSkippedCommand(cmd_str)) return true;
     if (output.isQuiet() or output.isJson() or output.isNdjson() or output.isDryRun()) return true;
-    if (notifierDisabled(environ)) return true;
-    if (isCi(environ)) return true;
+    if (policy.notifierDisabled(environ)) return true;
+    if (policy.isCi(environ)) return true;
     const stderr_file: std.Io.File = .{ .handle = std.posix.STDERR_FILENO, .flags = .{ .nonblocking = false } };
     if (!(stderr_file.isTty(io) catch false)) return true;
     return false;
@@ -441,7 +222,7 @@ fn refreshOnce(
         .last_attempt = now,
     }) catch {};
 
-    replaceState(state, allocator, .{
+    cache.replaceState(state, allocator, .{
         .checked_at = now,
         .latest_tag = tag,
         .current_seen = seen_dup,
@@ -464,289 +245,7 @@ pub fn writeFailureMarker(io: std.Io, path: []const u8, prior: ?State, now: i64,
     }) catch {};
 }
 
-/// Read the entire contents of an absolute file path into a caller-owned slice.
-fn readFileAllAbsolute(io: std.Io, allocator: std.mem.Allocator, abs_path: []const u8, max_bytes: usize) ![]u8 {
-    const f = try std.Io.Dir.openFileAbsolute(io, abs_path, .{});
-    defer f.close(io);
-    const st = try f.stat(io);
-    const size = @min(@as(u64, max_bytes), st.size);
-    const buf = try allocator.alloc(u8, @intCast(size));
-    errdefer allocator.free(buf);
-    const n = try f.readPositionalAll(io, buf, 0);
-    if (n == buf.len) return buf;
-    if (allocator.resize(buf, n)) return buf[0..n];
-    const shrunk = try allocator.alloc(u8, n);
-    @memcpy(shrunk, buf[0..n]);
-    allocator.free(buf);
-    return shrunk;
-}
-
-// --- pure-logic tests ----------------------------------------------------
-
-test "shouldNotify: equal versions never notify (with or without leading v)" {
-    try std.testing.expect(!shouldNotify("0.10.0", "v0.10.0", "0.10.0"));
-    try std.testing.expect(!shouldNotify("0.10.0", "0.10.0", ""));
-}
-
-test "shouldNotify: newer latest fires notice" {
-    try std.testing.expect(shouldNotify("0.10.0", "v0.10.1", ""));
-    try std.testing.expect(shouldNotify("0.10.0", "v0.11.0", "0.9.0"));
-}
-
-test "shouldNotify: empty latest never fires" {
-    try std.testing.expect(!shouldNotify("0.10.0", "", ""));
-    try std.testing.expect(!shouldNotify("0.10.0", "v", ""));
-}
-
-test "shouldNotify: post-update suppression — current_seen matches both" {
-    // User updated to 0.10.1; cache still says latest=v0.10.1 — don't nag.
-    try std.testing.expect(!shouldNotify("0.10.1", "v0.10.1", "0.10.1"));
-}
-
-test "shouldNotify: stale cache with mismatched current_seen still fires" {
-    // Cache predates a downgrade-then-cache-rewrite; safe default is to fire.
-    try std.testing.expect(shouldNotify("0.9.0", "v0.10.0", "0.8.0"));
-}
-
-test "cacheStale: TTL boundary" {
-    try std.testing.expect(!cacheStale(100, 100, 60)); // equal ⇒ fresh (delta 0)
-    try std.testing.expect(!cacheStale(159, 100, 60)); // delta 59 < 60
-    try std.testing.expect(cacheStale(160, 100, 60)); // delta 60 ⇒ stale
-    try std.testing.expect(cacheStale(1000, 100, 60));
-}
-
-test "cacheStale: clock skew (cache from the future) is treated as fresh" {
-    try std.testing.expect(!cacheStale(50, 100, 60));
-}
-
-test "notifierDisabledFromValue: only literal \"1\" disables (matches MALT_ALLOW_UNVERIFIED)" {
-    try std.testing.expect(!notifierDisabledFromValue(null));
-    try std.testing.expect(!notifierDisabledFromValue(""));
-    try std.testing.expect(!notifierDisabledFromValue("0"));
-    try std.testing.expect(!notifierDisabledFromValue("true"));
-    try std.testing.expect(!notifierDisabledFromValue("yes"));
-    try std.testing.expect(notifierDisabledFromValue("1"));
-}
-
-test "isCiFromValues: any non-empty wins" {
-    const all_null = [_]?[]const u8{ null, null, null, null, null, null, null };
-    try std.testing.expect(!isCiFromValues(&all_null));
-
-    const empty_string_only = [_]?[]const u8{ "", null, null, null, null, null, null };
-    try std.testing.expect(!isCiFromValues(&empty_string_only));
-
-    const ci_set = [_]?[]const u8{ "true", null, null, null, null, null, null };
-    try std.testing.expect(isCiFromValues(&ci_set));
-
-    const gha_set = [_]?[]const u8{ null, "true", null, null, null, null, null };
-    try std.testing.expect(isCiFromValues(&gha_set));
-}
-
-test "cacheDirFrom: precedence is MALT_CACHE > XDG_CACHE_HOME > HOME" {
-    var buf: [256]u8 = undefined;
-    {
-        const got = cacheDirFrom(.{
-            .malt_cache = "/m",
-            .xdg_cache_home = "/x",
-            .home = "/h",
-        }, &buf) orelse return error.TestExpectedNonNull;
-        try std.testing.expectEqualStrings("/m", got);
-    }
-    {
-        const got = cacheDirFrom(.{
-            .xdg_cache_home = "/x",
-            .home = "/h",
-        }, &buf) orelse return error.TestExpectedNonNull;
-        try std.testing.expectEqualStrings("/x/malt", got);
-    }
-    {
-        const got = cacheDirFrom(.{ .home = "/h" }, &buf) orelse return error.TestExpectedNonNull;
-        try std.testing.expectEqualStrings("/h/.cache/malt", got);
-    }
-    try std.testing.expect(cacheDirFrom(.{}, &buf) == null);
-}
-
-test "cacheDirFrom: empty values fall through to the next candidate" {
-    var buf: [256]u8 = undefined;
-    const got = cacheDirFrom(.{
-        .malt_cache = "",
-        .xdg_cache_home = "",
-        .home = "/home/u",
-    }, &buf) orelse return error.TestExpectedNonNull;
-    try std.testing.expectEqualStrings("/home/u/.cache/malt", got);
-}
-
-test "encodeState/decodeState: round-trip preserves every field" {
-    const allocator = std.testing.allocator;
-    var buf: [1024]u8 = undefined;
-    const encoded = try encodeState(&buf, .{
-        .checked_at = 1714400000,
-        .latest_tag = "v0.10.1",
-        .current_seen = "0.10.0",
-    });
-
-    const got = (try decodeState(allocator, encoded)) orelse return error.TestExpectedNonNull;
-    defer freeState(allocator, got);
-
-    try std.testing.expectEqual(@as(i64, 1714400000), got.checked_at);
-    try std.testing.expectEqualStrings("v0.10.1", got.latest_tag);
-    try std.testing.expectEqualStrings("0.10.0", got.current_seen);
-}
-
-test "decodeState: malformed JSON yields error.InvalidPayload" {
-    try std.testing.expectError(error.InvalidPayload, decodeState(std.testing.allocator, "not json"));
-}
-
-test "decodeState: missing fields yield null (not an error)" {
-    const got = try decodeState(std.testing.allocator, "{\"checked_at\":1}");
-    try std.testing.expect(got == null);
-}
-
-test "decodeState: extra fields are ignored (forwards-compat)" {
-    const allocator = std.testing.allocator;
-    const json =
-        \\{"checked_at":1,"latest_tag":"v0.10.1","current_seen":"0.10.0","future_field":42}
-    ;
-    const got = (try decodeState(allocator, json)) orelse return error.TestExpectedNonNull;
-    defer freeState(allocator, got);
-    try std.testing.expectEqualStrings("v0.10.1", got.latest_tag);
-}
-
-test "encodeState: escapes JSON special characters in tag/version strings" {
-    var buf: [256]u8 = undefined;
-    const encoded = try encodeState(&buf, .{
-        .checked_at = 0,
-        .latest_tag = "v\"X",
-        .current_seen = "ok",
-    });
-    try std.testing.expect(std.mem.indexOf(u8, encoded, "\\\"") != null);
-}
-
-test "writeCache + readCache round-trip on a real file" {
-    const allocator = std.testing.allocator;
-    var threaded: std.Io.Threaded = .init(allocator, .{});
-    defer threaded.deinit();
-    const io = threaded.io();
-
-    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notifier_rt_{d}", .{std.Io.Clock.real.now(io).toNanoseconds()});
-    std.Io.Dir.cwd().deleteTree(io, dir) catch {};
-    defer std.Io.Dir.cwd().deleteTree(io, dir) catch {};
-
-    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
-
-    try writeCache(io, path, .{
-        .checked_at = 1714400000,
-        .latest_tag = "v0.10.1",
-        .current_seen = "0.10.0",
-    });
-    const got = (try readCache(io, allocator, path)) orelse return error.TestExpectedNonNull;
-    defer freeState(allocator, got);
-
-    try std.testing.expectEqual(@as(i64, 1714400000), got.checked_at);
-    try std.testing.expectEqualStrings("v0.10.1", got.latest_tag);
-    try std.testing.expectEqualStrings("0.10.0", got.current_seen);
-}
-
-test "writeCache replaces an existing cache atomically (rename, not in-place truncate)" {
-    // A torn write reaches disk only when the writer truncates `path` and
-    // streams into it. Rename-publish gives the destination a fresh inode,
-    // so a stable inode after overwrite is the visible truncate signature.
-    const allocator = std.testing.allocator;
-    var threaded: std.Io.Threaded = .init(allocator, .{});
-    defer threaded.deinit();
-    const io = threaded.io();
-
-    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notifier_atomic_{d}", .{std.Io.Clock.real.now(io).toNanoseconds()});
-    std.Io.Dir.cwd().deleteTree(io, dir) catch {};
-    defer std.Io.Dir.cwd().deleteTree(io, dir) catch {};
-
-    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
-
-    try writeCache(io, path, .{
-        .checked_at = 1714400000,
-        .latest_tag = "v0.10.1",
-        .current_seen = "0.10.0",
-    });
-    const before = blk: {
-        const f = try std.Io.Dir.openFileAbsolute(io, path, .{});
-        defer f.close(io);
-        break :blk try f.stat(io);
-    };
-
-    try writeCache(io, path, .{
-        .checked_at = 1714500000,
-        .latest_tag = "v0.10.2",
-        .current_seen = "0.10.0",
-    });
-    const after = blk: {
-        const f = try std.Io.Dir.openFileAbsolute(io, path, .{});
-        defer f.close(io);
-        break :blk try f.stat(io);
-    };
-
-    try std.testing.expect(before.inode != after.inode);
-
-    // No stale `.tmp` siblings — the rename must publish the new file.
-    var d = try std.Io.Dir.openDirAbsolute(io, dir, .{ .iterate = true });
-    defer d.close(io);
-    var iter = d.iterate();
-    var count: usize = 0;
-    while (try iter.next(io)) |entry| {
-        try std.testing.expectEqualStrings("version-notify.json", entry.name);
-        count += 1;
-    }
-    try std.testing.expectEqual(@as(usize, 1), count);
-}
-
-test "replaceState: prior null installs new without freeing" {
-    const allocator = std.testing.allocator;
-    var state: ?State = null;
-    const new_state: State = .{
-        .checked_at = 1,
-        .latest_tag = try allocator.dupe(u8, "v0.10.1"),
-        .current_seen = try allocator.dupe(u8, "0.10.0"),
-    };
-    replaceState(&state, allocator, new_state);
-    defer if (state) |s| freeState(allocator, s);
-    try std.testing.expect(state != null);
-    try std.testing.expectEqualStrings("v0.10.1", state.?.latest_tag);
-}
-
-test "replaceState: prior non-null is freed; caller's deferred free of new is single-owner" {
-    const allocator = std.testing.allocator;
-    var state: ?State = .{
-        .checked_at = 0,
-        .latest_tag = try allocator.dupe(u8, "v0.9.0"),
-        .current_seen = try allocator.dupe(u8, "0.8.0"),
-    };
-    const new_state: State = .{
-        .checked_at = 1,
-        .latest_tag = try allocator.dupe(u8, "v0.10.0"),
-        .current_seen = try allocator.dupe(u8, "0.9.0"),
-    };
-    replaceState(&state, allocator, new_state);
-    // Mirrors `runNotify`'s scope-exit pattern; testing.allocator catches a
-    // double-free of the prior pair or a leak of the prior pair.
-    defer if (state) |s| freeState(allocator, s);
-    try std.testing.expectEqual(@as(i64, 1), state.?.checked_at);
-    try std.testing.expectEqualStrings("v0.10.0", state.?.latest_tag);
-}
-
-test "readCache: missing file is null, not an error" {
-    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
-    defer threaded.deinit();
-    const io = threaded.io();
-
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const path = try std.fmt.bufPrint(&buf, "/tmp/malt_notifier_absent_{d}.json", .{std.Io.Clock.real.now(io).toNanoseconds()});
-    std.Io.Dir.deleteFileAbsolute(io, path) catch {};
-    const got = try readCache(io, std.testing.allocator, path);
-    try std.testing.expect(got == null);
-}
+// --- inline tests --------------------------------------------------------
 
 // Pins the heads-up layout: blank-line separator + flush-left prefixes
 // in both palettes. The blank line keeps the notice from sticking to a
@@ -790,4 +289,12 @@ test "printNotice: no color, no emoji → flush-left ASCII layout" {
         "i A newer malt is available: 0.11.6 (you're on 0.11.0).\n" ++
         "> Run 'mt version update' to upgrade, or set MALT_NO_VERSION_NOTIFIER=1 to silence this.\n";
     try std.testing.expectEqualStrings(want, buf.items);
+}
+
+// Submodules carry their own inline tests; pulling them in here keeps the
+// `lib_tests` total honest after a split — `refAllDecls` doesn't recurse
+// through private `@import`s.
+test {
+    _ = @import("notifier/policy.zig");
+    _ = @import("notifier/cache.zig");
 }

--- a/src/update/notifier/cache.zig
+++ b/src/update/notifier/cache.zig
@@ -1,0 +1,401 @@
+//! Notifier cache — file location resolution, codec, and atomic IO.
+//! Format compat is the load-bearing piece: a downgraded malt must still
+//! decode a newer cache, so the encoder bytes are pinned by the inline
+//! round-trip tests and the integration suite.
+
+const std = @import("std");
+
+const atomic = @import("../../fs/atomic.zig");
+const output = @import("../../ui/output.zig");
+
+const cache_filename = "version-notify.json";
+
+/// Persisted as `<cache_dir>/version-notify.json`. Decoder is tolerant
+/// so a downgraded malt doesn't strand the file.
+pub const State = struct {
+    checked_at: i64,
+    /// As returned by GitHub: with the leading `v`.
+    latest_tag: []const u8,
+    /// Lets a fresh cache skip notices for users who've just updated.
+    current_seen: []const u8,
+    /// Wall-clock of the most recent probe attempt (success or failure).
+    /// `last_attempt > checked_at` is the failure-marker shape: the next
+    /// invocation backs off until `failure_backoff_secs` has elapsed.
+    last_attempt: i64 = 0,
+};
+
+/// Precedence: `MALT_CACHE` > `XDG_CACHE_HOME` > `HOME`. Pulled into a
+/// struct so the rule is testable without touching the host environment.
+pub const EnvOverride = struct {
+    malt_cache: ?[]const u8 = null,
+    xdg_cache_home: ?[]const u8 = null,
+    home: ?[]const u8 = null,
+};
+
+/// Returns slice-into-`buf`, or null if no env var in the chain is set.
+pub fn cacheDirFrom(env: EnvOverride, buf: []u8) ?[]const u8 {
+    if (env.malt_cache) |v| if (v.len > 0) return std.fmt.bufPrint(buf, "{s}", .{v}) catch null;
+    if (env.xdg_cache_home) |v| if (v.len > 0) return std.fmt.bufPrint(buf, "{s}/malt", .{v}) catch null;
+    if (env.home) |v| if (v.len > 0) return std.fmt.bufPrint(buf, "{s}/.cache/malt", .{v}) catch null;
+    return null;
+}
+
+fn liveEnv(environ: std.process.Environ) EnvOverride {
+    return .{
+        .malt_cache = std.process.Environ.getPosix(environ, "MALT_CACHE"),
+        .xdg_cache_home = std.process.Environ.getPosix(environ, "XDG_CACHE_HOME"),
+        .home = std.process.Environ.getPosix(environ, "HOME"),
+    };
+}
+
+pub fn cacheDir(environ: std.process.Environ, buf: []u8) ?[]const u8 {
+    return cacheDirFrom(liveEnv(environ), buf);
+}
+
+pub fn cachePathFrom(env: EnvOverride, buf: []u8) ?[]const u8 {
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = cacheDirFrom(env, &dir_buf) orelse return null;
+    return std.fmt.bufPrint(buf, "{s}/{s}", .{ dir, cache_filename }) catch null;
+}
+
+pub fn cachePath(environ: std.process.Environ, buf: []u8) ?[]const u8 {
+    return cachePathFrom(liveEnv(environ), buf);
+}
+
+/// Realistic failure: `error.NoSpaceLeft` when `buf` is undersized.
+pub fn encodeState(buf: []u8, state: State) ![]u8 {
+    var w = std.Io.Writer.fixed(buf);
+    try w.writeAll("{\"checked_at\":");
+    var num_buf: [32]u8 = undefined;
+    const num = try std.fmt.bufPrint(&num_buf, "{d}", .{state.checked_at});
+    try w.writeAll(num);
+    try w.writeAll(",\"latest_tag\":");
+    try output.jsonStr(&w, state.latest_tag);
+    try w.writeAll(",\"current_seen\":");
+    try output.jsonStr(&w, state.current_seen);
+    try w.writeAll(",\"last_attempt\":");
+    const att = try std.fmt.bufPrint(&num_buf, "{d}", .{state.last_attempt});
+    try w.writeAll(att);
+    try w.writeAll("}\n");
+    return w.buffered();
+}
+
+/// Caller frees via `freeState`. OOM propagates; every other parse
+/// error collapses to `error.InvalidPayload` so a torn cache doesn't
+/// leak a JSON parser type into best-effort callers.
+pub fn decodeState(allocator: std.mem.Allocator, bytes: []const u8) !?State {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, bytes, .{}) catch |e| switch (e) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidPayload,
+    };
+    defer parsed.deinit();
+    const obj = switch (parsed.value) {
+        .object => |o| o,
+        else => return null,
+    };
+    const checked_at_v = obj.get("checked_at") orelse return null;
+    const latest_tag_v = obj.get("latest_tag") orelse return null;
+    const current_seen_v = obj.get("current_seen") orelse return null;
+    const checked_at_i = switch (checked_at_v) {
+        .integer => |i| i,
+        else => return null,
+    };
+    const latest_tag_s = switch (latest_tag_v) {
+        .string => |s| s,
+        else => return null,
+    };
+    const current_seen_s = switch (current_seen_v) {
+        .string => |s| s,
+        else => return null,
+    };
+    const tag_dup = try allocator.dupe(u8, latest_tag_s);
+    errdefer allocator.free(tag_dup);
+    const seen_dup = try allocator.dupe(u8, current_seen_s);
+    // Optional, default 0 so caches written by older malt still decode.
+    const last_attempt_i: i64 = if (obj.get("last_attempt")) |v| switch (v) {
+        .integer => |i| i,
+        else => 0,
+    } else 0;
+    return .{
+        .checked_at = checked_at_i,
+        .latest_tag = tag_dup,
+        .current_seen = seen_dup,
+        .last_attempt = last_attempt_i,
+    };
+}
+
+pub fn freeState(allocator: std.mem.Allocator, state: State) void {
+    allocator.free(state.latest_tag);
+    allocator.free(state.current_seen);
+}
+
+/// Install `new_value` first, then free the prior — single statement so a
+/// caller's `defer if (state) |s| freeState(...)` can never observe a freed
+/// pair, even if a future edit slips a fallible call in between.
+pub fn replaceState(state: *?State, allocator: std.mem.Allocator, new_value: State) void {
+    const prior = state.*;
+    state.* = new_value;
+    if (prior) |p| freeState(allocator, p);
+}
+
+/// Returns null when the file is absent (a torn or first run).
+pub fn readCache(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !?State {
+    const bytes = readFileAllAbsolute(io, allocator, path, 64 * 1024) catch |e| switch (e) {
+        error.FileNotFound => return null,
+        else => return e,
+    };
+    defer allocator.free(bytes);
+    return decodeState(allocator, bytes);
+}
+
+/// Creates the parent directory if missing. Routed through
+/// `atomicWriteFile` so a SIGKILL or concurrent writer can never publish
+/// a torn JSON — readers see either the old cache or the new one.
+pub fn writeCache(io: std.Io, path: []const u8, state: State) !void {
+    if (std.fs.path.dirname(path)) |dir| {
+        std.Io.Dir.cwd().createDirPath(io, dir) catch {};
+    }
+    var buf: [1024]u8 = undefined;
+    const encoded = try encodeState(&buf, state);
+    try atomic.atomicWriteFile(io, path, encoded);
+}
+
+/// Read the entire contents of an absolute file path into a caller-owned slice.
+fn readFileAllAbsolute(io: std.Io, allocator: std.mem.Allocator, abs_path: []const u8, max_bytes: usize) ![]u8 {
+    const f = try std.Io.Dir.openFileAbsolute(io, abs_path, .{});
+    defer f.close(io);
+    const st = try f.stat(io);
+    const size = @min(@as(u64, max_bytes), st.size);
+    const buf = try allocator.alloc(u8, @intCast(size));
+    errdefer allocator.free(buf);
+    const n = try f.readPositionalAll(io, buf, 0);
+    if (n == buf.len) return buf;
+    if (allocator.resize(buf, n)) return buf[0..n];
+    const shrunk = try allocator.alloc(u8, n);
+    @memcpy(shrunk, buf[0..n]);
+    allocator.free(buf);
+    return shrunk;
+}
+
+// --- inline tests --------------------------------------------------------
+
+test "cacheDirFrom: precedence is MALT_CACHE > XDG_CACHE_HOME > HOME" {
+    var buf: [256]u8 = undefined;
+    {
+        const got = cacheDirFrom(.{
+            .malt_cache = "/m",
+            .xdg_cache_home = "/x",
+            .home = "/h",
+        }, &buf) orelse return error.TestExpectedNonNull;
+        try std.testing.expectEqualStrings("/m", got);
+    }
+    {
+        const got = cacheDirFrom(.{
+            .xdg_cache_home = "/x",
+            .home = "/h",
+        }, &buf) orelse return error.TestExpectedNonNull;
+        try std.testing.expectEqualStrings("/x/malt", got);
+    }
+    {
+        const got = cacheDirFrom(.{ .home = "/h" }, &buf) orelse return error.TestExpectedNonNull;
+        try std.testing.expectEqualStrings("/h/.cache/malt", got);
+    }
+    try std.testing.expect(cacheDirFrom(.{}, &buf) == null);
+}
+
+test "cacheDirFrom: empty values fall through to the next candidate" {
+    var buf: [256]u8 = undefined;
+    const got = cacheDirFrom(.{
+        .malt_cache = "",
+        .xdg_cache_home = "",
+        .home = "/home/u",
+    }, &buf) orelse return error.TestExpectedNonNull;
+    try std.testing.expectEqualStrings("/home/u/.cache/malt", got);
+}
+
+test "encodeState: byte-for-byte JSON format is pinned" {
+    // Format compat: a downgrade-then-upgrade round-trip must read the
+    // same bytes a newer malt writes. The on-disk shape is part of the
+    // contract; any change here is a deliberate format break.
+    var buf: [256]u8 = undefined;
+    const encoded = try encodeState(&buf, .{
+        .checked_at = 42,
+        .latest_tag = "v0.10.1",
+        .current_seen = "0.10.0",
+        .last_attempt = 99,
+    });
+    const want = "{\"checked_at\":42,\"latest_tag\":\"v0.10.1\",\"current_seen\":\"0.10.0\",\"last_attempt\":99}\n";
+    try std.testing.expectEqualStrings(want, encoded);
+}
+
+test "encodeState/decodeState: round-trip preserves every field" {
+    const allocator = std.testing.allocator;
+    var buf: [1024]u8 = undefined;
+    const encoded = try encodeState(&buf, .{
+        .checked_at = 1714400000,
+        .latest_tag = "v0.10.1",
+        .current_seen = "0.10.0",
+    });
+
+    const got = (try decodeState(allocator, encoded)) orelse return error.TestExpectedNonNull;
+    defer freeState(allocator, got);
+
+    try std.testing.expectEqual(@as(i64, 1714400000), got.checked_at);
+    try std.testing.expectEqualStrings("v0.10.1", got.latest_tag);
+    try std.testing.expectEqualStrings("0.10.0", got.current_seen);
+}
+
+test "decodeState: malformed JSON yields error.InvalidPayload" {
+    try std.testing.expectError(error.InvalidPayload, decodeState(std.testing.allocator, "not json"));
+}
+
+test "decodeState: missing fields yield null (not an error)" {
+    const got = try decodeState(std.testing.allocator, "{\"checked_at\":1}");
+    try std.testing.expect(got == null);
+}
+
+test "decodeState: extra fields are ignored (forwards-compat)" {
+    const allocator = std.testing.allocator;
+    const json =
+        \\{"checked_at":1,"latest_tag":"v0.10.1","current_seen":"0.10.0","future_field":42}
+    ;
+    const got = (try decodeState(allocator, json)) orelse return error.TestExpectedNonNull;
+    defer freeState(allocator, got);
+    try std.testing.expectEqualStrings("v0.10.1", got.latest_tag);
+}
+
+test "encodeState: escapes JSON special characters in tag/version strings" {
+    var buf: [256]u8 = undefined;
+    const encoded = try encodeState(&buf, .{
+        .checked_at = 0,
+        .latest_tag = "v\"X",
+        .current_seen = "ok",
+    });
+    try std.testing.expect(std.mem.indexOf(u8, encoded, "\\\"") != null);
+}
+
+test "writeCache + readCache round-trip on a real file" {
+    const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notifier_rt_{d}", .{std.Io.Clock.real.now(io).toNanoseconds()});
+    std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
+
+    try writeCache(io, path, .{
+        .checked_at = 1714400000,
+        .latest_tag = "v0.10.1",
+        .current_seen = "0.10.0",
+    });
+    const got = (try readCache(io, allocator, path)) orelse return error.TestExpectedNonNull;
+    defer freeState(allocator, got);
+
+    try std.testing.expectEqual(@as(i64, 1714400000), got.checked_at);
+    try std.testing.expectEqualStrings("v0.10.1", got.latest_tag);
+    try std.testing.expectEqualStrings("0.10.0", got.current_seen);
+}
+
+test "writeCache replaces an existing cache atomically (rename, not in-place truncate)" {
+    // A torn write reaches disk only when the writer truncates `path` and
+    // streams into it. Rename-publish gives the destination a fresh inode,
+    // so a stable inode after overwrite is the visible truncate signature.
+    const allocator = std.testing.allocator;
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notifier_atomic_{d}", .{std.Io.Clock.real.now(io).toNanoseconds()});
+    std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}/version-notify.json", .{dir});
+
+    try writeCache(io, path, .{
+        .checked_at = 1714400000,
+        .latest_tag = "v0.10.1",
+        .current_seen = "0.10.0",
+    });
+    const before = blk: {
+        const f = try std.Io.Dir.openFileAbsolute(io, path, .{});
+        defer f.close(io);
+        break :blk try f.stat(io);
+    };
+
+    try writeCache(io, path, .{
+        .checked_at = 1714500000,
+        .latest_tag = "v0.10.2",
+        .current_seen = "0.10.0",
+    });
+    const after = blk: {
+        const f = try std.Io.Dir.openFileAbsolute(io, path, .{});
+        defer f.close(io);
+        break :blk try f.stat(io);
+    };
+
+    try std.testing.expect(before.inode != after.inode);
+
+    // No stale `.tmp` siblings — the rename must publish the new file.
+    var d = try std.Io.Dir.openDirAbsolute(io, dir, .{ .iterate = true });
+    defer d.close(io);
+    var iter = d.iterate();
+    var count: usize = 0;
+    while (try iter.next(io)) |entry| {
+        try std.testing.expectEqualStrings("version-notify.json", entry.name);
+        count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 1), count);
+}
+
+test "replaceState: prior null installs new without freeing" {
+    const allocator = std.testing.allocator;
+    var state: ?State = null;
+    const new_state: State = .{
+        .checked_at = 1,
+        .latest_tag = try allocator.dupe(u8, "v0.10.1"),
+        .current_seen = try allocator.dupe(u8, "0.10.0"),
+    };
+    replaceState(&state, allocator, new_state);
+    defer if (state) |s| freeState(allocator, s);
+    try std.testing.expect(state != null);
+    try std.testing.expectEqualStrings("v0.10.1", state.?.latest_tag);
+}
+
+test "replaceState: prior non-null is freed; caller's deferred free of new is single-owner" {
+    const allocator = std.testing.allocator;
+    var state: ?State = .{
+        .checked_at = 0,
+        .latest_tag = try allocator.dupe(u8, "v0.9.0"),
+        .current_seen = try allocator.dupe(u8, "0.8.0"),
+    };
+    const new_state: State = .{
+        .checked_at = 1,
+        .latest_tag = try allocator.dupe(u8, "v0.10.0"),
+        .current_seen = try allocator.dupe(u8, "0.9.0"),
+    };
+    replaceState(&state, allocator, new_state);
+    // Mirrors the orchestrator's scope-exit pattern; testing.allocator catches
+    // a double-free of the prior pair or a leak of the prior pair.
+    defer if (state) |s| freeState(allocator, s);
+    try std.testing.expectEqual(@as(i64, 1), state.?.checked_at);
+    try std.testing.expectEqualStrings("v0.10.0", state.?.latest_tag);
+}
+
+test "readCache: missing file is null, not an error" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&buf, "/tmp/malt_notifier_absent_{d}.json", .{std.Io.Clock.real.now(io).toNanoseconds()});
+    std.Io.Dir.deleteFileAbsolute(io, path) catch {};
+    const got = try readCache(io, std.testing.allocator, path);
+    try std.testing.expect(got == null);
+}

--- a/src/update/notifier/policy.zig
+++ b/src/update/notifier/policy.zig
@@ -1,0 +1,183 @@
+//! Pure notifier policy — the decision side of the version-notify
+//! contract. No IO, no allocator, no filesystem. The orchestrator
+//! composes these predicates with cache state + IO suppression rules.
+
+const std = @import("std");
+
+const release = @import("../release.zig");
+
+/// Match gh, npm, pnpm — smaller TTLs nag, larger lose freshness.
+pub const cache_ttl_secs: i64 = 24 * 60 * 60;
+
+/// Cooldown after a failed probe so a GitHub outage does not re-fire the
+/// 1.5 s timeout on every malt invocation. Short enough that a recovered
+/// network is picked up the next time the user runs anything.
+pub const failure_backoff_secs: i64 = 5 * 60;
+
+/// The `current == seen == latest_no_v` clause silences the notice for
+/// users who've just updated while the cache TTL is still alive.
+pub fn shouldNotify(current: []const u8, latest_tag: []const u8, current_seen: []const u8) bool {
+    const latest_no_v = release.stripVPrefix(latest_tag);
+    if (latest_no_v.len == 0) return false;
+    if (std.mem.eql(u8, current, latest_no_v)) return false;
+    if (std.mem.eql(u8, current, current_seen) and std.mem.eql(u8, current_seen, latest_no_v)) return false;
+    return true;
+}
+
+pub fn cacheStale(now_secs: i64, checked_at: i64, ttl: i64) bool {
+    // Cache from the future (clock skew) — treat as fresh, never re-fetch.
+    if (now_secs <= checked_at) return false;
+    return (now_secs - checked_at) >= ttl;
+}
+
+/// True when the previous probe failed recently and the caller should
+/// skip the network. `last_attempt > checked_at` is the failure shape:
+/// success bumps both fields together so they stay equal.
+pub fn inFailureBackoff(now_secs: i64, last_attempt: i64, checked_at: i64, backoff: i64) bool {
+    if (last_attempt <= checked_at) return false;
+    if (now_secs <= last_attempt) return false; // clock skew
+    return (now_secs - last_attempt) < backoff;
+}
+
+const ci_env_vars = [_][]const u8{
+    "CI",
+    "GITHUB_ACTIONS",
+    "BUILDKITE",
+    "JENKINS_URL",
+    "TF_BUILD",
+    "CIRCLECI",
+    "GITLAB_CI",
+};
+
+/// Pure variant of `isCi` so tests don't mutate the host environment.
+/// `values` parallels `ci_env_vars` entry-for-entry.
+pub fn isCiFromValues(values: []const ?[]const u8) bool {
+    std.debug.assert(values.len == ci_env_vars.len);
+    for (values) |v| {
+        if (v) |s| {
+            if (s.len > 0) return true;
+        }
+    }
+    return false;
+}
+
+pub fn isCi(environ: std.process.Environ) bool {
+    inline for (ci_env_vars) |name| {
+        if (std.process.Environ.getPosix(environ, name)) |v| {
+            if (v.len > 0) return true;
+        }
+    }
+    return false;
+}
+
+/// Install-pipeline commands deliberately aren't here — `bench.sh`
+/// redirects stderr, so the non-TTY rule in the orchestrator already
+/// exempts them from measurement while interactive users still get
+/// the notice.
+const meta_commands = [_][]const u8{ "version", "--version", "help", "--help", "-h" };
+
+/// Public so `tests/version_notify_test.zig` can pin the skip list
+/// without going through the full suppression flow.
+pub fn isSkippedCommand(cmd: []const u8) bool {
+    if (cmd.len == 0) return true;
+    for (meta_commands) |m| {
+        if (std.mem.eql(u8, cmd, m)) return true;
+    }
+    return false;
+}
+
+/// Mirrors `MALT_ALLOW_UNVERIFIED` / `MALT_ALLOW_RAW_POST_INSTALL`:
+/// the literal `"1"` is the on-state, anything else (incl. an empty
+/// value) is off, so a stray `=` doesn't accidentally silence notices.
+pub fn notifierDisabledFromValue(value: ?[]const u8) bool {
+    const v = value orelse return false;
+    return std.mem.eql(u8, v, "1");
+}
+
+pub fn notifierDisabled(environ: std.process.Environ) bool {
+    return notifierDisabledFromValue(std.process.Environ.getPosix(environ, "MALT_NO_VERSION_NOTIFIER"));
+}
+
+// --- inline tests --------------------------------------------------------
+
+test "shouldNotify: equal versions never notify (with or without leading v)" {
+    try std.testing.expect(!shouldNotify("0.10.0", "v0.10.0", "0.10.0"));
+    try std.testing.expect(!shouldNotify("0.10.0", "0.10.0", ""));
+}
+
+test "shouldNotify: newer latest fires notice" {
+    try std.testing.expect(shouldNotify("0.10.0", "v0.10.1", ""));
+    try std.testing.expect(shouldNotify("0.10.0", "v0.11.0", "0.9.0"));
+}
+
+test "shouldNotify: empty latest never fires" {
+    try std.testing.expect(!shouldNotify("0.10.0", "", ""));
+    try std.testing.expect(!shouldNotify("0.10.0", "v", ""));
+}
+
+test "shouldNotify: post-update suppression — current_seen matches both" {
+    // User updated to 0.10.1; cache still says latest=v0.10.1 — don't nag.
+    try std.testing.expect(!shouldNotify("0.10.1", "v0.10.1", "0.10.1"));
+}
+
+test "shouldNotify: stale cache with mismatched current_seen still fires" {
+    // Cache predates a downgrade-then-cache-rewrite; safe default is to fire.
+    try std.testing.expect(shouldNotify("0.9.0", "v0.10.0", "0.8.0"));
+}
+
+test "cacheStale: TTL boundary" {
+    try std.testing.expect(!cacheStale(100, 100, 60)); // equal ⇒ fresh (delta 0)
+    try std.testing.expect(!cacheStale(159, 100, 60)); // delta 59 < 60
+    try std.testing.expect(cacheStale(160, 100, 60)); // delta 60 ⇒ stale
+    try std.testing.expect(cacheStale(1000, 100, 60));
+}
+
+test "cacheStale: clock skew (cache from the future) is treated as fresh" {
+    try std.testing.expect(!cacheStale(50, 100, 60));
+}
+
+test "notifierDisabledFromValue: only literal \"1\" disables (matches MALT_ALLOW_UNVERIFIED)" {
+    try std.testing.expect(!notifierDisabledFromValue(null));
+    try std.testing.expect(!notifierDisabledFromValue(""));
+    try std.testing.expect(!notifierDisabledFromValue("0"));
+    try std.testing.expect(!notifierDisabledFromValue("true"));
+    try std.testing.expect(!notifierDisabledFromValue("yes"));
+    try std.testing.expect(notifierDisabledFromValue("1"));
+}
+
+test "isCiFromValues: any non-empty wins" {
+    const all_null = [_]?[]const u8{ null, null, null, null, null, null, null };
+    try std.testing.expect(!isCiFromValues(&all_null));
+
+    const empty_string_only = [_]?[]const u8{ "", null, null, null, null, null, null };
+    try std.testing.expect(!isCiFromValues(&empty_string_only));
+
+    const ci_set = [_]?[]const u8{ "true", null, null, null, null, null, null };
+    try std.testing.expect(isCiFromValues(&ci_set));
+
+    const gha_set = [_]?[]const u8{ null, "true", null, null, null, null, null };
+    try std.testing.expect(isCiFromValues(&gha_set));
+}
+
+test "inFailureBackoff: only fires when last_attempt > checked_at" {
+    // Equal pair = success shape; never a backoff.
+    try std.testing.expect(!inFailureBackoff(1000, 500, 500, 60));
+    // last_attempt newer than checked_at + within window → back off.
+    try std.testing.expect(inFailureBackoff(550, 500, 100, 60));
+    // Window elapsed → no longer backing off.
+    try std.testing.expect(!inFailureBackoff(600, 500, 100, 60));
+    // Clock skew (now < last_attempt) — never back off, never crash.
+    try std.testing.expect(!inFailureBackoff(400, 500, 100, 60));
+}
+
+test "isSkippedCommand: meta-command list" {
+    try std.testing.expect(isSkippedCommand(""));
+    try std.testing.expect(isSkippedCommand("version"));
+    try std.testing.expect(isSkippedCommand("--version"));
+    try std.testing.expect(isSkippedCommand("help"));
+    try std.testing.expect(isSkippedCommand("--help"));
+    try std.testing.expect(isSkippedCommand("-h"));
+    try std.testing.expect(!isSkippedCommand("install"));
+    try std.testing.expect(!isSkippedCommand("upgrade"));
+    try std.testing.expect(!isSkippedCommand("list"));
+}


### PR DESCRIPTION
## Description

Splits the notifier into `update/notifier/policy.zig` (pure predicates), `update/notifier/cache.zig` (file location + codec + atomic IO + state lifecycle), and a thin orchestrator. The on-disk cache format is unchanged - pinned by a new byte-for-byte encode test alongside the existing round-trip coverage.

## Related Issue

- None

## Notes for Reviewers

- The split is mechanical. The cache format contract is now pinned by a byte-exact `encodeState` test in `notifier/cache.zig`, so a future edit cannot drift the JSON shape without an explicit test update.
