### PR TITLE
feat(tui): search multi-select & info, loading state, and pane polish

### DIFF
--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -292,11 +292,7 @@ pub fn renderFrame(buf: []u8, app: *const App, cols: u16, rows: u16) []const u8 
     var f: tab.Frame = .{ .buf = buf };
     f.put("\x1b[2J"); // clear; every region then positions its own cursor
     switch (layout.compute(cols, rows)) {
-        .too_small => {
-            f.moveTo(1, 1);
-            var tmp: [80]u8 = undefined;
-            f.put(layout.render(&tmp, .{ .rows = &.{} }, cols, rows));
-        },
+        .too_small => renderTooSmall(&f, cols, rows),
         .ok => |r| {
             f.moveTo(r.tab_bar.row, 1);
             var tb: [256]u8 = undefined;
@@ -340,6 +336,38 @@ pub fn renderFrame(buf: []u8, app: *const App, cols: u16, rows: u16) []const u8 
 fn putRule(f: *tab.Frame, cols: u16) void {
     var i: u16 = 0;
     while (i < cols) : (i += 1) f.put("─");
+}
+
+/// The "terminal too small" fallback: the notice icon + message in the info
+/// colour, wrapped across rows (positioned with cursor moves, no raw newline) so
+/// it stays readable when the terminal is too narrow for one line. Trips on
+/// width or height alone — `layout.fits` requires both axes.
+fn renderTooSmall(f: *tab.Frame, cols: u16, rows: u16) void {
+    if (cols == 0 or rows == 0) return;
+    var mbuf: [64]u8 = undefined;
+    var buf: [96]u8 = undefined;
+    const icon: []const u8 = if (color.isEmojiEnabled()) "ⓘ " else "i ";
+    const msg = std.fmt.bufPrint(&buf, "{s}{s}", .{ icon, layout.tooSmallMessage(&mbuf) }) catch "terminal too small";
+    var rest = msg;
+    var row: u16 = 1;
+    while (rest.len > 0 and row <= rows) : (row += 1) {
+        var take = @min(@as(usize, cols), rest.len);
+        if (take < rest.len) {
+            var i = take; // break at the last space that fits, so words stay whole
+            while (i > 0) : (i -= 1) {
+                if (rest[i - 1] == ' ') {
+                    take = i;
+                    break;
+                }
+            }
+        }
+        f.moveTo(row, 1);
+        f.put(color.roleCode(.accent));
+        f.putContent(rest[0..take]);
+        f.put(color.Style.reset.code());
+        rest = rest[take..];
+        while (rest.len > 0 and rest[0] == ' ') rest = rest[1..];
+    }
 }
 
 fn loadingLine(buf: []u8, app: *const App) []const u8 {
@@ -1222,6 +1250,15 @@ test "the footer carries the active tab's keys next to the global keys" {
     const out = renderFrame(&buf, &a, 100, 24);
     try std.testing.expect(std.mem.indexOf(u8, out, "s: start") != null); // the active tab's keys
     try std.testing.expect(std.mem.indexOf(u8, out, "switch") != null); // and the global keys
+}
+
+test "a too-small terminal shows a wrapped, styled notice (width alone trips it)" {
+    var a: App = .{};
+    var buf: [8192]u8 = undefined;
+    const out = renderFrame(&buf, &a, 10, 24); // width below the minimum, height fine
+    try std.testing.expect(std.mem.indexOf(u8, out, "terminal") != null); // the notice shows
+    try std.testing.expect(std.mem.indexOf(u8, out, "\x1b[2;1H") != null); // wrapped onto a 2nd row
+    try std.testing.expect(std.mem.indexOf(u8, out, color.Style.reset.code()) != null); // info colour applied + reset
 }
 
 test "the footer shows a per-tab loading status during a blocking refetch" {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -173,6 +173,12 @@ fn activeFilterText(a: *const App) []const u8 {
     }
 }
 
+/// The input-box label for the active tab: on Search the box is the query, not a
+/// filter over an already-loaded list, so it says so.
+fn activeFilterLabel(a: *const App) []const u8 {
+    return if (a.active == .search) "search: " else "filter: ";
+}
+
 fn routeToTab(a: *App, key: Key) void {
     switch (a.active) {
         inline else => |t| moduleFor(t).step(&@field(a.states, @tagName(t)), key),
@@ -297,7 +303,7 @@ pub fn renderFrame(buf: []u8, app: *const App, cols: u16, rows: u16) []const u8 
 
             f.moveTo(r.filter.row, 1);
             var fb: [filter_input.max_len + 8]u8 = undefined;
-            f.put(filter_input.render(&fb, activeFilterText(app), app.editing, cols));
+            f.put(filter_input.render(&fb, activeFilterLabel(app), activeFilterText(app), app.editing, cols));
 
             renderActive(app, &f, r.content);
 
@@ -1135,6 +1141,7 @@ test "Enter on a data tab still routes as that tab's domain key, not a focus" {
 
 test "renderFrame shows the committed filter and the editing footer" {
     var a: App = .{};
+    a = step(a, ch('2')); // Installed tab: its box is a filter over the loaded list
     a = step(a, ch('/'));
     a = step(a, ch('j'));
     a = step(a, ch('q')); // 'q' is a literal char while editing, not quit
@@ -1143,6 +1150,17 @@ test "renderFrame shows the committed filter and the editing footer" {
     const out = renderFrame(&buf, &a, 80, 24);
     try std.testing.expect(std.mem.indexOf(u8, out, "filter: jq_") != null); // filter line with caret
     try std.testing.expect(std.mem.indexOf(u8, out, "accept") != null); // editing footer
+}
+
+test "the Search tab labels its input box as a query, not a filter" {
+    var a: App = .{ .active = .search };
+    a = step(a, ch('/'));
+    a = step(a, ch('r'));
+    a = step(a, ch('g'));
+    var buf: [8192]u8 = undefined;
+    const out = renderFrame(&buf, &a, 80, 24);
+    try std.testing.expect(std.mem.indexOf(u8, out, "search: rg_") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "filter:") == null);
 }
 
 test "renderFrame draws a footer rule above a dimmed help line" {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -421,6 +421,9 @@ const Store = struct {
     services: ?services_json.Parsed = null,
     doctor: ?doctor_json.Parsed = null,
     search: ?search_json.Parsed = null,
+    /// The Search tab's checkbox state, parallel to `search.?.items`. Owned here,
+    /// resized to the result count on each query, borrowed by the tab.
+    search_checked: []bool = &.{},
 
     fn deinit(self: *Store, allocator: std.mem.Allocator) void {
         if (self.installed) |p| p.deinit();
@@ -430,6 +433,7 @@ const Store = struct {
         if (self.services) |p| p.deinit();
         if (self.doctor) |p| p.deinit();
         if (self.search) |p| p.deinit();
+        if (self.search_checked.len != 0) allocator.free(self.search_checked);
     }
 };
 
@@ -771,31 +775,56 @@ fn loadSearch(io: std.Io, allocator: std.mem.Allocator, app: *App, store: *Store
     defer allocator.free(bytes);
 
     const parsed = try search_json.parse(allocator, bytes);
+    errdefer parsed.deinit();
+    // A fresh checkbox buffer, all clear: a new result set means an old selection
+    // would point at unrelated rows.
+    const checked = try allocator.alloc(bool, parsed.items.len);
+    @memset(checked, false);
+
     if (store.search) |old| old.deinit();
+    if (store.search_checked.len != 0) allocator.free(store.search_checked);
     store.search = parsed;
+    store.search_checked = checked;
     app.states.search.items = parsed.items;
+    app.states.search.checked = checked;
     app.states.search.phase = .loaded;
     // A fresh query is a new result set, so an old cursor would point at an
     // unrelated row; reset to the top.
     app.states.search.chrome.view = .{};
 }
 
-/// Build `mt install [--formula|--cask] <name>` for the selected hit. Pure over
-/// the tab state: null when nothing installable is selected (the no-op), else an
-/// owned argv whose `name` element borrows from the parse storage. Caller frees
-/// the returned slice (not its elements).
+/// Build the `mt install …` argv for the Search tab. Pure over the tab state:
+/// every checked, not-yet-installed hit, or — when nothing is checked — the
+/// active row. Null when nothing installable is selected (the no-op). A single
+/// target keeps the explicit `--formula`/`--cask` flag, because a name can exist
+/// as both and bare `mt install <name>` silently picks the formula; a multi
+/// install passes bare names and lets `mt` detect each one's kind. Names borrow
+/// from the parse storage; caller frees the returned slice, not its elements.
 fn installArgv(allocator: std.mem.Allocator, mt_path: []const u8, st: *const search.State) std.mem.Allocator.Error!?[]const []const u8 {
-    const m = search.selectedMatch(st) orelse return null; // empty list: no-op
-    if (m.installed) return null; // already installed: inert
-    // The search result's kind is authoritative, so disambiguate the install
-    // explicitly: a name can exist as both a formula and a cask, where bare
-    // `mt install <name>` silently picks the formula. Exhaustive switch — a new
-    // kind is a compile error, never a silent default.
-    const kind_flag: []const u8 = switch (m.kind) {
-        .formula => "--formula",
-        .cask => "--cask",
-    };
-    return try spawn.inlineArgv(allocator, mt_path, &.{ "install", kind_flag, m.name });
+    var idxs: std.ArrayList(usize) = .empty;
+    defer idxs.deinit(allocator);
+    for (st.items, 0..) |m, i| {
+        if (i < st.checked.len and st.checked[i] and !m.installed) try idxs.append(allocator, i);
+    }
+    if (idxs.items.len == 0) {
+        // Nothing checked: the active row, if it is installable.
+        const i = search.selectedIndex(st) orelse return null;
+        if (st.items[i].installed) return null;
+        try idxs.append(allocator, i);
+    }
+    if (idxs.items.len == 1) {
+        const m = st.items[idxs.items[0]];
+        const kind_flag: []const u8 = switch (m.kind) {
+            .formula => "--formula",
+            .cask => "--cask",
+        };
+        return try spawn.inlineArgv(allocator, mt_path, &.{ "install", kind_flag, m.name });
+    }
+    const argv = try allocator.alloc([]const u8, 2 + idxs.items.len);
+    argv[0] = mt_path;
+    argv[1] = "install";
+    for (idxs.items, 0..) |idx, k| argv[2 + k] = st.items[idx].name;
+    return argv;
 }
 
 /// Delegate the selected hit's install to the real `mt` inline, then re-run the
@@ -1496,6 +1525,38 @@ test "installArgv returns null on an already-installed hit and on an empty list"
     try std.testing.expect((try installArgv(std.testing.allocator, "/bin/mt", &st)) == null); // already installed
     const empty: search.State = .{ .items = &.{} };
     try std.testing.expect((try installArgv(std.testing.allocator, "/bin/mt", &empty)) == null); // nothing selected
+}
+
+test "installArgv installs every checked, not-installed hit as bare names for a batch" {
+    const items = [_]search.Match{
+        .{ .name = "wget", .kind = .formula, .installed = false },
+        .{ .name = "firefox", .kind = .cask, .installed = true }, // installed → excluded
+        .{ .name = "ripgrep", .kind = .formula, .installed = false },
+    };
+    var checked = [_]bool{ true, true, true };
+    const st: search.State = .{ .items = &items, .checked = &checked };
+    const argv = (try installArgv(std.testing.allocator, "/bin/mt", &st)).?;
+    defer std.testing.allocator.free(argv);
+    // mt, install, wget, ripgrep — a batch passes bare names (no global kind flag).
+    try std.testing.expectEqual(@as(usize, 4), argv.len);
+    try std.testing.expectEqualStrings("install", argv[1]);
+    try std.testing.expectEqualStrings("wget", argv[2]);
+    try std.testing.expectEqualStrings("ripgrep", argv[3]);
+}
+
+test "installArgv installs the checked row, not the active one, and keeps the kind flag for a single target" {
+    const items = [_]search.Match{
+        .{ .name = "wget", .kind = .formula, .installed = false },
+        .{ .name = "ripgrep", .kind = .formula, .installed = false },
+    };
+    var checked = [_]bool{ true, false }; // wget checked; ripgrep is active but unchecked
+    var st: search.State = .{ .items = &items, .checked = &checked };
+    st.chrome.view.selected = 1;
+    const argv = (try installArgv(std.testing.allocator, "/bin/mt", &st)).?;
+    defer std.testing.allocator.free(argv);
+    try std.testing.expectEqual(@as(usize, 4), argv.len); // single → mt, install, --formula, name
+    try std.testing.expectEqualStrings("--formula", argv[2]);
+    try std.testing.expectEqualStrings("wget", argv[3]); // the checked row, not active ripgrep
 }
 
 test "installArgv disambiguates a name that exists as both a formula and a cask" {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -227,10 +227,10 @@ fn stepFilter(a: *App, key: Key) void {
         .enter => { // commit, keep the filter
             a.editing = false;
             // Search divergence: its filter doubles as the search box, so
-            // committing the query *is* the search. Only the Search tab claims
-            // the commit — every other tab's filter merely narrows an already
-            // loaded list, so routing Enter there would mis-fire their domain key.
-            if (a.active == .search) routeToTab(a, .enter);
+            // committing the query *is* the search. Set the request directly
+            // rather than routing Enter to the tab, whose Enter now means "open
+            // info" — every other tab's filter just narrows a loaded list.
+            if (a.active == .search) a.states.search.request = .search;
         },
         .esc => { // cancel: clear the filter
             activeChrome(a).filter.clear();
@@ -270,10 +270,12 @@ fn stepNormal(a: *App, key: Key) void {
             routeToTab(a, key); // a domain key (e.g. u/f) belongs to the tab
         },
         .enter => {
-            // The Search tab's filter doubles as its query box, so Enter focuses
-            // it for typing (a second Enter then commits + searches). Every other
-            // tab uses Enter as a domain key (open detail, upgrade), so route it.
-            if (a.active == .search) a.editing = true else routeToTab(a, key);
+            // On Search, Enter focuses the query box when there are no results
+            // yet (so the user can type), and opens info for the active hit once
+            // results are loaded. Every other tab uses Enter as a domain key.
+            if (a.active == .search and a.states.search.items.len == 0) {
+                a.editing = true;
+            } else routeToTab(a, key);
         },
         .space, .end, .esc => routeToTab(a, key),
         // `end` needs the row count to land on the last row — deferred to the
@@ -345,12 +347,12 @@ fn loadingLine(buf: []u8, app: *const App) []const u8 {
 }
 
 /// The footer help line: while editing the filter, just the edit keys; otherwise
-/// the active tab's action keys, then the shell-wide keys — so every key a user
-/// can press from here is in one place. Built into `buf`; falls back to the
-/// global keys alone if it can't fit.
+/// the shell-wide keys first (so quit/switch survive a narrow terminal) then the
+/// active tab's action keys. Built into `buf`; falls back to the global keys
+/// alone if it can't fit.
 fn footerLine(buf: []u8, app: *const App) []const u8 {
     if (app.editing) return footerHelp(true);
-    return std.fmt.bufPrint(buf, "{s}   ·   {s}", .{ activeFooterHint(app), footerHelp(false) }) catch footerHelp(false);
+    return std.fmt.bufPrint(buf, "{s}   ·   {s}", .{ footerHelp(false), activeFooterHint(app) }) catch footerHelp(false);
 }
 
 fn footerHelp(editing: bool) []const u8 {
@@ -430,6 +432,9 @@ const Store = struct {
     /// The Search tab's checkbox state, parallel to `search.?.items`. Owned here,
     /// resized to the result count on each query, borrowed by the tab.
     search_checked: []bool = &.{},
+    /// Backing storage for the Search tab's open `mt info` pane (its own slot so
+    /// it never clobbers the Installed tab's detail parse).
+    search_detail: ?info_json.Parsed = null,
 
     fn deinit(self: *Store, allocator: std.mem.Allocator) void {
         if (self.installed) |p| p.deinit();
@@ -440,6 +445,7 @@ const Store = struct {
         if (self.doctor) |p| p.deinit();
         if (self.search) |p| p.deinit();
         if (self.search_checked.len != 0) allocator.free(self.search_checked);
+        if (self.search_detail) |p| p.deinit();
     }
 };
 
@@ -795,8 +801,13 @@ fn loadSearch(io: std.Io, allocator: std.mem.Allocator, app: *App, store: *Store
     app.states.search.checked = checked;
     app.states.search.phase = .loaded;
     // A fresh query is a new result set, so an old cursor would point at an
-    // unrelated row; reset to the top.
+    // unrelated row, and any open info pane is for a hit that may be gone.
     app.states.search.chrome.view = .{};
+    app.states.search.detail = null;
+    if (store.search_detail) |old| {
+        old.deinit();
+        store.search_detail = null;
+    }
 }
 
 /// Build the `mt install …` argv for the Search tab. Pure over the tab state:
@@ -866,7 +877,30 @@ fn serviceSearch(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, app: *
         .none => {},
         .search => try loadSearch(io, allocator, app, store),
         .install => try doInstall(io, allocator, t, app, store),
+        .info => try openSearchInfo(io, allocator, app, store),
     }
+}
+
+/// Open the `mt info` pane for the active hit. `mt info` resolves installed and
+/// uninstalled packages alike, so a search result can be inspected before any
+/// install. A read (no alt-screen drop); failure names the package in a banner
+/// and leaves the pane closed.
+fn openSearchInfo(io: std.Io, allocator: std.mem.Allocator, app: *App, store: *Store) RunError!void {
+    const m = search.selectedMatch(&app.states.search) orelse return; // empty list: no-op
+    errdefer |err| {
+        var sb: [96]u8 = undefined;
+        const op = std.fmt.bufPrint(&sb, "info for {s} failed", .{m.name}) catch "info read failed";
+        app.banner.set(op, @errorName(err));
+    }
+    const argv = try spawn.jsonArgv(allocator, app.mt_path, &.{ "info", m.name });
+    defer allocator.free(argv);
+    const bytes = try spawn.readJson(io, allocator, argv);
+    defer allocator.free(bytes);
+
+    const parsed = try info_json.parse(allocator, bytes);
+    if (store.search_detail) |old| old.deinit();
+    store.search_detail = parsed;
+    app.states.search.detail = parsed.info;
 }
 
 /// Drain the active tab's pending effects after a keypress. Each tab's service is
@@ -1130,6 +1164,16 @@ test "Enter on the Search tab focuses the query box rather than firing an empty 
     a = step(a, .enter);
     try std.testing.expect(a.editing); // the query box is now focused for typing
     try std.testing.expectEqual(search.Request.none, a.states.search.request); // no search fired yet
+}
+
+test "Enter on the Search tab opens info once results are loaded" {
+    const items = [_]search.Match{.{ .name = "wget", .kind = .formula, .installed = false }};
+    var a: App = .{ .active = .search };
+    a.states.search.items = &items;
+    a.states.search.phase = .loaded;
+    a = step(a, .enter);
+    try std.testing.expect(!a.editing); // a row is active, so Enter inspects it, not the box
+    try std.testing.expectEqual(search.Request.info, a.states.search.request);
 }
 
 test "Enter on a data tab still routes as that tab's domain key, not a focus" {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -139,6 +139,10 @@ pub const App = struct {
     /// footer, dismissed on the next keypress (`step`); a successful action just
     /// leaves it cleared.
     banner: Banner = .{},
+    /// Set by the loop only for the pre-read paint before a blocking lazy
+    /// refetch, so the synchronous freeze shows "Loading…" instead of a stale
+    /// frame. Never persisted: the read's own repaint clears it.
+    loading: bool = false,
 };
 
 /// After a delegated mutation the active tab was just re-read inline, so it is
@@ -184,6 +188,12 @@ fn renderActive(a: *const App, f: *tab.Frame, rect: tab.Rect) void {
 fn activeFooterHint(a: *const App) []const u8 {
     switch (a.active) {
         inline else => |t| return moduleFor(t).footerHint(),
+    }
+}
+
+fn activeTitle(a: *const App) []const u8 {
+    switch (a.active) {
+        inline else => |t| return moduleFor(t).title(),
     }
 }
 
@@ -291,12 +301,17 @@ pub fn renderFrame(buf: []u8, app: *const App, cols: u16, rows: u16) []const u8 
 
             renderActive(app, &f, r.content);
 
-            // Footer: a rule line separating content, then either the transient
-            // recoverable-error banner or the dimmed help line on the row below.
+            // Footer: a rule line separating content, then — by priority — the
+            // pre-read loading status, the transient error banner, or the help line.
             f.moveTo(r.footer.row, 1);
             putRule(&f, cols);
             f.moveTo(r.footer.row + 1, 1);
-            if (app.banner.isSet()) {
+            if (app.loading) {
+                var lb: [64]u8 = undefined;
+                f.put(color.roleCode(.accent));
+                f.putContent(scroll_list.truncate(loadingLine(&lb, app), cols));
+                f.put(color.Style.reset.code());
+            } else if (app.banner.isSet()) {
                 // Undimmed + yellow so a recoverable failure reads as a warning,
                 // not chrome; `putContent` drops line-breakers the sanitizer let
                 // through, `truncate` keeps it within the column budget.
@@ -317,6 +332,10 @@ pub fn renderFrame(buf: []u8, app: *const App, cols: u16, rows: u16) []const u8 
 fn putRule(f: *tab.Frame, cols: u16) void {
     var i: u16 = 0;
     while (i < cols) : (i += 1) f.put("─");
+}
+
+fn loadingLine(buf: []u8, app: *const App) []const u8 {
+    return std.fmt.bufPrint(buf, "Loading {s}…", .{activeTitle(app)}) catch "Loading…";
 }
 
 /// The footer help line: while editing the filter, just the edit keys; otherwise
@@ -910,6 +929,7 @@ pub fn run(io: std.Io, allocator: std.mem.Allocator, stderr: std.Io.File, enviro
                     app = step(app, k.key); // also clears any prior banner
                     if (app.quit) break;
                     paintSearching(fd, &frame, allocator, &app); // status before the blocking search
+                    paintLoading(fd, &frame, allocator, &app); // "Loading…" before a blocking lazy refetch
                     // A recoverable backend fault becomes the banner the failing
                     // op already set and the loop continues; only a fatal fault
                     // (terminal/OOM) propagates to the errdefer restore + exit.
@@ -935,6 +955,17 @@ fn paintSearching(fd: std.posix.fd_t, frame: *[]u8, allocator: std.mem.Allocator
     if (app.states.search.chrome.filter.slice().len == 0) return; // empty query: no spawn
     app.states.search.phase = .searching;
     repaint(fd, frame, allocator, app) catch {};
+}
+
+/// Before the active tab runs a blocking lazy refetch (it is dirty and will
+/// refetch on entry), paint a "Loading…" footer so the synchronous read reads as
+/// intentional, not a frozen or — before stderr was suppressed — garbled frame.
+/// Best-effort, like `paintSearching`; the read's own repaint draws the result.
+fn paintLoading(fd: std.posix.fd_t, frame: *[]u8, allocator: std.mem.Allocator, app: *App) void {
+    if (!app.dirty.contains(app.active)) return; // nothing will refetch this turn
+    app.loading = true;
+    repaint(fd, frame, allocator, app) catch {};
+    app.loading = false;
 }
 
 fn repaint(fd: std.posix.fd_t, frame: *[]u8, allocator: std.mem.Allocator, app: *App) std.mem.Allocator.Error!void {
@@ -1100,6 +1131,15 @@ test "the footer carries the active tab's keys next to the global keys" {
     const out = renderFrame(&buf, &a, 100, 24);
     try std.testing.expect(std.mem.indexOf(u8, out, "s: start") != null); // the active tab's keys
     try std.testing.expect(std.mem.indexOf(u8, out, "switch") != null); // and the global keys
+}
+
+test "the footer shows a per-tab loading status during a blocking refetch" {
+    var a: App = .{ .active = .doctor, .loading = true };
+    var buf: [8192]u8 = undefined;
+    const out = renderFrame(&buf, &a, 100, 24);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Loading Doctor") != null);
+    // Loading takes precedence over the help line so the freeze reads as intentional.
+    try std.testing.expect(std.mem.indexOf(u8, out, "switch") == null);
 }
 
 test "renderFrame uses cursor positioning and never emits a raw newline" {

--- a/src/tui/detail_pane.zig
+++ b/src/tui/detail_pane.zig
@@ -19,10 +19,14 @@ pub const Field = struct {
     value: []const u8,
 };
 
-/// Rows the pane needs to show every field at `width` with values wrapped, so a
-/// caller can size the split to the content instead of a fixed guess.
+// One dim rule sits at the top of the pane, marking where the list ends and the
+// detail begins so the pane doesn't read as overlapping the list.
+const separator_rows: u16 = 1;
+
+/// Rows the pane needs to show its separator plus every field at `width` with
+/// values wrapped, so a caller can size the split to the content.
 pub fn neededRows(fields: []const Field, width: u16) u16 {
-    var rows: u16 = 0;
+    var rows: u16 = separator_rows;
     for (fields) |field| {
         var it = wrapIter(field, width);
         var n: u16 = 0;
@@ -32,13 +36,22 @@ pub fn neededRows(fields: []const Field, width: u16) u16 {
     return rows;
 }
 
-/// Paint `fields` into `rect`: a dim `label:` then its value, the value wrapped
-/// across rows (continuations indented under it) so a long message stays
-/// readable on a narrow pane instead of being cut off. Clipped to `rect.height`,
-/// painted through `Frame.putContent` so untrusted child values can't break the
-/// frame. Pure function of `(fields, rect)` → reflows on resize.
+/// Paint a dim separator rule, then `fields`: a dim `label:` then its value, the
+/// value wrapped across rows (continuations indented under it) so a long message
+/// stays readable on a narrow pane instead of being cut off. Clipped to
+/// `rect.height`, painted through `Frame.putContent` so untrusted child values
+/// can't break the frame. Pure function of `(fields, rect)` → reflows on resize.
 pub fn render(f: *tab.Frame, fields: []const Field, rect: tab.Rect) void {
-    if (rect.width == 0) return;
+    if (rect.width == 0 or rect.height == 0) return;
+    f.moveTo(rect.row, rect.col);
+    f.put(color.roleCode(.muted));
+    var i: u16 = 0;
+    while (i < rect.width) : (i += 1) f.put("─");
+    f.put(color.Style.reset.code());
+    renderFields(f, fields, .{ .row = rect.row + separator_rows, .col = rect.col, .width = rect.width, .height = rect.height -| separator_rows });
+}
+
+fn renderFields(f: *tab.Frame, fields: []const Field, rect: tab.Rect) void {
     var row: u16 = 0;
     for (fields) |field| {
         if (row >= rect.height) break;
@@ -130,27 +143,29 @@ test "render dims the label and shows the value on its row" {
     try testing.expect(std.mem.indexOf(u8, out, "yes") != null);
     // The label is dimmed (muted role == dim on the basic tier under test).
     try testing.expect(std.mem.indexOf(u8, out, color.Style.dim.code()) != null);
-    try testing.expect(std.mem.indexOf(u8, out, "\x1b[3;1H") != null); // first field row
-    try testing.expect(std.mem.indexOf(u8, out, "\x1b[4;1H") != null); // second field row
+    try testing.expect(std.mem.indexOf(u8, out, "─") != null); // the separator rule
+    // The rule is on the pane's first row; the fields follow below it.
+    try testing.expect(std.mem.indexOf(u8, out, "\x1b[4;1H") != null); // first field row
+    try testing.expect(std.mem.indexOf(u8, out, "\x1b[5;1H") != null); // second field row
 }
 
 test "render wraps a long value across rows instead of cutting it off" {
     var fb: [1024]u8 = undefined;
     var f: tab.Frame = .{ .buf = &fb };
     const fields = [_]Field{.{ .label = "Detail", .value = "the prefix bin dir is not on PATH so installed commands will not be found" }};
-    render(&f, &fields, .{ .row = 1, .col = 1, .width = 24, .height = 6 });
+    render(&f, &fields, .{ .row = 1, .col = 1, .width = 24, .height = 10 });
     const out = f.slice();
     try testing.expect(std.mem.indexOf(u8, out, "found") != null); // the tail survives on a wrapped row
-    try testing.expect(std.mem.indexOf(u8, out, "\x1b[2;") != null); // a continuation row was positioned
+    try testing.expect(std.mem.indexOf(u8, out, ";9H") != null); // a continuation row aligned under the value
 }
 
 test "neededRows grows with a wrapped value and counts at least one row per field" {
     const short = [_]Field{.{ .label = "A", .value = "x" }};
-    try testing.expectEqual(@as(u16, 1), neededRows(&short, 40));
+    try testing.expectEqual(@as(u16, 2), neededRows(&short, 40)); // separator + one field row
     const long = [_]Field{.{ .label = "Detail", .value = "one two three four five six seven eight nine ten" }};
-    try testing.expect(neededRows(&long, 20) > 1); // wraps at width 20
+    try testing.expect(neededRows(&long, 20) > 2); // wraps to several rows at width 20
     const empty = [_]Field{.{ .label = "Deps", .value = "" }};
-    try testing.expectEqual(@as(u16, 1), neededRows(&empty, 40)); // the label row still counts
+    try testing.expectEqual(@as(u16, 2), neededRows(&empty, 40)); // separator + the label row
 }
 
 test "render clips fields past the pane height" {
@@ -161,11 +176,11 @@ test "render clips fields past the pane height" {
         .{ .label = "B", .value = "beta" },
         .{ .label = "C", .value = "gamma" },
     };
-    render(&f, &fields, .{ .row = 1, .col = 1, .width = 40, .height = 2 });
+    render(&f, &fields, .{ .row = 1, .col = 1, .width = 40, .height = 3 }); // separator + 2 field rows
     const out = f.slice();
     try testing.expect(std.mem.indexOf(u8, out, "alpha") != null);
     try testing.expect(std.mem.indexOf(u8, out, "beta") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "gamma") == null); // third field clipped
+    try testing.expect(std.mem.indexOf(u8, out, "gamma") == null); // third field clipped past the height
 }
 
 test "render hard-breaks a single word longer than the line so its tail survives" {
@@ -177,7 +192,7 @@ test "render hard-breaks a single word longer than the line so its tail survives
     render(&f, &fields, .{ .row = 1, .col = 1, .width = 20, .height = 8 });
     const out = f.slice();
     try testing.expect(std.mem.indexOf(u8, out, "all") != null); // the tail is reached
-    try testing.expect(std.mem.indexOf(u8, out, "\x1b[2;") != null); // wrapped past the first row
+    try testing.expect(std.mem.indexOf(u8, out, ";9H") != null); // wrapped onto an aligned continuation row
 }
 
 test "render and neededRows survive a pane narrower than the label" {

--- a/src/tui/detail_pane.zig
+++ b/src/tui/detail_pane.zig
@@ -8,48 +8,114 @@
 //! can't break the frame. Pure function of `(fields, rect)` → reflows on resize.
 
 const std = @import("std");
+const color = @import("../ui/color.zig");
 const tab = @import("tab.zig");
-const scroll_list = @import("scroll_list.zig");
 
-/// One labelled row. `value` is a single line; a multi-valued field (e.g. a
-/// dependency list) is pre-joined by the caller so the pane stays generic.
+/// One labelled row. `value` is a single logical line; a multi-valued field
+/// (e.g. a dependency list) is pre-joined by the caller so the pane stays
+/// generic. A long value wraps across rows rather than being truncated.
 pub const Field = struct {
     label: []const u8,
     value: []const u8,
 };
 
-/// Paint `fields` into `rect`, one `label: value` line each, top-aligned. Lines
-/// past `rect.height` are clipped; each line is width-truncated to `rect.width`.
+/// Rows the pane needs to show every field at `width` with values wrapped, so a
+/// caller can size the split to the content instead of a fixed guess.
+pub fn neededRows(fields: []const Field, width: u16) u16 {
+    var rows: u16 = 0;
+    for (fields) |field| {
+        var it = wrapIter(field, width);
+        var n: u16 = 0;
+        while (it.next()) |_| n += 1;
+        rows += @max(@as(u16, 1), n); // an empty value still takes the label row
+    }
+    return rows;
+}
+
+/// Paint `fields` into `rect`: a dim `label:` then its value, the value wrapped
+/// across rows (continuations indented under it) so a long message stays
+/// readable on a narrow pane instead of being cut off. Clipped to `rect.height`,
+/// painted through `Frame.putContent` so untrusted child values can't break the
+/// frame. Pure function of `(fields, rect)` → reflows on resize.
 pub fn render(f: *tab.Frame, fields: []const Field, rect: tab.Rect) void {
-    for (fields, 0..) |field, i| {
-        if (i >= rect.height) break; // clip to the pane height
-        f.moveTo(rect.row + @as(u16, @intCast(i)), rect.col);
-        var buf: [256]u8 = undefined;
-        f.putContent(scroll_list.truncate(line(&buf, field), rect.width));
+    if (rect.width == 0) return;
+    var row: u16 = 0;
+    for (fields) |field| {
+        if (row >= rect.height) break;
+        const indent = labelWidth(field);
+        // The dim `label: ` sits on the field's first row; the value flows after.
+        f.moveTo(rect.row + row, rect.col);
+        f.put(color.roleCode(.muted));
+        f.putContent(field.label);
+        f.putContent(": ");
+        f.put(color.Style.reset.code());
+
+        var it = wrapIter(field, rect.width);
+        var first = true;
+        var painted = false;
+        while (it.next()) |chunk| {
+            if (row >= rect.height) return;
+            // First chunk continues on the label's row; later chunks align under
+            // the value via the label-width indent.
+            if (!first) f.moveTo(rect.row + row, rect.col + indent);
+            f.putContent(chunk);
+            row += 1;
+            first = false;
+            painted = true;
+        }
+        if (!painted) row += 1; // empty value: the label row still consumed one
     }
 }
 
-/// Compose `"label: value"` into `buf`, bounded — a value longer than the
-/// scratch is cut, never overflowed (the pane re-truncates to width anyway).
-fn line(buf: []u8, field: Field) []const u8 {
-    var len: usize = 0;
-    appendInto(buf, &len, field.label);
-    appendInto(buf, &len, ": ");
-    appendInto(buf, &len, field.value);
-    return buf[0..len];
+fn labelWidth(field: Field) u16 {
+    return @intCast(field.label.len + 2); // "label: "
 }
 
-fn appendInto(buf: []u8, len: *usize, s: []const u8) void {
-    const n = @min(s.len, buf.len - len.*);
-    @memcpy(buf[len.*..][0..n], s[0..n]);
-    len.* += n;
+/// Width available for the value, after the `label: ` prefix; at least one
+/// column so wrapping always makes progress on a very narrow pane.
+fn valueWidth(field: Field, width: u16) usize {
+    const prefix = labelWidth(field);
+    return if (width > prefix) width - prefix else 1;
+}
+
+const WrapIter = struct {
+    rest: []const u8,
+    width: usize,
+
+    fn next(self: *WrapIter) ?[]const u8 {
+        if (self.rest.len == 0) return null;
+        const take = wrapTake(self.rest, self.width);
+        const chunk = self.rest[0..take];
+        self.rest = trimLeading(self.rest[take..]);
+        return chunk;
+    }
+};
+
+fn wrapIter(field: Field, width: u16) WrapIter {
+    return .{ .rest = field.value, .width = valueWidth(field, width) };
+}
+
+/// Bytes of `s` for one line of at most `max` columns: break at the last space
+/// that fits, else hard-break at `max` (a single word wider than the line).
+/// Grapheme-naive — one byte ≈ one column, like the rest of the TUI.
+fn wrapTake(s: []const u8, max: usize) usize {
+    if (s.len <= max) return s.len;
+    var i = max;
+    while (i > 0) : (i -= 1) if (s[i - 1] == ' ') return i; // include the break space
+    return max; // no space in the window: hard break
+}
+
+fn trimLeading(s: []const u8) []const u8 {
+    var r = s;
+    while (r.len > 0 and r[0] == ' ') r = r[1..];
+    return r;
 }
 
 // ─── tests ───────────────────────────────────────────────────────────
 
 const testing = std.testing;
 
-test "render paints one label: value line per field at its row" {
+test "render dims the label and shows the value on its row" {
     var fb: [512]u8 = undefined;
     var f: tab.Frame = .{ .buf = &fb };
     const fields = [_]Field{
@@ -58,35 +124,68 @@ test "render paints one label: value line per field at its row" {
     };
     render(&f, &fields, .{ .row = 3, .col = 1, .width = 40, .height = 10 });
     const out = f.slice();
-    try testing.expect(std.mem.indexOf(u8, out, "Tap: homebrew/core") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Pinned: yes") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Tap") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "homebrew/core") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "Pinned") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "yes") != null);
+    // The label is dimmed (muted role == dim on the basic tier under test).
+    try testing.expect(std.mem.indexOf(u8, out, color.Style.dim.code()) != null);
     try testing.expect(std.mem.indexOf(u8, out, "\x1b[3;1H") != null); // first field row
     try testing.expect(std.mem.indexOf(u8, out, "\x1b[4;1H") != null); // second field row
+}
+
+test "render wraps a long value across rows instead of cutting it off" {
+    var fb: [1024]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &fb };
+    const fields = [_]Field{.{ .label = "Detail", .value = "the prefix bin dir is not on PATH so installed commands will not be found" }};
+    render(&f, &fields, .{ .row = 1, .col = 1, .width = 24, .height = 6 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, "found") != null); // the tail survives on a wrapped row
+    try testing.expect(std.mem.indexOf(u8, out, "\x1b[2;") != null); // a continuation row was positioned
+}
+
+test "neededRows grows with a wrapped value and counts at least one row per field" {
+    const short = [_]Field{.{ .label = "A", .value = "x" }};
+    try testing.expectEqual(@as(u16, 1), neededRows(&short, 40));
+    const long = [_]Field{.{ .label = "Detail", .value = "one two three four five six seven eight nine ten" }};
+    try testing.expect(neededRows(&long, 20) > 1); // wraps at width 20
+    const empty = [_]Field{.{ .label = "Deps", .value = "" }};
+    try testing.expectEqual(@as(u16, 1), neededRows(&empty, 40)); // the label row still counts
 }
 
 test "render clips fields past the pane height" {
     var fb: [512]u8 = undefined;
     var f: tab.Frame = .{ .buf = &fb };
     const fields = [_]Field{
-        .{ .label = "A", .value = "1" },
-        .{ .label = "B", .value = "2" },
-        .{ .label = "C", .value = "3" },
+        .{ .label = "A", .value = "alpha" },
+        .{ .label = "B", .value = "beta" },
+        .{ .label = "C", .value = "gamma" },
     };
     render(&f, &fields, .{ .row = 1, .col = 1, .width = 40, .height = 2 });
     const out = f.slice();
-    try testing.expect(std.mem.indexOf(u8, out, "A: 1") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "B: 2") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "C: 3") == null); // clipped
+    try testing.expect(std.mem.indexOf(u8, out, "alpha") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "beta") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "gamma") == null); // third field clipped
 }
 
-test "render width-truncates a long value to the pane width" {
-    var fb: [512]u8 = undefined;
+test "render hard-breaks a single word longer than the line so its tail survives" {
+    var fb: [1024]u8 = undefined;
     var f: tab.Frame = .{ .buf = &fb };
-    const fields = [_]Field{.{ .label = "Deps", .value = "brotli, zstd, openssl@3, libssh2" }};
-    render(&f, &fields, .{ .row = 1, .col = 1, .width = 10, .height = 1 });
-    // "Deps: brot" — 10 visible columns, no more.
-    try testing.expect(std.mem.indexOf(u8, f.slice(), "Deps: brot") != null);
-    try testing.expect(std.mem.indexOf(u8, f.slice(), "openssl") == null);
+    // A long no-space token (a path) has no space to break at, so it wraps by a
+    // hard break — the end must still appear, not be cut off.
+    const fields = [_]Field{.{ .label = "Detail", .value = "/tmp/malt-test/bin/a/very/long/path/with/no/spaces/anywhere/at/all" }};
+    render(&f, &fields, .{ .row = 1, .col = 1, .width = 20, .height = 8 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, "all") != null); // the tail is reached
+    try testing.expect(std.mem.indexOf(u8, out, "\x1b[2;") != null); // wrapped past the first row
+}
+
+test "render and neededRows survive a pane narrower than the label" {
+    var fb: [256]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &fb };
+    const fields = [_]Field{.{ .label = "Dependencies", .value = "brotli, zstd" }};
+    _ = neededRows(&fields, 4); // a degenerate width must not loop forever
+    render(&f, &fields, .{ .row = 1, .col = 1, .width = 4, .height = 6 }); // must not trap
 }
 
 test "render of an embedded newline value cannot inject a frame line" {
@@ -94,6 +193,7 @@ test "render of an embedded newline value cannot inject a frame line" {
     var f: tab.Frame = .{ .buf = &fb };
     const fields = [_]Field{.{ .label = "X", .value = "a\nb" }};
     render(&f, &fields, .{ .row = 1, .col = 1, .width = 40, .height = 4 });
-    // The newline is dropped by putContent, so the value collapses to one line.
-    try testing.expect(std.mem.indexOf(u8, f.slice(), "X: ab") != null);
+    const out = f.slice();
+    try testing.expect(std.mem.indexOfScalar(u8, out, '\n') == null); // no raw newline in the frame
+    try testing.expect(std.mem.indexOf(u8, out, "ab") != null); // the newline collapsed to inert text
 }

--- a/src/tui/doctor_tab.zig
+++ b/src/tui/doctor_tab.zig
@@ -127,26 +127,33 @@ fn severityLabel(sev: Severity) []const u8 {
     };
 }
 
-// Bottom-pane budget: severity + fix + detail fit in three rows; the split never
-// takes more than half the content so the list always survives.
-const detail_rows: u16 = 3;
-
 // SGR reverse-video for the selection, matching the other tabs' convention.
 const reverse = "\x1b[7m";
 
 /// Pure render: the severity-ordered finding list and a detail pane for the
 /// selected finding. The `f: fix` key lives in the shared footer (the detail
-/// pane still shows whether the selected finding is fixable). A pure function of
-/// `(state, rect)` so a resize is a re-render.
+/// pane still shows whether the selected finding is fixable). The pane sizes to
+/// its (wrapped) content, capped at half the height so the list survives. A pure
+/// function of `(state, rect)` so a resize is a re-render.
 pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     if (r.height == 0) return;
     const sel = selectedFinding(s);
     var content: tab.Rect = r;
     if (sel) |fnd| {
-        const dh = @min(@as(u16, detail_rows), content.height / 2);
+        var fix_buf: [96]u8 = undefined;
+        const fix_value = if (fnd.fixable)
+            std.fmt.bufPrint(&fix_buf, "f → mt doctor --fix {s}", .{doctor_json.fixClassTag(fnd.fix_class)}) catch "f: fix"
+        else
+            "not auto-fixable";
+        const fields = [_]detail_pane.Field{
+            .{ .label = "Severity", .value = severityLabel(fnd.severity) },
+            .{ .label = "Fix", .value = fix_value },
+            .{ .label = "Detail", .value = if (fnd.detail.len != 0) fnd.detail else "-" },
+        };
+        const dh = @min(detail_pane.neededRows(&fields, content.width), content.height / 2);
         if (dh > 0 and dh < content.height) {
             content.height -= dh;
-            renderDetail(fnd, f, .{ .row = content.row + content.height, .col = content.col, .width = content.width, .height = dh });
+            detail_pane.render(f, &fields, .{ .row = content.row + content.height, .col = content.col, .width = content.width, .height = dh });
         }
     }
     renderList(s, f, content);
@@ -181,20 +188,6 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
             if (selected) f.put(color.Style.reset.code());
         }
     }
-}
-
-fn renderDetail(fnd: Row, f: *tab.Frame, rect: tab.Rect) void {
-    var fix_buf: [96]u8 = undefined;
-    const fix_value = if (fnd.fixable)
-        std.fmt.bufPrint(&fix_buf, "f → mt doctor --fix {s}", .{doctor_json.fixClassTag(fnd.fix_class)}) catch "f: fix"
-    else
-        "not auto-fixable";
-    const fields = [_]detail_pane.Field{
-        .{ .label = "Severity", .value = severityLabel(fnd.severity) },
-        .{ .label = "Fix", .value = fix_value },
-        .{ .label = "Detail", .value = if (fnd.detail.len != 0) fnd.detail else "-" },
-    };
-    detail_pane.render(f, &fields, rect);
 }
 
 // ─── tests ───────────────────────────────────────────────────────────

--- a/src/tui/filter_input.zig
+++ b/src/tui/filter_input.zig
@@ -39,10 +39,12 @@ pub const Filter = struct {
     }
 };
 
-/// Render the filter line. The `filter:` label is always shown so the
-/// affordance is visible; `/` activates editing, which adds a caret (`_`, since
-/// the real cursor is hidden). Truncated to `cols`. Returns a prefix of `buf`.
-pub fn render(buf: []u8, text: []const u8, editing: bool, cols: u16) []const u8 {
+/// Render the input line. `label` names what the box does for the active tab
+/// (`filter: ` everywhere a static list is narrowed, `search: ` on the Search
+/// tab where the box is the query) and is always shown so the affordance is
+/// visible; `/` activates editing, which adds a caret (`_`, since the real cursor
+/// is hidden). Truncated to `cols`. Returns a prefix of `buf`.
+pub fn render(buf: []u8, label: []const u8, text: []const u8, editing: bool, cols: u16) []const u8 {
     var len: usize = 0;
     const put = struct {
         fn f(b: []u8, l: *usize, s: []const u8) void {
@@ -51,7 +53,7 @@ pub fn render(buf: []u8, text: []const u8, editing: bool, cols: u16) []const u8 
             l.* += n;
         }
     }.f;
-    put(buf, &len, "filter: ");
+    put(buf, &len, label);
     put(buf, &len, text);
     if (editing) put(buf, &len, "_");
     return scroll_list.truncate(buf[0..len], cols);
@@ -84,16 +86,18 @@ test "backspace removes a whole multibyte rune" {
     try std.testing.expectEqual(@as(usize, 0), f.len);
 }
 
-test "render keeps the filter label visible; caret only while editing" {
+test "render shows the given label; caret only while editing" {
     var buf: [128]u8 = undefined;
-    try std.testing.expectEqualStrings("filter: ab_", render(&buf, "ab", true, 80));
-    try std.testing.expectEqualStrings("filter: ab", render(&buf, "ab", false, 80));
-    // The label persists even with no filter, so the affordance is discoverable.
-    try std.testing.expectEqualStrings("filter: ", render(&buf, "", false, 80));
+    try std.testing.expectEqualStrings("filter: ab_", render(&buf, "filter: ", "ab", true, 80));
+    try std.testing.expectEqualStrings("filter: ab", render(&buf, "filter: ", "ab", false, 80));
+    // The label persists even with no text, so the affordance is discoverable.
+    try std.testing.expectEqualStrings("filter: ", render(&buf, "filter: ", "", false, 80));
+    // The Search tab labels the same box as the query it really is.
+    try std.testing.expectEqualStrings("search: rip_", render(&buf, "search: ", "rip", true, 80));
 }
 
 test "render truncates to the column budget" {
     var buf: [128]u8 = undefined;
-    const out = render(&buf, "abcdef", true, 3); // "fil" — 3 visible cols
+    const out = render(&buf, "filter: ", "abcdef", true, 3); // "fil" — 3 visible cols
     try std.testing.expectEqual(@as(usize, 3), out.len);
 }

--- a/src/tui/installed_tab.zig
+++ b/src/tui/installed_tab.zig
@@ -120,18 +120,23 @@ pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     }
     var list_rect = content;
     if (s.detail) |d| {
-        const dh = @min(@as(u16, detail_rows), content.height / 2);
+        var size_buf: [16]u8 = undefined;
+        var deps_buf: [512]u8 = undefined;
+        const fields = [_]detail_pane.Field{
+            .{ .label = "Tap", .value = if (d.info.tap.len != 0) d.info.tap else "-" },
+            .{ .label = "Size", .value = humanSize(&size_buf, d.pkg.size_bytes) },
+            .{ .label = "Linked", .value = yesNo(d.pkg.linked) },
+            .{ .label = "Pinned", .value = if (d.pkg.pinned) "yes" else "no" },
+            .{ .label = "Dependencies", .value = joinDeps(&deps_buf, d.info.dependencies) },
+        };
+        const dh = @min(detail_pane.neededRows(&fields, content.width), content.height / 2);
         if (dh > 0 and dh < content.height) {
             list_rect.height = content.height - dh;
-            renderDetail(d, f, .{ .row = content.row + list_rect.height, .col = content.col, .width = content.width, .height = dh });
+            detail_pane.render(f, &fields, .{ .row = content.row + list_rect.height, .col = content.col, .width = content.width, .height = dh });
         }
     }
     renderList(s, f, list_rect);
 }
-
-/// Bottom-pane budget: five fields fit in `detail_rows`; the split never takes
-/// more than half the content so the list always survives.
-const detail_rows: u16 = 5;
 
 fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     if (rect.height == 0) return;
@@ -164,19 +169,6 @@ fn renderGuard(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     const line = std.fmt.bufPrint(&b, "Uninstall {s}? [y/N]", .{name}) catch "Uninstall? [y/N]";
     f.putContent(scroll_list.truncate(line, rect.width));
     f.put(color.Style.reset.code());
-}
-
-fn renderDetail(d: Detail, f: *tab.Frame, rect: tab.Rect) void {
-    var size_buf: [16]u8 = undefined;
-    var deps_buf: [512]u8 = undefined;
-    const fields = [_]detail_pane.Field{
-        .{ .label = "Tap", .value = if (d.info.tap.len != 0) d.info.tap else "-" },
-        .{ .label = "Size", .value = humanSize(&size_buf, d.pkg.size_bytes) },
-        .{ .label = "Linked", .value = yesNo(d.pkg.linked) },
-        .{ .label = "Pinned", .value = if (d.pkg.pinned) "yes" else "no" },
-        .{ .label = "Dependencies", .value = joinDeps(&deps_buf, d.info.dependencies) },
-    };
-    detail_pane.render(f, &fields, rect);
 }
 
 // SGR reverse-video for the selection / guard, matching `tab_bar`'s convention.

--- a/src/tui/layout.zig
+++ b/src/tui/layout.zig
@@ -32,7 +32,10 @@ pub const filter_rows: u16 = 1;
 pub const footer_rows: u16 = 2;
 pub const min_content_rows: u16 = 1;
 pub const min_rows: u16 = tab_bar_rows + filter_rows + footer_rows + min_content_rows;
-pub const min_cols: u16 = 20;
+// The narrowest width that still shows all five tabs; below it the bar can't
+// fit them, so the fallback shows rather than a clipped frame. A narrow-but-tall
+// window trips this on width alone — `fits` requires both axes.
+pub const min_cols: u16 = 50;
 
 /// Result of laying out `(cols, rows)`: the tiled regions, or a signal that the
 /// terminal is below the usable minimum and the fallback frame should render.
@@ -101,19 +104,24 @@ fn renderContent(buf: []u8, state: State, content: Rect) []const u8 {
     return buf[0..len];
 }
 
-/// The "terminal too small" frame: a single ASCII line naming the minimum,
-/// truncated to `cols` so it can never overflow the very terminal it reports as
-/// too small. ASCII keeps byte length == column width. Empty when there is no
-/// room to draw at all (`0` cols or rows).
-fn renderFallback(buf: []u8, cols: u16, rows: u16) []const u8 {
-    if (cols == 0 or rows == 0) return buf[0..0];
-    var msg_buf: [64]u8 = undefined;
-    const msg = std.fmt.bufPrint(
-        &msg_buf,
+/// The "terminal too small" notice text, naming the minimum. ASCII keeps byte
+/// length == column width. The single source of the message; callers add their
+/// own icon/colour and wrapping.
+pub fn tooSmallMessage(buf: []u8) []const u8 {
+    return std.fmt.bufPrint(
+        buf,
         "terminal too small (need >= {d}x{d})",
         .{ min_cols, min_rows },
     ) catch "terminal too small";
-    const fitted = scroll_list.truncate(msg, cols);
+}
+
+/// The "terminal too small" frame: the notice line truncated to `cols` so it can
+/// never overflow the very terminal it reports as too small. Empty when there is
+/// no room to draw at all (`0` cols or rows).
+fn renderFallback(buf: []u8, cols: u16, rows: u16) []const u8 {
+    if (cols == 0 or rows == 0) return buf[0..0];
+    var msg_buf: [64]u8 = undefined;
+    const fitted = scroll_list.truncate(tooSmallMessage(&msg_buf), cols);
     const n = @min(fitted.len, buf.len);
     @memcpy(buf[0..n], fitted[0..n]);
     return buf[0..n];
@@ -126,4 +134,10 @@ test "compute tiles the screen exactly and content absorbs the slack" {
     try std.testing.expectEqual(@as(u16, 20), r.content.height);
     try std.testing.expectEqual(@as(u16, 23), r.footer.row);
     try std.testing.expect(compute(1, 1) == .too_small);
+}
+
+test "compute is too_small when either axis alone is below the minimum" {
+    try std.testing.expect(compute(min_cols - 1, 24) == .too_small); // width only
+    try std.testing.expect(compute(80, min_rows - 1) == .too_small); // height only
+    try std.testing.expect(compute(min_cols, min_rows) == .ok); // exactly the minimum fits
 }

--- a/src/tui/outdated_tab.zig
+++ b/src/tui/outdated_tab.zig
@@ -134,7 +134,7 @@ fn requestUpgrade(s: *State) void {
 }
 
 /// Pure render: the filtered + scrolled checkbox list. The multi-select keys
-/// live in the shared footer, so the list owns the whole rect; the `[x]`
+/// live in the shared footer, so the list owns the whole rect; the `[✓]`
 /// checkboxes carry the selection. A pure function of `(state, rect)` so a
 /// resize is a re-render.
 pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
@@ -157,12 +157,15 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
         const screen = fi - v.offset;
         if (screen >= rect.height) break;
         f.moveTo(rect.row + @as(u16, @intCast(screen)), rect.col);
+        // The checkbox carries its own colour; a pinned row is held back so it
+        // shows the blocked box, never a check.
+        const is_checked = i < s.checked.len and s.checked[i];
+        tab.putCheckbox(f, if (p.pinned) .blocked else if (is_checked) tab.Check.on else .off);
         const selected = fi == v.selected;
         // The cursor row wins over the pinned dim so the selection stays legible.
         if (selected) f.put(reverse) else if (p.pinned) f.put(color.roleCode(.muted));
-        const is_checked = i < s.checked.len and s.checked[i];
         var rb: [256]u8 = undefined;
-        f.putContent(scroll_list.truncate(formatRow(&rb, p, is_checked), rect.width));
+        f.putContent(scroll_list.truncate(formatRow(&rb, p), rect.width -| 4)); // 4 cols on the checkbox
         if (selected or p.pinned) f.put(color.Style.reset.code());
     }
 }
@@ -170,13 +173,11 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
 // SGR reverse-video for the selection, matching the other tabs' convention.
 const reverse = "\x1b[7m";
 
-/// One list row: a checkbox (or a held-back marker for a pinned row), the name,
-/// the current→latest versions, the source type, and a pinned tag. ASCII columns,
-/// grapheme-naive like the rest; the arrow is width-aware via `truncate`.
-fn formatRow(buf: []u8, p: Row, checked: bool) []const u8 {
+/// One list row after the checkbox: the name, the current→latest versions, the
+/// source type, and a pinned tag. ASCII columns, grapheme-naive like the rest;
+/// the arrow is width-aware via `truncate`.
+fn formatRow(buf: []u8, p: Row) []const u8 {
     var len: usize = 0;
-    if (p.pinned) append(buf, &len, " -  ") // pinned: held back, no checkbox
-    else if (checked) append(buf, &len, "[x] ") else append(buf, &len, "[ ] ");
     appendPad(buf, &len, p.name, 22);
     append(buf, &len, " ");
     appendPad(buf, &len, p.installed, 12);
@@ -319,14 +320,14 @@ test "render lists checkboxes with current→latest and the type column" {
     const s: State = .{ .items = &sample, .checked = &checked };
     render(&s, &f, .{ .row = 2, .col = 1, .width = 80, .height = 12 });
     const out = f.slice();
-    try testing.expect(std.mem.indexOf(u8, out, "[x]") != null); // wget checked
+    try testing.expect(std.mem.indexOf(u8, out, "✓") != null); // wget checked
     try testing.expect(std.mem.indexOf(u8, out, "[ ]") != null); // an unchecked box
     try testing.expect(std.mem.indexOf(u8, out, "→") != null); // current→latest
     try testing.expect(std.mem.indexOf(u8, out, "1.25.0") != null); // latest version
     try testing.expect(std.mem.indexOf(u8, out, "cask") != null); // type column
 }
 
-test "render greys a pinned row, gives it no checkbox, and marks it pinned" {
+test "render greys a pinned row, shows the blocked box, and marks it pinned" {
     var buf: [4096]u8 = undefined;
     var f: tab.Frame = .{ .buf = &buf };
     var checked = [_]bool{false} ** 4;
@@ -334,6 +335,7 @@ test "render greys a pinned row, gives it no checkbox, and marks it pinned" {
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
     const out = f.slice();
     try testing.expect(std.mem.indexOf(u8, out, "pinned") != null); // curl marked
+    try testing.expect(std.mem.indexOf(u8, out, "[-]") != null); // a pinned row gets the blocked box, never a check
     try testing.expect(std.mem.indexOf(u8, out, color.Style.dim.code()) != null); // greyed: muted role == dim on the basic tier
 }
 

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -117,24 +117,17 @@ fn anyInstallable(s: *const State) bool {
 }
 
 // A closed switch on the kind: a new variant is a compile error here, never a
-// silent default — the glyph/colour must be chosen deliberately.
-fn kindGlyph(k: Kind) []const u8 {
+// silent default — the label must be chosen deliberately.
+fn kindLabel(k: Kind) []const u8 {
     return switch (k) {
-        .formula => "◆",
-        .cask => "▣",
+        .formula => "formula",
+        .cask => "cask",
     };
 }
 
-fn kindStyle(k: Kind) color.Role {
-    return switch (k) {
-        .formula => .accent,
-        .cask => .secondary,
-    };
-}
-
-/// Pure render: a dim action line, then — by phase — guidance, a "searching…"
-/// status, "no matches", or the ranked result list. A pure function of `(state,
-/// rect)` so a resize is a re-render.
+/// Pure render: by phase, guidance, a "searching…" status, "no matches", or the
+/// ranked result list. A pure function of `(state, rect)` so a resize is a
+/// re-render.
 pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     if (r.height == 0) return;
     // Keys live in the shared footer now, so the body owns the whole rect.
@@ -163,19 +156,15 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
         const screen = i - v.offset;
         if (screen >= rect.height) break;
         f.moveTo(rect.row + @as(u16, @intCast(screen)), rect.col);
-        // Multi-select checkbox, then the kind glyph — both keep their own colour;
-        // the reverse-video selection wraps only the text columns so the SGRs
-        // never tangle. An installed hit can't be selected, so it shows blocked.
+        // Multi-select checkbox first (its own colour); the reverse-video
+        // selection wraps only the text columns so the SGRs never tangle. An
+        // installed hit can't be selected, so it shows the blocked box.
         const checked = i < s.checked.len and s.checked[i];
         tab.putCheckbox(f, if (m.installed) .blocked else if (checked) tab.Check.on else .off);
-        f.put(color.roleCode(kindStyle(m.kind)));
-        f.put(kindGlyph(m.kind));
-        f.put(color.Style.reset.code());
-        f.put(" ");
         const selected = i == v.selected;
         if (selected) f.put(reverse);
         var rb: [256]u8 = undefined;
-        f.putContent(scroll_list.truncate(formatRow(&rb, m), rect.width -| 6)); // 4 checkbox + 2 glyph cols
+        f.putContent(scroll_list.truncate(formatRow(&rb, m), rect.width -| 4)); // 4 cols on the checkbox
         if (selected) f.put(color.Style.reset.code());
     }
 }
@@ -183,11 +172,14 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
 // SGR reverse-video for the selection, matching the other tabs' convention.
 const reverse = "\x1b[7m";
 
-/// One list row (after the glyph): the package name, then an "installed" marker
-/// for a hit already on the system. ASCII columns, grapheme-naive like the rest.
+/// One list row (after the checkbox): the package name, the kind (formula/cask),
+/// then an "installed" marker for a hit already on the system. ASCII columns,
+/// grapheme-naive like the rest.
 fn formatRow(buf: []u8, m: Match) []const u8 {
     var len: usize = 0;
-    appendPad(buf, &len, m.name, 32);
+    appendPad(buf, &len, m.name, 28);
+    append(buf, &len, " ");
+    appendPad(buf, &len, kindLabel(m.kind), 8);
     append(buf, &len, " ");
     if (m.installed) append(buf, &len, "installed");
     return buf[0..len];
@@ -327,7 +319,7 @@ test "render shows no-matches when a committed query returned zero results" {
     try testing.expect(std.mem.indexOf(u8, f.slice(), "No matches") != null);
 }
 
-test "render lists hits with a kind glyph and an installed marker" {
+test "render lists hits with the kind label and an installed marker" {
     var buf: [4096]u8 = undefined;
     var f: tab.Frame = .{ .buf = &buf };
     const s: State = .{ .items = &sample, .phase = .loaded };
@@ -335,10 +327,10 @@ test "render lists hits with a kind glyph and an installed marker" {
     const out = f.slice();
     try testing.expect(std.mem.indexOf(u8, out, "wget") != null);
     try testing.expect(std.mem.indexOf(u8, out, "firefox") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "◆") != null); // formula glyph
-    try testing.expect(std.mem.indexOf(u8, out, "▣") != null); // cask glyph
+    try testing.expect(std.mem.indexOf(u8, out, "formula") != null); // kind as plain text, no glyph
+    try testing.expect(std.mem.indexOf(u8, out, "cask") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "◆") == null); // the glyph is gone
     try testing.expect(std.mem.indexOf(u8, out, "installed") != null); // firefox marker
-    try testing.expect(std.mem.indexOf(u8, out, color.Style.cyan.code()) != null); // a coloured glyph
 }
 
 test "render highlights the selected hit" {

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -43,6 +43,9 @@ pub const State = struct {
     chrome: tab.Chrome = .{},
     /// The server's ranked results, borrowed from shell-owned parse storage.
     items: []const Match = &.{},
+    /// Per-row multi-select state, parallel to `items`, owned + sized by the
+    /// shell (like Outdated's). An already-installed hit is never checked.
+    checked: []bool = &.{},
     /// Pending effect for the shell to perform, then clear.
     request: Request = .none,
     /// Where the tab is in the read lifecycle; drives the render's status line.
@@ -55,7 +58,7 @@ pub fn title() []const u8 {
 
 /// The tab's action keys, surfaced in the shared footer next to the global keys.
 pub fn footerHint() []const u8 {
-    return "enter: search   i: install";
+    return "space: select   i: install";
 }
 
 /// The hit the selection points at, clamping the (shell-driven, unbounded)
@@ -63,9 +66,23 @@ pub fn footerHint() []const u8 {
 /// so the selection indexes straight into `items`. The shell reads its `name`
 /// and `kind` to build the install argv.
 pub fn selectedMatch(s: *const State) ?Match {
+    const i = selectedIndex(s) orelse return null;
+    return s.items[i];
+}
+
+/// The index of the active row in `items`, clamping the unbounded cursor. No
+/// filter, so the cursor indexes straight into `items`. Null on an empty list.
+pub fn selectedIndex(s: *const State) ?usize {
     if (s.items.len == 0) return null;
-    const sel = @min(s.chrome.view.selected, s.items.len - 1);
-    return s.items[sel];
+    return @min(s.chrome.view.selected, s.items.len - 1);
+}
+
+/// Toggle the active row's checkbox. An already-installed hit is never selectable
+/// (it would be a no-op install), mirroring how a pinned row is held back.
+fn toggle(s: *State) void {
+    const i = selectedIndex(s) orelse return;
+    if (s.items[i].installed) return;
+    if (i < s.checked.len) s.checked[i] = !s.checked[i];
 }
 
 /// Pure transition. Enter (re)runs the committed query — the filter doubles as
@@ -74,12 +91,29 @@ pub fn selectedMatch(s: *const State) ?Match {
 pub fn step(s: *State, key: tab.Key) void {
     switch (key) {
         .enter => s.request = .search,
+        .space => toggle(s),
+        // `i` installs the multi-selection (or the active row when nothing is
+        // checked); inert when there is nothing installable to do.
         .char => |c| if (c.len == 1 and c.bytes[0] == 'i') {
-            const m = selectedMatch(s) orelse return;
-            if (!m.installed) s.request = .install; // inert on an already-installed hit
+            if (anyInstallable(s)) s.request = .install;
         },
         else => {},
     }
+}
+
+/// True when `i` would install something: any checked, not-installed hit, or —
+/// with nothing checked — an installable active row. Mirrors what the shell's
+/// install argv resolves, so `i` stays inert when there is nothing to do.
+fn anyInstallable(s: *const State) bool {
+    var any_checked = false;
+    for (s.items, 0..) |m, i| {
+        if (i >= s.checked.len or !s.checked[i]) continue;
+        any_checked = true;
+        if (!m.installed) return true;
+    }
+    if (any_checked) return false; // only already-installed rows checked
+    const m = selectedMatch(s) orelse return false;
+    return !m.installed;
 }
 
 // A closed switch on the kind: a new variant is a compile error here, never a
@@ -129,9 +163,11 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
         const screen = i - v.offset;
         if (screen >= rect.height) break;
         f.moveTo(rect.row + @as(u16, @intCast(screen)), rect.col);
-        // The kind glyph keeps its own colour regardless of selection; the
-        // reverse-video selection wraps only the text columns so the two SGRs
-        // never tangle.
+        // Multi-select checkbox, then the kind glyph — both keep their own colour;
+        // the reverse-video selection wraps only the text columns so the SGRs
+        // never tangle. An installed hit can't be selected, so it shows blocked.
+        const checked = i < s.checked.len and s.checked[i];
+        tab.putCheckbox(f, if (m.installed) .blocked else if (checked) tab.Check.on else .off);
         f.put(color.roleCode(kindStyle(m.kind)));
         f.put(kindGlyph(m.kind));
         f.put(color.Style.reset.code());
@@ -139,7 +175,7 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
         const selected = i == v.selected;
         if (selected) f.put(reverse);
         var rb: [256]u8 = undefined;
-        f.putContent(scroll_list.truncate(formatRow(&rb, m), rect.width -| 2)); // 2 cols on the glyph
+        f.putContent(scroll_list.truncate(formatRow(&rb, m), rect.width -| 6)); // 4 checkbox + 2 glyph cols
         if (selected) f.put(color.Style.reset.code());
     }
 }
@@ -226,6 +262,47 @@ test "an unrelated key leaves the request alone" {
     try testing.expectEqual(Request.none, s.request);
 }
 
+test "space toggles the active row's checkbox; an installed hit is never selectable" {
+    var checked = [_]bool{false} ** 3;
+    var s: State = .{ .items = &sample, .checked = &checked, .phase = .loaded };
+    s.chrome.view.selected = 0; // wget, not installed
+    step(&s, .space);
+    try testing.expect(checked[0]);
+    step(&s, .space);
+    try testing.expect(!checked[0]); // toggles back off
+
+    s.chrome.view.selected = 1; // firefox, already installed
+    step(&s, .space);
+    try testing.expect(!checked[1]); // installed rows can't be checked
+}
+
+test "i installs a checked, not-installed hit even when the active row is installed" {
+    var checked = [_]bool{ true, false, false }; // wget checked
+    var s: State = .{ .items = &sample, .checked = &checked, .phase = .loaded };
+    s.chrome.view.selected = 1; // active = firefox (installed)
+    step(&s, ch('i'));
+    try testing.expectEqual(Request.install, s.request);
+}
+
+test "i is inert when only already-installed rows are checked" {
+    var checked = [_]bool{ false, true, false }; // firefox (installed) checked
+    var s: State = .{ .items = &sample, .checked = &checked, .phase = .loaded };
+    step(&s, ch('i'));
+    try testing.expectEqual(Request.none, s.request);
+}
+
+test "render draws a multi-select checkbox per result row" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    var checked = [_]bool{ true, false, false };
+    const s: State = .{ .items = &sample, .checked = &checked, .phase = .loaded };
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, "✓") != null); // wget checked
+    try testing.expect(std.mem.indexOf(u8, out, "[ ]") != null); // an unchecked box
+    try testing.expect(std.mem.indexOf(u8, out, "[-]") != null); // firefox installed → blocked
+}
+
 test "render shows guidance in the idle phase before any query is committed" {
     var buf: [4096]u8 = undefined;
     var f: tab.Frame = .{ .buf = &buf };
@@ -274,7 +351,7 @@ test "render highlights the selected hit" {
 }
 
 test "footerHint exposes the tab's action keys for the shared footer" {
-    try testing.expect(std.mem.indexOf(u8, footerHint(), "search") != null);
+    try testing.expect(std.mem.indexOf(u8, footerHint(), "select") != null);
     try testing.expect(std.mem.indexOf(u8, footerHint(), "install") != null);
 }
 

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -25,13 +25,16 @@ const color = @import("../ui/color.zig");
 const search_json = @import("json/search.zig");
 pub const Match = search_json.Match;
 const Kind = search_json.Kind;
+const info_json = @import("json/info.zig");
+const detail_pane = @import("detail_pane.zig");
 const scroll_list = @import("scroll_list.zig");
 const tab = @import("tab.zig");
 
 /// An effect the pure `step` defers to the impure shell, which performs it and
 /// resets the field. `step` never does I/O — this is the command channel.
-/// `search` (re)runs the committed query; `install` installs the selected hit.
-pub const Request = enum { none, search, install };
+/// `search` (re)runs the committed query; `install` installs the selection;
+/// `info` opens `mt info` for the active hit (works for uninstalled hits too).
+pub const Request = enum { none, search, install, info };
 
 /// The read lifecycle the render reflects. `idle` before any query is committed
 /// (show guidance), `searching` while the blocking remote read runs (the shell
@@ -46,6 +49,9 @@ pub const State = struct {
     /// Per-row multi-select state, parallel to `items`, owned + sized by the
     /// shell (like Outdated's). An already-installed hit is never checked.
     checked: []bool = &.{},
+    /// The open info pane for the active hit, if Enter requested one. Borrows
+    /// from shell-owned parse storage; cleared on Esc or a fresh query.
+    detail: ?info_json.Info = null,
     /// Pending effect for the shell to perform, then clear.
     request: Request = .none,
     /// Where the tab is in the read lifecycle; drives the render's status line.
@@ -58,7 +64,7 @@ pub fn title() []const u8 {
 
 /// The tab's action keys, surfaced in the shared footer next to the global keys.
 pub fn footerHint() []const u8 {
-    return "space: select   i: install";
+    return "space: select   enter: info   i: install";
 }
 
 /// The hit the selection points at, clamping the (shell-driven, unbounded)
@@ -90,13 +96,19 @@ fn toggle(s: *State) void {
 /// when it is not already installed; on an installed hit it is inert.
 pub fn step(s: *State, key: tab.Key) void {
     switch (key) {
-        .enter => s.request = .search,
+        // Enter on a result opens `mt info` for it. Committing the query (the
+        // other meaning of Enter) is driven by the shell on filter-commit, not
+        // here, so the two never collide.
+        .enter => if (selectedMatch(s) != null) {
+            s.request = .info;
+        },
         .space => toggle(s),
         // `i` installs the multi-selection (or the active row when nothing is
         // checked); inert when there is nothing installable to do.
         .char => |c| if (c.len == 1 and c.bytes[0] == 'i') {
             if (anyInstallable(s)) s.request = .install;
         },
+        .esc => s.detail = null, // close the info pane
         else => {},
     }
 }
@@ -137,8 +149,49 @@ pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
         .loaded => if (s.items.len == 0)
             renderStatus(f, r, "No matches.")
         else
-            renderList(s, f, r),
+            renderLoaded(s, f, r),
     }
+}
+
+// Bottom-pane budget for the info pane; the split never takes more than half the
+// content so the result list always survives.
+const detail_rows: u16 = 3;
+
+/// The results, with an `mt info` pane docked at the bottom when one is open.
+fn renderLoaded(s: *const State, f: *tab.Frame, r: tab.Rect) void {
+    var list_rect = r;
+    if (s.detail) |info| {
+        const dh = @min(@as(u16, detail_rows), r.height / 2);
+        if (dh > 0 and dh < r.height) {
+            list_rect.height = r.height - dh;
+            renderDetail(info, f, .{ .row = r.row + list_rect.height, .col = r.col, .width = r.width, .height = dh });
+        }
+    }
+    renderList(s, f, list_rect);
+}
+
+/// The `mt info` pane for the active hit — works for an uninstalled hit too,
+/// which is why a search result can open it at all.
+fn renderDetail(info: info_json.Info, f: *tab.Frame, rect: tab.Rect) void {
+    var deps_buf: [512]u8 = undefined;
+    const fields = [_]detail_pane.Field{
+        .{ .label = "Version", .value = if (info.version.len != 0) info.version else "-" },
+        .{ .label = "Tap", .value = if (info.tap.len != 0) info.tap else "-" },
+        .{ .label = "Dependencies", .value = joinDeps(&deps_buf, info.dependencies) },
+    };
+    detail_pane.render(f, &fields, rect);
+}
+
+/// Comma-join a dependency list into `buf`; "none" when empty. Truncates if the
+/// list overruns the buffer (the pane truncates to the column budget anyway).
+fn joinDeps(buf: []u8, deps: []const []const u8) []const u8 {
+    if (deps.len == 0) return "none";
+    var len: usize = 0;
+    for (deps, 0..) |d, i| {
+        if (i != 0) append(buf, &len, ", ");
+        append(buf, &len, d);
+    }
+    return buf[0..len];
 }
 
 fn renderStatus(f: *tab.Frame, rect: tab.Rect, msg: []const u8) void {
@@ -222,10 +275,23 @@ test "selectedMatch on an empty list is null (the action becomes a no-op)" {
     try testing.expect(selectedMatch(&s) == null);
 }
 
-test "enter requests a search — committing the query is the search" {
-    var s: State = .{ .items = &sample };
+test "enter opens info for the active hit" {
+    var s: State = .{ .items = &sample, .phase = .loaded };
     step(&s, .enter);
-    try testing.expectEqual(Request.search, s.request);
+    try testing.expectEqual(Request.info, s.request);
+}
+
+test "enter is inert on an empty result list" {
+    var s: State = .{ .items = &.{} };
+    step(&s, .enter);
+    try testing.expectEqual(Request.none, s.request);
+}
+
+test "esc closes the info pane" {
+    const info: info_json.Info = .{ .name = "wget", .version = "1", .tap = "", .dependencies = &.{} };
+    var s: State = .{ .items = &sample, .detail = info };
+    step(&s, .esc);
+    try testing.expect(s.detail == null);
 }
 
 test "i on a not-installed hit requests install; on an installed hit it is inert" {
@@ -293,6 +359,18 @@ test "render draws a multi-select checkbox per result row" {
     try testing.expect(std.mem.indexOf(u8, out, "✓") != null); // wget checked
     try testing.expect(std.mem.indexOf(u8, out, "[ ]") != null); // an unchecked box
     try testing.expect(std.mem.indexOf(u8, out, "[-]") != null); // firefox installed → blocked
+}
+
+test "render docks the info pane when one is open" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const info: info_json.Info = .{ .name = "wget", .version = "1.25.0", .tap = "homebrew/core", .dependencies = &.{"openssl@3"} };
+    const s: State = .{ .items = &sample, .phase = .loaded, .detail = info };
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 16 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, "1.25.0") != null); // version field
+    try testing.expect(std.mem.indexOf(u8, out, "openssl@3") != null); // a dependency
+    try testing.expect(std.mem.indexOf(u8, out, "wget") != null); // the list still shows
 }
 
 test "render shows guidance in the idle phase before any query is committed" {

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -153,33 +153,26 @@ pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     }
 }
 
-// Bottom-pane budget for the info pane; the split never takes more than half the
-// content so the result list always survives.
-const detail_rows: u16 = 3;
-
 /// The results, with an `mt info` pane docked at the bottom when one is open.
+/// The pane sizes to its (wrapped) content, capped at half the height so the
+/// result list survives. The info pane works for an uninstalled hit too, which
+/// is why a search result can open it at all.
 fn renderLoaded(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     var list_rect = r;
     if (s.detail) |info| {
-        const dh = @min(@as(u16, detail_rows), r.height / 2);
+        var deps_buf: [512]u8 = undefined;
+        const fields = [_]detail_pane.Field{
+            .{ .label = "Version", .value = if (info.version.len != 0) info.version else "-" },
+            .{ .label = "Tap", .value = if (info.tap.len != 0) info.tap else "-" },
+            .{ .label = "Dependencies", .value = joinDeps(&deps_buf, info.dependencies) },
+        };
+        const dh = @min(detail_pane.neededRows(&fields, r.width), r.height / 2);
         if (dh > 0 and dh < r.height) {
             list_rect.height = r.height - dh;
-            renderDetail(info, f, .{ .row = r.row + list_rect.height, .col = r.col, .width = r.width, .height = dh });
+            detail_pane.render(f, &fields, .{ .row = r.row + list_rect.height, .col = r.col, .width = r.width, .height = dh });
         }
     }
     renderList(s, f, list_rect);
-}
-
-/// The `mt info` pane for the active hit — works for an uninstalled hit too,
-/// which is why a search result can open it at all.
-fn renderDetail(info: info_json.Info, f: *tab.Frame, rect: tab.Rect) void {
-    var deps_buf: [512]u8 = undefined;
-    const fields = [_]detail_pane.Field{
-        .{ .label = "Version", .value = if (info.version.len != 0) info.version else "-" },
-        .{ .label = "Tap", .value = if (info.tap.len != 0) info.tap else "-" },
-        .{ .label = "Dependencies", .value = joinDeps(&deps_buf, info.dependencies) },
-    };
-    detail_pane.render(f, &fields, rect);
 }
 
 /// Comma-join a dependency list into `buf`; "none" when empty. Truncates if the
@@ -347,6 +340,15 @@ test "i is inert when only already-installed rows are checked" {
     var s: State = .{ .items = &sample, .checked = &checked, .phase = .loaded };
     step(&s, ch('i'));
     try testing.expectEqual(Request.none, s.request);
+}
+
+test "the cores tolerate a checked slice shorter than items without trapping" {
+    // Before the shell sizes `checked` it can be empty; the cores must not index
+    // past it. Toggle is then inert and install falls back to the active row.
+    var s: State = .{ .items = &sample, .checked = &.{}, .phase = .loaded };
+    step(&s, .space); // no checked slot for the active row → inert, no trap
+    step(&s, ch('i')); // resolves over the empty set + the active (installable) row
+    try testing.expectEqual(Request.install, s.request);
 }
 
 test "render draws a multi-select checkbox per result row" {

--- a/src/tui/spawn.zig
+++ b/src/tui/spawn.zig
@@ -72,7 +72,10 @@ fn captureJson(
     argv: []const []const u8,
     max_ok_exit: u8,
 ) ReadError![]u8 {
-    var child = std.process.spawn(io, .{ .argv = argv, .stdout = .pipe }) catch return error.SpawnFailed;
+    // Discard the child's stderr: inside the alt-screen its status/progress lines
+    // (e.g. `mt doctor`'s check log) would paint over the frame. A real failure is
+    // surfaced by the caller's banner, not by leaking child stderr onto the TUI.
+    var child = std.process.spawn(io, .{ .argv = argv, .stdout = .pipe, .stderr = .ignore }) catch return error.SpawnFailed;
 
     const bytes = drainStdout(io, allocator, child.stdout) catch |e| {
         // Kill so `wait` can't hang on a half-drained pipe, then surface.

--- a/src/tui/tab.zig
+++ b/src/tui/tab.zig
@@ -77,6 +77,32 @@ pub fn paintRows(f: *Frame, rows: []const []const u8, view: scroll_list.View, re
     }
 }
 
+/// A multi-select row checkbox: unselected, selected, or blocked (a row that
+/// can't be selected — pinned in Outdated, already-installed in Search).
+pub const Check = enum { off, on, blocked };
+
+/// Paint a selection checkbox at the cursor — the shared widget so Outdated and
+/// Search read identically. The selected check carries its own success colour
+/// via `put` (outside the `putContent` row sanitization). Always four cells
+/// (`[x] `), so callers budget the rest of the row with `width -| 4`.
+pub fn putCheckbox(f: *Frame, state: Check) void {
+    switch (state) {
+        .on => {
+            f.put("[");
+            f.put(color.roleCode(.success));
+            f.put("✓");
+            f.put(color.Style.reset.code());
+            f.put("] ");
+        },
+        .off => f.put("[ ] "),
+        .blocked => {
+            f.put(color.roleCode(.muted));
+            f.put("[-] ");
+            f.put(color.Style.reset.code());
+        },
+    }
+}
+
 /// Paint one dim line at the top of `rect` — the shared empty-state / "no
 /// matches" placeholder so every tab's empty list reads the same way instead of
 /// a blank pane. Content goes through `putContent` like every other row.
@@ -123,6 +149,29 @@ const GoodTab = struct {
 
 test "verify accepts a conforming tab module" {
     comptime verify(GoodTab);
+}
+
+test "putCheckbox renders each selection state with the right glyph" {
+    const cases = [_]struct { state: Check, want: []const u8, absent: []const u8 }{
+        .{ .state = .off, .want = "[ ] ", .absent = "✓" },
+        .{ .state = .on, .want = "✓", .absent = "[-]" },
+        .{ .state = .blocked, .want = "[-] ", .absent = "✓" },
+    };
+    for (cases) |c| {
+        var buf: [64]u8 = undefined;
+        var f: Frame = .{ .buf = &buf };
+        putCheckbox(&f, c.state);
+        try std.testing.expect(std.mem.indexOf(u8, f.slice(), c.want) != null);
+        try std.testing.expect(std.mem.indexOf(u8, f.slice(), c.absent) == null);
+    }
+}
+
+test "putCheckbox colours only the selected check, leaving the brackets plain" {
+    var buf: [64]u8 = undefined;
+    var f: Frame = .{ .buf = &buf };
+    putCheckbox(&f, .on);
+    // A reset follows the check so the row content after it isn't tinted green.
+    try std.testing.expect(std.mem.indexOf(u8, f.slice(), color.Style.reset.code()) != null);
 }
 
 test "renderHint paints the placeholder text into the frame" {

--- a/tests/tui_layout_test.zig
+++ b/tests/tui_layout_test.zig
@@ -38,7 +38,7 @@ test "regions tile the screen exactly across a range of sizes" {
     try expectTiles(80, 24);
     try expectTiles(120, 50);
     try expectTiles(200, 120);
-    try expectTiles(40, 6);
+    try expectTiles(52, 6); // a narrow-but-valid size, just above the width floor
 }
 
 test "fixed regions keep their heights; content absorbs the remainder" {

--- a/tests/tui_search_test.zig
+++ b/tests/tui_search_test.zig
@@ -5,8 +5,8 @@
 //! `mt search <query> --json` fixture (`scripts/fixtures/`), never live `mt` —
 //! proving the parser consumes the real versioned, install-aware schema and that
 //! the selection plus `i` map to installing exactly the selected, not-yet
-//! installed hit (the name the install argv would carry), while an Enter over the
-//! search box commits the query as a fresh remote read.
+//! installed hit (the name the install argv would carry), while Enter over a
+//! result opens its info pane.
 
 const std = @import("std");
 const testing = std.testing;
@@ -83,13 +83,15 @@ test "i over the fixture installs the selected not-yet-installed hit and is iner
     try testing.expectEqual(search_json.Kind.cask, search.selectedMatch(&st).?.kind);
 }
 
-test "Enter over the search box commits the query as a fresh remote read" {
+test "Enter over a result requests its info (committing the query is the shell's job)" {
     const bytes = try readFixture(testing.allocator, "tui_search.json");
     defer testing.allocator.free(bytes);
     var parsed = try search_json.parse(testing.allocator, bytes);
     defer parsed.deinit();
 
+    // Enter over a loaded result opens `mt info` for it; the query-commit path
+    // (filter editing → search) is driven by the app shell, not the tab core.
     var st: search.State = .{ .items = parsed.items, .phase = .loaded };
     search.step(&st, .enter);
-    try testing.expectEqual(search.Request.search, st.request);
+    try testing.expectEqual(search.Request.info, st.request);
 }


### PR DESCRIPTION
Second-pass `mt tui` improvements from hands-on testing, one fix/feat per commit:

- **Loading state.** Switching to a lazy tab (Outdated/Services/Doctor) now discards the child's stderr during the read and shows a `Loading <tab>…` footer, so the command's own progress no longer paints over the frame.
- **Shared selection checkbox.** Outdated's checkbox is now one themed widget - empty `[ ]`, a success-green `[✓]`, or a dim `[-]` for a row that can't be selected.
- **Search multi-select + batch install.** `space` toggles result rows (already-installed hits are held back); `i` installs the whole selection in one `mt install`, or the active row when nothing is checked.
- **Search box labelled a query.** The input reads `search:` on the Search tab (where it is the query) and `filter:` elsewhere, and the kind glyph is dropped for a plainer row.
- **`mt info` on Enter.** Enter on a result opens an info pane (version, tap, dependencies) for uninstalled hits too; Esc closes it.
- **Readable detail pane.** Long detail values wrap instead of being cut off on a narrow window, the key labels are dimmed, and a dim rule separates the pane from the list.
- **Responsive too-small notice.** The "terminal too small" fallback wraps to stay readable, leads with the notice icon in the info colour, and trips on width alone below the width where all tabs fit.

## Related Issue

- None

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 19 in a stack** made with GitButler:
- <kbd>&nbsp;19&nbsp;</kbd> #464
- <kbd>&nbsp;18&nbsp;</kbd> #463 👈 
- <kbd>&nbsp;17&nbsp;</kbd> #462
- <kbd>&nbsp;16&nbsp;</kbd> #461
- <kbd>&nbsp;15&nbsp;</kbd> #459
- <kbd>&nbsp;14&nbsp;</kbd> #458
- <kbd>&nbsp;13&nbsp;</kbd> #457
- <kbd>&nbsp;12&nbsp;</kbd> #456
- <kbd>&nbsp;11&nbsp;</kbd> #455
- <kbd>&nbsp;10&nbsp;</kbd> #454
- <kbd>&nbsp;9&nbsp;</kbd> #453
- <kbd>&nbsp;8&nbsp;</kbd> #451
- <kbd>&nbsp;7&nbsp;</kbd> #450
- <kbd>&nbsp;6&nbsp;</kbd> #448
- <kbd>&nbsp;5&nbsp;</kbd> #447
- <kbd>&nbsp;4&nbsp;</kbd> #446
- <kbd>&nbsp;3&nbsp;</kbd> #445
- <kbd>&nbsp;2&nbsp;</kbd> #444
- <kbd>&nbsp;1&nbsp;</kbd> #443
<!-- GitButler Footer Boundary Bottom -->