### PR TITLE
refactor(ui): extract terminal-size + SIGWINCH tracking into a leaf

### DIFF
--- a/src/tui/term.zig
+++ b/src/tui/term.zig
@@ -1,17 +1,27 @@
 //! malt — terminal control primitives for `mt tui`.
 //!
-//! Leaf module: imports only `std` (the `mt tui` dashboard pressure-tests
-//! the `--json` contract instead of reaching into `cli/*`/`core/*`). Provides
-//! raw-mode, alternate-screen, cursor, and window-size machinery plus a
-//! `SIGWINCH` handler so the current `(cols, rows)` stays live without a
-//! keypress. A single idempotent `restore()` undoes everything entered and is
-//! wired through `errdefer` downstream so a crash can never wedge the terminal.
+//! Leaf module: imports only `std` and the shared `ui/termsize` leaf (the
+//! `mt tui` dashboard pressure-tests the `--json` contract instead of reaching
+//! into `cli/*`/`core/*`). Provides raw-mode, alternate-screen, and cursor
+//! machinery; window-size + `SIGWINCH` tracking lives in `ui/termsize` and is
+//! re-exported here. A single idempotent `restore()` undoes everything entered
+//! and is wired through `errdefer` downstream so a crash can never wedge the
+//! terminal.
 
 const std = @import("std");
+const termsize = @import("../ui/termsize.zig");
 
-/// Current terminal geometry. The single source of truth every later layout
-/// task renders against.
-pub const Size = struct { cols: u16, rows: u16 };
+/// Window-size + `SIGWINCH` tracking lives in the shared `ui/termsize` leaf so
+/// the CLI side can reuse it without reaching into the TUI. Re-exported here so
+/// existing `term.*` callers compile unchanged.
+pub const Size = termsize.Size;
+pub const winsize = termsize.winsize;
+pub const installWinch = termsize.installWinch;
+pub const winchInstalled = termsize.winchInstalled;
+pub const takeResized = termsize.takeResized;
+pub const currentSize = termsize.currentSize;
+pub const setWinchInstalledForTest = termsize.setWinchInstalledForTest;
+pub const setResizedForTest = termsize.setResizedForTest;
 
 /// Escape sequences whose effect is idempotent at the terminal level, so the
 /// state guards below only exist to avoid redundant writes, not to stay correct.
@@ -27,13 +37,6 @@ pub const seq = struct {
 /// buffer is undersized — a 32-byte buffer always suffices.
 pub fn cursorMove(buf: []u8, row: u16, col: u16) error{NoSpaceLeft}![]const u8 {
     return std.fmt.bufPrint(buf, "\x1b[{d};{d}H", .{ row, col });
-}
-
-fn packSize(s: Size) u32 {
-    return (@as(u32, s.cols) << 16) | s.rows;
-}
-fn unpackSize(v: u32) Size {
-    return .{ .cols = @intCast(v >> 16), .rows = @truncate(v) };
 }
 
 pub const TermError = error{ NotATty, WriteFailed, TermiosFailed };
@@ -131,75 +134,6 @@ pub const Term = struct {
     }
 };
 
-/// Query the terminal window size via `TIOCGWINSZ`. `error.NotATty` when the
-/// fd is not a terminal — no errno decode, so the degrade path stays quiet.
-pub fn winsize(fd: std.posix.fd_t) TermError!Size {
-    var ws: std.posix.winsize = undefined;
-    const rc = std.posix.system.ioctl(fd, std.posix.T.IOCGWINSZ, @intFromPtr(&ws));
-    if (rc != 0) return TermError.NotATty;
-    return .{ .cols = ws.col, .rows = ws.row };
-}
-
-// ─── SIGWINCH resize tracking ────────────────────────────────────────
-//
-// Process-global because a signal handler carries no context, mirroring
-// `core/signals.zig`. The handler is the only writer; the main thread reads
-// the flag and the packed size between input reads, so a resize is observed
-// without any keypress.
-
-var resized_flag: std.atomic.Value(bool) = .init(false);
-var cached_size: std.atomic.Value(u32) = .init(0);
-var winch_installed: std.atomic.Value(bool) = .init(false);
-var winch_fd: std.posix.fd_t = -1;
-
-fn winchHandler(_: std.posix.SIG) callconv(.c) void {
-    resized_flag.store(true, .release);
-    // A single ioctl is signal-safe in practice; refreshing here is what lets
-    // a resize be seen without a read. A failed query keeps the last size.
-    if (winsize(winch_fd)) |s| {
-        cached_size.store(packSize(s), .release);
-    } else |_| {}
-}
-
-/// Wire `SIGWINCH` to keep `(cols, rows)` live. `fd` is the terminal queried
-/// in-handler. Idempotent so re-entry (tests, repeated dispatch) neither
-/// double-registers nor clobbers a flag the handler already raised.
-pub fn installWinch(fd: std.posix.fd_t) void {
-    if (winch_installed.swap(true, .acq_rel)) return;
-    winch_fd = fd;
-    if (winsize(fd)) |s| cached_size.store(packSize(s), .release) else |_| {}
-    const act = std.posix.Sigaction{
-        .handler = .{ .handler = &winchHandler },
-        .mask = std.posix.sigemptyset(),
-        .flags = 0,
-    };
-    std.posix.sigaction(std.posix.SIG.WINCH, &act, null);
-}
-
-pub fn winchInstalled() bool {
-    return winch_installed.load(.acquire);
-}
-
-/// True exactly once per resize: consumes the flag so the event loop reacts
-/// to each `SIGWINCH` a single time.
-pub fn takeResized() bool {
-    return resized_flag.swap(false, .acq_rel);
-}
-
-/// Last geometry seen by the handler (or the install-time seed).
-pub fn currentSize() Size {
-    return unpackSize(cached_size.load(.acquire));
-}
-
-/// Test-only: seed/reset the process-global install + flag state between
-/// cases so a test starts from a known baseline (mirrors `core/signals.zig`).
-pub fn setWinchInstalledForTest(v: bool) void {
-    winch_installed.store(v, .release);
-}
-pub fn setResizedForTest(v: bool) void {
-    resized_flag.store(v, .release);
-}
-
 test "alt-screen and cursor escape sequences are the expected bytes" {
     try std.testing.expectEqualStrings("\x1b[?1049h", seq.alt_enter);
     try std.testing.expectEqualStrings("\x1b[?1049l", seq.alt_leave);
@@ -211,22 +145,4 @@ test "cursorMove writes a 1-based CUP sequence" {
     var buf: [32]u8 = undefined;
     try std.testing.expectEqualStrings("\x1b[3;5H", try cursorMove(&buf, 3, 5));
     try std.testing.expectEqualStrings("\x1b[1;1H", try cursorMove(&buf, 1, 1));
-}
-
-test "Size carries cols and rows" {
-    const s: Size = .{ .cols = 80, .rows = 24 };
-    try std.testing.expectEqual(@as(u16, 80), s.cols);
-    try std.testing.expectEqual(@as(u16, 24), s.rows);
-}
-
-// A Size packs into one u32 so the SIGWINCH handler can publish it with a
-// single atomic store the main thread reads without a torn value.
-test "packSize/unpackSize round-trip a Size losslessly" {
-    const cases = [_]Size{
-        .{ .cols = 0, .rows = 0 },
-        .{ .cols = 80, .rows = 24 },
-        .{ .cols = 65535, .rows = 65535 },
-        .{ .cols = 1, .rows = 65535 },
-    };
-    for (cases) |s| try std.testing.expectEqual(s, unpackSize(packSize(s)));
 }

--- a/src/ui/termsize.zig
+++ b/src/ui/termsize.zig
@@ -1,0 +1,132 @@
+//! malt — terminal size + `SIGWINCH` tracking.
+//!
+//! `std`-only leaf shared by the CLI progress engine and the `mt tui` terminal
+//! layer so the resize machinery lives below both, never reached sideways from
+//! `ui/` into `tui/`. Owns the window-size query and a `SIGWINCH` handler that
+//! keeps the current `(cols, rows)` live without a keypress.
+
+const std = @import("std");
+
+/// Current terminal geometry. The single source of truth every later layout
+/// task renders against.
+pub const Size = struct { cols: u16, rows: u16 };
+
+fn packSize(s: Size) u32 {
+    return (@as(u32, s.cols) << 16) | s.rows;
+}
+fn unpackSize(v: u32) Size {
+    return .{ .cols = @intCast(v >> 16), .rows = @truncate(v) };
+}
+
+/// Query the terminal window size via `TIOCGWINSZ`. `error.NotATty` when the
+/// fd is not a terminal — no errno decode, so the degrade path stays quiet.
+pub fn winsize(fd: std.posix.fd_t) error{NotATty}!Size {
+    var ws: std.posix.winsize = undefined;
+    const rc = std.posix.system.ioctl(fd, std.posix.T.IOCGWINSZ, @intFromPtr(&ws));
+    if (rc != 0) return error.NotATty;
+    return .{ .cols = ws.col, .rows = ws.row };
+}
+
+// ─── SIGWINCH resize tracking ────────────────────────────────────────
+//
+// Process-global because a signal handler carries no context, mirroring
+// `core/signals.zig`. The handler is the only writer; the main thread reads
+// the flag and the packed size between input reads, so a resize is observed
+// without any keypress.
+
+var resized_flag: std.atomic.Value(bool) = .init(false);
+var cached_size: std.atomic.Value(u32) = .init(0);
+var winch_installed: std.atomic.Value(bool) = .init(false);
+var winch_fd: std.posix.fd_t = -1;
+
+fn winchHandler(_: std.posix.SIG) callconv(.c) void {
+    resized_flag.store(true, .release);
+    // A single ioctl is signal-safe in practice; refreshing here is what lets
+    // a resize be seen without a read. A failed query keeps the last size.
+    if (winsize(winch_fd)) |s| {
+        cached_size.store(packSize(s), .release);
+    } else |_| {}
+}
+
+/// Wire `SIGWINCH` to keep `(cols, rows)` live. `fd` is the terminal queried
+/// in-handler. Idempotent so re-entry (tests, repeated dispatch) neither
+/// double-registers nor clobbers a flag the handler already raised.
+pub fn installWinch(fd: std.posix.fd_t) void {
+    if (winch_installed.swap(true, .acq_rel)) return;
+    winch_fd = fd;
+    if (winsize(fd)) |s| cached_size.store(packSize(s), .release) else |_| {}
+    const act = std.posix.Sigaction{
+        .handler = .{ .handler = &winchHandler },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    };
+    std.posix.sigaction(std.posix.SIG.WINCH, &act, null);
+}
+
+pub fn winchInstalled() bool {
+    return winch_installed.load(.acquire);
+}
+
+/// True exactly once per resize: consumes the flag so the event loop reacts
+/// to each `SIGWINCH` a single time.
+pub fn takeResized() bool {
+    return resized_flag.swap(false, .acq_rel);
+}
+
+/// Last geometry seen by the handler (or the install-time seed).
+pub fn currentSize() Size {
+    return unpackSize(cached_size.load(.acquire));
+}
+
+/// Test-only: seed/reset the process-global install + flag state between
+/// cases so a test starts from a known baseline (mirrors `core/signals.zig`).
+pub fn setWinchInstalledForTest(v: bool) void {
+    winch_installed.store(v, .release);
+}
+pub fn setResizedForTest(v: bool) void {
+    resized_flag.store(v, .release);
+}
+/// Test-only: publish a size the way the handler would, so `currentSize` is
+/// unit-testable without a real terminal.
+pub fn setSizeForTest(s: Size) void {
+    cached_size.store(packSize(s), .release);
+}
+
+// A Size packs into one u32 so the SIGWINCH handler can publish it with a
+// single atomic store the main thread reads without a torn value.
+test "packSize/unpackSize round-trip a Size losslessly" {
+    const cases = [_]Size{
+        .{ .cols = 0, .rows = 0 },
+        .{ .cols = 80, .rows = 24 },
+        .{ .cols = 65535, .rows = 65535 },
+        .{ .cols = 1, .rows = 65535 },
+    };
+    for (cases) |s| try std.testing.expectEqual(s, unpackSize(packSize(s)));
+}
+
+test "winsize off a non-tty errors cleanly" {
+    var fds: [2]std.posix.fd_t = undefined;
+    try std.testing.expectEqual(@as(c_int, 0), std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+    try std.testing.expectError(error.NotATty, winsize(fds[0]));
+}
+
+test "installWinch is idempotent" {
+    setWinchInstalledForTest(false);
+    installWinch(std.posix.STDIN_FILENO);
+    try std.testing.expect(winchInstalled());
+    installWinch(std.posix.STDIN_FILENO); // second call is a no-op
+    try std.testing.expect(winchInstalled());
+}
+
+test "takeResized consumes the flag exactly once" {
+    setResizedForTest(true);
+    try std.testing.expect(takeResized());
+    try std.testing.expect(!takeResized());
+}
+
+test "currentSize reflects the last published size" {
+    setSizeForTest(.{ .cols = 80, .rows = 24 });
+    try std.testing.expectEqual(Size{ .cols = 80, .rows = 24 }, currentSize());
+}

--- a/tests/tui_purity_test.zig
+++ b/tests/tui_purity_test.zig
@@ -94,9 +94,10 @@ fn importAllowed(importer_dir: []const u8, path: []const u8) bool {
     const resolved = resolvePosix(&buf, importer_dir, path) orelse return false;
     // Inside the leaf root → intra-leaf composition, always allowed.
     if (std.mem.startsWith(u8, resolved, scanned_root ++ "/")) return true;
-    // Otherwise only the two read-only ui helpers may be reached.
+    // Otherwise only the read-only ui helpers may be reached.
     return std.mem.eql(u8, resolved, "src/ui/color.zig") or
-        std.mem.eql(u8, resolved, "src/ui/term_sanitize.zig");
+        std.mem.eql(u8, resolved, "src/ui/term_sanitize.zig") or
+        std.mem.eql(u8, resolved, "src/ui/termsize.zig");
 }
 
 /// Normalise `rel` against `base` into a repo-relative POSIX path, collapsing
@@ -140,6 +141,11 @@ test "importAllowed permits a subdirectory sibling and the ui helpers from a sub
     try testing.expect(importAllowed("src/tui/json", "list.zig")); // within the subdir
     try testing.expect(importAllowed("src/tui/json", "../../ui/color.zig"));
     try testing.expect(importAllowed("src/tui/json", "../../ui/term_sanitize.zig"));
+}
+
+test "importAllowed permits the shared termsize leaf" {
+    try testing.expect(importAllowed("src/tui", "../ui/termsize.zig"));
+    try testing.expect(importAllowed("src/tui/json", "../../ui/termsize.zig"));
 }
 
 test "importAllowed rejects an outward reach from any depth" {


### PR DESCRIPTION
## Description

Terminal-size detection and SIGWINCH tracking move out of the TUI into a std-only `ui/termsize` leaf that both the TUI and the CLI progress engine can depend on, without the CLI reaching into TUI code. This is a behaviour-preserving extraction. 

## Related Issue

- None

## Notes for Reviewers

- Pure move: `Size`, `winsize`, the SIGWINCH globals + handler, `installWinch`, `takeResized`, `currentSize` and the test seams relocate verbatim into `src/ui/termsize.zig`. `tui/term.zig` re-exports them, so every existing `term.*` caller (`tui/app.zig`) and the `tui_term_test` integration suite compile and pass unchanged.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #474
- <kbd>&nbsp;2&nbsp;</kbd> #472
- <kbd>&nbsp;1&nbsp;</kbd> #471 👈 
<!-- GitButler Footer Boundary Bottom -->