### PR TITLE
test: pin two network-flaky tests offline for deterministic runs

### DIFF
--- a/scripts/regressions/info_rollback_history.sh
+++ b/scripts/regressions/info_rollback_history.sh
@@ -34,6 +34,11 @@ PREFIX="/tmp/mt_info_hist_reg"
 export MALT_PREFIX="$PREFIX"
 export NO_COLOR=1
 export MALT_NO_EMOJI=1
+# Hermetic: every assertion is served from the seeded DB + store below, so a
+# local-lookup miss must never fall through to live Homebrew metadata, whose real
+# wget version can echo the current "1.22" the rollback section is asserted to
+# skip — the source of the parallel-batch flake.
+export MALT_OFFLINE=1
 rm -rf "$PREFIX"
 mkdir -p "$PREFIX/db"
 trap 'rm -rf "$PREFIX"' EXIT

--- a/tests/bundle_test.zig
+++ b/tests/bundle_test.zig
@@ -480,7 +480,10 @@ test "silent-sink dispatcher: member failure surfaces via Report with no stderr 
 
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
-    const app: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    // offline keeps the unresolvable formula failing fast (no network), so the
+    // test never races on connectivity and the HTTP/TLS layer never writes to the
+    // global stderr we assert is empty — the source of the parallel-batch flake.
+    const app: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty, .offline = true };
     var ictx: SilentInstallCtx = .{ .app = &app };
     const dispatcher = runner.Dispatcher{
         .ctx = &ictx,


### PR DESCRIPTION
Stabilizes two pre-existing, network-flaky tests that pass in isolation but flap under the parallel test batch.

## Related Issue

- None

## Notes for Reviewers

- None