### PR TITLE
feat(cli/install): add --download-only mode for bottles and casks

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -171,6 +171,7 @@ pub fn build(b: *std.Build) void {
         "tests/cli_services_test.zig",
         "tests/install_execute_test.zig",
         "tests/install_ambiguity_test.zig",
+        "tests/install_download_only_test.zig",
         "tests/install_idempotent_test.zig",
         "tests/no_readall_in_loop_test.zig",
         "tests/test_io_primitives_test.zig",

--- a/scripts/regressions/install_download_only.sh
+++ b/scripts/regressions/install_download_only.sh
@@ -100,4 +100,39 @@ pass "--only-dependencies combo refused"
 [[ -d "$PREFIX/Cellar/$TARGET" ]] || fail "Cellar/$TARGET missing after follow-up install"
 pass "follow-up install populated Cellar/$TARGET"
 
+# ── 5. Cask --download-only: cache filled, no Caskroom row, no app. ───
+# copilot-cli is a binary cask with no /Applications slot — safe to
+# exercise without touching shared system state.
+CASK_TARGET="${CASK_TARGET:-copilot-cli}"
+CASK_LOG="$PREFIX/cask_install.log"
+printf '▸ malt install --download-only --cask %s\n' "$CASK_TARGET"
+"$BIN" install --download-only --cask "$CASK_TARGET" >"$CASK_LOG" 2>&1 || {
+  printf '---- last 40 lines of cask download log ----\n' >&2
+  tail -40 "$CASK_LOG" >&2
+  fail "--download-only --cask failed for $CASK_TARGET — see $CASK_LOG"
+}
+pass "--download-only --cask ran cleanly"
+
+# Cache file must exist; nothing should live under Caskroom or the casks table.
+cache_count=$(find "$PREFIX/cache/Cask" -mindepth 1 -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+[[ "$cache_count" -ge 1 ]] || fail "cache/Cask empty after --download-only --cask"
+pass "cache/Cask holds $cache_count artefact(s)"
+
+casks_rows=$(sqlite3 "$DB" "SELECT COUNT(*) FROM casks WHERE token = '$CASK_TARGET';")
+[[ "$casks_rows" = "0" ]] || fail "casks row created by --download-only --cask (rows=$casks_rows)"
+pass "casks table untouched"
+
+grep -q "downloaded to $PREFIX/cache/Cask/" "$CASK_LOG" || fail "cask cache path not printed"
+pass "cask cache path printed"
+
+# Follow-up real cask install must consume the cache (no second fetch).
+"$BIN" install --cask "$CASK_TARGET" >>"$CASK_LOG" 2>&1 || {
+  printf '---- last 40 lines of cask install log ----\n' >&2
+  tail -40 "$CASK_LOG" >&2
+  fail "follow-up cask install failed — see $CASK_LOG"
+}
+follow_rows=$(sqlite3 "$DB" "SELECT COUNT(*) FROM casks WHERE token = '$CASK_TARGET';")
+[[ "$follow_rows" = "1" ]] || fail "follow-up cask install did not record (rows=$follow_rows)"
+pass "follow-up cask install populated casks row"
+
 printf '\n✔ install-download-only regression test passed\n'

--- a/scripts/regressions/install_download_only.sh
+++ b/scripts/regressions/install_download_only.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Regression test for `mt install --download-only`.
+#
+# Warms the bottle store and stops before materialise/link/record. A
+# follow-up plain install of the same package must consume the warmed
+# bytes (no second download), the Cellar must be empty after the warm
+# step, and the kegs table must report zero rows. Catches regressions
+# in the new exit point inside cli/install.zig + the split download
+# phase in install/download.zig.
+#
+# Usage: scripts/regressions/install_download_only.sh
+# Requirements: built `malt` binary at $MALT_BIN or zig-out/bin/malt,
+# network access to ghcr.io / formulae.brew.sh, sqlite3 in PATH.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null || {
+  echo "sqlite3 not on PATH" >&2
+  exit 2
+}
+
+PREFIX="/tmp/mt_dlonly"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+# `hello` is the smallest live formula with no deps — cheap to fetch,
+# easy to assert against. If it disappears upstream, swap to another
+# zero-dep leaf.
+TARGET="${TARGET:-hello}"
+LOG="$PREFIX/install.log"
+
+# ── 1. --download-only must warm the store and stop. ──────────────────
+printf '▸ malt install --download-only %s (logs → %s)\n' "$TARGET" "$LOG"
+"$BIN" install --download-only "$TARGET" >"$LOG" 2>&1 || {
+  printf '---- last 40 lines of install log ----\n' >&2
+  tail -40 "$LOG" >&2
+  fail "--download-only failed for $TARGET — see $LOG"
+}
+pass "--download-only ran cleanly"
+
+# Cellar must be untouched.
+[[ -d "$PREFIX/Cellar/$TARGET" ]] && fail "Cellar/$TARGET populated by --download-only"
+pass "Cellar/$TARGET absent after --download-only"
+
+# Store must hold at least one bottle dir.
+store_entries=$(find "$PREFIX/store" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+[[ "$store_entries" -ge 1 ]] || fail "store empty after --download-only"
+pass "store holds $store_entries bottle(s)"
+
+# kegs must be empty.
+DB="$PREFIX/db/malt.db"
+[[ -f "$DB" ]] || fail "expected $DB to exist after --download-only"
+keg_rows=$(sqlite3 "$DB" "SELECT COUNT(*) FROM kegs;")
+[[ "$keg_rows" = "0" ]] || fail "kegs table not empty after --download-only (rows=$keg_rows)"
+pass "kegs table empty"
+
+# Human output carries the resolved bottle path.
+grep -q "downloaded to $PREFIX/store/" "$LOG" || fail "resolved bottle path not printed"
+pass "resolved bottle path printed"
+
+# ── 2. --ndjson emits download_started + download_complete. ───────────
+ND_LOG="$PREFIX/ndjson.log"
+"$BIN" --output-format=ndjson install --download-only "$TARGET" >"$ND_LOG" 2>>"$LOG" || {
+  printf '---- last 40 lines of ndjson run ----\n' >&2
+  tail -40 "$LOG" >&2
+  fail "--output-format=ndjson run failed — see $LOG"
+}
+grep -q '"event":"download_started"' "$ND_LOG" || fail "missing download_started event"
+grep -q '"event":"download_complete"' "$ND_LOG" || fail "missing download_complete event"
+pass "ndjson emits download_started + download_complete"
+
+# ── 3. --download-only refuses --only-dependencies. ───────────────────
+if "$BIN" install --download-only --only-dependencies "$TARGET" >/dev/null 2>&1; then
+  fail "--download-only --only-dependencies combo was not refused"
+fi
+pass "--only-dependencies combo refused"
+
+# ── 4. Follow-up real install consumes the warmed bytes. ──────────────
+"$BIN" install "$TARGET" >>"$LOG" 2>&1 || {
+  printf '---- last 40 lines of install log ----\n' >&2
+  tail -40 "$LOG" >&2
+  fail "follow-up real install failed — see $LOG"
+}
+[[ -d "$PREFIX/Cellar/$TARGET" ]] || fail "Cellar/$TARGET missing after follow-up install"
+pass "follow-up install populated Cellar/$TARGET"
+
+printf '\n✔ install-download-only regression test passed\n'

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -137,7 +137,7 @@ pub const bash_script =
     \\
     \\    local cmd_flags=""
     \\    case "$cmd" in
-    \\        install)          cmd_flags="--cask --formula --local --dry-run --force --quiet -q --json" ;;
+    \\        install)          cmd_flags="--cask --formula --local --dry-run --force --download-only --only-dependencies --quiet -q --json" ;;
     \\        backup)           cmd_flags="--output -o --versions --quiet -q" ;;
     \\        restore)          cmd_flags="--dry-run --force --quiet -q" ;;
     \\        purge)            cmd_flags="--store-orphans --unused-deps --cache --cache= --downloads --stale-casks --old-versions --housekeeping --wipe --backup -b --keep-cache --remove-binary --yes -y --dry-run -n" ;;
@@ -253,6 +253,8 @@ pub const zsh_script =
     \\                        '--local[Install from a local .rb path]:formula:_files -g "*.rb"' \
     \\                        '--dry-run[Show what would be installed]' \
     \\                        '--force[Overwrite existing installations]' \
+    \\                        '--download-only[Warm the bottle store; skip materialise/link/record]' \
+    \\                        '--only-dependencies[Install transitive deps, skip the requested package]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
     \\                        '--json[Output result as JSON]' \
     \\                        '*::package:'
@@ -518,6 +520,8 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l local   -d 'Install from a local .rb path'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l dry-run -d 'Preview'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l force   -d 'Overwrite existing'
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l download-only -d 'Warm the bottle store; skip materialise/link/record'
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l only-dependencies -d 'Install transitive deps; skip the requested package'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l json    -d 'JSON output'
     \\
     \\    # uninstall / remove

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -253,7 +253,7 @@ pub const zsh_script =
     \\                        '--local[Install from a local .rb path]:formula:_files -g "*.rb"' \
     \\                        '--dry-run[Show what would be installed]' \
     \\                        '--force[Overwrite existing installations]' \
-    \\                        '--download-only[Warm the bottle store; skip materialise/link/record]' \
+    \\                        '--download-only[Warm the bottle store or cask cache; skip install]' \
     \\                        '--only-dependencies[Install transitive deps, skip the requested package]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
     \\                        '--json[Output result as JSON]' \
@@ -520,7 +520,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l local   -d 'Install from a local .rb path'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l dry-run -d 'Preview'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l force   -d 'Overwrite existing'
-    \\    complete -c $__malt_bin -n '__malt_using_command install' -l download-only -d 'Warm the bottle store; skip materialise/link/record'
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l download-only -d 'Warm the bottle store or cask cache; skip install'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l only-dependencies -d 'Install transitive deps; skip the requested package'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l json    -d 'JSON output'
     \\

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -73,6 +73,9 @@ const install_help =
     \\  --only-dependencies  Install transitive deps but skip the requested package
     \\                     (deps are recorded as `dependency` so `mt purge --unused-deps`
     \\                     can later GC them)
+    \\  --download-only    Warm the bottle store and stop before materialise/link/record.
+    \\                     The Cellar and DB stay untouched; a follow-up `mt install`
+    \\                     consumes the cached bytes. Refused with --only-dependencies.
     \\  --use-system-ruby[=<name>,...]  Run post_install via the system Ruby interpreter
     \\                     (experimental, sandboxed). A bare flag requires a single
     \\                     package; use =<name>,... to scope when installing multiple.

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -73,9 +73,11 @@ const install_help =
     \\  --only-dependencies  Install transitive deps but skip the requested package
     \\                     (deps are recorded as `dependency` so `mt purge --unused-deps`
     \\                     can later GC them)
-    \\  --download-only    Warm the bottle store and stop before materialise/link/record.
-    \\                     The Cellar and DB stay untouched; a follow-up `mt install`
-    \\                     consumes the cached bytes. Refused with --only-dependencies.
+    \\  --download-only    Warm the bottle store (formulas) or the Cask cache (casks)
+    \\                     and stop before materialise/link/record. The Cellar,
+    \\                     /Applications, and DB stay untouched; a follow-up
+    \\                     `mt install` consumes the cached bytes. Tap formulas
+    \\                     are not supported yet. Refused with --only-dependencies.
     \\  --use-system-ruby[=<name>,...]  Run post_install via the system Ruby interpreter
     \\                     (experimental, sandboxed). A bare flag requires a single
     \\                     package; use =<name>,... to scope when installing multiple.

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -315,6 +315,7 @@ const InstallFlag = enum {
     quiet,
     json,
     only_dependencies,
+    download_only,
 };
 
 const install_flag_map = std.StaticStringMap(InstallFlag).initComptime(.{
@@ -328,6 +329,7 @@ const install_flag_map = std.StaticStringMap(InstallFlag).initComptime(.{
     .{ "-q", .quiet },
     .{ "--json", .json },
     .{ "--only-dependencies", .only_dependencies },
+    .{ "--download-only", .download_only },
 });
 
 /// `allocator` must be an arena (see `installAll`).
@@ -363,6 +365,10 @@ fn executeWithOpts(
     // brew parity: resolve the dep graph, bail before the requested package's
     // materialise+link. Deps stay marked `dependency` for `mt purge --unused-deps`.
     var only_dependencies = false;
+    // Warm the bottle store; skip materialise/link/record. Refcount stays
+    // at 0 so warmed entries are invisible to `purge --store-orphans`
+    // until a follow-up install picks them up.
+    var download_only = false;
 
     // StaticStringMap + exhaustive switch: the compiler checks every flag
     // has a handler, so adding a new variant without wiring it fails to build.
@@ -385,6 +391,7 @@ fn executeWithOpts(
             .quiet => output.setQuiet(true),
             .json => output.setMode(.json),
             .only_dependencies => only_dependencies = true,
+            .download_only => download_only = true,
         } else if (!std.mem.startsWith(u8, arg, "-")) {
             packages.append(allocator, arg) catch return error.OutOfMemory;
         }
@@ -410,6 +417,14 @@ fn executeWithOpts(
             output.err("--local does not run post_install; --use-system-ruby has no effect and is refused", .{});
             return error.Aborted;
         }
+    }
+
+    // The two flags pull in opposite directions: --only-dependencies skips
+    // the requested package, --download-only skips materialise+link entirely.
+    // Document the refusal up front rather than silently picking a winner.
+    if (download_only and only_dependencies) {
+        output.err("--download-only cannot be combined with --only-dependencies", .{});
+        return error.Aborted;
     }
 
     if (packages.items.len == 0) {
@@ -680,6 +695,15 @@ fn executeWithOpts(
     defer allocator.free(mats);
     for (mats) |*m| m.* = .{ .ok = false, .err = null };
 
+    // `--download-only`: emit per-job `download_started` from the main
+    // thread before the pool spawns so consumers see a deterministic
+    // pre-fetch line. Paired with `download_complete` after the join.
+    if (download_only and output.isNdjson()) {
+        for (all_jobs.items) |job| {
+            output.emitNdjsonEvent(.download_started, job.name, null);
+        }
+    }
+
     // `--force` pre-materialize: clonefile refuses to overwrite a populated
     // keg dir, so wipe the resolved-version dir up front. Destructive DB +
     // symlink cleanup is deferred to the serial link phase so a materialize
@@ -777,6 +801,7 @@ fn executeWithOpts(
             .cache = &formula_cache,
             .results = mats,
             .worker_backing = std.heap.smp_allocator,
+            .download_only = download_only,
         };
 
         const pool_threads = allocator.alloc(std.Thread, worker_count) catch
@@ -810,6 +835,27 @@ fn executeWithOpts(
             output.emitNdjsonEvent(.extracted, job.name, "ok");
             output.emitNdjsonEvent(.stored, job.name, "ok");
         }
+    }
+
+    // --download-only stops here. Skip the serial link phase and surface
+    // each warmed bottle's `<prefix>/store/<sha>` path so a follow-up
+    // real install can consume the bytes.
+    if (download_only) {
+        for (all_jobs.items) |job| {
+            if (!job.succeeded) {
+                output.emitNdjsonEvent(.download_complete, job.name, "failed");
+                output.err("Download failed for {s}", .{job.name});
+                continue;
+            }
+            output.emitNdjsonEvent(.download_complete, job.name, "ok");
+            output.success("{s} {s} downloaded to {s}/store/{s}", .{
+                job.name,
+                job.version_str,
+                prefix,
+                job.store_sha256,
+            });
+        }
+        return;
     }
 
     // Check for Ctrl-C between the pool and the serial link phase

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -610,7 +610,7 @@ fn executeWithOpts(
                     continue;
                 }
                 // Try cask
-                installCask(ctx, allocator, pkg_name, &db, &api, dry_run) catch |e| {
+                installCask(ctx, allocator, pkg_name, &db, &api, dry_run, download_only) catch |e| {
                     output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
                 };
                 continue;
@@ -640,7 +640,7 @@ fn executeWithOpts(
             };
             output.emitNdjsonEvent(.resolved, pkg_name, null);
         } else {
-            installCask(ctx, allocator, pkg_name, &db, &api, dry_run) catch |e| {
+            installCask(ctx, allocator, pkg_name, &db, &api, dry_run, download_only) catch |e| {
                 output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
             };
         }
@@ -1102,7 +1102,9 @@ fn resolveCaskArtifactViaHead(ctx: *const AppCtx, allocator: std.mem.Allocator, 
     return cask_mod.resolveArtifactType(allocator, resolved.final_url, resolved.content_disposition);
 }
 
-/// Install a cask (DMG, ZIP, or PKG).
+/// Install a cask (DMG, ZIP, or PKG). When `download_only` is set, the
+/// flow stops after `<prefix>/cache/Cask/<file>` is sha-verified — no
+/// `/Applications` writes, no DB inserts.
 fn installCask(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
@@ -1110,6 +1112,7 @@ fn installCask(
     db: *sqlite.Database,
     api: *api_mod.BrewApi,
     dry_run: bool,
+    download_only: bool,
 ) !void {
     const cask_json = api.fetchCask(token) catch {
         output.err("Cask '{s}' not found", .{token});
@@ -1123,8 +1126,11 @@ fn installCask(
     };
     defer cask.deinit();
 
-    // Check if already installed
-    if (cask_mod.isInstalled(db, cask.token)) {
+    // `--download-only` deliberately ignores `isInstalled` so a user can
+    // refresh the cached artefact ahead of an `mt upgrade` even when an
+    // older revision is on disk. The real install path keeps the
+    // "already installed" short-circuit.
+    if (!download_only and cask_mod.isInstalled(db, cask.token)) {
         output.info("{s} is already installed", .{cask.token});
         return;
     }
@@ -1157,8 +1163,6 @@ fn installCask(
         output.warn("{s} is a PKG cask and requires sudo to install via macOS Installer.", .{cask.token});
     }
 
-    output.info("Installing cask {s} {s}...", .{ cask.token, cask.version });
-
     const prefix = atomic.maltPrefixOrAbort();
 
     var installer = cask_mod.CaskInstaller.init(ctx.io, ctx.environ, allocator, db, prefix);
@@ -1170,6 +1174,23 @@ fn installCask(
         .context = @ptrCast(&bar),
         .func = &progressBridge,
     };
+
+    if (download_only) {
+        output.emitNdjsonEvent(.download_started, cask.token, null);
+        const cache_path = installer.downloadOnly(&cask) catch |e| {
+            bar.finish();
+            output.emitNdjsonEvent(.download_complete, cask.token, "failed");
+            output.err("Failed to download cask {s}: {s}", .{ cask.token, @errorName(e) });
+            return InstallError.CaskNotFound;
+        };
+        bar.finish();
+        defer allocator.free(cache_path);
+        output.emitNdjsonEvent(.download_complete, cask.token, "ok");
+        output.success("{s} {s} downloaded to {s}", .{ cask.token, cask.version, cache_path });
+        return;
+    }
+
+    output.info("Installing cask {s} {s}...", .{ cask.token, cask.version });
 
     const app_path = installer.install(&cask) catch |e| {
         bar.finish();

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -555,86 +555,8 @@ pub fn installKegFromBottle(
 ) InstallError!InstallKegResult {
     const bottle = formula_mod.resolveBottle(formula) catch return InstallError.NoBottle;
 
-    if (!deps.store.exists(bottle.sha256)) {
-        const ref = ghcr_url.parseGhcrUrl(bottle.url) orelse return InstallError.DownloadFailed;
-
-        const tmp_dir = atomic.createTempDir(ctx.io, allocator, formula.name) catch
-            return InstallError.DownloadFailed;
-
-        const progress_cb: ?client_mod.ProgressCallback = if (deps.bar) |bar| .{
-            .context = @ptrCast(bar),
-            .func = &progressBridge,
-        } else null;
-
-        const max_attempts: u8 = 3;
-        const retry_delays_ms = [_]u64{ 100, 400 };
-        var dl_attempt: u8 = 0;
-        var dl_ok = false;
-        var last_err: bottle_mod.BottleError = bottle_mod.BottleError.DownloadFailed;
-        var last_mismatch: ?bottle_mod.MismatchInfo = null;
-        while (dl_attempt < max_attempts) : (dl_attempt += 1) {
-            var mismatch: bottle_mod.MismatchInfo = undefined;
-            if (bottle_mod.download(
-                ctx.io,
-                allocator,
-                deps.ghcr,
-                deps.http,
-                ref.repo,
-                ref.digest,
-                bottle.sha256,
-                tmp_dir,
-                progress_cb,
-                &mismatch,
-            )) |_| {
-                dl_ok = true;
-                break;
-            } else |dl_err| {
-                last_err = dl_err;
-                atomic.cleanupTempDir(ctx.io, tmp_dir);
-                if (dl_err == bottle_mod.BottleError.DownloadPermanent) {
-                    output.err("  {s}: permanent HTTP error (404/410), not retrying", .{formula.name});
-                    break;
-                }
-                if (dl_err == bottle_mod.BottleError.Sha256Mismatch) {
-                    last_mismatch = mismatch;
-                } else if (isDeterministicDownloadError(dl_err)) {
-                    output.err("  {s}: {s}", .{ formula.name, @errorName(dl_err) });
-                    break;
-                }
-                if (dl_attempt + 1 < max_attempts) {
-                    if (!cancellableBackoff(ctx.io, retry_delays_ms[dl_attempt])) break;
-                }
-            }
-        }
-
-        if (!dl_ok and last_err == bottle_mod.BottleError.Sha256Mismatch) {
-            if (last_mismatch) |m| {
-                output.err(
-                    "  {s}: Sha256Mismatch (expected={s} got={s} bytes={d})",
-                    .{ formula.name, m.expected[0..@min(64, m.expected.len)], m.computed[0..], m.body_len },
-                );
-            } else {
-                output.err("  {s}: Sha256Mismatch", .{formula.name});
-            }
-        }
-
-        if (!dl_ok) {
-            if (deps.bar) |bar| bar.finish();
-            if (dl_attempt >= max_attempts) {
-                output.err("  {s}: {s} (after {d} attempts)", .{ formula.name, @errorName(last_err), max_attempts });
-            }
-            allocator.free(tmp_dir);
-            return InstallError.DownloadFailed;
-        }
-        if (deps.bar) |bar| bar.finish();
-
-        deps.store.commitFrom(bottle.sha256, tmp_dir) catch {
-            atomic.cleanupTempDir(ctx.io, tmp_dir);
-            allocator.free(tmp_dir);
-            return InstallError.StoreFailed;
-        };
-        allocator.free(tmp_dir);
-
+    const committed = try downloadBottleToStore(ctx, allocator, deps, formula, bottle);
+    if (committed) {
         // Advisory refcount: commit succeeded so the bytes are ours; a
         // bumped warning is not a failure of the materialize.
         deps.store.incrementRef(bottle.sha256) catch |e| {
@@ -658,6 +580,102 @@ pub fn installKegFromBottle(
     return .{ .sha256 = bottle.sha256, .keg = keg };
 }
 
+/// Ensure the bottle bytes live at `<prefix>/store/<sha>/`. Returns
+/// `true` when a fresh commit happened (i.e. the store didn't already
+/// hold the SHA), `false` for the warm-store skip. The refcount and
+/// materialise steps are the caller's job — this seam is shared by
+/// `installKegFromBottle` and the `--download-only` pool worker.
+pub fn downloadBottleToStore(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    deps: InstallKegDeps,
+    formula: *const formula_mod.Formula,
+    bottle: formula_mod.BottleFile,
+) InstallError!bool {
+    if (deps.store.exists(bottle.sha256)) return false;
+
+    const ref = ghcr_url.parseGhcrUrl(bottle.url) orelse return InstallError.DownloadFailed;
+
+    const tmp_dir = atomic.createTempDir(ctx.io, allocator, formula.name) catch
+        return InstallError.DownloadFailed;
+
+    const progress_cb: ?client_mod.ProgressCallback = if (deps.bar) |bar| .{
+        .context = @ptrCast(bar),
+        .func = &progressBridge,
+    } else null;
+
+    const max_attempts: u8 = 3;
+    const retry_delays_ms = [_]u64{ 100, 400 };
+    var dl_attempt: u8 = 0;
+    var dl_ok = false;
+    var last_err: bottle_mod.BottleError = bottle_mod.BottleError.DownloadFailed;
+    var last_mismatch: ?bottle_mod.MismatchInfo = null;
+    while (dl_attempt < max_attempts) : (dl_attempt += 1) {
+        var mismatch: bottle_mod.MismatchInfo = undefined;
+        if (bottle_mod.download(
+            ctx.io,
+            allocator,
+            deps.ghcr,
+            deps.http,
+            ref.repo,
+            ref.digest,
+            bottle.sha256,
+            tmp_dir,
+            progress_cb,
+            &mismatch,
+        )) |_| {
+            dl_ok = true;
+            break;
+        } else |dl_err| {
+            last_err = dl_err;
+            atomic.cleanupTempDir(ctx.io, tmp_dir);
+            if (dl_err == bottle_mod.BottleError.DownloadPermanent) {
+                output.err("  {s}: permanent HTTP error (404/410), not retrying", .{formula.name});
+                break;
+            }
+            if (dl_err == bottle_mod.BottleError.Sha256Mismatch) {
+                last_mismatch = mismatch;
+            } else if (isDeterministicDownloadError(dl_err)) {
+                output.err("  {s}: {s}", .{ formula.name, @errorName(dl_err) });
+                break;
+            }
+            if (dl_attempt + 1 < max_attempts) {
+                if (!cancellableBackoff(ctx.io, retry_delays_ms[dl_attempt])) break;
+            }
+        }
+    }
+
+    if (!dl_ok and last_err == bottle_mod.BottleError.Sha256Mismatch) {
+        if (last_mismatch) |m| {
+            output.err(
+                "  {s}: Sha256Mismatch (expected={s} got={s} bytes={d})",
+                .{ formula.name, m.expected[0..@min(64, m.expected.len)], m.computed[0..], m.body_len },
+            );
+        } else {
+            output.err("  {s}: Sha256Mismatch", .{formula.name});
+        }
+    }
+
+    if (!dl_ok) {
+        if (deps.bar) |bar| bar.finish();
+        if (dl_attempt >= max_attempts) {
+            output.err("  {s}: {s} (after {d} attempts)", .{ formula.name, @errorName(last_err), max_attempts });
+        }
+        allocator.free(tmp_dir);
+        return InstallError.DownloadFailed;
+    }
+    if (deps.bar) |bar| bar.finish();
+
+    deps.store.commitFrom(bottle.sha256, tmp_dir) catch {
+        atomic.cleanupTempDir(ctx.io, tmp_dir);
+        allocator.free(tmp_dir);
+        return InstallError.StoreFailed;
+    };
+    allocator.free(tmp_dir);
+
+    return true;
+}
+
 /// Shared state for the install-time per-keg worker pool. Each worker
 /// grabs the next slot in `jobs` atomically, borrows an HTTP client
 /// from `http_pool`, and calls `installKegFromBottle` against the
@@ -678,6 +696,10 @@ pub const InstallPool = struct {
     /// tests can drive the pool under `testing.allocator`; production
     /// keeps a thread-safe heap (typically `smp_allocator`).
     worker_backing: std.mem.Allocator,
+    /// When set, workers stop after the per-keg download phase. The
+    /// caller's serial link loop bails on this flag; refcount stays at 0
+    /// so warmed bytes are invisible to `purge --store-orphans`.
+    download_only: bool = false,
 };
 
 /// Thread entry-point for the install pool. Drains `pool.jobs` via the
@@ -719,6 +741,31 @@ fn installOneJob(pool: *InstallPool, job: *DownloadJob, result: *MaterializeResu
     // buffer before the arena drops.
     var arena = std.heap.ArenaAllocator.init(pool.worker_backing);
     defer arena.deinit();
+
+    if (pool.download_only) {
+        const bottle = formula_mod.resolveBottle(formula) catch {
+            result.* = .{ .ok = false, .err = null };
+            job.succeeded = false;
+            return;
+        };
+        _ = downloadBottleToStore(
+            pool.ctx,
+            arena.allocator(),
+            .{ .ghcr = pool.ghcr, .http = http, .store = pool.store, .bar = job.bar },
+            formula,
+            bottle,
+        ) catch {
+            result.* = .{ .ok = false, .err = null };
+            job.succeeded = false;
+            return;
+        };
+        // No keg path — materialise is skipped. The serial loop bails
+        // on `pool.download_only` before it would read `keg_path_buf`.
+        result.* = .{ .ok = true, .err = null };
+        job.store_sha256 = bottle.sha256;
+        job.succeeded = true;
+        return;
+    }
 
     // `cellar_diag` captures the specific `CellarError` variant when
     // materialise fails so the serial link phase below can still print
@@ -987,6 +1034,76 @@ test "installKegFromBottle returns NoBottle before reaching ghcr/store when no p
             "/tmp/malt_iknfb_test",
         ),
     );
+}
+
+// `downloadBottleToStore` returning `false` on the warm-store path is
+// the contract `installKegFromBottle` relies on to skip the refcount
+// bump, and that the `--download-only` pool worker relies on to keep
+// the warm fast path zero-I/O.
+test "downloadBottleToStore returns false when the store already holds the bottle" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx_value: AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    const ts = std.Io.Clock.real.now(ctx_value.io).toNanoseconds();
+    const prefix_path = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "/tmp/malt_dlonly_skip_{d}",
+        .{ts},
+    );
+    defer std.testing.allocator.free(prefix_path);
+    std.Io.Dir.cwd().deleteTree(ctx_value.io, prefix_path) catch {};
+    try std.Io.Dir.cwd().createDirPath(ctx_value.io, prefix_path);
+    defer std.Io.Dir.cwd().deleteTree(ctx_value.io, prefix_path) catch {};
+
+    const sha = "ba" ** 32;
+    const seeded = try std.fmt.allocPrint(std.testing.allocator, "{s}/store/{s}", .{ prefix_path, sha });
+    defer std.testing.allocator.free(seeded);
+    try std.Io.Dir.cwd().createDirPath(ctx_value.io, seeded);
+
+    var http = client_mod.HttpClient.init(ctx_value.io, ctx_value.environ, std.testing.allocator);
+    defer http.deinit();
+    var ghcr = ghcr_mod.GhcrClient.init(ctx_value.io, std.testing.allocator, &http);
+    defer ghcr.deinit();
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    var store = store_mod.Store.init(ctx_value.io, std.testing.allocator, &db, prefix_path);
+
+    // Build a minimal Formula via the public parser so the test stays
+    // independent of internal field shape changes.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const formula_json = try std.fmt.allocPrint(
+        arena.allocator(),
+        \\{{
+        \\  "name": "warm",
+        \\  "full_name": "warm",
+        \\  "tap": "homebrew/core",
+        \\  "desc": "",
+        \\  "homepage": "",
+        \\  "versions": {{"stable": "1.0"}},
+        \\  "revision": 0,
+        \\  "dependencies": [],
+        \\  "keg_only": false,
+        \\  "post_install_defined": false,
+        \\  "oldnames": [],
+        \\  "bottle": {{"stable": {{"files": {{"all": {{"cellar": ":any", "url": "https://ghcr.io/v2/x/blobs/sha256:{s}", "sha256": "{s}"}}}}}}}}
+        \\}}
+    ,
+        .{ sha, sha },
+    );
+    var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
+    defer formula.deinit();
+    const bottle = try formula_mod.resolveBottle(&formula);
+
+    const committed = try downloadBottleToStore(
+        &ctx_value,
+        std.testing.allocator,
+        .{ .ghcr = &ghcr, .http = &http, .store = &store },
+        &formula,
+        bottle,
+    );
+    try std.testing.expect(!committed);
 }
 
 test "FetchFormulaCtx: arena backed by testing.allocator runs leak-clean across the dupe-then-deinit shape" {

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -482,13 +482,14 @@ pub const CaskInstaller = struct {
         return .{ .allocator = allocator, .io = io, .environ = environ, .db = db, .prefix = prefix, .progress = null };
     }
 
-    /// Install a cask. Downloads, verifies SHA256, and installs based on artifact type.
-    /// Returns the installed app path on success.
-    pub fn install(self: *CaskInstaller, cask: *const Cask) CaskError![]const u8 {
+    /// Fetch + sha-verify the cask artefact into `<prefix>/cache/Cask/` and
+    /// return the on-disk path. No `/Applications` writes, no DB inserts —
+    /// the seam `mt install --download-only --cask <token>` reuses to warm
+    /// the cache before going offline. Caller owns the returned slice.
+    pub fn downloadOnly(self: *CaskInstaller, cask: *const Cask) CaskError![]const u8 {
         const artifact_type = self.artifact_type_override orelse artifactTypeFromUrl(cask.url);
         if (artifact_type == .unknown) return CaskError.InstallFailed;
 
-        // Ensure cache/Cask/ directory exists
         var cache_buf: [512]u8 = undefined;
         const cache_dir = std.fmt.bufPrint(&cache_buf, "{s}/cache/Cask", .{self.prefix}) catch
             return CaskError.OutOfMemory;
@@ -497,18 +498,30 @@ pub const CaskInstaller = struct {
             else => return CaskError.InstallFailed,
         };
 
-        // Download to cache
         const cache_path = self.downloadToCache(cask, cache_dir, self.progress) catch
             return CaskError.DownloadFailed;
         errdefer {
-            // cache already leaked to disk; nothing to do on cleanup failure.
             std.Io.Dir.cwd().deleteFile(self.io, cache_path) catch {};
             self.allocator.free(cache_path);
         }
 
-        // Verify SHA256
         self.verifySha256(cache_path, cask.sha256) catch
             return CaskError.Sha256Mismatch;
+
+        return cache_path;
+    }
+
+    /// Install a cask. Downloads, verifies SHA256, and installs based on artifact type.
+    /// Returns the installed app path on success.
+    pub fn install(self: *CaskInstaller, cask: *const Cask) CaskError![]const u8 {
+        const artifact_type = self.artifact_type_override orelse artifactTypeFromUrl(cask.url);
+        if (artifact_type == .unknown) return CaskError.InstallFailed;
+
+        const cache_path = try self.downloadOnly(cask);
+        errdefer {
+            std.Io.Dir.cwd().deleteFile(self.io, cache_path) catch {};
+            self.allocator.free(cache_path);
+        }
 
         // Determine target: prefix-aware sandbox / /Applications / ~/Applications.
         var app_dir_buf: [512]u8 = undefined;

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -563,6 +563,12 @@ pub const NdjsonEvent = enum {
     linked,
     recorded,
     install_complete,
+    // Bracketing pair for the `--download-only` warm-cache path. Distinct
+    // from `.downloaded` so consumers (CI pipelines, Docker layer warmers)
+    // can time per-bottle work without conflating it with the install-time
+    // emit shape.
+    download_started,
+    download_complete,
     // Shared with --json's existing post_install summary line.
     post_install,
     // No-transition outcomes.

--- a/tests/install_download_only_test.zig
+++ b/tests/install_download_only_test.zig
@@ -1,0 +1,358 @@
+//! malt — `mt install --download-only` integration tests.
+//!
+//! Pins the new exit point in the install pipeline:
+//!   - bottle bytes land in `<prefix>/store/<sha>/...`
+//!   - Cellar and the `kegs` table stay untouched
+//!   - `--ndjson` emits `download_started` / `download_complete` events
+//!   - argv refuses the ambiguous `--only-dependencies` combo
+//!   - human stdout prints the resolved bottle paths
+//!
+//! Bottle bytes are seeded into the store before `install.execute` runs
+//! so the test stays offline — the warm-store branch inside
+//! `installKegFromBottle` is the production code-path the download-only
+//! exit point reuses for the "already cached" case.
+
+const std = @import("std");
+const malt = @import("malt");
+const test_io = @import("test_io");
+const testing = std.testing;
+const install = malt.install;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+fn setupPrefix(suffix: []const u8) ![:0]u8 {
+    const path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "/tmp/malt_install_dlonly_{d}_{s}",
+        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
+        0,
+    );
+    test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, path);
+    inline for (.{ "store", "Cellar", "cache", "db" }) |sub| {
+        const dir = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ path, sub });
+        defer testing.allocator.free(dir);
+        try test_io.cwd().createDirPath(std.Options.debug_io, dir);
+    }
+    _ = c.setenv("MALT_PREFIX", path.ptr, 1);
+    return path;
+}
+
+fn seedFormulaCache(prefix: []const u8, name: []const u8, json: []const u8) !void {
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{prefix});
+    defer testing.allocator.free(cache_api);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_api);
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/formula_{s}.json", .{ cache_api, name });
+    defer testing.allocator.free(path);
+    const f = try test_io.cwd().createFile(std.Options.debug_io, path, .{});
+    defer f.close(std.Options.debug_io);
+    try f.writeStreamingAll(std.Options.debug_io, json);
+}
+
+// Seed `<prefix>/store/<sha>/...` so `installKegFromBottle` takes the warm
+// path and never reaches the network. The same layout an offline-cached
+// run would produce.
+fn seedStoreBottle(prefix: []const u8, sha: []const u8, name: []const u8, version: []const u8) !void {
+    const inner = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/store/{s}/{s}/{s}",
+        .{ prefix, sha, name, version },
+    );
+    defer testing.allocator.free(inner);
+    try test_io.cwd().createDirPath(std.Options.debug_io, inner);
+    const readme = try std.fmt.allocPrint(testing.allocator, "{s}/README", .{inner});
+    defer testing.allocator.free(readme);
+    const f = try test_io.cwd().createFile(std.Options.debug_io, readme, .{});
+    defer f.close(std.Options.debug_io);
+    try f.writeStreamingAll(std.Options.debug_io, "download-only fixture\n");
+}
+
+fn warmFormulaJson(allocator: std.mem.Allocator, name: []const u8, sha: []const u8) ![]const u8 {
+    // `"all"` platform key wins on every host arch — keeps these tests
+    // arch-independent and avoids encoding the macOS codename list twice.
+    return std.fmt.allocPrint(
+        allocator,
+        \\{{
+        \\  "name": "{s}",
+        \\  "full_name": "{s}",
+        \\  "tap": "homebrew/core",
+        \\  "desc": "",
+        \\  "homepage": "",
+        \\  "versions": {{"stable": "1.0"}},
+        \\  "revision": 0,
+        \\  "dependencies": [],
+        \\  "keg_only": false,
+        \\  "post_install_defined": false,
+        \\  "oldnames": [],
+        \\  "bottle": {{"stable": {{"files": {{"all": {{"cellar": ":any", "url": "https://ghcr.io/v2/homebrew/core/{s}/blobs/sha256:{s}", "sha256": "{s}"}}}}}}}}
+        \\}}
+    ,
+        .{ name, name, name, sha, sha },
+    );
+}
+
+fn kegRowCount(prefix: []const u8) !i64 {
+    const db_path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "{s}/db/malt.db",
+        .{prefix},
+        0,
+    );
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    var stmt = try db.prepare("SELECT COUNT(*) FROM kegs;");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    return stmt.columnInt(0);
+}
+
+fn pathExists(path: []const u8) bool {
+    test_io.accessAbsolute(std.Options.debug_io, path, .{}) catch return false;
+    return true;
+}
+
+test "execute refuses --download-only combined with --only-dependencies" {
+    // The two flags are semantically ambiguous: one says "don't touch the
+    // requested package", the other says "don't materialise anything".
+    // Document the refusal up front rather than silently picking a winner.
+    // The check must run before any infra setup so the test does not need
+    // to seed a cache or stub the network.
+    const prefix = try setupPrefix("ambig");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try testing.expectError(
+        error.Aborted,
+        install.execute(
+            &ctx,
+            arena.allocator(),
+            &.{ "--download-only", "--only-dependencies", "alpha" },
+        ),
+    );
+}
+
+test "--download-only --ndjson emits download_started + download_complete around the fetch" {
+    // Pin the event shape new consumers (CI pipelines, Docker layer
+    // builders) get from the warm-cache path. The events must bracket
+    // every per-job fetch — no fan-out, no dropped events, and
+    // download_complete carries "ok" for the warm-store skip.
+    const prefix = try setupPrefix("nd");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha = "cd" ** 32;
+    try seedStoreBottle(prefix, sha, "ndpkg", "1.0");
+    var arena_json = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_json.deinit();
+    const json = try warmFormulaJson(arena_json.allocator(), "ndpkg", sha);
+    try seedFormulaCache(prefix, "ndpkg", json);
+
+    const prior = malt.output.isNdjson();
+    malt.output.setNdjson(true);
+    defer malt.output.setNdjson(prior);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStdoutCapture(testing.allocator, &captured);
+    defer malt.output.endStdoutCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try install.execute(&ctx, arena.allocator(), &.{ "--download-only", "--quiet", "ndpkg" });
+
+    // Exactly one started + one complete for the single requested package.
+    try testing.expectEqual(
+        @as(usize, 1),
+        std.mem.count(u8, captured.items, "\"event\":\"download_started\",\"name\":\"ndpkg\""),
+    );
+    try testing.expectEqual(
+        @as(usize, 1),
+        std.mem.count(u8, captured.items, "\"event\":\"download_complete\",\"name\":\"ndpkg\",\"status\":\"ok\""),
+    );
+}
+
+test "--download-only prints the resolved bottle path under the prefix store" {
+    // The visible signal a user gets when warming a cache: the absolute
+    // `<prefix>/store/<sha>` path of each downloaded bottle. Without this
+    // line the command would look like a silent no-op against the user's
+    // expectation of "fetched X to disk".
+    const prefix = try setupPrefix("paths");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha = "ef" ** 32;
+    try seedStoreBottle(prefix, sha, "pathpkg", "1.0");
+    var arena_json = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_json.deinit();
+    const json = try warmFormulaJson(arena_json.allocator(), "pathpkg", sha);
+    try seedFormulaCache(prefix, "pathpkg", json);
+
+    // Quiet is process-global and other tests leave it set; reset so the
+    // success line reaches our capture.
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try install.execute(&ctx, arena.allocator(), &.{ "--download-only", "pathpkg" });
+
+    const expected = try std.fmt.allocPrint(
+        testing.allocator,
+        "pathpkg 1.0 downloaded to {s}/store/{s}",
+        .{ prefix, sha },
+    );
+    defer testing.allocator.free(expected);
+    try testing.expect(std.mem.indexOf(u8, captured.items, expected) != null);
+}
+
+test "--download-only --dry-run prints the plan and never touches the store" {
+    // dry-run takes precedence — the plan header still fires, no
+    // download_started/complete events are emitted, and the bottle path
+    // line is not printed. Locks in the precedence so a future refactor
+    // can't accidentally make --download-only swallow --dry-run.
+    const prefix = try setupPrefix("dr");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha = "aa" ** 32;
+    var arena_json = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_json.deinit();
+    const json = try warmFormulaJson(arena_json.allocator(), "dr", sha);
+    try seedFormulaCache(prefix, "dr", json);
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try install.execute(&ctx, arena.allocator(), &.{ "--download-only", "--dry-run", "dr" });
+
+    try testing.expect(std.mem.indexOf(u8, captured.items, "would install") != null);
+    try testing.expect(std.mem.indexOf(u8, captured.items, "downloaded to") == null);
+
+    // Nothing seeded the store, and dry-run skipped the fetch, so the
+    // SHA directory must still be absent.
+    const store_dir = try std.fmt.allocPrint(testing.allocator, "{s}/store/{s}", .{ prefix, sha });
+    defer testing.allocator.free(store_dir);
+    try testing.expect(!pathExists(store_dir));
+}
+
+test "--download-only with multiple packages prints one resolved path per package" {
+    // Two leaf formulas exercise the loop in the download-only short-circuit
+    // and pin the per-package emit order: success lines must appear for
+    // every requested name, not just the first.
+    const prefix = try setupPrefix("multi");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha_a = "11" ** 32;
+    const sha_b = "22" ** 32;
+    try seedStoreBottle(prefix, sha_a, "alpha", "1.0");
+    try seedStoreBottle(prefix, sha_b, "beta", "1.0");
+    var arena_json = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_json.deinit();
+    const a_json = try warmFormulaJson(arena_json.allocator(), "alpha", sha_a);
+    const b_json = try warmFormulaJson(arena_json.allocator(), "beta", sha_b);
+    try seedFormulaCache(prefix, "alpha", a_json);
+    try seedFormulaCache(prefix, "beta", b_json);
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try install.execute(&ctx, arena.allocator(), &.{ "--download-only", "alpha", "beta" });
+
+    const want_a = try std.fmt.allocPrint(testing.allocator, "alpha 1.0 downloaded to {s}/store/{s}", .{ prefix, sha_a });
+    defer testing.allocator.free(want_a);
+    const want_b = try std.fmt.allocPrint(testing.allocator, "beta 1.0 downloaded to {s}/store/{s}", .{ prefix, sha_b });
+    defer testing.allocator.free(want_b);
+    try testing.expect(std.mem.indexOf(u8, captured.items, want_a) != null);
+    try testing.expect(std.mem.indexOf(u8, captured.items, want_b) != null);
+}
+
+test "--download-only populates the store and skips Cellar + kegs" {
+    // Pre-seed the store so the warm-path branch inside the install pool
+    // skips the network entirely. The new exit point must short-circuit
+    // before `materializeWithCellar`, leaving Cellar empty and the kegs
+    // table at zero rows — that is the property a follow-up real install
+    // can rely on when consuming the warmed bytes.
+    const prefix = try setupPrefix("warm");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha = "ab" ** 32; // 64-char hex placeholder
+    try seedStoreBottle(prefix, sha, "warmpkg", "1.0");
+    var arena_json = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_json.deinit();
+    const json = try warmFormulaJson(arena_json.allocator(), "warmpkg", sha);
+    try seedFormulaCache(prefix, "warmpkg", json);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try install.execute(&ctx, arena.allocator(), &.{ "--download-only", "--quiet", "warmpkg" });
+
+    const cellar = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/warmpkg/1.0", .{prefix});
+    defer testing.allocator.free(cellar);
+    try testing.expect(!pathExists(cellar));
+
+    const store_dir = try std.fmt.allocPrint(testing.allocator, "{s}/store/{s}", .{ prefix, sha });
+    defer testing.allocator.free(store_dir);
+    try testing.expect(pathExists(store_dir));
+
+    try testing.expectEqual(@as(i64, 0), try kegRowCount(prefix));
+}

--- a/tests/install_download_only_test.zig
+++ b/tests/install_download_only_test.zig
@@ -320,6 +320,75 @@ test "--download-only with multiple packages prints one resolved path per packag
     try testing.expect(std.mem.indexOf(u8, captured.items, want_b) != null);
 }
 
+test "--download-only --cask is plumbed into the cask path and threads the flag" {
+    // The argv parser must accept `--download-only` alongside `--cask`,
+    // and the per-package dispatcher must route the request through
+    // `installCask` (which honours the flag). Anchor via the cached-API
+    // already-installed branch: a seeded `casks` row would normally
+    // trigger the "already installed" short-circuit on the regular path,
+    // but `--download-only` deliberately bypasses that gate so warmed
+    // caches can be refreshed ahead of an upgrade. We assert the bypass
+    // by capturing that no "already installed" line is printed even
+    // though the row exists — and the run still terminates with a
+    // cask-fetch error (because there's no network in this test, the
+    // cache lookup for the cask JSON misses).
+    const prefix_z: [:0]const u8 = "/tmp/mc_dl";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
+    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Seed a `casks` row for the same token so the normal `isInstalled`
+    // gate would short-circuit. `--download-only` must skip the gate.
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{prefix_z});
+    defer testing.allocator.free(db_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, db_dir);
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/malt.db", .{db_dir}, 0);
+    defer testing.allocator.free(db_path);
+    {
+        var db = try malt.sqlite.Database.open(db_path);
+        defer db.close();
+        try malt.schema.initSchema(&db);
+        var stmt = try db.prepare(
+            \\INSERT INTO casks (token, name, version, url, sha256, app_path)
+            \\VALUES (?, ?, ?, ?, ?, ?);
+        );
+        defer stmt.finalize();
+        try stmt.bindText(1, "ghost-cask");
+        try stmt.bindText(2, "ghost-cask");
+        try stmt.bindText(3, "1.0");
+        try stmt.bindText(4, "https://example.test/ghost.dmg");
+        try stmt.bindText(5, "0" ** 64);
+        try stmt.bindText(6, "/Applications/Ghost.app");
+        _ = try stmt.step();
+    }
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    // `--cask` + an unresolvable token → `fetchCask` errors. The
+    // important assertion is that we DIDN'T short-circuit on the seeded
+    // already-installed row — i.e., `--download-only` rerouted the flow
+    // through the download path.
+    install.execute(&ctx, arena.allocator(), &.{ "--download-only", "--cask", "ghost-cask" }) catch {};
+
+    try testing.expect(std.mem.indexOf(u8, captured.items, "ghost-cask is already installed") == null);
+    try testing.expect(std.mem.indexOf(u8, captured.items, "Cask 'ghost-cask' not found") != null);
+}
+
 test "--download-only populates the store and skips Cellar + kegs" {
     // Pre-seed the store so the warm-path branch inside the install pool
     // skips the network entirely. The new exit point must short-circuit


### PR DESCRIPTION
## Description

Adds `mt install --download-only`. The command runs the existing install pipeline up through download and sha verification, then stops cleanly before any artefact install. Bottles land in `<prefix>/store/<sha>`; casks land in `<prefix>/cache/Cask/<token>-<version>.<ext>`. The Cellar, `/Applications`, and DB stay untouched. Useful for laptop pre-warm before going offline and for Docker layer construction.

`--ndjson` emits `download_started` / `download_complete` events around each per-package fetch on the new path. Combining with `--only-dependencies` is refused explicitly. The human output prints the absolute cache path of every downloaded artefact so a follow-up real install can consume the warmed bytes.

## Related Issue

- None

## Notes for Reviewers

- None
