### PR TITLE
fix(cask): restore font files on rollback and reinstall

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -193,6 +193,7 @@ pub fn build(b: *std.Build) void {
         "tests/cask_extra_test.zig",
         "tests/cask_font_install_test.zig",
         "tests/cask_font_uninstall_test.zig",
+        "tests/cask_font_rollback_test.zig",
         "tests/cask_resolve_test.zig",
         "tests/dsl_interpreter_extra_test.zig",
         "tests/list_test.zig",

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -478,6 +478,10 @@ pub const CaskInstaller = struct {
     progress: ?client_mod.ProgressCallback,
     /// Pre-resolved type for extensionless URLs (HEAD fallback).
     artifact_type_override: ?ArtifactType = null,
+    /// Font stanzas to place instead of parsing them from the cask JSON.
+    /// Set by `reinstallFromHistory` from the per-version sidecar so a
+    /// rollback's synthetic, artifact-less cask still restores its fonts.
+    font_entries_override: ?[]const cask_font.FontEntry = null,
     /// Mirrors `ctx.offline` from the cli/ caller. Threaded onto the
     /// internal HttpClient so a download miss surfaces `OfflineRequired`
     /// instead of stalling on connect.
@@ -714,6 +718,17 @@ pub const CaskInstaller = struct {
             .parsed = parsed_empty,
         };
 
+        // Re-source font stanzas for this version from the sidecar: the
+        // synthetic cask carries no artifacts, so without this a font cask
+        // would fall through to the .app path and fail. Non-font casks have no
+        // sidecar — the override stays null and behaviour is unchanged. A read
+        // error degrades to "no override" (a font cask then fails loud at the
+        // .app path); it never aborts the rollback before the install attempt.
+        var spec_opt = self.readFontSpec(row.token, row.version) catch null;
+        defer if (spec_opt) |*s| s.deinit(self.allocator);
+        if (spec_opt) |*s| self.font_entries_override = s.entries;
+        defer self.font_entries_override = null;
+
         const app_path = try self.install(&synthetic);
         defer self.allocator.free(app_path);
 
@@ -862,6 +877,12 @@ pub const CaskInstaller = struct {
     /// the dispatch is exercisable in tests without driving ditto extraction
     /// or the network. Returns the path recorded as `app_path`.
     pub fn placeExtracted(self: *CaskInstaller, extract_dir: []const u8, app_dir: []const u8, cask: *const Cask) ![]const u8 {
+        // Rollback re-sources the stanzas via this override (the synthetic
+        // cask's JSON is empty); a fresh install collects them from the JSON.
+        if (self.font_entries_override) |entries| {
+            return self.installFontArtifacts(extract_dir, cask, entries);
+        }
+
         // Font casks carry one `font` stanza per file and no `.app`; route
         // them to the leaf before the .app demand below. Everything else
         // falls through to the unchanged bundle-promotion path.
@@ -923,7 +944,98 @@ pub const CaskInstaller = struct {
         const manifest_path = try std.fmt.allocPrint(self.allocator, "{s}/{s}", .{ caskroom_ver, cask_font.MANIFEST_NAME });
         errdefer self.allocator.free(manifest_path);
         try cask_font.writeManifest(self.io, manifest_path, manifest);
+
+        // Persist the stanzas next to the cached artifact so a later rollback
+        // restores them offline. Best-effort: a failed sidecar only degrades a
+        // future rollback, never this install (as with recordCaskVersion).
+        self.writeFontSpec(cask.token, cask.version, entries) catch {};
+
         return manifest_path;
+    }
+
+    /// Per-version sidecar of the placed font stanzas, co-located with the
+    /// cached artifact at `<prefix>/cache/Cask/<token>-<version>.fonts`. It
+    /// lets `reinstallFromHistory` re-place fonts offline without the cask
+    /// JSON, which the synthetic rollback cask lacks. Format: one
+    /// `source\ttarget` line per stanza; a tab-less line has no rename target.
+    /// Sanitization still runs in the leaf at placement, so the persisted
+    /// strings are re-validated there rather than trusted here.
+    pub const FontSpec = struct {
+        bytes: []u8,
+        entries: []cask_font.FontEntry,
+
+        pub fn deinit(self: *FontSpec, allocator: std.mem.Allocator) void {
+            allocator.free(self.entries);
+            allocator.free(self.bytes);
+        }
+    };
+
+    fn fontSpecPath(self: *CaskInstaller, token: []const u8, version: []const u8, buf: []u8) ![]const u8 {
+        return std.fmt.bufPrint(buf, "{s}/cache/Cask/{s}-{s}.fonts", .{ self.prefix, token, version });
+    }
+
+    fn writeFontSpec(self: *CaskInstaller, token: []const u8, version: []const u8, entries: []const cask_font.FontEntry) !void {
+        var path_buf: [512]u8 = undefined;
+        const path = try self.fontSpecPath(token, version, &path_buf);
+
+        var bytes: std.ArrayList(u8) = .empty;
+        defer bytes.deinit(self.allocator);
+        for (entries) |e| {
+            try bytes.appendSlice(self.allocator, e.source);
+            if (e.target) |t| {
+                try bytes.append(self.allocator, '\t');
+                try bytes.appendSlice(self.allocator, t);
+            }
+            try bytes.append(self.allocator, '\n');
+        }
+
+        if (std.fs.path.dirname(path)) |dir| try std.Io.Dir.cwd().createDirPath(self.io, dir);
+        const file = try std.Io.Dir.createFileAbsolute(self.io, path, .{ .truncate = true });
+        defer file.close(self.io);
+        try file.writeStreamingAll(self.io, bytes.items);
+    }
+
+    /// Read the sidecar for `(token, version)`, or null when none was written
+    /// (a non-font cask, or a pre-sidecar install). Entries borrow the
+    /// returned `bytes`; free both via `FontSpec.deinit`.
+    pub fn readFontSpec(self: *CaskInstaller, token: []const u8, version: []const u8) !?FontSpec {
+        var path_buf: [512]u8 = undefined;
+        const path = try self.fontSpecPath(token, version, &path_buf);
+
+        const file = std.Io.Dir.openFileAbsolute(self.io, path, .{}) catch |e| switch (e) {
+            error.FileNotFound => return null,
+            else => return e,
+        };
+        defer file.close(self.io);
+
+        const stat = try file.stat(self.io);
+        const bytes = try self.allocator.alloc(u8, stat.size);
+        errdefer self.allocator.free(bytes);
+        const n = try file.readPositionalAll(self.io, bytes, 0);
+        const data = bytes[0..n];
+
+        var count: usize = 0;
+        var counter = std.mem.splitScalar(u8, data, '\n');
+        while (counter.next()) |line| {
+            if (line.len != 0) count += 1;
+        }
+
+        const entries = try self.allocator.alloc(cask_font.FontEntry, count);
+        errdefer self.allocator.free(entries);
+
+        var i: usize = 0;
+        var it = std.mem.splitScalar(u8, data, '\n');
+        while (it.next()) |line| {
+            if (line.len == 0) continue;
+            if (std.mem.indexOfScalar(u8, line, '\t')) |t| {
+                entries[i] = .{ .source = line[0..t], .target = line[t + 1 ..] };
+            } else {
+                entries[i] = .{ .source = line, .target = null };
+            }
+            i += 1;
+        }
+
+        return .{ .bytes = bytes, .entries = entries };
     }
 
     /// Install a `.tar.gz` cask. Two shapes are supported:

--- a/tests/cask_font_rollback_test.zig
+++ b/tests/cask_font_rollback_test.zig
@@ -157,6 +157,26 @@ test "a fresh font install persists a per-version sidecar that round-trips the s
     try testing.expect(spec.entries[1].target == null);
 }
 
+fn readSpecUnderOom(alloc: std.mem.Allocator, db: *sqlite.Database, prefix: [:0]const u8) !void {
+    var installer = cask.CaskInstaller.init(std.Options.debug_io, testEnviron(), alloc, db, prefix);
+    if (try installer.readFontSpec("font-x", "1.0")) |spec| {
+        var s = spec;
+        s.deinit(alloc);
+    }
+}
+
+test "readFontSpec frees its buffers on allocation failure" {
+    const io = std.Options.debug_io;
+    const prefix: [:0]const u8 = "/tmp/malt_font_rollback_oom_it";
+    test_io.deleteTreeAbsolute(io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+    try putFile(io, prefix ++ "/cache/Cask/font-x-1.0.fonts", "ttf/A.ttf\t/x/Renamed.ttf\nB.ttf\n");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try testing.checkAllAllocationFailures(testing.allocator, readSpecUnderOom, .{ &db, prefix });
+}
+
 test "readFontSpec returns null when no sidecar was written" {
     const prefix: [:0]const u8 = "/tmp/malt_font_rollback_nospec_it";
     test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};

--- a/tests/cask_font_rollback_test.zig
+++ b/tests/cask_font_rollback_test.zig
@@ -1,0 +1,174 @@
+//! malt — font-cask rollback re-source
+//! reinstallFromHistory re-drives install() with a synthetic, artifact-less
+//! cask, so the JSON font stanzas are gone. T-004 re-sources them from a
+//! per-version sidecar written at install time and fed back via an installer
+//! override. These tests cover the two offline-testable seams: the override
+//! drives the font branch, and the sidecar round-trips the stanza list.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const test_io = @import("test_io");
+const cask = malt.cask;
+const cask_font = malt.cask_font;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+
+fn testEnviron() std.process.Environ {
+    return malt.app_ctx.processEnviron();
+}
+
+fn putFile(io: std.Io, path: []const u8, body: []const u8) !void {
+    if (test_io.path.dirname(path)) |dir| try test_io.cwd().createDirPath(io, dir);
+    const f = try test_io.createFileAbsolute(io, path, .{ .truncate = true });
+    defer f.close(io);
+    try f.writeStreamingAll(io, body);
+}
+
+fn expectFileBody(io: std.Io, path: []const u8, body: []const u8) !void {
+    const got = try test_io.readFileAbsoluteAlloc(io, testing.allocator, path, 4096);
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings(body, got);
+}
+
+// A synthetic cask the way reinstallFromHistory builds it: valid metadata but
+// no `artifacts` array, so collectFontArtifacts finds nothing.
+const synthetic_json =
+    \\{"token":"font-x","name":["FontX"],"version":"1.0","desc":"","homepage":"",
+    \\ "url":"https://example.com/x.zip","sha256":"no_check","auto_updates":false}
+;
+
+fn newInstaller(threaded: *std.Io.Threaded, db: *sqlite.Database, prefix: [:0]const u8) cask.CaskInstaller {
+    return cask.CaskInstaller.init(threaded.io(), testEnviron(), testing.allocator, db, prefix);
+}
+
+test "placeExtracted honors font_entries_override on an artifact-less cask" {
+    const io = std.Options.debug_io;
+    const prefix: [:0]const u8 = "/tmp/malt_font_rollback_override_it";
+    test_io.deleteTreeAbsolute(io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+
+    const extract = prefix ++ "/extract";
+    try putFile(io, extract ++ "/ttf/A.ttf", "AAA");
+
+    var c = try cask.parseCask(testing.allocator, synthetic_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    var installer = newInstaller(&threaded, &db, prefix);
+
+    // The override carries the stanzas the synthetic JSON lost — rollback's
+    // re-source path. With it set, the font branch must fire despite the empty
+    // artifacts.
+    const entries = [_]cask_font.FontEntry{.{ .source = "ttf/A.ttf", .target = null }};
+    installer.font_entries_override = &entries;
+
+    const app_path = try installer.placeExtracted(extract, prefix ++ "/Applications", &c);
+    defer testing.allocator.free(app_path);
+
+    try testing.expectEqualStrings(prefix ++ "/Caskroom/font-x/1.0/" ++ cask_font.MANIFEST_NAME, app_path);
+    try expectFileBody(io, prefix ++ "/Fonts/A.ttf", "AAA");
+}
+
+const font_cask_json =
+    \\{"token":"font-x","name":["FontX"],"version":"1.0","desc":"","homepage":"",
+    \\ "url":"https://example.com/x.zip","sha256":"no_check","auto_updates":false,
+    \\ "artifacts":[
+    \\   {"font":["ttf/A.ttf"],"target":"/$HOME/Library/Fonts/Renamed.ttf"},
+    \\   {"font":["B.ttf"]}
+    \\ ]}
+;
+
+test "font_entries_override is re-sanitized: a tampered sidecar entry cannot traverse" {
+    const io = std.Options.debug_io;
+    const prefix: [:0]const u8 = "/tmp/malt_font_rollback_tamper_it";
+    test_io.deleteTreeAbsolute(io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+
+    const extract = prefix ++ "/extract";
+    try putFile(io, extract ++ "/Good.ttf", "GOOD");
+    try putFile(io, prefix ++ "/secret", "SECRET");
+
+    var c = try cask.parseCask(testing.allocator, synthetic_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    var installer = newInstaller(&threaded, &db, prefix);
+
+    // The override comes from an on-disk sidecar that could be tampered; the
+    // leaf must re-sanitize at placement so a `..` hop is still rejected.
+    const entries = [_]cask_font.FontEntry{
+        .{ .source = "../secret", .target = null },
+        .{ .source = "Good.ttf", .target = null },
+    };
+    installer.font_entries_override = &entries;
+
+    const app_path = try installer.placeExtracted(extract, prefix ++ "/Applications", &c);
+    defer testing.allocator.free(app_path);
+
+    const fonts = prefix ++ "/Fonts";
+    try expectFileBody(io, fonts ++ "/Good.ttf", "GOOD");
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, fonts ++ "/secret", .{}));
+}
+
+test "a fresh font install persists a per-version sidecar that round-trips the stanzas" {
+    const io = std.Options.debug_io;
+    const prefix: [:0]const u8 = "/tmp/malt_font_rollback_sidecar_it";
+    test_io.deleteTreeAbsolute(io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+
+    const extract = prefix ++ "/extract";
+    try putFile(io, extract ++ "/ttf/A.ttf", "AAA");
+    try putFile(io, extract ++ "/B.ttf", "BBB");
+
+    var c = try cask.parseCask(testing.allocator, font_cask_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    var installer = newInstaller(&threaded, &db, prefix);
+
+    // Installing (the font branch) must persist the stanzas next to the cached
+    // artifact so a later rollback can restore them offline, JSON-free.
+    const app_path = try installer.placeExtracted(extract, prefix ++ "/Applications", &c);
+    defer testing.allocator.free(app_path);
+
+    var spec = (try installer.readFontSpec("font-x", "1.0")).?;
+    defer spec.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 2), spec.entries.len);
+    try testing.expectEqualStrings("ttf/A.ttf", spec.entries[0].source);
+    try testing.expectEqualStrings("/$HOME/Library/Fonts/Renamed.ttf", spec.entries[0].target.?);
+    try testing.expectEqualStrings("B.ttf", spec.entries[1].source);
+    try testing.expect(spec.entries[1].target == null);
+}
+
+test "readFontSpec returns null when no sidecar was written" {
+    const prefix: [:0]const u8 = "/tmp/malt_font_rollback_nospec_it";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    var installer = newInstaller(&threaded, &db, prefix);
+
+    try testing.expect((try installer.readFontSpec("absent", "9.9")) == null);
+}


### PR DESCRIPTION
## Description

`mt rollback <font-cask> --to <version>` (and any reinstall-from-history) now
restores the font files instead of failing. `reinstallFromHistory` re-drives
`install()` with a synthetic, artifact-less cask, so the JSON font stanzas are
gone and the font branch never fired → `InstallFailed`. This persists each
version's stanzas in a per-version sidecar
(`<prefix>/cache/Cask/<token>-<version>.fonts`) co-located with the cached
artifact, and re-injects them through an installer override so the font branch
fires, re-places the files, and rewrites the manifest. Offline by design: no
cask-JSON re-fetch (the API only serves the current version anyway). Non-font
rollback is byte-for-byte unchanged.

Verified end-to-end: install `font-fira-code` (7 glyphs + sidecar) → bump the
installed row → wipe the Fonts dir → `mt rollback --to 6.2` restores all 7.

## Related Issue

- None

## Notes for Reviewers

- Approach: persist stanzas in a cache-co-located sidecar (the analysis's option
  b, hardened). Beats re-fetching JSON (the API serves only the current version,
  needs network) and re-deriving from the zip by extension (abandons the
  stanza-driven contract, drops `target` renames, risks placing LICENSE/README).
  The sidecar's lifecycle matches the cached zip rollback already requires, so no
  schema migration and no new failure mode.
- Security: the sidecar is on disk and could be tampered, so the override path
  re-runs the leaf's `sanitizeFontName` at placement — a `../secret` entry is
  rejected (test included). Persisted strings are never trusted.
- Clear failure, not silent empty install: a missing sidecar (or evicted zip)
  surfaces `InstallFailed` rather than landing an empty install.
- Font knowledge stays in the leaf (`FontEntry`, sanitization); `cask.zig` owns
  the sidecar serialization adjacent to the cache layout it already manages
  (mirrors the T-003 manifest handling).
- Tests: 4 in `tests/cask_font_rollback_test.zig` — override drives the font
  branch, tamper re-sanitization, sidecar round-trip (incl. `target` rename),
  absent-sidecar → null. The networked rollback path stays covered by the
  existing reinstall/rollback regressions plus the e2e above.
- Out of scope (noted): truly offline rollback also needs the generic zip
  download to reuse the per-version cache — a cross-cutting concern for all
  casks, not font-specific.
- Bench unaffected; binary size grows only by the sidecar I/O.

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #522
- <kbd>&nbsp;4&nbsp;</kbd> #521 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #520
- <kbd>&nbsp;2&nbsp;</kbd> #519
- <kbd>&nbsp;1&nbsp;</kbd> #518
<!-- GitButler Footer Boundary Bottom -->