### PR TITLE
fix(services): register background services from real formulae

### DIFF
--- a/scripts/smokes/smoke_services.sh
+++ b/scripts/smokes/smoke_services.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 # Smoke test for `malt services` against real launchd.
 #
-# Exercises register → start → status → logs → stop → unregister against a
-# trivial throwaway service. Uses an isolated MALT_PREFIX so it does not
-# touch the real installation. Safe to run on a developer machine; do not
-# run in CI (touches the user's launchd domain).
+# Two phases, both against isolated throwaway prefixes so they never touch the
+# real installation:
+#   1. A real `malt install` of a service-providing formula, asserting the
+#      parse → register path resolves `$HOMEBREW_PREFIX` and registers cleanly.
+#      The hand-rolled phase below bypasses parsing entirely, so this is the
+#      only phase that guards formula-sourced service definitions.
+#   2. A hand-rolled echo service driving register → start → logs → stop →
+#      backup → restore against real launchd.
+#
+# Safe to run on a developer machine; do not run in CI (touches the user's
+# launchd domain).
 #
 # Usage: scripts/smokes/smoke_services.sh
-# Requirements: built `malt` binary in zig-out/bin, macOS.
+# Requirements: built `malt` binary in zig-out/bin, macOS, network (phase 1).
 
 set -euo pipefail
 
@@ -22,6 +29,53 @@ BIN="$ROOT/zig-out/bin/malt"
   echo "build malt first: zig build" >&2
   exit 2
 }
+
+# ── Phase 1: a real install registers a formula's service definition ──────
+# The Homebrew API renders service paths as `$HOMEBREW_PREFIX/…`; malt must
+# resolve that token before validation or registration fails for every formula.
+SVC_FORMULA="dnsmasq"
+IPREFIX=$(mktemp -d -t malt_smoke_install_XXXXXX)
+trap 'rm -rf "$IPREFIX"' EXIT
+echo "=== install $SVC_FORMULA into a throwaway prefix (real network install)"
+install_log=$(MALT_PREFIX="$IPREFIX" NO_COLOR=1 MALT_NO_EMOJI=1 "$BIN" install "$SVC_FORMULA" 2>&1) || {
+  echo "$install_log"
+  echo "FAIL: install $SVC_FORMULA exited non-zero"
+  exit 1
+}
+echo "$install_log"
+
+grep -q "could not register service" <<<"$install_log" && {
+  echo "FAIL: service registration warned during install"
+  exit 1
+}
+echo "  ✓ install registered the service without warning"
+
+# The human table prints to stderr; stdout is reserved for `--json`.
+MALT_PREFIX="$IPREFIX" "$BIN" services list 2>&1 | grep -q "$SVC_FORMULA" || {
+  echo "FAIL: $SVC_FORMULA absent from services list after install"
+  exit 1
+}
+echo "  ✓ services list shows $SVC_FORMULA"
+
+IPLIST=$(sqlite3 "$IPREFIX/db/malt.db" "SELECT plist_path FROM services WHERE keg_name='$SVC_FORMULA';")
+[[ -f "$IPLIST" ]] || {
+  echo "FAIL: no plist registered for $SVC_FORMULA"
+  exit 1
+}
+grep -q 'HOMEBREW_PREFIX' "$IPLIST" && {
+  echo "FAIL: plist still carries an unexpanded \$HOMEBREW_PREFIX token"
+  cat "$IPLIST"
+  exit 1
+}
+grep -q "$IPREFIX" "$IPLIST" || {
+  echo "FAIL: plist does not reference the malt prefix"
+  cat "$IPLIST"
+  exit 1
+}
+echo "  ✓ plist paths resolved to the malt prefix"
+rm -rf "$IPREFIX"
+
+# ── Phase 2: hand-rolled echo service exercises the launchd lifecycle ─────
 
 PREFIX=$(mktemp -d -t malt_smoke_XXXXXX)
 export MALT_PREFIX="$PREFIX"

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -57,13 +57,13 @@ const drive = post_install_mod.drive;
 const rb_parse_mod = @import("install/rb_parse.zig");
 const record_mod = @import("install/record.zig");
 const InstallError = record_mod.InstallError;
-const sink_mod = @import("install/sink.zig");
-const OutputSink = sink_mod.OutputSink;
 const recordKeg = record_mod.recordKeg;
 const deleteKeg = record_mod.deleteKeg;
 const recordDeps = record_mod.recordDeps;
 const ensureDirs = record_mod.ensureDirs;
 const localErrorIsAnnounced = record_mod.localErrorIsAnnounced;
+const sink_mod = @import("install/sink.zig");
+const OutputSink = sink_mod.OutputSink;
 
 // Internal aliases for names the orchestrator body uses. Names not in
 // this block are reached via their submodule (`args_mod.X`, etc.) or
@@ -1236,14 +1236,34 @@ fn maybeRegisterService(
     const def = formula.service orelse return;
     if (def.run.len == 0) return;
 
+    // The Homebrew API renders service paths as `$HOMEBREW_PREFIX/…`; launchd
+    // does not expand the token and the validator rejects it, so resolve it to
+    // malt's prefix here. Scratch strings live in a scoped arena — `register`
+    // renders them into the plist and DB before it returns.
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
     var label_buf: [256]u8 = undefined;
     const label = std.fmt.bufPrint(&label_buf, "com.malt.{s}", .{formula.name}) catch return;
 
+    const run = aa.alloc([]const u8, def.run.len) catch return;
+    for (def.run, 0..) |arg, i| run[i] = plist_mod.expandPrefix(aa, arg, prefix) catch return;
+
+    const working_dir = if (def.working_dir) |wd|
+        (plist_mod.expandPrefix(aa, wd, prefix) catch return)
+    else
+        null;
+
     var stdout_buf: [512]u8 = undefined;
     var stderr_buf: [512]u8 = undefined;
-    const stdout_path = def.log_path orelse
+    const stdout_path = if (def.log_path) |lp|
+        (plist_mod.expandPrefix(aa, lp, prefix) catch return)
+    else
         (std.fmt.bufPrint(&stdout_buf, "{s}/var/log/{s}.out", .{ prefix, formula.name }) catch return);
-    const stderr_path = def.error_log_path orelse
+    const stderr_path = if (def.error_log_path) |elp|
+        (plist_mod.expandPrefix(aa, elp, prefix) catch return)
+    else
         (std.fmt.bufPrint(&stderr_buf, "{s}/var/log/{s}.err", .{ prefix, formula.name }) catch return);
 
     // Ensure the log directory exists.
@@ -1262,8 +1282,8 @@ fn maybeRegisterService(
 
     const spec: plist_mod.ServiceSpec = .{
         .label = label,
-        .program_args = def.run,
-        .working_dir = def.working_dir,
+        .program_args = run,
+        .working_dir = working_dir,
         .stdout_path = stdout_path,
         .stderr_path = stderr_path,
         .run_at_load = def.run_at_load,

--- a/src/core/formula.zig
+++ b/src/core/formula.zig
@@ -226,8 +226,12 @@ pub fn parseFormula(allocator: std.mem.Allocator, json_data: []const u8) !Formul
                         .working_dir = getString(so, "working_dir"),
                         .log_path = getString(so, "log_path"),
                         .error_log_path = getString(so, "error_log_path"),
+                        // The API encodes keep_alive as a directive object
+                        // (`{"always": true}`, …), not just a bool — treat any
+                        // present value as "keep alive" unless it is literally
+                        // `false`, which malt renders as no KeepAlive.
                         .keep_alive = if (so.get("keep_alive")) |k|
-                            (k == .bool and k.bool)
+                            (k != .bool or k.bool)
                         else
                             true,
                         .run_at_load = if (so.get("run_at_load")) |k|

--- a/src/core/services/plist.zig
+++ b/src/core/services/plist.zig
@@ -4,6 +4,8 @@
 //! deterministic (fixed key order) so golden tests can byte-compare.
 
 const std = @import("std");
+const testing = std.testing;
+
 const dsl_sandbox = @import("../dsl/sandbox.zig");
 
 pub const EnvPair = struct {
@@ -51,6 +53,23 @@ pub const ValidationError = error{
 pub const max_program_args: usize = 64;
 /// Cap on a single argv or path string.
 pub const max_arg_len: usize = 4096;
+
+/// The Homebrew API renders every service path with this literal token rather
+/// than the resolved prefix (`$HOMEBREW_PREFIX/opt/redis/bin/redis-server`).
+pub const homebrew_prefix_token = "$HOMEBREW_PREFIX";
+
+/// Resolve `$HOMEBREW_PREFIX` to malt's install prefix in a service string.
+/// launchd does not expand environment variables in `ProgramArguments`, and the
+/// token resolves to the *default Homebrew* prefix, not malt's — so without this
+/// every real formula's `service:` block fails `validate` (its executable head
+/// is not an absolute path under the malt prefix). Replaces every occurrence;
+/// returns an owned copy the caller frees.
+pub fn expandPrefix(allocator: std.mem.Allocator, s: []const u8, prefix: []const u8) std.mem.Allocator.Error![]u8 {
+    const size = std.mem.replacementSize(u8, s, homebrew_prefix_token, prefix);
+    const out = try allocator.alloc(u8, size);
+    _ = std.mem.replace(u8, s, homebrew_prefix_token, prefix, out);
+    return out;
+}
 
 /// Reject launchd interpreters as the leading executable. If a formula
 /// actually ships its own cellar-local `sh` it must invoke it via its
@@ -206,4 +225,47 @@ fn writeEscaped(writer: *std.Io.Writer, s: []const u8) !void {
             else => try writer.writeByte(c),
         }
     }
+}
+
+test "expandPrefix resolves a leading token to malt's prefix" {
+    const out = try expandPrefix(testing.allocator, "$HOMEBREW_PREFIX/opt/redis/bin/redis-server", "/opt/malt");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/opt/malt/opt/redis/bin/redis-server", out);
+}
+
+test "expandPrefix resolves a token embedded mid-argument" {
+    const out = try expandPrefix(testing.allocator, "--datadir=$HOMEBREW_PREFIX/var/mysql", "/opt/malt");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("--datadir=/opt/malt/var/mysql", out);
+}
+
+test "expandPrefix resolves every occurrence in one string" {
+    const out = try expandPrefix(testing.allocator, "$HOMEBREW_PREFIX/a:$HOMEBREW_PREFIX/b", "/opt/malt");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/opt/malt/a:/opt/malt/b", out);
+}
+
+test "expandPrefix resolves a token-only string" {
+    const out = try expandPrefix(testing.allocator, "$HOMEBREW_PREFIX", "/opt/malt");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/opt/malt", out);
+}
+
+test "expandPrefix returns a token-free string unchanged" {
+    const out = try expandPrefix(testing.allocator, "--daemonize", "/opt/malt");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("--daemonize", out);
+}
+
+test "expandPrefix returns an empty string unchanged" {
+    const out = try expandPrefix(testing.allocator, "", "/opt/malt");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("", out);
+}
+
+test "expandPrefix matches the whole token, not a sibling Homebrew variable" {
+    // `$HOMEBREW_CELLAR` shares a prefix with the token but must be left intact.
+    const out = try expandPrefix(testing.allocator, "$HOMEBREW_CELLAR/redis", "/opt/malt");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("$HOMEBREW_CELLAR/redis", out);
 }

--- a/tests/formula_test.zig
+++ b/tests/formula_test.zig
@@ -227,6 +227,47 @@ test "parse formula with service block" {
     try testing.expect(svc.keep_alive);
 }
 
+test "parse formula with realistic Homebrew API service shape" {
+    var arena = testArena();
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // The live API renders paths with a literal `$HOMEBREW_PREFIX` token (kept
+    // verbatim here; expansion happens at registration) and encodes keep_alive
+    // as an object (`{"always": true}`), not a bare bool.
+    const json =
+        \\{
+        \\  "name": "redis",
+        \\  "full_name": "redis",
+        \\  "tap": "homebrew/core",
+        \\  "desc": "Redis",
+        \\  "homepage": "",
+        \\  "revision": 0,
+        \\  "keg_only": false,
+        \\  "post_install_defined": false,
+        \\  "versions": { "stable": "8.0" },
+        \\  "dependencies": [],
+        \\  "oldnames": [],
+        \\  "bottle": {},
+        \\  "service": {
+        \\    "run": ["$HOMEBREW_PREFIX/opt/redis/bin/redis-server", "$HOMEBREW_PREFIX/etc/redis.conf"],
+        \\    "run_type": "immediate",
+        \\    "keep_alive": { "always": true },
+        \\    "working_dir": "$HOMEBREW_PREFIX/var",
+        \\    "log_path": "$HOMEBREW_PREFIX/var/log/redis.log"
+        \\  }
+        \\}
+    ;
+    var formula = try formula_mod.parseFormula(alloc, json);
+    defer formula.deinit();
+    const svc = formula.service orelse return error.TestExpectedSomething;
+    try testing.expectEqual(@as(usize, 2), svc.run.len);
+    try testing.expectEqualStrings("$HOMEBREW_PREFIX/opt/redis/bin/redis-server", svc.run[0]);
+    // An object keep_alive means "keep this service alive" — not the `false`
+    // that a bool-only check would yield.
+    try testing.expect(svc.keep_alive);
+}
+
 test "formula without service block has null service" {
     var arena = testArena();
     defer arena.deinit();

--- a/tests/services_validate_test.zig
+++ b/tests/services_validate_test.zig
@@ -8,6 +8,7 @@
 
 const std = @import("std");
 const testing = std.testing;
+
 const plist = @import("malt").services_plist;
 
 const cellar = "/opt/malt/Cellar/foo/1.0";
@@ -148,4 +149,26 @@ test "validate: stderr_path dot-dot escape rejected" {
         .stdout_path = good_out,
         .stderr_path = "/opt/malt/../etc/foo.err",
     }, cellar, prefix));
+}
+
+// The Homebrew API hands us `$HOMEBREW_PREFIX/…` heads: they must be expanded
+// before validation, or every real service is rejected as a relative path.
+test "validate: raw $HOMEBREW_PREFIX head rejected, expanded head passes" {
+    const raw = [_][]const u8{"$HOMEBREW_PREFIX/opt/foo/bin/foo"};
+    try testing.expectError(error.RelativeExecutable, plist.validate(.{
+        .label = "com.malt.foo",
+        .program_args = raw[0..],
+        .stdout_path = good_out,
+        .stderr_path = good_err,
+    }, cellar, prefix));
+
+    const head = try plist.expandPrefix(testing.allocator, raw[0], prefix);
+    defer testing.allocator.free(head);
+    const args = [_][]const u8{head};
+    try plist.validate(.{
+        .label = "com.malt.foo",
+        .program_args = args[0..],
+        .stdout_path = good_out,
+        .stderr_path = good_err,
+    }, cellar, prefix);
 }


### PR DESCRIPTION
## Description

This PR:

- Resolves `$HOMEBREW_PREFIX` to malt's install prefix across `run`, `working_dir`, and the log paths before the spec is validated and rendered.
- Treats any present `keep_alive` value other than literal `false` as keep-alive, matching the API's object encoding.
- Rewrites the services smoke to drive a real `malt install` through the parse->register path the old hand-rolled fixture bypassed, the reason this went undetected, asserting the generated plist carries the resolved prefix and no `$HOMEBREW_PREFIX` token.

## Related Issue

- None

## Notes for Reviewers

- None