### PR TITLE
feat(cli): add mt reinstall <pkg> as a first-class verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Usage: malt <command> [options] [arguments]
 
 Commands:
   install       Install formulas, casks, or tap formulas
+  reinstall     Wipe and re-materialise an installed package
   uninstall     Remove installed packages
   upgrade       Upgrade installed packages
   update        Refresh metadata cache
@@ -247,6 +248,8 @@ mt install --dry-run jq                  # preview without installing
 ```
 
 Other flags: `--force` (overwrite existing), `--use-system-ruby[=<name>,…]` (delegate `post_install` to system Ruby, sandboxed, per-formula), `--quiet`/`-q`, `--json`.
+
+`mt reinstall <pkg>` is the discoverable peer of `mt install --force`. It looks the package up in the DB, refuses cleanly if it isn't installed, and otherwise forwards through the shared install pipeline with `--force` so the existing keg or cask is wiped and re-materialised. Reinstall is package-scoped — transitive dependencies are not reinstalled. Global flags (`--json`, `--quiet`, `--dry-run`) pass through unchanged.
 
 `mt run <pkg> -- <args...>` runs a binary without a permanent install. Useful for one-off invocations:
 

--- a/build.zig
+++ b/build.zig
@@ -174,6 +174,7 @@ pub fn build(b: *std.Build) void {
         "tests/install_ambiguity_test.zig",
         "tests/install_download_only_test.zig",
         "tests/install_idempotent_test.zig",
+        "tests/reinstall_test.zig",
         "tests/no_readall_in_loop_test.zig",
         "tests/test_io_primitives_test.zig",
         "tests/no_io_mod_in_src_test.zig",

--- a/scripts/smokes/smoke_test.sh
+++ b/scripts/smokes/smoke_test.sh
@@ -154,7 +154,7 @@ else
 fi
 
 # Per-command --help on everything documented.
-for cmd in install uninstall upgrade update outdated list info search uses deps which \
+for cmd in install reinstall uninstall upgrade update outdated list info search uses deps which \
   doctor purge cleanup tap untap migrate backup restore services bundle \
   rollback run link unlink pin unpin version completions shellenv; do
   run_ok "t1.help.$cmd" -- "$MT_BIN" "$cmd" --help

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -87,7 +87,7 @@ pub const bash_script =
     \\    words=("${COMP_WORDS[@]}")
     \\    cword=$COMP_CWORD
     \\
-    \\    local commands="install uninstall remove upgrade update outdated list ls info search uses deps which doctor tap untap migrate rollback link unlink pin unpin run version completions shellenv backup restore purge cleanup services bundle help"
+    \\    local commands="install reinstall uninstall remove upgrade update outdated list ls info search uses deps which doctor tap untap migrate rollback link unlink pin unpin run version completions shellenv backup restore purge cleanup services bundle help"
     \\    local global_flags="--verbose -v --quiet -q --json --output-format=ndjson --dry-run --offline --help -h --version"
     \\
     \\    # Find the first non-flag word after the program — that's the subcommand.
@@ -138,6 +138,7 @@ pub const bash_script =
     \\    local cmd_flags=""
     \\    case "$cmd" in
     \\        install)          cmd_flags="--cask --formula --local --dry-run --force --download-only --only-dependencies --quiet -q --json" ;;
+    \\        reinstall)        cmd_flags="--cask --dry-run --quiet -q --json" ;;
     \\        backup)           cmd_flags="--output -o --versions --quiet -q" ;;
     \\        restore)          cmd_flags="--dry-run --force --quiet -q" ;;
     \\        purge)            cmd_flags="--store-orphans --unused-deps --cache --cache= --downloads --stale-casks --old-versions --housekeeping --wipe --backup -b --keep-cache --remove-binary --yes -y --dry-run -n" ;;
@@ -195,6 +196,7 @@ pub const zsh_script =
     \\
     \\    commands=(
     \\        'install:Install formulas, casks, or tap formulas'
+    \\        'reinstall:Wipe and re-materialise an installed package'
     \\        'uninstall:Remove installed packages'
     \\        'remove:Remove installed packages (alias for uninstall)'
     \\        'upgrade:Upgrade installed packages'
@@ -256,6 +258,14 @@ pub const zsh_script =
     \\                        '--force[Overwrite existing installations]' \
     \\                        '--download-only[Warm the bottle, cask, or tap-archive cache; skip install]' \
     \\                        '--only-dependencies[Install transitive deps, skip the requested package]' \
+    \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
+    \\                        '--json[Output result as JSON]' \
+    \\                        '*::package:'
+    \\                    ;;
+    \\                reinstall)
+    \\                    _arguments \
+    \\                        '--cask[Force cask path (auto-detected from the DB)]' \
+    \\                        '--dry-run[Show what would be reinstalled]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
     \\                        '--json[Output result as JSON]' \
     \\                        '*::package:'
@@ -484,6 +494,7 @@ pub const fish_script =
     \\
     \\    # Subcommands
     \\    complete -c $__malt_bin -n __malt_needs_command -a install     -d 'Install formulas, casks, or tap formulas'
+    \\    complete -c $__malt_bin -n __malt_needs_command -a reinstall   -d 'Wipe and re-materialise an installed package'
     \\    complete -c $__malt_bin -n __malt_needs_command -a uninstall   -d 'Remove installed packages'
     \\    complete -c $__malt_bin -n __malt_needs_command -a remove      -d 'Remove installed packages (alias)'
     \\    complete -c $__malt_bin -n __malt_needs_command -a upgrade     -d 'Upgrade installed packages'
@@ -526,6 +537,11 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l download-only -d 'Warm the bottle, cask, or tap-archive cache; skip install'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l only-dependencies -d 'Install transitive deps; skip the requested package'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l json    -d 'JSON output'
+    \\
+    \\    # reinstall
+    \\    complete -c $__malt_bin -n '__malt_using_command reinstall' -l cask    -d 'Force cask path (auto-detected from the DB)'
+    \\    complete -c $__malt_bin -n '__malt_using_command reinstall' -l dry-run -d 'Preview'
+    \\    complete -c $__malt_bin -n '__malt_using_command reinstall' -l json    -d 'JSON output'
     \\
     \\    # uninstall / remove
     \\    complete -c $__malt_bin -n '__malt_using_command uninstall' -l force   -d 'Remove even if depended on'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -22,6 +22,7 @@ pub fn showIfRequested(ctx: *const AppCtx, args: []const []const u8, command: []
 pub fn helpFor(command: []const u8) []const u8 {
     const map = std.StaticStringMap([]const u8).initComptime(.{
         .{ "install", install_help },
+        .{ "reinstall", reinstall_help },
         .{ "uninstall", uninstall_help },
         .{ "upgrade", upgrade_help },
         .{ "update", update_help },
@@ -84,6 +85,31 @@ const install_help =
     \\                     package; use =<name>,... to scope when installing multiple.
     \\  --quiet, -q        Suppress non-error output
     \\  --json             Output result as JSON
+    \\
+;
+
+const reinstall_help =
+    \\Usage: malt reinstall <package> [flags]
+    \\
+    \\Wipe and re-materialise an already-installed package through the
+    \\shared install pipeline. The discoverable peer of `malt install
+    \\--force`; lets you fix a corrupted Cellar entry or re-run the
+    \\install protocol without retyping the --force flag.
+    \\
+    \\Reinstall is package-scoped — transitive dependencies are NOT
+    \\reinstalled. To rebuild a dep, name it explicitly.
+    \\
+    \\Flags pass through to `install`; the common ones:
+    \\  --cask               Force cask path (auto-detected from the DB row)
+    \\  --dry-run            Show what would be reinstalled
+    \\  --quiet, -q          Suppress non-error output
+    \\  --json               JSON output (mirrors `mt install --json`)
+    \\  --output-format=ndjson
+    \\                       Stream one event per state transition
+    \\
+    \\Examples:
+    \\  malt reinstall wget
+    \\  malt reinstall --cask firefox
     \\
 ;
 

--- a/src/cli/reinstall.zig
+++ b/src/cli/reinstall.zig
@@ -1,0 +1,174 @@
+//! malt — reinstall command.
+//! Thin shim over the install pipeline. Refuses when the named package
+//! isn't installed; otherwise prepends `--force` and forwards argv into
+//! `install.execute`. Mirrors the `cleanup → purge` shape so global
+//! flags (`--json`, `--quiet`, `--dry-run`) reach the downstream parser
+//! untouched. Package-scoped — transitive deps are not reinstalled.
+
+const std = @import("std");
+
+const AppCtx = @import("../app_ctx.zig").AppCtx;
+const sqlite = @import("../db/sqlite.zig");
+const schema = @import("../db/schema.zig");
+const atomic = @import("../fs/atomic.zig");
+const output = @import("../ui/output.zig");
+const help = @import("help.zig");
+const install = @import("install.zig");
+
+/// First positional that doesn't look like a flag is the package name.
+/// Multiple positionals are tolerated to match `mt install`'s shape,
+/// but the install dispatch arm only refuses on the install side if
+/// anything is actually broken — we just need the first name to drive
+/// the "is this installed?" lookup.
+fn firstPositional(args: []const []const u8) ?[]const u8 {
+    for (args) |a| {
+        if (a.len > 0 and a[0] != '-') return a;
+    }
+    return null;
+}
+
+const Presence = enum { keg, cask, missing };
+
+/// Single source of truth for "is this package installed?" — keeps the
+/// reinstall dispatch arm aligned with the install pipeline's keg /
+/// cask split. Empty `name` short-circuits to `.missing` so the SQL
+/// layer never sees an empty bind parameter on a guarded code path.
+pub fn classify(db: *sqlite.Database, name: []const u8) Presence {
+    if (name.len == 0) return .missing;
+    {
+        var stmt = db.prepare("SELECT 1 FROM kegs WHERE name = ?1 LIMIT 1;") catch return .missing;
+        defer stmt.finalize();
+        stmt.bindText(1, name) catch return .missing;
+        if (stmt.step() catch false) return .keg;
+    }
+    {
+        var stmt = db.prepare("SELECT 1 FROM casks WHERE token = ?1 LIMIT 1;") catch return .missing;
+        defer stmt.finalize();
+        stmt.bindText(1, name) catch return .missing;
+        if (stmt.step() catch false) return .cask;
+    }
+    return .missing;
+}
+
+pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
+    if (help.showIfRequested(ctx, args, "reinstall")) return;
+
+    const name = firstPositional(args) orelse {
+        output.err("Usage: mt reinstall <package>", .{});
+        return error.Aborted;
+    };
+
+    const prefix = atomic.maltPrefixOrAbort();
+
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch
+        return error.Aborted;
+
+    // No DB file means nothing was ever installed under this prefix —
+    // collapse to the same `not installed` line so the user sees a
+    // single verb response, not a stack of plumbing errors.
+    std.Io.Dir.accessAbsolute(ctx.io, db_path, .{}) catch {
+        output.err("{s} is not installed", .{name});
+        return error.Aborted;
+    };
+
+    const presence = blk: {
+        var db = sqlite.Database.open(db_path) catch {
+            output.err("Failed to open database", .{});
+            return error.Aborted;
+        };
+        defer db.close();
+        schema.initSchema(&db) catch return error.Aborted;
+        break :blk classify(&db, name);
+    };
+
+    // Forward argv with `--force` prepended; add `--cask` only for the
+    // cask branch so the install dispatch routes without the user
+    // having to retype it. Exhaustive switch pins all three Presence
+    // variants — a future addition fails the build here.
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(allocator);
+    try argv.ensureTotalCapacity(allocator, args.len + 2);
+    switch (presence) {
+        .missing => {
+            output.err("{s} is not installed", .{name});
+            return error.Aborted;
+        },
+        .keg => argv.appendAssumeCapacity("--force"),
+        .cask => {
+            argv.appendAssumeCapacity("--force");
+            argv.appendAssumeCapacity("--cask");
+        },
+    }
+    argv.appendSliceAssumeCapacity(args);
+    return install.execute(ctx, allocator, argv.items);
+}
+
+const testing = std.testing;
+
+test "firstPositional skips flags and returns the first non-flag arg" {
+    try testing.expectEqualStrings("wget", firstPositional(&.{ "--force", "wget" }).?);
+    try testing.expectEqualStrings("firefox", firstPositional(&.{ "--cask", "--quiet", "firefox" }).?);
+}
+
+test "firstPositional returns null when only flags are present" {
+    try testing.expect(firstPositional(&.{ "--force", "--quiet" }) == null);
+    try testing.expect(firstPositional(&.{}) == null);
+}
+
+test "classify returns .missing for an empty DB" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try testing.expectEqual(Presence.missing, classify(&db, "wget"));
+}
+
+test "classify returns .missing for an empty name without binding to SQLite" {
+    // Defensive: an empty positional that slips past `firstPositional`
+    // would otherwise bind to "" against `name = ?1`; collapse early
+    // so the SQL layer never sees the malformed query.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try testing.expectEqual(Presence.missing, classify(&db, ""));
+}
+
+test "classify finds an installed keg" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES ('wget', 'wget', '1.24', 'sha-x', '/opt/malt/Cellar/wget/1.24');
+    );
+    try testing.expectEqual(Presence.keg, classify(&db, "wget"));
+}
+
+test "classify finds an installed cask" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO casks (token, name, version, url)
+        \\VALUES ('firefox', 'firefox', '120.0', 'https://x.invalid/f.dmg');
+    );
+    try testing.expectEqual(Presence.cask, classify(&db, "firefox"));
+}
+
+test "classify prefers the keg row when both name + token match" {
+    // Defensive pin: a future schema migration that lets a name appear
+    // in both tables must not make the dispatch arm ambiguous. Keg
+    // wins because the install pipeline treats `--cask` as opt-in.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES ('shared', 'shared', '1.0', 'sha-y', '/opt/malt/Cellar/shared/1.0');
+    );
+    try db.exec(
+        \\INSERT INTO casks (token, name, version, url)
+        \\VALUES ('shared', 'shared', '1.0', 'https://x.invalid/s.dmg');
+    );
+    try testing.expectEqual(Presence.keg, classify(&db, "shared"));
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -29,6 +29,7 @@ pub const cli_pin = @import("cli/pin.zig");
 pub const purge = @import("cli/purge.zig");
 pub const purge_json = @import("cli/purge/json.zig");
 pub const purge_report = @import("cli/purge/report.zig");
+pub const cli_reinstall = @import("cli/reinstall.zig");
 pub const cli_restore = @import("cli/restore.zig");
 pub const cli_rollback = @import("cli/rollback.zig");
 pub const cli_run = @import("cli/run.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -17,6 +17,7 @@ const migrate = @import("cli/migrate.zig");
 const outdated = @import("cli/outdated.zig");
 const pin_cmd = @import("cli/pin.zig");
 const purge = @import("cli/purge.zig");
+const reinstall = @import("cli/reinstall.zig");
 const restore = @import("cli/restore.zig");
 const rollback = @import("cli/rollback.zig");
 const run_cmd = @import("cli/run.zig");
@@ -80,6 +81,7 @@ fn maltLogFn(
 // CLI command modules
 const Command = enum {
     install,
+    reinstall,
     uninstall,
     upgrade,
     update,
@@ -120,6 +122,7 @@ const command_names = [_]struct {
     names: []const []const u8,
 }{
     .{ .tag = .install, .names = &.{"install"} },
+    .{ .tag = .reinstall, .names = &.{"reinstall"} },
     .{ .tag = .uninstall, .names = &.{ "uninstall", "remove" } },
     .{ .tag = .upgrade, .names = &.{"upgrade"} },
     .{ .tag = .update, .names = &.{"update"} },
@@ -260,6 +263,12 @@ test "command_map resolves cleanup to the cleanup tag" {
     // `mt cleanup` is the Homebrew-shaped alias for `mt purge --housekeeping`.
     // Pin the tag so a rename can't silently break the dispatch arm.
     try std.testing.expectEqual(@as(?Command, .cleanup), command_map.get("cleanup"));
+}
+
+test "command_map resolves reinstall to the reinstall tag" {
+    // `mt reinstall` is the discoverable verb for `mt install --force`.
+    // Pin the tag so a rename can't silently break the dispatch arm.
+    try std.testing.expectEqual(@as(?Command, .reinstall), command_map.get("reinstall"));
 }
 
 test "dispatch clears stale interrupt under the test runner" {
@@ -449,6 +458,7 @@ fn dispatch(allocator: std.mem.Allocator, ctx: *const AppCtx, cmd: Command, cmd_
     }
     switch (cmd) {
         .install => try install.execute(ctx, allocator, cmd_args),
+        .reinstall => try reinstall.execute(ctx, allocator, cmd_args),
         .uninstall => try uninstall.execute(ctx, allocator, cmd_args),
         .upgrade => try upgrade.execute(ctx, allocator, cmd_args),
         .update => try update.execute(ctx, allocator, cmd_args),
@@ -500,6 +510,7 @@ fn printUsage(ctx: *const AppCtx) void {
         \\
         \\Commands:
         \\  install       Install formulas, casks, or tap formulas
+        \\  reinstall     Wipe and re-materialise an installed package
         \\  uninstall     Remove installed packages
         \\  upgrade       Upgrade installed packages
         \\  update        Refresh metadata cache

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -36,14 +36,14 @@ test "scriptFor routes each shell to a non-empty script" {
 }
 
 const all_commands = [_][]const u8{
-    "install", "uninstall",   "remove",   "upgrade",
-    "update",  "outdated",    "list",     "ls",
-    "info",    "search",      "doctor",   "tap",
-    "untap",   "migrate",     "rollback", "link",
-    "unlink",  "pin",         "unpin",    "run",
-    "version", "completions", "shellenv", "backup",
-    "restore", "purge",       "cleanup",  "services",
-    "bundle",  "which",       "deps",
+    "install",  "reinstall", "uninstall",   "remove",
+    "upgrade",  "update",    "outdated",    "list",
+    "ls",       "info",      "search",      "doctor",
+    "tap",      "untap",     "migrate",     "rollback",
+    "link",     "unlink",    "pin",         "unpin",
+    "run",      "version",   "completions", "shellenv",
+    "backup",   "restore",   "purge",       "cleanup",
+    "services", "bundle",    "which",       "deps",
 };
 
 fn expectContains(haystack: []const u8, needle: []const u8) !void {
@@ -155,6 +155,15 @@ test "purge completions surface --json and --output-format=ndjson" {
     // surfaces as a purge-specific failure.
     try expectContains(completions.bash_script, "--output-format=ndjson");
     try expectContains(completions.fish_script, "output-format=ndjson");
+}
+
+test "all completions expose reinstall as a top-level verb" {
+    // Substring presence isn't enough — `restore`/`reinstall` overlap
+    // English-wise, so pin the per-shell token shapes used for the
+    // top-level command row.
+    try expectContains(completions.bash_script, "install reinstall uninstall");
+    try expectContains(completions.zsh_script, "'reinstall:");
+    try expectContains(completions.fish_script, "__malt_needs_command -a reinstall");
 }
 
 test "all completions expose cleanup as a top-level verb" {

--- a/tests/reinstall_test.zig
+++ b/tests/reinstall_test.zig
@@ -1,0 +1,166 @@
+//! malt — reinstall command integration tests.
+//!
+//! Pins the user-visible contract of `mt reinstall`:
+//!   - refuses cleanly when the package isn't installed,
+//!   - falls through to the install pipeline (DB opened, lock taken)
+//!     when the keg row exists.
+//!
+//! The happy-path test stops short of asserting the eventual install
+//! outcome — the API-bound resolver is unreachable in unit-test land —
+//! and only checks that the dispatch arm got past `classify` and into
+//! the shared primitive. That's the seam reinstall actually owns; the
+//! install pipeline carries its own coverage from `install_*_test.zig`.
+
+const std = @import("std");
+const malt = @import("malt");
+const test_io = @import("test_io");
+const testing = std.testing;
+const reinstall = malt.cli_reinstall;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+fn pathExists(path: []const u8) bool {
+    test_io.accessAbsolute(std.Options.debug_io, path, .{}) catch return false;
+    return true;
+}
+
+fn setupPrefix(suffix: []const u8) ![:0]u8 {
+    const path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "/tmp/malt_reinstall_{d}_{s}",
+        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
+        0,
+    );
+    test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, path);
+    _ = c.setenv("MALT_PREFIX", path.ptr, 1);
+    return path;
+}
+
+test "execute errors clearly when the package is not installed" {
+    const prefix = try setupPrefix("missing");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try testing.expectError(error.Aborted, reinstall.execute(&ctx, arena.allocator(), &.{"ghostpkg"}));
+
+    // No `installAll` delegation means no `db/malt.lock` reached the disk:
+    // the refusal short-circuited before the install pipeline ran.
+    const lock_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.lock", .{prefix});
+    defer testing.allocator.free(lock_file);
+    try testing.expect(!pathExists(lock_file));
+
+    try testing.expect(std.mem.indexOf(u8, captured.items, "ghostpkg is not installed") != null);
+}
+
+test "execute short-circuits on --help without touching the DB" {
+    // `mt reinstall --help` is a UX guarantee: it must never spin up
+    // the prefix-bound DB plumbing. Asserting "no malt.db on disk"
+    // pins that the help fast-path stays ahead of the lookup.
+    const prefix = try setupPrefix("help");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try reinstall.execute(&ctx, arena.allocator(), &.{"--help"});
+
+    const db_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.db", .{prefix});
+    defer testing.allocator.free(db_file);
+    try testing.expect(!pathExists(db_file));
+}
+
+test "execute refuses when no package is named" {
+    const prefix = try setupPrefix("noargs");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try testing.expectError(error.Aborted, reinstall.execute(&ctx, arena.allocator(), &.{}));
+}
+
+test "execute reaches the install pipeline when the keg row exists" {
+    const prefix = try setupPrefix("present");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    // Seed both the on-disk Cellar entry AND the DB keg row so the
+    // fast-path classification lands on `.keg` and dispatch hands off
+    // to `installAll`. The lock file's appearance proves we crossed
+    // the seam reinstall actually owns; the install pipeline itself
+    // is covered by `install_*_test.zig`.
+    const cellar_dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/RESOLVABLE_FIXTURE/1.0", .{prefix});
+    defer testing.allocator.free(cellar_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cellar_dir);
+
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{prefix});
+    defer testing.allocator.free(db_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, db_dir);
+
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/malt.db", .{db_dir}, 0);
+    defer testing.allocator.free(db_path);
+    {
+        var db = try malt.sqlite.Database.open(db_path);
+        defer db.close();
+        try malt.schema.initSchema(&db);
+        try db.exec(
+            \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+            \\VALUES ('RESOLVABLE_FIXTURE', 'RESOLVABLE_FIXTURE', '1.0', 'sha-x',
+            \\        '/opt/malt/Cellar/RESOLVABLE_FIXTURE/1.0');
+        );
+    }
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = malt.app_ctx.processEnviron() };
+
+    // Eventual failure (API unreachable for a synthetic name) is fine;
+    // the assertion is structural — did the dispatch arm hand off?
+    reinstall.execute(&ctx, arena.allocator(), &.{ "--quiet", "RESOLVABLE_FIXTURE" }) catch {};
+
+    const lock_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.lock", .{prefix});
+    defer testing.allocator.free(lock_file);
+    try testing.expect(pathExists(lock_file));
+}


### PR DESCRIPTION
## Description

Adds the `mt reinstall <pkg>` verb. The capability already lived behind `mt install --force`; this PR gives it the verb users reach for and removes the overload on the install command's force flag.

Reinstall looks the package up in the `kegs` / `casks` tables, refuses cleanly when it isn't installed, and otherwise forwards the user's argv (with `--force` prepended, plus `--cask` when the DB row lives in `casks`) into `install.execute`. Mirrors the `cleanup -> purge` shim shape so global flags (`--json`, `--quiet`, `--dry-run`) reach the downstream parser untouched.

Reinstall is package-scoped; dependents are not reinstalled.

Output and ndjson event shape match `mt install`; transitive dependencies are not reinstalled.

## Related Issue

- None

## Notes for Reviewers

- None