### PR TITLE
refactor: small Zig idiom cleanups

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -841,10 +841,9 @@ fn executeWithOpts(
 
         if (!mats[i].ok) {
             const err = mats[i].err orelse cellar_mod.CellarError.CloneFailed;
-            output.err(
-                "Failed to materialize {s}: {s} ({s})",
-                .{ job.name, @errorName(err), cellar_mod.describeError(err) },
-            );
+            var msg_buf: [256]u8 = undefined;
+            const msg = formatMaterializeFailure(&msg_buf, job.name, err);
+            output.err("{s}", .{msg});
             output.emitNdjsonEvent(.materialized, job.name, "failed");
             try failed_kegs.put(job.name, {});
             failed_count += 1;
@@ -1140,6 +1139,36 @@ fn installCask(
     allocator.free(app_path);
 
     output.success("{s} {s} installed", .{ cask.token, cask.version });
+}
+
+// Format the user-facing materialize-failure line. Trivial cellar tags
+// (where describeError == @errorName) drop the parenthetical so the
+// message reads `Failed to materialize X: CloneFailed` instead of
+// `Failed to materialize X: CloneFailed (CloneFailed)`.
+fn formatMaterializeFailure(buf: []u8, name: []const u8, err: cellar_mod.CellarError) []const u8 {
+    const tag = @errorName(err);
+    const desc = cellar_mod.describeError(err);
+    const result = if (std.mem.eql(u8, tag, desc))
+        std.fmt.bufPrint(buf, "Failed to materialize {s}: {s}", .{ name, tag })
+    else
+        std.fmt.bufPrint(buf, "Failed to materialize {s}: {s} ({s})", .{ name, tag, desc });
+    // Overflow only fires on pathologically long names; fall back to a
+    // truncated form rather than swallowing the failure silently.
+    return result catch "Failed to materialize <truncated>";
+}
+
+test "formatMaterializeFailure: trivial tag drops the parenthetical" {
+    var buf: [256]u8 = undefined;
+    const msg = formatMaterializeFailure(&buf, "lld@21", cellar_mod.CellarError.CloneFailed);
+    try std.testing.expectEqualStrings("Failed to materialize lld@21: CloneFailed", msg);
+}
+
+test "formatMaterializeFailure: action-hint tag keeps the parenthetical prose" {
+    var buf: [256]u8 = undefined;
+    const msg = formatMaterializeFailure(&buf, "pkg", cellar_mod.CellarError.InstallNameToolMissing);
+    try std.testing.expect(std.mem.startsWith(u8, msg, "Failed to materialize pkg: InstallNameToolMissing ("));
+    try std.testing.expect(std.mem.endsWith(u8, msg, ")"));
+    try std.testing.expect(std.mem.indexOf(u8, msg, "install_name_tool not found on PATH") != null);
 }
 
 test "kegPresent returns true only when <prefix>/Cellar/<name> exists" {

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -379,16 +379,10 @@ pub fn installLocalFormula(
         output.err("Cannot read local formula: {s}", .{realpath});
         return InstallError.LocalFormulaNotReadable;
     };
-    const body = if (n == body_buf.len) body_buf else blk: {
-        if (allocator.resize(body_buf, n)) break :blk body_buf[0..n];
-        const trimmed = allocator.alloc(u8, n) catch {
-            allocator.free(body_buf);
-            output.err("Cannot read local formula: {s}", .{realpath});
-            return InstallError.LocalFormulaNotReadable;
-        };
-        @memcpy(trimmed, body_buf[0..n]);
+    const body = if (n == body_buf.len) body_buf else allocator.realloc(body_buf, n) catch {
         allocator.free(body_buf);
-        break :blk trimmed;
+        output.err("Cannot read local formula: {s}", .{realpath});
+        return InstallError.LocalFormulaNotReadable;
     };
     defer allocator.free(body);
 

--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -142,12 +142,11 @@ pub fn routePostInstallOutcomeWithBody(
             if (output.isVerbose()) flog.printUnknown(name);
             if (output.isDebug()) flog.printFatal(name);
             const ruby_stdio: sandbox.Stdio = .{ .out = ctx.stdout.handle, .err = ctx.stderr.handle };
-            const ruby_result: anyerror!void = if (pre_resolved_body) |body|
+            const ruby_result: ruby_sub.RubyError!void = if (pre_resolved_body) |body|
                 ruby_sub.runPostInstallWithBody(ctx.io, ctx.environ, allocator, name, version_str, prefix, body, ruby_stdio)
             else
                 ruby_sub.runPostInstall(ctx.io, ctx.environ, allocator, name, version_str, prefix, ruby_stdio);
-            ruby_result catch |e| {
-                const err: ruby_sub.RubyError = @errorCast(e);
+            ruby_result catch |err| {
                 output.warn("post_install subprocess failed for {s}: {s}", .{ name, ruby_sub.describeError(err) });
                 break :blk .ruby_fallback_failed;
             };

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -32,15 +32,12 @@ pub const CellarError = error{
 /// Human-readable description for a CellarError tag.
 /// Used by `mt install` when surfacing a materialize failure.
 pub fn describeError(err: CellarError) []const u8 {
+    // Only spell out the mappings that carry user-actionable hints;
+    // trivial tags speak for themselves via @errorName.
     return switch (err) {
-        CellarError.CloneFailed => "APFS clonefile or copy failed",
-        CellarError.PatchFailed => "Mach-O or text-file path patching failed",
-        CellarError.PathTooLong => "new prefix path is longer than the bottle was built with",
         CellarError.InsufficientHeaderPad => "install_name_tool: bottle built without -headerpad_max_install_names",
         CellarError.InstallNameToolMissing => "install_name_tool not found on PATH (install Xcode Command Line Tools)",
-        CellarError.CodesignFailed => "codesign re-signing failed",
-        CellarError.RemoveFailed => "cellar directory removal failed",
-        CellarError.OutOfMemory => "out of memory",
+        else => @errorName(err),
     };
 }
 
@@ -498,4 +495,23 @@ pub fn remove(io: std.Io, prefix: []const u8, name: []const u8, version: []const
     const cellar_path = std.fmt.bufPrint(&buf, "{s}/Cellar/{s}/{s}", .{ prefix, name, version }) catch
         return CellarError.OutOfMemory;
     std.Io.Dir.cwd().deleteTree(io, cellar_path) catch return CellarError.RemoveFailed;
+}
+
+// Pins the describeError split: only the user-actionable mappings carry
+// prose; every other tag falls through to @errorName.
+test "describeError: action-hint tags keep prose, trivial tags fall back to @errorName" {
+    try std.testing.expect(std.mem.indexOf(u8, describeError(CellarError.InsufficientHeaderPad), "-headerpad_max_install_names") != null);
+    try std.testing.expect(std.mem.indexOf(u8, describeError(CellarError.InstallNameToolMissing), "install_name_tool not found on PATH") != null);
+
+    const fallback_tags = [_]CellarError{
+        CellarError.CloneFailed,
+        CellarError.PatchFailed,
+        CellarError.PathTooLong,
+        CellarError.CodesignFailed,
+        CellarError.RemoveFailed,
+        CellarError.OutOfMemory,
+    };
+    inline for (fallback_tags) |e| {
+        try std.testing.expectEqualStrings(@errorName(e), describeError(e));
+    }
 }

--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -816,7 +816,7 @@ pub const Parser = struct {
             self.skipNewlines();
             const elsif_body = try self.parseBlock();
             elsif_branches.append(self.allocator, .{
-                .condition = try self.makeNodePtr(elsif_cond),
+                .condition = elsif_cond,
                 .body = elsif_body,
             }) catch return DslError.OutOfMemory;
         }
@@ -835,7 +835,7 @@ pub const Parser = struct {
         return self.allocNode(.{
             .loc = loc,
             .kind = .{ .if_else = .{
-                .condition = try self.makeNodePtr(condition),
+                .condition = condition,
                 .then_body = then_body,
                 .elsif_branches = elsif_slice,
                 .else_body = else_body,
@@ -864,7 +864,7 @@ pub const Parser = struct {
         return self.allocNode(.{
             .loc = loc,
             .kind = .{ .unless_statement = .{
-                .condition = try self.makeNodePtr(condition),
+                .condition = condition,
                 .body = body,
                 .else_body = else_body,
             } },
@@ -1153,13 +1153,6 @@ pub const Parser = struct {
         const ptr = self.allocator.create(Node) catch return DslError.OutOfMemory;
         ptr.* = node;
         return ptr;
-    }
-
-    fn makeNodePtr(self: *Parser, node: anytype) DslError!*const Node {
-        // If already a pointer, return it directly
-        if (@TypeOf(node) == *const Node) return node;
-        // Otherwise it's a Node value — need to allocate
-        return self.emitError("internal: cannot convert to node pointer");
     }
 
     fn emitError(self: *Parser, message: []const u8) DslError {

--- a/src/fs/atomic.zig
+++ b/src/fs/atomic.zig
@@ -183,12 +183,7 @@ fn atomicWriteFileImpl(
 ) !void {
     var rand_bytes: [4]u8 = undefined;
     std.c.arc4random_buf(&rand_bytes, rand_bytes.len);
-    const hex_chars = "0123456789abcdef";
-    var hex: [8]u8 = undefined;
-    for (rand_bytes, 0..) |b, i| {
-        hex[i * 2] = hex_chars[b >> 4];
-        hex[i * 2 + 1] = hex_chars[b & 0x0f];
-    }
+    const hex = std.fmt.bytesToHex(rand_bytes, .lower);
 
     var tmp_buf: [std.fs.max_path_bytes]u8 = undefined;
     const tmp_path = std.fmt.bufPrint(&tmp_buf, "{s}.{s}.tmp", .{ dst_path, &hex }) catch
@@ -235,13 +230,7 @@ pub fn createTempDir(io: std.Io, allocator: std.mem.Allocator, label: []const u8
     // Generate 8 random bytes -> 16 hex chars.
     var rand_bytes: [8]u8 = undefined;
     std.c.arc4random_buf(&rand_bytes, rand_bytes.len);
-
-    var hex_buf: [16]u8 = undefined;
-    const hex_chars = "0123456789abcdef";
-    for (rand_bytes, 0..) |b, i| {
-        hex_buf[i * 2] = hex_chars[b >> 4];
-        hex_buf[i * 2 + 1] = hex_chars[b & 0x0f];
-    }
+    const hex_buf = std.fmt.bytesToHex(rand_bytes, .lower);
 
     const dir_path = try std.fmt.allocPrint(allocator, "{s}/tmp/{s}_{s}", .{ prefix, label, &hex_buf });
 


### PR DESCRIPTION
## Description

Five small idiom cleanups: switch to `allocator.realloc` for shrink in install/local; drop a redundant `anyerror` widen + `@errorCast` in post_install; tighten `makeNodePtr` against the single call shape it sees; replace two hand-rolled hex encoders with `std.fmt.bytesToHex`; collapse the cellar error map to its non-obvious mappings only.

## Related Issue

- None

## Notes for Reviewers

- The cellar error map collapse is the only one with user-visible output churn; the kept mappings (`InsufficientHeaderPad`, `InstallNameToolMissing`) are the ones that carry user-actionable hints.
- Trivial cellar tags would otherwise read `Failed to materialize X: CloneFailed (CloneFailed)` after the collapse — the install-side formatter drops the parenthetical when `describeError == @errorName`, so the message reads `Failed to materialize X: CloneFailed`. Net output is shorter and cleaner.