### PR TITLE
fix(release): drop wrap_in_directory so cask paths resolve

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,10 +212,8 @@ jobs:
             exit 1
           fi
           tar -xzf "$TARBALL"
-          # archives.wrap_in_directory=true → tarball roots at <name>/.
-          EXTRACTED_DIR=$(tar -tzf "$TARBALL" | head -1 | cut -d/ -f1)
-          "./${EXTRACTED_DIR}/malt" --version
-          "./${EXTRACTED_DIR}/mt" --version
+          ./malt --version
+          ./mt --version
 
   # Push the rendered cask to indaco/homebrew-tap. Runs only after
   # verify-artifacts so a failed smoke leaves the tap untouched — the

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,7 +35,6 @@ archives:
       # archive root.
       - src: "dist/*_darwin_all*/mt"
         dst: "."
-    wrap_in_directory: true
 
 checksum:
   name_template: checksums.txt

--- a/scripts/test/install_sh_test.sh
+++ b/scripts/test/install_sh_test.sh
@@ -88,16 +88,16 @@ make_release_fixture() {
   local archive_name="malt_${version}_darwin_all.tar.gz"
   local stage="$TMP/stage_${version}"
   rm -rf "$stage"
-  mkdir -p "$stage/malt_${version}_darwin_all"
+  mkdir -p "$stage"
   # Minimal contents: install.sh does a `find -name malt -type f -perm
   # -u+x` after extraction. A shell script with the exec bit satisfies
   # it without requiring a real binary.
-  cat >"$stage/malt_${version}_darwin_all/malt" <<'SH'
+  cat >"$stage/malt" <<'SH'
 #!/usr/bin/env bash
 exit 0
 SH
-  chmod +x "$stage/malt_${version}_darwin_all/malt"
-  tar -C "$stage" -czf "$dest/v${version}/${archive_name}" "malt_${version}_darwin_all"
+  chmod +x "$stage/malt"
+  tar -C "$stage" -czf "$dest/v${version}/${archive_name}" malt
   # Correct checksum so the happy path passes. install.sh itself uses
   # /usr/bin/shasum; the fixture generator avoids it because some
   # developer environments ship a broken perl-backed shasum ahead of


### PR DESCRIPTION
## Description

The generated cask declares `binary "malt"` at the staged root, but `archives.wrap_in_directory: true` ships a tarball that wraps everything in `malt_VERSION_darwin_all/`. brew can't find the binary at the cask's expected path and aborts at the symlink step.

Dropping `wrap_in_directory: true` makes the tarball layout match what the cask already expects. No tap change needed.

Files changed:

- `.goreleaser.yaml`: drop the line.
- `.github/workflows/release.yml`: verify-artifacts smoke probed `./${EXTRACTED_DIR}/malt`; switch to `./malt` against the new layout.
- `scripts/test/install_sh_test.sh`: fixture used a wrapped tarball; rebuild it flat. `install.sh` itself was already layout-tolerant (`find -name malt`), no change there.

## Related Issue

Fixes #375

## Notes for Reviewers

- `./scripts/test/install_sh_test.sh` passes 7/7 against the new fixture.
- No Zig code touched, so `zig build` / `zig build test` aren't affected.
- The release workflow only runs on a `v*` tag push, so the smoke-test change is reviewed by eye.
