### PR TITLE
chore(release): record ci fix in v0.14.0 changelog

### DIFF
--- a/.changes/v0.14.0.md
+++ b/.changes/v0.14.0.md
@@ -68,6 +68,10 @@ brew install --cask indaco/tap/malt
 
 - stabilize info_cli human-output assertions under TTY stderr ([4fee64c](https://github.com/indaco/malt/commit/4fee64c)) ([#391](https://github.com/indaco/malt/pull/391))
 
+### 🤖 CI
+
+- **ci:** unblock release pipeline on macos-14 bash 3.2 ([75493b0](https://github.com/indaco/malt/commit/75493b0)) ([#394](https://github.com/indaco/malt/pull/394))
+
 ### 🏡 Chores
 
 - **release:** cross-check cask binary paths against the tarball layout ([df61a3f](https://github.com/indaco/malt/commit/df61a3f)) ([#379](https://github.com/indaco/malt/pull/379))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@ brew install --cask indaco/tap/malt
 
 - stabilize info_cli human-output assertions under TTY stderr ([4fee64c](https://github.com/indaco/malt/commit/4fee64c)) ([#391](https://github.com/indaco/malt/pull/391))
 
+### 🤖 CI
+
+- **ci:** unblock release pipeline on macos-14 bash 3.2 ([75493b0](https://github.com/indaco/malt/commit/75493b0)) ([#394](https://github.com/indaco/malt/pull/394))
+
 ### 🏡 Chores
 
 - **release:** cross-check cask binary paths against the tarball layout ([df61a3f](https://github.com/indaco/malt/commit/df61a3f)) ([#379](https://github.com/indaco/malt/pull/379))


### PR DESCRIPTION
## Description

v0.14.0 will be retagged at main HEAD to incorporate the workflow fix that unblocked the release pipeline on macOS-14 (the previous tag pointed at a commit that predated the fix). This PR refreshes the v0.14.0 fragment and CHANGELOG so the published release notes accurately describe what ships in the artifacts.

## Related Issue

- None

## Notes for Reviewers

- None