### PR TITLE
perf(net): conditional-GET the bulk dump so a fresh outdated is cheap

### DIFF
--- a/src/cli/install/rb_parse.zig
+++ b/src/cli/install/rb_parse.zig
@@ -215,7 +215,49 @@ fn deriveVersionFromUrl(url: []const u8) ?[]const u8 {
         return stripArchiveSuffixThenValidate(after);
     }
 
-    return null;
+    // No path marker carried the tag: fall back to the bare filename.
+    return versionFromFilename(url);
+}
+
+/// Last-resort derivation for a self-hosted release whose version lives only
+/// in the filename (`…/tool-1.2.3.tar.gz`, `…/tool_1.2.3_amd64.zip`) with no
+/// `/archive/` or `/releases/` marker. Strip a known archive suffix, split
+/// the stem on `-`/`_`, and accept a version only when EXACTLY one token is
+/// an unambiguous dotted version. Zero or several such tokens → null, so a
+/// digit-led name (`7zip`) or a multi-version filename never mis-derives —
+/// a wrong version is worse than none (it fakes an "outdated").
+fn versionFromFilename(url: []const u8) ?[]const u8 {
+    const slash = std.mem.lastIndexOfScalar(u8, url, '/') orelse return null;
+    const filename = url[slash + 1 ..];
+
+    const stem = for (tap_archive_suffixes) |suffix| {
+        if (std.mem.endsWith(u8, filename, suffix))
+            break filename[0 .. filename.len - suffix.len];
+    } else return null;
+
+    var found: ?[]const u8 = null;
+    var it = std.mem.tokenizeAny(u8, stem, "-_");
+    while (it.next()) |tok| {
+        const ver = strictVersionToken(tok) orelse continue;
+        if (found != null) return null; // >1 version-like token → ambiguous
+        found = ver;
+    }
+    return found;
+}
+
+/// Stricter than `validateVersionToken`: the *whole* token must read as a
+/// dotted version (`v?` then only digits and dots). Used when guessing a
+/// version out of a bare filename, where the loose first-byte check would
+/// misread a name segment like `7zip` as a version. Returns the v-stripped
+/// token or null.
+fn strictVersionToken(s: []const u8) ?[]const u8 {
+    var body = s;
+    if (body.len > 0 and (body[0] == 'v' or body[0] == 'V')) body = body[1..];
+    if (body.len == 0 or !std.ascii.isDigit(body[0])) return null;
+    for (body) |c| {
+        if (!std.ascii.isDigit(c) and c != '.') return null;
+    }
+    return body;
 }
 
 /// Validate the path segment up to the next `/` as a version token.
@@ -422,6 +464,45 @@ test "deriveVersionFromUrl: GitLab floating release tag is rejected" {
     try std.testing.expect(deriveVersionFromUrl(
         "https://gitlab.com/foo/bar/-/releases/latest/downloads/bar.tar.gz",
     ) == null);
+}
+
+test "deriveVersionFromUrl: derives from a bare versioned filename, null when ambiguous" {
+    const cases = [_]struct { url: []const u8, want: ?[]const u8 }{
+        // The headline shape: a self-hosted release with the version only
+        // in the filename, no `/archive/` or `/releases/` path marker.
+        .{ .url = "https://host.example.com/dl/tool-1.2.3.tar.gz", .want = "1.2.3" },
+        // Underscore-delimited, version in the middle (`_<version>_`).
+        .{ .url = "https://host.example.com/dl/tool_1.2.3_amd64.zip", .want = "1.2.3" },
+        // A leading `v` is stripped just like the path-marker shapes.
+        .{ .url = "https://host.example.com/dl/tool-v2.4.0.tgz", .want = "2.4.0" },
+        // A name with leading digits must not be mistaken for the version.
+        .{ .url = "https://host.example.com/dl/7zip-22.01.tar.xz", .want = "22.01" },
+        // No version-like token → graceful skip, never a guess.
+        .{ .url = "https://host.example.com/dl/tool.tar.gz", .want = null },
+        // Two version-like tokens are ambiguous → null, not a wrong pick.
+        .{ .url = "https://host.example.com/dl/tool-1.2-3.4.tar.gz", .want = null },
+        // Unrecognised archive suffix → no stem to read → null.
+        .{ .url = "https://host.example.com/dl/tool-1.2.3.bin", .want = null },
+    };
+    for (cases) |c| {
+        const got = deriveVersionFromUrl(c.url);
+        if (c.want) |w| {
+            try std.testing.expectEqualStrings(w, got orelse return error.TestUnexpectedNull);
+        } else {
+            try std.testing.expect(got == null);
+        }
+    }
+}
+
+test "parseRubyFormula: derives version from a bare versioned filename" {
+    const src =
+        \\class Foo < Formula
+        \\  url "https://downloads.example.com/foo-1.2.3.tar.gz"
+        \\  sha256 "deadbeef"
+        \\end
+    ;
+    const got = parseRubyFormula(src) orelse return error.TestUnexpectedNull;
+    try std.testing.expectEqualStrings("1.2.3", got.version);
 }
 
 test "extractQuoted: extracts between prefix and the next quote" {

--- a/src/net/api.zig
+++ b/src/net/api.zig
@@ -404,11 +404,40 @@ pub const BrewApi = struct {
     /// Folding the two extractors into one fetch is a requirement, not an
     /// optimisation: it stops a cold versions fetch from re-pulling a dump
     /// the names fetch already has on disk. Caller owns both slices.
+    ///
+    /// The GET is conditional: a stored ETag rides as `If-None-Match`, so an
+    /// unchanged dump answers 304 with no body and both side-cars are merely
+    /// marked fresh. A 200 (changed dump, or first-ever fetch) re-extracts
+    /// both and persists the new ETag. The public dump needs no auth header,
+    /// so none is sent — formulae.brew.sh is a CDN that ignores it.
     fn fetchAndWriteIndex(self: *BrewApi, kind: Kind, key: []const u8) ApiError!IndexPair {
         var url_buf: [512]u8 = undefined;
         const url = try buildNamesIndexUrl(&url_buf, self.base_url, kind);
-        var resp = self.http.get(url) catch return ApiError.ApiUnreachable;
+
+        const stored_etag = self.readIndexEtag(key);
+        defer if (stored_etag) |e| self.allocator.free(e);
+
+        var resp = self.http.getConditional(url, stored_etag, &.{}) catch return ApiError.ApiUnreachable;
         defer resp.deinit();
+
+        if (resp.not_modified) {
+            // Unchanged upstream: restart both side-cars' TTL without a
+            // rewrite and serve the bytes already on disk.
+            self.touchIndex("names_", key);
+            self.touchIndex("versions_", key);
+            if (self.readIndexFile("names_", key, null)) |names| {
+                if (self.readIndexFile("versions_", key, null)) |versions| {
+                    return .{ .names = names, .versions = versions };
+                }
+                self.allocator.free(names);
+            }
+            // ETag present but a side-car is gone (evicted / wiped): drop the
+            // ETag so the next refresh re-downloads unconditionally rather
+            // than looping on a 304 it can no longer satisfy.
+            self.deleteIndexEtag(key);
+            return ApiError.ApiUnreachable;
+        }
+
         if (resp.status != 200) return ApiError.ApiUnreachable;
 
         const names = extractNames(self.allocator, kind, resp.body) catch |e| switch (e) {
@@ -424,6 +453,7 @@ pub const BrewApi = struct {
 
         self.writeIndexFile("names_", key, names);
         self.writeIndexFile("versions_", key, versions);
+        self.writeIndexEtag(key, resp.etag);
         return .{ .names = names, .versions = versions };
     }
 
@@ -472,6 +502,71 @@ pub const BrewApi = struct {
         defer f.close(self.io);
         // Partial index is discarded on next miss; next fetch re-populates from network.
         f.writeStreamingAll(self.io, data) catch {};
+    }
+
+    /// Real ETags are tens of bytes; anything larger is corrupt and ignored
+    /// so a garbage `If-None-Match` never rides out to upstream.
+    const max_etag_bytes: u64 = 256;
+
+    /// Read the stored bulk-dump ETag for `key` (`api/<key>.etag`), or null
+    /// if absent / unreadable / implausibly large. Caller owns the bytes.
+    fn readIndexEtag(self: *BrewApi, key: []const u8) ?[]const u8 {
+        var path_buf: [512]u8 = undefined;
+        const p = std.fmt.bufPrint(&path_buf, "{s}/api/{s}.etag", .{ self.cache_dir, key }) catch return null;
+        const file = std.Io.Dir.cwd().openFile(self.io, p, .{}) catch return null;
+        defer file.close(self.io);
+        const s = file.stat(self.io) catch return null;
+        if (s.size == 0 or s.size > max_etag_bytes) return null;
+        const buf = self.allocator.alloc(u8, s.size) catch return null;
+        const n = file.readPositionalAll(self.io, buf, 0) catch {
+            self.allocator.free(buf);
+            return null;
+        };
+        if (n < buf.len) {
+            self.allocator.free(buf);
+            return null;
+        }
+        return buf;
+    }
+
+    /// Persist the bulk-dump ETag for `key` atomically so a crash mid-write
+    /// can't leave a torn token that forces a needless full re-download. A
+    /// null `etag` (server omitted the header) clears any stored value so
+    /// the next fetch is unconditional rather than replaying a stale token.
+    fn writeIndexEtag(self: *const BrewApi, key: []const u8, etag: ?[]const u8) void {
+        const e = etag orelse return self.deleteIndexEtag(key);
+        var dir_buf: [512]u8 = undefined;
+        const dir = std.fmt.bufPrint(&dir_buf, "{s}/api", .{self.cache_dir}) catch return;
+        std.Io.Dir.createDirAbsolute(self.io, dir, .default_dir) catch |err| switch (err) {
+            error.PathAlreadyExists => {},
+            else => return,
+        };
+        var path_buf: [512]u8 = undefined;
+        const p = std.fmt.bufPrint(&path_buf, "{s}/api/{s}.etag", .{ self.cache_dir, key }) catch return;
+        // Best-effort: a failed write just means the next fetch is
+        // unconditional, never wrong — the side-cars are already on disk.
+        atomic.atomicWriteFile(self.io, p, e) catch {};
+    }
+
+    /// Remove the stored ETag for `key`; best-effort.
+    fn deleteIndexEtag(self: *const BrewApi, key: []const u8) void {
+        var path_buf: [512]u8 = undefined;
+        const p = std.fmt.bufPrint(&path_buf, "{s}/api/{s}.etag", .{ self.cache_dir, key }) catch return;
+        // A leftover ETag at worst triggers one needless conditional GET;
+        // a delete failure is harmless, so swallow it.
+        std.Io.Dir.cwd().deleteFile(self.io, p) catch {};
+    }
+
+    /// Reset a side-car's mtime to now so a 304 restarts its TTL window
+    /// without rewriting the bytes already on disk.
+    fn touchIndex(self: *const BrewApi, infix: []const u8, key: []const u8) void {
+        var path_buf: [512]u8 = undefined;
+        const p = std.fmt.bufPrint(&path_buf, "{s}/api/{s}{s}.txt", .{ self.cache_dir, infix, key }) catch return;
+        const file = std.Io.Dir.cwd().openFile(self.io, p, .{ .mode = .write_only }) catch return;
+        defer file.close(self.io);
+        // If the touch fails the side-car just looks stale next time and we
+        // re-issue the (cheap) conditional GET — correctness is unaffected.
+        file.setTimestampsNow(self.io) catch {};
     }
 
     /// Invalidate all cached API responses.

--- a/tests/api_test.zig
+++ b/tests/api_test.zig
@@ -507,6 +507,87 @@ const CountingServer = struct {
     }
 };
 
+// Conditional-GET server: returns `body` + `ETag: etag` on 200, or an
+// empty 304 when the request's `If-None-Match` matches `etag`. Counts
+// answered requests so a test can assert the refresh hit the network
+// exactly once. Loop exits when the listener is closed from the test.
+const EtagServer = struct {
+    io: std.Io,
+    listener: *net.Server,
+    body: []const u8,
+    // When null, the 200 reply carries no ETag header — models an upstream
+    // that stops advertising one, exercising the stale-token-clear path.
+    etag: ?[]const u8,
+    count: std.atomic.Value(u32),
+    // How many answered requests carried an `If-None-Match` — lets a test
+    // prove the refresh went out conditional (or, when 0, unconditional).
+    conditional_count: std.atomic.Value(u32),
+
+    fn serve(self: *EtagServer) void {
+        while (true) {
+            const stream = self.listener.accept(self.io) catch return;
+            defer stream.close(self.io);
+            var rbuf: [16 * 1024]u8 = undefined;
+            var wbuf: [16 * 1024]u8 = undefined;
+            var reader = stream.reader(self.io, &rbuf);
+            var writer = stream.writer(self.io, &wbuf);
+            var srv = std.http.Server.init(&reader.interface, &writer.interface);
+            var req = srv.receiveHead() catch return;
+
+            var if_none_match: ?[]const u8 = null;
+            var it = req.iterateHeaders();
+            while (it.next()) |h| {
+                if (std.ascii.eqlIgnoreCase(h.name, "if-none-match")) if_none_match = h.value;
+            }
+            if (if_none_match != null) _ = self.conditional_count.fetchAdd(1, .monotonic);
+
+            var headers: [1]std.http.Header = undefined;
+            const extra: []const std.http.Header = if (self.etag) |e| blk: {
+                headers[0] = .{ .name = "ETag", .value = e };
+                break :blk headers[0..1];
+            } else &.{};
+
+            if (self.etag) |e| {
+                if (if_none_match) |inm| {
+                    if (std.mem.eql(u8, inm, e)) {
+                        req.respond("", .{ .status = .not_modified, .extra_headers = extra }) catch return;
+                        _ = self.count.fetchAdd(1, .monotonic);
+                        continue;
+                    }
+                }
+            }
+            req.respond(self.body, .{ .extra_headers = extra }) catch return;
+            _ = self.count.fetchAdd(1, .monotonic);
+        }
+    }
+};
+
+/// Backdate an index side-car's mtime to 1970 so the freshness gate treats
+/// it as stale and the next fetch takes the refresh path.
+fn backdateIndex(dir_path: []const u8, rel: []const u8) !void {
+    var path_buf: [512]u8 = undefined;
+    const full = try std.fmt.bufPrint(&path_buf, "{s}/api/{s}", .{ dir_path, rel });
+    const file = try test_io.cwd().openFile(std.Options.debug_io, full, .{ .mode = .write_only });
+    defer file.close(std.Options.debug_io);
+    try file.setTimestamps(std.Options.debug_io, .{
+        .access_timestamp = .{ .new = .{ .nanoseconds = 0 } },
+        .modify_timestamp = .{ .new = .{ .nanoseconds = 0 } },
+    });
+}
+
+/// Read an `api/<rel>` cache file into caller-owned bytes, or null if absent.
+fn readCacheFileAlloc(allocator: std.mem.Allocator, dir_path: []const u8, rel: []const u8) !?[]const u8 {
+    var path_buf: [512]u8 = undefined;
+    const full = try std.fmt.bufPrint(&path_buf, "{s}/api/{s}", .{ dir_path, rel });
+    const file = test_io.cwd().openFile(std.Options.debug_io, full, .{}) catch return null;
+    defer file.close(std.Options.debug_io);
+    const s = try file.stat(std.Options.debug_io);
+    const buf = try allocator.alloc(u8, s.size);
+    errdefer allocator.free(buf);
+    const n = try file.readPositionalAll(std.Options.debug_io, buf, 0);
+    return buf[0..n];
+}
+
 test "fetchVersionsIndex returns a fresh pre-seeded side-car without touching the network" {
     var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
     defer http.deinit();
@@ -621,6 +702,435 @@ test "a cold names+versions cycle downloads the bulk dump exactly once" {
     try test_io.accessAbsolute(io, vpath, .{});
     api.invalidateCache();
     try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, vpath, .{}));
+}
+
+// --- conditional GET: ETag/304 refresh of the bulk dump ---
+
+test "a stale side-car with an unchanged dump refreshes via 304, no re-download" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const etag = "W/\"unchanged\"";
+    // Server body differs from the seeded side-cars on purpose: a 304 must
+    // return the cached bytes, never re-extract the body.
+    const fixture =
+        \\[{"name":"server","versions":{"stable":"0.0.0"}}]
+    ;
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+    var srv = EtagServer{
+        .io = io,
+        .listener = &listener,
+        .body = fixture,
+        .etag = etag,
+        .count = std.atomic.Value(u32).init(0),
+        .conditional_count = std.atomic.Value(u32).init(0),
+    };
+    const thread = try std.Thread.spawn(.{}, EtagServer.serve, .{&srv});
+
+    var dir = try TempCacheDir.init("etag_304_refresh");
+    defer dir.deinit();
+
+    const seeded_versions = "wget\t9.9.9\t0\n";
+    const seeded_names = "wget\njq\n";
+    try dir.writeCacheFile("versions_formula.txt", seeded_versions);
+    try dir.writeCacheFile("names_formula.txt", seeded_names);
+    try dir.writeCacheFile("formula.etag", etag);
+    // Both side-cars are stale so the versions fetch takes the refresh path.
+    try backdateIndex(dir.path, "versions_formula.txt");
+    try backdateIndex(dir.path, "names_formula.txt");
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client_mod.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(io, testing.allocator, &http, dir.path);
+    var base_buf: [64]u8 = undefined;
+    api.base_url = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    const versions = try api.fetchVersionsIndex(.formula);
+    defer testing.allocator.free(versions);
+    // The 304 path serves the seeded bytes verbatim — proof no body was read.
+    try testing.expectEqualStrings(seeded_versions, versions);
+
+    // The 304 also refreshed the names side-car, so search stays warm with
+    // no second download.
+    const names = try api.fetchNamesIndex(.formula);
+    defer testing.allocator.free(names);
+    try testing.expectEqualStrings(seeded_names, names);
+
+    listener.deinit(io);
+    thread.join();
+
+    // Exactly one conditional request; the warm names read hit no network.
+    try testing.expectEqual(@as(u32, 1), srv.count.load(.monotonic));
+    // That request carried If-None-Match — the stored ETag rode out.
+    try testing.expectEqual(@as(u32, 1), srv.conditional_count.load(.monotonic));
+
+    // The stored ETag is unchanged after a 304.
+    const stored = (try readCacheFileAlloc(testing.allocator, dir.path, "formula.etag")).?;
+    defer testing.allocator.free(stored);
+    try testing.expectEqualStrings(etag, stored);
+}
+
+test "a changed dump (new ETag) re-extracts both side-cars and stores the new ETag" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const old_etag = "W/\"old\"";
+    const new_etag = "W/\"new\"";
+    const fixture =
+        \\[{"name":"wget","versions":{"stable":"1.21.4"},"revision":0}]
+    ;
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+    var srv = EtagServer{
+        .io = io,
+        .listener = &listener,
+        .body = fixture,
+        .etag = new_etag,
+        .count = std.atomic.Value(u32).init(0),
+        .conditional_count = std.atomic.Value(u32).init(0),
+    };
+    const thread = try std.Thread.spawn(.{}, EtagServer.serve, .{&srv});
+
+    var dir = try TempCacheDir.init("etag_200_changed");
+    defer dir.deinit();
+
+    // Seed a stale cache pinned to the old ETag — the dump has since moved on.
+    try dir.writeCacheFile("versions_formula.txt", "stale\t0.0.0\t0\n");
+    try dir.writeCacheFile("names_formula.txt", "stale\n");
+    try dir.writeCacheFile("formula.etag", old_etag);
+    try backdateIndex(dir.path, "versions_formula.txt");
+    try backdateIndex(dir.path, "names_formula.txt");
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client_mod.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(io, testing.allocator, &http, dir.path);
+    var base_buf: [64]u8 = undefined;
+    api.base_url = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    const versions = try api.fetchVersionsIndex(.formula);
+    defer testing.allocator.free(versions);
+
+    listener.deinit(io);
+    thread.join();
+
+    // 200 path re-extracted from the fresh body, replacing the stale seed.
+    const want_versions = try api_mod.extractVersions(testing.allocator, .formula, fixture);
+    defer testing.allocator.free(want_versions);
+    try testing.expectEqualStrings(want_versions, versions);
+
+    // The new ETag is now persisted for the next round's conditional GET.
+    const stored = (try readCacheFileAlloc(testing.allocator, dir.path, "formula.etag")).?;
+    defer testing.allocator.free(stored);
+    try testing.expectEqualStrings(new_etag, stored);
+}
+
+test "a first-ever fetch (no stored ETag) does an unconditional GET and stores the ETag" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const etag = "W/\"v1\"";
+    const fixture =
+        \\[{"name":"jq","versions":{"stable":"1.7"}}]
+    ;
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+    var srv = EtagServer{
+        .io = io,
+        .listener = &listener,
+        .body = fixture,
+        .etag = etag,
+        .count = std.atomic.Value(u32).init(0),
+        .conditional_count = std.atomic.Value(u32).init(0),
+    };
+    const thread = try std.Thread.spawn(.{}, EtagServer.serve, .{&srv});
+
+    var dir = try TempCacheDir.init("etag_cold_store");
+    defer dir.deinit();
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client_mod.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(io, testing.allocator, &http, dir.path);
+    var base_buf: [64]u8 = undefined;
+    api.base_url = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    const versions = try api.fetchVersionsIndex(.formula);
+    defer testing.allocator.free(versions);
+
+    listener.deinit(io);
+    thread.join();
+
+    const want_versions = try api_mod.extractVersions(testing.allocator, .formula, fixture);
+    defer testing.allocator.free(want_versions);
+    try testing.expectEqualStrings(want_versions, versions);
+    try testing.expectEqual(@as(u32, 1), srv.count.load(.monotonic));
+    // No stored ETag yet, so the GET went out unconditional.
+    try testing.expectEqual(@as(u32, 0), srv.conditional_count.load(.monotonic));
+
+    // Cold fetch stored the server's ETag so the next refresh can 304.
+    const stored = (try readCacheFileAlloc(testing.allocator, dir.path, "formula.etag")).?;
+    defer testing.allocator.free(stored);
+    try testing.expectEqualStrings(etag, stored);
+}
+
+test "a 200 without an ETag header clears a previously stored ETag" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const fixture =
+        \\[{"name":"wget","versions":{"stable":"1.21.4"}}]
+    ;
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+    var srv = EtagServer{
+        .io = io,
+        .listener = &listener,
+        .body = fixture,
+        .etag = null, // upstream stops advertising an ETag
+        .count = std.atomic.Value(u32).init(0),
+        .conditional_count = std.atomic.Value(u32).init(0),
+    };
+    const thread = try std.Thread.spawn(.{}, EtagServer.serve, .{&srv});
+
+    var dir = try TempCacheDir.init("etag_cleared");
+    defer dir.deinit();
+
+    try dir.writeCacheFile("versions_formula.txt", "stale\t0.0.0\t0\n");
+    try dir.writeCacheFile("names_formula.txt", "stale\n");
+    try dir.writeCacheFile("formula.etag", "W/\"gone\"");
+    try backdateIndex(dir.path, "versions_formula.txt");
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client_mod.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(io, testing.allocator, &http, dir.path);
+    var base_buf: [64]u8 = undefined;
+    api.base_url = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    const versions = try api.fetchVersionsIndex(.formula);
+    defer testing.allocator.free(versions);
+
+    listener.deinit(io);
+    thread.join();
+
+    // The stale token is gone, so the next refresh starts unconditional.
+    try testing.expect(try readCacheFileAlloc(testing.allocator, dir.path, "formula.etag") == null);
+}
+
+test "an implausibly large stored ETag is ignored and the GET goes out unconditional" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const new_etag = "W/\"sane\"";
+    const fixture =
+        \\[{"name":"jq","versions":{"stable":"1.7"}}]
+    ;
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+    var srv = EtagServer{
+        .io = io,
+        .listener = &listener,
+        .body = fixture,
+        .etag = new_etag,
+        .count = std.atomic.Value(u32).init(0),
+        .conditional_count = std.atomic.Value(u32).init(0),
+    };
+    const thread = try std.Thread.spawn(.{}, EtagServer.serve, .{&srv});
+
+    var dir = try TempCacheDir.init("etag_oversized");
+    defer dir.deinit();
+
+    // A corrupt, multi-KiB ETag must never ride out as If-None-Match.
+    const huge = "x" ** 4096;
+    try dir.writeCacheFile("versions_formula.txt", "stale\t0.0.0\t0\n");
+    try dir.writeCacheFile("formula.etag", huge);
+    try backdateIndex(dir.path, "versions_formula.txt");
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client_mod.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(io, testing.allocator, &http, dir.path);
+    var base_buf: [64]u8 = undefined;
+    api.base_url = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    const versions = try api.fetchVersionsIndex(.formula);
+    defer testing.allocator.free(versions);
+
+    listener.deinit(io);
+    thread.join();
+
+    // The bad token was dropped, so the request was unconditional...
+    try testing.expectEqual(@as(u32, 0), srv.conditional_count.load(.monotonic));
+    // ...and the freshly extracted bytes plus a sane ETag now replace it.
+    const want = try api_mod.extractVersions(testing.allocator, .formula, fixture);
+    defer testing.allocator.free(want);
+    try testing.expectEqualStrings(want, versions);
+    const stored = (try readCacheFileAlloc(testing.allocator, dir.path, "formula.etag")).?;
+    defer testing.allocator.free(stored);
+    try testing.expectEqualStrings(new_etag, stored);
+}
+
+test "a 304 with a missing side-car drops the ETag and surfaces ApiUnreachable" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const etag = "W/\"orphan\"";
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+    var srv = EtagServer{
+        .io = io,
+        .listener = &listener,
+        .body = "[]",
+        .etag = etag,
+        .count = std.atomic.Value(u32).init(0),
+        .conditional_count = std.atomic.Value(u32).init(0),
+    };
+    const thread = try std.Thread.spawn(.{}, EtagServer.serve, .{&srv});
+
+    var dir = try TempCacheDir.init("etag_orphan");
+    defer dir.deinit();
+
+    // ETag present but only one side-car on disk: the versions read-back
+    // after the 304 fails, so the cache is inconsistent.
+    try dir.writeCacheFile("names_formula.txt", "wget\n");
+    try dir.writeCacheFile("formula.etag", etag);
+    try backdateIndex(dir.path, "names_formula.txt");
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client_mod.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(io, testing.allocator, &http, dir.path);
+    var base_buf: [64]u8 = undefined;
+    api.base_url = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    try testing.expectError(api_mod.ApiError.ApiUnreachable, api.fetchVersionsIndex(.formula));
+
+    listener.deinit(io);
+    thread.join();
+
+    // The orphaned ETag is dropped so the next run re-downloads cleanly.
+    try testing.expect(try readCacheFileAlloc(testing.allocator, dir.path, "formula.etag") == null);
+}
+
+test "the conditional refresh is kind-agnostic: a cask 304 refreshes and keeps cask.etag" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const etag = "W/\"cask-unchanged\"";
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+    var srv = EtagServer{
+        .io = io,
+        .listener = &listener,
+        .body = "[]",
+        .etag = etag,
+        .count = std.atomic.Value(u32).init(0),
+        .conditional_count = std.atomic.Value(u32).init(0),
+    };
+    const thread = try std.Thread.spawn(.{}, EtagServer.serve, .{&srv});
+
+    var dir = try TempCacheDir.init("etag_304_cask");
+    defer dir.deinit();
+
+    const seeded = "firefox\t125.0\t0\n";
+    try dir.writeCacheFile("versions_cask.txt", seeded);
+    try dir.writeCacheFile("names_cask.txt", "firefox\n");
+    try dir.writeCacheFile("cask.etag", etag);
+    try backdateIndex(dir.path, "versions_cask.txt");
+    try backdateIndex(dir.path, "names_cask.txt");
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client_mod.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(io, testing.allocator, &http, dir.path);
+    var base_buf: [64]u8 = undefined;
+    api.base_url = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    const versions = try api.fetchVersionsIndex(.cask);
+    defer testing.allocator.free(versions);
+
+    listener.deinit(io);
+    thread.join();
+
+    // Same 304 short-circuit as formula, keyed on the cask sidecars.
+    try testing.expectEqualStrings(seeded, versions);
+    try testing.expectEqual(@as(u32, 1), srv.conditional_count.load(.monotonic));
+    const stored = (try readCacheFileAlloc(testing.allocator, dir.path, "cask.etag")).?;
+    defer testing.allocator.free(stored);
+    try testing.expectEqualStrings(etag, stored);
+}
+
+// Answers every request with a fixed non-2xx status — used to pin the
+// "neither 200 nor 304" mapping to ApiUnreachable.
+const StatusServer = struct {
+    io: std.Io,
+    listener: *net.Server,
+    status: std.http.Status,
+
+    fn serve(self: *StatusServer) void {
+        while (true) {
+            const stream = self.listener.accept(self.io) catch return;
+            defer stream.close(self.io);
+            var rbuf: [16 * 1024]u8 = undefined;
+            var wbuf: [16 * 1024]u8 = undefined;
+            var reader = stream.reader(self.io, &rbuf);
+            var writer = stream.writer(self.io, &wbuf);
+            var srv = std.http.Server.init(&reader.interface, &writer.interface);
+            var req = srv.receiveHead() catch return;
+            req.respond("", .{ .status = self.status }) catch return;
+        }
+    }
+};
+
+test "a refresh that is neither 200 nor 304 surfaces ApiUnreachable" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // 404 is non-transient, so getConditional returns it without retrying.
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+    var srv = StatusServer{ .io = io, .listener = &listener, .status = .not_found };
+    const thread = try std.Thread.spawn(.{}, StatusServer.serve, .{&srv});
+
+    var dir = try TempCacheDir.init("etag_bad_status");
+    defer dir.deinit();
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client_mod.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(io, testing.allocator, &http, dir.path);
+    var base_buf: [64]u8 = undefined;
+    api.base_url = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    try testing.expectError(api_mod.ApiError.ApiUnreachable, api.fetchVersionsIndex(.formula));
+
+    listener.deinit(io);
+    thread.join();
 }
 
 test "readNotFoundCache returns false for stale marker" {


### PR DESCRIPTION
## Description

A fresh `mt outdated` (CLI or TUI launch) no longer re-downloads the multi-MB Homebrew dump every five minutes. The bulk fetch backing the version map runs on a 5-minute TTL, but the dump itself changes only every few hours, so previously every "check again after a while" paid for a full ~4.9 MB transfer even when nothing upstream had moved.

## Related Issue

- None

## Notes for Reviewers

- None
