### PR TITLE
fix(tui): refresh the Doctor tab after a fix instead of treating its severity exit as a failure

### DIFF
--- a/scripts/e2e/tui_doctor_fix_roundtrip.sh
+++ b/scripts/e2e/tui_doctor_fix_roundtrip.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# scripts/e2e/tui_doctor_fix_roundtrip.sh
+#
+# The Doctor-fix round-trip: pressing `f` on a fixable finding drops the
+# alt-screen, re-execs the real `mt doctor --fix <class>`, re-enters, and
+# refreshes the pane to the post-fix findings. This is the doctor sibling of
+# tui_delegation_roundtrip.sh (uninstall), and it guards a specific seam:
+# `mt doctor` exits non-zero by *severity* (1 = warnings), not by pass/fail, so
+# a successful fix of a warning-class finding still exits 1. The inline runner
+# must tolerate that severity exit and still run the refresh — otherwise the
+# pane keeps its pre-fix findings behind a spurious "doctor fix failed" banner.
+#
+# Asserts:
+#   - the delegated `mt doctor --fix` actually ran (its "swept" line is in the
+#     stream), i.e. `f` still delegates;
+#   - no "doctor fix failed" banner — a severity exit must not read as a fault;
+#   - the post-fix frame no longer shows the orphan's warning detail
+#     ("mt purge --store-orphans"), proving the in-session refresh ran.
+#
+# The fixture is a complete prefix (all expected dirs present, bin on PATH) so
+# the seeded orphan is the *only* finding — it sorts to the top, is selected on
+# load, and its detail pane carries the warning string we assert on. If the
+# directory_structure check's expected set changes, update DIRS below.
+#
+# Usage:   MT_BIN=./zig-out/bin/malt ./scripts/e2e/tui_doctor_fix_roundtrip.sh
+# Exit:    0 on pass, 1 on failure, 2 when the binary or pty tooling is missing.
+
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+# shellcheck source=scripts/lib/tui_pty.sh
+# shellcheck disable=SC1091 # sourced lib resolved at runtime; absent when this file is linted alone
+source "$ROOT/scripts/lib/tui_pty.sh"
+
+tui_pty_guard
+tui_pty_make_prefix
+trap 'rm -rf "$TUI_PREFIX"' EXIT
+
+# Make the prefix structurally complete so directory_structure and prefix_on_path
+# stay green — then the orphan is the sole finding and is the selected row.
+DIRS=(store Cellar Caskroom opt bin lib tmp cache db)
+for d in "${DIRS[@]}"; do mkdir -p "$TUI_PREFIX/$d"; done
+export PATH="$TUI_PREFIX/bin:$PATH"
+
+tui_pty_seed_orphan_store
+
+fail() {
+  echo "tui-doctor-fix: FAIL — $*" >&2
+  exit 1
+}
+
+CAP="$TUI_PREFIX/cap.bin"
+# Launch opens on Search; four `tab`s reach Doctor (search→installed→outdated→
+# services→doctor). `f` fixes the selected orphan finding inline, then the pane
+# refetches. The orphan sweep does not prompt, so no confirm input is needed.
+out=$(
+  tui_pty_drive "$CAP" 110 30 <<'ACT'
+settle 0.4
+send \t
+settle 0.3
+send \t
+settle 0.3
+send \t
+settle 0.3
+send \t
+settle 0.7
+send f
+settle 1.4
+mark DONE
+send q
+quitwait 1.5
+ACT
+)
+echo "$out" | grep -q "EXIT_STATUS=0" || fail "mt tui did not exit 0 on q ($out)"
+
+# The real subcommand ran inline (its output landed in the captured stream).
+grep -qa "swept .* orphaned store entr" "$CAP" || fail "no 'swept' output — mt doctor --fix was not delegated"
+
+# A severity exit must not be misread as a failure: no error banner anywhere.
+grep -qa "doctor fix failed" "$CAP" && fail "spurious 'doctor fix failed' banner — severity exit treated as a fault"
+
+# The pane refreshed: the orphan's warning detail is gone from the final frame.
+# ("mt purge --store-orphans" is the warn-only detail string; the swept line does
+#  not contain it, so a match in the post-DONE frame means stale, unrefreshed.)
+perl -0777 -e '
+  my $data = do { local $/; <STDIN> };
+  my ($final) = $data =~ /\n\@\@DONE\@\@(.*)\z/s;
+  defined $final or die "no final frame after DONE\n";
+  $final !~ /mt purge --store-orphans/ or die "orphan warning still shown after refresh\n";
+' <"$CAP" || fail "pane did not refresh after the delegated fix"
+
+echo "tui-doctor-fix: OK — f re-execs real mt doctor --fix and refreshes the pane"

--- a/scripts/lib/tui_pty.sh
+++ b/scripts/lib/tui_pty.sh
@@ -84,6 +84,16 @@ tui_pty_seed_keg_real() {
   : >"$TUI_PREFIX/Cellar/$name/1.0/marker"
 }
 
+# Seed one orphaned store entry: a sha256 dir under store/ with no live
+# store_refs row — the exact shape `mt doctor --fix orphaned_store` sweeps. The
+# doctor walker counts any store dir lacking a refcount>0 row as orphaned, so the
+# missing row alone makes it a fixable warning. Optional arg overrides the sha.
+tui_pty_seed_orphan_store() {
+  local sha="${1:-deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef}"
+  mkdir -p "$TUI_PREFIX/store/$sha"
+  : >"$TUI_PREFIX/store/$sha/payload"
+}
+
 # Drive `mt tui` under the pty. Args: <capfile> <cols> <rows>; the action
 # program is read from this function's stdin. Echoes the driver's
 # "EXIT_STATUS=<n>" line so the caller can assert on the child's exit code.

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -890,14 +890,16 @@ fn doDoctorFix(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter:
     const argv = (try doctorFixArgv(allocator, app.mt_path, &app.states.doctor)) orelse return; // nothing fixable selected
     defer allocator.free(argv);
     {
-        // A non-zero `mt doctor --fix` re-enters the dashboard (the user keeps
-        // malt's real output, including any typed-confirm, in their scrollback)
-        // and surfaces as a recoverable banner; only a terminal fault is fatal.
+        // `mt doctor --fix` exits by severity (1 warn / 2 err), not pass/fail —
+        // a clean sweep of a warning-class finding still exits 1 — so tolerate
+        // exits up to 2 (symmetric with the doctor read's `max_ok_exit`). A real
+        // fault (exit > 2, signal, terminal fault) still surfaces as a banner;
+        // a severity exit re-enters cleanly and falls through to the refresh.
         // Scoped so the refresh below reports under its own op, not the fix.
         errdefer |err| app.banner.set("doctor fix failed", @errorName(err));
-        try spawn.runInlineReenter(t, argv);
+        try spawn.runInlineReenterTolerant(t, argv, 2);
     }
-    try loadDoctor(io, allocator, painter, app, store); // the finding may be resolved — refetch
+    try loadDoctor(io, allocator, painter, app, store); // exit can't say what remains — the refresh is the truth
     markStaleAfterMutation(app);
 }
 

--- a/src/tui/spawn.zig
+++ b/src/tui/spawn.zig
@@ -50,15 +50,26 @@ pub fn jsonArgv(
 }
 
 /// Spawn `argv` inheriting the parent's stdio (so the child's prompts and
-/// progress reach the user's scrollback) and map its exit to an error. A
-/// non-zero exit, signal, or stop surfaces as `ChildFailed` — never swallowed.
-pub fn runChild(io: std.Io, argv: []const []const u8) SpawnError!void {
+/// progress reach the user's scrollback) and map its exit to an error. `code <=
+/// max_ok_exit` is success: most mutations pass `0`, but `mt doctor --fix` passes
+/// `2` because its exit code is the *pre-fix* severity (1 warn / 2 err), not a
+/// pass/fail — so a successful sweep of a warning-class finding still exits 1.
+/// A signal, stop, or a code above the cap is `ChildFailed` — never swallowed.
+/// Mirrors `captureJson`'s `max_ok_exit` so the read and mutation paths share
+/// one exit policy.
+pub fn runChildTolerant(io: std.Io, argv: []const []const u8, max_ok_exit: u8) SpawnError!void {
     var child = std.process.spawn(io, .{ .argv = argv }) catch return error.SpawnFailed;
     const status = child.wait(io) catch return error.WaitFailed;
     switch (status) {
-        .exited => |code| if (code != 0) return error.ChildFailed,
+        .exited => |code| if (code > max_ok_exit) return error.ChildFailed,
         .signal, .stopped, .unknown => return error.ChildFailed,
     }
+}
+
+/// `runChildTolerant` with a zero cap: any non-zero exit is `ChildFailed`. The
+/// policy for install/uninstall/upgrade/services, whose success is exit 0.
+pub fn runChild(io: std.Io, argv: []const []const u8) SpawnError!void {
+    return runChildTolerant(io, argv, 0);
 }
 
 /// Spawn `argv`, drain its stdout fully, then wait. Returns the captured bytes
@@ -263,19 +274,22 @@ const TermCtrl = struct {
     }
 };
 
-/// The mutation body: re-exec `mt` inheriting stdio.
+/// The mutation body: re-exec `mt` inheriting stdio. `max_ok_exit` is the highest
+/// child exit code that still counts as success (0 for plain mutations, 2 for the
+/// doctor severity exit).
 const ChildBody = struct {
     io: std.Io,
     argv: []const []const u8,
+    max_ok_exit: u8,
     fn run(self: ChildBody) SpawnError!void {
-        return runChild(self.io, self.argv);
+        return runChildTolerant(self.io, self.argv, self.max_ok_exit);
     }
 };
 
 /// Run a delegated mutation inline: leave the alt-screen, re-exec `mt`, wait,
 /// re-enter. On any fault the terminal is restored before the error propagates.
 pub fn runInline(t: *term.Term, argv: []const []const u8) InlineError!void {
-    return around(TermCtrl{ .t = t }, ChildBody{ .io = t.io, .argv = argv });
+    return around(TermCtrl{ .t = t }, ChildBody{ .io = t.io, .argv = argv, .max_ok_exit = 0 });
 }
 
 /// Like `around`, but a *child* failure re-enters the dashboard and surfaces the
@@ -297,7 +311,15 @@ fn aroundReenter(ctrl: anytype, body: anytype) !void {
 /// Run a delegated mutation inline on the graceful path: a non-zero child exit
 /// re-enters the dashboard and is returned as a recoverable value.
 pub fn runInlineReenter(t: *term.Term, argv: []const []const u8) InlineError!void {
-    return aroundReenter(TermCtrl{ .t = t }, ChildBody{ .io = t.io, .argv = argv });
+    return aroundReenter(TermCtrl{ .t = t }, ChildBody{ .io = t.io, .argv = argv, .max_ok_exit = 0 });
+}
+
+/// Like `runInlineReenter`, but accept child exit codes up to `max_ok_exit` as
+/// success — for `mt doctor --fix`, whose exit code is its severity (≤ 2), not a
+/// pass/fail. The caller runs its own refresh regardless; only an exit above the
+/// cap, a signal, or a terminal fault surfaces as an error.
+pub fn runInlineReenterTolerant(t: *term.Term, argv: []const []const u8, max_ok_exit: u8) InlineError!void {
+    return aroundReenter(TermCtrl{ .t = t }, ChildBody{ .io = t.io, .argv = argv, .max_ok_exit = max_ok_exit });
 }
 
 // ─── tests ───────────────────────────────────────────────────────────
@@ -355,6 +377,36 @@ test "runChild surfaces a missing program as SpawnFailed" {
     var t = threaded();
     defer t.deinit();
     try testing.expectError(error.SpawnFailed, runChild(t.io(), &.{"/nonexistent/malt_tui_spawn_probe"}));
+}
+
+test "runChildTolerant accepts a zero exit" {
+    var t = threaded();
+    defer t.deinit();
+    try runChildTolerant(t.io(), &.{"/usr/bin/true"}, 2);
+}
+
+test "runChildTolerant tolerates a severity exit within the cap where runChild would fail it" {
+    var t = threaded();
+    defer t.deinit();
+    // `/usr/bin/false` exits 1 — a doctor "warnings" severity, not a fault — so a
+    // cap of 2 accepts it where the generic runner rejects any non-zero exit.
+    try runChildTolerant(t.io(), &.{"/usr/bin/false"}, 2);
+    try testing.expectError(error.ChildFailed, runChild(t.io(), &.{"/usr/bin/false"}));
+}
+
+test "runChildTolerant rejects an exit above the cap" {
+    var t = threaded();
+    defer t.deinit();
+    // A cap of 0 is the install/uninstall policy: even exit 1 is a fault.
+    // (An exit > 2 with the doctor cap needs a shell fixture the argv-only
+    // invariant forbids here; tests/tui_spawn_test.zig covers it.)
+    try testing.expectError(error.ChildFailed, runChildTolerant(t.io(), &.{"/usr/bin/false"}, 0));
+}
+
+test "runChildTolerant surfaces a missing program as SpawnFailed" {
+    var t = threaded();
+    defer t.deinit();
+    try testing.expectError(error.SpawnFailed, runChildTolerant(t.io(), &.{"/nonexistent/malt_tui_spawn_probe"}, 2));
 }
 
 test "readJson captures the child's stdout for the parser" {

--- a/tests/tui_spawn_test.zig
+++ b/tests/tui_spawn_test.zig
@@ -52,6 +52,34 @@ test "runChild surfaces a non-zero exit instead of swallowing it" {
     try testing.expectError(error.ChildFailed, spawn.runChild(t.io(), &.{"/usr/bin/false"}));
 }
 
+// `runChildTolerant` is the mutation-side mirror of the doctor read's
+// `max_ok_exit`: `mt doctor --fix` exits by severity (≤ 2) even on a clean
+// sweep, so the inline runner must accept that yet still reject a genuine fault
+// above the cap. The exit-above-cap case needs a non-zero exit from a known
+// program, which only a shell fixture gives; the `src/` argv-only invariant
+// keeps it here rather than inline.
+
+test "runChildTolerant accepts a severity exit at the cap" {
+    var t = threaded();
+    defer t.deinit();
+    try spawn.runChildTolerant(t.io(), &.{ "/bin/sh", "-c", "exit 2" }, 2);
+}
+
+test "runChildTolerant rejects an exit above the cap as ChildFailed" {
+    var t = threaded();
+    defer t.deinit();
+    // Only 0/1/2 are doctor severities; a higher code is a genuine fault.
+    try testing.expectError(error.ChildFailed, spawn.runChildTolerant(t.io(), &.{ "/bin/sh", "-c", "exit 3" }, 2));
+}
+
+test "runChildTolerant treats a signalled child as ChildFailed regardless of the cap" {
+    var t = threaded();
+    defer t.deinit();
+    // A signal is a crash, not a severity — tolerance must never mask it, or a
+    // doctor that segfaults mid-fix would read as a clean sweep.
+    try testing.expectError(error.ChildFailed, spawn.runChildTolerant(t.io(), &.{ "/bin/sh", "-c", "kill -TERM $$" }, 2));
+}
+
 test "the refresh hook refetches the active tab and marks the rest dirty on view" {
     var a: app.App = .{ .active = .services };
     app.markStaleAfterMutation(&a);


### PR DESCRIPTION
## Description

This PR fixes an issue where applying a fix from the `mt tui` Doctor tab left the screen looking like it had failed. Pressing `f` on a fixable finding did apply the fix, but the tab still showed the old problem behind a "doctor fix failed" error, so a working feature read as broken until you quit and relaunched. Now the tab refreshes in place and the resolved finding disappears, with no spurious error.

## Related Issue

- None

## Notes for Reviewers

- None