### PR TITLE
feat(tui): delegate mutations to mt and refresh after

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -247,6 +247,7 @@ pub fn build(b: *std.Build) void {
         "tests/tui_layout_test.zig",
         "tests/tui_scroll_list_test.zig",
         "tests/tui_app_test.zig",
+        "tests/tui_spawn_test.zig",
         "tests/tui_purity_test.zig",
     };
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -98,6 +98,7 @@ pub const tui_filter_input = @import("tui/filter_input.zig");
 pub const tui_keys = @import("tui/keys.zig");
 pub const tui_layout = @import("tui/layout.zig");
 pub const tui_scroll_list = @import("tui/scroll_list.zig");
+pub const tui_spawn = @import("tui/spawn.zig");
 pub const tui_tab = @import("tui/tab.zig");
 pub const tui_tab_bar = @import("tui/tab_bar.zig");
 pub const tui_tab_doctor = @import("tui/doctor_tab.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -543,7 +543,11 @@ fn dispatch(allocator: std.mem.Allocator, ctx: *const AppCtx, cmd: Command, cmd_
         // can't reach `cli/help`. Reads parse `mt … --json`; writes re-exec `mt`.
         .tui => {
             if (cli_help.showIfRequested(ctx, cmd_args, "tui")) return;
-            try @import("tui/app.zig").run(ctx.io, allocator, ctx.stderr, ctx.environ);
+            // Resolve this binary's path so the TUI re-execs the *same* `mt` for
+            // delegated mutations; fall back to `mt` (PATH) if it can't be read.
+            var self_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const mt_path = if (std.process.executablePath(ctx.io, &self_buf)) |n| self_buf[0..n] else |_| "mt";
+            try @import("tui/app.zig").run(ctx.io, allocator, ctx.stderr, ctx.environ, mt_path);
         },
         .bundle => try bundle.execute(ctx, allocator, cmd_args),
         .uses => try uses.execute(ctx, allocator, cmd_args),

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -63,7 +63,31 @@ pub const App = struct {
     editing: bool = false,
     quit: bool = false,
     states: TabStates = .{},
+    /// Tabs whose data may be stale after a delegated mutation. Lazy per-tab: a
+    /// dirty tab refetches its `--json` only when entered (README open question
+    /// #4), so an unrelated mutation never pays for a tab the user isn't viewing.
+    dirty: std.EnumSet(Tab) = .initEmpty(),
+    /// Resolved self-exe path injected by the `main.zig` bridge so the data and
+    /// action tabs re-exec *this* `mt` (not whatever PATH resolves) for reads
+    /// and mutations.
+    mt_path: []const u8 = "",
 };
+
+/// After a delegated mutation the active tab was just re-read inline, so it is
+/// fresh; the others may now be stale. Mark them dirty — a dirty tab refetches
+/// only when entered (`takeDirty`), so the cost is paid lazily, on view.
+pub fn markStaleAfterMutation(a: *App) void {
+    a.dirty = std.EnumSet(Tab).initFull();
+    a.dirty.remove(a.active);
+}
+
+/// Consume `t`'s dirty flag: true exactly once after it was marked, so the
+/// caller refetches its `--json` at most once per staleness.
+pub fn takeDirty(a: *App, t: Tab) bool {
+    if (!a.dirty.contains(t)) return false;
+    a.dirty.remove(t);
+    return true;
+}
 
 fn activeChrome(a: *App) *tab.Chrome {
     switch (a.active) {
@@ -251,7 +275,7 @@ fn writeAll(fd: std.posix.fd_t, bytes: []const u8) void {
 
 /// Launch the dashboard. Refuses (exit 2) on a non-interactive terminal rather
 /// than degrading. Every fault path restores the terminal via `errdefer`.
-pub fn run(io: std.Io, allocator: std.mem.Allocator, stderr: std.Io.File, environ: std.process.Environ) RunError!void {
+pub fn run(io: std.Io, allocator: std.mem.Allocator, stderr: std.Io.File, environ: std.process.Environ, mt_path: []const u8) RunError!void {
     const in_fd = std.posix.STDIN_FILENO;
     const out_fd = std.posix.STDOUT_FILENO;
     if (refusalReason(
@@ -276,7 +300,7 @@ pub fn run(io: std.Io, allocator: std.mem.Allocator, stderr: std.Io.File, enviro
     errdefer t.restore();
     term.installWinch(fd);
 
-    var app: App = .{};
+    var app: App = .{ .mt_path = mt_path }; // re-exec this mt for delegated mutations
     var frame = try allocator.alloc(u8, frameCap(term.currentSize()));
     defer allocator.free(frame);
 
@@ -465,6 +489,27 @@ test "renderFrame reflows on resize from the same state" {
     const small = renderFrame(&b1, &a, 40, 10);
     const large = renderFrame(&b2, &a, 120, 40);
     try std.testing.expect(!std.mem.eql(u8, small, large));
+}
+
+test "a delegated mutation marks every other tab dirty and keeps the active tab fresh" {
+    var a: App = .{ .active = .outdated };
+    markStaleAfterMutation(&a);
+    try std.testing.expect(!a.dirty.contains(.outdated)); // refreshed inline, still fresh
+    try std.testing.expect(a.dirty.contains(.installed));
+    try std.testing.expect(a.dirty.contains(.services));
+    try std.testing.expect(a.dirty.contains(.doctor));
+}
+
+test "entering a dirty tab consumes the flag so its refetch runs at most once" {
+    var a: App = .{ .active = .installed };
+    markStaleAfterMutation(&a);
+    try std.testing.expect(takeDirty(&a, .doctor)); // first entry → refetch
+    try std.testing.expect(!takeDirty(&a, .doctor)); // now fresh → no refetch
+}
+
+test "a tab that was never marked dirty does not trigger a refetch" {
+    var a: App = .{};
+    try std.testing.expect(!takeDirty(&a, .outdated));
 }
 
 test "refusalReason refuses non-tty, NO_COLOR, and CI; allows a clean tty" {

--- a/src/tui/spawn.zig
+++ b/src/tui/spawn.zig
@@ -1,0 +1,271 @@
+//! malt — `mt tui` process delegation: re-exec the real `mt` for every mutation.
+//!
+//! Leaf module (imports only `std` + the sibling `term.zig`). Implements the
+//! delegation principle: the TUI never reimplements a mutation. `runInline`
+//! drops the alt-screen + raw mode, re-execs `mt <subcommand>` inheriting the
+//! parent's stdio so its progress bars and typed-confirm prompts land in the
+//! user's scrollback exactly as on the CLI, waits, then re-enters — every fault
+//! path restoring the terminal via `errdefer` so a failed child can never wedge
+//! it. `readJson` is the read side: capture `mt … --json` stdout for the tab
+//! parsers. argv[0] is the resolved self-exe path injected from the `main.zig`
+//! bridge, so the child is the *same* `mt`, not whatever PATH resolves.
+
+const std = @import("std");
+const term = @import("term.zig");
+
+pub const SpawnError = error{ SpawnFailed, WaitFailed, ChildFailed };
+pub const ReadError = SpawnError || error{ EmptyOutput, ReadFailed, OutOfMemory };
+pub const InlineError = term.TermError || SpawnError;
+
+/// Per-read cap on captured `--json` bytes. Sized for the largest read shape
+/// (`mt list --json` over a full Cellar) with headroom.
+const max_json_bytes: usize = 4 * 1024 * 1024;
+
+/// Build `[mt, rest...]` — the argv for a delegated mutation (`mt <sub> [args]`).
+/// `rest` is `subcommand` followed by its arguments. Strings are borrowed from
+/// the caller; only the returned slice is owned (free it, not its elements).
+pub fn inlineArgv(
+    allocator: std.mem.Allocator,
+    mt_path: []const u8,
+    rest: []const []const u8,
+) std.mem.Allocator.Error![]const []const u8 {
+    const argv = try allocator.alloc([]const u8, 1 + rest.len);
+    argv[0] = mt_path;
+    @memcpy(argv[1..], rest);
+    return argv;
+}
+
+/// Build `[mt, rest..., "--json"]` — the read shape the tab parsers consume.
+/// Same ownership contract as `inlineArgv`.
+pub fn jsonArgv(
+    allocator: std.mem.Allocator,
+    mt_path: []const u8,
+    rest: []const []const u8,
+) std.mem.Allocator.Error![]const []const u8 {
+    const argv = try allocator.alloc([]const u8, 2 + rest.len);
+    argv[0] = mt_path;
+    @memcpy(argv[1 .. 1 + rest.len], rest);
+    argv[argv.len - 1] = "--json";
+    return argv;
+}
+
+/// Spawn `argv` inheriting the parent's stdio (so the child's prompts and
+/// progress reach the user's scrollback) and map its exit to an error. A
+/// non-zero exit, signal, or stop surfaces as `ChildFailed` — never swallowed.
+pub fn runChild(io: std.Io, argv: []const []const u8) SpawnError!void {
+    var child = std.process.spawn(io, .{ .argv = argv }) catch return error.SpawnFailed;
+    const status = child.wait(io) catch return error.WaitFailed;
+    switch (status) {
+        .exited => |code| if (code != 0) return error.ChildFailed,
+        .signal, .stopped, .unknown => return error.ChildFailed,
+    }
+}
+
+/// Capture `mt … --json` stdout for a tab parser. stderr stays inherited so a
+/// genuine failure is still visible. Errors on a non-zero exit or empty output
+/// so a parser never sees a half-written document. Caller frees the bytes.
+pub fn readJson(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+) ReadError![]u8 {
+    var child = std.process.spawn(io, .{ .argv = argv, .stdout = .pipe }) catch return error.SpawnFailed;
+
+    const bytes = drainStdout(io, allocator, child.stdout) catch |e| {
+        // Kill so `wait` can't hang on a half-drained pipe, then surface.
+        child.kill(io);
+        return e;
+    };
+    errdefer allocator.free(bytes);
+
+    const status = child.wait(io) catch return error.WaitFailed;
+    switch (status) {
+        .exited => |code| if (code != 0) return error.ChildFailed,
+        .signal, .stopped, .unknown => return error.ChildFailed,
+    }
+    if (bytes.len == 0) return error.EmptyOutput; // a parser must never see half a doc
+    return bytes;
+}
+
+/// Drain the child's stdout pipe fully before `wait`, bounded by
+/// `max_json_bytes`. Mirrors `core/child.zig`'s drain; stdout-only because the
+/// read commands keep stderr inherited.
+fn drainStdout(io: std.Io, allocator: std.mem.Allocator, pipe: ?std.Io.File) ReadError![]u8 {
+    const file = pipe orelse return error.ReadFailed;
+    var read_buf: [4096]u8 = undefined;
+    var reader = file.readerStreaming(io, &read_buf);
+    return reader.interface.allocRemaining(allocator, std.Io.Limit.limited(max_json_bytes)) catch |e| switch (e) {
+        error.OutOfMemory => error.OutOfMemory,
+        else => error.ReadFailed,
+    };
+}
+
+/// Drop the dashboard, run `body`, re-enter. Generic over the controller and
+/// the body so the leave → run → re-enter order — and that every error path
+/// restores the terminal via `errdefer` — is provable with a fake (no PTY, no
+/// runtime vtable; the production instantiation monomorphizes to one).
+fn around(ctrl: anytype, body: anytype) !void {
+    ctrl.leave(); // hand the terminal to the child
+    errdefer ctrl.leave(); // a child or re-enter fault still leaves it restored
+    try body.run();
+    try ctrl.enter(); // back to the dashboard
+}
+
+/// Live controller over a `term.Term`: leave drops everything entered, enter
+/// re-establishes raw + alt-screen + hidden cursor in the same order `run` does.
+const TermCtrl = struct {
+    t: *term.Term,
+    fn leave(self: TermCtrl) void {
+        self.t.restore();
+    }
+    fn enter(self: TermCtrl) term.TermError!void {
+        try self.t.enterRaw();
+        try self.t.enterAltScreen();
+        try self.t.hideCursor();
+    }
+};
+
+/// The mutation body: re-exec `mt` inheriting stdio.
+const ChildBody = struct {
+    io: std.Io,
+    argv: []const []const u8,
+    fn run(self: ChildBody) SpawnError!void {
+        return runChild(self.io, self.argv);
+    }
+};
+
+/// Run a delegated mutation inline: leave the alt-screen, re-exec `mt`, wait,
+/// re-enter. On any fault the terminal is restored before the error propagates.
+pub fn runInline(t: *term.Term, argv: []const []const u8) InlineError!void {
+    return around(TermCtrl{ .t = t }, ChildBody{ .io = t.io, .argv = argv });
+}
+
+// ─── tests ───────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+fn threaded() std.Io.Threaded {
+    return .init(testing.allocator, .{});
+}
+
+test "inlineArgv re-execs the resolved mt with the subcommand and its args" {
+    const argv = try inlineArgv(testing.allocator, "/opt/homebrew/bin/mt", &.{ "upgrade", "ripgrep" });
+    defer testing.allocator.free(argv);
+    try testing.expectEqual(@as(usize, 3), argv.len);
+    try testing.expectEqualStrings("/opt/homebrew/bin/mt", argv[0]); // the same mt, not PATH's
+    try testing.expectEqualStrings("upgrade", argv[1]);
+    try testing.expectEqualStrings("ripgrep", argv[2]);
+}
+
+test "jsonArgv appends --json after the command for the parsers" {
+    const argv = try jsonArgv(testing.allocator, "/opt/homebrew/bin/mt", &.{"list"});
+    defer testing.allocator.free(argv);
+    try testing.expectEqual(@as(usize, 3), argv.len);
+    try testing.expectEqualStrings("/opt/homebrew/bin/mt", argv[0]);
+    try testing.expectEqualStrings("list", argv[1]);
+    try testing.expectEqualStrings("--json", argv[2]);
+}
+
+test "argv builders hold at the empty-args boundary" {
+    const a = try inlineArgv(testing.allocator, "/bin/mt", &.{});
+    defer testing.allocator.free(a);
+    try testing.expectEqual(@as(usize, 1), a.len);
+    try testing.expectEqualStrings("/bin/mt", a[0]);
+
+    const j = try jsonArgv(testing.allocator, "/bin/mt", &.{});
+    defer testing.allocator.free(j);
+    try testing.expectEqual(@as(usize, 2), j.len);
+    try testing.expectEqualStrings("/bin/mt", j[0]);
+    try testing.expectEqualStrings("--json", j[1]);
+}
+
+test "runChild returns void on a zero exit" {
+    var t = threaded();
+    defer t.deinit();
+    try runChild(t.io(), &.{"/usr/bin/true"});
+}
+
+test "runChild surfaces a non-zero exit as ChildFailed, not swallowed" {
+    var t = threaded();
+    defer t.deinit();
+    try testing.expectError(error.ChildFailed, runChild(t.io(), &.{"/usr/bin/false"}));
+}
+
+test "runChild surfaces a missing program as SpawnFailed" {
+    var t = threaded();
+    defer t.deinit();
+    try testing.expectError(error.SpawnFailed, runChild(t.io(), &.{"/nonexistent/malt_tui_spawn_probe"}));
+}
+
+test "readJson captures the child's stdout for the parser" {
+    var t = threaded();
+    defer t.deinit();
+    const out = try readJson(t.io(), testing.allocator, &.{ "/bin/echo", "hello-json" });
+    defer testing.allocator.free(out);
+    try testing.expect(std.mem.indexOf(u8, out, "hello-json") != null);
+}
+
+test "readJson errors on an empty document so a parser never sees half a doc" {
+    var t = threaded();
+    defer t.deinit();
+    try testing.expectError(error.EmptyOutput, readJson(t.io(), testing.allocator, &.{"/usr/bin/true"}));
+}
+
+test "readJson errors on a non-zero exit" {
+    var t = threaded();
+    defer t.deinit();
+    try testing.expectError(error.ChildFailed, readJson(t.io(), testing.allocator, &.{"/usr/bin/false"}));
+}
+
+// A fake terminal controller + body record the call order so the sequencing
+// and errdefer-restore contract are provable without a PTY.
+const FakeTerm = struct {
+    entered: bool = true, // starts in the dashboard
+    enter_fails: bool = false,
+    log: *std.ArrayList(u8),
+    fn leave(self: *FakeTerm) void {
+        self.entered = false;
+        self.log.append(testing.allocator, 'L') catch {};
+    }
+    fn enter(self: *FakeTerm) error{Reenter}!void {
+        self.log.append(testing.allocator, 'E') catch {};
+        if (self.enter_fails) return error.Reenter;
+        self.entered = true;
+    }
+};
+
+const FakeBody = struct {
+    fails: bool,
+    log: *std.ArrayList(u8),
+    fn run(self: FakeBody) error{Spawn}!void {
+        self.log.append(testing.allocator, 'S') catch {};
+        if (self.fails) return error.Spawn;
+    }
+};
+
+test "runInline order: leave → spawn → re-enter, ending in the dashboard" {
+    var log: std.ArrayList(u8) = .empty;
+    defer log.deinit(testing.allocator);
+    var ft: FakeTerm = .{ .log = &log };
+    try around(&ft, FakeBody{ .fails = false, .log = &log });
+    try testing.expectEqualStrings("LSE", log.items);
+    try testing.expect(ft.entered);
+}
+
+test "a child failure restores the terminal and surfaces the error" {
+    var log: std.ArrayList(u8) = .empty;
+    defer log.deinit(testing.allocator);
+    var ft: FakeTerm = .{ .log = &log };
+    try testing.expectError(error.Spawn, around(&ft, FakeBody{ .fails = true, .log = &log }));
+    try testing.expectEqualStrings("LSL", log.items); // leave, spawn(fail), errdefer leave
+    try testing.expect(!ft.entered);
+}
+
+test "a re-enter fault still restores the terminal" {
+    var log: std.ArrayList(u8) = .empty;
+    defer log.deinit(testing.allocator);
+    var ft: FakeTerm = .{ .log = &log, .enter_fails = true };
+    try testing.expectError(error.Reenter, around(&ft, FakeBody{ .fails = false, .log = &log }));
+    try testing.expectEqualStrings("LSEL", log.items); // leave, spawn, enter(fail), errdefer leave
+    try testing.expect(!ft.entered);
+}

--- a/tests/tui_spawn_test.zig
+++ b/tests/tui_spawn_test.zig
@@ -1,0 +1,64 @@
+//! malt — integration tests for `mt tui` process delegation + refresh policy.
+//!
+//! Drives the public surface (`malt.tui_spawn`, `malt.tui_app`): the argv
+//! shapes that re-exec the same `mt`, the `--json` read capture and its error
+//! gates, and the lazy per-tab refresh hook. The live spawn round-trip (drop
+//! alt-screen → run → re-enter on a real PTY) is deferred to the TUI-016 e2e.
+
+const std = @import("std");
+const testing = std.testing;
+
+const spawn = @import("malt").tui_spawn;
+const app = @import("malt").tui_app;
+const Tab = @import("malt").tui_tab_bar.Tab;
+
+fn threaded() std.Io.Threaded {
+    return .init(testing.allocator, .{});
+}
+
+test "inlineArgv re-execs the injected mt with the subcommand and its args" {
+    const argv = try spawn.inlineArgv(testing.allocator, "/usr/local/bin/mt", &.{ "uninstall", "wget" });
+    defer testing.allocator.free(argv);
+    try testing.expectEqual(@as(usize, 3), argv.len);
+    try testing.expectEqualStrings("/usr/local/bin/mt", argv[0]);
+    try testing.expectEqualStrings("uninstall", argv[1]);
+    try testing.expectEqualStrings("wget", argv[2]);
+}
+
+test "jsonArgv builds mt <cmd> --json for the tab parsers" {
+    const argv = try spawn.jsonArgv(testing.allocator, "/usr/local/bin/mt", &.{"outdated"});
+    defer testing.allocator.free(argv);
+    try testing.expectEqual(@as(usize, 3), argv.len);
+    try testing.expectEqualStrings("/usr/local/bin/mt", argv[0]);
+    try testing.expectEqualStrings("outdated", argv[1]);
+    try testing.expectEqualStrings("--json", argv[2]);
+}
+
+test "readJson captures stdout and errors on empty or non-zero output" {
+    var t = threaded();
+    defer t.deinit();
+    const out = try spawn.readJson(t.io(), testing.allocator, &.{ "/bin/echo", "{\"ok\":true}" });
+    defer testing.allocator.free(out);
+    try testing.expect(std.mem.indexOf(u8, out, "\"ok\":true") != null);
+
+    try testing.expectError(error.EmptyOutput, spawn.readJson(t.io(), testing.allocator, &.{"/usr/bin/true"}));
+    try testing.expectError(error.ChildFailed, spawn.readJson(t.io(), testing.allocator, &.{"/usr/bin/false"}));
+}
+
+test "runChild surfaces a non-zero exit instead of swallowing it" {
+    var t = threaded();
+    defer t.deinit();
+    try spawn.runChild(t.io(), &.{"/usr/bin/true"});
+    try testing.expectError(error.ChildFailed, spawn.runChild(t.io(), &.{"/usr/bin/false"}));
+}
+
+test "the refresh hook refetches the active tab and marks the rest dirty on view" {
+    var a: app.App = .{ .active = .services };
+    app.markStaleAfterMutation(&a);
+    // The tab the user just acted on is refreshed inline, so it stays fresh.
+    try testing.expect(!app.takeDirty(&a, .services));
+    // Every other tab refetches once when entered, then is fresh again.
+    try testing.expect(app.takeDirty(&a, .installed));
+    try testing.expect(!app.takeDirty(&a, .installed));
+    try testing.expect(app.takeDirty(&a, .doctor));
+}


### PR DESCRIPTION
## Description

Implements malt's delegation principle for the TUI: every mutation runs the real `mt` subcommand instead of being reimplemented. On a mutation the dashboard drops out of the alternate screen, runs `mt <subcommand>` inline so its progress bars and typed-confirm prompts appear in the user's scrollback exactly as on the CLI, waits, then re-enters and refreshes the affected pane. The read side captures `mt … --json` stdout for the tab parsers. A non-zero child exit is surfaced and the terminal is always restored, even on failure. Mutation behaviour cannot diverge from the CLI because the TUI is the CLI for every write.

New leaf `src/tui/spawn.zig`:

- `inlineArgv` / `jsonArgv` — build `[mt, <sub>, args…]` and `[mt, <cmd>, args…, --json]`. argv[0] is the resolved self-exe path, so the child is the *same* `mt`, not whatever PATH resolves.
- `runInline` — leave alt-screen + raw → re-exec `mt` inheriting stdio → wait → re-enter; every fault path restores the terminal via `errdefer`.
- `readJson` — capture `--json` stdout, bounded, erroring on a non-zero exit or empty document so a parser never sees half a doc.

## Related Issue

- None

## Notes for Reviewers

- `src/tui/spawn.zig` is a leaf: it imports only `std` + the sibling `term.zig`, so it cannot reach `app_ctx.zig`. The resolved `mt` path is injected from the `main.zig` bridge (`std.process.executablePath`), which also already forwards `environ`.
- The child **inherits** env (fork+exec semantics, matching every existing `std.process.spawn` site in malt). The boot-time `AppCtx.environ` snapshot is the same env the child inherits, so no `Environ→Map` forwarding is added.

<!-- GitButler Footer Boundary Top -->
---
This is **part 15 of 19 in a stack** made with GitButler:
- <kbd>&nbsp;19&nbsp;</kbd> #464
- <kbd>&nbsp;18&nbsp;</kbd> #463
- <kbd>&nbsp;17&nbsp;</kbd> #462
- <kbd>&nbsp;16&nbsp;</kbd> #461
- <kbd>&nbsp;15&nbsp;</kbd> #459
- <kbd>&nbsp;14&nbsp;</kbd> #458
- <kbd>&nbsp;13&nbsp;</kbd> #457
- <kbd>&nbsp;12&nbsp;</kbd> #456
- <kbd>&nbsp;11&nbsp;</kbd> #455
- <kbd>&nbsp;10&nbsp;</kbd> #454
- <kbd>&nbsp;9&nbsp;</kbd> #453
- <kbd>&nbsp;8&nbsp;</kbd> #451
- <kbd>&nbsp;7&nbsp;</kbd> #450
- <kbd>&nbsp;6&nbsp;</kbd> #448
- <kbd>&nbsp;5&nbsp;</kbd> #447 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #446
- <kbd>&nbsp;3&nbsp;</kbd> #445
- <kbd>&nbsp;2&nbsp;</kbd> #444
- <kbd>&nbsp;1&nbsp;</kbd> #443
<!-- GitButler Footer Boundary Bottom -->