### PR TITLE
fix(core/dsl): confine native post_install spawns, not just the system-ruby path

### DIFF
--- a/src/core/dsl/builtins/process.zig
+++ b/src/core/dsl/builtins/process.zig
@@ -37,9 +37,17 @@ pub fn system(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     sandbox.validateArgv(argv_slice, ctx.cellar_path, ctx.malt_prefix) catch
         return BuiltinError.PathSandboxViolation;
 
+    // The lint above waves bare/system-dir argv0 through; the real write
+    // containment is the sandbox-exec fence wrapping the spawn (parity with
+    // the --use-system-ruby path).
+    const spawn_argv = sandbox.fenceArgv(ctx.allocator, argv_slice, ctx.cellar_path, ctx.malt_prefix) catch |e| switch (e) {
+        error.OutOfMemory => return BuiltinError.OutOfMemory,
+        error.PathSandboxViolation => return BuiltinError.PathSandboxViolation,
+    };
+
     const child_stdout = childStdoutMode(ctx.suppress_child_stdout);
     var child = std.process.spawn(ctx.io, .{
-        .argv = argv_slice,
+        .argv = spawn_argv,
         .stdout = child_stdout,
     }) catch return BuiltinError.SystemCommandFailed;
     const term = child.wait(ctx.io) catch return BuiltinError.SystemCommandFailed;

--- a/src/core/dsl/sandbox.zig
+++ b/src/core/dsl/sandbox.zig
@@ -2,9 +2,13 @@
 //! Validates that filesystem-mutating operations stay within allowed boundaries.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const macos = @import("../sandbox/macos.zig");
 
 pub const SandboxError = error{PathSandboxViolation};
+
+/// `fenceArgv` either rejects (unsafe profile path) or allocates the wrapper.
+pub const FenceError = error{ PathSandboxViolation, OutOfMemory };
 
 /// Validate that `target_path` is within allowed boundaries.
 /// Allowed prefixes:
@@ -74,6 +78,39 @@ fn underSandboxPathDir(argv0: []const u8) bool {
     return false;
 }
 
+/// Wrap `argv` so the spawn runs under the same real `sandbox-exec` write
+/// fence the `--use-system-ruby` path gets — `validateArgv` is only a lint
+/// (it waves bare/system-dir argv0 through), so the OS fence is what actually
+/// stops a destructive write the formula's *arguments* aim outside the keg.
+///
+/// Returns `argv` unchanged off macOS (no `sandbox-exec` there) so the
+/// builtin stays portable; on macOS returns a fresh argv prefixed with
+/// `/usr/bin/sandbox-exec -p <profile>`. The profile and wrapper live on
+/// `allocator` (the per-formula arena). An unsafe cellar/prefix path fails
+/// closed as a sandbox violation rather than spawning unconfined.
+pub fn fenceArgv(
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+    cellar_path: []const u8,
+    malt_prefix: []const u8,
+) FenceError![]const []const u8 {
+    if (builtin.os.tag != .macos or argv.len == 0) return argv;
+
+    const profile = macos.renderRubyProfile(allocator, cellar_path, malt_prefix) catch |e| switch (e) {
+        // The renderer only allocates and validates: an alloc miss is OOM,
+        // anything else (unsafe path) means we can't confine — fail closed.
+        error.ProfileBuildFailed => return FenceError.OutOfMemory,
+        else => return FenceError.PathSandboxViolation,
+    };
+
+    const wrapped = try allocator.alloc([]const u8, argv.len + 3);
+    wrapped[0] = "/usr/bin/sandbox-exec";
+    wrapped[1] = "-p";
+    wrapped[2] = profile;
+    @memcpy(wrapped[3..], argv);
+    return wrapped;
+}
+
 /// Resolve a path to its canonical form (resolving symlinks)
 /// and then validate it.
 pub fn validateResolved(
@@ -131,6 +168,48 @@ test "validateArgv rejects traversal and relative paths with separators" {
     try std.testing.expectError(
         SandboxError.PathSandboxViolation,
         validateArgv(&.{"./evil"}, cellar, "/opt/malt"),
+    );
+}
+
+test "fenceArgv wraps argv under sandbox-exec with the keg/prefix profile" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const wrapped = try fenceArgv(arena.allocator(), &.{ "make", "install" }, "/opt/malt/Cellar/foo/1.0", "/opt/malt");
+    try std.testing.expectEqualStrings("/usr/bin/sandbox-exec", wrapped[0]);
+    try std.testing.expectEqualStrings("-p", wrapped[1]);
+    try std.testing.expect(std.mem.indexOf(u8, wrapped[2], "(deny default)") != null);
+    // Original argv preserved in order after the wrapper prefix.
+    try std.testing.expectEqualStrings("make", wrapped[3]);
+    try std.testing.expectEqualStrings("install", wrapped[4]);
+    try std.testing.expectEqual(@as(usize, 5), wrapped.len);
+}
+
+test "fenceArgv leaves empty argv untouched" {
+    const empty: []const []const u8 = &.{};
+    const out = try fenceArgv(std.testing.allocator, empty, "/opt/malt/Cellar/foo/1.0", "/opt/malt");
+    try std.testing.expectEqual(@as(usize, 0), out.len);
+}
+
+test "fenceArgv fails closed when the profile path is unsafe" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    // An SCL-metachar in the cellar can't render a safe profile — reject the
+    // spawn rather than running it unconfined.
+    try std.testing.expectError(
+        FenceError.PathSandboxViolation,
+        fenceArgv(arena.allocator(), &.{"make"}, "/opt/malt\"/evil", "/opt/malt"),
+    );
+}
+
+test "fenceArgv maps a profile allocation failure to OutOfMemory" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    // Clean paths pass validation, so the only failure left is the profile
+    // allocation — it must surface as OutOfMemory, not a sandbox violation.
+    try std.testing.expectError(
+        FenceError.OutOfMemory,
+        fenceArgv(std.testing.failing_allocator, &.{"make"}, "/opt/malt/Cellar/foo/1.0", "/opt/malt"),
     );
 }
 

--- a/tests/dsl_builtins_test.zig
+++ b/tests/dsl_builtins_test.zig
@@ -4,6 +4,7 @@
 //! interpreter-level tests don't already touch.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const malt = @import("malt");
 const test_io = @import("test_io");
 const testing = std.testing;
@@ -793,6 +794,120 @@ test "quietSystem always returns nil regardless of exit code" {
     defer lio.deinit();
     const v = try process.quietSystem(arenaCtxLive(&arena, &lio, "/tmp/malt"), null, &.{.{ .string = "/usr/bin/false" }});
     try testing.expect(v == .nil);
+}
+
+// ---------------------------------------------------------------------------
+// Native post_install containment. `system` spawns must run under the same
+// real sandbox-exec fence the --use-system-ruby path gets: the DSL argv lint
+// (validateArgv) accepts any bare/system-dir argv0, so only the OS fence can
+// stop a destructive write the formula's *arguments* aim outside the keg.
+// ---------------------------------------------------------------------------
+
+/// Realpath of a fresh temp dir, skipping the test when it lands under a
+/// profile-writable root (/tmp, /private/tmp, /private/var/folders) — there
+/// the fence's write rules would pass the write through and the assertion
+/// would prove nothing. A CI tmp relocation surfaces as a skip, not a false
+/// pass.
+fn fenceTmpBase(tmp: *std.testing.TmpDir, buf: []u8) ![]const u8 {
+    const n = try std.Io.Dir.realPath(tmp.dir, std.Options.debug_io, buf);
+    const base = buf[0..n];
+    if (std.mem.startsWith(u8, base, "/tmp/") or
+        std.mem.startsWith(u8, base, "/private/tmp/") or
+        std.mem.startsWith(u8, base, "/private/var/folders/"))
+        return error.SkipZigTest;
+    return base;
+}
+
+test "system: a write outside the keg/prefix is blocked by the fence, not the argv lint" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    try test_io.skipIfNoSubprocess();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var base_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const base = try fenceTmpBase(&tmp, &base_buf);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const prefix = try std.fmt.allocPrint(a, "{s}/opt/malt", .{base});
+    const cellar = try std.fmt.allocPrint(a, "{s}/Cellar/foo/1.0", .{prefix});
+    // Sibling of the prefix: outside both the keg and every blessed subtree.
+    const outside = try std.fmt.allocPrint(a, "{s}/pwned", .{base});
+
+    var lio = LiveIo.init();
+    defer lio.deinit();
+    const ctx = ExecCtx{
+        .allocator = a,
+        .io = lio.io(),
+        .environ = malt.app_ctx.processEnviron(),
+        .cellar_path = cellar,
+        .malt_prefix = prefix,
+    };
+
+    // argv0 (/usr/bin/touch) is a system-dir path the lint accepts; only the OS
+    // fence can stop the out-of-root write the argument targets. The denied
+    // write makes touch print "Operation not permitted" to the inherited
+    // stderr; mute fd 2 around the spawn (the argv-only invariant rules out a
+    // shell redirect) so it can't leak into the build runner's error capture
+    // and read as a spurious failure. Restored before the assertions.
+    const v = blk: {
+        const devnull = try std.Io.Dir.cwd().openFile(std.Options.debug_io, "/dev/null", .{ .mode = .write_only });
+        defer devnull.close(std.Options.debug_io);
+        const saved_err = std.c.dup(std.posix.STDERR_FILENO);
+        defer {
+            _ = std.c.dup2(saved_err, std.posix.STDERR_FILENO);
+            _ = std.c.close(saved_err);
+        }
+        _ = std.c.dup2(devnull.handle, std.posix.STDERR_FILENO);
+        break :blk try process.system(ctx, null, &.{
+            .{ .string = "/usr/bin/touch" },
+            .{ .string = outside },
+        });
+    };
+
+    try testing.expect(!v.bool); // denied write → touch exits nonzero
+    if (std.Io.Dir.cwd().access(std.Options.debug_io, outside, .{})) |_|
+        return error.SandboxFenceLeaked
+    else |_| {}
+}
+
+test "system: a write into the keg still succeeds under the fence (no over-confinement)" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    try test_io.skipIfNoSubprocess();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var base_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const base = try fenceTmpBase(&tmp, &base_buf);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const prefix = try std.fmt.allocPrint(a, "{s}/opt/malt", .{base});
+    const cellar = try std.fmt.allocPrint(a, "{s}/Cellar/foo/1.0", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(std.Options.debug_io, cellar);
+    const inside = try std.fmt.allocPrint(a, "{s}/marker", .{cellar});
+
+    var lio = LiveIo.init();
+    defer lio.deinit();
+    const ctx = ExecCtx{
+        .allocator = a,
+        .io = lio.io(),
+        .environ = malt.app_ctx.processEnviron(),
+        .cellar_path = cellar,
+        .malt_prefix = prefix,
+    };
+
+    // A keg-local write is exactly what a real post_install does; the fence
+    // must allow it or it would reject the whole regression corpus.
+    const v = try process.system(ctx, null, &.{
+        .{ .string = "/usr/bin/touch" },
+        .{ .string = inside },
+    });
+
+    try testing.expect(v.bool); // allowed write → touch exits 0
+    try std.Io.Dir.cwd().access(std.Options.debug_io, inside, .{});
 }
 
 test "fileExist checks a real path" {


### PR DESCRIPTION
## Description

A destructive `system` call in a natively interpreted `post_install` could write anywhere on disk. The DSL argv check (`validateArgv`) is only a lint - it waves any bare or system-dir command through - and the real `sandbox-exec` write fence wrapped solely the `--use-system-ruby` path. Native `system` spawns now run under that same fence, so a hostile or buggy `post_install` is confined to the keg/prefix regardless of the argv-level allowlist. Legitimate keg-local
writes are unaffected.

The fence is routed through the existing `core/dsl/sandbox` seam (which already owns the macOS profile import), so that seam now both lints and confines - one place for the DSL's process scope, no new module coupling.

## Related Issue

- None

## Notes for Reviewers

- None
