### PR TITLE
feat(cli/services): surface a service's schedule in list output

### DIFF
--- a/src/cli/services.zig
+++ b/src/cli/services.zig
@@ -23,6 +23,8 @@ pub const JsonRow = struct {
     state: []const u8,
     auto_start: bool,
     keg_name: []const u8,
+    /// Schedule label ("interval 300s", "cron 30 4 * * 6"); "" for run-at-load.
+    schedule: []const u8,
 };
 
 /// Emit `{"schema_version":1,"services":[{name,state,auto_start,keg_name},...]}\n`
@@ -41,6 +43,8 @@ pub fn writeServicesJson(w: *std.Io.Writer, rows: []const JsonRow) !void {
         try w.writeAll(if (row.auto_start) "true" else "false");
         try w.writeAll(",\"keg_name\":");
         try output.jsonStr(w, row.keg_name);
+        try w.writeAll(",\"schedule\":");
+        try output.jsonStr(w, row.schedule);
         try w.writeAll("}");
     }
     try w.writeAll("]}\n");
@@ -126,11 +130,13 @@ fn cmdList(io: std.Io, allocator: std.mem.Allocator, db: *sqlite.Database) !void
     for (items) |s| {
         const runtime = supervisor.queryRuntime(io, allocator, s.name);
         const as: []const u8 = if (s.auto_start) "auto" else "manual";
-        output.plain("{s}\t{s}\t{s}\t{s}", .{
+        // Trailing schedule column; empty for run-at-load services.
+        output.plain("{s}\t{s}\t{s}\t{s}\t{s}", .{
             s.name,
             supervisor.runtimeStateName(runtime),
             as,
             s.keg_name,
+            s.schedule,
         });
     }
 }
@@ -170,6 +176,7 @@ fn emitJson(io: std.Io, allocator: std.mem.Allocator, items: []const supervisor.
             .state = state,
             .auto_start = s.auto_start,
             .keg_name = s.keg_name,
+            .schedule = s.schedule,
         });
     }
     var aw: std.Io.Writer.Allocating = .init(allocator);
@@ -235,16 +242,33 @@ test "writeServicesJson: empty input still emits the versioned root with an empt
 
 test "writeServicesJson: emits name, state, auto_start, keg_name per row under the versioned root" {
     const rows = [_]JsonRow{
-        .{ .name = "redis", .state = "running", .auto_start = true, .keg_name = "redis" },
-        .{ .name = "postgres", .state = "not-loaded", .auto_start = false, .keg_name = "postgresql@16" },
+        .{ .name = "redis", .state = "running", .auto_start = true, .keg_name = "redis", .schedule = "" },
+        .{ .name = "postgres", .state = "not-loaded", .auto_start = false, .keg_name = "postgresql@16", .schedule = "" },
     };
     var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
     try writeServicesJson(&aw.writer, &rows);
     try std.testing.expectEqualStrings(
         "{\"schema_version\":1,\"services\":[" ++
-            "{\"name\":\"redis\",\"state\":\"running\",\"auto_start\":true,\"keg_name\":\"redis\"}," ++
-            "{\"name\":\"postgres\",\"state\":\"not-loaded\",\"auto_start\":false,\"keg_name\":\"postgresql@16\"}" ++
+            "{\"name\":\"redis\",\"state\":\"running\",\"auto_start\":true,\"keg_name\":\"redis\",\"schedule\":\"\"}," ++
+            "{\"name\":\"postgres\",\"state\":\"not-loaded\",\"auto_start\":false,\"keg_name\":\"postgresql@16\",\"schedule\":\"\"}" ++
+            "]}\n",
+        aw.written(),
+    );
+}
+
+test "writeServicesJson: emits the schedule label as a trailing field per row" {
+    const rows = [_]JsonRow{
+        .{ .name = "redis", .state = "running", .auto_start = true, .keg_name = "redis", .schedule = "interval 300s" },
+        .{ .name = "postgres", .state = "not-loaded", .auto_start = false, .keg_name = "postgresql@16", .schedule = "" },
+    };
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try writeServicesJson(&aw.writer, &rows);
+    try std.testing.expectEqualStrings(
+        "{\"schema_version\":1,\"services\":[" ++
+            "{\"name\":\"redis\",\"state\":\"running\",\"auto_start\":true,\"keg_name\":\"redis\",\"schedule\":\"interval 300s\"}," ++
+            "{\"name\":\"postgres\",\"state\":\"not-loaded\",\"auto_start\":false,\"keg_name\":\"postgresql@16\",\"schedule\":\"\"}" ++
             "]}\n",
         aw.written(),
     );

--- a/src/core/services/supervisor.zig
+++ b/src/core/services/supervisor.zig
@@ -30,6 +30,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const sqlite = @import("../../db/sqlite.zig");
 const plist_mod = @import("plist.zig");
+const service_types = @import("types.zig");
 const atomic = @import("../../fs/atomic.zig");
 
 pub const SupervisorError = error{
@@ -74,6 +75,9 @@ pub const ServiceInfo = struct {
     plist_path: []const u8,
     auto_start: bool,
     last_status: []const u8,
+    /// Human schedule label ("interval 300s", "cron 30 4 * * 6"); "" for
+    /// run-at-load. A convenience cache; the plist stays authoritative.
+    schedule: []const u8,
 };
 
 /// Returns the services directory: `{prefix}/var/malt/services`.
@@ -103,7 +107,7 @@ pub fn logPath(allocator: std.mem.Allocator, name: []const u8, stream: enum { st
 /// List services from the `services` table.
 pub fn list(ctx: SupervisorCtx) SupervisorError![]ServiceInfo {
     const allocator = ctx.allocator;
-    var stmt = ctx.db.prepare("SELECT name, keg_name, plist_path, auto_start, last_status FROM services ORDER BY name;") catch
+    var stmt = ctx.db.prepare("SELECT name, keg_name, plist_path, auto_start, last_status, schedule FROM services ORDER BY name;") catch
         return SupervisorError.DatabaseError;
     defer stmt.finalize();
 
@@ -137,6 +141,10 @@ pub fn list(ctx: SupervisorCtx) SupervisorError![]ServiceInfo {
             allocator.dupe(u8, "unknown") catch
                 return SupervisorError.OutOfMemory;
         errdefer allocator.free(status_owned);
+        // NULL schedule (pre-feature rows / run-at-load) reads back as "".
+        const sched_owned = allocator.dupe(u8, if (stmt.columnText(5)) |p| std.mem.sliceTo(p, 0) else "") catch
+            return SupervisorError.OutOfMemory;
+        errdefer allocator.free(sched_owned);
 
         buf.append(allocator, .{
             .name = name_owned,
@@ -144,6 +152,7 @@ pub fn list(ctx: SupervisorCtx) SupervisorError![]ServiceInfo {
             .plist_path = plist_owned,
             .auto_start = stmt.columnBool(3),
             .last_status = status_owned,
+            .schedule = sched_owned,
         }) catch return SupervisorError.OutOfMemory;
     }
 
@@ -155,6 +164,7 @@ fn freeServiceInfoFields(allocator: std.mem.Allocator, info: ServiceInfo) void {
     allocator.free(info.keg_name);
     allocator.free(info.plist_path);
     allocator.free(info.last_status);
+    allocator.free(info.schedule);
 }
 
 pub fn freeServiceInfos(allocator: std.mem.Allocator, services: []ServiceInfo) void {
@@ -206,15 +216,22 @@ pub fn register(
     plist_mod.render(spec, &aw.writer) catch return SupervisorError.IoFailed;
     file.writeStreamingAll(ctx.io, aw.written()) catch return SupervisorError.IoFailed;
 
+    // Cache the schedule as a human label so `services list` shows why a
+    // service exists without re-parsing the plist.
+    const schedule_label = service_types.scheduleLabel(allocator, spec.schedule) catch
+        return SupervisorError.OutOfMemory;
+    defer allocator.free(schedule_label);
+
     var stmt = ctx.db.prepare(
-        \\INSERT OR REPLACE INTO services(name, keg_name, plist_path, auto_start, last_status)
-        \\VALUES (?, ?, ?, ?, 'registered');
+        \\INSERT OR REPLACE INTO services(name, keg_name, plist_path, auto_start, last_status, schedule)
+        \\VALUES (?, ?, ?, ?, 'registered', ?);
     ) catch return SupervisorError.DatabaseError;
     defer stmt.finalize();
     stmt.bindText(1, spec.label) catch return SupervisorError.DatabaseError;
     stmt.bindText(2, keg_name) catch return SupervisorError.DatabaseError;
     stmt.bindText(3, plist_path) catch return SupervisorError.DatabaseError;
     stmt.bindInt(4, if (auto_start) 1 else 0) catch return SupervisorError.DatabaseError;
+    stmt.bindText(5, schedule_label) catch return SupervisorError.DatabaseError;
     _ = stmt.step() catch return SupervisorError.DatabaseError;
 }
 

--- a/src/core/services/types.zig
+++ b/src/core/services/types.zig
@@ -3,6 +3,9 @@
 //! A std-only leaf shared by the formula parser and the plist emitter, so
 //! neither side has to import the other just to name a schedule.
 
+const std = @import("std");
+const testing = std.testing;
+
 /// One launchd `StartCalendarInterval` entry. Defined now so adding cron
 /// support is purely additive; unused until then.
 pub const CalendarInterval = struct {
@@ -33,3 +36,61 @@ pub const max_interval_secs: u32 = 365 * 24 * 60 * 60;
 /// plist; 60 covers every real formula ("every 5 minutes" is 12 entries)
 /// while staying small. Gates both the cron parser and `plist.validate`.
 pub const max_calendar_entries: usize = 60;
+
+/// Render a short human label for a schedule, e.g. `"interval 300s"` or
+/// `"cron 30 4 * * 6"`. `.immediate` yields `""` so a run-at-load service
+/// shows no schedule. The label is the convenience cache stored on the
+/// services row; the on-disk plist stays authoritative. Caller owns the slice.
+pub fn scheduleLabel(allocator: std.mem.Allocator, sched: Schedule) std.mem.Allocator.Error![]u8 {
+    return switch (sched) {
+        .immediate => allocator.dupe(u8, ""),
+        .interval => |secs| std.fmt.allocPrint(allocator, "interval {d}s", .{secs}),
+        .calendar => |entries| calendarLabel(allocator, entries),
+    };
+}
+
+/// Re-render calendar entries as a cron-order label `"cron <min> <hour> <dom>
+/// <month> <dow>"`. `parseCron` emits the full cartesian product per field, so
+/// collecting each field's distinct values reconstructs an equivalent
+/// expression (`*` where every entry left the field unset).
+fn calendarLabel(allocator: std.mem.Allocator, entries: []const CalendarInterval) std.mem.Allocator.Error![]u8 {
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
+    // Allocating.Writer only fails on OOM; map that single cause back.
+    w.writeAll("cron") catch return error.OutOfMemory;
+    appendCronField(w, entries, "minute") catch return error.OutOfMemory;
+    appendCronField(w, entries, "hour") catch return error.OutOfMemory;
+    appendCronField(w, entries, "day") catch return error.OutOfMemory;
+    appendCronField(w, entries, "month") catch return error.OutOfMemory;
+    appendCronField(w, entries, "weekday") catch return error.OutOfMemory;
+    return allocator.dupe(u8, aw.written());
+}
+
+fn appendCronField(w: *std.Io.Writer, entries: []const CalendarInterval, comptime field: []const u8) !void {
+    try w.writeByte(' ');
+    // A field unset in the first entry is unset in all (cron fields enumerate
+    // together), so `*` covers it.
+    if (entries.len == 0 or @field(entries[0], field) == null) return w.writeByte('*');
+    var seen = [_]bool{false} ** 256;
+    for (entries) |e| if (@field(e, field)) |v| {
+        seen[v] = true;
+    };
+    var first = true;
+    for (0..256) |v| if (seen[v]) {
+        if (!first) try w.writeByte(',');
+        first = false;
+        try w.print("{d}", .{v});
+    };
+}
+
+test "scheduleLabel: expanded entries collect each field's distinct values" {
+    // `*/15 * * * *` expands to four minute entries; the label collects them
+    // back into one comma list rather than printing four cron lines.
+    const entries = [_]CalendarInterval{
+        .{ .minute = 0 }, .{ .minute = 15 }, .{ .minute = 30 }, .{ .minute = 45 },
+    };
+    const label = try scheduleLabel(testing.allocator, .{ .calendar = &entries });
+    defer testing.allocator.free(label);
+    try testing.expectEqualStrings("cron 0,15,30,45 * * * *", label);
+}

--- a/src/db/schema.zig
+++ b/src/db/schema.zig
@@ -126,7 +126,7 @@ pub fn initSchema(db: *sqlite.Database) MigrateError!void {
 /// Highest schema version this binary knows how to operate on. Bump in
 /// lockstep with the last `migrateVNtoVN+1` step so a future binary's
 /// DB doesn't get silently used against older SQL.
-pub const known_schema_version: i64 = 12;
+pub const known_schema_version: i64 = 13;
 
 pub const MigrateError = sqlite.SqliteError || error{SchemaTooNew};
 
@@ -148,12 +148,15 @@ pub fn migrate(db: *sqlite.Database) MigrateError!void {
     if (ver < 10) try migrateV9toV10(db);
     if (ver < 11) try migrateV10toV11(db);
     if (ver < 12) try migrateV11toV12(db);
+    if (ver < 13) try migrateV12toV13(db);
 }
 
 fn migrateV1toV2(db: *sqlite.Database) sqlite.SqliteError!void {
     try db.beginTransaction();
     errdefer db.rollback();
 
+    // `schedule` is added by v13's ALTER on upgraded DBs; the fresh shape
+    // ships with it so both paths converge. Nullable: a NULL means run-at-load.
     try db.exec(
         \\CREATE TABLE IF NOT EXISTS services (
         \\    name             TEXT PRIMARY KEY,
@@ -161,7 +164,8 @@ fn migrateV1toV2(db: *sqlite.Database) sqlite.SqliteError!void {
         \\    plist_path       TEXT NOT NULL,
         \\    auto_start       INTEGER NOT NULL DEFAULT 0,
         \\    last_started_at  INTEGER,
-        \\    last_status      TEXT
+        \\    last_status      TEXT,
+        \\    schedule         TEXT
         \\);
     );
 
@@ -639,6 +643,40 @@ fn migrateV11toV12(db: *sqlite.Database) sqlite.SqliteError!void {
     try db.commit();
 }
 
+/// v13 — record a service's schedule as a short human label so
+/// `mt services list` can show *why* a service exists ("interval 300s",
+/// "cron 30 4 * * 6") without re-parsing the on-disk plist. Nullable: a
+/// NULL means run-at-load, so every pre-feature row reads back as
+/// no-schedule. The plist stays authoritative; this column is a listing
+/// cache. Same PRAGMA-guarded shape as the column-adds above so re-runs
+/// against partial fixtures stay idempotent.
+fn migrateV12toV13(db: *sqlite.Database) sqlite.SqliteError!void {
+    try db.beginTransaction();
+    errdefer db.rollback();
+
+    var have_table = false;
+    var have_column = false;
+    {
+        var stmt = try db.prepare("PRAGMA table_info(services);");
+        defer stmt.finalize();
+        while (try stmt.step()) {
+            have_table = true;
+            const name = stmt.columnText(1) orelse continue;
+            if (std.mem.eql(u8, std.mem.sliceTo(name, 0), "schedule")) {
+                have_column = true;
+                break;
+            }
+        }
+    }
+    if (have_table and !have_column) {
+        try db.exec("ALTER TABLE services ADD COLUMN schedule TEXT;");
+    }
+
+    try db.exec("INSERT OR IGNORE INTO schema_version (version) VALUES (13);");
+
+    try db.commit();
+}
+
 /// Return true iff every column in `wanted` is present on the `casks`
 /// table. Mirrors the PRAGMA-guarded probes used by v2→v3 / v3→v4 /
 /// v5→v6; centralised here because the v6→v7 backfill needs five
@@ -832,7 +870,7 @@ test "v6→v7 migration backfills cask_versions from existing casks rows" {
     const token1 = stmt.columnText(0) orelse return error.TestUnexpectedResult;
     try testing.expectEqualStrings("flux-markdown", std.mem.sliceTo(token1, 0));
 
-    try testing.expectEqual(@as(i64, 12), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
 }
 
 test "v6→v7 migration is idempotent when cask_versions already carries the rows" {
@@ -881,7 +919,7 @@ test "fresh DB ships with taps.head_etag (v8 shape)" {
         }
     }
     try testing.expect(found);
-    try testing.expectEqual(@as(i64, 12), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
 }
 
 test "v7→v8 migration adds head_etag and preserves existing tap rows" {
@@ -912,7 +950,7 @@ test "v7→v8 migration adds head_etag and preserves existing tap rows" {
     );
     // Pre-v8 rows must carry NULL until a conditional GET populates it.
     try testing.expect(probe.columnText(1) == null);
-    try testing.expectEqual(@as(i64, 12), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
 }
 
 test "v7→v8 migration is idempotent when head_etag is already present" {
@@ -961,7 +999,7 @@ test "fresh DB ships with taps.github_owner and taps.github_repo (v9 shape)" {
     }
     try testing.expect(owner_seen);
     try testing.expect(repo_seen);
-    try testing.expectEqual(@as(i64, 12), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
 }
 
 test "v8→v9 migration backfills (user, \"homebrew-\" || repo) from existing slugs" {
@@ -981,7 +1019,7 @@ test "v8→v9 migration backfills (user, \"homebrew-\" || repo) from existing sl
 
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 12), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
 
     var probe = try db.prepare(
         "SELECT name, github_owner, github_repo FROM taps ORDER BY name;",
@@ -1043,7 +1081,7 @@ test "v8→v9 migration bumps the marker even when taps is empty" {
     try db.exec("DELETE FROM schema_version WHERE version >= 9;");
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 12), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
 }
 
 // Pre-v3 rows could in theory have escaped slug validation. The CASE
@@ -1070,7 +1108,7 @@ test "v8→v9 migration tolerates a slug starting with a slash (degenerate fixtu
 
     // We don't pin the specific (owner, repo) values for degenerate
     // input — only that the migration completes and the marker bumps.
-    try testing.expectEqual(@as(i64, 12), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
 }
 
 test "v8→v9 migration falls back to verbatim name on a slug missing the slash" {
@@ -1115,7 +1153,7 @@ test "fresh DB ships with kegs.bin_isolated (v10 shape)" {
         }
     }
     try testing.expect(found);
-    try testing.expectEqual(@as(i64, 12), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
 }
 
 test "v9→v10 migration adds bin_isolated and defaults existing rows to 0" {
@@ -1134,7 +1172,7 @@ test "v9→v10 migration adds bin_isolated and defaults existing rows to 0" {
 
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 12), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
 
     var probe = try db.prepare("SELECT name, bin_isolated FROM kegs ORDER BY name;");
     defer probe.finalize();
@@ -1208,7 +1246,7 @@ test "fresh DB ships with taps.host defaulting to github.com (v11 shape)" {
     try testing.expect(try probe.step());
     try testing.expectEqualStrings("github.com", std.mem.sliceTo(probe.columnText(0) orelse "", 0));
 
-    try testing.expectEqual(@as(i64, 12), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
 }
 
 test "v10→v11 migration backfills host=github.com on existing tap rows" {
@@ -1226,7 +1264,7 @@ test "v10→v11 migration backfills host=github.com on existing tap rows" {
 
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 12), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
 
     var probe = try db.prepare("SELECT host FROM taps WHERE name='aeroxy/tap';");
     defer probe.finalize();
@@ -1267,7 +1305,7 @@ test "v10→v11 migration bumps the marker even when taps is empty" {
     try db.exec("DELETE FROM schema_version WHERE version >= 11;");
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 12), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
 }
 
 // v11→v12 adds taps.forge so a tap can name its provider explicitly when
@@ -1303,7 +1341,7 @@ test "fresh DB ships with a nullable taps.forge column (v12 shape)" {
     try testing.expect(try probe.step());
     try testing.expect(probe.columnText(0) == null);
 
-    try testing.expectEqual(@as(i64, 12), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
 }
 
 test "v11→v12 migration adds taps.forge as NULL on existing rows" {
@@ -1319,7 +1357,7 @@ test "v11→v12 migration adds taps.forge as NULL on existing rows" {
 
     try migrate(&db);
 
-    try testing.expectEqual(@as(i64, 12), try currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
 
     var probe = try db.prepare("SELECT forge FROM taps WHERE name='aeroxy/tap';");
     defer probe.finalize();
@@ -1345,6 +1383,88 @@ test "v11→v12 migration is idempotent and preserves an explicit forge" {
     defer probe.finalize();
     try testing.expect(try probe.step());
     try testing.expectEqualStrings("gitlab", std.mem.sliceTo(probe.columnText(0) orelse "", 0));
+}
+
+// v12→v13 adds services.schedule, a nullable human label cache ("interval
+// 300s", "cron 30 4 * * 6", or NULL for run-at-load). The plist stays the
+// source of truth; this column is a listing convenience. Nullable so every
+// pre-feature row reads back as no-schedule with no migration error.
+
+test "fresh DB ships with a nullable services.schedule column (v13 shape)" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    var stmt = try db.prepare("PRAGMA table_info(services);");
+    defer stmt.finalize();
+    var found = false;
+    while (try stmt.step()) {
+        const name = stmt.columnText(1) orelse continue;
+        if (std.mem.eql(u8, std.mem.sliceTo(name, 0), "schedule")) {
+            found = true;
+            break;
+        }
+    }
+    try testing.expect(found);
+
+    // A row inserted without naming `schedule` leaves it NULL — the path a
+    // pre-schedule registration relied on.
+    try db.exec(
+        \\INSERT INTO services (name, keg_name, plist_path)
+        \\VALUES ('redis', 'redis', '/dev/null');
+    );
+    var probe = try db.prepare("SELECT schedule FROM services WHERE name='redis';");
+    defer probe.finalize();
+    try testing.expect(try probe.step());
+    try testing.expect(probe.columnText(0) == null);
+
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+}
+
+test "v12→v13 migration adds services.schedule as NULL on existing rows" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    // Seed a service on the current shape, then rewind the marker so migrate
+    // re-enters the v12→v13 step against a row that pre-dates the column.
+    try db.exec(
+        \\INSERT INTO services (name, keg_name, plist_path, auto_start, last_status)
+        \\VALUES ('redis', 'redis', '/dev/null', 0, 'registered');
+    );
+    try db.exec("DELETE FROM schema_version WHERE version >= 13;");
+
+    try migrate(&db);
+
+    try testing.expectEqual(@as(i64, 13), try currentVersion(&db));
+
+    var probe = try db.prepare("SELECT schedule FROM services WHERE name='redis';");
+    defer probe.finalize();
+    try testing.expect(try probe.step());
+    try testing.expect(probe.columnText(0) == null);
+}
+
+test "v12→v13 migration is idempotent and preserves an explicit schedule" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO services (name, keg_name, plist_path, schedule)
+        \\VALUES ('redis', 'redis', '/dev/null', 'interval 300s');
+    );
+    try db.exec("DELETE FROM schema_version WHERE version >= 13;");
+    try migrate(&db);
+    try db.exec("DELETE FROM schema_version WHERE version >= 13;");
+    try migrate(&db);
+
+    var probe = try db.prepare("SELECT schedule FROM services WHERE name='redis';");
+    defer probe.finalize();
+    try testing.expect(try probe.step());
+    try testing.expectEqualStrings(
+        "interval 300s",
+        std.mem.sliceTo(probe.columnText(0) orelse "", 0),
+    );
 }
 
 test "migrate refuses a DB whose schema_version exceeds the known max" {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -789,6 +789,7 @@ fn loadServices(io: std.Io, allocator: std.mem.Allocator, painter: Painter, app:
         if (store.services) |old| old.deinit();
         store.services = null;
         app.states.services.items = &.{};
+        app.states.services.detail = null; // the old detail borrowed the freed rows
         return;
     };
     defer allocator.free(bytes);
@@ -797,6 +798,7 @@ fn loadServices(io: std.Io, allocator: std.mem.Allocator, painter: Painter, app:
     if (store.services) |old| old.deinit();
     store.services = parsed;
     app.states.services.items = parsed.items;
+    app.states.services.detail = null; // a refreshed list invalidates the old detail
 }
 
 /// Build `mt services <action> <name>` for the selected service. Pure over the

--- a/src/tui/json/services.zig
+++ b/src/tui/json/services.zig
@@ -20,6 +20,9 @@ pub const ServiceRow = struct {
     state: []const u8,
     auto_start: bool,
     keg_name: []const u8 = "",
+    /// Schedule label ("interval 300s", "cron 30 4 * * 6"); "" / absent for
+    /// run-at-load. Defaulted so a row from an older malt still parses.
+    schedule: []const u8 = "",
 };
 
 /// Owns the parsed rows; `items` borrow from the arena. Free with `deinit`.
@@ -92,6 +95,24 @@ test "parse ignores unknown fields and schema_version" {
     defer p.deinit();
     try testing.expectEqual(@as(usize, 1), p.items.len);
     try testing.expectEqualStrings("a", p.items[0].name);
+}
+
+test "parse reads the schedule label when present" {
+    const bytes =
+        \\{"services":[{"name":"backup","state":"loaded","auto_start":false,"keg_name":"backup","schedule":"interval 300s"}]}
+    ;
+    var p = try parse(testing.allocator, bytes);
+    defer p.deinit();
+    try testing.expectEqualStrings("interval 300s", p.items[0].schedule);
+}
+
+test "parse tolerates an absent schedule (defaults to empty — backward compatible)" {
+    const bytes =
+        \\{"services":[{"name":"redis","state":"running","auto_start":true,"keg_name":"redis"}]}
+    ;
+    var p = try parse(testing.allocator, bytes);
+    defer p.deinit();
+    try testing.expectEqualStrings("", p.items[0].schedule);
 }
 
 test "parse tolerates an absent keg_name (defaults to empty)" {

--- a/src/tui/services_tab.zig
+++ b/src/tui/services_tab.zig
@@ -16,6 +16,7 @@ const testing = std.testing;
 const color = @import("../ui/color.zig");
 const services_json = @import("json/services.zig");
 pub const Row = services_json.ServiceRow;
+const detail_pane = @import("detail_pane.zig");
 const scroll_list = @import("scroll_list.zig");
 const tab = @import("tab.zig");
 
@@ -29,6 +30,9 @@ pub const State = struct {
     items: []const Row = &.{},
     /// Pending lifecycle effect for the shell to perform, then clear.
     request: Request = .none,
+    /// The row whose detail pane is open (Enter), or null when closed (Esc).
+    /// A copy of the selected Row — its slices borrow the same shell storage.
+    detail: ?Row = null,
 };
 
 pub fn title() []const u8 {
@@ -37,7 +41,7 @@ pub fn title() []const u8 {
 
 /// The tab's action keys, surfaced in the shared footer next to the global keys.
 pub fn footerHint() []const u8 {
-    return "s: start   x: stop   r: restart";
+    return "enter: details   s: start   x: stop   r: restart";
 }
 
 /// Case-insensitive substring match of `filter` against `name`. An empty filter
@@ -72,9 +76,13 @@ pub fn selectedService(s: *const State) ?Row {
 }
 
 /// Pure transition: record a lifecycle intent for the shell to act on. `s` start,
-/// `x`/`X` stop, `r` restart — reversible, so no confirm guard.
+/// `x`/`X` stop, `r` restart — reversible, so no confirm guard. Enter opens the
+/// detail pane (all its fields are already on the Row, so no shell round-trip),
+/// Esc closes it.
 pub fn step(s: *State, key: tab.Key) void {
     switch (key) {
+        .enter => s.detail = selectedService(s),
+        .esc => s.detail = null,
         .char => |c| if (c.len == 1) switch (c.bytes[0]) {
             's' => s.request = .start,
             'x', 'X' => s.request = .stop,
@@ -116,7 +124,21 @@ fn dotStyle(st: Status) color.Role {
 /// `(state, rect)` so a resize is a re-render.
 pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     if (r.height == 0) return;
-    renderList(s, f, r);
+    var list_rect = r;
+    if (s.detail) |d| {
+        const fields = [_]detail_pane.Field{
+            .{ .label = "Schedule", .value = if (d.schedule.len != 0) d.schedule else "-" },
+            .{ .label = "Keg", .value = if (d.keg_name.len != 0) d.keg_name else "-" },
+            .{ .label = "State", .value = d.state },
+            .{ .label = "Auto-start", .value = if (d.auto_start) "yes" else "no" },
+        };
+        const dh = @min(detail_pane.neededRows(&fields, r.width), r.height / 2);
+        if (dh > 0 and dh < r.height) {
+            list_rect.height = r.height - dh;
+            detail_pane.render(f, &fields, .{ .row = r.row + list_rect.height, .col = r.col, .width = r.width, .height = dh });
+        }
+    }
+    renderList(s, f, list_rect);
 }
 
 fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
@@ -129,8 +151,7 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
         .{ .label = "NAME", .width = 24 },
         .{ .label = "STATE", .width = 12 },
         .{ .label = "START", .width = 8 },
-        .{ .label = "KEG", .width = 16, .gap = 0 }, // START→KEG carries no separator
-        .{ .label = "SCHED", .width = 5 },
+        .{ .label = "KEG", .width = 3, .gap = 0 }, // formatRow appends the keg with no separator
     });
     const list: tab.Rect = .{ .row = rect.row + 1, .col = rect.col, .width = rect.width, .height = rect.height -| 1 };
     if (list.height == 0) return; // the heading took the only row
@@ -162,20 +183,37 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     }
 }
 
-/// One list row (after the dot): the name, the runtime state, the auto-start
-/// hint, the owning keg, then the schedule label. ASCII columns, grapheme-naive
-/// like the rest. An empty schedule (run-at-load) leaves the last column blank.
+/// A single-cell clock marking a scheduled service. Same single-width family as
+/// the status dots (`● ○ ◌`); the full label lives in the ENTER detail pane.
+const sched_marker = "◷"; // U+25F7, 3 bytes, 1 display column
+
+/// One list row (after the dot): the name (with a `◷` when scheduled), the
+/// runtime state, the auto-start hint, then the owning keg. ASCII columns,
+/// grapheme-naive like the rest.
 fn formatRow(buf: []u8, s: Row) []const u8 {
     var len: usize = 0;
-    appendPad(buf, &len, s.name, 24);
+    appendName(buf, &len, s.name, s.schedule.len != 0, 24);
     append(buf, &len, " ");
     appendPad(buf, &len, s.state, 12);
     append(buf, &len, " ");
     appendPad(buf, &len, if (s.auto_start) "auto" else "manual", 8);
-    appendPad(buf, &len, s.keg_name, 16);
-    append(buf, &len, " ");
-    append(buf, &len, s.schedule);
+    append(buf, &len, s.keg_name);
     return buf[0..len];
+}
+
+/// Write the name, a ` ◷` marker when scheduled, then pad to `width` *display*
+/// cells so the next column aligns regardless of the marker. The marker's extra
+/// bytes (3-byte glyph, 1 cell) don't count toward the cell budget, so columns
+/// never drift. A name too long to fit the marker simply doesn't get one.
+fn appendName(buf: []u8, len: *usize, name: []const u8, scheduled: bool, width: usize) void {
+    append(buf, len, name);
+    var cells = name.len; // one byte ≈ one cell for the ASCII name
+    if (scheduled and cells + 2 <= width) {
+        append(buf, len, " ");
+        append(buf, len, sched_marker);
+        cells += 2; // a space plus the 1-cell clock
+    }
+    while (cells < width) : (cells += 1) append(buf, len, " ");
 }
 
 fn append(buf: []u8, len: *usize, s: []const u8) void {
@@ -202,6 +240,12 @@ const sample = [_]Row{
     .{ .name = "dnsmasq", .state = "not-loaded", .auto_start = true, .keg_name = "dnsmasq" },
     .{ .name = "weird", .state = "degraded", .auto_start = false, .keg_name = "weird" },
 };
+
+test "footerHint advertises the details affordance alongside the lifecycle keys" {
+    const h = footerHint();
+    try testing.expect(std.mem.indexOf(u8, h, "enter: details") != null);
+    try testing.expect(std.mem.indexOf(u8, h, "s: start") != null);
+}
 
 test "matches is a case-insensitive substring; empty filter matches all" {
     try testing.expect(matches("redis", ""));
@@ -267,11 +311,63 @@ test "render heads the columns in bold, indented past the status dot" {
     const out = f.slice();
     try testing.expect(std.mem.indexOf(u8, out, color.Style.bold.code()) != null);
     // The 2-col dot indent plus exact padding aligns the labels over values.
-    try testing.expect(std.mem.indexOf(u8, out, "  NAME" ++ " " ** 21 ++ "STATE" ++ " " ** 8 ++ "START" ++ " " ** 3 ++ "KEG" ++ " " ** 14 ++ "SCHED") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "  NAME" ++ " " ** 21 ++ "STATE" ++ " " ** 8 ++ "START" ++ " " ** 3 ++ "KEG") != null);
     try testing.expect(std.mem.indexOf(u8, out, "redis") != null); // the list still renders below
 }
 
-test "render shows the schedule label and heads a SCHED column" {
+test "formatRow marks a scheduled service with a clock and keeps STATE aligned" {
+    var a: [256]u8 = undefined;
+    var b: [256]u8 = undefined;
+    const scheduled = formatRow(&a, .{ .name = "backup", .state = "loaded", .auto_start = false, .keg_name = "backup", .schedule = "interval 300s" });
+    const plain = formatRow(&b, .{ .name = "backup", .state = "loaded", .auto_start = false, .keg_name = "backup", .schedule = "" });
+    // The clock marks only the scheduled row; the label itself stays out of the list.
+    try testing.expect(std.mem.indexOf(u8, scheduled, "◷") != null);
+    try testing.expect(std.mem.indexOf(u8, plain, "◷") == null);
+    try testing.expect(std.mem.indexOf(u8, scheduled, "interval 300s") == null);
+    // STATE lands at the same display column: the marker's only byte cost over the
+    // plain row is the clock's 2 non-display bytes (3-byte glyph, 1 display cell).
+    const i_plain = std.mem.indexOf(u8, plain, "loaded").?;
+    const i_sched = std.mem.indexOf(u8, scheduled, "loaded").?;
+    try testing.expectEqual(i_plain + 2, i_sched);
+}
+
+test "ENTER opens a detail pane showing the schedule label; ESC closes it" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const rows = [_]Row{
+        .{ .name = "backup", .state = "loaded", .auto_start = false, .keg_name = "backup", .schedule = "interval 300s" },
+    };
+    var s: State = .{ .items = &rows };
+    step(&s, .enter);
+    try testing.expect(s.detail != null);
+
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 60, .height = 12 });
+    const out = f.slice();
+    // The label moved off the list into the pane, so this text can only be here.
+    try testing.expect(std.mem.indexOf(u8, out, "Schedule") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "interval 300s") != null);
+
+    step(&s, .esc);
+    try testing.expect(s.detail == null);
+}
+
+test "detail pane shows no schedule label for a run-at-load service" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const rows = [_]Row{
+        .{ .name = "redis", .state = "running", .auto_start = true, .keg_name = "redis", .schedule = "" },
+    };
+    var s: State = .{ .items = &rows };
+    step(&s, .enter);
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 60, .height = 12 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, "Schedule") != null);
+    // An empty schedule must not surface a bogus interval/cron label.
+    try testing.expect(std.mem.indexOf(u8, out, "interval") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "cron") == null);
+}
+
+test "render shows the schedule marker but not the label or a SCHED column" {
     var buf: [4096]u8 = undefined;
     var f: tab.Frame = .{ .buf = &buf };
     const rows = [_]Row{
@@ -280,8 +376,9 @@ test "render shows the schedule label and heads a SCHED column" {
     const s: State = .{ .items = &rows };
     render(&s, &f, .{ .row = 2, .col = 1, .width = 80, .height = 12 });
     const out = f.slice();
-    try testing.expect(std.mem.indexOf(u8, out, "SCHED") != null); // column heading
-    try testing.expect(std.mem.indexOf(u8, out, "interval 300s") != null); // the row's label
+    try testing.expect(std.mem.indexOf(u8, out, "◷") != null); // at-a-glance marker
+    try testing.expect(std.mem.indexOf(u8, out, "SCHED") == null); // no 5th column heading
+    try testing.expect(std.mem.indexOf(u8, out, "interval 300s") == null); // label lives in the detail pane
 }
 
 test "render lists services with a state dot, the state, and the auto-start hint" {

--- a/src/tui/services_tab.zig
+++ b/src/tui/services_tab.zig
@@ -129,7 +129,8 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
         .{ .label = "NAME", .width = 24 },
         .{ .label = "STATE", .width = 12 },
         .{ .label = "START", .width = 8 },
-        .{ .label = "KEG", .width = 3, .gap = 0 }, // formatRow appends the keg with no separator
+        .{ .label = "KEG", .width = 16, .gap = 0 }, // START→KEG carries no separator
+        .{ .label = "SCHED", .width = 5 },
     });
     const list: tab.Rect = .{ .row = rect.row + 1, .col = rect.col, .width = rect.width, .height = rect.height -| 1 };
     if (list.height == 0) return; // the heading took the only row
@@ -162,7 +163,8 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
 }
 
 /// One list row (after the dot): the name, the runtime state, the auto-start
-/// hint, then the owning keg. ASCII columns, grapheme-naive like the rest.
+/// hint, the owning keg, then the schedule label. ASCII columns, grapheme-naive
+/// like the rest. An empty schedule (run-at-load) leaves the last column blank.
 fn formatRow(buf: []u8, s: Row) []const u8 {
     var len: usize = 0;
     appendPad(buf, &len, s.name, 24);
@@ -170,7 +172,9 @@ fn formatRow(buf: []u8, s: Row) []const u8 {
     appendPad(buf, &len, s.state, 12);
     append(buf, &len, " ");
     appendPad(buf, &len, if (s.auto_start) "auto" else "manual", 8);
-    append(buf, &len, s.keg_name);
+    appendPad(buf, &len, s.keg_name, 16);
+    append(buf, &len, " ");
+    append(buf, &len, s.schedule);
     return buf[0..len];
 }
 
@@ -263,8 +267,21 @@ test "render heads the columns in bold, indented past the status dot" {
     const out = f.slice();
     try testing.expect(std.mem.indexOf(u8, out, color.Style.bold.code()) != null);
     // The 2-col dot indent plus exact padding aligns the labels over values.
-    try testing.expect(std.mem.indexOf(u8, out, "  NAME" ++ " " ** 21 ++ "STATE" ++ " " ** 8 ++ "START" ++ " " ** 3 ++ "KEG") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "  NAME" ++ " " ** 21 ++ "STATE" ++ " " ** 8 ++ "START" ++ " " ** 3 ++ "KEG" ++ " " ** 14 ++ "SCHED") != null);
     try testing.expect(std.mem.indexOf(u8, out, "redis") != null); // the list still renders below
+}
+
+test "render shows the schedule label and heads a SCHED column" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const rows = [_]Row{
+        .{ .name = "backup", .state = "loaded", .auto_start = false, .keg_name = "backup", .schedule = "interval 300s" },
+    };
+    const s: State = .{ .items = &rows };
+    render(&s, &f, .{ .row = 2, .col = 1, .width = 80, .height = 12 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, "SCHED") != null); // column heading
+    try testing.expect(std.mem.indexOf(u8, out, "interval 300s") != null); // the row's label
 }
 
 test "render lists services with a state dot, the state, and the auto-start hint" {

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -1148,7 +1148,7 @@ test "v6→v7 migration leaves cask_versions empty when casks has a broken shape
     _ = try stmt.step();
     try testing.expectEqual(@as(i64, 0), stmt.columnInt(0));
     // Migration still bumps the schema marker so a future run skips this path.
-    try testing.expectEqual(@as(i64, 12), try schema.currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try schema.currentVersion(&db));
 }
 
 // v7→v8 / v8→v9 ALTERs must skip when `taps` is missing entirely
@@ -1169,7 +1169,7 @@ test "v7→v8 migration tolerates a missing taps table" {
 
     try schema.migrate(&db);
 
-    try testing.expectEqual(@as(i64, 12), try schema.currentVersion(&db));
+    try testing.expectEqual(@as(i64, 13), try schema.currentVersion(&db));
 }
 
 // --- coverage: lookupCaskVersion refuses a malformed row ----------------

--- a/tests/cli_services_test.zig
+++ b/tests/cli_services_test.zig
@@ -188,6 +188,73 @@ fn seedService(prefix: []const u8, name: []const u8, keg: []const u8, auto_start
     _ = try stmt.step();
 }
 
+fn seedScheduledService(prefix: []const u8, name: []const u8, keg: []const u8, schedule: []const u8) !void {
+    var path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+
+    var stmt = try db.prepare(
+        \\INSERT INTO services(name, keg_name, plist_path, auto_start, last_status, schedule)
+        \\VALUES (?, ?, '/dev/null', 0, 'registered', ?);
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    try stmt.bindText(2, keg);
+    try stmt.bindText(3, schedule);
+    _ = try stmt.step();
+}
+
+test "execute list (human) shows the schedule label" {
+    const prefix = try setupPrefix("list_schedule_human");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+    try seedScheduledService(prefix, "backup", "backup", "interval 60s");
+
+    const prior_json = malt.output.isJson();
+    malt.output.setMode(.human);
+    defer malt.output.setMode(if (prior_json) .json else .human);
+
+    // The human table prints to stderr; stdout is reserved for --json.
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &stderr_buf);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try services_cli.execute(&ctx, testing.allocator, &.{"list"});
+
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "interval 60s") != null);
+}
+
+test "execute list --json surfaces the schedule label end-to-end" {
+    const prefix = try setupPrefix("list_schedule_json");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+    try seedScheduledService(prefix, "backup", "backup", "interval 60s");
+
+    const prior_json = malt.output.isJson();
+    malt.output.setMode(.json);
+    defer malt.output.setMode(if (prior_json) .json else .human);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    malt.output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer malt.output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try services_cli.execute(&ctx, testing.allocator, &.{"list"});
+
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"schedule\":\"interval 60s\"") != null);
+}
+
 test "execute list --json on a populated DB emits one object per row" {
     const prefix = try setupPrefix("list_populated_json");
     defer testing.allocator.free(prefix);

--- a/tests/db_schema_v2_test.zig
+++ b/tests/db_schema_v2_test.zig
@@ -54,7 +54,7 @@ test "initSchema runs v1 then migrates to the current known version" {
     try testing.expect(try tableExists(&tdb.db, "bundle_members"));
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 12), ver);
+    try testing.expectEqual(@as(i64, 13), ver);
 }
 
 test "migrate is idempotent on re-run" {
@@ -66,7 +66,7 @@ test "migrate is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 12), ver);
+    try testing.expectEqual(@as(i64, 13), ver);
 }
 
 test "v4 migration adds pinned column to casks" {
@@ -96,7 +96,7 @@ test "v4 migration is idempotent on re-run" {
     try schema.migrate(&tdb.db);
 
     const ver = try schema.currentVersion(&tdb.db);
-    try testing.expectEqual(@as(i64, 12), ver);
+    try testing.expectEqual(@as(i64, 13), ver);
 }
 
 test "v6 migration adds tap column to casks" {

--- a/tests/supervisor_pure_test.zig
+++ b/tests/supervisor_pure_test.zig
@@ -122,6 +122,8 @@ test "register writes a plist and a DB row that list reports back" {
     try testing.expectEqualStrings("testkeg", list[0].keg_name);
     try testing.expectEqualStrings("registered", list[0].last_status);
     try testing.expect(list[0].auto_start);
+    // A run-at-load service carries no schedule label.
+    try testing.expectEqualStrings("", list[0].schedule);
 
     // plist file exists on disk
     var f = try test_io.openFileAbsolute(std.Options.debug_io, list[0].plist_path, .{});
@@ -153,6 +155,7 @@ test "register writes an interval plist with StartInterval and RunAtLoad false" 
     const list = try supervisor.list(ctx);
     defer supervisor.freeServiceInfos(testing.allocator, list);
     try testing.expectEqual(@as(usize, 1), list.len);
+    try testing.expectEqualStrings("interval 3600s", list[0].schedule);
 
     // The plist that landed on disk through the real validate→render path
     // must carry the interval, not a run-at-load fallback.
@@ -162,6 +165,37 @@ test "register writes an interval plist with StartInterval and RunAtLoad false" 
     try testing.expect(std.mem.indexOf(u8, xml, "<integer>3600</integer>") != null);
     try testing.expect(std.mem.indexOf(u8, xml, "<key>RunAtLoad</key>\n    <false/>") != null);
     try testing.expect(std.mem.indexOf(u8, xml, "KeepAlive") == null);
+}
+
+test "register stores a cron schedule label that list reports back" {
+    const prefix = "/tmp/malt_sup_cron_label";
+    const cellar = prefix ++ "/Cellar/testkeg/1.0";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    _ = c.setenv("MALT_PREFIX", prefix, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    // `30 4 * * 6` → one calendar entry; the label re-renders it in cron order
+    // (minute hour day-of-month month day-of-week) with `*` for unset fields.
+    const entries = [_]plist_mod.CalendarInterval{.{ .minute = 30, .hour = 4, .weekday = 6 }};
+    const spec = plist_mod.ServiceSpec{
+        .label = "com.malt.test.cron",
+        .program_args = &.{cellar ++ "/bin/backup"},
+        .stdout_path = prefix ++ "/out.log",
+        .stderr_path = prefix ++ "/err.log",
+        .schedule = .{ .calendar = &entries },
+    };
+    const ctx: supervisor.SupervisorCtx = .{ .allocator = testing.allocator, .io = std.Options.debug_io, .db = &db };
+    try supervisor.register(ctx, spec, "testkeg", true, cellar, prefix);
+
+    const list = try supervisor.list(ctx);
+    defer supervisor.freeServiceInfos(testing.allocator, list);
+    try testing.expectEqual(@as(usize, 1), list.len);
+    try testing.expectEqualStrings("cron 30 4 * * 6", list[0].schedule);
 }
 
 test "register rejects an out-of-range interval via the validate gate" {


### PR DESCRIPTION
## Description

`mt services list` now shows *why* a service exists — its schedule (`interval 300s`, `cron 30 4 * * 6`, or run-at-load) — across the human table, `--json`, and the TUI Services tab.

## Related Issue

- None

## Notes for Reviewers

- **Schema:** v12→v13 adds a nullable `services.schedule` (fresh `CREATE` + PRAGMA-guarded `ALTER`, mirroring the prior column-adds); pre-feature rows read back as no-schedule.
