### PR TITLE
feat(core/forge): resolve taps hosted on Codeberg/Forgejo

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -233,6 +233,7 @@ pub fn build(b: *std.Build) void {
         "tests/tap_head_etag_integration_test.zig",
         "tests/tap_raw_rb_auth_test.zig",
         "tests/tap_gitlab_resolution_test.zig",
+        "tests/tap_codeberg_resolution_test.zig",
         "tests/linker_isolation_test.zig",
         "tests/install_isolation_test.zig",
         "tests/doctor_isolation_test.zig",

--- a/scripts/fixtures/codeberg_commits_head.json
+++ b/scripts/fixtures/codeberg_commits_head.json
@@ -1,0 +1,1 @@
+[{"sha":"0123456789abcdef0123456789abcdef01234567","url":"https://codeberg.org/api/v1/repos/grp/tap/git/commits/0123456789abcdef0123456789abcdef01234567","created":"2026-05-01T12:00:00Z","commit":{"message":"Update glow to 1.5.1\n","tree":{"sha":"fedcba9876543210fedcba9876543210fedcba98"}},"author":{"login":"maint"}}]

--- a/scripts/regressions/tap_codeberg_resolution.sh
+++ b/scripts/regressions/tap_codeberg_resolution.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Lock the Codeberg/Forgejo tap registration + resolution-URL contract,
+# no network.
+#
+# Resolution itself fetches over HTTPS, so it can't run offline through the
+# binary; the deterministic, offline-observable contract is the persisted
+# browse URL `mt tap --json` projects from (host, owner, repo, forge). That
+# URL is exactly what drives resolution, so pinning it here guards the
+# Codeberg arm without a live request (the HTTP round-trip is covered by the
+# recorded-response integration test `tests/tap_codeberg_resolution_test.zig`).
+#
+# Pinned behaviour:
+#   1. A codeberg.org tap projects a codeberg.org browse URL (not
+#      github-shaped), no `homebrew-` synthesis, unpinned.
+#   2. A self-hosted Forgejo instance with `--forge codeberg` projects the
+#      instance host's browse URL — the hint picks Codeberg where the host
+#      name (not codeberg.org) can't.
+#
+# Usage: scripts/regressions/tap_codeberg_resolution.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+PREFIX=$(mktemp -d -t mt_codeberg.XXXXXX)
+mkdir -p "$PREFIX/db"
+trap 'rm -rf "$PREFIX"' EXIT
+export MALT_PREFIX="$PREFIX"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+# 1. codeberg.org tap: codeberg-shaped browse URL, no homebrew- synthesis.
+"$MALT_BIN" tap grp/tap --host codeberg.org --repo grp/tap >/dev/null 2>&1 ||
+  fail 'mt tap --host codeberg.org --repo grp/tap exited non-zero'
+
+json=$("$MALT_BIN" tap --json)
+printf '%s' "$json" | grep -q '"host":"codeberg.org"' || fail 'codeberg.org tap host not surfaced'
+printf '%s' "$json" | grep -q '"url":"https://codeberg.org/grp/tap"' ||
+  fail 'codeberg.org tap did not project a codeberg.org browse URL'
+printf '%s' "$json" | grep -q '"commit_sha":null' || fail 'codeberg.org tap should be unpinned'
+printf '%s' "$json" | grep -q 'homebrew-' && fail 'unexpected homebrew- synthesis for a codeberg tap'
+
+# 2. self-hosted Forgejo: --forge codeberg pins Gitea where the host can't.
+"$MALT_BIN" tap team/tap --host git.example.org --forge codeberg --repo team/tap >/dev/null 2>&1 ||
+  fail 'mt tap --host git.example.org --forge codeberg --repo team/tap exited non-zero'
+
+json=$("$MALT_BIN" tap --json)
+printf '%s' "$json" | grep -q '"host":"git.example.org"' || fail 'self-hosted Forgejo host not surfaced'
+printf '%s' "$json" | grep -q '"url":"https://git.example.org/team/tap"' ||
+  fail '--forge codeberg did not project the instance-host browse URL'
+
+# Forge hint persisted on the row (best-effort: only when sqlite3 is present).
+if command -v sqlite3 >/dev/null; then
+  stored=$(sqlite3 "$PREFIX/db/malt.db" "SELECT forge FROM taps WHERE name='team/tap';" 2>/dev/null || true)
+  [[ "$stored" == "codeberg" ]] || fail "expected stored forge 'codeberg', got '$stored'"
+fi
+
+printf 'OK: Codeberg tap registration projects forge-correct URLs and --forge pins self-hosted Forgejo.\n'

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -435,7 +435,7 @@ pub const zsh_script =
     \\                        '--pin[Explicitly pin <slug> to <sha>]' \
     \\                        '--repo[Point the tap at owner/exact-repo (no homebrew- prefix)]:owner/exact-repo:' \
     \\                        '--host[Register the tap on a non-GitHub forge (e.g. gitlab.com)]:forge-host:' \
-    \\                        '--forge[Pin the provider for a custom-domain host]:provider:(github gitlab)' \
+    \\                        '--forge[Pin the provider for a custom-domain host]:provider:(github gitlab codeberg)' \
     \\                        '--url[Derive (host, owner, repo) from a full repo URL]:repo-url:' \
     \\                        '--force[Rebind an existing tap to a new --repo target]' \
     \\                        '(--yes -y)'{--yes,-y}'[Confirm --refresh --all apply]' \
@@ -655,7 +655,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -l pin     -d 'Explicitly pin <slug> to <sha>'
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -l repo    -x -d 'Point the tap at owner/exact-repo (no homebrew- prefix)'
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -l host    -x -d 'Register the tap on a non-GitHub forge (e.g. gitlab.com)'
-    \\    complete -c $__malt_bin -n '__malt_using_command tap' -l forge   -x -a 'github gitlab' -d 'Pin the provider for a custom-domain host'
+    \\    complete -c $__malt_bin -n '__malt_using_command tap' -l forge   -x -a 'github gitlab codeberg' -d 'Pin the provider for a custom-domain host'
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -l url     -x -d 'Derive (host, owner, repo) from a full repo URL'
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -l force   -d 'Rebind an existing tap to a new --repo target'
     \\    complete -c $__malt_bin -n '__malt_using_command tap' -s y -l yes -d 'Confirm --refresh --all apply'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -319,10 +319,12 @@ const tap_help =
     \\                       explicit --repo — the `homebrew-<repo>` default
     \\                       only applies to github.com. The tap registers
     \\                       unpinned; `mt tap --refresh <slug>` pins its HEAD.
-    \\  --forge <provider>   Pin the forge explicitly (github or gitlab) when
-    \\                       the host can't reveal it — a custom-domain GitLab
-    \\                       like code.acme.com. gitlab.* hosts auto-classify,
-    \\                       so this is only needed for non-obvious domains.
+    \\  --forge <provider>   Pin the forge explicitly (github, gitlab, or
+    \\                       codeberg) when the host can't reveal it — a
+    \\                       custom-domain GitLab like code.acme.com or a
+    \\                       self-hosted Forgejo/Gitea. gitlab.* and
+    \\                       codeberg.org auto-classify, so this is only
+    \\                       needed for non-obvious domains.
     \\  --url <repo-url>     Derive (host, owner, repo) from a full
     \\                       `https://<host>/<owner>/<repo>` URL instead of
     \\                       naming --host and --repo separately.

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -710,7 +710,7 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
             return error.Aborted;
         }
         forge_hint = std.meta.stringToEnum(forge.Forge, f) orelse {
-            output.err("Unknown --forge '{s}'. Supported: github, gitlab.", .{f});
+            output.err("Unknown --forge '{s}'. Supported: github, gitlab, codeberg.", .{f});
             return error.Aborted;
         };
     }

--- a/src/core/forge.zig
+++ b/src/core/forge.zig
@@ -9,8 +9,8 @@ const std = @import("std");
 
 /// Source forge hosting a tap repo. Each variant forces an
 /// exhaustive-switch compile error until every concern below handles it,
-/// so a new forge (Codeberg next) can never be half-wired.
-pub const Forge = enum { github, gitlab };
+/// so a new forge can never be half-wired.
+pub const Forge = enum { github, gitlab, codeberg };
 
 const github_browse_fmt = "https://github.com/{s}/{s}";
 // GitLab's browse, repo, and `/-/raw` URLs all share the instance host,
@@ -28,7 +28,8 @@ pub fn repoBrowseUrl(
 ) std.fmt.BufPrintError![]const u8 {
     return switch (forge) {
         .github => std.fmt.bufPrint(buf, github_browse_fmt, .{ owner, repo }),
-        .gitlab => std.fmt.bufPrint(buf, gitlab_browse_fmt, .{ host, owner, repo }),
+        // gitlab and codeberg both browse at the instance host.
+        .gitlab, .codeberg => std.fmt.bufPrint(buf, gitlab_browse_fmt, .{ host, owner, repo }),
     };
 }
 
@@ -43,7 +44,7 @@ pub fn allocRepoBrowseUrl(
 ) std.mem.Allocator.Error![]const u8 {
     return switch (forge) {
         .github => std.fmt.allocPrint(allocator, github_browse_fmt, .{ owner, repo }),
-        .gitlab => std.fmt.allocPrint(allocator, gitlab_browse_fmt, .{ host, owner, repo }),
+        .gitlab, .codeberg => std.fmt.allocPrint(allocator, gitlab_browse_fmt, .{ host, owner, repo }),
     };
 }
 
@@ -74,9 +75,9 @@ pub fn rawFileUrl(
     name: []const u8,
 ) std.fmt.BufPrintError![]const u8 {
     return switch (forge) {
-        // Same tail for both: the forge-specific infix already lives in
-        // `raw_base` (github: bare; gitlab: `/-/raw`).
-        .github, .gitlab => std.fmt.bufPrint(buf, "{s}/{s}/{s}/{s}.rb", .{
+        // Same tail for all: the forge-specific infix already lives in
+        // `raw_base` (github: bare; gitlab: `/-/raw`; codeberg: `/raw`).
+        .github, .gitlab, .codeberg => std.fmt.bufPrint(buf, "{s}/{s}/{s}/{s}.rb", .{
             raw_base, sha, kind.subdir(), name,
         }),
     };
@@ -89,6 +90,10 @@ pub fn fromHost(host: []const u8) Forge {
     // Narrow `gitlab.` prefix (covers gitlab.com and self-hosted
     // gitlab.<org>); a look-alike like notgitlab.com must not match.
     if (std.mem.startsWith(u8, host, "gitlab.")) return .gitlab;
+    // codeberg.org is the only name-detectable Gitea host; an exact match
+    // keeps a look-alike like notcodeberg.org from auto-classifying.
+    // Self-hosted Forgejo uses explicit `--forge codeberg` registration.
+    if (std.mem.eql(u8, host, "codeberg.org")) return .codeberg;
     return .github;
 }
 
@@ -207,6 +212,26 @@ pub fn buildBaseUrls(
 
             return .{ .forge = forge, .api_head_url = api_head_url, .repo_url = repo_url, .raw_base = raw_base };
         },
+        .codeberg => {
+            // Gitea's v1 API keys by plain owner/repo (no URL-encoding,
+            // unlike gitlab); `commits?limit=1` returns a one-element array
+            // so HEAD costs one round-trip. Raw has no `/-/` infix. All
+            // three URLs ride the row's `host` for self-hosted Forgejo.
+            const api_head_url = try std.fmt.allocPrint(
+                allocator,
+                "https://{s}/api/v1/repos/{s}/{s}/commits?limit=1&stat=false",
+                .{ host, owner, repo },
+            );
+            errdefer allocator.free(api_head_url);
+
+            const repo_url = try std.fmt.allocPrint(allocator, gitlab_browse_fmt, .{ host, owner, repo });
+            errdefer allocator.free(repo_url);
+
+            const raw_base = try std.fmt.allocPrint(allocator, "https://{s}/{s}/{s}/raw", .{ host, owner, repo });
+            errdefer allocator.free(raw_base);
+
+            return .{ .forge = forge, .api_head_url = api_head_url, .repo_url = repo_url, .raw_base = raw_base };
+        },
     }
 }
 
@@ -229,6 +254,7 @@ pub fn authHeader(forge: Forge, environ: std.process.Environ, buf: []u8) ?std.ht
             return .{ .name = "Authorization", .value = value };
         },
         .gitlab => return gitlabPrivateToken(environ, buf),
+        .codeberg => return codebergToken(environ, buf),
     }
 }
 
@@ -243,6 +269,17 @@ fn gitlabPrivateToken(environ: std.process.Environ, buf: []u8) ?std.http.Header 
     return .{ .name = "PRIVATE-TOKEN", .value = value };
 }
 
+/// Gitea/Forgejo's `Authorization: token <PAT>` header from
+/// `MALT_CODEBERG_TOKEN`, or null when unset/empty. Shared by the API and
+/// the instance-host raw fetch — both authenticate the same way, against
+/// the same host. The `token` scheme is Gitea's, not github's `Bearer`.
+fn codebergToken(environ: std.process.Environ, buf: []u8) ?std.http.Header {
+    const raw = std.process.Environ.getPosix(environ, "MALT_CODEBERG_TOKEN") orelse return null;
+    if (raw.len == 0) return null;
+    const value = std.fmt.bufPrint(buf, "token {s}", .{raw}) catch return null;
+    return .{ .name = "Authorization", .value = value };
+}
+
 /// Auth header for a **raw `.rb`** fetch, or null when the forge's raw
 /// host needs none. GitHub serves raw content from a separate public CDN
 /// (`raw.githubusercontent.com`) the API token does not belong to —
@@ -253,6 +290,8 @@ pub fn rawAuthHeader(forge: Forge, environ: std.process.Environ, buf: []u8) ?std
     return switch (forge) {
         .github => null,
         .gitlab => gitlabPrivateToken(environ, buf),
+        // Gitea serves `/raw` from the authenticated instance host, like gitlab.
+        .codeberg => codebergToken(environ, buf),
     };
 }
 
@@ -287,9 +326,12 @@ fn firstShaField(body: []const u8, marker: []const u8) ?[]const u8 {
 /// Pull the HEAD commit sha out of a forge's `commits/HEAD` response, as
 /// the caller dupes it. The shape differs only in the leading key:
 /// GitHub emits `"sha"` first; GitLab emits `"id"` (not `sha`) first.
+/// Codeberg/Gitea wraps the same GitHub-shaped `"sha"` in a one-element
+/// array, so the first-field scan finds it without parsing the array — an
+/// empty `[]` simply has no `"sha"` and falls through to null.
 pub fn parseHeadSha(forge: Forge, body: []const u8) ?[]const u8 {
     return switch (forge) {
-        .github => firstShaField(body, "\"sha\""),
+        .github, .codeberg => firstShaField(body, "\"sha\""),
         .gitlab => firstShaField(body, "\"id\""),
     };
 }
@@ -711,4 +753,176 @@ test "rawFileUrl gitlab: cask kind builds the /-/raw Casks tail" {
         gitlab_raw_base ++ "/" ++ raw_sha_fixture ++ "/Casks/glow.rb",
         url,
     );
+}
+
+// ── fromHost (codeberg) ────────────────────────────────────────────
+// codeberg.org is the only name-detectable Gitea host. Self-hosted
+// Forgejo/Gitea instances aren't, so they reach `.codeberg` only via
+// explicit `--forge codeberg` registration, never host sniffing.
+
+test "fromHost classifies codeberg.org as .codeberg" {
+    try std.testing.expectEqual(Forge.codeberg, fromHost("codeberg.org"));
+}
+
+test "fromHost leaves an unnamed Forgejo host as .github" {
+    // A self-hosted Gitea like git.example.org isn't name-detectable; it
+    // must be registered with `--forge codeberg`, not auto-classified.
+    try std.testing.expectEqual(Forge.github, fromHost("git.example.org"));
+}
+
+test "fromHost leaves a codeberg look-alike host as .github" {
+    // Exact host match, not a substring: `notcodeberg.org` must not match.
+    try std.testing.expectEqual(Forge.github, fromHost("notcodeberg.org"));
+}
+
+// ── parseHeadSha (codeberg) ────────────────────────────────────────
+// Gitea's `commits?limit=1` returns a JSON *array*; the head sha is the
+// first element's top-level `"sha"` (GitHub-shaped, unlike gitlab's id).
+// Same untrusted-input discipline: empty array / malformed entry → null
+// so resolve reports MalformedJson rather than pinning a bad sha.
+
+test "parseHeadSha codeberg: single-element commits array yields the sha" {
+    const body =
+        \\[{"sha":"0123456789abcdef0123456789abcdef01234567","commit":{"message":"x"}}]
+    ;
+    const got = parseHeadSha(.codeberg, body) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(valid_sha_fixture, got);
+}
+
+test "parseHeadSha codeberg: picks the element's top-level sha, not a nested tree sha" {
+    const body =
+        \\[{"sha":"0123456789abcdef0123456789abcdef01234567","commit":{"tree":{"sha":"ffffffffffffffffffffffffffffffffffffffff"}}}]
+    ;
+    const got = parseHeadSha(.codeberg, body) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(valid_sha_fixture, got);
+}
+
+test "parseHeadSha codeberg: empty array yields null" {
+    try std.testing.expectEqual(@as(?[]const u8, null), parseHeadSha(.codeberg, "[]"));
+}
+
+test "parseHeadSha codeberg: malformed sha entry yields null" {
+    const body =
+        \\[{"sha":"not-a-valid-sha"}]
+    ;
+    try std.testing.expectEqual(@as(?[]const u8, null), parseHeadSha(.codeberg, body));
+}
+
+test "parseHeadSha codeberg: empty body yields null" {
+    try std.testing.expectEqual(@as(?[]const u8, null), parseHeadSha(.codeberg, ""));
+}
+
+// ── buildBaseUrls (codeberg) ───────────────────────────────────────
+// Gitea keys its v1 API by plain `{owner}/{repo}` (no URL-encoding,
+// unlike gitlab), serves raw under `/raw` (no `/-/` infix), and browses
+// at the instance host — all driven by the row's `host`, so self-hosted
+// Forgejo resolves against its own domain.
+
+test "buildBaseUrls codeberg: builds the v1 commits / raw / browse triple" {
+    const urls = try buildBaseUrls(std.testing.allocator, .codeberg, "codeberg.org", "o", "r");
+    defer urls.deinit(std.testing.allocator);
+    try std.testing.expectEqual(Forge.codeberg, urls.forge);
+    try std.testing.expectEqualStrings(
+        "https://codeberg.org/api/v1/repos/o/r/commits?limit=1&stat=false",
+        urls.api_head_url,
+    );
+    try std.testing.expectEqualStrings("https://codeberg.org/o/r", urls.repo_url);
+    try std.testing.expectEqualStrings("https://codeberg.org/o/r/raw", urls.raw_base);
+}
+
+test "buildBaseUrls codeberg: a self-hosted Forgejo host drives every URL" {
+    const urls = try buildBaseUrls(std.testing.allocator, .codeberg, "git.example.org", "team", "tap");
+    defer urls.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings(
+        "https://git.example.org/api/v1/repos/team/tap/commits?limit=1&stat=false",
+        urls.api_head_url,
+    );
+    try std.testing.expectEqualStrings("https://git.example.org/team/tap", urls.repo_url);
+    try std.testing.expectEqualStrings("https://git.example.org/team/tap/raw", urls.raw_base);
+}
+
+fn buildCodebergAndFree(allocator: std.mem.Allocator) !void {
+    const urls = try buildBaseUrls(allocator, .codeberg, "codeberg.org", "grp", "tap");
+    urls.deinit(allocator);
+}
+
+test "buildBaseUrls codeberg: no leak on any allocation failure" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, buildCodebergAndFree, .{});
+}
+
+// ── browse URL (codeberg) ──────────────────────────────────────────
+// Like gitlab, the instance host (not a literal) drives the browse URL.
+
+test "repoBrowseUrl codeberg: the instance host drives the browse URL" {
+    var buf: [256]u8 = undefined;
+    const url = try repoBrowseUrl(&buf, .codeberg, "codeberg.org", "grp", "tap");
+    try std.testing.expectEqualStrings("https://codeberg.org/grp/tap", url);
+}
+
+test "allocRepoBrowseUrl codeberg: allocates the instance-host browse URL" {
+    const url = try allocRepoBrowseUrl(std.testing.allocator, .codeberg, "git.example.org", "team", "tap");
+    defer std.testing.allocator.free(url);
+    try std.testing.expectEqualStrings("https://git.example.org/team/tap", url);
+}
+
+// ── rawFileUrl (codeberg) ──────────────────────────────────────────
+// Gitea's raw route has no `/-/` infix; raw_base already ends in `/raw`,
+// so the shared tail appends `<sha>/Formula/<name>.rb`.
+
+const codeberg_raw_base = "https://codeberg.org/grp/tap/raw";
+
+test "rawFileUrl codeberg: formula kind builds the /raw Formula tail" {
+    var buf: [512]u8 = undefined;
+    const url = try rawFileUrl(&buf, .codeberg, codeberg_raw_base, raw_sha_fixture, .formula, "glow");
+    try std.testing.expectEqualStrings(
+        codeberg_raw_base ++ "/" ++ raw_sha_fixture ++ "/Formula/glow.rb",
+        url,
+    );
+}
+
+test "rawFileUrl codeberg: cask kind builds the /raw Casks tail" {
+    var buf: [512]u8 = undefined;
+    const url = try rawFileUrl(&buf, .codeberg, codeberg_raw_base, raw_sha_fixture, .cask, "glow");
+    try std.testing.expectEqualStrings(
+        codeberg_raw_base ++ "/" ++ raw_sha_fixture ++ "/Casks/glow.rb",
+        url,
+    );
+}
+
+// ── authHeader (codeberg) ──────────────────────────────────────────
+// Gitea/Forgejo authenticate with `Authorization: token <PAT>` — the
+// `token` scheme, not github's `Bearer`. MALT_CODEBERG_TOKEN keys it.
+
+test "authHeader codeberg: null when MALT_CODEBERG_TOKEN unset" {
+    var buf: [256]u8 = undefined;
+    try std.testing.expect(authHeader(.codeberg, .empty, &buf) == null);
+}
+
+test "authHeader codeberg: token header when MALT_CODEBERG_TOKEN set" {
+    const entries = [_:null]?[*:0]const u8{"MALT_CODEBERG_TOKEN=cb_testtoken"};
+    var buf: [256]u8 = undefined;
+    const h = authHeader(.codeberg, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
+    try std.testing.expectEqualStrings("Authorization", h.name);
+    try std.testing.expectEqualStrings("token cb_testtoken", h.value);
+}
+
+test "authHeader codeberg: empty-string token behaves as unset" {
+    const entries = [_:null]?[*:0]const u8{"MALT_CODEBERG_TOKEN="};
+    var buf: [256]u8 = undefined;
+    try std.testing.expect(authHeader(.codeberg, envWith(entries), &buf) == null);
+}
+
+test "rawAuthHeader codeberg: token attached — raw lives on the instance host" {
+    // Gitea serves `/raw` from the authenticated instance host (like gitlab,
+    // unlike github's public CDN), so a private tap's raw fetch carries it.
+    const entries = [_:null]?[*:0]const u8{"MALT_CODEBERG_TOKEN=cb_testtoken"};
+    var buf: [256]u8 = undefined;
+    const h = rawAuthHeader(.codeberg, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
+    try std.testing.expectEqualStrings("Authorization", h.name);
+    try std.testing.expectEqualStrings("token cb_testtoken", h.value);
+}
+
+test "rawAuthHeader codeberg: null when MALT_CODEBERG_TOKEN unset" {
+    var buf: [256]u8 = undefined;
+    try std.testing.expect(rawAuthHeader(.codeberg, .empty, &buf) == null);
 }

--- a/tests/cli_tap_test.zig
+++ b/tests/cli_tap_test.zig
@@ -401,6 +401,27 @@ test "execute --host with --forge persists the explicit provider for a custom do
     try testing.expectEqualStrings("gitlab", stored_forge orelse "");
 }
 
+test "execute --host with --forge codeberg persists the provider for a self-hosted Forgejo" {
+    // A self-hosted Forgejo/Gitea on a custom domain isn't name-detectable,
+    // so --forge codeberg is the only signal; it must persist so resolution
+    // targets the Gitea API, not the github default.
+    const prefix = try setupPrefix("forge_codeberg_register");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try tap_cli.execute(&ctx, testing.allocator, &.{ "team/tap", "--host", "git.example.org", "--forge", "codeberg", "--repo", "team/tap" });
+
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/db/malt.db", .{prefix}, 0);
+    defer testing.allocator.free(db_path);
+    const stored_forge = try readTapForge(db_path, "team/tap");
+    defer if (stored_forge) |f| testing.allocator.free(f);
+    try testing.expectEqualStrings("codeberg", stored_forge orelse "");
+}
+
 test "execute --forge rejects an unknown provider" {
     const prefix = try setupPrefix("forge_unknown");
     defer testing.allocator.free(prefix);

--- a/tests/tap_codeberg_resolution_test.zig
+++ b/tests/tap_codeberg_resolution_test.zig
@@ -1,0 +1,172 @@
+//! malt — offline integration for Codeberg/Forgejo (Gitea) tap resolution.
+//!
+//! Inline tests in `src/core/forge.zig` cover the URL/parse/auth shapes
+//! in isolation; this file pins the assembled HTTP path against a
+//! **recorded** Gitea `commits?limit=1` response (`scripts/fixtures/`),
+//! never live network. It proves three things end-to-end for `.codeberg`:
+//!   1. a recorded `[{"sha":"<sha>"}]` array body resolves to the right
+//!      sha, and that sha builds the right `/raw/.../Formula/<n>.rb` URL;
+//!   2. the API request carries `Authorization: token` when
+//!      MALT_CODEBERG_TOKEN is set;
+//!   3. the raw fetch also carries it — Gitea serves `/raw` from the
+//!      authenticated instance host, unlike github's public raw CDN.
+
+const std = @import("std");
+const testing = std.testing;
+const test_io = @import("test_io");
+
+const malt = @import("malt");
+const client = malt.client;
+const tap = malt.tap;
+const forge = malt.forge;
+const net = std.Io.net;
+
+// The sha recorded in scripts/fixtures/codeberg_commits_head.json.
+const fixture_sha = "0123456789abcdef0123456789abcdef01234567";
+const raw_body = "class Glow < Formula\nend\n";
+
+fn readFixture(allocator: std.mem.Allocator) ![]u8 {
+    const io = std.Options.debug_io;
+    var dir = try test_io.cwd().openDir(io, "scripts/fixtures", .{});
+    defer dir.close(io);
+    const file = try dir.openFile(io, "codeberg_commits_head.json", .{});
+    defer file.close(io);
+    const stat = try file.stat(io);
+    const buf = try allocator.alloc(u8, @intCast(stat.size));
+    errdefer allocator.free(buf);
+    _ = try file.readPositionalAll(io, buf, 0);
+    return buf;
+}
+
+const Fixture = struct {
+    io: std.Io,
+    listener: *net.Server,
+    body: []const u8,
+    // Captured `Authorization` value, if the request carried one.
+    authorization: [128]u8 = undefined,
+    authorization_len: usize = 0,
+};
+
+// Serves one request, recording the request's Authorization header (if
+// any) before responding with `fx.body`. Errors are swallowed: a failed
+// serve surfaces as a client-side assertion failure in the test thread.
+fn serveOnce(fx: *Fixture) void {
+    const stream = fx.listener.accept(fx.io) catch return;
+    defer stream.close(fx.io);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var reader = stream.reader(fx.io, &rbuf);
+    var writer = stream.writer(fx.io, &wbuf);
+    var srv = std.http.Server.init(&reader.interface, &writer.interface);
+    var req = srv.receiveHead() catch return;
+    var it = req.iterateHeaders();
+    while (it.next()) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, "authorization") and h.value.len <= fx.authorization.len) {
+            @memcpy(fx.authorization[0..h.value.len], h.value);
+            fx.authorization_len = h.value.len;
+        }
+    }
+    req.respond(fx.body, .{}) catch return;
+}
+
+fn envWithCodebergToken() std.process.Environ {
+    const entries = [_:null]?[*:0]const u8{"MALT_CODEBERG_TOKEN=cb-itest"};
+    return .{ .block = .{ .slice = entries[0..1 :null] } };
+}
+
+fn listenLocal(io: std.Io) !net.Server {
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    return addr.listen(io, .{ .reuse_address = true });
+}
+
+test "codeberg resolve: a recorded commits array body yields the sha and its raw .rb URL" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const body = try readFixture(testing.allocator);
+    defer testing.allocator.free(body);
+
+    var listener = try listenLocal(io);
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var fx = Fixture{ .io = io, .listener = &listener, .body = body };
+    const server_thread = try std.Thread.spawn(.{}, serveOnce, .{&fx});
+    defer server_thread.join();
+
+    var url_buf: [96]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/api/v1/repos/grp/tap/commits?limit=1&stat=false", .{port});
+
+    var res = try tap.resolveHeadCommit(io, .empty, testing.allocator, .codeberg, url, null);
+    defer res.deinit();
+    try testing.expect(!res.not_modified);
+    try testing.expectEqualStrings(fixture_sha, res.sha.?);
+
+    // The resolved sha builds the forge-correct raw `.rb` URL — the other
+    // half of criterion: registering + resolving yields the right raw URL.
+    var raw_buf: [256]u8 = undefined;
+    const raw_url = try forge.rawFileUrl(
+        &raw_buf,
+        .codeberg,
+        "https://codeberg.org/grp/tap/raw",
+        res.sha.?,
+        .formula,
+        "glow",
+    );
+    try testing.expectEqualStrings(
+        "https://codeberg.org/grp/tap/raw/" ++ fixture_sha ++ "/Formula/glow.rb",
+        raw_url,
+    );
+}
+
+test "codeberg resolve: the API request carries Authorization token when MALT_CODEBERG_TOKEN is set" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const body = try readFixture(testing.allocator);
+    defer testing.allocator.free(body);
+
+    var listener = try listenLocal(io);
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var fx = Fixture{ .io = io, .listener = &listener, .body = body };
+    const server_thread = try std.Thread.spawn(.{}, serveOnce, .{&fx});
+    defer server_thread.join();
+
+    var url_buf: [96]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/api/v1/repos/grp/tap/commits?limit=1&stat=false", .{port});
+
+    var res = try tap.resolveHeadCommit(io, envWithCodebergToken(), testing.allocator, .codeberg, url, null);
+    defer res.deinit();
+    try testing.expectEqualStrings("token cb-itest", fx.authorization[0..fx.authorization_len]);
+}
+
+test "codeberg raw fetch: getRawFile carries Authorization token — raw lives on the instance host" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var listener = try listenLocal(io);
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var fx = Fixture{ .io = io, .listener = &listener, .body = raw_body };
+    const server_thread = try std.Thread.spawn(.{}, serveOnce, .{&fx});
+    defer server_thread.join();
+
+    var url_buf: [96]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/grp/tap/raw/{s}/Formula/glow.rb", .{ port, fixture_sha });
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, envWithCodebergToken(), testing.allocator);
+    defer http.deinit();
+
+    var resp = try tap.getRawFile(&http, envWithCodebergToken(), .codeberg, url);
+    defer resp.deinit();
+    try testing.expectEqual(@as(u16, 200), resp.status);
+    try testing.expectEqualStrings(raw_body, resp.body);
+    try testing.expectEqualStrings("token cb-itest", fx.authorization[0..fx.authorization_len]);
+}


### PR DESCRIPTION
## Description

Adds Codeberg/Forgejo (Gitea API) as a tap forge: a `Forge.codeberg` arm in `core/forge.zig` with the Gitea v1 commits endpoint (single-element array sha), the `/raw/` file layout, the browse URL, host classification, and `token` auth.

Self-hosted Forgejo/Gitea is supported via the per-tap host - auto-classified only for `codeberg.org`, otherwise pinned with `--forge codeberg`. 

## Related Issue

- None

## Notes for Reviewers

- The commit sha comes from a one-element array (`?limit=1`); the test covers the empty-array and malformed cases. The `/branches/{default}` fallback is intentionally not wired - `buildBaseUrls` always emits the single commits call, so the branch shape never arrives.
