### PR TITLE
refactor(cli/install): route installAll through an OutputSink

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -175,6 +175,7 @@ pub fn build(b: *std.Build) void {
         "tests/cli_tap_test.zig",
         "tests/cli_services_test.zig",
         "tests/install_execute_test.zig",
+        "tests/install_sink_test.zig",
         "tests/install_ambiguity_test.zig",
         "tests/install_download_only_test.zig",
         "tests/install_idempotent_test.zig",

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -1,20 +1,22 @@
 //! malt — bundle command
 
 const std = @import("std");
+
 const AppCtx = @import("../app_ctx.zig").AppCtx;
-const sqlite = @import("../db/sqlite.zig");
-const schema = @import("../db/schema.zig");
-const atomic = @import("../fs/atomic.zig");
-const output = @import("../ui/output.zig");
-const manifest_mod = @import("../core/bundle/manifest.zig");
 const brewfile_mod = @import("../core/bundle/brewfile.zig");
 const brewfile_emit = @import("../core/bundle/brewfile_emit.zig");
-const runner_mod = @import("../core/bundle/runner.zig");
 const cleanup_mod = @import("../core/bundle/cleanup.zig");
+const manifest_mod = @import("../core/bundle/manifest.zig");
+const runner_mod = @import("../core/bundle/runner.zig");
+const schema = @import("../db/schema.zig");
+const sqlite = @import("../db/sqlite.zig");
+const atomic = @import("../fs/atomic.zig");
+const output = @import("../ui/output.zig");
+const install_sink_mod = @import("install/sink.zig");
 const install_cmd = @import("install.zig");
-const uninstall_cmd = @import("uninstall.zig");
-const tap_cmd = @import("tap.zig");
 const services_cmd = @import("services.zig");
+const tap_cmd = @import("tap.zig");
+const uninstall_cmd = @import("uninstall.zig");
 
 // Default in-process dispatcher: the CLI layer supplies this so the
 // runner can stay ignorant of cli/* while still calling into the real
@@ -49,12 +51,14 @@ fn bundleInstallCtxFromOpaque(ctx: ?*anyopaque) *const BundleInstallCtx {
 
 fn cliInstallFormula(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner_mod.DispatchError!void {
     const bd = bundleInstallCtxFromOpaque(ctx);
-    install_cmd.installAll(bd.app, allocator, &.{name}, .{ .isolate_deps = bd.isolate_deps }) catch |e| return narrowDispatch(e);
+    // Silent sink: the bundle `Report` is the per-member channel, so the
+    // install pipeline's per-keg lines would only be noise over it.
+    install_cmd.installAll(bd.app, allocator, &.{name}, .{ .isolate_deps = bd.isolate_deps, .sink = install_sink_mod.silent }) catch |e| return narrowDispatch(e);
 }
 
 fn cliInstallCask(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner_mod.DispatchError!void {
     const bd = bundleInstallCtxFromOpaque(ctx);
-    install_cmd.installAll(bd.app, allocator, &.{name}, .{ .cask = true, .isolate_deps = bd.isolate_deps }) catch |e| return narrowDispatch(e);
+    install_cmd.installAll(bd.app, allocator, &.{name}, .{ .cask = true, .isolate_deps = bd.isolate_deps, .sink = install_sink_mod.silent }) catch |e| return narrowDispatch(e);
 }
 
 fn cliTapAdd(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner_mod.DispatchError!void {

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -57,6 +57,8 @@ const drive = post_install_mod.drive;
 const rb_parse_mod = @import("install/rb_parse.zig");
 const record_mod = @import("install/record.zig");
 const InstallError = record_mod.InstallError;
+const sink_mod = @import("install/sink.zig");
+const OutputSink = sink_mod.OutputSink;
 const recordKeg = record_mod.recordKeg;
 const deleteKeg = record_mod.deleteKeg;
 const recordDeps = record_mod.recordDeps;
@@ -343,6 +345,10 @@ pub const InstallAllOpts = struct {
     /// opts struct so the bundle runner can opt in without spelling
     /// the flag out.
     isolate_deps: bool = false,
+    /// Where per-keg human output goes. Defaults to the terminal sink
+    /// (behaviour identical to `mt install`); the bundle runner passes a
+    /// silent sink so its `Report` is the only channel.
+    sink: OutputSink = sink_mod.terminal,
 };
 
 /// Non-argv primitive used by `core/bundle/runner.zig` via its injected
@@ -362,7 +368,7 @@ pub fn installAll(
     if (opts.cask) try argv.append(allocator, "--cask");
     if (opts.isolate_deps) try argv.append(allocator, "--isolate-deps");
     for (packages) |p| try argv.append(allocator, p);
-    return executeWithOpts(ctx, allocator, argv.items, .{ .skip_lock = opts.skip_lock });
+    return executeWithOpts(ctx, allocator, argv.items, .{ .skip_lock = opts.skip_lock, .sink = opts.sink });
 }
 
 /// Internal options that don't have an argv form. Kept private so the
@@ -370,6 +376,9 @@ pub fn installAll(
 /// contract instead of leaking into the user-visible flag surface.
 const ExecuteOpts = struct {
     skip_lock: bool = false,
+    /// Where per-keg human output goes. Terminal for the argv path; the
+    /// bundle runner threads a silent sink in via `installAll`.
+    sink: OutputSink = sink_mod.terminal,
 };
 
 const InstallFlag = enum {
@@ -420,6 +429,9 @@ fn executeWithOpts(
     exec_opts: ExecuteOpts,
 ) !void {
     if (help.showIfRequested(ctx, args, "install")) return;
+
+    // Single emission seam for this run; default forwards to `ui/output`.
+    const sink = exec_opts.sink;
 
     // Parse flags
     var packages: std.ArrayList([]const u8) = .empty;
@@ -480,22 +492,22 @@ fn executeWithOpts(
 
     if (local_only and packages.items.len == 0) {
         // `error.Aborted` per the main.zig contract — avoids a raw stack trace.
-        output.err("--local requires a path to a .rb file", .{});
+        sink.err("--local requires a path to a .rb file", .{});
         return error.Aborted;
     }
 
     // Refuse ambiguous argv so `--local` cannot silently drop another mode.
     if (local_only) {
         if (force_cask) {
-            output.err("--local cannot be combined with --cask (a .rb file is never a cask)", .{});
+            sink.err("--local cannot be combined with --cask (a .rb file is never a cask)", .{});
             return error.Aborted;
         }
         if (force_formula) {
-            output.err("--local already selects formula mode; drop --formula", .{});
+            sink.err("--local already selects formula mode; drop --formula", .{});
             return error.Aborted;
         }
         if (use_system_ruby_bare or use_system_ruby_scope.items.len > 0) {
-            output.err("--local does not run post_install; --use-system-ruby has no effect and is refused", .{});
+            sink.err("--local does not run post_install; --use-system-ruby has no effect and is refused", .{});
             return error.Aborted;
         }
     }
@@ -504,12 +516,12 @@ fn executeWithOpts(
     // requested package, --download-only skips materialise+link entirely.
     // Document the refusal up front rather than silently picking a winner.
     if (download_only and only_deps) {
-        output.err("--download-only cannot be combined with --only-deps", .{});
+        sink.err("--download-only cannot be combined with --only-deps", .{});
         return error.Aborted;
     }
 
     if (packages.items.len == 0) {
-        output.err("No package names specified", .{});
+        sink.err("No package names specified", .{});
         return InstallError.NoPackages;
     }
 
@@ -519,7 +531,7 @@ fn executeWithOpts(
     // rev/origin tracking.
     for (packages.items) |pkg| {
         if (isSelfInstall(pkg)) {
-            output.err("Refusing to install malt itself ('{s}'). Use 'mt version update' to upgrade.", .{pkg});
+            sink.err("Refusing to install malt itself ('{s}'). Use 'mt version update' to upgrade.", .{pkg});
             return error.Aborted;
         }
     }
@@ -530,7 +542,7 @@ fn executeWithOpts(
         if (packages.items.len == 1) {
             try use_system_ruby_scope.append(allocator, packages.items[0]);
         } else {
-            output.err(
+            sink.err(
                 "--use-system-ruby needs a scope when multiple packages are installed; use --use-system-ruby={s}[,<name>...]",
                 .{packages.items[0]},
             );
@@ -545,11 +557,11 @@ fn executeWithOpts(
     // Absurdly long prefixes overflow install_name_tool's load-command slots.
     checkPrefixSane(prefix) catch |err| switch (err) {
         error.PrefixAbsurd => {
-            output.err(
+            sink.err(
                 "MALT_PREFIX '{s}' is {d} bytes, beyond the {d}-byte sanity cap.",
                 .{ prefix, prefix.len, max_prefix_sane_len },
             );
-            output.err("Set MALT_PREFIX to a reasonable path and retry.", .{});
+            sink.err("Set MALT_PREFIX to a reasonable path and retry.", .{});
             return InstallError.PrefixAbsurd;
         },
     };
@@ -573,7 +585,7 @@ fn executeWithOpts(
         // gate the early return.
         if (anyNamedNeedsPromotion(ctx, prefix, packages.items)) break :fast;
         for (packages.items) |pkg| {
-            output.info("{s} is already installed", .{pkg});
+            sink.info("{s} is already installed", .{pkg});
             // Fast-path skips the protocol; positive signal so consumers
             // can tell idempotent success from "command never ran".
             output.emitNdjsonEvent(.already_installed, pkg, null);
@@ -589,14 +601,14 @@ fn executeWithOpts(
     const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch
         return InstallError.DatabaseError;
     var db = sqlite.Database.open(db_path) catch {
-        output.err("Failed to open database at {s}", .{db_path});
+        sink.err("Failed to open database at {s}", .{db_path});
         return InstallError.DatabaseError;
     };
     defer db.close();
 
     // Initialize schema
     schema.initSchema(&db) catch {
-        output.err("Failed to initialize database schema", .{});
+        sink.err("Failed to initialize database schema", .{});
         return InstallError.DatabaseError;
     };
 
@@ -610,7 +622,7 @@ fn executeWithOpts(
         const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch
             return InstallError.LockError;
         lk = lock_mod.LockFile.acquire(ctx.io, lock_path, 30000) catch {
-            output.err("Another mt process is running. Wait or run mt doctor.", .{});
+            sink.err("Another mt process is running. Wait or run mt doctor.", .{});
             return InstallError.LockError;
         };
         output.emitNdjsonEvent(.lock_acquired, "", null);
@@ -628,7 +640,7 @@ fn executeWithOpts(
     // 4-slot worker pool — same budget as the materialize pool; enough to
     // saturate cold installs while reusing TLS contexts.
     var http_pool = pool_mod.HttpClientPool.init(ctx.io, ctx.environ, allocator, 4) catch {
-        output.err("Failed to initialise HTTP client pool", .{});
+        sink.err("Failed to initialise HTTP client pool", .{});
         return InstallError.DownloadFailed;
     };
     defer http_pool.deinit();
@@ -659,7 +671,7 @@ fn executeWithOpts(
     // correctly short-circuits without re-downloading the keg.
     for (packages.items) |pkg_name| {
         if (promoteIsolatedDepIfAny(&db, &linker, pkg_name)) {
-            output.success("{s} promoted to direct: bin/sbin links restored", .{pkg_name});
+            sink.success("{s} promoted to direct: bin/sbin links restored", .{pkg_name});
         }
     }
 
@@ -677,14 +689,14 @@ fn executeWithOpts(
 
     // Check for Ctrl-C before resolution phase
     if (signals.isInterrupted()) {
-        output.warn("Interrupted before resolution.", .{});
+        sink.warn("Interrupted before resolution.", .{});
         return;
     }
 
     for (packages.items) |pkg_name| {
         // Check for Ctrl-C between packages during resolution
         if (signals.isInterrupted()) {
-            output.warn("Interrupted during resolution.", .{});
+            sink.warn("Interrupted during resolution.", .{});
             // Surface counted misses so a Ctrl-C after some packages
             // already failed dispatch still exits non-zero.
             if (failed_count > 0) return InstallError.PartialFailure;
@@ -694,11 +706,11 @@ fn executeWithOpts(
         // Path wins over tap-form when `.rb` is present — a typo like
         // `user/repo/foo.rb` hits local-file error, not a GitHub 404.
         if (local_only or isLocalFormulaPath(pkg_name)) {
-            installLocalFormula(ctx, allocator, pkg_name, &db, &linker, prefix, dry_run, force) catch |e| {
+            installLocalFormula(ctx, allocator, pkg_name, &db, &linker, prefix, dry_run, force, sink) catch |e| {
                 // Skip the generic summary when the inner error line already
                 // told the user what went wrong.
                 if (!localErrorIsAnnounced(e)) {
-                    output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
+                    sink.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
                 }
                 failed_count += 1;
             };
@@ -707,8 +719,8 @@ fn executeWithOpts(
 
         // Handle tap formulas separately (they don't use GHCR)
         if (isTapFormula(pkg_name)) {
-            installTapFormula(ctx, allocator, pkg_name, &db, &linker, prefix, dry_run, force, download_only) catch |e| {
-                output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
+            installTapFormula(ctx, allocator, pkg_name, &db, &linker, prefix, dry_run, force, download_only, sink) catch |e| {
+                sink.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
                 failed_count += 1;
             };
             continue;
@@ -721,25 +733,25 @@ fn executeWithOpts(
                 // didn't have it" line instead of falling through to a
                 // cask probe that would also miss with the same noise.
                 if (fetch_err == api_mod.ApiError.OfflineRequired) {
-                    output.err("offline mode: formula '{s}' not cached", .{pkg_name});
+                    sink.err("offline mode: formula '{s}' not cached", .{pkg_name});
                     failed_count += 1;
                     continue;
                 }
                 if (force_formula) {
                     if (mapApiFetchError(fetch_err) != null) {
-                        output.err("Cannot reach Homebrew API for formula '{s}'", .{pkg_name});
+                        sink.err("Cannot reach Homebrew API for formula '{s}'", .{pkg_name});
                     } else {
-                        output.err("Formula '{s}' not found", .{pkg_name});
+                        sink.err("Formula '{s}' not found", .{pkg_name});
                     }
                     failed_count += 1;
                     continue;
                 }
                 // Try cask
-                installCask(ctx, allocator, pkg_name, &db, &api, dry_run, download_only) catch |e| {
+                installCask(ctx, allocator, pkg_name, &db, &api, dry_run, download_only, sink) catch |e| {
                     if (e == api_mod.ApiError.OfflineRequired) {
-                        output.err("offline mode: '{s}' not cached as formula or cask", .{pkg_name});
+                        sink.err("offline mode: '{s}' not cached as formula or cask", .{pkg_name});
                     } else {
-                        output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
+                        sink.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
                     }
                     failed_count += 1;
                 };
@@ -750,7 +762,7 @@ fn executeWithOpts(
             if (!force_formula and api.cachedExists(pkg_name, .cask)) {
                 if (api.fetchCask(pkg_name)) |cask_json| {
                     allocator.free(cask_json);
-                    output.info("{s} exists as both a formula and a cask. Installing formula. Use --cask to install the cask instead.", .{pkg_name});
+                    sink.info("{s} exists as both a formula and a cask. Installing formula. Use --cask to install the cask instead.", .{pkg_name});
                 } else |_| {}
             }
 
@@ -764,15 +776,16 @@ fn executeWithOpts(
                 .store = &store,
                 .cache = &formula_cache,
                 .worker_backing = std.heap.smp_allocator,
+                .sink = sink,
             }, pkg_name, formula_json, force, &all_jobs) catch |e| {
-                output.err("Failed to resolve {s}: {s}", .{ pkg_name, @errorName(e) });
+                sink.err("Failed to resolve {s}: {s}", .{ pkg_name, @errorName(e) });
                 failed_count += 1;
                 continue;
             };
             output.emitNdjsonEvent(.resolved, pkg_name, null);
         } else {
-            installCask(ctx, allocator, pkg_name, &db, &api, dry_run, download_only) catch |e| {
-                output.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
+            installCask(ctx, allocator, pkg_name, &db, &api, dry_run, download_only, sink) catch |e| {
+                sink.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
                 failed_count += 1;
             };
         }
@@ -792,10 +805,10 @@ fn executeWithOpts(
     }
 
     if (dry_run) {
-        output.info("Dry run: would install {d} package(s):", .{all_jobs.items.len});
+        sink.info("Dry run: would install {d} package(s):", .{all_jobs.items.len});
         for (all_jobs.items) |job| {
             const tag: []const u8 = if (job.is_dep) " (dependency)" else "";
-            output.info("  {s} {s}{s}", .{ job.name, job.version_str, tag });
+            sink.info("  {s} {s}{s}", .{ job.name, job.version_str, tag });
             // No transition outcome to report on a plan-only run.
             output.emitNdjsonEvent(.would_install, job.name, null);
         }
@@ -860,9 +873,9 @@ fn executeWithOpts(
     {
         if (to_download > 0) {
             if (to_download == 1) {
-                output.info("Downloading 1 bottle...", .{});
+                sink.info("Downloading 1 bottle...", .{});
             } else {
-                output.info("Downloading {d} bottles...", .{to_download});
+                sink.info("Downloading {d} bottles...", .{to_download});
             }
 
             // Fold every repo into one multi-scope `/token` round-trip; workers
@@ -891,8 +904,10 @@ fn executeWithOpts(
 
         // Multi-progress + bars only exist when at least one job downloads.
         // Warm-only installs skip terminal setup entirely; their pool
-        // workers materialise without a progress callback.
-        var multi: ?progress_mod.MultiProgress = if (to_download > 0)
+        // workers materialise without a progress callback. A non-terminal
+        // sink (bundle) skips bars too — the global progress mode is
+        // set-once and can't be quieted mid-run.
+        var multi: ?progress_mod.MultiProgress = if (sink.show_progress and to_download > 0)
             progress_mod.MultiProgress.init(assignDownloadLineIndices(all_jobs.items))
         else
             null;
@@ -943,6 +958,7 @@ fn executeWithOpts(
             .results = mats,
             .worker_backing = std.heap.smp_allocator,
             .download_only = download_only,
+            .sink = sink,
         };
 
         const pool_threads = allocator.alloc(std.Thread, worker_count) catch
@@ -985,12 +1001,12 @@ fn executeWithOpts(
         for (all_jobs.items) |job| {
             if (!job.succeeded) {
                 output.emitNdjsonEvent(.download_complete, job.name, "failed");
-                output.err("Download failed for {s}", .{job.name});
+                sink.err("Download failed for {s}", .{job.name});
                 failed_count += 1;
                 continue;
             }
             output.emitNdjsonEvent(.download_complete, job.name, "ok");
-            output.success("{s} {s} downloaded to {s}/store/{s}", .{
+            sink.success("{s} {s} downloaded to {s}/store/{s}", .{
                 job.name,
                 job.version_str,
                 prefix,
@@ -1006,7 +1022,7 @@ fn executeWithOpts(
 
     // Check for Ctrl-C between the pool and the serial link phase
     if (signals.isInterrupted()) {
-        output.warn("Interrupted. Cleaning up...", .{});
+        sink.warn("Interrupted. Cleaning up...", .{});
         // Pool already joined; pull its `!job.succeeded` results into
         // failed_count before bailing so the exit code reflects any
         // bottle that failed to download alongside earlier dispatch misses.
@@ -1025,7 +1041,7 @@ fn executeWithOpts(
 
     for (all_jobs.items, 0..) |*job, i| {
         if (signals.isInterrupted()) {
-            output.warn("Interrupted. Stopping install.", .{});
+            sink.warn("Interrupted. Stopping install.", .{});
             break;
         }
 
@@ -1033,7 +1049,7 @@ fn executeWithOpts(
         // findFailedDep check relies on this map, and a silent drop would
         // let dependents install on top of a broken graph.
         if (!job.succeeded) {
-            output.err("Download failed for {s}, skipping", .{job.name});
+            sink.err("Download failed for {s}, skipping", .{job.name});
             try failed_kegs.put(job.name, {});
             failed_count += 1;
             continue;
@@ -1043,7 +1059,7 @@ fn executeWithOpts(
             const err = mats[i].err orelse cellar_mod.CellarError.CloneFailed;
             var msg_buf: [256]u8 = undefined;
             const msg = formatMaterializeFailure(&msg_buf, job.name, err);
-            output.err("{s}", .{msg});
+            sink.err("{s}", .{msg});
             output.emitNdjsonEvent(.materialized, job.name, "failed");
             try failed_kegs.put(job.name, {});
             failed_count += 1;
@@ -1054,7 +1070,7 @@ fn executeWithOpts(
         // Failed-dep → skip: installing on a broken graph yields a dyld-unresolvable
         // keg. Remove the already-materialised keg so orphans don't linger.
         if (findFailedDep(&formula_cache, &failed_kegs, job.name, job.formula_json)) |failed_dep| {
-            output.warn(
+            sink.warn(
                 "Skipping {s}: dependency {s} failed to install",
                 .{ job.name, failed_dep },
             );
@@ -1075,7 +1091,7 @@ fn executeWithOpts(
             unlinkStaleKegLinks(&db, &linker, job.name, mats[i].kegPath());
         }
 
-        linkAndRecord(ctx.io, allocator, job, mats[i].kegPath(), &db, &linker, prefix, &formula_cache, isolate_deps) catch {
+        linkAndRecord(ctx.io, allocator, job, mats[i].kegPath(), &db, &linker, prefix, &formula_cache, isolate_deps, sink) catch {
             // The underlying error was already logged with a tag by
             // linkAndRecord — just record that this job failed so its
             // dependents in the rest of the loop get skipped above.
@@ -1094,7 +1110,7 @@ fn executeWithOpts(
         }
 
         if (job.post_install_defined) {
-            drive(ctx, allocator, job.name, job.version_str, job.formula_json, prefix, use_system_ruby_list, &formula_cache);
+            drive(ctx, allocator, job.name, job.version_str, job.formula_json, prefix, use_system_ruby_list, &formula_cache, sink);
         }
 
         // ca-certificates' macOS post_install can't run natively, so the
@@ -1105,7 +1121,7 @@ fn executeWithOpts(
 
     if (failed_count > 0) {
         const pkg_word: []const u8 = if (failed_count == 1) "package" else "packages";
-        output.err(
+        sink.err(
             "{d} {s} failed to install. See errors above.",
             .{ failed_count, pkg_word },
         );
@@ -1130,6 +1146,7 @@ fn linkAndRecord(
     prefix: []const u8,
     cache: *deps_mod.FormulaCache,
     isolate_deps: bool,
+    sink: OutputSink,
 ) !void {
     const reason: []const u8 = if (job.is_dep) "dependency" else "direct";
     const bin_isolated = isolate_deps and job.is_dep;
@@ -1138,7 +1155,7 @@ fn linkAndRecord(
     // never reached collectFormulaJobs (none today).
     const formula = cache.get(job.name) orelse blk: {
         break :blk cache.getOrParse(job.name, job.formula_json) catch |err| {
-            output.err("Failed to parse formula for {s}: {s}", .{ job.name, @errorName(err) });
+            sink.err("Failed to parse formula for {s}: {s}", .{ job.name, @errorName(err) });
             cellar_mod.remove(io, prefix, job.name, job.version_str) catch {};
             return InstallError.CellarFailed;
         };
@@ -1151,11 +1168,11 @@ fn linkAndRecord(
     if (!job.keg_only) {
         const conflicts = linker.checkConflicts(keg_path, bin_isolated) catch &.{};
         if (conflicts.len > 0) {
-            output.err("{s}: {d} symlink conflict(s) detected:", .{ job.name, conflicts.len });
+            sink.err("{s}: {d} symlink conflict(s) detected:", .{ job.name, conflicts.len });
             for (conflicts) |conflict| {
-                output.err("  {s} already linked by {s}", .{ conflict.link_path, conflict.existing_keg });
+                sink.err("  {s} already linked by {s}", .{ conflict.link_path, conflict.existing_keg });
             }
-            output.err("Use --force to overwrite, or uninstall the conflicting package first.", .{});
+            sink.err("Use --force to overwrite, or uninstall the conflicting package first.", .{});
             cellar_mod.remove(io, prefix, job.name, job.version_str) catch {};
             return InstallError.LinkFailed;
         }
@@ -1164,13 +1181,13 @@ fn linkAndRecord(
     // Link + record
     if (!job.keg_only) {
         const keg_id = recordKeg(db, formula, job.store_sha256, keg_path, reason, bin_isolated, .{}) catch |err| {
-            output.err("Failed to record {s} in database: {s}", .{ job.name, @errorName(err) });
+            sink.err("Failed to record {s} in database: {s}", .{ job.name, @errorName(err) });
             cellar_mod.remove(io, prefix, job.name, job.version_str) catch {};
             return InstallError.RecordFailed;
         };
 
         linker.link(keg_path, job.name, keg_id, bin_isolated) catch |err| {
-            output.err("Failed to link {s}: {s}", .{ job.name, @errorName(err) });
+            sink.err("Failed to link {s}: {s}", .{ job.name, @errorName(err) });
             output.emitNdjsonEvent(.linked, job.name, "failed");
             // Rollback: unlink what was partially created + remove DB record + cellar.
             linker.unlink(keg_id) catch {};
@@ -1183,27 +1200,27 @@ fn linkAndRecord(
         output.emitNdjsonEvent(.linked, job.name, "ok");
         output.emitNdjsonEvent(.recorded, job.name, "ok");
         linker.linkOpt(job.name, job.version_str) catch |e| {
-            output.warn("opt link for {s} failed: {s} — dependents may fail to load at runtime", .{ job.name, @errorName(e) });
+            sink.warn("opt link for {s} failed: {s} — dependents may fail to load at runtime", .{ job.name, @errorName(e) });
         };
         recordDeps(db, keg_id, formula);
     } else {
         const keg_id = recordKeg(db, formula, job.store_sha256, keg_path, reason, bin_isolated, .{}) catch |err| {
-            output.err("Failed to record {s} in database: {s}", .{ job.name, @errorName(err) });
+            sink.err("Failed to record {s} in database: {s}", .{ job.name, @errorName(err) });
             cellar_mod.remove(io, prefix, job.name, job.version_str) catch {};
             return InstallError.RecordFailed;
         };
         // keg-only has no public link phase to roll back.
         output.emitNdjsonEvent(.recorded, job.name, "ok");
         linker.linkOpt(job.name, job.version_str) catch |e| {
-            output.warn("opt link for {s} failed: {s} — dependents may fail to load at runtime", .{ job.name, @errorName(e) });
+            sink.warn("opt link for {s} failed: {s} — dependents may fail to load at runtime", .{ job.name, @errorName(e) });
         };
         recordDeps(db, keg_id, formula);
     }
-    maybeRegisterService(io, allocator, db, formula, prefix);
+    maybeRegisterService(io, allocator, db, formula, prefix, sink);
     // Annotate keg-only packages inline so the single line reads as success,
     // not as a "not linking" warning paired with a separate ✓.
     const keg_only_suffix: []const u8 = if (job.keg_only) " (keg-only — dependency only)" else "";
-    output.success("{s} {s} installed{s}", .{ job.name, job.version_str, keg_only_suffix });
+    sink.success("{s} {s} installed{s}", .{ job.name, job.version_str, keg_only_suffix });
 }
 
 /// Register a launchd service when the formula carries a `service:` block.
@@ -1214,6 +1231,7 @@ fn maybeRegisterService(
     db: *sqlite.Database,
     formula: *const formula_mod.Formula,
     prefix: []const u8,
+    sink: OutputSink,
 ) void {
     const def = formula.service orelse return;
     if (def.run.len == 0) return;
@@ -1253,7 +1271,7 @@ fn maybeRegisterService(
     };
 
     supervisor_mod.register(.{ .allocator = allocator, .io = io, .db = db }, spec, formula.name, false, cellar_path, prefix) catch |err| {
-        output.warn("could not register service for {s}: {s}", .{ formula.name, @errorName(err) });
+        sink.warn("could not register service for {s}: {s}", .{ formula.name, @errorName(err) });
     };
 }
 
@@ -1299,22 +1317,23 @@ fn installCask(
     api: *api_mod.BrewApi,
     dry_run: bool,
     download_only: bool,
+    sink: OutputSink,
 ) !void {
     const cask_json = api.fetchCask(token) catch |e| {
         // Propagate the typed OfflineRequired so the outer dispatch
         // surfaces the snapshot-miss message instead of "not found".
         if (e == api_mod.ApiError.OfflineRequired) return e;
         if (mapApiFetchError(e)) |mapped| {
-            output.err("Cannot reach Homebrew API for cask '{s}'", .{token});
+            sink.err("Cannot reach Homebrew API for cask '{s}'", .{token});
             return mapped;
         }
-        output.err("Cask '{s}' not found", .{token});
+        sink.err("Cask '{s}' not found", .{token});
         return InstallError.CaskNotFound;
     };
     defer allocator.free(cask_json);
 
     var cask = cask_mod.parseCask(allocator, cask_json) catch {
-        output.err("Failed to parse cask JSON for '{s}'", .{token});
+        sink.err("Failed to parse cask JSON for '{s}'", .{token});
         return InstallError.CaskNotFound;
     };
     defer cask.deinit();
@@ -1324,7 +1343,7 @@ fn installCask(
     // older revision is on disk. The real install path keeps the
     // "already installed" short-circuit.
     if (!download_only and cask_mod.isInstalled(db, cask.token)) {
-        output.info("{s} is already installed", .{cask.token});
+        sink.info("{s} is already installed", .{cask.token});
         return;
     }
 
@@ -1337,7 +1356,7 @@ fn installCask(
     }
 
     if (dry_run) {
-        output.info("Dry run: would install cask {s} {s} ({s})", .{
+        sink.info("Dry run: would install cask {s} {s} ({s})", .{
             cask.token,
             cask.version,
             @tagName(artifact_type),
@@ -1346,14 +1365,14 @@ fn installCask(
     }
 
     if (artifact_type == .unknown) {
-        output.err("Unsupported cask format for '{s}' — URL: {s}", .{ cask.token, cask.url });
-        output.err("malt supports .dmg, .zip, and .pkg casks. Use: brew install --cask {s}", .{cask.token});
+        sink.err("Unsupported cask format for '{s}' — URL: {s}", .{ cask.token, cask.url });
+        sink.err("malt supports .dmg, .zip, and .pkg casks. Use: brew install --cask {s}", .{cask.token});
         return InstallError.CaskNotFound;
     }
 
     // Warn for PKG casks (require sudo)
     if (artifact_type == .pkg) {
-        output.warn("{s} is a PKG cask and requires sudo to install via macOS Installer.", .{cask.token});
+        sink.warn("{s} is a PKG cask and requires sudo to install via macOS Installer.", .{cask.token});
     }
 
     const prefix = atomic.maltPrefixOrAbort();
@@ -1362,46 +1381,50 @@ fn installCask(
     installer.artifact_type_override = artifact_type;
     installer.offline = ctx.offline;
 
-    // Progress bar for cask download
+    // Progress bar for cask download. A non-terminal sink (bundle) skips
+    // it — the global progress mode is set-once and can't be quieted
+    // mid-run. `init` is pure; only update/finish touch the terminal.
     var bar = progress_mod.ProgressBar.init(cask.token, 0);
-    installer.progress = .{
-        .context = @ptrCast(&bar),
-        .func = &progressBridge,
-    };
+    if (sink.show_progress) {
+        installer.progress = .{
+            .context = @ptrCast(&bar),
+            .func = &progressBridge,
+        };
+    }
 
     if (download_only) {
         output.emitNdjsonEvent(.download_started, cask.token, null);
         const cache_path = installer.downloadOnly(&cask) catch |e| {
-            bar.finish();
+            if (sink.show_progress) bar.finish();
             output.emitNdjsonEvent(.download_complete, cask.token, "failed");
-            output.err("Failed to download cask {s}: {s}", .{ cask.token, @errorName(e) });
+            sink.err("Failed to download cask {s}: {s}", .{ cask.token, @errorName(e) });
             return InstallError.CaskNotFound;
         };
-        bar.finish();
+        if (sink.show_progress) bar.finish();
         defer allocator.free(cache_path);
         output.emitNdjsonEvent(.download_complete, cask.token, "ok");
-        output.success("{s} {s} downloaded to {s}", .{ cask.token, cask.version, cache_path });
+        sink.success("{s} {s} downloaded to {s}", .{ cask.token, cask.version, cache_path });
         return;
     }
 
-    output.info("Installing cask {s} {s}...", .{ cask.token, cask.version });
+    sink.info("Installing cask {s} {s}...", .{ cask.token, cask.version });
 
     const app_path = installer.install(&cask) catch |e| {
-        bar.finish();
+        if (sink.show_progress) bar.finish();
         // Surface the specific cause (Sha256Mismatch, DownloadFailed, …) —
         // users can't act on a bare "failed to install".
-        output.err("Failed to install cask {s}: {s}", .{ cask.token, @errorName(e) });
+        sink.err("Failed to install cask {s}: {s}", .{ cask.token, @errorName(e) });
         return InstallError.CaskNotFound;
     };
-    bar.finish();
+    if (sink.show_progress) bar.finish();
 
     // Core API casks have no third-party tap origin to record.
     cask_mod.recordInstall(db, &cask, app_path, null) catch {
-        output.warn("Failed to record cask {s} in database", .{cask.token});
+        sink.warn("Failed to record cask {s} in database", .{cask.token});
     };
     allocator.free(app_path);
 
-    output.success("{s} {s} installed", .{ cask.token, cask.version });
+    sink.success("{s} {s} installed", .{ cask.token, cask.version });
 }
 
 // Format the user-facing materialize-failure line. Trivial cellar tags

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -17,11 +17,12 @@ const api_mod = @import("../../net/api.zig");
 const client_mod = @import("../../net/client.zig");
 const pool_mod = @import("../../net/client_pool.zig");
 const ghcr_mod = @import("../../net/ghcr.zig");
-const output = @import("../../ui/output.zig");
 const progress_mod = @import("../../ui/progress.zig");
 const ghcr_url = @import("ghcr_url.zig");
 const record = @import("record.zig");
 const InstallError = record.InstallError;
+const sink_mod = @import("sink.zig");
+const OutputSink = sink_mod.OutputSink;
 
 /// Named-field bundle for `collectFormulaJobs` so callers stop threading
 /// six pointers through every call. Opens a DI seam for tests to swap in
@@ -39,6 +40,9 @@ pub const InstallJobDeps = struct {
     /// so tests run workers under `testing.allocator` for leak coverage;
     /// production keeps a thread-safe heap (typically `smp_allocator`).
     worker_backing: std.mem.Allocator,
+    /// Where resolution-phase human lines go; terminal by default so the
+    /// upgrade re-entry and `mt install` are unchanged.
+    sink: OutputSink = sink_mod.terminal,
 };
 
 /// A bottle download job for parallel processing.
@@ -242,13 +246,13 @@ pub fn collectFormulaJobs(
 
     // Single seam for every parse — cached entries outlive this function.
     const formula = cache.getOrParse(pkg_name, formula_json) catch |e| {
-        output.err("Failed to parse formula JSON for '{s}': {s}", .{ pkg_name, @errorName(e) });
+        ctx.sink.err("Failed to parse formula JSON for '{s}': {s}", .{ pkg_name, @errorName(e) });
         return InstallError.FormulaNotFound;
     };
 
     // Check if already installed
     if (!force and record.isInstalled(db, formula.name)) {
-        output.info("{s} is already installed", .{formula.name});
+        ctx.sink.info("{s} is already installed", .{formula.name});
         return;
     }
 
@@ -401,7 +405,7 @@ pub fn collectFormulaJobs(
 
     // Add main formula
     const bottle = formula_mod.resolveBottle(formula) catch {
-        output.err("No bottle available for {s} on this platform", .{formula.name});
+        ctx.sink.err("No bottle available for {s} on this platform", .{formula.name});
         return InstallError.NoBottle;
     };
 
@@ -429,7 +433,7 @@ pub fn collectFormulaJobs(
     }) catch return InstallError.DownloadFailed;
 
     const pkg_word: []const u8 = if (jobs.items.len == 1) "package" else "packages";
-    output.info("Resolved {s} {s} ({d} {s})", .{ formula.name, formula.version, jobs.items.len, pkg_word });
+    ctx.sink.info("Resolved {s} {s} ({d} {s})", .{ formula.name, formula.version, jobs.items.len, pkg_word });
 }
 
 /// Stamp a contiguous `line_index` on every job that still needs to download,
@@ -523,6 +527,9 @@ pub const InstallKegDeps = struct {
     /// historical "Failed to materialize X: <variant>" diagnostic
     /// without rerouting through a wider error set.
     cellar_diag: ?*?cellar_mod.CellarError = null,
+    /// Where per-keg download-failure lines go; terminal by default so
+    /// the shared upgrade per-keg loop is unchanged.
+    sink: OutputSink = sink_mod.terminal,
 };
 
 /// Result of `installKegFromBottle`. `sha256` borrows from the formula's
@@ -631,13 +638,13 @@ pub fn downloadBottleToStore(
             last_err = dl_err;
             atomic.cleanupTempDir(ctx.io, tmp_dir);
             if (dl_err == bottle_mod.BottleError.DownloadPermanent) {
-                output.err("  {s}: permanent HTTP error (404/410), not retrying", .{formula.name});
+                deps.sink.err("  {s}: permanent HTTP error (404/410), not retrying", .{formula.name});
                 break;
             }
             if (dl_err == bottle_mod.BottleError.Sha256Mismatch) {
                 last_mismatch = mismatch;
             } else if (isDeterministicDownloadError(dl_err)) {
-                output.err("  {s}: {s}", .{ formula.name, @errorName(dl_err) });
+                deps.sink.err("  {s}: {s}", .{ formula.name, @errorName(dl_err) });
                 break;
             }
             if (dl_attempt + 1 < max_attempts) {
@@ -648,19 +655,19 @@ pub fn downloadBottleToStore(
 
     if (!dl_ok and last_err == bottle_mod.BottleError.Sha256Mismatch) {
         if (last_mismatch) |m| {
-            output.err(
+            deps.sink.err(
                 "  {s}: Sha256Mismatch (expected={s} got={s} bytes={d})",
                 .{ formula.name, m.expected[0..@min(64, m.expected.len)], m.computed[0..], m.body_len },
             );
         } else {
-            output.err("  {s}: Sha256Mismatch", .{formula.name});
+            deps.sink.err("  {s}: Sha256Mismatch", .{formula.name});
         }
     }
 
     if (!dl_ok) {
         if (deps.bar) |bar| bar.finish();
         if (dl_attempt >= max_attempts) {
-            output.err("  {s}: {s} (after {d} attempts)", .{ formula.name, @errorName(last_err), max_attempts });
+            deps.sink.err("  {s}: {s} (after {d} attempts)", .{ formula.name, @errorName(last_err), max_attempts });
         }
         allocator.free(tmp_dir);
         return InstallError.DownloadFailed;
@@ -701,6 +708,8 @@ pub const InstallPool = struct {
     /// caller's serial link loop bails on this flag; refcount stays at 0
     /// so warmed bytes are invisible to `purge --store-orphans`.
     download_only: bool = false,
+    /// Where per-keg worker output goes; terminal by default.
+    sink: OutputSink = sink_mod.terminal,
 };
 
 /// Thread entry-point for the install pool. Drains `pool.jobs` via the
@@ -752,7 +761,7 @@ fn installOneJob(pool: *InstallPool, job: *DownloadJob, result: *MaterializeResu
         _ = downloadBottleToStore(
             pool.ctx,
             arena.allocator(),
-            .{ .ghcr = pool.ghcr, .http = http, .store = pool.store, .bar = job.bar },
+            .{ .ghcr = pool.ghcr, .http = http, .store = pool.store, .bar = job.bar, .sink = pool.sink },
             formula,
             bottle,
         ) catch {
@@ -783,6 +792,7 @@ fn installOneJob(pool: *InstallPool, job: *DownloadJob, result: *MaterializeResu
             .store = pool.store,
             .bar = job.bar,
             .cellar_diag = &cellar_diag,
+            .sink = pool.sink,
         },
         formula,
         pool.prefix,

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -28,6 +28,8 @@ const parseCaskApp = rb_parse.parseCaskApp;
 const tapCaskArtifactKind = rb_parse.tapCaskArtifactKind;
 const record = @import("record.zig");
 const InstallError = record.InstallError;
+const sink_mod = @import("sink.zig");
+const OutputSink = sink_mod.OutputSink;
 
 /// Maximum size of a `.rb` formula file that `malt install --local`
 /// will read. Real Homebrew formulas top out well below this (the
@@ -159,8 +161,9 @@ pub fn installTapFormula(
     dry_run: bool,
     force: bool,
     download_only: bool,
+    sink: OutputSink,
 ) !void {
-    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, download_only, .formula_or_cask);
+    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, download_only, .formula_or_cask, sink);
 }
 
 /// Install a tap cask whose owning tap is already known. Skips the
@@ -178,8 +181,9 @@ pub fn installTapCask(
     prefix: []const u8,
     dry_run: bool,
     force: bool,
+    sink: OutputSink,
 ) !void {
-    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, false, .cask_only);
+    return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, false, .cask_only, sink);
 }
 
 fn installTapRb(
@@ -193,13 +197,14 @@ fn installTapRb(
     force: bool,
     download_only: bool,
     kind: TapResolveKind,
+    sink: OutputSink,
 ) !void {
     const parts = args.parseTapName(pkg_name) orelse {
-        output.err("Invalid tap formula format: {s}", .{pkg_name});
+        sink.err("Invalid tap formula format: {s}", .{pkg_name});
         return InstallError.FormulaNotFound;
     };
 
-    output.info("Resolving tap {s}/{s}/{s}...", .{ parts.user, parts.repo, parts.formula });
+    sink.info("Resolving tap {s}/{s}/{s}...", .{ parts.user, parts.repo, parts.formula });
 
     // Determine the commit SHA to fetch against. Prefer the pin
     // already in the DB (set at tap-add or last --refresh); if no pin
@@ -223,12 +228,12 @@ fn installTapRb(
             break :blk cached;
         }
         var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, null) catch |e| {
-            output.err("Could not resolve {s}'s HEAD commit: {s}", .{ tap_slug, tap_mod.describeResolveError(e) });
+            sink.err("Could not resolve {s}'s HEAD commit: {s}", .{ tap_slug, tap_mod.describeResolveError(e) });
             return mapTapResolveError(e);
         };
         defer head_res.deinit();
         const sha = head_res.sha orelse {
-            output.err("Could not resolve {s}'s HEAD commit: empty response", .{tap_slug});
+            sink.err("Could not resolve {s}'s HEAD commit: empty response", .{tap_slug});
             return InstallError.FormulaNotFound;
         };
         const sha_owned = try allocator.dupe(u8, sha);
@@ -256,7 +261,7 @@ fn installTapRb(
     }) catch return InstallError.FormulaNotFound;
 
     var rb_resp = http.get(rb_url) catch {
-        output.err("Cannot fetch tap from GitHub", .{});
+        sink.err("Cannot fetch tap from GitHub", .{});
         return InstallError.FormulaNotFound;
     };
     defer rb_resp.deinit();
@@ -281,20 +286,20 @@ fn installTapRb(
         }) catch return InstallError.FormulaNotFound;
 
         cask_resp = http.get(cask_url) catch {
-            output.err("Cannot fetch tap from GitHub", .{});
+            sink.err("Cannot fetch tap from GitHub", .{});
             return InstallError.FormulaNotFound;
         };
         break :blk &cask_resp.?;
     };
 
     if (resp.status != 200) {
-        output.err("Tap formula/cask not found: {s}", .{pkg_name});
+        sink.err("Tap formula/cask not found: {s}", .{pkg_name});
         return InstallError.FormulaNotFound;
     }
 
     // Parse the Ruby formula to extract name, version, URL, SHA256 for current arch
     const rb = parseRubyFormula(resp.body) orelse {
-        output.err("Cannot parse tap formula (unsupported Ruby DSL shape). Use: brew install {s}", .{pkg_name});
+        sink.err("Cannot parse tap formula (unsupported Ruby DSL shape). Use: brew install {s}", .{pkg_name});
         return InstallError.FormulaNotFound;
     };
 
@@ -318,7 +323,7 @@ fn installTapRb(
             .head_etag = fresh_head_etag,
         },
     };
-    try materializeRubyFormula(ctx, allocator, resolved, &http, db, linker, prefix, dry_run, force, download_only);
+    try materializeRubyFormula(ctx, allocator, resolved, &http, db, linker, prefix, dry_run, force, download_only, sink);
 }
 
 /// Install a formula from a local `.rb` file on disk. Gated by the
@@ -339,12 +344,13 @@ pub fn installLocalFormula(
     prefix: []const u8,
     dry_run: bool,
     force: bool,
+    sink: OutputSink,
 ) InstallError!void {
     // Expand a leading `~/` to `$HOME` so the common "drop it in
     // your dotfiles" path works without requiring shell expansion.
     var home_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
     const expanded = args.expandTildePath(ctx, &home_buf, pkg_arg) orelse {
-        output.err("Cannot resolve home directory for '{s}'", .{pkg_arg});
+        sink.err("Cannot resolve home directory for '{s}'", .{pkg_arg});
         return InstallError.LocalFormulaNotReadable;
     };
 
@@ -355,12 +361,12 @@ pub fn installLocalFormula(
     var real_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
     const real_n = if (std.fs.path.isAbsolute(expanded))
         std.Io.Dir.realPathFileAbsolute(ctx.io, expanded, &real_buf) catch {
-            output.err("Cannot open local formula: {s}", .{pkg_arg});
+            sink.err("Cannot open local formula: {s}", .{pkg_arg});
             return InstallError.LocalFormulaNotReadable;
         }
     else
         std.Io.Dir.cwd().realPathFile(ctx.io, expanded, &real_buf) catch {
-            output.err("Cannot open local formula: {s}", .{pkg_arg});
+            sink.err("Cannot open local formula: {s}", .{pkg_arg});
             return InstallError.LocalFormulaNotReadable;
         };
     const realpath = real_buf[0..real_n];
@@ -369,25 +375,25 @@ pub fn installLocalFormula(
     // vector (parse is pure, but post_install + the archive URL trust
     // this file). Printing the realpath surfaces hidden /tmp or
     // world-writable locations to an attentive reader.
-    output.warn("Installing from local file '{s}'. Only install .rb files you trust.", .{realpath});
+    sink.warn("Installing from local file '{s}'. Only install .rb files you trust.", .{realpath});
 
     // Reject non-regular files outright (directory, socket, device)
     // before allocating a read buffer.
     const f = std.Io.Dir.openFileAbsolute(ctx.io, realpath, .{ .mode = .read_only }) catch {
-        output.err("Cannot open local formula: {s}", .{realpath});
+        sink.err("Cannot open local formula: {s}", .{realpath});
         return InstallError.LocalFormulaNotReadable;
     };
     defer f.close(ctx.io);
     const st = f.stat(ctx.io) catch {
-        output.err("Cannot stat local formula: {s}", .{realpath});
+        sink.err("Cannot stat local formula: {s}", .{realpath});
         return InstallError.LocalFormulaNotReadable;
     };
     if (st.kind != .file) {
-        output.err("Local formula is not a regular file: {s}", .{realpath});
+        sink.err("Local formula is not a regular file: {s}", .{realpath});
         return InstallError.LocalFormulaNotReadable;
     }
     if (st.size > max_local_formula_bytes) {
-        output.err("Local formula exceeds {d}-byte read cap: {s}", .{ max_local_formula_bytes, realpath });
+        sink.err("Local formula exceeds {d}-byte read cap: {s}", .{ max_local_formula_bytes, realpath });
         return InstallError.LocalFormulaNotReadable;
     }
 
@@ -396,30 +402,30 @@ pub fn installLocalFormula(
     // block — but we make the risk visible on the same line style as
     // the primary security warning.
     if (fstatRisk(f)) |risk| switch (risk) {
-        .world_writable => output.warn("Local formula is world-writable — any local user could rewrite it between reads.", .{}),
-        .other_owner => output.warn("Local formula is not owned by you — another account wrote this file.", .{}),
+        .world_writable => sink.warn("Local formula is world-writable — any local user could rewrite it between reads.", .{}),
+        .other_owner => sink.warn("Local formula is not owned by you — another account wrote this file.", .{}),
     };
 
     const size: usize = @intCast(@min(@as(u64, max_local_formula_bytes), st.size));
     const body_buf = allocator.alloc(u8, size) catch {
-        output.err("Cannot read local formula: {s}", .{realpath});
+        sink.err("Cannot read local formula: {s}", .{realpath});
         return InstallError.LocalFormulaNotReadable;
     };
     const n = f.readPositionalAll(ctx.io, body_buf, 0) catch {
         allocator.free(body_buf);
-        output.err("Cannot read local formula: {s}", .{realpath});
+        sink.err("Cannot read local formula: {s}", .{realpath});
         return InstallError.LocalFormulaNotReadable;
     };
     const body = if (n == body_buf.len) body_buf else allocator.realloc(body_buf, n) catch {
         allocator.free(body_buf);
-        output.err("Cannot read local formula: {s}", .{realpath});
+        sink.err("Cannot read local formula: {s}", .{realpath});
         return InstallError.LocalFormulaNotReadable;
     };
     defer allocator.free(body);
 
     // Parse the Ruby formula to extract name, version, URL, SHA256 for current arch
     const rb = parseRubyFormula(body) orelse {
-        output.err("Cannot parse local formula (missing version/url/sha256 or unsupported DSL shape): {s}", .{realpath});
+        sink.err("Cannot parse local formula (missing version/url/sha256 or unsupported DSL shape): {s}", .{realpath});
         return InstallError.FormulaNotFound;
     };
 
@@ -428,7 +434,7 @@ pub fn installLocalFormula(
     // the canonical surface for the cellar path, bin name, and DB row.
     const base = std.fs.path.basename(realpath);
     if (!std.mem.endsWith(u8, base, ".rb") or base.len <= 3) {
-        output.err("Local formula must end in .rb: {s}", .{realpath});
+        sink.err("Local formula must end in .rb: {s}", .{realpath});
         return InstallError.LocalFormulaNotReadable;
     }
     const name = base[0 .. base.len - 3];
@@ -452,7 +458,7 @@ pub fn installLocalFormula(
     // `--local` is out of scope for `--download-only`: the user already
     // holds the archive on disk so warming a tap-cache entry adds no
     // value. Hard-wire false here rather than threading the flag.
-    try materializeRubyFormula(ctx, allocator, resolved, &http, db, linker, prefix, dry_run, force, false);
+    try materializeRubyFormula(ctx, allocator, resolved, &http, db, linker, prefix, dry_run, force, false, sink);
 }
 
 /// Ordered set of advisory risk labels that may fire on a `.rb` file
@@ -514,15 +520,16 @@ pub fn materializeRubyFormula(
     dry_run: bool,
     force: bool,
     download_only: bool,
+    sink: OutputSink,
 ) InstallError!void {
-    output.info("Found {s} {s}", .{ resolved.name, resolved.version });
+    sink.info("Found {s} {s}", .{ resolved.name, resolved.version });
 
     // Refuse any scheme other than `https://`. A `.rb` that smuggled
     // `http://` (downgrade), `file:///etc/passwd`, `ftp://`, or a data
     // URI would otherwise be trusted by the HTTP client. Enforced for
     // every caller of this helper — tap and local share the check.
     if (!args.isAllowedArchiveUrl(resolved.url)) {
-        output.err("Refusing to fetch non-HTTPS archive URL for {s}: {s}", .{ resolved.name, resolved.url });
+        sink.err("Refusing to fetch non-HTTPS archive URL for {s}: {s}", .{ resolved.name, resolved.url });
         return InstallError.InsecureArchiveUrl;
     }
 
@@ -530,18 +537,18 @@ pub fn materializeRubyFormula(
     // mounting, ditto, and `installer` live there. Tar.gz/tar.xz/zip
     // formula archives keep the simple-extract path below.
     if (tapCaskArtifactKind(resolved.url, resolved.app_name != null)) |kind| {
-        return materializeTapCask(ctx, allocator, resolved, db, kind, dry_run, force, download_only);
+        return materializeTapCask(ctx, allocator, resolved, db, kind, dry_run, force, download_only, sink);
     }
 
     if (dry_run) {
-        output.info("Dry run: would install {s} {s} from {s}", .{ resolved.name, resolved.version, resolved.url });
+        sink.info("Dry run: would install {s} {s} from {s}", .{ resolved.name, resolved.version, resolved.url });
         return;
     }
 
     // `--download-only` deliberately skips `isInstalled`: a warm
     // request must refresh the cache regardless of install state.
     if (!download_only and !force and record.isInstalled(db, resolved.name)) {
-        output.info("{s} is already installed", .{resolved.name});
+        sink.info("{s} is already installed", .{resolved.name});
         return;
     }
 
@@ -550,8 +557,8 @@ pub fn materializeRubyFormula(
     // work. Unknown formats fail fast — no point fetching bytes we
     // can't extract.
     const archive_kind = TapArchiveKind.fromUrl(resolved.url) orelse {
-        output.err("Unsupported archive format for {s}: {s}", .{ resolved.name, resolved.url });
-        output.err("Supported formats: .tar.gz, .tar.xz, .zip.", .{});
+        sink.err("Unsupported archive format for {s}: {s}", .{ resolved.name, resolved.url });
+        sink.err("Supported formats: .tar.gz, .tar.xz, .zip.", .{});
         return InstallError.DownloadFailed;
     };
     const archive_ext = archive_kind.extension();
@@ -585,20 +592,23 @@ pub fn materializeRubyFormula(
         // permanent cache path. A crash mid-write leaves only the
         // staging file (which `mt doctor --fix` and the tap-tmp
         // cleanup regression already reclaim).
+        // A non-terminal sink (bundle) skips the bar — the global progress
+        // mode is set-once and can't be quieted mid-run.
         var bar = progress_mod.ProgressBar.init(resolved.name, 0);
-        var download_resp = http.getWithHeaders(resolved.url, &.{}, .{
-            .context = @ptrCast(&bar),
-            .func = &download.progressBridge,
-        }) catch {
-            bar.finish();
-            output.err("Failed to download {s}", .{resolved.name});
+        const bar_cb: ?client_mod.ProgressCallback = if (sink.show_progress)
+            .{ .context = @ptrCast(&bar), .func = &download.progressBridge }
+        else
+            null;
+        var download_resp = http.getWithHeaders(resolved.url, &.{}, bar_cb) catch {
+            if (sink.show_progress) bar.finish();
+            sink.err("Failed to download {s}", .{resolved.name});
             return InstallError.DownloadFailed;
         };
         defer download_resp.deinit();
-        bar.finish();
+        if (sink.show_progress) bar.finish();
 
         if (download_resp.status != 200) {
-            output.err("Download failed with status {d}", .{download_resp.status});
+            sink.err("Download failed with status {d}", .{download_resp.status});
             return InstallError.DownloadFailed;
         }
 
@@ -616,7 +626,7 @@ pub fn materializeRubyFormula(
         // leaks per-byte progress via timing, giving an adaptive
         // attacker a byte-by-byte oracle against the expected hash.
         if (!hash.constantTimeEql(u8, computed, resolved.sha256)) {
-            output.err("SHA256 mismatch for {s}", .{resolved.name});
+            sink.err("SHA256 mismatch for {s}", .{resolved.name});
             return InstallError.DownloadFailed;
         }
 
@@ -651,7 +661,7 @@ pub fn materializeRubyFormula(
     if (download_only) {
         output.emitNdjsonEvent(.download_complete, resolved.name, "ok");
         dl_complete_emitted = true;
-        output.success("{s} {s} downloaded to {s}", .{ resolved.name, resolved.version, cache_path });
+        sink.success("{s} {s} downloaded to {s}", .{ resolved.name, resolved.version, cache_path });
         return;
     }
 
@@ -691,15 +701,15 @@ pub fn materializeRubyFormula(
     const archive_mod = @import("../../fs/archive.zig");
     switch (archive_kind) {
         .tar_gz => archive_mod.extractTarGz(ctx.io, cache_path, cellar_path) catch {
-            output.err("Failed to extract archive for {s}", .{resolved.name});
+            sink.err("Failed to extract archive for {s}", .{resolved.name});
             return InstallError.CellarFailed;
         },
         .tar_xz => archive_mod.extractTarXzFile(ctx.io, cache_path, cellar_path) catch {
-            output.err("Failed to extract .tar.xz archive for {s}", .{resolved.name});
+            sink.err("Failed to extract .tar.xz archive for {s}", .{resolved.name});
             return InstallError.CellarFailed;
         },
         .zip => archive_mod.extractZip(ctx.io, cache_path, cellar_path) catch {
-            output.err("Failed to extract .zip archive for {s}", .{resolved.name});
+            sink.err("Failed to extract .zip archive for {s}", .{resolved.name});
             return InstallError.CellarFailed;
         },
     }
@@ -736,7 +746,7 @@ pub fn materializeRubyFormula(
         }
     }
 
-    output.info("Linking {s}...", .{resolved.name});
+    sink.info("Linking {s}...", .{resolved.name});
 
     // Single DB transaction: keg row → optional tap registration →
     // linker work → commit. `errdefer rollback` unwinds cleanly if any
@@ -787,10 +797,10 @@ pub fn materializeRubyFormula(
     }
 
     linker.link(cellar_path, resolved.name, keg_id, false) catch {
-        output.warn("Some links for {s} could not be created", .{resolved.name});
+        sink.warn("Some links for {s} could not be created", .{resolved.name});
     };
     linker.linkOpt(resolved.name, resolved.version) catch {
-        output.warn("Could not create opt link for {s}", .{resolved.name});
+        sink.warn("Could not create opt link for {s}", .{resolved.name});
     };
 
     // `--force` post-link: the new row is recorded and the pin (if
@@ -804,7 +814,7 @@ pub fn materializeRubyFormula(
 
     db.commit() catch return InstallError.RecordFailed;
 
-    output.success("{s} {s} installed", .{ resolved.name, resolved.version });
+    sink.success("{s} {s} installed", .{ resolved.name, resolved.version });
 }
 
 /// Hand a tap cask off to the shared `core/cask.zig` installer by
@@ -823,18 +833,19 @@ fn materializeTapCask(
     dry_run: bool,
     force: bool,
     download_only: bool,
+    sink: OutputSink,
 ) InstallError!void {
     // `--download-only` deliberately ignores `isInstalled` so a user
     // can refresh the cached artefact ahead of an `mt upgrade` even
     // when an older revision is on disk. The regular install path
     // keeps the "already installed" short-circuit.
     if (!download_only and !force and cask_mod.isInstalled(db, resolved.name)) {
-        output.info("{s} is already installed", .{resolved.name});
+        sink.info("{s} is already installed", .{resolved.name});
         return;
     }
 
     if (dry_run) {
-        output.info("Dry run: would install cask {s} {s} from {s}", .{ resolved.name, resolved.version, resolved.url });
+        sink.info("Dry run: would install cask {s} {s} from {s}", .{ resolved.name, resolved.version, resolved.url });
         return;
     }
 
@@ -848,7 +859,7 @@ fn materializeTapCask(
     buildSyntheticCaskJson(allocator, &json_buf, resolved) catch return InstallError.RecordFailed;
 
     var cask = cask_mod.parseCask(allocator, json_buf.items) catch {
-        output.err("Failed to materialise cask {s} from tap DSL", .{resolved.name});
+        sink.err("Failed to materialise cask {s} from tap DSL", .{resolved.name});
         return InstallError.CaskNotFound;
     };
     defer cask.deinit();
@@ -857,14 +868,18 @@ fn materializeTapCask(
     installer.artifact_type_override = kind;
     installer.offline = ctx.offline;
 
+    // A non-terminal sink (bundle) skips the bar — the global progress
+    // mode is set-once and can't be quieted mid-run.
     var bar = progress_mod.ProgressBar.init(cask.token, 0);
-    installer.progress = .{
-        .context = @ptrCast(&bar),
-        .func = &download.progressBridge,
-    };
+    if (sink.show_progress) {
+        installer.progress = .{
+            .context = @ptrCast(&bar),
+            .func = &download.progressBridge,
+        };
+    }
 
     if (kind == .pkg) {
-        output.warn("{s} is a PKG cask and requires sudo to install via macOS Installer.", .{cask.token});
+        sink.warn("{s} is a PKG cask and requires sudo to install via macOS Installer.", .{cask.token});
     }
 
     // `--download-only` for a cask-shaped tap entry reuses the cask
@@ -874,38 +889,38 @@ fn materializeTapCask(
     if (download_only) {
         output.emitNdjsonEvent(.download_started, cask.token, null);
         const cache_path = installer.downloadOnly(&cask) catch |e| {
-            bar.finish();
+            if (sink.show_progress) bar.finish();
             output.emitNdjsonEvent(.download_complete, cask.token, "failed");
-            output.err("Failed to download cask {s}: {s}", .{ cask.token, @errorName(e) });
+            sink.err("Failed to download cask {s}: {s}", .{ cask.token, @errorName(e) });
             return switch (e) {
                 error.DownloadFailed, error.Sha256Mismatch => InstallError.DownloadFailed,
                 error.OutOfMemory => InstallError.RecordFailed,
                 else => InstallError.CaskNotFound,
             };
         };
-        bar.finish();
+        if (sink.show_progress) bar.finish();
         defer allocator.free(cache_path);
         output.emitNdjsonEvent(.download_complete, cask.token, "ok");
-        output.success("{s} {s} downloaded to {s}", .{ cask.token, cask.version, cache_path });
+        sink.success("{s} {s} downloaded to {s}", .{ cask.token, cask.version, cache_path });
         return;
     }
 
     const app_path = installer.install(&cask) catch |e| {
-        bar.finish();
-        output.err("Failed to install cask {s}: {s}", .{ cask.token, @errorName(e) });
+        if (sink.show_progress) bar.finish();
+        sink.err("Failed to install cask {s}: {s}", .{ cask.token, @errorName(e) });
         return switch (e) {
             error.DownloadFailed, error.Sha256Mismatch => InstallError.DownloadFailed,
             error.OutOfMemory => InstallError.RecordFailed,
             else => InstallError.CaskNotFound,
         };
     };
-    bar.finish();
+    if (sink.show_progress) bar.finish();
     defer allocator.free(app_path);
 
     // `try` is the invariant: success line never fires without a row.
-    try finalizeTapCaskInstall(allocator, db, &cask, app_path, resolved.tap_label, resolved.tap_registration);
+    try finalizeTapCaskInstall(allocator, db, &cask, app_path, resolved.tap_label, resolved.tap_registration, sink);
 
-    output.success("{s} {s} installed", .{ cask.token, cask.version });
+    sink.success("{s} {s} installed", .{ cask.token, cask.version });
 }
 
 /// Serialize a Homebrew-cask-API-shaped JSON document so the existing
@@ -987,9 +1002,10 @@ fn finalizeTapCaskInstall(
     app_path: ?[]const u8,
     tap_label: []const u8,
     tap_registration: ?TapRegistration,
+    sink: OutputSink,
 ) InstallError!void {
     cask_mod.recordInstall(db, cask, app_path, tap_label) catch {
-        output.err("failed to record installed cask {s}", .{cask.token});
+        sink.err("failed to record installed cask {s}", .{cask.token});
         return InstallError.RecordFailed;
     };
     // Tap row + etag are advisory; the cask row is the install
@@ -1090,7 +1106,7 @@ test "finalizeTapCaskInstall persists the cask row on the happy path" {
     var cask = try cask_mod.parseCask(std.testing.allocator, json_buf.items);
     defer cask.deinit();
 
-    try finalizeTapCaskInstall(std.testing.allocator, &db, &cask, "/tmp/Deck.app", "yuzeguitarist/deck", null);
+    try finalizeTapCaskInstall(std.testing.allocator, &db, &cask, "/tmp/Deck.app", "yuzeguitarist/deck", null, sink_mod.terminal);
 
     var stmt = try db.prepare("SELECT version, tap FROM casks WHERE token = ?1;");
     defer stmt.finalize();
@@ -1151,7 +1167,7 @@ test "finalizeTapCaskInstall stamps the owning tap when tap_registration is set"
         .url = "https://github.com/yuzeguitarist/homebrew-deck",
         .commit_sha = sha,
         .head_etag = "\"etag-abc\"",
-    });
+    }, sink_mod.terminal);
 
     var stmt = try db.prepare("SELECT commit_sha, head_etag FROM taps WHERE name = ?1;");
     defer stmt.finalize();
@@ -1188,9 +1204,11 @@ test "finalizeTapCaskInstall fails loud when the cask DB row cannot persist" {
     output.beginStderrCapture(std.testing.allocator, &captured);
     defer output.endStderrCapture();
 
-    // Mirror the materializeTapCask call site shape.
+    // Mirror the materializeTapCask call site shape. The terminal sink
+    // forwards to `ui/output`, so the captured stderr below still sees
+    // finalize's error line — proving the diagnostic survives the sink.
     var finalize_err: ?InstallError = null;
-    finalizeTapCaskInstall(std.testing.allocator, &db, &cask, null, "yuzeguitarist/deck", null) catch |e| {
+    finalizeTapCaskInstall(std.testing.allocator, &db, &cask, null, "yuzeguitarist/deck", null, sink_mod.terminal) catch |e| {
         finalize_err = e;
     };
     if (finalize_err == null) {

--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -5,15 +5,18 @@
 //! human + JSON envelopes regardless of which command did the work.
 
 const std = @import("std");
+
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
 const deps_mod = @import("../../core/deps.zig");
-const formula_mod = @import("../../core/formula.zig");
 const dsl = @import("../../core/dsl/root.zig");
+const formula_mod = @import("../../core/formula.zig");
 const ruby_sub = @import("../../core/ruby_subprocess.zig");
 const sandbox = @import("../../core/sandbox/macos.zig");
 const output = @import("../../ui/output.zig");
-
 const download = @import("download.zig");
+pub const DownloadJob = download.DownloadJob;
+const sink_mod = @import("sink.zig");
+const OutputSink = sink_mod.OutputSink;
 
 /// Extract the post_install body from a tap's `<name>.rb`. Tap kegs
 /// aren't reachable from the bottle DSL pipeline (the locator only
@@ -25,8 +28,6 @@ const download = @import("download.zig");
 pub fn extractRbPostInstallBody(io: std.Io, allocator: std.mem.Allocator, rb_path: []const u8) ?[]const u8 {
     return ruby_sub.extractPostInstallBody(io, allocator, rb_path);
 }
-
-pub const DownloadJob = download.DownloadJob;
 
 /// Whether --use-system-ruby opts the named formula into the Ruby
 /// post_install path. Caller carries the parsed scope from the flag.
@@ -88,6 +89,7 @@ pub fn routePostInstallOutcome(
     prefix: []const u8,
     flog: *const dsl.FallbackLog,
     use_system_ruby_list: []const []const u8,
+    sink: OutputSink,
 ) void {
     routePostInstallOutcomeWithBody(
         ctx,
@@ -98,6 +100,7 @@ pub fn routePostInstallOutcome(
         flog,
         use_system_ruby_list,
         null,
+        sink,
     );
 }
 
@@ -114,10 +117,11 @@ pub fn routePostInstallOutcomeWithBody(
     flog: *const dsl.FallbackLog,
     use_system_ruby_list: []const []const u8,
     pre_resolved_body: ?[]const u8,
+    sink: OutputSink,
 ) void {
     const status: PostInstallStatus = blk: {
         if (flog.hasFatal()) {
-            output.warn("post_install DSL failed for {s} (fatal)", .{name});
+            sink.warn("post_install DSL failed for {s} (fatal)", .{name});
             flog.printFatal(name);
             // `--debug` also surfaces the non-fatal context so a bug
             // report includes every reason the DSL logged, not just the
@@ -126,7 +130,7 @@ pub fn routePostInstallOutcomeWithBody(
             break :blk .fatal;
         }
         if (!flog.hasErrors()) {
-            output.info("post_install completed for {s}", .{name});
+            sink.info("post_install completed for {s}", .{name});
             break :blk .completed;
         }
         // Auto-included Ruby-interpreter kegs (`ruby`, `ruby@N`) skip the
@@ -138,7 +142,7 @@ pub fn routePostInstallOutcomeWithBody(
         const explicit_opt_in = useSystemRubyForFormula(use_system_ruby_list, name);
         const auto_self_hosting = isSelfHostingRubyKeg(name);
         if (explicit_opt_in or (auto_self_hosting and !flog.dslDidWork())) {
-            output.warn("post_install DSL incomplete for {s}, falling back to system Ruby...", .{name});
+            sink.warn("post_install DSL incomplete for {s}, falling back to system Ruby...", .{name});
             if (output.isVerbose()) flog.printUnknown(name);
             if (output.isDebug()) flog.printFatal(name);
             const ruby_stdio: sandbox.Stdio = .{ .out = ctx.stdout.handle, .err = ctx.stderr.handle };
@@ -147,15 +151,15 @@ pub fn routePostInstallOutcomeWithBody(
             else
                 ruby_sub.runPostInstall(ctx.io, ctx.environ, allocator, name, version_str, prefix, ruby_stdio);
             ruby_result catch |err| {
-                output.warn("post_install subprocess failed for {s}: {s}", .{ name, ruby_sub.describeError(err) });
+                sink.warn("post_install subprocess failed for {s}: {s}", .{ name, ruby_sub.describeError(err) });
                 break :blk .ruby_fallback_failed;
             };
             // Symmetric with the native "completed" info so scripted users
             // see a positive signal when the Ruby escape hatch succeeded.
-            output.info("post_install completed for {s} (via system Ruby)", .{name});
+            sink.info("post_install completed for {s} (via system Ruby)", .{name});
             break :blk .ran_via_ruby;
         }
-        output.warn("{s}: post_install partially skipped (use --use-system-ruby={s} to attempt via Ruby)", .{ name, name });
+        sink.warn("{s}: post_install partially skipped (use --use-system-ruby={s} to attempt via Ruby)", .{ name, name });
         if (output.isVerbose()) flog.printUnknown(name);
         if (output.isDebug()) flog.printFatal(name);
         break :blk .partially_skipped;
@@ -170,7 +174,7 @@ pub fn routePostInstallOutcomeWithBody(
     if (output.isJson()) {
         switch (output.postInstallEmit()) {
             .stream => emitPostInstallStreamLine(allocator, name, status, flog),
-            .embed => bufferPostInstallEvent(allocator, name, status, flog),
+            .embed => bufferPostInstallEvent(allocator, name, status, flog, sink),
         }
     }
 }
@@ -201,6 +205,7 @@ fn bufferPostInstallEvent(
     name: []const u8,
     status: PostInstallStatus,
     flog: *const dsl.FallbackLog,
+    sink: OutputSink,
 ) void {
     var aw: std.Io.Writer.Allocating = .init(allocator);
     defer aw.deinit();
@@ -210,7 +215,7 @@ fn bufferPostInstallEvent(
     w.writeAll("}") catch return;
     // Surface push errors loudly so a half-populated summary is obvious.
     output.pushPostInstallEvent(aw.written()) catch |e|
-        output.warn("post_install event buffering failed for {s}: {s}", .{ name, @errorName(e) });
+        sink.warn("post_install event buffering failed for {s}: {s}", .{ name, @errorName(e) });
 }
 
 /// Shared payload writer so the streaming line and buffered embed
@@ -261,6 +266,7 @@ pub fn executeDslPostInstall(
     prefix: []const u8,
     use_system_ruby_list: []const []const u8,
     cache: ?*deps_mod.FormulaCache,
+    sink: OutputSink,
 ) DslPostInstallOutcome {
     var owned: ?formula_mod.Formula = null;
     defer if (owned) |*f| f.deinit();
@@ -268,13 +274,13 @@ pub fn executeDslPostInstall(
     const dsl_version: []const u8, const pkg_version: []const u8 = blk: {
         if (cache) |c| {
             const f = c.getOrParse(name, formula_json) catch {
-                output.warn("post_install: failed to parse formula for {s}", .{name});
+                sink.warn("post_install: failed to parse formula for {s}", .{name});
                 return .parse_failed;
             };
             break :blk .{ f.version, f.pkg_version };
         }
         owned = formula_mod.parseFormula(allocator, formula_json) catch {
-            output.warn("post_install: failed to parse formula for {s}", .{name});
+            sink.warn("post_install: failed to parse formula for {s}", .{name});
             return .parse_failed;
         };
         break :blk .{ owned.?.version, owned.?.pkg_version };
@@ -290,6 +296,7 @@ pub fn executeDslPostInstall(
         post_install_src,
         prefix,
         use_system_ruby_list,
+        sink,
     );
     return .handled;
 }
@@ -310,6 +317,7 @@ pub fn executeDslPostInstallFields(
     post_install_src: []const u8,
     prefix: []const u8,
     use_system_ruby_list: []const []const u8,
+    sink: OutputSink,
 ) void {
     var flog = dsl.FallbackLog.init(allocator);
     defer flog.deinit();
@@ -330,6 +338,7 @@ pub fn executeDslPostInstallFields(
         &flog,
         use_system_ruby_list,
         post_install_src,
+        sink,
     );
 }
 
@@ -367,6 +376,7 @@ pub fn drive(
     prefix: []const u8,
     use_system_ruby_list: []const []const u8,
     cache: ?*deps_mod.FormulaCache,
+    sink: OutputSink,
 ) void {
     if (locateDslSource(ctx, allocator, name)) |src| {
         defer allocator.free(src);
@@ -380,6 +390,7 @@ pub fn drive(
             prefix,
             use_system_ruby_list,
             cache,
+            sink,
         )) {
             .handled => return,
             // parse_failed leaves the DSL path unusable — fall through so
@@ -389,13 +400,13 @@ pub fn drive(
     }
 
     if (useSystemRubyForFormula(use_system_ruby_list, name) or isSelfHostingRubyKeg(name)) {
-        output.warn("Running post_install for {s} via system Ruby...", .{name});
+        sink.warn("Running post_install for {s} via system Ruby...", .{name});
         const ruby_stdio: sandbox.Stdio = .{ .out = ctx.stdout.handle, .err = ctx.stderr.handle };
         ruby_sub.runPostInstall(ctx.io, ctx.environ, allocator, name, version_str, prefix, ruby_stdio) catch |e| {
-            output.warn("post_install failed for {s}: {s}", .{ name, ruby_sub.describeError(e) });
+            sink.warn("post_install failed for {s}: {s}", .{ name, ruby_sub.describeError(e) });
         };
     } else {
-        output.warn("{s}: post_install skipped (use --use-system-ruby={s} or brew install {s})", .{ name, name, name });
+        sink.warn("{s}: post_install skipped (use --use-system-ruby={s} or brew install {s})", .{ name, name, name });
     }
 }
 
@@ -418,6 +429,7 @@ pub fn driveTap(
     post_install_src: []const u8,
     prefix: []const u8,
     use_system_ruby_list: []const []const u8,
+    sink: OutputSink,
 ) void {
     executeDslPostInstallFields(
         ctx,
@@ -429,6 +441,7 @@ pub fn driveTap(
         post_install_src,
         prefix,
         use_system_ruby_list,
+        sink,
     );
 }
 

--- a/src/cli/install/sink.zig
+++ b/src/cli/install/sink.zig
@@ -1,0 +1,167 @@
+//! malt — install output sink.
+//!
+//! Injected emission seam for the install pipeline. The bundle runner's
+//! `Dispatcher` calls `installAll`, but the global `ui/output` quiet/mode
+//! flags are set once before workers spawn and must not be flipped at
+//! runtime — so a non-terminal consumer cannot quiet per-keg output by
+//! toggling the global. A sink threaded through `InstallAllOpts` lets it.
+//!
+//! Mirrors `core/bundle/runner.zig`'s `Dispatcher`: `ctx` + runtime
+//! function pointers, so a future headless consumer injects its own sink
+//! rather than picking from a closed mode enum. The built-in `terminal`
+//! sink forwards to `ui/output` (behaviour identical to today); `silent`
+//! swallows the human lines so bundle's structured `Report` is the only
+//! channel. ndjson events and `--dry-run`/`--json` queries stay on the
+//! global on purpose — they are an always-on machine channel and run
+//! configuration, not suppressible human output.
+
+const std = @import("std");
+
+const output = @import("../../ui/output.zig");
+
+pub const OutputSink = struct {
+    ctx: ?*anyopaque = null,
+    writeInfo: *const fn (ctx: ?*anyopaque, msg: []const u8) void,
+    writeWarn: *const fn (ctx: ?*anyopaque, msg: []const u8) void,
+    writeSuccess: *const fn (ctx: ?*anyopaque, msg: []const u8) void,
+    writeErr: *const fn (ctx: ?*anyopaque, msg: []const u8) void,
+    /// Whether long-running steps render progress bars. Bars also self-gate
+    /// on the global progress mode, but bundle can't flip that mid-run, so
+    /// the silent sink clears this and the construction sites skip the bar.
+    show_progress: bool = true,
+
+    /// Comptime format wrappers mirror `output.emitPrefixLine`'s 4096-byte
+    /// `bufPrint` so an over-long message is dropped identically to today;
+    /// the rendered bytes then dispatch through the runtime vtable.
+    pub fn info(self: *const OutputSink, comptime fmt: []const u8, args: anytype) void {
+        var buf: [4096]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
+        self.writeInfo(self.ctx, msg);
+    }
+    pub fn warn(self: *const OutputSink, comptime fmt: []const u8, args: anytype) void {
+        var buf: [4096]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
+        self.writeWarn(self.ctx, msg);
+    }
+    pub fn success(self: *const OutputSink, comptime fmt: []const u8, args: anytype) void {
+        var buf: [4096]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
+        self.writeSuccess(self.ctx, msg);
+    }
+    pub fn err(self: *const OutputSink, comptime fmt: []const u8, args: anytype) void {
+        var buf: [4096]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
+        self.writeErr(self.ctx, msg);
+    }
+};
+
+// `"{s}"` re-format keeps `output`'s prefix/colour/quiet handling intact;
+// the message bytes are identical regardless of the formatting round-trip.
+fn termInfo(_: ?*anyopaque, msg: []const u8) void {
+    output.info("{s}", .{msg});
+}
+fn termWarn(_: ?*anyopaque, msg: []const u8) void {
+    output.warn("{s}", .{msg});
+}
+fn termSuccess(_: ?*anyopaque, msg: []const u8) void {
+    output.success("{s}", .{msg});
+}
+fn termErr(_: ?*anyopaque, msg: []const u8) void {
+    output.err("{s}", .{msg});
+}
+
+fn swallow(_: ?*anyopaque, _: []const u8) void {}
+
+/// Default sink: behaviour identical to calling `ui/output.*` directly.
+pub const terminal: OutputSink = .{
+    .writeInfo = termInfo,
+    .writeWarn = termWarn,
+    .writeSuccess = termSuccess,
+    .writeErr = termErr,
+    .show_progress = true,
+};
+
+/// Non-terminal sink: human lines are dropped so a structured consumer
+/// (the bundle runner's `Report`) owns reporting. ndjson still flows.
+pub const silent: OutputSink = .{
+    .writeInfo = swallow,
+    .writeWarn = swallow,
+    .writeSuccess = swallow,
+    .writeErr = swallow,
+    .show_progress = false,
+};
+
+test "terminal sink forwards human lines to ui/output" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    output.beginStderrCapture(std.testing.allocator, &buf);
+    defer output.endStderrCapture();
+
+    terminal.info("hello {d}", .{7});
+    terminal.err("boom", .{});
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "hello 7") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "boom") != null);
+}
+
+test "silent sink swallows every human line" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    output.beginStderrCapture(std.testing.allocator, &buf);
+    defer output.endStderrCapture();
+
+    silent.info("x", .{});
+    silent.warn("y", .{});
+    silent.success("z", .{});
+    silent.err("w", .{});
+
+    try std.testing.expectEqual(@as(usize, 0), buf.items.len);
+}
+
+test "silent sink disables progress; terminal enables it" {
+    try std.testing.expect(terminal.show_progress);
+    try std.testing.expect(!silent.show_progress);
+}
+
+const RecordingSink = struct {
+    infos: usize = 0,
+    errs: usize = 0,
+
+    fn writeInfo(ctx: ?*anyopaque, _: []const u8) void {
+        const self: *RecordingSink = @ptrCast(@alignCast(ctx));
+        self.infos += 1;
+    }
+    fn writeErr(ctx: ?*anyopaque, _: []const u8) void {
+        const self: *RecordingSink = @ptrCast(@alignCast(ctx));
+        self.errs += 1;
+    }
+    fn writeNoop(_: ?*anyopaque, _: []const u8) void {}
+
+    fn sink(self: *RecordingSink) OutputSink {
+        return .{
+            .ctx = self,
+            .writeInfo = writeInfo,
+            .writeWarn = writeNoop,
+            .writeSuccess = writeNoop,
+            .writeErr = writeErr,
+        };
+    }
+};
+
+test "injected sink routes through ctx, not the global output" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    output.beginStderrCapture(std.testing.allocator, &buf);
+    defer output.endStderrCapture();
+
+    var rec: RecordingSink = .{};
+    const s = rec.sink();
+    s.info("a", .{});
+    s.info("b", .{});
+    s.err("c", .{});
+
+    try std.testing.expectEqual(@as(usize, 2), rec.infos);
+    try std.testing.expectEqual(@as(usize, 1), rec.errs);
+    // A custom sink must not leak onto the global stderr channel.
+    try std.testing.expectEqual(@as(usize, 0), buf.items.len);
+}

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -4,22 +4,24 @@
 //! shrinks to flag parsing, scan, and dispatch.
 
 const std = @import("std");
+
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
-const sqlite = @import("../../db/sqlite.zig");
-const formula_mod = @import("../../core/formula.zig");
 const bottle_mod = @import("../../core/bottle.zig");
-const store_mod = @import("../../core/store.zig");
 const cellar_mod = @import("../../core/cellar.zig");
+const formula_mod = @import("../../core/formula.zig");
+const install_receipt_mod = @import("../../core/install_receipt.zig");
 const linker_mod = @import("../../core/linker.zig");
+const store_mod = @import("../../core/store.zig");
+const sqlite = @import("../../db/sqlite.zig");
+const atomic = @import("../../fs/atomic.zig");
+const api_mod = @import("../../net/api.zig");
 const client_mod = @import("../../net/client.zig");
 const ghcr_mod = @import("../../net/ghcr.zig");
-const api_mod = @import("../../net/api.zig");
-const atomic = @import("../../fs/atomic.zig");
 const output = @import("../../ui/output.zig");
 const progress_mod = @import("../../ui/progress.zig");
 const post_install_mod = @import("../install/post_install.zig");
+const install_sink_mod = @import("../install/sink.zig");
 const post_install_queue_mod = @import("post_install_queue.zig");
-const install_receipt_mod = @import("../../core/install_receipt.zig");
 
 /// Width budget for the "<tap>/<keg_name>" qualifier we record in
 /// `kegs.full_name`. Long org/tap pairs in private taps push past
@@ -226,6 +228,7 @@ pub fn migrateKeg(
                     deps.prefix,
                     deps.use_system_ruby_scope,
                     null,
+                    install_sink_mod.terminal,
                 );
             };
         } else {
@@ -238,6 +241,7 @@ pub fn migrateKeg(
                 deps.prefix,
                 deps.use_system_ruby_scope,
                 null,
+                install_sink_mod.terminal,
             );
         }
     }
@@ -394,6 +398,7 @@ fn runTapPostInstallIfDefined(
                 body,
                 deps.prefix,
                 deps.use_system_ruby_scope,
+                install_sink_mod.terminal,
             );
         };
     } else {
@@ -405,6 +410,7 @@ fn runTapPostInstallIfDefined(
             body,
             deps.prefix,
             deps.use_system_ruby_scope,
+            install_sink_mod.terminal,
         );
     }
 }

--- a/src/cli/migrate/post_install_queue.zig
+++ b/src/cli/migrate/post_install_queue.zig
@@ -16,8 +16,10 @@
 //! matter for correctness.
 
 const std = @import("std");
-const post_install_mod = @import("../install/post_install.zig");
+
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
+const post_install_mod = @import("../install/post_install.zig");
+const install_sink_mod = @import("../install/sink.zig");
 
 /// Two queueable shapes share the same FIFO and drain so order across
 /// bottle and tap kegs is preserved (fc-cache races care about
@@ -141,6 +143,7 @@ pub const Queue = struct {
                 prefix,
                 use_system_ruby_scope,
                 null,
+                install_sink_mod.terminal,
             ),
             .tap => |tp| post_install_mod.driveTap(
                 ctx,
@@ -150,6 +153,7 @@ pub const Queue = struct {
                 tp.post_install_src,
                 prefix,
                 use_system_ruby_scope,
+                install_sink_mod.terminal,
             ),
         };
     }

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -27,6 +27,7 @@ const install_local_mod = @import("install/local.zig");
 const install_rb_parse_mod = @import("install/rb_parse.zig");
 const install_record_mod = @import("install/record.zig");
 const InstallError = install_record_mod.InstallError;
+const install_sink_mod = @import("install/sink.zig");
 const install_mod = @import("install.zig");
 const pin_mod = @import("pin.zig");
 
@@ -527,7 +528,7 @@ fn upgradeTapFormula(
     defer allocator.free(full_name);
 
     var linker = linker_mod.Linker.init(ctx.io, allocator, db, prefix);
-    install_local_mod.installTapFormula(ctx, allocator, full_name, db, &linker, prefix, dry_run, true, false) catch {
+    install_local_mod.installTapFormula(ctx, allocator, full_name, db, &linker, prefix, dry_run, true, false, install_sink_mod.terminal) catch {
         output.err("Failed to upgrade tap formula {s}", .{full_name});
         return error.Aborted;
     };
@@ -658,7 +659,7 @@ fn upgradeRoutedTapCask(
     // never enters the Formula/ probe that would open a nested DB
     // transaction inside our outer one.
     var linker = linker_mod.Linker.init(ctx.io, allocator, db, prefix);
-    install_local_mod.installTapCask(ctx, allocator, full_name, db, &linker, prefix, dry_run, true) catch |in_err| {
+    install_local_mod.installTapCask(ctx, allocator, full_name, db, &linker, prefix, dry_run, true, install_sink_mod.terminal) catch |in_err| {
         output.err("Failed to upgrade tap cask {s}: {s}", .{ full_name, @errorName(in_err) });
         db.rollback();
         return error.Aborted;

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -19,6 +19,7 @@ pub const install_local = @import("cli/install/local.zig");
 pub const install_post_install = @import("cli/install/post_install.zig");
 pub const install_rb_parse = @import("cli/install/rb_parse.zig");
 pub const install_record = @import("cli/install/record.zig");
+pub const install_sink = @import("cli/install/sink.zig");
 pub const cli_link = @import("cli/link.zig");
 pub const cli_list = @import("cli/list.zig");
 pub const cli_migrate = @import("cli/migrate.zig");

--- a/tests/bundle_test.zig
+++ b/tests/bundle_test.zig
@@ -11,6 +11,9 @@ const sqlite = malt.sqlite;
 const schema = malt.schema;
 const manifest_mod = malt.bundle_manifest;
 const runner = malt.bundle_runner;
+const install = malt.install;
+const install_sink = malt.install_sink;
+const output = malt.output;
 
 const TempDb = struct {
     dir: []const u8,
@@ -434,4 +437,76 @@ test "real-world Brewfile shapes parse without error" {
 
     var report = try runner.run(std.Options.debug_io, testing.allocator, &t.db, m, .{ .dry_run = true, .prefix = t.dir });
     defer report.deinit();
+}
+
+/// Mirrors `cli/bundle.zig`'s real dispatcher: route a member install
+/// through `installAll` with the silent sink, mapping any failure to a
+/// structured `MemberFailed` so the runner's `Report` carries it.
+const SilentInstallCtx = struct {
+    app: *const malt.app_ctx.AppCtx,
+
+    fn installFormulaFn(ctx: ?*anyopaque, allocator: std.mem.Allocator, name: []const u8) runner.DispatchError!void {
+        const self: *SilentInstallCtx = @ptrCast(@alignCast(ctx.?));
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        install.installAll(self.app, arena.allocator(), &.{name}, .{ .sink = install_sink.silent }) catch
+            return runner.DispatchError.MemberFailed;
+    }
+    fn unusedFn(_: ?*anyopaque, _: std.mem.Allocator, _: []const u8) runner.DispatchError!void {
+        unreachable;
+    }
+};
+
+test "silent-sink dispatcher: member failure surfaces via Report with no stderr spam" {
+    var t = try TempDb.init("silent_sink");
+    defer t.deinit();
+
+    // installAll resolves its prefix from MALT_PREFIX; pin it to the temp dir.
+    const prefix_z = try std.fmt.allocPrintSentinel(testing.allocator, "{s}", .{t.dir}, 0);
+    defer testing.allocator.free(prefix_z);
+    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Single unresolvable formula isolates the install path: only
+    // installFormula fires, and it fails fast offline.
+    var m = manifest_mod.Manifest.init(testing.allocator);
+    defer m.deinit();
+    const a = m.allocator();
+    m.name = try a.dupe(u8, "solo");
+    m.version = manifest_mod.schema_version;
+    const formulas = try a.alloc(manifest_mod.FormulaEntry, 1);
+    formulas[0] = .{ .name = try a.dupe(u8, "zz_nonexistent_formula_xyz") };
+    m.formulas = formulas;
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const app: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    var ictx: SilentInstallCtx = .{ .app = &app };
+    const dispatcher = runner.Dispatcher{
+        .ctx = &ictx,
+        .installFormula = SilentInstallCtx.installFormulaFn,
+        .installCask = SilentInstallCtx.unusedFn,
+        .tapAdd = SilentInstallCtx.unusedFn,
+        .serviceStart = SilentInstallCtx.unusedFn,
+    };
+
+    var out_buf: std.ArrayList(u8) = .empty;
+    defer out_buf.deinit(testing.allocator);
+    output.beginStderrCapture(testing.allocator, &out_buf);
+    defer output.endStderrCapture();
+
+    var report = try runner.run(threaded.io(), testing.allocator, &t.db, m, .{
+        .dry_run = false,
+        .prefix = t.dir,
+        .dispatcher = &dispatcher,
+    });
+    defer report.deinit();
+
+    // Structured per-member outcome survives the silent sink...
+    try testing.expect(report.hasFailure());
+    try testing.expectEqual(@as(usize, 1), report.failures.len);
+    try testing.expectEqual(runner.DispatchError.MemberFailed, report.failures[0].err);
+    try testing.expectEqualStrings("zz_nonexistent_formula_xyz", report.failures[0].name);
+    // ...while the per-keg lines never reach the global stderr channel.
+    try testing.expectEqual(@as(usize, 0), out_buf.items.len);
 }

--- a/tests/install_download_only_test.zig
+++ b/tests/install_download_only_test.zig
@@ -514,6 +514,7 @@ test "--download-only on tap formula with warm tap cache prints path + skips Cel
         false, // dry_run
         false, // force
         true, // download_only
+        malt.install_sink.terminal,
     );
 
     const want = try std.fmt.allocPrint(
@@ -600,6 +601,7 @@ test "--download-only --force on tap formula with warm cache is a no-op refresh"
         false, // dry_run
         true, // force
         true, // download_only
+        malt.install_sink.terminal,
     );
 
     // Cache file untouched.
@@ -690,6 +692,7 @@ test "--download-only --ndjson on tap formula emits download_started + complete 
         false, // dry_run
         false, // force
         true, // download_only
+        malt.install_sink.terminal,
     );
 
     try testing.expectEqual(

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -9,6 +9,7 @@ const install_args = @import("malt").install_args;
 const install_download = @import("malt").install_download;
 const install_ghcr_url = @import("malt").install_ghcr_url;
 const install_post_install = @import("malt").install_post_install;
+const install_sink = @import("malt").install_sink;
 const install_rb_parse = @import("malt").install_rb_parse;
 const install_record = @import("malt").install_record;
 
@@ -1124,7 +1125,7 @@ fn runRoute(
     const dn = try devnullCtx();
     defer closeDevnullCtx(dn.fd);
 
-    install_post_install.routePostInstallOutcome(&dn.ctx, testing.allocator, name, "1.0", "/tmp/irrelevant", flog, scope);
+    install_post_install.routePostInstallOutcome(&dn.ctx, testing.allocator, name, "1.0", "/tmp/irrelevant", flog, scope, install_sink.terminal);
 
     return buf.toOwnedSlice(testing.allocator);
 }
@@ -1437,7 +1438,7 @@ fn runRouteCaptureStdout(
     const dn = try devnullCtx();
     defer closeDevnullCtx(dn.fd);
 
-    install_post_install.routePostInstallOutcome(&dn.ctx, testing.allocator, name, "1.0", "/tmp/irrelevant", flog, scope);
+    install_post_install.routePostInstallOutcome(&dn.ctx, testing.allocator, name, "1.0", "/tmp/irrelevant", flog, scope, install_sink.terminal);
     return stdout_buf.toOwnedSlice(testing.allocator);
 }
 
@@ -1507,6 +1508,7 @@ test "executeDslPostInstall returns .parse_failed when formula JSON is unparseab
         "/tmp/irrelevant",
         &.{},
         null,
+        install_sink.terminal,
     );
     try testing.expectEqual(install_post_install.DslPostInstallOutcome.parse_failed, outcome);
 }
@@ -1533,6 +1535,7 @@ test "executeDslPostInstall returns .handled when DSL executes against a valid f
         "/tmp/irrelevant",
         &.{},
         null,
+        install_sink.terminal,
     );
     try testing.expectEqual(install_post_install.DslPostInstallOutcome.handled, outcome);
 }
@@ -1563,6 +1566,7 @@ test "executeDslPostInstall routes through the shared FormulaCache once per name
         "/tmp/irrelevant",
         &.{},
         &cache,
+        install_sink.terminal,
     );
     try testing.expectEqual(install_post_install.DslPostInstallOutcome.handled, first);
     try testing.expectEqual(@as(usize, 1), cache.parse_count);
@@ -1577,6 +1581,7 @@ test "executeDslPostInstall routes through the shared FormulaCache once per name
         "/tmp/irrelevant",
         &.{},
         &cache,
+        install_sink.terminal,
     );
     try testing.expectEqual(install_post_install.DslPostInstallOutcome.handled, second);
     try testing.expectEqual(@as(usize, 1), cache.parse_count);
@@ -1609,6 +1614,7 @@ test "executeDslPostInstall reuses an entry the install pipeline already parsed"
         "/tmp/irrelevant",
         &.{},
         &cache,
+        install_sink.terminal,
     );
     try testing.expectEqual(install_post_install.DslPostInstallOutcome.handled, outcome);
     try testing.expectEqual(@as(usize, 1), cache.parse_count);
@@ -1645,6 +1651,7 @@ test "drive: no DSL source and no scope match emits the unified skip hint" {
         "/tmp/irrelevant",
         &.{},
         null,
+        install_sink.terminal,
     );
 
     // The skip hint is the byte-for-byte string both install and migrate

--- a/tests/install_sink_test.zig
+++ b/tests/install_sink_test.zig
@@ -1,0 +1,138 @@
+//! malt — install OutputSink integration tests.
+//! Proves `installAll` routes per-keg human output through the injected
+//! sink instead of the global `ui/output`, so a non-terminal consumer (the
+//! bundle runner) can quiet emission while the structured failure path —
+//! the error returned to the caller — stays intact.
+
+const std = @import("std");
+const malt = @import("malt");
+const test_io = @import("test_io");
+const testing = std.testing;
+
+const install = malt.install;
+const install_record = malt.install_record;
+const install_sink = malt.install_sink;
+const output = malt.output;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+/// Counts the human lines a sink receives so a test can assert routing
+/// went through `ctx` and never touched the global stderr.
+const RecordingSink = struct {
+    infos: usize = 0,
+    warns: usize = 0,
+    successes: usize = 0,
+    errs: usize = 0,
+
+    fn writeInfo(ctx: ?*anyopaque, _: []const u8) void {
+        cast(ctx).infos += 1;
+    }
+    fn writeWarn(ctx: ?*anyopaque, _: []const u8) void {
+        cast(ctx).warns += 1;
+    }
+    fn writeSuccess(ctx: ?*anyopaque, _: []const u8) void {
+        cast(ctx).successes += 1;
+    }
+    fn writeErr(ctx: ?*anyopaque, _: []const u8) void {
+        cast(ctx).errs += 1;
+    }
+    fn cast(ctx: ?*anyopaque) *RecordingSink {
+        return @ptrCast(@alignCast(ctx));
+    }
+
+    fn sink(self: *RecordingSink) install_sink.OutputSink {
+        return .{
+            .ctx = self,
+            .writeInfo = writeInfo,
+            .writeWarn = writeWarn,
+            .writeSuccess = writeSuccess,
+            .writeErr = writeErr,
+            .show_progress = false,
+        };
+    }
+};
+
+test "installAll routes the per-keg failure line through the injected sink" {
+    const prefix_z: [:0]const u8 = "/tmp/malt_install_sink_route";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
+    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    // Capture the global stderr so a leaked direct `output.*` write fails
+    // the test rather than going unnoticed.
+    var out_buf: std.ArrayList(u8) = .empty;
+    defer out_buf.deinit(testing.allocator);
+    output.beginStderrCapture(testing.allocator, &out_buf);
+    defer output.endStderrCapture();
+
+    var rec: RecordingSink = .{};
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.installAll(&ctx, arena.allocator(), &.{"zz_nonexistent_formula_xyz"}, .{ .sink = rec.sink() }),
+    );
+
+    // The unresolvable keg's error line is the structured "this keg failed"
+    // surface bundle relies on — it must reach the sink, not the global.
+    try testing.expect(rec.errs >= 1);
+    try testing.expectEqual(@as(usize, 0), out_buf.items.len);
+}
+
+/// Run `installAll` for one unresolvable package under `sink`, capturing
+/// the global stderr. Returns the captured bytes (caller frees) and the
+/// install result so each test asserts its own contract.
+fn runUnresolvable(
+    sink: install_sink.OutputSink,
+    suffix: []const u8,
+    out_buf: *std.ArrayList(u8),
+) anyerror!void {
+    const prefix = try std.fmt.allocPrintSentinel(testing.allocator, "/tmp/malt_install_sink_{s}", .{suffix}, 0);
+    defer testing.allocator.free(prefix);
+    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+    _ = c.setenv("MALT_PREFIX", prefix.ptr, 1);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    output.beginStderrCapture(testing.allocator, out_buf);
+    defer output.endStderrCapture();
+
+    try testing.expectError(
+        install_record.InstallError.PartialFailure,
+        install.installAll(&ctx, arena.allocator(), &.{"zz_nonexistent_formula_xyz"}, .{ .sink = sink }),
+    );
+}
+
+test "default sink routes the failure line to ui/output" {
+    var out_buf: std.ArrayList(u8) = .empty;
+    defer out_buf.deinit(testing.allocator);
+    // No sink supplied → InstallAllOpts defaults to the terminal sink, so
+    // the per-keg error must land on the global stderr exactly as today.
+    try runUnresolvable(install_sink.terminal, "default", &out_buf);
+    try testing.expect(std.mem.indexOf(u8, out_buf.items, "zz_nonexistent_formula_xyz") != null);
+}
+
+test "silent sink quiets the failure line but the install still fails" {
+    var out_buf: std.ArrayList(u8) = .empty;
+    defer out_buf.deinit(testing.allocator);
+    // Bundle's sink: nothing reaches the global channel, yet the
+    // PartialFailure return (which feeds the runner's Report) is unchanged.
+    try runUnresolvable(install_sink.silent, "silent", &out_buf);
+    try testing.expectEqual(@as(usize, 0), out_buf.items.len);
+}


### PR DESCRIPTION
## Description

Threads an optional `OutputSink` through `installAll` and the install submodules so non-terminal consumers (today: the bundle runner) can quiet per-keg emission without losing the structured `Report` path. The default sink wraps the existing `ui/output.*` calls; behaviour for the `mt install` and `mt upgrade` paths is unchanged.

## Related Issue

- None

## Notes for Reviewers

- None