### PR TITLE
feat(tui): basket view with clear and remove keys

### DIFF
--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -439,19 +439,20 @@ fn footerLine(buf: []u8, app: *const App) []const u8 {
     if (app.editing) return footerHelp(true);
     var hb: [96]u8 = undefined;
     const hint = if (app.active == .search)
-        searchFooterHint(&hb, app.states.search.selected_count)
+        searchFooterHint(&hb, app.states.search.view, app.states.search.selected_count)
     else
         activeFooterHint(app);
     return std.fmt.bufPrint(buf, "{s}   ·   {s}", .{ footerHelp(false), hint }) catch footerHelp(false);
 }
 
-/// The Search footer hint with the live basket count folded in — the shell owns
-/// the basket, so it owns the count. `i: install N selected` once a pick is in
-/// the basket (also signalling `i` acts on the basket, not the cursor row); the
-/// bare `i: install` when empty. Built into `buf`.
-fn searchFooterHint(buf: []u8, selected: usize) []const u8 {
-    if (selected == 0) return search.footerHint();
-    return std.fmt.bufPrint(buf, "{s} {d} selected", .{ search.footerHint(), selected }) catch search.footerHint();
+/// The Search footer hint for the active view, with the live basket count folded
+/// in — the shell owns the basket, so it owns the count. `i: install N selected`
+/// once a pick is in the basket (also signalling `i` acts on the basket, not the
+/// cursor row); the bare view hint when empty. Built into `buf`.
+fn searchFooterHint(buf: []u8, view: search.View, selected: usize) []const u8 {
+    const base = search.footerHintFor(view);
+    if (selected == 0) return base;
+    return std.fmt.bufPrint(buf, "{s} {d} selected", .{ base, selected }) catch base;
 }
 
 fn footerHelp(editing: bool) []const u8 {
@@ -548,7 +549,9 @@ const LoadTicker = struct {
 /// so a pick outlives the per-query parse it was checked in. Shell-owned; the
 /// pure leaf never sees it — only the projected `checked` slice.
 const SearchSelection = struct {
-    const Entry = struct { name: []u8, kind: search_json.Kind };
+    // The leaf's borrowed-row type, so the basket view reads `entries.items`
+    // directly with no copy. The shell still owns and frees each `name`.
+    const Entry = search.SelEntry;
     entries: std.ArrayList(Entry) = .empty,
 
     fn indexOf(self: *const SearchSelection, name: []const u8, kind: search_json.Kind) ?usize {
@@ -575,6 +578,22 @@ const SearchSelection = struct {
         try self.entries.append(allocator, .{ .name = owned, .kind = kind });
     }
 
+    /// Drop the pick if present, freeing its bytes — the basket-view `d`/`space`.
+    /// Absent is a no-op, so a stale removal can never trap.
+    fn remove(self: *SearchSelection, allocator: std.mem.Allocator, name: []const u8, kind: search_json.Kind) void {
+        if (self.indexOf(name, kind)) |i| {
+            allocator.free(self.entries.items[i].name);
+            _ = self.entries.swapRemove(i); // order is irrelevant for a set
+        }
+    }
+
+    /// Empty the basket, freeing every pick's bytes — the `n` escape hatch. Keeps
+    /// the backing capacity for reuse; `deinit` releases that at teardown.
+    fn clear(self: *SearchSelection, allocator: std.mem.Allocator) void {
+        for (self.entries.items) |e| allocator.free(e.name);
+        self.entries.clearRetainingCapacity();
+    }
+
     fn deinit(self: *SearchSelection, allocator: std.mem.Allocator) void {
         for (self.entries.items) |e| allocator.free(e.name);
         self.entries.deinit(allocator);
@@ -595,11 +614,14 @@ fn projectSearchChecked(store: *Store) void {
     projectChecked(items, store.search_checked, &store.search_selected);
 }
 
-/// Mirror the shell-owned basket size onto the leaf so the pure core can gate `i`
-/// and the footer can size `N selected` — the leaf holds no allocator and never
-/// sees the selection itself. Called wherever the basket changes.
+/// Mirror the shell-owned basket onto the leaf: the count (so the core can gate
+/// `i` and the footer can size `N selected`) and the entries slice the basket view
+/// renders. The leaf holds no allocator and never owns the picks — it borrows this
+/// slice, which the shell refreshes here after every basket mutation (an append
+/// can move the backing buffer, so a stale slice would dangle).
 fn syncSearchSelectedCount(app: *App, store: *const Store) void {
     app.states.search.selected_count = store.search_selected.entries.items.len;
+    app.states.search.basket = store.search_selected.entries.items;
 }
 
 /// Owns the JSON parse results the tabs borrow from. Reads re-exec `mt … --json`
@@ -1175,6 +1197,20 @@ fn serviceSearch(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, app: *
         .toggle => {
             const m = search.selectedMatch(&app.states.search) orelse return;
             try store.search_selected.toggle(allocator, m.name, m.kind);
+            projectSearchChecked(store);
+            syncSearchSelectedCount(app, store);
+        },
+        // Drop the highlighted basket pick (read its name/kind before freeing it),
+        // then re-project so any on-screen row for it clears its checkmark.
+        .remove => {
+            const e = search.selectedBasketEntry(&app.states.search) orelse return;
+            store.search_selected.remove(allocator, e.name, e.kind);
+            projectSearchChecked(store);
+            syncSearchSelectedCount(app, store);
+        },
+        // Empty the whole basket; the projection then clears every on-screen check.
+        .clear => {
+            store.search_selected.clear(allocator);
             projectSearchChecked(store);
             syncSearchSelectedCount(app, store);
         },
@@ -2250,6 +2286,85 @@ test "re-adding a removed pick yields a single entry, not a duplicate" {
     try sel.toggle(alloc, "bat", .formula); // add again
     try std.testing.expect(sel.contains("bat", .formula));
     try std.testing.expectEqual(@as(usize, 1), sel.entries.items.len);
+}
+
+test "search selection remove deletes exactly the named pick and frees it" {
+    const alloc = std.testing.allocator; // a missed free shows up as a leak here
+    var sel: SearchSelection = .{};
+    defer sel.deinit(alloc);
+    try sel.toggle(alloc, "bat", .formula);
+    try sel.toggle(alloc, "redis", .formula);
+    sel.remove(alloc, "bat", .formula);
+    try std.testing.expect(!sel.contains("bat", .formula));
+    try std.testing.expect(sel.contains("redis", .formula)); // the other pick is untouched
+    try std.testing.expectEqual(@as(usize, 1), sel.entries.items.len);
+    sel.remove(alloc, "ghost", .cask); // an absent pick is a harmless no-op
+    try std.testing.expectEqual(@as(usize, 1), sel.entries.items.len);
+}
+
+test "search selection clear empties the basket and frees every pick" {
+    const alloc = std.testing.allocator; // a missed free shows up as a leak here
+    var sel: SearchSelection = .{};
+    defer sel.deinit(alloc);
+    try sel.toggle(alloc, "bat", .formula);
+    try sel.toggle(alloc, "redis", .cask);
+    sel.clear(alloc);
+    try std.testing.expectEqual(@as(usize, 0), sel.entries.items.len);
+    try std.testing.expect(!sel.contains("bat", .formula));
+}
+
+test "removing a basket pick re-projects its on-screen row to unchecked" {
+    const alloc = std.testing.allocator;
+    var store: Store = .{};
+    defer store.deinit(alloc);
+    store.search = try search_json.parse(alloc,
+        \\{"results":[{"name":"bat","type":"formula","installed":false}]}
+    );
+    store.search_checked = try alloc.alloc(bool, 1);
+    @memset(store.search_checked, false);
+    try store.search_selected.toggle(alloc, "bat", .formula);
+    projectSearchChecked(&store);
+    try std.testing.expect(store.search_checked[0]); // checked before the remove
+    store.search_selected.remove(alloc, "bat", .formula);
+    projectSearchChecked(&store);
+    try std.testing.expect(!store.search_checked[0]); // the row reflects the removal
+}
+
+test "the shell mirrors the basket entries onto the leaf for the basket view" {
+    const alloc = std.testing.allocator;
+    var a: App = .{ .active = .search };
+    var store: Store = .{};
+    defer store.deinit(alloc);
+    try store.search_selected.toggle(alloc, "bat", .formula);
+    syncSearchSelectedCount(&a, &store);
+    try std.testing.expectEqual(@as(usize, 1), a.states.search.basket.len);
+    try std.testing.expectEqualStrings("bat", a.states.search.basket[0].name);
+}
+
+test "removing a pick then installing builds an argv without the removed name" {
+    const alloc = std.testing.allocator;
+    var sel: SearchSelection = .{};
+    defer sel.deinit(alloc);
+    // Two picks gathered across queries (the cross-query basket); the user opens
+    // the basket view, removes bat, then installs — only redis reaches the argv.
+    try sel.toggle(alloc, "bat", .formula);
+    try sel.toggle(alloc, "redis", .formula);
+    sel.remove(alloc, "bat", .formula);
+    const st: search.State = .{ .items = &.{} };
+    const argv = (try installArgv(alloc, "/bin/mt", &sel, &st)).?;
+    defer alloc.free(argv);
+    try std.testing.expectEqual(@as(usize, 4), argv.len); // single → mt, install, --formula, name
+    try std.testing.expectEqualStrings("redis", argv[3]);
+    try std.testing.expect(std.mem.indexOf(u8, argv[3], "bat") == null);
+}
+
+test "the Search footer switches to the basket-view keys when the basket view is open" {
+    var a: App = .{ .active = .search };
+    a.states.search.view = .basket;
+    var buf: [8192]u8 = undefined;
+    const out = renderFrame(&buf, &a, 120, 24);
+    try std.testing.expect(std.mem.indexOf(u8, out, "remove") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "l: results") != null);
 }
 
 test "projectChecked leaves every row unchecked for an empty selection" {

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -22,11 +22,11 @@ const std = @import("std");
 const testing = std.testing;
 
 const color = @import("../ui/color.zig");
+const detail_pane = @import("detail_pane.zig");
+const info_json = @import("json/info.zig");
 const search_json = @import("json/search.zig");
 pub const Match = search_json.Match;
 const Kind = search_json.Kind;
-const info_json = @import("json/info.zig");
-const detail_pane = @import("detail_pane.zig");
 const scroll_list = @import("scroll_list.zig");
 const tab = @import("tab.zig");
 
@@ -231,11 +231,17 @@ fn renderResults(s: *const State, f: *tab.Frame, r: tab.Rect) void {
 /// `(basket, rect)` so a resize is a re-render.
 fn renderBasket(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     if (s.basket.len == 0) return tab.renderHint(f, rect, "Nothing selected.");
-    tab.renderHeading(f, rect, 0, &.{
+    // A dim title orients a fresh toggle-in and carries the count, so the row it
+    // costs isn't pure decoration.
+    var tb: [48]u8 = undefined;
+    tab.renderHint(f, rect, std.fmt.bufPrint(&tb, "Basket - {d} selected", .{s.basket.len}) catch "Basket");
+    const head: tab.Rect = .{ .row = rect.row + 1, .col = rect.col, .width = rect.width, .height = rect.height -| 1 };
+    if (head.height == 0) return; // the title took the only row
+    tab.renderHeading(f, head, 0, &.{
         .{ .label = "NAME", .width = 28 },
         .{ .label = "KIND", .width = 8 },
     });
-    const list: tab.Rect = .{ .row = rect.row + 1, .col = rect.col, .width = rect.width, .height = rect.height -| 1 };
+    const list: tab.Rect = .{ .row = head.row + 1, .col = head.col, .width = head.width, .height = head.height -| 1 };
     if (list.height == 0) return; // the heading took the only row
     const v = scroll_list.clamp(s.chrome.view, s.basket.len, list.height);
     for (s.basket, 0..) |e, i| {
@@ -597,6 +603,18 @@ test "the basket view lists every pick, including ones off the current results" 
     try testing.expect(std.mem.indexOf(u8, out, "firefox") != null);
     try testing.expect(std.mem.indexOf(u8, out, "formula") != null);
     try testing.expect(std.mem.indexOf(u8, out, "cask") != null);
+}
+
+test "the basket view heads the list with a dim selected-count title" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const s: State = .{ .phase = .loaded, .view = .basket, .basket = &basket_sample }; // 2 picks
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, "Basket") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "2 selected") != null); // the live count
+    try testing.expect(std.mem.indexOf(u8, out, color.roleCode(.muted)) != null); // dim
+    try testing.expect(std.mem.indexOf(u8, out, "bat") != null); // the list still renders below
 }
 
 test "the basket view shows a placeholder when nothing is selected, not a blank pane" {

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -35,14 +35,20 @@ const tab = @import("tab.zig");
 /// `search` (re)runs the committed query; `install` installs the selection;
 /// `info` opens `mt info` for the active hit (works for uninstalled hits too);
 /// `toggle` adds/removes the active hit in the shell-owned cross-query basket
-/// (selection outlives the per-query result list, so the leaf cannot own it).
-pub const Request = enum { none, search, install, info, toggle };
+/// (selection outlives the per-query result list, so the leaf cannot own it);
+/// `remove` drops the highlighted basket pick; `clear` empties the whole basket.
+pub const Request = enum { none, search, install, info, toggle, remove, clear };
 
 /// The read lifecycle the render reflects. `idle` before any query is committed
 /// (show guidance), `searching` while the blocking remote read runs (the shell
 /// flips it and repaints first), `loaded` once results are parsed (the list, or
 /// "no matches" when empty).
 pub const Phase = enum { idle, searching, loaded };
+
+/// Which list the body shows. `results` is the ranked query hits (default);
+/// `basket` is the cross-query selection, so a pick made under an earlier query
+/// stays visible — and removable — even when its row is off the current results.
+pub const View = enum { results, basket };
 
 pub const State = struct {
     chrome: tab.Chrome = .{},
@@ -62,15 +68,37 @@ pub const State = struct {
     /// allocator here). Gates `i` (a non-empty basket installs even with no rows
     /// on screen) and sizes the footer's `N selected`.
     selected_count: usize = 0,
+    /// The cross-query basket's entries, borrowed from the shell-owned set (no
+    /// allocator here). Rendered in the `basket` view and indexed by the cursor
+    /// there; the leaf reads names/kinds only — the shell owns and frees them.
+    basket: []const SelEntry = &.{},
+    /// Which list the body shows; `l` toggles it.
+    view: View = .results,
 };
+
+/// One basket row the shell hands the leaf: a borrowed `(name, kind)`. The bytes
+/// are owned (and freed) by the shell-owned set; the leaf renders them (scrubbed)
+/// and reads them to name a removal — never interprets or frees them.
+pub const SelEntry = struct { name: []const u8, kind: Kind };
 
 pub fn title() []const u8 {
     return "Search";
 }
 
 /// The tab's action keys, surfaced in the shared footer next to the global keys.
+/// The contract default is the results view; the shell calls `footerHintFor` with
+/// the live view so the footer tracks `l`.
 pub fn footerHint() []const u8 {
-    return "space: select   enter: info   i: install";
+    return footerHintFor(.results);
+}
+
+/// The action keys for a given view. Both hints end in `i: install` so the shell
+/// can fold the basket count straight onto the tail (`i: install N selected`).
+pub fn footerHintFor(view: View) []const u8 {
+    return switch (view) {
+        .results => "space: select   enter: info   l: basket   i: install",
+        .basket => "space/d: remove   l: results   n: clear   i: install",
+    };
 }
 
 /// The hit the selection points at, clamping the (shell-driven, unbounded)
@@ -98,6 +126,28 @@ fn requestToggle(s: *State) void {
     s.request = .toggle;
 }
 
+/// The basket pick the cursor points at, clamping the (shell-driven, unbounded)
+/// selection into the basket. The shell reads its `name`/`kind` to resolve a
+/// removal. Null on an empty basket.
+pub fn selectedBasketEntry(s: *const State) ?SelEntry {
+    if (s.basket.len == 0) return null;
+    return s.basket[@min(s.chrome.view.selected, s.basket.len - 1)];
+}
+
+/// Request dropping the highlighted basket pick; inert on an empty basket.
+fn requestRemove(s: *State) void {
+    if (selectedBasketEntry(s) != null) s.request = .remove;
+}
+
+/// `space` selects in the results view and removes in the basket view — the one
+/// key, its meaning set by the view.
+fn selectKey(s: *State) void {
+    switch (s.view) {
+        .results => requestToggle(s),
+        .basket => requestRemove(s),
+    }
+}
+
 /// Pure transition. Enter (re)runs the committed query — the filter doubles as
 /// the search box, so committing it is the search. `i` installs the selected hit
 /// when it is not already installed; on an installed hit it is inert.
@@ -109,11 +159,22 @@ pub fn step(s: *State, key: tab.Key) void {
         .enter => if (selectedMatch(s) != null) {
             s.request = .info;
         },
-        .space => requestToggle(s),
-        // `i` installs the multi-selection (or the active row when nothing is
-        // checked); inert when there is nothing installable to do.
-        .char => |c| if (c.len == 1 and c.bytes[0] == 'i') {
-            if (anyInstallable(s)) s.request = .install;
+        // `space` selects in the results view and removes in the basket view; `d`
+        // is the basket-view remove alias and is inert in the results view.
+        .space => selectKey(s),
+        .char => |c| if (c.len == 1) switch (c.bytes[0]) {
+            // `i` installs the multi-selection (or the active row when nothing is
+            // checked); inert when there is nothing installable to do.
+            'i' => if (anyInstallable(s)) {
+                s.request = .install;
+            },
+            'l' => s.view = if (s.view == .results) .basket else .results,
+            // `n` clears the whole basket from either view; inert when it is empty.
+            'n' => if (s.selected_count > 0) {
+                s.request = .clear;
+            },
+            'd' => if (s.view == .basket) requestRemove(s),
+            else => {},
         },
         .esc => s.detail = null, // close the info pane
         else => {},
@@ -144,7 +205,16 @@ fn kindLabel(k: Kind) []const u8 {
 /// re-render.
 pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     if (r.height == 0) return;
-    // Keys live in the shared footer now, so the body owns the whole rect.
+    // Keys live in the shared footer now, so the body owns the whole rect. The
+    // basket view is phase-independent: it shows the cross-query picks, which
+    // outlive any single query's lifecycle.
+    switch (s.view) {
+        .results => renderResults(s, f, r),
+        .basket => renderBasket(s, f, r),
+    }
+}
+
+fn renderResults(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     switch (s.phase) {
         .searching => renderStatus(f, r, "searching…"),
         .idle => renderStatus(f, r, "Press Enter or / to type a query, then Enter to search."),
@@ -153,6 +223,45 @@ pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
         else
             renderLoaded(s, f, r),
     }
+}
+
+/// The cross-query basket: every pick listed by `(name, kind)`, with the cursor
+/// row highlighted. No checkbox — membership is the list — and the names go
+/// through `putContent`, so a hostile pick name stays inert. A pure function of
+/// `(basket, rect)` so a resize is a re-render.
+fn renderBasket(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
+    if (s.basket.len == 0) return tab.renderHint(f, rect, "Nothing selected.");
+    tab.renderHeading(f, rect, 0, &.{
+        .{ .label = "NAME", .width = 28 },
+        .{ .label = "KIND", .width = 8 },
+    });
+    const list: tab.Rect = .{ .row = rect.row + 1, .col = rect.col, .width = rect.width, .height = rect.height -| 1 };
+    if (list.height == 0) return; // the heading took the only row
+    const v = scroll_list.clamp(s.chrome.view, s.basket.len, list.height);
+    for (s.basket, 0..) |e, i| {
+        if (i < v.offset) continue;
+        const screen = i - v.offset;
+        if (screen >= list.height) break;
+        f.moveTo(list.row + @as(u16, @intCast(screen)), list.col);
+        const selected = i == v.selected;
+        if (selected) {
+            f.put(color.selectionAccent());
+            f.put(color.Style.reverse.code());
+        }
+        var rb: [256]u8 = undefined;
+        f.putContent(scroll_list.truncate(formatBasketRow(&rb, e), list.width));
+        if (selected) f.put(color.Style.reset.code());
+    }
+}
+
+/// One basket row: the package name and its kind, same column widths as a result
+/// row's. ASCII columns, grapheme-naive like the rest.
+fn formatBasketRow(buf: []u8, e: SelEntry) []const u8 {
+    var len: usize = 0;
+    appendPad(buf, &len, e.name, 28);
+    append(buf, &len, " ");
+    appendPad(buf, &len, kindLabel(e.kind), 8);
+    return buf[0..len];
 }
 
 /// The results, with an `mt info` pane docked at the bottom when one is open.
@@ -460,6 +569,127 @@ test "render highlights the selected hit" {
 test "footerHint exposes the tab's action keys for the shared footer" {
     try testing.expect(std.mem.indexOf(u8, footerHint(), "select") != null);
     try testing.expect(std.mem.indexOf(u8, footerHint(), "install") != null);
+}
+
+test "l flips the body between the results and basket views" {
+    var s: State = .{ .items = &sample, .phase = .loaded };
+    try testing.expectEqual(View.results, s.view); // results by default
+    step(&s, ch('l'));
+    try testing.expectEqual(View.basket, s.view);
+    step(&s, ch('l')); // and back
+    try testing.expectEqual(View.results, s.view);
+}
+
+const basket_sample = [_]SelEntry{
+    .{ .name = "bat", .kind = .formula },
+    .{ .name = "firefox", .kind = .cask },
+};
+
+test "the basket view lists every pick, including ones off the current results" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    // `sample` holds wget/firefox/ripgrep; the basket holds bat (off the results)
+    // and firefox. The basket view must show bat even though no result row carries it.
+    const s: State = .{ .items = &sample, .phase = .loaded, .view = .basket, .basket = &basket_sample };
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, "bat") != null); // an off-results pick is visible
+    try testing.expect(std.mem.indexOf(u8, out, "firefox") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "formula") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "cask") != null);
+}
+
+test "the basket view shows a placeholder when nothing is selected, not a blank pane" {
+    var buf: [1024]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const s: State = .{ .items = &sample, .phase = .loaded, .view = .basket, .basket = &.{} };
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
+    try testing.expect(std.mem.indexOf(u8, f.slice(), "Nothing selected") != null);
+}
+
+test "a hostile basket name cannot inject a control sequence into the frame" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const evil = [_]SelEntry{.{ .name = "ev\x1b]0;pwn\x07il", .kind = .formula }};
+    const s: State = .{ .phase = .loaded, .view = .basket, .basket = &evil };
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 });
+    const out = f.slice();
+    try testing.expect(std.mem.indexOf(u8, out, "\x1b]0;pwn") == null); // OSC introducer broken
+    try testing.expect(std.mem.indexOfScalar(u8, out, 0x07) == null); // BEL dropped
+}
+
+test "the basket view on a zero-height rect is a clean no-op" {
+    var buf: [256]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    const s: State = .{ .phase = .loaded, .view = .basket, .basket = &basket_sample };
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 0 }); // must not trap
+    try testing.expectEqual(@as(usize, 0), f.slice().len);
+}
+
+test "selectedBasketEntry names the highlighted pick, clamping the cursor" {
+    var s: State = .{ .view = .basket, .basket = &basket_sample };
+    s.chrome.view.selected = 0;
+    try testing.expectEqualStrings("bat", selectedBasketEntry(&s).?.name);
+    s.chrome.view.selected = 99; // clamps to the last pick
+    try testing.expectEqualStrings("firefox", selectedBasketEntry(&s).?.name);
+}
+
+test "selectedBasketEntry on an empty basket is null" {
+    const s: State = .{ .view = .basket, .basket = &.{} };
+    try testing.expect(selectedBasketEntry(&s) == null);
+}
+
+test "space in the basket view requests removing the highlighted pick" {
+    var s: State = .{ .view = .basket, .basket = &basket_sample };
+    s.chrome.view.selected = 0;
+    step(&s, .space);
+    try testing.expectEqual(Request.remove, s.request);
+}
+
+test "d in the basket view also requests a remove" {
+    var s: State = .{ .view = .basket, .basket = &basket_sample };
+    s.chrome.view.selected = 1;
+    step(&s, ch('d'));
+    try testing.expectEqual(Request.remove, s.request);
+}
+
+test "d in the results view is inert (remove is a basket-only key)" {
+    var s: State = .{ .items = &sample, .phase = .loaded, .view = .results };
+    step(&s, ch('d'));
+    try testing.expectEqual(Request.none, s.request);
+}
+
+test "space in the basket view is inert when the basket is empty" {
+    var s: State = .{ .view = .basket, .basket = &.{} };
+    step(&s, .space);
+    try testing.expectEqual(Request.none, s.request);
+}
+
+test "n requests clearing the basket from either view when it holds picks" {
+    var s: State = .{ .items = &sample, .phase = .loaded, .selected_count = 2 };
+    step(&s, ch('n')); // results view
+    try testing.expectEqual(Request.clear, s.request);
+
+    s.request = .none;
+    s.view = .basket;
+    step(&s, ch('n')); // basket view
+    try testing.expectEqual(Request.clear, s.request);
+}
+
+test "n on an empty basket is inert" {
+    var s: State = .{ .items = &sample, .phase = .loaded, .selected_count = 0 };
+    step(&s, ch('n'));
+    try testing.expectEqual(Request.none, s.request);
+}
+
+test "the footer hint reflects the active view" {
+    // Results view: the select/install keys plus the basket toggle.
+    try testing.expect(std.mem.indexOf(u8, footerHintFor(.results), "l: basket") != null);
+    try testing.expect(std.mem.indexOf(u8, footerHintFor(.results), "install") != null);
+    // Basket view: remove + the toggle back to results.
+    try testing.expect(std.mem.indexOf(u8, footerHintFor(.basket), "remove") != null);
+    try testing.expect(std.mem.indexOf(u8, footerHintFor(.basket), "l: results") != null);
+    try testing.expect(std.mem.indexOf(u8, footerHintFor(.basket), "install") != null);
 }
 
 test "render reflows: the same state at two widths differs" {

--- a/tests/tui_search_test.zig
+++ b/tests/tui_search_test.zig
@@ -104,6 +104,33 @@ test "i fires for a cross-query basket even when the cursor sits on an installed
     try testing.expectEqual(search.Request.none, st.request);
 }
 
+test "the basket view surfaces and removes an off-results pick from a real query" {
+    const bytes = try readFixture(testing.allocator, "tui_search.json");
+    defer testing.allocator.free(bytes);
+    var parsed = try search_json.parse(testing.allocator, bytes);
+    defer parsed.deinit();
+
+    // The cross-query case the basket exists for: `gimp` was checked under an
+    // earlier query and is absent from this result set, while `firejail` is on
+    // screen. The shell hands both to the leaf as the borrowed basket.
+    const basket = [_]search.SelEntry{
+        .{ .name = "gimp", .kind = .cask }, // off the current results
+        .{ .name = "firejail", .kind = .formula }, // also a row in the fixture
+    };
+    var st: search.State = .{ .items = parsed.items, .phase = .loaded, .basket = &basket };
+
+    // `l` opens the basket; the off-results pick is the highlighted row.
+    search.step(&st, ch('l'));
+    try testing.expectEqual(search.View.basket, st.view);
+    st.chrome.view.selected = 0;
+    try testing.expectEqualStrings("gimp", search.selectedBasketEntry(&st).?.name);
+
+    // `d` asks the shell to drop exactly that pick — the name the removal carries.
+    search.step(&st, ch('d'));
+    try testing.expectEqual(search.Request.remove, st.request);
+    try testing.expectEqualStrings("gimp", search.selectedBasketEntry(&st).?.name);
+}
+
 test "Enter over a result requests its info (committing the query is the shell's job)" {
     const bytes = try readFixture(testing.allocator, "tui_search.json");
     defer testing.allocator.free(bytes);


### PR DESCRIPTION
## Description

The TUI Search tab gains a basket view: press `l` to switch between the search results and the list of everything you have selected across all your searches, so packages picked under an earlier query are no longer invisible. In the basket view you can remove an entry you no longer want (`space`/`d`), and `n` clears the whole basket from either view. Selected-package names stay scrubbed on screen, the same as search results.

## Related Issue

- None

## Notes for Reviewers

- None
