### PR TITLE
feat(core/tap,cli/tap): accept third-party taps without the homebrew- prefix

### DIFF
--- a/scripts/regressions/tap_no_inline_homebrew_synthesis.sh
+++ b/scripts/regressions/tap_no_inline_homebrew_synthesis.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Structural enforcement that no fetch site inlines the
+# `homebrew-<repo>` prefix synthesis. Every URL-building helper must
+# read `(github_owner, github_repo)` from the tap row, which means
+# `homebrew-{` may live in exactly the allowed files below and nowhere
+# else.
+#
+# Allowed sites:
+#   - src/core/tap.zig          single-point fallback in `effectiveOwnerRepo`
+#                               (the cold path during initial `mt tap`).
+#   - src/db/schema.zig         v8→v9 migration backfill needs the prefix
+#                               literal to derive (owner, "homebrew-" || repo)
+#                               from the existing slug.
+#   - src/cli/migrate/keg.zig   `<prefix>/Library/Taps/<user>/homebrew-<repo>`
+#                               on-disk path — Homebrew's filesystem layout,
+#                               not a URL.
+#
+# Any new hit outside this list fails the regression suite — that is the
+# coverage-drift guard against a future helper that bypasses the seam.
+#
+# Usage: scripts/regressions/tap_no_inline_homebrew_synthesis.sh
+# Requirements: POSIX grep — no network, no build.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+hits=$(grep -rn --include='*.zig' -F 'homebrew-{' src || true)
+
+filtered=$(printf '%s\n' "$hits" |
+  grep -v '^src/core/tap\.zig:' |
+  grep -v '^src/db/schema\.zig:' |
+  grep -v '^src/cli/migrate/keg\.zig:' |
+  grep -v '^$' || true)
+
+if [[ -n "$filtered" ]]; then
+  printf "FAIL: inline homebrew- synthesis outside the allow-list:\n\n" >&2
+  printf '%s\n' "$filtered" >&2
+  printf "\nAdd the new site to the allow-list only if the synthesis is\n" >&2
+  printf "load-bearing for the migration or the on-disk path. Otherwise\n" >&2
+  printf "route through src/core/tap.zig:effectiveOwnerRepo.\n" >&2
+  exit 1
+fi
+
+printf "OK: no inline 'homebrew-{' synthesis outside the allow-list.\n"

--- a/scripts/regressions/tap_v9_schema_migration.sh
+++ b/scripts/regressions/tap_v9_schema_migration.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# End-to-end check that the v8→v9 migration runs cleanly when triggered
+# by the actual `mt` binary, and that the (github_owner, github_repo)
+# pair is backfilled correctly from existing slugs.
+#
+# Pinned behaviour:
+#   1. A v8-shaped DB (taps with name/url/commit_sha/head_etag but
+#      *without* github_owner/github_repo) upgrades to v9 on first
+#      `mt` open. Existing rows backfill to (user, "homebrew-" || repo).
+#   2. The `taps.url` projection in `mt --json tap` reflects the
+#      stored (github_owner, github_repo) pair — a custom-repo row
+#      surfaces its exact URL, not the `homebrew-<repo>` synthesis.
+#   3. The new columns carry NOT NULL — the migration's DEFAULT ''
+#      plus the backfill UPDATE must converge on real values.
+#
+# Methodology: build a v8 DB by hand against the current binary's
+# initSchema, rewind the schema_version marker, then re-run `mt tap`
+# (which calls initSchema → migrate). No network needed.
+#
+# Requirements: a built malt binary at zig-out/bin/malt; sqlite3 CLI;
+# jq for JSON probes.
+#
+# Usage: scripts/regressions/tap_v9_schema_migration.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MT="$ROOT/zig-out/bin/malt"
+if [[ ! -x "$MT" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MT" >&2
+  exit 1
+fi
+command -v sqlite3 >/dev/null || {
+  printf 'SKIP: sqlite3 CLI required.\n' >&2
+  exit 0
+}
+command -v jq >/dev/null || {
+  printf 'SKIP: jq required.\n' >&2
+  exit 0
+}
+
+PREFIX=$(mktemp -d -t mt_v9_XXXXXX)
+trap 'rm -rf "$PREFIX"' EXIT
+mkdir -p "$PREFIX/db"
+DB="$PREFIX/db/malt.db"
+
+export MALT_PREFIX="$PREFIX"
+
+# Step 1: bootstrap the DB at the current schema (v9), seed a row, then
+# rewind schema_version to 8 so the next `mt` invocation re-runs v8→v9.
+"$MT" tap >/dev/null 2>&1 || true
+[[ -f "$DB" ]] || {
+  printf 'FAIL: mt did not create %s\n' "$DB" >&2
+  exit 1
+}
+
+ver=$(sqlite3 "$DB" "SELECT MAX(version) FROM schema_version;")
+[[ "$ver" == "9" ]] || {
+  printf 'FAIL: fresh DB at v%s, expected v9.\n' "$ver" >&2
+  exit 1
+}
+
+# Drop the v9 columns and rewind to simulate an upgraded-from-v8 DB.
+# SQLite has no DROP COLUMN before 3.35 — emulate via table rebuild.
+sqlite3 "$DB" <<'SQL'
+BEGIN;
+DELETE FROM schema_version WHERE version >= 9;
+CREATE TABLE taps_v8 (
+    id         INTEGER PRIMARY KEY,
+    name       TEXT NOT NULL UNIQUE,
+    url        TEXT NOT NULL,
+    added_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    commit_sha TEXT,
+    head_etag  TEXT
+);
+INSERT INTO taps_v8 (id, name, url, added_at, commit_sha, head_etag)
+SELECT id, name, url, added_at, commit_sha, head_etag FROM taps;
+DROP TABLE taps;
+ALTER TABLE taps_v8 RENAME TO taps;
+INSERT INTO taps (name, url, commit_sha) VALUES
+  ('aeroxy/tap',  'https://github.com/aeroxy/homebrew-tap',  '0123456789abcdef0123456789abcdef01234567'),
+  ('user/repo',   'https://github.com/user/homebrew-repo',   NULL),
+  ('user-1/some.v2', 'https://github.com/user-1/homebrew-some.v2', NULL);
+COMMIT;
+SQL
+
+ver_after=$(sqlite3 "$DB" "SELECT MAX(version) FROM schema_version;")
+[[ "$ver_after" == "8" ]] || {
+  printf 'FAIL: rewind did not land at v8 (got %s).\n' "$ver_after" >&2
+  exit 1
+}
+
+# Step 2: run `mt tap` so initSchema → migrate triggers v8→v9.
+"$MT" tap >/dev/null 2>&1 || true
+
+# Step 3: assert the migration landed at v9 with the expected backfill.
+ver_post=$(sqlite3 "$DB" "SELECT MAX(version) FROM schema_version;")
+[[ "$ver_post" == "9" ]] || {
+  printf 'FAIL: migration did not bump to v9 (got %s).\n' "$ver_post" >&2
+  exit 1
+}
+printf '  ✓ schema_version bumped 8 -> 9\n'
+
+row1=$(sqlite3 -separator '|' "$DB" "SELECT github_owner, github_repo FROM taps WHERE name='aeroxy/tap';")
+[[ "$row1" == "aeroxy|homebrew-tap" ]] || {
+  printf 'FAIL: aeroxy/tap backfill = %s, expected aeroxy|homebrew-tap.\n' "$row1" >&2
+  exit 1
+}
+printf '  ✓ aeroxy/tap backfilled to (aeroxy, homebrew-tap)\n'
+
+row2=$(sqlite3 -separator '|' "$DB" "SELECT github_owner, github_repo FROM taps WHERE name='user-1/some.v2';")
+[[ "$row2" == "user-1|homebrew-some.v2" ]] || {
+  printf 'FAIL: user-1/some.v2 backfill = %s.\n' "$row2" >&2
+  exit 1
+}
+printf '  ✓ hyphens and dots preserved in backfill\n'
+
+# Step 4: insert a custom-repo row directly, confirm the URL projection
+# in `mt --json tap` reflects the stored pair (not the homebrew- default).
+sqlite3 "$DB" "INSERT INTO taps (name, url, commit_sha, github_owner, github_repo) VALUES ('aeroxy/ast-outline', 'https://example.invalid/decorative', NULL, 'aeroxy', 'ast-outline');"
+
+json=$("$MT" --json tap 2>/dev/null)
+projected=$(printf '%s' "$json" | jq -r '.[] | select(.name=="aeroxy/ast-outline") | .url')
+[[ "$projected" == "https://github.com/aeroxy/ast-outline" ]] || {
+  printf 'FAIL: custom-repo URL projection = %s, expected https://github.com/aeroxy/ast-outline.\n' "$projected" >&2
+  exit 1
+}
+printf '  ✓ custom-repo URL projected from (github_owner, github_repo)\n'
+
+# Step 5: rerun migration on the now-v9 DB — must be a no-op.
+"$MT" tap >/dev/null 2>&1 || true
+row1_post=$(sqlite3 -separator '|' "$DB" "SELECT github_owner, github_repo FROM taps WHERE name='aeroxy/tap';")
+[[ "$row1_post" == "aeroxy|homebrew-tap" ]] || {
+  printf 'FAIL: idempotent rerun mutated the row (%s).\n' "$row1_post" >&2
+  exit 1
+}
+printf '  ✓ migration is idempotent on an already-v9 DB\n'
+
+printf '\n✔ tap v8→v9 schema migration regression passed\n'

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -159,7 +159,7 @@ pub const bash_script =
     \\        bundle)           cmd_flags="--dry-run -n --format --from-installed --purge --yes -y" ;;
     \\        run)              cmd_flags="--keep" ;;
     \\        doctor)           cmd_flags="--fix --dry-run" ;;
-    \\        tap)              cmd_flags="--refresh --all --pin --yes -y --json" ;;
+    \\        tap)              cmd_flags="--refresh --all --pin --repo --force --yes -y --json" ;;
     \\    esac
     \\
     \\    if [[ "$cur" == -* ]]; then
@@ -424,6 +424,8 @@ pub const zsh_script =
     \\                        '--refresh[Advance the pin to current HEAD]' \
     \\                        '--all[With --refresh: walk every registered tap]' \
     \\                        '--pin[Explicitly pin <slug> to <sha>]' \
+    \\                        '--repo[Point the tap at owner/exact-repo (no homebrew- prefix)]:owner/exact-repo:' \
+    \\                        '--force[Rebind an existing tap to a new --repo target]' \
     \\                        '(--yes -y)'{--yes,-y}'[Confirm --refresh --all apply]' \
     \\                        '--json[Emit refresh-all diff as JSON]' \
     \\                        '*::slug:'
@@ -630,6 +632,8 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -l refresh -d 'Advance the pin to current HEAD'
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -l all     -d 'With --refresh: walk every registered tap'
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -l pin     -d 'Explicitly pin <slug> to <sha>'
+    \\    complete -c $__malt_bin -n '__malt_using_command tap' -l repo    -x -d 'Point the tap at owner/exact-repo (no homebrew- prefix)'
+    \\    complete -c $__malt_bin -n '__malt_using_command tap' -l force   -d 'Rebind an existing tap to a new --repo target'
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -s y -l yes -d 'Confirm --refresh --all apply'
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -l json    -d 'Emit refresh-all diff as JSON'
     \\

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -267,6 +267,7 @@ const doctor_help =
 
 const tap_help =
     \\Usage: malt tap [<user>/<repo>]
+    \\       malt tap <user>/<repo> --repo <owner>/<exact-repo> [--force]
     \\       malt tap --refresh <user>/<repo>
     \\       malt tap --refresh --all [--yes] [--json]
     \\       malt tap --pin <user>/<repo> <sha>
@@ -288,6 +289,15 @@ const tap_help =
     \\  --pin <slug> <sha>   Explicitly pin <slug> to <sha>. The SHA is
     \\                       validated for reachability through GitHub's
     \\                       commits/<sha> endpoint before the pin lands.
+    \\  --repo <owner>/<exact-repo>
+    \\                       Point the tap at a GitHub repo whose name
+    \\                       does NOT carry the `homebrew-` prefix
+    \\                       (e.g. `mt tap aeroxy/ast-outline --repo
+    \\                       aeroxy/ast-outline`). Without this flag the
+    \\                       tap resolves against `homebrew-<repo>`.
+    \\  --force              Allow rebinding an existing tap to a new
+    \\                       --repo target. Clears the stale commit SHA
+    \\                       and ETag because the new repo has its own HEAD.
     \\  --yes, -y            Confirm the apply step of --refresh --all.
     \\  --json               Emit the --refresh --all diff as
     \\                       `{"taps":[{"tap","old_sha","new_sha","status"}]}`.

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -5,30 +5,28 @@
 //! this path changes.
 
 const std = @import("std");
+
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
-const sqlite = @import("../../db/sqlite.zig");
-const atomic = @import("../../fs/atomic.zig");
 const cask_mod = @import("../../core/cask.zig");
+const hash = @import("../../core/hash.zig");
 const linker_mod = @import("../../core/linker.zig");
 const tap_mod = @import("../../core/tap.zig");
 const tap_cache = @import("../../core/tap_cache.zig");
+const sqlite = @import("../../db/sqlite.zig");
+const atomic = @import("../../fs/atomic.zig");
 const client_mod = @import("../../net/client.zig");
-const hash = @import("../../core/hash.zig");
 const output = @import("../../ui/output.zig");
 const progress_mod = @import("../../ui/progress.zig");
-
+const install_mod = @import("../install.zig");
 const args = @import("args.zig");
-const record = @import("record.zig");
 const download = @import("download.zig");
 const rb_parse = @import("rb_parse.zig");
-const install_mod = @import("../install.zig");
-
 const RubyFormulaInfo = rb_parse.RubyFormulaInfo;
 const parseRubyFormula = rb_parse.parseRubyFormula;
 const parseCaskBinary = rb_parse.parseCaskBinary;
 const parseCaskApp = rb_parse.parseCaskApp;
 const tapCaskArtifactKind = rb_parse.tapCaskArtifactKind;
-
+const record = @import("record.zig");
 const InstallError = record.InstallError;
 
 /// Maximum size of a `.rb` formula file that `malt install --local`
@@ -211,7 +209,7 @@ fn installTapRb(
     const tap_slug = std.fmt.bufPrint(&tap_slug_buf, "{s}/{s}", .{ parts.user, parts.repo }) catch
         return InstallError.FormulaNotFound;
 
-    const urls = try tap_mod.resolveTapBaseUrls(allocator, tap_slug);
+    const urls = try tap_mod.resolveTapBaseUrls(allocator, db, tap_slug);
     defer urls.deinit(allocator);
 
     // Cold-start: pass null for cached_etag (no pin → no etag either);
@@ -778,11 +776,13 @@ pub fn materializeRubyFormula(
             // `COALESCE` in tap_mod.add pins the commit on first install
             // and leaves later pins untouched. Tap row is advisory — keg
             // is already recorded; a missing tap row self-heals next sync.
-            tap_mod.add(db, resolved.tap_label, t.url, t.commit_sha) catch {};
-            // Stamp the captured etag so the next resolve can send
-            // If-None-Match. Warm-path installs leave `head_etag` null —
-            // there's no fresh etag to overwrite an older cached one with.
-            if (t.head_etag) |et| tap_mod.updateHead(db, resolved.tap_label, t.commit_sha, et) catch {};
+            // (owner, repo) routes through `effectiveOwnerRepo` so the
+            // synthesis used at fetch time and at persist time can't drift.
+            if (tap_mod.effectiveOwnerRepo(allocator, db, resolved.tap_label)) |pair| {
+                defer pair.deinit(allocator);
+                tap_mod.add(db, resolved.tap_label, pair.owner, pair.repo, t.commit_sha) catch {};
+                if (t.head_etag) |et| tap_mod.updateHead(db, resolved.tap_label, t.commit_sha, et) catch {};
+            } else |_| {}
         }
     }
 
@@ -903,7 +903,7 @@ fn materializeTapCask(
     defer allocator.free(app_path);
 
     // `try` is the invariant: success line never fires without a row.
-    try finalizeTapCaskInstall(db, &cask, app_path, resolved.tap_label, resolved.tap_registration);
+    try finalizeTapCaskInstall(allocator, db, &cask, app_path, resolved.tap_label, resolved.tap_registration);
 
     output.success("{s} {s} installed", .{ cask.token, cask.version });
 }
@@ -981,6 +981,7 @@ fn mapTapResolveError(e: tap_mod.TapError) InstallError {
 /// the caller cannot print "installed" without a committed row. The
 /// err wording is a public contract for `scripts/regressions/*.sh`.
 fn finalizeTapCaskInstall(
+    allocator: std.mem.Allocator,
     db: *sqlite.Database,
     cask: *const cask_mod.Cask,
     app_path: ?[]const u8,
@@ -993,9 +994,14 @@ fn finalizeTapCaskInstall(
     };
     // Tap row + etag are advisory; the cask row is the install
     // source of truth and tap_mod state self-heals on next sync.
+    // (owner, repo) routes through `effectiveOwnerRepo` so the
+    // persisted pair matches the one fetched against.
     if (tap_registration) |t| {
-        tap_mod.add(db, tap_label, t.url, t.commit_sha) catch {};
-        if (t.head_etag) |et| tap_mod.updateHead(db, tap_label, t.commit_sha, et) catch {};
+        if (tap_mod.effectiveOwnerRepo(allocator, db, tap_label)) |pair| {
+            defer pair.deinit(allocator);
+            tap_mod.add(db, tap_label, pair.owner, pair.repo, t.commit_sha) catch {};
+            if (t.head_etag) |et| tap_mod.updateHead(db, tap_label, t.commit_sha, et) catch {};
+        } else |_| {}
     }
 }
 
@@ -1084,7 +1090,7 @@ test "finalizeTapCaskInstall persists the cask row on the happy path" {
     var cask = try cask_mod.parseCask(std.testing.allocator, json_buf.items);
     defer cask.deinit();
 
-    try finalizeTapCaskInstall(&db, &cask, "/tmp/Deck.app", "yuzeguitarist/deck", null);
+    try finalizeTapCaskInstall(std.testing.allocator, &db, &cask, "/tmp/Deck.app", "yuzeguitarist/deck", null);
 
     var stmt = try db.prepare("SELECT version, tap FROM casks WHERE token = ?1;");
     defer stmt.finalize();
@@ -1118,7 +1124,9 @@ test "finalizeTapCaskInstall stamps the owning tap when tap_registration is set"
         \\    name TEXT PRIMARY KEY,
         \\    url TEXT NOT NULL,
         \\    commit_sha TEXT,
-        \\    head_etag TEXT
+        \\    head_etag TEXT,
+        \\    github_owner TEXT NOT NULL DEFAULT '',
+        \\    github_repo TEXT NOT NULL DEFAULT ''
         \\);
     );
 
@@ -1139,7 +1147,7 @@ test "finalizeTapCaskInstall stamps the owning tap when tap_registration is set"
 
     // updateHead validates SHA shape; a short SHA silently skips etag.
     const sha = "0123456789abcdef0123456789abcdef01234567";
-    try finalizeTapCaskInstall(&db, &cask, "/tmp/Deck.app", "yuzeguitarist/deck", .{
+    try finalizeTapCaskInstall(std.testing.allocator, &db, &cask, "/tmp/Deck.app", "yuzeguitarist/deck", .{
         .url = "https://github.com/yuzeguitarist/homebrew-deck",
         .commit_sha = sha,
         .head_etag = "\"etag-abc\"",
@@ -1182,7 +1190,7 @@ test "finalizeTapCaskInstall fails loud when the cask DB row cannot persist" {
 
     // Mirror the materializeTapCask call site shape.
     var finalize_err: ?InstallError = null;
-    finalizeTapCaskInstall(&db, &cask, null, "yuzeguitarist/deck", null) catch |e| {
+    finalizeTapCaskInstall(std.testing.allocator, &db, &cask, null, "yuzeguitarist/deck", null) catch |e| {
         finalize_err = e;
     };
     if (finalize_err == null) {

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -466,7 +466,7 @@ const HeadResolverCtx = struct {
     fn resolve(userdata: *anyopaque, a: std.mem.Allocator, tap_label: []const u8) ?[]const u8 {
         // Unpack the userdata pointer the cache hands back per call.
         const self: *HeadResolverCtx = @ptrCast(@alignCast(userdata));
-        const urls = tap_mod.resolveTapBaseUrls(a, tap_label) catch return null;
+        const urls = tap_mod.resolveTapBaseUrls(a, self.db, tap_label) catch return null;
 
         // catch null: a DB hiccup here just degrades to "no cached pin /
         // etag" — the resolve then runs unconditional (same as a cold
@@ -530,7 +530,7 @@ fn tapCaskLatestVersion(
 
     // The .rb fetch is per-cask (different token per row), so it stays
     // out of the cache — only the tap-HEAD resolve dedups.
-    const urls = tap_mod.resolveTapBaseUrls(alloc, tap_label) catch return null;
+    const urls = tap_mod.resolveTapBaseUrls(alloc, db, tap_label) catch return null;
     defer urls.deinit(alloc);
 
     var http = client_mod.HttpClient.init(io, environ, alloc);

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -2,15 +2,68 @@
 //! Manage taps (tap/untap).
 
 const std = @import("std");
+
 const AppCtx = @import("../app_ctx.zig").AppCtx;
-const sqlite = @import("../db/sqlite.zig");
-const schema = @import("../db/schema.zig");
 const tap_mod = @import("../core/tap.zig");
+const schema = @import("../db/schema.zig");
+const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
 const help = @import("help.zig");
 
 pub const TapNameError = error{InvalidTapName};
+
+pub const RepoOverrideError = error{InvalidRepoOverride} || std.mem.Allocator.Error;
+
+/// Parse `--repo <owner>/<exact-repo>` into an owned `(owner, repo)`
+/// pair. Reuses the slug-validation rules so the override can't sneak
+/// past validateTapName by going through the flag. Caller owns both
+/// slices via `TapPair.deinit`.
+pub fn parseRepoOverride(allocator: std.mem.Allocator, raw: []const u8) RepoOverrideError!tap_mod.TapPair {
+    validateTapName(raw) catch return RepoOverrideError.InvalidRepoOverride;
+    const slash = std.mem.indexOfScalar(u8, raw, '/') orelse unreachable;
+    const owner = raw[0..slash];
+    const repo = raw[slash + 1 ..];
+    const owner_owned = try allocator.dupe(u8, owner);
+    errdefer allocator.free(owner_owned);
+    const repo_owned = try allocator.dupe(u8, repo);
+    return .{ .owner = owner_owned, .repo = repo_owned };
+}
+
+test "parseRepoOverride accepts user/repo and returns the owned pair" {
+    const pair = try parseRepoOverride(std.testing.allocator, "aeroxy/ast-outline");
+    defer pair.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("aeroxy", pair.owner);
+    try std.testing.expectEqualStrings("ast-outline", pair.repo);
+}
+
+test "parseRepoOverride rejects a malformed override (no slash, double slash, empty parts)" {
+    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "noslash"));
+    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "user//repo"));
+    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "user/"));
+    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "/repo"));
+}
+
+test "parseRepoOverride preserves hyphens, digits, dots in both components" {
+    // GitHub allows these in user and repo names; the validator must
+    // not reject them when a user passes them through --repo.
+    const pair = try parseRepoOverride(std.testing.allocator, "user-1/some.repo_v2");
+    defer pair.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("user-1", pair.owner);
+    try std.testing.expectEqualStrings("some.repo_v2", pair.repo);
+}
+
+test "parseRepoOverride rejects components longer than 64 chars" {
+    // Pre-existing validateTapName cap. Documented here so a future
+    // relaxation surfaces as a test diff rather than silent acceptance.
+    const long = "a" ** 65 ++ "/" ++ "b" ** 4;
+    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, long));
+}
+
+test "parseRepoOverride rejects a leading dot (path-traversal-shaped names)" {
+    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, ".hidden/repo"));
+    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "user/.hidden"));
+}
 
 /// Reject malformed `user/repo` inputs before they're formatted into a
 /// GitHub URL or stored as a tap name. No security boundary (no shell
@@ -341,11 +394,17 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
     // --refresh <name>: update the stored commit pin to current HEAD.
     // --pin <user/repo> <sha>: explicit pin; consumes the next two argv slots.
     // --refresh --all: walk every registered tap and refresh in batch.
+    // --repo <owner>/<exact-repo>: pin the GitHub repo identifier for
+    //   third-party taps whose repo does not carry the `homebrew-` prefix.
+    // --force: rebind an existing row to a new --repo target, clearing
+    //   the stale commit pin in the process.
     var refresh_target: ?[]const u8 = null;
     var refresh_all = false;
     var pin_slug: ?[]const u8 = null;
     var pin_sha: ?[]const u8 = null;
     var yes = false;
+    var force = false;
+    var repo_override: ?[]const u8 = null;
     var positional: ?[]const u8 = null;
     var i: usize = 0;
     while (i < args.len) : (i += 1) {
@@ -358,6 +417,25 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
             refresh_all = true;
         } else if (std.mem.eql(u8, arg, "--yes") or std.mem.eql(u8, arg, "-y")) {
             yes = true;
+        } else if (std.mem.eql(u8, arg, "--force")) {
+            force = true;
+        } else if (std.mem.eql(u8, arg, "--repo")) {
+            if (action != .add) {
+                output.err("--repo is only valid with `mt tap`", .{});
+                return error.Aborted;
+            }
+            if (i + 1 >= args.len) {
+                output.err("Usage: mt tap <slug> --repo <owner>/<exact-repo>", .{});
+                return error.Aborted;
+            }
+            repo_override = args[i + 1];
+            i += 1;
+        } else if (std.mem.startsWith(u8, arg, "--repo=")) {
+            if (action != .add) {
+                output.err("--repo is only valid with `mt tap`", .{});
+                return error.Aborted;
+            }
+            repo_override = arg["--repo=".len..];
         } else if (std.mem.eql(u8, arg, "--pin")) {
             if (action != .add) {
                 output.err("--pin is only valid with `mt tap`", .{});
@@ -376,6 +454,23 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
     }
     if (refresh_target) |rt| {
         if (rt.len == 0) refresh_target = positional;
+    }
+
+    // --repo / --force only make sense on the add path with a positional
+    // slug. Refuse early so silent drops don't masquerade as success.
+    if (repo_override != null) {
+        if (refresh_all or refresh_target != null or pin_slug != null) {
+            output.err("--repo cannot be combined with --refresh or --pin", .{});
+            return error.Aborted;
+        }
+        if (positional == null) {
+            output.err("Usage: mt tap <user>/<repo> --repo <owner>/<exact-repo>", .{});
+            return error.Aborted;
+        }
+    }
+    if (force and repo_override == null) {
+        output.err("--force is only valid alongside --repo", .{});
+        return error.Aborted;
     }
 
     const prefix = atomic.maltPrefixOrAbort();
@@ -472,13 +567,56 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
 
     switch (action) {
         .add => {
-            const urls = try tap_mod.resolveTapBaseUrls(allocator, name);
+            // --repo overrides any stored pair; otherwise the helper
+            // reads the row, falling back to the slug-derived
+            // `(user, "homebrew-" || repo)` default the first time round.
+            const target_pair = pair: {
+                if (repo_override) |rep| break :pair parseRepoOverride(allocator, rep) catch |e| switch (e) {
+                    error.InvalidRepoOverride => {
+                        output.err("Invalid --repo '{s}'. Expected: owner/exact-repo with [A-Za-z0-9._-]", .{rep});
+                        return error.Aborted;
+                    },
+                    error.OutOfMemory => return error.OutOfMemory,
+                };
+                break :pair try tap_mod.effectiveOwnerRepo(allocator, &db, name);
+            };
+            defer target_pair.deinit(allocator);
+
+            // Rebind policy: refuse if a row already pins a different
+            // (owner, repo) unless --force. Matches the pin-stays-sticky
+            // posture of `tap_mod.add`'s COALESCE on commit_sha.
+            const stored_opt = tap_mod.getOwnerRepo(allocator, &db, name) catch null;
+            defer if (stored_opt) |p| p.deinit(allocator);
+            var rebinding = false;
+            if (stored_opt) |stored| {
+                const same = std.mem.eql(u8, stored.owner, target_pair.owner) and
+                    std.mem.eql(u8, stored.repo, target_pair.repo);
+                if (!same) {
+                    if (!force) {
+                        output.err("Tap {s} is already bound to {s}/{s}. Re-run with --force to rebind to {s}/{s}.", .{ name, stored.owner, stored.repo, target_pair.owner, target_pair.repo });
+                        return error.Aborted;
+                    }
+                    rebinding = true;
+                }
+            }
+
+            // Apply the rebind before any HTTP work. Clearing the pin
+            // upfront means a network failure leaves the row in the
+            // "needs refresh" state rather than half-rebound with stale
+            // SHA + new (owner, repo).
+            if (rebinding) {
+                tap_mod.rebind(&db, name, target_pair.owner, target_pair.repo) catch {
+                    output.err("Failed to rebind tap {s}", .{name});
+                    return error.Aborted;
+                };
+            }
+
+            const urls = try tap_mod.buildTapBaseUrls(allocator, target_pair.owner, target_pair.repo);
             defer urls.deinit(allocator);
 
-            // Resolve HEAD so the tap is pinned from day one. Failing
-            // here beats silently registering an unpinned tap. Idempotent
-            // re-adds reuse the cached etag so a second `tap add` against
-            // a stable tap costs zero rate-limit tokens.
+            // Idempotent re-adds reuse the cached etag for stable taps —
+            // a rebind cleared both fields above, so this is null on
+            // that path.
             const cached_sha_opt = tap_mod.getCommitSha(allocator, &db, name) catch null;
             defer if (cached_sha_opt) |s| allocator.free(s);
             const cached_etag_opt = tap_mod.getHeadEtag(allocator, &db, name) catch null;
@@ -486,6 +624,9 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
 
             var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, cached_etag_opt) catch |e| {
                 output.err("Could not resolve {s}'s HEAD commit: {s}", .{ name, tap_mod.describeResolveError(e) });
+                // Rebind already moved (owner, repo) and cleared the pin —
+                // the row is unfetchable until `mt tap --refresh {slug}` lands a fresh SHA.
+                if (rebinding) output.warn("Rebind applied with no pin — run `mt tap --refresh {s}` to recover.", .{name});
                 return error.Aborted;
             };
             defer head_res.deinit();
@@ -499,7 +640,7 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
                     output.err("Could not resolve {s}'s HEAD commit: empty response", .{name});
                     return error.Aborted;
                 });
-            tap_mod.add(&db, name, urls.repo_url, sha) catch {
+            tap_mod.add(&db, name, target_pair.owner, target_pair.repo, sha) catch {
                 output.err("Failed to add tap {s}", .{name});
                 return error.Aborted;
             };
@@ -543,7 +684,7 @@ fn pinTap(
     // installs will use. A 404 means GitHub has no such commit on this repo.
     // /commits/<sha> is sha-pinned so the ETag has no caching value — pass
     // null and ignore any etag the server happens to return.
-    const commit_url = try tap_mod.resolveCommitUrl(allocator, slug, sha);
+    const commit_url = try tap_mod.resolveCommitUrl(allocator, db, slug, sha);
     defer allocator.free(commit_url);
     var echoed_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, commit_url, null) catch |e| {
         if (e == error.NotFound) {
@@ -566,9 +707,9 @@ fn pinTap(
         return error.Aborted;
     }
 
-    const urls = try tap_mod.resolveTapBaseUrls(allocator, slug);
-    defer urls.deinit(allocator);
-    tap_mod.add(db, slug, urls.repo_url, sha) catch {
+    const pair = try tap_mod.effectiveOwnerRepo(allocator, db, slug);
+    defer pair.deinit(allocator);
+    tap_mod.add(db, slug, pair.owner, pair.repo, sha) catch {
         output.err("Failed to pin {s}", .{slug});
         return error.Aborted;
     };
@@ -617,7 +758,7 @@ fn refreshAll(
     try rows.ensureTotalCapacityPrecise(allocator, taps.len);
 
     for (taps) |t| {
-        const pair = resolveOneHead(ctx, allocator, t.name) catch null;
+        const pair = resolveOneHead(ctx, allocator, db, t.name) catch null;
         const new_sha: ?[]const u8 = if (pair) |p| p.sha else null;
         const new_et: ?[]const u8 = if (pair) |p| p.etag else null;
         new_shas.appendAssumeCapacity(new_sha);
@@ -657,9 +798,10 @@ const RefreshedHead = struct { sha: []const u8, etag: ?[]const u8 };
 fn resolveOneHead(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
+    db: *sqlite.Database,
     slug: []const u8,
 ) !RefreshedHead {
-    const urls = try tap_mod.resolveTapBaseUrls(allocator, slug);
+    const urls = try tap_mod.resolveTapBaseUrls(allocator, db, slug);
     defer urls.deinit(allocator);
     // `tap --refresh` is the explicit "force fresh" verb — never send
     // If-None-Match so a stale-but-unmoved upstream still surfaces a
@@ -693,7 +835,7 @@ fn refreshTap(ctx: *const AppCtx, allocator: std.mem.Allocator, db: *sqlite.Data
         output.err("Invalid tap '{s}'. Expected: user/repo with [A-Za-z0-9._-]", .{name});
         return error.Aborted;
     };
-    const urls = try tap_mod.resolveTapBaseUrls(allocator, name);
+    const urls = try tap_mod.resolveTapBaseUrls(allocator, db, name);
     defer urls.deinit(allocator);
     // Force fresh: bypass the cached etag so the operator sees the
     // current body. The new etag is still persisted afterwards so the

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -2,32 +2,33 @@
 //! Upgrade installed packages and casks.
 
 const std = @import("std");
+
 const AppCtx = @import("../app_ctx.zig").AppCtx;
-const sqlite = @import("../db/sqlite.zig");
-const schema = @import("../db/schema.zig");
-const atomic = @import("../fs/atomic.zig");
-const output = @import("../ui/output.zig");
-const lock_mod = @import("../db/lock.zig");
-const client_mod = @import("../net/client.zig");
-const api_mod = @import("../net/api.zig");
 const cask_mod = @import("../core/cask.zig");
-const formula_mod = @import("../core/formula.zig");
-const store_mod = @import("../core/store.zig");
 const cellar_mod = @import("../core/cellar.zig");
+const deps_mod = @import("../core/deps.zig");
+const formula_mod = @import("../core/formula.zig");
 const linker_mod = @import("../core/linker.zig");
+const store_mod = @import("../core/store.zig");
+const tap_mod = @import("../core/tap.zig");
+const lock_mod = @import("../db/lock.zig");
+const schema = @import("../db/schema.zig");
+const sqlite = @import("../db/sqlite.zig");
+const atomic = @import("../fs/atomic.zig");
+const api_mod = @import("../net/api.zig");
+const client_mod = @import("../net/client.zig");
 const ghcr_mod = @import("../net/ghcr.zig");
+const output = @import("../ui/output.zig");
+const progress_mod = @import("../ui/progress.zig");
 const help = @import("help.zig");
-const pin_mod = @import("pin.zig");
-const install_mod = @import("install.zig");
-const install_local_mod = @import("install/local.zig");
-const install_rb_parse_mod = @import("install/rb_parse.zig");
 const install_args_mod = @import("install/args.zig");
 const install_download_mod = @import("install/download.zig");
+const install_local_mod = @import("install/local.zig");
+const install_rb_parse_mod = @import("install/rb_parse.zig");
 const install_record_mod = @import("install/record.zig");
 const InstallError = install_record_mod.InstallError;
-const progress_mod = @import("../ui/progress.zig");
-const tap_mod = @import("../core/tap.zig");
-const deps_mod = @import("../core/deps.zig");
+const install_mod = @import("install.zig");
+const pin_mod = @import("pin.zig");
 
 const UpgradeFlag = enum { quiet, cask, formula, dry_run, force, pinned };
 
@@ -441,7 +442,7 @@ fn upgradeTapFormula(
         return error.Aborted;
     }
 
-    const urls = try tap_mod.resolveTapBaseUrls(allocator, tap_label);
+    const urls = try tap_mod.resolveTapBaseUrls(allocator, db, tap_label);
     defer urls.deinit(allocator);
 
     // `mt upgrade` asks GitHub "has HEAD moved?". Sending the cached
@@ -488,10 +489,19 @@ fn upgradeTapFormula(
 
     // Persist the new pin BEFORE installTapFormula reads it. Use add()
     // so a missing tap row (legacy install) is created instead of erroring.
-    tap_mod.add(db, tap_label, urls.repo_url, fresh_sha) catch {
-        output.err("Could not pin {s} to {s}", .{ tap_label, fresh_sha });
-        return error.Aborted;
-    };
+    // (owner, repo) routes through `effectiveOwnerRepo` so the synthesis
+    // used at HEAD resolve time matches the row that records the pin.
+    {
+        const pair = tap_mod.effectiveOwnerRepo(allocator, db, tap_label) catch {
+            output.err("Could not pin {s} to {s}", .{ tap_label, fresh_sha });
+            return error.Aborted;
+        };
+        defer pair.deinit(allocator);
+        tap_mod.add(db, tap_label, pair.owner, pair.repo, fresh_sha) catch {
+            output.err("Could not pin {s} to {s}", .{ tap_label, fresh_sha });
+            return error.Aborted;
+        };
+    }
     // Refresh the etag on 200 so the next upgrade short-circuits. On 304
     // the etag we already hold is by definition still current.
     if (!head_res.not_modified) {
@@ -534,7 +544,7 @@ fn upgradeRoutedTapCask(
     const slash = std.mem.indexOfScalar(u8, tap_label, '/') orelse return error.Aborted;
     if (slash == 0 or slash == tap_label.len - 1) return error.Aborted;
 
-    const urls = tap_mod.resolveTapBaseUrls(allocator, tap_label) catch return error.Aborted;
+    const urls = tap_mod.resolveTapBaseUrls(allocator, db, tap_label) catch return error.Aborted;
     defer urls.deinit(allocator);
 
     // Send the cached etag so a stable tap 304s for free; on 200 we
@@ -585,10 +595,17 @@ fn upgradeRoutedTapCask(
 
     // Persist the new pin BEFORE installTapFormula reads it via
     // `tap_mod.getCommitSha`. Same pattern as `upgradeTapFormula`.
-    tap_mod.add(db, tap_label, urls.repo_url, fresh_sha) catch {
-        output.err("Could not pin {s} to {s}", .{ tap_label, fresh_sha });
-        return error.Aborted;
-    };
+    {
+        const pair = tap_mod.effectiveOwnerRepo(allocator, db, tap_label) catch {
+            output.err("Could not pin {s} to {s}", .{ tap_label, fresh_sha });
+            return error.Aborted;
+        };
+        defer pair.deinit(allocator);
+        tap_mod.add(db, tap_label, pair.owner, pair.repo, fresh_sha) catch {
+            output.err("Could not pin {s} to {s}", .{ tap_label, fresh_sha });
+            return error.Aborted;
+        };
+    }
     // On 200, refresh the etag so the next round can 304. On 304 the
     // cached etag is by definition still current.
     if (!head_res.not_modified) {

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const sqlite = @import("../db/sqlite.zig");
 const client_mod = @import("../net/client.zig");
 
@@ -15,7 +16,8 @@ pub const TapError = error{
     /// Catch-all for causes we could not classify (5xx, unknown status, etc.).
     ResolveFailed,
     InvalidSha,
-    /// GitHub answered 404 — the tap repo is not at `homebrew-<repo>`.
+    /// GitHub answered 404 — the resolved `(owner, repo)` does not name
+    /// a real repo. Triggers the `--repo` remediation hint in `describeResolveError`.
     NotFound,
     /// GitHub answered 403 — public cap is 60/hr per IP.
     RateLimited,
@@ -55,7 +57,7 @@ pub fn githubAuthHeader(environ: std.process.Environ, buf: []u8) ?std.http.Heade
 pub fn describeResolveError(err: TapError) []const u8 {
     return switch (err) {
         error.RateLimited => "GitHub API rate limit reached. Set MALT_GITHUB_TOKEN to an authorized GitHub token to lift the 60/hr anonymous cap.",
-        error.NotFound => "GitHub returned 404 for the tap repo. Third-party taps must live at github.com/<user>/homebrew-<repo>; taps that drop the 'homebrew-' prefix are not yet supported.",
+        error.NotFound => "GitHub returned 404 for the tap repo. If the repo lives at github.com/<user>/<exact-name> instead of github.com/<user>/homebrew-<repo>, rerun with --repo <user>/<exact-name>.",
         error.NetworkError => "Network failure while reaching api.github.com — check connectivity and retry.",
         error.MalformedJson => "Unexpected response shape from GitHub — rerun with --debug and attach the log when filing an issue.",
         error.InvalidSha => "GitHub returned a commit SHA that failed validation (not 40-char lowercase hex).",
@@ -64,28 +66,77 @@ pub fn describeResolveError(err: TapError) []const u8 {
     };
 }
 
+/// Format string for the `taps.url` projection. Centralised so the
+/// INSERT/rebind writer and the read-time projection in `list()` can't
+/// drift — a future host swap (GitLab, Gitea) flips this one literal.
+const repo_url_fmt = "https://github.com/{s}/{s}";
+
+/// Materialise `taps.url` from `(owner, repo)` into a caller buffer.
+/// `buf` must hold ≥160 bytes (19 prefix + 2·64 component cap + 1 slash).
+fn writeRepoUrl(buf: []u8, owner: []const u8, repo: []const u8) sqlite.SqliteError![]const u8 {
+    return std.fmt.bufPrint(buf, repo_url_fmt, .{ owner, repo }) catch
+        sqlite.SqliteError.ExecFailed;
+}
+
 pub fn add(
     db: *sqlite.Database,
     name: []const u8,
-    url: []const u8,
+    owner: []const u8,
+    repo: []const u8,
     commit_sha: ?[]const u8,
 ) sqlite.SqliteError!void {
-    // URL is sticky on conflict (URL doesn't change once registered);
-    // commit_sha is sticky unless the caller passes a new one. Refresh
-    // goes through `updateCommit` which forces a replacement.
+    // Owner/repo are sticky on conflict — the rebind verb is the only
+    // sanctioned mutator. commit_sha is sticky unless a fresh one is
+    // passed (refresh goes through `updateCommit`/`updateHead`).
+    var url_buf: [256]u8 = undefined;
+    const derived_url = try writeRepoUrl(&url_buf, owner, repo);
+
     var stmt = try db.prepare(
-        \\INSERT INTO taps (name, url, commit_sha) VALUES (?1, ?2, ?3)
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo) VALUES (?1, ?2, ?3, ?4, ?5)
         \\ON CONFLICT(name) DO UPDATE SET
         \\    commit_sha = COALESCE(excluded.commit_sha, taps.commit_sha);
     );
     defer stmt.finalize();
     try stmt.bindText(1, name);
-    try stmt.bindText(2, url);
+    try stmt.bindText(2, derived_url);
     if (commit_sha) |s| {
         try stmt.bindText(3, s);
     } else {
         try stmt.bindNull(3);
     }
+    try stmt.bindText(4, owner);
+    try stmt.bindText(5, repo);
+    _ = try stmt.step();
+}
+
+/// Rebind an existing tap row to a new `(owner, repo)` pair. Clears the
+/// commit SHA and ETag because the moved repo has its own HEAD — keeping
+/// the old pin would freeze the row at a SHA that doesn't exist on the
+/// new repo. The CLI `--force` path is the only sanctioned caller; the
+/// default refuse-without-`--force` policy lives at the CLI layer.
+pub fn rebind(
+    db: *sqlite.Database,
+    name: []const u8,
+    owner: []const u8,
+    repo: []const u8,
+) sqlite.SqliteError!void {
+    var url_buf: [256]u8 = undefined;
+    const derived_url = try writeRepoUrl(&url_buf, owner, repo);
+
+    var stmt = try db.prepare(
+        \\UPDATE taps SET
+        \\    github_owner = ?1,
+        \\    github_repo  = ?2,
+        \\    url          = ?3,
+        \\    commit_sha   = NULL,
+        \\    head_etag    = NULL
+        \\WHERE name = ?4;
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, owner);
+    try stmt.bindText(2, repo);
+    try stmt.bindText(3, derived_url);
+    try stmt.bindText(4, name);
     _ = try stmt.step();
 }
 
@@ -178,19 +229,25 @@ pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) ![]TapInfo {
         taps.deinit(allocator);
     }
 
-    var stmt = try db.prepare("SELECT name, url, commit_sha FROM taps;");
+    // Project `url` from (github_owner, github_repo) so the listing
+    // can't disagree with the actual fetch target.
+    var stmt = try db.prepare("SELECT name, github_owner, github_repo, commit_sha FROM taps;");
     defer stmt.finalize();
 
     while (try stmt.step()) {
         const n = stmt.columnText(0) orelse continue;
-        const u = stmt.columnText(1) orelse continue;
+        const o = stmt.columnText(1) orelse continue;
+        const r = stmt.columnText(2) orelse continue;
 
-        // Build the row in locals so a later dupe failure can't strand an earlier one.
         const name_owned = try allocator.dupe(u8, std.mem.sliceTo(n, 0));
         errdefer allocator.free(name_owned);
-        const url_owned = try allocator.dupe(u8, std.mem.sliceTo(u, 0));
+        const url_owned = try std.fmt.allocPrint(
+            allocator,
+            repo_url_fmt,
+            .{ std.mem.sliceTo(o, 0), std.mem.sliceTo(r, 0) },
+        );
         errdefer allocator.free(url_owned);
-        const sha_owned: ?[]const u8 = if (stmt.columnText(2)) |s| blk: {
+        const sha_owned: ?[]const u8 = if (stmt.columnText(3)) |s| blk: {
             const trimmed = std.mem.sliceTo(s, 0);
             if (trimmed.len == 0) break :blk null;
             break :blk try allocator.dupe(u8, trimmed);
@@ -218,18 +275,18 @@ pub fn resolveFormula(allocator: std.mem.Allocator, user: []const u8, repo: []co
     return std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{ user, repo, formula });
 }
 
-/// URLs every tap fetch site needs, derived from one slug parse so the
-/// `homebrew-<repo>` synthesis lives in exactly one place. For raw
-/// fetches callers append `/<sha>/Formula/<name>.rb` (or `Casks/`) to
-/// `raw_base` — keeping the sha out of the helper means the API URL
-/// (queried before any sha exists) shares the same synthesis path.
+/// URLs every tap fetch site needs, derived from a `(github_owner,
+/// github_repo)` pair so the prefix decision lives in the row (or in
+/// the `effectiveOwnerRepo` cold-path fallback), never in the URL
+/// template. For raw fetches callers append `/<sha>/Formula/<name>.rb`
+/// (or `Casks/`) to `raw_base`.
 pub const TapBaseUrls = struct {
-    /// `https://api.github.com/repos/<user>/homebrew-<repo>/commits/HEAD`
+    /// `https://api.github.com/repos/<owner>/<repo>/commits/HEAD`
     api_head_url: []const u8,
-    /// `https://github.com/<user>/homebrew-<repo>` — the URL that actually
-    /// resolves; written to `taps.url`.
+    /// `https://github.com/<owner>/<repo>` — the URL that actually
+    /// resolves; mirrored into `taps.url` at INSERT/rebind time.
     repo_url: []const u8,
-    /// `https://raw.githubusercontent.com/<user>/homebrew-<repo>` — caller
+    /// `https://raw.githubusercontent.com/<owner>/<repo>` — caller
     /// appends `/<sha>/Formula/<name>.rb` or `/<sha>/Casks/<name>.rb`.
     raw_base: []const u8,
 
@@ -240,37 +297,34 @@ pub const TapBaseUrls = struct {
     }
 };
 
-/// Build every URL needed to talk to a tap repo from its `user/repo` slug.
-/// Single seam for `homebrew-<repo>` prefix synthesis — a future change
-/// to the URL shape (prefixless taps, non-GitHub hosts) lands in one
-/// file. `slug` must be a validated `user/repo` form (see
-/// `cli/tap.zig:validateTapName`); a missing `/` trips `unreachable`.
-pub fn resolveTapBaseUrls(
+/// Build the URL triple from an explicit `(owner, repo)` pair. Single
+/// site where the GitHub URL shape lives; both the row-read path and
+/// the cold registration path (`mt tap --repo X/Y`, default derivation
+/// before the row exists) route through here. Adding a non-GitHub host
+/// later is a switch on the host column at this seam.
+pub fn buildTapBaseUrls(
     allocator: std.mem.Allocator,
-    slug: []const u8,
+    owner: []const u8,
+    repo: []const u8,
 ) std.mem.Allocator.Error!TapBaseUrls {
-    const slash = std.mem.indexOfScalar(u8, slug, '/') orelse unreachable;
-    const user = slug[0..slash];
-    const repo = slug[slash + 1 ..];
-
     const api_head_url = try std.fmt.allocPrint(
         allocator,
-        "https://api.github.com/repos/{s}/homebrew-{s}/commits/HEAD",
-        .{ user, repo },
+        "https://api.github.com/repos/{s}/{s}/commits/HEAD",
+        .{ owner, repo },
     );
     errdefer allocator.free(api_head_url);
 
     const repo_url = try std.fmt.allocPrint(
         allocator,
-        "https://github.com/{s}/homebrew-{s}",
-        .{ user, repo },
+        "https://github.com/{s}/{s}",
+        .{ owner, repo },
     );
     errdefer allocator.free(repo_url);
 
     const raw_base = try std.fmt.allocPrint(
         allocator,
-        "https://raw.githubusercontent.com/{s}/homebrew-{s}",
-        .{ user, repo },
+        "https://raw.githubusercontent.com/{s}/{s}",
+        .{ owner, repo },
     );
     errdefer allocator.free(raw_base);
 
@@ -279,6 +333,77 @@ pub fn resolveTapBaseUrls(
         .repo_url = repo_url,
         .raw_base = raw_base,
     };
+}
+
+/// Owner+repo pair read off a tap row. Caller owns both slices.
+pub const TapPair = struct {
+    owner: []const u8,
+    repo: []const u8,
+
+    pub fn deinit(self: TapPair, allocator: std.mem.Allocator) void {
+        allocator.free(self.owner);
+        allocator.free(self.repo);
+    }
+};
+
+/// Read `(github_owner, github_repo)` for `slug`, or null when the row
+/// doesn't exist yet (cold path during `mt tap` registration).
+pub fn getOwnerRepo(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    slug: []const u8,
+) !?TapPair {
+    var stmt = try db.prepare(
+        "SELECT github_owner, github_repo FROM taps WHERE name = ?1;",
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, slug);
+    if (!(try stmt.step())) return null;
+    const owner_raw = stmt.columnText(0) orelse return null;
+    const repo_raw = stmt.columnText(1) orelse return null;
+    const owner_trim = std.mem.sliceTo(owner_raw, 0);
+    const repo_trim = std.mem.sliceTo(repo_raw, 0);
+    if (owner_trim.len == 0 or repo_trim.len == 0) return null;
+
+    const owner_owned = try allocator.dupe(u8, owner_trim);
+    errdefer allocator.free(owner_owned);
+    const repo_owned = try allocator.dupe(u8, repo_trim);
+    return .{ .owner = owner_owned, .repo = repo_owned };
+}
+
+/// Single point where the slug-derived default `(user, "homebrew-" || repo)`
+/// is synthesised — the cold path during initial `mt tap` registration,
+/// before the row is written. Future fetch sites that need a pair MUST
+/// route through here so the prefix synthesis can never drift across
+/// helpers. `slug` must be a validated `user/repo` form.
+pub fn effectiveOwnerRepo(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    slug: []const u8,
+) !TapPair {
+    if (try getOwnerRepo(allocator, db, slug)) |pair| return pair;
+    const slash = std.mem.indexOfScalar(u8, slug, '/') orelse unreachable;
+    const user = slug[0..slash];
+    const repo_part = slug[slash + 1 ..];
+    const owner_owned = try allocator.dupe(u8, user);
+    errdefer allocator.free(owner_owned);
+    const repo_owned = try std.fmt.allocPrint(allocator, "homebrew-{s}", .{repo_part});
+    return .{ .owner = owner_owned, .repo = repo_owned };
+}
+
+/// Build every URL needed to talk to a tap repo. Reads the row's
+/// `(github_owner, github_repo)` when present and falls back to the
+/// slug-derived default through `effectiveOwnerRepo` — the single seam
+/// where the `homebrew-<repo>` synthesis lives. `slug` must be a
+/// validated `user/repo` form.
+pub fn resolveTapBaseUrls(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    slug: []const u8,
+) !TapBaseUrls {
+    const pair = try effectiveOwnerRepo(allocator, db, slug);
+    defer pair.deinit(allocator);
+    return buildTapBaseUrls(allocator, pair.owner, pair.repo);
 }
 
 // ── resolveFromConditional: response → HeadResolution conversion ────
@@ -429,7 +554,7 @@ test "getHeadEtag returns null on a fresh row (no etag stamped yet)" {
     defer db.close();
     const schema = @import("../db/schema.zig");
     try schema.initSchema(&db);
-    try add(&db, "user/repo", "https://github.com/user/repo", null);
+    try add(&db, "user/repo", "user", "homebrew-repo", null);
     const et = try getHeadEtag(std.testing.allocator, &db, "user/repo");
     try std.testing.expectEqual(@as(?[]const u8, null), et);
 }
@@ -439,7 +564,7 @@ test "updateHead persists sha + etag atomically; getHeadEtag round-trips" {
     defer db.close();
     const schema = @import("../db/schema.zig");
     try schema.initSchema(&db);
-    try add(&db, "user/repo", "https://github.com/user/repo", null);
+    try add(&db, "user/repo", "user", "homebrew-repo", null);
 
     const sha = "0123456789abcdef0123456789abcdef01234567";
     try updateHead(&db, "user/repo", sha, "W/\"feed\"");
@@ -458,7 +583,7 @@ test "updateHead with null etag clears the column (server omitted ETag)" {
     defer db.close();
     const schema = @import("../db/schema.zig");
     try schema.initSchema(&db);
-    try add(&db, "user/repo", "https://github.com/user/repo", null);
+    try add(&db, "user/repo", "user", "homebrew-repo", null);
 
     const sha = "0123456789abcdef0123456789abcdef01234567";
     try updateHead(&db, "user/repo", sha, "W/\"feed\"");
@@ -496,7 +621,7 @@ test "updateHead rejects an invalid SHA before touching the row" {
     defer db.close();
     const schema = @import("../db/schema.zig");
     try schema.initSchema(&db);
-    try add(&db, "user/repo", "https://github.com/user/repo", null);
+    try add(&db, "user/repo", "user", "homebrew-repo", null);
     try updateHead(&db, "user/repo", "0123456789abcdef0123456789abcdef01234567", "W/\"feed\"");
 
     // Validator runs first — DB stays at the prior value.
@@ -507,8 +632,17 @@ test "updateHead rejects an invalid SHA before touching the row" {
     try std.testing.expectEqualStrings("W/\"feed\"", et);
 }
 
-test "resolveTapBaseUrls synthesises homebrew- prefix once per field" {
-    const urls = try resolveTapBaseUrls(std.testing.allocator, "aeroxy/tap");
+test "resolveTapBaseUrls falls back to slug-derived defaults when no row exists" {
+    // Cold path during initial `mt tap` registration — the row hasn't
+    // been written yet, so the helper synthesises the `homebrew-<repo>`
+    // default from the slug so the HEAD resolve can find the row's
+    // first commit before we persist it.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+
+    const urls = try resolveTapBaseUrls(std.testing.allocator, &db, "aeroxy/tap");
     defer urls.deinit(std.testing.allocator);
 
     try std.testing.expectEqualStrings(
@@ -525,28 +659,90 @@ test "resolveTapBaseUrls synthesises homebrew- prefix once per field" {
     );
 }
 
-/// Build the `commits/<sha>` URL siblings of `api_head_url`. Routed
-/// through the same `homebrew-<repo>` synthesis so `mt tap --pin` and the
-/// HEAD path can't drift apart — a 200 here means the SHA is reachable
-/// against the exact repo subsequent installs will fetch from.
-pub fn resolveCommitUrl(
-    allocator: std.mem.Allocator,
-    slug: []const u8,
-    sha: []const u8,
-) std.mem.Allocator.Error![]const u8 {
-    const slash = std.mem.indexOfScalar(u8, slug, '/') orelse unreachable;
-    const user = slug[0..slash];
-    const repo = slug[slash + 1 ..];
-    return std.fmt.allocPrint(
-        allocator,
-        "https://api.github.com/repos/{s}/homebrew-{s}/commits/{s}",
-        .{ user, repo, sha },
+test "resolveTapBaseUrls reads (owner, repo) from the row when present" {
+    // The structural-enforcement claim: once the row exists, the helper
+    // reads the stored pair and *never* re-synthesises the `homebrew-`
+    // prefix. A custom-repo row produces URLs that hit the user's
+    // exact GitHub identifier.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo)
+        \\VALUES ('aeroxy/ast-outline',
+        \\        'https://github.com/aeroxy/ast-outline',
+        \\        NULL, 'aeroxy', 'ast-outline');
+    );
+
+    const urls = try resolveTapBaseUrls(std.testing.allocator, &db, "aeroxy/ast-outline");
+    defer urls.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(
+        "https://api.github.com/repos/aeroxy/ast-outline/commits/HEAD",
+        urls.api_head_url,
+    );
+    try std.testing.expectEqualStrings(
+        "https://github.com/aeroxy/ast-outline",
+        urls.repo_url,
+    );
+    try std.testing.expectEqualStrings(
+        "https://raw.githubusercontent.com/aeroxy/ast-outline",
+        urls.raw_base,
     );
 }
 
-test "resolveCommitUrl builds the homebrew- prefixed commits/<sha> URL" {
+test "resolveTapBaseUrls reads the stored prefixed pair byte-for-byte" {
+    // A default-prefixed row read through the helper produces the same
+    // URLs the cold path would have synthesised — the helper must not
+    // re-derive the prefix when the row already carries it.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo)
+        \\VALUES ('user-1/some.v2',
+        \\        'https://github.com/user-1/homebrew-some.v2',
+        \\        NULL, 'user-1', 'homebrew-some.v2');
+    );
+
+    const urls = try resolveTapBaseUrls(std.testing.allocator, &db, "user-1/some.v2");
+    defer urls.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(
+        "https://api.github.com/repos/user-1/homebrew-some.v2/commits/HEAD",
+        urls.api_head_url,
+    );
+}
+
+/// Build the `commits/<sha>` URL sibling of `api_head_url`. Routes
+/// through the same `effectiveOwnerRepo` seam the HEAD path uses — a
+/// 200 here proves the SHA is reachable against the exact repo
+/// subsequent installs will fetch from.
+pub fn resolveCommitUrl(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    slug: []const u8,
+    sha: []const u8,
+) ![]const u8 {
+    const pair = try effectiveOwnerRepo(allocator, db, slug);
+    defer pair.deinit(allocator);
+    return std.fmt.allocPrint(
+        allocator,
+        "https://api.github.com/repos/{s}/{s}/commits/{s}",
+        .{ pair.owner, pair.repo, sha },
+    );
+}
+
+test "resolveCommitUrl falls back to slug-derived default when no row exists" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
     const sha = "0123456789abcdef0123456789abcdef01234567";
-    const url = try resolveCommitUrl(std.testing.allocator, "user/repo", sha);
+
+    const url = try resolveCommitUrl(std.testing.allocator, &db, "user/repo", sha);
     defer std.testing.allocator.free(url);
     try std.testing.expectEqualStrings(
         "https://api.github.com/repos/user/homebrew-repo/commits/" ++ sha,
@@ -554,18 +750,40 @@ test "resolveCommitUrl builds the homebrew- prefixed commits/<sha> URL" {
     );
 }
 
-test "resolveCommitUrl preserves hyphens and digits in repo names" {
+test "resolveCommitUrl reads (owner, repo) from the row when present" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo)
+        \\VALUES ('aeroxy/ast-outline',
+        \\        'https://github.com/aeroxy/ast-outline',
+        \\        NULL, 'aeroxy', 'ast-outline');
+    );
     const sha = "0123456789abcdef0123456789abcdef01234567";
-    const url = try resolveCommitUrl(std.testing.allocator, "user-1/some-tap.v2", sha);
+
+    const url = try resolveCommitUrl(std.testing.allocator, &db, "aeroxy/ast-outline", sha);
     defer std.testing.allocator.free(url);
     try std.testing.expectEqualStrings(
-        "https://api.github.com/repos/user-1/homebrew-some-tap.v2/commits/" ++ sha,
+        "https://api.github.com/repos/aeroxy/ast-outline/commits/" ++ sha,
         url,
     );
 }
 
-test "resolveTapBaseUrls preserves repo names containing hyphens and digits" {
-    const urls = try resolveTapBaseUrls(std.testing.allocator, "user-1/some-tap.v2");
+test "resolveTapBaseUrls preserves repo names containing hyphens and digits via the row" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo)
+        \\VALUES ('user-1/some-tap.v2',
+        \\        'https://github.com/user-1/homebrew-some-tap.v2',
+        \\        NULL, 'user-1', 'homebrew-some-tap.v2');
+    );
+
+    const urls = try resolveTapBaseUrls(std.testing.allocator, &db, "user-1/some-tap.v2");
     defer urls.deinit(std.testing.allocator);
 
     try std.testing.expectEqualStrings(

--- a/src/db/schema.zig
+++ b/src/db/schema.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const testing = std.testing;
+
 const sqlite = @import("sqlite.zig");
 
 /// Initialize the database schema (CREATE TABLE IF NOT EXISTS).
@@ -122,7 +124,7 @@ pub fn initSchema(db: *sqlite.Database) MigrateError!void {
 /// Highest schema version this binary knows how to operate on. Bump in
 /// lockstep with the last `migrateVNtoVN+1` step so a future binary's
 /// DB doesn't get silently used against older SQL.
-pub const known_schema_version: i64 = 8;
+pub const known_schema_version: i64 = 9;
 
 pub const MigrateError = sqlite.SqliteError || error{SchemaTooNew};
 
@@ -140,6 +142,7 @@ pub fn migrate(db: *sqlite.Database) MigrateError!void {
     if (ver < 6) try migrateV5toV6(db);
     if (ver < 7) try migrateV6toV7(db);
     if (ver < 8) try migrateV7toV8(db);
+    if (ver < 9) try migrateV8toV9(db);
 }
 
 fn migrateV1toV2(db: *sqlite.Database) sqlite.SqliteError!void {
@@ -463,6 +466,66 @@ fn migrateV7toV8(db: *sqlite.Database) sqlite.SqliteError!void {
     try db.commit();
 }
 
+/// v9 — promote the `homebrew-<repo>` prefix decision from inline format
+/// strings into structured `(github_owner, github_repo)` columns. The
+/// helper at `core/tap.zig` reads from the row; the prefix is no longer
+/// synthesised at fetch time. Existing rows backfill from the slug, so
+/// pre-v9 prefixed taps keep fetching from the same URLs byte-for-byte.
+fn migrateV8toV9(db: *sqlite.Database) sqlite.SqliteError!void {
+    try db.beginTransaction();
+    errdefer db.rollback();
+
+    // PRAGMA table_info returns zero rows when the table is missing — same
+    // partial-shape fixture defensiveness as v7→v8.
+    var have_table = false;
+    var have_owner = false;
+    var have_repo = false;
+    {
+        var stmt = try db.prepare("PRAGMA table_info(taps);");
+        defer stmt.finalize();
+        while (try stmt.step()) {
+            have_table = true;
+            const name = stmt.columnText(1) orelse continue;
+            const n = std.mem.sliceTo(name, 0);
+            if (std.mem.eql(u8, n, "github_owner")) have_owner = true;
+            if (std.mem.eql(u8, n, "github_repo")) have_repo = true;
+        }
+    }
+    if (have_table and !have_owner) {
+        // DEFAULT '' so ALTER over a non-empty table doesn't violate
+        // NOT NULL; the backfill below replaces every '' with a real value.
+        try db.exec("ALTER TABLE taps ADD COLUMN github_owner TEXT NOT NULL DEFAULT '';");
+    }
+    if (have_table and !have_repo) {
+        try db.exec("ALTER TABLE taps ADD COLUMN github_repo TEXT NOT NULL DEFAULT '';");
+    }
+
+    // Backfill only rows that still carry the ALTER default. A row whose
+    // pair was already populated (re-run, fresh DB, custom `--repo` insert
+    // applied before the migration marker rewound) keeps its value.
+    //
+    // `instr(name, '/')`: SQLite returns 0 when the slash is absent. The
+    // CASE branches keep malformed slugs from corrupting the row — the
+    // verbatim fallback preserves what's there rather than producing a
+    // negative substring length.
+    if (have_table) {
+        try db.exec(
+            \\UPDATE taps SET
+            \\    github_owner = CASE WHEN instr(name, '/') > 0
+            \\                        THEN substr(name, 1, instr(name, '/') - 1)
+            \\                        ELSE name END,
+            \\    github_repo  = CASE WHEN instr(name, '/') > 0
+            \\                        THEN 'homebrew-' || substr(name, instr(name, '/') + 1)
+            \\                        ELSE name END
+            \\WHERE github_owner = '' OR github_repo = '';
+        );
+    }
+
+    try db.exec("INSERT OR IGNORE INTO schema_version (version) VALUES (9);");
+
+    try db.commit();
+}
+
 /// Return true iff every column in `wanted` is present on the `casks`
 /// table. Mirrors the PRAGMA-guarded probes used by v2→v3 / v3→v4 /
 /// v5→v6; centralised here because the v6→v7 backfill needs five
@@ -492,8 +555,6 @@ pub fn currentVersion(db: *sqlite.Database) sqlite.SqliteError!i64 {
 
     return stmt.columnInt(0);
 }
-
-const testing = std.testing;
 
 fn foreignKeysOn(db: *sqlite.Database) !bool {
     var stmt = try db.prepare("PRAGMA foreign_keys;");
@@ -658,7 +719,7 @@ test "v6→v7 migration backfills cask_versions from existing casks rows" {
     const token1 = stmt.columnText(0) orelse return error.TestUnexpectedResult;
     try testing.expectEqualStrings("flux-markdown", std.mem.sliceTo(token1, 0));
 
-    try testing.expectEqual(@as(i64, 8), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 9), try currentVersion(&db));
 }
 
 test "v6→v7 migration is idempotent when cask_versions already carries the rows" {
@@ -707,7 +768,7 @@ test "fresh DB ships with taps.head_etag (v8 shape)" {
         }
     }
     try testing.expect(found);
-    try testing.expectEqual(@as(i64, 8), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 9), try currentVersion(&db));
 }
 
 test "v7→v8 migration adds head_etag and preserves existing tap rows" {
@@ -738,7 +799,7 @@ test "v7→v8 migration adds head_etag and preserves existing tap rows" {
     );
     // Pre-v8 rows must carry NULL until a conditional GET populates it.
     try testing.expect(probe.columnText(1) == null);
-    try testing.expectEqual(@as(i64, 8), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 9), try currentVersion(&db));
 }
 
 test "v7→v8 migration is idempotent when head_etag is already present" {
@@ -763,6 +824,161 @@ test "v7→v8 migration is idempotent when head_etag is already present" {
     try testing.expect(try probe.step());
     const et = probe.columnText(0) orelse return error.TestUnexpectedResult;
     try testing.expectEqualStrings("W/\"deadbeef\"", std.mem.sliceTo(et, 0));
+}
+
+// v8→v9 promotes the prefix decision into structured (github_owner,
+// github_repo) columns so the helper has no string synthesis left to
+// forget. Fresh DBs ship with the v9 shape; upgraded DBs get
+// `(user, "homebrew-" || repo)` backfilled from the existing slug.
+
+test "fresh DB ships with taps.github_owner and taps.github_repo (v9 shape)" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    var stmt = try db.prepare("PRAGMA table_info(taps);");
+    defer stmt.finalize();
+    var owner_seen = false;
+    var repo_seen = false;
+    while (try stmt.step()) {
+        const name = stmt.columnText(1) orelse continue;
+        const n = std.mem.sliceTo(name, 0);
+        if (std.mem.eql(u8, n, "github_owner")) owner_seen = true;
+        if (std.mem.eql(u8, n, "github_repo")) repo_seen = true;
+    }
+    try testing.expect(owner_seen);
+    try testing.expect(repo_seen);
+    try testing.expectEqual(@as(i64, 9), try currentVersion(&db));
+}
+
+test "v8→v9 migration backfills (user, \"homebrew-\" || repo) from existing slugs" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    // Seed three v8-shape tap rows, then rewind the schema marker so the
+    // next migrate run re-enters the v8→v9 step.
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha) VALUES
+        \\    ('aeroxy/tap',   'https://github.com/aeroxy/homebrew-tap',   '0123456789abcdef0123456789abcdef01234567'),
+        \\    ('user/repo',    'https://github.com/user/homebrew-repo',    NULL),
+        \\    ('user-1/some.v2','https://github.com/user-1/homebrew-some.v2', NULL);
+    );
+    try db.exec("DELETE FROM schema_version WHERE version >= 9;");
+
+    try migrate(&db);
+
+    try testing.expectEqual(@as(i64, 9), try currentVersion(&db));
+
+    var probe = try db.prepare(
+        "SELECT name, github_owner, github_repo FROM taps ORDER BY name;",
+    );
+    defer probe.finalize();
+
+    try testing.expect(try probe.step());
+    const n0 = std.mem.sliceTo(probe.columnText(0) orelse return error.TestUnexpectedResult, 0);
+    try testing.expectEqualStrings("aeroxy/tap", n0);
+    try testing.expectEqualStrings("aeroxy", std.mem.sliceTo(probe.columnText(1) orelse "", 0));
+    try testing.expectEqualStrings("homebrew-tap", std.mem.sliceTo(probe.columnText(2) orelse "", 0));
+
+    try testing.expect(try probe.step());
+    const n1 = std.mem.sliceTo(probe.columnText(0) orelse return error.TestUnexpectedResult, 0);
+    try testing.expectEqualStrings("user-1/some.v2", n1);
+    try testing.expectEqualStrings("user-1", std.mem.sliceTo(probe.columnText(1) orelse "", 0));
+    try testing.expectEqualStrings("homebrew-some.v2", std.mem.sliceTo(probe.columnText(2) orelse "", 0));
+
+    try testing.expect(try probe.step());
+    const n2 = std.mem.sliceTo(probe.columnText(0) orelse return error.TestUnexpectedResult, 0);
+    try testing.expectEqualStrings("user/repo", n2);
+    try testing.expectEqualStrings("user", std.mem.sliceTo(probe.columnText(1) orelse "", 0));
+    try testing.expectEqualStrings("homebrew-repo", std.mem.sliceTo(probe.columnText(2) orelse "", 0));
+}
+
+test "v8→v9 migration is idempotent when columns are already populated" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    // Stamp a custom (owner, repo) pair, rewind, re-run the migration.
+    // The PRAGMA guard must skip the ALTER and the backfill must not
+    // overwrite a non-default pair.
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo) VALUES
+        \\    ('aeroxy/ast-outline', 'https://github.com/aeroxy/ast-outline', NULL, 'aeroxy', 'ast-outline');
+    );
+    try db.exec("DELETE FROM schema_version WHERE version >= 9;");
+
+    try migrate(&db);
+
+    var probe = try db.prepare(
+        "SELECT github_owner, github_repo FROM taps WHERE name='aeroxy/ast-outline';",
+    );
+    defer probe.finalize();
+    try testing.expect(try probe.step());
+    try testing.expectEqualStrings("aeroxy", std.mem.sliceTo(probe.columnText(0) orelse "", 0));
+    try testing.expectEqualStrings("ast-outline", std.mem.sliceTo(probe.columnText(1) orelse "", 0));
+}
+
+// Empty `taps` table is the most common pre-v9 shape — the ALTER must
+// add the columns, the backfill UPDATE must safely no-op, and the
+// version marker still bumps so a re-run skips this path.
+test "v8→v9 migration bumps the marker even when taps is empty" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec("DELETE FROM schema_version WHERE version >= 9;");
+    try migrate(&db);
+
+    try testing.expectEqual(@as(i64, 9), try currentVersion(&db));
+}
+
+// Pre-v3 rows could in theory have escaped slug validation. The CASE
+// branches keep `substr(name, 1, -1)` from corrupting the row — a
+// malformed slug falls back to writing the verbatim name into both
+// columns so the row stays reachable rather than ending up with a
+// negative-length substring.
+test "v8→v9 migration tolerates a slug starting with a slash (degenerate fixture)" {
+    // `instr('/repo', '/') = 1` makes `substr(name, 1, 0) = ''` — the
+    // owner would land empty. The backfill WHERE filters by '' so this
+    // is benign on first pass, but a re-run could loop. The current
+    // schema rejects empty components on read (`getOwnerRepo` returns
+    // null) so this row's URLs fall through to the slug fallback.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha) VALUES
+        \\    ('/repo', 'https://example.invalid/leading-slash', NULL);
+    );
+    try db.exec("DELETE FROM schema_version WHERE version >= 9;");
+    try migrate(&db);
+
+    // We don't pin the specific (owner, repo) values for degenerate
+    // input — only that the migration completes and the marker bumps.
+    try testing.expectEqual(@as(i64, 9), try currentVersion(&db));
+}
+
+test "v8→v9 migration falls back to verbatim name on a slug missing the slash" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha) VALUES
+        \\    ('legacy', 'https://example.invalid/legacy', NULL);
+    );
+    try db.exec("DELETE FROM schema_version WHERE version >= 9;");
+    try migrate(&db);
+
+    var probe = try db.prepare(
+        "SELECT github_owner, github_repo FROM taps WHERE name='legacy';",
+    );
+    defer probe.finalize();
+    try testing.expect(try probe.step());
+    try testing.expectEqualStrings("legacy", std.mem.sliceTo(probe.columnText(0) orelse "", 0));
+    try testing.expectEqualStrings("legacy", std.mem.sliceTo(probe.columnText(1) orelse "", 0));
 }
 
 test "migrate refuses a DB whose schema_version exceeds the known max" {

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -2,11 +2,14 @@
 //! Tests for cask JSON parsing, artifact type detection, and DB operations.
 
 const std = @import("std");
+const testing = std.testing;
+
 const malt = @import("malt");
-const test_io = @import("test_io");
 const cask = malt.cask;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
+const test_io = @import("test_io");
+const malt_fs = test_io;
 
 fn testIo() std.Io {
     return std.Options.debug_io;
@@ -441,9 +444,6 @@ test "isOutdated surfaces SqliteError when schema is missing" {
 // upstream zip was bit-perfect but malt rejected it. These tests
 // exercise the chunk loop at every boundary and prove the hash
 // output against independently-computed digests.
-
-const testing = std.testing;
-const malt_fs = test_io;
 
 /// 64 KiB — the internal SHA256 read buffer size. Every boundary
 /// case below is expressed relative to this so the tests stay
@@ -1148,12 +1148,13 @@ test "v6→v7 migration leaves cask_versions empty when casks has a broken shape
     _ = try stmt.step();
     try testing.expectEqual(@as(i64, 0), stmt.columnInt(0));
     // Migration still bumps the schema marker so a future run skips this path.
-    try testing.expectEqual(@as(i64, 8), try schema.currentVersion(&db));
+    try testing.expectEqual(@as(i64, 9), try schema.currentVersion(&db));
 }
 
-// v7→v8 ALTER must skip when `taps` is missing entirely (forensic DBs
-// hand-built without the v3-era table); the migration still bumps the
-// schema marker so a future run treats the chain as caught up.
+// v7→v8 / v8→v9 ALTERs must skip when `taps` is missing entirely
+// (forensic DBs hand-built without the v3-era table); the migration
+// still bumps the schema marker so a future run treats the chain as
+// caught up.
 test "v7→v8 migration tolerates a missing taps table" {
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
@@ -1168,7 +1169,7 @@ test "v7→v8 migration tolerates a missing taps table" {
 
     try schema.migrate(&db);
 
-    try testing.expectEqual(@as(i64, 8), try schema.currentVersion(&db));
+    try testing.expectEqual(@as(i64, 9), try schema.currentVersion(&db));
 }
 
 // --- coverage: lookupCaskVersion refuses a malformed row ----------------

--- a/tests/cli_tap_test.zig
+++ b/tests/cli_tap_test.zig
@@ -3,10 +3,13 @@
 //! directory, so the dispatch opens a real SQLite database under the prefix.
 
 const std = @import("std");
-const malt = @import("malt");
-const test_io = @import("test_io");
 const testing = std.testing;
+
+const malt = @import("malt");
 const tap_cli = @import("malt").cli_tap;
+const TapNameError = tap_cli.TapNameError;
+const bad = TapNameError.InvalidTapName;
+const test_io = @import("test_io");
 
 const c = struct {
     extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
@@ -112,7 +115,8 @@ test "execute with --json output is a parseable JSON array" {
         try malt.tap.add(
             &db,
             "user/repo",
-            "https://github.com/user/homebrew-repo",
+            "user",
+            "homebrew-repo",
             "0123456789abcdef0123456789abcdef01234567",
         );
     }
@@ -158,10 +162,11 @@ test "execute with --json on a populated DB emits one object per tap" {
         try malt.tap.add(
             &db,
             "user/repo",
-            "https://github.com/user/homebrew-repo",
+            "user",
+            "homebrew-repo",
             "0123456789abcdef0123456789abcdef01234567",
         );
-        try malt.tap.add(&db, "x/y", "https://github.com/x/homebrew-y", null);
+        try malt.tap.add(&db, "x/y", "x", "homebrew-y", null);
     }
 
     const prior_json = malt.output.isJson();
@@ -216,9 +221,6 @@ test "execute with --help short-circuits before touching the database" {
 // ---------------------------------------------------------------------------
 // validateTapName
 // ---------------------------------------------------------------------------
-
-const TapNameError = tap_cli.TapNameError;
-const bad = TapNameError.InvalidTapName;
 
 test "validateTapName: accepts canonical user/repo" {
     try tap_cli.validateTapName("homebrew/core");
@@ -444,6 +446,219 @@ test "execute --refresh --all under `mt untap` is rejected" {
     );
 }
 
+test "execute rejects --repo without a positional slug" {
+    // `mt tap --repo X/Y` with no slug is meaningless — refuse early
+    // rather than silently dispatching to the listing branch.
+    const prefix = try setupPrefix("repo_no_positional");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(&ctx, testing.allocator, &.{ "--repo", "aeroxy/ast-outline" }),
+    );
+    try testing.expect(std.mem.indexOf(u8, captured.items, "Usage:") != null);
+}
+
+test "execute rejects --repo combined with --refresh" {
+    const prefix = try setupPrefix("repo_with_refresh");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(&ctx, testing.allocator, &.{
+            "user/repo", "--repo", "user/repo", "--refresh",
+        }),
+    );
+    try testing.expect(std.mem.indexOf(u8, captured.items, "--repo cannot be combined") != null);
+}
+
+test "execute rejects --force without --repo (no-op flag, surface the mistake)" {
+    const prefix = try setupPrefix("force_without_repo");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(&ctx, testing.allocator, &.{ "user/repo", "--force" }),
+    );
+    try testing.expect(std.mem.indexOf(u8, captured.items, "--force is only valid") != null);
+}
+
+test "execute reports a clean error on a malformed --repo value" {
+    const prefix = try setupPrefix("repo_malformed");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(&ctx, testing.allocator, &.{ "user/repo", "--repo", "no-slash" }),
+    );
+    try testing.expect(std.mem.indexOf(u8, captured.items, "Invalid --repo") != null);
+}
+
+test "execute rejects --repo over an existing row that pins a different pair" {
+    // Rebind policy: refuse without --force. The refusal fires before
+    // any HTTP work so the assertion is deterministic against a row
+    // already bound to a different (owner, repo).
+    const prefix = try setupPrefix("repo_rebind_refuse");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const db_path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "{s}/db/malt.db",
+        .{prefix},
+        0,
+    );
+    defer testing.allocator.free(db_path);
+    {
+        var db = try malt.sqlite.Database.open(db_path);
+        defer db.close();
+        try malt.schema.initSchema(&db);
+        try malt.tap.add(
+            &db,
+            "aeroxy/ast-outline",
+            "aeroxy",
+            "homebrew-ast-outline",
+            null,
+        );
+    }
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(&ctx, testing.allocator, &.{
+            "aeroxy/ast-outline", "--repo", "aeroxy/ast-outline",
+        }),
+    );
+    try testing.expect(std.mem.indexOf(u8, captured.items, "--force") != null);
+}
+
+test "execute --repo --force rebinds the row and clears the stale pin before any HTTP work" {
+    // Force-rebind invalidates the pin upfront so a network failure
+    // can't leave the row pointing at the new repo with the old SHA.
+    // We drive that invariant with a deliberately-404ing target so the
+    // post-rebind HEAD resolve fails — the rebind side effects must
+    // already be visible in the DB by then.
+    const prefix = try setupPrefix("repo_force_rebind");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const db_path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "{s}/db/malt.db",
+        .{prefix},
+        0,
+    );
+    defer testing.allocator.free(db_path);
+
+    const stale_sha = "0123456789abcdef0123456789abcdef01234567";
+    {
+        var db = try malt.sqlite.Database.open(db_path);
+        defer db.close();
+        try malt.schema.initSchema(&db);
+        try malt.tap.add(&db, "aeroxy/tap", "aeroxy", "homebrew-tap", stale_sha);
+        try malt.tap.updateHead(&db, "aeroxy/tap", stale_sha, "W/\"stale-etag\"");
+    }
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{
+        .io = threaded.io(),
+        .environ = malt.app_ctx.processEnviron(),
+    };
+
+    // `aeroxy/this-repo-does-not-exist-...` is a deterministic 404
+    // against api.github.com — the rebind runs before the resolve, so
+    // the row mutation is observable even though the command aborts.
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(&ctx, testing.allocator, &.{
+            "aeroxy/tap", "--repo", "aeroxy/missing-prefixless-repo", "--force",
+        }),
+    );
+
+    // The "needs refresh" warning fires only when rebind landed before
+    // the resolve failure — pinning the message guards the ordering.
+    try testing.expect(std.mem.indexOf(u8, captured.items, "Rebind applied with no pin") != null);
+
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    var stmt = try db.prepare(
+        "SELECT github_owner, github_repo, commit_sha, head_etag FROM taps WHERE name = ?1;",
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, "aeroxy/tap");
+    try testing.expect(try stmt.step());
+    try testing.expectEqualStrings(
+        "aeroxy",
+        std.mem.sliceTo(stmt.columnText(0) orelse "", 0),
+    );
+    try testing.expectEqualStrings(
+        "missing-prefixless-repo",
+        std.mem.sliceTo(stmt.columnText(1) orelse "", 0),
+    );
+    try testing.expect(stmt.columnText(2) == null);
+    try testing.expect(stmt.columnText(3) == null);
+}
+
 test "execute --refresh --all with only failed rows does not gate the apply" {
     // Pre-seed a row whose remote 404s. `--all` walks it, surfaces the
     // failure, but the no-moved-rows path still exits cleanly without
@@ -467,7 +682,8 @@ test "execute --refresh --all with only failed rows does not gate the apply" {
         try malt.tap.add(
             &db,
             "user/repo",
-            "https://github.com/user/homebrew-repo",
+            "user",
+            "homebrew-repo",
             "0123456789abcdef0123456789abcdef01234567",
         );
     }

--- a/tests/db_schema_v2_test.zig
+++ b/tests/db_schema_v2_test.zig
@@ -2,10 +2,11 @@
 
 const std = @import("std");
 const testing = std.testing;
+
 const malt = @import("malt");
-const test_io = @import("test_io");
 const sqlite = malt.sqlite;
 const schema = malt.schema;
+const test_io = @import("test_io");
 
 const TempDb = struct {
     dir: []const u8,
@@ -53,7 +54,7 @@ test "initSchema runs v1 then migrates to the current known version" {
     try testing.expect(try tableExists(&tdb.db, "bundle_members"));
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 8), ver);
+    try testing.expectEqual(@as(i64, 9), ver);
 }
 
 test "migrate is idempotent on re-run" {
@@ -65,7 +66,7 @@ test "migrate is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 8), ver);
+    try testing.expectEqual(@as(i64, 9), ver);
 }
 
 test "v4 migration adds pinned column to casks" {
@@ -95,7 +96,7 @@ test "v4 migration is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 8), ver);
+    try testing.expectEqual(@as(i64, 9), ver);
 }
 
 test "v6 migration adds tap column to casks" {

--- a/tests/tap_head_etag_integration_test.zig
+++ b/tests/tap_head_etag_integration_test.zig
@@ -9,6 +9,7 @@
 
 const std = @import("std");
 const testing = std.testing;
+
 const malt = @import("malt");
 const sqlite = malt.sqlite;
 const schema = malt.schema;
@@ -32,7 +33,7 @@ fn openDb() !sqlite.Database {
 test "cold start: getHeadEtag returns null before any resolve" {
     var db = try openDb();
     defer db.close();
-    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+    try tap.add(&db, "aeroxy/tap", "aeroxy", "homebrew-tap", null);
 
     const et = try tap.getHeadEtag(testing.allocator, &db, "aeroxy/tap");
     try testing.expectEqual(@as(?[]const u8, null), et);
@@ -41,7 +42,7 @@ test "cold start: getHeadEtag returns null before any resolve" {
 test "warm start: a 200 response persists (sha, etag); next round can short-circuit" {
     var db = try openDb();
     defer db.close();
-    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+    try tap.add(&db, "aeroxy/tap", "aeroxy", "homebrew-tap", null);
 
     // Simulate the cold-start resolve: HeadResolution{sha, etag} →
     // updateHead atomically pairs them in the row.
@@ -60,7 +61,7 @@ test "warm start: a 200 response persists (sha, etag); next round can short-circ
 test "304 response: caller keeps cached sha, no DB write happens" {
     var db = try openDb();
     defer db.close();
-    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+    try tap.add(&db, "aeroxy/tap", "aeroxy", "homebrew-tap", null);
     try tap.updateHead(&db, "aeroxy/tap", fresh_sha, fresh_etag);
 
     // Mimic resolveFromConditional on a 304: HeadResolution.not_modified=true,
@@ -91,7 +92,7 @@ test "304 response: caller keeps cached sha, no DB write happens" {
 test "cache-bust: a clobbered etag triggers a 200 path that updates both fields" {
     var db = try openDb();
     defer db.close();
-    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+    try tap.add(&db, "aeroxy/tap", "aeroxy", "homebrew-tap", null);
     try tap.updateHead(&db, "aeroxy/tap", fresh_sha, "W/\"stale\"");
 
     // The server returns 200 because the stale etag doesn't match.
@@ -129,7 +130,7 @@ test "server omits ETag on 200: sha persists, etag column is cleared" {
     // GET on the next round rather than carrying a stale etag forward.
     var db = try openDb();
     defer db.close();
-    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+    try tap.add(&db, "aeroxy/tap", "aeroxy", "homebrew-tap", null);
     try tap.updateHead(&db, "aeroxy/tap", fresh_sha, fresh_etag);
 
     var resp: client.ConditionalResponse = .{
@@ -188,7 +189,7 @@ test "sequential writers of the same (sha, etag) last-writer-wins" {
     // 16x in a row must end at the agreed values.
     var db = try openDb();
     defer db.close();
-    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+    try tap.add(&db, "aeroxy/tap", "aeroxy", "homebrew-tap", null);
 
     for (0..16) |_| {
         try tap.updateHead(&db, "aeroxy/tap", fresh_sha, fresh_etag);
@@ -235,7 +236,7 @@ const ConcurrentCtx = struct {
 test "concurrent workers (real threads) leave the row consistent under SQLite SERIALIZED" {
     var db = try openDb();
     defer db.close();
-    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+    try tap.add(&db, "aeroxy/tap", "aeroxy", "homebrew-tap", null);
 
     const thread_count: usize = 8;
     const iterations_per_thread: usize = 64;
@@ -269,7 +270,7 @@ test "updateHead's validator runs before the UPDATE, even with a non-null etag" 
     // invariant is upheld at every callsite.
     var db = try openDb();
     defer db.close();
-    try tap.add(&db, "aeroxy/tap", "https://github.com/aeroxy/homebrew-tap", null);
+    try tap.add(&db, "aeroxy/tap", "aeroxy", "homebrew-tap", null);
     try tap.updateHead(&db, "aeroxy/tap", fresh_sha, fresh_etag);
 
     try testing.expectError(

--- a/tests/tap_test.zig
+++ b/tests/tap_test.zig
@@ -4,10 +4,10 @@
 
 const std = @import("std");
 const testing = std.testing;
+
 const malt = @import("malt");
 const sqlite = malt.sqlite;
 const schema = malt.schema;
-
 const tap = malt.tap;
 
 const valid_sha = "0123456789abcdef0123456789abcdef01234567";
@@ -36,18 +36,20 @@ test "list returns empty slice on a fresh database" {
     try testing.expectEqual(@as(usize, 0), taps.len);
 }
 
-test "add then list round-trips tap name, url, and commit SHA" {
+test "add then list round-trips tap name, derived URL, and commit SHA" {
     var db = try openDb();
     defer db.close();
     try schema.initSchema(&db);
 
-    try tap.add(&db, "user/repo", "https://github.com/user/repo", valid_sha);
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", valid_sha);
 
     const taps = try tap.list(testing.allocator, &db);
     defer freeTaps(taps);
     try testing.expectEqual(@as(usize, 1), taps.len);
     try testing.expectEqualStrings("user/repo", taps[0].name);
-    try testing.expectEqualStrings("https://github.com/user/repo", taps[0].url);
+    // url is projected from (github_owner, github_repo) — not the lie
+    // it was in v8 where bare-slug got written verbatim.
+    try testing.expectEqualStrings("https://github.com/user/homebrew-repo", taps[0].url);
     try testing.expectEqualStrings(valid_sha, taps[0].commit_sha.?);
 }
 
@@ -56,7 +58,7 @@ test "add with null SHA persists as unpinned" {
     defer db.close();
     try schema.initSchema(&db);
 
-    try tap.add(&db, "user/repo", "https://github.com/user/repo", null);
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", null);
 
     const taps = try tap.list(testing.allocator, &db);
     defer freeTaps(taps);
@@ -64,18 +66,20 @@ test "add with null SHA persists as unpinned" {
     try testing.expectEqual(@as(?[]const u8, null), taps[0].commit_sha);
 }
 
-test "add preserves URL on conflict (URL is sticky)" {
+test "add preserves (owner, repo) on conflict — rebind requires the explicit verb" {
     var db = try openDb();
     defer db.close();
     try schema.initSchema(&db);
 
-    try tap.add(&db, "user/repo", "https://github.com/user/repo", null);
-    try tap.add(&db, "user/repo", "https://github.com/user/repo-other", null);
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", null);
+    // Second add with a different repo must NOT mutate the existing
+    // pair — the only sanctioned rebind path is `tap.rebind`.
+    try tap.add(&db, "user/repo", "user", "homebrew-repo-other", null);
 
     const taps = try tap.list(testing.allocator, &db);
     defer freeTaps(taps);
     try testing.expectEqual(@as(usize, 1), taps.len);
-    try testing.expectEqualStrings("https://github.com/user/repo", taps[0].url);
+    try testing.expectEqualStrings("https://github.com/user/homebrew-repo", taps[0].url);
 }
 
 test "add preserves existing commit pin when new add passes null" {
@@ -83,9 +87,9 @@ test "add preserves existing commit pin when new add passes null" {
     defer db.close();
     try schema.initSchema(&db);
 
-    try tap.add(&db, "user/repo", "https://x", valid_sha);
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", valid_sha);
     // Second add without a SHA must NOT wipe the pin.
-    try tap.add(&db, "user/repo", "https://x", null);
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", null);
 
     const taps = try tap.list(testing.allocator, &db);
     defer freeTaps(taps);
@@ -97,12 +101,208 @@ test "add replaces existing pin when new add passes a different non-null SHA" {
     defer db.close();
     try schema.initSchema(&db);
 
-    try tap.add(&db, "user/repo", "https://x", valid_sha);
-    try tap.add(&db, "user/repo", "https://x", other_sha);
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", valid_sha);
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", other_sha);
 
     const taps = try tap.list(testing.allocator, &db);
     defer freeTaps(taps);
     try testing.expectEqualStrings(other_sha, taps[0].commit_sha.?);
+}
+
+test "add persists the (github_owner, github_repo) pair passed at INSERT" {
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "aeroxy/ast-outline", "aeroxy", "ast-outline", null);
+
+    var stmt = try db.prepare(
+        "SELECT github_owner, github_repo FROM taps WHERE name = ?1;",
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, "aeroxy/ast-outline");
+    try testing.expect(try stmt.step());
+    try testing.expectEqualStrings(
+        "aeroxy",
+        std.mem.sliceTo(stmt.columnText(0) orelse "", 0),
+    );
+    try testing.expectEqualStrings(
+        "ast-outline",
+        std.mem.sliceTo(stmt.columnText(1) orelse "", 0),
+    );
+}
+
+test "rebind moves (owner, repo) and clears commit_sha and head_etag" {
+    // Rebinding to a new repo invalidates the old pin — the new repo has
+    // its own HEAD, and keeping the stale SHA would freeze the row at a
+    // commit that doesn't exist on the new target. Force-rebind is the
+    // only sanctioned mutator.
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", valid_sha);
+    try tap.updateHead(&db, "user/repo", valid_sha, "W/\"stale\"");
+
+    try tap.rebind(&db, "user/repo", "user", "other-name");
+
+    var stmt = try db.prepare(
+        "SELECT github_owner, github_repo, commit_sha, head_etag FROM taps WHERE name = ?1;",
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, "user/repo");
+    try testing.expect(try stmt.step());
+    try testing.expectEqualStrings(
+        "user",
+        std.mem.sliceTo(stmt.columnText(0) orelse "", 0),
+    );
+    try testing.expectEqualStrings(
+        "other-name",
+        std.mem.sliceTo(stmt.columnText(1) orelse "", 0),
+    );
+    try testing.expect(stmt.columnText(2) == null);
+    try testing.expect(stmt.columnText(3) == null);
+}
+
+test "rebind also rewrites the derived url column" {
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", null);
+    try tap.rebind(&db, "user/repo", "user", "exact-name");
+
+    const taps = try tap.list(testing.allocator, &db);
+    defer freeTaps(taps);
+    try testing.expectEqualStrings(
+        "https://github.com/user/exact-name",
+        taps[0].url,
+    );
+}
+
+test "effectiveOwnerRepo reads from the row when present" {
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+    try tap.add(&db, "aeroxy/ast-outline", "aeroxy", "ast-outline", null);
+
+    const pair = try tap.effectiveOwnerRepo(testing.allocator, &db, "aeroxy/ast-outline");
+    defer pair.deinit(testing.allocator);
+    try testing.expectEqualStrings("aeroxy", pair.owner);
+    try testing.expectEqualStrings("ast-outline", pair.repo);
+}
+
+test "effectiveOwnerRepo falls back to slug-derived (user, \"homebrew-\" || repo)" {
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    const pair = try tap.effectiveOwnerRepo(testing.allocator, &db, "aeroxy/tap");
+    defer pair.deinit(testing.allocator);
+    try testing.expectEqualStrings("aeroxy", pair.owner);
+    try testing.expectEqualStrings("homebrew-tap", pair.repo);
+}
+
+test "add is idempotent on owner/repo — second add with same pair preserves state" {
+    // Mirrors today's `tap.add` ON CONFLICT semantics for the new
+    // columns: the (owner, repo) sticks, only commit_sha rotates.
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", valid_sha);
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", null);
+
+    var stmt = try db.prepare(
+        "SELECT github_owner, github_repo, commit_sha FROM taps WHERE name = ?1;",
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, "user/repo");
+    try testing.expect(try stmt.step());
+    try testing.expectEqualStrings("user", std.mem.sliceTo(stmt.columnText(0) orelse "", 0));
+    try testing.expectEqualStrings("homebrew-repo", std.mem.sliceTo(stmt.columnText(1) orelse "", 0));
+    try testing.expectEqualStrings(valid_sha, std.mem.sliceTo(stmt.columnText(2) orelse "", 0));
+}
+
+test "rebind is a no-op when the row is missing (mirrors updateCommit)" {
+    // SQLite UPDATE on a missing row affects zero rows without raising.
+    // Documented so the CLI layer doesn't try to handle a NotFound case
+    // that can't happen.
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.rebind(&db, "ghost/tap", "ghost", "other");
+
+    const taps = try tap.list(testing.allocator, &db);
+    defer freeTaps(taps);
+    try testing.expectEqual(@as(usize, 0), taps.len);
+}
+
+test "effectiveOwnerRepo treats half-empty rows as missing (forgiving against corruption)" {
+    // If only one column carries an empty default — e.g. a manual DB
+    // hack or an interrupted backfill — the helper falls back to the
+    // slug-derived default rather than handing back a half-pair that
+    // would build an invalid URL.
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO taps (name, url, github_owner, github_repo)
+        \\VALUES ('user/repo', 'https://x', '', 'something');
+    );
+
+    const pair = try tap.effectiveOwnerRepo(testing.allocator, &db, "user/repo");
+    defer pair.deinit(testing.allocator);
+    try testing.expectEqualStrings("user", pair.owner);
+    try testing.expectEqualStrings("homebrew-repo", pair.repo);
+}
+
+test "list mixes custom-repo and default-prefixed rows without cross-contamination" {
+    // Each row projects its own URL from its own (owner, repo) — no
+    // shared template state across rows.
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "aeroxy/ast-outline", "aeroxy", "ast-outline", null);
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", null);
+
+    const taps = try tap.list(testing.allocator, &db);
+    defer freeTaps(taps);
+    try testing.expectEqual(@as(usize, 2), taps.len);
+    // ORDER BY isn't applied in `list` — sort manually before asserting.
+    for (taps) |t| {
+        if (std.mem.eql(u8, t.name, "aeroxy/ast-outline")) {
+            try testing.expectEqualStrings("https://github.com/aeroxy/ast-outline", t.url);
+        } else {
+            try testing.expectEqualStrings("https://github.com/user/homebrew-repo", t.url);
+        }
+    }
+}
+
+test "list URL projection follows rebind end-to-end" {
+    // Touches the read-time projection: after a force-rebind, the
+    // listing must show the new repo, not the cached lie.
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "aeroxy/ast-outline", "aeroxy", "homebrew-ast-outline", null);
+    try tap.rebind(&db, "aeroxy/ast-outline", "aeroxy", "ast-outline");
+
+    const taps = try tap.list(testing.allocator, &db);
+    defer freeTaps(taps);
+    try testing.expectEqualStrings(
+        "https://github.com/aeroxy/ast-outline",
+        taps[0].url,
+    );
+    try testing.expectEqual(@as(?[]const u8, null), taps[0].commit_sha);
+}
+
+test "describeResolveError(NotFound) names the --repo remediation" {
+    const msg = tap.describeResolveError(error.NotFound);
+    try testing.expect(std.mem.indexOf(u8, msg, "--repo") != null);
 }
 
 test "updateCommit replaces an existing pin" {
@@ -110,7 +310,7 @@ test "updateCommit replaces an existing pin" {
     defer db.close();
     try schema.initSchema(&db);
 
-    try tap.add(&db, "user/repo", "https://x", valid_sha);
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", valid_sha);
     try tap.updateCommit(&db, "user/repo", other_sha);
 
     const taps = try tap.list(testing.allocator, &db);
@@ -123,7 +323,7 @@ test "updateCommit rejects malformed SHA" {
     defer db.close();
     try schema.initSchema(&db);
 
-    try tap.add(&db, "user/repo", "https://x", valid_sha);
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", valid_sha);
     try testing.expectError(error.InvalidSha, tap.updateCommit(&db, "user/repo", "notasha"));
     try testing.expectError(error.InvalidSha, tap.updateCommit(&db, "user/repo", "XXXX567890abcdef0123456789abcdef01234567"));
 }
@@ -145,7 +345,7 @@ test "getCommitSha returns the stored pin" {
     defer db.close();
     try schema.initSchema(&db);
 
-    try tap.add(&db, "user/repo", "https://x", valid_sha);
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", valid_sha);
     const got = (try tap.getCommitSha(testing.allocator, &db, "user/repo")) orelse
         return error.TestUnexpectedResult;
     defer testing.allocator.free(got);
@@ -157,7 +357,7 @@ test "getCommitSha returns null for unpinned tap" {
     defer db.close();
     try schema.initSchema(&db);
 
-    try tap.add(&db, "user/repo", "https://x", null);
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", null);
     try testing.expectEqual(
         @as(?[]const u8, null),
         try tap.getCommitSha(testing.allocator, &db, "user/repo"),
@@ -198,8 +398,8 @@ test "remove deletes a tap" {
     defer db.close();
     try schema.initSchema(&db);
 
-    try tap.add(&db, "a/b", "https://x", valid_sha);
-    try tap.add(&db, "c/d", "https://y", valid_sha);
+    try tap.add(&db, "a/b", "a", "homebrew-b", valid_sha);
+    try tap.add(&db, "c/d", "c", "homebrew-d", valid_sha);
     try tap.remove(&db, "a/b");
 
     const taps = try tap.list(testing.allocator, &db);
@@ -217,7 +417,7 @@ test "add surfaces SqliteError when schema is missing" {
 
     try testing.expectError(
         sqlite.SqliteError.PrepareFailed,
-        tap.add(&db, "user/repo", "https://x", valid_sha),
+        tap.add(&db, "user/repo", "user", "homebrew-repo", valid_sha),
     );
 }
 
@@ -249,8 +449,8 @@ test "list: partial-dupe failure on any allocation leaves zero leaks" {
     defer db.close();
     try schema.initSchema(&db);
 
-    try tap.add(&db, "alpha/one", "https://github.com/alpha/one", valid_sha);
-    try tap.add(&db, "beta/two", "https://github.com/beta/two", null);
+    try tap.add(&db, "alpha/one", "alpha", "homebrew-one", valid_sha);
+    try tap.add(&db, "beta/two", "beta", "homebrew-two", null);
 
     try testing.checkAllAllocationFailures(testing.allocator, listAndFree, .{&db});
 }


### PR DESCRIPTION
## Description

Third-party taps whose GitHub repos do not carry the conventional `homebrew-` prefix now register and install end-to-end. Use `mt tap user/repo --repo user/exact-repo-name` to point malt at the actual GitHub identifier; the existing `mt tap user/repo` form keeps today's `homebrew-<repo>` derivation byte-for-byte.

Re-`tap`ping the same slug with a different `--repo` refuses without `--force`, matching the pin-stays-sticky model the rest of the tap pipeline uses.

## Related Issue

- Closes #311 

## Notes for Reviewers

- None