### PR TITLE
fix(cli/install): propagate single-package install failures to a non-zero exit

### DIFF
--- a/scripts/regressions/outdated_tap_cask.sh
+++ b/scripts/regressions/outdated_tap_cask.sh
@@ -72,19 +72,9 @@ pass "${SLUG}: installed"
 DB="$PREFIX/db/malt.db"
 [[ -f "$DB" ]] || fail "expected DB at $DB after install"
 
-# Row precondition: install exited 0 but the dispatch loop swallows
-# tap-install errors today, so a transient upstream condition can hand
-# us exit 0 with no row. Classified-log = upstream transient → skip;
-# clean log = real partial-success bug → loud fail.
 installed_version=$(sqlite3 "$DB" "SELECT version FROM casks WHERE token='${TOKEN}';")
-if [[ -z "$installed_version" ]]; then
-  if grep -qE "rate limit|Network failure|Tap formula/cask not found|Failed to (install|download)|Sha256Mismatch|DownloadFailed|failed to record installed cask" "$INSTALL_LOG"; then
-    skip "${TOKEN}: install hit a classified upstream condition; row not persisted"
-    exit 0
-  fi
-  tail -30 "$INSTALL_LOG" >&2
-  fail "${TOKEN}: install reported success but no casks row exists (installed=ø)"
-fi
+[[ -n "$installed_version" ]] ||
+  fail "${TOKEN}: post-install row missing (install exited 0, dispatch contract broken)"
 pass "${TOKEN}: post-install casks row present (version='${installed_version}')"
 
 # Force a version mismatch by tampering the installed version.

--- a/scripts/regressions/upgrade_tap_cask_legacy_backfill.sh
+++ b/scripts/regressions/upgrade_tap_cask_legacy_backfill.sh
@@ -68,18 +68,9 @@ pass "${SLUG}: installed"
 DB="$PREFIX/db/malt.db"
 [[ -f "$DB" ]] || fail "expected DB at $DB after install"
 
-# Row precondition: dispatch swallows tap-install errors today, so a
-# transient upstream condition can yield exit 0 + no row. Classified
-# log → skip (upstream issue); clean log → loud fail (real bug).
 installed_version=$(sqlite3 "$DB" "SELECT version FROM casks WHERE token='${TOKEN}';")
-if [[ -z "$installed_version" ]]; then
-  if grep -qE "rate limit|Network failure|Tap formula/cask not found|Failed to (install|download)|Sha256Mismatch|DownloadFailed|failed to record installed cask" "$INSTALL_LOG"; then
-    skip "${TOKEN}: install hit a classified upstream condition; row not persisted"
-    exit 0
-  fi
-  tail -30 "$INSTALL_LOG" >&2
-  fail "${TOKEN}: install reported success but no casks row exists (installed=ø)"
-fi
+[[ -n "$installed_version" ]] ||
+  fail "${TOKEN}: post-install row missing (install exited 0, dispatch contract broken)"
 pass "${TOKEN}: post-install casks row present (version='${installed_version}')"
 
 # Verify install wrote the tap automatically (the v6 contract).

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -588,6 +588,9 @@ fn executeWithOpts(
         // Check for Ctrl-C between packages during resolution
         if (signals.isInterrupted()) {
             output.warn("Interrupted during resolution.", .{});
+            // Surface counted misses so a Ctrl-C after some packages
+            // already failed dispatch still exits non-zero.
+            if (failed_count > 0) return InstallError.PartialFailure;
             return;
         }
 
@@ -907,6 +910,13 @@ fn executeWithOpts(
     // Check for Ctrl-C between the pool and the serial link phase
     if (signals.isInterrupted()) {
         output.warn("Interrupted. Cleaning up...", .{});
+        // Pool already joined; pull its `!job.succeeded` results into
+        // failed_count before bailing so the exit code reflects any
+        // bottle that failed to download alongside earlier dispatch misses.
+        for (all_jobs.items) |job| {
+            if (!job.succeeded) failed_count += 1;
+        }
+        if (failed_count > 0) return InstallError.PartialFailure;
         return;
     }
 

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -549,7 +549,10 @@ fn executeWithOpts(
 
     // Set up API client
     var cache_dir_buf: [512]u8 = undefined;
-    const cache_dir = std.fmt.bufPrint(&cache_dir_buf, "{s}/cache", .{prefix}) catch return;
+    // Prefix is sanity-capped at max_prefix_sane_len (256); "/cache" adds 6.
+    // The 512-byte buffer cannot overflow — the prior `catch return;` was a
+    // silent exit on a path that never fires.
+    const cache_dir = std.fmt.bufPrint(&cache_dir_buf, "{s}/cache", .{prefix}) catch unreachable;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
     api.base_url = ctx.mirrors.api_base;
     api.offline = ctx.offline;

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -696,6 +696,9 @@ fn executeWithOpts(
             // No transition outcome to report on a plan-only run.
             output.emitNdjsonEvent(.would_install, job.name, null);
         }
+        // Mixed runs (one cached + one 404) print a partial plan; mirror
+        // the empty-list gate so the exit code still reflects the miss.
+        if (failed_count > 0) return InstallError.PartialFailure;
         return;
     }
 

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -549,9 +549,9 @@ fn executeWithOpts(
 
     // Set up API client
     var cache_dir_buf: [512]u8 = undefined;
-    // Prefix is sanity-capped at max_prefix_sane_len (256); "/cache" adds 6.
-    // The 512-byte buffer cannot overflow — the prior `catch return;` was a
-    // silent exit on a path that never fires.
+    // Pin the unreachable: prefix is sanity-capped + format suffix is fixed,
+    // so a future bump to either side fails the build instead of the catch.
+    comptime std.debug.assert(max_prefix_sane_len + "/cache".len + 1 <= cache_dir_buf.len);
     const cache_dir = std.fmt.bufPrint(&cache_dir_buf, "{s}/cache", .{prefix}) catch unreachable;
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
     api.base_url = ctx.mirrors.api_base;

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -883,6 +883,7 @@ fn executeWithOpts(
             if (!job.succeeded) {
                 output.emitNdjsonEvent(.download_complete, job.name, "failed");
                 output.err("Download failed for {s}", .{job.name});
+                failed_count += 1;
                 continue;
             }
             output.emitNdjsonEvent(.download_complete, job.name, "ok");
@@ -893,6 +894,10 @@ fn executeWithOpts(
                 job.store_sha256,
             });
         }
+        // Symmetric with the link-phase trailer: surface a non-zero exit
+        // when any bottle failed to download or any dispatch-time miss
+        // was already counted upstream.
+        if (failed_count > 0) return InstallError.PartialFailure;
         return;
     }
 

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -571,6 +571,10 @@ fn executeWithOpts(
     var all_jobs: std.ArrayList(DownloadJob) = .empty;
     defer all_jobs.deinit(allocator);
 
+    // Shared across resolution + link so a dispatch-time miss
+    // surfaces the same PartialFailure the bottle phase already does.
+    var failed_count: usize = 0;
+
     // Check for Ctrl-C before resolution phase
     if (signals.isInterrupted()) {
         output.warn("Interrupted before resolution.", .{});
@@ -593,6 +597,7 @@ fn executeWithOpts(
                 if (!localErrorIsAnnounced(e)) {
                     output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
                 }
+                failed_count += 1;
             };
             continue;
         }
@@ -601,6 +606,7 @@ fn executeWithOpts(
         if (isTapFormula(pkg_name)) {
             installTapFormula(ctx, allocator, pkg_name, &db, &linker, prefix, dry_run, force, download_only) catch |e| {
                 output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
+                failed_count += 1;
             };
             continue;
         }
@@ -613,6 +619,7 @@ fn executeWithOpts(
                 // cask probe that would also miss with the same noise.
                 if (fetch_err == api_mod.ApiError.OfflineRequired) {
                     output.err("offline mode: formula '{s}' not cached", .{pkg_name});
+                    failed_count += 1;
                     continue;
                 }
                 if (force_formula) {
@@ -621,6 +628,7 @@ fn executeWithOpts(
                     } else {
                         output.err("Formula '{s}' not found", .{pkg_name});
                     }
+                    failed_count += 1;
                     continue;
                 }
                 // Try cask
@@ -630,6 +638,7 @@ fn executeWithOpts(
                     } else {
                         output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
                     }
+                    failed_count += 1;
                 };
                 continue;
             };
@@ -654,12 +663,14 @@ fn executeWithOpts(
                 .worker_backing = std.heap.smp_allocator,
             }, pkg_name, formula_json, force, &all_jobs) catch |e| {
                 output.err("Failed to resolve {s}: {s}", .{ pkg_name, @errorName(e) });
+                failed_count += 1;
                 continue;
             };
             output.emitNdjsonEvent(.resolved, pkg_name, null);
         } else {
             installCask(ctx, allocator, pkg_name, &db, &api, dry_run, download_only) catch |e| {
                 output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
+                failed_count += 1;
             };
         }
     }
@@ -669,7 +680,13 @@ fn executeWithOpts(
     // and `mt purge --unused-deps` reclaims them once nothing direct retains them.
     if (only_dependencies) dropTopLevelJobs(allocator, &all_jobs);
 
-    if (all_jobs.items.len == 0) return;
+    if (all_jobs.items.len == 0) {
+        // Resolution-only failures never reach the link loop's trailing
+        // PartialFailure; surface it here so the exit code matches the
+        // printed error. Clean empty runs (cask-only happy path) keep 0.
+        if (failed_count > 0) return InstallError.PartialFailure;
+        return;
+    }
 
     if (dry_run) {
         output.info("Dry run: would install {d} package(s):", .{all_jobs.items.len});
@@ -887,7 +904,6 @@ fn executeWithOpts(
     // graph; linker + SQLite writes cannot be parallelised.
     var failed_kegs = std.StringHashMap(void).init(allocator);
     defer failed_kegs.deinit();
-    var failed_count: usize = 0;
 
     for (all_jobs.items, 0..) |*job, i| {
         if (signals.isInterrupted()) {

--- a/src/core/signals.zig
+++ b/src/core/signals.zig
@@ -10,18 +10,45 @@ const std = @import("std");
 /// Raised by `sigintHandler`, polled at step boundaries.
 var interrupted: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 
+/// Test-only countdown: when > 0, the Nth subsequent `isInterrupted()`
+/// poll flips `interrupted` to true. Lets a test target a specific
+/// mid-execute interrupt site (resolution-loop, pre-link) that a plain
+/// pre-set flag can't reach because the pre-resolution gate fires first.
+/// In production this stays at 0, so the fast-path costs one atomic load.
+var arm_after: std.atomic.Value(usize) = std.atomic.Value(usize).init(0);
+
 /// Tracks whether `installHandler` has wired SIGINT. Lets dispatch
 /// distinguish a real production run (preserve any flag the handler set)
 /// from a test runner re-entering with stale state from a prior case.
 var handler_installed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 
 pub fn isInterrupted() bool {
+    if (arm_after.load(.acquire) > 0) {
+        var prev = arm_after.load(.acquire);
+        while (prev > 0) {
+            if (arm_after.cmpxchgWeak(prev, prev - 1, .acq_rel, .acquire)) |fresh| {
+                prev = fresh;
+                continue;
+            }
+            if (prev == 1) interrupted.store(true, .release);
+            break;
+        }
+    }
     return interrupted.load(.acquire);
 }
 
 /// Test-only override — raising real SIGINT would race the test runner.
 pub fn setInterruptedForTest(v: bool) void {
     interrupted.store(v, .release);
+}
+
+/// Test-only: flip `interrupted` on the Nth subsequent `isInterrupted()`
+/// poll. `n == 0` disarms. Use to reach interrupt sites past the pre-
+/// resolution gate (the resolution-loop check or the pre-link check)
+/// which a plain pre-set flag would never reach because the earlier
+/// gate fires first.
+pub fn armInterruptAfterForTest(n: usize) void {
+    arm_after.store(n, .release);
 }
 
 /// Test-only override so the production-mode preservation branch is
@@ -51,6 +78,32 @@ pub fn installHandler() void {
     };
     std.posix.sigaction(std.posix.SIG.INT, &act, null);
     handler_installed.store(true, .release);
+}
+
+test "armInterruptAfterForTest fires on the Nth subsequent poll" {
+    const prior_interrupted = isInterrupted();
+    defer setInterruptedForTest(prior_interrupted);
+    setInterruptedForTest(false);
+    armInterruptAfterForTest(3);
+    defer armInterruptAfterForTest(0);
+
+    try std.testing.expect(!isInterrupted()); // poll 1
+    try std.testing.expect(!isInterrupted()); // poll 2
+    try std.testing.expect(isInterrupted()); // poll 3 → flips
+    try std.testing.expect(isInterrupted()); // already flipped, stays true
+}
+
+test "armInterruptAfterForTest(0) disarms without flipping" {
+    const prior_interrupted = isInterrupted();
+    defer setInterruptedForTest(prior_interrupted);
+    setInterruptedForTest(false);
+    armInterruptAfterForTest(2);
+    armInterruptAfterForTest(0);
+    defer armInterruptAfterForTest(0);
+
+    try std.testing.expect(!isInterrupted());
+    try std.testing.expect(!isInterrupted());
+    try std.testing.expect(!isInterrupted());
 }
 
 test "setInterruptedForTest round-trips through isInterrupted" {

--- a/tests/install_download_only_test.zig
+++ b/tests/install_download_only_test.zig
@@ -17,6 +17,7 @@ const malt = @import("malt");
 const test_io = @import("test_io");
 const testing = std.testing;
 const install = malt.install;
+const install_record = malt.install_record;
 
 const c = struct {
     extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
@@ -382,8 +383,13 @@ test "--download-only --cask is plumbed into the cask path and threads the flag"
     // `--cask` + an unresolvable token → `fetchCask` errors. The
     // important assertion is that we DIDN'T short-circuit on the seeded
     // already-installed row — i.e., `--download-only` rerouted the flow
-    // through the download path.
-    install.execute(&ctx, arena.allocator(), &.{ "--download-only", "--cask", "ghost-cask" }) catch {};
+    // through the download path. The cask-dispatch failure now counts
+    // into `failed_count`, so the single-package run exits with
+    // PartialFailure.
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.execute(&ctx, arena.allocator(), &.{ "--download-only", "--cask", "ghost-cask" }),
+    );
 
     try testing.expect(std.mem.indexOf(u8, captured.items, "ghost-cask is already installed") == null);
     try testing.expect(std.mem.indexOf(u8, captured.items, "Cask 'ghost-cask' not found") != null);

--- a/tests/install_download_only_test.zig
+++ b/tests/install_download_only_test.zig
@@ -321,6 +321,45 @@ test "--download-only with multiple packages prints one resolved path per packag
     try testing.expect(std.mem.indexOf(u8, captured.items, want_b) != null);
 }
 
+test "--download-only with one cached + one 404 package exits PartialFailure" {
+    // Mixed --download-only: alpha is cache-warm + store-seeded so the
+    // pool short-circuits to success; zzbad is .404 so the dispatch loop
+    // counts the miss. Pre-fix the download-only early return ignored
+    // `failed_count` and exited 0 with a printed "Cask 'zzbad' not found"
+    // — the very antipattern T-049 was supposed to close.
+    const prefix = try setupPrefix("dlmix");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha_a = "33" ** 32;
+    try seedStoreBottle(prefix, sha_a, "alpha", "1.0");
+    var arena_json = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_json.deinit();
+    const a_json = try warmFormulaJson(arena_json.allocator(), "alpha", sha_a);
+    try seedFormulaCache(prefix, "alpha", a_json);
+
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{prefix});
+    defer testing.allocator.free(cache_api);
+    inline for (.{ "formula_zzbad.404", "cask_zzbad.404" }) |name| {
+        const p = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ cache_api, name });
+        defer testing.allocator.free(p);
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, p, .{ .truncate = true });
+        f.close(std.Options.debug_io);
+    }
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.execute(&ctx, arena.allocator(), &.{ "--download-only", "--quiet", "alpha", "zzbad" }),
+    );
+}
+
 test "--download-only --cask is plumbed into the cask path and threads the flag" {
     // The argv parser must accept `--download-only` alongside `--cask`,
     // and the per-package dispatcher must route the request through

--- a/tests/install_execute_test.zig
+++ b/tests/install_execute_test.zig
@@ -106,16 +106,18 @@ test "execute with --formula forces formula-only and errors on an unresolvable n
     defer _ = c.unsetenv("MALT_PREFIX");
 
     // `--formula` + an unknown name → fetchFormula fails → formula-only
-    // early-return without touching the cask path. No PartialFailure is
-    // raised for a single unknown name (the catch branch reports via
-    // output.err but doesn't queue any jobs, so the later all_jobs.len==0
-    // return fires first).
+    // dispatch path emits its error line and counts the failure. The
+    // single-package run exits with PartialFailure so the user-facing
+    // exit code mirrors the printed miss.
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
-    try install.execute(&ctx, arena.allocator(), &.{ "--formula", "--dry-run", "--quiet", "zz_nonexistent_formula_xyz" });
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.execute(&ctx, arena.allocator(), &.{ "--formula", "--dry-run", "--quiet", "zz_nonexistent_formula_xyz" }),
+    );
 }
 
 test "execute with a tap-formula-shaped name routes through the tap path in dry-run" {
@@ -126,15 +128,78 @@ test "execute with a tap-formula-shaped name routes through the tap path in dry-
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
 
-    // user/repo/formula triggers installTapFormula, which early-returns
-    // when the tap isn't cloned locally. No exception is raised; the error
-    // surfaces via output.err.
+    // user/repo/formula triggers installTapFormula, which fails when the
+    // tap isn't cloned locally. The dispatch loop counts the failure so
+    // a single-package run exits with PartialFailure.
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
-    try install.execute(&ctx, arena.allocator(), &.{ "--dry-run", "--quiet", "zzuser/zzrepo/zzformula" });
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.execute(&ctx, arena.allocator(), &.{ "--dry-run", "--quiet", "zzuser/zzrepo/zzformula" }),
+    );
+}
+
+test "execute with neither --formula nor --cask: 404 cache markers route through the cask fall-through and exit PartialFailure" {
+    // Default dispatch shape: `fetchFormula` 404s → cask fall-through →
+    // `installCask`'s `fetchCask` 404s too → both catches now count into
+    // `failed_count` so a single-package miss exits non-zero. The two
+    // `.404` markers keep the test offline-clean — no network roundtrip.
+    const prefix_z: [:0]const u8 = "/tmp/mcft";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
+    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{prefix_z});
+    defer testing.allocator.free(cache_api);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_api);
+    inline for (.{ "formula_zzcft.404", "cask_zzcft.404" }) |name| {
+        const p = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ cache_api, name });
+        defer testing.allocator.free(p);
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, p, .{ .truncate = true });
+        f.close(std.Options.debug_io);
+    }
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.execute(&ctx, arena.allocator(), &.{ "--quiet", "zzcft" }),
+    );
+}
+
+test "execute in offline mode with no cached snapshot exits PartialFailure on the typed OfflineRequired branch" {
+    // The OfflineRequired branch is a sibling of the cask fall-through:
+    // when `ctx.offline` is set and the formula isn't cached, the catch
+    // prints the snapshot-miss line *without* probing cask. T-049 counts
+    // that miss into `failed_count` so the exit code is non-zero.
+    const prefix_z: [:0]const u8 = "/tmp/mofl";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
+    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{
+        .io = threaded.io(),
+        .environ = .empty,
+        .offline = true,
+    };
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.execute(&ctx, arena.allocator(), &.{ "--quiet", "zzoffline" }),
+    );
 }
 
 test "execute --dry-run with an already-installed package short-circuits" {

--- a/tests/install_execute_test.zig
+++ b/tests/install_execute_test.zig
@@ -254,6 +254,101 @@ test "execute --dry-run with one cached + one 404 package exits PartialFailure" 
     );
 }
 
+test "Ctrl-C between pool and link sweeps !job.succeeded and exits PartialFailure" {
+    // L901 — the pre-link interrupt check. Pre-fix the warn line printed
+    // and execute() returned void even when pool workers left a job
+    // un-materialised. The arm seam flips the flag on the worker's
+    // first poll (poll 3 after L581 + iter 1 L588) so the worker exits
+    // before draining the queue, the pool joins with !job.succeeded,
+    // and the new sweep + gate surfaces PartialFailure.
+    const prefix_z: [:0]const u8 = "/tmp/mirq2";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
+    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Cache the formula so dispatch resolves (1 job lands in all_jobs)
+    // but DON'T seed the store, so the worker would have to fetch — the
+    // armed interrupt makes it exit instead, leaving !job.succeeded.
+    const json =
+        \\{"name":"alpha","full_name":"alpha","tap":"homebrew/core","desc":"","homepage":"",
+        \\ "versions":{"stable":"1.0"},"revision":0,"dependencies":[],"oldnames":[],
+        \\ "keg_only":false,"post_install_defined":false,
+        \\ "bottle":{"stable":{"root_url":"https://ghcr.io/v2/homebrew/core/alpha/blobs",
+        \\   "files":{
+        \\     "arm64_sequoia":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_sonoma":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_ventura":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_monterey":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "sequoia":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+        \\     "sonoma":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+        \\     "ventura":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+        \\     "monterey":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"}
+        \\   }}}}
+    ;
+    try seedFormulaCache(prefix_z, "alpha", json);
+
+    const prior_interrupted = malt.signals.isInterrupted();
+    defer malt.signals.setInterruptedForTest(prior_interrupted);
+    malt.signals.setInterruptedForTest(false);
+    // 3 polls: L581 → iter 1 L588 → worker's first poll flips the flag.
+    malt.signals.armInterruptAfterForTest(3);
+    defer malt.signals.armInterruptAfterForTest(0);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.execute(&ctx, arena.allocator(), &.{ "--quiet", "alpha" }),
+    );
+}
+
+test "Ctrl-C mid-resolution after a counted miss exits PartialFailure" {
+    // L588 — the in-resolution interrupt check. Pre-fix the warn line
+    // printed and execute() returned void even after the dispatch loop
+    // had counted a miss. The arm seam flips the flag on the 3rd poll
+    // so iter 1 dispatches (and fails) and iter 2's interrupt check
+    // fires the new gate.
+    const prefix_z: [:0]const u8 = "/tmp/mirq";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
+    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{prefix_z});
+    defer testing.allocator.free(cache_api);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_api);
+    inline for (.{ "formula_zzbad1.404", "cask_zzbad1.404", "formula_zzbad2.404", "cask_zzbad2.404" }) |name| {
+        const p = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ cache_api, name });
+        defer testing.allocator.free(p);
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, p, .{ .truncate = true });
+        f.close(std.Options.debug_io);
+    }
+
+    const prior_interrupted = malt.signals.isInterrupted();
+    defer malt.signals.setInterruptedForTest(prior_interrupted);
+    malt.signals.setInterruptedForTest(false);
+    // 3 polls until iter 2's L588: poll 1 (L581), poll 2 (iter 1 L588),
+    // poll 3 (iter 2 L588 — flips the flag).
+    malt.signals.armInterruptAfterForTest(3);
+    defer malt.signals.armInterruptAfterForTest(0);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.execute(&ctx, arena.allocator(), &.{ "--quiet", "zzbad1", "zzbad2" }),
+    );
+}
+
 test "execute --dry-run with an already-installed package short-circuits" {
     const prefix_z: [:0]const u8 = "/tmp/mi";
     test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};

--- a/tests/install_execute_test.zig
+++ b/tests/install_execute_test.zig
@@ -202,6 +202,58 @@ test "execute in offline mode with no cached snapshot exits PartialFailure on th
     );
 }
 
+test "execute --dry-run with one cached + one 404 package exits PartialFailure" {
+    // Mixed dry-run: `alpha` resolves from the seeded cache so a
+    // surviving job lands in `all_jobs`, while `zzbad` 404s and the
+    // dispatch loop counts the miss. Pre-fix the dry-run early return
+    // ignored `failed_count` and exited 0; the gate now mirrors the
+    // empty-list path so any planned-vs-failed mismatch surfaces.
+    const prefix_z: [:0]const u8 = "/tmp/mmix";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
+    const prefix: []const u8 = prefix_z;
+    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const json =
+        \\{"name":"alpha","full_name":"alpha","tap":"homebrew/core","desc":"","homepage":"",
+        \\ "versions":{"stable":"1.0"},"revision":0,"dependencies":[],"oldnames":[],
+        \\ "keg_only":false,"post_install_defined":false,
+        \\ "bottle":{"stable":{"root_url":"https://ghcr.io/v2/homebrew/core/alpha/blobs",
+        \\   "files":{
+        \\     "arm64_sequoia":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_sonoma":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_ventura":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "arm64_monterey":{"cellar":":any","url":"https://ghcr.io/v2/arm","sha256":"aa"},
+        \\     "sequoia":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+        \\     "sonoma":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+        \\     "ventura":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"},
+        \\     "monterey":{"cellar":":any","url":"https://ghcr.io/v2/x86","sha256":"xx"}
+        \\   }}}}
+    ;
+    try seedFormulaCache(prefix, "alpha", json);
+
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{prefix});
+    defer testing.allocator.free(cache_api);
+    inline for (.{ "formula_zzbad.404", "cask_zzbad.404" }) |name| {
+        const p = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ cache_api, name });
+        defer testing.allocator.free(p);
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, p, .{ .truncate = true });
+        f.close(std.Options.debug_io);
+    }
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.execute(&ctx, arena.allocator(), &.{ "--dry-run", "--quiet", "alpha", "zzbad" }),
+    );
+}
+
 test "execute --dry-run with an already-installed package short-circuits" {
     const prefix_z: [:0]const u8 = "/tmp/mi";
     test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};

--- a/tests/install_local_test.zig
+++ b/tests/install_local_test.zig
@@ -539,10 +539,10 @@ test "execute --local without a path operand exits cleanly (error.Aborted)" {
     );
 }
 
-test "execute --local with a missing file reports gracefully and continues" {
-    // installLocalFormula catches its own error and logs via output.err so
-    // execute() returns normally. The key invariant is that no panic
-    // escapes and no DB writes happen for a missing file.
+test "execute --local with a missing file exits with PartialFailure" {
+    // installLocalFormula catches its own error and logs via output.err.
+    // execute() counts the dispatch-time failure into `failed_count` so a
+    // single-package miss surfaces as a non-zero exit instead of silent 0.
     const prefix: [:0]const u8 = "/tmp/mlb";
     try setupPrefix(prefix);
     defer cleanupPrefix(prefix);
@@ -552,12 +552,16 @@ test "execute --local with a missing file reports gracefully and continues" {
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
-    try install.execute(&ctx, arena.allocator(), &.{ "--local", "--quiet", "/tmp/mlb_missing.rb" });
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.execute(&ctx, arena.allocator(), &.{ "--local", "--quiet", "/tmp/mlb_missing.rb" }),
+    );
 }
 
 test "execute --local with a non-.rb realpath is rejected before parse" {
     // Pass a real file whose basename does not end in .rb. The realpath
-    // + basename check rejects it cleanly.
+    // + basename check rejects it cleanly and the dispatcher surfaces the
+    // miss as PartialFailure.
     const prefix: [:0]const u8 = "/tmp/mlc";
     try setupPrefix(prefix);
     defer cleanupPrefix(prefix);
@@ -571,7 +575,10 @@ test "execute --local with a non-.rb realpath is rejected before parse" {
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
-    try install.execute(&ctx, arena.allocator(), &.{ "--local", "--quiet", rb_path });
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.execute(&ctx, arena.allocator(), &.{ "--local", "--quiet", rb_path }),
+    );
 }
 
 test "execute --local --dry-run with a valid .rb prints a plan" {
@@ -662,13 +669,17 @@ test "execute --local rejects a .rb whose archive URL is not https" {
 
     // Non-dry-run so the URL check is exercised (dry-run short-circuits
     // before the URL gate). installLocalFormula catches the returned
-    // InsecureArchiveUrl so execute() itself returns cleanly.
+    // InsecureArchiveUrl; the dispatch loop now counts the miss into
+    // `failed_count` so execute() exits with PartialFailure.
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
-    try install.execute(&ctx, arena.allocator(), &.{ "--local", "--quiet", rb_path });
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.execute(&ctx, arena.allocator(), &.{ "--local", "--quiet", rb_path }),
+    );
 }
 
 test "execute --local --dry-run accepts a cask DSL multi-arch fixture and reaches materialise" {
@@ -730,15 +741,18 @@ test "execute --local rejects a malformed .rb (missing version/url/sha256)" {
     defer testing.allocator.free(rb_path);
     try writeFile(rb_path, "class Broken < Formula\nend\n");
 
-    // installLocalFormula catches the error and reports via output.err;
-    // execute() itself returns normally so the batch install doesn't
-    // abort on one bad entry.
+    // installLocalFormula catches the error and reports via output.err.
+    // The dispatch loop counts the failure so a single-package run exits
+    // with PartialFailure instead of swallowing the miss.
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
-    try install.execute(&ctx, arena.allocator(), &.{ "--local", "--dry-run", "--quiet", rb_path });
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.execute(&ctx, arena.allocator(), &.{ "--local", "--dry-run", "--quiet", rb_path }),
+    );
 }
 
 // ─── Cross-command integration: uninstall/info/list on a local keg ──
@@ -838,5 +852,8 @@ test "execute --local rejects a directory path (not a regular file)" {
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
-    try install.execute(&ctx, arena.allocator(), &.{ "--local", "--dry-run", "--quiet", dir_path });
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.execute(&ctx, arena.allocator(), &.{ "--local", "--dry-run", "--quiet", dir_path }),
+    );
 }

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -546,9 +546,13 @@ test "installAll honours skip_lock so an outer holder can re-enter without a sel
     defer output.setQuiet(false);
 
     // skip_lock=true must bypass the per-fd flock entirely. The 404
-    // markers drain the resolution queue, so a clean return proves we
-    // never blocked on the lock.
-    try install.installAll(&ctx, testing.allocator, &.{"zzghost"}, .{ .skip_lock = true });
+    // markers force the formula→cask fall-through to fail, so the
+    // dispatcher surfaces PartialFailure — proving we reached resolution
+    // (i.e. never blocked on the lock) while exiting with the right code.
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.installAll(&ctx, testing.allocator, &.{"zzghost"}, .{ .skip_lock = true }),
+    );
 }
 
 // Regression: when the new bottle of an installed formula introduces a dep


### PR DESCRIPTION
## Description

`mt install` no longer mixes a printed error with exit 0. Every path in `executeWithOpts` that previously returned void after a counted miss now surfaces `PartialFailure`, mirroring the trailer the bottle phase has always used.

## Related Issue

- None

## Notes for Reviewers

- The user-visible change is the CLI exit-code contract for any single-package failure.