### PR TITLE
refactor(core/dsl): make FallbackLog record-only, render in callers

### DIFF
--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -119,14 +119,17 @@ pub fn routePostInstallOutcomeWithBody(
     pre_resolved_body: ?[]const u8,
     sink: OutputSink,
 ) void {
+    // Diagnostics the DSL recorded during execution render first, matching
+    // the pre-refactor order where they printed inline before routing.
+    renderNotes(flog);
     const status: PostInstallStatus = blk: {
         if (flog.hasFatal()) {
             sink.warn("post_install DSL failed for {s} (fatal)", .{name});
-            flog.printFatal(name);
+            renderFatal(flog, name);
             // `--debug` also surfaces the non-fatal context so a bug
             // report includes every reason the DSL logged, not just the
             // one that aborted execution.
-            if (output.isDebug()) flog.printUnknown(name);
+            if (output.isDebug()) renderUnknown(flog, name);
             break :blk .fatal;
         }
         if (!flog.hasErrors()) {
@@ -143,8 +146,8 @@ pub fn routePostInstallOutcomeWithBody(
         const auto_self_hosting = isSelfHostingRubyKeg(name);
         if (explicit_opt_in or (auto_self_hosting and !flog.dslDidWork())) {
             sink.warn("post_install DSL incomplete for {s}, falling back to system Ruby...", .{name});
-            if (output.isVerbose()) flog.printUnknown(name);
-            if (output.isDebug()) flog.printFatal(name);
+            if (output.isVerbose()) renderUnknown(flog, name);
+            if (output.isDebug()) renderFatal(flog, name);
             const ruby_stdio: sandbox.Stdio = .{ .out = ctx.stdout.handle, .err = ctx.stderr.handle };
             const ruby_result: ruby_sub.RubyError!void = if (pre_resolved_body) |body|
                 ruby_sub.runPostInstallWithBody(ctx.io, ctx.environ, allocator, name, version_str, prefix, body, ruby_stdio)
@@ -160,8 +163,8 @@ pub fn routePostInstallOutcomeWithBody(
             break :blk .ran_via_ruby;
         }
         sink.warn("{s}: post_install partially skipped (use --use-system-ruby={s} to attempt via Ruby)", .{ name, name });
-        if (output.isVerbose()) flog.printUnknown(name);
-        if (output.isDebug()) flog.printFatal(name);
+        if (output.isVerbose()) renderUnknown(flog, name);
+        if (output.isDebug()) renderFatal(flog, name);
         break :blk .partially_skipped;
     };
 
@@ -177,6 +180,45 @@ pub fn routePostInstallOutcomeWithBody(
             .embed => bufferPostInstallEvent(allocator, name, status, flog, sink),
         }
     }
+}
+
+/// Render the log entries whose reason is in `reasons` as
+/// `tag:line:col: [reason] detail` lines. Rendering lives here, not in
+/// core/dsl: the fallback log is pure recording, the CLI owns the UI.
+fn renderEntries(flog: *const dsl.FallbackLog, tag: []const u8, comptime reasons: []const dsl.FallbackReason) void {
+    for (flog.entries()) |entry| {
+        if (std.mem.indexOfScalar(dsl.FallbackReason, reasons, entry.reason) == null) continue;
+        var buf: [1024]u8 = undefined;
+        const formatted = if (entry.loc) |loc|
+            std.fmt.bufPrint(&buf, "  {s}:{d}:{d}: [{s}] {s}\n", .{
+                tag, loc.line, loc.col, @tagName(entry.reason), entry.detail,
+            }) catch continue
+        else
+            std.fmt.bufPrint(&buf, "  {s}: [{s}] {s}\n", .{
+                tag, @tagName(entry.reason), entry.detail,
+            }) catch continue;
+        output.writeStderrAll(formatted);
+    }
+}
+
+/// Fatal-or-diagnostic entries (`parse_error` included so users get the
+/// file:line:col before a `--use-system-ruby` salvage).
+fn renderFatal(flog: *const dsl.FallbackLog, tag: []const u8) void {
+    renderEntries(flog, tag, &.{ .sandbox_violation, .system_command_failed, .parse_error });
+}
+
+/// The log-only reasons `renderFatal` skips; shown under `--verbose`.
+fn renderUnknown(flog: *const dsl.FallbackLog, tag: []const u8) void {
+    renderEntries(flog, tag, &.{ .unknown_method, .unsupported_node });
+}
+
+/// Emit the pure log's free-form diagnostics (raise messages, inreplace
+/// fallback warnings) plus any OOM-drop notice. The DSL records these
+/// during execution; rendering is the CLI's job so core/dsl stays UI-free.
+fn renderNotes(flog: *const dsl.FallbackLog) void {
+    for (flog.notes()) |line| output.writeStderrAll(line);
+    if (flog.dropped_oom)
+        output.writeStderrAll("malt: fallback log dropped an entry due to OOM\n");
 }
 
 /// Write one JSON line per post_install routing decision to stdout. One
@@ -323,12 +365,16 @@ pub fn executeDslPostInstallFields(
     defer flog.deinit();
 
     // DSL errors reflect in `flog`; the router reads the log as the source
-    // of truth so silent skips downgrade the same as hard failures.
-    dsl.executePostInstall(ctx.io, ctx.environ, allocator, .{
+    // of truth so silent skips downgrade the same as hard failures. The
+    // stdio mode is read here (CLI owns --json/--ndjson) and threaded in so
+    // a spawned child's stdout can't corrupt the document.
+    dsl.executePostInstallWithOpts(ctx.io, ctx.environ, allocator, .{
         .name = name,
         .version = dsl_version,
         .pkg_version = pkg_version,
-    }, post_install_src, prefix, &flog) catch {};
+    }, post_install_src, prefix, &flog, .{
+        .suppress_child_stdout = output.isJson() or output.isNdjson(),
+    }) catch {};
     routePostInstallOutcomeWithBody(
         ctx,
         allocator,

--- a/src/core/dsl/builtins/inreplace.zig
+++ b/src/core/dsl/builtins/inreplace.zig
@@ -6,7 +6,6 @@ const std = @import("std");
 const values = @import("../values.zig");
 const sandbox = @import("../sandbox.zig");
 const pathname = @import("pathname.zig");
-const output = @import("../../../ui/output.zig");
 const text_replace = @import("../../../text_replace.zig");
 
 const Value = values.Value;
@@ -57,9 +56,9 @@ pub fn inreplace(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Valu
         var buf: [512]u8 = undefined;
         const underlying = underlying_name orelse @errorName(e);
         const msg = formatAtomicWriteFailureMessage(&buf, e, underlying) catch return Value{ .nil = {} };
-        // Route through the capture-aware seam so tests see the warning
-        // and CI logs do not interleave with raw-fd writes.
-        output.writeStderrAll(msg);
+        // Record the warning; the post_install caller renders notes. Keeps
+        // this builtin free of ui/output.
+        if (ctx.fallback_log) |flog| flog.note(msg);
         writeDirectly(ctx.io, path, new_content);
     };
 

--- a/src/core/dsl/builtins/pathname.zig
+++ b/src/core/dsl/builtins/pathname.zig
@@ -9,6 +9,7 @@ const std = @import("std");
 const values = @import("../values.zig");
 const sandbox = @import("../sandbox.zig");
 const ast = @import("../ast.zig");
+const fallback_log = @import("../fallback_log.zig");
 
 const Value = values.Value;
 
@@ -28,6 +29,12 @@ pub const ExecCtx = struct {
     environ: std.process.Environ,
     cellar_path: []const u8,
     malt_prefix: []const u8,
+    /// Suppress a spawned child's stdout (set under --json/--ndjson so it
+    /// can't corrupt the document). Threaded in by the interpreter.
+    suppress_child_stdout: bool = false,
+    /// Record-only diagnostics sink for builtins (e.g. inreplace's
+    /// atomic-write fallback). Optional so test contexts can omit it.
+    fallback_log: ?*fallback_log.FallbackLog = null,
 };
 
 /// mkpath — recursive directory creation

--- a/src/core/dsl/builtins/process.zig
+++ b/src/core/dsl/builtins/process.zig
@@ -5,11 +5,18 @@ const std = @import("std");
 const values = @import("../values.zig");
 const pathname = @import("pathname.zig");
 const sandbox = @import("../sandbox.zig");
-const output = @import("../../../ui/output.zig");
 
 const Value = values.Value;
 const BuiltinError = pathname.BuiltinError;
 const ExecCtx = pathname.ExecCtx;
+
+/// Subprocess stdout shares the FD with malt's `--json` / `--ndjson`
+/// document, so verbose tools like fc-cache would corrupt it. The caller
+/// decides via `ExecCtx.suppress_child_stdout`; stderr stays inherited so
+/// warnings still surface for the user.
+fn childStdoutMode(suppress: bool) std.process.SpawnOptions.StdIo {
+    return if (suppress) .ignore else .inherit;
+}
 
 /// system — execute a command
 pub fn system(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
@@ -30,11 +37,7 @@ pub fn system(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     sandbox.validateArgv(argv_slice, ctx.cellar_path, ctx.malt_prefix) catch
         return BuiltinError.PathSandboxViolation;
 
-    // Subprocess stdout shares the FD with malt's `--json` / `--ndjson`
-    // document, so verbose tools like fc-cache would corrupt it. Stderr
-    // stays inherited so warnings still surface for the user.
-    const child_stdout: std.process.SpawnOptions.StdIo =
-        if (output.isJson() or output.isNdjson()) .ignore else .inherit;
+    const child_stdout = childStdoutMode(ctx.suppress_child_stdout);
     var child = std.process.spawn(ctx.io, .{
         .argv = argv_slice,
         .stdout = child_stdout,
@@ -231,6 +234,13 @@ fn readPipeAll(file: std.Io.File, allocator: std.mem.Allocator, max_bytes: usize
     var buf: [4096]u8 = undefined;
     var r = file.readerStreaming(threaded.io(), &buf);
     return r.interface.allocRemaining(allocator, std.Io.Limit.limited(max_bytes));
+}
+
+test "childStdoutMode ignores subprocess stdout only when suppression is requested" {
+    // Under --json/--ndjson the caller suppresses the child's stdout so it
+    // can't corrupt the document; otherwise it inherits malt's fd.
+    try std.testing.expect(std.meta.activeTag(childStdoutMode(true)) == .ignore);
+    try std.testing.expect(std.meta.activeTag(childStdoutMode(false)) == .inherit);
 }
 
 test "system rejects an argv0 outside the sandbox roots before spawning" {

--- a/src/core/dsl/context.zig
+++ b/src/core/dsl/context.zig
@@ -115,6 +115,11 @@ pub const ExecContext = struct {
     // Fallback log writer
     fallback_log_writer: *FallbackLog,
 
+    /// Suppress a spawned child's stdout under --json/--ndjson. Set once at
+    /// DSL entry by the caller (which owns the output mode) so builtins
+    /// never reach into ui/output for the global flag.
+    suppress_child_stdout: bool = false,
+
     // Formula name for fallback log entries
     formula_name: []const u8,
 

--- a/src/core/dsl/fallback_log.zig
+++ b/src/core/dsl/fallback_log.zig
@@ -3,7 +3,6 @@
 
 const std = @import("std");
 const ast = @import("ast.zig");
-const output = @import("../../ui/output.zig");
 
 pub const FallbackReason = enum {
     unknown_method,
@@ -23,8 +22,16 @@ pub const FallbackEntry = struct {
 };
 
 pub const FallbackLog = struct {
-    entries: std.ArrayList(FallbackEntry),
+    _entries: std.ArrayList(FallbackEntry),
+    /// Free-form diagnostics (raise messages, inreplace fallback warnings)
+    /// the caller renders verbatim. Kept separate from `_entries` so a note
+    /// never participates in routing (`hasErrors`/`hasFatal`/`toJson`).
+    _notes: std.ArrayList([]const u8),
     allocator: std.mem.Allocator,
+    /// Set when an append fails under memory pressure. A pure log can't
+    /// render, so the caller reads this at the rendering seam and warns
+    /// that "post_install was partially skipped" was itself dropped.
+    dropped_oom: bool = false,
     /// Top-level statements the interpreter attempted to evaluate. Bumped
     /// per-node by `Interpreter.execute`; tests construct synthetic logs by
     /// setting this directly.
@@ -38,26 +45,51 @@ pub const FallbackLog = struct {
 
     pub fn init(allocator: std.mem.Allocator) FallbackLog {
         return .{
-            .entries = .empty,
+            ._entries = .empty,
+            ._notes = .empty,
             .allocator = allocator,
         };
     }
 
     pub fn deinit(self: *FallbackLog) void {
-        self.entries.deinit(self.allocator);
+        for (self._notes.items) |n| self.allocator.free(n);
+        self._notes.deinit(self.allocator);
+        self._entries.deinit(self.allocator);
     }
 
     pub fn log(self: *FallbackLog, entry: FallbackEntry) void {
-        self.entries.append(self.allocator, entry) catch {
-            // OOM still drops the entry, but stay loud about it: this log
-            // is the only signal the user has for "post_install was
-            // partially skipped" during a large `mt migrate`.
-            output.writeStderrAll("malt: fallback log dropped an entry due to OOM\n");
+        self._entries.append(self.allocator, entry) catch {
+            // Record the drop as a flag the caller renders — the pure log
+            // never writes stderr itself.
+            self.dropped_oom = true;
         };
     }
 
+    /// Record a free-form diagnostic line, owning a copy. Append-only and
+    /// OOM-tolerant: a failed dupe flags `dropped_oom` rather than raising.
+    pub fn note(self: *FallbackLog, line: []const u8) void {
+        const owned = self.allocator.dupe(u8, line) catch {
+            self.dropped_oom = true;
+            return;
+        };
+        self._notes.append(self.allocator, owned) catch {
+            self.allocator.free(owned);
+            self.dropped_oom = true;
+        };
+    }
+
+    /// Read-only view of the routing entries — callers render at their seam.
+    pub fn entries(self: *const FallbackLog) []const FallbackEntry {
+        return self._entries.items;
+    }
+
+    /// Read-only view of the diagnostic notes.
+    pub fn notes(self: *const FallbackLog) []const []const u8 {
+        return self._notes.items;
+    }
+
     pub fn hasErrors(self: *const FallbackLog) bool {
-        return self.entries.items.len > 0;
+        return self._entries.items.len > 0;
     }
 
     /// True when at least one top-level statement evaluated without a new
@@ -70,62 +102,13 @@ pub const FallbackLog = struct {
     }
 
     pub fn hasFatal(self: *const FallbackLog) bool {
-        for (self.entries.items) |entry| {
+        for (self._entries.items) |entry| {
             switch (entry.reason) {
                 .sandbox_violation, .system_command_failed => return true,
                 else => {},
             }
         }
         return false;
-    }
-
-    /// Print every fatal-or-diagnostic entry in `tag:line:col: message` form.
-    /// `parse_error` is included so users see the exact file:line:col when the
-    /// DSL falls back to `--use-system-ruby`; it is not treated as fatal by
-    /// `hasFatal`, keeping the salvage path open.
-    pub fn printFatal(self: *const FallbackLog, tag: []const u8) void {
-        for (self.entries.items) |entry| {
-            const printable = switch (entry.reason) {
-                .sandbox_violation, .system_command_failed, .parse_error => true,
-                else => false,
-            };
-            if (!printable) continue;
-            var buf: [1024]u8 = undefined;
-            const formatted = if (entry.loc) |loc|
-                std.fmt.bufPrint(&buf, "  {s}:{d}:{d}: [{s}] {s}\n", .{
-                    tag, loc.line, loc.col, @tagName(entry.reason), entry.detail,
-                }) catch continue
-            else
-                std.fmt.bufPrint(&buf, "  {s}: [{s}] {s}\n", .{
-                    tag, @tagName(entry.reason), entry.detail,
-                }) catch continue;
-            output.writeStderrAll(formatted);
-        }
-    }
-
-    /// Print unknown_method / unsupported_node entries to stderr — the
-    /// log-only reasons that `printFatal` intentionally skips. Called by
-    /// the install CLI under `--verbose` so users can see which helpers
-    /// the DSL silently downgraded instead of only the "partially skipped"
-    /// hint.
-    pub fn printUnknown(self: *const FallbackLog, tag: []const u8) void {
-        for (self.entries.items) |entry| {
-            const unknown = switch (entry.reason) {
-                .unknown_method, .unsupported_node => true,
-                else => false,
-            };
-            if (!unknown) continue;
-            var buf: [1024]u8 = undefined;
-            const formatted = if (entry.loc) |loc|
-                std.fmt.bufPrint(&buf, "  {s}:{d}:{d}: [{s}] {s}\n", .{
-                    tag, loc.line, loc.col, @tagName(entry.reason), entry.detail,
-                }) catch continue
-            else
-                std.fmt.bufPrint(&buf, "  {s}: [{s}] {s}\n", .{
-                    tag, @tagName(entry.reason), entry.detail,
-                }) catch continue;
-            output.writeStderrAll(formatted);
-        }
     }
 
     /// Serialize to JSON for telemetry reporting.
@@ -135,7 +118,7 @@ pub const FallbackLog = struct {
         const writer = &aw.writer;
 
         try writer.writeAll("[");
-        for (self.entries.items, 0..) |entry, i| {
+        for (self._entries.items, 0..) |entry, i| {
             if (i > 0) try writer.writeAll(",");
             try writer.writeAll("{\"formula\":\"");
             try writer.writeAll(entry.formula);
@@ -182,22 +165,81 @@ test "dslDidWork: at least one handled statement flips the signal" {
     try std.testing.expect(flog.dslDidWork());
 }
 
-// Under memory pressure the diagnostic log itself can fail to grow.
-// A silent drop hides the only signal the user has for "post_install
-// was partially skipped"; surface a one-line warning instead.
-test "log surfaces a warning when the entry append OOMs" {
+// Under memory pressure the diagnostic log itself can fail to grow. A
+// pure log can't render, so it records the drop as a flag the caller
+// reads at the rendering seam — no stderr write, no test capture.
+test "log flags dropped_oom when the entry append OOMs and records nothing" {
     var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
     var flog = FallbackLog.init(failing.allocator());
     defer flog.deinit();
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(std.testing.allocator);
-    output.beginStderrCapture(std.testing.allocator, &buf);
-    defer output.endStderrCapture();
-
     flog.log(.{ .formula = "demo", .reason = .unknown_method, .detail = "boom", .loc = null });
 
-    try std.testing.expectEqual(@as(usize, 0), flog.entries.items.len);
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, "fallback log dropped") != null);
-    try std.testing.expect(std.mem.endsWith(u8, buf.items, "\n"));
+    try std.testing.expectEqual(@as(usize, 0), flog.entries().len);
+    try std.testing.expect(flog.dropped_oom);
+}
+
+test "entries() exposes the logged entries without stderr capture" {
+    var flog = FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+    flog.log(.{ .formula = "wget", .reason = .sandbox_violation, .detail = "/etc/passwd", .loc = null });
+
+    const items = flog.entries();
+    try std.testing.expectEqual(@as(usize, 1), items.len);
+    try std.testing.expectEqual(FallbackReason.sandbox_violation, items[0].reason);
+    try std.testing.expectEqualStrings("/etc/passwd", items[0].detail);
+}
+
+// The notes channel records free-form diagnostics (raise, inreplace
+// fallback) the caller renders verbatim. It must stay independent of
+// routing: a note alone is not an error and does not flip hasErrors.
+test "note() records a diagnostic the caller can read, without affecting routing" {
+    var flog = FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+
+    flog.note("  x boom\n");
+
+    try std.testing.expectEqual(@as(usize, 1), flog.notes().len);
+    try std.testing.expectEqualStrings("  x boom\n", flog.notes()[0]);
+    try std.testing.expect(!flog.hasErrors());
+    try std.testing.expect(!flog.hasFatal());
+    try std.testing.expectEqual(@as(usize, 0), flog.entries().len);
+}
+
+test "note() owns its copy: the source buffer may be reused after the call" {
+    var flog = FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+
+    var buf: [16]u8 = undefined;
+    @memcpy(buf[0..5], "hello");
+    flog.note(buf[0..5]);
+    @memcpy(buf[0..5], "world"); // clobber the source
+
+    try std.testing.expectEqualStrings("hello", flog.notes()[0]);
+}
+
+test "note() preserves insertion order across multiple records" {
+    var flog = FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+
+    flog.note("first");
+    flog.note("second");
+
+    try std.testing.expectEqual(@as(usize, 2), flog.notes().len);
+    try std.testing.expectEqualStrings("first", flog.notes()[0]);
+    try std.testing.expectEqualStrings("second", flog.notes()[1]);
+}
+
+// Edge: the diagnostics channel is OOM-tolerant too. A failed dupe must
+// flag the drop rather than record a dangling slice — same contract as
+// `log`, so the caller's "dropped due to OOM" notice still fires.
+test "note() flags dropped_oom and records nothing when the dupe OOMs" {
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    var flog = FallbackLog.init(failing.allocator());
+    defer flog.deinit();
+
+    flog.note("would-be diagnostic");
+
+    try std.testing.expectEqual(@as(usize, 0), flog.notes().len);
+    try std.testing.expect(flog.dropped_oom);
 }

--- a/src/core/dsl/interpreter.zig
+++ b/src/core/dsl/interpreter.zig
@@ -10,10 +10,6 @@ const sandbox = @import("sandbox.zig");
 const fallback_log = @import("fallback_log.zig");
 const builtins_root = @import("builtins/root.zig");
 const context = @import("context.zig");
-// Same UI seam used by `odie` and the fallback log; routing through
-// the output module keeps test stderr capture working instead of
-// punching directly to fd 2.
-const output = @import("../../ui/output.zig");
 
 const Node = ast.Node;
 const SourceLoc = ast.SourceLoc;
@@ -64,7 +60,7 @@ pub const Interpreter = struct {
             // A statement counts as "handled" only if its eval threw nothing
             // and logged nothing — the router uses that signal to gate the
             // system-Ruby fallback away from already-applied bodies.
-            const before_entries = self.ctx.fallback_log_writer.entries.items.len;
+            const before_entries = self.ctx.fallback_log_writer.entries().len;
             // Exhaustive: new DslError tags must be classified, not dropped.
             _ = self.eval(node) catch |e| switch (e) {
                 DslError.PostInstallFailed => return e,
@@ -82,7 +78,7 @@ pub const Interpreter = struct {
                 // value is discarded because there's no caller.
                 DslError.ReturnSignal => {
                     self.ctx.return_value = Value{ .nil = {} };
-                    if (self.ctx.fallback_log_writer.entries.items.len == before_entries) {
+                    if (self.ctx.fallback_log_writer.entries().len == before_entries) {
                         self.ctx.fallback_log_writer.handled_top_level += 1;
                     }
                     return;
@@ -95,7 +91,7 @@ pub const Interpreter = struct {
                 DslError.OutOfMemory,
                 => continue,
             };
-            if (self.ctx.fallback_log_writer.entries.items.len == before_entries) {
+            if (self.ctx.fallback_log_writer.entries().len == before_entries) {
                 self.ctx.fallback_log_writer.handled_top_level += 1;
             }
         }
@@ -258,6 +254,8 @@ pub const Interpreter = struct {
             .environ = self.ctx.environ,
             .cellar_path = self.ctx.cellar_path,
             .malt_prefix = self.ctx.malt_prefix,
+            .suppress_child_stdout = self.ctx.suppress_child_stdout,
+            .fallback_log = self.ctx.fallback_log_writer,
         };
 
         if (mc.receiver) |receiver_node| {
@@ -578,7 +576,9 @@ pub const Interpreter = struct {
             // assembly OOM and the stream failure are tolerated.
             if (std.fmt.allocPrint(self.allocator, "  x {s}\n", .{msg_str})) |line| {
                 defer self.allocator.free(line);
-                output.writeStderrAll(line);
+                // Record-only: the post_install caller renders notes. Keeps
+                // the interpreter free of ui/output.
+                self.ctx.fallback_log_writer.note(line);
             } else |_| {}
         }
         return DslError.PostInstallFailed;
@@ -746,6 +746,8 @@ pub const Interpreter = struct {
             .environ = self.ctx.environ,
             .cellar_path = self.ctx.cellar_path,
             .malt_prefix = self.ctx.malt_prefix,
+            .suppress_child_stdout = self.ctx.suppress_child_stdout,
+            .fallback_log = self.ctx.fallback_log_writer,
         };
         if (builtins_root.receiver_builtins.get(sym)) |func| {
             return func(builtin_ctx, item, &.{}) catch |e| mapBuiltinError(e);
@@ -911,6 +913,13 @@ fn compare(left: Value, op: []const u8, right: Value) bool {
     return false;
 }
 
+/// Options the caller sets once at DSL entry. Carries the output-mode
+/// decision so builtins never reach into ui/output for global state.
+pub const PostInstallOpts = struct {
+    /// Suppress spawned children's stdout (set under --json/--ndjson).
+    suppress_child_stdout: bool = false,
+};
+
 /// Execute a formula's post_install block.
 pub fn executePostInstall(
     io: std.Io,
@@ -920,6 +929,22 @@ pub fn executePostInstall(
     ruby_source: []const u8,
     malt_prefix: []const u8,
     flog: *FallbackLog,
+) DslError!void {
+    return executePostInstallWithOpts(io, environ, allocator, ref, ruby_source, malt_prefix, flog, .{});
+}
+
+/// Variant carrying the caller's output-mode opts. The bare
+/// `executePostInstall` delegates here with defaults so test callers stay
+/// untouched; the CLI passes the live `--json`/`--ndjson` state.
+pub fn executePostInstallWithOpts(
+    io: std.Io,
+    environ: std.process.Environ,
+    allocator: std.mem.Allocator,
+    ref: FormulaRef,
+    ruby_source: []const u8,
+    malt_prefix: []const u8,
+    flog: *FallbackLog,
+    opts: PostInstallOpts,
 ) DslError!void {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
@@ -944,6 +969,7 @@ pub fn executePostInstall(
 
     var ctx = try ExecContext.init(a, io, environ, ref, malt_prefix, flog);
     defer ctx.deinit();
+    ctx.suppress_child_stdout = opts.suppress_child_stdout;
     var interp = Interpreter.init(&ctx);
     try interp.execute(nodes);
 }

--- a/src/core/dsl/root.zig
+++ b/src/core/dsl/root.zig
@@ -13,6 +13,8 @@ pub const builtins = @import("builtins/root.zig");
 
 // Public API re-exports
 pub const executePostInstall = interpreter.executePostInstall;
+pub const executePostInstallWithOpts = interpreter.executePostInstallWithOpts;
+pub const PostInstallOpts = interpreter.PostInstallOpts;
 pub const DslError = context.DslError;
 pub const ExecContext = context.ExecContext;
 pub const FormulaRef = context.FormulaRef;

--- a/tests/dsl_install_symlink_test.zig
+++ b/tests/dsl_install_symlink_test.zig
@@ -88,7 +88,7 @@ test "install_symlink: ca-certificates-shaped post_install lands the cert symlin
 
     // rm_f on a missing target is a silent no-op — neither it nor
     // install_symlink may be logged as unknown_method.
-    for (flog.entries.items) |entry| {
+    for (flog.entries()) |entry| {
         if (entry.reason == .unknown_method) {
             std.debug.print("unexpected unknown_method: {s}\n", .{entry.detail});
             return error.UnexpectedUnknownMethod;

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -72,6 +72,34 @@ fn runSnippet(
     return null;
 }
 
+/// Like `runSnippet`, but records into the caller-owned `flog` so the test
+/// can inspect `flog.notes()` / `flog.entries()` afterward — the pure log
+/// replaces the old stderr-capture seam.
+fn runSnippetInto(
+    arena: *std.heap.ArenaAllocator,
+    ruby_src: []const u8,
+    malt_prefix: []const u8,
+    flog: *dsl.FallbackLog,
+) !void {
+    const alloc = arena.allocator();
+
+    const json = try minimalJson(alloc, "testpkg", "1.0");
+    var f = try formula_mod.parseFormula(alloc, json);
+    defer f.deinit();
+
+    const environ = malt.app_ctx.processEnviron();
+    var threaded: std.Io.Threaded = .init(alloc, .{ .environ = environ });
+    defer threaded.deinit();
+
+    dsl.executePostInstall(threaded.io(), environ, alloc, .{
+        .name = f.name,
+        .version = f.version,
+        .pkg_version = f.pkg_version,
+        // DSL errors are reflected in `flog`; the test asserts on the log,
+        // so the propagated error is intentionally discarded here.
+    }, ruby_src, malt_prefix, flog) catch {};
+}
+
 /// Create the cellar directory tree that ExecContext expects.
 fn setupCellar(prefix_dir: []const u8) !void {
     // Create Cellar/testpkg/1.0
@@ -286,25 +314,26 @@ test "interpreter: raise causes PostInstallFailed" {
     try testing.expectEqual(dsl.DslError.PostInstallFailed, err.?);
 }
 
-test "interpreter: raise message is captured by the output module seam" {
-    // Pins the routing fix: `raise` emits via output.writeStderrAll so
-    // beginStderrCapture intercepts the line and `zig build test` stays
-    // quiet. A regression to direct fd-2 writes would let the message
-    // leak past the capture and the assertion below would fail.
+test "interpreter: raise message is recorded as a note, not written to stderr" {
+    // `raise` records its message in the pure log; the post_install caller
+    // renders notes. Asserting on `flog.notes()` removes the stderr-capture
+    // dependency and proves the message no longer leaks to fd 2.
     var arena = testArena();
     defer arena.deinit();
 
     const prefix = try makeTempPrefix();
     defer testing.allocator.free(prefix);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(testing.allocator);
-    malt.output.beginStderrCapture(testing.allocator, &buf);
-    defer malt.output.endStderrCapture();
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
 
-    const err = try runSnippet(&arena, "raise \"boom\"", prefix);
-    try testing.expect(err != null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "boom") != null);
+    try runSnippetInto(&arena, "raise \"boom\"", prefix, &flog);
+
+    var found = false;
+    for (flog.notes()) |n| {
+        if (std.mem.indexOf(u8, n, "boom") != null) found = true;
+    }
+    try testing.expect(found);
 }
 
 test "interpreter: begin rescue handles error" {
@@ -325,6 +354,38 @@ test "interpreter: begin rescue handles error" {
     const err = try runSnippet(&arena, src, prefix);
     // rescue catches PostInstallFailed — execution completes successfully
     try testing.expect(err == null);
+}
+
+// Edge: a rescued raise still records its message (the diagnostic is
+// useful even when recovered) but, because the rescue swallowed the
+// failure, it stays a note — never a routing entry. Guards that the
+// note/control-flow interaction can't flip the post_install envelope.
+test "interpreter: a rescued raise records a note without a routing entry" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+
+    const src =
+        \\begin
+        \\  raise "kaboom"
+        \\rescue
+        \\  x = 1
+        \\end
+    ;
+    try runSnippetInto(&arena, src, prefix, &flog);
+
+    var found = false;
+    for (flog.notes()) |n| {
+        if (std.mem.indexOf(u8, n, "kaboom") != null) found = true;
+    }
+    try testing.expect(found);
+    try testing.expectEqual(@as(usize, 0), flog.entries().len);
+    try testing.expect(!flog.hasErrors());
 }
 
 test "interpreter: multiple statements execute in order" {
@@ -642,10 +703,10 @@ test "interpreter: inreplace replaces content in file" {
     try testing.expectEqualStrings("setting=NEW_VALUE\n", buf[0..n]);
 }
 
-// Regression: the atomic-write fallback warning previously bypassed the
-// output module by writing to STDERR_FILENO directly, which let the line
-// leak past `beginStderrCapture` and interleave with `zig test` output.
-test "interpreter: inreplace fallback warning is captured by output stderr seam" {
+// The atomic-write fallback warning is recorded as a pure-log note now,
+// not written to stderr — the caller renders notes at the post_install
+// seam. Asserting on `flog.notes()` removes the stderr-capture dependency.
+test "interpreter: inreplace fallback warning is recorded as a note" {
     var arena = testArena();
     defer arena.deinit();
 
@@ -679,16 +740,23 @@ test "interpreter: inreplace fallback warning is captured by output stderr seam"
     if (c.chmod(target_dir_z, 0o555) != 0) return error.TestUnexpectedResult;
     defer _ = c.chmod(target_dir_z, 0o755);
 
-    var stderr_buf: std.ArrayList(u8) = .empty;
-    defer stderr_buf.deinit(testing.allocator);
-    malt.output.beginStderrCapture(testing.allocator, &stderr_buf);
-    defer malt.output.endStderrCapture();
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
 
     const src = "inreplace prefix/\"config.txt\", \"OLD_VALUE\", \"NEW_VALUE\"";
-    _ = try runSnippet(&arena, src, prefix);
+    try runSnippetInto(&arena, src, prefix, &flog);
 
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "inreplace atomic write failed") != null);
-    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "TempCreateFailed") != null);
+    var found = false;
+    for (flog.notes()) |n| {
+        if (std.mem.indexOf(u8, n, "inreplace atomic write failed") != null and
+            std.mem.indexOf(u8, n, "TempCreateFailed") != null) found = true;
+    }
+    try testing.expect(found);
+    // Regression guard for the byte-identical envelope: the fallback is a
+    // note, never a routing entry, so a body that only hit it still routes
+    // to `completed` (hasErrors stays false).
+    try testing.expectEqual(@as(usize, 0), flog.entries().len);
+    try testing.expect(!flog.hasErrors());
 }
 
 // ---------------------------------------------------------------------------
@@ -1641,7 +1709,7 @@ test "parse_error: malformed source populates fallback log with location" {
     try testing.expect(!flog.hasFatal());
 
     var saw_parse_error = false;
-    for (flog.entries.items) |entry| {
+    for (flog.entries()) |entry| {
         if (entry.reason == .parse_error) {
             saw_parse_error = true;
             try testing.expect(entry.loc != null);

--- a/tests/fallback_log_test.zig
+++ b/tests/fallback_log_test.zig
@@ -52,18 +52,23 @@ test "hasFatal does NOT trip on parse_error (fallback path stays open)" {
     try testing.expect(!log.hasFatal());
 }
 
-test "printFatal does not crash on empty / fatal / non-fatal mixes" {
-    // Exercises the formatting branches (with-loc / no-loc / non-fatal-skipped).
-    // Writes route through `output.writeStderrAll` which silently drops when
-    // no capture buffer is set.
+test "entries() preserves reason, detail, and loc in log order for the renderer" {
+    // The log is pure: it hands the caller an ordered view and the caller
+    // owns the `tag:line:col: [reason] detail` formatting. Pin the data the
+    // renderer reads rather than the rendered bytes.
     var log = FallbackLog.init(testing.allocator);
     defer log.deinit();
-    log.printFatal("empty"); // empty list, no-op
+    try testing.expectEqual(@as(usize, 0), log.entries().len);
 
     log.log(.{ .formula = "wget", .reason = .unknown_method, .detail = "skip me", .loc = null });
     log.log(.{ .formula = "wget", .reason = .parse_error, .detail = "unexpected token", .loc = .{ .line = 12, .col = 4 } });
     log.log(.{ .formula = "wget", .reason = .sandbox_violation, .detail = "/etc/passwd", .loc = null });
-    log.printFatal("wget");
+
+    const items = log.entries();
+    try testing.expectEqual(@as(usize, 3), items.len);
+    try testing.expectEqual(FallbackReason.parse_error, items[1].reason);
+    try testing.expectEqual(@as(u32, 12), items[1].loc.?.line);
+    try testing.expectEqualStrings("/etc/passwd", items[2].detail);
 }
 
 test "toJson emits an empty array for no entries" {

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -1403,9 +1403,64 @@ test "routePostInstallOutcome: fatal + --debug also prints non-fatal context" {
     defer testing.allocator.free(out);
 
     try testing.expect(std.mem.indexOf(u8, out, "DSL failed for z (fatal)") != null);
-    // Sandbox violation surfaces via printFatal; tangential helper via printUnknown.
+    // Sandbox violation surfaces via renderFatal; tangential helper via renderUnknown.
     try testing.expect(std.mem.indexOf(u8, out, "[sandbox_violation] /etc/passwd") != null);
     try testing.expect(std.mem.indexOf(u8, out, "[unknown_method] tangential_helper") != null);
+}
+
+test "routePostInstallOutcome: renders recorded diagnostic notes at the completion seam" {
+    // raise / inreplace record notes in the pure log during execution; the
+    // router renders them so the user still sees the message.
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.note("  x boom\n");
+
+    const out = try runRoute(&flog, "demo", &.{});
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "x boom") != null);
+}
+
+test "routePostInstallOutcome: surfaces the dropped_oom notice" {
+    // A log that dropped an entry under memory pressure is the user's only
+    // signal that "partially skipped" was itself incomplete.
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.dropped_oom = true;
+
+    const out = try runRoute(&flog, "demo", &.{});
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "dropped an entry due to OOM") != null);
+}
+
+// Byte-identical-envelope guard: diagnostics (notes / dropped_oom) live in
+// a channel routing ignores. A body that recorded a note but logged no
+// entry must still report `completed`, exactly as before the split —
+// otherwise the refactor would silently re-route a clean install.
+test "routePostInstallOutcome: a notes-only log still reports completed and renders the note" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.note("  x boom\n"); // e.g. a rescued raise
+
+    const out = try runRoute(&flog, "demo", &.{});
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "post_install completed for demo") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "partially skipped") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "x boom") != null); // still surfaced
+}
+
+test "routePostInstallOutcome: dropped_oom alone does not downgrade the routing decision" {
+    var flog = dsl.FallbackLog.init(testing.allocator);
+    defer flog.deinit();
+    flog.dropped_oom = true; // no entries logged
+
+    const out = try runRoute(&flog, "demo", &.{});
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "post_install completed for demo") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "partially skipped") == null);
 }
 
 // ---------------------------------------------------------------------------
@@ -1681,8 +1736,8 @@ test "invariant: two FallbackLogs stay isolated (per-formula scope)" {
     a.log(.{ .formula = "a", .reason = .unknown_method, .detail = "a_helper", .loc = null });
     try testing.expect(a.hasErrors());
     try testing.expect(!b.hasErrors());
-    try testing.expectEqual(@as(usize, 1), a.entries.items.len);
-    try testing.expectEqual(@as(usize, 0), b.entries.items.len);
+    try testing.expectEqual(@as(usize, 1), a.entries().len);
+    try testing.expectEqual(@as(usize, 0), b.entries().len);
 }
 
 test "invariant: router emits exactly one partially-skipped warn regardless of entry count" {

--- a/tests/ruby_subprocess_test.zig
+++ b/tests/ruby_subprocess_test.zig
@@ -449,7 +449,7 @@ test "ca-certificates-shape: dispatcher with unparseable siblings leaves flog cl
     }, body, "/tmp/malt_cacerts_test", &flog);
 
     try testing.expect(!flog.hasFatal());
-    try testing.expectEqual(@as(usize, 0), flog.entries.items.len);
+    try testing.expectEqual(@as(usize, 0), flog.entries().len);
 }
 
 // Defense-in-depth — runPostInstall must reject hostile name / version


### PR DESCRIPTION
## Description

Splits the DSL fallback log into pure recording (in `core/dsl/`) and rendering (in `cli/install/post_install.zig`, shared by `mt install` and `mt migrate`). `FallbackLog`, the interpreter, `inreplace`, and the `process` builtin no longer reach into `ui/output.zig`:

- `FallbackLog` is record-only. It exposes `entries()` for the routing log and a separate `notes()` channel for free-form diagnostics (the `raise` message and the `inreplace` atomic-write fallback warning), which never participate in routing. An append failure under memory pressure sets a `dropped_oom` flag instead of writing stderr.
- `process.system` reads its stdio mode from the exec context (`suppress_child_stdout`, set once at DSL entry from `--json`/
  `--ndjson`) instead of probing `output.isJson()`/`isNdjson()`.
- The post_install router renders the fatal/unknown entries, the notes, and the OOM notice at its seam.


## Related Issue

- None

## Notes for Reviewers

- None