### PR TITLE
fix(tui): first-pass dashboard usability fixes

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -371,13 +371,6 @@ pub fn main(init: std.process.Init.Minimal) !void {
     // step boundaries and clean up before exiting.
     signals.installHandler();
 
-    // Run terminal-background detection once, up front, before any
-    // output.* call can trigger a lazy OSC 11 probe mid-stream (the
-    // query write could otherwise land inside a progress-bar frame).
-    _ = color_mod.background();
-    _ = color_mod.truecolorSupported();
-    _ = color_mod.theme(); // resolve MALT_THEME once, before any TUI frame
-
     var arena = std.heap.ArenaAllocator.init(backing);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -420,6 +413,14 @@ pub fn main(init: std.process.Init.Minimal) !void {
     // never re-read the env so install/upgrade/migrate stay in lockstep.
     progress_mod.setMode(progress_mod.resolveModeFromEnviron(ctx.environ));
     color_mod.setRuntime(ctx.io, ctx.environ);
+
+    // Resolve the env-derived colour state once, now that the real environ is
+    // seeded — before any output (or TUI frame) reads it. Doing the OSC 11
+    // background probe up front keeps the query write out of a progress frame;
+    // resolving MALT_THEME / COLORTERM here is what lets the TUI theme apply.
+    _ = color_mod.background();
+    _ = color_mod.truecolorSupported();
+    _ = color_mod.theme();
 
     var args_it = try init.args.iterateAllocator(allocator);
     defer args_it.deinit();

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -640,7 +640,10 @@ fn loadDoctor(io: std.Io, allocator: std.mem.Allocator, app: *App, store: *Store
     errdefer |err| app.banner.set("doctor refresh failed", @errorName(err));
     const argv = try spawn.jsonArgv(allocator, app.mt_path, &.{"doctor"});
     defer allocator.free(argv);
-    const bytes = (try spawn.readJsonAllowEmpty(io, allocator, argv)) orelse {
+    // `mt doctor` exits non-zero by severity (1 warn / 2 err) while still
+    // emitting its findings JSON — exactly when the tab is most useful — so the
+    // doctor read tolerates those exits where the generic read would reject them.
+    const bytes = (try spawn.readDoctorJson(io, allocator, argv)) orelse {
         // Fresh prefix: no findings. Clear the rows.
         if (store.doctor) |old| old.deinit();
         store.doctor = null;

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -247,7 +247,13 @@ fn stepNormal(a: *App, key: Key) void {
             };
             routeToTab(a, key); // a domain key (e.g. u/f) belongs to the tab
         },
-        .enter, .space, .end, .esc => routeToTab(a, key),
+        .enter => {
+            // The Search tab's filter doubles as its query box, so Enter focuses
+            // it for typing (a second Enter then commits + searches). Every other
+            // tab uses Enter as a domain key (open detail, upgrade), so route it.
+            if (a.active == .search) a.editing = true else routeToTab(a, key);
+        },
+        .space, .end, .esc => routeToTab(a, key),
         // `end` needs the row count to land on the last row — deferred to the
         // data tab; Esc routes so a tab can close a pane / cancel its guard;
         // `backspace`/`unknown` are inert outside edit mode.
@@ -1035,6 +1041,20 @@ test "per-tab filters are independent across tabs" {
     a = step(a, .enter);
     a = step(a, .tab); // outdated
     try std.testing.expectEqualStrings("", activeFilterText(&a)); // its own empty filter
+}
+
+test "Enter on the Search tab focuses the query box rather than firing an empty search" {
+    var a: App = .{ .active = .search };
+    a = step(a, .enter);
+    try std.testing.expect(a.editing); // the query box is now focused for typing
+    try std.testing.expectEqual(search.Request.none, a.states.search.request); // no search fired yet
+}
+
+test "Enter on a data tab still routes as that tab's domain key, not a focus" {
+    var a: App = .{ .active = .installed };
+    a = step(a, .enter);
+    try std.testing.expect(!a.editing);
+    try std.testing.expectEqual(installed.Request.open_detail, a.states.installed.request);
 }
 
 test "renderFrame shows the committed filter and the editing footer" {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -181,6 +181,12 @@ fn renderActive(a: *const App, f: *tab.Frame, rect: tab.Rect) void {
     }
 }
 
+fn activeFooterHint(a: *const App) []const u8 {
+    switch (a.active) {
+        inline else => |t| return moduleFor(t).footerHint(),
+    }
+}
+
 fn tabTitles() [tab_bar.count][]const u8 {
     var t: [tab_bar.count][]const u8 = undefined;
     inline for (@typeInfo(Tab).@"enum".fields, 0..) |fld, i| {
@@ -298,8 +304,9 @@ pub fn renderFrame(buf: []u8, app: *const App, cols: u16, rows: u16) []const u8 
                 f.putContent(scroll_list.truncate(app.banner.slice(), cols));
                 f.put(color.Style.reset.code());
             } else {
+                var hb: [256]u8 = undefined;
                 f.put(color.roleCode(.muted));
-                f.put(scroll_list.truncate(footerHelp(app.editing), cols));
+                f.put(scroll_list.truncate(footerLine(&hb, app), cols));
                 f.put(color.Style.reset.code());
             }
         },
@@ -310,6 +317,15 @@ pub fn renderFrame(buf: []u8, app: *const App, cols: u16, rows: u16) []const u8 
 fn putRule(f: *tab.Frame, cols: u16) void {
     var i: u16 = 0;
     while (i < cols) : (i += 1) f.put("─");
+}
+
+/// The footer help line: while editing the filter, just the edit keys; otherwise
+/// the active tab's action keys, then the shell-wide keys — so every key a user
+/// can press from here is in one place. Built into `buf`; falls back to the
+/// global keys alone if it can't fit.
+fn footerLine(buf: []u8, app: *const App) []const u8 {
+    if (app.editing) return footerHelp(true);
+    return std.fmt.bufPrint(buf, "{s}   ·   {s}", .{ activeFooterHint(app), footerHelp(false) }) catch footerHelp(false);
 }
 
 fn footerHelp(editing: bool) []const u8 {
@@ -1076,6 +1092,14 @@ test "renderFrame draws a footer rule above a dimmed help line" {
     try std.testing.expect(std.mem.indexOf(u8, out, "─") != null); // horizontal rule
     try std.testing.expect(std.mem.indexOf(u8, out, color.Style.dim.code()) != null); // dimmed help: muted role == dim on the basic tier
     try std.testing.expect(std.mem.indexOf(u8, out, "quit") != null);
+}
+
+test "the footer carries the active tab's keys next to the global keys" {
+    var a: App = .{ .active = .services };
+    var buf: [8192]u8 = undefined;
+    const out = renderFrame(&buf, &a, 100, 24);
+    try std.testing.expect(std.mem.indexOf(u8, out, "s: start") != null); // the active tab's keys
+    try std.testing.expect(std.mem.indexOf(u8, out, "switch") != null); // and the global keys
 }
 
 test "renderFrame uses cursor positioning and never emits a raw newline" {

--- a/src/tui/doctor_tab.zig
+++ b/src/tui/doctor_tab.zig
@@ -37,6 +37,11 @@ pub fn title() []const u8 {
     return "Doctor";
 }
 
+/// The tab's action keys, surfaced in the shared footer next to the global keys.
+pub fn footerHint() []const u8 {
+    return "f: fix";
+}
+
 /// Case-insensitive substring match of `filter` against a finding `title`. An
 /// empty filter matches everything.
 pub fn matches(name: []const u8, filter: []const u8) bool {
@@ -129,16 +134,14 @@ const detail_rows: u16 = 3;
 // SGR reverse-video for the selection, matching the other tabs' convention.
 const reverse = "\x1b[7m";
 
-/// Pure render: a fix-key action line (only when the selected finding is
-/// fixable), the severity-ordered finding list, and a detail pane for the
-/// selected finding. A pure function of `(state, rect)` so a resize is a
-/// re-render.
+/// Pure render: the severity-ordered finding list and a detail pane for the
+/// selected finding. The `f: fix` key lives in the shared footer (the detail
+/// pane still shows whether the selected finding is fixable). A pure function of
+/// `(state, rect)` so a resize is a re-render.
 pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     if (r.height == 0) return;
     const sel = selectedFinding(s);
-    renderActionLine(sel, f, .{ .row = r.row, .col = r.col, .width = r.width, .height = 1 });
-
-    var content: tab.Rect = .{ .row = r.row + 1, .col = r.col, .width = r.width, .height = r.height -| 1 };
+    var content: tab.Rect = r;
     if (sel) |fnd| {
         const dh = @min(@as(u16, detail_rows), content.height / 2);
         if (dh > 0 and dh < content.height) {
@@ -147,17 +150,6 @@ pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
         }
     }
     renderList(s, f, content);
-}
-
-/// The dim action line: the fix key, shown only when the selected finding is
-/// fixable — a non-fixable finding gets guidance in the detail pane, not a key.
-fn renderActionLine(sel: ?Row, f: *tab.Frame, rect: tab.Rect) void {
-    const fixable = if (sel) |fnd| fnd.fixable else false;
-    if (!fixable) return; // blank line; the pane carries the non-fixable guidance
-    f.moveTo(rect.row, rect.col);
-    f.put(color.roleCode(.muted));
-    f.putContent(scroll_list.truncate("f: fix", rect.width));
-    f.put(color.Style.reset.code());
 }
 
 fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
@@ -316,16 +308,19 @@ test "selecting a finding shows its detail" {
     try testing.expect(std.mem.indexOf(u8, f.slice(), "3 orphaned entries") != null);
 }
 
-test "a fixable selection exposes the f key" {
+test "a fixable selection spells out the delegated fix in the detail pane" {
     var buf: [8192]u8 = undefined;
     var f: tab.Frame = .{ .buf = &buf };
     var s: State = .{ .items = &sample };
     s.chrome.view.selected = 1; // fixable
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 20 });
-    const out = f.slice();
-    try testing.expect(std.mem.indexOf(u8, out, "f: fix") != null);
-    // The detail pane spells out the exact delegated command, with the class token.
-    try testing.expect(std.mem.indexOf(u8, out, "mt doctor --fix orphaned_store") != null);
+    // The detail pane names the exact delegated command, with the class token;
+    // the `f` key itself now lives in the shared footer, not the tab body.
+    try testing.expect(std.mem.indexOf(u8, f.slice(), "mt doctor --fix orphaned_store") != null);
+}
+
+test "footerHint exposes the fix key for the shared footer" {
+    try testing.expect(std.mem.indexOf(u8, footerHint(), "f: fix") != null);
 }
 
 test "a non-fixable selection shows guidance, not the f key" {

--- a/src/tui/doctor_tab.zig
+++ b/src/tui/doctor_tab.zig
@@ -164,6 +164,7 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     if (rect.height == 0) return;
     const filter = s.chrome.filter.slice();
     const nf = filteredCount(s.items, filter);
+    if (nf == 0) return tab.renderHint(f, rect, if (filter.len != 0) "No matches." else "No findings.");
     const v = scroll_list.clamp(s.chrome.view, nf, rect.height);
 
     var di: usize = 0;
@@ -380,11 +381,12 @@ test "a hostile finding title cannot inject a control sequence into the frame" {
     try testing.expect(std.mem.indexOfScalar(u8, out, 0x07) == null); // BEL dropped
 }
 
-test "render on an empty list is a clean no-crash frame" {
+test "render on an empty list shows the no-findings placeholder, not a blank pane" {
     var buf: [1024]u8 = undefined;
     var f: tab.Frame = .{ .buf = &buf };
     const s: State = .{ .items = &.{} };
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 16 }); // must not trap
+    try std.testing.expect(std.mem.indexOf(u8, f.slice(), "No findings") != null);
 }
 
 test "render clamps to a height of one without crashing" {

--- a/src/tui/installed_tab.zig
+++ b/src/tui/installed_tab.zig
@@ -132,6 +132,7 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     if (rect.height == 0) return;
     const filter = s.chrome.filter.slice();
     const nf = filteredCount(s.items, filter);
+    if (nf == 0) return tab.renderHint(f, rect, if (filter.len != 0) "No matches." else "No packages installed yet.");
     const v = scroll_list.clamp(s.chrome.view, nf, rect.height);
 
     var fi: usize = 0;
@@ -400,11 +401,21 @@ test "render reflows: the same state at two widths differs" {
     try testing.expect(!std.mem.eql(u8, fa.slice(), fb.slice()));
 }
 
-test "render on an empty list is a clean no-crash empty-ish frame" {
+test "render on an empty list shows the empty-state placeholder, not a blank pane" {
     var buf: [1024]u8 = undefined;
     var f: tab.Frame = .{ .buf = &buf };
     const s: State = .{ .items = &.{} };
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 10 }); // must not trap
+    try testing.expect(std.mem.indexOf(u8, f.slice(), "No packages installed") != null);
+}
+
+test "a filter that excludes every row shows the no-matches placeholder" {
+    var buf: [1024]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    var s: State = .{ .items = &sample };
+    s.chrome.filter.push("zzznomatch");
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 10 });
+    try testing.expect(std.mem.indexOf(u8, f.slice(), "No matches") != null);
 }
 
 test "conforms to the tab contract" {

--- a/src/tui/installed_tab.zig
+++ b/src/tui/installed_tab.zig
@@ -48,6 +48,11 @@ pub fn title() []const u8 {
     return "Installed";
 }
 
+/// The tab's action keys, surfaced in the shared footer next to the global keys.
+pub fn footerHint() []const u8 {
+    return "enter: details   x: uninstall";
+}
+
 /// Case-insensitive substring match of `filter` against `name`. An empty filter
 /// matches everything.
 pub fn matches(name: []const u8, filter: []const u8) bool {

--- a/src/tui/outdated_tab.zig
+++ b/src/tui/outdated_tab.zig
@@ -155,6 +155,7 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     if (rect.height == 0) return;
     const filter = s.chrome.filter.slice();
     const nf = filteredCount(s.items, filter);
+    if (nf == 0) return tab.renderHint(f, rect, if (filter.len != 0) "No matches." else "Everything is up to date.");
     const v = scroll_list.clamp(s.chrome.view, nf, rect.height);
 
     var fi: usize = 0;
@@ -401,11 +402,12 @@ test "render reflows: the same state at two widths differs" {
     try testing.expect(!std.mem.eql(u8, fa.slice(), fb.slice()));
 }
 
-test "render on an empty list is a clean no-crash frame" {
+test "render on an empty list shows the up-to-date placeholder, not a blank pane" {
     var buf: [1024]u8 = undefined;
     var f: tab.Frame = .{ .buf = &buf };
     const s: State = .{ .items = &.{} };
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 }); // must not trap
+    try std.testing.expect(std.mem.indexOf(u8, f.slice(), "up to date") != null);
 }
 
 test "the cores tolerate a checked slice shorter than items without trapping" {

--- a/src/tui/outdated_tab.zig
+++ b/src/tui/outdated_tab.zig
@@ -38,6 +38,11 @@ pub fn title() []const u8 {
     return "Outdated";
 }
 
+/// The tab's action keys, surfaced in the shared footer next to the global keys.
+pub fn footerHint() []const u8 {
+    return "space: toggle   a: all   n: none   u: upgrade";
+}
+
 /// Case-insensitive substring match of `filter` against `name`. An empty filter
 /// matches everything.
 pub fn matches(name: []const u8, filter: []const u8) bool {
@@ -128,27 +133,13 @@ fn requestUpgrade(s: *State) void {
     if (selectedCount(s) > 0) s.request = .upgrade; // empty selection is a no-op
 }
 
-/// Pure render: a dim action line on top, then the filtered + scrolled checkbox
-/// list below. A pure function of `(state, rect)` so a resize is a re-render.
+/// Pure render: the filtered + scrolled checkbox list. The multi-select keys
+/// live in the shared footer, so the list owns the whole rect; the `[x]`
+/// checkboxes carry the selection. A pure function of `(state, rect)` so a
+/// resize is a re-render.
 pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     if (r.height == 0) return;
-    renderActionLine(s, f, .{ .row = r.row, .col = r.col, .width = r.width, .height = 1 });
-    renderList(s, f, .{ .row = r.row + 1, .col = r.col, .width = r.width, .height = r.height -| 1 });
-}
-
-/// The dim action line: the multi-select keys plus the current batch size, or a
-/// hint when nothing is selected — the empty-selection no-op's only feedback.
-fn renderActionLine(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
-    f.moveTo(rect.row, rect.col);
-    f.put(color.roleCode(.muted));
-    var b: [128]u8 = undefined;
-    const n = selectedCount(s);
-    const line = if (n > 0)
-        std.fmt.bufPrint(&b, "u: upgrade selected ({d})   space: toggle   a: all   n: none", .{n}) catch "u: upgrade   space: toggle   a: all   n: none"
-    else
-        "space: select rows to upgrade   a: all   n: none";
-    f.putContent(scroll_list.truncate(line, rect.width));
-    f.put(color.Style.reset.code());
+    renderList(s, f, r);
 }
 
 fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
@@ -368,26 +359,10 @@ test "render highlights the selected row" {
     try testing.expect(std.mem.indexOf(u8, f.slice(), reverse) != null);
 }
 
-test "the action line shows the batch size when rows are selected" {
-    var buf: [4096]u8 = undefined;
-    var f: tab.Frame = .{ .buf = &buf };
-    var checked = [_]bool{ true, false, true, false }; // wget + firefox
-    const s: State = .{ .items = &sample, .checked = &checked };
-    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
-    const out = f.slice();
-    try testing.expect(std.mem.indexOf(u8, out, "upgrade") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "(2)") != null); // two selected
-}
-
-test "the action line shows the empty-selection hint and no upgrade count" {
-    var buf: [4096]u8 = undefined;
-    var f: tab.Frame = .{ .buf = &buf };
-    var checked = [_]bool{false} ** 4;
-    const s: State = .{ .items = &sample, .checked = &checked };
-    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
-    const out = f.slice();
-    try testing.expect(std.mem.indexOf(u8, out, "select") != null); // a hint, not a count
-    try testing.expect(std.mem.indexOf(u8, out, "(0)") == null);
+test "footerHint exposes the multi-select keys for the shared footer" {
+    // The selection is carried by the row checkboxes; the keys live in the footer.
+    try testing.expect(std.mem.indexOf(u8, footerHint(), "space") != null);
+    try testing.expect(std.mem.indexOf(u8, footerHint(), "upgrade") != null);
 }
 
 test "render reflows: the same state at two widths differs" {

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -103,7 +103,7 @@ pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     if (body.height == 0) return;
     switch (s.phase) {
         .searching => renderStatus(f, body, "searching…"),
-        .idle => renderStatus(f, body, "Type a query, then Enter to search."),
+        .idle => renderStatus(f, body, "Press Enter or / to type a query, then Enter to search."),
         .loaded => if (s.items.len == 0)
             renderStatus(f, body, "No matches.")
         else
@@ -237,7 +237,7 @@ test "render shows guidance in the idle phase before any query is committed" {
     var f: tab.Frame = .{ .buf = &buf };
     const s: State = .{ .phase = .idle };
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
-    try testing.expect(std.mem.indexOf(u8, f.slice(), "Type a query") != null);
+    try testing.expect(std.mem.indexOf(u8, f.slice(), "type a query") != null);
 }
 
 test "render shows the searching status during the remote read" {

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -53,6 +53,11 @@ pub fn title() []const u8 {
     return "Search";
 }
 
+/// The tab's action keys, surfaced in the shared footer next to the global keys.
+pub fn footerHint() []const u8 {
+    return "enter: search   i: install";
+}
+
 /// The hit the selection points at, clamping the (shell-driven, unbounded)
 /// selection into the result list. No filter: the query already ran server-side,
 /// so the selection indexes straight into `items`. The shell reads its `name`
@@ -98,26 +103,15 @@ fn kindStyle(k: Kind) color.Role {
 /// rect)` so a resize is a re-render.
 pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     if (r.height == 0) return;
-    renderActionLine(f, .{ .row = r.row, .col = r.col, .width = r.width, .height = 1 });
-    const body: tab.Rect = .{ .row = r.row + 1, .col = r.col, .width = r.width, .height = r.height -| 1 };
-    if (body.height == 0) return;
+    // Keys live in the shared footer now, so the body owns the whole rect.
     switch (s.phase) {
-        .searching => renderStatus(f, body, "searching…"),
-        .idle => renderStatus(f, body, "Press Enter or / to type a query, then Enter to search."),
+        .searching => renderStatus(f, r, "searching…"),
+        .idle => renderStatus(f, r, "Press Enter or / to type a query, then Enter to search."),
         .loaded => if (s.items.len == 0)
-            renderStatus(f, body, "No matches.")
+            renderStatus(f, r, "No matches.")
         else
-            renderList(s, f, body),
+            renderList(s, f, r),
     }
-}
-
-/// The dim action line: the tab's keys, so they are discoverable (the global
-/// footer carries only the shell-wide keys).
-fn renderActionLine(f: *tab.Frame, rect: tab.Rect) void {
-    f.moveTo(rect.row, rect.col);
-    f.put(color.roleCode(.muted));
-    f.putContent(scroll_list.truncate("enter: search   i: install", rect.width));
-    f.put(color.Style.reset.code());
 }
 
 fn renderStatus(f: *tab.Frame, rect: tab.Rect, msg: []const u8) void {
@@ -279,14 +273,9 @@ test "render highlights the selected hit" {
     try testing.expect(std.mem.indexOf(u8, f.slice(), reverse) != null);
 }
 
-test "render shows the action line keys so they are discoverable" {
-    var buf: [4096]u8 = undefined;
-    var f: tab.Frame = .{ .buf = &buf };
-    const s: State = .{ .phase = .idle };
-    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
-    const out = f.slice();
-    try testing.expect(std.mem.indexOf(u8, out, "search") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "install") != null);
+test "footerHint exposes the tab's action keys for the shared footer" {
+    try testing.expect(std.mem.indexOf(u8, footerHint(), "search") != null);
+    try testing.expect(std.mem.indexOf(u8, footerHint(), "install") != null);
 }
 
 test "render reflows: the same state at two widths differs" {

--- a/src/tui/services_tab.zig
+++ b/src/tui/services_tab.zig
@@ -35,6 +35,11 @@ pub fn title() []const u8 {
     return "Services";
 }
 
+/// The tab's action keys, surfaced in the shared footer next to the global keys.
+pub fn footerHint() []const u8 {
+    return "s: start   x: stop   r: restart";
+}
+
 /// Case-insensitive substring match of `filter` against `name`. An empty filter
 /// matches everything.
 pub fn matches(name: []const u8, filter: []const u8) bool {
@@ -106,21 +111,12 @@ fn dotStyle(st: Status) color.Role {
     };
 }
 
-/// Pure render: a dim action line on top, then the filtered + scrolled service
-/// list below. A pure function of `(state, rect)` so a resize is a re-render.
+/// Pure render: the filtered + scrolled service list. The lifecycle keys live in
+/// the shared footer, so the list owns the whole rect. A pure function of
+/// `(state, rect)` so a resize is a re-render.
 pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     if (r.height == 0) return;
-    renderActionLine(f, .{ .row = r.row, .col = r.col, .width = r.width, .height = 1 });
-    renderList(s, f, .{ .row = r.row + 1, .col = r.col, .width = r.width, .height = r.height -| 1 });
-}
-
-/// The dim action line: the lifecycle keys, so they are discoverable (the global
-/// footer carries only the shell-wide keys).
-fn renderActionLine(f: *tab.Frame, rect: tab.Rect) void {
-    f.moveTo(rect.row, rect.col);
-    f.put(color.roleCode(.muted));
-    f.putContent(scroll_list.truncate("s: start   x: stop   r: restart", rect.width));
-    f.put(color.Style.reset.code());
+    renderList(s, f, r);
 }
 
 fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
@@ -296,14 +292,9 @@ test "render highlights the selected row" {
     try testing.expect(std.mem.indexOf(u8, f.slice(), reverse) != null);
 }
 
-test "render shows the lifecycle action line" {
-    var buf: [4096]u8 = undefined;
-    var f: tab.Frame = .{ .buf = &buf };
-    const s: State = .{ .items = &sample };
-    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
-    const out = f.slice();
-    try testing.expect(std.mem.indexOf(u8, out, "start") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "restart") != null);
+test "footerHint exposes the lifecycle keys for the shared footer" {
+    try testing.expect(std.mem.indexOf(u8, footerHint(), "start") != null);
+    try testing.expect(std.mem.indexOf(u8, footerHint(), "restart") != null);
 }
 
 test "render reflows: the same state at two widths differs" {
@@ -338,11 +329,11 @@ test "render on an empty list shows the no-services placeholder, not a blank pan
     try std.testing.expect(std.mem.indexOf(u8, f.slice(), "No services registered") != null);
 }
 
-test "render clamps to a height of one (action line only) without crashing" {
+test "render clamps to a height of one without crashing" {
     var buf: [1024]u8 = undefined;
     var f: tab.Frame = .{ .buf = &buf };
     const s: State = .{ .items = &sample };
-    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 1 }); // no list rows fit
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 1 }); // one list row fits
 }
 
 test "conforms to the tab contract" {

--- a/src/tui/services_tab.zig
+++ b/src/tui/services_tab.zig
@@ -127,6 +127,7 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     if (rect.height == 0) return;
     const filter = s.chrome.filter.slice();
     const nf = filteredCount(s.items, filter);
+    if (nf == 0) return tab.renderHint(f, rect, if (filter.len != 0) "No matches." else "No services registered.");
     const v = scroll_list.clamp(s.chrome.view, nf, rect.height);
 
     var fi: usize = 0;
@@ -329,11 +330,12 @@ test "a hostile service name cannot inject a control sequence into the frame" {
     try testing.expect(std.mem.indexOfScalar(u8, out, 0x07) == null); // BEL dropped
 }
 
-test "render on an empty list is a clean no-crash frame" {
+test "render on an empty list shows the no-services placeholder, not a blank pane" {
     var buf: [1024]u8 = undefined;
     var f: tab.Frame = .{ .buf = &buf };
     const s: State = .{ .items = &.{} };
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 }); // must not trap
+    try std.testing.expect(std.mem.indexOf(u8, f.slice(), "No services registered") != null);
 }
 
 test "render clamps to a height of one (action line only) without crashing" {

--- a/src/tui/spawn.zig
+++ b/src/tui/spawn.zig
@@ -61,13 +61,16 @@ pub fn runChild(io: std.Io, argv: []const []const u8) SpawnError!void {
     }
 }
 
-/// Capture `mt … --json` stdout for a tab parser. stderr stays inherited so a
-/// genuine failure is still visible. Errors on a non-zero exit or empty output
-/// so a parser never sees a half-written document. Caller frees the bytes.
-pub fn readJson(
+/// Spawn `argv`, drain its stdout fully, then wait. Returns the captured bytes
+/// (possibly empty) on an accepted exit. `max_ok_exit` is the highest exit code
+/// that still counts as a successful read: most reads pass `0`, but `mt doctor`
+/// passes `2` because its exit code is its severity, not a failure. A signal,
+/// stop, or a code above `max_ok_exit` is `ChildFailed`. Caller frees the bytes.
+fn captureJson(
     io: std.Io,
     allocator: std.mem.Allocator,
     argv: []const []const u8,
+    max_ok_exit: u8,
 ) ReadError![]u8 {
     var child = std.process.spawn(io, .{ .argv = argv, .stdout = .pipe }) catch return error.SpawnFailed;
 
@@ -80,10 +83,40 @@ pub fn readJson(
 
     const status = child.wait(io) catch return error.WaitFailed;
     switch (status) {
-        .exited => |code| if (code != 0) return error.ChildFailed,
+        .exited => |code| if (code > max_ok_exit) return error.ChildFailed,
         .signal, .stopped, .unknown => return error.ChildFailed,
     }
+    return bytes;
+}
+
+/// Capture `mt … --json` stdout for a tab parser. stderr stays inherited so a
+/// genuine failure is still visible. Errors on a non-zero exit or empty output
+/// so a parser never sees a half-written document. Caller frees the bytes.
+pub fn readJson(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+) ReadError![]u8 {
+    const bytes = try captureJson(io, allocator, argv, 0);
+    errdefer allocator.free(bytes);
     if (bytes.len == 0) return error.EmptyOutput; // a parser must never see half a doc
+    return bytes;
+}
+
+/// Capture `mt doctor --json`, whose exit code is its severity (0 ok / 1 warn /
+/// 2 err), not a pass/fail — so a non-zero severity with a document is a
+/// successful read, never `ChildFailed`. An exit-with-no-output (a fresh prefix)
+/// maps to `null` like `readJsonAllowEmpty`. Caller frees the bytes.
+pub fn readDoctorJson(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+) ReadError!?[]u8 {
+    const bytes = try captureJson(io, allocator, argv, 2);
+    if (bytes.len == 0) {
+        allocator.free(bytes);
+        return null;
+    }
     return bytes;
 }
 
@@ -253,6 +286,37 @@ test "readJson errors on a non-zero exit" {
     var t = threaded();
     defer t.deinit();
     try testing.expectError(error.ChildFailed, readJson(t.io(), testing.allocator, &.{"/usr/bin/false"}));
+}
+
+test "readDoctorJson tolerates a severity exit where readJson would fail it" {
+    var t = threaded();
+    defer t.deinit();
+    // `/usr/bin/false` exits 1 — a doctor "warnings" severity, not a fault — so
+    // the doctor read keeps going where the generic read returns ChildFailed.
+    // (A non-zero exit *with* a document is exercised in tests/tui_spawn_test.zig,
+    // which may use a shell fixture the src/ argv-only invariant forbids here.)
+    try testing.expect((try readDoctorJson(t.io(), testing.allocator, &.{"/usr/bin/false"})) == null);
+    try testing.expectError(error.ChildFailed, readJson(t.io(), testing.allocator, &.{"/usr/bin/false"}));
+}
+
+test "readDoctorJson returns the captured document on a successful read" {
+    var t = threaded();
+    defer t.deinit();
+    const out = (try readDoctorJson(t.io(), testing.allocator, &.{ "/bin/echo", "{\"checks\":[]}" })).?;
+    defer testing.allocator.free(out);
+    try testing.expect(std.mem.indexOf(u8, out, "checks") != null);
+}
+
+test "readDoctorJson maps an exit-with-no-output to null (fresh prefix)" {
+    var t = threaded();
+    defer t.deinit();
+    try testing.expect((try readDoctorJson(t.io(), testing.allocator, &.{"/usr/bin/true"})) == null);
+}
+
+test "readDoctorJson surfaces a missing program as SpawnFailed" {
+    var t = threaded();
+    defer t.deinit();
+    try testing.expectError(error.SpawnFailed, readDoctorJson(t.io(), testing.allocator, &.{"/nonexistent/malt_doctor_probe"}));
 }
 
 // A fake terminal controller + body record the call order so the sequencing

--- a/src/tui/tab.zig
+++ b/src/tui/tab.zig
@@ -9,6 +9,7 @@
 //! content is stripped of line-breaking controls before it reaches the frame.
 
 const std = @import("std");
+const color = @import("../ui/color.zig");
 const scroll_list = @import("scroll_list.zig");
 const layout = @import("layout.zig");
 const filter_input = @import("filter_input.zig");
@@ -76,6 +77,17 @@ pub fn paintRows(f: *Frame, rows: []const []const u8, view: scroll_list.View, re
     }
 }
 
+/// Paint one dim line at the top of `rect` — the shared empty-state / "no
+/// matches" placeholder so every tab's empty list reads the same way instead of
+/// a blank pane. Content goes through `putContent` like every other row.
+pub fn renderHint(f: *Frame, rect: Rect, msg: []const u8) void {
+    if (rect.height == 0) return;
+    f.moveTo(rect.row, rect.col);
+    f.put(color.roleCode(.muted));
+    f.putContent(scroll_list.truncate(msg, rect.width));
+    f.put(color.Style.reset.code());
+}
+
 /// Comptime contract check: a conforming tab module exposes `State` (with a
 /// `chrome: Chrome` field), `title`, `step`, and `render`. Called on each tab so
 /// a missing or mis-typed piece fails the build, not the dashboard at runtime.
@@ -108,6 +120,20 @@ const GoodTab = struct {
 
 test "verify accepts a conforming tab module" {
     comptime verify(GoodTab);
+}
+
+test "renderHint paints the placeholder text into the frame" {
+    var buf: [128]u8 = undefined;
+    var f: Frame = .{ .buf = &buf };
+    renderHint(&f, .{ .row = 2, .col = 1, .width = 40, .height = 6 }, "Nothing here.");
+    try std.testing.expect(std.mem.indexOf(u8, f.slice(), "Nothing here.") != null);
+}
+
+test "renderHint on a zero-height rect is a clean no-op" {
+    var buf: [64]u8 = undefined;
+    var f: Frame = .{ .buf = &buf };
+    renderHint(&f, .{ .row = 1, .col = 1, .width = 40, .height = 0 }, "x"); // must not trap
+    try std.testing.expectEqual(@as(usize, 0), f.slice().len);
 }
 
 test "Frame.put is bounded and never overflows the buffer" {

--- a/src/tui/tab.zig
+++ b/src/tui/tab.zig
@@ -95,7 +95,7 @@ pub fn verify(comptime M: type) void {
     if (!@hasDecl(M, "State")) @compileError(@typeName(M) ++ ": tab must expose `pub const State`");
     if (!@hasField(M.State, "chrome")) @compileError(@typeName(M) ++ ".State must embed a `chrome` field");
     if (@FieldType(M.State, "chrome") != Chrome) @compileError(@typeName(M) ++ ".State.chrome must be tab.Chrome");
-    for ([_][]const u8{ "title", "step", "render" }) |decl| {
+    for ([_][]const u8{ "title", "footerHint", "step", "render" }) |decl| {
         if (!@hasDecl(M, decl)) @compileError(@typeName(M) ++ ": tab must expose `pub fn " ++ decl ++ "`");
     }
 }
@@ -106,6 +106,9 @@ const GoodTab = struct {
     pub const State = struct { chrome: Chrome = .{} };
     pub fn title() []const u8 {
         return "Good";
+    }
+    pub fn footerHint() []const u8 {
+        return "g: go";
     }
     pub fn step(s: *State, key: Key) void {
         _ = s;

--- a/src/ui/color.zig
+++ b/src/ui/color.zig
@@ -84,9 +84,36 @@ var pkg_environ: std.process.Environ = .{ .block = .{ .slice = &[_:null]?[*:0]co
 
 /// Seed the io/environ used by env reads and TTY probes. Called by
 /// `main` after `AppCtx` is built. Inverse of relying on globals.
+///
+/// Re-seeding invalidates every env-derived cache: a value resolved against the
+/// empty default environ (a boot-time pre-warm before this call) must not stick,
+/// or MALT_THEME / COLORTERM / NO_COLOR silently freeze at their unset defaults.
 pub fn setRuntime(io: std.Io, environ: std.process.Environ) void {
     pkg_io = io;
     pkg_environ = environ;
+    color_enabled = null;
+    emoji_enabled = null;
+    background_cached = null;
+    truecolor_cached = null;
+    theme_cached = null;
+}
+
+test "setRuntime re-seeds the theme cache so a pre-seed warm cannot freeze it" {
+    // Reproduces the boot hazard: theme() warmed against the empty default
+    // environ (before main seeds the real one) must not stick at .default once
+    // the environ carrying MALT_THEME arrives — or the TUI never themes.
+    const io = std.Options.debug_io;
+    const empty: std.process.Environ = .{ .block = .{ .slice = &[_:null]?[*:0]const u8{} } };
+    const themed: std.process.Environ = .{ .block = .{ .slice = &[_:null]?[*:0]const u8{"MALT_THEME=dracula"} } };
+
+    setRuntime(io, empty);
+    try std.testing.expectEqual(Theme.default, theme()); // warmed before the env is known
+
+    setRuntime(io, themed); // the real environ arrives; the stale cache must drop
+    try std.testing.expectEqual(Theme.dracula, theme());
+
+    setRuntime(io, empty); // leave module state clean for sibling tests
+    setThemeForTest(null);
 }
 
 fn lookupEnv(name: []const u8) ?[:0]const u8 {

--- a/tests/tui_spawn_test.zig
+++ b/tests/tui_spawn_test.zig
@@ -62,3 +62,28 @@ test "the refresh hook refetches the active tab and marks the rest dirty on view
     try testing.expect(!app.takeDirty(&a, .installed));
     try testing.expect(app.takeDirty(&a, .doctor));
 }
+
+// `mt doctor --json` exits non-zero *by severity* (1 warn / 2 err) while still
+// emitting its findings document — so the Doctor tab must read it as success,
+// not ChildFailed. These need a process that exits non-zero with output, which
+// only a shell fixture produces; the `src/` argv-only invariant forbids naming a
+// shell there, so the with-output cases live here.
+
+test "readDoctorJson keeps the document emitted alongside a severity exit (2)" {
+    var t = threaded();
+    defer t.deinit();
+    const out = (try spawn.readDoctorJson(t.io(), testing.allocator, &.{
+        "/bin/sh", "-c", "printf '{\"checks\":[]}'; exit 2",
+    })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("{\"checks\":[]}", out);
+}
+
+test "readDoctorJson still rejects an exit above the severity range" {
+    var t = threaded();
+    defer t.deinit();
+    // Only 0/1/2 are doctor severities; a higher code is a genuine fault.
+    try testing.expectError(error.ChildFailed, spawn.readDoctorJson(t.io(), testing.allocator, &.{
+        "/bin/sh", "-c", "printf x; exit 3",
+    }));
+}


### PR DESCRIPTION
## Description

First-pass usability fixes for `mt tui`, each its own commit:

- **Themes reach the dashboard.** The colour caches (theme, truecolor, background) were warmed before the real environ was seeded, freezing them at their unset defaults - so `MALT_THEME` and truecolor never applied. They are now re-seeded and resolved once the environ is in place.
- **Doctor tab loads on an unhealthy system.** `mt doctor` exits non-zero *by severity* (1 warn / 2 err) while still emitting its findings JSON, so the generic read rejected it as a failure exactly when the tab had something to show. The Doctor read now accepts those severity exits.
- **Meaningful empty states.** A fresh prefix (or a filter that excludes every row) left the Installed, Outdated, Services, and Doctor tabs blank; each now renders a short, tab-specific placeholder (or "No matches." under a filter).
- **Search is usable.** On the Search tab the query box only opened with `/`, so Enter fired an empty search and typing did nothing. Enter now focuses the query box (a second Enter commits + searches); the guidance says so.
- **Keybindings in the footer.** Each tab's action keys lived in a dim line at the top of its content (and were absent on the Installed tab). Every tab now declares a footer hint shown next to the global keys, so all the keys are in one place and the tab body reclaims a row.

## Related Issue

- None

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 19 in a stack** made with GitButler:
- <kbd>&nbsp;19&nbsp;</kbd> #464
- <kbd>&nbsp;18&nbsp;</kbd> #463
- <kbd>&nbsp;17&nbsp;</kbd> #462 👈 
- <kbd>&nbsp;16&nbsp;</kbd> #461
- <kbd>&nbsp;15&nbsp;</kbd> #459
- <kbd>&nbsp;14&nbsp;</kbd> #458
- <kbd>&nbsp;13&nbsp;</kbd> #457
- <kbd>&nbsp;12&nbsp;</kbd> #456
- <kbd>&nbsp;11&nbsp;</kbd> #455
- <kbd>&nbsp;10&nbsp;</kbd> #454
- <kbd>&nbsp;9&nbsp;</kbd> #453
- <kbd>&nbsp;8&nbsp;</kbd> #451
- <kbd>&nbsp;7&nbsp;</kbd> #450
- <kbd>&nbsp;6&nbsp;</kbd> #448
- <kbd>&nbsp;5&nbsp;</kbd> #447
- <kbd>&nbsp;4&nbsp;</kbd> #446
- <kbd>&nbsp;3&nbsp;</kbd> #445
- <kbd>&nbsp;2&nbsp;</kbd> #444
- <kbd>&nbsp;1&nbsp;</kbd> #443
<!-- GitButler Footer Boundary Bottom -->