### PR TITLE
refactor(net/client): add HttpClient.initWith for test injection

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -167,6 +167,7 @@ pub fn build(b: *std.Build) void {
         "tests/child_test.zig",
         "tests/net_client_test.zig",
         "tests/net_client_pool_test.zig",
+        "tests/http_inject_test.zig",
         "tests/term_sanitize_test.zig",
         "tests/perms_test.zig",
         "tests/doctor_render_test.zig",

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -267,11 +267,26 @@ pub const HttpClient = struct {
     const blob_timeout_ns: u64 = 600 * std.time.ns_per_s; // 10 minutes
 
     pub fn init(io: std.Io, environ: std.process.Environ, allocator: std.mem.Allocator) HttpClient {
+        var c: std.http.Client = .{ .allocator = allocator, .io = io };
+        return initWith(&c, io, environ, allocator);
+    }
+
+    /// Injection seam for offline tests: takes an externally-built
+    /// `std.http.Client` (e.g. pointed at a localhost `std.http.Server`)
+    /// so HTTP-using commands run without a process-level network mock.
+    /// The client is copied in and owned thereafter — `deinit` frees it,
+    /// so callers must not deinit the passed-in client separately.
+    pub fn initWith(
+        client: *std.http.Client,
+        io: std.Io,
+        environ: std.process.Environ,
+        allocator: std.mem.Allocator,
+    ) HttpClient {
         return .{
             .io = io,
             .environ = environ,
             .allocator = allocator,
-            .client = .{ .allocator = allocator, .io = io },
+            .client = client.*,
         };
     }
 
@@ -897,6 +912,43 @@ test "ConditionalResponse.deinit: 304 path with empty body frees correctly" {
         .allocator = std.testing.allocator,
     };
     cr.deinit();
+}
+
+test "HttpClient.initWith: injected client is copied in, distinct from the struct allocator" {
+    // Build the client with one allocator and pass a *different* one as the
+    // struct allocator. The seam must keep the injected client's allocator
+    // (proving it copied the client, not rebuilt it from the param) while the
+    // struct's own allocator tracks the param.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const struct_alloc = arena.allocator();
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = std.Options.debug_io };
+    var http = HttpClient.initWith(&inner, std.Options.debug_io, std.process.Environ.empty, struct_alloc);
+    defer http.deinit();
+    try std.testing.expectEqual(std.testing.allocator.ptr, http.client.allocator.ptr);
+    try std.testing.expectEqual(struct_alloc.ptr, http.allocator.ptr);
+    try std.testing.expect(http.client.allocator.ptr != http.allocator.ptr);
+}
+
+test "HttpClient.initWith: preserves field defaults" {
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = std.Options.debug_io };
+    var http = HttpClient.initWith(&inner, std.Options.debug_io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+    try std.testing.expect(!http.offline);
+    try std.testing.expectEqual(HttpClient.default_timeout_ns, http.timeout_ns);
+    try std.testing.expectEqual(@as(?*const fn () bool, null), http.cancel);
+    try std.testing.expectEqual(@as(?[]u8, null), http.zstd_window);
+    try std.testing.expectEqual(@as(?[]u8, null), http.flate_window);
+}
+
+test "HttpClient.init: delegates to initWith without losing defaults" {
+    // Pins the refactor: init now builds its own client and forwards to
+    // initWith — the defaults the production path relies on must survive.
+    var http = HttpClient.init(std.Options.debug_io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+    try std.testing.expect(!http.offline);
+    try std.testing.expectEqual(HttpClient.default_timeout_ns, http.timeout_ns);
+    try std.testing.expectEqual(std.testing.allocator.ptr, http.client.allocator.ptr);
 }
 
 test "HttpClient.offline defaults to false" {

--- a/tests/http_inject_test.zig
+++ b/tests/http_inject_test.zig
@@ -1,0 +1,85 @@
+//! malt — offline integration test for `HttpClient.initWith`.
+//! Stands up a localhost `std.http.Server` on an ephemeral port and
+//! exercises the same HTTP operations doctor's API-reachable probe
+//! uses (HEAD → status) plus a GET body round-trip — proving an HTTP
+//! consumer runs end-to-end without touching the real network.
+
+const std = @import("std");
+const client = @import("malt").client;
+const net = std.Io.net;
+
+const body_json = "{\"tag_name\":\"v9.9.9\"}";
+
+const Fixture = struct {
+    io: std.Io,
+    listener: *net.Server,
+};
+
+// Serves exactly one request, then closes the connection. Errors are
+// swallowed: a failed serve surfaces as a client-side failure in the
+// test thread, which fails the assertion loudly there.
+fn serveOnce(fx: *Fixture) void {
+    const stream = fx.listener.accept(fx.io) catch return;
+    defer stream.close(fx.io);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var reader = stream.reader(fx.io, &rbuf);
+    var writer = stream.writer(fx.io, &wbuf);
+    var srv = std.http.Server.init(&reader.interface, &writer.interface);
+    var req = srv.receiveHead() catch return;
+    req.respond(body_json, .{}) catch return;
+}
+
+test "HttpClient.initWith: GET round-trips a body from a localhost server (offline)" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var fx = Fixture{ .io = io, .listener = &listener };
+    const server_thread = try std.Thread.spawn(.{}, serveOnce, .{&fx});
+    defer server_thread.join();
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/releases/latest", .{port});
+
+    // The injected client is owned by HttpClient after initWith copies it
+    // in (same as init), so the caller must not deinit `inner` separately.
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    var resp = try http.get(url);
+    defer resp.deinit();
+    try std.testing.expectEqual(@as(u16, 200), resp.status);
+    try std.testing.expectEqualStrings(body_json, resp.body);
+}
+
+test "HttpClient.initWith: HEAD probe returns the server status (doctor's API-reachable path)" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var fx = Fixture{ .io = io, .listener = &listener };
+    const server_thread = try std.Thread.spawn(.{}, serveOnce, .{&fx});
+    defer server_thread.join();
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/health", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    const status = try http.head(url);
+    try std.testing.expectEqual(@as(u16, 200), status);
+}


### PR DESCRIPTION
## Description

Opens a constructor-only injection seam on `HttpClient` so HTTP-using commands can be exercised offline, end-to-end, against a localhost `std.http.Server`. `init` keeps its convenience signature and now delegates to the new `initWith`, so every existing call site and the production request path are unchanged.

## Related Issue

- None

## Notes for Reviewers

- None
