### PR TITLE
fix(tui): refresh the header keg count after a cross-tab install

### DIFF
--- a/scripts/e2e/tui_header_counts.sh
+++ b/scripts/e2e/tui_header_counts.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# scripts/e2e/tui_header_counts.sh
+#
+# The dashboard header must show the live `<n> kegs` and `<m> outdated` counts on
+# launch, sourced from cheap DB reads, without the user entering the Installed or
+# Outdated tabs. Inline tests cover the count-refresh functions in isolation; this
+# proves the launch path wires them into the header under a real pty.
+#
+# Asserts (with 8 seeded kegs, a fresh prefix → 0 outdated):
+#   - the header reads "8 kegs" at launch, before any tab switch;
+#   - the header reads "0 outdated" at launch;
+#   - the Installed tab was never entered (no seeded row appears), so the count
+#     came from the launch prime, not a lazy tab load.
+#
+# Usage:   MT_BIN=./zig-out/bin/malt ./scripts/e2e/tui_header_counts.sh
+# Exit:    0 on pass, 1 on failure, 2 when the binary or pty tooling is missing.
+
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+# shellcheck source=scripts/lib/tui_pty.sh
+# shellcheck disable=SC1091 # sourced lib resolved at runtime; absent when this file is linted alone
+source "$ROOT/scripts/lib/tui_pty.sh"
+
+tui_pty_guard
+tui_pty_make_prefix
+trap 'rm -rf "$TUI_PREFIX"' EXIT
+tui_pty_seed_kegs 8
+
+fail() {
+  echo "tui-header-counts: FAIL — $*" >&2
+  exit 1
+}
+
+CAP="$TUI_PREFIX/cap.bin"
+# Launch on Search, let the count primes return, then quit — never switching tabs,
+# so a passing keg count can only have come from the launch prime.
+out=$(
+  tui_pty_drive "$CAP" 90 24 <<'ACT'
+settle 0.6
+send q
+quitwait 1.5
+ACT
+)
+
+echo "$out" | grep -q "EXIT_STATUS=0" || fail "mt tui did not exit 0 on q ($out)"
+
+grep -qa "8 kegs" "$CAP" || fail "header never showed the seeded keg count at launch"
+grep -qa "0 outdated" "$CAP" || fail "header never showed the outdated count at launch"
+grep -qa "pkg01" "$CAP" && fail "Installed tab was entered — count did not come from the launch prime"
+
+echo "tui-header-counts: PASS"

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -1022,6 +1022,10 @@ fn doInstall(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, app: *App,
     // backend's install-aware `installed` flag does the rest (no `mt list` call).
     try loadSearch(io, allocator, app, store);
     markStaleAfterMutation(app); // Installed/Outdated/Services may have changed too
+    // The keg set grew but we are on Search, so the lazy Installed reload won't
+    // run until that tab is entered — refresh just the count now (cheaply) so the
+    // header is live immediately, not stale until Installed is opened.
+    try refreshInstalledCount(io, allocator, app);
 }
 
 /// Perform any effect the pure `step` requested on the Search tab, then clear it.
@@ -1648,6 +1652,35 @@ test "refreshOutdatedCount populates the outdated count on a fresh prefix" {
     try refreshOutdatedCount(t.io(), std.testing.allocator, &app);
     try std.testing.expectEqual(@as(?usize, 0), app.outdated_count);
     try std.testing.expect(!app.banner.isSet());
+}
+
+test "the post-install count refresh overwrites a stale count without entering Installed" {
+    var t = std.Io.Threaded.init(std.testing.allocator, .{});
+    defer t.deinit();
+    // The cross-tab-install gap: a count from before the mutation, with Installed
+    // marked dirty (its full --size --linked payload reloads only on entry).
+    var app: App = .{ .mt_path = "/usr/bin/true", .active = .search, .installed_count = 6 };
+    app.dirty.insert(.installed);
+    try refreshInstalledCount(t.io(), std.testing.allocator, &app);
+    try std.testing.expectEqual(@as(?usize, 0), app.installed_count); // live again, not the stale 6
+    try std.testing.expect(app.dirty.contains(.installed)); // full payload still loads lazily on entry
+}
+
+test "a broken keg-count read banners and leaves the prior count untouched" {
+    var t = std.Io.Threaded.init(std.testing.allocator, .{});
+    defer t.deinit();
+    var app: App = .{ .mt_path = "/bin/echo", .installed_count = 6 }; // echo emits non-JSON → parse fails
+    try std.testing.expectError(error.BadJson, refreshInstalledCount(t.io(), std.testing.allocator, &app));
+    try std.testing.expectEqualStrings("keg count refresh failed: BadJson", app.banner.slice());
+    try std.testing.expectEqual(@as(?usize, 6), app.installed_count); // a failed read keeps the last-good count
+}
+
+test "a broken outdated-count read banners under its own op" {
+    var t = std.Io.Threaded.init(std.testing.allocator, .{});
+    defer t.deinit();
+    var app: App = .{ .mt_path = "/bin/echo" };
+    try std.testing.expectError(error.BadJson, refreshOutdatedCount(t.io(), std.testing.allocator, &app));
+    try std.testing.expectEqualStrings("outdated count refresh failed: BadJson", app.banner.slice());
 }
 
 test "loadOutdated treats an exit-0 empty response (fresh prefix) as an empty tab" {


### PR DESCRIPTION
## Description

The header `<n> kegs` count is sourced from `installed_count`, which was only recomputed by the lazy Installed load. Installing from the **Search** tab grew the keg set but never refreshed the count, so the header stayed stale until the user opened the Installed tab.

`doInstall` now calls `refreshInstalledCount` (the cheap `mt list --json` count read, no `--size --linked` walk) right after the post-install re-search, so the header is live immediately. The full Installed payload still loads lazily on tab entry. This mirrors how `doUpgrade` already refreshes the outdated count in place via `loadOutdated`.

## Related Issue

- None (internal; reproduced by the maintainer)

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #491  👈
- <kbd>&nbsp;2&nbsp;</kbd> #489 
- <kbd>&nbsp;1&nbsp;</kbd> #488  
<!-- GitButler Footer Boundary Bottom -->
