### PR TITLE
test: stabilize info_cli human-output assertions under TTY stderr

### DIFF
--- a/tests/info_cli_test.zig
+++ b/tests/info_cli_test.zig
@@ -14,6 +14,7 @@ const info = malt.cli_info;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
 const output = malt.output;
+const color = malt.color;
 
 const c = struct {
     extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
@@ -115,6 +116,10 @@ fn captureExecute(
     args: []const []const u8,
     tag: []const u8,
 ) ![]u8 {
+    // Pin color off so byte-level human assertions don't break when
+    // stderr is a TTY (e.g. under `kcov`).
+    color.setForTest(false, null);
+
     const ts = test_io.nanoTimestamp(std.Options.debug_io);
     const cap_path = try std.fmt.allocPrintSentinel(
         allocator,


### PR DESCRIPTION
## Description

Pin color off in `captureExecute` so ANSI escapes can't break byte-level substring matches when stderr is a TTY (e.g. under `just coverage` /   kcov launched from a real shell).

## Related Issue

- None

## Notes for Reviewers

- None
