### PR TITLE
fix(cli): replace phantom lock-contention errors with the real cause

### DIFF
--- a/scripts/regressions/upgrade_fresh_prefix_no_lock_error.sh
+++ b/scripts/regressions/upgrade_fresh_prefix_no_lock_error.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Regression: `mt upgrade` against a fresh, never-initialised prefix.
+#
+# When malt is installed via the Homebrew cask, nothing creates the
+# prefix (e.g. /opt/malt) up front. Running `mt upgrade` before the
+# first install therefore reached the advisory lock at
+# `<prefix>/db/malt.lock`, whose parent `db/` did not exist. The lock
+# create failed with ENOENT, which `LockFile.acquire` collapsed into a
+# generic open error, and the command reported:
+#
+#   ✗ Could not acquire lock. Another malt process may be running.
+#
+# — a flat-out wrong diagnosis (no other process was involved) and a
+# non-zero exit. The fix distinguishes a missing lock directory
+# (DirMissing) from real contention (Timeout): a fresh prefix has
+# nothing installed and therefore nothing to upgrade, so `mt upgrade`
+# exits 0 silently instead of crying contention.
+#
+# This script points MALT_PREFIX at a path that does not exist, runs
+# `mt upgrade`, and asserts a clean exit with no contention message.
+#
+# Usage: scripts/regressions/upgrade_fresh_prefix_no_lock_error.sh
+# Requirements: built `malt` binary at $MALT_BIN or zig-out/bin/malt.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# A prefix that is guaranteed not to exist: parent is created, the prefix
+# itself (and its db/ dir) is not, mirroring a just-installed cask.
+PREFIX="/tmp/mt_fresh_prefix_$$"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+printf '\xe2\x96\xb8 mt upgrade on a non-existent prefix %s\n' "$PREFIX"
+
+# Capture both streams and the exit code without tripping `set -e`.
+OUT=$("$BIN" upgrade 2>&1) && RC=0 || RC=$?
+
+# --- 1. Clean exit -----------------------------------------------------
+[[ "$RC" -eq 0 ]] ||
+  fail "expected exit 0 on a fresh prefix, got $RC; output: $OUT"
+pass "exit 0 (nothing installed = nothing to upgrade)"
+
+# --- 2. No phantom contention message ----------------------------------
+if echo "$OUT" | grep -qi "Another malt process"; then
+  fail "reported phantom lock contention; output: $OUT"
+fi
+pass "no 'Another malt process' message"
+
+# --- 3. The prefix was not silently created as a side effect -----------
+# `mt upgrade` is read-only on an empty system; it must not materialise a
+# prefix just to discover there is nothing to do.
+[[ ! -e "$PREFIX" ]] ||
+  fail "upgrade created $PREFIX as a side effect"
+pass "prefix left untouched"
+
+printf '\n\xe2\x9c\x94 upgrade-fresh-prefix regression passed\n'

--- a/src/cli/lock_report.zig
+++ b/src/cli/lock_report.zig
@@ -1,0 +1,36 @@
+//! Shared, exhaustive messaging for lock-acquisition failures.
+//!
+//! `DirMissing` is deliberately not handled here: a fresh prefix means
+//! different things to different commands (upgrade: "nothing to upgrade";
+//! uninstall: "package not installed"), so each caller handles it before
+//! falling through to this common reporter.
+
+const std = @import("std");
+const output = @import("../ui/output.zig");
+const lock = @import("../db/lock.zig");
+
+/// Emit a clear, actionable message for every lock failure other than
+/// `DirMissing`. `prefix` is the install prefix, used to point the user at
+/// the exact `db/` directory involved.
+pub fn reportAcquireFailure(e: lock.LockError, prefix: []const u8) void {
+    switch (e) {
+        // Callers must handle the fresh-prefix case themselves.
+        error.DirMissing => unreachable,
+        error.AccessDenied => output.err(
+            "Cannot write the malt lock under {s}/db — the directory exists but isn't writable. Fix ownership with: sudo chown -R \"$USER\" {s}",
+            .{ prefix, prefix },
+        ),
+        error.Timeout => output.err(
+            "Timed out waiting for the malt lock under {s}/db — another malt process is still running. Wait for it to finish, or run `mt doctor` to clear a stale lock.",
+            .{prefix},
+        ),
+        error.OpenFailed => output.err(
+            "Could not open the malt lock under {s}/db.",
+            .{prefix},
+        ),
+        error.WriteFailed => output.err(
+            "Took the malt lock under {s}/db but failed to record the process id.",
+            .{prefix},
+        ),
+    }
+}

--- a/src/cli/uninstall.zig
+++ b/src/cli/uninstall.zig
@@ -14,6 +14,7 @@ const cask_mod = @import("../core/cask.zig");
 const formula_mod = @import("../core/formula.zig");
 const supervisor_mod = @import("../core/services/supervisor.zig");
 const help = @import("help.zig");
+const lock_report = @import("lock_report.zig");
 
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(ctx, args, "uninstall")) return;
@@ -44,9 +45,18 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // Acquire lock
     var lock_path_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return;
-    var lock = lock_mod.LockFile.acquire(ctx.io, lock_path, 5000) catch {
-        output.err("Could not acquire lock. Another malt process may be running.", .{});
-        return error.Aborted;
+    var lock = lock_mod.LockFile.acquire(ctx.io, lock_path, 5000) catch |e| switch (e) {
+        // Fresh prefix with no `db/` dir → nothing is installed, so the
+        // requested package certainly isn't. Say so plainly instead of
+        // reporting phantom lock contention.
+        error.DirMissing => {
+            output.err("{s} is not installed", .{name});
+            return error.Aborted;
+        },
+        else => {
+            lock_report.reportAcquireFailure(e, prefix);
+            return error.Aborted;
+        },
     };
     defer lock.release(ctx.io);
 

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -22,6 +22,7 @@ const ghcr_mod = @import("../net/ghcr.zig");
 const output = @import("../ui/output.zig");
 const progress_mod = @import("../ui/progress.zig");
 const help = @import("help.zig");
+const lock_report = @import("lock_report.zig");
 const install_args_mod = @import("install/args.zig");
 const install_download_mod = @import("install/download.zig");
 const install_local_mod = @import("install/local.zig");
@@ -101,13 +102,18 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     var lock_path_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return;
-    var lk = lock_mod.LockFile.acquire(ctx.io, lock_path, 5000) catch {
+    var lk = lock_mod.LockFile.acquire(ctx.io, lock_path, 5000) catch |e| switch (e) {
         // Fresh prefix: no `db/` yet = nothing installed, nothing to
         // upgrade. Exit 0 silently rather than treating the missing
         // lock directory as contention with another process.
-        if (dry_run) return;
-        output.err("Could not acquire lock. Another malt process may be running.", .{});
-        return error.Aborted;
+        error.DirMissing => return,
+        // dry_run audits stay quiet on any other failure; otherwise tell
+        // the user exactly what went wrong.
+        else => {
+            if (dry_run) return;
+            lock_report.reportAcquireFailure(e, prefix);
+            return error.Aborted;
+        },
     };
     defer lk.release(ctx.io);
     // LIFO: install_complete fires before lk.release. Inline gate keeps

--- a/src/db/lock.zig
+++ b/src/db/lock.zig
@@ -1,8 +1,20 @@
 const std = @import("std");
 
 pub const LockError = error{
+    /// Genuine contention: another live process still holds the lock when
+    /// the timeout elapses.
     Timeout,
+    /// The lock's parent directory does not exist — a fresh prefix that has
+    /// never had anything installed. Kept distinct from contention so callers
+    /// can treat it as "nothing installed" instead of a phantom "process
+    /// running".
+    DirMissing,
+    /// The lock's directory exists but is not writable — e.g. a root-owned
+    /// /opt/malt created by `sudo mkdir` without a follow-up `chown`.
+    AccessDenied,
+    /// Any other failure opening the lock file.
     OpenFailed,
+    /// The lock was taken but its pid could not be recorded.
     WriteFailed,
 };
 
@@ -22,7 +34,12 @@ pub const LockFile = struct {
         const file = std.Io.Dir.createFileAbsolute(io, path, .{
             .read = true,
             .truncate = false,
-        }) catch return error.OpenFailed;
+        }) catch |e| switch (e) {
+            // ENOENT on the parent dir = fresh prefix, not contention.
+            error.FileNotFound => return error.DirMissing,
+            error.AccessDenied, error.PermissionDenied => return error.AccessDenied,
+            else => return error.OpenFailed,
+        };
         errdefer file.close(io);
 
         try acquireLockWithin(io, file, timeout_ms);
@@ -91,6 +108,61 @@ fn writePidAndSync(io: std.Io, file: std.Io.File) LockError!void {
     // Durability of the live pid for `mt doctor` after a SIGKILL —
     // without this the pid lives only in the page cache.
     file.sync(io) catch return error.WriteFailed;
+}
+
+test "acquire reports DirMissing when the lock's parent directory is absent" {
+    // A fresh prefix that never had anything installed has no `db/` dir, so
+    // the lock create hits ENOENT. The historical bug surfaced that to the
+    // user as "another malt process may be running". Pin the distinct error
+    // so callers can treat it as "nothing installed", not contention.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var rnd: [9]u8 = undefined;
+    io.random(&rnd);
+    var suffix: [std.base64.url_safe.Encoder.calcSize(9)]u8 = undefined;
+    _ = std.base64.url_safe.Encoder.encode(&suffix, &rnd);
+
+    // The `<base>/db` parent is deliberately never created.
+    const path = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "/tmp/malt-lock-missing-{s}/db/malt.lock",
+        .{suffix},
+    );
+    defer std.testing.allocator.free(path);
+
+    try std.testing.expectError(error.DirMissing, LockFile.acquire(io, path, 100));
+}
+
+test "acquire records a pid while held and release vacates it" {
+    // The success path is the other half of the DirMissing contract: when
+    // the dir exists the lock must take, expose its holder pid, then clear
+    // it on release so `mt doctor` never reports a phantom holder.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var rnd: [9]u8 = undefined;
+    io.random(&rnd);
+    var suffix: [std.base64.url_safe.Encoder.calcSize(9)]u8 = undefined;
+    _ = std.base64.url_safe.Encoder.encode(&suffix, &rnd);
+
+    const dir = try std.fmt.allocPrint(std.testing.allocator, "/tmp/malt-lock-ok-{s}", .{suffix});
+    defer std.testing.allocator.free(dir);
+    const path = try std.fmt.allocPrint(std.testing.allocator, "{s}/malt.lock", .{dir});
+    defer std.testing.allocator.free(path);
+
+    try std.Io.Dir.createDirAbsolute(io, dir, .default_dir);
+    defer {
+        std.Io.Dir.deleteFileAbsolute(io, path) catch {};
+        std.Io.Dir.deleteDirAbsolute(io, dir) catch {};
+    }
+
+    var lk = try LockFile.acquire(io, path, 1000);
+    try std.testing.expect(LockFile.holderPid(io, path) != null);
+    lk.release(io);
+    try std.testing.expect(LockFile.holderPid(io, path) == null);
 }
 
 test "acquire has a single close path (regression guard for double-close)" {


### PR DESCRIPTION
## Description

Installing malt via the Homebrew cask never creates the prefix (`/opt/malt`), so the first thing a user does after install - `malt upgrade` - touched the advisory lock at a path whose directory did not exist yet. The missing directory was misreported as lock contention:

> ✗ Could not acquire lock. Another malt process may be running.

Wrong diagnosis (no other process was involved) that also exited non-zero. `malt uninstall` had the same flaw.

Lock acquisition now tells three situations apart instead of collapsing them into one error: 

- a missing prefix directory (a fresh system that has nothing installed)
- a prefix that exists but isn't writable (a root-owned `/opt/malt` left by `sudo mkdir` without a follow-up `chown`)
-  a genuine contention with another running process. 

Each command reacts correctly and tells the user exactly what happened:

- `upgrade` against a fresh prefix exits cleanly — nothing is installed, so there is nothing to upgrade.
- `uninstall` against a fresh prefix says the package is not installed.
- A non-writable prefix and real contention each get a specific, actionable message naming the directory and the fix.

## Related Issue

- None

## Notes for Reviewers

- None