### PR TITLE
refactor: thread caller allocator into worker arenas

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -30,23 +30,13 @@ const ghcr_mod = @import("../net/ghcr.zig");
 const output = @import("../ui/output.zig");
 const progress_mod = @import("../ui/progress.zig");
 const help = @import("help.zig");
-
 const args_mod = @import("install/args.zig");
-const download_mod = @import("install/download.zig");
-const ghcr_url_mod = @import("install/ghcr_url.zig");
-const local_mod = @import("install/local.zig");
-const post_install_mod = @import("install/post_install.zig");
-const rb_parse_mod = @import("install/rb_parse.zig");
-const record_mod = @import("install/record.zig");
-
-// Internal aliases for names the orchestrator body uses. Names not in
-// this block are reached via their submodule (`args_mod.X`, etc.) or
-// only consumed by tests through `lib.install_<sub>.X`.
 const max_prefix_sane_len = args_mod.max_prefix_sane_len;
 const checkPrefixSane = args_mod.checkPrefixSane;
 const isTapFormula = args_mod.isTapFormula;
 const isLocalFormulaPath = args_mod.isLocalFormulaPath;
 const isSelfInstall = args_mod.isSelfInstall;
+const download_mod = @import("install/download.zig");
 const DownloadJob = download_mod.DownloadJob;
 const collectFormulaJobs = download_mod.collectFormulaJobs;
 const findFailedDep = download_mod.findFailedDep;
@@ -56,10 +46,15 @@ const MaterializeResult = download_mod.MaterializeResult;
 const InstallPool = download_mod.InstallPool;
 const installPoolWorker = download_mod.installPoolWorker;
 const progressBridge = download_mod.progressBridge;
+const ghcr_url_mod = @import("install/ghcr_url.zig");
 const parseGhcrUrl = ghcr_url_mod.parseGhcrUrl;
+const local_mod = @import("install/local.zig");
 const installTapFormula = local_mod.installTapFormula;
 const installLocalFormula = local_mod.installLocalFormula;
+const post_install_mod = @import("install/post_install.zig");
 const drive = post_install_mod.drive;
+const rb_parse_mod = @import("install/rb_parse.zig");
+const record_mod = @import("install/record.zig");
 const InstallError = record_mod.InstallError;
 const recordKeg = record_mod.recordKeg;
 const deleteKeg = record_mod.deleteKeg;
@@ -67,6 +62,9 @@ const recordDeps = record_mod.recordDeps;
 const ensureDirs = record_mod.ensureDirs;
 const localErrorIsAnnounced = record_mod.localErrorIsAnnounced;
 
+// Internal aliases for names the orchestrator body uses. Names not in
+// this block are reached via their submodule (`args_mod.X`, etc.) or
+// only consumed by tests through `lib.install_<sub>.X`.
 /// Wipe `<prefix>/Cellar/<name>/<version>` so a `--force` reinstall can
 /// re-materialize on top of it. No-op when the dir is missing or the
 /// path overflows the buffer; failures are best-effort because the
@@ -618,6 +616,7 @@ fn executeWithOpts(
                 .db = &db,
                 .store = &store,
                 .cache = &formula_cache,
+                .worker_backing = std.heap.smp_allocator,
             }, pkg_name, formula_json, force, &all_jobs) catch |e| {
                 output.err("Failed to resolve {s}: {s}", .{ pkg_name, @errorName(e) });
                 continue;
@@ -775,6 +774,7 @@ fn executeWithOpts(
             .store = &store,
             .cache = &formula_cache,
             .results = mats,
+            .worker_backing = std.heap.smp_allocator,
         };
 
         const pool_threads = allocator.alloc(std.Thread, worker_count) catch

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -3,24 +3,23 @@
 //! worker pools used by `collectFormulaJobs` and the execute flow.
 
 const std = @import("std");
+
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
-const sqlite = @import("../../db/sqlite.zig");
-const formula_mod = @import("../../core/formula.zig");
 const bottle_mod = @import("../../core/bottle.zig");
-const store_mod = @import("../../core/store.zig");
 const cellar_mod = @import("../../core/cellar.zig");
 const deps_mod = @import("../../core/deps.zig");
+const formula_mod = @import("../../core/formula.zig");
+const signals = @import("../../core/signals.zig");
+const store_mod = @import("../../core/store.zig");
+const sqlite = @import("../../db/sqlite.zig");
+const atomic = @import("../../fs/atomic.zig");
+const api_mod = @import("../../net/api.zig");
 const client_mod = @import("../../net/client.zig");
 const ghcr_mod = @import("../../net/ghcr.zig");
-const api_mod = @import("../../net/api.zig");
-const atomic = @import("../../fs/atomic.zig");
 const output = @import("../../ui/output.zig");
 const progress_mod = @import("../../ui/progress.zig");
-
-const signals = @import("../../core/signals.zig");
 const ghcr_url = @import("ghcr_url.zig");
 const record = @import("record.zig");
-
 const InstallError = record.InstallError;
 
 /// Named-field bundle for `collectFormulaJobs` so callers stop threading
@@ -35,6 +34,10 @@ pub const InstallJobDeps = struct {
     store: *store_mod.Store,
     /// Shared parsed-formula cache for the whole install run.
     cache: *deps_mod.FormulaCache,
+    /// Per-worker arena backing for the dep-fetch pool. Caller-supplied
+    /// so tests run workers under `testing.allocator` for leak coverage;
+    /// production keeps a thread-safe heap (typically `smp_allocator`).
+    worker_backing: std.mem.Allocator,
 };
 
 /// A bottle download job for parallel processing.
@@ -106,9 +109,9 @@ pub fn isDeterministicDownloadError(err: bottle_mod.BottleError) bool {
 }
 
 /// Per-dep worker context for parallel formula fetching. Owns its own
-/// `ArenaAllocator` backed by `page_allocator` so workers never touch
-/// a shared bump-pointer and the resolve path stays off the caller's
-/// allocator on a cross-thread boundary.
+/// `ArenaAllocator` backed by `InstallJobDeps.worker_backing` so workers
+/// never touch a shared bump-pointer and the resolve path stays off the
+/// caller's allocator on a cross-thread boundary.
 ///
 /// Why the pool on the HTTP side: creating a fresh `HttpClient` per
 /// worker paid a full TLS context + cert store setup per dep. For
@@ -269,8 +272,8 @@ pub fn collectFormulaJobs(
     // borrows a client from the shared `http_pool` for the duration
     // of its request so TLS contexts are reused across deps.
     //
-    // Allocator strategy (S7): each worker owns a `FetchFormulaCtx`
-    // with its own `ArenaAllocator` on `page_allocator` — no shared
+    // Allocator strategy: each worker owns a `FetchFormulaCtx` with its
+    // own `ArenaAllocator` over `ctx.worker_backing` — no shared
     // bump-pointer across threads. JSON bodies live in the worker's
     // arena until after `join`, then get duped into the caller's
     // `allocator` so they outlive the per-worker deinit.
@@ -287,7 +290,7 @@ pub fn collectFormulaJobs(
         for (ctxs, 0..) |*c, i| {
             c.* = .{
                 .io = ctx.io,
-                .arena = std.heap.ArenaAllocator.init(std.heap.page_allocator),
+                .arena = std.heap.ArenaAllocator.init(ctx.worker_backing),
                 .pool = http_pool,
                 .cache_dir = api.cache_dir,
                 .dep_name = deps[i].name,
@@ -666,6 +669,10 @@ pub const InstallPool = struct {
     store: *store_mod.Store,
     cache: *deps_mod.FormulaCache,
     results: []MaterializeResult,
+    /// Per-job arena backing for `installOneJob`. Caller-supplied so
+    /// tests can drive the pool under `testing.allocator`; production
+    /// keeps a thread-safe heap (typically `smp_allocator`).
+    worker_backing: std.mem.Allocator,
 };
 
 /// Thread entry-point for the install pool. Drains `pool.jobs` via the
@@ -705,7 +712,7 @@ fn installOneJob(pool: *InstallPool, job: *DownloadJob, result: *MaterializeResu
     // Short-lived arena: keg.path is duped out of `materializeWithCellar`
     // using this allocator, so we copy it into the result's inline
     // buffer before the arena drops.
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    var arena = std.heap.ArenaAllocator.init(pool.worker_backing);
     defer arena.deinit();
 
     // `cellar_diag` captures the specific `CellarError` variant when
@@ -975,4 +982,27 @@ test "installKegFromBottle returns NoBottle before reaching ghcr/store when no p
             "/tmp/malt_iknfb_test",
         ),
     );
+}
+
+test "FetchFormulaCtx: arena backed by testing.allocator runs leak-clean across the dupe-then-deinit shape" {
+    // Pin the worker arena's KB-scale alloc + dupe + deinit shape so a
+    // future regression where the backing reverts to `page_allocator`
+    // immediately loses `testing.allocator`'s leak detection.
+    var ctx_value: FetchFormulaCtx = .{
+        .io = std.Options.debug_io,
+        .arena = std.heap.ArenaAllocator.init(std.testing.allocator),
+        .pool = undefined,
+        .cache_dir = "",
+        .dep_name = "",
+    };
+    defer ctx_value.arena.deinit();
+
+    const a = ctx_value.arena.allocator();
+    // Mirror the worker's real allocation mix: a name dupe + KB-shaped
+    // body buffer + a result string built via `allocPrint`.
+    _ = try a.dupe(u8, "wget");
+    _ = try a.alloc(u8, 4096);
+    const result = try std.fmt.allocPrint(a, "fetched-{s}", .{"wget"});
+    ctx_value.result = result;
+    try std.testing.expectEqualStrings("fetched-wget", ctx_value.result.?);
 }

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -5,30 +5,30 @@
 //! install protocol. Never modifies the Homebrew installation.
 
 const std = @import("std");
+
 const AppCtx = @import("../app_ctx.zig").AppCtx;
-const sqlite = @import("../db/sqlite.zig");
-const schema = @import("../db/schema.zig");
-const lock_mod = @import("../db/lock.zig");
+const linker_mod = @import("../core/linker.zig");
 const signals = @import("../core/signals.zig");
 const store_mod = @import("../core/store.zig");
-const linker_mod = @import("../core/linker.zig");
+const lock_mod = @import("../db/lock.zig");
+const schema = @import("../db/schema.zig");
+const sqlite = @import("../db/sqlite.zig");
+const atomic = @import("../fs/atomic.zig");
+const codesign = @import("../macho/codesign.zig");
+const api_mod = @import("../net/api.zig");
 const client_mod = @import("../net/client.zig");
 const ghcr_mod = @import("../net/ghcr.zig");
-const api_mod = @import("../net/api.zig");
-const atomic = @import("../fs/atomic.zig");
 const color = @import("../ui/color.zig");
 const output = @import("../ui/output.zig");
 const progress_mod = @import("../ui/progress.zig");
-const codesign = @import("../macho/codesign.zig");
 const help = @import("help.zig");
 const keg_mod = @import("migrate/keg.zig");
-const manifest_mod = @import("migrate/manifest.zig");
-const parallel_mod = @import("migrate/parallel.zig");
-const post_install_queue_mod = @import("migrate/post_install_queue.zig");
-
 const KegResult = keg_mod.KegResult;
 const MigrateDeps = keg_mod.MigrateDeps;
 const migrateKeg = keg_mod.migrateKeg;
+const manifest_mod = @import("migrate/manifest.zig");
+const parallel_mod = @import("migrate/parallel.zig");
+const post_install_queue_mod = @import("migrate/post_install_queue.zig");
 
 /// Test seam — pins dispatch decisions without relying on observable
 /// side-effects. Reset on every `execute` entry.
@@ -377,6 +377,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             .manifest_path = manifest_path,
             .manifest_allocator = allocator,
             .post_install_queue = &post_install_queue,
+            .worker_backing = std.heap.smp_allocator,
             .bar_for_keg = bar_for_keg,
         };
         try parallel_mod.run(allocator, &pool, worker_count);

--- a/src/cli/migrate/parallel.zig
+++ b/src/cli/migrate/parallel.zig
@@ -3,16 +3,17 @@
 //! a shared mutex so transactions stay atomic across threads.
 
 const std = @import("std");
+
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
-const sqlite = @import("../../db/sqlite.zig");
-const store_mod = @import("../../core/store.zig");
 const linker_mod = @import("../../core/linker.zig");
+const signals = @import("../../core/signals.zig");
+const store_mod = @import("../../core/store.zig");
+const sqlite = @import("../../db/sqlite.zig");
+const api_mod = @import("../../net/api.zig");
 const client_mod = @import("../../net/client.zig");
 const ghcr_mod = @import("../../net/ghcr.zig");
-const api_mod = @import("../../net/api.zig");
 const output = @import("../../ui/output.zig");
 const progress_mod = @import("../../ui/progress.zig");
-const signals = @import("../../core/signals.zig");
 const keg_mod = @import("keg.zig");
 const manifest_mod = @import("manifest.zig");
 const post_install_queue_mod = @import("post_install_queue.zig");
@@ -79,6 +80,11 @@ pub const Pool = struct {
 
     post_install_queue: *post_install_queue_mod.Queue,
 
+    /// Per-iteration arena backing for the worker. Caller-supplied so
+    /// tests can drive the pool under `testing.allocator`; production
+    /// keeps a thread-safe heap (typically `smp_allocator`).
+    worker_backing: std.mem.Allocator,
+
     /// Per-keg bar pointer. Length matches `keg_names`; an entry is null
     /// when the orchestrator pre-filtered that keg (already installed
     /// per manifest+DB at run start) and didn't reserve a multi-progress
@@ -124,7 +130,7 @@ fn worker(pool: *Pool) void {
             continue;
         }
 
-        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        var arena = std.heap.ArenaAllocator.init(pool.worker_backing);
         defer arena.deinit();
         const a = arena.allocator();
 
@@ -262,6 +268,7 @@ test "worker interrupt branch routes untouched kegs to .cancelled" {
         .manifest_path = "",
         .manifest_allocator = std.testing.allocator,
         .post_install_queue = undefined,
+        .worker_backing = std.testing.allocator,
     };
     try run(std.testing.allocator, &pool, 2);
 

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -419,10 +419,11 @@ fn runPool(
         for (ctxs) |*c| c.arena.deinit();
         allocator.free(ctxs);
     }
+    // Thread-safe heap for per-row worker arenas.
     for (ctxs, 0..) |*c, i| c.* = .{
         .io = ctx.io,
         .environ = ctx.environ,
-        .arena = std.heap.ArenaAllocator.init(std.heap.page_allocator),
+        .arena = std.heap.ArenaAllocator.init(std.heap.smp_allocator),
         .pool = &http_pool,
         .cache_dir = cache_dir,
         .row = kegs[i],
@@ -459,6 +460,27 @@ fn runPool(
     for (ctxs) |c| {
         if (c.err) |e| return e;
     }
+}
+
+test "WorkerCtx: per-row arena accepts testing.allocator backing without leaking" {
+    // Pin the per-row dupe + KB-scale alloc + deinit shape. Production
+    // backs the same arena with `smp_allocator`; the inline test
+    // guarantees `testing.allocator` still works so future leak coverage
+    // can land here without re-plumbing.
+    var wctx: WorkerCtx = .{
+        .io = std.Options.debug_io,
+        .environ = std.process.Environ.empty,
+        .arena = std.heap.ArenaAllocator.init(std.testing.allocator),
+        .pool = undefined,
+        .cache_dir = "",
+        .row = .{ .name = "", .version = "" },
+        .kind = .formula,
+    };
+    defer wctx.arena.deinit();
+
+    const a = wctx.arena.allocator();
+    _ = try a.dupe(u8, "wget");
+    _ = try a.alloc(u8, 1024);
 }
 
 test "outdatedWorkerCount caps at the default for large N" {

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -2,13 +2,16 @@
 //! Search formulas and casks.
 
 const std = @import("std");
+const testing = std.testing;
+
 const AppCtx = @import("../app_ctx.zig").AppCtx;
+const schema = @import("../db/schema.zig");
+const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
-const output = @import("../ui/output.zig");
-const color = @import("../ui/color.zig");
 const api_mod = @import("../net/api.zig");
 const client_mod = @import("../net/client.zig");
-const sqlite = @import("../db/sqlite.zig");
+const color = @import("../ui/color.zig");
+const output = @import("../ui/output.zig");
 const help = @import("help.zig");
 
 /// Where a `mt search` query should look. Default is local-first with a
@@ -107,9 +110,6 @@ pub fn searchLocalKind(
 
     return out.toOwnedSlice(allocator);
 }
-
-const testing = std.testing;
-const schema = @import("../db/schema.zig");
 
 test "parseScope: no scope flags returns default" {
     try testing.expectEqual(Scope.default, parseScope(&.{"wget"}));
@@ -392,11 +392,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     const json_mode = output.isJson();
 
-    // One arena per kind: the worker-thread API path keeps each `KindResults`
-    // bump-pointer disjoint, and local matches join later in the same arena.
-    var f_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    // One arena per kind: the worker-thread API path keeps each
+    // `KindResults` bump-pointer disjoint, and local matches join later
+    // in the same arena. `smp_allocator` stays thread-safe across
+    // the cask/formula worker.
+    var f_arena = std.heap.ArenaAllocator.init(std.heap.smp_allocator);
     defer f_arena.deinit();
-    var c_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    var c_arena = std.heap.ArenaAllocator.init(std.heap.smp_allocator);
     defer c_arena.deinit();
     const f_alloc = f_arena.allocator();
     const c_alloc = c_arena.allocator();

--- a/tests/install_parse_cache_test.zig
+++ b/tests/install_parse_cache_test.zig
@@ -9,12 +9,13 @@
 
 const std = @import("std");
 const testing = std.testing;
+
 const malt = @import("malt");
-const test_io = @import("test_io");
 const install_download = malt.install_download;
 const deps_mod = malt.deps;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
+const test_io = @import("test_io");
 
 const TempDb = struct {
     dir: []const u8,
@@ -149,6 +150,7 @@ test "collectFormulaJobs parses each formula exactly once via shared cache" {
             .db = &tdb.db,
             .store = &store_inst,
             .cache = &formula_cache,
+            .worker_backing = alloc,
         },
         "root",
         root_json,
@@ -225,6 +227,7 @@ test "FormulaCache holds at most one entry per unique dep across the run" {
             .db = &tdb.db,
             .store = &store_inst,
             .cache = &formula_cache,
+            .worker_backing = alloc,
         },
         "root",
         root_json,
@@ -399,6 +402,7 @@ test "shared deps across multi-package install collapse to one parse" {
         .db = &tdb.db,
         .store = &store_inst,
         .cache = &formula_cache,
+        .worker_backing = alloc,
     };
 
     try install_download.collectFormulaJobs(ctx, "alpha", alpha_json, false, &jobs);

--- a/tests/install_pool_test.zig
+++ b/tests/install_pool_test.zig
@@ -8,12 +8,13 @@
 //! pipeline runs the same store + cellar code paths production hits.
 
 const std = @import("std");
-const malt = @import("malt");
-const test_io = @import("test_io");
 const testing = std.testing;
+
+const malt = @import("malt");
 const formula_mod = malt.formula;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
+const test_io = @import("test_io");
 
 fn setupPrefix(suffix: []const u8) ![:0]u8 {
     const path = try std.fmt.allocPrintSentinel(
@@ -156,6 +157,7 @@ test "installPoolWorker drains every job against a warm store and stamps each re
         .store = &store,
         .cache = &cache,
         .results = &results,
+        .worker_backing = testing.allocator,
     };
 
     malt.install_download.installPoolWorker(&pool);
@@ -252,6 +254,7 @@ test "installPoolWorker drains a 3-job pool concurrently across two workers" {
         .store = &store,
         .cache = &cache,
         .results = &results,
+        .worker_backing = testing.allocator,
     };
 
     const t1 = try std.Thread.spawn(.{}, malt.install_download.installPoolWorker, .{&pool});
@@ -346,6 +349,7 @@ test "installPoolWorker propagates the specific CellarError variant into result.
         .store = &store,
         .cache = &cache,
         .results = &results,
+        .worker_backing = testing.allocator,
     };
 
     malt.install_download.installPoolWorker(&pool);
@@ -419,6 +423,7 @@ test "installPoolWorker bails between jobs when Ctrl-C fires" {
         .store = &store,
         .cache = &cache,
         .results = &results,
+        .worker_backing = testing.allocator,
     };
 
     malt.signals.setInterruptedForTest(true);
@@ -473,6 +478,7 @@ test "installPoolWorker leaves the result untouched and marks job not-succeeded 
         .store = &store,
         .cache = &cache,
         .results = &results,
+        .worker_backing = testing.allocator,
     };
 
     malt.install_download.installPoolWorker(&pool);

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -7,8 +7,8 @@
 
 const std = @import("std");
 const testing = std.testing;
+
 const malt = @import("malt");
-const test_io = @import("test_io");
 const install = malt.install;
 const install_args = malt.install_args;
 const install_download = malt.install_download;
@@ -17,6 +17,7 @@ const install_rb_parse = malt.install_rb_parse;
 const install_record = malt.install_record;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
+const test_io = @import("test_io");
 
 /// Fixture formula with `post_install_defined: true` and no dependencies.
 /// Empty deps ensure the parallel-fetch phase is skipped so the test can
@@ -107,7 +108,7 @@ test "collectFormulaJobs queues a formula with a post_install hook" {
     defer cache.deinit();
 
     try install_download.collectFormulaJobs(
-        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache },
+        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache, .worker_backing = alloc },
         "needs-ruby",
         json,
         false,
@@ -349,7 +350,7 @@ test "collectFormulaJobs queues the main formula when nothing is installed" {
     defer cache.deinit();
 
     try install_download.collectFormulaJobs(
-        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache },
+        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache, .worker_backing = alloc },
         "hello",
         json,
         false,
@@ -390,7 +391,7 @@ test "collectFormulaJobs no-ops when the formula is already installed" {
     defer cache.deinit();
 
     try install_download.collectFormulaJobs(
-        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache },
+        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache, .worker_backing = alloc },
         "hello",
         json,
         false, // force=false
@@ -476,7 +477,7 @@ test "collectFormulaJobs queues a dep and its parent from a seeded cache" {
     defer cache.deinit();
 
     try install_download.collectFormulaJobs(
-        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst, .cache = &cache },
+        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst, .cache = &cache, .worker_backing = alloc },
         "alpha",
         root_json,
         false,
@@ -525,7 +526,7 @@ test "collectFormulaJobs deduplicates deps already queued by a prior call" {
     var cache = malt.deps.FormulaCache.init(alloc);
     defer cache.deinit();
 
-    const deps_ctx: install_download.InstallJobDeps = .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst, .cache = &cache };
+    const deps_ctx: install_download.InstallJobDeps = .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst, .cache = &cache, .worker_backing = alloc };
     try install_download.collectFormulaJobs(deps_ctx, "alpha", root_a, false, &jobs);
     try install_download.collectFormulaJobs(deps_ctx, "omega", root_b, false, &jobs);
 
@@ -558,7 +559,7 @@ test "collectFormulaJobs surfaces FormulaNotFound for unparseable JSON" {
     try testing.expectError(
         install_record.InstallError.FormulaNotFound,
         install_download.collectFormulaJobs(
-            .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache },
+            .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache, .worker_backing = alloc },
             "broken",
             "not-a-json",
             false,
@@ -596,7 +597,7 @@ test "collectFormulaJobs with post_install leaves the DB untouched" {
     defer cache.deinit();
 
     _ = install_download.collectFormulaJobs(
-        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache },
+        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache, .worker_backing = alloc },
         "needs-ruby",
         json,
         false,
@@ -659,7 +660,7 @@ test "collectFormulaJobs carries the _<revision> suffix in version_str" {
     defer cache.deinit();
 
     try install_download.collectFormulaJobs(
-        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache },
+        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache, .worker_backing = alloc },
         "rev",
         json,
         false,
@@ -699,7 +700,7 @@ test "collectFormulaJobs leaves plain-version formulas unchanged" {
     defer cache.deinit();
 
     try install_download.collectFormulaJobs(
-        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache },
+        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache, .worker_backing = alloc },
         "needs-ruby",
         json,
         false,
@@ -814,7 +815,7 @@ test "collectFormulaJobs leaves no parsed-tree leaks under testing.allocator (>=
     defer cache.deinit();
 
     try install_download.collectFormulaJobs(
-        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst, .cache = &cache },
+        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http_pool, .db = &tdb.db, .store = &store_inst, .cache = &cache, .worker_backing = alloc },
         "root",
         root_json,
         false,

--- a/tests/worker_arena_test.zig
+++ b/tests/worker_arena_test.zig
@@ -1,8 +1,11 @@
-//! malt — worker-local arena stress test (S7)
+//! malt — worker-local arena stress test
 //!
-//! Validates the invariant S7 introduced: each parallel worker in the
-//! install / search paths owns its own `ArenaAllocator` on
-//! `page_allocator`, never sharing a bump-pointer across threads.
+//! Validates the cross-thread invariant: each parallel worker in the
+//! install / search paths owns its own `ArenaAllocator` and never shares
+//! a bump-pointer across threads. Workers now take their arena backing
+//! from the caller (production uses `smp_allocator`); the stress here
+//! drives the same shape under `testing.allocator` so leak coverage
+//! extends across the worker boundary.
 //!
 //! The test does not exercise `install.zig` / `search.zig` directly —
 //! those pull in the full HTTP + DB stack. Instead it mirrors the
@@ -54,7 +57,7 @@ test "each parallel worker has its own arena; results survive per-worker deinit"
     }
     for (ctxs, 0..) |*c, i| {
         c.* = .{
-            .arena = std.heap.ArenaAllocator.init(std.heap.page_allocator),
+            .arena = std.heap.ArenaAllocator.init(testing.allocator),
             .seed = @as(u64, i) + 1,
         };
     }
@@ -98,7 +101,7 @@ test "spawn-failure fallback path still runs the worker inline" {
     // context's `run` must be callable on the caller thread and
     // produce the same result shape as the spawned variant.
     var ctx: Ctx = .{
-        .arena = std.heap.ArenaAllocator.init(std.heap.page_allocator),
+        .arena = std.heap.ArenaAllocator.init(testing.allocator),
         .seed = 42,
     };
     defer ctx.arena.deinit();


### PR DESCRIPTION
## Description

Threads a caller-chosen allocator into the parallel worker arenas across `install`, `migrate --parallel`, `outdated`, and `search`. Production picks `smp_allocator` (thread-safe, skips the 4 KiB rounding `page_allocator` paid for every KB-scale formula JSON or temp-path string); tests can now drive the same workers under `testing.allocator`, so leak detection finally reaches across the worker boundary. No worker invariant changed - each worker still owns its arena.

## Related Issue

- None

## Notes for Reviewers

- None