### PR TITLE
refactor(net): import HttpClientPool from its own module and drop the client shim

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -26,6 +26,7 @@ const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
 const api_mod = @import("../net/api.zig");
 const client_mod = @import("../net/client.zig");
+const pool_mod = @import("../net/client_pool.zig");
 const ghcr_mod = @import("../net/ghcr.zig");
 const output = @import("../ui/output.zig");
 const progress_mod = @import("../ui/progress.zig");
@@ -626,7 +627,7 @@ fn executeWithOpts(
 
     // 4-slot worker pool — same budget as the materialize pool; enough to
     // saturate cold installs while reusing TLS contexts.
-    var http_pool = client_mod.HttpClientPool.init(ctx.io, ctx.environ, allocator, 4) catch {
+    var http_pool = pool_mod.HttpClientPool.init(ctx.io, ctx.environ, allocator, 4) catch {
         output.err("Failed to initialise HTTP client pool", .{});
         return InstallError.DownloadFailed;
     };

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -15,6 +15,7 @@ const sqlite = @import("../../db/sqlite.zig");
 const atomic = @import("../../fs/atomic.zig");
 const api_mod = @import("../../net/api.zig");
 const client_mod = @import("../../net/client.zig");
+const pool_mod = @import("../../net/client_pool.zig");
 const ghcr_mod = @import("../../net/ghcr.zig");
 const output = @import("../../ui/output.zig");
 const progress_mod = @import("../../ui/progress.zig");
@@ -29,7 +30,7 @@ pub const InstallJobDeps = struct {
     io: std.Io,
     allocator: std.mem.Allocator,
     api: *api_mod.BrewApi,
-    http_pool: *client_mod.HttpClientPool,
+    http_pool: *pool_mod.HttpClientPool,
     db: *sqlite.Database,
     store: *store_mod.Store,
     /// Shared parsed-formula cache for the whole install run.
@@ -123,7 +124,7 @@ pub fn isDeterministicDownloadError(err: bottle_mod.BottleError) bool {
 const FetchFormulaCtx = struct {
     io: std.Io,
     arena: std.heap.ArenaAllocator,
-    pool: *client_mod.HttpClientPool,
+    pool: *pool_mod.HttpClientPool,
     cache_dir: []const u8,
     /// Snapshot of `api.base_url` so workers inherit the mirror
     /// override without re-reading the env on a worker thread.
@@ -688,7 +689,7 @@ pub const InstallPool = struct {
     jobs: []DownloadJob,
     prefix: []const u8,
     ghcr: *ghcr_mod.GhcrClient,
-    http_pool: *client_mod.HttpClientPool,
+    http_pool: *pool_mod.HttpClientPool,
     store: *store_mod.Store,
     cache: *deps_mod.FormulaCache,
     results: []MaterializeResult,

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -17,6 +17,7 @@ const atomic = @import("../fs/atomic.zig");
 const codesign = @import("../macho/codesign.zig");
 const api_mod = @import("../net/api.zig");
 const client_mod = @import("../net/client.zig");
+const pool_mod = @import("../net/client_pool.zig");
 const ghcr_mod = @import("../net/ghcr.zig");
 const color = @import("../ui/color.zig");
 const output = @import("../ui/output.zig");
@@ -314,7 +315,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
         // Borrowed clients keep TLS contexts warm across kegs without
         // paying a fresh handshake per worker.
-        var http_pool = client_mod.HttpClientPool.init(ctx.io, ctx.environ, allocator, @intCast(@max(worker_count, 1))) catch {
+        var http_pool = pool_mod.HttpClientPool.init(ctx.io, ctx.environ, allocator, @intCast(@max(worker_count, 1))) catch {
             output.err("Failed to initialise HTTP client pool", .{});
             return error.Aborted;
         };

--- a/src/cli/migrate/parallel.zig
+++ b/src/cli/migrate/parallel.zig
@@ -10,7 +10,7 @@ const signals = @import("../../core/signals.zig");
 const store_mod = @import("../../core/store.zig");
 const sqlite = @import("../../db/sqlite.zig");
 const api_mod = @import("../../net/api.zig");
-const client_mod = @import("../../net/client.zig");
+const pool_mod = @import("../../net/client_pool.zig");
 const ghcr_mod = @import("../../net/ghcr.zig");
 const output = @import("../../ui/output.zig");
 const progress_mod = @import("../../ui/progress.zig");
@@ -85,7 +85,7 @@ pub const Pool = struct {
     homebrew_prefix: []const u8,
     use_system_ruby_scope: []const []const u8,
 
-    http_pool: *client_mod.HttpClientPool,
+    http_pool: *pool_mod.HttpClientPool,
     store: *store_mod.Store,
     linker: *linker_mod.Linker,
     db: *sqlite.Database,

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -14,6 +14,7 @@ const tap_mod = @import("../../core/tap.zig");
 const sqlite = @import("../../db/sqlite.zig");
 const api_mod = @import("../../net/api.zig");
 const client_mod = @import("../../net/client.zig");
+const pool_mod = @import("../../net/client_pool.zig");
 const output = @import("../../ui/output.zig");
 const install_args_mod = @import("../install/args.zig");
 const install_rb_parse_mod = @import("../install/rb_parse.zig");
@@ -617,7 +618,7 @@ const WorkerCtx = struct {
     /// workers serialise on the per-statement mutex.
     db: *sqlite.Database,
     arena: std.heap.ArenaAllocator,
-    pool: *client_mod.HttpClientPool,
+    pool: *pool_mod.HttpClientPool,
     cache_dir: []const u8,
     /// Snapshot of `ctx.mirrors.api_base` so workers inherit the
     /// mirror override without re-walking the env on a worker thread.
@@ -682,7 +683,7 @@ fn runPool(
     const worker_count = outdatedWorkerCount(kegs.len, workers_override);
     std.debug.assert(worker_count > 0);
 
-    var http_pool = try client_mod.HttpClientPool.init(ctx.io, ctx.environ, allocator, worker_count);
+    var http_pool = try pool_mod.HttpClientPool.init(ctx.io, ctx.environ, allocator, worker_count);
     defer http_pool.deinit();
     http_pool.setOfflineAll(ctx.offline);
 

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -846,10 +846,6 @@ fn formatUri(allocator: std.mem.Allocator, uri: std.Uri) ![]const u8 {
     return std.fmt.allocPrint(allocator, "{s}://{s}{s}", .{ scheme, host, path });
 }
 
-/// Pool now lives in `net/client_pool.zig`; re-exported for one release
-/// so existing `client_mod.HttpClientPool` callers keep resolving.
-pub const HttpClientPool = @import("client_pool.zig").HttpClientPool;
-
 test "extractEtagFromHead: finds ETag header by exact name" {
     const bytes = "200 OK\r\nServer: github\r\nETag: \"abc123\"\r\nContent-Length: 0\r\n\r\n";
     const et = extractEtagFromHead(bytes);

--- a/src/net/ghcr.zig
+++ b/src/net/ghcr.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 
 const client_mod = @import("client.zig");
+const pool_mod = @import("client_pool.zig");
 const mirror_mod = @import("mirror.zig");
 
 pub const GhcrError = error{
@@ -290,7 +291,7 @@ pub fn extractTokenField(allocator: std.mem.Allocator, json_bytes: []const u8) !
 const testing = std.testing;
 
 test "GhcrClient.init defaults base_url to the upstream GHCR host" {
-    var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
+    var pool = try pool_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
     defer pool.deinit();
     const http = pool.acquire();
     defer pool.release(http);

--- a/tests/ghcr_test.zig
+++ b/tests/ghcr_test.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 const testing = std.testing;
 const client_mod = @import("malt").client;
+const pool_mod = @import("malt").client_pool;
 const ghcr = @import("malt").ghcr;
 const io_mod = @import("malt").output;
 
@@ -29,7 +30,7 @@ test "extractTokenField returns InvalidResponse when token field is not a string
 }
 
 test "GhcrClient.init/deinit does not leak and starts without cached token" {
-    var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
+    var pool = try pool_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
     defer pool.deinit();
 
     const http = pool.acquire();
@@ -47,7 +48,7 @@ test "GhcrClient honours a base_url override across token and blob URLs" {
     // Pins the override on the struct, then exercises the pure URL
     // builders against the same value to prove the registry endpoints
     // malt would hit match the mirror.
-    var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
+    var pool = try pool_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
     defer pool.deinit();
     const http = pool.acquire();
     defer pool.release(http);
@@ -120,7 +121,7 @@ test "hasTokenFor is false before any fetch and true after a direct cache seed" 
     // Black-box probe: without hitting the network we can still verify
     // the scope-set cache behaves the way fetchToken / prefetchTokens
     // promise. Seed the cache by hand, then probe.
-    var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
+    var pool = try pool_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
     defer pool.deinit();
     const http = pool.acquire();
     defer pool.release(http);
@@ -163,7 +164,7 @@ test "classifyGhcrStatus: 503 maps to DownloadHttpServerError" {
 }
 
 test "hasTokenFor treats expired tokens as cache-miss" {
-    var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
+    var pool = try pool_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
     defer pool.deinit();
     const http = pool.acquire();
     defer pool.release(http);
@@ -185,7 +186,7 @@ test "fetchToken on cache hit returns an owned dupe the caller must free" {
     // allocation, distinct from `cached_token`. If fetchToken ever
     // reverts to a borrow, this test double-frees the cached buffer
     // and the testing allocator aborts the run.
-    var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
+    var pool = try pool_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
     defer pool.deinit();
     const http = pool.acquire();
     defer pool.release(http);
@@ -216,7 +217,7 @@ test "fetchToken is safe against concurrent cache churn" {
     const fetchers: usize = 4;
     const iterations: usize = 2000;
 
-    var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
+    var pool = try pool_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
     defer pool.deinit();
     const http = pool.acquire();
     defer pool.release(http);

--- a/tests/install_parse_cache_test.zig
+++ b/tests/install_parse_cache_test.zig
@@ -118,7 +118,7 @@ test "collectFormulaJobs parses each formula exactly once via shared cache" {
     try seedCache(cache_dir, "d_d", bottleJsonUniqueSha("d_d", "dd"));
     try seedCache(cache_dir, "d_e", bottleJsonUniqueSha("d_e", "ee"));
 
-    var http_pool = try malt.client.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 2);
+    var http_pool = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 2);
     defer http_pool.deinit();
     var real_http = malt.client.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, alloc);
     defer real_http.deinit();
@@ -195,7 +195,7 @@ test "FormulaCache holds at most one entry per unique dep across the run" {
     try seedCache(cache_dir, "d_d", bottleJsonUniqueSha("d_d", "dd"));
     try seedCache(cache_dir, "d_e", bottleJsonUniqueSha("d_e", "ee"));
 
-    var http_pool = try malt.client.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 2);
+    var http_pool = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 2);
     defer http_pool.deinit();
     var real_http = malt.client.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, alloc);
     defer real_http.deinit();
@@ -371,7 +371,7 @@ test "shared deps across multi-package install collapse to one parse" {
     try seedCache(cache_dir, "omega", omega_json);
     try seedCache(cache_dir, "shared_lib", bottleJsonUniqueSha("shared_lib", "ss"));
 
-    var http_pool = try malt.client.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 2);
+    var http_pool = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 2);
     defer http_pool.deinit();
     var real_http = malt.client.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, alloc);
     defer real_http.deinit();

--- a/tests/install_pool_test.zig
+++ b/tests/install_pool_test.zig
@@ -123,7 +123,7 @@ test "installPoolWorker drains every job against a warm store and stamps each re
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
 
-    var http_pool = try malt.client.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 1);
+    var http_pool = try malt.client_pool.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 1);
     defer http_pool.deinit();
     // ghcr/http are required by the worker signature but the warm-store
     // fast path inside `installKegFromBottle` short-circuits before any
@@ -221,7 +221,7 @@ test "installPoolWorker drains a 3-job pool concurrently across two workers" {
 
     // Two-slot HTTP pool so the two workers can both acquire without
     // either one blocking on the warm-store fast path.
-    var http_pool = try malt.client.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 2);
+    var http_pool = try malt.client_pool.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 2);
     defer http_pool.deinit();
     var http = malt.client.HttpClient.init(ctx.io, ctx.environ, testing.allocator);
     defer http.deinit();
@@ -325,7 +325,7 @@ test "installPoolWorker propagates the specific CellarError variant into result.
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
-    var http_pool = try malt.client.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 1);
+    var http_pool = try malt.client_pool.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 1);
     defer http_pool.deinit();
     var http = malt.client.HttpClient.init(ctx.io, ctx.environ, testing.allocator);
     defer http.deinit();
@@ -393,7 +393,7 @@ test "installPoolWorker bails between jobs when Ctrl-C fires" {
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
-    var http_pool = try malt.client.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 1);
+    var http_pool = try malt.client_pool.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 1);
     defer http_pool.deinit();
     var http = malt.client.HttpClient.init(ctx.io, ctx.environ, testing.allocator);
     defer http.deinit();
@@ -453,7 +453,7 @@ test "installPoolWorker leaves the result untouched and marks job not-succeeded 
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
 
-    var http_pool = try malt.client.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 1);
+    var http_pool = try malt.client_pool.HttpClientPool.init(ctx.io, ctx.environ, testing.allocator, 1);
     defer http_pool.deinit();
     var http = malt.client.HttpClient.init(ctx.io, ctx.environ, testing.allocator);
     defer http.deinit();

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -93,7 +93,7 @@ test "collectFormulaJobs queues a formula with a post_install hook" {
     test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
 
-    var http = try malt.client.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
+    var http = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
     defer http.deinit();
     var real_http = malt.client.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, alloc);
     defer real_http.deinit();
@@ -334,7 +334,7 @@ test "collectFormulaJobs queues the main formula when nothing is installed" {
     test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
 
-    var http = try malt.client.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
+    var http = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
     defer http.deinit();
     // A real single-client HttpClient is safe because it's never touched
     // when deps.len == 0.
@@ -381,7 +381,7 @@ test "collectFormulaJobs no-ops when the formula is already installed" {
 
     const json = bottleJsonWithoutDeps("hello");
 
-    var http: malt.client.HttpClientPool = undefined;
+    var http: malt.client_pool.HttpClientPool = undefined;
     var api: malt.api.BrewApi = undefined;
     var store_inst: malt.store.Store = undefined;
     var jobs: std.ArrayList(install_download.DownloadJob) = .empty;
@@ -463,7 +463,7 @@ test "collectFormulaJobs queues a dep and its parent from a seeded cache" {
     const root_json = formulaJsonWithDep("alpha", "beta");
     try seedCache(cache_dir, "alpha", root_json);
 
-    var http_pool = try malt.client.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 2);
+    var http_pool = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 2);
     defer http_pool.deinit();
     var real_http = malt.client.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, alloc);
     defer real_http.deinit();
@@ -513,7 +513,7 @@ test "collectFormulaJobs deduplicates deps already queued by a prior call" {
     try seedCache(cache_dir, "alpha", root_a);
     try seedCache(cache_dir, "omega", root_b);
 
-    var http_pool = try malt.client.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 2);
+    var http_pool = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 2);
     defer http_pool.deinit();
     var real_http = malt.client.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, alloc);
     defer real_http.deinit();
@@ -547,7 +547,7 @@ test "collectFormulaJobs surfaces FormulaNotFound for unparseable JSON" {
     var tdb = try TempDb.init("bad_json");
     defer tdb.deinit();
 
-    var http: malt.client.HttpClientPool = undefined;
+    var http: malt.client_pool.HttpClientPool = undefined;
     var api: malt.api.BrewApi = undefined;
     var store_inst: malt.store.Store = undefined;
     var jobs: std.ArrayList(install_download.DownloadJob) = .empty;
@@ -582,7 +582,7 @@ test "collectFormulaJobs with post_install leaves the DB untouched" {
     test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
 
-    var http = try malt.client.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
+    var http = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
     defer http.deinit();
     var real_http = malt.client.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, alloc);
     defer real_http.deinit();
@@ -646,7 +646,7 @@ test "collectFormulaJobs carries the _<revision> suffix in version_str" {
     test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
 
-    var http = try malt.client.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
+    var http = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
     defer http.deinit();
     var real_http = malt.client.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, alloc);
     defer real_http.deinit();
@@ -686,7 +686,7 @@ test "collectFormulaJobs leaves plain-version formulas unchanged" {
     test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
 
-    var http = try malt.client.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
+    var http = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
     defer http.deinit();
     var real_http = malt.client.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, alloc);
     defer real_http.deinit();
@@ -787,7 +787,7 @@ test "collectFormulaJobs leaves no parsed-tree leaks under testing.allocator (>=
     const root_json = formulaJsonWithThreeDeps("root", "dep_a", "dep_b", "dep_c");
     try seedCache(cache_dir, "root", root_json);
 
-    var http_pool = try malt.client.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 2);
+    var http_pool = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 2);
     defer http_pool.deinit();
     var real_http = malt.client.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, alloc);
     defer real_http.deinit();

--- a/tests/net_client_pool_test.zig
+++ b/tests/net_client_pool_test.zig
@@ -16,3 +16,10 @@ test "client_pool exposes a usable pool + borrowed HttpClient via its own module
     try testing.expect(!c.offline); // borrowed client is the real type, default online
     pool.release(c);
 }
+
+test "HttpClientPool lives only in client_pool, not re-exported from client" {
+    // The transition re-export from net/client.zig is gone — callers import
+    // the pool from its own module, keeping the client↔pool import cycle broken.
+    try testing.expect(@hasDecl(@import("malt").client_pool, "HttpClientPool"));
+    try testing.expect(!@hasDecl(@import("malt").client, "HttpClientPool"));
+}

--- a/tests/progress_test.zig
+++ b/tests/progress_test.zig
@@ -7,6 +7,7 @@ const test_io = @import("test_io");
 const testing = std.testing;
 const progress_mod = @import("malt").progress;
 const client_mod = @import("malt").client;
+const pool_mod = @import("malt").client_pool;
 const output_mod = @import("malt").output;
 
 // --- ProgressBar unit tests ---
@@ -392,18 +393,17 @@ test "output verbose/dryrun/mode setters and getters round-trip" {
 //
 // Deterministic pool bookkeeping is unit-tested inline in
 // net/client_pool.zig. The blocking cond.wait branch needs a second
-// thread, so it lives here; it also keeps the client.zig re-export
-// exercised through `client_mod.HttpClientPool`.
+// thread, so it lives here.
 
 test "HttpClientPool blocks acquire when all clients are busy" {
-    var pool = try client_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
+    var pool = try pool_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
     defer pool.deinit();
 
     // Hold the only client, then spawn a thread that tries to acquire.
     const held = pool.acquire();
 
     const Ctx = struct {
-        p: *client_mod.HttpClientPool,
+        p: *pool_mod.HttpClientPool,
         got: *client_mod.HttpClient,
         done: *std.atomic.Value(bool),
 


### PR DESCRIPTION
## Description

Makes `HttpClientPool` resolvable from one place only, its own `net/client_pool` module, and retires the transitional re-export that `net/client` carried for callers mid-migration. Every pool consumer now depends on the module that actually defines the type, which breaks the `client <-> client_pool` import cycle and keeps the pool's surface out of
the client module. Behaviour is unchanged.

## Related Issue

- None

## Notes for Reviewers

- None