### PR TITLE
feat(man): generate and commit a single man malt page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,21 @@ jobs:
         with:
           version: 0.16.0
 
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
       - name: Build (Debug)
-        run: zig build
+        run: just build
+
+      # Drift guard: the committed man page is generated from the binary's
+      # own --help, so a --help edit that skips `just man-gen` fails here.
+      - name: Man page drift check
+        run: just man-check
 
       - name: Build (ReleaseSafe)
-        run: zig build -Doptimize=ReleaseSafe
+        run: just build-release
 
       - name: Run unit tests
         run: zig build test --summary all
@@ -65,7 +75,7 @@ jobs:
         run: ./scripts/smokes/smoke_security.sh
 
       - name: Build universal binary
-        run: zig build universal -Doptimize=ReleaseSafe
+        run: just build-universal
 
   lint:
     name: Lint

--- a/dist/man/malt.1
+++ b/dist/man/malt.1
@@ -1,0 +1,743 @@
+.TH MALT 1 "malt 0.18.0" "malt 0.18.0" "malt manual"
+.SH NAME
+malt \- a fast, drop-in Homebrew alternative for macOS
+.SH SYNOPSIS
+.nf
+malt <command> [options] [arguments]
+mt   <command> [options] [arguments]
+.fi
+.SH DESCRIPTION
+.nf
+malt — a fast, drop-in Homebrew alternative for macOS.
+Warm installs in milliseconds. post_install scripts that actually run.
+Full operational surface beyond install and uninstall.
+
+Usage: malt <command> [options] [arguments]
+       mt <command> [options] [arguments]    (alias)
+
+Commands:
+  install       Install formulas, casks, or tap formulas
+  reinstall     Wipe and re-materialise an installed package
+  uninstall     Remove installed packages
+  upgrade       Upgrade installed packages
+  update        Refresh metadata cache
+  outdated      List packages with newer versions available
+  list          List installed packages
+  info          Show detailed package information
+  search        Search formulas and casks
+  uses          Show installed packages that depend on a formula
+  deps          Show what a formula depends on (forward of `uses`)
+  which         Resolve a prefix binary (or path) to its keg
+  doctor        System health check
+  tap/untap     Manage taps
+  migrate       Import existing Homebrew installation
+  rollback      Revert a package to its previous version
+  link          Create symlinks for an installed keg
+  unlink        Remove symlinks (keg stays installed)
+  pin           Protect an installed formula or cask from `upgrade`
+  unpin         Lift the pin so `upgrade` resumes touching it
+  run           Run a package binary without installing
+  completions   Generate shell completion scripts (bash, zsh, fish)
+  shellenv      Print PATH/MANPATH/HOMEBREW_PREFIX exports for shell init
+  backup        Dump installed packages to a restorable text file
+  restore       Reinstall every package listed in a backup file
+  purge         Housekeeping or full wipe (--store-orphans, --unused-deps,
+                --cache, --downloads, --stale-casks, --old-versions,
+                --housekeeping, --wipe)
+  cleanup       Shorthand for `purge --housekeeping`
+  services      Manage long-running launchd services (start/stop/status/logs)
+  tui           Interactive dashboard (search, installed, outdated, services, doctor)
+  bundle        Install or export a Brewfile/Maltfile.json set of packages
+  version       Show version (use 'version update' to self-update)
+
+Global flags:
+  --verbose, -v   Verbose output
+  --debug         Surface every DSL diagnostic (implies verbose);
+                  pair with issue reports for full context
+  --quiet, -q     Suppress non-error output
+  --json          JSON output (read commands)
+  --output-format=ndjson
+                  Stream one JSON event per state transition for
+                  install/upgrade/migrate (orthogonal to --json)
+  --dry-run       Preview without executing
+  --offline       Serve every fetch from the snapshot cache; fail
+                  fast with OfflineRequired on a miss
+  --help, -h      Show help
+  --version       Show version
+
+.fi
+.SH COMMANDS
+.SS install
+.nf
+Usage: malt install <package> [<package> ...] [flags]
+
+Install formulas, casks, or tap formulas.
+
+  malt install <name>                    auto-detect formula or cask
+  malt install <name>@<version>          specific version
+  malt install --cask <app>              explicit cask
+  malt install --formula <name>          explicit formula
+  malt install <user>/<tap>/<formula>    inline tap
+  malt install --local <path.rb>         install from a local Ruby formula
+
+Flags:
+  --cask             Force cask installation
+  --formula          Force formula installation
+  --local            Install from a local .rb file path (code-exec surface:
+                     only pass files you trust)
+  --dry-run          Show what would be installed
+  --force            Overwrite existing installations
+  --only-deps        Install transitive deps but skip the requested package
+                     (deps are recorded as `dependency` so `mt purge --unused-deps`
+                     can later GC them). `--only-dependencies` accepted for
+                     brew-parity.
+  --download-only    Warm the bottle store (formulas), the Cask cache (casks),
+                     or the tap archive cache (`<prefix>/cache/Tap/` for
+                     `user/repo/<formula>`) and stop before materialise/link/
+                     record. The Cellar, /Applications, and DB stay untouched;
+                     a follow-up `mt install` consumes the cached bytes.
+                     Refused with --only-deps.
+  --use-system-ruby[=<name>,...]  Run post_install via the system Ruby interpreter
+                     (experimental, sandboxed). A bare flag requires a single
+                     package; use =<name>,... to scope when installing multiple.
+  --isolate-deps     Keep every transitive dep out of <prefix>/bin and
+                     <prefix>/sbin. The package(s) you named still link
+                     normally; deps land in the Cellar with their `opt/`
+                     anchor (Mach-O dependents stay resolvable) but their
+                     bin/sbin contents are skipped. The choice is recorded
+                     per-keg so a later `mt upgrade` replays it. Shell-
+                     based formulas that bare-name-exec their deps
+                     (e.g. `python` vs `/full/path/python`) may break;
+                     use `mt link <dep>` to undo per-keg.
+                     `--isolate-dependencies` accepted as an alias.
+  --quiet, -q        Suppress non-error output
+  --json             Output result as JSON
+.fi
+.SS reinstall
+.nf
+Usage: malt reinstall <package> [flags]
+
+Wipe and re-materialise an already-installed package through the
+shared install pipeline. The discoverable peer of `malt install
+--force`; lets you fix a corrupted Cellar entry or re-run the
+install protocol without retyping the --force flag.
+
+Reinstall is package-scoped — transitive dependencies are NOT
+reinstalled. To rebuild a dep, name it explicitly.
+
+Flags pass through to `install`; the common ones:
+  --cask               Force cask path (auto-detected from the DB row)
+  --dry-run            Show what would be reinstalled
+  --quiet, -q          Suppress non-error output
+  --json               JSON output (mirrors `mt install --json`)
+  --isolate-deps       New deps follow the flag; existing rows keep
+                       whatever isolation policy they were recorded with
+  --output-format=ndjson
+                       Stream one event per state transition
+
+Examples:
+  malt reinstall wget
+  malt reinstall --cask firefox
+.fi
+.SS uninstall
+.nf
+Usage: malt uninstall <package> [flags]
+
+Remove installed packages.
+
+Flags:
+  --force        Remove even if other packages depend on it
+  --zap          Deep clean (cask only)
+  --dry-run      Show what would be removed
+.fi
+.SS upgrade
+.nf
+Usage: malt upgrade [<package>] [flags]
+
+Upgrade installed packages to latest versions. Pinned kegs and
+casks are skipped with a "pinned, skipped" line; pass --force to
+override.
+
+Flags:
+  --all          Upgrade everything (formulas + casks)
+  --cask         Upgrade casks only
+  --formula      Upgrade formulas only
+  --dry-run      Show what would be upgraded
+  --pinned       Audit pinned formulas + casks (requires --dry-run or --force)
+  --force, -f    Bypass pin protection (dangerous; user-initiated)
+  --isolate-deps New deps pulled in by this upgrade keep their bins
+                 out of <prefix>/bin and <prefix>/sbin. Existing kegs
+                 replay whatever they were already recorded with.
+                 `--isolate-dependencies` accepted as an alias.
+.fi
+.SS update
+.nf
+Usage: malt update [flags]
+
+Refresh the local formula/cask metadata cache and the outdated snapshot.
+
+Flags:
+  --check     Refresh only the outdated snapshot (skip API cache wipe)
+  --quiet, -q Suppress status messages
+.fi
+.SS outdated
+.nf
+Usage: malt outdated [flags]
+
+List packages with newer versions available.
+
+Flags:
+  --json         Output as JSON
+  --formula      Show outdated formulas only
+  --cask         Show outdated casks only
+  --pinned-only  Audit pinned formulas + casks only (CVE watch)
+  --tap <label>  Only packages from <label> (e.g. `user/repo`).
+                 Strict equality: legacy v6-era casks with no
+                 recorded tap won't match. Forces a live recompute.
+  --refresh      Force live recompute, bypassing the cached snapshot
+  --quiet, -q    Suppress status messages
+
+Reads the cached snapshot at {cache}/outdated.json when fresh
+(<= MALT_OUTDATED_MAX_AGE minutes, default 5); past that it recomputes
+live (or serves the cached read offline). --refresh always recomputes.
+.fi
+.SS list
+.nf
+Usage: malt list [flags]
+
+List installed packages.
+
+Flags:
+  --versions     Show version numbers
+  --formula      Formulas only
+  --cask         Casks only
+  --pinned       Pinned packages only
+  --tap <label>  Only packages from <label> (e.g. `user/repo`).
+                 Strict equality: legacy v6-era casks with no
+                 recorded tap won't match — run `mt upgrade <token>`
+                 to trigger attribution, or omit the filter.
+  --json         Output as JSON
+  --size         With --json: add size_bytes (on-disk size) per row.
+                 Opt-in — it walks each keg/cask dir, so the default
+                 --json stays metadata-only and pays no walk cost.
+  --linked       With --json: add linked (is the keg active in the
+                 prefix). Casks are always linked once installed.
+  --quiet, -q    Names only, one per line
+.fi
+.SS info
+.nf
+Usage: malt info <package> [flags]
+
+Show detailed information about a formula or cask. If the package
+has retained rollback versions (multi-version store entries for
+formulas, cask_versions history for casks), they are listed under
+an "Available rollback versions" section so `mt rollback <pkg>`
+and `mt info <pkg>` agree on what's retrievable. The same listing
+is exposed in `--json` as the `available_rollback_versions` array.
+
+Flags:
+  --formula      Show formula info only
+  --cask         Show cask info only
+  --json         Output as JSON
+.fi
+.SS search
+.nf
+Usage: malt search <query> [flags]
+
+Search formulas and casks by name.
+
+Default scope: query the Homebrew API (same as `brew search`). Use
+--installed when you only want to know what's already on disk.
+
+Scope:
+  --installed    Query kegs.name + casks.token only. No network.
+  --api          Explicit form of the default (Homebrew API).
+  --all          Run both passes and merge results, deduped + sorted.
+  --offline      Alias of --installed (mirrors MALT_OFFLINE=1).
+
+Kind filter:
+  --formula      Search formulas only
+  --cask         Search casks only
+
+Output:
+  --json         Output as JSON
+.fi
+.SS uses
+.nf
+Usage: malt uses <formula> [flags]
+
+Show installed packages that depend on <formula>. By default only
+direct dependents are shown — pass --recursive for the transitive
+closure.
+
+Flags:
+  --recursive, -r   Include transitive dependents
+  --json            Output as JSON
+  --quiet, -q       Suppress status messages
+
+Examples:
+  malt uses openssl@3
+  malt uses --recursive icu4c@78
+  malt --json uses node@20
+.fi
+.SS deps
+.nf
+Usage: malt deps <formula> [flags]
+
+Show what <formula> depends on — the forward symmetric of
+`mt uses`. Installed kegs read from the local DB; uninstalled
+formulas walk the upstream API.
+
+Flags:
+  --recursive, -r   Walk the transitive closure
+  --installed       Restrict to kegs that resolve locally (skips
+                    the API fallback; offline-safe)
+  --json            Emit `[{"formula","depends_on":[…]}, …]`
+  --quiet, -q       Suppress status messages
+
+Examples:
+  malt deps openssl@3
+  malt deps --recursive ffmpeg
+  malt deps --installed -r node@20
+  malt --json deps wget
+.fi
+.SS which
+.nf
+Usage: malt which <name|path>
+
+Resolve a prefix binary to the keg that owns it. Accepts a bare
+name (resolved through `{prefix}/bin/<name>`) or an absolute path
+to a malt-managed symlink. Pairs with `mt uses` as the
+forward/reverse lookup pair.
+
+Flags:
+  --json   Emit `{"name", "version", "keg"}` as JSON
+
+Examples:
+  malt which jq
+  malt which /opt/malt/bin/jq
+  malt --json which jq
+.fi
+.SS doctor
+.nf
+Usage: malt doctor [--fix [<id>]]
+
+Run system health checks: database integrity, orphaned store
+entries, broken symlinks, disk space, API reachability, and more.
+
+Trailing report:
+  Retained cask versions — for every cask token whose
+  `cask_versions` history has rows that are not the live
+  install, the count + on-disk bytes are summarised. Empty
+  state stays silent. Read-only: `mt purge --old-versions`
+  is what actually reclaims the space.
+
+Options:
+  --fix [<id>]   Apply the safe-class fixers (stale lock,
+                 orphaned store entries, broken symlinks).
+                 With an <id> (stale_lock, orphaned_store,
+                 broken_symlinks) apply only that class; with
+                 no id apply them all. Pair with --dry-run to
+                 preview the plan. Dangerous classes (corrupt
+                 DB, missing kegs) still print a manual
+                 remediation command.
+  --verbose      List every offender under the count-only
+                 checks (Mach-O placeholders, broken symlinks,
+                 missing kegs) on its own indented line, and
+                 include the per-(token version) breakdown
+                 under the retained-cask-versions summary.
+  --json         Emit the retained-cask-versions report as a
+                 stable `{cask_history: {retained_versions,
+                 bytes}}` payload on stdout. Empty state still
+                 surfaces with zero values.
+.fi
+.SS tap/untap
+.nf
+Usage: malt tap [<user>/<repo>]
+       malt tap <user>/<repo> --repo <owner>/<exact-repo> [--force]
+       malt tap <slug> --host <forge-host> [--forge <provider>] --repo <owner>/<repo>
+       malt tap <slug> --url https://<host>/<owner>/<repo>
+       malt tap --refresh <user>/<repo>
+       malt tap --refresh --all [--yes] [--json]
+       malt tap --pin <user>/<repo> <sha>
+       malt untap <user>/<repo>
+
+Manage taps. Without arguments, lists registered taps + their
+pinned commit. `tap <slug>` resolves the repo's HEAD commit at
+that moment and stores it; subsequent installs from the tap fetch
+against the pin, not whatever HEAD happens to point to later.
+
+Flags:
+  --refresh [<slug>]   Advance the pin to the current HEAD. With a
+                       slug, refreshes that one tap; with --all,
+                       walks every registered tap.
+  --all                Pairs with --refresh: batch every tap, print
+                       a per-row `old_sha[..7] -> new_sha[..7]` diff,
+                       and refuse to apply without --yes when any
+                       tap moved.
+  --pin <slug> <sha>   Explicitly pin <slug> to <sha>. The SHA is
+                       validated for reachability through the tap's own
+                       forge's commits/<sha> endpoint before it lands.
+  --repo <owner>/<exact-repo>
+                       Point the tap at a GitHub repo whose name
+                       does NOT carry the `homebrew-` prefix
+                       (e.g. `mt tap aeroxy/ast-outline --repo
+                       aeroxy/ast-outline`). Without this flag the
+                       tap resolves against `homebrew-<repo>`.
+  --host <forge-host>  Register the tap against a non-GitHub forge
+                       (e.g. gitlab.com, gitlab.gnome.org). Requires an
+                       explicit --repo — the `homebrew-<repo>` default
+                       only applies to github.com. The tap registers
+                       unpinned; `mt tap --refresh <slug>` pins its HEAD.
+  --forge <provider>   Pin the forge explicitly (github, gitlab,
+                       gitea, or gogs) when the host can't reveal it
+                       — a custom-domain GitLab like code.acme.com or
+                       a self-hosted Forgejo/Gitea/Gogs. gitlab.* and
+                       codeberg.org auto-classify, so this is only
+                       needed for non-obvious domains.
+  --url <repo-url>     Derive (host, owner, repo) from a full
+                       `https://<host>/<owner>/<repo>` URL instead of
+                       naming --host and --repo separately.
+  --force              Allow rebinding an existing tap to a new
+                       --repo target. Clears the stale commit SHA
+                       and ETag because the new repo has its own HEAD.
+  --yes, -y            Confirm the apply step of --refresh --all.
+  --json               Emit the --refresh --all diff as
+                       `{"taps":[{"tap","old_sha","new_sha","status"}]}`.
+
+Taps are auto-resolved during install, so explicit `tap` is
+usually unnecessary — the auto-tap also pins the SHA on first use.
+.fi
+.SS migrate
+.nf
+Usage: malt migrate [flags]
+
+Import an existing Homebrew installation into malt.
+Does NOT modify the Homebrew installation.
+
+Flags:
+  --dry-run          Show what would be migrated
+  --parallel         Migrate kegs concurrently with a bounded worker pool
+                     (default 4 workers; override with
+                     MALT_MIGRATE_PARALLEL_WORKERS=N). Successful kegs are
+                     recorded in {prefix}/cache/migrate.progress.json so a
+                     re-run after a crash or ^C resumes where it stopped.
+  --json             Emit a machine-readable summary on stdout (pairs with
+                     --dry-run to list kegs, or with a real run to report
+                     per-category names + counts for migrated / skipped /
+                     failed).
+  --use-system-ruby=<name>,...  Run post_install via the system Ruby interpreter
+                     (experimental, sandboxed) for the named kegs only. A bare
+                     `--use-system-ruby` is not allowed here — it would widen
+                     the trust boundary to every keg discovered in the Cellar.
+.fi
+.SS rollback
+.nf
+Usage: malt rollback <package> [flags]
+       malt rollback --list <package>
+       malt rollback --to <version> <package>
+
+Revert a formula or cask to a previous version. Formulas
+reuse the content-addressable store (no re-download). Casks
+reuse the per-version cache when present and re-download from
+the recorded URL otherwise; SHA256 is verified either way.
+
+Without --to, lands on the most recent previous entry.
+
+Flags:
+  --list             Print every retained version for <package>
+                     and exit without changes
+  --to <version>     Roll back to the exact version if present;
+                     otherwise refuse and print --list. A --to
+                     of the currently-installed version is a
+                     clean no-op (exit 0)
+  --json             Emit --list output as JSON (scriptable)
+  --dry-run          Show what would happen
+.fi
+.SS link
+.nf
+Usage: malt link <formula> [flags]
+       malt link --isolate <name>
+       malt link --isolate --all
+
+Default form: create symlinks for an installed keg in the prefix
+(bin/, lib/, etc.). Re-linking a previously isolated dep also
+clears the isolation flag so DB and filesystem agree.
+
+`--isolate <name>` removes the keg's bin/sbin symlinks and marks
+the row `bin_isolated=1`. Useful retroactively on a dep that
+predates `--isolate-deps`. Refused on `install_reason='direct'`
+kegs — uninstall first if you want a direct keg hidden from PATH.
+
+`--isolate --all` isolates every dep keg currently linking
+bin/sbin.
+
+Flags:
+  --overwrite    Replace existing symlinks
+  --force, -f    Same as --overwrite
+  --isolate      Remove bin/sbin symlinks; mark the keg isolated
+  --all          With --isolate: operate on every dep keg
+.fi
+.SS unlink
+.nf
+Usage: malt unlink <formula>
+
+Remove symlinks for an installed keg from the prefix.
+The keg remains installed in the Cellar.
+.fi
+.SS pin
+.nf
+Usage: malt pin <name>
+
+Mark an installed formula or cask as pinned so `malt upgrade` skips
+it. The pin survives across upgrades and is visible in
+`mt list --pinned`. Use `mt unpin <name>` to lift it, or
+`mt upgrade --force <name>` to override the pin once.
+.fi
+.SS unpin
+.nf
+Usage: malt unpin <name>
+
+Lift the pin on an installed formula or cask so subsequent
+`malt upgrade` runs touch it again.
+.fi
+.SS run
+.nf
+Usage: malt run [--keep] <package> [-- <args...>]
+
+Run a package binary without installing it. Downloads to a
+temp directory, executes, and cleans up. If the package is
+already installed, runs the installed binary directly.
+
+Flags:
+  --keep    Cache the extracted bottle under {cache}/run/<sha256>/
+            so subsequent runs skip download. Wipe with
+            `mt purge --cache`.
+
+Example:
+  malt run jq -- --version
+  malt run --keep jq -- --version
+.fi
+.SS completions
+.nf
+Usage: malt completions <shell>
+
+Generate a shell completion script. The script is printed to stdout
+so it can be eval'd for the current shell or redirected to a file.
+
+Shells:
+  bash    Source with: eval "$(malt completions bash)"
+  zsh     Source with: eval "$(malt completions zsh)"
+  fish    Source with: malt completions fish | source
+
+Permanent install:
+  bash    malt completions bash > /usr/local/etc/bash_completion.d/malt
+  zsh     malt completions zsh  > "${fpath[1]}/_malt"
+  fish    malt completions fish > ~/.config/fish/completions/malt.fish
+.fi
+.SS shellenv
+.nf
+Usage: malt shellenv [bash|zsh|fish]
+
+Print shell-init lines that export HOMEBREW_PREFIX and prepend
+malt's bin/sbin/man/info dirs onto PATH/MANPATH/INFOPATH. With no
+argument the shell is detected from $SHELL.
+
+Source from your rc file:
+  bash/zsh   eval "$(malt shellenv)"
+  fish       malt shellenv fish | source
+.fi
+.SS backup
+.nf
+Usage: malt backup [flags]
+
+Dump the list of directly-installed formulae and casks to a plain-text
+file that `malt restore` can consume to reproduce the environment on
+another machine.
+
+By default the file is written to the current directory with a
+timestamped name, e.g. `malt-backup-2026-04-10T14-32-05.txt`.
+
+Flags:
+  --output, -o <path>  Write to a specific file (use `-` for stdout)
+  --versions           Pin each entry to its current version (@ver)
+  --services           Include auto-start services so `malt restore`
+                       re-bootstraps launchd state on the destination
+  --quiet, -q          Suppress non-error output
+
+Examples:
+  malt backup
+  malt backup -o ~/dotfiles/packages.txt
+  malt backup --versions -o - > snapshot.txt
+  malt backup --services -o ~/dotfiles/packages.txt
+.fi
+.SS restore
+.nf
+Usage: malt restore <file> [flags]
+
+Read a backup file produced by `malt backup` and install every entry
+it lists. Formulae and casks are installed in a single batched run each
+so dependency resolution and parallel downloads apply normally.
+
+Flags:
+  --dry-run     Print the list of packages that would be installed
+  --force       Pass --force to the underlying install
+  --quiet, -q   Suppress non-error output
+
+Example:
+  malt restore malt-backup-2026-04-10T14-32-05.txt
+.fi
+.SS purge
+.nf
+Usage: malt purge <scope> [<scope>...] [flags]
+
+Unified housekeeping and full-wipe command. At least one scope flag
+is required — running `malt purge` with no scope is an error.
+
+Scopes (one or more required):
+  --store-orphans      Refcount-0 blobs in {prefix}/store
+  --unused-deps        Indirect-install kegs no other package needs
+  --cache[=DAYS]       Cache files older than DAYS (default 30)
+  --downloads          Wipe {cache}/downloads entirely        (typed confirm)
+  --stale-casks        Cask cache + Caskroom for uninstalled casks
+  --old-versions       Non-latest Cellar versions + retained cask history (typed confirm)
+  --housekeeping       = --store-orphans --unused-deps --cache --stale-casks
+  --wipe               Nuclear: every malt artefact on disk    (typed confirm)
+
+Shared flags:
+  --dry-run, -n        Preview only
+  --yes, -y            Skip every typed confirmation prompt
+  --quiet, -q          Suppress per-item output
+  --verbose, -v        Show every per-scope item (no truncation, full SHAs)
+  --backup, -b <path>  Write a `mt restore`-compatible manifest first
+
+Structured output (stdout; stderr stays the human surface):
+  --json                  Single summary object: version, dry_run, scopes,
+                          totals, time_ms.
+  --output-format=ndjson  One {"event":...} line per state transition
+                          (scope_started, scope_completed, purge_complete).
+
+--wipe-only flags:
+  --keep-cache         Do not delete the cache directory
+  --remove-binary      Also unlink /usr/local/bin/{mt,malt}
+
+Examples:
+  malt purge --housekeeping
+  malt purge --store-orphans --dry-run
+  malt purge --cache=60 --stale-casks
+  malt purge --old-versions --yes
+  malt purge --wipe --backup ~/malt-snapshot.txt --remove-binary --yes
+
+For per-package removal use `mt uninstall <name>`.
+.fi
+.SS cleanup
+.nf
+Usage: malt cleanup [flags]
+
+Shorthand for `malt purge --housekeeping` — the safe daily-driver
+scope (store-orphans + unused-deps + cache + stale-casks). For the
+full menu (downloads scrub, old-versions, wipe) use `mt purge`.
+
+Flags pass through to `purge`; the common ones:
+  --dry-run, -n        Preview only
+  --yes, -y            Skip every typed confirmation
+  --quiet, -q          Suppress per-item output
+  --verbose, -v        Show every per-scope item, full SHAs
+  --cache=<DAYS>       Override the 30-day cache cutoff
+  --backup, -b <path>  Write a `mt restore`-compatible manifest first
+  --json               Single summary object on stdout
+  --output-format=ndjson
+                       One event per scope start/complete
+
+Examples:
+  malt cleanup
+  malt cleanup --dry-run
+  malt cleanup --cache=7 --yes
+.fi
+.SS services
+.nf
+Usage: malt services <subcommand> [args]
+
+Subcommands:
+  list              Show registered services.
+  start <name>      Bootstrap the service under launchd.
+  stop <name>       Boot the service out of launchd.
+  restart <name>    stop then start.
+  status [name]     Show registered state (falls back to list).
+  logs <name> [--tail N] [--stderr] [--follow|-f]
+                    Print the last N lines of the service log.
+                    --follow / -f tails appended bytes until SIGINT.
+.fi
+.SS tui
+.nf
+Usage: malt tui
+
+Launch the interactive dashboard: a tab bar (Search, Installed, Outdated,
+Services, Doctor), a `/`-activated filter, and a list that reflows
+live as you resize the terminal. Switch tabs with `tab`, the left/right
+arrows, or `1`-`5`; quit with `q` or Ctrl-C.
+
+Reads come from `mt … --json`; actions delegate to the real `mt`
+subcommands. Requires an interactive terminal — on a pipe, in CI, or
+with NO_COLOR set it refuses to launch (exit 2) rather than emit a
+corrupted frame.
+
+Environment:
+  MALT_THEME   Colour theme for all malt output — the CLI and this
+               dashboard alike: default, dracula, catppuccin-mocha,
+               catppuccin-latte, rose-pine, rose-pine-dawn, nord,
+               tokyo-night, gruvbox-dark, gruvbox-light, everforest.
+               light/dark/auto keep the background-aware default theme;
+               unknown ⇒ default.
+               Named themes need a truecolor terminal (COLORTERM) and
+               degrade to the default palette on a basic terminal or one
+               whose background contradicts the theme (e.g. a dark theme
+               on a light terminal).
+  MALT_THEMES_FILE  JSON file of custom themes (see the README); read once
+               at boot, else {prefix}/etc/malt/themes.json if present.
+.fi
+.SS bundle
+.nf
+Usage: malt bundle <subcommand> [args]
+
+Subcommands:
+  install [--isolate-deps] [file]
+                              Install formulae/casks/taps/services from a Brewfile or Maltfile.json.
+                              --isolate-deps keeps transitive runtime deps out of <prefix>/bin
+                              and <prefix>/sbin (per-keg state, replays on upgrade).
+  cleanup [--yes] [--dry-run] [file]
+                              Uninstall packages present on disk but absent from the Brewfile.
+  create  [--format brewfile|json] [--services] [path]
+                              Write currently-installed set to a bundle file.
+                              --services also emits auto-start services (JSON only).
+  list                        List bundles registered in the database.
+  remove <name>               Unregister a bundle (does NOT uninstall members).
+  export  [--format brewfile|json] [--services] [name]
+                              Print bundle (or current install) to stdout.
+                              --services also emits auto-start services (JSON only).
+  import  <file>              Register a bundle definition without installing.
+
+Lookup order for install/export without an explicit path:
+  ./Brewfile, ./Maltfile.json, ~/.config/malt/Brewfile, ~/.config/malt/Maltfile.json
+.fi
+.SS version
+.nf
+malt 0.18.0
+.fi
+.SH ENVIRONMENT
+.nf
+Environment:
+  MALT_PREFIX       Override install prefix (default: /opt/malt)
+  MALT_CACHE        Override cache directory
+  NO_COLOR          Disable colored output
+  MALT_NO_EMOJI     Disable emoji in output
+  MALT_PROGRESS=tty|plain|none
+                    Choose how install/upgrade/migrate report progress;
+                    default auto-detects (CI=true flips to plain)
+  MALT_OFFLINE=1    Same as --offline: every fetch must serve from
+                    the snapshot cache
+  MALT_NO_VERSION_NOTIFIER=1
+                    Suppress the "newer malt available" stderr notice
+.fi
+.SH SEE ALSO
+.BR brew (1)

--- a/justfile
+++ b/justfile
@@ -439,6 +439,25 @@ record-demo:
 record-themes:
     ./scripts/record-themes.sh
 
+# Regenerate the committed man page from the built binary's --help.
+[group('docs')]
+man-gen: build
+    ./scripts/gen-man.sh dist/man/malt.1
+
+# Drift guard: fail if dist/man/malt.1 is stale vs the binary's --help.
+# Reuses the already-built binary (CI runs it right after the build step).
+[group('docs')]
+man-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tmp=$(mktemp)
+    trap 'rm -f "$tmp"' EXIT
+    ./scripts/gen-man.sh "$tmp"
+    if ! diff -u dist/man/malt.1 "$tmp"; then
+      echo "error: dist/man/malt.1 is out of date — run 'just man-gen'" >&2
+      exit 1
+    fi
+
 # Regenerate docs/contrast-previews/*.png for the four palette cells
 # (dark|light) × (truecolor|basic). Internal: only run after editing
 # the palette cells in src/ui/color.zig or the sample text in

--- a/scripts/gen-man.sh
+++ b/scripts/gen-man.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# scripts/gen-man.sh — generate the single `man malt` page from the binary's
+# own --help output. Emits roff to <output-path>.
+#
+# Why generate from the binary: the root command list lives in main.zig's
+# printUsage while per-command help lives in a separate map — only running the
+# built binary unifies both, so the page cannot drift from what users see.
+#
+# Determinism is load-bearing: the CI `man-check` diff flakes on any
+# wall-clock date / $USER / absolute path, so the .TH date slot carries the
+# version (from .version) instead. Re-running must be byte-identical.
+#
+# Usage:
+#   scripts/gen-man.sh dist/man/malt.1
+#   MALT_BIN=/path/to/malt scripts/gen-man.sh out.1
+
+set -euo pipefail
+
+OUT="${1:?usage: gen-man.sh <output-path>}"
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+
+[ -x "$BIN" ] || {
+  echo "malt binary not found at $BIN (run: zig build)" >&2
+  exit 1
+}
+VERSION=$(tr -d '[:space:]' <"$ROOT/.version")
+[ -n "$VERSION" ] || {
+  echo "empty .version at $ROOT/.version" >&2
+  exit 1
+}
+
+# Escape a verbatim help block for a .nf/.fi no-fill region: no-fill stops
+# roff filling text, not interpreting control lines, so a backslash must
+# survive as \e and a leading . or ' must be neutralised with \&.
+esc() { sed -e 's/\\/\\e/g' -e 's/^\([.'\'']\)/\\\&\1/'; }
+
+# Capture a command's help. Merge stderr: services/bundle print their usage to
+# stderr, not stdout, so stdout-only would yield an empty section. Suppress the
+# version notifier (a network-dependent stderr line) and colour to keep the
+# page byte-deterministic.
+help() { MALT_NO_VERSION_NOTIFIER=1 NO_COLOR=1 "$BIN" "$@" --help 2>&1; }
+
+# Token stream of the root --help Commands column (one per line, e.g.
+# "tap/untap", "services"). The same scrape drives coverage in the test.
+commands() {
+  help | awk '/^Commands:/{f=1;next} /^Global flags:/{f=0} f && /^  [^ ]/{print $1}'
+}
+
+emit() {
+  printf '.TH MALT 1 "malt %s" "malt %s" "malt manual"\n' "$VERSION" "$VERSION"
+
+  printf '.SH NAME\n'
+  printf 'malt \\- a fast, drop-in Homebrew alternative for macOS\n'
+
+  printf '.SH SYNOPSIS\n.nf\n'
+  printf 'malt <command> [options] [arguments]\n'
+  printf 'mt   <command> [options] [arguments]\n'
+  printf '.fi\n'
+
+  # DESCRIPTION: the root --help, minus its trailing Environment block (which
+  # gets its own section). Split on malt's own stable "Environment:" heading.
+  printf '.SH DESCRIPTION\n.nf\n'
+  help | awk '/^Environment:/{exit} {print}' | esc
+  printf '.fi\n'
+
+  printf '.SH COMMANDS\n'
+  while IFS= read -r tok; do
+    # tap/untap documents the canonical command; run its pre-slash form.
+    cmd="${tok%%/*}"
+    printf '.SS %s\n.nf\n' "$tok"
+    help "$cmd" | esc
+    printf '.fi\n'
+  done < <(commands)
+
+  printf '.SH ENVIRONMENT\n.nf\n'
+  help | awk '/^Environment:/{f=1} f{print}' | esc
+  printf '.fi\n'
+
+  printf '.SH SEE ALSO\n'
+  printf '.BR brew (1)\n'
+}
+
+mkdir -p "$(dirname "$OUT")"
+emit >"$OUT"

--- a/scripts/test/gen_man_test.sh
+++ b/scripts/test/gen_man_test.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# scripts/test/gen_man_test.sh — regression tests for scripts/gen-man.sh and
+# the `just man-check` drift guard.
+#
+# Covers the four guarantees the man-page generator exists to provide:
+#
+#   1. determinism  — two regenerations are byte-identical, and the output
+#      carries no machine-specific leaks ($HOME, $USER, wall-clock date).
+#   2. coverage     — every command in `malt --help`'s Commands column is a
+#      section in the page (the drift this approach exists to prevent).
+#   3. roff lint    — `mandoc -T lint` is clean bar the one documented,
+#      version-derived `.TH` date warning (skipped when mandoc is absent).
+#   4. man-check    — `just man-check` exits non-zero on a stale committed
+#      page and zero when it matches.
+#
+# Usage:
+#   ./scripts/test/gen_man_test.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+GEN="$ROOT/scripts/gen-man.sh"
+BIN="$ROOT/zig-out/bin/malt"
+COMMITTED="$ROOT/dist/man/malt.1"
+
+[ -x "$BIN" ] || {
+  echo "malt binary missing at $BIN — run 'zig build' first" >&2
+  exit 2
+}
+[ -x "$GEN" ] || {
+  echo "generator missing or not executable at $GEN" >&2
+  exit 2
+}
+
+TMP=$(mktemp -d /tmp/malt_gen_man_test.XXXXXX)
+# The man-check test mutates the committed page in place; the trap restores it
+# from BACKUP even if the run is interrupted before the inline restore.
+BACKUP=""
+cleanup() {
+  [ -n "$BACKUP" ] && [ -f "$BACKUP" ] && cp "$BACKUP" "$COMMITTED"
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+pass=0
+fail=0
+failures=()
+
+ok() {
+  printf '  ✓ %s\n' "$1"
+  pass=$((pass + 1))
+}
+ko() {
+  printf '  ✗ %s\n' "$1" >&2
+  fail=$((fail + 1))
+  failures+=("$1")
+}
+
+# ── 1: determinism ───────────────────────────────────────────────────
+printf '▸ determinism\n'
+"$GEN" "$TMP/a.1"
+"$GEN" "$TMP/b.1"
+if cmp -s "$TMP/a.1" "$TMP/b.1"; then
+  ok "two regenerations are byte-identical"
+else
+  ko "regenerations differ (non-deterministic output)"
+fi
+
+# No machine-specific leaks. $HOME and the username must never reach the page;
+# a wall-clock month name would also break the byte-stable diff.
+leaked=0
+grep -qF "$HOME" "$TMP/a.1" && {
+  ko "output leaks \$HOME ($HOME)"
+  leaked=1
+}
+grep -qw "$(whoami)" "$TMP/a.1" && {
+  ko "output leaks \$USER ($(whoami))"
+  leaked=1
+}
+[ "$leaked" -eq 0 ] && ok "no \$HOME/\$USER leaks in output"
+
+# ── 2: coverage ──────────────────────────────────────────────────────
+# A heading alone documents nothing — services/bundle/version emit their help
+# on stderr, so the body must be captured too. Assert each .SS section exists
+# AND carries at least one content line between its .nf/.fi.
+printf '▸ coverage\n'
+missing=0
+empty=0
+while IFS= read -r tok; do
+  if ! grep -qE "^\.SS ${tok//\//\\/}\$" "$TMP/a.1"; then
+    ko "command '$tok' has no .SS section in the page"
+    missing=1
+    continue
+  fi
+  body=$(awk -v t="$tok" '
+    $0==".SS " t {ins=1; next}
+    ins && $0==".nf" {innf=1; next}
+    ins && innf && $0==".fi" {exit}
+    ins && innf {print}
+  ' "$TMP/a.1")
+  if [ -z "$(printf '%s' "$body" | tr -d '[:space:]')" ]; then
+    ko "command '$tok' has an empty .SS body"
+    empty=1
+  fi
+done < <("$BIN" --help | awk '/^Commands:/{f=1;next} /^Global flags:/{f=0} f && /^  [^ ]/{print $1}')
+[ "$missing" -eq 0 ] && ok "every Commands-column token has a section"
+[ "$empty" -eq 0 ] && ok "every section body is non-empty"
+
+# ── 3: roff lint ─────────────────────────────────────────────────────
+printf '▸ roff lint\n'
+if command -v mandoc >/dev/null 2>&1; then
+  # The page deliberately carries a version string in the .TH date slot for
+  # byte-determinism, so mandoc emits exactly one "cannot parse date" warning.
+  # Treat that single line as expected; any other lint output is a failure.
+  lint=$(mandoc -T lint "$TMP/a.1" 2>&1 || true)
+  other=$(printf '%s\n' "$lint" | grep -v 'cannot parse date' | grep -v '^[[:space:]]*$' || true)
+  if [ -z "$other" ]; then
+    ok "mandoc -T lint clean (bar the documented date warning)"
+  else
+    ko "mandoc -T lint reported unexpected issues:"
+    printf '%s\n' "$other" >&2
+  fi
+else
+  printf '  - mandoc absent, skipping roff lint\n'
+fi
+
+# ── 4: man-check drift guard ─────────────────────────────────────────
+printf '▸ man-check\n'
+if [ -f "$COMMITTED" ]; then
+  BACKUP="$TMP/committed.bak"
+  cp "$COMMITTED" "$BACKUP"
+  restore() { cp "$BACKUP" "$COMMITTED"; }
+
+  # Matches: exit 0.
+  if (cd "$ROOT" && just man-check >/dev/null 2>&1); then
+    ok "man-check exits 0 when the committed page matches"
+  else
+    ko "man-check failed against an in-sync committed page"
+  fi
+
+  # Stale: mutate the committed page, expect non-zero.
+  printf '\n.\\" drift\n' >>"$COMMITTED"
+  rc=0
+  (cd "$ROOT" && just man-check >/dev/null 2>&1) || rc=$?
+  restore
+  if [ "$rc" -ne 0 ]; then
+    ok "man-check exits non-zero on a stale committed page"
+  else
+    ko "man-check passed a stale committed page"
+  fi
+else
+  ko "committed page missing at $COMMITTED (run 'just man-gen')"
+fi
+
+# ── summary ──────────────────────────────────────────────────────────
+printf '\n── summary ──\npass: %d\nfail: %d\n' "$pass" "$fail"
+if [ "$fail" -ne 0 ]; then
+  printf 'failures:\n'
+  for f in "${failures[@]}"; do printf '  %s\n' "$f"; done
+  exit 1
+fi


### PR DESCRIPTION
## Description

malt now ships a single `man malt` page, generated from the binary's own `--help` and committed as `dist/man/malt.1`. 

Output is deterministic (version-derived `.TH` date, no wall-clock), and no Zig source changed.

Adds `scripts/gen-man.sh`, the committed page, `just man-gen`/`man-check`, a CI drift step, and `scripts/test/gen_man_test.sh` (determinism, coverage, roff
lint, man-check behaviour).

## Related Issue

- None

## Notes for Reviewers

- None
