### PR TITLE
test(e2e): keep TUI delegation roundtrip green under full-suite load

### DIFF
--- a/scripts/e2e/tui_delegation_roundtrip.sh
+++ b/scripts/e2e/tui_delegation_roundtrip.sh
@@ -46,10 +46,10 @@ settle 0.4
 send x
 settle 0.4
 send y
-settle 1.2
+settle 2.0
 mark DONE
 send q
-quitwait 1.5
+quitwait 3.0
 ACT
 )
 echo "$out" | grep -q "EXIT_STATUS=0" || fail "mt tui did not exit 0 on q ($out)"


### PR DESCRIPTION
## Description

The TUI delegation roundtrip e2e drives the heaviest path in the suite: it drops the alt-screen, re-execs a real `mt uninstall`, re-enters, and refetches the pane before quitting. When the box is busy - running the full ship-readiness suite right before the bench - that delegated subprocess and pane refetch overran the post-confirm settle and quit windows, surfacing as a spurious quit timeout rather than a real regression. Widening the post-confirm settle and quit budgets keeps the round-trip reliable under load while leaving the assertions unchanged.

## Related Issue

- None

## Notes for Reviewers

- None