### PR TITLE
feat(core/services): add Schedule type and StartInterval support

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1300,7 +1300,7 @@ fn maybeRegisterService(
         .working_dir = working_dir,
         .stdout_path = stdout_path,
         .stderr_path = stderr_path,
-        .run_at_load = def.run_at_load,
+        .schedule = def.schedule,
         .keep_alive = def.keep_alive,
     };
 

--- a/src/core/formula.zig
+++ b/src/core/formula.zig
@@ -5,10 +5,21 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const service_types = @import("services/types.zig");
+pub const Schedule = service_types.Schedule;
+
 pub const FormulaError = error{
     InvalidJson,
     MissingField,
     NoBottleAvailable,
+    /// `run_type :cron` — malt can't manage calendar schedules yet, so reject
+    /// loudly rather than silently installing a run-once service.
+    UnsupportedRunType,
+    /// `run_type` is neither immediate, interval, nor cron.
+    UnknownRunType,
+    /// `run_type :interval` with a missing, non-numeric, or out-of-range
+    /// `interval`. Never falls back to `.immediate`.
+    InvalidInterval,
 };
 
 /// Bottle descriptor for one platform. All three strings live in the
@@ -31,7 +42,7 @@ pub const ServiceDef = struct {
     log_path: ?[]const u8 = null,
     error_log_path: ?[]const u8 = null,
     keep_alive: bool = true,
-    run_at_load: bool = true,
+    schedule: Schedule = .immediate,
 };
 
 /// Format Homebrew's canonical on-disk version label into `buf`.
@@ -128,6 +139,25 @@ fn getInt(obj: std.json.ObjectMap, key: []const u8) i64 {
         .integer => |i| i,
         else => 0,
     };
+}
+
+/// Map a service block's `run_type` to a `Schedule`. Absent/`"immediate"`
+/// keeps today's run-at-load behaviour; `"interval"` requires a numeric,
+/// in-range `interval`; `"cron"` and anything else are rejected loudly so a
+/// mis-scheduled service never materialises silently.
+fn parseSchedule(so: std.json.ObjectMap) FormulaError!Schedule {
+    const run_type = getString(so, "run_type") orelse return .immediate;
+    if (std.mem.eql(u8, run_type, "immediate")) return .immediate;
+    if (std.mem.eql(u8, run_type, "cron")) return FormulaError.UnsupportedRunType;
+    if (!std.mem.eql(u8, run_type, "interval")) return FormulaError.UnknownRunType;
+
+    const iv = so.get("interval") orelse return FormulaError.InvalidInterval;
+    const secs = switch (iv) {
+        .integer => |n| n,
+        else => return FormulaError.InvalidInterval,
+    };
+    if (secs < 1 or secs > service_types.max_interval_secs) return FormulaError.InvalidInterval;
+    return .{ .interval = @intCast(secs) };
 }
 
 fn getStringArray(allocator: std.mem.Allocator, obj: std.json.ObjectMap, key: []const u8) ![]const []const u8 {
@@ -234,10 +264,7 @@ pub fn parseFormula(allocator: std.mem.Allocator, json_data: []const u8) !Formul
                             (k != .bool or k.bool)
                         else
                             true,
-                        .run_at_load = if (so.get("run_at_load")) |k|
-                            (k == .bool and k.bool)
-                        else
-                            true,
+                        .schedule = try parseSchedule(so),
                     };
                 };
             }

--- a/src/core/services/plist.zig
+++ b/src/core/services/plist.zig
@@ -7,6 +7,10 @@ const std = @import("std");
 const testing = std.testing;
 
 const dsl_sandbox = @import("../dsl/sandbox.zig");
+const types = @import("types.zig");
+
+pub const Schedule = types.Schedule;
+pub const CalendarInterval = types.CalendarInterval;
 
 pub const EnvPair = struct {
     key: []const u8,
@@ -20,7 +24,7 @@ pub const ServiceSpec = struct {
     env: []const EnvPair = &.{},
     stdout_path: []const u8,
     stderr_path: []const u8,
-    run_at_load: bool = true,
+    schedule: Schedule = .immediate,
     keep_alive: bool = true,
 };
 
@@ -47,12 +51,16 @@ pub const ValidationError = error{
     EmbeddedNul,
     /// program_args[0] is not an absolute path.
     RelativeExecutable,
+    /// schedule is `.interval` with a zero or out-of-range second count.
+    BadSchedule,
 };
 
 /// Cap on argv count. Real launchd services carry fewer than a dozen.
 pub const max_program_args: usize = 64;
 /// Cap on a single argv or path string.
 pub const max_arg_len: usize = 4096;
+/// Upper bound on an interval schedule, in seconds (shared with the parser).
+pub const max_interval_secs = types.max_interval_secs;
 
 /// The Homebrew API renders every service path with this literal token rather
 /// than the resolved prefix (`$HOMEBREW_PREFIX/opt/redis/bin/redis-server`).
@@ -107,6 +115,14 @@ pub fn validate(
 ) ValidationError!void {
     if (spec.program_args.len == 0) return ValidationError.Empty;
     if (spec.program_args.len > max_program_args) return ValidationError.TooManyArgs;
+
+    switch (spec.schedule) {
+        .immediate => {},
+        .interval => |secs| if (secs == 0 or secs > max_interval_secs)
+            return ValidationError.BadSchedule,
+        // No rules yet; the parser never builds this and render rejects it.
+        .calendar => {},
+    }
 
     for (spec.program_args) |a| try checkString(a);
     try checkString(spec.label);
@@ -197,18 +213,31 @@ pub fn render(spec: ServiceSpec, writer: *std.Io.Writer) !void {
     try writeEscaped(writer, spec.stderr_path);
     try writer.writeAll("</string>\n");
 
-    try writer.writeAll("    <key>RunAtLoad</key>\n    ");
-    try writer.writeAll(if (spec.run_at_load) "<true/>\n" else "<false/>\n");
-
-    if (spec.keep_alive) {
-        try writer.writeAll(
-            \\    <key>KeepAlive</key>
-            \\    <dict>
-            \\        <key>SuccessfulExit</key>
-            \\        <false/>
-            \\    </dict>
-            \\
-        );
+    // RunAtLoad is derived from the schedule. An interval job also gets a
+    // StartInterval and, deliberately, no KeepAlive: relaunch-on-exit would
+    // restart it immediately and defeat the interval.
+    switch (spec.schedule) {
+        .immediate => {
+            try writer.writeAll("    <key>RunAtLoad</key>\n    <true/>\n");
+            if (spec.keep_alive) {
+                try writer.writeAll(
+                    \\    <key>KeepAlive</key>
+                    \\    <dict>
+                    \\        <key>SuccessfulExit</key>
+                    \\        <false/>
+                    \\    </dict>
+                    \\
+                );
+            }
+        },
+        .interval => |secs| {
+            try writer.writeAll("    <key>RunAtLoad</key>\n    <false/>\n");
+            try writer.writeAll("    <key>StartInterval</key>\n    <integer>");
+            try writer.print("{d}", .{secs});
+            try writer.writeAll("</integer>\n");
+        },
+        // Reserved for cron support; the parser never builds this yet.
+        .calendar => unreachable,
     }
 
     try writer.writeAll("</dict>\n</plist>\n");

--- a/src/core/services/types.zig
+++ b/src/core/services/types.zig
@@ -1,0 +1,29 @@
+//! malt — service schedule model
+//!
+//! A std-only leaf shared by the formula parser and the plist emitter, so
+//! neither side has to import the other just to name a schedule.
+
+/// One launchd `StartCalendarInterval` entry. Defined now so adding cron
+/// support is purely additive; unused until then.
+pub const CalendarInterval = struct {
+    minute: ?u8 = null,
+    hour: ?u8 = null,
+    day: ?u8 = null,
+    weekday: ?u8 = null,
+    month: ?u8 = null,
+};
+
+/// How a service is scheduled under launchd.
+pub const Schedule = union(enum) {
+    /// `RunAtLoad true`, no interval — run once when loaded (today's default).
+    immediate,
+    /// `RunAtLoad false` + `StartInterval <secs>`.
+    interval: u32,
+    /// `StartCalendarInterval` — not emitted yet; reserved for cron support.
+    calendar: []const CalendarInterval,
+};
+
+/// Upper bound on a `StartInterval`, in seconds. A year is far beyond any
+/// real periodic service while keeping the value a small bounded integer —
+/// the same value gates both the parser and `plist.validate`.
+pub const max_interval_secs: u32 = 365 * 24 * 60 * 60;

--- a/tests/formula_test.zig
+++ b/tests/formula_test.zig
@@ -268,6 +268,91 @@ test "parse formula with realistic Homebrew API service shape" {
     try testing.expect(svc.keep_alive);
 }
 
+// Wrap a `service` block in an otherwise-minimal formula and parse it, so the
+// schedule tests vary only the part under test.
+fn parseWithService(alloc: std.mem.Allocator, service_block: []const u8) !formula_mod.Formula {
+    const json = try std.fmt.allocPrint(alloc,
+        \\{{
+        \\  "name": "svc", "full_name": "svc", "tap": "homebrew/core",
+        \\  "desc": "", "homepage": "", "revision": 0, "keg_only": false,
+        \\  "post_install_defined": false, "versions": {{ "stable": "1.0" }},
+        \\  "dependencies": [], "oldnames": [], "bottle": {{}},
+        \\  "service": {{ "run": ["/opt/malt/opt/svc/bin/svc"]{s} }}
+        \\}}
+    , .{service_block});
+    return formula_mod.parseFormula(alloc, json);
+}
+
+test "parse run_type interval builds an interval schedule" {
+    var arena = testArena();
+    defer arena.deinit();
+    var formula = try parseWithService(arena.allocator(), ", \"run_type\": \"interval\", \"interval\": 300");
+    defer formula.deinit();
+    const svc = formula.service orelse return error.TestExpectedSomething;
+    try testing.expectEqual(formula_mod.Schedule{ .interval = 300 }, svc.schedule);
+}
+
+test "parse run_type immediate yields immediate schedule" {
+    var arena = testArena();
+    defer arena.deinit();
+    var formula = try parseWithService(arena.allocator(), ", \"run_type\": \"immediate\"");
+    defer formula.deinit();
+    const svc = formula.service orelse return error.TestExpectedSomething;
+    try testing.expectEqual(formula_mod.Schedule.immediate, svc.schedule);
+}
+
+test "parse absent run_type defaults to immediate" {
+    var arena = testArena();
+    defer arena.deinit();
+    var formula = try parseWithService(arena.allocator(), "");
+    defer formula.deinit();
+    const svc = formula.service orelse return error.TestExpectedSomething;
+    try testing.expectEqual(formula_mod.Schedule.immediate, svc.schedule);
+}
+
+test "parse run_type cron is rejected loudly" {
+    var arena = testArena();
+    defer arena.deinit();
+    try testing.expectError(
+        error.UnsupportedRunType,
+        parseWithService(arena.allocator(), ", \"run_type\": \"cron\""),
+    );
+}
+
+test "parse unknown run_type is a hard error" {
+    var arena = testArena();
+    defer arena.deinit();
+    try testing.expectError(
+        error.UnknownRunType,
+        parseWithService(arena.allocator(), ", \"run_type\": \"sometimes\""),
+    );
+}
+
+test "parse interval run_type with a malformed interval is a hard error" {
+    var arena = testArena();
+    defer arena.deinit();
+    const malformed = [_][]const u8{
+        ", \"run_type\": \"interval\"", // missing interval
+        ", \"run_type\": \"interval\", \"interval\": \"300\"", // non-numeric
+        ", \"run_type\": \"interval\", \"interval\": 0", // zero, out of range
+        ", \"run_type\": \"interval\", \"interval\": -5", // negative
+        ", \"run_type\": \"interval\", \"interval\": 31536001", // one past the cap
+    };
+    for (malformed) |block| {
+        try testing.expectError(error.InvalidInterval, parseWithService(arena.allocator(), block));
+    }
+}
+
+test "parse interval at the cap is accepted" {
+    var arena = testArena();
+    defer arena.deinit();
+    // max_interval_secs == 365 days in seconds; the boundary must parse, not reject.
+    var formula = try parseWithService(arena.allocator(), ", \"run_type\": \"interval\", \"interval\": 31536000");
+    defer formula.deinit();
+    const svc = formula.service orelse return error.TestExpectedSomething;
+    try testing.expectEqual(formula_mod.Schedule{ .interval = 31_536_000 }, svc.schedule);
+}
+
 test "formula without service block has null service" {
     var arena = testArena();
     defer arena.deinit();

--- a/tests/services_plist_test.zig
+++ b/tests/services_plist_test.zig
@@ -61,7 +61,6 @@ test "render full spec with env and working_dir" {
         },
         .stdout_path = "/opt/malt/var/log/postgresql@16.out",
         .stderr_path = "/opt/malt/var/log/postgresql@16.err",
-        .run_at_load = true,
         .keep_alive = true,
     };
     try plist.render(spec, &aw.writer);
@@ -86,6 +85,47 @@ test "XML-escapes special characters" {
 
     try testing.expect(std.mem.indexOf(u8, aw.written(), "&lt;ampersand&amp;test&gt;") != null);
     try testing.expect(std.mem.indexOf(u8, aw.written(), "a&quot;b.log") != null);
+}
+
+test "render interval schedule emits StartInterval and RunAtLoad false" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    const spec: plist.ServiceSpec = .{
+        .label = "com.malt.backup",
+        .program_args = &.{"/opt/malt/opt/backup/bin/backup"},
+        .stdout_path = "/opt/malt/var/log/backup.out",
+        .stderr_path = "/opt/malt/var/log/backup.err",
+        .schedule = .{ .interval = 300 },
+        // keep_alive is irrelevant for interval jobs — it must not appear.
+        .keep_alive = true,
+    };
+    try plist.render(spec, &aw.writer);
+
+    const expected =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\    <key>Label</key>
+        \\    <string>com.malt.backup</string>
+        \\    <key>ProgramArguments</key>
+        \\    <array>
+        \\        <string>/opt/malt/opt/backup/bin/backup</string>
+        \\    </array>
+        \\    <key>StandardOutPath</key>
+        \\    <string>/opt/malt/var/log/backup.out</string>
+        \\    <key>StandardErrorPath</key>
+        \\    <string>/opt/malt/var/log/backup.err</string>
+        \\    <key>RunAtLoad</key>
+        \\    <false/>
+        \\    <key>StartInterval</key>
+        \\    <integer>300</integer>
+        \\</dict>
+        \\</plist>
+        \\
+    ;
+    try testing.expectEqualStrings(expected, aw.written());
 }
 
 test "keep_alive false omits KeepAlive dict" {

--- a/tests/services_validate_test.zig
+++ b/tests/services_validate_test.zig
@@ -172,3 +172,35 @@ test "validate: raw $HOMEBREW_PREFIX head rejected, expanded head passes" {
         .stderr_path = good_err,
     }, cellar, prefix);
 }
+
+// validate is the single gate before launchd; the interval bound is enforced
+// here too, independently of the parser, so a spec built any other way is caught.
+fn validateWithSchedule(sched: plist.Schedule) anyerror!void {
+    const args = [_][]const u8{"/opt/malt/Cellar/foo/1.0/bin/foo"};
+    return plist.validate(.{
+        .label = "com.malt.foo",
+        .program_args = args[0..],
+        .stdout_path = good_out,
+        .stderr_path = good_err,
+        .schedule = sched,
+    }, cellar, prefix);
+}
+
+test "validate: in-range interval passes" {
+    try validateWithSchedule(.{ .interval = 300 });
+}
+
+test "validate: zero interval rejected" {
+    try testing.expectError(error.BadSchedule, validateWithSchedule(.{ .interval = 0 }));
+}
+
+test "validate: interval above the cap rejected" {
+    try testing.expectError(
+        error.BadSchedule,
+        validateWithSchedule(.{ .interval = plist.max_interval_secs + 1 }),
+    );
+}
+
+test "validate: interval at the cap passes" {
+    try validateWithSchedule(.{ .interval = plist.max_interval_secs });
+}

--- a/tests/supervisor_pure_test.zig
+++ b/tests/supervisor_pure_test.zig
@@ -106,7 +106,6 @@ test "register writes a plist and a DB row that list reports back" {
         .program_args = &.{ "/tmp/malt_sup_register/Cellar/testkeg/1.0/bin/echo", "hi" },
         .working_dir = null,
         .env = &.{},
-        .run_at_load = false,
         .keep_alive = false,
         .stdout_path = "/tmp/malt_sup_register/out.log",
         .stderr_path = "/tmp/malt_sup_register/err.log",
@@ -127,6 +126,62 @@ test "register writes a plist and a DB row that list reports back" {
     // plist file exists on disk
     var f = try test_io.openFileAbsolute(std.Options.debug_io, list[0].plist_path, .{});
     f.close(std.Options.debug_io);
+}
+
+test "register writes an interval plist with StartInterval and RunAtLoad false" {
+    const prefix = "/tmp/malt_sup_interval";
+    const cellar = "/tmp/malt_sup_interval/Cellar/testkeg/1.0";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    _ = c.setenv("MALT_PREFIX", prefix, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    const spec = plist_mod.ServiceSpec{
+        .label = "com.malt.test.interval",
+        .program_args = &.{"/tmp/malt_sup_interval/Cellar/testkeg/1.0/bin/backup"},
+        .stdout_path = "/tmp/malt_sup_interval/out.log",
+        .stderr_path = "/tmp/malt_sup_interval/err.log",
+        .schedule = .{ .interval = 3600 },
+    };
+    const ctx: supervisor.SupervisorCtx = .{ .allocator = testing.allocator, .io = std.Options.debug_io, .db = &db };
+    try supervisor.register(ctx, spec, "testkeg", true, cellar, prefix);
+
+    const list = try supervisor.list(ctx);
+    defer supervisor.freeServiceInfos(testing.allocator, list);
+    try testing.expectEqual(@as(usize, 1), list.len);
+
+    // The plist that landed on disk through the real validate→render path
+    // must carry the interval, not a run-at-load fallback.
+    const xml = try test_io.readFileAbsoluteAlloc(std.Options.debug_io, testing.allocator, list[0].plist_path, 64 * 1024);
+    defer testing.allocator.free(xml);
+    try testing.expect(std.mem.indexOf(u8, xml, "<key>StartInterval</key>") != null);
+    try testing.expect(std.mem.indexOf(u8, xml, "<integer>3600</integer>") != null);
+    try testing.expect(std.mem.indexOf(u8, xml, "<key>RunAtLoad</key>\n    <false/>") != null);
+    try testing.expect(std.mem.indexOf(u8, xml, "KeepAlive") == null);
+}
+
+test "register rejects an out-of-range interval via the validate gate" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    const prefix = "/tmp/malt_sup_badsched";
+    const cellar = "/tmp/malt_sup_badsched/Cellar/testkeg/1.0";
+    const spec = plist_mod.ServiceSpec{
+        .label = "com.malt.test.badsched",
+        .program_args = &.{"/tmp/malt_sup_badsched/Cellar/testkeg/1.0/bin/svc"},
+        .stdout_path = "/tmp/malt_sup_badsched/out.log",
+        .stderr_path = "/tmp/malt_sup_badsched/err.log",
+        .schedule = .{ .interval = 0 },
+    };
+    const ctx: supervisor.SupervisorCtx = .{ .allocator = testing.allocator, .io = std.Options.debug_io, .db = &db };
+    // validate is the single gate; a zero interval must never reach disk or the DB.
+    try testing.expectError(error.InvalidService, supervisor.register(ctx, spec, "testkeg", true, cellar, prefix));
+    try testing.expect(!supervisor.hasService(&db, "com.malt.test.badsched"));
 }
 
 test "tailLog writes the last N lines into the provided writer" {


### PR DESCRIPTION
## Description

malt can now manage interval-scheduled services. A formula's `run_type :interval` is parsed into a first-class Schedule and emitted as launchd `StartInterval`, instead of being silently dropped to run-once-at-load. `run_type :cron` is now rejected loudly so users know malt can't manage it yet rather than getting wrong semantics, and a malformed interval block fails at install rather than materialising a mis-scheduled agent. `:immediate` services are byte-identical to before. Schedule values are validated at parse and again at the single plist gate, and only reach the generated XML as integers - there is no injection surface.

## Related Issue

- None

## Notes for Reviewers

- None
