### PR TITLE
chore(release): cross-check cask binary paths against the tarball layout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,12 @@ jobs:
     environment:
       name: Release
     steps:
+      - name: Checkout repo
+        # Needed so the cask-paths cross-check helper
+        # (scripts/release/verify_cask_paths.sh) is on disk for the
+        # verify step below.
+        uses: actions/checkout@v6
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.1.1
 
@@ -178,6 +184,15 @@ jobs:
             --repo "${{ github.repository }}" \
             --dir /tmp/verify
           ls -la /tmp/verify
+
+      - name: Download rendered cask
+        # Same artifact publish-cask consumes downstream — pulling it
+        # here lets us cross-check the cask's declared paths against
+        # the tarball *before* the tap push happens.
+        uses: actions/download-artifact@v8
+        with:
+          name: homebrew-cask
+          path: /tmp/cask
 
       - name: Verify cosign signature on checksums
         run: |
@@ -214,6 +229,20 @@ jobs:
           tar -xzf "$TARBALL"
           ./malt --version
           ./mt --version
+
+      - name: Verify cask paths resolve in tarball
+        # Static cross-check: every `binary "..."` and `#{staged_path}/...`
+        # declared by the rendered cask must exist under the extracted
+        # tarball root. Closes the gap that let #375 ship — a tarball
+        # that ran fine via install.sh but broke `brew install --cask`.
+        run: |
+          mapfile -t found < <(find /tmp/cask -type f -name '*.rb')
+          if [ "${#found[@]}" -ne 1 ]; then
+            echo "::error::expected exactly one .rb in cask artifact, got ${#found[@]}"
+            printf '  %s\n' "${found[@]}" >&2
+            exit 1
+          fi
+          bash scripts/release/verify_cask_paths.sh /tmp/verify "${found[0]}"
 
   # Push the rendered cask to indaco/homebrew-tap. Runs only after
   # verify-artifacts so a failed smoke leaves the tap untouched — the

--- a/justfile
+++ b/justfile
@@ -71,13 +71,13 @@ fmt:
 # Lint shell scripts with shellcheck + shfmt.
 [group('lint')]
 shell-lint:
-    shellcheck scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh scripts/smokes/*.sh
-    shfmt -i 2 -d scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh scripts/smokes/*.sh
+    shellcheck scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh scripts/smokes/*.sh scripts/release/*.sh
+    shfmt -i 2 -d scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh scripts/smokes/*.sh scripts/release/*.sh
 
 # Apply shfmt formatting in place. Run after a failing `shell-lint`.
 [group('lint')]
 shell-fmt:
-    shfmt -i 2 -w scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh scripts/smokes/*.sh
+    shfmt -i 2 -w scripts/*.sh scripts/lib/*.sh scripts/test/*.sh scripts/e2e/*.sh scripts/regressions/*.sh scripts/smokes/*.sh scripts/release/*.sh
 
 # Lint: format check + build + test
 [group('lint')]
@@ -300,6 +300,26 @@ patch:
     #   sley tag create --push
     echo "▸ Bump + changelog ready on $branch."
     echo "▸ Review, then run: git push origin $branch && sley tag create --push"
+
+# Cross-check every `binary "..."` / `#{staged_path}/...` declared by the
+# rendered cask against the extracted release tarball in dist/. Run after
+# `goreleaser release --snapshot --clean` to catch a cask/tarball path
+# mismatch locally before CI does — the same check runs in
+# verify-artifacts at release time.
+[group('release')]
+verify-cask-paths:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    tarball=$(find dist -maxdepth 1 -name '*_darwin_all.tar.gz' | head -1)
+    cask=$(find dist -name '*.rb' | head -1)
+    [ -n "$tarball" ] || { echo "no tarball in dist/ - run 'goreleaser release --snapshot --clean --skip=sign' first" >&2; exit 1; }
+    [ -n "$cask" ] || { echo "no rendered cask in dist/" >&2; exit 1; }
+
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    tar -xzf "$tarball" -C "$tmp"
+    bash scripts/release/verify_cask_paths.sh "$tmp" "$cask"
 
 # Roll back a published release. Flips the GitHub release back to draft,
 # re-promotes the previous release to --latest, and reverts the matching

--- a/scripts/release/verify_cask_paths.sh
+++ b/scripts/release/verify_cask_paths.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# scripts/release/verify_cask_paths.sh — release-time static cross-check
+#
+# Parses a rendered Homebrew cask and asserts every `binary "..."` and
+# `#{staged_path}/...` reference resolves to a real file (or non-dangling
+# symlink) under the extracted-tarball root. Closes the gap that let
+# #375 ship: goreleaser renders the cask and the tarball independently
+# with no path-consistency check between them.
+#
+# Usage:
+#   verify_cask_paths.sh <extracted_root> <cask_rb_path>
+#
+# Exit:
+#   0  every declared path resolved
+#   1  one or more paths missing — each printed to stderr as
+#      "cask path missing in tarball: <path>"  (stable prefix; do not
+#      reword without updating the release-monitoring scrape).
+#   2  usage error.
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <extracted_root> <cask_rb_path>" >&2
+  exit 2
+fi
+
+root="$1"
+cask="$2"
+
+[ -d "$root" ] || {
+  echo "extracted root not a directory: $root" >&2
+  exit 2
+}
+[ -f "$cask" ] || {
+  echo "cask file not found: $cask" >&2
+  exit 2
+}
+
+# Collect every declared path, deduped via `sort -u`. The postflight
+# typically re-references a path already declared as `binary`, and
+# reporting the same miss twice is just noise. `binary "x"` lives
+# anywhere in the cask; `#{staged_path}/x` references live inside
+# `postflight do ... end` but the regex is specific enough that a
+# flat scan is safe.
+paths=()
+while IFS= read -r p; do
+  [ -n "$p" ] && paths+=("$p")
+done < <(
+  {
+    sed -nE 's/^[[:space:]]*binary[[:space:]]+"([^"]+)".*/\1/p' "$cask"
+    sed -nE 's/.*#\{staged_path\}\/([^"]+).*/\1/p' "$cask"
+  } | sort -u
+)
+
+if [ "${#paths[@]}" -eq 0 ]; then
+  echo "no binary or staged_path references found in $cask" >&2
+  exit 2
+fi
+
+missing=0
+for p in "${paths[@]}"; do
+  # `test -e` follows symlinks; a dangling `mt -> malt` therefore
+  # fails (correct behaviour — the user would hit the same failure
+  # at install time).
+  if [ -e "$root/$p" ]; then
+    printf 'verified: %s\n' "$p"
+  else
+    printf 'cask path missing in tarball: %s\n' "$p" >&2
+    missing=$((missing + 1))
+  fi
+done
+
+[ "$missing" -eq 0 ]

--- a/scripts/test/verify_cask_paths_test.sh
+++ b/scripts/test/verify_cask_paths_test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# scripts/test/verify_cask_paths_test.sh — release-time cross-check
+# regression tests for scripts/release/verify_cask_paths.sh.
+#
+# Each fixture synthesises a (tarball-root, cask.rb) pair and asserts
+# the helper's exit code and stderr greppability:
+#
+#   1. flat tarball + cask with root-relative binaries → pass
+#   2. wrapped tarball + cask declaring wrapped-relative binaries → pass
+#   3. cask declares a path the tarball doesn't contain → fail with
+#      "cask path missing in tarball: <path>" per missing entry
+#
+# Usage:
+#   ./scripts/test/verify_cask_paths_test.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+HELPER="$ROOT/scripts/release/verify_cask_paths.sh"
+
+[ -x "$HELPER" ] || {
+  echo "verify_cask_paths.sh missing or not executable at $HELPER" >&2
+  exit 2
+}
+
+TMP=$(mktemp -d /tmp/malt_verify_cask_paths_test.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+failures=()
+
+# Build a flat tarball-root layout: malt + mt symlink + LICENSE at root.
+# Mirrors what goreleaser produces post-#376.
+make_flat_root() {
+  local root="$1"
+  mkdir -p "$root"
+  printf '#!/bin/sh\nexit 0\n' >"$root/malt"
+  chmod +x "$root/malt"
+  ln -sfn malt "$root/mt"
+  printf 'license text\n' >"$root/LICENSE"
+}
+
+# Build a wrapped layout: everything under <root>/malt_X_Y_darwin_all/.
+# Forward-compat for any future config that re-introduces wrap_in_directory.
+make_wrapped_root() {
+  local root="$1" wrapper="$2"
+  mkdir -p "$root/$wrapper"
+  printf '#!/bin/sh\nexit 0\n' >"$root/$wrapper/malt"
+  chmod +x "$root/$wrapper/malt"
+  ln -sfn malt "$root/$wrapper/mt"
+}
+
+# Render a minimal cask.rb. $1 is the path, $2 is the binary stanza
+# body (one path per line, e.g. "malt\nmt" or "wrap/malt\nwrap/mt"),
+# $3 is the postflight reference suffix (e.g. "malt" → "#{staged_path}/malt").
+write_cask() {
+  local cask_path="$1" binaries="$2" staged_suffix="$3"
+  {
+    printf 'cask "malt" do\n'
+    printf '  version "9.9.9"\n'
+    while IFS= read -r b; do
+      [ -n "$b" ] || continue
+      printf '  binary "%s"\n' "$b"
+    done <<<"$binaries"
+    printf '  postflight do\n'
+    printf '    if OS.mac?\n'
+    printf '      system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/%s"]\n' "$staged_suffix"
+    printf '    end\n'
+    printf '  end\n'
+    printf 'end\n'
+  } >"$cask_path"
+}
+
+# ── test 1: flat tarball, root-relative binaries ─────────────────────
+printf '▸ flat tarball + root-relative binaries\n'
+ROOT1="$TMP/flat-root"
+CASK1="$TMP/flat.rb"
+make_flat_root "$ROOT1"
+write_cask "$CASK1" "malt
+mt" "malt"
+if "$HELPER" "$ROOT1" "$CASK1" >"$TMP/flat.out" 2>&1; then
+  printf '  ✓ flat layout accepted\n'
+  pass=$((pass + 1))
+else
+  printf '  ✗ flat layout rejected (rc=%s)\n' "$?" >&2
+  cat "$TMP/flat.out" >&2
+  fail=$((fail + 1))
+  failures+=("flat-rejected")
+fi
+
+# ── test 2: wrapped tarball, wrapped-relative binaries ───────────────
+printf '▸ wrapped tarball + wrapped-relative binaries\n'
+ROOT2="$TMP/wrapped-root"
+CASK2="$TMP/wrapped.rb"
+WRAP="malt_9.9.9_darwin_all"
+make_wrapped_root "$ROOT2" "$WRAP"
+write_cask "$CASK2" "$WRAP/malt
+$WRAP/mt" "$WRAP/malt"
+if "$HELPER" "$ROOT2" "$CASK2" >"$TMP/wrapped.out" 2>&1; then
+  printf '  ✓ wrapped layout accepted\n'
+  pass=$((pass + 1))
+else
+  printf '  ✗ wrapped layout rejected (rc=%s)\n' "$?" >&2
+  cat "$TMP/wrapped.out" >&2
+  fail=$((fail + 1))
+  failures+=("wrapped-rejected")
+fi
+
+# ── test 3: regression of #375 — flat tarball but cask hardcodes the
+#            wrapped path; helper must report both binaries missing. ──
+printf '▸ cask paths missing in tarball (#375 shape)\n'
+ROOT3="$TMP/regression-root"
+CASK3="$TMP/regression.rb"
+make_flat_root "$ROOT3"
+write_cask "$CASK3" "$WRAP/malt
+$WRAP/mt" "$WRAP/malt"
+rc=0
+"$HELPER" "$ROOT3" "$CASK3" >"$TMP/regression.out" 2>&1 || rc=$?
+if [ "$rc" = "0" ]; then
+  printf '  ✗ missing paths NOT rejected (rc=0)\n' >&2
+  fail=$((fail + 1))
+  failures+=("missing-allowed")
+else
+  printf '  ✓ missing paths rejected (rc=%s)\n' "$rc"
+  pass=$((pass + 1))
+fi
+# Stable failure prefix is the public contract for any future
+# release-monitoring scrape — assert it appears for each missing path.
+for missing in "$WRAP/malt" "$WRAP/mt"; do
+  if grep -q "cask path missing in tarball: $missing" "$TMP/regression.out"; then
+    printf '  ✓ stderr names %s\n' "$missing"
+    pass=$((pass + 1))
+  else
+    printf '  ✗ stderr did not name %s\n' "$missing" >&2
+    cat "$TMP/regression.out" >&2
+    fail=$((fail + 1))
+    failures+=("missing-no-mention-$missing")
+  fi
+done
+
+# ── summary ──────────────────────────────────────────────────────────
+printf '\n── summary ──\npass: %d\nfail: %d\n' "$pass" "$fail"
+if [ "$fail" -ne 0 ]; then
+  printf 'failures:\n'
+  for f in "${failures[@]}"; do printf '  %s\n' "$f"; done
+  exit 1
+fi


### PR DESCRIPTION
## Description

Add a static cross-check during release verification that asserts every `binary "..."` and `#{staged_path}/...` reference declared in the rendered Homebrew cask exists inside the extracted release tarball. The check is a small shell helper (`scripts/release/verify_cask_paths.sh`) wired into the `verify-artifacts` job, so a mismatch fails the release before the cask is pushed to the tap.

The cask is the only release consumer that requires a static path the cask author wrote - every other install path (`install.sh`, `mt version update`, source build) locates the binary recursively and is layout-tolerant. That asymmetry is what let the `wrap_in_directory` / cask-paths mismatch ship in v0.13.0 with every smoke green. The helper closes the gap without needing a live `brew install --cask` round-trip in CI.

Local iteration is covered by a new `just verify-cask-paths` recipe that runs against `dist/` after `goreleaser release --snapshot --clean --skip=sign`.

## Related Issue

- None

## Notes for Reviewers

- Nons