### PR TITLE
feat(outdated): resolve core rows from the cached version map

### DIFF
--- a/scripts/lib/tui_pty.sh
+++ b/scripts/lib/tui_pty.sh
@@ -51,6 +51,9 @@ tui_pty_make_prefix() {
   TUI_PREFIX=$(mktemp -d /tmp/mt_tui_e2e.XXXXXX)
   export MALT_PREFIX="$TUI_PREFIX"
   export MALT_CACHE="$TUI_PREFIX/cache"
+  # Genuinely offline so the launch-time outdated audit never reaches the
+  # network — without this the bulk version-map fetch stalls the header.
+  export MALT_OFFLINE=1
   unset CI NO_COLOR
   # `mt list` initialises + migrates the schema only when db/ already exists.
   mkdir -p "$TUI_PREFIX/db"

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
 const cask_mod = @import("../../core/cask.zig");
+const formula_mod = @import("../../core/formula.zig");
 const tap_mod = @import("../../core/tap.zig");
 const forge = @import("../../core/forge.zig");
 const sqlite = @import("../../db/sqlite.zig");
@@ -133,6 +134,107 @@ pub fn collectOutdatedCasks(
 
 const Kind = enum { formula, cask };
 
+/// One upstream version record parsed out of the cached version side-car.
+/// `stable` is borrowed from the index bytes the map was built from, so
+/// those bytes must outlive the map.
+const VersionEntry = struct { stable: []const u8, revision: i64 };
+
+/// Parse the `<name>\t<stable>\t<revision>` version side-car into a map
+/// keyed by name. Keys and `stable` borrow from `index_bytes`. Malformed
+/// lines (missing fields, empty name/version, non-integer revision) are
+/// skipped — a corrupt line must never abort the whole audit.
+fn buildVersionMap(
+    allocator: std.mem.Allocator,
+    index_bytes: []const u8,
+) std.mem.Allocator.Error!std.StringHashMap(VersionEntry) {
+    var map = std.StringHashMap(VersionEntry).init(allocator);
+    errdefer map.deinit();
+
+    var lines = std.mem.splitScalar(u8, index_bytes, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        var fields = std.mem.splitScalar(u8, line, '\t');
+        const name = fields.next() orelse continue;
+        const stable = fields.next() orelse continue;
+        const rev_str = fields.next() orelse continue;
+        if (name.len == 0 or stable.len == 0) continue;
+        const revision = std.fmt.parseInt(i64, rev_str, 10) catch continue;
+        try map.put(name, .{ .stable = stable, .revision = revision });
+    }
+    return map;
+}
+
+/// True when `row` resolves against the bulk version map: every formula,
+/// and any cask from the core tap (or with no tap). Non-core tap casks
+/// fall through to the per-HEAD `.rb` path the bulk dump can't cover.
+fn isCorePathRow(kind: Kind, row: KegRow) bool {
+    return switch (kind) {
+        .formula => true,
+        .cask => if (row.tap) |t| install_args_mod.isCoreTap(t) else true,
+    };
+}
+
+/// Resolve one keg against its version-map entry. Sets `found` to map
+/// membership (so the caller can tell "current" from "absent"), and
+/// returns a caller-owned `<stable>_<rev>` string when the row is
+/// outdated, null when it's up to date or absent.
+fn mapLatest(
+    allocator: std.mem.Allocator,
+    map: *const std.StringHashMap(VersionEntry),
+    row: KegRow,
+    found: *bool,
+) std.mem.Allocator.Error!?[]u8 {
+    const entry = map.get(row.name) orelse {
+        found.* = false;
+        return null;
+    };
+    found.* = true;
+
+    var latest_buf: [256]u8 = undefined;
+    var installed_buf: [256]u8 = undefined;
+    // pkgVersion only fails on buffer overflow — a version longer than any
+    // real keg. Treat as unresolvable rather than crash the audit.
+    const latest = formula_mod.pkgVersion(&latest_buf, entry.stable, entry.revision) catch return null;
+    const installed = formula_mod.pkgVersion(&installed_buf, row.version, row.revision) catch return null;
+    if (std.mem.eql(u8, installed, latest)) return null;
+    return try allocator.dupe(u8, latest);
+}
+
+/// Warn that the bulk version map matched none of the installed core
+/// packages — a likely upstream schema shift. Fail loud: the caller then
+/// falls back to per-package fetches rather than reporting everything up
+/// to date on an empty map.
+fn warnVersionMapDegraded(kind: Kind, core_rows: usize) void {
+    output.warn(
+        "{s} version map matched none of {d} installed package(s); falling back to per-package checks",
+        .{ @tagName(kind), core_rows },
+    );
+}
+
+/// Per-keg network resolution (serial below the pool threshold, pooled
+/// above) for the rows the map can't cover — tap casks, and every row
+/// when the map is unusable. Fills `latest_versions` by index.
+fn resolveViaFetch(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    head_cache: *TapHeadResolve,
+    db: *sqlite.Database,
+    api: *api_mod.BrewApi,
+    cache_dir: []const u8,
+    kegs: []const KegRow,
+    workers_override: ?usize,
+    kind: Kind,
+    latest_versions: []?[]u8,
+) std.mem.Allocator.Error!void {
+    if (!shouldUsePool(kegs.len)) {
+        for (kegs, 0..) |row, i| {
+            latest_versions[i] = try fetchLatest(allocator, head_cache, db, api, ctx.io, ctx.environ, kind, row);
+        }
+    } else {
+        try runPool(ctx, allocator, head_cache, db, cache_dir, kegs, workers_override, kind, latest_versions);
+    }
+}
+
 fn collectOutdated(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
@@ -145,9 +247,9 @@ fn collectOutdated(
 ) std.mem.Allocator.Error![]OutdatedEntry {
     if (kegs.len == 0) return allocator.alloc(OutdatedEntry, 0);
 
-    // Per-row latest-version slot. Workers fill `latest_versions[i]`
-    // with a caller-allocator-owned string when row `i` is outdated;
-    // null otherwise. Indexed-write keeps the pool free of locks.
+    // Per-row latest-version slot: a caller-owned string when row `i` is
+    // outdated, null otherwise. Map lookups fill core rows here directly;
+    // `resolveViaFetch` fills the rest.
     const latest_versions = try allocator.alloc(?[]u8, kegs.len);
     defer allocator.free(latest_versions);
     @memset(latest_versions, null);
@@ -155,18 +257,103 @@ fn collectOutdated(
         if (maybe) |v| allocator.free(v);
     };
 
-    // One dedup cache per `collectOutdated` call shared by every row.
-    // Lifetime: scoped to this function — workers borrow shas back
-    // (cache outlives every worker's resolve usage).
+    // `needs_fetch[i]` = resolve row `i` via the per-keg network path:
+    // tap casks always; every row when the map is missing or degraded.
+    const needs_fetch = try allocator.alloc(bool, kegs.len);
+    defer allocator.free(needs_fetch);
+    @memset(needs_fetch, false);
+
+    // Phase 1 — the bulk version map. Only fetched when at least one row
+    // can use it; a fetch error (offline/down/schema) degrades to per-keg.
+    var has_core = false;
+    for (kegs) |row| {
+        if (isCorePathRow(kind, row)) {
+            has_core = true;
+            break;
+        }
+    }
+
+    const api_kind: api_mod.BrewApi.Kind = switch (kind) {
+        .formula => .formula,
+        .cask => .cask,
+    };
+
+    var have_map = false;
+    var map: std.StringHashMap(VersionEntry) = undefined;
+    var index_bytes: ?[]const u8 = null;
+    if (has_core) {
+        if (api.fetchVersionsIndex(api_kind)) |bytes| {
+            index_bytes = bytes;
+            map = try buildVersionMap(allocator, bytes);
+            have_map = true;
+        } else |_| {}
+    }
+    defer if (index_bytes) |b| allocator.free(b);
+    defer if (have_map) map.deinit();
+
+    if (have_map) {
+        var core_rows: usize = 0;
+        var matched: usize = 0;
+        for (kegs, 0..) |row, i| {
+            if (!isCorePathRow(kind, row)) {
+                needs_fetch[i] = true; // tap cask → per-HEAD
+                continue;
+            }
+            core_rows += 1;
+            var found = false;
+            const latest = try mapLatest(allocator, &map, row, &found);
+            if (found) {
+                matched += 1;
+                latest_versions[i] = latest; // null when up to date
+            }
+            // A miss on a healthy map means "no upstream info" — drop the
+            // row like a 404, no per-keg refetch.
+        }
+
+        // Fail loud: core rows present but none matched → bad map.
+        if (core_rows > 0 and matched == 0) {
+            warnVersionMapDegraded(kind, core_rows);
+            for (kegs, 0..) |row, i| {
+                if (isCorePathRow(kind, row)) needs_fetch[i] = true;
+            }
+        }
+    } else {
+        @memset(needs_fetch, true); // no map → every row via per-keg
+    }
+
+    // One dedup cache shared by every per-keg row (tap-HEAD coalescing).
     var head_cache = TapHeadResolve.init(allocator, ctx.io);
     defer head_cache.deinit();
 
-    if (!shouldUsePool(kegs.len)) {
+    // Phase 2 — gather the rows still needing a network resolve and run
+    // them through the (sub-)serial-or-pool path, then scatter results.
+    var n_fetch: usize = 0;
+    for (needs_fetch) |f| {
+        if (f) n_fetch += 1;
+    }
+    if (n_fetch > 0) {
+        const sub_kegs = try allocator.alloc(KegRow, n_fetch);
+        defer allocator.free(sub_kegs);
+        const sub_idx = try allocator.alloc(usize, n_fetch);
+        defer allocator.free(sub_idx);
+        const sub_latest = try allocator.alloc(?[]u8, n_fetch);
+        defer allocator.free(sub_latest);
+        @memset(sub_latest, null);
+        errdefer for (sub_latest) |maybe| {
+            if (maybe) |v| allocator.free(v);
+        };
+
+        var j: usize = 0;
         for (kegs, 0..) |row, i| {
-            latest_versions[i] = try fetchLatest(allocator, &head_cache, db, api, ctx.io, ctx.environ, kind, row);
+            if (needs_fetch[i]) {
+                sub_kegs[j] = row;
+                sub_idx[j] = i;
+                j += 1;
+            }
         }
-    } else {
-        try runPool(ctx, allocator, &head_cache, db, cache_dir, kegs, workers_override, kind, latest_versions);
+
+        try resolveViaFetch(ctx, allocator, &head_cache, db, api, cache_dir, sub_kegs, workers_override, kind, sub_latest);
+        for (sub_idx, 0..) |orig, k| latest_versions[orig] = sub_latest[k];
     }
 
     return assembleEntries(allocator, kegs, latest_versions);
@@ -196,7 +383,11 @@ fn assembleEntries(
 
         const name_dup = try allocator.dupe(u8, row.name);
         errdefer allocator.free(name_dup);
-        const installed_dup = try allocator.dupe(u8, row.version);
+        // Show the keg's revision-aware version so a `1.2_1 -> 1.2_2`
+        // bump reads correctly; revision 0 stays the bare `1.2`.
+        var installed_buf: [256]u8 = undefined;
+        const installed_str = formula_mod.pkgVersion(&installed_buf, row.version, row.revision) catch row.version;
+        const installed_dup = try allocator.dupe(u8, installed_str);
 
         try out.append(allocator, .{
             .name = name_dup,
@@ -881,6 +1072,39 @@ test "warnTapCaskFetchFailed names both the tap and the token" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "yuzeguitarist/deck") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "deckclip") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "404") != null);
+}
+
+test "buildVersionMap parses tab-delimited entries with stable and revision" {
+    const idx = "wget\t1.21.4\t0\nopenssl@3\t3.2.1\t2\n";
+    var map = try buildVersionMap(std.testing.allocator, idx);
+    defer map.deinit();
+    try std.testing.expectEqual(@as(usize, 2), map.count());
+    const w = map.get("wget") orelse return error.MissingEntry;
+    try std.testing.expectEqualStrings("1.21.4", w.stable);
+    try std.testing.expectEqual(@as(i64, 0), w.revision);
+    const o = map.get("openssl@3") orelse return error.MissingEntry;
+    try std.testing.expectEqualStrings("3.2.1", o.stable);
+    try std.testing.expectEqual(@as(i64, 2), o.revision);
+}
+
+test "isCorePathRow sends formulae and core casks to the map, tap casks per-HEAD" {
+    // Formulae always use the map, tap attribution notwithstanding.
+    try std.testing.expect(isCorePathRow(.formula, .{ .name = "wget", .version = "1" }));
+    try std.testing.expect(isCorePathRow(.formula, .{ .name = "x", .version = "1", .tap = "user/repo" }));
+    // Casks: no tap or the core tap → map; a third-party tap → per-HEAD.
+    try std.testing.expect(isCorePathRow(.cask, .{ .name = "firefox", .version = "1" }));
+    try std.testing.expect(isCorePathRow(.cask, .{ .name = "f", .version = "1", .tap = "homebrew/cask" }));
+    try std.testing.expect(!isCorePathRow(.cask, .{ .name = "f", .version = "1", .tap = "user/repo" }));
+}
+
+test "buildVersionMap skips malformed lines without aborting" {
+    // Missing fields, empty version, and a non-integer revision must each
+    // drop their line, not crash the parse.
+    const idx = "good\t1.0\t0\nbadline\nempty\t\t0\nrev\t2.0\tnotnum\n";
+    var map = try buildVersionMap(std.testing.allocator, idx);
+    defer map.deinit();
+    try std.testing.expectEqual(@as(usize, 1), map.count());
+    try std.testing.expect(map.get("good") != null);
 }
 
 test "parseFormulaLatest pulls versions.stable from a real-shape document" {

--- a/src/cli/outdated/rows.zig
+++ b/src/cli/outdated/rows.zig
@@ -20,6 +20,10 @@ const sqlite = @import("../../db/sqlite.zig");
 pub const KegRow = struct {
     name: []const u8,
     version: []const u8,
+    /// Homebrew revision of the installed keg (`kegs.revision`); 0 for
+    /// casks, which have no revision. Paired with `version` via
+    /// `formula.pkgVersion` to compare against upstream revision bumps.
+    revision: i64 = 0,
     tap: ?[]const u8 = null,
     /// True for `mt pin`-held rows. Surfaced so `mt outdated --json` can
     /// keep a pinned-but-outdated package visible with `pinned:true`.
@@ -47,10 +51,10 @@ pub fn loadFormulaRows(
     filter: KegFilter,
 ) ![]KegRow {
     const sql: [:0]const u8 = switch (filter) {
-        .all => "SELECT name, version, tap, pinned FROM kegs ORDER BY name;",
-        .pinned_only => "SELECT name, version, tap, pinned FROM kegs WHERE pinned = 1 ORDER BY name;",
+        .all => "SELECT name, version, revision, tap, pinned FROM kegs ORDER BY name;",
+        .pinned_only => "SELECT name, version, revision, tap, pinned FROM kegs WHERE pinned = 1 ORDER BY name;",
         // NOCASE so `--tap User/Repo` resolves a row stored lowercase.
-        .by_tap => "SELECT name, version, tap, pinned FROM kegs WHERE tap = ?1 COLLATE NOCASE ORDER BY name;",
+        .by_tap => "SELECT name, version, revision, tap, pinned FROM kegs WHERE tap = ?1 COLLATE NOCASE ORDER BY name;",
     };
     const bind: ?[]const u8 = switch (filter) {
         .by_tap => |label| label,
@@ -68,11 +72,13 @@ pub fn loadCaskRows(
     db: *sqlite.Database,
     filter: KegFilter,
 ) ![]KegRow {
+    // Casks have no revision; `0 AS revision` keeps the column layout
+    // uniform with the formula query so `loadKegRows` reads one shape.
     const sql: [:0]const u8 = switch (filter) {
-        .all => "SELECT token, version, tap, pinned FROM casks ORDER BY token;",
-        .pinned_only => "SELECT token, version, tap, pinned FROM casks WHERE pinned = 1 ORDER BY token;",
+        .all => "SELECT token, version, 0 AS revision, tap, pinned FROM casks ORDER BY token;",
+        .pinned_only => "SELECT token, version, 0 AS revision, tap, pinned FROM casks WHERE pinned = 1 ORDER BY token;",
         // NOCASE so `--tap User/Repo` resolves a row stored lowercase.
-        .by_tap => "SELECT token, version, tap, pinned FROM casks WHERE tap = ?1 COLLATE NOCASE ORDER BY token;",
+        .by_tap => "SELECT token, version, 0 AS revision, tap, pinned FROM casks WHERE tap = ?1 COLLATE NOCASE ORDER BY token;",
     };
     const bind: ?[]const u8 = switch (filter) {
         .by_tap => |label| label,
@@ -147,10 +153,11 @@ fn loadKegRows(
         errdefer allocator.free(name_dup);
         const ver_dup = try allocator.dupe(u8, ver_slice);
         errdefer allocator.free(ver_dup);
-        // Column 2 is `tap`: null for core-API rows and v5-era casks
-        // not yet backfilled. Column 3 is the `pinned` flag.
+        // Column layout (uniform across formula/cask): 0 name, 1 version,
+        // 2 revision, 3 tap (null for core-API rows / v5-era casks),
+        // 4 pinned.
         var tap_dup: ?[]u8 = null;
-        if (stmt.columnText(2)) |tap_ptr| {
+        if (stmt.columnText(3)) |tap_ptr| {
             const tap_slice = std.mem.sliceTo(tap_ptr, 0);
             tap_dup = try allocator.dupe(u8, tap_slice);
         }
@@ -158,8 +165,9 @@ fn loadKegRows(
         try rows.append(allocator, .{
             .name = name_dup,
             .version = ver_dup,
+            .revision = stmt.columnInt(2),
             .tap = tap_dup,
-            .pinned = stmt.columnBool(3),
+            .pinned = stmt.columnBool(4),
         });
     }
     return rows.toOwnedSlice(allocator);

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -100,12 +100,28 @@ fn openTestDb() !sqlite.Database {
     return db;
 }
 
+/// Append one `<name>\t<stable>\t0` record to a version side-car so the
+/// map path resolves the row. Read-modify-write keeps it simple for tests.
+fn appendVersionsLine(dir: *TempCacheDir, rel: []const u8, name: []const u8, stable: []const u8) !void {
+    var path_buf: [512]u8 = undefined;
+    const full = try std.fmt.bufPrint(&path_buf, "{s}/api/{s}", .{ dir.path, rel });
+    const prev = test_io.readFileAbsoluteAlloc(std.Options.debug_io, dir.allocator, full, 1 << 20) catch
+        try dir.allocator.dupe(u8, "");
+    defer dir.allocator.free(prev);
+    const combined = try std.fmt.allocPrint(dir.allocator, "{s}{s}\t{s}\t0\n", .{ prev, name, stable });
+    defer dir.allocator.free(combined);
+    try dir.writeCacheFile(rel, combined);
+}
+
 fn seedFormula(dir: *TempCacheDir, name: []const u8, latest: []const u8) !void {
     var key_buf: [128]u8 = undefined;
     const file = try std.fmt.bufPrint(&key_buf, "formula_{s}.json", .{name});
     var body_buf: [256]u8 = undefined;
     const body = try std.fmt.bufPrint(&body_buf, "{{\"name\":\"{s}\",\"versions\":{{\"stable\":\"{s}\"}}}}", .{ name, latest });
     try dir.writeCacheFile(file, body);
+    // Version side-car drives the map path; the JSON above stays as the
+    // per-keg fallback so both routes are exercised by the suite.
+    try appendVersionsLine(dir, "versions_formula.txt", name, latest);
 }
 
 fn seedCask(dir: *TempCacheDir, token: []const u8, latest: []const u8) !void {
@@ -119,6 +135,7 @@ fn seedCask(dir: *TempCacheDir, token: []const u8, latest: []const u8) !void {
         .{ token, token, latest, token },
     );
     try dir.writeCacheFile(file, body);
+    try appendVersionsLine(dir, "versions_cask.txt", token, latest);
 }
 
 test "collectOutdatedFormulas (small-N, single-client path) returns sorted outdated rows only" {
@@ -270,6 +287,98 @@ test "collectOutdatedCasks (large-N, pool path) preserves sorted order" {
         try testing.expectEqualStrings("1.0", entry.installed);
         try testing.expectEqualStrings("2.0", entry.latest);
     }
+}
+
+// --- version-map path: routing, revision bumps, fail-loud ---
+
+test "collectOutdated resolves core rows from the version map with no per-keg cache" {
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init(testing.allocator, "map_only");
+    defer dir.deinit();
+
+    // Side-car only — no formula_*.json. Under offline the per-keg path
+    // can't reach the network, so a resolved row proves the map was used.
+    try dir.writeCacheFile("versions_formula.txt", "alpha\t2.0\t0\nbravo\t1.0\t0\n");
+
+    var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
+    api.offline = true;
+
+    const kegs = [_]outdated_mod.KegRow{
+        .{ .name = "alpha", .version = "1.0" }, // outdated via map
+        .{ .name = "bravo", .version = "1.0" }, // up to date via map
+    };
+    var db = try openTestDb();
+    defer db.close();
+    const out = try outdated_mod.collectOutdatedFormulas(&malt.app_ctx.debug_ctx, testing.allocator, &db, &api, dir.path, &kegs, null);
+    defer freeEntries(testing.allocator, out);
+
+    try testing.expectEqual(@as(usize, 1), out.len);
+    try testing.expectEqualStrings("alpha", out[0].name);
+    try testing.expectEqualStrings("1.0", out[0].installed);
+    try testing.expectEqualStrings("2.0", out[0].latest);
+}
+
+test "collectOutdated detects an upstream revision bump" {
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init(testing.allocator, "rev_bump");
+    defer dir.deinit();
+
+    // Upstream is 1.2 revision 2 for both packages.
+    try dir.writeCacheFile("versions_formula.txt", "behind\t1.2\t2\ncurrent\t1.2\t2\n");
+
+    var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
+    api.offline = true;
+
+    const kegs = [_]outdated_mod.KegRow{
+        .{ .name = "behind", .version = "1.2", .revision = 1 }, // 1.2_1 < 1.2_2
+        .{ .name = "current", .version = "1.2", .revision = 2 }, // 1.2_2 == 1.2_2
+    };
+    var db = try openTestDb();
+    defer db.close();
+    const out = try outdated_mod.collectOutdatedFormulas(&malt.app_ctx.debug_ctx, testing.allocator, &db, &api, dir.path, &kegs, null);
+    defer freeEntries(testing.allocator, out);
+
+    // Only the revision-behind keg is outdated; `latest` carries the full
+    // <stable>_<rev>, `installed` shows the keg's own revision.
+    try testing.expectEqual(@as(usize, 1), out.len);
+    try testing.expectEqualStrings("behind", out[0].name);
+    try testing.expectEqualStrings("1.2_1", out[0].installed);
+    try testing.expectEqualStrings("1.2_2", out[0].latest);
+}
+
+test "collectOutdated warns and falls back to per-keg on an empty version map" {
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init(testing.allocator, "fail_loud");
+    defer dir.deinit();
+
+    // Empty side-car (schema shift) but a healthy per-keg cache. The audit
+    // must warn and fall back, never report the install as all up to date.
+    try dir.writeCacheFile("versions_formula.txt", "");
+    try dir.writeCacheFile("formula_alpha.json", "{\"name\":\"alpha\",\"versions\":{\"stable\":\"2.0\"}}");
+
+    var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
+    api.offline = true;
+
+    var warn_buf: std.ArrayList(u8) = .empty;
+    defer warn_buf.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &warn_buf);
+    defer malt.output.endStderrCapture();
+
+    const kegs = [_]outdated_mod.KegRow{
+        .{ .name = "alpha", .version = "1.0" },
+    };
+    var db = try openTestDb();
+    defer db.close();
+    const out = try outdated_mod.collectOutdatedFormulas(&malt.app_ctx.debug_ctx, testing.allocator, &db, &api, dir.path, &kegs, null);
+    defer freeEntries(testing.allocator, out);
+
+    try testing.expectEqual(@as(usize, 1), out.len);
+    try testing.expectEqualStrings("alpha", out[0].name);
+    try testing.expectEqualStrings("2.0", out[0].latest);
+    try testing.expect(std.mem.indexOf(u8, warn_buf.items, "falling back") != null);
 }
 
 // --- --pinned-only filter ---
@@ -424,6 +533,31 @@ test "loadCaskRows surfaces the owning tap when set" {
 
     try testing.expectEqualStrings("legacy-cask", rows[1].name);
     try testing.expect(rows[1].tap == null);
+}
+
+test "loadFormulaRows surfaces the keg revision; casks report 0" {
+    // The revision feeds the pkgVersion comparison; casks have no such
+    // column, so the query's `0 AS revision` must come back as 0.
+    var db = try openTestDb();
+    defer db.close();
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+        \\VALUES ('rev', 'rev', '1.2', 3, 'sha', '/c/rev/1.2_3');
+    );
+    try db.exec(
+        \\INSERT INTO casks (token, name, version, url)
+        \\VALUES ('app', 'app', '4.0', 'https://example.invalid');
+    );
+
+    const frows = try outdated_mod.loadFormulaRows(testing.allocator, &db, .all);
+    defer outdated_mod.freeKegRows(testing.allocator, frows);
+    try testing.expectEqual(@as(usize, 1), frows.len);
+    try testing.expectEqual(@as(i64, 3), frows[0].revision);
+
+    const crows = try outdated_mod.loadCaskRows(testing.allocator, &db, .all);
+    defer outdated_mod.freeKegRows(testing.allocator, crows);
+    try testing.expectEqual(@as(usize, 1), crows.len);
+    try testing.expectEqual(@as(i64, 0), crows[0].revision);
 }
 
 test "loadFormulaRows .all surfaces the pinned flag and tap attribution" {


### PR DESCRIPTION
## Description

`mt outdated` now resolves every core formula and core cask against a single
cached version map instead of firing one HTTP round-trip per installed package.
A cold check collapses from `slowest_fetch × ceil(N / 8)` network round-trips to
**one bulk read followed by pure in-memory lookups**; on a warm cache (e.g. after
any `mt search`) it does zero network work. Tap casks keep their per-HEAD `.rb`
path, which the core bulk dump can't cover.

## Related Issue

- None

## Notes for Reviewers

- None