### PR TITLE
fix(doctor): drop the noisy SSL CA bundle row until ca-certificates is installed

### DIFF
--- a/scripts/regressions/doctor_ssl_ca_bundle_gating.sh
+++ b/scripts/regressions/doctor_ssl_ca_bundle_gating.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Gate the doctor "SSL CA bundle" row on its precondition: the bundle is
+# only worth verifying once ca-certificates is installed.
+#
+# Before the fix the check always drew a row and, when cert.pem was absent,
+# rendered a contradictory green check with a "HTTPS verification fails"
+# detail — noise on every prefix that simply hadn't installed
+# ca-certificates.
+#
+# Pinned behaviour (hermetic — MALT_OFFLINE short-circuits the network):
+#   1. ca-certificates not installed → no SSL row at all (human + json).
+#   2. installed but cert.pem unlinked → a warn row naming the fault, and a
+#      json finding with severity "warn".
+#   3. installed and cert.pem linked → a clean ok row, json severity "ok".
+#
+# Usage: scripts/regressions/doctor_ssl_ca_bundle_gating.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+export MALT_OFFLINE=1 NO_COLOR=1 MALT_NO_EMOJI=1
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+# Seed a scratch prefix with the expected layout. `$2` truthy links
+# opt/ca-certificates (the "installed" signal); `$3` truthy lands the
+# openssl@3 cert.pem.
+seed() {
+  local pfx="$1" with_ca="$2" with_cert="$3"
+  mkdir -p "$pfx/store" "$pfx/Cellar" "$pfx/Caskroom" "$pfx/opt" \
+    "$pfx/bin" "$pfx/lib" "$pfx/tmp" "$pfx/cache" "$pfx/db"
+  if [[ -n "$with_ca" ]]; then
+    mkdir -p "$pfx/opt/ca-certificates"
+  fi
+  if [[ -n "$with_cert" ]]; then
+    mkdir -p "$pfx/etc/openssl@3"
+    : >"$pfx/etc/openssl@3/cert.pem"
+  fi
+}
+
+# Run both views of doctor against $1; populate the globals HUMAN / JSON.
+run_doctor() {
+  export MALT_PREFIX="$1"
+  HUMAN=$("$MALT_BIN" doctor 2>&1 1>/dev/null || true)
+  JSON=$("$MALT_BIN" doctor --json 2>/dev/null || true)
+}
+
+# ── 1. not installed → fully silent on the SSL dimension ────────────────
+PFX=$(mktemp -d -t mt_doctor_ssl_none.XXXXXX)
+trap 'rm -rf "$PFX"' EXIT
+seed "$PFX" "" ""
+run_doctor "$PFX"
+if printf '%s' "$HUMAN" | grep -q 'SSL CA bundle'; then
+  fail 'uninstalled ca-certificates still drew an SSL row on stderr'
+fi
+if printf '%s' "$JSON" | grep -q '"id":"ssl_ca_bundle"'; then
+  fail 'uninstalled ca-certificates still emitted an ssl_ca_bundle json finding'
+fi
+rm -rf "$PFX"
+
+# ── 2. installed but unlinked → a warn naming the fault ─────────────────
+PFX=$(mktemp -d -t mt_doctor_ssl_unlinked.XXXXXX)
+trap 'rm -rf "$PFX"' EXIT
+seed "$PFX" 1 ""
+run_doctor "$PFX"
+printf '%s' "$HUMAN" | grep -q "SSL CA bundle .* isn't linked" ||
+  fail 'installed-but-unlinked bundle did not warn about the unlinked cert'
+printf '%s' "$JSON" | grep -q '"id":"ssl_ca_bundle","severity":"warn"' ||
+  fail 'installed-but-unlinked bundle did not serialize a warn json finding'
+rm -rf "$PFX"
+
+# ── 3. installed and linked → a clean ok row ───────────────────────────
+PFX=$(mktemp -d -t mt_doctor_ssl_linked.XXXXXX)
+trap 'rm -rf "$PFX"' EXIT
+seed "$PFX" 1 1
+run_doctor "$PFX"
+printf '%s' "$HUMAN" | grep -q 'SSL CA bundle' ||
+  fail 'a healthy bundle dropped its confirming SSL row'
+if printf '%s' "$HUMAN" | grep -q "isn't linked"; then
+  fail 'a healthy bundle still rendered the unlinked-cert warning'
+fi
+printf '%s' "$JSON" | grep -q '"id":"ssl_ca_bundle","severity":"ok"' ||
+  fail 'a healthy bundle did not serialize an ok json finding'
+rm -rf "$PFX"
+
+trap - EXIT
+printf 'PASS: doctor SSL CA bundle row is gated on ca-certificates being installed\n'

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -1139,14 +1139,9 @@ fn checkDiskSpace(ctx: CheckCtx, name: []const u8) CheckResult {
     return .warn_status;
 }
 
-/// Surface the dep-keg bin/sbin link census. Linked deps are the
-/// default state, not a defect — the check stays at `.ok` severity so
-/// `mt doctor` exits clean. Detail + enumeration only emit under
-/// `--verbose` so default runs stay silent on this dimension and
-/// downstream "grep for warnings" gates don't false-positive.
 /// Detail line for the "SSL CA bundle" row. `null` when the bundle is
-/// present (clean row); a short flag when it's missing. `pub` so the
-/// render test can pin the text without a filesystem fixture.
+/// present (clean row); the unlinked-bundle hint when it's missing. `pub`
+/// so the render test can pin the text without a filesystem fixture.
 pub fn formatSslCertDetail(present: bool) ?[]const u8 {
     return if (present)
         null
@@ -1192,6 +1187,11 @@ fn checkSslCaBundle(ctx: CheckCtx, name: []const u8) CheckResult {
     return status;
 }
 
+/// Surface the dep-keg bin/sbin link census. Linked deps are the
+/// default state, not a defect — the check stays at `.ok` severity so
+/// `mt doctor` exits clean. Detail + enumeration only emit under
+/// `--verbose` so default runs stay silent on this dimension and
+/// downstream "grep for warnings" gates don't false-positive.
 fn checkIsolationLeaks(ctx: CheckCtx, name: []const u8) CheckResult {
     var db_path_buf: [512]u8 = undefined;
     const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{ctx.prefix}, 0) catch {

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -1151,14 +1151,22 @@ pub fn formatSslCertDetail(present: bool) ?[]const u8 {
     return if (present)
         null
     else
-        "cert.pem missing — HTTPS verification fails until ca-certificates is installed";
+        "ca-certificates installed but cert.pem isn't linked";
 }
 
-/// Informational check: `<prefix>/etc/openssl@3/cert.pem` is what
-/// OpenSSL reaches for at runtime. A missing bundle breaks every HTTPS
-/// client behind OpenSSL, but it's a remediation hint, never a failure —
-/// the row stays `.ok` so doctor exits clean.
+/// Check gated on its precondition: `<prefix>/etc/openssl@3/cert.pem` is
+/// what OpenSSL reaches for at runtime, but it only exists once
+/// `ca-certificates` is installed. A prefix that never installed it has no
+/// bundle to verify — the absence is expected, not a defect — so the check
+/// stays silent. When `ca-certificates` *is* installed but its bundle
+/// isn't linked, that's a real misconfiguration: warn.
 fn checkSslCaBundle(ctx: CheckCtx, name: []const u8) CheckResult {
+    // Precondition: the `ca-certificates` opt link. Absent ⇒ nothing to
+    // verify, so emit no row at all (default runs stay quiet on this).
+    var opt_buf: [512]u8 = undefined;
+    const opt = std.fmt.bufPrint(&opt_buf, "{s}/opt/ca-certificates", .{ctx.prefix}) catch return .ok;
+    std.Io.Dir.cwd().access(ctx.io, opt, .{}) catch return .ok;
+
     var buf: [512]u8 = undefined;
     const cert = std.fmt.bufPrint(&buf, "{s}/etc/openssl@3/cert.pem", .{ctx.prefix}) catch {
         printCheck(name, .ok, null);
@@ -1168,19 +1176,20 @@ fn checkSslCaBundle(ctx: CheckCtx, name: []const u8) CheckResult {
         std.Io.Dir.cwd().access(ctx.io, cert, .{}) catch break :blk false;
         break :blk true;
     };
-    printCheck(name, .ok, formatSslCertDetail(present));
+    const status: CheckStatus = if (present) .ok else .warn_status;
+    printCheck(name, status, formatSslCertDetail(present));
     if (!present) {
-        // Verbose-only remediation: install the formula, or relink the
-        // bundle by hand if the keg is already on disk.
+        // Verbose-only remediation: the keg is on disk, so relink the
+        // bundle by hand.
         var manual_buf: [768]u8 = undefined;
         const manual = std.fmt.bufPrint(
             &manual_buf,
             "ln -sf {s}/opt/ca-certificates/share/ca-certificates/cacert.pem {s}/etc/openssl@3/cert.pem",
             .{ ctx.prefix, ctx.prefix },
         ) catch "ln -sf <prefix>/opt/ca-certificates/share/ca-certificates/cacert.pem <prefix>/etc/openssl@3/cert.pem";
-        writeVerboseList(&.{ "mt install ca-certificates", manual });
+        writeVerboseList(&.{manual});
     }
-    return .ok;
+    return status;
 }
 
 fn checkIsolationLeaks(ctx: CheckCtx, name: []const u8) CheckResult {
@@ -1430,11 +1439,13 @@ test "findingId: collapses non-alphanumeric runs and trims the edges" {
     try testing.expectEqualStrings("a_b_c", got);
 }
 
-test "formatSslCertDetail: null when present, remediation hint when absent" {
+test "formatSslCertDetail: null when present, unlinked-bundle hint when absent" {
     try testing.expect(formatSslCertDetail(true) == null);
     const missing = formatSslCertDetail(false) orelse return error.TestUnexpectedResult;
-    // The hint must name the fix so a user can act on it directly.
+    // The hint names the precondition (ca-certificates is installed) and
+    // the actual fault (the bundle isn't linked) so a user can act on it.
     try testing.expect(std.mem.indexOf(u8, missing, "ca-certificates") != null);
+    try testing.expect(std.mem.indexOf(u8, missing, "isn't linked") != null);
 }
 
 test "emitFixHintIfNeeded: silent without arming" {

--- a/tests/doctor_json_test.zig
+++ b/tests/doctor_json_test.zig
@@ -376,3 +376,67 @@ test "the human walk still renders rows to stderr (capture gate is JSON-only)" {
 
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "MALT_PREFIX") != null);
 }
+
+// ── SSL CA bundle: gated on ca-certificates being installed ───────────
+// The human/severity behaviour is pinned in doctor_ssl_test.zig; these
+// lock the `--json` `checks[]` contract for each state.
+
+fn linkCaCerts(allocator: std.mem.Allocator, prefix: []const u8) !void {
+    const opt = try std.fmt.allocPrint(allocator, "{s}/opt/ca-certificates", .{prefix});
+    defer allocator.free(opt);
+    try test_io.cwd().createDirPath(std.Options.debug_io, opt);
+}
+
+test "ca-certificates not installed: no ssl_ca_bundle finding in checks[]" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "ssl_absent");
+    defer s.deinit(allocator);
+    try s.initSchema();
+
+    var result = walk(allocator, s.path);
+    defer result.deinit();
+
+    // The precondition is absent, so the check emits nothing — consumers
+    // see no entry rather than a misleading ok/warn.
+    try testing.expect(findById(result.findings(), "ssl_ca_bundle") == null);
+}
+
+test "ca-certificates installed but unlinked: a warn ssl_ca_bundle finding" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "ssl_unlinked");
+    defer s.deinit(allocator);
+    try s.initSchema();
+    try linkCaCerts(allocator, s.path);
+
+    var result = walk(allocator, s.path);
+    defer result.deinit();
+
+    const f = findById(result.findings(), "ssl_ca_bundle") orelse
+        return error.MissingSslFinding;
+    try testing.expectEqual(doctor.CheckStatus.warn_status, f.severity);
+    // Informational warn — doctor surfaces it but --fix can't act on it.
+    try testing.expect(!f.fixable);
+    try testing.expect(f.fix_class == null);
+}
+
+test "ca-certificates installed and linked: an ok ssl_ca_bundle finding" {
+    const allocator = testing.allocator;
+    var s = try Scratch.init(allocator, "ssl_linked");
+    defer s.deinit(allocator);
+    try s.initSchema();
+    try linkCaCerts(allocator, s.path);
+
+    const dir = try std.fmt.allocPrint(allocator, "{s}/etc/openssl@3", .{s.path});
+    defer allocator.free(dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, dir);
+    const cert = try std.fmt.allocPrint(allocator, "{s}/cert.pem", .{dir});
+    defer allocator.free(cert);
+    (try test_io.createFileAbsolute(std.Options.debug_io, cert, .{})).close(std.Options.debug_io);
+
+    var result = walk(allocator, s.path);
+    defer result.deinit();
+
+    const f = findById(result.findings(), "ssl_ca_bundle") orelse
+        return error.MissingSslFinding;
+    try testing.expectEqual(doctor.CheckStatus.ok, f.severity);
+}

--- a/tests/doctor_ssl_test.zig
+++ b/tests/doctor_ssl_test.zig
@@ -1,9 +1,11 @@
 //! `mt doctor` SSL CA bundle check tests.
 //!
-//! The check is informational: it flags a missing
-//! `<prefix>/etc/openssl@3/cert.pem` with a remediation hint but never
-//! bumps doctor's exit code — a fresh prefix without ca-certificates is
-//! a normal state, not a defect.
+//! The check is gated on its precondition: it verifies the OpenSSL trust
+//! bundle (`<prefix>/etc/openssl@3/cert.pem`) only when `ca-certificates`
+//! is installed (`<prefix>/opt/ca-certificates`). A prefix that never
+//! installed `ca-certificates` is a normal state, not a defect — the check
+//! stays silent. An installed-but-unlinked bundle is a real
+//! misconfiguration and warns.
 
 const std = @import("std");
 const testing = std.testing;
@@ -21,9 +23,16 @@ fn uniquePrefix(suffix: []const u8) ![]u8 {
     );
 }
 
-fn makePrefix(suffix: []const u8, with_cert: bool) ![]u8 {
+/// Seed a scratch prefix. `with_ca` links `opt/ca-certificates` (the
+/// "installed" signal); `with_cert` lands `etc/openssl@3/cert.pem`.
+fn makePrefix(suffix: []const u8, with_ca: bool, with_cert: bool) ![]u8 {
     const prefix = try uniquePrefix(suffix);
     try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+    if (with_ca) {
+        const opt = try std.fmt.allocPrint(testing.allocator, "{s}/opt/ca-certificates", .{prefix});
+        defer testing.allocator.free(opt);
+        try test_io.cwd().createDirPath(std.Options.debug_io, opt);
+    }
     if (with_cert) {
         const dir = try std.fmt.allocPrint(testing.allocator, "{s}/etc/openssl@3", .{prefix});
         defer testing.allocator.free(dir);
@@ -53,8 +62,17 @@ fn sslCheckResult(ctx: doctor.CheckCtx) doctor.CheckResult {
     @panic("SSL CA bundle check not registered");
 }
 
-// The pure `formatSslCertDetail` formatter is unit-tested inline in
-// `doctor.zig`; this file covers the fs-backed check behaviour.
+/// Run the SSL check with stderr captured so a test can assert on the row
+/// text (or its absence). Returns the check result; `buf` holds the
+/// rendered row bytes.
+fn sslRun(ctx: doctor.CheckCtx, buf: *std.ArrayList(u8)) doctor.CheckResult {
+    const prior = output.isQuiet();
+    output.setQuiet(false);
+    defer output.setQuiet(prior);
+    output.beginStderrCapture(testing.allocator, buf);
+    defer output.endStderrCapture();
+    return sslCheckResult(ctx);
+}
 
 test "checks table includes the SSL CA bundle check" {
     var found = false;
@@ -67,31 +85,47 @@ test "checks table includes the SSL CA bundle check" {
     try testing.expect(found);
 }
 
-test "SSL CA bundle check returns ok when cert.pem is present" {
-    const prefix = try makePrefix("present", true);
+test "ca-certificates not installed: the check stays silent (no row, no warn)" {
+    // The precondition is absent, so a missing cert.pem is expected, not a
+    // defect — the check must emit nothing on either stream.
+    const prefix = try makePrefix("no_ca", false, false);
     defer testing.allocator.free(prefix);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
-    try testing.expectEqual(doctor.CheckResult.ok, sslCheckResult(ctxFor(prefix)));
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const result = sslRun(ctxFor(prefix), &buf);
+
+    try testing.expectEqual(doctor.CheckResult.ok, result);
+    try testing.expectEqualStrings("", buf.items);
 }
 
-test "SSL CA bundle check stays ok (informational) when cert.pem is absent" {
-    // Quiet the verbose-remediation stderr so the assert reads clean.
-    output.setQuiet(true);
-    defer output.setQuiet(false);
-    const prefix = try makePrefix("absent", false);
+test "ca-certificates installed + cert.pem present: a clean ok row" {
+    const prefix = try makePrefix("linked", true, true);
     defer testing.allocator.free(prefix);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
-    try testing.expectEqual(doctor.CheckResult.ok, sslCheckResult(ctxFor(prefix)));
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const result = sslRun(ctxFor(prefix), &buf);
+
+    try testing.expectEqual(doctor.CheckResult.ok, result);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "SSL CA bundle") != null);
+    // The clean row carries no remediation detail.
+    try testing.expect(std.mem.indexOf(u8, buf.items, "isn't linked") == null);
 }
 
-test "SSL CA bundle check is ok under --verbose when cert.pem is absent" {
-    const prior = output.isVerbose();
-    output.setVerbose(true);
-    defer output.setVerbose(prior);
-    output.setQuiet(true);
-    defer output.setQuiet(false);
-    const prefix = try makePrefix("verbose_absent", false);
+test "ca-certificates installed + cert.pem missing: warns about the unlinked bundle" {
+    // The keg is on disk but its bundle isn't linked — a genuine
+    // misconfiguration that must surface (warn), not a silent ok.
+    const prefix = try makePrefix("unlinked", true, false);
     defer testing.allocator.free(prefix);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
-    try testing.expectEqual(doctor.CheckResult.ok, sslCheckResult(ctxFor(prefix)));
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    const result = sslRun(ctxFor(prefix), &buf);
+
+    try testing.expectEqual(doctor.CheckResult.warn_status, result);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "isn't linked") != null);
 }


### PR DESCRIPTION
## Description

`mt doctor` always printed an "SSL CA bundle" row, and when `etc/openssl@3/cert.pem` was absent it rendered a contradictory green check carrying a "HTTPS verification fails until ca-certificates is installed" detail. On any prefix that simply hadn't installed `ca-certificates`, that line was pure noise on every run.

This gates the check on its precondition instead of the symptom: the OpenSSL trust bundle is only worth verifying once `ca-certificates` is installed.

- **Not installed** (`opt/ca-certificates` absent) -> emit nothing. A missing bundle is the expected consequence of not installing the package, not a malt defect, so the row disappears from both the human view and `checks[]`.
- **Installed, bundle linked** -> a clean `✓ SSL CA bundle` row.
- **Installed, bundle unlinked** -> a real `⚠` warning ("ca-certificates installed but cert.pem isn't linked"), replacing the previous misleading green check. This is a genuine misconfiguration worth surfacing.

## Related Issue

- None

## Notes for Reviewers

- None
