### PR TITLE
feat(cli/install): extend --download-only mode to tap formulas

### DIFF
--- a/scripts/regressions/install_download_only.sh
+++ b/scripts/regressions/install_download_only.sh
@@ -135,4 +135,75 @@ follow_rows=$(sqlite3 "$DB" "SELECT COUNT(*) FROM casks WHERE token = '$CASK_TAR
 [[ "$follow_rows" = "1" ]] || fail "follow-up cask install did not record (rows=$follow_rows)"
 pass "follow-up cask install populated casks row"
 
+# ── 6. Tap formula --download-only: warm cache/Tap, no Cellar/db. ─────
+# Real binary tap that ships a single executable through the
+# materializeRubyFormula path. Transient classified failures (rate
+# limits, DNS) are skipped, not failures — same shape as
+# install_tap_tmp_cleanup.sh.
+TAP_TARGET="${TAP_TARGET:-indaco/tap/sley}"
+TAP_LOG="$PREFIX/tap_install.log"
+printf '▸ malt install --download-only %s\n' "$TAP_TARGET"
+if ! "$BIN" install --download-only "$TAP_TARGET" >"$TAP_LOG" 2>&1; then
+  if grep -qE "rate limit|Network failure|Cannot fetch tap from GitHub|Tap formula/cask not found" "$TAP_LOG"; then
+    printf '  - %s: transient classified failure; skipping tap section\n' "$TAP_TARGET"
+    printf '\n✔ install-download-only regression test passed (tap section skipped)\n'
+    exit 0
+  fi
+  tail -40 "$TAP_LOG" >&2
+  fail "--download-only failed for $TAP_TARGET — see $TAP_LOG"
+fi
+pass "tap --download-only ran cleanly"
+
+# Tap formula short name lives in the slug's last segment.
+TAP_NAME="${TAP_TARGET##*/}"
+[[ -d "$PREFIX/Cellar/$TAP_NAME" ]] && fail "Cellar/$TAP_NAME populated by tap --download-only"
+pass "Cellar/$TAP_NAME absent after tap --download-only"
+
+tap_cache_count=$(find "$PREFIX/cache/Tap" -mindepth 1 -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+[[ "$tap_cache_count" -ge 1 ]] || fail "cache/Tap empty after tap --download-only"
+pass "cache/Tap holds $tap_cache_count archive(s)"
+
+tap_kegs=$(sqlite3 "$DB" "SELECT COUNT(*) FROM kegs WHERE name = '$TAP_NAME';")
+[[ "$tap_kegs" = "0" ]] || fail "kegs row created by tap --download-only (rows=$tap_kegs)"
+pass "kegs table untouched by tap --download-only"
+
+grep -q "downloaded to $PREFIX/cache/Tap/" "$TAP_LOG" || fail "tap cache path not printed"
+pass "tap cache path printed"
+
+# Staging file was renamed, not leaked — pins the install_tap_tmp_cleanup
+# invariant for the download-only path too.
+leftover=$(find "$PREFIX/tmp" -maxdepth 1 -name 'tap_download*' 2>/dev/null || true)
+[[ -z "$leftover" ]] || fail "stale tap_download* in tmp after --download-only"
+pass "tmp/ clean after tap --download-only"
+
+# ── 7. Follow-up tap install consumes the cache (no second fetch). ────
+cache_before=$(find "$PREFIX/cache/Tap" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')
+"$BIN" install "$TAP_TARGET" >>"$TAP_LOG" 2>&1 || {
+  tail -40 "$TAP_LOG" >&2
+  fail "follow-up tap install failed — see $TAP_LOG"
+}
+[[ -d "$PREFIX/Cellar/$TAP_NAME" ]] || fail "Cellar/$TAP_NAME missing after follow-up install"
+cache_after=$(find "$PREFIX/cache/Tap" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')
+[[ "$cache_before" = "$cache_after" ]] || fail "cache/Tap grew on follow-up (before=$cache_before after=$cache_after)"
+pass "follow-up tap install consumed cache and populated Cellar/$TAP_NAME"
+
+# ── 8. mt doctor reports tap-cache size; purge --cache reclaims it. ───
+DOCTOR_LOG="$PREFIX/doctor.log"
+"$BIN" doctor >"$DOCTOR_LOG" 2>&1 || true
+grep -q "Tap archive cache" "$DOCTOR_LOG" || fail "mt doctor did not surface tap-cache size"
+pass "mt doctor reports tap-cache size"
+
+PURGE_LOG="$PREFIX/purge.log"
+# Sleep 2 so the cache file's mtime is reliably > 0 seconds in the
+# past; otherwise the recursive walker's `now - mtime > max_age_secs`
+# check could miss a same-second file when max_age_days=0.
+sleep 2
+"$BIN" purge --cache=0 --yes >"$PURGE_LOG" 2>&1 || {
+  tail -40 "$PURGE_LOG" >&2
+  fail "purge --cache=0 failed"
+}
+tap_cache_after_purge=$(find "$PREFIX/cache/Tap" -mindepth 1 -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+[[ "$tap_cache_after_purge" = "0" ]] || fail "purge --cache=0 left tap cache entries ($tap_cache_after_purge remaining)"
+pass "purge --cache=0 reclaimed tap cache entries"
+
 printf '\n✔ install-download-only regression test passed\n'

--- a/scripts/regressions/tap_formula_url_version.sh
+++ b/scripts/regressions/tap_formula_url_version.sh
@@ -12,12 +12,16 @@
 # This script asserts the end-to-end install against a live tap whose
 # formula has no `version` directive:
 #   1. `malt install aeroxy/tap/ast-outline` exits 0.
-#   2. The install log surfaces the derived version (`Found ast-outline 2.0.0`),
+#   2. The install log surfaces the derived version (`Found ast-outline 2.1.1`),
 #      proving the parser took the URL-derivation branch rather than an
 #      explicit-version branch.
-#   3. The keg is materialised at `$PREFIX/Cellar/ast-outline/2.0.0/...`
+#   3. The keg is materialised at `$PREFIX/Cellar/ast-outline/2.1.1/...`
 #      and `$PREFIX/bin/ast-outline` symlinks into it.
-#   4. The installed binary runs `--version` and reports `2.0.0`.
+#   4. The installed binary runs `--version` and reports `2.1.1`.
+#
+# `EXPECTED_VERSION` tracks the upstream tap's latest release — bump
+# it when `aeroxy/ast-outline` cuts a new tag, since the formula
+# always points at HEAD.
 #
 # Usage: scripts/regressions/tap_formula_url_version.sh
 # Requirements: built malt at $MALT_BIN or zig-out/bin/malt, network
@@ -50,7 +54,7 @@ fail() {
 
 SLUG="aeroxy/tap/ast-outline"
 TOKEN="ast-outline"
-EXPECTED_VERSION="2.0.0"
+EXPECTED_VERSION="2.1.1"
 LOG="$PREFIX/install.log"
 
 printf '▸ malt install %s (logs → %s)\n' "$SLUG" "$LOG"

--- a/scripts/smokes/local-smoke-install.sh
+++ b/scripts/smokes/local-smoke-install.sh
@@ -302,6 +302,87 @@ install_only_deps_wget() {
   fi
 }
 
+# Warm-cache reuse for the tap-archive cache: `--download-only` populates
+# `$PREFIX/cache/Tap/<sha>.<ext>` and leaves Cellar+kegs untouched; a
+# follow-up `mt install` consumes the warmed bytes without growing the
+# cache. The single new install-surface contract from T-048 — the
+# bottle/cask warm-reuse paths are pinned by
+# `scripts/regressions/install_download_only.sh`.
+#
+# Transient tap-resolution failures (rate limit, DNS blip) shape-match
+# the existing `install_tap_tmp_cleanup` regression handling: SKIP, not
+# FAIL, so the smoke stays honest about what's verifiable today.
+install_download_only_tap_reuse() {
+  local tag="smoke.install.download_only.tap"
+  local slug="indaco/tap/sley"
+  local name="sley"
+  local cache_dir="$PREFIX/cache/Tap"
+
+  local dl_log
+  dl_log="$LOGDIR/$(printf '%s' "$tag.dl" | tr -c 'A-Za-z0-9' _).log"
+  printf '  RUN   [%s.dl] %s install --download-only %s\n' "$tag" "$MT_BIN" "$slug"
+  if ! "$MT_BIN" install --download-only "$slug" >"$dl_log" 2>&1; then
+    if grep -qE "rate limit|Network failure|Cannot fetch tap from GitHub|Tap formula/cask not found" "$dl_log"; then
+      printf '  SKIP  [%s] %s: transient classified failure\n' "$tag" "$slug"
+      SKIP=$((SKIP + 1))
+      SKIPS+=("$tag")
+      return
+    fi
+    printf '  FAIL  [%s.dl] %s --download-only failed\n' "$tag" "$slug"
+    tail -30 "$dl_log" | sed 's/^/        | /'
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$tag.dl")
+    return
+  fi
+  printf '  PASS  [%s.dl] %s --download-only completed\n' "$tag" "$slug"
+  PASS=$((PASS + 1))
+
+  if [[ -d "$PREFIX/Cellar/$name" ]]; then
+    printf '  FAIL  [%s.dl.cellar] Cellar/%s populated by --download-only\n' "$tag" "$name"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$tag.dl.cellar")
+    return
+  fi
+  printf '  PASS  [%s.dl.cellar] Cellar/%s absent after --download-only\n' "$tag" "$name"
+  PASS=$((PASS + 1))
+
+  local cache_before
+  cache_before=$(find "$cache_dir" -mindepth 1 -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+  if [[ "$cache_before" -lt 1 ]]; then
+    printf '  FAIL  [%s.dl.cache] cache/Tap empty after --download-only\n' "$tag"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$tag.dl.cache")
+    return
+  fi
+  printf '  PASS  [%s.dl.cache] cache/Tap holds %s archive(s)\n' "$tag" "$cache_before"
+  PASS=$((PASS + 1))
+
+  if ! run "$tag.reuse" "$MT_BIN" install "$slug"; then
+    return
+  fi
+  INSTALLED_FORMULAS+=("$name")
+
+  if [[ ! -d "$PREFIX/Cellar/$name" ]]; then
+    printf '  FAIL  [%s.reuse.cellar] Cellar/%s missing after follow-up install\n' "$tag" "$name"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$tag.reuse.cellar")
+    return
+  fi
+  printf '  PASS  [%s.reuse.cellar] Cellar/%s populated by follow-up install\n' "$tag" "$name"
+  PASS=$((PASS + 1))
+
+  local cache_after
+  cache_after=$(find "$cache_dir" -mindepth 1 -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+  if [[ "$cache_after" != "$cache_before" ]]; then
+    printf '  FAIL  [%s.reuse.cache] cache/Tap grew on follow-up (before=%s after=%s)\n' "$tag" "$cache_before" "$cache_after"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$tag.reuse.cache")
+    return
+  fi
+  printf '  PASS  [%s.reuse.cache] cache/Tap stable across reuse (count=%s)\n' "$tag" "$cache_after"
+  PASS=$((PASS + 1))
+}
+
 # Reverse what we installed. Casks first because they touch /Applications;
 # formulas second (they live entirely under MALT_PREFIX, but uninstalling
 # also exercises the uninstall path). Best-effort: a stuck uninstall must
@@ -327,6 +408,7 @@ printf '  CACHE=%s\n' "$CACHE"
 printf '  MT_BIN=%s\n\n' "$MT_BIN"
 
 run smoke.update "$MT_BIN" update
+install_download_only_tap_reuse
 install_formula smoke.install.node node
 install_formula smoke.install.zig zig
 install_formula smoke.install.rust rust

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -253,7 +253,7 @@ pub const zsh_script =
     \\                        '--local[Install from a local .rb path]:formula:_files -g "*.rb"' \
     \\                        '--dry-run[Show what would be installed]' \
     \\                        '--force[Overwrite existing installations]' \
-    \\                        '--download-only[Warm the bottle store or cask cache; skip install]' \
+    \\                        '--download-only[Warm the bottle, cask, or tap-archive cache; skip install]' \
     \\                        '--only-dependencies[Install transitive deps, skip the requested package]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
     \\                        '--json[Output result as JSON]' \
@@ -520,7 +520,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l local   -d 'Install from a local .rb path'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l dry-run -d 'Preview'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l force   -d 'Overwrite existing'
-    \\    complete -c $__malt_bin -n '__malt_using_command install' -l download-only -d 'Warm the bottle store or cask cache; skip install'
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l download-only -d 'Warm the bottle, cask, or tap-archive cache; skip install'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l only-dependencies -d 'Install transitive deps; skip the requested package'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l json    -d 'JSON output'
     \\

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -12,6 +12,7 @@ const lock_mod = @import("../db/lock.zig");
 const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
+const tap_cache_mod = @import("../core/tap_cache.zig");
 const clonefile = @import("../fs/clonefile.zig");
 const parser = @import("../macho/parser.zig");
 const client_mod = @import("../net/client.zig");
@@ -125,6 +126,46 @@ pub fn emitCaskHistoryReport(allocator: std.mem.Allocator, io: std.Io, prefix: [
     output.writeStderrAll(aw.written());
 }
 
+/// Walk `<prefix>/cache/Tap` and emit the warmed tap-archive size
+/// alongside doctor's other reports. Routes to stdout (JSON) with a
+/// stable schema (zero values, not omission) or to stderr (human),
+/// which stays silent when the cache is empty so the clean case adds
+/// no noise. Pure read; safe to invoke from `execute` post-checks.
+pub fn emitTapCacheReport(allocator: std.mem.Allocator, io: std.Io, prefix: []const u8) void {
+    const bytes = tap_cache_mod.bytesUnder(io, allocator, prefix);
+
+    if (output.isJson()) {
+        var aw: std.Io.Writer.Allocating = .init(allocator);
+        defer aw.deinit();
+        aw.writer.print("{{\"tap_cache\":{{\"bytes\":{d}}}}}\n", .{bytes}) catch return;
+        output.writeStdoutAll(aw.written());
+        return;
+    }
+
+    if (bytes == 0) return;
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    var size_buf: [32]u8 = undefined;
+    const size = formatBytes(bytes, &size_buf);
+    aw.writer.print("  > Tap archive cache: {s}. Run: mt purge --cache\n", .{size}) catch return;
+    output.writeStderrAll(aw.written());
+}
+
+/// Local mirror of `cli/purge/util.zig::formatBytes` / the cask-history
+/// formatter — doctor can't reach across the sibling-CLI boundary into
+/// `cli/purge`, and the byte format must match what `purge --cache`
+/// would surface so users see one number shape across both commands.
+fn formatBytes(bytes: u64, buf: []u8) []const u8 {
+    const units = [_][]const u8{ "B", "KB", "MB", "GB", "TB" };
+    var value: f64 = @floatFromInt(bytes);
+    var unit: usize = 0;
+    while (value >= 1024.0 and unit + 1 < units.len) {
+        value /= 1024.0;
+        unit += 1;
+    }
+    return std.fmt.bufPrint(buf, "{d:.1} {s}", .{ value, units[unit] }) catch "?";
+}
+
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(ctx, args, "doctor")) return;
 
@@ -151,6 +192,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     }, &checks);
 
     emitCaskHistoryReport(allocator, ctx.io, prefix);
+    emitTapCacheReport(allocator, ctx.io, prefix);
 
     if (fix_requested) {
         output.plain("", .{});
@@ -971,6 +1013,80 @@ test "resetFixHint: clears a previously-armed flag" {
     var captured = try captureFixEmit(testing.allocator, false);
     defer captured.deinit(testing.allocator);
     try testing.expect(!fixHintEmitted(captured.items));
+}
+
+test "emitTapCacheReport: silent on stderr when cache is empty" {
+    // No `cache/Tap` entries → no extra line under the check rows.
+    // A change that surfaced an "always-on" zero line would noise up
+    // every clean run, so pin the silent shape.
+    const allocator = testing.allocator;
+    const ts = std.Io.Clock.real.now(std.Options.debug_io).toNanoseconds();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_doctor_tap_empty_{d}", .{ts});
+    std.Io.Dir.cwd().deleteTree(std.Options.debug_io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(std.Options.debug_io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &buf);
+    defer output.endStderrCapture();
+    emitTapCacheReport(allocator, std.Options.debug_io, prefix);
+
+    try testing.expectEqualStrings("", buf.items);
+}
+
+test "emitTapCacheReport: emits stable JSON schema even when cache is empty" {
+    // Doctor's JSON consumers must always be able to read
+    // `tap_cache.bytes` — omitting the field on the empty case
+    // forces every consumer to special-case a null/missing path.
+    const allocator = testing.allocator;
+    const ts = std.Io.Clock.real.now(std.Options.debug_io).toNanoseconds();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_doctor_tap_json_empty_{d}", .{ts});
+
+    output.setMode(.json);
+    defer output.setMode(.human);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &buf);
+    defer output.endStdoutCapture();
+    emitTapCacheReport(allocator, std.Options.debug_io, prefix);
+
+    try testing.expectEqualStrings("{\"tap_cache\":{\"bytes\":0}}\n", buf.items);
+}
+
+test "emitTapCacheReport: human one-liner when cache holds bytes" {
+    const allocator = testing.allocator;
+    const ts = std.Io.Clock.real.now(std.Options.debug_io).toNanoseconds();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_doctor_tap_full_{d}", .{ts});
+    std.Io.Dir.cwd().deleteTree(std.Options.debug_io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(std.Options.debug_io, prefix) catch {};
+
+    var cache_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_dir = try std.fmt.bufPrint(&cache_dir_buf, "{s}/cache/Tap", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(std.Options.debug_io, cache_dir);
+
+    var entry_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const entry = try std.fmt.bufPrint(&entry_buf, "{s}/{s}.tar.gz", .{ cache_dir, "ab" ** 32 });
+    {
+        const f = try std.Io.Dir.createFileAbsolute(std.Options.debug_io, entry, .{});
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "x" ** 256);
+    }
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &buf);
+    defer output.endStderrCapture();
+    emitTapCacheReport(allocator, std.Options.debug_io, prefix);
+
+    try testing.expectEqualStrings(
+        "  > Tap archive cache: 256.0 B. Run: mt purge --cache\n",
+        buf.items,
+    );
 }
 
 test "checks table includes the mirror-overrides row" {

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -73,11 +73,12 @@ const install_help =
     \\  --only-dependencies  Install transitive deps but skip the requested package
     \\                     (deps are recorded as `dependency` so `mt purge --unused-deps`
     \\                     can later GC them)
-    \\  --download-only    Warm the bottle store (formulas) or the Cask cache (casks)
-    \\                     and stop before materialise/link/record. The Cellar,
-    \\                     /Applications, and DB stay untouched; a follow-up
-    \\                     `mt install` consumes the cached bytes. Tap formulas
-    \\                     are not supported yet. Refused with --only-dependencies.
+    \\  --download-only    Warm the bottle store (formulas), the Cask cache (casks),
+    \\                     or the tap archive cache (`<prefix>/cache/Tap/` for
+    \\                     `user/repo/<formula>`) and stop before materialise/link/
+    \\                     record. The Cellar, /Applications, and DB stay untouched;
+    \\                     a follow-up `mt install` consumes the cached bytes.
+    \\                     Refused with --only-dependencies.
     \\  --use-system-ruby[=<name>,...]  Run post_install via the system Ruby interpreter
     \\                     (experimental, sandboxed). A bare flag requires a single
     \\                     package; use =<name>,... to scope when installing multiple.

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -596,7 +596,7 @@ fn executeWithOpts(
 
         // Handle tap formulas separately (they don't use GHCR)
         if (isTapFormula(pkg_name)) {
-            installTapFormula(ctx, allocator, pkg_name, &db, &linker, prefix, dry_run, force) catch |e| {
+            installTapFormula(ctx, allocator, pkg_name, &db, &linker, prefix, dry_run, force, download_only) catch |e| {
                 output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
             };
             continue;

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -11,6 +11,7 @@ const atomic = @import("../../fs/atomic.zig");
 const cask_mod = @import("../../core/cask.zig");
 const linker_mod = @import("../../core/linker.zig");
 const tap_mod = @import("../../core/tap.zig");
+const tap_cache = @import("../../core/tap_cache.zig");
 const client_mod = @import("../../net/client.zig");
 const hash = @import("../../core/hash.zig");
 const output = @import("../../ui/output.zig");
@@ -39,8 +40,11 @@ pub const max_local_formula_bytes: usize = 1 * 1024 * 1024;
 
 /// Post-parse payload shared by the tap and local-file install paths.
 /// Slices point into caller-owned memory (parsed `.rb`, interpolated
-/// URL buffer) and must outlive `materializeRubyFormula`.
-const ResolvedRubyFormula = struct {
+/// URL buffer) and must outlive `materializeRubyFormula`. `pub` so
+/// `tests/install_download_only_test.zig` can drive the materialise
+/// path with a fabricated payload (cache-hit fixtures, ndjson event
+/// shape).
+pub const ResolvedRubyFormula = struct {
     /// Short formula name — becomes the Cellar dir, bin basename, and
     /// `kegs.name` column.
     name: []const u8,
@@ -150,14 +154,17 @@ pub fn installTapFormula(
     prefix: []const u8,
     dry_run: bool,
     force: bool,
+    download_only: bool,
 ) !void {
-    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, .formula_or_cask);
+    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, download_only, .formula_or_cask);
 }
 
 /// Install a tap cask whose owning tap is already known. Skips the
 /// `Formula/` probe — safe to call from inside an open DB transaction
 /// because the formula branch of `materializeRubyFormula` (which
-/// begins its own transaction) is structurally unreachable.
+/// begins its own transaction) is structurally unreachable. Upgrade
+/// callers never opt into `download_only`, so the legacy false is
+/// hard-wired here rather than forwarded.
 pub fn installTapCask(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
@@ -168,7 +175,7 @@ pub fn installTapCask(
     dry_run: bool,
     force: bool,
 ) !void {
-    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, .cask_only);
+    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, false, .cask_only);
 }
 
 fn installTapRb(
@@ -180,6 +187,7 @@ fn installTapRb(
     prefix: []const u8,
     dry_run: bool,
     force: bool,
+    download_only: bool,
     kind: TapResolveKind,
 ) !void {
     const parts = args.parseTapName(pkg_name) orelse {
@@ -287,7 +295,7 @@ fn installTapRb(
         .app_name = parseCaskApp(resp.body),
         .tap_registration = .{ .url = urls.repo_url, .commit_sha = commit_sha },
     };
-    try materializeRubyFormula(ctx, allocator, resolved, &http, db, linker, prefix, dry_run, force);
+    try materializeRubyFormula(ctx, allocator, resolved, &http, db, linker, prefix, dry_run, force, download_only);
 }
 
 /// Install a formula from a local `.rb` file on disk. Gated by the
@@ -417,7 +425,10 @@ pub fn installLocalFormula(
 
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
-    try materializeRubyFormula(ctx, allocator, resolved, &http, db, linker, prefix, dry_run, force);
+    // `--local` is out of scope for `--download-only`: the user already
+    // holds the archive on disk so warming a tap-cache entry adds no
+    // value. Hard-wire false here rather than threading the flag.
+    try materializeRubyFormula(ctx, allocator, resolved, &http, db, linker, prefix, dry_run, force, false);
 }
 
 /// Ordered set of advisory risk labels that may fire on a `.rb` file
@@ -465,7 +476,10 @@ pub fn formatTapDownloadName(
 /// Shared "from parsed `.rb` to linked keg" path, used by the tap and
 /// local installers. Does the network fetch for the archive, SHA256
 /// verification, cellar materialisation, and DB + linker commit.
-fn materializeRubyFormula(
+/// `pub` so the integration tests can drive the materialise flow with
+/// a fabricated `ResolvedRubyFormula` (cache-hit fixtures, ndjson
+/// shape) without standing up a tap-resolution stub.
+pub fn materializeRubyFormula(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
     resolved: ResolvedRubyFormula,
@@ -475,6 +489,7 @@ fn materializeRubyFormula(
     prefix: []const u8,
     dry_run: bool,
     force: bool,
+    download_only: bool,
 ) InstallError!void {
     output.info("Found {s} {s}", .{ resolved.name, resolved.version });
 
@@ -491,7 +506,7 @@ fn materializeRubyFormula(
     // mounting, ditto, and `installer` live there. Tar.gz/tar.xz/zip
     // formula archives keep the simple-extract path below.
     if (tapCaskArtifactKind(resolved.url, resolved.app_name != null)) |kind| {
-        return materializeTapCask(ctx, allocator, resolved, db, kind, dry_run, force);
+        return materializeTapCask(ctx, allocator, resolved, db, kind, dry_run, force, download_only);
     }
 
     if (dry_run) {
@@ -499,47 +514,121 @@ fn materializeRubyFormula(
         return;
     }
 
-    // Skip silently when the keg is already present (unless --force).
-    if (!force and record.isInstalled(db, resolved.name)) {
+    // `--download-only` deliberately skips `isInstalled`: a warm
+    // request must refresh the cache regardless of install state.
+    if (!download_only and !force and record.isInstalled(db, resolved.name)) {
         output.info("{s} is already installed", .{resolved.name});
         return;
     }
 
-    // Stream with a progress bar, matching formula/cask downloads.
-    var bar = progress_mod.ProgressBar.init(resolved.name, 0);
-    var download_resp = http.getWithHeaders(resolved.url, &.{}, .{
-        .context = @ptrCast(&bar),
-        .func = &download.progressBridge,
-    }) catch {
-        bar.finish();
-        output.err("Failed to download {s}", .{resolved.name});
+    // Pick the archive kind early so the cache-or-fetch step below
+    // can compose `<prefix>/cache/Tap/<sha>.<ext>` before any HTTP
+    // work. Unknown formats fail fast — no point fetching bytes we
+    // can't extract.
+    const archive_kind = TapArchiveKind.fromUrl(resolved.url) orelse {
+        output.err("Unsupported archive format for {s}: {s}", .{ resolved.name, resolved.url });
+        output.err("Supported formats: .tar.gz, .tar.xz, .zip.", .{});
         return InstallError.DownloadFailed;
     };
-    defer download_resp.deinit();
-    bar.finish();
+    const archive_ext = archive_kind.extension();
 
-    if (download_resp.status != 200) {
-        output.err("Download failed with status {d}", .{download_resp.status});
-        return InstallError.DownloadFailed;
-    }
+    // Same ndjson event shape as the bottle + cask paths so CI
+    // pipelines see one event vocabulary across the dispatcher.
+    if (download_only) output.emitNdjsonEvent(.download_started, resolved.name, null);
+    // Errdefer guarantees a paired `download_complete` even on the
+    // error paths below; the success branch sets the flag first so we
+    // never double-fire.
+    var dl_complete_emitted = false;
+    errdefer if (download_only and !dl_complete_emitted) {
+        output.emitNdjsonEvent(.download_complete, resolved.name, "failed");
+    };
 
-    // Verify SHA256 before anything touches the filesystem.
-    var digest: [32]u8 = undefined;
-    std.crypto.hash.sha2.Sha256.hash(download_resp.body, &digest, .{});
-    var hex_buf: [64]u8 = undefined;
-    const hex_chars = "0123456789abcdef";
-    for (digest, 0..) |b, i| {
-        hex_buf[i * 2] = hex_chars[b >> 4];
-        hex_buf[i * 2 + 1] = hex_chars[b & 0x0f];
-    }
-    const computed: []const u8 = &hex_buf;
+    // Prefer the persistent cache; fall back to a network fetch that
+    // publishes via atomic rename. Either branch yields `cache_path`
+    // as the on-disk source the extractor reads from below.
+    var cache_path_buf: [512]u8 = undefined;
+    const cache_path = blk: {
+        if (tap_cache.exists(ctx.io, prefix, resolved.sha256, archive_ext)) {
+            // Warm cache: skip the fetch. SHA-keyed filename is its
+            // own verification — a follow-up install of the same
+            // formula consumes the warmed bytes instead of refetching.
+            break :blk tap_cache.cachePath(&cache_path_buf, prefix, resolved.sha256, archive_ext) catch
+                return InstallError.DownloadFailed;
+        }
 
-    // Constant-time compare on the SHA256: a stock `mem.eql` leaks
-    // per-byte progress via timing, giving an adaptive attacker a
-    // byte-by-byte oracle against the expected hash.
-    if (!hash.constantTimeEql(u8, computed, resolved.sha256)) {
-        output.err("SHA256 mismatch for {s}", .{resolved.name});
-        return InstallError.DownloadFailed;
+        // Cold cache: stream the archive into pid-suffixed staging,
+        // SHA-verify the in-memory body, then atomic-rename to the
+        // permanent cache path. A crash mid-write leaves only the
+        // staging file (which `mt doctor --fix` and the tap-tmp
+        // cleanup regression already reclaim).
+        var bar = progress_mod.ProgressBar.init(resolved.name, 0);
+        var download_resp = http.getWithHeaders(resolved.url, &.{}, .{
+            .context = @ptrCast(&bar),
+            .func = &download.progressBridge,
+        }) catch {
+            bar.finish();
+            output.err("Failed to download {s}", .{resolved.name});
+            return InstallError.DownloadFailed;
+        };
+        defer download_resp.deinit();
+        bar.finish();
+
+        if (download_resp.status != 200) {
+            output.err("Download failed with status {d}", .{download_resp.status});
+            return InstallError.DownloadFailed;
+        }
+
+        var digest: [32]u8 = undefined;
+        std.crypto.hash.sha2.Sha256.hash(download_resp.body, &digest, .{});
+        var hex_buf: [64]u8 = undefined;
+        const hex_chars = "0123456789abcdef";
+        for (digest, 0..) |b, i| {
+            hex_buf[i * 2] = hex_chars[b >> 4];
+            hex_buf[i * 2 + 1] = hex_chars[b & 0x0f];
+        }
+        const computed: []const u8 = &hex_buf;
+
+        // Constant-time compare on the SHA256: a stock `mem.eql`
+        // leaks per-byte progress via timing, giving an adaptive
+        // attacker a byte-by-byte oracle against the expected hash.
+        if (!hash.constantTimeEql(u8, computed, resolved.sha256)) {
+            output.err("SHA256 mismatch for {s}", .{resolved.name});
+            return InstallError.DownloadFailed;
+        }
+
+        var tmp_buf: [512]u8 = undefined;
+        const tmp_archive = formatTapDownloadName(&tmp_buf, prefix, archive_ext, std.c.getpid()) catch
+            return InstallError.DownloadFailed;
+
+        const tmp_file = std.Io.Dir.createFileAbsolute(ctx.io, tmp_archive, .{}) catch return InstallError.DownloadFailed;
+        tmp_file.writeStreamingAll(ctx.io, download_resp.body) catch {
+            tmp_file.close(ctx.io);
+            std.Io.Dir.cwd().deleteFile(ctx.io, tmp_archive) catch {};
+            return InstallError.DownloadFailed;
+        };
+        tmp_file.close(ctx.io);
+        // promoteStagingToCache succeeds → tmp_archive no longer
+        // exists at its source path. On failure we still wipe it so
+        // the next run's pid collision space stays clean.
+        errdefer std.Io.Dir.cwd().deleteFile(ctx.io, tmp_archive) catch {};
+        break :blk tap_cache.promoteStagingToCache(
+            ctx.io,
+            prefix,
+            resolved.sha256,
+            archive_ext,
+            tmp_archive,
+            &cache_path_buf,
+        ) catch return InstallError.DownloadFailed;
+    };
+
+    // `--download-only` stops once the cache holds the SHA-verified
+    // bytes — no Cellar writes, no DB inserts. A follow-up
+    // `mt install` consumes the warmed entry above.
+    if (download_only) {
+        output.emitNdjsonEvent(.download_complete, resolved.name, "ok");
+        dl_complete_emitted = true;
+        output.success("{s} {s} downloaded to {s}", .{ resolved.name, resolved.version, cache_path });
+        return;
     }
 
     // Extract to Cellar directly (tap-style binaries are simple archives).
@@ -575,38 +664,17 @@ fn materializeRubyFormula(
         else => return InstallError.CellarFailed,
     };
 
-    // Pick archive kind from the URL suffix; reject unknown formats
-    // rather than feeding them to tar and printing a generic "failed".
-    const archive_kind = TapArchiveKind.fromUrl(resolved.url) orelse {
-        output.err("Unsupported archive format for {s}: {s}", .{ resolved.name, resolved.url });
-        output.err("Supported formats: .tar.gz, .tar.xz, .zip.", .{});
-        return InstallError.DownloadFailed;
-    };
-    var tmp_buf: [512]u8 = undefined;
-    const tmp_archive = formatTapDownloadName(&tmp_buf, prefix, archive_kind.extension(), std.c.getpid()) catch
-        return InstallError.DownloadFailed;
-
-    const tmp_file = std.Io.Dir.createFileAbsolute(ctx.io, tmp_archive, .{}) catch return InstallError.DownloadFailed;
-    tmp_file.writeStreamingAll(ctx.io, download_resp.body) catch {
-        tmp_file.close(ctx.io);
-        return InstallError.DownloadFailed;
-    };
-    tmp_file.close(ctx.io);
-    // Best-effort cleanup; the per-pid name keeps a leak (panic / SIGKILL)
-    // from colliding with the next install's archive.
-    defer std.Io.Dir.cwd().deleteFile(ctx.io, tmp_archive) catch {};
-
     const archive_mod = @import("../../fs/archive.zig");
     switch (archive_kind) {
-        .tar_gz => archive_mod.extractTarGz(ctx.io, tmp_archive, cellar_path) catch {
+        .tar_gz => archive_mod.extractTarGz(ctx.io, cache_path, cellar_path) catch {
             output.err("Failed to extract archive for {s}", .{resolved.name});
             return InstallError.CellarFailed;
         },
-        .tar_xz => archive_mod.extractTarXzFile(ctx.io, tmp_archive, cellar_path) catch {
+        .tar_xz => archive_mod.extractTarXzFile(ctx.io, cache_path, cellar_path) catch {
             output.err("Failed to extract .tar.xz archive for {s}", .{resolved.name});
             return InstallError.CellarFailed;
         },
-        .zip => archive_mod.extractZip(ctx.io, tmp_archive, cellar_path) catch {
+        .zip => archive_mod.extractZip(ctx.io, cache_path, cellar_path) catch {
             output.err("Failed to extract .zip archive for {s}", .{resolved.name});
             return InstallError.CellarFailed;
         },
@@ -713,7 +781,9 @@ fn materializeRubyFormula(
 /// minting a Homebrew-API-shaped JSON document from the parsed Ruby
 /// directives. Reuses every download/SHA/extract path the brew-API
 /// cask flow already exercises — the only thing the tap path adds is
-/// the JSON adapter.
+/// the JSON adapter. When `download_only` is set, the cask installer's
+/// `downloadOnly` seam reuses the existing `<prefix>/cache/Cask/`
+/// layout established by T-028 instead of writing to `cache/Tap/`.
 fn materializeTapCask(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
@@ -722,8 +792,13 @@ fn materializeTapCask(
     kind: cask_mod.ArtifactType,
     dry_run: bool,
     force: bool,
+    download_only: bool,
 ) InstallError!void {
-    if (!force and cask_mod.isInstalled(db, resolved.name)) {
+    // `--download-only` deliberately ignores `isInstalled` so a user
+    // can refresh the cached artefact ahead of an `mt upgrade` even
+    // when an older revision is on disk. The regular install path
+    // keeps the "already installed" short-circuit.
+    if (!download_only and !force and cask_mod.isInstalled(db, resolved.name)) {
         output.info("{s} is already installed", .{resolved.name});
         return;
     }
@@ -759,6 +834,29 @@ fn materializeTapCask(
 
     if (kind == .pkg) {
         output.warn("{s} is a PKG cask and requires sudo to install via macOS Installer.", .{cask.token});
+    }
+
+    // `--download-only` for a cask-shaped tap entry reuses the cask
+    // cache established by T-028 (`<prefix>/cache/Cask/`). The shared
+    // `downloadOnly` seam handles sha-verify against the archive
+    // bytes; we stop before /Applications writes and DB inserts.
+    if (download_only) {
+        output.emitNdjsonEvent(.download_started, cask.token, null);
+        const cache_path = installer.downloadOnly(&cask) catch |e| {
+            bar.finish();
+            output.emitNdjsonEvent(.download_complete, cask.token, "failed");
+            output.err("Failed to download cask {s}: {s}", .{ cask.token, @errorName(e) });
+            return switch (e) {
+                error.DownloadFailed, error.Sha256Mismatch => InstallError.DownloadFailed,
+                error.OutOfMemory => InstallError.RecordFailed,
+                else => InstallError.CaskNotFound,
+            };
+        };
+        bar.finish();
+        defer allocator.free(cache_path);
+        output.emitNdjsonEvent(.download_complete, cask.token, "ok");
+        output.success("{s} {s} downloaded to {s}", .{ cask.token, cask.version, cache_path });
+        return;
     }
 
     const app_path = installer.install(&cask) catch |e| {

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -478,7 +478,7 @@ fn upgradeTapFormula(
     defer allocator.free(full_name);
 
     var linker = linker_mod.Linker.init(ctx.io, allocator, db, prefix);
-    install_local_mod.installTapFormula(ctx, allocator, full_name, db, &linker, prefix, dry_run, true) catch {
+    install_local_mod.installTapFormula(ctx, allocator, full_name, db, &linker, prefix, dry_run, true, false) catch {
         output.err("Failed to upgrade tap formula {s}", .{full_name});
         return error.Aborted;
     };

--- a/src/core/tap_cache.zig
+++ b/src/core/tap_cache.zig
@@ -1,0 +1,218 @@
+//! Persistent cache for tap-formula archives. Layout:
+//! `<prefix>/cache/Tap/<sha256>.<ext>`. Keyed by the .rb-declared
+//! SHA so two archives can never collide on the filename; lifetime is
+//! managed by `mt purge --cache` (age-based) and `mt doctor` (size
+//! reporting). Sibling to the cask cache at `<prefix>/cache/Cask/`.
+
+const std = @import("std");
+
+/// Compose the canonical cache path for a tap archive. `ext` includes
+/// the leading dot (e.g. `.tar.gz`, `.zip`). Pure: no filesystem
+/// access; surfaces `NoSpaceLeft` on buffer overflow so the caller
+/// can fail loud instead of stranding bytes at a truncated path.
+pub fn cachePath(buf: []u8, prefix: []const u8, sha256: []const u8, ext: []const u8) ![]const u8 {
+    return std.fmt.bufPrint(buf, "{s}/cache/Tap/{s}{s}", .{ prefix, sha256, ext });
+}
+
+/// Idempotent `mkdir -p` for `<prefix>/cache/Tap`. Safe across
+/// concurrent installs — `PathAlreadyExists` is the expected hot
+/// path and not an error.
+pub fn ensureCacheDir(io: std.Io, prefix: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const dir = try std.fmt.bufPrint(&buf, "{s}/cache/Tap", .{prefix});
+    std.Io.Dir.createDirAbsolute(io, dir, .default_dir) catch |e| switch (e) {
+        error.PathAlreadyExists => return,
+        else => return e,
+    };
+}
+
+/// Single-`access` probe of the cache entry for `(sha256, ext)`. Hot
+/// path for the "warm cache" short-circuit: a cache hit lets the
+/// caller skip both the HTTP archive fetch and the SHA recomputation
+/// (the filename IS the SHA).
+pub fn exists(io: std.Io, prefix: []const u8, sha256: []const u8, ext: []const u8) bool {
+    var buf: [512]u8 = undefined;
+    const path = cachePath(&buf, prefix, sha256, ext) catch return false;
+    std.Io.Dir.accessAbsolute(io, path, .{}) catch return false;
+    return true;
+}
+
+/// Atomically promote a freshly-written staging archive to its
+/// permanent SHA-keyed cache slot. Returns the cache path on success.
+/// The rename is the publish point: a crash mid-write leaves only the
+/// pid-suffixed staging file (which `mt doctor` and the existing
+/// `install_tap_tmp_cleanup` regression already wipe), never a half-
+/// written archive at a permanent filename. Caller has already
+/// SHA-verified the staging bytes.
+pub fn promoteStagingToCache(
+    io: std.Io,
+    prefix: []const u8,
+    sha256: []const u8,
+    ext: []const u8,
+    staging_path: []const u8,
+    cache_path_buf: []u8,
+) ![]const u8 {
+    try ensureCacheDir(io, prefix);
+    const cache_path = try cachePath(cache_path_buf, prefix, sha256, ext);
+    // rename(2) is atomic on the same filesystem — staging + cache
+    // live under the same `<prefix>` so this is the hot path.
+    try std.Io.Dir.renameAbsolute(staging_path, cache_path, io);
+    return cache_path;
+}
+
+/// Recursive byte sum under `<prefix>/cache/Tap`. Best-effort: any
+/// I/O failure contributes zero so doctor's read stays infallible.
+pub fn bytesUnder(io: std.Io, allocator: std.mem.Allocator, prefix: []const u8) u64 {
+    var buf: [512]u8 = undefined;
+    const dir_path = std.fmt.bufPrint(&buf, "{s}/cache/Tap", .{prefix}) catch return 0;
+    var dir = std.Io.Dir.openDirAbsolute(io, dir_path, .{ .iterate = true }) catch return 0;
+    defer dir.close(io);
+    var walker = dir.walk(allocator) catch return 0;
+    defer walker.deinit();
+    var total: u64 = 0;
+    while (walker.next(io) catch null) |entry| {
+        if (entry.kind != .file) continue;
+        const stat = std.Io.Dir.statFile(entry.dir, io, entry.basename, .{}) catch continue;
+        total += stat.size;
+    }
+    return total;
+}
+
+test "cachePath: composes prefix/cache/Tap/<sha>.<ext>" {
+    var buf: [256]u8 = undefined;
+    const got = try cachePath(&buf, "/opt/h", "ab" ** 32, ".tar.gz");
+    try std.testing.expectEqualStrings(
+        "/opt/h/cache/Tap/" ++ ("ab" ** 32) ++ ".tar.gz",
+        got,
+    );
+}
+
+test "cachePath: surfaces NoSpaceLeft on buffer overflow" {
+    // Truncating to a half-written path would later strand bytes at
+    // the wrong location. Fail loud instead.
+    var buf: [4]u8 = undefined;
+    try std.testing.expectError(
+        error.NoSpaceLeft,
+        cachePath(&buf, "/opt/h", "ab" ** 32, ".tar.gz"),
+    );
+}
+
+test "cachePath: distinct SHAs produce distinct paths" {
+    // The SHA is the only collision-defeating component, so a
+    // typo in the formatter that dropped it would fail this.
+    var a: [256]u8 = undefined;
+    var b: [256]u8 = undefined;
+    const p1 = try cachePath(&a, "/opt/h", "ab" ** 32, ".zip");
+    const p2 = try cachePath(&b, "/opt/h", "cd" ** 32, ".zip");
+    try std.testing.expect(!std.mem.eql(u8, p1, p2));
+}
+
+test "exists: returns false when cache dir absent" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    const prefix = try std.fmt.bufPrint(&buf, "/tmp/malt_tap_cache_exists_absent_{d}", .{ts});
+    try std.testing.expect(!exists(io, prefix, "ab" ** 32, ".tar.gz"));
+}
+
+test "exists: returns true when SHA-keyed entry is on disk" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_tap_cache_exists_hit_{d}", .{ts});
+    std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+
+    var cache_parent_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_parent = try std.fmt.bufPrint(&cache_parent_buf, "{s}/cache", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(io, cache_parent);
+    try ensureCacheDir(io, prefix);
+
+    var entry_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const entry = try cachePath(&entry_buf, prefix, "cd" ** 32, ".zip");
+    const f = try std.Io.Dir.createFileAbsolute(io, entry, .{});
+    f.close(io);
+
+    try std.testing.expect(exists(io, prefix, "cd" ** 32, ".zip"));
+    try std.testing.expect(!exists(io, prefix, "ee" ** 32, ".zip"));
+}
+
+test "promoteStagingToCache: renames staging file to SHA-keyed slot" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_tap_cache_promote_{d}", .{ts});
+    std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+
+    inline for ([_][]const u8{ "/tmp", "/cache" }) |sub| {
+        var b: [std.fs.max_path_bytes]u8 = undefined;
+        const p = try std.fmt.bufPrint(&b, "{s}{s}", .{ prefix, sub });
+        try std.Io.Dir.cwd().createDirPath(io, p);
+    }
+
+    var staging_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const staging = try std.fmt.bufPrint(&staging_buf, "{s}/tmp/tap_download.9999.tar.gz", .{prefix});
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, staging, .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "payload-bytes");
+    }
+
+    var cache_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_path = try promoteStagingToCache(io, prefix, "aa" ** 32, ".tar.gz", staging, &cache_buf);
+
+    var want_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const want = try cachePath(&want_buf, prefix, "aa" ** 32, ".tar.gz");
+    try std.testing.expectEqualStrings(want, cache_path);
+
+    // The rename moved the staging file; the source path must be gone.
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(io, staging, .{}));
+    try std.Io.Dir.accessAbsolute(io, cache_path, .{});
+}
+
+test "bytesUnder: returns 0 when cache dir is absent" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_tap_cache_bytes_absent_{d}", .{ts});
+    // Deliberately do not create <prefix>/cache/Tap.
+    try std.testing.expectEqual(@as(u64, 0), bytesUnder(io, std.testing.allocator, prefix));
+}
+
+test "bytesUnder: sums regular file sizes under cache/Tap" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_tap_cache_bytes_sum_{d}", .{ts});
+    std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+
+    // Production callers reach `ensureCacheDir` only after the
+    // top-level `ensureDirs` has seeded `<prefix>/cache`; mirror
+    // that here so the test pins the production invariant.
+    var cache_parent_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_parent = try std.fmt.bufPrint(&cache_parent_buf, "{s}/cache", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(io, cache_parent);
+
+    try ensureCacheDir(io, prefix);
+
+    var entry_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const entry = try cachePath(&entry_buf, prefix, "00" ** 32, ".tar.gz");
+    const f = try std.Io.Dir.createFileAbsolute(io, entry, .{});
+    defer f.close(io);
+    try f.writeStreamingAll(io, "x" ** 256);
+
+    try std.testing.expectEqual(@as(u64, 256), bytesUnder(io, std.testing.allocator, prefix));
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -68,6 +68,7 @@ pub const services_supervisor = @import("core/services/supervisor.zig");
 pub const signals = @import("core/signals.zig");
 pub const store = @import("core/store.zig");
 pub const tap = @import("core/tap.zig");
+pub const tap_cache = @import("core/tap_cache.zig");
 pub const lock = @import("db/lock.zig");
 pub const schema = @import("db/schema.zig");
 pub const sqlite = @import("db/sqlite.zig");

--- a/tests/install_download_only_test.zig
+++ b/tests/install_download_only_test.zig
@@ -389,6 +389,274 @@ test "--download-only --cask is plumbed into the cask path and threads the flag"
     try testing.expect(std.mem.indexOf(u8, captured.items, "Cask 'ghost-cask' not found") != null);
 }
 
+test "--download-only on tap formula with warm tap cache prints path + skips Cellar" {
+    // Pin the new tap exit point: when `<prefix>/cache/Tap/<sha>.<ext>`
+    // already holds the archive, `materializeRubyFormula` must short-
+    // circuit before the HTTP fetch, print the resolved cache path, and
+    // leave the Cellar + kegs untouched. The URL is deliberately a
+    // non-resolvable host so a regression that drops the cache-hit
+    // branch would surface as a network failure instead of a silent
+    // pass.
+    const prefix = try setupPrefix("tap_warm");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha = "ee" ** 32;
+
+    var cache_parent_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_parent = try std.fmt.bufPrint(&cache_parent_buf, "{s}/cache/Tap", .{prefix});
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_parent);
+
+    var cache_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_path = try malt.tap_cache.cachePath(&cache_path_buf, prefix, sha, ".tar.gz");
+    {
+        const f = try test_io.cwd().createFile(std.Options.debug_io, cache_path, .{});
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "warm-tap-archive-fixture\n");
+    }
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, allocator);
+    defer http.deinit();
+
+    const db_path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "{s}/db/malt.db",
+        .{prefix},
+        0,
+    );
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+
+    var linker = malt.linker.Linker.init(ctx.io, allocator, &db, prefix);
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    const resolved: malt.install_local.ResolvedRubyFormula = .{
+        .name = "tappkg",
+        .full_name = "user/repo/tappkg",
+        .tap_label = "user/repo",
+        .version = "1.0",
+        .url = "https://malt-tap-test.invalid/tappkg-1.0.tar.gz",
+        .sha256 = sha,
+    };
+
+    try malt.install_local.materializeRubyFormula(
+        &ctx,
+        allocator,
+        resolved,
+        &http,
+        &db,
+        &linker,
+        prefix,
+        false, // dry_run
+        false, // force
+        true, // download_only
+    );
+
+    const want = try std.fmt.allocPrint(
+        testing.allocator,
+        "tappkg 1.0 downloaded to {s}",
+        .{cache_path},
+    );
+    defer testing.allocator.free(want);
+    try testing.expect(std.mem.indexOf(u8, captured.items, want) != null);
+
+    const cellar = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/tappkg", .{prefix});
+    defer testing.allocator.free(cellar);
+    try testing.expect(!pathExists(cellar));
+
+    try testing.expectEqual(@as(i64, 0), try kegRowCount(prefix));
+}
+
+test "--download-only --force on tap formula with warm cache is a no-op refresh" {
+    // `--force` semantics for a regular install pre-wipe the Cellar
+    // dir; for `--download-only` there's no Cellar to wipe, and the
+    // cache filename is the SHA so a "force" cannot mean refetch the
+    // same bytes. Pin that the combination prints the cache path,
+    // leaves the cache file intact, and never touches Cellar or kegs.
+    const prefix = try setupPrefix("tap_force");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha = "22" ** 32;
+
+    var cache_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_dir = try std.fmt.bufPrint(&cache_dir_buf, "{s}/cache/Tap", .{prefix});
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_dir);
+
+    var cache_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_path = try malt.tap_cache.cachePath(&cache_path_buf, prefix, sha, ".tar.gz");
+    {
+        const f = try test_io.cwd().createFile(std.Options.debug_io, cache_path, .{});
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "force-tap-fixture\n");
+    }
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, allocator);
+    defer http.deinit();
+
+    const db_path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "{s}/db/malt.db",
+        .{prefix},
+        0,
+    );
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+
+    var linker = malt.linker.Linker.init(ctx.io, allocator, &db, prefix);
+
+    const resolved: malt.install_local.ResolvedRubyFormula = .{
+        .name = "forcetap",
+        .full_name = "user/repo/forcetap",
+        .tap_label = "user/repo",
+        .version = "1.0",
+        .url = "https://malt-tap-test.invalid/forcetap-1.0.tar.gz",
+        .sha256 = sha,
+    };
+
+    try malt.install_local.materializeRubyFormula(
+        &ctx,
+        allocator,
+        resolved,
+        &http,
+        &db,
+        &linker,
+        prefix,
+        false, // dry_run
+        true, // force
+        true, // download_only
+    );
+
+    // Cache file untouched.
+    try test_io.accessAbsolute(std.Options.debug_io, cache_path, .{});
+
+    // Cellar untouched.
+    const cellar = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/forcetap", .{prefix});
+    defer testing.allocator.free(cellar);
+    try testing.expect(!pathExists(cellar));
+
+    try testing.expectEqual(@as(i64, 0), try kegRowCount(prefix));
+}
+
+test "--download-only --ndjson on tap formula emits download_started + complete around fetch" {
+    // Pin the ndjson event vocabulary for the tap path so CI pipelines
+    // can rely on the same `download_started` / `download_complete`
+    // bracket they see on the bottle + cask paths. Warm-cache fixture
+    // keeps the test offline; the events fire either way.
+    const prefix = try setupPrefix("tap_nd");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha = "11" ** 32;
+
+    var cache_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_dir = try std.fmt.bufPrint(&cache_dir_buf, "{s}/cache/Tap", .{prefix});
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_dir);
+
+    var cache_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_path = try malt.tap_cache.cachePath(&cache_path_buf, prefix, sha, ".tar.gz");
+    {
+        const f = try test_io.cwd().createFile(std.Options.debug_io, cache_path, .{});
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "ndjson-tap-fixture\n");
+    }
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, allocator);
+    defer http.deinit();
+
+    const db_path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "{s}/db/malt.db",
+        .{prefix},
+        0,
+    );
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+
+    var linker = malt.linker.Linker.init(ctx.io, allocator, &db, prefix);
+
+    const prior_nd = malt.output.isNdjson();
+    malt.output.setNdjson(true);
+    defer malt.output.setNdjson(prior_nd);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStdoutCapture(testing.allocator, &captured);
+    defer malt.output.endStdoutCapture();
+
+    const resolved: malt.install_local.ResolvedRubyFormula = .{
+        .name = "ndtap",
+        .full_name = "user/repo/ndtap",
+        .tap_label = "user/repo",
+        .version = "1.0",
+        .url = "https://malt-tap-test.invalid/ndtap-1.0.tar.gz",
+        .sha256 = sha,
+    };
+
+    try malt.install_local.materializeRubyFormula(
+        &ctx,
+        allocator,
+        resolved,
+        &http,
+        &db,
+        &linker,
+        prefix,
+        false, // dry_run
+        false, // force
+        true, // download_only
+    );
+
+    try testing.expectEqual(
+        @as(usize, 1),
+        std.mem.count(u8, captured.items, "\"event\":\"download_started\",\"name\":\"ndtap\""),
+    );
+    try testing.expectEqual(
+        @as(usize, 1),
+        std.mem.count(u8, captured.items, "\"event\":\"download_complete\",\"name\":\"ndtap\",\"status\":\"ok\""),
+    );
+}
+
 test "--download-only populates the store and skips Cellar + kegs" {
     // Pre-seed the store so the warm-path branch inside the install pool
     // skips the network entirely. The new exit point must short-circuit


### PR DESCRIPTION
## Description

Extends `mt install --download-only` to tap formulas. A new persistent cache at `<prefix>/cache/Tap/<sha>.<ext>` lets a warmed tap archive be consumed by a subsequent regular install without a second HTTP fetch.

The flow honours the same `--ndjson` event vocabulary (`download_started` / `download_complete`) as the bottle and cask paths established in #382. Cask-shaped tap entries route through the cask cache, so `user/repo/cask-token` warms hit the existing
`<prefix>/cache/Cask/` slot.

`mt purge --cache` reclaims the new directory (the existing recursive walker naturally covers it) and `mt doctor` reports tap-cache size alongside its other reports - silent on the empty case, JSON schema stable.

## Related Issue

- None

## Notes for Reviewers

- None
