### PR TITLE
refactor(core): extract a forge seam for tap URL/HEAD/auth resolution

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -185,6 +185,7 @@ pub fn build(b: *std.Build) void {
         "tests/test_io_primitives_test.zig",
         "tests/no_io_mod_in_src_test.zig",
         "tests/no_cli_in_core_test.zig",
+        "tests/forge_purity_test.zig",
         "tests/no_main_reach_in_cli_test.zig",
         "tests/ui_color_theme_test.zig",
         "tests/install_local_test.zig",

--- a/scripts/regressions/tap-resolution-contract.sh
+++ b/scripts/regressions/tap-resolution-contract.sh
@@ -1,23 +1,25 @@
 #!/usr/bin/env bash
-# Lock the tap-resolution contract to a single seam in src/core/tap.zig.
+# Lock the tap-resolution contract to the core/tap.zig + core/forge.zig
+# seam.
 #
 # Every fetch URL, every writeback URL, and the `MALT_GITHUB_TOKEN`
-# auth reach are co-located in one file so a future URL-shape change
-# (prefixless taps, non-GitHub hosts) or auth-policy change lands in
-# exactly one place. Drift here is the refresh-regression mode the
+# auth reach are co-located behind the forge seam so a future URL-shape
+# change (prefixless taps, non-GitHub hosts) or auth-policy change lands
+# in exactly one place. Drift here is the refresh-regression mode the
 # tap-resolution refactor was designed to structurally prevent.
 #
 # Three anti-patterns are flagged:
 #   1. `homebrew-{` — duplicated `homebrew-<repo>` synthesis (API/raw URLs)
 #   2. `https://github.com/{s}"` — decorative writeback that lied about
 #      the actually-resolvable repo URL
-#   3. `MALT_GITHUB_TOKEN` / `githubAuthHeader` outside the helper —
+#   3. `MALT_GITHUB_TOKEN` / `authHeader` outside the seam —
 #      the token reaches exactly the GitHub API HEAD call and never
 #      the raw Formula/Cask fetches. Widening (or narrowing) the reach
 #      without explicit intent is a contract change.
 #
 # Allowed sites:
-#   - src/core/tap.zig          the helper itself
+#   - src/core/forge.zig        the host-shaped seam (URLs, parse, auth)
+#   - src/core/tap.zig          the row/orchestration caller of the seam
 #   - src/cli/migrate/keg.zig   on-disk Cellar path
 #                                 (<prefix>/Library/Taps/<user>/homebrew-<repo>) —
 #                                 Homebrew's filesystem layout, not a URL
@@ -36,22 +38,23 @@ cd "$ROOT"
 hits_prefix=$(grep -rn --include='*.zig' -F 'homebrew-{' src || true)
 hits_bare_slug=$(grep -rn --include='*.zig' -F 'https://github.com/{s}"' src || true)
 hits_token=$(grep -rn --include='*.zig' -F 'MALT_GITHUB_TOKEN' src || true)
-hits_auth_helper=$(grep -rn --include='*.zig' -F 'githubAuthHeader' src || true)
+hits_auth_helper=$(grep -rn --include='*.zig' -F 'authHeader' src || true)
 
 all=$(printf '%s\n%s\n%s\n%s\n' \
   "$hits_prefix" "$hits_bare_slug" "$hits_token" "$hits_auth_helper")
 
 filtered=$(printf '%s\n' "$all" |
+  grep -v '^src/core/forge\.zig:' |
   grep -v '^src/core/tap\.zig:' |
   grep -v '^src/cli/migrate/keg\.zig:' |
   grep -v '^$' || true)
 
 if [[ -n "$filtered" ]]; then
-  printf "FAIL: tap-resolution contract violation outside src/core/tap.zig:\n\n" >&2
+  printf "FAIL: tap-resolution contract violation outside the forge seam:\n\n" >&2
   printf '%s\n\n' "$filtered" >&2
-  printf 'Route URLs through resolveTapBaseUrls; keep MALT_GITHUB_TOKEN reach\n' >&2
-  printf 'inside resolveHeadCommit via githubAuthHeader.\n' >&2
+  printf 'Route URLs through forge.buildBaseUrls/forge.rawFileUrl; keep the\n' >&2
+  printf 'MALT_GITHUB_TOKEN reach inside forge.authHeader.\n' >&2
   exit 1
 fi
 
-echo "OK: tap-resolution contract holds — all fetches and auth go through src/core/tap.zig"
+echo "OK: tap-resolution contract holds — all fetches and auth go through the forge seam"

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -11,6 +11,7 @@ const cask_mod = @import("../../core/cask.zig");
 const hash = @import("../../core/hash.zig");
 const linker_mod = @import("../../core/linker.zig");
 const tap_mod = @import("../../core/tap.zig");
+const forge = @import("../../core/forge.zig");
 const tap_cache = @import("../../core/tap_cache.zig");
 const sqlite = @import("../../db/sqlite.zig");
 const atomic = @import("../../fs/atomic.zig");
@@ -248,17 +249,19 @@ fn installTapRb(
 
     // First probe: Formula/ for the default mode, Casks/ when the
     // caller has pinned the resolve to cask-only.
-    const initial_subdir: []const u8 = switch (kind) {
-        .formula_or_cask => "Formula",
-        .cask_only => "Casks",
+    const initial_kind: forge.RawKind = switch (kind) {
+        .formula_or_cask => .formula,
+        .cask_only => .cask,
     };
     var url_buf: [512]u8 = undefined;
-    const rb_url = std.fmt.bufPrint(&url_buf, "{s}/{s}/{s}/{s}.rb", .{
+    const rb_url = forge.rawFileUrl(
+        &url_buf,
+        .github,
         urls.raw_base,
         commit_sha,
-        initial_subdir,
+        initial_kind,
         parts.formula,
-    }) catch return InstallError.FormulaNotFound;
+    ) catch return InstallError.FormulaNotFound;
 
     var rb_resp = http.get(rb_url) catch {
         sink.err("Cannot fetch tap from GitHub", .{});
@@ -279,11 +282,14 @@ fn installTapRb(
         // the not-found error.
         if (kind == .cask_only) break :blk &rb_resp;
 
-        const cask_url = std.fmt.bufPrint(&url_buf, "{s}/{s}/Casks/{s}.rb", .{
+        const cask_url = forge.rawFileUrl(
+            &url_buf,
+            .github,
             urls.raw_base,
             commit_sha,
+            .cask,
             parts.formula,
-        }) catch return InstallError.FormulaNotFound;
+        ) catch return InstallError.FormulaNotFound;
 
         cask_resp = http.get(cask_url) catch {
             sink.err("Cannot fetch tap from GitHub", .{});

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -11,6 +11,7 @@ const std = @import("std");
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
 const cask_mod = @import("../../core/cask.zig");
 const tap_mod = @import("../../core/tap.zig");
+const forge = @import("../../core/forge.zig");
 const sqlite = @import("../../db/sqlite.zig");
 const api_mod = @import("../../net/api.zig");
 const client_mod = @import("../../net/client.zig");
@@ -539,7 +540,7 @@ fn tapCaskLatestVersion(
     http.offline = offline;
 
     var rb_url_buf: [512]u8 = undefined;
-    const rb_url = std.fmt.bufPrint(&rb_url_buf, "{s}/{s}/Casks/{s}.rb", .{ urls.raw_base, fresh_sha, token }) catch return null;
+    const rb_url = forge.rawFileUrl(&rb_url_buf, .github, urls.raw_base, fresh_sha, .cask, token) catch return null;
 
     var rb_resp = http.get(rb_url) catch {
         warnTapCaskFetchFailed(tap_label, token, "Network failure while reading the .rb");

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 
 const AppCtx = @import("../app_ctx.zig").AppCtx;
 const tap_mod = @import("../core/tap.zig");
+const forge = @import("../core/forge.zig");
 const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
@@ -611,7 +612,7 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
                 };
             }
 
-            const urls = try tap_mod.buildTapBaseUrls(allocator, target_pair.owner, target_pair.repo);
+            const urls = try forge.buildBaseUrls(allocator, .github, "github.com", target_pair.owner, target_pair.repo);
             defer urls.deinit(allocator);
 
             // Idempotent re-adds reuse the cached etag for stable taps —

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -11,6 +11,7 @@ const formula_mod = @import("../core/formula.zig");
 const linker_mod = @import("../core/linker.zig");
 const store_mod = @import("../core/store.zig");
 const tap_mod = @import("../core/tap.zig");
+const forge = @import("../core/forge.zig");
 const lock_mod = @import("../db/lock.zig");
 const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
@@ -589,7 +590,7 @@ fn upgradeRoutedTapCask(
     http.offline = ctx.offline;
 
     var rb_url_buf: [512]u8 = undefined;
-    const rb_url = std.fmt.bufPrint(&rb_url_buf, "{s}/{s}/Casks/{s}.rb", .{ urls.raw_base, fresh_sha, token }) catch return error.Aborted;
+    const rb_url = forge.rawFileUrl(&rb_url_buf, .github, urls.raw_base, fresh_sha, .cask, token) catch return error.Aborted;
 
     var rb_resp = http.get(rb_url) catch |e| {
         output.err("Could not fetch {s} from tap {s}: {s}", .{ token, tap_label, @errorName(e) });

--- a/src/core/forge.zig
+++ b/src/core/forge.zig
@@ -1,0 +1,397 @@
+//! Pure leaf owning every host-shaped tap decision: the URL triple, the
+//! raw-`.rb` tail, the HEAD-commit sha parse, and the auth header. A
+//! single enum-`switch` per concern means a new forge (GitLab, Codeberg)
+//! is a new arm the compiler forces you to handle — never a scattered
+//! edit across call sites. Imports neither `cli/*` nor `ui/*` (guarded by
+//! `tests/forge_purity_test.zig`); never renders user-facing strings.
+
+const std = @import("std");
+
+/// Source forge hosting a tap repo. GitHub is the only variant today;
+/// GitLab/Codeberg arrive as new arms, each forcing an exhaustive-switch
+/// compile error until every concern below handles it.
+pub const Forge = enum { github };
+
+const github_browse_fmt = "https://github.com/{s}/{s}";
+
+/// Browse URL for `taps.url`, written into a caller buffer. `host` is
+/// plumbed for non-github arms; the github arm's host is fixed.
+pub fn repoBrowseUrl(
+    buf: []u8,
+    forge: Forge,
+    host: []const u8,
+    owner: []const u8,
+    repo: []const u8,
+) std.fmt.BufPrintError![]const u8 {
+    _ = host;
+    return switch (forge) {
+        .github => std.fmt.bufPrint(buf, github_browse_fmt, .{ owner, repo }),
+    };
+}
+
+/// Allocating sibling of `repoBrowseUrl` for the read-time projection in
+/// `list`, where each row owns its slice. Same bytes as the buffered form.
+pub fn allocRepoBrowseUrl(
+    allocator: std.mem.Allocator,
+    forge: Forge,
+    host: []const u8,
+    owner: []const u8,
+    repo: []const u8,
+) std.mem.Allocator.Error![]const u8 {
+    _ = host;
+    return switch (forge) {
+        .github => std.fmt.allocPrint(allocator, github_browse_fmt, .{ owner, repo }),
+    };
+}
+
+/// Which tap subtree a raw `.rb` lives under. The `Formula/` vs
+/// `Casks/` split callers used to inline as a string literal.
+pub const RawKind = enum {
+    formula,
+    cask,
+
+    fn subdir(self: RawKind) []const u8 {
+        return switch (self) {
+            .formula => "Formula",
+            .cask => "Casks",
+        };
+    }
+};
+
+/// Build a raw `.rb` URL into `buf` by appending the
+/// `<sha>/<subdir>/<name>.rb` tail to a forge's `raw_base`. GitHub's
+/// raw layout puts the sha right after the base; other forges differ
+/// only in `raw_base` (the infix), so the tail is uniform here today.
+pub fn rawFileUrl(
+    buf: []u8,
+    forge: Forge,
+    raw_base: []const u8,
+    sha: []const u8,
+    kind: RawKind,
+    name: []const u8,
+) std.fmt.BufPrintError![]const u8 {
+    return switch (forge) {
+        .github => std.fmt.bufPrint(buf, "{s}/{s}/{s}/{s}.rb", .{
+            raw_base, sha, kind.subdir(), name,
+        }),
+    };
+}
+
+/// Map a host to its forge. Defaults to `.github` — the only variant
+/// today; the `host` argument is plumbed now so AP-002 only feeds it,
+/// never re-threads signatures.
+pub fn fromHost(host: []const u8) Forge {
+    _ = host;
+    return .github;
+}
+
+/// URLs every tap fetch site needs. For raw fetches callers append the
+/// `<sha>/Formula/<name>.rb` (or `Casks/`) tail via `rawFileUrl`.
+pub const TapBaseUrls = struct {
+    /// `https://api.github.com/repos/<owner>/<repo>/commits/HEAD`
+    api_head_url: []const u8,
+    /// `https://github.com/<owner>/<repo>` — the URL that actually
+    /// resolves; mirrored into `taps.url` at INSERT/rebind time.
+    repo_url: []const u8,
+    /// `https://raw.githubusercontent.com/<owner>/<repo>` — `rawFileUrl`
+    /// appends the `<sha>/Formula/<name>.rb` or `Casks/` tail.
+    raw_base: []const u8,
+
+    pub fn deinit(self: TapBaseUrls, allocator: std.mem.Allocator) void {
+        allocator.free(self.api_head_url);
+        allocator.free(self.repo_url);
+        allocator.free(self.raw_base);
+    }
+};
+
+/// Build the URL triple for a tap repo. `host` is plumbed for the
+/// non-GitHub arms (AP-002 feeds it from the row); the github arm's
+/// hosts are fixed, so it ignores `host` today.
+pub fn buildBaseUrls(
+    allocator: std.mem.Allocator,
+    forge: Forge,
+    host: []const u8,
+    owner: []const u8,
+    repo: []const u8,
+) std.mem.Allocator.Error!TapBaseUrls {
+    switch (forge) {
+        .github => {
+            _ = host; // github hosts are fixed; host drives only non-github arms
+            const api_head_url = try std.fmt.allocPrint(
+                allocator,
+                "https://api.github.com/repos/{s}/{s}/commits/HEAD",
+                .{ owner, repo },
+            );
+            errdefer allocator.free(api_head_url);
+
+            const repo_url = try std.fmt.allocPrint(
+                allocator,
+                "https://github.com/{s}/{s}",
+                .{ owner, repo },
+            );
+            errdefer allocator.free(repo_url);
+
+            const raw_base = try std.fmt.allocPrint(
+                allocator,
+                "https://raw.githubusercontent.com/{s}/{s}",
+                .{ owner, repo },
+            );
+            errdefer allocator.free(raw_base);
+
+            return .{ .api_head_url = api_head_url, .repo_url = repo_url, .raw_base = raw_base };
+        },
+    }
+}
+
+/// Build the per-forge auth header into `buf` from the forge's token
+/// env var, or null when unset/empty. GitHub: `Authorization: Bearer
+/// <MALT_GITHUB_TOKEN>`. The reach is deliberately narrow — only the
+/// tap-resolution caller passes this header — so the token never leaks
+/// onto unrelated requests.
+pub fn authHeader(forge: Forge, environ: std.process.Environ, buf: []u8) ?std.http.Header {
+    switch (forge) {
+        .github => {
+            const raw = std.process.Environ.getPosix(environ, "MALT_GITHUB_TOKEN") orelse return null;
+            if (raw.len == 0) return null;
+            const value = std.fmt.bufPrint(buf, "Bearer {s}", .{raw}) catch return null;
+            return .{ .name = "Authorization", .value = value };
+        },
+    }
+}
+
+/// A 40-char lowercase hex commit SHA — git's printable form. Kept
+/// leaf-local so `forge` never reaches into `tap`'s `validateCommitSha`
+/// (which carries `TapError` + row semantics this module must not pull in).
+fn isCommitSha(sha: []const u8) bool {
+    if (sha.len != 40) return false;
+    for (sha) |c| switch (c) {
+        '0'...'9', 'a'...'f' => {},
+        else => return false,
+    };
+    return true;
+}
+
+/// Pull the HEAD commit sha out of a forge's `commits/HEAD` response.
+/// GitHub: the first top-level `"sha"` string, validated as 40-char
+/// lowercase hex. Untrusted input — malformed or unexpected shapes
+/// return null rather than a misleading sha. The result borrows from
+/// `body`; the caller dupes it.
+pub fn parseHeadSha(forge: Forge, body: []const u8) ?[]const u8 {
+    switch (forge) {
+        .github => {
+            // First top-level `"sha"` takes the value — GitHub always emits
+            // the commit SHA before the nested tree/parent objects.
+            const marker = "\"sha\"";
+            const idx = std.mem.indexOf(u8, body, marker) orelse return null;
+            var cur = idx + marker.len;
+            while (cur < body.len and (body[cur] == ' ' or body[cur] == ':' or body[cur] == '\t')) : (cur += 1) {}
+            if (cur >= body.len or body[cur] != '"') return null;
+            cur += 1;
+            const end = std.mem.indexOfScalarPos(u8, body, cur, '"') orelse return null;
+            const sha = body[cur..end];
+            if (!isCommitSha(sha)) return null;
+            return sha;
+        },
+    }
+}
+
+test "fromHost classifies github.com as .github" {
+    try std.testing.expectEqual(Forge.github, fromHost("github.com"));
+}
+
+test "fromHost defaults unknown hosts to .github (only variant today)" {
+    try std.testing.expectEqual(Forge.github, fromHost("example.com"));
+}
+
+// ── parseHeadSha (github) ──────────────────────────────────────────
+// Security-sensitive: picking up the wrong "sha" field would pin malt
+// to an attacker-influenced commit instead of the real HEAD. Exhaustive
+// coverage of shapes a real GitHub `commits/HEAD` response can take.
+
+const valid_sha_fixture = "0123456789abcdef0123456789abcdef01234567";
+
+test "parseHeadSha github: canonical GitHub response" {
+    const body =
+        \\{"sha":"0123456789abcdef0123456789abcdef01234567","node_id":"X","commit":{"author":{"name":"x"}}}
+    ;
+    const got = parseHeadSha(.github, body) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(valid_sha_fixture, got);
+}
+
+test "parseHeadSha github: tolerates whitespace around ':' and value" {
+    const body =
+        \\{  "sha"  :  "0123456789abcdef0123456789abcdef01234567" , "other": 1 }
+    ;
+    const got = parseHeadSha(.github, body) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(valid_sha_fixture, got);
+}
+
+test "parseHeadSha github: returns first top-level sha even when nested sha exists" {
+    const body =
+        \\{"sha":"0123456789abcdef0123456789abcdef01234567","commit":{"tree":{"sha":"ffffffffffffffffffffffffffffffffffffffff"}}}
+    ;
+    const got = parseHeadSha(.github, body) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(valid_sha_fixture, got);
+}
+
+test "parseHeadSha github: missing sha field yields null" {
+    const body =
+        \\{"node_id":"X","commit":{"author":{"name":"x"}}}
+    ;
+    try std.testing.expectEqual(@as(?[]const u8, null), parseHeadSha(.github, body));
+}
+
+test "parseHeadSha github: non-string value yields null" {
+    const body =
+        \\{"sha": 42}
+    ;
+    try std.testing.expectEqual(@as(?[]const u8, null), parseHeadSha(.github, body));
+}
+
+test "parseHeadSha github: truncated value yields null" {
+    const body =
+        \\{"sha":"deadbeef
+    ;
+    try std.testing.expectEqual(@as(?[]const u8, null), parseHeadSha(.github, body));
+}
+
+test "parseHeadSha github: malformed SHA value yields null" {
+    const body =
+        \\{"sha":"not-a-valid-sha"}
+    ;
+    try std.testing.expectEqual(@as(?[]const u8, null), parseHeadSha(.github, body));
+}
+
+test "parseHeadSha github: empty body yields null" {
+    try std.testing.expectEqual(@as(?[]const u8, null), parseHeadSha(.github, ""));
+}
+
+test "parseHeadSha github: uppercase hex in value is rejected" {
+    const body =
+        \\{"sha":"0123456789ABCDEF0123456789ABCDEF01234567"}
+    ;
+    try std.testing.expectEqual(@as(?[]const u8, null), parseHeadSha(.github, body));
+}
+
+// ── authHeader (github) ────────────────────────────────────────────
+// Only the `/commits/HEAD` call picks up MALT_GITHUB_TOKEN. The Bearer
+// format must match GitHub's contract. Environs are constructed inline
+// so the test never mutates real process state.
+
+fn envWith(comptime entries: anytype) std.process.Environ {
+    const slice = entries;
+    return .{ .block = .{ .slice = slice[0..slice.len :null] } };
+}
+
+test "authHeader github: null when MALT_GITHUB_TOKEN unset" {
+    var buf: [256]u8 = undefined;
+    try std.testing.expect(authHeader(.github, .empty, &buf) == null);
+}
+
+test "authHeader github: Bearer header when MALT_GITHUB_TOKEN set" {
+    const entries = [_:null]?[*:0]const u8{"MALT_GITHUB_TOKEN=ghp_testtoken"};
+    var buf: [256]u8 = undefined;
+    const h = authHeader(.github, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
+    try std.testing.expectEqualStrings("Authorization", h.name);
+    try std.testing.expectEqualStrings("Bearer ghp_testtoken", h.value);
+}
+
+test "authHeader github: empty-string token behaves as unset" {
+    const entries = [_:null]?[*:0]const u8{"MALT_GITHUB_TOKEN="};
+    var buf: [256]u8 = undefined;
+    try std.testing.expect(authHeader(.github, envWith(entries), &buf) == null);
+}
+
+// ── buildBaseUrls (github) ─────────────────────────────────────────
+// The URL triple every tap fetch site needs. Byte shapes are the
+// contract — `core/tap.zig`'s resolve path and every install/upgrade
+// caller depend on them being identical to today.
+
+test "buildBaseUrls github: builds the api-head / repo / raw triple" {
+    const urls = try buildBaseUrls(std.testing.allocator, .github, "github.com", "aeroxy", "ast-outline");
+    defer urls.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings(
+        "https://api.github.com/repos/aeroxy/ast-outline/commits/HEAD",
+        urls.api_head_url,
+    );
+    try std.testing.expectEqualStrings("https://github.com/aeroxy/ast-outline", urls.repo_url);
+    try std.testing.expectEqualStrings("https://raw.githubusercontent.com/aeroxy/ast-outline", urls.raw_base);
+}
+
+test "buildBaseUrls github: preserves hyphens and dots in the repo component" {
+    const urls = try buildBaseUrls(std.testing.allocator, .github, "github.com", "user-1", "homebrew-some-tap.v2");
+    defer urls.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings(
+        "https://api.github.com/repos/user-1/homebrew-some-tap.v2/commits/HEAD",
+        urls.api_head_url,
+    );
+}
+
+fn buildAndFree(allocator: std.mem.Allocator) !void {
+    const urls = try buildBaseUrls(allocator, .github, "github.com", "user", "homebrew-repo");
+    urls.deinit(allocator);
+}
+
+test "buildBaseUrls github: no leak on any allocation failure" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, buildAndFree, .{});
+}
+
+// ── rawFileUrl (github) ────────────────────────────────────────────
+// The `<sha>/Formula/<name>.rb` vs `Casks/` tail tap install/upgrade
+// callers used to append inline. Centralised so a forge with a
+// different raw layout is one arm, not edits at every fetch site.
+
+const raw_sha_fixture = "0123456789abcdef0123456789abcdef01234567";
+const github_raw_base = "https://raw.githubusercontent.com/aeroxy/ast-outline";
+
+test "rawFileUrl github: formula kind builds the Formula/ tail" {
+    var buf: [512]u8 = undefined;
+    const url = try rawFileUrl(&buf, .github, github_raw_base, raw_sha_fixture, .formula, "glow");
+    try std.testing.expectEqualStrings(
+        github_raw_base ++ "/" ++ raw_sha_fixture ++ "/Formula/glow.rb",
+        url,
+    );
+}
+
+test "rawFileUrl github: cask kind builds the Casks/ tail" {
+    var buf: [512]u8 = undefined;
+    const url = try rawFileUrl(&buf, .github, github_raw_base, raw_sha_fixture, .cask, "glow");
+    try std.testing.expectEqualStrings(
+        github_raw_base ++ "/" ++ raw_sha_fixture ++ "/Casks/glow.rb",
+        url,
+    );
+}
+
+test "rawFileUrl github: overflowing buffer surfaces NoSpaceLeft" {
+    var buf: [8]u8 = undefined;
+    try std.testing.expectError(
+        error.NoSpaceLeft,
+        rawFileUrl(&buf, .github, github_raw_base, raw_sha_fixture, .formula, "glow"),
+    );
+}
+
+// ── browse URL (github) ────────────────────────────────────────────
+// The `taps.url` projection: the URL that actually resolves in a
+// browser, written at INSERT/rebind and re-derived in `list`. Both
+// shapes must agree byte-for-byte, hence one seam.
+
+test "repoBrowseUrl github: writes the github.com browse URL into a buffer" {
+    var buf: [256]u8 = undefined;
+    const url = try repoBrowseUrl(&buf, .github, "github.com", "user", "homebrew-repo");
+    try std.testing.expectEqualStrings("https://github.com/user/homebrew-repo", url);
+}
+
+test "allocRepoBrowseUrl github: allocates the same browse URL" {
+    const url = try allocRepoBrowseUrl(std.testing.allocator, .github, "github.com", "aeroxy", "ast-outline");
+    defer std.testing.allocator.free(url);
+    try std.testing.expectEqualStrings("https://github.com/aeroxy/ast-outline", url);
+}
+
+fn browseAndFree(allocator: std.mem.Allocator) !void {
+    const url = try allocRepoBrowseUrl(allocator, .github, "github.com", "user", "homebrew-repo");
+    allocator.free(url);
+}
+
+test "allocRepoBrowseUrl github: no leak on allocation failure" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, browseAndFree, .{});
+}

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const sqlite = @import("../db/sqlite.zig");
 const client_mod = @import("../net/client.zig");
+const forge = @import("forge.zig");
 
 pub const TapInfo = struct {
     name: []const u8,
@@ -39,17 +40,6 @@ pub fn classifyResolveStatus(status: u16) TapError {
     };
 }
 
-/// Build a `Authorization: Bearer <token>` header into `buf` from
-/// `MALT_GITHUB_TOKEN`, or return null when the env var is unset or
-/// empty. Exclusive to `resolveHeadCommit` — no other codepath picks up
-/// this env var, so users who set it only affect tap-resolution calls.
-pub fn githubAuthHeader(environ: std.process.Environ, buf: []u8) ?std.http.Header {
-    const raw = std.process.Environ.getPosix(environ, "MALT_GITHUB_TOKEN") orelse return null;
-    if (raw.len == 0) return null;
-    const value = std.fmt.bufPrint(buf, "Bearer {s}", .{raw}) catch return null;
-    return .{ .name = "Authorization", .value = value };
-}
-
 /// Short remediation hint for each `TapError` variant. Keeping the
 /// strings here (not at the call site) means `cli/install/local.zig`
 /// and `cli/tap.zig` cannot drift out of sync, and unit tests can pin
@@ -66,15 +56,11 @@ pub fn describeResolveError(err: TapError) []const u8 {
     };
 }
 
-/// Format string for the `taps.url` projection. Centralised so the
-/// INSERT/rebind writer and the read-time projection in `list()` can't
-/// drift — a future host swap (GitLab, Gitea) flips this one literal.
-const repo_url_fmt = "https://github.com/{s}/{s}";
-
-/// Materialise `taps.url` from `(owner, repo)` into a caller buffer.
+/// Materialise `taps.url` from `(owner, repo)` into a caller buffer
+/// through the forge seam, so the browse-URL shape lives in one place.
 /// `buf` must hold ≥160 bytes (19 prefix + 2·64 component cap + 1 slash).
 fn writeRepoUrl(buf: []u8, owner: []const u8, repo: []const u8) sqlite.SqliteError![]const u8 {
-    return std.fmt.bufPrint(buf, repo_url_fmt, .{ owner, repo }) catch
+    return forge.repoBrowseUrl(buf, .github, "github.com", owner, repo) catch
         sqlite.SqliteError.ExecFailed;
 }
 
@@ -241,10 +227,12 @@ pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) ![]TapInfo {
 
         const name_owned = try allocator.dupe(u8, std.mem.sliceTo(n, 0));
         errdefer allocator.free(name_owned);
-        const url_owned = try std.fmt.allocPrint(
+        const url_owned = try forge.allocRepoBrowseUrl(
             allocator,
-            repo_url_fmt,
-            .{ std.mem.sliceTo(o, 0), std.mem.sliceTo(r, 0) },
+            .github,
+            "github.com",
+            std.mem.sliceTo(o, 0),
+            std.mem.sliceTo(r, 0),
         );
         errdefer allocator.free(url_owned);
         const sha_owned: ?[]const u8 = if (stmt.columnText(3)) |s| blk: {
@@ -275,65 +263,10 @@ pub fn resolveFormula(allocator: std.mem.Allocator, user: []const u8, repo: []co
     return std.fmt.allocPrint(allocator, "{s}/{s}/{s}", .{ user, repo, formula });
 }
 
-/// URLs every tap fetch site needs, derived from a `(github_owner,
-/// github_repo)` pair so the prefix decision lives in the row (or in
-/// the `effectiveOwnerRepo` cold-path fallback), never in the URL
-/// template. For raw fetches callers append `/<sha>/Formula/<name>.rb`
-/// (or `Casks/`) to `raw_base`.
-pub const TapBaseUrls = struct {
-    /// `https://api.github.com/repos/<owner>/<repo>/commits/HEAD`
-    api_head_url: []const u8,
-    /// `https://github.com/<owner>/<repo>` — the URL that actually
-    /// resolves; mirrored into `taps.url` at INSERT/rebind time.
-    repo_url: []const u8,
-    /// `https://raw.githubusercontent.com/<owner>/<repo>` — caller
-    /// appends `/<sha>/Formula/<name>.rb` or `/<sha>/Casks/<name>.rb`.
-    raw_base: []const u8,
-
-    pub fn deinit(self: TapBaseUrls, allocator: std.mem.Allocator) void {
-        allocator.free(self.api_head_url);
-        allocator.free(self.repo_url);
-        allocator.free(self.raw_base);
-    }
-};
-
-/// Build the URL triple from an explicit `(owner, repo)` pair. Single
-/// site where the GitHub URL shape lives; both the row-read path and
-/// the cold registration path (`mt tap --repo X/Y`, default derivation
-/// before the row exists) route through here. Adding a non-GitHub host
-/// later is a switch on the host column at this seam.
-pub fn buildTapBaseUrls(
-    allocator: std.mem.Allocator,
-    owner: []const u8,
-    repo: []const u8,
-) std.mem.Allocator.Error!TapBaseUrls {
-    const api_head_url = try std.fmt.allocPrint(
-        allocator,
-        "https://api.github.com/repos/{s}/{s}/commits/HEAD",
-        .{ owner, repo },
-    );
-    errdefer allocator.free(api_head_url);
-
-    const repo_url = try std.fmt.allocPrint(
-        allocator,
-        "https://github.com/{s}/{s}",
-        .{ owner, repo },
-    );
-    errdefer allocator.free(repo_url);
-
-    const raw_base = try std.fmt.allocPrint(
-        allocator,
-        "https://raw.githubusercontent.com/{s}/{s}",
-        .{ owner, repo },
-    );
-    errdefer allocator.free(raw_base);
-
-    return .{
-        .api_head_url = api_head_url,
-        .repo_url = repo_url,
-        .raw_base = raw_base,
-    };
-}
+/// The URL triple every tap fetch site needs. Re-exported from the
+/// forge seam, which owns the host-shaped layout; `tap` keeps the
+/// row/SQLite logic that decides the `(owner, repo)` fed into it.
+pub const TapBaseUrls = forge.TapBaseUrls;
 
 /// Owner+repo pair read off a tap row. Caller owns both slices.
 pub const TapPair = struct {
@@ -403,7 +336,7 @@ pub fn resolveTapBaseUrls(
 ) !TapBaseUrls {
     const pair = try effectiveOwnerRepo(allocator, db, slug);
     defer pair.deinit(allocator);
-    return buildTapBaseUrls(allocator, pair.owner, pair.repo);
+    return forge.buildBaseUrls(allocator, .github, "github.com", pair.owner, pair.repo);
 }
 
 // ── resolveFromConditional: response → HeadResolution conversion ────
@@ -809,27 +742,6 @@ pub fn validateCommitSha(sha: []const u8) TapError!void {
     };
 }
 
-/// Pull the first top-level `"sha"` field out of a GitHub commits/HEAD
-/// response. Exposed for unit tests; production code reaches it via
-/// `resolveHeadCommit`.
-///
-/// Takes only the first match because GitHub's response always has
-/// the commit SHA before the nested tree/parent objects. The result
-/// is validated as a 40-char lowercase hex string — malformed or
-/// unexpected shapes return null rather than misleading SHAs.
-pub fn parseCommitShaFromJson(body: []const u8) ?[]const u8 {
-    const marker = "\"sha\"";
-    const idx = std.mem.indexOf(u8, body, marker) orelse return null;
-    var cur = idx + marker.len;
-    while (cur < body.len and (body[cur] == ' ' or body[cur] == ':' or body[cur] == '\t')) : (cur += 1) {}
-    if (cur >= body.len or body[cur] != '"') return null;
-    cur += 1;
-    const end = std.mem.indexOfScalarPos(u8, body, cur, '"') orelse return null;
-    const sha = body[cur..end];
-    validateCommitSha(sha) catch return null;
-    return sha;
-}
-
 /// HEAD-resolve outcome. `sha` is set on a fresh body (200) and null
 /// on 304 — the caller's cached sha is still authoritative in that
 /// case. `etag`, when set, is GitHub's current ETag for `/commits/HEAD`;
@@ -873,7 +785,7 @@ pub fn resolveFromConditional(
 
     if (resp.status != 200) return classifyResolveStatus(resp.status);
 
-    const sha = parseCommitShaFromJson(resp.body) orelse return TapError.MalformedJson;
+    const sha = forge.parseHeadSha(.github, resp.body) orelse return TapError.MalformedJson;
     const sha_owned = allocator.dupe(u8, sha) catch return TapError.OutOfMemory;
     errdefer allocator.free(sha_owned);
 
@@ -914,7 +826,7 @@ pub fn resolveHeadCommit(
     // — both authenticate against the same 5000/hr quota that 304s don't
     // touch.
     var auth_buf: [256]u8 = undefined;
-    var resp = if (githubAuthHeader(environ, &auth_buf)) |header| blk: {
+    var resp = if (forge.authHeader(.github, environ, &auth_buf)) |header| blk: {
         const headers = [_]std.http.Header{header};
         break :blk http.getConditional(api_head_url, cached_etag, &headers) catch return TapError.NetworkError;
     } else http.getConditional(api_head_url, cached_etag, &.{}) catch return TapError.NetworkError;

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -56,6 +56,7 @@ pub const child = @import("core/child.zig");
 pub const deps = @import("core/deps.zig");
 pub const dsl = @import("core/dsl/root.zig");
 pub const formula = @import("core/formula.zig");
+pub const forge = @import("core/forge.zig");
 pub const hash = @import("core/hash.zig");
 pub const install_receipt = @import("core/install_receipt.zig");
 pub const linker = @import("core/linker.zig");

--- a/tests/forge_purity_test.zig
+++ b/tests/forge_purity_test.zig
@@ -1,0 +1,63 @@
+//! Pin test: `src/core/forge.zig` is a pure leaf — it imports neither
+//! `cli/*` nor `ui/*`. The forge seam exists so a new host is one enum
+//! arm; letting it reach into the CLI or render layer would re-couple
+//! the very concerns it was extracted to isolate. Mirrors
+//! `tests/no_io_mod_in_src_test.zig`.
+
+const std = @import("std");
+const testing = std.testing;
+const test_io = @import("test_io");
+
+const forge_path = "src/core/forge.zig";
+const import_prefix = "@import(\"";
+
+test "core/forge.zig imports neither cli/* nor ui/*" {
+    const io = std.Options.debug_io;
+
+    var dir = try test_io.cwd().openDir(io, "src/core", .{});
+    defer dir.close(io);
+
+    const file = try dir.openFile(io, "forge.zig", .{});
+    defer file.close(io);
+    const stat = try file.stat(io);
+    const content = try testing.allocator.alloc(u8, @intCast(stat.size));
+    defer testing.allocator.free(content);
+    _ = try file.readPositionalAll(io, content, 0);
+
+    var failures: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (failures.items) |s| testing.allocator.free(s);
+        failures.deinit(testing.allocator);
+    }
+
+    var cursor: usize = 0;
+    while (std.mem.indexOfPos(u8, content, cursor, import_prefix)) |start| {
+        const path_start = start + import_prefix.len;
+        const end = std.mem.indexOfScalarPos(u8, content, path_start, '"') orelse break;
+        const import_path = content[path_start..end];
+        cursor = end + 1;
+
+        if (crossesInto(import_path, "cli") or crossesInto(import_path, "ui")) {
+            const msg = try std.fmt.allocPrint(
+                testing.allocator,
+                "{s} imports {s}",
+                .{ forge_path, import_path },
+            );
+            try failures.append(testing.allocator, msg);
+        }
+    }
+
+    if (failures.items.len != 0) {
+        for (failures.items) |f| std.debug.print("{s}\n", .{f});
+        return error.ForgeIsNotALeaf;
+    }
+}
+
+/// True when a relative `@import` path resolves into `<layer>/` after
+/// stripping leading `../` segments.
+fn crossesInto(path: []const u8, comptime layer: []const u8) bool {
+    var rest = path;
+    while (std.mem.startsWith(u8, rest, "../")) rest = rest[3..];
+    return std.mem.startsWith(u8, rest, layer ++ "/") or
+        std.mem.eql(u8, rest, layer ++ ".zig");
+}

--- a/tests/tap_test.zig
+++ b/tests/tap_test.zig
@@ -461,81 +461,9 @@ test "resolveFormula joins user/repo/formula with slashes" {
     try testing.expectEqualStrings("u/r/f", s);
 }
 
-// ────────────────────────────────────────────────────────────────────
-// parseCommitShaFromJson — security-sensitive: picking up the wrong
-// "sha" field would pin malt to an attacker-influenced commit instead
-// of the real HEAD. Exhaustive coverage of shapes a real GitHub
-// `commits/HEAD` response can take.
-// ────────────────────────────────────────────────────────────────────
-
-test "parseCommitShaFromJson: canonical GitHub response" {
-    const body =
-        \\{"sha":"0123456789abcdef0123456789abcdef01234567","node_id":"X","commit":{"author":{"name":"x"}}}
-    ;
-    const got = tap.parseCommitShaFromJson(body) orelse return error.TestUnexpectedResult;
-    try testing.expectEqualStrings(valid_sha, got);
-}
-
-test "parseCommitShaFromJson: tolerates whitespace around ':' and value" {
-    const body =
-        \\{  "sha"  :  "0123456789abcdef0123456789abcdef01234567" , "other": 1 }
-    ;
-    const got = tap.parseCommitShaFromJson(body) orelse return error.TestUnexpectedResult;
-    try testing.expectEqualStrings(valid_sha, got);
-}
-
-test "parseCommitShaFromJson: returns first top-level sha even when nested sha exists" {
-    // Real responses have `commit.tree.sha` as a separate field —
-    // the parser's first-match behaviour is the whole point: the
-    // top-level commit SHA appears first.
-    const body =
-        \\{"sha":"0123456789abcdef0123456789abcdef01234567","commit":{"tree":{"sha":"ffffffffffffffffffffffffffffffffffffffff"}}}
-    ;
-    const got = tap.parseCommitShaFromJson(body) orelse return error.TestUnexpectedResult;
-    try testing.expectEqualStrings(valid_sha, got);
-}
-
-test "parseCommitShaFromJson: missing sha field yields null" {
-    const body =
-        \\{"node_id":"X","commit":{"author":{"name":"x"}}}
-    ;
-    try testing.expectEqual(@as(?[]const u8, null), tap.parseCommitShaFromJson(body));
-}
-
-test "parseCommitShaFromJson: non-string value yields null" {
-    // Defense: if upstream ever returned a number or null for sha we'd
-    // rather refuse than misparse.
-    const body =
-        \\{"sha": 42}
-    ;
-    try testing.expectEqual(@as(?[]const u8, null), tap.parseCommitShaFromJson(body));
-}
-
-test "parseCommitShaFromJson: truncated value yields null" {
-    const body =
-        \\{"sha":"deadbeef
-    ;
-    try testing.expectEqual(@as(?[]const u8, null), tap.parseCommitShaFromJson(body));
-}
-
-test "parseCommitShaFromJson: malformed SHA value yields null" {
-    // Right structural shape, wrong content — validator rejects.
-    const body =
-        \\{"sha":"not-a-valid-sha"}
-    ;
-    try testing.expectEqual(@as(?[]const u8, null), tap.parseCommitShaFromJson(body));
-}
-
-test "parseCommitShaFromJson: empty body yields null" {
-    try testing.expectEqual(@as(?[]const u8, null), tap.parseCommitShaFromJson(""));
-}
-
-test "parseCommitShaFromJson: uppercase hex in value is rejected" {
-    const body =
-        \\{"sha":"0123456789ABCDEF0123456789ABCDEF01234567"}
-    ;
-    try testing.expectEqual(@as(?[]const u8, null), tap.parseCommitShaFromJson(body));
-}
+// parseHeadSha and githubAuthHeader moved to the forge seam in the
+// extraction; their exhaustive coverage now lives as inline tests in
+// `src/core/forge.zig` (`parseHeadSha github: …`, `authHeader github: …`).
 
 // ────────────────────────────────────────────────────────────────────
 // classifyResolveStatus — callers rely on distinct tags to map each
@@ -560,40 +488,6 @@ test "classifyResolveStatus: unexpected 5xx falls back to ResolveFailed" {
 
 test "classifyResolveStatus: 401 (bad auth) is distinct from rate limit" {
     try testing.expectEqual(tap.TapError.ResolveFailed, tap.classifyResolveStatus(401));
-}
-
-// ────────────────────────────────────────────────────────────────────
-// githubAuthHeader — only the `/commits/HEAD` call picks up
-// MALT_GITHUB_TOKEN; everything else keeps the existing HOMEBREW token
-// plumbing. Bearer header format must match GitHub's contract.
-// ────────────────────────────────────────────────────────────────────
-
-const c_env = struct {
-    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
-    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
-};
-
-test "githubAuthHeader: returns null when MALT_GITHUB_TOKEN unset" {
-    _ = c_env.unsetenv("MALT_GITHUB_TOKEN");
-    var buf: [256]u8 = undefined;
-    try testing.expect(tap.githubAuthHeader(malt.app_ctx.processEnviron(), &buf) == null);
-}
-
-test "githubAuthHeader: returns Bearer header when MALT_GITHUB_TOKEN set" {
-    _ = c_env.setenv("MALT_GITHUB_TOKEN", "ghp_testtoken", 1);
-    defer _ = c_env.unsetenv("MALT_GITHUB_TOKEN");
-
-    var buf: [256]u8 = undefined;
-    const h = tap.githubAuthHeader(malt.app_ctx.processEnviron(), &buf) orelse return error.TestUnexpectedNull;
-    try testing.expectEqualStrings("Authorization", h.name);
-    try testing.expectEqualStrings("Bearer ghp_testtoken", h.value);
-}
-
-test "githubAuthHeader: empty-string token behaves as unset" {
-    _ = c_env.setenv("MALT_GITHUB_TOKEN", "", 1);
-    defer _ = c_env.unsetenv("MALT_GITHUB_TOKEN");
-    var buf: [256]u8 = undefined;
-    try testing.expect(tap.githubAuthHeader(malt.app_ctx.processEnviron(), &buf) == null);
 }
 
 // ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Introduces `core/forge.zig`, a pure leaf that owns every host-shaped tap decision: the api-head / repo / raw-base URL triple, the raw-`.rb` tail, the HEAD-commit sha parse, and the auth header.

This unblocks adding other providers (e.g. GitLab, Codeberg) as enum arms rather than edits scattered across every call site.

## Related Issue

- None

## Notes for Reviewers

- None