### PR TITLE
refactor(cli/install): drive the install pool through installKegFromBottle

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -219,6 +219,7 @@ pub fn build(b: *std.Build) void {
         "tests/bottle_test.zig",
         "tests/cleanup_cli_test.zig",
         "tests/install_keg_from_bottle_test.zig",
+        "tests/install_pool_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -746,33 +746,30 @@ fn executeWithOpts(
         // Multi-progress + bars only exist when at least one job downloads.
         // Warm-only installs skip terminal setup entirely; their pool
         // workers materialise without a progress callback.
-        const has_multi = to_download > 0;
-        const download_index: u16 = if (has_multi)
-            assignDownloadLineIndices(all_jobs.items)
+        var multi: ?progress_mod.MultiProgress = if (to_download > 0)
+            progress_mod.MultiProgress.init(assignDownloadLineIndices(all_jobs.items))
         else
-            0;
-        var multi: progress_mod.MultiProgress = undefined;
-        if (has_multi) multi = progress_mod.MultiProgress.init(download_index);
+            null;
         // Anchor the DECSET pair to scope exit so an early return between
         // here and the worker join doesn't leave the terminal in DECRESET.
-        defer if (has_multi) multi.finish();
+        defer if (multi) |*m| m.finish();
 
         var bars: []progress_mod.ProgressBar = &.{};
         defer if (bars.len > 0) allocator.free(bars);
 
-        if (has_multi) {
-            if (allocator.alloc(progress_mod.ProgressBar, download_index)) |s| {
+        if (multi) |*m| {
+            if (allocator.alloc(progress_mod.ProgressBar, m.total_lines)) |s| {
                 bars = s;
             } else |_| {}
             var bar_idx: usize = 0;
             for (all_jobs.items) |*job| {
                 if (job.succeeded) continue;
-                job.multi = &multi;
+                job.multi = m;
                 if (bar_idx < bars.len) {
                     bars[bar_idx] = progress_mod.ProgressBar.init(job.name, 0);
                     bars[bar_idx].label_width = max_name_len;
                     bars[bar_idx].line_index = job.line_index;
-                    bars[bar_idx].multi = &multi;
+                    bars[bar_idx].multi = m;
                     job.bar = &bars[bar_idx];
                     // Draw the initial frame now so this line is not blank
                     // while the worker is waiting to be scheduled.
@@ -819,16 +816,17 @@ fn executeWithOpts(
     }
 
     // Emit from the main thread so ndjson order is deterministic
-    // regardless of worker interleaving. Per-keg sequence groups each
-    // package's events together; consumers group by `name` either way.
+    // regardless of worker interleaving. Cross-keg invariant: every
+    // succeeded job's `downloaded/extracted/stored` triple lands
+    // before any `materialized` event — `.materialized` fires from
+    // the serial link phase below so it stays interleaved with the
+    // per-keg `linked/recorded` pair the consumers already expect.
     if (output.isNdjson()) {
-        for (all_jobs.items, 0..) |job, i| {
+        for (all_jobs.items) |job| {
             if (!job.succeeded) continue;
             output.emitNdjsonEvent(.downloaded, job.name, "ok");
             output.emitNdjsonEvent(.extracted, job.name, "ok");
             output.emitNdjsonEvent(.stored, job.name, "ok");
-            const mat_status: []const u8 = if (mats[i].ok) "ok" else "failed";
-            output.emitNdjsonEvent(.materialized, job.name, mat_status);
         }
     }
 
@@ -867,10 +865,12 @@ fn executeWithOpts(
                 "Failed to materialize {s}: {s} ({s})",
                 .{ job.name, @errorName(err), cellar_mod.describeError(err) },
             );
+            output.emitNdjsonEvent(.materialized, job.name, "failed");
             try failed_kegs.put(job.name, {});
             failed_count += 1;
             continue;
         }
+        output.emitNdjsonEvent(.materialized, job.name, "ok");
 
         // Failed-dep → skip: installing on a broken graph yields a dyld-unresolvable
         // keg. Remove the already-materialised keg so orphans don't linger.

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -47,10 +47,9 @@ pub const dropTopLevelJobs = download_mod.dropTopLevelJobs;
 pub const assignDownloadLineIndices = download_mod.assignDownloadLineIndices;
 pub const isDeterministicDownloadError = download_mod.isDeterministicDownloadError;
 const progressBridge = download_mod.progressBridge;
-const downloadWorker = download_mod.downloadWorker;
-const MaterializeResult = download_mod.MaterializeResult;
-const MaterializePool = download_mod.MaterializePool;
-const materializePoolWorker = download_mod.materializePoolWorker;
+pub const MaterializeResult = download_mod.MaterializeResult;
+pub const InstallPool = download_mod.InstallPool;
+pub const installPoolWorker = download_mod.installPoolWorker;
 const ghcr_url_mod = @import("install/ghcr_url.zig");
 pub const GhcrRef = ghcr_url_mod.GhcrRef;
 pub const parseGhcrUrl = ghcr_url_mod.parseGhcrUrl;
@@ -669,7 +668,10 @@ fn executeWithOpts(
         return;
     }
 
-    // ── Parallel download phase ──────────────────────────────────────
+    // ── Parallel download + materialize phase ────────────────────────
+    // One bounded pool drives `installKegFromBottle` per keg, overlapping
+    // download I/O with codesign CPU inside each worker rather than
+    // staging them across two pools.
 
     // Compute max label width for aligned progress bars
     var max_name_len: u8 = 0;
@@ -691,139 +693,110 @@ fn executeWithOpts(
         }
     }
 
-    if (to_download > 0) {
-        if (to_download == 1) {
-            output.info("Downloading 1 bottle...", .{});
-        } else {
-            output.info("Downloading {d} bottles...", .{to_download});
-        }
+    // Results live across the pool join + the serial link phase below.
+    const mats = allocator.alloc(MaterializeResult, all_jobs.items.len) catch
+        return InstallError.CellarFailed;
+    defer allocator.free(mats);
+    for (mats) |*m| m.* = .{ .ok = false, .err = null };
 
-        // Fold every repo into one multi-scope `/token` round-trip; workers
-        // hit the cache instead of racing. Bookkeeping OOM must propagate —
-        // only the token fetch itself is best-effort.
-        var repo_set: std.StringHashMapUnmanaged(void) = .empty;
-        defer repo_set.deinit(allocator);
-        for (all_jobs.items) |*job| {
-            if (job.succeeded) continue;
-            const ref = parseGhcrUrl(job.bottle_url) orelse continue;
-            try repo_set.put(allocator, ref.repo, {});
-        }
-        if (repo_set.count() > 0) {
-            var repos: std.ArrayList([]const u8) = .empty;
-            defer repos.deinit(allocator);
-            try repos.ensureTotalCapacity(allocator, repo_set.count());
-            var it = repo_set.keyIterator();
-            while (it.next()) |k| try repos.append(allocator, k.*);
-            const pre_http = http_pool.acquire();
-            defer http_pool.release(pre_http);
-            // Best-effort cache warm — any failure (OOM or network) is
-            // absorbed so workers fall back to per-repo fetchToken calls.
-            ghcr.prefetchTokens(pre_http, repos.items) catch {};
-        }
-
-        // Set up multi-progress: assign line indices and create coordinator
-        const download_index = assignDownloadLineIndices(all_jobs.items);
-        var multi = progress_mod.MultiProgress.init(download_index);
-        // Anchor the DECSET pair to scope exit so an early return between
-        // here and the worker join doesn't leave the terminal in DECRESET.
-        defer multi.finish();
-
-        // Main-thread bar allocation — draw an initial frame on every line
-        // before workers spawn, and keep pointers stable for them.
-        var bars: []progress_mod.ProgressBar = &.{};
-        if (allocator.alloc(progress_mod.ProgressBar, download_index)) |s| {
-            bars = s;
-        } else |_| {}
-        defer if (bars.len > 0) allocator.free(bars);
-
-        var bar_idx: usize = 0;
-        for (all_jobs.items) |*job| {
-            if (job.succeeded) continue;
-            job.multi = &multi;
-            if (bar_idx < bars.len) {
-                bars[bar_idx] = progress_mod.ProgressBar.init(job.name, 0);
-                bars[bar_idx].label_width = max_name_len;
-                bars[bar_idx].line_index = job.line_index;
-                bars[bar_idx].multi = &multi;
-                job.bar = &bars[bar_idx];
-                // Draw the initial frame now so this line is not blank while
-                // the worker is waiting to be scheduled.
-                bars[bar_idx].update(0);
-                bar_idx += 1;
-            }
-        }
-
-        var threads: std.ArrayList(std.Thread) = .empty;
-        defer threads.deinit(allocator);
-
-        for (all_jobs.items) |*job| {
-            if (job.succeeded) {
-                continue;
-            }
-            const t = std.Thread.spawn(.{}, downloadWorker, .{
-                ctx.io, allocator, &ghcr, &http_pool, &store, job,
-            }) catch {
-                downloadWorker(ctx.io, allocator, &ghcr, &http_pool, &store, job);
-                continue;
-            };
-            threads.append(allocator, t) catch {
-                t.join();
-                continue;
-            };
-        }
-
-        for (threads.items) |t| t.join();
-    }
-
-    // Emit from the main thread so ndjson order is deterministic
-    // regardless of worker interleaving.
-    if (output.isNdjson()) {
-        for (all_jobs.items) |job| {
-            if (!job.succeeded) continue;
-            output.emitNdjsonEvent(.downloaded, job.name, "ok");
-            output.emitNdjsonEvent(.extracted, job.name, "ok");
-            output.emitNdjsonEvent(.stored, job.name, "ok");
-        }
-    }
-
-    // Check for Ctrl-C between download and materialize phases
-    if (signals.isInterrupted()) {
-        output.warn("Interrupted. Cleaning up...", .{});
-        return;
-    }
-
-    // `--force` pre-materialize: the cellar's clonefile/copy refuses
-    // to overwrite a populated dir, so wipe the resolved-version dir
-    // up front. The destructive part of the cleanup — dropping stale
-    // DB rows, unlinking prior symlinks, sweeping orphan dirs — is
-    // deferred to the serial link phase below so a materialize crash
-    // leaves the user's prior keg + row intact for the revision-bump
-    // case. Pin survives because INSERT OR REPLACE in `recordKeg`
-    // inherits via COALESCE-MAX on `pinned` by name.
+    // `--force` pre-materialize: clonefile refuses to overwrite a populated
+    // keg dir, so wipe the resolved-version dir up front. Destructive DB +
+    // symlink cleanup is deferred to the serial link phase so a materialize
+    // crash leaves the user's prior keg + row intact for the revision-bump
+    // case. Pin survives because `recordKeg` inherits via COALESCE-MAX on
+    // `pinned` by name.
     if (force) {
         for (all_jobs.items) |job| {
             pruneCellarForReinstall(ctx, prefix, job.name, job.version_str);
         }
     }
 
-    // ── Parallel materialize phase ──────────────────────────────────
-    // Materialize steps are per-keg independent; shared state is deferred
-    // to the serial link phase. 4-worker cap — unbounded spawn regressed
-    // warm ffmpeg via page-cache + codesign contention.
-    const mats = allocator.alloc(MaterializeResult, all_jobs.items.len) catch
-        return InstallError.CellarFailed;
-    defer allocator.free(mats);
-    for (mats) |*m| m.* = .{ .ok = false, .err = null };
-
     {
+        if (to_download > 0) {
+            if (to_download == 1) {
+                output.info("Downloading 1 bottle...", .{});
+            } else {
+                output.info("Downloading {d} bottles...", .{to_download});
+            }
+
+            // Fold every repo into one multi-scope `/token` round-trip; workers
+            // hit the cache instead of racing. Bookkeeping OOM must propagate —
+            // only the token fetch itself is best-effort.
+            var repo_set: std.StringHashMapUnmanaged(void) = .empty;
+            defer repo_set.deinit(allocator);
+            for (all_jobs.items) |*job| {
+                if (job.succeeded) continue;
+                const ref = parseGhcrUrl(job.bottle_url) orelse continue;
+                try repo_set.put(allocator, ref.repo, {});
+            }
+            if (repo_set.count() > 0) {
+                var repos: std.ArrayList([]const u8) = .empty;
+                defer repos.deinit(allocator);
+                try repos.ensureTotalCapacity(allocator, repo_set.count());
+                var it = repo_set.keyIterator();
+                while (it.next()) |k| try repos.append(allocator, k.*);
+                const pre_http = http_pool.acquire();
+                defer http_pool.release(pre_http);
+                // Best-effort cache warm — any failure (OOM or network) is
+                // absorbed so workers fall back to per-repo fetchToken calls.
+                ghcr.prefetchTokens(pre_http, repos.items) catch {};
+            }
+        }
+
+        // Multi-progress + bars only exist when at least one job downloads.
+        // Warm-only installs skip terminal setup entirely; their pool
+        // workers materialise without a progress callback.
+        const has_multi = to_download > 0;
+        const download_index: u16 = if (has_multi)
+            assignDownloadLineIndices(all_jobs.items)
+        else
+            0;
+        var multi: progress_mod.MultiProgress = undefined;
+        if (has_multi) multi = progress_mod.MultiProgress.init(download_index);
+        // Anchor the DECSET pair to scope exit so an early return between
+        // here and the worker join doesn't leave the terminal in DECRESET.
+        defer if (has_multi) multi.finish();
+
+        var bars: []progress_mod.ProgressBar = &.{};
+        defer if (bars.len > 0) allocator.free(bars);
+
+        if (has_multi) {
+            if (allocator.alloc(progress_mod.ProgressBar, download_index)) |s| {
+                bars = s;
+            } else |_| {}
+            var bar_idx: usize = 0;
+            for (all_jobs.items) |*job| {
+                if (job.succeeded) continue;
+                job.multi = &multi;
+                if (bar_idx < bars.len) {
+                    bars[bar_idx] = progress_mod.ProgressBar.init(job.name, 0);
+                    bars[bar_idx].label_width = max_name_len;
+                    bars[bar_idx].line_index = job.line_index;
+                    bars[bar_idx].multi = &multi;
+                    job.bar = &bars[bar_idx];
+                    // Draw the initial frame now so this line is not blank
+                    // while the worker is waiting to be scheduled.
+                    bars[bar_idx].update(0);
+                    bar_idx += 1;
+                }
+            }
+        }
+
+        // 4-worker cap — overlap download I/O with codesign CPU inside each
+        // worker. Unbounded spawn regressed warm ffmpeg via page-cache +
+        // codesign contention.
         const max_workers: usize = 4;
         const worker_count = @min(max_workers, all_jobs.items.len);
 
-        var pool_ctx: MaterializePool = .{
-            .io = ctx.io,
+        var pool_ctx: InstallPool = .{
+            .ctx = ctx,
             .next_idx = std.atomic.Value(usize).init(0),
             .jobs = all_jobs.items,
             .prefix = prefix,
+            .ghcr = &ghcr,
+            .http_pool = &http_pool,
+            .store = &store,
+            .cache = &formula_cache,
             .results = mats,
         };
 
@@ -833,16 +806,36 @@ fn executeWithOpts(
 
         var spawned: usize = 0;
         for (0..worker_count) |_| {
-            if (std.Thread.spawn(.{}, materializePoolWorker, .{&pool_ctx})) |t| {
+            if (std.Thread.spawn(.{}, installPoolWorker, .{&pool_ctx})) |t| {
                 pool_threads[spawned] = t;
                 spawned += 1;
             } else |_| {
                 // Fall back to inline execution if spawn fails. The pool
                 // loop will pick up remaining jobs on this thread.
-                materializePoolWorker(&pool_ctx);
+                installPoolWorker(&pool_ctx);
             }
         }
         for (pool_threads[0..spawned]) |t| t.join();
+    }
+
+    // Emit from the main thread so ndjson order is deterministic
+    // regardless of worker interleaving. Per-keg sequence groups each
+    // package's events together; consumers group by `name` either way.
+    if (output.isNdjson()) {
+        for (all_jobs.items, 0..) |job, i| {
+            if (!job.succeeded) continue;
+            output.emitNdjsonEvent(.downloaded, job.name, "ok");
+            output.emitNdjsonEvent(.extracted, job.name, "ok");
+            output.emitNdjsonEvent(.stored, job.name, "ok");
+            const mat_status: []const u8 = if (mats[i].ok) "ok" else "failed";
+            output.emitNdjsonEvent(.materialized, job.name, mat_status);
+        }
+    }
+
+    // Check for Ctrl-C between the pool and the serial link phase
+    if (signals.isInterrupted()) {
+        output.warn("Interrupted. Cleaning up...", .{});
+        return;
     }
 
     // ── Serial link + record phase ──────────────────────────────────
@@ -874,12 +867,10 @@ fn executeWithOpts(
                 "Failed to materialize {s}: {s} ({s})",
                 .{ job.name, @errorName(err), cellar_mod.describeError(err) },
             );
-            output.emitNdjsonEvent(.materialized, job.name, "failed");
             try failed_kegs.put(job.name, {});
             failed_count += 1;
             continue;
         }
-        output.emitNdjsonEvent(.materialized, job.name, "ok");
 
         // Failed-dep → skip: installing on a broken graph yields a dyld-unresolvable
         // keg. Remove the already-materialised keg so orphans don't linger.

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -17,6 +17,7 @@ const atomic = @import("../../fs/atomic.zig");
 const output = @import("../../ui/output.zig");
 const progress_mod = @import("../../ui/progress.zig");
 
+const signals = @import("../../core/signals.zig");
 const ghcr_url = @import("ghcr_url.zig");
 const record = @import("record.zig");
 
@@ -669,9 +670,11 @@ pub const InstallPool = struct {
 
 /// Thread entry-point for the install pool. Drains `pool.jobs` via the
 /// atomic index, running one `installKegFromBottle` per job until the
-/// queue is empty.
+/// queue is empty. Honours Ctrl-C between jobs so a wide dep graph
+/// doesn't keep grinding through queued work after the user interrupts.
 pub fn installPoolWorker(pool: *InstallPool) void {
     while (true) {
+        if (signals.isInterrupted()) return;
         const idx = pool.next_idx.fetchAdd(1, .acq_rel);
         if (idx >= pool.jobs.len) return;
         installOneJob(pool, &pool.jobs[idx], &pool.results[idx]);

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -104,135 +104,10 @@ pub fn isDeterministicDownloadError(err: bottle_mod.BottleError) bool {
     };
 }
 
-/// Download a bottle and commit to store. Runs in a worker thread.
-/// `http_pool` is shared across all download workers — each worker
-/// borrows a client for the duration of a single blob download and
-/// releases it so another worker can reuse the same TLS context.
-pub fn downloadWorker(
-    io: std.Io,
-    _: std.mem.Allocator,
-    ghcr: *ghcr_mod.GhcrClient,
-    http_pool: *client_mod.HttpClientPool,
-    store: *store_mod.Store,
-    job: *DownloadJob,
-) void {
-    // Each thread gets its own arena — the parent arena is not thread-safe.
-    var thread_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer thread_arena.deinit();
-    const allocator = thread_arena.allocator();
-
-    // Skip if already in store
-    if (store.exists(job.sha256)) {
-        job.store_sha256 = job.sha256;
-        job.succeeded = true;
-        return;
-    }
-
-    // Extract repo + digest from bottle URL via the shared parser so
-    // the token-prefetch path in `execute` can collect scopes without
-    // duplicating this logic. Slices borrow from `job.bottle_url`,
-    // which outlives the worker.
-    const ref = ghcr_url.parseGhcrUrl(job.bottle_url) orelse return;
-    const repo = ref.repo;
-    const digest = ref.digest;
-
-    // Create temp dir
-    const tmp_dir = atomic.createTempDir(io, allocator, job.name) catch return;
-
-    // The progress bar was created and pre-rendered by the main thread so that
-    // every reserved line has content even before this worker starts producing
-    // bytes. We just feed updates into it via the progress callback.
-    const bar = job.bar orelse return;
-    const progress_cb = client_mod.ProgressCallback{
-        .context = @ptrCast(bar),
-        .func = &progressBridge,
-    };
-
-    // Borrow a client from the shared pool for the duration of this
-    // download. The pool blocks if all clients are in use by other
-    // workers, then hands us one with its TLS context already warm.
-    const http = http_pool.acquire();
-    defer http_pool.release(http);
-
-    const max_attempts: u8 = 3;
-    const retry_delays_ms = [_]u64{ 100, 400 };
-    var dl_attempt: u8 = 0;
-    var dl_ok = false;
-    var last_err: bottle_mod.BottleError = bottle_mod.BottleError.DownloadFailed;
-    var last_mismatch: ?bottle_mod.MismatchInfo = null;
-    while (dl_attempt < max_attempts) : (dl_attempt += 1) {
-        var mismatch: bottle_mod.MismatchInfo = undefined;
-        if (bottle_mod.download(io, allocator, ghcr, http, repo, digest, job.sha256, tmp_dir, progress_cb, &mismatch)) |_| {
-            dl_ok = true;
-            break;
-        } else |dl_err| {
-            last_err = dl_err;
-            atomic.cleanupTempDir(io, tmp_dir);
-            if (dl_err == bottle_mod.BottleError.DownloadPermanent) {
-                output.err("  {s}: permanent HTTP error (404/410), not retrying", .{job.name});
-                break;
-            }
-            if (dl_err == bottle_mod.BottleError.Sha256Mismatch) {
-                last_mismatch = mismatch;
-                // SHA mismatch is usually deterministic (wrong blob, wrong
-                // expected hash) but in-flight corruption is real, so a
-                // bounded retry rescues a real class of transient
-                // failures. Each retry pays a fresh download — bytes,
-                // hash, all of it — so a malicious server that returns
-                // a wrong-SHA blob cannot have its blob accepted by
-                // exhausting the budget.
-            } else if (isDeterministicDownloadError(dl_err)) {
-                output.err("  {s}: {s}", .{ job.name, @errorName(dl_err) });
-                break;
-            }
-            if (dl_attempt + 1 < max_attempts) {
-                if (!cancellableBackoff(io, retry_delays_ms[dl_attempt])) break;
-            }
-        }
-    }
-    if (!dl_ok and last_err == bottle_mod.BottleError.Sha256Mismatch) {
-        // Same blob hashed the same wrong value across every attempt —
-        // log expected/got/length so the failure is debuggable in the
-        // wild without a re-run under --debug.
-        if (last_mismatch) |m| {
-            output.err(
-                "  {s}: Sha256Mismatch (expected={s} got={s} bytes={d})",
-                .{ job.name, m.expected[0..@min(64, m.expected.len)], m.computed[0..], m.body_len },
-            );
-        } else {
-            output.err("  {s}: Sha256Mismatch", .{job.name});
-        }
-    }
-    if (!dl_ok) {
-        bar.finish();
-        if (dl_attempt >= max_attempts) {
-            output.err("  {s}: {s} (after {d} attempts)", .{ job.name, @errorName(last_err), max_attempts });
-        }
-        allocator.free(tmp_dir);
-        return;
-    }
-    bar.finish();
-
-    // Commit to store
-    store.commitFrom(job.sha256, tmp_dir) catch {
-        atomic.cleanupTempDir(io, tmp_dir);
-        allocator.free(tmp_dir);
-        return;
-    };
-    allocator.free(tmp_dir);
-
-    store.incrementRef(job.sha256) catch |e| {
-        std.log.warn("refcount increment failed for {s}: {s}", .{ job.sha256, @errorName(e) });
-    };
-
-    job.store_sha256 = job.sha256;
-    job.succeeded = true;
-}
-
 /// Per-dep worker context for parallel formula fetching. Owns its own
 /// `ArenaAllocator` backed by `page_allocator` so workers never touch
-/// a shared bump-pointer — matches the `downloadWorker` pattern and
-/// removes the last cross-thread allocator on the resolve path.
+/// a shared bump-pointer and the resolve path stays off the caller's
+/// allocator on a cross-thread boundary.
 ///
 /// Why the pool on the HTTP side: creating a fresh `HttpClient` per
 /// worker paid a full TLS context + cert store setup per dep. For
@@ -270,8 +145,8 @@ pub fn collectFetchWorkerCount(deps_to_fetch: usize) usize {
     return @min(MAX_COLLECT_FETCH_WORKERS, deps_to_fetch);
 }
 
-/// Shared state for the dep-fetch pool. Mirrors `MaterializePool`: a
-/// single atomic index hands out `ctxs` slots to workers until the
+/// Shared state for the dep-fetch pool. Mirrors `InstallPool` below:
+/// a single atomic index hands out `ctxs` slots to workers until the
 /// array is drained. Already-installed deps are skipped in-thread.
 const FetchJobsPool = struct {
     next_idx: std.atomic.Value(usize),
@@ -421,7 +296,7 @@ pub fn collectFormulaJobs(
         // Bounded pool: one-thread-per-dep over-allocated stacks and
         // queued on the 4-slot HTTP client pool anyway. Workers share
         // an atomic index and drain `ctxs` — same pattern as
-        // `materializePoolWorker`.
+        // `installPoolWorker`.
         var to_fetch: usize = 0;
         for (deps) |d| {
             if (!d.already_installed) to_fetch += 1;
@@ -622,73 +497,6 @@ pub const MaterializeResult = struct {
     }
 };
 
-/// Shared state for a bounded work-stealing thread pool that executes
-/// the materialize phase. `next_idx` hands out jobs atomically so
-/// workers grab the next available job until the queue is drained —
-/// natural load-balancing without waves.
-pub const MaterializePool = struct {
-    io: std.Io,
-    next_idx: std.atomic.Value(usize),
-    jobs: []DownloadJob,
-    prefix: []const u8,
-    results: []MaterializeResult,
-};
-
-/// Thread entry-point for the bounded materialize pool. Each worker
-/// loops grabbing the next job index atomically and running
-/// `materializeOne` on it until the index passes the end of the jobs
-/// array. The pool is capped at 4 workers (see the call site in
-/// `execute`) to keep file-I/O and codesign-subprocess contention low.
-pub fn materializePoolWorker(pool: *MaterializePool) void {
-    while (true) {
-        const idx = pool.next_idx.fetchAdd(1, .acq_rel);
-        if (idx >= pool.jobs.len) return;
-        const job = &pool.jobs[idx];
-        if (!job.succeeded) continue;
-        materializeOne(pool.io, job, pool.prefix, &pool.results[idx]);
-    }
-}
-
-/// Runs the clonefile + Mach-O patching + codesign pipeline for one
-/// job and stores the result. Thread-safe because each call operates
-/// on its own keg path (different name/version) and the cellar
-/// module's I/O paths never overlap between jobs.
-///
-/// Uses a per-call arena for short-lived allocations (walker, patcher
-/// buffers, etc.). The keg path is copied into the result's inline
-/// buffer so it outlives the arena without crossing thread boundaries
-/// through a global allocator.
-fn materializeOne(
-    io: std.Io,
-    job: *DownloadJob,
-    prefix: []const u8,
-    result: *MaterializeResult,
-) void {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-    const tmp_allocator = arena.allocator();
-
-    const keg = cellar_mod.materializeWithCellar(
-        io,
-        tmp_allocator,
-        prefix,
-        job.store_sha256,
-        job.name,
-        job.version_str,
-        job.cellar_type,
-    ) catch |err| {
-        result.* = .{ .ok = false, .err = err };
-        return;
-    };
-
-    // Cellar paths are bounded by the OS PATH_MAX; assert the invariant.
-    std.debug.assert(keg.path.len <= result.keg_path_buf.len);
-    @memcpy(result.keg_path_buf[0..keg.path.len], keg.path);
-    result.ok = true;
-    result.err = null;
-    result.keg_path_len = keg.path.len;
-}
-
 /// Long-lived collaborators that the per-keg materialize pipeline borrows.
 /// Caller owns the lifetimes; the function never closes or deinits them.
 pub const InstallKegDeps = struct {
@@ -829,6 +637,97 @@ pub fn installKegFromBottle(
     ) catch return InstallError.CellarFailed;
 
     return .{ .sha256 = bottle.sha256, .keg = keg };
+}
+
+/// Shared state for the install-time per-keg worker pool. Each worker
+/// grabs the next slot in `jobs` atomically, borrows an HTTP client
+/// from `http_pool`, and calls `installKegFromBottle` against the
+/// formula already cached in `cache` by `collectFormulaJobs`. Results
+/// land in `MaterializeResult` slots so the serial link phase below
+/// reads them by index without caring how they were produced.
+pub const InstallPool = struct {
+    ctx: *const AppCtx,
+    next_idx: std.atomic.Value(usize),
+    jobs: []DownloadJob,
+    prefix: []const u8,
+    ghcr: *ghcr_mod.GhcrClient,
+    http_pool: *client_mod.HttpClientPool,
+    store: *store_mod.Store,
+    cache: *deps_mod.FormulaCache,
+    results: []MaterializeResult,
+};
+
+/// Thread entry-point for the install pool. Drains `pool.jobs` via the
+/// atomic index, running one `installKegFromBottle` per job until the
+/// queue is empty.
+pub fn installPoolWorker(pool: *InstallPool) void {
+    while (true) {
+        const idx = pool.next_idx.fetchAdd(1, .acq_rel);
+        if (idx >= pool.jobs.len) return;
+        installOneJob(pool, &pool.jobs[idx], &pool.results[idx]);
+    }
+}
+
+/// Per-job body of the install pool: look up the pre-parsed formula,
+/// borrow an HTTP client, drive `installKegFromBottle`, and stamp the
+/// keg path into the result's inline buffer so it outlives the per-
+/// call arena. Error mapping splits along the download/materialise
+/// boundary: cellar failures keep `job.succeeded = true` so the serial
+/// loop reports "Failed to materialize"; every other variant marks the
+/// job not-succeeded so the serial loop reports "Download failed".
+fn installOneJob(pool: *InstallPool, job: *DownloadJob, result: *MaterializeResult) void {
+    // `collectFormulaJobs` is the only legitimate path into the pool and
+    // always pre-caches every formula it queues. A miss here is a bug
+    // upstream — surface it as a not-succeeded job so the serial link
+    // phase routes the package into the "Download failed" branch.
+    const formula = pool.cache.get(job.name) orelse {
+        result.* = .{ .ok = false, .err = null };
+        job.succeeded = false;
+        return;
+    };
+
+    const http = pool.http_pool.acquire();
+    defer pool.http_pool.release(http);
+
+    // Short-lived arena: keg.path is duped out of `materializeWithCellar`
+    // using this allocator, so we copy it into the result's inline
+    // buffer before the arena drops.
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+
+    const fetch = installKegFromBottle(
+        pool.ctx,
+        arena.allocator(),
+        .{ .ghcr = pool.ghcr, .http = http, .store = pool.store, .bar = job.bar },
+        formula,
+        pool.prefix,
+    ) catch |err| {
+        if (err == InstallError.CellarFailed) {
+            // Download (or warm-store skip) succeeded; only the cellar
+            // step failed. `installKegFromBottle` collapses every
+            // `CellarError` into one `CellarFailed`, so the serial loop
+            // gets the historical catch-all `CloneFailed` — the same
+            // label the materialise-error regression scripts grep for.
+            result.* = .{ .ok = false, .err = cellar_mod.CellarError.CloneFailed };
+            job.succeeded = true;
+        } else {
+            // Every other variant means the download (or store commit)
+            // never produced bytes — route into the serial loop's
+            // "Download failed" branch.
+            result.* = .{ .ok = false, .err = null };
+            job.succeeded = false;
+        }
+        return;
+    };
+
+    std.debug.assert(fetch.keg.path.len <= result.keg_path_buf.len);
+    @memcpy(result.keg_path_buf[0..fetch.keg.path.len], fetch.keg.path);
+    result.keg_path_len = fetch.keg.path.len;
+    result.ok = true;
+    result.err = null;
+
+    job.store_sha256 = fetch.sha256;
+    job.succeeded = true;
 }
 
 fn testJob(succeeded: bool) DownloadJob {

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -506,6 +506,13 @@ pub const InstallKegDeps = struct {
     /// Optional progress bar fed by the per-blob download callback. `null`
     /// is fine — the download still runs but emits no bar updates.
     bar: ?*progress_mod.ProgressBar = null,
+    /// Optional sink for the specific `CellarError` variant when the
+    /// cellar materialise step fails. The function still returns
+    /// `InstallError.CellarFailed` for control flow; the variant is
+    /// captured here so callers (the install pool) can preserve the
+    /// historical "Failed to materialize X: <variant>" diagnostic
+    /// without rerouting through a wider error set.
+    cellar_diag: ?*?cellar_mod.CellarError = null,
 };
 
 /// Result of `installKegFromBottle`. `sha256` borrows from the formula's
@@ -634,7 +641,10 @@ pub fn installKegFromBottle(
         formula.name,
         formula.pkg_version,
         bottle.cellar,
-    ) catch return InstallError.CellarFailed;
+    ) catch |err| {
+        if (deps.cellar_diag) |out| out.* = err;
+        return InstallError.CellarFailed;
+    };
 
     return .{ .sha256 = bottle.sha256, .keg = keg };
 }
@@ -695,20 +705,31 @@ fn installOneJob(pool: *InstallPool, job: *DownloadJob, result: *MaterializeResu
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
 
+    // `cellar_diag` captures the specific `CellarError` variant when
+    // materialise fails so the serial link phase below can still print
+    // "Failed to materialize X: <variant>" with the real cause instead
+    // of a generic catch-all.
+    var cellar_diag: ?cellar_mod.CellarError = null;
+
     const fetch = installKegFromBottle(
         pool.ctx,
         arena.allocator(),
-        .{ .ghcr = pool.ghcr, .http = http, .store = pool.store, .bar = job.bar },
+        .{
+            .ghcr = pool.ghcr,
+            .http = http,
+            .store = pool.store,
+            .bar = job.bar,
+            .cellar_diag = &cellar_diag,
+        },
         formula,
         pool.prefix,
     ) catch |err| {
         if (err == InstallError.CellarFailed) {
             // Download (or warm-store skip) succeeded; only the cellar
-            // step failed. `installKegFromBottle` collapses every
-            // `CellarError` into one `CellarFailed`, so the serial loop
-            // gets the historical catch-all `CloneFailed` — the same
-            // label the materialise-error regression scripts grep for.
-            result.* = .{ .ok = false, .err = cellar_mod.CellarError.CloneFailed };
+            // step failed. Preserve the specific variant the helper
+            // captured into `cellar_diag` so user-facing diagnostics
+            // (and the gh-85 regression script) see the real cause.
+            result.* = .{ .ok = false, .err = cellar_diag };
             job.succeeded = true;
         } else {
             // Every other variant means the download (or store commit)

--- a/tests/install_keg_from_bottle_test.zig
+++ b/tests/install_keg_from_bottle_test.zig
@@ -167,3 +167,80 @@ test "installKegFromBottle skips the download branch when the store already hold
     defer testing.allocator.free(cellar_readme);
     try std.Io.Dir.accessAbsolute(std.Options.debug_io, cellar_readme, .{});
 }
+
+test "installKegFromBottle stamps the specific CellarError variant into cellar_diag on materialise failure" {
+    const prefix = try setupPrefix("diag");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    // Pre-seed `store/<sha>/` so `installKegFromBottle` skips the
+    // download branch and goes straight to `materializeWithCellar`.
+    const sha = "feed" ** 16;
+    const store_inner = try std.fmt.allocPrint(testing.allocator, "{s}/store/{s}", .{ prefix, sha });
+    defer testing.allocator.free(store_inner);
+    try test_io.cwd().createDirPath(std.Options.debug_io, store_inner);
+
+    // A 230 + 230 char name+version overflows the cellar-path 512-byte
+    // stack buffer in `materializeWithCellar`, which surfaces as
+    // `CellarError.OutOfMemory`. We pin that specific variant to prove
+    // `cellar_diag` carries the real cause, not a generic catch-all.
+    const long_name = "a" ** 230;
+    const long_ver = "1" ** 230;
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const formula_json = try std.fmt.allocPrint(
+        arena.allocator(),
+        \\{{
+        \\  "name": "{s}",
+        \\  "full_name": "{s}",
+        \\  "tap": "homebrew/core",
+        \\  "desc": "",
+        \\  "homepage": "",
+        \\  "versions": {{"stable": "{s}"}},
+        \\  "revision": 0,
+        \\  "dependencies": [],
+        \\  "keg_only": false,
+        \\  "post_install_defined": false,
+        \\  "oldnames": [],
+        \\  "bottle": {{"stable": {{"files": {{"all": {{"cellar": ":any", "url": "https://ghcr.io/v2/homebrew/core/x/blobs/sha256:{s}", "sha256": "{s}"}}}}}}}}
+        \\}}
+    ,
+        .{ long_name, long_name, long_ver, sha, sha },
+    );
+    var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
+    defer formula.deinit();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, testing.allocator);
+    defer http.deinit();
+    var ghcr = malt.ghcr.GhcrClient.init(ctx.io, testing.allocator, &http);
+    defer ghcr.deinit();
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var store = malt.store.Store.init(ctx.io, testing.allocator, &db, prefix);
+
+    var cellar_diag: ?malt.cellar.CellarError = null;
+    try testing.expectError(
+        malt.install.InstallError.CellarFailed,
+        malt.install.installKegFromBottle(
+            &ctx,
+            testing.allocator,
+            .{
+                .ghcr = &ghcr,
+                .http = &http,
+                .store = &store,
+                .cellar_diag = &cellar_diag,
+            },
+            &formula,
+            prefix,
+        ),
+    );
+    try testing.expectEqual(
+        @as(?malt.cellar.CellarError, malt.cellar.CellarError.OutOfMemory),
+        cellar_diag,
+    );
+}

--- a/tests/install_pool_test.zig
+++ b/tests/install_pool_test.zig
@@ -1,0 +1,333 @@
+//! Integration tests for `cli/install/download.zig::installPoolWorker`.
+//!
+//! The pool is what `cli/install.zig::execute` spawns once per install
+//! run: a bounded set of workers that each pull the next job index
+//! atomically and call `installKegFromBottle` against the per-job
+//! formula. These tests pin the worker's draining contract end-to-end
+//! against a real on-disk prefix with a pre-seeded warm store, so the
+//! pipeline runs the same store + cellar code paths production hits.
+
+const std = @import("std");
+const malt = @import("malt");
+const test_io = @import("test_io");
+const testing = std.testing;
+const formula_mod = malt.formula;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+
+fn setupPrefix(suffix: []const u8) ![:0]u8 {
+    const path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "/tmp/malt_installpool_{d}_{s}",
+        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
+        0,
+    );
+    test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, path);
+    inline for (.{ "store", "Cellar" }) |sub| {
+        const dir = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ path, sub });
+        defer testing.allocator.free(dir);
+        try test_io.cwd().createDirPath(std.Options.debug_io, dir);
+    }
+    return path;
+}
+
+fn seedWarmStore(
+    prefix: []const u8,
+    sha: []const u8,
+    name: []const u8,
+    version: []const u8,
+) !void {
+    const inner = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/store/{s}/{s}/{s}",
+        .{ prefix, sha, name, version },
+    );
+    defer testing.allocator.free(inner);
+    try test_io.cwd().createDirPath(std.Options.debug_io, inner);
+    const readme = try std.fmt.allocPrint(testing.allocator, "{s}/README", .{inner});
+    defer testing.allocator.free(readme);
+    const f = try test_io.cwd().createFile(std.Options.debug_io, readme, .{});
+    defer f.close(std.Options.debug_io);
+    try f.writeStreamingAll(std.Options.debug_io, "warm-pool integration probe\n");
+}
+
+fn anyPlatformFormulaJson(
+    arena: std.mem.Allocator,
+    name: []const u8,
+    version: []const u8,
+    sha: []const u8,
+) ![]const u8 {
+    return std.fmt.allocPrint(arena,
+        \\{{
+        \\  "name": "{s}",
+        \\  "full_name": "{s}",
+        \\  "tap": "homebrew/core",
+        \\  "desc": "",
+        \\  "homepage": "",
+        \\  "versions": {{"stable": "{s}"}},
+        \\  "revision": 0,
+        \\  "dependencies": [],
+        \\  "keg_only": false,
+        \\  "post_install_defined": false,
+        \\  "oldnames": [],
+        \\  "bottle": {{"stable": {{"files": {{"all": {{"cellar": ":any", "url": "https://ghcr.io/v2/homebrew/core/{s}/blobs/sha256:{s}", "sha256": "{s}"}}}}}}}}
+        \\}}
+    , .{ name, name, version, name, sha, sha });
+}
+
+fn makeJob(name: []const u8, version: []const u8, sha: []const u8) malt.install.DownloadJob {
+    return .{
+        .name = name,
+        .version_str = version,
+        .sha256 = sha,
+        .bottle_url = "",
+        .is_dep = false,
+        .keg_only = false,
+        .post_install_defined = false,
+        .formula_json = "",
+        .cellar_type = ":any",
+        .label_width = 0,
+        .line_index = 0,
+        .multi = null,
+        .bar = null,
+        .store_sha256 = "",
+        .succeeded = false,
+    };
+}
+
+test "installPoolWorker drains every job against a warm store and stamps each result" {
+    const prefix = try setupPrefix("drain");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    // Two jobs, both warm. The atomic-index loop must hand both out and
+    // stop cleanly at the end — no off-by-one, no double-processing.
+    const sha_a = "aaaa" ** 16;
+    const sha_b = "bbbb" ** 16;
+    try seedWarmStore(prefix, sha_a, "alpha", "1.0");
+    try seedWarmStore(prefix, sha_b, "beta", "2.0");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const json_a = try anyPlatformFormulaJson(arena.allocator(), "alpha", "1.0", sha_a);
+    const json_b = try anyPlatformFormulaJson(arena.allocator(), "beta", "2.0", sha_b);
+
+    var cache = malt.deps.FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+    _ = try cache.getOrParse("alpha", json_a);
+    _ = try cache.getOrParse("beta", json_b);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var http_pool = try malt.client.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 1);
+    defer http_pool.deinit();
+    // ghcr/http are required by the worker signature but the warm-store
+    // fast path inside `installKegFromBottle` short-circuits before any
+    // network call, so the local HttpClient never opens a connection.
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, testing.allocator);
+    defer http.deinit();
+    var ghcr = malt.ghcr.GhcrClient.init(ctx.io, testing.allocator, &http);
+    defer ghcr.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var store = malt.store.Store.init(ctx.io, testing.allocator, &db, prefix);
+
+    var jobs = [_]malt.install.DownloadJob{
+        makeJob("alpha", "1.0", sha_a),
+        makeJob("beta", "2.0", sha_b),
+    };
+    var results: [2]malt.install.MaterializeResult = .{
+        .{ .ok = false, .err = null },
+        .{ .ok = false, .err = null },
+    };
+
+    var pool: malt.install.InstallPool = .{
+        .ctx = &ctx,
+        .next_idx = std.atomic.Value(usize).init(0),
+        .jobs = &jobs,
+        .prefix = prefix,
+        .ghcr = &ghcr,
+        .http_pool = &http_pool,
+        .store = &store,
+        .cache = &cache,
+        .results = &results,
+    };
+
+    malt.install.installPoolWorker(&pool);
+
+    // Every slot must have been touched — atomic index handed each one
+    // out exactly once; success means warm path landed both kegs.
+    for (results, 0..) |r, i| {
+        try testing.expect(r.ok);
+        try testing.expect(r.err == null);
+        try testing.expect(r.keg_path_len > 0);
+        try testing.expect(jobs[i].succeeded);
+    }
+
+    // Keg paths match the canonical Cellar/<name>/<version> shape so the
+    // serial link phase downstream has a valid path to hand to the linker.
+    const path_a = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/alpha/1.0", .{prefix});
+    defer testing.allocator.free(path_a);
+    const path_b = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/beta/2.0", .{prefix});
+    defer testing.allocator.free(path_b);
+    try testing.expectEqualStrings(path_a, results[0].kegPath());
+    try testing.expectEqualStrings(path_b, results[1].kegPath());
+
+    // Cellar/<name>/<version>/README — cellar materialise actually wrote
+    // the keg, not just stamped the result struct.
+    const readme_a = try std.fmt.allocPrint(testing.allocator, "{s}/README", .{path_a});
+    defer testing.allocator.free(readme_a);
+    try std.Io.Dir.accessAbsolute(std.Options.debug_io, readme_a, .{});
+}
+
+test "installPoolWorker drains a 3-job pool concurrently across two workers" {
+    const prefix = try setupPrefix("concurrent");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    // Three warm jobs, two workers: each worker must skip past slots
+    // already claimed by its sibling without re-processing them. The
+    // atomic counter handles the handoff; a regression here would
+    // double-materialise or skip a slot.
+    const sha_a = "1111" ** 16;
+    const sha_b = "2222" ** 16;
+    const sha_c = "3333" ** 16;
+    try seedWarmStore(prefix, sha_a, "one", "1.0");
+    try seedWarmStore(prefix, sha_b, "two", "2.0");
+    try seedWarmStore(prefix, sha_c, "three", "3.0");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const json_a = try anyPlatformFormulaJson(arena.allocator(), "one", "1.0", sha_a);
+    const json_b = try anyPlatformFormulaJson(arena.allocator(), "two", "2.0", sha_b);
+    const json_c = try anyPlatformFormulaJson(arena.allocator(), "three", "3.0", sha_c);
+
+    var cache = malt.deps.FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+    _ = try cache.getOrParse("one", json_a);
+    _ = try cache.getOrParse("two", json_b);
+    _ = try cache.getOrParse("three", json_c);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    // Two-slot HTTP pool so the two workers can both acquire without
+    // either one blocking on the warm-store fast path.
+    var http_pool = try malt.client.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 2);
+    defer http_pool.deinit();
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, testing.allocator);
+    defer http.deinit();
+    var ghcr = malt.ghcr.GhcrClient.init(ctx.io, testing.allocator, &http);
+    defer ghcr.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var store = malt.store.Store.init(ctx.io, testing.allocator, &db, prefix);
+
+    var jobs = [_]malt.install.DownloadJob{
+        makeJob("one", "1.0", sha_a),
+        makeJob("two", "2.0", sha_b),
+        makeJob("three", "3.0", sha_c),
+    };
+    var results: [3]malt.install.MaterializeResult = .{
+        .{ .ok = false, .err = null },
+        .{ .ok = false, .err = null },
+        .{ .ok = false, .err = null },
+    };
+
+    var pool: malt.install.InstallPool = .{
+        .ctx = &ctx,
+        .next_idx = std.atomic.Value(usize).init(0),
+        .jobs = &jobs,
+        .prefix = prefix,
+        .ghcr = &ghcr,
+        .http_pool = &http_pool,
+        .store = &store,
+        .cache = &cache,
+        .results = &results,
+    };
+
+    const t1 = try std.Thread.spawn(.{}, malt.install.installPoolWorker, .{&pool});
+    const t2 = try std.Thread.spawn(.{}, malt.install.installPoolWorker, .{&pool});
+    t1.join();
+    t2.join();
+
+    // Atomic index gave each worker a distinct slot; no slot got
+    // double-handled (would have re-materialised over an existing dir
+    // and surfaced as a CellarError), none got skipped.
+    for (results, 0..) |r, i| {
+        try testing.expect(r.ok);
+        try testing.expect(r.err == null);
+        try testing.expect(r.keg_path_len > 0);
+        try testing.expect(jobs[i].succeeded);
+    }
+
+    // Final index sat past the last slot — confirms no extra increments
+    // leaked from a re-entry.
+    try testing.expectEqual(@as(usize, 5), pool.next_idx.load(.acquire));
+}
+
+// The materialise-failure → CloneFailed mapping is covered end-to-end by
+// `scripts/regressions/install_zig_clonefail_gh85.sh`, which runs a real
+// install against pre-planted stale Cellar dirs and greps the install
+// log for the `Failed to materialize ... CloneFailed` surface. A purely
+// hermetic CellarFailed is hard to provoke without faking filesystem
+// permissions — the regression script is the source of truth here.
+
+test "installPoolWorker leaves the result untouched and marks job not-succeeded on a missing-formula entry" {
+    const prefix = try setupPrefix("nocache");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var cache = malt.deps.FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var http_pool = try malt.client.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 1);
+    defer http_pool.deinit();
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, testing.allocator);
+    defer http.deinit();
+    var ghcr = malt.ghcr.GhcrClient.init(ctx.io, testing.allocator, &http);
+    defer ghcr.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var store = malt.store.Store.init(ctx.io, testing.allocator, &db, prefix);
+
+    var jobs = [_]malt.install.DownloadJob{makeJob("ghost", "0.1", "deadbeef" ** 8)};
+    var results: [1]malt.install.MaterializeResult = .{.{ .ok = false, .err = null }};
+
+    var pool: malt.install.InstallPool = .{
+        .ctx = &ctx,
+        .next_idx = std.atomic.Value(usize).init(0),
+        .jobs = &jobs,
+        .prefix = prefix,
+        .ghcr = &ghcr,
+        .http_pool = &http_pool,
+        .store = &store,
+        .cache = &cache,
+        .results = &results,
+    };
+
+    malt.install.installPoolWorker(&pool);
+
+    // collectFormulaJobs is the only legitimate path into the pool and
+    // always pre-caches the formula; a miss here is a programming error.
+    // The worker must surface it as a not-succeeded job so the serial
+    // link phase routes the package into the "Download failed" branch
+    // rather than dereferencing a stale result.
+    try testing.expect(!results[0].ok);
+    try testing.expect(results[0].err == null);
+    try testing.expect(!jobs[0].succeeded);
+}

--- a/tests/install_pool_test.zig
+++ b/tests/install_pool_test.zig
@@ -274,12 +274,167 @@ test "installPoolWorker drains a 3-job pool concurrently across two workers" {
     try testing.expectEqual(@as(usize, 5), pool.next_idx.load(.acquire));
 }
 
-// The materialise-failure → CloneFailed mapping is covered end-to-end by
-// `scripts/regressions/install_zig_clonefail_gh85.sh`, which runs a real
-// install against pre-planted stale Cellar dirs and greps the install
-// log for the `Failed to materialize ... CloneFailed` surface. A purely
-// hermetic CellarFailed is hard to provoke without faking filesystem
-// permissions — the regression script is the source of truth here.
+test "installPoolWorker propagates the specific CellarError variant into result.err on materialise failure" {
+    const prefix = try setupPrefix("matvariant");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    // Pre-seed store/<sha>/ so installKegFromBottle skips download and
+    // hits materializeWithCellar, whose 512-byte cellar-path buffer
+    // overflows on a 230+230 char name+version. The helper captures
+    // the resulting CellarError.OutOfMemory through `cellar_diag`; the
+    // pool worker must forward it into `result.err` instead of falling
+    // back to the historical CloneFailed catch-all.
+    const sha = "f00d" ** 16;
+    const store_inner = try std.fmt.allocPrint(testing.allocator, "{s}/store/{s}", .{ prefix, sha });
+    defer testing.allocator.free(store_inner);
+    try test_io.cwd().createDirPath(std.Options.debug_io, store_inner);
+
+    const long_name = "a" ** 230;
+    const long_ver = "1" ** 230;
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const formula_json = try std.fmt.allocPrint(
+        arena.allocator(),
+        \\{{
+        \\  "name": "{s}",
+        \\  "full_name": "{s}",
+        \\  "tap": "homebrew/core",
+        \\  "desc": "",
+        \\  "homepage": "",
+        \\  "versions": {{"stable": "{s}"}},
+        \\  "revision": 0,
+        \\  "dependencies": [],
+        \\  "keg_only": false,
+        \\  "post_install_defined": false,
+        \\  "oldnames": [],
+        \\  "bottle": {{"stable": {{"files": {{"all": {{"cellar": ":any", "url": "https://ghcr.io/v2/homebrew/core/x/blobs/sha256:{s}", "sha256": "{s}"}}}}}}}}
+        \\}}
+    ,
+        .{ long_name, long_name, long_ver, sha, sha },
+    );
+
+    var cache = malt.deps.FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+    _ = try cache.getOrParse(long_name, formula_json);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    var http_pool = try malt.client.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 1);
+    defer http_pool.deinit();
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, testing.allocator);
+    defer http.deinit();
+    var ghcr = malt.ghcr.GhcrClient.init(ctx.io, testing.allocator, &http);
+    defer ghcr.deinit();
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var store = malt.store.Store.init(ctx.io, testing.allocator, &db, prefix);
+
+    var jobs = [_]malt.install.DownloadJob{makeJob(long_name, long_ver, sha)};
+    var results: [1]malt.install.MaterializeResult = .{.{ .ok = false, .err = null }};
+
+    var pool: malt.install.InstallPool = .{
+        .ctx = &ctx,
+        .next_idx = std.atomic.Value(usize).init(0),
+        .jobs = &jobs,
+        .prefix = prefix,
+        .ghcr = &ghcr,
+        .http_pool = &http_pool,
+        .store = &store,
+        .cache = &cache,
+        .results = &results,
+    };
+
+    malt.install.installPoolWorker(&pool);
+
+    // Download phase implicitly succeeded (store.exists was true), so
+    // job.succeeded stays true and the serial link phase routes this
+    // into "Failed to materialize" rather than "Download failed".
+    try testing.expect(!results[0].ok);
+    try testing.expectEqual(
+        @as(?malt.cellar.CellarError, malt.cellar.CellarError.OutOfMemory),
+        results[0].err,
+    );
+    try testing.expect(jobs[0].succeeded);
+}
+
+test "installPoolWorker bails between jobs when Ctrl-C fires" {
+    const prefix = try setupPrefix("interrupt");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    // Two warm jobs, but interrupted is set before the worker spawns
+    // so the loop body should never run installKegFromBottle. The
+    // user-facing effect: hitting Ctrl-C during a wide dep-graph
+    // install stops the pool quickly instead of grinding through every
+    // queued keg first.
+    const sha_a = "abab" ** 16;
+    const sha_b = "cdcd" ** 16;
+    try seedWarmStore(prefix, sha_a, "alpha", "1.0");
+    try seedWarmStore(prefix, sha_b, "beta", "2.0");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const json_a = try anyPlatformFormulaJson(arena.allocator(), "alpha", "1.0", sha_a);
+    const json_b = try anyPlatformFormulaJson(arena.allocator(), "beta", "2.0", sha_b);
+
+    var cache = malt.deps.FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+    _ = try cache.getOrParse("alpha", json_a);
+    _ = try cache.getOrParse("beta", json_b);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    var http_pool = try malt.client.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 1);
+    defer http_pool.deinit();
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, testing.allocator);
+    defer http.deinit();
+    var ghcr = malt.ghcr.GhcrClient.init(ctx.io, testing.allocator, &http);
+    defer ghcr.deinit();
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var store = malt.store.Store.init(ctx.io, testing.allocator, &db, prefix);
+
+    var jobs = [_]malt.install.DownloadJob{
+        makeJob("alpha", "1.0", sha_a),
+        makeJob("beta", "2.0", sha_b),
+    };
+    var results: [2]malt.install.MaterializeResult = .{
+        .{ .ok = false, .err = null },
+        .{ .ok = false, .err = null },
+    };
+
+    var pool: malt.install.InstallPool = .{
+        .ctx = &ctx,
+        .next_idx = std.atomic.Value(usize).init(0),
+        .jobs = &jobs,
+        .prefix = prefix,
+        .ghcr = &ghcr,
+        .http_pool = &http_pool,
+        .store = &store,
+        .cache = &cache,
+        .results = &results,
+    };
+
+    malt.signals.setInterruptedForTest(true);
+    defer malt.signals.setInterruptedForTest(false);
+
+    malt.install.installPoolWorker(&pool);
+
+    // Nothing got drained: the worker noticed the interrupt before its
+    // first fetchAdd, so both jobs stay in their pre-pool state.
+    try testing.expectEqual(@as(usize, 0), pool.next_idx.load(.acquire));
+    for (results) |r| {
+        try testing.expect(!r.ok);
+        try testing.expect(r.err == null);
+    }
+    for (jobs) |j| try testing.expect(!j.succeeded);
+}
 
 test "installPoolWorker leaves the result untouched and marks job not-succeeded on a missing-formula entry" {
     const prefix = try setupPrefix("nocache");

--- a/tests/ndjson_test.zig
+++ b/tests/ndjson_test.zig
@@ -28,11 +28,12 @@ const c = struct {
 /// Two ordering notes for consumers:
 ///   - For a single-package install, events arrive in this exact order.
 ///   - For a multi-package install (e.g. `mt install wget` with deps),
-///     download-class events (downloaded/extracted/stored) emit for
-///     every job before the first materialized event, because the
-///     protocol downloads in parallel and materialises serially.
-///     Each per-package event carries `name` so consumers group by it
-///     instead of relying on strict per-package linearity.
+///     the pool runs download + materialise per keg, then emits the
+///     four pool events (downloaded/extracted/stored/materialized) for
+///     each keg in jobs order from the main thread. Link and recorded
+///     events follow per keg from the serial link phase. Each event
+///     carries `name` so consumers group by it instead of relying on
+///     strict per-package linearity.
 const install_step_events = [_]output.NdjsonEvent{
     .lock_acquired,
     .resolved,

--- a/tests/ndjson_test.zig
+++ b/tests/ndjson_test.zig
@@ -28,12 +28,11 @@ const c = struct {
 /// Two ordering notes for consumers:
 ///   - For a single-package install, events arrive in this exact order.
 ///   - For a multi-package install (e.g. `mt install wget` with deps),
-///     the pool runs download + materialise per keg, then emits the
-///     four pool events (downloaded/extracted/stored/materialized) for
-///     each keg in jobs order from the main thread. Link and recorded
-///     events follow per keg from the serial link phase. Each event
-///     carries `name` so consumers group by it instead of relying on
-///     strict per-package linearity.
+///     download-class events (downloaded/extracted/stored) emit for
+///     every job before the first materialized event, because the
+///     protocol downloads in parallel and materialises serially.
+///     Each per-package event carries `name` so consumers group by it
+///     instead of relying on strict per-package linearity.
 const install_step_events = [_]output.NdjsonEvent{
     .lock_acquired,
     .resolved,


### PR DESCRIPTION
## Description

Collapses `cli/install.zig`'s prior download-pool + materialize-pool into a single per-keg pool driven by `installKegFromBottle`. The shared primitive now has exactly one call site per consumer - one in `cli/install.zig` (via the new `InstallPool`), one in `cli/upgrade.zig` - closing the remaining half of the install-pipeline modularity work.

Each pool worker overlaps download I/O with codesign CPU inside the same arena instead of staging them across two pools. The 4-worker cap is preserved; warm-only installs skip terminal progress setup entirely.
NDJSON `downloaded`/`extracted`/`stored` events emit from a single post-pool block on the main thread; `materialized` keeps its prior slot in the serial link loop, so the public cross-keg ordering documented in `ndjson_test.zig` is unchanged.

The per-keg cellar materialise step's specific `CellarError` variant flows back through a new `cellar_diag` field on `InstallKegDeps`, so "Failed to materialize X: \<variant\>" diagnostics keep the real cause instead of collapsing to a generic catch-all.

`downloadWorker`, `MaterializePool`, `materializePoolWorker`, and `materializeOne` are removed.

## Related Issue

- None

## Notes for Reviewers

- None
