### PR TITLE
feat(cask): install font casks into the user Fonts directory

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -191,6 +191,7 @@ pub fn build(b: *std.Build) void {
         "tests/custom_theme_test.zig",
         "tests/install_local_test.zig",
         "tests/cask_extra_test.zig",
+        "tests/cask_font_install_test.zig",
         "tests/cask_resolve_test.zig",
         "tests/dsl_interpreter_extra_test.zig",
         "tests/list_test.zig",

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -8,6 +8,7 @@ const client_mod = @import("../net/client.zig");
 const archive_mod = @import("../fs/archive.zig");
 const hash_mod = @import("hash.zig");
 const child_mod = @import("child.zig");
+const cask_font = @import("cask_font.zig");
 
 pub const CaskError = error{
     ParseFailed,
@@ -828,6 +829,21 @@ pub const CaskInstaller = struct {
         const ditto_argv = [_][]const u8{ "ditto", "-xk", zip_path, extract_dir };
         child_mod.runOrFail(self.io, self.allocator, &ditto_argv) catch return error.InstallFailed;
 
+        return self.placeExtracted(extract_dir, app_dir, cask);
+    }
+
+    /// Dispatch a freshly-extracted zip to its placement strategy. Public so
+    /// the dispatch is exercisable in tests without driving ditto extraction
+    /// or the network. Returns the path recorded as `app_path`.
+    pub fn placeExtracted(self: *CaskInstaller, extract_dir: []const u8, app_dir: []const u8, cask: *const Cask) ![]const u8 {
+        // Font casks carry one `font` stanza per file and no `.app`; route
+        // them to the leaf before the .app demand below. Everything else
+        // falls through to the unchanged bundle-promotion path.
+        if (try cask_font.collectFontArtifacts(self.allocator, cask.parsed.value.object)) |entries| {
+            defer self.allocator.free(entries);
+            return self.installFontArtifacts(extract_dir, cask, entries);
+        }
+
         // Find the .app. app_name_buf owns the fallback past iterator teardown.
         var app_name_buf: [256]u8 = undefined;
         const app_name = parseAppName(cask.parsed.value.object) orelse
@@ -849,6 +865,39 @@ pub const CaskInstaller = struct {
         child_mod.runOrFail(self.io, self.allocator, &mv_argv) catch return error.InstallFailed;
 
         return dst_app;
+    }
+
+    /// Font branch of the zip dispatch. Wires the installer's environ,
+    /// prefix, and Caskroom layout to the leaf, which owns all font-
+    /// specific policy (destination, sanitization, manifest format).
+    /// Places every artifact, persists the placed-paths manifest under
+    /// `Caskroom/<token>/<version>/`, and returns that manifest path —
+    /// recorded as `app_path` so uninstall reads it back. Caller owns the
+    /// returned slice.
+    fn installFontArtifacts(
+        self: *CaskInstaller,
+        extract_dir: []const u8,
+        cask: *const Cask,
+        entries: []const cask_font.FontEntry,
+    ) ![]const u8 {
+        var fonts_buf: [512]u8 = undefined;
+        const env_home = std.process.Environ.getPosix(self.environ, "HOME");
+        const fonts_dir = cask_font.resolveFontsDir(self.prefix, env_home, &fonts_buf);
+
+        const manifest = try cask_font.placeFonts(self.io, self.allocator, extract_dir, fonts_dir, entries);
+        defer self.allocator.free(manifest);
+
+        // Create Caskroom/<token>/<version>/ before the manifest write,
+        // mirroring recordCaskroom's ordering.
+        var caskroom_buf: [512]u8 = undefined;
+        const caskroom_ver = std.fmt.bufPrint(&caskroom_buf, "{s}/Caskroom/{s}/{s}", .{
+            self.prefix, cask.token, cask.version,
+        }) catch return error.InstallFailed;
+
+        const manifest_path = try std.fmt.allocPrint(self.allocator, "{s}/{s}", .{ caskroom_ver, cask_font.MANIFEST_NAME });
+        errdefer self.allocator.free(manifest_path);
+        try cask_font.writeManifest(self.io, manifest_path, manifest);
+        return manifest_path;
     }
 
     /// Install a `.tar.gz` cask. Two shapes are supported:

--- a/tests/cask_font_install_test.zig
+++ b/tests/cask_font_install_test.zig
@@ -1,0 +1,231 @@
+//! malt — font-cask install integration
+//! Drives the post-extraction dispatch seam: a font cask routes to the
+//! cask_font leaf (placing files + recording a Caskroom manifest) while a
+//! normal app zip stays on the unchanged .app promotion path. Avoids ditto
+//! extraction and the network by feeding a pre-populated extract dir.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const test_io = @import("test_io");
+const cask = malt.cask;
+const cask_font = malt.cask_font;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+
+fn testEnviron() std.process.Environ {
+    return malt.app_ctx.processEnviron();
+}
+
+/// Materialize a fixture file (and its parents) inside the extract dir.
+fn putFile(io: std.Io, path: []const u8, body: []const u8) !void {
+    if (test_io.path.dirname(path)) |dir| try test_io.cwd().createDirPath(io, dir);
+    const f = try test_io.createFileAbsolute(io, path, .{ .truncate = true });
+    defer f.close(io);
+    try f.writeStreamingAll(io, body);
+}
+
+fn expectFileBody(io: std.Io, path: []const u8, body: []const u8) !void {
+    const got = try test_io.readFileAbsoluteAlloc(io, testing.allocator, path, 4096);
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings(body, got);
+}
+
+fn newInstaller(threaded: *std.Io.Threaded, db: *sqlite.Database, prefix: [:0]const u8) cask.CaskInstaller {
+    return cask.CaskInstaller.init(threaded.io(), testEnviron(), testing.allocator, db, prefix);
+}
+
+test "placeExtracted routes a font cask: places files and returns the Caskroom manifest path" {
+    const io = std.Options.debug_io;
+    // Non-default prefix → resolveFontsDir lands in <prefix>/Fonts, isolating
+    // the test from the real ~/Library/Fonts.
+    const prefix: [:0]const u8 = "/tmp/malt_font_install_it";
+    test_io.deleteTreeAbsolute(io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+
+    const extract = prefix ++ "/extract";
+    try putFile(io, extract ++ "/ttf/FiraCode-Bold.ttf", "BOLD");
+    try putFile(io, extract ++ "/HackNerdFont-Regular.ttf", "HACK");
+
+    const cask_json =
+        \\{"token":"font-fira-code","name":["FiraCode"],"version":"6.2","desc":"","homepage":"",
+        \\ "url":"https://example.com/FiraCode.zip","sha256":"no_check","auto_updates":false,
+        \\ "artifacts":[
+        \\   {"font":["ttf/FiraCode-Bold.ttf"],"target":"/$HOME/Library/Fonts/FiraCode-Bold.ttf"},
+        \\   {"font":["HackNerdFont-Regular.ttf"]}
+        \\ ]}
+    ;
+    var c = try cask.parseCask(testing.allocator, cask_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    var installer = newInstaller(&threaded, &db, prefix);
+
+    // app_dir is irrelevant on the font path; pass a scratch one.
+    const app_path = try installer.placeExtracted(extract, prefix ++ "/Applications", &c);
+    defer testing.allocator.free(app_path);
+
+    // Returns the manifest path under Caskroom/<token>/<version>/.
+    try testing.expectEqualStrings(prefix ++ "/Caskroom/font-fira-code/6.2/" ++ cask_font.MANIFEST_NAME, app_path);
+
+    // Both fonts placed by basename into <prefix>/Fonts.
+    const fonts = prefix ++ "/Fonts";
+    try expectFileBody(io, fonts ++ "/FiraCode-Bold.ttf", "BOLD");
+    try expectFileBody(io, fonts ++ "/HackNerdFont-Regular.ttf", "HACK");
+
+    // Manifest lists every placed absolute path, newline-joined.
+    try expectFileBody(io, app_path, fonts ++ "/FiraCode-Bold.ttf\n" ++ fonts ++ "/HackNerdFont-Regular.ttf");
+}
+
+test "placeExtracted prefers the font branch when a cask carries both app and font artifacts" {
+    const io = std.Options.debug_io;
+    const prefix: [:0]const u8 = "/tmp/malt_font_install_mixed_it";
+    test_io.deleteTreeAbsolute(io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+
+    const extract = prefix ++ "/extract";
+    try putFile(io, extract ++ "/A.ttf", "AAA");
+
+    // A non-empty font stanza must win over a sibling app stanza so a font
+    // cask never falls into the .app demand below it.
+    const cask_json =
+        \\{"token":"mixed","name":["Mixed"],"version":"3.0","desc":"","homepage":"",
+        \\ "url":"https://example.com/Mixed.zip","sha256":"no_check","auto_updates":false,
+        \\ "artifacts":[{"app":["Mixed.app"]},{"font":["A.ttf"]}]}
+    ;
+    var c = try cask.parseCask(testing.allocator, cask_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    var installer = newInstaller(&threaded, &db, prefix);
+
+    const app_path = try installer.placeExtracted(extract, prefix ++ "/Applications", &c);
+    defer testing.allocator.free(app_path);
+
+    try testing.expectEqualStrings(prefix ++ "/Caskroom/mixed/3.0/" ++ cask_font.MANIFEST_NAME, app_path);
+    try expectFileBody(io, prefix ++ "/Fonts/A.ttf", "AAA");
+}
+
+test "placeExtracted drops a traversal entry and manifests only the safe font" {
+    const io = std.Options.debug_io;
+    const prefix: [:0]const u8 = "/tmp/malt_font_install_evil_it";
+    test_io.deleteTreeAbsolute(io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+
+    const extract = prefix ++ "/extract";
+    try putFile(io, extract ++ "/Good.ttf", "GOOD");
+    // A file the cask must never be able to reach via a `..` hop.
+    try putFile(io, prefix ++ "/secret", "SECRET");
+
+    const cask_json =
+        \\{"token":"evil","name":["Evil"],"version":"1.0","desc":"","homepage":"",
+        \\ "url":"https://example.com/Evil.zip","sha256":"no_check","auto_updates":false,
+        \\ "artifacts":[{"font":["../secret"]},{"font":["Good.ttf"]}]}
+    ;
+    var c = try cask.parseCask(testing.allocator, cask_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    var installer = newInstaller(&threaded, &db, prefix);
+
+    const app_path = try installer.placeExtracted(extract, prefix ++ "/Applications", &c);
+    defer testing.allocator.free(app_path);
+
+    // Only the safe font is placed and recorded; the `..` entry is skipped.
+    const fonts = prefix ++ "/Fonts";
+    try expectFileBody(io, app_path, fonts ++ "/Good.ttf");
+    try expectFileBody(io, fonts ++ "/Good.ttf", "GOOD");
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, fonts ++ "/secret", .{}));
+}
+
+test "placeExtracted on an all-unsafe font cask places nothing and records an empty manifest" {
+    const io = std.Options.debug_io;
+    const prefix: [:0]const u8 = "/tmp/malt_font_install_allevil_it";
+    test_io.deleteTreeAbsolute(io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+
+    const extract = prefix ++ "/extract";
+    try putFile(io, extract ++ "/decoy.ttf", "DECOY");
+    try putFile(io, prefix ++ "/secret", "SECRET");
+
+    // Every stanza is attacker-crafted: a `..` hop and an absolute path. The
+    // worst case must be a no-op, never a traversal or a crash.
+    const cask_json =
+        \\{"token":"allevil","name":["AllEvil"],"version":"9.9","desc":"","homepage":"",
+        \\ "url":"https://example.com/AllEvil.zip","sha256":"no_check","auto_updates":false,
+        \\ "artifacts":[{"font":["../secret"]},{"font":["/etc/hosts"]}]}
+    ;
+    var c = try cask.parseCask(testing.allocator, cask_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    var installer = newInstaller(&threaded, &db, prefix);
+
+    const app_path = try installer.placeExtracted(extract, prefix ++ "/Applications", &c);
+    defer testing.allocator.free(app_path);
+
+    // A manifest is still written (the recorded app_path stays valid) but it
+    // lists nothing, and no file escaped into the Fonts dir.
+    try expectFileBody(io, app_path, "");
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, prefix ++ "/Fonts/secret", .{}));
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, prefix ++ "/Fonts/hosts", .{}));
+}
+
+test "placeExtracted leaves a normal app zip on the .app path and writes no font manifest" {
+    const io = std.Options.debug_io;
+    const prefix: [:0]const u8 = "/tmp/malt_font_install_app_it";
+    test_io.deleteTreeAbsolute(io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+
+    const extract = prefix ++ "/extract";
+    const app_dir = prefix ++ "/Applications";
+    try putFile(io, extract ++ "/Foo.app/Contents/Info.plist", "PLIST");
+    try test_io.cwd().createDirPath(io, app_dir);
+
+    const cask_json =
+        \\{"token":"foo","name":["Foo"],"version":"1.0","desc":"","homepage":"",
+        \\ "url":"https://example.com/Foo.zip","sha256":"no_check","auto_updates":false,
+        \\ "artifacts":[{"app":["Foo.app"]}]}
+    ;
+    var c = try cask.parseCask(testing.allocator, cask_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    var installer = newInstaller(&threaded, &db, prefix);
+
+    const app_path = try installer.placeExtracted(extract, app_dir, &c);
+    defer testing.allocator.free(app_path);
+
+    // App branch: returns the promoted bundle path, whose contents are now
+    // in place under app_dir.
+    try testing.expectEqualStrings(app_dir ++ "/Foo.app", app_path);
+    try expectFileBody(io, app_dir ++ "/Foo.app/Contents/Info.plist", "PLIST");
+
+    // The font dispatch did not fire: no Caskroom manifest was written.
+    try testing.expectError(error.FileNotFound, test_io.openDirAbsolute(io, prefix ++ "/Caskroom", .{}));
+}


### PR DESCRIPTION
## Description

`mt install --cask font-*` now installs Homebrew font and nerd-font casks into
the user's policy-resolved Fonts directory (`~/Library/Fonts`, or
`<prefix>/Fonts` under a non-default prefix), matching the brew workflow users
expect. The zip installer dispatches to the `cask_font` leaf before the `.app`
demand: it places each sanitized font file and records a per-version
`.malt-fonts` manifest under `Caskroom/<token>/<version>/`, whose path is stored
in `casks.app_path`. Reuses the existing download/verify/extract pipeline — no
new CLI flag, help, completions, or TUI change, and no DB migration. Non-font
zips keep the unchanged `.app` promotion path.

Verified end-to-end against the live Homebrew API: `font-fira-code` (nested
sources) and `font-hack-nerd-font` (bare sources) place every `.ttf` and exit
success; re-install short-circuits as a no-op.

## Related Issue

- None

## Notes for Reviewers

- Font knowledge stays confined to the `cask_font` leaf; `cask.zig` only
  orchestrates (resolve dir → place → write manifest). `placeExtracted` is `pub`
  solely as the testable dispatch seam, so the font/app routing is exercised
  without driving ditto extraction or the network.
- Tests: 5 integration tests in `tests/cask_font_install_test.zig` — font route +
  manifest content, app+font precedence, partial-traversal skip, all-unsafe
  no-op (security boundary), and the app fall-through writing no manifest. The
  dispatch decision was mutation-verified (forcing the font branch turns the app
  regression red).
- Removing placed fonts on uninstall is intentionally out of scope here and lands
  in a follow-up: uninstall currently drops the DB row + Caskroom (including the
  manifest) but leaves the font files in place, by design.
- Bench is unaffected (this is a cask-install-only path; `scripts/bench.sh`
  exercises formula installs). Binary size unchanged.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #522
- <kbd>&nbsp;4&nbsp;</kbd> #521
- <kbd>&nbsp;3&nbsp;</kbd> #520
- <kbd>&nbsp;2&nbsp;</kbd> #519 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #518
<!-- GitButler Footer Boundary Bottom -->