### PR TITLE
fix(ui/progress): repaint bars on terminal resize instead of corrupting output

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -938,6 +938,10 @@ fn executeWithOpts(
                     bar_idx += 1;
                 }
             }
+            // Hand the group its bars so the first worker to observe a resize
+            // repaints every row at the new width. `bars` may be shorter than
+            // the slice if alloc partially failed; pass the populated prefix.
+            m.bars = bars[0..bar_idx];
         }
 
         // 4-worker cap — overlap download I/O with codesign CPU inside each

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -374,6 +374,10 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             bars[slot].update(0);
             bar_for_keg[keg_idx] = &bars[slot];
         }
+        // Hand the group its bars so the first worker to see a resize can
+        // repaint every row at the new width. Set after the loop — the alloc
+        // is uninitialised until each slot is written.
+        multi.bars = bars;
 
         var pool: parallel_mod.Pool = .{
             .app_ctx = ctx,

--- a/src/ui/progress.zig
+++ b/src/ui/progress.zig
@@ -225,6 +225,10 @@ pub const MultiProgress = struct {
     total_lines: u16,
     mutex: std.Io.Mutex,
     is_tty: bool,
+    /// Bars in row order, so the first worker to see a resize can repaint the
+    /// whole group at the new width. Empty for groups whose caller never
+    /// registers its bars (the resize path is then a no-op).
+    bars: []ProgressBar = &.{},
 
     pub fn init(count: u16) MultiProgress {
         // `is_tty` here means "TTY-mode bar is active": the rendering
@@ -236,6 +240,10 @@ pub const MultiProgress = struct {
         // Autowrap disabled so an over-width bar clips instead of wrapping —
         // wrapping would break the ESC[NA cursor-up math each bar relies on.
         if (tty and !output.isQuiet()) {
+            // Arm SIGWINCH so a mid-render resize repaints the group on the
+            // next tick. Flag-only handler: the repaint owner queries the new
+            // width in normal context, no syscall in signal context.
+            termsize.installWinchFlagOnly();
             // 11-byte prefix; newlines emitted in 256-byte chunks so a u16-max
             // line count doesn't blow the stack frame.
             writeStderrAll("\x1b[?25l\x1b[?7l");
@@ -253,6 +261,20 @@ pub const MultiProgress = struct {
             .mutex = .init,
             .is_tty = tty,
         };
+    }
+
+    /// First worker to observe a `SIGWINCH` repaints the whole group at the
+    /// new width; later workers this tick see the consumed flag and skip it.
+    /// Caller holds the group mutex, so the repaint serialises against
+    /// in-flight single-line draws. No-op without a pending resize.
+    fn repaintIfResized(self: *MultiProgress) void {
+        if (!termsize.takeResized()) return;
+        // Some emulators re-enable DECAWM on resize: re-assert autowrap-off so
+        // a reflowed over-width bar clips instead of wrapping and desyncing the
+        // cursor-up math. Each bar's draw re-queries the live width and keeps
+        // its own `\x1b[K`, so a narrowing redraw erases the stale wider tail.
+        writeStderrAll("\x1b[?7l");
+        for (self.bars) |*bar| bar.drawLine();
     }
 
     /// Restore cursor, autowrap, and reset to column 0 after all bars are done.
@@ -354,11 +376,24 @@ pub const ProgressBar = struct {
         // front of the label.
         self.spinner_frame +%= 1;
 
-        if (self.total > 0) {
-            self.renderDeterminate();
+        // The group mutex guards every multi-bar draw; hold it across the
+        // resize check + draw so a resize repaints the whole group atomically
+        // against in-flight worker draws.
+        if (self.multi) |mp| {
+            mp.mutex.lockUncancelable(pkg_io);
+            defer mp.mutex.unlock(pkg_io);
+            mp.repaintIfResized();
+            self.drawLine();
         } else {
-            self.renderIndeterminate();
+            self.drawLine();
         }
+    }
+
+    /// Draw this bar's single line in place — no locking, so the group mutex
+    /// is held by the caller (`render`) and by `repaintIfResized`. Determinacy
+    /// selects the body; both honour the group's cursor-up/down math.
+    fn drawLine(self: *const ProgressBar) void {
+        if (self.total > 0) self.drawDeterminate() else self.drawIndeterminate();
     }
 
     /// Return the glyph shown in front of the label: a spinner frame while
@@ -519,14 +554,10 @@ pub const ProgressBar = struct {
         return pos + seq.len;
     }
 
-    fn renderDeterminate(self: *const ProgressBar) void {
+    fn drawDeterminate(self: *const ProgressBar) void {
         const cols = queryCols();
         const layout = barLayout(cols, self.label_width);
         const pct: u64 = if (self.total > 0) @min((self.current * 100) / self.total, 100) else 0;
-
-        // Lock mutex if part of a MultiProgress group
-        if (self.multi) |mp| mp.mutex.lockUncancelable(pkg_io);
-        defer if (self.multi) |mp| mp.mutex.unlock(pkg_io);
 
         var buf: [768]u8 = undefined;
         var pos: usize = 0;
@@ -691,11 +722,8 @@ pub const ProgressBar = struct {
         return pos;
     }
 
-    fn renderIndeterminate(self: *const ProgressBar) void {
+    fn drawIndeterminate(self: *const ProgressBar) void {
         const cols = queryCols();
-
-        if (self.multi) |mp| mp.mutex.lockUncancelable(pkg_io);
-        defer if (self.multi) |mp| mp.mutex.unlock(pkg_io);
 
         var buf: [512]u8 = undefined;
         var pos: usize = 0;
@@ -1265,6 +1293,275 @@ test "MultiProgress in tty mode on a TTY emits the cursor-hide prelude" {
     // Prelude + 2 reserved newlines + restore-on-finish (autowrap on,
     // cursor on, carriage return).
     try std.testing.expectEqualStrings("\x1b[?25l\x1b[?7l\n\n\x1b[?7h\x1b[?25h\r", buf.items);
+}
+
+// A TTY-mode group arms SIGWINCH so a mid-render resize is observed without
+// a keypress; plain/none never install a handler (next test). The handler is
+// the flag-only variant — no syscall in signal context.
+test "MultiProgress in tty mode installs the flag-only winch handler" {
+    const prior_mode = mode();
+    setMode(.tty);
+    defer setMode(prior_mode);
+    setSupportsAnsiForTest(true);
+    defer setSupportsAnsiForTest(null);
+    termsize.setWinchInstalledForTest(false);
+    defer termsize.setWinchInstalledForTest(false);
+
+    var mp = MultiProgress.init(2);
+    mp.finish();
+
+    try std.testing.expect(termsize.winchInstalled());
+}
+
+test "MultiProgress in plain mode installs no winch handler" {
+    const prior_mode = mode();
+    setMode(.plain);
+    defer setMode(prior_mode);
+    setSupportsAnsiForTest(true);
+    defer setSupportsAnsiForTest(null);
+    termsize.setWinchInstalledForTest(false);
+    defer termsize.setWinchInstalledForTest(false);
+
+    var mp = MultiProgress.init(2);
+    mp.finish();
+
+    try std.testing.expect(!termsize.winchInstalled());
+}
+
+// AC: a resize mid-render repaints the whole group at the new width — the
+// autowrap-disable prelude is re-asserted and every bar's line is redrawn, not
+// just the worker that happened to tick. The flag is consumed once, so a burst
+// of resizes collapses to a single repaint per tick.
+test "a resize repaints the whole group with autowrap re-asserted" {
+    const prior_mode = mode();
+    setMode(.tty);
+    defer setMode(prior_mode);
+    setSupportsAnsiForTest(true);
+    defer setSupportsAnsiForTest(null);
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+    setColsForTest(100);
+    defer setColsForTest(null);
+    termsize.setWinchInstalledForTest(true); // skip the real sigaction
+    defer termsize.setWinchInstalledForTest(false);
+    termsize.setResizedForTest(false);
+    defer termsize.setResizedForTest(false);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    beginStderrCapture(std.testing.allocator, &buf);
+    defer endStderrCapture();
+
+    var mp = MultiProgress.init(2);
+    mp.is_tty = true;
+
+    var bars = [_]ProgressBar{
+        ProgressBar.init("alpha", 100),
+        ProgressBar.init("bravo", 100),
+    };
+    for (&bars, 0..) |*b, i| {
+        b.is_tty = true;
+        b.multi = &mp;
+        b.line_index = @intCast(i);
+    }
+    mp.bars = &bars;
+
+    // Isolate the repaint from the init prelude + reserved newlines.
+    buf.clearRetainingCapacity();
+
+    // A resize lands; the next worker to tick repaints the whole group.
+    termsize.setResizedForTest(true);
+    bars[1].update(50);
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\x1b[?7l") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "alpha") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "bravo") != null);
+    // The flag is consumed — a burst can't trigger a second repaint this tick.
+    try std.testing.expect(!termsize.takeResized());
+
+    // A later tick with no pending resize redraws only the worker's own line.
+    buf.clearRetainingCapacity();
+    bars[0].last_render_ns = 0; // bypass the 10 Hz throttle
+    bars[0].update(60);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "alpha") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "bravo") == null);
+}
+
+// AC: migrate's indeterminate bars inherit the repaint with no bespoke code —
+// the generic `drawLine` dispatch repaints a sibling spinner row too.
+test "a resize repaints indeterminate (migrate) bars" {
+    const prior_mode = mode();
+    setMode(.tty);
+    defer setMode(prior_mode);
+    setSupportsAnsiForTest(true);
+    defer setSupportsAnsiForTest(null);
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+    setColsForTest(100);
+    defer setColsForTest(null);
+    termsize.setWinchInstalledForTest(true);
+    defer termsize.setWinchInstalledForTest(false);
+    termsize.setResizedForTest(false);
+    defer termsize.setResizedForTest(false);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    beginStderrCapture(std.testing.allocator, &buf);
+    defer endStderrCapture();
+
+    var mp = MultiProgress.init(2);
+    mp.is_tty = true;
+    var bars = [_]ProgressBar{
+        ProgressBar.init("redis", 0), // total 0 → indeterminate
+        ProgressBar.init("kafka", 0),
+    };
+    for (&bars, 0..) |*b, i| {
+        b.is_tty = true;
+        b.multi = &mp;
+        b.line_index = @intCast(i);
+    }
+    mp.bars = &bars;
+    buf.clearRetainingCapacity();
+
+    termsize.setResizedForTest(true);
+    bars[0].update(4096);
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\x1b[?7l") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "redis") != null);
+    // The sibling bar, whose worker did not tick, was repainted too.
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "kafka") != null);
+}
+
+// AC headline: the repaint re-derives the live width. A terminal that narrows
+// below the floor collapses the repainted bars to bare counters — proof the
+// repaint reads the new width, not the width the bars were first drawn at.
+test "a resize repaints at the new width, collapsing to counters when it narrows" {
+    const prior_mode = mode();
+    setMode(.tty);
+    defer setMode(prior_mode);
+    setSupportsAnsiForTest(true);
+    defer setSupportsAnsiForTest(null);
+    color.setForTest(true, true);
+    defer color.setForTest(null, null);
+    setColsForTest(120); // wide: full bars
+    defer setColsForTest(null);
+    termsize.setWinchInstalledForTest(true);
+    defer termsize.setWinchInstalledForTest(false);
+    termsize.setResizedForTest(false);
+    defer termsize.setResizedForTest(false);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    beginStderrCapture(std.testing.allocator, &buf);
+    defer endStderrCapture();
+
+    var mp = MultiProgress.init(2);
+    mp.is_tty = true;
+    var bars = [_]ProgressBar{
+        ProgressBar.init("alpha", 1000),
+        ProgressBar.init("bravo", 1000),
+    };
+    for (&bars, 0..) |*b, i| {
+        b.is_tty = true;
+        b.multi = &mp;
+        b.line_index = @intCast(i);
+    }
+    mp.bars = &bars;
+    bars[0].update(500);
+    try std.testing.expect(barCellCount(buf.items) > 0); // wide draw has bars
+    buf.clearRetainingCapacity();
+
+    // The terminal shrinks hard, then a resize lands.
+    setColsForTest(20);
+    termsize.setResizedForTest(true);
+    bars[0].last_render_ns = 0;
+    bars[0].update(600);
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\x1b[?7l") != null);
+    try std.testing.expectEqual(@as(usize, 0), barCellCount(buf.items)); // counters at new width
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "alpha") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "bravo") != null);
+}
+
+// Edge: a resize before the caller registers its bars must not crash on the
+// empty slice — the repaint still re-asserts autowrap and the ticking worker
+// draws its own line.
+test "a resize with no registered bars re-asserts autowrap without crashing" {
+    const prior_mode = mode();
+    setMode(.tty);
+    defer setMode(prior_mode);
+    setSupportsAnsiForTest(true);
+    defer setSupportsAnsiForTest(null);
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+    setColsForTest(80);
+    defer setColsForTest(null);
+    termsize.setWinchInstalledForTest(true);
+    defer termsize.setWinchInstalledForTest(false);
+    termsize.setResizedForTest(false);
+    defer termsize.setResizedForTest(false);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    beginStderrCapture(std.testing.allocator, &buf);
+    defer endStderrCapture();
+
+    var mp = MultiProgress.init(1);
+    mp.is_tty = true;
+    var bar = ProgressBar.init("solo", 100);
+    bar.is_tty = true;
+    bar.multi = &mp;
+    bar.line_index = 0;
+    // mp.bars deliberately left empty — caller never registered it.
+    buf.clearRetainingCapacity();
+
+    termsize.setResizedForTest(true);
+    bar.update(50);
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\x1b[?7l") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "solo") != null);
+}
+
+// AC: single-package `upgrade` draws through SingleBar — a group of one. A
+// resize must repaint that bar at the new width too: wide bar collapses to a
+// counter, autowrap re-asserted. Proves the upgrade path inherits the fix
+// with no bespoke wiring (the bar repaints itself on its next tick).
+test "a resize repaints the single-bar (upgrade) group at the new width" {
+    const prior_mode = mode();
+    setMode(.tty);
+    defer setMode(prior_mode);
+    setSupportsAnsiForTest(true);
+    defer setSupportsAnsiForTest(null);
+    color.setForTest(true, true);
+    defer color.setForTest(null, null);
+    setColsForTest(100); // wide: a real bar
+    defer setColsForTest(null);
+    termsize.setWinchInstalledForTest(true);
+    defer termsize.setWinchInstalledForTest(false);
+    termsize.setResizedForTest(false);
+    defer termsize.setResizedForTest(false);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    beginStderrCapture(std.testing.allocator, &buf);
+    defer endStderrCapture();
+
+    var sp = SingleBar.init("ffmpeg", 1000);
+    const bar = sp.bind();
+    bar.is_tty = true;
+    bar.update(400);
+    try std.testing.expect(barCellCount(buf.items) > 0); // wide bar present
+    buf.clearRetainingCapacity();
+
+    setColsForTest(20); // narrow, then a resize
+    termsize.setResizedForTest(true);
+    bar.last_render_ns = 0;
+    bar.update(500);
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\x1b[?7l") != null);
+    try std.testing.expectEqual(@as(usize, 0), barCellCount(buf.items)); // counter at new width
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "ffmpeg") != null);
+    sp.finish();
 }
 
 // The single-bar entry point must inherit the same terminal setup as the

--- a/src/ui/termsize.zig
+++ b/src/ui/termsize.zig
@@ -63,6 +63,26 @@ pub fn installWinch(fd: std.posix.fd_t) void {
     std.posix.sigaction(std.posix.SIG.WINCH, &act, null);
 }
 
+/// Stricter `SIGWINCH` handler for the CLI progress engine: raise the flag
+/// and nothing else. The repaint owner queries the live size in normal
+/// context, so no syscall runs in signal context.
+fn winchHandlerFlagOnly(_: std.posix.SIG) callconv(.c) void {
+    resized_flag.store(true, .release);
+}
+
+/// Wire `SIGWINCH` to raise only the resize flag — no `ioctl` in signal
+/// context, unlike `installWinch`. The progress engine reads the live width
+/// itself on the next render tick. Idempotent like `installWinch`.
+pub fn installWinchFlagOnly() void {
+    if (winch_installed.swap(true, .acq_rel)) return;
+    const act = std.posix.Sigaction{
+        .handler = .{ .handler = &winchHandlerFlagOnly },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    };
+    std.posix.sigaction(std.posix.SIG.WINCH, &act, null);
+}
+
 pub fn winchInstalled() bool {
     return winch_installed.load(.acquire);
 }
@@ -124,6 +144,35 @@ test "takeResized consumes the flag exactly once" {
     setResizedForTest(true);
     try std.testing.expect(takeResized());
     try std.testing.expect(!takeResized());
+}
+
+// The install-path handler must do no work in signal context beyond raising
+// the flag — proven by a sentinel size left untouched (a `winsize` query
+// would overwrite it).
+test "flag-only winch handler raises the flag without querying winsize" {
+    setResizedForTest(false);
+    setSizeForTest(.{ .cols = 111, .rows = 222 });
+    winchHandlerFlagOnly(std.posix.SIG.WINCH);
+    try std.testing.expect(takeResized());
+    try std.testing.expectEqual(Size{ .cols = 111, .rows = 222 }, currentSize());
+}
+
+// A redundant install (repeated CLI dispatch, tests re-entering setup) must
+// not clobber a flag a prior handler already raised — the swap guard returns
+// before re-registering. Mirrors the SIGINT idempotency contract.
+test "installWinchFlagOnly does not clobber a raised resize flag" {
+    const prior_installed = winchInstalled();
+    defer setWinchInstalledForTest(prior_installed);
+    setWinchInstalledForTest(false);
+    setResizedForTest(false);
+
+    installWinchFlagOnly();
+    try std.testing.expect(winchInstalled());
+
+    // Simulate the handler firing between two install attempts.
+    setResizedForTest(true);
+    installWinchFlagOnly(); // idempotent no-op
+    try std.testing.expect(takeResized());
 }
 
 test "currentSize reflects the last published size" {


### PR DESCRIPTION
## Description

Resizing the terminal while `install`, `upgrade`, or `migrate` is drawing progress bars no longer corrupts the output. Previously the in-place redraw assumed each bar stayed on one physical row; a resize reflowed the lines and every tick stacked onto a fresh row, producing a column of half-finished bars. The engine now tracks SIGWINCH through the shared `ui/termsize` leaf and repaints the whole group at the new width on the next render tick — the same "flag, then redraw on next tick" contract the TUI already uses. The install path uses a stricter, flag-only signal handler so no syscall runs in signal context; the repaint owner queries the live width in normal context. Non-TTY and plain/none output are untouched.

The first worker to observe the resize repaints every bar in the group under the existing group mutex; later workers that tick the same cycle see the consumed flag and redraw only their own line. `migrate`'s indeterminate bars and `upgrade`'s single-bar group inherit the fix with no bespoke code.

## Related Issue

- None

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #474 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #472
- <kbd>&nbsp;1&nbsp;</kbd> #471
<!-- GitButler Footer Boundary Bottom -->