### PR TITLE
fix: guide cask users to a usable prefix and a working PATH

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -77,6 +77,20 @@ homebrew_casks:
     binaries:
       - malt
       - mt
+    # The cask drops the binaries but cannot create malt's install prefix:
+    # it lives under root-owned /opt, so it needs one privileged step the
+    # cask itself must not take. Spell it out, plus the PATH entry that
+    # makes installed commands resolve. `scripts/install.sh` already does
+    # both for the script-install path.
+    caveats: |
+      malt installs packages into a prefix that must exist and be owned by you.
+      Create it once (default /opt/malt; override with MALT_PREFIX):
+
+        sudo mkdir -p /opt/malt && sudo chown "$USER" /opt/malt
+
+      Then add its bin directory to your PATH, e.g. in ~/.zshrc:
+
+        export PATH="/opt/malt/bin:$PATH"
     hooks:
       post:
         install: |

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -77,6 +77,7 @@ pub const checks = [_]Check{
     .{ .name = patch.external_tool_name, .run = checkExternalTool },
     .{ .name = "APFS volume", .run = checkApfs },
     .{ .name = "Prefix permissions", .run = checkPrefixPermissions },
+    .{ .name = "Prefix on PATH", .run = checkPrefixPath },
     .{ .name = "Mirror overrides", .run = checkMirrorOverrides },
     .{ .name = "Offline mode", .run = checkOfflineMode },
     .{ .name = "API reachable", .run = checkApiReachable },
@@ -592,6 +593,30 @@ fn checkPrefixPermissions(ctx: CheckCtx, name: []const u8) CheckResult {
         const line = std.fmt.bufPrint(&line_buf, "{s} ({s})", .{ f.path, reason }) catch continue;
         writeStyledDetail(line);
     }
+    return .warn_status;
+}
+
+/// Warn when the prefix's `bin` directory isn't on PATH — the common
+/// cask-install symptom where `malt install`ed commands are "not found"
+/// because nothing ever added `<prefix>/bin` to the user's shell.
+fn checkPrefixPath(ctx: CheckCtx, name: []const u8) CheckResult {
+    var bin_buf: [512]u8 = undefined;
+    const bin = std.fmt.bufPrint(&bin_buf, "{s}/bin", .{ctx.prefix}) catch {
+        printCheck(name, .ok, null);
+        return .ok;
+    };
+    const path_env = std.process.Environ.getPosix(ctx.environ, "PATH") orelse "";
+    if (pathContainsDir(path_env, bin)) {
+        printCheck(name, .ok, null);
+        return .ok;
+    }
+    var msg_buf: [640]u8 = undefined;
+    const msg = std.fmt.bufPrint(
+        &msg_buf,
+        "{s} is not on PATH — installed commands won't be found. Add: export PATH=\"{s}:$PATH\"",
+        .{ bin, bin },
+    ) catch "Prefix bin directory is not on PATH";
+    printCheck(name, .warn_status, msg);
     return .warn_status;
 }
 
@@ -1111,6 +1136,21 @@ fn hasUnpatchedPlaceholder(
     return false;
 }
 
+/// True if `dir` appears as a complete, colon-separated entry in `path_env`.
+/// Whole-entry match (not substring) so `/opt/malt/binary` never satisfies a
+/// query for `/opt/malt/bin`; trailing slashes on either side are ignored.
+/// `pub` so the membership logic is unit-tested without a fabricated environ.
+pub fn pathContainsDir(path_env: []const u8, dir: []const u8) bool {
+    const want = std.mem.trimEnd(u8, dir, "/");
+    if (want.len == 0) return false;
+    var it = std.mem.splitScalar(u8, path_env, ':');
+    while (it.next()) |entry| {
+        if (entry.len == 0) continue;
+        if (std.mem.eql(u8, std.mem.trimEnd(u8, entry, "/"), want)) return true;
+    }
+    return false;
+}
+
 /// Fast existence check for a platform relocation tool on PATH.
 /// Tries `/usr/bin/<tool>` first (where Xcode Command Line Tools land
 /// install_name_tool) and then walks `PATH` entry-by-entry. `pub` so
@@ -1309,6 +1349,41 @@ test "checks table includes the mirror-overrides row" {
     var found = false;
     for (checks) |c| {
         if (std.mem.eql(u8, c.name, "Mirror overrides")) {
+            found = true;
+            break;
+        }
+    }
+    try testing.expect(found);
+}
+
+test "pathContainsDir: matches a complete entry, ignores trailing slashes" {
+    // The "Prefix on PATH" check is only correct if it matches whole PATH
+    // entries — a substring match would falsely pass for `/opt/malt/binary`
+    // when only `/opt/malt/bin` is wanted, hiding a broken PATH from the user.
+    try testing.expect(pathContainsDir("/opt/malt/bin:/usr/bin", "/opt/malt/bin"));
+    try testing.expect(pathContainsDir("/usr/bin:/opt/malt/bin", "/opt/malt/bin"));
+    try testing.expect(pathContainsDir("/a:/opt/malt/bin:/b", "/opt/malt/bin"));
+    // Trailing slash on either side must not defeat the match.
+    try testing.expect(pathContainsDir("/opt/malt/bin/:/usr/bin", "/opt/malt/bin"));
+    try testing.expect(pathContainsDir("/opt/malt/bin", "/opt/malt/bin/"));
+}
+
+test "pathContainsDir: rejects substrings, missing entries, and empties" {
+    try testing.expect(!pathContainsDir("/opt/malt/binary:/usr/bin", "/opt/malt/bin"));
+    try testing.expect(!pathContainsDir("/usr/bin:/usr/local/bin", "/opt/malt/bin"));
+    try testing.expect(!pathContainsDir("", "/opt/malt/bin"));
+    try testing.expect(!pathContainsDir("::", "/opt/malt/bin"));
+    // A degenerate prefix must never match an empty PATH entry.
+    try testing.expect(!pathContainsDir("/usr/bin::/bin", "/"));
+}
+
+test "checks table includes the prefix-on-PATH row" {
+    // Pins the onboarding signal: without this row a cask user whose
+    // /opt/malt/bin isn't exported gets no hint why installed commands
+    // are "not found".
+    var found = false;
+    for (checks) |c| {
+        if (std.mem.eql(u8, c.name, "Prefix on PATH")) {
             found = true;
             break;
         }


### PR DESCRIPTION
## Description

Installing malt through the Homebrew cask leaves two setup steps unmet: the install prefix (default `/opt/malt`) is never created, and its `bin` directory is never added to PATH. The result is that a user's first command after installing fails in a way that looks like a malt bug — a permission error creating the prefix, or installed commands that are "not found" - when the real cause is missing onboarding.

This closes that gap from both ends:

- **On install**, the cask now prints clear guidance: the one privileged step it cannot take for the user (create the prefix and make them its owner), plus the PATH entry that makes installed commands resolve. The cask stays unprivileged and never edits the user's shell - it tells them exactly what to run. The script installer already does both for its own path and is unchanged.
- **At runtime**, `doctor` now reports whether the prefix's `bin` directory is on PATH and, when it isn't, shows the precise `export PATH=...` line to add - so anyone who skipped that step gets an explanation instead of a silent "command not found".

## Related Issue

- None

## Notes for Reviewers

- None