### PR TITLE
fix(dsl): stop FS builtins from writing through symlinks out of the keg

### DIFF
--- a/scripts/regressions/dsl-fs-builtins-follow-symlinks-arbitrary-write.sh
+++ b/scripts/regressions/dsl-fs-builtins-follow-symlinks-arbitrary-write.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Regression: an in-process DSL filesystem builtin must not write through a
+# keg-confined symlink to a file outside the keg.
+#
+# The bug: `sandbox.validatePath` only inspects the literal path string, while
+# the write-path builtins opened with `O_CREAT|O_WRONLY|O_TRUNC` and no
+# `O_NOFOLLOW`. A formula could plant `keg/pwn -> /outside/victim`, then write
+# `keg/pwn` — the literal check passed and the kernel followed the link,
+# truncating an arbitrary file as the user running malt.
+#
+# No CLI subcommand exposes a raw write builtin in isolation, so the guard is
+# exercised by a focused unit test that plants the symlink, calls the builtin,
+# and asserts both rejection and that the out-of-keg file is byte-for-byte
+# untouched. This script builds the colocated test binary and runs that test by
+# name; it exits non-zero if the guard regresses or the test goes missing.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s once the test binary is built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+FILTER="write refuses to follow a symlink out of the keg"
+
+# The guard lives in a colocated `test {}` block; if it is ever deleted the
+# name filter below would match nothing and silently pass. Fail loudly instead.
+if ! grep -Rqs -- "$FILTER" "$ROOT/src/core/dsl/builtins/pathname.zig"; then
+  echo "FAIL: the symlink-follow guard test is missing from pathname.zig" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+if [[ ! -x "$BIN" ]]; then
+  (cd "$ROOT" && zig build test-bin >/dev/null 2>&1) || {
+    echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+    exit 1
+  }
+fi
+
+# The runner has no per-test filter, so run the colocated suite and judge only
+# this guard's line: a pass ends in "OK", a regression prints the failure there.
+OUT=$("$BIN" 2>&1 || true)
+LINE=$(printf '%s\n' "$OUT" | grep -F -- "$FILTER" || true)
+if [[ -z "$LINE" ]]; then
+  echo "FAIL: the symlink-follow guard test did not run" >&2
+  exit 1
+fi
+if [[ "$LINE" != *OK ]]; then
+  echo "FAIL: a DSL write builtin followed a keg-confined symlink out of the keg" >&2
+  exit 1
+fi
+
+echo "PASS: keg-confined symlink not followed to an out-of-keg write"

--- a/src/core/dsl/builtins/fileutils.zig
+++ b/src/core/dsl/builtins/fileutils.zig
@@ -79,12 +79,15 @@ pub fn cp(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     switch (args[0]) {
         .array => |items| {
             std.Io.Dir.cwd().createDirPath(ctx.io, dst) catch {};
+            // dst is the directory we copy into; resolve it (it may be a planted
+            // symlink) before landing files in it. Entries replace a final-
+            // component symlink atomically, so they need no extra guard.
+            sandbox.validateDirTarget(ctx.io, dst, ctx.cellar_path, ctx.malt_prefix) catch
+                return BuiltinError.PathSandboxViolation;
             for (items) |item| {
                 const src = item.asString(ctx.allocator) catch continue;
                 const base = std.fs.path.basename(src);
                 const dest_path = std.fs.path.join(ctx.allocator, &.{ dst, base }) catch continue;
-                // dst itself may be a planted symlink; re-resolve per entry.
-                sandbox.validateWriteDir(ctx.io, dest_path, ctx.cellar_path, ctx.malt_prefix) catch continue;
                 std.Io.Dir.copyFileAbsolute(src, dest_path, ctx.io, .{}) catch {};
             }
         },
@@ -107,7 +110,7 @@ pub fn cpR(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     // Try as single file first
     std.Io.Dir.copyFileAbsolute(src, dst, ctx.io, .{}) catch {
         // Try as directory: walk and copy
-        copyDirRecursive(ctx.io, ctx.allocator, src, dst) catch {};
+        copyDirRecursive(ctx.io, ctx.allocator, src, dst, ctx.cellar_path, ctx.malt_prefix) catch {};
     };
     return Value{ .nil = {} };
 }
@@ -134,38 +137,41 @@ pub fn chmod(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
 
     switch (args[1]) {
         .array => |items| {
+            // Best-effort per entry: skip anything that escapes or follows a link.
             for (items) |item| {
                 const p = item.asString(ctx.allocator) catch continue;
-                sandbox.validatePath(p, ctx.cellar_path, ctx.malt_prefix) catch continue;
-                chmodPath(ctx.io, p, mode);
+                chmodNoFollow(ctx, p, mode) catch continue;
             }
         },
         else => {
             const path = args[1].asString(ctx.allocator) catch return Value{ .nil = {} };
-            sandbox.validatePath(path, ctx.cellar_path, ctx.malt_prefix) catch
-                return BuiltinError.PathSandboxViolation;
-            chmodPath(ctx.io, path, mode);
+            chmodNoFollow(ctx, path, mode) catch |e| switch (e) {
+                error.PathSandboxViolation => return BuiltinError.PathSandboxViolation,
+                else => {},
+            };
         },
     }
     return Value{ .nil = {} };
 }
 
-fn chmodPath(io: std.Io, path: []const u8, mode: std.posix.mode_t) void {
-    const file = std.Io.Dir.openFileAbsolute(io, path, .{ .mode = .read_only }) catch return;
-    defer file.close(io);
-    file.setPermissions(io, std.Io.File.Permissions.fromMode(mode)) catch {};
+/// chmod via an `O_NOFOLLOW` handle so a symlinked leaf chmods the link, not its
+/// (possibly out-of-keg) target. Opens read-only — `fchmod` only needs the fd.
+fn chmodNoFollow(ctx: ExecCtx, path: []const u8, mode: std.posix.mode_t) (sandbox.SandboxError || std.posix.OpenError)!void {
+    const file = try sandbox.openTargetNoFollow(ctx.io, path, ctx.cellar_path, ctx.malt_prefix, .{ .write = false });
+    defer file.close(ctx.io);
+    file.setPermissions(ctx.io, std.Io.File.Permissions.fromMode(mode)) catch {};
 }
 
 /// touch — create file or update timestamp
 pub fn touch(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     if (args.len == 0) return Value{ .nil = {} };
     const path = try args[0].asString(ctx.allocator);
-    sandbox.validatePath(path, ctx.cellar_path, ctx.malt_prefix) catch
-        return BuiltinError.PathSandboxViolation;
 
-    // Try to open existing file, or create
-    const file = std.Io.Dir.createFileAbsolute(ctx.io, path, .{ .truncate = false }) catch {
-        return Value{ .nil = {} };
+    // Create (no truncate) through an O_NOFOLLOW handle: a symlinked leaf must
+    // not let touch create/clobber a file outside the keg.
+    const file = sandbox.openTargetNoFollow(ctx.io, path, ctx.cellar_path, ctx.malt_prefix, .{ .create = true }) catch |e| switch (e) {
+        error.PathSandboxViolation => return BuiltinError.PathSandboxViolation,
+        else => return Value{ .nil = {} },
     };
     file.close(ctx.io);
     return Value{ .nil = {} };
@@ -263,8 +269,183 @@ test "cp refuses to copy through an intermediate-directory symlink out of the ke
     try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, escaped, .{}));
 }
 
-fn copyDirRecursive(io: std.Io, allocator: std.mem.Allocator, src: []const u8, dst: []const u8) !void {
+test "touch refuses to create through a symlink out of the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const target = try std.fs.path.join(alloc, &.{ base, "outside" }); // out of keg, never created
+    defer alloc.free(target);
+    const link = try std.fs.path.join(alloc, &.{ keg, "pwn" }); // keg/pwn -> base/outside
+    defer alloc.free(link);
+
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    try std.Io.Dir.symLinkAbsolute(io, target, link, .{});
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        touch(ctx, null, &.{Value{ .string = link }}),
+    );
+    // The link's out-of-keg target was not created behind it.
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, target, .{}));
+}
+
+test "chmod refuses to follow a symlink out of the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const victim = try std.fs.path.join(alloc, &.{ base, "victim" });
+    defer alloc.free(victim);
+    const link = try std.fs.path.join(alloc, &.{ keg, "pwn" });
+    defer alloc.free(link);
+
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    {
+        const vf = try std.Io.Dir.createFileAbsolute(io, victim, .{});
+        defer vf.close(io);
+    }
+    try std.Io.Dir.symLinkAbsolute(io, victim, link, .{});
+    // Snapshot the victim's mode so we can prove it was untouched.
+    const before = (try std.Io.Dir.cwd().statFile(io, victim, .{})).permissions.toMode();
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        chmod(ctx, null, &.{ Value{ .int = 0o777 }, Value{ .string = link } }),
+    );
+    const after = (try std.Io.Dir.cwd().statFile(io, victim, .{})).permissions.toMode();
+    try std.testing.expectEqual(before, after);
+}
+
+test "cp_r refuses a symlink planted deep in the dest subtree" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const outside = try std.fs.path.join(alloc, &.{ base, "outside" });
+    defer alloc.free(outside);
+
+    // Source tree: src/sub/file.txt
+    const src = try std.fs.path.join(alloc, &.{ keg, "src" });
+    defer alloc.free(src);
+    const src_file = try std.fs.path.join(alloc, &.{ keg, "src", "sub", "file.txt" });
+    defer alloc.free(src_file);
+    try std.Io.Dir.cwd().createDirPath(io, std.fs.path.dirname(src_file).?);
+    {
+        const sf = try std.Io.Dir.createFileAbsolute(io, src_file, .{});
+        defer sf.close(io);
+        try sf.writeStreamingAll(io, "secret");
+    }
+
+    // Dest tree with a planted symlink at dst/sub -> outside.
+    const dst = try std.fs.path.join(alloc, &.{ keg, "dst" });
+    defer alloc.free(dst);
+    const dst_sub = try std.fs.path.join(alloc, &.{ keg, "dst", "sub" });
+    defer alloc.free(dst_sub);
+    const escaped = try std.fs.path.join(alloc, &.{ outside, "file.txt" });
+    defer alloc.free(escaped);
+    try std.Io.Dir.cwd().createDirPath(io, dst);
+    try std.Io.Dir.cwd().createDirPath(io, outside);
+    try std.Io.Dir.symLinkAbsolute(io, outside, dst_sub, .{}); // dst/sub -> outside
+
+    // cp_r joins child paths on ctx.allocator (the per-formula arena in prod);
+    // give it an arena here so the recursion's scratch paths are reclaimed.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ctx: ExecCtx = .{ .allocator = arena.allocator(), .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    // cp_r swallows per-entry failures; the contract is that nothing escapes.
+    _ = try cpR(ctx, null, &.{ Value{ .string = src }, Value{ .string = dst } });
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, escaped, .{}));
+}
+
+test "cp copies a regular file within the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const keg = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const src = try std.fs.path.join(alloc, &.{ keg, "src.txt" });
+    defer alloc.free(src);
+    const dst = try std.fs.path.join(alloc, &.{ keg, "dst.txt" });
+    defer alloc.free(dst);
+    {
+        const sf = try std.Io.Dir.createFileAbsolute(io, src, .{});
+        defer sf.close(io);
+        try sf.writeStreamingAll(io, "hi");
+    }
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    _ = try cp(ctx, null, &.{ Value{ .string = src }, Value{ .string = dst } });
+
+    var rb: [8]u8 = undefined;
+    const df = try std.Io.Dir.openFileAbsolute(io, dst, .{});
+    defer df.close(io);
+    try std.testing.expectEqualStrings("hi", rb[0..try df.readPositionalAll(io, &rb, 0)]);
+}
+
+test "touch creates a regular file in the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const keg = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const target = try std.fs.path.join(alloc, &.{ keg, "stamp" });
+    defer alloc.free(target);
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    _ = try touch(ctx, null, &.{Value{ .string = target }});
+    try std.Io.Dir.cwd().access(io, target, .{}); // exists now
+}
+
+test "chmod changes the mode of a regular keg file" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const keg = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const file = try std.fs.path.join(alloc, &.{ keg, "script" });
+    defer alloc.free(file);
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, file, .{});
+        f.close(io);
+    }
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    _ = try chmod(ctx, null, &.{ Value{ .int = 0o755 }, Value{ .string = file } });
+
+    const got = (try std.Io.Dir.cwd().statFile(io, file, .{})).permissions.toMode();
+    try std.testing.expectEqual(@as(std.posix.mode_t, 0o755), got & 0o777);
+}
+
+fn copyDirRecursive(io: std.Io, allocator: std.mem.Allocator, src: []const u8, dst: []const u8, cellar_path: []const u8, malt_prefix: []const u8) !void {
     std.Io.Dir.cwd().createDirPath(io, dst) catch {};
+    // Per level: refuse to descend if dst resolves out of the keg, so a symlink
+    // planted anywhere in the dest subtree can't redirect the copy. Files land
+    // directly in dst (validated here) and replace any leaf symlink atomically.
+    sandbox.validateDirTarget(io, dst, cellar_path, malt_prefix) catch return;
 
     var dir = std.Io.Dir.openDirAbsolute(io, src, .{ .iterate = true }) catch return;
     defer dir.close(io);
@@ -275,7 +456,7 @@ fn copyDirRecursive(io: std.Io, allocator: std.mem.Allocator, src: []const u8, d
         const dst_child = std.fs.path.join(allocator, &.{ dst, entry.name }) catch continue;
 
         if (entry.kind == .directory) {
-            try copyDirRecursive(io, allocator, src_child, dst_child);
+            try copyDirRecursive(io, allocator, src_child, dst_child, cellar_path, malt_prefix);
         } else {
             std.Io.Dir.copyFileAbsolute(src_child, dst_child, io, .{}) catch {};
         }

--- a/src/core/dsl/builtins/fileutils.zig
+++ b/src/core/dsl/builtins/fileutils.zig
@@ -70,7 +70,9 @@ pub fn mkdirP(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
 pub fn cp(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     if (args.len < 2) return Value{ .nil = {} };
     const dst = try args[1].asString(ctx.allocator);
-    sandbox.validatePath(dst, ctx.cellar_path, ctx.malt_prefix) catch
+    // Resolve the dest's parent so an intermediate-directory symlink can't pull
+    // the copy out of the keg; the final component is replaced atomically.
+    sandbox.validateWriteDir(ctx.io, dst, ctx.cellar_path, ctx.malt_prefix) catch
         return BuiltinError.PathSandboxViolation;
 
     // If first arg is an array, copy each file into dst directory
@@ -81,6 +83,8 @@ pub fn cp(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
                 const src = item.asString(ctx.allocator) catch continue;
                 const base = std.fs.path.basename(src);
                 const dest_path = std.fs.path.join(ctx.allocator, &.{ dst, base }) catch continue;
+                // dst itself may be a planted symlink; re-resolve per entry.
+                sandbox.validateWriteDir(ctx.io, dest_path, ctx.cellar_path, ctx.malt_prefix) catch continue;
                 std.Io.Dir.copyFileAbsolute(src, dest_path, ctx.io, .{}) catch {};
             }
         },
@@ -97,7 +101,7 @@ pub fn cpR(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     if (args.len < 2) return Value{ .nil = {} };
     const src = try args[0].asString(ctx.allocator);
     const dst = try args[1].asString(ctx.allocator);
-    sandbox.validatePath(dst, ctx.cellar_path, ctx.malt_prefix) catch
+    sandbox.validateWriteDir(ctx.io, dst, ctx.cellar_path, ctx.malt_prefix) catch
         return BuiltinError.PathSandboxViolation;
 
     // Try as single file first
@@ -217,6 +221,46 @@ pub fn lnSf(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
         },
     }
     return Value{ .nil = {} };
+}
+
+test "cp refuses to copy through an intermediate-directory symlink out of the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const outside = try std.fs.path.join(alloc, &.{ base, "outside" });
+    defer alloc.free(outside);
+    const dirlink = try std.fs.path.join(alloc, &.{ keg, "d" });
+    defer alloc.free(dirlink);
+    const src = try std.fs.path.join(alloc, &.{ keg, "src.txt" });
+    defer alloc.free(src);
+    const dst = try std.fs.path.join(alloc, &.{ dirlink, "x" }); // keg/d/x, d -> outside
+    defer alloc.free(dst);
+    const escaped = try std.fs.path.join(alloc, &.{ outside, "x" });
+    defer alloc.free(escaped);
+
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    try std.Io.Dir.cwd().createDirPath(io, outside);
+    {
+        const sf = try std.Io.Dir.createFileAbsolute(io, src, .{});
+        defer sf.close(io);
+        try sf.writeStreamingAll(io, "data");
+    }
+    try std.Io.Dir.symLinkAbsolute(io, outside, dirlink, .{});
+
+    // keg is the only writable boundary, so base/outside is genuinely out of bounds.
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        cp(ctx, null, &.{ Value{ .string = src }, Value{ .string = dst } }),
+    );
+    // Nothing landed outside the keg.
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, escaped, .{}));
 }
 
 fn copyDirRecursive(io: std.Io, allocator: std.mem.Allocator, src: []const u8, dst: []const u8) !void {

--- a/src/core/dsl/builtins/inreplace.zig
+++ b/src/core/dsl/builtins/inreplace.zig
@@ -121,7 +121,7 @@ fn formatAtomicWriteFailureMessage(buf: []u8, kind: AtomicWriteError, underlying
 /// Fallback: direct overwrite (no atomicity guarantee). Still refuses to follow
 /// a symlink out of the keg — a best-effort fallback must not become an escape.
 fn writeDirectly(ctx: ExecCtx, path: []const u8, content: []const u8) void {
-    const out = sandbox.openWriteTargetNoFollow(ctx.io, path, ctx.cellar_path, ctx.malt_prefix) catch return;
+    const out = sandbox.openTargetNoFollow(ctx.io, path, ctx.cellar_path, ctx.malt_prefix, .{ .create = true, .truncate = true }) catch return;
     defer out.close(ctx.io);
     // Fallback path already logged a warning; no error channel left to surface.
     out.writeStreamingAll(ctx.io, content) catch {};

--- a/src/core/dsl/builtins/inreplace.zig
+++ b/src/core/dsl/builtins/inreplace.zig
@@ -32,8 +32,9 @@ pub fn inreplace(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Valu
     const from = try args[1].asString(ctx.allocator);
     const to = try args[2].asString(ctx.allocator);
 
-    // Sandbox validation — inreplace is a mutating operation
-    sandbox.validatePath(path, ctx.cellar_path, ctx.malt_prefix) catch
+    // Sandbox validation — inreplace is a mutating operation. The parent-dir
+    // resolve also blocks an intermediate-directory symlink escape.
+    sandbox.validateWriteDir(ctx.io, path, ctx.cellar_path, ctx.malt_prefix) catch
         return BuiltinError.PathSandboxViolation;
 
     // Read file contents
@@ -59,7 +60,7 @@ pub fn inreplace(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Valu
         // Record the warning; the post_install caller renders notes. Keeps
         // this builtin free of ui/output.
         if (ctx.fallback_log) |flog| flog.note(msg);
-        writeDirectly(ctx.io, path, new_content);
+        writeDirectly(ctx, path, new_content);
     };
 
     return Value{ .nil = {} };
@@ -117,12 +118,13 @@ fn formatAtomicWriteFailureMessage(buf: []u8, kind: AtomicWriteError, underlying
     );
 }
 
-/// Fallback: direct overwrite (no atomicity guarantee).
-fn writeDirectly(io: std.Io, path: []const u8, content: []const u8) void {
-    const out = std.Io.Dir.createFileAbsolute(io, path, .{ .truncate = true }) catch return;
-    defer out.close(io);
+/// Fallback: direct overwrite (no atomicity guarantee). Still refuses to follow
+/// a symlink out of the keg — a best-effort fallback must not become an escape.
+fn writeDirectly(ctx: ExecCtx, path: []const u8, content: []const u8) void {
+    const out = sandbox.openWriteTargetNoFollow(ctx.io, path, ctx.cellar_path, ctx.malt_prefix) catch return;
+    defer out.close(ctx.io);
     // Fallback path already logged a warning; no error channel left to surface.
-    out.writeStreamingAll(io, content) catch {};
+    out.writeStreamingAll(ctx.io, content) catch {};
 }
 
 /// Read the entire contents of an absolute file path into a caller-owned slice.

--- a/src/core/dsl/builtins/pathname.zig
+++ b/src/core/dsl/builtins/pathname.zig
@@ -86,7 +86,7 @@ pub fn write(ctx: ExecCtx, receiver: ?Value, args: []const Value) BuiltinError!V
 
     // O_NOFOLLOW + parent-dir resolve: a keg-confined path must not write
     // through a symlink to a target outside the keg.
-    const file = sandbox.openWriteTargetNoFollow(ctx.io, path, ctx.cellar_path, ctx.malt_prefix) catch |e| switch (e) {
+    const file = sandbox.openTargetNoFollow(ctx.io, path, ctx.cellar_path, ctx.malt_prefix, .{ .create = true, .truncate = true }) catch |e| switch (e) {
         error.PathSandboxViolation => return BuiltinError.PathSandboxViolation,
         else => return Value{ .nil = {} },
     };

--- a/src/core/dsl/builtins/pathname.zig
+++ b/src/core/dsl/builtins/pathname.zig
@@ -81,13 +81,14 @@ pub fn symlinkQ(ctx: ExecCtx, receiver: ?Value, _: []const Value) BuiltinError!V
 pub fn write(ctx: ExecCtx, receiver: ?Value, args: []const Value) BuiltinError!Value {
     const path = try receiverPath(ctx.allocator, receiver);
     if (path.len == 0) return Value{ .nil = {} };
-    sandbox.validatePath(path, ctx.cellar_path, ctx.malt_prefix) catch
-        return BuiltinError.PathSandboxViolation;
 
     const content = if (args.len > 0) try args[0].asString(ctx.allocator) else "";
 
-    const file = std.Io.Dir.createFileAbsolute(ctx.io, path, .{}) catch {
-        return Value{ .nil = {} };
+    // O_NOFOLLOW + parent-dir resolve: a keg-confined path must not write
+    // through a symlink to a target outside the keg.
+    const file = sandbox.openWriteTargetNoFollow(ctx.io, path, ctx.cellar_path, ctx.malt_prefix) catch |e| switch (e) {
+        error.PathSandboxViolation => return BuiltinError.PathSandboxViolation,
+        else => return Value{ .nil = {} },
     };
     defer file.close(ctx.io);
     file.writeStreamingAll(ctx.io, content) catch {};
@@ -438,4 +439,51 @@ test "pkgetc keeps an @-versioned formula name intact" {
     const etc = try pkgetc(ctx, Value{ .pathname = "/opt/malt/opt/openssl@3" }, &.{});
     defer std.testing.allocator.free(etc.pathname);
     try std.testing.expectEqualStrings("/opt/malt/etc/openssl@3", etc.pathname);
+}
+
+test "write refuses to follow a symlink out of the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var base_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const base = base_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &base_buf)];
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "Cellar", "foo", "1.0" });
+    defer alloc.free(keg);
+    const victim = try std.fs.path.join(alloc, &.{ base, "victim" });
+    defer alloc.free(victim);
+    const link = try std.fs.path.join(alloc, &.{ keg, "pwn" });
+    defer alloc.free(link);
+
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    {
+        const vf = try std.Io.Dir.createFileAbsolute(io, victim, .{});
+        defer vf.close(io);
+        try vf.writeStreamingAll(io, "PRECIOUS");
+    }
+    // keg/pwn -> outside victim: a keg-confined link name pointing out of the keg.
+    try std.Io.Dir.symLinkAbsolute(io, victim, link, .{});
+
+    const ctx: ExecCtx = .{
+        .allocator = alloc,
+        .io = io,
+        .environ = undefined,
+        .cellar_path = keg,
+        .malt_prefix = base,
+    };
+
+    // Writing through the link must be refused, not followed.
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        write(ctx, Value{ .pathname = link }, &.{Value{ .string = "owned" }}),
+    );
+
+    // And the out-of-keg target must be byte-for-byte untouched.
+    var rb: [32]u8 = undefined;
+    const vf = try std.Io.Dir.openFileAbsolute(io, victim, .{});
+    defer vf.close(io);
+    const n = try vf.readPositionalAll(io, &rb, 0);
+    try std.testing.expectEqualStrings("PRECIOUS", rb[0..n]);
 }

--- a/src/core/dsl/sandbox.zig
+++ b/src/core/dsl/sandbox.zig
@@ -120,26 +120,26 @@ fn realPathOr(io: std.Io, path: []const u8, buf: []u8, fallback: []const u8) []c
     return buf[0..n];
 }
 
-/// Validate a create/copy write target: the literal `validatePath` checks plus a
-/// resolved-boundary check on the nearest existing ancestor *directory*. This
-/// closes the intermediate-directory symlink escape (`ln_s "/etc", keg/d` then a
-/// write under `keg/d/...`). A final-component symlink is deliberately left to
-/// the open — an atomic copy replaces it, and `openWriteTargetNoFollow` refuses
-/// it via `O_NOFOLLOW`. A target whose parents don't exist yet can't escape (the
-/// open just fails), so a resolve miss up to the root is allowed.
-pub fn validateWriteDir(
+/// Resolve the nearest existing directory at or above `start` and require it to
+/// stay within the *resolved* keg/prefix. `start == null` (root reached) or a
+/// fully unresolvable chain means nothing exists yet to escape through, so it
+/// passes — the subsequent open/copy simply fails if the path is unusable.
+fn resolvedDirWithinBoundary(
     io: std.Io,
-    target_path: []const u8,
+    start: ?[]const u8,
     cellar_path: []const u8,
     malt_prefix: []const u8,
 ) SandboxError!void {
-    try validatePath(target_path, cellar_path, malt_prefix);
-
     var buf: [std.fs.max_path_bytes]u8 = undefined;
-    var probe: []const u8 = target_path;
-    const dir_real = while (std.fs.path.dirname(probe)) |parent| {
-        const n = std.Io.Dir.cwd().realPathFile(io, parent, &buf) catch {
-            probe = parent;
+    var probe: ?[]const u8 = start;
+    const dir_real = while (probe) |p| {
+        // Stop once the walk leaves the literal keg/prefix: nothing inside the
+        // boundary exists yet, so there is no symlink there to redirect us, and
+        // an existing ancestor *above* the boundary (e.g. `/opt`) is not ours to
+        // judge. `validatePath` already confirmed the target itself is in bounds.
+        if (!pathHasPrefix(p, cellar_path) and !pathHasPrefix(p, malt_prefix)) return;
+        const n = std.Io.Dir.cwd().realPathFile(io, p, &buf) catch {
+            probe = std.fs.path.dirname(p);
             continue;
         };
         break buf[0..n];
@@ -157,26 +157,68 @@ pub fn validateWriteDir(
     return SandboxError.PathSandboxViolation;
 }
 
-/// Open a create/truncate write target without following a final-component
-/// symlink, after `validateWriteDir` confirms the containing directory stays in
-/// the keg/prefix. `O_NOFOLLOW` makes the refusal atomic at the kernel (no
-/// lstat→open race); both an out-of-keg directory and a symlinked leaf map to
-/// `PathSandboxViolation`. Other open failures surface as `OpenError` so callers
-/// keep their swallow-on-IO contract.
-pub fn openWriteTargetNoFollow(
+/// Validate a write target whose final component is a *file*: the literal
+/// `validatePath` checks plus a resolved-boundary check on its parent directory.
+/// This closes the intermediate-directory symlink escape (`ln_s "/etc", keg/d`
+/// then a write under `keg/d/...`). The final component itself is left to the
+/// open — an atomic copy replaces it, and `openTargetNoFollow` refuses it via
+/// `O_NOFOLLOW` — so a legitimate in-keg symlink leaf is not falsely rejected
+/// here.
+pub fn validateWriteDir(
     io: std.Io,
     target_path: []const u8,
     cellar_path: []const u8,
     malt_prefix: []const u8,
+) SandboxError!void {
+    try validatePath(target_path, cellar_path, malt_prefix);
+    try resolvedDirWithinBoundary(io, std.fs.path.dirname(target_path), cellar_path, malt_prefix);
+}
+
+/// Validate a *directory* that will be written into (cp / cp_r dest). Unlike
+/// `validateWriteDir`, the directory itself is resolved: when copying into `D`, a
+/// symlinked `D` pointing out of the keg is the escape, not a safe replace
+/// target. Used per recursion level so a planted symlink anywhere in the dest
+/// subtree is caught.
+pub fn validateDirTarget(
+    io: std.Io,
+    dir_path: []const u8,
+    cellar_path: []const u8,
+    malt_prefix: []const u8,
+) SandboxError!void {
+    try validatePath(dir_path, cellar_path, malt_prefix);
+    try resolvedDirWithinBoundary(io, dir_path, cellar_path, malt_prefix);
+}
+
+/// How `openTargetNoFollow` opens the leaf. `write` toggles WRONLY vs RDONLY
+/// (chmod only needs a handle to `fchmod`); `create`/`truncate` map to
+/// `O_CREAT`/`O_TRUNC`.
+pub const OpenIntent = struct {
+    write: bool = true,
+    create: bool = false,
+    truncate: bool = false,
+};
+
+/// Open `target_path` without following a final-component symlink, after
+/// `validateWriteDir` confirms the containing directory stays in the keg/prefix.
+/// `O_NOFOLLOW` makes the refusal atomic at the kernel (no lstat→open race);
+/// both an out-of-keg directory and a symlinked leaf map to
+/// `PathSandboxViolation`. Other open failures surface as `OpenError` so callers
+/// keep their swallow-on-IO contract.
+pub fn openTargetNoFollow(
+    io: std.Io,
+    target_path: []const u8,
+    cellar_path: []const u8,
+    malt_prefix: []const u8,
+    intent: OpenIntent,
 ) (SandboxError || std.posix.OpenError)!std.Io.File {
     try validateWriteDir(io, target_path, cellar_path, malt_prefix);
     const fd = std.posix.openat(std.posix.AT.FDCWD, target_path, .{
-        .ACCMODE = .WRONLY,
-        .CREAT = true,
-        .TRUNC = true,
+        .ACCMODE = if (intent.write) .WRONLY else .RDONLY,
+        .CREAT = intent.create,
+        .TRUNC = intent.truncate,
         .CLOEXEC = true,
         .NOFOLLOW = true,
-    }, 0o644) catch |e| switch (e) {
+    }, 0o666) catch |e| switch (e) { // 0o666 & umask, matching the prior createFileAbsolute default
         // O_NOFOLLOW yields ELOOP (SymLinkLoop) when the leaf is a symlink.
         error.SymLinkLoop => return SandboxError.PathSandboxViolation,
         else => return e,
@@ -258,7 +300,7 @@ test "fenceArgv maps a profile allocation failure to OutOfMemory" {
     );
 }
 
-test "openWriteTargetNoFollow writes a normal in-keg file" {
+test "openTargetNoFollow writes a normal in-keg file" {
     const io = std.Options.debug_io;
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -271,7 +313,7 @@ test "openWriteTargetNoFollow writes a normal in-keg file" {
     const target = try std.fs.path.join(alloc, &.{ keg, "out.txt" });
     defer alloc.free(target);
 
-    const f = try openWriteTargetNoFollow(io, target, keg, keg);
+    const f = try openTargetNoFollow(io, target, keg, keg, .{ .create = true, .truncate = true });
     {
         defer f.close(io);
         try f.writeStreamingAll(io, "ok");
@@ -282,7 +324,7 @@ test "openWriteTargetNoFollow writes a normal in-keg file" {
     try std.testing.expectEqualStrings("ok", rb[0..try rf.readPositionalAll(io, &rb, 0)]);
 }
 
-test "openWriteTargetNoFollow refuses a final-component symlink out of the keg" {
+test "openTargetNoFollow refuses a final-component symlink out of the keg" {
     const io = std.Options.debug_io;
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -307,13 +349,43 @@ test "openWriteTargetNoFollow refuses a final-component symlink out of the keg" 
 
     try std.testing.expectError(
         SandboxError.PathSandboxViolation,
-        openWriteTargetNoFollow(io, link, keg, base),
+        openTargetNoFollow(io, link, keg, base, .{ .create = true, .truncate = true }),
     );
 
     var rb: [16]u8 = undefined;
     const vf = try std.Io.Dir.openFileAbsolute(io, victim, .{});
     defer vf.close(io);
     try std.testing.expectEqualStrings("PRECIOUS", rb[0..try vf.readPositionalAll(io, &rb, 0)]);
+}
+
+test "validateDirTarget accepts a real in-keg dir and rejects a symlinked one" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const realdir = try std.fs.path.join(alloc, &.{ keg, "real" });
+    defer alloc.free(realdir);
+    const outside = try std.fs.path.join(alloc, &.{ base, "outside" });
+    defer alloc.free(outside);
+    const dirlink = try std.fs.path.join(alloc, &.{ keg, "d" });
+    defer alloc.free(dirlink);
+
+    try std.Io.Dir.cwd().createDirPath(io, realdir);
+    try std.Io.Dir.cwd().createDirPath(io, outside);
+    try std.Io.Dir.symLinkAbsolute(io, outside, dirlink, .{});
+
+    // A genuine directory inside the keg is fine to write into.
+    try validateDirTarget(io, realdir, keg, keg);
+    // A directory that is itself a symlink out of the keg is not.
+    try std.testing.expectError(
+        SandboxError.PathSandboxViolation,
+        validateDirTarget(io, dirlink, keg, keg),
+    );
 }
 
 fn containsDotDot(path: []const u8) bool {

--- a/src/core/dsl/sandbox.zig
+++ b/src/core/dsl/sandbox.zig
@@ -111,32 +111,77 @@ pub fn fenceArgv(
     return wrapped;
 }
 
-/// Resolve a path to its canonical form (resolving symlinks)
-/// and then validate it.
-pub fn validateResolved(
+/// Resolve `path` to its canonical form, or return `fallback` when it can't be
+/// resolved (e.g. it doesn't exist). Used to compare against the *resolved*
+/// keg/prefix so a legitimately symlinked root (macOS `/tmp` → `/private/tmp`)
+/// is not mistaken for an escape.
+fn realPathOr(io: std.Io, path: []const u8, buf: []u8, fallback: []const u8) []const u8 {
+    const n = std.Io.Dir.cwd().realPathFile(io, path, buf) catch return fallback;
+    return buf[0..n];
+}
+
+/// Validate a create/copy write target: the literal `validatePath` checks plus a
+/// resolved-boundary check on the nearest existing ancestor *directory*. This
+/// closes the intermediate-directory symlink escape (`ln_s "/etc", keg/d` then a
+/// write under `keg/d/...`). A final-component symlink is deliberately left to
+/// the open — an atomic copy replaces it, and `openWriteTargetNoFollow` refuses
+/// it via `O_NOFOLLOW`. A target whose parents don't exist yet can't escape (the
+/// open just fails), so a resolve miss up to the root is allowed.
+pub fn validateWriteDir(
     io: std.Io,
     target_path: []const u8,
     cellar_path: []const u8,
     malt_prefix: []const u8,
 ) SandboxError!void {
-    // First validate the literal path
     try validatePath(target_path, cellar_path, malt_prefix);
 
-    // Try to resolve symlinks. If the path doesn't exist yet,
-    // that's fine — just validate the literal path.
     var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const n = std.Io.Dir.cwd().realPathFile(io, target_path, &buf) catch {
-        return; // Path doesn't exist yet — literal validation passed
-    };
-    const resolved = buf[0..n];
+    var probe: []const u8 = target_path;
+    const dir_real = while (std.fs.path.dirname(probe)) |parent| {
+        const n = std.Io.Dir.cwd().realPathFile(io, parent, &buf) catch {
+            probe = parent;
+            continue;
+        };
+        break buf[0..n];
+    } else return;
 
-    // Re-validate the resolved path with the same boundary rules.
-    if (containsDotDot(resolved)) return SandboxError.PathSandboxViolation;
-    if (!pathHasPrefix(resolved, cellar_path) and
-        !pathHasPrefix(resolved, malt_prefix))
-    {
-        return SandboxError.PathSandboxViolation;
-    }
+    if (containsDotDot(dir_real)) return SandboxError.PathSandboxViolation;
+
+    var cbuf: [std.fs.max_path_bytes]u8 = undefined;
+    var xbuf: [std.fs.max_path_bytes]u8 = undefined;
+    const cellar_real = realPathOr(io, cellar_path, &cbuf, cellar_path);
+    const prefix_real = realPathOr(io, malt_prefix, &xbuf, malt_prefix);
+
+    if (pathHasPrefix(dir_real, cellar_real)) return;
+    if (pathHasPrefix(dir_real, prefix_real)) return;
+    return SandboxError.PathSandboxViolation;
+}
+
+/// Open a create/truncate write target without following a final-component
+/// symlink, after `validateWriteDir` confirms the containing directory stays in
+/// the keg/prefix. `O_NOFOLLOW` makes the refusal atomic at the kernel (no
+/// lstat→open race); both an out-of-keg directory and a symlinked leaf map to
+/// `PathSandboxViolation`. Other open failures surface as `OpenError` so callers
+/// keep their swallow-on-IO contract.
+pub fn openWriteTargetNoFollow(
+    io: std.Io,
+    target_path: []const u8,
+    cellar_path: []const u8,
+    malt_prefix: []const u8,
+) (SandboxError || std.posix.OpenError)!std.Io.File {
+    try validateWriteDir(io, target_path, cellar_path, malt_prefix);
+    const fd = std.posix.openat(std.posix.AT.FDCWD, target_path, .{
+        .ACCMODE = .WRONLY,
+        .CREAT = true,
+        .TRUNC = true,
+        .CLOEXEC = true,
+        .NOFOLLOW = true,
+    }, 0o644) catch |e| switch (e) {
+        // O_NOFOLLOW yields ELOOP (SymLinkLoop) when the leaf is a symlink.
+        error.SymLinkLoop => return SandboxError.PathSandboxViolation,
+        else => return e,
+    };
+    return .{ .handle = fd, .flags = .{ .nonblocking = false } };
 }
 
 test "validateArgv accepts bare command names" {
@@ -211,6 +256,64 @@ test "fenceArgv maps a profile allocation failure to OutOfMemory" {
         FenceError.OutOfMemory,
         fenceArgv(std.testing.failing_allocator, &.{"make"}, "/opt/malt/Cellar/foo/1.0", "/opt/malt"),
     );
+}
+
+test "openWriteTargetNoFollow writes a normal in-keg file" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    // Resolved root exercises the /tmp → /private/tmp case: a symlinked prefix
+    // must not read as an escape.
+    const keg = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const target = try std.fs.path.join(alloc, &.{ keg, "out.txt" });
+    defer alloc.free(target);
+
+    const f = try openWriteTargetNoFollow(io, target, keg, keg);
+    {
+        defer f.close(io);
+        try f.writeStreamingAll(io, "ok");
+    }
+    var rb: [8]u8 = undefined;
+    const rf = try std.Io.Dir.openFileAbsolute(io, target, .{});
+    defer rf.close(io);
+    try std.testing.expectEqualStrings("ok", rb[0..try rf.readPositionalAll(io, &rb, 0)]);
+}
+
+test "openWriteTargetNoFollow refuses a final-component symlink out of the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const victim = try std.fs.path.join(alloc, &.{ base, "victim" });
+    defer alloc.free(victim);
+    const link = try std.fs.path.join(alloc, &.{ keg, "pwn" });
+    defer alloc.free(link);
+
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    {
+        const vf = try std.Io.Dir.createFileAbsolute(io, victim, .{});
+        defer vf.close(io);
+        try vf.writeStreamingAll(io, "PRECIOUS");
+    }
+    try std.Io.Dir.symLinkAbsolute(io, victim, link, .{});
+
+    try std.testing.expectError(
+        SandboxError.PathSandboxViolation,
+        openWriteTargetNoFollow(io, link, keg, base),
+    );
+
+    var rb: [16]u8 = undefined;
+    const vf = try std.Io.Dir.openFileAbsolute(io, victim, .{});
+    defer vf.close(io);
+    try std.testing.expectEqualStrings("PRECIOUS", rb[0..try vf.readPositionalAll(io, &rb, 0)]);
 }
 
 fn containsDotDot(path: []const u8) bool {

--- a/tests/dsl_sandbox_test.zig
+++ b/tests/dsl_sandbox_test.zig
@@ -164,6 +164,24 @@ test "sandbox: validateWriteDir rejects outside prefix" {
     try testing.expectError(SandboxError.PathSandboxViolation, result);
 }
 
+test "sandbox: validateWriteDir is lenient when the whole prefix subtree is absent" {
+    // Regression: when no part of the keg/prefix exists on disk, the resolve
+    // walk must stop at the boundary and pass — not climb to an existing
+    // ancestor (the tmp root, `/opt`, …) and reject. This is environment-
+    // independent: the prefix dir below deliberately does not exist.
+    const io = std.Options.debug_io;
+    const tmp = std.testing.tmpDir(.{});
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const base = buf[0..try std.Io.Dir.realPath(tmp.dir, io, &buf)];
+
+    const absent_prefix = try std.fs.path.join(testing.allocator, &.{ base, "no_such_prefix" });
+    defer testing.allocator.free(absent_prefix);
+    const target = try std.fs.path.join(testing.allocator, &.{ absent_prefix, "bin", "mybin" });
+    defer testing.allocator.free(target);
+
+    try sandbox.validateWriteDir(io, target, absent_prefix, absent_prefix);
+}
+
 // ---------------------------------------------------------------------------
 // Extended sandbox tests
 // ---------------------------------------------------------------------------

--- a/tests/dsl_sandbox_test.zig
+++ b/tests/dsl_sandbox_test.zig
@@ -130,12 +130,13 @@ test "sandbox: dotdot in middle" {
 }
 
 // ---------------------------------------------------------------------------
-// validateResolved
+// validateWriteDir
 // ---------------------------------------------------------------------------
 
-test "sandbox: validateResolved accepts valid literal path" {
-    // Path does not exist on disk, so only literal validation runs
-    try sandbox.validateResolved(
+test "sandbox: validateWriteDir accepts a valid path whose dirs don't exist yet" {
+    // None of these dirs exist on disk, so the resolve walks to root and the
+    // literal validation is what stands — a missing parent can't escape.
+    try sandbox.validateWriteDir(
         std.Options.debug_io,
         "/opt/malt/Cellar/foo/1.0/bin/mybin",
         cellar,
@@ -143,8 +144,8 @@ test "sandbox: validateResolved accepts valid literal path" {
     );
 }
 
-test "sandbox: validateResolved rejects dotdot" {
-    const result = sandbox.validateResolved(
+test "sandbox: validateWriteDir rejects dotdot" {
+    const result = sandbox.validateWriteDir(
         std.Options.debug_io,
         "/opt/malt/Cellar/foo/1.0/../../evil",
         cellar,
@@ -153,8 +154,8 @@ test "sandbox: validateResolved rejects dotdot" {
     try testing.expectError(SandboxError.PathSandboxViolation, result);
 }
 
-test "sandbox: validateResolved rejects outside prefix" {
-    const result = sandbox.validateResolved(
+test "sandbox: validateWriteDir rejects outside prefix" {
+    const result = sandbox.validateWriteDir(
         std.Options.debug_io,
         "/etc/passwd",
         cellar,
@@ -167,44 +168,30 @@ test "sandbox: validateResolved rejects outside prefix" {
 // Extended sandbox tests
 // ---------------------------------------------------------------------------
 
-test "sandbox: symlink escape detected by validateResolved" {
-    // Create a temp directory and a symlink pointing outside the sandbox
+test "sandbox: validateWriteDir catches an intermediate-directory symlink escape" {
+    const io = std.Options.debug_io;
     const tmp = std.testing.tmpDir(.{});
     var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const tmp_path = blk: {
-        const n = try std.Io.Dir.realPath(tmp.dir, std.Options.debug_io, &buf);
-        break :blk buf[0..n];
-    };
+    const tmp_path = buf[0..try std.Io.Dir.realPath(tmp.dir, io, &buf)];
 
-    // Create a "cellar" subdir
-    try std.Io.Dir.createDirPath(tmp.dir, std.Options.debug_io, "cellar/pkg/1.0/bin");
+    try std.Io.Dir.createDirPath(tmp.dir, io, "cellar/pkg/1.0/bin");
 
-    // Create a symlink from cellar/pkg/1.0/bin/escape -> /tmp
-    const symlink_dir = try std.fs.path.join(
-        testing.allocator,
-        &.{ tmp_path, "cellar", "pkg", "1.0", "bin", "escape" },
-    );
-    defer testing.allocator.free(symlink_dir);
-
-    const cellar_dir = try std.fs.path.join(
-        testing.allocator,
-        &.{ tmp_path, "cellar", "pkg", "1.0" },
-    );
+    // bin/escape is a directory symlink pointing out of the keg.
+    const link_dir = try std.fs.path.join(testing.allocator, &.{ tmp_path, "cellar", "pkg", "1.0", "bin", "escape" });
+    defer testing.allocator.free(link_dir);
+    const cellar_dir = try std.fs.path.join(testing.allocator, &.{ tmp_path, "cellar", "pkg", "1.0" });
     defer testing.allocator.free(cellar_dir);
+    // A would-be write target *under* the symlinked directory.
+    const target = try std.fs.path.join(testing.allocator, &.{ link_dir, "x" });
+    defer testing.allocator.free(target);
 
-    test_io.cwd().symLink(std.Options.debug_io, "/tmp", symlink_dir, .{}) catch {
-        // If we can't create symlinks (permissions), skip the test
-        return;
-    };
+    test_io.cwd().symLink(io, "/tmp", link_dir, .{}) catch return; // skip if symlinks unavailable
 
-    // validateResolved should catch the escape because resolved path is /tmp
-    const result = sandbox.validateResolved(
-        std.Options.debug_io,
-        symlink_dir,
-        cellar_dir,
-        tmp_path,
+    // The literal path is inside the keg, but its resolved parent is /tmp.
+    try testing.expectError(
+        SandboxError.PathSandboxViolation,
+        sandbox.validateWriteDir(io, target, cellar_dir, tmp_path),
     );
-    try testing.expectError(SandboxError.PathSandboxViolation, result);
 }
 
 test "sandbox: deep nesting valid path" {


### PR DESCRIPTION
## Description

Formula and cask DSL runs in-process, confined only by a literal path check. That check inspected the path string but never the filesystem, so the FS-mutating builtins would follow a symlink on the final path component (and walk through a symlinked parent directory) straight out of the keg. A malicious formula — or an extracted bottle/tarball — could plant a link under the keg and overwrite, create, or re-mode an arbitrary file as the user running malt.

This makes the confinement match what the name check promised, across every FS-mutating builtin:

- **Create/truncate writes** (`Pathname#write`, `inreplace`'s non-atomic fallback) open with `O_NOFOLLOW`, so the kernel refuses a symlinked leaf atomically — no check-then-open race.
- **`touch`** opens create-without-truncate under `O_NOFOLLOW`; **`chmod`** opens read-only under `O_NOFOLLOW` and `fchmod`s the handle — so neither follows a symlinked leaf to a target outside the keg.
- **`cp` / `cp_r`** resolve the destination directory (per recursion level for `cp_r`), rejecting a symlink planted anywhere in the dest subtree. Final components are replaced atomically by the std copy, so an in-keg symlink leaf is not falsely rejected.
- All builtins resolve the destination's containing directory and reject it if it escapes the keg/prefix, closing the intermediate-directory variant. Resolution compares against the resolved keg/prefix, so a legitimately symlinked root (e.g. macOS `/tmp` → `/private/tmp`) is not mistaken for an escape, and the walk stops at the boundary so an absent keg subtree is not judged against an existing ancestor like `/opt`.
- A refused symlink reuses the existing `PathSandboxViolation`; the dead `validateResolved` guard is replaced by the live `validateWriteDir` / `validateDirTarget` / `openTargetNoFollow` helpers.

Legitimate cross-keg and system symlinks created via `ln_s` are untouched: the defense is on the write side, which also covers a planted link arriving via an extracted bottle/tarball.

`rm` / `rm_r` / `unlink` / `mv` operate on the link itself (not its target) and are intentionally left unchanged.

## Related Issue

- None

## Notes for Reviewers

- None