### PR TITLE
fix(upgrade): upgrade every named package instead of only the first

### DIFF
--- a/man/malt.1
+++ b/man/malt.1
@@ -152,7 +152,7 @@ Flags:
 .fi
 .SS upgrade
 .nf
-Usage: malt upgrade [<package>] [flags]
+Usage: malt upgrade [<package>...] [flags]
 
 Upgrade installed packages to latest versions. Pinned kegs and
 casks are skipped with a "pinned, skipped" line; pass --force to

--- a/scripts/regressions/upgrade-multi-package-args.sh
+++ b/scripts/regressions/upgrade-multi-package-args.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Regression: `mt upgrade <a> <b>` must process every named package, not
+# just the first positional.
+#
+# The TUI Outdated tab builds `mt upgrade <name1> <name2> ...` for a
+# select-all batch. A CLI defect kept only the first positional and
+# silently dropped the rest, so a bulk upgrade touched exactly one
+# package and the others reappeared as still-outdated on the next refetch.
+#
+# This proves both names reach the per-package upgrade path without any
+# network. Two synthetic core kegs are seeded and a `.404` cache marker
+# is planted for each, so every lookup fails offline with a deterministic
+# "Could not fetch formula info for <name>" line. The pre-fix CLI emits
+# that line for the first name only; the fixed CLI emits it for both.
+# Asserting the SECOND name's error surfaces is exactly the
+# dropped-positional signal.
+#
+# Usage: scripts/regressions/upgrade-multi-package-args.sh
+# Requirements: built malt at $MALT_BIN or zig-out/bin/malt, sqlite3.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+# MALT_PREFIX must be <= 13 bytes (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_umpkg"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+# Bootstrap the schema the same way malt does: a `list` call opens and
+# initialises the DB on a fresh prefix.
+mkdir -p "$PREFIX/db"
+"$BIN" list >/dev/null 2>&1 || true
+DB="$PREFIX/db/malt.db"
+[[ -f "$DB" ]] || fail "expected DB at $DB after a list call"
+
+FIRST="wget"
+SECOND="ffmpeg"
+
+# Seed two core kegs (empty tap → core-API path, not tap routing).
+sqlite3 "$DB" <<SQL || fail "could not seed kegs"
+INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason)
+VALUES ('$FIRST', '$FIRST', '1', 0, '', '/c/$FIRST/1', 'direct'),
+       ('$SECOND', '$SECOND', '1', 0, '', '/c/$SECOND/1', 'direct');
+SQL
+
+# Plant 404 markers so each lookup fails network-free with a stable line.
+mkdir -p "$PREFIX/cache/api"
+: >"$PREFIX/cache/api/formula_$FIRST.404"
+: >"$PREFIX/cache/api/formula_$SECOND.404"
+
+# The exact argv shape the TUI Outdated tab builds for a 2-row select-all.
+LOG="$PREFIX/upgrade.log"
+printf '\xe2\x96\xb8 mt upgrade %s %s (offline, expect both to be probed)\n' "$FIRST" "$SECOND"
+"$BIN" upgrade "$FIRST" "$SECOND" >"$LOG" 2>&1 || true
+
+# Sanity: the first positional is always processed.
+grep -q "Could not fetch formula info for $FIRST" "$LOG" || {
+  cat "$LOG" >&2
+  fail "first package was not processed — harness is broken"
+}
+pass "first package processed"
+
+# The defect: the second positional is silently dropped. Its error line
+# appears only when every name reaches the per-package upgrade path.
+grep -q "Could not fetch formula info for $SECOND" "$LOG" || {
+  cat "$LOG" >&2
+  fail "second package dropped — only the first positional was honored"
+}
+pass "second package processed"
+
+printf '\n\xe2\x9c\x94 upgrade-multi-package-args regression passed\n'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -140,7 +140,7 @@ const uninstall_help =
 ;
 
 const upgrade_help =
-    \\Usage: malt upgrade [<package>] [flags]
+    \\Usage: malt upgrade [<package>...] [flags]
     \\
     \\Upgrade installed packages to latest versions. Pinned kegs and
     \\casks are skipped with a "pinned, skipped" line; pass --force to

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -71,7 +71,10 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // Applies only to deps newly introduced by this upgrade — existing
     // kegs replay their stored `bin_isolated` regardless of the flag.
     var isolate_deps = false;
-    var pkg_name: ?[]const u8 = null;
+    // Collect every positional, mirroring `install`: tokens borrow from
+    // `args` (process-lifetime), so no dup is needed.
+    var names: std.ArrayList([]const u8) = .empty;
+    defer names.deinit(allocator);
 
     // StaticStringMap + exhaustive switch: every flag routes to a handler.
     for (args) |arg| {
@@ -84,7 +87,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             .pinned => pinned_only = true,
             .isolate_deps => isolate_deps = true,
         } else if (arg.len > 0 and arg[0] != '-') {
-            if (pkg_name == null) pkg_name = arg;
+            names.append(allocator, arg) catch return error.OutOfMemory;
         }
     }
 
@@ -146,22 +149,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // and surface error.Aborted so main.zig maps it to a non-zero exit.
     var any_failed = false;
 
-    if (pkg_name) |name| {
-        // Upgrade a specific package — try formula first, then cask
-        if (!cask_only) {
-            if (isFormulaInstalled(&db, name)) {
-                upgradeFormula(ctx, allocator, name, &db, &api, &http, prefix, dry_run, force, pinned_only, isolate_deps) catch {
-                    any_failed = true;
-                };
-                if (any_failed) return error.Aborted;
-                return;
-            }
-        }
-        // Not a formula (or --cask): try cask
-        upgradeCask(ctx, allocator, name, &db, &api, prefix, dry_run, force, pinned_only) catch {
-            any_failed = true;
-        };
-    } else {
+    if (names.items.len == 0) {
         // Upgrade all
         if (!cask_only) {
             upgradeAllFormulas(ctx, allocator, &db, &api, &http, prefix, dry_run, force, pinned_only, isolate_deps) catch {
@@ -170,6 +158,22 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         }
         if (!formula_only) {
             upgradeAllCasks(ctx, allocator, &db, &api, prefix, dry_run, force, pinned_only) catch {
+                any_failed = true;
+            };
+        }
+    } else {
+        // Upgrade each named package — formula first, then cask. A failed
+        // or aborted name aggregates into `any_failed` and the loop moves
+        // on, so one bad name never abandons the rest of the batch.
+        for (names.items) |name| {
+            if (!cask_only and isFormulaInstalled(&db, name)) {
+                upgradeFormula(ctx, allocator, name, &db, &api, &http, prefix, dry_run, force, pinned_only, isolate_deps) catch {
+                    any_failed = true;
+                };
+                continue;
+            }
+            // Not a formula (or --cask): try cask
+            upgradeCask(ctx, allocator, name, &db, &api, prefix, dry_run, force, pinned_only) catch {
                 any_failed = true;
             };
         }

--- a/tests/upgrade_cli_test.zig
+++ b/tests/upgrade_cli_test.zig
@@ -161,6 +161,65 @@ test "execute upgrades a single named keg, surfaces error.Aborted on cached-404 
     );
 }
 
+test "execute upgrades every named keg, not just the first positional" {
+    // Two kegs: the first is already at latest (cached JSON, no failure),
+    // the second 404s. Only a CLI that walks BOTH positionals reaches the
+    // second and surfaces error.Aborted. Pre-fix the loop kept only the
+    // first name, the up-to-date skip returned success, and the dropped
+    // second name's failure never showed — so this asserts Aborted to
+    // prove the second positional is honored.
+    var s = try Scratch.init(testing.allocator, "multi_named");
+    defer s.deinit(testing.allocator);
+
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{s.path});
+    defer testing.allocator.free(cache_api);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_api);
+
+    // First name: cached formula JSON at the installed version → "already
+    // at latest", which returns cleanly without touching the network.
+    const up_to_date_json = try std.fmt.allocPrint(testing.allocator, "{s}/formula_wget.json", .{cache_api});
+    defer testing.allocator.free(up_to_date_json);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, up_to_date_json, .{ .truncate = true });
+        const body =
+            \\{"name":"wget","full_name":"wget","tap":"homebrew/core","desc":"","homepage":"","license":null,"revision":0,"keg_only":false,"post_install_defined":false,"versions":{"stable":"1.21"},"dependencies":[],"oldnames":[],"bottle":{}}
+        ;
+        try f.writeStreamingAll(std.Options.debug_io, body);
+        f.close(std.Options.debug_io);
+    }
+
+    // Second name: 404 marker → NotFound → error.Aborted, but only if the
+    // CLI actually processes it.
+    const marker = try std.fmt.allocPrint(testing.allocator, "{s}/formula_ffmpeg.404", .{cache_api});
+    defer testing.allocator.free(marker);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, marker, .{ .truncate = true });
+        f.close(std.Options.debug_io);
+    }
+
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{s.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+        var stmt = try db.prepare(
+            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason)
+            \\VALUES ('wget', 'wget', '1.21', 0, '', '/c/wget/1.21', 'direct'),
+            \\       ('ffmpeg', 'ffmpeg', '6', 0, '', '/c/ffmpeg/6', 'direct');
+        );
+        defer stmt.finalize();
+        _ = try stmt.step();
+    }
+
+    quiet();
+    defer unquiet();
+    try testing.expectError(
+        error.Aborted,
+        upgrade.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "wget", "ffmpeg" }),
+    );
+}
+
 test "execute --pinned --dry-run audits without leaking the parsed Formula" {
     // Plant a cached formula JSON so the audit reaches parseFormula;
     // testing.allocator is the leak gate.


### PR DESCRIPTION
## Description

`mt upgrade` now upgrades every package you name, not just the first.

The fix brings `upgrade` to parity with `install`: positionals are collected into a list and each name runs through the existing formula-first-then-cask path under the single per-invocation lock.

Per-name failures aggregate into the existing `error. Aborted` exit instead of abandoning the rest of the batch. The zero-positional "upgrade all" branch and every flag combination behave exactly as before.

## Related Issue

- None

## Notes for Reviewers

- None
