### PR TITLE
refactor(net,core/forge): attach forge auth explicitly, harden host-match

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -231,6 +231,7 @@ pub fn build(b: *std.Build) void {
         "tests/install_keg_from_bottle_test.zig",
         "tests/install_pool_test.zig",
         "tests/tap_head_etag_integration_test.zig",
+        "tests/tap_raw_rb_auth_test.zig",
         "tests/linker_isolation_test.zig",
         "tests/install_isolation_test.zig",
         "tests/doctor_isolation_test.zig",

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -228,7 +228,7 @@ fn installTapRb(
         if ((tap_mod.getCommitSha(allocator, db, tap_slug) catch null)) |cached| {
             break :blk cached;
         }
-        var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, null) catch |e| {
+        var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.forge, urls.api_head_url, null) catch |e| {
             sink.err("Could not resolve {s}'s HEAD commit: {s}", .{ tap_slug, tap_mod.describeResolveError(e) });
             return mapTapResolveError(e);
         };
@@ -256,20 +256,20 @@ fn installTapRb(
     var url_buf: [512]u8 = undefined;
     const rb_url = forge.rawFileUrl(
         &url_buf,
-        .github,
+        urls.forge,
         urls.raw_base,
         commit_sha,
         initial_kind,
         parts.formula,
     ) catch return InstallError.FormulaNotFound;
 
-    var rb_resp = http.get(rb_url) catch {
+    var rb_resp = tap_mod.getRawFile(&http, ctx.environ, urls.forge, rb_url) catch {
         sink.err("Cannot fetch tap from GitHub", .{});
         return InstallError.FormulaNotFound;
     };
     defer rb_resp.deinit();
 
-    // Distinct handle for the Casks/ retry: each http.get() pairs with
+    // Distinct handle for the Casks/ retry: each fetch pairs with
     // its own defer, so a future reorder cannot turn the previous
     // single-`resp` reuse into a double-free or use-after-free.
     var cask_resp: ?client_mod.Response = null;
@@ -284,14 +284,14 @@ fn installTapRb(
 
         const cask_url = forge.rawFileUrl(
             &url_buf,
-            .github,
+            urls.forge,
             urls.raw_base,
             commit_sha,
             .cask,
             parts.formula,
         ) catch return InstallError.FormulaNotFound;
 
-        cask_resp = http.get(cask_url) catch {
+        cask_resp = tap_mod.getRawFile(&http, ctx.environ, urls.forge, cask_url) catch {
             sink.err("Cannot fetch tap from GitHub", .{});
             return InstallError.FormulaNotFound;
         };

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -476,7 +476,7 @@ const HeadResolverCtx = struct {
         const cached_sha = tap_mod.getCommitSha(a, self.db, tap_label) catch null;
         const cached_etag = tap_mod.getHeadEtag(a, self.db, tap_label) catch null;
 
-        var res = tap_mod.resolveHeadCommit(self.io, self.environ, a, urls.api_head_url, cached_etag) catch |err| {
+        var res = tap_mod.resolveHeadCommit(self.io, self.environ, a, urls.forge, urls.api_head_url, cached_etag) catch |err| {
             warnTapHeadResolveFailed(tap_label, err);
             return null;
         };
@@ -540,9 +540,9 @@ fn tapCaskLatestVersion(
     http.offline = offline;
 
     var rb_url_buf: [512]u8 = undefined;
-    const rb_url = forge.rawFileUrl(&rb_url_buf, .github, urls.raw_base, fresh_sha, .cask, token) catch return null;
+    const rb_url = forge.rawFileUrl(&rb_url_buf, urls.forge, urls.raw_base, fresh_sha, .cask, token) catch return null;
 
-    var rb_resp = http.get(rb_url) catch {
+    var rb_resp = tap_mod.getRawFile(&http, environ, urls.forge, rb_url) catch {
         warnTapCaskFetchFailed(tap_label, token, "Network failure while reading the .rb");
         return null;
     };

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -858,7 +858,7 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
             const cached_etag_opt = tap_mod.getHeadEtag(allocator, &db, name) catch null;
             defer if (cached_etag_opt) |e| allocator.free(e);
 
-            var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, cached_etag_opt) catch |e| {
+            var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.forge, urls.api_head_url, cached_etag_opt) catch |e| {
                 output.err("Could not resolve {s}'s HEAD commit: {s}", .{ name, tap_mod.describeResolveError(e) });
                 // Rebind already moved (owner, repo) and cleared the pin —
                 // the row is unfetchable until `mt tap --refresh {slug}` lands a fresh SHA.
@@ -922,7 +922,9 @@ fn pinTap(
     // null and ignore any etag the server happens to return.
     const commit_url = try tap_mod.resolveCommitUrl(allocator, db, slug, sha);
     defer allocator.free(commit_url);
-    var echoed_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, commit_url, null) catch |e| {
+    // Pinning (`commits/<sha>`) is a GitHub-only verb today, matching
+    // `resolveCommitUrl`'s github-only URL shape.
+    var echoed_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, .github, commit_url, null) catch |e| {
         if (e == error.NotFound) {
             output.err("Cannot pin {s} @ {s}: GitHub has no such commit on this tap.", .{ slug, sha[0..@min(sha.len, 7)] });
         } else {
@@ -1044,7 +1046,7 @@ fn resolveOneHead(
     // If-None-Match so a stale-but-unmoved upstream still surfaces a
     // fresh body and the operator can confirm the tap really hasn't
     // budged. Per task implementation notes.
-    var res = try tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, null);
+    var res = try tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.forge, urls.api_head_url, null);
     defer res.deinit();
     const sha = res.sha orelse return error.MalformedJson;
     const sha_owned = try allocator.dupe(u8, sha);
@@ -1077,7 +1079,7 @@ fn refreshTap(ctx: *const AppCtx, allocator: std.mem.Allocator, db: *sqlite.Data
     // Force fresh: bypass the cached etag so the operator sees the
     // current body. The new etag is still persisted afterwards so the
     // *next* non-refresh resolve can short-circuit.
-    var res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, null) catch |e| {
+    var res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.forge, urls.api_head_url, null) catch |e| {
         output.err("Could not resolve {s}'s HEAD commit: {s}", .{ name, tap_mod.describeResolveError(e) });
         return error.Aborted;
     };

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -474,7 +474,7 @@ fn upgradeTapFormula(
     const cached_etag_opt = tap_mod.getHeadEtag(allocator, db, tap_label) catch null;
     defer if (cached_etag_opt) |e| allocator.free(e);
 
-    var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, cached_etag_opt) catch |e| {
+    var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.forge, urls.api_head_url, cached_etag_opt) catch |e| {
         output.err("Could not resolve {s} HEAD: {s}", .{ tap_label, tap_mod.describeResolveError(e) });
         return error.Aborted;
     };
@@ -575,7 +575,7 @@ fn upgradeRoutedTapCask(
     const cached_etag_opt = tap_mod.getHeadEtag(allocator, db, tap_label) catch null;
     defer if (cached_etag_opt) |e| allocator.free(e);
 
-    var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.api_head_url, cached_etag_opt) catch |e| {
+    var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.forge, urls.api_head_url, cached_etag_opt) catch |e| {
         output.err("Could not resolve {s} HEAD: {s}", .{ tap_label, tap_mod.describeResolveError(e) });
         return error.Aborted;
     };
@@ -590,9 +590,9 @@ fn upgradeRoutedTapCask(
     http.offline = ctx.offline;
 
     var rb_url_buf: [512]u8 = undefined;
-    const rb_url = forge.rawFileUrl(&rb_url_buf, .github, urls.raw_base, fresh_sha, .cask, token) catch return error.Aborted;
+    const rb_url = forge.rawFileUrl(&rb_url_buf, urls.forge, urls.raw_base, fresh_sha, .cask, token) catch return error.Aborted;
 
-    var rb_resp = http.get(rb_url) catch |e| {
+    var rb_resp = tap_mod.getRawFile(&http, ctx.environ, urls.forge, rb_url) catch |e| {
         output.err("Could not fetch {s} from tap {s}: {s}", .{ token, tap_label, @errorName(e) });
         return error.Aborted;
     };

--- a/src/core/forge.zig
+++ b/src/core/forge.zig
@@ -88,6 +88,9 @@ pub fn fromHost(host: []const u8) Forge {
 /// URLs every tap fetch site needs. For raw fetches callers append the
 /// `<sha>/Formula/<name>.rb` (or `Casks/`) tail via `rawFileUrl`.
 pub const TapBaseUrls = struct {
+    /// The forge these URLs were built for. Carried so resolve sites pick
+    /// the right HEAD parse and auth header without re-deriving it.
+    forge: Forge,
     /// `https://api.github.com/repos/<owner>/<repo>/commits/HEAD`
     api_head_url: []const u8,
     /// `https://github.com/<owner>/<repo>` — the URL that actually
@@ -138,16 +141,21 @@ pub fn buildBaseUrls(
             );
             errdefer allocator.free(raw_base);
 
-            return .{ .api_head_url = api_head_url, .repo_url = repo_url, .raw_base = raw_base };
+            return .{ .forge = forge, .api_head_url = api_head_url, .repo_url = repo_url, .raw_base = raw_base };
         },
     }
 }
 
-/// Build the per-forge auth header into `buf` from the forge's token
-/// env var, or null when unset/empty. GitHub: `Authorization: Bearer
-/// <MALT_GITHUB_TOKEN>`. The reach is deliberately narrow — only the
-/// tap-resolution caller passes this header — so the token never leaks
-/// onto unrelated requests.
+/// Auth header for the forge's **API** request (the `commits/HEAD`
+/// call), built into `buf` from the forge's token env var, or null when
+/// unset/empty. The token contract is one env var per forge, keyed by
+/// forge rather than by host, so a self-hosted instance reuses its
+/// forge's var:
+///   - github:   `MALT_GITHUB_TOKEN`   → `Authorization: Bearer <t>`
+///   - gitlab:   `MALT_GITLAB_TOKEN`   → `PRIVATE-TOKEN: <t>`
+///   - codeberg: `MALT_CODEBERG_TOKEN` → `Authorization: token <t>`
+/// The reach is deliberately narrow — only the tap-resolution callers
+/// pass this header — so the token never leaks onto unrelated requests.
 pub fn authHeader(forge: Forge, environ: std.process.Environ, buf: []u8) ?std.http.Header {
     switch (forge) {
         .github => {
@@ -157,6 +165,20 @@ pub fn authHeader(forge: Forge, environ: std.process.Environ, buf: []u8) ?std.ht
             return .{ .name = "Authorization", .value = value };
         },
     }
+}
+
+/// Auth header for a **raw `.rb`** fetch, or null when the forge's raw
+/// host needs none. GitHub serves raw content from a separate public CDN
+/// (`raw.githubusercontent.com`) the API token does not belong to —
+/// attaching it there would only widen the token's reach, so the github
+/// raw fetch stays unauthenticated, exactly as before. Forges whose raw
+/// path lives on the authenticated instance host attach their token here.
+pub fn rawAuthHeader(forge: Forge, environ: std.process.Environ, buf: []u8) ?std.http.Header {
+    _ = environ;
+    _ = buf;
+    return switch (forge) {
+        .github => null,
+    };
 }
 
 /// A 40-char lowercase hex commit SHA — git's printable form. Kept
@@ -302,10 +324,27 @@ test "authHeader github: empty-string token behaves as unset" {
     try std.testing.expect(authHeader(.github, envWith(entries), &buf) == null);
 }
 
+test "rawAuthHeader github: null even when MALT_GITHUB_TOKEN is set" {
+    // The API token belongs to api.github.com, not the raw CDN — the raw
+    // fetch stays unauthenticated so the token's reach never widens.
+    const entries = [_:null]?[*:0]const u8{"MALT_GITHUB_TOKEN=ghp_testtoken"};
+    var buf: [256]u8 = undefined;
+    try std.testing.expect(rawAuthHeader(.github, envWith(entries), &buf) == null);
+    try std.testing.expect(rawAuthHeader(.github, .empty, &buf) == null);
+}
+
 // ── buildBaseUrls (github) ─────────────────────────────────────────
 // The URL triple every tap fetch site needs. Byte shapes are the
 // contract — `core/tap.zig`'s resolve path and every install/upgrade
 // caller depend on them being identical to today.
+
+test "buildBaseUrls github: records the originating forge on the result" {
+    // The row's forge must ride along with the URL triple so resolve sites
+    // (auth + body parse) consult it without re-deriving it from the host.
+    const urls = try buildBaseUrls(std.testing.allocator, .github, "github.com", "o", "r");
+    defer urls.deinit(std.testing.allocator);
+    try std.testing.expectEqual(Forge.github, urls.forge);
+}
 
 test "buildBaseUrls github: builds the api-head / repo / raw triple" {
     const urls = try buildBaseUrls(std.testing.allocator, .github, "github.com", "aeroxy", "ast-outline");

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -412,6 +412,24 @@ fn makeConditional(
     };
 }
 
+test "resolveFromConditional: routes the body through the row's forge parser" {
+    // The forge selects the HEAD parser; a github row reads GitHub's `"sha"`.
+    // A future non-github arm reuses this seam — same wiring, different parse.
+    var resp = try makeConditional(
+        200,
+        false,
+        "{\"sha\":\"0123456789abcdef0123456789abcdef01234567\"}",
+        null,
+    );
+    defer resp.deinit();
+    var res = try resolveFromConditional(std.testing.allocator, .github, resp);
+    defer res.deinit();
+    try std.testing.expectEqualStrings(
+        "0123456789abcdef0123456789abcdef01234567",
+        res.sha.?,
+    );
+}
+
 test "resolveFromConditional: 200 with body+etag yields sha and persists etag" {
     var resp = try makeConditional(
         200,
@@ -421,7 +439,7 @@ test "resolveFromConditional: 200 with body+etag yields sha and persists etag" {
     );
     defer resp.deinit();
 
-    var res = try resolveFromConditional(std.testing.allocator, resp);
+    var res = try resolveFromConditional(std.testing.allocator, .github, resp);
     defer res.deinit();
     try std.testing.expect(!res.not_modified);
     try std.testing.expectEqualStrings(
@@ -440,7 +458,7 @@ test "resolveFromConditional: 200 without etag still yields sha (etag stays null
     );
     defer resp.deinit();
 
-    var res = try resolveFromConditional(std.testing.allocator, resp);
+    var res = try resolveFromConditional(std.testing.allocator, .github, resp);
     defer res.deinit();
     try std.testing.expect(!res.not_modified);
     try std.testing.expect(res.sha != null);
@@ -451,7 +469,7 @@ test "resolveFromConditional: 304 yields not_modified=true, sha=null, etag prese
     var resp = try makeConditional(304, true, "", "W/\"deadbeef\"");
     defer resp.deinit();
 
-    var res = try resolveFromConditional(std.testing.allocator, resp);
+    var res = try resolveFromConditional(std.testing.allocator, .github, resp);
     defer res.deinit();
     try std.testing.expect(res.not_modified);
     try std.testing.expectEqual(@as(?[]const u8, null), res.sha);
@@ -464,7 +482,7 @@ test "resolveFromConditional: 304 without ETag header — caller falls back to c
     var resp = try makeConditional(304, true, "", null);
     defer resp.deinit();
 
-    var res = try resolveFromConditional(std.testing.allocator, resp);
+    var res = try resolveFromConditional(std.testing.allocator, .github, resp);
     defer res.deinit();
     try std.testing.expect(res.not_modified);
     try std.testing.expectEqual(@as(?[]const u8, null), res.etag);
@@ -475,7 +493,7 @@ test "resolveFromConditional: 404 classifies as NotFound" {
     defer resp.deinit();
     try std.testing.expectError(
         TapError.NotFound,
-        resolveFromConditional(std.testing.allocator, resp),
+        resolveFromConditional(std.testing.allocator, .github, resp),
     );
 }
 
@@ -484,7 +502,7 @@ test "resolveFromConditional: 403 classifies as RateLimited" {
     defer resp.deinit();
     try std.testing.expectError(
         TapError.RateLimited,
-        resolveFromConditional(std.testing.allocator, resp),
+        resolveFromConditional(std.testing.allocator, .github, resp),
     );
 }
 
@@ -493,7 +511,7 @@ test "resolveFromConditional: 5xx classifies as ResolveFailed" {
     defer resp.deinit();
     try std.testing.expectError(
         TapError.ResolveFailed,
-        resolveFromConditional(std.testing.allocator, resp),
+        resolveFromConditional(std.testing.allocator, .github, resp),
     );
 }
 
@@ -502,7 +520,7 @@ test "resolveFromConditional: 200 with malformed JSON classifies as MalformedJso
     defer resp.deinit();
     try std.testing.expectError(
         TapError.MalformedJson,
-        resolveFromConditional(std.testing.allocator, resp),
+        resolveFromConditional(std.testing.allocator, .github, resp),
     );
 }
 
@@ -962,12 +980,14 @@ pub const HeadResolution = struct {
     }
 };
 
-/// Convert a `ConditionalResponse` from GitHub's `/commits/HEAD` into a
-/// `HeadResolution`. Pure: takes ownership of `resp.etag` only when the
+/// Convert a forge's `/commits/HEAD` `ConditionalResponse` into a
+/// `HeadResolution`; `forge_kind` selects the body parser. Pure: takes
+/// ownership of `resp.etag` only when the
 /// status is convertible; otherwise reports the classified `TapError`
 /// (`resp.deinit` still frees both body and etag in the error path).
 pub fn resolveFromConditional(
     allocator: std.mem.Allocator,
+    forge_kind: forge.Forge,
     resp: client_mod.ConditionalResponse,
 ) TapError!HeadResolution {
     if (resp.not_modified) {
@@ -986,7 +1006,7 @@ pub fn resolveFromConditional(
 
     if (resp.status != 200) return classifyResolveStatus(resp.status);
 
-    const sha = forge.parseHeadSha(.github, resp.body) orelse return TapError.MalformedJson;
+    const sha = forge.parseHeadSha(forge_kind, resp.body) orelse return TapError.MalformedJson;
     const sha_owned = allocator.dupe(u8, sha) catch return TapError.OutOfMemory;
     errdefer allocator.free(sha_owned);
 
@@ -1003,10 +1023,11 @@ pub fn resolveFromConditional(
     };
 }
 
-/// Ask GitHub for the current HEAD commit of a tap's repo, sending
+/// Ask the forge for the current HEAD commit of a tap's repo, sending
 /// `If-None-Match` when `cached_etag` is set so a stable tap costs
-/// zero rate-limit tokens. Returns a `HeadResolution` so callers can
-/// distinguish "fresh sha" from "304: cached sha is still good".
+/// zero rate-limit tokens. `forge_kind` selects the auth header and HEAD
+/// parser. Returns a `HeadResolution` so callers can distinguish
+/// "fresh sha" from "304: cached sha is still good".
 ///
 /// `api_head_url` must come from `resolveTapBaseUrls` — that single seam
 /// owns the `homebrew-<repo>` synthesis. A bare-args overload that
@@ -1016,22 +1037,43 @@ pub fn resolveHeadCommit(
     io: std.Io,
     environ: std.process.Environ,
     allocator: std.mem.Allocator,
+    forge_kind: forge.Forge,
     api_head_url: []const u8,
     cached_etag: ?[]const u8,
 ) TapError!HeadResolution {
     var http = client_mod.HttpClient.init(io, environ, allocator);
     defer http.deinit();
 
-    // MALT_GITHUB_TOKEN takes precedence; falling through to `extra=&.{}`
-    // lets net/client's HOMEBREW_GITHUB_API_TOKEN auto-inject still apply
-    // — both authenticate against the same 5000/hr quota that 304s don't
-    // touch.
+    // The forge's own token (e.g. MALT_GITHUB_TOKEN) is attached per
+    // request; falling through to `extra=&.{}` lets net/client's
+    // HOMEBREW_GITHUB_API_TOKEN auto-inject still apply for github hosts.
+    // 304s don't spend the rate-limit quota either way.
     var auth_buf: [256]u8 = undefined;
-    var resp = if (forge.authHeader(.github, environ, &auth_buf)) |header| blk: {
+    var resp = if (forge.authHeader(forge_kind, environ, &auth_buf)) |header| blk: {
         const headers = [_]std.http.Header{header};
         break :blk http.getConditional(api_head_url, cached_etag, &headers) catch return TapError.NetworkError;
     } else http.getConditional(api_head_url, cached_etag, &.{}) catch return TapError.NetworkError;
     defer resp.deinit();
 
-    return resolveFromConditional(allocator, resp);
+    return resolveFromConditional(allocator, forge_kind, resp);
+}
+
+/// Fetch a tap's raw `.rb`, attaching the forge's raw-auth header when it
+/// needs one. Auth rides this explicit per-request path so a private
+/// forge whose raw lives on the instance host (e.g. GitLab `PRIVATE-TOKEN`)
+/// is reached without leaning on `net/client`'s host-substring auto-inject.
+/// GitHub's raw CDN needs none, so its fetch is byte-identical to a plain
+/// GET. Caller owns the returned `Response`.
+pub fn getRawFile(
+    http: *client_mod.HttpClient,
+    environ: std.process.Environ,
+    forge_kind: forge.Forge,
+    rb_url: []const u8,
+) !client_mod.Response {
+    var auth_buf: [256]u8 = undefined;
+    if (forge.rawAuthHeader(forge_kind, environ, &auth_buf)) |header| {
+        const headers = [_]std.http.Header{header};
+        return http.getWithHeaders(rb_url, &headers, null);
+    }
+    return http.get(rb_url);
 }

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -310,16 +310,51 @@ pub const HttpClient = struct {
         return w;
     }
 
+    /// Host component of an http(s) URL — no scheme, userinfo, port, or
+    /// path. Null for non-http(s) inputs (never auth-eligible). Strips
+    /// userinfo so `github.com@evil.tld` resolves to its real host
+    /// `evil.tld`, closing the substring-match token leak.
+    fn urlHost(url: []const u8) ?[]const u8 {
+        const after_scheme = if (std.mem.startsWith(u8, url, "https://"))
+            url["https://".len..]
+        else if (std.mem.startsWith(u8, url, "http://"))
+            url["http://".len..]
+        else
+            return null;
+
+        var authority = after_scheme;
+        if (std.mem.indexOfAny(u8, authority, "/?#")) |i| authority = authority[0..i];
+        if (std.mem.lastIndexOfScalar(u8, authority, '@')) |i| authority = authority[i + 1 ..];
+        if (std.mem.lastIndexOfScalar(u8, authority, ':')) |i| authority = authority[0..i];
+        // A trailing dot is the FQDN root form of the same host (`github.com.`).
+        if (authority.len > 0 and authority[authority.len - 1] == '.')
+            authority = authority[0 .. authority.len - 1];
+        return authority;
+    }
+
+    /// True when `url`'s host component is one of the GitHub/Homebrew hosts
+    /// the metadata token is meant for. Matches the *host*, not a substring,
+    /// so a look-alike like `https://github.com.evil.tld/` or a path like
+    /// `https://evil.tld/github.com` never receives the token. Hosts are
+    /// compared case-insensitively (DNS is case-insensitive), so a legit
+    /// host never loses the token to capitalisation.
+    fn githubTokenApplies(url: []const u8) bool {
+        const host = urlHost(url) orelse return false;
+        if (std.ascii.eqlIgnoreCase(host, "github.com")) return true;
+        if (std.ascii.endsWithIgnoreCase(host, ".github.com")) return true;
+        if (std.ascii.eqlIgnoreCase(host, "formulae.brew.sh")) return true;
+        if (std.ascii.eqlIgnoreCase(host, "ghcr.io")) return true;
+        return false;
+    }
+
     /// GET request; auto-injects HOMEBREW_GITHUB_API_TOKEN as Authorization
     /// for GitHub/Homebrew hosts. Caller owns the returned `Response`.
     pub fn get(self: *HttpClient, url: []const u8) !Response {
         if (self.offline) return error.OfflineRequired;
         if (std.process.Environ.getPosix(self.environ, "HOMEBREW_GITHUB_API_TOKEN")) |token| {
-            // Apply token to GitHub and Homebrew API requests
-            if (std.mem.indexOf(u8, url, "github.com") != null or
-                std.mem.indexOf(u8, url, "formulae.brew.sh") != null or
-                std.mem.indexOf(u8, url, "ghcr.io") != null)
-            {
+            // Host-component match, not substring: a look-alike host or a
+            // path containing "github.com" must never receive the token.
+            if (githubTokenApplies(url)) {
                 var auth_buf: [256]u8 = undefined;
                 const auth_value = std.fmt.bufPrint(&auth_buf, "token {s}", .{std.mem.sliceTo(token, 0)}) catch
                     return self.doGet(url, &.{});
@@ -951,6 +986,69 @@ test "HttpClient.offline defaults to false" {
     var http = HttpClient.init(std.Options.debug_io, std.process.Environ.empty, std.testing.allocator);
     defer http.deinit();
     try std.testing.expect(!http.offline);
+}
+
+// ── githubTokenApplies: host-component match ───────────────────────
+// Security-sensitive: a substring match leaked the metadata token to
+// any URL *containing* "github.com" — a look-alike host or even a path
+// segment. The token must ride only on the real GitHub/Homebrew hosts.
+
+test "githubTokenApplies: matches github.com and its api subdomain" {
+    try std.testing.expect(HttpClient.githubTokenApplies("https://github.com/Homebrew/homebrew-core"));
+    try std.testing.expect(HttpClient.githubTokenApplies("https://api.github.com/repos/x/y/commits/HEAD"));
+}
+
+test "githubTokenApplies: matches formulae.brew.sh and ghcr.io" {
+    try std.testing.expect(HttpClient.githubTokenApplies("https://formulae.brew.sh/api/formula/glow.json"));
+    try std.testing.expect(HttpClient.githubTokenApplies("https://ghcr.io/v2/homebrew/core/glow/manifests/1.0"));
+}
+
+test "githubTokenApplies: rejects a look-alike host suffix" {
+    // The core leak: `github.com.evil.tld`'s host is not github.com.
+    try std.testing.expect(!HttpClient.githubTokenApplies("https://github.com.evil.tld/Homebrew/x"));
+    try std.testing.expect(!HttpClient.githubTokenApplies("https://api.github.com.evil.tld/x"));
+}
+
+test "githubTokenApplies: rejects the host in userinfo or path" {
+    // userinfo before '@' is not the host; a path segment is not the host.
+    try std.testing.expect(!HttpClient.githubTokenApplies("https://github.com@evil.tld/x"));
+    try std.testing.expect(!HttpClient.githubTokenApplies("https://evil.tld/github.com"));
+}
+
+test "githubTokenApplies: rejects non-forge and raw hosts" {
+    // raw.githubusercontent.com is a different host and was never matched.
+    try std.testing.expect(!HttpClient.githubTokenApplies("https://raw.githubusercontent.com/x/y/HEAD/F.rb"));
+    try std.testing.expect(!HttpClient.githubTokenApplies("https://gitlab.com/o/r"));
+    try std.testing.expect(!HttpClient.githubTokenApplies("https://example.com/x"));
+}
+
+test "githubTokenApplies: tolerates a port and matches the host" {
+    try std.testing.expect(HttpClient.githubTokenApplies("https://github.com:443/x"));
+    try std.testing.expect(!HttpClient.githubTokenApplies("https://github.com.evil.tld:8443/x"));
+}
+
+test "githubTokenApplies: matches a host-only URL with no path" {
+    try std.testing.expect(HttpClient.githubTokenApplies("https://github.com"));
+}
+
+test "githubTokenApplies: rejects non-http(s) schemes and empty input" {
+    // urlHost only resolves http(s); anything else is never auth-eligible.
+    try std.testing.expect(!HttpClient.githubTokenApplies("git://github.com/x"));
+    try std.testing.expect(!HttpClient.githubTokenApplies("ssh://git@github.com/x"));
+    try std.testing.expect(!HttpClient.githubTokenApplies(""));
+}
+
+test "githubTokenApplies: host comparison is case-insensitive (no token lost to caps)" {
+    try std.testing.expect(HttpClient.githubTokenApplies("https://GitHub.com/Homebrew/x"));
+    try std.testing.expect(HttpClient.githubTokenApplies("https://API.GITHUB.COM/repos/x"));
+    // ...but a capitalised look-alike is still rejected.
+    try std.testing.expect(!HttpClient.githubTokenApplies("https://GitHub.com.evil.tld/x"));
+}
+
+test "githubTokenApplies: tolerates the FQDN trailing-dot root form" {
+    try std.testing.expect(HttpClient.githubTokenApplies("https://github.com./x"));
+    try std.testing.expect(HttpClient.githubTokenApplies("https://api.github.com./x"));
+    try std.testing.expect(!HttpClient.githubTokenApplies("https://github.com.evil.tld./x"));
 }
 
 test "HttpClient.get returns OfflineRequired when offline is set" {

--- a/tests/tap_head_etag_integration_test.zig
+++ b/tests/tap_head_etag_integration_test.zig
@@ -75,7 +75,7 @@ test "304 response: caller keeps cached sha, no DB write happens" {
         .allocator = testing.allocator,
     };
     defer resp.deinit();
-    var res = try tap.resolveFromConditional(testing.allocator, resp);
+    var res = try tap.resolveFromConditional(testing.allocator, .github, resp);
     defer res.deinit();
     try testing.expect(res.not_modified);
     try testing.expectEqual(@as(?[]const u8, null), res.sha);
@@ -107,7 +107,7 @@ test "cache-bust: a clobbered etag triggers a 200 path that updates both fields"
         .allocator = testing.allocator,
     };
     defer resp.deinit();
-    var res = try tap.resolveFromConditional(testing.allocator, resp);
+    var res = try tap.resolveFromConditional(testing.allocator, .github, resp);
     defer res.deinit();
     try testing.expect(!res.not_modified);
     try testing.expectEqualStrings(moved_sha, res.sha.?);
@@ -144,7 +144,7 @@ test "server omits ETag on 200: sha persists, etag column is cleared" {
         .allocator = testing.allocator,
     };
     defer resp.deinit();
-    var res = try tap.resolveFromConditional(testing.allocator, resp);
+    var res = try tap.resolveFromConditional(testing.allocator, .github, resp);
     defer res.deinit();
     try tap.updateHead(&db, "aeroxy/tap", res.sha.?, res.etag);
 

--- a/tests/tap_raw_rb_auth_test.zig
+++ b/tests/tap_raw_rb_auth_test.zig
@@ -1,0 +1,75 @@
+//! malt — offline integration test for tap raw-`.rb` fetch auth.
+//! Stands up a localhost `std.http.Server` that records the request's
+//! Authorization header, then drives `tap.getRawFile` to prove GitHub's
+//! raw fetch stays unauthenticated even when `MALT_GITHUB_TOKEN` is set:
+//! the API token belongs to api.github.com, not the raw CDN, so routing
+//! raw through the forge seam must not widen the token's reach. Forges
+//! whose raw lives on the authenticated instance host attach their token
+//! via `forge.rawAuthHeader`; that positive path arrives with those arms.
+
+const std = @import("std");
+const malt = @import("malt");
+const client = malt.client;
+const tap = malt.tap;
+const net = std.Io.net;
+
+const body_rb = "class Glow < Formula\nend\n";
+
+const Fixture = struct {
+    io: std.Io,
+    listener: *net.Server,
+    saw_auth: bool = false,
+};
+
+// Serves one request, recording whether it carried an Authorization
+// header before responding. Errors are swallowed: a failed serve
+// surfaces as a client-side assertion failure in the test thread.
+fn serveOnce(fx: *Fixture) void {
+    const stream = fx.listener.accept(fx.io) catch return;
+    defer stream.close(fx.io);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var reader = stream.reader(fx.io, &rbuf);
+    var writer = stream.writer(fx.io, &wbuf);
+    var srv = std.http.Server.init(&reader.interface, &writer.interface);
+    var req = srv.receiveHead() catch return;
+    var it = req.iterateHeaders();
+    while (it.next()) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, "authorization")) fx.saw_auth = true;
+    }
+    req.respond(body_rb, .{}) catch return;
+}
+
+fn envWithToken() std.process.Environ {
+    const entries = [_:null]?[*:0]const u8{"MALT_GITHUB_TOKEN=ghp_rawtoken"};
+    return .{ .block = .{ .slice = entries[0..1 :null] } };
+}
+
+test "getRawFile: github raw fetch carries no auth header even with MALT_GITHUB_TOKEN set" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var fx = Fixture{ .io = io, .listener = &listener };
+    const server_thread = try std.Thread.spawn(.{}, serveOnce, .{&fx});
+    defer server_thread.join();
+
+    var url_buf: [80]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/Formula/glow.rb", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, envWithToken(), std.testing.allocator);
+    defer http.deinit();
+
+    var resp = try tap.getRawFile(&http, envWithToken(), .github, url);
+    defer resp.deinit();
+    try std.testing.expectEqual(@as(u16, 200), resp.status);
+    try std.testing.expectEqualStrings(body_rb, resp.body);
+    // The API token must not ride the raw fetch — github raw is unchanged.
+    try std.testing.expect(!fx.saw_auth);
+}


### PR DESCRIPTION
## Description

Consolidates forge authentication so every tap request attaches its credential explicitly, and tightens the metadata-token host check so it can only fire on the real GitHub/Homebrew hosts.

- Tap HEAD resolution now carries the forge's auth header per request, selected from the tap row's forge rather than a hardcoded GitHub path. The row's forge rides alongside the resolved URLs, so the auth header and the HEAD-body parser are both chosen from it.

GitHub tap behaviour is unchanged for legitimate hosts; the only observable delta is that the token is no longer attached to look-alike or path hosts.

## Related Issue

- None

## Notes for Reviewers

- None
