### PR TITLE
refactor(net/client): extract HttpClientPool to its own module

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -166,6 +166,7 @@ pub fn build(b: *std.Build) void {
         "tests/spawn_invariant_test.zig",
         "tests/child_test.zig",
         "tests/net_client_test.zig",
+        "tests/net_client_pool_test.zig",
         "tests/term_sanitize_test.zig",
         "tests/perms_test.zig",
         "tests/doctor_render_test.zig",

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -81,6 +81,7 @@ pub const parser = @import("macho/parser.zig");
 pub const patcher = @import("macho/patcher.zig");
 pub const api = @import("net/api.zig");
 pub const client = @import("net/client.zig");
+pub const client_pool = @import("net/client_pool.zig");
 pub const ghcr = @import("net/ghcr.zig");
 pub const mirror = @import("net/mirror.zig");
 pub const offline = @import("net/offline.zig");

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -831,75 +831,9 @@ fn formatUri(allocator: std.mem.Allocator, uri: std.Uri) ![]const u8 {
     return std.fmt.allocPrint(allocator, "{s}://{s}{s}", .{ scheme, host, path });
 }
 
-/// Thread-safe borrow/return pool of `HttpClient`s. `std.http.Client` is
-/// not thread-safe, but per-request construction pays the full TLS
-/// handshake every time; pooling preserves no-sharing while reusing
-/// connections across the hot phase of an install.
-pub const HttpClientPool = struct {
-    io: std.Io,
-    allocator: std.mem.Allocator,
-    clients: []HttpClient,
-    busy: []bool,
-    mutex: std.Io.Mutex,
-    cond: std.Io.Condition,
-
-    pub fn init(io: std.Io, environ: std.process.Environ, allocator: std.mem.Allocator, size: usize) !HttpClientPool {
-        const clients = try allocator.alloc(HttpClient, size);
-        errdefer allocator.free(clients);
-        const busy = try allocator.alloc(bool, size);
-        errdefer allocator.free(busy);
-        @memset(busy, false);
-        for (clients) |*c| c.* = HttpClient.init(io, environ, allocator);
-        return .{
-            .io = io,
-            .allocator = allocator,
-            .clients = clients,
-            .busy = busy,
-            .mutex = .init,
-            .cond = .init,
-        };
-    }
-
-    pub fn deinit(self: *HttpClientPool) void {
-        for (self.clients) |*c| c.deinit();
-        self.allocator.free(self.clients);
-        self.allocator.free(self.busy);
-    }
-
-    /// Block until idle, mark busy, return exclusive pointer until `release`.
-    pub fn acquire(self: *HttpClientPool) *HttpClient {
-        self.mutex.lockUncancelable(self.io);
-        defer self.mutex.unlock(self.io);
-        while (true) {
-            for (self.busy, 0..) |b, i| {
-                if (!b) {
-                    self.busy[i] = true;
-                    return &self.clients[i];
-                }
-            }
-            self.cond.waitUncancelable(self.io, &self.mutex);
-        }
-    }
-
-    /// Mirror `offline` onto every pooled client. Cli/ call sites use
-    /// this right after `init` so workers borrowed under offline mode
-    /// short-circuit with `OfflineRequired` rather than dialing out.
-    pub fn setOfflineAll(self: *HttpClientPool, offline: bool) void {
-        for (self.clients) |*c| c.offline = offline;
-    }
-
-    /// Return an acquired client; foreign pointers are a programmer error.
-    pub fn release(self: *HttpClientPool, client: *HttpClient) void {
-        self.mutex.lockUncancelable(self.io);
-        defer self.mutex.unlock(self.io);
-        const base = @intFromPtr(self.clients.ptr);
-        const addr = @intFromPtr(client);
-        const idx = (addr - base) / @sizeOf(HttpClient);
-        std.debug.assert(idx < self.clients.len);
-        self.busy[idx] = false;
-        self.cond.signal(self.io);
-    }
-};
+/// Pool now lives in `net/client_pool.zig`; re-exported for one release
+/// so existing `client_mod.HttpClientPool` callers keep resolving.
+pub const HttpClientPool = @import("client_pool.zig").HttpClientPool;
 
 test "extractEtagFromHead: finds ETag header by exact name" {
     const bytes = "200 OK\r\nServer: github\r\nETag: \"abc123\"\r\nContent-Length: 0\r\n\r\n";

--- a/src/net/client_pool.zig
+++ b/src/net/client_pool.zig
@@ -1,0 +1,153 @@
+//! Borrow/return pool of `HttpClient`s, split out of `net/client.zig`
+//! so pool-only tests link here without dragging in the idle-watchdog
+//! and redirect state machines that live alongside `HttpClient`.
+
+const std = @import("std");
+const client_mod = @import("client.zig");
+
+/// Re-exported so pool consumers name the borrowed type without also
+/// importing `net/client`.
+pub const HttpClient = client_mod.HttpClient;
+
+/// Thread-safe borrow/return pool of `HttpClient`s. `std.http.Client` is
+/// not thread-safe, but per-request construction pays the full TLS
+/// handshake every time; pooling preserves no-sharing while reusing
+/// connections across the hot phase of an install.
+pub const HttpClientPool = struct {
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    clients: []HttpClient,
+    busy: []bool,
+    mutex: std.Io.Mutex,
+    cond: std.Io.Condition,
+
+    pub fn init(io: std.Io, environ: std.process.Environ, allocator: std.mem.Allocator, size: usize) !HttpClientPool {
+        const clients = try allocator.alloc(HttpClient, size);
+        errdefer allocator.free(clients);
+        const busy = try allocator.alloc(bool, size);
+        errdefer allocator.free(busy);
+        @memset(busy, false);
+        for (clients) |*c| c.* = HttpClient.init(io, environ, allocator);
+        return .{
+            .io = io,
+            .allocator = allocator,
+            .clients = clients,
+            .busy = busy,
+            .mutex = .init,
+            .cond = .init,
+        };
+    }
+
+    pub fn deinit(self: *HttpClientPool) void {
+        for (self.clients) |*c| c.deinit();
+        self.allocator.free(self.clients);
+        self.allocator.free(self.busy);
+    }
+
+    /// Block until idle, mark busy, return exclusive pointer until `release`.
+    pub fn acquire(self: *HttpClientPool) *HttpClient {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        while (true) {
+            for (self.busy, 0..) |b, i| {
+                if (!b) {
+                    self.busy[i] = true;
+                    return &self.clients[i];
+                }
+            }
+            self.cond.waitUncancelable(self.io, &self.mutex);
+        }
+    }
+
+    /// Mirror `offline` onto every pooled client. Cli/ call sites use
+    /// this right after `init` so workers borrowed under offline mode
+    /// short-circuit with `OfflineRequired` rather than dialing out.
+    pub fn setOfflineAll(self: *HttpClientPool, offline: bool) void {
+        for (self.clients) |*c| c.offline = offline;
+    }
+
+    /// Return an acquired client; foreign pointers are a programmer error.
+    pub fn release(self: *HttpClientPool, client: *HttpClient) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        const base = @intFromPtr(self.clients.ptr);
+        const addr = @intFromPtr(client);
+        const idx = (addr - base) / @sizeOf(HttpClient);
+        std.debug.assert(idx < self.clients.len);
+        self.busy[idx] = false;
+        self.cond.signal(self.io);
+    }
+};
+
+// Pure allocator + mutex bookkeeping — no network — so the pool is fully
+// unit-testable without HTTP traffic. The blocking cond.wait branch needs
+// a second thread and lives in tests/progress_test.zig.
+
+const testing = std.testing;
+const test_io = std.Options.debug_io;
+const empty_env = std.process.Environ.empty;
+
+test "init seeds size clients, all idle" {
+    var pool = try HttpClientPool.init(test_io, empty_env, testing.allocator, 3);
+    defer pool.deinit();
+    try testing.expectEqual(@as(usize, 3), pool.clients.len);
+    for (pool.busy) |b| try testing.expect(!b);
+}
+
+test "acquire marks busy; release returns the same slot for reuse" {
+    var pool = try HttpClientPool.init(test_io, empty_env, testing.allocator, 1);
+    defer pool.deinit();
+
+    const c1 = pool.acquire();
+    try testing.expect(pool.busy[0]);
+    pool.release(c1);
+    try testing.expect(!pool.busy[0]);
+    // Sole slot is reused, not leaked into a phantom second client.
+    const c2 = pool.acquire();
+    try testing.expectEqual(c1, c2);
+    pool.release(c2);
+}
+
+test "acquire hands out distinct clients while several are borrowed" {
+    var pool = try HttpClientPool.init(test_io, empty_env, testing.allocator, 2);
+    defer pool.deinit();
+
+    const a = pool.acquire();
+    const b = pool.acquire();
+    try testing.expect(a != b);
+    pool.release(a);
+    pool.release(b);
+}
+
+test "deinit cleans up a zero-use pool" {
+    var pool = try HttpClientPool.init(test_io, empty_env, testing.allocator, 1);
+    pool.deinit();
+}
+
+test "setOfflineAll mirrors the flag onto every pooled client" {
+    var pool = try HttpClientPool.init(test_io, empty_env, testing.allocator, 3);
+    defer pool.deinit();
+
+    pool.setOfflineAll(true);
+    for (pool.clients) |c| try testing.expect(c.offline);
+    // Toggling back must clear it everywhere too.
+    pool.setOfflineAll(false);
+    for (pool.clients) |c| try testing.expect(!c.offline);
+}
+
+test "init propagates allocator failure on the first allocation" {
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    try testing.expectError(
+        error.OutOfMemory,
+        HttpClientPool.init(test_io, empty_env, failing.allocator(), 2),
+    );
+}
+
+test "init propagates allocator failure on the second allocation" {
+    // Failing the `busy` alloc exercises the errdefer that frees `clients`.
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 1 });
+    try testing.expectError(
+        error.OutOfMemory,
+        HttpClientPool.init(test_io, empty_env, failing.allocator(), 2),
+    );
+}

--- a/tests/net_client_pool_test.zig
+++ b/tests/net_client_pool_test.zig
@@ -1,0 +1,18 @@
+//! malt — net/client_pool seam test
+//! Guards the public module boundary: a consumer can borrow and return
+//! `HttpClient`s through `malt.client_pool` alone, without importing the
+//! full `net/client` surface (and its idle-watchdog / redirect machinery).
+//! Pool behaviour itself is unit-tested inline in src/net/client_pool.zig.
+
+const std = @import("std");
+const testing = std.testing;
+const pool_mod = @import("malt").client_pool;
+
+test "client_pool exposes a usable pool + borrowed HttpClient via its own module" {
+    var pool = try pool_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
+    defer pool.deinit();
+
+    const c: *pool_mod.HttpClient = pool.acquire();
+    try testing.expect(!c.offline); // borrowed client is the real type, default online
+    pool.release(c);
+}

--- a/tests/offline_mode_test.zig
+++ b/tests/offline_mode_test.zig
@@ -67,21 +67,8 @@ test "HttpClient.OfflineRequired is non-transient" {
     try testing.expect(!client_mod.isTransientError(error.OfflineRequired));
 }
 
-// ── HttpClientPool propagation ───────────────────────────────────────
-
-test "HttpClientPool.setOfflineAll mirrors the flag onto every pooled client" {
-    var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 3);
-    defer pool.deinit();
-    pool.setOfflineAll(true);
-
-    // Acquire each in turn; release order doesn't matter here — we just
-    // want to read every client's `offline` field once.
-    var seen: [3]*client_mod.HttpClient = undefined;
-    for (0..3) |i| seen[i] = pool.acquire();
-    defer for (seen) |c| pool.release(c);
-
-    for (seen) |c| try testing.expect(c.offline);
-}
+// `HttpClientPool.setOfflineAll` propagation is unit-tested inline in
+// net/client_pool.zig; the offline composition path is covered below.
 
 // ── BrewApi end-to-end: cache hit serves under offline ───────────────
 

--- a/tests/progress_test.zig
+++ b/tests/progress_test.zig
@@ -388,28 +388,12 @@ test "output verbose/dryrun/mode setters and getters round-trip" {
     try testing.expect(!output_mod.isJson());
 }
 
-// --- HttpClientPool coverage ---
+// --- HttpClientPool concurrency coverage ---
 //
-// The pool itself is pure allocator + mutex bookkeeping — no network —
-// so we can exercise init/acquire/release/deinit without HTTP traffic.
-
-test "HttpClientPool acquire and release cycle a single client" {
-    var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 2);
-    defer pool.deinit();
-
-    const c1 = pool.acquire();
-    const c2 = pool.acquire();
-    // Both slots are in use — release c1 and re-acquire to flip busy back.
-    pool.release(c1);
-    const c3 = pool.acquire();
-    pool.release(c2);
-    pool.release(c3);
-}
-
-test "HttpClientPool deinit cleans up a zero-use pool" {
-    var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
-    pool.deinit();
-}
+// Deterministic pool bookkeeping is unit-tested inline in
+// net/client_pool.zig. The blocking cond.wait branch needs a second
+// thread, so it lives here; it also keeps the client.zig re-export
+// exercised through `client_mod.HttpClientPool`.
 
 test "HttpClientPool blocks acquire when all clients are busy" {
     var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
@@ -464,16 +448,6 @@ test "Response.deinit frees the owned body buffer" {
 // injection branch in HttpClient.get().
 extern fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
 extern fn unsetenv(name: [*:0]const u8) c_int;
-
-test "HttpClientPool.init propagates allocator failure on the second allocation" {
-    // The pool allocates two slices — clients and busy. Failing on the
-    // second alloc exercises the errdefer branch that frees the first one.
-    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 1 });
-    try testing.expectError(
-        error.OutOfMemory,
-        client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, failing.allocator(), 2),
-    );
-}
 
 test "HttpClient.get retries on a 503 response status" {
     // httpbin.org/status/503 returns a deterministic 503 which is one of


### PR DESCRIPTION
## Description

Splits the HTTP client pool out of `net/client.zig` into its own `net/client_pool.zig` module.

Pool behaviour is unchanged and the bottle download hot path is byte-for-byte identical - the value is a cleaner boundary: pool-only tests now link the pool alone, without dragging in the idle-watchdog and redirect state machines that live next to `HttpClient`, and the upcoming HTTP test-injection seam has a smaller surface to migrate.

A one-release re-export from `client.zig` keeps every existing call site resolving unchanged.

## Related Issue

- None

## Notes for Reviewers

- Pure structural move.
- Pool bookkeeping is now unit-tested inline in `net/client_pool.zig` (acquire/release reuse, distinct borrows, zero-use deinit, offline propagation, and allocator-failure on both allocations). The blocking cond.wait branch stays in `tests/progress_test.zig` (needs a second thread) and keeps the re-export exercised; `tests/net_client_pool_test.zig` is a focused seam test that imports only `malt.client_pool`.
