### PR TITLE
feat(cli/backup): include services in plain-text backup

### DIFF
--- a/scripts/smokes/smoke_services.sh
+++ b/scripts/smokes/smoke_services.sh
@@ -93,5 +93,31 @@ echo "=== stop"
 echo "=== final list (expect status=not-loaded after bootout)"
 "$BIN" services list
 
+# --- backup --services + restore round-trip ----------------------------
+# Pins the plain-text half of the bundle/backup round-trip: the
+# service must surface in the file, and restore must re-bootstrap it.
+
+echo "=== mark smoke-echo as auto_start so backup picks it up"
+sqlite3 "$PREFIX/db/malt.db" "UPDATE services SET auto_start = 1 WHERE name = 'smoke-echo';"
+
+SNAP="$PREFIX/snap.txt"
+echo "=== mt backup --services -o $SNAP"
+"$BIN" backup --services -o "$SNAP"
+
+grep -q '^service smoke-echo$' "$SNAP" || {
+  echo "FAIL: expected 'service smoke-echo' line in $SNAP"
+  cat "$SNAP"
+  exit 1
+}
+echo "  ✓ backup carries 'service smoke-echo'"
+
+echo "=== mt restore $SNAP (re-bootstrap via services dispatcher)"
+"$BIN" restore "$SNAP"
+
+# Re-bootstrap means launchd loaded the plist again — clean up so the
+# trap's `services stop` is a no-op rather than a leak across runs.
+echo "=== post-restore stop"
+"$BIN" services stop smoke-echo
+
 echo
 echo "OK — smoke test passed"

--- a/src/cli/backup.zig
+++ b/src/cli/backup.zig
@@ -15,14 +15,15 @@
 //! honoured by `malt restore`.
 
 const std = @import("std");
+
 const AppCtx = @import("../app_ctx.zig").AppCtx;
-const sqlite = @import("../db/sqlite.zig");
 const schema = @import("../db/schema.zig");
+const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
 const help = @import("help.zig");
 
-pub const Kind = enum { formula, cask };
+pub const Kind = enum { formula, cask, service };
 
 /// A parsed backup entry. For entries produced by `parseBackup`, `name` and
 /// `version` are slices into the input text and live as long as that text.
@@ -61,7 +62,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         } else if (std.mem.eql(u8, arg, "--versions")) {
             include_versions = true;
         } else if (std.mem.eql(u8, arg, "--services")) {
-            // Honoured by the JSON writer below; plain-text has no service line.
+            // Honoured by both writers; plain-text emits `service <name>`
+            // lines per auto_start row, JSON adds a `services` array.
             include_services = true;
         } else if (std.mem.eql(u8, arg, "-q") or std.mem.eql(u8, arg, "--quiet")) {
             output.setQuiet(true);
@@ -147,6 +149,22 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
                 try writeEntry(w, .cask, token, version, include_versions);
             }
             count += 1;
+        }
+    }
+
+    // Mirrors the JSON path's auto_start filter so both writers carry
+    // the same re-bootstrap invariant — presence of the line implies
+    // auto_start, no extra token needed.
+    if (include_services) {
+        var sstmt = db.prepare("SELECT name FROM services WHERE auto_start = 1 ORDER BY name;") catch null;
+        if (sstmt) |*st| {
+            defer st.finalize();
+            while (st.step() catch false) {
+                const name_ptr = st.columnText(0) orelse continue;
+                const name = std.mem.sliceTo(name_ptr, 0);
+                try writeEntry(w, .service, name, "", false);
+                count += 1;
+            }
         }
     }
 
@@ -370,10 +388,13 @@ pub fn writeEntry(w: *std.Io.Writer, kind: Kind, name: []const u8, version: []co
     const prefix: []const u8 = switch (kind) {
         .formula => "formula ",
         .cask => "cask ",
+        .service => "service ",
     };
     try w.writeAll(prefix);
     try w.writeAll(name);
-    if (include_versions and version.len > 0) {
+    // Services don't carry a version; the suffix would collide with
+    // their `name@channel` shape (e.g. `postgresql@16`) on parse.
+    if (kind != .service and include_versions and version.len > 0) {
         try w.writeAll("@");
         try w.writeAll(version);
     }
@@ -395,10 +416,17 @@ pub fn parseLine(line: []const u8) ?Entry {
     } else if (std.mem.startsWith(u8, s, "cask ")) {
         kind = .cask;
         s = std.mem.trim(u8, s["cask ".len..], " \t\r\n");
+    } else if (std.mem.startsWith(u8, s, "service ")) {
+        kind = .service;
+        s = std.mem.trim(u8, s["service ".len..], " \t\r\n");
     } else {
         return null;
     }
     if (s.len == 0) return null;
+
+    // Services keep `@` as part of their label (e.g. `postgresql@16`);
+    // only formulas/casks split a trailing `@<version>` off the name.
+    if (kind == .service) return .{ .kind = kind, .name = s, .version = "" };
 
     var name = s;
     var version: []const u8 = "";
@@ -453,4 +481,56 @@ pub fn defaultBackupPath(ctx: *const AppCtx, allocator: std.mem.Allocator) ![]u8
             day_seconds.getSecondsIntoMinute(),
         },
     );
+}
+
+// ── inline unit tests ──────────────────────────────────────────────────
+// CLI-level integration coverage lives under `tests/backup_cli_test.zig`;
+// the pure-helper coverage for the .service variant sits next to the
+// code it pins.
+
+test "writeEntry emits `service <name>` with no version suffix" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeEntry(&aw.writer, .service, "postgresql@16", "", false);
+    try std.testing.expectEqualStrings("service postgresql@16\n", aw.written());
+}
+
+test "writeEntry never appends a version suffix to a service entry" {
+    // Services don't carry a version in the schema; `include_versions`
+    // must be a no-op here so a future caller can't smuggle one in.
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeEntry(&aw.writer, .service, "redis", "8.0", true);
+    try std.testing.expectEqualStrings("service redis\n", aw.written());
+}
+
+test "parseLine parses a service line and keeps `@` inside the name" {
+    // Service labels like `postgresql@16` keep the `@channel` suffix as
+    // part of the name — versioning is keg-side, not service-side, so
+    // the parser must not split on `@`.
+    const a = parseLine("service postgresql@16").?;
+    try std.testing.expectEqual(Kind.service, a.kind);
+    try std.testing.expectEqualStrings("postgresql@16", a.name);
+    try std.testing.expectEqualStrings("", a.version);
+
+    const b = parseLine("service redis").?;
+    try std.testing.expectEqual(Kind.service, b.kind);
+    try std.testing.expectEqualStrings("redis", b.name);
+    try std.testing.expectEqualStrings("", b.version);
+}
+
+test "parseBackup silently drops any future unknown kind (forward-compat)" {
+    // Pre-T-042 binaries see new `service` lines as unknown kinds and
+    // skip them. Pin the same contract for any future variant so a
+    // newer malt can ship a new line shape without breaking the backups
+    // an older malt is asked to read.
+    const text =
+        "formula git\n" ++
+        "widget acme\n" ++ // hypothetical newer-than-this-reader kind
+        "cask firefox\n";
+    const entries = try parseBackup(std.testing.allocator, text);
+    defer std.testing.allocator.free(entries);
+    try std.testing.expectEqual(@as(usize, 2), entries.len);
+    try std.testing.expectEqualStrings("git", entries[0].name);
+    try std.testing.expectEqualStrings("firefox", entries[1].name);
 }

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -139,7 +139,7 @@ pub const bash_script =
     \\    case "$cmd" in
     \\        install)          cmd_flags="--cask --formula --local --dry-run --force --download-only --only-dependencies --quiet -q --json" ;;
     \\        reinstall)        cmd_flags="--cask --dry-run --quiet -q --json" ;;
-    \\        backup)           cmd_flags="--output -o --versions --quiet -q" ;;
+    \\        backup)           cmd_flags="--output -o --versions --services --quiet -q" ;;
     \\        restore)          cmd_flags="--dry-run --force --quiet -q" ;;
     \\        purge)            cmd_flags="--store-orphans --unused-deps --cache --cache= --downloads --stale-casks --old-versions --housekeeping --wipe --backup -b --keep-cache --remove-binary --yes -y --dry-run -n" ;;
     \\        uninstall|remove) cmd_flags="--force --zap --dry-run" ;;
@@ -367,6 +367,7 @@ pub const zsh_script =
     \\                    _arguments \
     \\                        '(--output -o)'{--output,-o}'[Write to a specific file]:path:_files' \
     \\                        '--versions[Pin each entry to its current version]' \
+    \\                        '--services[Include auto-start services so restore re-bootstraps launchd]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]'
     \\                    ;;
     \\                restore)
@@ -641,6 +642,7 @@ pub const fish_script =
     \\    # backup
     \\    complete -c $__malt_bin -n '__malt_using_command backup' -s o -l output   -r -d 'Output file (use - for stdout)'
     \\    complete -c $__malt_bin -n '__malt_using_command backup'      -l versions    -d 'Pin each entry to its current version'
+    \\    complete -c $__malt_bin -n '__malt_using_command backup'      -l services    -d 'Include auto-start services for restore'
     \\
     \\    # restore — positional backup file
     \\    complete -c $__malt_bin -n '__malt_using_command restore' -l dry-run -d 'Preview without installing'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -426,12 +426,15 @@ const backup_help =
     \\Flags:
     \\  --output, -o <path>  Write to a specific file (use `-` for stdout)
     \\  --versions           Pin each entry to its current version (@ver)
+    \\  --services           Include auto-start services so `malt restore`
+    \\                       re-bootstraps launchd state on the destination
     \\  --quiet, -q          Suppress non-error output
     \\
     \\Examples:
     \\  malt backup
     \\  malt backup -o ~/dotfiles/packages.txt
     \\  malt backup --versions -o - > snapshot.txt
+    \\  malt backup --services -o ~/dotfiles/packages.txt
     \\
 ;
 

--- a/src/cli/restore.zig
+++ b/src/cli/restore.zig
@@ -4,11 +4,13 @@
 //! the heavy lifting (DB lock, download, dependency resolution).
 
 const std = @import("std");
+
 const AppCtx = @import("../app_ctx.zig").AppCtx;
-const backup_mod = @import("backup.zig");
-const install_mod = @import("install.zig");
 const output = @import("../ui/output.zig");
+const backup_mod = @import("backup.zig");
 const help = @import("help.zig");
+const install_mod = @import("install.zig");
+const services_mod = @import("services.zig");
 
 pub const Error = error{
     MissingFileArgument,
@@ -72,7 +74,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         return;
     }
 
-    // ── Split into formula / cask arg lists ──────────────────────────────
+    // ── Split into formula / cask / service arg lists ────────────────────
     var formulae: std.ArrayList([]const u8) = .empty;
     defer {
         // Each item is an owned `<name>` or `<name>@<version>` slice.
@@ -85,6 +87,11 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         for (casks.items) |item| allocator.free(item);
         casks.deinit(allocator);
     }
+    var services: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (services.items) |item| allocator.free(item);
+        services.deinit(allocator);
+    }
 
     for (entries) |e| {
         // Reconstruct the install-style argument: `<name>` or `<name>@<version>`
@@ -96,18 +103,21 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         switch (e.kind) {
             .formula => try formulae.append(allocator, arg),
             .cask => try casks.append(allocator, arg),
+            .service => try services.append(allocator, arg),
         }
     }
 
-    output.info("Restoring {d} formula(e) and {d} cask(s) from {s}", .{
+    output.info("Restoring {d} formula(e), {d} cask(s) and {d} service(s) from {s}", .{
         formulae.items.len,
         casks.items.len,
+        services.items.len,
         path,
     });
 
     if (dry_run) {
         for (formulae.items) |name| output.info("  formula {s}", .{name});
         for (casks.items) |name| output.info("  cask    {s}", .{name});
+        for (services.items) |name| output.info("  service {s}", .{name});
         output.info("Dry run — no packages installed.", .{});
         return;
     }
@@ -140,6 +150,16 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         install_mod.execute(ctx, allocator, argv.items) catch |e| {
             output.err("Cask restore returned error: {s}", .{@errorName(e)});
             any_failed = true;
+        };
+    }
+
+    // Services come last so each plist's owning keg already exists. A
+    // missing keg surfaces as ServiceNotFound from the supervisor; we
+    // warn and continue so one missing service doesn't abort the rest
+    // of the restore.
+    for (services.items) |name| {
+        services_mod.servicesStart(ctx, allocator, name) catch |e| {
+            output.warn("service {s} skipped: {s}", .{ name, @errorName(e) });
         };
     }
 

--- a/tests/backup_cli_test.zig
+++ b/tests/backup_cli_test.zig
@@ -6,13 +6,14 @@
 //! fills the dispatch + DB-walk + output-routing branches.
 
 const std = @import("std");
-const malt = @import("malt");
-const test_io = @import("test_io");
 const testing = std.testing;
+
+const malt = @import("malt");
 const backup = malt.backup;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
 const output = malt.output;
+const test_io = @import("test_io");
 
 const c = struct {
     extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
@@ -568,8 +569,11 @@ test "execute --json --services composes with --versions and --output -" {
     try testing.expect(parsed.value.object.get("casks") != null);
 }
 
-test "execute --services on plain-text backup is a silent no-op (no `service` line)" {
-    var s = try Scratch.init(testing.allocator, "text_services_noop");
+test "execute --services on plain-text backup emits a `service <name>` line per auto_start row" {
+    // Plain-text parity with the JSON path: `--services` carries the
+    // auto_start invariant into the file `mt restore` consumes, so
+    // launchd state survives a host migration.
+    var s = try Scratch.init(testing.allocator, "text_services_emits");
     defer s.deinit(testing.allocator);
     try seedServices(s.path);
 
@@ -582,8 +586,87 @@ test "execute --services on plain-text backup is a silent no-op (no `service` li
 
     const body = try readAll(testing.allocator, out_path);
     defer testing.allocator.free(body);
+    // auto_start=1 row surfaces with the full `name@channel` intact.
+    try testing.expect(std.mem.indexOf(u8, body, "service postgresql@16\n") != null);
+    // auto_start=0 row stays off the file — the backup carries only the
+    // re-bootstrap invariant, not the full services table.
+    try testing.expect(std.mem.indexOf(u8, body, "service redis") == null);
+}
+
+test "execute without --services omits service lines from plain-text backup" {
+    // Backward compat: the default plain-text shape is unchanged so
+    // pre-T-042 readers and existing user scripts keep parsing byte-
+    // identical files when the flag isn't passed.
+    var s = try Scratch.init(testing.allocator, "text_services_default_off");
+    defer s.deinit(testing.allocator);
+    try seedServices(s.path);
+
+    const out_path = try std.fmt.allocPrint(testing.allocator, "{s}/snap.txt", .{s.path});
+    defer testing.allocator.free(out_path);
+
+    quiet();
+    defer unquiet();
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--output", out_path });
+
+    const body = try readAll(testing.allocator, out_path);
+    defer testing.allocator.free(body);
     try testing.expect(std.mem.indexOf(u8, body, "service ") == null);
     try testing.expect(std.mem.indexOf(u8, body, "postgresql@16") == null);
+}
+
+test "execute --services on an empty services table is a clean no-op (plain text)" {
+    // Pin the "presence implies auto_start" contract under the empty
+    // case for plain text: opting in shouldn't synthesise lines.
+    var s = try Scratch.init(testing.allocator, "text_services_empty");
+    defer s.deinit(testing.allocator);
+    // schema only — no services seeded.
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+    }
+
+    const out_path = try std.fmt.allocPrint(testing.allocator, "{s}/snap.txt", .{s.path});
+    defer testing.allocator.free(out_path);
+
+    quiet();
+    defer unquiet();
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--services", "--output", out_path });
+
+    const body = try readAll(testing.allocator, out_path);
+    defer testing.allocator.free(body);
+    try testing.expect(std.mem.indexOf(u8, body, "service ") == null);
+}
+
+test "execute --services --versions never appends @version to a service line" {
+    // `--versions` is a formula/cask concern; bleeding into a service
+    // line would re-introduce the `name@channel` ambiguity parseLine
+    // explicitly avoids.
+    var s = try Scratch.init(testing.allocator, "text_services_versions");
+    defer s.deinit(testing.allocator);
+    try seedServices(s.path);
+    try seedRows(s.path);
+
+    const out_path = try std.fmt.allocPrint(testing.allocator, "{s}/snap.txt", .{s.path});
+    defer testing.allocator.free(out_path);
+
+    quiet();
+    defer unquiet();
+    try backup.execute(
+        &malt.app_ctx.debug_ctx,
+        testing.allocator,
+        &.{ "--services", "--versions", "--output", out_path },
+    );
+
+    const body = try readAll(testing.allocator, out_path);
+    defer testing.allocator.free(body);
+    // Formulas still pinned; the service line stays unsuffixed.
+    try testing.expect(std.mem.indexOf(u8, body, "formula wget@1.21") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "service postgresql@16\n") != null);
+    // No `postgresql@16@<...>` artefact from the version writer.
+    try testing.expect(std.mem.indexOf(u8, body, "postgresql@16@") == null);
 }
 
 test "execute --json with --output <path> writes JSON to the file" {

--- a/tests/backup_test.zig
+++ b/tests/backup_test.zig
@@ -5,6 +5,7 @@
 
 const std = @import("std");
 const testing = std.testing;
+
 const malt = @import("malt");
 const backup = malt.backup;
 
@@ -102,6 +103,7 @@ test "parseLine returns null for unknown kinds and malformed lines" {
     // Kind prefix without a name.
     try testing.expect(backup.parseLine("formula ") == null);
     try testing.expect(backup.parseLine("cask   ") == null);
+    try testing.expect(backup.parseLine("service ") == null);
     // No space between kind and name (missed prefix).
     try testing.expect(backup.parseLine("formulagit") == null);
 }
@@ -187,11 +189,16 @@ test "writeEntry + parseBackup round-trip preserves every entry" {
         kind: backup.Kind,
         name: []const u8,
         version: []const u8,
+        expected_version: []const u8,
     }{
-        .{ .kind = .formula, .name = "git", .version = "2.44.0" },
-        .{ .kind = .formula, .name = "wget", .version = "1.24.5" },
-        .{ .kind = .cask, .name = "firefox", .version = "124.0" },
-        .{ .kind = .cask, .name = "slack", .version = "4.36.140" },
+        .{ .kind = .formula, .name = "git", .version = "2.44.0", .expected_version = "2.44.0" },
+        .{ .kind = .formula, .name = "wget", .version = "1.24.5", .expected_version = "1.24.5" },
+        .{ .kind = .cask, .name = "firefox", .version = "124.0", .expected_version = "124.0" },
+        .{ .kind = .cask, .name = "slack", .version = "4.36.140", .expected_version = "4.36.140" },
+        // Services round-trip with the full `name@channel` intact and no
+        // version surfaced — the schema doesn't carry one.
+        .{ .kind = .service, .name = "postgresql@16", .version = "", .expected_version = "" },
+        .{ .kind = .service, .name = "redis", .version = "", .expected_version = "" },
     };
 
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
@@ -209,7 +216,7 @@ test "writeEntry + parseBackup round-trip preserves every entry" {
     inline for (fixtures, 0..) |f, i| {
         try testing.expectEqual(f.kind, entries[i].kind);
         try testing.expectEqualStrings(f.name, entries[i].name);
-        try testing.expectEqualStrings(f.version, entries[i].version);
+        try testing.expectEqualStrings(f.expected_version, entries[i].version);
     }
 }
 

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -186,3 +186,12 @@ test "all bundle completions expose the cleanup subcommand and its flags" {
     try expectContains(completions.zsh_script, "cleanup[");
     try expectContains(completions.fish_script, "-l yes");
 }
+
+test "backup completions expose --services across every shell" {
+    // `mt backup --services` is the user-visible verb that closes the
+    // launchd-bootstrap round-trip; the completions must surface it so
+    // it's discoverable without consulting --help.
+    try expectContains(completions.bash_script, "--services");
+    try expectContains(completions.zsh_script, "'--services[");
+    try expectContains(completions.fish_script, "-l services");
+}

--- a/tests/restore_cli_test.zig
+++ b/tests/restore_cli_test.zig
@@ -6,11 +6,12 @@
 //! the install tests — restore just emits the argv and forwards.
 
 const std = @import("std");
-const malt = @import("malt");
-const test_io = @import("test_io");
 const testing = std.testing;
+
+const malt = @import("malt");
 const restore = malt.cli_restore;
 const output = malt.output;
+const test_io = @import("test_io");
 
 const c = struct {
     extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
@@ -168,4 +169,95 @@ test "execute treats unknown kinds as comments and reports zero entries" {
     output.setQuiet(true);
     defer output.setQuiet(false);
     try restore.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{path});
+}
+
+// --- service-entry dispatch ---------------------------------------------
+
+test "execute summary line carries formula + cask + service counts in that order" {
+    // Pin the exact summary phrasing so users grepping for "service(s)"
+    // in their restore output don't suddenly miss it after a future
+    // formatting tweak.
+    var s = try Scratch.init(testing.allocator, "summary");
+    defer s.deinit(testing.allocator);
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/snap.txt", .{s.path});
+    defer testing.allocator.free(path);
+    try writeFile(path,
+        \\formula wget
+        \\cask firefox
+        \\service postgresql@16
+        \\
+    );
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(testing.allocator);
+    output.beginStderrCapture(testing.allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    output.setDryRun(true);
+    defer output.setDryRun(false);
+
+    try restore.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{path});
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "1 formula(e), 1 cask(s) and 1 service(s)") != null);
+}
+
+test "execute --dry-run buckets a service entry and prints it after formulas/casks" {
+    // T-042 surface contract: services arrive ordered after kegs so the
+    // launchd bootstrap happens once the keg backing each service exists.
+    var s = try Scratch.init(testing.allocator, "dry_services");
+    defer s.deinit(testing.allocator);
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/snap.txt", .{s.path});
+    defer testing.allocator.free(path);
+    try writeFile(path,
+        \\formula postgresql@16
+        \\service postgresql@16
+        \\
+    );
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(testing.allocator);
+    output.beginStderrCapture(testing.allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    output.setDryRun(true);
+    defer output.setDryRun(false);
+
+    try restore.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{path});
+
+    // Summary line counts services alongside formulae and casks.
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "1 service(s)") != null);
+    // Per-entry dry-run line for the service surfaces with the full label.
+    const svc_line = std.mem.indexOf(u8, stderr_buf.items, "service postgresql@16") orelse
+        return error.MissingServiceDryRunLine;
+    const formula_line = std.mem.indexOf(u8, stderr_buf.items, "formula postgresql@16") orelse
+        return error.MissingFormulaDryRunLine;
+    // Services must come after kegs in dispatch order.
+    try testing.expect(svc_line > formula_line);
+}
+
+test "execute warns-and-continues when a service entry can't be bootstrapped" {
+    // Acceptance: missing kegs (no services row to look up) must not
+    // fail the restore. The supervisor returns ServiceNotFound; restore
+    // catches it, surfaces a warning naming the service, and returns
+    // success so the rest of the backup keeps applying.
+    var s = try Scratch.init(testing.allocator, "missing_keg_service");
+    defer s.deinit(testing.allocator);
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/snap.txt", .{s.path});
+    defer testing.allocator.free(path);
+    // db/ must exist so services_cmd can open the DB and init the schema.
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{s.path});
+    defer testing.allocator.free(db_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, db_dir);
+
+    try writeFile(path, "service ghost_service\n");
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(testing.allocator);
+    output.beginStderrCapture(testing.allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    // Not dry-run — exercise the real dispatch arm.
+    try restore.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{path});
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "ghost_service") != null);
 }


### PR DESCRIPTION
## Description
Closes the plain-text half of the bundle/backup round-trip: `mt backup --services` now emits `service <name>` lines that `mt restore` re-bootstraps via the services subsystem. The JSON path already carried this; this task brings the human-edit-friendly format to parity, so dotfiles workflows that prefer the canonical text file can also reproduce launchd state on a fresh host.

## Related Issue

- None

## Notes for Reviewers

- Legacy backup files (no `service` lines) restore byte-for-byte as before; new `service` lines are silently ignored by thanks to `parseLine`'s existing unknown-kind tolerance — pinned by a forward-compat test against a synthetic future `widget` kind so the contract doesn't regress.
- `--services` is `auto_start = 1` only on both writers, mirroring the JSON path; presence of a line implies auto-start, no extra token in the grammar.
- Restore dispatches services after formulas and casks so each plist's owning keg already exists; missing kegs warn and continue (matches bundle-install semantics).
