### PR TITLE
feat(info): expose the dependency list in JSON for installed packages

### DIFF
--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -125,11 +125,66 @@ fn emitInstalledFormula(
     defer rollback.freeEntries(allocator, &history);
 
     if (json_mode) {
-        try writeJsonInfo(name, &stmt, history.items, stdout);
+        // Deps are read from the local `dependencies` table, never the
+        // network, so the detail pane works offline for installed packages.
+        const deps = collectInstalledDeps(allocator, db, name);
+        defer freeDeps(allocator, deps);
+        try writeJsonInfo(name, &stmt, history.items, deps, stdout);
     } else {
         try writeHumanInfo(name, &stmt, history.items, stdout, colorize);
     }
     return true;
+}
+
+/// Read an installed keg's recorded runtime dependency names from the
+/// local `dependencies` table. Offline by construction — the dashboard's
+/// detail pane must show deps for already-installed packages without a
+/// network round-trip. Returns an empty slice (never null) for a leaf or
+/// an unrecorded keg so the JSON emits `[]`. Degrades to empty on any DB
+/// error: info is informational and must not fail on a partial dep table.
+/// Caller owns the slice and every string; free with `freeDeps`.
+pub fn collectInstalledDeps(
+    allocator: std.mem.Allocator,
+    db: *sqlite.Database,
+    name: []const u8,
+) []const []const u8 {
+    var keg_stmt = db.prepare("SELECT id FROM kegs WHERE name = ?1 LIMIT 1;") catch return &.{};
+    defer keg_stmt.finalize();
+    keg_stmt.bindText(1, name) catch return &.{};
+    if (!(keg_stmt.step() catch false)) return &.{};
+    const keg_id = keg_stmt.columnInt(0);
+
+    // Stable alphabetical order matches `mt deps`'s DB reader so both
+    // commands present the same list for the same keg.
+    var stmt = db.prepare(
+        "SELECT dep_name FROM dependencies WHERE keg_id = ?1 ORDER BY dep_name;",
+    ) catch return &.{};
+    defer stmt.finalize();
+    stmt.bindInt(1, keg_id) catch return &.{};
+
+    var out: std.ArrayList([]const u8) = .empty;
+    while (stmt.step() catch false) {
+        const raw = stmt.columnText(0) orelse continue;
+        const owned = allocator.dupe(u8, std.mem.sliceTo(raw, 0)) catch break;
+        out.append(allocator, owned) catch {
+            allocator.free(owned);
+            break;
+        };
+    }
+    return out.toOwnedSlice(allocator) catch blk: {
+        // Shrink-realloc OOM: `out` still owns every name, so free them
+        // all before degrading to the empty sentinel.
+        for (out.items) |s| allocator.free(s);
+        out.deinit(allocator);
+        break :blk &.{};
+    };
+}
+
+/// Free a slice returned by `collectInstalledDeps`. Safe on the empty
+/// sentinel — `allocator.free` on a zero-length slice is a no-op.
+fn freeDeps(allocator: std.mem.Allocator, deps: []const []const u8) void {
+    for (deps) |d| allocator.free(d);
+    allocator.free(deps);
 }
 
 /// Cask counterpart to `emitInstalledFormula`.
@@ -479,6 +534,7 @@ fn writeJsonInfo(
     name: []const u8,
     stmt: *sqlite.Statement,
     history: []const rollback.Entry,
+    dependencies: []const []const u8,
     stdout: *std.Io.Writer,
 ) !void {
     const ver = stmt.columnText(1);
@@ -494,6 +550,7 @@ fn writeJsonInfo(
         pinned,
         if (installed_at) |d| std.mem.sliceTo(d, 0) else "",
         history,
+        dependencies,
     );
 }
 
@@ -539,6 +596,7 @@ pub fn encodeInstalledFormulaJson(
     pinned: bool,
     installed_at: []const u8,
     history: []const rollback.Entry,
+    dependencies: []const []const u8,
 ) !void {
     try w.writeAll("{\"name\":");
     try output.jsonStr(w, name);
@@ -546,7 +604,15 @@ pub fn encodeInstalledFormulaJson(
     try output.jsonStr(w, version);
     try w.writeAll(",\"tap\":");
     try output.jsonStr(w, tap);
-    try w.writeAll(",\"pinned\":");
+    // `dependencies` mirrors the not-installed emitter's shape (same name,
+    // array of strings, adjacent to `tap`) so consumers parse one field
+    // regardless of install state.
+    try w.writeAll(",\"dependencies\":[");
+    for (dependencies, 0..) |dep, i| {
+        if (i != 0) try w.writeAll(",");
+        try output.jsonStr(w, dep);
+    }
+    try w.writeAll("],\"pinned\":");
     try w.writeAll(if (pinned) "true" else "false");
     try w.writeAll(",\"installed_at\":");
     try output.jsonStr(w, installed_at);
@@ -680,4 +746,567 @@ fn writeJsonCaskInfo(
 
     const row = readInstalledCaskRow(&stmt, name);
     try encodeInstalledCaskJson(stdout, &row, history);
+}
+
+// --- unit tests (pure encoders) ---------------------------------------------
+//
+// The `encode*` fns are pure: bytes in, bytes out, no I/O. They're driven
+// here with a buffered `std.Io.Writer.Allocating` so the emission shape is
+// asserted without a DB or the filesystem. DB-backed and filesystem
+// behaviour (`collectInstalledDeps`, `openDb`) live in `tests/info_test.zig`.
+
+const testing = std.testing;
+
+const FORMULA_FIXTURE =
+    \\{
+    \\  "name":"wget",
+    \\  "full_name":"wget",
+    \\  "tap":"homebrew/core",
+    \\  "desc":"Internet file retriever",
+    \\  "homepage":"https://www.gnu.org/software/wget/",
+    \\  "license":"GPL-3.0-or-later",
+    \\  "revision":0,
+    \\  "versions":{"stable":"1.24.5"},
+    \\  "dependencies":["libidn2","openssl@3"],
+    \\  "keg_only":false,
+    \\  "post_install_defined":false
+    \\}
+;
+
+const CASK_FIXTURE =
+    \\{
+    \\  "token":"firefox",
+    \\  "name":["Mozilla Firefox"],
+    \\  "version":"149.0.2",
+    \\  "desc":"Web browser",
+    \\  "homepage":"https://www.mozilla.org/firefox/",
+    \\  "url":"https://example.com/firefox.dmg",
+    \\  "sha256":"deadbeef",
+    \\  "auto_updates":false
+    \\}
+;
+
+const ns_per_s: i128 = std.time.ns_per_s;
+
+const two_entries = [_]rollback.Entry{
+    .{ .sha256 = "aaa111", .pkg_version = "1.24", .mtime_ns = 1_700_000_000 * ns_per_s },
+    .{ .sha256 = "bbb222", .pkg_version = "1.23", .mtime_ns = 1_699_000_000 * ns_per_s },
+};
+
+test "encodeInstallHint surfaces both malt and mt invocations" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [512]u8 = undefined;
+    try encodeInstallHint(&aw.writer, &scratch, "wget", false, false, 14);
+    const out = aw.written();
+    try testing.expect(std.mem.indexOf(u8, out, "Status:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Not installed") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Install:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "malt install wget") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "mt install wget") != null);
+}
+
+test "encodeInstallHint collapses to a bare line in quiet mode" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [512]u8 = undefined;
+    try encodeInstallHint(&aw.writer, &scratch, "wget", true, false, 14);
+    try testing.expectEqualStrings("Not installed\n", aw.written());
+}
+
+test "encodeApiFormulaHuman includes metadata and install hint" {
+    // parseFormula allocates a few auxiliary slices (dependencies,
+    // oldnames) outside of its `Parsed` tree, and the public
+    // `Formula.deinit` only frees the tree — so driving this with a
+    // single-call test allocator would leak. An arena scoped to the
+    // test body cleans up everything in one shot.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var f = try formula_mod.parseFormula(arena.allocator(), FORMULA_FIXTURE);
+    defer f.deinit();
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try encodeApiFormulaHuman(&aw.writer, &scratch, &f, false, false);
+
+    const out = aw.written();
+    try testing.expect(std.mem.indexOf(u8, out, "wget: stable 1.24.5\n") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Description:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Internet file retriever") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Homepage:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "https://www.gnu.org/software/wget/") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Status:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Install:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "malt install wget") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "From:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "homebrew/core") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Dependencies:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "libidn2, openssl@3\n") != null);
+}
+
+test "encodeApiFormulaJson produces the documented shape" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var f = try formula_mod.parseFormula(arena.allocator(), FORMULA_FIXTURE);
+    defer f.deinit();
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeApiFormulaJson(&aw.writer, &f);
+
+    try testing.expectEqualStrings(
+        "{\"name\":\"wget\",\"type\":\"formula\",\"installed\":false,\"version\":\"1.24.5\",\"desc\":\"Internet file retriever\",\"homepage\":\"https://www.gnu.org/software/wget/\",\"tap\":\"homebrew/core\",\"dependencies\":[\"libidn2\",\"openssl@3\"]}\n",
+        aw.written(),
+    );
+}
+
+test "encodeApiCaskHuman includes metadata and install hint" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var c = try cask_mod.parseCask(arena.allocator(), CASK_FIXTURE);
+    defer c.deinit();
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try encodeApiCaskHuman(&aw.writer, &scratch, &c, false, false);
+
+    const out = aw.written();
+    try testing.expect(std.mem.indexOf(u8, out, "firefox: 149.0.2 (cask)\n") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Name:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Mozilla Firefox") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Description:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Web browser") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Status:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Install:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "malt install firefox") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "URL:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "https://example.com/firefox.dmg") != null);
+}
+
+test "encodeApiCaskJson produces the documented shape" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var c = try cask_mod.parseCask(arena.allocator(), CASK_FIXTURE);
+    defer c.deinit();
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeApiCaskJson(&aw.writer, &c);
+
+    try testing.expectEqualStrings(
+        "{\"name\":\"firefox\",\"type\":\"cask\",\"installed\":false,\"version\":\"149.0.2\",\"full_name\":\"Mozilla Firefox\",\"desc\":\"Web browser\",\"homepage\":\"https://www.mozilla.org/firefox/\",\"url\":\"https://example.com/firefox.dmg\"}\n",
+        aw.written(),
+    );
+}
+
+test "encodeInstalledCaskHuman renders every populated field" {
+    const row: InstalledCaskRow = .{
+        .token = "firefox",
+        .name = "Firefox",
+        .version = "120.0",
+        .url = "https://example.com/firefox.dmg",
+        .app_path = "/Applications/Firefox.app",
+        .auto_updates = true,
+        .installed_at = "2026-05-13 10:40:56",
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try encodeInstalledCaskHuman(&aw.writer, &scratch, &row, no_history, false);
+
+    const out = aw.written();
+    try testing.expect(std.mem.indexOf(u8, out, "firefox: 120.0 (cask)\n") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Name:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Firefox") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "URL:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "https://example.com/firefox.dmg") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "App:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "/Applications/Firefox.app") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Auto-updates:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Installed:") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "2026-05-13 10:40:56") != null);
+}
+
+test "encodeInstalledCaskHuman omits Auto-updates when false and uses fallbacks for nulls" {
+    const row: InstalledCaskRow = .{
+        .token = "ghost",
+        .name = "ghost",
+        // version/url/app_path/installed_at null → human fallbacks ("unknown"/"N/A")
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try encodeInstalledCaskHuman(&aw.writer, &scratch, &row, no_history, false);
+
+    const out = aw.written();
+    try testing.expect(std.mem.indexOf(u8, out, "ghost: unknown (cask)\n") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Auto-updates:") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "URL:          N/A") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "App:          N/A") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Installed:    N/A") != null);
+}
+
+test "encodeInstalledCaskJson produces the documented shape" {
+    const row: InstalledCaskRow = .{
+        .token = "firefox",
+        .name = "Firefox",
+        .version = "120.0",
+        .url = "https://example.com/firefox.dmg",
+        .app_path = "/Applications/Firefox.app",
+        .auto_updates = false,
+        .installed_at = "2026-05-13 10:40:56",
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeInstalledCaskJson(&aw.writer, &row, no_history);
+
+    try testing.expectEqualStrings(
+        "{\"name\":\"firefox\",\"type\":\"cask\",\"installed\":true,\"version\":\"120.0\",\"full_name\":\"Firefox\",\"url\":\"https://example.com/firefox.dmg\",\"app_path\":\"/Applications/Firefox.app\",\"auto_updates\":false,\"installed_at\":\"2026-05-13 10:40:56\",\"tap\":\"\",\"available_rollback_versions\":[]}\n",
+        aw.written(),
+    );
+}
+
+test "encodeInstalledCaskJson emits empty strings for null fields" {
+    const row: InstalledCaskRow = .{
+        .token = "ghost",
+        .name = "ghost",
+        .auto_updates = true,
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeInstalledCaskJson(&aw.writer, &row, no_history);
+
+    try testing.expectEqualStrings(
+        "{\"name\":\"ghost\",\"type\":\"cask\",\"installed\":true,\"version\":\"\",\"full_name\":\"ghost\",\"url\":\"\",\"app_path\":\"\",\"auto_updates\":true,\"installed_at\":\"\",\"tap\":\"\",\"available_rollback_versions\":[]}\n",
+        aw.written(),
+    );
+}
+
+test "encodeInstalledCaskHuman surfaces the owning tap when set" {
+    const row: InstalledCaskRow = .{
+        .token = "deckclip",
+        .name = "deckclip",
+        .version = "1.4.5",
+        .installed_at = "2026-05-13 10:40:56",
+        .tap = "yuzeguitarist/deck",
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try encodeInstalledCaskHuman(&aw.writer, &scratch, &row, no_history, false);
+
+    const out = aw.written();
+    try testing.expect(std.mem.indexOf(u8, out, "Tap:          yuzeguitarist/deck") != null);
+    // Tap is appended after Installed so the top of the dump stays
+    // stable for scripts that grep the first N lines of `mt info`.
+    const installed_idx = std.mem.indexOf(u8, out, "Installed:") orelse return error.NoInstalledLine;
+    const tap_idx = std.mem.indexOf(u8, out, "Tap:") orelse return error.NoTapLine;
+    try testing.expect(installed_idx < tap_idx);
+}
+
+test "encodeInstalledCaskHuman omits the Tap line when null (core-API cask)" {
+    const row: InstalledCaskRow = .{
+        .token = "firefox",
+        .name = "Firefox",
+        .version = "120.0",
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try encodeInstalledCaskHuman(&aw.writer, &scratch, &row, no_history, false);
+
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "Tap:") == null);
+}
+
+test "encodeInstalledCaskJson includes tap as an empty string for null and the label for tap casks" {
+    const tapped: InstalledCaskRow = .{
+        .token = "deckclip",
+        .name = "deckclip",
+        .version = "1.4.5",
+        .tap = "yuzeguitarist/deck",
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeInstalledCaskJson(&aw.writer, &tapped, no_history);
+
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "\"tap\":\"yuzeguitarist/deck\"") != null);
+}
+
+// `mt info` reuses `mt rollback <pkg> --list`'s listing so users see one
+// shape across both verbs. These tests pin: (a) empty history is invisible
+// in human output but stable as `[]` in JSON, (b) non-empty history emits
+// the `mt rollback --list` section under both formula and cask paths, and
+// (c) the installed-formula JSON carries the `dependencies` array.
+
+test "encodeInstalledFormulaHuman omits the rollback section when history is empty" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try encodeInstalledFormulaHuman(
+        &aw.writer,
+        &scratch,
+        "wget",
+        "1.24.5",
+        "homebrew/core",
+        "/opt/malt/Cellar/wget/1.24.5",
+        false,
+        "2026-05-13 10:40:56",
+        no_history,
+        false,
+    );
+    // Byte-identical to today's shape — adding history must not alter the
+    // dump for a fresh single-version install.
+    try testing.expectEqualStrings(
+        "wget: stable 1.24.5\n" ++
+            "From:      homebrew/core\n" ++
+            "Path:      /opt/malt/Cellar/wget/1.24.5\n" ++
+            "Installed: 2026-05-13 10:40:56\n",
+        aw.written(),
+    );
+}
+
+test "encodeInstalledFormulaHuman appends the rollback listing when history is non-empty" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try encodeInstalledFormulaHuman(
+        &aw.writer,
+        &scratch,
+        "wget",
+        "1.24.5",
+        "homebrew/core",
+        "/opt/malt/Cellar/wget/1.24.5",
+        false,
+        "2026-05-13 10:40:56",
+        &two_entries,
+        false,
+    );
+    const out = aw.written();
+    try testing.expect(std.mem.indexOf(u8, out, "Available rollback versions for wget") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.24") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.23") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "aaa111") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "bbb222") != null);
+    // Section sits below the field block so the top of the dump stays
+    // stable for greppers reading the first N lines.
+    const installed_idx = std.mem.indexOf(u8, out, "Installed:").?;
+    const section_idx = std.mem.indexOf(u8, out, "Available rollback versions").?;
+    try testing.expect(installed_idx < section_idx);
+}
+
+test "encodeInstalledFormulaJson emits available_rollback_versions:[] for an empty history" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeInstalledFormulaJson(
+        &aw.writer,
+        "wget",
+        "1.24.5",
+        "homebrew/core",
+        false,
+        "2026-05-13 10:40:56",
+        no_history,
+        &.{},
+    );
+    try testing.expectEqualStrings(
+        "{\"name\":\"wget\",\"type\":\"formula\",\"installed\":true,\"version\":\"1.24.5\"," ++
+            "\"tap\":\"homebrew/core\",\"dependencies\":[],\"pinned\":false,\"installed_at\":\"2026-05-13 10:40:56\"," ++
+            "\"available_rollback_versions\":[]}\n",
+        aw.written(),
+    );
+}
+
+test "encodeInstalledFormulaJson splices the same entries[] shape mt rollback --list emits" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeInstalledFormulaJson(
+        &aw.writer,
+        "wget",
+        "1.24.5",
+        "homebrew/core",
+        true,
+        "2026-05-13 10:40:56",
+        &two_entries,
+        &.{},
+    );
+    // Pinning the entries-array bytes here is the splice contract:
+    // downstream consumers already parse `mt rollback --list --json`'s
+    // `entries[]`, and the info payload must hand them the same shape.
+    try testing.expectEqualStrings(
+        "{\"name\":\"wget\",\"type\":\"formula\",\"installed\":true,\"version\":\"1.24.5\"," ++
+            "\"tap\":\"homebrew/core\",\"dependencies\":[],\"pinned\":true,\"installed_at\":\"2026-05-13 10:40:56\"," ++
+            "\"available_rollback_versions\":[" ++
+            "{\"sha256\":\"aaa111\",\"version\":\"1.24\",\"mtime\":1700000000}," ++
+            "{\"sha256\":\"bbb222\",\"version\":\"1.23\",\"mtime\":1699000000}" ++
+            "]}\n",
+        aw.written(),
+    );
+}
+
+test "encodeInstalledFormulaJson output parses as JSON with available_rollback_versions reachable" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeInstalledFormulaJson(
+        &aw.writer,
+        "wget",
+        "1.24.5",
+        "homebrew/core",
+        false,
+        "2026-05-13 10:40:56",
+        &two_entries,
+        &.{},
+    );
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+
+    const arr = parsed.value.object.get("available_rollback_versions") orelse return error.MissingKey;
+    try testing.expectEqual(@as(usize, 2), arr.array.items.len);
+    try testing.expectEqualStrings("1.24", arr.array.items[0].object.get("version").?.string);
+    try testing.expectEqualStrings("aaa111", arr.array.items[0].object.get("sha256").?.string);
+    try testing.expectEqual(@as(i64, 1_700_000_000), arr.array.items[0].object.get("mtime").?.integer);
+}
+
+// The installed path must surface the same `dependencies` array the
+// not-installed (API) path already returns, so a `jq` consumer reads one
+// field regardless of install state. The array sits right after `tap`,
+// mirroring `encodeApiFormulaJson`'s `tap` → `dependencies` adjacency.
+test "encodeInstalledFormulaJson emits a dependencies array mirroring the not-installed shape" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeInstalledFormulaJson(
+        &aw.writer,
+        "wget",
+        "1.24.5",
+        "homebrew/core",
+        false,
+        "2026-05-13 10:40:56",
+        no_history,
+        &.{ "libidn2", "openssl@3" },
+    );
+    try testing.expectEqualStrings(
+        "{\"name\":\"wget\",\"type\":\"formula\",\"installed\":true,\"version\":\"1.24.5\"," ++
+            "\"tap\":\"homebrew/core\",\"dependencies\":[\"libidn2\",\"openssl@3\"]," ++
+            "\"pinned\":false,\"installed_at\":\"2026-05-13 10:40:56\"," ++
+            "\"available_rollback_versions\":[]}\n",
+        aw.written(),
+    );
+}
+
+// Edge: a leaf formula (or a keg whose deps were never recorded) must
+// emit `"dependencies":[]` — never null, never an absent key — so
+// consumers can branch on length without guarding for a missing field.
+test "encodeInstalledFormulaJson emits dependencies:[] for a formula with no deps" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeInstalledFormulaJson(
+        &aw.writer,
+        "wget",
+        "1.24.5",
+        "homebrew/core",
+        false,
+        "2026-05-13 10:40:56",
+        no_history,
+        &.{},
+    );
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "\"dependencies\":[]") != null);
+}
+
+test "encodeInstalledCaskHuman omits the rollback section when history is empty" {
+    const row: InstalledCaskRow = .{
+        .token = "firefox",
+        .name = "Firefox",
+        .version = "120.0",
+        .url = "https://example.com/firefox.dmg",
+        .app_path = "/Applications/Firefox.app",
+        .auto_updates = false,
+        .installed_at = "2026-05-13 10:40:56",
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try encodeInstalledCaskHuman(&aw.writer, &scratch, &row, no_history, false);
+
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "Available rollback versions") == null);
+}
+
+test "encodeInstalledCaskHuman appends the rollback listing when history is non-empty" {
+    const row: InstalledCaskRow = .{
+        .token = "flux-markdown",
+        .name = "flux-markdown",
+        .version = "1.32.0",
+    };
+    const cask_history = [_]rollback.Entry{
+        .{ .sha256 = "aa", .pkg_version = "1.31.0", .mtime_ns = 1_700_000_000 * ns_per_s },
+        .{ .sha256 = "bb", .pkg_version = "1.30.0", .mtime_ns = 1_699_000_000 * ns_per_s },
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    var scratch: [4096]u8 = undefined;
+    try encodeInstalledCaskHuman(&aw.writer, &scratch, &row, &cask_history, false);
+
+    const out = aw.written();
+    try testing.expect(std.mem.indexOf(u8, out, "Available rollback versions for flux-markdown") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.31.0") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "1.30.0") != null);
+}
+
+test "encodeInstalledCaskJson splices history entries into the installed-cask object" {
+    const row: InstalledCaskRow = .{
+        .token = "flux-markdown",
+        .name = "flux-markdown",
+        .version = "1.32.0",
+        .auto_updates = false,
+        .installed_at = "2026-05-13 10:40:56",
+    };
+    const cask_history = [_]rollback.Entry{
+        .{ .sha256 = "aa", .pkg_version = "1.31.0", .mtime_ns = 1_700_000_000 * ns_per_s },
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeInstalledCaskJson(&aw.writer, &row, &cask_history);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+
+    const arr = parsed.value.object.get("available_rollback_versions") orelse return error.MissingKey;
+    try testing.expectEqual(@as(usize, 1), arr.array.items.len);
+    try testing.expectEqualStrings("1.31.0", arr.array.items[0].object.get("version").?.string);
+    try testing.expectEqual(@as(i64, 1_700_000_000), arr.array.items[0].object.get("mtime").?.integer);
+}
+
+test "encodeInstalledCaskJson output parses as JSON with .tap reachable" {
+    // Loose shape guard: catches future reorderings or sibling-field
+    // additions that the exact-bytes test would also catch, but keeps
+    // working even if a later refactor reorders the object keys. WHY
+    // this matters: downstream consumers branch on `.tap`, not on byte
+    // position — a parses-as test pins the contract they actually rely on.
+    const row: InstalledCaskRow = .{
+        .token = "deckclip",
+        .name = "deckclip",
+        .version = "1.4.5",
+        .tap = "yuzeguitarist/deck",
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try encodeInstalledCaskJson(&aw.writer, &row, no_history);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+
+    const tap_val = parsed.value.object.get("tap") orelse return error.MissingTapKey;
+    try testing.expectEqualStrings("yuzeguitarist/deck", tap_val.string);
+    const type_val = parsed.value.object.get("type") orelse return error.MissingTypeKey;
+    try testing.expectEqualStrings("cask", type_val.string);
 }

--- a/tests/info_test.zig
+++ b/tests/info_test.zig
@@ -1,15 +1,17 @@
-//! malt — info command tests
+//! malt — info command integration tests
 //!
-//! `mt info` is read-only metadata — it must tolerate a prefix without
-//! a pre-existing database (e.g. a fresh install on a new machine)
-//! instead of failing with "Failed to open database". These tests
-//! pin that behavior via the `openDb` helper.
+//! Integration coverage that needs real side effects: the `openDb`
+//! filesystem behaviour (a prefix with/without a `db/` dir) and the
+//! DB-backed dependency read. The pure encoder unit tests live inline in
+//! `src/cli/info.zig`.
 
 const std = @import("std");
 const testing = std.testing;
 const malt = @import("malt");
 const test_io = @import("test_io");
 const info = malt.cli_info;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
 
 test "openDb returns null when the prefix has no db/ directory" {
     // Fresh prefix with no db/ subdir at all — SQLite's OPEN_CREATE
@@ -45,519 +47,84 @@ test "openDb returns null when the prefix itself does not exist" {
     try testing.expect(info.openDb(prefix) == null);
 }
 
-// --- install hint --------------------------------------------------------
-
-test "encodeInstallHint surfaces both malt and mt invocations" {
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    var scratch: [512]u8 = undefined;
-    try info.encodeInstallHint(&aw.writer, &scratch, "wget", false, false, 14);
-    const out = aw.written();
-    try testing.expect(std.mem.indexOf(u8, out, "Status:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Not installed") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Install:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "malt install wget") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "mt install wget") != null);
-}
-
-test "encodeInstallHint collapses to a bare line in quiet mode" {
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    var scratch: [512]u8 = undefined;
-    try info.encodeInstallHint(&aw.writer, &scratch, "wget", true, false, 14);
-    try testing.expectEqualStrings("Not installed\n", aw.written());
-}
-
-// --- API-metadata encoders -----------------------------------------------
-
-const malt_formula = @import("malt").formula;
-const malt_cask = @import("malt").cask;
-const rollback = @import("malt").cli_rollback;
-
-const FORMULA_FIXTURE =
-    \\{
-    \\  "name":"wget",
-    \\  "full_name":"wget",
-    \\  "tap":"homebrew/core",
-    \\  "desc":"Internet file retriever",
-    \\  "homepage":"https://www.gnu.org/software/wget/",
-    \\  "license":"GPL-3.0-or-later",
-    \\  "revision":0,
-    \\  "versions":{"stable":"1.24.5"},
-    \\  "dependencies":["libidn2","openssl@3"],
-    \\  "keg_only":false,
-    \\  "post_install_defined":false
-    \\}
-;
-
-const CASK_FIXTURE =
-    \\{
-    \\  "token":"firefox",
-    \\  "name":["Mozilla Firefox"],
-    \\  "version":"149.0.2",
-    \\  "desc":"Web browser",
-    \\  "homepage":"https://www.mozilla.org/firefox/",
-    \\  "url":"https://example.com/firefox.dmg",
-    \\  "sha256":"deadbeef",
-    \\  "auto_updates":false
-    \\}
-;
-
-test "encodeApiFormulaHuman includes metadata and install hint" {
-    // parseFormula allocates a few auxiliary slices (dependencies,
-    // oldnames) outside of its `Parsed` tree, and the public
-    // `Formula.deinit` only frees the tree — so driving this with a
-    // single-call test allocator would leak. An arena scoped to the
-    // test body cleans up everything in one shot.
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    var f = try malt_formula.parseFormula(arena.allocator(), FORMULA_FIXTURE);
-    defer f.deinit();
-
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    var scratch: [4096]u8 = undefined;
-    try info.encodeApiFormulaHuman(&aw.writer, &scratch, &f, false, false);
-
-    const out = aw.written();
-    try testing.expect(std.mem.indexOf(u8, out, "wget: stable 1.24.5\n") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Description:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Internet file retriever") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Homepage:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "https://www.gnu.org/software/wget/") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Status:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Install:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "malt install wget") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "From:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "homebrew/core") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Dependencies:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "libidn2, openssl@3\n") != null);
-}
-
-test "encodeApiFormulaJson produces the documented shape" {
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    var f = try malt_formula.parseFormula(arena.allocator(), FORMULA_FIXTURE);
-    defer f.deinit();
-
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    try info.encodeApiFormulaJson(&aw.writer, &f);
-
-    try testing.expectEqualStrings(
-        "{\"name\":\"wget\",\"type\":\"formula\",\"installed\":false,\"version\":\"1.24.5\",\"desc\":\"Internet file retriever\",\"homepage\":\"https://www.gnu.org/software/wget/\",\"tap\":\"homebrew/core\",\"dependencies\":[\"libidn2\",\"openssl@3\"]}\n",
-        aw.written(),
-    );
-}
-
-test "encodeApiCaskHuman includes metadata and install hint" {
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    var c = try malt_cask.parseCask(arena.allocator(), CASK_FIXTURE);
-    defer c.deinit();
-
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    var scratch: [4096]u8 = undefined;
-    try info.encodeApiCaskHuman(&aw.writer, &scratch, &c, false, false);
-
-    const out = aw.written();
-    try testing.expect(std.mem.indexOf(u8, out, "firefox: 149.0.2 (cask)\n") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Name:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Mozilla Firefox") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Description:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Web browser") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Status:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Install:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "malt install firefox") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "URL:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "https://example.com/firefox.dmg") != null);
-}
-
-test "encodeApiCaskJson produces the documented shape" {
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    var c = try malt_cask.parseCask(arena.allocator(), CASK_FIXTURE);
-    defer c.deinit();
-
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    try info.encodeApiCaskJson(&aw.writer, &c);
-
-    try testing.expectEqualStrings(
-        "{\"name\":\"firefox\",\"type\":\"cask\",\"installed\":false,\"version\":\"149.0.2\",\"full_name\":\"Mozilla Firefox\",\"desc\":\"Web browser\",\"homepage\":\"https://www.mozilla.org/firefox/\",\"url\":\"https://example.com/firefox.dmg\"}\n",
-        aw.written(),
-    );
-}
-
-// --- installed-cask encoders -------------------------------------------
-
-test "encodeInstalledCaskHuman renders every populated field" {
-    const row: info.InstalledCaskRow = .{
-        .token = "firefox",
-        .name = "Firefox",
-        .version = "120.0",
-        .url = "https://example.com/firefox.dmg",
-        .app_path = "/Applications/Firefox.app",
-        .auto_updates = true,
-        .installed_at = "2026-05-13 10:40:56",
-    };
-
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    var scratch: [4096]u8 = undefined;
-    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, info.no_history, false);
-
-    const out = aw.written();
-    try testing.expect(std.mem.indexOf(u8, out, "firefox: 120.0 (cask)\n") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Name:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Firefox") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "URL:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "https://example.com/firefox.dmg") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "App:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "/Applications/Firefox.app") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Auto-updates:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Installed:") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "2026-05-13 10:40:56") != null);
-}
-
-test "encodeInstalledCaskHuman omits Auto-updates when false and uses fallbacks for nulls" {
-    const row: info.InstalledCaskRow = .{
-        .token = "ghost",
-        .name = "ghost",
-        // version/url/app_path/installed_at null → human fallbacks ("unknown"/"N/A")
-    };
-
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    var scratch: [4096]u8 = undefined;
-    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, info.no_history, false);
-
-    const out = aw.written();
-    try testing.expect(std.mem.indexOf(u8, out, "ghost: unknown (cask)\n") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Auto-updates:") == null);
-    try testing.expect(std.mem.indexOf(u8, out, "URL:          N/A") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "App:          N/A") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Installed:    N/A") != null);
-}
-
-test "encodeInstalledCaskJson produces the documented shape" {
-    const row: info.InstalledCaskRow = .{
-        .token = "firefox",
-        .name = "Firefox",
-        .version = "120.0",
-        .url = "https://example.com/firefox.dmg",
-        .app_path = "/Applications/Firefox.app",
-        .auto_updates = false,
-        .installed_at = "2026-05-13 10:40:56",
-    };
-
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    try info.encodeInstalledCaskJson(&aw.writer, &row, info.no_history);
-
-    try testing.expectEqualStrings(
-        "{\"name\":\"firefox\",\"type\":\"cask\",\"installed\":true,\"version\":\"120.0\",\"full_name\":\"Firefox\",\"url\":\"https://example.com/firefox.dmg\",\"app_path\":\"/Applications/Firefox.app\",\"auto_updates\":false,\"installed_at\":\"2026-05-13 10:40:56\",\"tap\":\"\",\"available_rollback_versions\":[]}\n",
-        aw.written(),
-    );
-}
-
-test "encodeInstalledCaskJson emits empty strings for null fields" {
-    const row: info.InstalledCaskRow = .{
-        .token = "ghost",
-        .name = "ghost",
-        .auto_updates = true,
-    };
-
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    try info.encodeInstalledCaskJson(&aw.writer, &row, info.no_history);
-
-    try testing.expectEqualStrings(
-        "{\"name\":\"ghost\",\"type\":\"cask\",\"installed\":true,\"version\":\"\",\"full_name\":\"ghost\",\"url\":\"\",\"app_path\":\"\",\"auto_updates\":true,\"installed_at\":\"\",\"tap\":\"\",\"available_rollback_versions\":[]}\n",
-        aw.written(),
-    );
-}
-
-test "encodeInstalledCaskHuman surfaces the owning tap when set" {
-    const row: info.InstalledCaskRow = .{
-        .token = "deckclip",
-        .name = "deckclip",
-        .version = "1.4.5",
-        .installed_at = "2026-05-13 10:40:56",
-        .tap = "yuzeguitarist/deck",
-    };
-
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    var scratch: [4096]u8 = undefined;
-    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, info.no_history, false);
-
-    const out = aw.written();
-    try testing.expect(std.mem.indexOf(u8, out, "Tap:          yuzeguitarist/deck") != null);
-    // Tap is appended after Installed so the top of the dump stays
-    // stable for scripts that grep the first N lines of `mt info`.
-    const installed_idx = std.mem.indexOf(u8, out, "Installed:") orelse return error.NoInstalledLine;
-    const tap_idx = std.mem.indexOf(u8, out, "Tap:") orelse return error.NoTapLine;
-    try testing.expect(installed_idx < tap_idx);
-}
-
-test "encodeInstalledCaskHuman omits the Tap line when null (core-API cask)" {
-    const row: info.InstalledCaskRow = .{
-        .token = "firefox",
-        .name = "Firefox",
-        .version = "120.0",
-    };
-
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    var scratch: [4096]u8 = undefined;
-    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, info.no_history, false);
-
-    try testing.expect(std.mem.indexOf(u8, aw.written(), "Tap:") == null);
-}
-
-test "encodeInstalledCaskJson includes tap as an empty string for null and the label for tap casks" {
-    const tapped: info.InstalledCaskRow = .{
-        .token = "deckclip",
-        .name = "deckclip",
-        .version = "1.4.5",
-        .tap = "yuzeguitarist/deck",
-    };
-
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    try info.encodeInstalledCaskJson(&aw.writer, &tapped, info.no_history);
-
-    try testing.expect(std.mem.indexOf(u8, aw.written(), "\"tap\":\"yuzeguitarist/deck\"") != null);
-}
-
-// --- rollback history surfaces ------------------------------------------
+// --- collectInstalledDeps: DB-backed dependency read --------------------
 //
-// `mt info` reuses `mt rollback <pkg> --list`'s listing so users see one
-// shape across both verbs. These tests pin: (a) empty history is invisible
-// in human output but stable as `[]` in JSON, (b) non-empty history emits
-// the `mt rollback --list` section under both formula and cask paths.
+// The detail pane must read an installed keg's deps from the recorded
+// `dependencies` table — offline, no network re-resolve. These tests
+// build a tiny kegs+dependencies fixture and pin the caller-observable
+// list, including the empty-deps and not-installed edges.
 
-const ns_per_s: i128 = std.time.ns_per_s;
-
-const two_entries = [_]rollback.Entry{
-    .{ .sha256 = "aaa111", .pkg_version = "1.24", .mtime_ns = 1_700_000_000 * ns_per_s },
-    .{ .sha256 = "bbb222", .pkg_version = "1.23", .mtime_ns = 1_699_000_000 * ns_per_s },
-};
-
-test "encodeInstalledFormulaHuman omits the rollback section when history is empty" {
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    var scratch: [4096]u8 = undefined;
-    try info.encodeInstalledFormulaHuman(
-        &aw.writer,
-        &scratch,
-        "wget",
-        "1.24.5",
-        "homebrew/core",
-        "/opt/malt/Cellar/wget/1.24.5",
-        false,
-        "2026-05-13 10:40:56",
-        info.no_history,
-        false,
-    );
-    // Byte-identical to the pre-T-040 shape — adding history must not
-    // alter the dump for a fresh single-version install.
-    try testing.expectEqualStrings(
-        "wget: stable 1.24.5\n" ++
-            "From:      homebrew/core\n" ++
-            "Path:      /opt/malt/Cellar/wget/1.24.5\n" ++
-            "Installed: 2026-05-13 10:40:56\n",
-        aw.written(),
-    );
+fn makeDepsDb(tag: []const u8) !sqlite.Database {
+    var path_buf: [256]u8 = undefined;
+    const path = try std.fmt.bufPrintSentinel(&path_buf, "/tmp/malt_info_deps_test_{s}.db", .{tag}, 0);
+    test_io.deleteFileAbsolute(std.Options.debug_io, path) catch {};
+    var db = try sqlite.Database.open(path);
+    try schema.initSchema(&db);
+    return db;
 }
 
-test "encodeInstalledFormulaHuman appends the rollback listing when history is non-empty" {
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    var scratch: [4096]u8 = undefined;
-    try info.encodeInstalledFormulaHuman(
-        &aw.writer,
-        &scratch,
-        "wget",
-        "1.24.5",
-        "homebrew/core",
-        "/opt/malt/Cellar/wget/1.24.5",
-        false,
-        "2026-05-13 10:40:56",
-        &two_entries,
-        false,
+fn insertKegRow(db: *sqlite.Database, name: []const u8) !i64 {
+    var stmt = try db.prepare(
+        "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)" ++
+            " VALUES (?1, ?1, '1.0', ?1, '/tmp/cellar') RETURNING id;",
     );
-    const out = aw.written();
-    try testing.expect(std.mem.indexOf(u8, out, "Available rollback versions for wget") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "1.24") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "1.23") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "aaa111") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "bbb222") != null);
-    // Section sits below the field block so the top of the dump stays
-    // stable for greppers reading the first N lines.
-    const installed_idx = std.mem.indexOf(u8, out, "Installed:").?;
-    const section_idx = std.mem.indexOf(u8, out, "Available rollback versions").?;
-    try testing.expect(installed_idx < section_idx);
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    _ = try stmt.step();
+    return stmt.columnInt(0);
 }
 
-test "encodeInstalledFormulaJson emits available_rollback_versions:[] for an empty history" {
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    try info.encodeInstalledFormulaJson(
-        &aw.writer,
-        "wget",
-        "1.24.5",
-        "homebrew/core",
-        false,
-        "2026-05-13 10:40:56",
-        info.no_history,
+fn addDepRow(db: *sqlite.Database, keg_id: i64, dep_name: []const u8) !void {
+    var stmt = try db.prepare(
+        "INSERT INTO dependencies (keg_id, dep_name) VALUES (?1, ?2);",
     );
-    try testing.expectEqualStrings(
-        "{\"name\":\"wget\",\"type\":\"formula\",\"installed\":true,\"version\":\"1.24.5\"," ++
-            "\"tap\":\"homebrew/core\",\"pinned\":false,\"installed_at\":\"2026-05-13 10:40:56\"," ++
-            "\"available_rollback_versions\":[]}\n",
-        aw.written(),
-    );
+    defer stmt.finalize();
+    try stmt.bindInt(1, keg_id);
+    try stmt.bindText(2, dep_name);
+    _ = try stmt.step();
 }
 
-test "encodeInstalledFormulaJson splices the same entries[] shape mt rollback --list emits" {
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    try info.encodeInstalledFormulaJson(
-        &aw.writer,
-        "wget",
-        "1.24.5",
-        "homebrew/core",
-        true,
-        "2026-05-13 10:40:56",
-        &two_entries,
-    );
-    // Pinning the entries-array bytes here is the splice contract:
-    // downstream consumers already parse `mt rollback --list --json`'s
-    // `entries[]`, and the info payload must hand them the same shape.
-    try testing.expectEqualStrings(
-        "{\"name\":\"wget\",\"type\":\"formula\",\"installed\":true,\"version\":\"1.24.5\"," ++
-            "\"tap\":\"homebrew/core\",\"pinned\":true,\"installed_at\":\"2026-05-13 10:40:56\"," ++
-            "\"available_rollback_versions\":[" ++
-            "{\"sha256\":\"aaa111\",\"version\":\"1.24\",\"mtime\":1700000000}," ++
-            "{\"sha256\":\"bbb222\",\"version\":\"1.23\",\"mtime\":1699000000}" ++
-            "]}\n",
-        aw.written(),
-    );
+fn freeDepsSlice(deps: []const []const u8) void {
+    for (deps) |d| testing.allocator.free(d);
+    testing.allocator.free(deps);
 }
 
-test "encodeInstalledFormulaJson output parses as JSON with available_rollback_versions reachable" {
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    try info.encodeInstalledFormulaJson(
-        &aw.writer,
-        "wget",
-        "1.24.5",
-        "homebrew/core",
-        false,
-        "2026-05-13 10:40:56",
-        &two_entries,
-    );
-    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
-    defer parsed.deinit();
+test "collectInstalledDeps reads a fixture keg's recorded deps, alphabetised" {
+    var db = try makeDepsDb("populated");
+    defer db.close();
 
-    const arr = parsed.value.object.get("available_rollback_versions") orelse return error.MissingKey;
-    try testing.expectEqual(@as(usize, 2), arr.array.items.len);
-    try testing.expectEqualStrings("1.24", arr.array.items[0].object.get("version").?.string);
-    try testing.expectEqualStrings("aaa111", arr.array.items[0].object.get("sha256").?.string);
-    try testing.expectEqual(@as(i64, 1_700_000_000), arr.array.items[0].object.get("mtime").?.integer);
+    // Insert deps out of order to prove the reader sorts rather than
+    // leaking insertion order to consumers.
+    const wget_id = try insertKegRow(&db, "wget");
+    try addDepRow(&db, wget_id, "openssl@3");
+    try addDepRow(&db, wget_id, "libidn2");
+
+    const deps = info.collectInstalledDeps(testing.allocator, &db, "wget");
+    defer freeDepsSlice(deps);
+
+    try testing.expectEqual(@as(usize, 2), deps.len);
+    try testing.expectEqualStrings("libidn2", deps[0]);
+    try testing.expectEqualStrings("openssl@3", deps[1]);
 }
 
-test "encodeInstalledCaskHuman omits the rollback section when history is empty" {
-    const row: info.InstalledCaskRow = .{
-        .token = "firefox",
-        .name = "Firefox",
-        .version = "120.0",
-        .url = "https://example.com/firefox.dmg",
-        .app_path = "/Applications/Firefox.app",
-        .auto_updates = false,
-        .installed_at = "2026-05-13 10:40:56",
-    };
+test "collectInstalledDeps returns an empty slice for an installed leaf" {
+    var db = try makeDepsDb("leaf");
+    defer db.close();
 
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    var scratch: [4096]u8 = undefined;
-    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, info.no_history, false);
+    _ = try insertKegRow(&db, "tree");
 
-    try testing.expect(std.mem.indexOf(u8, aw.written(), "Available rollback versions") == null);
+    const deps = info.collectInstalledDeps(testing.allocator, &db, "tree");
+    defer freeDepsSlice(deps);
+
+    try testing.expectEqual(@as(usize, 0), deps.len);
 }
 
-test "encodeInstalledCaskHuman appends the rollback listing when history is non-empty" {
-    const row: info.InstalledCaskRow = .{
-        .token = "flux-markdown",
-        .name = "flux-markdown",
-        .version = "1.32.0",
-    };
-    const cask_history = [_]rollback.Entry{
-        .{ .sha256 = "aa", .pkg_version = "1.31.0", .mtime_ns = 1_700_000_000 * ns_per_s },
-        .{ .sha256 = "bb", .pkg_version = "1.30.0", .mtime_ns = 1_699_000_000 * ns_per_s },
-    };
+test "collectInstalledDeps returns an empty slice when the keg is not installed" {
+    var db = try makeDepsDb("absent");
+    defer db.close();
 
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    var scratch: [4096]u8 = undefined;
-    try info.encodeInstalledCaskHuman(&aw.writer, &scratch, &row, &cask_history, false);
+    const deps = info.collectInstalledDeps(testing.allocator, &db, "ghost");
+    defer freeDepsSlice(deps);
 
-    const out = aw.written();
-    try testing.expect(std.mem.indexOf(u8, out, "Available rollback versions for flux-markdown") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "1.31.0") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "1.30.0") != null);
-}
-
-test "encodeInstalledCaskJson splices history entries into the installed-cask object" {
-    const row: info.InstalledCaskRow = .{
-        .token = "flux-markdown",
-        .name = "flux-markdown",
-        .version = "1.32.0",
-        .auto_updates = false,
-        .installed_at = "2026-05-13 10:40:56",
-    };
-    const cask_history = [_]rollback.Entry{
-        .{ .sha256 = "aa", .pkg_version = "1.31.0", .mtime_ns = 1_700_000_000 * ns_per_s },
-    };
-
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    try info.encodeInstalledCaskJson(&aw.writer, &row, &cask_history);
-
-    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
-    defer parsed.deinit();
-
-    const arr = parsed.value.object.get("available_rollback_versions") orelse return error.MissingKey;
-    try testing.expectEqual(@as(usize, 1), arr.array.items.len);
-    try testing.expectEqualStrings("1.31.0", arr.array.items[0].object.get("version").?.string);
-    try testing.expectEqual(@as(i64, 1_700_000_000), arr.array.items[0].object.get("mtime").?.integer);
-}
-
-test "encodeInstalledCaskJson output parses as JSON with .tap reachable" {
-    // Loose shape guard: catches future reorderings or sibling-field
-    // additions that the exact-bytes test would also catch, but keeps
-    // working even if a later refactor reorders the object keys. WHY
-    // this matters: downstream consumers branch on `.tap`, not on byte
-    // position — a parses-as test pins the contract they actually rely on.
-    const row: info.InstalledCaskRow = .{
-        .token = "deckclip",
-        .name = "deckclip",
-        .version = "1.4.5",
-        .tap = "yuzeguitarist/deck",
-    };
-
-    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
-    defer aw.deinit();
-    try info.encodeInstalledCaskJson(&aw.writer, &row, info.no_history);
-
-    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
-    defer parsed.deinit();
-
-    const tap_val = parsed.value.object.get("tap") orelse return error.MissingTapKey;
-    try testing.expectEqualStrings("yuzeguitarist/deck", tap_val.string);
-    const type_val = parsed.value.object.get("type") orelse return error.MissingTypeKey;
-    try testing.expectEqualStrings("cask", type_val.string);
+    try testing.expectEqual(@as(usize, 0), deps.len);
 }


### PR DESCRIPTION
## Description

`mt info <pkg> --json` now includes a `dependencies` array for installed packages, matching the shape the not-installed path already returns. Any `jq` consumer can now read the dependency list for software the user already has, offline, from the recorded install data.
Empty dependency sets emit `[]` for a stable, predictable shape.

## Related Issue

- None

## Notes for Reviewers

- Deps are read from the local `dependencies` table (recorded at install time), never the network
