### PR TITLE
refactor(core/bundle): type dispatcher errors

### DIFF
--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -21,34 +21,46 @@ const services_cmd = @import("services.zig");
 // install/tap/services primitives. The opaque `ctx` slot carries the
 // process-wide AppCtx so the dispatch helpers can thread io / environ
 // through to install/tap/services without re-deriving them.
-fn cliInstallFormula(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
-    const app_ctx = appCtxFromOpaque(ctx);
-    return install_cmd.installAll(app_ctx, allocator, &.{name}, .{});
+//
+// CLI primitives already print rich per-failure diagnostics before
+// returning, so the wrapper narrows everything except OOM to
+// DispatchFailed — the runner records the kind+name and the dispatcher
+// type stays closed.
+fn narrowDispatch(e: anyerror) runner_mod.DispatchError {
+    return switch (e) {
+        error.OutOfMemory => runner_mod.DispatchError.OutOfMemory,
+        else => runner_mod.DispatchError.DispatchFailed,
+    };
 }
 
-fn cliInstallCask(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+fn cliInstallFormula(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner_mod.DispatchError!void {
     const app_ctx = appCtxFromOpaque(ctx);
-    return install_cmd.installAll(app_ctx, allocator, &.{name}, .{ .cask = true });
+    install_cmd.installAll(app_ctx, allocator, &.{name}, .{}) catch |e| return narrowDispatch(e);
 }
 
-fn cliTapAdd(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+fn cliInstallCask(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner_mod.DispatchError!void {
     const app_ctx = appCtxFromOpaque(ctx);
-    return tap_cmd.tapAdd(app_ctx, allocator, name);
+    install_cmd.installAll(app_ctx, allocator, &.{name}, .{ .cask = true }) catch |e| return narrowDispatch(e);
 }
 
-fn cliServiceStart(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+fn cliTapAdd(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner_mod.DispatchError!void {
     const app_ctx = appCtxFromOpaque(ctx);
-    return services_cmd.servicesStart(app_ctx, allocator, name);
+    tap_cmd.tapAdd(app_ctx, allocator, name) catch |e| return narrowDispatch(e);
 }
 
-fn cliUninstallFormula(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+fn cliServiceStart(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner_mod.DispatchError!void {
     const app_ctx = appCtxFromOpaque(ctx);
-    return uninstall_cmd.execute(app_ctx, allocator, &.{name});
+    services_cmd.servicesStart(app_ctx, allocator, name) catch |e| return narrowDispatch(e);
 }
 
-fn cliUninstallCask(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+fn cliUninstallFormula(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) cleanup_mod.DispatchError!void {
     const app_ctx = appCtxFromOpaque(ctx);
-    return uninstall_cmd.execute(app_ctx, allocator, &.{ "--cask", name });
+    uninstall_cmd.execute(app_ctx, allocator, &.{name}) catch |e| return narrowDispatch(e);
+}
+
+fn cliUninstallCask(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) cleanup_mod.DispatchError!void {
+    const app_ctx = appCtxFromOpaque(ctx);
+    uninstall_cmd.execute(app_ctx, allocator, &.{ "--cask", name }) catch |e| return narrowDispatch(e);
 }
 
 /// Cast the dispatcher's opaque `ctx` slot back to a borrowed AppCtx pointer.

--- a/src/core/bundle/cleanup.zig
+++ b/src/core/bundle/cleanup.zig
@@ -7,12 +7,17 @@
 const std = @import("std");
 const manifest_mod = @import("manifest.zig");
 const sqlite = @import("../../db/sqlite.zig");
+const runner_mod = @import("runner.zig");
 
 pub const CleanupError = error{
     OutOfMemory,
     NoDispatcher,
     DatabaseError,
 };
+
+/// Shared with the install dispatcher in `runner.zig`: one closed error
+/// set means `@errorName` on `MemberError.err` is bounded at comptime.
+pub const DispatchError = runner_mod.DispatchError;
 
 pub const MemberKind = enum { formula, cask };
 
@@ -24,7 +29,7 @@ pub const MemberPreview = struct {
 pub const MemberError = struct {
     kind: MemberKind,
     name: []const u8,
-    err: anyerror,
+    err: DispatchError,
 };
 
 /// Layering seam: the CLI wires `cli/uninstall` behind this. Keeping the
@@ -32,8 +37,8 @@ pub const MemberError = struct {
 /// imports, mirroring the existing bundle runner.
 pub const Dispatcher = struct {
     ctx: ?*anyopaque = null,
-    uninstallFormula: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void,
-    uninstallCask: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void,
+    uninstallFormula: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) DispatchError!void,
+    uninstallCask: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) DispatchError!void,
 };
 
 pub const Options = struct {
@@ -459,14 +464,14 @@ const TestDispatcher = struct {
         return @ptrCast(@alignCast(ctx.?));
     }
 
-    fn uninstallFormulaFn(ctx: ?*anyopaque, _: std.mem.Allocator, name: []const u8) anyerror!void {
+    fn uninstallFormulaFn(ctx: ?*anyopaque, _: std.mem.Allocator, name: []const u8) DispatchError!void {
         const self = unwrap(ctx);
-        try self.formulas.append(self.allocator, name);
+        self.formulas.append(self.allocator, name) catch return DispatchError.OutOfMemory;
     }
 
-    fn uninstallCaskFn(ctx: ?*anyopaque, _: std.mem.Allocator, name: []const u8) anyerror!void {
+    fn uninstallCaskFn(ctx: ?*anyopaque, _: std.mem.Allocator, name: []const u8) DispatchError!void {
         const self = unwrap(ctx);
-        try self.casks.append(self.allocator, name);
+        self.casks.append(self.allocator, name) catch return DispatchError.OutOfMemory;
     }
 };
 
@@ -542,8 +547,8 @@ test "run records per-member failures and keeps going" {
     defer plan.deinit();
 
     const Failer = struct {
-        fn alwaysFails(_: ?*anyopaque, _: std.mem.Allocator, _: []const u8) anyerror!void {
-            return error.MemberFailed;
+        fn alwaysFails(_: ?*anyopaque, _: std.mem.Allocator, _: []const u8) DispatchError!void {
+            return DispatchError.MemberFailed;
         }
     };
     const dispatcher = Dispatcher{
@@ -559,6 +564,12 @@ test "run records per-member failures and keeps going" {
     try testing.expectEqualStrings("jq", report.failures[0].name);
     try testing.expectEqual(MemberKind.cask, report.failures[2].kind);
     try testing.expectEqualStrings("ghostty", report.failures[2].name);
+    // Pins MemberError.err to the closed DispatchError set; an `anyerror`
+    // regression would fail the explicit coercion below at comptime.
+    for (report.failures) |f| {
+        const expected: DispatchError = DispatchError.MemberFailed;
+        try testing.expectEqual(expected, f.err);
+    }
 }
 
 test "orderForRemoval reorders formulas so dependents land before their deps" {

--- a/src/core/bundle/runner.zig
+++ b/src/core/bundle/runner.zig
@@ -34,6 +34,23 @@ pub const RunnerError = error{
     NoDispatcher,
 };
 
+/// Closed error set every dispatcher exit must land on. Kept in
+/// `core/bundle/runner.zig` so neither runner nor `cleanup.zig` has to
+/// depend on `cli/*` to spell its members' failure modes; the CLI layer
+/// narrows underlying CLI errors at the boundary (see `cli/bundle.zig`),
+/// keeping the type-system check exhaustive without reverse-layering.
+pub const DispatchError = error{
+    /// In-process runner needs a dispatcher (and none was wired).
+    NoDispatcher,
+    /// Subprocess dispatch (`malt_bin`) exited non-zero.
+    MemberFailed,
+    /// Boundary narrowing tag: the underlying CLI primitive already
+    /// surfaced a user-facing diagnostic; the runner records the failure
+    /// without re-rendering the cause.
+    DispatchFailed,
+    OutOfMemory,
+};
+
 pub fn describeError(err: RunnerError) []const u8 {
     return switch (err) {
         RunnerError.DatabaseError => "database error during bundle install",
@@ -52,7 +69,7 @@ pub const MemberKind = enum { tap, formula, cask, service_start };
 pub const MemberError = struct {
     kind: MemberKind,
     name: []const u8,
-    err: anyerror,
+    err: DispatchError,
 };
 
 /// Entry in the dry-run preview list — what the CLI would render as
@@ -88,10 +105,10 @@ pub const Report = struct {
 /// interface is what lets `core/bundle/runner.zig` avoid a `cli/*` import.
 pub const Dispatcher = struct {
     ctx: ?*anyopaque = null,
-    installFormula: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void,
-    installCask: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void,
-    tapAdd: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void,
-    serviceStart: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void,
+    installFormula: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) DispatchError!void,
+    installCask: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) DispatchError!void,
+    tapAdd: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) DispatchError!void,
+    serviceStart: *const fn (ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) DispatchError!void,
 };
 
 pub const Options = struct {
@@ -169,6 +186,7 @@ pub fn run(
     // 5. Record bundle and members in DB (even on partial failure). Skipped
     //    in dry-run so the preview path stays read-only.
     if (!opts.dry_run) recordBundle(io, db, manifest) catch |e| {
+        // recordBundle's inferred set spans sqlite + clock; keep @errorName.
         db_record_error = @errorName(e);
     };
 
@@ -234,12 +252,12 @@ fn recordMember(
     };
 }
 
-fn callMember(io: std.Io, allocator: std.mem.Allocator, call: MemberCall, opts: Options) !void {
+fn callMember(io: std.Io, allocator: std.mem.Allocator, call: MemberCall, opts: Options) DispatchError!void {
     // Test escape hatch: when malt_bin is set, fall back to subprocess so
     // tests can substitute /usr/bin/false to assert exit-code propagation.
     if (opts.malt_bin) |bin| return runSubprocess(io, allocator, bin, call);
 
-    const d = opts.dispatcher orelse return RunnerError.NoDispatcher;
+    const d = opts.dispatcher orelse return DispatchError.NoDispatcher;
     switch (call) {
         .tap => |n| try d.tapAdd(d.ctx, allocator, n),
         .formula => |n| try d.installFormula(d.ctx, allocator, n),
@@ -248,37 +266,25 @@ fn callMember(io: std.Io, allocator: std.mem.Allocator, call: MemberCall, opts: 
     }
 }
 
-fn runSubprocess(io: std.Io, allocator: std.mem.Allocator, bin: []const u8, call: MemberCall) !void {
-    var argv: std.ArrayList([]const u8) = .empty;
-    defer argv.deinit(allocator);
-    try argv.append(allocator, bin);
-    switch (call) {
-        .tap => |n| {
-            try argv.append(allocator, "tap");
-            try argv.append(allocator, n);
-        },
-        .formula => |n| {
-            try argv.append(allocator, "install");
-            try argv.append(allocator, n);
-        },
-        .cask => |n| {
-            try argv.append(allocator, "install");
-            try argv.append(allocator, "--cask");
-            try argv.append(allocator, n);
-        },
-        .service_start => |n| {
-            try argv.append(allocator, "services");
-            try argv.append(allocator, "start");
-            try argv.append(allocator, n);
-        },
-    }
+fn runSubprocess(io: std.Io, allocator: std.mem.Allocator, bin: []const u8, call: MemberCall) DispatchError!void {
+    const argv = buildSubprocessArgv(allocator, bin, call) catch return DispatchError.OutOfMemory;
+    defer allocator.free(argv);
 
-    var child = std.process.spawn(io, .{ .argv = argv.items }) catch return error.MemberFailed;
-    const term = child.wait(io) catch return error.MemberFailed;
+    var child = std.process.spawn(io, .{ .argv = argv }) catch return DispatchError.MemberFailed;
+    const term = child.wait(io) catch return DispatchError.MemberFailed;
     switch (term) {
-        .exited => |code| if (code != 0) return error.MemberFailed,
-        else => return error.MemberFailed,
+        .exited => |code| if (code != 0) return DispatchError.MemberFailed,
+        else => return DispatchError.MemberFailed,
     }
+}
+
+fn buildSubprocessArgv(allocator: std.mem.Allocator, bin: []const u8, call: MemberCall) ![][]const u8 {
+    return switch (call) {
+        .tap => |n| try allocator.dupe([]const u8, &.{ bin, "tap", n }),
+        .formula => |n| try allocator.dupe([]const u8, &.{ bin, "install", n }),
+        .cask => |n| try allocator.dupe([]const u8, &.{ bin, "install", "--cask", n }),
+        .service_start => |n| try allocator.dupe([]const u8, &.{ bin, "services", "start", n }),
+    };
 }
 
 fn recordBundle(

--- a/tests/bundle_test.zig
+++ b/tests/bundle_test.zig
@@ -90,6 +90,11 @@ test "non-dry runner with mocked malt_bin records bundle even on member failure"
     defer report.deinit();
     try testing.expect(report.hasFailure());
     try testing.expectEqual(@as(usize, 4), report.failures.len);
+    // Subprocess exit-code propagation lands as the typed MemberFailed tag.
+    for (report.failures) |f| {
+        const expected: runner.DispatchError = runner.DispatchError.MemberFailed;
+        try testing.expectEqual(expected, f.err);
+    }
 
     var stmt = try t.db.prepare("SELECT COUNT(*) FROM bundles WHERE name='devtools';");
     defer stmt.finalize();
@@ -175,21 +180,21 @@ const Calls = struct {
         return @ptrCast(@alignCast(ctx.?));
     }
 
-    fn tapAddFn(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+    fn tapAddFn(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner.DispatchError!void {
         const self = unwrap(ctx);
-        try record(&self.taps, allocator, name);
+        record(&self.taps, allocator, name) catch return runner.DispatchError.OutOfMemory;
     }
-    fn installFormulaFn(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+    fn installFormulaFn(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner.DispatchError!void {
         const self = unwrap(ctx);
-        try record(&self.formulas, allocator, name);
+        record(&self.formulas, allocator, name) catch return runner.DispatchError.OutOfMemory;
     }
-    fn installCaskFn(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+    fn installCaskFn(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner.DispatchError!void {
         const self = unwrap(ctx);
-        try record(&self.casks, allocator, name);
+        record(&self.casks, allocator, name) catch return runner.DispatchError.OutOfMemory;
     }
-    fn serviceStartFn(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) anyerror!void {
+    fn serviceStartFn(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner.DispatchError!void {
         const self = unwrap(ctx);
-        try record(&self.services, allocator, name);
+        record(&self.services, allocator, name) catch return runner.DispatchError.OutOfMemory;
     }
 };
 
@@ -258,8 +263,15 @@ test "runner refuses in-process bundle install with no dispatcher and no malt_bi
     defer report.deinit();
     try testing.expect(report.hasFailure());
     try testing.expectEqual(@as(usize, 4), report.failures.len);
-    // Each member's err is RunnerError.NoDispatcher on this path.
-    for (report.failures) |f| try testing.expectEqual(anyerror.NoDispatcher, f.err);
+    // Each member's err is DispatchError.NoDispatcher. The explicit type
+    // coercion on the literal pins that MemberError.err is the closed
+    // DispatchError set, not anyerror — a regression here surfaces at
+    // comptime before the runtime assertion ever fires.
+    for (report.failures) |f| {
+        const expected: runner.DispatchError = runner.DispatchError.NoDispatcher;
+        try testing.expectEqual(expected, f.err);
+        try testing.expectEqualStrings("NoDispatcher", @errorName(f.err));
+    }
 
     var stmt = try t.db.prepare("SELECT COUNT(*) FROM bundles WHERE name='devtools';");
     defer stmt.finalize();
@@ -267,6 +279,43 @@ test "runner refuses in-process bundle install with no dispatcher and no malt_bi
     // recordBundle still runs even on partial failure, matching the
     // existing `/usr/bin/false` test — this pins that invariant.
     try testing.expectEqual(@as(i64, 1), stmt.columnInt(0));
+}
+
+test "dispatcher returning DispatchFailed lands as a typed MemberError" {
+    // Pins the boundary contract: cli/bundle.zig narrows underlying CLI
+    // errors to DispatchFailed before the runner sees them. A regression
+    // that re-widens to anyerror would fail the comptime coercion below.
+    var t = try TempDb.init("typed_dispatch_failed");
+    defer t.deinit();
+
+    const Failing = struct {
+        fn fail(_: ?*anyopaque, _: std.mem.Allocator, _: []const u8) runner.DispatchError!void {
+            return runner.DispatchError.DispatchFailed;
+        }
+    };
+    const dispatcher = runner.Dispatcher{
+        .installFormula = Failing.fail,
+        .installCask = Failing.fail,
+        .tapAdd = Failing.fail,
+        .serviceStart = Failing.fail,
+    };
+
+    var m = try buildManifest(testing.allocator);
+    defer m.deinit();
+
+    var report = try runner.run(std.Options.debug_io, testing.allocator, &t.db, m, .{
+        .dry_run = false,
+        .prefix = t.dir,
+        .dispatcher = &dispatcher,
+    });
+    defer report.deinit();
+    try testing.expect(report.hasFailure());
+    try testing.expectEqual(@as(usize, 4), report.failures.len);
+    for (report.failures) |f| {
+        const expected: runner.DispatchError = runner.DispatchError.DispatchFailed;
+        try testing.expectEqual(expected, f.err);
+        try testing.expectEqualStrings("DispatchFailed", @errorName(f.err));
+    }
 }
 
 test "round-trip: parse Brewfile fixture, run dry, no panic" {


### PR DESCRIPTION
## Description

Replaces the bundle dispatcher's `anyerror!void` vtable with a closed `DispatchError` set, defined once in `core/bundle/runner.zig` and shared by `cleanup.zig`. The CLI layer narrows underlying primitives at the boundary, so the runner now has a compile-time guarantee that every dispatch exit carries a known tag - without dragging `cli/*` into `core/*`. User-visible failure reporting (kind + name) is unchanged.

## Related Issue

- None

## Notes for Reviewers

- None