### PR TITLE
feat(db,core/tap): persist the forge host for each tap

### DIFF
--- a/scripts/regressions/tap_v11_schema_migration.sh
+++ b/scripts/regressions/tap_v11_schema_migration.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# End-to-end check that the v10→v11 migration runs cleanly when triggered
+# by the actual `mt` binary, and that the new `host` column backfills to
+# `github.com` for every pre-v11 row.
+#
+# Pinned behaviour:
+#   1. A v10-shaped DB (taps with name/url/commit_sha/head_etag/
+#      github_owner/github_repo but *without* host) upgrades to v11 on
+#      first `mt` open. Existing rows backfill to host='github.com'.
+#   2. A row carrying a non-github host survives unchanged, and the
+#      `taps.url` projection in `mt --json tap` stays github-shaped (the
+#      host is read, but the forge arms that change the URL land later).
+#
+# Methodology: build a v11 DB against the current binary's initSchema,
+# rewind the taps table to the v10 shape and the schema_version marker to
+# 10, then re-run `mt tap` (which calls initSchema → migrate). No network.
+#
+# Requirements: a built malt binary at zig-out/bin/malt; sqlite3 CLI; jq.
+#
+# Usage: scripts/regressions/tap_v11_schema_migration.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MT="$ROOT/zig-out/bin/malt"
+if [[ ! -x "$MT" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MT" >&2
+  exit 1
+fi
+command -v sqlite3 >/dev/null || {
+  printf 'SKIP: sqlite3 CLI required.\n' >&2
+  exit 0
+}
+command -v jq >/dev/null || {
+  printf 'SKIP: jq required.\n' >&2
+  exit 0
+}
+
+PREFIX=$(mktemp -d -t mt_v11_XXXXXX)
+trap 'rm -rf "$PREFIX"' EXIT
+mkdir -p "$PREFIX/db"
+DB="$PREFIX/db/malt.db"
+
+export MALT_PREFIX="$PREFIX"
+
+# Step 1: bootstrap the DB at the current schema (>=v11).
+"$MT" tap >/dev/null 2>&1 || true
+[[ -f "$DB" ]] || {
+  printf 'FAIL: mt did not create %s\n' "$DB" >&2
+  exit 1
+}
+
+ver=$(sqlite3 "$DB" "SELECT MAX(version) FROM schema_version;")
+[[ "$ver" -ge 11 ]] || {
+  printf 'FAIL: fresh DB at v%s, expected at least v11.\n' "$ver" >&2
+  exit 1
+}
+
+# Rewind the taps table to the v10 shape (drop host) and the marker to 10
+# so the next `mt` invocation re-runs v10→v11.
+sqlite3 "$DB" <<'SQL'
+BEGIN;
+DELETE FROM schema_version WHERE version >= 11;
+CREATE TABLE taps_v10 (
+    id            INTEGER PRIMARY KEY,
+    name          TEXT NOT NULL UNIQUE,
+    url           TEXT NOT NULL,
+    added_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    commit_sha    TEXT,
+    head_etag     TEXT,
+    github_owner  TEXT NOT NULL DEFAULT '',
+    github_repo   TEXT NOT NULL DEFAULT ''
+);
+INSERT INTO taps_v10 (id, name, url, added_at, commit_sha, head_etag, github_owner, github_repo)
+SELECT id, name, url, added_at, commit_sha, head_etag, github_owner, github_repo FROM taps;
+DROP TABLE taps;
+ALTER TABLE taps_v10 RENAME TO taps;
+INSERT INTO taps (name, url, commit_sha, github_owner, github_repo) VALUES
+  ('aeroxy/tap', 'https://github.com/aeroxy/homebrew-tap', '0123456789abcdef0123456789abcdef01234567', 'aeroxy', 'homebrew-tap'),
+  ('user/repo',  'https://github.com/user/homebrew-repo',  NULL, 'user', 'homebrew-repo');
+COMMIT;
+SQL
+
+ver_after=$(sqlite3 "$DB" "SELECT MAX(version) FROM schema_version;")
+[[ "$ver_after" == "10" ]] || {
+  printf 'FAIL: rewind did not land at v10 (got %s).\n' "$ver_after" >&2
+  exit 1
+}
+
+# Step 2: run `mt tap` so initSchema → migrate triggers v10→v11.
+"$MT" tap >/dev/null 2>&1 || true
+
+# Step 3: assert the migration landed at v11 (or newer) with host backfilled.
+ver_post=$(sqlite3 "$DB" "SELECT MAX(version) FROM schema_version;")
+[[ "$ver_post" -ge 11 ]] || {
+  printf 'FAIL: migration did not bump to at least v11 (got %s).\n' "$ver_post" >&2
+  exit 1
+}
+printf '  ✓ schema_version reached at least v11 (got %s)\n' "$ver_post"
+
+host1=$(sqlite3 "$DB" "SELECT host FROM taps WHERE name='aeroxy/tap';")
+[[ "$host1" == "github.com" ]] || {
+  printf 'FAIL: aeroxy/tap host = %s, expected github.com.\n' "$host1" >&2
+  exit 1
+}
+host2=$(sqlite3 "$DB" "SELECT host FROM taps WHERE name='user/repo';")
+[[ "$host2" == "github.com" ]] || {
+  printf 'FAIL: user/repo host = %s, expected github.com.\n' "$host2" >&2
+  exit 1
+}
+printf '  ✓ existing rows backfilled to host=github.com\n'
+
+# Step 4: a non-github host persists and is read, but the URL projection
+# stays github-shaped until the forge arms land.
+sqlite3 "$DB" "INSERT INTO taps (name, url, commit_sha, github_owner, github_repo, host) VALUES ('grp/tap', 'https://gitlab.com/grp/tap', NULL, 'grp', 'tap', 'gitlab.com');"
+
+host3=$(sqlite3 "$DB" "SELECT host FROM taps WHERE name='grp/tap';")
+[[ "$host3" == "gitlab.com" ]] || {
+  printf 'FAIL: grp/tap host = %s, expected gitlab.com.\n' "$host3" >&2
+  exit 1
+}
+
+json=$("$MT" --json tap 2>/dev/null)
+projected=$(printf '%s' "$json" | jq -r '.[] | select(.name=="grp/tap") | .url')
+[[ "$projected" == "https://github.com/grp/tap" ]] || {
+  printf 'FAIL: grp/tap URL projection = %s, expected github-shaped URL.\n' "$projected" >&2
+  exit 1
+}
+printf '  ✓ non-github host stored and read; URL projection still github-shaped\n'
+
+# Step 5: rerun migration on the now-v11 DB — must be a no-op.
+"$MT" tap >/dev/null 2>&1 || true
+host1_post=$(sqlite3 "$DB" "SELECT host FROM taps WHERE name='aeroxy/tap';")
+[[ "$host1_post" == "github.com" ]] || {
+  printf 'FAIL: idempotent rerun mutated the row host (%s).\n' "$host1_post" >&2
+  exit 1
+}
+printf '  ✓ migration is idempotent on an already-v11 DB\n'
+
+printf '\n✔ tap v10→v11 schema migration regression passed\n'

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -1152,7 +1152,8 @@ test "finalizeTapCaskInstall stamps the owning tap when tap_registration is set"
         \\    commit_sha TEXT,
         \\    head_etag TEXT,
         \\    github_owner TEXT NOT NULL DEFAULT '',
-        \\    github_repo TEXT NOT NULL DEFAULT ''
+        \\    github_repo TEXT NOT NULL DEFAULT '',
+        \\    host TEXT NOT NULL DEFAULT 'github.com'
         \\);
     );
 

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -28,7 +28,11 @@ pub fn parseRepoOverride(allocator: std.mem.Allocator, raw: []const u8) RepoOver
     const owner_owned = try allocator.dupe(u8, owner);
     errdefer allocator.free(owner_owned);
     const repo_owned = try allocator.dupe(u8, repo);
-    return .{ .owner = owner_owned, .repo = repo_owned };
+    errdefer allocator.free(repo_owned);
+    // `--repo` is a GitHub-only override today; a chosen host will be
+    // threaded through here later. Default keeps the pair self-consistent.
+    const host_owned = try allocator.dupe(u8, "github.com");
+    return .{ .owner = owner_owned, .repo = repo_owned, .host = host_owned };
 }
 
 test "parseRepoOverride accepts user/repo and returns the owned pair" {

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -215,22 +215,25 @@ pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) ![]TapInfo {
         taps.deinit(allocator);
     }
 
-    // Project `url` from (github_owner, github_repo) so the listing
+    // Project `url` from (github_owner, github_repo, host) so the listing
     // can't disagree with the actual fetch target.
-    var stmt = try db.prepare("SELECT name, github_owner, github_repo, commit_sha FROM taps;");
+    var stmt = try db.prepare("SELECT name, github_owner, github_repo, commit_sha, host FROM taps;");
     defer stmt.finalize();
 
     while (try stmt.step()) {
         const n = stmt.columnText(0) orelse continue;
         const o = stmt.columnText(1) orelse continue;
         const r = stmt.columnText(2) orelse continue;
+        // host is NOT NULL DEFAULT 'github.com'; the orelse only guards
+        // the impossible NULL so the row still projects.
+        const host = std.mem.sliceTo(stmt.columnText(4) orelse "github.com", 0);
 
         const name_owned = try allocator.dupe(u8, std.mem.sliceTo(n, 0));
         errdefer allocator.free(name_owned);
         const url_owned = try forge.allocRepoBrowseUrl(
             allocator,
-            .github,
-            "github.com",
+            forge.fromHost(host),
+            host,
             std.mem.sliceTo(o, 0),
             std.mem.sliceTo(r, 0),
         );
@@ -268,14 +271,18 @@ pub fn resolveFormula(allocator: std.mem.Allocator, user: []const u8, repo: []co
 /// row/SQLite logic that decides the `(owner, repo)` fed into it.
 pub const TapBaseUrls = forge.TapBaseUrls;
 
-/// Owner+repo pair read off a tap row. Caller owns both slices.
+/// Owner+repo+host read off a tap row. `host` feeds `forge.fromHost`
+/// so resolution targets the forge the row was registered on. Caller
+/// owns all three slices.
 pub const TapPair = struct {
     owner: []const u8,
     repo: []const u8,
+    host: []const u8,
 
     pub fn deinit(self: TapPair, allocator: std.mem.Allocator) void {
         allocator.free(self.owner);
         allocator.free(self.repo);
+        allocator.free(self.host);
     }
 };
 
@@ -287,13 +294,16 @@ pub fn getOwnerRepo(
     slug: []const u8,
 ) !?TapPair {
     var stmt = try db.prepare(
-        "SELECT github_owner, github_repo FROM taps WHERE name = ?1;",
+        "SELECT github_owner, github_repo, host FROM taps WHERE name = ?1;",
     );
     defer stmt.finalize();
     try stmt.bindText(1, slug);
     if (!(try stmt.step())) return null;
     const owner_raw = stmt.columnText(0) orelse return null;
     const repo_raw = stmt.columnText(1) orelse return null;
+    // host is NOT NULL DEFAULT 'github.com'; the orelse only guards the
+    // impossible NULL so a forge is never lost on read.
+    const host_trim = std.mem.sliceTo(stmt.columnText(2) orelse "github.com", 0);
     const owner_trim = std.mem.sliceTo(owner_raw, 0);
     const repo_trim = std.mem.sliceTo(repo_raw, 0);
     if (owner_trim.len == 0 or repo_trim.len == 0) return null;
@@ -301,7 +311,9 @@ pub fn getOwnerRepo(
     const owner_owned = try allocator.dupe(u8, owner_trim);
     errdefer allocator.free(owner_owned);
     const repo_owned = try allocator.dupe(u8, repo_trim);
-    return .{ .owner = owner_owned, .repo = repo_owned };
+    errdefer allocator.free(repo_owned);
+    const host_owned = try allocator.dupe(u8, host_trim);
+    return .{ .owner = owner_owned, .repo = repo_owned, .host = host_owned };
 }
 
 /// Single point where the slug-derived default `(user, "homebrew-" || repo)`
@@ -321,7 +333,11 @@ pub fn effectiveOwnerRepo(
     const owner_owned = try allocator.dupe(u8, user);
     errdefer allocator.free(owner_owned);
     const repo_owned = try std.fmt.allocPrint(allocator, "homebrew-{s}", .{repo_part});
-    return .{ .owner = owner_owned, .repo = repo_owned };
+    errdefer allocator.free(repo_owned);
+    // Cold path predates any stored row; the homebrew-<repo> synthesis is
+    // GitHub-only, so the synthesised pair is github.com by construction.
+    const host_owned = try allocator.dupe(u8, "github.com");
+    return .{ .owner = owner_owned, .repo = repo_owned, .host = host_owned };
 }
 
 /// Build every URL needed to talk to a tap repo. Reads the row's
@@ -336,7 +352,9 @@ pub fn resolveTapBaseUrls(
 ) !TapBaseUrls {
     const pair = try effectiveOwnerRepo(allocator, db, slug);
     defer pair.deinit(allocator);
-    return forge.buildBaseUrls(allocator, .github, "github.com", pair.owner, pair.repo);
+    // The row's host selects the forge; github.com rows resolve exactly
+    // as before since `fromHost` maps everything to `.github` today.
+    return forge.buildBaseUrls(allocator, forge.fromHost(pair.host), pair.host, pair.owner, pair.repo);
 }
 
 // ── resolveFromConditional: response → HeadResolution conversion ────
@@ -647,6 +665,74 @@ test "resolveTapBaseUrls reads the stored prefixed pair byte-for-byte" {
         "https://api.github.com/repos/user-1/homebrew-some.v2/commits/HEAD",
         urls.api_head_url,
     );
+}
+
+test "getOwnerRepo reads the row's host, defaulting to github.com" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try add(&db, "user/repo", "user", "homebrew-repo", null);
+
+    const pair = (try getOwnerRepo(std.testing.allocator, &db, "user/repo")).?;
+    defer pair.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("github.com", pair.host);
+}
+
+test "getOwnerRepo reads a non-default host written to the row" {
+    // Until the host-registration UX lands, a non-github host can only
+    // reach the row via a direct write — exercise the read path now so
+    // the persisted host is provably surfaced ahead of the forge arms.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo, host)
+        \\VALUES ('grp/tap', 'https://gitlab.com/grp/tap', NULL, 'grp', 'tap', 'gitlab.com');
+    );
+
+    const pair = (try getOwnerRepo(std.testing.allocator, &db, "grp/tap")).?;
+    defer pair.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("gitlab.com", pair.host);
+    try std.testing.expectEqualStrings("grp", pair.owner);
+    try std.testing.expectEqualStrings("tap", pair.repo);
+}
+
+test "effectiveOwnerRepo cold path defaults host to github.com" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+
+    const pair = try effectiveOwnerRepo(std.testing.allocator, &db, "aeroxy/tap");
+    defer pair.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("github.com", pair.host);
+    try std.testing.expectEqualStrings("aeroxy", pair.owner);
+    try std.testing.expectEqualStrings("homebrew-tap", pair.repo);
+}
+
+test "resolveTapBaseUrls routes the row's host through the forge seam" {
+    // The host is read and handed to `forge.fromHost`. Until the GitLab
+    // arm lands, `fromHost` maps every host to `.github`, so the URLs
+    // stay github-shaped — proving the host is *read*, not that the
+    // output changed. The owner/repo come through verbatim (no synthesis).
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo, host)
+        \\VALUES ('grp/tap', 'https://gitlab.com/grp/tap', NULL, 'grp', 'tap', 'gitlab.com');
+    );
+
+    const urls = try resolveTapBaseUrls(std.testing.allocator, &db, "grp/tap");
+    defer urls.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings(
+        "https://api.github.com/repos/grp/tap/commits/HEAD",
+        urls.api_head_url,
+    );
+    try std.testing.expectEqualStrings("https://github.com/grp/tap", urls.repo_url);
 }
 
 /// Build the `commits/<sha>` URL sibling of `api_head_url`. Routes

--- a/src/db/schema.zig
+++ b/src/db/schema.zig
@@ -126,7 +126,7 @@ pub fn initSchema(db: *sqlite.Database) MigrateError!void {
 /// Highest schema version this binary knows how to operate on. Bump in
 /// lockstep with the last `migrateVNtoVN+1` step so a future binary's
 /// DB doesn't get silently used against older SQL.
-pub const known_schema_version: i64 = 10;
+pub const known_schema_version: i64 = 11;
 
 pub const MigrateError = sqlite.SqliteError || error{SchemaTooNew};
 
@@ -146,6 +146,7 @@ pub fn migrate(db: *sqlite.Database) MigrateError!void {
     if (ver < 8) try migrateV7toV8(db);
     if (ver < 9) try migrateV8toV9(db);
     if (ver < 10) try migrateV9toV10(db);
+    if (ver < 11) try migrateV10toV11(db);
 }
 
 fn migrateV1toV2(db: *sqlite.Database) sqlite.SqliteError!void {
@@ -566,6 +567,44 @@ fn migrateV9toV10(db: *sqlite.Database) sqlite.SqliteError!void {
     try db.commit();
 }
 
+/// v11 — record which forge hosts each tap so resolution can pick the
+/// right provider per row instead of always synthesising GitHub URLs.
+/// DEFAULT 'github.com' (the full host, usable directly as the `host`
+/// argument to `forge.buildBaseUrls`) keeps every pre-feature row
+/// resolving against GitHub byte-for-byte. Same PRAGMA-guarded shape as
+/// v7→v8 / v8→v9 / v9→v10 so re-runs against partial fixtures stay
+/// idempotent.
+fn migrateV10toV11(db: *sqlite.Database) sqlite.SqliteError!void {
+    try db.beginTransaction();
+    errdefer db.rollback();
+
+    // PRAGMA table_info returns zero rows when the table is missing —
+    // same partial-shape fixture defensiveness as v7→v8 onward.
+    var have_table = false;
+    var have_column = false;
+    {
+        var stmt = try db.prepare("PRAGMA table_info(taps);");
+        defer stmt.finalize();
+        while (try stmt.step()) {
+            have_table = true;
+            const name = stmt.columnText(1) orelse continue;
+            if (std.mem.eql(u8, std.mem.sliceTo(name, 0), "host")) {
+                have_column = true;
+                break;
+            }
+        }
+    }
+    if (have_table and !have_column) {
+        try db.exec(
+            "ALTER TABLE taps ADD COLUMN host TEXT NOT NULL DEFAULT 'github.com';",
+        );
+    }
+
+    try db.exec("INSERT OR IGNORE INTO schema_version (version) VALUES (11);");
+
+    try db.commit();
+}
+
 /// Return true iff every column in `wanted` is present on the `casks`
 /// table. Mirrors the PRAGMA-guarded probes used by v2→v3 / v3→v4 /
 /// v5→v6; centralised here because the v6→v7 backfill needs five
@@ -759,7 +798,7 @@ test "v6→v7 migration backfills cask_versions from existing casks rows" {
     const token1 = stmt.columnText(0) orelse return error.TestUnexpectedResult;
     try testing.expectEqualStrings("flux-markdown", std.mem.sliceTo(token1, 0));
 
-    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 11), try currentVersion(&db));
 }
 
 test "v6→v7 migration is idempotent when cask_versions already carries the rows" {
@@ -808,7 +847,7 @@ test "fresh DB ships with taps.head_etag (v8 shape)" {
         }
     }
     try testing.expect(found);
-    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 11), try currentVersion(&db));
 }
 
 test "v7→v8 migration adds head_etag and preserves existing tap rows" {
@@ -839,7 +878,7 @@ test "v7→v8 migration adds head_etag and preserves existing tap rows" {
     );
     // Pre-v8 rows must carry NULL until a conditional GET populates it.
     try testing.expect(probe.columnText(1) == null);
-    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 11), try currentVersion(&db));
 }
 
 test "v7→v8 migration is idempotent when head_etag is already present" {
@@ -888,7 +927,7 @@ test "fresh DB ships with taps.github_owner and taps.github_repo (v9 shape)" {
     }
     try testing.expect(owner_seen);
     try testing.expect(repo_seen);
-    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 11), try currentVersion(&db));
 }
 
 test "v8→v9 migration backfills (user, \"homebrew-\" || repo) from existing slugs" {
@@ -908,7 +947,7 @@ test "v8→v9 migration backfills (user, \"homebrew-\" || repo) from existing sl
 
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 11), try currentVersion(&db));
 
     var probe = try db.prepare(
         "SELECT name, github_owner, github_repo FROM taps ORDER BY name;",
@@ -970,7 +1009,7 @@ test "v8→v9 migration bumps the marker even when taps is empty" {
     try db.exec("DELETE FROM schema_version WHERE version >= 9;");
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 11), try currentVersion(&db));
 }
 
 // Pre-v3 rows could in theory have escaped slug validation. The CASE
@@ -997,7 +1036,7 @@ test "v8→v9 migration tolerates a slug starting with a slash (degenerate fixtu
 
     // We don't pin the specific (owner, repo) values for degenerate
     // input — only that the migration completes and the marker bumps.
-    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 11), try currentVersion(&db));
 }
 
 test "v8→v9 migration falls back to verbatim name on a slug missing the slash" {
@@ -1042,7 +1081,7 @@ test "fresh DB ships with kegs.bin_isolated (v10 shape)" {
         }
     }
     try testing.expect(found);
-    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 11), try currentVersion(&db));
 }
 
 test "v9→v10 migration adds bin_isolated and defaults existing rows to 0" {
@@ -1061,7 +1100,7 @@ test "v9→v10 migration adds bin_isolated and defaults existing rows to 0" {
 
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 10), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 11), try currentVersion(&db));
 
     var probe = try db.prepare("SELECT name, bin_isolated FROM kegs ORDER BY name;");
     defer probe.finalize();
@@ -1100,6 +1139,101 @@ test "v9→v10 migration is idempotent and preserves bin_isolated=1" {
     defer probe.finalize();
     try testing.expect(try probe.step());
     try testing.expectEqual(@as(i64, 1), probe.columnInt(0));
+}
+
+// v10→v11 adds taps.host so a tap row remembers which forge hosts it
+// (github.com today; GitLab/Codeberg arrive as forge arms later). The
+// DEFAULT keeps every pre-feature row resolving against GitHub exactly
+// as before. Fresh and upgraded DBs must converge on the same shape.
+
+test "fresh DB ships with taps.host defaulting to github.com (v11 shape)" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    var stmt = try db.prepare("PRAGMA table_info(taps);");
+    defer stmt.finalize();
+    var found = false;
+    while (try stmt.step()) {
+        const name = stmt.columnText(1) orelse continue;
+        if (std.mem.eql(u8, std.mem.sliceTo(name, 0), "host")) {
+            found = true;
+            break;
+        }
+    }
+    try testing.expect(found);
+
+    // A row inserted without naming `host` takes the column DEFAULT —
+    // this is the path `tap.add` relies on to stamp github.com.
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo)
+        \\VALUES ('user/repo', 'https://github.com/user/homebrew-repo', NULL, 'user', 'homebrew-repo');
+    );
+    var probe = try db.prepare("SELECT host FROM taps WHERE name='user/repo';");
+    defer probe.finalize();
+    try testing.expect(try probe.step());
+    try testing.expectEqualStrings("github.com", std.mem.sliceTo(probe.columnText(0) orelse "", 0));
+
+    try testing.expectEqual(@as(i64, 11), try currentVersion(&db));
+}
+
+test "v10→v11 migration backfills host=github.com on existing tap rows" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    // Seed a tap on the current shape, then rewind the marker so migrate
+    // re-enters the v10→v11 step against a row that pre-dates the column.
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo)
+        \\VALUES ('aeroxy/tap', 'https://github.com/aeroxy/homebrew-tap', NULL, 'aeroxy', 'homebrew-tap');
+    );
+    try db.exec("DELETE FROM schema_version WHERE version >= 11;");
+
+    try migrate(&db);
+
+    try testing.expectEqual(@as(i64, 11), try currentVersion(&db));
+
+    var probe = try db.prepare("SELECT host FROM taps WHERE name='aeroxy/tap';");
+    defer probe.finalize();
+    try testing.expect(try probe.step());
+    try testing.expectEqualStrings("github.com", std.mem.sliceTo(probe.columnText(0) orelse "", 0));
+}
+
+// A row already carrying a non-default host must survive a re-run — the
+// PRAGMA guard skips the ALTER so the explicit value is never clobbered
+// back to github.com.
+test "v10→v11 migration is idempotent and preserves a non-default host" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo, host)
+        \\VALUES ('grp/tap', 'https://gitlab.com/grp/tap', NULL, 'grp', 'tap', 'gitlab.com');
+    );
+    try db.exec("DELETE FROM schema_version WHERE version >= 11;");
+    try migrate(&db);
+    try db.exec("DELETE FROM schema_version WHERE version >= 11;");
+    try migrate(&db);
+
+    var probe = try db.prepare("SELECT host FROM taps WHERE name='grp/tap';");
+    defer probe.finalize();
+    try testing.expect(try probe.step());
+    try testing.expectEqualStrings("gitlab.com", std.mem.sliceTo(probe.columnText(0) orelse "", 0));
+}
+
+// The empty-taps case is the most common upgrade shape: the ALTER must
+// add the column and the marker must still bump so a re-run skips it.
+test "v10→v11 migration bumps the marker even when taps is empty" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec("DELETE FROM schema_version WHERE version >= 11;");
+    try migrate(&db);
+
+    try testing.expectEqual(@as(i64, 11), try currentVersion(&db));
 }
 
 test "migrate refuses a DB whose schema_version exceeds the known max" {

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -1148,7 +1148,7 @@ test "v6→v7 migration leaves cask_versions empty when casks has a broken shape
     _ = try stmt.step();
     try testing.expectEqual(@as(i64, 0), stmt.columnInt(0));
     // Migration still bumps the schema marker so a future run skips this path.
-    try testing.expectEqual(@as(i64, 10), try schema.currentVersion(&db));
+    try testing.expectEqual(@as(i64, 11), try schema.currentVersion(&db));
 }
 
 // v7→v8 / v8→v9 ALTERs must skip when `taps` is missing entirely
@@ -1169,7 +1169,7 @@ test "v7→v8 migration tolerates a missing taps table" {
 
     try schema.migrate(&db);
 
-    try testing.expectEqual(@as(i64, 10), try schema.currentVersion(&db));
+    try testing.expectEqual(@as(i64, 11), try schema.currentVersion(&db));
 }
 
 // --- coverage: lookupCaskVersion refuses a malformed row ----------------

--- a/tests/db_schema_v2_test.zig
+++ b/tests/db_schema_v2_test.zig
@@ -54,7 +54,7 @@ test "initSchema runs v1 then migrates to the current known version" {
     try testing.expect(try tableExists(&tdb.db, "bundle_members"));
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 10), ver);
+    try testing.expectEqual(@as(i64, 11), ver);
 }
 
 test "migrate is idempotent on re-run" {
@@ -66,7 +66,7 @@ test "migrate is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 10), ver);
+    try testing.expectEqual(@as(i64, 11), ver);
 }
 
 test "v4 migration adds pinned column to casks" {
@@ -96,7 +96,7 @@ test "v4 migration is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 10), ver);
+    try testing.expectEqual(@as(i64, 11), ver);
 }
 
 test "v6 migration adds tap column to casks" {

--- a/tests/tap_test.zig
+++ b/tests/tap_test.zig
@@ -132,6 +132,43 @@ test "add persists the (github_owner, github_repo) pair passed at INSERT" {
     );
 }
 
+test "add stamps the default host github.com, read back via getOwnerRepo" {
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try tap.add(&db, "user/repo", "user", "homebrew-repo", null);
+
+    const pair = (try tap.getOwnerRepo(testing.allocator, &db, "user/repo")).?;
+    defer pair.deinit(testing.allocator);
+    try testing.expectEqualStrings("github.com", pair.host);
+}
+
+test "a non-github host round-trips through getOwnerRepo and list" {
+    // Persistence half of multi-forge support: the host is stored and
+    // read back. Resolution still produces github-shaped URLs because the
+    // non-github forge arms aren't here yet — assert the host is *read*,
+    // not that the URL changed.
+    var db = try openDb();
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo, host)
+        \\VALUES ('grp/tap', 'https://gitlab.com/grp/tap', NULL, 'grp', 'tap', 'gitlab.com');
+    );
+
+    const pair = (try tap.getOwnerRepo(testing.allocator, &db, "grp/tap")).?;
+    defer pair.deinit(testing.allocator);
+    try testing.expectEqualStrings("gitlab.com", pair.host);
+
+    const taps = try tap.list(testing.allocator, &db);
+    defer freeTaps(taps);
+    try testing.expectEqual(@as(usize, 1), taps.len);
+    try testing.expectEqualStrings("grp/tap", taps[0].name);
+    try testing.expectEqualStrings("https://github.com/grp/tap", taps[0].url);
+}
+
 test "rebind moves (owner, repo) and clears commit_sha and head_etag" {
     // Rebinding to a new repo invalidates the old pin — the new repo has
     // its own HEAD, and keeping the stale SHA would freeze the row at a


### PR DESCRIPTION
## Description

Adds a `host` column to the taps table (schema v11, default `github.com`) and threads it through tap resolution so each tap remembers which forge hosts it.
Existing taps migrate to `github.com` and resolve byte-identically - there is no
non-GitHub behaviour yet. This is the persistence half of multi-forge tap support.

The stored host now drives `forge.fromHost` + `forge.buildBaseUrls` at every
resolution site (`resolveTapBaseUrls`, `getOwnerRepo`, `effectiveOwnerRepo`, and
the `taps.url` projection in `list`), so when the forge arms land they switch on the row's host with no further plumbing.

## Related Issue

- None

## Notes for Reviewers

- None