### PR TITLE
feat(list): add pinned, size, and linked status to JSON output

### DIFF
--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -146,7 +146,7 @@ pub const bash_script =
     \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --pinned --force -f --isolate-deps --isolate-dependencies" ;;
     \\        outdated)         cmd_flags="--json --formula --cask --pinned-only --tap --refresh --quiet -q" ;;
     \\        update)           cmd_flags="--check --quiet -q" ;;
-    \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --tap --json --quiet -q" ;;
+    \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --tap --json --size --linked --quiet -q" ;;
     \\        info)             cmd_flags="--formula --cask --json" ;;
     \\        search)           cmd_flags="--formula --cask --json --installed --api --all --offline" ;;
     \\        uses)             cmd_flags="--recursive -r --json --quiet -q" ;;
@@ -330,6 +330,8 @@ pub const zsh_script =
     \\                        '--pinned[Pinned packages only]' \
     \\                        '--tap[Only packages from <label> (e.g. user/repo)]:tap label:' \
     \\                        '--json[Output as JSON]' \
+    \\                        '--size[With --json: add on-disk size_bytes per row]' \
+    \\                        '--linked[With --json: add link status per row]' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Names only]'
     \\                    ;;
     \\                info)
@@ -599,6 +601,8 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l pinned   -d 'Pinned only'
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l tap      -x -d 'Only packages from <label>'
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l json     -d 'JSON output'
+    \\    complete -c $__malt_bin -n '__malt_using_command list' -l size     -d 'With --json: add on-disk size_bytes'
+    \\    complete -c $__malt_bin -n '__malt_using_command list' -l linked   -d 'With --json: add link status'
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l versions -d 'Show version numbers'
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l formula  -d 'Formulas only'
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l cask     -d 'Casks only'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -207,6 +207,11 @@ const list_help =
     \\                 recorded tap won't match — run `mt upgrade <token>`
     \\                 to trigger attribution, or omit the filter.
     \\  --json         Output as JSON
+    \\  --size         With --json: add size_bytes (on-disk size) per row.
+    \\                 Opt-in — it walks each keg/cask dir, so the default
+    \\                 --json stays metadata-only and pays no walk cost.
+    \\  --linked       With --json: add linked (is the keg active in the
+    \\                 prefix). Casks are always linked once installed.
     \\  --quiet, -q    Names only, one per line
     \\
 ;

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -2,12 +2,15 @@
 //! List installed packages.
 
 const std = @import("std");
+
 const AppCtx = @import("../app_ctx.zig").AppCtx;
-const sqlite = @import("../db/sqlite.zig");
+const linker = @import("../core/linker.zig");
 const schema = @import("../db/schema.zig");
+const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
-const output = @import("../ui/output.zig");
+const dirsize = @import("../fs/dirsize.zig");
 const color = @import("../ui/color.zig");
+const output = @import("../ui/output.zig");
 const help = @import("help.zig");
 
 pub fn execute(ctx: *const AppCtx, args: []const []const u8) !void {
@@ -20,6 +23,8 @@ pub fn execute(ctx: *const AppCtx, args: []const []const u8) !void {
     var show_cask = false;
     var show_versions = false;
     var show_pinned = false;
+    var show_size = false;
+    var show_linked = false;
     var tap_filter: ?[]const u8 = null;
 
     var i: usize = 0;
@@ -33,6 +38,10 @@ pub fn execute(ctx: *const AppCtx, args: []const []const u8) !void {
             show_versions = true;
         } else if (std.mem.eql(u8, arg, "--pinned")) {
             show_pinned = true;
+        } else if (std.mem.eql(u8, arg, "--size")) {
+            show_size = true;
+        } else if (std.mem.eql(u8, arg, "--linked")) {
+            show_linked = true;
         } else if (std.mem.eql(u8, arg, "--tap")) {
             if (i + 1 >= args.len) {
                 output.err("--tap requires a label (e.g. `--tap user/repo`)", .{});
@@ -71,7 +80,7 @@ pub fn execute(ctx: *const AppCtx, args: []const []const u8) !void {
     defer stdout.flush() catch {};
 
     if (json_mode) {
-        try writeJsonOutput(ctx, &db, show_formula, show_cask, show_pinned, tap_filter, stdout);
+        try writeJsonOutput(ctx, &db, prefix, show_formula, show_cask, show_pinned, show_size, show_linked, tap_filter, stdout);
     } else {
         try writeHumanOutput(&db, show_formula, show_cask, show_versions, show_pinned, tap_filter, stdout);
     }
@@ -176,10 +185,10 @@ fn listSqlVariant(show_pinned: bool, tap_filter: bool) ListSqlVariant {
 /// always attributed at install time, so this is purely future-proofing.
 fn formulaListSql(show_pinned: bool, tap_filter: bool) [:0]const u8 {
     return switch (listSqlVariant(show_pinned, tap_filter)) {
-        .plain => "SELECT name, version, pinned FROM kegs ORDER BY name;",
-        .tap => "SELECT name, version, pinned FROM kegs WHERE tap = ?1 ORDER BY name;",
-        .pinned => "SELECT name, version, pinned FROM kegs WHERE pinned = 1 ORDER BY name;",
-        .pinned_tap => "SELECT name, version, pinned FROM kegs WHERE pinned = 1 AND tap = ?1 ORDER BY name;",
+        .plain => "SELECT name, version, pinned, id, cellar_path FROM kegs ORDER BY name;",
+        .tap => "SELECT name, version, pinned, id, cellar_path FROM kegs WHERE tap = ?1 ORDER BY name;",
+        .pinned => "SELECT name, version, pinned, id, cellar_path FROM kegs WHERE pinned = 1 ORDER BY name;",
+        .pinned_tap => "SELECT name, version, pinned, id, cellar_path FROM kegs WHERE pinned = 1 AND tap = ?1 ORDER BY name;",
     };
 }
 
@@ -189,10 +198,10 @@ fn formulaListSql(show_pinned: bool, tap_filter: bool) [:0]const u8 {
 /// help string.
 fn caskListSql(show_pinned: bool, tap_filter: bool) [:0]const u8 {
     return switch (listSqlVariant(show_pinned, tap_filter)) {
-        .plain => "SELECT token, version FROM casks ORDER BY token;",
-        .tap => "SELECT token, version FROM casks WHERE tap = ?1 ORDER BY token;",
-        .pinned => "SELECT token, version FROM casks WHERE pinned = 1 ORDER BY token;",
-        .pinned_tap => "SELECT token, version FROM casks WHERE pinned = 1 AND tap = ?1 ORDER BY token;",
+        .plain => "SELECT token, version, pinned, app_path FROM casks ORDER BY token;",
+        .tap => "SELECT token, version, pinned, app_path FROM casks WHERE tap = ?1 ORDER BY token;",
+        .pinned => "SELECT token, version, pinned, app_path FROM casks WHERE pinned = 1 ORDER BY token;",
+        .pinned_tap => "SELECT token, version, pinned, app_path FROM casks WHERE pinned = 1 AND tap = ?1 ORDER BY token;",
     };
 }
 
@@ -256,26 +265,31 @@ fn pinnedUnionKind(show_formula: bool, show_cask: bool) PinnedUnionKind {
 /// `?1` is bound once and reused across both UNION branches when
 /// `tap_filter` is set — sqlite parameter reuse is well-defined.
 fn pinnedUnionSql(show_formula: bool, show_cask: bool, tap_filter: bool) ?[:0]const u8 {
+    // Column shape across every branch: name, version, kind, ref_id,
+    // ref_path. `ref_id` is the keg id (NULL for casks); `ref_path` is the
+    // keg's cellar_path or the cask's app_path — feeds size/linked extras.
+    const kegs_select = "SELECT name, version, 'formula' AS kind, id AS ref_id, cellar_path AS ref_path FROM kegs WHERE pinned = 1";
+    const casks_select = "SELECT token AS name, version, 'cask' AS kind, NULL AS ref_id, app_path AS ref_path FROM casks WHERE pinned = 1";
     return switch (pinnedUnionKind(show_formula, show_cask)) {
         .neither => null,
         .both => if (tap_filter)
-            "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 AND tap = ?1 " ++
+            kegs_select ++ " AND tap = ?1 " ++
                 "UNION ALL " ++
-                "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 AND tap = ?1 " ++
+                casks_select ++ " AND tap = ?1 " ++
                 "ORDER BY name;"
         else
-            "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 " ++
+            kegs_select ++ " " ++
                 "UNION ALL " ++
-                "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 " ++
+                casks_select ++ " " ++
                 "ORDER BY name;",
         .formula_only => if (tap_filter)
-            "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 AND tap = ?1 ORDER BY name;"
+            kegs_select ++ " AND tap = ?1 ORDER BY name;"
         else
-            "SELECT name, version, 'formula' AS kind FROM kegs WHERE pinned = 1 ORDER BY name;",
+            kegs_select ++ " ORDER BY name;",
         .cask_only => if (tap_filter)
-            "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 AND tap = ?1 ORDER BY name;"
+            casks_select ++ " AND tap = ?1 ORDER BY name;"
         else
-            "SELECT token AS name, version, 'cask' AS kind FROM casks WHERE pinned = 1 ORDER BY name;",
+            casks_select ++ " ORDER BY name;",
     };
 }
 
@@ -310,14 +324,17 @@ fn writeStyledSpan(
 fn writeJsonOutput(
     ctx: *const AppCtx,
     db: *sqlite.Database,
+    prefix: []const u8,
     show_formula: bool,
     show_cask: bool,
     show_pinned: bool,
+    show_size: bool,
+    show_linked: bool,
     tap_filter: ?[]const u8,
     stdout: *std.Io.Writer,
 ) !void {
     const start_ts = std.Io.Clock.real.now(ctx.io).toMilliseconds();
-    try buildListJson(db, stdout, show_formula, show_cask, show_pinned, tap_filter, start_ts);
+    try buildListJson(db, stdout, ctx.io, prefix, show_formula, show_cask, show_pinned, show_size, show_linked, tap_filter, start_ts);
 }
 
 /// Build the `{ "installed": [...], "formulae": [...], "casks": [...], "time_ms": N }`
@@ -327,33 +344,41 @@ fn writeJsonOutput(
 pub fn buildListJson(
     db: *sqlite.Database,
     w: *std.Io.Writer,
+    io: std.Io,
+    prefix: []const u8,
     show_formula: bool,
     show_cask: bool,
     show_pinned: bool,
+    show_size: bool,
+    show_linked: bool,
     tap_filter: ?[]const u8,
     start_ts: i64,
 ) !void {
+    // `--size`/`--linked` enrich only the `installed` array; the legacy
+    // formulae/casks arrays stay byte-stable for existing consumers.
+    const extras: Extras = .{ .io = io, .prefix = prefix, .size = show_size, .linked = show_linked };
+
     try w.writeAll("{\"installed\":[");
     var first = true;
     if (show_pinned) {
-        try writePinnedInstalled(db, w, show_formula, show_cask, tap_filter, &first);
+        try writePinnedInstalled(db, w, show_formula, show_cask, tap_filter, extras, &first);
     } else {
-        if (show_formula) try writeFormulaRows(db, w, false, tap_filter, .installed, &first);
-        if (show_cask) try writeCaskRows(db, w, false, tap_filter, .installed, &first);
+        if (show_formula) try writeFormulaRows(db, w, false, tap_filter, .installed, extras, &first);
+        if (show_cask) try writeCaskRows(db, w, false, tap_filter, .installed, extras, &first);
     }
     try w.writeAll("]");
 
     if (show_formula) {
         try w.writeAll(",\"formulae\":[");
         var legacy_first = true;
-        try writeFormulaRows(db, w, show_pinned, tap_filter, .legacy, &legacy_first);
+        try writeFormulaRows(db, w, show_pinned, tap_filter, .legacy, extras.legacy(), &legacy_first);
         try w.writeAll("]");
     }
 
     if (show_cask) {
         try w.writeAll(",\"casks\":[");
         var legacy_first = true;
-        try writeCaskRows(db, w, show_pinned, tap_filter, .legacy, &legacy_first);
+        try writeCaskRows(db, w, show_pinned, tap_filter, .legacy, extras.legacy(), &legacy_first);
         try w.writeAll("]");
     }
 
@@ -370,6 +395,7 @@ fn writePinnedInstalled(
     show_formula: bool,
     show_cask: bool,
     tap_filter: ?[]const u8,
+    extras: Extras,
     first: *bool,
 ) !void {
     const sql = pinnedUnionSql(show_formula, show_cask, tap_filter != null) orelse return;
@@ -381,23 +407,58 @@ fn writePinnedInstalled(
         const name = stmt.columnText(0) orelse continue;
         const ver = stmt.columnText(1);
         const kind = stmt.columnText(2);
+        const name_slice = std.mem.sliceTo(name, 0);
         const is_cask = if (kind) |k| std.mem.eql(u8, std.mem.sliceTo(k, 0), "cask") else false;
 
         if (!first.*) try w.writeAll(",");
         first.* = false;
         try w.writeAll("{\"name\":");
-        try output.jsonStr(w, std.mem.sliceTo(name, 0));
+        try output.jsonStr(w, name_slice);
         try w.writeAll(",\"version\":");
         try output.jsonStr(w, if (ver) |v| std.mem.sliceTo(v, 0) else "");
         if (is_cask) {
-            try w.writeAll(",\"type\":\"cask\",\"pinned\":true}");
+            const app_path = if (stmt.columnText(4)) |p| std.mem.sliceTo(p, 0) else "";
+            try w.writeAll(",\"type\":\"cask\",\"pinned\":true");
+            try writeCaskSizeField(w, extras, name_slice, app_path);
+            try writeLinkedField(w, extras, .cask, db);
+            try w.writeAll("}");
         } else {
-            try w.writeAll(",\"type\":\"formula\",\"pinned\":true}");
+            const keg_id = stmt.columnInt(3);
+            const cellar = if (stmt.columnText(4)) |c| std.mem.sliceTo(c, 0) else "";
+            try w.writeAll(",\"type\":\"formula\",\"pinned\":true");
+            try writeSizeField(w, extras, cellar);
+            try writeLinkedField(w, extras, .{ .formula = keg_id }, db);
+            try w.writeAll("}");
         }
     }
 }
 
 const RowShape = enum { installed, legacy };
+
+/// Per-row enrichment for the `installed` array. The legacy arrays pass
+/// `.legacy()` so their bytes stay stable for existing consumers.
+const Extras = struct {
+    io: std.Io,
+    prefix: []const u8,
+    size: bool,
+    linked: bool,
+
+    /// Same io/prefix but both opt-in fields off — for the legacy arrays.
+    fn legacy(self: Extras) Extras {
+        return .{ .io = self.io, .prefix = self.prefix, .size = false, .linked = false };
+    }
+};
+
+/// Append `,"size_bytes":N` for a real on-disk directory when `--size`
+/// is on. `dir` empty (or missing on disk) yields 0 — a partial keg must
+/// not crash the writer.
+fn writeSizeField(w: *std.Io.Writer, extras: Extras, dir: []const u8) !void {
+    if (!extras.size) return;
+    const bytes = if (dir.len == 0) 0 else dirsize.dirSizeBytes(extras.io, dir);
+    // 40 > label (14) + max u64 (20 digits) — bufPrint cannot run out.
+    var buf: [40]u8 = undefined;
+    try w.writeAll(std.fmt.bufPrint(&buf, ",\"size_bytes\":{d}", .{bytes}) catch return);
+}
 
 fn writeFormulaRows(
     db: *sqlite.Database,
@@ -405,6 +466,7 @@ fn writeFormulaRows(
     show_pinned: bool,
     tap_filter: ?[]const u8,
     shape: RowShape,
+    extras: Extras,
     first: *bool,
 ) !void {
     const sql = formulaListSql(show_pinned, tap_filter != null);
@@ -425,8 +487,12 @@ fn writeFormulaRows(
         try output.jsonStr(w, if (ver) |v| std.mem.sliceTo(v, 0) else "");
         switch (shape) {
             .installed => {
+                const keg_id = stmt.columnInt(3);
+                const cellar = if (stmt.columnText(4)) |c| std.mem.sliceTo(c, 0) else "";
                 try w.writeAll(",\"type\":\"formula\",\"pinned\":");
                 try w.writeAll(if (pinned) "true" else "false");
+                try writeSizeField(w, extras, cellar);
+                try writeLinkedField(w, extras, .{ .formula = keg_id }, db);
                 try w.writeAll("}");
             },
             .legacy => {
@@ -444,6 +510,7 @@ fn writeCaskRows(
     show_pinned: bool,
     tap_filter: ?[]const u8,
     shape: RowShape,
+    extras: Extras,
     first: *bool,
 ) !void {
     const sql = caskListSql(show_pinned, tap_filter != null);
@@ -454,16 +521,23 @@ fn writeCaskRows(
     while (stmt.step() catch false) {
         const token = stmt.columnText(0) orelse continue;
         const ver = stmt.columnText(1);
+        const pinned = stmt.columnBool(2);
         const ver_str: []const u8 = if (ver) |v| std.mem.sliceTo(v, 0) else "";
         if (!first.*) try w.writeAll(",");
         first.* = false;
         switch (shape) {
             .installed => {
+                const token_slice = std.mem.sliceTo(token, 0);
+                const app_path = if (stmt.columnText(3)) |p| std.mem.sliceTo(p, 0) else "";
                 try w.writeAll("{\"name\":");
-                try output.jsonStr(w, std.mem.sliceTo(token, 0));
+                try output.jsonStr(w, token_slice);
                 try w.writeAll(",\"version\":");
                 try output.jsonStr(w, ver_str);
-                try w.writeAll(",\"type\":\"cask\"}");
+                try w.writeAll(",\"type\":\"cask\",\"pinned\":");
+                try w.writeAll(if (pinned) "true" else "false");
+                try writeCaskSizeField(w, extras, token_slice, app_path);
+                try writeLinkedField(w, extras, .cask, db);
+                try w.writeAll("}");
             },
             .legacy => {
                 try w.writeAll("{\"token\":");
@@ -474,4 +548,39 @@ fn writeCaskRows(
             },
         }
     }
+}
+
+/// A cask's on-disk footprint is its in-prefix `Caskroom/<token>` plus the
+/// installed artifact at `app_path` (often a `.app` bundle outside the
+/// prefix). The symlink-safe walk means a binary cask's `app_path`
+/// symlink-into-Caskroom is never double-counted.
+fn writeCaskSizeField(w: *std.Io.Writer, extras: Extras, token: []const u8, app_path: []const u8) !void {
+    if (!extras.size) return;
+    var total: u64 = 0;
+    var buf: [512]u8 = undefined;
+    if (std.fmt.bufPrint(&buf, "{s}/Caskroom/{s}", .{ extras.prefix, token })) |caskroom| {
+        total +|= dirsize.dirSizeBytes(extras.io, caskroom);
+    } else |_| {}
+    if (app_path.len > 0) total +|= dirsize.dirSizeBytes(extras.io, app_path);
+    // 40 > label (14) + max u64 (20 digits) — bufPrint cannot run out.
+    var nb: [40]u8 = undefined;
+    try w.writeAll(std.fmt.bufPrint(&nb, ",\"size_bytes\":{d}", .{total}) catch return);
+}
+
+/// `linked` source per kind: a formula keg consults the `links` table
+/// (via `core/linker`); a cask has no prefix-link concept and is always
+/// active once installed, so it reports `true`.
+const LinkSource = union(enum) {
+    formula: i64,
+    cask,
+};
+
+fn writeLinkedField(w: *std.Io.Writer, extras: Extras, src: LinkSource, db: *sqlite.Database) !void {
+    if (!extras.linked) return;
+    const is_linked = switch (src) {
+        .formula => |keg_id| linker.isKegLinked(db, keg_id),
+        .cask => true,
+    };
+    try w.writeAll(",\"linked\":");
+    try w.writeAll(if (is_linked) "true" else "false");
 }

--- a/src/core/linker.zig
+++ b/src/core/linker.zig
@@ -1,4 +1,7 @@
 const std = @import("std");
+const testing = std.testing;
+
+const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
 
 pub const LinkError = error{ ConflictFound, LinkFailed, UnlinkFailed, OutOfMemory };
@@ -203,3 +206,37 @@ pub const Linker = struct {
         _ = try del_stmt.step();
     }
 };
+
+/// Read-only link status for a keg: true iff any symlink is recorded for
+/// it in `links`. Counterpart to `link`/`unlink`; `mt list --json
+/// --linked` uses it to report whether a keg is active in the prefix.
+/// Any DB error reads as "not linked" rather than failing the row.
+pub fn isKegLinked(db: *sqlite.Database, keg_id: i64) bool {
+    var stmt = db.prepare("SELECT EXISTS(SELECT 1 FROM links WHERE keg_id = ?1);") catch return false;
+    defer stmt.finalize();
+    stmt.bindInt(1, keg_id) catch return false;
+    if (stmt.step() catch false) return stmt.columnInt(0) != 0;
+    return false;
+}
+
+test "isKegLinked reflects whether the keg has link rows" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (id, name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (1, 'linked-keg', 'linked-keg', '1.0', 'aa', '/c/linked-keg/1.0'),
+        \\       (2, 'bare-keg',   'bare-keg',   '2.0', 'bb', '/c/bare-keg/2.0');
+    );
+    // Only keg 1 has a recorded symlink.
+    try db.exec(
+        \\INSERT INTO links (keg_id, link_path, target)
+        \\VALUES (1, '/opt/malt/bin/linked-keg', '/c/linked-keg/1.0/bin/linked-keg');
+    );
+
+    try testing.expect(isKegLinked(&db, 1));
+    try testing.expect(!isKegLinked(&db, 2));
+    // A keg id that doesn't exist is simply "not linked".
+    try testing.expect(!isKegLinked(&db, 999));
+}

--- a/src/fs/dirsize.zig
+++ b/src/fs/dirsize.zig
@@ -1,0 +1,130 @@
+//! malt — recursive on-disk size of a directory tree.
+//!
+//! A leaf helper used by `mt list --json --size` to report `size_bytes`
+//! per installed keg/cask. Symlink-safe: regular files are summed,
+//! real subdirectories are recursed, and symlinks are neither counted
+//! nor followed — so a keg's internal symlinks and a cask's `app_path`
+//! symlink-into-Caskroom never double-count or escape the tree.
+
+const std = @import("std");
+const testing = std.testing;
+
+/// Sum the byte size of every regular file under `path`, recursively.
+/// Missing or unreadable directories contribute 0 rather than failing —
+/// a partial/absent keg dir must not crash the row writer.
+pub fn dirSizeBytes(io: std.Io, path: []const u8) u64 {
+    var dir = std.Io.Dir.openDirAbsolute(io, path, .{ .iterate = true }) catch return 0;
+    defer dir.close(io);
+    return sumDir(io, &dir);
+}
+
+/// Walk one directory level: count regular files, recurse real
+/// subdirectories. Anything else (symlinks, sockets, devices) is left
+/// alone so symlinks are never counted nor traversed. Saturating add
+/// guards the theoretical u64 overflow on a pathological tree.
+fn sumDir(io: std.Io, dir: *std.Io.Dir) u64 {
+    var total: u64 = 0;
+    var it = dir.iterate();
+    while (it.next(io) catch null) |entry| {
+        switch (entry.kind) {
+            .file => {
+                const st = dir.statFile(io, entry.name, .{ .follow_symlinks = false }) catch continue;
+                total +|= st.size;
+            },
+            .directory => {
+                var sub = dir.openDir(io, entry.name, .{ .iterate = true }) catch continue;
+                defer sub.close(io);
+                total +|= sumDir(io, &sub);
+            },
+            else => {},
+        }
+    }
+    return total;
+}
+
+test "dirSizeBytes sums nested regular files and skips symlinks" {
+    const io = std.Options.debug_io;
+    const root = "/tmp/malt_dirsize_nested";
+    std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    try std.Io.Dir.cwd().createDirPath(io, root ++ "/sub");
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, root ++ "/a.txt", .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "12345"); // 5 bytes
+    }
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, root ++ "/sub/b.txt", .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "678"); // 3 bytes
+    }
+    // A symlink to a real 5-byte file must contribute nothing.
+    var sub = try std.Io.Dir.openDirAbsolute(io, root, .{});
+    defer sub.close(io);
+    sub.symLink(io, root ++ "/a.txt", "link", .{}) catch {};
+
+    try testing.expectEqual(@as(u64, 8), dirSizeBytes(io, root));
+}
+
+test "dirSizeBytes does not follow a symlink that points at a directory" {
+    // The escape/double-count guard: a keg/cask can contain a symlink to
+    // another directory. Following it would count bytes outside the tree.
+    const io = std.Options.debug_io;
+    const root = "/tmp/malt_dirsize_dirlink";
+    const outside = "/tmp/malt_dirsize_outside";
+    std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    std.Io.Dir.cwd().deleteTree(io, outside) catch {};
+    try std.Io.Dir.cwd().createDirPath(io, root ++ "/real");
+    try std.Io.Dir.createDirAbsolute(io, outside, .default_dir);
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, outside) catch {};
+
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, root ++ "/real/keep", .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "1234"); // 4 bytes — the only thing counted
+    }
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, outside ++ "/escaped", .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "SHOULD-NOT-COUNT"); // behind a dir symlink
+    }
+    var rd = try std.Io.Dir.openDirAbsolute(io, root, .{});
+    defer rd.close(io);
+    rd.symLink(io, outside, "danger", .{}) catch {};
+
+    try testing.expectEqual(@as(u64, 4), dirSizeBytes(io, root));
+}
+
+test "dirSizeBytes returns 0 for a missing directory" {
+    const io = std.Options.debug_io;
+    try testing.expectEqual(@as(u64, 0), dirSizeBytes(io, "/tmp/malt_dirsize_does_not_exist_xyz"));
+}
+
+test "dirSizeBytes counts a zero-byte file as 0 without skipping the tree" {
+    const io = std.Options.debug_io;
+    const root = "/tmp/malt_dirsize_zerofile";
+    std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    try std.Io.Dir.createDirAbsolute(io, root, .default_dir);
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, root ++ "/empty", .{});
+        f.close(io);
+    }
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, root ++ "/data", .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "xyz"); // 3 bytes
+    }
+    try testing.expectEqual(@as(u64, 3), dirSizeBytes(io, root));
+}
+
+test "dirSizeBytes returns 0 for an empty directory" {
+    const io = std.Options.debug_io;
+    const root = "/tmp/malt_dirsize_empty";
+    std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    try std.Io.Dir.createDirAbsolute(io, root, .default_dir);
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    try testing.expectEqual(@as(u64, 0), dirSizeBytes(io, root));
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -78,6 +78,7 @@ pub const sqlite = @import("db/sqlite.zig");
 pub const archive = @import("fs/archive.zig");
 pub const atomic = @import("fs/atomic.zig");
 pub const clonefile = @import("fs/clonefile.zig");
+pub const dirsize = @import("fs/dirsize.zig");
 pub const codesign = @import("macho/codesign.zig");
 pub const parser = @import("macho/parser.zig");
 pub const patcher = @import("macho/patcher.zig");

--- a/tests/list_test.zig
+++ b/tests/list_test.zig
@@ -91,13 +91,52 @@ fn runBuildTap(
     show_pinned: bool,
     tap_filter: ?[]const u8,
 ) ![]u8 {
+    return runBuildFull(allocator, db, show_formula, show_cask, show_pinned, false, false, tap_filter, "");
+}
+
+/// Full encoder entry point: lets size/linked tests opt into the new
+/// `--size`/`--linked` enrichment and supply the prefix used to resolve
+/// cask `Caskroom/<token>` paths.
+fn runBuildFull(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    show_formula: bool,
+    show_cask: bool,
+    show_pinned: bool,
+    show_size: bool,
+    show_linked: bool,
+    tap_filter: ?[]const u8,
+    prefix: []const u8,
+) ![]u8 {
     var aw: std.Io.Writer.Allocating = .init(allocator);
     errdefer aw.deinit();
     // Use a fixed start_ts so the ",\"time_ms\":N" suffix is predictable.
-    try cli_list.buildListJson(db, &aw.writer, show_formula, show_cask, show_pinned, tap_filter, test_io.milliTimestamp(
+    try cli_list.buildListJson(
+        db,
+        &aw.writer,
         std.Options.debug_io,
-    ));
+        prefix,
+        show_formula,
+        show_cask,
+        show_pinned,
+        show_size,
+        show_linked,
+        tap_filter,
+        test_io.milliTimestamp(std.Options.debug_io),
+    );
     return aw.toOwnedSlice();
+}
+
+/// Write `body` to `parent/rel`, creating intermediate dirs. Mirrors the
+/// keg-dir fixtures other suites build for on-disk walks.
+fn writeTreeFile(parent: []const u8, rel: []const u8, body: []const u8) !void {
+    const io = std.Options.debug_io;
+    var buf: [512]u8 = undefined;
+    const abs = try std.fmt.bufPrint(&buf, "{s}/{s}", .{ parent, rel });
+    if (std.fs.path.dirname(abs)) |d| std.Io.Dir.cwd().createDirPath(io, d) catch {};
+    const f = try std.Io.Dir.createFileAbsolute(io, abs, .{});
+    defer f.close(io);
+    try f.writeStreamingAll(io, body);
 }
 
 // Strip the non-deterministic ",\"time_ms\":N}\n" suffix so assertions can
@@ -230,9 +269,37 @@ test "buildListJson: cask-only, one cask" {
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
         "{\"installed\":[" ++
-            "{\"name\":\"firefox\",\"version\":\"120.0\",\"type\":\"cask\"}" ++
+            "{\"name\":\"firefox\",\"version\":\"120.0\",\"type\":\"cask\",\"pinned\":false}" ++
             "],\"casks\":[" ++
             "{\"token\":\"firefox\",\"version\":\"120.0\"}" ++
+            "]",
+        body,
+    );
+}
+
+test "buildListJson: cask .installed row carries pinned, matching formulae" {
+    // Symmetry with formula rows: a pinned cask must surface `pinned:true`
+    // in the installed array so the dashboard can show held casks too.
+    var t = try TempDb.init("cask_pinned");
+    defer t.deinit();
+
+    try insertCask(&t.db, "loose", "1.0"); // unpinned
+    try t.db.exec(
+        \\INSERT INTO casks (token, name, version, url, pinned)
+        \\VALUES ('held', 'held', '2.0', 'https://example.invalid', 1);
+    );
+
+    const out = try runBuild(testing.allocator, &t.db, false, true, false);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"held\",\"version\":\"2.0\",\"type\":\"cask\",\"pinned\":true}," ++
+            "{\"name\":\"loose\",\"version\":\"1.0\",\"type\":\"cask\",\"pinned\":false}" ++
+            "],\"casks\":[" ++
+            "{\"token\":\"held\",\"version\":\"2.0\"}," ++
+            "{\"token\":\"loose\",\"version\":\"1.0\"}" ++
             "]",
         body,
     );
@@ -252,7 +319,7 @@ test "buildListJson: mixed kegs and casks, comma between types in installed" {
     try testing.expectEqualStrings(
         "{\"installed\":[" ++
             "{\"name\":\"zsh\",\"version\":\"5.9\",\"type\":\"formula\",\"pinned\":false}," ++
-            "{\"name\":\"slack\",\"version\":\"4.0\",\"type\":\"cask\"}" ++
+            "{\"name\":\"slack\",\"version\":\"4.0\",\"type\":\"cask\",\"pinned\":false}" ++
             "],\"formulae\":[" ++
             "{\"name\":\"zsh\",\"version\":\"5.9\",\"pinned\":false}" ++
             "],\"casks\":[" ++
@@ -508,7 +575,7 @@ test "buildListJson --tap filters both installed and legacy arrays" {
     try testing.expectEqualStrings(
         "{\"installed\":[" ++
             "{\"name\":\"tap-formula\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":false}," ++
-            "{\"name\":\"tap-cask\",\"version\":\"3.0\",\"type\":\"cask\"}" ++
+            "{\"name\":\"tap-cask\",\"version\":\"3.0\",\"type\":\"cask\",\"pinned\":false}" ++
             "],\"formulae\":[" ++
             "{\"name\":\"tap-formula\",\"version\":\"1.0\",\"pinned\":false}" ++
             "],\"casks\":[" ++
@@ -577,4 +644,356 @@ test "buildListJson: output parses as valid JSON" {
     try testing.expect(root.get("formulae") != null);
     try testing.expect(root.get("casks") != null);
     try testing.expect(root.get("time_ms") != null);
+}
+
+test "buildListJson --size --linked output parses as valid JSON with both fields" {
+    var t = try TempDb.init("valid_json_extras");
+    defer t.deinit();
+    try insertKeg(&t.db, "tree", "2.1", false);
+    try insertCask(&t.db, "obs", "30.0");
+
+    const out = try runBuildFull(testing.allocator, &t.db, true, true, false, true, true, null, t.dir);
+    defer testing.allocator.free(out);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, out, .{});
+    defer parsed.deinit();
+
+    const installed = parsed.value.object.get("installed").?.array;
+    try testing.expectEqual(@as(usize, 2), installed.items.len);
+    for (installed.items) |row| {
+        try testing.expect(row.object.get("size_bytes").? == .integer);
+        try testing.expect(row.object.get("linked").? == .bool);
+    }
+    // Legacy arrays must stay lean — no enrichment leaked into them.
+    const legacy_formulae = parsed.value.object.get("formulae").?.array;
+    try testing.expect(legacy_formulae.items[0].object.get("size_bytes") == null);
+    try testing.expect(legacy_formulae.items[0].object.get("linked") == null);
+}
+
+// --- --size ------------------------------------------------------------
+
+test "buildListJson --size sums size_bytes from the keg cellar dir" {
+    var t = try TempDb.init("size_formula");
+    defer t.deinit();
+
+    var cb: [256]u8 = undefined;
+    const cellar = try std.fmt.bufPrint(&cb, "{s}/Cellar/treesize/1.0", .{t.dir});
+    try writeTreeFile(cellar, "bin/a", "12345"); // 5 bytes
+    try writeTreeFile(cellar, "lib/b", "678"); // 3 bytes
+
+    var sb: [600]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &sb,
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path) VALUES ('treesize','treesize','1.0','deadbeef','{s}');",
+        .{cellar},
+    );
+    try t.db.exec(sql);
+
+    const out = try runBuildFull(testing.allocator, &t.db, true, false, false, true, false, null, t.dir);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"treesize\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":false,\"size_bytes\":8}" ++
+            "],\"formulae\":[" ++
+            "{\"name\":\"treesize\",\"version\":\"1.0\",\"pinned\":false}" ++
+            "]",
+        body,
+    );
+}
+
+test "buildListJson --size emits size_bytes:0 when the keg cellar dir is missing" {
+    // A partial/absent keg dir must not crash the writer — it reads as 0.
+    var t = try TempDb.init("size_missing");
+    defer t.deinit();
+    try insertKeg(&t.db, "ghost", "1.0", false); // cellar_path points nowhere real
+
+    const out = try runBuildFull(testing.allocator, &t.db, true, false, false, true, false, null, t.dir);
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "\"size_bytes\":0") != null);
+}
+
+test "buildListJson --size emits size_bytes:0 for an empty cellar dir" {
+    var t = try TempDb.init("size_empty");
+    defer t.deinit();
+
+    var cb: [256]u8 = undefined;
+    const cellar = try std.fmt.bufPrint(&cb, "{s}/Cellar/empty/1.0", .{t.dir});
+    try std.Io.Dir.cwd().createDirPath(std.Options.debug_io, cellar);
+
+    var sb: [600]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &sb,
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path) VALUES ('empty','empty','1.0','deadbeef','{s}');",
+        .{cellar},
+    );
+    try t.db.exec(sql);
+
+    const out = try runBuildFull(testing.allocator, &t.db, true, false, false, true, false, null, t.dir);
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "\"size_bytes\":0") != null);
+}
+
+test "buildListJson --size sums a cask's Caskroom dir and app_path bundle" {
+    var t = try TempDb.init("size_cask");
+    defer t.deinit();
+
+    var crb: [256]u8 = undefined;
+    const caskroom = try std.fmt.bufPrint(&crb, "{s}/Caskroom/widget", .{t.dir});
+    try writeTreeFile(caskroom, "1.0/data", "abcd"); // 4 bytes in-prefix bookkeeping
+
+    var ab: [256]u8 = undefined;
+    const app = try std.fmt.bufPrint(&ab, "{s}/Applications/Widget.app", .{t.dir});
+    try writeTreeFile(app, "Contents/MacOS/widget", "binary"); // 6 bytes app payload
+
+    var sb: [700]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &sb,
+        "INSERT INTO casks (token, name, version, url, app_path) VALUES ('widget','Widget','1.0','https://example.invalid','{s}');",
+        .{app},
+    );
+    try t.db.exec(sql);
+
+    const out = try runBuildFull(testing.allocator, &t.db, false, true, false, true, false, null, t.dir);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"widget\",\"version\":\"1.0\",\"type\":\"cask\",\"pinned\":false,\"size_bytes\":10}" ++
+            "],\"casks\":[" ++
+            "{\"token\":\"widget\",\"version\":\"1.0\"}" ++
+            "]",
+        body,
+    );
+}
+
+test "buildListJson --size on a cask with no app_path counts only the Caskroom dir" {
+    // A cask row may carry a NULL app_path; size must fall back to the
+    // in-prefix Caskroom dir without crashing the writer.
+    var t = try TempDb.init("size_cask_no_app");
+    defer t.deinit();
+
+    var crb: [256]u8 = undefined;
+    const caskroom = try std.fmt.bufPrint(&crb, "{s}/Caskroom/barecask", .{t.dir});
+    try writeTreeFile(caskroom, "1.0/payload", "abcdef"); // 6 bytes
+    try insertCask(&t.db, "barecask", "1.0"); // app_path stays NULL
+
+    const out = try runBuildFull(testing.allocator, &t.db, false, true, false, true, false, null, t.dir);
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "\"size_bytes\":6") != null);
+}
+
+test "buildListJson --size does not double-count a cask app_path symlinked into Caskroom" {
+    // Binary casks symlink their installed name back into the payload that
+    // already lives under Caskroom. The symlink-safe walk must count the
+    // 7-byte payload once (via Caskroom) and ignore the app_path symlink.
+    var t = try TempDb.init("size_cask_symlink");
+    defer t.deinit();
+    const io = std.Options.debug_io;
+
+    var crb: [256]u8 = undefined;
+    const caskroom = try std.fmt.bufPrint(&crb, "{s}/Caskroom/tool", .{t.dir});
+    try writeTreeFile(caskroom, "2.0/tool", "1234567"); // 7 bytes
+
+    var binb: [256]u8 = undefined;
+    const bindir = try std.fmt.bufPrint(&binb, "{s}/bin", .{t.dir});
+    std.Io.Dir.cwd().createDirPath(io, bindir) catch {};
+    var tgtb: [320]u8 = undefined;
+    const target = try std.fmt.bufPrint(&tgtb, "{s}/2.0/tool", .{caskroom});
+    var bd = try std.Io.Dir.openDirAbsolute(io, bindir, .{});
+    defer bd.close(io);
+    bd.symLink(io, target, "tool", .{}) catch {};
+
+    var appb: [256]u8 = undefined;
+    const app = try std.fmt.bufPrint(&appb, "{s}/tool", .{bindir});
+    var sb: [700]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &sb,
+        "INSERT INTO casks (token, name, version, url, app_path) VALUES ('tool','tool','2.0','https://example.invalid','{s}');",
+        .{app},
+    );
+    try t.db.exec(sql);
+
+    const out = try runBuildFull(testing.allocator, &t.db, false, true, false, true, false, null, t.dir);
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "\"size_bytes\":7") != null);
+}
+
+// --- --linked ----------------------------------------------------------
+
+test "buildListJson --linked reports keg link status from the links table" {
+    var t = try TempDb.init("linked_formula");
+    defer t.deinit();
+
+    try t.db.exec(
+        \\INSERT INTO kegs (id, name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (1,'active','active','1.0','aa','/c/active/1.0'),
+        \\       (2,'dormant','dormant','2.0','bb','/c/dormant/2.0');
+    );
+    // Only the first keg has a recorded symlink.
+    try t.db.exec(
+        \\INSERT INTO links (keg_id, link_path, target)
+        \\VALUES (1,'/opt/malt/bin/active','/c/active/1.0/bin/active');
+    );
+
+    const out = try runBuildFull(testing.allocator, &t.db, true, false, false, false, true, null, t.dir);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"active\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":false,\"linked\":true}," ++
+            "{\"name\":\"dormant\",\"version\":\"2.0\",\"type\":\"formula\",\"pinned\":false,\"linked\":false}" ++
+            "],\"formulae\":[" ++
+            "{\"name\":\"active\",\"version\":\"1.0\",\"pinned\":false}," ++
+            "{\"name\":\"dormant\",\"version\":\"2.0\",\"pinned\":false}" ++
+            "]",
+        body,
+    );
+}
+
+test "buildListJson --linked reports casks as always linked" {
+    // Casks have no prefix-link concept; an installed cask is active.
+    var t = try TempDb.init("linked_cask");
+    defer t.deinit();
+    try insertCask(&t.db, "firefox", "120.0");
+
+    const out = try runBuildFull(testing.allocator, &t.db, false, true, false, false, true, null, t.dir);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"firefox\",\"version\":\"120.0\",\"type\":\"cask\",\"pinned\":false,\"linked\":true}" ++
+            "],\"casks\":[" ++
+            "{\"token\":\"firefox\",\"version\":\"120.0\"}" ++
+            "]",
+        body,
+    );
+}
+
+test "buildListJson --size --linked emits size_bytes before linked" {
+    // Pins the field order so consumers and the schema doc agree.
+    var t = try TempDb.init("size_linked_order");
+    defer t.deinit();
+
+    var cb: [256]u8 = undefined;
+    const cellar = try std.fmt.bufPrint(&cb, "{s}/Cellar/combo/1.0", .{t.dir});
+    try writeTreeFile(cellar, "bin/x", "ab"); // 2 bytes
+
+    var sb: [600]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &sb,
+        "INSERT INTO kegs (id, name, full_name, version, store_sha256, cellar_path) VALUES (1,'combo','combo','1.0','aa','{s}');",
+        .{cellar},
+    );
+    try t.db.exec(sql);
+    try t.db.exec(
+        \\INSERT INTO links (keg_id, link_path, target) VALUES (1,'/opt/malt/bin/combo','/x');
+    );
+
+    const out = try runBuildFull(testing.allocator, &t.db, true, false, false, true, true, null, t.dir);
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(
+        u8,
+        out,
+        "\"pinned\":false,\"size_bytes\":2,\"linked\":true}",
+    ) != null);
+}
+
+test "buildListJson --tap --size --linked keeps column alignment in the tap SQL" {
+    // The tap SELECT variant carries the same trailing id/cellar_path/
+    // app_path columns; this guards their index alignment under a filter.
+    var t = try TempDb.init("tap_extras");
+    defer t.deinit();
+
+    var cb: [256]u8 = undefined;
+    const cellar = try std.fmt.bufPrint(&cb, "{s}/Cellar/tapped/1.0", .{t.dir});
+    try writeTreeFile(cellar, "bin/y", "abc"); // 3 bytes
+
+    var sb: [600]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &sb,
+        "INSERT INTO kegs (id, name, full_name, version, store_sha256, cellar_path, tap) VALUES (1,'tapped','tapped','1.0','aa','{s}','user/repo');",
+        .{cellar},
+    );
+    try t.db.exec(sql);
+    try t.db.exec(
+        \\INSERT INTO links (keg_id, link_path, target) VALUES (1,'/opt/malt/bin/tapped','/x');
+    );
+    // A second keg in a different tap must be excluded by the filter.
+    try insertKegTap(&t.db, "other", "9.0", "other/repo");
+
+    const out = try runBuildFull(testing.allocator, &t.db, true, false, false, true, true, "user/repo", t.dir);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"tapped\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":false,\"size_bytes\":3,\"linked\":true}" ++
+            "],\"formulae\":[" ++
+            "{\"name\":\"tapped\",\"version\":\"1.0\",\"pinned\":false}" ++
+            "]",
+        body,
+    );
+}
+
+// --- --pinned parity ---------------------------------------------------
+
+test "buildListJson --pinned --size --linked enriches the pinned installed rows" {
+    var t = try TempDb.init("pinned_extras");
+    defer t.deinit();
+
+    var cb: [256]u8 = undefined;
+    const cellar = try std.fmt.bufPrint(&cb, "{s}/Cellar/held/1.0", .{t.dir});
+    try writeTreeFile(cellar, "bin/h", "abcd"); // 4 bytes
+
+    var sb: [600]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(
+        &sb,
+        "INSERT INTO kegs (id, name, full_name, version, store_sha256, cellar_path, pinned) VALUES (1,'held','held','1.0','aa','{s}',1);",
+        .{cellar},
+    );
+    try t.db.exec(sql);
+    try t.db.exec(
+        \\INSERT INTO links (keg_id, link_path, target) VALUES (1,'/opt/malt/bin/held','/x');
+    );
+
+    const out = try runBuildFull(testing.allocator, &t.db, true, false, true, true, true, null, t.dir);
+    defer testing.allocator.free(out);
+
+    const body = trimTimeSuffix(out);
+    try testing.expectEqualStrings(
+        "{\"installed\":[" ++
+            "{\"name\":\"held\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":true,\"size_bytes\":4,\"linked\":true}" ++
+            "],\"formulae\":[" ++
+            "{\"name\":\"held\",\"version\":\"1.0\",\"pinned\":true}" ++
+            "]",
+        body,
+    );
+}
+
+test "buildListJson --pinned --linked marks pinned casks linked" {
+    var t = try TempDb.init("pinned_cask_linked");
+    defer t.deinit();
+    try t.db.exec(
+        \\INSERT INTO casks (token, name, version, url, pinned)
+        \\VALUES ('held','held','2.0','https://example.invalid',1);
+    );
+
+    const out = try runBuildFull(testing.allocator, &t.db, false, true, true, false, true, null, t.dir);
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(
+        u8,
+        out,
+        "\"type\":\"cask\",\"pinned\":true,\"linked\":true",
+    ) != null);
 }


### PR DESCRIPTION
## Description

`mt list --json` now reports `pinned` on cask rows (matching formulae), and two opt-in flags expose richer per-keg data without slowing the default path: `--size` adds `size_bytes` (on-disk size) and `--linked` adds `linked` (is the keg active in the prefix). The default `mt list --json` stays O(kegs) metadata and runs no directory walk, so scripts and pipelines pay nothing.

## Related Issue

- None

## Notes for Reviewers

- None