### PR TITLE
refactor(core/tap): name the tap's own forge in resolve errors

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -235,6 +235,7 @@ pub fn build(b: *std.Build) void {
         "tests/tap_gitlab_resolution_test.zig",
         "tests/tap_codeberg_resolution_test.zig",
         "tests/tap_pin_forge_test.zig",
+        "tests/tap_resolve_error_test.zig",
         "tests/linker_isolation_test.zig",
         "tests/install_isolation_test.zig",
         "tests/doctor_isolation_test.zig",
@@ -330,7 +331,7 @@ pub fn build(b: *std.Build) void {
     });
     test_io_mod.addImport("malt", malt_lib);
 
-    @setEvalBranchQuota(20000);
+    @setEvalBranchQuota(30000);
     inline for (test_modules) |test_file| {
         // e.g. "tests/formula_test.zig" → "formula_test" (so each test binary
         // has a unique install name, which `test-bin` / kcov need).

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -228,8 +228,9 @@ fn installTapRb(
         if ((tap_mod.getCommitSha(allocator, db, tap_slug) catch null)) |cached| {
             break :blk cached;
         }
+        var rerr_buf: [512]u8 = undefined;
         var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.forge, urls.api_head_url, null) catch |e| {
-            sink.err("Could not resolve {s}'s HEAD commit: {s}", .{ tap_slug, tap_mod.describeResolveError(e) });
+            sink.err("Could not resolve {s}'s HEAD commit: {s}", .{ tap_slug, tap_mod.describeResolveError(&rerr_buf, e, urls.forge, urls.host) });
             return mapTapResolveError(e);
         };
         defer head_res.deinit();

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -440,10 +440,11 @@ test "TapHeadResolve: concurrent same-label calls resolve exactly once" {
 /// the only thing wrong was a transient rate limit. The wording mirrors
 /// `describeResolveError` so the install/upgrade/outdated paths share
 /// one user-actionable line.
-fn warnTapHeadResolveFailed(tap_label: []const u8, err: tap_mod.TapError) void {
+fn warnTapHeadResolveFailed(tap_label: []const u8, err: tap_mod.TapError, forge_kind: forge.Forge, host: []const u8) void {
+    var rerr_buf: [512]u8 = undefined;
     output.warn(
         "Could not resolve {s}'s HEAD: {s}",
-        .{ tap_label, tap_mod.describeResolveError(err) },
+        .{ tap_label, tap_mod.describeResolveError(&rerr_buf, err, forge_kind, host) },
     );
 }
 
@@ -477,19 +478,19 @@ const HeadResolverCtx = struct {
         const cached_etag = tap_mod.getHeadEtag(a, self.db, tap_label) catch null;
 
         var res = tap_mod.resolveHeadCommit(self.io, self.environ, a, urls.forge, urls.api_head_url, cached_etag) catch |err| {
-            warnTapHeadResolveFailed(tap_label, err);
+            warnTapHeadResolveFailed(tap_label, err, urls.forge, urls.host);
             return null;
         };
         defer res.deinit();
 
         const final_sha = if (res.not_modified)
             (cached_sha orelse {
-                warnTapHeadResolveFailed(tap_label, tap_mod.TapError.ResolveFailed);
+                warnTapHeadResolveFailed(tap_label, tap_mod.TapError.ResolveFailed, urls.forge, urls.host);
                 return null;
             })
         else
             (res.sha orelse {
-                warnTapHeadResolveFailed(tap_label, tap_mod.TapError.MalformedJson);
+                warnTapHeadResolveFailed(tap_label, tap_mod.TapError.MalformedJson, urls.forge, urls.host);
                 return null;
             });
 
@@ -812,7 +813,7 @@ test "warnTapHeadResolveFailed surfaces rate-limit reason with the tap label" {
     output.beginStderrCapture(std.testing.allocator, &buf);
     defer output.endStderrCapture();
 
-    warnTapHeadResolveFailed("yuzeguitarist/deck", tap_mod.TapError.RateLimited);
+    warnTapHeadResolveFailed("yuzeguitarist/deck", tap_mod.TapError.RateLimited, .github, "github.com");
 
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "yuzeguitarist/deck") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "Could not resolve") != null);
@@ -825,7 +826,7 @@ test "warnTapHeadResolveFailed surfaces network failure for the regression skip-
     output.beginStderrCapture(std.testing.allocator, &buf);
     defer output.endStderrCapture();
 
-    warnTapHeadResolveFailed("user/repo", tap_mod.TapError.NetworkError);
+    warnTapHeadResolveFailed("user/repo", tap_mod.TapError.NetworkError, .github, "github.com");
 
     // Wording must hit both the user-facing "Could not resolve" header
     // and the existing skip-guard regex (`Network failure`) so the
@@ -833,6 +834,40 @@ test "warnTapHeadResolveFailed surfaces network failure for the regression skip-
     // assertion miss.
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "Could not resolve") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "Network failure") != null);
+}
+
+test "warnTapHeadResolveFailed renders the gitlab host + token on the CLI output path" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    output.beginStderrCapture(std.testing.allocator, &buf);
+    defer output.endStderrCapture();
+
+    warnTapHeadResolveFailed("grp/tap", tap_mod.TapError.RateLimited, .gitlab, "gitlab.com");
+
+    // The whole point: a non-github tap's resolve failure reaches stderr
+    // naming its own host + token var, never GitHub's.
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "grp/tap") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "gitlab.com") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "MALT_GITLAB_TOKEN") != null);
+    // No github host or token leaked — a single "github" substring would
+    // catch either (and avoids hard-coding the token literal the
+    // tap-resolution-contract guard forbids outside the forge seam).
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "github") == null);
+}
+
+test "warnTapHeadResolveFailed keeps the Network-failure skip-guard phrase for codeberg" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    output.beginStderrCapture(std.testing.allocator, &buf);
+    defer output.endStderrCapture();
+
+    warnTapHeadResolveFailed("team/tap", tap_mod.TapError.NetworkError, .codeberg, "git.example.org");
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "git.example.org") != null);
+    // The regressions/*.sh skip-guards grep "Network failure" — it must hold
+    // for every forge, not just github.
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "Network failure") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "Could not resolve") != null);
 }
 
 test "warnTapCaskFetchFailed names both the tap and the token" {

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -899,8 +899,9 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
             const cached_etag_opt = tap_mod.getHeadEtag(allocator, &db, name) catch null;
             defer if (cached_etag_opt) |e| allocator.free(e);
 
+            var rerr_buf: [512]u8 = undefined;
             var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.forge, urls.api_head_url, cached_etag_opt) catch |e| {
-                output.err("Could not resolve {s}'s HEAD commit: {s}", .{ name, tap_mod.describeResolveError(e) });
+                output.err("Could not resolve {s}'s HEAD commit: {s}", .{ name, tap_mod.describeResolveError(&rerr_buf, e, urls.forge, urls.host) });
                 // Rebind already moved (owner, repo) and cleared the pin —
                 // the row is unfetchable until `mt tap --refresh {slug}` lands a fresh SHA.
                 if (rebinding) output.warn("Rebind applied with no pin — run `mt tap --refresh {s}` to recover.", .{name});
@@ -969,11 +970,12 @@ fn pinTap(
     // caching value — pass null and ignore any etag the server returns.
     const commit_url = try tap_mod.resolveCommitUrl(allocator, db, slug, sha);
     defer allocator.free(commit_url);
+    var perr_buf: [512]u8 = undefined;
     var echoed_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, pair.forge, commit_url, null) catch |e| {
         if (e == error.NotFound) {
             output.err("Cannot pin {s} @ {s}: {s} has no such commit on this tap.", .{ slug, sha[0..@min(sha.len, 7)], pair.host });
         } else {
-            output.err("Could not verify {s} @ {s}: {s}", .{ slug, sha[0..@min(sha.len, 7)], tap_mod.describeResolveError(e) });
+            output.err("Could not verify {s} @ {s}: {s}", .{ slug, sha[0..@min(sha.len, 7)], tap_mod.describeResolveError(&perr_buf, e, pair.forge, pair.host) });
         }
         return error.Aborted;
     };
@@ -1122,8 +1124,9 @@ fn refreshTap(ctx: *const AppCtx, allocator: std.mem.Allocator, db: *sqlite.Data
     // Force fresh: bypass the cached etag so the operator sees the
     // current body. The new etag is still persisted afterwards so the
     // *next* non-refresh resolve can short-circuit.
+    var rerr_buf: [512]u8 = undefined;
     var res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.forge, urls.api_head_url, null) catch |e| {
-        output.err("Could not resolve {s}'s HEAD commit: {s}", .{ name, tap_mod.describeResolveError(e) });
+        output.err("Could not resolve {s}'s HEAD commit: {s}", .{ name, tap_mod.describeResolveError(&rerr_buf, e, urls.forge, urls.host) });
         return error.Aborted;
     };
     defer res.deinit();

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -474,8 +474,9 @@ fn upgradeTapFormula(
     const cached_etag_opt = tap_mod.getHeadEtag(allocator, db, tap_label) catch null;
     defer if (cached_etag_opt) |e| allocator.free(e);
 
+    var rerr_buf: [512]u8 = undefined;
     var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.forge, urls.api_head_url, cached_etag_opt) catch |e| {
-        output.err("Could not resolve {s} HEAD: {s}", .{ tap_label, tap_mod.describeResolveError(e) });
+        output.err("Could not resolve {s} HEAD: {s}", .{ tap_label, tap_mod.describeResolveError(&rerr_buf, e, urls.forge, urls.host) });
         return error.Aborted;
     };
     defer head_res.deinit();
@@ -575,8 +576,9 @@ fn upgradeRoutedTapCask(
     const cached_etag_opt = tap_mod.getHeadEtag(allocator, db, tap_label) catch null;
     defer if (cached_etag_opt) |e| allocator.free(e);
 
+    var rerr_buf: [512]u8 = undefined;
     var head_res = tap_mod.resolveHeadCommit(ctx.io, ctx.environ, allocator, urls.forge, urls.api_head_url, cached_etag_opt) catch |e| {
-        output.err("Could not resolve {s} HEAD: {s}", .{ tap_label, tap_mod.describeResolveError(e) });
+        output.err("Could not resolve {s} HEAD: {s}", .{ tap_label, tap_mod.describeResolveError(&rerr_buf, e, urls.forge, urls.host) });
         return error.Aborted;
     };
     defer head_res.deinit();

--- a/src/core/forge.zig
+++ b/src/core/forge.zig
@@ -103,6 +103,9 @@ pub const TapBaseUrls = struct {
     /// The forge these URLs were built for. Carried so resolve sites pick
     /// the right HEAD parse and auth header without re-deriving it.
     forge: Forge,
+    /// The row's host. Carried alongside `forge` so a resolve failure can
+    /// name the tap's own instance without re-reading the row.
+    host: []const u8,
     /// `https://api.github.com/repos/<owner>/<repo>/commits/HEAD`
     api_head_url: []const u8,
     /// `https://github.com/<owner>/<repo>` — the URL that actually
@@ -113,6 +116,7 @@ pub const TapBaseUrls = struct {
     raw_base: []const u8,
 
     pub fn deinit(self: TapBaseUrls, allocator: std.mem.Allocator) void {
+        allocator.free(self.host);
         allocator.free(self.api_head_url);
         allocator.free(self.repo_url);
         allocator.free(self.raw_base);
@@ -163,6 +167,9 @@ pub fn buildBaseUrls(
     owner: []const u8,
     repo: []const u8,
 ) std.mem.Allocator.Error!TapBaseUrls {
+    // Owned so the result survives the caller's borrowed `host`; freed in deinit.
+    const host_owned = try allocator.dupe(u8, host);
+    errdefer allocator.free(host_owned);
     switch (forge) {
         .github => {
             // github hosts are fixed; only the gitlab arm consults `host`.
@@ -187,7 +194,7 @@ pub fn buildBaseUrls(
             );
             errdefer allocator.free(raw_base);
 
-            return .{ .forge = forge, .api_head_url = api_head_url, .repo_url = repo_url, .raw_base = raw_base };
+            return .{ .forge = forge, .host = host_owned, .api_head_url = api_head_url, .repo_url = repo_url, .raw_base = raw_base };
         },
         .gitlab => {
             // Worst case every byte escapes to 3 chars; the "/" separator too.
@@ -210,7 +217,7 @@ pub fn buildBaseUrls(
             const raw_base = try std.fmt.allocPrint(allocator, "https://{s}/{s}/{s}/-/raw", .{ host, owner, repo });
             errdefer allocator.free(raw_base);
 
-            return .{ .forge = forge, .api_head_url = api_head_url, .repo_url = repo_url, .raw_base = raw_base };
+            return .{ .forge = forge, .host = host_owned, .api_head_url = api_head_url, .repo_url = repo_url, .raw_base = raw_base };
         },
         .codeberg => {
             // Gitea's v1 API keys by plain owner/repo (no URL-encoding,
@@ -230,7 +237,7 @@ pub fn buildBaseUrls(
             const raw_base = try std.fmt.allocPrint(allocator, "https://{s}/{s}/{s}/raw", .{ host, owner, repo });
             errdefer allocator.free(raw_base);
 
-            return .{ .forge = forge, .api_head_url = api_head_url, .repo_url = repo_url, .raw_base = raw_base };
+            return .{ .forge = forge, .host = host_owned, .api_head_url = api_head_url, .repo_url = repo_url, .raw_base = raw_base };
         },
     }
 }
@@ -610,6 +617,7 @@ test "buildBaseUrls github: records the originating forge on the result" {
     const urls = try buildBaseUrls(std.testing.allocator, .github, "github.com", "o", "r");
     defer urls.deinit(std.testing.allocator);
     try std.testing.expectEqual(Forge.github, urls.forge);
+    try std.testing.expectEqualStrings("github.com", urls.host);
 }
 
 test "buildBaseUrls github: builds the api-head / repo / raw triple" {
@@ -738,6 +746,8 @@ test "buildBaseUrls gitlab: builds the encoded v4 / raw / browse triple" {
 test "buildBaseUrls gitlab: a self-hosted instance host drives every URL" {
     const urls = try buildBaseUrls(std.testing.allocator, .gitlab, "gitlab.gnome.org", "GNOME", "glib");
     defer urls.deinit(std.testing.allocator);
+    // The instance host rides along so a resolve failure can name it.
+    try std.testing.expectEqualStrings("gitlab.gnome.org", urls.host);
     try std.testing.expectEqualStrings(
         "https://gitlab.gnome.org/api/v4/projects/GNOME%2Fglib/repository/commits/HEAD",
         urls.api_head_url,
@@ -877,6 +887,8 @@ test "buildBaseUrls codeberg: builds the v1 commits / raw / browse triple" {
 test "buildBaseUrls codeberg: a self-hosted Forgejo host drives every URL" {
     const urls = try buildBaseUrls(std.testing.allocator, .codeberg, "git.example.org", "team", "tap");
     defer urls.deinit(std.testing.allocator);
+    // The instance host rides along so a resolve failure can name it.
+    try std.testing.expectEqualStrings("git.example.org", urls.host);
     try std.testing.expectEqualStrings(
         "https://git.example.org/api/v1/repos/team/tap/commits?limit=1&stat=false",
         urls.api_head_url,

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -43,11 +43,23 @@ pub fn classifyResolveStatus(status: u16) TapError {
     };
 }
 
-/// Short remediation hint for each `TapError` variant. Keeping the
-/// strings here (not at the call site) means `cli/install/local.zig`
-/// and `cli/tap.zig` cannot drift out of sync, and unit tests can pin
-/// every tag without touching the network or the UI layer.
-pub fn describeResolveError(err: TapError) []const u8 {
+/// Short remediation hint for each `TapError` variant, naming the tap's
+/// own forge and host so a GitLab/Codeberg failure never reports GitHub
+/// hosts or the wrong token env var. Keeping the strings here (not at the
+/// call site) means every resolve site stays in sync, and unit tests can
+/// pin every tag without touching the network or the UI layer. `buf` holds
+/// the formatted non-github message; it must be ≥ 512 B (a DNS host is
+/// ≤ 253 B, every template < 256 B), so `bufPrint` cannot overflow.
+pub fn describeResolveError(buf: []u8, err: TapError, forge_kind: forge.Forge, host: []const u8) []const u8 {
+    return switch (forge_kind) {
+        .github => githubResolveError(err),
+        .gitlab => forgeResolveError(buf, err, "GitLab", "MALT_GITLAB_TOKEN", host),
+        .codeberg => forgeResolveError(buf, err, "Codeberg", "MALT_CODEBERG_TOKEN", host),
+    };
+}
+
+/// GitHub's resolve hints — fixed hosts, so no `host`/`buf` threading.
+fn githubResolveError(err: TapError) []const u8 {
     return switch (err) {
         error.RateLimited => "GitHub API rate limit reached. Set MALT_GITHUB_TOKEN to an authorized GitHub token to lift the 60/hr anonymous cap.",
         error.NotFound => "GitHub returned 404 for the tap repo. If the repo lives at github.com/<user>/<exact-name> instead of github.com/<user>/homebrew-<repo>, rerun with --repo <user>/<exact-name>.",
@@ -57,6 +69,114 @@ pub fn describeResolveError(err: TapError) []const u8 {
         error.ResolveFailed => "GitHub returned an unexpected status while resolving HEAD — retry, or set MALT_GITHUB_TOKEN if this persists.",
         error.OutOfMemory => "Out of memory while resolving HEAD commit.",
     };
+}
+
+/// Resolve hints for a non-github forge, naming its instance `host` and
+/// per-forge `token_var`. `bufPrint` writes into the caller's `buf`
+/// (≥ 512 B); host is registration-validated to ≤ 253 B and every template
+/// is < 256 B, so the format cannot overflow — same sizing contract as
+/// `forge.encodeProjectPath`'s `catch unreachable`. `NetworkError` keeps the
+/// literal "Network failure" the regression skip-guards key on.
+fn forgeResolveError(
+    buf: []u8,
+    err: TapError,
+    name: []const u8,
+    token_var: []const u8,
+    host: []const u8,
+) []const u8 {
+    return switch (err) {
+        error.RateLimited => std.fmt.bufPrint(buf, "{s} API rate limit reached at {s}. Set {s} to an authorized token to lift the anonymous cap.", .{ name, host, token_var }) catch unreachable,
+        // No homebrew-/--repo hint: that synthesis is github-only.
+        error.NotFound => std.fmt.bufPrint(buf, "{s} returned 404 for the tap repo at {s}. Verify the owner/repo, or set {s} if the repo is private.", .{ name, host, token_var }) catch unreachable,
+        error.NetworkError => std.fmt.bufPrint(buf, "Network failure while reaching {s} — check connectivity and retry.", .{host}) catch unreachable,
+        error.MalformedJson => std.fmt.bufPrint(buf, "Unexpected response shape from {s} ({s}) — rerun with --debug and attach the log when filing an issue.", .{ name, host }) catch unreachable,
+        error.InvalidSha => std.fmt.bufPrint(buf, "{s} ({s}) returned a commit SHA that failed validation (not 40-char lowercase hex).", .{ name, host }) catch unreachable,
+        error.ResolveFailed => std.fmt.bufPrint(buf, "{s} ({s}) returned an unexpected status while resolving HEAD — retry, or set {s} if this persists.", .{ name, host, token_var }) catch unreachable,
+        error.OutOfMemory => "Out of memory while resolving HEAD commit.",
+    };
+}
+
+// ── describeResolveError (forge-aware) ──────────────────────────────
+// A GitLab/Codeberg tap must report its own host and token env var, not
+// GitHub's. github stays byte-identical; the regression skip-guards key
+// on "Network failure", so every forge's NetworkError keeps that phrase.
+
+test "describeResolveError github: NetworkError stays byte-identical (host ignored)" {
+    var buf: [512]u8 = undefined;
+    // github hosts are fixed, so a different `host` arg must not leak in.
+    const msg = describeResolveError(&buf, error.NetworkError, .github, "github.com");
+    try std.testing.expectEqualStrings(
+        "Network failure while reaching api.github.com — check connectivity and retry.",
+        msg,
+    );
+}
+
+test "describeResolveError gitlab: RateLimited names the host and MALT_GITLAB_TOKEN" {
+    var buf: [512]u8 = undefined;
+    const msg = describeResolveError(&buf, error.RateLimited, .gitlab, "gitlab.com");
+    try std.testing.expect(std.mem.indexOf(u8, msg, "gitlab.com") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "MALT_GITLAB_TOKEN") != null);
+    // No GitHub host or token leaking onto a GitLab tap.
+    try std.testing.expect(std.mem.indexOf(u8, msg, "MALT_GITHUB_TOKEN") == null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "github.com") == null);
+}
+
+test "describeResolveError gitlab: NetworkError names the instance host, not api.github.com" {
+    var buf: [512]u8 = undefined;
+    const msg = describeResolveError(&buf, error.NetworkError, .gitlab, "gitlab.gnome.org");
+    try std.testing.expect(std.mem.indexOf(u8, msg, "gitlab.gnome.org") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "api.github.com") == null);
+    // The skip-guard regex in scripts/regressions/*.sh keys on this phrase.
+    try std.testing.expect(std.mem.indexOf(u8, msg, "Network failure") != null);
+}
+
+test "describeResolveError gitlab: NotFound drops the github-only homebrew-/--repo hint" {
+    var buf: [512]u8 = undefined;
+    const msg = describeResolveError(&buf, error.NotFound, .gitlab, "gitlab.com");
+    try std.testing.expect(std.mem.indexOf(u8, msg, "gitlab.com") != null);
+    // The homebrew-<repo> synthesis is github-only; it must not appear here.
+    try std.testing.expect(std.mem.indexOf(u8, msg, "homebrew-") == null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "--repo") == null);
+}
+
+test "describeResolveError codeberg: RateLimited names the host and MALT_CODEBERG_TOKEN" {
+    var buf: [512]u8 = undefined;
+    const msg = describeResolveError(&buf, error.RateLimited, .codeberg, "codeberg.org");
+    try std.testing.expect(std.mem.indexOf(u8, msg, "codeberg.org") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "MALT_CODEBERG_TOKEN") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "MALT_GITHUB_TOKEN") == null);
+}
+
+test "describeResolveError codeberg: a self-hosted Forgejo host is named" {
+    var buf: [512]u8 = undefined;
+    const msg = describeResolveError(&buf, error.MalformedJson, .codeberg, "git.example.org");
+    try std.testing.expect(std.mem.indexOf(u8, msg, "git.example.org") != null);
+}
+
+test "describeResolveError gitlab: ResolveFailed (the 5xx catch-all) names host and token" {
+    var buf: [512]u8 = undefined;
+    const msg = describeResolveError(&buf, error.ResolveFailed, .gitlab, "gitlab.gnome.org");
+    try std.testing.expect(std.mem.indexOf(u8, msg, "gitlab.gnome.org") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "MALT_GITLAB_TOKEN") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "MALT_GITHUB_TOKEN") == null);
+}
+
+test "describeResolveError gitlab: InvalidSha names the instance host" {
+    var buf: [512]u8 = undefined;
+    const msg = describeResolveError(&buf, error.InvalidSha, .gitlab, "gitlab.com");
+    try std.testing.expect(std.mem.indexOf(u8, msg, "gitlab.com") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "GitLab") != null);
+}
+
+test "describeResolveError github: ignores a non-canonical host (fixed-host literals win)" {
+    // The github arm's hosts are fixed; a stray host arg must never leak into
+    // the message — it keeps the api.github.com literal verbatim.
+    var buf: [512]u8 = undefined;
+    const msg = describeResolveError(&buf, error.NetworkError, .github, "evil.example.com");
+    try std.testing.expectEqualStrings(
+        "Network failure while reaching api.github.com — check connectivity and retry.",
+        msg,
+    );
 }
 
 /// Materialise `taps.url` from `(host, owner, repo)` into a caller buffer

--- a/tests/tap_resolve_error_test.zig
+++ b/tests/tap_resolve_error_test.zig
@@ -1,0 +1,98 @@
+//! malt — offline integration for forge-aware tap resolve-error messages.
+//!
+//! Inline tests in `src/core/tap.zig` cover `describeResolveError` per
+//! (forge × error class) in isolation. This file pins the *assembled* path
+//! that `mt tap --refresh` walks for a non-github tap: a recorded non-200
+//! over the wire classifies to a `TapError` whose rendered message names
+//! the tap's own host and token env var, never GitHub's. No live network —
+//! a localhost server replies with the status under test.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const tap = malt.tap;
+const net = std.Io.net;
+
+const StatusFixture = struct {
+    io: std.Io,
+    listener: *net.Server,
+    status: std.http.Status,
+};
+
+// Replies once with `fx.status` and an empty body. The resolve path
+// classifies on status alone, so the body is irrelevant. Errors are
+// swallowed — a failed serve surfaces as a client-side assertion miss.
+fn serveStatus(fx: *StatusFixture) void {
+    const stream = fx.listener.accept(fx.io) catch return;
+    defer stream.close(fx.io);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var reader = stream.reader(fx.io, &rbuf);
+    var writer = stream.writer(fx.io, &wbuf);
+    var srv = std.http.Server.init(&reader.interface, &writer.interface);
+    var req = srv.receiveHead() catch return;
+    req.respond("", .{ .status = fx.status }) catch return;
+}
+
+fn listenLocal(io: std.Io) !net.Server {
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    return addr.listen(io, .{ .reuse_address = true });
+}
+
+test "gitlab refresh over a 403 reports a forge-correct rate-limit message" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var listener = try listenLocal(io);
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var fx = StatusFixture{ .io = io, .listener = &listener, .status = .forbidden };
+    const server_thread = try std.Thread.spawn(.{}, serveStatus, .{&fx});
+    defer server_thread.join();
+
+    var url_buf: [96]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/api/v4/projects/grp%2Ftap/repository/commits/HEAD", .{port});
+
+    // The wire 403 must classify to RateLimited on the gitlab path...
+    try testing.expectError(error.RateLimited, tap.resolveHeadCommit(io, .empty, testing.allocator, .gitlab, url, null));
+
+    // ...and the message the CLI prints names the gitlab instance + token.
+    var msg_buf: [512]u8 = undefined;
+    const msg = tap.describeResolveError(&msg_buf, error.RateLimited, .gitlab, "gitlab.com");
+    try testing.expect(std.mem.indexOf(u8, msg, "gitlab.com") != null);
+    try testing.expect(std.mem.indexOf(u8, msg, "MALT_GITLAB_TOKEN") != null);
+    try testing.expect(std.mem.indexOf(u8, msg, "MALT_GITHUB_TOKEN") == null);
+    try testing.expect(std.mem.indexOf(u8, msg, "api.github.com") == null);
+}
+
+test "codeberg refresh over a 404 names the instance host and drops the github-only hint" {
+    // 404 is non-retryable; a 5xx would trip the client's retry-with-backoff,
+    // which a single-serve localhost server can't satisfy (the 5xx→ResolveFailed
+    // classification is covered by the resolveFromConditional unit test instead).
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var listener = try listenLocal(io);
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var fx = StatusFixture{ .io = io, .listener = &listener, .status = .not_found };
+    const server_thread = try std.Thread.spawn(.{}, serveStatus, .{&fx});
+    defer server_thread.join();
+
+    var url_buf: [96]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/api/v1/repos/grp/tap/commits?limit=1&stat=false", .{port});
+
+    try testing.expectError(error.NotFound, tap.resolveHeadCommit(io, .empty, testing.allocator, .codeberg, url, null));
+
+    var msg_buf: [512]u8 = undefined;
+    const msg = tap.describeResolveError(&msg_buf, error.NotFound, .codeberg, "git.example.org");
+    try testing.expect(std.mem.indexOf(u8, msg, "git.example.org") != null);
+    // The homebrew-<repo>/--repo remediation is github-only; it must not leak here.
+    try testing.expect(std.mem.indexOf(u8, msg, "homebrew-") == null);
+    try testing.expect(std.mem.indexOf(u8, msg, "--repo") == null);
+    try testing.expect(std.mem.indexOf(u8, msg, "GitHub") == null);
+}

--- a/tests/tap_test.zig
+++ b/tests/tap_test.zig
@@ -338,7 +338,8 @@ test "list URL projection follows rebind end-to-end" {
 }
 
 test "describeResolveError(NotFound) names the --repo remediation" {
-    const msg = tap.describeResolveError(error.NotFound);
+    var buf: [512]u8 = undefined;
+    const msg = tap.describeResolveError(&buf, error.NotFound, .github, "github.com");
     try testing.expect(std.mem.indexOf(u8, msg, "--repo") != null);
 }
 
@@ -534,33 +535,41 @@ test "classifyResolveStatus: 401 (bad auth) is distinct from rate limit" {
 // blanket "floating HEAD" message.
 // ────────────────────────────────────────────────────────────────────
 
-test "describeResolveError: RateLimited names MALT_GITHUB_TOKEN" {
-    const msg = tap.describeResolveError(tap.TapError.RateLimited);
+test "describeResolveError: github RateLimited names MALT_GITHUB_TOKEN" {
+    var buf: [512]u8 = undefined;
+    const msg = tap.describeResolveError(&buf, tap.TapError.RateLimited, .github, "github.com");
     try testing.expect(std.mem.indexOf(u8, msg, "MALT_GITHUB_TOKEN") != null);
     try testing.expect(std.mem.indexOf(u8, msg, "rate limit") != null);
 }
 
-test "describeResolveError: NotFound explains the homebrew- prefix rule" {
-    const msg = tap.describeResolveError(tap.TapError.NotFound);
+test "describeResolveError: github NotFound explains the homebrew- prefix rule" {
+    var buf: [512]u8 = undefined;
+    const msg = tap.describeResolveError(&buf, tap.TapError.NotFound, .github, "github.com");
     try testing.expect(std.mem.indexOf(u8, msg, "homebrew-") != null);
 }
 
-test "describeResolveError: NetworkError mentions connectivity" {
-    const msg = tap.describeResolveError(tap.TapError.NetworkError);
+test "describeResolveError: github NetworkError mentions connectivity" {
+    var buf: [512]u8 = undefined;
+    const msg = tap.describeResolveError(&buf, tap.TapError.NetworkError, .github, "github.com");
     try testing.expect(std.mem.indexOf(u8, msg, "etwork") != null or
         std.mem.indexOf(u8, msg, "onnect") != null);
 }
 
-test "describeResolveError: MalformedJson is distinct from ResolveFailed" {
-    const malformed = tap.describeResolveError(tap.TapError.MalformedJson);
-    const generic = tap.describeResolveError(tap.TapError.ResolveFailed);
+test "describeResolveError: github MalformedJson is distinct from ResolveFailed" {
+    var bm: [512]u8 = undefined;
+    var bg: [512]u8 = undefined;
+    const malformed = tap.describeResolveError(&bm, tap.TapError.MalformedJson, .github, "github.com");
+    const generic = tap.describeResolveError(&bg, tap.TapError.ResolveFailed, .github, "github.com");
     try testing.expect(!std.mem.eql(u8, malformed, generic));
 }
 
-test "describeResolveError: every TapError variant gets a non-empty hint" {
-    inline for (@typeInfo(tap.TapError).error_set.?) |e| {
-        const err = @field(tap.TapError, e.name);
-        const msg = tap.describeResolveError(err);
-        try testing.expect(msg.len > 0);
+test "describeResolveError: every forge × TapError variant gets a non-empty hint" {
+    inline for (.{ .github, .gitlab, .codeberg }) |f| {
+        inline for (@typeInfo(tap.TapError).error_set.?) |e| {
+            var buf: [512]u8 = undefined;
+            const err = @field(tap.TapError, e.name);
+            const msg = tap.describeResolveError(&buf, err, f, "example.com");
+            try testing.expect(msg.len > 0);
+        }
     }
 }


### PR DESCRIPTION
## Description

Makes tap resolve-failure messages name the tap's own forge.

## Related Issue

- None

## Notes for Reviewers

- None