### PR TITLE
refactor(core/cask): surface sqlite errors at the boundary

### DIFF
--- a/src/cli/uninstall.zig
+++ b/src/cli/uninstall.zig
@@ -270,8 +270,11 @@ fn uninstallCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []cons
     output.info("Uninstalling cask {s}...", .{token});
 
     var installer = cask_mod.CaskInstaller.init(ctx.io, ctx.environ, allocator, db, prefix);
-    installer.uninstall(token) catch {
-        output.err("Failed to uninstall cask {s}", .{token});
+    installer.uninstall(token) catch |un_err| {
+        output.err(
+            "Failed to uninstall cask {s}: {s} ({s})",
+            .{ token, @errorName(un_err), db.errMsg() },
+        );
         return error.Aborted;
     };
 

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -18,6 +18,10 @@ pub const CaskError = error{
     OutOfMemory,
 };
 
+/// `uninstall` lets the `removeRecord` SQLite failure bubble through so
+/// the CLI caller can log `db.errMsg()` instead of swallowing it.
+pub const UninstallError = CaskError || sqlite.SqliteError;
+
 /// Parsed Homebrew cask. Every `[]const u8` borrows from `parsed`; valid
 /// only until `deinit()`. Callers holding strings past that point must dupe.
 pub const Cask = struct {
@@ -542,26 +546,39 @@ pub const CaskInstaller = struct {
     }
 
     /// Uninstall a cask by token. Looks up app_path from DB, removes app, cleans up.
-    pub fn uninstall(self: *CaskInstaller, token: []const u8) CaskError!void {
-        // Look up from DB
-        var stmt = self.db.prepare(
-            "SELECT app_path FROM casks WHERE token = ?1 LIMIT 1;",
-        ) catch return CaskError.UninstallFailed;
-        defer stmt.finalize();
-        stmt.bindText(1, token) catch return CaskError.UninstallFailed;
+    /// `removeRecord` propagates its SQLite failure so the CLI caller can
+    /// log `db.errMsg()` instead of marking a half-cleaned DB as success.
+    pub fn uninstall(self: *CaskInstaller, token: []const u8) UninstallError!void {
+        // Copy app_path out of SQLite-owned memory and finalize the SELECT
+        // before any later DB op. Otherwise the SELECT's deferred finalize
+        // runs *after* `removeRecord` fails and resets `db.errMsg()` to
+        // "not an error", blanking the message the caller wants to log.
+        var app_path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+        var app_path_len: usize = 0;
+        {
+            var stmt = self.db.prepare(
+                "SELECT app_path FROM casks WHERE token = ?1 LIMIT 1;",
+            ) catch return CaskError.UninstallFailed;
+            defer stmt.finalize();
+            stmt.bindText(1, token) catch return CaskError.UninstallFailed;
 
-        const found = stmt.step() catch return CaskError.UninstallFailed;
-        if (!found) return CaskError.UninstallFailed;
+            const found = stmt.step() catch return CaskError.UninstallFailed;
+            if (!found) return CaskError.UninstallFailed;
 
-        const path_ptr = stmt.columnText(0);
-        if (path_ptr) |p| {
-            // sqlite3_column_text returns a null-terminated UTF-8 string per
-            // the SQLite C API contract, so `sliceTo(.., 0)` is safe here.
-            // There is an inherent TOCTOU window between this read and the
-            // `deleteTreeAbsolute` below — accepted because cask uninstall
-            // is a single-user operation and the bundle is protected by
-            // filesystem permissions.
-            const app_path = std.mem.sliceTo(p, 0);
+            if (stmt.columnText(0)) |p| {
+                // sqlite3_column_text returns a null-terminated UTF-8 string per
+                // the SQLite C API contract. There is an inherent TOCTOU window
+                // between this read and the `deleteTree` below — accepted
+                // because cask uninstall is a single-user operation and the
+                // bundle is protected by filesystem permissions.
+                const slice = std.mem.sliceTo(p, 0);
+                app_path_len = @min(slice.len, app_path_buf.len);
+                @memcpy(app_path_buf[0..app_path_len], slice[0..app_path_len]);
+            }
+        }
+
+        if (app_path_len > 0) {
+            const app_path = app_path_buf[0..app_path_len];
 
             // Check if the app is running (best-effort)
             if (isAppRunning(self.io, app_path)) return CaskError.UninstallFailed;
@@ -594,8 +611,10 @@ pub const CaskInstaller = struct {
             _ = hist_stmt.step() catch false;
         } else |_| {}
 
-        // DB row cleanup; uninstall already did the user-visible work.
-        removeRecord(self.db, token) catch {};
+        // DB row cleanup. User-visible work is done; surfacing the
+        // failure lets the CLI caller log `db.errMsg()` instead of
+        // silently leaving the row behind.
+        try removeRecord(self.db, token);
     }
 
     /// Reinstall a previously-installed cask version from history. Drives
@@ -661,16 +680,25 @@ pub const CaskInstaller = struct {
     }
 
     /// Check installed version vs API version. Returns true if outdated.
-    pub fn isOutdated(self: *CaskInstaller, token: []const u8, latest_version: []const u8) bool {
-        var stmt = self.db.prepare(
+    /// SQLite errors flow up as `SqliteError` so the caller can log
+    /// `db.errMsg()` instead of silently treating a broken row as fresh.
+    pub fn isOutdated(
+        self: *CaskInstaller,
+        token: []const u8,
+        latest_version: []const u8,
+    ) sqlite.SqliteError!bool {
+        var stmt = try self.db.prepare(
             "SELECT version FROM casks WHERE token = ?1 LIMIT 1;",
-        ) catch return false;
+        );
         defer stmt.finalize();
-        stmt.bindText(1, token) catch return false;
+        try stmt.bindText(1, token);
 
-        const found = stmt.step() catch return false;
+        const found = try stmt.step();
         if (!found) return false;
 
+        // SQLite NULL in `version` is structurally impossible (NOT NULL
+        // column); treat the absent pointer as "no installed row" so the
+        // caller's not-outdated default still kicks in for that one case.
         const ver_ptr = stmt.columnText(0) orelse return false;
         const installed = std.mem.sliceTo(ver_ptr, 0);
         return !std.mem.eql(u8, installed, latest_version);

--- a/tests/cask_extra_test.zig
+++ b/tests/cask_extra_test.zig
@@ -47,7 +47,7 @@ test "CaskInstaller.isOutdated returns false for an unknown token" {
     var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
     defer threaded.deinit();
     var installer = cask.CaskInstaller.init(threaded.io(), testEnviron(), testing.allocator, &db, prefix);
-    try testing.expect(!installer.isOutdated("nope-nope", "1.0"));
+    try testing.expect(!try installer.isOutdated("nope-nope", "1.0"));
 }
 
 test "CaskInstaller.install rejects a cask with an unknown artifact URL extension" {
@@ -100,6 +100,54 @@ test "artifact_type_override bypasses URL detection" {
     const result = installer.install(&c);
     // Should fail on download, not on the type gate
     try testing.expectError(cask.CaskError.DownloadFailed, result);
+}
+
+// Locking the connection read-only after the row is staged makes the
+// `removeRecord` DELETE fail at `sqlite3_step`. The previous `catch {}`
+// swallowed the failure into "uninstall succeeded"; the typed error path
+// gives the CLI caller something to log `db.errMsg()` for.
+test "CaskInstaller.uninstall propagates removeRecord SqliteError" {
+    const test_cask_json =
+        \\{"token":"firefox","name":["Firefox"],"version":"123.0","desc":"","homepage":"",
+        \\ "url":"https://example.com/firefox.dmg",
+        \\ "sha256":"00000000000000000000000000000000000000000000000000000000deadbeef",
+        \\ "auto_updates":false,"artifacts":[{"app":["Firefox.app"]}]}
+    ;
+    var c = try cask.parseCask(testing.allocator, test_cask_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    const base = "/tmp/malt_cask_uninstall_readonly_test";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, base);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+
+    const app_path_z = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "{s}/Firefox.app",
+        .{base},
+        0,
+    );
+    defer testing.allocator.free(app_path_z);
+    try test_io.makeDirAbsolute(std.Options.debug_io, app_path_z);
+
+    try cask.recordInstall(&db, &c, app_path_z, null);
+
+    // Writes now fail at step; SELECT keeps working so uninstall reaches
+    // the previously-swallowed `removeRecord` call.
+    try db.exec("PRAGMA query_only=ON;");
+
+    const prefix: [:0]const u8 = "/tmp/mc-uninstall-readonly";
+    test_io.cwd().createDirPath(std.Options.debug_io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    var installer = cask.CaskInstaller.init(threaded.io(), testEnviron(), testing.allocator, &db, prefix);
+
+    try testing.expectError(sqlite.SqliteError.StepFailed, installer.uninstall("firefox"));
 }
 
 test "CaskInstaller.uninstall removes app_path, caskroom, cache, and the DB row" {

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -411,8 +411,26 @@ test "isOutdated detects version mismatch" {
     defer threaded.deinit();
     var installer = cask.CaskInstaller.init(threaded.io(), malt.app_ctx.processEnviron(), std.testing.allocator, &db, prefix);
 
-    try std.testing.expect(installer.isOutdated("firefox", "124.0"));
-    try std.testing.expect(!installer.isOutdated("firefox", "123.0"));
+    try std.testing.expect(try installer.isOutdated("firefox", "124.0"));
+    try std.testing.expect(!try installer.isOutdated("firefox", "123.0"));
+}
+
+// A schema-less DB makes `prepare` fail. Swallowing that into `false`
+// silently flagged corrupt rows as "not outdated"; the typed error lets
+// the caller log `db.errMsg()` and decide.
+test "isOutdated surfaces SqliteError when schema is missing" {
+    var db = try openTestDb();
+    defer db.close();
+
+    const prefix: [:0]const u8 = "/tmp/malt_test_isoutdated_noschema";
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{ .environ = malt.app_ctx.processEnviron() });
+    defer threaded.deinit();
+    var installer = cask.CaskInstaller.init(threaded.io(), malt.app_ctx.processEnviron(), std.testing.allocator, &db, prefix);
+
+    try std.testing.expectError(
+        sqlite.SqliteError.PrepareFailed,
+        installer.isOutdated("firefox", "1.0"),
+    );
 }
 
 // ─── hashFileSha256 / verifyFileSha256 ───────────────────────────────

--- a/tests/uninstall_test.zig
+++ b/tests/uninstall_test.zig
@@ -13,6 +13,7 @@ const uninstall = malt.cli_uninstall;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
 const output = malt.output;
+const cask = malt.cask;
 
 const c = struct {
     extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
@@ -285,6 +286,75 @@ test "execute --force bypasses the dependents check" {
     // --force breaks through the guard.
     try uninstall.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--force", "foo" });
     try testing.expect(!try kegRowExists(prefix.path, "foo"));
+}
+
+// A BEFORE DELETE trigger on `casks` makes `removeRecord` fail with
+// SQLITE_CONSTRAINT after the app teardown has already succeeded. The
+// previous catch{} treated this as a clean uninstall; the CLI catch
+// must now surface the SQLite error name AND `db.errMsg()` so the user
+// has something to act on instead of "looks fine, row still there".
+test "execute on a cask surfaces removeRecord SqliteError with db.errMsg in the log" {
+    var prefix = try ScratchPrefix.init(testing.allocator, "cask_errmsg");
+    defer prefix.deinit(testing.allocator);
+
+    const token = "firefox";
+
+    // Stage a cask row + a BEFORE DELETE trigger that aborts the row's
+    // removal. `RAISE(ABORT, 'cask-row-pinned-by-test-trigger')` sets the
+    // SQLite error message verbatim — that's what we expect in the log.
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+
+        const cask_json =
+            \\{"token":"firefox","name":["Firefox"],"version":"123.0","desc":"","homepage":"",
+            \\ "url":"https://example.com/firefox.dmg",
+            \\ "sha256":"00000000000000000000000000000000000000000000000000000000deadbeef",
+            \\ "auto_updates":false,"artifacts":[{"app":["Firefox.app"]}]}
+        ;
+        var parsed = try cask.parseCask(testing.allocator, cask_json);
+        defer parsed.deinit();
+
+        const app_path = try std.fmt.allocPrint(testing.allocator, "{s}/Firefox.app", .{prefix.path});
+        defer testing.allocator.free(app_path);
+        try cask.recordInstall(&db, &parsed, app_path, null);
+
+        try db.exec(
+            \\CREATE TRIGGER block_cask_delete BEFORE DELETE ON casks
+            \\BEGIN SELECT RAISE(ABORT, 'cask-row-pinned-by-test-trigger'); END;
+        );
+    }
+
+    // Stage the app directory so the `isAppRunning` and `deleteTree`
+    // steps inside uninstall reach the DB step where the trigger fires.
+    const app_path_z = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "{s}/Firefox.app",
+        .{prefix.path},
+        0,
+    );
+    defer testing.allocator.free(app_path_z);
+    try test_io.makeDirAbsolute(std.Options.debug_io, app_path_z);
+
+    const prior_quiet = output.isQuiet();
+    output.setQuiet(false);
+    defer output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    output.beginStderrCapture(testing.allocator, &captured);
+    defer output.endStderrCapture();
+
+    try testing.expectError(
+        error.Aborted,
+        uninstall.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{token}),
+    );
+
+    try testing.expect(std.mem.indexOf(u8, captured.items, "cask-row-pinned-by-test-trigger") != null);
+    try testing.expect(std.mem.indexOf(u8, captured.items, "ConstraintViolation") != null);
 }
 
 test "execute drops the kegs row and decrements the store ref together" {


### PR DESCRIPTION
## Description

Stops swallowing SQLite errors at the cask boundary. `removeRecord`
and `isOutdated` now route through `sqlite.SqliteError`; the caller
decides whether to keep "not outdated" as the default and logs the underlying `db.errMsg()` instead of treating every failure as a silent no-op. A corrupt `casks` row no longer marks every cask as fresh, and an uninstall that can't drop its DB row now surfaces the real cause.

## Related Issue

- None

## Notes for Reviewers

- None