### PR TITLE
refactor: rename SCREAMING_SNAKE_CASE constants to snake_case

### DIFF
--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -140,13 +140,13 @@ const FetchFormulaCtx = struct {
 /// `collectFormulaJobs`. Matches the install-time HTTP client pool so
 /// workers never block on `pool.acquire` — extra workers would just sit
 /// idle waiting for a client.
-pub const MAX_COLLECT_FETCH_WORKERS: usize = 4;
+pub const max_collect_fetch_workers: usize = 4;
 
 /// Bounded worker count for a given dep-fetch load. Exposed so tests
 /// can pin the "no more than N threads" invariant without scraping
 /// `std.Thread.spawn` call counts.
 pub fn collectFetchWorkerCount(deps_to_fetch: usize) usize {
-    return @min(MAX_COLLECT_FETCH_WORKERS, deps_to_fetch);
+    return @min(max_collect_fetch_workers, deps_to_fetch);
 }
 
 /// Shared state for the dep-fetch pool. Mirrors `InstallPool` below:

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -13,8 +13,8 @@ const color = @import("../ui/color.zig");
 const output = @import("../ui/output.zig");
 const help = @import("help.zig");
 const refresh_mod = @import("outdated/refresh.zig");
-pub const OUTDATED_DEFAULT_WORKERS = refresh_mod.OUTDATED_DEFAULT_WORKERS;
-pub const OUTDATED_WORKERS_ENV = refresh_mod.OUTDATED_WORKERS_ENV;
+pub const outdated_default_workers = refresh_mod.outdated_default_workers;
+pub const outdated_workers_env = refresh_mod.outdated_workers_env;
 pub const parseWorkersEnv = refresh_mod.parseWorkersEnv;
 pub const outdatedWorkerCount = refresh_mod.outdatedWorkerCount;
 pub const shouldUsePool = refresh_mod.shouldUsePool;
@@ -29,10 +29,10 @@ pub const loadFormulaRows = rows_mod.loadFormulaRows;
 pub const loadCaskRows = rows_mod.loadCaskRows;
 pub const freeKegRows = rows_mod.freeKegRows;
 const snap_mod = @import("outdated/snapshot.zig");
-pub const SNAPSHOT_DEFAULT_MAX_AGE_HOURS = snap_mod.SNAPSHOT_DEFAULT_MAX_AGE_HOURS;
-pub const SNAPSHOT_MAX_AGE_ENV = snap_mod.SNAPSHOT_MAX_AGE_ENV;
-pub const SNAPSHOT_VERSION = snap_mod.SNAPSHOT_VERSION;
-pub const SNAPSHOT_FILE = snap_mod.SNAPSHOT_FILE;
+pub const snapshot_default_max_age_hours = snap_mod.snapshot_default_max_age_hours;
+pub const snapshot_max_age_env = snap_mod.snapshot_max_age_env;
+pub const snapshot_version = snap_mod.snapshot_version;
+pub const snapshot_file = snap_mod.snapshot_file;
 pub const OutdatedEntry = snap_mod.OutdatedEntry;
 pub const Snapshot = snap_mod.Snapshot;
 pub const OwnedSnapshot = snap_mod.OwnedSnapshot;
@@ -309,8 +309,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     defer db.close();
     schema.initSchema(&db) catch return;
 
-    const max_age_hours = parseMaxAgeHoursEnv(std.process.Environ.getPosix(ctx.environ, SNAPSHOT_MAX_AGE_ENV)) orelse
-        SNAPSHOT_DEFAULT_MAX_AGE_HOURS;
+    const max_age_hours = parseMaxAgeHoursEnv(std.process.Environ.getPosix(ctx.environ, snapshot_max_age_env)) orelse
+        snapshot_default_max_age_hours;
     const snap_opt = readSnapshot(ctx.io, allocator, cache_dir);
     defer if (snap_opt) |s| freeSnapshot(allocator, s);
 
@@ -399,7 +399,7 @@ fn recomputeAndEmit(
     defer http.deinit();
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
 
-    const workers_override = parseWorkersEnv(std.process.Environ.getPosix(ctx.environ, OUTDATED_WORKERS_ENV));
+    const workers_override = parseWorkersEnv(std.process.Environ.getPosix(ctx.environ, outdated_workers_env));
 
     var formula_count: usize = 0;
     var cask_count: usize = 0;

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -26,11 +26,11 @@ const OutdatedEntry = snap_mod.OutdatedEntry;
 /// dominates `mt outdated` on machines with many installed packages, so
 /// we hand the work to a bounded pool the same way `cli/install` and
 /// `cli/search` do.
-pub const OUTDATED_DEFAULT_WORKERS: usize = 8;
+pub const outdated_default_workers: usize = 8;
 
 /// Env var that lets users tune the pool size (e.g. crank it on a fat
 /// uplink, or lower it to one to reproduce serial behaviour).
-pub const OUTDATED_WORKERS_ENV = "MALT_OUTDATED_WORKERS";
+pub const outdated_workers_env = "MALT_OUTDATED_WORKERS";
 
 /// Parse the worker-count override env var. Anything non-positive or
 /// non-numeric falls back to the default — matches the lenient style
@@ -47,7 +47,7 @@ pub fn parseWorkersEnv(s: ?[]const u8) ?usize {
 /// never spawn idle workers, and at the env override (or the default
 /// ceiling) so we never starve the network.
 pub fn outdatedWorkerCount(jobs: usize, env_override: ?usize) usize {
-    const cap = env_override orelse OUTDATED_DEFAULT_WORKERS;
+    const cap = env_override orelse outdated_default_workers;
     return @min(cap, jobs);
 }
 
@@ -55,7 +55,7 @@ pub fn outdatedWorkerCount(jobs: usize, env_override: ?usize) usize {
 /// thread-spawn + HTTP-pool init overhead is not worth it for a
 /// handful of round-trips.
 pub fn shouldUsePool(jobs: usize) bool {
-    return jobs >= OUTDATED_DEFAULT_WORKERS;
+    return jobs >= outdated_default_workers;
 }
 
 /// Recompute every outdated entry (formulas + casks) and overwrite the
@@ -485,7 +485,7 @@ test "WorkerCtx: per-row arena accepts testing.allocator backing without leaking
 
 test "outdatedWorkerCount caps at the default for large N" {
     try std.testing.expectEqual(
-        @as(usize, OUTDATED_DEFAULT_WORKERS),
+        @as(usize, outdated_default_workers),
         outdatedWorkerCount(50, null),
     );
 }
@@ -503,8 +503,8 @@ test "outdatedWorkerCount respects env overrides above and below the default" {
 
 test "shouldUsePool flips at the default-worker boundary" {
     try std.testing.expect(!shouldUsePool(0));
-    try std.testing.expect(!shouldUsePool(OUTDATED_DEFAULT_WORKERS - 1));
-    try std.testing.expect(shouldUsePool(OUTDATED_DEFAULT_WORKERS));
+    try std.testing.expect(!shouldUsePool(outdated_default_workers - 1));
+    try std.testing.expect(shouldUsePool(outdated_default_workers));
     try std.testing.expect(shouldUsePool(50));
 }
 

--- a/src/cli/outdated/snapshot.zig
+++ b/src/cli/outdated/snapshot.zig
@@ -13,18 +13,18 @@ const output = @import("../../ui/output.zig");
 /// Default max age (hours) for the cached `outdated.json` snapshot. Picked
 /// to match the analysis doc: "shell-prompt integrations want instant
 /// startup; ~daily refresh is plenty for security awareness".
-pub const SNAPSHOT_DEFAULT_MAX_AGE_HOURS: u64 = 24;
+pub const snapshot_default_max_age_hours: u64 = 24;
 
-/// Env var override for `SNAPSHOT_DEFAULT_MAX_AGE_HOURS`. Same lenient
-/// parsing rules as `OUTDATED_WORKERS_ENV`.
-pub const SNAPSHOT_MAX_AGE_ENV = "MALT_OUTDATED_MAX_AGE";
+/// Env var override for `snapshot_default_max_age_hours`. Same lenient
+/// parsing rules as `outdated_workers_env`.
+pub const snapshot_max_age_env = "MALT_OUTDATED_MAX_AGE";
 
 /// On-disk snapshot version. Mismatched snapshots are treated as misses
 /// so a downgrade never tries to read a future shape.
-pub const SNAPSHOT_VERSION: u32 = 1;
+pub const snapshot_version: u32 = 1;
 
 /// Snapshot filename under `{cache}/`.
-pub const SNAPSHOT_FILE = "outdated.json";
+pub const snapshot_file = "outdated.json";
 
 /// Result row for a single outdated package. All slices are owned by
 /// the caller's allocator.
@@ -55,7 +55,7 @@ pub const OwnedSnapshot = struct {
 
 /// Resolve the snapshot max-age threshold (in hours) from an env value.
 /// Returns `null` for unset / empty / non-numeric so the caller can apply
-/// `SNAPSHOT_DEFAULT_MAX_AGE_HOURS`; preserves an explicit `"0"` as `0`
+/// `snapshot_default_max_age_hours`; preserves an explicit `"0"` as `0`
 /// so users who set the env to 0 actually get "always stale".
 pub fn parseMaxAgeHoursEnv(s: ?[]const u8) ?u64 {
     const raw = s orelse return null;
@@ -87,7 +87,7 @@ pub fn renderSnapshot(allocator: std.mem.Allocator, snap: Snapshot) RenderError!
     defer aw.deinit();
     const w = &aw.writer;
 
-    try w.print("{{\"version\":{d},\"generated_at_ms\":{d},\"formulas\":[", .{ SNAPSHOT_VERSION, snap.generated_at_ms });
+    try w.print("{{\"version\":{d},\"generated_at_ms\":{d},\"formulas\":[", .{ snapshot_version, snap.generated_at_ms });
     for (snap.formulas, 0..) |e, i| {
         if (i != 0) try w.writeAll(",");
         try writeEntryJson(w, e);
@@ -148,7 +148,7 @@ pub fn parseSnapshot(allocator: std.mem.Allocator, bytes: []const u8) SnapshotPa
     };
     defer parsed.deinit();
 
-    if (parsed.value.version != SNAPSHOT_VERSION) return error.InvalidSnapshot;
+    if (parsed.value.version != snapshot_version) return error.InvalidSnapshot;
 
     const formulas = try dupEntryDocs(allocator, parsed.value.formulas);
     errdefer freeEntrySlice(allocator, formulas);
@@ -200,7 +200,7 @@ pub fn freeEntrySlice(allocator: std.mem.Allocator, slice: []OutdatedEntry) void
 
 /// Resolve the absolute snapshot path under `cache_dir`. Caller frees.
 pub fn snapshotPath(allocator: std.mem.Allocator, cache_dir: []const u8) ![]u8 {
-    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ cache_dir, SNAPSHOT_FILE });
+    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ cache_dir, snapshot_file });
 }
 
 /// Atomically write `snap` to `{cache_dir}/outdated.json`. Creates the

--- a/src/core/pins.zig
+++ b/src/core/pins.zig
@@ -25,7 +25,7 @@ pub const homebrew_core_commit_sha: [40]u8 = "1292ccec721918a4ebe7208c8383cfb11a
 const MANIFEST_TEXT: []const u8 = @embedFile("pins_manifest.txt");
 
 /// Length of a lowercase hex SHA256 digest.
-pub const SHA256_HEX_LEN: usize = 64;
+pub const sha256_hex_len: usize = 64;
 
 /// Look up the expected SHA256 (as lowercase hex) for a formula at the
 /// pinned commit. Returns null when no entry exists — the caller must
@@ -55,8 +55,8 @@ pub fn lookupIn(manifest: []const u8, name: []const u8) ?[]const u8 {
         if (!std.mem.eql(u8, entry_name, name)) continue;
 
         const rest = std.mem.trimStart(u8, line[sep..], " \t");
-        if (rest.len < SHA256_HEX_LEN) return null;
-        const hash = rest[0..SHA256_HEX_LEN];
+        if (rest.len < sha256_hex_len) return null;
+        const hash = rest[0..sha256_hex_len];
         if (!isHexLower(hash)) return null;
         return hash;
     }
@@ -72,8 +72,8 @@ fn isHexLower(s: []const u8) bool {
 }
 
 /// Compute the SHA256 of `bytes` as lowercase hex. Returns the caller-
-/// owned `[SHA256_HEX_LEN]u8` written in-place to `out`.
-pub fn sha256Hex(bytes: []const u8, out: *[SHA256_HEX_LEN]u8) void {
+/// owned `[sha256_hex_len]u8` written in-place to `out`.
+pub fn sha256Hex(bytes: []const u8, out: *[sha256_hex_len]u8) void {
     var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
     std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
     const hex = std.fmt.bytesToHex(digest, .lower);
@@ -108,7 +108,7 @@ test "lookupIn — rejects entry with non-hex hash" {
 }
 
 test "sha256Hex — known vector" {
-    var out: [SHA256_HEX_LEN]u8 = undefined;
+    var out: [sha256_hex_len]u8 = undefined;
     sha256Hex("hello", &out);
     try std.testing.expectEqualStrings(
         "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",

--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -170,7 +170,7 @@ fn fetchPostInstallFromGitHubTagged(
     if (resp.status != 200) return .fetch_failed;
     if (resp.body.len == 0 or resp.body.len > max_formula_rb_bytes) return .fetch_failed;
 
-    var actual_hex: [pins.SHA256_HEX_LEN]u8 = undefined;
+    var actual_hex: [pins.sha256_hex_len]u8 = undefined;
     pins.sha256Hex(resp.body, &actual_hex);
     if (!std.mem.eql(u8, actual_hex[0..], expected_hash)) return .fetch_failed;
 
@@ -688,7 +688,7 @@ pub fn runPostInstallWithBody(
     const home = std.process.Environ.getPosix(environ, "HOME") orelse "/tmp";
     const env: sandbox.ScrubbedEnv = .{
         .home = home,
-        .path = sandbox.SANDBOX_PATH,
+        .path = sandbox.sandbox_path,
         .malt_prefix = prefix,
         .tmpdir = "/tmp",
     };

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -37,7 +37,7 @@ pub const ScrubbedEnv = struct {
 };
 
 /// Minimal PATH — keeps a hostile formula off user-owned bin prefixes.
-pub const SANDBOX_PATH: []const u8 = "/usr/bin:/bin:/usr/sbin:/sbin";
+pub const sandbox_path: []const u8 = "/usr/bin:/bin:/usr/sbin:/sbin";
 
 /// Where the sandboxed child's stdout/stderr land. Production passes the
 /// process's real fd 1/2; tests redirect to `/dev/null` so subprocess

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -828,12 +828,12 @@ test "collectFormulaJobs leaves no parsed-tree leaks under testing.allocator (>=
     try testing.expect(!jobs.items[3].is_dep);
 }
 
-test "collectFetchWorkerCount clamps to MAX_COLLECT_FETCH_WORKERS" {
+test "collectFetchWorkerCount clamps to max_collect_fetch_workers" {
     // Pool invariant: the dep-fetch phase never spawns more than
-    // MAX_COLLECT_FETCH_WORKERS threads, even on heavy graphs (40+ deps).
+    // max_collect_fetch_workers threads, even on heavy graphs (40+ deps).
     // The old one-thread-per-dep loop would scale linearly; the pool
     // caps it so threads never outnumber HTTP client pool slots.
-    const cap = install_download.MAX_COLLECT_FETCH_WORKERS;
+    const cap = install_download.max_collect_fetch_workers;
 
     try testing.expectEqual(@as(usize, 0), install_download.collectFetchWorkerCount(0));
     try testing.expectEqual(@as(usize, 1), install_download.collectFetchWorkerCount(1));

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -118,7 +118,7 @@ test "collectOutdatedFormulas (large-N, pool path) preserves sorted order" {
     defer dir.deinit();
 
     // 10 fake formulas, all outdated (installed=1.0, latest=2.0).
-    // 10 > OUTDATED_DEFAULT_WORKERS so the pool path runs.
+    // 10 > outdated_default_workers so the pool path runs.
     const names = [_][]const u8{
         "f00", "f01", "f02", "f03", "f04",
         "f05", "f06", "f07", "f08", "f09",

--- a/tests/pins_test.zig
+++ b/tests/pins_test.zig
@@ -29,7 +29,7 @@ test "expectedSha256 rejects empty name" {
 }
 
 test "sha256Hex — empty input matches SHA256('')" {
-    var out: [pins.SHA256_HEX_LEN]u8 = undefined;
+    var out: [pins.sha256_hex_len]u8 = undefined;
     pins.sha256Hex("", &out);
     try testing.expectEqualStrings(
         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -38,7 +38,7 @@ test "sha256Hex — empty input matches SHA256('')" {
 }
 
 test "sha256Hex — short known vector" {
-    var out: [pins.SHA256_HEX_LEN]u8 = undefined;
+    var out: [pins.sha256_hex_len]u8 = undefined;
     pins.sha256Hex("abc", &out);
     try testing.expectEqualStrings(
         "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
@@ -123,7 +123,7 @@ test "lookupIn — CRLF line endings tolerated" {
 }
 
 test "lookupIn — trailing text after hash ignored (length gate)" {
-    // lookupIn slices exactly SHA256_HEX_LEN chars; anything after is
+    // lookupIn slices exactly sha256_hex_len chars; anything after is
     // out of bounds of the returned hash but mustn't crash the parser.
     const m = "node " ++ good_hash ++ "  # with comment\n";
     const h = pins.lookupIn(m, "node") orelse return error.TestUnexpectedResult;

--- a/tests/sandbox_macos_test.zig
+++ b/tests/sandbox_macos_test.zig
@@ -75,9 +75,9 @@ test "ScrubbedEnv type smoke — only allowlisted keys" {
     try testing.expectEqualStrings("tmpdir", info.fields[3].name);
 }
 
-test "SANDBOX_PATH restricts to system directories only" {
+test "sandbox_path restricts to system directories only" {
     // Nothing in the minimal PATH should be user-writable.
-    try testing.expectEqualStrings("/usr/bin:/bin:/usr/sbin:/sbin", sandbox.SANDBOX_PATH);
+    try testing.expectEqualStrings("/usr/bin:/bin:/usr/sbin:/sbin", sandbox.sandbox_path);
 }
 
 test "std.posix.rlimit_resource tags resolve on macOS for CPU/FSIZE/AS" {
@@ -116,7 +116,7 @@ test "spawnFilteredWithHooks reaps child when first reader-thread spawn fails" {
 
     const envp = try sandbox.buildEnvp(testing.allocator, .{
         .home = "/tmp",
-        .path = sandbox.SANDBOX_PATH,
+        .path = sandbox.sandbox_path,
         .malt_prefix = "/tmp",
         .tmpdir = "/tmp",
     });
@@ -144,7 +144,7 @@ test "spawnFilteredWithHooks reaps child and joins out-thread when second spawn 
 
     const envp = try sandbox.buildEnvp(testing.allocator, .{
         .home = "/tmp",
-        .path = sandbox.SANDBOX_PATH,
+        .path = sandbox.sandbox_path,
         .malt_prefix = "/tmp",
         .tmpdir = "/tmp",
     });
@@ -177,7 +177,7 @@ test "spawnFilteredWithHooks routes child stderr to the configured fd" {
 
     const envp = try sandbox.buildEnvp(testing.allocator, .{
         .home = "/tmp",
-        .path = sandbox.SANDBOX_PATH,
+        .path = sandbox.sandbox_path,
         .malt_prefix = "/tmp",
         .tmpdir = "/tmp",
     });


### PR DESCRIPTION
## Description

Renames the remaining SCREAMING_SNAKE_CASE value constant bindings in the codebase to snake_case so they match stdlib idiom and the rest of the project. Env-variable string values (what the user types) are unchanged - only binding names move.

## Related Issue

- None

## Notes for Reviewers

- None