### PR TITLE
fix(doctor): keep --json a clean stdout-only stream

### DIFF
--- a/scripts/regressions/doctor_json_quiet_stderr.sh
+++ b/scripts/regressions/doctor_json_quiet_stderr.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Lock `mt doctor --json` to a clean stream split: the versioned JSON
+# document on stdout, nothing on stderr.
+#
+# `--json` is a machine-output mode. Before the fix it mirrored the full
+# human report — the "Running health checks..." line, every check row, and
+# the severity footer — onto stderr in parallel with the JSON on stdout, so
+# an interactive run rendered both views at once.
+#
+# Pinned behaviour:
+#   1. `--json` writes the versioned document to stdout and keeps stderr
+#      empty (no progress line, no rows, no footer).
+#   2. The severity-based exit code stays load-bearing: a seeded stale lock
+#      warns, so the run still exits non-zero.
+#   3. The human path is untouched: without `--json`, the rows still render
+#      on stderr.
+#
+# Hermetic: MALT_OFFLINE short-circuits the network probe so no run needs
+# the wire.
+#
+# Usage: scripts/regressions/doctor_json_quiet_stderr.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+export MALT_OFFLINE=1
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+# A PID well outside the macOS range so the lock reads as stale (dead PID):
+# guarantees one warn finding, so the severity exit code is observable.
+DEAD_PID=999999
+
+PFX=$(mktemp -d -t mt_doctor_json_quiet.XXXXXX)
+export MALT_PREFIX="$PFX"
+trap 'rm -rf "$PFX"' EXIT
+
+# Seed the expected directory structure plus a seeded stale lock.
+mkdir -p "$PFX/store" "$PFX/Cellar" "$PFX/Caskroom" "$PFX/opt" \
+  "$PFX/bin" "$PFX/lib" "$PFX/tmp" "$PFX/cache" "$PFX/db"
+printf '%s' "$DEAD_PID" >"$PFX/db/malt.lock"
+
+OUT=$(mktemp -t mt_doctor_json_out.XXXXXX)
+ERR=$(mktemp -t mt_doctor_json_err.XXXXXX)
+trap 'rm -rf "$PFX" "$OUT" "$ERR"' EXIT
+
+# ── 1. --json: JSON on stdout, stderr silent ───────────────────────────
+set +e
+"$MALT_BIN" doctor --json >"$OUT" 2>"$ERR"
+json_code=$?
+set -e
+
+if [[ -s "$ERR" ]]; then
+  printf 'stderr was:\n' >&2
+  cat "$ERR" >&2
+  fail '--json leaked the human report onto stderr (expected an empty stderr)'
+fi
+
+grep -q '"schema_version"' "$OUT" ||
+  fail '--json did not write the versioned JSON document to stdout'
+grep -q '"checks"' "$OUT" ||
+  fail '--json stdout is missing the checks array'
+
+# ── 2. severity exit code preserved (stale lock warns) ─────────────────
+[[ "$json_code" -ne 0 ]] ||
+  fail '--json exited zero despite a warning (severity exit code must hold)'
+
+# ── 3. human path still renders rows on stderr ─────────────────────────
+human_err=$("$MALT_BIN" doctor 2>&1 1>/dev/null || true)
+printf '%s' "$human_err" | grep -q 'MALT_PREFIX' ||
+  fail 'human doctor stopped rendering check rows on stderr'
+
+printf 'PASS: doctor --json keeps stderr silent while preserving the exit code\n'

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -41,8 +41,14 @@ pub const writeChecksJson = render.writeChecksJson;
 /// the human row — one source of truth for both views. Pub so tests can
 /// drive the row path directly.
 pub fn printCheck(name: []const u8, status: CheckStatus, detail: ?[]const u8) void {
+    // Under --json the sink is active: capture the structured finding for
+    // stdout and skip the human row, so the JSON document isn't mirrored
+    // onto stderr. The human path (no sink) renders as before.
+    if (g_sink) |sink| {
+        recordFinding(sink, name, status, detail);
+        return;
+    }
     render.printCheck(name, status, detail);
-    if (g_sink) |sink| recordFinding(sink, name, status, detail);
 }
 /// Per-check outcome; same tags the row renderer uses so the walker
 /// can tally without re-translating.
@@ -394,9 +400,10 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     resetVerboseHint();
     resetFixHint();
-    output.info("Running health checks...", .{});
     // Capture findings only under --json; the human path stays render-only.
     const want_checks_json = output.isJson();
+    // The progress line is human-only: --json keeps stderr silent.
+    if (!want_checks_json) output.info("Running health checks...", .{});
     var walk = collectFindings(allocator, .{
         .allocator = allocator,
         .prefix = prefix,
@@ -452,17 +459,27 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         }
     }
 
-    output.plain("", .{});
-    emitVerboseHintIfNeeded();
+    // The severity footer is the human view; --json carries each finding's
+    // severity in the document itself. Suppress the stderr prints under
+    // --json but keep the severity-based exit code — the TUI fix round-trip
+    // depends on it.
+    if (!want_checks_json) {
+        output.plain("", .{});
+        emitVerboseHintIfNeeded();
+    }
     if (tally.errors > 0) {
-        output.err("{d} error(s), {d} warning(s)", .{ tally.errors, tally.warnings });
-        emitFixHintIfNeeded(fix_requested);
+        if (!want_checks_json) {
+            output.err("{d} error(s), {d} warning(s)", .{ tally.errors, tally.warnings });
+            emitFixHintIfNeeded(fix_requested);
+        }
         std.process.exit(2);
     } else if (tally.warnings > 0) {
-        output.warn("{d} warning(s)", .{tally.warnings});
-        emitFixHintIfNeeded(fix_requested);
+        if (!want_checks_json) {
+            output.warn("{d} warning(s)", .{tally.warnings});
+            emitFixHintIfNeeded(fix_requested);
+        }
         std.process.exit(1);
-    } else {
+    } else if (!want_checks_json) {
         output.success("Your malt installation is healthy", .{});
     }
 }

--- a/tests/doctor_json_test.zig
+++ b/tests/doctor_json_test.zig
@@ -313,3 +313,66 @@ test "every finding keeps the fixable/fix_class invariant" {
     // The planted broken symlink guarantees at least one fixable arm ran.
     try testing.expect(saw_fixable);
 }
+
+test "the capturing walk renders no rows to stderr (--json stays stdout-only)" {
+    // `--json` is a machine-output mode: the JSON document goes to stdout
+    // and stderr must stay silent. The capturing walk (collect=true) is the
+    // JSON path, so it must record findings without drawing the human rows —
+    // here, with quiet OFF, so the only thing keeping stderr clean is the
+    // capture gate, not `--quiet`.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "json_quiet_stderr");
+    defer s.deinit(allocator);
+    try s.initSchema();
+
+    const prior_quiet = output.isQuiet();
+    output.setQuiet(false);
+    defer output.setQuiet(prior_quiet);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    var result = doctor.collectFindings(allocator, .{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks, true);
+    defer result.deinit();
+
+    // Findings still captured for the JSON document …
+    try testing.expect(result.findings().len >= 5);
+    // … but not one byte of the human report reached stderr.
+    try testing.expectEqualStrings("", stderr_buf.items);
+}
+
+test "the human walk still renders rows to stderr (capture gate is JSON-only)" {
+    // The fix must not silence the human path: with collect=false and quiet
+    // off, the check rows still render — proving the gate keys on capture
+    // mode, not a blanket mute.
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "human_rows");
+    defer s.deinit(allocator);
+    try s.initSchema();
+
+    const prior_quiet = output.isQuiet();
+    output.setQuiet(false);
+    defer output.setQuiet(prior_quiet);
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    var result = doctor.collectFindings(allocator, .{
+        .allocator = allocator,
+        .prefix = s.path,
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &doctor.checks, false);
+    defer result.deinit();
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "MALT_PREFIX") != null);
+}


### PR DESCRIPTION
## Description

`mt doctor --json` wrote the versioned JSON document to stdout while, in parallel, mirroring the entire human report  onto stderr. On an interactive terminal both views rendered at once, which reads like a bug ("why both?") and breaks the `--json` machine-output contract that most CLIs honour (quiet stderr, reserved for real errors).

This gates the human-facing emissions behind the non-`--json` path so`--json` is a clean, stdout-only machine stream and stays silent on stderr.

## Related Issue

- None

## Notes for Reviewers

- None