### PR TITLE
feat(net): honour MALT_API_DOMAIN and MALT_BOTTLE_DOMAIN

### DIFF
--- a/scripts/regressions/mirror_env_overrides.sh
+++ b/scripts/regressions/mirror_env_overrides.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Lock the corporate-mirror env contract end-to-end at the binary edge.
+#
+# Three behaviours pinned:
+#   1. Defaults shape — no env, doctor row reads "using upstream Homebrew defaults".
+#   2. HTTPS-only refusal — a non-https override exits non-zero before any
+#      subcommand runs, with the operator-facing message.
+#   3. Override + fallback precedence — MALT_* wins over HOMEBREW_*; both
+#      knobs surface in the doctor row exactly as resolved (incl.
+#      trailing-slash normalisation).
+#
+# Usage: scripts/regressions/mirror_env_overrides.sh
+# Requirements: a built malt binary at zig-out/bin/malt (just build).
+# No network access required — `mt doctor` runs locally against
+# MALT_PREFIX and only the env probe is asserted.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+# Use a throwaway prefix so doctor never touches /opt/malt.
+PREFIX=$(mktemp -d -t malt_mirror_reg.XXXXXX)
+trap 'rm -rf "$PREFIX"' EXIT
+
+# Strip any inherited mirror env so the host's shell can't poison
+# the deterministic assertions below.
+unset MALT_API_DOMAIN MALT_BOTTLE_DOMAIN HOMEBREW_API_DOMAIN HOMEBREW_BOTTLE_DOMAIN
+
+run_doctor() {
+  MALT_PREFIX="$PREFIX" "$MALT_BIN" doctor 2>&1 || true
+}
+
+# (1) Defaults — no override, the upstream-defaults message must surface.
+out=$(run_doctor)
+if ! grep -q "Mirror overrides — using upstream Homebrew defaults" <<<"$out"; then
+  printf 'FAIL: defaults row missing.\n%s\n' "$out" >&2
+  exit 1
+fi
+
+# (2) HTTPS-only refusal — a non-https override exits non-zero before
+# any subcommand runs, with the canonical message.
+set +e
+err=$(MALT_PREFIX="$PREFIX" MALT_API_DOMAIN=http://insecure.example.com "$MALT_BIN" --help 2>&1)
+rc=$?
+set -e
+if [[ $rc -eq 0 ]]; then
+  printf 'FAIL: non-https override should exit non-zero (got rc=0).\n' >&2
+  exit 1
+fi
+if ! grep -q "must use https://" <<<"$err"; then
+  printf 'FAIL: non-https error message missing.\n%s\n' "$err" >&2
+  exit 1
+fi
+
+# (3a) MALT_* wins over HOMEBREW_* and trailing slash is normalised.
+out=$(MALT_PREFIX="$PREFIX" \
+  MALT_API_DOMAIN="https://malt.example.com/api/" \
+  HOMEBREW_API_DOMAIN="https://hb.example.com/api" \
+  MALT_BOTTLE_DOMAIN="https://reg.example.com/" \
+  run_doctor)
+if ! grep -q "API=https://malt.example.com/api, Bottle=https://reg.example.com" <<<"$out"; then
+  printf 'FAIL: MALT_* precedence or trailing-slash normalisation regressed.\n%s\n' "$out" >&2
+  exit 1
+fi
+
+# (3b) HOMEBREW_* fallback surfaces when MALT_* is unset.
+out=$(MALT_PREFIX="$PREFIX" \
+  HOMEBREW_API_DOMAIN="https://hb-fallback.example.com/api" \
+  run_doctor)
+if ! grep -q "API=https://hb-fallback.example.com/api" <<<"$out"; then
+  printf 'FAIL: HOMEBREW_* fallback row missing.\n%s\n' "$out" >&2
+  exit 1
+fi
+
+# (3c) The API-reachable probe targets the resolved host (no fall-back
+# to the upstream URL on override).
+out=$(MALT_PREFIX="$PREFIX" \
+  MALT_API_DOMAIN="https://probe-host.example.com/api" \
+  run_doctor)
+if ! grep -q "Cannot reach https://probe-host.example.com" <<<"$out"; then
+  printf 'FAIL: API-reachable probe did not target the override host.\n%s\n' "$out" >&2
+  exit 1
+fi
+
+echo "OK: mirror env-override contract holds (defaults, https-only, precedence, probe host)."

--- a/src/app_ctx.zig
+++ b/src/app_ctx.zig
@@ -10,6 +10,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const mirror = @import("net/mirror.zig");
 
 pub const AppCtx = struct {
     io: std.Io,
@@ -20,6 +21,10 @@ pub const AppCtx = struct {
     /// tests opt in to a captured or `/dev/null` sink as needed.
     stdout: std.Io.File = .{ .handle = -1, .flags = .{ .nonblocking = false } },
     stderr: std.Io.File = .{ .handle = -1, .flags = .{ .nonblocking = false } },
+    /// Process-wide mirror snapshot resolved once in `main`. cli/ call
+    /// sites read this instead of re-walking the env per request;
+    /// tests and `debug_ctx` get the upstream Homebrew defaults.
+    mirrors: mirror.Mirrors = .{},
 };
 
 /// Parent `environ` as `std.process.Environ`. Production `main` builds an

--- a/src/cli/deps.zig
+++ b/src/cli/deps.zig
@@ -438,6 +438,7 @@ fn collectGraph(
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
+    api.base_url = ctx.mirrors.api_base;
     var api_ctx = ApiCtx{ .allocator = allocator, .api = &api };
     const api_lookup = apiDepLookup(&api_ctx);
 

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -15,6 +15,7 @@ const atomic = @import("../fs/atomic.zig");
 const clonefile = @import("../fs/clonefile.zig");
 const parser = @import("../macho/parser.zig");
 const client_mod = @import("../net/client.zig");
+const mirror_mod = @import("../net/mirror.zig");
 const color = @import("../ui/color.zig");
 const output = @import("../ui/output.zig");
 pub const cask_history = @import("doctor/cask_history.zig");
@@ -41,6 +42,10 @@ pub const CheckCtx = struct {
     prefix: []const u8,
     io: std.Io,
     environ: std.process.Environ,
+    /// Mirror snapshot — drives the API-reachable probe host and the
+    /// "Mirror overrides" row. Defaults to upstream so tests and
+    /// `debug_ctx`-shaped fixtures keep working without plumbing.
+    mirrors: mirror_mod.Mirrors = .{},
 };
 
 /// One entry in the health walk. `run` prints its row(s) and returns
@@ -66,6 +71,7 @@ pub const checks = [_]Check{
     .{ .name = patch.external_tool_name, .run = checkExternalTool },
     .{ .name = "APFS volume", .run = checkApfs },
     .{ .name = "Prefix permissions", .run = checkPrefixPermissions },
+    .{ .name = "Mirror overrides", .run = checkMirrorOverrides },
     .{ .name = "API reachable", .run = checkApiReachable },
     .{ .name = "Orphaned store entries", .run = checkOrphanedStore },
     .{ .name = "Missing kegs", .run = checkMissingKegs },
@@ -141,6 +147,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         .prefix = prefix,
         .io = ctx.io,
         .environ = ctx.environ,
+        .mirrors = ctx.mirrors,
     }, &checks);
 
     emitCaskHistoryReport(allocator, ctx.io, prefix);
@@ -474,8 +481,11 @@ fn checkPrefixPermissions(ctx: CheckCtx, name: []const u8) CheckResult {
 fn checkApiReachable(ctx: CheckCtx, name: []const u8) CheckResult {
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, ctx.allocator);
     defer http.deinit();
-    const status = http.head("https://formulae.brew.sh") catch {
-        printCheck(name, .warn_status, "Cannot reach formulae.brew.sh");
+    const probe_url = mirror_mod.hostProbeUrl(ctx.mirrors.api_base);
+    const status = http.head(probe_url) catch {
+        var buf: [512]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "Cannot reach {s}", .{probe_url}) catch "Cannot reach API host";
+        printCheck(name, .warn_status, msg);
         return .warn_status;
     };
     if (status >= 200 and status < 400) {
@@ -484,6 +494,39 @@ fn checkApiReachable(ctx: CheckCtx, name: []const u8) CheckResult {
     }
     printCheck(name, .warn_status, "API returned error status");
     return .warn_status;
+}
+
+/// Report active corporate-mirror overrides so operators can confirm
+/// `MALT_API_DOMAIN` / `MALT_BOTTLE_DOMAIN` (or the `HOMEBREW_*`
+/// fallbacks) landed correctly. Emits the override URLs as the row
+/// detail so the operator can eyeball the value without re-grepping
+/// their shell config.
+fn checkMirrorOverrides(ctx: CheckCtx, name: []const u8) CheckResult {
+    if (!ctx.mirrors.api_overridden and !ctx.mirrors.bottle_overridden) {
+        printCheck(name, .ok, "using upstream Homebrew defaults");
+        return .ok;
+    }
+    var buf: [1024]u8 = undefined;
+    const detail = formatMirrorOverrideDetail(&buf, ctx.mirrors);
+    printCheck(name, .ok, detail);
+    return .ok;
+}
+
+/// Pure formatter for `checkMirrorOverrides`'s detail string. `pub` so
+/// the doctor render test can pin the exact text without a process
+/// fixture.
+pub fn formatMirrorOverrideDetail(buf: []u8, mirrors: mirror_mod.Mirrors) []const u8 {
+    if (mirrors.api_overridden and mirrors.bottle_overridden) {
+        return std.fmt.bufPrint(buf, "API={s}, Bottle={s}", .{ mirrors.api_base, mirrors.bottle_base }) catch
+            "API + Bottle overrides active";
+    }
+    if (mirrors.api_overridden) {
+        return std.fmt.bufPrint(buf, "API={s}", .{mirrors.api_base}) catch "API override active";
+    }
+    if (mirrors.bottle_overridden) {
+        return std.fmt.bufPrint(buf, "Bottle={s}", .{mirrors.bottle_base}) catch "Bottle override active";
+    }
+    return "using upstream Homebrew defaults";
 }
 
 fn checkOrphanedStore(ctx: CheckCtx, name: []const u8) CheckResult {
@@ -928,4 +971,17 @@ test "resetFixHint: clears a previously-armed flag" {
     var captured = try captureFixEmit(testing.allocator, false);
     defer captured.deinit(testing.allocator);
     try testing.expect(!fixHintEmitted(captured.items));
+}
+
+test "checks table includes the mirror-overrides row" {
+    // Pins the wiring so a future shuffle of the static table can't
+    // silently drop the operator's only signal that a mirror is active.
+    var found = false;
+    for (checks) |c| {
+        if (std.mem.eql(u8, c.name, "Mirror overrides")) {
+            found = true;
+            break;
+        }
+    }
+    try testing.expect(found);
 }

--- a/src/cli/doctor/post_install.zig
+++ b/src/cli/doctor/post_install.zig
@@ -41,6 +41,7 @@ pub fn checkPostInstallStatus(ctx: *const AppCtx, allocator: std.mem.Allocator, 
     var cache_buf: [512]u8 = undefined;
     const cache_dir = std.fmt.bufPrint(&cache_buf, "{s}/cache", .{prefix}) catch return;
     var api = api_mod.BrewApi.init(io, allocator, &http, cache_dir);
+    api.base_url = ctx.mirrors.api_base;
 
     while (stmt.step() catch false) {
         const name_raw = stmt.columnText(0) orelse continue;

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -196,6 +196,7 @@ fn emitApiMetadata(
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
+    api.base_url = ctx.mirrors.api_base;
 
     if (!force_cask) {
         if (try emitApiFormula(allocator, &api, name, stdout, json_mode, colorize)) return true;

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -534,9 +534,11 @@ fn executeWithOpts(
     var cache_dir_buf: [512]u8 = undefined;
     const cache_dir = std.fmt.bufPrint(&cache_dir_buf, "{s}/cache", .{prefix}) catch return;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
+    api.base_url = ctx.mirrors.api_base;
 
     // Set up GHCR client
     var ghcr = ghcr_mod.GhcrClient.init(ctx.io, allocator, &http);
+    ghcr.base_url = ctx.mirrors.bottle_base;
     defer ghcr.deinit();
 
     // Set up store + linker

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -125,6 +125,9 @@ const FetchFormulaCtx = struct {
     arena: std.heap.ArenaAllocator,
     pool: *client_mod.HttpClientPool,
     cache_dir: []const u8,
+    /// Snapshot of `api.base_url` so workers inherit the mirror
+    /// override without re-reading the env on a worker thread.
+    api_base: []const u8,
     dep_name: []const u8,
     result: ?[]const u8 = null,
 
@@ -132,6 +135,7 @@ const FetchFormulaCtx = struct {
         const http = self.pool.acquire();
         defer self.pool.release(http);
         var local_api = api_mod.BrewApi.init(self.io, self.arena.allocator(), http, self.cache_dir);
+        local_api.base_url = self.api_base;
         self.result = local_api.fetchFormula(self.dep_name) catch null;
     }
 };
@@ -293,6 +297,7 @@ pub fn collectFormulaJobs(
                 .arena = std.heap.ArenaAllocator.init(ctx.worker_backing),
                 .pool = http_pool,
                 .cache_dir = api.cache_dir,
+                .api_base = api.base_url,
                 .dep_name = deps[i].name,
             };
         }
@@ -993,6 +998,7 @@ test "FetchFormulaCtx: arena backed by testing.allocator runs leak-clean across 
         .arena = std.heap.ArenaAllocator.init(std.testing.allocator),
         .pool = undefined,
         .cache_dir = "",
+        .api_base = "",
         .dep_name = "",
     };
     defer ctx_value.arena.deinit();

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -240,8 +240,10 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     var cache_dir_buf: [512]u8 = undefined;
     const cache_dir = std.fmt.bufPrint(&cache_dir_buf, "{s}/cache", .{prefix}) catch return;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
+    api.base_url = ctx.mirrors.api_base;
 
     var ghcr = ghcr_mod.GhcrClient.init(ctx.io, allocator, &http);
+    ghcr.base_url = ctx.mirrors.bottle_base;
     defer ghcr.deinit();
 
     var store = store_mod.Store.init(ctx.io, allocator, &db, prefix);

--- a/src/cli/migrate/parallel.zig
+++ b/src/cli/migrate/parallel.zig
@@ -137,7 +137,9 @@ fn worker(pool: *Pool) void {
         const http = pool.http_pool.acquire();
         defer pool.http_pool.release(http);
         var api = api_mod.BrewApi.init(io, a, http, pool.cache_dir);
+        api.base_url = pool.app_ctx.mirrors.api_base;
         var ghcr = ghcr_mod.GhcrClient.init(io, a, http);
+        ghcr.base_url = pool.app_ctx.mirrors.bottle_base;
         defer ghcr.deinit();
 
         const result = keg_mod.migrateKeg(pool.app_ctx, a, keg_name, .{

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -398,6 +398,7 @@ fn recomputeAndEmit(
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
+    api.base_url = ctx.mirrors.api_base;
 
     const workers_override = parseWorkersEnv(std.process.Environ.getPosix(ctx.environ, outdated_workers_env));
 

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -358,6 +358,9 @@ const WorkerCtx = struct {
     arena: std.heap.ArenaAllocator,
     pool: *client_mod.HttpClientPool,
     cache_dir: []const u8,
+    /// Snapshot of `ctx.mirrors.api_base` so workers inherit the
+    /// mirror override without re-walking the env on a worker thread.
+    api_base: []const u8,
     row: KegRow,
     kind: Kind,
     /// Result allocated on the **caller** allocator so it survives
@@ -389,6 +392,7 @@ fn runOne(out_alloc: std.mem.Allocator, wctx: *WorkerCtx) void {
 
     const arena_alloc = wctx.arena.allocator();
     var local_api = api_mod.BrewApi.init(wctx.io, arena_alloc, http, wctx.cache_dir);
+    local_api.base_url = wctx.api_base;
     const latest = upstreamLatest(arena_alloc, &local_api, wctx.io, wctx.environ, wctx.kind, wctx.row) orelse return;
     if (std.mem.eql(u8, wctx.row.version, latest)) return;
 
@@ -426,6 +430,7 @@ fn runPool(
         .arena = std.heap.ArenaAllocator.init(std.heap.smp_allocator),
         .pool = &http_pool,
         .cache_dir = cache_dir,
+        .api_base = ctx.mirrors.api_base,
         .row = kegs[i],
         .kind = kind,
     };
@@ -473,6 +478,7 @@ test "WorkerCtx: per-row arena accepts testing.allocator backing without leaking
         .arena = std.heap.ArenaAllocator.init(std.testing.allocator),
         .pool = undefined,
         .cache_dir = "",
+        .api_base = "",
         .row = .{ .name = "", .version = "" },
         .kind = .formula,
     };

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -129,6 +129,7 @@ fn ephemeralRun(
     var cache_buf: [512]u8 = undefined;
     const cache_dir = std.fmt.bufPrint(&cache_buf, "{s}/cache", .{prefix}) catch return;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
+    api.base_url = ctx.mirrors.api_base;
 
     const formula_json = api.fetchFormula(pkg_name) catch {
         output.err("Formula '{s}' not found", .{pkg_name});
@@ -193,6 +194,7 @@ fn ephemeralRun(
     }
 
     var ghcr = ghcr_mod.GhcrClient.init(ctx.io, allocator, &http);
+    ghcr.base_url = ctx.mirrors.bottle_base;
     defer ghcr.deinit();
 
     // Cache slot under {cache} so `mt purge --cache` wipes it; a tmp dir otherwise.

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -579,6 +579,7 @@ fn runKindIsolated(
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
+    api.base_url = ctx.mirrors.api_base;
     var r: KindResults = .{};
     r.exact = api.exists(query, kind) catch false;
     if (api.fetchNamesIndex(kind)) |idx| {

--- a/src/cli/update.zig
+++ b/src/cli/update.zig
@@ -81,6 +81,7 @@ fn refreshSnapshot(ctx: *const AppCtx, allocator: std.mem.Allocator, cache_dir: 
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
+    api.base_url = ctx.mirrors.api_base;
 
     try outdated_mod.refreshSnapshot(ctx, allocator, &db, &api, cache_dir, null);
 }

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -120,6 +120,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     var cache_dir_buf: [512]u8 = undefined;
     const cache_dir = std.fmt.bufPrint(&cache_dir_buf, "{s}/cache", .{prefix}) catch return;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
+    api.base_url = ctx.mirrors.api_base;
 
     // Per-package errors must not be swallowed: a batch that fails every
     // item used to exit 0, hiding the failure from CI. We aggregate here
@@ -298,6 +299,7 @@ fn upgradeFormula(
     // pipeline. One primitive means upgrade inherits the install path's
     // retry-with-backoff and `:any` skip-relocation hot path for free.
     var ghcr = ghcr_mod.GhcrClient.init(ctx.io, allocator, http);
+    ghcr.base_url = ctx.mirrors.bottle_base;
     defer ghcr.deinit();
 
     var store = store_mod.Store.init(ctx.io, allocator, db, prefix);

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -80,6 +80,7 @@ pub const patcher = @import("macho/patcher.zig");
 pub const api = @import("net/api.zig");
 pub const client = @import("net/client.zig");
 pub const ghcr = @import("net/ghcr.zig");
+pub const mirror = @import("net/mirror.zig");
 pub const text_replace = @import("text_replace.zig");
 pub const color = @import("ui/color.zig");
 pub const output = @import("ui/output.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -31,7 +31,9 @@ const uses = @import("cli/uses.zig");
 const version_update = @import("cli/version_update.zig");
 const which_cmd = @import("cli/which.zig");
 const signals = @import("core/signals.zig");
+const mirror_mod = @import("net/mirror.zig");
 const color_mod = @import("ui/color.zig");
+const output_mod = @import("ui/output.zig");
 const progress_mod = @import("ui/progress.zig");
 const notifier = @import("update/notifier.zig");
 const version_mod = @import("version.zig");
@@ -325,16 +327,32 @@ pub fn main(init: std.process.Init.Minimal) !void {
     // Single Threaded io for the whole process; outlives the ctx it backs.
     var threaded: std.Io.Threaded = .init(backing, .{ .environ = init.environ });
     defer threaded.deinit();
+
+    // Resolve corporate-mirror overrides once, before any net/* call
+    // site can read the env. A non-https override is fatal — refusing
+    // it here keeps the redirect-downgrade guard in `net/client.zig`
+    // load-bearing.
+    const mirrors = mirror_mod.resolve(init.environ) catch |e| switch (e) {
+        error.NonHttpsOverride => {
+            const stderr = std.Io.File.stderr();
+            stderr.writeStreamingAll(
+                threaded.io(),
+                "malt: MALT_API_DOMAIN / MALT_BOTTLE_DOMAIN (and HOMEBREW_* fallbacks) must use https://\n",
+            ) catch {};
+            std.process.exit(1);
+        },
+    };
+
     const ctx: AppCtx = .{
         .io = threaded.io(),
         .environ = init.environ,
         .stdout = std.Io.File.stdout(),
         .stderr = std.Io.File.stderr(),
+        .mirrors = mirrors,
     };
 
     // Seed the ui package state once so output/progress/color stop
     // pulling io/environ/stdio from module-level globals.
-    const output_mod = @import("ui/output.zig");
     output_mod.setRuntime(ctx.io, ctx.environ, ctx.stdout, ctx.stderr);
     progress_mod.setRuntime(ctx.io, ctx.stderr);
     // `MALT_PROGRESS` and CI auto-detect resolve here; per-bar call sites

--- a/src/net/api.zig
+++ b/src/net/api.zig
@@ -4,8 +4,8 @@
 const std = @import("std");
 const atomic = @import("../fs/atomic.zig");
 const client_mod = @import("client.zig");
+const mirror_mod = @import("mirror.zig");
 
-const base_url = "https://formulae.brew.sh/api";
 const cache_ttl_secs: i64 = 300; // 5 minutes
 
 /// Names-index TTL. The full Homebrew name list changes on the order of days
@@ -123,6 +123,10 @@ pub const BrewApi = struct {
     allocator: std.mem.Allocator,
     http: *client_mod.HttpClient,
     cache_dir: []const u8,
+    /// Metadata-API base URL. Mutable post-init so cli/ call sites can
+    /// drop in `ctx.mirrors.api_base`; mirror precedence + HTTPS
+    /// validation are enforced upstream by `mirror.resolve`.
+    base_url: []const u8 = mirror_mod.default_api_base_url,
 
     pub fn init(io: std.Io, allocator: std.mem.Allocator, http: *client_mod.HttpClient, cache_dir: []const u8) BrewApi {
         return .{
@@ -133,12 +137,34 @@ pub const BrewApi = struct {
         };
     }
 
+    /// Build the formula JSON URL for `name`. Pure — `pub` so tests
+    /// can pin the override-honouring shape without driving the cache.
+    pub fn buildFormulaUrl(buf: []u8, base: []const u8, name: []const u8) ApiError![]const u8 {
+        return std.fmt.bufPrint(buf, "{s}/formula/{s}.json", .{ base, name }) catch
+            ApiError.OutOfMemory;
+    }
+
+    /// Build the cask JSON URL for `token`. Pure — see `buildFormulaUrl`.
+    pub fn buildCaskUrl(buf: []u8, base: []const u8, token: []const u8) ApiError![]const u8 {
+        return std.fmt.bufPrint(buf, "{s}/cask/{s}.json", .{ base, token }) catch
+            ApiError.OutOfMemory;
+    }
+
+    /// Build the names-index URL for `kind`. Pure — see `buildFormulaUrl`.
+    pub fn buildNamesIndexUrl(buf: []u8, base: []const u8, kind: Kind) ApiError![]const u8 {
+        const suffix: []const u8 = switch (kind) {
+            .formula => "/formula.json",
+            .cask => "/cask.json",
+        };
+        return std.fmt.bufPrint(buf, "{s}{s}", .{ base, suffix }) catch
+            ApiError.OutOfMemory;
+    }
+
     /// Fetch formula JSON. Returns caller-owned bytes.
     pub fn fetchFormula(self: *BrewApi, name: []const u8) ApiError![]const u8 {
         try validateName(name);
         var url_buf: [512]u8 = undefined;
-        const url = std.fmt.bufPrint(&url_buf, base_url ++ "/formula/{s}.json", .{name}) catch
-            return ApiError.OutOfMemory;
+        const url = try buildFormulaUrl(&url_buf, self.base_url, name);
         return self.fetchCached(name, url, "formula_");
     }
 
@@ -146,8 +172,7 @@ pub const BrewApi = struct {
     pub fn fetchCask(self: *BrewApi, token: []const u8) ApiError![]const u8 {
         try validateName(token);
         var url_buf: [512]u8 = undefined;
-        const url = std.fmt.bufPrint(&url_buf, base_url ++ "/cask/{s}.json", .{token}) catch
-            return ApiError.OutOfMemory;
+        const url = try buildCaskUrl(&url_buf, self.base_url, token);
         return self.fetchCached(token, url, "cask_");
     }
 
@@ -222,10 +247,8 @@ pub const BrewApi = struct {
         };
         if (self.readNamesIndex(key)) |cached| return cached;
 
-        const url: []const u8 = switch (kind) {
-            .formula => base_url ++ "/formula.json",
-            .cask => base_url ++ "/cask.json",
-        };
+        var url_buf: [512]u8 = undefined;
+        const url = try buildNamesIndexUrl(&url_buf, self.base_url, kind);
         var resp = self.http.get(url) catch return ApiError.ApiUnreachable;
         defer resp.deinit();
         if (resp.status != 200) return ApiError.ApiUnreachable;
@@ -466,3 +489,39 @@ pub const BrewApi = struct {
         return total;
     }
 };
+
+// ── inline tests: pure URL builders + base_url default ──────────────────
+
+const testing = std.testing;
+
+test "BrewApi.init defaults base_url to the upstream Homebrew API" {
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    const api = BrewApi.init(std.Options.debug_io, testing.allocator, &http, "/tmp/mt_api_base_default");
+    try testing.expectEqualStrings(mirror_mod.default_api_base_url, api.base_url);
+}
+
+test "buildFormulaUrl threads the override base into the path" {
+    var buf: [256]u8 = undefined;
+    const url = try BrewApi.buildFormulaUrl(&buf, "https://mirror.example.com/api", "wget");
+    try testing.expectEqualStrings("https://mirror.example.com/api/formula/wget.json", url);
+}
+
+test "buildCaskUrl threads the override base into the path" {
+    var buf: [256]u8 = undefined;
+    const url = try BrewApi.buildCaskUrl(&buf, "https://mirror.example.com/api", "firefox");
+    try testing.expectEqualStrings("https://mirror.example.com/api/cask/firefox.json", url);
+}
+
+test "buildNamesIndexUrl emits formula vs cask paths against the override" {
+    var buf: [256]u8 = undefined;
+    const f = try BrewApi.buildNamesIndexUrl(&buf, "https://mirror.example.com/api", .formula);
+    try testing.expectEqualStrings("https://mirror.example.com/api/formula.json", f);
+    const c = try BrewApi.buildNamesIndexUrl(&buf, "https://mirror.example.com/api", .cask);
+    try testing.expectEqualStrings("https://mirror.example.com/api/cask.json", c);
+}
+
+test "buildFormulaUrl returns OutOfMemory when the buffer can't hold the URL" {
+    var tiny: [4]u8 = undefined;
+    try testing.expectError(ApiError.OutOfMemory, BrewApi.buildFormulaUrl(&tiny, "https://example.com", "wget"));
+}

--- a/src/net/ghcr.zig
+++ b/src/net/ghcr.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 
 const client_mod = @import("client.zig");
+const mirror_mod = @import("mirror.zig");
 
 pub const GhcrError = error{
     TokenFetchFailed,
@@ -32,6 +33,11 @@ pub const GhcrClient = struct {
     cached_scopes: std.StringHashMapUnmanaged(void),
     token_expiry: i64,
     mutex: std.Io.Mutex,
+    /// Bottle/registry base URL (no trailing slash). Mutable post-init
+    /// so cli/ call sites can drop in `ctx.mirrors.bottle_base`;
+    /// mirror precedence + HTTPS validation are enforced upstream by
+    /// `mirror.resolve`.
+    base_url: []const u8 = mirror_mod.default_bottle_base_url,
 
     pub fn init(io: std.Io, allocator: std.mem.Allocator, http: *client_mod.HttpClient) GhcrClient {
         return .{
@@ -73,18 +79,27 @@ pub const GhcrClient = struct {
         return self.cached_scopes.contains(repo);
     }
 
-    /// Build the GHCR token URL covering every repo in `repos`. One
-    /// `scope=repository:{repo}:pull` query param per repo; GHCR
-    /// returns a token valid for all of them. Caller owns the result.
-    pub fn buildTokenUrl(allocator: std.mem.Allocator, repos: []const []const u8) ![]u8 {
+    /// Build the registry token URL covering every repo in `repos`. One
+    /// `scope=repository:{repo}:pull` query param per repo; the registry
+    /// returns a token valid for all of them. `base` lets corporate
+    /// mirrors point at their own `/token` endpoint. Caller owns the
+    /// result.
+    pub fn buildTokenUrl(allocator: std.mem.Allocator, base: []const u8, repos: []const []const u8) ![]u8 {
         var aw: std.Io.Writer.Allocating = .init(allocator);
         errdefer aw.deinit();
-        try aw.writer.writeAll("https://ghcr.io/token?");
+        try aw.writer.print("{s}/token?", .{base});
         for (repos, 0..) |repo, i| {
             if (i != 0) try aw.writer.writeByte('&');
             try aw.writer.print("scope=repository:{s}:pull", .{repo});
         }
         return aw.toOwnedSlice();
+    }
+
+    /// Build the registry blob URL for `(repo, digest)`. Pure, `pub`
+    /// so tests can pin the override-honouring shape.
+    pub fn buildBlobUrl(buf: []u8, base: []const u8, repo: []const u8, digest: []const u8) GhcrError![]const u8 {
+        return std.fmt.bufPrint(buf, "{s}/v2/{s}/blobs/{s}", .{ base, repo, digest }) catch
+            GhcrError.OutOfMemory;
     }
 
     /// Fetch one token covering every repo in `repos` with a single
@@ -109,7 +124,7 @@ pub const GhcrClient = struct {
 
         self.clearCache();
 
-        const url = buildTokenUrl(self.allocator, repos) catch return GhcrError.OutOfMemory;
+        const url = buildTokenUrl(self.allocator, self.base_url, repos) catch return GhcrError.OutOfMemory;
         defer self.allocator.free(url);
 
         var resp = http.get(url) catch return GhcrError.TokenFetchFailed;
@@ -173,7 +188,7 @@ pub const GhcrClient = struct {
         }
 
         const repos = [_][]const u8{repo};
-        const url = buildTokenUrl(self.allocator, &repos) catch
+        const url = buildTokenUrl(self.allocator, self.base_url, &repos) catch
             return GhcrError.OutOfMemory;
         defer self.allocator.free(url);
 
@@ -218,8 +233,7 @@ pub const GhcrClient = struct {
         defer self.allocator.free(token);
 
         var url_buf: [512]u8 = undefined;
-        const url = std.fmt.bufPrint(&url_buf, "https://ghcr.io/v2/{s}/blobs/{s}", .{ repo, digest }) catch
-            return GhcrError.OutOfMemory;
+        const url = try buildBlobUrl(&url_buf, self.base_url, repo, digest);
 
         var auth_buf: [2048]u8 = undefined;
         const auth_value = std.fmt.bufPrint(&auth_buf, "Bearer {s}", .{token}) catch
@@ -269,4 +283,43 @@ pub fn extractTokenField(allocator: std.mem.Allocator, json_bytes: []const u8) !
     };
 
     return allocator.dupe(u8, token_str);
+}
+
+// ── inline tests: base_url default + URL builders honour overrides ──
+
+const testing = std.testing;
+
+test "GhcrClient.init defaults base_url to the upstream GHCR host" {
+    var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
+    defer pool.deinit();
+    const http = pool.acquire();
+    defer pool.release(http);
+
+    var g = GhcrClient.init(std.Options.debug_io, testing.allocator, http);
+    defer g.deinit();
+
+    try testing.expectEqualStrings(mirror_mod.default_bottle_base_url, g.base_url);
+}
+
+test "buildTokenUrl emits scope params against a mirror base URL" {
+    const repos = [_][]const u8{ "homebrew/core/wget", "homebrew/core/tree" };
+    const url = try GhcrClient.buildTokenUrl(testing.allocator, "https://reg.example.com", &repos);
+    defer testing.allocator.free(url);
+    try testing.expectEqualStrings(
+        "https://reg.example.com/token?" ++
+            "scope=repository:homebrew/core/wget:pull&" ++
+            "scope=repository:homebrew/core/tree:pull",
+        url,
+    );
+}
+
+test "buildBlobUrl threads the override base into the blob path" {
+    var buf: [256]u8 = undefined;
+    const url = try GhcrClient.buildBlobUrl(&buf, "https://reg.example.com", "homebrew/core/wget", "sha256:abc");
+    try testing.expectEqualStrings("https://reg.example.com/v2/homebrew/core/wget/blobs/sha256:abc", url);
+}
+
+test "buildBlobUrl returns OutOfMemory when the buffer can't hold the URL" {
+    var tiny: [8]u8 = undefined;
+    try testing.expectError(GhcrError.OutOfMemory, GhcrClient.buildBlobUrl(&tiny, "https://reg.example.com", "homebrew/core/wget", "sha256:abc"));
 }

--- a/src/net/mirror.zig
+++ b/src/net/mirror.zig
@@ -1,0 +1,273 @@
+//! malt — corporate-mirror env resolution.
+//! Reads `MALT_API_DOMAIN` / `MALT_BOTTLE_DOMAIN` once (with the
+//! `HOMEBREW_*` peers as fallbacks) so every net/* call site can
+//! consume a single resolved base URL instead of re-reading the env.
+//! HTTPS-only by design: a plaintext mirror would weaken the
+//! redirect-downgrade guard in `net/client.zig`.
+
+const std = @import("std");
+
+pub const default_api_base_url: []const u8 = "https://formulae.brew.sh/api";
+pub const default_bottle_base_url: []const u8 = "https://ghcr.io";
+
+pub const Error = error{NonHttpsOverride};
+
+/// Process-wide resolved snapshot. Built once by `main` and threaded
+/// through `AppCtx`; per-call sites read `api_base` / `bottle_base`
+/// directly. The `*_overridden` flags drive `mt doctor`'s mirror row
+/// without re-walking the env.
+pub const Mirrors = struct {
+    api_base: []const u8 = default_api_base_url,
+    bottle_base: []const u8 = default_bottle_base_url,
+    api_overridden: bool = false,
+    bottle_overridden: bool = false,
+};
+
+/// True iff `url` is a syntactically valid `https://...` URL. We reject
+/// every other scheme — even `http://` — because the redirect guard in
+/// `net/client.zig` would otherwise have to relax for mirror traffic.
+pub fn isHttpsUrl(url: []const u8) bool {
+    if (!std.mem.startsWith(u8, url, "https://")) return false;
+    return url.len > "https://".len;
+}
+
+/// Resolve a single override knob: `primary` wins, `fallback` is read
+/// only if `primary` is unset. Returns `null` when neither is set (or
+/// when the value is whitespace-only, so a leftover `MALT_API_DOMAIN=`
+/// in a shell rc doesn't poison the run). Trims trailing slashes so
+/// every URL builder can `{base}/path` without doubling up. Validates
+/// HTTPS at the boundary so downstream consumers trust the slice.
+fn resolveOverride(
+    environ: std.process.Environ,
+    primary: []const u8,
+    fallback: []const u8,
+) Error!?[]const u8 {
+    const raw_z = std.process.Environ.getPosix(environ, primary) orelse
+        std.process.Environ.getPosix(environ, fallback) orelse
+        return null;
+    const trimmed = std.mem.trim(u8, std.mem.sliceTo(raw_z, 0), &std.ascii.whitespace);
+    if (trimmed.len == 0) return null;
+    const normalized = std.mem.trimEnd(u8, trimmed, "/");
+    if (!isHttpsUrl(normalized)) return Error.NonHttpsOverride;
+    return normalized;
+}
+
+/// Resolve the metadata-API base URL. Honours `MALT_API_DOMAIN`,
+/// falls back to `HOMEBREW_API_DOMAIN`. Returns the default when
+/// neither is set.
+pub fn resolveApiBase(environ: std.process.Environ) Error![]const u8 {
+    const ov = try resolveOverride(environ, "MALT_API_DOMAIN", "HOMEBREW_API_DOMAIN");
+    return ov orelse default_api_base_url;
+}
+
+/// Resolve the bottle/registry base URL. Honours `MALT_BOTTLE_DOMAIN`,
+/// falls back to `HOMEBREW_BOTTLE_DOMAIN`. Returns the default when
+/// neither is set.
+pub fn resolveBottleBase(environ: std.process.Environ) Error![]const u8 {
+    const ov = try resolveOverride(environ, "MALT_BOTTLE_DOMAIN", "HOMEBREW_BOTTLE_DOMAIN");
+    return ov orelse default_bottle_base_url;
+}
+
+/// One-shot resolution of every mirror knob. Called from `main` after
+/// `AppCtx` is built; the result is owned by `AppCtx.mirrors` and the
+/// strings borrow from the parent process environ (lifetime ≥ AppCtx).
+pub fn resolve(environ: std.process.Environ) Error!Mirrors {
+    const api_ov = try resolveOverride(environ, "MALT_API_DOMAIN", "HOMEBREW_API_DOMAIN");
+    const bot_ov = try resolveOverride(environ, "MALT_BOTTLE_DOMAIN", "HOMEBREW_BOTTLE_DOMAIN");
+    return .{
+        .api_base = api_ov orelse default_api_base_url,
+        .bottle_base = bot_ov orelse default_bottle_base_url,
+        .api_overridden = api_ov != null,
+        .bottle_overridden = bot_ov != null,
+    };
+}
+
+/// Best-effort host probe URL for `mt doctor`'s API-reachable check.
+/// Strips the path component so a HEAD on `<scheme>://<host>` exercises
+/// the mirror endpoint without paying for `/formula.json`. Leaves
+/// host-only URLs untouched.
+pub fn hostProbeUrl(base_url: []const u8) []const u8 {
+    if (!std.mem.startsWith(u8, base_url, "https://")) return base_url;
+    const after = base_url["https://".len..];
+    const slash = std.mem.indexOfScalar(u8, after, '/') orelse return base_url;
+    return base_url[0 .. "https://".len + slash];
+}
+
+// ── tests ────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "isHttpsUrl accepts https URLs with a host" {
+    try testing.expect(isHttpsUrl("https://example.com"));
+    try testing.expect(isHttpsUrl("https://example.com/api"));
+    try testing.expect(isHttpsUrl("https://example.com:8443/path"));
+}
+
+test "isHttpsUrl rejects every non-https scheme" {
+    try testing.expect(!isHttpsUrl("http://example.com"));
+    try testing.expect(!isHttpsUrl("ftp://example.com"));
+    try testing.expect(!isHttpsUrl("ws://example.com"));
+    try testing.expect(!isHttpsUrl(""));
+    try testing.expect(!isHttpsUrl("https://"));
+}
+
+test "resolveApiBase returns the default when no env is set" {
+    const got = try resolveApiBase(std.process.Environ.empty);
+    try testing.expectEqualStrings(default_api_base_url, got);
+}
+
+test "resolveApiBase honours MALT_API_DOMAIN" {
+    const entries = [_:null]?[*:0]const u8{"MALT_API_DOMAIN=https://mirror.example.com/api".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    const got = try resolveApiBase(env);
+    try testing.expectEqualStrings("https://mirror.example.com/api", got);
+}
+
+test "resolveApiBase falls back to HOMEBREW_API_DOMAIN" {
+    const entries = [_:null]?[*:0]const u8{"HOMEBREW_API_DOMAIN=https://hb-mirror.example.com/api".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    const got = try resolveApiBase(env);
+    try testing.expectEqualStrings("https://hb-mirror.example.com/api", got);
+}
+
+test "resolveApiBase prefers MALT_* over HOMEBREW_* when both are set" {
+    const entries = [_:null]?[*:0]const u8{
+        "MALT_API_DOMAIN=https://malt.example.com/api".ptr,
+        "HOMEBREW_API_DOMAIN=https://hb.example.com/api".ptr,
+    };
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..2 :null] } };
+    const got = try resolveApiBase(env);
+    try testing.expectEqualStrings("https://malt.example.com/api", got);
+}
+
+test "resolveApiBase rejects non-https overrides" {
+    const entries = [_:null]?[*:0]const u8{"MALT_API_DOMAIN=http://insecure.example.com/api".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    try testing.expectError(Error.NonHttpsOverride, resolveApiBase(env));
+}
+
+test "resolveApiBase treats an empty value as unset and returns the default" {
+    const entries = [_:null]?[*:0]const u8{"MALT_API_DOMAIN=".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    const got = try resolveApiBase(env);
+    try testing.expectEqualStrings(default_api_base_url, got);
+}
+
+test "resolveApiBase treats whitespace-only as unset" {
+    // A leftover `MALT_API_DOMAIN=   ` line in a shell rc must not
+    // surface as NonHttpsOverride — that error confuses operators who
+    // never intended to set the knob.
+    const entries = [_:null]?[*:0]const u8{"MALT_API_DOMAIN=   \t".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    const got = try resolveApiBase(env);
+    try testing.expectEqualStrings(default_api_base_url, got);
+}
+
+test "resolveApiBase strips trailing slashes so URL builders don't double up" {
+    const entries = [_:null]?[*:0]const u8{"MALT_API_DOMAIN=https://mirror.example.com/api/".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    const got = try resolveApiBase(env);
+    try testing.expectEqualStrings("https://mirror.example.com/api", got);
+}
+
+test "resolveApiBase strips multiple trailing slashes" {
+    const entries = [_:null]?[*:0]const u8{"MALT_API_DOMAIN=https://mirror.example.com/api///".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    const got = try resolveApiBase(env);
+    try testing.expectEqualStrings("https://mirror.example.com/api", got);
+}
+
+test "resolveApiBase trims surrounding whitespace before validation" {
+    const entries = [_:null]?[*:0]const u8{"MALT_API_DOMAIN=  https://mirror.example.com/api  ".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    const got = try resolveApiBase(env);
+    try testing.expectEqualStrings("https://mirror.example.com/api", got);
+}
+
+test "resolveBottleBase strips trailing slashes" {
+    // GHCR blob URLs are built as `{base}/v2/{repo}/blobs/{digest}` —
+    // a trailing slash on `base` would land a `//v2/...` path that
+    // most registries serve as 404.
+    const entries = [_:null]?[*:0]const u8{"MALT_BOTTLE_DOMAIN=https://reg.example.com/".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    const got = try resolveBottleBase(env);
+    try testing.expectEqualStrings("https://reg.example.com", got);
+}
+
+test "resolveBottleBase returns the default when no env is set" {
+    const got = try resolveBottleBase(std.process.Environ.empty);
+    try testing.expectEqualStrings(default_bottle_base_url, got);
+}
+
+test "resolveBottleBase honours MALT_BOTTLE_DOMAIN" {
+    const entries = [_:null]?[*:0]const u8{"MALT_BOTTLE_DOMAIN=https://reg.example.com".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    const got = try resolveBottleBase(env);
+    try testing.expectEqualStrings("https://reg.example.com", got);
+}
+
+test "resolveBottleBase falls back to HOMEBREW_BOTTLE_DOMAIN" {
+    const entries = [_:null]?[*:0]const u8{"HOMEBREW_BOTTLE_DOMAIN=https://hb-reg.example.com".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    const got = try resolveBottleBase(env);
+    try testing.expectEqualStrings("https://hb-reg.example.com", got);
+}
+
+test "resolveBottleBase prefers MALT_* over HOMEBREW_*" {
+    const entries = [_:null]?[*:0]const u8{
+        "MALT_BOTTLE_DOMAIN=https://malt-reg.example.com".ptr,
+        "HOMEBREW_BOTTLE_DOMAIN=https://hb-reg.example.com".ptr,
+    };
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..2 :null] } };
+    const got = try resolveBottleBase(env);
+    try testing.expectEqualStrings("https://malt-reg.example.com", got);
+}
+
+test "resolveBottleBase rejects non-https overrides" {
+    const entries = [_:null]?[*:0]const u8{"MALT_BOTTLE_DOMAIN=http://reg.example.com".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    try testing.expectError(Error.NonHttpsOverride, resolveBottleBase(env));
+}
+
+test "resolve returns defaults with both *_overridden flags false on empty env" {
+    const got = try resolve(std.process.Environ.empty);
+    try testing.expectEqualStrings(default_api_base_url, got.api_base);
+    try testing.expectEqualStrings(default_bottle_base_url, got.bottle_base);
+    try testing.expect(!got.api_overridden);
+    try testing.expect(!got.bottle_overridden);
+}
+
+test "resolve flags overridden bases when both env knobs are set" {
+    const entries = [_:null]?[*:0]const u8{
+        "MALT_API_DOMAIN=https://m-api.example.com".ptr,
+        "MALT_BOTTLE_DOMAIN=https://m-reg.example.com".ptr,
+    };
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..2 :null] } };
+    const got = try resolve(env);
+    try testing.expectEqualStrings("https://m-api.example.com", got.api_base);
+    try testing.expectEqualStrings("https://m-reg.example.com", got.bottle_base);
+    try testing.expect(got.api_overridden);
+    try testing.expect(got.bottle_overridden);
+}
+
+test "resolve surfaces a non-https override regardless of which knob trips it" {
+    const entries = [_:null]?[*:0]const u8{"MALT_BOTTLE_DOMAIN=http://reg.example.com".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    try testing.expectError(Error.NonHttpsOverride, resolve(env));
+}
+
+test "hostProbeUrl strips the path component" {
+    try testing.expectEqualStrings("https://formulae.brew.sh", hostProbeUrl("https://formulae.brew.sh/api"));
+    try testing.expectEqualStrings("https://mirror.example.com:8443", hostProbeUrl("https://mirror.example.com:8443/path/extra"));
+}
+
+test "hostProbeUrl is a no-op for host-only URLs" {
+    try testing.expectEqualStrings("https://example.com", hostProbeUrl("https://example.com"));
+}
+
+test "hostProbeUrl leaves non-https inputs untouched (defensive)" {
+    // We never feed non-https URLs in production (the resolver rejects
+    // them), but the helper stays total so a future caller can't trip
+    // an unreachable.
+    try testing.expectEqualStrings("ftp://example.com/x", hostProbeUrl("ftp://example.com/x"));
+}

--- a/tests/api_test.zig
+++ b/tests/api_test.zig
@@ -104,6 +104,48 @@ test "fetchFormula returns a pre-seeded cache without touching the network" {
     try testing.expectEqualStrings(json, out);
 }
 
+test "BrewApi honours a base_url override and threads it through fetchFormula's URL" {
+    // We can't easily intercept the live HTTP call inside fetchFormula
+    // without a fake client, so split the assertion: pin the override
+    // on the struct, then exercise the pure URL builder against the
+    // same value to prove the path malt would request matches the
+    // mirror.
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("fetchformula_override");
+    defer dir.deinit();
+
+    var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
+    api.base_url = "https://mirror.example.com/api";
+    try testing.expectEqualStrings("https://mirror.example.com/api", api.base_url);
+
+    var url_buf: [256]u8 = undefined;
+    const url = try api_mod.BrewApi.buildFormulaUrl(&url_buf, api.base_url, "wget");
+    try testing.expectEqualStrings("https://mirror.example.com/api/formula/wget.json", url);
+}
+
+test "BrewApi cache lookup is shared between the default and the override" {
+    // Pre-seeded cache hits short-circuit before the URL is built, so a
+    // warm cache works regardless of which base_url is active. Pins the
+    // contract that flipping the env knob doesn't invalidate prior cache
+    // bytes for the same formula name.
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("fetchformula_shared_cache");
+    defer dir.deinit();
+
+    const json =
+        \\{"name":"wget","versions":{"stable":"1.0"}}
+    ;
+    try dir.writeCacheFile("formula_wget.json", json);
+
+    var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
+    api.base_url = "https://mirror.example.com/api";
+    const out = try api.fetchFormula("wget");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings(json, out);
+}
+
 test "fetchCask returns a pre-seeded cache without touching the network" {
     var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
     defer http.deinit();

--- a/tests/doctor_render_test.zig
+++ b/tests/doctor_render_test.zig
@@ -146,6 +146,56 @@ test "null detail omits the em-dash entirely" {
     try testing.expect(std.mem.indexOf(u8, s, "-") == null);
 }
 
+// ── mirror-override reporting ───────────────────────────────────────
+//
+// Pin the `mt doctor` row that surfaces active corporate-mirror knobs.
+// Pure formatter so the integration assertion stays hermetic — no env
+// fiddling, no AppCtx fixture.
+
+const mirror_mod = @import("malt").mirror;
+
+test "formatMirrorOverrideDetail reports both overrides when both are active" {
+    var buf: [512]u8 = undefined;
+    const detail = doctor.formatMirrorOverrideDetail(&buf, .{
+        .api_base = "https://m-api.example.com",
+        .bottle_base = "https://m-reg.example.com",
+        .api_overridden = true,
+        .bottle_overridden = true,
+    });
+    try testing.expectEqualStrings(
+        "API=https://m-api.example.com, Bottle=https://m-reg.example.com",
+        detail,
+    );
+}
+
+test "formatMirrorOverrideDetail reports the API override on its own" {
+    var buf: [512]u8 = undefined;
+    const detail = doctor.formatMirrorOverrideDetail(&buf, .{
+        .api_base = "https://m-api.example.com",
+        .bottle_base = mirror_mod.default_bottle_base_url,
+        .api_overridden = true,
+        .bottle_overridden = false,
+    });
+    try testing.expectEqualStrings("API=https://m-api.example.com", detail);
+}
+
+test "formatMirrorOverrideDetail reports the bottle override on its own" {
+    var buf: [512]u8 = undefined;
+    const detail = doctor.formatMirrorOverrideDetail(&buf, .{
+        .api_base = mirror_mod.default_api_base_url,
+        .bottle_base = "https://m-reg.example.com",
+        .api_overridden = false,
+        .bottle_overridden = true,
+    });
+    try testing.expectEqualStrings("Bottle=https://m-reg.example.com", detail);
+}
+
+test "formatMirrorOverrideDetail falls back to a non-overridden message" {
+    var buf: [512]u8 = undefined;
+    const detail = doctor.formatMirrorOverrideDetail(&buf, .{});
+    try testing.expectEqualStrings("using upstream Homebrew defaults", detail);
+}
+
 // ── countMissingLocalSources ────────────────────────────────────────
 //
 // The local-source check walks `kegs WHERE tap='local'` and reports

--- a/tests/ghcr_test.zig
+++ b/tests/ghcr_test.zig
@@ -43,6 +43,35 @@ test "GhcrClient.init/deinit does not leak and starts without cached token" {
     try testing.expectEqual(@as(i64, 0), g.token_expiry);
 }
 
+test "GhcrClient honours a base_url override across token and blob URLs" {
+    // Pins the override on the struct, then exercises the pure URL
+    // builders against the same value to prove the registry endpoints
+    // malt would hit match the mirror.
+    var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
+    defer pool.deinit();
+    const http = pool.acquire();
+    defer pool.release(http);
+
+    var g = ghcr.GhcrClient.init(std.Options.debug_io, testing.allocator, http);
+    defer g.deinit();
+    g.base_url = "https://reg.example.com";
+
+    const repos = [_][]const u8{"homebrew/core/wget"};
+    const token_url = try ghcr.GhcrClient.buildTokenUrl(testing.allocator, g.base_url, &repos);
+    defer testing.allocator.free(token_url);
+    try testing.expectEqualStrings(
+        "https://reg.example.com/token?scope=repository:homebrew/core/wget:pull",
+        token_url,
+    );
+
+    var blob_buf: [256]u8 = undefined;
+    const blob_url = try ghcr.GhcrClient.buildBlobUrl(&blob_buf, g.base_url, "homebrew/core/wget", "sha256:deadbeef");
+    try testing.expectEqualStrings(
+        "https://reg.example.com/v2/homebrew/core/wget/blobs/sha256:deadbeef",
+        blob_url,
+    );
+}
+
 // S10: GHCR multi-scope token prefetch. GHCR's /token endpoint accepts
 // multiple `scope=repository:<repo>:pull` query params and returns one
 // token valid for every requested scope. `buildTokenUrl` is the pure
@@ -53,7 +82,7 @@ test "GhcrClient.init/deinit does not leak and starts without cached token" {
 
 test "buildTokenUrl emits one scope param for a single repo" {
     const repos = [_][]const u8{"homebrew/core/wget"};
-    const url = try ghcr.GhcrClient.buildTokenUrl(testing.allocator, &repos);
+    const url = try ghcr.GhcrClient.buildTokenUrl(testing.allocator, "https://ghcr.io", &repos);
     defer testing.allocator.free(url);
     try testing.expectEqualStrings(
         "https://ghcr.io/token?scope=repository:homebrew/core/wget:pull",
@@ -67,7 +96,7 @@ test "buildTokenUrl joins multiple scopes with '&' in input order" {
         "homebrew/core/wget",
         "homebrew/core/openssl/3",
     };
-    const url = try ghcr.GhcrClient.buildTokenUrl(testing.allocator, &repos);
+    const url = try ghcr.GhcrClient.buildTokenUrl(testing.allocator, "https://ghcr.io", &repos);
     defer testing.allocator.free(url);
     try testing.expectEqualStrings(
         "https://ghcr.io/token?" ++
@@ -82,7 +111,7 @@ test "buildTokenUrl returns just the prefix on an empty repo list" {
     // prefetchTokens short-circuits on empty input, but the URL builder
     // stays well-defined — no scope params, just the endpoint path.
     const repos = [_][]const u8{};
-    const url = try ghcr.GhcrClient.buildTokenUrl(testing.allocator, &repos);
+    const url = try ghcr.GhcrClient.buildTokenUrl(testing.allocator, "https://ghcr.io", &repos);
     defer testing.allocator.free(url);
     try testing.expectEqualStrings("https://ghcr.io/token?", url);
 }


### PR DESCRIPTION
## Description

Adds `MALT_API_DOMAIN` and `MALT_BOTTLE_DOMAIN` env knobs (with
`HOMEBREW_*` fallbacks) so malt can run against a corporate brew mirror. Overrides are resolved once at process start and threaded through `AppCtx.mirrors`, so every `net/*` call site reads a single resolved value instead of re-walking the env. HTTPS enforcement is preserved - non-https overrides are refused before any subcommand
runs. `mt doctor` reports the active overrides alongside the existing "API reachable" check, and the reachability probe now targets the resolved API host.

## Related Issue

- None

## Notes for Reviewers

- Precedence: `MALT_* > HOMEBREW_* > upstream default`. Empty /
  whitespace-only values are treated as unset; trailing slashes are normalised in the resolver so URL builders never double up.
