### PR TITLE
fix(doctor): downgrade filesystem-vs-DB findings while an operation is in flight

### DIFF
--- a/scripts/regressions/doctor-downgrades-findings-under-live-lock.sh
+++ b/scripts/regressions/doctor-downgrades-findings-under-live-lock.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Regression: `mt doctor` must downgrade filesystem-vs-DB findings to an
+# informational "operation in progress" note while an install/upgrade holds
+# the prefix lock — and only then. The transients it would otherwise flag
+# (a kegs row recorded before its cellar dir materialises; a symlink dangling
+# during an upgrade's keg swap) are expected intermediate states of a correct
+# operation, not health defects, so reporting them as err/warn produces the
+# "doctor was angry last night, fine this morning" false positive.
+#
+# The downgrade must be gated on a *live* lock holder: a stale lock from a
+# dead PID must NOT mask real findings. This seeds both transient shapes, then
+# checks doctor with a live lock present (findings downgraded to `info`) and
+# again with the lock gone (findings back at their real `err`/`warn`).
+#
+# Uses `--json` so the per-finding severity is asserted deterministically, and
+# MALT_OFFLINE=1 so the API-reachable probe never reaches the network.
+#
+# Usage: scripts/regressions/doctor-downgrades-findings-under-live-lock.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt, sqlite3. Offline.
+
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT" || exit 1
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+command -v sqlite3 >/dev/null 2>&1 || {
+  printf 'SKIP: sqlite3 not on PATH — needed to seed the missing-keg row.\n' >&2
+  exit 2
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+PFX=$(mktemp -d -t mt_doctor_live_lock.XXXXXX)
+export MALT_PREFIX="$PFX"
+export MALT_OFFLINE=1
+SLEEPER=""
+cleanup() {
+  [[ -n "$SLEEPER" ]] && kill "$SLEEPER" 2>/dev/null
+  rm -rf "$PFX"
+}
+trap cleanup EXIT
+
+# A structurally complete prefix so the seeded transients are the findings
+# under test, not missing-dir noise.
+for d in store Cellar Caskroom opt bin lib sbin tmp cache db; do mkdir -p "$PFX/$d"; done
+
+# Initialise the schema, then seed the two transient shapes.
+"$MALT_BIN" list >/dev/null 2>&1 || true
+# Missing keg: a kegs row whose cellar_path does not exist on disk.
+sqlite3 "$PFX/db/malt.db" \
+  "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, pinned)
+   VALUES ('ghost', 'ghost', '1.0', 'sha', '$PFX/Cellar/ghost/1.0', 0);"
+# Broken symlink: a dangling link under bin/.
+ln -s "$PFX/Cellar/ghost/1.0/bin/ghost" "$PFX/bin/ghost"
+
+sev_of() { # sev_of <json> <finding-id> → prints the finding's severity token
+  printf '%s' "$1" | grep -o "\"id\":\"$2\",\"severity\":\"[a-z]*\"" | grep -o '"severity":"[a-z]*"' | grep -o '[a-z]*"$' | tr -d '"'
+}
+
+# ── live lock: an install is "in flight" ────────────────────────────────
+sleep 300 &
+SLEEPER=$!
+printf '%s' "$SLEEPER" >"$PFX/db/malt.lock"
+
+live=$("$MALT_BIN" doctor --json 2>/dev/null || true)
+[[ "$(sev_of "$live" missing_kegs)" == "info" ]] ||
+  fail "missing-keg finding not downgraded to info under a live lock (got '$(sev_of "$live" missing_kegs)')"
+[[ "$(sev_of "$live" broken_symlinks)" == "info" ]] ||
+  fail "broken-symlink finding not downgraded to info under a live lock (got '$(sev_of "$live" broken_symlinks)')"
+
+# ── lock gone: the downgrade must lift, real severities return ───────────
+kill "$SLEEPER" 2>/dev/null
+wait "$SLEEPER" 2>/dev/null
+SLEEPER=""
+rm -f "$PFX/db/malt.lock"
+
+dead=$("$MALT_BIN" doctor --json 2>/dev/null || true)
+[[ "$(sev_of "$dead" missing_kegs)" == "err" ]] ||
+  fail "missing-keg finding not restored to err without a lock (got '$(sev_of "$dead" missing_kegs)') — downgrade is not lock-gated"
+[[ "$(sev_of "$dead" broken_symlinks)" == "warn" ]] ||
+  fail "broken-symlink finding not restored to warn without a lock (got '$(sev_of "$dead" broken_symlinks)')"
+
+printf 'PASS: doctor downgrades fs-vs-DB findings only while a live lock is held\n'

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -69,7 +69,31 @@ pub const CheckCtx = struct {
     /// row and short-circuits the API-reachable probe so an air-gapped
     /// machine doesn't get a warn row for an expected network gap.
     offline: bool = false,
+    /// A live install/upgrade holds the prefix lock. The filesystem-vs-DB
+    /// checks observe its non-atomic intermediate states (a keg row before
+    /// its dir, a mid-swap symlink); when set they downgrade those findings
+    /// to an informational "operation in progress" note instead of a fault.
+    op_in_flight: bool = false,
 };
+
+/// The single in-progress note the lock-aware checks share.
+const op_in_flight_note = "operation in progress — re-run after it completes";
+
+/// True when the prefix lock is held by a *live* process. A dead-PID lock is
+/// a stale lock, not an in-flight operation, so it must read false here — else
+/// it would mask real findings until cleared. Mirrors `checkStaleLock`.
+pub fn operationInFlight(io: std.Io, prefix: []const u8) bool {
+    var lock_buf: [512]u8 = undefined;
+    const lock_path = std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix}) catch return false;
+    const pid = lock_mod.LockFile.holderPid(io, lock_path) orelse return false;
+    return pidAlive(pid);
+}
+
+/// kill(pid, 0): true when the process exists (and is signalable). Shared by
+/// `operationInFlight` and `checkStaleLock` so live-vs-dead stays one rule.
+fn pidAlive(pid: std.posix.pid_t) bool {
+    return std.c.kill(pid, @enumFromInt(0)) == 0;
+}
 
 /// One entry in the health walk. `run` prints its row(s) and returns
 /// the walker's tally tag.
@@ -117,6 +141,8 @@ pub fn runChecks(ctx: CheckCtx, table: []const Check) Tally {
             .ok => {},
             .warn_status => tally.warnings += 1,
             .err_status => tally.errors += 1,
+            // In-progress downgrade: informational, never a fault.
+            .info_status => {},
         }
     }
     return tally;
@@ -411,6 +437,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         .environ = ctx.environ,
         .mirrors = ctx.mirrors,
         .offline = ctx.offline,
+        .op_in_flight = operationInFlight(ctx.io, prefix),
     }, &checks, want_checks_json);
     defer walk.deinit();
     const tally = walk.tally;
@@ -692,16 +719,16 @@ fn checkStaleLock(ctx: CheckCtx, name: []const u8) CheckResult {
     };
     const pid = lock_mod.LockFile.holderPid(ctx.io, lock_path);
     if (pid) |p| {
-        const is_alive = std.c.kill(p, @enumFromInt(0)) == 0;
-        var pid_buf: [256]u8 = undefined;
-        if (is_alive) {
-            const s = std.fmt.bufPrint(&pid_buf, "Lock held by active PID {d}", .{p}) catch "Lock held";
-            printCheck(name, .warn_status, s);
-        } else {
-            const s = std.fmt.bufPrint(&pid_buf, "Stale lock from dead PID {d}. Run: rm {s}", .{ p, lock_path }) catch "Stale lock detected";
-            printCheck(name, .warn_status, s);
-            armFixHint(.stale_lock);
+        // A live holder is an operation in flight, not a defect — report the
+        // shared in-progress note so a normal install doesn't read as a fault.
+        if (pidAlive(p)) {
+            printCheck(name, .info_status, op_in_flight_note);
+            return .info_status;
         }
+        var pid_buf: [256]u8 = undefined;
+        const s = std.fmt.bufPrint(&pid_buf, "Stale lock from dead PID {d}. Run: rm {s}", .{ p, lock_path }) catch "Stale lock detected";
+        printCheck(name, .warn_status, s);
+        armFixHint(.stale_lock);
         return .warn_status;
     }
     printCheck(name, .ok, null);
@@ -919,6 +946,10 @@ fn checkOrphanedStore(ctx: CheckCtx, name: []const u8) CheckResult {
         printCheck(name, .ok, null);
         return .ok;
     }
+    if (ctx.op_in_flight) {
+        printCheck(name, .info_status, op_in_flight_note);
+        return .info_status;
+    }
     var msg_buf: [256]u8 = undefined;
     const msg = std.fmt.bufPrint(
         &msg_buf,
@@ -971,6 +1002,10 @@ fn checkMissingKegs(ctx: CheckCtx, name: []const u8) CheckResult {
         printCheck(name, .ok, null);
         return .ok;
     }
+    if (ctx.op_in_flight) {
+        printCheck(name, .info_status, op_in_flight_note);
+        return .info_status;
+    }
     var msg_buf: [256]u8 = undefined;
     const msg = std.fmt.bufPrint(
         &msg_buf,
@@ -1012,6 +1047,10 @@ fn checkBrokenSymlinks(ctx: CheckCtx, name: []const u8) CheckResult {
     if (offenders.items.len == 0) {
         printCheck(name, .ok, null);
         return .ok;
+    }
+    if (ctx.op_in_flight) {
+        printCheck(name, .info_status, op_in_flight_note);
+        return .info_status;
     }
     var msg_buf: [256]u8 = undefined;
     const msg = std.fmt.bufPrint(
@@ -1623,4 +1662,33 @@ test "writeDoctorJson stays one valid JSON object with schema_version on the emp
     try testing.expectEqual(@as(usize, 0), parsed.value.object.get("checks").?.array.items.len);
     try testing.expectEqual(@as(usize, 0), parsed.value.object.get("taps").?.array.items.len);
     try testing.expectEqual(@as(i64, 0), parsed.value.object.get("tap_cache").?.object.get("bytes").?.integer);
+}
+
+fn infoCheckForTest(ctx: CheckCtx, name: []const u8) CheckResult {
+    _ = ctx;
+    _ = name;
+    return .info_status;
+}
+
+test "runChecks: an info_status finding counts as neither warning nor error" {
+    // The in-progress downgrade must not trip the severity exit — otherwise
+    // a busy prefix still reads as a fault.
+    const table = [_]Check{.{ .name = "x", .run = infoCheckForTest }};
+    output.setQuiet(true);
+    defer output.setQuiet(false);
+    const tally = runChecks(.{
+        .allocator = testing.allocator,
+        .prefix = "/nonexistent",
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    }, &table);
+    try testing.expectEqual(@as(u32, 0), tally.warnings);
+    try testing.expectEqual(@as(u32, 0), tally.errors);
+}
+
+test "pidAlive: true for our own PID, false for a dead one" {
+    // The downgrade gates on this: a live holder means an operation is in
+    // flight; a dead PID is a stale lock that must not mask real findings.
+    try testing.expect(pidAlive(std.c.getpid()));
+    try testing.expect(!pidAlive(999999));
 }

--- a/src/cli/doctor/render.zig
+++ b/src/cli/doctor/render.zig
@@ -9,7 +9,10 @@ const output = @import("../../ui/output.zig");
 const color = @import("../../ui/color.zig");
 const fix_mod = @import("fix.zig");
 
-pub const CheckStatus = enum { ok, warn_status, err_status };
+// `info_status` is the in-progress downgrade: a finding that would be a
+// warn/err is recast as informational while an operation holds the prefix
+// lock. It does not count toward the severity exit.
+pub const CheckStatus = enum { ok, warn_status, err_status, info_status };
 
 /// Safe-fix vocabulary shared with `--fix`. `mt doctor --json` reports a
 /// finding's class from this set (or `none`) so the dashboard and the
@@ -41,6 +44,7 @@ pub fn severityTag(status: CheckStatus) []const u8 {
         .ok => "ok",
         .warn_status => "warn",
         .err_status => "err",
+        .info_status => "info",
     };
 }
 
@@ -123,10 +127,12 @@ fn glyphFor(status: CheckStatus, emoji: bool) []const u8 {
         .ok => "✓",
         .warn_status => "⚠",
         .err_status => "✗",
+        .info_status => "ℹ",
     } else switch (status) {
         .ok => "*",
         .warn_status => "!",
         .err_status => "x",
+        .info_status => "i",
     };
 }
 
@@ -135,6 +141,7 @@ fn statusCode(status: CheckStatus) []const u8 {
         .ok => color.SemanticStyle.success.code(),
         .warn_status => color.SemanticStyle.warn.code(),
         .err_status => color.SemanticStyle.err.code(),
+        .info_status => color.SemanticStyle.info.code(),
     };
 }
 
@@ -196,6 +203,8 @@ test "severityTag maps every CheckStatus to its JSON token" {
     try testing.expectEqualStrings("ok", severityTag(.ok));
     try testing.expectEqualStrings("warn", severityTag(.warn_status));
     try testing.expectEqualStrings("err", severityTag(.err_status));
+    // `info` is the in-progress downgrade — a non-fault, JSON-visible state.
+    try testing.expectEqualStrings("info", severityTag(.info_status));
 }
 
 test "fixClassTag maps null to none and each FixKind to its tag" {
@@ -273,6 +282,23 @@ test "writeChecksJson: a fixable warn finding carries its fix_class" {
             "\"detail\":\"Stale lock from dead PID 42\",\"fixable\":true,\"fix_class\":\"stale_lock\"}]}\n",
         try checksToBuf(&findings, &buf),
     );
+}
+
+test "writeChecksJson: an in-progress finding serializes severity info, non-fixable" {
+    // The downgrade must be visible in the contract, not silently dropped —
+    // and never fixable (a transient is not actionable).
+    var buf: [256]u8 = undefined;
+    const findings = [_]Finding{
+        .{
+            .id = "missing_kegs",
+            .severity = .info_status,
+            .title = "Missing kegs",
+            .detail = "operation in progress — re-run after it completes",
+        },
+    };
+    const out = try checksToBuf(&findings, &buf);
+    try testing.expect(std.mem.indexOf(u8, out, "\"severity\":\"info\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"fixable\":false") != null);
 }
 
 test "writeChecksJson: comma-separates multiple findings" {

--- a/src/tui/doctor_tab.zig
+++ b/src/tui/doctor_tab.zig
@@ -55,7 +55,7 @@ pub fn matches(name: []const u8, filter: []const u8) bool {
 /// Display order: errors first, then warnings, then ok — the scan-ability sort.
 /// Both the selection mapping and the renderer walk findings in this order so a
 /// cursor lands on exactly the row painted at that screen position.
-const severity_order = [_]Severity{ .err, .warn, .ok };
+const severity_order = [_]Severity{ .err, .warn, .info, .ok };
 
 fn filteredCount(items: []const Row, filter: []const u8) usize {
     var n: usize = 0;
@@ -112,6 +112,7 @@ fn glyph(sev: Severity) []const u8 {
         .ok => "✓",
         .warn => "⚠",
         .err => "✗",
+        .info => "ℹ",
     };
 }
 
@@ -120,6 +121,8 @@ fn glyphStyle(sev: Severity) color.Role {
         .ok => .success,
         .warn => .warning,
         .err => .danger,
+        // No dedicated info role; accent reads as a neutral highlight.
+        .info => .accent,
     };
 }
 
@@ -128,6 +131,7 @@ fn severityLabel(sev: Severity) []const u8 {
         .ok => "ok",
         .warn => "warning",
         .err => "error",
+        .info => "in progress",
     };
 }
 
@@ -153,12 +157,14 @@ fn humanBytes(bytes: u64, buf: []u8) []const u8 {
 const Counts = struct {
     err: usize = 0,
     warn: usize = 0,
+    /// In-progress (informational) findings — never actionable, never attention.
+    info: usize = 0,
     ok: usize = 0,
-    /// Fixable findings within err+warn — `ok` findings are never "fixable" work.
+    /// Fixable findings within err+warn — `ok`/`info` findings are never "fixable" work.
     fixable: usize = 0,
 
     fn total(self: Counts) usize {
-        return self.err + self.warn + self.ok;
+        return self.err + self.warn + self.info + self.ok;
     }
     fn attention(self: Counts) usize {
         return self.err + self.warn;
@@ -174,9 +180,10 @@ fn tally(items: []const Row, filter: []const u8) Counts {
         switch (fnd.severity) {
             .err => c.err += 1,
             .warn => c.warn += 1,
+            .info => c.info += 1,
             .ok => c.ok += 1,
         }
-        if (fnd.severity != .ok and fnd.fixable) c.fixable += 1;
+        if ((fnd.severity == .err or fnd.severity == .warn) and fnd.fixable) c.fixable += 1;
     }
     return c;
 }
@@ -185,6 +192,9 @@ fn tally(items: []const Row, filter: []const u8) Counts {
 fn worst(c: Counts) Severity {
     if (c.err > 0) return .err;
     if (c.warn > 0) return .warn;
+    // In-progress outranks ok so the banner says "operation in progress"
+    // rather than falsely "all checks passed" while a transient is shown.
+    if (c.info > 0) return .info;
     return .ok;
 }
 
@@ -194,6 +204,7 @@ fn verdictLabel(sev: Severity) []const u8 {
         // covers both ("issues") while `warn` means warnings alone.
         .err => "issues found",
         .warn => "warnings found",
+        .info => "operation in progress",
         .ok => "all checks passed",
     };
 }
@@ -228,13 +239,15 @@ fn buildBanner(lb: *tab.Frame, c: Counts) void {
 /// rounding keeps the sum exact (the boundaries telescope, so they can't drift off
 /// the bar width); a present-but-tiny bucket is then guaranteed ≥1 cell — stolen
 /// from the largest segment — so it stays visible. Per-segment ceil scaling can't
-/// be reused here: three segments sharing one bar must partition it, not overshoot.
-fn compositionCells(c: Counts, bar: usize) [3]usize {
+/// be reused here: the segments sharing one bar must partition it, not overshoot.
+/// Order matches `severity_order`: err → warn → info → ok.
+fn compositionCells(c: Counts, bar: usize) [4]usize {
     const total = c.total(); // caller guards total > 0
     const b_err = (c.err * bar + total / 2) / total;
     const b_ew = ((c.err + c.warn) * bar + total / 2) / total;
-    var seg = [3]usize{ b_err, b_ew - b_err, bar - b_ew };
-    const counts = [3]usize{ c.err, c.warn, c.ok };
+    const b_ewi = ((c.err + c.warn + c.info) * bar + total / 2) / total;
+    var seg = [4]usize{ b_err, b_ew - b_err, b_ewi - b_ew, bar - b_ewi };
+    const counts = [4]usize{ c.err, c.warn, c.info, c.ok };
     for (counts, 0..) |n, i| {
         if (n > 0 and seg[i] == 0) {
             var max_i: usize = 0;
@@ -248,7 +261,7 @@ fn compositionCells(c: Counts, bar: usize) [3]usize {
     return seg;
 }
 
-/// Paint the stacked composition bar: err→warn→ok cells, each run in its severity
+/// Paint the stacked composition bar: err→warn→info→ok cells, each run in its severity
 /// colour, on the shared `total` scale. Empty segments emit no colour, so adjacent
 /// runs stay visually distinct.
 fn buildCompositionBar(lb: *tab.Frame, c: Counts, bar: usize) void {
@@ -305,6 +318,11 @@ fn buildPlainCounts(lb: *tab.Frame, c: Counts) void {
     buildPlainCount(lb, .err, c.err);
     lb.put("  ");
     buildPlainCount(lb, .warn, c.warn);
+    // Only while an operation is in flight, so the steady-state legend is unchanged.
+    if (c.info > 0) {
+        lb.put("  ");
+        buildPlainCount(lb, .info, c.info);
+    }
     lb.put("  ");
     buildPlainCount(lb, .ok, c.ok);
 }
@@ -564,11 +582,12 @@ pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
 
     const reclaim = reclaimFrom(s.stats);
 
-    // An all-clear run (no filter, findings present, none needing attention) has
-    // no verdict to weigh: collapse the band to the calm summary line, plus the
-    // reclaimable section when there is disk to reclaim. No histogram, fixable
-    // line, or detail pane — nothing needs the user's attention.
-    if (filter.len == 0 and counts.total() > 0 and counts.attention() == 0) {
+    // An all-clear run (no filter, findings present, none needing attention and
+    // none in progress) has no verdict to weigh: collapse the band to the calm
+    // summary line, plus the reclaimable section when there is disk to reclaim.
+    // In-progress (info) findings keep the band so the "operation in progress"
+    // verdict still shows instead of a misleading all-clear.
+    if (filter.len == 0 and counts.total() > 0 and counts.attention() == 0 and counts.info == 0) {
         renderAllClear(f, r, counts);
         if (reclaim) |rc| {
             const max = r.height -| 1; // the summary line takes the top row
@@ -686,6 +705,10 @@ const warn_only = [_]Row{
 const all_ok = [_]Row{
     .{ .id = "malt_prefix", .severity = .ok, .title = "MALT_PREFIX", .detail = "/opt/malt", .fixable = false, .fix_class = .none },
 };
+const info_only = [_]Row{
+    .{ .id = "missing_kegs", .severity = .info, .title = "Missing kegs", .detail = "operation in progress", .fixable = false, .fix_class = .none },
+    .{ .id = "malt_prefix", .severity = .ok, .title = "MALT_PREFIX", .detail = "/opt/malt", .fixable = false, .fix_class = .none },
+};
 
 // A skewed store (0 err, 2 warn, 16 ok) for the total-scaled composition bar:
 // on a shared scale ok must dominate warn, not sit at near-parity.
@@ -735,6 +758,16 @@ test "selectedFinding maps the cursor through the filter" {
 test "selectedFinding on an empty list is null" {
     const s: State = .{ .items = &.{} };
     try testing.expect(selectedFinding(&s) == null);
+}
+
+test "an info finding is in-progress: its own glyph, never counted as attention" {
+    const items = [_]Row{
+        .{ .id = "missing_kegs", .severity = .info, .title = "Missing kegs", .detail = "operation in progress", .fixable = false, .fix_class = .none },
+    };
+    const c = tally(&items, "");
+    try testing.expectEqual(@as(usize, 1), c.info);
+    try testing.expectEqual(@as(usize, 0), c.attention());
+    try testing.expectEqualStrings("ℹ", glyph(.info));
 }
 
 test "f on a fixable finding requests a fix" {
@@ -958,6 +991,7 @@ test "the band's status banner reads the worst severity present" {
     const cases = [_]struct { items: []const Row, verdict: []const u8 }{
         .{ .items = &sample, .verdict = "issues found" }, // an err is present (may include warnings)
         .{ .items = &warn_only, .verdict = "warnings found" }, // warn is the worst, no errors
+        .{ .items = &info_only, .verdict = "operation in progress" }, // info outranks ok
     };
     for (cases) |c| {
         var buf: [4096]u8 = undefined;

--- a/src/tui/json/doctor.zig
+++ b/src/tui/json/doctor.zig
@@ -17,9 +17,10 @@ const testing = std.testing;
 pub const Error = error{ BadJson, OutOfMemory };
 
 /// Finding severity, mirroring the CLI's `CheckStatus` wire tags `ok`/`warn`/
-/// `err`. Closed enum: a new severity must bump the schema, so parsing it is a
-/// deliberate change, not a tolerated unknown.
-pub const Severity = enum { ok, warn, err };
+/// `err`/`info`. `info` is the in-progress downgrade the CLI emits while an
+/// operation holds the prefix lock. Closed enum: a new severity must bump the
+/// schema, so parsing it is a deliberate change, not a tolerated unknown.
+pub const Severity = enum { ok, warn, err, info };
 
 /// Safe-fix class, mirroring the CLI `--fix` vocabulary. `none` is the wire tag
 /// for a non-fixable finding. The fixable findings' `f` action delegates to
@@ -191,7 +192,8 @@ test "parse decodes every severity tag" {
         \\{"checks":[
         \\{"id":"a","severity":"ok","title":"A"},
         \\{"id":"b","severity":"warn","title":"B"},
-        \\{"id":"c","severity":"err","title":"C"}
+        \\{"id":"c","severity":"err","title":"C"},
+        \\{"id":"d","severity":"info","title":"D"}
         \\]}
     ;
     var p = try parse(testing.allocator, bytes);
@@ -199,6 +201,9 @@ test "parse decodes every severity tag" {
     try testing.expectEqual(Severity.ok, p.items[0].severity);
     try testing.expectEqual(Severity.warn, p.items[1].severity);
     try testing.expectEqual(Severity.err, p.items[2].severity);
+    // `info` is the in-progress downgrade; the parser must accept it or the
+    // Doctor tab breaks whenever an operation is in flight.
+    try testing.expectEqual(Severity.info, p.items[3].severity);
 }
 
 test "parse decodes every fix_class tag" {

--- a/tests/doctor_dispatch_test.zig
+++ b/tests/doctor_dispatch_test.zig
@@ -149,6 +149,112 @@ test "runChecks surfaces an error when a keg row points at a missing Cellar dir"
     try testing.expect(tally.errors >= 1);
 }
 
+// --- in-flight downgrade (lock-aware checks) ---------------------------
+
+fn severityOf(items: anytype, id: []const u8) ?doctor.CheckStatus {
+    for (items) |f| if (std.mem.eql(u8, f.id, id)) return f.severity;
+    return null;
+}
+
+test "operationInFlight: true only for a live lock holder" {
+    var s = try Scratch.init(testing.allocator, "opinflight");
+    defer s.deinit(testing.allocator);
+
+    var lock_buf: [512]u8 = undefined;
+    const lock_path = try std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{s.path});
+
+    // No lock file → nothing in flight.
+    try testing.expect(!doctor.operationInFlight(std.Options.debug_io, s.path));
+
+    // A dead PID is a stale lock — must not read as in-flight.
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, lock_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "999999");
+    }
+    try testing.expect(!doctor.operationInFlight(std.Options.debug_io, s.path));
+
+    // Our own (live) PID → an operation is in flight.
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, lock_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        var b: [16]u8 = undefined;
+        try f.writeStreamingAll(std.Options.debug_io, try std.fmt.bufPrint(&b, "{d}", .{std.c.getpid()}));
+    }
+    try testing.expect(doctor.operationInFlight(std.Options.debug_io, s.path));
+}
+
+test "in-flight downgrade: all three fs-vs-DB checks become info only while an op is live" {
+    var s = try Scratch.init(testing.allocator, "downgrade_all");
+    defer s.deinit(testing.allocator);
+
+    // missing keg: a kegs row whose cellar dir does not exist (err).
+    // orphaned store: a store/<sha> dir with a refcount-0 ref row (warn).
+    const orphan_sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+        var stmt = try db.prepare(
+            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+            \\VALUES ('phantom', 'phantom', '9.9', 0, '', '/tmp/malt_phantom_missing_inflight');
+        );
+        defer stmt.finalize();
+        _ = try stmt.step();
+
+        var store_dir_buf: [512]u8 = undefined;
+        const store_dir = try std.fmt.bufPrint(&store_dir_buf, "{s}/store/{s}", .{ s.path, orphan_sha });
+        try test_io.cwd().createDirPath(std.Options.debug_io, store_dir);
+        var store = store_mod.Store.init(std.Options.debug_io, testing.allocator, &db, s.path);
+        try store.incrementRef(orphan_sha);
+        try store.decrementRef(orphan_sha);
+    }
+    // broken symlink: a dangling link under bin/ (warn).
+    {
+        var bin_buf: [512]u8 = undefined;
+        const bin_dir = try std.fmt.bufPrint(&bin_buf, "{s}/bin", .{s.path});
+        var bin = try test_io.openDirAbsolute(std.Options.debug_io, bin_dir, .{ .iterate = true });
+        defer bin.close(std.Options.debug_io);
+        try bin.symLink(std.Options.debug_io, "/tmp/malt_inflight_vanished_target", "ghost", .{});
+    }
+
+    quiet();
+    defer unquiet();
+
+    // Not in flight: each finding shows its real severity.
+    {
+        var walk = doctor.collectFindings(testing.allocator, .{
+            .allocator = testing.allocator,
+            .prefix = s.path,
+            .io = std.Options.debug_io,
+            .environ = .empty,
+        }, &doctor.checks, true);
+        defer walk.deinit();
+        try testing.expectEqual(doctor.CheckStatus.err_status, severityOf(walk.findings(), "missing_kegs").?);
+        try testing.expectEqual(doctor.CheckStatus.warn_status, severityOf(walk.findings(), "orphaned_store_entries").?);
+        try testing.expectEqual(doctor.CheckStatus.warn_status, severityOf(walk.findings(), "broken_symlinks").?);
+        try testing.expect(walk.tally.errors >= 1);
+    }
+
+    // In flight: all three are expected transients → info, no fault.
+    {
+        var walk = doctor.collectFindings(testing.allocator, .{
+            .allocator = testing.allocator,
+            .prefix = s.path,
+            .io = std.Options.debug_io,
+            .environ = .empty,
+            .op_in_flight = true,
+        }, &doctor.checks, true);
+        defer walk.deinit();
+        try testing.expectEqual(doctor.CheckStatus.info_status, severityOf(walk.findings(), "missing_kegs").?);
+        try testing.expectEqual(doctor.CheckStatus.info_status, severityOf(walk.findings(), "orphaned_store_entries").?);
+        try testing.expectEqual(doctor.CheckStatus.info_status, severityOf(walk.findings(), "broken_symlinks").?);
+        try testing.expectEqual(@as(u32, 0), walk.tally.errors);
+    }
+}
+
 // --- execute pre-loop branches -----------------------------------------
 
 test "execute --help short-circuits before opening anything" {

--- a/tests/doctor_json_test.zig
+++ b/tests/doctor_json_test.zig
@@ -225,10 +225,10 @@ test "collect=false leaves the sink empty (human path pays nothing)" {
     try testing.expectEqual(@as(usize, 0), result.findings().len);
 }
 
-test "a lock held by a live PID warns but stays non-fixable" {
-    // The same Stale lock row is fixable for a dead PID and not for a
-    // live one. A live holder must report warn + fixable:false so a
-    // consumer never offers `--fix` against a legitimately held lock.
+test "a lock held by a live PID is reported in-progress, not a fixable warn" {
+    // A live holder is an operation in flight, not a stale lock: the row must
+    // be informational (info) and non-fixable, so a consumer never offers
+    // `--fix` against a legitimately held lock. (A dead PID → fixable stale_lock.)
     const allocator = testing.allocator;
     var s = try Scratch.init(allocator, "live_lock");
     defer s.deinit(allocator);
@@ -248,7 +248,7 @@ test "a lock held by a live PID warns but stays non-fixable" {
     defer result.deinit();
 
     const f = findById(result.findings(), "stale_lock") orelse return error.MissingLockFinding;
-    try testing.expectEqual(doctor.CheckStatus.warn_status, f.severity);
+    try testing.expectEqual(doctor.CheckStatus.info_status, f.severity);
     try testing.expect(!f.fixable);
     try testing.expect(f.fix_class == null);
 }


### PR DESCRIPTION
## Description

`mt doctor` ran its filesystem-vs-DB checks (missing keg, broken symlink, orphaned store) as point-in-time snapshots with no lock, so they observed the non-atomic intermediate states of a running `install`/`upgrade` — a `kegs` row recorded before its cellar dir materialises, a symlink dangling mid keg-swap  and reported them as err/warn that self-resolve once the operation completes.
The active-lock row likewise warned on every concurrent run. 

When the prefix lock is held by a **live** process, these findings now downgrade to an informational "operation in progress - re-run after it completes" note. 

This is a new `info` severity that does **not** count toward the severity exit, so a busy prefix exits 0 instead of reading as a fault. A **dead-PID (stale)** lock is unaffected - it must not mask real findings, so a stale lock stays a fixable warn. Other checks (integrity, directory structure) keep their normal severity.

## Related Issue

- None

## Notes for Reviewers

- None
