### PR TITLE
feat(core/linker): isolate dependency-only kegs from prefix/bin and prefix/sbin

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -224,6 +224,9 @@ pub fn build(b: *std.Build) void {
         "tests/install_keg_from_bottle_test.zig",
         "tests/install_pool_test.zig",
         "tests/tap_head_etag_integration_test.zig",
+        "tests/linker_isolation_test.zig",
+        "tests/install_isolation_test.zig",
+        "tests/doctor_isolation_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/scripts/regressions/bin_isolation_basics.sh
+++ b/scripts/regressions/bin_isolation_basics.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Regression guard for the --isolate-deps install policy.
+#
+# Sequence:
+#   1. install a formula with a runtime dep under --isolate-deps;
+#      assert the parent's bin lands in <prefix>/bin while the dep's
+#      bin does NOT, kegs.bin_isolated=1 for the dep, links table
+#      agrees.
+#   2. upgrade the same formula without re-passing the flag;
+#      assert isolation sticks (the replay path reads kegs.bin_isolated
+#      and feeds it back to recordKeg + Linker.link).
+#   3. install the dep directly; assert promotion to install_reason=
+#      'direct', bin_isolated cleared, bin link materialised.
+#   4. uninstall everything; assert links table is empty for both.
+#
+# Pick: `cmark` is a tiny formula whose runtime deps live entirely
+# in `cmake` (build-only) — too narrow. Use `coreutils` which depends
+# on `gmp` at runtime: both ship a bin file, both are bottled small,
+# revisions stable enough that the test isn't a churn magnet.
+#
+# Usage: scripts/regressions/bin_isolation_basics.sh
+# Requirements: built `malt` binary, network access to
+# formulae.brew.sh + ghcr.io.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+PREFIX="/tmp/mt_bin_isolation"
+export MALT_PREFIX="$PREFIX"
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+PARENT="coreutils"
+DEP="gmp"
+DB="$PREFIX/db/malt.db"
+
+# ── Step 1: install parent under --isolate-deps ─────────────────────
+printf '▸ malt install --isolate-deps %s\n' "$PARENT"
+"$BIN" install --quiet --isolate-deps "$PARENT" || fail "install --isolate-deps failed"
+
+[[ -f "$DB" ]] || fail "DB not created at $DB"
+
+# Parent's bin must be present (parent is direct, never isolated).
+# `find -mindepth 1 -maxdepth 1 -print -quit` exits on the first hit
+# so this is O(1) even when bin/ has many entries.
+[[ -n "$(find "$PREFIX/bin/" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]] ||
+  fail "no bin files under <prefix>/bin after parent install"
+pass "<prefix>/bin populated by parent"
+
+# Dep's bin must NOT be in <prefix>/bin.
+# coreutils ships `cksum`, gmp does not ship a binary so we check
+# the opt link is present (anchoring works) and the row says isolated.
+[[ -L "$PREFIX/opt/$DEP" ]] || fail "opt/$DEP anchor missing"
+pass "opt/$DEP anchor present (Mach-O resolves through here)"
+
+dep_isolated=$(sqlite3 "$DB" "SELECT bin_isolated FROM kegs WHERE name='$DEP';" 2>/dev/null || echo "")
+[[ "$dep_isolated" == "1" ]] || fail "kegs.bin_isolated=$dep_isolated for $DEP (expected 1)"
+pass "$DEP row has bin_isolated=1"
+
+dep_reason=$(sqlite3 "$DB" "SELECT install_reason FROM kegs WHERE name='$DEP';" 2>/dev/null || echo "")
+[[ "$dep_reason" == "dependency" ]] || fail "$DEP install_reason=$dep_reason (expected dependency)"
+pass "$DEP recorded as dependency"
+
+dep_bin_links=$(sqlite3 "$DB" "SELECT COUNT(*) FROM links l JOIN kegs k ON l.keg_id=k.id WHERE k.name='$DEP' AND (l.link_path LIKE '%/bin/%' OR l.link_path LIKE '%/sbin/%');" 2>/dev/null || echo "0")
+[[ "$dep_bin_links" == "0" ]] || fail "$DEP has $dep_bin_links bin/sbin link rows (expected 0)"
+pass "links table has no bin/sbin rows for $DEP"
+
+# ── Step 2: upgrade without the flag must replay isolation ──────────
+printf '▸ malt upgrade %s (no flag — must replay isolation)\n' "$PARENT"
+# Upgrade is a no-op when already at latest; that's fine — what we
+# really want is the replay path. Re-run install --force to retrigger
+# the same record+link pass without changing version.
+"$BIN" install --quiet --force "$PARENT" || fail "force-reinstall to test replay failed"
+
+dep_isolated=$(sqlite3 "$DB" "SELECT bin_isolated FROM kegs WHERE name='$DEP';" 2>/dev/null || echo "")
+[[ "$dep_isolated" == "1" ]] || fail "after replay, $DEP bin_isolated=$dep_isolated (expected 1)"
+pass "$DEP isolation replays across re-record without re-passing the flag"
+
+# ── Step 3: install the dep directly — promotion path ──────────────
+printf '▸ malt install %s (promote isolated dep to direct)\n' "$DEP"
+"$BIN" install --quiet "$DEP" || fail "promotion install failed"
+
+dep_reason=$(sqlite3 "$DB" "SELECT install_reason FROM kegs WHERE name='$DEP';" 2>/dev/null || echo "")
+[[ "$dep_reason" == "direct" ]] || fail "$DEP install_reason=$dep_reason after promotion (expected direct)"
+pass "$DEP promoted to install_reason=direct"
+
+dep_isolated=$(sqlite3 "$DB" "SELECT bin_isolated FROM kegs WHERE name='$DEP';" 2>/dev/null || echo "")
+[[ "$dep_isolated" == "0" ]] || fail "$DEP bin_isolated=$dep_isolated after promotion (expected 0)"
+pass "$DEP bin_isolated cleared on promotion"
+
+# ── Step 4: uninstall everything; assert links clean ───────────────
+printf '▸ malt uninstall %s %s\n' "$PARENT" "$DEP"
+"$BIN" uninstall --quiet --force "$PARENT" || fail "uninstall $PARENT failed"
+"$BIN" uninstall --quiet --force "$DEP" || fail "uninstall $DEP failed"
+
+orphan_links=$(sqlite3 "$DB" "SELECT COUNT(*) FROM links;" 2>/dev/null || echo "0")
+[[ "$orphan_links" == "0" ]] || fail "links table not empty after uninstall ($orphan_links rows)"
+pass "links table is empty post-uninstall"
+
+orphan_kegs=$(sqlite3 "$DB" "SELECT COUNT(*) FROM kegs WHERE name IN ('$PARENT', '$DEP');" 2>/dev/null || echo "0")
+[[ "$orphan_kegs" == "0" ]] || fail "kegs table still carries $PARENT or $DEP rows ($orphan_kegs)"
+pass "kegs table is clean for $PARENT + $DEP"
+
+printf '✓ bin_isolation_basics: all stages passed\n'

--- a/scripts/regressions/tap_v9_schema_migration.sh
+++ b/scripts/regressions/tap_v9_schema_migration.sh
@@ -57,8 +57,8 @@ export MALT_PREFIX="$PREFIX"
 }
 
 ver=$(sqlite3 "$DB" "SELECT MAX(version) FROM schema_version;")
-[[ "$ver" == "9" ]] || {
-  printf 'FAIL: fresh DB at v%s, expected v9.\n' "$ver" >&2
+[[ "$ver" -ge 9 ]] || {
+  printf 'FAIL: fresh DB at v%s, expected at least v9.\n' "$ver" >&2
   exit 1
 }
 
@@ -95,13 +95,13 @@ ver_after=$(sqlite3 "$DB" "SELECT MAX(version) FROM schema_version;")
 # Step 2: run `mt tap` so initSchema → migrate triggers v8→v9.
 "$MT" tap >/dev/null 2>&1 || true
 
-# Step 3: assert the migration landed at v9 with the expected backfill.
+# Step 3: assert the migration landed at v9 (or newer) with the expected backfill.
 ver_post=$(sqlite3 "$DB" "SELECT MAX(version) FROM schema_version;")
-[[ "$ver_post" == "9" ]] || {
-  printf 'FAIL: migration did not bump to v9 (got %s).\n' "$ver_post" >&2
+[[ "$ver_post" -ge 9 ]] || {
+  printf 'FAIL: migration did not bump to at least v9 (got %s).\n' "$ver_post" >&2
   exit 1
 }
-printf '  ✓ schema_version bumped 8 -> 9\n'
+printf '  ✓ schema_version reached at least v9 (got %s)\n' "$ver_post"
 
 row1=$(sqlite3 -separator '|' "$DB" "SELECT github_owner, github_repo FROM taps WHERE name='aeroxy/tap';")
 [[ "$row1" == "aeroxy|homebrew-tap" ]] || {

--- a/scripts/smokes/smoke_install_release.sh
+++ b/scripts/smokes/smoke_install_release.sh
@@ -87,8 +87,10 @@ INSTALLER_URL="https://raw.githubusercontent.com/indaco/malt/main/scripts/instal
 # /usr/bin/shasum or /usr/bin/curl with broken homebrew/nanobrew
 # wrappers — install.sh probes command -v and would pick those up. The
 # test isn't about dev-env pollution, so force a minimal PATH plus
-# cosign's directory.
-SAFE_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+# cosign's directory. `$INSTALL_DIR` is also prepended so install.sh's
+# trailing `command -v malt` check resolves the binary it just wrote
+# and the smoke output stays free of the "not in PATH" warning.
+SAFE_PATH="$INSTALL_DIR:/usr/bin:/bin:/usr/sbin:/sbin"
 if [ -n "$COSIGN_PATH" ]; then
   SAFE_PATH="$(dirname "$COSIGN_PATH"):$SAFE_PATH"
 fi

--- a/scripts/smokes/smoke_isolate_deps_yt_dlp.sh
+++ b/scripts/smokes/smoke_isolate_deps_yt_dlp.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# scripts/smokes/smoke_isolate_deps_yt_dlp.sh
+#
+# Canonical-example smoke for the `--isolate-deps` contract.
+#
+# The feature is motivated by yt-dlp: a real-world formula whose
+# runtime deps include `deno` and `python@3.14`. The PR's user-facing
+# promise is "I asked for yt-dlp, I get yt-dlp in my PATH — not also
+# deno and python3.14 just because yt-dlp needed them." This smoke
+# drives that exact scenario against the live Homebrew API and asserts
+# the contract end-to-end.
+#
+# Slower than `scripts/regressions/bin_isolation_basics.sh` (downloads
+# python@3.14 + deno; ~5 min on a warm connection), so it lives under
+# `smokes/` rather than `regressions/`.
+#
+# Assertions:
+#   1. <prefix>/bin/yt-dlp present (user's named package lands in PATH).
+#   2. <prefix>/bin/deno and <prefix>/bin/python3.14 absent (deps are
+#      isolated).
+#   3. <prefix>/opt/deno and <prefix>/opt/python@3.14 present (Mach-O
+#      and rewritten-shebang dependents still resolve).
+#   4. DB rows: yt-dlp is `direct, bin_isolated=0`; every transitive
+#      dep is `dependency, bin_isolated=1`.
+#   5. `links` table holds zero bin/sbin rows for any isolated dep.
+#   6. `yt-dlp --version` runs cleanly — verifies the bottle-time
+#      shebang rewriting that pins yt-dlp to its own Cellar's python
+#      still works under isolation.
+#
+# Usage: scripts/smokes/smoke_isolate_deps_yt_dlp.sh
+# Requirements: built `malt` binary, network to formulae.brew.sh + ghcr.io.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+PREFIX="/tmp/mt_yt"
+export MALT_PREFIX="$PREFIX"
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+DB="$PREFIX/db/malt.db"
+TARGET="yt-dlp"
+ISOLATED_DEPS=("deno" "python@3.14" "certifi")
+
+printf '▸ malt install --isolate-deps %s\n' "$TARGET"
+"$BIN" install --quiet --isolate-deps "$TARGET" || fail "install --isolate-deps $TARGET failed"
+
+[[ -f "$DB" ]] || fail "DB not created at $DB"
+
+# ── 1. Named package's bin landed in <prefix>/bin ─────────────────
+[[ -e "$PREFIX/bin/$TARGET" ]] || fail "$TARGET binary not linked into <prefix>/bin"
+pass "<prefix>/bin/$TARGET present (named package in PATH)"
+
+# ── 2. Each isolated dep's bin is *absent* from <prefix>/bin ──────
+# Use the formula's bottled bin names; brew exposes deno as `deno`
+# and python@3.14 as `python3.14` (the versioned name the formula
+# installs into bin/).
+for absent in "deno" "python3.14"; do
+  if [[ -e "$PREFIX/bin/$absent" ]]; then
+    fail "$absent leaked into <prefix>/bin under --isolate-deps"
+  fi
+  pass "<prefix>/bin/$absent absent (isolated dep hidden from PATH)"
+done
+
+# ── 3. opt/ anchors present so Mach-O + rewritten shebangs work ───
+for dep in "${ISOLATED_DEPS[@]}"; do
+  [[ -L "$PREFIX/opt/$dep" ]] || fail "opt/$dep anchor missing — dyld/shebang resolution would break"
+  pass "opt/$dep anchor present"
+done
+
+# ── 4. DB rows confirm the recorded intent ────────────────────────
+direct_target_isolated=$(sqlite3 "$DB" "SELECT bin_isolated FROM kegs WHERE name='$TARGET';")
+[[ "$direct_target_isolated" == "0" ]] ||
+  fail "$TARGET bin_isolated=$direct_target_isolated (expected 0 — user-named package stays direct)"
+pass "$TARGET row: bin_isolated=0 (direct keg, kept in PATH)"
+
+direct_target_reason=$(sqlite3 "$DB" "SELECT install_reason FROM kegs WHERE name='$TARGET';")
+[[ "$direct_target_reason" == "direct" ]] ||
+  fail "$TARGET install_reason=$direct_target_reason (expected direct)"
+pass "$TARGET row: install_reason=direct"
+
+for dep in "${ISOLATED_DEPS[@]}"; do
+  dep_isolated=$(sqlite3 "$DB" "SELECT bin_isolated FROM kegs WHERE name='$dep';" 2>/dev/null || echo "")
+  dep_reason=$(sqlite3 "$DB" "SELECT install_reason FROM kegs WHERE name='$dep';" 2>/dev/null || echo "")
+  [[ "$dep_isolated" == "1" ]] || fail "$dep bin_isolated=$dep_isolated (expected 1)"
+  [[ "$dep_reason" == "dependency" ]] ||
+    fail "$dep install_reason=$dep_reason (expected dependency)"
+  pass "$dep row: dependency + bin_isolated=1"
+done
+
+# ── 5. links table has zero bin/sbin rows for any isolated dep ────
+for dep in "${ISOLATED_DEPS[@]}"; do
+  bin_count=$(sqlite3 "$DB" "SELECT COUNT(*) FROM links l JOIN kegs k ON l.keg_id=k.id WHERE k.name='$dep' AND (l.link_path LIKE '%/bin/%' OR l.link_path LIKE '%/sbin/%');" 2>/dev/null || echo "0")
+  [[ "$bin_count" == "0" ]] ||
+    fail "$dep has $bin_count bin/sbin link rows (expected 0)"
+done
+pass "links table holds zero bin/sbin rows for the isolated deps"
+
+# ── 6. yt-dlp runs — exercises the bottle-time shebang rewriting ──
+#    Bottle authors `inreplace` `#!/usr/bin/env python3` into a path
+#    that anchors yt-dlp to its own Cellar interpreter. Under
+#    isolation `<prefix>/bin/python3.14` is missing, but the
+#    pinned path stays valid through `<prefix>/opt/python@3.14`.
+out=$("$PREFIX/bin/$TARGET" --version 2>&1 | head -1)
+[[ -n "$out" ]] || fail "$TARGET --version produced no output"
+printf '  ✓ %s --version → %s\n' "$TARGET" "$out"
+
+printf '\n✓ smoke_isolate_deps_yt_dlp: yt-dlp/deno/python3.14 contract holds\n'

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -156,7 +156,7 @@ fn cmdInstall(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []
     var explicit_path: ?[]const u8 = null;
     var isolate_deps = false;
     for (rest) |a| {
-        if (std.mem.eql(u8, a, "--isolate-deps")) {
+        if (std.mem.eql(u8, a, "--isolate-deps") or std.mem.eql(u8, a, "--isolate-dependencies")) {
             isolate_deps = true;
         } else if (std.mem.startsWith(u8, a, "-")) {
             output.warn("ignored flag: {s}", .{a});

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -33,24 +33,38 @@ fn narrowDispatch(e: anyerror) runner_mod.DispatchError {
     };
 }
 
+/// Per-`bundle install` invocation context. Carries the user's
+/// `--isolate-deps` intent so the runner's per-member install calls
+/// honour the same flag without it having to thread through the
+/// dispatcher's fn-pointer ABI.
+const BundleInstallCtx = struct {
+    app: *const AppCtx,
+    isolate_deps: bool,
+};
+
+fn bundleInstallCtxFromOpaque(ctx: ?*anyopaque) *const BundleInstallCtx {
+    const non_null = ctx orelse @panic("bundle: install dispatcher invoked without BundleInstallCtx");
+    return @ptrCast(@alignCast(non_null));
+}
+
 fn cliInstallFormula(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner_mod.DispatchError!void {
-    const app_ctx = appCtxFromOpaque(ctx);
-    install_cmd.installAll(app_ctx, allocator, &.{name}, .{}) catch |e| return narrowDispatch(e);
+    const bd = bundleInstallCtxFromOpaque(ctx);
+    install_cmd.installAll(bd.app, allocator, &.{name}, .{ .isolate_deps = bd.isolate_deps }) catch |e| return narrowDispatch(e);
 }
 
 fn cliInstallCask(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner_mod.DispatchError!void {
-    const app_ctx = appCtxFromOpaque(ctx);
-    install_cmd.installAll(app_ctx, allocator, &.{name}, .{ .cask = true }) catch |e| return narrowDispatch(e);
+    const bd = bundleInstallCtxFromOpaque(ctx);
+    install_cmd.installAll(bd.app, allocator, &.{name}, .{ .cask = true, .isolate_deps = bd.isolate_deps }) catch |e| return narrowDispatch(e);
 }
 
 fn cliTapAdd(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner_mod.DispatchError!void {
-    const app_ctx = appCtxFromOpaque(ctx);
-    tap_cmd.tapAdd(app_ctx, allocator, name) catch |e| return narrowDispatch(e);
+    const bd = bundleInstallCtxFromOpaque(ctx);
+    tap_cmd.tapAdd(bd.app, allocator, name) catch |e| return narrowDispatch(e);
 }
 
 fn cliServiceStart(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner_mod.DispatchError!void {
-    const app_ctx = appCtxFromOpaque(ctx);
-    services_cmd.servicesStart(app_ctx, allocator, name) catch |e| return narrowDispatch(e);
+    const bd = bundleInstallCtxFromOpaque(ctx);
+    services_cmd.servicesStart(bd.app, allocator, name) catch |e| return narrowDispatch(e);
 }
 
 fn cliUninstallFormula(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) cleanup_mod.DispatchError!void {
@@ -72,9 +86,9 @@ fn appCtxFromOpaque(ctx: ?*anyopaque) *const AppCtx {
     return @ptrCast(@alignCast(non_null));
 }
 
-fn runDispatcher(ctx: *const AppCtx) runner_mod.Dispatcher {
+fn runDispatcher(bd: *const BundleInstallCtx) runner_mod.Dispatcher {
     return .{
-        .ctx = @ptrCast(@constCast(ctx)),
+        .ctx = @ptrCast(@constCast(bd)),
         .installFormula = cliInstallFormula,
         .installCask = cliInstallCask,
         .tapAdd = cliTapAdd,
@@ -140,8 +154,11 @@ fn cmdInstall(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []
     // subcommand (install, upgrade, purge, …) and with its envelope.
     const dry_run = output.isDryRun();
     var explicit_path: ?[]const u8 = null;
+    var isolate_deps = false;
     for (rest) |a| {
-        if (std.mem.startsWith(u8, a, "-")) {
+        if (std.mem.eql(u8, a, "--isolate-deps")) {
+            isolate_deps = true;
+        } else if (std.mem.startsWith(u8, a, "-")) {
             output.warn("ignored flag: {s}", .{a});
         } else {
             explicit_path = a;
@@ -161,7 +178,8 @@ fn cmdInstall(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []
     var db = try openDb(ctx);
     defer db.close();
 
-    const dispatcher = runDispatcher(ctx);
+    const bd = BundleInstallCtx{ .app = ctx, .isolate_deps = isolate_deps };
+    const dispatcher = runDispatcher(&bd);
     var report = runner_mod.run(ctx.io, allocator, &db, manifest, .{
         .dry_run = dry_run,
         .dispatcher = &dispatcher,
@@ -626,7 +644,10 @@ fn printHelp(ctx: *const AppCtx) !void {
         \\Usage: malt bundle <subcommand> [args]
         \\
         \\Subcommands:
-        \\  install [file]              Install formulae/casks/taps/services from a Brewfile or Maltfile.json.
+        \\  install [--isolate-deps] [file]
+        \\                              Install formulae/casks/taps/services from a Brewfile or Maltfile.json.
+        \\                              --isolate-deps keeps transitive runtime deps out of <prefix>/bin
+        \\                              and <prefix>/sbin (per-keg state, replays on upgrade).
         \\  cleanup [--yes] [--dry-run] [file]
         \\                              Uninstall packages present on disk but absent from the Brewfile.
         \\  create  [--format brewfile|json] [--services] [path]

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -137,13 +137,13 @@ pub const bash_script =
     \\
     \\    local cmd_flags=""
     \\    case "$cmd" in
-    \\        install)          cmd_flags="--cask --formula --local --dry-run --force --download-only --only-dependencies --quiet -q --json" ;;
-    \\        reinstall)        cmd_flags="--cask --dry-run --quiet -q --json" ;;
+    \\        install)          cmd_flags="--cask --formula --local --dry-run --force --download-only --only-dependencies --isolate-deps --quiet -q --json" ;;
+    \\        reinstall)        cmd_flags="--cask --dry-run --isolate-deps --quiet -q --json" ;;
     \\        backup)           cmd_flags="--output -o --versions --services --quiet -q" ;;
     \\        restore)          cmd_flags="--dry-run --force --quiet -q" ;;
     \\        purge)            cmd_flags="--store-orphans --unused-deps --cache --cache= --downloads --stale-casks --old-versions --housekeeping --wipe --backup -b --keep-cache --remove-binary --yes -y --dry-run -n" ;;
     \\        uninstall|remove) cmd_flags="--force --zap --dry-run" ;;
-    \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --pinned --force -f" ;;
+    \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --pinned --force -f --isolate-deps" ;;
     \\        outdated)         cmd_flags="--json --formula --cask --pinned-only --tap --refresh --quiet -q" ;;
     \\        update)           cmd_flags="--check --quiet -q" ;;
     \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --tap --json --quiet -q" ;;
@@ -154,9 +154,9 @@ pub const bash_script =
     \\        which)            cmd_flags="--json" ;;
     \\        migrate)          cmd_flags="--dry-run" ;;
     \\        rollback)         cmd_flags="--dry-run --list --to --json" ;;
-    \\        link)             cmd_flags="--overwrite --force -f" ;;
+    \\        link)             cmd_flags="--overwrite --force -f --isolate --all" ;;
     \\        services)         cmd_flags="--tail --stderr --follow -f --system --json" ;;
-    \\        bundle)           cmd_flags="--dry-run -n --format --from-installed --purge --yes -y" ;;
+    \\        bundle)           cmd_flags="--dry-run -n --format --from-installed --purge --yes -y --isolate-deps" ;;
     \\        run)              cmd_flags="--keep" ;;
     \\        doctor)           cmd_flags="--fix --dry-run" ;;
     \\        tap)              cmd_flags="--refresh --all --pin --repo --force --yes -y --json" ;;
@@ -258,6 +258,7 @@ pub const zsh_script =
     \\                        '--force[Overwrite existing installations]' \
     \\                        '--download-only[Warm the bottle, cask, or tap-archive cache; skip install]' \
     \\                        '--only-dependencies[Install transitive deps, skip the requested package]' \
+    \\                        '--isolate-deps[Keep transitive deps out of <prefix>/bin and <prefix>/sbin]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
     \\                        '--json[Output result as JSON]' \
     \\                        '*::package:'
@@ -266,6 +267,7 @@ pub const zsh_script =
     \\                    _arguments \
     \\                        '--cask[Force cask path (auto-detected from the DB)]' \
     \\                        '--dry-run[Show what would be reinstalled]' \
+    \\                        '--isolate-deps[Apply isolation to any newly fetched dep]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
     \\                        '--json[Output result as JSON]' \
     \\                        '*::package:'
@@ -285,6 +287,7 @@ pub const zsh_script =
     \\                        '--dry-run[Show what would be upgraded]' \
     \\                        '--pinned[Audit pinned formulas + casks (requires --dry-run or --force)]' \
     \\                        '(--force -f)'{--force,-f}'[Bypass pin protection]' \
+    \\                        '--isolate-deps[Apply isolation to deps newly pulled in by this upgrade]' \
     \\                        '*::package:'
     \\                    ;;
     \\                pin|unpin)
@@ -358,6 +361,8 @@ pub const zsh_script =
     \\                    _arguments \
     \\                        '--overwrite[Replace existing symlinks]' \
     \\                        '(--force -f)'{--force,-f}'[Same as --overwrite]' \
+    \\                        '--isolate[Remove bin/sbin links and mark a dep isolated]' \
+    \\                        '--all[With --isolate: every dep keg]' \
     \\                        '*::formula:'
     \\                    ;;
     \\                completions|shellenv)
@@ -539,11 +544,13 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l force   -d 'Overwrite existing'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l download-only -d 'Warm the bottle, cask, or tap-archive cache; skip install'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l only-dependencies -d 'Install transitive deps; skip the requested package'
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l isolate-deps -d 'Keep transitive deps out of <prefix>/bin and <prefix>/sbin'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l json    -d 'JSON output'
     \\
     \\    # reinstall
     \\    complete -c $__malt_bin -n '__malt_using_command reinstall' -l cask    -d 'Force cask path (auto-detected from the DB)'
     \\    complete -c $__malt_bin -n '__malt_using_command reinstall' -l dry-run -d 'Preview'
+    \\    complete -c $__malt_bin -n '__malt_using_command reinstall' -l isolate-deps -d 'Apply isolation to deps newly fetched by this reinstall'
     \\    complete -c $__malt_bin -n '__malt_using_command reinstall' -l json    -d 'JSON output'
     \\
     \\    # uninstall / remove
@@ -561,6 +568,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l dry-run -d 'Preview'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l pinned  -d 'Audit pinned formulas + casks (needs --dry-run or --force)'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -s f -l force -d 'Bypass pin protection'
+    \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l isolate-deps -d 'Apply isolation to deps newly pulled in by this upgrade'
     \\
     \\    # outdated
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l json        -d 'JSON output'
@@ -624,6 +632,8 @@ pub const fish_script =
     \\    # link
     \\    complete -c $__malt_bin -n '__malt_using_command link' -l overwrite -d 'Replace existing symlinks'
     \\    complete -c $__malt_bin -n '__malt_using_command link' -s f -l force -d 'Same as --overwrite'
+    \\    complete -c $__malt_bin -n '__malt_using_command link' -l isolate    -d 'Remove bin/sbin links and mark a dep isolated'
+    \\    complete -c $__malt_bin -n '__malt_using_command link' -l all        -d 'With --isolate: every dep keg'
     \\
     \\    # run
     \\    complete -c $__malt_bin -n '__malt_using_command run' -l keep -d 'Cache extracted bottle under {cache}/run/<sha256>/'
@@ -696,6 +706,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l format -r -a 'brewfile json' -d 'Output format'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l from-installed -d 'Populate from installed packages'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l purge          -d 'Also uninstall members on remove'
+    \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l isolate-deps   -d 'Apply isolation to transitive deps of every member'
     \\end
     \\
     \\set -e __malt_bin

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -137,7 +137,7 @@ pub const bash_script =
     \\
     \\    local cmd_flags=""
     \\    case "$cmd" in
-    \\        install)          cmd_flags="--cask --formula --local --dry-run --force --download-only --only-dependencies --isolate-deps --quiet -q --json" ;;
+    \\        install)          cmd_flags="--cask --formula --local --dry-run --force --download-only --only-deps --only-dependencies --isolate-deps --quiet -q --json" ;;
     \\        reinstall)        cmd_flags="--cask --dry-run --isolate-deps --quiet -q --json" ;;
     \\        backup)           cmd_flags="--output -o --versions --services --quiet -q" ;;
     \\        restore)          cmd_flags="--dry-run --force --quiet -q" ;;
@@ -257,7 +257,8 @@ pub const zsh_script =
     \\                        '--dry-run[Show what would be installed]' \
     \\                        '--force[Overwrite existing installations]' \
     \\                        '--download-only[Warm the bottle, cask, or tap-archive cache; skip install]' \
-    \\                        '--only-dependencies[Install transitive deps, skip the requested package]' \
+    \\                        '--only-deps[Install transitive deps, skip the requested package]' \
+    \\                        '--only-dependencies[Brew-parity alias of --only-deps]' \
     \\                        '--isolate-deps[Keep transitive deps out of <prefix>/bin and <prefix>/sbin]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
     \\                        '--json[Output result as JSON]' \
@@ -543,7 +544,8 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l dry-run -d 'Preview'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l force   -d 'Overwrite existing'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l download-only -d 'Warm the bottle, cask, or tap-archive cache; skip install'
-    \\    complete -c $__malt_bin -n '__malt_using_command install' -l only-dependencies -d 'Install transitive deps; skip the requested package'
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l only-deps         -d 'Install transitive deps; skip the requested package'
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l only-dependencies -d 'Brew-parity alias of --only-deps'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l isolate-deps -d 'Keep transitive deps out of <prefix>/bin and <prefix>/sbin'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l json    -d 'JSON output'
     \\

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -137,13 +137,13 @@ pub const bash_script =
     \\
     \\    local cmd_flags=""
     \\    case "$cmd" in
-    \\        install)          cmd_flags="--cask --formula --local --dry-run --force --download-only --only-deps --only-dependencies --isolate-deps --quiet -q --json" ;;
-    \\        reinstall)        cmd_flags="--cask --dry-run --isolate-deps --quiet -q --json" ;;
+    \\        install)          cmd_flags="--cask --formula --local --dry-run --force --download-only --only-deps --only-dependencies --isolate-deps --isolate-dependencies --quiet -q --json" ;;
+    \\        reinstall)        cmd_flags="--cask --dry-run --isolate-deps --isolate-dependencies --quiet -q --json" ;;
     \\        backup)           cmd_flags="--output -o --versions --services --quiet -q" ;;
     \\        restore)          cmd_flags="--dry-run --force --quiet -q" ;;
     \\        purge)            cmd_flags="--store-orphans --unused-deps --cache --cache= --downloads --stale-casks --old-versions --housekeeping --wipe --backup -b --keep-cache --remove-binary --yes -y --dry-run -n" ;;
     \\        uninstall|remove) cmd_flags="--force --zap --dry-run" ;;
-    \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --pinned --force -f --isolate-deps" ;;
+    \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --pinned --force -f --isolate-deps --isolate-dependencies" ;;
     \\        outdated)         cmd_flags="--json --formula --cask --pinned-only --tap --refresh --quiet -q" ;;
     \\        update)           cmd_flags="--check --quiet -q" ;;
     \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --tap --json --quiet -q" ;;
@@ -156,7 +156,7 @@ pub const bash_script =
     \\        rollback)         cmd_flags="--dry-run --list --to --json" ;;
     \\        link)             cmd_flags="--overwrite --force -f --isolate --all" ;;
     \\        services)         cmd_flags="--tail --stderr --follow -f --system --json" ;;
-    \\        bundle)           cmd_flags="--dry-run -n --format --from-installed --purge --yes -y --isolate-deps" ;;
+    \\        bundle)           cmd_flags="--dry-run -n --format --from-installed --purge --yes -y --isolate-deps --isolate-dependencies" ;;
     \\        run)              cmd_flags="--keep" ;;
     \\        doctor)           cmd_flags="--fix --dry-run" ;;
     \\        tap)              cmd_flags="--refresh --all --pin --repo --force --yes -y --json" ;;
@@ -260,6 +260,7 @@ pub const zsh_script =
     \\                        '--only-deps[Install transitive deps, skip the requested package]' \
     \\                        '--only-dependencies[Brew-parity alias of --only-deps]' \
     \\                        '--isolate-deps[Keep transitive deps out of <prefix>/bin and <prefix>/sbin]' \
+    \\                        '--isolate-dependencies[Alias of --isolate-deps]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
     \\                        '--json[Output result as JSON]' \
     \\                        '*::package:'
@@ -269,6 +270,7 @@ pub const zsh_script =
     \\                        '--cask[Force cask path (auto-detected from the DB)]' \
     \\                        '--dry-run[Show what would be reinstalled]' \
     \\                        '--isolate-deps[Apply isolation to any newly fetched dep]' \
+    \\                        '--isolate-dependencies[Alias of --isolate-deps]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
     \\                        '--json[Output result as JSON]' \
     \\                        '*::package:'
@@ -289,6 +291,7 @@ pub const zsh_script =
     \\                        '--pinned[Audit pinned formulas + casks (requires --dry-run or --force)]' \
     \\                        '(--force -f)'{--force,-f}'[Bypass pin protection]' \
     \\                        '--isolate-deps[Apply isolation to deps newly pulled in by this upgrade]' \
+    \\                        '--isolate-dependencies[Alias of --isolate-deps]' \
     \\                        '*::package:'
     \\                    ;;
     \\                pin|unpin)
@@ -546,13 +549,15 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l download-only -d 'Warm the bottle, cask, or tap-archive cache; skip install'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l only-deps         -d 'Install transitive deps; skip the requested package'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l only-dependencies -d 'Brew-parity alias of --only-deps'
-    \\    complete -c $__malt_bin -n '__malt_using_command install' -l isolate-deps -d 'Keep transitive deps out of <prefix>/bin and <prefix>/sbin'
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l isolate-deps         -d 'Keep transitive deps out of <prefix>/bin and <prefix>/sbin'
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l isolate-dependencies -d 'Alias of --isolate-deps'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l json    -d 'JSON output'
     \\
     \\    # reinstall
     \\    complete -c $__malt_bin -n '__malt_using_command reinstall' -l cask    -d 'Force cask path (auto-detected from the DB)'
     \\    complete -c $__malt_bin -n '__malt_using_command reinstall' -l dry-run -d 'Preview'
-    \\    complete -c $__malt_bin -n '__malt_using_command reinstall' -l isolate-deps -d 'Apply isolation to deps newly fetched by this reinstall'
+    \\    complete -c $__malt_bin -n '__malt_using_command reinstall' -l isolate-deps         -d 'Apply isolation to deps newly fetched by this reinstall'
+    \\    complete -c $__malt_bin -n '__malt_using_command reinstall' -l isolate-dependencies -d 'Alias of --isolate-deps'
     \\    complete -c $__malt_bin -n '__malt_using_command reinstall' -l json    -d 'JSON output'
     \\
     \\    # uninstall / remove
@@ -570,7 +575,8 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l dry-run -d 'Preview'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l pinned  -d 'Audit pinned formulas + casks (needs --dry-run or --force)'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -s f -l force -d 'Bypass pin protection'
-    \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l isolate-deps -d 'Apply isolation to deps newly pulled in by this upgrade'
+    \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l isolate-deps         -d 'Apply isolation to deps newly pulled in by this upgrade'
+    \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l isolate-dependencies -d 'Alias of --isolate-deps'
     \\
     \\    # outdated
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l json        -d 'JSON output'
@@ -708,7 +714,8 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l format -r -a 'brewfile json' -d 'Output format'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l from-installed -d 'Populate from installed packages'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l purge          -d 'Also uninstall members on remove'
-    \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l isolate-deps   -d 'Apply isolation to transitive deps of every member'
+    \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l isolate-deps         -d 'Apply isolation to transitive deps of every member'
+    \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l isolate-dependencies -d 'Alias of --isolate-deps'
     \\end
     \\
     \\set -e __malt_bin

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -85,7 +85,7 @@ pub const checks = [_]Check{
     .{ .name = "Mach-O placeholders", .run = checkMachOPlaceholders },
     .{ .name = "Disk space", .run = checkDiskSpace },
     .{ .name = "Local formula sources", .run = checkLocalSources },
-    .{ .name = "Dependency bin/sbin leaks", .run = checkIsolationLeaks },
+    .{ .name = "Dependency bin/sbin link census", .run = checkIsolationLeaks },
 };
 
 /// Walks the table and tallies warn/err contributions. Exposed so
@@ -871,11 +871,11 @@ fn checkDiskSpace(ctx: CheckCtx, name: []const u8) CheckResult {
     return .warn_status;
 }
 
-/// Enumerate dep kegs whose bin/sbin are still linked into the prefix —
-/// the leak the isolation feature targets. Reports a count by default;
-/// verbose mode lists each offender with the `mt link --isolate <name>`
-/// remediation. Warning (not error) severity: nothing is broken, the
-/// user simply has more in PATH than they may want.
+/// Surface the dep-keg bin/sbin link census. Linked deps are the
+/// default state, not a defect — the check stays at `.ok` severity so
+/// `mt doctor` exits clean. Detail + enumeration only emit under
+/// `--verbose` so default runs stay silent on this dimension and
+/// downstream "grep for warnings" gates don't false-positive.
 fn checkIsolationLeaks(ctx: CheckCtx, name: []const u8) CheckResult {
     var db_path_buf: [512]u8 = undefined;
     const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{ctx.prefix}, 0) catch {
@@ -887,6 +887,11 @@ fn checkIsolationLeaks(ctx: CheckCtx, name: []const u8) CheckResult {
         return .ok;
     };
     defer db.close();
+
+    if (!output.isVerbose()) {
+        printCheck(name, .ok, null);
+        return .ok;
+    }
 
     var stmt = db.prepare(
         \\SELECT k.name
@@ -910,7 +915,7 @@ fn checkIsolationLeaks(ctx: CheckCtx, name: []const u8) CheckResult {
         const k_name = std.mem.sliceTo(stmt.columnText(0) orelse continue, 0);
         const row = std.fmt.allocPrint(
             ctx.allocator,
-            "{s}   (remediation: mt link --isolate {s})",
+            "{s}   (mt link --isolate {s} to hide from PATH)",
             .{ k_name, k_name },
         ) catch continue;
         offenders.append(ctx.allocator, row) catch {
@@ -927,13 +932,12 @@ fn checkIsolationLeaks(ctx: CheckCtx, name: []const u8) CheckResult {
     var msg_buf: [256]u8 = undefined;
     const msg = std.fmt.bufPrint(
         &msg_buf,
-        "{d} dependency keg(s) still link bin/sbin. Run `mt link --isolate <name>` to hide them from PATH.",
+        "{d} dependency keg(s) link bin/sbin (use `mt link --isolate <name>` to hide).",
         .{offenders.items.len},
-    ) catch "Dependency kegs are still linked into bin/sbin.";
-    printCheck(name, .warn_status, msg);
-    armVerboseHint();
+    ) catch "Dependency kegs are linked into bin/sbin.";
+    printCheck(name, .ok, msg);
     writeVerboseList(offenders.items);
-    return .warn_status;
+    return .ok;
 }
 
 fn checkLocalSources(ctx: CheckCtx, name: []const u8) CheckResult {

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -85,6 +85,7 @@ pub const checks = [_]Check{
     .{ .name = "Mach-O placeholders", .run = checkMachOPlaceholders },
     .{ .name = "Disk space", .run = checkDiskSpace },
     .{ .name = "Local formula sources", .run = checkLocalSources },
+    .{ .name = "Dependency bin/sbin leaks", .run = checkIsolationLeaks },
 };
 
 /// Walks the table and tallies warn/err contributions. Exposed so
@@ -867,6 +868,71 @@ fn checkDiskSpace(ctx: CheckCtx, name: []const u8) CheckResult {
         .{free_mb},
     ) catch "Low disk space (< 1 GB free)";
     printCheck(name, .warn_status, msg);
+    return .warn_status;
+}
+
+/// Enumerate dep kegs whose bin/sbin are still linked into the prefix —
+/// the leak the isolation feature targets. Reports a count by default;
+/// verbose mode lists each offender with the `mt link --isolate <name>`
+/// remediation. Warning (not error) severity: nothing is broken, the
+/// user simply has more in PATH than they may want.
+fn checkIsolationLeaks(ctx: CheckCtx, name: []const u8) CheckResult {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{ctx.prefix}, 0) catch {
+        printCheck(name, .ok, null);
+        return .ok;
+    };
+    var db = sqlite.Database.open(db_path) catch {
+        printCheck(name, .ok, null);
+        return .ok;
+    };
+    defer db.close();
+
+    var stmt = db.prepare(
+        \\SELECT k.name
+        \\FROM kegs k
+        \\JOIN links l ON l.keg_id = k.id
+        \\WHERE k.install_reason = 'dependency'
+        \\  AND k.bin_isolated = 0
+        \\  AND (l.link_path LIKE '%/bin/%' OR l.link_path LIKE '%/sbin/%')
+        \\GROUP BY k.id
+        \\ORDER BY k.name;
+    ) catch {
+        printCheck(name, .ok, null);
+        return .ok;
+    };
+    defer stmt.finalize();
+
+    var offenders: std.ArrayList([]u8) = .empty;
+    defer freeOwnedStringList(ctx.allocator, &offenders);
+
+    while (stmt.step() catch false) {
+        const k_name = std.mem.sliceTo(stmt.columnText(0) orelse continue, 0);
+        const row = std.fmt.allocPrint(
+            ctx.allocator,
+            "{s}   (remediation: mt link --isolate {s})",
+            .{ k_name, k_name },
+        ) catch continue;
+        offenders.append(ctx.allocator, row) catch {
+            ctx.allocator.free(row);
+            continue;
+        };
+    }
+
+    if (offenders.items.len == 0) {
+        printCheck(name, .ok, null);
+        return .ok;
+    }
+
+    var msg_buf: [256]u8 = undefined;
+    const msg = std.fmt.bufPrint(
+        &msg_buf,
+        "{d} dependency keg(s) still link bin/sbin. Run `mt link --isolate <name>` to hide them from PATH.",
+        .{offenders.items.len},
+    ) catch "Dependency kegs are still linked into bin/sbin.";
+    printCheck(name, .warn_status, msg);
+    armVerboseHint();
+    writeVerboseList(offenders.items);
     return .warn_status;
 }
 

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -93,6 +93,7 @@ const install_help =
     \\                     based formulas that bare-name-exec their deps
     \\                     (e.g. `python` vs `/full/path/python`) may break;
     \\                     use `mt link <dep>` to undo per-keg.
+    \\                     `--isolate-dependencies` accepted as an alias.
     \\  --quiet, -q        Suppress non-error output
     \\  --json             Output result as JSON
     \\
@@ -154,6 +155,7 @@ const upgrade_help =
     \\  --isolate-deps New deps pulled in by this upgrade keep their bins
     \\                 out of <prefix>/bin and <prefix>/sbin. Existing kegs
     \\                 replay whatever they were already recorded with.
+    \\                 `--isolate-dependencies` accepted as an alias.
     \\
 ;
 

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -83,6 +83,15 @@ const install_help =
     \\  --use-system-ruby[=<name>,...]  Run post_install via the system Ruby interpreter
     \\                     (experimental, sandboxed). A bare flag requires a single
     \\                     package; use =<name>,... to scope when installing multiple.
+    \\  --isolate-deps     Keep every transitive dep out of <prefix>/bin and
+    \\                     <prefix>/sbin. The package(s) you named still link
+    \\                     normally; deps land in the Cellar with their `opt/`
+    \\                     anchor (Mach-O dependents stay resolvable) but their
+    \\                     bin/sbin contents are skipped. The choice is recorded
+    \\                     per-keg so a later `mt upgrade` replays it. Shell-
+    \\                     based formulas that bare-name-exec their deps
+    \\                     (e.g. `python` vs `/full/path/python`) may break;
+    \\                     use `mt link <dep>` to undo per-keg.
     \\  --quiet, -q        Suppress non-error output
     \\  --json             Output result as JSON
     \\
@@ -104,6 +113,8 @@ const reinstall_help =
     \\  --dry-run            Show what would be reinstalled
     \\  --quiet, -q          Suppress non-error output
     \\  --json               JSON output (mirrors `mt install --json`)
+    \\  --isolate-deps       New deps follow the flag; existing rows keep
+    \\                       whatever isolation policy they were recorded with
     \\  --output-format=ndjson
     \\                       Stream one event per state transition
     \\
@@ -139,6 +150,9 @@ const upgrade_help =
     \\  --dry-run      Show what would be upgraded
     \\  --pinned       Audit pinned formulas + casks (requires --dry-run or --force)
     \\  --force, -f    Bypass pin protection (dangerous; user-initiated)
+    \\  --isolate-deps New deps pulled in by this upgrade keep their bins
+    \\                 out of <prefix>/bin and <prefix>/sbin. Existing kegs
+    \\                 replay whatever they were already recorded with.
     \\
 ;
 
@@ -375,12 +389,26 @@ const run_help =
 
 const link_help =
     \\Usage: malt link <formula> [flags]
+    \\       malt link --isolate <name>
+    \\       malt link --isolate --all
     \\
-    \\Create symlinks for an installed keg in the prefix (bin/, lib/, etc.).
+    \\Default form: create symlinks for an installed keg in the prefix
+    \\(bin/, lib/, etc.). Re-linking a previously isolated dep also
+    \\clears the isolation flag so DB and filesystem agree.
+    \\
+    \\`--isolate <name>` removes the keg's bin/sbin symlinks and marks
+    \\the row `bin_isolated=1`. Useful retroactively on a dep that
+    \\predates `--isolate-deps`. Refused on `install_reason='direct'`
+    \\kegs — uninstall first if you want a direct keg hidden from PATH.
+    \\
+    \\`--isolate --all` isolates every dep keg currently linking
+    \\bin/sbin.
     \\
     \\Flags:
     \\  --overwrite    Replace existing symlinks
     \\  --force, -f    Same as --overwrite
+    \\  --isolate      Remove bin/sbin symlinks; mark the keg isolated
+    \\  --all          With --isolate: operate on every dep keg
     \\
 ;
 

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -71,15 +71,16 @@ const install_help =
     \\                     only pass files you trust)
     \\  --dry-run          Show what would be installed
     \\  --force            Overwrite existing installations
-    \\  --only-dependencies  Install transitive deps but skip the requested package
+    \\  --only-deps        Install transitive deps but skip the requested package
     \\                     (deps are recorded as `dependency` so `mt purge --unused-deps`
-    \\                     can later GC them)
+    \\                     can later GC them). `--only-dependencies` accepted for
+    \\                     brew-parity.
     \\  --download-only    Warm the bottle store (formulas), the Cask cache (casks),
     \\                     or the tap archive cache (`<prefix>/cache/Tap/` for
     \\                     `user/repo/<formula>`) and stop before materialise/link/
     \\                     record. The Cellar, /Applications, and DB stay untouched;
     \\                     a follow-up `mt install` consumes the cached bytes.
-    \\                     Refused with --only-dependencies.
+    \\                     Refused with --only-deps.
     \\  --use-system-ruby[=<name>,...]  Run post_install via the system Ruby interpreter
     \\                     (experimental, sandboxed). A bare flag requires a single
     \\                     package; use =<name>,... to scope when installing multiple.

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -269,6 +269,65 @@ fn kegPresent(ctx: *const AppCtx, prefix: []const u8, name: []const u8) bool {
     return true;
 }
 
+/// Read-only DB probe used by the fast-path gate. Returns true iff any
+/// named pkg currently has `install_reason='dependency'` AND
+/// `bin_isolated=1` — i.e. the user is asking us to promote a dep keg
+/// the install pipeline must then re-link bin/sbin for. Quiet on
+/// errors: a missing DB is the empty case, not a failure to surface.
+fn anyNamedNeedsPromotion(ctx: *const AppCtx, prefix: []const u8, packages: []const []const u8) bool {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return false;
+    std.Io.Dir.accessAbsolute(ctx.io, db_path, .{}) catch return false;
+    var db = sqlite.Database.open(db_path) catch return false;
+    defer db.close();
+
+    var stmt = db.prepare(
+        "SELECT 1 FROM kegs WHERE name=?1 AND install_reason='dependency' AND bin_isolated=1 LIMIT 1;",
+    ) catch return false;
+    defer stmt.finalize();
+
+    for (packages) |pkg| {
+        stmt.reset() catch return false;
+        stmt.bindText(1, pkg) catch return false;
+        if (stmt.step() catch false) return true;
+    }
+    return false;
+}
+
+/// Promote one named keg if it is currently an isolated dep: clear
+/// `bin_isolated`, set `install_reason='direct'`, and re-link
+/// bin/sbin. Returns true on a successful promotion. Idempotent on
+/// already-direct rows.
+fn promoteIsolatedDepIfAny(
+    db: *sqlite.Database,
+    linker: *linker_mod.Linker,
+    name: []const u8,
+) bool {
+    var sel = db.prepare(
+        "SELECT id, version, cellar_path FROM kegs WHERE name=?1 AND install_reason='dependency' AND bin_isolated=1 LIMIT 1;",
+    ) catch return false;
+    defer sel.finalize();
+    sel.bindText(1, name) catch return false;
+    const ok = sel.step() catch false;
+    if (!ok) return false;
+    const keg_id = sel.columnInt(0);
+    const ver_ptr = sel.columnText(1) orelse return false;
+    const cellar_ptr = sel.columnText(2) orelse return false;
+    const version = std.mem.sliceTo(ver_ptr, 0);
+    const cellar = std.mem.sliceTo(cellar_ptr, 0);
+
+    var upd = db.prepare(
+        "UPDATE kegs SET install_reason='direct', bin_isolated=0 WHERE id=?1;",
+    ) catch return false;
+    defer upd.finalize();
+    upd.bindInt(1, keg_id) catch return false;
+    _ = upd.step() catch return false;
+
+    linker.link(cellar, name, keg_id, false) catch return false;
+    linker.linkOpt(name, version) catch {}; // opt link already present on a promoted dep; best-effort refresh.
+    return true;
+}
+
 pub const InstallAllOpts = struct {
     /// Treat every package as a cask; equivalent to `--cask`.
     cask: bool = false,
@@ -277,6 +336,10 @@ pub const InstallAllOpts = struct {
     /// otherwise EAGAIN-loop against its own hold and 30 s-timeout with
     /// the misleading "another mt process is running" error.
     skip_lock: bool = false,
+    /// Equivalent to `--isolate-deps` on the argv form. Mirrored on the
+    /// opts struct so the bundle runner can opt in without spelling
+    /// the flag out.
+    isolate_deps: bool = false,
 };
 
 /// Non-argv primitive used by `core/bundle/runner.zig` via its injected
@@ -294,6 +357,7 @@ pub fn installAll(
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(allocator);
     if (opts.cask) try argv.append(allocator, "--cask");
+    if (opts.isolate_deps) try argv.append(allocator, "--isolate-deps");
     for (packages) |p| try argv.append(allocator, p);
     return executeWithOpts(ctx, allocator, argv.items, .{ .skip_lock = opts.skip_lock });
 }
@@ -316,6 +380,7 @@ const InstallFlag = enum {
     json,
     only_dependencies,
     download_only,
+    isolate_deps,
 };
 
 const install_flag_map = std.StaticStringMap(InstallFlag).initComptime(.{
@@ -330,6 +395,7 @@ const install_flag_map = std.StaticStringMap(InstallFlag).initComptime(.{
     .{ "--json", .json },
     .{ "--only-dependencies", .only_dependencies },
     .{ "--download-only", .download_only },
+    .{ "--isolate-deps", .isolate_deps },
 });
 
 /// `allocator` must be an arena (see `installAll`).
@@ -369,6 +435,10 @@ fn executeWithOpts(
     // at 0 so warmed entries are invisible to `purge --store-orphans`
     // until a follow-up install picks them up.
     var download_only = false;
+    // Per-pass user intent: every dep keg materialised during this run
+    // gets `bin_isolated=1`. Direct kegs (the names the user asked for)
+    // are unaffected so they still land in PATH.
+    var isolate_deps = false;
 
     // StaticStringMap + exhaustive switch: the compiler checks every flag
     // has a handler, so adding a new variant without wiring it fails to build.
@@ -392,6 +462,7 @@ fn executeWithOpts(
             .json => output.setMode(.json),
             .only_dependencies => only_dependencies = true,
             .download_only => download_only = true,
+            .isolate_deps => isolate_deps = true,
         } else if (!std.mem.startsWith(u8, arg, "-")) {
             packages.append(allocator, arg) catch return error.OutOfMemory;
         }
@@ -485,6 +556,12 @@ fn executeWithOpts(
             if (isTapFormula(pkg) or isLocalFormulaPath(pkg)) break :fast;
             if (!kegPresent(ctx, prefix, pkg)) break :fast;
         }
+        // Promotion target — a named pkg currently recorded as an
+        // isolated dependency — needs `install_reason` cleared and
+        // bin/sbin symlinks materialised. That work fails open the DB
+        // and the lock, so it lives in the slow path; here we just
+        // gate the early return.
+        if (anyNamedNeedsPromotion(ctx, prefix, packages.items)) break :fast;
         for (packages.items) |pkg| {
             output.info("{s} is already installed", .{pkg});
             // Fast-path skips the protocol; positive signal so consumers
@@ -565,6 +642,16 @@ fn executeWithOpts(
     // Set up store + linker
     var store = store_mod.Store.init(ctx.io, allocator, &db, prefix);
     var linker = linker_mod.Linker.init(ctx.io, allocator, &db, prefix);
+
+    // Promote any named pkg currently recorded as an isolated dep.
+    // Done before resolution so the subsequent flow sees the post-
+    // promotion state ("direct + present") and `collectFormulaJobs`
+    // correctly short-circuits without re-downloading the keg.
+    for (packages.items) |pkg_name| {
+        if (promoteIsolatedDepIfAny(&db, &linker, pkg_name)) {
+            output.success("{s} promoted to direct: bin/sbin links restored", .{pkg_name});
+        }
+    }
 
     // One parsed-formula cache for the whole run; single free site.
     var formula_cache = deps_mod.FormulaCache.init(allocator);
@@ -978,7 +1065,7 @@ fn executeWithOpts(
             unlinkStaleKegLinks(&db, &linker, job.name, mats[i].kegPath());
         }
 
-        linkAndRecord(ctx.io, allocator, job, mats[i].kegPath(), &db, &linker, prefix, &formula_cache) catch {
+        linkAndRecord(ctx.io, allocator, job, mats[i].kegPath(), &db, &linker, prefix, &formula_cache, isolate_deps) catch {
             // The underlying error was already logged with a tag by
             // linkAndRecord — just record that this job failed so its
             // dependents in the rest of the loop get skipped above.
@@ -1013,6 +1100,11 @@ fn executeWithOpts(
 
 /// Link + record a materialised keg. Must run serially: linker conflict
 /// checks read live symlink state and SQLite is single-writer.
+///
+/// `isolate_deps` is the per-pass user flag. The keg's `bin_isolated`
+/// is computed as `isolate_deps and job.is_dep` so direct kegs always
+/// land in PATH even when the flag is set — the contract is "isolate
+/// transitive deps, never the named package."
 fn linkAndRecord(
     io: std.Io,
     allocator: std.mem.Allocator,
@@ -1022,8 +1114,10 @@ fn linkAndRecord(
     linker: *linker_mod.Linker,
     prefix: []const u8,
     cache: *deps_mod.FormulaCache,
+    isolate_deps: bool,
 ) !void {
     const reason: []const u8 = if (job.is_dep) "dependency" else "direct";
+    const bin_isolated = isolate_deps and job.is_dep;
 
     // Cache hit on the warm path; miss only happens for jobs whose JSON
     // never reached collectFormulaJobs (none today).
@@ -1035,9 +1129,12 @@ fn linkAndRecord(
         };
     };
 
-    // Check for symlink conflicts before linking
+    // Check for symlink conflicts before linking. The probe must mirror
+    // the link policy — otherwise an isolated dep would trigger a
+    // spurious bin/sbin conflict against a keg whose bins were never
+    // linked in the first place.
     if (!job.keg_only) {
-        const conflicts = linker.checkConflicts(keg_path) catch &.{};
+        const conflicts = linker.checkConflicts(keg_path, bin_isolated) catch &.{};
         if (conflicts.len > 0) {
             output.err("{s}: {d} symlink conflict(s) detected:", .{ job.name, conflicts.len });
             for (conflicts) |conflict| {
@@ -1051,13 +1148,13 @@ fn linkAndRecord(
 
     // Link + record
     if (!job.keg_only) {
-        const keg_id = recordKeg(db, formula, job.store_sha256, keg_path, reason, .{}) catch |err| {
+        const keg_id = recordKeg(db, formula, job.store_sha256, keg_path, reason, bin_isolated, .{}) catch |err| {
             output.err("Failed to record {s} in database: {s}", .{ job.name, @errorName(err) });
             cellar_mod.remove(io, prefix, job.name, job.version_str) catch {};
             return InstallError.RecordFailed;
         };
 
-        linker.link(keg_path, job.name, keg_id) catch |err| {
+        linker.link(keg_path, job.name, keg_id, bin_isolated) catch |err| {
             output.err("Failed to link {s}: {s}", .{ job.name, @errorName(err) });
             output.emitNdjsonEvent(.linked, job.name, "failed");
             // Rollback: unlink what was partially created + remove DB record + cellar.
@@ -1075,7 +1172,7 @@ fn linkAndRecord(
         };
         recordDeps(db, keg_id, formula);
     } else {
-        const keg_id = recordKeg(db, formula, job.store_sha256, keg_path, reason, .{}) catch |err| {
+        const keg_id = recordKeg(db, formula, job.store_sha256, keg_path, reason, bin_isolated, .{}) catch |err| {
             output.err("Failed to record {s} in database: {s}", .{ job.name, @errorName(err) });
             cellar_mod.remove(io, prefix, job.name, job.version_str) catch {};
             return InstallError.RecordFailed;

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -294,10 +294,11 @@ fn anyNamedNeedsPromotion(ctx: *const AppCtx, prefix: []const u8, packages: []co
     return false;
 }
 
-/// Promote one named keg if it is currently an isolated dep: clear
-/// `bin_isolated`, set `install_reason='direct'`, and re-link
-/// bin/sbin. Returns true on a successful promotion. Idempotent on
-/// already-direct rows.
+/// Promote one named keg if it is currently an isolated dep: re-link
+/// bin/sbin, then clear `bin_isolated` and set `install_reason='direct'`.
+/// FS work happens before the DB update so a link failure leaves the
+/// row's prior `bin_isolated=1` intact — coherent with the (still
+/// absent) bin/sbin links and recoverable on retry.
 fn promoteIsolatedDepIfAny(
     db: *sqlite.Database,
     linker: *linker_mod.Linker,
@@ -316,6 +317,9 @@ fn promoteIsolatedDepIfAny(
     const version = std.mem.sliceTo(ver_ptr, 0);
     const cellar = std.mem.sliceTo(cellar_ptr, 0);
 
+    linker.link(cellar, name, keg_id, false) catch return false;
+    linker.linkOpt(name, version) catch {}; // opt link already present on a promoted dep; best-effort refresh.
+
     var upd = db.prepare(
         "UPDATE kegs SET install_reason='direct', bin_isolated=0 WHERE id=?1;",
     ) catch return false;
@@ -323,8 +327,6 @@ fn promoteIsolatedDepIfAny(
     upd.bindInt(1, keg_id) catch return false;
     _ = upd.step() catch return false;
 
-    linker.link(cellar, name, keg_id, false) catch return false;
-    linker.linkOpt(name, version) catch {}; // opt link already present on a promoted dep; best-effort refresh.
     return true;
 }
 

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -380,7 +380,7 @@ const InstallFlag = enum {
     use_system_ruby,
     quiet,
     json,
-    only_dependencies,
+    only_deps,
     download_only,
     isolate_deps,
 };
@@ -395,7 +395,11 @@ const install_flag_map = std.StaticStringMap(InstallFlag).initComptime(.{
     .{ "--quiet", .quiet },
     .{ "-q", .quiet },
     .{ "--json", .json },
-    .{ "--only-dependencies", .only_dependencies },
+    .{ "--only-deps", .only_deps },
+    // brew-parity alias — `--only-dependencies` is what `brew install`
+    // accepts, so muscle memory keeps working alongside the canonical
+    // `--only-deps` spelling that mirrors `--isolate-deps`.
+    .{ "--only-dependencies", .only_deps },
     .{ "--download-only", .download_only },
     .{ "--isolate-deps", .isolate_deps },
 });
@@ -432,7 +436,7 @@ fn executeWithOpts(
     var local_only = false;
     // brew parity: resolve the dep graph, bail before the requested package's
     // materialise+link. Deps stay marked `dependency` for `mt purge --unused-deps`.
-    var only_dependencies = false;
+    var only_deps = false;
     // Warm the bottle store; skip materialise/link/record. Refcount stays
     // at 0 so warmed entries are invisible to `purge --store-orphans`
     // until a follow-up install picks them up.
@@ -462,7 +466,7 @@ fn executeWithOpts(
             .use_system_ruby => use_system_ruby_bare = true,
             .quiet => output.setQuiet(true),
             .json => output.setMode(.json),
-            .only_dependencies => only_dependencies = true,
+            .only_deps => only_deps = true,
             .download_only => download_only = true,
             .isolate_deps => isolate_deps = true,
         } else if (!std.mem.startsWith(u8, arg, "-")) {
@@ -492,11 +496,11 @@ fn executeWithOpts(
         }
     }
 
-    // The two flags pull in opposite directions: --only-dependencies skips
-    // the requested package, --download-only skips materialise+link entirely.
+    // The two flags pull in opposite directions: --only-deps skips the
+    // requested package, --download-only skips materialise+link entirely.
     // Document the refusal up front rather than silently picking a winner.
-    if (download_only and only_dependencies) {
-        output.err("--download-only cannot be combined with --only-dependencies", .{});
+    if (download_only and only_deps) {
+        output.err("--download-only cannot be combined with --only-deps", .{});
         return error.Aborted;
     }
 
@@ -548,11 +552,11 @@ fn executeWithOpts(
 
     // Idempotent fast path — skip DB / lock / HTTP setup when every named
     // arg already has a Cellar entry. Flags that change semantics
-    // (--force / --cask / --local / --dry-run / --only-dependencies) and
+    // (--force / --cask / --local / --dry-run / --only-deps) and
     // tap-form / .rb-path args route to the regular flow. All-or-nothing
     // on multi-arg keeps the gate state-free.
     const fastpath_eligible = !force and !force_cask and !local_only and
-        !dry_run and !only_dependencies;
+        !dry_run and !only_deps;
     if (fastpath_eligible) fast: {
         for (packages.items) |pkg| {
             if (isTapFormula(pkg) or isLocalFormulaPath(pkg)) break :fast;
@@ -773,7 +777,7 @@ fn executeWithOpts(
     // top-level skipped; deps still recorded for GC. Surviving jobs keep
     // `is_dep=true`, so `linkAndRecord` writes `install_reason='dependency'`
     // and `mt purge --unused-deps` reclaims them once nothing direct retains them.
-    if (only_dependencies) dropTopLevelJobs(allocator, &all_jobs);
+    if (only_deps) dropTopLevelJobs(allocator, &all_jobs);
 
     if (all_jobs.items.len == 0) {
         // Resolution-only failures never reach the link loop's trailing

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -402,6 +402,9 @@ const install_flag_map = std.StaticStringMap(InstallFlag).initComptime(.{
     .{ "--only-dependencies", .only_deps },
     .{ "--download-only", .download_only },
     .{ "--isolate-deps", .isolate_deps },
+    // Long-form alias — mirrors the `--only-deps` / `--only-dependencies`
+    // pair so the flag surface stays predictable.
+    .{ "--isolate-dependencies", .isolate_deps },
 });
 
 /// `allocator` must be an arena (see `installAll`).

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -445,7 +445,7 @@ pub fn assignDownloadLineIndices(jobs: []DownloadJob) u16 {
     return idx;
 }
 
-/// Drop top-level (`is_dep == false`) jobs from `jobs` so `--only-dependencies`
+/// Drop top-level (`is_dep == false`) jobs from `jobs` so `--only-deps`
 /// can bail before the requested package is materialised. Frees the same five
 /// strings `dupeJobStrings` allocated; `formula_json` on top-level jobs is
 /// borrowed from `api.fetchFormula`, so freeing it here would double-free.

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -786,7 +786,7 @@ pub fn materializeRubyFormula(
         }
     }
 
-    linker.link(cellar_path, resolved.name, keg_id) catch {
+    linker.link(cellar_path, resolved.name, keg_id, false) catch {
         output.warn("Some links for {s} could not be created", .{resolved.name});
     };
     linker.linkOpt(resolved.name, resolved.version) catch {

--- a/src/cli/install/record.zig
+++ b/src/cli/install/record.zig
@@ -112,12 +112,17 @@ pub const RecordOpts = struct {
 /// underlying cause through `db.errMsg()` instead of seeing a flat
 /// `RecordFailed` — particularly load-bearing for the upgrade path
 /// where a UNIQUE collision must surface to the user.
+///
+/// `bin_isolated` is the user's per-keg "don't link bin/sbin into
+/// prefix/bin" intent; it round-trips so a later upgrade reads back
+/// the same policy without the user re-passing a flag.
 pub fn recordKeg(
     db: *sqlite.Database,
     formula: *const formula_mod.Formula,
     store_sha256: []const u8,
     cellar_path: []const u8,
     install_reason: []const u8,
+    bin_isolated: bool,
     opts: RecordOpts,
 ) sqlite.SqliteError!i64 {
     if (!opts.in_transaction) {
@@ -130,11 +135,11 @@ pub fn recordKeg(
     // REPLACE handles same-(name, version) re-records (install --force,
     // revision bumps); upgrade (different version) just INSERTs alongside.
     const sql = if (opts.inherit_pin)
-        "INSERT OR REPLACE INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason, pinned)" ++
-            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, COALESCE((SELECT MAX(pinned) FROM kegs WHERE name = ?1), 0));"
+        "INSERT OR REPLACE INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason, bin_isolated, pinned)" ++
+            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, COALESCE((SELECT MAX(pinned) FROM kegs WHERE name = ?1), 0));"
     else
-        "INSERT OR REPLACE INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason, pinned)" ++
-            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 0);";
+        "INSERT OR REPLACE INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path, install_reason, bin_isolated, pinned)" ++
+            " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0);";
 
     var stmt = try db.prepare(sql);
     defer stmt.finalize();
@@ -147,6 +152,7 @@ pub fn recordKeg(
     try stmt.bindText(6, store_sha256);
     try stmt.bindText(7, cellar_path);
     try stmt.bindText(8, install_reason);
+    try stmt.bindInt(9, if (bin_isolated) 1 else 0);
 
     _ = try stmt.step();
 

--- a/src/cli/link.zig
+++ b/src/cli/link.zig
@@ -115,14 +115,20 @@ pub fn executeLink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []con
     }
 
     // A full link materialises bin/sbin, so the row's `bin_isolated`
-    // must agree with the filesystem; clear it unconditionally. The
-    // UPDATE is a no-op for already-direct rows.
-    var clr = db.prepare("UPDATE kegs SET bin_isolated = 0 WHERE id = ?1;") catch return;
-    defer clr.finalize();
-    clr.bindInt(1, keg_id) catch return;
-    _ = clr.step() catch {};
+    // must agree with the filesystem; clear it unconditionally. Best-
+    // effort: the FS work already succeeded, so on a DB write error
+    // we still print success and let `mt doctor` self-heal — bailing
+    // here would swallow the user-visible outcome.
+    clearBinIsolated(&db, keg_id);
 
     output.success("{s} linked", .{target_name});
+}
+
+fn clearBinIsolated(db: *sqlite.Database, keg_id: i64) void {
+    var stmt = db.prepare("UPDATE kegs SET bin_isolated = 0 WHERE id = ?1;") catch return;
+    defer stmt.finalize();
+    stmt.bindInt(1, keg_id) catch return;
+    _ = stmt.step() catch {};
 }
 
 /// `mt link --isolate <name|--all>` — remove bin/sbin links and mark

--- a/src/cli/link.zig
+++ b/src/cli/link.zig
@@ -156,8 +156,6 @@ fn executeLinkIsolate(ctx: *const AppCtx, allocator: std.mem.Allocator, name: ?[
     defer db.close();
     schema.initSchema(&db) catch {};
 
-    var linker = linker_mod.Linker.init(ctx.io, allocator, &db, prefix);
-
     if (all_flag) {
         var sel = db.prepare(
             "SELECT id, name FROM kegs WHERE install_reason='dependency' AND bin_isolated=0 ORDER BY name;",
@@ -189,7 +187,7 @@ fn executeLinkIsolate(ctx: *const AppCtx, allocator: std.mem.Allocator, name: ?[
         }
 
         for (names.items, ids.items) |n, id| {
-            isolateOne(ctx, &db, &linker, n, id) catch {
+            isolateOne(ctx, &db, id) catch {
                 output.warn("could not isolate {s}", .{n});
                 continue;
             };
@@ -216,7 +214,7 @@ fn executeLinkIsolate(ctx: *const AppCtx, allocator: std.mem.Allocator, name: ?[
         return error.Aborted;
     }
 
-    try isolateOne(ctx, &db, &linker, target, keg_id);
+    try isolateOne(ctx, &db, keg_id);
     output.success("{s} isolated: bin/sbin links removed", .{target});
 }
 
@@ -227,13 +225,8 @@ fn executeLinkIsolate(ctx: *const AppCtx, allocator: std.mem.Allocator, name: ?[
 fn isolateOne(
     ctx: *const AppCtx,
     db: *sqlite.Database,
-    linker: *linker_mod.Linker,
-    name: []const u8,
     keg_id: i64,
 ) !void {
-    _ = name;
-    _ = linker;
-
     var sel = try db.prepare(
         "SELECT link_path FROM links WHERE keg_id = ?1 AND (link_path LIKE '%/bin/%' OR link_path LIKE '%/sbin/%');",
     );
@@ -241,6 +234,8 @@ fn isolateOne(
     try sel.bindInt(1, keg_id);
     while (try sel.step()) {
         const p = sel.columnText(0) orelse continue;
+        // Symlink may already be gone from the filesystem; the DB
+        // DELETE below is the source of truth being flushed.
         std.Io.Dir.cwd().deleteFile(ctx.io, std.mem.sliceTo(p, 0)) catch {};
     }
 

--- a/src/cli/link.zig
+++ b/src/cli/link.zig
@@ -13,17 +13,32 @@ const help = @import("help.zig");
 pub fn executeLink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(ctx, args, "link")) return;
 
-    if (args.len == 0) {
-        output.err("Usage: mt link <formula>", .{});
-        output.info("Create symlinks for an installed keg in the prefix (bin/, lib/, etc.)", .{});
-        return error.Aborted;
+    var isolate = false;
+    var all_flag = false;
+    var overwrite = false;
+    var name: ?[]const u8 = null;
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--isolate")) {
+            isolate = true;
+        } else if (std.mem.eql(u8, arg, "--all")) {
+            all_flag = true;
+        } else if (std.mem.eql(u8, arg, "--overwrite") or std.mem.eql(u8, arg, "--force") or std.mem.eql(u8, arg, "-f")) {
+            overwrite = true;
+        } else if (arg.len > 0 and arg[0] != '-') {
+            if (name == null) name = arg;
+        }
     }
 
-    const name = args[0];
-    var overwrite = false;
-    for (args[1..]) |arg| {
-        if (std.mem.eql(u8, arg, "--overwrite") or std.mem.eql(u8, arg, "--force") or std.mem.eql(u8, arg, "-f")) overwrite = true;
+    if (isolate) {
+        return executeLinkIsolate(ctx, allocator, name, all_flag);
     }
+
+    const target_name = name orelse {
+        output.err("Usage: mt link <formula>", .{});
+        output.info("Create symlinks for an installed keg in the prefix (bin/, lib/, etc.)", .{});
+        output.info("Use 'mt link --isolate <name>' to remove bin/sbin links and mark a dep isolated.", .{});
+        return error.Aborted;
+    };
 
     const prefix = atomic.maltPrefixOrAbort();
 
@@ -43,17 +58,17 @@ pub fn executeLink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []con
         return error.Aborted;
     };
     defer stmt.finalize();
-    stmt.bindText(1, name) catch return;
+    stmt.bindText(1, target_name) catch return;
 
     const has_row = stmt.step() catch false;
     if (!has_row) {
-        output.err("{s} is not installed", .{name});
+        output.err("{s} is not installed", .{target_name});
         return error.Aborted;
     }
 
     const keg_id = stmt.columnInt(0);
     const cellar_path_raw = stmt.columnText(2) orelse {
-        output.err("No cellar path recorded for {s}", .{name});
+        output.err("No cellar path recorded for {s}", .{target_name});
         return error.Aborted;
     };
     const cellar_path = std.mem.sliceTo(cellar_path_raw, 0);
@@ -62,7 +77,7 @@ pub fn executeLink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []con
 
     // Check for conflicts unless --overwrite
     if (!overwrite) {
-        const conflicts = linker.checkConflicts(cellar_path) catch &.{};
+        const conflicts = linker.checkConflicts(cellar_path, false) catch &.{};
         defer {
             // checkConflicts hands back an owned slice plus dupe'd
             // link_path / existing_keg strings; the empty-slice fallback
@@ -74,7 +89,7 @@ pub fn executeLink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []con
             if (conflicts.len > 0) allocator.free(conflicts);
         }
         if (conflicts.len > 0) {
-            output.err("{s}: {d} symlink conflict(s):", .{ name, conflicts.len });
+            output.err("{s}: {d} symlink conflict(s):", .{ target_name, conflicts.len });
             for (conflicts) |c| {
                 output.err("  {s} already linked by {s}", .{ c.link_path, c.existing_keg });
             }
@@ -83,8 +98,8 @@ pub fn executeLink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []con
         }
     }
 
-    linker.link(cellar_path, name, keg_id) catch {
-        output.err("Failed to create symlinks for {s}", .{name});
+    linker.link(cellar_path, target_name, keg_id, false) catch {
+        output.err("Failed to create symlinks for {s}", .{target_name});
         return error.Aborted;
     };
 
@@ -95,11 +110,145 @@ pub fn executeLink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []con
     if (ver_stmt.step() catch false) {
         if (ver_stmt.columnText(0)) |v| {
             // opt/ link is a convenience pointer; primary link.link already succeeded.
-            linker.linkOpt(name, std.mem.sliceTo(v, 0)) catch {};
+            linker.linkOpt(target_name, std.mem.sliceTo(v, 0)) catch {};
         }
     }
 
-    output.success("{s} linked", .{name});
+    // A full link materialises bin/sbin, so the row's `bin_isolated`
+    // must agree with the filesystem; clear it unconditionally. The
+    // UPDATE is a no-op for already-direct rows.
+    var clr = db.prepare("UPDATE kegs SET bin_isolated = 0 WHERE id = ?1;") catch return;
+    defer clr.finalize();
+    clr.bindInt(1, keg_id) catch return;
+    _ = clr.step() catch {};
+
+    output.success("{s} linked", .{target_name});
+}
+
+/// `mt link --isolate <name|--all>` — remove bin/sbin links and mark
+/// the dep keg as isolated. Refuses on `install_reason='direct'`
+/// kegs: a user can't accidentally hide a top-level package from
+/// PATH via this verb; they'd have to uninstall first.
+fn executeLinkIsolate(ctx: *const AppCtx, allocator: std.mem.Allocator, name: ?[]const u8, all_flag: bool) !void {
+    if (name == null and !all_flag) {
+        output.err("Usage: mt link --isolate <name>  or  mt link --isolate --all", .{});
+        return error.Aborted;
+    }
+    if (name != null and all_flag) {
+        output.err("--isolate accepts either <name> or --all, not both", .{});
+        return error.Aborted;
+    }
+
+    const prefix = atomic.maltPrefixOrAbort();
+
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
+    var db = sqlite.Database.open(db_path) catch {
+        output.err("Failed to open database", .{});
+        return error.Aborted;
+    };
+    defer db.close();
+    schema.initSchema(&db) catch {};
+
+    var linker = linker_mod.Linker.init(ctx.io, allocator, &db, prefix);
+
+    if (all_flag) {
+        var sel = db.prepare(
+            "SELECT id, name FROM kegs WHERE install_reason='dependency' AND bin_isolated=0 ORDER BY name;",
+        ) catch return error.Aborted;
+        defer sel.finalize();
+
+        var names: std.ArrayList([]const u8) = .empty;
+        defer {
+            for (names.items) |n| allocator.free(n);
+            names.deinit(allocator);
+        }
+        var ids: std.ArrayList(i64) = .empty;
+        defer ids.deinit(allocator);
+
+        while (sel.step() catch false) {
+            const id = sel.columnInt(0);
+            const nm = sel.columnText(1) orelse continue;
+            const owned = allocator.dupe(u8, std.mem.sliceTo(nm, 0)) catch continue;
+            names.append(allocator, owned) catch {
+                allocator.free(owned);
+                continue;
+            };
+            ids.append(allocator, id) catch continue;
+        }
+
+        if (names.items.len == 0) {
+            output.info("No dependency kegs with linked bin/sbin to isolate.", .{});
+            return;
+        }
+
+        for (names.items, ids.items) |n, id| {
+            isolateOne(ctx, &db, &linker, n, id) catch {
+                output.warn("could not isolate {s}", .{n});
+                continue;
+            };
+            output.success("{s} isolated", .{n});
+        }
+        return;
+    }
+
+    const target = name.?;
+    var sel = db.prepare("SELECT id, install_reason FROM kegs WHERE name = ?1 LIMIT 1;") catch return error.Aborted;
+    defer sel.finalize();
+    sel.bindText(1, target) catch return error.Aborted;
+
+    const has = sel.step() catch false;
+    if (!has) {
+        output.err("{s} is not installed", .{target});
+        return error.Aborted;
+    }
+    const keg_id = sel.columnInt(0);
+    const reason_ptr = sel.columnText(1) orelse "direct";
+    const reason = std.mem.sliceTo(reason_ptr, 0);
+    if (!std.mem.eql(u8, reason, "dependency")) {
+        output.err("{s} is a direct install — refusing to isolate. Uninstall first if you want it hidden from PATH.", .{target});
+        return error.Aborted;
+    }
+
+    try isolateOne(ctx, &db, &linker, target, keg_id);
+    output.success("{s} isolated: bin/sbin links removed", .{target});
+}
+
+/// Delete every bin/sbin row + filesystem symlink for one keg, then
+/// stamp the row as isolated. Filesystem first so a crash leaves the
+/// DB as the recoverable source of truth — matches `Linker.unlink`'s
+/// posture.
+fn isolateOne(
+    ctx: *const AppCtx,
+    db: *sqlite.Database,
+    linker: *linker_mod.Linker,
+    name: []const u8,
+    keg_id: i64,
+) !void {
+    _ = name;
+    _ = linker;
+
+    var sel = try db.prepare(
+        "SELECT link_path FROM links WHERE keg_id = ?1 AND (link_path LIKE '%/bin/%' OR link_path LIKE '%/sbin/%');",
+    );
+    defer sel.finalize();
+    try sel.bindInt(1, keg_id);
+    while (try sel.step()) {
+        const p = sel.columnText(0) orelse continue;
+        std.Io.Dir.cwd().deleteFile(ctx.io, std.mem.sliceTo(p, 0)) catch {};
+    }
+
+    var del = try db.prepare(
+        "DELETE FROM links WHERE keg_id = ?1 AND (link_path LIKE '%/bin/%' OR link_path LIKE '%/sbin/%');",
+    );
+    defer del.finalize();
+    try del.bindInt(1, keg_id);
+    _ = try del.step();
+
+    var upd = try db.prepare("UPDATE kegs SET bin_isolated = 1 WHERE id = ?1;");
+    defer upd.finalize();
+    try upd.bindInt(1, keg_id);
+    _ = try upd.step();
 }
 
 pub fn executeUnlink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -181,7 +181,7 @@ pub fn migrateKeg(
             return .failed_install;
         };
 
-        deps.linker.link(keg.path, formula.name, keg_id) catch {
+        deps.linker.link(keg.path, formula.name, keg_id, false) catch {
             output.warn("    {s}: some links could not be created", .{keg_name});
             output.emitNdjsonEvent(.linked, keg_name, "failed");
             // Rollback: unlink partial links and delete keg row; user already warned above.
@@ -333,7 +333,7 @@ fn migrateFromLocalCellar(
         return .failed_install;
     };
 
-    deps.linker.link(keg.path, keg_name, keg_id) catch {
+    deps.linker.link(keg.path, keg_name, keg_id, false) catch {
         output.warn("    {s}: some links could not be created", .{keg_name});
         deps.linker.unlink(keg_id) catch {};
         deleteKeg(deps.db, keg_id) catch {};

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -205,7 +205,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     ) catch return error.Aborted;
 
     // Link the old version
-    linker.link(keg.path, name, keg_id) catch {
+    linker.link(keg.path, name, keg_id, false) catch {
         output.warn("Could not link restored {s} — try: mt link {s}", .{ name, name });
     };
     linker.linkOpt(name, target.pkg_version) catch {

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -30,7 +30,7 @@ const InstallError = install_record_mod.InstallError;
 const install_mod = @import("install.zig");
 const pin_mod = @import("pin.zig");
 
-const UpgradeFlag = enum { quiet, cask, formula, dry_run, force, pinned };
+const UpgradeFlag = enum { quiet, cask, formula, dry_run, force, pinned, isolate_deps };
 
 const upgrade_flag_map = std.StaticStringMap(UpgradeFlag).initComptime(.{
     .{ "-q", .quiet },
@@ -41,6 +41,7 @@ const upgrade_flag_map = std.StaticStringMap(UpgradeFlag).initComptime(.{
     .{ "--force", .force },
     .{ "-f", .force },
     .{ "--pinned", .pinned },
+    .{ "--isolate-deps", .isolate_deps },
 });
 
 /// True when this name should be skipped due to a user pin. Pure gate so
@@ -61,6 +62,9 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     var dry_run = output.isDryRun();
     var force = false;
     var pinned_only = false;
+    // Applies only to deps newly introduced by this upgrade — existing
+    // kegs replay their stored `bin_isolated` regardless of the flag.
+    var isolate_deps = false;
     var pkg_name: ?[]const u8 = null;
 
     // StaticStringMap + exhaustive switch: every flag routes to a handler.
@@ -72,6 +76,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             .dry_run => dry_run = true,
             .force => force = true,
             .pinned => pinned_only = true,
+            .isolate_deps => isolate_deps = true,
         } else if (arg.len > 0 and arg[0] != '-') {
             if (pkg_name == null) pkg_name = arg;
         }
@@ -134,7 +139,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         // Upgrade a specific package — try formula first, then cask
         if (!cask_only) {
             if (isFormulaInstalled(&db, name)) {
-                upgradeFormula(ctx, allocator, name, &db, &api, &http, prefix, dry_run, force, pinned_only) catch {
+                upgradeFormula(ctx, allocator, name, &db, &api, &http, prefix, dry_run, force, pinned_only, isolate_deps) catch {
                     any_failed = true;
                 };
                 if (any_failed) return error.Aborted;
@@ -148,7 +153,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     } else {
         // Upgrade all
         if (!cask_only) {
-            upgradeAllFormulas(ctx, allocator, &db, &api, &http, prefix, dry_run, force, pinned_only) catch {
+            upgradeAllFormulas(ctx, allocator, &db, &api, &http, prefix, dry_run, force, pinned_only, isolate_deps) catch {
                 any_failed = true;
             };
         }
@@ -186,6 +191,7 @@ fn upgradeFormula(
     dry_run: bool,
     force: bool,
     audit_mode: bool,
+    isolate_deps: bool,
 ) !void {
     // Honor pins before any network or filesystem work — the whole
     // point is that a pinned keg never gets touched. Audit mode
@@ -198,9 +204,11 @@ fn upgradeFormula(
         return;
     }
 
-    // Step 1: Look up installed version from DB
+    // Step 1: Look up installed version from DB. `bin_isolated` is
+    // read so the upgraded row replays the user's prior isolation
+    // intent without re-passing a flag.
     var find_stmt = db.prepare(
-        "SELECT id, version, revision, store_sha256, cellar_path, tap FROM kegs WHERE name = ?1 LIMIT 1;",
+        "SELECT id, version, revision, store_sha256, cellar_path, tap, bin_isolated FROM kegs WHERE name = ?1 LIMIT 1;",
     ) catch return;
     defer find_stmt.finalize();
     find_stmt.bindText(1, name) catch return;
@@ -217,6 +225,7 @@ fn upgradeFormula(
     const old_sha_ptr = find_stmt.columnText(3);
     const old_cellar_ptr = find_stmt.columnText(4);
     const tap_ptr = find_stmt.columnText(5);
+    const replay_bin_isolated = find_stmt.columnInt(6) != 0;
     const old_version = if (old_ver_ptr) |v| std.mem.sliceTo(v, 0) else "unknown";
     const old_sha256 = if (old_sha_ptr) |s| std.mem.sliceTo(s, 0) else "";
     const old_cellar_path = if (old_cellar_ptr) |c| std.mem.sliceTo(c, 0) else "";
@@ -291,7 +300,10 @@ fn upgradeFormula(
             // BSD flock is per-fd, so without skip_lock the inner acquire
             // would EAGAIN-loop on our own hold and 30 s-timeout as
             // misleading "Another mt process is running" contention.
-            install_mod.installAll(ctx, allocator, missing, .{ .skip_lock = true }) catch {
+            install_mod.installAll(ctx, allocator, missing, .{
+                .skip_lock = true,
+                .isolate_deps = isolate_deps,
+            }) catch {
                 output.err("Could not install new dep(s) for {s}", .{name});
                 return error.Aborted;
             };
@@ -349,7 +361,7 @@ fn upgradeFormula(
         return error.Aborted;
     };
 
-    const new_keg_id = upgradeDbAtomic(db, &linker, old_keg_id, &formula, fetch.sha256, new_keg.path) catch |db_err| {
+    const new_keg_id = upgradeDbAtomic(db, &linker, old_keg_id, &formula, fetch.sha256, new_keg.path, replay_bin_isolated) catch |db_err| {
         output.err(
             "Failed to record new version of {s} in database: {s} ({s})",
             .{ name, @errorName(db_err), db.errMsg() },
@@ -358,7 +370,7 @@ fn upgradeFormula(
         // FS rollback: the txn restored old keg/links rows; we still
         // need to recreate the old symlinks (FS isn't transactional)
         // and drop the freshly-materialized new cellar dir.
-        restoreOldLinks(db, &linker, old_cellar_path, name, old_keg_id);
+        restoreOldLinks(db, &linker, old_cellar_path, name, old_keg_id, replay_bin_isolated);
         cellar_mod.remove(ctx.io, prefix, formula.name, formula.pkg_version) catch {};
         return error.Aborted;
     };
@@ -371,7 +383,7 @@ fn upgradeFormula(
         db.rollback();
         // best-effort FS cleanup before falling back to the old version.
         linker.unlink(new_keg_id) catch {};
-        restoreOldLinks(db, &linker, old_cellar_path, name, old_keg_id);
+        restoreOldLinks(db, &linker, old_cellar_path, name, old_keg_id, replay_bin_isolated);
         cellar_mod.remove(ctx.io, prefix, formula.name, formula.pkg_version) catch {};
         return error.Aborted;
     };
@@ -729,34 +741,56 @@ pub fn upgradeDbAtomic(
     formula: *const formula_mod.Formula,
     store_sha256: []const u8,
     new_cellar_path: []const u8,
+    bin_isolated: bool,
 ) !i64 {
     try linker.unlink(old_keg_id);
     // `in_transaction = true` so the upgrade wrapper's outer BEGIN/COMMIT
     // owns atomicity for unlink → record → link → delete; the unified
     // recordKeg never nests BEGIN IMMEDIATE here.
+    //
+    // `install_reason` stays whatever the prior row carried — upgrade
+    // never changes the keg's role, only its version. A dep that the
+    // user opted into isolation stays isolated; a direct keg keeps its
+    // bin links.
+    const prior_reason: []const u8 = blk: {
+        var stmt = db.prepare("SELECT install_reason FROM kegs WHERE id = ?1 LIMIT 1;") catch break :blk "direct";
+        defer stmt.finalize();
+        stmt.bindInt(1, old_keg_id) catch break :blk "direct";
+        const ok = stmt.step() catch false;
+        if (!ok) break :blk "direct";
+        if (stmt.columnText(0)) |t| {
+            const s = std.mem.sliceTo(t, 0);
+            if (std.mem.eql(u8, s, "dependency")) break :blk "dependency";
+        }
+        break :blk "direct";
+    };
     const new_keg_id = try install_record_mod.recordKeg(
         db,
         formula,
         store_sha256,
         new_cellar_path,
-        "direct",
+        prior_reason,
+        bin_isolated,
         .{ .in_transaction = true },
     );
-    try linker.link(new_cellar_path, formula.name, new_keg_id);
+    try linker.link(new_cellar_path, formula.name, new_keg_id, bin_isolated);
     install_record_mod.deleteKeg(db, old_keg_id);
     return new_keg_id;
 }
 
-/// Re-link old version during rollback.
+/// Re-link old version during rollback. Replays the old row's
+/// `bin_isolated` so a partially-rolled-back keg matches the user's
+/// prior intent.
 fn restoreOldLinks(
     _: *sqlite.Database,
     linker: *linker_mod.Linker,
     old_cellar_path: []const u8,
     name: []const u8,
     old_keg_id: i64,
+    bin_isolated: bool,
 ) void {
     if (old_cellar_path.len == 0) return;
-    linker.link(old_cellar_path, name, old_keg_id) catch {
+    linker.link(old_cellar_path, name, old_keg_id, bin_isolated) catch {
         output.err("CRITICAL: Failed to restore old symlinks for {s}. Manual intervention may be required.", .{name});
     };
 }
@@ -781,6 +815,7 @@ fn upgradeAllFormulas(
     dry_run: bool,
     force: bool,
     pinned_only: bool,
+    isolate_deps: bool,
 ) !void {
     const sql: [:0]const u8 = if (pinned_only)
         "SELECT name, version FROM kegs WHERE pinned = 1 ORDER BY name;"
@@ -819,7 +854,7 @@ fn upgradeAllFormulas(
     defer failed_names.deinit(allocator);
 
     for (names.items) |name| {
-        upgradeFormula(ctx, allocator, name, db, api, http, prefix, dry_run, force, pinned_only) catch {
+        upgradeFormula(ctx, allocator, name, db, api, http, prefix, dry_run, force, pinned_only, isolate_deps) catch {
             failed_count += 1;
             // failed_count is the authoritative counter; list is for UX only.
             failed_names.append(allocator, name) catch {};

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -42,6 +42,9 @@ const upgrade_flag_map = std.StaticStringMap(UpgradeFlag).initComptime(.{
     .{ "-f", .force },
     .{ "--pinned", .pinned },
     .{ "--isolate-deps", .isolate_deps },
+    // Long-form alias matching the `--only-dependencies` / `--only-deps`
+    // shape so the flag surface stays predictable.
+    .{ "--isolate-dependencies", .isolate_deps },
 });
 
 /// True when this name should be skipped due to a user pin. Pure gate so

--- a/src/core/linker.zig
+++ b/src/core/linker.zig
@@ -18,10 +18,14 @@ pub const Linker = struct {
         return .{ .allocator = allocator, .io = io, .db = db, .prefix = prefix };
     }
 
-    /// Check for symlink conflicts before linking.
-    /// Returns a slice of conflicts (files already linked to a different keg).
-    pub fn checkConflicts(self: *Linker, keg_path: []const u8) ![]Conflict {
-        const dirs_to_check = [_][]const u8{ "bin", "sbin", "lib", "include", "share", "etc" };
+    /// Check for symlink conflicts before linking. When `bin_isolated`
+    /// is true, the probe skips `bin`/`sbin` to mirror the link-side
+    /// policy — otherwise a dep installed under isolation would falsely
+    /// trigger a conflict against a keg whose bins were never linked.
+    pub fn checkConflicts(self: *Linker, keg_path: []const u8, bin_isolated: bool) ![]Conflict {
+        const dirs_full = [_][]const u8{ "bin", "sbin", "lib", "include", "share", "etc" };
+        const dirs_isolated = [_][]const u8{ "lib", "include", "share", "etc" };
+        const dirs_to_check: []const []const u8 = if (bin_isolated) &dirs_isolated else &dirs_full;
         var conflicts: std.ArrayList(Conflict) = .empty;
 
         for (dirs_to_check) |subdir| {
@@ -82,8 +86,14 @@ pub const Linker = struct {
     }
 
     /// Create symlinks for all files in a keg, recording in DB.
-    pub fn link(self: *Linker, keg_path: []const u8, name: []const u8, keg_id: i64) !void {
-        const dirs_to_link = [_][]const u8{ "bin", "sbin", "lib", "include", "share", "etc" };
+    /// When `bin_isolated` is true, the keg's `bin`/`sbin` contents are
+    /// deliberately left unlinked — `opt/<name>` and dependents'
+    /// `LC_LOAD_DYLIB` paths continue to resolve via `lib`, so compiled
+    /// formulae are unaffected; only the global PATH entries disappear.
+    pub fn link(self: *Linker, keg_path: []const u8, name: []const u8, keg_id: i64, bin_isolated: bool) !void {
+        const dirs_full = [_][]const u8{ "bin", "sbin", "lib", "include", "share", "etc" };
+        const dirs_isolated = [_][]const u8{ "lib", "include", "share", "etc" };
+        const dirs_to_link: []const []const u8 = if (bin_isolated) &dirs_isolated else &dirs_full;
 
         for (dirs_to_link) |subdir| {
             self.linkSubdir(keg_path, subdir, name, keg_id) catch continue;

--- a/src/db/schema.zig
+++ b/src/db/schema.zig
@@ -17,7 +17,8 @@ pub fn initSchema(db: *sqlite.Database) MigrateError!void {
         \\);
     );
 
-    // 2. kegs
+    // 2. kegs. `bin_isolated` is added by v10's ALTER on upgraded DBs;
+    //    the fresh shape ships with it so both paths converge.
     try db.exec(
         \\CREATE TABLE IF NOT EXISTS kegs (
         \\    id            INTEGER PRIMARY KEY,
@@ -31,6 +32,7 @@ pub fn initSchema(db: *sqlite.Database) MigrateError!void {
         \\    installed_at  TEXT NOT NULL DEFAULT (datetime('now')),
         \\    pinned        INTEGER NOT NULL DEFAULT 0,
         \\    install_reason TEXT NOT NULL DEFAULT 'direct',
+        \\    bin_isolated  INTEGER NOT NULL DEFAULT 0,
         \\    UNIQUE(name, version)
         \\);
     );
@@ -124,7 +126,7 @@ pub fn initSchema(db: *sqlite.Database) MigrateError!void {
 /// Highest schema version this binary knows how to operate on. Bump in
 /// lockstep with the last `migrateVNtoVN+1` step so a future binary's
 /// DB doesn't get silently used against older SQL.
-pub const known_schema_version: i64 = 9;
+pub const known_schema_version: i64 = 10;
 
 pub const MigrateError = sqlite.SqliteError || error{SchemaTooNew};
 
@@ -143,6 +145,7 @@ pub fn migrate(db: *sqlite.Database) MigrateError!void {
     if (ver < 7) try migrateV6toV7(db);
     if (ver < 8) try migrateV7toV8(db);
     if (ver < 9) try migrateV8toV9(db);
+    if (ver < 10) try migrateV9toV10(db);
 }
 
 fn migrateV1toV2(db: *sqlite.Database) sqlite.SqliteError!void {
@@ -526,6 +529,43 @@ fn migrateV8toV9(db: *sqlite.Database) sqlite.SqliteError!void {
     try db.commit();
 }
 
+/// v10 — record per-keg "this keg's bin/sbin are deliberately not
+/// linked into prefix" so the linker can skip them on install and
+/// replay the policy on upgrades without the user re-passing a flag.
+/// Default 0 keeps every pre-feature row behaving exactly like today.
+fn migrateV9toV10(db: *sqlite.Database) sqlite.SqliteError!void {
+    try db.beginTransaction();
+    errdefer db.rollback();
+
+    // PRAGMA table_info returns zero rows when the table is missing —
+    // same partial-shape fixture defensiveness as v7→v8 / v8→v9 so a
+    // forensic DB without a `kegs` table still bumps the marker rather
+    // than aborting the whole chain.
+    var have_table = false;
+    var have_column = false;
+    {
+        var stmt = try db.prepare("PRAGMA table_info(kegs);");
+        defer stmt.finalize();
+        while (try stmt.step()) {
+            have_table = true;
+            const name = stmt.columnText(1) orelse continue;
+            if (std.mem.eql(u8, std.mem.sliceTo(name, 0), "bin_isolated")) {
+                have_column = true;
+                break;
+            }
+        }
+    }
+    if (have_table and !have_column) {
+        try db.exec(
+            "ALTER TABLE kegs ADD COLUMN bin_isolated INTEGER NOT NULL DEFAULT 0;",
+        );
+    }
+
+    try db.exec("INSERT OR IGNORE INTO schema_version (version) VALUES (10);");
+
+    try db.commit();
+}
+
 /// Return true iff every column in `wanted` is present on the `casks`
 /// table. Mirrors the PRAGMA-guarded probes used by v2→v3 / v3→v4 /
 /// v5→v6; centralised here because the v6→v7 backfill needs five
@@ -719,7 +759,7 @@ test "v6→v7 migration backfills cask_versions from existing casks rows" {
     const token1 = stmt.columnText(0) orelse return error.TestUnexpectedResult;
     try testing.expectEqualStrings("flux-markdown", std.mem.sliceTo(token1, 0));
 
-    try testing.expectEqual(@as(i64, 9), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
 }
 
 test "v6→v7 migration is idempotent when cask_versions already carries the rows" {
@@ -768,7 +808,7 @@ test "fresh DB ships with taps.head_etag (v8 shape)" {
         }
     }
     try testing.expect(found);
-    try testing.expectEqual(@as(i64, 9), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
 }
 
 test "v7→v8 migration adds head_etag and preserves existing tap rows" {
@@ -799,7 +839,7 @@ test "v7→v8 migration adds head_etag and preserves existing tap rows" {
     );
     // Pre-v8 rows must carry NULL until a conditional GET populates it.
     try testing.expect(probe.columnText(1) == null);
-    try testing.expectEqual(@as(i64, 9), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
 }
 
 test "v7→v8 migration is idempotent when head_etag is already present" {
@@ -848,7 +888,7 @@ test "fresh DB ships with taps.github_owner and taps.github_repo (v9 shape)" {
     }
     try testing.expect(owner_seen);
     try testing.expect(repo_seen);
-    try testing.expectEqual(@as(i64, 9), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
 }
 
 test "v8→v9 migration backfills (user, \"homebrew-\" || repo) from existing slugs" {
@@ -868,7 +908,7 @@ test "v8→v9 migration backfills (user, \"homebrew-\" || repo) from existing sl
 
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 9), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
 
     var probe = try db.prepare(
         "SELECT name, github_owner, github_repo FROM taps ORDER BY name;",
@@ -930,7 +970,7 @@ test "v8→v9 migration bumps the marker even when taps is empty" {
     try db.exec("DELETE FROM schema_version WHERE version >= 9;");
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 9), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
 }
 
 // Pre-v3 rows could in theory have escaped slug validation. The CASE
@@ -957,7 +997,7 @@ test "v8→v9 migration tolerates a slug starting with a slash (degenerate fixtu
 
     // We don't pin the specific (owner, repo) values for degenerate
     // input — only that the migration completes and the marker bumps.
-    try testing.expectEqual(@as(i64, 9), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
 }
 
 test "v8→v9 migration falls back to verbatim name on a slug missing the slash" {
@@ -979,6 +1019,87 @@ test "v8→v9 migration falls back to verbatim name on a slug missing the slash"
     try testing.expect(try probe.step());
     try testing.expectEqualStrings("legacy", std.mem.sliceTo(probe.columnText(0) orelse "", 0));
     try testing.expectEqualStrings("legacy", std.mem.sliceTo(probe.columnText(1) orelse "", 0));
+}
+
+// v9→v10 adds kegs.bin_isolated so the install pipeline can record
+// "this dep's bin/sbin are deliberately not symlinked into prefix/bin"
+// per-keg. Default 0 keeps every pre-feature install behaving exactly
+// like today.
+
+test "fresh DB ships with kegs.bin_isolated (v10 shape)" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    var stmt = try db.prepare("PRAGMA table_info(kegs);");
+    defer stmt.finalize();
+    var found = false;
+    while (try stmt.step()) {
+        const name = stmt.columnText(1) orelse continue;
+        if (std.mem.eql(u8, std.mem.sliceTo(name, 0), "bin_isolated")) {
+            found = true;
+            break;
+        }
+    }
+    try testing.expect(found);
+    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
+}
+
+test "v9→v10 migration adds bin_isolated and defaults existing rows to 0" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    // Seed kegs on the current shape and rewind the marker so the
+    // migration step runs over rows that pre-date the column.
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, install_reason)
+        \\VALUES ('foo', 'foo', '1.0', 'sha-foo', '/c/foo/1.0', 'direct'),
+        \\       ('bar', 'bar', '2.0', 'sha-bar', '/c/bar/2.0', 'dependency');
+    );
+    try db.exec("DELETE FROM schema_version WHERE version >= 10;");
+
+    try migrate(&db);
+
+    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
+
+    var probe = try db.prepare("SELECT name, bin_isolated FROM kegs ORDER BY name;");
+    defer probe.finalize();
+    try testing.expect(try probe.step());
+    try testing.expectEqualStrings(
+        "bar",
+        std.mem.sliceTo(probe.columnText(0) orelse "", 0),
+    );
+    try testing.expectEqual(@as(i64, 0), probe.columnInt(1));
+    try testing.expect(try probe.step());
+    try testing.expectEqualStrings(
+        "foo",
+        std.mem.sliceTo(probe.columnText(0) orelse "", 0),
+    );
+    try testing.expectEqual(@as(i64, 0), probe.columnInt(1));
+}
+
+test "v9→v10 migration is idempotent and preserves bin_isolated=1" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    // Seed a keg whose bin_isolated is already true, rewind the marker,
+    // and re-run migrate twice. The PRAGMA guard must skip the ALTER
+    // and the row must keep its explicit value.
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, install_reason, bin_isolated)
+        \\VALUES ('foo', 'foo', '1.0', 'sha-foo', '/c/foo/1.0', 'dependency', 1);
+    );
+    try db.exec("DELETE FROM schema_version WHERE version >= 10;");
+    try migrate(&db);
+    try db.exec("DELETE FROM schema_version WHERE version >= 10;");
+    try migrate(&db);
+
+    var probe = try db.prepare("SELECT bin_isolated FROM kegs WHERE name='foo';");
+    defer probe.finalize();
+    try testing.expect(try probe.step());
+    try testing.expectEqual(@as(i64, 1), probe.columnInt(0));
 }
 
 test "migrate refuses a DB whose schema_version exceeds the known max" {

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -1148,7 +1148,7 @@ test "v6→v7 migration leaves cask_versions empty when casks has a broken shape
     _ = try stmt.step();
     try testing.expectEqual(@as(i64, 0), stmt.columnInt(0));
     // Migration still bumps the schema marker so a future run skips this path.
-    try testing.expectEqual(@as(i64, 9), try schema.currentVersion(&db));
+    try testing.expectEqual(@as(i64, 10), try schema.currentVersion(&db));
 }
 
 // v7→v8 / v8→v9 ALTERs must skip when `taps` is missing entirely
@@ -1169,7 +1169,7 @@ test "v7→v8 migration tolerates a missing taps table" {
 
     try schema.migrate(&db);
 
-    try testing.expectEqual(@as(i64, 9), try schema.currentVersion(&db));
+    try testing.expectEqual(@as(i64, 10), try schema.currentVersion(&db));
 }
 
 // --- coverage: lookupCaskVersion refuses a malformed row ----------------

--- a/tests/db_schema_v2_test.zig
+++ b/tests/db_schema_v2_test.zig
@@ -54,7 +54,7 @@ test "initSchema runs v1 then migrates to the current known version" {
     try testing.expect(try tableExists(&tdb.db, "bundle_members"));
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 9), ver);
+    try testing.expectEqual(@as(i64, 10), ver);
 }
 
 test "migrate is idempotent on re-run" {
@@ -66,7 +66,7 @@ test "migrate is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 9), ver);
+    try testing.expectEqual(@as(i64, 10), ver);
 }
 
 test "v4 migration adds pinned column to casks" {
@@ -96,7 +96,7 @@ test "v4 migration is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 9), ver);
+    try testing.expectEqual(@as(i64, 10), ver);
 }
 
 test "v6 migration adds tap column to casks" {

--- a/tests/doctor_isolation_test.zig
+++ b/tests/doctor_isolation_test.zig
@@ -1,0 +1,136 @@
+//! `mt doctor` dependency bin/sbin-leak enumeration tests.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const test_io = @import("test_io");
+
+const doctor = malt.doctor;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+
+fn uniquePrefix(suffix: []const u8) ![]u8 {
+    return std.fmt.allocPrint(
+        testing.allocator,
+        "/tmp/malt_doctor_iso_{d}_{s}",
+        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
+    );
+}
+
+// Seed: direct keg with bin links, isolated dep with no bin links, and
+// a pre-feature dep keg with bin_isolated=0 + a bin link in `links`
+// (the offender). The check must flag only the offender.
+fn seedFixture(prefix: []const u8) !void {
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{prefix});
+    defer testing.allocator.free(db_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, db_dir);
+
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, install_reason, bin_isolated)
+        \\VALUES
+        \\  ('direct_keg', 'direct_keg', '1.0', 'sha-d', '/c/direct_keg/1.0', 'direct',     0),
+        \\  ('isolated',   'isolated',   '1.0', 'sha-i', '/c/isolated/1.0',   'dependency', 1),
+        \\  ('leaker',     'leaker',     '1.0', 'sha-l', '/c/leaker/1.0',     'dependency', 0);
+    );
+
+    // direct_keg has bin link (expected, not flagged).
+    try db.exec(
+        \\INSERT INTO links (keg_id, link_path, target) VALUES
+        \\  ((SELECT id FROM kegs WHERE name='direct_keg'),
+        \\   '/p/bin/direct_keg', '/c/direct_keg/1.0/bin/direct_keg'),
+        \\  ((SELECT id FROM kegs WHERE name='leaker'),
+        \\   '/p/bin/leaker', '/c/leaker/1.0/bin/leaker');
+    );
+}
+
+test "doctor isolation check flags only dep kegs with bin/sbin links and bin_isolated=0" {
+    const prefix = try uniquePrefix("leaker");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try seedFixture(prefix);
+
+    const ctx: doctor.CheckCtx = .{
+        .allocator = testing.allocator,
+        .prefix = prefix,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+        .mirrors = .{},
+        .offline = false,
+    };
+
+    // Run the check directly so we don't depend on doctor's stdout-printing.
+    const result = checkResult(ctx);
+    try testing.expectEqual(doctor.CheckResult.warn_status, result);
+}
+
+// Clean prefix: no dep kegs leak. Check returns ok.
+test "doctor isolation check returns ok when no dep keg leaks bin/sbin" {
+    const prefix = try uniquePrefix("clean");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{prefix});
+    defer testing.allocator.free(db_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, db_dir);
+
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, install_reason, bin_isolated)
+        \\VALUES
+        \\  ('direct_keg', 'direct_keg', '1.0', 'sha-d', '/c/direct_keg/1.0', 'direct',     0),
+        \\  ('isolated',   'isolated',   '1.0', 'sha-i', '/c/isolated/1.0',   'dependency', 1);
+    );
+    try db.exec(
+        \\INSERT INTO links (keg_id, link_path, target) VALUES
+        \\  ((SELECT id FROM kegs WHERE name='direct_keg'),
+        \\   '/p/bin/direct_keg', '/c/direct_keg/1.0/bin/direct_keg');
+    );
+
+    const ctx: doctor.CheckCtx = .{
+        .allocator = testing.allocator,
+        .prefix = prefix,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+        .mirrors = .{},
+        .offline = false,
+    };
+
+    const result = checkResult(ctx);
+    try testing.expectEqual(doctor.CheckResult.ok, result);
+}
+
+// The check table must include the new entry — guards against
+// silently dropping it from the registered walk.
+test "checks table includes the dependency bin/sbin leak check" {
+    var found = false;
+    for (doctor.checks) |c| {
+        if (std.mem.eql(u8, c.name, "Dependency bin/sbin leaks")) {
+            found = true;
+            break;
+        }
+    }
+    try testing.expect(found);
+}
+
+// Find the registered check function by name and invoke it.
+fn checkResult(ctx: doctor.CheckCtx) doctor.CheckResult {
+    for (doctor.checks) |c| {
+        if (std.mem.eql(u8, c.name, "Dependency bin/sbin leaks")) {
+            return c.run(ctx, c.name);
+        }
+    }
+    @panic("isolation check not registered");
+}

--- a/tests/doctor_isolation_test.zig
+++ b/tests/doctor_isolation_test.zig
@@ -8,6 +8,7 @@ const test_io = @import("test_io");
 const doctor = malt.doctor;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
+const output = malt.output;
 
 fn uniquePrefix(suffix: []const u8) ![]u8 {
     return std.fmt.allocPrint(
@@ -50,7 +51,12 @@ fn seedFixture(prefix: []const u8) !void {
     );
 }
 
-test "doctor isolation check flags only dep kegs with bin/sbin links and bin_isolated=0" {
+test "doctor isolation check stays informational even when dep kegs link bin/sbin" {
+    // Per the task contract: linked deps are the default state, not a
+    // defect — `mt doctor` must exit clean so first-time users aren't
+    // moralised at every run. The check surfaces the count via its
+    // detail line (verified by the SQL — there *are* offenders in the
+    // fixture) but the tally tag stays `.ok` so doctor exits 0.
     const prefix = try uniquePrefix("leaker");
     defer testing.allocator.free(prefix);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
@@ -65,9 +71,8 @@ test "doctor isolation check flags only dep kegs with bin/sbin links and bin_iso
         .offline = false,
     };
 
-    // Run the check directly so we don't depend on doctor's stdout-printing.
     const result = checkResult(ctx);
-    try testing.expectEqual(doctor.CheckResult.warn_status, result);
+    try testing.expectEqual(doctor.CheckResult.ok, result);
 }
 
 // Clean prefix: no dep kegs leak. Check returns ok.
@@ -112,12 +117,39 @@ test "doctor isolation check returns ok when no dep keg leaks bin/sbin" {
     try testing.expectEqual(doctor.CheckResult.ok, result);
 }
 
+// Verbose mode must keep the check informational too — the
+// enumeration is just bonus detail, never an exit-code bump.
+test "doctor isolation check is .ok under --verbose with offenders" {
+    const prior_verbose = output.isVerbose();
+    output.setVerbose(true);
+    defer output.setVerbose(prior_verbose);
+    output.setQuiet(true); // silence the writeVerboseList stderr noise during testing
+    defer output.setQuiet(false);
+
+    const prefix = try uniquePrefix("verbose_leaker");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try seedFixture(prefix);
+
+    const ctx: doctor.CheckCtx = .{
+        .allocator = testing.allocator,
+        .prefix = prefix,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+        .mirrors = .{},
+        .offline = false,
+    };
+
+    const result = checkResult(ctx);
+    try testing.expectEqual(doctor.CheckResult.ok, result);
+}
+
 // The check table must include the new entry — guards against
 // silently dropping it from the registered walk.
 test "checks table includes the dependency bin/sbin leak check" {
     var found = false;
     for (doctor.checks) |c| {
-        if (std.mem.eql(u8, c.name, "Dependency bin/sbin leaks")) {
+        if (std.mem.eql(u8, c.name, "Dependency bin/sbin link census")) {
             found = true;
             break;
         }
@@ -128,7 +160,7 @@ test "checks table includes the dependency bin/sbin leak check" {
 // Find the registered check function by name and invoke it.
 fn checkResult(ctx: doctor.CheckCtx) doctor.CheckResult {
     for (doctor.checks) |c| {
-        if (std.mem.eql(u8, c.name, "Dependency bin/sbin leaks")) {
+        if (std.mem.eql(u8, c.name, "Dependency bin/sbin link census")) {
             return c.run(ctx, c.name);
         }
     }

--- a/tests/help_test.zig
+++ b/tests/help_test.zig
@@ -102,6 +102,22 @@ test "deps help documents --recursive, --installed, and --json" {
     try testing.expect(std.mem.indexOf(u8, text, "--json") != null);
 }
 
+test "install/upgrade/reinstall help documents --isolate-deps" {
+    // Discoverability guard for the dep-bin isolation feature: a user
+    // can't opt into a flag they can't find in --help. The contract
+    // must be visible on every install-flavoured verb.
+    inline for (&[_][]const u8{ "install", "upgrade", "reinstall" }) |verb| {
+        const text = help.helpFor(verb);
+        try testing.expect(std.mem.indexOf(u8, text, "--isolate-deps") != null);
+    }
+}
+
+test "link help documents --isolate and --all" {
+    const text = help.helpFor("link");
+    try testing.expect(std.mem.indexOf(u8, text, "--isolate") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "--all") != null);
+}
+
 test "helpFor falls back gracefully for unknown commands" {
     try testing.expectEqualStrings("No help available.\n", help.helpFor("not-a-real-command"));
 }

--- a/tests/install_execute_test.zig
+++ b/tests/install_execute_test.zig
@@ -463,10 +463,12 @@ test "execute --only-dependencies on a leaf formula plans nothing" {
     try testing.expect(std.mem.indexOf(u8, captured.items, "Dry run: would install") == null);
 }
 
-test "execute --only-dependencies --dry-run plans deps but skips the requested formula" {
-    // Brew parity: --only-dependencies installs the transitive deps but
-    // never materialises or links the requested package. Captured stderr
-    // is the cheapest way to assert the plan's contents from the outside.
+test "execute --only-deps --dry-run plans deps but skips the requested formula" {
+    // Brew parity: --only-deps installs the transitive deps but never
+    // materialises or links the requested package. Captured stderr is
+    // the cheapest way to assert the plan's contents from the outside.
+    // The earlier `--only-dependencies` test pins the brew-parity alias;
+    // this one pins the canonical short spelling.
     const prefix_z: [:0]const u8 = "/tmp/mod";
     test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
@@ -527,7 +529,7 @@ test "execute --only-dependencies --dry-run plans deps but skips the requested f
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
-    try install.execute(&ctx, arena.allocator(), &.{ "--dry-run", "--only-dependencies", "alpha" });
+    try install.execute(&ctx, arena.allocator(), &.{ "--dry-run", "--only-deps", "alpha" });
 
     // The dry-run plan header is the load-bearing observation: with the
     // top-level filtered, only the single dep should land in the plan.

--- a/tests/install_isolation_test.zig
+++ b/tests/install_isolation_test.zig
@@ -364,6 +364,29 @@ test "isolate_deps is a no-op on direct kegs (named pkg stays linked)" {
     try testing.expectEqual(@as(i64, 0), probe.columnInt(0));
 }
 
+// Long-form spelling is an accepted alias of the canonical flag.
+// Pinning the alias keeps a future flag-map cleanup from silently
+// dropping the form some users will reach for first.
+test "execute accepts --isolate-dependencies as an alias of --isolate-deps" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const result = malt.install.execute(
+        &malt.app_ctx.debug_ctx,
+        arena.allocator(),
+        &.{ "--dry-run", "--isolate-dependencies", "--quiet", "zz_nonexistent_formula_xyz" },
+    );
+    if (result) |_| {} else |e| switch (e) {
+        error.PartialFailure,
+        error.FormulaNotFound,
+        error.NetworkError,
+        error.RateLimited,
+        error.DownloadFailed,
+        => {},
+        else => return e,
+    }
+}
+
 // Flag-acceptance smoke: `mt install --isolate-deps --dry-run <pkg>`
 // must not error on flag parsing. Verifies argv plumbing exists.
 test "execute accepts --isolate-deps without erroring during dry-run" {

--- a/tests/install_isolation_test.zig
+++ b/tests/install_isolation_test.zig
@@ -1,0 +1,338 @@
+//! Integration tests for the `--isolate-deps` install policy:
+//! flag plumbing, schema replay across upgrade/reinstall, promotion
+//! semantics, and the "direct kegs are never isolated" invariant.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const test_io = @import("test_io");
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+const install_record = malt.install_record;
+const linker_mod = malt.linker;
+const formula_mod = malt.formula;
+
+const fake_formula_json =
+    \\{
+    \\  "name": "depkeg",
+    \\  "full_name": "depkeg",
+    \\  "tap": "homebrew/core",
+    \\  "desc": "",
+    \\  "homepage": "",
+    \\  "versions": {"stable": "1.0"},
+    \\  "revision": 0,
+    \\  "dependencies": [],
+    \\  "keg_only": false,
+    \\  "post_install_defined": false,
+    \\  "oldnames": [],
+    \\  "bottle": {"stable": {"files": {}}}
+    \\}
+;
+
+fn uniquePrefix(suffix: []const u8) ![]u8 {
+    return std.fmt.allocPrint(
+        testing.allocator,
+        "/tmp/malt_install_iso_{d}_{s}",
+        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
+    );
+}
+
+fn makeKegWithBin(prefix: []const u8, name: []const u8, version: []const u8) ![]u8 {
+    const keg = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/Cellar/{s}/{s}",
+        .{ prefix, name, version },
+    );
+    try test_io.cwd().createDirPath(std.Options.debug_io, keg);
+
+    const bin_dir = try std.fmt.allocPrint(testing.allocator, "{s}/bin", .{keg});
+    defer testing.allocator.free(bin_dir);
+    try test_io.makeDirAbsolute(std.Options.debug_io, bin_dir);
+
+    const bin_path = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ bin_dir, name });
+    defer testing.allocator.free(bin_path);
+    const f = try test_io.createFileAbsolute(std.Options.debug_io, bin_path, .{});
+    try f.writeStreamingAll(std.Options.debug_io, "#!/bin/sh\necho hi\n");
+    f.close(std.Options.debug_io);
+
+    return keg;
+}
+
+fn pathExists(absolute: []const u8) bool {
+    var f = test_io.openFileAbsolute(std.Options.debug_io, absolute, .{}) catch return false;
+    f.close(std.Options.debug_io);
+    return true;
+}
+
+// What the install pipeline does for a dep keg installed under
+// `--isolate-deps`: recordKeg writes bin_isolated=1, the linker skips
+// bin/sbin. This integration covers the wiring contract the flag must
+// guarantee end-to-end — even before the full `mt install` plumbing
+// lands, the primitives must compose correctly.
+test "isolated dep install: bin_isolated=1, no bin symlink, opt link still present via Linker.linkOpt" {
+    const prefix = try uniquePrefix("isolated_dep");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+    const keg = try makeKegWithBin(prefix, "depkeg", "1.0");
+    defer testing.allocator.free(keg);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var f = try formula_mod.parseFormula(arena.allocator(), fake_formula_json);
+    defer f.deinit();
+
+    const keg_id = try install_record.recordKeg(
+        &db,
+        &f,
+        "0" ** 64,
+        keg,
+        "dependency",
+        true,
+        .{},
+    );
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg, "depkeg", keg_id, true);
+    try linker.linkOpt("depkeg", "1.0");
+
+    // No bin/sbin link in prefix.
+    var bin_buf: [512]u8 = undefined;
+    const bin_link = try std.fmt.bufPrint(&bin_buf, "{s}/bin/depkeg", .{prefix});
+    try testing.expect(!pathExists(bin_link));
+
+    // opt/depkeg is anchored — Mach-O dependents still resolve.
+    var opt_buf: [512]u8 = undefined;
+    const opt_link = try std.fmt.bufPrint(&opt_buf, "{s}/opt/depkeg", .{prefix});
+    var t_buf: [std.fs.max_path_bytes]u8 = undefined;
+    _ = try test_io.readLinkAbsolute(std.Options.debug_io, opt_link, &t_buf);
+
+    var probe = try db.prepare("SELECT install_reason, bin_isolated FROM kegs WHERE id = ?1;");
+    defer probe.finalize();
+    try probe.bindInt(1, keg_id);
+    _ = try probe.step();
+    try testing.expectEqualStrings(
+        "dependency",
+        std.mem.sliceTo(probe.columnText(0) orelse "", 0),
+    );
+    try testing.expectEqual(@as(i64, 1), probe.columnInt(1));
+}
+
+// The direct half of the same install pass: --isolate-deps must
+// never isolate the package the user actually named, even if the
+// flag was passed. install_reason='direct' shields it.
+test "direct keg under --isolate-deps still links bins and stays bin_isolated=0" {
+    const prefix = try uniquePrefix("direct_under_iso");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+    const keg = try makeKegWithBin(prefix, "depkeg", "1.0");
+    defer testing.allocator.free(keg);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var f = try formula_mod.parseFormula(arena.allocator(), fake_formula_json);
+    defer f.deinit();
+
+    // Caller computed: bin_isolated = flag and is_dep → false here.
+    const keg_id = try install_record.recordKeg(
+        &db,
+        &f,
+        "0" ** 64,
+        keg,
+        "direct",
+        false,
+        .{},
+    );
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg, "depkeg", keg_id, false);
+
+    var bin_buf: [512]u8 = undefined;
+    const bin_link = try std.fmt.bufPrint(&bin_buf, "{s}/bin/depkeg", .{prefix});
+    try testing.expect(pathExists(bin_link));
+
+    var probe = try db.prepare("SELECT install_reason, bin_isolated FROM kegs WHERE id = ?1;");
+    defer probe.finalize();
+    try probe.bindInt(1, keg_id);
+    _ = try probe.step();
+    try testing.expectEqualStrings(
+        "direct",
+        std.mem.sliceTo(probe.columnText(0) orelse "", 0),
+    );
+    try testing.expectEqual(@as(i64, 0), probe.columnInt(1));
+}
+
+// Replay invariant: a keg recorded with `bin_isolated=1` keeps that
+// flag through an `upgradeDbAtomic` round-trip. The caller is the
+// upgrade pipeline, which SELECTs the prior row's value and feeds it
+// back in — no user re-flagging required.
+test "upgradeDbAtomic preserves bin_isolated across an upgrade" {
+    const prefix = try uniquePrefix("upgrade_replay");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+    const old_keg = try makeKegWithBin(prefix, "depkeg", "1.0");
+    defer testing.allocator.free(old_keg);
+    const new_keg = try makeKegWithBin(prefix, "depkeg", "2.0");
+    defer testing.allocator.free(new_keg);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var f_old = try formula_mod.parseFormula(arena.allocator(), fake_formula_json);
+    defer f_old.deinit();
+    const old_id = try install_record.recordKeg(
+        &db,
+        &f_old,
+        "0" ** 64,
+        old_keg,
+        "dependency",
+        true,
+        .{},
+    );
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(old_keg, "depkeg", old_id, true);
+
+    // Simulate upgradeDbAtomic: read replay, unlink, recordKeg with
+    // bumped version, link with replayed bin_isolated.
+    var sel = try db.prepare("SELECT bin_isolated FROM kegs WHERE id = ?1;");
+    defer sel.finalize();
+    try sel.bindInt(1, old_id);
+    _ = try sel.step();
+    const replay = sel.columnInt(0) != 0;
+
+    try linker.unlink(old_id);
+
+    const new_formula_json =
+        \\{"name": "depkeg", "full_name": "depkeg", "tap": "homebrew/core",
+        \\ "desc": "", "homepage": "", "versions": {"stable": "2.0"},
+        \\ "revision": 0, "dependencies": [], "keg_only": false,
+        \\ "post_install_defined": false, "oldnames": [],
+        \\ "bottle": {"stable": {"files": {}}}}
+    ;
+    var f_new = try formula_mod.parseFormula(arena.allocator(), new_formula_json);
+    defer f_new.deinit();
+    const new_id = try install_record.recordKeg(
+        &db,
+        &f_new,
+        "1" ** 64,
+        new_keg,
+        "dependency",
+        replay,
+        .{},
+    );
+    try linker.link(new_keg, "depkeg", new_id, replay);
+
+    var probe = try db.prepare("SELECT bin_isolated, install_reason FROM kegs WHERE id = ?1;");
+    defer probe.finalize();
+    try probe.bindInt(1, new_id);
+    _ = try probe.step();
+    try testing.expectEqual(@as(i64, 1), probe.columnInt(0));
+    try testing.expectEqualStrings(
+        "dependency",
+        std.mem.sliceTo(probe.columnText(1) orelse "", 0),
+    );
+
+    var bin_buf: [512]u8 = undefined;
+    const bin_link = try std.fmt.bufPrint(&bin_buf, "{s}/bin/depkeg", .{prefix});
+    try testing.expect(!pathExists(bin_link));
+}
+
+// Promotion contract: a dep keg recorded with bin_isolated=1 must
+// end up direct with bins linked after the user runs `mt install
+// <dep>`. The integration here exercises the same UPDATE + Linker.link
+// sequence the install pipeline triggers in its pre-resolution sweep.
+test "promotion: isolated dep becomes direct with bin link on user install" {
+    const prefix = try uniquePrefix("promote");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+    const keg = try makeKegWithBin(prefix, "depkeg", "1.0");
+    defer testing.allocator.free(keg);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var f = try formula_mod.parseFormula(arena.allocator(), fake_formula_json);
+    defer f.deinit();
+    const keg_id = try install_record.recordKeg(
+        &db,
+        &f,
+        "0" ** 64,
+        keg,
+        "dependency",
+        true,
+        .{},
+    );
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg, "depkeg", keg_id, true);
+
+    // Bins absent under isolation.
+    var bin_buf: [512]u8 = undefined;
+    const bin_link = try std.fmt.bufPrint(&bin_buf, "{s}/bin/depkeg", .{prefix});
+    try testing.expect(!pathExists(bin_link));
+
+    // Simulate the promotion the install command performs.
+    try db.exec("UPDATE kegs SET install_reason='direct', bin_isolated=0 WHERE name='depkeg';");
+    try linker.link(keg, "depkeg", keg_id, false);
+
+    try testing.expect(pathExists(bin_link));
+
+    var probe = try db.prepare("SELECT install_reason, bin_isolated FROM kegs WHERE id = ?1;");
+    defer probe.finalize();
+    try probe.bindInt(1, keg_id);
+    _ = try probe.step();
+    try testing.expectEqualStrings(
+        "direct",
+        std.mem.sliceTo(probe.columnText(0) orelse "", 0),
+    );
+    try testing.expectEqual(@as(i64, 0), probe.columnInt(1));
+}
+
+// Flag-acceptance smoke: `mt install --isolate-deps --dry-run <pkg>`
+// must not error on flag parsing. Verifies argv plumbing exists.
+test "execute accepts --isolate-deps without erroring during dry-run" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    // --dry-run + a guaranteed-404 name routes through PartialFailure,
+    // but the parser must reach that point — never reject --isolate-deps
+    // as an unknown flag.
+    const result = malt.install.execute(
+        &malt.app_ctx.debug_ctx,
+        arena.allocator(),
+        &.{ "--dry-run", "--isolate-deps", "--quiet", "zz_nonexistent_formula_xyz" },
+    );
+    // Any of PartialFailure / FormulaNotFound / NetworkError is fine —
+    // they mean parsing got past the flag stage.
+    if (result) |_| {} else |e| switch (e) {
+        error.PartialFailure,
+        error.FormulaNotFound,
+        error.NetworkError,
+        error.RateLimited,
+        error.DownloadFailed,
+        => {},
+        else => return e,
+    }
+}

--- a/tests/install_isolation_test.zig
+++ b/tests/install_isolation_test.zig
@@ -12,6 +12,11 @@ const install_record = malt.install_record;
 const linker_mod = malt.linker;
 const formula_mod = malt.formula;
 
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
 const fake_formula_json =
     \\{
     \\  "name": "depkeg",
@@ -368,41 +373,43 @@ test "isolate_deps is a no-op on direct kegs (named pkg stays linked)" {
 // Pinning the alias keeps a future flag-map cleanup from silently
 // dropping the form some users will reach for first.
 test "execute accepts --isolate-dependencies as an alias of --isolate-deps" {
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-
-    const result = malt.install.execute(
-        &malt.app_ctx.debug_ctx,
-        arena.allocator(),
-        &.{ "--dry-run", "--isolate-dependencies", "--quiet", "zz_nonexistent_formula_xyz" },
-    );
-    if (result) |_| {} else |e| switch (e) {
-        error.PartialFailure,
-        error.FormulaNotFound,
-        error.NetworkError,
-        error.RateLimited,
-        error.DownloadFailed,
-        => {},
-        else => return e,
-    }
+    try runFlagAcceptanceProbe("iso_alias", "--isolate-dependencies");
 }
 
 // Flag-acceptance smoke: `mt install --isolate-deps --dry-run <pkg>`
 // must not error on flag parsing. Verifies argv plumbing exists.
 test "execute accepts --isolate-deps without erroring during dry-run" {
+    try runFlagAcceptanceProbe("iso_canonical", "--isolate-deps");
+}
+
+// Shared helper: drive `install.execute` against a scratch
+// MALT_PREFIX so `ensureDirs` doesn't trip on `/opt/malt` being
+// unwritable (CI). Any of the downstream "no such formula" errors
+// counts as proof the parser reached past the flag stage; raising
+// any other error means the flag was rejected.
+fn runFlagAcceptanceProbe(suffix: []const u8, flag: []const u8) !void {
+    const prefix = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "/tmp/malt_iso_probe_{d}_{s}",
+        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
+        0,
+    );
+    defer testing.allocator.free(prefix);
+    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    _ = c.setenv("MALT_PREFIX", prefix.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
 
-    // --dry-run + a guaranteed-404 name routes through PartialFailure,
-    // but the parser must reach that point — never reject --isolate-deps
-    // as an unknown flag.
     const result = malt.install.execute(
         &malt.app_ctx.debug_ctx,
         arena.allocator(),
-        &.{ "--dry-run", "--isolate-deps", "--quiet", "zz_nonexistent_formula_xyz" },
+        &.{ "--dry-run", flag, "--quiet", "zz_nonexistent_formula_xyz" },
     );
-    // Any of PartialFailure / FormulaNotFound / NetworkError is fine —
-    // they mean parsing got past the flag stage.
     if (result) |_| {} else |e| switch (e) {
         error.PartialFailure,
         error.FormulaNotFound,

--- a/tests/install_isolation_test.zig
+++ b/tests/install_isolation_test.zig
@@ -310,6 +310,60 @@ test "promotion: isolated dep becomes direct with bin link on user install" {
     try testing.expectEqual(@as(i64, 0), probe.columnInt(1));
 }
 
+// Invariant: a direct keg installed during the same pass as a flag-
+// enabled run must NOT pick up isolation. The computation lives in
+// linkAndRecord as `bin_isolated = isolate_deps and job.is_dep`, but
+// the user-visible promise is "the name I typed always lands in PATH".
+test "isolate_deps is a no-op on direct kegs (named pkg stays linked)" {
+    const prefix = try uniquePrefix("direct_noop");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+    const keg = try makeKegWithBin(prefix, "depkeg", "1.0");
+    defer testing.allocator.free(keg);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var f = try formula_mod.parseFormula(arena.allocator(), fake_formula_json);
+    defer f.deinit();
+
+    // What the install pipeline computes for a direct keg even when
+    // the user passed --isolate-deps: bin_isolated = flag(true) and
+    // is_dep(false) = false. Mirror that exact call here.
+    const isolate_deps_flag = true;
+    const job_is_dep = false;
+    const computed_bin_isolated = isolate_deps_flag and job_is_dep;
+    try testing.expect(!computed_bin_isolated);
+
+    const keg_id = try install_record.recordKeg(
+        &db,
+        &f,
+        "0" ** 64,
+        keg,
+        "direct",
+        computed_bin_isolated,
+        .{},
+    );
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg, "depkeg", keg_id, computed_bin_isolated);
+
+    var bin_buf: [512]u8 = undefined;
+    const bin_link = try std.fmt.bufPrint(&bin_buf, "{s}/bin/depkeg", .{prefix});
+    try testing.expect(pathExists(bin_link));
+
+    var probe = try db.prepare("SELECT bin_isolated FROM kegs WHERE id = ?1;");
+    defer probe.finalize();
+    try probe.bindInt(1, keg_id);
+    _ = try probe.step();
+    try testing.expectEqual(@as(i64, 0), probe.columnInt(0));
+}
+
 // Flag-acceptance smoke: `mt install --isolate-deps --dry-run <pkg>`
 // must not error on flag parsing. Verifies argv plumbing exists.
 test "execute accepts --isolate-deps without erroring during dry-run" {

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -719,7 +719,7 @@ test "isInstalled is false before recordKeg, true after" {
 
     var f = try parseFake(arena.allocator());
     defer f.deinit();
-    const keg_id = try install_record.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", .{});
+    const keg_id = try install_record.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", false, .{});
     try testing.expect(keg_id > 0);
     try testing.expect(install_record.isInstalled(&db, "foo"));
 }
@@ -787,7 +787,7 @@ test "install_record.recordKeg preserves a prior pinned flag on REPLACE (force-r
 
     var f = try parseFake(arena.allocator());
     defer f.deinit();
-    const keg_id = try install_record.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", .{});
+    const keg_id = try install_record.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", false, .{});
 
     var stmt = try db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;");
     defer stmt.finalize();
@@ -805,7 +805,7 @@ test "install_record.recordKeg defaults pinned=0 when no prior keg of that name 
 
     var f = try parseFake(arena.allocator());
     defer f.deinit();
-    const keg_id = try install_record.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", .{});
+    const keg_id = try install_record.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", false, .{});
 
     var stmt = try db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;");
     defer stmt.finalize();
@@ -835,6 +835,7 @@ test "install_record.recordKeg with inherit_pin=false clears the prior pin (opt-
         "0" ** 64,
         "/opt/malt/Cellar/foo/1.0",
         "direct",
+        false,
         .{ .inherit_pin = false },
     );
 
@@ -863,6 +864,7 @@ test "install_record.recordKeg with .{ .in_transaction = false } opens its own B
         "0" ** 64,
         "/opt/malt/Cellar/foo/1.0",
         "direct",
+        false,
         .{ .in_transaction = false },
     );
 
@@ -894,6 +896,7 @@ test "install_record.recordKeg with .{ .in_transaction = true } inside an outer 
         "0" ** 64,
         "/opt/malt/Cellar/foo/1.0",
         "direct",
+        false,
         .{ .in_transaction = true },
     );
     try db.commit();
@@ -903,6 +906,61 @@ test "install_record.recordKeg with .{ .in_transaction = true } inside an outer 
     try stmt.bindInt(1, keg_id);
     _ = try stmt.step();
     try testing.expectEqualStrings("foo", std.mem.sliceTo(stmt.columnText(0).?, 0));
+}
+
+// `bin_isolated` is the user's intent flag — it must round-trip
+// through the INSERT so a subsequent upgrade can replay the policy
+// without the caller re-passing it.
+test "install_record.recordKeg writes bin_isolated=1 when the caller passes true" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var f = try parseFake(arena.allocator());
+    defer f.deinit();
+    const keg_id = try install_record.recordKeg(
+        &db,
+        &f,
+        "0" ** 64,
+        "/opt/malt/Cellar/foo/1.0",
+        "dependency",
+        true,
+        .{},
+    );
+
+    var stmt = try db.prepare("SELECT bin_isolated FROM kegs WHERE id = ?1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, keg_id);
+    _ = try stmt.step();
+    try testing.expectEqual(@as(i64, 1), stmt.columnInt(0));
+}
+
+test "install_record.recordKeg writes bin_isolated=0 when the caller passes false" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var f = try parseFake(arena.allocator());
+    defer f.deinit();
+    const keg_id = try install_record.recordKeg(
+        &db,
+        &f,
+        "0" ** 64,
+        "/opt/malt/Cellar/foo/1.0",
+        "direct",
+        false,
+        .{},
+    );
+
+    var stmt = try db.prepare("SELECT bin_isolated FROM kegs WHERE id = ?1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, keg_id);
+    _ = try stmt.step();
+    try testing.expectEqual(@as(i64, 0), stmt.columnInt(0));
 }
 
 test "install_record.recordKeg with inherit_pin=true carries the prior pin (option's default branch)" {
@@ -925,6 +983,7 @@ test "install_record.recordKeg with inherit_pin=true carries the prior pin (opti
         "0" ** 64,
         "/opt/malt/Cellar/foo/1.0",
         "direct",
+        false,
         .{ .inherit_pin = true },
     );
 
@@ -944,7 +1003,7 @@ test "recordDeps inserts one row per dependency in the dependencies table" {
 
     var f = try parseFake(arena.allocator());
     defer f.deinit();
-    const keg_id = try install_record.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", .{});
+    const keg_id = try install_record.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", false, .{});
     install_record.recordDeps(&db, keg_id, &f);
 
     var stmt = try db.prepare("SELECT COUNT(*) FROM dependencies WHERE keg_id = ?1;");
@@ -963,7 +1022,7 @@ test "deleteKeg removes the row and isInstalled reports false again" {
 
     var f = try parseFake(arena.allocator());
     defer f.deinit();
-    const keg_id = try install_record.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", .{});
+    const keg_id = try install_record.recordKeg(&db, &f, "0" ** 64, "/opt/malt/Cellar/foo/1.0", "direct", false, .{});
     try testing.expect(install_record.isInstalled(&db, "foo"));
     install_record.deleteKeg(&db, keg_id);
     try testing.expect(!install_record.isInstalled(&db, "foo"));

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -1036,7 +1036,7 @@ test "stale-keg sweep (unlink + drop) clears the prior row, its symlinks, and it
     const keep_id = try insertKegRow(&tdb.db, "foo", "2.0", 0, keep_keg);
 
     var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
-    try linker.link(stale_keg, "foo", stale_id);
+    try linker.link(stale_keg, "foo", stale_id, false);
 
     // Sanity: stale row exists, stale symlink resolves.
     try testing.expectEqual(@as(i64, 2), try kegRowCount(&tdb.db, "foo"));
@@ -1123,7 +1123,7 @@ test "unlinkSameVersionKegLinks removes symlinks + links rows for the matching k
     const keg_id = try insertKegRow(&tdb.db, "foo", "1.0", 0, keg);
 
     var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
-    try linker.link(keg, "foo", keg_id);
+    try linker.link(keg, "foo", keg_id, false);
 
     var link_buf: [512]u8 = undefined;
     const link_path = try std.fmt.bufPrint(&link_buf, "{s}/bin/foo-tool", .{prefix});
@@ -1152,7 +1152,7 @@ test "unlinkSameVersionKegLinks is a no-op when no row matches the keep path" {
     const keg_id = try insertKegRow(&tdb.db, "foo", "1.0", 0, keg);
 
     var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
-    try linker.link(keg, "foo", keg_id);
+    try linker.link(keg, "foo", keg_id, false);
 
     // Different cellar_path than the seeded row → must not unlink.
     const other = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/foo/2.0", .{prefix});
@@ -1178,8 +1178,8 @@ test "unlinkSameVersionKegLinks leaves other packages untouched" {
     const bar_id = try insertKegRow(&tdb.db, "bar", "1.0", 0, bar);
 
     var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
-    try linker.link(foo, "foo", foo_id);
-    try linker.link(bar, "bar", bar_id);
+    try linker.link(foo, "foo", foo_id, false);
+    try linker.link(bar, "bar", bar_id, false);
 
     install.unlinkSameVersionKegLinks(&linker, &tdb.db, "foo", foo);
 
@@ -1282,7 +1282,7 @@ test "two-phase sweep preserves a pin set on the stale revision through INSERT O
     }
 
     var linker = malt.linker.Linker.init(std.Options.debug_io, testing.allocator, &tdb.db, prefix);
-    try linker.link(stale_keg, "foo", stale_id);
+    try linker.link(stale_keg, "foo", stale_id, false);
 
     // Pre-link: clear the stale install's symlinks so the new
     // linker.link does not collide. Row + pin flag stay.

--- a/tests/link_cli_test.zig
+++ b/tests/link_cli_test.zig
@@ -222,3 +222,100 @@ test "executeUnlink on a non-installed package returns Aborted" {
         link_mod.executeUnlink(&malt.app_ctx.debug_ctx, testing.allocator, &.{"ghost-pkg"}),
     );
 }
+
+// --- executeLink --isolate ----------------------------------------------
+
+// Seed a keg row and tag it dependency so the --isolate gate accepts.
+fn seedDepKeg(
+    allocator: std.mem.Allocator,
+    prefix: []const u8,
+    name: []const u8,
+    version: []const u8,
+    bin_name: []const u8,
+) !void {
+    try seedKeg(allocator, prefix, name, version, bin_name);
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    var stmt = try db.prepare("UPDATE kegs SET install_reason = 'dependency' WHERE name = ?1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    _ = try stmt.step();
+}
+
+test "executeLink --isolate on a dep keg removes bin links and sets bin_isolated=1" {
+    var s = try Scratch.init(testing.allocator, "isolate_dep");
+    defer s.deinit(testing.allocator);
+    try seedDepKeg(testing.allocator, s.path, "depbin", "1.0", "depbin");
+
+    quiet();
+    defer unquiet();
+
+    // First, link normally so the bin/ row + symlink exist.
+    try link_mod.executeLink(&malt.app_ctx.debug_ctx, testing.allocator, &.{"depbin"});
+    const linked = try std.fmt.allocPrint(testing.allocator, "{s}/bin/depbin", .{s.path});
+    defer testing.allocator.free(linked);
+    try testing.expect(pathExists(linked));
+
+    // Now isolate: bin symlink and links row must disappear; bin_isolated=1.
+    try link_mod.executeLink(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--isolate", "depbin" });
+    try testing.expect(!pathExists(linked));
+
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    var probe = try db.prepare("SELECT bin_isolated FROM kegs WHERE name='depbin';");
+    defer probe.finalize();
+    _ = try probe.step();
+    try testing.expectEqual(@as(i64, 1), probe.columnInt(0));
+
+    var cnt = try db.prepare("SELECT COUNT(*) FROM links WHERE link_path LIKE '%/bin/%';");
+    defer cnt.finalize();
+    _ = try cnt.step();
+    try testing.expectEqual(@as(i64, 0), cnt.columnInt(0));
+}
+
+test "executeLink --isolate refuses on a direct keg" {
+    var s = try Scratch.init(testing.allocator, "isolate_direct_refused");
+    defer s.deinit(testing.allocator);
+    try seedKeg(testing.allocator, s.path, "directbin", "1.0", "directbin");
+
+    quiet();
+    defer unquiet();
+
+    try testing.expectError(
+        error.Aborted,
+        link_mod.executeLink(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--isolate", "directbin" }),
+    );
+}
+
+test "executeLink on an isolated dep re-links bins and clears bin_isolated" {
+    var s = try Scratch.init(testing.allocator, "link_un_isolate");
+    defer s.deinit(testing.allocator);
+    try seedDepKeg(testing.allocator, s.path, "depbin", "1.0", "depbin");
+
+    quiet();
+    defer unquiet();
+
+    // Isolate first.
+    try link_mod.executeLink(&malt.app_ctx.debug_ctx, testing.allocator, &.{"depbin"});
+    try link_mod.executeLink(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--isolate", "depbin" });
+    const linked = try std.fmt.allocPrint(testing.allocator, "{s}/bin/depbin", .{s.path});
+    defer testing.allocator.free(linked);
+    try testing.expect(!pathExists(linked));
+
+    // Plain link must restore bins AND clear bin_isolated.
+    try link_mod.executeLink(&malt.app_ctx.debug_ctx, testing.allocator, &.{"depbin"});
+    try testing.expect(pathExists(linked));
+
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    var probe = try db.prepare("SELECT bin_isolated FROM kegs WHERE name='depbin';");
+    defer probe.finalize();
+    _ = try probe.step();
+    try testing.expectEqual(@as(i64, 0), probe.columnInt(0));
+}

--- a/tests/link_cli_test.zig
+++ b/tests/link_cli_test.zig
@@ -291,6 +291,69 @@ test "executeLink --isolate refuses on a direct keg" {
     );
 }
 
+test "executeLink --isolate without a name and without --all is rejected" {
+    var s = try Scratch.init(testing.allocator, "isolate_no_arg");
+    defer s.deinit(testing.allocator);
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+    }
+    quiet();
+    defer unquiet();
+    try testing.expectError(
+        error.Aborted,
+        link_mod.executeLink(&malt.app_ctx.debug_ctx, testing.allocator, &.{"--isolate"}),
+    );
+}
+
+test "executeLink --isolate with both a name and --all is rejected" {
+    var s = try Scratch.init(testing.allocator, "isolate_ambiguous");
+    defer s.deinit(testing.allocator);
+    try seedDepKeg(testing.allocator, s.path, "depbin", "1.0", "depbin");
+    quiet();
+    defer unquiet();
+    try testing.expectError(
+        error.Aborted,
+        link_mod.executeLink(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--isolate", "depbin", "--all" }),
+    );
+}
+
+test "executeLink --isolate <missing-name> returns Aborted" {
+    var s = try Scratch.init(testing.allocator, "isolate_missing_name");
+    defer s.deinit(testing.allocator);
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+    }
+    quiet();
+    defer unquiet();
+    try testing.expectError(
+        error.Aborted,
+        link_mod.executeLink(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--isolate", "ghost-pkg" }),
+    );
+}
+
+test "executeLink --isolate --all on a prefix with no dep kegs is a clean info" {
+    var s = try Scratch.init(testing.allocator, "isolate_all_empty");
+    defer s.deinit(testing.allocator);
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+    }
+    quiet();
+    defer unquiet();
+    try link_mod.executeLink(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--isolate", "--all" });
+}
+
 test "executeLink on an isolated dep re-links bins and clears bin_isolated" {
     var s = try Scratch.init(testing.allocator, "link_un_isolate");
     defer s.deinit(testing.allocator);

--- a/tests/linker_core_test.zig
+++ b/tests/linker_core_test.zig
@@ -70,7 +70,7 @@ test "link creates symlinks for every file in a keg and records them in the DB" 
     const keg_id: i64 = 1;
 
     var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
-    try linker.link(keg, "foo", keg_id);
+    try linker.link(keg, "foo", keg_id, false);
 
     // Symlink should exist at {prefix}/bin/foo-tool -> {keg}/bin/foo-tool
     var link_path_buf: [512]u8 = undefined;
@@ -201,10 +201,10 @@ test "checkConflicts flags a symlink that points into a different keg" {
     defer db.close();
     try schema.initSchema(&db);
     var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
-    try linker.link(keg_a, "alpha", 1);
+    try linker.link(keg_a, "alpha", 1, false);
 
     // Now the `bin/tool` symlink points into alpha. Check beta's conflicts.
-    const conflicts = try linker.checkConflicts(keg_b);
+    const conflicts = try linker.checkConflicts(keg_b, false);
     defer {
         for (conflicts) |c| {
             testing.allocator.free(c.link_path);
@@ -236,7 +236,7 @@ test "checkConflicts is empty when nothing is linked yet" {
     try schema.initSchema(&db);
     var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
 
-    const conflicts = try linker.checkConflicts(keg);
+    const conflicts = try linker.checkConflicts(keg, false);
     defer testing.allocator.free(conflicts);
     try testing.expectEqual(@as(usize, 0), conflicts.len);
 }

--- a/tests/linker_isolation_test.zig
+++ b/tests/linker_isolation_test.zig
@@ -1,0 +1,220 @@
+//! Linker bin/sbin-isolation matrix tests.
+//!
+//! Exercises the `bin_isolated` parameter on `Linker.link` and
+//! `Linker.checkConflicts` against a temp-prefix-rooted keg layout.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const test_io = @import("test_io");
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+const linker_mod = malt.linker;
+
+fn uniquePrefix(suffix: []const u8) ![]u8 {
+    return std.fmt.allocPrint(
+        testing.allocator,
+        "/tmp/malt_linker_iso_{d}_{s}",
+        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
+    );
+}
+
+// Build a keg with one file under each named subdir so both
+// `bin`/`sbin` and `lib` get exercised in the same fixture.
+fn makeKegWithFiles(
+    prefix: []const u8,
+    name: []const u8,
+    version: []const u8,
+    subdirs: []const []const u8,
+    file_name: []const u8,
+) ![]u8 {
+    const keg = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/Cellar/{s}/{s}",
+        .{ prefix, name, version },
+    );
+    try test_io.cwd().createDirPath(std.Options.debug_io, keg);
+
+    for (subdirs) |subdir| {
+        const sub = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ keg, subdir });
+        defer testing.allocator.free(sub);
+        try test_io.makeDirAbsolute(std.Options.debug_io, sub);
+
+        const file = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ sub, file_name });
+        defer testing.allocator.free(file);
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, file, .{});
+        try f.writeStreamingAll(std.Options.debug_io, "x\n");
+        f.close(std.Options.debug_io);
+    }
+    return keg;
+}
+
+fn seedKegRow(db: *sqlite.Database, name: []const u8, version: []const u8, cellar_path: []const u8) !i64 {
+    var insert = try db.prepare(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (?1, ?2, ?3, ?4, ?5);
+    );
+    defer insert.finalize();
+    try insert.bindText(1, name);
+    try insert.bindText(2, name);
+    try insert.bindText(3, version);
+    try insert.bindText(4, "0" ** 64);
+    try insert.bindText(5, cellar_path);
+    _ = try insert.step();
+
+    var id_stmt = try db.prepare("SELECT last_insert_rowid();");
+    defer id_stmt.finalize();
+    _ = try id_stmt.step();
+    return id_stmt.columnInt(0);
+}
+
+fn pathExists(absolute: []const u8) bool {
+    var f = test_io.openFileAbsolute(std.Options.debug_io, absolute, .{}) catch return false;
+    f.close(std.Options.debug_io);
+    return true;
+}
+
+// link(bin_isolated=true) keeps lib/include/share/etc linked but skips
+// bin and sbin. The DB row count for the keg must reflect what landed
+// on disk — the conflict probe must agree with the materialised state.
+test "link with bin_isolated=true skips bin and sbin but links lib" {
+    const prefix = try uniquePrefix("iso_true");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+    const keg = try makeKegWithFiles(prefix, "depkeg", "1.0", &.{ "bin", "sbin", "lib" }, "tool");
+    defer testing.allocator.free(keg);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    const keg_id = try seedKegRow(&db, "depkeg", "1.0", keg);
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg, "depkeg", keg_id, true);
+
+    var bin_buf: [512]u8 = undefined;
+    const bin_link = try std.fmt.bufPrint(&bin_buf, "{s}/bin/tool", .{prefix});
+    try testing.expect(!pathExists(bin_link));
+
+    var sbin_buf: [512]u8 = undefined;
+    const sbin_link = try std.fmt.bufPrint(&sbin_buf, "{s}/sbin/tool", .{prefix});
+    try testing.expect(!pathExists(sbin_link));
+
+    var lib_buf: [512]u8 = undefined;
+    const lib_link = try std.fmt.bufPrint(&lib_buf, "{s}/lib/tool", .{prefix});
+    try testing.expect(pathExists(lib_link));
+
+    var count = try db.prepare("SELECT COUNT(*) FROM links WHERE keg_id = ?1;");
+    defer count.finalize();
+    try count.bindInt(1, keg_id);
+    _ = try count.step();
+    try testing.expectEqual(@as(i64, 1), count.columnInt(0));
+}
+
+// link(bin_isolated=false) behaves exactly like the pre-feature path.
+// Pinning this prevents a future refactor from silently flipping the
+// default and breaking every existing install.
+test "link with bin_isolated=false links bin and sbin (default behaviour)" {
+    const prefix = try uniquePrefix("iso_false");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+    const keg = try makeKegWithFiles(prefix, "directkeg", "1.0", &.{ "bin", "sbin", "lib" }, "tool");
+    defer testing.allocator.free(keg);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    const keg_id = try seedKegRow(&db, "directkeg", "1.0", keg);
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg, "directkeg", keg_id, false);
+
+    var bin_buf: [512]u8 = undefined;
+    const bin_link = try std.fmt.bufPrint(&bin_buf, "{s}/bin/tool", .{prefix});
+    try testing.expect(pathExists(bin_link));
+
+    var sbin_buf: [512]u8 = undefined;
+    const sbin_link = try std.fmt.bufPrint(&sbin_buf, "{s}/sbin/tool", .{prefix});
+    try testing.expect(pathExists(sbin_link));
+
+    var lib_buf: [512]u8 = undefined;
+    const lib_link = try std.fmt.bufPrint(&lib_buf, "{s}/lib/tool", .{prefix});
+    try testing.expect(pathExists(lib_link));
+
+    var count = try db.prepare("SELECT COUNT(*) FROM links WHERE keg_id = ?1;");
+    defer count.finalize();
+    try count.bindInt(1, keg_id);
+    _ = try count.step();
+    try testing.expectEqual(@as(i64, 3), count.columnInt(0));
+}
+
+// Two isolated deps that ship the same bin name must not produce a
+// spurious conflict — neither one will materialise the link, so
+// `checkConflicts` should probe-skip bin/sbin before opening them.
+test "checkConflicts with bin_isolated=true skips bin and sbin probes" {
+    const prefix = try uniquePrefix("iso_conflict_skip");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const keg_a = try makeKegWithFiles(prefix, "depa", "1.0", &.{"bin"}, "tool");
+    defer testing.allocator.free(keg_a);
+    const keg_b = try makeKegWithFiles(prefix, "depb", "1.0", &.{"bin"}, "tool");
+    defer testing.allocator.free(keg_b);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    const a_id = try seedKegRow(&db, "depa", "1.0", keg_a);
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg_a, "depa", a_id, false);
+
+    // Now depb wants to install under isolation: even though depa owns
+    // <prefix>/bin/tool, the probe must skip bin and report zero.
+    const conflicts = try linker.checkConflicts(keg_b, true);
+    defer {
+        for (conflicts) |c| {
+            testing.allocator.free(c.link_path);
+            testing.allocator.free(c.existing_keg);
+        }
+        testing.allocator.free(conflicts);
+    }
+    try testing.expectEqual(@as(usize, 0), conflicts.len);
+}
+
+// And the same pair without isolation must still surface the conflict
+// — the bin_isolated=false branch keeps today's contract.
+test "checkConflicts with bin_isolated=false still flags bin collisions" {
+    const prefix = try uniquePrefix("iso_conflict_keep");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const keg_a = try makeKegWithFiles(prefix, "alpha", "1.0", &.{"bin"}, "tool");
+    defer testing.allocator.free(keg_a);
+    const keg_b = try makeKegWithFiles(prefix, "beta", "1.0", &.{"bin"}, "tool");
+    defer testing.allocator.free(keg_b);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    const a_id = try seedKegRow(&db, "alpha", "1.0", keg_a);
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg_a, "alpha", a_id, false);
+
+    const conflicts = try linker.checkConflicts(keg_b, false);
+    defer {
+        for (conflicts) |c| {
+            testing.allocator.free(c.link_path);
+            testing.allocator.free(c.existing_keg);
+        }
+        testing.allocator.free(conflicts);
+    }
+    try testing.expect(conflicts.len >= 1);
+}

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -210,7 +210,7 @@ test "recordKeg inherits pinned=1 from an existing keg of the same name" {
     var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
     defer formula.deinit();
 
-    const new_keg_id = try install_record.recordKeg(&db, &formula, "deadbeef2", "/cellar/alpha/2.0", "direct", .{});
+    const new_keg_id = try install_record.recordKeg(&db, &formula, "deadbeef2", "/cellar/alpha/2.0", "direct", false, .{});
 
     var stmt = try db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;");
     defer stmt.finalize();
@@ -283,7 +283,7 @@ test "recordKeg defaults pinned=0 when no prior keg of that name exists" {
     var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
     defer formula.deinit();
 
-    const new_keg_id = try install_record.recordKeg(&db, &formula, "deadbeef0", "/cellar/fresh/1.0", "direct", .{});
+    const new_keg_id = try install_record.recordKeg(&db, &formula, "deadbeef0", "/cellar/fresh/1.0", "direct", false, .{});
 
     var stmt = try db.prepare("SELECT pinned FROM kegs WHERE id = ?1 LIMIT 1;");
     defer stmt.finalize();
@@ -320,7 +320,7 @@ test "recordKeg runs inside an outer beginTransaction without nesting errors" {
     defer formula.deinit();
 
     try db.beginTransaction();
-    const new_keg_id = try install_record.recordKeg(&db, &formula, "sha-inner", "/cellar/inside-txn/2.0", "direct", .{ .in_transaction = true });
+    const new_keg_id = try install_record.recordKeg(&db, &formula, "sha-inner", "/cellar/inside-txn/2.0", "direct", false, .{ .in_transaction = true });
     try db.commit();
 
     var stmt = try db.prepare("SELECT name, version FROM kegs WHERE id = ?1;");
@@ -363,7 +363,7 @@ test "recordKeg INSERT OR REPLACE rewrites an existing (name,version,revision)" 
     var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
     defer formula.deinit();
 
-    const new_keg_id = try install_record.recordKeg(&db, &formula, "sha-new", "/cellar/collide/1.0", "direct", .{});
+    const new_keg_id = try install_record.recordKeg(&db, &formula, "sha-new", "/cellar/collide/1.0", "direct", false, .{});
 
     var count_stmt = try db.prepare("SELECT COUNT(*) FROM kegs WHERE name='collide';");
     defer count_stmt.finalize();
@@ -487,7 +487,7 @@ test "recordKeg succeeds on a same-version revision-bump upgrade" {
     var formula = try formula_mod.parseFormula(arena.allocator(), formula_json);
     defer formula.deinit();
 
-    const new_keg_id = try install_record.recordKeg(&db, &formula, "sha-new", "/cellar/libgit2/1.9.2_2", "direct", .{});
+    const new_keg_id = try install_record.recordKeg(&db, &formula, "sha-new", "/cellar/libgit2/1.9.2_2", "direct", false, .{});
 
     // Both rows must coexist briefly — upgradeFormula deletes the old
     // one in step 8, after symlinks flip to the new keg.


### PR DESCRIPTION
## Description

Adds an opt-in `--isolate-deps` flag to `mt install`, `mt upgrade`, `mt reinstall`, and `mt bundle install`. With the flag, every package pulled in as a transitive runtime dependency lands in the Cellar and gets the usual `opt/<dep>` anchor — but its `bin/` and `sbin/` contents are no longer symlinked into `<prefix>/bin`. The package the user actually asked for keeps its bins linked exactly like today.

The user-facing contract: "I asked for `yt-dlp`, I get `yt-dlp` in my PATH - not also `deno` and `python3.14` just because yt-dlp needed them." Mach-O dependents continue resolving through `<prefix>/opt/<dep>/lib`, and bottle-rewritten script shebangs continue resolving through their pinned Cellar interpreters, so compiled formulae and well-formed scripts are unaffected.

Intent is recorded per-keg on a new `kegs.bin_isolated` column, so a subsequent `mt upgrade <pkg>` replays the isolation without the user re-passing the flag. Explicit user actions move kegs in and out of isolation: `mt install <dep-name>` promotes a dep to direct and re-links its bins; `mt link <dep>` un-isolates without promoting; `mt link --isolate <dep>` retroactively isolates a dep that predates the feature.

The default stays off so no existing install surprises anyone.
`mt doctor --verbose` enumerates dep kegs that still link `bin/sbin` from a pre-flag install; the default (non-verbose) doctor stays silent on this dimension so first-time users aren't moralised at every run.

## Related Issue

- None

## Notes for Reviewers

- Downgrading a malt binary to a pre-this-feature release against a DB carrying `bin_isolated=1` rows will silently un-isolate on the next upgrade (the older binary's `INSERT OR REPLACE` doesn't bind the column, so the DEFAULT 0 kicks in). One-way schema - worth a changelog mention.
