### PR TITLE
test(smoke): put install prefix bin on PATH so doctor stays green

### DIFF
--- a/scripts/smokes/test_smoke_install.sh
+++ b/scripts/smokes/test_smoke_install.sh
@@ -126,6 +126,10 @@ export MALT_PREFIX="$PREFIX"
 export MALT_CACHE="$CACHE"
 export MALT_NO_EMOJI=1
 export NO_COLOR=1
+# Put the install prefix's bin on PATH — the realistic post-install state, and
+# what `mt doctor`'s "Prefix on PATH" check expects. Without it doctor emits a
+# warning and exits non-zero, failing the smoke for an environmental reason.
+export PATH="$PREFIX/bin:$PATH"
 
 # ── 1. Install ────────────────────────────────────────────────────────────
 log "installing ${PACKAGES[*]} into $PREFIX …"


### PR DESCRIPTION
The install smoke (`scripts/smokes/test_smoke_install.sh`) ran `mt doctor` against a throwaway `/tmp` prefix that was never placed on `PATH`. Doctor's "Prefix on PATH" check therefore warned and exited non-zero, failing the smoke for a purely environmental reason on every run.

This exports the install prefix's `bin` onto `PATH` before the checks.

## Related Issue

- None

## Notes for Reviewers

- None