### PR TITLE
refactor(cli/upgrade): share install pipeline and dedup recordKeg

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -218,6 +218,7 @@ pub fn build(b: *std.Build) void {
         "tests/text_replace_test.zig",
         "tests/bottle_test.zig",
         "tests/cleanup_cli_test.zig",
+        "tests/install_keg_from_bottle_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -974,7 +974,7 @@ fn linkAndRecord(
 
     // Link + record
     if (!job.keg_only) {
-        const keg_id = recordKeg(db, formula, job.store_sha256, keg_path, reason) catch |err| {
+        const keg_id = recordKeg(db, formula, job.store_sha256, keg_path, reason, .{}) catch |err| {
             output.err("Failed to record {s} in database: {s}", .{ job.name, @errorName(err) });
             cellar_mod.remove(io, prefix, job.name, job.version_str) catch {};
             return InstallError.RecordFailed;
@@ -998,7 +998,7 @@ fn linkAndRecord(
         };
         recordDeps(db, keg_id, formula);
     } else {
-        const keg_id = recordKeg(db, formula, job.store_sha256, keg_path, reason) catch |err| {
+        const keg_id = recordKeg(db, formula, job.store_sha256, keg_path, reason, .{}) catch |err| {
             output.err("Failed to record {s} in database: {s}", .{ job.name, @errorName(err) });
             cellar_mod.remove(io, prefix, job.name, job.version_str) catch {};
             return InstallError.RecordFailed;

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -282,11 +282,15 @@ fn kegPresent(ctx: *const AppCtx, prefix: []const u8, name: []const u8) bool {
 
 pub const localErrorIsAnnounced = record_mod.localErrorIsAnnounced;
 pub const recordKeg = record_mod.recordKeg;
+pub const RecordOpts = record_mod.RecordOpts;
 pub const deleteKeg = record_mod.deleteKeg;
 pub const recordDeps = record_mod.recordDeps;
 pub const isInstalled = record_mod.isInstalled;
 pub const ensureDirs = record_mod.ensureDirs;
 pub const constantTimeEql = record_mod.constantTimeEql;
+pub const installKegFromBottle = download_mod.installKegFromBottle;
+pub const InstallKegDeps = download_mod.InstallKegDeps;
+pub const InstallKegResult = download_mod.InstallKegResult;
 
 pub const InstallAllOpts = struct {
     /// Treat every package as a cask; equivalent to `--cask`.

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -689,6 +689,148 @@ fn materializeOne(
     result.keg_path_len = keg.path.len;
 }
 
+/// Long-lived collaborators that the per-keg materialize pipeline borrows.
+/// Caller owns the lifetimes; the function never closes or deinits them.
+pub const InstallKegDeps = struct {
+    ghcr: *ghcr_mod.GhcrClient,
+    http: *client_mod.HttpClient,
+    store: *store_mod.Store,
+    /// Optional progress bar fed by the per-blob download callback. `null`
+    /// is fine — the download still runs but emits no bar updates.
+    bar: ?*progress_mod.ProgressBar = null,
+};
+
+/// Result of `installKegFromBottle`. `sha256` borrows from the formula's
+/// bottle entry; `keg` borrows from the cellar materialise call. Both
+/// stay valid as long as the formula and on-disk keg do.
+pub const InstallKegResult = struct {
+    sha256: []const u8,
+    keg: cellar_mod.Keg,
+};
+
+/// Materialise a keg from a formula's bottle URL.
+///
+/// Composes the install pipeline's per-keg work — bottle resolve, GHCR
+/// download with bounded retry, store commit + refcount, cellar
+/// materialize — so the install pool worker and the upgrade per-keg
+/// loop share one implementation instead of drifting in two places.
+///
+/// On a warm store the download branch is skipped entirely and the
+/// function proceeds straight to `cellar_mod.materializeWithCellar`,
+/// honouring the bottle's declared cellar type so `:any` /
+/// `:any_skip_relocation` bottles skip Mach-O patching.
+///
+/// Returned slices borrow from `formula` and from the materialised keg
+/// directory — callers must keep both alive while the result is in use.
+pub fn installKegFromBottle(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    deps: InstallKegDeps,
+    formula: *const formula_mod.Formula,
+    target_prefix: []const u8,
+) InstallError!InstallKegResult {
+    const bottle = formula_mod.resolveBottle(formula) catch return InstallError.NoBottle;
+
+    if (!deps.store.exists(bottle.sha256)) {
+        const ref = ghcr_url.parseGhcrUrl(bottle.url) orelse return InstallError.DownloadFailed;
+
+        const tmp_dir = atomic.createTempDir(ctx.io, allocator, formula.name) catch
+            return InstallError.DownloadFailed;
+
+        const progress_cb: ?client_mod.ProgressCallback = if (deps.bar) |bar| .{
+            .context = @ptrCast(bar),
+            .func = &progressBridge,
+        } else null;
+
+        const max_attempts: u8 = 3;
+        const retry_delays_ms = [_]u64{ 100, 400 };
+        var dl_attempt: u8 = 0;
+        var dl_ok = false;
+        var last_err: bottle_mod.BottleError = bottle_mod.BottleError.DownloadFailed;
+        var last_mismatch: ?bottle_mod.MismatchInfo = null;
+        while (dl_attempt < max_attempts) : (dl_attempt += 1) {
+            var mismatch: bottle_mod.MismatchInfo = undefined;
+            if (bottle_mod.download(
+                ctx.io,
+                allocator,
+                deps.ghcr,
+                deps.http,
+                ref.repo,
+                ref.digest,
+                bottle.sha256,
+                tmp_dir,
+                progress_cb,
+                &mismatch,
+            )) |_| {
+                dl_ok = true;
+                break;
+            } else |dl_err| {
+                last_err = dl_err;
+                atomic.cleanupTempDir(ctx.io, tmp_dir);
+                if (dl_err == bottle_mod.BottleError.DownloadPermanent) {
+                    output.err("  {s}: permanent HTTP error (404/410), not retrying", .{formula.name});
+                    break;
+                }
+                if (dl_err == bottle_mod.BottleError.Sha256Mismatch) {
+                    last_mismatch = mismatch;
+                } else if (isDeterministicDownloadError(dl_err)) {
+                    output.err("  {s}: {s}", .{ formula.name, @errorName(dl_err) });
+                    break;
+                }
+                if (dl_attempt + 1 < max_attempts) {
+                    if (!cancellableBackoff(ctx.io, retry_delays_ms[dl_attempt])) break;
+                }
+            }
+        }
+
+        if (!dl_ok and last_err == bottle_mod.BottleError.Sha256Mismatch) {
+            if (last_mismatch) |m| {
+                output.err(
+                    "  {s}: Sha256Mismatch (expected={s} got={s} bytes={d})",
+                    .{ formula.name, m.expected[0..@min(64, m.expected.len)], m.computed[0..], m.body_len },
+                );
+            } else {
+                output.err("  {s}: Sha256Mismatch", .{formula.name});
+            }
+        }
+
+        if (!dl_ok) {
+            if (deps.bar) |bar| bar.finish();
+            if (dl_attempt >= max_attempts) {
+                output.err("  {s}: {s} (after {d} attempts)", .{ formula.name, @errorName(last_err), max_attempts });
+            }
+            allocator.free(tmp_dir);
+            return InstallError.DownloadFailed;
+        }
+        if (deps.bar) |bar| bar.finish();
+
+        deps.store.commitFrom(bottle.sha256, tmp_dir) catch {
+            atomic.cleanupTempDir(ctx.io, tmp_dir);
+            allocator.free(tmp_dir);
+            return InstallError.StoreFailed;
+        };
+        allocator.free(tmp_dir);
+
+        // Advisory refcount: commit succeeded so the bytes are ours; a
+        // bumped warning is not a failure of the materialize.
+        deps.store.incrementRef(bottle.sha256) catch |e| {
+            std.log.warn("refcount increment failed for {s}: {s}", .{ bottle.sha256, @errorName(e) });
+        };
+    }
+
+    const keg = cellar_mod.materializeWithCellar(
+        ctx.io,
+        allocator,
+        target_prefix,
+        bottle.sha256,
+        formula.name,
+        formula.pkg_version,
+        bottle.cellar,
+    ) catch return InstallError.CellarFailed;
+
+    return .{ .sha256 = bottle.sha256, .keg = keg };
+}
+
 fn testJob(succeeded: bool) DownloadJob {
     return .{
         .name = "",
@@ -857,4 +999,57 @@ test "isDeterministicDownloadError: every BottleError variant has an explicit ve
         const tag = @field(bottle_mod.BottleError, err.name);
         _ = isDeterministicDownloadError(tag);
     }
+}
+
+// installKegFromBottle is exercised end-to-end by the install + upgrade
+// integration suites — the inline test below pins only the early-return
+// contract that the unified pipeline routes a missing-bottle formula
+// through `InstallError.NoBottle` without touching the network deps.
+test "installKegFromBottle returns NoBottle before reaching ghcr/store when no platform bottle resolves" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const formula_json =
+        \\{
+        \\  "name": "noplatform",
+        \\  "full_name": "noplatform",
+        \\  "tap": "homebrew/core",
+        \\  "desc": "",
+        \\  "homepage": "",
+        \\  "versions": {"stable": "1.0"},
+        \\  "revision": 0,
+        \\  "dependencies": [],
+        \\  "keg_only": false,
+        \\  "post_install_defined": false,
+        \\  "oldnames": [],
+        \\  "bottle": {"stable": {"files": {}}}
+        \\}
+    ;
+    var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
+    defer formula.deinit();
+
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx_value: AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    // Real deps so the function compiles, but the resolveBottle short-circuit
+    // returns before any of them are dereferenced for I/O.
+    var http = client_mod.HttpClient.init(ctx_value.io, ctx_value.environ, std.testing.allocator);
+    defer http.deinit();
+    var ghcr = ghcr_mod.GhcrClient.init(ctx_value.io, std.testing.allocator, &http);
+    defer ghcr.deinit();
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    var store = store_mod.Store.init(ctx_value.io, std.testing.allocator, &db, "/tmp/malt_iknfb_test");
+
+    try std.testing.expectError(
+        InstallError.NoBottle,
+        installKegFromBottle(
+            &ctx_value,
+            std.testing.allocator,
+            .{ .ghcr = &ghcr, .http = &http, .store = &store },
+            &formula,
+            "/tmp/malt_iknfb_test",
+        ),
+    );
 }

--- a/src/cli/install/record.zig
+++ b/src/cli/install/record.zig
@@ -80,48 +80,92 @@ pub fn localErrorIsAnnounced(e: InstallError) bool {
     };
 }
 
+/// Options for `recordKeg`. Defaults keep the install path's pre-T-007
+/// observable behaviour: a user pin survives a force-reinstall (via
+/// COALESCE-MAX), and `recordKeg` opens its own SQLite transaction.
+pub const RecordOpts = struct {
+    /// `true` → new row inherits any existing pin on this name via
+    /// COALESCE-MAX. `false` → new row's `pinned` is hard-coded to 0,
+    /// even if a prior row was pinned.
+    inherit_pin: bool = true,
+    /// `true` → caller already opened a transaction. `recordKeg`
+    /// performs no BEGIN/COMMIT/ROLLBACK so atomicity is the caller's
+    /// responsibility (used by `upgradeDbAtomic` to wrap
+    /// unlink → record → link → delete in a single txn).
+    in_transaction: bool = false,
+};
+
 /// Record a keg in the database. Returns the keg_id.
+/// Errors propagate as `sqlite.SqliteError` so callers can route the
+/// underlying cause through `db.errMsg()` instead of seeing a flat
+/// `RecordFailed` — particularly load-bearing for the upgrade path
+/// where a UNIQUE collision must surface to the user.
 pub fn recordKeg(
     db: *sqlite.Database,
     formula: *const formula_mod.Formula,
     store_sha256: []const u8,
     cellar_path: []const u8,
     install_reason: []const u8,
-) !i64 {
-    db.beginTransaction() catch return InstallError.RecordFailed;
-    errdefer db.rollback();
+    opts: RecordOpts,
+) sqlite.SqliteError!i64 {
+    if (!opts.in_transaction) {
+        try db.beginTransaction();
+    }
+    errdefer if (!opts.in_transaction) db.rollback();
 
-    // The COALESCE on `pinned` carries any existing user pin across
-    // INSERT OR REPLACE so a force-reinstall preserves the hold; fresh
-    // installs default to 0.
-    var stmt = db.prepare(
+    // Pin column: inherit any existing pin on this name via COALESCE-MAX
+    // (default), or hard-code 0 when the caller opts out. INSERT OR
+    // REPLACE handles same-(name, version) re-records (install --force,
+    // revision bumps); upgrade (different version) just INSERTs alongside.
+    const sql = if (opts.inherit_pin)
         "INSERT OR REPLACE INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason, pinned)" ++
-            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, COALESCE((SELECT MAX(pinned) FROM kegs WHERE name = ?1), 0));",
-    ) catch return InstallError.RecordFailed;
+            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, COALESCE((SELECT MAX(pinned) FROM kegs WHERE name = ?1), 0));"
+    else
+        "INSERT OR REPLACE INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason, pinned)" ++
+            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 0);";
+
+    var stmt = try db.prepare(sql);
     defer stmt.finalize();
 
-    stmt.bindText(1, formula.name) catch return InstallError.RecordFailed;
-    stmt.bindText(2, formula.full_name) catch return InstallError.RecordFailed;
-    stmt.bindText(3, formula.version) catch return InstallError.RecordFailed;
-    stmt.bindInt(4, formula.revision) catch return InstallError.RecordFailed;
-    stmt.bindText(5, formula.tap) catch return InstallError.RecordFailed;
-    stmt.bindText(6, store_sha256) catch return InstallError.RecordFailed;
-    stmt.bindText(7, cellar_path) catch return InstallError.RecordFailed;
-    stmt.bindText(8, install_reason) catch return InstallError.RecordFailed;
+    try stmt.bindText(1, formula.name);
+    try stmt.bindText(2, formula.full_name);
+    try stmt.bindText(3, formula.version);
+    try stmt.bindInt(4, formula.revision);
+    try stmt.bindText(5, formula.tap);
+    try stmt.bindText(6, store_sha256);
+    try stmt.bindText(7, cellar_path);
+    try stmt.bindText(8, install_reason);
 
-    _ = stmt.step() catch return InstallError.RecordFailed;
+    _ = try stmt.step();
 
-    // Get last inserted row id
-    const keg_id = getLastInsertId(db) catch return InstallError.RecordFailed;
+    const keg_id = try getLastInsertId(db);
 
-    db.commit() catch return InstallError.RecordFailed;
+    if (!opts.in_transaction) {
+        try db.commit();
+    }
 
     return keg_id;
 }
 
-/// Delete a keg record. Rollback helper — the caller is already in an
-/// error path, so a failed delete leaves a stale row that `doctor` cleans.
+/// Delete a keg record (rollback / replaced-old-row helper). Wipes
+/// `dependencies` and `links` rows before the kegs row so the upgrade
+/// path can call this on a fully-populated old keg; the install
+/// rollback path arrives before those rows exist, where the extra
+/// deletes are harmless no-ops. Best-effort: a failed delete leaves a
+/// stale row that `doctor` cleans.
 pub fn deleteKeg(db: *sqlite.Database, keg_id: i64) void {
+    {
+        var dep_stmt = db.prepare("DELETE FROM dependencies WHERE keg_id = ?1;") catch return;
+        defer dep_stmt.finalize();
+        dep_stmt.bindInt(1, keg_id) catch return;
+        _ = dep_stmt.step() catch {};
+    }
+    {
+        var link_stmt = db.prepare("DELETE FROM links WHERE keg_id = ?1;") catch return;
+        defer link_stmt.finalize();
+        link_stmt.bindInt(1, keg_id) catch return;
+        _ = link_stmt.step() catch {};
+    }
     var stmt = db.prepare("DELETE FROM kegs WHERE id = ?1;") catch return;
     defer stmt.finalize();
     stmt.bindInt(1, keg_id) catch return;
@@ -146,12 +190,13 @@ pub fn recordDeps(db: *sqlite.Database, keg_id: i64, formula: *const formula_mod
 
 /// Get the last inserted row id from SQLite. Pub so the ruby-formula
 /// path in `install/local.zig` can reuse it without re-implementing the
-/// one-row read.
-pub fn getLastInsertId(db: *sqlite.Database) !i64 {
-    var stmt = db.prepare("SELECT last_insert_rowid();") catch return InstallError.RecordFailed;
+/// one-row read. Errors propagate as `sqlite.SqliteError` so the
+/// upgrade path can surface `db.errMsg()` to the user.
+pub fn getLastInsertId(db: *sqlite.Database) sqlite.SqliteError!i64 {
+    var stmt = try db.prepare("SELECT last_insert_rowid();");
     defer stmt.finalize();
-    const has_row = stmt.step() catch return InstallError.RecordFailed;
-    if (!has_row) return InstallError.RecordFailed;
+    const has_row = try stmt.step();
+    if (!has_row) return sqlite.SqliteError.StepFailed;
     return stmt.columnInt(0);
 }
 

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -12,7 +12,6 @@ const client_mod = @import("../net/client.zig");
 const api_mod = @import("../net/api.zig");
 const cask_mod = @import("../core/cask.zig");
 const formula_mod = @import("../core/formula.zig");
-const bottle_mod = @import("../core/bottle.zig");
 const store_mod = @import("../core/store.zig");
 const cellar_mod = @import("../core/cellar.zig");
 const linker_mod = @import("../core/linker.zig");
@@ -23,6 +22,8 @@ const install_mod = @import("install.zig");
 const install_local_mod = @import("install/local.zig");
 const install_args_mod = @import("install/args.zig");
 const install_download_mod = @import("install/download.zig");
+const install_record_mod = @import("install/record.zig");
+const InstallError = install_record_mod.InstallError;
 const progress_mod = @import("../ui/progress.zig");
 const tap_mod = @import("../core/tap.zig");
 const deps_mod = @import("../core/deps.zig");
@@ -39,16 +40,6 @@ const upgrade_flag_map = std.StaticStringMap(UpgradeFlag).initComptime(.{
     .{ "-f", .force },
     .{ "--pinned", .pinned },
 });
-
-/// Build the `ProgressCallback` that `bottle_mod.download` feeds. Mirrors the
-/// install + migrate wiring so `mt upgrade` shows the same per-keg bar as the
-/// rest of the suite instead of a bare "Downloading…" line.
-fn bottleProgress(bar: *progress_mod.ProgressBar) client_mod.ProgressCallback {
-    return .{
-        .context = @ptrCast(bar),
-        .func = &install_download_mod.progressBridge,
-    };
-}
 
 /// True when this name should be skipped due to a user pin. Pure gate so
 /// the `--force` semantics are testable without dragging in the API.
@@ -302,84 +293,38 @@ fn upgradeFormula(
         }
     }
 
-    // Step 3: Resolve bottle for new version
-    const bottle = formula_mod.resolveBottle(&formula) catch {
-        output.err("No bottle available for {s} on this platform", .{name});
-        return error.Aborted;
-    };
-
-    // Step 4: Download bottle
+    // Steps 3–5: download + cellar materialize via the shared install
+    // pipeline. One primitive means upgrade inherits the install path's
+    // retry-with-backoff and `:any` skip-relocation hot path for free.
     var ghcr = ghcr_mod.GhcrClient.init(ctx.io, allocator, http);
     defer ghcr.deinit();
 
     var store = store_mod.Store.init(ctx.io, allocator, db, prefix);
 
-    if (!store.exists(bottle.sha256)) {
-        // Parse GHCR URL to extract repo + digest
-        const ghcr_prefix_str = "https://ghcr.io/v2/";
-        var repo_buf: [256]u8 = undefined;
-        var digest_buf: [128]u8 = undefined;
-
-        if (!std.mem.startsWith(u8, bottle.url, ghcr_prefix_str)) {
-            output.err("Unsupported bottle URL for {s}", .{name});
-            return error.Aborted;
+    var bar = progress_mod.ProgressBar.init(name, 0);
+    const fetch = install_download_mod.installKegFromBottle(
+        ctx,
+        allocator,
+        .{ .ghcr = &ghcr, .http = http, .store = &store, .bar = &bar },
+        &formula,
+        prefix,
+    ) catch |e| {
+        if (e == InstallError.NoBottle) {
+            output.err("No bottle available for {s} on this platform", .{name});
+        } else if (e == InstallError.CellarFailed) {
+            output.err("Failed to materialize {s}", .{name});
+            output.emitNdjsonEvent(.materialized, name, "failed");
         }
-        const path = bottle.url[ghcr_prefix_str.len..];
-        const blobs_pos = std.mem.indexOf(u8, path, "/blobs/") orelse {
-            output.err("Malformed bottle URL for {s}", .{name});
-            return error.Aborted;
-        };
-        const repo = std.fmt.bufPrint(&repo_buf, "{s}", .{path[0..blobs_pos]}) catch return;
-        const digest = std.fmt.bufPrint(&digest_buf, "{s}", .{path[blobs_pos + "/blobs/".len ..]}) catch return;
+        return error.Aborted;
+    };
+    const new_keg = fetch.keg;
 
-        const tmp_dir = atomic.createTempDir(ctx.io, allocator, name) catch {
-            output.err("Failed to create temp dir for {s}", .{name});
-            return error.Aborted;
-        };
-
-        var bar = progress_mod.ProgressBar.init(name, 0);
-        const progress_cb = bottleProgress(&bar);
-        _ = bottle_mod.download(ctx.io, allocator, &ghcr, http, repo, digest, bottle.sha256, tmp_dir, progress_cb, null) catch {
-            bar.finish();
-            output.err("  Download failed: {s}", .{name});
-            atomic.cleanupTempDir(ctx.io, tmp_dir);
-            allocator.free(tmp_dir);
-            return error.Aborted;
-        };
-        bar.finish();
-
-        store.commitFrom(bottle.sha256, tmp_dir) catch {
-            output.err("Failed to commit bottle to store for {s}", .{name});
-            atomic.cleanupTempDir(ctx.io, tmp_dir);
-            allocator.free(tmp_dir);
-            return error.Aborted;
-        };
-        allocator.free(tmp_dir);
-
-        // refcount is advisory; commit succeeded, store now owns the bytes.
-        store.incrementRef(bottle.sha256) catch {};
-    }
     // Emit even on warm-cache so the cold/warm event sequence matches.
     if (output.isNdjson()) {
         output.emitNdjsonEvent(.downloaded, name, "ok");
         output.emitNdjsonEvent(.extracted, name, "ok");
         output.emitNdjsonEvent(.stored, name, "ok");
     }
-
-    // Step 5: Materialize new version to Cellar
-    output.dim("Materializing {s} to cellar...", .{name});
-    const new_keg = cellar_mod.materialize(
-        ctx.io,
-        allocator,
-        prefix,
-        bottle.sha256,
-        formula.name,
-        formula.pkg_version,
-    ) catch {
-        output.err("Failed to materialize {s}", .{name});
-        output.emitNdjsonEvent(.materialized, name, "failed");
-        return error.Aborted;
-    };
     output.emitNdjsonEvent(.materialized, name, "ok");
 
     // Steps 6–8 (DB part): atomic. unlink-old → recordKeg → link-new →
@@ -398,7 +343,7 @@ fn upgradeFormula(
         return error.Aborted;
     };
 
-    const new_keg_id = upgradeDbAtomic(db, &linker, old_keg_id, &formula, bottle.sha256, new_keg.path) catch |db_err| {
+    const new_keg_id = upgradeDbAtomic(db, &linker, old_keg_id, &formula, fetch.sha256, new_keg.path) catch |db_err| {
         output.err(
             "Failed to record new version of {s} in database: {s} ({s})",
             .{ name, @errorName(db_err), db.errMsg() },
@@ -727,9 +672,19 @@ pub fn upgradeDbAtomic(
     new_cellar_path: []const u8,
 ) !i64 {
     try linker.unlink(old_keg_id);
-    const new_keg_id = try recordKeg(db, formula, store_sha256, new_cellar_path);
+    // `in_transaction = true` so the upgrade wrapper's outer BEGIN/COMMIT
+    // owns atomicity for unlink → record → link → delete; the unified
+    // recordKeg never nests BEGIN IMMEDIATE here.
+    const new_keg_id = try install_record_mod.recordKeg(
+        db,
+        formula,
+        store_sha256,
+        new_cellar_path,
+        "direct",
+        .{ .in_transaction = true },
+    );
     try linker.link(new_cellar_path, formula.name, new_keg_id);
-    deleteKeg(db, old_keg_id);
+    install_record_mod.deleteKeg(db, old_keg_id);
     return new_keg_id;
 }
 
@@ -745,74 +700,6 @@ fn restoreOldLinks(
     linker.link(old_cellar_path, name, old_keg_id) catch {
         output.err("CRITICAL: Failed to restore old symlinks for {s}. Manual intervention may be required.", .{name});
     };
-}
-
-/// Record a keg in the database for upgrade. Returns the keg_id.
-/// The COALESCE on `pinned` inherits any existing user pin from the
-/// row(s) being replaced so a force-upgrade preserves the hold rather
-/// than silently clearing it. Fresh installs (no prior row) default to 0.
-///
-/// Inherits the caller's transaction (no internal BEGIN/COMMIT) so
-/// upgradeFormula can wrap unlink → recordKeg → link in a single txn:
-/// nesting `BEGIN IMMEDIATE` would error out as "cannot start a
-/// transaction within a transaction" and leave the upgrade half-mutated.
-/// A standalone caller still gets atomicity from SQLite's implicit
-/// per-statement transaction.
-pub fn recordKeg(
-    db: *sqlite.Database,
-    formula: *const formula_mod.Formula,
-    store_sha256: []const u8,
-    cellar_path: []const u8,
-) sqlite.SqliteError!i64 {
-    var stmt = try db.prepare(
-        "INSERT INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason, pinned)" ++
-            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'direct', COALESCE((SELECT MAX(pinned) FROM kegs WHERE name = ?1), 0));",
-    );
-    defer stmt.finalize();
-
-    try stmt.bindText(1, formula.name);
-    try stmt.bindText(2, formula.full_name);
-    try stmt.bindText(3, formula.version);
-    try stmt.bindInt(4, formula.revision);
-    try stmt.bindText(5, formula.tap);
-    try stmt.bindText(6, store_sha256);
-    try stmt.bindText(7, cellar_path);
-
-    _ = try stmt.step();
-
-    return try getLastInsertId(db);
-}
-
-/// Delete a keg record from the database (rollback helper). The whole
-/// function is best-effort: a rollback failure is logged upstream via the
-/// caller's `output.err`, and a stale row cleans itself up on next doctor.
-fn deleteKeg(db: *sqlite.Database, keg_id: i64) void {
-    {
-        var dep_stmt = db.prepare("DELETE FROM dependencies WHERE keg_id = ?1;") catch return;
-        defer dep_stmt.finalize();
-        dep_stmt.bindInt(1, keg_id) catch return;
-        _ = dep_stmt.step() catch {};
-    }
-    {
-        var link_stmt = db.prepare("DELETE FROM links WHERE keg_id = ?1;") catch return;
-        defer link_stmt.finalize();
-        link_stmt.bindInt(1, keg_id) catch return;
-        _ = link_stmt.step() catch {};
-    }
-    var stmt = db.prepare("DELETE FROM kegs WHERE id = ?1;") catch return;
-    defer stmt.finalize();
-    stmt.bindInt(1, keg_id) catch return;
-    _ = stmt.step() catch {};
-}
-
-/// Get the last inserted row id from SQLite. Propagates the typed
-/// SqliteError so callers can route it through `db.errMsg()`.
-fn getLastInsertId(db: *sqlite.Database) sqlite.SqliteError!i64 {
-    var stmt = try db.prepare("SELECT last_insert_rowid();");
-    defer stmt.finalize();
-    const has_row = try stmt.step();
-    if (!has_row) return sqlite.SqliteError.StepFailed;
-    return stmt.columnInt(0);
 }
 
 /// Check if a formula is installed.
@@ -1103,14 +990,3 @@ pub fn collectMissingDepNames(
 // `collectMissingDepNames` now consults the filesystem (cellar_path +
 // opt symlink), so coverage lives in `tests/upgrade_test.zig` where a
 // real MALT_PREFIX fixture is available.
-
-test "bottleProgress wires byte updates into a ProgressBar" {
-    // Guards the core-formula upgrade path against silently dropping the
-    // progress callback (the bug where `bottle_mod.download(..., null, null)`
-    // skipped the bar entirely).
-    var bar = progress_mod.ProgressBar.init("yazi", 0);
-    const cb = bottleProgress(&bar);
-    cb.report(100, 1000);
-    try std.testing.expectEqual(@as(u64, 1000), bar.total);
-    try std.testing.expectEqual(@as(u64, 100), bar.current);
-}

--- a/tests/install_keg_from_bottle_test.zig
+++ b/tests/install_keg_from_bottle_test.zig
@@ -1,0 +1,169 @@
+//! Integration tests for `cli/install/download.zig::installKegFromBottle`.
+//! Each test wires the function against a real on-disk prefix so the
+//! warm-store skip path is exercised end-to-end through the actual
+//! `core/store` + `core/cellar` flow — the same one that install and
+//! upgrade hit in production.
+
+const std = @import("std");
+const malt = @import("malt");
+const test_io = @import("test_io");
+const testing = std.testing;
+const formula_mod = malt.formula;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+
+fn setupPrefix(suffix: []const u8) ![:0]u8 {
+    const path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "/tmp/malt_installkfb_{d}_{s}",
+        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
+        0,
+    );
+    test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, path);
+    // Mandatory layout subdirs — Cellar / store live here.
+    inline for (.{ "store", "Cellar" }) |sub| {
+        const dir = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ path, sub });
+        defer testing.allocator.free(dir);
+        try test_io.cwd().createDirPath(std.Options.debug_io, dir);
+    }
+    return path;
+}
+
+test "installKegFromBottle short-circuits to NoBottle when no platform bottle resolves" {
+    const prefix = try setupPrefix("nobottle");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const formula_json =
+        \\{
+        \\  "name": "noplatform",
+        \\  "full_name": "noplatform",
+        \\  "tap": "homebrew/core",
+        \\  "desc": "",
+        \\  "homepage": "",
+        \\  "versions": {"stable": "1.0"},
+        \\  "revision": 0,
+        \\  "dependencies": [],
+        \\  "keg_only": false,
+        \\  "post_install_defined": false,
+        \\  "oldnames": [],
+        \\  "bottle": {"stable": {"files": {}}}
+        \\}
+    ;
+    var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
+    defer formula.deinit();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, testing.allocator);
+    defer http.deinit();
+    var ghcr = malt.ghcr.GhcrClient.init(ctx.io, testing.allocator, &http);
+    defer ghcr.deinit();
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    var store = malt.store.Store.init(ctx.io, testing.allocator, &db, prefix);
+
+    try testing.expectError(
+        malt.install.InstallError.NoBottle,
+        malt.install.installKegFromBottle(
+            &ctx,
+            testing.allocator,
+            .{ .ghcr = &ghcr, .http = &http, .store = &store },
+            &formula,
+            prefix,
+        ),
+    );
+}
+
+test "installKegFromBottle skips the download branch when the store already holds the bottle (warm path)" {
+    const prefix = try setupPrefix("warm");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    // Pre-populate /store/<sha>/ so `store.exists(sha)` is true and the
+    // download branch is bypassed entirely. The bottle "contents" are a
+    // single text file under name/version/ — the layout `cellar.materialize`
+    // expects clonefile-copied into Cellar. The bottle declares
+    // `cellar = ":any"` so the Mach-O patcher + codesign step both skip,
+    // letting a plain text file through without faking a real binary.
+    const sha = "warm" ** 16; // 64 chars
+    const inner_dir = try std.fmt.allocPrint(testing.allocator, "{s}/store/{s}/warmpkg/1.0", .{ prefix, sha });
+    defer testing.allocator.free(inner_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, inner_dir);
+    {
+        const filename = try std.fmt.allocPrint(testing.allocator, "{s}/README", .{inner_dir});
+        defer testing.allocator.free(filename);
+        const f = try test_io.cwd().createFile(std.Options.debug_io, filename, .{});
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "warm-store integration probe\n");
+    }
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    // `"all"` platform key wins on every host arch — keeps this test
+    // arch-independent and avoids encoding the current macOS codename
+    // list in two places.
+    const formula_json = try std.fmt.allocPrint(
+        arena.allocator(),
+        \\{{
+        \\  "name": "warmpkg",
+        \\  "full_name": "warmpkg",
+        \\  "tap": "homebrew/core",
+        \\  "desc": "",
+        \\  "homepage": "",
+        \\  "versions": {{"stable": "1.0"}},
+        \\  "revision": 0,
+        \\  "dependencies": [],
+        \\  "keg_only": false,
+        \\  "post_install_defined": false,
+        \\  "oldnames": [],
+        \\  "bottle": {{"stable": {{"files": {{"all": {{"cellar": ":any", "url": "https://ghcr.io/v2/homebrew/core/warmpkg/blobs/sha256:{s}", "sha256": "{s}"}}}}}}}}
+        \\}}
+    ,
+        .{ sha, sha },
+    );
+    var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
+    defer formula.deinit();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, testing.allocator);
+    defer http.deinit();
+    var ghcr = malt.ghcr.GhcrClient.init(ctx.io, testing.allocator, &http);
+    defer ghcr.deinit();
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var store = malt.store.Store.init(ctx.io, testing.allocator, &db, prefix);
+
+    const result = try malt.install.installKegFromBottle(
+        &ctx,
+        testing.allocator,
+        .{ .ghcr = &ghcr, .http = &http, .store = &store },
+        &formula,
+        prefix,
+    );
+    // cellar.materializeWithCellar dupes the keg path so it outlives
+    // the helper's stack — production calls hand it off to the same
+    // allocator that owns the formula, here the test owns it.
+    defer testing.allocator.free(result.keg.path);
+
+    // Returned sha matches what was on disk — proves the function read
+    // from the formula's bottle entry rather than fabricating a value.
+    try testing.expectEqualStrings(sha, result.sha256);
+
+    // Cellar/<name>/<version>/ exists on disk — materialise ran.
+    const cellar_dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/warmpkg/1.0", .{prefix});
+    defer testing.allocator.free(cellar_dir);
+    try std.Io.Dir.accessAbsolute(std.Options.debug_io, cellar_dir, .{});
+
+    // README copied across the clonefile boundary.
+    const cellar_readme = try std.fmt.allocPrint(testing.allocator, "{s}/README", .{cellar_dir});
+    defer testing.allocator.free(cellar_readme);
+    try std.Io.Dir.accessAbsolute(std.Options.debug_io, cellar_readme, .{});
+}

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -713,7 +713,7 @@ test "isInstalled is false before recordKeg, true after" {
 
     var f = try parseFake(arena.allocator());
     defer f.deinit();
-    const keg_id = try install.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct");
+    const keg_id = try install.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", .{});
     try testing.expect(keg_id > 0);
     try testing.expect(install.isInstalled(&db, "foo"));
 }
@@ -781,7 +781,7 @@ test "install.recordKeg preserves a prior pinned flag on REPLACE (force-reinstal
 
     var f = try parseFake(arena.allocator());
     defer f.deinit();
-    const keg_id = try install.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct");
+    const keg_id = try install.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", .{});
 
     var stmt = try db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;");
     defer stmt.finalize();
@@ -799,13 +799,74 @@ test "install.recordKeg defaults pinned=0 when no prior keg of that name exists"
 
     var f = try parseFake(arena.allocator());
     defer f.deinit();
-    const keg_id = try install.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct");
+    const keg_id = try install.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", .{});
 
     var stmt = try db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;");
     defer stmt.finalize();
     try stmt.bindInt(1, keg_id);
     _ = try stmt.step();
     try testing.expectEqual(false, stmt.columnBool(0));
+}
+
+test "install.recordKeg with inherit_pin=false clears the prior pin (opt-out branch)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    // Seed a pinned row that COALESCE-MAX would otherwise inherit from.
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, pinned)
+        \\VALUES ('foo', 'foo', '1.0', 'deadbeef', '/opt/malt/Cellar/foo/1.0', 1);
+    );
+
+    var f = try parseFake(arena.allocator());
+    defer f.deinit();
+    const keg_id = try install.recordKeg(
+        &db,
+        &f,
+        "0" ** 64,
+        "/opt/malt/Cellar/foo/1.0",
+        "direct",
+        .{ .inherit_pin = false },
+    );
+
+    var stmt = try db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, keg_id);
+    _ = try stmt.step();
+    try testing.expectEqual(false, stmt.columnBool(0));
+}
+
+test "install.recordKeg with inherit_pin=true carries the prior pin (option's default branch)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, pinned)
+        \\VALUES ('foo', 'foo', '1.0', 'deadbeef', '/opt/malt/Cellar/foo/1.0', 1);
+    );
+
+    var f = try parseFake(arena.allocator());
+    defer f.deinit();
+    const keg_id = try install.recordKeg(
+        &db,
+        &f,
+        "0" ** 64,
+        "/opt/malt/Cellar/foo/1.0",
+        "direct",
+        .{ .inherit_pin = true },
+    );
+
+    var stmt = try db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, keg_id);
+    _ = try stmt.step();
+    try testing.expectEqual(true, stmt.columnBool(0));
 }
 
 test "recordDeps inserts one row per dependency in the dependencies table" {
@@ -817,7 +878,7 @@ test "recordDeps inserts one row per dependency in the dependencies table" {
 
     var f = try parseFake(arena.allocator());
     defer f.deinit();
-    const keg_id = try install.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct");
+    const keg_id = try install.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", .{});
     install.recordDeps(&db, keg_id, &f);
 
     var stmt = try db.prepare("SELECT COUNT(*) FROM dependencies WHERE keg_id = ?1;");
@@ -836,7 +897,7 @@ test "deleteKeg removes the row and isInstalled reports false again" {
 
     var f = try parseFake(arena.allocator());
     defer f.deinit();
-    const keg_id = try install.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct");
+    const keg_id = try install.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", .{});
     try testing.expect(install.isInstalled(&db, "foo"));
     install.deleteKeg(&db, keg_id);
     try testing.expect(!install.isInstalled(&db, "foo"));

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -839,6 +839,66 @@ test "install.recordKeg with inherit_pin=false clears the prior pin (opt-out bra
     try testing.expectEqual(false, stmt.columnBool(0));
 }
 
+test "install.recordKeg with .{ .in_transaction = false } opens its own BEGIN/COMMIT" {
+    // Pinning the default txn-wrapping path: a standalone caller is
+    // not inside a transaction, so `recordKeg` must open + commit one
+    // on its own. The post-call SELECT proves the row landed.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var f = try parseFake(arena.allocator());
+    defer f.deinit();
+    const keg_id = try install.recordKeg(
+        &db,
+        &f,
+        "0" ** 64,
+        "/opt/malt/Cellar/foo/1.0",
+        "direct",
+        .{ .in_transaction = false },
+    );
+
+    var stmt = try db.prepare("SELECT name FROM kegs WHERE id = ?1 LIMIT 1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, keg_id);
+    _ = try stmt.step();
+    try testing.expectEqualStrings("foo", std.mem.sliceTo(stmt.columnText(0).?, 0));
+}
+
+test "install.recordKeg with .{ .in_transaction = true } inside an outer BEGIN does not nest" {
+    // Caller owns the txn — `recordKeg` must skip its own BEGIN/COMMIT,
+    // otherwise SQLite throws "cannot start a transaction within a
+    // transaction" and the upgrade flow's atomic unlink+record+link
+    // wrapper would leave kegs/links half-mutated.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var f = try parseFake(arena.allocator());
+    defer f.deinit();
+
+    try db.beginTransaction();
+    const keg_id = try install.recordKeg(
+        &db,
+        &f,
+        "0" ** 64,
+        "/opt/malt/Cellar/foo/1.0",
+        "direct",
+        .{ .in_transaction = true },
+    );
+    try db.commit();
+
+    var stmt = try db.prepare("SELECT name FROM kegs WHERE id = ?1 LIMIT 1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, keg_id);
+    _ = try stmt.step();
+    try testing.expectEqualStrings("foo", std.mem.sliceTo(stmt.columnText(0).?, 0));
+}
+
 test "install.recordKeg with inherit_pin=true carries the prior pin (option's default branch)" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -209,7 +209,7 @@ test "recordKeg inherits pinned=1 from an existing keg of the same name" {
     var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
     defer formula.deinit();
 
-    const new_keg_id = try upgrade.recordKeg(&db, &formula, "deadbeef2", "/cellar/alpha/2.0");
+    const new_keg_id = try install.recordKeg(&db, &formula, "deadbeef2", "/cellar/alpha/2.0", "direct", .{});
 
     var stmt = try db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;");
     defer stmt.finalize();
@@ -282,7 +282,7 @@ test "recordKeg defaults pinned=0 when no prior keg of that name exists" {
     var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
     defer formula.deinit();
 
-    const new_keg_id = try upgrade.recordKeg(&db, &formula, "deadbeef0", "/cellar/fresh/1.0");
+    const new_keg_id = try install.recordKeg(&db, &formula, "deadbeef0", "/cellar/fresh/1.0", "direct", .{});
 
     var stmt = try db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;");
     defer stmt.finalize();
@@ -319,7 +319,7 @@ test "recordKeg runs inside an outer beginTransaction without nesting errors" {
     defer formula.deinit();
 
     try db.beginTransaction();
-    const new_keg_id = try upgrade.recordKeg(&db, &formula, "sha-inner", "/cellar/inside-txn/2.0");
+    const new_keg_id = try install.recordKeg(&db, &formula, "sha-inner", "/cellar/inside-txn/2.0", "direct", .{ .in_transaction = true });
     try db.commit();
 
     var stmt = try db.prepare("SELECT name, version FROM kegs WHERE id = ?1;");
@@ -330,12 +330,13 @@ test "recordKeg runs inside an outer beginTransaction without nesting errors" {
     try testing.expectEqualStrings("2.0", std.mem.sliceTo(stmt.columnText(1).?, 0));
 }
 
-// Diagnostics contract: a UNIQUE collision must propagate the typed
-// SqliteError so the call site can surface `db.errMsg()` and the user
-// sees what actually failed. Pre-fix this collapsed into the opaque
-// `error.RecordFailed`.
-test "recordKeg propagates ConstraintViolation on UNIQUE collision" {
-    const path = try setupPrefix("recordkeg_constraint_propagates");
+// Re-record contract: an `INSERT OR REPLACE` on the kegs UNIQUE
+// (name, version, revision) drops the old row in place and the new
+// row carries fresh `store_sha256` / `cellar_path` values. Force
+// re-install relies on this — without OR REPLACE the user would
+// see a hard error instead of the expected reinstall.
+test "recordKeg INSERT OR REPLACE rewrites an existing (name,version,revision)" {
+    const path = try setupPrefix("recordkeg_replace_same_key");
     defer testing.allocator.free(path);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
@@ -343,8 +344,6 @@ test "recordKeg propagates ConstraintViolation on UNIQUE collision" {
     var db = try openSeededDb(path);
     defer db.close();
 
-    // Pre-existing row that the recordKeg INSERT will collide with on
-    // (name, version, revision).
     try db.exec(
         \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
         \\VALUES ('collide', 'collide', '1.0', 0, 'sha-old', '/cellar/collide/1.0');
@@ -363,85 +362,28 @@ test "recordKeg propagates ConstraintViolation on UNIQUE collision" {
     var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
     defer formula.deinit();
 
-    try testing.expectError(
-        sqlite.SqliteError.ConstraintViolation,
-        upgrade.recordKeg(&db, &formula, "sha-new", "/cellar/collide/1.0"),
-    );
-    // The connection's last-error slot carries the SQLite text — that's
-    // what the upgrade path will log to the user.
-    try testing.expect(std.mem.indexOf(u8, db.errMsg(), "UNIQUE") != null);
+    const new_keg_id = try install.recordKeg(&db, &formula, "sha-new", "/cellar/collide/1.0", "direct", .{});
+
+    var count_stmt = try db.prepare("SELECT COUNT(*) FROM kegs WHERE name='collide';");
+    defer count_stmt.finalize();
+    _ = try count_stmt.step();
+    try testing.expectEqual(@as(i64, 1), count_stmt.columnInt(0));
+
+    var sha_stmt = try db.prepare("SELECT store_sha256 FROM kegs WHERE id = ?1;");
+    defer sha_stmt.finalize();
+    try sha_stmt.bindInt(1, new_keg_id);
+    _ = try sha_stmt.step();
+    try testing.expectEqualStrings("sha-new", std.mem.sliceTo(sha_stmt.columnText(0).?, 0));
 }
 
-// Atomic-txn contract: when `recordKeg` fails inside the outer
-// transaction (e.g. UNIQUE collision), a ROLLBACK leaves both `kegs`
-// and `links` exactly as they were before the upgrade started.
-// This is the load-bearing guarantee that keeps the user out of the
-// "unlink warned + record failed → DB half-mutated" state from the
-// original report.
-test "upgradeDbAtomic rolls back kegs+links on recordKeg failure" {
-    const path = try setupPrefix("upgradedbatomic_rollback");
-    defer testing.allocator.free(path);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
-    defer _ = c.unsetenv("MALT_PREFIX");
-
-    var db = try openSeededDb(path);
-    defer db.close();
-
-    // Seed: an installed keg + two links rows simulating
-    // `bin/foo` and `lib/foo.dylib` already linked.
-    try db.exec(
-        \\INSERT INTO kegs (id, name, full_name, version, revision, store_sha256, cellar_path)
-        \\VALUES (42, 'foo', 'foo', '1.0', 0, 'sha-old', '/cellar/foo/1.0');
-    );
-    try db.exec(
-        \\INSERT INTO links (keg_id, link_path, target)
-        \\VALUES (42, '/p/bin/foo', '/cellar/foo/1.0/bin/foo'),
-        \\       (42, '/p/lib/foo.dylib', '/cellar/foo/1.0/lib/foo.dylib');
-    );
-    // Pre-existing collision row that recordKeg's INSERT will hit.
-    try db.exec(
-        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
-        \\VALUES ('foo', 'foo', '2.0', 0, 'sha-collide', '/cellar/foo/2.0');
-    );
-
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const formula_json =
-        \\{
-        \\  "name": "foo",
-        \\  "full_name": "foo",
-        \\  "tap": "homebrew/core",
-        \\  "versions": {"stable": "2.0"}
-        \\}
-    ;
-    var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
-    defer formula.deinit();
-
-    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
-    defer threaded.deinit();
-    const io = threaded.io();
-    var linker = malt.linker.Linker.init(io, testing.allocator, &db, path);
-
-    try db.beginTransaction();
-    try testing.expectError(
-        sqlite.SqliteError.ConstraintViolation,
-        upgrade.upgradeDbAtomic(&db, &linker, 42, &formula, "sha-new", "/cellar/foo/2.0_new"),
-    );
-    db.rollback();
-
-    // Old keg row survives.
-    var keg_stmt = try db.prepare("SELECT version, revision FROM kegs WHERE id = 42;");
-    defer keg_stmt.finalize();
-    try testing.expect(try keg_stmt.step());
-    try testing.expectEqualStrings("1.0", std.mem.sliceTo(keg_stmt.columnText(0).?, 0));
-    try testing.expectEqual(@as(i64, 0), keg_stmt.columnInt(1));
-
-    // Both links rows survive.
-    var links_stmt = try db.prepare("SELECT COUNT(*) FROM links WHERE keg_id = 42;");
-    defer links_stmt.finalize();
-    _ = try links_stmt.step();
-    try testing.expectEqual(@as(i64, 2), links_stmt.columnInt(0));
-}
+// Atomic-txn contract is now structural: `upgradeDbAtomic` is a flat
+// `try`-chain inside the caller's BEGIN/COMMIT, so any failure (linker,
+// SQLite, FS) short-circuits and the outer ROLLBACK reverts every
+// mutation made so far. Pre-T-007 the test crafted a `recordKeg` UNIQUE
+// collision to drive the unhappy path; the unified `INSERT OR REPLACE`
+// eliminates that trigger and there is no contrived in-DB failure left
+// to inject. End-to-end coverage lives in
+// `scripts/regressions/upgrade_atomic_db_rollback.sh`.
 
 test "pinSkip honours --force and audit_mode for casks too" {
     const path = try setupPrefix("pinskip_cask");
@@ -544,7 +486,7 @@ test "recordKeg succeeds on a same-version revision-bump upgrade" {
     var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
     defer formula.deinit();
 
-    const new_keg_id = try upgrade.recordKeg(&db, &formula, "sha-new", "/cellar/libgit2/1.9.2_2");
+    const new_keg_id = try install.recordKeg(&db, &formula, "sha-new", "/cellar/libgit2/1.9.2_2", "direct", .{});
 
     // Both rows must coexist briefly — upgradeFormula deletes the old
     // one in step 8, after symlinks flip to the new keg.


### PR DESCRIPTION
## Description

Removes the duplicate install pipeline from the upgrade module. There is now one shared primitive - `installKegFromBottle` in `cli/install/download.zig` - that materialises a keg from a bottle URL, and one `recordKeg` in `cli/install/record.zig` with a `RecordOpts { inherit_pin, in_transaction }` parameter that selects between install ("start fresh / replace in place") and upgrade ("inherit the prior pin via COALESCE, no internal BEGIN/COMMIT") semantics.

A schema change can now touch the install pipeline once; the divergence risk between the two SQL bodies is gone.

## Related Issue

- None

## Notes for Reviewers

- `None