### PR TITLE
feat(core/services): support run_type :cron via StartCalendarInterval

### DIFF
--- a/src/core/formula.zig
+++ b/src/core/formula.zig
@@ -6,15 +6,13 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 const service_types = @import("services/types.zig");
+const cron = @import("services/cron.zig");
 pub const Schedule = service_types.Schedule;
 
 pub const FormulaError = error{
     InvalidJson,
     MissingField,
     NoBottleAvailable,
-    /// `run_type :cron` — malt can't manage calendar schedules yet, so reject
-    /// loudly rather than silently installing a run-once service.
-    UnsupportedRunType,
     /// `run_type` is neither immediate, interval, nor cron.
     UnknownRunType,
     /// `run_type :interval` with a missing, non-numeric, or out-of-range
@@ -143,12 +141,17 @@ fn getInt(obj: std.json.ObjectMap, key: []const u8) i64 {
 
 /// Map a service block's `run_type` to a `Schedule`. Absent/`"immediate"`
 /// keeps today's run-at-load behaviour; `"interval"` requires a numeric,
-/// in-range `interval`; `"cron"` and anything else are rejected loudly so a
-/// mis-scheduled service never materialises silently.
-fn parseSchedule(so: std.json.ObjectMap) FormulaError!Schedule {
+/// in-range `interval`; `"cron"` parses its expression into calendar entries;
+/// anything else is rejected loudly so a mis-scheduled service never
+/// materialises silently. Calendar entries are allocated in `arena`.
+fn parseSchedule(arena: std.mem.Allocator, so: std.json.ObjectMap) !Schedule {
     const run_type = getString(so, "run_type") orelse return .immediate;
     if (std.mem.eql(u8, run_type, "immediate")) return .immediate;
-    if (std.mem.eql(u8, run_type, "cron")) return FormulaError.UnsupportedRunType;
+    if (std.mem.eql(u8, run_type, "cron")) {
+        // A missing `cron` string is a hard error, never a silent fallback.
+        const expr = getString(so, "cron") orelse return cron.CronError.CronMalformed;
+        return .{ .calendar = try cron.parseCron(arena, expr) };
+    }
     if (!std.mem.eql(u8, run_type, "interval")) return FormulaError.UnknownRunType;
 
     const iv = so.get("interval") orelse return FormulaError.InvalidInterval;
@@ -264,7 +267,7 @@ pub fn parseFormula(allocator: std.mem.Allocator, json_data: []const u8) !Formul
                             (k != .bool or k.bool)
                         else
                             true,
-                        .schedule = try parseSchedule(so),
+                        .schedule = try parseSchedule(arena, so),
                     };
                 };
             }

--- a/src/core/services/cron.zig
+++ b/src/core/services/cron.zig
@@ -1,0 +1,327 @@
+//! malt — cron expression parser for launchd StartCalendarInterval
+//!
+//! Parses the 5-field cron grammar (minute hour day-of-month month
+//! day-of-week) into one or more launchd CalendarInterval entries. Only the
+//! subset launchd can represent is accepted; lists/steps/ranges enumerate into
+//! the cartesian product of dicts (an absent field means "every"). Anything
+//! launchd cannot express — named days/months, @macros, ?/L/W — is rejected
+//! loudly so a schedule is never silently approximated. Field bounds are
+//! validated here so every emitted value is a known-safe integer.
+
+const std = @import("std");
+const testing = std.testing;
+
+const types = @import("types.zig");
+
+pub const CalendarInterval = types.CalendarInterval;
+
+pub const CronError = error{
+    /// Wrong field count, an empty field, or an unparseable number/range.
+    CronMalformed,
+    /// A value sits outside its field's range (e.g. minute 60).
+    CronOutOfRange,
+    /// A token launchd cannot represent: named days/months, @macros, ?, L, W.
+    CronUnsupported,
+    /// The list/step/range expansion exceeds max_calendar_entries.
+    CronTooComplex,
+} || std.mem.Allocator.Error;
+
+/// Cap on enumerated CalendarInterval entries; shared with `plist.validate`.
+pub const max_calendar_entries = types.max_calendar_entries;
+
+const FieldSpec = struct { min: u8, max: u8 };
+
+/// Inclusive bounds per cron field, in grammar order:
+/// minute hour day-of-month month day-of-week. Weekday allows 7 (Sunday)
+/// which is canonicalised to 0 during parsing.
+const field_specs = [5]FieldSpec{
+    .{ .min = 0, .max = 59 }, // minute
+    .{ .min = 0, .max = 23 }, // hour
+    .{ .min = 1, .max = 31 }, // day-of-month
+    .{ .min = 1, .max = 12 }, // month
+    .{ .min = 0, .max = 7 }, // day-of-week
+};
+
+pub fn parseCron(allocator: std.mem.Allocator, expr: []const u8) CronError![]CalendarInterval {
+    const trimmed = std.mem.trim(u8, expr, " \t");
+    if (trimmed.len == 0) return CronError.CronMalformed;
+    // @macros (@daily, @reboot, …) replace the whole expression; launchd has
+    // no equivalent, so reject before field splitting would call them malformed.
+    if (trimmed[0] == '@') return CronError.CronUnsupported;
+
+    var fields: [5][]const u8 = undefined;
+    var n: usize = 0;
+    var it = std.mem.tokenizeAny(u8, trimmed, " \t");
+    while (it.next()) |f| {
+        if (n == 5) return CronError.CronMalformed; // too many fields
+        fields[n] = f;
+        n += 1;
+    }
+    if (n != 5) return CronError.CronMalformed;
+
+    // A null set is a wildcard (`*`); a concrete set is the field's value list.
+    var sets: [5]?Set = undefined;
+    for (fields, 0..) |f, i| sets[i] = try parseField(f, field_specs[i], i == 4);
+
+    // launchd ORs an array of dicts, so a cron list/step/range becomes the
+    // cartesian product of the per-field value sets (wildcards contribute one
+    // "every" slot each). The entry count is that product.
+    var count: usize = 1;
+    for (sets) |maybe| {
+        if (maybe) |s| count *= s.count();
+    }
+    if (count > max_calendar_entries) return CronError.CronTooComplex;
+
+    const out = try allocator.alloc(CalendarInterval, count);
+    fillEntries(sets, out);
+    return out;
+}
+
+const Set = std.StaticBitSet(64);
+
+/// Parse one field into a value set, or null for `*` (launchd's "every").
+/// Comma-separated parts each contribute their values to the set.
+fn parseField(field: []const u8, spec: FieldSpec, is_weekday: bool) CronError!?Set {
+    if (field.len == 0) return CronError.CronMalformed;
+    if (field.len == 1 and field[0] == '*') return null;
+
+    var set = Set.initEmpty();
+    var it = std.mem.splitScalar(u8, field, ',');
+    while (it.next()) |part| try parsePart(part, spec, is_weekday, &set);
+    if (set.count() == 0) return CronError.CronMalformed;
+    return set;
+}
+
+/// Add one comma-list part's values to `set`. A part is a single literal,
+/// an inclusive range `a-b`, or either of those with a step `.../N` (where
+/// a bare `*` base spans the field's whole range).
+fn parsePart(part: []const u8, spec: FieldSpec, is_weekday: bool, set: *Set) CronError!void {
+    if (part.len == 0) return CronError.CronMalformed;
+
+    var base = part;
+    var step: u8 = 1;
+    if (std.mem.indexOfScalar(u8, part, '/')) |slash| {
+        base = part[0..slash];
+        step = try parseNum(part[slash + 1 ..]);
+        if (step == 0) return CronError.CronMalformed;
+    }
+
+    var lo: u8 = undefined;
+    var hi: u8 = undefined;
+    if (base.len == 1 and base[0] == '*') {
+        lo = spec.min;
+        hi = spec.max;
+    } else if (std.mem.indexOfScalar(u8, base, '-')) |dash| {
+        lo = try parseNum(base[0..dash]);
+        hi = try parseNum(base[dash + 1 ..]);
+    } else {
+        lo = try parseNum(base);
+        hi = lo;
+    }
+    if (lo < spec.min or hi > spec.max or lo > hi) return CronError.CronOutOfRange;
+
+    // launchd and cron both treat weekday 7 as Sunday; fold it onto 0 so the
+    // emitted value is canonical and `0,7` dedups to one entry. The accumulator
+    // is widened so a large step can't overflow u8 mid-stride (hi ≤ 59).
+    var v: usize = lo;
+    while (v <= hi) : (v += step) {
+        const canon: u8 = if (is_weekday and v == 7) 0 else @intCast(v);
+        set.set(canon);
+    }
+}
+
+fn parseNum(s: []const u8) CronError!u8 {
+    if (s.len == 0) return CronError.CronMalformed;
+    // Non-digit bytes are names / Quartz tokens (MON, ?, L, 15W) launchd can't
+    // express; an overflow is a value far past any field's range.
+    return std.fmt.parseInt(u8, s, 10) catch |e| switch (e) {
+        error.InvalidCharacter => CronError.CronUnsupported,
+        error.Overflow => CronError.CronOutOfRange,
+    };
+}
+
+/// Materialise the cartesian product of the field sets into `out` (length
+/// already equals the product). Wildcard fields emit null; others step through
+/// their values via an odometer with the weekday field varying fastest.
+fn fillEntries(sets: [5]?Set, out: []CalendarInterval) void {
+    var values: [5][64]u8 = undefined;
+    var lens: [5]usize = undefined;
+    var wild: [5]bool = undefined;
+    for (sets, 0..) |maybe, i| {
+        if (maybe) |s| {
+            wild[i] = false;
+            var m: usize = 0;
+            var bit: usize = 0;
+            while (bit < 64) : (bit += 1) {
+                if (s.isSet(bit)) {
+                    values[i][m] = @intCast(bit);
+                    m += 1;
+                }
+            }
+            lens[i] = m;
+        } else {
+            wild[i] = true;
+            lens[i] = 1; // single "every" slot
+        }
+    }
+
+    var idx = [_]usize{0} ** 5;
+    var oi: usize = 0;
+    while (oi < out.len) : (oi += 1) {
+        var v: [5]?u8 = undefined;
+        for (0..5) |i| v[i] = if (wild[i]) null else values[i][idx[i]];
+        out[oi] = .{
+            .minute = v[0],
+            .hour = v[1],
+            .day = v[2],
+            .month = v[3],
+            .weekday = v[4],
+        };
+        var k: usize = 5;
+        while (k > 0) {
+            k -= 1;
+            idx[k] += 1;
+            if (idx[k] < lens[k]) break;
+            idx[k] = 0;
+        }
+    }
+}
+
+test "parseCron literal fields and * build a single dict" {
+    const out = try parseCron(testing.allocator, "30 4 * * *");
+    defer testing.allocator.free(out);
+    try testing.expectEqual(@as(usize, 1), out.len);
+    try testing.expectEqual(@as(?u8, 30), out[0].minute);
+    try testing.expectEqual(@as(?u8, 4), out[0].hour);
+    try testing.expectEqual(@as(?u8, null), out[0].day);
+    try testing.expectEqual(@as(?u8, null), out[0].month);
+    try testing.expectEqual(@as(?u8, null), out[0].weekday);
+}
+
+test "parseCron all-wildcard yields one every-minute entry with no fields set" {
+    // `* * * * *` is "every minute": a single dict with every field absent.
+    const out = try parseCron(testing.allocator, "* * * * *");
+    defer testing.allocator.free(out);
+    try testing.expectEqual(@as(usize, 1), out.len);
+    try testing.expectEqual(CalendarInterval{}, out[0]);
+}
+
+test "parseCron expands two list fields into their cartesian product" {
+    // launchd ORs dicts, so two lists must enumerate every combination.
+    const out = try parseCron(testing.allocator, "0,30 0,12 * * *");
+    defer testing.allocator.free(out);
+    try testing.expectEqual(@as(usize, 4), out.len);
+    const want = [_][2]u8{ .{ 0, 0 }, .{ 0, 12 }, .{ 30, 0 }, .{ 30, 12 } };
+    for (out, want) |e, w| {
+        try testing.expectEqual(@as(?u8, w[0]), e.minute);
+        try testing.expectEqual(@as(?u8, w[1]), e.hour);
+    }
+}
+
+test "parseCron comma list expands one field into multiple dicts" {
+    const out = try parseCron(testing.allocator, "0,30 12 * * *");
+    defer testing.allocator.free(out);
+    try testing.expectEqual(@as(usize, 2), out.len);
+    try testing.expectEqual(@as(?u8, 0), out[0].minute);
+    try testing.expectEqual(@as(?u8, 30), out[1].minute);
+    // Non-list fields repeat across every expanded entry.
+    for (out) |e| try testing.expectEqual(@as(?u8, 12), e.hour);
+}
+
+test "parseCron range a-b enumerates each value" {
+    const out = try parseCron(testing.allocator, "0 0 * * 1-5");
+    defer testing.allocator.free(out);
+    try testing.expectEqual(@as(usize, 5), out.len);
+    for (out, 0..) |e, i| try testing.expectEqual(@as(?u8, @intCast(i + 1)), e.weekday);
+}
+
+test "parseCron step over wildcard enumerates the stride" {
+    const out = try parseCron(testing.allocator, "*/15 * * * *");
+    defer testing.allocator.free(out);
+    try testing.expectEqual(@as(usize, 4), out.len);
+    const want = [_]u8{ 0, 15, 30, 45 };
+    for (out, want) |e, w| try testing.expectEqual(@as(?u8, w), e.minute);
+}
+
+test "parseCron step over a range honours both bounds" {
+    const out = try parseCron(testing.allocator, "10-20/5 * * * *");
+    defer testing.allocator.free(out);
+    try testing.expectEqual(@as(usize, 3), out.len);
+    const want = [_]u8{ 10, 15, 20 };
+    for (out, want) |e, w| try testing.expectEqual(@as(?u8, w), e.minute);
+}
+
+test "parseCron weekday 7 canonicalises to Sunday 0" {
+    const sun7 = try parseCron(testing.allocator, "0 0 * * 7");
+    defer testing.allocator.free(sun7);
+    try testing.expectEqual(@as(usize, 1), sun7.len);
+    try testing.expectEqual(@as(?u8, 0), sun7[0].weekday);
+
+    // `0,7` is Sunday twice — it must collapse to one entry, not two.
+    const both = try parseCron(testing.allocator, "0 0 * * 0,7");
+    defer testing.allocator.free(both);
+    try testing.expectEqual(@as(usize, 1), both.len);
+    try testing.expectEqual(@as(?u8, 0), both[0].weekday);
+}
+
+test "parseCron rejects an over-cap expansion" {
+    // `*/1 * * * *` is 60 minute entries — exactly the cap, accepted.
+    const ok = try parseCron(testing.allocator, "*/1 * * * *");
+    defer testing.allocator.free(ok);
+    try testing.expectEqual(max_calendar_entries, ok.len);
+
+    // Two enumerated fields (60 minutes * 2 hours = 120) blow past the cap.
+    try testing.expectError(CronError.CronTooComplex, parseCron(testing.allocator, "*/1 0-1 * * *"));
+}
+
+test "parseCron rejects tokens launchd cannot express as unsupported" {
+    const unsupported = [_][]const u8{
+        "@daily", // macro
+        "@reboot", // macro
+        "0 0 * * MON", // named weekday
+        "0 0 * JAN *", // named month
+        "0 0 ? * *", // Quartz no-op
+        "0 0 L * *", // last-day-of-month
+        "0 0 15W * *", // nearest weekday
+    };
+    for (unsupported) |expr| {
+        try testing.expectError(CronError.CronUnsupported, parseCron(testing.allocator, expr));
+    }
+}
+
+test "parseCron step past the field max stops without overflow" {
+    // 59 + step would overflow a u8 mid-loop; the stride must terminate
+    // cleanly with just the in-range value rather than trapping.
+    const out = try parseCron(testing.allocator, "59/200 * * * *");
+    defer testing.allocator.free(out);
+    try testing.expectEqual(@as(usize, 1), out.len);
+    try testing.expectEqual(@as(?u8, 59), out[0].minute);
+}
+
+test "parseCron rejects out-of-range field values" {
+    const out_of_range = [_][]const u8{
+        "60 0 * * *", // minute past 59
+        "0 24 * * *", // hour past 23
+        "0 0 0 * *", // day-of-month below 1
+        "0 0 32 * *", // day-of-month past 31
+        "0 0 * 13 *", // month past 12
+        "0 0 * * 8", // weekday past 7
+        "5-1 * * * *", // reversed range
+    };
+    for (out_of_range) |expr| {
+        try testing.expectError(CronError.CronOutOfRange, parseCron(testing.allocator, expr));
+    }
+}
+
+test "parseCron rejects structurally malformed expressions" {
+    const malformed = [_][]const u8{
+        "", // empty
+        "0 0 * *", // too few fields
+        "0 0 * * * *", // too many fields
+        "0,,30 * * * *", // empty list element
+        "*/0 * * * *", // zero step
+    };
+    for (malformed) |expr| {
+        try testing.expectError(CronError.CronMalformed, parseCron(testing.allocator, expr));
+    }
+}

--- a/src/core/services/plist.zig
+++ b/src/core/services/plist.zig
@@ -61,6 +61,8 @@ pub const max_program_args: usize = 64;
 pub const max_arg_len: usize = 4096;
 /// Upper bound on an interval schedule, in seconds (shared with the parser).
 pub const max_interval_secs = types.max_interval_secs;
+/// Cap on calendar entries (shared with the cron parser).
+pub const max_calendar_entries = types.max_calendar_entries;
 
 /// The Homebrew API renders every service path with this literal token rather
 /// than the resolved prefix (`$HOMEBREW_PREFIX/opt/redis/bin/redis-server`).
@@ -120,8 +122,13 @@ pub fn validate(
         .immediate => {},
         .interval => |secs| if (secs == 0 or secs > max_interval_secs)
             return ValidationError.BadSchedule,
-        // No rules yet; the parser never builds this and render rejects it.
-        .calendar => {},
+        // Defence in depth: reject an empty or over-cap entry list, or any
+        // field out of range, even though the cron parser already bounds these.
+        .calendar => |entries| {
+            if (entries.len == 0 or entries.len > max_calendar_entries)
+                return ValidationError.BadSchedule;
+            for (entries) |ci| if (!calInRange(ci)) return ValidationError.BadSchedule;
+        },
     }
 
     for (spec.program_args) |a| try checkString(a);
@@ -159,6 +166,17 @@ pub fn validate(
         dsl_sandbox.validatePath(p, cellar_path, malt_prefix) catch
             return ValidationError.PathEscape;
     }
+}
+
+/// True when every set field of a CalendarInterval sits in launchd's range.
+/// Weekday allows 0–7 (both 0 and 7 are Sunday).
+fn calInRange(ci: CalendarInterval) bool {
+    if (ci.minute) |m| if (m > 59) return false;
+    if (ci.hour) |h| if (h > 23) return false;
+    if (ci.day) |d| if (d < 1 or d > 31) return false;
+    if (ci.weekday) |w| if (w > 7) return false;
+    if (ci.month) |mo| if (mo < 1 or mo > 12) return false;
+    return true;
 }
 
 fn checkString(s: []const u8) ValidationError!void {
@@ -236,11 +254,39 @@ pub fn render(spec: ServiceSpec, writer: *std.Io.Writer) !void {
             try writer.print("{d}", .{secs});
             try writer.writeAll("</integer>\n");
         },
-        // Reserved for cron support; the parser never builds this yet.
-        .calendar => unreachable,
+        .calendar => |entries| {
+            try writer.writeAll("    <key>RunAtLoad</key>\n    <false/>\n");
+            try writer.writeAll("    <key>StartCalendarInterval</key>\n");
+            // launchd accepts a bare dict for one entry; a list/step/range
+            // expansion becomes an array of dicts it ORs together.
+            if (entries.len == 1) {
+                try writeCalDict(writer, entries[0], "    ");
+            } else {
+                try writer.writeAll("    <array>\n");
+                for (entries) |ci| try writeCalDict(writer, ci, "        ");
+                try writer.writeAll("    </array>\n");
+            }
+        },
     }
 
     try writer.writeAll("</dict>\n</plist>\n");
+}
+
+/// Emit one launchd `CalendarInterval` as a `<dict>` indented by `indent`.
+/// Only set fields appear; values are validated integers, never formula text.
+fn writeCalDict(writer: *std.Io.Writer, ci: CalendarInterval, indent: []const u8) !void {
+    try writer.print("{s}<dict>\n", .{indent});
+    try writeCalField(writer, indent, "Minute", ci.minute);
+    try writeCalField(writer, indent, "Hour", ci.hour);
+    try writeCalField(writer, indent, "Day", ci.day);
+    try writeCalField(writer, indent, "Weekday", ci.weekday);
+    try writeCalField(writer, indent, "Month", ci.month);
+    try writer.print("{s}</dict>\n", .{indent});
+}
+
+fn writeCalField(writer: *std.Io.Writer, indent: []const u8, key: []const u8, value: ?u8) !void {
+    const v = value orelse return;
+    try writer.print("{s}    <key>{s}</key>\n{s}    <integer>{d}</integer>\n", .{ indent, key, indent, v });
 }
 
 fn writeEscaped(writer: *std.Io.Writer, s: []const u8) !void {

--- a/src/core/services/types.zig
+++ b/src/core/services/types.zig
@@ -27,3 +27,9 @@ pub const Schedule = union(enum) {
 /// real periodic service while keeping the value a small bounded integer —
 /// the same value gates both the parser and `plist.validate`.
 pub const max_interval_secs: u32 = 365 * 24 * 60 * 60;
+
+/// Cap on enumerated `StartCalendarInterval` entries. A pathological cron
+/// expansion (e.g. `*/1` across two fields) would otherwise produce a huge
+/// plist; 60 covers every real formula ("every 5 minutes" is 12 entries)
+/// while staying small. Gates both the cron parser and `plist.validate`.
+pub const max_calendar_entries: usize = 60;

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -66,6 +66,7 @@ pub const pins = @import("core/pins.zig");
 pub const relocated_store = @import("core/relocated_store.zig");
 pub const ruby_subprocess = @import("core/ruby_subprocess.zig");
 pub const sandbox_macos = @import("core/sandbox/macos.zig");
+pub const services_cron = @import("core/services/cron.zig");
 pub const services_plist = @import("core/services/plist.zig");
 pub const services_supervisor = @import("core/services/supervisor.zig");
 pub const signals = @import("core/signals.zig");

--- a/tests/formula_test.zig
+++ b/tests/formula_test.zig
@@ -310,13 +310,31 @@ test "parse absent run_type defaults to immediate" {
     try testing.expectEqual(formula_mod.Schedule.immediate, svc.schedule);
 }
 
-test "parse run_type cron is rejected loudly" {
+test "parse run_type cron builds a calendar schedule" {
     var arena = testArena();
     defer arena.deinit();
-    try testing.expectError(
-        error.UnsupportedRunType,
-        parseWithService(arena.allocator(), ", \"run_type\": \"cron\""),
-    );
+    var formula = try parseWithService(arena.allocator(), ", \"run_type\": \"cron\", \"cron\": \"30 4 * * *\"");
+    defer formula.deinit();
+    const svc = formula.service orelse return error.TestExpectedSomething;
+    switch (svc.schedule) {
+        .calendar => |entries| {
+            try testing.expectEqual(@as(usize, 1), entries.len);
+            try testing.expectEqual(@as(?u8, 30), entries[0].minute);
+            try testing.expectEqual(@as(?u8, 4), entries[0].hour);
+        },
+        else => return error.TestExpectedCalendarSchedule,
+    }
+}
+
+test "parse run_type cron with a missing or malformed expression is a hard error" {
+    var arena = testArena();
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    // A missing `cron` string never silently falls back to immediate.
+    try testing.expectError(error.CronMalformed, parseWithService(alloc, ", \"run_type\": \"cron\""));
+    // Bounds and unsupported tokens surface the parser's specific errors.
+    try testing.expectError(error.CronOutOfRange, parseWithService(alloc, ", \"run_type\": \"cron\", \"cron\": \"99 0 * * *\""));
+    try testing.expectError(error.CronUnsupported, parseWithService(alloc, ", \"run_type\": \"cron\", \"cron\": \"@daily\""));
 }
 
 test "parse unknown run_type is a hard error" {

--- a/tests/services_plist_test.zig
+++ b/tests/services_plist_test.zig
@@ -128,6 +128,98 @@ test "render interval schedule emits StartInterval and RunAtLoad false" {
     try testing.expectEqualStrings(expected, aw.written());
 }
 
+test "render calendar schedule with one entry emits a StartCalendarInterval dict" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    const spec: plist.ServiceSpec = .{
+        .label = "com.malt.report",
+        .program_args = &.{"/opt/malt/opt/report/bin/report"},
+        .stdout_path = "/opt/malt/var/log/report.out",
+        .stderr_path = "/opt/malt/var/log/report.err",
+        .schedule = .{ .calendar = &.{.{ .minute = 30, .hour = 4 }} },
+    };
+    try plist.render(spec, &aw.writer);
+
+    const expected =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\    <key>Label</key>
+        \\    <string>com.malt.report</string>
+        \\    <key>ProgramArguments</key>
+        \\    <array>
+        \\        <string>/opt/malt/opt/report/bin/report</string>
+        \\    </array>
+        \\    <key>StandardOutPath</key>
+        \\    <string>/opt/malt/var/log/report.out</string>
+        \\    <key>StandardErrorPath</key>
+        \\    <string>/opt/malt/var/log/report.err</string>
+        \\    <key>RunAtLoad</key>
+        \\    <false/>
+        \\    <key>StartCalendarInterval</key>
+        \\    <dict>
+        \\        <key>Minute</key>
+        \\        <integer>30</integer>
+        \\        <key>Hour</key>
+        \\        <integer>4</integer>
+        \\    </dict>
+        \\</dict>
+        \\</plist>
+        \\
+    ;
+    try testing.expectEqualStrings(expected, aw.written());
+}
+
+test "render calendar schedule with many entries emits a StartCalendarInterval array" {
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    const spec: plist.ServiceSpec = .{
+        .label = "com.malt.report",
+        .program_args = &.{"/opt/malt/opt/report/bin/report"},
+        .stdout_path = "/opt/malt/var/log/report.out",
+        .stderr_path = "/opt/malt/var/log/report.err",
+        .schedule = .{ .calendar = &.{ .{ .minute = 0 }, .{ .minute = 30 } } },
+    };
+    try plist.render(spec, &aw.writer);
+
+    const expected =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\    <key>Label</key>
+        \\    <string>com.malt.report</string>
+        \\    <key>ProgramArguments</key>
+        \\    <array>
+        \\        <string>/opt/malt/opt/report/bin/report</string>
+        \\    </array>
+        \\    <key>StandardOutPath</key>
+        \\    <string>/opt/malt/var/log/report.out</string>
+        \\    <key>StandardErrorPath</key>
+        \\    <string>/opt/malt/var/log/report.err</string>
+        \\    <key>RunAtLoad</key>
+        \\    <false/>
+        \\    <key>StartCalendarInterval</key>
+        \\    <array>
+        \\        <dict>
+        \\            <key>Minute</key>
+        \\            <integer>0</integer>
+        \\        </dict>
+        \\        <dict>
+        \\            <key>Minute</key>
+        \\            <integer>30</integer>
+        \\        </dict>
+        \\    </array>
+        \\</dict>
+        \\</plist>
+        \\
+    ;
+    try testing.expectEqualStrings(expected, aw.written());
+}
+
 test "keep_alive false omits KeepAlive dict" {
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();

--- a/tests/services_validate_test.zig
+++ b/tests/services_validate_test.zig
@@ -204,3 +204,22 @@ test "validate: interval above the cap rejected" {
 test "validate: interval at the cap passes" {
     try validateWithSchedule(.{ .interval = plist.max_interval_secs });
 }
+
+test "validate: in-range calendar entry passes" {
+    try validateWithSchedule(.{ .calendar = &.{.{ .minute = 30, .hour = 4 }} });
+}
+
+test "validate: empty calendar rejected" {
+    try testing.expectError(error.BadSchedule, validateWithSchedule(.{ .calendar = &.{} }));
+}
+
+test "validate: calendar above the entry cap rejected" {
+    const too_many = [_]plist.CalendarInterval{.{}} ** (plist.max_calendar_entries + 1);
+    try testing.expectError(error.BadSchedule, validateWithSchedule(.{ .calendar = &too_many }));
+}
+
+test "validate: out-of-range calendar field rejected" {
+    // Defence in depth: even a spec the cron parser never builds is caught.
+    try testing.expectError(error.BadSchedule, validateWithSchedule(.{ .calendar = &.{.{ .minute = 60 }} }));
+    try testing.expectError(error.BadSchedule, validateWithSchedule(.{ .calendar = &.{.{ .weekday = 8 }} }));
+}


### PR DESCRIPTION
## Description

malt can now manage cron-scheduled services. A formula's `run_type :cron` is parsed into one or more launchd CalendarInterval entries and emitted as StartCalendarInterval (a single dict, or an array when lists/steps/ranges expand). The supported cron subset is exactly what launchd can express; named days, macros, and `?`/`L`/`W` are rejected with a clear error rather than silently approximated, and an over-complex expression is capped rather than producing a huge plist. This is additive on the Schedule type shipped with #513   `:interval` and `:immediate` are unchanged. Field bounds are validated during parsing and again at the plist gate, and values reach the XML only as integers.

## Related Issue

- None

## Notes for Reviewers

- None
