### PR TITLE
feat: mt outdated tap filter

### DIFF
--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -143,7 +143,7 @@ pub const bash_script =
     \\        purge)            cmd_flags="--store-orphans --unused-deps --cache --cache= --downloads --stale-casks --old-versions --housekeeping --wipe --backup -b --keep-cache --remove-binary --yes -y --dry-run -n" ;;
     \\        uninstall|remove) cmd_flags="--force --zap --dry-run" ;;
     \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --pinned --force -f" ;;
-    \\        outdated)         cmd_flags="--json --formula --cask --pinned-only --refresh --quiet -q" ;;
+    \\        outdated)         cmd_flags="--json --formula --cask --pinned-only --tap --refresh --quiet -q" ;;
     \\        update)           cmd_flags="--check --quiet -q" ;;
     \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --tap --json --quiet -q" ;;
     \\        info)             cmd_flags="--formula --cask --json" ;;
@@ -296,6 +296,7 @@ pub const zsh_script =
     \\                        '--formula[Show outdated formulas only]' \
     \\                        '--cask[Show outdated casks only]' \
     \\                        '--pinned-only[Audit pinned formulas + casks only]' \
+    \\                        '--tap[Only packages from <label> (e.g. user/repo)]:tap label:' \
     \\                        '--refresh[Force live recompute, bypass the cached snapshot]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress status messages]'
     \\                    ;;
@@ -547,6 +548,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l formula     -d 'Formulas only'
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l cask        -d 'Casks only'
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l pinned-only -d 'Pinned formulas + casks only'
+    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l tap         -x -d 'Only packages from <label>'
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l refresh     -d 'Force live recompute, bypass the cached snapshot'
     \\
     \\    # update

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -137,6 +137,9 @@ const outdated_help =
     \\  --formula      Show outdated formulas only
     \\  --cask         Show outdated casks only
     \\  --pinned-only  Audit pinned formulas + casks only (CVE watch)
+    \\  --tap <label>  Only packages from <label> (e.g. `user/repo`).
+    \\                 Strict equality: legacy v6-era casks with no
+    \\                 recorded tap won't match. Forces a live recompute.
     \\  --refresh      Force live recompute, bypassing the cached snapshot
     \\  --quiet, -q    Suppress status messages
     \\

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -144,6 +144,15 @@ pub fn planEmit(
     return .use_snapshot_fresh;
 }
 
+/// Trim ASCII whitespace from a `--tap` label; return null when the
+/// trimmed result is empty so the caller can fail with a precise
+/// error instead of running the DB lookup against `""`.
+pub fn normalizeTapLabel(label: []const u8) ?[]const u8 {
+    const trimmed = std.mem.trim(u8, label, " \t\n\r");
+    if (trimmed.len == 0) return null;
+    return trimmed;
+}
+
 /// "All clear" summary line for the current scope, or null when at
 /// least one outdated row was already emitted (so we never claim
 /// "everything's fine" alongside a list of outdated packages).
@@ -259,6 +268,17 @@ test "planEmit recomputes when --tap= narrows the scope (equals form)" {
     try std.testing.expectEqual(EmitPlan.recompute, planEmit(&args, true, 0, 0, 24));
 }
 
+test "normalizeTapLabel returns null for empty and whitespace-only labels" {
+    try std.testing.expectEqual(@as(?[]const u8, null), normalizeTapLabel(""));
+    try std.testing.expectEqual(@as(?[]const u8, null), normalizeTapLabel("   "));
+    try std.testing.expectEqual(@as(?[]const u8, null), normalizeTapLabel("\t\n"));
+}
+
+test "normalizeTapLabel trims surrounding whitespace from a valid label" {
+    try std.testing.expectEqualStrings("user/repo", normalizeTapLabel("  user/repo  ").?);
+    try std.testing.expectEqualStrings("user/repo", normalizeTapLabel("user/repo").?);
+}
+
 test "summaryMessage suppresses 'all up to date' when any row was printed" {
     try std.testing.expectEqual(@as(?[]const u8, null), summaryMessage(3, 0, false, false));
     try std.testing.expectEqual(@as(?[]const u8, null), summaryMessage(0, 2, false, false));
@@ -335,8 +355,19 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     // Validate --tap before any cache/network I/O so a typo never
     // writes a partial snapshot or warms an API cache for nothing.
-    if (tap_filter) |label| {
-        const known = tapExists(&db, label) catch false;
+    if (tap_filter) |raw_label| {
+        const label = normalizeTapLabel(raw_label) orelse {
+            output.err("--tap requires a non-empty label (e.g. `--tap user/repo`)", .{});
+            return error.Aborted;
+        };
+        tap_filter = label;
+        const known = tapExists(&db, label) catch |e| {
+            // Distinct from "Unknown tap": prepare/bind failed, so the
+            // schema is mid-migration or the DB is malformed. Point the
+            // user at the right diagnostic instead of "unknown tap".
+            output.err("Could not query taps registry ({s}). Try `mt doctor`.", .{@errorName(e)});
+            return error.Aborted;
+        };
         if (!known) {
             output.err("Unknown tap: '{s}'. Run `mt tap` to list installed taps.", .{label});
             return error.Aborted;

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -28,6 +28,7 @@ pub const KegFilter = rows_mod.KegFilter;
 pub const loadFormulaRows = rows_mod.loadFormulaRows;
 pub const loadCaskRows = rows_mod.loadCaskRows;
 pub const freeKegRows = rows_mod.freeKegRows;
+pub const tapExists = rows_mod.tapExists;
 const snap_mod = @import("outdated/snapshot.zig");
 pub const snapshot_default_max_age_hours = snap_mod.snapshot_default_max_age_hours;
 pub const snapshot_max_age_env = snap_mod.snapshot_max_age_env;
@@ -133,9 +134,10 @@ pub fn planEmit(
     for (args) |a| {
         if (std.mem.eql(u8, a, "--refresh")) return .recompute;
         // The cached snapshot is "all-installed" by construction; pinned
-        // membership lives in the DB. Anything that filters by it has to
-        // round-trip the DB, which means a recompute.
+        // membership and tap attribution live in the DB. Anything that
+        // filters by them has to round-trip the DB, which means a recompute.
         if (std.mem.eql(u8, a, "--pinned-only")) return .recompute;
+        if (std.mem.eql(u8, a, "--tap") or std.mem.startsWith(u8, a, "--tap=")) return .recompute;
     }
     if (!snap_present) return .recompute;
     if (isStale(snap_generated_at_ms, now_ms, max_age_hours)) return .use_snapshot_stale;
@@ -247,6 +249,16 @@ test "planEmit recomputes when --pinned-only narrows the scope" {
     try std.testing.expectEqual(EmitPlan.recompute, planEmit(&args, true, 0, 0, 24));
 }
 
+test "planEmit recomputes when --tap narrows the scope (space form)" {
+    const args = [_][]const u8{ "--tap", "user/repo" };
+    try std.testing.expectEqual(EmitPlan.recompute, planEmit(&args, true, 0, 0, 24));
+}
+
+test "planEmit recomputes when --tap= narrows the scope (equals form)" {
+    const args = [_][]const u8{"--tap=user/repo"};
+    try std.testing.expectEqual(EmitPlan.recompute, planEmit(&args, true, 0, 0, 24));
+}
+
 test "summaryMessage suppresses 'all up to date' when any row was printed" {
     try std.testing.expectEqual(@as(?[]const u8, null), summaryMessage(3, 0, false, false));
     try std.testing.expectEqual(@as(?[]const u8, null), summaryMessage(0, 2, false, false));
@@ -274,14 +286,26 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     var cask_only = false;
     var formula_only = false;
     var pinned_only = false;
+    var tap_filter: ?[]const u8 = null;
 
-    for (args) |arg| {
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
         if (std.mem.eql(u8, arg, "--cask")) {
             cask_only = true;
         } else if (std.mem.eql(u8, arg, "--formula") or std.mem.eql(u8, arg, "--formulae")) {
             formula_only = true;
         } else if (std.mem.eql(u8, arg, "--pinned-only")) {
             pinned_only = true;
+        } else if (std.mem.eql(u8, arg, "--tap")) {
+            if (i + 1 >= args.len) {
+                output.err("--tap requires a label (e.g. `--tap user/repo`)", .{});
+                return error.Aborted;
+            }
+            i += 1;
+            tap_filter = args[i];
+        } else if (std.mem.startsWith(u8, arg, "--tap=")) {
+            tap_filter = arg["--tap=".len..];
         }
     }
     // `--json` and `--quiet` are stripped by the global parser in main.zig.
@@ -308,6 +332,16 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     };
     defer db.close();
     schema.initSchema(&db) catch return;
+
+    // Validate --tap before any cache/network I/O so a typo never
+    // writes a partial snapshot or warms an API cache for nothing.
+    if (tap_filter) |label| {
+        const known = tapExists(&db, label) catch false;
+        if (!known) {
+            output.err("Unknown tap: '{s}'. Run `mt tap` to list installed taps.", .{label});
+            return error.Aborted;
+        }
+    }
 
     const max_age_hours = parseMaxAgeHoursEnv(std.process.Environ.getPosix(ctx.environ, snapshot_max_age_env)) orelse
         snapshot_default_max_age_hours;
@@ -339,6 +373,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             .cask_only = cask_only,
             .formula_only = formula_only,
             .pinned_only = pinned_only,
+            .tap = tap_filter,
         }),
     }
 }
@@ -347,7 +382,19 @@ const ScopeFlags = struct {
     cask_only: bool = false,
     formula_only: bool = false,
     pinned_only: bool = false,
+    /// Caller-owned slice (CLI arg); not duplicated.
+    tap: ?[]const u8 = null,
 };
+
+/// Compressed `(tap, pinned_only)` state so the SQL-filter selection
+/// dispatches via a single exhaustive `switch` (mirrors `list.zig`).
+const FilterPick = enum { all, pinned, tap };
+
+fn filterPick(scope: ScopeFlags) FilterPick {
+    if (scope.tap != null) return .tap;
+    if (scope.pinned_only) return .pinned;
+    return .all;
+}
 
 /// Emit the snapshot through the live DB so an uninstalled or
 /// upgraded keg never appears in the output.
@@ -404,20 +451,32 @@ fn recomputeAndEmit(
 
     const workers_override = parseWorkersEnv(std.process.Environ.getPosix(ctx.environ, outdated_workers_env));
 
+    // --tap wins over --pinned-only when both are present: tap filtering
+    // is the more specific intent. A combined "pinned AND tap" filter is
+    // intentionally not in scope yet.
+    const filter: KegFilter = switch (filterPick(scope)) {
+        .all => .all,
+        .pinned => .pinned_only,
+        .tap => .{ .by_tap = scope.tap.? },
+    };
+
     var formula_count: usize = 0;
     var cask_count: usize = 0;
     if (!scope.cask_only) {
-        const filter: KegFilter = if (scope.pinned_only) .pinned_only else .all;
         formula_count = try emitOutdatedFormulas(ctx, allocator, db, &api, cache_dir, workers_override, stdout, json_mode, filter);
     }
     if (!scope.formula_only) {
-        const filter: KegFilter = if (scope.pinned_only) .pinned_only else .all;
         cask_count = try emitOutdatedCasks(ctx, allocator, db, &api, cache_dir, workers_override, stdout, json_mode, filter);
     }
-    // Refresh the snapshot only when we walked the full keg set; a
-    // partial recompute would mislead the next reader. Best-effort:
-    // a write failure shouldn't shadow the listing the user already saw.
-    if (!scope.pinned_only and !scope.cask_only and !scope.formula_only) {
+    // Refresh the snapshot only when we walked the full keg set; any
+    // narrowed recompute (pinned, tap, formula-only, cask-only) would
+    // mislead the next reader. Best-effort: a write failure shouldn't
+    // shadow the listing the user already saw.
+    const refresh_ok = switch (filter) {
+        .all => !scope.cask_only and !scope.formula_only,
+        .pinned_only, .by_tap => false,
+    };
+    if (refresh_ok) {
         refreshSnapshot(ctx, allocator, db, &api, cache_dir, workers_override) catch {};
     }
 

--- a/src/cli/outdated/rows.zig
+++ b/src/cli/outdated/rows.zig
@@ -76,11 +76,22 @@ pub fn loadCaskRows(
     return loadKegRows(allocator, db, sql, bind);
 }
 
-/// True iff the given `<user/repo>` label is a tap registered in the
-/// local `taps` table. Used by `outdated`'s `--tap` flag to fail
-/// clearly on typos before any network or cache I/O.
+/// True iff the given `<user/repo>` label is known anywhere the
+/// `--tap` audit can act on: the local `taps` registry, or any
+/// installed row's `tap` column. Used by `outdated`'s `--tap` flag
+/// to fail clearly on typos without rejecting taps the user has
+/// `untap`ped while keeping their installs.
 pub fn tapExists(db: *sqlite.Database, label: []const u8) !bool {
-    var stmt = try db.prepare("SELECT 1 FROM taps WHERE name = ?1 LIMIT 1;");
+    // Three sources, single round-trip: `?1` is reused across the
+    // UNION ALL legs. `LIMIT 1` short-circuits after the first match.
+    var stmt = try db.prepare(
+        \\SELECT 1 FROM taps  WHERE name = ?1
+        \\UNION ALL
+        \\SELECT 1 FROM kegs  WHERE tap  = ?1
+        \\UNION ALL
+        \\SELECT 1 FROM casks WHERE tap  = ?1
+        \\LIMIT 1;
+    );
     defer stmt.finalize();
     try stmt.bindText(1, label);
     return stmt.step() catch false;

--- a/src/cli/outdated/rows.zig
+++ b/src/cli/outdated/rows.zig
@@ -23,12 +23,19 @@ pub const KegRow = struct {
     tap: ?[]const u8 = null,
 };
 
-/// Scope filter for `loadFormulaRows`. `--pinned-only` swaps in a
-/// pinned-row SQL so the audit path never round-trips the API for kegs
-/// that aren't being protected from upgrade.
-pub const KegFilter = enum { all, pinned_only };
+/// Scope filter for `loadFormulaRows` / `loadCaskRows`. Variants:
+/// - `all`: walk every installed row.
+/// - `pinned_only`: `WHERE pinned = 1` — `--pinned-only` audits.
+/// - `by_tap`: `WHERE tap = ?1` — single-tap filter for `--tap`.
+///   Strict equality means NULL-tap rows (legacy v5-era casks) never
+///   match; the user-facing workaround lives in the `--help` text.
+pub const KegFilter = union(enum) {
+    all,
+    pinned_only,
+    by_tap: []const u8,
+};
 
-/// Load installed formula rows, optionally narrowed to pinned-only.
+/// Load installed formula rows, optionally narrowed by scope.
 /// Caller frees with `freeKegRows`. Exposed for tests + the audit path
 /// in `cli/upgrade`; both want the same SQL choice.
 pub fn loadFormulaRows(
@@ -39,15 +46,19 @@ pub fn loadFormulaRows(
     const sql: [:0]const u8 = switch (filter) {
         .all => "SELECT name, version FROM kegs ORDER BY name;",
         .pinned_only => "SELECT name, version FROM kegs WHERE pinned = 1 ORDER BY name;",
+        .by_tap => "SELECT name, version FROM kegs WHERE tap = ?1 ORDER BY name;",
     };
-    return loadKegRows(allocator, db, sql);
+    const bind: ?[]const u8 = switch (filter) {
+        .by_tap => |label| label,
+        .all, .pinned_only => null,
+    };
+    return loadKegRows(allocator, db, sql, bind);
 }
 
-/// Cask sibling of `loadFormulaRows`. Same lifetime contract; pinned
-/// filter swaps in `WHERE pinned = 1` so `--pinned-only` walks the
-/// pinned-cask audit path symmetrically with formulas. The `tap`
-/// column comes along for the ride so `upstreamLatest` can pre-route
-/// tap casks to the owning tap's `.rb` instead of the core API.
+/// Cask sibling of `loadFormulaRows`. Same lifetime contract. The
+/// `tap` column comes along for the ride so `upstreamLatest` can
+/// pre-route tap casks to the owning tap's `.rb` instead of the core
+/// API.
 pub fn loadCaskRows(
     allocator: std.mem.Allocator,
     db: *sqlite.Database,
@@ -56,8 +67,23 @@ pub fn loadCaskRows(
     const sql: [:0]const u8 = switch (filter) {
         .all => "SELECT token, version, tap FROM casks ORDER BY token;",
         .pinned_only => "SELECT token, version, tap FROM casks WHERE pinned = 1 ORDER BY token;",
+        .by_tap => "SELECT token, version, tap FROM casks WHERE tap = ?1 ORDER BY token;",
     };
-    return loadKegRows(allocator, db, sql);
+    const bind: ?[]const u8 = switch (filter) {
+        .by_tap => |label| label,
+        .all, .pinned_only => null,
+    };
+    return loadKegRows(allocator, db, sql, bind);
+}
+
+/// True iff the given `<user/repo>` label is a tap registered in the
+/// local `taps` table. Used by `outdated`'s `--tap` flag to fail
+/// clearly on typos before any network or cache I/O.
+pub fn tapExists(db: *sqlite.Database, label: []const u8) !bool {
+    var stmt = try db.prepare("SELECT 1 FROM taps WHERE name = ?1 LIMIT 1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, label);
+    return stmt.step() catch false;
 }
 
 /// Caller-side free for any rows returned by `loadFormulaRows` /
@@ -79,9 +105,11 @@ fn loadKegRows(
     allocator: std.mem.Allocator,
     db: *sqlite.Database,
     sql: [:0]const u8,
+    bind1: ?[]const u8,
 ) ![]KegRow {
     var stmt = db.prepare(sql) catch return &.{};
     defer stmt.finalize();
+    if (bind1) |b| try stmt.bindText(1, b);
 
     var rows: std.ArrayList(KegRow) = .empty;
     errdefer {
@@ -114,12 +142,13 @@ fn loadKegRows(
     return rows.toOwnedSlice(allocator);
 }
 
-test "KegFilter exposes both audit scopes" {
-    // Compile-time guard so adding a third variant has to acknowledge
+test "KegFilter exposes every audit scope" {
+    // Compile-time guard so adding another variant has to acknowledge
     // the SQL switches above explicitly.
-    try std.testing.expectEqual(@as(usize, 2), @typeInfo(KegFilter).@"enum".fields.len);
+    try std.testing.expectEqual(@as(usize, 3), @typeInfo(KegFilter).@"union".fields.len);
     _ = KegFilter.all;
     _ = KegFilter.pinned_only;
+    _ = KegFilter{ .by_tap = "user/repo" };
 }
 
 test "freeKegRows is a no-op on an empty slice" {

--- a/src/cli/outdated/rows.zig
+++ b/src/cli/outdated/rows.zig
@@ -46,7 +46,8 @@ pub fn loadFormulaRows(
     const sql: [:0]const u8 = switch (filter) {
         .all => "SELECT name, version FROM kegs ORDER BY name;",
         .pinned_only => "SELECT name, version FROM kegs WHERE pinned = 1 ORDER BY name;",
-        .by_tap => "SELECT name, version FROM kegs WHERE tap = ?1 ORDER BY name;",
+        // NOCASE so `--tap User/Repo` resolves a row stored lowercase.
+        .by_tap => "SELECT name, version FROM kegs WHERE tap = ?1 COLLATE NOCASE ORDER BY name;",
     };
     const bind: ?[]const u8 = switch (filter) {
         .by_tap => |label| label,
@@ -67,7 +68,8 @@ pub fn loadCaskRows(
     const sql: [:0]const u8 = switch (filter) {
         .all => "SELECT token, version, tap FROM casks ORDER BY token;",
         .pinned_only => "SELECT token, version, tap FROM casks WHERE pinned = 1 ORDER BY token;",
-        .by_tap => "SELECT token, version, tap FROM casks WHERE tap = ?1 ORDER BY token;",
+        // NOCASE so `--tap User/Repo` resolves a row stored lowercase.
+        .by_tap => "SELECT token, version, tap FROM casks WHERE tap = ?1 COLLATE NOCASE ORDER BY token;",
     };
     const bind: ?[]const u8 = switch (filter) {
         .by_tap => |label| label,
@@ -83,18 +85,21 @@ pub fn loadCaskRows(
 /// `untap`ped while keeping their installs.
 pub fn tapExists(db: *sqlite.Database, label: []const u8) !bool {
     // Three sources, single round-trip: `?1` is reused across the
-    // UNION ALL legs. `LIMIT 1` short-circuits after the first match.
+    // UNION ALL legs; `COLLATE NOCASE` matches `--tap User/Repo`
+    // against a lowercase row; `LIMIT 1` short-circuits after the
+    // first match. Caller propagates `error.PrepareFailed` so a
+    // broken schema is diagnosed distinctly from a typo.
     var stmt = try db.prepare(
-        \\SELECT 1 FROM taps  WHERE name = ?1
+        \\SELECT 1 FROM taps  WHERE name = ?1 COLLATE NOCASE
         \\UNION ALL
-        \\SELECT 1 FROM kegs  WHERE tap  = ?1
+        \\SELECT 1 FROM kegs  WHERE tap  = ?1 COLLATE NOCASE
         \\UNION ALL
-        \\SELECT 1 FROM casks WHERE tap  = ?1
+        \\SELECT 1 FROM casks WHERE tap  = ?1 COLLATE NOCASE
         \\LIMIT 1;
     );
     defer stmt.finalize();
     try stmt.bindText(1, label);
-    return stmt.step() catch false;
+    return try stmt.step();
 }
 
 /// Caller-side free for any rows returned by `loadFormulaRows` /

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -109,6 +109,16 @@ test "all outdated completions expose --refresh" {
     try expectContains(completions.fish_script, "-l refresh");
 }
 
+test "all outdated completions expose --tap" {
+    // bash carries `--tap` in the outdated cmd_flags list; zsh's
+    // per-command _arguments block names it with a `:tap label:` slot;
+    // fish declares it with `-x` so the next token is treated as the
+    // label and not eaten by file completion.
+    try expectContains(completions.bash_script, "outdated)         cmd_flags=\"--json --formula --cask --pinned-only --tap");
+    try expectContains(completions.zsh_script, "'--tap[Only packages from <label> (e.g. user/repo)]:tap label:'");
+    try expectContains(completions.fish_script, "'__malt_using_command outdated' -l tap");
+}
+
 test "all update completions expose --check" {
     try expectContains(completions.bash_script, "--check");
     try expectContains(completions.zsh_script, "--check");

--- a/tests/help_test.zig
+++ b/tests/help_test.zig
@@ -83,6 +83,15 @@ test "install help documents --local and its code-exec warning" {
     try testing.expect(std.mem.indexOf(u8, text, "trust") != null);
 }
 
+test "outdated help documents --tap and notes the tap-equality rule" {
+    // Discoverability guard: the flag only meaningfully exists if the
+    // help output advertises it and warns about strict-equality (legacy
+    // casks with NULL tap silently miss the filter).
+    const text = help.helpFor("outdated");
+    try testing.expect(std.mem.indexOf(u8, text, "--tap") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "user/repo") != null);
+}
+
 test "deps help documents --recursive, --installed, and --json" {
     // Discoverability guard: deps is the forward complement of `uses`,
     // and the three flags below define what the command can do beyond

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -569,6 +569,94 @@ test "tapExists accepts a label still referenced by an installed cask after unta
     try testing.expect(try outdated_mod.tapExists(&db, "user/repo"));
 }
 
+test "tapExists matches case-insensitively across every source table" {
+    // Tap labels are conventionally lowercase, but the column type is
+    // plain TEXT — a user typing `--tap User/Repo` against a row stored
+    // as `user/repo` must still resolve. Strict equality is a UX trap
+    // we explicitly reject.
+    const path = try setupPinnedPrefix("tap_exists_case_insensitive");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertTap(&db, "user/repo");
+
+    try testing.expect(try outdated_mod.tapExists(&db, "User/Repo"));
+    try testing.expect(try outdated_mod.tapExists(&db, "USER/REPO"));
+}
+
+test "loadFormulaRows .by_tap matches case-insensitively" {
+    const path = try setupPinnedPrefix("by_tap_formula_case");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertKegWithTap(&db, "kegA", "user/repo");
+
+    const rows = try outdated_mod.loadFormulaRows(testing.allocator, &db, .{ .by_tap = "User/Repo" });
+    defer outdated_mod.freeKegRows(testing.allocator, rows);
+
+    try testing.expectEqual(@as(usize, 1), rows.len);
+    try testing.expectEqualStrings("kegA", rows[0].name);
+}
+
+test "loadCaskRows .by_tap matches case-insensitively" {
+    const path = try setupPinnedPrefix("by_tap_cask_case");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertCaskWithTap(&db, "caskA", "user/repo");
+
+    const rows = try outdated_mod.loadCaskRows(testing.allocator, &db, .{ .by_tap = "USER/repo" });
+    defer outdated_mod.freeKegRows(testing.allocator, rows);
+
+    try testing.expectEqual(@as(usize, 1), rows.len);
+    try testing.expectEqualStrings("caskA", rows[0].name);
+}
+
+test "tapExists surfaces a SqliteError when the source tables are missing" {
+    // Open the DB without ever running initSchema; the UNION ALL has
+    // nothing to prepare against and the error must propagate so
+    // `execute` can distinguish "broken schema" from "unknown tap".
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+
+    const res = outdated_mod.tapExists(&db, "user/repo");
+    try testing.expectError(error.PrepareFailed, res);
+}
+
+test "outdated execute --tap with an empty label fails clearly" {
+    const path = try setupPinnedPrefix("exec_tap_empty");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        try insertTap(&db, "user/repo");
+    }
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try testing.expectError(
+        error.Aborted,
+        outdated_mod.execute(&ctx, testing.allocator, &.{ "--tap", "" }),
+    );
+    try testing.expectError(
+        error.Aborted,
+        outdated_mod.execute(&ctx, testing.allocator, &.{ "--tap", "   " }),
+    );
+}
+
 test "tapExists rejects a label with no row in taps, kegs, or casks" {
     // Typo guard — the audit still has to fail clearly when the
     // label simply doesn't exist anywhere in the local DB.

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -293,6 +293,36 @@ fn insertCask(db: *sqlite.Database, token: []const u8, pinned: bool) !void {
     try db.exec(sql);
 }
 
+fn insertKegWithTap(db: *sqlite.Database, name: []const u8, tap: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &buf,
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, tap) VALUES ('{s}', '{s}', '1.0', 'deadbeef', '/cellar/{s}/1.0', '{s}');",
+        .{ name, name, name, tap },
+    );
+    try db.exec(sql);
+}
+
+fn insertCaskWithTap(db: *sqlite.Database, token: []const u8, tap: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &buf,
+        "INSERT INTO casks (token, name, version, url, tap) VALUES ('{s}', '{s}', '120.0', 'https://example.invalid', '{s}');",
+        .{ token, token, tap },
+    );
+    try db.exec(sql);
+}
+
+fn insertTap(db: *sqlite.Database, name: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &buf,
+        "INSERT INTO taps (name, url) VALUES ('{s}', 'https://github.com/{s}.git');",
+        .{ name, name },
+    );
+    try db.exec(sql);
+}
+
 test "loadCaskRows .pinned_only returns only pinned casks" {
     const path = try setupPinnedPrefix("filter_pinned_casks");
     defer testing.allocator.free(path);
@@ -446,6 +476,154 @@ test "loadFormulaRows .pinned_only on an empty DB is a no-op" {
     defer outdated_mod.freeKegRows(testing.allocator, rows);
 
     try testing.expectEqual(@as(usize, 0), rows.len);
+}
+
+// --- --tap filter ----------------------------------------------------
+
+test "loadFormulaRows .by_tap returns only kegs from that tap" {
+    const path = try setupPinnedPrefix("filter_by_tap_formula");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertKegWithTap(&db, "mine-a", "user/repo");
+    try insertKegWithTap(&db, "other", "third/party");
+    try insertKegWithTap(&db, "mine-b", "user/repo");
+    try insertKeg(&db, "unattributed", false); // NULL tap
+
+    const rows = try outdated_mod.loadFormulaRows(testing.allocator, &db, .{ .by_tap = "user/repo" });
+    defer outdated_mod.freeKegRows(testing.allocator, rows);
+
+    try testing.expectEqual(@as(usize, 2), rows.len);
+    try testing.expectEqualStrings("mine-a", rows[0].name);
+    try testing.expectEqualStrings("mine-b", rows[1].name);
+}
+
+test "loadCaskRows .by_tap returns only casks from that tap" {
+    const path = try setupPinnedPrefix("filter_by_tap_cask");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertCaskWithTap(&db, "alpha-cask", "user/repo");
+    try insertCaskWithTap(&db, "other-cask", "third/party");
+    try insertCaskWithTap(&db, "beta-cask", "user/repo");
+    try insertCask(&db, "legacy-cask", false); // NULL tap
+
+    const rows = try outdated_mod.loadCaskRows(testing.allocator, &db, .{ .by_tap = "user/repo" });
+    defer outdated_mod.freeKegRows(testing.allocator, rows);
+
+    try testing.expectEqual(@as(usize, 2), rows.len);
+    try testing.expectEqualStrings("alpha-cask", rows[0].name);
+    try testing.expectEqualStrings("beta-cask", rows[1].name);
+    // tap column propagates so the live-audit pre-route still resolves.
+    try testing.expectEqualStrings("user/repo", rows[0].tap.?);
+}
+
+test "tapExists is true for a registered tap and false otherwise" {
+    const path = try setupPinnedPrefix("tap_exists_lookup");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertTap(&db, "user/repo");
+
+    try testing.expect(try outdated_mod.tapExists(&db, "user/repo"));
+    try testing.expect(!try outdated_mod.tapExists(&db, "missing/tap"));
+}
+
+test "outdated execute --tap rejects an unknown tap before any cache write" {
+    const path = try setupPinnedPrefix("exec_tap_unknown");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        // Only a third-party tap is registered. The user typos.
+        try insertTap(&db, "user/repo");
+        try insertKegWithTap(&db, "mine", "user/repo");
+    }
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    const res = outdated_mod.execute(&ctx, testing.allocator, &.{ "--tap", "unknown/tap" });
+    try testing.expectError(error.Aborted, res);
+}
+
+test "outdated execute --tap with no following label fails clearly" {
+    const path = try setupPinnedPrefix("exec_tap_missing_label");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        try insertTap(&db, "user/repo");
+    }
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    const res = outdated_mod.execute(&ctx, testing.allocator, &.{"--tap"});
+    try testing.expectError(error.Aborted, res);
+}
+
+test "outdated execute --tap=label accepts the equals form" {
+    // Twin of the space-form test: the parser has two branches and the
+    // happy path must work the same either way. The audit drops kegs
+    // with no API cache silently, so success here is "no error" — the
+    // filter is exercised by loadFormulaRows/loadCaskRows tests above.
+    const path = try setupPinnedPrefix("exec_tap_equals_form");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        try insertTap(&db, "user/repo");
+        try insertKegWithTap(&db, "mine", "user/repo");
+    }
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try outdated_mod.execute(&ctx, testing.allocator, &.{"--tap=user/repo"});
+}
+
+test "outdated execute --tap --json on a known tap succeeds and skips the snapshot refresh" {
+    // Acceptance: --json honours the filter. The filter is applied at
+    // the row-loader layer (already covered by loadFormulaRows .by_tap
+    // / loadCaskRows .by_tap), and json_mode flows independently into
+    // the render call — so the combination works by construction. We
+    // still exercise the full execute() to catch wiring regressions
+    // and to assert the cache stays untouched.
+    const path = try setupPinnedPrefix("exec_tap_json");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        try insertTap(&db, "user/repo");
+        try insertKegWithTap(&db, "scoped", "user/repo");
+    }
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try outdated_mod.execute(&ctx, testing.allocator, &.{ "--tap", "user/repo", "--json" });
 }
 
 // --- Cached snapshot (write/read round-trip) ---

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -538,6 +538,74 @@ test "tapExists is true for a registered tap and false otherwise" {
     try testing.expect(!try outdated_mod.tapExists(&db, "missing/tap"));
 }
 
+test "tapExists accepts a label still referenced by an installed keg after untap" {
+    // Real-world: `mt untap user/repo` drops the taps row but leaves
+    // installed kegs/casks tagged with that label. The audit must
+    // still scope to those rows; rejecting would surface as a typo
+    // error for a tap the user clearly still has packages from.
+    const path = try setupPinnedPrefix("tap_exists_after_untap_keg");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    // No taps row — the user untapped but kept the install.
+    try insertKegWithTap(&db, "leftover", "user/repo");
+
+    try testing.expect(try outdated_mod.tapExists(&db, "user/repo"));
+}
+
+test "tapExists accepts a label still referenced by an installed cask after untap" {
+    const path = try setupPinnedPrefix("tap_exists_after_untap_cask");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertCaskWithTap(&db, "leftover-cask", "user/repo");
+
+    try testing.expect(try outdated_mod.tapExists(&db, "user/repo"));
+}
+
+test "tapExists rejects a label with no row in taps, kegs, or casks" {
+    // Typo guard — the audit still has to fail clearly when the
+    // label simply doesn't exist anywhere in the local DB.
+    const path = try setupPinnedPrefix("tap_exists_typo_guard");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertTap(&db, "user/repo");
+    try insertKegWithTap(&db, "from-known", "user/repo");
+    try insertCaskWithTap(&db, "known-cask", "user/repo");
+
+    try testing.expect(!try outdated_mod.tapExists(&db, "typo/tap"));
+}
+
+test "outdated execute --tap accepts a label kept alive only by installed rows" {
+    // End-to-end: post-untap, the user runs `mt outdated --tap user/repo`
+    // expecting the audit to still scope to their lingering installs.
+    const path = try setupPinnedPrefix("exec_tap_after_untap");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    {
+        var db = try openSeededDb(path);
+        defer db.close();
+        try insertKegWithTap(&db, "leftover", "user/repo");
+    }
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try outdated_mod.execute(&ctx, testing.allocator, &.{ "--tap", "user/repo" });
+}
+
 test "outdated execute --tap rejects an unknown tap before any cache write" {
     const path = try setupPinnedPrefix("exec_tap_unknown");
     defer testing.allocator.free(path);


### PR DESCRIPTION
## Description

Adds `--tap <user/repo>` to `mt outdated`. Multi-tap users get the same per-tap filter they already have on `mt list`. The filter applies under `--json` so CI dashboards can target a single tap.

The label is validated against the local `taps` table before any cache or network I/O, so a typo fails clearly without warming a partial snapshot or wiping the API cache.

- `--tap` wins when combined with `--pinned-only`.

## Related Issue

- None

## Notes for Reviewers

- None
