### PR TITLE
fix(doctor): explain why --fix could not sweep an orphan instead of a silent no-op

### DIFF
--- a/scripts/regressions/doctor-fix-orphan-blocked-reports-reason.sh
+++ b/scripts/regressions/doctor-fix-orphan-blocked-reports-reason.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Regression: `mt doctor --fix` must explain why it could not sweep an
+# orphaned store entry, instead of silently reporting nothing.
+#
+# The orphan reaper skipped any entry whose directory could not be removed
+# (permissions, a held file, an immutable flag) and never incremented its
+# swept count — so a blocked fix printed no "swept" line at all, exactly
+# like a clean prefix. A user watching `--fix` do nothing could not tell
+# "already clean" from "tried and could not".
+#
+# This seeds a true refcount-0 orphan, makes its directory undeletable with
+# the macOS immutable flag, runs `mt doctor --fix`, and asserts the output
+# names the blocker. The flag also makes the case root-proof: an immutable
+# entry resists removal even for the superuser, so the bug reproduces in any
+# CI environment.
+#
+# Usage: scripts/regressions/doctor-fix-orphan-blocked-reports-reason.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt, sqlite3 on
+# PATH, macOS (chflags). Offline.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+command -v sqlite3 >/dev/null 2>&1 || {
+  printf 'SKIP: sqlite3 not on PATH — needed to seed the refcount-0 row.\n' >&2
+  exit 2
+}
+command -v chflags >/dev/null 2>&1 || {
+  printf 'SKIP: chflags not available — this guard needs macOS.\n' >&2
+  exit 2
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+SHA="deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+PFX=$(mktemp -d -t mt_doctor_fix_blocked.XXXXXX)
+export MALT_PREFIX="$PFX"
+# Clear the immutable flag before removing, or cleanup itself is blocked.
+trap 'chflags -R nouchg "$PFX" 2>/dev/null || true; rm -rf "$PFX"' EXIT
+
+mkdir -p "$PFX/db" "$PFX/store/$SHA"
+
+# Materialise the schema via the real initializer, then seed a refcount-0
+# row so the store dir is a true orphan the reaper will try to sweep.
+"$MALT_BIN" purge --store-orphans </dev/null >/dev/null 2>&1 || true
+sqlite3 "$PFX/db/malt.db" \
+  "INSERT OR REPLACE INTO store_refs (store_sha256, refcount) VALUES ('$SHA', 0);"
+
+# Make the entry undeletable: rmdir of an immutable dir fails with EPERM.
+chflags uchg "$PFX/store/$SHA"
+
+out=$("$MALT_BIN" doctor --fix </dev/null 2>&1 || true)
+
+# Bug present (pre-fix): the blocked entry is silently skipped — no "swept"
+# line, no diagnostic — so the run looks identical to a clean prefix.
+# Bug absent (post-fix): the run names the blocker.
+printf '%s' "$out" | grep -qi "could not sweep" ||
+  fail "doctor --fix did not explain why it could not sweep the blocked orphan"
+
+# Sanity: the undeletable entry is in fact still present.
+[[ -d "$PFX/store/$SHA" ]] ||
+  fail "expected the immutable orphan dir to survive the blocked sweep"
+
+printf 'PASS: doctor --fix surfaces a reason when an orphan cannot be swept\n'

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -451,6 +451,12 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             if (outcome.orphans_removed > 0) {
                 output.success("swept {d} orphaned store entry(s)", .{outcome.orphans_removed});
             }
+            if (outcome.orphans_blocked > 0) {
+                output.warn("could not sweep {d} orphaned store entry(s): {s}", .{
+                    outcome.orphans_blocked,
+                    outcome.orphans_block_reason orelse "unknown reason",
+                });
+            }
         }
 
         var mit = outcome.plan.manual.iterator();

--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -144,40 +144,62 @@ pub fn fixStaleLock(io: std.Io, prefix: []const u8) bool {
 /// doctor check and `purge --store-orphans` so all three report the same
 /// entries.
 pub fn probeOrphanedStoreCount(io: std.Io, prefix: []const u8) u32 {
-    return countOrphans(io, prefix, false);
+    return walkOrphans(io, prefix, false).count;
 }
+
+/// Outcome of an orphan walk. Probe (`do_remove = false`): `count` is the
+/// number of orphans detected, `blocked` is always 0. Reap (`do_remove =
+/// true`): `count` is the number removed, `blocked` is the number of orphans
+/// that could not be removed (undeletable dir — permissions, a held file, an
+/// immutable flag); `reason` names the blocker so `--fix` can explain a
+/// partial sweep rather than report a silent no-op.
+pub const OrphanSweep = struct {
+    count: u32 = 0,
+    blocked: u32 = 0,
+    reason: ?[]const u8 = null,
+};
 
 /// Sweep orphan store directories and clear their `store_refs` rows so
-/// repeated `--fix` runs converge to zero. Silent on partial failure —
-/// the next run will pick up whatever is left.
-pub fn fixOrphanedStore(io: std.Io, prefix: []const u8) u32 {
-    return countOrphans(io, prefix, true);
+/// repeated `--fix` runs converge to zero. An orphan that cannot be removed
+/// is surfaced via `blocked`/`reason`, not skipped silently — a blocked fix
+/// must never be mistaken for a clean prefix.
+pub fn fixOrphanedStore(io: std.Io, prefix: []const u8) OrphanSweep {
+    return walkOrphans(io, prefix, true);
 }
 
-fn countOrphans(io: std.Io, prefix: []const u8, do_remove: bool) u32 {
+fn walkOrphans(io: std.Io, prefix: []const u8, do_remove: bool) OrphanSweep {
+    var result: OrphanSweep = .{};
     var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return 0;
-    var db = sqlite.Database.open(db_path) catch return 0;
+    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return result;
+    var db = sqlite.Database.open(db_path) catch return result;
     defer db.close();
 
     var store_path_buf: [512]u8 = undefined;
-    const store_path = std.fmt.bufPrint(&store_path_buf, "{s}/store", .{prefix}) catch return 0;
-    var store_dir = std.Io.Dir.openDirAbsolute(io, store_path, .{ .iterate = true }) catch return 0;
+    const store_path = std.fmt.bufPrint(&store_path_buf, "{s}/store", .{prefix}) catch return result;
+    var store_dir = std.Io.Dir.openDirAbsolute(io, store_path, .{ .iterate = true }) catch return result;
     defer store_dir.close(io);
 
-    var count: u32 = 0;
     var iter = store_dir.iterate();
     while (iter.next(io) catch null) |entry| {
         if (!isOrphanRow(&db, entry.name)) continue;
-        if (do_remove) {
-            var entry_buf: [768]u8 = undefined;
-            const entry_path = std.fmt.bufPrint(&entry_buf, "{s}/store/{s}", .{ prefix, entry.name }) catch continue;
-            std.Io.Dir.cwd().deleteTree(io, entry_path) catch continue;
-            deleteRefRow(&db, entry.name);
+        if (do_remove and !removeEntry(io, prefix, &db, entry.name)) {
+            result.blocked += 1;
+            if (result.reason == null) result.reason = "could not remove store entry";
+            continue;
         }
-        count += 1;
+        result.count += 1;
     }
-    return count;
+    return result;
+}
+
+/// Remove one orphan's store dir and clear its ref row. Returns false when
+/// the directory could not be removed, so the caller can report it.
+fn removeEntry(io: std.Io, prefix: []const u8, db: *sqlite.Database, name: []const u8) bool {
+    var entry_buf: [768]u8 = undefined;
+    const entry_path = std.fmt.bufPrint(&entry_buf, "{s}/store/{s}", .{ prefix, name }) catch return false;
+    std.Io.Dir.cwd().deleteTree(io, entry_path) catch return false;
+    deleteRefRow(db, name);
+    return true;
 }
 
 /// A store entry is a purgeable orphan iff its `store_refs` row exists and
@@ -313,6 +335,10 @@ pub const FixOutcome = struct {
     plan: Plan,
     stale_lock_removed: bool = false,
     orphans_removed: u32 = 0,
+    /// Orphans detected but not removable, with the blocker's reason — so a
+    /// partial sweep is reported instead of read as "nothing to do".
+    orphans_blocked: u32 = 0,
+    orphans_block_reason: ?[]const u8 = null,
     broken_symlinks_removed: u32 = 0,
 
     pub fn fixesApplied(self: FixOutcome) u32 {
@@ -344,7 +370,10 @@ pub fn executeFix(ctx: FixCtx, dry_run: bool) FixOutcome {
         outcome.stale_lock_removed = fixStaleLock(ctx.io, ctx.prefix);
     }
     if (plan.safe.contains(.orphaned_store)) {
-        outcome.orphans_removed = fixOrphanedStore(ctx.io, ctx.prefix);
+        const sweep = fixOrphanedStore(ctx.io, ctx.prefix);
+        outcome.orphans_removed = sweep.count;
+        outcome.orphans_blocked = sweep.blocked;
+        outcome.orphans_block_reason = sweep.reason;
     }
     if (plan.safe.contains(.broken_symlinks)) {
         outcome.broken_symlinks_removed = fixBrokenSymlinks(ctx.io, ctx.prefix);
@@ -357,6 +386,22 @@ pub fn executeFix(ctx: FixCtx, dry_run: bool) FixOutcome {
 test "planFixes: clean conditions yield empty plan" {
     const plan = planFixes(.{});
     try std.testing.expect(plan.isEmpty());
+}
+
+test "FixOutcome: a blocked orphan is not an applied fix yet stays distinguishable from clean" {
+    const plan = planFixes(.{});
+    const clean: FixOutcome = .{ .plan = plan };
+    const blocked: FixOutcome = .{
+        .plan = plan,
+        .orphans_blocked = 1,
+        .orphans_block_reason = "could not remove store entry",
+    };
+    // A blocked entry was not removed, so it is not an applied fix.
+    try std.testing.expectEqual(@as(u32, 0), clean.fixesApplied());
+    try std.testing.expectEqual(@as(u32, 0), blocked.fixesApplied());
+    // But the blocked outcome is legible: it carries a reason the clean one lacks.
+    try std.testing.expect(clean.orphans_block_reason == null);
+    try std.testing.expect(blocked.orphans_block_reason != null);
 }
 
 test "planFixes: stale lock joins the safe-fix set" {

--- a/tests/doctor_fix_test.zig
+++ b/tests/doctor_fix_test.zig
@@ -15,6 +15,13 @@ const sqlite = malt.sqlite;
 const schema = malt.schema;
 const store_mod = malt.store;
 
+// macOS user-immutable flag: makes a directory undeletable (rmdir → EPERM)
+// even for root, so a blocked sweep is deterministic across environments.
+const c = struct {
+    extern "c" fn chflags(path: [*:0]const u8, flags: c_uint) c_int;
+};
+const UF_IMMUTABLE: c_uint = 0x00000002;
+
 fn randHex(buf: *[16]u8) void {
     var rand: [8]u8 = undefined;
     fs_compat.randomBytes(std.Options.debug_io, &rand);
@@ -274,9 +281,107 @@ test "fixOrphanedStore: sweeps refcount-zero entries against a real DB" {
     try store.decrementRef(sha);
 
     try testing.expectEqual(@as(u32, 1), fix.probeOrphanedStoreCount(io, prefix));
-    try testing.expectEqual(@as(u32, 1), fix.fixOrphanedStore(io, prefix));
+    const sweep = fix.fixOrphanedStore(io, prefix);
+    try testing.expectEqual(@as(u32, 1), sweep.count);
+    try testing.expectEqual(@as(u32, 0), sweep.blocked);
     try testing.expectEqual(@as(u32, 0), fix.probeOrphanedStoreCount(io, prefix));
     try testing.expect(!pathExists(entry_dir));
+}
+
+test "fixOrphanedStore: an undeletable orphan is reported as blocked, not silently skipped" {
+    // A refcount-0 orphan whose directory cannot be removed must surface as
+    // blocked with a reason — not a silent count of 0 that reads exactly like
+    // a clean prefix. Here the macOS immutable flag is the (root-proof) blocker.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "blocked");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db_dir_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_dir_buf, "{s}/db", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, db_dir);
+
+    var store_dir_buf: [256]u8 = undefined;
+    const store_dir = try std.fmt.bufPrint(&store_dir_buf, "{s}/store", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, store_dir);
+
+    var db_path_buf: [256]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    const sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    var entry_dir_buf: [320]u8 = undefined;
+    const entry_dir = try std.fmt.bufPrint(&entry_dir_buf, "{s}/store/{s}", .{ prefix, sha });
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, entry_dir);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var store = store_mod.Store.init(io, testing.allocator, &db, prefix);
+    try store.incrementRef(sha);
+    try store.decrementRef(sha);
+
+    // Make the entry undeletable; clear the flag before the prefix teardown,
+    // or deleteTree of the prefix would itself be blocked.
+    var entry_z_buf: [320]u8 = undefined;
+    const entry_z = try std.fmt.bufPrintSentinel(&entry_z_buf, "{s}/store/{s}", .{ prefix, sha }, 0);
+    try testing.expectEqual(@as(c_int, 0), c.chflags(entry_z.ptr, UF_IMMUTABLE));
+    defer _ = c.chflags(entry_z.ptr, 0);
+
+    const sweep = fix.fixOrphanedStore(io, prefix);
+    try testing.expectEqual(@as(u32, 0), sweep.count); // nothing actually removed
+    try testing.expectEqual(@as(u32, 1), sweep.blocked); // the one orphan, blocked
+    try testing.expect(sweep.reason != null);
+    try testing.expect(pathExists(entry_dir)); // still on disk
+}
+
+test "fixOrphanedStore: a partial sweep removes what it can and reports the rest as blocked" {
+    // Two orphans, one removable and one immutable: the sweep must credit the
+    // removable one and still surface the blocked one — neither masking the
+    // other, so "swept 1" and "could not sweep 1" can both be reported.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "partial");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db_dir_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_dir_buf, "{s}/db", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, db_dir);
+    var store_dir_buf: [256]u8 = undefined;
+    const store_dir = try std.fmt.bufPrint(&store_dir_buf, "{s}/store", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, store_dir);
+
+    var db_path_buf: [256]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var store = store_mod.Store.init(io, testing.allocator, &db, prefix);
+    const removable = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const locked = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    inline for (.{ removable, locked }) |sha| {
+        var dir_buf: [320]u8 = undefined;
+        const dir = try std.fmt.bufPrint(&dir_buf, "{s}/store/{s}", .{ prefix, sha });
+        try fs_compat.makeDirAbsolute(std.Options.debug_io, dir);
+        try store.incrementRef(sha);
+        try store.decrementRef(sha);
+    }
+
+    var locked_z_buf: [320]u8 = undefined;
+    const locked_z = try std.fmt.bufPrintSentinel(&locked_z_buf, "{s}/store/{s}", .{ prefix, locked }, 0);
+    try testing.expectEqual(@as(c_int, 0), c.chflags(locked_z.ptr, UF_IMMUTABLE));
+    defer _ = c.chflags(locked_z.ptr, 0);
+
+    const sweep = fix.fixOrphanedStore(io, prefix);
+    try testing.expectEqual(@as(u32, 1), sweep.count); // the removable one
+    try testing.expectEqual(@as(u32, 1), sweep.blocked); // the immutable one
+    try testing.expect(sweep.reason != null);
 }
 
 test "orphan parity: a no-row store entry is invisible to both doctor and purge" {
@@ -336,7 +441,9 @@ test "fixOrphanedStore: missing DB is a no-op (returns 0)" {
     const io = threaded.io();
 
     try testing.expectEqual(@as(u32, 0), fix.probeOrphanedStoreCount(io, prefix));
-    try testing.expectEqual(@as(u32, 0), fix.fixOrphanedStore(io, prefix));
+    const sweep = fix.fixOrphanedStore(io, prefix);
+    try testing.expectEqual(@as(u32, 0), sweep.count);
+    try testing.expectEqual(@as(u32, 0), sweep.blocked);
 }
 
 test "executeFix: idempotent — second run finds nothing left to do" {


### PR DESCRIPTION
## Description

`mt doctor --fix` could silently do nothing on the orphan class. The reaper skipped any orphan whose store directory could not be removed - permissions, a held file, a macOS immutable flag, or DB-lock contention from a concurrent `install`/`upgrade` - and never counted it. A blocked sweep therefore printed no result line at all, identical to a clean prefix. A user watching `--fix` do nothing had no way to tell "already clean" from "tried and could not".

This is the diagnostic half of the doctor-orphan story (the sibling fix made `doctor`/`purge --store-orphans` agree on what an orphan is). The reaper now reports unremovable orphans as **blocked**, with the reason, so a partial
sweep — "swept N, could not sweep M" is surfaced instead of swallowed. The probe path stays tolerant (a count may shrug); only the fixer speaks up. No change to what gets removed, the orphan definition, the JSON contract, or any flag.

## Related Issue

- None

## Notes for Reviewers

- None
