### PR TITLE
feat: etag aware tap head resolve

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -222,6 +222,7 @@ pub fn build(b: *std.Build) void {
         "tests/cleanup_cli_test.zig",
         "tests/install_keg_from_bottle_test.zig",
         "tests/install_pool_test.zig",
+        "tests/tap_head_etag_integration_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/scripts/regressions/tap_head_etag_304.sh
+++ b/scripts/regressions/tap_head_etag_304.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Lock the ETag-aware tap HEAD-resolve contract end-to-end against the
+# real GitHub API.
+#
+# Pinned behaviour:
+#   1. Cold-start `mt tap add <user/repo>` resolves HEAD and stamps
+#      both `taps.commit_sha` and `taps.head_etag`.
+#   2. A second `mt tap add <user/repo>` against the same tap sends
+#      `If-None-Match` — GitHub answers 304, and the GitHub REST rate
+#      limit's `core.remaining` does NOT decrement on the second call.
+#
+# Requirements: a built malt binary, a MALT_GITHUB_TOKEN with REST
+# read scope (any classic PAT or fine-grained "public read" works).
+# The token is mandatory: without it the test cannot meaningfully
+# observe the 5000/hr cap, so we skip-loud instead of silently passing.
+#
+# Usage: scripts/regressions/tap_head_etag_304.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+if [[ -z "${MALT_GITHUB_TOKEN:-}" ]]; then
+  printf 'SKIP: MALT_GITHUB_TOKEN unset — cannot read GitHub REST rate-limit\n' >&2
+  printf '       headers without it (anonymous limits are noisy across runs).\n' >&2
+  exit 0
+fi
+
+# Stable, low-churn tap that exists at github.com/<user>/homebrew-<repo>.
+# Picked because its HEAD rarely moves; if upstream force-pushes a fresh
+# commit between calls 1 and 2 the test would (correctly) fail —
+# re-running once the dust settles is the right response.
+TAP=${MALT_TAP_REGRESSION:-aeroxy/tap}
+
+PREFIX=$(mktemp -d -t malt_etag_reg.XXXXXX)
+trap 'rm -rf "$PREFIX"' EXIT
+
+remaining_before_call() {
+  curl -fsSL \
+    -H "Authorization: Bearer $MALT_GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    https://api.github.com/rate_limit |
+    python3 -c 'import json,sys; print(json.load(sys.stdin)["resources"]["core"]["remaining"])'
+}
+
+probe_etag_persisted() {
+  MALT_PREFIX="$PREFIX" "$MALT_BIN" tap --json 2>/dev/null
+}
+
+# ---- Cold start: tap add against a fresh prefix ----
+before_cold=$(remaining_before_call)
+MALT_PREFIX="$PREFIX" "$MALT_BIN" tap add "$TAP" >/dev/null
+after_cold=$(remaining_before_call)
+cold_delta=$((before_cold - after_cold))
+if ((cold_delta < 1)); then
+  printf 'FAIL: cold tap add did not move rate-limit remaining (before=%d after=%d).\n' \
+    "$before_cold" "$after_cold" >&2
+  printf '       Either GitHub returned 304 (impossible without a cached etag)\n' >&2
+  printf '       or the rate-limit endpoint diverged from the tap-resolve path.\n' >&2
+  exit 1
+fi
+
+# ---- Hot start: same `tap add`, cached etag in play ----
+before_hot=$(remaining_before_call)
+MALT_PREFIX="$PREFIX" "$MALT_BIN" tap add "$TAP" >/dev/null
+after_hot=$(remaining_before_call)
+hot_delta=$((before_hot - after_hot))
+if ((hot_delta != 0)); then
+  printf 'FAIL: hot tap add decremented rate-limit by %d (expected 0 — 304 is free).\n' \
+    "$hot_delta" >&2
+  printf '       before=%d after=%d. The cached ETag was not sent or the\n' \
+    "$before_hot" "$after_hot" >&2
+  printf '       server returned 200 instead of 304.\n' >&2
+  exit 1
+fi
+
+# ---- Sanity: the etag was actually stored ----
+tap_json=$(probe_etag_persisted)
+if ! grep -q '"commit_sha"' <<<"$tap_json"; then
+  printf 'FAIL: tap list does not surface a commit_sha for %s after the\n' "$TAP" >&2
+  printf '       cold-start resolve.\n%s\n' "$tap_json" >&2
+  exit 1
+fi
+
+printf 'PASS: cold start spent %d token(s); hot start spent %d (304 short-circuit).\n' \
+  "$cold_delta" "$hot_delta"

--- a/scripts/regressions/tap_head_etag_304.sh
+++ b/scripts/regressions/tap_head_etag_304.sh
@@ -108,5 +108,58 @@ if command -v sqlite3 >/dev/null; then
   fi
 fi
 
-printf 'PASS: cold spent %d token; hot spent %d (304 short-circuit) — a=%d b=%d c=%d\n' \
+printf 'PASS (etag round-trip): cold spent %d token; hot spent %d (304 short-circuit) — a=%d b=%d c=%d\n' \
   "$cold_cost" "$hot_cost" "$a" "$b" "$c"
+
+# ---- Within-process dedup (gap #2): N casks from one tap → 1 HEAD ----
+# Seed 10 fake casks routed to TAP so `mt outdated` walks them through
+# the tap-resolve path. The .rb fetches will 404 on the raw CDN (not
+# rate-limited) — only the HEAD resolve spends an API token. Clobber
+# the cached etag first so the HEAD call returns 200 (not 304), making
+# the dedup distinguishable at the rate-limit level: with dedup the
+# 10 workers share 1 HEAD call; without dedup they each pay one.
+if ! command -v sqlite3 >/dev/null; then
+  printf 'SKIP (dedup check): sqlite3 not on PATH — skipping the within-process\n' >&2
+  printf '      dedup assertion. The cross-process etag path was verified above.\n' >&2
+  exit 0
+fi
+
+sqlite3 "$PREFIX/db/malt.db" \
+  "UPDATE taps SET head_etag = 'W/\"stale-force-200\"' WHERE name='$TAP';" 2>/dev/null
+
+# 10 > outdated_default_workers (8) so this exercises the pool path.
+sqlite3 "$PREFIX/db/malt.db" "$(
+  cat <<SQL
+INSERT INTO casks (token, name, version, url, tap) VALUES
+  ('zzfake1', 'zzfake1', '0', 'https://example.invalid/x.dmg', '$TAP'),
+  ('zzfake2', 'zzfake2', '0', 'https://example.invalid/x.dmg', '$TAP'),
+  ('zzfake3', 'zzfake3', '0', 'https://example.invalid/x.dmg', '$TAP'),
+  ('zzfake4', 'zzfake4', '0', 'https://example.invalid/x.dmg', '$TAP'),
+  ('zzfake5', 'zzfake5', '0', 'https://example.invalid/x.dmg', '$TAP'),
+  ('zzfake6', 'zzfake6', '0', 'https://example.invalid/x.dmg', '$TAP'),
+  ('zzfake7', 'zzfake7', '0', 'https://example.invalid/x.dmg', '$TAP'),
+  ('zzfake8', 'zzfake8', '0', 'https://example.invalid/x.dmg', '$TAP'),
+  ('zzfake9', 'zzfake9', '0', 'https://example.invalid/x.dmg', '$TAP'),
+  ('zzfakeA', 'zzfakeA', '0', 'https://example.invalid/x.dmg', '$TAP');
+SQL
+)" 2>/dev/null
+
+d=$(probe_remaining)
+# `--json` suppresses the per-row "couldn't check" warnings the fake
+# tokens trigger. Exit code may be non-zero (snapshot write may fail
+# on a partial prefix) — we only care about the rate-limit delta.
+MALT_PREFIX="$PREFIX" "$MALT_BIN" outdated --json >/dev/null 2>&1 || true
+e=$(probe_remaining)
+dedup_cost=$((d - e - 1))
+
+# With dedup: 1 HEAD (200, stale etag) = 1 token. Without: 10.
+if ((dedup_cost > 1)); then
+  printf 'FAIL: within-process dedup leaked %d token(s) for 10 same-tap casks (expected ≤1).\n' \
+    "$dedup_cost" >&2
+  printf '       d=%d e=%d. Workers sharing a tap should pay 1 HEAD call,\n' "$d" "$e" >&2
+  printf '       not N — the TapHeadResolve cache is missing or unwired.\n' >&2
+  exit 1
+fi
+
+printf 'PASS (dedup): 10 same-tap casks shared %d HEAD token (d=%d e=%d)\n' \
+  "$dedup_cost" "$d" "$e"

--- a/scripts/regressions/tap_head_etag_304.sh
+++ b/scripts/regressions/tap_head_etag_304.sh
@@ -3,11 +3,18 @@
 # real GitHub API.
 #
 # Pinned behaviour:
-#   1. Cold-start `mt tap add <user/repo>` resolves HEAD and stamps
-#      both `taps.commit_sha` and `taps.head_etag`.
-#   2. A second `mt tap add <user/repo>` against the same tap sends
-#      `If-None-Match` — GitHub answers 304, and the GitHub REST rate
-#      limit's `core.remaining` does NOT decrement on the second call.
+#   1. Cold-start `mt tap <user/repo>` resolves HEAD and stamps both
+#      `taps.commit_sha` and `taps.head_etag`.
+#   2. A second `mt tap <user/repo>` against the same tap sends
+#      `If-None-Match` — GitHub answers 304, and the conditional GET
+#      does NOT decrement `X-RateLimit-Remaining`.
+#
+# Methodology: GitHub's `/rate_limit` endpoint is a cached snapshot
+# that lags reality by several seconds. The truth is the
+# `X-RateLimit-Remaining` response header on the actual call. So we
+# probe `/repos/.../commits/HEAD` directly before and after each
+# `mt tap` invocation and read the live header — the inter-probe
+# delta minus the probe's own cost is what `mt` spent.
 #
 # Requirements: a built malt binary, a MALT_GITHUB_TOKEN with REST
 # read scope (any classic PAT or fine-grained "public read" works).
@@ -38,56 +45,68 @@ fi
 # commit between calls 1 and 2 the test would (correctly) fail —
 # re-running once the dust settles is the right response.
 TAP=${MALT_TAP_REGRESSION:-aeroxy/tap}
+SLASH_IDX=$(awk -v s="$TAP" 'BEGIN{print index(s, "/")}')
+USER=${TAP:0:$((SLASH_IDX - 1))}
+REPO=${TAP:SLASH_IDX}
+PROBE_URL="https://api.github.com/repos/${USER}/homebrew-${REPO}/commits/HEAD"
 
-PREFIX=$(mktemp -d -t malt_etag_reg.XXXXXX)
+PREFIX=$(mktemp -d -t mt_etag.XXXXXX)
+mkdir -p "$PREFIX/db"
 trap 'rm -rf "$PREFIX"' EXIT
 
-remaining_before_call() {
-  curl -fsSL \
+# Issue an unconditional probe to the same endpoint malt resolves and
+# extract `X-RateLimit-Remaining` from the response header. The header
+# reflects post-call state (i.e. includes this very call), which is
+# exactly what we want.
+probe_remaining() {
+  local hdr
+  hdr=$(curl -fsSL -o /dev/null -D - \
     -H "Authorization: Bearer $MALT_GITHUB_TOKEN" \
     -H "Accept: application/vnd.github+json" \
-    https://api.github.com/rate_limit |
-    python3 -c 'import json,sys; print(json.load(sys.stdin)["resources"]["core"]["remaining"])'
+    "$PROBE_URL")
+  awk 'BEGIN{IGNORECASE=1} /^x-ratelimit-remaining:/{gsub(/[\r\n ]/, "", $2); print $2; exit}' <<<"$hdr"
 }
 
-probe_etag_persisted() {
-  MALT_PREFIX="$PREFIX" "$MALT_BIN" tap --json 2>/dev/null
-}
+# ---- Probe A: baseline before any mt call ----
+a=$(probe_remaining)
 
-# ---- Cold start: tap add against a fresh prefix ----
-before_cold=$(remaining_before_call)
-MALT_PREFIX="$PREFIX" "$MALT_BIN" tap add "$TAP" >/dev/null
-after_cold=$(remaining_before_call)
-cold_delta=$((before_cold - after_cold))
-if ((cold_delta < 1)); then
-  printf 'FAIL: cold tap add did not move rate-limit remaining (before=%d after=%d).\n' \
-    "$before_cold" "$after_cold" >&2
-  printf '       Either GitHub returned 304 (impossible without a cached etag)\n' >&2
-  printf '       or the rate-limit endpoint diverged from the tap-resolve path.\n' >&2
+# ---- Cold start: tap against a fresh prefix ----
+MALT_PREFIX="$PREFIX" "$MALT_BIN" tap "$TAP" >/dev/null
+
+# ---- Probe B: shows post-cold state (b = a - mt_cold_cost - 1) ----
+b=$(probe_remaining)
+cold_cost=$((a - b - 1))
+if ((cold_cost < 1)); then
+  printf 'FAIL: cold tap resolve did not spend a token (a=%d b=%d cold=%d).\n' \
+    "$a" "$b" "$cold_cost" >&2
+  printf '       Expected at least 1 — the unconditional GET should have hit the limit.\n' >&2
   exit 1
 fi
 
-# ---- Hot start: same `tap add`, cached etag in play ----
-before_hot=$(remaining_before_call)
-MALT_PREFIX="$PREFIX" "$MALT_BIN" tap add "$TAP" >/dev/null
-after_hot=$(remaining_before_call)
-hot_delta=$((before_hot - after_hot))
-if ((hot_delta != 0)); then
-  printf 'FAIL: hot tap add decremented rate-limit by %d (expected 0 — 304 is free).\n' \
-    "$hot_delta" >&2
-  printf '       before=%d after=%d. The cached ETag was not sent or the\n' \
-    "$before_hot" "$after_hot" >&2
-  printf '       server returned 200 instead of 304.\n' >&2
+# ---- Hot start: same tap, cached etag now persisted ----
+MALT_PREFIX="$PREFIX" "$MALT_BIN" tap "$TAP" >/dev/null
+
+# ---- Probe C: shows post-hot state (c = b - mt_hot_cost - 1) ----
+c=$(probe_remaining)
+hot_cost=$((b - c - 1))
+if ((hot_cost != 0)); then
+  printf 'FAIL: hot tap re-resolve spent %d token(s) (expected 0 — 304 is free).\n' \
+    "$hot_cost" >&2
+  printf '       a=%d b=%d c=%d. The cached ETag was not sent or the server\n' \
+    "$a" "$b" "$c" >&2
+  printf '       returned 200 instead of 304.\n' >&2
   exit 1
 fi
 
-# ---- Sanity: the etag was actually stored ----
-tap_json=$(probe_etag_persisted)
-if ! grep -q '"commit_sha"' <<<"$tap_json"; then
-  printf 'FAIL: tap list does not surface a commit_sha for %s after the\n' "$TAP" >&2
-  printf '       cold-start resolve.\n%s\n' "$tap_json" >&2
-  exit 1
+# ---- Sanity: the etag actually landed in the DB ----
+if command -v sqlite3 >/dev/null; then
+  et=$(sqlite3 "$PREFIX/db/malt.db" \
+    "SELECT head_etag FROM taps WHERE name='$TAP';" 2>/dev/null || true)
+  if [[ -z "$et" ]]; then
+    printf 'FAIL: head_etag not persisted for %s after cold-start resolve.\n' "$TAP" >&2
+    exit 1
+  fi
 fi
 
-printf 'PASS: cold start spent %d token(s); hot start spent %d (304 short-circuit).\n' \
-  "$cold_delta" "$hot_delta"
+printf 'PASS: cold spent %d token; hot spent %d (304 short-circuit) — a=%d b=%d c=%d\n' \
+  "$cold_cost" "$hot_cost" "$a" "$b" "$c"

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -76,6 +76,12 @@ pub const ResolvedRubyFormula = struct {
 const TapRegistration = struct {
     url: []const u8,
     commit_sha: []const u8,
+    /// GitHub ETag for `/commits/HEAD` captured during cold-start
+    /// resolve. Persisted alongside `commit_sha` so the next resolve
+    /// sends `If-None-Match` and lets stable taps 304 free. Null on
+    /// the warm path (cached SHA hit, no resolve needed) and when
+    /// the server omitted the header.
+    head_etag: ?[]const u8 = null,
 };
 
 /// Archive container formats the tap/local install path extracts.
@@ -208,14 +214,28 @@ fn installTapRb(
     const urls = try tap_mod.resolveTapBaseUrls(allocator, tap_slug);
     defer urls.deinit(allocator);
 
+    // Cold-start: pass null for cached_etag (no pin → no etag either);
+    // warm-start: skip resolve entirely. The etag captured here is
+    // forwarded into TapRegistration so the persist step at the bottom
+    // of materializeRubyFormula writes both fields atomically.
+    var fresh_head_etag: ?[]const u8 = null;
+    defer if (fresh_head_etag) |e| allocator.free(e);
     const commit_sha = blk: {
         if ((tap_mod.getCommitSha(allocator, db, tap_slug) catch null)) |cached| {
             break :blk cached;
         }
-        break :blk tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url) catch |e| {
+        var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, null) catch |e| {
             output.err("Could not resolve {s}'s HEAD commit: {s}", .{ tap_slug, tap_mod.describeResolveError(e) });
             return InstallError.FormulaNotFound;
         };
+        defer head_res.deinit();
+        const sha = head_res.sha orelse {
+            output.err("Could not resolve {s}'s HEAD commit: empty response", .{tap_slug});
+            return InstallError.FormulaNotFound;
+        };
+        const sha_owned = try allocator.dupe(u8, sha);
+        if (head_res.etag) |e| fresh_head_etag = try allocator.dupe(u8, e);
+        break :blk sha_owned;
     };
     defer allocator.free(commit_sha);
 
@@ -294,7 +314,11 @@ fn installTapRb(
         .sha256 = rb.sha256,
         .binary_name = parseCaskBinary(resp.body),
         .app_name = parseCaskApp(resp.body),
-        .tap_registration = .{ .url = urls.repo_url, .commit_sha = commit_sha },
+        .tap_registration = .{
+            .url = urls.repo_url,
+            .commit_sha = commit_sha,
+            .head_etag = fresh_head_etag,
+        },
     };
     try materializeRubyFormula(ctx, allocator, resolved, &http, db, linker, prefix, dry_run, force, download_only);
 }
@@ -755,6 +779,10 @@ pub fn materializeRubyFormula(
             // and leaves later pins untouched. Tap row is advisory — keg
             // is already recorded; a missing tap row self-heals next sync.
             tap_mod.add(db, resolved.tap_label, t.url, t.commit_sha) catch {};
+            // Stamp the captured etag so the next resolve can send
+            // If-None-Match. Warm-path installs leave `head_etag` null —
+            // there's no fresh etag to overwrite an older cached one with.
+            if (t.head_etag) |et| tap_mod.updateHead(db, resolved.tap_label, t.commit_sha, et) catch {};
         }
     }
 
@@ -885,6 +913,7 @@ fn materializeTapCask(
         // Tap row is advisory — the install already succeeded; a missing
         // tap row self-heals on the next sync so swallowing is safe here.
         tap_mod.add(db, resolved.tap_label, t.url, t.commit_sha) catch {};
+        if (t.head_etag) |et| tap_mod.updateHead(db, resolved.tap_label, t.commit_sha, et) catch {};
     }
 
     output.success("{s} {s} installed", .{ cask.token, cask.version });

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -442,7 +442,7 @@ fn emitOutdatedFormulas(
     const rows = try loadFormulaRows(allocator, db, filter);
     defer freeKegRows(allocator, rows);
 
-    const entries = try collectOutdatedFormulas(ctx, allocator, api, cache_dir, rows, workers_override);
+    const entries = try collectOutdatedFormulas(ctx, allocator, db, api, cache_dir, rows, workers_override);
     defer freeEntrySlice(allocator, entries);
 
     try render_mod.writeFormulaEntries(allocator, stdout, entries, json_mode);
@@ -463,7 +463,7 @@ fn emitOutdatedCasks(
     const rows = try loadCaskRows(allocator, db, filter);
     defer freeKegRows(allocator, rows);
 
-    const entries = try collectOutdatedCasks(ctx, allocator, api, cache_dir, rows, workers_override);
+    const entries = try collectOutdatedCasks(ctx, allocator, db, api, cache_dir, rows, workers_override);
     defer freeEntrySlice(allocator, entries);
 
     try render_mod.writeCaskEntries(stdout, entries, json_mode);

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -75,7 +75,7 @@ pub fn refreshSnapshot(
     const cask_rows = try rows_mod.loadCaskRows(allocator, db, .all);
     defer rows_mod.freeKegRows(allocator, cask_rows);
 
-    const formulas = try collectOutdatedFormulas(ctx, allocator, api, cache_dir, formula_rows, workers_override);
+    const formulas = try collectOutdatedFormulas(ctx, allocator, db, api, cache_dir, formula_rows, workers_override);
     defer {
         for (formulas) |e| {
             allocator.free(e.name);
@@ -84,7 +84,7 @@ pub fn refreshSnapshot(
         }
         allocator.free(formulas);
     }
-    const casks = try collectOutdatedCasks(ctx, allocator, api, cache_dir, cask_rows, workers_override);
+    const casks = try collectOutdatedCasks(ctx, allocator, db, api, cache_dir, cask_rows, workers_override);
     defer {
         for (casks) |e| {
             allocator.free(e.name);
@@ -107,24 +107,26 @@ pub fn refreshSnapshot(
 pub fn collectOutdatedFormulas(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
+    db: *sqlite.Database,
     api: *api_mod.BrewApi,
     cache_dir: []const u8,
     kegs: []const KegRow,
     workers_override: ?usize,
 ) std.mem.Allocator.Error![]OutdatedEntry {
-    return collectOutdated(ctx, allocator, api, cache_dir, kegs, workers_override, .formula);
+    return collectOutdated(ctx, allocator, db, api, cache_dir, kegs, workers_override, .formula);
 }
 
 /// Cask sibling of `collectOutdatedFormulas`. Same lifetime contract.
 pub fn collectOutdatedCasks(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
+    db: *sqlite.Database,
     api: *api_mod.BrewApi,
     cache_dir: []const u8,
     kegs: []const KegRow,
     workers_override: ?usize,
 ) std.mem.Allocator.Error![]OutdatedEntry {
-    return collectOutdated(ctx, allocator, api, cache_dir, kegs, workers_override, .cask);
+    return collectOutdated(ctx, allocator, db, api, cache_dir, kegs, workers_override, .cask);
 }
 
 const Kind = enum { formula, cask };
@@ -132,6 +134,7 @@ const Kind = enum { formula, cask };
 fn collectOutdated(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
+    db: *sqlite.Database,
     api: *api_mod.BrewApi,
     cache_dir: []const u8,
     kegs: []const KegRow,
@@ -152,10 +155,10 @@ fn collectOutdated(
 
     if (!shouldUsePool(kegs.len)) {
         for (kegs, 0..) |row, i| {
-            latest_versions[i] = try fetchLatest(allocator, api, ctx.io, ctx.environ, kind, row);
+            latest_versions[i] = try fetchLatest(allocator, db, api, ctx.io, ctx.environ, kind, row);
         }
     } else {
-        try runPool(ctx, allocator, cache_dir, kegs, workers_override, kind, latest_versions);
+        try runPool(ctx, allocator, db, cache_dir, kegs, workers_override, kind, latest_versions);
     }
 
     return assembleEntries(allocator, kegs, latest_versions);
@@ -205,6 +208,7 @@ fn assembleEntries(
 /// shared HTTP client.
 fn upstreamLatest(
     alloc: std.mem.Allocator,
+    db: *sqlite.Database,
     api: *api_mod.BrewApi,
     io: std.Io,
     environ: std.process.Environ,
@@ -223,7 +227,7 @@ fn upstreamLatest(
             // drop the row from the audit. Same shape as `upgradeCask`.
             if (row.tap) |tap_label| {
                 if (!install_args_mod.isCoreTap(tap_label)) {
-                    break :blk tapCaskLatestVersion(alloc, io, environ, tap_label, row.name, api.offline);
+                    break :blk tapCaskLatestVersion(alloc, db, io, environ, tap_label, row.name, api.offline);
                 }
             }
             const json = api.fetchCask(row.name) catch break :blk null;
@@ -265,6 +269,7 @@ fn warnTapCaskFetchFailed(tap_label: []const u8, token: []const u8, reason: []co
 /// "couldn't reach the tap".
 fn tapCaskLatestVersion(
     alloc: std.mem.Allocator,
+    db: *sqlite.Database,
     io: std.Io,
     environ: std.process.Environ,
     tap_label: []const u8,
@@ -277,11 +282,37 @@ fn tapCaskLatestVersion(
     const urls = tap_mod.resolveTapBaseUrls(alloc, tap_label) catch return null;
     defer urls.deinit(alloc);
 
-    const fresh_sha = tap_mod.resolveHeadCommit(io, environ, alloc, urls.api_head_url) catch |err| {
+    // Send the cached etag so a second `mt outdated` against the same
+    // prefix 304s for free — the core acceptance criterion for this
+    // task. 304 keeps `fresh_sha` pointing at the cached value.
+    const cached_sha_opt = tap_mod.getCommitSha(alloc, db, tap_label) catch null;
+    defer if (cached_sha_opt) |s| alloc.free(s);
+    const cached_etag_opt = tap_mod.getHeadEtag(alloc, db, tap_label) catch null;
+    defer if (cached_etag_opt) |e| alloc.free(e);
+
+    var head_res = tap_mod.resolveHeadCommit(io, environ, alloc, urls.api_head_url, cached_etag_opt) catch |err| {
         warnTapHeadResolveFailed(tap_label, err);
         return null;
     };
-    defer alloc.free(fresh_sha);
+    defer head_res.deinit();
+
+    const fresh_sha = if (head_res.not_modified)
+        (cached_sha_opt orelse {
+            warnTapHeadResolveFailed(tap_label, tap_mod.TapError.ResolveFailed);
+            return null;
+        })
+    else
+        (head_res.sha orelse {
+            warnTapHeadResolveFailed(tap_label, tap_mod.TapError.MalformedJson);
+            return null;
+        });
+
+    // Best-effort etag persistence on 200 — failure here only costs an
+    // extra API call next round, never a wrong sha. SQLite SERIALIZED
+    // mode handles concurrent writes from sibling workers safely.
+    if (!head_res.not_modified) {
+        if (head_res.etag) |et| tap_mod.updateHead(db, tap_label, fresh_sha, et) catch {};
+    }
 
     var http = client_mod.HttpClient.init(io, environ, alloc);
     defer http.deinit();
@@ -313,13 +344,14 @@ fn tapCaskLatestVersion(
 /// string if `row` is outdated, null otherwise.
 fn fetchLatest(
     allocator: std.mem.Allocator,
+    db: *sqlite.Database,
     api: *api_mod.BrewApi,
     io: std.Io,
     environ: std.process.Environ,
     kind: Kind,
     row: KegRow,
 ) std.mem.Allocator.Error!?[]u8 {
-    const v = upstreamLatest(allocator, api, io, environ, kind, row) orelse return null;
+    const v = upstreamLatest(allocator, db, api, io, environ, kind, row) orelse return null;
     if (std.mem.eql(u8, row.version, v)) {
         allocator.free(v);
         return null;
@@ -357,6 +389,10 @@ const WorkerCtx = struct {
     /// through `tap_mod.resolveHeadCommit`, which reads GitHub auth
     /// tokens from the parent process environ.
     environ: std.process.Environ,
+    /// Shared DB pointer for cached-etag lookup / persist. Safe under
+    /// SQLite SERIALIZED mode (the build sets THREADSAFE=1) — sibling
+    /// workers serialise on the per-statement mutex.
+    db: *sqlite.Database,
     arena: std.heap.ArenaAllocator,
     pool: *client_mod.HttpClientPool,
     cache_dir: []const u8,
@@ -399,7 +435,7 @@ fn runOne(out_alloc: std.mem.Allocator, wctx: *WorkerCtx) void {
     var local_api = api_mod.BrewApi.init(wctx.io, arena_alloc, http, wctx.cache_dir);
     local_api.base_url = wctx.api_base;
     local_api.offline = wctx.offline;
-    const latest = upstreamLatest(arena_alloc, &local_api, wctx.io, wctx.environ, wctx.kind, wctx.row) orelse return;
+    const latest = upstreamLatest(arena_alloc, wctx.db, &local_api, wctx.io, wctx.environ, wctx.kind, wctx.row) orelse return;
     if (std.mem.eql(u8, wctx.row.version, latest)) return;
 
     // Move into the caller's allocator so the result outlives `arena.deinit()`.
@@ -412,6 +448,7 @@ fn runOne(out_alloc: std.mem.Allocator, wctx: *WorkerCtx) void {
 fn runPool(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
+    db: *sqlite.Database,
     cache_dir: []const u8,
     kegs: []const KegRow,
     workers_override: ?usize,
@@ -434,6 +471,7 @@ fn runPool(
     for (ctxs, 0..) |*c, i| c.* = .{
         .io = ctx.io,
         .environ = ctx.environ,
+        .db = db,
         .arena = std.heap.ArenaAllocator.init(std.heap.smp_allocator),
         .pool = &http_pool,
         .cache_dir = cache_dir,
@@ -480,9 +518,13 @@ test "WorkerCtx: per-row arena accepts testing.allocator backing without leaking
     // backs the same arena with `smp_allocator`; the inline test
     // guarantees `testing.allocator` still works so future leak coverage
     // can land here without re-plumbing.
+    // Field-only smoke: db isn't dereferenced, so an undefined ptr is
+    // safe here (mirrors `.pool = undefined`). Real workers always get
+    // a live DB from `runPool`.
     var wctx: WorkerCtx = .{
         .io = std.Options.debug_io,
         .environ = std.process.Environ.empty,
+        .db = undefined,
         .arena = std.heap.ArenaAllocator.init(std.testing.allocator),
         .pool = undefined,
         .cache_dir = "",

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -153,12 +153,18 @@ fn collectOutdated(
         if (maybe) |v| allocator.free(v);
     };
 
+    // One dedup cache per `collectOutdated` call shared by every row.
+    // Lifetime: scoped to this function — workers borrow shas back
+    // (cache outlives every worker's resolve usage).
+    var head_cache = TapHeadResolve.init(allocator, ctx.io);
+    defer head_cache.deinit();
+
     if (!shouldUsePool(kegs.len)) {
         for (kegs, 0..) |row, i| {
-            latest_versions[i] = try fetchLatest(allocator, db, api, ctx.io, ctx.environ, kind, row);
+            latest_versions[i] = try fetchLatest(allocator, &head_cache, db, api, ctx.io, ctx.environ, kind, row);
         }
     } else {
-        try runPool(ctx, allocator, db, cache_dir, kegs, workers_override, kind, latest_versions);
+        try runPool(ctx, allocator, &head_cache, db, cache_dir, kegs, workers_override, kind, latest_versions);
     }
 
     return assembleEntries(allocator, kegs, latest_versions);
@@ -208,6 +214,7 @@ fn assembleEntries(
 /// shared HTTP client.
 fn upstreamLatest(
     alloc: std.mem.Allocator,
+    head_cache: *TapHeadResolve,
     db: *sqlite.Database,
     api: *api_mod.BrewApi,
     io: std.Io,
@@ -227,7 +234,7 @@ fn upstreamLatest(
             // drop the row from the audit. Same shape as `upgradeCask`.
             if (row.tap) |tap_label| {
                 if (!install_args_mod.isCoreTap(tap_label)) {
-                    break :blk tapCaskLatestVersion(alloc, db, io, environ, tap_label, row.name, api.offline);
+                    break :blk tapCaskLatestVersion(alloc, head_cache, db, io, environ, tap_label, row.name, api.offline);
                 }
             }
             const json = api.fetchCask(row.name) catch break :blk null;
@@ -237,6 +244,185 @@ fn upstreamLatest(
             break :blk alloc.dupe(u8, cask.version) catch null;
         },
     };
+}
+
+/// In-process dedup cache for tap-HEAD resolves during one
+/// `mt outdated` invocation. N installed casks from the same tap
+/// share a single underlying conditional GET — without this, the
+/// worker pool fired N parallel resolves and (in the rare case
+/// upstream just moved) spent N rate-limit tokens for what the
+/// next invocation would coalesce to one. Cross-process caching
+/// still lives in the DB's `head_etag` column.
+///
+/// A single mutex serialises distinct-tap resolves too — the
+/// alternative (per-tap mutex + condition variable) was rejected
+/// as over-engineering for the typical 1–3 distinct taps an
+/// `mt outdated` actually sees. The resolver is injected so tests
+/// can drive dedup mechanics without an HTTP transport.
+pub const TapHeadResolve = struct {
+    arena: std.heap.ArenaAllocator,
+    io: std.Io,
+    mutex: std.Io.Mutex = .init,
+    /// `null` value caches a known-failing resolve so sibling workers
+    /// don't retry the same dead endpoint within one invocation.
+    map: std.StringHashMap(?[]const u8),
+
+    pub const ResolverFn = *const fn (
+        userdata: *anyopaque,
+        alloc: std.mem.Allocator,
+        tap_label: []const u8,
+    ) ?[]const u8;
+
+    pub fn init(backing: std.mem.Allocator, io: std.Io) TapHeadResolve {
+        return .{
+            .arena = std.heap.ArenaAllocator.init(backing),
+            .io = io,
+            .map = .init(backing),
+        };
+    }
+
+    pub fn deinit(self: *TapHeadResolve) void {
+        self.map.deinit();
+        self.arena.deinit();
+    }
+
+    /// Lookup-or-resolve. The returned slice (when non-null) is borrowed
+    /// from the cache's arena and stays valid for the cache's lifetime.
+    /// Holds the mutex across the resolver by design: that's the
+    /// invariant that turns N concurrent same-label calls into one.
+    pub fn getOrResolve(
+        self: *TapHeadResolve,
+        tap_label: []const u8,
+        userdata: *anyopaque,
+        resolve: ResolverFn,
+    ) ?[]const u8 {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+
+        if (self.map.get(tap_label)) |maybe_sha| return maybe_sha;
+
+        const a = self.arena.allocator();
+        const sha = resolve(userdata, a, tap_label);
+        // If the key dupe / map put fails (OOM), skip caching but still
+        // return the resolved sha — losing the cache slot is recoverable;
+        // returning null because of an alloc hiccup is not.
+        const key_owned = a.dupe(u8, tap_label) catch return sha;
+        self.map.put(key_owned, sha) catch return sha;
+        return sha;
+    }
+};
+
+test "TapHeadResolve: second call for same label returns cached value (no second resolve)" {
+    var cache = TapHeadResolve.init(std.testing.allocator, std.Options.debug_io);
+    defer cache.deinit();
+
+    const Counter = struct {
+        var count: usize = 0;
+        fn resolve(_: *anyopaque, a: std.mem.Allocator, _: []const u8) ?[]const u8 {
+            count += 1;
+            return a.dupe(u8, "0123456789abcdef0123456789abcdef01234567") catch null;
+        }
+    };
+    Counter.count = 0;
+    var dummy: u8 = 0;
+
+    const a1 = cache.getOrResolve("user/repo", &dummy, Counter.resolve);
+    const a2 = cache.getOrResolve("user/repo", &dummy, Counter.resolve);
+    try std.testing.expect(a1 != null);
+    try std.testing.expect(a2 != null);
+    try std.testing.expectEqualStrings(a1.?, a2.?);
+    try std.testing.expectEqual(@as(usize, 1), Counter.count);
+}
+
+test "TapHeadResolve: distinct labels resolve independently (1 call each)" {
+    var cache = TapHeadResolve.init(std.testing.allocator, std.Options.debug_io);
+    defer cache.deinit();
+
+    const Counter = struct {
+        var count: usize = 0;
+        fn resolve(_: *anyopaque, a: std.mem.Allocator, label: []const u8) ?[]const u8 {
+            count += 1;
+            return a.dupe(u8, label) catch null;
+        }
+    };
+    Counter.count = 0;
+    var dummy: u8 = 0;
+
+    _ = cache.getOrResolve("user/repo-a", &dummy, Counter.resolve);
+    _ = cache.getOrResolve("user/repo-b", &dummy, Counter.resolve);
+    _ = cache.getOrResolve("user/repo-a", &dummy, Counter.resolve);
+    _ = cache.getOrResolve("user/repo-b", &dummy, Counter.resolve);
+    try std.testing.expectEqual(@as(usize, 2), Counter.count);
+}
+
+test "TapHeadResolve: caches a null result so sibling workers don't retry a dead endpoint" {
+    var cache = TapHeadResolve.init(std.testing.allocator, std.Options.debug_io);
+    defer cache.deinit();
+
+    const Counter = struct {
+        var count: usize = 0;
+        fn resolve(_: *anyopaque, _: std.mem.Allocator, _: []const u8) ?[]const u8 {
+            count += 1;
+            return null;
+        }
+    };
+    Counter.count = 0;
+    var dummy: u8 = 0;
+
+    _ = cache.getOrResolve("user/repo", &dummy, Counter.resolve);
+    _ = cache.getOrResolve("user/repo", &dummy, Counter.resolve);
+    _ = cache.getOrResolve("user/repo", &dummy, Counter.resolve);
+    try std.testing.expectEqual(@as(usize, 1), Counter.count);
+}
+
+const ConcurrentResolveCtx = struct {
+    cache: *TapHeadResolve,
+    label: []const u8,
+    counter: *std.atomic.Value(usize),
+    /// Barrier so all N threads reach the cache call simultaneously —
+    /// otherwise the first thread might finish before the rest start
+    /// and the test passes for the wrong reason (single-thread serial
+    /// rather than locked dedup).
+    barrier: *std.atomic.Value(usize),
+    expected: usize,
+
+    fn resolve(userdata: *anyopaque, a: std.mem.Allocator, _: []const u8) ?[]const u8 {
+        const self: *ConcurrentResolveCtx = @ptrCast(@alignCast(userdata));
+        _ = self.counter.fetchAdd(1, .acq_rel);
+        return a.dupe(u8, "0123456789abcdef0123456789abcdef01234567") catch null;
+    }
+
+    fn worker(self: *ConcurrentResolveCtx) void {
+        _ = self.barrier.fetchAdd(1, .acq_rel);
+        while (self.barrier.load(.acquire) < self.expected) {} // spin until everyone arrived
+        _ = self.cache.getOrResolve(self.label, self, ConcurrentResolveCtx.resolve);
+    }
+};
+
+test "TapHeadResolve: concurrent same-label calls resolve exactly once" {
+    var cache = TapHeadResolve.init(std.testing.allocator, std.Options.debug_io);
+    defer cache.deinit();
+
+    var counter = std.atomic.Value(usize).init(0);
+    var barrier = std.atomic.Value(usize).init(0);
+    const thread_count: usize = 8;
+    var ctxs: [thread_count]ConcurrentResolveCtx = undefined;
+    for (&ctxs) |*c| c.* = .{
+        .cache = &cache,
+        .label = "user/repo",
+        .counter = &counter,
+        .barrier = &barrier,
+        .expected = thread_count,
+    };
+
+    var threads: [thread_count]std.Thread = undefined;
+    for (&threads, &ctxs) |*t, *c| {
+        t.* = try std.Thread.spawn(.{}, ConcurrentResolveCtx.worker, .{c});
+    }
+    for (threads) |t| t.join();
+
+    // The whole point of this fix: N concurrent same-label calls collapse to 1.
+    try std.testing.expectEqual(@as(usize, 1), counter.load(.acquire));
 }
 
 /// Surface a tap HEAD-resolve failure during the outdated audit. Pre-
@@ -261,6 +447,49 @@ fn warnTapCaskFetchFailed(tap_label: []const u8, token: []const u8, reason: []co
     );
 }
 
+/// Production resolver: the conditional-GET path with DB-cached etag.
+/// Bound to the `*HeadResolverCtx` the cache passes back per call. The
+/// arena `a` is the cache's arena, so returned slices live for the
+/// cache's lifetime without an extra dupe at the call site.
+const HeadResolverCtx = struct {
+    io: std.Io,
+    environ: std.process.Environ,
+    db: *sqlite.Database,
+
+    fn resolve(userdata: *anyopaque, a: std.mem.Allocator, tap_label: []const u8) ?[]const u8 {
+        const self: *HeadResolverCtx = @ptrCast(@alignCast(userdata));
+        const urls = tap_mod.resolveTapBaseUrls(a, tap_label) catch return null;
+
+        const cached_sha = tap_mod.getCommitSha(a, self.db, tap_label) catch null;
+        const cached_etag = tap_mod.getHeadEtag(a, self.db, tap_label) catch null;
+
+        var res = tap_mod.resolveHeadCommit(self.io, self.environ, a, urls.api_head_url, cached_etag) catch |err| {
+            warnTapHeadResolveFailed(tap_label, err);
+            return null;
+        };
+        defer res.deinit();
+
+        const final_sha = if (res.not_modified)
+            (cached_sha orelse {
+                warnTapHeadResolveFailed(tap_label, tap_mod.TapError.ResolveFailed);
+                return null;
+            })
+        else
+            (res.sha orelse {
+                warnTapHeadResolveFailed(tap_label, tap_mod.TapError.MalformedJson);
+                return null;
+            });
+
+        // Dupe into arena so the cache owns the slice after res.deinit()
+        // (arena's free is a no-op so this is purely for ownership clarity).
+        const sha_owned = a.dupe(u8, final_sha) catch return null;
+        if (!res.not_modified) {
+            if (res.etag) |et| tap_mod.updateHead(self.db, tap_label, sha_owned, et) catch {};
+        }
+        return sha_owned;
+    }
+};
+
 /// Resolve a tap cask's upstream version by fetching the owning tap's
 /// `Casks/<token>.rb` at fresh HEAD and reading the `version` field.
 /// Returns null on any failure so the caller leaves the row alone, but
@@ -269,6 +498,7 @@ fn warnTapCaskFetchFailed(tap_label: []const u8, token: []const u8, reason: []co
 /// "couldn't reach the tap".
 fn tapCaskLatestVersion(
     alloc: std.mem.Allocator,
+    head_cache: *TapHeadResolve,
     db: *sqlite.Database,
     io: std.Io,
     environ: std.process.Environ,
@@ -279,40 +509,15 @@ fn tapCaskLatestVersion(
     const slash = std.mem.indexOfScalar(u8, tap_label, '/') orelse return null;
     if (slash == 0 or slash == tap_label.len - 1) return null;
 
+    // Dedup'd HEAD resolve: N workers for the same tap pay 1 API call,
+    // not N (and the rare moved-tap race costs 1 token, not N).
+    var rctx = HeadResolverCtx{ .io = io, .environ = environ, .db = db };
+    const fresh_sha = head_cache.getOrResolve(tap_label, &rctx, HeadResolverCtx.resolve) orelse return null;
+
+    // The .rb fetch is per-cask (different token per row), so it stays
+    // out of the cache — only the tap-HEAD resolve dedups.
     const urls = tap_mod.resolveTapBaseUrls(alloc, tap_label) catch return null;
     defer urls.deinit(alloc);
-
-    // Send the cached etag so a second `mt outdated` against the same
-    // prefix 304s for free — the core acceptance criterion for this
-    // task. 304 keeps `fresh_sha` pointing at the cached value.
-    const cached_sha_opt = tap_mod.getCommitSha(alloc, db, tap_label) catch null;
-    defer if (cached_sha_opt) |s| alloc.free(s);
-    const cached_etag_opt = tap_mod.getHeadEtag(alloc, db, tap_label) catch null;
-    defer if (cached_etag_opt) |e| alloc.free(e);
-
-    var head_res = tap_mod.resolveHeadCommit(io, environ, alloc, urls.api_head_url, cached_etag_opt) catch |err| {
-        warnTapHeadResolveFailed(tap_label, err);
-        return null;
-    };
-    defer head_res.deinit();
-
-    const fresh_sha = if (head_res.not_modified)
-        (cached_sha_opt orelse {
-            warnTapHeadResolveFailed(tap_label, tap_mod.TapError.ResolveFailed);
-            return null;
-        })
-    else
-        (head_res.sha orelse {
-            warnTapHeadResolveFailed(tap_label, tap_mod.TapError.MalformedJson);
-            return null;
-        });
-
-    // Best-effort etag persistence on 200 — failure here only costs an
-    // extra API call next round, never a wrong sha. SQLite SERIALIZED
-    // mode handles concurrent writes from sibling workers safely.
-    if (!head_res.not_modified) {
-        if (head_res.etag) |et| tap_mod.updateHead(db, tap_label, fresh_sha, et) catch {};
-    }
 
     var http = client_mod.HttpClient.init(io, environ, alloc);
     defer http.deinit();
@@ -344,6 +549,7 @@ fn tapCaskLatestVersion(
 /// string if `row` is outdated, null otherwise.
 fn fetchLatest(
     allocator: std.mem.Allocator,
+    head_cache: *TapHeadResolve,
     db: *sqlite.Database,
     api: *api_mod.BrewApi,
     io: std.Io,
@@ -351,7 +557,7 @@ fn fetchLatest(
     kind: Kind,
     row: KegRow,
 ) std.mem.Allocator.Error!?[]u8 {
-    const v = upstreamLatest(allocator, db, api, io, environ, kind, row) orelse return null;
+    const v = upstreamLatest(allocator, head_cache, db, api, io, environ, kind, row) orelse return null;
     if (std.mem.eql(u8, row.version, v)) {
         allocator.free(v);
         return null;
@@ -389,6 +595,9 @@ const WorkerCtx = struct {
     /// through `tap_mod.resolveHeadCommit`, which reads GitHub auth
     /// tokens from the parent process environ.
     environ: std.process.Environ,
+    /// Shared dedup cache: N workers checking the same tap_label pay
+    /// 1 API call across the whole `mt outdated` invocation.
+    head_cache: *TapHeadResolve,
     /// Shared DB pointer for cached-etag lookup / persist. Safe under
     /// SQLite SERIALIZED mode (the build sets THREADSAFE=1) — sibling
     /// workers serialise on the per-statement mutex.
@@ -435,7 +644,7 @@ fn runOne(out_alloc: std.mem.Allocator, wctx: *WorkerCtx) void {
     var local_api = api_mod.BrewApi.init(wctx.io, arena_alloc, http, wctx.cache_dir);
     local_api.base_url = wctx.api_base;
     local_api.offline = wctx.offline;
-    const latest = upstreamLatest(arena_alloc, wctx.db, &local_api, wctx.io, wctx.environ, wctx.kind, wctx.row) orelse return;
+    const latest = upstreamLatest(arena_alloc, wctx.head_cache, wctx.db, &local_api, wctx.io, wctx.environ, wctx.kind, wctx.row) orelse return;
     if (std.mem.eql(u8, wctx.row.version, latest)) return;
 
     // Move into the caller's allocator so the result outlives `arena.deinit()`.
@@ -448,6 +657,7 @@ fn runOne(out_alloc: std.mem.Allocator, wctx: *WorkerCtx) void {
 fn runPool(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
+    head_cache: *TapHeadResolve,
     db: *sqlite.Database,
     cache_dir: []const u8,
     kegs: []const KegRow,
@@ -471,6 +681,7 @@ fn runPool(
     for (ctxs, 0..) |*c, i| c.* = .{
         .io = ctx.io,
         .environ = ctx.environ,
+        .head_cache = head_cache,
         .db = db,
         .arena = std.heap.ArenaAllocator.init(std.heap.smp_allocator),
         .pool = &http_pool,
@@ -524,6 +735,7 @@ test "WorkerCtx: per-row arena accepts testing.allocator backing without leaking
     var wctx: WorkerCtx = .{
         .io = std.Options.debug_io,
         .environ = std.process.Environ.empty,
+        .head_cache = undefined,
         .db = undefined,
         .arena = std.heap.ArenaAllocator.init(std.testing.allocator),
         .pool = undefined,

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -267,11 +267,16 @@ pub const TapHeadResolve = struct {
     /// don't retry the same dead endpoint within one invocation.
     map: std.StringHashMap(?[]const u8),
 
-    pub const ResolverFn = *const fn (
+    /// Bundled userdata + fn pointer — mirrors `client.ProgressCallback`'s
+    /// shape so call sites read uniformly across the codebase.
+    pub const Resolver = struct {
         userdata: *anyopaque,
-        alloc: std.mem.Allocator,
-        tap_label: []const u8,
-    ) ?[]const u8;
+        resolve: *const fn (
+            userdata: *anyopaque,
+            alloc: std.mem.Allocator,
+            tap_label: []const u8,
+        ) ?[]const u8,
+    };
 
     pub fn init(backing: std.mem.Allocator, io: std.Io) TapHeadResolve {
         return .{
@@ -293,8 +298,7 @@ pub const TapHeadResolve = struct {
     pub fn getOrResolve(
         self: *TapHeadResolve,
         tap_label: []const u8,
-        userdata: *anyopaque,
-        resolve: ResolverFn,
+        resolver: Resolver,
     ) ?[]const u8 {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
@@ -302,10 +306,10 @@ pub const TapHeadResolve = struct {
         if (self.map.get(tap_label)) |maybe_sha| return maybe_sha;
 
         const a = self.arena.allocator();
-        const sha = resolve(userdata, a, tap_label);
-        // If the key dupe / map put fails (OOM), skip caching but still
-        // return the resolved sha — losing the cache slot is recoverable;
-        // returning null because of an alloc hiccup is not.
+        const sha = resolver.resolve(resolver.userdata, a, tap_label);
+        // catch return sha: cache-insert OOM degrades to "no cache hit
+        // next time" — sibling workers re-resolve but no correctness
+        // issue. Returning null instead would hide a successful resolve.
         const key_owned = a.dupe(u8, tap_label) catch return sha;
         self.map.put(key_owned, sha) catch return sha;
         return sha;
@@ -326,8 +330,8 @@ test "TapHeadResolve: second call for same label returns cached value (no second
     Counter.count = 0;
     var dummy: u8 = 0;
 
-    const a1 = cache.getOrResolve("user/repo", &dummy, Counter.resolve);
-    const a2 = cache.getOrResolve("user/repo", &dummy, Counter.resolve);
+    const a1 = cache.getOrResolve("user/repo", .{ .userdata = &dummy, .resolve = Counter.resolve });
+    const a2 = cache.getOrResolve("user/repo", .{ .userdata = &dummy, .resolve = Counter.resolve });
     try std.testing.expect(a1 != null);
     try std.testing.expect(a2 != null);
     try std.testing.expectEqualStrings(a1.?, a2.?);
@@ -348,10 +352,11 @@ test "TapHeadResolve: distinct labels resolve independently (1 call each)" {
     Counter.count = 0;
     var dummy: u8 = 0;
 
-    _ = cache.getOrResolve("user/repo-a", &dummy, Counter.resolve);
-    _ = cache.getOrResolve("user/repo-b", &dummy, Counter.resolve);
-    _ = cache.getOrResolve("user/repo-a", &dummy, Counter.resolve);
-    _ = cache.getOrResolve("user/repo-b", &dummy, Counter.resolve);
+    const r: TapHeadResolve.Resolver = .{ .userdata = &dummy, .resolve = Counter.resolve };
+    _ = cache.getOrResolve("user/repo-a", r);
+    _ = cache.getOrResolve("user/repo-b", r);
+    _ = cache.getOrResolve("user/repo-a", r);
+    _ = cache.getOrResolve("user/repo-b", r);
     try std.testing.expectEqual(@as(usize, 2), Counter.count);
 }
 
@@ -369,9 +374,10 @@ test "TapHeadResolve: caches a null result so sibling workers don't retry a dead
     Counter.count = 0;
     var dummy: u8 = 0;
 
-    _ = cache.getOrResolve("user/repo", &dummy, Counter.resolve);
-    _ = cache.getOrResolve("user/repo", &dummy, Counter.resolve);
-    _ = cache.getOrResolve("user/repo", &dummy, Counter.resolve);
+    const r: TapHeadResolve.Resolver = .{ .userdata = &dummy, .resolve = Counter.resolve };
+    _ = cache.getOrResolve("user/repo", r);
+    _ = cache.getOrResolve("user/repo", r);
+    _ = cache.getOrResolve("user/repo", r);
     try std.testing.expectEqual(@as(usize, 1), Counter.count);
 }
 
@@ -387,6 +393,7 @@ const ConcurrentResolveCtx = struct {
     expected: usize,
 
     fn resolve(userdata: *anyopaque, a: std.mem.Allocator, _: []const u8) ?[]const u8 {
+        // Unpack the userdata pointer the cache hands back per call.
         const self: *ConcurrentResolveCtx = @ptrCast(@alignCast(userdata));
         _ = self.counter.fetchAdd(1, .acq_rel);
         return a.dupe(u8, "0123456789abcdef0123456789abcdef01234567") catch null;
@@ -395,7 +402,7 @@ const ConcurrentResolveCtx = struct {
     fn worker(self: *ConcurrentResolveCtx) void {
         _ = self.barrier.fetchAdd(1, .acq_rel);
         while (self.barrier.load(.acquire) < self.expected) {} // spin until everyone arrived
-        _ = self.cache.getOrResolve(self.label, self, ConcurrentResolveCtx.resolve);
+        _ = self.cache.getOrResolve(self.label, .{ .userdata = self, .resolve = ConcurrentResolveCtx.resolve });
     }
 };
 
@@ -457,9 +464,13 @@ const HeadResolverCtx = struct {
     db: *sqlite.Database,
 
     fn resolve(userdata: *anyopaque, a: std.mem.Allocator, tap_label: []const u8) ?[]const u8 {
+        // Unpack the userdata pointer the cache hands back per call.
         const self: *HeadResolverCtx = @ptrCast(@alignCast(userdata));
         const urls = tap_mod.resolveTapBaseUrls(a, tap_label) catch return null;
 
+        // catch null: a DB hiccup here just degrades to "no cached pin /
+        // etag" — the resolve then runs unconditional (same as a cold
+        // start), which is the right fallback.
         const cached_sha = tap_mod.getCommitSha(a, self.db, tap_label) catch null;
         const cached_etag = tap_mod.getHeadEtag(a, self.db, tap_label) catch null;
 
@@ -512,7 +523,10 @@ fn tapCaskLatestVersion(
     // Dedup'd HEAD resolve: N workers for the same tap pay 1 API call,
     // not N (and the rare moved-tap race costs 1 token, not N).
     var rctx = HeadResolverCtx{ .io = io, .environ = environ, .db = db };
-    const fresh_sha = head_cache.getOrResolve(tap_label, &rctx, HeadResolverCtx.resolve) orelse return null;
+    const fresh_sha = head_cache.getOrResolve(tap_label, .{
+        .userdata = &rctx,
+        .resolve = HeadResolverCtx.resolve,
+    }) orelse return null;
 
     // The .rb fetch is per-cask (different token per row), so it stays
     // out of the cache — only the tap-HEAD resolve dedups.

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -476,16 +476,40 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
             defer urls.deinit(allocator);
 
             // Resolve HEAD so the tap is pinned from day one. Failing
-            // here beats silently registering an unpinned tap.
-            const sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url) catch |e| {
+            // here beats silently registering an unpinned tap. Idempotent
+            // re-adds reuse the cached etag so a second `tap add` against
+            // a stable tap costs zero rate-limit tokens.
+            const cached_sha_opt = tap_mod.getCommitSha(allocator, &db, name) catch null;
+            defer if (cached_sha_opt) |s| allocator.free(s);
+            const cached_etag_opt = tap_mod.getHeadEtag(allocator, &db, name) catch null;
+            defer if (cached_etag_opt) |e| allocator.free(e);
+
+            var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, cached_etag_opt) catch |e| {
                 output.err("Could not resolve {s}'s HEAD commit: {s}", .{ name, tap_mod.describeResolveError(e) });
                 return error.Aborted;
             };
-            defer allocator.free(sha);
+            defer head_res.deinit();
+            const sha = if (head_res.not_modified)
+                (cached_sha_opt orelse {
+                    output.err("Could not resolve {s}'s HEAD commit: 304 without cached sha", .{name});
+                    return error.Aborted;
+                })
+            else
+                (head_res.sha orelse {
+                    output.err("Could not resolve {s}'s HEAD commit: empty response", .{name});
+                    return error.Aborted;
+                });
             tap_mod.add(&db, name, urls.repo_url, sha) catch {
                 output.err("Failed to add tap {s}", .{name});
                 return error.Aborted;
             };
+            // Stamp the etag in the same row so the next resolve sends
+            // If-None-Match. Best-effort — a failure here only costs us
+            // an extra API call on the next round, never a wrong sha.
+            // 304 path keeps the cached etag — it's still current.
+            if (!head_res.not_modified) {
+                if (head_res.etag) |et| tap_mod.updateHead(&db, name, sha, et) catch {};
+            }
             output.info("Tapped {s} @ {s}", .{ name, sha[0..@min(sha.len, 7)] });
         },
         .remove => {
@@ -517,9 +541,11 @@ fn pinTap(
     // Route reachability through the same HTTP path as HEAD resolution so a
     // 200 here proves the SHA is fetchable from the exact repo subsequent
     // installs will use. A 404 means GitHub has no such commit on this repo.
+    // /commits/<sha> is sha-pinned so the ETag has no caching value — pass
+    // null and ignore any etag the server happens to return.
     const commit_url = try tap_mod.resolveCommitUrl(allocator, slug, sha);
     defer allocator.free(commit_url);
-    const echoed = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, commit_url) catch |e| {
+    var echoed_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, commit_url, null) catch |e| {
         if (e == error.NotFound) {
             output.err("Cannot pin {s} @ {s}: GitHub has no such commit on this tap.", .{ slug, sha[0..@min(sha.len, 7)] });
         } else {
@@ -527,7 +553,11 @@ fn pinTap(
         }
         return error.Aborted;
     };
-    defer allocator.free(echoed);
+    defer echoed_res.deinit();
+    const echoed = echoed_res.sha orelse {
+        output.err("Cannot pin {s} @ {s}: GitHub returned an empty response.", .{ slug, sha[0..@min(sha.len, 7)] });
+        return error.Aborted;
+    };
 
     // Defensive: GitHub's `commits/<sha>` echoes the resolved full SHA. If
     // it differs, treat as unreachable rather than store a mismatched pin.
@@ -569,21 +599,29 @@ fn refreshAll(
 
     // Resolve each tap's HEAD up-front so the diff display reflects the
     // full plan before any write happens — including the case where the
-    // user immediately passes `--yes`.
+    // user immediately passes `--yes`. Etag travels alongside the sha so
+    // the post-confirm apply step writes both atomically via updateHead.
     var new_shas: std.ArrayList(?[]const u8) = .empty;
+    var new_etags: std.ArrayList(?[]const u8) = .empty;
     defer {
         for (new_shas.items) |maybe_sha| if (maybe_sha) |sha| allocator.free(sha);
         new_shas.deinit(allocator);
+        for (new_etags.items) |maybe_et| if (maybe_et) |et| allocator.free(et);
+        new_etags.deinit(allocator);
     }
     try new_shas.ensureTotalCapacityPrecise(allocator, taps.len);
+    try new_etags.ensureTotalCapacityPrecise(allocator, taps.len);
 
     var rows: std.ArrayList(RefreshRow) = .empty;
     defer rows.deinit(allocator);
     try rows.ensureTotalCapacityPrecise(allocator, taps.len);
 
     for (taps) |t| {
-        const new_sha = resolveOneHead(ctx, allocator, t.name) catch null;
+        const pair = resolveOneHead(ctx, allocator, t.name) catch null;
+        const new_sha: ?[]const u8 = if (pair) |p| p.sha else null;
+        const new_et: ?[]const u8 = if (pair) |p| p.etag else null;
         new_shas.appendAssumeCapacity(new_sha);
+        new_etags.appendAssumeCapacity(new_et);
         rows.appendAssumeCapacity(.{
             .name = t.name,
             .old_sha = t.commit_sha,
@@ -600,25 +638,40 @@ fn refreshAll(
     }
 
     // Apply only the rows that actually moved; unchanged is a no-op and
-    // failed has no SHA to write.
-    for (rows.items) |row| {
+    // failed has no SHA to write. updateHead atomically pairs the new
+    // sha with its etag — the next non-refresh resolve short-circuits.
+    for (rows.items, new_etags.items) |row, maybe_et| {
         if (row.status != .moved) continue;
         const new_sha = row.new_sha orelse continue;
-        tap_mod.updateCommit(db, row.name, new_sha) catch {
+        tap_mod.updateHead(db, row.name, new_sha, maybe_et) catch {
             output.err("Failed to update commit pin for {s}", .{row.name});
             return error.Aborted;
         };
     }
 }
 
+/// Resolve a tap's HEAD on the `--refresh` path. Caller takes ownership
+/// of both `sha` and `etag`; deinit by freeing each individually.
+const RefreshedHead = struct { sha: []const u8, etag: ?[]const u8 };
+
 fn resolveOneHead(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
     slug: []const u8,
-) ![]const u8 {
+) !RefreshedHead {
     const urls = try tap_mod.resolveTapBaseUrls(allocator, slug);
     defer urls.deinit(allocator);
-    return tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url);
+    // `tap --refresh` is the explicit "force fresh" verb — never send
+    // If-None-Match so a stale-but-unmoved upstream still surfaces a
+    // fresh body and the operator can confirm the tap really hasn't
+    // budged. Per task implementation notes.
+    var res = try tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, null);
+    defer res.deinit();
+    const sha = res.sha orelse return error.MalformedJson;
+    const sha_owned = try allocator.dupe(u8, sha);
+    errdefer allocator.free(sha_owned);
+    const et_owned: ?[]const u8 = if (res.etag) |e| try allocator.dupe(u8, e) else null;
+    return .{ .sha = sha_owned, .etag = et_owned };
 }
 
 fn emitRefreshAll(ctx: *const AppCtx, rows: []const RefreshRow) !void {
@@ -642,12 +695,22 @@ fn refreshTap(ctx: *const AppCtx, allocator: std.mem.Allocator, db: *sqlite.Data
     };
     const urls = try tap_mod.resolveTapBaseUrls(allocator, name);
     defer urls.deinit(allocator);
-    const sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url) catch |e| {
+    // Force fresh: bypass the cached etag so the operator sees the
+    // current body. The new etag is still persisted afterwards so the
+    // *next* non-refresh resolve can short-circuit.
+    var res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, null) catch |e| {
         output.err("Could not resolve {s}'s HEAD commit: {s}", .{ name, tap_mod.describeResolveError(e) });
         return error.Aborted;
     };
-    defer allocator.free(sha);
-    tap_mod.updateCommit(db, name, sha) catch {
+    defer res.deinit();
+    const sha = res.sha orelse {
+        output.err("Could not resolve {s}'s HEAD commit: empty response", .{name});
+        return error.Aborted;
+    };
+    // updateHead pairs the new sha with the new etag atomically; falling
+    // back to updateCommit if the row is absent isn't a concern here —
+    // refresh runs against rows the user already `tap added`.
+    tap_mod.updateHead(db, name, sha, res.etag) catch {
         output.err("Failed to update commit pin for {s}", .{name});
         return error.Aborted;
     };

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -444,16 +444,33 @@ fn upgradeTapFormula(
     const urls = try tap_mod.resolveTapBaseUrls(allocator, tap_label);
     defer urls.deinit(allocator);
 
-    // The whole point of `mt upgrade` is "give me the latest", so we
-    // ignore any cached pin and force-resolve HEAD.
-    const fresh_sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url) catch |e| {
+    // `mt upgrade` asks GitHub "has HEAD moved?". Sending the cached
+    // etag lets a stable tap answer 304 for free — same outcome as
+    // before (we still see whether the sha moved) without burning a
+    // rate-limit token.
+    const cached_sha_opt = tap_mod.getCommitSha(allocator, db, tap_label) catch null;
+    defer if (cached_sha_opt) |s| allocator.free(s);
+    const cached_etag_opt = tap_mod.getHeadEtag(allocator, db, tap_label) catch null;
+    defer if (cached_etag_opt) |e| allocator.free(e);
+
+    var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, cached_etag_opt) catch |e| {
         output.err("Could not resolve {s} HEAD: {s}", .{ tap_label, tap_mod.describeResolveError(e) });
         return error.Aborted;
     };
-    defer allocator.free(fresh_sha);
+    defer head_res.deinit();
 
-    const cached_sha_opt = tap_mod.getCommitSha(allocator, db, tap_label) catch null;
-    defer if (cached_sha_opt) |s| allocator.free(s);
+    // 304 → cached_sha is still authoritative. 200 → use the fresh sha
+    // and persist (sha, etag) below so the next round can short-circuit.
+    const fresh_sha = if (head_res.not_modified)
+        (cached_sha_opt orelse {
+            output.err("Could not resolve {s} HEAD: 304 without cached sha", .{tap_label});
+            return error.Aborted;
+        })
+    else
+        (head_res.sha orelse {
+            output.err("Could not resolve {s} HEAD: empty response", .{tap_label});
+            return error.Aborted;
+        });
     const same_commit = if (cached_sha_opt) |c| std.mem.eql(u8, c, fresh_sha) else false;
 
     if (!force and same_commit) {
@@ -475,6 +492,11 @@ fn upgradeTapFormula(
         output.err("Could not pin {s} to {s}", .{ tap_label, fresh_sha });
         return error.Aborted;
     };
+    // Refresh the etag on 200 so the next upgrade short-circuits. On 304
+    // the etag we already hold is by definition still current.
+    if (!head_res.not_modified) {
+        if (head_res.etag) |et| tap_mod.updateHead(db, tap_label, fresh_sha, et) catch {};
+    }
 
     const full_name = std.fmt.allocPrint(allocator, "{s}/{s}", .{ tap_label, name }) catch return error.Aborted;
     defer allocator.free(full_name);
@@ -515,15 +537,23 @@ fn upgradeRoutedTapCask(
     const urls = tap_mod.resolveTapBaseUrls(allocator, tap_label) catch return error.Aborted;
     defer urls.deinit(allocator);
 
-    // Always force-resolve HEAD: the whole point of `mt upgrade` is
-    // "give me the latest", so we ignore any cached pin here. Same
-    // error shape as `upgradeTapFormula` so probe-loop callers can
-    // grep for the resolve failure consistently.
-    const fresh_sha = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url) catch |e| {
+    // Send the cached etag so a stable tap 304s for free; on 200 we
+    // still pick up the moved sha. Same error shape as `upgradeTapFormula`
+    // so probe-loop callers can grep for the resolve failure consistently.
+    const cached_sha_opt = tap_mod.getCommitSha(allocator, db, tap_label) catch null;
+    defer if (cached_sha_opt) |s| allocator.free(s);
+    const cached_etag_opt = tap_mod.getHeadEtag(allocator, db, tap_label) catch null;
+    defer if (cached_etag_opt) |e| allocator.free(e);
+
+    var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, cached_etag_opt) catch |e| {
         output.err("Could not resolve {s} HEAD: {s}", .{ tap_label, tap_mod.describeResolveError(e) });
         return error.Aborted;
     };
-    defer allocator.free(fresh_sha);
+    defer head_res.deinit();
+    const fresh_sha = if (head_res.not_modified)
+        (cached_sha_opt orelse return error.Aborted)
+    else
+        (head_res.sha orelse return error.Aborted);
 
     var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
     defer http.deinit();
@@ -559,6 +589,11 @@ fn upgradeRoutedTapCask(
         output.err("Could not pin {s} to {s}", .{ tap_label, fresh_sha });
         return error.Aborted;
     };
+    // On 200, refresh the etag so the next round can 304. On 304 the
+    // cached etag is by definition still current.
+    if (!head_res.not_modified) {
+        if (head_res.etag) |et| tap_mod.updateHead(db, tap_label, fresh_sha, et) catch {};
+    }
 
     output.info("Upgrading {s} {s} -> {s}...", .{ token, installed_version, rb_info.version });
 

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -124,6 +124,52 @@ pub fn getCommitSha(
     return try allocator.dupe(u8, trimmed);
 }
 
+/// Read the cached `head_etag` for a tap, or null when never seen or
+/// stamped empty. Caller owns the returned slice. Sibling of
+/// `getCommitSha`; the two columns travel together at every call site.
+pub fn getHeadEtag(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    name: []const u8,
+) !?[]const u8 {
+    var stmt = try db.prepare("SELECT head_etag FROM taps WHERE name = ?1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    if (!(try stmt.step())) return null;
+    const raw = stmt.columnText(0) orelse return null;
+    const trimmed = std.mem.sliceTo(raw, 0);
+    if (trimmed.len == 0) return null;
+    return try allocator.dupe(u8, trimmed);
+}
+
+/// Atomic write of both `commit_sha` and `head_etag` for an existing
+/// tap row. Order matters: the etag is paired with the sha that owns
+/// it, so a partial failure cannot leave the DB pointing at the old
+/// sha with a fresh etag (which would freeze the tap at the stale sha
+/// until manual refresh). `etag` may be null when the server omitted
+/// the header — the row's etag is then cleared so the next resolve
+/// falls back to an unconditional GET.
+pub fn updateHead(
+    db: *sqlite.Database,
+    name: []const u8,
+    commit_sha: []const u8,
+    etag: ?[]const u8,
+) !void {
+    try validateCommitSha(commit_sha);
+    var stmt = try db.prepare(
+        "UPDATE taps SET commit_sha = ?1, head_etag = ?2 WHERE name = ?3;",
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, commit_sha);
+    if (etag) |e| {
+        try stmt.bindText(2, e);
+    } else {
+        try stmt.bindNull(2);
+    }
+    try stmt.bindText(3, name);
+    _ = try stmt.step();
+}
+
 pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) ![]TapInfo {
     var taps: std.ArrayList(TapInfo) = .empty;
     // ArrayList.deinit doesn't reach row sub-allocations; walk them too.
@@ -235,6 +281,232 @@ pub fn resolveTapBaseUrls(
     };
 }
 
+// ── resolveFromConditional: response → HeadResolution conversion ────
+//
+// `resolveHeadCommit` defers all classification to this pure helper so
+// every shape GitHub can return (200+etag, 200 no-etag, 304, 404, 403,
+// 5xx) is testable without spinning an HTTP transport.
+
+fn makeConditional(
+    status: u16,
+    not_modified: bool,
+    body: []const u8,
+    etag: ?[]const u8,
+) !client_mod.ConditionalResponse {
+    return .{
+        .status = status,
+        .not_modified = not_modified,
+        .body = try std.testing.allocator.dupe(u8, body),
+        .etag = if (etag) |e| try std.testing.allocator.dupe(u8, e) else null,
+        .allocator = std.testing.allocator,
+    };
+}
+
+test "resolveFromConditional: 200 with body+etag yields sha and persists etag" {
+    var resp = try makeConditional(
+        200,
+        false,
+        "{\"sha\":\"0123456789abcdef0123456789abcdef01234567\",\"commit\":{}}",
+        "W/\"deadbeef\"",
+    );
+    defer resp.deinit();
+
+    var res = try resolveFromConditional(std.testing.allocator, resp);
+    defer res.deinit();
+    try std.testing.expect(!res.not_modified);
+    try std.testing.expectEqualStrings(
+        "0123456789abcdef0123456789abcdef01234567",
+        res.sha.?,
+    );
+    try std.testing.expectEqualStrings("W/\"deadbeef\"", res.etag.?);
+}
+
+test "resolveFromConditional: 200 without etag still yields sha (etag stays null)" {
+    var resp = try makeConditional(
+        200,
+        false,
+        "{\"sha\":\"0123456789abcdef0123456789abcdef01234567\"}",
+        null,
+    );
+    defer resp.deinit();
+
+    var res = try resolveFromConditional(std.testing.allocator, resp);
+    defer res.deinit();
+    try std.testing.expect(!res.not_modified);
+    try std.testing.expect(res.sha != null);
+    try std.testing.expectEqual(@as(?[]const u8, null), res.etag);
+}
+
+test "resolveFromConditional: 304 yields not_modified=true, sha=null, etag preserved" {
+    var resp = try makeConditional(304, true, "", "W/\"deadbeef\"");
+    defer resp.deinit();
+
+    var res = try resolveFromConditional(std.testing.allocator, resp);
+    defer res.deinit();
+    try std.testing.expect(res.not_modified);
+    try std.testing.expectEqual(@as(?[]const u8, null), res.sha);
+    try std.testing.expectEqualStrings("W/\"deadbeef\"", res.etag.?);
+}
+
+test "resolveFromConditional: 304 without ETag header — caller falls back to cached" {
+    // GitHub always sends ETag on 304, but a stripping reverse proxy in
+    // front of `api.github.com` could violate that — degrade gracefully.
+    var resp = try makeConditional(304, true, "", null);
+    defer resp.deinit();
+
+    var res = try resolveFromConditional(std.testing.allocator, resp);
+    defer res.deinit();
+    try std.testing.expect(res.not_modified);
+    try std.testing.expectEqual(@as(?[]const u8, null), res.etag);
+}
+
+test "resolveFromConditional: 404 classifies as NotFound" {
+    var resp = try makeConditional(404, false, "{\"message\":\"Not Found\"}", null);
+    defer resp.deinit();
+    try std.testing.expectError(
+        TapError.NotFound,
+        resolveFromConditional(std.testing.allocator, resp),
+    );
+}
+
+test "resolveFromConditional: 403 classifies as RateLimited" {
+    var resp = try makeConditional(403, false, "{\"message\":\"API rate limit exceeded\"}", null);
+    defer resp.deinit();
+    try std.testing.expectError(
+        TapError.RateLimited,
+        resolveFromConditional(std.testing.allocator, resp),
+    );
+}
+
+test "resolveFromConditional: 5xx classifies as ResolveFailed" {
+    var resp = try makeConditional(502, false, "<html>bad gateway</html>", null);
+    defer resp.deinit();
+    try std.testing.expectError(
+        TapError.ResolveFailed,
+        resolveFromConditional(std.testing.allocator, resp),
+    );
+}
+
+test "resolveFromConditional: 200 with malformed JSON classifies as MalformedJson" {
+    var resp = try makeConditional(200, false, "{\"sha\":\"too-short\"}", null);
+    defer resp.deinit();
+    try std.testing.expectError(
+        TapError.MalformedJson,
+        resolveFromConditional(std.testing.allocator, resp),
+    );
+}
+
+test "HeadResolution.deinit: tolerates partial sets (sha-only, etag-only, both null)" {
+    var sha_only: HeadResolution = .{
+        .sha = try std.testing.allocator.dupe(u8, "abc"),
+        .etag = null,
+        .not_modified = false,
+        .allocator = std.testing.allocator,
+    };
+    sha_only.deinit();
+
+    var etag_only: HeadResolution = .{
+        .sha = null,
+        .etag = try std.testing.allocator.dupe(u8, "W/\"x\""),
+        .not_modified = true,
+        .allocator = std.testing.allocator,
+    };
+    etag_only.deinit();
+
+    var both_null: HeadResolution = .{
+        .sha = null,
+        .etag = null,
+        .not_modified = true,
+        .allocator = std.testing.allocator,
+    };
+    both_null.deinit();
+}
+
+// ── getHeadEtag / updateHead: per-tap etag persistence ─────────────
+
+test "getHeadEtag returns null on a fresh row (no etag stamped yet)" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try add(&db, "user/repo", "https://github.com/user/repo", null);
+    const et = try getHeadEtag(std.testing.allocator, &db, "user/repo");
+    try std.testing.expectEqual(@as(?[]const u8, null), et);
+}
+
+test "updateHead persists sha + etag atomically; getHeadEtag round-trips" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try add(&db, "user/repo", "https://github.com/user/repo", null);
+
+    const sha = "0123456789abcdef0123456789abcdef01234567";
+    try updateHead(&db, "user/repo", sha, "W/\"feed\"");
+
+    const stored_sha = (try getCommitSha(std.testing.allocator, &db, "user/repo")).?;
+    defer std.testing.allocator.free(stored_sha);
+    try std.testing.expectEqualStrings(sha, stored_sha);
+
+    const stored_et = (try getHeadEtag(std.testing.allocator, &db, "user/repo")).?;
+    defer std.testing.allocator.free(stored_et);
+    try std.testing.expectEqualStrings("W/\"feed\"", stored_et);
+}
+
+test "updateHead with null etag clears the column (server omitted ETag)" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try add(&db, "user/repo", "https://github.com/user/repo", null);
+
+    const sha = "0123456789abcdef0123456789abcdef01234567";
+    try updateHead(&db, "user/repo", sha, "W/\"feed\"");
+    try updateHead(&db, "user/repo", sha, null);
+
+    const et = try getHeadEtag(std.testing.allocator, &db, "user/repo");
+    try std.testing.expectEqual(@as(?[]const u8, null), et);
+}
+
+test "getHeadEtag returns null for a tap name that was never added" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    const et = try getHeadEtag(std.testing.allocator, &db, "ghost/tap");
+    try std.testing.expectEqual(@as(?[]const u8, null), et);
+}
+
+test "updateHead is a silent no-op on a missing row (mirrors updateCommit)" {
+    // SQLite UPDATE against a missing row affects zero rows without
+    // raising — same semantics as `updateCommit`. Documented here so
+    // callers don't expect a `NotFound`-style error.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+
+    try updateHead(&db, "ghost/tap", "0123456789abcdef0123456789abcdef01234567", "W/\"x\"");
+    const et = try getHeadEtag(std.testing.allocator, &db, "ghost/tap");
+    try std.testing.expectEqual(@as(?[]const u8, null), et);
+}
+
+test "updateHead rejects an invalid SHA before touching the row" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try add(&db, "user/repo", "https://github.com/user/repo", null);
+    try updateHead(&db, "user/repo", "0123456789abcdef0123456789abcdef01234567", "W/\"feed\"");
+
+    // Validator runs first — DB stays at the prior value.
+    try std.testing.expectError(TapError.InvalidSha, updateHead(&db, "user/repo", "not-a-sha", "W/\"new\""));
+
+    const et = (try getHeadEtag(std.testing.allocator, &db, "user/repo")).?;
+    defer std.testing.allocator.free(et);
+    try std.testing.expectEqualStrings("W/\"feed\"", et);
+}
+
 test "resolveTapBaseUrls synthesises homebrew- prefix once per field" {
     const urls = try resolveTapBaseUrls(std.testing.allocator, "aeroxy/tap");
     defer urls.deinit(std.testing.allocator);
@@ -340,10 +612,70 @@ pub fn parseCommitShaFromJson(body: []const u8) ?[]const u8 {
     return sha;
 }
 
-/// Ask GitHub for the current HEAD commit of a tap's repo. Returns
-/// the 40-char lowercase hex SHA or a classified `TapError` so callers
-/// can surface the actual cause (rate limit, 404, network, JSON). Caller
-/// owns the returned slice.
+/// HEAD-resolve outcome. `sha` is set on a fresh body (200) and null
+/// on 304 — the caller's cached sha is still authoritative in that
+/// case. `etag`, when set, is GitHub's current ETag for `/commits/HEAD`;
+/// callers persist it via `tap_mod.updateHead` so the next round can
+/// short-circuit again. A null `etag` means the server omitted the
+/// header (rare but legal); the caller's previously cached etag, if any,
+/// stays valid.
+pub const HeadResolution = struct {
+    sha: ?[]const u8,
+    etag: ?[]const u8,
+    not_modified: bool,
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: *HeadResolution) void {
+        if (self.sha) |s| self.allocator.free(s);
+        if (self.etag) |e| self.allocator.free(e);
+    }
+};
+
+/// Convert a `ConditionalResponse` from GitHub's `/commits/HEAD` into a
+/// `HeadResolution`. Pure: takes ownership of `resp.etag` only when the
+/// status is convertible; otherwise reports the classified `TapError`
+/// (`resp.deinit` still frees both body and etag in the error path).
+pub fn resolveFromConditional(
+    allocator: std.mem.Allocator,
+    resp: client_mod.ConditionalResponse,
+) TapError!HeadResolution {
+    if (resp.not_modified) {
+        // 304: keep cached SHA, only the ETag may have rotated.
+        const etag_owned: ?[]const u8 = if (resp.etag) |e|
+            allocator.dupe(u8, e) catch return TapError.OutOfMemory
+        else
+            null;
+        return .{
+            .sha = null,
+            .etag = etag_owned,
+            .not_modified = true,
+            .allocator = allocator,
+        };
+    }
+
+    if (resp.status != 200) return classifyResolveStatus(resp.status);
+
+    const sha = parseCommitShaFromJson(resp.body) orelse return TapError.MalformedJson;
+    const sha_owned = allocator.dupe(u8, sha) catch return TapError.OutOfMemory;
+    errdefer allocator.free(sha_owned);
+
+    const etag_owned: ?[]const u8 = if (resp.etag) |e|
+        allocator.dupe(u8, e) catch return TapError.OutOfMemory
+    else
+        null;
+
+    return .{
+        .sha = sha_owned,
+        .etag = etag_owned,
+        .not_modified = false,
+        .allocator = allocator,
+    };
+}
+
+/// Ask GitHub for the current HEAD commit of a tap's repo, sending
+/// `If-None-Match` when `cached_etag` is set so a stable tap costs
+/// zero rate-limit tokens. Returns a `HeadResolution` so callers can
+/// distinguish "fresh sha" from "304: cached sha is still good".
 ///
 /// `api_head_url` must come from `resolveTapBaseUrls` — that single seam
 /// owns the `homebrew-<repo>` synthesis. A bare-args overload that
@@ -354,21 +686,21 @@ pub fn resolveHeadCommit(
     environ: std.process.Environ,
     allocator: std.mem.Allocator,
     api_head_url: []const u8,
-) TapError![]const u8 {
+    cached_etag: ?[]const u8,
+) TapError!HeadResolution {
     var http = client_mod.HttpClient.init(io, environ, allocator);
     defer http.deinit();
 
-    // MALT_GITHUB_TOKEN takes precedence; otherwise `http.get` falls
-    // back to the HOMEBREW_GITHUB_API_TOKEN auto-inject in net/client.
+    // MALT_GITHUB_TOKEN takes precedence; falling through to `extra=&.{}`
+    // lets net/client's HOMEBREW_GITHUB_API_TOKEN auto-inject still apply
+    // — both authenticate against the same 5000/hr quota that 304s don't
+    // touch.
     var auth_buf: [256]u8 = undefined;
     var resp = if (githubAuthHeader(environ, &auth_buf)) |header| blk: {
         const headers = [_]std.http.Header{header};
-        break :blk http.getWithHeaders(api_head_url, &headers, null) catch return TapError.NetworkError;
-    } else http.get(api_head_url) catch return TapError.NetworkError;
+        break :blk http.getConditional(api_head_url, cached_etag, &headers) catch return TapError.NetworkError;
+    } else http.getConditional(api_head_url, cached_etag, &.{}) catch return TapError.NetworkError;
     defer resp.deinit();
 
-    if (resp.status != 200) return classifyResolveStatus(resp.status);
-
-    const sha = parseCommitShaFromJson(resp.body) orelse return TapError.MalformedJson;
-    return allocator.dupe(u8, sha) catch TapError.OutOfMemory;
+    return resolveFromConditional(allocator, resp);
 }

--- a/src/db/schema.zig
+++ b/src/db/schema.zig
@@ -122,7 +122,7 @@ pub fn initSchema(db: *sqlite.Database) MigrateError!void {
 /// Highest schema version this binary knows how to operate on. Bump in
 /// lockstep with the last `migrateVNtoVN+1` step so a future binary's
 /// DB doesn't get silently used against older SQL.
-pub const known_schema_version: i64 = 7;
+pub const known_schema_version: i64 = 8;
 
 pub const MigrateError = sqlite.SqliteError || error{SchemaTooNew};
 
@@ -139,6 +139,7 @@ pub fn migrate(db: *sqlite.Database) MigrateError!void {
     if (ver < 5) try migrateV4toV5(db);
     if (ver < 6) try migrateV5toV6(db);
     if (ver < 7) try migrateV6toV7(db);
+    if (ver < 8) try migrateV7toV8(db);
 }
 
 fn migrateV1toV2(db: *sqlite.Database) sqlite.SqliteError!void {
@@ -413,6 +414,42 @@ fn migrateV6toV7(db: *sqlite.Database) sqlite.SqliteError!void {
     try db.commit();
 }
 
+/// v8 — persist the GitHub ETag for `/commits/HEAD` alongside the
+/// commit SHA so subsequent resolves can send `If-None-Match` and let
+/// 304 responses short-circuit the GitHub rate-limit cost. Same
+/// PRAGMA-guarded ALTER shape as v2→v3 / v3→v4 / v5→v6 so re-runs
+/// against partially migrated fixtures stay idempotent.
+fn migrateV7toV8(db: *sqlite.Database) sqlite.SqliteError!void {
+    try db.beginTransaction();
+    errdefer db.rollback();
+
+    // PRAGMA table_info returns zero rows when the table is missing — the
+    // forensic/partial-shape fixtures exercised by the v6→v7 migration
+    // tests sometimes ship without a `taps` table, and aborting the
+    // chain there would surface as a hard "schema_init" failure later.
+    var have_table = false;
+    var have_column = false;
+    {
+        var stmt = try db.prepare("PRAGMA table_info(taps);");
+        defer stmt.finalize();
+        while (try stmt.step()) {
+            have_table = true;
+            const name = stmt.columnText(1) orelse continue;
+            if (std.mem.eql(u8, std.mem.sliceTo(name, 0), "head_etag")) {
+                have_column = true;
+                break;
+            }
+        }
+    }
+    if (have_table and !have_column) {
+        try db.exec("ALTER TABLE taps ADD COLUMN head_etag TEXT;");
+    }
+
+    try db.exec("INSERT OR IGNORE INTO schema_version (version) VALUES (8);");
+
+    try db.commit();
+}
+
 /// Return true iff every column in `wanted` is present on the `casks`
 /// table. Mirrors the PRAGMA-guarded probes used by v2→v3 / v3→v4 /
 /// v5→v6; centralised here because the v6→v7 backfill needs five
@@ -568,7 +605,7 @@ test "v6→v7 migration backfills cask_versions from existing casks rows" {
     const token1 = stmt.columnText(0) orelse return error.TestUnexpectedResult;
     try testing.expectEqualStrings("flux-markdown", std.mem.sliceTo(token1, 0));
 
-    try testing.expectEqual(@as(i64, 7), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 8), try currentVersion(&db));
 }
 
 test "v6→v7 migration is idempotent when cask_versions already carries the rows" {
@@ -594,6 +631,85 @@ test "v6→v7 migration is idempotent when cask_versions already carries the row
     defer cnt.finalize();
     _ = try cnt.step();
     try testing.expectEqual(@as(i64, 1), cnt.columnInt(0));
+}
+
+// v7→v8 adds taps.head_etag so resolveHeadCommit can send
+// `If-None-Match` and let GitHub answer 304 without spending a
+// rate-limit token. Fresh and upgraded DBs must converge on the same
+// shape; the migration is PRAGMA-guarded so re-runs against partially
+// migrated fixtures stay idempotent.
+test "fresh DB ships with taps.head_etag (v8 shape)" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    var stmt = try db.prepare("PRAGMA table_info(taps);");
+    defer stmt.finalize();
+    var found = false;
+    while (try stmt.step()) {
+        const name = stmt.columnText(1) orelse continue;
+        if (std.mem.eql(u8, std.mem.sliceTo(name, 0), "head_etag")) {
+            found = true;
+            break;
+        }
+    }
+    try testing.expect(found);
+    try testing.expectEqual(@as(i64, 8), try currentVersion(&db));
+}
+
+test "v7→v8 migration adds head_etag and preserves existing tap rows" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    // Seed a tap row on the current shape, then rewind the version marker
+    // to v7 so `migrate` re-enters the v7→v8 step against the seeded row.
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha)
+        \\VALUES ('aeroxy/tap', 'https://github.com/aeroxy/homebrew-tap',
+        \\        '0123456789abcdef0123456789abcdef01234567');
+    );
+    try db.exec("DELETE FROM schema_version WHERE version >= 8;");
+
+    try migrate(&db);
+
+    var probe = try db.prepare(
+        "SELECT commit_sha, head_etag FROM taps WHERE name='aeroxy/tap';",
+    );
+    defer probe.finalize();
+    try testing.expect(try probe.step());
+    const sha = probe.columnText(0) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings(
+        "0123456789abcdef0123456789abcdef01234567",
+        std.mem.sliceTo(sha, 0),
+    );
+    // Pre-v8 rows must carry NULL until a conditional GET populates it.
+    try testing.expect(probe.columnText(1) == null);
+    try testing.expectEqual(@as(i64, 8), try currentVersion(&db));
+}
+
+test "v7→v8 migration is idempotent when head_etag is already present" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    // Stamp the column with a value, rewind, re-run the migration. The
+    // PRAGMA guard must skip the ALTER and leave the value untouched.
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, head_etag)
+        \\VALUES ('aeroxy/tap', 'https://github.com/aeroxy/homebrew-tap',
+        \\        '0123456789abcdef0123456789abcdef01234567',
+        \\        'W/"deadbeef"');
+    );
+    try db.exec("DELETE FROM schema_version WHERE version >= 8;");
+
+    try migrate(&db);
+
+    var probe = try db.prepare("SELECT head_etag FROM taps WHERE name='aeroxy/tap';");
+    defer probe.finalize();
+    try testing.expect(try probe.step());
+    const et = probe.columnText(0) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings("W/\"deadbeef\"", std.mem.sliceTo(et, 0));
 }
 
 test "migrate refuses a DB whose schema_version exceeds the known max" {

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -525,6 +525,79 @@ pub const HttpClient = struct {
         return self.doGetWithRetry(url, extra_headers, max_metadata_bytes, null);
     }
 
+    /// Read a response body with the same decompress + idle/total
+    /// watchdog + size cap that the legacy `doGetLimited` path uses.
+    /// Both the generic GET and the conditional GET converge here so
+    /// the single transport policy is enforced in one place — only the
+    /// `total_timeout_ns` differs between callers (blob downloads scale
+    /// it from `content_length`; metadata reads pin it to `self.timeout_ns`).
+    fn readResponseBody(
+        self: *HttpClient,
+        req: *std.http.Client.Request,
+        response: *std.http.Client.Response,
+        max_bytes: usize,
+        progress: ?ProgressCallback,
+        total_timeout_ns: u64,
+    ) !([]const u8) {
+        const content_length: ?u64 = response.head.content_length;
+
+        var body_writer: std.Io.Writer.Allocating = .init(self.allocator);
+        errdefer body_writer.deinit();
+
+        const decompress_buffer: []u8 = switch (response.head.content_encoding) {
+            .identity => &.{},
+            .zstd => try self.getZstdWindow(),
+            .deflate, .gzip => try self.getFlateWindow(),
+            .compress => return error.ReadFailed,
+        };
+
+        var transfer_buffer: [16384]u8 = undefined;
+        var decompress: std.http.Decompress = undefined;
+        var body_reader = response.readerDecompressing(&transfer_buffer, &decompress, decompress_buffer);
+
+        var counting = CountingWriter{
+            .inner = &body_writer,
+            .bytes_written = std.atomic.Value(u64).init(0),
+            .max_bytes = max_bytes,
+            .limit_exceeded = false,
+            .progress = progress,
+            .content_length = content_length,
+        };
+
+        const idle_timeout = idleTimeoutNsFromEnv(
+            std.process.Environ.getPosix(self.environ, "MALT_HTTP_IDLE_TIMEOUT_SECS"),
+        );
+        var wake = try Wake.init();
+        const watchdog = std.Thread.spawn(.{}, watchdogFn, .{
+            self.io,
+            wake.read_fd,
+            &counting.bytes_written,
+            idle_timeout,
+            total_timeout_ns,
+            req,
+            self.cancel,
+        }) catch {
+            wake.deinit();
+            return error.WatchdogSpawnFailed;
+        };
+        defer {
+            wake.signal();
+            watchdog.join();
+            wake.deinit();
+        }
+        _ = body_reader.streamRemaining(&counting.writer) catch |e| switch (e) {
+            error.WriteFailed => {
+                if (counting.limit_exceeded) return error.ResponseTooLarge;
+                return error.ReadFailed;
+            },
+            error.ReadFailed => return error.ReadFailed,
+        };
+
+        if (counting.limit_exceeded) return error.ResponseTooLarge;
+
+        return try body_writer.toOwnedSlice();
+    }
+
     /// Cancellable backoff between retry attempts. Common to every
     /// retry loop so a Ctrl-C during the wait surfaces immediately
     /// instead of being swallowed by std.Io.sleep's silent return.
@@ -609,67 +682,9 @@ pub const HttpClient = struct {
             };
         }
 
-        // Body-read path mirrors doGetLimited (decompress + watchdog +
-        // size cap). Capped at `max_metadata_bytes` — conditional GETs
-        // target tiny JSON, never blobs.
-        const content_length: ?u64 = response.head.content_length;
-
-        var body_writer: std.Io.Writer.Allocating = .init(self.allocator);
-        errdefer body_writer.deinit();
-
-        const decompress_buffer: []u8 = switch (response.head.content_encoding) {
-            .identity => &.{},
-            .zstd => try self.getZstdWindow(),
-            .deflate, .gzip => try self.getFlateWindow(),
-            .compress => return error.ReadFailed,
-        };
-
-        var transfer_buffer: [16384]u8 = undefined;
-        var decompress: std.http.Decompress = undefined;
-        var body_reader = response.readerDecompressing(&transfer_buffer, &decompress, decompress_buffer);
-
-        var counting = CountingWriter{
-            .inner = &body_writer,
-            .bytes_written = std.atomic.Value(u64).init(0),
-            .max_bytes = max_metadata_bytes,
-            .limit_exceeded = false,
-            .progress = null,
-            .content_length = content_length,
-        };
-
-        const total_timeout = self.timeout_ns;
-        const idle_timeout = idleTimeoutNsFromEnv(
-            std.process.Environ.getPosix(self.environ, "MALT_HTTP_IDLE_TIMEOUT_SECS"),
-        );
-        var wake = try Wake.init();
-        const watchdog = std.Thread.spawn(.{}, watchdogFn, .{
-            self.io,
-            wake.read_fd,
-            &counting.bytes_written,
-            idle_timeout,
-            total_timeout,
-            &req,
-            self.cancel,
-        }) catch {
-            wake.deinit();
-            return error.WatchdogSpawnFailed;
-        };
-        defer {
-            wake.signal();
-            watchdog.join();
-            wake.deinit();
-        }
-        _ = body_reader.streamRemaining(&counting.writer) catch |e| switch (e) {
-            error.WriteFailed => {
-                if (counting.limit_exceeded) return error.ResponseTooLarge;
-                return error.ReadFailed;
-            },
-            error.ReadFailed => return error.ReadFailed,
-        };
-
-        if (counting.limit_exceeded) return error.ResponseTooLarge;
-
-        const body = try body_writer.toOwnedSlice();
+        // Conditional GETs target tiny JSON, never blobs — pin both
+        // size cap and total timeout to the metadata constants.
+        const body = try self.readResponseBody(&req, &response, max_metadata_bytes, null, self.timeout_ns);
         return .{
             .status = status,
             .not_modified = false,
@@ -746,81 +761,14 @@ pub const HttpClient = struct {
 
         const status: u16 = @intFromEnum(response.head.status);
 
-        // Content-Length from HTTP headers (may be null for chunked transfer).
-        // Note: this reflects the *compressed* size when content-encoding is set.
-        const content_length: ?u64 = response.head.content_length;
-
-        // Read response body with decompression (servers may send gzip).
-        // Enforce MAX_RESPONSE_BYTES to prevent OOM from oversized responses.
-        var body_writer: std.Io.Writer.Allocating = .init(self.allocator);
-        errdefer body_writer.deinit();
-
-        // Pooled decompression windows (see HttpClient.zstd_window / flate_window).
-        const decompress_buffer: []u8 = switch (response.head.content_encoding) {
-            .identity => &.{},
-            .zstd => try self.getZstdWindow(),
-            .deflate, .gzip => try self.getFlateWindow(),
-            .compress => return error.ReadFailed,
-        };
-
-        var transfer_buffer: [16384]u8 = undefined;
-        var decompress: std.http.Decompress = undefined;
-        var body_reader = response.readerDecompressing(&transfer_buffer, &decompress, decompress_buffer);
-
-        // `CountingWriter` enforces `max_bytes` per-write so oversized bodies
-        // are rejected mid-stream, not after buffering. Created before the
-        // watchdog spawns so its atomic byte counter is the watchdog's
-        // progress signal.
-        var counting = CountingWriter{
-            .inner = &body_writer,
-            .bytes_written = std.atomic.Value(u64).init(0),
-            .max_bytes = max_bytes,
-            .limit_exceeded = false,
-            .progress = progress,
-            .content_length = content_length,
-        };
-
-        // Two-deadline watchdog: idle (no bytes in `idle_timeout_ns`) +
-        // whole-transfer (`scaledTimeoutNs` backstop). Idle is the
-        // fail-fast for genuine 0 B/s stalls; total catches a slow
-        // trickle that would otherwise sit forever under just the
-        // idle clock if the server dribbles a byte every few seconds.
+        // Blob downloads scale the total deadline from the projected
+        // transfer time; metadata reads keep the per-request constant.
+        // Idle-timeout backstop lives inside `readResponseBody`.
         const total_timeout = if (max_bytes > max_metadata_bytes)
-            @max(blob_timeout_ns, scaledTimeoutNs(content_length))
+            @max(blob_timeout_ns, scaledTimeoutNs(response.head.content_length))
         else
             self.timeout_ns;
-        const idle_timeout = idleTimeoutNsFromEnv(
-            std.process.Environ.getPosix(self.environ, "MALT_HTTP_IDLE_TIMEOUT_SECS"),
-        );
-        var wake = try Wake.init();
-        const watchdog = std.Thread.spawn(.{}, watchdogFn, .{
-            self.io,
-            wake.read_fd,
-            &counting.bytes_written,
-            idle_timeout,
-            total_timeout,
-            &req,
-            self.cancel,
-        }) catch {
-            wake.deinit();
-            return error.WatchdogSpawnFailed;
-        };
-        defer {
-            wake.signal();
-            watchdog.join();
-            wake.deinit();
-        }
-        _ = body_reader.streamRemaining(&counting.writer) catch |e| switch (e) {
-            error.WriteFailed => {
-                if (counting.limit_exceeded) return error.ResponseTooLarge;
-                return error.ReadFailed;
-            },
-            error.ReadFailed => return error.ReadFailed,
-        };
-
-        if (counting.limit_exceeded) return error.ResponseTooLarge;
-
-        const body = try body_writer.toOwnedSlice();
+        const body = try self.readResponseBody(&req, &response, max_bytes, progress, total_timeout);
 
         return .{
             .status = status,

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -199,6 +199,38 @@ pub const Response = struct {
     }
 };
 
+/// Result of `HttpClient.getConditional`. `not_modified` is true iff
+/// the server answered 304 — `body` is empty in that case and the
+/// caller can keep using the cached payload. `etag`, when set, is the
+/// server's current ETag (sent on both 200 and 304); callers persist
+/// it so the next round can short-circuit again.
+pub const ConditionalResponse = struct {
+    status: u16,
+    not_modified: bool,
+    body: []const u8,
+    etag: ?[]const u8,
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: *ConditionalResponse) void {
+        self.allocator.free(self.body);
+        if (self.etag) |e| self.allocator.free(e);
+    }
+};
+
+/// Find the `ETag` value in a parsed `Response.Head.bytes` buffer.
+/// Returns a slice borrowed from `bytes` (caller dupes if it needs to
+/// outlive the response). GitHub sends weak ETags as `W/"abc"` — the
+/// `W/` prefix is preserved verbatim because the server compares the
+/// `If-None-Match` value textually and stripping it breaks the 304
+/// short-circuit.
+pub fn extractEtagFromHead(bytes: []const u8) ?[]const u8 {
+    var it = std.http.HeaderIterator.init(bytes);
+    while (it.next()) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, "etag")) return h.value;
+    }
+    return null;
+}
+
 /// True if the URI scheme is exactly "https" (ascii case-insensitive).
 pub fn schemeIsHttps(scheme: []const u8) bool {
     return std.ascii.eqlIgnoreCase(scheme, "https");
@@ -338,6 +370,36 @@ pub const HttpClient = struct {
 
     const max_head_redirects = 5;
 
+    /// Conditional GET — sends `If-None-Match: <etag>` when `if_none_match`
+    /// is non-null and returns a `ConditionalResponse` that surfaces the
+    /// server's ETag plus a `not_modified` flag when the server answered
+    /// 304. Caller passes any extra headers (e.g. `Authorization`); the
+    /// `If-None-Match` header is prepended internally. Caller owns the
+    /// returned `ConditionalResponse`.
+    pub fn getConditional(
+        self: *HttpClient,
+        url: []const u8,
+        if_none_match: ?[]const u8,
+        extra_headers: []const std.http.Header,
+    ) !ConditionalResponse {
+        if (self.offline) return error.OfflineRequired;
+
+        // Stack-buffered header list: today's only callers add at most
+        // `If-None-Match` + `Authorization`. Bump if a real caller exceeds.
+        var hdr_buf: [8]std.http.Header = undefined;
+        var hdr_len: usize = 0;
+        if (if_none_match) |inm| {
+            hdr_buf[hdr_len] = .{ .name = "If-None-Match", .value = inm };
+            hdr_len += 1;
+        }
+        for (extra_headers) |h| {
+            std.debug.assert(hdr_len < hdr_buf.len);
+            hdr_buf[hdr_len] = h;
+            hdr_len += 1;
+        }
+        return self.doGetConditionalWithRetry(url, hdr_buf[0..hdr_len]);
+    }
+
     /// HEAD with manual redirect follow — stdlib skips redirects on HEAD.
     pub fn headResolved(self: *HttpClient, url: []const u8) !HeadResolved {
         if (self.offline) return error.OfflineRequired;
@@ -461,6 +523,160 @@ pub const HttpClient = struct {
         extra_headers: []const std.http.Header,
     ) !Response {
         return self.doGetWithRetry(url, extra_headers, max_metadata_bytes, null);
+    }
+
+    /// Cancellable backoff between retry attempts. Common to every
+    /// retry loop so a Ctrl-C during the wait surfaces immediately
+    /// instead of being swallowed by std.Io.sleep's silent return.
+    fn retrySleep(self: *HttpClient, attempt: usize) error{Canceled}!void {
+        std.Io.sleep(
+            self.io,
+            std.Io.Duration.fromNanoseconds(@intCast(retry_delays_ms[attempt] * std.time.ns_per_ms)),
+            .awake,
+        ) catch |e| switch (e) {
+            error.Canceled => return error.Canceled,
+        };
+    }
+
+    fn doGetConditionalWithRetry(
+        self: *HttpClient,
+        url: []const u8,
+        extra_headers: []const std.http.Header,
+    ) !ConditionalResponse {
+        var attempt: usize = 0;
+        while (true) {
+            const result = self.doGetConditionalOnce(url, extra_headers);
+            if (result) |resp| {
+                if (classifyStatus(resp.status)) |dl_err| {
+                    if (isTransientError(dl_err) and attempt < max_retries) {
+                        var r = resp;
+                        r.deinit();
+                        try self.retrySleep(attempt);
+                        attempt += 1;
+                        continue;
+                    }
+                }
+                return resp;
+            } else |err| {
+                if (attempt < max_retries) {
+                    try self.retrySleep(attempt);
+                    attempt += 1;
+                    continue;
+                }
+                return err;
+            }
+        }
+    }
+
+    fn doGetConditionalOnce(
+        self: *HttpClient,
+        url: []const u8,
+        extra_headers: []const std.http.Header,
+    ) !ConditionalResponse {
+        const uri = try std.Uri.parse(url);
+        const https_origin = schemeIsHttps(uri.scheme);
+
+        var req = try self.client.request(.GET, uri, .{ .extra_headers = extra_headers });
+        defer req.deinit();
+
+        try req.sendBodiless();
+
+        var redirect_buf: [32 * 1024]u8 = undefined;
+        var response = try req.receiveHead(&redirect_buf);
+
+        if (https_origin and !schemeIsHttps(req.uri.scheme))
+            return error.TlsDowngradeRefused;
+
+        const status: u16 = @intFromEnum(response.head.status);
+        // Etag is borrowed from response.head.bytes; dupe before the head
+        // buffer is dropped on function exit.
+        const etag_owned: ?[]const u8 = if (extractEtagFromHead(response.head.bytes)) |e|
+            try self.allocator.dupe(u8, e)
+        else
+            null;
+        errdefer if (etag_owned) |e| self.allocator.free(e);
+
+        // 304 has no body per HTTP spec — return immediately with an
+        // empty owned slice so deinit's `free(body)` stays uniform.
+        if (status == 304) {
+            const empty = try self.allocator.alloc(u8, 0);
+            return .{
+                .status = status,
+                .not_modified = true,
+                .body = empty,
+                .etag = etag_owned,
+                .allocator = self.allocator,
+            };
+        }
+
+        // Body-read path mirrors doGetLimited (decompress + watchdog +
+        // size cap). Capped at `max_metadata_bytes` — conditional GETs
+        // target tiny JSON, never blobs.
+        const content_length: ?u64 = response.head.content_length;
+
+        var body_writer: std.Io.Writer.Allocating = .init(self.allocator);
+        errdefer body_writer.deinit();
+
+        const decompress_buffer: []u8 = switch (response.head.content_encoding) {
+            .identity => &.{},
+            .zstd => try self.getZstdWindow(),
+            .deflate, .gzip => try self.getFlateWindow(),
+            .compress => return error.ReadFailed,
+        };
+
+        var transfer_buffer: [16384]u8 = undefined;
+        var decompress: std.http.Decompress = undefined;
+        var body_reader = response.readerDecompressing(&transfer_buffer, &decompress, decompress_buffer);
+
+        var counting = CountingWriter{
+            .inner = &body_writer,
+            .bytes_written = std.atomic.Value(u64).init(0),
+            .max_bytes = max_metadata_bytes,
+            .limit_exceeded = false,
+            .progress = null,
+            .content_length = content_length,
+        };
+
+        const total_timeout = self.timeout_ns;
+        const idle_timeout = idleTimeoutNsFromEnv(
+            std.process.Environ.getPosix(self.environ, "MALT_HTTP_IDLE_TIMEOUT_SECS"),
+        );
+        var wake = try Wake.init();
+        const watchdog = std.Thread.spawn(.{}, watchdogFn, .{
+            self.io,
+            wake.read_fd,
+            &counting.bytes_written,
+            idle_timeout,
+            total_timeout,
+            &req,
+            self.cancel,
+        }) catch {
+            wake.deinit();
+            return error.WatchdogSpawnFailed;
+        };
+        defer {
+            wake.signal();
+            watchdog.join();
+            wake.deinit();
+        }
+        _ = body_reader.streamRemaining(&counting.writer) catch |e| switch (e) {
+            error.WriteFailed => {
+                if (counting.limit_exceeded) return error.ResponseTooLarge;
+                return error.ReadFailed;
+            },
+            error.ReadFailed => return error.ReadFailed,
+        };
+
+        if (counting.limit_exceeded) return error.ResponseTooLarge;
+
+        const body = try body_writer.toOwnedSlice();
+        return .{
+            .status = status,
+            .not_modified = false,
+            .body = body,
+            .etag = etag_owned,
+            .allocator = self.allocator,
+        };
     }
 
     fn doGetWithRetry(
@@ -737,6 +953,70 @@ pub const HttpClientPool = struct {
     }
 };
 
+test "extractEtagFromHead: finds ETag header by exact name" {
+    const bytes = "200 OK\r\nServer: github\r\nETag: \"abc123\"\r\nContent-Length: 0\r\n\r\n";
+    const et = extractEtagFromHead(bytes);
+    try std.testing.expectEqualStrings("\"abc123\"", et.?);
+}
+
+test "extractEtagFromHead: header lookup is case-insensitive" {
+    // GitHub spells it `ETag`; reverse proxies sometimes downcase to `etag`.
+    const bytes = "200 OK\r\netag: \"abc123\"\r\n\r\n";
+    const et = extractEtagFromHead(bytes);
+    try std.testing.expectEqualStrings("\"abc123\"", et.?);
+}
+
+test "extractEtagFromHead: preserves GitHub's weak-ETag W/ prefix verbatim" {
+    // Stripping W/ would break the 304 path — GitHub compares textually.
+    const bytes = "304 Not Modified\r\nETag: W/\"deadbeef\"\r\n\r\n";
+    const et = extractEtagFromHead(bytes);
+    try std.testing.expectEqualStrings("W/\"deadbeef\"", et.?);
+}
+
+test "extractEtagFromHead: returns null when ETag header is absent" {
+    const bytes = "200 OK\r\nContent-Length: 0\r\n\r\n";
+    try std.testing.expectEqual(@as(?[]const u8, null), extractEtagFromHead(bytes));
+}
+
+test "extractEtagFromHead: skips lookalikes (`If-None-Match`, prefix matches)" {
+    const bytes = "200 OK\r\nIf-None-Match: \"req-side\"\r\nETagged: \"nope\"\r\n\r\n";
+    try std.testing.expectEqual(@as(?[]const u8, null), extractEtagFromHead(bytes));
+}
+
+test "ConditionalResponse.deinit: frees body and etag together" {
+    var cr: ConditionalResponse = .{
+        .status = 200,
+        .not_modified = false,
+        .body = try std.testing.allocator.dupe(u8, "{}"),
+        .etag = try std.testing.allocator.dupe(u8, "W/\"abc\""),
+        .allocator = std.testing.allocator,
+    };
+    cr.deinit();
+}
+
+test "ConditionalResponse.deinit: tolerates null etag (server omitted the header)" {
+    var cr: ConditionalResponse = .{
+        .status = 200,
+        .not_modified = false,
+        .body = try std.testing.allocator.dupe(u8, "{}"),
+        .etag = null,
+        .allocator = std.testing.allocator,
+    };
+    cr.deinit();
+}
+
+test "ConditionalResponse.deinit: 304 path with empty body frees correctly" {
+    var cr: ConditionalResponse = .{
+        .status = 304,
+        .not_modified = true,
+        // 304 has no body but the wrapper still owns a (possibly empty) slice.
+        .body = try std.testing.allocator.alloc(u8, 0),
+        .etag = try std.testing.allocator.dupe(u8, "W/\"abc\""),
+        .allocator = std.testing.allocator,
+    };
+    cr.deinit();
+}
+
 test "HttpClient.offline defaults to false" {
     var http = HttpClient.init(std.Options.debug_io, std.process.Environ.empty, std.testing.allocator);
     defer http.deinit();
@@ -750,6 +1030,16 @@ test "HttpClient.get returns OfflineRequired when offline is set" {
     // Use a host that would 404/connect-refuse in the real world — the
     // gate must trip before any DNS / TCP work happens.
     try std.testing.expectError(error.OfflineRequired, http.get("https://example.invalid/x"));
+}
+
+test "HttpClient.getConditional returns OfflineRequired when offline is set" {
+    var http = HttpClient.init(std.Options.debug_io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+    http.offline = true;
+    try std.testing.expectError(
+        error.OfflineRequired,
+        http.getConditional("https://example.invalid/x", null, &.{}),
+    );
 }
 
 test "HttpClient.head returns OfflineRequired when offline is set" {

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -1148,7 +1148,27 @@ test "v6→v7 migration leaves cask_versions empty when casks has a broken shape
     _ = try stmt.step();
     try testing.expectEqual(@as(i64, 0), stmt.columnInt(0));
     // Migration still bumps the schema marker so a future run skips this path.
-    try testing.expectEqual(@as(i64, 7), try schema.currentVersion(&db));
+    try testing.expectEqual(@as(i64, 8), try schema.currentVersion(&db));
+}
+
+// v7→v8 ALTER must skip when `taps` is missing entirely (forensic DBs
+// hand-built without the v3-era table); the migration still bumps the
+// schema marker so a future run treats the chain as caught up.
+test "v7→v8 migration tolerates a missing taps table" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+
+    try db.exec(
+        \\CREATE TABLE schema_version (
+        \\    version INTEGER PRIMARY KEY,
+        \\    applied TEXT NOT NULL DEFAULT (datetime('now'))
+        \\);
+    );
+    try db.exec("INSERT INTO schema_version (version) VALUES (7);");
+
+    try schema.migrate(&db);
+
+    try testing.expectEqual(@as(i64, 8), try schema.currentVersion(&db));
 }
 
 // --- coverage: lookupCaskVersion refuses a malformed row ----------------

--- a/tests/db_schema_v2_test.zig
+++ b/tests/db_schema_v2_test.zig
@@ -53,7 +53,7 @@ test "initSchema runs v1 then migrates to the current known version" {
     try testing.expect(try tableExists(&tdb.db, "bundle_members"));
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 7), ver);
+    try testing.expectEqual(@as(i64, 8), ver);
 }
 
 test "migrate is idempotent on re-run" {
@@ -65,7 +65,7 @@ test "migrate is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 7), ver);
+    try testing.expectEqual(@as(i64, 8), ver);
 }
 
 test "v4 migration adds pinned column to casks" {
@@ -95,7 +95,7 @@ test "v4 migration is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 7), ver);
+    try testing.expectEqual(@as(i64, 8), ver);
 }
 
 test "v6 migration adds tap column to casks" {

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -60,6 +60,18 @@ fn freeEntries(allocator: std.mem.Allocator, entries: []outdated_mod.OutdatedEnt
     allocator.free(entries);
 }
 
+/// In-memory DB primed with the malt schema. Tests that don't exercise
+/// the tap-cask branch still need a live DB pointer for the etag-cache
+/// lookup that `tap_mod.getCommitSha` / `getHeadEtag` perform — they
+/// no-op against an empty taps table and the rest of the test runs
+/// untouched.
+fn openTestDb() !sqlite.Database {
+    var db = try sqlite.Database.open(":memory:");
+    errdefer db.close();
+    try schema.initSchema(&db);
+    return db;
+}
+
 fn seedFormula(dir: *TempCacheDir, name: []const u8, latest: []const u8) !void {
     var key_buf: [128]u8 = undefined;
     const file = try std.fmt.bufPrint(&key_buf, "formula_{s}.json", .{name});
@@ -99,7 +111,9 @@ test "collectOutdatedFormulas (small-N, single-client path) returns sorted outda
         .{ .name = "charlie", .version = "3.0" }, // outdated
     };
 
-    const out = try outdated_mod.collectOutdatedFormulas(&malt.app_ctx.debug_ctx, testing.allocator, &api, dir.path, &kegs, null);
+    var db = try openTestDb();
+    defer db.close();
+    const out = try outdated_mod.collectOutdatedFormulas(&malt.app_ctx.debug_ctx, testing.allocator, &db, &api, dir.path, &kegs, null);
     defer freeEntries(testing.allocator, out);
 
     try testing.expectEqual(@as(usize, 2), out.len);
@@ -129,7 +143,9 @@ test "collectOutdatedFormulas (large-N, pool path) preserves sorted order" {
     for (names, 0..) |n, i| rows_buf[i] = .{ .name = n, .version = "1.0" };
 
     var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
-    const out = try outdated_mod.collectOutdatedFormulas(&malt.app_ctx.debug_ctx, testing.allocator, &api, dir.path, &rows_buf, null);
+    var db = try openTestDb();
+    defer db.close();
+    const out = try outdated_mod.collectOutdatedFormulas(&malt.app_ctx.debug_ctx, testing.allocator, &db, &api, dir.path, &rows_buf, null);
     defer freeEntries(testing.allocator, out);
 
     try testing.expectEqual(@as(usize, names.len), out.len);
@@ -161,7 +177,9 @@ test "collectOutdatedFormulas tolerates a missing/404 entry without aborting" {
         .{ .name = "zulu", .version = "1.0" },
     };
 
-    const out = try outdated_mod.collectOutdatedFormulas(&malt.app_ctx.debug_ctx, testing.allocator, &api, dir.path, &kegs, null);
+    var db = try openTestDb();
+    defer db.close();
+    const out = try outdated_mod.collectOutdatedFormulas(&malt.app_ctx.debug_ctx, testing.allocator, &db, &api, dir.path, &kegs, null);
     defer freeEntries(testing.allocator, out);
 
     try testing.expectEqual(@as(usize, 2), out.len);
@@ -187,7 +205,9 @@ test "collectOutdatedCasks (small-N) returns sorted outdated rows only" {
         .{ .name = "apptwo", .version = "1.0" }, // outdated
     };
 
-    const out = try outdated_mod.collectOutdatedCasks(&malt.app_ctx.debug_ctx, testing.allocator, &api, dir.path, &kegs, null);
+    var db = try openTestDb();
+    defer db.close();
+    const out = try outdated_mod.collectOutdatedCasks(&malt.app_ctx.debug_ctx, testing.allocator, &db, &api, dir.path, &kegs, null);
     defer freeEntries(testing.allocator, out);
 
     try testing.expectEqual(@as(usize, 2), out.len);
@@ -211,7 +231,9 @@ test "collectOutdatedCasks (large-N, pool path) preserves sorted order" {
     for (tokens, 0..) |t, i| rows_buf[i] = .{ .name = t, .version = "1.0" };
 
     var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
-    const out = try outdated_mod.collectOutdatedCasks(&malt.app_ctx.debug_ctx, testing.allocator, &api, dir.path, &rows_buf, null);
+    var db = try openTestDb();
+    defer db.close();
+    const out = try outdated_mod.collectOutdatedCasks(&malt.app_ctx.debug_ctx, testing.allocator, &db, &api, dir.path, &rows_buf, null);
     defer freeEntries(testing.allocator, out);
 
     try testing.expectEqual(@as(usize, tokens.len), out.len);

--- a/tests/tap_head_etag_integration_test.zig
+++ b/tests/tap_head_etag_integration_test.zig
@@ -1,0 +1,229 @@
+//! malt — end-to-end integration for the ETag-aware tap HEAD resolve.
+//!
+//! Inline tests in `src/core/tap.zig` cover `resolveFromConditional` in
+//! isolation; the regression script `scripts/regressions/tap_head_etag_304.sh`
+//! covers the real-network conditional GET. This file pins the
+//! assembled middle layer: schema v8 + `getHeadEtag` + `updateHead`
+//! survive a full cold-start → warm-start → cache-bust cycle without
+//! drifting the (sha, etag) invariant.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+const tap = malt.tap;
+const client = malt.client;
+
+const fresh_sha = "0123456789abcdef0123456789abcdef01234567";
+const moved_sha = "abcdef0123456789abcdef0123456789abcdef01";
+const fresh_etag = "W/\"abc123\"";
+const moved_etag = "W/\"def456\"";
+
+fn openDb() !sqlite.Database {
+    var db = try sqlite.Database.open(":memory:");
+    errdefer db.close();
+    try schema.initSchema(&db);
+    return db;
+}
+
+// ── End-to-end DB+helper integration ───────────────────────────────
+
+test "cold start: getHeadEtag returns null before any resolve" {
+    var db = try openDb();
+    defer db.close();
+    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+
+    const et = try tap.getHeadEtag(testing.allocator, &db, "aeroxy/tap");
+    try testing.expectEqual(@as(?[]const u8, null), et);
+}
+
+test "warm start: a 200 response persists (sha, etag); next round can short-circuit" {
+    var db = try openDb();
+    defer db.close();
+    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+
+    // Simulate the cold-start resolve: HeadResolution{sha, etag} →
+    // updateHead atomically pairs them in the row.
+    try tap.updateHead(&db, "aeroxy/tap", fresh_sha, fresh_etag);
+
+    // The next round reads both back; the caller passes cached_etag to
+    // resolveHeadCommit, which sends it as If-None-Match.
+    const sha = (try tap.getCommitSha(testing.allocator, &db, "aeroxy/tap")).?;
+    defer testing.allocator.free(sha);
+    const et = (try tap.getHeadEtag(testing.allocator, &db, "aeroxy/tap")).?;
+    defer testing.allocator.free(et);
+    try testing.expectEqualStrings(fresh_sha, sha);
+    try testing.expectEqualStrings(fresh_etag, et);
+}
+
+test "304 response: caller keeps cached sha, no DB write happens" {
+    var db = try openDb();
+    defer db.close();
+    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+    try tap.updateHead(&db, "aeroxy/tap", fresh_sha, fresh_etag);
+
+    // Mimic resolveFromConditional on a 304: HeadResolution.not_modified=true,
+    // sha=null. Caller-side logic (install / outdated / upgrade) reads
+    // cached_sha and skips updateHead.
+    var resp: client.ConditionalResponse = .{
+        .status = 304,
+        .not_modified = true,
+        .body = try testing.allocator.alloc(u8, 0),
+        .etag = try testing.allocator.dupe(u8, fresh_etag),
+        .allocator = testing.allocator,
+    };
+    defer resp.deinit();
+    var res = try tap.resolveFromConditional(testing.allocator, resp);
+    defer res.deinit();
+    try testing.expect(res.not_modified);
+    try testing.expectEqual(@as(?[]const u8, null), res.sha);
+
+    // DB row is unchanged.
+    const sha_after = (try tap.getCommitSha(testing.allocator, &db, "aeroxy/tap")).?;
+    defer testing.allocator.free(sha_after);
+    const et_after = (try tap.getHeadEtag(testing.allocator, &db, "aeroxy/tap")).?;
+    defer testing.allocator.free(et_after);
+    try testing.expectEqualStrings(fresh_sha, sha_after);
+    try testing.expectEqualStrings(fresh_etag, et_after);
+}
+
+test "cache-bust: a clobbered etag triggers a 200 path that updates both fields" {
+    var db = try openDb();
+    defer db.close();
+    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+    try tap.updateHead(&db, "aeroxy/tap", fresh_sha, "W/\"stale\"");
+
+    // The server returns 200 because the stale etag doesn't match.
+    var resp: client.ConditionalResponse = .{
+        .status = 200,
+        .not_modified = false,
+        .body = try testing.allocator.dupe(
+            u8,
+            "{\"sha\":\"" ++ moved_sha ++ "\"}",
+        ),
+        .etag = try testing.allocator.dupe(u8, moved_etag),
+        .allocator = testing.allocator,
+    };
+    defer resp.deinit();
+    var res = try tap.resolveFromConditional(testing.allocator, resp);
+    defer res.deinit();
+    try testing.expect(!res.not_modified);
+    try testing.expectEqualStrings(moved_sha, res.sha.?);
+    try testing.expectEqualStrings(moved_etag, res.etag.?);
+
+    // Caller persists — order matters: updateHead writes sha+etag in
+    // one statement so a partial-failure window cannot leave the row
+    // pointing at the old sha with the new etag.
+    try tap.updateHead(&db, "aeroxy/tap", res.sha.?, res.etag);
+    const sha_after = (try tap.getCommitSha(testing.allocator, &db, "aeroxy/tap")).?;
+    defer testing.allocator.free(sha_after);
+    const et_after = (try tap.getHeadEtag(testing.allocator, &db, "aeroxy/tap")).?;
+    defer testing.allocator.free(et_after);
+    try testing.expectEqualStrings(moved_sha, sha_after);
+    try testing.expectEqualStrings(moved_etag, et_after);
+}
+
+test "server omits ETag on 200: sha persists, etag column is cleared" {
+    // Behind-a-proxy edge case — caller must fall back to unconditional
+    // GET on the next round rather than carrying a stale etag forward.
+    var db = try openDb();
+    defer db.close();
+    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+    try tap.updateHead(&db, "aeroxy/tap", fresh_sha, fresh_etag);
+
+    var resp: client.ConditionalResponse = .{
+        .status = 200,
+        .not_modified = false,
+        .body = try testing.allocator.dupe(
+            u8,
+            "{\"sha\":\"" ++ moved_sha ++ "\"}",
+        ),
+        .etag = null,
+        .allocator = testing.allocator,
+    };
+    defer resp.deinit();
+    var res = try tap.resolveFromConditional(testing.allocator, resp);
+    defer res.deinit();
+    try tap.updateHead(&db, "aeroxy/tap", res.sha.?, res.etag);
+
+    const et_after = try tap.getHeadEtag(testing.allocator, &db, "aeroxy/tap");
+    try testing.expectEqual(@as(?[]const u8, null), et_after);
+}
+
+// ── Migration path: pre-v8 DB upgrades cleanly ─────────────────────
+
+test "pre-v8 DB upgrades to v8 and carries existing tap rows forward (etag NULL)" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha)
+        \\VALUES ('aeroxy/tap', 'https://github.com/aeroxy/homebrew-tap',
+        \\        '0123456789abcdef0123456789abcdef01234567');
+    );
+    try db.exec("DELETE FROM schema_version WHERE version >= 8;");
+    try schema.migrate(&db);
+
+    const sha = (try tap.getCommitSha(testing.allocator, &db, "aeroxy/tap")).?;
+    defer testing.allocator.free(sha);
+    try testing.expectEqualStrings("0123456789abcdef0123456789abcdef01234567", sha);
+
+    const et = try tap.getHeadEtag(testing.allocator, &db, "aeroxy/tap");
+    try testing.expectEqual(@as(?[]const u8, null), et);
+
+    // Next resolve hits the unconditional-GET path; on 200 we land
+    // here, populating the etag for subsequent rounds.
+    try tap.updateHead(&db, "aeroxy/tap", "0123456789abcdef0123456789abcdef01234567", fresh_etag);
+    const et2 = (try tap.getHeadEtag(testing.allocator, &db, "aeroxy/tap")).?;
+    defer testing.allocator.free(et2);
+    try testing.expectEqualStrings(fresh_etag, et2);
+}
+
+// ── Concurrent writers: SERIALIZED-mode SQLite tolerates dup writes ─
+
+test "multiple workers writing the same (sha, etag) last-writer-wins, no corruption" {
+    // Outdated's worker pool: N parallel resolveHeadCommit calls for
+    // casks sharing one tap. Each gets the same response, each calls
+    // updateHead. SERIALIZED mode (THREADSAFE=1 in build) serialises
+    // per-statement; the row always ends with the agreed values.
+    var db = try openDb();
+    defer db.close();
+    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+
+    for (0..16) |_| {
+        try tap.updateHead(&db, "aeroxy/tap", fresh_sha, fresh_etag);
+    }
+
+    const sha = (try tap.getCommitSha(testing.allocator, &db, "aeroxy/tap")).?;
+    defer testing.allocator.free(sha);
+    const et = (try tap.getHeadEtag(testing.allocator, &db, "aeroxy/tap")).?;
+    defer testing.allocator.free(et);
+    try testing.expectEqualStrings(fresh_sha, sha);
+    try testing.expectEqualStrings(fresh_etag, et);
+}
+
+// ── Edge case: validator rejects bad SHA before any write ──────────
+
+test "updateHead's validator runs before the UPDATE, even with a non-null etag" {
+    // A bad sha must not silently store an etag tied to a phantom row;
+    // the validator gates both fields together so the (sha, etag)
+    // invariant is upheld at every callsite.
+    var db = try openDb();
+    defer db.close();
+    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+    try tap.updateHead(&db, "aeroxy/tap", fresh_sha, fresh_etag);
+
+    try testing.expectError(
+        tap.TapError.InvalidSha,
+        tap.updateHead(&db, "aeroxy/tap", "00", "W/\"new\""),
+    );
+
+    const sha = (try tap.getCommitSha(testing.allocator, &db, "aeroxy/tap")).?;
+    defer testing.allocator.free(sha);
+    const et = (try tap.getHeadEtag(testing.allocator, &db, "aeroxy/tap")).?;
+    defer testing.allocator.free(et);
+    try testing.expectEqualStrings(fresh_sha, sha);
+    try testing.expectEqualStrings(fresh_etag, et);
+}

--- a/tests/tap_head_etag_integration_test.zig
+++ b/tests/tap_head_etag_integration_test.zig
@@ -183,11 +183,9 @@ test "pre-v8 DB upgrades to v8 and carries existing tap rows forward (etag NULL)
 
 // ── Concurrent writers: SERIALIZED-mode SQLite tolerates dup writes ─
 
-test "multiple workers writing the same (sha, etag) last-writer-wins, no corruption" {
-    // Outdated's worker pool: N parallel resolveHeadCommit calls for
-    // casks sharing one tap. Each gets the same response, each calls
-    // updateHead. SERIALIZED mode (THREADSAFE=1 in build) serialises
-    // per-statement; the row always ends with the agreed values.
+test "sequential writers of the same (sha, etag) last-writer-wins" {
+    // Sanity floor for the concurrent test below: the same row mutated
+    // 16x in a row must end at the agreed values.
     var db = try openDb();
     defer db.close();
     try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
@@ -196,6 +194,65 @@ test "multiple workers writing the same (sha, etag) last-writer-wins, no corrupt
         try tap.updateHead(&db, "aeroxy/tap", fresh_sha, fresh_etag);
     }
 
+    const sha = (try tap.getCommitSha(testing.allocator, &db, "aeroxy/tap")).?;
+    defer testing.allocator.free(sha);
+    const et = (try tap.getHeadEtag(testing.allocator, &db, "aeroxy/tap")).?;
+    defer testing.allocator.free(et);
+    try testing.expectEqualStrings(fresh_sha, sha);
+    try testing.expectEqualStrings(fresh_etag, et);
+}
+
+// Real-thread concurrency check. The outdated worker pool can have N
+// workers hitting `updateHead` / `getHeadEtag` on the shared DB pointer
+// at once when several installed casks share a tap. SERIALIZED mode
+// (THREADSAFE=1 in build.zig) serialises per-API call inside SQLite —
+// this test exercises that empirically rather than trusting the docs.
+const ConcurrentCtx = struct {
+    db: *sqlite.Database,
+    iterations: usize,
+    // SqliteError is the only failure modeled; the runner widens to
+    // anyerror so a stray OOM from getHeadEtag's allocator surfaces too.
+    err: ?anyerror = null,
+
+    fn run(self: *ConcurrentCtx) void {
+        var i: usize = 0;
+        while (i < self.iterations) : (i += 1) {
+            tap.updateHead(self.db, "aeroxy/tap", fresh_sha, fresh_etag) catch |e| {
+                self.err = e;
+                return;
+            };
+            // Mix read + write so the serialisation has to cover both
+            // sides of the API surface, not just writes.
+            const got = tap.getHeadEtag(testing.allocator, self.db, "aeroxy/tap") catch |e| {
+                self.err = e;
+                return;
+            };
+            if (got) |g| testing.allocator.free(g);
+        }
+    }
+};
+
+test "concurrent workers (real threads) leave the row consistent under SQLite SERIALIZED" {
+    var db = try openDb();
+    defer db.close();
+    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+
+    const thread_count: usize = 8;
+    const iterations_per_thread: usize = 64;
+
+    var ctxs: [thread_count]ConcurrentCtx = undefined;
+    for (&ctxs) |*c| c.* = .{ .db = &db, .iterations = iterations_per_thread };
+
+    var threads: [thread_count]std.Thread = undefined;
+    for (&threads, &ctxs) |*t, *c| {
+        t.* = try std.Thread.spawn(.{}, ConcurrentCtx.run, .{c});
+    }
+    for (threads) |t| t.join();
+
+    // No worker tripped on a SQLITE_BUSY / OOM / mapped-error.
+    for (ctxs) |c| try testing.expect(c.err == null);
+
+    // Row converged to the agreed value (all writers wrote the same).
     const sha = (try tap.getCommitSha(testing.allocator, &db, "aeroxy/tap")).?;
     defer testing.allocator.free(sha);
     const et = (try tap.getHeadEtag(testing.allocator, &db, "aeroxy/tap")).?;


### PR DESCRIPTION
## Description

`mt install`, `mt outdated`, and `mt upgrade` against third-party taps each previously cost one unconditional `GET commits/HEAD` - 60/hr cap unauthenticated, 5000/hr with `MALT_GITHUB_TOKEN`. The tap-resolve path now persists the GitHub `ETag` alongside the commit SHA and sends `If-None-Match` on subsequent resolves; 304 responses do not count against the rate limit, so a stable tap costs one API call when first seen and zero until upstream moves.

- `mt tap --refresh` deliberately bypasses the etag cache so users have a "force fresh" verb; `mt tap add` reuses the cached etag so a re-add against a stable tap costs zero API tokens.

## Related Issue

- None

## Notes for Reviewers

- None