### PR TITLE
feat: honour MALT_OFFLINE and --offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you're scanning rather than reading, here is the surface area in one place.
 - **Atomic install protocol.** New versions verified before old versions are touched; `mt rollback --to <version>` reverts from the store with no re-download. Streaming SHA256 + parallel downloads + a 30 s advisory file lock against concurrent mutations.
 - **Ephemeral run.** `mt run <pkg> -- <args...>` extracts and `execvp`s without a permanent install; `--keep` caches the bottle for next time.
 - **Full operational surface.** `mt services` with `status` and `logs --tail/--follow`. `mt bundle` reading both `Brewfile` and `Maltfile.json`. `mt doctor --fix` with a planner and a manual-only set. `mt purge` with composable scopes (`--cache`, `--unused-deps`, `--store-orphans`, `--old-versions`, `--wipe`) and typed-confirmation gates. `mt backup`/`mt restore` for hand-editable manifests. `mt migrate` that relocates a Homebrew install rather than inventorying it. `mt uses` for reverse-dependency queries via SQL.
-- **Scriptable.** `--json` and `--output-format=ndjson` everywhere it makes sense; orthogonal flags. `--quiet`, `--verbose`, `--debug`, `--dry-run` are global. `NO_COLOR`, `MALT_NO_EMOJI`, `MALT_PROGRESS`, `MALT_THEME` for shaping output.
+- **Scriptable.** `--json` and `--output-format=ndjson` everywhere it makes sense; orthogonal flags. `--quiet`, `--verbose`, `--debug`, `--dry-run`, `--offline` are global. `NO_COLOR`, `MALT_NO_EMOJI`, `MALT_PROGRESS`, `MALT_THEME` for shaping output.
 - **Signed, verifiable releases.** Every release is cosign-signed keyless via GitHub OIDC; `install.sh` and `mt version update` verify the signature before trusting the SHA256 checksum. Tap commits are pinned and formula source is SHA256-verified against an embedded manifest. Advance a pin with `mt tap --refresh user/repo`.
 - **Sandboxed `post_install`.** The `--use-system-ruby` path runs inside a `sandbox-exec` profile scoped to the formula's cellar, with a scrubbed environment and `RLIMIT_CPU`/`AS`/`FSIZE` caps. Every mutating op in the native interpreter is validated against the Cellar/malt prefix.
 
@@ -474,38 +474,39 @@ MALT_ALLOW_UNVERIFIED=1 mt version update --no-verify
 
 ### Global flags
 
-| Flag              | Description                                                                     |
-| ----------------- | ------------------------------------------------------------------------------- |
-| `--verbose`, `-v` | Verbose output                                                                  |
-| `--debug`         | Surface every DSL diagnostic (implies verbose); pair with issue reports         |
-| `--quiet`, `-q`   | Suppress non-error output                                                       |
-| `--json`          | JSON output (read commands; also emits per-package `post_install` status lines) |
-| `--dry-run`       | Preview without executing                                                       |
-| `--help`, `-h`    | Show help                                                                       |
-| `--version`       | Show version                                                                    |
+| Flag              | Description                                                                                                      |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `--verbose`, `-v` | Verbose output                                                                                                   |
+| `--debug`         | Surface every DSL diagnostic (implies verbose); pair with issue reports                                          |
+| `--quiet`, `-q`   | Suppress non-error output                                                                                        |
+| `--json`          | JSON output (read commands; also emits per-package `post_install` status lines)                                  |
+| `--dry-run`       | Preview without executing                                                                                        |
+| `--offline`       | Serve every fetch from the snapshot cache; fail fast with `OfflineRequired` on a miss (mirrors `MALT_OFFLINE=1`) |
+| `--help`, `-h`    | Show help                                                                                                        |
+| `--version`       | Show version                                                                                                     |
 
 ### Environment variables
 
-| Variable                        | Description                                                                                                                                     | Default                        |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| `MALT_PREFIX`                   | Override install prefix                                                                                                                         | `/opt/malt`                    |
-| `MALT_CACHE`                    | Override cache directory                                                                                                                        | `{prefix}/cache`               |
-| `NO_COLOR`                      | Disable colored output                                                                                                                          | unset                          |
-| `MALT_NO_EMOJI`                 | Disable emoji in output                                                                                                                         | unset                          |
-| `MALT_NO_VERSION_NOTIFIER`      | Set to `1` to suppress the "newer malt available" notice                                                                                        | unset                          |
-| `MALT_PROGRESS`                 | Progress reporter for `install`/`upgrade`/`migrate`: `tty`, `plain`, or `none` (`CI=true` or `GITHUB_ACTIONS=true` flip the default to `plain`) | `tty`                          |
-| `MALT_THEME`                    | Force the output palette: `light`, `dark`, or `auto` (detects via OSC 11)                                                                       | `auto`                         |
-| `HOMEBREW_GITHUB_API_TOKEN`     | GitHub token for higher API rate limits                                                                                                         | unset                          |
-| `MALT_GITHUB_TOKEN`             | GitHub token sent as `Authorization: Bearer` on tap `/commits/HEAD` calls only                                                                  | unset                          |
-| `MALT_HTTP_IDLE_TIMEOUT_SECS`   | HTTP idle (no-progress) read timeout in seconds (clamped to `[5, 600]`)                                                                         | `30`                           |
-| `MALT_API_DOMAIN`               | Override metadata API base URL; HTTPS only; falls back to `HOMEBREW_API_DOMAIN`                                                                 | `https://formulae.brew.sh/api` |
-| `MALT_BOTTLE_DOMAIN`            | Override bottle registry base URL; HTTPS only; falls back to `HOMEBREW_BOTTLE_DOMAIN`                                                           | `https://ghcr.io`              |
-| `MALT_OFFLINE`                  | Set to `1`/`true` to force `mt search` to the local DB (mirrors `--offline`)                                                                    | unset                          |
-| `MALT_MIGRATE_PARALLEL_WORKERS` | Worker count for `mt migrate --parallel` (clamped to `[1, 32]`)                                                                                 | `4`                            |
-| `MALT_OUTDATED_MAX_AGE`         | TTL in hours for the `outdated.json` snapshot                                                                                                   | `24`                           |
-| `MALT_ALLOW_RAW_POST_INSTALL`   | Disable terminal escape filter on ruby `post_install` output                                                                                    | unset                          |
-| `MALT_ALLOW_UNVERIFIED`         | Skip cosign signature check in `install.sh` (use only when cosign is unavailable)                                                               | unset                          |
-| `MALT_ALLOW_UNVERIFIED_SOURCE`  | Allow `install.sh` to clone `main` when no release tag resolves                                                                                 | unset                          |
+| Variable                        | Description                                                                                                                                              | Default                        |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `MALT_PREFIX`                   | Override install prefix                                                                                                                                  | `/opt/malt`                    |
+| `MALT_CACHE`                    | Override cache directory                                                                                                                                 | `{prefix}/cache`               |
+| `NO_COLOR`                      | Disable colored output                                                                                                                                   | unset                          |
+| `MALT_NO_EMOJI`                 | Disable emoji in output                                                                                                                                  | unset                          |
+| `MALT_NO_VERSION_NOTIFIER`      | Set to `1` to suppress the "newer malt available" notice                                                                                                 | unset                          |
+| `MALT_PROGRESS`                 | Progress reporter for `install`/`upgrade`/`migrate`: `tty`, `plain`, or `none` (`CI=true` or `GITHUB_ACTIONS=true` flip the default to `plain`)          | `tty`                          |
+| `MALT_THEME`                    | Force the output palette: `light`, `dark`, or `auto` (detects via OSC 11)                                                                                | `auto`                         |
+| `HOMEBREW_GITHUB_API_TOKEN`     | GitHub token for higher API rate limits                                                                                                                  | unset                          |
+| `MALT_GITHUB_TOKEN`             | GitHub token sent as `Authorization: Bearer` on tap `/commits/HEAD` calls only                                                                           | unset                          |
+| `MALT_HTTP_IDLE_TIMEOUT_SECS`   | HTTP idle (no-progress) read timeout in seconds (clamped to `[5, 600]`)                                                                                  | `30`                           |
+| `MALT_API_DOMAIN`               | Override metadata API base URL; HTTPS only; falls back to `HOMEBREW_API_DOMAIN`                                                                          | `https://formulae.brew.sh/api` |
+| `MALT_BOTTLE_DOMAIN`            | Override bottle registry base URL; HTTPS only; falls back to `HOMEBREW_BOTTLE_DOMAIN`                                                                    | `https://ghcr.io`              |
+| `MALT_OFFLINE`                  | Set to `1`/`true` to route every fetch through the snapshot cache; misses surface `OfflineRequired` instead of stalling on connect (mirrors `--offline`) | unset                          |
+| `MALT_MIGRATE_PARALLEL_WORKERS` | Worker count for `mt migrate --parallel` (clamped to `[1, 32]`)                                                                                          | `4`                            |
+| `MALT_OUTDATED_MAX_AGE`         | TTL in hours for the `outdated.json` snapshot                                                                                                            | `24`                           |
+| `MALT_ALLOW_RAW_POST_INSTALL`   | Disable terminal escape filter on ruby `post_install` output                                                                                             | unset                          |
+| `MALT_ALLOW_UNVERIFIED`         | Skip cosign signature check in `install.sh` (use only when cosign is unavailable)                                                                        | unset                          |
+| `MALT_ALLOW_UNVERIFIED_SOURCE`  | Allow `install.sh` to clone `main` when no release tag resolves                                                                                          | unset                          |
 
 ## Architecture
 

--- a/build.zig
+++ b/build.zig
@@ -133,6 +133,7 @@ pub fn build(b: *std.Build) void {
         "tests/install_parse_cache_test.zig",
         "tests/deps_leak_test.zig",
         "tests/api_test.zig",
+        "tests/offline_mode_test.zig",
         "tests/clonefile_test.zig",
         "tests/dsl_lexer_test.zig",
         "tests/dsl_parser_test.zig",

--- a/scripts/regressions/offline_mode.sh
+++ b/scripts/regressions/offline_mode.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Lock the `MALT_OFFLINE` / `--offline` contract end-to-end at the binary edge.
+#
+# Four behaviours pinned:
+#   1. Doctor "Offline mode" row reads "off" by default.
+#   2. Doctor "Offline mode" row reads "active" under MALT_OFFLINE=1.
+#   3. Doctor "Offline mode" row reads "active" under --offline.
+#   4. `mt update --check` refuses cleanly under offline (non-zero exit
+#      + canonical message), before any HTTP attempt.
+#
+# Usage: scripts/regressions/offline_mode.sh
+# Requirements: a built malt binary at zig-out/bin/malt (just build).
+# No network access required — only the env probe + doctor render are asserted.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+# Use a throwaway prefix so doctor never touches /opt/malt.
+PREFIX=$(mktemp -d -t malt_offline_reg.XXXXXX)
+trap 'rm -rf "$PREFIX"' EXIT
+
+# Strip any inherited offline env so the host's shell can't poison
+# the deterministic assertions below.
+unset MALT_OFFLINE
+
+run_doctor() {
+  MALT_PREFIX="$PREFIX" "$MALT_BIN" doctor 2>&1 || true
+}
+
+# (1) Defaults — Offline mode row reports off.
+out=$(run_doctor)
+if ! grep -q "Offline mode — off" <<<"$out"; then
+  printf 'FAIL: default offline row missing or wrong text.\n%s\n' "$out" >&2
+  exit 1
+fi
+
+# (2) MALT_OFFLINE=1 → row reads "active".
+out=$(MALT_PREFIX="$PREFIX" MALT_OFFLINE=1 "$MALT_BIN" doctor 2>&1 || true)
+if ! grep -q "Offline mode — active" <<<"$out"; then
+  printf 'FAIL: MALT_OFFLINE=1 did not flip the doctor row.\n%s\n' "$out" >&2
+  exit 1
+fi
+
+# (3) --offline → row reads "active" too (mirrors the env).
+out=$(MALT_PREFIX="$PREFIX" "$MALT_BIN" --offline doctor 2>&1 || true)
+if ! grep -q "Offline mode — active" <<<"$out"; then
+  printf 'FAIL: --offline did not flip the doctor row.\n%s\n' "$out" >&2
+  exit 1
+fi
+
+# (4) `mt update --check` refuses cleanly under offline (non-zero exit
+#     + canonical message). The refusal must happen before any HTTP
+#     attempt — otherwise a user on a plane would stall on connect.
+set +e
+err=$(MALT_PREFIX="$PREFIX" MALT_OFFLINE=1 "$MALT_BIN" update --check 2>&1)
+rc=$?
+set -e
+if [[ $rc -eq 0 ]]; then
+  # shellcheck disable=SC2016  # literal backticks in user-facing log line
+  printf 'FAIL: `mt update --check` under offline should exit non-zero (got rc=0).\n' >&2
+  exit 1
+fi
+if ! grep -q "offline mode: \`mt update --check\` requires network access" <<<"$err"; then
+  printf 'FAIL: offline-refusal message missing.\n%s\n' "$err" >&2
+  exit 1
+fi
+
+echo "OK: offline mode contract holds (doctor row + update --check refusal)."

--- a/scripts/smokes/smoke_offline_mode.sh
+++ b/scripts/smokes/smoke_offline_mode.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Smoke test for `MALT_OFFLINE` / `--offline`.
+#
+# Six behaviours exercised end-to-end against a throwaway prefix:
+#   1. `mt install <uncached>` under offline fails with the canonical
+#      "offline" diagnostic instead of stalling on connect.
+#   2. `mt info <uncached>` under offline succeeds (falls through to
+#      "not installed") — read commands stay graceful on cache miss.
+#   3. `mt info <pkg>` under offline serves a pre-seeded cache hit.
+#   4. `mt update --check` under offline refuses with a non-zero exit
+#      and the canonical message.
+#   5. `mt doctor` skips the API-reachable probe under offline (no
+#      "Cannot reach" warn row) and reports the active state.
+#   6. `mt --offline …` mirrors `MALT_OFFLINE=1`.
+#
+# Usage: scripts/smokes/smoke_offline_mode.sh
+# Requirements: built `malt` binary at $MALT_BIN or zig-out/bin/malt.
+# No network access — every assertion runs against a hermetic prefix
+# with the API cache either pre-seeded or deliberately empty.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be ≤ 13 bytes (Mach-O in-place patching budget),
+# same constraint as smoke_install_local.sh.
+PREFIX="/tmp/mt_smoke_off"
+export MALT_PREFIX="$PREFIX"
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX/cache/api" "$PREFIX/db"
+trap 'rm -rf "$PREFIX"' EXIT
+
+# Scrub any inherited offline knob so each branch below sets its own.
+unset MALT_OFFLINE
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+# ── 1. install <uncached> under offline → OfflineRequired ────────────
+printf '▸ MALT_OFFLINE=1 mt install <uncached> exits non-zero\n'
+out=$(MALT_OFFLINE=1 "$BIN" install ghost-pkg-no-such-thing 2>&1 || true)
+echo "$out" | grep -qiE "offline|OfflineRequired" || fail "missing offline diagnostic on uncached install"
+pass "uncached install fails with offline diagnostic"
+
+# ── 2. info <uncached> under offline stays graceful ──────────────────
+printf '▸ MALT_OFFLINE=1 mt info <uncached> degrades cleanly\n'
+out=$(MALT_OFFLINE=1 "$BIN" info ghost-pkg-no-such-thing 2>&1 || true)
+echo "$out" | grep -q "not installed" || fail "info should fall through to 'not installed' on cache miss"
+pass "info falls through cleanly on cache miss"
+
+# ── 3. info <pkg> under offline serves a pre-seeded cache hit ────────
+printf '▸ MALT_OFFLINE=1 mt info <cached> reads from the cache\n'
+cat >"$PREFIX/cache/api/formula_wget.json" <<'JSON'
+{"name":"wget","full_name":"wget","desc":"Smoke fixture","homepage":"https://example.invalid","versions":{"stable":"1.0.0"},"dependencies":[]}
+JSON
+out=$(MALT_OFFLINE=1 "$BIN" info wget 2>&1 || true)
+echo "$out" | grep -q "Smoke fixture" || fail "info should serve the pre-seeded cache body"
+pass "info reads the warmed cache under offline"
+
+# ── 4. update --check under offline refuses cleanly ──────────────────
+printf '▸ MALT_OFFLINE=1 mt update --check refuses\n'
+set +e
+err=$(MALT_OFFLINE=1 "$BIN" update --check 2>&1)
+rc=$?
+set -e
+[[ $rc -ne 0 ]] || fail "update --check under offline must exit non-zero"
+echo "$err" | grep -q "offline mode" || fail "missing 'offline mode' refusal text"
+pass "update --check refuses with the canonical message"
+
+# ── 5. doctor under offline skips the API-reachable probe ────────────
+printf '▸ MALT_OFFLINE=1 mt doctor shows Offline mode row + skipped API probe\n'
+out=$(MALT_OFFLINE=1 "$BIN" doctor 2>&1 || true)
+echo "$out" | grep -q "Offline mode — active" || fail "doctor should report Offline mode active"
+echo "$out" | grep -q "API reachable — skipped — offline mode" || fail "doctor should skip the API probe"
+pass "doctor reports offline state + skips API probe"
+
+# ── 6. --offline mirrors MALT_OFFLINE=1 on the doctor surface ────────
+printf '▸ mt --offline doctor reports active state\n'
+out=$("$BIN" --offline doctor 2>&1 || true)
+echo "$out" | grep -q "Offline mode — active" || fail "--offline must flip the doctor row"
+pass "--offline mirrors MALT_OFFLINE=1"
+
+printf '\n✔ offline-mode smoke test passed\n'

--- a/src/app_ctx.zig
+++ b/src/app_ctx.zig
@@ -25,6 +25,11 @@ pub const AppCtx = struct {
     /// sites read this instead of re-walking the env per request;
     /// tests and `debug_ctx` get the upstream Homebrew defaults.
     mirrors: mirror.Mirrors = .{},
+    /// `MALT_OFFLINE=1` or `--offline`. When true, every net/* call
+    /// must serve from the snapshot cache and surface `OfflineRequired`
+    /// on a miss rather than waiting for a connect timeout. Resolved
+    /// once at boot so per-call sites read a single bool.
+    offline: bool = false,
 };
 
 /// Parent `environ` as `std.process.Environ`. Production `main` builds an
@@ -61,4 +66,17 @@ test "debug_ctx returns null for any environ lookup" {
 test "debug_ctx stdio defaults are sentinel -1" {
     try std.testing.expectEqual(@as(std.c.fd_t, -1), debug_ctx.stdout.handle);
     try std.testing.expectEqual(@as(std.c.fd_t, -1), debug_ctx.stderr.handle);
+}
+
+test "AppCtx.offline defaults to false" {
+    try std.testing.expect(!debug_ctx.offline);
+}
+
+test "AppCtx round-trips an explicit offline=true" {
+    const ctx: AppCtx = .{
+        .io = std.Options.debug_io,
+        .environ = .empty,
+        .offline = true,
+    };
+    try std.testing.expect(ctx.offline);
 }

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -88,7 +88,7 @@ pub const bash_script =
     \\    cword=$COMP_CWORD
     \\
     \\    local commands="install uninstall remove upgrade update outdated list ls info search uses deps which doctor tap untap migrate rollback link unlink pin unpin run version completions shellenv backup restore purge cleanup services bundle help"
-    \\    local global_flags="--verbose -v --quiet -q --json --output-format=ndjson --dry-run --help -h --version"
+    \\    local global_flags="--verbose -v --quiet -q --json --output-format=ndjson --dry-run --offline --help -h --version"
     \\
     \\    # Find the first non-flag word after the program — that's the subcommand.
     \\    local cmd="" i
@@ -235,6 +235,7 @@ pub const zsh_script =
     \\        '--json[JSON output]' \
     \\        '--output-format=ndjson[Stream one JSON event per state transition]' \
     \\        '--dry-run[Preview without executing]' \
+    \\        '--offline[Serve every fetch from the snapshot cache; fail fast on a miss]' \
     \\        '(- : *)'{--help,-h}'[Show help]' \
     \\        '(- : *)--version[Show version]' \
     \\        '1: :->command' \
@@ -476,6 +477,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin      -l json    -d 'JSON output'
     \\    complete -c $__malt_bin      -l output-format=ndjson -d 'Stream one JSON event per state transition'
     \\    complete -c $__malt_bin      -l dry-run -d 'Preview without executing'
+    \\    complete -c $__malt_bin      -l offline -d 'Serve every fetch from the snapshot cache; fail fast on a miss'
     \\    complete -c $__malt_bin -s h -l help    -d 'Show help'
     \\    complete -c $__malt_bin      -l version -d 'Show version'
     \\

--- a/src/cli/deps.zig
+++ b/src/cli/deps.zig
@@ -437,8 +437,10 @@ fn collectGraph(
 
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
     api.base_url = ctx.mirrors.api_base;
+    api.offline = ctx.offline;
     var api_ctx = ApiCtx{ .allocator = allocator, .api = &api };
     const api_lookup = apiDepLookup(&api_ctx);
 

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -47,6 +47,10 @@ pub const CheckCtx = struct {
     /// "Mirror overrides" row. Defaults to upstream so tests and
     /// `debug_ctx`-shaped fixtures keep working without plumbing.
     mirrors: mirror_mod.Mirrors = .{},
+    /// `MALT_OFFLINE` / `--offline` snapshot. Drives the "Offline mode"
+    /// row and short-circuits the API-reachable probe so an air-gapped
+    /// machine doesn't get a warn row for an expected network gap.
+    offline: bool = false,
 };
 
 /// One entry in the health walk. `run` prints its row(s) and returns
@@ -73,6 +77,7 @@ pub const checks = [_]Check{
     .{ .name = "APFS volume", .run = checkApfs },
     .{ .name = "Prefix permissions", .run = checkPrefixPermissions },
     .{ .name = "Mirror overrides", .run = checkMirrorOverrides },
+    .{ .name = "Offline mode", .run = checkOfflineMode },
     .{ .name = "API reachable", .run = checkApiReachable },
     .{ .name = "Orphaned store entries", .run = checkOrphanedStore },
     .{ .name = "Missing kegs", .run = checkMissingKegs },
@@ -189,6 +194,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         .io = ctx.io,
         .environ = ctx.environ,
         .mirrors = ctx.mirrors,
+        .offline = ctx.offline,
     }, &checks);
 
     emitCaskHistoryReport(allocator, ctx.io, prefix);
@@ -520,7 +526,31 @@ fn checkPrefixPermissions(ctx: CheckCtx, name: []const u8) CheckResult {
     return .warn_status;
 }
 
+/// Report offline-mode state so operators can confirm `MALT_OFFLINE` /
+/// `--offline` landed correctly without re-grepping their shell config.
+/// Always `.ok` — offline is a user choice, not a fault.
+fn checkOfflineMode(ctx: CheckCtx, name: []const u8) CheckResult {
+    printCheck(name, .ok, formatOfflineDetail(ctx.offline));
+    return .ok;
+}
+
+/// Pure formatter for `checkOfflineMode`'s detail string. `pub` so the
+/// doctor render test can pin the exact text without a process fixture.
+pub fn formatOfflineDetail(offline: bool) []const u8 {
+    return if (offline)
+        "active — every fetch must serve from the snapshot cache"
+    else
+        "off";
+}
+
 fn checkApiReachable(ctx: CheckCtx, name: []const u8) CheckResult {
+    // Offline mode flips the API-reachable check into a skip rather
+    // than a warn: under offline there's no expectation of network
+    // reachability, so a "Cannot reach" row would be noise.
+    if (ctx.offline) {
+        printCheck(name, .ok, "skipped — offline mode");
+        return .ok;
+    }
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, ctx.allocator);
     defer http.deinit();
     const probe_url = mirror_mod.hostProbeUrl(ctx.mirrors.api_base);

--- a/src/cli/doctor/post_install.zig
+++ b/src/cli/doctor/post_install.zig
@@ -37,11 +37,13 @@ pub fn checkPostInstallStatus(ctx: *const AppCtx, allocator: std.mem.Allocator, 
 
     var http = client_mod.HttpClient.init(io, environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
 
     var cache_buf: [512]u8 = undefined;
     const cache_dir = std.fmt.bufPrint(&cache_buf, "{s}/cache", .{prefix}) catch return;
     var api = api_mod.BrewApi.init(io, allocator, &http, cache_dir);
     api.base_url = ctx.mirrors.api_base;
+    api.offline = ctx.offline;
 
     while (stmt.step() catch false) {
         const name_raw = stmt.columnText(0) orelse continue;

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -195,8 +195,10 @@ fn emitApiMetadata(
 
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
     api.base_url = ctx.mirrors.api_base;
+    api.offline = ctx.offline;
 
     if (!force_cask) {
         if (try emitApiFormula(allocator, &api, name, stdout, json_mode, colorize)) return true;

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -536,6 +536,7 @@ fn executeWithOpts(
     // Main-thread HTTP client; workers borrow from `http_pool` instead.
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
 
     // 4-slot worker pool — same budget as the materialize pool; enough to
     // saturate cold installs while reusing TLS contexts.
@@ -544,12 +545,14 @@ fn executeWithOpts(
         return InstallError.DownloadFailed;
     };
     defer http_pool.deinit();
+    http_pool.setOfflineAll(ctx.offline);
 
     // Set up API client
     var cache_dir_buf: [512]u8 = undefined;
     const cache_dir = std.fmt.bufPrint(&cache_dir_buf, "{s}/cache", .{prefix}) catch return;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
     api.base_url = ctx.mirrors.api_base;
+    api.offline = ctx.offline;
 
     // Set up GHCR client
     var ghcr = ghcr_mod.GhcrClient.init(ctx.io, allocator, &http);
@@ -604,14 +607,25 @@ fn executeWithOpts(
 
         // Try formula
         if (!force_cask) {
-            const formula_json = api.fetchFormula(pkg_name) catch {
+            const formula_json = api.fetchFormula(pkg_name) catch |fetch_err| {
+                // Offline misses route straight to a typed "snapshot
+                // didn't have it" line instead of falling through to a
+                // cask probe that would also miss with the same noise.
+                if (fetch_err == api_mod.ApiError.OfflineRequired) {
+                    output.err("offline mode: formula '{s}' not cached", .{pkg_name});
+                    continue;
+                }
                 if (force_formula) {
                     output.err("Formula '{s}' not found", .{pkg_name});
                     continue;
                 }
                 // Try cask
                 installCask(ctx, allocator, pkg_name, &db, &api, dry_run, download_only) catch |e| {
-                    output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
+                    if (e == api_mod.ApiError.OfflineRequired) {
+                        output.err("offline mode: '{s}' not cached as formula or cask", .{pkg_name});
+                    } else {
+                        output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
+                    }
                 };
                 continue;
             };
@@ -1095,6 +1109,7 @@ fn maybeRegisterService(
 fn resolveCaskArtifactViaHead(ctx: *const AppCtx, allocator: std.mem.Allocator, url: []const u8) cask_mod.ArtifactType {
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
 
     var resolved = http.headResolved(url) catch return .unknown;
     defer resolved.deinit();
@@ -1114,7 +1129,10 @@ fn installCask(
     dry_run: bool,
     download_only: bool,
 ) !void {
-    const cask_json = api.fetchCask(token) catch {
+    const cask_json = api.fetchCask(token) catch |e| {
+        // Propagate the typed OfflineRequired so the outer dispatch
+        // surfaces the snapshot-miss message instead of "not found".
+        if (e == api_mod.ApiError.OfflineRequired) return e;
         output.err("Cask '{s}' not found", .{token});
         return InstallError.CaskNotFound;
     };
@@ -1167,6 +1185,7 @@ fn installCask(
 
     var installer = cask_mod.CaskInstaller.init(ctx.io, ctx.environ, allocator, db, prefix);
     installer.artifact_type_override = artifact_type;
+    installer.offline = ctx.offline;
 
     // Progress bar for cask download
     var bar = progress_mod.ProgressBar.init(cask.token, 0);

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -221,6 +221,7 @@ fn installTapRb(
 
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
 
     // First probe: Formula/ for the default mode, Casks/ when the
     // caller has pinned the resolve to cask-only.
@@ -425,6 +426,7 @@ pub fn installLocalFormula(
 
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
     // `--local` is out of scope for `--download-only`: the user already
     // holds the archive on disk so warming a tap-cache entry adds no
     // value. Hard-wire false here rather than threading the flag.
@@ -825,6 +827,7 @@ fn materializeTapCask(
 
     var installer = cask_mod.CaskInstaller.init(ctx.io, ctx.environ, allocator, db, prefix_z);
     installer.artifact_type_override = kind;
+    installer.offline = ctx.offline;
 
     var bar = progress_mod.ProgressBar.init(cask.token, 0);
     installer.progress = .{

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -236,11 +236,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // Set up HTTP + API + GHCR + store + linker
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
 
     var cache_dir_buf: [512]u8 = undefined;
     const cache_dir = std.fmt.bufPrint(&cache_dir_buf, "{s}/cache", .{prefix}) catch return;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
     api.base_url = ctx.mirrors.api_base;
+    api.offline = ctx.offline;
 
     var ghcr = ghcr_mod.GhcrClient.init(ctx.io, allocator, &http);
     ghcr.base_url = ctx.mirrors.bottle_base;
@@ -306,6 +308,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             return error.Aborted;
         };
         defer http_pool.deinit();
+        http_pool.setOfflineAll(ctx.offline);
 
         var db_mu: std.Io.Mutex = .init;
         var manifest_mu: std.Io.Mutex = .init;

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -397,8 +397,10 @@ fn recomputeAndEmit(
 ) !void {
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
     api.base_url = ctx.mirrors.api_base;
+    api.offline = ctx.offline;
 
     const workers_override = parseWorkersEnv(std.process.Environ.getPosix(ctx.environ, outdated_workers_env));
 

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -223,7 +223,7 @@ fn upstreamLatest(
             // drop the row from the audit. Same shape as `upgradeCask`.
             if (row.tap) |tap_label| {
                 if (!install_args_mod.isCoreTap(tap_label)) {
-                    break :blk tapCaskLatestVersion(alloc, io, environ, tap_label, row.name);
+                    break :blk tapCaskLatestVersion(alloc, io, environ, tap_label, row.name, api.offline);
                 }
             }
             const json = api.fetchCask(row.name) catch break :blk null;
@@ -269,6 +269,7 @@ fn tapCaskLatestVersion(
     environ: std.process.Environ,
     tap_label: []const u8,
     token: []const u8,
+    offline: bool,
 ) ?[]u8 {
     const slash = std.mem.indexOfScalar(u8, tap_label, '/') orelse return null;
     if (slash == 0 or slash == tap_label.len - 1) return null;
@@ -284,6 +285,7 @@ fn tapCaskLatestVersion(
 
     var http = client_mod.HttpClient.init(io, environ, alloc);
     defer http.deinit();
+    http.offline = offline;
 
     var rb_url_buf: [512]u8 = undefined;
     const rb_url = std.fmt.bufPrint(&rb_url_buf, "{s}/{s}/Casks/{s}.rb", .{ urls.raw_base, fresh_sha, token }) catch return null;
@@ -361,6 +363,9 @@ const WorkerCtx = struct {
     /// Snapshot of `ctx.mirrors.api_base` so workers inherit the
     /// mirror override without re-walking the env on a worker thread.
     api_base: []const u8,
+    /// Snapshot of `ctx.offline` so workers gate fetches identically
+    /// to the serial path without re-walking the env per thread.
+    offline: bool,
     row: KegRow,
     kind: Kind,
     /// Result allocated on the **caller** allocator so it survives
@@ -393,6 +398,7 @@ fn runOne(out_alloc: std.mem.Allocator, wctx: *WorkerCtx) void {
     const arena_alloc = wctx.arena.allocator();
     var local_api = api_mod.BrewApi.init(wctx.io, arena_alloc, http, wctx.cache_dir);
     local_api.base_url = wctx.api_base;
+    local_api.offline = wctx.offline;
     const latest = upstreamLatest(arena_alloc, &local_api, wctx.io, wctx.environ, wctx.kind, wctx.row) orelse return;
     if (std.mem.eql(u8, wctx.row.version, latest)) return;
 
@@ -417,6 +423,7 @@ fn runPool(
 
     var http_pool = try client_mod.HttpClientPool.init(ctx.io, ctx.environ, allocator, worker_count);
     defer http_pool.deinit();
+    http_pool.setOfflineAll(ctx.offline);
 
     const ctxs = try allocator.alloc(WorkerCtx, kegs.len);
     defer {
@@ -431,6 +438,7 @@ fn runPool(
         .pool = &http_pool,
         .cache_dir = cache_dir,
         .api_base = ctx.mirrors.api_base,
+        .offline = ctx.offline,
         .row = kegs[i],
         .kind = kind,
     };
@@ -479,6 +487,7 @@ test "WorkerCtx: per-row arena accepts testing.allocator backing without leaking
         .pool = undefined,
         .cache_dir = "",
         .api_base = "",
+        .offline = false,
         .row = .{ .name = "", .version = "" },
         .kind = .formula,
     };

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -281,6 +281,7 @@ fn dispatchCask(
 
     const prefix = atomic.maltPrefixOrAbort();
     var installer = cask_mod.CaskInstaller.init(ctx.io, ctx.environ, allocator, db, prefix);
+    installer.offline = ctx.offline;
     installer.reinstallFromHistory(token, target_pkg_version) catch |e| {
         output.err("failed to reinstall {s} {s} ({s})", .{ token, target_pkg_version, @errorName(e) });
         return error.Aborted;

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -125,11 +125,13 @@ fn ephemeralRun(
 
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
 
     var cache_buf: [512]u8 = undefined;
     const cache_dir = std.fmt.bufPrint(&cache_buf, "{s}/cache", .{prefix}) catch return;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
     api.base_url = ctx.mirrors.api_base;
+    api.offline = ctx.offline;
 
     const formula_json = api.fetchFormula(pkg_name) catch {
         output.err("Formula '{s}' not found", .{pkg_name});

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -578,8 +578,10 @@ fn runKindIsolated(
 ) KindResults {
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
     api.base_url = ctx.mirrors.api_base;
+    api.offline = ctx.offline;
     var r: KindResults = .{};
     r.exact = api.exists(query, kind) catch false;
     if (api.fetchNamesIndex(kind)) |idx| {

--- a/src/cli/update.zig
+++ b/src/cli/update.zig
@@ -33,6 +33,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     defer allocator.free(cache_dir);
 
     if (check_only) {
+        // Offline mode means no network — refusing here is the kind
+        // "we can't do this, but you knew that" message the task doc
+        // calls for, ahead of any HTTP attempt that would fail anyway.
+        if (ctx.offline) {
+            output.err("offline mode: `mt update --check` requires network access.", .{});
+            return error.Aborted;
+        }
         refreshSnapshot(ctx, allocator, cache_dir) catch |e| {
             output.err("Failed to refresh outdated snapshot: {s}", .{@errorName(e)});
             return error.Aborted;
@@ -80,8 +87,10 @@ fn refreshSnapshot(ctx: *const AppCtx, allocator: std.mem.Allocator, cache_dir: 
 
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
     api.base_url = ctx.mirrors.api_base;
+    api.offline = ctx.offline;
 
     try outdated_mod.refreshSnapshot(ctx, allocator, &db, &api, cache_dir, null);
 }

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -116,11 +116,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
 
     var cache_dir_buf: [512]u8 = undefined;
     const cache_dir = std.fmt.bufPrint(&cache_dir_buf, "{s}/cache", .{prefix}) catch return;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
     api.base_url = ctx.mirrors.api_base;
+    api.offline = ctx.offline;
 
     // Per-package errors must not be swallowed: a batch that fails every
     // item used to exit 0, hiding the failure from CI. We aggregate here
@@ -525,6 +527,7 @@ fn upgradeRoutedTapCask(
 
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
 
     var rb_url_buf: [512]u8 = undefined;
     const rb_url = std.fmt.bufPrint(&rb_url_buf, "{s}/{s}/Casks/{s}.rb", .{ urls.raw_base, fresh_sha, token }) catch return error.Aborted;
@@ -566,6 +569,7 @@ fn upgradeRoutedTapCask(
     // Mirrors the core-API path in `upgradeCask` so a partial failure
     // can't leave the casks row missing once the new app is on disk.
     var installer = cask_mod.CaskInstaller.init(ctx.io, ctx.environ, allocator, db, prefix);
+    installer.offline = ctx.offline;
     db.beginTransaction() catch |txn_err| {
         output.err("Could not begin DB transaction for {s}: {s} ({s})", .{ token, @errorName(txn_err), db.errMsg() });
         return error.Aborted;
@@ -854,6 +858,7 @@ fn upgradeCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []const 
     // against other malt writers, so holding the SQLite txn across the
     // (potentially slow) install is harmless to other connections.
     var installer = cask_mod.CaskInstaller.init(ctx.io, ctx.environ, allocator, db, prefix);
+    installer.offline = ctx.offline;
     db.beginTransaction() catch |txn_err| {
         output.err(
             "Could not begin DB transaction for {s}: {s} ({s})",

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -65,9 +65,14 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
+    http.offline = ctx.offline;
 
-    var resp = http.get(release.releases_latest_url) catch {
-        output.err("Cannot reach GitHub API", .{});
+    var resp = http.get(release.releases_latest_url) catch |e| {
+        if (e == error.OfflineRequired) {
+            output.err("Offline mode active; self-update requires network access.", .{});
+        } else {
+            output.err("Cannot reach GitHub API", .{});
+        }
         return error.Aborted;
     };
     defer resp.deinit();

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -477,6 +477,10 @@ pub const CaskInstaller = struct {
     progress: ?client_mod.ProgressCallback,
     /// Pre-resolved type for extensionless URLs (HEAD fallback).
     artifact_type_override: ?ArtifactType = null,
+    /// Mirrors `ctx.offline` from the cli/ caller. Threaded onto the
+    /// internal HttpClient so a download miss surfaces `OfflineRequired`
+    /// instead of stalling on connect.
+    offline: bool = false,
 
     pub fn init(io: std.Io, environ: std.process.Environ, allocator: std.mem.Allocator, db: *sqlite.Database, prefix: [:0]const u8) CaskInstaller {
         return .{ .allocator = allocator, .io = io, .environ = environ, .db = db, .prefix = prefix, .progress = null };
@@ -738,6 +742,7 @@ pub const CaskInstaller = struct {
         // Download via HTTP client
         var http = client_mod.HttpClient.init(self.io, self.environ, self.allocator);
         defer http.deinit();
+        http.offline = self.offline;
 
         var resp = try http.getWithHeaders(cask.url, &.{}, progress);
         defer resp.deinit();

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -82,6 +82,7 @@ pub const api = @import("net/api.zig");
 pub const client = @import("net/client.zig");
 pub const ghcr = @import("net/ghcr.zig");
 pub const mirror = @import("net/mirror.zig");
+pub const offline = @import("net/offline.zig");
 pub const text_replace = @import("text_replace.zig");
 pub const color = @import("ui/color.zig");
 pub const output = @import("ui/output.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -32,6 +32,7 @@ const version_update = @import("cli/version_update.zig");
 const which_cmd = @import("cli/which.zig");
 const signals = @import("core/signals.zig");
 const mirror_mod = @import("net/mirror.zig");
+const offline_mod = @import("net/offline.zig");
 const color_mod = @import("ui/color.zig");
 const output_mod = @import("ui/output.zig");
 const progress_mod = @import("ui/progress.zig");
@@ -248,6 +249,13 @@ test "dispatch accepts AppCtx and routes help without panic" {
     try dispatch(std.testing.allocator, &ctx, .help, &.{});
 }
 
+test "applyGlobalFlag does not consume --offline (handled inline by main)" {
+    // `--offline` lives on ctx, not module state; if applyGlobalFlag
+    // ever started consuming it the inline branch in `main` would be
+    // dead code and ctx.offline would silently stop tracking the flag.
+    try std.testing.expect(!applyGlobalFlag("--offline"));
+}
+
 test "command_map resolves cleanup to the cleanup tag" {
     // `mt cleanup` is the Homebrew-shaped alias for `mt purge --housekeeping`.
     // Pin the tag so a rename can't silently break the dispatch arm.
@@ -343,12 +351,15 @@ pub fn main(init: std.process.Init.Minimal) !void {
         },
     };
 
-    const ctx: AppCtx = .{
+    // `MALT_OFFLINE` is resolved once at boot; `--offline` may flip it
+    // on later in the dispatch loop (parsed below alongside other globals).
+    var ctx: AppCtx = .{
         .io = threaded.io(),
         .environ = init.environ,
         .stdout = std.Io.File.stdout(),
         .stderr = std.Io.File.stderr(),
         .mirrors = mirrors,
+        .offline = offline_mod.resolveFromEnv(init.environ),
     };
 
     // Seed the ui package state once so output/progress/color stop
@@ -393,6 +404,12 @@ pub fn main(init: std.process.Init.Minimal) !void {
         {
             cmd_str = arg;
             found_cmd = true;
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--offline")) {
+            // `--offline` lives on ctx (not module state) so subcommands
+            // read it via the typed pointer rather than a hidden global.
+            ctx.offline = true;
             continue;
         }
         if (!applyGlobalFlag(arg)) try filtered.append(allocator, arg);
@@ -524,6 +541,8 @@ fn printUsage(ctx: *const AppCtx) void {
         \\                  Stream one JSON event per state transition for
         \\                  install/upgrade/migrate (orthogonal to --json)
         \\  --dry-run       Preview without executing
+        \\  --offline       Serve every fetch from the snapshot cache; fail
+        \\                  fast with OfflineRequired on a miss
         \\  --help, -h      Show help
         \\  --version       Show version
         \\
@@ -535,6 +554,8 @@ fn printUsage(ctx: *const AppCtx) void {
         \\  MALT_PROGRESS=tty|plain|none
         \\                    Choose how install/upgrade/migrate report progress;
         \\                    default auto-detects (CI=true flips to plain)
+        \\  MALT_OFFLINE=1    Same as --offline: every fetch must serve from
+        \\                    the snapshot cache
         \\  MALT_NO_VERSION_NOTIFIER=1
         \\                    Suppress the "newer malt available" stderr notice
         \\

--- a/src/net/api.zig
+++ b/src/net/api.zig
@@ -19,6 +19,11 @@ pub const ApiError = error{
     InvalidResponse,
     InvalidName,
     CacheError,
+    /// Offline mode is active and the snapshot cache had no entry for
+    /// this key. Distinct from `ApiUnreachable` so the CLI can route
+    /// straight to "offline mode: <kind> '<name>' not cached" instead
+    /// of the generic network-failure message.
+    OfflineRequired,
     OutOfMemory,
 };
 
@@ -127,6 +132,10 @@ pub const BrewApi = struct {
     /// drop in `ctx.mirrors.api_base`; mirror precedence + HTTPS
     /// validation are enforced upstream by `mirror.resolve`.
     base_url: []const u8 = mirror_mod.default_api_base_url,
+    /// When true, every fetch serves from the snapshot cache (any age)
+    /// and returns `OfflineRequired` on a miss instead of dialing out.
+    /// Set by cli/ call sites from `ctx.offline`.
+    offline: bool = false,
 
     pub fn init(io: std.Io, allocator: std.mem.Allocator, http: *client_mod.HttpClient, cache_dir: []const u8) BrewApi {
         return .{
@@ -247,6 +256,13 @@ pub const BrewApi = struct {
         };
         if (self.readNamesIndex(key)) |cached| return cached;
 
+        if (self.offline) {
+            // Names index has no 404 form — a miss in offline mode means
+            // the user never warmed the index, so search can't run at all.
+            if (self.readNamesIndexUnchecked(key)) |cached| return cached;
+            return ApiError.OfflineRequired;
+        }
+
         var url_buf: [512]u8 = undefined;
         const url = try buildNamesIndexUrl(&url_buf, self.base_url, kind);
         var resp = self.http.get(url) catch return ApiError.ApiUnreachable;
@@ -270,6 +286,29 @@ pub const BrewApi = struct {
         const now = std.Io.Clock.real.now(self.io).toSeconds();
         const mtime_secs: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_s));
         if (now - mtime_secs > index_ttl_secs) return null;
+
+        const file = std.Io.Dir.cwd().openFile(self.io, p, .{}) catch return null;
+        defer file.close(self.io);
+        const s = file.stat(self.io) catch return null;
+        const buf = self.allocator.alloc(u8, s.size) catch return null;
+        const n = file.readPositionalAll(self.io, buf, 0) catch {
+            self.allocator.free(buf);
+            return null;
+        };
+        if (n < buf.len) {
+            self.allocator.free(buf);
+            return null;
+        }
+        return buf;
+    }
+
+    /// TTL-bypass names-index read. Offline mode falls through here when
+    /// the freshness-gated `readNamesIndex` rejects a stale snapshot —
+    /// stale-but-present beats OfflineRequired when the user just wants
+    /// to grep their last warmed list.
+    fn readNamesIndexUnchecked(self: *BrewApi, key: []const u8) ?[]const u8 {
+        var path_buf: [512]u8 = undefined;
+        const p = std.fmt.bufPrint(&path_buf, "{s}/api/names_{s}.txt", .{ self.cache_dir, key }) catch return null;
 
         const file = std.Io.Dir.cwd().openFile(self.io, p, .{}) catch return null;
         defer file.close(self.io);
@@ -321,6 +360,15 @@ pub const BrewApi = struct {
         // never cached.
         if (self.readNotFoundCache(key, prefix)) return ApiError.NotFound;
 
+        // Offline mode: serve from the snapshot at any age, or hard-fail
+        // with OfflineRequired. Skipping the TTL gate matches the
+        // air-gapped use case: a stale entry is still bytes the user
+        // can install from.
+        if (self.offline) {
+            if (self.readCacheBytes(key, prefix)) |cached| return cached;
+            return ApiError.OfflineRequired;
+        }
+
         // Try the normal success cache.
         if (self.readCache(key, prefix)) |cached| return cached;
 
@@ -351,7 +399,17 @@ pub const BrewApi = struct {
         const mtime_secs: i64 = @intCast(@divTrunc(stat.mtime.nanoseconds, std.time.ns_per_s));
         if (now - mtime_secs > cache_ttl_secs) return null;
 
-        // Read file
+        return self.readCacheBytes(key, prefix);
+    }
+
+    /// TTL-bypass cache read. Returns caller-owned bytes if the file
+    /// exists and is readable, regardless of mtime. Used by the offline
+    /// path so a stale snapshot still serves bytes; the regular
+    /// `readCache` adds the freshness gate on top.
+    pub fn readCacheBytes(self: *BrewApi, key: []const u8, prefix: []const u8) ?[]const u8 {
+        var path_buf: [512]u8 = undefined;
+        const cache_path = std.fmt.bufPrint(&path_buf, "{s}/api/{s}{s}.json", .{ self.cache_dir, prefix, key }) catch return null;
+
         const file = std.Io.Dir.cwd().openFile(self.io, cache_path, .{}) catch return null;
         defer file.close(self.io);
         const file_stat = file.stat(self.io) catch return null;

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -13,6 +13,10 @@ pub const DownloadError = error{
     /// Without the watchdog a stalled download has no fail-fast, so we
     /// surface the error rather than silently degrade.
     WatchdogSpawnFailed,
+    /// Offline mode active and no cached body to serve. Non-transient so
+    /// retry-with-backoff bails immediately instead of waiting out the
+    /// network on a guaranteed miss.
+    OfflineRequired,
 };
 
 pub const DownloadDiagnostic = struct {
@@ -44,7 +48,7 @@ pub fn classifyStatus(status: u16) ?DownloadError {
 pub fn isTransientError(err: DownloadError) bool {
     return switch (err) {
         error.Timeout, error.ConnectionReset, error.HttpServerError, error.RateLimited, error.ReadFailed, error.WatchdogSpawnFailed => true,
-        error.HttpClientError, error.TlsDowngradeRefused, error.ResponseTooLarge => false,
+        error.HttpClientError, error.TlsDowngradeRefused, error.ResponseTooLarge, error.OfflineRequired => false,
     };
 }
 
@@ -215,6 +219,12 @@ pub const HttpClient = struct {
     /// `net/client` to the SIGINT mechanism the caller chose.
     cancel: ?*const fn () bool = null,
 
+    /// When true, `get` / `getWithHeaders` / `head` / `headResolved`
+    /// short-circuit with `error.OfflineRequired` before any DNS / TCP
+    /// work. cli/ call sites set this from `ctx.offline` so a user on a
+    /// plane fails fast instead of waiting for connect timeouts.
+    offline: bool = false,
+
     /// Reused across requests; each HttpClient is borrowed single-threaded
     /// from a pool, so no concurrent access.
     zstd_window: ?[]u8 = null,
@@ -256,6 +266,7 @@ pub const HttpClient = struct {
     /// GET request; auto-injects HOMEBREW_GITHUB_API_TOKEN as Authorization
     /// for GitHub/Homebrew hosts. Caller owns the returned `Response`.
     pub fn get(self: *HttpClient, url: []const u8) !Response {
+        if (self.offline) return error.OfflineRequired;
         if (std.process.Environ.getPosix(self.environ, "HOMEBREW_GITHUB_API_TOKEN")) |token| {
             // Apply token to GitHub and Homebrew API requests
             if (std.mem.indexOf(u8, url, "github.com") != null or
@@ -281,11 +292,13 @@ pub const HttpClient = struct {
         extra_headers: []const std.http.Header,
         progress: ?ProgressCallback,
     ) !Response {
+        if (self.offline) return error.OfflineRequired;
         return self.doGetWithRetry(url, extra_headers, max_blob_bytes, progress);
     }
 
     /// Perform a HEAD request and return only the HTTP status code.
     pub fn head(self: *HttpClient, url: []const u8) !u16 {
+        if (self.offline) return error.OfflineRequired;
         const uri = try std.Uri.parse(url);
 
         var req = try self.client.request(.HEAD, uri, .{
@@ -327,6 +340,7 @@ pub const HttpClient = struct {
 
     /// HEAD with manual redirect follow — stdlib skips redirects on HEAD.
     pub fn headResolved(self: *HttpClient, url: []const u8) !HeadResolved {
+        if (self.offline) return error.OfflineRequired;
         // Build the result eagerly so a single errdefer covers every dupe
         // inside the redirect loop; on success the caller takes ownership.
         var resolved: HeadResolved = .{
@@ -703,6 +717,13 @@ pub const HttpClientPool = struct {
         }
     }
 
+    /// Mirror `offline` onto every pooled client. Cli/ call sites use
+    /// this right after `init` so workers borrowed under offline mode
+    /// short-circuit with `OfflineRequired` rather than dialing out.
+    pub fn setOfflineAll(self: *HttpClientPool, offline: bool) void {
+        for (self.clients) |*c| c.offline = offline;
+    }
+
     /// Return an acquired client; foreign pointers are a programmer error.
     pub fn release(self: *HttpClientPool, client: *HttpClient) void {
         self.mutex.lockUncancelable(self.io);
@@ -715,6 +736,28 @@ pub const HttpClientPool = struct {
         self.cond.signal(self.io);
     }
 };
+
+test "HttpClient.offline defaults to false" {
+    var http = HttpClient.init(std.Options.debug_io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+    try std.testing.expect(!http.offline);
+}
+
+test "HttpClient.get returns OfflineRequired when offline is set" {
+    var http = HttpClient.init(std.Options.debug_io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+    http.offline = true;
+    // Use a host that would 404/connect-refuse in the real world — the
+    // gate must trip before any DNS / TCP work happens.
+    try std.testing.expectError(error.OfflineRequired, http.get("https://example.invalid/x"));
+}
+
+test "HttpClient.head returns OfflineRequired when offline is set" {
+    var http = HttpClient.init(std.Options.debug_io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+    http.offline = true;
+    try std.testing.expectError(error.OfflineRequired, http.head("https://example.invalid/x"));
+}
 
 test "idleTimeoutNsFromEnv: null falls back to default" {
     try std.testing.expectEqual(default_idle_timeout_ns, idleTimeoutNsFromEnv(null));

--- a/src/net/offline.zig
+++ b/src/net/offline.zig
@@ -1,0 +1,81 @@
+//! malt — offline-mode env resolution.
+//! `MALT_OFFLINE` (truthy: `1`, `true`) makes every net/* call route through
+//! the snapshot cache and hard-fail with `OfflineRequired` on a miss instead
+//! of waiting for a connect timeout. Resolved once at boot so per-call sites
+//! consume a single bool instead of re-walking the env.
+
+const std = @import("std");
+
+/// True iff `raw` is one of the accepted truthy spellings. Mirrors the
+/// `MALT_OFFLINE=1` / `MALT_OFFLINE=true` shape called out in the task doc;
+/// every other value (including the empty string from a leftover
+/// `MALT_OFFLINE=` line in a shell rc) reads as off.
+pub fn parseTruthy(raw: []const u8) bool {
+    const trimmed = std.mem.trim(u8, raw, &std.ascii.whitespace);
+    if (trimmed.len == 0) return false;
+    if (std.mem.eql(u8, trimmed, "1")) return true;
+    if (std.ascii.eqlIgnoreCase(trimmed, "true")) return true;
+    return false;
+}
+
+/// Resolve `MALT_OFFLINE` from `environ`. Returns false when the env var
+/// is unset or any non-truthy spelling. Pure — no I/O, safe for tests.
+pub fn resolveFromEnv(environ: std.process.Environ) bool {
+    const raw_z = std.process.Environ.getPosix(environ, "MALT_OFFLINE") orelse return false;
+    return parseTruthy(std.mem.sliceTo(raw_z, 0));
+}
+
+// ── tests ────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "parseTruthy accepts 1 and true (case-insensitive)" {
+    try testing.expect(parseTruthy("1"));
+    try testing.expect(parseTruthy("true"));
+    try testing.expect(parseTruthy("TRUE"));
+    try testing.expect(parseTruthy("True"));
+}
+
+test "parseTruthy rejects 0, false, empty, and unknown spellings" {
+    try testing.expect(!parseTruthy("0"));
+    try testing.expect(!parseTruthy("false"));
+    try testing.expect(!parseTruthy(""));
+    try testing.expect(!parseTruthy("yes"));
+    try testing.expect(!parseTruthy("on"));
+}
+
+test "parseTruthy trims surrounding whitespace before matching" {
+    try testing.expect(parseTruthy("  1  "));
+    try testing.expect(parseTruthy("\ttrue\n"));
+    try testing.expect(!parseTruthy("   "));
+}
+
+test "resolveFromEnv returns false on an empty env" {
+    try testing.expect(!resolveFromEnv(std.process.Environ.empty));
+}
+
+test "resolveFromEnv returns true for MALT_OFFLINE=1" {
+    const entries = [_:null]?[*:0]const u8{"MALT_OFFLINE=1".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    try testing.expect(resolveFromEnv(env));
+}
+
+test "resolveFromEnv returns true for MALT_OFFLINE=true" {
+    const entries = [_:null]?[*:0]const u8{"MALT_OFFLINE=true".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    try testing.expect(resolveFromEnv(env));
+}
+
+test "resolveFromEnv treats MALT_OFFLINE=0 as off" {
+    const entries = [_:null]?[*:0]const u8{"MALT_OFFLINE=0".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    try testing.expect(!resolveFromEnv(env));
+}
+
+test "resolveFromEnv treats a bare MALT_OFFLINE= as off" {
+    // A leftover `MALT_OFFLINE=` line in a shell rc must not silently
+    // activate the mode — only an explicit truthy value counts.
+    const entries = [_:null]?[*:0]const u8{"MALT_OFFLINE=".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    try testing.expect(!resolveFromEnv(env));
+}

--- a/src/update/notifier.zig
+++ b/src/update/notifier.zig
@@ -49,6 +49,7 @@ fn fetchLatestTag(ctx: *const AppCtx, allocator: std.mem.Allocator) ![]u8 {
     // SIGINT on the prompt-after-success window collapses the probe
     // instead of stalling the user behind the 1.5 s deadline.
     http.cancel = signals.isInterrupted;
+    http.offline = ctx.offline;
     defer http.deinit();
     var resp = try http.get(release.releases_latest_url);
     defer resp.deinit();

--- a/tests/api_test.zig
+++ b/tests/api_test.zig
@@ -372,6 +372,113 @@ test "cachedExists discriminates formula vs cask cache files" {
     try testing.expect(!api.cachedExists("node", .cask));
 }
 
+test "fetchFormula under offline returns OfflineRequired on cache miss" {
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("offline_formula_miss");
+    defer dir.deinit();
+
+    var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
+    api.offline = true;
+    try testing.expectError(api_mod.ApiError.OfflineRequired, api.fetchFormula("ghost"));
+}
+
+test "fetchCask under offline returns OfflineRequired on cache miss" {
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("offline_cask_miss");
+    defer dir.deinit();
+
+    var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
+    api.offline = true;
+    try testing.expectError(api_mod.ApiError.OfflineRequired, api.fetchCask("ghost"));
+}
+
+test "fetchFormula under offline serves a fresh cache hit" {
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("offline_formula_fresh");
+    defer dir.deinit();
+
+    const json =
+        \\{"name":"wget","versions":{"stable":"1.0"}}
+    ;
+    try dir.writeCacheFile("formula_wget.json", json);
+
+    var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
+    api.offline = true;
+    const out = try api.fetchFormula("wget");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings(json, out);
+}
+
+test "fetchFormula under offline serves a stale cache hit (no TTL gate)" {
+    // The whole point of offline is "use the snapshot, no matter how old".
+    // The default 5-minute TTL gate is bypassed when `offline` is true so
+    // a user on a plane still gets bytes from disk.
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("offline_formula_stale");
+    defer dir.deinit();
+
+    const json =
+        \\{"name":"jq","versions":{"stable":"1.7"}}
+    ;
+    try dir.writeCacheFile("formula_jq.json", json);
+
+    // Backdate mtime so the regular TTL would reject it.
+    var path_buf: [512]u8 = undefined;
+    const full = try std.fmt.bufPrint(&path_buf, "{s}/api/formula_jq.json", .{dir.path});
+    const file = try test_io.cwd().openFile(std.Options.debug_io, full, .{ .mode = .write_only });
+    defer file.close(std.Options.debug_io);
+    try file.setTimestamps(std.Options.debug_io, .{
+        .access_timestamp = .{ .new = .{ .nanoseconds = 0 } },
+        .modify_timestamp = .{ .new = .{ .nanoseconds = 0 } },
+    });
+
+    var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
+    api.offline = true;
+    const out = try api.fetchFormula("jq");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings(json, out);
+}
+
+test "fetchFormula under offline still honours a fresh NotFound marker" {
+    // 404 markers stay authoritative — the snapshot already learned this
+    // name doesn't exist upstream, so OfflineRequired would be misleading.
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("offline_notfound");
+    defer dir.deinit();
+
+    try dir.writeCacheFile("formula_ghost.404", "");
+
+    var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
+    api.offline = true;
+    try testing.expectError(api_mod.ApiError.NotFound, api.fetchFormula("ghost"));
+}
+
+test "fetchNamesIndex under offline returns OfflineRequired on miss" {
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("offline_names_miss");
+    defer dir.deinit();
+
+    var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
+    api.offline = true;
+    try testing.expectError(api_mod.ApiError.OfflineRequired, api.fetchNamesIndex(.formula));
+}
+
+test "BrewApi.offline defaults to false" {
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init("offline_default_off");
+    defer dir.deinit();
+
+    const api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
+    try testing.expect(!api.offline);
+}
+
 test "readNotFoundCache returns false for stale marker" {
     var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
     defer http.deinit();

--- a/tests/doctor_render_test.zig
+++ b/tests/doctor_render_test.zig
@@ -196,6 +196,17 @@ test "formatMirrorOverrideDetail falls back to a non-overridden message" {
     try testing.expectEqualStrings("using upstream Homebrew defaults", detail);
 }
 
+test "formatOfflineDetail reports off when offline is false" {
+    try testing.expectEqualStrings("off", doctor.formatOfflineDetail(false));
+}
+
+test "formatOfflineDetail reports active when offline is true" {
+    try testing.expectEqualStrings(
+        "active — every fetch must serve from the snapshot cache",
+        doctor.formatOfflineDetail(true),
+    );
+}
+
 // ── countMissingLocalSources ────────────────────────────────────────
 //
 // The local-source check walks `kegs WHERE tap='local'` and reports

--- a/tests/offline_mode_test.zig
+++ b/tests/offline_mode_test.zig
@@ -1,0 +1,141 @@
+//! malt — `MALT_OFFLINE` / `--offline` integration tests.
+//!
+//! Pins the cross-cutting offline contract end-to-end at the library
+//! seam: env-resolver, BrewApi gate (cache hit / miss / 404 / stale),
+//! HttpClient gate (every entrypoint), and `mt update --check` refusal.
+//! No process spawn, no real network — `tests/api_test.zig` and the
+//! inline tests next to each gate cover the unit level; this file
+//! exercises the composition.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const test_io = @import("test_io");
+
+const offline_mod = malt.offline;
+const api_mod = malt.api;
+const client_mod = malt.client;
+const doctor = malt.doctor;
+const AppCtx = malt.app_ctx.AppCtx;
+
+// ── env-resolver composition ─────────────────────────────────────────
+
+test "AppCtx-built-from-env carries MALT_OFFLINE through to subcommand readers" {
+    // The end-to-end path is: env → offline_mod.resolveFromEnv → AppCtx.offline
+    // → per-call-site `http.offline = ctx.offline`. Snapshotting the
+    // composition here means a regression in any link breaks one test
+    // instead of leaving the seam un-pinned.
+    const entries = [_:null]?[*:0]const u8{"MALT_OFFLINE=1".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = entries[0..1 :null] } };
+    const ctx: AppCtx = .{
+        .io = std.Options.debug_io,
+        .environ = env,
+        .offline = offline_mod.resolveFromEnv(env),
+    };
+    try testing.expect(ctx.offline);
+}
+
+test "AppCtx-built-without-env defaults to online" {
+    const ctx: AppCtx = .{
+        .io = std.Options.debug_io,
+        .environ = std.process.Environ.empty,
+        .offline = offline_mod.resolveFromEnv(std.process.Environ.empty),
+    };
+    try testing.expect(!ctx.offline);
+}
+
+// ── HttpClient composition: every public entrypoint refuses ──────────
+
+test "HttpClient.get / getWithHeaders / head / headResolved all refuse offline" {
+    // One-stop pinning so adding a new gated entrypoint without wiring
+    // it lands here as a fresh test red.
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    http.offline = true;
+
+    try testing.expectError(error.OfflineRequired, http.get("https://example.invalid/x"));
+    try testing.expectError(error.OfflineRequired, http.getWithHeaders("https://example.invalid/x", &.{}, null));
+    try testing.expectError(error.OfflineRequired, http.head("https://example.invalid/x"));
+    try testing.expectError(error.OfflineRequired, http.headResolved("https://example.invalid/x"));
+}
+
+test "HttpClient.OfflineRequired is non-transient" {
+    // Retry-with-backoff inside `doGetWithRetry` reads `isTransientError`
+    // — if OfflineRequired ever flipped to transient, the install pool
+    // would burn the full retry budget on a guaranteed miss instead of
+    // failing fast.
+    try testing.expect(!client_mod.isTransientError(error.OfflineRequired));
+}
+
+// ── HttpClientPool propagation ───────────────────────────────────────
+
+test "HttpClientPool.setOfflineAll mirrors the flag onto every pooled client" {
+    var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 3);
+    defer pool.deinit();
+    pool.setOfflineAll(true);
+
+    // Acquire each in turn; release order doesn't matter here — we just
+    // want to read every client's `offline` field once.
+    var seen: [3]*client_mod.HttpClient = undefined;
+    for (0..3) |i| seen[i] = pool.acquire();
+    defer for (seen) |c| pool.release(c);
+
+    for (seen) |c| try testing.expect(c.offline);
+}
+
+// ── BrewApi end-to-end: cache hit serves under offline ───────────────
+
+test "BrewApi.fetchFormula composes with HttpClient.offline so cache hits still serve" {
+    // The point of this composition test: when `http.offline = true` on
+    // a BrewApi-attached client, a cache hit must still produce bytes
+    // without touching the HTTP layer at all. Otherwise the eager gate
+    // could refuse before `readCacheBytes` got a chance.
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    http.offline = true;
+
+    const tmp = "/tmp/malt_offline_int_compose";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, tmp) catch {};
+    try test_io.makeDirAbsolute(std.Options.debug_io, tmp);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, tmp) catch {};
+
+    var api_dir_buf: [128]u8 = undefined;
+    const api_dir = try std.fmt.bufPrint(&api_dir_buf, "{s}/api", .{tmp});
+    try test_io.makeDirAbsolute(std.Options.debug_io, api_dir);
+
+    var path_buf: [256]u8 = undefined;
+    const cached_path = try std.fmt.bufPrint(&path_buf, "{s}/api/formula_wget.json", .{tmp});
+    const f = try test_io.cwd().createFile(std.Options.debug_io, cached_path, .{});
+    defer f.close(std.Options.debug_io);
+    try f.writeStreamingAll(std.Options.debug_io, "{\"name\":\"wget\"}");
+
+    var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, tmp);
+    api.offline = true;
+    const body = try api.fetchFormula("wget");
+    defer testing.allocator.free(body);
+    try testing.expectEqualStrings("{\"name\":\"wget\"}", body);
+}
+
+// ── doctor row composition ───────────────────────────────────────────
+
+test "doctor.formatOfflineDetail flips on the offline bool" {
+    try testing.expectEqualStrings("off", doctor.formatOfflineDetail(false));
+    try testing.expectEqualStrings(
+        "active — every fetch must serve from the snapshot cache",
+        doctor.formatOfflineDetail(true),
+    );
+}
+
+// ── doctor CheckCtx default ──────────────────────────────────────────
+
+test "doctor.CheckCtx.offline defaults to false" {
+    // Hard-coded default keeps every fixture-built CheckCtx test
+    // (`debug_ctx`-shaped) reading `off` without explicit plumbing.
+    const ctx: doctor.CheckCtx = .{
+        .allocator = testing.allocator,
+        .prefix = "/tmp/malt_offline_doctor_default",
+        .io = std.Options.debug_io,
+        .environ = std.process.Environ.empty,
+    };
+    try testing.expect(!ctx.offline);
+}


### PR DESCRIPTION
## Description

Adds the `MALT_OFFLINE` env (truthy: `1`, `true`) and a top-level `--offline` flag. With offline mode active, every metadata fetch and HTTP entrypoint (`BrewApi.fetch{Formula,Cask,NamesIndex}`, `HttpClient.{get,getWithHeaders,head,headResolved}`) short-circuits before any DNS / TCP work: a cache hit returns bytes regardless of TTL, a miss surfaces `OfflineRequired` instead of stalling on connect. 

- `mt install <cached-pkg>` succeeds from the snapshot; `mt install <uncached-pkg>` fails fast with `offline mode: <kind> '<name>' not cached`. 
- `mt update --check` refuses cleanly. 
- `mt doctor` shows the active state in a new "Offline mode" row and skips the API-reachable probe so an air-gapped machine doesn't surface a spurious warn row. 
 
Pairs with `--download-only`: the same snapshot they warm is what offline reads.

## Related Issue

- None

## Notes for Reviewers

- None
