### PR TITLE
fix(test): stop parallel outdated_test runs from clobbering each other's cache

### DIFF
--- a/scripts/regressions/outdated_test_concurrent_tmp_isolation.sh
+++ b/scripts/regressions/outdated_test_concurrent_tmp_isolation.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Regression: each outdated_test cache dir must be unique per process+init, so
+# two overlapping test runs cannot wipe each other's seeded cache mid-test.
+#
+# The bug: the test helpers opened a FIXED /tmp path and deleteTree'd it on
+# setup. A second concurrent outdated_test process wiped the first's seeded
+# cache, surfacing as `expected N, found 0` (TestExpectedEqual) or
+# `unexpected errno: 22` on a directory whose parent vanished underneath it.
+# A single isolated run never collides — which is exactly why it read as a
+# non-reproducing flake.
+#
+# This script forces the race: it runs several outdated_test processes
+# concurrently and fails if any temp-path corruption signature appears. The
+# unrelated, still-open sqlite WAL `OpenFailed` flake is deliberately ignored so
+# this guard does not itself flake on it.
+#
+# Usage: scripts/regressions/outdated_test_concurrent_tmp_isolation.sh
+# Requirements: built test binary at zig-out/test-bin/outdated_test.
+# No network access required.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="$ROOT/zig-out/test-bin/outdated_test"
+[[ -x "$BIN" ]] || zig build test-bin >/dev/null 2>&1 || true
+[[ -x "$BIN" ]] || {
+  echo "build the test binary first: zig build test-bin" >&2
+  exit 2
+}
+
+WORK=$(mktemp -d -t malt_outdated_conc.XXXXXX)
+trap 'rm -rf "$WORK" /tmp/malt_outdated_test_* /tmp/malt_outdated_pinned_* /tmp/malt_update_test_* 2>/dev/null || true' EXIT
+
+CONC=8
+ROUNDS=6
+for _ in $(seq 1 "$ROUNDS"); do
+  for j in $(seq 1 "$CONC"); do
+    "$BIN" >"$WORK/o.$$.$j.$RANDOM" 2>&1 &
+  done
+  # A process may exit non-zero on the orthogonal WAL flake; ignore exit codes
+  # here — the temp-path verdict comes solely from the signature grep below.
+  wait || true
+done
+
+if grep -rqE "found 0|unexpected errno: 22" "$WORK"; then
+  echo "FAIL: concurrent outdated_test runs corrupted a shared temp cache dir" >&2
+  grep -rhE "found 0|unexpected errno: 22" "$WORK" | sort -u | head >&2
+  exit 1
+fi
+
+echo "ok: $((CONC * ROUNDS)) concurrent outdated_test runs, no temp-path corruption"

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -18,22 +18,50 @@ const schema = malt.schema;
 const c = struct {
     extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
     extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+    extern "c" fn getpid() c_int;
 };
 
 // --- Integration: collectOutdatedFormulas / collectOutdatedCasks ---
 
+// Per-init counter; with the pid it makes every cache dir unique across both
+// concurrent processes and repeated inits within one process.
+var temp_seq = std.atomic.Value(u32).init(0);
+
 const TempCacheDir = struct {
+    allocator: std.mem.Allocator,
     path: []const u8,
 
-    fn init(comptime tag: []const u8) !TempCacheDir {
-        const p = "/tmp/malt_outdated_test_" ++ tag;
+    fn init(allocator: std.mem.Allocator, tag: []const u8) !TempCacheDir {
+        // Unique per process+init so overlapping test runs never share a tree
+        // (a shared tree let one init's deleteTree wipe another's seeded cache).
+        const p = try std.fmt.allocPrint(allocator, "/tmp/malt_outdated_test_{s}_{d}_{d}", .{
+            tag, c.getpid(), temp_seq.fetchAdd(1, .monotonic),
+        });
+        errdefer allocator.free(p);
         test_io.deleteTreeAbsolute(std.Options.debug_io, p) catch {};
         try test_io.makeDirAbsolute(std.Options.debug_io, p);
-        return .{ .path = p };
+        return .{ .allocator = allocator, .path = p };
     }
 
     fn deinit(self: *TempCacheDir) void {
         test_io.deleteTreeAbsolute(std.Options.debug_io, self.path) catch {};
+        self.allocator.free(self.path);
+    }
+
+    // Two instances sharing a tag model two concurrent test processes opening
+    // their cache dir. The second's setup must not wipe the first's seeded
+    // files — that clobber is what makes the suite flaky under overlapping runs.
+    test "a second cache dir with the same tag does not clobber the first" {
+        var a = try TempCacheDir.init(testing.allocator, "clobber_guard");
+        defer a.deinit();
+        try a.writeCacheFile("formula_x.json", "{}");
+
+        var b = try TempCacheDir.init(testing.allocator, "clobber_guard");
+        defer b.deinit();
+
+        var buf: [512]u8 = undefined;
+        const seeded = try std.fmt.bufPrint(&buf, "{s}/api/formula_x.json", .{a.path});
+        try test_io.accessAbsolute(std.Options.debug_io, seeded, .{});
     }
 
     fn writeCacheFile(self: *TempCacheDir, rel: []const u8, content: []const u8) !void {
@@ -96,7 +124,7 @@ fn seedCask(dir: *TempCacheDir, token: []const u8, latest: []const u8) !void {
 test "collectOutdatedFormulas (small-N, single-client path) returns sorted outdated rows only" {
     var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
     defer http.deinit();
-    var dir = try TempCacheDir.init("formulas_small");
+    var dir = try TempCacheDir.init(testing.allocator, "formulas_small");
     defer dir.deinit();
 
     try seedFormula(&dir, "alpha", "2.0");
@@ -128,7 +156,7 @@ test "collectOutdatedFormulas (small-N, single-client path) returns sorted outda
 test "collectOutdatedFormulas (large-N, pool path) preserves sorted order" {
     var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
     defer http.deinit();
-    var dir = try TempCacheDir.init("formulas_large");
+    var dir = try TempCacheDir.init(testing.allocator, "formulas_large");
     defer dir.deinit();
 
     // 10 fake formulas, all outdated (installed=1.0, latest=2.0).
@@ -162,7 +190,7 @@ test "collectOutdatedFormulas tolerates a missing/404 entry without aborting" {
     // whole command.
     var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
     defer http.deinit();
-    var dir = try TempCacheDir.init("formulas_partial");
+    var dir = try TempCacheDir.init(testing.allocator, "formulas_partial");
     defer dir.deinit();
 
     try seedFormula(&dir, "alpha", "2.0");
@@ -190,7 +218,7 @@ test "collectOutdatedFormulas tolerates a missing/404 entry without aborting" {
 test "collectOutdatedCasks (small-N) returns sorted outdated rows only" {
     var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
     defer http.deinit();
-    var dir = try TempCacheDir.init("casks_small");
+    var dir = try TempCacheDir.init(testing.allocator, "casks_small");
     defer dir.deinit();
 
     try seedCask(&dir, "appone", "5.0");
@@ -218,7 +246,7 @@ test "collectOutdatedCasks (small-N) returns sorted outdated rows only" {
 test "collectOutdatedCasks (large-N, pool path) preserves sorted order" {
     var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
     defer http.deinit();
-    var dir = try TempCacheDir.init("casks_large");
+    var dir = try TempCacheDir.init(testing.allocator, "casks_large");
     defer dir.deinit();
 
     const tokens = [_][]const u8{
@@ -1169,7 +1197,7 @@ test "outdated execute --refresh skips the snapshot and recomputes" {
 }
 
 test "writeSnapshot then readSnapshot round-trips entries through the cache file" {
-    var dir = try TempCacheDir.init("snapshot_round_trip");
+    var dir = try TempCacheDir.init(testing.allocator, "snapshot_round_trip");
     defer dir.deinit();
 
     const formulas = [_]outdated_mod.OutdatedEntry{
@@ -1199,13 +1227,13 @@ test "writeSnapshot then readSnapshot round-trips entries through the cache file
 }
 
 test "readSnapshot returns null when the file is missing" {
-    var dir = try TempCacheDir.init("snapshot_missing");
+    var dir = try TempCacheDir.init(testing.allocator, "snapshot_missing");
     defer dir.deinit();
     try testing.expectEqual(@as(?outdated_mod.OwnedSnapshot, null), outdated_mod.readSnapshot(std.Options.debug_io, testing.allocator, dir.path));
 }
 
 test "readSnapshot returns null on garbage contents" {
-    var dir = try TempCacheDir.init("snapshot_garbage");
+    var dir = try TempCacheDir.init(testing.allocator, "snapshot_garbage");
     defer dir.deinit();
     const path = try outdated_mod.snapshotPath(testing.allocator, dir.path);
     defer testing.allocator.free(path);
@@ -1216,8 +1244,12 @@ test "readSnapshot returns null on garbage contents" {
 }
 
 test "writeSnapshot creates the cache directory if missing" {
-    const tag = "snapshot_mkdir";
-    const path = "/tmp/malt_outdated_test_" ++ tag;
+    // Unique per process+init so overlapping runs don't share this dir; it must
+    // not exist yet, so writeSnapshot is the one that creates it.
+    const path = try std.fmt.allocPrint(testing.allocator, "/tmp/malt_outdated_test_snapshot_mkdir_{d}_{d}", .{
+        c.getpid(), temp_seq.fetchAdd(1, .monotonic),
+    });
+    defer testing.allocator.free(path);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
 


### PR DESCRIPTION
## Description

`outdated_test` failed intermittently under `zig build test`, reporting a couple of failing cases (`expected N, found 0`) with no stable repro - same seed, different outcome.

**Root cause:** the test's per-case cache directories used a **fixed** `/tmp` path and wiped it on setup. When two `outdated_test` processes overlapped (e.g. two `zig build test` / `test-bin` runs, or a coverage run alongside a test run), one process's setup deleted the other's freshly-seeded cache mid-test, so the reader found an empty cache. A single isolated run never collides - which is exactly why it read as a non-deterministic flake.

**Fix:** make each cache directory unique per process and per init, so overlapping runs stay fully isolated. Pure test-infrastructure change - no production code is touched and the shipped binary is unchanged.

A regression guard forces the parallel race and fails on the temp-path corruption signature,.

## Related Issue

- None

## Notes for Reviewers

- Test-only change