### PR TITLE
feat(doctor): emit structured findings in JSON output

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -216,6 +216,7 @@ pub fn build(b: *std.Build) void {
         "tests/doctor_dispatch_test.zig",
         "tests/doctor_cask_history_test.zig",
         "tests/doctor_tap_forge_test.zig",
+        "tests/doctor_json_test.zig",
         "tests/info_cli_test.zig",
         "tests/backup_cli_test.zig",
         "tests/run_cli_test.zig",

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -32,7 +32,18 @@ const render = @import("doctor/render.zig");
 pub const CheckStatus = render.CheckStatus;
 pub const CheckStyle = render.CheckStyle;
 pub const renderCheckRow = render.renderCheckRow;
-pub const printCheck = render.printCheck;
+pub const Finding = render.Finding;
+pub const writeChecksJson = render.writeChecksJson;
+
+/// Render a check row to stderr (via the pure renderer) and, when a
+/// finding sink is active, capture the structured finding so
+/// `mt doctor --json` serializes `checks[]` from the same call that drew
+/// the human row — one source of truth for both views. Pub so tests can
+/// drive the row path directly.
+pub fn printCheck(name: []const u8, status: CheckStatus, detail: ?[]const u8) void {
+    render.printCheck(name, status, detail);
+    if (g_sink) |sink| recordFinding(sink, name, status, detail);
+}
 /// Per-check outcome; same tags the row renderer uses so the walker
 /// can tally without re-translating.
 pub const CheckResult = render.CheckStatus;
@@ -103,6 +114,100 @@ pub fn runChecks(ctx: CheckCtx, table: []const Check) Tally {
         }
     }
     return tally;
+}
+
+/// Collects structured findings during a health walk so
+/// `mt doctor --json` can serialize `checks[]`. The arena owns every
+/// string and the list backing, so a single `deinit` frees the lot.
+const FindingSink = struct {
+    arena: std.heap.ArenaAllocator,
+    list: std.ArrayList(render.Finding),
+
+    fn init(gpa: std.mem.Allocator) FindingSink {
+        return .{ .arena = .init(gpa), .list = .empty };
+    }
+    fn deinit(self: *FindingSink) void {
+        self.arena.deinit();
+    }
+};
+
+/// Active finding sink, set only while `collectFindings` drives the
+/// walk; null on the human path so `printCheck` stays render-only and
+/// pays nothing. Process-global to mirror the existing hint flags —
+/// doctor is never run concurrently.
+var g_sink: ?*FindingSink = null;
+
+fn recordFinding(sink: *FindingSink, name: []const u8, status: CheckStatus, detail: ?[]const u8) void {
+    const a = sink.arena.allocator();
+    // Best-effort: an allocator failure drops one finding from the JSON
+    // payload rather than aborting the whole doctor run.
+    const id = findingId(a, name) catch return;
+    const title = a.dupe(u8, name) catch return;
+    const det = a.dupe(u8, detail orelse "") catch return;
+    sink.list.append(a, .{ .id = id, .severity = status, .title = title, .detail = det }) catch {};
+}
+
+/// Stable machine id for a finding: a slug of its title — lowercased,
+/// each run of non-alphanumeric bytes collapsed to a single `_`, edges
+/// trimmed. The title is static, so the id is stable across runs.
+fn findingId(a: std.mem.Allocator, title: []const u8) ![]const u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(a);
+    var pending_sep = false;
+    for (title) |ch| {
+        const lower = std.ascii.toLower(ch);
+        if (std.ascii.isAlphanumeric(lower)) {
+            if (pending_sep and buf.items.len != 0) try buf.append(a, '_');
+            pending_sep = false;
+            try buf.append(a, lower);
+        } else {
+            pending_sep = true;
+        }
+    }
+    return buf.toOwnedSlice(a);
+}
+
+/// Outcome of a finding-collecting walk: the populated sink plus the
+/// same warn/err tally `runChecks` returns. Caller owns the sink.
+pub const WalkResult = struct {
+    sink: FindingSink,
+    tally: Tally,
+
+    pub fn deinit(self: *WalkResult) void {
+        self.sink.deinit();
+    }
+    pub fn findings(self: *const WalkResult) []const render.Finding {
+        return self.sink.list.items;
+    }
+};
+
+/// Run the health walk while capturing each row as a structured finding.
+/// Drives the same `runChecks` walker — identical stderr rows — with a
+/// sink active, so the human rows and `checks[]` share one source of
+/// truth. `collect=false` skips capture entirely (the human path pays
+/// nothing). Caller owns the returned sink.
+pub fn collectFindings(
+    allocator: std.mem.Allocator,
+    ctx: CheckCtx,
+    table: []const Check,
+    collect: bool,
+) WalkResult {
+    var sink = FindingSink.init(allocator);
+    if (collect) g_sink = &sink;
+    defer g_sink = null;
+    const tally = runChecks(ctx, table);
+    return .{ .sink = sink, .tally = tally };
+}
+
+/// Serialize the collected findings as `mt doctor --json`'s `checks[]`
+/// payload to stdout, alongside the existing cask_history/tap_cache/taps
+/// fragments. Best-effort: a writer failure drops the payload rather
+/// than aborting the run.
+fn emitChecksJson(allocator: std.mem.Allocator, findings: []const render.Finding) void {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    render.writeChecksJson(&aw.writer, findings) catch return;
+    output.writeStdoutAll(aw.written());
 }
 
 /// Walk retained cask versions and emit the report doctor surfaces
@@ -257,14 +362,20 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     resetVerboseHint();
     resetFixHint();
     output.info("Running health checks...", .{});
-    const tally = runChecks(.{
+    // Capture findings only under --json; the human path stays render-only.
+    const want_checks_json = output.isJson();
+    var walk = collectFindings(allocator, .{
         .allocator = allocator,
         .prefix = prefix,
         .io = ctx.io,
         .environ = ctx.environ,
         .mirrors = ctx.mirrors,
         .offline = ctx.offline,
-    }, &checks);
+    }, &checks, want_checks_json);
+    defer walk.deinit();
+    const tally = walk.tally;
+
+    if (want_checks_json) emitChecksJson(allocator, walk.findings());
 
     emitCaskHistoryReport(allocator, ctx.io, prefix);
     emitTapCacheReport(allocator, ctx.io, prefix);
@@ -367,9 +478,19 @@ pub fn resetFixHint() void {
 
 /// Internal arm — called by checks that detect a safe-class
 /// condition `--fix` can resolve. `emitFixHintIfNeeded` decides
-/// whether to surface the nudge.
-fn armFixHint() void {
+/// whether to surface the nudge. `fix_class` is the safe-fix class the
+/// offender belongs to; it also tags the just-rendered finding so
+/// `mt doctor --json` reports the same `fixable`/`fix_class` the inline
+/// nudge is driven by — one fixability signal for both views.
+fn armFixHint(fix_class: FixKind) void {
     fix_hint_armed = true;
+    if (g_sink) |sink| {
+        if (sink.list.items.len != 0) {
+            const last = &sink.list.items[sink.list.items.len - 1];
+            last.fixable = true;
+            last.fix_class = fix_class;
+        }
+    }
 }
 
 /// Emit a "run with --fix to apply safe-class fixes" nudge after the
@@ -519,7 +640,7 @@ fn checkStaleLock(ctx: CheckCtx, name: []const u8) CheckResult {
         } else {
             const s = std.fmt.bufPrint(&pid_buf, "Stale lock from dead PID {d}. Run: rm {s}", .{ p, lock_path }) catch "Stale lock detected";
             printCheck(name, .warn_status, s);
-            armFixHint();
+            armFixHint(.stale_lock);
         }
         return .warn_status;
     }
@@ -747,7 +868,7 @@ fn checkOrphanedStore(ctx: CheckCtx, name: []const u8) CheckResult {
         .{orphan_count},
     ) catch "Orphaned store entries found. Run: mt purge --store-orphans";
     printCheck(name, .warn_status, msg);
-    armFixHint();
+    armFixHint(.orphaned_store);
     return .warn_status;
 }
 
@@ -842,7 +963,7 @@ fn checkBrokenSymlinks(ctx: CheckCtx, name: []const u8) CheckResult {
     ) catch "Broken symlinks found. Run: mt cleanup";
     printCheck(name, .warn_status, msg);
     armVerboseHint();
-    armFixHint();
+    armFixHint(.broken_symlinks);
     writeVerboseList(offenders.items);
     return .warn_status;
 }
@@ -1230,6 +1351,31 @@ fn captureFixEmit(allocator: std.mem.Allocator, fix_requested: bool) !std.ArrayL
     return buf;
 }
 
+test "findingId: slugifies a title into a stable lowercase id" {
+    const cases = [_]struct { title: []const u8, id: []const u8 }{
+        .{ .title = "MALT_PREFIX", .id = "malt_prefix" },
+        .{ .title = "SQLite integrity", .id = "sqlite_integrity" },
+        .{ .title = "Stale lock", .id = "stale_lock" },
+        .{ .title = "Orphaned store entries", .id = "orphaned_store_entries" },
+        .{ .title = "Mach-O placeholders", .id = "mach_o_placeholders" },
+        .{ .title = "Dependency bin/sbin link census", .id = "dependency_bin_sbin_link_census" },
+        .{ .title = "Prefix on PATH", .id = "prefix_on_path" },
+    };
+    for (cases) |c| {
+        const got = try findingId(testing.allocator, c.title);
+        defer testing.allocator.free(got);
+        try testing.expectEqualStrings(c.id, got);
+    }
+}
+
+test "findingId: collapses non-alphanumeric runs and trims the edges" {
+    // Leading/trailing separators and repeated punctuation must never
+    // leak doubled or edge underscores into the id.
+    const got = try findingId(testing.allocator, "  A -- B/C  ");
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("a_b_c", got);
+}
+
 test "formatSslCertDetail: null when present, remediation hint when absent" {
     try testing.expect(formatSslCertDetail(true) == null);
     const missing = formatSslCertDetail(false) orelse return error.TestUnexpectedResult;
@@ -1246,7 +1392,7 @@ test "emitFixHintIfNeeded: silent without arming" {
 
 test "emitFixHintIfNeeded: emits when armed and --fix is off" {
     resetFixHint();
-    armFixHint();
+    armFixHint(.stale_lock);
     var captured = try captureFixEmit(testing.allocator, false);
     defer captured.deinit(testing.allocator);
     try testing.expect(fixHintEmitted(captured.items));
@@ -1254,7 +1400,7 @@ test "emitFixHintIfNeeded: emits when armed and --fix is off" {
 
 test "emitFixHintIfNeeded: silent when --fix was already passed" {
     resetFixHint();
-    armFixHint();
+    armFixHint(.stale_lock);
     var captured = try captureFixEmit(testing.allocator, true);
     defer captured.deinit(testing.allocator);
     try testing.expect(!fixHintEmitted(captured.items));
@@ -1262,7 +1408,7 @@ test "emitFixHintIfNeeded: silent when --fix was already passed" {
 
 test "resetFixHint: clears a previously-armed flag" {
     resetFixHint();
-    armFixHint();
+    armFixHint(.stale_lock);
     resetFixHint();
     var captured = try captureFixEmit(testing.allocator, false);
     defer captured.deinit(testing.allocator);

--- a/src/cli/doctor/render.zig
+++ b/src/cli/doctor/render.zig
@@ -7,8 +7,77 @@
 const std = @import("std");
 const output = @import("../../ui/output.zig");
 const color = @import("../../ui/color.zig");
+const fix_mod = @import("fix.zig");
 
 pub const CheckStatus = enum { ok, warn_status, err_status };
+
+/// Safe-fix vocabulary shared with `--fix`. `mt doctor --json` reports a
+/// finding's class from this set (or `none`) so the dashboard and the
+/// per-finding selector pin one vocabulary.
+pub const FixKind = fix_mod.FixKind;
+
+/// One machine-readable doctor finding. `mt doctor --json`'s `checks[]`
+/// serializes these; the human rows render from the same call, so the
+/// two views never drift.
+pub const Finding = struct {
+    /// Stable per-finding slug (same finding → same id across runs).
+    id: []const u8,
+    severity: CheckStatus,
+    /// Human row title (the check name).
+    title: []const u8,
+    detail: []const u8 = "",
+    /// True when `mt doctor --fix` can act on this finding.
+    fixable: bool = false,
+    /// Safe-fix class, or `null` (serialized as `"none"`) when `--fix`
+    /// cannot resolve it.
+    fix_class: ?FixKind = null,
+};
+
+/// JSON severity vocabulary, mirroring `CheckStatus`. Exhaustive switch
+/// (no `else =>`) so a new status can't silently leak an unmapped tag
+/// into the published contract.
+pub fn severityTag(status: CheckStatus) []const u8 {
+    return switch (status) {
+        .ok => "ok",
+        .warn_status => "warn",
+        .err_status => "err",
+    };
+}
+
+/// JSON fix-class vocabulary. `null` → `"none"`; otherwise the safe-fix
+/// class name. Explicit exhaustive switch so a renamed/added `FixKind`
+/// is a compile error here, never a silent API change.
+pub fn fixClassTag(kind: ?FixKind) []const u8 {
+    const k = kind orelse return "none";
+    return switch (k) {
+        .stale_lock => "stale_lock",
+        .orphaned_store => "orphaned_store",
+        .broken_symlinks => "broken_symlinks",
+    };
+}
+
+/// Serialize findings as a `{"checks":[...]}` object. Pure writer so
+/// tests pin the bytes; every string routes through the shared JSON
+/// escaper. `detail` is always present (empty string when the row had
+/// no detail) so consumers never special-case a missing field.
+pub fn writeChecksJson(w: *std.Io.Writer, findings: []const Finding) !void {
+    try w.writeAll("{\"checks\":[");
+    for (findings, 0..) |f, i| {
+        if (i != 0) try w.writeAll(",");
+        try w.writeAll("{\"id\":");
+        try output.jsonStr(w, f.id);
+        try w.writeAll(",\"severity\":");
+        try output.jsonStr(w, severityTag(f.severity));
+        try w.writeAll(",\"title\":");
+        try output.jsonStr(w, f.title);
+        try w.writeAll(",\"detail\":");
+        try output.jsonStr(w, f.detail);
+        try w.writeAll(if (f.fixable) ",\"fixable\":true,\"fix_class\":" else ",\"fixable\":false,\"fix_class\":");
+        try output.jsonStr(w, fixClassTag(f.fix_class));
+        try w.writeAll("}");
+    }
+    try w.writeAll("]}\n");
+}
 
 pub const CheckStyle = struct {
     /// Emit ANSI colour codes. False for plain terminals and tests.
@@ -85,4 +154,83 @@ pub fn printCheck(name: []const u8, status: CheckStatus, detail: ?[]const u8) vo
         .emoji = color.isEmojiEnabled(),
     }) catch {};
     output.writeStderrAll(w.buffered());
+}
+
+// ── inline unit tests: JSON findings vocabulary + serializer ─────────
+
+const testing = std.testing;
+
+test "severityTag maps every CheckStatus to its JSON token" {
+    try testing.expectEqualStrings("ok", severityTag(.ok));
+    try testing.expectEqualStrings("warn", severityTag(.warn_status));
+    try testing.expectEqualStrings("err", severityTag(.err_status));
+}
+
+test "fixClassTag maps null to none and each FixKind to its tag" {
+    try testing.expectEqualStrings("none", fixClassTag(null));
+    try testing.expectEqualStrings("stale_lock", fixClassTag(.stale_lock));
+    try testing.expectEqualStrings("orphaned_store", fixClassTag(.orphaned_store));
+    try testing.expectEqualStrings("broken_symlinks", fixClassTag(.broken_symlinks));
+}
+
+fn checksToBuf(findings: []const Finding, buf: []u8) ![]const u8 {
+    var w: std.Io.Writer = .fixed(buf);
+    try writeChecksJson(&w, findings);
+    return w.buffered();
+}
+
+test "writeChecksJson: empty findings keep a stable empty array" {
+    var buf: [64]u8 = undefined;
+    try testing.expectEqualStrings("{\"checks\":[]}\n", try checksToBuf(&.{}, &buf));
+}
+
+test "writeChecksJson: ok finding serializes detail and none/false defaults" {
+    var buf: [256]u8 = undefined;
+    const findings = [_]Finding{
+        .{ .id = "malt_prefix", .severity = .ok, .title = "MALT_PREFIX", .detail = "/opt/malt (default)" },
+    };
+    try testing.expectEqualStrings(
+        "{\"checks\":[{\"id\":\"malt_prefix\",\"severity\":\"ok\",\"title\":\"MALT_PREFIX\"," ++
+            "\"detail\":\"/opt/malt (default)\",\"fixable\":false,\"fix_class\":\"none\"}]}\n",
+        try checksToBuf(&findings, &buf),
+    );
+}
+
+test "writeChecksJson: a fixable warn finding carries its fix_class" {
+    var buf: [256]u8 = undefined;
+    const findings = [_]Finding{
+        .{
+            .id = "stale_lock",
+            .severity = .warn_status,
+            .title = "Stale lock",
+            .detail = "Stale lock from dead PID 42",
+            .fixable = true,
+            .fix_class = .stale_lock,
+        },
+    };
+    try testing.expectEqualStrings(
+        "{\"checks\":[{\"id\":\"stale_lock\",\"severity\":\"warn\",\"title\":\"Stale lock\"," ++
+            "\"detail\":\"Stale lock from dead PID 42\",\"fixable\":true,\"fix_class\":\"stale_lock\"}]}\n",
+        try checksToBuf(&findings, &buf),
+    );
+}
+
+test "writeChecksJson: comma-separates multiple findings" {
+    var buf: [256]u8 = undefined;
+    const findings = [_]Finding{
+        .{ .id = "a", .severity = .ok, .title = "A" },
+        .{ .id = "b", .severity = .err_status, .title = "B" },
+    };
+    const out = try checksToBuf(&findings, &buf);
+    try testing.expect(std.mem.indexOf(u8, out, "},{") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"severity\":\"err\"") != null);
+}
+
+test "writeChecksJson: detail with quotes is JSON-escaped" {
+    var buf: [256]u8 = undefined;
+    const findings = [_]Finding{
+        .{ .id = "x", .severity = .warn_status, .title = "X", .detail = "needs \"quotes\"" },
+    };
+    const out = try checksToBuf(&findings, &buf);
+    try testing.expect(std.mem.indexOf(u8, out, "\\\"quotes\\\"") != null);
 }

--- a/tests/doctor_json_test.zig
+++ b/tests/doctor_json_test.zig
@@ -1,0 +1,315 @@
+//! malt — `mt doctor --json` structured `checks[]` integration tests.
+//!
+//! Drives `doctor.collectFindings` with the production check table
+//! against a scratch prefix seeded with a known condition, then asserts
+//! the captured finding (and its serialized JSON) carries the right
+//! `severity` / `fixable` / `fix_class`. The walker prints the same
+//! human rows it always did; these tests pin the machine view that the
+//! dashboard and `jq`/script consumers read.
+
+const std = @import("std");
+const malt = @import("malt");
+const test_io = @import("test_io");
+const testing = std.testing;
+const doctor = malt.doctor;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+const output = malt.output;
+
+const Scratch = struct {
+    path: []u8,
+
+    fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
+        const ts = test_io.nanoTimestamp(std.Options.debug_io);
+        const path = try std.fmt.allocPrint(allocator, "/tmp/malt_doctor_json_{s}_{d}", .{ tag, ts });
+        test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, path);
+        const subs = [_][]const u8{ "store", "Cellar", "Caskroom", "opt", "bin", "lib", "tmp", "cache", "db" };
+        for (subs) |sd| {
+            const dir = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ path, sd });
+            defer allocator.free(dir);
+            try test_io.cwd().createDirPath(std.Options.debug_io, dir);
+        }
+        return .{ .path = path };
+    }
+
+    fn deinit(self: *Scratch, allocator: std.mem.Allocator) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.path) catch {};
+        allocator.free(self.path);
+    }
+
+    fn initSchema(self: *Scratch) !void {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{self.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+    }
+};
+
+fn findById(findings: []const doctor.Finding, id: []const u8) ?doctor.Finding {
+    for (findings) |f| {
+        if (std.mem.eql(u8, f.id, id)) return f;
+    }
+    return null;
+}
+
+fn walk(allocator: std.mem.Allocator, prefix: []const u8) doctor.WalkResult {
+    // Quiet suppresses the stderr rows; findings are still collected.
+    const prior = output.isQuiet();
+    output.setQuiet(true);
+    defer output.setQuiet(prior);
+    return doctor.collectFindings(allocator, .{
+        .allocator = allocator,
+        .prefix = prefix,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks, true);
+}
+
+test "collectFindings captures one finding per row, including a stable always-ok entry" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "ok_entry");
+    defer s.deinit(allocator);
+    try s.initSchema();
+
+    var result = walk(allocator, s.path);
+    defer result.deinit();
+
+    // At least the static rows are present.
+    try testing.expect(result.findings().len >= 5);
+
+    // MALT_PREFIX is unconditionally healthy — the anchor for the
+    // "ok finding ⇒ none/false" shape every consumer relies on.
+    const prefix_finding = findById(result.findings(), "malt_prefix") orelse
+        return error.MissingPrefixFinding;
+    try testing.expectEqual(doctor.CheckStatus.ok, prefix_finding.severity);
+    try testing.expect(!prefix_finding.fixable);
+    try testing.expect(prefix_finding.fix_class == null);
+    try testing.expect(prefix_finding.detail.len > 0);
+}
+
+test "a broken symlink serializes a fixable broken_symlinks finding" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "broken_symlink");
+    defer s.deinit(allocator);
+
+    const link_path = try std.fmt.allocPrint(allocator, "{s}/bin/ghost-json", .{s.path});
+    defer allocator.free(link_path);
+    try std.Io.Dir.symLinkAbsolute(
+        std.Options.debug_io,
+        "/tmp/malt_doctor_json_broken_target_dne",
+        link_path,
+        .{},
+    );
+
+    var result = walk(allocator, s.path);
+    defer result.deinit();
+
+    const f = findById(result.findings(), "broken_symlinks") orelse
+        return error.MissingBrokenSymlinkFinding;
+    try testing.expectEqual(doctor.CheckStatus.warn_status, f.severity);
+    try testing.expect(f.fixable);
+    try testing.expectEqual(doctor.FixKind.broken_symlinks, f.fix_class.?);
+    try testing.expectEqualStrings("Broken symlinks", f.title);
+
+    // The same finding serializes with fixable:true and its class.
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try doctor.writeChecksJson(&aw.writer, result.findings());
+    const json = aw.written();
+    try testing.expect(std.mem.startsWith(u8, json, "{\"checks\":["));
+    try testing.expect(std.mem.indexOf(
+        u8,
+        json,
+        "\"id\":\"broken_symlinks\",\"severity\":\"warn\"",
+    ) != null);
+    try testing.expect(std.mem.indexOf(
+        u8,
+        json,
+        "\"fixable\":true,\"fix_class\":\"broken_symlinks\"",
+    ) != null);
+}
+
+test "an orphaned store entry serializes a fixable orphaned_store finding" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "orphan_store");
+    defer s.deinit(allocator);
+    try s.initSchema();
+
+    // A store/<sha> dir with no matching store_refs row is an orphan.
+    const orphan = try std.fmt.allocPrint(
+        allocator,
+        "{s}/store/0000000000000000000000000000000000000000000000000000000000000000",
+        .{s.path},
+    );
+    defer allocator.free(orphan);
+    try test_io.cwd().createDirPath(std.Options.debug_io, orphan);
+
+    var result = walk(allocator, s.path);
+    defer result.deinit();
+
+    const f = findById(result.findings(), "orphaned_store_entries") orelse
+        return error.MissingOrphanFinding;
+    try testing.expectEqual(doctor.CheckStatus.warn_status, f.severity);
+    try testing.expect(f.fixable);
+    try testing.expectEqual(doctor.FixKind.orphaned_store, f.fix_class.?);
+}
+
+test "a missing keg serializes a non-fixable err finding (manual class)" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "missing_keg");
+    defer s.deinit(allocator);
+    try s.initSchema();
+
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        var stmt = try db.prepare(
+            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+            \\VALUES ('phantom', 'phantom', '9.9', 0, '', '/tmp/malt_doctor_json_phantom_dne');
+        );
+        defer stmt.finalize();
+        _ = try stmt.step();
+    }
+
+    var result = walk(allocator, s.path);
+    defer result.deinit();
+
+    const f = findById(result.findings(), "missing_kegs") orelse
+        return error.MissingKegFinding;
+    try testing.expectEqual(doctor.CheckStatus.err_status, f.severity);
+    // Manual-class: --fix never auto-resolves a missing keg.
+    try testing.expect(!f.fixable);
+    try testing.expect(f.fix_class == null);
+
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try doctor.writeChecksJson(&aw.writer, result.findings());
+    try testing.expect(std.mem.indexOf(
+        u8,
+        aw.written(),
+        "\"id\":\"missing_kegs\",\"severity\":\"err\"",
+    ) != null);
+}
+
+test "collect=false leaves the sink empty (human path pays nothing)" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "no_collect");
+    defer s.deinit(allocator);
+    try s.initSchema();
+
+    const prior = output.isQuiet();
+    output.setQuiet(true);
+    defer output.setQuiet(prior);
+
+    var result = doctor.collectFindings(allocator, .{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks, false);
+    defer result.deinit();
+
+    try testing.expectEqual(@as(usize, 0), result.findings().len);
+}
+
+test "a lock held by a live PID warns but stays non-fixable" {
+    // The same Stale lock row is fixable for a dead PID and not for a
+    // live one. A live holder must report warn + fixable:false so a
+    // consumer never offers `--fix` against a legitimately held lock.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "live_lock");
+    defer s.deinit(allocator);
+
+    const lock_path = try std.fmt.allocPrint(allocator, "{s}/db/malt.lock", .{s.path});
+    defer allocator.free(lock_path);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, lock_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        var buf: [16]u8 = undefined;
+        // Our own PID is, by definition, alive for the duration of the test.
+        const line = try std.fmt.bufPrint(&buf, "{d}\n", .{std.c.getpid()});
+        try f.writeStreamingAll(std.Options.debug_io, line);
+    }
+
+    var result = walk(allocator, s.path);
+    defer result.deinit();
+
+    const f = findById(result.findings(), "stale_lock") orelse return error.MissingLockFinding;
+    try testing.expectEqual(doctor.CheckStatus.warn_status, f.severity);
+    try testing.expect(!f.fixable);
+    try testing.expect(f.fix_class == null);
+}
+
+test "a lock from a dead PID is a fixable stale_lock finding" {
+    // The fixable arm of the same row: a holder PID that cannot exist
+    // means the lock is abandoned, so --fix can safely remove it.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "dead_lock");
+    defer s.deinit(allocator);
+
+    const lock_path = try std.fmt.allocPrint(allocator, "{s}/db/malt.lock", .{s.path});
+    defer allocator.free(lock_path);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, lock_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        // Well above macOS's max PID, so kill(pid, 0) is always ESRCH.
+        try f.writeStreamingAll(std.Options.debug_io, "4000000\n");
+    }
+
+    var result = walk(allocator, s.path);
+    defer result.deinit();
+
+    const f = findById(result.findings(), "stale_lock") orelse return error.MissingLockFinding;
+    try testing.expectEqual(doctor.CheckStatus.warn_status, f.severity);
+    try testing.expect(f.fixable);
+    try testing.expectEqual(doctor.FixKind.stale_lock, f.fix_class.?);
+
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    try doctor.writeChecksJson(&aw.writer, result.findings());
+    try testing.expect(std.mem.indexOf(
+        u8,
+        aw.written(),
+        "\"id\":\"stale_lock\",\"severity\":\"warn\"",
+    ) != null);
+    try testing.expect(std.mem.indexOf(
+        u8,
+        aw.written(),
+        "\"fixable\":true,\"fix_class\":\"stale_lock\"",
+    ) != null);
+}
+
+test "every finding keeps the fixable/fix_class invariant" {
+    // Cross-cutting contract the dashboard relies on: fixable ⇔ a class
+    // is set, and an ok row is never fixable. One walk with a planted
+    // fixable warn exercises both arms.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "invariant");
+    defer s.deinit(allocator);
+    try s.initSchema();
+
+    const link_path = try std.fmt.allocPrint(allocator, "{s}/bin/ghost-inv", .{s.path});
+    defer allocator.free(link_path);
+    try std.Io.Dir.symLinkAbsolute(std.Options.debug_io, "/tmp/malt_doctor_json_inv_dne", link_path, .{});
+
+    var result = walk(allocator, s.path);
+    defer result.deinit();
+
+    var saw_fixable = false;
+    for (result.findings()) |f| {
+        try testing.expectEqual(f.fix_class != null, f.fixable);
+        if (f.severity == .ok) {
+            try testing.expect(!f.fixable);
+            try testing.expect(f.fix_class == null);
+        }
+        if (f.fixable) saw_fixable = true;
+        try testing.expect(f.id.len > 0);
+        try testing.expect(f.title.len > 0);
+    }
+    // The planted broken symlink guarantees at least one fixable arm ran.
+    try testing.expect(saw_fixable);
+}


### PR DESCRIPTION
## Description

Adds a structured `checks[]` array to `mt doctor --json`. Each finding carries a stable `id`, a `severity` (`ok`/`warn`/`err`), a human `title`/`detail`, a `fixable` flag, and a `fix_class` from doctor's safe-fix vocabulary. 

This gives `jq`/script consumers (and the upcoming dashboard) a first-class view of every health finding, and is the contract the per-finding `--fix <id>` selector builds on.

The check walk now collects findings into a single list that drives both the unchanged human rows and the new JSON payload: the row renderer (`printCheck`) records each row as it draws it, and the same safe-fix signal that arms doctor's `--fix` nudge tags the finding's `fixable`/`fix_class`. 

The existing fragments and the stderr output are byte-identical to before.

## Related Issue

- None

## Notes for Reviewers

- None