### PR TITLE
feat(tui): services tab with start/stop/restart

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -250,6 +250,7 @@ pub fn build(b: *std.Build) void {
         "tests/tui_spawn_test.zig",
         "tests/tui_installed_tab_test.zig",
         "tests/tui_outdated_test.zig",
+        "tests/tui_services_test.zig",
         "tests/tui_purity_test.zig",
     };
 

--- a/scripts/fixtures/tui_services.json
+++ b/scripts/fixtures/tui_services.json
@@ -1,0 +1,1 @@
+{"schema_version":1,"services":[{"name":"redis","state":"running","auto_start":true,"keg_name":"redis"},{"name":"postgresql@16","state":"stopped","auto_start":false,"keg_name":"postgresql@16"},{"name":"dnsmasq","state":"not-loaded","auto_start":true,"keg_name":"dnsmasq"},{"name":"unbound","state":"degraded","auto_start":false,"keg_name":"unbound"}],"time_ms":4}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -99,6 +99,7 @@ pub const tui_filter_input = @import("tui/filter_input.zig");
 pub const tui_json_info = @import("tui/json/info.zig");
 pub const tui_json_list = @import("tui/json/list.zig");
 pub const tui_json_outdated = @import("tui/json/outdated.zig");
+pub const tui_json_services = @import("tui/json/services.zig");
 pub const tui_keys = @import("tui/keys.zig");
 pub const tui_layout = @import("tui/layout.zig");
 pub const tui_scroll_list = @import("tui/scroll_list.zig");

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -24,6 +24,7 @@ const spawn = @import("spawn.zig");
 const list_json = @import("json/list.zig");
 const info_json = @import("json/info.zig");
 const outdated_json = @import("json/outdated.zig");
+const services_json = @import("json/services.zig");
 
 const installed = @import("installed_tab.zig");
 const outdated = @import("outdated_tab.zig");
@@ -322,7 +323,7 @@ fn refusalMessage(r: Refusal) []const u8 {
 
 pub const RunError = term.TermError || std.mem.Allocator.Error ||
     spawn.ReadError || spawn.InlineError || list_json.Error || info_json.Error ||
-    outdated_json.Error || error{ReadFailed};
+    outdated_json.Error || services_json.Error || error{ReadFailed};
 
 /// How the event loop treats a run-loop error: a `recoverable` backend fault
 /// becomes an inline banner and the session keeps running; a `fatal` fault
@@ -363,12 +364,14 @@ const Store = struct {
     /// The Outdated tab's checkbox state, parallel to `outdated.?.items`. Owned
     /// here, resized to the row count on each (re)load, borrowed by the tab.
     outdated_checked: []bool = &.{},
+    services: ?services_json.Parsed = null,
 
     fn deinit(self: *Store, allocator: std.mem.Allocator) void {
         if (self.installed) |p| p.deinit();
         if (self.detail) |p| p.deinit();
         if (self.outdated) |p| p.deinit();
         if (self.outdated_checked.len != 0) allocator.free(self.outdated_checked);
+        if (self.services) |p| p.deinit();
     }
 };
 
@@ -525,12 +528,77 @@ fn serviceOutdated(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, app:
     }
 }
 
+/// (Re)read `mt services list --json` and repoint the Services tab's rows at the
+/// fresh parse, freeing the previous one.
+fn loadServices(io: std.Io, allocator: std.mem.Allocator, app: *App, store: *Store) RunError!void {
+    // Annotate any failure as a recoverable banner; the loop boundary decides
+    // recoverable vs fatal. The store is swapped only after a clean parse, so a
+    // failure keeps the last-good rows and their selection.
+    errdefer |err| app.banner.set("services refresh failed", @errorName(err));
+    const argv = try spawn.jsonArgv(allocator, app.mt_path, &.{ "services", "list" });
+    defer allocator.free(argv);
+    const bytes = try spawn.readJson(io, allocator, argv);
+    defer allocator.free(bytes);
+
+    const parsed = try services_json.parse(allocator, bytes);
+    if (store.services) |old| old.deinit();
+    store.services = parsed;
+    app.states.services.items = parsed.items;
+}
+
+/// Build `mt services <action> <name>` for the selected service. Pure over the
+/// tab state: null when nothing is selected (the no-op), else an owned argv whose
+/// `name` element borrows from the parse storage. Caller frees the returned slice
+/// (not its elements).
+fn serviceActionArgv(allocator: std.mem.Allocator, mt_path: []const u8, action: []const u8, st: *const services.State) std.mem.Allocator.Error!?[]const []const u8 {
+    const svc = services.selectedService(st) orelse return null; // empty list: no-op
+    return try spawn.inlineArgv(allocator, mt_path, &.{ "services", action, svc.name });
+}
+
+/// Delegate a service lifecycle action to the real `mt` inline, then refresh. The
+/// argv's `name` borrows from the current parse storage; the post-spawn reload
+/// frees that storage, so the name is not read afterwards.
+fn doServiceAction(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, app: *App, store: *Store, action: []const u8) RunError!void {
+    const argv = (try serviceActionArgv(allocator, app.mt_path, action, &app.states.services)) orelse return; // nothing selected
+    defer allocator.free(argv);
+    {
+        // A non-zero `mt services <action>` re-enters the dashboard (the user
+        // keeps malt's real output in their scrollback) and surfaces as a
+        // recoverable banner; only a terminal fault is fatal. Scoped so the
+        // refresh below reports under its own op, not the action.
+        errdefer |err| app.banner.set("service action failed", @errorName(err));
+        try spawn.runInlineReenter(t, argv);
+    }
+    try loadServices(io, allocator, app, store); // the state changed — refetch
+    markStaleAfterMutation(app);
+}
+
+/// Perform any lifecycle effect the pure `step` requested on the Services tab,
+/// then clear it, and lazily (re)load on first entry or after a mutation marked
+/// it dirty.
+fn serviceServices(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, app: *App, store: *Store) RunError!void {
+    const req = app.states.services.request;
+    app.states.services.request = .none;
+    switch (req) {
+        .none => {},
+        .start => try doServiceAction(io, allocator, t, app, store, "start"),
+        .stop => try doServiceAction(io, allocator, t, app, store, "stop"),
+        .restart => try doServiceAction(io, allocator, t, app, store, "restart"),
+    }
+    // Lazy per-tab load: first activation and post-mutation staleness both arrive
+    // as the dirty flag (set at init and by `markStaleAfterMutation`).
+    if (app.active == .services and takeDirty(app, .services)) {
+        try loadServices(io, allocator, app, store);
+    }
+}
+
 /// Drain the active tab's pending effects after a keypress. Each tab's service is
 /// a no-op unless that tab is active and has a request or is due a lazy refresh,
-/// so calling both each loop is cheap and keeps the dispatch flat.
+/// so calling each one each loop is cheap and keeps the dispatch flat.
 fn service(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, app: *App, store: *Store) RunError!void {
     try serviceInstalled(io, allocator, t, app, store);
     try serviceOutdated(io, allocator, t, app, store);
+    try serviceServices(io, allocator, t, app, store);
 }
 
 fn isTty(io: std.Io, fd: std.posix.fd_t) bool {
@@ -587,6 +655,7 @@ pub fn run(io: std.Io, allocator: std.mem.Allocator, stderr: std.Io.File, enviro
 
     var app: App = .{ .mt_path = mt_path }; // re-exec this mt for delegated mutations
     app.dirty.insert(.outdated); // lazy: load `mt outdated --json` on first activation
+    app.dirty.insert(.services); // lazy: load `mt services list --json` on first activation
     var store: Store = .{};
     defer store.deinit(allocator);
     var frame = try allocator.alloc(u8, frameCap(term.currentSize()));
@@ -955,6 +1024,38 @@ test "a failed outdated refresh names the op in the banner and keeps the last-go
     try std.testing.expectError(error.BadJson, loadOutdated(t.io(), std.testing.allocator, &app, &store));
     try std.testing.expectEqualStrings("outdated refresh failed: BadJson", app.banner.slice());
     try std.testing.expectEqual(@as(usize, 0), app.states.outdated.items.len); // last-good kept
+}
+
+test "serviceActionArgv builds `mt services <action> <name>` for the selected service" {
+    const items = [_]services.Row{
+        .{ .name = "redis", .state = "running", .auto_start = true, .keg_name = "redis" },
+        .{ .name = "postgresql", .state = "stopped", .auto_start = false, .keg_name = "postgresql@16" },
+    };
+    var st: services.State = .{ .items = &items };
+    st.chrome.view.selected = 1; // postgresql
+    const argv = (try serviceActionArgv(std.testing.allocator, "/opt/homebrew/bin/mt", "restart", &st)).?;
+    defer std.testing.allocator.free(argv);
+    try std.testing.expectEqual(@as(usize, 4), argv.len);
+    try std.testing.expectEqualStrings("/opt/homebrew/bin/mt", argv[0]);
+    try std.testing.expectEqualStrings("services", argv[1]);
+    try std.testing.expectEqualStrings("restart", argv[2]);
+    try std.testing.expectEqualStrings("postgresql", argv[3]); // the selected row's name
+}
+
+test "serviceActionArgv returns null when nothing is selected so the action is a no-op" {
+    const st: services.State = .{ .items = &.{} };
+    try std.testing.expect((try serviceActionArgv(std.testing.allocator, "/bin/mt", "start", &st)) == null);
+}
+
+test "a failed services refresh names the op in the banner and keeps the last-good rows" {
+    var t = std.Io.Threaded.init(std.testing.allocator, .{});
+    defer t.deinit();
+    var app: App = .{ .mt_path = "/bin/echo" }; // echo emits non-JSON → parse fails
+    var store: Store = .{};
+    defer store.deinit(std.testing.allocator);
+    try std.testing.expectError(error.BadJson, loadServices(t.io(), std.testing.allocator, &app, &store));
+    try std.testing.expectEqualStrings("services refresh failed: BadJson", app.banner.slice());
+    try std.testing.expectEqual(@as(usize, 0), app.states.services.items.len); // last-good kept
 }
 
 test "refusalReason refuses non-tty, NO_COLOR, and CI; allows a clean tty" {

--- a/src/tui/json/services.zig
+++ b/src/tui/json/services.zig
@@ -1,0 +1,131 @@
+//! malt — parse `mt services list --json` into TUI-local structs.
+//!
+//! Leaf module: imports only `std`. The versioned `services` array is the
+//! contract; `schema_version`, `time_ms`, and any future field are ignored, so a
+//! schema addition never breaks parsing. `ServiceRow` is TUI-local — never the
+//! core `JsonRow` — so the `--json` shape is the only coupling. `state` is kept a
+//! free-form string: the renderer buckets it, so an unknown/future runtime state
+//! parses without an enum to break against.
+
+const std = @import("std");
+const testing = std.testing;
+
+pub const Error = error{ BadJson, OutOfMemory };
+
+/// One service row — the subset the Services tab paints and acts on. `state` is
+/// the runtime state verbatim (`running`/`stopped`/`not-loaded`/…); `auto_start`
+/// drives the auto/manual hint; `keg_name` is the owning keg.
+pub const ServiceRow = struct {
+    name: []const u8,
+    state: []const u8,
+    auto_start: bool,
+    keg_name: []const u8 = "",
+};
+
+/// Owns the parsed rows; `items` borrow from the arena. Free with `deinit`.
+pub const Parsed = struct {
+    doc: std.json.Parsed(Doc),
+    items: []const ServiceRow,
+
+    pub fn deinit(self: Parsed) void {
+        self.doc.deinit();
+    }
+};
+
+// The wire keys match `ServiceRow`'s field names, so we parse straight into it;
+// `keg_name` defaults so a row that omits it still parses. Everything outside
+// `services` is dropped via `ignore_unknown_fields`.
+const Doc = struct {
+    services: []ServiceRow,
+};
+
+/// Parse the captured `mt services list --json` document. Malformed or
+/// non-conforming input is `BadJson`; the caller restores the terminal and
+/// surfaces it.
+pub fn parse(allocator: std.mem.Allocator, bytes: []const u8) Error!Parsed {
+    const doc = std.json.parseFromSlice(Doc, allocator, bytes, .{
+        .ignore_unknown_fields = true,
+        // Copy strings into the arena: the shell frees the source buffer right
+        // after parsing while the tab keeps borrowing the rows.
+        .allocate = .alloc_always,
+    }) catch return error.BadJson;
+    return .{ .doc = doc, .items = doc.value.services };
+}
+
+// ─── tests ───────────────────────────────────────────────────────────
+
+test "parse reads the services array with all columns" {
+    const bytes =
+        \\{"schema_version":1,"services":[
+        \\{"name":"redis","state":"running","auto_start":true,"keg_name":"redis"},
+        \\{"name":"postgres","state":"not-loaded","auto_start":false,"keg_name":"postgresql@16"}
+        \\],"time_ms":3}
+    ;
+    var p = try parse(testing.allocator, bytes);
+    defer p.deinit();
+    try testing.expectEqual(@as(usize, 2), p.items.len);
+    try testing.expectEqualStrings("redis", p.items[0].name);
+    try testing.expectEqualStrings("running", p.items[0].state);
+    try testing.expectEqual(true, p.items[0].auto_start);
+    try testing.expectEqualStrings("redis", p.items[0].keg_name);
+    try testing.expectEqualStrings("postgres", p.items[1].name);
+    try testing.expectEqualStrings("not-loaded", p.items[1].state);
+    try testing.expectEqual(false, p.items[1].auto_start);
+    try testing.expectEqualStrings("postgresql@16", p.items[1].keg_name);
+}
+
+test "parse keeps an unusual state string verbatim (no enum to break against)" {
+    const bytes =
+        \\{"services":[{"name":"weird","state":"degraded","auto_start":false,"keg_name":"weird"}]}
+    ;
+    var p = try parse(testing.allocator, bytes);
+    defer p.deinit();
+    try testing.expectEqualStrings("degraded", p.items[0].state);
+}
+
+test "parse ignores unknown fields and schema_version" {
+    const bytes =
+        \\{"schema_version":1,"services":[{"name":"a","state":"running","auto_start":true,"keg_name":"a"}],
+        \\"future_key":42,"time_ms":1}
+    ;
+    var p = try parse(testing.allocator, bytes);
+    defer p.deinit();
+    try testing.expectEqual(@as(usize, 1), p.items.len);
+    try testing.expectEqualStrings("a", p.items[0].name);
+}
+
+test "parse tolerates an absent keg_name (defaults to empty)" {
+    const bytes =
+        \\{"services":[{"name":"a","state":"running","auto_start":true}]}
+    ;
+    var p = try parse(testing.allocator, bytes);
+    defer p.deinit();
+    try testing.expectEqualStrings("", p.items[0].keg_name);
+}
+
+test "parse yields zero items for an empty services array" {
+    var p = try parse(testing.allocator, "{\"schema_version\":1,\"services\":[]}");
+    defer p.deinit();
+    try testing.expectEqual(@as(usize, 0), p.items.len);
+}
+
+test "parse rejects malformed and empty input as BadJson" {
+    try testing.expectError(error.BadJson, parse(testing.allocator, "not json"));
+    try testing.expectError(error.BadJson, parse(testing.allocator, ""));
+    try testing.expectError(error.BadJson, parse(testing.allocator, "{}")); // no services key
+}
+
+test "parsed strings own their bytes — the source buffer can be freed/overwritten" {
+    // The shell frees the captured `--json` buffer right after parsing; the tab
+    // keeps borrowing the rows, so the parse must copy, not reference the input.
+    const src =
+        \\{"services":[{"name":"redis","state":"running","auto_start":true,"keg_name":"redis"}]}
+    ;
+    const buf = try testing.allocator.dupe(u8, src);
+    defer testing.allocator.free(buf);
+    var p = try parse(testing.allocator, buf);
+    defer p.deinit();
+    @memset(buf, 'X'); // scribble the source — a referencing parse would now read garbage
+    try testing.expectEqualStrings("redis", p.items[0].name);
+    try testing.expectEqualStrings("running", p.items[0].state);
+}

--- a/src/tui/services_tab.zig
+++ b/src/tui/services_tab.zig
@@ -316,6 +316,19 @@ test "render reflows: the same state at two widths differs" {
     try testing.expect(!std.mem.eql(u8, fa.slice(), fb.slice()));
 }
 
+test "a hostile service name cannot inject a control sequence into the frame" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const evil = [_]Row{.{ .name = "ev\x1b]0;pwn\x07il", .state = "running", .auto_start = false, .keg_name = "k" }};
+    const s: State = .{ .items = &evil };
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
+    const out = f.slice();
+    // The dot legitimately emits its own SGR via `put`; the row *content* is funnelled
+    // through `putContent`, so the name's OSC title-set and BEL are neutralized there.
+    try testing.expect(std.mem.indexOf(u8, out, "\x1b]0;pwn") == null); // OSC introducer broken
+    try testing.expect(std.mem.indexOfScalar(u8, out, 0x07) == null); // BEL dropped
+}
+
 test "render on an empty list is a clean no-crash frame" {
     var buf: [1024]u8 = undefined;
     var f: tab.Frame = .{ .buf = &buf };

--- a/src/tui/services_tab.zig
+++ b/src/tui/services_tab.zig
@@ -1,23 +1,334 @@
-//! malt — Services tab for `mt tui` (placeholder; data lands in a later layer).
+//! malt — Services tab for `mt tui`: the service lifecycle pane.
+//!
+//! Leaf module. Pure cores only: `step(state, key)` records a lifecycle intent
+//! (`start`/`stop`/`restart`) as a `request` for the impure shell to delegate to
+//! the real `mt services <action> <name>`; `render(state, frame, rect)` is a pure
+//! function of `(state, rect)` so a resize is a re-render. The shell owns the row
+//! data; `items` borrow from that storage. Each row shows a state dot (running /
+//! stopped / unknown) and the auto-start hint. The `state` string is bucketed,
+//! not matched against an enum, so a future/unusual runtime state still renders.
+//! No in-TUI confirm: the service actions are reversible, so the keystroke
+//! delegates straight to `mt`, trusting any sudo/confirm prompt `mt` itself raises.
 
+const std = @import("std");
+const testing = std.testing;
+
+const color = @import("../ui/color.zig");
+const services_json = @import("json/services.zig");
+pub const Row = services_json.ServiceRow;
+const scroll_list = @import("scroll_list.zig");
 const tab = @import("tab.zig");
 
-pub const State = struct { chrome: tab.Chrome = .{} };
+/// A lifecycle effect the pure `step` defers to the impure shell, which performs
+/// it and resets the field. `step` never does I/O — this is the command channel.
+pub const Request = enum { none, start, stop, restart };
+
+pub const State = struct {
+    chrome: tab.Chrome = .{},
+    /// Service rows, borrowed from shell-owned parse storage.
+    items: []const Row = &.{},
+    /// Pending lifecycle effect for the shell to perform, then clear.
+    request: Request = .none,
+};
 
 pub fn title() []const u8 {
     return "Services";
 }
 
+/// Case-insensitive substring match of `filter` against `name`. An empty filter
+/// matches everything.
+pub fn matches(name: []const u8, filter: []const u8) bool {
+    return filter.len == 0 or std.ascii.indexOfIgnoreCase(name, filter) != null;
+}
+
+fn filteredCount(items: []const Row, filter: []const u8) usize {
+    var n: usize = 0;
+    for (items) |s| {
+        if (matches(s.name, filter)) n += 1;
+    }
+    return n;
+}
+
+/// The service the selection points at, after applying the filter and clamping
+/// the (shell-driven, unbounded) selection into the filtered list. The shell
+/// reads its `name` to build `mt services <action> <name>`.
+pub fn selectedService(s: *const State) ?Row {
+    const filter = s.chrome.filter.slice();
+    const nf = filteredCount(s.items, filter);
+    if (nf == 0) return null;
+    const sel = @min(s.chrome.view.selected, nf - 1);
+    var fi: usize = 0;
+    for (s.items) |svc| {
+        if (!matches(svc.name, filter)) continue;
+        if (fi == sel) return svc;
+        fi += 1;
+    }
+    return null; // unreachable: sel < nf
+}
+
+/// Pure transition: record a lifecycle intent for the shell to act on. `s` start,
+/// `x`/`X` stop, `r` restart — reversible, so no confirm guard.
 pub fn step(s: *State, key: tab.Key) void {
-    _ = s;
-    _ = key;
+    switch (key) {
+        .char => |c| if (c.len == 1) switch (c.bytes[0]) {
+            's' => s.request = .start,
+            'x', 'X' => s.request = .stop,
+            'r' => s.request = .restart,
+            else => {},
+        },
+        else => {},
+    }
 }
 
+/// The three state buckets the dot encodes. `state` is bucketed rather than
+/// matched exhaustively, so any unrecognized value lands in `unknown`.
+const Status = enum { running, stopped, unknown };
+
+fn statusOf(state: []const u8) Status {
+    if (std.mem.eql(u8, state, "running")) return .running;
+    if (std.mem.eql(u8, state, "stopped") or std.mem.eql(u8, state, "not-loaded")) return .stopped;
+    return .unknown; // loaded / degraded / any future or unusual state
+}
+
+fn dotGlyph(st: Status) []const u8 {
+    return switch (st) {
+        .running => "●",
+        .stopped => "○",
+        .unknown => "◌",
+    };
+}
+
+fn dotStyle(st: Status) color.Style {
+    return switch (st) {
+        .running => .green, // a live service reads as healthy
+        .stopped => .dim,
+        .unknown => .dim,
+    };
+}
+
+/// Pure render: a dim action line on top, then the filtered + scrolled service
+/// list below. A pure function of `(state, rect)` so a resize is a re-render.
 pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
-    tab.paintRows(f, &placeholder, s.chrome.view, r);
+    if (r.height == 0) return;
+    renderActionLine(f, .{ .row = r.row, .col = r.col, .width = r.width, .height = 1 });
+    renderList(s, f, .{ .row = r.row + 1, .col = r.col, .width = r.width, .height = r.height -| 1 });
 }
 
-const placeholder = [_][]const u8{"Services — no data yet"};
+/// The dim action line: the lifecycle keys, so they are discoverable (the global
+/// footer carries only the shell-wide keys).
+fn renderActionLine(f: *tab.Frame, rect: tab.Rect) void {
+    f.moveTo(rect.row, rect.col);
+    f.put(color.Style.dim.code());
+    f.putContent(scroll_list.truncate("s: start   x: stop   r: restart", rect.width));
+    f.put(color.Style.reset.code());
+}
+
+fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
+    if (rect.height == 0) return;
+    const filter = s.chrome.filter.slice();
+    const nf = filteredCount(s.items, filter);
+    const v = scroll_list.clamp(s.chrome.view, nf, rect.height);
+
+    var fi: usize = 0;
+    for (s.items) |svc| {
+        if (!matches(svc.name, filter)) continue;
+        defer fi += 1;
+        if (fi < v.offset) continue;
+        const screen = fi - v.offset;
+        if (screen >= rect.height) break;
+        f.moveTo(rect.row + @as(u16, @intCast(screen)), rect.col);
+        // The dot keeps its own colour regardless of selection; the reverse-video
+        // selection wraps only the text columns so the two SGRs never tangle.
+        const st = statusOf(svc.state);
+        f.put(dotStyle(st).code());
+        f.put(dotGlyph(st));
+        f.put(color.Style.reset.code());
+        f.put(" ");
+        const selected = fi == v.selected;
+        if (selected) f.put(reverse);
+        var rb: [256]u8 = undefined;
+        f.putContent(scroll_list.truncate(formatRow(&rb, svc), rect.width -| 2)); // 2 cols spent on the dot
+        if (selected) f.put(color.Style.reset.code());
+    }
+}
+
+// SGR reverse-video for the selection, matching the other tabs' convention.
+const reverse = "\x1b[7m";
+
+/// One list row (after the dot): the name, the runtime state, the auto-start
+/// hint, then the owning keg. ASCII columns, grapheme-naive like the rest.
+fn formatRow(buf: []u8, s: Row) []const u8 {
+    var len: usize = 0;
+    appendPad(buf, &len, s.name, 24);
+    append(buf, &len, " ");
+    appendPad(buf, &len, s.state, 12);
+    append(buf, &len, " ");
+    appendPad(buf, &len, if (s.auto_start) "auto" else "manual", 8);
+    append(buf, &len, s.keg_name);
+    return buf[0..len];
+}
+
+fn append(buf: []u8, len: *usize, s: []const u8) void {
+    const n = @min(s.len, buf.len - len.*);
+    @memcpy(buf[len.*..][0..n], s[0..n]);
+    len.* += n;
+}
+
+fn appendPad(buf: []u8, len: *usize, s: []const u8, width: usize) void {
+    append(buf, len, s);
+    var i = s.len;
+    while (i < width) : (i += 1) append(buf, len, " ");
+}
+
+// ─── tests ───────────────────────────────────────────────────────────
+
+fn ch(c: u8) tab.Key {
+    return .{ .char = .{ .bytes = .{ c, 0, 0, 0 }, .len = 1 } };
+}
+
+const sample = [_]Row{
+    .{ .name = "redis", .state = "running", .auto_start = true, .keg_name = "redis" },
+    .{ .name = "postgresql", .state = "stopped", .auto_start = false, .keg_name = "postgresql@16" },
+    .{ .name = "dnsmasq", .state = "not-loaded", .auto_start = true, .keg_name = "dnsmasq" },
+    .{ .name = "weird", .state = "degraded", .auto_start = false, .keg_name = "weird" },
+};
+
+test "matches is a case-insensitive substring; empty filter matches all" {
+    try testing.expect(matches("redis", ""));
+    try testing.expect(matches("Redis", "red"));
+    try testing.expect(!matches("redis", "zzz"));
+}
+
+test "s requests start, x and X request stop, r requests restart" {
+    var s: State = .{ .items = &sample };
+    step(&s, ch('s'));
+    try testing.expectEqual(Request.start, s.request);
+    step(&s, ch('x'));
+    try testing.expectEqual(Request.stop, s.request);
+    step(&s, ch('X'));
+    try testing.expectEqual(Request.stop, s.request);
+    step(&s, ch('r'));
+    try testing.expectEqual(Request.restart, s.request);
+}
+
+test "an unrelated key leaves the request alone" {
+    var s: State = .{ .items = &sample };
+    step(&s, ch('z'));
+    try testing.expectEqual(Request.none, s.request);
+    step(&s, .enter);
+    try testing.expectEqual(Request.none, s.request);
+}
+
+test "selectedService maps the cursor through the filter and clamps out-of-range" {
+    var s: State = .{ .items = &sample };
+    s.chrome.view.selected = 0;
+    try testing.expectEqualStrings("redis", selectedService(&s).?.name);
+
+    s.chrome.filter.push("d"); // redis, dnsmasq, weird (all contain 'd'; not postgresql)
+    s.chrome.view.selected = 0;
+    try testing.expectEqualStrings("redis", selectedService(&s).?.name);
+    s.chrome.view.selected = 99; // clamps to the last match
+    try testing.expectEqualStrings("weird", selectedService(&s).?.name);
+
+    s.chrome.filter.clear();
+    s.chrome.filter.push("zzz");
+    try testing.expect(selectedService(&s) == null);
+}
+
+test "selectedService on an empty list is null (the action becomes a no-op)" {
+    const s: State = .{ .items = &.{} };
+    try testing.expect(selectedService(&s) == null);
+}
+
+test "statusOf buckets known states and treats anything else as unknown" {
+    try testing.expectEqual(Status.running, statusOf("running"));
+    try testing.expectEqual(Status.stopped, statusOf("stopped"));
+    try testing.expectEqual(Status.stopped, statusOf("not-loaded"));
+    try testing.expectEqual(Status.unknown, statusOf("loaded"));
+    try testing.expectEqual(Status.unknown, statusOf("degraded"));
+    try testing.expectEqual(Status.unknown, statusOf(""));
+}
+
+test "render lists services with a state dot, the state, and the auto-start hint" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const s: State = .{ .items = &sample };
+    render(&s, &f, .{ .row = 2, .col = 1, .width = 80, .height = 12 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, "redis") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "running") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "auto") != null); // auto-start hint
+    try testing.expect(std.mem.indexOf(u8, out, "manual") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "●") != null); // running dot
+    try testing.expect(std.mem.indexOf(u8, out, color.Style.green.code()) != null); // coloured
+}
+
+test "render of an unusual state does not crash and uses the unknown dot" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    // Only the degraded (unknown) row, so the unknown glyph is unambiguous.
+    const only = [_]Row{sample[3]};
+    const s: State = .{ .items = &only };
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, "degraded") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "◌") != null); // unknown dot
+}
+
+test "render narrows to the filter" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    var s: State = .{ .items = &sample };
+    s.chrome.filter.push("redis");
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, "redis") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "postgresql") == null); // filtered out
+}
+
+test "render highlights the selected row" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    var s: State = .{ .items = &sample };
+    s.chrome.view.selected = 0;
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
+    try testing.expect(std.mem.indexOf(u8, f.slice(), reverse) != null);
+}
+
+test "render shows the lifecycle action line" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const s: State = .{ .items = &sample };
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, "start") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "restart") != null);
+}
+
+test "render reflows: the same state at two widths differs" {
+    var a: [8192]u8 = undefined;
+    var b: [8192]u8 = undefined;
+    var fa: tab.Frame = .{ .buf = &a };
+    var fb: tab.Frame = .{ .buf = &b };
+    const s: State = .{ .items = &sample };
+    render(&s, &fa, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
+    render(&s, &fb, .{ .row = 1, .col = 1, .width = 30, .height = 6 });
+    try testing.expect(!std.mem.eql(u8, fa.slice(), fb.slice()));
+}
+
+test "render on an empty list is a clean no-crash frame" {
+    var buf: [1024]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const s: State = .{ .items = &.{} };
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 }); // must not trap
+}
+
+test "render clamps to a height of one (action line only) without crashing" {
+    var buf: [1024]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const s: State = .{ .items = &sample };
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 1 }); // no list rows fit
+}
 
 test "conforms to the tab contract" {
     comptime tab.verify(@This());

--- a/src/tui/tab.zig
+++ b/src/tui/tab.zig
@@ -48,14 +48,17 @@ pub const Frame = struct {
         self.put(term.cursorMove(&tmp, row, col) catch return);
     }
 
-    /// Paint untrusted row content: drop line-breaking controls (LF/VT/FF/CR)
-    /// and turn TAB into a space, so a sanitized child row (where
-    /// `term_sanitize` lets `\n` through) cannot inject an extra frame line or
-    /// disturb column alignment. ESC and everything else pass through.
+    /// Paint untrusted row content as inert text: TAB becomes a space and every
+    /// C0 control byte — ESC included — plus DEL is dropped, so a child-derived
+    /// row can neither re-drive the cursor (ESC/CSI), set the window title (OSC),
+    /// inject an extra frame line (LF/CR/VT/FF), nor disturb column alignment
+    /// (TAB). Printable bytes and UTF-8 continuation bytes (≥ 0x80) pass through.
+    /// Every tab paints row content through here, so frame integrity is enforced
+    /// in this one choke point rather than trusted to each renderer.
     pub fn putContent(self: *Frame, bytes: []const u8) void {
         for (bytes) |b| switch (b) {
-            '\n', '\r', 0x0b, 0x0c => {}, // line breakers: drop
             '\t' => self.put(" "), // tab: collapse to one column
+            0x00...0x08, 0x0a...0x1f, 0x7f => {}, // C0 controls (incl. ESC), CR/LF, DEL: drop
             else => self.put(&[_]u8{b}),
         };
     }
@@ -63,7 +66,7 @@ pub const Frame = struct {
 
 /// Paint `rows` into `rect`: clamp the view to the height, take the visible
 /// window, position each row and paint it through `putContent`. The single
-/// place row content reaches the frame — so the newline defense lives here once.
+/// place row content reaches the frame — so the control-byte defense lives here once.
 pub fn paintRows(f: *Frame, rows: []const []const u8, view: scroll_list.View, rect: Rect) void {
     const v = scroll_list.clamp(view, rows.len, rect.height);
     const win = scroll_list.visible(rows, v, rect.height);
@@ -128,11 +131,23 @@ test "Frame.putContent strips line breakers and turns tab into a space" {
     try std.testing.expectEqualStrings("ab cde", f.slice());
 }
 
-test "putContent keeps an SGR escape intact (only line breakers are dropped)" {
+test "putContent drops an ESC so a child row cannot re-drive the cursor or set color" {
     var buf: [32]u8 = undefined;
     var f: Frame = .{ .buf = &buf };
-    f.putContent("\x1b[1mX\x1b[0m");
-    try std.testing.expectEqualStrings("\x1b[1mX\x1b[0m", f.slice());
+    f.putContent("\x1b[1mX\x1b[0m"); // an SGR a hostile package name might carry
+    try std.testing.expectEqualStrings("[1mX[0m", f.slice()); // ESC bytes gone; the remnant is inert text
+    try std.testing.expect(std.mem.indexOfScalar(u8, f.slice(), 0x1b) == null);
+}
+
+test "putContent strips the control introducers from a hostile row (OSC + BEL + erase)" {
+    var buf: [64]u8 = undefined;
+    var f: Frame = .{ .buf = &buf };
+    // An OSC title-set, a BEL, and an erase-display a hostile child name might carry.
+    f.putContent("x\x1b]0;pwn\x07y\x1b[2J");
+    const out = f.slice();
+    try std.testing.expect(std.mem.indexOfScalar(u8, out, 0x1b) == null); // no ESC → no CSI/OSC executes
+    try std.testing.expect(std.mem.indexOfScalar(u8, out, 0x07) == null); // BEL dropped
+    try std.testing.expect(std.mem.indexOf(u8, out, "x") != null and std.mem.indexOf(u8, out, "y") != null);
 }
 
 test "paintRows positions each row and a row's embedded newline never injects a frame line" {

--- a/tests/tui_services_test.zig
+++ b/tests/tui_services_test.zig
@@ -1,0 +1,93 @@
+//! malt — integration tests for the `mt tui` Services tab.
+//!
+//! Inline tests in the leaf modules cover the parse/render/step shapes against
+//! literal bytes; this file pins the assembled path against a **recorded**
+//! `mt services list --json` fixture (`scripts/fixtures/`), never live `mt` —
+//! proving the parser consumes the real versioned schema and that the selection
+//! plus a lifecycle key map to the exact `mt services <action> <name>` argv with
+//! the selected row's name.
+
+const std = @import("std");
+const testing = std.testing;
+
+const malt = @import("malt");
+const services_json = malt.tui_json_services;
+const services = malt.tui_tab_services;
+const test_io = @import("test_io");
+
+fn readFixture(allocator: std.mem.Allocator, name: []const u8) ![]u8 {
+    const io = std.Options.debug_io;
+    var dir = try test_io.cwd().openDir(io, "scripts/fixtures", .{});
+    defer dir.close(io);
+    const file = try dir.openFile(io, name, .{});
+    defer file.close(io);
+    const stat = try file.stat(io);
+    const buf = try allocator.alloc(u8, @intCast(stat.size));
+    errdefer allocator.free(buf);
+    _ = try file.readPositionalAll(io, buf, 0);
+    return buf;
+}
+
+test "services parser consumes the recorded mt services list --json fixture" {
+    const bytes = try readFixture(testing.allocator, "tui_services.json");
+    defer testing.allocator.free(bytes);
+
+    var parsed = try services_json.parse(testing.allocator, bytes);
+    defer parsed.deinit();
+
+    try testing.expectEqual(@as(usize, 4), parsed.items.len);
+
+    // A running, auto-start service carries its keg through.
+    const redis = parsed.items[0];
+    try testing.expectEqualStrings("redis", redis.name);
+    try testing.expectEqualStrings("running", redis.state);
+    try testing.expectEqual(true, redis.auto_start);
+    try testing.expectEqualStrings("redis", redis.keg_name);
+
+    // A stopped, manual service.
+    const pg = parsed.items[1];
+    try testing.expectEqualStrings("postgresql@16", pg.name);
+    try testing.expectEqualStrings("stopped", pg.state);
+    try testing.expectEqual(false, pg.auto_start);
+
+    // An unusual runtime state parses verbatim — no enum to break against.
+    const unbound = parsed.items[3];
+    try testing.expectEqualStrings("unbound", unbound.name);
+    try testing.expectEqualStrings("degraded", unbound.state);
+}
+
+test "a lifecycle key over the fixture targets the selected service" {
+    const bytes = try readFixture(testing.allocator, "tui_services.json");
+    defer testing.allocator.free(bytes);
+    var parsed = try services_json.parse(testing.allocator, bytes);
+    defer parsed.deinit();
+
+    var st: services.State = .{ .items = parsed.items };
+
+    // Cursor on dnsmasq (index 2); `r` requests a restart of exactly that row.
+    st.chrome.view.selected = 2;
+    services.step(&st, .{ .char = .{ .bytes = .{ 'r', 0, 0, 0 }, .len = 1 } });
+    try testing.expectEqual(services.Request.restart, st.request);
+    try testing.expectEqualStrings("dnsmasq", services.selectedService(&st).?.name);
+
+    // `s` on postgresql@16 requests a start of that row — the argv `mt services`
+    // would receive is `start postgresql@16`.
+    st.chrome.view.selected = 1;
+    services.step(&st, .{ .char = .{ .bytes = .{ 's', 0, 0, 0 }, .len = 1 } });
+    try testing.expectEqual(services.Request.start, st.request);
+    try testing.expectEqualStrings("postgresql@16", services.selectedService(&st).?.name);
+}
+
+test "a filter narrows the lifecycle target to a matching service" {
+    const bytes = try readFixture(testing.allocator, "tui_services.json");
+    defer testing.allocator.free(bytes);
+    var parsed = try services_json.parse(testing.allocator, bytes);
+    defer parsed.deinit();
+
+    var st: services.State = .{ .items = parsed.items };
+    st.chrome.filter.push("postgres"); // only postgresql@16 matches
+    st.chrome.view.selected = 0;
+    services.step(&st, .{ .char = .{ .bytes = .{ 'x', 0, 0, 0 }, .len = 1 } });
+    try testing.expectEqual(services.Request.stop, st.request);
+    try testing.expectEqualStrings("postgresql@16", services.selectedService(&st).?.name);
+}


### PR DESCRIPTION
## Description

Adds the Services tab to `mt tui`: one live pane over `mt services list --json` with a running/stopped status dot and an auto-start hint per service, narrowable with the filter. Keys `s`, `x`/`X`, and `r` start, stop, and restart the selected service by delegating to the real `mt services` subcommand; the pane then refreshes. This turns what is six separate CLI subcommands into a single glanceable, actionable view.

## Related Issue

- None

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 11 of 19 in a stack** made with GitButler:
- <kbd>&nbsp;19&nbsp;</kbd> #464
- <kbd>&nbsp;18&nbsp;</kbd> #463
- <kbd>&nbsp;17&nbsp;</kbd> #462
- <kbd>&nbsp;16&nbsp;</kbd> #461
- <kbd>&nbsp;15&nbsp;</kbd> #459
- <kbd>&nbsp;14&nbsp;</kbd> #458
- <kbd>&nbsp;13&nbsp;</kbd> #457
- <kbd>&nbsp;12&nbsp;</kbd> #456
- <kbd>&nbsp;11&nbsp;</kbd> #455
- <kbd>&nbsp;10&nbsp;</kbd> #454
- <kbd>&nbsp;9&nbsp;</kbd> #453 👈 
- <kbd>&nbsp;8&nbsp;</kbd> #451
- <kbd>&nbsp;7&nbsp;</kbd> #450
- <kbd>&nbsp;6&nbsp;</kbd> #448
- <kbd>&nbsp;5&nbsp;</kbd> #447
- <kbd>&nbsp;4&nbsp;</kbd> #446
- <kbd>&nbsp;3&nbsp;</kbd> #445
- <kbd>&nbsp;2&nbsp;</kbd> #444
- <kbd>&nbsp;1&nbsp;</kbd> #443
<!-- GitButler Footer Boundary Bottom -->