### PR TITLE
fix(install): refuse source-built tap formulas instead of linking an empty keg

### DIFF
--- a/scripts/regressions/tap-source-build-false-success-gh479.sh
+++ b/scripts/regressions/tap-source-build-false-success-gh479.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Regression: a source-built formula must be refused, not recorded as a
+# false success.
+#
+# A formula whose `def install` builds from source (`system "make"`, …)
+# ships a source archive, not a prebuilt binary. malt extracts the
+# archive, finds no binary to promote into bin/, and — pre-fix — linked
+# an empty bin/, recorded the keg, and printed `installed`. The fix
+# detects the empty bin/ on the extracted result and refuses, naming the
+# `brew install` escape hatch and unwinding the half-extracted keg.
+#
+# This drives the REAL install path: a genuine source archive is fetched,
+# extracted, and walked — the detection is on the actual result, not a
+# textual guess (a prebuilt formula also carries a `def install`, so a
+# parse-time check would wrongly refuse it). The archive's sha256 is
+# computed at run time, so an upstream tarball regeneration never stales
+# the guard; only an unreachable host does, and that is a SKIP.
+#
+# Asserts:
+#   1. `malt install --local <fixture>` exits non-zero (refusal).
+#   2. stdout/stderr never carries the false-success `installed` line.
+#   3. no keg is left under $PREFIX/Cellar/<name> (the keg was unwound).
+#   4. the refusal explains the source-build cause (mentions `build`).
+#
+# Usage: scripts/regressions/tap-source-build-false-success-gh479.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt; network to
+# the source archive host (override with SRC_ARCHIVE_URL=...).
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+# A tiny, stable source tarball — a pure-JS package with no file named
+# after our fixture, so the promote walk finds nothing to lift into bin/.
+URL="${SRC_ARCHIVE_URL:-https://github.com/sindresorhus/slugify/archive/refs/tags/v2.0.0.tar.gz}"
+
+PREFIX="/tmp/mt_srcbuild"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+
+WORK=$(mktemp -d)
+FIXTURE="$WORK/srcbuildprobe.rb"
+trap 'rm -rf "$PREFIX" "$WORK"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+# Fetching is the network gate; a miss is a SKIP, not a failure — the bug
+# under test is the post-extract record, not the download.
+ARCHIVE="$WORK/archive.tar.gz"
+if ! curl -fsSL "$URL" -o "$ARCHIVE"; then
+  echo "SKIP: cannot reach source archive host (network/offline)"
+  exit 0
+fi
+
+SHA=$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')
+[[ -n "$SHA" ]] || fail "could not compute sha256 of the source archive"
+
+# A def-install source formula (the issue's shape): the archive is the
+# source tree, the binary is produced by the build, which malt won't run.
+cat >"$FIXTURE" <<RB
+class Srcbuildprobe < Formula
+  url "$URL"
+  sha256 "$SHA"
+  version "2.0.0"
+  def install
+    system "make"
+    bin.install "#{buildpath}/bin/srcbuildprobe"
+  end
+end
+RB
+
+printf '▸ malt install --local %s\n' "$FIXTURE"
+set +e
+OUT=$("$BIN" install --local "$FIXTURE" 2>&1)
+RC=$?
+set -e
+
+if [[ "$RC" -eq 0 ]] || printf '%s' "$OUT" | grep -q 'installed'; then
+  printf '%s\n' "$OUT" >&2
+  fail "source-built formula was extracted and recorded as a false success"
+fi
+pass "install refused with a non-zero exit and no 'installed' line"
+
+KEG="$PREFIX/Cellar/srcbuildprobe"
+if [[ -d "$KEG" ]] && [[ -n "$(ls -A "$KEG" 2>/dev/null)" ]]; then
+  printf '%s\n' "$OUT" >&2
+  fail "a keg was left under \$PREFIX/Cellar/srcbuildprobe (refusal did not unwind it)"
+fi
+pass "no keg materialised — the extracted source tree was unwound"
+
+if ! printf '%s' "$OUT" | grep -qi 'build'; then
+  printf '%s\n' "$OUT" >&2
+  fail "refusal message did not explain the source-build cause"
+fi
+pass "refusal message names the source-build cause"
+
+printf '\n✔ source-build refusal regression passed\n'

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -57,6 +57,9 @@ const drive = post_install_mod.drive;
 const rb_parse_mod = @import("install/rb_parse.zig");
 const record_mod = @import("install/record.zig");
 const InstallError = record_mod.InstallError;
+/// Re-exported so `main`'s dispatch handler can exit quietly on an
+/// already-printed install/upgrade failure (see `isReportedInstallError`).
+pub const isReportedInstallError = record_mod.isReportedInstallError;
 const recordKeg = record_mod.recordKeg;
 const deleteKeg = record_mod.deleteKeg;
 const recordDeps = record_mod.recordDeps;
@@ -720,7 +723,14 @@ fn executeWithOpts(
         // Handle tap formulas separately (they don't use GHCR)
         if (isTapFormula(pkg_name)) {
             installTapFormula(ctx, allocator, pkg_name, &db, &linker, prefix, dry_run, force, download_only, sink) catch |e| {
-                sink.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
+                // A source-build refusal already printed an actionable line
+                // plus the `brew install` hint, so don't bury it under a
+                // generic summary that just repeats the error enum name.
+                // (installTapFormula's error set is wider than InstallError,
+                // so this checks the one value rather than localErrorIsAnnounced.)
+                if (e != InstallError.BuildFromSourceUnsupported) {
+                    sink.err("Failed to install {s}: {s}", .{ pkg_name, @errorName(e) });
+                }
                 failed_count += 1;
             };
             continue;

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -712,6 +712,13 @@ pub fn materializeRubyFormula(
     // mixes new and prior files at the same paths, and the post-link
     // sweep would only address symlinks + DB rows. Matches the JSON
     // pipeline's pre-materialize call.
+    //
+    // Known limitation: pruning here, before extraction, means a --force
+    // reinstall of a formula whose *same-version* artifact flipped from a
+    // prebuilt binary to a source build hits the no-artifact backstop below
+    // with the old keg already gone (doctor reclaims the dangling links).
+    // Not staged behind the backstop because an artifact swap without a
+    // version bump does not happen in practice.
     if (force) {
         install_mod.pruneCellarForReinstall(ctx, prefix, resolved.name, resolved.version);
     }
@@ -773,6 +780,39 @@ pub fn materializeRubyFormula(
                 bin_file.setPermissions(ctx.io, std.Io.File.Permissions.fromMode(0o755)) catch {};
                 break;
             }
+        }
+    }
+
+    // Refuse a source archive: a formula whose `def install` builds from
+    // source (`system "make"`, etc.) ships no prebuilt artifacts, so after
+    // extraction + the promote walk none of the keg's linkable dirs hold
+    // anything. Detecting it here — on the actual extracted result — is
+    // precise where a textual `def install` check is not: a prebuilt
+    // formula carries a `def install` too (just `bin.install "<file>"`),
+    // and that case lands a binary in bin/ and passes. Gate on the same
+    // dir set the linker links so a binary-, lib-, or header-only keg all
+    // count as success; only a raw source tree (its files nested under a
+    // `<name>-<version>/` wrapper, never at a keg prefix) is empty here.
+    // Unwind the half-extracted keg and return ahead of the DB
+    // transaction — nothing is recorded.
+    {
+        var produced_artifact = false;
+        for (linker_mod.Linker.linkable_dirs) |sub| {
+            var sub_buf: [512]u8 = undefined;
+            const sub_path = std.fmt.bufPrint(&sub_buf, "{s}/{s}", .{ cellar_path, sub }) catch continue;
+            var sub_dir = std.Io.Dir.openDirAbsolute(ctx.io, sub_path, .{ .iterate = true }) catch continue;
+            defer sub_dir.close(ctx.io);
+            var sub_it = sub_dir.iterate();
+            if ((sub_it.next(ctx.io) catch null) != null) {
+                produced_artifact = true;
+                break;
+            }
+        }
+        if (!produced_artifact) {
+            sink.err("{s} ships no prebuilt files — its archive builds from source, which malt does not run.", .{resolved.name});
+            sink.err("Install it with: brew install {s}", .{resolved.full_name});
+            std.Io.Dir.cwd().deleteTree(ctx.io, cellar_path) catch {};
+            return InstallError.BuildFromSourceUnsupported;
         }
     }
 

--- a/src/cli/install/rb_parse.zig
+++ b/src/cli/install/rb_parse.zig
@@ -498,3 +498,23 @@ test "tapCaskArtifactKind: tar.gz formula archives stay on the keg path" {
     try std.testing.expect(tapCaskArtifactKind("https://example.com/tool.tgz", true) == null);
     try std.testing.expect(tapCaskArtifactKind("https://example.com/tool.tar.xz", false) == null);
 }
+
+test "parseRubyFormula: a formula carrying a def install block still parses" {
+    // A `def install` block is no refusal signal — a prebuilt formula
+    // also carries one (`bin.install "<file-in-archive>"`). The parser
+    // must surface version/url/sha256 regardless; whether the archive
+    // yields a binary is decided downstream on the extracted result.
+    const rb =
+        \\class Sketchybar < Formula
+        \\  url "https://example.com/sketchybar-2.24.0.tar.gz"
+        \\  sha256 "deadbeef"
+        \\  version "2.24.0"
+        \\  def install
+        \\    system "make"
+        \\  end
+        \\end
+    ;
+    const got = parseRubyFormula(rb) orelse return error.TestUnexpectedNull;
+    try std.testing.expectEqualStrings("2.24.0", got.version);
+    try std.testing.expectEqualStrings("deadbeef", got.sha256);
+}

--- a/src/cli/install/record.zig
+++ b/src/cli/install/record.zig
@@ -33,6 +33,12 @@ pub const InstallError = error{
     /// Raised before any dep resolution or job queueing so nothing is
     /// downloaded, materialised, or linked for the affected package.
     PostInstallUnsupported,
+    /// The formula's archive builds from source: after extraction the
+    /// promote walk found no binary and bin/ is empty, so nothing
+    /// runnable would be linked. malt (a bottle/binary client) does not
+    /// run build blocks, so it unwinds the half-extracted keg and records
+    /// nothing — the user is pointed at `brew install` instead.
+    BuildFromSourceUnsupported,
     /// `--use-system-ruby` used with multiple formulas and no explicit
     /// scope list. The flag widens the trust boundary (runs full Ruby
     /// with only OS-level sandboxing), so malt requires the user to
@@ -71,6 +77,9 @@ pub fn localErrorIsAnnounced(e: InstallError) bool {
         InstallError.CellarFailed,
         InstallError.RateLimited,
         InstallError.NetworkError,
+        // Raise site prints the actionable "builds from source" line, so
+        // the generic dispatch summary stays suppressed.
+        InstallError.BuildFromSourceUnsupported,
         => true,
 
         InstallError.NoPackages,

--- a/src/cli/install/record.zig
+++ b/src/cli/install/record.zig
@@ -62,6 +62,19 @@ pub const InstallError = error{
     NetworkError,
 };
 
+/// True for any `InstallError`. The install/upgrade commands always print
+/// a user-facing line before returning one of these, so the top-level
+/// dispatch in `main` exits non-zero *quietly* on them — the same
+/// treatment as `error.Aborted` — instead of dumping the error enum name
+/// (and, in debug, a return trace) on top of the message the command
+/// already showed. Comptime-derived so a new tag is covered automatically.
+pub fn isReportedInstallError(e: anyerror) bool {
+    inline for (@typeInfo(InstallError).error_set.?) |variant| {
+        if (e == @field(InstallError, variant.name)) return true;
+    }
+    return false;
+}
+
 /// True when the given error has already surfaced a specific,
 /// user-facing `output.err` line from inside the install helpers, so
 /// the dispatch-loop shouldn't add a generic "Failed to install X: E"

--- a/src/core/linker.zig
+++ b/src/core/linker.zig
@@ -17,6 +17,13 @@ pub const Linker = struct {
     db: *sqlite.Database,
     prefix: []const u8,
 
+    /// Keg subdirectories whose top-level files get symlinked into the
+    /// prefix. `bin`/`sbin` lead so the bin-isolated variant is a tail
+    /// slice (`[2..]`). The install path also reads this to decide whether
+    /// an extracted archive produced anything linkable at all — keep that
+    /// check and `link` reading the same list so they cannot drift.
+    pub const linkable_dirs = [_][]const u8{ "bin", "sbin", "lib", "include", "share", "etc" };
+
     pub fn init(io: std.Io, allocator: std.mem.Allocator, db: *sqlite.Database, prefix: []const u8) Linker {
         return .{ .allocator = allocator, .io = io, .db = db, .prefix = prefix };
     }
@@ -94,9 +101,8 @@ pub const Linker = struct {
     /// `LC_LOAD_DYLIB` paths continue to resolve via `lib`, so compiled
     /// formulae are unaffected; only the global PATH entries disappear.
     pub fn link(self: *Linker, keg_path: []const u8, name: []const u8, keg_id: i64, bin_isolated: bool) !void {
-        const dirs_full = [_][]const u8{ "bin", "sbin", "lib", "include", "share", "etc" };
-        const dirs_isolated = [_][]const u8{ "lib", "include", "share", "etc" };
-        const dirs_to_link: []const []const u8 = if (bin_isolated) &dirs_isolated else &dirs_full;
+        // bin-isolated drops the leading `bin`/`sbin`; full keeps them.
+        const dirs_to_link: []const []const u8 = if (bin_isolated) linkable_dirs[2..] else &linkable_dirs;
 
         for (dirs_to_link) |subdir| {
             self.linkSubdir(keg_path, subdir, name, keg_id) catch continue;

--- a/src/main.zig
+++ b/src/main.zig
@@ -489,10 +489,17 @@ pub fn main(init: std.process.Init.Minimal) !void {
         // Any command can signal a user-facing failure by returning
         // `error.Aborted`; the message has already been emitted via
         // `output.err`, so we just exit non-zero without a stack trace.
-        // Every other error still propagates and surfaces normally.
+        // install / reinstall / upgrade additionally surface typed
+        // `InstallError` values (kept that way for testability) that have
+        // likewise already been printed — treat them the same so a clean
+        // refusal isn't followed by a raw `error: <Enum>` line. Scoped to
+        // that family because Zig error values are global by name: a
+        // same-named error (e.g. NetworkError) from another command must
+        // still surface loudly. Truly unexpected errors propagate too.
+        const install_family = cmd == .install or cmd == .reinstall or cmd == .upgrade;
         dispatch(allocator, &ctx, cmd, cmd_args) catch |e| switch (e) {
             error.Aborted => std.process.exit(1),
-            else => return e,
+            else => if (install_family and install.isReportedInstallError(e)) std.process.exit(1) else return e,
         };
         // Best-effort passive notice on successful subcommands. Owns its
         // own suppression list (CI, --quiet/--json/ndjson/--dry-run, env

--- a/tests/install_download_only_test.zig
+++ b/tests/install_download_only_test.zig
@@ -116,6 +116,19 @@ fn pathExists(path: []const u8) bool {
     return true;
 }
 
+// Real `Threaded` io to spawn `tar` — `std.Options.debug_io`'s failing
+// allocator can't back a child spawn. Used to mint a source-tree fixture.
+fn runTar(argv: []const []const u8) !void {
+    var threaded: std.Io.Threaded = .init(std.heap.c_allocator, .{ .environ = malt.app_ctx.processEnviron() });
+    defer threaded.deinit();
+    const io = threaded.io();
+    var child = try std.process.spawn(io, .{ .argv = argv, .stdout = .ignore, .stderr = .ignore });
+    switch (try child.wait(io)) {
+        .exited => |code| if (code != 0) return error.TarFailed,
+        else => return error.TarFailed,
+    }
+}
+
 test "execute refuses --download-only combined with --only-dependencies" {
     // The two flags are semantically ambiguous: one says "don't touch the
     // requested package", the other says "don't materialise anything".
@@ -740,4 +753,186 @@ test "--download-only populates the store and skips Cellar + kegs" {
     try testing.expect(pathExists(store_dir));
 
     try testing.expectEqual(@as(i64, 0), try kegRowCount(prefix));
+}
+
+test "materializeRubyFormula refuses a source archive that yields no linkable artifact, unwinding the keg" {
+    // A source-built formula ships a tree with no prebuilt binary: after
+    // extraction the promote walk lifts nothing and bin/ stays empty.
+    // materialise must refuse with BuildFromSourceUnsupported and unwind —
+    // no keg row, no leftover Cellar/<name>/<version>. Pre-fix this linked
+    // an empty bin/, recorded the keg, and printed `installed`.
+    //
+    // The detection is on the extracted result, not a textual `def install`
+    // check: a prebuilt formula carries `def install` too, so the warm-tap
+    // sibling test above (which lands a binary) proves the happy path still
+    // records — together they pin "refuse only when no binary was produced".
+    const prefix = try setupPrefix("srcbackstop");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha = "cd" ** 32;
+
+    // Build a real source-tree tarball (a file NOT named after the
+    // formula) and seed it at the sha-keyed cache path so materialise
+    // takes the warm-cache branch and never hits the network.
+    const work = try std.fmt.allocPrint(testing.allocator, "{s}/srcwork", .{prefix});
+    defer testing.allocator.free(work);
+    {
+        const payload_dir = try std.fmt.allocPrint(testing.allocator, "{s}/payload", .{work});
+        defer testing.allocator.free(payload_dir);
+        try test_io.cwd().createDirPath(std.Options.debug_io, payload_dir);
+    }
+    {
+        const readme = try std.fmt.allocPrint(testing.allocator, "{s}/payload/readme.txt", .{work});
+        defer testing.allocator.free(readme);
+        const f = try test_io.cwd().createFile(std.Options.debug_io, readme, .{});
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "source, no binary\n");
+    }
+
+    var cache_parent_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_parent = try std.fmt.bufPrint(&cache_parent_buf, "{s}/cache/Tap", .{prefix});
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_parent);
+    var cache_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_path = try malt.tap_cache.cachePath(&cache_path_buf, prefix, sha, ".tar.gz");
+    try runTar(&.{ "tar", "czf", cache_path, "-C", work, "payload" });
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, allocator);
+    defer http.deinit();
+
+    const db_path = try std.fmt.allocPrintSentinel(
+        testing.allocator,
+        "{s}/db/malt.db",
+        .{prefix},
+        0,
+    );
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+
+    var linker = malt.linker.Linker.init(ctx.io, allocator, &db, prefix);
+
+    const resolved: malt.install_local.ResolvedRubyFormula = .{
+        .name = "srcpkg",
+        .full_name = "user/repo/srcpkg",
+        .tap_label = "user/repo",
+        .version = "1.0",
+        .url = "https://malt-srcbuild-test.invalid/srcpkg-1.0.tar.gz",
+        .sha256 = sha,
+    };
+
+    try testing.expectError(install_record.InstallError.BuildFromSourceUnsupported, malt.install_local.materializeRubyFormula(
+        &ctx,
+        allocator,
+        resolved,
+        &http,
+        &db,
+        &linker,
+        prefix,
+        false, // dry_run
+        false, // force
+        false, // download_only
+        malt.install_sink.terminal,
+    ));
+
+    // Keg unwound: the version dir is gone and no keg row was written.
+    const keg_ver = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/srcpkg/1.0", .{prefix});
+    defer testing.allocator.free(keg_ver);
+    try testing.expect(!pathExists(keg_ver));
+    try testing.expectEqual(@as(i64, 0), try kegRowCount(prefix));
+}
+
+test "materializeRubyFormula installs a lib-only keg that ships no binary" {
+    // A prebuilt formula may ship only libs/headers (no bin/). The refusal
+    // gate is "no linkable artifact at all", not "no binary" — so a keg
+    // whose archive is keg-shaped (top-level lib/) installs and links,
+    // keeping malt usable for non-CLI tap formulas. Distinguishes from the
+    // source-tree case above, whose files nest under a wrapper dir and
+    // never land at a keg prefix.
+    const prefix = try setupPrefix("libonly");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const sha = "ef" ** 32;
+
+    // Keg-shaped archive: a top-level lib/ with one file, no binary.
+    const work = try std.fmt.allocPrint(testing.allocator, "{s}/libwork", .{prefix});
+    defer testing.allocator.free(work);
+    {
+        const lib_dir = try std.fmt.allocPrint(testing.allocator, "{s}/lib", .{work});
+        defer testing.allocator.free(lib_dir);
+        try test_io.cwd().createDirPath(std.Options.debug_io, lib_dir);
+        const dylib = try std.fmt.allocPrint(testing.allocator, "{s}/libfoo.dylib", .{lib_dir});
+        defer testing.allocator.free(dylib);
+        const f = try test_io.cwd().createFile(std.Options.debug_io, dylib, .{});
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "prebuilt lib\n");
+    }
+
+    var cache_parent_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_parent = try std.fmt.bufPrint(&cache_parent_buf, "{s}/cache/Tap", .{prefix});
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_parent);
+    var cache_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_path = try malt.tap_cache.cachePath(&cache_path_buf, prefix, sha, ".tar.gz");
+    try runTar(&.{ "tar", "czf", cache_path, "-C", work, "lib" });
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var http = malt.client.HttpClient.init(ctx.io, ctx.environ, allocator);
+    defer http.deinit();
+
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/db/malt.db", .{prefix}, 0);
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+
+    var linker = malt.linker.Linker.init(ctx.io, allocator, &db, prefix);
+
+    const resolved: malt.install_local.ResolvedRubyFormula = .{
+        .name = "libpkg",
+        .full_name = "user/repo/libpkg",
+        .tap_label = "user/repo",
+        .version = "1.0",
+        .url = "https://malt-libonly-test.invalid/libpkg-1.0.tar.gz",
+        .sha256 = sha,
+    };
+
+    try malt.install_local.materializeRubyFormula(
+        &ctx,
+        allocator,
+        resolved,
+        &http,
+        &db,
+        &linker,
+        prefix,
+        false, // dry_run
+        false, // force
+        false, // download_only
+        malt.install_sink.terminal,
+    );
+
+    // Recorded and linked: a keg row exists and lib/libfoo.dylib is linked
+    // into the prefix.
+    try testing.expectEqual(@as(i64, 1), try kegRowCount(prefix));
+    const link = try std.fmt.allocPrint(testing.allocator, "{s}/lib/libfoo.dylib", .{prefix});
+    defer testing.allocator.free(link);
+    try testing.expect(pathExists(link));
 }


### PR DESCRIPTION
## Description

Installing a tap or local formula whose archive builds from source (its `def install` runs `make`/`go build`/etc. and produces the binary at build time) used to "succeed" while doing nothing useful: malt extracted the source tree into the Cellar, found no binary to promote, linked an empty `bin/`, recorded the keg, and printed `✓ <name> <version> installed`. The package then showed in `mt list` with no executable on disk.

malt is a bottle/binary client and does not run Ruby build blocks, so the right outcome is a loud refusal - but only for archives that yield nothing installable. After extraction and the binary-promote walk, if none of the keg's linkable directories (`bin sbin lib include share etc`, the set `linker.link` symlinks) holds a file, the archive was a raw source tree: malt unwinds the half-extracted keg (no row, no links, no leftover Cellar dir) and fails with an actionable message pointing at `brew install`.

Detection is on the **extracted result**, not on the presence of a `def install` block: nearly every prebuilt tap formula also carries a `def install` (just `bin.install "<file-already-in-the-archive>"`), so a textual check would wrongly refuse them. A source tarball extracts into a `<name>-<version>/` wrapper, so its files never land at a keg prefix and the keg reads as empty; a prebuilt archive is keg-shaped and passes - whether it ships a binary (ast-outline, yabai, …) or only libs/headers. Only true source builds are refused.

Error output:

```
✗ sketchybar ships no prebuilt files — its archive builds from source, which malt does not run.
✗ Install it with: brew install felixkratz/formulae/sketchybar
```

Because the keg row is never written, the phantom `mt list` entry disappears on its own.

## Related Issue

- Closes #479

## Notes for Reviewers

- None

