### PR TITLE
fix(cli/install): exit non-zero when the cask DB row didn't persist

### DIFF
--- a/scripts/regressions/outdated_tap_cask.sh
+++ b/scripts/regressions/outdated_tap_cask.sh
@@ -60,7 +60,7 @@ TOKEN="${SLUG##*/}"
 INSTALL_LOG="$PREFIX/install_${TOKEN}.log"
 printf '\xe2\x96\xb8 mt install %s (logs \xe2\x86\x92 %s)\n' "$SLUG" "$INSTALL_LOG"
 if ! "$BIN" install "$SLUG" >"$INSTALL_LOG" 2>&1; then
-  if grep -qE "rate limit|Network failure|Tap formula/cask not found|Failed to (install|download)|Sha256Mismatch|DownloadFailed" "$INSTALL_LOG"; then
+  if grep -qE "rate limit|Network failure|Tap formula/cask not found|Failed to (install|download)|Sha256Mismatch|DownloadFailed|failed to record installed cask" "$INSTALL_LOG"; then
     skip "${SLUG}: install hit a classified upstream condition; cannot exercise outdated"
     exit 0
   fi
@@ -71,6 +71,21 @@ pass "${SLUG}: installed"
 
 DB="$PREFIX/db/malt.db"
 [[ -f "$DB" ]] || fail "expected DB at $DB after install"
+
+# Row precondition: install exited 0 but the dispatch loop swallows
+# tap-install errors today, so a transient upstream condition can hand
+# us exit 0 with no row. Classified-log = upstream transient → skip;
+# clean log = real partial-success bug → loud fail.
+installed_version=$(sqlite3 "$DB" "SELECT version FROM casks WHERE token='${TOKEN}';")
+if [[ -z "$installed_version" ]]; then
+  if grep -qE "rate limit|Network failure|Tap formula/cask not found|Failed to (install|download)|Sha256Mismatch|DownloadFailed|failed to record installed cask" "$INSTALL_LOG"; then
+    skip "${TOKEN}: install hit a classified upstream condition; row not persisted"
+    exit 0
+  fi
+  tail -30 "$INSTALL_LOG" >&2
+  fail "${TOKEN}: install reported success but no casks row exists (installed=ø)"
+fi
+pass "${TOKEN}: post-install casks row present (version='${installed_version}')"
 
 # Force a version mismatch by tampering the installed version.
 sqlite3 "$DB" "UPDATE casks SET version='0.0.0' WHERE token='${TOKEN}';"

--- a/scripts/regressions/upgrade_tap_cask_legacy_backfill.sh
+++ b/scripts/regressions/upgrade_tap_cask_legacy_backfill.sh
@@ -56,7 +56,7 @@ EXPECTED_TAP="yuzeguitarist/deck"
 INSTALL_LOG="$PREFIX/install_${TOKEN}.log"
 printf '\xe2\x96\xb8 mt install %s (logs \xe2\x86\x92 %s)\n' "$SLUG" "$INSTALL_LOG"
 if ! "$BIN" install "$SLUG" >"$INSTALL_LOG" 2>&1; then
-  if grep -qE "rate limit|Network failure|Tap formula/cask not found|Failed to (install|download)|Sha256Mismatch|DownloadFailed" "$INSTALL_LOG"; then
+  if grep -qE "rate limit|Network failure|Tap formula/cask not found|Failed to (install|download)|Sha256Mismatch|DownloadFailed|failed to record installed cask" "$INSTALL_LOG"; then
     skip "${SLUG}: install hit a classified upstream condition; cannot exercise backfill"
     exit 0
   fi
@@ -67,6 +67,20 @@ pass "${SLUG}: installed"
 
 DB="$PREFIX/db/malt.db"
 [[ -f "$DB" ]] || fail "expected DB at $DB after install"
+
+# Row precondition: dispatch swallows tap-install errors today, so a
+# transient upstream condition can yield exit 0 + no row. Classified
+# log → skip (upstream issue); clean log → loud fail (real bug).
+installed_version=$(sqlite3 "$DB" "SELECT version FROM casks WHERE token='${TOKEN}';")
+if [[ -z "$installed_version" ]]; then
+  if grep -qE "rate limit|Network failure|Tap formula/cask not found|Failed to (install|download)|Sha256Mismatch|DownloadFailed|failed to record installed cask" "$INSTALL_LOG"; then
+    skip "${TOKEN}: install hit a classified upstream condition; row not persisted"
+    exit 0
+  fi
+  tail -30 "$INSTALL_LOG" >&2
+  fail "${TOKEN}: install reported success but no casks row exists (installed=ø)"
+fi
+pass "${TOKEN}: post-install casks row present (version='${installed_version}')"
 
 # Verify install wrote the tap automatically (the v6 contract).
 post_install_tap=$(sqlite3 "$DB" "SELECT tap FROM casks WHERE token='${TOKEN}';")

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -616,7 +616,11 @@ fn executeWithOpts(
                     continue;
                 }
                 if (force_formula) {
-                    output.err("Formula '{s}' not found", .{pkg_name});
+                    if (mapApiFetchError(fetch_err) != null) {
+                        output.err("Cannot reach Homebrew API for formula '{s}'", .{pkg_name});
+                    } else {
+                        output.err("Formula '{s}' not found", .{pkg_name});
+                    }
                     continue;
                 }
                 // Try cask
@@ -1104,6 +1108,24 @@ fn maybeRegisterService(
     };
 }
 
+/// Classify a Homebrew-API fetch failure. Network-layer failures map
+/// to `NetworkError` so the user-facing summary names the real cause
+/// instead of the path-specific "not found" fallback. `null` means
+/// the caller picks its own fallback (formula vs. cask). Exhaustive
+/// so a new `ApiError` tag fails compilation here.
+fn mapApiFetchError(e: api_mod.ApiError) ?InstallError {
+    return switch (e) {
+        error.ApiUnreachable => InstallError.NetworkError,
+        error.NotFound,
+        error.InvalidResponse,
+        error.InvalidName,
+        error.CacheError,
+        error.OfflineRequired,
+        error.OutOfMemory,
+        => null,
+    };
+}
+
 /// HEAD-based fallback for extensionless cask URLs.
 /// Follows redirects to discover the real file extension.
 fn resolveCaskArtifactViaHead(ctx: *const AppCtx, allocator: std.mem.Allocator, url: []const u8) cask_mod.ArtifactType {
@@ -1133,6 +1155,10 @@ fn installCask(
         // Propagate the typed OfflineRequired so the outer dispatch
         // surfaces the snapshot-miss message instead of "not found".
         if (e == api_mod.ApiError.OfflineRequired) return e;
+        if (mapApiFetchError(e)) |mapped| {
+            output.err("Cannot reach Homebrew API for cask '{s}'", .{token});
+            return mapped;
+        }
         output.err("Cask '{s}' not found", .{token});
         return InstallError.CaskNotFound;
     };
@@ -1243,6 +1269,21 @@ fn formatMaterializeFailure(buf: []u8, name: []const u8, err: cellar_mod.CellarE
     // Overflow only fires on pathologically long names; fall back to a
     // truncated form rather than swallowing the failure silently.
     return result catch "Failed to materialize <truncated>";
+}
+
+test "mapApiFetchError surfaces ApiUnreachable as NetworkError" {
+    // Pre-fix the bottle/cask paths collapsed any fetch failure to a
+    // path-specific "not found" tag, so the dispatch summary said
+    // FormulaNotFound or CaskNotFound when the cause was a flaky DNS.
+    try std.testing.expectEqual(InstallError.NetworkError, mapApiFetchError(error.ApiUnreachable).?);
+}
+
+test "mapApiFetchError leaves other ApiError variants for the path's own fallback" {
+    try std.testing.expect(mapApiFetchError(error.NotFound) == null);
+    try std.testing.expect(mapApiFetchError(error.OfflineRequired) == null);
+    try std.testing.expect(mapApiFetchError(error.InvalidResponse) == null);
+    try std.testing.expect(mapApiFetchError(error.InvalidName) == null);
+    try std.testing.expect(mapApiFetchError(error.CacheError) == null);
 }
 
 test "formatMaterializeFailure: trivial tag drops the parenthetical" {

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -226,7 +226,7 @@ fn installTapRb(
         }
         var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, null) catch |e| {
             output.err("Could not resolve {s}'s HEAD commit: {s}", .{ tap_slug, tap_mod.describeResolveError(e) });
-            return InstallError.FormulaNotFound;
+            return mapTapResolveError(e);
         };
         defer head_res.deinit();
         const sha = head_res.sha orelse {
@@ -902,19 +902,8 @@ fn materializeTapCask(
     bar.finish();
     defer allocator.free(app_path);
 
-    // tap_label is the third-party tap origin (`user/repo`) — drives
-    // pre-routing in `mt upgrade` so subsequent invocations skip the
-    // multi-tap probe loop.
-    cask_mod.recordInstall(db, &cask, app_path, resolved.tap_label) catch {
-        output.warn("Failed to record cask {s} in database", .{cask.token});
-    };
-
-    if (resolved.tap_registration) |t| {
-        // Tap row is advisory — the install already succeeded; a missing
-        // tap row self-heals on the next sync so swallowing is safe here.
-        tap_mod.add(db, resolved.tap_label, t.url, t.commit_sha) catch {};
-        if (t.head_etag) |et| tap_mod.updateHead(db, resolved.tap_label, t.commit_sha, et) catch {};
-    }
+    // `try` is the invariant: success line never fires without a row.
+    try finalizeTapCaskInstall(db, &cask, app_path, resolved.tap_label, resolved.tap_registration);
 
     output.success("{s} {s} installed", .{ cask.token, cask.version });
 }
@@ -971,6 +960,45 @@ fn writeJsonString(allocator: std.mem.Allocator, out: *std.ArrayList(u8), s: []c
     try out.append(allocator, '"');
 }
 
+/// Map `tap_mod` resolve errors to specific `InstallError` tags so the
+/// dispatch line ("Failed to install X: <tag>") names the cause —
+/// `RateLimited` / `NetworkError` instead of collapsing every failure
+/// to the misleading `FormulaNotFound`.
+fn mapTapResolveError(e: tap_mod.TapError) InstallError {
+    return switch (e) {
+        error.RateLimited => InstallError.RateLimited,
+        error.NetworkError => InstallError.NetworkError,
+        error.NotFound,
+        error.MalformedJson,
+        error.InvalidSha,
+        error.ResolveFailed,
+        => InstallError.FormulaNotFound,
+        error.OutOfMemory => InstallError.RecordFailed,
+    };
+}
+
+/// Persist before print: any failure surfaces as `RecordFailed` so
+/// the caller cannot print "installed" without a committed row. The
+/// err wording is a public contract for `scripts/regressions/*.sh`.
+fn finalizeTapCaskInstall(
+    db: *sqlite.Database,
+    cask: *const cask_mod.Cask,
+    app_path: ?[]const u8,
+    tap_label: []const u8,
+    tap_registration: ?TapRegistration,
+) InstallError!void {
+    cask_mod.recordInstall(db, cask, app_path, tap_label) catch {
+        output.err("failed to record installed cask {s}", .{cask.token});
+        return InstallError.RecordFailed;
+    };
+    // Tap row + etag are advisory; the cask row is the install
+    // source of truth and tap_mod state self-heals on next sync.
+    if (tap_registration) |t| {
+        tap_mod.add(db, tap_label, t.url, t.commit_sha) catch {};
+        if (t.head_etag) |et| tap_mod.updateHead(db, tap_label, t.commit_sha, et) catch {};
+    }
+}
+
 test "formatTapDownloadName encodes pid + extension into tmp/ path" {
     var buf: [128]u8 = undefined;
     const got = try formatTapDownloadName(&buf, "/opt/h", ".tar.gz", 4242);
@@ -991,4 +1019,180 @@ test "formatTapDownloadName distinct pids produce distinct paths" {
 test "formatTapDownloadName surfaces NoSpaceLeft instead of truncating" {
     var buf: [4]u8 = undefined;
     try std.testing.expectError(error.NoSpaceLeft, formatTapDownloadName(&buf, "/opt/h", ".tar.gz", 4242));
+}
+
+test "mapTapResolveError surfaces rate limit and network failure as their own tags" {
+    // Bug repro: pre-fix every resolve error collapsed to FormulaNotFound,
+    // so "Failed to install X: FormulaNotFound" told the user the wrong
+    // story when the real cause was a 60/hr rate-limit or a flaky DNS.
+    try std.testing.expectEqual(InstallError.RateLimited, mapTapResolveError(error.RateLimited));
+    try std.testing.expectEqual(InstallError.NetworkError, mapTapResolveError(error.NetworkError));
+}
+
+test "mapTapResolveError keeps non-classified causes on FormulaNotFound" {
+    try std.testing.expectEqual(InstallError.FormulaNotFound, mapTapResolveError(error.NotFound));
+    try std.testing.expectEqual(InstallError.FormulaNotFound, mapTapResolveError(error.MalformedJson));
+    try std.testing.expectEqual(InstallError.FormulaNotFound, mapTapResolveError(error.InvalidSha));
+    try std.testing.expectEqual(InstallError.FormulaNotFound, mapTapResolveError(error.ResolveFailed));
+}
+
+test "mapTapResolveError handles every TapError tag" {
+    // Comptime sweep: a future TapError addition without a switch arm
+    // fails to compile here, surfacing the gap loudly.
+    inline for (@typeInfo(tap_mod.TapError).error_set.?) |err| {
+        const tag = @field(tap_mod.TapError, err.name);
+        const mapped = mapTapResolveError(tag);
+        try std.testing.expect(mapped == InstallError.RateLimited or
+            mapped == InstallError.NetworkError or
+            mapped == InstallError.FormulaNotFound or
+            mapped == InstallError.RecordFailed);
+    }
+}
+
+test "finalizeTapCaskInstall persists the cask row on the happy path" {
+    // Guards against "always RecordFailed" or a recordInstall arg-swap
+    // regression that the failure-mode test alone would not catch.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try db.exec(
+        \\CREATE TABLE casks (
+        \\    id INTEGER PRIMARY KEY,
+        \\    token TEXT NOT NULL UNIQUE,
+        \\    name TEXT NOT NULL,
+        \\    version TEXT NOT NULL,
+        \\    url TEXT NOT NULL,
+        \\    sha256 TEXT,
+        \\    app_path TEXT,
+        \\    auto_updates INTEGER NOT NULL DEFAULT 0,
+        \\    pinned INTEGER NOT NULL DEFAULT 0,
+        \\    tap TEXT
+        \\);
+    );
+
+    var json_buf: std.ArrayList(u8) = .empty;
+    defer json_buf.deinit(std.testing.allocator);
+    try buildSyntheticCaskJson(std.testing.allocator, &json_buf, .{
+        .name = "deckclip",
+        .full_name = "yuzeguitarist/deck/deckclip",
+        .tap_label = "yuzeguitarist/deck",
+        .version = "1.4.5",
+        .url = "https://example.com/Deck.dmg",
+        .sha256 = "deadbeefcafe",
+        .app_name = "Deck.app",
+    });
+
+    var cask = try cask_mod.parseCask(std.testing.allocator, json_buf.items);
+    defer cask.deinit();
+
+    try finalizeTapCaskInstall(&db, &cask, "/tmp/Deck.app", "yuzeguitarist/deck", null);
+
+    var stmt = try db.prepare("SELECT version, tap FROM casks WHERE token = ?1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, "deckclip");
+    try std.testing.expect(try stmt.step());
+    try std.testing.expectEqualStrings("1.4.5", std.mem.sliceTo(stmt.columnText(0) orelse "", 0));
+    try std.testing.expectEqualStrings("yuzeguitarist/deck", std.mem.sliceTo(stmt.columnText(1) orelse "", 0));
+}
+
+test "finalizeTapCaskInstall stamps the owning tap when tap_registration is set" {
+    // tap row + etag must persist so subsequent `mt upgrade` pre-routes
+    // via `casks.tap` instead of probing every registered tap.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try db.exec(
+        \\CREATE TABLE casks (
+        \\    id INTEGER PRIMARY KEY,
+        \\    token TEXT NOT NULL UNIQUE,
+        \\    name TEXT NOT NULL,
+        \\    version TEXT NOT NULL,
+        \\    url TEXT NOT NULL,
+        \\    sha256 TEXT,
+        \\    app_path TEXT,
+        \\    auto_updates INTEGER NOT NULL DEFAULT 0,
+        \\    pinned INTEGER NOT NULL DEFAULT 0,
+        \\    tap TEXT
+        \\);
+    );
+    try db.exec(
+        \\CREATE TABLE taps (
+        \\    name TEXT PRIMARY KEY,
+        \\    url TEXT NOT NULL,
+        \\    commit_sha TEXT,
+        \\    head_etag TEXT
+        \\);
+    );
+
+    var json_buf: std.ArrayList(u8) = .empty;
+    defer json_buf.deinit(std.testing.allocator);
+    try buildSyntheticCaskJson(std.testing.allocator, &json_buf, .{
+        .name = "deckclip",
+        .full_name = "yuzeguitarist/deck/deckclip",
+        .tap_label = "yuzeguitarist/deck",
+        .version = "1.4.5",
+        .url = "https://example.com/Deck.dmg",
+        .sha256 = "deadbeefcafe",
+        .app_name = "Deck.app",
+    });
+
+    var cask = try cask_mod.parseCask(std.testing.allocator, json_buf.items);
+    defer cask.deinit();
+
+    // updateHead validates SHA shape; a short SHA silently skips etag.
+    const sha = "0123456789abcdef0123456789abcdef01234567";
+    try finalizeTapCaskInstall(&db, &cask, "/tmp/Deck.app", "yuzeguitarist/deck", .{
+        .url = "https://github.com/yuzeguitarist/homebrew-deck",
+        .commit_sha = sha,
+        .head_etag = "\"etag-abc\"",
+    });
+
+    var stmt = try db.prepare("SELECT commit_sha, head_etag FROM taps WHERE name = ?1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, "yuzeguitarist/deck");
+    try std.testing.expect(try stmt.step());
+    try std.testing.expectEqualStrings(sha, std.mem.sliceTo(stmt.columnText(0) orelse "", 0));
+    try std.testing.expectEqualStrings("\"etag-abc\"", std.mem.sliceTo(stmt.columnText(1) orelse "", 0));
+}
+
+test "finalizeTapCaskInstall fails loud when the cask DB row cannot persist" {
+    // Reproduces the partial-success bug: persist failure must NOT
+    // collapse to "installed" stdout + exit 0.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    // No schema → recordInstall fails at prepare (no casks table).
+
+    var json_buf: std.ArrayList(u8) = .empty;
+    defer json_buf.deinit(std.testing.allocator);
+    try buildSyntheticCaskJson(std.testing.allocator, &json_buf, .{
+        .name = "deckclip",
+        .full_name = "yuzeguitarist/deck/deckclip",
+        .tap_label = "yuzeguitarist/deck",
+        .version = "1.4.5",
+        .url = "https://example.com/Deck.dmg",
+        .sha256 = "deadbeefcafe",
+        .app_name = "Deck.app",
+    });
+
+    var cask = try cask_mod.parseCask(std.testing.allocator, json_buf.items);
+    defer cask.deinit();
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(std.testing.allocator);
+    output.beginStderrCapture(std.testing.allocator, &captured);
+    defer output.endStderrCapture();
+
+    // Mirror the materializeTapCask call site shape.
+    var finalize_err: ?InstallError = null;
+    finalizeTapCaskInstall(&db, &cask, null, "yuzeguitarist/deck", null) catch |e| {
+        finalize_err = e;
+    };
+    if (finalize_err == null) {
+        output.success("{s} {s} installed", .{ cask.token, cask.version });
+        return error.TestExpectedRecordFailed;
+    }
+    try std.testing.expectEqual(InstallError.RecordFailed, finalize_err.?);
+
+    // Substring is the public contract for the regression skip-classifier.
+    try std.testing.expect(std.mem.indexOf(u8, captured.items, "failed to record installed cask") != null);
+    // Success line must never fire on a failed persist.
+    try std.testing.expect(std.mem.indexOf(u8, captured.items, "deckclip 1.4.5 installed") == null);
 }

--- a/src/cli/install/record.zig
+++ b/src/cli/install/record.zig
@@ -3,9 +3,10 @@
 //! narrow set and the dispatch loop can classify errors exhaustively.
 
 const std = @import("std");
+
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
-const sqlite = @import("../../db/sqlite.zig");
 const formula_mod = @import("../../core/formula.zig");
+const sqlite = @import("../../db/sqlite.zig");
 const output = @import("../../ui/output.zig");
 
 pub const InstallError = error{
@@ -46,6 +47,13 @@ pub const InstallError = error{
     /// `ftp://`, or plaintext `http://` URL cannot be turned into an
     /// exploit just by `malt install --local`-ing the file.
     InsecureArchiveUrl,
+    /// GitHub-API rate limit hit while resolving a tap's HEAD commit.
+    /// Distinct from `FormulaNotFound` so the user-facing summary
+    /// names the real cause instead of "formula does not exist."
+    RateLimited,
+    /// Network-layer failure (no HTTP status) while resolving a tap.
+    /// Distinct tag so retry policies can differentiate from 4xx/5xx.
+    NetworkError,
 };
 
 /// True when the given error has already surfaced a specific,
@@ -61,6 +69,8 @@ pub fn localErrorIsAnnounced(e: InstallError) bool {
         InstallError.FormulaNotFound,
         InstallError.DownloadFailed,
         InstallError.CellarFailed,
+        InstallError.RateLimited,
+        InstallError.NetworkError,
         => true,
 
         InstallError.NoPackages,
@@ -70,6 +80,9 @@ pub fn localErrorIsAnnounced(e: InstallError) bool {
         InstallError.NoBottle,
         InstallError.StoreFailed,
         InstallError.LinkFailed,
+        // Some RecordFailed paths emit a classified err first, others
+        // (db.beginTransaction failure) do not — leave the generic
+        // dispatch summary on so the silent path still surfaces.
         InstallError.RecordFailed,
         InstallError.PartialFailure,
         InstallError.PrefixAbsurd,


### PR DESCRIPTION
## Description

A transient SQLite write during a tap-cask install used to print "installed" and exit 0 while leaving the `casks` row absent, silently corrupting downstream `mt outdated` / `mt upgrade` and any regression script that follows install with a `sqlite3 UPDATE`. The cask install now persists before the success print and surfaces a classified `failed to record installed cask` line on failure.

Install failure classification is now accurate across all three install paths. Tap-resolve no longer collapses every error to a misleading `FormulaNotFound`: rate-limit and network failures ride their own `InstallError.RateLimited` / `NetworkError` tags. The bottle and core-API cask paths map `ApiError.ApiUnreachable` to `InstallError.NetworkError` instead of the path-specific "not found" fallback, so the dispatch's `Failed to install X: <tag>` summary names the real cause.

## Related Issue

- None

## Notes for Reviewers

- None