### PR TITLE
feat(cask): remove placed font files on uninstall

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -192,6 +192,7 @@ pub fn build(b: *std.Build) void {
         "tests/install_local_test.zig",
         "tests/cask_extra_test.zig",
         "tests/cask_font_install_test.zig",
+        "tests/cask_font_uninstall_test.zig",
         "tests/cask_resolve_test.zig",
         "tests/dsl_interpreter_extra_test.zig",
         "tests/list_test.zig",

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -598,11 +598,18 @@ pub const CaskInstaller = struct {
         if (app_path_len > 0) {
             const app_path = app_path_buf[0..app_path_len];
 
-            // Check if the app is running (best-effort)
-            if (isAppRunning(self.io, app_path)) return CaskError.UninstallFailed;
+            if (std.mem.eql(u8, std.fs.path.basename(app_path), cask_font.MANIFEST_NAME)) {
+                // Font cask: app_path is the manifest, not a removable bundle.
+                // Unlink each placed font; the Caskroom wipe below removes the
+                // manifest itself.
+                self.removeManifestedFonts(app_path);
+            } else {
+                // Check if the app is running (best-effort)
+                if (isAppRunning(self.io, app_path)) return CaskError.UninstallFailed;
 
-            // app may already be gone (manual delete); continue to DB cleanup.
-            std.Io.Dir.cwd().deleteTree(self.io, app_path) catch {};
+                // app may already be gone (manual delete); continue to DB cleanup.
+                std.Io.Dir.cwd().deleteTree(self.io, app_path) catch {};
+            }
         }
 
         // Caskroom bookkeeping; continue so later removals still run.
@@ -633,6 +640,25 @@ pub const CaskInstaller = struct {
         // failure lets the CLI caller log `db.errMsg()` instead of
         // silently leaving the row behind.
         try removeRecord(self.db, token);
+    }
+
+    /// Unlink every font recorded in the `.malt-fonts` manifest at
+    /// `manifest_path`. Best-effort by contract: a missing manifest (manual
+    /// Caskroom deletion) reads as empty and an already-removed font unlinks
+    /// as a no-op, so uninstall always proceeds to DB cleanup. The manifest
+    /// file itself is left for the caller's Caskroom wipe to remove.
+    fn removeManifestedFonts(self: *CaskInstaller, manifest_path: []const u8) void {
+        // A read error (e.g. permissions) leaves the fonts in place rather
+        // than aborting uninstall — drift is recoverable, a stuck row is not.
+        const bytes = cask_font.readManifest(self.io, self.allocator, manifest_path) catch return;
+        defer self.allocator.free(bytes);
+
+        var it = std.mem.splitScalar(u8, bytes, '\n');
+        while (it.next()) |line| {
+            if (line.len == 0) continue;
+            // Stale entry (font already gone) is a no-op; never abort here.
+            std.Io.Dir.deleteFileAbsolute(self.io, line) catch {};
+        }
     }
 
     /// Reinstall a previously-installed cask version from history. Drives

--- a/tests/cask_font_uninstall_test.zig
+++ b/tests/cask_font_uninstall_test.zig
@@ -1,0 +1,99 @@
+//! malt — font-cask uninstall integration
+//! A font cask records its `.malt-fonts` manifest path as `app_path`. Uninstall
+//! must read that manifest and unlink each placed font before wiping the
+//! Caskroom — otherwise the glyphs orphan in the Fonts dir. A missing manifest
+//! must not abort uninstall. Non-font casks keep the deleteTree(app_path) path.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const test_io = @import("test_io");
+const cask = malt.cask;
+const cask_font = malt.cask_font;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+
+fn testEnviron() std.process.Environ {
+    return malt.app_ctx.processEnviron();
+}
+
+fn putFile(io: std.Io, path: []const u8, body: []const u8) !void {
+    if (test_io.path.dirname(path)) |dir| try test_io.cwd().createDirPath(io, dir);
+    const f = try test_io.createFileAbsolute(io, path, .{ .truncate = true });
+    defer f.close(io);
+    try f.writeStreamingAll(io, body);
+}
+
+const font_cask_json =
+    \\{"token":"font-x","name":["FontX"],"version":"1.0","desc":"","homepage":"",
+    \\ "url":"https://example.com/x.zip","sha256":"no_check","auto_updates":false,
+    \\ "artifacts":[{"font":["A.ttf"]},{"font":["B.ttf"]}]}
+;
+
+fn newInstaller(threaded: *std.Io.Threaded, db: *sqlite.Database, prefix: [:0]const u8) cask.CaskInstaller {
+    return cask.CaskInstaller.init(threaded.io(), testEnviron(), testing.allocator, db, prefix);
+}
+
+test "uninstall unlinks every font listed in the manifest, then drops Caskroom and the DB row" {
+    const io = std.Options.debug_io;
+    const prefix: [:0]const u8 = "/tmp/malt_font_uninstall_it";
+    test_io.deleteTreeAbsolute(io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+
+    // Reconstruct the post-install on-disk state without driving a real
+    // install: two placed fonts plus the manifest that records them.
+    const fonts = prefix ++ "/Fonts";
+    try putFile(io, fonts ++ "/A.ttf", "AAA");
+    try putFile(io, fonts ++ "/B.ttf", "BBB");
+    const manifest_path = prefix ++ "/Caskroom/font-x/1.0/" ++ cask_font.MANIFEST_NAME;
+    try cask_font.writeManifest(io, manifest_path, fonts ++ "/A.ttf\n" ++ fonts ++ "/B.ttf");
+
+    var c = try cask.parseCask(testing.allocator, font_cask_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try cask.recordInstall(&db, &c, manifest_path, null);
+    try testing.expect(cask.isInstalled(&db, "font-x"));
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    var installer = newInstaller(&threaded, &db, prefix);
+
+    try installer.uninstall("font-x");
+
+    // Every manifested font is gone, the Caskroom (and the manifest) is wiped,
+    // and the DB row is cleared.
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, fonts ++ "/A.ttf", .{}));
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, fonts ++ "/B.ttf", .{}));
+    try testing.expectError(error.FileNotFound, test_io.openDirAbsolute(io, prefix ++ "/Caskroom/font-x", .{}));
+    try testing.expect(!cask.isInstalled(&db, "font-x"));
+}
+
+test "uninstall survives a missing manifest and still clears the DB row" {
+    const io = std.Options.debug_io;
+    const prefix: [:0]const u8 = "/tmp/malt_font_uninstall_drift_it";
+    test_io.deleteTreeAbsolute(io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+
+    // The Caskroom (and its manifest) was manually nuked: app_path points at a
+    // manifest that no longer exists. Uninstall must treat this as "nothing to
+    // unlink" and still finish cleaning the DB row.
+    const manifest_path = prefix ++ "/Caskroom/font-x/1.0/" ++ cask_font.MANIFEST_NAME;
+
+    var c = try cask.parseCask(testing.allocator, font_cask_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try cask.recordInstall(&db, &c, manifest_path, null);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    var installer = newInstaller(&threaded, &db, prefix);
+
+    try installer.uninstall("font-x");
+    try testing.expect(!cask.isInstalled(&db, "font-x"));
+}

--- a/tests/cask_font_uninstall_test.zig
+++ b/tests/cask_font_uninstall_test.zig
@@ -71,6 +71,47 @@ test "uninstall unlinks every font listed in the manifest, then drops Caskroom a
     try testing.expect(!cask.isInstalled(&db, "font-x"));
 }
 
+test "uninstall removes only manifested fonts and tolerates a stale entry" {
+    const io = std.Options.debug_io;
+    const prefix: [:0]const u8 = "/tmp/malt_font_uninstall_precise_it";
+    test_io.deleteTreeAbsolute(io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+
+    const fonts = prefix ++ "/Fonts";
+    try putFile(io, fonts ++ "/A.ttf", "AAA"); // manifested, present
+    try putFile(io, fonts ++ "/Keep.ttf", "KEEP"); // a co-resident font from another cask
+
+    // The manifest also lists a font that was already manually deleted; the
+    // stale entry must not abort uninstall, and Keep.ttf (never recorded here)
+    // must survive — the manifest is the exact record of what this cask placed.
+    const manifest_path = prefix ++ "/Caskroom/font-x/1.0/" ++ cask_font.MANIFEST_NAME;
+    try cask_font.writeManifest(io, manifest_path, fonts ++ "/A.ttf\n" ++ fonts ++ "/Gone.ttf");
+
+    var c = try cask.parseCask(testing.allocator, font_cask_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try cask.recordInstall(&db, &c, manifest_path, null);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    var installer = newInstaller(&threaded, &db, prefix);
+
+    try installer.uninstall("font-x");
+
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, fonts ++ "/A.ttf", .{}));
+    try expectKept(io, fonts ++ "/Keep.ttf", "KEEP");
+    try testing.expect(!cask.isInstalled(&db, "font-x"));
+}
+
+fn expectKept(io: std.Io, path: []const u8, body: []const u8) !void {
+    const got = try test_io.readFileAbsoluteAlloc(io, testing.allocator, path, 4096);
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings(body, got);
+}
+
 test "uninstall survives a missing manifest and still clears the DB row" {
     const io = std.Options.debug_io;
     const prefix: [:0]const u8 = "/tmp/malt_font_uninstall_drift_it";


### PR DESCRIPTION
## Description

`mt uninstall <font-cask>` now removes the font files it installed, using the
on-disk `.malt-fonts` manifest (recorded as `app_path`) as the exact record of
what was placed — no orphaned glyphs left in the Fonts directory. Uninstall reads the manifest, unlinks each listed font, then the existing `Caskroom/<token>` wipe removes the manifest itself. Non-font (app/dmg) uninstall is byte-for-byte
unchanged: it still runs the running-app check and `deleteTree(app_path)`. A manually-deleted Caskroom (missing manifest) reads as empty, so uninstall never aborts on drift and still clears the database row.

## Related Issue

- None

## Notes for Reviewers

- None