### PR TITLE
feat(tui): keyboard input decoder

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -243,6 +243,7 @@ pub fn build(b: *std.Build) void {
         "tests/install_isolation_test.zig",
         "tests/doctor_isolation_test.zig",
         "tests/tui_term_test.zig",
+        "tests/tui_keys_test.zig",
         "tests/tui_purity_test.zig",
     };
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -93,6 +93,7 @@ pub const color = @import("ui/color.zig");
 pub const output = @import("ui/output.zig");
 pub const progress = @import("ui/progress.zig");
 pub const term_sanitize = @import("ui/term_sanitize.zig");
+pub const tui_keys = @import("tui/keys.zig");
 pub const tui_term = @import("tui/term.zig");
 pub const update_cleanup = @import("update/cleanup.zig");
 pub const update_notifier = @import("update/notifier.zig");

--- a/src/tui/keys.zig
+++ b/src/tui/keys.zig
@@ -1,0 +1,215 @@
+//! malt — keyboard input decoder for `mt tui`.
+//!
+//! Leaf module: imports only `std`. A pure DFA that turns raw input bytes into
+//! `Key` values without touching the terminal, so it is fully table-testable
+//! without a PTY. The decoder owns a small fixed pending buffer so an escape
+//! sequence split across two reads resumes on the next bytes; it never
+//! allocates and never errors, so malformed input can never unwind past the
+//! caller's `errdefer` terminal restore.
+
+const std = @import("std");
+
+const cap = 8; // longest sequence buffered before draining to `.unknown`
+
+/// A printable character as its raw UTF-8 bytes (1–4). Display width is *not*
+/// decoded here — that is the layout layer's job (matches `term_sanitize`'s
+/// raw-UTF-8 stance).
+pub const Char = struct {
+    bytes: [4]u8,
+    len: u3,
+
+    pub fn slice(self: *const Char) []const u8 {
+        return self.bytes[0..self.len];
+    }
+};
+
+/// One decoded keypress. A closed tagged union: exhaustive `switch`es over it
+/// take no `else`, so a future arm is a compile error until handled. `.unknown`
+/// is a real event (a complete but unrecognised sequence), never an error.
+pub const Key = union(enum) {
+    up,
+    down,
+    left,
+    right,
+    enter,
+    space,
+    tab,
+    esc,
+    backspace,
+    ctrl_c,
+    page_up,
+    page_down,
+    home,
+    end,
+    char: Char,
+    unknown,
+};
+
+/// Result of one `decode` call.
+pub const Decoded = union(enum) {
+    /// A decoded key plus how many bytes of *this* slice it consumed. Bytes
+    /// carried over from a prior call are not re-counted.
+    key: struct { key: Key, consumed: usize },
+    /// The slice ended mid-sequence; the tail is buffered. Feed more bytes, or
+    /// call `flush` at EOF to surface a lone ESC.
+    incomplete,
+};
+
+/// A stream key decoder. Default-initialised (`.{}`); allocation-free.
+pub const Decoder = struct {
+    buf: [cap]u8 = undefined,
+    len: usize = 0,
+
+    /// Decode the first key in `bytes`, resuming any sequence buffered from a
+    /// prior call. `consumed` counts only bytes from *this* slice, so the caller
+    /// advances its own read buffer by it; carried-over prefix bytes are not
+    /// re-counted. `.incomplete` means the slice ended mid-sequence and the tail
+    /// is now buffered.
+    pub fn decode(self: *Decoder, bytes: []const u8) Decoded {
+        var i: usize = 0;
+        while (i < bytes.len) {
+            self.buf[self.len] = bytes[i];
+            self.len += 1;
+            i += 1;
+            switch (recognize(self.buf[0..self.len])) {
+                .done => |d| {
+                    // Bytes past the key (a lone ESC's follow-on) are pushed
+                    // back: not buffered, and excluded from `consumed` so the
+                    // caller re-presents them on the next call.
+                    const leftover = self.len - d.len;
+                    self.len = 0;
+                    return .{ .key = .{ .key = d.key, .consumed = i - leftover } };
+                },
+                .need_more => if (self.len == cap) {
+                    // Buffer full with no match: drain it as one unknown event so
+                    // a hostile stream can never overflow or stall the decoder.
+                    self.len = 0;
+                    return .{ .key = .{ .key = .unknown, .consumed = i } };
+                },
+            }
+        }
+        return .incomplete;
+    }
+
+    /// At EOF (no more bytes will arrive), surface a buffered tail: a lone ESC
+    /// becomes `.esc`, any other partial sequence `.unknown`. Returns null when
+    /// nothing is buffered. This is the only place a trailing ESC resolves,
+    /// since a pure DFA cannot use the inter-byte timeout a PTY would.
+    pub fn flush(self: *Decoder) ?Key {
+        if (self.len == 0) return null;
+        const lone_esc = self.len == 1 and self.buf[0] == 0x1b;
+        self.len = 0;
+        return if (lone_esc) .esc else .unknown;
+    }
+};
+
+/// One DFA step over the accumulated prefix.
+const Step = union(enum) {
+    need_more,
+    done: struct { key: Key, len: usize },
+};
+
+fn done(key: Key, len: usize) Step {
+    return .{ .done = .{ .key = key, .len = len } };
+}
+
+fn char1(b: u8) Key {
+    return .{ .char = .{ .bytes = .{ b, 0, 0, 0 }, .len = 1 } };
+}
+
+/// Classify the accumulated prefix `buf` (always ≥ 1 byte). Pure: same prefix →
+/// same step, no I/O, never errors.
+fn recognize(buf: []const u8) Step {
+    const b0 = buf[0];
+    if (b0 == 0x1b) return recognizeEsc(buf);
+    if (b0 >= 0x80) return recognizeUtf8(buf);
+    return switch (b0) {
+        0x03 => done(.ctrl_c, 1), // raw mode delivers Ctrl-C as a byte, not SIGINT
+        0x09 => done(.tab, 1),
+        0x0a, 0x0d => done(.enter, 1), // LF or CR
+        0x08, 0x7f => done(.backspace, 1), // BS or DEL
+        0x20 => done(.space, 1),
+        else => if (b0 >= 0x21 and b0 <= 0x7e) done(char1(b0), 1) else done(.unknown, 1),
+    };
+}
+
+/// ESC and the bracketed CSI form. A non-`[` byte after ESC means the ESC was
+/// lone (consumed alone; the byte is pushed back); SS3 (`ESC O …`) is out of
+/// scope because the dashboard never enables application-cursor mode.
+fn recognizeEsc(buf: []const u8) Step {
+    if (buf.len == 1) return .need_more; // need the byte after ESC
+    if (buf[1] != '[') return done(.esc, 1);
+    if (buf.len == 2) return .need_more; // "ESC [" alone
+    const last = buf[buf.len - 1];
+    if (last >= 0x40 and last <= 0x7e) return done(csiKey(buf[2..]), buf.len); // final byte
+    if (last >= 0x20 and last <= 0x3f) return .need_more; // param/intermediate
+    return done(.unknown, buf.len); // malformed CSI byte
+}
+
+/// Map a CSI body (params + final byte) to a key. Unmapped-but-complete
+/// sequences are `.unknown`, never errors, so unhandled keys are inert.
+fn csiKey(body: []const u8) Key {
+    const eql = std.mem.eql;
+    if (eql(u8, body, "A")) return .up;
+    if (eql(u8, body, "B")) return .down;
+    if (eql(u8, body, "C")) return .right;
+    if (eql(u8, body, "D")) return .left;
+    if (eql(u8, body, "H") or eql(u8, body, "1~")) return .home;
+    if (eql(u8, body, "F") or eql(u8, body, "4~")) return .end;
+    if (eql(u8, body, "5~")) return .page_up;
+    if (eql(u8, body, "6~")) return .page_down;
+    return .unknown;
+}
+
+/// Accumulate a UTF-8 char by its lead-byte length; carry the raw bytes. Any
+/// invalid lead or continuation drains the lead alone as `.unknown` and pushes
+/// the rest back, so a bad byte never swallows the keys after it.
+fn recognizeUtf8(buf: []const u8) Step {
+    const want = std.unicode.utf8ByteSequenceLength(buf[0]) catch return done(.unknown, 1);
+    const have = @min(buf.len, @as(usize, want));
+    for (buf[1..have]) |c| {
+        if (c < 0x80 or c > 0xbf) return done(.unknown, 1); // not a continuation
+    }
+    if (buf.len < want) return .need_more;
+    var ch: Char = .{ .bytes = .{ 0, 0, 0, 0 }, .len = want };
+    @memcpy(ch.bytes[0..want], buf[0..want]);
+    return done(.{ .char = ch }, want);
+}
+
+test "Char.slice returns only the populated bytes" {
+    const c: Char = .{ .bytes = .{ 0xc3, 0xa9, 0, 0 }, .len = 2 };
+    try std.testing.expectEqualStrings("\xc3\xa9", c.slice());
+}
+
+test "recognize classifies the single-byte control and printable cases" {
+    try std.testing.expectEqual(@as(usize, 1), recognize("\x03").done.len);
+    try std.testing.expect(recognize("\x03").done.key == .ctrl_c);
+    try std.testing.expect(recognize("\t").done.key == .tab);
+    try std.testing.expect(recognize("\r").done.key == .enter);
+    try std.testing.expect(recognize(" ").done.key == .space);
+    try std.testing.expect(recognize("\x7f").done.key == .backspace);
+    try std.testing.expect(recognize("a").done.key == .char);
+    try std.testing.expect(recognize("\x01").done.key == .unknown); // a stray C0 control
+}
+
+test "recognizeEsc waits for the byte after ESC then resolves" {
+    try std.testing.expect(recognize("\x1b") == .need_more);
+    try std.testing.expect(recognize("\x1b[") == .need_more);
+    try std.testing.expect(recognize("\x1bx").done.key == .esc); // lone ESC, 'x' pushed back
+    try std.testing.expectEqual(@as(usize, 1), recognize("\x1bx").done.len);
+}
+
+test "csiKey maps the supported finals and is unknown otherwise" {
+    try std.testing.expect(csiKey("A") == .up);
+    try std.testing.expect(csiKey("1~") == .home);
+    try std.testing.expect(csiKey("6~") == .page_down);
+    try std.testing.expect(csiKey("Z") == .unknown);
+}
+
+test "an over-long escape sequence drains to unknown at the buffer cap" {
+    var d: Decoder = .{};
+    const r = d.decode("\x1b[1;2;3;4;5A"); // far longer than the param forms we map
+    try std.testing.expect(r == .key);
+    try std.testing.expect(r.key.key == .unknown);
+    try std.testing.expectEqual(@as(usize, cap), r.key.consumed);
+}

--- a/tests/tui_keys_test.zig
+++ b/tests/tui_keys_test.zig
@@ -1,0 +1,186 @@
+//! malt — integration tests for the `tui/keys.zig` keyboard decoder.
+//!
+//! Table-driven over byte slices: every supported key is asserted to decode to
+//! the right `Key` with the right `consumed` count. Split-across-reads, lone
+//! ESC, unknown sequences, Ctrl-C, and UTF-8 round out the cases. No PTY — the
+//! decoder is a pure DFA, so byte slices are all it takes.
+
+const std = @import("std");
+const testing = std.testing;
+const keys = @import("malt").tui_keys;
+
+const Key = keys.Key;
+
+fn keyEql(a: Key, b: Key) bool {
+    if (std.meta.activeTag(a) != std.meta.activeTag(b)) return false;
+    return switch (a) {
+        .char => |c| std.mem.eql(u8, c.slice(), b.char.slice()),
+        // Closed switch: a new payload-carrying arm forces a decision here.
+        .up, .down, .left, .right, .enter, .space, .tab, .esc, .backspace, .ctrl_c, .page_up, .page_down, .home, .end, .unknown => true,
+    };
+}
+
+fn expectKey(input: []const u8, want: Key, want_consumed: usize) !void {
+    var d: keys.Decoder = .{};
+    const r = d.decode(input);
+    try testing.expect(r == .key);
+    try testing.expectEqual(want_consumed, r.key.consumed);
+    if (!keyEql(want, r.key.key)) {
+        std.debug.print("key mismatch: want {any}, got {any}\n", .{ want, r.key.key });
+        return error.KeyMismatch;
+    }
+}
+
+test "single-byte keys decode with consumed == 1" {
+    try expectKey("\r", .enter, 1);
+    try expectKey("\n", .enter, 1);
+    try expectKey(" ", .space, 1);
+    try expectKey("\t", .tab, 1);
+    try expectKey("\x7f", .backspace, 1); // DEL
+    try expectKey("\x08", .backspace, 1); // BS
+    try expectKey("\x03", .ctrl_c, 1); // raw mode delivers no SIGINT
+}
+
+test "printable ASCII decodes to char carrying the byte" {
+    try expectKey("a", .{ .char = .{ .bytes = .{ 'a', 0, 0, 0 }, .len = 1 } }, 1);
+    try expectKey("Z", .{ .char = .{ .bytes = .{ 'Z', 0, 0, 0 }, .len = 1 } }, 1);
+    try expectKey("~", .{ .char = .{ .bytes = .{ '~', 0, 0, 0 }, .len = 1 } }, 1);
+}
+
+test "arrow keys decode from CSI with consumed == 3" {
+    try expectKey("\x1b[A", .up, 3);
+    try expectKey("\x1b[B", .down, 3);
+    try expectKey("\x1b[C", .right, 3);
+    try expectKey("\x1b[D", .left, 3);
+}
+
+test "home and end decode from both CSI variants" {
+    try expectKey("\x1b[H", .home, 3);
+    try expectKey("\x1b[F", .end, 3);
+    try expectKey("\x1b[1~", .home, 4);
+    try expectKey("\x1b[4~", .end, 4);
+}
+
+test "page up and page down decode with consumed == 4" {
+    try expectKey("\x1b[5~", .page_up, 4);
+    try expectKey("\x1b[6~", .page_down, 4);
+}
+
+test "unknown CSI sequence decodes to .unknown, fully consumed" {
+    try expectKey("\x1b[Z", .unknown, 3); // shift-tab: complete but unmapped
+    try expectKey("\x1b[3~", .unknown, 4); // delete: complete but unmapped
+}
+
+test "a lone ESC followed by a non-bracket byte decodes as esc, byte pushed back" {
+    var d: keys.Decoder = .{};
+    const r = d.decode("\x1bx");
+    try testing.expect(r == .key);
+    try testing.expect(keyEql(.esc, r.key.key));
+    try testing.expectEqual(@as(usize, 1), r.key.consumed); // only the ESC
+    // The 'x' was pushed back; re-feeding the remainder yields it.
+    const r2 = d.decode("x");
+    try testing.expect(r2 == .key);
+    try testing.expect(keyEql(.{ .char = .{ .bytes = .{ 'x', 0, 0, 0 }, .len = 1 } }, r2.key.key));
+}
+
+test "a CSI sequence split across two reads resumes correctly" {
+    var d: keys.Decoder = .{};
+    try testing.expect(d.decode("\x1b") == .incomplete);
+    const r = d.decode("[A");
+    try testing.expect(r == .key);
+    try testing.expect(keyEql(.up, r.key.key));
+    try testing.expectEqual(@as(usize, 2), r.key.consumed); // only the new bytes
+}
+
+test "a page sequence split mid-stream resumes correctly" {
+    var d: keys.Decoder = .{};
+    try testing.expect(d.decode("\x1b[5") == .incomplete);
+    const r = d.decode("~");
+    try testing.expect(r == .key);
+    try testing.expect(keyEql(.page_up, r.key.key));
+    try testing.expectEqual(@as(usize, 1), r.key.consumed);
+}
+
+test "flush surfaces a trailing lone ESC, then nothing" {
+    var d: keys.Decoder = .{};
+    try testing.expect(d.decode("\x1b") == .incomplete);
+    try testing.expect(keyEql(.esc, d.flush().?));
+    try testing.expect(d.flush() == null); // buffer drained
+}
+
+test "two keys in one slice decode one at a time via consumed" {
+    var d: keys.Decoder = .{};
+    const r1 = d.decode("a\x1b[B");
+    try testing.expect(r1 == .key);
+    try testing.expect(keyEql(.{ .char = .{ .bytes = .{ 'a', 0, 0, 0 }, .len = 1 } }, r1.key.key));
+    try testing.expectEqual(@as(usize, 1), r1.key.consumed);
+
+    const r2 = d.decode("\x1b[B");
+    try testing.expect(r2 == .key);
+    try testing.expect(keyEql(.down, r2.key.key));
+    try testing.expectEqual(@as(usize, 3), r2.key.consumed);
+}
+
+test "multi-byte UTF-8 decodes to a char carrying every byte" {
+    // é = U+00E9 = 0xC3 0xA9 (2 bytes)
+    try expectKey("\xc3\xa9", .{ .char = .{ .bytes = .{ 0xc3, 0xa9, 0, 0 }, .len = 2 } }, 2);
+    // € = U+20AC = 0xE2 0x82 0xAC (3 bytes)
+    try expectKey("\xe2\x82\xac", .{ .char = .{ .bytes = .{ 0xe2, 0x82, 0xac, 0 }, .len = 3 } }, 3);
+    // 😀 = U+1F600 = 0xF0 0x9F 0x98 0x80 (4 bytes)
+    try expectKey("\xf0\x9f\x98\x80", .{ .char = .{ .bytes = .{ 0xf0, 0x9f, 0x98, 0x80 }, .len = 4 } }, 4);
+}
+
+test "a UTF-8 char split across two reads resumes correctly" {
+    var d: keys.Decoder = .{};
+    try testing.expect(d.decode("\xe2\x82") == .incomplete);
+    const r = d.decode("\xac");
+    try testing.expect(r == .key);
+    try testing.expect(keyEql(.{ .char = .{ .bytes = .{ 0xe2, 0x82, 0xac, 0 }, .len = 3 } }, r.key.key));
+    try testing.expectEqual(@as(usize, 1), r.key.consumed);
+}
+
+test "a stray UTF-8 continuation byte decodes to .unknown" {
+    try expectKey("\x80", .unknown, 1);
+}
+
+test "an invalid UTF-8 lead byte decodes to .unknown" {
+    try expectKey("\xff", .unknown, 1); // 0xf8–0xff are never valid leads
+}
+
+test "a bad UTF-8 continuation drains the lead alone and re-decodes the rest" {
+    var d: keys.Decoder = .{};
+    const r = d.decode("\xc3A"); // 0xc3 promises a continuation; 'A' is not one
+    try testing.expect(r == .key);
+    try testing.expect(keyEql(.unknown, r.key.key));
+    try testing.expectEqual(@as(usize, 1), r.key.consumed); // only the bad lead
+    // The 'A' was pushed back, so re-feeding the remainder yields it intact.
+    const r2 = d.decode("A");
+    try testing.expect(r2 == .key);
+    try testing.expect(keyEql(.{ .char = .{ .bytes = .{ 'A', 0, 0, 0 }, .len = 1 } }, r2.key.key));
+}
+
+test "flush of a partial escape sequence yields unknown, then nothing" {
+    var d: keys.Decoder = .{};
+    try testing.expect(d.decode("\x1b[5") == .incomplete); // partial page sequence
+    try testing.expect(keyEql(.unknown, d.flush().?));
+    try testing.expect(d.flush() == null);
+}
+
+test "a control byte inside a CSI sequence decodes to unknown" {
+    try expectKey("\x1b[\x01", .unknown, 3); // not a param, intermediate, or final
+}
+
+test "empty input with an empty buffer is incomplete" {
+    var d: keys.Decoder = .{};
+    try testing.expect(d.decode("") == .incomplete);
+}
+
+test "ESC immediately followed by ESC: first is lone, second is buffered" {
+    var d: keys.Decoder = .{};
+    const r = d.decode("\x1b\x1b");
+    try testing.expect(r == .key);
+    try testing.expect(keyEql(.esc, r.key.key));
+    try testing.expectEqual(@as(usize, 1), r.key.consumed); // first ESC only
+    try testing.expect(d.decode("\x1b") == .incomplete); // second ESC awaits a follow-on
+    try testing.expect(keyEql(.esc, d.flush().?)); // EOF resolves it
+}


### PR DESCRIPTION
## Description

Adds `src/tui/keys.zig`, a pure keyboard decoder for `mt tui`: a DFA that turns raw input bytes into a `Key` enum (arrows, enter, space, tab, esc, backspace, Ctrl-C, printable char, page up/down, home, end) and reports how many bytes it consumed. It handles the common xterm CSI escape sequences, disambiguates a lone ESC from an ESC-sequence, and resumes cleanly when a sequence is split across reads via a small fixed pending buffer - so it never allocates and never errors.

Because raw mode delivers Ctrl-C as the byte `0x03` rather than `SIGINT`, the decoder maps it to an abort key locally instead of leaning on `core/signals.zig`. Being a pure function over byte slices, it is fully table-testable without a PTY.

Unknown or malformed input always resolves to a defined `.unknown` key (never an error, panic, or `unreachable`), so the caller's `errdefer` terminal restore can never be bypassed. The module is a leaf and the existing purity guard test already covers it (it scans all of `src/tui/`).

## Related Issue

- None

## Notes for Reviewers

- SS3 (`ESC O …`) is intentionally out of scope: `term.zig` never enables application-cursor mode, so arrows arrive as CSI (`ESC [ A`). A lone `ESC` followed by a non-`[` byte decodes as `.esc` with the byte pushed back; a trailing `ESC` at EOF is surfaced by `flush()`, the only place a pure DFA can resolve the ESC-vs-sequence ambiguity without an inter-byte timeout.

<!-- GitButler Footer Boundary Top -->
---
This is **part 18 of 19 in a stack** made with GitButler:
- <kbd>&nbsp;19&nbsp;</kbd> #464
- <kbd>&nbsp;18&nbsp;</kbd> #463
- <kbd>&nbsp;17&nbsp;</kbd> #462
- <kbd>&nbsp;16&nbsp;</kbd> #461
- <kbd>&nbsp;15&nbsp;</kbd> #459
- <kbd>&nbsp;14&nbsp;</kbd> #458
- <kbd>&nbsp;13&nbsp;</kbd> #457
- <kbd>&nbsp;12&nbsp;</kbd> #456
- <kbd>&nbsp;11&nbsp;</kbd> #455
- <kbd>&nbsp;10&nbsp;</kbd> #454
- <kbd>&nbsp;9&nbsp;</kbd> #453
- <kbd>&nbsp;8&nbsp;</kbd> #451
- <kbd>&nbsp;7&nbsp;</kbd> #450
- <kbd>&nbsp;6&nbsp;</kbd> #448
- <kbd>&nbsp;5&nbsp;</kbd> #447
- <kbd>&nbsp;4&nbsp;</kbd> #446
- <kbd>&nbsp;3&nbsp;</kbd> #445
- <kbd>&nbsp;2&nbsp;</kbd> #444 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #443
<!-- GitButler Footer Boundary Bottom -->