### PR TITLE
feat(tui): clearer list tabs and a calmer Doctor

### DIFF
--- a/scripts/regressions/tui_tab_chrome_separator_and_headings.sh
+++ b/scripts/regressions/tui_tab_chrome_separator_and_headings.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Lock the `mt tui` list-tab chrome: a header/content separator and column
+# headings.
+#
+# Pinned behaviour:
+#   1. The Installed, Outdated, and Services tabs render a bold column-heading
+#      row aligned over their value columns (NAME/VERSION/SIZE, etc.), so the
+#      list reads as a table rather than loose text.
+#   2. The shell paints a dim full-width rule between the filter row and the
+#      content region on a list tab; the Doctor tab is left to its own band
+#      rule so it never shows a doubled separator.
+#
+# The TUI render core is pure (`render`/`renderFrame` are functions of state +
+# size), so this drives those cores directly through a standalone `zig test`
+# rather than a PTY. The check imports the real source modules, so a regression
+# in the render code fails it.
+#
+# Usage: scripts/regressions/tui_tab_chrome_separator_and_headings.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v zig >/dev/null 2>&1 || fail 'zig not found on PATH'
+
+WORK=$(mktemp -d -t mt_tui_chrome.XXXXXX)
+# The check file must sit at the repo root so its imports stay inside the
+# module path (the tui render modules reach into src/ui/). Both temp artifacts
+# are removed on exit.
+CHECK="$ROOT/.tui_chrome_check.zig"
+trap 'rm -rf "$WORK" "$CHECK"' EXIT
+
+cat >"$CHECK" <<ZIG
+const std = @import("std");
+const color = @import("src/ui/color.zig");
+const tab = @import("src/tui/tab.zig");
+const installed = @import("src/tui/installed_tab.zig");
+const outdated = @import("src/tui/outdated_tab.zig");
+const services = @import("src/tui/services_tab.zig");
+const search = @import("src/tui/search_tab.zig");
+const app = @import("src/tui/app.zig");
+
+const bold = "\x1b[1m";
+
+fn renderHas(comptime want: []const u8, out: []const u8) !void {
+    try std.testing.expect(std.mem.indexOf(u8, out, want) != null);
+}
+
+// True when a dim separator sits at the cursor-move row_cup: the move, the muted
+// SGR, then a box-drawing rule. Matches the exact chrome signature so a muted
+// hint line (Doctor's "No findings.") at the same row never reads as a rule.
+fn separatorAtRow(out: []const u8, comptime row_cup: []const u8) bool {
+    const at = std.mem.indexOf(u8, out, row_cup) orelse return false;
+    const after = out[at + row_cup.len ..];
+    const muted = color.roleCode(.muted);
+    if (!std.mem.startsWith(u8, after, muted)) return false;
+    return std.mem.startsWith(u8, after[muted.len..], "\xe2\x94\x80");
+}
+
+test "installed tab heads its columns, bold and aligned" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const items = [_]installed.Pkg{
+        .{ .name = "brotli", .version = "1.2.0", .kind = .formula, .pinned = false, .size_bytes = 1902690, .linked = true },
+    };
+    const s: installed.State = .{ .items = &items };
+    installed.render(&s, &f, .{ .row = 3, .col = 1, .width = 80, .height = 10 });
+    const out = f.slice();
+    try renderHas(bold, out);
+    // Exact padded heading proves the labels sit over the value columns.
+    try renderHas("NAME" ++ " " ** 19 ++ "VERSION" ++ " " ** 8 ++ "SIZE", out);
+    try renderHas("brotli", out); // the list still renders below the heading
+}
+
+test "outdated tab heads its columns past the checkbox" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    var checked = [_]bool{false};
+    const items = [_]outdated.Row{
+        .{ .name = "wget", .installed = "1.24.5", .latest = "1.25.0", .kind = .formula, .pinned = false, .tap = "" },
+    };
+    const s: outdated.State = .{ .items = &items, .checked = &checked };
+    outdated.render(&s, &f, .{ .row = 3, .col = 1, .width = 80, .height = 10 });
+    const out = f.slice();
+    try renderHas(bold, out);
+    try renderHas("    NAME" ++ " " ** 19 ++ "CURRENT" ++ " " ** 6 ++ "AVAILABLE" ++ " " ** 4 ++ "KIND", out);
+    try renderHas("wget", out);
+}
+
+test "services tab heads its columns past the status dot" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const items = [_]services.Row{
+        .{ .name = "redis", .state = "running", .auto_start = true, .keg_name = "redis" },
+    };
+    const s: services.State = .{ .items = &items };
+    services.render(&s, &f, .{ .row = 3, .col = 1, .width = 80, .height = 10 });
+    const out = f.slice();
+    try renderHas(bold, out);
+    try renderHas("  NAME" ++ " " ** 21 ++ "STATE" ++ " " ** 8 ++ "START" ++ " " ** 3 ++ "KEG", out);
+    try renderHas("redis", out);
+}
+
+test "search tab heads its result columns past the checkbox" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const items = [_]search.Match{.{ .name = "wget", .kind = .formula, .installed = false }};
+    const s: search.State = .{ .items = &items, .phase = .loaded };
+    search.render(&s, &f, .{ .row = 3, .col = 1, .width = 80, .height = 10 });
+    const out = f.slice();
+    try renderHas(bold, out);
+    try renderHas("    NAME" ++ " " ** 25 ++ "KIND", out);
+    try renderHas("wget", out);
+}
+
+test "a list tab gets a separator rule below the filter; Doctor does not double it" {
+    var buf: [8192]u8 = undefined;
+    // Search is the default list-style tab; content starts at row 4 (80x24).
+    var a: app.App = .{};
+    try std.testing.expect(separatorAtRow(app.renderFrame(&buf, &a, 80, 24), "\x1b[4;1H"));
+
+    // Doctor is left to its own band rule — the shell must not add one at the
+    // content top, or the tab would show a doubled rule. With no findings the
+    // row carries only the muted hint, no rule.
+    var buf2: [8192]u8 = undefined;
+    var d: app.App = .{ .active = .doctor };
+    try std.testing.expect(!separatorAtRow(app.renderFrame(&buf2, &d, 80, 24), "\x1b[4;1H"));
+}
+ZIG
+
+if ! zig test "$CHECK" 2>"$WORK/err.txt"; then
+  sed 's/^/  /' "$WORK/err.txt" >&2
+  fail 'tui chrome render check failed — missing column headings and/or filter separator'
+fi
+
+printf 'PASS: tui list tabs render column headings and a filter separator\n'

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -339,12 +339,20 @@ pub fn renderFrame(buf: []u8, app: *const App, cols: u16, rows: u16) []const u8 
             var fb: [filter_input.max_len + 8]u8 = undefined;
             f.put(filter_input.render(&fb, activeFilterLabel(app), activeFilterText(app), app.editing, cols));
 
-            renderActive(app, &f, r.content);
+            // A dim rule below the filter sets the chrome off from the content on
+            // the list tabs. Doctor paints its own rule at the band top, so it is
+            // left out here and never shows a doubled rule; the rule costs the tab
+            // one content row.
+            var body = r.content;
+            if (app.active != .doctor) {
+                tab.renderSeparator(&f, r.content, r.content.row, true);
+                body = .{ .row = r.content.row + 1, .col = r.content.col, .width = r.content.width, .height = r.content.height -| 1 };
+            }
+            renderActive(app, &f, body);
 
             // Footer: a rule line separating content, then — by priority — the
             // pre-read loading status, the transient error banner, or the help line.
-            f.moveTo(r.footer.row, 1);
-            putRule(&f, cols);
+            tab.renderSeparator(&f, r.footer, r.footer.row, false);
             f.moveTo(r.footer.row + 1, 1);
             if (app.loading) {
                 var lb: [64]u8 = undefined;
@@ -367,11 +375,6 @@ pub fn renderFrame(buf: []u8, app: *const App, cols: u16, rows: u16) []const u8 
         },
     }
     return f.slice();
-}
-
-fn putRule(f: *tab.Frame, cols: u16) void {
-    var i: u16 = 0;
-    while (i < cols) : (i += 1) f.put("─");
 }
 
 /// The "terminal too small" fallback: the notice icon + message in the info
@@ -1591,6 +1594,32 @@ test "a newline in a child-derived op cannot inject an extra footer frame line" 
     const out = renderFrame(&buf, &a, 80, 24);
     try std.testing.expect(std.mem.indexOfScalar(u8, out, '\n') == null);
     try std.testing.expect(std.mem.indexOf(u8, out, "evil failed: BadJson") != null); // \n stripped, text joined
+}
+
+/// True when `out` paints a dim separator at `row`: the cursor move to that row,
+/// the muted SGR, then a box-drawing rule. Matches the exact chrome signature so
+/// Doctor's muted "No findings." hint at the same row doesn't read as a rule.
+fn hasSeparatorAtRow(out: []const u8, comptime row: u16) bool {
+    const cup = std.fmt.comptimePrint("\x1b[{d};1H", .{row});
+    const at = std.mem.indexOf(u8, out, cup) orelse return false;
+    const after = out[at + cup.len ..];
+    const muted = color.roleCode(.muted);
+    if (!std.mem.startsWith(u8, after, muted)) return false;
+    return std.mem.startsWith(u8, after[muted.len..], "─");
+}
+
+test "a dim rule separates the filter from the content; Doctor keeps its own" {
+    var buf: [8192]u8 = undefined;
+    var a: App = .{}; // Search — a list-style tab
+    const out = renderFrame(&buf, &a, 80, 24);
+    // Content starts at row 4 (header 1, tab-bar 2, filter 3); the rule sits there.
+    try std.testing.expect(hasSeparatorAtRow(out, 4));
+
+    // Doctor paints its own band rule at the content top, so the shell must not
+    // add one there — or the tab would show a doubled rule.
+    var d: App = .{ .active = .doctor };
+    const dout = renderFrame(&buf, &d, 80, 24);
+    try std.testing.expect(!hasSeparatorAtRow(dout, 4));
 }
 
 test "classify splits recoverable backend faults from fatal terminal/OOM faults" {

--- a/src/tui/detail_pane.zig
+++ b/src/tui/detail_pane.zig
@@ -43,11 +43,7 @@ pub fn neededRows(fields: []const Field, width: u16) u16 {
 /// can't break the frame. Pure function of `(fields, rect)` → reflows on resize.
 pub fn render(f: *tab.Frame, fields: []const Field, rect: tab.Rect) void {
     if (rect.width == 0 or rect.height == 0) return;
-    f.moveTo(rect.row, rect.col);
-    f.put(color.roleCode(.muted));
-    var i: u16 = 0;
-    while (i < rect.width) : (i += 1) f.put("─");
-    f.put(color.Style.reset.code());
+    tab.renderSeparator(f, rect, rect.row, true);
     renderFields(f, fields, .{ .row = rect.row + separator_rows, .col = rect.col, .width = rect.width, .height = rect.height -| separator_rows });
 }
 

--- a/src/tui/doctor_tab.zig
+++ b/src/tui/doctor_tab.zig
@@ -564,6 +564,19 @@ pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
 
     const reclaim = reclaimFrom(s.stats);
 
+    // An all-clear run (no filter, findings present, none needing attention) has
+    // no verdict to weigh: collapse the band to the calm summary line, plus the
+    // reclaimable section when there is disk to reclaim. No histogram, fixable
+    // line, or detail pane — nothing needs the user's attention.
+    if (filter.len == 0 and counts.total() > 0 and counts.attention() == 0) {
+        renderAllClear(f, r, counts);
+        if (reclaim) |rc| {
+            const max = r.height -| 1; // the summary line takes the top row
+            if (max > 0) _ = paintReclaim(f, r, r.row + 1, rc, max);
+        }
+        return;
+    }
+
     var content: tab.Rect = r;
     // The band rides above the list: reserve its rows from the top before the
     // detail pane claims from the bottom, so the list gets height − band − detail.
@@ -621,9 +634,8 @@ fn renderList(s: *const State, f: *tab.Frame, counts: Counts, rect: tab.Rect) vo
     const filter = s.chrome.filter.slice();
     // No-data stays neutral: we can't claim "all clear" for checks we never received.
     if (counts.total() == 0) return tab.renderHint(f, rect, if (filter.len != 0) "No matches." else "No findings.");
-    // Only without a filter: "N checks passed" must mean the whole run, and a
-    // filter that matches only ok rows should still list them.
-    if (filter.len == 0 and counts.attention() == 0) return renderAllClear(f, rect, counts);
+    // The unfiltered all-clear summary is handled in `render`; here a filter that
+    // matches only ok rows still lists them, so we always fall through to the list.
     const v = scroll_list.clamp(s.chrome.view, counts.total(), rect.height);
 
     var di: usize = 0;
@@ -873,6 +885,22 @@ test "render shows an all-clear summary when every check passed, not a per-check
     try testing.expect(std.mem.indexOf(u8, out, "All clear") != null);
     try testing.expect(std.mem.indexOf(u8, out, "1 checks passed") != null); // names the passed count
     try testing.expect(std.mem.indexOf(u8, out, color.roleCode(.success)) != null); // success role
+    try testing.expect(std.mem.indexOf(u8, out, "all checks passed") == null); // the band verdict is collapsed away
+    try testing.expect(std.mem.indexOf(u8, out, "auto-fixable") == null); // and so is the fixable line
+}
+
+test "the all-clear collapse keeps the reclaimable section but drops the band verdict" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    // Every check passes, but there is cask disk to reclaim: the reclaimable
+    // section stays, the verdict/histogram/fixable band does not.
+    const s: State = .{ .items = &all_ok, .stats = .{ .cask_bytes = 2048, .retained_versions = 1 } };
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 20 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, "All clear") != null); // the calm summary
+    try testing.expect(std.mem.indexOf(u8, out, "Reclaimable:") != null); // reclaimable kept
+    try testing.expect(std.mem.indexOf(u8, out, "all checks passed") == null); // verdict dropped
+    try testing.expect(std.mem.indexOf(u8, out, "auto-fixable") == null); // fixable line dropped
 }
 
 test "an active filter matching only ok findings lists them, never the all-clear summary" {
@@ -925,10 +953,11 @@ test "render clamps to a height of one without crashing" {
 // ─── health band ─────────────────────────────────────────────────────
 
 test "the band's status banner reads the worst severity present" {
+    // all_ok has no band — its all-clear case is covered separately — so only the
+    // attention verdicts are exercised here.
     const cases = [_]struct { items: []const Row, verdict: []const u8 }{
         .{ .items = &sample, .verdict = "issues found" }, // an err is present (may include warnings)
         .{ .items = &warn_only, .verdict = "warnings found" }, // warn is the worst, no errors
-        .{ .items = &all_ok, .verdict = "all checks passed" }, // nothing wrong
     };
     for (cases) |c| {
         var buf: [4096]u8 = undefined;
@@ -976,7 +1005,7 @@ test "the histogram is one bar scaled to the total, so ok dominates warn (not ne
     try testing.expectEqual(barWidth(80), warn_cells + ok_cells); // err is 0 here
 }
 
-test "an all-ok store renders a full all-success composition bar" {
+test "an all-ok store collapses the band, so no composition bar is drawn" {
     var buf: [8192]u8 = undefined;
     var f: tab.Frame = .{ .buf = &buf };
     const only_ok = [_]Row{
@@ -988,7 +1017,7 @@ test "an all-ok store renders a full all-success composition bar" {
     render(&st, &f, .{ .row = 1, .col = 1, .width = 80, .height = 20 });
     const out = f.slice();
     const ok_cells = segCells(out, color.roleCode(.success), color.Style.reset.code());
-    try testing.expectEqual(barWidth(80), ok_cells); // the whole bar is the ok segment
+    try testing.expectEqual(@as(u16, 0), ok_cells); // all-clear collapses away the histogram
 }
 
 test "the histogram surfaces the total checks count alongside the bar" {

--- a/src/tui/doctor_tab.zig
+++ b/src/tui/doctor_tab.zig
@@ -497,16 +497,6 @@ fn paintBandLine(f: *tab.Frame, rect: tab.Rect, row: u16, line: []const u8) void
     f.put(scroll_list.truncate(line, rect.width));
 }
 
-/// A dim full-width rule, like the detail pane's, setting the band off from the
-/// list above and below it.
-fn paintRule(f: *tab.Frame, rect: tab.Rect, row: u16) void {
-    f.moveTo(row, rect.col);
-    f.put(color.roleCode(.muted));
-    var i: u16 = 0;
-    while (i < rect.width) : (i += 1) f.put("─");
-    f.put(color.Style.reset.code());
-}
-
 /// Paint the health band into `rect` and return the rows used. The band is
 /// enclosed by a dim rule top and bottom; inside, the segments shed lowest-signal
 /// first (histogram, then the fixable line) so a short pane keeps the verdict. The
@@ -517,7 +507,7 @@ fn renderBand(f: *tab.Frame, counts: Counts, reclaim: ?Reclaim, rect: tab.Rect) 
     var buf: [512]u8 = undefined; // wide enough for a full-row composition bar
     var used: u16 = 0;
 
-    paintRule(f, rect, rect.row + used);
+    tab.renderSeparator(f, rect, rect.row + used, true);
     used += 1;
 
     var banner: tab.Frame = .{ .buf = &buf };
@@ -556,7 +546,7 @@ fn renderBand(f: *tab.Frame, counts: Counts, reclaim: ?Reclaim, rect: tab.Rect) 
         if (capacity > 0) used += paintReclaim(f, rect, rect.row + used, rc, capacity);
     }
 
-    paintRule(f, rect, rect.row + used);
+    tab.renderSeparator(f, rect, rect.row + used, true);
     used += 1;
 
     return used;

--- a/src/tui/installed_tab.zig
+++ b/src/tui/installed_tab.zig
@@ -143,7 +143,15 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     const filter = s.chrome.filter.slice();
     const nf = filteredCount(s.items, filter);
     if (nf == 0) return tab.renderHint(f, rect, if (filter.len != 0) "No matches." else "No packages installed yet.");
-    const v = scroll_list.clamp(s.chrome.view, nf, rect.height);
+    // A fixed bold heading rides above the list and costs it one row.
+    tab.renderHeading(f, rect, 0, &.{
+        .{ .label = "NAME", .width = 22 },
+        .{ .label = "VERSION", .width = 14 },
+        .{ .label = "SIZE", .width = 10 },
+    });
+    const list: tab.Rect = .{ .row = rect.row + 1, .col = rect.col, .width = rect.width, .height = rect.height -| 1 };
+    if (list.height == 0) return; // the heading took the only row
+    const v = scroll_list.clamp(s.chrome.view, nf, list.height);
 
     var fi: usize = 0;
     for (s.items) |p| {
@@ -151,15 +159,15 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
         defer fi += 1;
         if (fi < v.offset) continue;
         const screen = fi - v.offset;
-        if (screen >= rect.height) break;
-        f.moveTo(rect.row + @as(u16, @intCast(screen)), rect.col);
+        if (screen >= list.height) break;
+        f.moveTo(list.row + @as(u16, @intCast(screen)), list.col);
         const selected = fi == v.selected;
         if (selected) { // mark the cursor row; the accent backgrounds it under a theme
             f.put(color.selectionAccent());
             f.put(color.Style.reverse.code());
         }
         var rb: [256]u8 = undefined;
-        f.putContent(scroll_list.truncate(formatRow(&rb, p), rect.width));
+        f.putContent(scroll_list.truncate(formatRow(&rb, p), list.width));
         if (selected) f.put(color.Style.reset.code());
     }
 }
@@ -316,6 +324,39 @@ test "while the guard is up, x's domain keys do not re-arm or leak" {
     step(&s, .enter); // Enter is "default No" — cancels, no detail request
     try testing.expect(!s.confirm_uninstall);
     try testing.expectEqual(Request.none, s.request);
+}
+
+test "render heads the columns in bold, aligned over their values" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const s: State = .{ .items = &sample };
+    render(&s, &f, .{ .row = 3, .col = 1, .width = 80, .height = 10 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, color.Style.bold.code()) != null);
+    // Exact padding proves NAME / VERSION / SIZE sit over their value columns.
+    try testing.expect(std.mem.indexOf(u8, out, "NAME" ++ " " ** 19 ++ "VERSION" ++ " " ** 8 ++ "SIZE") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "brotli") != null); // the list still renders below
+}
+
+test "the heading sits at the top row and shifts the first list row down one" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const s: State = .{ .items = &sample };
+    render(&s, &f, .{ .row = 5, .col = 1, .width = 80, .height = 10 });
+    const out = f.slice();
+    const head = std.mem.indexOf(u8, out, "\x1b[5;1H").?; // heading at the content top row
+    const first = std.mem.indexOf(u8, out, "\x1b[6;1H").?; // first item one row below
+    try testing.expect(head < first);
+    try testing.expect(std.mem.indexOf(u8, out[head..first], "NAME") != null); // heading on the top row
+    try testing.expect(std.mem.indexOf(u8, out[first..], "brotli") != null); // first item below it
+}
+
+test "render at height one shows only the heading and never traps" {
+    var buf: [1024]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const s: State = .{ .items = &sample };
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 1 }); // the heading eats the only row
+    try testing.expect(std.mem.indexOf(u8, f.slice(), "NAME") != null);
 }
 
 test "render lists rows with name, version, and a humanized size" {

--- a/src/tui/outdated_tab.zig
+++ b/src/tui/outdated_tab.zig
@@ -147,7 +147,16 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     const filter = s.chrome.filter.slice();
     const nf = filteredCount(s.items, filter);
     if (nf == 0) return tab.renderHint(f, rect, if (filter.len != 0) "No matches." else "Everything is up to date.");
-    const v = scroll_list.clamp(s.chrome.view, nf, rect.height);
+    // A fixed bold heading rides above the list and costs it one row.
+    tab.renderHeading(f, rect, 4, &.{
+        .{ .label = "NAME", .width = 22 },
+        .{ .label = "CURRENT", .width = 12 },
+        .{ .label = "AVAILABLE", .width = 12 },
+        .{ .label = "KIND", .width = 8 },
+    });
+    const list: tab.Rect = .{ .row = rect.row + 1, .col = rect.col, .width = rect.width, .height = rect.height -| 1 };
+    if (list.height == 0) return; // the heading took the only row
+    const v = scroll_list.clamp(s.chrome.view, nf, list.height);
 
     var fi: usize = 0;
     for (s.items, 0..) |p, i| {
@@ -155,8 +164,8 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
         defer fi += 1;
         if (fi < v.offset) continue;
         const screen = fi - v.offset;
-        if (screen >= rect.height) break;
-        f.moveTo(rect.row + @as(u16, @intCast(screen)), rect.col);
+        if (screen >= list.height) break;
+        f.moveTo(list.row + @as(u16, @intCast(screen)), list.col);
         // The checkbox carries its own colour; a pinned row is held back so it
         // shows the blocked box, never a check.
         const is_checked = i < s.checked.len and s.checked[i];
@@ -169,20 +178,21 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
             f.put(color.Style.reverse.code());
         } else if (p.pinned) f.put(color.roleCode(.muted));
         var rb: [256]u8 = undefined;
-        f.putContent(scroll_list.truncate(formatRow(&rb, p), rect.width -| 4)); // 4 cols on the checkbox
+        f.putContent(scroll_list.truncate(formatRow(&rb, p), list.width -| 4)); // 4 cols on the checkbox
         if (selected or p.pinned) f.put(color.Style.reset.code());
     }
 }
 
-/// One list row after the checkbox: the name, the current→latest versions, the
-/// source type, and a pinned tag. ASCII columns, grapheme-naive like the rest;
-/// the arrow is width-aware via `truncate`.
+/// One list row after the checkbox: the name, the current and latest versions,
+/// the source type, and a pinned tag. The CURRENT/AVAILABLE headings name the two
+/// version columns, so they sit side by side with no arrow between them. ASCII
+/// columns, grapheme-naive like the rest.
 fn formatRow(buf: []u8, p: Row) []const u8 {
     var len: usize = 0;
     appendPad(buf, &len, p.name, 22);
     append(buf, &len, " ");
     appendPad(buf, &len, p.installed, 12);
-    append(buf, &len, "→ ");
+    append(buf, &len, " ");
     appendPad(buf, &len, p.latest, 12);
     append(buf, &len, " ");
     appendPad(buf, &len, kindLabel(p.kind), 8);
@@ -314,7 +324,20 @@ test "selectedIndex maps the cursor through the filter and clamps out-of-range" 
     try testing.expectEqual(@as(?usize, null), selectedIndex(&s));
 }
 
-test "render lists checkboxes with current→latest and the type column" {
+test "render heads the columns in bold, indented past the checkbox" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    var checked = [_]bool{false} ** 4;
+    const s: State = .{ .items = &sample, .checked = &checked };
+    render(&s, &f, .{ .row = 3, .col = 1, .width = 80, .height = 12 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, color.Style.bold.code()) != null);
+    // The 4-col checkbox indent plus exact padding aligns the labels over values.
+    try testing.expect(std.mem.indexOf(u8, out, "    NAME" ++ " " ** 19 ++ "CURRENT" ++ " " ** 6 ++ "AVAILABLE" ++ " " ** 4 ++ "KIND") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "wget") != null); // the list still renders below
+}
+
+test "render lists checkboxes with the current and latest versions and the type column" {
     var buf: [4096]u8 = undefined;
     var f: tab.Frame = .{ .buf = &buf };
     var checked = [_]bool{ true, false, false, false };
@@ -323,7 +346,8 @@ test "render lists checkboxes with current→latest and the type column" {
     const out = f.slice();
     try testing.expect(std.mem.indexOf(u8, out, "✓") != null); // wget checked
     try testing.expect(std.mem.indexOf(u8, out, "[ ]") != null); // an unchecked box
-    try testing.expect(std.mem.indexOf(u8, out, "→") != null); // current→latest
+    try testing.expect(std.mem.indexOf(u8, out, "→") == null); // the arrow is gone; the headings name the columns
+    try testing.expect(std.mem.indexOf(u8, out, "1.24.5") != null); // current version
     try testing.expect(std.mem.indexOf(u8, out, "1.25.0") != null); // latest version
     try testing.expect(std.mem.indexOf(u8, out, "cask") != null); // type column
 }

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -196,12 +196,20 @@ fn renderStatus(f: *tab.Frame, rect: tab.Rect, msg: []const u8) void {
 
 fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     if (rect.height == 0) return;
-    const v = scroll_list.clamp(s.chrome.view, s.items.len, rect.height);
+    // A fixed bold heading rides above the results and costs them one row, past
+    // the 4-col checkbox.
+    tab.renderHeading(f, rect, 4, &.{
+        .{ .label = "NAME", .width = 28 },
+        .{ .label = "KIND", .width = 8 },
+    });
+    const list: tab.Rect = .{ .row = rect.row + 1, .col = rect.col, .width = rect.width, .height = rect.height -| 1 };
+    if (list.height == 0) return; // the heading took the only row
+    const v = scroll_list.clamp(s.chrome.view, s.items.len, list.height);
     for (s.items, 0..) |m, i| {
         if (i < v.offset) continue;
         const screen = i - v.offset;
-        if (screen >= rect.height) break;
-        f.moveTo(rect.row + @as(u16, @intCast(screen)), rect.col);
+        if (screen >= list.height) break;
+        f.moveTo(list.row + @as(u16, @intCast(screen)), list.col);
         // Multi-select checkbox first (its own colour); the reverse-video
         // selection wraps only the text columns so the SGRs never tangle. An
         // installed hit can't be selected, so it shows the blocked box.
@@ -213,7 +221,7 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
             f.put(color.Style.reverse.code());
         }
         var rb: [256]u8 = undefined;
-        f.putContent(scroll_list.truncate(formatRow(&rb, m), rect.width -| 4)); // 4 cols on the checkbox
+        f.putContent(scroll_list.truncate(formatRow(&rb, m), list.width -| 4)); // 4 cols on the checkbox
         if (selected) f.put(color.Style.reset.code());
     }
 }
@@ -397,6 +405,18 @@ test "render shows no-matches when a committed query returned zero results" {
     const s: State = .{ .items = &.{}, .phase = .loaded };
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
     try testing.expect(std.mem.indexOf(u8, f.slice(), "No matches") != null);
+}
+
+test "render heads the result columns in bold, indented past the checkbox" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const s: State = .{ .items = &sample, .phase = .loaded };
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, color.Style.bold.code()) != null);
+    // 4-col checkbox indent plus exact padding aligns NAME / KIND over their values.
+    try testing.expect(std.mem.indexOf(u8, out, "    NAME" ++ " " ** 25 ++ "KIND") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "wget") != null); // the list still renders below
 }
 
 test "render lists hits with the kind label and an installed marker" {

--- a/src/tui/services_tab.zig
+++ b/src/tui/services_tab.zig
@@ -124,7 +124,16 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     const filter = s.chrome.filter.slice();
     const nf = filteredCount(s.items, filter);
     if (nf == 0) return tab.renderHint(f, rect, if (filter.len != 0) "No matches." else "No services registered.");
-    const v = scroll_list.clamp(s.chrome.view, nf, rect.height);
+    // A fixed bold heading rides above the list and costs it one row.
+    tab.renderHeading(f, rect, 2, &.{
+        .{ .label = "NAME", .width = 24 },
+        .{ .label = "STATE", .width = 12 },
+        .{ .label = "START", .width = 8 },
+        .{ .label = "KEG", .width = 3, .gap = 0 }, // formatRow appends the keg with no separator
+    });
+    const list: tab.Rect = .{ .row = rect.row + 1, .col = rect.col, .width = rect.width, .height = rect.height -| 1 };
+    if (list.height == 0) return; // the heading took the only row
+    const v = scroll_list.clamp(s.chrome.view, nf, list.height);
 
     var fi: usize = 0;
     for (s.items) |svc| {
@@ -132,8 +141,8 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
         defer fi += 1;
         if (fi < v.offset) continue;
         const screen = fi - v.offset;
-        if (screen >= rect.height) break;
-        f.moveTo(rect.row + @as(u16, @intCast(screen)), rect.col);
+        if (screen >= list.height) break;
+        f.moveTo(list.row + @as(u16, @intCast(screen)), list.col);
         // The dot keeps its own colour regardless of selection; the reverse-video
         // selection wraps only the text columns so the two SGRs never tangle.
         const st = statusOf(svc.state);
@@ -147,7 +156,7 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
             f.put(color.Style.reverse.code());
         }
         var rb: [256]u8 = undefined;
-        f.putContent(scroll_list.truncate(formatRow(&rb, svc), rect.width -| 2)); // 2 cols spent on the dot
+        f.putContent(scroll_list.truncate(formatRow(&rb, svc), list.width -| 2)); // 2 cols spent on the dot
         if (selected) f.put(color.Style.reset.code());
     }
 }
@@ -244,6 +253,18 @@ test "statusOf buckets known states and treats anything else as unknown" {
     try testing.expectEqual(Status.unknown, statusOf("loaded"));
     try testing.expectEqual(Status.unknown, statusOf("degraded"));
     try testing.expectEqual(Status.unknown, statusOf(""));
+}
+
+test "render heads the columns in bold, indented past the status dot" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const s: State = .{ .items = &sample };
+    render(&s, &f, .{ .row = 3, .col = 1, .width = 80, .height = 12 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, color.Style.bold.code()) != null);
+    // The 2-col dot indent plus exact padding aligns the labels over values.
+    try testing.expect(std.mem.indexOf(u8, out, "  NAME" ++ " " ** 21 ++ "STATE" ++ " " ** 8 ++ "START" ++ " " ** 3 ++ "KEG") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "redis") != null); // the list still renders below
 }
 
 test "render lists services with a state dot, the state, and the auto-start hint" {

--- a/src/tui/tab.zig
+++ b/src/tui/tab.zig
@@ -103,6 +103,48 @@ pub fn putCheckbox(f: *Frame, state: Check) void {
     }
 }
 
+/// A full-width horizontal rule across `rect` at `row` — the shared `<hr>` of
+/// the dashboard. `dimmed` muted-styles it (the band, detail pane, and chrome
+/// separator) or leaves it in the terminal default (the footer divider), so
+/// every rule is drawn by this one helper.
+pub fn renderSeparator(f: *Frame, rect: Rect, row: u16, dimmed: bool) void {
+    f.moveTo(row, rect.col);
+    if (dimmed) f.put(color.roleCode(.muted));
+    var i: u16 = 0;
+    while (i < rect.width) : (i += 1) f.put("─");
+    if (dimmed) f.put(color.Style.reset.code());
+}
+
+/// One column in a list heading: its `label`, the `width` it pads to (matching
+/// the row's `appendPad`), and the `gap` of blank cells before it — 1 for a
+/// normal column, 2 where the row uses a two-cell separator like `→ `. The first
+/// column's gap is unused; the checkbox/dot prefix is the heading's `indent`.
+pub const HeadingCol = struct { label: []const u8, width: u16, gap: u16 = 1 };
+
+/// Paint a bold column heading at the top of `rect`: `indent` leading blanks for
+/// a checkbox/dot prefix, then each column left-justified to its width and
+/// preceded by its gap, so labels sit over `appendPad`-formatted values. The one
+/// heading painter every list tab shares; width-truncated and reset like a row.
+pub fn renderHeading(f: *Frame, rect: Rect, indent: u16, cols: []const HeadingCol) void {
+    var b: [128]u8 = undefined;
+    var hf: Frame = .{ .buf = &b };
+    blanks(&hf, indent);
+    for (cols, 0..) |c, i| {
+        if (i != 0) blanks(&hf, c.gap);
+        hf.put(c.label);
+        if (c.label.len < c.width) blanks(&hf, c.width - @as(u16, @intCast(c.label.len)));
+    }
+    f.moveTo(rect.row, rect.col);
+    f.put(color.Style.bold.code());
+    f.putContent(scroll_list.truncate(hf.slice(), rect.width));
+    f.put(color.Style.reset.code());
+}
+
+fn blanks(f: *Frame, n: u16) void {
+    var i: u16 = 0;
+    while (i < n) : (i += 1) f.put(" ");
+}
+
 /// Paint one dim line at the top of `rect` — the shared empty-state / "no
 /// matches" placeholder so every tab's empty list reads the same way instead of
 /// a blank pane. Content goes through `putContent` like every other row.
@@ -179,6 +221,50 @@ test "renderHint paints the placeholder text into the frame" {
     var f: Frame = .{ .buf = &buf };
     renderHint(&f, .{ .row = 2, .col = 1, .width = 40, .height = 6 }, "Nothing here.");
     try std.testing.expect(std.mem.indexOf(u8, f.slice(), "Nothing here.") != null);
+}
+
+test "renderSeparator paints a full-width rule, dim only when asked" {
+    var buf: [256]u8 = undefined;
+    var f: Frame = .{ .buf = &buf };
+    renderSeparator(&f, .{ .row = 5, .col = 1, .width = 4, .height = 1 }, 5, true);
+    const dim = f.slice();
+    try std.testing.expect(std.mem.indexOf(u8, dim, color.roleCode(.muted)) != null);
+    try std.testing.expect(std.mem.indexOf(u8, dim, "────") != null); // width box-drawing cells
+    try std.testing.expect(std.mem.indexOf(u8, dim, color.Style.reset.code()) != null);
+
+    // Undimmed: the bare rule, terminal default — no muted SGR, no reset.
+    var pbuf: [256]u8 = undefined;
+    var pf: Frame = .{ .buf = &pbuf };
+    renderSeparator(&pf, .{ .row = 1, .col = 1, .width = 4, .height = 1 }, 1, false);
+    const plain = pf.slice();
+    try std.testing.expect(std.mem.indexOf(u8, plain, "────") != null);
+    try std.testing.expect(std.mem.indexOf(u8, plain, color.roleCode(.muted)) == null);
+}
+
+test "renderHeading lays bold columns with an indent and per-column gaps" {
+    var buf: [256]u8 = undefined;
+    var f: Frame = .{ .buf = &buf };
+    renderHeading(&f, .{ .row = 1, .col = 1, .width = 80, .height = 1 }, 2, &.{
+        .{ .label = "A", .width = 4 },
+        .{ .label = "B", .width = 4, .gap = 2 },
+    });
+    const out = f.slice();
+    try std.testing.expect(std.mem.indexOf(u8, out, color.Style.bold.code()) != null);
+    // 2-space indent, A padded to width 4, then a 2-cell gap before B.
+    try std.testing.expect(std.mem.indexOf(u8, out, "  A" ++ " " ** 5 ++ "B") != null);
+}
+
+test "renderHeading truncates to the rect width and still closes the bold" {
+    var buf: [512]u8 = undefined;
+    var f: Frame = .{ .buf = &buf };
+    // Width 6 is narrower than the heading: it must cut cleanly, never overflow.
+    renderHeading(&f, .{ .row = 1, .col = 1, .width = 6, .height = 1 }, 2, &.{
+        .{ .label = "NAME", .width = 22 },
+        .{ .label = "VERSION", .width = 14 },
+    });
+    const out = f.slice();
+    try std.testing.expect(std.mem.indexOf(u8, out, "VERSION") == null); // cut past the width
+    try std.testing.expect(std.mem.indexOf(u8, out, color.Style.reset.code()) != null); // bold still closed
 }
 
 test "renderHint on a zero-height rect is a clean no-op" {


### PR DESCRIPTION
## Description

A few touches to make the `mt tui` dashboard easier to read at a glance:

- The list tabs (Installed, Outdated, Services, Search) now have labelled column headers and a line separating the filter from the content, so they read as tidy tables instead of loose text.
- When everything is healthy, the Doctor tab shows a calm "All clear" line instead of the full status panel and still points out reclaimable disk when there is any.

## Related Issue

- None

## Notes for Reviewers

- None