### PR TITLE
feat(doctor): allow fixing a single finding by id

### DIFF
--- a/scripts/regressions/doctor_fix_selector.sh
+++ b/scripts/regressions/doctor_fix_selector.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Lock the `mt doctor --fix <id>` per-finding selector end-to-end.
+#
+# Pinned behaviour:
+#   1. `--fix <id>` applies only the named class (stale_lock here) and
+#      leaves the other safe-class offenders (a broken symlink) in place.
+#   2. `--fix` with no id stays apply-all: lock + symlink both go.
+#   3. An unknown id exits non-zero and mutates nothing.
+#   4. `--fix <id> --dry-run` plans but mutates nothing.
+#
+# `mt doctor` exits non-zero by design whenever any check still warns
+# (the leftover broken symlink does), so the apply runs are captured with
+# `|| true` and the lock/symlink state is what we actually assert.
+#
+# Usage: scripts/regressions/doctor_fix_selector.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+# A PID well outside the macOS range so the lock reads as stale (dead PID).
+DEAD_PID=999999
+
+# Seed a prefix with one stale lock and one broken symlink — two distinct
+# safe-fix classes so a targeted fix is observably narrower than apply-all.
+seed_prefix() {
+  local pfx="$1"
+  mkdir -p "$pfx/db" "$pfx/bin"
+  printf '%s' "$DEAD_PID" >"$pfx/db/malt.lock"
+  ln -s /tmp/mt_doctor_fix_selector_vanished_target "$pfx/bin/dead"
+}
+
+# ── 1. --fix <id> applies only that class ──────────────────────────────
+PFX=$(mktemp -d -t mt_doctor_fix_one.XXXXXX)
+export MALT_PREFIX="$PFX"
+seed_prefix "$PFX"
+
+"$MALT_BIN" doctor --fix stale_lock >/dev/null 2>&1 || true
+[[ ! -f "$PFX/db/malt.lock" ]] ||
+  fail '--fix stale_lock did not remove the stale lock'
+[[ -L "$PFX/bin/dead" ]] ||
+  fail '--fix stale_lock also removed the broken symlink (should target only stale_lock)'
+rm -rf "$PFX"
+
+# ── 2. bare --fix stays apply-all ──────────────────────────────────────
+PFX=$(mktemp -d -t mt_doctor_fix_all.XXXXXX)
+export MALT_PREFIX="$PFX"
+seed_prefix "$PFX"
+
+"$MALT_BIN" doctor --fix >/dev/null 2>&1 || true
+[[ ! -f "$PFX/db/malt.lock" ]] ||
+  fail 'apply-all --fix did not remove the stale lock'
+[[ ! -L "$PFX/bin/dead" ]] ||
+  fail 'apply-all --fix did not remove the broken symlink'
+rm -rf "$PFX"
+
+# ── 3. unknown id → non-zero exit, no mutation ─────────────────────────
+PFX=$(mktemp -d -t mt_doctor_fix_bad.XXXXXX)
+export MALT_PREFIX="$PFX"
+seed_prefix "$PFX"
+
+set +e
+out=$("$MALT_BIN" doctor --fix not_a_real_id 2>&1)
+code=$?
+set -e
+[[ "$code" -ne 0 ]] ||
+  fail 'unknown --fix id exited zero (expected a non-zero usage error)'
+printf '%s' "$out" | grep -q "unknown --fix id 'not_a_real_id'" ||
+  fail 'unknown --fix id did not surface a clear error naming the id'
+[[ -f "$PFX/db/malt.lock" ]] ||
+  fail 'unknown --fix id removed the stale lock (must mutate nothing)'
+[[ -L "$PFX/bin/dead" ]] ||
+  fail 'unknown --fix id removed the broken symlink (must mutate nothing)'
+rm -rf "$PFX"
+
+# ── 4. --fix <id> --dry-run plans but mutates nothing ──────────────────
+PFX=$(mktemp -d -t mt_doctor_fix_dry.XXXXXX)
+export MALT_PREFIX="$PFX"
+seed_prefix "$PFX"
+
+out=$("$MALT_BIN" doctor --fix stale_lock --dry-run 2>&1 || true)
+printf '%s' "$out" | grep -qi 'would remove stale lock file' ||
+  fail '--fix stale_lock --dry-run did not print the planned action'
+[[ -f "$PFX/db/malt.lock" ]] ||
+  fail '--fix stale_lock --dry-run removed the lock (dry-run must mutate nothing)'
+rm -rf "$PFX"
+
+printf 'PASS: doctor --fix <id> selector behaves correctly\n'

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -133,6 +133,13 @@ pub const bash_script =
     \\                return 0
     \\            fi
     \\            ;;
+    \\        doctor)
+    \\            # `--fix <id>` takes one of the safe-fix class ids as its value.
+    \\            if [[ "${words[cword-1]}" == "--fix" ]]; then
+    \\                COMPREPLY=( $(compgen -W "stale_lock orphaned_store broken_symlinks" -- "$cur") )
+    \\                return 0
+    \\            fi
+    \\            ;;
     \\    esac
     \\
     \\    local cmd_flags=""
@@ -444,6 +451,11 @@ pub const zsh_script =
     \\                        '--json[Emit refresh-all diff as JSON]' \
     \\                        '*::slug:'
     \\                    ;;
+    \\                doctor)
+    \\                    _arguments \
+    \\                        '--fix[Apply safe-class fixers; with <id>, only that class]::fix-id:(stale_lock orphaned_store broken_symlinks)' \
+    \\                        '--dry-run[Preview the fix plan without applying]'
+    \\                    ;;
     \\            esac
     \\            ;;
     \\    esac
@@ -636,6 +648,10 @@ pub const fish_script =
     \\
     \\    # which
     \\    complete -c $__malt_bin -n '__malt_using_command which' -l json -d 'JSON output'
+    \\
+    \\    # doctor — --fix takes an optional safe-fix class id
+    \\    complete -c $__malt_bin -n '__malt_using_command doctor' -l fix -r -a 'stale_lock orphaned_store broken_symlinks' -d 'Apply safe-class fixers; with <id>, only that class'
+    \\    complete -c $__malt_bin -n '__malt_using_command doctor' -l dry-run -d 'Preview the fix plan without applying'
     \\
     \\    # migrate / rollback
     \\    complete -c $__malt_bin -n '__malt_using_command migrate'    -l dry-run -d 'Preview'

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -357,7 +357,17 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         }
     }
 
-    const fix_requested = fix_mod.wantsFix(args);
+    // Resolve the `--fix` selector up front so an unknown id fails fast
+    // — before any check runs — and never reaches the mutating executor.
+    const fix_req = fix_mod.parseFix(args);
+    const fix_only: ?FixKind = switch (fix_req) {
+        .none, .all => null,
+        .one => |id| render.fixKindFromId(id) catch {
+            output.err("unknown --fix id '{s}' (valid: {s})", .{ id, render.fix_ids_csv });
+            std.process.exit(2);
+        },
+    };
+    const fix_requested = fix_req.isRequested();
 
     resetVerboseHint();
     resetFixHint();
@@ -390,7 +400,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             output.info("Applying safe-class fixes:", .{});
         }
 
-        const outcome = fix_mod.executeFix(.{ .prefix = prefix, .io = ctx.io }, dry_run);
+        const outcome = fix_mod.executeFix(.{ .prefix = prefix, .io = ctx.io, .only = fix_only }, dry_run);
 
         if (outcome.plan.safe.count() == 0) {
             output.dim("no safe-class fixes to apply", .{});

--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -42,6 +42,15 @@ pub const Plan = struct {
     pub fn isEmpty(self: Plan) bool {
         return self.safe.count() == 0 and self.manual.count() == 0;
     }
+
+    /// Narrow a plan to a single safe class — the `--fix <id>` selector.
+    /// Manual hints are dropped: a targeted fix reports only its class,
+    /// not unrelated remediation noise.
+    pub fn onlySafe(self: Plan, kind: FixKind) Plan {
+        var p: Plan = .{};
+        if (self.safe.contains(kind)) p.safe.insert(kind);
+        return p;
+    }
 };
 
 /// Pure: route conditions to the safe-fix set or the manual-command
@@ -188,10 +197,38 @@ fn deleteRefRow(db: *sqlite.Database, sha: []const u8) void {
 
 // ── flag parsing ────────────────────────────────────────────────────
 
-/// True when argv contains the `--fix` flag.
-pub fn wantsFix(args: []const []const u8) bool {
-    for (args) |a| if (std.mem.eql(u8, a, "--fix")) return true;
-    return false;
+/// How `--fix` was invoked. `--fix` alone applies every safe class
+/// (today's behaviour); `--fix <id>` targets one class so the Doctor
+/// tab can remediate just the finding under the cursor.
+pub const FixRequest = union(enum) {
+    /// `--fix` absent: doctor runs check-only.
+    none,
+    /// `--fix` with no id: apply every safe class.
+    all,
+    /// `--fix <id>`: apply only the named class. The id is validated
+    /// against the published vocabulary by the caller.
+    one: []const u8,
+
+    pub fn isRequested(self: FixRequest) bool {
+        return switch (self) {
+            .none => false,
+            .all, .one => true,
+        };
+    }
+};
+
+/// Parse the `--fix` selector from argv. The id is the token immediately
+/// after `--fix` when it isn't another flag; a trailing `--fix` or one
+/// followed by a flag is apply-all.
+pub fn parseFix(args: []const []const u8) FixRequest {
+    for (args, 0..) |a, i| {
+        if (!std.mem.eql(u8, a, "--fix")) continue;
+        if (i + 1 < args.len and !std.mem.startsWith(u8, args[i + 1], "-")) {
+            return .{ .one = args[i + 1] };
+        }
+        return .all;
+    }
+    return .none;
 }
 
 // ── render ──────────────────────────────────────────────────────────
@@ -256,6 +293,9 @@ pub const FixCtx = struct {
     /// safe-class conditions itself. Tests inject explicit conditions
     /// (including dangerous classes) without requiring a real prefix.
     conditions: ?Conditions = null,
+    /// `--fix <id>` selector: when set, only this safe class is applied
+    /// and reported. `null` is apply-all (the same executor, no filter).
+    only: ?FixKind = null,
 };
 
 pub const FixOutcome = struct {
@@ -282,7 +322,9 @@ pub fn executeFix(ctx: FixCtx, dry_run: bool) FixOutcome {
         .orphan_store_count = probeOrphanedStoreCount(ctx.io, ctx.prefix),
         .broken_symlink_count = probeBrokenSymlinks(ctx.io, ctx.prefix),
     };
-    const plan = planFixes(conditions);
+    // `--fix <id>` narrows the same plan to one class; apply-all leaves
+    // the filter empty so this is the identical code path.
+    const plan = if (ctx.only) |kind| planFixes(conditions).onlySafe(kind) else planFixes(conditions);
 
     var outcome: FixOutcome = .{ .plan = plan };
     if (dry_run) return outcome;
@@ -366,6 +408,27 @@ test "planFixes: safe and manual sets coexist" {
     try std.testing.expect(!plan.isEmpty());
 }
 
+test "onlySafe: keeps the targeted class, drops the other safe classes" {
+    const plan = planFixes(.{ .stale_lock = true, .broken_symlink_count = 3 });
+    const narrowed = plan.onlySafe(.stale_lock);
+    try std.testing.expect(narrowed.safe.contains(.stale_lock));
+    try std.testing.expect(!narrowed.safe.contains(.broken_symlinks));
+    try std.testing.expectEqual(@as(usize, 1), narrowed.safe.count());
+}
+
+test "onlySafe: a class not in the plan yields an empty plan" {
+    const plan = planFixes(.{ .stale_lock = true });
+    const narrowed = plan.onlySafe(.orphaned_store);
+    try std.testing.expect(narrowed.isEmpty());
+}
+
+test "onlySafe: drops manual hints so a targeted fix reports only its class" {
+    const plan = planFixes(.{ .stale_lock = true, .db_corrupt = true });
+    const narrowed = plan.onlySafe(.stale_lock);
+    try std.testing.expect(narrowed.safe.contains(.stale_lock));
+    try std.testing.expectEqual(@as(usize, 0), narrowed.manual.count());
+}
+
 fn renderToBuf(plan: Plan, dry_run: bool, buf: []u8) ![]const u8 {
     var w: std.Io.Writer = .fixed(buf);
     try renderPlan(&w, plan, dry_run);
@@ -437,22 +500,40 @@ test "renderPlan: every manual kind has a hint" {
     }
 }
 
-test "wantsFix: empty argv is check-only" {
-    try std.testing.expect(!wantsFix(&.{}));
+test "parseFix: empty argv is check-only" {
+    try std.testing.expect(parseFix(&.{}) == .none);
+    try std.testing.expect(!parseFix(&.{}).isRequested());
 }
 
-test "wantsFix: --fix flips the mode" {
-    try std.testing.expect(wantsFix(&.{"--fix"}));
+test "parseFix: bare --fix is apply-all" {
+    try std.testing.expect(parseFix(&.{"--fix"}) == .all);
+    try std.testing.expect(parseFix(&.{"--fix"}).isRequested());
 }
 
-test "wantsFix: only the exact flag matches" {
-    try std.testing.expect(!wantsFix(&.{"--fixxx"}));
-    try std.testing.expect(!wantsFix(&.{"fix"}));
+test "parseFix: only the exact flag matches" {
+    try std.testing.expect(parseFix(&.{"--fixxx"}) == .none);
+    try std.testing.expect(parseFix(&.{"fix"}) == .none);
 }
 
-test "wantsFix: position does not matter" {
-    try std.testing.expect(wantsFix(&.{ "--quiet", "--fix" }));
-    try std.testing.expect(wantsFix(&.{ "--fix", "--quiet" }));
+test "parseFix: --fix position does not matter" {
+    try std.testing.expect(parseFix(&.{ "--quiet", "--fix" }) == .all);
+}
+
+test "parseFix: --fix <id> captures the id" {
+    const req = parseFix(&.{ "--fix", "stale_lock" });
+    try std.testing.expect(req == .one);
+    try std.testing.expectEqualStrings("stale_lock", req.one);
+}
+
+test "parseFix: a flag after --fix is apply-all, not an id" {
+    // `--fix --verbose` must not read `--verbose` as a finding id.
+    try std.testing.expect(parseFix(&.{ "--fix", "--verbose" }) == .all);
+}
+
+test "parseFix: an empty-string id is captured (caller rejects it as unknown)" {
+    const req = parseFix(&.{ "--fix", "" });
+    try std.testing.expect(req == .one);
+    try std.testing.expectEqualStrings("", req.one);
 }
 
 test "executeFix: dry run does not touch filesystem state" {

--- a/src/cli/doctor/render.zig
+++ b/src/cli/doctor/render.zig
@@ -56,6 +56,30 @@ pub fn fixClassTag(kind: ?FixKind) []const u8 {
     };
 }
 
+/// Resolve a `--fix <id>` token back to its safe-fix class, reusing the
+/// `fixClassTag` vocabulary so the selector and the JSON findings can
+/// never disagree on one set of ids. Unknown ids — including `"none"`
+/// and the empty string — error; only the real safe classes resolve.
+pub fn fixKindFromId(id: []const u8) error{UnknownFixId}!FixKind {
+    inline for (std.meta.fields(FixKind)) |f| {
+        const kind: FixKind = @field(FixKind, f.name);
+        if (std.mem.eql(u8, id, fixClassTag(kind))) return kind;
+    }
+    return error.UnknownFixId;
+}
+
+/// Comma-joined list of the valid `--fix <id>` ids, built from the same
+/// vocabulary so an unknown-id error can name the alternatives without a
+/// hand-maintained string drifting from the enum.
+pub const fix_ids_csv = blk: {
+    var s: []const u8 = "";
+    for (std.meta.fields(FixKind), 0..) |f, i| {
+        const kind: FixKind = @field(FixKind, f.name);
+        s = s ++ (if (i == 0) "" else ", ") ++ fixClassTag(kind);
+    }
+    break :blk s;
+};
+
 /// Serialize findings as a `{"checks":[...]}` object. Pure writer so
 /// tests pin the bytes; every string routes through the shared JSON
 /// escaper. `detail` is always present (empty string when the row had
@@ -171,6 +195,34 @@ test "fixClassTag maps null to none and each FixKind to its tag" {
     try testing.expectEqualStrings("stale_lock", fixClassTag(.stale_lock));
     try testing.expectEqualStrings("orphaned_store", fixClassTag(.orphaned_store));
     try testing.expectEqualStrings("broken_symlinks", fixClassTag(.broken_symlinks));
+}
+
+test "fixKindFromId resolves every published id to its class" {
+    try testing.expectEqual(FixKind.stale_lock, try fixKindFromId("stale_lock"));
+    try testing.expectEqual(FixKind.orphaned_store, try fixKindFromId("orphaned_store"));
+    try testing.expectEqual(FixKind.broken_symlinks, try fixKindFromId("broken_symlinks"));
+}
+
+test "fixKindFromId round-trips fixClassTag for every FixKind" {
+    // The selector must accept exactly the ids the JSON findings emit;
+    // pin the round-trip so the two views can never drift.
+    inline for (std.meta.fields(FixKind)) |f| {
+        const kind: FixKind = @field(FixKind, f.name);
+        try testing.expectEqual(kind, try fixKindFromId(fixClassTag(kind)));
+    }
+}
+
+test "fixKindFromId rejects unknown, none, and empty ids" {
+    try testing.expectError(error.UnknownFixId, fixKindFromId("bogus"));
+    try testing.expectError(error.UnknownFixId, fixKindFromId("none"));
+    try testing.expectError(error.UnknownFixId, fixKindFromId(""));
+}
+
+test "fix_ids_csv lists every safe-fix id" {
+    inline for (std.meta.fields(FixKind)) |f| {
+        const kind: FixKind = @field(FixKind, f.name);
+        try testing.expect(std.mem.indexOf(u8, fix_ids_csv, fixClassTag(kind)) != null);
+    }
 }
 
 fn checksToBuf(findings: []const Finding, buf: []u8) ![]const u8 {

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -257,7 +257,7 @@ const search_help =
 ;
 
 const doctor_help =
-    \\Usage: malt doctor [--fix]
+    \\Usage: malt doctor [--fix [<id>]]
     \\
     \\Run system health checks: database integrity, orphaned store
     \\entries, broken symlinks, disk space, API reachability, and more.
@@ -270,11 +270,14 @@ const doctor_help =
     \\  is what actually reclaims the space.
     \\
     \\Options:
-    \\  --fix          Apply the safe-class fixers (stale lock,
+    \\  --fix [<id>]   Apply the safe-class fixers (stale lock,
     \\                 orphaned store entries, broken symlinks).
-    \\                 Pair with --dry-run to preview the plan.
-    \\                 Dangerous classes (corrupt DB, missing kegs)
-    \\                 still print a manual remediation command.
+    \\                 With an <id> (stale_lock, orphaned_store,
+    \\                 broken_symlinks) apply only that class; with
+    \\                 no id apply them all. Pair with --dry-run to
+    \\                 preview the plan. Dangerous classes (corrupt
+    \\                 DB, missing kegs) still print a manual
+    \\                 remediation command.
     \\  --verbose      List every offender under the count-only
     \\                 checks (Mach-O placeholders, broken symlinks,
     \\                 missing kegs) on its own indented line, and

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -109,6 +109,16 @@ test "all outdated completions expose --refresh" {
     try expectContains(completions.fish_script, "-l refresh");
 }
 
+test "all doctor completions offer the --fix class ids" {
+    // The `--fix <id>` selector is only discoverable if each shell
+    // offers the safe-fix class ids as completion candidates. All three
+    // embed the same space-joined id list, so one needle pins them all.
+    const ids = "stale_lock orphaned_store broken_symlinks";
+    try expectContains(completions.bash_script, ids);
+    try expectContains(completions.zsh_script, ids);
+    try expectContains(completions.fish_script, ids);
+}
+
 test "all outdated completions expose --tap" {
     // bash carries `--tap` in the outdated cmd_flags list; zsh's
     // per-command _arguments block names it with a `:tap label:` slot;

--- a/tests/doctor_fix_test.zig
+++ b/tests/doctor_fix_test.zig
@@ -316,6 +316,106 @@ test "executeFix: idempotent — second run finds nothing left to do" {
     try testing.expect(second.plan.isEmpty());
 }
 
+// ── selective apply (`--fix <id>`) ──────────────────────────────────
+
+test "executeFix: only=stale_lock removes the lock and leaves broken symlinks" {
+    // A targeted fix must touch only its class. Seed both a stale lock
+    // and a broken symlink; selecting stale_lock alone must remove the
+    // lock and leave the dangling symlink in place.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "only-lock");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_buf, "{s}/db", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, db_dir);
+    var lock_buf: [256]u8 = undefined;
+    const lock_path = try std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix});
+    try writeFile(lock_path, dead_pid_str);
+
+    var bin_buf: [256]u8 = undefined;
+    const bin_dir = try std.fmt.bufPrint(&bin_buf, "{s}/bin", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, bin_dir);
+    var bin = try fs_compat.openDirAbsolute(std.Options.debug_io, bin_dir, .{ .iterate = true });
+    defer bin.close(std.Options.debug_io);
+    try bin.symLink(std.Options.debug_io, "/tmp/malt-doctor-fix-only-target-dne", "dead", .{});
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const outcome = fix.executeFix(.{ .prefix = prefix, .io = io, .only = .stale_lock }, false);
+    try testing.expect(outcome.stale_lock_removed);
+    try testing.expectEqual(@as(u32, 0), outcome.broken_symlinks_removed);
+    try testing.expectEqual(@as(u32, 1), outcome.fixesApplied());
+    // The plan the user is shown lists only the targeted class.
+    try testing.expectEqual(@as(usize, 1), outcome.plan.safe.count());
+    try testing.expect(outcome.plan.safe.contains(.stale_lock));
+
+    try testing.expect(!pathExists(lock_path));
+    // `access()` follows the link, so a surviving dangling symlink reads
+    // as absent — confirm the entry itself is still present by iterating.
+    try testing.expect(symlinkEntryExists(io, bin_dir, "dead"));
+}
+
+/// True when `name` exists as a symlink entry under `dir_path`, without
+/// following the link (unlike `pathExists`, which `access()`es through).
+fn symlinkEntryExists(io: std.Io, dir_path: []const u8, name: []const u8) bool {
+    var dir = fs_compat.openDirAbsolute(io, dir_path, .{ .iterate = true }) catch return false;
+    defer dir.close(io);
+    var it = dir.iterate();
+    while (it.next(io) catch null) |entry| {
+        if (entry.kind == .sym_link and std.mem.eql(u8, entry.name, name)) return true;
+    }
+    return false;
+}
+
+test "executeFix: a valid id whose condition is absent is a clean no-op" {
+    // `--fix broken_symlinks` on a prefix that only has a stale lock
+    // must change nothing and leave the lock intact.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "only-absent");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_buf, "{s}/db", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, db_dir);
+    var lock_buf: [256]u8 = undefined;
+    const lock_path = try std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix});
+    try writeFile(lock_path, dead_pid_str);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const outcome = fix.executeFix(.{ .prefix = prefix, .io = io, .only = .broken_symlinks }, false);
+    try testing.expectEqual(@as(u32, 0), outcome.fixesApplied());
+    try testing.expect(outcome.plan.isEmpty());
+    try testing.expect(pathExists(lock_path));
+}
+
+test "executeFix: only=stale_lock --dry-run plans but mutates nothing" {
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "only-dry");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_buf, "{s}/db", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, db_dir);
+    var lock_buf: [256]u8 = undefined;
+    const lock_path = try std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix});
+    try writeFile(lock_path, dead_pid_str);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const outcome = fix.executeFix(.{ .prefix = prefix, .io = io, .only = .stale_lock }, true);
+    try testing.expectEqual(@as(u32, 0), outcome.fixesApplied());
+    try testing.expect(outcome.plan.safe.contains(.stale_lock));
+    try testing.expect(pathExists(lock_path));
+}
+
 test "executeFix: dangerous classes carry into the plan, not the safe set" {
     const outcome = fix.executeFix(
         .{


### PR DESCRIPTION
## Description

Lets `mt doctor --fix` target a single finding by id (e.g. `mt doctor --fix stale_lock`) instead of always applying every safe-class fix. `--fix` with no id keeps today's apply-all behaviour, and an unknown id fails cleanly without touching anything. This makes the fix path addressable — the Doctor dashboard can remediate just the finding under the cursor, and script users can repair a single class — while reusing the existing safe-fix classes and confirmation posture unchanged.

The selector reuses the published `fix_class` vocabulary: `fixKindFromId` is the inverse of the JSON `fixClassTag`, so the CLI, the shell completions, and the `mt doctor --json` findings can never disagree on the id set. The apply-all path is the same executor with an empty filter, so existing `--fix` behaviour is preserved by construction.

## Related Issue

- None

## Notes for Reviewers

- **Fail-fast, no mutation.** An unknown id exits non-zero before any check runs, so nothing is touched. This CLI-level guard (`std.process.exit`) is proven by a new regression script rather than a Zig test.
- **Behaviour note:** a non-flag token after `--fix` was previously ignored (apply-all); it is now read as the id, so an unrecognised one errors. Flag-prefixed tokens (`--fix --dry-run`) still resolve to apply-all. This is the intended additive `--fix <id>` form; no existing documented usage changes.

