### PR TITLE
feat(cli/tap): register taps on GitLab/Codeberg via --host

### DIFF
--- a/scripts/regressions/tap_register_host.sh
+++ b/scripts/regressions/tap_register_host.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Lock the non-GitHub tap registration contract end-to-end, no network.
+#
+# Pinned behaviour:
+#   1. `mt tap <slug> --host <host> --repo <o>/<r>` persists the row with
+#      the chosen host, no `homebrew-` synthesis, and unpinned (resolution
+#      for non-GitHub forges lands in a later release).
+#   2. `mt tap <slug> --url https://<host>/<o>/<r>` derives and persists
+#      (host, owner, repo) the same way.
+#   3. `mt tap --json` / `mt tap` surface the host.
+#   4. A non-GitHub host with no explicit repo fails with a hint — never a
+#      silent `homebrew-<repo>` guess.
+#   5. A `--host` carrying a scheme/path is rejected.
+#
+# The non-GitHub path never touches the network, so this runs offline.
+#
+# Usage: scripts/regressions/tap_register_host.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+PREFIX=$(mktemp -d -t mt_taphost.XXXXXX)
+mkdir -p "$PREFIX/db"
+trap 'rm -rf "$PREFIX"' EXIT
+export MALT_PREFIX="$PREFIX"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+# 1. --host + --repo registers a gitlab tap, unpinned, no homebrew- synthesis.
+"$MALT_BIN" tap grp/tap --host gitlab.com --repo grp/tap >/dev/null 2>&1 ||
+  fail 'mt tap --host gitlab.com --repo grp/tap exited non-zero'
+
+json=$("$MALT_BIN" tap --json)
+printf '%s' "$json" | grep -q '"name":"grp/tap"' || fail 'gitlab tap missing from --json'
+printf '%s' "$json" | grep -q '"host":"gitlab.com"' || fail 'gitlab tap host not surfaced in --json'
+printf '%s' "$json" | grep -q '"commit_sha":null' || fail 'gitlab tap should be unpinned'
+printf '%s' "$json" | grep -q 'homebrew-' && fail 'unexpected homebrew- synthesis for a gitlab tap'
+
+# text listing tags the off-github host.
+"$MALT_BIN" tap | grep -q '\[gitlab.com\]' || fail 'text listing does not tag the gitlab host'
+
+# 2. --url derives (host, owner, repo).
+"$MALT_BIN" tap mygrp/mytap --url https://codeberg.org/o/r >/dev/null 2>&1 ||
+  fail 'mt tap --url https://codeberg.org/o/r exited non-zero'
+json=$("$MALT_BIN" tap --json)
+printf '%s' "$json" | grep -q '"host":"codeberg.org"' || fail 'codeberg tap host not surfaced in --json'
+
+# 4. non-github host without a repo fails with a hint.
+if "$MALT_BIN" tap other/tap --host gitlab.com >/dev/null 2>"$PREFIX/err.log"; then
+  fail 'non-github --host without --repo should fail'
+fi
+grep -q 'needs an explicit repo' "$PREFIX/err.log" || fail 'missing explicit-repo hint'
+
+# 5. a --host with a scheme/path is rejected.
+if "$MALT_BIN" tap bad/tap --host https://gitlab.com --repo bad/tap >/dev/null 2>"$PREFIX/err.log"; then
+  fail 'a --host carrying a scheme should be rejected'
+fi
+grep -q 'Invalid --host' "$PREFIX/err.log" || fail 'missing invalid-host message'
+
+printf 'OK: non-GitHub tap registration persists host, skips homebrew- synthesis, and validates input.\n'

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -159,7 +159,7 @@ pub const bash_script =
     \\        bundle)           cmd_flags="--dry-run -n --format --from-installed --purge --yes -y --isolate-deps --isolate-dependencies" ;;
     \\        run)              cmd_flags="--keep" ;;
     \\        doctor)           cmd_flags="--fix --dry-run" ;;
-    \\        tap)              cmd_flags="--refresh --all --pin --repo --force --yes -y --json" ;;
+    \\        tap)              cmd_flags="--refresh --all --pin --repo --host --url --force --yes -y --json" ;;
     \\    esac
     \\
     \\    if [[ "$cur" == -* ]]; then
@@ -434,6 +434,8 @@ pub const zsh_script =
     \\                        '--all[With --refresh: walk every registered tap]' \
     \\                        '--pin[Explicitly pin <slug> to <sha>]' \
     \\                        '--repo[Point the tap at owner/exact-repo (no homebrew- prefix)]:owner/exact-repo:' \
+    \\                        '--host[Register the tap on a non-GitHub forge (e.g. gitlab.com)]:forge-host:' \
+    \\                        '--url[Derive (host, owner, repo) from a full repo URL]:repo-url:' \
     \\                        '--force[Rebind an existing tap to a new --repo target]' \
     \\                        '(--yes -y)'{--yes,-y}'[Confirm --refresh --all apply]' \
     \\                        '--json[Emit refresh-all diff as JSON]' \
@@ -651,6 +653,8 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -l all     -d 'With --refresh: walk every registered tap'
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -l pin     -d 'Explicitly pin <slug> to <sha>'
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -l repo    -x -d 'Point the tap at owner/exact-repo (no homebrew- prefix)'
+    \\    complete -c $__malt_bin -n '__malt_using_command tap' -l host    -x -d 'Register the tap on a non-GitHub forge (e.g. gitlab.com)'
+    \\    complete -c $__malt_bin -n '__malt_using_command tap' -l url     -x -d 'Derive (host, owner, repo) from a full repo URL'
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -l force   -d 'Rebind an existing tap to a new --repo target'
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -s y -l yes -d 'Confirm --refresh --all apply'
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -l json    -d 'Emit refresh-all diff as JSON'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -285,6 +285,8 @@ const doctor_help =
 const tap_help =
     \\Usage: malt tap [<user>/<repo>]
     \\       malt tap <user>/<repo> --repo <owner>/<exact-repo> [--force]
+    \\       malt tap <slug> --host <forge-host> --repo <owner>/<repo>
+    \\       malt tap <slug> --url https://<host>/<owner>/<repo>
     \\       malt tap --refresh <user>/<repo>
     \\       malt tap --refresh --all [--yes] [--json]
     \\       malt tap --pin <user>/<repo> <sha>
@@ -312,6 +314,14 @@ const tap_help =
     \\                       (e.g. `mt tap aeroxy/ast-outline --repo
     \\                       aeroxy/ast-outline`). Without this flag the
     \\                       tap resolves against `homebrew-<repo>`.
+    \\  --host <forge-host>  Register the tap against a non-GitHub forge
+    \\                       (e.g. gitlab.com, codeberg.org). Requires an
+    \\                       explicit --repo — the `homebrew-<repo>` default
+    \\                       only applies to github.com. Resolution for
+    \\                       non-GitHub forges arrives in a later release.
+    \\  --url <repo-url>     Derive (host, owner, repo) from a full
+    \\                       `https://<host>/<owner>/<repo>` URL instead of
+    \\                       naming --host and --repo separately.
     \\  --force              Allow rebinding an existing tap to a new
     \\                       --repo target. Clears the stale commit SHA
     \\                       and ETag because the new repo has its own HEAD.

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -796,7 +796,7 @@ pub fn materializeRubyFormula(
             // is already recorded; a missing tap row self-heals next sync.
             // (owner, repo) routes through `effectiveOwnerRepo` so the
             // synthesis used at fetch time and at persist time can't drift.
-            if (tap_mod.effectiveOwnerRepo(allocator, db, resolved.tap_label)) |pair| {
+            if (tap_mod.effectiveOwnerRepo(allocator, db, resolved.tap_label, "github.com")) |pair| {
                 defer pair.deinit(allocator);
                 tap_mod.add(db, resolved.tap_label, pair.owner, pair.repo, t.commit_sha) catch {};
                 if (t.head_etag) |et| tap_mod.updateHead(db, resolved.tap_label, t.commit_sha, et) catch {};
@@ -1023,7 +1023,7 @@ fn finalizeTapCaskInstall(
     // (owner, repo) routes through `effectiveOwnerRepo` so the
     // persisted pair matches the one fetched against.
     if (tap_registration) |t| {
-        if (tap_mod.effectiveOwnerRepo(allocator, db, tap_label)) |pair| {
+        if (tap_mod.effectiveOwnerRepo(allocator, db, tap_label, "github.com")) |pair| {
             defer pair.deinit(allocator);
             tap_mod.add(db, tap_label, pair.owner, pair.repo, t.commit_sha) catch {};
             if (t.head_etag) |et| tap_mod.updateHead(db, tap_label, t.commit_sha, et) catch {};

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -16,11 +16,59 @@ pub const TapNameError = error{InvalidTapName};
 
 pub const RepoOverrideError = error{InvalidRepoOverride} || std.mem.Allocator.Error;
 
+pub const ForgeHostError = error{InvalidForgeHost};
+
+pub const RepoUrlError = error{InvalidRepoUrl} || std.mem.Allocator.Error;
+
+/// Parse a full `https://<host>/<owner>/<repo>` registration URL into an
+/// owned `(host, owner, repo)` triple, deriving the forge host so the
+/// user need not name `--host` separately. Host and path components are
+/// validated by the same rules `--host` and `--repo` enforce. A single
+/// trailing slash is tolerated; deeper paths and non-https URLs are
+/// rejected. Caller owns the triple via `TapPair.deinit`.
+pub fn parseRepoUrl(allocator: std.mem.Allocator, raw: []const u8) RepoUrlError!tap_mod.TapPair {
+    const scheme = "https://";
+    if (!std.mem.startsWith(u8, raw, scheme)) return error.InvalidRepoUrl;
+    const rest = std.mem.trimEnd(u8, raw[scheme.len..], "/");
+    const slash = std.mem.indexOfScalar(u8, rest, '/') orelse return error.InvalidRepoUrl;
+    const host = rest[0..slash];
+    const path = rest[slash + 1 ..];
+    validateForgeHost(host) catch return error.InvalidRepoUrl;
+    validateTapName(path) catch return error.InvalidRepoUrl;
+    const path_slash = std.mem.indexOfScalar(u8, path, '/').?;
+    const owner = path[0..path_slash];
+    const repo = path[path_slash + 1 ..];
+
+    const host_owned = try allocator.dupe(u8, host);
+    errdefer allocator.free(host_owned);
+    const owner_owned = try allocator.dupe(u8, owner);
+    errdefer allocator.free(owner_owned);
+    const repo_owned = try allocator.dupe(u8, repo);
+    return .{ .owner = owner_owned, .repo = repo_owned, .host = host_owned };
+}
+
+/// Validate a `--host` value as a bare forge host: an HTTPS host with no
+/// scheme and no path. Rejecting `:` and `/` rules out `https://…`, a
+/// trailing path, and `host:port` in one sweep; the dot requirement stops
+/// a stray path fragment from masquerading as a host.
+pub fn validateForgeHost(host: []const u8) ForgeHostError!void {
+    if (host.len == 0 or host.len > 253) return error.InvalidForgeHost;
+    if (host[0] == '.' or host[0] == '-') return error.InvalidForgeHost;
+    if (host[host.len - 1] == '.' or host[host.len - 1] == '-') return error.InvalidForgeHost;
+    var has_dot = false;
+    for (host) |ch| switch (ch) {
+        'a'...'z', 'A'...'Z', '0'...'9', '-' => {},
+        '.' => has_dot = true,
+        else => return error.InvalidForgeHost,
+    };
+    if (!has_dot) return error.InvalidForgeHost;
+}
+
 /// Parse `--repo <owner>/<exact-repo>` into an owned `(owner, repo)`
 /// pair. Reuses the slug-validation rules so the override can't sneak
 /// past validateTapName by going through the flag. Caller owns both
 /// slices via `TapPair.deinit`.
-pub fn parseRepoOverride(allocator: std.mem.Allocator, raw: []const u8) RepoOverrideError!tap_mod.TapPair {
+pub fn parseRepoOverride(allocator: std.mem.Allocator, raw: []const u8, host: []const u8) RepoOverrideError!tap_mod.TapPair {
     validateTapName(raw) catch return RepoOverrideError.InvalidRepoOverride;
     const slash = std.mem.indexOfScalar(u8, raw, '/') orelse unreachable;
     const owner = raw[0..slash];
@@ -29,30 +77,39 @@ pub fn parseRepoOverride(allocator: std.mem.Allocator, raw: []const u8) RepoOver
     errdefer allocator.free(owner_owned);
     const repo_owned = try allocator.dupe(u8, repo);
     errdefer allocator.free(repo_owned);
-    // `--repo` is a GitHub-only override today; a chosen host will be
-    // threaded through here later. Default keeps the pair self-consistent.
-    const host_owned = try allocator.dupe(u8, "github.com");
+    // `host` is the forge chosen via `--host` (or github.com by default);
+    // pairing it here keeps the row's `(owner, repo, host)` self-consistent.
+    const host_owned = try allocator.dupe(u8, host);
     return .{ .owner = owner_owned, .repo = repo_owned, .host = host_owned };
 }
 
 test "parseRepoOverride accepts user/repo and returns the owned pair" {
-    const pair = try parseRepoOverride(std.testing.allocator, "aeroxy/ast-outline");
+    const pair = try parseRepoOverride(std.testing.allocator, "aeroxy/ast-outline", "github.com");
     defer pair.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("aeroxy", pair.owner);
     try std.testing.expectEqualStrings("ast-outline", pair.repo);
+    try std.testing.expectEqualStrings("github.com", pair.host);
+}
+
+test "parseRepoOverride threads the chosen forge host onto the pair" {
+    const pair = try parseRepoOverride(std.testing.allocator, "mygroup/mytap", "gitlab.com");
+    defer pair.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("mygroup", pair.owner);
+    try std.testing.expectEqualStrings("mytap", pair.repo);
+    try std.testing.expectEqualStrings("gitlab.com", pair.host);
 }
 
 test "parseRepoOverride rejects a malformed override (no slash, double slash, empty parts)" {
-    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "noslash"));
-    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "user//repo"));
-    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "user/"));
-    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "/repo"));
+    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "noslash", "github.com"));
+    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "user//repo", "github.com"));
+    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "user/", "github.com"));
+    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "/repo", "github.com"));
 }
 
 test "parseRepoOverride preserves hyphens, digits, dots in both components" {
     // GitHub allows these in user and repo names; the validator must
     // not reject them when a user passes them through --repo.
-    const pair = try parseRepoOverride(std.testing.allocator, "user-1/some.repo_v2");
+    const pair = try parseRepoOverride(std.testing.allocator, "user-1/some.repo_v2", "github.com");
     defer pair.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("user-1", pair.owner);
     try std.testing.expectEqualStrings("some.repo_v2", pair.repo);
@@ -62,12 +119,12 @@ test "parseRepoOverride rejects components longer than 64 chars" {
     // Pre-existing validateTapName cap. Documented here so a future
     // relaxation surfaces as a test diff rather than silent acceptance.
     const long = "a" ** 65 ++ "/" ++ "b" ** 4;
-    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, long));
+    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, long, "github.com"));
 }
 
 test "parseRepoOverride rejects a leading dot (path-traversal-shaped names)" {
-    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, ".hidden/repo"));
-    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "user/.hidden"));
+    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, ".hidden/repo", "github.com"));
+    try std.testing.expectError(RepoOverrideError.InvalidRepoOverride, parseRepoOverride(std.testing.allocator, "user/.hidden", "github.com"));
 }
 
 /// Reject malformed `user/repo` inputs before they're formatted into a
@@ -83,6 +140,48 @@ pub fn validateTapName(name: []const u8) TapNameError!void {
     if (std.mem.findScalarPos(u8, name, slash + 1, '/') != null) return TapNameError.InvalidTapName;
     try validateComponent(name[0..slash]);
     try validateComponent(name[slash + 1 ..]);
+}
+
+test "parseRepoUrl derives (host, owner, repo) from a full HTTPS repo URL" {
+    const pair = try parseRepoUrl(std.testing.allocator, "https://gitlab.com/mygroup/mytap");
+    defer pair.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("gitlab.com", pair.host);
+    try std.testing.expectEqualStrings("mygroup", pair.owner);
+    try std.testing.expectEqualStrings("mytap", pair.repo);
+}
+
+test "parseRepoUrl tolerates a single trailing slash" {
+    const pair = try parseRepoUrl(std.testing.allocator, "https://codeberg.org/o/r/");
+    defer pair.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("codeberg.org", pair.host);
+    try std.testing.expectEqualStrings("o", pair.owner);
+    try std.testing.expectEqualStrings("r", pair.repo);
+}
+
+test "parseRepoUrl rejects non-https, missing-repo, deep-path, and bad-host URLs" {
+    try std.testing.expectError(RepoUrlError.InvalidRepoUrl, parseRepoUrl(std.testing.allocator, "http://gitlab.com/o/r"));
+    try std.testing.expectError(RepoUrlError.InvalidRepoUrl, parseRepoUrl(std.testing.allocator, "https://gitlab.com/o"));
+    try std.testing.expectError(RepoUrlError.InvalidRepoUrl, parseRepoUrl(std.testing.allocator, "https://gitlab.com/o/r/sub"));
+    try std.testing.expectError(RepoUrlError.InvalidRepoUrl, parseRepoUrl(std.testing.allocator, "https://gitlab .com/o/r"));
+    try std.testing.expectError(RepoUrlError.InvalidRepoUrl, parseRepoUrl(std.testing.allocator, "https://gitlab.com//r"));
+}
+
+test "validateForgeHost accepts bare HTTPS hosts" {
+    try validateForgeHost("gitlab.com");
+    try validateForgeHost("codeberg.org");
+    try validateForgeHost("git.example.com");
+    try validateForgeHost("github.com");
+}
+
+test "validateForgeHost rejects schemes, paths, ports, and dotless hosts" {
+    try std.testing.expectError(ForgeHostError.InvalidForgeHost, validateForgeHost("https://gitlab.com"));
+    try std.testing.expectError(ForgeHostError.InvalidForgeHost, validateForgeHost("gitlab.com/group/tap"));
+    try std.testing.expectError(ForgeHostError.InvalidForgeHost, validateForgeHost("gitlab.com:8443"));
+    try std.testing.expectError(ForgeHostError.InvalidForgeHost, validateForgeHost("localhost"));
+    try std.testing.expectError(ForgeHostError.InvalidForgeHost, validateForgeHost(""));
+    try std.testing.expectError(ForgeHostError.InvalidForgeHost, validateForgeHost("gitlab .com"));
+    try std.testing.expectError(ForgeHostError.InvalidForgeHost, validateForgeHost(".gitlab.com"));
+    try std.testing.expectError(ForgeHostError.InvalidForgeHost, validateForgeHost("gitlab.com."));
 }
 
 fn validateComponent(part: []const u8) TapNameError!void {
@@ -140,9 +239,10 @@ fn writeRefreshRowText(w: *std.Io.Writer, row: RefreshRow) !void {
     }
 }
 
-/// Emit `[{ "name", "url", "commit_sha" }, ...]\n` for `mt tap --json`.
-/// `commit_sha` is `null` when the tap is unpinned. Kept `pub` so tests can
-/// pin the exact bytes without staging a DB or running the dispatcher.
+/// Emit `[{ "name", "url", "commit_sha", "host" }, ...]\n` for `mt tap
+/// --json`. `commit_sha` is `null` when the tap is unpinned; `host` names
+/// the forge the tap resolves against. Kept `pub` so tests can pin the
+/// exact bytes without staging a DB or running the dispatcher.
 pub fn writeTapListJson(w: *std.Io.Writer, taps: []const tap_mod.TapInfo) !void {
     try w.writeAll("[");
     for (taps, 0..) |t, i| {
@@ -153,6 +253,8 @@ pub fn writeTapListJson(w: *std.Io.Writer, taps: []const tap_mod.TapInfo) !void 
         try output.jsonStr(w, t.url);
         try w.writeAll(",\"commit_sha\":");
         if (t.commit_sha) |sha| try output.jsonStr(w, sha) else try w.writeAll("null");
+        try w.writeAll(",\"host\":");
+        try output.jsonStr(w, t.host);
         try w.writeAll("}");
     }
     try w.writeAll("]\n");
@@ -180,14 +282,21 @@ fn writeRefreshRowsJson(w: *std.Io.Writer, rows: []const RefreshRow) !void {
 /// the returned slice. Kept in one place so the refresh hint stays in
 /// sync with `mt tap --refresh` and the exact byte layout is testable.
 fn formatTapLine(allocator: std.mem.Allocator, t: tap_mod.TapInfo) ![]u8 {
+    // GitHub is the implicit default; tag only off-github taps so the
+    // common listing stays uncluttered. A hostname fits in 256 bytes.
+    var host_buf: [288]u8 = undefined;
+    const host_tag: []const u8 = if (std.mem.eql(u8, t.host, "github.com"))
+        ""
+    else
+        std.fmt.bufPrint(&host_buf, " [{s}]", .{t.host}) catch "";
     if (t.commit_sha) |sha| {
         const short_len = @min(sha.len, 7);
-        return std.fmt.allocPrint(allocator, "{s} @ {s}\n", .{ t.name, sha[0..short_len] });
+        return std.fmt.allocPrint(allocator, "{s} @ {s}{s}\n", .{ t.name, sha[0..short_len], host_tag });
     }
     return std.fmt.allocPrint(
         allocator,
-        "{s} (unpinned — run `mt tap --refresh {s}`)\n",
-        .{ t.name, t.name },
+        "{s} (unpinned — run `mt tap --refresh {s}`){s}\n",
+        .{ t.name, t.name, host_tag },
     );
 }
 
@@ -211,6 +320,31 @@ test "formatTapLine renders refresh hint for an unpinned tap" {
     try std.testing.expectEqualStrings(
         "user/repo (unpinned — run `mt tap --refresh user/repo`)\n",
         line,
+    );
+}
+
+test "formatTapLine annotates a non-github tap with its forge host" {
+    // GitHub is the implicit default — only off-github taps carry the
+    // host tag so the common listing stays uncluttered.
+    const pinned = try formatTapLine(std.testing.allocator, .{
+        .name = "grp/tap",
+        .url = "https://gitlab.com/grp/tap",
+        .commit_sha = "0123456789abcdef0123456789abcdef01234567",
+        .host = "gitlab.com",
+    });
+    defer std.testing.allocator.free(pinned);
+    try std.testing.expectEqualStrings("grp/tap @ 0123456 [gitlab.com]\n", pinned);
+
+    const unpinned = try formatTapLine(std.testing.allocator, .{
+        .name = "grp/tap",
+        .url = "https://gitlab.com/grp/tap",
+        .commit_sha = null,
+        .host = "gitlab.com",
+    });
+    defer std.testing.allocator.free(unpinned);
+    try std.testing.expectEqualStrings(
+        "grp/tap (unpinned — run `mt tap --refresh grp/tap`) [gitlab.com]\n",
+        unpinned,
     );
 }
 
@@ -347,23 +481,23 @@ test "writeTapListJson: escapes embedded quotes/backslashes in url so output is 
     defer aw.deinit();
     try writeTapListJson(&aw.writer, &rows);
     try std.testing.expectEqualStrings(
-        "[{\"name\":\"user/repo\",\"url\":\"https://x/\\\"weird\\\\path\\\"\",\"commit_sha\":null}]\n",
+        "[{\"name\":\"user/repo\",\"url\":\"https://x/\\\"weird\\\\path\\\"\",\"commit_sha\":null,\"host\":\"github.com\"}]\n",
         aw.written(),
     );
 }
 
-test "writeTapListJson: emits `name`, `url`, `commit_sha` per tap; null when unpinned" {
+test "writeTapListJson: emits `name`, `url`, `commit_sha`, `host` per tap; null when unpinned" {
     const rows = [_]tap_mod.TapInfo{
         .{ .name = "user/repo", .url = "https://github.com/user/homebrew-repo", .commit_sha = sha_old },
-        .{ .name = "x/y", .url = "https://github.com/x/homebrew-y", .commit_sha = null },
+        .{ .name = "grp/tap", .url = "https://gitlab.com/grp/tap", .commit_sha = null, .host = "gitlab.com" },
     };
     var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
     try writeTapListJson(&aw.writer, &rows);
     try std.testing.expectEqualStrings(
         "[" ++
-            "{\"name\":\"user/repo\",\"url\":\"https://github.com/user/homebrew-repo\",\"commit_sha\":\"" ++ sha_old ++ "\"}," ++
-            "{\"name\":\"x/y\",\"url\":\"https://github.com/x/homebrew-y\",\"commit_sha\":null}" ++
+            "{\"name\":\"user/repo\",\"url\":\"https://github.com/user/homebrew-repo\",\"commit_sha\":\"" ++ sha_old ++ "\",\"host\":\"github.com\"}," ++
+            "{\"name\":\"grp/tap\",\"url\":\"https://gitlab.com/grp/tap\",\"commit_sha\":null,\"host\":\"gitlab.com\"}" ++
             "]\n",
         aw.written(),
     );
@@ -410,6 +544,10 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
     var yes = false;
     var force = false;
     var repo_override: ?[]const u8 = null;
+    // --host <forge-host>: register the tap against a non-GitHub forge.
+    // --url <repo-url>: derive (host, owner, repo) from a full repo URL.
+    var host_flag: ?[]const u8 = null;
+    var url_flag: ?[]const u8 = null;
     var positional: ?[]const u8 = null;
     var i: usize = 0;
     while (i < args.len) : (i += 1) {
@@ -441,6 +579,40 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
                 return error.Aborted;
             }
             repo_override = arg["--repo=".len..];
+        } else if (std.mem.eql(u8, arg, "--host")) {
+            if (action != .add) {
+                output.err("--host is only valid with `mt tap`", .{});
+                return error.Aborted;
+            }
+            if (i + 1 >= args.len) {
+                output.err("Usage: mt tap <slug> --host <forge-host>", .{});
+                return error.Aborted;
+            }
+            host_flag = args[i + 1];
+            i += 1;
+        } else if (std.mem.startsWith(u8, arg, "--host=")) {
+            if (action != .add) {
+                output.err("--host is only valid with `mt tap`", .{});
+                return error.Aborted;
+            }
+            host_flag = arg["--host=".len..];
+        } else if (std.mem.eql(u8, arg, "--url")) {
+            if (action != .add) {
+                output.err("--url is only valid with `mt tap`", .{});
+                return error.Aborted;
+            }
+            if (i + 1 >= args.len) {
+                output.err("Usage: mt tap <slug> --url https://<host>/<owner>/<repo>", .{});
+                return error.Aborted;
+            }
+            url_flag = args[i + 1];
+            i += 1;
+        } else if (std.mem.startsWith(u8, arg, "--url=")) {
+            if (action != .add) {
+                output.err("--url is only valid with `mt tap`", .{});
+                return error.Aborted;
+            }
+            url_flag = arg["--url=".len..];
         } else if (std.mem.eql(u8, arg, "--pin")) {
             if (action != .add) {
                 output.err("--pin is only valid with `mt tap`", .{});
@@ -477,6 +649,30 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
         output.err("--force is only valid alongside --repo", .{});
         return error.Aborted;
     }
+
+    // --url already carries host + owner/repo, so pairing it with --host
+    // or --repo is contradictory. Refuse rather than silently pick one.
+    if (url_flag != null and (host_flag != null or repo_override != null)) {
+        output.err("--url cannot be combined with --host or --repo", .{});
+        return error.Aborted;
+    }
+    // --host / --url need a positional slug to name the tap locally.
+    if ((host_flag != null or url_flag != null) and positional == null) {
+        output.err("Usage: mt tap <slug> --host <host> --repo <owner>/<repo>  (or --url <repo-url>)", .{});
+        return error.Aborted;
+    }
+    if ((host_flag != null or url_flag != null) and
+        (refresh_all or refresh_target != null or pin_slug != null))
+    {
+        output.err("--host/--url cannot be combined with --refresh or --pin", .{});
+        return error.Aborted;
+    }
+    // Validate the forge host up front so an invalid `--host` reports the
+    // real problem rather than a downstream "needs --repo" hint.
+    if (host_flag) |h| validateForgeHost(h) catch {
+        output.err("Invalid --host '{s}'. Expected a bare HTTPS host like gitlab.com (no scheme, no path).", .{h});
+        return error.Aborted;
+    };
 
     const prefix = atomic.maltPrefixOrAbort();
 
@@ -533,6 +729,7 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
             for (taps) |t| {
                 allocator.free(t.name);
                 allocator.free(t.url);
+                allocator.free(t.host);
                 if (t.commit_sha) |sha| allocator.free(sha);
             }
             allocator.free(taps);
@@ -572,37 +769,71 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
 
     switch (action) {
         .add => {
-            // --repo overrides any stored pair; otherwise the helper
-            // reads the row, falling back to the slug-derived
-            // `(user, "homebrew-" || repo)` default the first time round.
+            // --url carries (host, owner, repo); --repo overrides the pair
+            // on the chosen host; otherwise the helper reads the row,
+            // falling back to the slug-derived `(user, "homebrew-" || repo)`
+            // default — github.com only.
+            const chosen_host: []const u8 = host_flag orelse "github.com";
             const target_pair = pair: {
-                if (repo_override) |rep| break :pair parseRepoOverride(allocator, rep) catch |e| switch (e) {
+                if (url_flag) |u| break :pair parseRepoUrl(allocator, u) catch |e| switch (e) {
+                    error.InvalidRepoUrl => {
+                        output.err("Invalid --url '{s}'. Expected https://<host>/<owner>/<repo>.", .{u});
+                        return error.Aborted;
+                    },
+                    error.OutOfMemory => return error.OutOfMemory,
+                };
+                if (repo_override) |rep| break :pair parseRepoOverride(allocator, rep, chosen_host) catch |e| switch (e) {
                     error.InvalidRepoOverride => {
                         output.err("Invalid --repo '{s}'. Expected: owner/exact-repo with [A-Za-z0-9._-]", .{rep});
                         return error.Aborted;
                     },
                     error.OutOfMemory => return error.OutOfMemory,
                 };
-                break :pair try tap_mod.effectiveOwnerRepo(allocator, &db, name);
+                break :pair tap_mod.effectiveOwnerRepo(allocator, &db, name, chosen_host) catch |e| switch (e) {
+                    error.ExplicitRepoRequired => {
+                        output.err("Registering a {s} tap needs an explicit repo — add --repo <owner>/<repo> or use --url <repo-url>. The homebrew-<repo> default only applies to github.com.", .{chosen_host});
+                        return error.Aborted;
+                    },
+                    else => return e,
+                };
             };
             defer target_pair.deinit(allocator);
 
             // Rebind policy: refuse if a row already pins a different
-            // (owner, repo) unless --force. Matches the pin-stays-sticky
+            // (owner, repo, host) unless --force. Matches the pin-stays-sticky
             // posture of `tap_mod.add`'s COALESCE on commit_sha.
             const stored_opt = tap_mod.getOwnerRepo(allocator, &db, name) catch null;
             defer if (stored_opt) |p| p.deinit(allocator);
             var rebinding = false;
             if (stored_opt) |stored| {
                 const same = std.mem.eql(u8, stored.owner, target_pair.owner) and
-                    std.mem.eql(u8, stored.repo, target_pair.repo);
+                    std.mem.eql(u8, stored.repo, target_pair.repo) and
+                    std.mem.eql(u8, stored.host, target_pair.host);
                 if (!same) {
                     if (!force) {
-                        output.err("Tap {s} is already bound to {s}/{s}. Re-run with --force to rebind to {s}/{s}.", .{ name, stored.owner, stored.repo, target_pair.owner, target_pair.repo });
+                        output.err("Tap {s} is already bound to {s}/{s} on {s}. Re-run with --force to rebind to {s}/{s} on {s}.", .{ name, stored.owner, stored.repo, stored.host, target_pair.owner, target_pair.repo, target_pair.host });
                         return error.Aborted;
                     }
                     rebinding = true;
                 }
+            }
+
+            // Off-GitHub forges have no resolver yet — persist the row so
+            // the tap is recorded, but skip the GitHub-shaped HEAD resolve
+            // (it would mis-resolve against api.github.com). Rebinding onto
+            // another forge needs the host-aware rebind the provider arms
+            // bring, so refuse it for now rather than half-apply it.
+            if (!std.mem.eql(u8, target_pair.host, "github.com")) {
+                if (rebinding) {
+                    output.err("Rebinding {s} onto {s} isn't supported yet — run `mt untap {s}` then re-register.", .{ name, target_pair.host, name });
+                    return error.Aborted;
+                }
+                tap_mod.addWithHost(&db, name, target_pair.owner, target_pair.repo, target_pair.host, null) catch {
+                    output.err("Failed to register tap {s}", .{name});
+                    return error.Aborted;
+                };
+                output.warn("Registered {s} → {s}/{s} on {s}. Resolution for non-GitHub forges arrives in a later release; the tap is stored but not yet fetchable.", .{ name, target_pair.owner, target_pair.repo, target_pair.host });
+                return;
             }
 
             // Apply the rebind before any HTTP work. Clearing the pin
@@ -712,7 +943,7 @@ fn pinTap(
         return error.Aborted;
     }
 
-    const pair = try tap_mod.effectiveOwnerRepo(allocator, db, slug);
+    const pair = try tap_mod.effectiveOwnerRepo(allocator, db, slug, "github.com");
     defer pair.deinit(allocator);
     tap_mod.add(db, slug, pair.owner, pair.repo, sha) catch {
         output.err("Failed to pin {s}", .{slug});
@@ -738,6 +969,7 @@ fn refreshAll(
         for (taps) |t| {
             allocator.free(t.name);
             allocator.free(t.url);
+            allocator.free(t.host);
             if (t.commit_sha) |sha| allocator.free(sha);
         }
         allocator.free(taps);

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -512,7 +512,7 @@ fn upgradeTapFormula(
     // (owner, repo) routes through `effectiveOwnerRepo` so the synthesis
     // used at HEAD resolve time matches the row that records the pin.
     {
-        const pair = tap_mod.effectiveOwnerRepo(allocator, db, tap_label) catch {
+        const pair = tap_mod.effectiveOwnerRepo(allocator, db, tap_label, "github.com") catch {
             output.err("Could not pin {s} to {s}", .{ tap_label, fresh_sha });
             return error.Aborted;
         };
@@ -616,7 +616,7 @@ fn upgradeRoutedTapCask(
     // Persist the new pin BEFORE installTapFormula reads it via
     // `tap_mod.getCommitSha`. Same pattern as `upgradeTapFormula`.
     {
-        const pair = tap_mod.effectiveOwnerRepo(allocator, db, tap_label) catch {
+        const pair = tap_mod.effectiveOwnerRepo(allocator, db, tap_label, "github.com") catch {
             output.err("Could not pin {s} to {s}", .{ tap_label, fresh_sha });
             return error.Aborted;
         };
@@ -711,6 +711,7 @@ fn upgradeTapCaskFallback(
         for (taps) |t| {
             allocator.free(t.name);
             allocator.free(t.url);
+            allocator.free(t.host);
             if (t.commit_sha) |s| allocator.free(s);
         }
         allocator.free(taps);

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -11,6 +11,9 @@ pub const TapInfo = struct {
     /// for rows carried over from pre-pin schema or for additions that
     /// couldn't resolve a remote commit at tap time.
     commit_sha: ?[]const u8 = null,
+    /// Forge host the tap resolves against. Defaults to github.com so
+    /// pre-host rows and synthetic test fixtures stay valid.
+    host: []const u8 = "github.com",
 };
 
 pub const TapError = error{
@@ -56,14 +59,17 @@ pub fn describeResolveError(err: TapError) []const u8 {
     };
 }
 
-/// Materialise `taps.url` from `(owner, repo)` into a caller buffer
+/// Materialise `taps.url` from `(host, owner, repo)` into a caller buffer
 /// through the forge seam, so the browse-URL shape lives in one place.
 /// `buf` must hold ≥160 bytes (19 prefix + 2·64 component cap + 1 slash).
-fn writeRepoUrl(buf: []u8, owner: []const u8, repo: []const u8) sqlite.SqliteError![]const u8 {
-    return forge.repoBrowseUrl(buf, .github, "github.com", owner, repo) catch
+fn writeRepoUrl(buf: []u8, host: []const u8, owner: []const u8, repo: []const u8) sqlite.SqliteError![]const u8 {
+    return forge.repoBrowseUrl(buf, forge.fromHost(host), host, owner, repo) catch
         sqlite.SqliteError.ExecFailed;
 }
 
+/// GitHub-default `add` — the overwhelming majority of taps. Delegates to
+/// `addWithHost` so the 5-arg call sites stay untouched; host is sticky
+/// on conflict, so a re-add never clobbers a non-github row's forge.
 pub fn add(
     db: *sqlite.Database,
     name: []const u8,
@@ -71,14 +77,28 @@ pub fn add(
     repo: []const u8,
     commit_sha: ?[]const u8,
 ) sqlite.SqliteError!void {
-    // Owner/repo are sticky on conflict — the rebind verb is the only
+    return addWithHost(db, name, owner, repo, "github.com", commit_sha);
+}
+
+/// Register a tap row carrying its forge `host`. The `mt tap --host` /
+/// `--url` registration path is the only caller that names a non-github
+/// host; everything else routes through `add`.
+pub fn addWithHost(
+    db: *sqlite.Database,
+    name: []const u8,
+    owner: []const u8,
+    repo: []const u8,
+    host: []const u8,
+    commit_sha: ?[]const u8,
+) sqlite.SqliteError!void {
+    // Owner/repo/host are sticky on conflict — the rebind verb is the only
     // sanctioned mutator. commit_sha is sticky unless a fresh one is
     // passed (refresh goes through `updateCommit`/`updateHead`).
     var url_buf: [256]u8 = undefined;
-    const derived_url = try writeRepoUrl(&url_buf, owner, repo);
+    const derived_url = try writeRepoUrl(&url_buf, host, owner, repo);
 
     var stmt = try db.prepare(
-        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo) VALUES (?1, ?2, ?3, ?4, ?5)
+        \\INSERT INTO taps (name, url, commit_sha, github_owner, github_repo, host) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
         \\ON CONFLICT(name) DO UPDATE SET
         \\    commit_sha = COALESCE(excluded.commit_sha, taps.commit_sha);
     );
@@ -92,6 +112,7 @@ pub fn add(
     }
     try stmt.bindText(4, owner);
     try stmt.bindText(5, repo);
+    try stmt.bindText(6, host);
     _ = try stmt.step();
 }
 
@@ -107,7 +128,10 @@ pub fn rebind(
     repo: []const u8,
 ) sqlite.SqliteError!void {
     var url_buf: [256]u8 = undefined;
-    const derived_url = try writeRepoUrl(&url_buf, owner, repo);
+    // Rebind is a GitHub-only verb today (`mt tap --repo`); the row's host
+    // is left untouched by the UPDATE below, so deriving the browse URL
+    // against github.com matches the row that stays.
+    const derived_url = try writeRepoUrl(&url_buf, "github.com", owner, repo);
 
     var stmt = try db.prepare(
         \\UPDATE taps SET
@@ -230,6 +254,8 @@ pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) ![]TapInfo {
 
         const name_owned = try allocator.dupe(u8, std.mem.sliceTo(n, 0));
         errdefer allocator.free(name_owned);
+        const host_owned = try allocator.dupe(u8, host);
+        errdefer allocator.free(host_owned);
         const url_owned = try forge.allocRepoBrowseUrl(
             allocator,
             forge.fromHost(host),
@@ -249,6 +275,7 @@ pub fn list(allocator: std.mem.Allocator, db: *sqlite.Database) ![]TapInfo {
             .name = name_owned,
             .url = url_owned,
             .commit_sha = sha_owned,
+            .host = host_owned,
         });
     }
 
@@ -259,6 +286,7 @@ fn freeTapInfoFields(allocator: std.mem.Allocator, info: TapInfo) void {
     allocator.free(info.name);
     allocator.free(info.url);
     if (info.commit_sha) |sha| allocator.free(sha);
+    allocator.free(info.host);
 }
 
 /// Resolve a tap formula — builds the full tap formula name.
@@ -325,8 +353,13 @@ pub fn effectiveOwnerRepo(
     allocator: std.mem.Allocator,
     db: *sqlite.Database,
     slug: []const u8,
+    host: []const u8,
 ) !TapPair {
     if (try getOwnerRepo(allocator, db, slug)) |pair| return pair;
+    // Cold path predates any stored row. The `homebrew-<repo>` synthesis is
+    // a GitHub-community convention — it does not hold on other forges, so
+    // a non-github registration must name its repo explicitly.
+    if (!std.mem.eql(u8, host, "github.com")) return error.ExplicitRepoRequired;
     const slash = std.mem.indexOfScalar(u8, slug, '/') orelse unreachable;
     const user = slug[0..slash];
     const repo_part = slug[slash + 1 ..];
@@ -334,8 +367,6 @@ pub fn effectiveOwnerRepo(
     errdefer allocator.free(owner_owned);
     const repo_owned = try std.fmt.allocPrint(allocator, "homebrew-{s}", .{repo_part});
     errdefer allocator.free(repo_owned);
-    // Cold path predates any stored row; the homebrew-<repo> synthesis is
-    // GitHub-only, so the synthesised pair is github.com by construction.
     const host_owned = try allocator.dupe(u8, "github.com");
     return .{ .owner = owner_owned, .repo = repo_owned, .host = host_owned };
 }
@@ -350,7 +381,10 @@ pub fn resolveTapBaseUrls(
     db: *sqlite.Database,
     slug: []const u8,
 ) !TapBaseUrls {
-    const pair = try effectiveOwnerRepo(allocator, db, slug);
+    // The cold-path hint is github.com: this helper is only reached on the
+    // resolve/refresh path, which non-github taps skip until their forge
+    // arm lands. When a row exists its persisted host wins anyway.
+    const pair = try effectiveOwnerRepo(allocator, db, slug, "github.com");
     defer pair.deinit(allocator);
     // The row's host selects the forge; github.com rows resolve exactly
     // as before since `fromHost` maps everything to `.github` today.
@@ -667,6 +701,55 @@ test "resolveTapBaseUrls reads the stored prefixed pair byte-for-byte" {
     );
 }
 
+test "addWithHost persists the row's forge host" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try addWithHost(&db, "grp/tap", "grp", "tap", "gitlab.com", null);
+
+    const pair = (try getOwnerRepo(std.testing.allocator, &db, "grp/tap")).?;
+    defer pair.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("gitlab.com", pair.host);
+    try std.testing.expectEqualStrings("grp", pair.owner);
+    try std.testing.expectEqualStrings("tap", pair.repo);
+}
+
+test "add defaults the host to github.com (delegates to addWithHost)" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try add(&db, "user/repo", "user", "homebrew-repo", null);
+
+    const pair = (try getOwnerRepo(std.testing.allocator, &db, "user/repo")).?;
+    defer pair.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("github.com", pair.host);
+}
+
+test "list surfaces each row's forge host" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try add(&db, "user/repo", "user", "homebrew-repo", null);
+    try addWithHost(&db, "grp/tap", "grp", "tap", "gitlab.com", null);
+
+    const taps = try list(std.testing.allocator, &db);
+    defer {
+        for (taps) |t| freeTapInfoFields(std.testing.allocator, t);
+        std.testing.allocator.free(taps);
+    }
+    try std.testing.expectEqual(@as(usize, 2), taps.len);
+    for (taps) |t| {
+        if (std.mem.eql(u8, t.name, "grp/tap")) {
+            try std.testing.expectEqualStrings("gitlab.com", t.host);
+        } else {
+            try std.testing.expectEqualStrings("github.com", t.host);
+        }
+    }
+}
+
 test "getOwnerRepo reads the row's host, defaulting to github.com" {
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
@@ -699,17 +782,48 @@ test "getOwnerRepo reads a non-default host written to the row" {
     try std.testing.expectEqualStrings("tap", pair.repo);
 }
 
-test "effectiveOwnerRepo cold path defaults host to github.com" {
+test "effectiveOwnerRepo cold path synthesizes homebrew- for github.com" {
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
     const schema = @import("../db/schema.zig");
     try schema.initSchema(&db);
 
-    const pair = try effectiveOwnerRepo(std.testing.allocator, &db, "aeroxy/tap");
+    const pair = try effectiveOwnerRepo(std.testing.allocator, &db, "aeroxy/tap", "github.com");
     defer pair.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("github.com", pair.host);
     try std.testing.expectEqualStrings("aeroxy", pair.owner);
     try std.testing.expectEqualStrings("homebrew-tap", pair.repo);
+}
+
+test "effectiveOwnerRepo refuses to synthesize a repo for non-github hosts" {
+    // The `homebrew-<repo>` convention is GitHub-community-specific; on
+    // other forges there is no safe default repo to guess, so the cold
+    // path must demand an explicit repo rather than mis-resolve.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+
+    try std.testing.expectError(
+        error.ExplicitRepoRequired,
+        effectiveOwnerRepo(std.testing.allocator, &db, "grp/tap", "gitlab.com"),
+    );
+}
+
+test "effectiveOwnerRepo reads the stored row regardless of the host hint" {
+    // Once a row exists its persisted host wins; the hint only governs
+    // the cold-path synthesis decision.
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    const schema = @import("../db/schema.zig");
+    try schema.initSchema(&db);
+    try addWithHost(&db, "grp/tap", "grp", "tap", "gitlab.com", null);
+
+    const pair = try effectiveOwnerRepo(std.testing.allocator, &db, "grp/tap", "github.com");
+    defer pair.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("gitlab.com", pair.host);
+    try std.testing.expectEqualStrings("grp", pair.owner);
+    try std.testing.expectEqualStrings("tap", pair.repo);
 }
 
 test "resolveTapBaseUrls routes the row's host through the forge seam" {
@@ -745,7 +859,8 @@ pub fn resolveCommitUrl(
     slug: []const u8,
     sha: []const u8,
 ) ![]const u8 {
-    const pair = try effectiveOwnerRepo(allocator, db, slug);
+    // `commits/<sha>` is a GitHub-only verb today (`mt tap --pin`).
+    const pair = try effectiveOwnerRepo(allocator, db, slug, "github.com");
     defer pair.deinit(allocator);
     return std.fmt.allocPrint(
         allocator,

--- a/tests/cli_tap_test.zig
+++ b/tests/cli_tap_test.zig
@@ -314,6 +314,119 @@ test "execute with a bare name (no slash) surfaces error.Aborted" {
 }
 
 // ---------------------------------------------------------------------------
+// --host / --url forge registration
+// ---------------------------------------------------------------------------
+
+fn readTapRow(db_path: [:0]const u8, name: []const u8) !struct { host: []u8, owner: []u8, repo: []u8, pinned: bool } {
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    var stmt = try db.prepare("SELECT host, github_owner, github_repo, commit_sha FROM taps WHERE name = ?1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    try testing.expect(try stmt.step());
+    const host = try testing.allocator.dupe(u8, std.mem.sliceTo(stmt.columnText(0) orelse "", 0));
+    const owner = try testing.allocator.dupe(u8, std.mem.sliceTo(stmt.columnText(1) orelse "", 0));
+    const repo = try testing.allocator.dupe(u8, std.mem.sliceTo(stmt.columnText(2) orelse "", 0));
+    const pinned = stmt.columnText(3) != null;
+    return .{ .host = host, .owner = owner, .repo = repo, .pinned = pinned };
+}
+
+test "execute --host with --repo registers a non-github tap unpinned, no network" {
+    const prefix = try setupPrefix("host_repo_register");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    // Empty environ → if the code routed to GitHub HTTP this would fail;
+    // the non-github path must persist without touching the network.
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try tap_cli.execute(&ctx, testing.allocator, &.{ "grp/tap", "--host", "gitlab.com", "--repo", "grp/tap" });
+
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/db/malt.db", .{prefix}, 0);
+    defer testing.allocator.free(db_path);
+    const row = try readTapRow(db_path, "grp/tap");
+    defer testing.allocator.free(row.host);
+    defer testing.allocator.free(row.owner);
+    defer testing.allocator.free(row.repo);
+    try testing.expectEqualStrings("gitlab.com", row.host);
+    try testing.expectEqualStrings("grp", row.owner);
+    try testing.expectEqualStrings("tap", row.repo);
+    try testing.expect(!row.pinned); // unpinned: resolution lands in a later release
+}
+
+test "execute --url derives and persists (host, owner, repo) unpinned" {
+    const prefix = try setupPrefix("url_register");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try tap_cli.execute(&ctx, testing.allocator, &.{ "mygrp/mytap", "--url", "https://codeberg.org/o/r" });
+
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/db/malt.db", .{prefix}, 0);
+    defer testing.allocator.free(db_path);
+    const row = try readTapRow(db_path, "mygrp/mytap");
+    defer testing.allocator.free(row.host);
+    defer testing.allocator.free(row.owner);
+    defer testing.allocator.free(row.repo);
+    try testing.expectEqualStrings("codeberg.org", row.host);
+    try testing.expectEqualStrings("o", row.owner);
+    try testing.expectEqualStrings("r", row.repo);
+    try testing.expect(!row.pinned);
+}
+
+test "execute --host without an explicit repo fails with a hint, not a homebrew- guess" {
+    const prefix = try setupPrefix("host_no_repo");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(&ctx, testing.allocator, &.{ "grp/tap", "--host", "gitlab.com" }),
+    );
+    try testing.expect(std.mem.indexOf(u8, captured.items, "needs an explicit repo") != null);
+}
+
+test "execute rejects a --host that carries a scheme or path" {
+    const prefix = try setupPrefix("host_bad");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try testing.expectError(
+        error.Aborted,
+        tap_cli.execute(&ctx, testing.allocator, &.{ "grp/tap", "--host", "https://gitlab.com", "--repo", "grp/tap" }),
+    );
+    try testing.expect(std.mem.indexOf(u8, captured.items, "Invalid --host") != null);
+}
+
+// ---------------------------------------------------------------------------
 // --pin <user/repo> <sha>
 // ---------------------------------------------------------------------------
 

--- a/tests/tap_test.zig
+++ b/tests/tap_test.zig
@@ -22,6 +22,7 @@ fn freeTaps(taps: []tap.TapInfo) void {
         testing.allocator.free(t.name);
         testing.allocator.free(t.url);
         if (t.commit_sha) |sha| testing.allocator.free(sha);
+        testing.allocator.free(t.host);
     }
     testing.allocator.free(taps);
 }
@@ -223,7 +224,7 @@ test "effectiveOwnerRepo reads from the row when present" {
     try schema.initSchema(&db);
     try tap.add(&db, "aeroxy/ast-outline", "aeroxy", "ast-outline", null);
 
-    const pair = try tap.effectiveOwnerRepo(testing.allocator, &db, "aeroxy/ast-outline");
+    const pair = try tap.effectiveOwnerRepo(testing.allocator, &db, "aeroxy/ast-outline", "github.com");
     defer pair.deinit(testing.allocator);
     try testing.expectEqualStrings("aeroxy", pair.owner);
     try testing.expectEqualStrings("ast-outline", pair.repo);
@@ -234,7 +235,7 @@ test "effectiveOwnerRepo falls back to slug-derived (user, \"homebrew-\" || repo
     defer db.close();
     try schema.initSchema(&db);
 
-    const pair = try tap.effectiveOwnerRepo(testing.allocator, &db, "aeroxy/tap");
+    const pair = try tap.effectiveOwnerRepo(testing.allocator, &db, "aeroxy/tap", "github.com");
     defer pair.deinit(testing.allocator);
     try testing.expectEqualStrings("aeroxy", pair.owner);
     try testing.expectEqualStrings("homebrew-tap", pair.repo);
@@ -289,7 +290,7 @@ test "effectiveOwnerRepo treats half-empty rows as missing (forgiving against co
         \\VALUES ('user/repo', 'https://x', '', 'something');
     );
 
-    const pair = try tap.effectiveOwnerRepo(testing.allocator, &db, "user/repo");
+    const pair = try tap.effectiveOwnerRepo(testing.allocator, &db, "user/repo", "github.com");
     defer pair.deinit(testing.allocator);
     try testing.expectEqualStrings("user", pair.owner);
     try testing.expectEqualStrings("homebrew-repo", pair.repo);
@@ -474,6 +475,7 @@ fn listAndFree(alloc: std.mem.Allocator, db: *sqlite.Database) !void {
         alloc.free(t.name);
         alloc.free(t.url);
         if (t.commit_sha) |sha| alloc.free(sha);
+        alloc.free(t.host);
     }
     alloc.free(taps);
 }


### PR DESCRIPTION
## Description

Lets users register a tap hosted on a non-GitHub forge: `mt tap <slug> --host <host> --repo <owner>/<repo>` or `mt tap <slug> --url https://<host>/<owner>/<repo>`. The chosen host is persisted and the GitHub-specific `homebrew-<repo>` name synthesis is skipped for non-GitHub hosts, where that convention doesn't apply. GitHub registration is unchanged. `mt tap --list` and `--json` now surface the host.

Because the GitLab/Codeberg resolvers don't exist yet, a non-GitHub
registration persists the row unpinned and prints a clear "stored but not yet
fetchable" message rather than running a GitHub-shaped HEAD resolve against the
wrong API. `--host` accepts any bare HTTPS host (no scheme or path).

## Related Issue

- None

## Notes for Reviewers

- None