### PR TITLE
fix(doctor): stop flagging warm store bytes as unpurgeable orphans

### DIFF
--- a/scripts/lib/tui_pty.sh
+++ b/scripts/lib/tui_pty.sh
@@ -84,14 +84,16 @@ tui_pty_seed_keg_real() {
   : >"$TUI_PREFIX/Cellar/$name/1.0/marker"
 }
 
-# Seed one orphaned store entry: a sha256 dir under store/ with no live
-# store_refs row — the exact shape `mt doctor --fix orphaned_store` sweeps. The
-# doctor walker counts any store dir lacking a refcount>0 row as orphaned, so the
-# missing row alone makes it a fixable warning. Optional arg overrides the sha.
+# Seed one orphaned store entry: a sha256 dir under store/ plus a store_refs
+# row whose refcount has dropped to 0 — the exact shape `mt doctor --fix
+# orphaned_store` and `mt purge --store-orphans` both sweep. A bare dir with no
+# row is a warm / in-flight commit, not an orphan. Optional arg overrides the sha.
 tui_pty_seed_orphan_store() {
   local sha="${1:-deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef}"
   mkdir -p "$TUI_PREFIX/store/$sha"
   : >"$TUI_PREFIX/store/$sha/payload"
+  sqlite3 "$TUI_PREFIX/db/malt.db" \
+    "INSERT OR REPLACE INTO store_refs (store_sha256, refcount) VALUES ('$sha', 0);"
 }
 
 # Drive `mt tui` under the pty. Args: <capfile> <cols> <rows>; the action

--- a/scripts/regressions/doctor-purge-orphan-definition-parity.sh
+++ b/scripts/regressions/doctor-purge-orphan-definition-parity.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Regression: `mt doctor` and `mt purge --store-orphans` must share one
+# definition of "orphaned store entry", with no dependence on timing.
+#
+# A store directory committed without a `store_refs` row is a warm /
+# in-flight commit: `mt install --download-only` leaves one deliberately,
+# and any install interrupted between the bottle commit and `incrementRef`
+# leaves one accidentally. `mt purge --store-orphans` is DB-driven
+# (`WHERE refcount <= 0`) and structurally cannot see such an entry.
+#
+# Pre-fix, doctor's disk-driven check counted a no-row entry as an orphan
+# and printed "Run: mt purge --store-orphans" — a command that can never
+# clear it. The warning then survived the recommended remediation: a
+# dead-end loop. This script pins that the entry doctor routes to purge is
+# one purge can actually remove, i.e. doctor no longer flags warm bytes.
+#
+# Property under test: run doctor; if it routes the no-row entry to
+# `mt purge --store-orphans`, that command must clear it. The bug makes
+# the warning persist after the purge with the entry still on disk.
+#
+# Usage: scripts/regressions/doctor-purge-orphan-definition-parity.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt. Offline.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+# The string doctor prints only when it routes a store entry at the
+# purge-orphans remediation. Never appears on the OK line.
+REMEDIATION='Run: mt purge --store-orphans'
+
+PFX=$(mktemp -d -t mt_doctor_orphan_parity.XXXXXX)
+export MALT_PREFIX="$PFX"
+trap 'rm -rf "$PFX"' EXIT
+
+# A store dir with no `store_refs` row — a warm / interrupted commit.
+SHA="deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+mkdir -p "$PFX/db" "$PFX/store/$SHA"
+
+# Materialise the schema (store_refs table) via the real initializer so
+# doctor's row lookup runs against a valid table; the empty store has no
+# orphan, so this removes nothing.
+"$MALT_BIN" purge --store-orphans </dev/null >/dev/null 2>&1 || true
+
+out1=$("$MALT_BIN" doctor </dev/null 2>&1 || true)
+
+if printf '%s' "$out1" | grep -qF "$REMEDIATION"; then
+  # Doctor routed the no-row entry to purge. Take it at its word.
+  "$MALT_BIN" purge --store-orphans </dev/null >/dev/null 2>&1 || true
+  out2=$("$MALT_BIN" doctor </dev/null 2>&1 || true)
+  if printf '%s' "$out2" | grep -qF "$REMEDIATION" && [[ -d "$PFX/store/$SHA" ]]; then
+    fail "doctor recommends 'purge --store-orphans' for a no-row entry that command cannot remove"
+  fi
+fi
+
+printf 'PASS: doctor and purge --store-orphans agree on the orphan definition\n'

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -904,11 +904,9 @@ fn checkOrphanedStore(ctx: CheckCtx, name: []const u8) CheckResult {
         defer stmt.finalize();
         stmt.bindText(1, entry.name) catch continue;
         const has_row = stmt.step() catch false;
-        if (has_row) {
-            if (stmt.columnInt(0) <= 0) orphan_count += 1;
-        } else {
-            orphan_count += 1;
-        }
+        const refcount: i64 = if (has_row) stmt.columnInt(0) else 0;
+        // No ref row ⇒ warm / in-flight commit purge cannot clear; not an orphan.
+        if (fix_mod.isPurgeableOrphan(has_row, refcount)) orphan_count += 1;
     }
 
     if (orphan_count == 0) {

--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -139,9 +139,10 @@ pub fn fixStaleLock(io: std.Io, prefix: []const u8) bool {
     return true;
 }
 
-/// Count orphaned store directories (entry on disk with refcount <= 0
-/// or no `store_refs` row). Mirrors the doctor walker so `--fix` and
-/// the inline check report the same number.
+/// Count orphaned store directories (entry on disk whose `store_refs`
+/// refcount has dropped to <= 0). Shares one definition with the inline
+/// doctor check and `purge --store-orphans` so all three report the same
+/// entries.
 pub fn probeOrphanedStoreCount(io: std.Io, prefix: []const u8) u32 {
     return countOrphans(io, prefix, false);
 }
@@ -179,13 +180,23 @@ fn countOrphans(io: std.Io, prefix: []const u8, do_remove: bool) u32 {
     return count;
 }
 
+/// A store entry is a purgeable orphan iff its `store_refs` row exists and
+/// its refcount has dropped to <= 0 — the predicate `Store.orphans()` /
+/// `purge --store-orphans` use. A *missing* row is a warm / in-flight commit
+/// (`--download-only`, or an install interrupted before the ref is taken);
+/// purge cannot clear it, so it is not an orphan. Detection and remediation
+/// share this single definition.
+pub fn isPurgeableOrphan(has_row: bool, refcount: i64) bool {
+    return has_row and refcount <= 0;
+}
+
 fn isOrphanRow(db: *sqlite.Database, sha: []const u8) bool {
     var stmt = db.prepare("SELECT refcount FROM store_refs WHERE store_sha256 = ?1;") catch return false;
     defer stmt.finalize();
     stmt.bindText(1, sha) catch return false;
     const has_row = stmt.step() catch false;
-    if (!has_row) return true; // entry on disk with no ref-row is orphan by definition
-    return stmt.columnInt(0) <= 0;
+    const refcount: i64 = if (has_row) stmt.columnInt(0) else 0;
+    return isPurgeableOrphan(has_row, refcount);
 }
 
 fn deleteRefRow(db: *sqlite.Database, sha: []const u8) void {
@@ -568,4 +579,14 @@ test "fixStaleLock: missing lock file is a no-op" {
 
 test "probeStaleLock: missing prefix returns false" {
     try std.testing.expect(!probeStaleLock(std.Options.debug_io, "/nonexistent/malt/prefix"));
+}
+
+test "isPurgeableOrphan: only a refcount<=0 row is an orphan" {
+    // Matches `Store.orphans()` (WHERE refcount <= 0) so detection and
+    // remediation share one definition.
+    try std.testing.expect(isPurgeableOrphan(true, 0));
+    try std.testing.expect(isPurgeableOrphan(true, -1));
+    try std.testing.expect(!isPurgeableOrphan(true, 1));
+    // No ref row: a warm / in-flight commit purge cannot clear — not an orphan.
+    try std.testing.expect(!isPurgeableOrphan(false, 0));
 }

--- a/tests/doctor_dispatch_test.zig
+++ b/tests/doctor_dispatch_test.zig
@@ -14,6 +14,7 @@ const macho = std.macho;
 const doctor = malt.doctor;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
+const store_mod = malt.store;
 const output = malt.output;
 
 const c = struct {
@@ -696,25 +697,25 @@ test "fix hint fires when a broken symlink is present and --fix is off" {
 }
 
 test "fix hint fires when an orphaned store entry is present" {
-    // Plant a store/<sha> directory with no matching store_refs row;
-    // checkOrphanedStore counts it and must arm the hint.
+    // Plant a store/<sha> directory whose store_refs refcount has dropped
+    // to 0 — a true orphan; checkOrphanedStore counts it and arms the hint.
     const allocator = testing.allocator;
     var s = try Scratch.init(allocator, "fix_hint_orphan");
     defer s.deinit(allocator);
 
+    const sha = "0000000000000000000000000000000000000000000000000000000000000000";
     {
         var db_path_buf: [512]u8 = undefined;
         const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
         var db = try sqlite.Database.open(db_path);
         defer db.close();
         try schema.initSchema(&db);
+        var store = store_mod.Store.init(std.Options.debug_io, allocator, &db, s.path);
+        try store.incrementRef(sha);
+        try store.decrementRef(sha);
     }
 
-    const orphan = try std.fmt.allocPrint(
-        allocator,
-        "{s}/store/0000000000000000000000000000000000000000000000000000000000000000",
-        .{s.path},
-    );
+    const orphan = try std.fmt.allocPrint(allocator, "{s}/store/{s}", .{ s.path, sha });
     defer allocator.free(orphan);
     try test_io.cwd().createDirPath(std.Options.debug_io, orphan);
 

--- a/tests/doctor_fix_test.zig
+++ b/tests/doctor_fix_test.zig
@@ -279,6 +279,53 @@ test "fixOrphanedStore: sweeps refcount-zero entries against a real DB" {
     try testing.expect(!pathExists(entry_dir));
 }
 
+test "orphan parity: a no-row store entry is invisible to both doctor and purge" {
+    // A store dir with no `store_refs` row is a warm / in-flight commit
+    // (`--download-only`, or an install interrupted before `incrementRef`).
+    // `purge --store-orphans` is DB-driven and cannot remove it; doctor must
+    // not flag it as one, or it routes the user to a command that no-ops.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "norow");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db_dir_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_dir_buf, "{s}/db", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, db_dir);
+
+    var store_dir_buf: [256]u8 = undefined;
+    const store_dir = try std.fmt.bufPrint(&store_dir_buf, "{s}/store", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, store_dir);
+
+    var db_path_buf: [256]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    // On disk but never `incrementRef`-d: no `store_refs` row.
+    const sha = "feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface";
+    var entry_dir_buf: [320]u8 = undefined;
+    const entry_dir = try std.fmt.bufPrint(&entry_dir_buf, "{s}/store/{s}", .{ prefix, sha });
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, entry_dir);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // Remediation side: purge enumerates nothing.
+    var store = store_mod.Store.init(io, testing.allocator, &db, prefix);
+    var orphans = try store.orphans();
+    defer {
+        for (orphans.items) |item| testing.allocator.free(item);
+        orphans.deinit(testing.allocator);
+    }
+    try testing.expectEqual(@as(usize, 0), orphans.items.len);
+
+    // Detection side (shared by `--fix` and the inline doctor check) must agree.
+    try testing.expectEqual(@as(u32, 0), fix.probeOrphanedStoreCount(io, prefix));
+    try testing.expect(pathExists(entry_dir));
+}
+
 test "fixOrphanedStore: missing DB is a no-op (returns 0)" {
     var prefix_buf: [128]u8 = undefined;
     const prefix = try makePrefix(&prefix_buf, "no-db");

--- a/tests/doctor_json_test.zig
+++ b/tests/doctor_json_test.zig
@@ -14,6 +14,7 @@ const testing = std.testing;
 const doctor = malt.doctor;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
+const store_mod = malt.store;
 const output = malt.output;
 
 const Scratch = struct {
@@ -137,14 +138,22 @@ test "an orphaned store entry serializes a fixable orphaned_store finding" {
     defer s.deinit(allocator);
     try s.initSchema();
 
-    // A store/<sha> dir with no matching store_refs row is an orphan.
-    const orphan = try std.fmt.allocPrint(
-        allocator,
-        "{s}/store/0000000000000000000000000000000000000000000000000000000000000000",
-        .{s.path},
-    );
+    // A store/<sha> dir whose store_refs refcount has dropped to 0 is a
+    // true orphan — the entry `purge --store-orphans` removes.
+    const sha = "0000000000000000000000000000000000000000000000000000000000000000";
+    const orphan = try std.fmt.allocPrint(allocator, "{s}/store/{s}", .{ s.path, sha });
     defer allocator.free(orphan);
     try test_io.cwd().createDirPath(std.Options.debug_io, orphan);
+
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        var store = store_mod.Store.init(std.Options.debug_io, allocator, &db, s.path);
+        try store.incrementRef(sha);
+        try store.decrementRef(sha);
+    }
 
     var result = walk(allocator, s.path);
     defer result.deinit();


### PR DESCRIPTION
## Description

`mt doctor` and `mt purge --store-orphans` disagreed on what an "orphaned store entry" is, leaving users at a dead-end.

This aligns detection with remediation on a single definition: an entry is a purgeable orphan only when its `store_refs` row exists and its refcount has dropped to `<= 0` — exactly what `Store.orphans()` / `purge --store-orphans` already use. The inline doctor check and `--fix` now both route through one shared predicate; warm bytes are left untouched for the follow-up install that consumes them. No store-model, schema, or `--download-only` behaviour changes; the release binary is byte-identical.

## Related Issue

- None 

## Notes for Reviewers

- None
