### PR TITLE
feat(json): add schema_version to read-command JSON output

### DIFF
--- a/scripts/regressions/doctor_tap_forge.sh
+++ b/scripts/regressions/doctor_tap_forge.sh
@@ -4,7 +4,7 @@
 # Pinned behaviour:
 #   1. With taps registered, `mt doctor` lists each one as `<name> [<host>]`
 #      under a "Registered taps" block — github and off-github alike.
-#   2. `mt doctor --json` carries a `{"taps":[{"name","host"},...]}` payload.
+#   2. `mt doctor --json` carries a `"taps":[{"name","host"},...]` member.
 #   3. On a prefix with no taps, the block is silent (no "Registered taps").
 #
 # Registration and doctor render never touch the network, so this runs offline.
@@ -48,7 +48,7 @@ printf '%s' "$human" | grep -q 'grp/tap \[gitlab.com\]' ||
   fail 'doctor did not list the gitlab tap with its host'
 
 json=$("$MALT_BIN" doctor --json 2>/dev/null || true)
-printf '%s' "$json" | grep -q '{"taps":\[' ||
+printf '%s' "$json" | grep -q '"taps":\[' ||
   fail 'doctor --json missing the taps payload'
 printf '%s' "$json" | grep -q '"name":"grp/tap","host":"gitlab.com"' ||
   fail 'doctor --json did not carry the gitlab tap name+host'

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -199,33 +199,14 @@ pub fn collectFindings(
     return .{ .sink = sink, .tally = tally };
 }
 
-/// Serialize the collected findings as `mt doctor --json`'s `checks[]`
-/// payload to stdout, alongside the existing cask_history/tap_cache/taps
-/// fragments. Best-effort: a writer failure drops the payload rather
-/// than aborting the run.
-fn emitChecksJson(allocator: std.mem.Allocator, findings: []const render.Finding) void {
-    var aw: std.Io.Writer.Allocating = .init(allocator);
-    defer aw.deinit();
-    render.writeChecksJson(&aw.writer, findings) catch return;
-    output.writeStdoutAll(aw.written());
-}
-
-/// Walk retained cask versions and emit the report doctor surfaces
-/// after the check rows. Pure read-only: routes to stdout (JSON) or
-/// stderr (human + optional verbose entry list) by reading
-/// `output.isJson()` and `output.isVerbose()`. Held public so the
+/// Walk retained cask versions and emit the human report doctor surfaces
+/// after the check rows (optionally a verbose entry list). The `--json`
+/// view of this data is emitted as one member of the merged document in
+/// `emitDoctorJson`, so this path is human-only. Held public so the
 /// integration test can drive the same path `execute` uses.
 pub fn emitCaskHistoryReport(allocator: std.mem.Allocator, io: std.Io, prefix: []const u8) void {
     var census = cask_history.collectCensus(allocator, io, prefix);
     defer census.deinit(allocator);
-
-    if (output.isJson()) {
-        var aw: std.Io.Writer.Allocating = .init(allocator);
-        defer aw.deinit();
-        cask_history.writeJson(&aw.writer, census) catch return;
-        output.writeStdoutAll(aw.written());
-        return;
-    }
 
     if (census.entries.len == 0) return;
 
@@ -240,21 +221,12 @@ pub fn emitCaskHistoryReport(allocator: std.mem.Allocator, io: std.Io, prefix: [
     output.writeStderrAll(aw.written());
 }
 
-/// Walk `<prefix>/cache/Tap` and emit the warmed tap-archive size
-/// alongside doctor's other reports. Routes to stdout (JSON) with a
-/// stable schema (zero values, not omission) or to stderr (human),
-/// which stays silent when the cache is empty so the clean case adds
-/// no noise. Pure read; safe to invoke from `execute` post-checks.
+/// Walk `<prefix>/cache/Tap` and emit the warmed tap-archive size as a
+/// human line, silent when the cache is empty so the clean case adds no
+/// noise. The `--json` view is a member of the merged document built in
+/// `emitDoctorJson`. Pure read; safe to invoke from `execute` post-checks.
 pub fn emitTapCacheReport(allocator: std.mem.Allocator, io: std.Io, prefix: []const u8) void {
     const bytes = tap_cache_mod.bytesUnder(io, allocator, prefix);
-
-    if (output.isJson()) {
-        var aw: std.Io.Writer.Allocating = .init(allocator);
-        defer aw.deinit();
-        aw.writer.print("{{\"tap_cache\":{{\"bytes\":{d}}}}}\n", .{bytes}) catch return;
-        output.writeStdoutAll(aw.written());
-        return;
-    }
 
     if (bytes == 0) return;
     var aw: std.Io.Writer.Allocating = .init(allocator);
@@ -283,8 +255,8 @@ pub fn writeTapForgeHuman(w: *std.Io.Writer, taps: []const tap_mod.TapInfo) !voi
 /// stays present (empty, not omitted) so scripted consumers can always
 /// read it. Strings route through `output.jsonStr` for escaping. Pure
 /// for byte-pinning tests.
-pub fn writeTapForgeJson(w: *std.Io.Writer, taps: []const tap_mod.TapInfo) !void {
-    try w.writeAll("{\"taps\":[");
+pub fn writeTapForgeField(w: *std.Io.Writer, taps: []const tap_mod.TapInfo) !void {
+    try w.writeAll("\"taps\":[");
     for (taps, 0..) |t, i| {
         if (i != 0) try w.writeAll(",");
         try w.writeAll("{\"name\":");
@@ -293,41 +265,92 @@ pub fn writeTapForgeJson(w: *std.Io.Writer, taps: []const tap_mod.TapInfo) !void
         try output.jsonStr(w, t.host);
         try w.writeAll("}");
     }
-    try w.writeAll("]}\n");
+    try w.writeAll("]");
 }
 
-/// Walk the registered taps and emit their forge/host alongside doctor's
-/// other reports. Routes to stdout (JSON, stable empty array) or stderr
-/// (human, silent when no taps). Pure read; safe from `execute`'s
-/// post-check phase. Best-effort: a DB or list failure drops the report
-/// rather than failing the whole doctor run.
-pub fn emitTapForgeReport(allocator: std.mem.Allocator, prefix: []const u8) void {
+/// Standalone `{"taps":[...]}` document. Pure for byte-pinning tests;
+/// wraps `writeTapForgeField`.
+pub fn writeTapForgeJson(w: *std.Io.Writer, taps: []const tap_mod.TapInfo) !void {
+    try w.writeAll("{");
+    try writeTapForgeField(w, taps);
+    try w.writeAll("}\n");
+}
+
+/// Read the registered taps from the prefix DB. Returns `null` on any
+/// DB/list failure so a caller drops the taps report rather than failing
+/// the whole doctor run. Free with `freeTaps`.
+fn collectTaps(allocator: std.mem.Allocator, prefix: []const u8) ?[]tap_mod.TapInfo {
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
-    var db = sqlite.Database.open(db_path) catch return;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return null;
+    var db = sqlite.Database.open(db_path) catch return null;
     defer db.close();
     schema.initSchema(&db) catch {};
+    return tap_mod.list(allocator, &db) catch null;
+}
 
-    const taps = tap_mod.list(allocator, &db) catch return;
-    defer {
-        for (taps) |t| {
-            allocator.free(t.name);
-            allocator.free(t.url);
-            allocator.free(t.host);
-            if (t.commit_sha) |sha| allocator.free(sha);
-        }
-        allocator.free(taps);
+fn freeTaps(allocator: std.mem.Allocator, taps: []tap_mod.TapInfo) void {
+    for (taps) |t| {
+        allocator.free(t.name);
+        allocator.free(t.url);
+        allocator.free(t.host);
+        if (t.commit_sha) |sha| allocator.free(sha);
     }
+    allocator.free(taps);
+}
+
+/// Emit the registered-tap forge/host block as human lines (silent when
+/// no taps). The `--json` view is a member of the merged document built
+/// in `emitDoctorJson`. Pure read; safe from `execute`'s post-check phase.
+pub fn emitTapForgeReport(allocator: std.mem.Allocator, prefix: []const u8) void {
+    const taps = collectTaps(allocator, prefix) orelse return;
+    defer freeTaps(allocator, taps);
 
     var aw: std.Io.Writer.Allocating = .init(allocator);
     defer aw.deinit();
-    if (output.isJson()) {
-        writeTapForgeJson(&aw.writer, taps) catch return;
-        output.writeStdoutAll(aw.written());
-        return;
-    }
     writeTapForgeHuman(&aw.writer, taps) catch return;
     output.writeStderrAll(aw.written());
+}
+
+/// Compose the single versioned `mt doctor --json` document. Pure writer
+/// (no IO/collection) so tests pin the exact bytes and confirm it parses
+/// as one JSON object. The four data members are always present — empty
+/// `checks`/`taps` arrays and zeroed `cask_history`/`tap_cache` rather
+/// than omission — so consumers never special-case a missing key.
+pub fn writeDoctorJson(
+    w: *std.Io.Writer,
+    findings: []const render.Finding,
+    census: cask_history.Census,
+    tap_cache_bytes: u64,
+    taps: []const tap_mod.TapInfo,
+) !void {
+    try output.writeSchemaVersionPrefix(w);
+    try render.writeChecksField(w, findings);
+    try w.writeAll(",");
+    try cask_history.writeField(w, census);
+    try w.print(",\"tap_cache\":{{\"bytes\":{d}}}", .{tap_cache_bytes});
+    try w.writeAll(",");
+    try writeTapForgeField(w, taps);
+    try w.writeAll("}\n");
+}
+
+/// Collect the three post-check data sources and emit them with the
+/// checks as one merged `--json` document. Best-effort: a writer failure
+/// drops the payload rather than aborting the run. Held public so the
+/// integration tests can drive the same path `execute` uses under `--json`.
+pub fn emitDoctorJson(allocator: std.mem.Allocator, io: std.Io, prefix: []const u8, findings: []const render.Finding) void {
+    var census = cask_history.collectCensus(allocator, io, prefix);
+    defer census.deinit(allocator);
+    const tap_cache_bytes = tap_cache_mod.bytesUnder(io, allocator, prefix);
+    // Free the collected slice even when empty-but-allocated; only the
+    // collection-failed (`null`) case substitutes a static empty slice.
+    const taps_opt = collectTaps(allocator, prefix);
+    defer if (taps_opt) |t| freeTaps(allocator, t);
+    const taps: []const tap_mod.TapInfo = taps_opt orelse &.{};
+
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    writeDoctorJson(&aw.writer, findings, census, tap_cache_bytes, taps) catch return;
+    output.writeStdoutAll(aw.written());
 }
 
 /// Local mirror of `cli/purge/util.zig::formatBytes` / the cask-history
@@ -385,11 +408,15 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     defer walk.deinit();
     const tally = walk.tally;
 
-    if (want_checks_json) emitChecksJson(allocator, walk.findings());
-
-    emitCaskHistoryReport(allocator, ctx.io, prefix);
-    emitTapCacheReport(allocator, ctx.io, prefix);
-    emitTapForgeReport(allocator, prefix);
+    // `--json` is one merged, versioned document; the human view keeps the
+    // three reports split so each renders in its own place after the rows.
+    if (want_checks_json) {
+        emitDoctorJson(allocator, ctx.io, prefix, walk.findings());
+    } else {
+        emitCaskHistoryReport(allocator, ctx.io, prefix);
+        emitTapCacheReport(allocator, ctx.io, prefix);
+        emitTapForgeReport(allocator, prefix);
+    }
 
     if (fix_requested) {
         output.plain("", .{});
@@ -1446,27 +1473,6 @@ test "emitTapCacheReport: silent on stderr when cache is empty" {
     try testing.expectEqualStrings("", buf.items);
 }
 
-test "emitTapCacheReport: emits stable JSON schema even when cache is empty" {
-    // Doctor's JSON consumers must always be able to read
-    // `tap_cache.bytes` — omitting the field on the empty case
-    // forces every consumer to special-case a null/missing path.
-    const allocator = testing.allocator;
-    const ts = std.Io.Clock.real.now(std.Options.debug_io).toNanoseconds();
-    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_doctor_tap_json_empty_{d}", .{ts});
-
-    output.setMode(.json);
-    defer output.setMode(.human);
-
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(allocator);
-    output.beginStdoutCapture(allocator, &buf);
-    defer output.endStdoutCapture();
-    emitTapCacheReport(allocator, std.Options.debug_io, prefix);
-
-    try testing.expectEqualStrings("{\"tap_cache\":{\"bytes\":0}}\n", buf.items);
-}
-
 test "emitTapCacheReport: human one-liner when cache holds bytes" {
     const allocator = testing.allocator;
     const ts = std.Io.Clock.real.now(std.Options.debug_io).toNanoseconds();
@@ -1545,4 +1551,44 @@ test "checks table includes the prefix-on-PATH row" {
         }
     }
     try testing.expect(found);
+}
+
+test "writeDoctorJson merges all four members under one versioned root" {
+    const findings = [_]render.Finding{
+        .{ .id = "stale_lock", .severity = .warn_status, .title = "Stale lock", .detail = "d", .fixable = true, .fix_class = .stale_lock },
+    };
+    const census: cask_history.Census = .{ .entries = &.{}, .total_bytes = 42 };
+    const taps = [_]tap_mod.TapInfo{
+        .{ .name = "u/r", .url = "", .host = "gitlab.com", .commit_sha = null },
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try writeDoctorJson(&aw.writer, &findings, census, 7, &taps);
+
+    try testing.expectEqualStrings(
+        "{\"schema_version\":1," ++
+            "\"checks\":[{\"id\":\"stale_lock\",\"severity\":\"warn\",\"title\":\"Stale lock\",\"detail\":\"d\",\"fixable\":true,\"fix_class\":\"stale_lock\"}]," ++
+            "\"cask_history\":{\"retained_versions\":0,\"bytes\":42}," ++
+            "\"tap_cache\":{\"bytes\":7}," ++
+            "\"taps\":[{\"name\":\"u/r\",\"host\":\"gitlab.com\"}]}\n",
+        aw.written(),
+    );
+}
+
+test "writeDoctorJson stays one valid JSON object with schema_version on the empty case" {
+    // The merged doc must parse as a single object (the old multi-document
+    // concatenation did not) and carry the version even with nothing found.
+    const census: cask_history.Census = .{ .entries = &.{}, .total_bytes = 0 };
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try writeDoctorJson(&aw.writer, &.{}, census, 0, &.{});
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(i64, 1), parsed.value.object.get("schema_version").?.integer);
+    try testing.expectEqual(@as(usize, 0), parsed.value.object.get("checks").?.array.items.len);
+    try testing.expectEqual(@as(usize, 0), parsed.value.object.get("taps").?.array.items.len);
+    try testing.expectEqual(@as(i64, 0), parsed.value.object.get("tap_cache").?.object.get("bytes").?.integer);
 }

--- a/src/cli/doctor/cask_history.zig
+++ b/src/cli/doctor/cask_history.zig
@@ -173,15 +173,23 @@ pub fn writeHumanEntries(w: *std.Io.Writer, census: Census) !void {
     }
 }
 
-/// Emit doctor's `--json` payload as a single line. The schema stays
-/// stable across the empty case (zero values, not omission) so
-/// scripted consumers can always read `cask_history.retained_versions`
-/// and `cask_history.bytes`. Pure for byte-pinning tests.
-pub fn writeJson(w: *std.Io.Writer, census: Census) !void {
+/// Write the `"cask_history":{...}` field (no braces/newline) for the
+/// doctor `--json` merger. The schema stays stable across the empty case
+/// (zero values, not omission) so scripted consumers can always read
+/// `cask_history.retained_versions` and `cask_history.bytes`.
+pub fn writeField(w: *std.Io.Writer, census: Census) !void {
     try w.print(
-        "{{\"cask_history\":{{\"retained_versions\":{d},\"bytes\":{d}}}}}\n",
+        "\"cask_history\":{{\"retained_versions\":{d},\"bytes\":{d}}}",
         .{ census.entries.len, census.total_bytes },
     );
+}
+
+/// Standalone single-line `{"cask_history":{...}}` document. Pure for
+/// byte-pinning tests; wraps `writeField`.
+pub fn writeJson(w: *std.Io.Writer, census: Census) !void {
+    try w.writeAll("{");
+    try writeField(w, census);
+    try w.writeAll("}\n");
 }
 
 /// Format a byte count as `{d:.1} {unit}` (B/KB/MB/GB/TB). Local mirror

--- a/src/cli/doctor/render.zig
+++ b/src/cli/doctor/render.zig
@@ -80,12 +80,12 @@ pub const fix_ids_csv = blk: {
     break :blk s;
 };
 
-/// Serialize findings as a `{"checks":[...]}` object. Pure writer so
-/// tests pin the bytes; every string routes through the shared JSON
-/// escaper. `detail` is always present (empty string when the row had
-/// no detail) so consumers never special-case a missing field.
-pub fn writeChecksJson(w: *std.Io.Writer, findings: []const Finding) !void {
-    try w.writeAll("{\"checks\":[");
+/// Write the `"checks":[...]` field (no surrounding braces, no newline)
+/// so the doctor `--json` merger can embed it as one member of the single
+/// versioned root. `detail` is always present (empty string when the row
+/// had no detail) so consumers never special-case a missing field.
+pub fn writeChecksField(w: *std.Io.Writer, findings: []const Finding) !void {
+    try w.writeAll("\"checks\":[");
     for (findings, 0..) |f, i| {
         if (i != 0) try w.writeAll(",");
         try w.writeAll("{\"id\":");
@@ -100,7 +100,15 @@ pub fn writeChecksJson(w: *std.Io.Writer, findings: []const Finding) !void {
         try output.jsonStr(w, fixClassTag(f.fix_class));
         try w.writeAll("}");
     }
-    try w.writeAll("]}\n");
+    try w.writeAll("]");
+}
+
+/// Serialize findings as a standalone `{"checks":[...]}` object. Pure
+/// writer so tests pin the bytes; wraps `writeChecksField`.
+pub fn writeChecksJson(w: *std.Io.Writer, findings: []const Finding) !void {
+    try w.writeAll("{");
+    try writeChecksField(w, findings);
+    try w.writeAll("}\n");
 }
 
 pub const CheckStyle = struct {

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -401,7 +401,8 @@ fn encodeHeader(
 }
 
 pub fn encodeApiFormulaJson(w: *std.Io.Writer, f: *const formula_mod.Formula) !void {
-    try w.writeAll("{\"name\":");
+    try output.writeSchemaVersionPrefix(w);
+    try w.writeAll("\"name\":");
     try output.jsonStr(w, f.name);
     try w.writeAll(",\"type\":\"formula\",\"installed\":false,\"version\":");
     try output.jsonStr(w, f.version);
@@ -420,7 +421,8 @@ pub fn encodeApiFormulaJson(w: *std.Io.Writer, f: *const formula_mod.Formula) !v
 }
 
 pub fn encodeApiCaskJson(w: *std.Io.Writer, c: *const cask_mod.Cask) !void {
-    try w.writeAll("{\"name\":");
+    try output.writeSchemaVersionPrefix(w);
+    try w.writeAll("\"name\":");
     try output.jsonStr(w, c.token);
     try w.writeAll(",\"type\":\"cask\",\"installed\":false,\"version\":");
     try output.jsonStr(w, c.version);
@@ -492,7 +494,8 @@ fn writeJsonNotInstalled(
     name: []const u8,
     stdout: *std.Io.Writer,
 ) !void {
-    try stdout.writeAll("{\"name\":");
+    try output.writeSchemaVersionPrefix(stdout);
+    try stdout.writeAll("\"name\":");
     try output.jsonStr(stdout, name);
     try stdout.writeAll(",\"type\":\"formula\",\"installed\":false}\n");
 }
@@ -598,7 +601,8 @@ pub fn encodeInstalledFormulaJson(
     history: []const rollback.Entry,
     dependencies: []const []const u8,
 ) !void {
-    try w.writeAll("{\"name\":");
+    try output.writeSchemaVersionPrefix(w);
+    try w.writeAll("\"name\":");
     try output.jsonStr(w, name);
     try w.writeAll(",\"type\":\"formula\",\"installed\":true,\"version\":");
     try output.jsonStr(w, version);
@@ -689,7 +693,8 @@ pub fn encodeInstalledCaskJson(
     row: *const InstalledCaskRow,
     history: []const rollback.Entry,
 ) !void {
-    try w.writeAll("{\"name\":");
+    try output.writeSchemaVersionPrefix(w);
+    try w.writeAll("\"name\":");
     try output.jsonStr(w, row.token);
     try w.writeAll(",\"type\":\"cask\",\"installed\":true,\"version\":");
     try output.jsonStr(w, row.version orelse "");
@@ -856,7 +861,7 @@ test "encodeApiFormulaJson produces the documented shape" {
     try encodeApiFormulaJson(&aw.writer, &f);
 
     try testing.expectEqualStrings(
-        "{\"name\":\"wget\",\"type\":\"formula\",\"installed\":false,\"version\":\"1.24.5\",\"desc\":\"Internet file retriever\",\"homepage\":\"https://www.gnu.org/software/wget/\",\"tap\":\"homebrew/core\",\"dependencies\":[\"libidn2\",\"openssl@3\"]}\n",
+        "{\"schema_version\":1,\"name\":\"wget\",\"type\":\"formula\",\"installed\":false,\"version\":\"1.24.5\",\"desc\":\"Internet file retriever\",\"homepage\":\"https://www.gnu.org/software/wget/\",\"tap\":\"homebrew/core\",\"dependencies\":[\"libidn2\",\"openssl@3\"]}\n",
         aw.written(),
     );
 }
@@ -896,7 +901,19 @@ test "encodeApiCaskJson produces the documented shape" {
     try encodeApiCaskJson(&aw.writer, &c);
 
     try testing.expectEqualStrings(
-        "{\"name\":\"firefox\",\"type\":\"cask\",\"installed\":false,\"version\":\"149.0.2\",\"full_name\":\"Mozilla Firefox\",\"desc\":\"Web browser\",\"homepage\":\"https://www.mozilla.org/firefox/\",\"url\":\"https://example.com/firefox.dmg\"}\n",
+        "{\"schema_version\":1,\"name\":\"firefox\",\"type\":\"cask\",\"installed\":false,\"version\":\"149.0.2\",\"full_name\":\"Mozilla Firefox\",\"desc\":\"Web browser\",\"homepage\":\"https://www.mozilla.org/firefox/\",\"url\":\"https://example.com/firefox.dmg\"}\n",
+        aw.written(),
+    );
+}
+
+test "writeJsonNotInstalled carries schema_version on the minimal not-found root" {
+    // The unknown-package fallback is the smallest --json root; it must
+    // still version itself so a consumer parses one shape for every case.
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try writeJsonNotInstalled("ghost", &aw.writer);
+    try testing.expectEqualStrings(
+        "{\"schema_version\":1,\"name\":\"ghost\",\"type\":\"formula\",\"installed\":false}\n",
         aw.written(),
     );
 }
@@ -966,7 +983,7 @@ test "encodeInstalledCaskJson produces the documented shape" {
     try encodeInstalledCaskJson(&aw.writer, &row, no_history);
 
     try testing.expectEqualStrings(
-        "{\"name\":\"firefox\",\"type\":\"cask\",\"installed\":true,\"version\":\"120.0\",\"full_name\":\"Firefox\",\"url\":\"https://example.com/firefox.dmg\",\"app_path\":\"/Applications/Firefox.app\",\"auto_updates\":false,\"installed_at\":\"2026-05-13 10:40:56\",\"tap\":\"\",\"available_rollback_versions\":[]}\n",
+        "{\"schema_version\":1,\"name\":\"firefox\",\"type\":\"cask\",\"installed\":true,\"version\":\"120.0\",\"full_name\":\"Firefox\",\"url\":\"https://example.com/firefox.dmg\",\"app_path\":\"/Applications/Firefox.app\",\"auto_updates\":false,\"installed_at\":\"2026-05-13 10:40:56\",\"tap\":\"\",\"available_rollback_versions\":[]}\n",
         aw.written(),
     );
 }
@@ -983,7 +1000,7 @@ test "encodeInstalledCaskJson emits empty strings for null fields" {
     try encodeInstalledCaskJson(&aw.writer, &row, no_history);
 
     try testing.expectEqualStrings(
-        "{\"name\":\"ghost\",\"type\":\"cask\",\"installed\":true,\"version\":\"\",\"full_name\":\"ghost\",\"url\":\"\",\"app_path\":\"\",\"auto_updates\":true,\"installed_at\":\"\",\"tap\":\"\",\"available_rollback_versions\":[]}\n",
+        "{\"schema_version\":1,\"name\":\"ghost\",\"type\":\"cask\",\"installed\":true,\"version\":\"\",\"full_name\":\"ghost\",\"url\":\"\",\"app_path\":\"\",\"auto_updates\":true,\"installed_at\":\"\",\"tap\":\"\",\"available_rollback_versions\":[]}\n",
         aw.written(),
     );
 }
@@ -1117,7 +1134,7 @@ test "encodeInstalledFormulaJson emits available_rollback_versions:[] for an emp
         &.{},
     );
     try testing.expectEqualStrings(
-        "{\"name\":\"wget\",\"type\":\"formula\",\"installed\":true,\"version\":\"1.24.5\"," ++
+        "{\"schema_version\":1,\"name\":\"wget\",\"type\":\"formula\",\"installed\":true,\"version\":\"1.24.5\"," ++
             "\"tap\":\"homebrew/core\",\"dependencies\":[],\"pinned\":false,\"installed_at\":\"2026-05-13 10:40:56\"," ++
             "\"available_rollback_versions\":[]}\n",
         aw.written(),
@@ -1141,7 +1158,7 @@ test "encodeInstalledFormulaJson splices the same entries[] shape mt rollback --
     // downstream consumers already parse `mt rollback --list --json`'s
     // `entries[]`, and the info payload must hand them the same shape.
     try testing.expectEqualStrings(
-        "{\"name\":\"wget\",\"type\":\"formula\",\"installed\":true,\"version\":\"1.24.5\"," ++
+        "{\"schema_version\":1,\"name\":\"wget\",\"type\":\"formula\",\"installed\":true,\"version\":\"1.24.5\"," ++
             "\"tap\":\"homebrew/core\",\"dependencies\":[],\"pinned\":true,\"installed_at\":\"2026-05-13 10:40:56\"," ++
             "\"available_rollback_versions\":[" ++
             "{\"sha256\":\"aaa111\",\"version\":\"1.24\",\"mtime\":1700000000}," ++
@@ -1192,7 +1209,7 @@ test "encodeInstalledFormulaJson emits a dependencies array mirroring the not-in
         &.{ "libidn2", "openssl@3" },
     );
     try testing.expectEqualStrings(
-        "{\"name\":\"wget\",\"type\":\"formula\",\"installed\":true,\"version\":\"1.24.5\"," ++
+        "{\"schema_version\":1,\"name\":\"wget\",\"type\":\"formula\",\"installed\":true,\"version\":\"1.24.5\"," ++
             "\"tap\":\"homebrew/core\",\"dependencies\":[\"libidn2\",\"openssl@3\"]," ++
             "\"pinned\":false,\"installed_at\":\"2026-05-13 10:40:56\"," ++
             "\"available_rollback_versions\":[]}\n",

--- a/src/cli/list.zig
+++ b/src/cli/list.zig
@@ -337,7 +337,7 @@ fn writeJsonOutput(
     try buildListJson(db, stdout, ctx.io, prefix, show_formula, show_cask, show_pinned, show_size, show_linked, tap_filter, start_ts);
 }
 
-/// Build the `{ "installed": [...], "formulae": [...], "casks": [...], "time_ms": N }`
+/// Build the `{ "schema_version": 1, "installed": [...], "formulae": [...], "casks": [...], "time_ms": N }`
 /// payload into `w`. Kept `pub` so tests can assert on the exact bytes without
 /// going through a real file. On per-section SQLite failures we emit an empty
 /// array for that section rather than truncating the whole document.
@@ -358,7 +358,8 @@ pub fn buildListJson(
     // formulae/casks arrays stay byte-stable for existing consumers.
     const extras: Extras = .{ .io = io, .prefix = prefix, .size = show_size, .linked = show_linked };
 
-    try w.writeAll("{\"installed\":[");
+    try output.writeSchemaVersionPrefix(w);
+    try w.writeAll("\"installed\":[");
     var first = true;
     if (show_pinned) {
         try writePinnedInstalled(db, w, show_formula, show_cask, tap_filter, extras, &first);

--- a/src/cli/outdated/render.zig
+++ b/src/cli/outdated/render.zig
@@ -1,9 +1,9 @@
 //! malt — outdated render helpers
 //!
-//! Presentation layer for `mt outdated` rows: JSON (one document for
-//! formulas, NDJSON for casks — matches the legacy CLI shape) and the
-//! human row format shared with `mt list` / `mt search`. Pulled into
-//! its own module so the orchestrator stays focused on dispatch.
+//! Presentation layer for `mt outdated` rows: one versioned JSON root
+//! (`{"schema_version":1,"outdated":[...]}`) carrying formulae and casks,
+//! and the human row format shared with `mt list` / `mt search`. Pulled
+//! into its own module so the orchestrator stays focused on dispatch.
 
 const std = @import("std");
 
@@ -42,10 +42,11 @@ pub fn writeCaskEntries(stdout: *std.Io.Writer, entries: []const OutdatedEntry) 
     for (entries) |e| writeEntry(stdout, e, "cask");
 }
 
-/// Render a mixed slice of formula + cask rows as one top-level JSON
-/// array — the unified `mt outdated --json` shape. Casks live inside
-/// the array alongside formulae (a deliberate break from the old
-/// per-line cask NDJSON), and every row carries `pinned` + `tap`.
+/// Render a mixed slice of formula + cask rows under one versioned JSON
+/// root — `{"schema_version":1,"outdated":[...]}`. Casks live inside the
+/// array alongside formulae (a deliberate break from the old per-line
+/// cask NDJSON), and every row carries `pinned` + `tap`. The object wrap
+/// gives the array a root that can carry `schema_version`.
 pub fn writeJsonArray(
     allocator: std.mem.Allocator,
     stdout: *std.Io.Writer,
@@ -54,7 +55,8 @@ pub fn writeJsonArray(
     var aw: std.Io.Writer.Allocating = .init(allocator);
     defer aw.deinit();
     const w = &aw.writer;
-    try w.writeAll("[");
+    try output.writeSchemaVersionPrefix(w);
+    try w.writeAll("\"outdated\":[");
     for (rows, 0..) |r, i| {
         if (i != 0) try w.writeAll(",");
         try w.writeAll("{\"name\":");
@@ -72,7 +74,7 @@ pub fn writeJsonArray(
         try output.jsonStr(w, r.tap);
         try w.writeAll("}");
     }
-    try w.writeAll("]\n");
+    try w.writeAll("]}\n");
     stdout.writeAll(aw.written()) catch return;
 }
 
@@ -120,7 +122,7 @@ fn writeStyledSpan(
     if (use_color) stdout.writeAll(color.Style.reset.code()) catch return;
 }
 
-test "writeJsonArray emits one array with formulae and casks and all six fields" {
+test "writeJsonArray wraps formulae and casks in a versioned root with all six fields" {
     var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
 
@@ -131,7 +133,7 @@ test "writeJsonArray emits one array with formulae and casks and all six fields"
     try writeJsonArray(std.testing.allocator, &aw.writer, &rows);
 
     const want =
-        \\[{"name":"alpha","installed":"1.0","latest":"2.0","type":"formula","pinned":false,"tap":""},{"name":"beta-cask","installed":"3.0","latest":"4.0","type":"cask","pinned":true,"tap":"user/repo"}]
+        \\{"schema_version":1,"outdated":[{"name":"alpha","installed":"1.0","latest":"2.0","type":"formula","pinned":false,"tap":""},{"name":"beta-cask","installed":"3.0","latest":"4.0","type":"cask","pinned":true,"tap":"user/repo"}]}
     ++ "\n";
     try std.testing.expectEqualStrings(want, aw.written());
 }
@@ -148,8 +150,8 @@ test "writeJsonArray keeps casks inside the array, not as per-line NDJSON" {
     try writeJsonArray(std.testing.allocator, &aw.writer, &rows);
 
     const out = aw.written();
-    try std.testing.expect(out[0] == '[');
-    try std.testing.expectEqualStrings("]\n", out[out.len - 2 ..]);
+    try std.testing.expect(std.mem.startsWith(u8, out, "{\"schema_version\":1,\"outdated\":["));
+    try std.testing.expectEqualStrings("]}\n", out[out.len - 3 ..]);
     try std.testing.expect(std.mem.indexOf(u8, out, "\"type\":\"cask\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "}\n{") == null);
 }
@@ -166,16 +168,16 @@ test "writeJsonArray comma-separates a formula-only array with no trailing comma
     try writeJsonArray(std.testing.allocator, &aw.writer, &rows);
 
     const want =
-        \\[{"name":"alpha","installed":"1.0","latest":"2.0","type":"formula","pinned":false,"tap":""},{"name":"bravo","installed":"3.0","latest":"4.0","type":"formula","pinned":false,"tap":""}]
+        \\{"schema_version":1,"outdated":[{"name":"alpha","installed":"1.0","latest":"2.0","type":"formula","pinned":false,"tap":""},{"name":"bravo","installed":"3.0","latest":"4.0","type":"formula","pinned":false,"tap":""}]}
     ++ "\n";
     try std.testing.expectEqualStrings(want, aw.written());
 }
 
-test "writeJsonArray emits an empty array for no rows" {
+test "writeJsonArray emits an empty array under the versioned root for no rows" {
     var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
     try writeJsonArray(std.testing.allocator, &aw.writer, &.{});
-    try std.testing.expectEqualStrings("[]\n", aw.written());
+    try std.testing.expectEqualStrings("{\"schema_version\":1,\"outdated\":[]}\n", aw.written());
 }
 
 test "writeJsonArray keeps a pinned-but-outdated row with pinned:true" {
@@ -189,7 +191,7 @@ test "writeJsonArray keeps a pinned-but-outdated row with pinned:true" {
     try writeJsonArray(std.testing.allocator, &aw.writer, &rows);
 
     const want =
-        \\[{"name":"held","installed":"1.0","latest":"2.0","type":"formula","pinned":true,"tap":""}]
+        \\{"schema_version":1,"outdated":[{"name":"held","installed":"1.0","latest":"2.0","type":"formula","pinned":true,"tap":""}]}
     ++ "\n";
     try std.testing.expectEqualStrings(want, aw.written());
 }
@@ -206,7 +208,7 @@ test "writeJsonArray escapes embedded quotes in name and tap" {
     try writeJsonArray(std.testing.allocator, &aw.writer, &rows);
 
     const want =
-        \\[{"name":"a\"b","installed":"1.0","latest":"2.0","type":"cask","pinned":false,"tap":"x\"y"}]
+        \\{"schema_version":1,"outdated":[{"name":"a\"b","installed":"1.0","latest":"2.0","type":"cask","pinned":false,"tap":"x\"y"}]}
     ++ "\n";
     try std.testing.expectEqualStrings(want, aw.written());
 }

--- a/src/cli/services.zig
+++ b/src/cli/services.zig
@@ -25,10 +25,12 @@ pub const JsonRow = struct {
     keg_name: []const u8,
 };
 
-/// Emit `[{name,state,auto_start,keg_name},...]\n` for
-/// `mt services list --json` and `mt services status <name> --json`.
+/// Emit `{"schema_version":1,"services":[{name,state,auto_start,keg_name},...]}\n`
+/// for `mt services list --json` and `mt services status <name> --json`. The
+/// object wrap gives the row array a root that can carry `schema_version`.
 pub fn writeServicesJson(w: *std.Io.Writer, rows: []const JsonRow) !void {
-    try w.writeAll("[");
+    try output.writeSchemaVersionPrefix(w);
+    try w.writeAll("\"services\":[");
     for (rows, 0..) |row, i| {
         if (i != 0) try w.writeAll(",");
         try w.writeAll("{\"name\":");
@@ -41,7 +43,7 @@ pub fn writeServicesJson(w: *std.Io.Writer, rows: []const JsonRow) !void {
         try output.jsonStr(w, row.keg_name);
         try w.writeAll("}");
     }
-    try w.writeAll("]\n");
+    try w.writeAll("]}\n");
 }
 
 pub fn describeError(err: ServicesError) []const u8 {
@@ -224,14 +226,14 @@ fn openDb(ctx: *const AppCtx) !sqlite.Database {
     return sqlite.Database.open(path);
 }
 
-test "writeServicesJson: empty input emits `[]\\n`" {
+test "writeServicesJson: empty input still emits the versioned root with an empty array" {
     var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
     try writeServicesJson(&aw.writer, &.{});
-    try std.testing.expectEqualStrings("[]\n", aw.written());
+    try std.testing.expectEqualStrings("{\"schema_version\":1,\"services\":[]}\n", aw.written());
 }
 
-test "writeServicesJson: emits name, state, auto_start, keg_name per row" {
+test "writeServicesJson: emits name, state, auto_start, keg_name per row under the versioned root" {
     const rows = [_]JsonRow{
         .{ .name = "redis", .state = "running", .auto_start = true, .keg_name = "redis" },
         .{ .name = "postgres", .state = "not-loaded", .auto_start = false, .keg_name = "postgresql@16" },
@@ -240,10 +242,10 @@ test "writeServicesJson: emits name, state, auto_start, keg_name per row" {
     defer aw.deinit();
     try writeServicesJson(&aw.writer, &rows);
     try std.testing.expectEqualStrings(
-        "[" ++
+        "{\"schema_version\":1,\"services\":[" ++
             "{\"name\":\"redis\",\"state\":\"running\",\"auto_start\":true,\"keg_name\":\"redis\"}," ++
             "{\"name\":\"postgres\",\"state\":\"not-loaded\",\"auto_start\":false,\"keg_name\":\"postgresql@16\"}" ++
-            "]\n",
+            "]}\n",
         aw.written(),
     );
 }

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -532,6 +532,19 @@ pub fn jsonStringArray(w: *std.Io.Writer, items: []const []const u8) !void {
     try w.writeAll("]");
 }
 
+/// Version stamped on every read command's `--json` root (`list`, `info`,
+/// `outdated`, `services`, `doctor`). Bump when a documented field shape
+/// changes so consumers can refuse a shape they don't understand —
+/// documented in `docs/json-schema.md`.
+pub const json_schema_version: u32 = 1;
+
+/// Write the opening `{"schema_version":N,` of a versioned `--json` root.
+/// The caller appends its own fields and the closing `}`. Centralises the
+/// version so a bump touches one constant, not every read command.
+pub fn writeSchemaVersionPrefix(w: *std.Io.Writer) !void {
+    try w.print("{{\"schema_version\":{d},", .{json_schema_version});
+}
+
 /// Write the `,"time_ms":N` suffix used by `--json` commands; `start_ts` is a `milliTimestamp()`.
 pub fn jsonTimeSuffix(w: *std.Io.Writer, start_ts: i64) !void {
     const elapsed = std.Io.Clock.real.now(pkg_io).toMilliseconds() - start_ts;
@@ -693,6 +706,13 @@ test "notice is suppressed by --quiet" {
 
     notice("hidden", .{});
     try std.testing.expectEqualStrings("", buf.items);
+}
+
+test "writeSchemaVersionPrefix opens a versioned object root" {
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeSchemaVersionPrefix(&aw.writer);
+    try std.testing.expectEqualStrings("{\"schema_version\":1,", aw.written());
 }
 
 test "isNdjson defaults to false and setNdjson toggles it" {

--- a/tests/cli_services_test.zig
+++ b/tests/cli_services_test.zig
@@ -139,7 +139,7 @@ test "execute list --json on a prefix with no db/ directory emits `[]`" {
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
     try services_cli.execute(&ctx, testing.allocator, &.{"list"});
-    try testing.expectEqualStrings("[]\n", stdout_buf.items);
+    try testing.expectEqualStrings("{\"schema_version\":1,\"services\":[]}\n", stdout_buf.items);
 }
 
 test "execute list --json on an empty DB emits `[]`" {
@@ -161,13 +161,13 @@ test "execute list --json on an empty DB emits `[]`" {
     defer threaded.deinit();
     const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
     try services_cli.execute(&ctx, testing.allocator, &.{"list"});
-    try testing.expectEqualStrings("[]\n", stdout_buf.items);
+    try testing.expectEqualStrings("{\"schema_version\":1,\"services\":[]}\n", stdout_buf.items);
 
     // `status` with no name routes through cmdList; under --json it must
     // emit the same empty array so consumers can rely on a single shape.
     stdout_buf.clearRetainingCapacity();
     try services_cli.execute(&ctx, testing.allocator, &.{"status"});
-    try testing.expectEqualStrings("[]\n", stdout_buf.items);
+    try testing.expectEqualStrings("{\"schema_version\":1,\"services\":[]}\n", stdout_buf.items);
 }
 
 fn seedService(prefix: []const u8, name: []const u8, keg: []const u8, auto_start: bool) !void {
@@ -219,11 +219,11 @@ test "execute list --json on a populated DB emits one object per row" {
     // Runtime probe is best-effort on non-macOS / when launchctl misses;
     // it still must surface a textual state, never a numeric code.
     try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"state\":\"") != null);
-    try testing.expect(std.mem.startsWith(u8, stdout_buf.items, "["));
-    try testing.expect(std.mem.endsWith(u8, stdout_buf.items, "]\n"));
+    try testing.expect(std.mem.startsWith(u8, stdout_buf.items, "{\"schema_version\":1,\"services\":["));
+    try testing.expect(std.mem.endsWith(u8, stdout_buf.items, "]}\n"));
 }
 
-test "execute list --json output is a parseable JSON array" {
+test "execute list --json output is a parseable versioned JSON object" {
     const prefix = try setupPrefix("list_json_parse");
     defer testing.allocator.free(prefix);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
@@ -247,8 +247,10 @@ test "execute list --json output is a parseable JSON array" {
     const trimmed = std.mem.trim(u8, stdout_buf.items, " \t\r\n");
     var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, trimmed, .{});
     defer parsed.deinit();
-    try testing.expectEqual(@as(usize, 1), parsed.value.array.items.len);
-    const row = parsed.value.array.items[0].object;
+    try testing.expectEqual(@as(i64, 1), parsed.value.object.get("schema_version").?.integer);
+    const services = parsed.value.object.get("services").?.array;
+    try testing.expectEqual(@as(usize, 1), services.items.len);
+    const row = services.items[0].object;
     try testing.expectEqualStrings("redis", row.get("name").?.string);
     try testing.expectEqualStrings("redis", row.get("keg_name").?.string);
     try testing.expectEqual(true, row.get("auto_start").?.bool);
@@ -281,8 +283,8 @@ test "execute status <name> --json emits a single-element array" {
     // Only one row in the array — pin the bracketing so `postgres` (not
     // seeded here) can't sneak in via a typo in the filter SQL.
     try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "postgres") == null);
-    try testing.expect(std.mem.startsWith(u8, stdout_buf.items, "[{"));
-    try testing.expect(std.mem.endsWith(u8, stdout_buf.items, "}]\n"));
+    try testing.expect(std.mem.startsWith(u8, stdout_buf.items, "{\"schema_version\":1,\"services\":[{"));
+    try testing.expect(std.mem.endsWith(u8, stdout_buf.items, "}]}\n"));
 }
 
 test "execute status <missing> --json still surfaces SupervisorError" {

--- a/tests/doctor_cask_history_test.zig
+++ b/tests/doctor_cask_history_test.zig
@@ -145,7 +145,7 @@ test "emitCaskHistoryReport: --verbose lists every retained (token version) unde
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "        alpha 1.5") != null);
 }
 
-test "emitCaskHistoryReport: --json emits the cask_history payload on stdout" {
+test "emitDoctorJson: the merged --json carries the cask_history payload on stdout" {
     const allocator = testing.allocator;
     var s = try Scratch.init(allocator, "json");
     defer s.deinit(allocator);
@@ -165,39 +165,15 @@ test "emitCaskHistoryReport: --json emits the cask_history payload on stdout" {
     output.beginStderrCapture(allocator, &stderr_buf);
     defer output.endStderrCapture();
 
-    doctor.emitCaskHistoryReport(allocator, std.Options.debug_io, s.path);
+    // The cask_history data is now one member of the single merged document.
+    doctor.emitDoctorJson(allocator, std.Options.debug_io, s.path, &.{});
 
-    // Stable JSON shape — same byte sequence the inline `writeJson`
-    // test pins, so a refactor that changes either path catches both.
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"schema_version\":1") != null);
     try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"cask_history\":") != null);
     try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"retained_versions\":2") != null);
     try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"bytes\":") != null);
-    // JSON mode routes the report away from stderr — no human summary
-    // line should appear there.
+    // JSON routes the report away from stderr — no human summary line.
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "Retained cask versions") == null);
-}
-
-test "emitCaskHistoryReport: --json stays stable when nothing is retained" {
-    const allocator = testing.allocator;
-    var s = try Scratch.init(allocator, "json_empty");
-    defer s.deinit(allocator);
-
-    resetOutputFlags();
-    defer resetOutputFlags();
-    output.setMode(.json);
-
-    var stdout_buf: std.ArrayList(u8) = .empty;
-    defer stdout_buf.deinit(allocator);
-    output.beginStdoutCapture(allocator, &stdout_buf);
-    defer output.endStdoutCapture();
-
-    doctor.emitCaskHistoryReport(allocator, std.Options.debug_io, s.path);
-
-    // Schema contract: the section is always present, even when empty.
-    try testing.expectEqualStrings(
-        "{\"cask_history\":{\"retained_versions\":0,\"bytes\":0}}\n",
-        stdout_buf.items,
-    );
 }
 
 test "emitCaskHistoryReport: read-only — cask_versions rows survive the walk" {

--- a/tests/doctor_tap_forge_test.zig
+++ b/tests/doctor_tap_forge_test.zig
@@ -104,7 +104,7 @@ test "emitTapForgeReport: human mode stays silent when no taps are registered" {
     try testing.expectEqual(@as(usize, 0), stderr_buf.items.len);
 }
 
-test "emitTapForgeReport: --json emits the taps payload on stdout" {
+test "emitDoctorJson: the merged --json carries the taps payload on stdout" {
     const allocator = testing.allocator;
     var s = try Scratch.init(allocator, "json");
     defer s.deinit(allocator);
@@ -119,16 +119,19 @@ test "emitTapForgeReport: --json emits the taps payload on stdout" {
     output.beginStdoutCapture(allocator, &stdout_buf);
     defer output.endStdoutCapture();
 
-    doctor.emitTapForgeReport(allocator, s.path);
+    // The taps data is now one member of the single merged document.
+    doctor.emitDoctorJson(allocator, std.Options.debug_io, s.path, &.{});
 
-    try testing.expectEqualStrings(
-        "{\"taps\":[{\"name\":\"user/repo\",\"host\":\"github.com\"}," ++
-            "{\"name\":\"grp/tap\",\"host\":\"gitlab.com\"}]}\n",
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"schema_version\":1") != null);
+    try testing.expect(std.mem.indexOf(
+        u8,
         stdout_buf.items,
-    );
+        "\"taps\":[{\"name\":\"user/repo\",\"host\":\"github.com\"}," ++
+            "{\"name\":\"grp/tap\",\"host\":\"gitlab.com\"}]",
+    ) != null);
 }
 
-test "emitTapForgeReport: --json emits an empty array when no taps exist" {
+test "emitDoctorJson: the merged --json keeps an empty taps array when no taps exist" {
     const allocator = testing.allocator;
     var s = try Scratch.init(allocator, "json_empty");
     defer s.deinit(allocator);
@@ -142,7 +145,7 @@ test "emitTapForgeReport: --json emits an empty array when no taps exist" {
     output.beginStdoutCapture(allocator, &stdout_buf);
     defer output.endStdoutCapture();
 
-    doctor.emitTapForgeReport(allocator, s.path);
+    doctor.emitDoctorJson(allocator, std.Options.debug_io, s.path, &.{});
 
-    try testing.expectEqualStrings("{\"taps\":[]}\n", stdout_buf.items);
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"taps\":[]") != null);
 }

--- a/tests/list_test.zig
+++ b/tests/list_test.zig
@@ -226,7 +226,7 @@ test "buildListJson: empty DB, both flags" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[],\"formulae\":[],\"casks\":[]",
+        "{\"schema_version\":1,\"installed\":[],\"formulae\":[],\"casks\":[]",
         body,
     );
     // Suffix structure intact.
@@ -246,7 +246,7 @@ test "buildListJson: formula-only, two kegs, pinned flag preserved" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"alpha\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":false}," ++
             "{\"name\":\"bravo\",\"version\":\"2.1\",\"type\":\"formula\",\"pinned\":true}" ++
             "],\"formulae\":[" ++
@@ -268,7 +268,7 @@ test "buildListJson: cask-only, one cask" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"firefox\",\"version\":\"120.0\",\"type\":\"cask\",\"pinned\":false}" ++
             "],\"casks\":[" ++
             "{\"token\":\"firefox\",\"version\":\"120.0\"}" ++
@@ -294,7 +294,7 @@ test "buildListJson: cask .installed row carries pinned, matching formulae" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"held\",\"version\":\"2.0\",\"type\":\"cask\",\"pinned\":true}," ++
             "{\"name\":\"loose\",\"version\":\"1.0\",\"type\":\"cask\",\"pinned\":false}" ++
             "],\"casks\":[" ++
@@ -317,7 +317,7 @@ test "buildListJson: mixed kegs and casks, comma between types in installed" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"zsh\",\"version\":\"5.9\",\"type\":\"formula\",\"pinned\":false}," ++
             "{\"name\":\"slack\",\"version\":\"4.0\",\"type\":\"cask\",\"pinned\":false}" ++
             "],\"formulae\":[" ++
@@ -341,7 +341,7 @@ test "buildListJson: --pinned filters formulae to pinned only" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"two\",\"version\":\"2.0\",\"type\":\"formula\",\"pinned\":true}" ++
             "],\"formulae\":[" ++
             "{\"name\":\"two\",\"version\":\"2.0\",\"pinned\":true}" ++
@@ -369,7 +369,7 @@ test "buildListJson: --pinned UNIONs pinned formulas and casks sorted by name" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"firefox\",\"version\":\"120.0\",\"type\":\"cask\",\"pinned\":true}," ++
             "{\"name\":\"zsh\",\"version\":\"5.9\",\"type\":\"formula\",\"pinned\":true}" ++
             "],\"formulae\":[" ++
@@ -400,7 +400,7 @@ test "buildListJson: --pinned installed array interleaves formulas and casks by 
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"alpha\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":true}," ++
             "{\"name\":\"bravo\",\"version\":\"2.0\",\"type\":\"cask\",\"pinned\":true}," ++
             "{\"name\":\"charlie\",\"version\":\"3.0\",\"type\":\"formula\",\"pinned\":true}," ++
@@ -431,7 +431,7 @@ test "buildListJson: --pinned legacy casks array excludes unpinned casks" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"held-cask\",\"version\":\"2.0\",\"type\":\"cask\",\"pinned\":true}" ++
             "],\"casks\":[" ++
             "{\"token\":\"held-cask\",\"version\":\"2.0\"}" ++
@@ -573,7 +573,7 @@ test "buildListJson --tap filters both installed and legacy arrays" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"tap-formula\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":false}," ++
             "{\"name\":\"tap-cask\",\"version\":\"3.0\",\"type\":\"cask\",\"pinned\":false}" ++
             "],\"formulae\":[" ++
@@ -596,7 +596,7 @@ test "buildListJson --tap with no matches produces empty arrays" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[],\"formulae\":[],\"casks\":[]",
+        "{\"schema_version\":1,\"installed\":[],\"formulae\":[],\"casks\":[]",
         body,
     );
 }
@@ -616,7 +616,7 @@ test "buildListJson --tap with --pinned cross-filters" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"held\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":true}" ++
             "],\"formulae\":[" ++
             "{\"name\":\"held\",\"version\":\"1.0\",\"pinned\":true}" ++
@@ -694,7 +694,7 @@ test "buildListJson --size sums size_bytes from the keg cellar dir" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"treesize\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":false,\"size_bytes\":8}" ++
             "],\"formulae\":[" ++
             "{\"name\":\"treesize\",\"version\":\"1.0\",\"pinned\":false}" ++
@@ -762,7 +762,7 @@ test "buildListJson --size sums a cask's Caskroom dir and app_path bundle" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"widget\",\"version\":\"1.0\",\"type\":\"cask\",\"pinned\":false,\"size_bytes\":10}" ++
             "],\"casks\":[" ++
             "{\"token\":\"widget\",\"version\":\"1.0\"}" ++
@@ -847,7 +847,7 @@ test "buildListJson --linked reports keg link status from the links table" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"active\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":false,\"linked\":true}," ++
             "{\"name\":\"dormant\",\"version\":\"2.0\",\"type\":\"formula\",\"pinned\":false,\"linked\":false}" ++
             "],\"formulae\":[" ++
@@ -869,7 +869,7 @@ test "buildListJson --linked reports casks as always linked" {
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"firefox\",\"version\":\"120.0\",\"type\":\"cask\",\"pinned\":false,\"linked\":true}" ++
             "],\"casks\":[" ++
             "{\"token\":\"firefox\",\"version\":\"120.0\"}" ++
@@ -936,7 +936,7 @@ test "buildListJson --tap --size --linked keeps column alignment in the tap SQL"
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"tapped\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":false,\"size_bytes\":3,\"linked\":true}" ++
             "],\"formulae\":[" ++
             "{\"name\":\"tapped\",\"version\":\"1.0\",\"pinned\":false}" ++
@@ -971,7 +971,7 @@ test "buildListJson --pinned --size --linked enriches the pinned installed rows"
 
     const body = trimTimeSuffix(out);
     try testing.expectEqualStrings(
-        "{\"installed\":[" ++
+        "{\"schema_version\":1,\"installed\":[" ++
             "{\"name\":\"held\",\"version\":\"1.0\",\"type\":\"formula\",\"pinned\":true,\"size_bytes\":4,\"linked\":true}" ++
             "],\"formulae\":[" ++
             "{\"name\":\"held\",\"version\":\"1.0\",\"pinned\":true}" ++


### PR DESCRIPTION
## Description

Versions the JSON contract. Adds `schema_version: 1` to the `--json` root of `list`, `outdated`, `services list`, `info`, and `doctor`.

Today these read commands are unversioned, so a future shape change is invisible to consumers. 

## Related Issue

- None

## Notes for Reviewers

- None