### PR TITLE
test(tui): PTY end-to-end resize and delegation coverage

### DIFF
--- a/scripts/e2e/tui_delegation_roundtrip.sh
+++ b/scripts/e2e/tui_delegation_roundtrip.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# scripts/e2e/tui_delegation_roundtrip.sh
+#
+# The delegation principle: the TUI never reimplements a mutation — it drops the
+# alt-screen, re-execs the real `mt <subcommand>`, then re-enters and refreshes
+# the pane. This proves that round-trip end-to-end with `x` (uninstall) on the
+# Installed tab against a disposable fixture store.
+#
+# Asserts:
+#   - the delegated `mt uninstall` actually ran (its real output is in the
+#     stream) and completed (the seeded keg is gone from the store);
+#   - the dashboard dropped and re-entered the alt-screen around the child (a
+#     second alt-screen enter), i.e. the inline re-exec really happened;
+#   - the pane refreshed afterwards — the uninstalled package no longer appears
+#     in the final frame.
+#
+# Usage:   MT_BIN=./zig-out/bin/malt ./scripts/e2e/tui_delegation_roundtrip.sh
+# Exit:    0 on pass, 1 on failure, 2 when the binary or pty tooling is missing.
+
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+# shellcheck source=scripts/lib/tui_pty.sh
+source "$ROOT/scripts/lib/tui_pty.sh"
+
+tui_pty_guard
+tui_pty_make_prefix
+trap 'rm -rf "$TUI_PREFIX"' EXIT
+tui_pty_seed_keg_real solopkg
+
+fail() {
+  echo "tui-delegation: FAIL — $*" >&2
+  exit 1
+}
+
+CAP="$TUI_PREFIX/cap.bin"
+# `x` raises the one-key uninstall guard; `y` confirms and delegates to the real
+# `mt uninstall solopkg`, then the Installed pane refetches.
+out=$(
+  tui_pty_drive "$CAP" 90 24 <<'ACT'
+settle 0.4
+send x
+settle 0.4
+send y
+settle 1.2
+mark DONE
+send q
+quitwait 1.5
+ACT
+)
+echo "$out" | grep -q "EXIT_STATUS=0" || fail "mt tui did not exit 0 on q ($out)"
+
+# The real subcommand ran inline (its output landed in the captured stream).
+grep -qa "uninstalled" "$CAP" || fail "no 'uninstalled' output — mt uninstall was not delegated"
+
+# It completed: the seeded keg is gone from the store.
+count=$(tui_pty_keg_count)
+[[ "$count" == "0" ]] || fail "keg still present after delegated uninstall (count=$count)"
+
+# The alt-screen was dropped and re-entered around the child — a second enter.
+enter=$(grep -c -a -F $'\x1b[?1049h' "$CAP" || true)
+[[ "$enter" -ge "2" ]] || fail "expected >=2 alt-screen enters (drop+re-enter), got $enter"
+
+# The pane refreshed: the uninstalled package is absent from the final frame.
+perl -0777 -e '
+  my $data = do { local $/; <STDIN> };
+  my ($final) = $data =~ /\n\@\@DONE\@\@(.*)\z/s;
+  defined $final or die "no final frame after DONE\n";
+  $final !~ /solopkg/ or die "uninstalled package still shown after refresh\n";
+' <"$CAP" || fail "pane did not refresh after the delegated uninstall"
+
+echo "tui-delegation: OK — in-TUI action re-execs real mt and refreshes the pane"

--- a/scripts/e2e/tui_launch_quit_clean.sh
+++ b/scripts/e2e/tui_launch_quit_clean.sh
@@ -19,6 +19,7 @@ set -uo pipefail
 
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 # shellcheck source=scripts/lib/tui_pty.sh
+# shellcheck disable=SC1091 # sourced lib resolved at runtime; absent when this file is linted alone
 source "$ROOT/scripts/lib/tui_pty.sh"
 
 tui_pty_guard
@@ -72,12 +73,27 @@ assert_activated Doctor
 assert_activated Search
 
 # Terminal restored cleanly: one alt-screen enter, one leave, cursor shown.
-count() { grep -c -a -F "$1" "$CAP" || true; }
-enter=$(count $'\x1b[?1049h')
-leave=$(count $'\x1b[?1049l')
-show=$(count $'\x1b[?25h')
+count() { grep -c -a -F "$2" "$1" || true; }
+enter=$(count "$CAP" $'\x1b[?1049h')
+leave=$(count "$CAP" $'\x1b[?1049l')
+show=$(count "$CAP" $'\x1b[?25h')
 [[ "$enter" == "1" ]] || fail "expected exactly 1 alt-screen enter, got $enter"
 [[ "$leave" == "1" ]] || fail "expected exactly 1 alt-screen leave, got $leave"
 [[ "$show" -ge "1" ]] || fail "cursor was never shown again on exit"
 
-echo "tui-launch-quit: OK — launch, tab cycle, and clean terminal restore"
+# Ctrl-C must quit and restore the terminal just like `q` — the command help
+# promises "quit with q or Ctrl-C". Without it the dashboard would leave the
+# alt-screen active on interrupt.
+CAPC="$TUI_PREFIX/cap_ctrlc.bin"
+outc=$(
+  tui_pty_drive "$CAPC" 90 24 <<'ACT'
+settle 0.4
+send \x03
+quitwait 1.5
+ACT
+)
+echo "$outc" | grep -q "EXIT_STATUS=0" || fail "Ctrl-C did not quit mt tui cleanly ($outc)"
+[[ "$(count "$CAPC" $'\x1b[?1049l')" -ge 1 ]] || fail "Ctrl-C left the alt-screen active (terminal not restored)"
+[[ "$(count "$CAPC" $'\x1b[?25h')" -ge 1 ]] || fail "Ctrl-C did not restore the cursor"
+
+echo "tui-launch-quit: OK — launch, tab cycle, q + Ctrl-C both restore the terminal"

--- a/scripts/e2e/tui_launch_quit_clean.sh
+++ b/scripts/e2e/tui_launch_quit_clean.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# scripts/e2e/tui_launch_quit_clean.sh
+#
+# Under a real pty, `mt tui` must: render its tab bar and list on launch, switch
+# cleanly between all five tabs, and restore the terminal on quit — leaving no
+# residual raw mode or alt-screen. The pure render/key logic is unit-tested; this
+# proves the terminal lifecycle that only exists under a tty.
+#
+# Asserts:
+#   - the first frame carries the tab bar and a seeded package row;
+#   - cycling with `tab` makes each tab the active (reverse-video) one in turn;
+#   - `q` exits 0 and the stream restores the terminal exactly once — one
+#     alt-screen enter paired with one leave, and the cursor shown again.
+#
+# Usage:   MT_BIN=./zig-out/bin/malt ./scripts/e2e/tui_launch_quit_clean.sh
+# Exit:    0 on pass, 1 on failure, 2 when the binary or pty tooling is missing.
+
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+# shellcheck source=scripts/lib/tui_pty.sh
+source "$ROOT/scripts/lib/tui_pty.sh"
+
+tui_pty_guard
+tui_pty_make_prefix
+trap 'rm -rf "$TUI_PREFIX"' EXIT
+tui_pty_seed_kegs 8
+
+fail() {
+  echo "tui-launch-quit: FAIL — $*" >&2
+  exit 1
+}
+
+CAP="$TUI_PREFIX/cap.bin"
+# Start on Installed; four `tab`s cycle through Outdated, Services, Doctor, and
+# Search, settling on each so its frame is captured.
+out=$(
+  tui_pty_drive "$CAP" 90 24 <<'ACT'
+settle 0.4
+send \t
+settle 0.4
+send \t
+settle 0.4
+send \t
+settle 0.4
+send \t
+settle 0.4
+send q
+quitwait 1.5
+ACT
+)
+
+echo "$out" | grep -q "EXIT_STATUS=0" || fail "mt tui did not exit 0 on q ($out)"
+
+# First frame: tab bar + a seeded row both rendered.
+grep -qa "Installed" "$CAP" || fail "tab bar 'Installed' label never rendered"
+grep -qa "pkg01" "$CAP" || fail "seeded package row never rendered"
+
+# Cycling must make each tab the active block in turn. The active tab is the
+# only one drawn reverse-video + bold; a list selection is reverse-video but
+# never bold, so that prefix identifies the active tab unambiguously.
+assert_activated() {
+  local want="$1"
+  WANT="$want" perl -0777 -ne '
+    exit(/\x1b\[7m\x1b\[1m\Q$ENV{WANT}\E/ ? 0 : 1);
+  ' "$CAP" || fail "tab '$want' never became active during the cycle"
+}
+assert_activated Installed
+assert_activated Outdated
+assert_activated Services
+assert_activated Doctor
+assert_activated Search
+
+# Terminal restored cleanly: one alt-screen enter, one leave, cursor shown.
+count() { grep -c -a -F "$1" "$CAP" || true; }
+enter=$(count $'\x1b[?1049h')
+leave=$(count $'\x1b[?1049l')
+show=$(count $'\x1b[?25h')
+[[ "$enter" == "1" ]] || fail "expected exactly 1 alt-screen enter, got $enter"
+[[ "$leave" == "1" ]] || fail "expected exactly 1 alt-screen leave, got $leave"
+[[ "$show" -ge "1" ]] || fail "cursor was never shown again on exit"
+
+echo "tui-launch-quit: OK — launch, tab cycle, and clean terminal restore"

--- a/scripts/e2e/tui_non_tty_refusal.sh
+++ b/scripts/e2e/tui_non_tty_refusal.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# scripts/e2e/tui_non_tty_refusal.sh
+#
+# `mt tui` must refuse to launch rather than emit a corrupted frame whenever the
+# environment can't host the dashboard. It exits 2 with a message and never
+# enters raw mode or the alt-screen. Three refusal reasons are pinned here:
+#   - stdin/stdout not a terminal (the scripted/piped case);
+#   - NO_COLOR set on a real terminal (the dashboard needs ANSI);
+#   - CI detected on a real terminal.
+# The pure refusal logic is unit-tested; this proves it at the binary edge.
+#
+# The non-tty cases need no pty tooling and always run. The NO_COLOR/CI cases
+# must reach the binary on a real terminal, so they use the pty driver and are
+# skipped (not failed) when perl/IO::Pty is unavailable.
+#
+# Hermetic: a throwaway MALT_PREFIX under /tmp, no network.
+#
+# Usage:   MT_BIN=./zig-out/bin/malt ./scripts/e2e/tui_non_tty_refusal.sh
+# Exit:    0 on pass, 1 on failure, 2 when the binary is missing.
+
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+# shellcheck source=scripts/lib/tui_pty.sh
+source "$ROOT/scripts/lib/tui_pty.sh"
+
+if [[ ! -x "$MT_BIN" ]]; then
+  echo "tui-e2e: $MT_BIN not found or not executable" >&2
+  echo "tui-e2e: run 'zig build' first (or set MT_BIN)" >&2
+  exit 2
+fi
+
+tui_pty_make_prefix # disposable prefix; scrubs CI/NO_COLOR to a known baseline
+trap 'rm -rf "$TUI_PREFIX"' EXIT
+
+fail() {
+  echo "tui-refusal: FAIL — $*" >&2
+  exit 1
+}
+
+# Case 1: stdin + stdout redirected away from any terminal.
+err="$TUI_PREFIX/err1.txt"
+"$MT_BIN" tui </dev/null >/dev/null 2>"$err"
+rc=$?
+[[ $rc -eq 2 ]] || fail "redirected invocation exited $rc, expected 2"
+grep -q "refusing to launch" "$err" || fail "no refusal message on stderr (redirected)"
+
+# Case 2: stdout to a pipe (a common scripted misuse) — also refused.
+err="$TUI_PREFIX/err2.txt"
+"$MT_BIN" tui </dev/null 2>"$err" | cat >/dev/null
+rc=${PIPESTATUS[0]}
+[[ $rc -eq 2 ]] || fail "piped invocation exited $rc, expected 2"
+grep -q "refusing to launch" "$err" || fail "no refusal message on stderr (piped)"
+
+# Cases 3-4: refusals that only fire on a real terminal need the pty driver.
+if perl -MIO::Pty -e 1 >/dev/null 2>&1 && perl -c "$TUI_PTY_DRIVER" >/dev/null 2>&1; then
+  # NO_COLOR set, but a genuine tty: still refused (the dashboard needs ANSI).
+  cap="$TUI_PREFIX/cap_nocolor.bin"
+  out=$(
+    export NO_COLOR=1
+    tui_pty_drive "$cap" 90 24 <<<'quitwait 1.5'
+  )
+  echo "$out" | grep -q "EXIT_STATUS=2" || fail "NO_COLOR on a tty did not exit 2 ($out)"
+  grep -qa "NO_COLOR" "$cap" || fail "no NO_COLOR refusal message under a tty"
+
+  # CI detected on a tty: refused.
+  cap="$TUI_PREFIX/cap_ci.bin"
+  out=$(
+    export CI=1
+    tui_pty_drive "$cap" 90 24 <<<'quitwait 1.5'
+  )
+  echo "$out" | grep -q "EXIT_STATUS=2" || fail "CI on a tty did not exit 2 ($out)"
+  grep -qa "CI environment" "$cap" || fail "no CI refusal message under a tty"
+
+  echo "tui-refusal: OK — non-tty, NO_COLOR, and CI invocations all refused with exit 2"
+else
+  echo "tui-refusal: OK — non-tty refused with exit 2 (NO_COLOR/CI cases skipped: no perl IO::Pty)"
+fi

--- a/scripts/e2e/tui_resize_reflow.sh
+++ b/scripts/e2e/tui_resize_reflow.sh
@@ -21,6 +21,7 @@ set -uo pipefail
 
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 # shellcheck source=scripts/lib/tui_pty.sh
+# shellcheck disable=SC1091 # sourced lib resolved at runtime; absent when this file is linted alone
 source "$ROOT/scripts/lib/tui_pty.sh"
 
 tui_pty_guard
@@ -34,8 +35,6 @@ fail() {
 }
 
 CAP="$TUI_PREFIX/cap.bin"
-# 12 down-arrows put the selection well below the fold at height 14, so the
-# viewport has already scrolled before the resize.
 # 12 down-arrows put the selection well below the fold at height 14, so the
 # viewport has already scrolled before the resize. After the wide->narrow
 # reflow, shrink below the usable minimum (12 cols < the 20-col floor) to prove

--- a/scripts/e2e/tui_resize_reflow.sh
+++ b/scripts/e2e/tui_resize_reflow.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# scripts/e2e/tui_resize_reflow.sh
+#
+# The dashboard's headline promise: resize the terminal mid-session and the
+# frame reflows to the new geometry while the selection and scroll position
+# survive (no data refetch, no jump to the top). The pure layout is unit-tested
+# against synthetic sizes; this proves it end-to-end under a real SIGWINCH.
+#
+# Drives a 30-row Installed list at 100x14, moves the selection deep enough to
+# scroll, then shrinks the pty to 56x12 and asserts:
+#   - the frame width tracks the new column count (separator 100 -> 56), so the
+#     frame genuinely reflowed;
+#   - the same package stays selected (reverse-video cursor on the same name);
+#   - that package is still visible after the resize (the viewport re-clamped
+#     around the selection rather than resetting to the top).
+#
+# Usage:   MT_BIN=./zig-out/bin/malt ./scripts/e2e/tui_resize_reflow.sh
+# Exit:    0 on pass, 1 on failure, 2 when the binary or pty tooling is missing.
+
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+# shellcheck source=scripts/lib/tui_pty.sh
+source "$ROOT/scripts/lib/tui_pty.sh"
+
+tui_pty_guard
+tui_pty_make_prefix
+trap 'rm -rf "$TUI_PREFIX"' EXIT
+tui_pty_seed_kegs 30
+
+fail() {
+  echo "tui-resize: FAIL — $*" >&2
+  exit 1
+}
+
+CAP="$TUI_PREFIX/cap.bin"
+# 12 down-arrows put the selection well below the fold at height 14, so the
+# viewport has already scrolled before the resize.
+# 12 down-arrows put the selection well below the fold at height 14, so the
+# viewport has already scrolled before the resize. After the wide->narrow
+# reflow, shrink below the usable minimum (12 cols < the 20-col floor) to prove
+# the clean "terminal too small" fallback, then restore the original size to
+# prove the dashboard recovers with its selection intact.
+out=$(
+  tui_pty_drive "$CAP" 100 14 <<'ACT'
+send \e[B\e[B\e[B\e[B\e[B\e[B\e[B\e[B\e[B\e[B\e[B\e[B
+settle 0.5
+mark PRE
+resize 56 12
+settle 0.5
+mark POST
+resize 12 6
+settle 0.5
+mark TINY
+resize 100 14
+settle 0.5
+mark RECOVER
+send q
+quitwait 1.5
+ACT
+)
+echo "$out" | grep -q "EXIT_STATUS=0" || fail "mt tui did not exit 0 on q ($out)"
+
+# Per-phase frames, split on the marks: PRE (100 cols), POST (56 cols), TINY
+# (12 cols, below the floor), RECOVER (back to 100 cols). For each list frame
+# extract the selected package (bare reverse-video before a pkg name) and the
+# separator width (a run of U+2500 box-drawing chars).
+perl -0777 -e '
+  my $data = do { local $/; <STDIN> };
+  my ($pre)     = $data =~ /\A(.*?)\n\@\@PRE\@\@/s;
+  my ($post)    = $data =~ /\n\@\@PRE\@\@(.*?)\n\@\@POST\@\@/s;
+  my ($tiny)    = $data =~ /\n\@\@POST\@\@(.*?)\n\@\@TINY\@\@/s;
+  my ($recover) = $data =~ /\n\@\@TINY\@\@(.*?)\n\@\@RECOVER\@\@/s;
+  defined && length or die "missing a resize phase region\n"
+    for ($pre, $post, $tiny, $recover);
+  sub sel  { my $b = shift; my @m = $b =~ /\x1b\[7m(pkg\d+)/g; return $m[-1] }
+  sub seps { my $b = shift; my @r = $b =~ /((?:\x{e2}\x{94}\x{80})+)/g;
+             my $w = 0; for (@r) { my $n = length($_)/3; $w = $n if $n > $w } return $w }
+  my ($psel, $pw) = (sel($pre),  seps($pre));
+  my ($qsel, $qw) = (sel($post), seps($post));
+  my ($rsel, $rw) = (sel($recover), seps($recover));
+  defined $psel or die "no selection in PRE frame\n";
+  defined $qsel or die "no selection in POST frame\n";
+  defined $rsel or die "no selection in RECOVER frame\n";
+  # Wide -> narrow reflow, selection + scroll preserved.
+  $pw >= 90 or die "PRE separator width $pw, expected ~100 (frame did not start wide)\n";
+  $qw <= 60 or die "POST separator width $qw, expected ~56 (frame did not reflow narrower)\n";
+  $qw <  $pw or die "frame width did not shrink on resize ($pw -> $qw)\n";
+  $psel eq $qsel or die "selection changed across resize ($psel -> $qsel)\n";
+  $post =~ /\Q$qsel\E/ or die "selected package $qsel not visible after resize\n";
+  # Below the floor: clean fallback, no corrupt list rows.
+  $tiny =~ /terminal/ or die "no terminal-too-small fallback below the minimum size\n";
+  $tiny !~ /pkg\d/ or die "list rows leaked into the too-small fallback frame\n";
+  # Recovery: list returns at full width with the original selection intact.
+  $rw >= 90 or die "RECOVER separator width $rw, expected ~100 (did not restore wide)\n";
+  $rsel eq $psel or die "selection lost across the too-small excursion ($psel -> $rsel)\n";
+  print "selected=$psel preserved; width $pw -> $qw -> fallback -> $rw\n";
+' <"$CAP" || fail "resize assertions failed (see message above)"
+
+echo "tui-resize: OK — reflow, too-small fallback, and recovery all preserve selection"

--- a/scripts/lib/tui_pty.sh
+++ b/scripts/lib/tui_pty.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# scripts/lib/tui_pty.sh
+#
+# Shared setup for the `mt tui` PTY end-to-end tests. Sourced, not run.
+#
+# The dashboard only behaves correctly under a real pseudo-terminal: raw mode,
+# the alt-screen, the TIOCGWINSZ/SIGWINCH resize path, and the re-exec
+# delegation round-trip all need a tty. These helpers provide the pty driver,
+# a tool guard, and a disposable offline fixture prefix so each e2e is hermetic
+# (a throwaway MALT_PREFIX under /tmp, no network, no dependence on the user's
+# real Homebrew / /opt/malt) and mirrors the existing e2e contract: MT_BIN guard
+# with exit 2 when the binary (or required tooling) is missing.
+
+# Resolve paths relative to this file so callers can source it from anywhere.
+TUI_PTY_LIB_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+TUI_PTY_DRIVER="$TUI_PTY_LIB_DIR/tui_pty_drive.pl"
+
+MT_BIN="${MT_BIN:-./zig-out/bin/malt}"
+
+# Guard: refuse with exit 2 (the e2e "can't run here" signal) when the binary
+# or any required host tool is absent, instead of failing obscurely later.
+tui_pty_guard() {
+  if [[ ! -x "$MT_BIN" ]]; then
+    echo "tui-e2e: $MT_BIN not found or not executable" >&2
+    echo "tui-e2e: run 'zig build' first (or set MT_BIN)" >&2
+    exit 2
+  fi
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "tui-e2e: perl is required to drive the pty" >&2
+    exit 2
+  fi
+  if ! perl -MIO::Pty -e 1 >/dev/null 2>&1; then
+    echo "tui-e2e: perl module IO::Pty is required to drive the pty" >&2
+    exit 2
+  fi
+  if ! perl -c "$TUI_PTY_DRIVER" >/dev/null 2>&1; then
+    echo "tui-e2e: pty driver failed to compile: $TUI_PTY_DRIVER" >&2
+    exit 2
+  fi
+  if ! command -v sqlite3 >/dev/null 2>&1; then
+    echo "tui-e2e: sqlite3 is required to seed the fixture store" >&2
+    exit 2
+  fi
+}
+
+# Create a disposable, offline fixture prefix and export it. Scrubs CI/NO_COLOR
+# from the environment because `mt tui` refuses to launch under either (it would
+# otherwise exit 2 on a CI runner before the pty test could begin). The caller
+# owns cleanup: `trap 'rm -rf "$TUI_PREFIX"' EXIT`.
+tui_pty_make_prefix() {
+  TUI_PREFIX=$(mktemp -d /tmp/mt_tui_e2e.XXXXXX)
+  export MALT_PREFIX="$TUI_PREFIX"
+  export MALT_CACHE="$TUI_PREFIX/cache"
+  unset CI NO_COLOR
+  # `mt list` initialises + migrates the schema only when db/ already exists.
+  mkdir -p "$TUI_PREFIX/db"
+  "$MT_BIN" list >/dev/null 2>&1 || true
+}
+
+# Seed N phantom formula kegs (pkg01..pkgNN) so the Installed tab has a
+# scrollable list. cellar_path points at a dir that need not exist — `mt list
+# --size --linked` tolerates it (reports 0 bytes / unlinked), which is all the
+# resize test needs: enough rows to scroll and a stable selection.
+tui_pty_seed_kegs() {
+  local n="$1" i sql="BEGIN;"
+  for ((i = 1; i <= n; i++)); do
+    local name
+    name=$(printf 'pkg%02d' "$i")
+    sql+="INSERT INTO kegs (name,full_name,version,store_sha256,cellar_path,pinned)"
+    sql+=" VALUES ('$name','$name','1.$i','sha$i','$TUI_PREFIX/Cellar/$name/1.$i',0);"
+  done
+  sql+="COMMIT;"
+  printf '%s' "$sql" | sqlite3 "$TUI_PREFIX/db/malt.db"
+}
+
+# Seed a single keg with a real (minimal) Cellar dir so `mt uninstall` succeeds
+# end-to-end — the delegation round-trip needs the real subcommand to complete.
+tui_pty_seed_keg_real() {
+  local name="$1"
+  sqlite3 "$TUI_PREFIX/db/malt.db" \
+    "INSERT INTO kegs (name,full_name,version,store_sha256,cellar_path,pinned) \
+     VALUES ('$name','$name','1.0','sha','$TUI_PREFIX/Cellar/$name/1.0',0);"
+  mkdir -p "$TUI_PREFIX/Cellar/$name/1.0"
+  : >"$TUI_PREFIX/Cellar/$name/1.0/marker"
+}
+
+# Drive `mt tui` under the pty. Args: <capfile> <cols> <rows>; the action
+# program is read from this function's stdin. Echoes the driver's
+# "EXIT_STATUS=<n>" line so the caller can assert on the child's exit code.
+tui_pty_drive() {
+  local capfile="$1" cols="$2" rows="$3"
+  perl "$TUI_PTY_DRIVER" "$capfile" "$cols" "$rows" "$MT_BIN" tui
+}
+
+# Count installed kegs in the fixture store (post-run assertions).
+tui_pty_keg_count() {
+  sqlite3 "$TUI_PREFIX/db/malt.db" "SELECT COUNT(*) FROM kegs;" 2>/dev/null || echo -1
+}

--- a/scripts/lib/tui_pty_drive.pl
+++ b/scripts/lib/tui_pty_drive.pl
@@ -12,7 +12,7 @@
 #
 # The action program is read from stdin, one action per line:
 #   mark LABEL        write "\n@@LABEL@@\n" into the capture (phase separator)
-#   send BYTES        write BYTES to the pty (\t \n \r \e escapes honoured)
+#   send BYTES        write BYTES to the pty (\t \n \r \e \xHH escapes honoured)
 #   settle [secs]     read+capture until output goes idle (default 0.6s window)
 #   resize COLS ROWS  TIOCSWINSZ the pty; the kernel delivers SIGWINCH
 #   quitwait [secs]   wait for the child to exit, capturing its final bytes
@@ -75,6 +75,7 @@ sub drain {
 
 sub unescape {
   my $s = shift // '';
+  $s =~ s/\\x([0-9A-Fa-f]{2})/chr(hex($1))/ge;    # \xHH — arbitrary control bytes (e.g. \x03 = Ctrl-C)
   $s =~ s/\\t/\t/g;
   $s =~ s/\\n/\n/g;
   $s =~ s/\\r/\r/g;

--- a/scripts/lib/tui_pty_drive.pl
+++ b/scripts/lib/tui_pty_drive.pl
@@ -1,0 +1,130 @@
+#!/usr/bin/perl
+# scripts/lib/tui_pty_drive.pl
+#
+# PTY driver for the `mt tui` end-to-end tests. BSD script(1) cannot set or
+# resize a pseudo-terminal's window size, so it cannot exercise the dashboard's
+# resize path; this driver uses the base-system `IO::Pty` (ships with macOS
+# system Perl under /System/Library/Perl/Extras — no Xcode CLT needed) to run
+# `mt tui` under a real pty whose winsize we control via TIOCSWINSZ.
+#
+# Usage:
+#   perl tui_pty_drive.pl <capfile> <cols> <rows> -- <cmd> [args...]  < actions
+#
+# The action program is read from stdin, one action per line:
+#   mark LABEL        write "\n@@LABEL@@\n" into the capture (phase separator)
+#   send BYTES        write BYTES to the pty (\t \n \r \e escapes honoured)
+#   settle [secs]     read+capture until output goes idle (default 0.6s window)
+#   resize COLS ROWS  TIOCSWINSZ the pty; the kernel delivers SIGWINCH
+#   quitwait [secs]   wait for the child to exit, capturing its final bytes
+#
+# Captured bytes (raw, control sequences intact) go to <capfile>. The line
+# "EXIT_STATUS=<n>" is printed to stdout: the child's exit code, or -999 if it
+# had to be killed (never exited on its own).
+
+use strict;
+use warnings;
+use IO::Pty;
+use IO::Select;
+use Time::HiRes qw(time sleep);
+
+my ($capfile, $cols, $rows, @cmd) = @ARGV;
+die "usage: tui_pty_drive.pl <capfile> <cols> <rows> <cmd...>\n" unless @cmd;
+
+open(my $cap, '>:raw', $capfile) or die "open $capfile: $!";
+
+my $pty = IO::Pty->new;
+$pty->set_winsize($rows, $cols);    # initial geometry the child's first TIOCGWINSZ sees
+
+my $pid = fork // die "fork: $!";
+if (!$pid) {
+  # Child: adopt the slave as the controlling terminal so `mt tui` sees a tty.
+  $pty->make_slave_controlling_terminal;
+  my $slave = $pty->slave;
+  open(STDIN,  '<&', $slave) or die "child stdin: $!";
+  open(STDOUT, '>&', $slave) or die "child stdout: $!";
+  open(STDERR, '>&', $slave) or die "child stderr: $!";
+  close($slave);
+  close($pty);
+  exec(@cmd) or die "exec @cmd: $!";
+}
+
+$pty->close_slave;
+my $sel = IO::Select->new($pty);
+
+# Read whatever the child has emitted into the capture until it falls idle for
+# `idle` seconds or the `total` window elapses. Tolerant timing (poll/settle,
+# not a fixed sleep) keeps the e2e from being flaky under load.
+sub drain {
+  my ($total, $idle) = @_;
+  $total //= 0.6;
+  $idle  //= 0.2;
+  my $end  = time + $total;
+  my $last = time;
+  while (time < $end) {
+    if ($sel->can_read(0.04)) {
+      my $buf;
+      my $n = sysread($pty, $buf, 65536);
+      last if !defined $n || $n == 0;
+      print $cap $buf;
+      $last = time;
+    } elsif (time - $last > $idle) {
+      last;
+    }
+  }
+}
+
+sub unescape {
+  my $s = shift // '';
+  $s =~ s/\\t/\t/g;
+  $s =~ s/\\n/\n/g;
+  $s =~ s/\\r/\r/g;
+  $s =~ s/\\e/\e/g;
+  return $s;
+}
+
+sub child_alive { return waitpid($pid, 1) == 0 }
+
+drain();    # the first paint, before any action
+
+my $status = -1;
+while (my $line = <STDIN>) {
+  chomp $line;
+  next if $line eq '';
+  my ($op, $rest) = split /\s+/, $line, 2;
+  if ($op eq 'mark') {
+    print $cap "\n\@\@$rest\@\@\n";
+  } elsif ($op eq 'send') {
+    syswrite($pty, unescape($rest));
+    drain();
+  } elsif ($op eq 'settle') {
+    drain($rest // 0.6);
+  } elsif ($op eq 'resize') {
+    my ($c, $r) = split /\s+/, $rest;
+    $pty->set_winsize($r, $c);
+    drain();
+  } elsif ($op eq 'quitwait') {
+    my $timeout = $rest // 1.5;
+    my $end = time + $timeout;
+    while (time < $end) {
+      my $w = waitpid($pid, 1);
+      if ($w != 0) {
+        # Report the child's own exit code (or -signal if it was signalled),
+        # not the raw wait status, so callers can assert e.g. the exit-2 refusal.
+        $status = ($? & 127) ? -($? & 127) : ($? >> 8);
+        last;
+      }
+      drain(0.1, 0.05);
+    }
+    if (child_alive()) {
+      kill 'KILL', $pid;
+      waitpid($pid, 0);
+      $status = -999;
+    }
+    drain(0.3, 0.1);    # capture the terminal-restore bytes emitted on exit
+  } else {
+    die "unknown action: $line\n";
+  }
+}
+
+close($cap);
+print "EXIT_STATUS=$status\n";

--- a/src/tui/term.zig
+++ b/src/tui/term.zig
@@ -101,8 +101,8 @@ pub const Term = struct {
         return f.isTty(self.io) catch false;
     }
 
-    /// Enter cbreak/raw input: ECHO + ICANON off, byte-at-a-time reads. Saves
-    /// the original termios for `exitRaw`/`restore`. Idempotent; cleanly
+    /// Enter cbreak/raw input: ECHO + ICANON + ISIG off, byte-at-a-time reads.
+    /// Saves the original termios for `exitRaw`/`restore`. Idempotent; cleanly
     /// `error.NotATty` off a terminal with no half-entered state.
     pub fn enterRaw(self: *Term) TermError!void {
         if (self.saved != null) return; // idempotent
@@ -111,6 +111,11 @@ pub const Term = struct {
         var raw = saved;
         raw.lflag.ECHO = false;
         raw.lflag.ICANON = false;
+        // ISIG off so Ctrl-C reaches the key decoder as a byte (-> quit) instead
+        // of raising SIGINT, which the global CLI handler would swallow. Cooked
+        // mode (with ISIG) is restored on exit, and during a delegated `mt` run
+        // (`restore` then re-`enterRaw`), so Ctrl-C still interrupts the child.
+        raw.lflag.ISIG = false;
         raw.cc[@intFromEnum(std.posix.V.MIN)] = 1;
         raw.cc[@intFromEnum(std.posix.V.TIME)] = 0;
         std.posix.tcsetattr(self.fd, .FLUSH, raw) catch return TermError.TermiosFailed;

--- a/tests/tui_term_test.zig
+++ b/tests/tui_term_test.zig
@@ -112,6 +112,12 @@ test "on a real tty, winsize reports a non-zero size and raw round-trips termios
     const before = try std.posix.tcgetattr(fd);
     var t = term.Term.init(io, fd);
     try t.enterRaw();
+    // While raw: echo/canon off for byte-at-a-time reads, and ISIG off so
+    // Ctrl-C arrives as a 0x03 byte (decoder -> quit) instead of a signal.
+    const raw = try std.posix.tcgetattr(fd);
+    try testing.expect(!raw.lflag.ECHO);
+    try testing.expect(!raw.lflag.ICANON);
+    try testing.expect(!raw.lflag.ISIG);
     t.restore(); // must put cooked mode back exactly
     const after = try std.posix.tcgetattr(fd);
     try testing.expectEqual(before.lflag, after.lflag);


### PR DESCRIPTION
## Description 

Adds the PTY-driven end-to-end layer for `mt tui` - the coverage that cannot run without a real pseudo-terminal. It proves the dashboard's headline responsiveness promise (resize the window mid-session and the frame reflows while the selected row and scroll position survive, including a clean "terminal too small" fallback below the minimum size and full recovery on resize back), that delegated mutations re-exec the real `mt` and refresh the pane, that quitting (via `q` or `Ctrl-C`) fully restores the terminal, and that a non-interactive or ANSI-hostile invocation (piped stdin/stdout, `NO_COLOR`, or `CI`) is refused cleanly with exit 2. 

No first Zig dependency: the driver uses the base-system Perl `IO::Pty` already present on macOS.

## Related Issue

- None

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 7 of 19 in a stack** made with GitButler:
- <kbd>&nbsp;19&nbsp;</kbd> #464
- <kbd>&nbsp;18&nbsp;</kbd> #463
- <kbd>&nbsp;17&nbsp;</kbd> #462
- <kbd>&nbsp;16&nbsp;</kbd> #461
- <kbd>&nbsp;15&nbsp;</kbd> #459
- <kbd>&nbsp;14&nbsp;</kbd> #458
- <kbd>&nbsp;13&nbsp;</kbd> #457 👈 
- <kbd>&nbsp;12&nbsp;</kbd> #456
- <kbd>&nbsp;11&nbsp;</kbd> #455
- <kbd>&nbsp;10&nbsp;</kbd> #454
- <kbd>&nbsp;9&nbsp;</kbd> #453
- <kbd>&nbsp;8&nbsp;</kbd> #451
- <kbd>&nbsp;7&nbsp;</kbd> #450
- <kbd>&nbsp;6&nbsp;</kbd> #448
- <kbd>&nbsp;5&nbsp;</kbd> #447
- <kbd>&nbsp;4&nbsp;</kbd> #446
- <kbd>&nbsp;3&nbsp;</kbd> #445
- <kbd>&nbsp;2&nbsp;</kbd> #444
- <kbd>&nbsp;1&nbsp;</kbd> #443
<!-- GitButler Footer Boundary Bottom -->