### PR TITLE
fix(core/dsl): implement rm_f and Homebrew-shaped install_symlink

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -139,6 +139,8 @@ pub fn build(b: *std.Build) void {
         "tests/dsl_parser_test.zig",
         "tests/dsl_sandbox_test.zig",
         "tests/dsl_interpreter_test.zig",
+        "tests/dsl_install_symlink_test.zig",
+        "tests/doctor_ssl_test.zig",
         "tests/db_schema_v2_test.zig",
         "tests/bundle_brewfile_test.zig",
         "tests/services_plist_test.zig",

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -86,6 +86,7 @@ pub const checks = [_]Check{
     .{ .name = "Disk space", .run = checkDiskSpace },
     .{ .name = "Local formula sources", .run = checkLocalSources },
     .{ .name = "Dependency bin/sbin link census", .run = checkIsolationLeaks },
+    .{ .name = "SSL CA bundle", .run = checkSslCaBundle },
 };
 
 /// Walks the table and tallies warn/err contributions. Exposed so
@@ -876,6 +877,45 @@ fn checkDiskSpace(ctx: CheckCtx, name: []const u8) CheckResult {
 /// `mt doctor` exits clean. Detail + enumeration only emit under
 /// `--verbose` so default runs stay silent on this dimension and
 /// downstream "grep for warnings" gates don't false-positive.
+/// Detail line for the "SSL CA bundle" row. `null` when the bundle is
+/// present (clean row); a short flag when it's missing. `pub` so the
+/// render test can pin the text without a filesystem fixture.
+pub fn formatSslCertDetail(present: bool) ?[]const u8 {
+    return if (present)
+        null
+    else
+        "cert.pem missing — HTTPS verification fails until ca-certificates is installed";
+}
+
+/// Informational check: `<prefix>/etc/openssl@3/cert.pem` is what
+/// OpenSSL reaches for at runtime. A missing bundle breaks every HTTPS
+/// client behind OpenSSL, but it's a remediation hint, never a failure —
+/// the row stays `.ok` so doctor exits clean.
+fn checkSslCaBundle(ctx: CheckCtx, name: []const u8) CheckResult {
+    var buf: [512]u8 = undefined;
+    const cert = std.fmt.bufPrint(&buf, "{s}/etc/openssl@3/cert.pem", .{ctx.prefix}) catch {
+        printCheck(name, .ok, null);
+        return .ok;
+    };
+    const present = blk: {
+        std.Io.Dir.cwd().access(ctx.io, cert, .{}) catch break :blk false;
+        break :blk true;
+    };
+    printCheck(name, .ok, formatSslCertDetail(present));
+    if (!present) {
+        // Verbose-only remediation: install the formula, or relink the
+        // bundle by hand if the keg is already on disk.
+        var manual_buf: [768]u8 = undefined;
+        const manual = std.fmt.bufPrint(
+            &manual_buf,
+            "ln -sf {s}/opt/ca-certificates/share/ca-certificates/cacert.pem {s}/etc/openssl@3/cert.pem",
+            .{ ctx.prefix, ctx.prefix },
+        ) catch "ln -sf <prefix>/opt/ca-certificates/share/ca-certificates/cacert.pem <prefix>/etc/openssl@3/cert.pem";
+        writeVerboseList(&.{ "mt install ca-certificates", manual });
+    }
+    return .ok;
+}
+
 fn checkIsolationLeaks(ctx: CheckCtx, name: []const u8) CheckResult {
     var db_path_buf: [512]u8 = undefined;
     const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{ctx.prefix}, 0) catch {
@@ -1081,6 +1121,13 @@ fn captureFixEmit(allocator: std.mem.Allocator, fix_requested: bool) !std.ArrayL
     defer output.endStderrCapture();
     emitFixHintIfNeeded(fix_requested);
     return buf;
+}
+
+test "formatSslCertDetail: null when present, remediation hint when absent" {
+    try testing.expect(formatSslCertDetail(true) == null);
+    const missing = formatSslCertDetail(false) orelse return error.TestUnexpectedResult;
+    // The hint must name the fix so a user can act on it directly.
+    try testing.expect(std.mem.indexOf(u8, missing, "ca-certificates") != null);
 }
 
 test "emitFixHintIfNeeded: silent without arming" {

--- a/src/cli/shellenv.zig
+++ b/src/cli/shellenv.zig
@@ -25,20 +25,23 @@ pub fn detectFromShellPath(value: ?[]const u8) ?Shell {
     return parseShell(base);
 }
 
-/// Caller owns the returned slice.
+/// Caller owns the returned slice. `cert_present` gates the
+/// `SSL_CERT_FILE` line: emit it only when the CA bundle exists so the
+/// var never points at a missing file.
 pub fn render(
     allocator: std.mem.Allocator,
     shell: Shell,
     prefix: []const u8,
+    cert_present: bool,
 ) std.mem.Allocator.Error![]u8 {
     var aw: std.Io.Writer.Allocating = .init(allocator);
     errdefer aw.deinit();
     // The writer is allocator-backed, so its `WriteFailed` is always OOM.
-    writeShellEnv(&aw.writer, shell, prefix) catch return error.OutOfMemory;
+    writeShellEnv(&aw.writer, shell, prefix, cert_present) catch return error.OutOfMemory;
     return aw.toOwnedSlice();
 }
 
-fn writeShellEnv(w: *std.Io.Writer, shell: Shell, prefix: []const u8) std.Io.Writer.Error!void {
+fn writeShellEnv(w: *std.Io.Writer, shell: Shell, prefix: []const u8, cert_present: bool) std.Io.Writer.Error!void {
     // Fish uses `set -gx` because `export` is a syntax error in fish;
     // bash/zsh share the POSIX form.
     switch (shell) {
@@ -49,6 +52,7 @@ fn writeShellEnv(w: *std.Io.Writer, shell: Shell, prefix: []const u8) std.Io.Wri
             try w.print("export PATH=\"{s}/bin:{s}/sbin${{PATH+:$PATH}}\";\n", .{ prefix, prefix });
             try w.print("export MANPATH=\"{s}/share/man${{MANPATH+:$MANPATH}}:\";\n", .{prefix});
             try w.print("export INFOPATH=\"{s}/share/info:${{INFOPATH:-}}\";\n", .{prefix});
+            if (cert_present) try w.print("export SSL_CERT_FILE=\"{s}/etc/openssl@3/cert.pem\";\n", .{prefix});
         },
         .fish => {
             try w.print("set -gx HOMEBREW_PREFIX \"{s}\";\n", .{prefix});
@@ -57,6 +61,7 @@ fn writeShellEnv(w: *std.Io.Writer, shell: Shell, prefix: []const u8) std.Io.Wri
             try w.print("set -gx PATH \"{s}/bin\" \"{s}/sbin\" $PATH;\n", .{ prefix, prefix });
             try w.print("set -gx MANPATH \"{s}/share/man\" $MANPATH;\n", .{prefix});
             try w.print("set -gx INFOPATH \"{s}/share/info\" $INFOPATH;\n", .{prefix});
+            if (cert_present) try w.print("set -gx SSL_CERT_FILE \"{s}/etc/openssl@3/cert.pem\";\n", .{prefix});
         },
     }
 }
@@ -66,9 +71,19 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     const shell = resolveShell(ctx, args) orelse std.process.exit(2);
 
-    const out = try render(allocator, shell, atomic.maltPrefixOrAbort());
+    const prefix = atomic.maltPrefixOrAbort();
+    const out = try render(allocator, shell, prefix, sslCertPresent(ctx.io, prefix));
     defer allocator.free(out);
     output.writeStdoutAll(out);
+}
+
+/// True when the OpenSSL CA bundle exists at the canonical path. Drives
+/// the `SSL_CERT_FILE` export so it never names a missing file.
+fn sslCertPresent(io: std.Io, prefix: []const u8) bool {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = std.fmt.bufPrint(&buf, "{s}/etc/openssl@3/cert.pem", .{prefix}) catch return false;
+    std.Io.Dir.cwd().access(io, path, .{}) catch return false;
+    return true;
 }
 
 fn resolveShell(ctx: *const AppCtx, args: []const []const u8) ?Shell {

--- a/src/core/dsl/builtins/pathname.zig
+++ b/src/core/dsl/builtins/pathname.zig
@@ -204,25 +204,54 @@ pub fn unlink(ctx: ExecCtx, receiver: ?Value, _: []const Value) BuiltinError!Val
     return Value{ .nil = {} };
 }
 
-/// install_symlink — create a symlink (sandbox-validated)
+/// install_symlink — link source(s) into the receiver directory.
+///
+/// Homebrew semantics: the receiver is the *target directory*, each arg
+/// names a source. A bare source lands at `<dir>/<basename(source)>`; a
+/// hash entry `source => link_name` overrides the link name; an array
+/// links each element by basename. The link path is sandbox-validated.
 pub fn installSymlink(ctx: ExecCtx, receiver: ?Value, args: []const Value) BuiltinError!Value {
-    const source = try receiverPath(ctx.allocator, receiver);
-    const target = if (args.len > 0) try args[0].asString(ctx.allocator) else return Value{ .nil = {} };
+    const dir = try receiverPath(ctx.allocator, receiver);
+    if (dir.len == 0) return Value{ .nil = {} };
+    for (args) |arg| try installSymlinkArg(ctx, dir, arg);
+    return Value{ .nil = {} };
+}
 
-    // Guard against empty/invalid paths
-    if (source.len == 0 or target.len == 0) return Value{ .nil = {} };
+fn installSymlinkArg(ctx: ExecCtx, dir: []const u8, arg: Value) BuiltinError!void {
+    switch (arg) {
+        // `source => link_name`: key is the source, value the link name.
+        .hash => |pairs| for (pairs) |p| {
+            const source = try p.key.asString(ctx.allocator);
+            const name = try p.value.asString(ctx.allocator);
+            try linkInto(ctx, dir, source, name);
+        },
+        .array => |items| for (items) |item| {
+            const source = try item.asString(ctx.allocator);
+            try linkInto(ctx, dir, source, std.fs.path.basename(source));
+        },
+        else => {
+            const source = try arg.asString(ctx.allocator);
+            try linkInto(ctx, dir, source, std.fs.path.basename(source));
+        },
+    }
+}
 
-    sandbox.validatePath(target, ctx.cellar_path, ctx.malt_prefix) catch
+/// Symlink `<dir>/<name>` → `<source>`, sandbox-validated on the link
+/// path. Same non-raising fs contract as the rest of this module: a
+/// failed mkdir/symlink surfaces downstream, not here.
+fn linkInto(ctx: ExecCtx, dir: []const u8, source: []const u8, name: []const u8) BuiltinError!void {
+    if (source.len == 0 or name.len == 0) return;
+
+    var link_buf: [std.fs.max_path_bytes]u8 = undefined;
+    // Overflow means a pathological path — skip rather than truncate.
+    const link = std.fmt.bufPrint(&link_buf, "{s}/{s}", .{ dir, name }) catch return;
+
+    sandbox.validatePath(link, ctx.cellar_path, ctx.malt_prefix) catch
         return BuiltinError.PathSandboxViolation;
 
-    // Ensure parent exists
-    if (std.fs.path.dirname(target)) |parent| {
-        std.Io.Dir.cwd().createDirPath(ctx.io, parent) catch {};
-    }
-
-    std.Io.Dir.cwd().deleteFile(ctx.io, target) catch {};
-    std.Io.Dir.symLinkAbsolute(ctx.io, source, target, .{}) catch {};
-    return Value{ .nil = {} };
+    std.Io.Dir.cwd().createDirPath(ctx.io, dir) catch {};
+    std.Io.Dir.cwd().deleteFile(ctx.io, link) catch {};
+    std.Io.Dir.symLinkAbsolute(ctx.io, source, link, .{}) catch {};
 }
 
 /// glob(pattern) — match files in a directory against a glob pattern

--- a/src/core/dsl/builtins/root.zig
+++ b/src/core/dsl/builtins/root.zig
@@ -21,6 +21,8 @@ pub const BuiltinFn = *const fn (ExecCtx, ?Value, []const Value) BuiltinError!Va
 pub const bare_builtins = std.StaticStringMap(BuiltinFn).initComptime(.{
     // FileUtils
     .{ "rm", fileutils.rm },
+    // rm_f is rm's force variant; rm already swallows missing-file errors.
+    .{ "rm_f", fileutils.rm },
     .{ "rm_r", fileutils.rmR },
     .{ "rm_rf", fileutils.rmRf },
     .{ "mkdir_p", fileutils.mkdirP },

--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -365,7 +365,12 @@ pub const Parser = struct {
             self.skipNewlines();
             if (self.current.kind == .rparen) break;
             switch (try self.parseOneArg()) {
-                .arg => |a| args.append(self.allocator, a) catch return DslError.OutOfMemory,
+                .arg => |a| {
+                    // A `=>` after the arg starts an implicit trailing hash,
+                    // which is terminal — the rest of the list is its pairs.
+                    if (try self.maybeTrailingHash(args, a)) break;
+                    args.append(self.allocator, a) catch return DslError.OutOfMemory;
+                },
                 .block_pass => |bp| {
                     block_pass_out.* = bp;
                     break;
@@ -388,18 +393,66 @@ pub const Parser = struct {
         block_pass_out: *?*const Node,
     ) DslError!void {
         const first = try self.parseExpression();
+        if (try self.maybeTrailingHash(args, first)) return;
         args.append(self.allocator, first) catch return DslError.OutOfMemory;
         while (self.current.kind == .comma) {
             self.advanceToken();
             self.skipNewlines();
             switch (try self.parseOneArg()) {
-                .arg => |a| args.append(self.allocator, a) catch return DslError.OutOfMemory,
+                .arg => |a| {
+                    if (try self.maybeTrailingHash(args, a)) return;
+                    args.append(self.allocator, a) catch return DslError.OutOfMemory;
+                },
                 .block_pass => |bp| {
                     block_pass_out.* = bp;
                     break;
                 },
             }
         }
+    }
+
+    /// If the current token is `=>`, the just-parsed `key` opens an
+    /// implicit trailing hash: every remaining comma-separated element is
+    /// a `key => value` pair, folded into one hash_literal arg. Ruby
+    /// lowers `f a, k1 => v1, k2 => v2` this way. Returns true when a hash
+    /// was appended (the arg list is then terminal).
+    fn maybeTrailingHash(
+        self: *Parser,
+        args: *std.ArrayList(*const Node),
+        key: *const Node,
+    ) DslError!bool {
+        if (self.current.kind != .fat_arrow) return false;
+        const hash = try self.parseTrailingHash(key);
+        args.append(self.allocator, hash) catch return DslError.OutOfMemory;
+        return true;
+    }
+
+    /// Collect `key => value (`,` key => value)*` into a hash_literal,
+    /// starting from an already-parsed `first_key` sitting on `=>`. Stops
+    /// at the first non-`=>` element so a malformed tail degrades instead
+    /// of crashing — only one hash level is supported at this position.
+    fn parseTrailingHash(self: *Parser, first_key: *const Node) DslError!*const Node {
+        var entries: std.ArrayList(ast.HashEntry) = .empty;
+        var key = first_key;
+        while (true) {
+            self.advanceToken(); // consume '=>'
+            self.skipNewlines();
+            const value = try self.parseExpression();
+            entries.append(self.allocator, .{ .key = key, .value = value }) catch return DslError.OutOfMemory;
+            if (self.current.kind != .comma) break;
+            self.advanceToken(); // consume ','
+            self.skipNewlines();
+            // A trailing comma before the list close ends the hash.
+            if (self.current.kind == .rparen or self.current.kind == .eof or
+                self.current.kind == .newline) break;
+            key = try self.parseExpression();
+            if (self.current.kind != .fat_arrow) break;
+        }
+        const slice = entries.toOwnedSlice(self.allocator) catch return DslError.OutOfMemory;
+        return self.allocNode(.{
+            .loc = first_key.loc,
+            .kind = .{ .hash_literal = slice },
+        });
     }
 
     /// Consume an optional `do |params| … end` or `{ |params| … }` tail
@@ -1208,6 +1261,7 @@ pub const Parser = struct {
             .{ "odie", {} },
             .{ "mkdir_p", {} },
             .{ "rm", {} },
+            .{ "rm_f", {} },
             .{ "rm_r", {} },
             .{ "rm_rf", {} },
             .{ "cp", {} },

--- a/tests/doctor_ssl_test.zig
+++ b/tests/doctor_ssl_test.zig
@@ -1,0 +1,97 @@
+//! `mt doctor` SSL CA bundle check tests.
+//!
+//! The check is informational: it flags a missing
+//! `<prefix>/etc/openssl@3/cert.pem` with a remediation hint but never
+//! bumps doctor's exit code — a fresh prefix without ca-certificates is
+//! a normal state, not a defect.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const test_io = @import("test_io");
+
+const doctor = malt.doctor;
+const output = malt.output;
+
+fn uniquePrefix(suffix: []const u8) ![]u8 {
+    return std.fmt.allocPrint(
+        testing.allocator,
+        "/tmp/malt_doctor_ssl_{d}_{s}",
+        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
+    );
+}
+
+fn makePrefix(suffix: []const u8, with_cert: bool) ![]u8 {
+    const prefix = try uniquePrefix(suffix);
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+    if (with_cert) {
+        const dir = try std.fmt.allocPrint(testing.allocator, "{s}/etc/openssl@3", .{prefix});
+        defer testing.allocator.free(dir);
+        try test_io.cwd().createDirPath(std.Options.debug_io, dir);
+        const cert = try std.fmt.allocPrint(testing.allocator, "{s}/cert.pem", .{dir});
+        defer testing.allocator.free(cert);
+        (try test_io.createFileAbsolute(std.Options.debug_io, cert, .{})).close(std.Options.debug_io);
+    }
+    return prefix;
+}
+
+fn ctxFor(prefix: []const u8) doctor.CheckCtx {
+    return .{
+        .allocator = testing.allocator,
+        .prefix = prefix,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+        .mirrors = .{},
+        .offline = false,
+    };
+}
+
+fn sslCheckResult(ctx: doctor.CheckCtx) doctor.CheckResult {
+    for (doctor.checks) |c| {
+        if (std.mem.eql(u8, c.name, "SSL CA bundle")) return c.run(ctx, c.name);
+    }
+    @panic("SSL CA bundle check not registered");
+}
+
+// The pure `formatSslCertDetail` formatter is unit-tested inline in
+// `doctor.zig`; this file covers the fs-backed check behaviour.
+
+test "checks table includes the SSL CA bundle check" {
+    var found = false;
+    for (doctor.checks) |c| {
+        if (std.mem.eql(u8, c.name, "SSL CA bundle")) {
+            found = true;
+            break;
+        }
+    }
+    try testing.expect(found);
+}
+
+test "SSL CA bundle check returns ok when cert.pem is present" {
+    const prefix = try makePrefix("present", true);
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try testing.expectEqual(doctor.CheckResult.ok, sslCheckResult(ctxFor(prefix)));
+}
+
+test "SSL CA bundle check stays ok (informational) when cert.pem is absent" {
+    // Quiet the verbose-remediation stderr so the assert reads clean.
+    output.setQuiet(true);
+    defer output.setQuiet(false);
+    const prefix = try makePrefix("absent", false);
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try testing.expectEqual(doctor.CheckResult.ok, sslCheckResult(ctxFor(prefix)));
+}
+
+test "SSL CA bundle check is ok under --verbose when cert.pem is absent" {
+    const prior = output.isVerbose();
+    output.setVerbose(true);
+    defer output.setVerbose(prior);
+    output.setQuiet(true);
+    defer output.setQuiet(false);
+    const prefix = try makePrefix("verbose_absent", false);
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try testing.expectEqual(doctor.CheckResult.ok, sslCheckResult(ctxFor(prefix)));
+}

--- a/tests/dsl_builtins_test.zig
+++ b/tests/dsl_builtins_test.zig
@@ -230,24 +230,229 @@ test "Pathname.unlink deletes a file in the sandbox" {
     try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(std.Options.debug_io, path, .{}));
 }
 
-test "Pathname.install_symlink creates and replaces a symlink in the sandbox" {
-    const root = try uniqueSandbox("install_symlink");
+test "Pathname.install_symlink (positional) links <dir>/<basename(source)> -> source" {
+    // Homebrew semantics: receiver is the target directory, arg[0] is the
+    // source. The link lands at <dir>/<basename(source)>.
+    const root = try uniqueSandbox("install_symlink_pos");
     defer testing.allocator.free(root);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
     const ctx = mkCtx(root);
 
     const src = try std.fmt.allocPrint(testing.allocator, "{s}/source.txt", .{root});
     defer testing.allocator.free(src);
-    const dst = try std.fmt.allocPrint(testing.allocator, "{s}/sub/link", .{root});
-    defer testing.allocator.free(dst);
+    const dir = try std.fmt.allocPrint(testing.allocator, "{s}/sub", .{root});
+    defer testing.allocator.free(dir);
     (try test_io.createFileAbsolute(std.Options.debug_io, src, .{})).close(std.Options.debug_io);
 
-    const args = [_]Value{.{ .string = dst }};
-    _ = try pathname.installSymlink(ctx, Value{ .pathname = src }, &args);
+    const args = [_]Value{.{ .string = src }};
+    _ = try pathname.installSymlink(ctx, Value{ .pathname = dir }, &args);
+
+    const link = try std.fmt.allocPrint(testing.allocator, "{s}/source.txt", .{dir});
+    defer testing.allocator.free(link);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expectEqualStrings(src, try test_io.readLinkAbsolute(std.Options.debug_io, link, &buf));
+}
+
+test "Pathname.install_symlink (hash) links <dir>/<link_name> -> source" {
+    // The `source => link_name` form: ca-certificates uses
+    // `openssl_pkgetc.install_symlink pkgshare/"cacert.pem" => "cert.pem"`.
+    const root = try uniqueSandbox("install_symlink_hash");
+    defer testing.allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const ctx = mkCtx(root);
+
+    const src = try std.fmt.allocPrint(testing.allocator, "{s}/cacert.pem", .{root});
+    defer testing.allocator.free(src);
+    const dir = try std.fmt.allocPrint(testing.allocator, "{s}/etc", .{root});
+    defer testing.allocator.free(dir);
+    (try test_io.createFileAbsolute(std.Options.debug_io, src, .{})).close(std.Options.debug_io);
+
+    const pairs = [_]Value.HashPair{.{ .key = .{ .pathname = src }, .value = .{ .string = "cert.pem" } }};
+    const args = [_]Value{.{ .hash = &pairs }};
+    _ = try pathname.installSymlink(ctx, Value{ .pathname = dir }, &args);
+
+    const link = try std.fmt.allocPrint(testing.allocator, "{s}/cert.pem", .{dir});
+    defer testing.allocator.free(link);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expectEqualStrings(src, try test_io.readLinkAbsolute(std.Options.debug_io, link, &buf));
+}
+
+test "Pathname.install_symlink (array) links each source by basename" {
+    const root = try uniqueSandbox("install_symlink_arr");
+    defer testing.allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const ctx = mkCtx(root);
+
+    const a = try std.fmt.allocPrint(testing.allocator, "{s}/a.conf", .{root});
+    defer testing.allocator.free(a);
+    const b = try std.fmt.allocPrint(testing.allocator, "{s}/b.conf", .{root});
+    defer testing.allocator.free(b);
+    const dir = try std.fmt.allocPrint(testing.allocator, "{s}/etc", .{root});
+    defer testing.allocator.free(dir);
+    for ([_][]const u8{ a, b }) |p| (try test_io.createFileAbsolute(std.Options.debug_io, p, .{})).close(std.Options.debug_io);
+
+    const items = [_]Value{ .{ .pathname = a }, .{ .pathname = b } };
+    const args = [_]Value{.{ .array = &items }};
+    _ = try pathname.installSymlink(ctx, Value{ .pathname = dir }, &args);
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const target = try test_io.readLinkAbsolute(std.Options.debug_io, dst, &buf);
-    try testing.expectEqualStrings(src, target);
+    for ([_][]const u8{ "a.conf", "b.conf" }) |name| {
+        const link = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ dir, name });
+        defer testing.allocator.free(link);
+        _ = try test_io.readLinkAbsolute(std.Options.debug_io, link, &buf);
+    }
+}
+
+test "Pathname.install_symlink replaces an existing link at the target name" {
+    const root = try uniqueSandbox("install_symlink_replace");
+    defer testing.allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const ctx = mkCtx(root);
+
+    const old_src = try std.fmt.allocPrint(testing.allocator, "{s}/old.pem", .{root});
+    defer testing.allocator.free(old_src);
+    const new_src = try std.fmt.allocPrint(testing.allocator, "{s}/new.pem", .{root});
+    defer testing.allocator.free(new_src);
+    const dir = try std.fmt.allocPrint(testing.allocator, "{s}/etc", .{root});
+    defer testing.allocator.free(dir);
+    for ([_][]const u8{ old_src, new_src }) |p| (try test_io.createFileAbsolute(std.Options.debug_io, p, .{})).close(std.Options.debug_io);
+
+    const args_old = [_]Value{.{ .hash = &[_]Value.HashPair{.{ .key = .{ .pathname = old_src }, .value = .{ .string = "cert.pem" } }} }};
+    _ = try pathname.installSymlink(ctx, Value{ .pathname = dir }, &args_old);
+    const args_new = [_]Value{.{ .hash = &[_]Value.HashPair{.{ .key = .{ .pathname = new_src }, .value = .{ .string = "cert.pem" } }} }};
+    _ = try pathname.installSymlink(ctx, Value{ .pathname = dir }, &args_new);
+
+    const link = try std.fmt.allocPrint(testing.allocator, "{s}/cert.pem", .{dir});
+    defer testing.allocator.free(link);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expectEqualStrings(new_src, try test_io.readLinkAbsolute(std.Options.debug_io, link, &buf));
+}
+
+test "Pathname.install_symlink rejects a target directory outside the sandbox" {
+    const root = try uniqueSandbox("install_symlink_violate");
+    defer testing.allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const ctx = mkCtx(root);
+    const args = [_]Value{.{ .string = "/some/source" }};
+    try testing.expectError(
+        error.PathSandboxViolation,
+        pathname.installSymlink(ctx, Value{ .pathname = "/etc/malt_bad_symlink_dir" }, &args),
+    );
+}
+
+test "Pathname.install_symlink with no args is a no-op returning nil" {
+    const root = try uniqueSandbox("install_symlink_noargs");
+    defer testing.allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const ctx = mkCtx(root);
+    const v = try pathname.installSymlink(ctx, Value{ .pathname = root }, &.{});
+    try testing.expect(v == .nil);
+}
+
+test "Pathname.install_symlink accepts a plain string source (not only pathname)" {
+    const root = try uniqueSandbox("install_symlink_strsrc");
+    defer testing.allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const ctx = mkCtx(root);
+    const src = try std.fmt.allocPrint(testing.allocator, "{s}/s.txt", .{root});
+    defer testing.allocator.free(src);
+    (try test_io.createFileAbsolute(std.Options.debug_io, src, .{})).close(std.Options.debug_io);
+
+    const args = [_]Value{.{ .string = src }};
+    _ = try pathname.installSymlink(ctx, Value{ .pathname = root }, &args);
+    const link = try std.fmt.allocPrint(testing.allocator, "{s}/s.txt", .{root});
+    defer testing.allocator.free(link);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    try testing.expectEqualStrings(src, try test_io.readLinkAbsolute(std.Options.debug_io, link, &buf));
+}
+
+test "Pathname.install_symlink hash with multiple pairs links each" {
+    const root = try uniqueSandbox("install_symlink_multi");
+    defer testing.allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const ctx = mkCtx(root);
+    const s1 = try std.fmt.allocPrint(testing.allocator, "{s}/one", .{root});
+    defer testing.allocator.free(s1);
+    const s2 = try std.fmt.allocPrint(testing.allocator, "{s}/two", .{root});
+    defer testing.allocator.free(s2);
+    const dir = try std.fmt.allocPrint(testing.allocator, "{s}/etc", .{root});
+    defer testing.allocator.free(dir);
+    for ([_][]const u8{ s1, s2 }) |p| (try test_io.createFileAbsolute(std.Options.debug_io, p, .{})).close(std.Options.debug_io);
+
+    const pairs = [_]Value.HashPair{
+        .{ .key = .{ .pathname = s1 }, .value = .{ .string = "a.pem" } },
+        .{ .key = .{ .pathname = s2 }, .value = .{ .string = "b.pem" } },
+    };
+    const args = [_]Value{.{ .hash = &pairs }};
+    _ = try pathname.installSymlink(ctx, Value{ .pathname = dir }, &args);
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    for ([_]struct { name: []const u8, src: []const u8 }{
+        .{ .name = "a.pem", .src = s1 },
+        .{ .name = "b.pem", .src = s2 },
+    }) |entry| {
+        const link = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ dir, entry.name });
+        defer testing.allocator.free(link);
+        try testing.expectEqualStrings(entry.src, try test_io.readLinkAbsolute(std.Options.debug_io, link, &buf));
+    }
+}
+
+test "Pathname.install_symlink skips a hash entry with an empty link name" {
+    const root = try uniqueSandbox("install_symlink_emptyname");
+    defer testing.allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const ctx = mkCtx(root);
+    const src = try std.fmt.allocPrint(testing.allocator, "{s}/src", .{root});
+    defer testing.allocator.free(src);
+    (try test_io.createFileAbsolute(std.Options.debug_io, src, .{})).close(std.Options.debug_io);
+
+    // Empty link name must not create `<root>/` or crash — just skip.
+    const pairs = [_]Value.HashPair{.{ .key = .{ .pathname = src }, .value = .{ .string = "" } }};
+    const args = [_]Value{.{ .hash = &pairs }};
+    const v = try pathname.installSymlink(ctx, Value{ .pathname = root }, &args);
+    try testing.expect(v == .nil);
+}
+
+test "rm_f removes an array of paths and skips out-of-sandbox entries" {
+    const root = try uniqueSandbox("rm_f_array");
+    defer testing.allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const ctx = mkCtx(root);
+    const rm_f = @import("malt").dsl.builtins.bare_builtins.get("rm_f").?;
+    const good = try std.fmt.allocPrint(testing.allocator, "{s}/g.txt", .{root});
+    defer testing.allocator.free(good);
+    (try test_io.createFileAbsolute(std.Options.debug_io, good, .{})).close(std.Options.debug_io);
+
+    const items = [_]Value{ .{ .string = "/etc/passwd" }, .{ .string = good } };
+    _ = try rm_f(ctx, null, &.{.{ .array = &items }});
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(std.Options.debug_io, good, .{}));
+}
+
+test "rm_f rejects a single path outside the sandbox (force does not bypass the boundary)" {
+    const root = try uniqueSandbox("rm_f_violate");
+    defer testing.allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const ctx = mkCtx(root);
+    const rm_f = @import("malt").dsl.builtins.bare_builtins.get("rm_f").?;
+    try testing.expectError(error.PathSandboxViolation, rm_f(ctx, null, &.{.{ .string = "/etc/passwd" }}));
+}
+
+test "rm_f is registered as an alias of rm in the bare-builtin table" {
+    const dispatch = @import("malt").dsl.builtins.bare_builtins;
+    try testing.expect(dispatch.get("rm_f") != null);
+    try testing.expect(dispatch.get("rm") != null);
+}
+
+test "rm_f silently no-ops on a missing target inside the sandbox" {
+    const root = try uniqueSandbox("rm_f_missing");
+    defer testing.allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const ctx = mkCtx(root);
+    const rm_f = @import("malt").dsl.builtins.bare_builtins.get("rm_f").?;
+    const missing = try std.fmt.allocPrint(testing.allocator, "{s}/etc/cert.pem", .{root});
+    defer testing.allocator.free(missing);
+    const v = try rm_f(ctx, null, &.{.{ .string = missing }});
+    try testing.expect(v == .nil);
 }
 
 test "Pathname.glob with receiver returns matching entries" {

--- a/tests/dsl_install_symlink_test.zig
+++ b/tests/dsl_install_symlink_test.zig
@@ -1,0 +1,178 @@
+//! malt — DSL install_symlink integration test
+//! Drives a synthetic ca-certificates-shaped post_install body through the
+//! full pipeline (parser trailing-hash → interpreter dispatch → rm_f +
+//! Homebrew-shaped install_symlink) and asserts the symlink lands.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const test_io = @import("test_io");
+const dsl = malt.dsl;
+const formula_mod = malt.formula;
+
+fn minimalJson(alloc: std.mem.Allocator) ![]const u8 {
+    return std.fmt.allocPrint(alloc,
+        \\{{
+        \\  "name": "testpkg",
+        \\  "full_name": "testpkg",
+        \\  "tap": "homebrew/core",
+        \\  "desc": "test",
+        \\  "homepage": "https://example.com",
+        \\  "license": "MIT",
+        \\  "revision": 0,
+        \\  "keg_only": false,
+        \\  "post_install_defined": true,
+        \\  "versions": {{ "stable": "1.0", "head": null }},
+        \\  "dependencies": [],
+        \\  "oldnames": [],
+        \\  "bottle": {{ "stable": {{ "root_url": "https://example.com", "files": {{}} }} }}
+        \\}}
+    , .{});
+}
+
+/// Build `<prefix>/Cellar/testpkg/1.0`, `<prefix>/etc`, and the keg's
+/// `share/` (where the symlink source lives). Returns the owned prefix.
+fn makePrefix() ![]const u8 {
+    const tmp = std.testing.tmpDir(.{});
+    var buf: [test_io.max_path_bytes]u8 = undefined;
+    const n = try std.Io.Dir.realPath(tmp.dir, std.Options.debug_io, &buf);
+    const prefix = try testing.allocator.dupe(u8, buf[0..n]);
+
+    const cellar_share = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/testpkg/1.0/share", .{prefix});
+    defer testing.allocator.free(cellar_share);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cellar_share);
+
+    const etc = try std.fmt.allocPrint(testing.allocator, "{s}/etc", .{prefix});
+    defer testing.allocator.free(etc);
+    try test_io.cwd().createDirPath(std.Options.debug_io, etc);
+
+    // The source the post_install body symlinks to.
+    const src = try std.fmt.allocPrint(testing.allocator, "{s}/src.pem", .{cellar_share});
+    defer testing.allocator.free(src);
+    (try test_io.createFileAbsolute(std.Options.debug_io, src, .{})).close(std.Options.debug_io);
+
+    return prefix;
+}
+
+test "install_symlink: ca-certificates-shaped post_install lands the cert symlink" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const prefix = try makePrefix();
+    defer testing.allocator.free(prefix);
+
+    const json = try minimalJson(alloc);
+    var f = try formula_mod.parseFormula(alloc, json);
+    defer f.deinit();
+
+    var flog = dsl.FallbackLog.init(alloc);
+    defer flog.deinit();
+
+    const environ = malt.app_ctx.processEnviron();
+    var threaded: std.Io.Threaded = .init(alloc, .{ .environ = environ });
+    defer threaded.deinit();
+
+    // Exact shape of ca-certificates' post_install: rm_f a (missing) cert,
+    // then install_symlink the keg's bundle into etc under a fixed name.
+    const ruby_src =
+        \\rm_f etc/"cert.pem"
+        \\etc.install_symlink share/"src.pem" => "cert.pem"
+    ;
+
+    try dsl.executePostInstall(threaded.io(), environ, alloc, .{
+        .name = f.name,
+        .version = f.version,
+        .pkg_version = f.pkg_version,
+    }, ruby_src, prefix, &flog);
+
+    // rm_f on a missing target is a silent no-op — neither it nor
+    // install_symlink may be logged as unknown_method.
+    for (flog.entries.items) |entry| {
+        if (entry.reason == .unknown_method) {
+            std.debug.print("unexpected unknown_method: {s}\n", .{entry.detail});
+            return error.UnexpectedUnknownMethod;
+        }
+    }
+
+    // <prefix>/etc/cert.pem is a symlink to the keg's share/src.pem.
+    const link = try std.fmt.allocPrint(testing.allocator, "{s}/etc/cert.pem", .{prefix});
+    defer testing.allocator.free(link);
+    const expected = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/testpkg/1.0/share/src.pem", .{prefix});
+    defer testing.allocator.free(expected);
+
+    var buf: [test_io.max_path_bytes]u8 = undefined;
+    try testing.expectEqualStrings(expected, try test_io.readLinkAbsolute(std.Options.debug_io, link, &buf));
+}
+
+test "install_symlink: positional form lands the link by basename end-to-end" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const prefix = try makePrefix();
+    defer testing.allocator.free(prefix);
+
+    const json = try minimalJson(alloc);
+    var f = try formula_mod.parseFormula(alloc, json);
+    defer f.deinit();
+    var flog = dsl.FallbackLog.init(alloc);
+    defer flog.deinit();
+    const environ = malt.app_ctx.processEnviron();
+    var threaded: std.Io.Threaded = .init(alloc, .{ .environ = environ });
+    defer threaded.deinit();
+
+    // No `=>`: the link name is the basename of the source.
+    const ruby_src = "etc.install_symlink share/\"src.pem\"";
+    try dsl.executePostInstall(threaded.io(), environ, alloc, .{
+        .name = f.name,
+        .version = f.version,
+        .pkg_version = f.pkg_version,
+    }, ruby_src, prefix, &flog);
+
+    const link = try std.fmt.allocPrint(testing.allocator, "{s}/etc/src.pem", .{prefix});
+    defer testing.allocator.free(link);
+    const expected = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/testpkg/1.0/share/src.pem", .{prefix});
+    defer testing.allocator.free(expected);
+    var buf: [test_io.max_path_bytes]u8 = undefined;
+    try testing.expectEqualStrings(expected, try test_io.readLinkAbsolute(std.Options.debug_io, link, &buf));
+}
+
+test "install_symlink: rm_f clears a pre-existing regular file before relinking" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const prefix = try makePrefix();
+    defer testing.allocator.free(prefix);
+
+    // Pre-seed etc/cert.pem as a *regular file* — the stale state
+    // ca-certificates' `rm_f` is there to clear.
+    const stale = try std.fmt.allocPrint(testing.allocator, "{s}/etc/cert.pem", .{prefix});
+    defer testing.allocator.free(stale);
+    (try test_io.createFileAbsolute(std.Options.debug_io, stale, .{})).close(std.Options.debug_io);
+
+    const json = try minimalJson(alloc);
+    var f = try formula_mod.parseFormula(alloc, json);
+    defer f.deinit();
+    var flog = dsl.FallbackLog.init(alloc);
+    defer flog.deinit();
+    const environ = malt.app_ctx.processEnviron();
+    var threaded: std.Io.Threaded = .init(alloc, .{ .environ = environ });
+    defer threaded.deinit();
+
+    const ruby_src =
+        \\rm_f etc/"cert.pem"
+        \\etc.install_symlink share/"src.pem" => "cert.pem"
+    ;
+    try dsl.executePostInstall(threaded.io(), environ, alloc, .{
+        .name = f.name,
+        .version = f.version,
+        .pkg_version = f.pkg_version,
+    }, ruby_src, prefix, &flog);
+
+    // The regular file is gone; cert.pem is now the symlink.
+    var buf: [test_io.max_path_bytes]u8 = undefined;
+    const got = try test_io.readLinkAbsolute(std.Options.debug_io, stale, &buf);
+    try testing.expect(std.mem.endsWith(u8, got, "/share/src.pem"));
+}

--- a/tests/dsl_parser_test.zig
+++ b/tests/dsl_parser_test.zig
@@ -428,6 +428,136 @@ test "parser: hash literal" {
 }
 
 // ---------------------------------------------------------------------------
+// Implicit trailing hash literal at a method-call's argument position
+//
+// Homebrew's `ca-certificates` post_install is
+// `openssl_pkgetc.install_symlink pkgshare/"cacert.pem" => "cert.pem"`.
+// The parser must fold a brace-less `k => v[, k => v]*` tail into a
+// single trailing hash_literal arg so the builtin sees one Value.hash.
+// ---------------------------------------------------------------------------
+
+test "parser: brace-less trailing hash with two pairs in a paren call" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "foo(\"a\" => \"b\", \"c\" => \"d\")");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+
+    const mc = nodes[0].kind.method_call;
+    try testing.expectEqualStrings("foo", mc.method);
+    try testing.expectEqual(@as(usize, 1), mc.args.len);
+
+    const entries = mc.args[0].kind.hash_literal;
+    try testing.expectEqual(@as(usize, 2), entries.len);
+    try testing.expectEqualStrings("a", entries[0].key.kind.string_literal.parts[0].literal);
+    try testing.expectEqualStrings("b", entries[0].value.kind.string_literal.parts[0].literal);
+    try testing.expectEqualStrings("c", entries[1].key.kind.string_literal.parts[0].literal);
+    try testing.expectEqualStrings("d", entries[1].value.kind.string_literal.parts[0].literal);
+}
+
+test "parser: positional arg before a trailing hash" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "bar(1, \"k\" => \"v\")");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+
+    const mc = nodes[0].kind.method_call;
+    try testing.expectEqualStrings("bar", mc.method);
+    try testing.expectEqual(@as(usize, 2), mc.args.len);
+    try testing.expectEqual(@as(i64, 1), mc.args[0].kind.int_literal);
+
+    const entries = mc.args[1].kind.hash_literal;
+    try testing.expectEqual(@as(usize, 1), entries.len);
+    try testing.expectEqualStrings("k", entries[0].key.kind.string_literal.parts[0].literal);
+    try testing.expectEqualStrings("v", entries[0].value.kind.string_literal.parts[0].literal);
+}
+
+test "parser: brace-less trailing hash on a receiver call (install_symlink shape)" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    // Exact bare-arg shape from ca-certificates' post_install.
+    const nodes = try parseSource(&arena, "dir.install_symlink pkgshare/\"cacert.pem\" => \"cert.pem\"");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+
+    const mc = nodes[0].kind.method_call;
+    try testing.expectEqualStrings("install_symlink", mc.method);
+    try testing.expect(mc.receiver != null);
+    try testing.expectEqual(@as(usize, 1), mc.args.len);
+
+    const entries = mc.args[0].kind.hash_literal;
+    try testing.expectEqual(@as(usize, 1), entries.len);
+    // Key is the source path_join, value is the link name string.
+    switch (entries[0].key.kind) {
+        .path_join => {},
+        else => return error.TestUnexpectedResult,
+    }
+    try testing.expectEqualStrings("cert.pem", entries[0].value.kind.string_literal.parts[0].literal);
+}
+
+test "parser: trailing hash tolerates a trailing comma before the close" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "foo(\"a\" => \"b\",)");
+    const mc = nodes[0].kind.method_call;
+    try testing.expectEqual(@as(usize, 1), mc.args.len);
+    try testing.expectEqual(@as(usize, 1), mc.args[0].kind.hash_literal.len);
+}
+
+test "parser: trailing hash value may be a path_join expression" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "foo(\"k\" => share/\"v\")");
+    const entries = nodes[0].kind.method_call.args[0].kind.hash_literal;
+    try testing.expectEqual(@as(usize, 1), entries.len);
+    switch (entries[0].value.kind) {
+        .path_join => {},
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "parser: receiver call with positional arg then trailing hash" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "obj.m 1, \"k\" => \"v\"");
+    const mc = nodes[0].kind.method_call;
+    try testing.expectEqualStrings("m", mc.method);
+    try testing.expectEqual(@as(usize, 2), mc.args.len);
+    try testing.expectEqual(@as(i64, 1), mc.args[0].kind.int_literal);
+    try testing.expectEqual(@as(usize, 1), mc.args[1].kind.hash_literal.len);
+}
+
+test "parser: brace hash arg still parses (regression guard for the explicit form)" {
+    // The implicit-hash change must not regress the explicit `{ ... }`
+    // arg that already worked.
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "foo({ \"a\" => \"b\" })");
+    const mc = nodes[0].kind.method_call;
+    try testing.expectEqual(@as(usize, 1), mc.args.len);
+    try testing.expectEqual(@as(usize, 1), mc.args[0].kind.hash_literal.len);
+}
+
+test "parser: rm_f parses as a bare method call with one arg" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "rm_f \"some/path\"");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+
+    const mc = nodes[0].kind.method_call;
+    try testing.expectEqualStrings("rm_f", mc.method);
+    try testing.expect(mc.receiver == null);
+    try testing.expectEqual(@as(usize, 1), mc.args.len);
+    try testing.expectEqualStrings("some/path", mc.args[0].kind.string_literal.parts[0].literal);
+}
+
+// ---------------------------------------------------------------------------
 // Raise statement
 // ---------------------------------------------------------------------------
 
@@ -1263,6 +1393,11 @@ test "parser: corpus AST snapshot pins every primary form" {
             .want = "(method_call m=all? r=(identifier xs) &(symbol_literal :exist?))",
         },
         .{ .src = "name", .want = "(identifier name)" },
+        .{
+            // Brace-less trailing hash folds into one hash_literal arg.
+            .src = "foo(\"a\" => \"b\")",
+            .want = "(method_call m=foo (hash_literal {(string_literal L\"a\")=>(string_literal L\"b\")}))",
+        },
     };
 
     var buf: [2 * 1024]u8 = undefined;

--- a/tests/shellenv_test.zig
+++ b/tests/shellenv_test.zig
@@ -39,7 +39,7 @@ fn expectContains(haystack: []const u8, needle: []const u8) !void {
 }
 
 test "render bash exports brew-compatible env so third-party scripts keep working" {
-    const out = try shellenv.render(testing.allocator, .bash, "/opt/malt");
+    const out = try shellenv.render(testing.allocator, .bash, "/opt/malt", false);
     defer testing.allocator.free(out);
 
     try expectContains(out, "export HOMEBREW_PREFIX=\"/opt/malt\"");
@@ -55,15 +55,15 @@ test "render bash exports brew-compatible env so third-party scripts keep workin
 }
 
 test "render bash and zsh emit byte-identical output (single shared arm)" {
-    const bash = try shellenv.render(testing.allocator, .bash, "/opt/malt");
+    const bash = try shellenv.render(testing.allocator, .bash, "/opt/malt", false);
     defer testing.allocator.free(bash);
-    const zsh = try shellenv.render(testing.allocator, .zsh, "/opt/malt");
+    const zsh = try shellenv.render(testing.allocator, .zsh, "/opt/malt", false);
     defer testing.allocator.free(zsh);
     try testing.expectEqualStrings(bash, zsh);
 }
 
 test "render bash prepends malt's bin before \\$PATH so its binaries win" {
-    const out = try shellenv.render(testing.allocator, .bash, "/opt/malt");
+    const out = try shellenv.render(testing.allocator, .bash, "/opt/malt", false);
     defer testing.allocator.free(out);
     // Binary order matters: an `append` would let the existing PATH shadow
     // malt-installed tools.
@@ -73,7 +73,7 @@ test "render bash prepends malt's bin before \\$PATH so its binaries win" {
 }
 
 test "render bash terminates every line with `;\\n` so eval sees full statements" {
-    const out = try shellenv.render(testing.allocator, .bash, "/opt/malt");
+    const out = try shellenv.render(testing.allocator, .bash, "/opt/malt", false);
     defer testing.allocator.free(out);
     try testing.expect(out.len > 0);
     try testing.expect(std.mem.endsWith(u8, out, ";\n"));
@@ -85,7 +85,7 @@ test "render bash terminates every line with `;\\n` so eval sees full statements
 }
 
 test "render fish uses set -gx and avoids POSIX export syntax" {
-    const out = try shellenv.render(testing.allocator, .fish, "/opt/malt");
+    const out = try shellenv.render(testing.allocator, .fish, "/opt/malt", false);
     defer testing.allocator.free(out);
 
     try expectContains(out, "set -gx HOMEBREW_PREFIX \"/opt/malt\"");
@@ -99,8 +99,61 @@ test "render fish uses set -gx and avoids POSIX export syntax" {
     try testing.expect(std.mem.indexOf(u8, out, "${") == null);
 }
 
+test "render emits SSL_CERT_FILE only when the CA bundle is present" {
+    // Present: a single export line pointing at the canonical bundle.
+    const with = try shellenv.render(testing.allocator, .bash, "/opt/malt", true);
+    defer testing.allocator.free(with);
+    try expectContains(with, "export SSL_CERT_FILE=\"/opt/malt/etc/openssl@3/cert.pem\";");
+
+    // Absent: nothing — the var must never name a missing file.
+    const without = try shellenv.render(testing.allocator, .bash, "/opt/malt", false);
+    defer testing.allocator.free(without);
+    try testing.expect(std.mem.indexOf(u8, without, "SSL_CERT_FILE") == null);
+}
+
+test "render bash SSL_CERT_FILE line is terminated and follows INFOPATH" {
+    const out = try shellenv.render(testing.allocator, .bash, "/opt/malt", true);
+    defer testing.allocator.free(out);
+    // Must keep the `;\n` line-termination contract eval relies on.
+    try testing.expect(std.mem.endsWith(u8, out, ";\n"));
+    // Ordering: SSL_CERT_FILE comes after the brew-compatible block.
+    const info = std.mem.indexOf(u8, out, "INFOPATH").?;
+    const ssl = std.mem.indexOf(u8, out, "SSL_CERT_FILE").?;
+    try testing.expect(ssl > info);
+}
+
+test "render fish uses set -gx for SSL_CERT_FILE when present" {
+    const out = try shellenv.render(testing.allocator, .fish, "/opt/malt", true);
+    defer testing.allocator.free(out);
+    try expectContains(out, "set -gx SSL_CERT_FILE \"/opt/malt/etc/openssl@3/cert.pem\";");
+    // No POSIX export / brace-expansion sneaks in via the new line.
+    try testing.expect(std.mem.indexOf(u8, out, "export ") == null);
+}
+
+test "render bash and zsh stay byte-identical with SSL_CERT_FILE present" {
+    const bash = try shellenv.render(testing.allocator, .bash, "/opt/malt", true);
+    defer testing.allocator.free(bash);
+    const zsh = try shellenv.render(testing.allocator, .zsh, "/opt/malt", true);
+    defer testing.allocator.free(zsh);
+    try testing.expectEqualStrings(bash, zsh);
+}
+
+test "render with SSL_CERT_FILE present survives a tiny budget without corruption" {
+    // The new write path must also fail cleanly to OutOfMemory.
+    try testing.checkAllAllocationFailures(
+        testing.allocator,
+        struct {
+            fn run(a: std.mem.Allocator) !void {
+                const out = try shellenv.render(a, .bash, "/opt/malt", true);
+                a.free(out);
+            }
+        }.run,
+        .{},
+    );
+}
+
 test "render honors a non-default prefix" {
-    const out = try shellenv.render(testing.allocator, .bash, "/usr/local");
+    const out = try shellenv.render(testing.allocator, .bash, "/usr/local", false);
     defer testing.allocator.free(out);
 
     try expectContains(out, "export HOMEBREW_PREFIX=\"/usr/local\"");
@@ -111,7 +164,7 @@ test "render honors a non-default prefix" {
 test "render surfaces allocator failure rather than swallowing it" {
     try testing.expectError(
         error.OutOfMemory,
-        shellenv.render(testing.failing_allocator, .bash, "/opt/malt"),
+        shellenv.render(testing.failing_allocator, .bash, "/opt/malt", false),
     );
 }
 
@@ -121,7 +174,7 @@ test "render with a tiny budget eventually returns OutOfMemory, not corruption" 
         testing.allocator,
         struct {
             fn run(a: std.mem.Allocator) !void {
-                const out = try shellenv.render(a, .fish, "/opt/malt");
+                const out = try shellenv.render(a, .fish, "/opt/malt", false);
                 a.free(out);
             }
         }.run,


### PR DESCRIPTION
## Description

Brings malt's post_install DSL closer to Homebrew's contract on three fronts that real formulas depend on:

- **`rm_f`** is now a first-class builtin (alias of `rm`, which already swallows missing-file errors), so post_install bodies that force-remove a path no longer trip `unknown_method` and silently degrade.
- **`install_symlink` now matches Homebrew's semantics.** The receiver is the *target directory* and the argument names the *source*:
  - `dir.install_symlink source` links `<dir>/<basename(source)>`
  - `dir.install_symlink source => name` overrides the link name, and an array links each element. The previous implementation had source and target inverted, so it never matched Homebrew's contract - e.g. `openssl@3`'s `openssldir.install_symlink …/cert.pem` now lands the link where it belongs instead of writing nothing useful.
- **The parser accepts brace-less trailing hashes** at a method call's argument position (`f a => b, c => d`), folding them into a single hash argument - the shape Homebrew uses for `source => link_name`.

Two adjacent user-facing touches:

- `mt shellenv` now exports `SSL_CERT_FILE=<prefix>/etc/openssl@3/cert.pem` **only when that bundle is present**, so the variable never points at a missing file.
- `mt doctor` gains an informational **"SSL CA bundle"** row: clean when the bundle exists, and a `--verbose` remediation hint when it does not. It stays `.ok` (a fresh prefix without the bundle is a normal state, not a fault).

## Related Issue

- None

## Notes for Reviewers

- None