### PR TITLE
feat(tui): terminal control primitives with resize awareness

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -242,6 +242,8 @@ pub fn build(b: *std.Build) void {
         "tests/linker_isolation_test.zig",
         "tests/install_isolation_test.zig",
         "tests/doctor_isolation_test.zig",
+        "tests/tui_term_test.zig",
+        "tests/tui_purity_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -93,6 +93,7 @@ pub const color = @import("ui/color.zig");
 pub const output = @import("ui/output.zig");
 pub const progress = @import("ui/progress.zig");
 pub const term_sanitize = @import("ui/term_sanitize.zig");
+pub const tui_term = @import("tui/term.zig");
 pub const update_cleanup = @import("update/cleanup.zig");
 pub const update_notifier = @import("update/notifier.zig");
 pub const update_origin = @import("update/origin.zig");

--- a/src/tui/term.zig
+++ b/src/tui/term.zig
@@ -1,0 +1,227 @@
+//! malt — terminal control primitives for `mt tui`.
+//!
+//! Leaf module: imports only `std` (the `mt tui` dashboard pressure-tests
+//! the `--json` contract instead of reaching into `cli/*`/`core/*`). Provides
+//! raw-mode, alternate-screen, cursor, and window-size machinery plus a
+//! `SIGWINCH` handler so the current `(cols, rows)` stays live without a
+//! keypress. A single idempotent `restore()` undoes everything entered and is
+//! wired through `errdefer` downstream so a crash can never wedge the terminal.
+
+const std = @import("std");
+
+/// Current terminal geometry. The single source of truth every later layout
+/// task renders against.
+pub const Size = struct { cols: u16, rows: u16 };
+
+/// Escape sequences whose effect is idempotent at the terminal level, so the
+/// state guards below only exist to avoid redundant writes, not to stay correct.
+pub const seq = struct {
+    pub const alt_enter = "\x1b[?1049h";
+    pub const alt_leave = "\x1b[?1049l";
+    pub const cursor_hide = "\x1b[?25l";
+    pub const cursor_show = "\x1b[?25h";
+};
+
+/// Write a 1-based cursor-position (CUP) sequence into a caller buffer, the
+/// `progress.zig` no-hidden-writer convention. `error.NoSpaceLeft` only when the
+/// buffer is undersized — a 32-byte buffer always suffices.
+pub fn cursorMove(buf: []u8, row: u16, col: u16) error{NoSpaceLeft}![]const u8 {
+    return std.fmt.bufPrint(buf, "\x1b[{d};{d}H", .{ row, col });
+}
+
+fn packSize(s: Size) u32 {
+    return (@as(u32, s.cols) << 16) | s.rows;
+}
+fn unpackSize(v: u32) Size {
+    return .{ .cols = @intCast(v >> 16), .rows = @truncate(v) };
+}
+
+pub const TermError = error{ NotATty, WriteFailed, TermiosFailed };
+
+/// A live terminal session. Tracks exactly what was entered so `restore`
+/// undoes precisely those things, idempotently and in a crash-safe order.
+/// `fd` is the controlling terminal (read+write); `io` only services the
+/// `isTty` probe so the raw-mode path degrades cleanly off a TTY.
+pub const Term = struct {
+    io: std.Io,
+    fd: std.posix.fd_t,
+    saved: ?std.posix.termios = null,
+    in_alt: bool = false,
+    cursor_hidden: bool = false,
+
+    pub fn init(io: std.Io, fd: std.posix.fd_t) Term {
+        return .{ .io = io, .fd = fd };
+    }
+
+    fn writeAll(self: *const Term, bytes: []const u8) TermError!void {
+        var off: usize = 0;
+        while (off < bytes.len) {
+            const n = std.c.write(self.fd, bytes[off..].ptr, bytes.len - off);
+            if (n <= 0) return TermError.WriteFailed;
+            off += @intCast(n);
+        }
+    }
+
+    pub fn enterAltScreen(self: *Term) TermError!void {
+        if (self.in_alt) return;
+        try self.writeAll(seq.alt_enter);
+        self.in_alt = true;
+    }
+
+    pub fn exitAltScreen(self: *Term) void {
+        if (!self.in_alt) return;
+        // Best-effort on the way out: a vanished tty has nothing to restore.
+        self.writeAll(seq.alt_leave) catch {};
+        self.in_alt = false;
+    }
+
+    pub fn hideCursor(self: *Term) TermError!void {
+        if (self.cursor_hidden) return;
+        try self.writeAll(seq.cursor_hide);
+        self.cursor_hidden = true;
+    }
+
+    pub fn showCursor(self: *Term) void {
+        if (!self.cursor_hidden) return;
+        self.writeAll(seq.cursor_show) catch {};
+        self.cursor_hidden = false;
+    }
+
+    /// Idempotent undo of everything entered, safe to call twice and mid-render.
+    /// Reverse of a typical entry (raw → alt → hide): show cursor, leave the
+    /// alt-screen, then drop back to cooked mode.
+    pub fn restore(self: *Term) void {
+        self.showCursor();
+        self.exitAltScreen();
+        self.exitRaw();
+    }
+
+    fn isTty(self: *const Term) bool {
+        const f: std.Io.File = .{ .handle = self.fd, .flags = .{ .nonblocking = false } };
+        return f.isTty(self.io) catch false;
+    }
+
+    /// Enter cbreak/raw input: ECHO + ICANON off, byte-at-a-time reads. Saves
+    /// the original termios for `exitRaw`/`restore`. Idempotent; cleanly
+    /// `error.NotATty` off a terminal with no half-entered state.
+    pub fn enterRaw(self: *Term) TermError!void {
+        if (self.saved != null) return; // idempotent
+        if (!self.isTty()) return TermError.NotATty; // guard avoids a noisy tcgetattr
+        const saved = std.posix.tcgetattr(self.fd) catch return TermError.TermiosFailed;
+        var raw = saved;
+        raw.lflag.ECHO = false;
+        raw.lflag.ICANON = false;
+        raw.cc[@intFromEnum(std.posix.V.MIN)] = 1;
+        raw.cc[@intFromEnum(std.posix.V.TIME)] = 0;
+        std.posix.tcsetattr(self.fd, .FLUSH, raw) catch return TermError.TermiosFailed;
+        self.saved = saved;
+    }
+
+    pub fn exitRaw(self: *Term) void {
+        const saved = self.saved orelse return;
+        // Best-effort: a gone tty cannot be put back, and there is no sane
+        // recovery from inside restore/errdefer.
+        std.posix.tcsetattr(self.fd, .FLUSH, saved) catch {};
+        self.saved = null;
+    }
+};
+
+/// Query the terminal window size via `TIOCGWINSZ`. `error.NotATty` when the
+/// fd is not a terminal — no errno decode, so the degrade path stays quiet.
+pub fn winsize(fd: std.posix.fd_t) TermError!Size {
+    var ws: std.posix.winsize = undefined;
+    const rc = std.posix.system.ioctl(fd, std.posix.T.IOCGWINSZ, @intFromPtr(&ws));
+    if (rc != 0) return TermError.NotATty;
+    return .{ .cols = ws.col, .rows = ws.row };
+}
+
+// ─── SIGWINCH resize tracking ────────────────────────────────────────
+//
+// Process-global because a signal handler carries no context, mirroring
+// `core/signals.zig`. The handler is the only writer; the main thread reads
+// the flag and the packed size between input reads, so a resize is observed
+// without any keypress.
+
+var resized_flag: std.atomic.Value(bool) = .init(false);
+var cached_size: std.atomic.Value(u32) = .init(0);
+var winch_installed: std.atomic.Value(bool) = .init(false);
+var winch_fd: std.posix.fd_t = -1;
+
+fn winchHandler(_: std.posix.SIG) callconv(.c) void {
+    resized_flag.store(true, .release);
+    // A single ioctl is signal-safe in practice; refreshing here is what lets
+    // a resize be seen without a read. A failed query keeps the last size.
+    if (winsize(winch_fd)) |s| {
+        cached_size.store(packSize(s), .release);
+    } else |_| {}
+}
+
+/// Wire `SIGWINCH` to keep `(cols, rows)` live. `fd` is the terminal queried
+/// in-handler. Idempotent so re-entry (tests, repeated dispatch) neither
+/// double-registers nor clobbers a flag the handler already raised.
+pub fn installWinch(fd: std.posix.fd_t) void {
+    if (winch_installed.swap(true, .acq_rel)) return;
+    winch_fd = fd;
+    if (winsize(fd)) |s| cached_size.store(packSize(s), .release) else |_| {}
+    const act = std.posix.Sigaction{
+        .handler = .{ .handler = &winchHandler },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    };
+    std.posix.sigaction(std.posix.SIG.WINCH, &act, null);
+}
+
+pub fn winchInstalled() bool {
+    return winch_installed.load(.acquire);
+}
+
+/// True exactly once per resize: consumes the flag so the event loop reacts
+/// to each `SIGWINCH` a single time.
+pub fn takeResized() bool {
+    return resized_flag.swap(false, .acq_rel);
+}
+
+/// Last geometry seen by the handler (or the install-time seed).
+pub fn currentSize() Size {
+    return unpackSize(cached_size.load(.acquire));
+}
+
+/// Test-only: seed/reset the process-global install + flag state between
+/// cases so a test starts from a known baseline (mirrors `core/signals.zig`).
+pub fn setWinchInstalledForTest(v: bool) void {
+    winch_installed.store(v, .release);
+}
+pub fn setResizedForTest(v: bool) void {
+    resized_flag.store(v, .release);
+}
+
+test "alt-screen and cursor escape sequences are the expected bytes" {
+    try std.testing.expectEqualStrings("\x1b[?1049h", seq.alt_enter);
+    try std.testing.expectEqualStrings("\x1b[?1049l", seq.alt_leave);
+    try std.testing.expectEqualStrings("\x1b[?25l", seq.cursor_hide);
+    try std.testing.expectEqualStrings("\x1b[?25h", seq.cursor_show);
+}
+
+test "cursorMove writes a 1-based CUP sequence" {
+    var buf: [32]u8 = undefined;
+    try std.testing.expectEqualStrings("\x1b[3;5H", try cursorMove(&buf, 3, 5));
+    try std.testing.expectEqualStrings("\x1b[1;1H", try cursorMove(&buf, 1, 1));
+}
+
+test "Size carries cols and rows" {
+    const s: Size = .{ .cols = 80, .rows = 24 };
+    try std.testing.expectEqual(@as(u16, 80), s.cols);
+    try std.testing.expectEqual(@as(u16, 24), s.rows);
+}
+
+// A Size packs into one u32 so the SIGWINCH handler can publish it with a
+// single atomic store the main thread reads without a torn value.
+test "packSize/unpackSize round-trip a Size losslessly" {
+    const cases = [_]Size{
+        .{ .cols = 0, .rows = 0 },
+        .{ .cols = 80, .rows = 24 },
+        .{ .cols = 65535, .rows = 65535 },
+        .{ .cols = 1, .rows = 65535 },
+    };
+    for (cases) |s| try std.testing.expectEqual(s, unpackSize(packSize(s)));
+}

--- a/tests/tui_purity_test.zig
+++ b/tests/tui_purity_test.zig
@@ -1,0 +1,85 @@
+//! Pin test: `src/tui/` is a leaf. Every `@import` in it must resolve only to
+//! `std`, `ui/color.zig`, or `ui/term_sanitize.zig` — never `cli/*`, `core/*`,
+//! `db/*`, `net/*`, `main.zig`, or `app_ctx.zig`. The TUI pressure-tests the
+//! `--json` contract instead of reaching across module boundaries.
+
+const std = @import("std");
+const testing = std.testing;
+
+const test_io = @import("test_io");
+
+const scanned_root = "src/tui";
+const import_prefix = "@import(\"";
+
+test "src/tui/* imports only std + the allowed ui helpers" {
+    const io = std.Options.debug_io;
+
+    var failures: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (failures.items) |s| testing.allocator.free(s);
+        failures.deinit(testing.allocator);
+    }
+
+    try scanRoot(io, scanned_root, &failures);
+
+    if (failures.items.len != 0) {
+        for (failures.items) |f| std.debug.print("{s}\n", .{f});
+        return error.TuiLeafViolated;
+    }
+}
+
+fn scanRoot(io: std.Io, root: []const u8, failures: *std.ArrayList([]const u8)) !void {
+    var dir = try test_io.cwd().openDir(io, root, .{ .iterate = true });
+    defer dir.close(io);
+
+    var walker = try dir.walk(testing.allocator);
+    defer walker.deinit();
+
+    while (try walker.next(io)) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.path, ".zig")) continue;
+
+        const file = try dir.openFile(io, entry.path, .{});
+        defer file.close(io);
+        const stat = try file.stat(io);
+        const content = try testing.allocator.alloc(u8, @intCast(stat.size));
+        defer testing.allocator.free(content);
+        _ = try file.readPositionalAll(io, content, 0);
+
+        try scanContent(root, entry.path, content, failures);
+    }
+}
+
+fn scanContent(
+    root: []const u8,
+    rel_path: []const u8,
+    content: []const u8,
+    failures: *std.ArrayList([]const u8),
+) !void {
+    var cursor: usize = 0;
+    while (std.mem.indexOfPos(u8, content, cursor, import_prefix)) |start| {
+        const path_start = start + import_prefix.len;
+        const end = std.mem.indexOfScalarPos(u8, content, path_start, '"') orelse break;
+        const import_path = content[path_start..end];
+        cursor = end + 1;
+
+        if (!isAllowedImport(import_path)) {
+            const msg = try std.fmt.allocPrint(
+                testing.allocator,
+                "{s}/{s} imports forbidden \"{s}\"",
+                .{ root, rel_path, import_path },
+            );
+            try failures.append(testing.allocator, msg);
+        }
+    }
+}
+
+/// The leaf whitelist: `std` (the only bare import), or a relative path that
+/// resolves to one of the two allowed read-only ui helpers.
+fn isAllowedImport(path: []const u8) bool {
+    if (std.mem.eql(u8, path, "std")) return true;
+    var rest = path;
+    while (std.mem.startsWith(u8, rest, "../")) rest = rest[3..];
+    return std.mem.eql(u8, rest, "ui/color.zig") or
+        std.mem.eql(u8, rest, "ui/term_sanitize.zig");
+}

--- a/tests/tui_term_test.zig
+++ b/tests/tui_term_test.zig
@@ -1,0 +1,145 @@
+//! malt — integration tests for the `tui/term.zig` terminal primitives.
+//!
+//! Drives the real syscalls (pipes, termios, ioctl, SIGWINCH) the inline unit
+//! tests can't: byte output is captured through a pipe drained to EOF, and the
+//! TTY-only paths run for real when a terminal is present and degrade-assert
+//! otherwise. No PTY — the live resize proof lands in TUI-016.
+
+const std = @import("std");
+const testing = std.testing;
+const term = @import("malt").tui_term;
+
+const io = std.Options.debug_io;
+
+// Drain a pipe read end to EOF into `buf`. The write end must be closed first
+// so this never blocks regardless of how many bytes were written.
+fn drainToEof(fd: std.posix.fd_t, buf: []u8) []const u8 {
+    var n: usize = 0;
+    while (n < buf.len) {
+        const r = std.c.read(fd, buf[n..].ptr, buf.len - n);
+        if (r <= 0) break;
+        n += @intCast(r);
+    }
+    return buf[0..n];
+}
+
+/// First fd among stdin/stdout/stderr that is a real terminal, else null —
+/// lets the TTY-only assertions run on a dev terminal and skip in CI.
+fn ttyFd() ?std.posix.fd_t {
+    for ([_]std.posix.fd_t{ std.posix.STDIN_FILENO, std.posix.STDOUT_FILENO, std.posix.STDERR_FILENO }) |fd| {
+        const f: std.Io.File = .{ .handle = fd, .flags = .{ .nonblocking = false } };
+        if (f.isTty(io) catch false) return fd;
+    }
+    return null;
+}
+
+test "alt-screen + cursor enter/exit are symmetric, idempotent, restore-ordered" {
+    var fds: [2]std.posix.fd_t = undefined;
+    try testing.expectEqual(@as(c_int, 0), std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    var t = term.Term.init(io, fds[1]);
+
+    try t.enterAltScreen();
+    try t.enterAltScreen(); // idempotent: writes nothing the second time
+    try t.hideCursor();
+    try t.hideCursor(); // idempotent
+
+    t.restore(); // shows cursor, then leaves the alt-screen
+    t.restore(); // idempotent: nothing left to undo
+
+    _ = std.c.close(fds[1]); // EOF terminates the drain
+    var buf: [64]u8 = undefined;
+    const got = drainToEof(fds[0], &buf);
+
+    const want = term.seq.alt_enter ++ term.seq.cursor_hide ++ term.seq.cursor_show ++ term.seq.alt_leave;
+    try testing.expectEqualStrings(want, got);
+}
+
+// A render that enters the terminal then fails must leave it restored via the
+// caller's `errdefer` — the contract that keeps a crashed TUI from wedging.
+fn renderThenFail(t: *term.Term) !void {
+    try t.enterAltScreen();
+    errdefer t.restore();
+    try t.hideCursor();
+    return error.Forced;
+}
+
+test "restore runs via errdefer when a render errors mid-frame" {
+    var fds: [2]std.posix.fd_t = undefined;
+    try testing.expectEqual(@as(c_int, 0), std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    var t = term.Term.init(io, fds[1]);
+
+    try testing.expectError(error.Forced, renderThenFail(&t));
+
+    t.restore(); // re-running after the errdefer already ran is safe
+
+    _ = std.c.close(fds[1]);
+    var buf: [64]u8 = undefined;
+    const got = drainToEof(fds[0], &buf);
+
+    // entry bytes, then exactly one undo from the errdefer — the second
+    // restore emits nothing, proving idempotency through the error path.
+    const want = term.seq.alt_enter ++ term.seq.cursor_hide ++ term.seq.cursor_show ++ term.seq.alt_leave;
+    try testing.expectEqualStrings(want, got);
+}
+
+test "enterRaw off a non-tty errors cleanly and enters no state" {
+    var fds: [2]std.posix.fd_t = undefined;
+    try testing.expectEqual(@as(c_int, 0), std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+    var t = term.Term.init(io, fds[1]);
+
+    try testing.expectError(term.TermError.NotATty, t.enterRaw());
+    t.restore(); // safe even though nothing was entered
+}
+
+test "winsize off a non-tty errors cleanly" {
+    var fds: [2]std.posix.fd_t = undefined;
+    try testing.expectEqual(@as(c_int, 0), std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+    try testing.expectError(term.TermError.NotATty, term.winsize(fds[0]));
+}
+
+test "on a real tty, winsize reports a non-zero size and raw round-trips termios" {
+    const fd = ttyFd() orelse return error.SkipZigTest;
+
+    const size = try term.winsize(fd);
+    try testing.expect(size.cols > 0 and size.rows > 0);
+
+    const before = try std.posix.tcgetattr(fd);
+    var t = term.Term.init(io, fd);
+    try t.enterRaw();
+    t.restore(); // must put cooked mode back exactly
+    const after = try std.posix.tcgetattr(fd);
+    try testing.expectEqual(before.lflag, after.lflag);
+    try testing.expectEqual(before.cc, after.cc);
+}
+
+test "SIGWINCH delivery sets the resized flag with no input read" {
+    term.setWinchInstalledForTest(false);
+    term.setResizedForTest(false);
+    term.installWinch(std.posix.STDIN_FILENO);
+    try testing.expect(term.winchInstalled());
+
+    try std.posix.raise(std.posix.SIG.WINCH);
+
+    try testing.expect(term.takeResized()); // raised by the handler alone
+    try testing.expect(!term.takeResized()); // consumed exactly once
+}
+
+test "installWinch is idempotent and never clobbers a raised flag" {
+    term.setWinchInstalledForTest(false);
+    term.setResizedForTest(false);
+
+    term.installWinch(std.posix.STDIN_FILENO);
+    try testing.expect(term.winchInstalled());
+
+    // Simulate the handler firing between two install attempts.
+    term.setResizedForTest(true);
+    term.installWinch(std.posix.STDIN_FILENO); // second call is a no-op
+    try testing.expect(term.winchInstalled());
+    try testing.expect(term.takeResized()); // flag survived the re-install
+}


### PR DESCRIPTION
## Description

Adds `src/tui/term.zig`, the terminal-control foundation for `mt tui`: raw-mode enter/exit, alternate-screen enter/exit, cursor hide/show/move, a `TIOCGWINSZ` window-size query, and a `SIGWINCH` handler that keeps the current `(cols, rows)` live without requiring a keypress. 

A single idempotent `restore()` undoes raw mode, the alt-screen, and cursor-hide, wired through `errdefer` on every entry path so a crash can never wedge the terminal. This is where the dashboard's resize-awareness requirement begins; later tasks render against the size this module exposes.

The module is a leaf: it imports only `std`/`std.posix`, enforced by a new purity guard test. It is wired into the test root only, not the `mt` binary, so non-`tui` cold start and binary size are unchanged until the dispatch lands.

## Related Issue

- None

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 19 of 19 in a stack** made with GitButler:
- <kbd>&nbsp;19&nbsp;</kbd> #464
- <kbd>&nbsp;18&nbsp;</kbd> #463
- <kbd>&nbsp;17&nbsp;</kbd> #462
- <kbd>&nbsp;16&nbsp;</kbd> #461
- <kbd>&nbsp;15&nbsp;</kbd> #459
- <kbd>&nbsp;14&nbsp;</kbd> #458
- <kbd>&nbsp;13&nbsp;</kbd> #457
- <kbd>&nbsp;12&nbsp;</kbd> #456
- <kbd>&nbsp;11&nbsp;</kbd> #455
- <kbd>&nbsp;10&nbsp;</kbd> #454
- <kbd>&nbsp;9&nbsp;</kbd> #453
- <kbd>&nbsp;8&nbsp;</kbd> #451
- <kbd>&nbsp;7&nbsp;</kbd> #450
- <kbd>&nbsp;6&nbsp;</kbd> #448
- <kbd>&nbsp;5&nbsp;</kbd> #447
- <kbd>&nbsp;4&nbsp;</kbd> #446
- <kbd>&nbsp;3&nbsp;</kbd> #445
- <kbd>&nbsp;2&nbsp;</kbd> #444
- <kbd>&nbsp;1&nbsp;</kbd> #443 👈 
<!-- GitButler Footer Boundary Bottom -->