### PR TITLE
feat(outdated): emit a single unified JSON array for formulae and casks

### DIFF
--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -110,6 +110,40 @@ fn dupEntry(allocator: std.mem.Allocator, e: OutdatedEntry) std.mem.Allocator.Er
     return .{ .name = name, .installed = installed, .latest = latest };
 }
 
+/// Stitch the live keg `pinned` + `tap` onto each outdated entry,
+/// appending unified render rows to `out`. Pinned/tap are DB attributes
+/// (not snapshot state), so we match each entry to its keg row by name;
+/// `tap` collapses a SQL NULL to `""` so the JSON field is always present
+/// (matching `mt info`). An entry with no matching keg degrades to
+/// unpinned/empty tap rather than failing the whole emit.
+fn appendRenderRows(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayList(render_mod.Row),
+    entries: []const OutdatedEntry,
+    kegs: []const KegRow,
+    kind: render_mod.Kind,
+) std.mem.Allocator.Error!void {
+    if (entries.len == 0) return;
+
+    var by_name: std.StringHashMap(KegRow) = .init(allocator);
+    defer by_name.deinit();
+    try by_name.ensureTotalCapacity(@intCast(kegs.len));
+    for (kegs) |row| by_name.putAssumeCapacity(row.name, row);
+
+    try out.ensureUnusedCapacity(allocator, entries.len);
+    for (entries) |e| {
+        const row = by_name.get(e.name);
+        out.appendAssumeCapacity(.{
+            .name = e.name,
+            .installed = e.installed,
+            .latest = e.latest,
+            .kind = kind,
+            .pinned = if (row) |r| r.pinned else false,
+            .tap = if (row) |r| (r.tap orelse "") else "",
+        });
+    }
+}
+
 /// What `mt outdated` should do for the current invocation. Picked once,
 /// up front, so the dispatch is testable and the rest of `execute`
 /// stays linear.
@@ -161,6 +195,80 @@ fn summaryMessage(formula_count: usize, cask_count: usize, formula_only: bool, c
     if (formula_only) return "All formulas are up to date.";
     if (cask_only) return "All casks are up to date.";
     return "All packages are up to date.";
+}
+
+test "appendRenderRows stitches pinned and tap onto entries by name" {
+    const entries = [_]OutdatedEntry{
+        .{ .name = @constCast("held"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
+        .{ .name = @constCast("scoped"), .installed = @constCast("3.0"), .latest = @constCast("4.0") },
+    };
+    const kegs = [_]KegRow{
+        .{ .name = "held", .version = "1.0", .tap = null, .pinned = true },
+        .{ .name = "scoped", .version = "3.0", .tap = "user/repo", .pinned = false },
+    };
+
+    var out: std.ArrayList(render_mod.Row) = .empty;
+    defer out.deinit(std.testing.allocator);
+    try appendRenderRows(std.testing.allocator, &out, &entries, &kegs, .cask);
+
+    try std.testing.expectEqual(@as(usize, 2), out.items.len);
+    try std.testing.expectEqualStrings("held", out.items[0].name);
+    try std.testing.expectEqual(render_mod.Kind.cask, out.items[0].kind);
+    try std.testing.expect(out.items[0].pinned);
+    try std.testing.expectEqualStrings("", out.items[0].tap);
+
+    try std.testing.expectEqualStrings("scoped", out.items[1].name);
+    try std.testing.expect(!out.items[1].pinned);
+    try std.testing.expectEqualStrings("user/repo", out.items[1].tap);
+}
+
+test "appendRenderRows appends nothing for empty entries" {
+    const kegs = [_]KegRow{.{ .name = "held", .version = "1.0", .pinned = true }};
+    var out: std.ArrayList(render_mod.Row) = .empty;
+    defer out.deinit(std.testing.allocator);
+    try appendRenderRows(std.testing.allocator, &out, &.{}, &kegs, .formula);
+    try std.testing.expectEqual(@as(usize, 0), out.items.len);
+}
+
+test "appendRenderRows composes formula-then-cask order across two calls" {
+    // Mirrors the orchestrator: formulae are appended before casks, so
+    // the unified array preserves that grouping.
+    const f_entries = [_]OutdatedEntry{
+        .{ .name = @constCast("wget"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
+    };
+    const c_entries = [_]OutdatedEntry{
+        .{ .name = @constCast("flux"), .installed = @constCast("0.1"), .latest = @constCast("0.2") },
+    };
+    const f_rows = [_]KegRow{.{ .name = "wget", .version = "1.0" }};
+    const c_rows = [_]KegRow{.{ .name = "flux", .version = "0.1", .tap = "user/repo" }};
+
+    var out: std.ArrayList(render_mod.Row) = .empty;
+    defer out.deinit(std.testing.allocator);
+    try appendRenderRows(std.testing.allocator, &out, &f_entries, &f_rows, .formula);
+    try appendRenderRows(std.testing.allocator, &out, &c_entries, &c_rows, .cask);
+
+    try std.testing.expectEqual(@as(usize, 2), out.items.len);
+    try std.testing.expectEqual(render_mod.Kind.formula, out.items[0].kind);
+    try std.testing.expectEqualStrings("wget", out.items[0].name);
+    try std.testing.expectEqual(render_mod.Kind.cask, out.items[1].kind);
+    try std.testing.expectEqualStrings("user/repo", out.items[1].tap);
+}
+
+test "appendRenderRows defaults to unpinned + empty tap when no keg matches" {
+    const entries = [_]OutdatedEntry{
+        .{ .name = @constCast("orphan"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
+    };
+    const kegs = [_]KegRow{};
+
+    var out: std.ArrayList(render_mod.Row) = .empty;
+    defer out.deinit(std.testing.allocator);
+    try appendRenderRows(std.testing.allocator, &out, &entries, &kegs, .formula);
+
+    try std.testing.expectEqual(@as(usize, 1), out.items.len);
+    try std.testing.expectEqual(render_mod.Kind.formula, out.items[0].kind);
+    try std.testing.expect(!out.items[0].pinned);
+    try std.testing.expectEqualStrings("", out.items[0].tap);
+    try std.testing.expectEqualStrings("2.0", out.items[0].latest);
 }
 
 test "intersectWithDb drops snapshot entries whose keg is no longer installed" {
@@ -428,7 +536,9 @@ fn filterPick(scope: ScopeFlags) FilterPick {
 }
 
 /// Emit the snapshot through the live DB so an uninstalled or
-/// upgraded keg never appears in the output.
+/// upgraded keg never appears in the output. The keg rows are kept
+/// alive alongside the filtered entries so the JSON path can read each
+/// row's live `pinned`/`tap` when stitching the unified array.
 fn emitFromSnapshot(
     allocator: std.mem.Allocator,
     db: *sqlite.Database,
@@ -437,30 +547,66 @@ fn emitFromSnapshot(
     json_mode: bool,
     scope: ScopeFlags,
 ) !void {
-    var formula_count: usize = 0;
-    var cask_count: usize = 0;
-
+    var f_rows: ?[]KegRow = null;
+    defer if (f_rows) |r| freeKegRows(allocator, r);
+    var f_entries: ?[]OutdatedEntry = null;
+    defer if (f_entries) |e| freeEntrySlice(allocator, e);
     if (!scope.cask_only) {
         const rows = try loadFormulaRows(allocator, db, .all);
-        defer freeKegRows(allocator, rows);
-        const filtered = try intersectWithDb(allocator, rows, snap.formulas);
-        defer freeEntrySlice(allocator, filtered);
-        try render_mod.writeFormulaEntries(allocator, stdout, filtered, json_mode);
-        formula_count = filtered.len;
-    }
-    if (!scope.formula_only) {
-        const rows = try loadCaskRows(allocator, db, .all);
-        defer freeKegRows(allocator, rows);
-        const filtered = try intersectWithDb(allocator, rows, snap.casks);
-        defer freeEntrySlice(allocator, filtered);
-        try render_mod.writeCaskEntries(stdout, filtered, json_mode);
-        cask_count = filtered.len;
+        f_rows = rows;
+        f_entries = try intersectWithDb(allocator, rows, snap.formulas);
     }
 
-    if (!json_mode) {
-        if (summaryMessage(formula_count, cask_count, scope.formula_only, scope.cask_only)) |msg| {
-            output.info("{s}", .{msg});
-        }
+    var c_rows: ?[]KegRow = null;
+    defer if (c_rows) |r| freeKegRows(allocator, r);
+    var c_entries: ?[]OutdatedEntry = null;
+    defer if (c_entries) |e| freeEntrySlice(allocator, e);
+    if (!scope.formula_only) {
+        const rows = try loadCaskRows(allocator, db, .all);
+        c_rows = rows;
+        c_entries = try intersectWithDb(allocator, rows, snap.casks);
+    }
+
+    try emitEntries(allocator, stdout, json_mode, scope, .{
+        .formula_entries = f_entries orelse &.{},
+        .formula_rows = f_rows orelse &.{},
+        .cask_entries = c_entries orelse &.{},
+        .cask_rows = c_rows orelse &.{},
+    });
+}
+
+/// The four slices `emitEntries` needs: outdated entries plus the live
+/// keg rows they came from (so JSON can read `pinned`/`tap`).
+const EmitSlices = struct {
+    formula_entries: []const OutdatedEntry,
+    formula_rows: []const KegRow,
+    cask_entries: []const OutdatedEntry,
+    cask_rows: []const KegRow,
+};
+
+/// Single emit point shared by the snapshot and recompute paths. JSON
+/// frames one array spanning formulae + casks; human mode keeps the
+/// two-section bullet output byte-identical to before.
+fn emitEntries(
+    allocator: std.mem.Allocator,
+    stdout: *std.Io.Writer,
+    json_mode: bool,
+    scope: ScopeFlags,
+    s: EmitSlices,
+) !void {
+    if (json_mode) {
+        var rows: std.ArrayList(render_mod.Row) = .empty;
+        defer rows.deinit(allocator);
+        try appendRenderRows(allocator, &rows, s.formula_entries, s.formula_rows, .formula);
+        try appendRenderRows(allocator, &rows, s.cask_entries, s.cask_rows, .cask);
+        try render_mod.writeJsonArray(allocator, stdout, rows.items);
+        return;
+    }
+
+    render_mod.writeFormulaEntries(stdout, s.formula_entries);
+    render_mod.writeCaskEntries(stdout, s.cask_entries);
+    if (summaryMessage(s.formula_entries.len, s.cask_entries.len, scope.formula_only, scope.cask_only)) |msg| {
+        output.info("{s}", .{msg});
     }
 }
 
@@ -491,14 +637,38 @@ fn recomputeAndEmit(
         .tap => .{ .by_tap = scope.tap.? },
     };
 
-    var formula_count: usize = 0;
-    var cask_count: usize = 0;
+    // Load keg rows + collect outdated entries for both kinds before
+    // emitting, so the JSON path can frame one array spanning formulae
+    // and casks and read each row's live `pinned`/`tap`. Rows outlive
+    // the emit; `&.{}` sentinels keep `free` a no-op when scope skips a
+    // kind.
+    var f_rows: ?[]KegRow = null;
+    defer if (f_rows) |r| freeKegRows(allocator, r);
+    var f_entries: ?[]OutdatedEntry = null;
+    defer if (f_entries) |e| freeEntrySlice(allocator, e);
     if (!scope.cask_only) {
-        formula_count = try emitOutdatedFormulas(ctx, allocator, db, &api, cache_dir, workers_override, stdout, json_mode, filter);
+        const rows = try loadFormulaRows(allocator, db, filter);
+        f_rows = rows;
+        f_entries = try collectOutdatedFormulas(ctx, allocator, db, &api, cache_dir, rows, workers_override);
     }
+
+    var c_rows: ?[]KegRow = null;
+    defer if (c_rows) |r| freeKegRows(allocator, r);
+    var c_entries: ?[]OutdatedEntry = null;
+    defer if (c_entries) |e| freeEntrySlice(allocator, e);
     if (!scope.formula_only) {
-        cask_count = try emitOutdatedCasks(ctx, allocator, db, &api, cache_dir, workers_override, stdout, json_mode, filter);
+        const rows = try loadCaskRows(allocator, db, filter);
+        c_rows = rows;
+        c_entries = try collectOutdatedCasks(ctx, allocator, db, &api, cache_dir, rows, workers_override);
     }
+
+    try emitEntries(allocator, stdout, json_mode, scope, .{
+        .formula_entries = f_entries orelse &.{},
+        .formula_rows = f_rows orelse &.{},
+        .cask_entries = c_entries orelse &.{},
+        .cask_rows = c_rows orelse &.{},
+    });
+
     // Refresh the snapshot only when we walked the full keg set; any
     // narrowed recompute (pinned, tap, formula-only, cask-only) would
     // mislead the next reader. Best-effort: a write failure shouldn't
@@ -510,52 +680,4 @@ fn recomputeAndEmit(
     if (refresh_ok) {
         refreshSnapshot(ctx, allocator, db, &api, cache_dir, workers_override) catch {};
     }
-
-    if (!json_mode) {
-        if (summaryMessage(formula_count, cask_count, scope.formula_only, scope.cask_only)) |msg| {
-            output.info("{s}", .{msg});
-        }
-    }
-}
-
-fn emitOutdatedFormulas(
-    ctx: *const AppCtx,
-    allocator: std.mem.Allocator,
-    db: *sqlite.Database,
-    api: *api_mod.BrewApi,
-    cache_dir: []const u8,
-    workers_override: ?usize,
-    stdout: *std.Io.Writer,
-    json_mode: bool,
-    filter: KegFilter,
-) !usize {
-    const rows = try loadFormulaRows(allocator, db, filter);
-    defer freeKegRows(allocator, rows);
-
-    const entries = try collectOutdatedFormulas(ctx, allocator, db, api, cache_dir, rows, workers_override);
-    defer freeEntrySlice(allocator, entries);
-
-    try render_mod.writeFormulaEntries(allocator, stdout, entries, json_mode);
-    return entries.len;
-}
-
-fn emitOutdatedCasks(
-    ctx: *const AppCtx,
-    allocator: std.mem.Allocator,
-    db: *sqlite.Database,
-    api: *api_mod.BrewApi,
-    cache_dir: []const u8,
-    workers_override: ?usize,
-    stdout: *std.Io.Writer,
-    json_mode: bool,
-    filter: KegFilter,
-) !usize {
-    const rows = try loadCaskRows(allocator, db, filter);
-    defer freeKegRows(allocator, rows);
-
-    const entries = try collectOutdatedCasks(ctx, allocator, db, api, cache_dir, rows, workers_override);
-    defer freeEntrySlice(allocator, entries);
-
-    try render_mod.writeCaskEntries(stdout, entries, json_mode);
-    return entries.len;
 }

--- a/src/cli/outdated/render.zig
+++ b/src/cli/outdated/render.zig
@@ -12,59 +12,68 @@ const output = @import("../../ui/output.zig");
 const snap_mod = @import("snapshot.zig");
 const OutdatedEntry = snap_mod.OutdatedEntry;
 
-/// Render formula rows as a single JSON array (one document, matches
-/// the documented `mt outdated --json` shape) or as styled bullets.
-pub fn writeFormulaEntries(
-    allocator: std.mem.Allocator,
-    stdout: *std.Io.Writer,
-    entries: []const OutdatedEntry,
-    json_mode: bool,
-) !void {
-    if (json_mode) {
-        var aw: std.Io.Writer.Allocating = .init(allocator);
-        defer aw.deinit();
-        const w = &aw.writer;
-        try w.writeAll("[");
-        for (entries, 0..) |e, i| {
-            if (i != 0) try w.writeAll(",");
-            try w.writeAll("{\"name\":");
-            try output.jsonStr(w, e.name);
-            try w.writeAll(",\"installed\":");
-            try output.jsonStr(w, e.installed);
-            try w.writeAll(",\"latest\":");
-            try output.jsonStr(w, e.latest);
-            try w.writeAll(",\"type\":\"formula\"}");
-        }
-        try w.writeAll("]\n");
-        stdout.writeAll(aw.written()) catch return;
-        return;
-    }
+/// Which package family a unified-array row describes. Exhaustive
+/// `switch` (no `else`) so a new kind is a compile error at the encoder.
+pub const Kind = enum { formula, cask };
 
+/// One row of the unified `mt outdated --json` array. `pinned` and `tap`
+/// are live DB attributes (not snapshot state), so the orchestrator
+/// stitches them onto the snapshot/recompute entries at emit time.
+/// `tap` is `""` when unattributed — present always, matching how
+/// `mt info` exposes tap.
+pub const Row = struct {
+    name: []const u8,
+    installed: []const u8,
+    latest: []const u8,
+    kind: Kind,
+    pinned: bool,
+    tap: []const u8,
+};
+
+/// Render formula rows as styled bullets. JSON now flows through the
+/// unified `writeJsonArray`; this path is human-only.
+pub fn writeFormulaEntries(stdout: *std.Io.Writer, entries: []const OutdatedEntry) void {
     for (entries) |e| writeEntry(stdout, e, null);
 }
 
-/// Render cask rows. JSON mode streams one document per line (NDJSON)
-/// to match the legacy `mt outdated --json --cask` shape; the human
-/// mode shares the bullet row with formulas plus a `[cask]` kind tag.
-pub fn writeCaskEntries(
-    stdout: *std.Io.Writer,
-    entries: []const OutdatedEntry,
-    json_mode: bool,
-) !void {
-    if (json_mode) {
-        for (entries) |e| {
-            stdout.writeAll("{\"name\":") catch continue;
-            output.jsonStr(stdout, e.name) catch continue;
-            stdout.writeAll(",\"installed\":") catch continue;
-            output.jsonStr(stdout, e.installed) catch continue;
-            stdout.writeAll(",\"latest\":") catch continue;
-            output.jsonStr(stdout, e.latest) catch continue;
-            stdout.writeAll(",\"type\":\"cask\"}\n") catch continue;
-        }
-        return;
-    }
-
+/// Cask sibling of `writeFormulaEntries`: the bullet row plus a `[cask]`
+/// kind tag. Human-only — casks join formulae in the unified JSON array.
+pub fn writeCaskEntries(stdout: *std.Io.Writer, entries: []const OutdatedEntry) void {
     for (entries) |e| writeEntry(stdout, e, "cask");
+}
+
+/// Render a mixed slice of formula + cask rows as one top-level JSON
+/// array — the unified `mt outdated --json` shape. Casks live inside
+/// the array alongside formulae (a deliberate break from the old
+/// per-line cask NDJSON), and every row carries `pinned` + `tap`.
+pub fn writeJsonArray(
+    allocator: std.mem.Allocator,
+    stdout: *std.Io.Writer,
+    rows: []const Row,
+) !void {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
+    try w.writeAll("[");
+    for (rows, 0..) |r, i| {
+        if (i != 0) try w.writeAll(",");
+        try w.writeAll("{\"name\":");
+        try output.jsonStr(w, r.name);
+        try w.writeAll(",\"installed\":");
+        try output.jsonStr(w, r.installed);
+        try w.writeAll(",\"latest\":");
+        try output.jsonStr(w, r.latest);
+        try w.writeAll(switch (r.kind) {
+            .formula => ",\"type\":\"formula\",\"pinned\":",
+            .cask => ",\"type\":\"cask\",\"pinned\":",
+        });
+        try w.writeAll(if (r.pinned) "true" else "false");
+        try w.writeAll(",\"tap\":");
+        try output.jsonStr(w, r.tap);
+        try w.writeAll("}");
+    }
+    try w.writeAll("]\n");
+    stdout.writeAll(aw.written()) catch return;
 }
 
 /// Match the `mt list` / `mt search` row shape: cyan bullet, plain
@@ -111,74 +120,95 @@ fn writeStyledSpan(
     if (use_color) stdout.writeAll(color.Style.reset.code()) catch return;
 }
 
-test "writeFormulaEntries --json emits a single canonical JSON array" {
+test "writeJsonArray emits one array with formulae and casks and all six fields" {
     var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
 
-    const entries = [_]OutdatedEntry{
-        .{ .name = @constCast("alpha"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
-        .{ .name = @constCast("bravo"), .installed = @constCast("3.0"), .latest = @constCast("4.0") },
+    const rows = [_]Row{
+        .{ .name = "alpha", .installed = "1.0", .latest = "2.0", .kind = .formula, .pinned = false, .tap = "" },
+        .{ .name = "beta-cask", .installed = "3.0", .latest = "4.0", .kind = .cask, .pinned = true, .tap = "user/repo" },
     };
-    try writeFormulaEntries(std.testing.allocator, &aw.writer, &entries, true);
+    try writeJsonArray(std.testing.allocator, &aw.writer, &rows);
 
     const want =
-        \\[{"name":"alpha","installed":"1.0","latest":"2.0","type":"formula"},{"name":"bravo","installed":"3.0","latest":"4.0","type":"formula"}]
+        \\[{"name":"alpha","installed":"1.0","latest":"2.0","type":"formula","pinned":false,"tap":""},{"name":"beta-cask","installed":"3.0","latest":"4.0","type":"cask","pinned":true,"tap":"user/repo"}]
     ++ "\n";
     try std.testing.expectEqualStrings(want, aw.written());
 }
 
-test "writeFormulaEntries --json emits an empty array for no entries" {
-    // Shell-prompt integrations parse the output unconditionally; an
-    // empty array is the documented "nothing outdated" shape.
+test "writeJsonArray keeps casks inside the array, not as per-line NDJSON" {
+    // Regression against the old cask shape: a cask row must be a member
+    // of the single array (no `}\n{` document boundary, no trailing line).
     var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
-    try writeFormulaEntries(std.testing.allocator, &aw.writer, &.{}, true);
+
+    const rows = [_]Row{
+        .{ .name = "only-cask", .installed = "1.0", .latest = "2.0", .kind = .cask, .pinned = false, .tap = "" },
+    };
+    try writeJsonArray(std.testing.allocator, &aw.writer, &rows);
+
+    const out = aw.written();
+    try std.testing.expect(out[0] == '[');
+    try std.testing.expectEqualStrings("]\n", out[out.len - 2 ..]);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"type\":\"cask\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "}\n{") == null);
+}
+
+test "writeJsonArray comma-separates a formula-only array with no trailing comma" {
+    // Formula-only scope still yields one array (not the old per-kind path).
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+
+    const rows = [_]Row{
+        .{ .name = "alpha", .installed = "1.0", .latest = "2.0", .kind = .formula, .pinned = false, .tap = "" },
+        .{ .name = "bravo", .installed = "3.0", .latest = "4.0", .kind = .formula, .pinned = false, .tap = "" },
+    };
+    try writeJsonArray(std.testing.allocator, &aw.writer, &rows);
+
+    const want =
+        \\[{"name":"alpha","installed":"1.0","latest":"2.0","type":"formula","pinned":false,"tap":""},{"name":"bravo","installed":"3.0","latest":"4.0","type":"formula","pinned":false,"tap":""}]
+    ++ "\n";
+    try std.testing.expectEqualStrings(want, aw.written());
+}
+
+test "writeJsonArray emits an empty array for no rows" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeJsonArray(std.testing.allocator, &aw.writer, &.{});
     try std.testing.expectEqualStrings("[]\n", aw.written());
 }
 
-test "writeFormulaEntries escapes embedded quotes in --json mode" {
-    // Names from third-party taps can contain shell-hostile characters;
-    // the JSON layer has to escape them, not pass them through raw.
+test "writeJsonArray keeps a pinned-but-outdated row with pinned:true" {
+    // Acceptance: pinned packages stay visible rather than being dropped.
     var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
 
-    const entries = [_]OutdatedEntry{
-        .{ .name = @constCast("a\"b"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
+    const rows = [_]Row{
+        .{ .name = "held", .installed = "1.0", .latest = "2.0", .kind = .formula, .pinned = true, .tap = "" },
     };
-    try writeFormulaEntries(std.testing.allocator, &aw.writer, &entries, true);
+    try writeJsonArray(std.testing.allocator, &aw.writer, &rows);
 
     const want =
-        \\[{"name":"a\"b","installed":"1.0","latest":"2.0","type":"formula"}]
+        \\[{"name":"held","installed":"1.0","latest":"2.0","type":"formula","pinned":true,"tap":""}]
     ++ "\n";
     try std.testing.expectEqualStrings(want, aw.written());
 }
 
-test "writeCaskEntries --json emits one NDJSON document per entry" {
-    // `mt outdated --json` for casks predates the formula array shape;
-    // changing it would break downstream parsers, so the NDJSON path
-    // is pinned.
+test "writeJsonArray escapes embedded quotes in name and tap" {
+    // Names/labels from third-party taps can carry shell-hostile bytes;
+    // the JSON layer escapes rather than passing them through raw.
     var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
 
-    const entries = [_]OutdatedEntry{
-        .{ .name = @constCast("alpha-cask"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
-        .{ .name = @constCast("beta-cask"), .installed = @constCast("3.0"), .latest = @constCast("4.0") },
+    const rows = [_]Row{
+        .{ .name = "a\"b", .installed = "1.0", .latest = "2.0", .kind = .cask, .pinned = false, .tap = "x\"y" },
     };
-    try writeCaskEntries(&aw.writer, &entries, true);
+    try writeJsonArray(std.testing.allocator, &aw.writer, &rows);
 
     const want =
-        \\{"name":"alpha-cask","installed":"1.0","latest":"2.0","type":"cask"}
-        \\{"name":"beta-cask","installed":"3.0","latest":"4.0","type":"cask"}
-        \\
-    ;
+        \\[{"name":"a\"b","installed":"1.0","latest":"2.0","type":"cask","pinned":false,"tap":"x\"y"}]
+    ++ "\n";
     try std.testing.expectEqualStrings(want, aw.written());
-}
-
-test "writeCaskEntries --json writes nothing when entries is empty" {
-    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
-    defer aw.deinit();
-    try writeCaskEntries(&aw.writer, &.{}, true);
-    try std.testing.expectEqualStrings("", aw.written());
 }
 
 test "writeFormulaEntries quiet mode prints only the name, no styling" {
@@ -194,7 +224,7 @@ test "writeFormulaEntries quiet mode prints only the name, no styling" {
         .{ .name = @constCast("alpha"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
         .{ .name = @constCast("bravo"), .installed = @constCast("3.0"), .latest = @constCast("4.0") },
     };
-    try writeFormulaEntries(std.testing.allocator, &aw.writer, &entries, false);
+    writeFormulaEntries(&aw.writer, &entries);
 
     try std.testing.expectEqualStrings("alpha\nbravo\n", aw.written());
 }
@@ -213,7 +243,7 @@ test "writeCaskEntries human mode no-color path adds the [cask] kind tag" {
     const entries = [_]OutdatedEntry{
         .{ .name = @constCast("alpha-cask"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
     };
-    try writeCaskEntries(&aw.writer, &entries, false);
+    writeCaskEntries(&aw.writer, &entries);
 
     try std.testing.expect(std.mem.indexOf(u8, aw.written(), "alpha-cask") != null);
     try std.testing.expect(std.mem.indexOf(u8, aw.written(), " (1.0)") != null);

--- a/src/cli/outdated/rows.zig
+++ b/src/cli/outdated/rows.zig
@@ -21,6 +21,9 @@ pub const KegRow = struct {
     name: []const u8,
     version: []const u8,
     tap: ?[]const u8 = null,
+    /// True for `mt pin`-held rows. Surfaced so `mt outdated --json` can
+    /// keep a pinned-but-outdated package visible with `pinned:true`.
+    pinned: bool = false,
 };
 
 /// Scope filter for `loadFormulaRows` / `loadCaskRows`. Variants:
@@ -44,10 +47,10 @@ pub fn loadFormulaRows(
     filter: KegFilter,
 ) ![]KegRow {
     const sql: [:0]const u8 = switch (filter) {
-        .all => "SELECT name, version FROM kegs ORDER BY name;",
-        .pinned_only => "SELECT name, version FROM kegs WHERE pinned = 1 ORDER BY name;",
+        .all => "SELECT name, version, tap, pinned FROM kegs ORDER BY name;",
+        .pinned_only => "SELECT name, version, tap, pinned FROM kegs WHERE pinned = 1 ORDER BY name;",
         // NOCASE so `--tap User/Repo` resolves a row stored lowercase.
-        .by_tap => "SELECT name, version FROM kegs WHERE tap = ?1 COLLATE NOCASE ORDER BY name;",
+        .by_tap => "SELECT name, version, tap, pinned FROM kegs WHERE tap = ?1 COLLATE NOCASE ORDER BY name;",
     };
     const bind: ?[]const u8 = switch (filter) {
         .by_tap => |label| label,
@@ -66,10 +69,10 @@ pub fn loadCaskRows(
     filter: KegFilter,
 ) ![]KegRow {
     const sql: [:0]const u8 = switch (filter) {
-        .all => "SELECT token, version, tap FROM casks ORDER BY token;",
-        .pinned_only => "SELECT token, version, tap FROM casks WHERE pinned = 1 ORDER BY token;",
+        .all => "SELECT token, version, tap, pinned FROM casks ORDER BY token;",
+        .pinned_only => "SELECT token, version, tap, pinned FROM casks WHERE pinned = 1 ORDER BY token;",
         // NOCASE so `--tap User/Repo` resolves a row stored lowercase.
-        .by_tap => "SELECT token, version, tap FROM casks WHERE tap = ?1 COLLATE NOCASE ORDER BY token;",
+        .by_tap => "SELECT token, version, tap, pinned FROM casks WHERE tap = ?1 COLLATE NOCASE ORDER BY token;",
     };
     const bind: ?[]const u8 = switch (filter) {
         .by_tap => |label| label,
@@ -113,10 +116,9 @@ pub fn freeKegRows(allocator: std.mem.Allocator, rows: []KegRow) void {
     allocator.free(rows);
 }
 
-/// Reads `name, version` (and optionally `tap` as column 2) into
-/// caller-owned `KegRow`s. Tap is left null when the column isn't
-/// part of the SELECT (formula loader) or when the row's value is
-/// SQL NULL (core-API cask, or a v5-era row not yet backfilled).
+/// Reads `name, version, tap, pinned` into caller-owned `KegRow`s.
+/// Tap is left null when the row's value is SQL NULL (core-API cask,
+/// or a v5-era row not yet backfilled).
 fn loadKegRows(
     allocator: std.mem.Allocator,
     db: *sqlite.Database,
@@ -145,15 +147,20 @@ fn loadKegRows(
         errdefer allocator.free(name_dup);
         const ver_dup = try allocator.dupe(u8, ver_slice);
         errdefer allocator.free(ver_dup);
-        // Column 2 is the `tap` field for cask loaders; formula
-        // loaders don't SELECT it, so `columnText` returns null and
-        // the row gets a null tap.
+        // Column 2 is `tap`: null for core-API rows and v5-era casks
+        // not yet backfilled. Column 3 is the `pinned` flag.
         var tap_dup: ?[]u8 = null;
         if (stmt.columnText(2)) |tap_ptr| {
             const tap_slice = std.mem.sliceTo(tap_ptr, 0);
             tap_dup = try allocator.dupe(u8, tap_slice);
         }
-        try rows.append(allocator, .{ .name = name_dup, .version = ver_dup, .tap = tap_dup });
+        errdefer if (tap_dup) |t| allocator.free(t);
+        try rows.append(allocator, .{
+            .name = name_dup,
+            .version = ver_dup,
+            .tap = tap_dup,
+            .pinned = stmt.columnBool(3),
+        });
     }
     return rows.toOwnedSlice(allocator);
 }

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -398,6 +398,56 @@ test "loadCaskRows surfaces the owning tap when set" {
     try testing.expect(rows[1].tap == null);
 }
 
+test "loadFormulaRows .all surfaces the pinned flag and tap attribution" {
+    // `mt outdated --json` reads pinned + tap off the keg row so a held
+    // package stays visible with `pinned:true` and rows can name their tap.
+    const path = try setupPinnedPrefix("formula_pinned_tap");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertKeg(&db, "held", true);
+    try insertKegWithTap(&db, "scoped", "user/repo");
+
+    const rows = try outdated_mod.loadFormulaRows(testing.allocator, &db, .all);
+    defer outdated_mod.freeKegRows(testing.allocator, rows);
+
+    try testing.expectEqual(@as(usize, 2), rows.len);
+    // ORDER BY name: 'held' < 'scoped'.
+    try testing.expectEqualStrings("held", rows[0].name);
+    try testing.expect(rows[0].pinned);
+    try testing.expect(rows[0].tap == null);
+
+    try testing.expectEqualStrings("scoped", rows[1].name);
+    try testing.expect(!rows[1].pinned);
+    try testing.expect(rows[1].tap != null);
+    try testing.expectEqualStrings("user/repo", rows[1].tap.?);
+}
+
+test "loadCaskRows .all surfaces the pinned flag" {
+    const path = try setupPinnedPrefix("cask_pinned_flag");
+    defer testing.allocator.free(path);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var db = try openSeededDb(path);
+    defer db.close();
+    try insertCask(&db, "free-cask", false);
+    try insertCask(&db, "held-cask", true);
+
+    const rows = try outdated_mod.loadCaskRows(testing.allocator, &db, .all);
+    defer outdated_mod.freeKegRows(testing.allocator, rows);
+
+    try testing.expectEqual(@as(usize, 2), rows.len);
+    // ORDER BY token: 'free-cask' < 'held-cask'.
+    try testing.expectEqualStrings("free-cask", rows[0].name);
+    try testing.expect(!rows[0].pinned);
+    try testing.expectEqualStrings("held-cask", rows[1].name);
+    try testing.expect(rows[1].pinned);
+}
+
 test "outdated execute --pinned-only walks pinned casks alongside formulas" {
     const path = try setupPinnedPrefix("exec_pinned_mixed");
     defer testing.allocator.free(path);


### PR DESCRIPTION
## Description

`mt outdated --json` now emits a single JSON array containing both formulae and casks, and every row carries `pinned` and `tap` alongside `name`, `installed`, `latest`, and `type`. Previously formulae came back as one array while casks streamed as NDJSON, forcing consumers to run two parsers; pinned-but-outdated packages now stay visible with `pinned:true` instead of vanishing. One parse path, richer rows - directly consumable by `jq`, and scripts.

This is a one-time, schema-versioned break to the cask NDJSON shape: casks now live inside the array. `tap` is empty-string when unattributed, matching how `mt info` exposes it. Human (non-JSON) output is byte-for-byte unchanged, and the cached snapshot codec is untouched, so `mt update --check` is unaffected.

## Related Issue

- None

## Notes for Reviewers

- None
