### PR TITLE
ci: unblock release pipeline on macos-14 bash 3.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,10 +233,14 @@ jobs:
       - name: Verify cask paths resolve in tarball
         # Static cross-check: every `binary "..."` and `#{staged_path}/...`
         # declared by the rendered cask must exist under the extracted
-        # tarball root. Closes the gap that let #375 ship — a tarball
-        # that ran fine via install.sh but broke `brew install --cask`.
+        # tarball root. Closes the gap that let a prior release ship a
+        # tarball that ran fine via install.sh but broke `brew install --cask`.
         run: |
-          mapfile -t found < <(find /tmp/cask -type f -name '*.rb')
+          # macos-14's /bin/bash is 3.2; avoid bash 4+ builtins (mapfile).
+          found=()
+          while IFS= read -r line; do
+            [ -n "$line" ] && found+=("$line")
+          done < <(find /tmp/cask -type f -name '*.rb')
           if [ "${#found[@]}" -ne 1 ]; then
             echo "::error::expected exactly one .rb in cask artifact, got ${#found[@]}"
             printf '  %s\n' "${found[@]}" >&2


### PR DESCRIPTION
## Description

The "Verify cask paths resolve in tarball" step in `release.yml` (the new static cross-check added to close the cask-vs-tarball drift) used `mapfile -t found < <(...)`. `mapfile` is a bash 4+ builtin, and the `verify-artifacts` job runs on `macos-14`, whose default `/bin/bash` is still 3.2 — so the step exited 127 and the release pipeline stalled mid-flight: goreleaser had already uploaded the draft, but `publish-cask`, `release-notes`, and `install-smoke` never ran.

This PR replaces the `mapfile` call with a portable `while/read` loop that keeps a single `find` invocation and preserves the array-based error output. The pattern in `publish-cask` is left alone — it runs on `ubuntu-latest` where bash 4+ is default — but a comment now flags the bash-3.2/macOS constraint so the next person editing this step doesn't re-introduce it.

Value: future macOS releases finish, the cask paths get verified before the tap push, and `install-smoke` actually runs against the published artifacts.

## Related Issue

- None

## Notes for Reviewers

- None