### PR TITLE
refactor(ui/progress): render every download through one progress-bar primitive

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1381,13 +1381,15 @@ fn installCask(
     installer.artifact_type_override = artifact_type;
     installer.offline = ctx.offline;
 
-    // Progress bar for cask download. A non-terminal sink (bundle) skips
-    // it — the global progress mode is set-once and can't be quieted
-    // mid-run. `init` is pure; only update/finish touch the terminal.
-    var bar = progress_mod.ProgressBar.init(cask.token, 0);
-    if (sink.show_progress) {
+    // Progress bar for cask download, rendered as a one-line group so it
+    // disables autowrap and restores on exit. A non-terminal sink (bundle)
+    // skips setup entirely — the global progress mode is set-once and
+    // can't be quieted mid-run.
+    var sp: ?progress_mod.SingleBar = if (sink.show_progress) progress_mod.SingleBar.init(cask.token, 0) else null;
+    defer if (sp) |*s| s.finish();
+    if (sp) |*s| {
         installer.progress = .{
-            .context = @ptrCast(&bar),
+            .context = @ptrCast(s.bind()),
             .func = &progressBridge,
         };
     }
@@ -1395,12 +1397,12 @@ fn installCask(
     if (download_only) {
         output.emitNdjsonEvent(.download_started, cask.token, null);
         const cache_path = installer.downloadOnly(&cask) catch |e| {
-            if (sink.show_progress) bar.finish();
+            if (sp) |*s| s.bar.finish();
             output.emitNdjsonEvent(.download_complete, cask.token, "failed");
             sink.err("Failed to download cask {s}: {s}", .{ cask.token, @errorName(e) });
             return InstallError.CaskNotFound;
         };
-        if (sink.show_progress) bar.finish();
+        if (sp) |*s| s.bar.finish();
         defer allocator.free(cache_path);
         output.emitNdjsonEvent(.download_complete, cask.token, "ok");
         sink.success("{s} {s} downloaded to {s}", .{ cask.token, cask.version, cache_path });
@@ -1410,13 +1412,13 @@ fn installCask(
     sink.info("Installing cask {s} {s}...", .{ cask.token, cask.version });
 
     const app_path = installer.install(&cask) catch |e| {
-        if (sink.show_progress) bar.finish();
+        if (sp) |*s| s.bar.finish();
         // Surface the specific cause (Sha256Mismatch, DownloadFailed, …) —
         // users can't act on a bare "failed to install".
         sink.err("Failed to install cask {s}: {s}", .{ cask.token, @errorName(e) });
         return InstallError.CaskNotFound;
     };
-    if (sink.show_progress) bar.finish();
+    if (sp) |*s| s.bar.finish();
 
     // Core API casks have no third-party tap origin to record.
     cask_mod.recordInstall(db, &cask, app_path, null) catch {

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -593,19 +593,21 @@ pub fn materializeRubyFormula(
         // staging file (which `mt doctor --fix` and the tap-tmp
         // cleanup regression already reclaim).
         // A non-terminal sink (bundle) skips the bar — the global progress
-        // mode is set-once and can't be quieted mid-run.
-        var bar = progress_mod.ProgressBar.init(resolved.name, 0);
-        const bar_cb: ?client_mod.ProgressCallback = if (sink.show_progress)
-            .{ .context = @ptrCast(&bar), .func = &download.progressBridge }
+        // mode is set-once and can't be quieted mid-run. Rendered as a
+        // one-line group so it disables autowrap and restores on exit.
+        var sp: ?progress_mod.SingleBar = if (sink.show_progress) progress_mod.SingleBar.init(resolved.name, 0) else null;
+        defer if (sp) |*s| s.finish();
+        const bar_cb: ?client_mod.ProgressCallback = if (sp) |*s|
+            .{ .context = @ptrCast(s.bind()), .func = &download.progressBridge }
         else
             null;
         var download_resp = http.getWithHeaders(resolved.url, &.{}, bar_cb) catch {
-            if (sink.show_progress) bar.finish();
+            if (sp) |*s| s.bar.finish();
             sink.err("Failed to download {s}", .{resolved.name});
             return InstallError.DownloadFailed;
         };
         defer download_resp.deinit();
-        if (sink.show_progress) bar.finish();
+        if (sp) |*s| s.bar.finish();
 
         if (download_resp.status != 200) {
             sink.err("Download failed with status {d}", .{download_resp.status});
@@ -869,11 +871,13 @@ fn materializeTapCask(
     installer.offline = ctx.offline;
 
     // A non-terminal sink (bundle) skips the bar — the global progress
-    // mode is set-once and can't be quieted mid-run.
-    var bar = progress_mod.ProgressBar.init(cask.token, 0);
-    if (sink.show_progress) {
+    // mode is set-once and can't be quieted mid-run. Rendered as a
+    // one-line group so it disables autowrap and restores on exit.
+    var sp: ?progress_mod.SingleBar = if (sink.show_progress) progress_mod.SingleBar.init(cask.token, 0) else null;
+    defer if (sp) |*s| s.finish();
+    if (sp) |*s| {
         installer.progress = .{
-            .context = @ptrCast(&bar),
+            .context = @ptrCast(s.bind()),
             .func = &download.progressBridge,
         };
     }
@@ -889,7 +893,7 @@ fn materializeTapCask(
     if (download_only) {
         output.emitNdjsonEvent(.download_started, cask.token, null);
         const cache_path = installer.downloadOnly(&cask) catch |e| {
-            if (sink.show_progress) bar.finish();
+            if (sp) |*s| s.bar.finish();
             output.emitNdjsonEvent(.download_complete, cask.token, "failed");
             sink.err("Failed to download cask {s}: {s}", .{ cask.token, @errorName(e) });
             return switch (e) {
@@ -898,7 +902,7 @@ fn materializeTapCask(
                 else => InstallError.CaskNotFound,
             };
         };
-        if (sink.show_progress) bar.finish();
+        if (sp) |*s| s.bar.finish();
         defer allocator.free(cache_path);
         output.emitNdjsonEvent(.download_complete, cask.token, "ok");
         sink.success("{s} {s} downloaded to {s}", .{ cask.token, cask.version, cache_path });
@@ -906,7 +910,7 @@ fn materializeTapCask(
     }
 
     const app_path = installer.install(&cask) catch |e| {
-        if (sink.show_progress) bar.finish();
+        if (sp) |*s| s.bar.finish();
         sink.err("Failed to install cask {s}: {s}", .{ cask.token, @errorName(e) });
         return switch (e) {
             error.DownloadFailed, error.Sha256Mismatch => InstallError.DownloadFailed,
@@ -914,7 +918,7 @@ fn materializeTapCask(
             else => InstallError.CaskNotFound,
         };
     };
-    if (sink.show_progress) bar.finish();
+    if (sp) |*s| s.bar.finish();
     defer allocator.free(app_path);
 
     // `try` is the invariant: success line never fires without a row.

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -439,10 +439,12 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
                 continue;
             }
 
-            // Standalone bar (no MultiProgress) — same shape as install.zig's
-            // cask path. Initial frame so the row isn't blank before the
-            // first progress callback fires.
-            var bar = progress_mod.ProgressBar.init(keg_name, 0);
+            // One-line group so the bar inherits autowrap-off + restore.
+            // Initial frame so the row isn't blank before the first
+            // progress callback fires.
+            var sp = progress_mod.SingleBar.init(keg_name, 0);
+            defer sp.finish();
+            const bar = sp.bind();
             bar.label_width = max_name_len;
             bar.update(0);
 
@@ -457,7 +459,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
                 .homebrew_prefix = brew_prefix,
                 .use_system_ruby_scope = use_system_ruby_scope.items,
                 .post_install_queue = &post_install_queue,
-                .bar = &bar,
+                .bar = bar,
             });
             bar.finish();
 

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -323,11 +323,14 @@ fn upgradeFormula(
 
     var store = store_mod.Store.init(ctx.io, allocator, db, prefix);
 
-    var bar = progress_mod.ProgressBar.init(name, 0);
+    // One-line group so the upgrade bar disables autowrap and restores on
+    // exit, instead of the old setup-free bar that stacked when over-width.
+    var sp = progress_mod.SingleBar.init(name, 0);
+    defer sp.finish();
     const fetch = install_download_mod.installKegFromBottle(
         ctx,
         allocator,
-        .{ .ghcr = &ghcr, .http = http, .store = &store, .bar = &bar },
+        .{ .ghcr = &ghcr, .http = http, .store = &store, .bar = sp.bind() },
         &formula,
         prefix,
     ) catch |e| {

--- a/src/ui/progress.zig
+++ b/src/ui/progress.zig
@@ -8,15 +8,15 @@
 //! mid-chain output.
 
 const std = @import("std");
+/// Process-wide io and stderr sink seeded once from `main` via
+/// `setRuntime`. `pkg_stderr` defaults to fd `-1` so unconfigured tests
+/// silently drop progress writes; `pkg_io` defaults to `debug_io`.
+var pkg_io: std.Io = std.Options.debug_io;
 const builtin = @import("builtin");
 
 const color = @import("color.zig");
 const output = @import("output.zig");
 
-/// Process-wide io and stderr sink seeded once from `main` via
-/// `setRuntime`. `pkg_stderr` defaults to fd `-1` so unconfigured tests
-/// silently drop progress writes; `pkg_io` defaults to `debug_io`.
-var pkg_io: std.Io = std.Options.debug_io;
 var pkg_stderr: std.Io.File = .{ .handle = -1, .flags = .{ .nonblocking = false } };
 
 /// Selects how long-running mutators report progress. Resolved once at
@@ -272,12 +272,10 @@ pub const ProgressBar = struct {
                 if (self.total > 0) {
                     self.current = self.total;
                 }
+                // Every bar belongs to a group that reserves its row up
+                // front (`SingleBar` for the one-bar case), so the final
+                // frame is an in-place redraw — no trailing newline.
                 self.render();
-                // Standalone bars own their trailing newline; multi-progress
-                // groups reserve the row up front.
-                if (self.multi == null) {
-                    writeStderrAll("\n");
-                }
             },
         }
     }
@@ -600,6 +598,43 @@ pub const ProgressBar = struct {
         }
 
         writeStderrAll(buf[0..pos]);
+    }
+};
+
+/// A single download bar rendered as a group of one. Standalone callers
+/// (single-package install, cask, single-keg migrate, upgrade) used to
+/// hand-roll a setup-free `ProgressBar`, which never disabled autowrap —
+/// so an over-width bar line wrapped and every redraw stacked a fresh row.
+/// Routing them through `MultiProgress.init(1)` reuses the same
+/// autowrap-off + cursor-hide + line-reservation + restore guarantees the
+/// multi-package path already had, killing the divergence and the bug.
+///
+/// Self-referential: `bar.multi` points back into this struct, so it must
+/// be pinned at its final address before use — `init` then `bind`.
+pub const SingleBar = struct {
+    multi: MultiProgress,
+    bar: ProgressBar,
+
+    pub fn init(label: []const u8, total: u64) SingleBar {
+        return .{
+            .multi = MultiProgress.init(1),
+            .bar = ProgressBar.init(label, total),
+        };
+    }
+
+    /// Attach the bar to its one-line group and hand back a stable pointer.
+    /// Call once, after the struct is at its final stack address.
+    pub fn bind(self: *SingleBar) *ProgressBar {
+        self.bar.multi = &self.multi;
+        self.bar.line_index = 0;
+        return &self.bar;
+    }
+
+    /// Restore terminal state (autowrap, cursor). The bar's final frame is
+    /// rendered by the caller's `bar.finish()`; this only tears down the
+    /// group, mirroring `defer multi.finish()` on the multi-package path.
+    pub fn finish(self: *SingleBar) void {
+        self.multi.finish();
     }
 };
 
@@ -1069,6 +1104,103 @@ test "MultiProgress in tty mode on a TTY emits the cursor-hide prelude" {
     // Prelude + 2 reserved newlines + restore-on-finish (autowrap on,
     // cursor on, carriage return).
     try std.testing.expectEqualStrings("\x1b[?25l\x1b[?7l\n\n\x1b[?7h\x1b[?25h\r", buf.items);
+}
+
+// The single-bar entry point must inherit the same terminal setup as the
+// multi-package path — a "group of one". Pinning the autowrap-disable
+// prelude here is the regression guard: a future change that drops back to
+// a setup-free standalone bar (the divergence that let over-width upgrade
+// bars wrap and stack) fails this test.
+test "SingleBar in tty mode emits the autowrap-disable prelude" {
+    const prior_mode = mode();
+    setMode(.tty);
+    defer setMode(prior_mode);
+    setSupportsAnsiForTest(true);
+    defer setSupportsAnsiForTest(null);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    beginStderrCapture(std.testing.allocator, &buf);
+    defer endStderrCapture();
+
+    var sp = SingleBar.init("tree", 0);
+    sp.finish();
+
+    // Prelude + 1 reserved newline + restore-on-finish.
+    try std.testing.expectEqualStrings("\x1b[?25l\x1b[?7l\n\x1b[?7h\x1b[?25h\r", buf.items);
+}
+
+// The unified single-bar path redraws in place via cursor moves; the only
+// newline in its output is the one reserved row from MultiProgress(1).
+// A per-tick or trailing `\n` would re-introduce the standalone bar's
+// "stack a fresh row per redraw" symptom.
+test "SingleBar renders one logical line with no stray newline" {
+    const prior_mode = mode();
+    setMode(.tty);
+    defer setMode(prior_mode);
+    setSupportsAnsiForTest(true);
+    defer setSupportsAnsiForTest(null);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    beginStderrCapture(std.testing.allocator, &buf);
+    defer endStderrCapture();
+
+    var sp = SingleBar.init("tree", 100);
+    const bar = sp.bind();
+    bar.update(50);
+    bar.finish();
+    sp.finish();
+
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, buf.items, "\n"));
+}
+
+// Regression guard for AC3: routing the single-bar case through a group
+// must not leak DECSET/cursor-hide setup into CI logs. In plain mode the
+// bar still emits its one starting / one done line and nothing else.
+test "SingleBar in plain mode emits plain lines and no ANSI setup" {
+    const prior_mode = mode();
+    setMode(.plain);
+    defer setMode(prior_mode);
+    setSupportsAnsiForTest(true);
+    defer setSupportsAnsiForTest(null);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    beginStderrCapture(std.testing.allocator, &buf);
+    defer endStderrCapture();
+
+    var sp = SingleBar.init("tree", 1000);
+    const bar = sp.bind();
+    bar.update(0);
+    bar.update(500); // intermediate updates do not spam new lines
+    bar.finish();
+    sp.finish();
+
+    try std.testing.expectEqualStrings("tree: starting\ntree: done\n", buf.items);
+}
+
+// Regression guard for AC3: none mode through the single-bar primitive
+// writes zero bytes, even with the TTY render branch forced.
+test "SingleBar in none mode writes no bytes" {
+    const prior_mode = mode();
+    setMode(.none);
+    defer setMode(prior_mode);
+    setSupportsAnsiForTest(true);
+    defer setSupportsAnsiForTest(null);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    beginStderrCapture(std.testing.allocator, &buf);
+    defer endStderrCapture();
+
+    var sp = SingleBar.init("tree", 1000);
+    const bar = sp.bind();
+    bar.update(500);
+    bar.finish();
+    sp.finish();
+
+    try std.testing.expectEqualStrings("", buf.items);
 }
 
 // A standalone bar that's `finish`-ed without any prior `update` still


### PR DESCRIPTION
## Description

Every download now renders through a single progress-bar primitive that owns terminal-state setup, so a single package shows one bar updating in place instead of a column of stacked, half-finished bars. The standalone `upgrade` / single-package / cask / single-keg-migrate paths previously hand-rolled a bar that never disabled autowrap; on a terminal narrower than the bar line each redraw wrapped and stacked. Folding those call sites onto the same primitive the multi-package install path already used removes the duplication and the bug together.

## Related Issue

- None

## Notes for Reviewers

- None
