### PR TITLE
feat(core): provision the OpenSSL CA bundle natively so HTTPS works in a malt prefix

### DIFF
--- a/scripts/regressions/ssl_ca_bundle.sh
+++ b/scripts/regressions/ssl_ca_bundle.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Regression: a malt-only prefix provisions a complete OpenSSL CA bundle.
+#
+# Two gaps used to leave HTTPS broken in a fresh malt prefix:
+#   1. ca-certificates' macOS post_install regenerates the trust store
+#      from the system keychain — Ruby surface the native DSL can't run —
+#      so it landed no cert.pem.
+#   2. `Formula["ca-certificates"].pkgetc` resolved to <opt>/ca-certificates/etc
+#      instead of <prefix>/etc/ca-certificates, so openssl@3's post_install
+#      symlink dangled.
+#
+# This asserts the native fix end-to-end:
+#   * mt install ca-certificates → <prefix>/etc/ca-certificates/cert.pem is a
+#     symlink to the shipped cacert.pem and matches it by sha256.
+#   * mt install openssl@3 → <prefix>/etc/openssl@3/cert.pem resolves (no
+#     dangle) through to the same bundle and matches it by sha256.
+#
+# Usage: scripts/regressions/ssl_ca_bundle.sh
+# Requirements: built `malt` binary at $MALT_BIN or zig-out/bin/malt,
+# network access to ghcr.io / formulae.brew.sh.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be ≤ 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_ca"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+sha() { shasum -a 256 "$1" | awk '{print $1}'; }
+
+SHIPPED="$PREFIX/opt/ca-certificates/share/ca-certificates/cacert.pem"
+
+# ── 1. ca-certificates provisions etc/ca-certificates/cert.pem. ──────
+printf '▸ malt install ca-certificates\n'
+"$BIN" install ca-certificates >"$PREFIX/ca.log" 2>&1 || fail "install ca-certificates failed — see $PREFIX/ca.log"
+pass "installed ca-certificates"
+
+[[ -e "$SHIPPED" ]] || fail "keg shipped no cacert.pem at $SHIPPED"
+
+CA_CERT="$PREFIX/etc/ca-certificates/cert.pem"
+[[ -L "$CA_CERT" ]] || fail "$CA_CERT is not a symlink"
+[[ -e "$CA_CERT" ]] || fail "$CA_CERT dangles (target missing)"
+pass "etc/ca-certificates/cert.pem is a symlink that resolves"
+
+[[ "$(sha "$CA_CERT")" == "$(sha "$SHIPPED")" ]] ||
+  fail "etc/ca-certificates/cert.pem does not match the shipped cacert.pem by sha256"
+pass "etc/ca-certificates/cert.pem matches the shipped bundle by sha256"
+
+# ── 2. openssl@3 links etc/openssl@3/cert.pem through the chain. ─────
+printf '▸ malt install openssl@3\n'
+"$BIN" install openssl@3 >"$PREFIX/ossl.log" 2>&1 || fail "install openssl@3 failed — see $PREFIX/ossl.log"
+pass "installed openssl@3"
+
+OSSL_CERT="$PREFIX/etc/openssl@3/cert.pem"
+[[ -L "$OSSL_CERT" ]] || fail "$OSSL_CERT is not a symlink"
+[[ -e "$OSSL_CERT" ]] || fail "$OSSL_CERT dangles — the cross-formula pkgetc chain is broken"
+pass "etc/openssl@3/cert.pem is a symlink that resolves (no dangle)"
+
+[[ "$(sha "$OSSL_CERT")" == "$(sha "$SHIPPED")" ]] ||
+  fail "etc/openssl@3/cert.pem does not resolve to the shipped cacert.pem"
+pass "etc/openssl@3/cert.pem reaches the shipped bundle (sha256 match)"
+
+printf '\n✔ ssl ca-bundle provisioning regression passed\n'

--- a/scripts/smokes/smoke_ssl_python.sh
+++ b/scripts/smokes/smoke_ssl_python.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# scripts/smokes/smoke_ssl_python.sh
+#
+# End-to-end TLS smoke for a malt-only prefix. Proves that the native
+# CA-bundle provisioning makes real HTTPS verification succeed — not just
+# that the cert.pem files exist on disk (the ssl_ca_bundle regression
+# covers that), but that a fresh interpreter linked against the malt
+# openssl@3 can actually verify a live certificate chain.
+#
+# Slower than the regression (downloads python@3.14 + openssl@3 +
+# ca-certificates), so it lives under smokes/ rather than regressions/.
+#
+# Assertions:
+#   1. <prefix>/bin/python3.14 present.
+#   2. mt shellenv exports SSL_CERT_FILE (the provisioned bundle).
+#   3. python3.14 urlopen("https://api.github.com/") returns HTTP 200 —
+#      i.e. no CERTIFICATE_VERIFY_FAILED.
+#
+# Usage: scripts/smokes/smoke_ssl_python.sh
+# Requirements: built `malt` binary, network to formulae.brew.sh + ghcr.io
+# + api.github.com.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# Short prefix: python@3.14's Mach-O dependents are patched in place.
+PREFIX=$(mktemp -d /tmp/mt.XXX)
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+cleanup() { [[ "$PREFIX" == /tmp/mt.* ]] && rm -rf "$PREFIX"; }
+trap cleanup EXIT INT TERM
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+printf '▸ malt install python@3.14 ca-certificates (logs → %s)\n' "$PREFIX/install.log"
+"$BIN" install python@3.14 ca-certificates >"$PREFIX/install.log" 2>&1 ||
+  fail "install python@3.14 ca-certificates failed — see $PREFIX/install.log"
+pass "installed python@3.14 + ca-certificates"
+
+PY="$PREFIX/bin/python3.14"
+[[ -x "$PY" ]] || fail "$PY not found / not executable"
+pass "python3.14 present in PATH"
+
+# The user-facing TLS contract: shellenv hands the interpreter a bundle.
+eval "$("$BIN" shellenv bash)"
+[[ -n "${SSL_CERT_FILE:-}" ]] || fail "mt shellenv did not export SSL_CERT_FILE"
+[[ -e "$SSL_CERT_FILE" ]] || fail "SSL_CERT_FILE points at a missing bundle: $SSL_CERT_FILE"
+pass "mt shellenv exports SSL_CERT_FILE → $SSL_CERT_FILE"
+
+printf '▸ python3.14 urlopen https://api.github.com/\n'
+STATUS=$("$PY" -c 'import urllib.request; print(urllib.request.urlopen("https://api.github.com/").status)' 2>"$PREFIX/py.err") ||
+  {
+    cat "$PREFIX/py.err" >&2
+    fail "python urlopen raised — likely CERTIFICATE_VERIFY_FAILED"
+  }
+[[ "$STATUS" == "200" ]] || fail "expected HTTP 200, got '$STATUS'"
+pass "python3.14 verified a live HTTPS chain (status 200)"
+
+printf '\n✔ ssl python TLS smoke passed\n'

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1095,6 +1095,11 @@ fn executeWithOpts(
         if (job.post_install_defined) {
             drive(ctx, allocator, job.name, job.version_str, job.formula_json, prefix, use_system_ruby_list, &formula_cache);
         }
+
+        // ca-certificates' macOS post_install can't run natively, so the
+        // shipped Mozilla bundle is linked into etc/<name>/cert.pem here.
+        // No-op for every keg that ships no CA bundle.
+        post_install_mod.provisionShippedCaBundle(ctx.io, prefix, job.name);
     }
 
     if (failed_count > 0) {

--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -432,6 +432,33 @@ pub fn driveTap(
     );
 }
 
+/// ca-certificates' macOS post_install regenerates the trust store from
+/// the system keychain — Ruby surface the native DSL can't run, so it
+/// lands no `cert.pem`. Mirror the formula's own documented fallback
+/// natively: when a keg ships `share/<name>/cacert.pem` but post_install
+/// left `etc/<name>/cert.pem` absent, symlink the shipped Mozilla bundle
+/// into place. opt-anchored so the link survives version bumps; no-op for
+/// any keg that ships no CA bundle, and idempotent once it is present.
+pub fn provisionShippedCaBundle(io: std.Io, prefix: []const u8, name: []const u8) void {
+    var shipped_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const shipped = std.fmt.bufPrint(&shipped_buf, "{s}/opt/{s}/share/{s}/cacert.pem", .{ prefix, name, name }) catch return;
+    // Keg ships no CA bundle → nothing to provision.
+    std.Io.Dir.cwd().access(io, shipped, .{}) catch return;
+
+    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "{s}/etc/{s}/cert.pem", .{ prefix, name }) catch return;
+    // post_install (or a prior provision) already landed a bundle → leave it.
+    if (std.Io.Dir.cwd().access(io, dest, .{})) |_| return else |_| {}
+
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir = std.fmt.bufPrint(&dir_buf, "{s}/etc/{s}", .{ prefix, name }) catch return;
+    // Same non-raising fs contract as the DSL fs builtins: a failed link
+    // surfaces downstream (doctor/shellenv report the missing bundle).
+    std.Io.Dir.cwd().createDirPath(io, dir) catch return;
+    std.Io.Dir.cwd().deleteFile(io, dest) catch {}; // replace a stale dangling link
+    std.Io.Dir.symLinkAbsolute(io, shipped, dest, .{}) catch {};
+}
+
 test "extractRbPostInstallBody: returns the body when the .rb defines post_install" {
     const dir = "/tmp/malt_pi_decl_yes";
     std.Io.Dir.cwd().deleteTree(std.Options.debug_io, dir) catch {};
@@ -501,4 +528,89 @@ test "isSelfHostingRubyKeg: non-ruby kegs and lookalikes are rejected" {
     try std.testing.expect(!isSelfHostingRubyKeg("ruby@"));
     try std.testing.expect(!isSelfHostingRubyKeg("ruby@stable"));
     try std.testing.expect(!isSelfHostingRubyKeg("ruby@3-rc1"));
+}
+
+/// Lay down `<prefix>/opt/<name>/share/<name>/cacert.pem` with `content`,
+/// mimicking a freshly linked CA-bundle keg.
+fn writeShippedBundle(prefix: []const u8, name: []const u8, content: []const u8) !void {
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const share_dir = try std.fmt.bufPrint(&dir_buf, "{s}/opt/{s}/share/{s}", .{ prefix, name, name });
+    try std.Io.Dir.cwd().createDirPath(std.Options.debug_io, share_dir);
+    var f_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const shipped = try std.fmt.bufPrint(&f_buf, "{s}/cacert.pem", .{share_dir});
+    const f = try std.Io.Dir.createFileAbsolute(std.Options.debug_io, shipped, .{ .truncate = true });
+    try f.writeStreamingAll(std.Options.debug_io, content);
+    f.close(std.Options.debug_io);
+}
+
+test "provisionShippedCaBundle: links cert.pem to the shipped cacert.pem when absent" {
+    const prefix = "/tmp/malt_ca_provision_link";
+    std.Io.Dir.cwd().deleteTree(std.Options.debug_io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(std.Options.debug_io, prefix) catch {};
+    try writeShippedBundle(prefix, "ca-certificates", "MOZILLA-BUNDLE");
+
+    provisionShippedCaBundle(std.Options.debug_io, prefix, "ca-certificates");
+
+    // cert.pem now resolves (opt-anchored) to the shipped bundle.
+    const dest = prefix ++ "/etc/ca-certificates/cert.pem";
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try std.Io.Dir.cwd().readLink(std.Options.debug_io, dest, &buf);
+    try std.testing.expectEqualStrings(prefix ++ "/opt/ca-certificates/share/ca-certificates/cacert.pem", buf[0..n]);
+}
+
+test "provisionShippedCaBundle: leaves an existing cert.pem untouched" {
+    const prefix = "/tmp/malt_ca_provision_keep";
+    std.Io.Dir.cwd().deleteTree(std.Options.debug_io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(std.Options.debug_io, prefix) catch {};
+    try writeShippedBundle(prefix, "ca-certificates", "MOZILLA-BUNDLE");
+
+    // A post_install (or system-Ruby regeneration) already wrote a real bundle.
+    const etc_dir = prefix ++ "/etc/ca-certificates";
+    try std.Io.Dir.cwd().createDirPath(std.Options.debug_io, etc_dir);
+    const dest = etc_dir ++ "/cert.pem";
+    {
+        const f = try std.Io.Dir.createFileAbsolute(std.Options.debug_io, dest, .{ .truncate = true });
+        try f.writeStreamingAll(std.Options.debug_io, "REAL-KEYCHAIN-BUNDLE");
+        f.close(std.Options.debug_io);
+    }
+
+    provisionShippedCaBundle(std.Options.debug_io, prefix, "ca-certificates");
+
+    // Untouched: still the regular file we wrote, not replaced by a symlink.
+    const st = try std.Io.Dir.cwd().statFile(std.Options.debug_io, dest, .{});
+    try std.testing.expect(st.kind == .file);
+}
+
+test "provisionShippedCaBundle: no-op when the keg ships no cacert.pem" {
+    const prefix = "/tmp/malt_ca_provision_noop";
+    std.Io.Dir.cwd().deleteTree(std.Options.debug_io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(std.Options.debug_io, prefix);
+    defer std.Io.Dir.cwd().deleteTree(std.Options.debug_io, prefix) catch {};
+
+    provisionShippedCaBundle(std.Options.debug_io, prefix, "tree");
+
+    const dest = prefix ++ "/etc/tree/cert.pem";
+    if (std.Io.Dir.cwd().access(std.Options.debug_io, dest, .{})) |_| {
+        return error.TestUnexpectedResult; // a non-CA keg must not get a cert.pem
+    } else |_| {}
+}
+
+test "provisionShippedCaBundle: self-heals a stale dangling cert.pem symlink" {
+    const prefix = "/tmp/malt_ca_provision_dangle";
+    std.Io.Dir.cwd().deleteTree(std.Options.debug_io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(std.Options.debug_io, prefix) catch {};
+    try writeShippedBundle(prefix, "ca-certificates", "MOZILLA-BUNDLE");
+
+    // A prior install left cert.pem pointing at a now-removed target.
+    const etc_dir = prefix ++ "/etc/ca-certificates";
+    try std.Io.Dir.cwd().createDirPath(std.Options.debug_io, etc_dir);
+    const dest = etc_dir ++ "/cert.pem";
+    try std.Io.Dir.symLinkAbsolute(std.Options.debug_io, prefix ++ "/gone/cacert.pem", dest, .{});
+
+    provisionShippedCaBundle(std.Options.debug_io, prefix, "ca-certificates");
+
+    // Repointed at the shipped bundle rather than left dangling.
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try std.Io.Dir.cwd().readLink(std.Options.debug_io, dest, &buf);
+    try std.testing.expectEqualStrings(prefix ++ "/opt/ca-certificates/share/ca-certificates/cacert.pem", buf[0..n]);
 }

--- a/src/core/dsl/builtins/pathname.zig
+++ b/src/core/dsl/builtins/pathname.zig
@@ -187,10 +187,14 @@ pub fn optInclude(ctx: ExecCtx, receiver: ?Value, _: []const Value) BuiltinError
     return Value{ .pathname = joined };
 }
 
-/// pkgetc — receiver/"etc" (Formula accessor for pkgetc)
+/// pkgetc — `Formula[name].pkgetc` is `<prefix>/etc/<name>`, not
+/// `<opt>/<name>/etc`. The receiver is the opt anchor (`<prefix>/opt/<name>`),
+/// so re-anchor under malt_prefix using its basename as the package name.
+/// The bare current-formula `pkgetc` resolves through path bindings, not here.
 pub fn pkgetc(ctx: ExecCtx, receiver: ?Value, _: []const Value) BuiltinError!Value {
     const path = try receiverPath(ctx.allocator, receiver);
-    const joined = std.fs.path.join(ctx.allocator, &.{ path, "etc" }) catch return BuiltinError.OutOfMemory;
+    const name = std.fs.path.basename(path);
+    const joined = std.fs.path.join(ctx.allocator, &.{ ctx.malt_prefix, "etc", name }) catch return BuiltinError.OutOfMemory;
     return Value{ .pathname = joined };
 }
 
@@ -392,4 +396,39 @@ fn readFileAllAbsolute(io: std.Io, allocator: std.mem.Allocator, abs_path: []con
     @memcpy(shrunk, buf[0..n]);
     allocator.free(buf);
     return shrunk;
+}
+
+// ---------------------------------------------------------------------------
+// Inline tests
+// ---------------------------------------------------------------------------
+
+/// pkgetc only reads `allocator` + `malt_prefix`; the rest is structurally
+/// required by ExecCtx but never touched on this path.
+fn testCtx(allocator: std.mem.Allocator, malt_prefix: []const u8) ExecCtx {
+    return .{
+        .allocator = allocator,
+        .io = undefined,
+        .environ = undefined,
+        .cellar_path = "",
+        .malt_prefix = malt_prefix,
+    };
+}
+
+test "pkgetc re-anchors a Formula[] opt path to <prefix>/etc/<name>" {
+    // Homebrew's `Formula[name].pkgetc` is `<prefix>/etc/<name>`, not
+    // `<opt>/<name>/etc`. The receiver is the opt anchor, so pkgetc rebuilds
+    // under malt_prefix; the bare current-formula pkgetc uses path bindings.
+    const ctx = testCtx(std.testing.allocator, "/opt/malt");
+    const etc = try pkgetc(ctx, Value{ .pathname = "/opt/malt/opt/ca-certificates" }, &.{});
+    defer std.testing.allocator.free(etc.pathname);
+    try std.testing.expectEqualStrings("/opt/malt/etc/ca-certificates", etc.pathname);
+}
+
+test "pkgetc keeps an @-versioned formula name intact" {
+    // openssl@3 et al. carry `@` in the keg name; the basename re-anchor
+    // must preserve it verbatim.
+    const ctx = testCtx(std.testing.allocator, "/opt/malt");
+    const etc = try pkgetc(ctx, Value{ .pathname = "/opt/malt/opt/openssl@3" }, &.{});
+    defer std.testing.allocator.free(etc.pathname);
+    try std.testing.expectEqualStrings("/opt/malt/etc/openssl@3", etc.pathname);
 }

--- a/tests/dsl_builtins_test.zig
+++ b/tests/dsl_builtins_test.zig
@@ -195,7 +195,7 @@ test "Pathname.basename/.dirname/.extname/.toS expose path components" {
     try testing.expectEqualStrings("/x/y", (try pathname.toS(ctx, Value{ .pathname = "/x/y" }, &.{})).string);
 }
 
-test "Pathname.opt_bin/.opt_lib/.opt_include/.pkgetc append the right subdir" {
+test "Pathname.opt_bin/.opt_lib/.opt_include append the right subdir" {
     const ctx = mkCtx("/tmp/malt");
     const v = Value{ .pathname = "/opt/malt/opt/foo" };
 
@@ -210,10 +210,6 @@ test "Pathname.opt_bin/.opt_lib/.opt_include/.pkgetc append the right subdir" {
     const inc = try pathname.optInclude(ctx, v, &.{});
     defer testing.allocator.free(inc.pathname);
     try testing.expectEqualStrings("/opt/malt/opt/foo/include", inc.pathname);
-
-    const etc = try pathname.pkgetc(ctx, v, &.{});
-    defer testing.allocator.free(etc.pathname);
-    try testing.expectEqualStrings("/opt/malt/opt/foo/etc", etc.pathname);
 }
 
 test "Pathname.unlink deletes a file in the sandbox" {

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -1332,6 +1332,33 @@ test "coverage: install_symlink creates link" {
     try testing.expect(err == null);
 }
 
+test "coverage: openssl@3 chain links etc/openssl@3/cert.pem to a sibling formula's pkgetc" {
+    // openssl@3's post_install runs
+    //   openssldir.install_symlink Formula["ca-certificates"].pkgetc/"cert.pem"
+    // The link target must resolve to <prefix>/etc/ca-certificates/cert.pem,
+    // proving the cross-formula pkgetc re-anchor lands a valid (non-dangling
+    // shape) symlink rather than <opt>/ca-certificates/etc/cert.pem.
+    var arena = testArena();
+    defer arena.deinit();
+
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    const src = "(etc/\"openssl@3\").install_symlink Formula[\"ca-certificates\"].pkgetc/\"cert.pem\"";
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
+
+    const link = try std.fs.path.join(testing.allocator, &.{ prefix, "etc", "openssl@3", "cert.pem" });
+    defer testing.allocator.free(link);
+    var buf: [test_io.max_path_bytes]u8 = undefined;
+    const n = try std.Io.Dir.cwd().readLink(std.Options.debug_io, link, &buf);
+    const target = buf[0..n];
+
+    const want = try std.fs.path.join(testing.allocator, &.{ prefix, "etc", "ca-certificates", "cert.pem" });
+    defer testing.allocator.free(want);
+    try testing.expectEqualStrings(want, target);
+}
+
 // ---------------------------------------------------------------------------
 // Coverage gap tests — UI
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Makes HTTPS actually work in a malt-only prefix. Before this, a fresh prefix could install `ca-certificates` and `openssl@3` and still fail every TLS handshake with `CERTIFICATE_VERIFY_FAILED`, because no usable CA bundle ever landed on disk. Two native gaps caused it, both closed here:

- **The trust store was never written.** `ca-certificates`' macOS `post_install` regenerates the bundle from the system keychain - Ruby surface the native DSL can't run - so it completed with zero unknowns while producing no `cert.pem`. Now, after a `ca-certificates` install, malt materialises the shipped Mozilla bundle (`share/ca-certificates/cacert.pem`) into `etc/ca-certificates/cert.pem` natively, mirroring the formula's own documented fallback. The seam keys on a keg shipping `share/<name>/cacert.pem`, not a hard-coded formula name, and is a no-op for every keg that ships no CA bundle.

- **`openssl@3`'s link pointed at the wrong place.** Cross-formula `Formula["ca-certificates"].pkgetc` resolved to `<opt>/ca-certificates/etc` instead of Homebrew's `<prefix>/etc/ca-certificates`, so `openssl@3`'s `post_install` symlink dangled. `pkgetc` on a `Formula[name]` result now re-anchors to `<prefix>/etc/<name>` (the bare current-formula `pkgetc` is unchanged). 

The provisioned link is opt-anchored so it survives version bumps and self-heals a stale dangling link on reinstall.

## Related Issue

- None

## Notes for Reviewers

- None
