### PR TITLE
fix(install): resolve tap formulas kept at the repository root

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -238,6 +238,7 @@ pub fn build(b: *std.Build) void {
         "tests/tap_gitlab_resolution_test.zig",
         "tests/tap_gitea_resolution_test.zig",
         "tests/tap_gogs_resolution_test.zig",
+        "tests/tap_root_layout_resolution_test.zig",
         "tests/tap_pin_forge_test.zig",
         "tests/tap_resolve_error_test.zig",
         "tests/linker_isolation_test.zig",

--- a/scripts/regressions/tap-root-layout-install-gh478.sh
+++ b/scripts/regressions/tap-root-layout-install-gh478.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Full end-to-end regression for root-layout tap installs.
+#
+# Sibling of tap-root-layout-resolve-*.sh: where that one stops at
+# --dry-run to prove the raw probes resolve, this one materialises the
+# keg. It installs a tap whose `<name>.rb` lives at the repository root
+# (the older Homebrew layout used by koekeishiya/felixkratz) all the way
+# to a runnable binary — the path that 404'd to FormulaNotFound before
+# the root-layout fallback probe existed.
+#
+# Asserts, against a live install of koekeishiya/formulae/yabai:
+#   1. `malt install <user>/<tap>/<formula>` exits 0 (pre-fix it aborted
+#      at resolve with FormulaNotFound).
+#   2. The keg is materialised at $PREFIX/Cellar/yabai/<version>/.
+#   3. $PREFIX/bin/yabai symlinks into the keg and is executable.
+#   4. The installed binary runs `--version` and reports `yabai-v<version>`,
+#      matching the version malt derived from the URL — proving the whole
+#      resolve -> download -> patch -> link chain is sound, not just resolve.
+#
+# The expected version is read back from the keg, so an upstream tap bump
+# never stales this script: it pins resolve/install/run *consistency*, not
+# a hardcoded release.
+#
+# Usage: scripts/regressions/tap-root-layout-install-gh478.sh
+# Requirements: built malt at $MALT_BIN or zig-out/bin/malt; network to
+# api.github.com / raw.githubusercontent.com / the yabai release asset
+# (rate-limit-proofed via MALT_GITHUB_TOKEN when present).
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be <= 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_yabai"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+export MALT_GITHUB_TOKEN="${MALT_GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+SLUG="koekeishiya/formulae"
+FORMULA="koekeishiya/formulae/yabai"
+TOKEN="yabai"
+LOG="$PREFIX/install.log"
+
+# Tapping is the network gate; a miss here is a SKIP, not a failure — the
+# bug under test is formula resolution, not tapping.
+if ! "$BIN" tap "$SLUG" >/dev/null 2>&1; then
+  echo "SKIP: cannot reach github to tap (network/rate-limit)"
+  exit 0
+fi
+
+printf '▸ malt install %s (logs → %s)\n' "$FORMULA" "$LOG"
+"$BIN" install "$FORMULA" >"$LOG" 2>&1 || {
+  tail -30 "$LOG" >&2
+  fail "${FORMULA}: install exited non-zero (root-layout resolve regressed?)"
+}
+
+# Resolve must have reached materialise, not died at the probe.
+if grep -qiE 'Tap formula/cask not found|FormulaNotFound' "$LOG"; then
+  tail -30 "$LOG" >&2
+  fail "${FORMULA}: install log shows the root-layout tap did not resolve"
+fi
+
+CELLAR_ROOT="$PREFIX/Cellar/${TOKEN}"
+[[ -d "$CELLAR_ROOT" ]] || fail "${FORMULA}: no keg under \$PREFIX/Cellar/${TOKEN}"
+# Single installed version — read it back rather than hardcoding a release.
+VERSION=$(find "$CELLAR_ROOT" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | head -1)
+[[ -n "$VERSION" ]] || fail "${FORMULA}: could not determine installed version from the keg"
+pass "${FORMULA}: keg materialised at \$PREFIX/Cellar/${TOKEN}/${VERSION}"
+
+LINK="$PREFIX/bin/${TOKEN}"
+[[ -L "$LINK" ]] || fail "${FORMULA}: \$PREFIX/bin/${TOKEN} symlink is missing"
+TARGET=$(readlink -f "$LINK" 2>/dev/null || readlink "$LINK")
+[[ -x "$TARGET" ]] || fail "${FORMULA}: \$PREFIX/bin/${TOKEN} resolves to a non-executable target"
+pass "${FORMULA}: \$PREFIX/bin/${TOKEN} → ${TARGET#"$PREFIX/"}"
+
+# Run the patched binary. Exit-zero with the matching version proves the
+# cellar layout and the Mach-O patch are both sound (no dyld breakage).
+VERSION_OUT=$("$LINK" --version 2>&1) || {
+  printf '%s\n' "$VERSION_OUT" >&2
+  fail "${FORMULA}: installed binary failed to run --version"
+}
+if [[ "$VERSION_OUT" != *"${TOKEN}-v${VERSION}"* ]]; then
+  printf '%s\n' "$VERSION_OUT" >&2
+  fail "${FORMULA}: --version output did not include ${TOKEN}-v${VERSION}"
+fi
+pass "${FORMULA}: binary runs and reports ${TOKEN}-v${VERSION}"
+
+printf '\n✔ root-layout tap end-to-end install regression passed\n'

--- a/scripts/regressions/tap-root-layout-resolve-gh478.sh
+++ b/scripts/regressions/tap-root-layout-resolve-gh478.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Regression guard for taps that keep `<name>.rb` at the repository root
+# instead of under `Formula/` or `Casks/` (the older Homebrew layout
+# still used by koekeishiya/felixkratz). The resolver probed only the
+# two subdir paths, so a root-layout tap 404'd both and aborted with
+# FormulaNotFound even though `brew install` resolves the same slug.
+#
+# Proves the fix end-to-end through the live raw probes, stopping at
+# --dry-run before any archive download or keg materialisation:
+#   1. `malt install <user>/<tap>/<formula>` resolves (no
+#      `Tap formula/cask not found` / `FormulaNotFound` in the output).
+#   2. The dry-run breadcrumb `Dry run: would install` fires, proving the
+#      resolve path reached materialise rather than dying at the probe.
+#
+# Network is inherent: the bug lives in raw-tree probing, so this hits
+# api.github.com (HEAD resolve) + raw.githubusercontent.com (two probes).
+# It exports MALT_GITHUB_TOKEN from `gh auth token` to dodge the
+# anonymous API cap, and SKIPs cleanly when neither token nor network is
+# available.
+#
+# Usage: scripts/regressions/tap-root-layout-resolve-gh478.sh
+# Requirements: built malt at $MALT_BIN or zig-out/bin/malt; network to
+# github (rate-limit-proofed via MALT_GITHUB_TOKEN when present).
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+PREFIX=$(mktemp -d)
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+export MALT_GITHUB_TOKEN="${MALT_GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+trap 'rm -rf "$PREFIX"' EXIT
+
+SLUG="koekeishiya/formulae"
+FORMULA="koekeishiya/formulae/yabai"
+
+# Tap first; a network/rate-limit miss here is a SKIP, not a failure —
+# the bug is in formula resolution, not in tapping.
+if ! "$BIN" tap "$SLUG" >/dev/null 2>&1; then
+  echo "SKIP: cannot reach github to tap (network/rate-limit)"
+  exit 0
+fi
+
+out=$("$BIN" install "$FORMULA" --dry-run 2>&1 || true)
+
+if printf '%s' "$out" | grep -qiE 'Tap formula/cask not found|FormulaNotFound'; then
+  printf 'FAIL: root-layout tap formula did not resolve\n%s\n' "$out" >&2
+  exit 1
+fi
+
+if ! printf '%s' "$out" | grep -q 'Dry run: would install'; then
+  printf 'FAIL: dry-run breadcrumb missing — resolve path changed\n%s\n' "$out" >&2
+  exit 1
+fi
+
+echo "OK: root-layout tap formula resolves through the raw probes"

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -270,11 +270,14 @@ fn installTapRb(
     };
     defer rb_resp.deinit();
 
-    // Distinct handle for the Casks/ retry: each fetch pairs with
-    // its own defer, so a future reorder cannot turn the previous
-    // single-`resp` reuse into a double-free or use-after-free.
+    // Distinct handles for the Casks/ and root-layout retries: each
+    // fetch pairs with its own defer, so a future reorder cannot turn
+    // the previous single-`resp` reuse into a double-free or
+    // use-after-free.
     var cask_resp: ?client_mod.Response = null;
     defer if (cask_resp) |*c| c.deinit();
+    var root_resp: ?client_mod.Response = null;
+    defer if (root_resp) |*r| r.deinit();
 
     const resp: *const client_mod.Response = blk: {
         if (rb_resp.status == 200) break :blk &rb_resp;
@@ -296,7 +299,25 @@ fn installTapRb(
             sink.err("Cannot fetch tap from GitHub", .{});
             return InstallError.FormulaNotFound;
         };
-        break :blk &cask_resp.?;
+        if (cask_resp.?.status == 200) break :blk &cask_resp.?;
+
+        // Last resort: the older Homebrew layout keeps `<name>.rb` at the
+        // repo root (koekeishiya/felixkratz taps). Only reached on the
+        // double-miss path, so the common Formula/ install pays no extra GET.
+        const root_url = forge.rawFileUrl(
+            &url_buf,
+            urls.forge,
+            urls.raw_base,
+            commit_sha,
+            .formula_root,
+            parts.formula,
+        ) catch return InstallError.FormulaNotFound;
+
+        root_resp = tap_mod.getRawFile(&http, ctx.environ, urls.forge, root_url) catch {
+            sink.err("Cannot fetch tap from GitHub", .{});
+            return InstallError.FormulaNotFound;
+        };
+        break :blk &root_resp.?;
     };
 
     if (resp.status != 200) {

--- a/src/core/forge.zig
+++ b/src/core/forge.zig
@@ -53,11 +53,18 @@ pub fn allocRepoBrowseUrl(
 pub const RawKind = enum {
     formula,
     cask,
+    /// Older Homebrew layout: `<name>.rb` kept at the repo root, no
+    /// subtree. `rawFileUrl` branches on this before the subdir lookup.
+    formula_root,
 
     fn subdir(self: RawKind) []const u8 {
         return switch (self) {
             .formula => "Formula",
             .cask => "Casks",
+            // Never consulted: rawFileUrl emits the no-subdir tail for
+            // this variant before reaching subdir(). An empty infix here
+            // would collapse to `//` in the tail.
+            .formula_root => "",
         };
     }
 };
@@ -74,6 +81,13 @@ pub fn rawFileUrl(
     kind: RawKind,
     name: []const u8,
 ) std.fmt.BufPrintError![]const u8 {
+    // Root-layout taps drop the subdir entirely: `<base>/<sha>/<name>.rb`.
+    // Branch before the forge switch so no empty infix collapses to `//`.
+    // The forge-specific infix already lives in `raw_base`, so this one
+    // arm covers every forge.
+    if (kind == .formula_root) {
+        return std.fmt.bufPrint(buf, "{s}/{s}/{s}.rb", .{ raw_base, sha, name });
+    }
     return switch (forge) {
         // Same tail for all: the forge-specific infix already lives in
         // `raw_base` (github: bare; gitlab: `/-/raw`; gitea/gogs: `/raw`).
@@ -696,6 +710,26 @@ test "rawFileUrl github: overflowing buffer surfaces NoSpaceLeft" {
     );
 }
 
+test "rawFileUrl github: formula_root kind builds the no-subdir root tail" {
+    var buf: [512]u8 = undefined;
+    const url = try rawFileUrl(&buf, .github, github_raw_base, raw_sha_fixture, .formula_root, "yabai");
+    try std.testing.expectEqualStrings(
+        github_raw_base ++ "/" ++ raw_sha_fixture ++ "/yabai.rb",
+        url,
+    );
+    // No `Formula/` infix and no `//` collapse: an empty subdir segment
+    // must never leak into the tail (that double-slash 404s the CDN).
+    try std.testing.expect(std.mem.indexOf(u8, url["https://".len..], "//") == null);
+}
+
+test "rawFileUrl github: formula_root overflowing buffer surfaces NoSpaceLeft" {
+    var buf: [8]u8 = undefined;
+    try std.testing.expectError(
+        error.NoSpaceLeft,
+        rawFileUrl(&buf, .github, github_raw_base, raw_sha_fixture, .formula_root, "yabai"),
+    );
+}
+
 // ── browse URL (github) ────────────────────────────────────────────
 // The `taps.url` projection: the URL that actually resolves in a
 // browser, written at INSERT/rebind and re-derived in `list`. Both
@@ -820,6 +854,18 @@ test "rawFileUrl gitlab: cask kind builds the /-/raw Casks tail" {
         gitlab_raw_base ++ "/" ++ raw_sha_fixture ++ "/Casks/glow.rb",
         url,
     );
+}
+
+test "rawFileUrl gitlab: formula_root kind builds the /-/raw root tail" {
+    // The root variant is forge-uniform: the `/-/raw` infix already lives
+    // in raw_base, so dropping the subdir yields `<base>/<sha>/<name>.rb`.
+    var buf: [512]u8 = undefined;
+    const url = try rawFileUrl(&buf, .gitlab, gitlab_raw_base, raw_sha_fixture, .formula_root, "glow");
+    try std.testing.expectEqualStrings(
+        gitlab_raw_base ++ "/" ++ raw_sha_fixture ++ "/glow.rb",
+        url,
+    );
+    try std.testing.expect(std.mem.indexOf(u8, url["https://".len..], "//") == null);
 }
 
 // ── fromHost (gitea) ────────────────────────────────────────────
@@ -956,6 +1002,16 @@ test "rawFileUrl gitea: cask kind builds the /raw Casks tail" {
         gitea_raw_base ++ "/" ++ raw_sha_fixture ++ "/Casks/glow.rb",
         url,
     );
+}
+
+test "rawFileUrl gitea: formula_root kind builds the /raw root tail" {
+    var buf: [512]u8 = undefined;
+    const url = try rawFileUrl(&buf, .gitea, gitea_raw_base, raw_sha_fixture, .formula_root, "glow");
+    try std.testing.expectEqualStrings(
+        gitea_raw_base ++ "/" ++ raw_sha_fixture ++ "/glow.rb",
+        url,
+    );
+    try std.testing.expect(std.mem.indexOf(u8, url["https://".len..], "//") == null);
 }
 
 // ── authHeader (gitea) ──────────────────────────────────────────
@@ -1131,6 +1187,16 @@ test "rawFileUrl gogs: shares the /raw Formula tail" {
         "https://git.example.org/team/tap/raw/" ++ raw_sha_fixture ++ "/Formula/glow.rb",
         url,
     );
+}
+
+test "rawFileUrl gogs: shares the /raw root tail" {
+    var buf: [512]u8 = undefined;
+    const url = try rawFileUrl(&buf, .gogs, "https://git.example.org/team/tap/raw", raw_sha_fixture, .formula_root, "glow");
+    try std.testing.expectEqualStrings(
+        "https://git.example.org/team/tap/raw/" ++ raw_sha_fixture ++ "/glow.rb",
+        url,
+    );
+    try std.testing.expect(std.mem.indexOf(u8, url["https://".len..], "//") == null);
 }
 
 test "repoBrowseUrl gogs: the instance host drives the browse URL" {

--- a/tests/tap_root_layout_resolution_test.zig
+++ b/tests/tap_root_layout_resolution_test.zig
@@ -1,0 +1,116 @@
+//! malt — offline integration for root-layout tap resolution.
+//!
+//! Inline tests in `src/core/forge.zig` cover the `.formula_root` URL
+//! shape in isolation; this file pins the *assembled probe sequence*
+//! `installTapRb` runs against a localhost `std.http.Server`, never live
+//! network. raw_base in production is https-only (built in
+//! `buildBaseUrls`), so the full `installTapRb` wiring is proven by the
+//! `scripts/regressions/tap-root-layout-resolve-*.sh` field test; here we
+//! drive the same forge seam (`rawFileUrl` + `getRawFile`) the probe loop
+//! uses, against a server that models a root-layout tap: `Formula/` and
+//! `Casks/` 404, the bare root `<name>.rb` 200s.
+//!
+//! It proves the fix's contract: a Formula/ + Casks/ double-404 falls
+//! back to the no-subdir root `.rb` and resolves — the URL the old probe
+//! chain never built.
+
+const std = @import("std");
+const testing = std.testing;
+
+const malt = @import("malt");
+const client = malt.client;
+const tap = malt.tap;
+const forge = malt.forge;
+const net = std.Io.net;
+
+const fixture_sha = "0123456789abcdef0123456789abcdef01234567";
+const root_body = "class Yabai < Formula\n  url \"https://example.com/yabai.tar.gz\"\nend\n";
+
+const Fixture = struct {
+    io: std.Io,
+    listener: *net.Server,
+    root_body: []const u8,
+    // Number of probe requests to serve before the thread returns.
+    expected: usize,
+};
+
+// Serves `fx.expected` requests, routing by target: any `/Formula/` or
+// `/Casks/` path 404s (the subtrees a root-layout tap lacks); everything
+// else 200s with the root body. `keep_alive = false` closes each
+// connection so the pooled client reconnects and `accept` fires per probe.
+// Errors are swallowed: a failed serve surfaces as a client-side
+// assertion failure in the test thread.
+fn serveProbes(fx: *Fixture) void {
+    var served: usize = 0;
+    while (served < fx.expected) : (served += 1) {
+        const stream = fx.listener.accept(fx.io) catch return;
+        defer stream.close(fx.io);
+        var rbuf: [16 * 1024]u8 = undefined;
+        var wbuf: [16 * 1024]u8 = undefined;
+        var reader = stream.reader(fx.io, &rbuf);
+        var writer = stream.writer(fx.io, &wbuf);
+        var srv = std.http.Server.init(&reader.interface, &writer.interface);
+        var req = srv.receiveHead() catch return;
+        const target = req.head.target;
+        const is_subdir = std.mem.indexOf(u8, target, "/Formula/") != null or
+            std.mem.indexOf(u8, target, "/Casks/") != null;
+        if (is_subdir) {
+            req.respond("not found\n", .{ .status = .not_found, .keep_alive = false }) catch return;
+        } else {
+            req.respond(fx.root_body, .{ .keep_alive = false }) catch return;
+        }
+    }
+}
+
+fn listenLocal(io: std.Io) !net.Server {
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    return addr.listen(io, .{ .reuse_address = true });
+}
+
+test "tap probe selection: Formula/ + Casks/ double-404 falls back to the root-layout .rb" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var listener = try listenLocal(io);
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var fx = Fixture{ .io = io, .listener = &listener, .root_body = root_body, .expected = 3 };
+    const server_thread = try std.Thread.spawn(.{}, serveProbes, .{&fx});
+    defer server_thread.join();
+
+    var base_buf: [64]u8 = undefined;
+    const raw_base = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, .empty, testing.allocator);
+    defer http.deinit();
+
+    var url_buf: [256]u8 = undefined;
+
+    // Probe 1 — Formula/ : the modern layout, absent here → 404.
+    const formula_url = try forge.rawFileUrl(&url_buf, .github, raw_base, fixture_sha, .formula, "yabai");
+    var formula_resp = try tap.getRawFile(&http, .empty, .github, formula_url);
+    defer formula_resp.deinit();
+    try testing.expectEqual(@as(u16, 404), formula_resp.status);
+
+    // Probe 2 — Casks/ : also absent → 404. Pre-fix the resolver gave up here.
+    const cask_url = try forge.rawFileUrl(&url_buf, .github, raw_base, fixture_sha, .cask, "yabai");
+    var cask_resp = try tap.getRawFile(&http, .empty, .github, cask_url);
+    defer cask_resp.deinit();
+    try testing.expectEqual(@as(u16, 404), cask_resp.status);
+
+    // Probe 3 — root `<name>.rb` : the added fallback resolves the formula.
+    const root_url = try forge.rawFileUrl(&url_buf, .github, raw_base, fixture_sha, .formula_root, "yabai");
+    var root_resp = try tap.getRawFile(&http, .empty, .github, root_url);
+    defer root_resp.deinit();
+    try testing.expectEqual(@as(u16, 200), root_resp.status);
+    try testing.expectEqualStrings(root_body, root_resp.body);
+
+    // The resolving URL is the no-subdir root tail — the URL the old
+    // two-probe chain never built.
+    var exp_buf: [256]u8 = undefined;
+    const expected = try std.fmt.bufPrint(&exp_buf, "http://127.0.0.1:{d}/{s}/yabai.rb", .{ port, fixture_sha });
+    try testing.expectEqualStrings(expected, root_url);
+}


### PR DESCRIPTION
## Description

Taps that keep `<name>.rb` at the repository root - the older Homebrew layout still used by `koekeishiya/homebrew-formulae` and `felixkratz/homebrew-formulae` - could not be installed. Resolution probed only `Formula/<name>.rb` and `Casks/<name>.rb`; a root-layout tap 404s both and aborted with `FormulaNotFound`, even though `brew install` resolves the same slug (Homebrew accepts both layouts).

This adds a root-layout fallback probe to the tap-formula resolver, reached only after both subdir probes miss. The common modern `Formula/` tap still resolves in a single request and pays no extra round-trip; the root probe is a strict miss-path addition. The no-subdir tail is forge-uniform, so GitHub, GitLab, and Gitea/Gogs root layouts all resolve through the same arm.

## Related Issue

- Closes #478

## Notes for Reviewers

- None