### PR TITLE
fix(core): plug temp-clone leak and surface broken opt symlinks

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -993,7 +993,9 @@ fn linkAndRecord(
         // row, so an early emit would lie if `linked:failed` follows.
         output.emitNdjsonEvent(.linked, job.name, "ok");
         output.emitNdjsonEvent(.recorded, job.name, "ok");
-        linker.linkOpt(job.name, job.version_str) catch {};
+        linker.linkOpt(job.name, job.version_str) catch |e| {
+            output.warn("opt link for {s} failed: {s} — dependents may fail to load at runtime", .{ job.name, @errorName(e) });
+        };
         recordDeps(db, keg_id, formula);
     } else {
         const keg_id = recordKeg(db, formula, job.store_sha256, keg_path, reason) catch |err| {
@@ -1003,7 +1005,9 @@ fn linkAndRecord(
         };
         // keg-only has no public link phase to roll back.
         output.emitNdjsonEvent(.recorded, job.name, "ok");
-        linker.linkOpt(job.name, job.version_str) catch {};
+        linker.linkOpt(job.name, job.version_str) catch |e| {
+            output.warn("opt link for {s} failed: {s} — dependents may fail to load at runtime", .{ job.name, @errorName(e) });
+        };
         recordDeps(db, keg_id, formula);
     }
     maybeRegisterService(io, allocator, db, formula, prefix);

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -194,7 +194,9 @@ pub fn migrateKeg(
         // the keg row, so an early emit would lie if link fails.
         output.emitNdjsonEvent(.linked, keg_name, "ok");
         output.emitNdjsonEvent(.recorded, keg_name, "ok");
-        deps.linker.linkOpt(formula.name, formula.pkg_version) catch {};
+        deps.linker.linkOpt(formula.name, formula.pkg_version) catch |e| {
+            output.warn("opt link for {s} failed: {s} — dependents may fail to load at runtime", .{ formula.name, @errorName(e) });
+        };
         recordDeps(deps.db, keg_id, &formula);
     } else {
         const keg_id = recordKeg(deps.db, &formula, bottle.sha256, keg.path, "direct") catch {
@@ -202,7 +204,9 @@ pub fn migrateKeg(
             return .failed_install;
         };
         output.emitNdjsonEvent(.recorded, keg_name, "ok");
-        deps.linker.linkOpt(formula.name, formula.pkg_version) catch {};
+        deps.linker.linkOpt(formula.name, formula.pkg_version) catch |e| {
+            output.warn("opt link for {s} failed: {s} — dependents may fail to load at runtime", .{ formula.name, @errorName(e) });
+        };
         recordDeps(deps.db, keg_id, &formula);
     }
 
@@ -336,7 +340,9 @@ fn migrateFromLocalCellar(
         cellar_mod.remove(ctx.io, deps.prefix, keg_name, receipt.version) catch {};
         return .failed_install;
     };
-    deps.linker.linkOpt(keg_name, receipt.version) catch {};
+    deps.linker.linkOpt(keg_name, receipt.version) catch |e| {
+        output.warn("opt link for {s} failed: {s} — dependents may fail to load at runtime", .{ keg_name, @errorName(e) });
+    };
     recordDepsFromList(deps.db, keg_id, receipt.runtime_deps);
 
     // Tap kegs aren't reachable from the bottle DSL pipeline (its body

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -430,8 +430,11 @@ fn upgradeFormula(
     output.emitNdjsonEvent(.linked, name, "ok");
     output.emitNdjsonEvent(.recorded, name, "ok");
 
-    // opt symlink is convenience; install is already functional via versioned link.
-    linker.linkOpt(formula.name, formula.pkg_version) catch {};
+    // opt symlink isn't convenience: dependents' LC_LOAD_DYLIB entries point
+    // into <prefix>/opt/<name>/lib/... — a silent miss surfaces at runtime.
+    linker.linkOpt(formula.name, formula.pkg_version) catch |e| {
+        output.warn("opt link for {s} failed: {s} — dependents may fail to load at runtime", .{ formula.name, @errorName(e) });
+    };
 
     // Step 8 (FS-only tail): drop the now-replaced cellar entry.
     cellar_mod.remove(ctx.io, prefix, name, old_pkg_version) catch {

--- a/src/core/linker.zig
+++ b/src/core/linker.zig
@@ -146,26 +146,32 @@ pub const Linker = struct {
         }
     }
 
-    /// Create opt/{name} -> Cellar/{name}/{version} symlink.
+    /// Create `opt/{name} -> Cellar/{name}/{version}` symlink.
+    ///
+    /// Dependents' relocated `LC_LOAD_DYLIB` entries point into
+    /// `<prefix>/opt/<dep>/lib/...`; a missing link there surfaces as a
+    /// dyld load failure at *runtime*, far from this call. Errors
+    /// propagate so the caller can surface them at install time.
     pub fn linkOpt(self: *Linker, name: []const u8, version: []const u8) !void {
         var opt_parent_buf: [512]u8 = undefined;
-        const opt_parent = std.fmt.bufPrint(&opt_parent_buf, "{s}/opt", .{self.prefix}) catch return;
+        const opt_parent = try std.fmt.bufPrint(&opt_parent_buf, "{s}/opt", .{self.prefix});
         std.Io.Dir.createDirAbsolute(self.io, opt_parent, .default_dir) catch |e| switch (e) {
             error.PathAlreadyExists => {},
-            else => return,
+            else => return e,
         };
 
-        var opt_dir = std.Io.Dir.openDirAbsolute(self.io, opt_parent, .{}) catch return;
+        var opt_dir = try std.Io.Dir.openDirAbsolute(self.io, opt_parent, .{});
         defer opt_dir.close(self.io);
 
         var cellar_buf: [512]u8 = undefined;
-        const cellar_path = std.fmt.bufPrint(&cellar_buf, "{s}/Cellar/{s}/{s}", .{ self.prefix, name, version }) catch return;
+        const cellar_path = try std.fmt.bufPrint(&cellar_buf, "{s}/Cellar/{s}/{s}", .{ self.prefix, name, version });
 
         // Stale opt link from a prior version; symLink would otherwise EEXIST.
+        // Best-effort: a directory at opt/<name> isn't removable here, and
+        // the symLink below surfaces the real obstruction as PathAlreadyExists.
         opt_dir.deleteFile(self.io, name) catch {};
 
-        // Opt is convenience; install remains functional via the versioned link.
-        opt_dir.symLink(self.io, cellar_path, name, .{}) catch {};
+        try opt_dir.symLink(self.io, cellar_path, name, .{});
     }
 
     /// Remove all symlinks for a keg (from DB).

--- a/src/core/relocated_store.zig
+++ b/src/core/relocated_store.zig
@@ -121,18 +121,22 @@ fn saveFresh(
     // Best-effort sweep of a stale temp from a previous crashed snapshot;
     // a real permission error here will resurface on the clone below.
     std.Io.Dir.cwd().deleteTree(io, tmp) catch {};
-    // Best-effort cleanup of the partial clone on failure paths — not
-    // worth surfacing if it itself fails, since the install already
-    // succeeded and the temp is invisible to the public cache layout.
-    errdefer std.Io.Dir.cwd().deleteTree(io, tmp) catch {};
+    // Drop the temp on every exit except the success arm that renames
+    // it into place — covers errors *and* the race-loss branch where
+    // a peer worker already published `dst`.
+    var tmp_consumed = false;
+    defer if (!tmp_consumed) {
+        std.Io.Dir.cwd().deleteTree(io, tmp) catch {};
+    };
 
     clonefile.cloneTree(io, allocator, src, tmp) catch return RelocatedStoreError.SaveFailed;
 
     // Race window: another worker may have published the same sha while we
-    // were cloning. If `dst` exists now, drop our temp (errdefer) and report
-    // success without overwriting the winner.
+    // were cloning. If `dst` exists now, drop our temp (defer above) and
+    // report success without overwriting the winner.
     std.Io.Dir.accessAbsolute(io, dst, .{}) catch {
         std.Io.Dir.renameAbsolute(tmp, dst, io) catch return RelocatedStoreError.SaveFailed;
+        tmp_consumed = true;
     };
 }
 
@@ -384,6 +388,41 @@ test "materialize replaces an existing destination" {
     const got = try readAllForTests(testing.allocator, stale);
     defer testing.allocator.free(got);
     try testing.expectEqualStrings(fixture_script, got);
+}
+
+test "saveFresh cleans the tempdir on the race-loss branch" {
+    const prefix = try tmpPrefixForTests(testing.allocator, "race_loss");
+    defer {
+        std.Io.Dir.cwd().deleteTree(testIo(), prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    try buildKegForTests(testing.allocator, prefix, "rl", "1.0");
+
+    // Force the race-loss branch: pre-create dst so saveFresh's second
+    // accessAbsolute(dst) succeeds, skipping the rename and falling through.
+    const dst = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/store-relocated/{s}",
+        .{ prefix, valid_sha_for_tests },
+    );
+    defer testing.allocator.free(dst);
+    try std.Io.Dir.cwd().createDirPath(testIo(), dst);
+
+    try saveFresh(testIo(), testing.allocator, prefix, "rl", "1.0", dst);
+
+    // Race winner kept dst; the loser's tempdir must not survive.
+    const store_root = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/store-relocated",
+        .{prefix},
+    );
+    defer testing.allocator.free(store_root);
+    var root_dir = try std.Io.Dir.openDirAbsolute(testIo(), store_root, .{ .iterate = true });
+    defer root_dir.close(testIo());
+    var iter = root_dir.iterate();
+    while (iter.next(testIo()) catch null) |entry| {
+        try testing.expect(std.mem.indexOf(u8, entry.name, ".tmp.") == null);
+    }
 }
 
 test "remove deletes the cache entry" {

--- a/tests/linker_core_test.zig
+++ b/tests/linker_core_test.zig
@@ -119,6 +119,42 @@ test "linkOpt creates opt/{name} -> Cellar/{name}/{version}" {
     try testing.expect(std.mem.endsWith(u8, target2, "/Cellar/bar/2.0"));
 }
 
+test "linkOpt replaces a stale regular file at opt/{name}" {
+    // `deleteFile` clears regular files (and stale symlinks), so the
+    // symLink call must still succeed — only a true obstruction (a
+    // non-removable directory) should surface as an error.
+    const prefix = try uniquePrefix("link_opt_regular_file");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const opt_parent = try std.fmt.allocPrint(testing.allocator, "{s}/opt", .{prefix});
+    defer testing.allocator.free(opt_parent);
+    try test_io.cwd().createDirPath(std.Options.debug_io, opt_parent);
+    const stale = try std.fmt.allocPrint(testing.allocator, "{s}/wget", .{opt_parent});
+    defer testing.allocator.free(stale);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, stale, .{});
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "stale\n");
+    }
+
+    const cellar = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/wget/1.0", .{prefix});
+    defer testing.allocator.free(cellar);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cellar);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.linkOpt("wget", "1.0");
+
+    var target_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const target = try test_io.readLinkAbsolute(std.Options.debug_io, stale, &target_buf);
+    try testing.expect(std.mem.endsWith(u8, target, "/Cellar/wget/1.0"));
+}
+
 test "linkOpt surfaces a typed error when opt/{name} is an obstructing directory" {
     const prefix = try uniquePrefix("link_opt_obstructed");
     defer testing.allocator.free(prefix);

--- a/tests/linker_core_test.zig
+++ b/tests/linker_core_test.zig
@@ -119,6 +119,35 @@ test "linkOpt creates opt/{name} -> Cellar/{name}/{version}" {
     try testing.expect(std.mem.endsWith(u8, target2, "/Cellar/bar/2.0"));
 }
 
+test "linkOpt surfaces a typed error when opt/{name} is an obstructing directory" {
+    const prefix = try uniquePrefix("link_opt_obstructed");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    // Pre-create `<prefix>/opt/blocked/` as a non-empty directory.
+    // `deleteFile` can't remove it, so the symLink call must fail —
+    // and the failure must propagate, not get silently swallowed.
+    const opt_blocked = try std.fmt.allocPrint(testing.allocator, "{s}/opt/blocked", .{prefix});
+    defer testing.allocator.free(opt_blocked);
+    try test_io.cwd().createDirPath(std.Options.debug_io, opt_blocked);
+    const sentinel = try std.fmt.allocPrint(testing.allocator, "{s}/sentinel", .{opt_blocked});
+    defer testing.allocator.free(sentinel);
+    const f = try test_io.createFileAbsolute(std.Options.debug_io, sentinel, .{});
+    f.close(std.Options.debug_io);
+
+    const cellar = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/blocked/9.9", .{prefix});
+    defer testing.allocator.free(cellar);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cellar);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try testing.expectError(error.PathAlreadyExists, linker.linkOpt("blocked", "9.9"));
+}
+
 test "checkConflicts flags a symlink that points into a different keg" {
     const prefix = try uniquePrefix("link_conflict");
     defer testing.allocator.free(prefix);


### PR DESCRIPTION
## Description

- The relocated-store fresh-write tempdir now gets cleaned on both branches instead of leaking on race-loss.
- A failed `opt/<name>` symlink is no longer silently swallowed; the user sees a warning at install time, before a dependent fails to dlopen at runtime.

## Related Issue

- None

## Notes for Reviewers

- None
