### PR TITLE
chore(tui): show a header bar with name, version, prefix and counts

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -100,6 +100,7 @@ pub const themes = @import("ui/themes.zig");
 pub const tui_app = @import("tui/app.zig");
 pub const tui_detail_pane = @import("tui/detail_pane.zig");
 pub const tui_filter_input = @import("tui/filter_input.zig");
+pub const tui_header = @import("tui/header.zig");
 pub const tui_json_doctor = @import("tui/json/doctor.zig");
 pub const tui_json_info = @import("tui/json/info.zig");
 pub const tui_json_list = @import("tui/json/list.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -569,7 +569,7 @@ fn dispatch(allocator: std.mem.Allocator, ctx: *const AppCtx, cmd: Command, cmd_
             // delegated mutations; fall back to `mt` (PATH) if it can't be read.
             var self_buf: [std.fs.max_path_bytes]u8 = undefined;
             const mt_path = if (std.process.executablePath(ctx.io, &self_buf)) |n| self_buf[0..n] else |_| "mt";
-            try @import("tui/app.zig").run(ctx.io, allocator, ctx.stderr, ctx.environ, mt_path);
+            try @import("tui/app.zig").run(ctx.io, allocator, ctx.stderr, ctx.environ, mt_path, version);
         },
         .bundle => try bundle.execute(ctx, allocator, cmd_args),
         .uses => try uses.execute(ctx, allocator, cmd_args),

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -14,6 +14,7 @@ const color = @import("../ui/color.zig");
 const term_sanitize = @import("../ui/term_sanitize.zig");
 const tab = @import("tab.zig");
 const tab_bar = @import("tab_bar.zig");
+const header = @import("header.zig");
 const filter_input = @import("filter_input.zig");
 const keys = @import("keys.zig");
 const term = @import("term.zig");
@@ -143,6 +144,14 @@ pub const App = struct {
     /// refetch, so the synchronous freeze shows "Loading…" instead of a stale
     /// frame. Never persisted: the read's own repaint clears it.
     loading: bool = false,
+    /// Header inputs. `version` (comptime) and `prefix` (env-resolved) are set
+    /// once in `run`; the counts mirror the loaded stores and stay null until
+    /// each store loads, so the header shows a placeholder rather than a wrong
+    /// number.
+    version: []const u8 = "",
+    prefix: []const u8 = "",
+    installed_count: ?usize = null,
+    outdated_count: ?usize = null,
 };
 
 /// After a delegated mutation the active tab was just re-read inline, so it is
@@ -294,6 +303,16 @@ pub fn renderFrame(buf: []u8, app: *const App, cols: u16, rows: u16) []const u8 
     switch (layout.compute(cols, rows)) {
         .too_small => renderTooSmall(&f, cols, rows),
         .ok => |r| {
+            f.moveTo(r.header.row, 1);
+            var hdb: [256]u8 = undefined;
+            f.put(header.render(&hdb, .{
+                .version = app.version,
+                .prefix = app.prefix,
+                .kegs = app.installed_count,
+                .outdated = app.outdated_count,
+            }, cols));
+            f.put(color.Style.reset.code()); // a truncated muted segment must not bleed downward
+
             f.moveTo(r.tab_bar.row, 1);
             var tb: [256]u8 = undefined;
             f.put(tab_bar.render(&tb, app.active, tabTitles(), cols));
@@ -493,6 +512,7 @@ fn loadInstalled(io: std.Io, allocator: std.mem.Allocator, app: *App, store: *St
         store.installed = null;
         app.states.installed.items = &.{};
         app.states.installed.detail = null;
+        app.installed_count = 0; // empty Cellar is a known zero, not "unknown"
         return;
     };
     defer allocator.free(bytes);
@@ -502,6 +522,7 @@ fn loadInstalled(io: std.Io, allocator: std.mem.Allocator, app: *App, store: *St
     store.installed = parsed;
     app.states.installed.items = parsed.items;
     app.states.installed.detail = null; // a refreshed list invalidates the old detail
+    app.installed_count = parsed.items.len;
 }
 
 /// Read `mt info <pkg> --json` for the selected row into the detail pane.
@@ -579,6 +600,7 @@ fn loadOutdated(io: std.Io, allocator: std.mem.Allocator, app: *App, store: *Sto
         store.outdated_checked = &.{};
         app.states.outdated.items = &.{};
         app.states.outdated.checked = &.{};
+        app.outdated_count = 0; // nothing outdated is a known zero, not "unknown"
         return;
     };
     defer allocator.free(bytes);
@@ -596,6 +618,7 @@ fn loadOutdated(io: std.Io, allocator: std.mem.Allocator, app: *App, store: *Sto
     store.outdated_checked = checked;
     app.states.outdated.items = parsed.items;
     app.states.outdated.checked = checked;
+    app.outdated_count = parsed.items.len;
 }
 
 /// Build the `mt upgrade <names...>` argv for the checked Outdated rows. Pure
@@ -969,7 +992,7 @@ fn writeAll(fd: std.posix.fd_t, bytes: []const u8) void {
 
 /// Launch the dashboard. Refuses (exit 2) on a non-interactive terminal rather
 /// than degrading. Every fault path restores the terminal via `errdefer`.
-pub fn run(io: std.Io, allocator: std.mem.Allocator, stderr: std.Io.File, environ: std.process.Environ, mt_path: []const u8) RunError!void {
+pub fn run(io: std.Io, allocator: std.mem.Allocator, stderr: std.Io.File, environ: std.process.Environ, mt_path: []const u8, version: []const u8) RunError!void {
     const in_fd = std.posix.STDIN_FILENO;
     const out_fd = std.posix.STDOUT_FILENO;
     if (refusalReason(
@@ -994,7 +1017,9 @@ pub fn run(io: std.Io, allocator: std.mem.Allocator, stderr: std.Io.File, enviro
     errdefer t.restore();
     term.installWinch(fd);
 
-    var app: App = .{ .mt_path = mt_path }; // re-exec this mt for delegated mutations
+    // The prefix the dashboard acts on, resolved the way the rest of malt does.
+    const prefix = std.process.Environ.getPosix(environ, "MALT_PREFIX") orelse "/opt/malt";
+    var app: App = .{ .mt_path = mt_path, .version = version, .prefix = prefix }; // re-exec this mt for delegated mutations
     app.dirty.insert(.outdated); // lazy: load `mt outdated --json` on first activation
     app.dirty.insert(.services); // lazy: load `mt services list --json` on first activation
     app.dirty.insert(.doctor); // lazy: load `mt doctor --json` on first activation

--- a/src/tui/header.zig
+++ b/src/tui/header.zig
@@ -1,0 +1,145 @@
+//! malt — header bar widget for `mt tui`.
+//!
+//! Leaf module: `std` + `ui/color` + `scroll_list` only. A pure function of its
+//! inputs and `cols`, modelled on `tab_bar.render` — the left segment
+//! (`mt <version>  •  <prefix>`) is always present; the right segment
+//! (`<n> kegs  •  <m> outdated`) is right-justified and dropped whole before the
+//! left is clipped, so name + version survive a narrow terminal longest.
+
+const std = @import("std");
+const color = @import("../ui/color.zig");
+const scroll_list = @import("scroll_list.zig");
+
+const name = "mt";
+const sep = "  •  ";
+const unknown = "—";
+
+/// Header inputs. `version` and `prefix` are always known; each count is null
+/// until its store loads, so an unloaded count renders as `unknown` rather than
+/// a stale or wrong number.
+pub const Fields = struct {
+    version: []const u8,
+    prefix: []const u8,
+    kegs: ?usize = null,
+    outdated: ?usize = null,
+};
+
+/// Render the muted header into `buf`, truncated to `cols`. The right segment is
+/// shown only when it fits with a column of gap; otherwise it is dropped whole
+/// so name + version survive a narrow terminal.
+pub fn render(buf: []u8, fields: Fields, cols: u16) []const u8 {
+    var lbuf: [192]u8 = undefined;
+    var rbuf: [64]u8 = undefined;
+    const left = leftSegment(&lbuf, fields);
+    const right = rightSegment(&rbuf, fields);
+    const lw = visibleWidth(left);
+    const rw = visibleWidth(right);
+
+    var len: usize = 0;
+    append(buf, &len, color.roleCode(.muted)); // chrome, like the footer
+    append(buf, &len, left);
+    // Right-justify the counts; keep at least one column of gap. When they can't
+    // fit, drop them whole rather than clip the left.
+    if (lw + rw < cols) {
+        var pad = cols - lw - rw;
+        while (pad > 0) : (pad -= 1) append(buf, &len, " ");
+        append(buf, &len, right);
+    }
+    append(buf, &len, color.Style.reset.code());
+    return scroll_list.truncate(buf[0..len], cols);
+}
+
+fn leftSegment(buf: []u8, fields: Fields) []const u8 {
+    return std.fmt.bufPrint(buf, "{s} {s}{s}{s}", .{ name, fields.version, sep, fields.prefix }) catch buf[0..0];
+}
+
+fn rightSegment(buf: []u8, fields: Fields) []const u8 {
+    var kb: [20]u8 = undefined;
+    var ob: [20]u8 = undefined;
+    return std.fmt.bufPrint(buf, "{s} kegs{s}{s} outdated", .{
+        countStr(&kb, fields.kegs), sep, countStr(&ob, fields.outdated),
+    }) catch buf[0..0];
+}
+
+/// A loaded count is its number; an unloaded one is `unknown`, never a stale value.
+fn countStr(buf: []u8, v: ?usize) []const u8 {
+    const n = v orelse return unknown;
+    return std.fmt.bufPrint(buf, "{d}", .{n}) catch unknown;
+}
+
+fn append(buf: []u8, len: *usize, s: []const u8) void {
+    const n = @min(s.len, buf.len - len.*);
+    @memcpy(buf[len.*..][0..n], s[0..n]);
+    len.* += n;
+}
+
+// ─── tests ───────────────────────────────────────────────────────────
+
+fn visibleWidth(s: []const u8) usize {
+    var w: usize = 0;
+    var i: usize = 0;
+    while (i < s.len) {
+        if (s[i] == 0x1b) {
+            i += 1;
+            if (i < s.len and s[i] == '[') {
+                i += 1;
+                while (i < s.len and !(s[i] >= 0x40 and s[i] <= 0x7e)) i += 1;
+            }
+            if (i < s.len) i += 1;
+            continue;
+        }
+        const n = std.unicode.utf8ByteSequenceLength(s[i]) catch 1;
+        i += @min(@as(usize, n), s.len - i);
+        w += 1;
+    }
+    return w;
+}
+
+test "render shows the name, version and prefix on the left" {
+    var buf: [256]u8 = undefined;
+    const out = render(&buf, .{ .version = "0.1.0", .prefix = "/opt/malt" }, 80);
+    try std.testing.expect(std.mem.indexOf(u8, out, "mt 0.1.0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "/opt/malt") != null);
+}
+
+test "render right-justifies both counts and fills the line" {
+    var buf: [256]u8 = undefined;
+    const out = render(&buf, .{ .version = "0.1.0", .prefix = "/opt/malt", .kegs = 192, .outdated = 17 }, 80);
+    try std.testing.expect(std.mem.indexOf(u8, out, "192 kegs") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "17 outdated") != null);
+    // Right-justified: the last visible text is the right segment (the trailing
+    // reset SGR rides along after it).
+    var visible = out;
+    const reset = color.Style.reset.code();
+    if (std.mem.endsWith(u8, visible, reset)) visible = visible[0 .. visible.len - reset.len];
+    try std.testing.expect(std.mem.endsWith(u8, visible, "17 outdated"));
+    try std.testing.expectEqual(@as(usize, 80), visibleWidth(out));
+}
+
+test "render shows an em-dash for a count whose store has not loaded" {
+    var buf: [256]u8 = undefined;
+    const out = render(&buf, .{ .version = "0.1.0", .prefix = "/opt/malt", .outdated = 17 }, 80);
+    try std.testing.expect(std.mem.indexOf(u8, out, unknown ++ " kegs") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "17 outdated") != null);
+}
+
+test "render shows em-dashes for both counts before anything loads" {
+    var buf: [256]u8 = undefined;
+    const out = render(&buf, .{ .version = "0.1.0", .prefix = "/opt/malt" }, 80);
+    try std.testing.expect(std.mem.indexOf(u8, out, unknown ++ " kegs") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, unknown ++ " outdated") != null);
+}
+
+test "render drops the right segment before clipping the left on a narrow terminal" {
+    var buf: [256]u8 = undefined;
+    const out = render(&buf, .{ .version = "0.1.0", .prefix = "/opt/malt", .kegs = 192, .outdated = 17 }, 20);
+    try std.testing.expect(std.mem.indexOf(u8, out, "mt 0.1.0") != null); // name+version survive
+    try std.testing.expect(std.mem.indexOf(u8, out, "kegs") == null); // counts dropped whole
+    try std.testing.expect(visibleWidth(out) <= 20);
+}
+
+test "render bounds the visible width to cols without counting SGR" {
+    var buf: [256]u8 = undefined;
+    const out = render(&buf, .{ .version = "0.1.0", .prefix = "/opt/malt", .kegs = 192, .outdated = 17 }, 8);
+    try std.testing.expect(visibleWidth(out) <= 8);
+}

--- a/src/tui/layout.zig
+++ b/src/tui/layout.zig
@@ -3,8 +3,8 @@
 //! Leaf module: imports only `std` and the read-only `ui/term_sanitize` helper
 //! (via `scroll_list`). The frame is a *pure function of `(cols, rows)`* so a
 //! terminal resize is just a re-render, not a data refetch, and the whole layer
-//! is testable without a PTY. Splits the screen into four stacked, full-width
-//! regions — tab-bar / filter / content / footer — and, below a minimum size,
+//! is testable without a PTY. Splits the screen into five stacked, full-width
+//! regions — header / tab-bar / filter / content / footer — and, below a minimum size,
 //! renders a clean "terminal too small" fallback instead of a corrupt frame.
 //! Nothing here touches the terminal, so a degenerate size yields the fallback,
 //! never a panic that would bypass the caller's `errdefer` restoration.
@@ -16,9 +16,10 @@ const scroll_list = @import("scroll_list.zig");
 /// loop can position the cursor at `region.row`/`region.col` directly.
 pub const Rect = struct { row: u16, col: u16, width: u16, height: u16 };
 
-/// The four stacked regions, top to bottom. They tile the screen exactly: no
+/// The five stacked regions, top to bottom. They tile the screen exactly: no
 /// gaps, no overlap, total height == `rows`.
 pub const Regions = struct {
+    header: Rect,
     tab_bar: Rect,
     filter: Rect,
     content: Rect,
@@ -27,11 +28,12 @@ pub const Regions = struct {
 
 // Fixed region heights; `content` takes whatever rows remain. `min_rows` is
 // derived so at least one content row always survives.
+pub const header_rows: u16 = 1;
 pub const tab_bar_rows: u16 = 1;
 pub const filter_rows: u16 = 1;
 pub const footer_rows: u16 = 2;
 pub const min_content_rows: u16 = 1;
-pub const min_rows: u16 = tab_bar_rows + filter_rows + footer_rows + min_content_rows;
+pub const min_rows: u16 = header_rows + tab_bar_rows + filter_rows + footer_rows + min_content_rows;
 // The narrowest width that still shows all five tabs; below it the bar can't
 // fit them, so the fallback shows rather than a clipped frame. A narrow-but-tall
 // window trips this on width alone — `fits` requires both axes.
@@ -52,12 +54,14 @@ pub fn fits(cols: u16, rows: u16) bool {
 /// `.too_small`; otherwise the four regions tile the screen exactly.
 pub fn compute(cols: u16, rows: u16) Layout {
     if (!fits(cols, rows)) return .too_small;
-    const content_rows = rows - tab_bar_rows - filter_rows - footer_rows;
-    const filter_row = 1 + tab_bar_rows;
+    const content_rows = rows - header_rows - tab_bar_rows - filter_rows - footer_rows;
+    const tab_bar_row = 1 + header_rows;
+    const filter_row = tab_bar_row + tab_bar_rows;
     const content_row = filter_row + filter_rows;
     const footer_row = content_row + content_rows;
     return .{ .ok = .{
-        .tab_bar = .{ .row = 1, .col = 1, .width = cols, .height = tab_bar_rows },
+        .header = .{ .row = 1, .col = 1, .width = cols, .height = header_rows },
+        .tab_bar = .{ .row = tab_bar_row, .col = 1, .width = cols, .height = tab_bar_rows },
         .filter = .{ .row = filter_row, .col = 1, .width = cols, .height = filter_rows },
         .content = .{ .row = content_row, .col = 1, .width = cols, .height = content_rows },
         .footer = .{ .row = footer_row, .col = 1, .width = cols, .height = footer_rows },
@@ -127,13 +131,22 @@ fn renderFallback(buf: []u8, cols: u16, rows: u16) []const u8 {
     return buf[0..n];
 }
 
-test "compute tiles the screen exactly and content absorbs the slack" {
+test "compute reserves the header row and tiles the screen exactly" {
     const r = compute(80, 24).ok;
-    try std.testing.expectEqual(@as(u16, 1), r.tab_bar.row);
-    try std.testing.expectEqual(@as(u16, 3), r.content.row);
-    try std.testing.expectEqual(@as(u16, 20), r.content.height);
+    try std.testing.expectEqual(@as(u16, 1), r.header.row);
+    try std.testing.expectEqual(@as(u16, 2), r.tab_bar.row);
+    try std.testing.expectEqual(@as(u16, 4), r.content.row);
+    try std.testing.expectEqual(@as(u16, 19), r.content.height);
     try std.testing.expectEqual(@as(u16, 23), r.footer.row);
     try std.testing.expect(compute(1, 1) == .too_small);
+}
+
+test "min_rows reserves a row for the header" {
+    try std.testing.expectEqual(
+        header_rows + tab_bar_rows + filter_rows + footer_rows + min_content_rows,
+        min_rows,
+    );
+    try std.testing.expectEqual(@as(u16, 6), min_rows);
 }
 
 test "compute is too_small when either axis alone is below the minimum" {

--- a/tests/tui_app_test.zig
+++ b/tests/tui_app_test.zig
@@ -82,6 +82,30 @@ test "a recoverable banner is painted in the footer and a keypress dismisses it"
     try testing.expect(std.mem.indexOf(u8, cleared, "quit") != null); // help line is back
 }
 
+test "the header bar paints name, version and prefix on row 1 above the tab bar" {
+    var a: app.App = .{ .version = "0.1.0", .prefix = "/opt/malt" };
+    var buf: [8192]u8 = undefined;
+    const out = app.renderFrame(&buf, &a, 80, 24);
+    const hdr = std.mem.indexOf(u8, out, "mt 0.1.0").?;
+    try testing.expect(std.mem.indexOf(u8, out, "/opt/malt") != null);
+    // Painted before the tab bar, which moves the cursor to row 2.
+    try testing.expect(hdr < std.mem.indexOf(u8, out, "\x1b[2;1H").?);
+}
+
+test "header counts are an em-dash before their stores load, the numbers after" {
+    var a: app.App = .{ .version = "0.1.0", .prefix = "/opt/malt" };
+    var buf: [8192]u8 = undefined;
+    const empty = app.renderFrame(&buf, &a, 120, 24);
+    try testing.expect(std.mem.indexOf(u8, empty, "\xe2\x80\x94 kegs") != null); // em-dash
+    try testing.expect(std.mem.indexOf(u8, empty, "\xe2\x80\x94 outdated") != null);
+
+    a.installed_count = 192;
+    a.outdated_count = 17;
+    const loaded = app.renderFrame(&buf, &a, 120, 24);
+    try testing.expect(std.mem.indexOf(u8, loaded, "192 kegs") != null);
+    try testing.expect(std.mem.indexOf(u8, loaded, "17 outdated") != null);
+}
+
 test "refusalReason refuses a non-interactive terminal and allows a clean tty" {
     try testing.expectEqual(@as(?app.Refusal, .not_a_tty), app.refusalReason(false, true, false, false));
     try testing.expectEqual(@as(?app.Refusal, .no_color), app.refusalReason(true, true, true, false));

--- a/tests/tui_layout_test.zig
+++ b/tests/tui_layout_test.zig
@@ -17,7 +17,7 @@ fn expectTiles(cols: u16, rows: u16) !void {
     const r = lay.ok;
 
     // Stacked top-to-bottom, full width, in order.
-    const regs = [_]layout.Rect{ r.tab_bar, r.filter, r.content, r.footer };
+    const regs = [_]layout.Rect{ r.header, r.tab_bar, r.filter, r.content, r.footer };
     var expected_row: u16 = 1;
     var total_height: u16 = 0;
     for (regs) |reg| {
@@ -46,7 +46,7 @@ test "fixed regions keep their heights; content absorbs the remainder" {
     try testing.expectEqual(layout.tab_bar_rows, r.tab_bar.height);
     try testing.expectEqual(layout.filter_rows, r.filter.height);
     try testing.expectEqual(layout.footer_rows, r.footer.height);
-    try testing.expectEqual(@as(u16, 24 - layout.tab_bar_rows - layout.filter_rows - layout.footer_rows), r.content.height);
+    try testing.expectEqual(@as(u16, 24 - layout.header_rows - layout.tab_bar_rows - layout.filter_rows - layout.footer_rows), r.content.height);
 }
 
 test "below the minimum is too_small; at or above is ok" {
@@ -121,7 +121,7 @@ test "compute at max u16 dimensions stays in bounds and tiles exactly" {
     const r = layout.compute(65535, 65535).ok;
     try testing.expectEqual(@as(u16, 65535), r.content.width);
     // content takes everything the fixed regions don't; footer still ends at the last row.
-    try testing.expectEqual(@as(u16, 65535 - layout.tab_bar_rows - layout.filter_rows - layout.footer_rows), r.content.height);
+    try testing.expectEqual(@as(u16, 65535 - layout.header_rows - layout.tab_bar_rows - layout.filter_rows - layout.footer_rows), r.content.height);
     try testing.expectEqual(@as(u32, 65535), @as(u32, r.footer.row) + r.footer.height - 1);
 }
 


### PR DESCRIPTION
## Description

`mt tui` now opens with a header bar above the tabs showing the binary name and version, the active prefix, and - once their tabs have loaded - the keg and outdated counts.

Name, version and prefix are present from the first frame; the counts fill in lazily from data the TUI already loads, so launch stays fast and offline.

## Related Issue

- None

## Notes for Reviewers

- None