### PR TITLE
docs: document supported tap forges and the archive-pin caveat

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,25 @@ The CI pipeline runs the full slate (including `local-bench.sh` and the smoke su
 - **`docs/`** - design notes, security audits, and the post_install DSL coverage doc live here. Skim the file most relevant to your change.
 - **`docs/plan/` and `docs/design/`** - ADRs and longer design write-ups. If you're proposing something architectural, check whether there's already an ADR on the topic.
 
+## Tap forges
+
+Taps resolve against three forges — GitHub, GitLab (incl. self-hosted), and
+Codeberg/Forgejo/Gitea. The user-facing matrix, the `mt tap --host` / `--url`
+registration forms, and the per-forge token env vars (`MALT_GITHUB_TOKEN`,
+`MALT_GITLAB_TOKEN`, `MALT_CODEBERG_TOKEN`) are documented in the README's
+[Custom sources](README.md#custom-sources) section — read it before touching tap
+resolution.
+
+For contributors: each forge is one arm of the enum-`switch` in
+`src/core/forge.zig`, which stays a pure leaf (no `cli/*` or `ui/*` imports, no
+user-facing strings). Adding a forge is a new enum arm, so the compiler flags
+every `switch` that hasn't handled it.
+
+When authoring a tap formula, prefer **release-asset** URLs over GitLab
+`/-/archive/` or Gitea `/archive/` tarballs for any pinned `sha256`: generated
+archives are regenerated server-side and their digest can shift across a forge
+upgrade, which surfaces as a `Sha256Mismatch` that isn't actually corruption.
+
 ## Security invariants
 
 ### Argv-only spawn

--- a/README.md
+++ b/README.md
@@ -400,6 +400,53 @@ mt untap user/repo                                # remove a tap
 
 Taps are auto-resolved during install (`mt install user/repo/formula`), so this is optional unless you want the explicit Homebrew-style workflow.
 
+#### Supported forges
+
+A tap can live on any of three forges. GitHub is the default; the others
+register with an explicit `--host` (which always needs an explicit `--repo`,
+since the `homebrew-<repo>` convention is GitHub-only).
+
+| Forge                      | Hosts                                     | Register with                                                                               | Token env var         |
+| -------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------- | --------------------- |
+| GitHub                     | `github.com`                              | `mt tap user/repo` (resolves `homebrew-repo`), or `--repo owner/repo` for a prefixless repo | `MALT_GITHUB_TOKEN`   |
+| GitLab (incl. self-hosted) | `gitlab.com`, `gitlab.gnome.org`, custom  | `mt tap <slug> --host <host> --repo <owner>/<repo>`                                         | `MALT_GITLAB_TOKEN`   |
+| Codeberg / Forgejo / Gitea | `codeberg.org`, self-hosted Forgejo/Gitea | `mt tap <slug> --host <host> --repo <owner>/<repo>`                                         | `MALT_CODEBERG_TOKEN` |
+
+`gitlab.*` and `codeberg.org` auto-classify from the host. A custom domain that
+doesn't reveal its provider (a self-hosted GitLab like `code.acme.com`, or a
+Forgejo/Gitea instance) needs `--forge gitlab` or `--forge codeberg` so malt
+knows which API to speak. See the [environment variables](#environment-variables)
+table for what each token is sent as.
+
+```bash
+# GitLab — --host requires an explicit --repo
+mt tap grp/tap --host gitlab.com --repo grp/homebrew-tap
+mt tap grp/tap --url https://gitlab.com/grp/homebrew-tap   # same, from a full URL
+
+# Self-hosted GitLab on a domain the host can't classify
+mt tap acme/tap --host code.acme.com --forge gitlab --repo acme/tap
+
+# Codeberg, and self-hosted Forgejo/Gitea
+mt tap org/tap --host codeberg.org --repo org/homebrew-tap
+mt tap org/tap --host git.acme.com --forge codeberg --repo org/tap
+```
+
+A non-GitHub tap registers unpinned; `mt tap --refresh <slug>` pins its current
+HEAD. `mt doctor` lists every registered tap with the forge host it resolves
+against, so you can confirm a `--host` registration landed where you intended.
+
+#### Pinning caveat: prefer release assets over generated archives
+
+GitLab `/-/archive/` and Gitea `/archive/` tarballs are **regenerated
+server-side** — their gzip framing can change across a forge upgrade even when
+the file contents don't. A tap formula that pins the `sha256` of such an archive
+can therefore break on a forge upgrade. Prefer a **release-asset** URL (an
+uploaded tarball, whose bytes are immutable) over a `/-/archive/` or `/archive/`
+URL when you pin a `sha256`. If a pinned archive's digest later mismatches, malt
+reports the usual `Sha256Mismatch`; on a generated-archive URL that often means
+the forge re-generated the tarball rather than that the download is corrupt —
+re-pin against a stable release asset.
+
 ### Manage malt
 
 ```bash

--- a/build.zig
+++ b/build.zig
@@ -215,6 +215,7 @@ pub fn build(b: *std.Build) void {
         "tests/search_cli_test.zig",
         "tests/doctor_dispatch_test.zig",
         "tests/doctor_cask_history_test.zig",
+        "tests/doctor_tap_forge_test.zig",
         "tests/info_cli_test.zig",
         "tests/backup_cli_test.zig",
         "tests/run_cli_test.zig",

--- a/scripts/regressions/doctor_tap_forge.sh
+++ b/scripts/regressions/doctor_tap_forge.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Lock the `mt doctor` registered-taps forge/host report end-to-end, no network.
+#
+# Pinned behaviour:
+#   1. With taps registered, `mt doctor` lists each one as `<name> [<host>]`
+#      under a "Registered taps" block — github and off-github alike.
+#   2. `mt doctor --json` carries a `{"taps":[{"name","host"},...]}` payload.
+#   3. On a prefix with no taps, the block is silent (no "Registered taps").
+#
+# Registration and doctor render never touch the network, so this runs offline.
+# `mt doctor` exits non-zero by design on a bare prefix (e.g. missing CA
+# bundle), so every doctor call is captured with `|| true`.
+#
+# Usage: scripts/regressions/doctor_tap_forge.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+# ── 1 & 2. taps registered → doctor surfaces forge/host (human + json) ──
+PREFIX=$(mktemp -d -t mt_doctor_forge.XXXXXX)
+mkdir -p "$PREFIX/db"
+export MALT_PREFIX="$PREFIX"
+
+"$MALT_BIN" tap zach/ast --repo aeroxy/ast-outline >/dev/null 2>&1 ||
+  fail 'mt tap --repo (prefixless github) exited non-zero'
+"$MALT_BIN" tap grp/tap --host gitlab.com --repo grp/tap >/dev/null 2>&1 ||
+  fail 'mt tap --host gitlab.com --repo grp/tap exited non-zero'
+
+human=$("$MALT_BIN" doctor 2>&1 || true)
+printf '%s' "$human" | grep -q '> Registered taps:' ||
+  fail 'doctor human output missing the "Registered taps" block'
+printf '%s' "$human" | grep -q 'zach/ast \[github.com\]' ||
+  fail 'doctor did not list the github tap with its host'
+printf '%s' "$human" | grep -q 'grp/tap \[gitlab.com\]' ||
+  fail 'doctor did not list the gitlab tap with its host'
+
+json=$("$MALT_BIN" doctor --json 2>/dev/null || true)
+printf '%s' "$json" | grep -q '{"taps":\[' ||
+  fail 'doctor --json missing the taps payload'
+printf '%s' "$json" | grep -q '"name":"grp/tap","host":"gitlab.com"' ||
+  fail 'doctor --json did not carry the gitlab tap name+host'
+
+rm -rf "$PREFIX"
+
+# ── 3. no taps → the block is silent ───────────────────────────────────
+EMPTY=$(mktemp -d -t mt_doctor_forge_empty.XXXXXX)
+mkdir -p "$EMPTY/db"
+export MALT_PREFIX="$EMPTY"
+
+empty_out=$("$MALT_BIN" doctor 2>&1 || true)
+if printf '%s' "$empty_out" | grep -q 'Registered taps:'; then
+  fail 'doctor printed a "Registered taps" block on a prefix with no taps'
+fi
+
+rm -rf "$EMPTY"
+
+printf 'OK: mt doctor surfaces each tap forge/host, and stays silent with no taps.\n'

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -13,6 +13,7 @@ const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
 const tap_cache_mod = @import("../core/tap_cache.zig");
+const tap_mod = @import("../core/tap.zig");
 const clonefile = @import("../fs/clonefile.zig");
 const parser = @import("../macho/parser.zig");
 const client_mod = @import("../net/client.zig");
@@ -158,6 +159,71 @@ pub fn emitTapCacheReport(allocator: std.mem.Allocator, io: std.Io, prefix: []co
     output.writeStderrAll(aw.written());
 }
 
+/// Emit the registered-tap forge/host block doctor shows after the
+/// check rows. Every tap carries its host (github.com included) so a
+/// user can confirm which forge a tap resolves against — the off-GitHub
+/// hosts are where a wrong registration silently resolves elsewhere.
+/// Empty list writes nothing, keeping the no-tap case quiet. Pure for
+/// byte-pinning tests.
+pub fn writeTapForgeHuman(w: *std.Io.Writer, taps: []const tap_mod.TapInfo) !void {
+    if (taps.len == 0) return;
+    try w.writeAll("  > Registered taps:\n");
+    for (taps) |t| {
+        try w.print("        {s} [{s}]\n", .{ t.name, t.host });
+    }
+}
+
+/// `mt doctor --json` payload for the registered taps. The `taps` array
+/// stays present (empty, not omitted) so scripted consumers can always
+/// read it. Strings route through `output.jsonStr` for escaping. Pure
+/// for byte-pinning tests.
+pub fn writeTapForgeJson(w: *std.Io.Writer, taps: []const tap_mod.TapInfo) !void {
+    try w.writeAll("{\"taps\":[");
+    for (taps, 0..) |t, i| {
+        if (i != 0) try w.writeAll(",");
+        try w.writeAll("{\"name\":");
+        try output.jsonStr(w, t.name);
+        try w.writeAll(",\"host\":");
+        try output.jsonStr(w, t.host);
+        try w.writeAll("}");
+    }
+    try w.writeAll("]}\n");
+}
+
+/// Walk the registered taps and emit their forge/host alongside doctor's
+/// other reports. Routes to stdout (JSON, stable empty array) or stderr
+/// (human, silent when no taps). Pure read; safe from `execute`'s
+/// post-check phase. Best-effort: a DB or list failure drops the report
+/// rather than failing the whole doctor run.
+pub fn emitTapForgeReport(allocator: std.mem.Allocator, prefix: []const u8) void {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
+    var db = sqlite.Database.open(db_path) catch return;
+    defer db.close();
+    schema.initSchema(&db) catch {};
+
+    const taps = tap_mod.list(allocator, &db) catch return;
+    defer {
+        for (taps) |t| {
+            allocator.free(t.name);
+            allocator.free(t.url);
+            allocator.free(t.host);
+            if (t.commit_sha) |sha| allocator.free(sha);
+        }
+        allocator.free(taps);
+    }
+
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    if (output.isJson()) {
+        writeTapForgeJson(&aw.writer, taps) catch return;
+        output.writeStdoutAll(aw.written());
+        return;
+    }
+    writeTapForgeHuman(&aw.writer, taps) catch return;
+    output.writeStderrAll(aw.written());
+}
+
 /// Local mirror of `cli/purge/util.zig::formatBytes` / the cask-history
 /// formatter — doctor can't reach across the sibling-CLI boundary into
 /// `cli/purge`, and the byte format must match what `purge --cache`
@@ -201,6 +267,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     emitCaskHistoryReport(allocator, ctx.io, prefix);
     emitTapCacheReport(allocator, ctx.io, prefix);
+    emitTapForgeReport(allocator, prefix);
 
     if (fix_requested) {
         output.plain("", .{});

--- a/tests/doctor_render_test.zig
+++ b/tests/doctor_render_test.zig
@@ -207,6 +207,115 @@ test "formatOfflineDetail reports active when offline is true" {
     );
 }
 
+// ── registered-taps forge/host report ───────────────────────────────
+//
+// `mt doctor` lists each registered tap with the forge host it resolves
+// against, so a user can see at a glance which forge a tap targets — the
+// off-GitHub hosts are exactly where a wrong registration silently
+// resolves elsewhere. Pure formatters so the bytes pin without a DB.
+
+const tap_mod = @import("malt").tap;
+
+test "writeTapForgeHuman lists every tap with its host, github included" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    const taps = [_]tap_mod.TapInfo{
+        .{ .name = "user/repo", .url = "https://github.com/user/homebrew-repo", .host = "github.com" },
+        .{ .name = "grp/tap", .url = "https://gitlab.com/grp/tap", .host = "gitlab.com" },
+    };
+    try doctor.writeTapForgeHuman(&aw.writer, &taps);
+    try testing.expectEqualStrings(
+        "  > Registered taps:\n" ++
+            "        user/repo [github.com]\n" ++
+            "        grp/tap [gitlab.com]\n",
+        aw.written(),
+    );
+}
+
+test "writeTapForgeHuman writes nothing when no taps are registered" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try doctor.writeTapForgeHuman(&aw.writer, &.{});
+    try testing.expectEqual(@as(usize, 0), aw.written().len);
+}
+
+test "writeTapForgeJson emits one {name,host} object per tap" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    const taps = [_]tap_mod.TapInfo{
+        .{ .name = "user/repo", .url = "https://github.com/user/homebrew-repo", .host = "github.com" },
+        .{ .name = "grp/tap", .url = "https://gitlab.com/grp/tap", .host = "gitlab.com" },
+    };
+    try doctor.writeTapForgeJson(&aw.writer, &taps);
+    try testing.expectEqualStrings(
+        "{\"taps\":[{\"name\":\"user/repo\",\"host\":\"github.com\"}," ++
+            "{\"name\":\"grp/tap\",\"host\":\"gitlab.com\"}]}\n",
+        aw.written(),
+    );
+}
+
+test "writeTapForgeJson keeps an empty array (stable schema) when no taps" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try doctor.writeTapForgeJson(&aw.writer, &.{});
+    try testing.expectEqualStrings("{\"taps\":[]}\n", aw.written());
+}
+
+// Edge: the forge report is host-focused — a pinned tap shows its host,
+// never the commit SHA. The pin belongs to `mt tap`'s listing, so a
+// future change that leaked the SHA into doctor would be a regression.
+test "writeTapForgeHuman shows the host of a pinned tap, not its SHA" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    const taps = [_]tap_mod.TapInfo{
+        .{
+            .name = "grp/tap",
+            .url = "https://gitlab.com/grp/tap",
+            .commit_sha = "0123456789abcdef0123456789abcdef01234567",
+            .host = "gitlab.com",
+        },
+    };
+    try doctor.writeTapForgeHuman(&aw.writer, &taps);
+    try testing.expectEqualStrings(
+        "  > Registered taps:\n        grp/tap [gitlab.com]\n",
+        aw.written(),
+    );
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "0123456") == null);
+}
+
+test "writeTapForgeJson omits the commit SHA for a pinned tap" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    const taps = [_]tap_mod.TapInfo{
+        .{
+            .name = "grp/tap",
+            .url = "https://gitlab.com/grp/tap",
+            .commit_sha = "0123456789abcdef0123456789abcdef01234567",
+            .host = "gitlab.com",
+        },
+    };
+    try doctor.writeTapForgeJson(&aw.writer, &taps);
+    try testing.expectEqualStrings(
+        "{\"taps\":[{\"name\":\"grp/tap\",\"host\":\"gitlab.com\"}]}\n",
+        aw.written(),
+    );
+}
+
+// Edge: a self-hosted host on a custom domain renders verbatim — the
+// report shows whatever host was registered, no github.com fallback.
+test "writeTapForgeHuman renders a self-hosted custom host verbatim" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    const taps = [_]tap_mod.TapInfo{
+        .{ .name = "acme/tap", .url = "https://code.acme.com/acme/tap", .host = "code.acme.com" },
+    };
+    try doctor.writeTapForgeHuman(&aw.writer, &taps);
+    try testing.expectEqualStrings(
+        "  > Registered taps:\n        acme/tap [code.acme.com]\n",
+        aw.written(),
+    );
+}
+
 // ── countMissingLocalSources ────────────────────────────────────────
 //
 // The local-source check walks `kegs WHERE tap='local'` and reports

--- a/tests/doctor_tap_forge_test.zig
+++ b/tests/doctor_tap_forge_test.zig
@@ -1,0 +1,148 @@
+//! malt — doctor registered-taps forge/host report integration tests.
+//!
+//! Drives `doctor.emitTapForgeReport` against a real seeded prefix and
+//! asserts the bytes that land on stderr (human) or stdout (JSON). The
+//! pure formatters are byte-pinned in `tests/doctor_render_test.zig`;
+//! this file pins the DB walk + `output.*` wiring.
+
+const std = @import("std");
+const malt = @import("malt");
+const test_io = @import("test_io");
+const testing = std.testing;
+const doctor = malt.doctor;
+const tap_mod = malt.tap;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+const output = malt.output;
+
+const Scratch = struct {
+    path: [:0]u8,
+
+    fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
+        const ts = test_io.nanoTimestamp(std.Options.debug_io);
+        const path = try std.fmt.allocPrintSentinel(
+            allocator,
+            "/tmp/malt_doctor_tap_forge_{s}_{d}",
+            .{ tag, ts },
+            0,
+        );
+        test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, path);
+        const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});
+        defer allocator.free(db_dir);
+        try test_io.cwd().createDirPath(std.Options.debug_io, db_dir);
+        // An initialized (empty) DB mirrors production: doctor's SQLite
+        // check creates the schema before the tap report runs.
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+        return .{ .path = path };
+    }
+
+    fn deinit(self: *Scratch, allocator: std.mem.Allocator) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.path) catch {};
+        allocator.free(self.path);
+    }
+
+    /// Register a github tap and a gitlab tap so the report has one of
+    /// each forge to surface.
+    fn seedTwoForges(self: *Scratch) !void {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{self.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+        try tap_mod.add(&db, "user/repo", "user", "repo", null);
+        try tap_mod.addWithHost(&db, "grp/tap", "grp", "tap", "gitlab.com", null);
+    }
+};
+
+fn resetOutputFlags() void {
+    output.setQuiet(false);
+    output.setVerbose(false);
+    output.setMode(.human);
+}
+
+test "emitTapForgeReport: human mode lists each tap with its host on stderr" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "human");
+    defer s.deinit(allocator);
+    try s.seedTwoForges();
+
+    resetOutputFlags();
+    defer resetOutputFlags();
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.emitTapForgeReport(allocator, s.path);
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "  > Registered taps:") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        user/repo [github.com]") != null);
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        grp/tap [gitlab.com]") != null);
+}
+
+test "emitTapForgeReport: human mode stays silent when no taps are registered" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "empty");
+    defer s.deinit(allocator);
+
+    resetOutputFlags();
+    defer resetOutputFlags();
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    doctor.emitTapForgeReport(allocator, s.path);
+
+    try testing.expectEqual(@as(usize, 0), stderr_buf.items.len);
+}
+
+test "emitTapForgeReport: --json emits the taps payload on stdout" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "json");
+    defer s.deinit(allocator);
+    try s.seedTwoForges();
+
+    resetOutputFlags();
+    defer resetOutputFlags();
+    output.setMode(.json);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    doctor.emitTapForgeReport(allocator, s.path);
+
+    try testing.expectEqualStrings(
+        "{\"taps\":[{\"name\":\"user/repo\",\"host\":\"github.com\"}," ++
+            "{\"name\":\"grp/tap\",\"host\":\"gitlab.com\"}]}\n",
+        stdout_buf.items,
+    );
+}
+
+test "emitTapForgeReport: --json emits an empty array when no taps exist" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "json_empty");
+    defer s.deinit(allocator);
+
+    resetOutputFlags();
+    defer resetOutputFlags();
+    output.setMode(.json);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(allocator);
+    output.beginStdoutCapture(allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    doctor.emitTapForgeReport(allocator, s.path);
+
+    try testing.expectEqualStrings("{\"taps\":[]}\n", stdout_buf.items);
+}


### PR DESCRIPTION
## Description

Documents malt's supported tap forges (GitHub, GitLab incl. self-hosted, Codeberg/Forgejo), the `mt tap --host`/`--url` registration forms (including the GitHub prefixless `--repo` form), and the per-forge token env vars. Adds the archive-digest-stability caveat — prefer release-asset URLs over regenerated `/-/archive/` and `/archive/` tarballs when pinning a `sha256` — and surfaces each registered tap's forge/host in `mt doctor` (a human "Registered taps" block plus a stable `{"taps":[…]}` payload under `--json`). No tap-resolution behaviour changes.

## Related Issue

- None

## Notes for Reviewers

- None
