### PR TITLE
fix: opportunistic latent low-severity hardening

### DIFF
--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -301,6 +301,17 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             keg_names.items.len,
         );
 
+        // Enforce the SQLite-threadsafe contract the pool depends on
+        // (lock-free `isInstalled` reads vs `db_mu`-holding writers).
+        // Skip when only one worker will actually run — single-thread
+        // can't race.
+        if (worker_count >= 2) {
+            parallel_mod.ensureSerializedThreading() catch {
+                output.err("malt was built without SQLite serialized threading; parallel migrate disabled. Rebuild with -DSQLITE_THREADSAFE=1 or set MALT_MIGRATE_PARALLEL_WORKERS=1.", .{});
+                return error.Aborted;
+            };
+        }
+
         // Borrowed clients keep TLS contexts warm across kegs without
         // paying a fresh handshake per worker.
         var http_pool = client_mod.HttpClientPool.init(ctx.io, ctx.environ, allocator, @intCast(@max(worker_count, 1))) catch {

--- a/src/cli/migrate/parallel.zig
+++ b/src/cli/migrate/parallel.zig
@@ -18,6 +18,24 @@ const keg_mod = @import("keg.zig");
 const manifest_mod = @import("manifest.zig");
 const post_install_queue_mod = @import("post_install_queue.zig");
 
+/// Surfaced when the linked SQLite isn't in serialized threading mode.
+/// The pool's lock-free reads (`isInstalled` outside `db_mu`) rely on
+/// the build-time `-DSQLITE_THREADSAFE=1` flag; without it those reads
+/// would race the writers that hold `db_mu`.
+pub const ThreadsafeError = error{SqliteNotSerialized};
+
+/// Refuses to run when the linked SQLite isn't serialized. Defer to
+/// `ensureSerializedThreadingMode` so tests can exercise both branches
+/// without depending on a real SQLite link.
+pub fn ensureSerializedThreading() ThreadsafeError!void {
+    return ensureSerializedThreadingMode(sqlite.threadsafeMode());
+}
+
+/// Test seam over `ensureSerializedThreading` — same policy, injectable mode.
+pub fn ensureSerializedThreadingMode(mode: c_int) ThreadsafeError!void {
+    if (mode != 1) return error.SqliteNotSerialized;
+}
+
 /// 4 matches the install-side HTTP client pool; higher just queues on TLS contexts.
 pub const default_workers: u32 = 4;
 
@@ -198,6 +216,19 @@ pub fn run(allocator: std.mem.Allocator, pool: *Pool, worker_count: u32) !void {
 }
 
 // ── Inline unit tests ──────────────────────────────────────────────
+
+test "ensureSerializedThreadingMode passes on mode 1 (serialized)" {
+    try ensureSerializedThreadingMode(1);
+}
+
+test "ensureSerializedThreadingMode rejects single-thread (0) and multi-thread (2)" {
+    try std.testing.expectError(ThreadsafeError.SqliteNotSerialized, ensureSerializedThreadingMode(0));
+    try std.testing.expectError(ThreadsafeError.SqliteNotSerialized, ensureSerializedThreadingMode(2));
+}
+
+test "ensureSerializedThreading agrees with the linked SQLite (built with SQLITE_THREADSAFE=1)" {
+    try ensureSerializedThreading();
+}
 
 test "workerCountFromEnv returns default when env is null" {
     try std.testing.expectEqual(default_workers, workerCountFromEnv(null));

--- a/src/core/bottle.zig
+++ b/src/core/bottle.zig
@@ -119,7 +119,10 @@ pub fn download(
     var tmp_path_buf: [512]u8 = undefined;
     const tmp_path = try buildTmpArchivePath(&tmp_path_buf, dest_dir);
 
-    const tmp_file = std.Io.Dir.createFileAbsolute(io, tmp_path, .{}) catch return BottleError.IoError;
+    // `truncate = true` so a leftover tmp from a prior attempt (e.g. a
+    // shared-tmp caller or a future retry that reuses the same path)
+    // can't leak a longer tail into the extract step.
+    const tmp_file = std.Io.Dir.createFileAbsolute(io, tmp_path, .{ .truncate = true }) catch return BottleError.IoError;
     tmp_file.writeStreamingAll(io, body.items) catch {
         tmp_file.close(io);
         return BottleError.IoError;

--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -5,6 +5,7 @@
 
 const std = @import("std");
 const pins = @import("pins.zig");
+const hash_mod = @import("hash.zig");
 const http_client = @import("../net/client.zig");
 const api_mod = @import("../net/api.zig");
 const sandbox = @import("sandbox/macos.zig");
@@ -172,7 +173,10 @@ fn fetchPostInstallFromGitHubTagged(
 
     var actual_hex: [pins.sha256_hex_len]u8 = undefined;
     pins.sha256Hex(resp.body, &actual_hex);
-    if (!std.mem.eql(u8, actual_hex[0..], expected_hash)) return .fetch_failed;
+    // Constant-time compare matches every other SHA check in the install
+    // / bottle / verify path; no timing oracle today, but the consistency
+    // makes the spawn-audit guard's job easier.
+    if (!hash_mod.constantTimeEql(u8, actual_hex[0..], expected_hash)) return .fetch_failed;
 
     if (extractPostInstallFromSource(allocator, resp.body)) |body| {
         return .{ .body = body };

--- a/src/core/store.zig
+++ b/src/core/store.zig
@@ -29,11 +29,12 @@ pub const Store = struct {
     pub fn commitFrom(self: *Store, sha256: []const u8, src_path: ?[]const u8) StoreError!void {
         self.mutex.lockUncancelable(self.io);
         defer self.mutex.unlock(self.io);
-        const src = src_path orelse blk: {
-            var src_buf: [512]u8 = undefined;
-            break :blk std.fmt.bufPrint(&src_buf, "{s}/tmp/{s}", .{ self.prefix, sha256 }) catch return StoreError.OutOfMemory;
-        };
+        // src_buf must outlive any subsequent stack-buf write below — if a
+        // future optimizer overlays it with dst_buf, the rename target
+        // could be clobbered.
+        var src_buf: [512]u8 = undefined;
         var dst_buf: [512]u8 = undefined;
+        const src = src_path orelse std.fmt.bufPrint(&src_buf, "{s}/tmp/{s}", .{ self.prefix, sha256 }) catch return StoreError.OutOfMemory;
         const dst = std.fmt.bufPrint(&dst_buf, "{s}/store/{s}", .{ self.prefix, sha256 }) catch return StoreError.OutOfMemory;
 
         // Check if already committed (idempotent)

--- a/src/db/schema.zig
+++ b/src/db/schema.zig
@@ -241,17 +241,24 @@ fn migrateV3toV4(db: *sqlite.Database) sqlite.SqliteError!void {
     try db.commit();
 }
 
-/// Best-effort restore of FK enforcement after the v5 rebuild window.
-/// `defer` cannot return an error, so a silent `catch {}` would leave
-/// the connection running without FKs for the rest of its lifetime if
-/// the re-enable hit a transient SQLITE_BUSY. One retry covers that
-/// case; surfacing remaining failures via `std.log.warn` is the only
-/// recourse left.
-fn reenableForeignKeys(db: *sqlite.Database) void {
+/// Restore FK enforcement after the v5 rebuild. Retries once on a
+/// transient SQLITE_BUSY, then escalates: a connection that stays
+/// FK-off would silently turn `ON DELETE CASCADE` into a no-op for the
+/// rest of its lifetime. Use this on the success path so the migration
+/// fails loud rather than committing the table rebuild over a dirty
+/// connection.
+fn ensureForeignKeysOn(db: *sqlite.Database) sqlite.SqliteError!void {
     db.exec("PRAGMA foreign_keys=ON;") catch {
-        db.exec("PRAGMA foreign_keys=ON;") catch |err| {
-            std.log.warn("foreign_keys re-enable failed: {s}", .{@errorName(err)});
-        };
+        return db.exec("PRAGMA foreign_keys=ON;");
+    };
+}
+
+/// Error-unwind variant: `errdefer` can't propagate, so all we can do
+/// when the rebuild itself failed is log and move on. The caller is
+/// already returning an error to its own caller.
+fn bestEffortEnableForeignKeys(db: *sqlite.Database) void {
+    ensureForeignKeysOn(db) catch |err| {
+        std.log.warn("foreign_keys re-enable failed during error unwind: {s}", .{@errorName(err)});
     };
 }
 
@@ -292,7 +299,8 @@ fn migrateV4toV5(db: *sqlite.Database) sqlite.SqliteError!void {
     // DROP `kegs` without tripping `dependencies.keg_id` / `links.keg_id`;
     // the RENAME then rewrites those references at the new table.
     try db.exec("PRAGMA foreign_keys=OFF;");
-    defer reenableForeignKeys(db);
+    // Split safety net: best-effort on unwind, hard re-enable on success.
+    errdefer bestEffortEnableForeignKeys(db);
 
     try db.beginTransaction();
     errdefer db.rollback();
@@ -338,6 +346,11 @@ fn migrateV4toV5(db: *sqlite.Database) sqlite.SqliteError!void {
     }
 
     try db.commit();
+
+    // Success path: FK enforcement must come back on or the connection
+    // stays dirty for its lifetime — a partial re-enable would silently
+    // demote every later ON DELETE CASCADE to a no-op.
+    try ensureForeignKeysOn(db);
 }
 
 /// v6 — record the originating tap on every cask row so `mt upgrade`
@@ -481,6 +494,46 @@ pub fn currentVersion(db: *sqlite.Database) sqlite.SqliteError!i64 {
 }
 
 const testing = std.testing;
+
+fn foreignKeysOn(db: *sqlite.Database) !bool {
+    var stmt = try db.prepare("PRAGMA foreign_keys;");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    return stmt.columnInt(0) == 1;
+}
+
+test "ensureForeignKeysOn turns FKs on against a fresh connection" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+
+    try db.exec("PRAGMA foreign_keys=OFF;");
+    try testing.expect(!try foreignKeysOn(&db));
+
+    try ensureForeignKeysOn(&db);
+    try testing.expect(try foreignKeysOn(&db));
+}
+
+test "ensureForeignKeysOn is idempotent when FKs are already on" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+
+    try db.exec("PRAGMA foreign_keys=ON;");
+    try ensureForeignKeysOn(&db);
+    try ensureForeignKeysOn(&db);
+    try testing.expect(try foreignKeysOn(&db));
+}
+
+// Without the success-path hard re-enable, a SQLITE_BUSY storm during
+// the v5 commit window would leave the connection FK-off for the rest
+// of its lifetime — every later ON DELETE CASCADE would silently
+// no-op. This nails down the happy-path post-condition.
+test "migrate leaves PRAGMA foreign_keys ON after a successful v5 rebuild" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+
+    try initSchema(&db);
+    try testing.expect(try foreignKeysOn(&db));
+}
 
 // Regression: a Homebrew revision-bump upgrade ("1.9.2" → "1.9.2_2")
 // transiently coexists with the old row inside upgradeFormula's

--- a/src/db/sqlite.zig
+++ b/src/db/sqlite.zig
@@ -178,7 +178,19 @@ pub const Database = struct {
     }
 };
 
+/// Reports the linked SQLite's compile-time threading mode:
+///   0 = single-thread, 1 = serialized, 2 = multi-thread.
+/// Callers that spawn workers across the same handle rely on 1.
+pub fn threadsafeMode() c_int {
+    return c.sqlite3_threadsafe();
+}
+
 const testing = std.testing;
+
+test "threadsafeMode returns one of the three documented values" {
+    const m = threadsafeMode();
+    try testing.expect(m == 0 or m == 1 or m == 2);
+}
 
 test "errMsg returns the underlying SQLite error string after a failed exec" {
     var db = try Database.open(":memory:");

--- a/src/fs/clonefile.zig
+++ b/src/fs/clonefile.zig
@@ -61,25 +61,39 @@ pub fn copyTreeFallback(io: std.Io, allocator: std.mem.Allocator, src_path: []co
     var walker = src_dir.walk(allocator) catch return error.OutOfMemory;
     defer walker.deinit();
 
-    // Per-entry clone is opportunistic: any single-entry failure skips that
-    // path and continues the walk. Callers verify the final tree shape.
+    // Per-entry clone is best-effort: a single failure must not abort
+    // the walk (so callers still get most of the tree), but the first
+    // failure is captured and returned so a half-cloned keg can't be
+    // mistaken for a complete one.
+    var first_err: ?anyerror = null;
     while (walker.next(io) catch return error.AccessDenied) |entry| {
         switch (entry.kind) {
             .directory => {
-                dst_dir.createDirPath(io, entry.path) catch {};
+                dst_dir.createDirPath(io, entry.path) catch |err| captureFirst(&first_err, err);
             },
             .file => {
                 if (std.fs.path.dirname(entry.path)) |parent| {
-                    dst_dir.createDirPath(io, parent) catch {};
+                    dst_dir.createDirPath(io, parent) catch |err| captureFirst(&first_err, err);
                 }
-                std.Io.Dir.copyFile(entry.dir, entry.basename, dst_dir, entry.path, io, .{}) catch {};
+                std.Io.Dir.copyFile(entry.dir, entry.basename, dst_dir, entry.path, io, .{}) catch |err|
+                    captureFirst(&first_err, err);
             },
             .sym_link => {
                 var link_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
-                const n = std.Io.Dir.readLink(entry.dir, io, entry.basename, &link_buf) catch continue;
-                dst_dir.symLink(io, link_buf[0..n], entry.path, .{}) catch {};
+                const n = std.Io.Dir.readLink(entry.dir, io, entry.basename, &link_buf) catch |err| {
+                    captureFirst(&first_err, err);
+                    continue;
+                };
+                dst_dir.symLink(io, link_buf[0..n], entry.path, .{}) catch |err|
+                    captureFirst(&first_err, err);
             },
             else => {},
         }
     }
+
+    if (first_err) |e| return e;
+}
+
+fn captureFirst(slot: *?anyerror, err: anyerror) void {
+    if (slot.* == null) slot.* = err;
 }

--- a/tests/clonefile_test.zig
+++ b/tests/clonefile_test.zig
@@ -175,6 +175,45 @@ test "copyTreeFallback is idempotent when the destination already exists" {
     defer f.close(std.Options.debug_io);
 }
 
+// Before per-entry failure capture, a non-APFS materialise that lost
+// `inner/` (e.g. because the destination already had a regular file
+// there) returned success — the keg landed missing files and the
+// install pipeline relocated/re-signed over a partial tree. The
+// function now surfaces the first per-entry failure so callers can
+// treat partial copies as failure rather than silently proceeding.
+test "copyTreeFallback surfaces a per-entry failure as an error" {
+    const root = tmpRoot("fallback_partial");
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    try setupSourceTree(root);
+
+    var src_buf: [512]u8 = undefined;
+    const src = try std.fmt.bufPrint(&src_buf, "{s}/src", .{root});
+    var dst_buf: [512]u8 = undefined;
+    const dst = try std.fmt.bufPrint(&dst_buf, "{s}/dst_partial", .{root});
+
+    // Pre-stage dst so the walker's `inner/` directory entry collides
+    // with an existing regular file — createDirPath then fails on the
+    // file collision, and the prior best-effort behaviour would swallow
+    // it. The new code captures and returns it.
+    try test_io.makeDirAbsolute(std.Options.debug_io, dst);
+    var collision_buf: [512]u8 = undefined;
+    const collision = try std.fmt.bufPrint(&collision_buf, "{s}/inner", .{dst});
+    const cf = try test_io.cwd().createFile(std.Options.debug_io, collision, .{});
+    cf.close(std.Options.debug_io);
+
+    try testing.expectError(
+        error.NotDir,
+        clonefile.copyTreeFallback(std.Options.debug_io, testing.allocator, src, dst),
+    );
+
+    // The top-level non-colliding file should still have been copied —
+    // capture-and-continue preserves the partial-tree contract.
+    var top_buf: [512]u8 = undefined;
+    const top = try std.fmt.bufPrint(&top_buf, "{s}/hello.txt", .{dst});
+    const f = try test_io.cwd().openFile(std.Options.debug_io, top, .{});
+    f.close(std.Options.debug_io);
+}
+
 test "copyTreeFallback errors when source directory does not exist" {
     try testing.expectError(
         error.FileNotFound,

--- a/tests/store_test.zig
+++ b/tests/store_test.zig
@@ -61,6 +61,56 @@ test "commit moves directory to store and exists returns true" {
     try testing.expect(ctx.store.exists("abc123sha"));
 }
 
+test "commitFrom with null src renames from {prefix}/tmp/{sha}" {
+    var ctx = try setupTestStore(testing.allocator);
+    defer {
+        ctx.db.close();
+        test_io.deleteTreeAbsolute(std.Options.debug_io, ctx.prefix) catch {};
+        testing.allocator.free(ctx.prefix);
+    }
+
+    const sha = "default_src_sha";
+
+    const tmp_dir = try std.fmt.allocPrint(testing.allocator, "{s}/tmp", .{ctx.prefix});
+    defer testing.allocator.free(tmp_dir);
+    test_io.makeDirAbsolute(std.Options.debug_io, tmp_dir) catch {};
+
+    const default_src = try std.fmt.allocPrint(testing.allocator, "{s}/tmp/{s}", .{ ctx.prefix, sha });
+    defer testing.allocator.free(default_src);
+    test_io.makeDirAbsolute(std.Options.debug_io, default_src) catch {};
+
+    const marker = try std.fmt.allocPrint(testing.allocator, "{s}/marker.txt", .{default_src});
+    defer testing.allocator.free(marker);
+    const f = try test_io.createFileAbsolute(std.Options.debug_io, marker, .{});
+    try f.writeStreamingAll(std.Options.debug_io, "moved");
+    f.close(std.Options.debug_io);
+
+    try ctx.store.commitFrom(sha, null);
+
+    try testing.expect(ctx.store.exists(sha));
+    // The marker must have moved with the directory, not stayed behind.
+    const moved_marker = try std.fmt.allocPrint(testing.allocator, "{s}/store/{s}/marker.txt", .{ ctx.prefix, sha });
+    defer testing.allocator.free(moved_marker);
+    var probe = try test_io.openFileAbsolute(std.Options.debug_io, moved_marker, .{});
+    probe.close(std.Options.debug_io);
+}
+
+test "commitFrom with null src returns CommitFailed when default tmp path is missing" {
+    var ctx = try setupTestStore(testing.allocator);
+    defer {
+        ctx.db.close();
+        test_io.deleteTreeAbsolute(std.Options.debug_io, ctx.prefix) catch {};
+        testing.allocator.free(ctx.prefix);
+    }
+
+    // No {prefix}/tmp/{sha} on disk, no {prefix}/store/{sha} either —
+    // atomicRename surfaces the missing source as CommitFailed.
+    try testing.expectError(
+        store_mod.StoreError.CommitFailed,
+        ctx.store.commitFrom("missing_default_src_sha", null),
+    );
+}
+
 test "duplicate commit is idempotent" {
     var ctx = try setupTestStore(testing.allocator);
     defer {


### PR DESCRIPTION
## Description

User-reachable changes:

- `fs/clonefile` - non-APFS partial copies now surface the first per-entry failure instead of returning success over a half-cloned keg, so the install pipeline can no longer relocate and re-sign over a silently-incomplete tree.
- `db/schema` - the v4→v5 rebuild now fails the migration loud if FK enforcement can't be brought back on the connection after the rebuild commit. Previously a double `SQLITE_BUSY` left the live connection FK-off for the rest of its lifetime, silently demoting every later `ON DELETE CASCADE` to a no-op.

Preventive / consistency changes:

- `cli/migrate/parallel` - the parallel worker pool now refuses to start when SQLite isn't running in serialized threading mode, making explicit the build-time invariant the lock-free `isInstalled` probe already depended on.
- `core/store.commitFrom` - the tmp source path buffer is hoisted to function scope, so a future optimizer cannot legally overlay it with the destination buffer.
- `core/ruby_subprocess` - the pins-manifest SHA verification now goes through the shared constant-time helper, matching every other SHA compare in the install / bottle / verify path.
- `core/bottle.download` - the tmp archive is created with `truncate = true` so a future caller that reuses the same path cannot leak prior-attempt bytes into the extract step.

## Related Issue

- None

## Notes for Reviewers

- None