### PR TITLE
fix(migrate): migrate renamed homebrew-core kegs instead of failing

### DIFF
--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -253,16 +253,18 @@ pub fn migrateKeg(
     return .migrated;
 }
 
-/// Copy-from-Cellar fallback for kegs the brew API can't resolve
-/// (private/third-party taps). Locates `<homebrew_prefix>/Cellar/<name>/`,
-/// picks the version subdir whose `INSTALL_RECEIPT.json` mtime is
-/// newest (matches brew's "current" version when multiples are present),
-/// reads the receipt, and — if the recorded tap is non-core — copies
-/// the keg tree into malt's Cellar via the same relocation pipeline
-/// the bottle path uses. A `homebrew/core` keg that's missing from
-/// the API is treated as a real API problem, not a fallback case:
-/// returning `.failed_api` keeps the user's attention on the brew side
-/// instead of papering over an upstream outage with a stale local copy.
+/// Copy-from-Cellar fallback for kegs the brew API can't resolve. Locates
+/// `<homebrew_prefix>/Cellar/<name>/`, picks the version subdir whose
+/// `INSTALL_RECEIPT.json` mtime is newest (matches brew's "current" version
+/// when multiples are present), reads the receipt, and copies the keg tree
+/// into malt's Cellar via the same relocation pipeline the bottle path uses.
+///
+/// This covers two cases that both reach here only on a clean `NotFound`:
+/// private/third-party taps (never in the API), and `homebrew/core` kegs
+/// renamed/aliased/removed upstream (e.g. `sdl2`, now an alias of
+/// `sdl2-compat`). A clean 404 is *not* an outage — outages surface as
+/// `ApiUnreachable` and never reach this fallback — so the locally-installed
+/// keg is the authoritative artifact to migrate, whatever its tap.
 fn migrateFromLocalCellar(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
@@ -288,10 +290,6 @@ fn migrateFromLocalCellar(
     };
     defer receipt.deinit();
 
-    if (install_receipt_mod.isCoreTap(receipt.tap)) {
-        output.err("  {s}: not found in Homebrew API (homebrew/core keg — refusing local-Cellar fallback)", .{keg_name});
-        return .failed_api;
-    }
     if (receipt.version.len == 0) {
         output.err("  {s}: INSTALL_RECEIPT.json has no source.versions.stable", .{keg_name});
         return .failed_api;

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -2390,6 +2390,136 @@ test "tap fallback stays silent when the tap formula has no post_install" {
     try testing.expect(!containsLine(stderr_buf.items, "post_install"));
 }
 
+// ── Renamed/aliased homebrew/core keg migrates from the local copy ──────
+//
+// A core keg whose name 404s on the brew API (renamed/aliased upstream, e.g.
+// `sdl2` → alias of `sdl2-compat`) is still installed locally. A clean 404 is
+// not an API outage — outages surface as ApiUnreachable and never reach the
+// fallback — so the locally-installed keg is the authoritative artifact and
+// must migrate, not be reported as a failure.
+
+test "renamed homebrew/core keg migrates from the local Cellar copy" {
+    resetOutput();
+    const brew = try scratchDir("brew_core_renamed");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, brew) catch {};
+        testing.allocator.free(brew);
+    }
+
+    const mt_z: [:0]const u8 = "/tmp/mt_core_renamed";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, mt_z) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, mt_z);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, mt_z) catch {};
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // Core keg present locally with a receipt; no tap .rb (core kegs carry none).
+    const keg_dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/widget/2.0", .{brew});
+    defer testing.allocator.free(keg_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, keg_dir);
+    const receipt_path = try std.fmt.allocPrint(testing.allocator, "{s}/INSTALL_RECEIPT.json", .{keg_dir});
+    defer testing.allocator.free(receipt_path);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, receipt_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io,
+            \\{"source":{"tap":"homebrew/core","versions":{"stable":"2.0"}}}
+        );
+    }
+
+    // 404 marker → fetchFormula returns NotFound offline, routing to the fallback.
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{mt_z});
+    defer testing.allocator.free(cache_api);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_api);
+    const marker = try std.fmt.allocPrint(testing.allocator, "{s}/formula_widget.404", .{cache_api});
+    defer testing.allocator.free(marker);
+    (try test_io.createFileAbsolute(std.Options.debug_io, marker, .{})).close(std.Options.debug_io);
+
+    output.setMode(.json);
+    defer resetOutput();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = malt.app_ctx.processEnviron() };
+    try migrate.execute(&ctx, arena.allocator(), &.{});
+
+    const parsed = try parseAndCheck(buf.items);
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try testing.expectEqual(@as(usize, 1), root.get("migrated").?.array.items.len);
+    try testing.expectEqualStrings("widget", root.get("migrated").?.array.items[0].string);
+    try testing.expectEqual(@as(usize, 0), root.get("failed").?.array.items.len);
+}
+
+test "core keg with a malformed receipt still fails after the core guard is gone" {
+    resetOutput();
+    const brew = try scratchDir("brew_core_bad_receipt");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, brew) catch {};
+        testing.allocator.free(brew);
+    }
+
+    const mt_z: [:0]const u8 = "/tmp/mt_core_badrcpt";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, mt_z) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, mt_z);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, mt_z) catch {};
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    const keg_dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/widget/2.0", .{brew});
+    defer testing.allocator.free(keg_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, keg_dir);
+    const receipt_path = try std.fmt.allocPrint(testing.allocator, "{s}/INSTALL_RECEIPT.json", .{keg_dir});
+    defer testing.allocator.free(receipt_path);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, receipt_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "{ not json");
+    }
+
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{mt_z});
+    defer testing.allocator.free(cache_api);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_api);
+    const marker = try std.fmt.allocPrint(testing.allocator, "{s}/formula_widget.404", .{cache_api});
+    defer testing.allocator.free(marker);
+    (try test_io.createFileAbsolute(std.Options.debug_io, marker, .{})).close(std.Options.debug_io);
+
+    output.setMode(.json);
+    defer resetOutput();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+    io_mod.beginStdoutCapture(testing.allocator, &buf);
+    defer io_mod.endStdoutCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = malt.app_ctx.processEnviron() };
+    try migrate.execute(&ctx, arena.allocator(), &.{});
+
+    const parsed = try parseAndCheck(buf.items);
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try testing.expectEqual(@as(usize, 0), root.get("migrated").?.array.items.len);
+    try testing.expectEqual(@as(usize, 1), root.get("failed").?.array.items.len);
+    try testing.expectEqualStrings("widget", root.get("failed").?.array.items[0].string);
+}
+
 // ── post_install drain runs only after every keg's linkOpt ──────────────
 //
 // Two kegs migrate via the parallel pool; each tap formula's post_install


### PR DESCRIPTION
## Description

`malt migrate` no longer aborts on a homebrew-core formula that was renamed or aliased upstream. Such a formula (for example `sdl2`, now a Homebrew alias of `sdl2-compat`) returns a 404 from the brew API even though it is still installed locally. Previously malt reported it as an API failure and failed the whole migration run. malt now migrates it from the local Cellar copy, the artifact the user actually has, the same way it already handles third-party-tap kegs.

The change is safe because a clean 404 is not an API outage: outages surface as a different error and never reach this fallback, so a 404 on an installed core keg means the formula was renamed/aliased/removed upstream and the local keg is the authoritative thing to migrate. Receipt validation still applies, so a core keg with a missing or malformed receipt still fails rather than being silently copied.

## Related Issue

- None

## Notes for Reviewers

- None
