### PR TITLE
fix(tui): wrap the footer help line so a tab's action keys survive a narrow terminal

### DIFF
--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -21,6 +21,7 @@ const keys = @import("keys.zig");
 const term = @import("term.zig");
 const layout = @import("layout.zig");
 const scroll_list = @import("scroll_list.zig");
+const text_wrap = @import("text_wrap.zig");
 
 const spawn = @import("spawn.zig");
 const list_json = @import("json/list.zig");
@@ -352,25 +353,21 @@ pub fn renderFrame(buf: []u8, app: *const App, cols: u16, rows: u16) []const u8 
 
             // Footer: a rule line separating content, then — by priority — the
             // pre-read loading status, the transient error banner, or the help line.
+            // Each wraps across the footer's text rows (below the separator) so a
+            // long line keeps its tail on a narrow terminal instead of truncating.
             tab.renderSeparator(&f, r.footer, r.footer.row, false);
-            f.moveTo(r.footer.row + 1, 1);
+            const text_rows = r.footer.height -| 1;
             if (app.loading) {
                 var lb: [64]u8 = undefined;
-                f.put(color.roleCode(.accent));
-                f.putContent(scroll_list.truncate(loadingLine(&lb, app), cols));
-                f.put(color.Style.reset.code());
+                renderFooterText(&f, loadingLine(&lb, app), color.roleCode(.accent), r.footer.row + 1, text_rows, cols);
             } else if (app.banner.isSet()) {
-                // Undimmed + yellow so a recoverable failure reads as a warning,
-                // not chrome; `putContent` drops line-breakers the sanitizer let
-                // through, `truncate` keeps it within the column budget.
-                f.put(color.roleCode(.warning));
-                f.putContent(scroll_list.truncate(app.banner.slice(), cols));
-                f.put(color.Style.reset.code());
+                // Undimmed + yellow so a recoverable failure reads as a warning, not
+                // chrome; the wrap paints through `putContent`, which drops the
+                // line-breakers the sanitizer let through.
+                renderFooterText(&f, app.banner.slice(), color.roleCode(.warning), r.footer.row + 1, text_rows, cols);
             } else {
                 var hb: [256]u8 = undefined;
-                f.put(color.roleCode(.muted));
-                f.put(scroll_list.truncate(footerLine(&hb, app), cols));
-                f.put(color.Style.reset.code());
+                renderFooterText(&f, footerLine(&hb, app), color.roleCode(.muted), r.footer.row + 1, text_rows, cols);
             }
         },
     }
@@ -406,6 +403,24 @@ fn renderTooSmall(f: *tab.Frame, cols: u16, rows: u16) void {
         f.put(color.Style.reset.code());
         rest = rest[take..];
         while (rest.len > 0 and rest[0] == ' ') rest = rest[1..];
+    }
+}
+
+/// Paint `text` wrapped across at most `max_rows` rows from `start_row`, styled
+/// with `role`. Each row is positioned by a cursor move (no raw newline) and
+/// painted through `putContent` so a child-derived banner can't inject a frame
+/// line. Rows past the cap are dropped — truncation only as the last resort
+/// below the bound. Shares `text_wrap` with the detail pane, so one wrap rule.
+fn renderFooterText(f: *tab.Frame, text: []const u8, role: []const u8, start_row: u16, max_rows: u16, cols: u16) void {
+    if (cols == 0 or max_rows == 0) return;
+    var it = text_wrap.iter(text, cols);
+    var row: u16 = 0;
+    while (it.next()) |chunk| : (row += 1) {
+        if (row >= max_rows) break;
+        f.moveTo(start_row + row, 1);
+        f.put(role);
+        f.putContent(chunk);
+        f.put(color.Style.reset.code());
     }
 }
 
@@ -1426,6 +1441,28 @@ test "the footer carries the active tab's keys next to the global keys" {
     const out = renderFrame(&buf, &a, 100, 24);
     try std.testing.expect(std.mem.indexOf(u8, out, "s: start") != null); // the active tab's keys
     try std.testing.expect(std.mem.indexOf(u8, out, "switch") != null); // and the global keys
+}
+
+test "the footer wraps a long hint so the tab's action keys survive a narrow terminal" {
+    var a: App = .{ .active = .outdated };
+    var buf: [8192]u8 = undefined;
+    // 70 cols is too narrow for the composed help+hint line on one row; truncating
+    // would drop the tail (the tab's action keys), wrapping keeps them.
+    const out = renderFrame(&buf, &a, 70, 24);
+    try std.testing.expect(std.mem.indexOf(u8, out, "u: upgrade") != null); // the action key survives
+    try std.testing.expect(std.mem.indexOf(u8, out, "switch") != null); // global keys still present
+}
+
+test "renderFooterText wraps into the row cap and drops any overflow below it" {
+    var buf: [512]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    // Three rows' worth of text at width 8, but the cap is two: the third row
+    // must not paint, or the footer would bleed into the content region.
+    renderFooterText(&f, "aaaa bbbb cccc dddd eeee", color.roleCode(.muted), 6, 2, 8);
+    const out = f.slice();
+    try std.testing.expect(std.mem.indexOf(u8, out, "\x1b[6;1H") != null); // first text row
+    try std.testing.expect(std.mem.indexOf(u8, out, "\x1b[7;1H") != null); // second text row
+    try std.testing.expect(std.mem.indexOf(u8, out, "\x1b[8;1H") == null); // capped — no third row
 }
 
 test "a too-small terminal shows a wrapped, styled notice (width alone trips it)" {

--- a/src/tui/detail_pane.zig
+++ b/src/tui/detail_pane.zig
@@ -10,6 +10,7 @@
 const std = @import("std");
 const color = @import("../ui/color.zig");
 const tab = @import("tab.zig");
+const text_wrap = @import("text_wrap.zig");
 
 /// One labelled row. `value` is a single logical line; a multi-valued field
 /// (e.g. a dependency list) is pre-joined by the caller so the pane stays
@@ -87,37 +88,10 @@ fn valueWidth(field: Field, width: u16) usize {
     return if (width > prefix) width - prefix else 1;
 }
 
-const WrapIter = struct {
-    rest: []const u8,
-    width: usize,
-
-    fn next(self: *WrapIter) ?[]const u8 {
-        if (self.rest.len == 0) return null;
-        const take = wrapTake(self.rest, self.width);
-        const chunk = self.rest[0..take];
-        self.rest = trimLeading(self.rest[take..]);
-        return chunk;
-    }
-};
-
-fn wrapIter(field: Field, width: u16) WrapIter {
-    return .{ .rest = field.value, .width = valueWidth(field, width) };
-}
-
-/// Bytes of `s` for one line of at most `max` columns: break at the last space
-/// that fits, else hard-break at `max` (a single word wider than the line).
-/// Grapheme-naive — one byte ≈ one column, like the rest of the TUI.
-fn wrapTake(s: []const u8, max: usize) usize {
-    if (s.len <= max) return s.len;
-    var i = max;
-    while (i > 0) : (i -= 1) if (s[i - 1] == ' ') return i; // include the break space
-    return max; // no space in the window: hard break
-}
-
-fn trimLeading(s: []const u8) []const u8 {
-    var r = s;
-    while (r.len > 0 and r[0] == ' ') r = r[1..];
-    return r;
+// The value wraps through the shared `text_wrap` leaf, so the footer and the
+// detail pane share one wrapping rule rather than two that drift.
+fn wrapIter(field: Field, width: u16) text_wrap.Iter {
+    return text_wrap.iter(field.value, valueWidth(field, width));
 }
 
 // ─── tests ───────────────────────────────────────────────────────────

--- a/src/tui/layout.zig
+++ b/src/tui/layout.zig
@@ -31,7 +31,10 @@ pub const Regions = struct {
 pub const header_rows: u16 = 1;
 pub const tab_bar_rows: u16 = 1;
 pub const filter_rows: u16 = 1;
-pub const footer_rows: u16 = 2;
+// One separator row + two text rows: the footer help/banner line wraps into the
+// two text rows on a narrow terminal instead of truncating its tail (the active
+// tab's action keys). Bounded so the layout stays a pure function of (cols, rows).
+pub const footer_rows: u16 = 3;
 pub const min_content_rows: u16 = 1;
 pub const min_rows: u16 = header_rows + tab_bar_rows + filter_rows + footer_rows + min_content_rows;
 // The narrowest width that still shows all five tabs; below it the bar can't
@@ -136,8 +139,8 @@ test "compute reserves the header row and tiles the screen exactly" {
     try std.testing.expectEqual(@as(u16, 1), r.header.row);
     try std.testing.expectEqual(@as(u16, 2), r.tab_bar.row);
     try std.testing.expectEqual(@as(u16, 4), r.content.row);
-    try std.testing.expectEqual(@as(u16, 19), r.content.height);
-    try std.testing.expectEqual(@as(u16, 23), r.footer.row);
+    try std.testing.expectEqual(@as(u16, 18), r.content.height);
+    try std.testing.expectEqual(@as(u16, 22), r.footer.row);
     try std.testing.expect(compute(1, 1) == .too_small);
 }
 
@@ -146,7 +149,7 @@ test "min_rows reserves a row for the header" {
         header_rows + tab_bar_rows + filter_rows + footer_rows + min_content_rows,
         min_rows,
     );
-    try std.testing.expectEqual(@as(u16, 6), min_rows);
+    try std.testing.expectEqual(@as(u16, 7), min_rows);
 }
 
 test "compute is too_small when either axis alone is below the minimum" {

--- a/src/tui/text_wrap.zig
+++ b/src/tui/text_wrap.zig
@@ -1,0 +1,74 @@
+//! malt — shared line-wrap primitive for `mt tui`.
+//!
+//! Leaf module: imports only `std`. Breaks a string into successive rows of at
+//! most `width` columns, breaking at the last fitting space (hard-breaking a
+//! single over-long token). Grapheme-naive — one byte ≈ one column, like the
+//! rest of the TUI. One wrapping rule shared by `detail_pane` (field values) and
+//! the footer help line, so the two can't drift apart.
+
+const std = @import("std");
+
+/// Iterator over the wrapped rows of a string. Each `next()` yields the next
+/// row's bytes (leading spaces from the previous break trimmed) until exhausted.
+pub const Iter = struct {
+    rest: []const u8,
+    width: usize,
+
+    pub fn next(self: *Iter) ?[]const u8 {
+        if (self.rest.len == 0) return null;
+        const take = wrapTake(self.rest, self.width);
+        const chunk = self.rest[0..take];
+        self.rest = trimLeading(self.rest[take..]);
+        return chunk;
+    }
+};
+
+/// Wrap `s` into rows of at most `width` columns. `width` is floored at one so a
+/// degenerate width still makes progress instead of looping forever.
+pub fn iter(s: []const u8, width: usize) Iter {
+    return .{ .rest = s, .width = @max(@as(usize, 1), width) };
+}
+
+/// Bytes of `s` for one row of at most `max` columns: break at the last space
+/// that fits, else hard-break at `max` (a single word wider than the row).
+/// Grapheme-naive — one byte ≈ one column.
+pub fn wrapTake(s: []const u8, max: usize) usize {
+    if (s.len <= max) return s.len;
+    var i = max;
+    while (i > 0) : (i -= 1) if (s[i - 1] == ' ') return i; // include the break space
+    return max; // no space in the window: hard break
+}
+
+fn trimLeading(s: []const u8) []const u8 {
+    var r = s;
+    while (r.len > 0 and r[0] == ' ') r = r[1..];
+    return r;
+}
+
+// ─── tests ───────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "wrapTake breaks at the last space that fits" {
+    try testing.expectEqual(@as(usize, 4), wrapTake("one two three", 6)); // "one " — last space ≤ 6
+    try testing.expectEqual(@as(usize, 13), wrapTake("one two three", 99)); // whole string fits
+}
+
+test "wrapTake hard-breaks a token with no space in the window" {
+    try testing.expectEqual(@as(usize, 5), wrapTake("abcdefgh", 5)); // no space → cut at max
+}
+
+test "iter yields successive rows and trims the break space" {
+    var it = iter("one two three", 6);
+    try testing.expectEqualStrings("one ", it.next().?);
+    try testing.expectEqualStrings("two ", it.next().?);
+    try testing.expectEqualStrings("three", it.next().?);
+    try testing.expect(it.next() == null);
+}
+
+test "iter on a degenerate zero width still terminates" {
+    var it = iter("ab", 0); // floored to width 1
+    try testing.expectEqualStrings("a", it.next().?);
+    try testing.expectEqualStrings("b", it.next().?);
+    try testing.expect(it.next() == null);
+}

--- a/tests/tui_layout_test.zig
+++ b/tests/tui_layout_test.zig
@@ -38,7 +38,7 @@ test "regions tile the screen exactly across a range of sizes" {
     try expectTiles(80, 24);
     try expectTiles(120, 50);
     try expectTiles(200, 120);
-    try expectTiles(52, 6); // a narrow-but-valid size, just above the width floor
+    try expectTiles(52, 7); // a narrow-but-valid size, just above the width floor
 }
 
 test "fixed regions keep their heights; content absorbs the remainder" {


### PR DESCRIPTION
## Description

The footer now wraps across its region the same way the detail pane does, so a tab's action keys stay readable when space is tight.

## Related Issue

- None

## Notes for Reviewers

- None
