### PR TITLE
fix(tui): colour the selected-row highlight with the active theme

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -255,6 +255,7 @@ pub fn build(b: *std.Build) void {
         "tests/tui_doctor_test.zig",
         "tests/tui_search_test.zig",
         "tests/tui_purity_test.zig",
+        "tests/tui_selection_theme_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/tui/doctor_tab.zig
+++ b/src/tui/doctor_tab.zig
@@ -127,9 +127,6 @@ fn severityLabel(sev: Severity) []const u8 {
     };
 }
 
-// SGR reverse-video for the selection, matching the other tabs' convention.
-const reverse = "\x1b[7m";
-
 /// Pure render: the severity-ordered finding list and a detail pane for the
 /// selected finding. The `f: fix` key lives in the shared footer (the detail
 /// pane still shows whether the selected finding is fixable). The pane sizes to
@@ -183,7 +180,10 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
             f.put(color.Style.reset.code());
             f.put(" ");
             const selected = di == v.selected;
-            if (selected) f.put(reverse);
+            if (selected) { // the accent backgrounds the cursor row under a theme
+                f.put(color.selectionAccent());
+                f.put(color.Style.reverse.code());
+            }
             f.putContent(scroll_list.truncate(fnd.title, rect.width -| 2)); // 2 cols spent on the glyph
             if (selected) f.put(color.Style.reset.code());
         }
@@ -333,7 +333,7 @@ test "render highlights the selected row" {
     var s: State = .{ .items = &sample };
     s.chrome.view.selected = 0;
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 16 });
-    try testing.expect(std.mem.indexOf(u8, f.slice(), reverse) != null);
+    try testing.expect(std.mem.indexOf(u8, f.slice(), color.Style.reverse.code()) != null);
 }
 
 test "render narrows to the filter" {

--- a/src/tui/installed_tab.zig
+++ b/src/tui/installed_tab.zig
@@ -154,7 +154,10 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
         if (screen >= rect.height) break;
         f.moveTo(rect.row + @as(u16, @intCast(screen)), rect.col);
         const selected = fi == v.selected;
-        if (selected) f.put(reverse); // mark the cursor row
+        if (selected) { // mark the cursor row; the accent backgrounds it under a theme
+            f.put(color.selectionAccent());
+            f.put(color.Style.reverse.code());
+        }
         var rb: [256]u8 = undefined;
         f.putContent(scroll_list.truncate(formatRow(&rb, p), rect.width));
         if (selected) f.put(color.Style.reset.code());
@@ -163,16 +166,13 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
 
 fn renderGuard(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     f.moveTo(rect.row, rect.col);
-    f.put(reverse);
+    f.put(color.Style.reverse.code());
     const name = if (selectedPkg(s)) |p| p.name else "?";
     var b: [256]u8 = undefined;
     const line = std.fmt.bufPrint(&b, "Uninstall {s}? [y/N]", .{name}) catch "Uninstall? [y/N]";
     f.putContent(scroll_list.truncate(line, rect.width));
     f.put(color.Style.reset.code());
 }
-
-// SGR reverse-video for the selection / guard, matching `tab_bar`'s convention.
-const reverse = "\x1b[7m";
 
 /// One list row: name and version in fixed columns, a humanized size, then the
 /// pinned / unlinked markers. ASCII columns, grapheme-naive like the rest.
@@ -358,7 +358,7 @@ test "render highlights the selected row" {
     s.chrome.view.selected = 1; // curl
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 10 });
     // The reverse-video SGR marks the cursor row.
-    try testing.expect(std.mem.indexOf(u8, f.slice(), "\x1b[7m") != null);
+    try testing.expect(std.mem.indexOf(u8, f.slice(), color.Style.reverse.code()) != null);
 }
 
 test "render shows the detail pane with the dependency list when open" {

--- a/src/tui/outdated_tab.zig
+++ b/src/tui/outdated_tab.zig
@@ -162,16 +162,17 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
         const is_checked = i < s.checked.len and s.checked[i];
         tab.putCheckbox(f, if (p.pinned) .blocked else if (is_checked) tab.Check.on else .off);
         const selected = fi == v.selected;
-        // The cursor row wins over the pinned dim so the selection stays legible.
-        if (selected) f.put(reverse) else if (p.pinned) f.put(color.roleCode(.muted));
+        // The cursor row wins over the pinned dim so the selection stays legible;
+        // under a theme the accent backgrounds it via reverse-video.
+        if (selected) {
+            f.put(color.selectionAccent());
+            f.put(color.Style.reverse.code());
+        } else if (p.pinned) f.put(color.roleCode(.muted));
         var rb: [256]u8 = undefined;
         f.putContent(scroll_list.truncate(formatRow(&rb, p), rect.width -| 4)); // 4 cols on the checkbox
         if (selected or p.pinned) f.put(color.Style.reset.code());
     }
 }
-
-// SGR reverse-video for the selection, matching the other tabs' convention.
-const reverse = "\x1b[7m";
 
 /// One list row after the checkbox: the name, the current→latest versions, the
 /// source type, and a pinned tag. ASCII columns, grapheme-naive like the rest;
@@ -358,7 +359,7 @@ test "render highlights the selected row" {
     var s: State = .{ .items = &sample, .checked = &checked };
     s.chrome.view.selected = 0;
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
-    try testing.expect(std.mem.indexOf(u8, f.slice(), reverse) != null);
+    try testing.expect(std.mem.indexOf(u8, f.slice(), color.Style.reverse.code()) != null);
 }
 
 test "footerHint exposes the multi-select keys for the shared footer" {

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -208,15 +208,15 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
         const checked = i < s.checked.len and s.checked[i];
         tab.putCheckbox(f, if (m.installed) .blocked else if (checked) tab.Check.on else .off);
         const selected = i == v.selected;
-        if (selected) f.put(reverse);
+        if (selected) { // the accent backgrounds the cursor row under a theme
+            f.put(color.selectionAccent());
+            f.put(color.Style.reverse.code());
+        }
         var rb: [256]u8 = undefined;
         f.putContent(scroll_list.truncate(formatRow(&rb, m), rect.width -| 4)); // 4 cols on the checkbox
         if (selected) f.put(color.Style.reset.code());
     }
 }
-
-// SGR reverse-video for the selection, matching the other tabs' convention.
-const reverse = "\x1b[7m";
 
 /// One list row (after the checkbox): the package name, the kind (formula/cask),
 /// then an "installed" marker for a hit already on the system. ASCII columns,
@@ -419,7 +419,7 @@ test "render highlights the selected hit" {
     var s: State = .{ .items = &sample, .phase = .loaded };
     s.chrome.view.selected = 0;
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
-    try testing.expect(std.mem.indexOf(u8, f.slice(), reverse) != null);
+    try testing.expect(std.mem.indexOf(u8, f.slice(), color.Style.reverse.code()) != null);
 }
 
 test "footerHint exposes the tab's action keys for the shared footer" {

--- a/src/tui/services_tab.zig
+++ b/src/tui/services_tab.zig
@@ -142,15 +142,15 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
         f.put(color.Style.reset.code());
         f.put(" ");
         const selected = fi == v.selected;
-        if (selected) f.put(reverse);
+        if (selected) { // the accent backgrounds the cursor row under a theme
+            f.put(color.selectionAccent());
+            f.put(color.Style.reverse.code());
+        }
         var rb: [256]u8 = undefined;
         f.putContent(scroll_list.truncate(formatRow(&rb, svc), rect.width -| 2)); // 2 cols spent on the dot
         if (selected) f.put(color.Style.reset.code());
     }
 }
-
-// SGR reverse-video for the selection, matching the other tabs' convention.
-const reverse = "\x1b[7m";
 
 /// One list row (after the dot): the name, the runtime state, the auto-start
 /// hint, then the owning keg. ASCII columns, grapheme-naive like the rest.
@@ -289,7 +289,7 @@ test "render highlights the selected row" {
     var s: State = .{ .items = &sample };
     s.chrome.view.selected = 0;
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
-    try testing.expect(std.mem.indexOf(u8, f.slice(), reverse) != null);
+    try testing.expect(std.mem.indexOf(u8, f.slice(), color.Style.reverse.code()) != null);
 }
 
 test "footerHint exposes the lifecycle keys for the shared footer" {

--- a/src/tui/tab_bar.zig
+++ b/src/tui/tab_bar.zig
@@ -29,10 +29,6 @@ fn accentCode() []const u8 {
     return color.roleCode(.accent);
 }
 
-// SGR reverse-video: highlights the active tab as a filled block. `color.zig`
-// owns named colours, not this attribute, so the code lives here.
-const reverse_code = "\x1b[7m";
-
 // Divider between tabs — a light vertical bar, one display column wide.
 const sep = " │ ";
 
@@ -51,7 +47,7 @@ pub fn render(buf: []u8, active: Tab, titles: [count][]const u8, cols: u16) []co
         if (i != 0) append(buf, &len, sep);
         append(buf, &len, accentCode()); // every title carries the accent
         if (i == @intFromEnum(active)) { // active is a reverse-video, bold block
-            append(buf, &len, reverse_code);
+            append(buf, &len, color.Style.reverse.code());
             append(buf, &len, color.Style.bold.code());
         }
         append(buf, &len, t);
@@ -112,7 +108,7 @@ test "render divides tabs, reverse+bolds the active, accents the rest" {
     try std.testing.expect(std.mem.indexOf(u8, out, sep) != null); // a divider between tabs
     // active: accent + reverse + bold + title + reset
     var ab: [64]u8 = undefined;
-    const active = try std.fmt.bufPrint(&ab, "{s}{s}{s}Outdated{s}", .{ accentCode(), reverse_code, color.Style.bold.code(), color.Style.reset.code() });
+    const active = try std.fmt.bufPrint(&ab, "{s}{s}{s}Outdated{s}", .{ accentCode(), color.Style.reverse.code(), color.Style.bold.code(), color.Style.reset.code() });
     try std.testing.expect(std.mem.indexOf(u8, out, active) != null);
     // inactive: accent + title (no reverse/bold) + reset
     var ib: [64]u8 = undefined;

--- a/src/ui/color.zig
+++ b/src/ui/color.zig
@@ -18,6 +18,9 @@ pub const Style = enum {
     reset,
     bold,
     dim,
+    /// SGR reverse-video — the TUI selection / active-block highlight attribute.
+    /// Centralised here so the leaf has one source, not a literal per tab.
+    reverse,
     red,
     green,
     yellow,
@@ -30,6 +33,7 @@ pub const Style = enum {
             .reset => "\x1b[0m",
             .bold => "\x1b[1m",
             .dim => "\x1b[2m",
+            .reverse => "\x1b[7m",
             .red => "\x1b[31m",
             .green => "\x1b[32m",
             .yellow => "\x1b[33m",
@@ -564,6 +568,21 @@ pub fn roleCode(role: Role) []const u8 {
     return resolveRole(theme(), role, bg, tc);
 }
 
+/// The theme `accent` the TUI emits immediately before `Style.reverse`, so
+/// reverse-video renders the accent as the selection/active-block *background*.
+/// Empty under `.default` (and any tier where no theme applies) so the
+/// out-of-box selection stays plain reverse-video; non-empty only when a custom
+/// or named theme is genuinely in effect — the same gate as `roleCode`, so the
+/// selection themes exactly when the rest of the TUI does.
+pub fn selectionAccent() []const u8 {
+    const bg = background();
+    const tc = truecolorSupported();
+    if (activeCustomPalette(bg, tc)) |p| return p.get(.accent);
+    const t = theme();
+    if (namedThemeApplies(t, bg, tc)) return themes.named(t).?.get(.accent);
+    return "";
+}
+
 /// Secondary accent — a blue with no cell in the existing semantic palette.
 const Secondary = struct { dark_tc: []const u8, light_tc: []const u8, basic: []const u8 };
 const secondary_blue: Secondary = .{
@@ -800,4 +819,56 @@ test "no themes file leaves the resolver untouched" {
     try std.testing.expectEqual(InstallResult.absent, seedCustom(null, true, .unknown, null));
     defer resetCustom();
     try std.testing.expectEqualStrings(resolveRole(.default, .accent, .unknown, true), roleCode(.accent));
+}
+
+// ─── selectionAccent (TUI selection highlight) ───────────────────────
+//
+// The accent emitted before reverse-video so the highlight follows the theme.
+// Empty under `.default` keeps the out-of-box selection plain reverse-video.
+
+test "selectionAccent is empty under .default so the selection stays plain reverse" {
+    clearCustomForTest();
+    setThemeForTest(.default);
+    setTruecolorForTest(true);
+    setBackgroundForTest(.unknown);
+    defer {
+        setThemeForTest(null);
+        setTruecolorForTest(null);
+        setBackgroundForTest(null);
+    }
+    try std.testing.expectEqualStrings("", selectionAccent());
+}
+
+test "selectionAccent carries a named theme's accent when it applies" {
+    clearCustomForTest();
+    setThemeForTest(.dracula);
+    setTruecolorForTest(true);
+    setBackgroundForTest(.unknown);
+    defer {
+        setThemeForTest(null);
+        setTruecolorForTest(null);
+        setBackgroundForTest(null);
+    }
+    // The same accent the rest of the TUI paints; reverse-video makes it the bg.
+    try std.testing.expectEqualStrings(themes.named(.dracula).?.get(.accent), selectionAccent());
+    try std.testing.expect(selectionAccent().len != 0);
+}
+
+test "selectionAccent is empty on a basic terminal (a named theme needs truecolor)" {
+    clearCustomForTest();
+    setThemeForTest(.dracula);
+    setTruecolorForTest(false);
+    setBackgroundForTest(.unknown);
+    defer {
+        setThemeForTest(null);
+        setTruecolorForTest(null);
+        setBackgroundForTest(null);
+    }
+    try std.testing.expectEqualStrings("", selectionAccent());
+}
+
+test "selectionAccent carries an active custom theme's accent" {
+    try std.testing.expectEqual(InstallResult.loaded, seedCustom("ocean", true, .unknown, custom_ocean_src));
+    defer resetCustom();
+    try std.testing.expectEqualStrings("\x1b[38;2;189;147;249m", selectionAccent());
 }

--- a/tests/tui_selection_theme_test.zig
+++ b/tests/tui_selection_theme_test.zig
@@ -1,0 +1,105 @@
+//! malt — integration tests for the themed TUI selection highlight.
+//!
+//! The selected-row highlight and the active-tab block emit the active theme's
+//! `accent` immediately before reverse-video, so reverse-video paints the accent
+//! as the highlight background. Under `.default` the highlight stays plain
+//! reverse-video, leaving the out-of-box TUI unchanged. These pin the assembled
+//! render bytes; the per-tier resolver is unit-tested inline in `ui/color.zig`.
+
+const std = @import("std");
+const testing = std.testing;
+
+const malt = @import("malt");
+const color = malt.color;
+const tab = malt.tui_tab;
+const installed = malt.tui_tab_installed;
+const tab_bar = malt.tui_tab_bar;
+const test_io = @import("test_io");
+
+const reverse = "\x1b[7m";
+// dracula accent — the same RGB the rest of the TUI paints under MALT_THEME=dracula.
+const dracula_accent = "\x1b[38;2;189;147;249m";
+
+const sample = [_]installed.Pkg{
+    .{ .name = "brotli", .version = "1.2.0", .kind = .formula, .pinned = false, .size_bytes = 1902690, .linked = true },
+    .{ .name = "curl", .version = "8.20.0", .kind = .formula, .pinned = true, .size_bytes = 4734154, .linked = false },
+};
+
+fn forceTheme(t: color.Theme) void {
+    color.setThemeForTest(t);
+    color.setTruecolorForTest(true);
+    color.setBackgroundForTest(.unknown);
+}
+
+fn clearTheme() void {
+    color.setThemeForTest(null);
+    color.setTruecolorForTest(null);
+    color.setBackgroundForTest(null);
+}
+
+test "a named theme paints the selected row's accent right before reverse-video" {
+    forceTheme(.dracula);
+    defer clearTheme();
+
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    var s: installed.State = .{ .items = &sample };
+    s.chrome.view.selected = 1; // curl
+    installed.render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 10 });
+
+    // The accent SGR lands immediately before the reverse-video that backgrounds it.
+    try testing.expect(std.mem.indexOf(u8, f.slice(), dracula_accent ++ reverse) != null);
+}
+
+test "the default theme keeps the selection plain reverse-video (no accent prefix)" {
+    forceTheme(.default);
+    defer clearTheme();
+
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    var s: installed.State = .{ .items = &sample };
+    s.chrome.view.selected = 1;
+    installed.render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 10 });
+
+    try testing.expect(std.mem.indexOf(u8, f.slice(), reverse) != null); // still highlighted
+    try testing.expect(std.mem.indexOf(u8, f.slice(), dracula_accent ++ reverse) == null); // but no accent bg
+}
+
+test "a named theme paints the active tab block's accent right before reverse-video" {
+    forceTheme(.dracula);
+    defer clearTheme();
+
+    var buf: [256]u8 = undefined;
+    const titles: [tab_bar.count][]const u8 = .{ "Search", "Installed", "Outdated", "Services", "Doctor" };
+    const out = tab_bar.render(&buf, .outdated, titles, 80);
+
+    try testing.expect(std.mem.indexOf(u8, out, dracula_accent ++ reverse) != null);
+}
+
+// Acceptance: all five tabs and the tab bar share the one reverse-video seam in
+// `ui/color`, so no raw `\x1b[7m` literal is left under `src/tui/`.
+test "no reverse-video literal remains under src/tui" {
+    const io = std.Options.debug_io;
+    var dir = try test_io.cwd().openDir(io, "src/tui", .{ .iterate = true });
+    defer dir.close(io);
+
+    var walker = try dir.walk(testing.allocator);
+    defer walker.deinit();
+
+    while (try walker.next(io)) |entry| {
+        if (entry.kind != .file or !std.mem.endsWith(u8, entry.path, ".zig")) continue;
+        const file = try dir.openFile(io, entry.path, .{});
+        defer file.close(io);
+        const stat = try file.stat(io);
+        const content = try testing.allocator.alloc(u8, @intCast(stat.size));
+        defer testing.allocator.free(content);
+        _ = try file.readPositionalAll(io, content, 0);
+
+        // The needle is the *source* spelling of the escape (a backslash, then
+        // `x1b[7m`), not the rendered ESC byte the assertions above match.
+        if (std.mem.indexOf(u8, content, "\\x1b[7m") != null) {
+            std.debug.print("src/tui/{s} still contains a raw reverse-video literal\n", .{entry.path});
+            return error.RawReverseLiteral;
+        }
+    }
+}


### PR DESCRIPTION
## Description

The TUI's selected-row highlight and active-tab block now follow the active theme.

Built-in and custom palettes are both covered through their existing accent colour, so there is no new theme/JSON colour key.

## Related Issue

- None

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #477 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #476
<!-- GitButler Footer Boundary Bottom -->