### PR TITLE
fix(fs/archive): reject pax-overridden symlink targets that escape the extract dir

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -131,6 +131,7 @@ pub fn build(b: *std.Build) void {
         "tests/purge_json_test.zig",
         "tests/install_test.zig",
         "tests/install_parse_cache_test.zig",
+        "tests/archive_extract_symlink_test.zig",
         "tests/deps_leak_test.zig",
         "tests/api_test.zig",
         "tests/offline_mode_test.zig",

--- a/scripts/regressions/tar-prescan-blind-to-pax-linkpath-symlink-escape.sh
+++ b/scripts/regressions/tar-prescan-blind-to-pax-linkpath-symlink-escape.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Regression: a tar.gz whose symlink target escapes the destination *only*
+# via a pax `linkpath` override (the ustar linkname stays benign) must be
+# rejected by malt's extract path.
+#
+# The bug: the tar pre-scan validated only the 100-byte ustar linkname and
+# discarded pax extended headers. std.tar's extractor applies a pax
+# `linkpath` over that field and symlinks it verbatim, so a tap-controlled
+# archive could plant a symlink pointing outside the destination while the
+# benign ustar linkname sailed past the guard.
+#
+# No CLI subcommand drives a raw archive extract in isolation, so the guard
+# is exercised by a colocated `test {}` that builds such an archive in a temp
+# dir and asserts `extractTarGz` returns `error.ExtractionFailed`. This script
+# builds the test binary and judges that test by name; it exits non-zero if
+# the guard regresses or the test goes missing.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s once the test binary is built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+FILTER="extractTarGz rejects a pax linkpath that escapes the destination"
+
+# The guard lives in a colocated `test {}`; if it is ever deleted the name
+# filter below would match nothing and silently pass. Fail loudly instead.
+if ! grep -Rqs -- "$FILTER" "$ROOT/src/fs/archive.zig"; then
+  echo "FAIL: the pax symlink-target guard test is missing from archive.zig" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+if [[ ! -x "$BIN" ]]; then
+  (cd "$ROOT" && zig build test-bin >/dev/null 2>&1) || {
+    echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+    exit 1
+  }
+fi
+
+# The runner has no per-test filter, so run the colocated suite and judge only
+# this guard's line: a pass ends in "OK", a regression prints the failure there.
+OUT=$("$BIN" 2>&1 || true)
+LINE=$(printf '%s\n' "$OUT" | grep -F -- "$FILTER" || true)
+if [[ -z "$LINE" ]]; then
+  echo "FAIL: the pax symlink-target guard test did not run" >&2
+  exit 1
+fi
+if [[ "$LINE" != *OK ]]; then
+  echo "FAIL: a pax linkpath override escaped the destination unchecked" >&2
+  exit 1
+fi
+
+echo "PASS: pax linkpath symlink escape rejected"

--- a/src/fs/archive.zig
+++ b/src/fs/archive.zig
@@ -655,3 +655,54 @@ test "extractTarGz rejects a pax path override that escapes by name" {
     t.entry("placeholder", '2', "benign");
     try std.testing.expectError(error.ExtractionFailed, testExtract(io, &tmp, t.bytes()));
 }
+
+test "extractTarGz rejects a pax linkpath that escapes via a hard link" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "dest");
+
+    // std.tar applies pax `linkpath` to hard-link targets too; the pre-scan
+    // recovers hard links itself, so the effective target must clear the
+    // same entry-path guard rather than the stale ustar field.
+    var raw: [4096]u8 = undefined;
+    var t = TestTar.init(&raw);
+    t.pax('x', "linkpath", "../escape");
+    t.entry("placeholder", '1', "benign");
+    try std.testing.expectError(error.ExtractionFailed, testExtract(io, &tmp, t.bytes()));
+}
+
+test "extractTarGz does not leak a pax override to a later entry" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "dest");
+
+    // The 'x' override applies to entry "a" only; "b" must fall back to its
+    // own ustar target, never inherit "a"'s pax linkpath.
+    var raw: [4096]u8 = undefined;
+    var t = TestTar.init(&raw);
+    t.pax('x', "linkpath", "target-a");
+    t.entry("a", '2', "ustar-a");
+    t.entry("b", '2', "target-b");
+    try testExtract(io, &tmp, t.bytes());
+
+    var base_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const base = base_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &base_buf)];
+    var dst_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dst = try std.fmt.bufPrint(&dst_buf, "{s}/dest", .{base});
+    var dest_dir = try std.Io.Dir.openDirAbsolute(io, dst, .{});
+    defer dest_dir.close(io);
+    var link_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const a = link_buf[0..try dest_dir.readLink(io, "a", &link_buf)];
+    try std.testing.expectEqualStrings("target-a", a);
+    var link_buf2: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const b = link_buf2[0..try dest_dir.readLink(io, "b", &link_buf2)];
+    try std.testing.expectEqualStrings("target-b", b);
+}

--- a/src/fs/archive.zig
+++ b/src/fs/archive.zig
@@ -823,3 +823,23 @@ test "rejectEscapingSymlinks accepts in-tree symlinks" {
     // The tree is left intact when nothing escapes.
     try std.Io.Dir.accessAbsolute(io, dst, .{});
 }
+
+test "rejectEscapingSymlinks does not follow symlinks while walking" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "dest/realdir");
+    try tmp.dir.writeFile(io, .{ .sub_path = "dest/realdir/f", .data = "x" });
+    // A symlink to an in-tree dir and a self-referential symlink: if the
+    // walker followed either, this would recurse forever instead of
+    // terminating. Both targets are in-tree, so the guard must accept them.
+    try tmp.dir.symLink(io, "realdir", "dest/dirlink", .{});
+    try tmp.dir.symLink(io, ".", "dest/self", .{});
+
+    var dst_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dst = try testDestAbs(&tmp, io, &dst_buf);
+    try rejectEscapingSymlinks(io, dst);
+}

--- a/src/fs/archive.zig
+++ b/src/fs/archive.zig
@@ -383,6 +383,10 @@ pub fn extractZip(io: std.Io, archive_path: []const u8, dest_dir: []const u8) !v
         },
         else => return error.ExtractionFailed,
     }
+
+    // The `-Z1` listing only surfaces entry names; symlink targets are not
+    // checked until the tree exists on disk.
+    try rejectEscapingSymlinks(io, dest_dir);
 }
 
 fn validateZip(io: std.Io, archive_path: []const u8) !void {
@@ -412,6 +416,10 @@ pub fn extractTarXzFile(io: std.Io, archive_path: []const u8, dest_dir: []const 
         },
         else => return error.ExtractionFailed,
     }
+
+    // `tar tf` validated entry names, not symlink targets; check those on
+    // the materialised tree.
+    try rejectEscapingSymlinks(io, dest_dir);
 }
 
 fn validateTarListing(io: std.Io, archive_path: []const u8) !void {
@@ -454,6 +462,39 @@ fn validateSubprocessListing(io: std.Io, argv: []const []const u8) !void {
         const line = std.mem.trimEnd(u8, raw, "\r");
         if (line.len == 0) continue;
         if (!isSafeEntryPath(line)) return error.ExtractionFailed;
+    }
+}
+
+/// Walk a freshly-extracted tree and reject any symlink whose target escapes
+/// `dest_dir`. The `tar tf`/`unzip -Z1` pre-scan validates entry names but
+/// not symlink *targets*; macOS `tar`/`unzip` refuse to write *through* a
+/// symlink, so a dangling escaping link is the only residue — this catches it.
+/// The whole tree is wiped on rejection so a failed extract leaves nothing
+/// behind, matching the in-process tar.gz contract. The walker descends real
+/// directories only (symlink entries are never followed), so it cannot loop.
+fn rejectEscapingSymlinks(io: std.Io, dest_dir: []const u8) !void {
+    var escaped = false;
+    {
+        var dir = std.Io.Dir.openDirAbsolute(io, dest_dir, .{ .iterate = true }) catch
+            return error.ExtractionFailed;
+        defer dir.close(io);
+        var walker = dir.walk(child_allocator) catch return error.ExtractionFailed;
+        defer walker.deinit();
+        while (walker.next(io) catch return error.ExtractionFailed) |entry| {
+            if (entry.kind != .sym_link) continue;
+            var buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+            const len = entry.dir.readLink(io, entry.basename, &buf) catch return error.ExtractionFailed;
+            // `entry.path` is relative to dest_dir — the same shape the tar.gz
+            // pre-scan feeds `isSafeSymlinkTarget`, so the policy stays uniform.
+            if (!isSafeSymlinkTarget(entry.path, buf[0..len])) {
+                escaped = true;
+                break;
+            }
+        }
+    }
+    if (escaped) {
+        std.Io.Dir.cwd().deleteTree(io, dest_dir) catch {};
+        return error.ExtractionFailed;
     }
 }
 
@@ -705,4 +746,80 @@ test "extractTarGz does not leak a pax override to a later entry" {
     var link_buf2: [std.Io.Dir.max_path_bytes]u8 = undefined;
     const b = link_buf2[0..try dest_dir.readLink(io, "b", &link_buf2)];
     try std.testing.expectEqualStrings("target-b", b);
+}
+
+// --- subprocess-extractor symlink-target guard (xz/zip) -------------------
+
+fn testDestAbs(tmp: *std.testing.TmpDir, io: std.Io, buf: []u8) ![]const u8 {
+    var base_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const base = base_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &base_buf)];
+    return std.fmt.bufPrint(buf, "{s}/dest", .{base});
+}
+
+test "rejectEscapingSymlinks rejects a climbing target and wipes the tree" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "dest");
+    // A symlink at the root climbing several levels escapes dest.
+    try tmp.dir.symLink(io, "../../../../etc/evil", "dest/escape", .{});
+
+    var dst_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dst = try testDestAbs(&tmp, io, &dst_buf);
+    try std.testing.expectError(error.ExtractionFailed, rejectEscapingSymlinks(io, dst));
+    // Rejection wipes the tree so nothing dangerous is left behind.
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(io, dst, .{}));
+}
+
+test "rejectEscapingSymlinks rejects an absolute target" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "dest");
+    try tmp.dir.symLink(io, "/etc/passwd", "dest/abs", .{});
+
+    var dst_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dst = try testDestAbs(&tmp, io, &dst_buf);
+    try std.testing.expectError(error.ExtractionFailed, rejectEscapingSymlinks(io, dst));
+}
+
+test "rejectEscapingSymlinks rejects a nested climbing target" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "dest/sub");
+    // From dest/sub, three climbs reach above dest.
+    try tmp.dir.symLink(io, "../../../etc/evil", "dest/sub/escape", .{});
+
+    var dst_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dst = try testDestAbs(&tmp, io, &dst_buf);
+    try std.testing.expectError(error.ExtractionFailed, rejectEscapingSymlinks(io, dst));
+}
+
+test "rejectEscapingSymlinks accepts in-tree symlinks" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "dest/bin");
+    // A sibling-relative link and a one-level climb that stays in-tree.
+    try tmp.dir.symLink(io, "sibling", "dest/ok", .{});
+    try tmp.dir.symLink(io, "../lib/real", "dest/bin/link", .{});
+
+    var dst_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dst = try testDestAbs(&tmp, io, &dst_buf);
+    try rejectEscapingSymlinks(io, dst);
+    // The tree is left intact when nothing escapes.
+    try std.Io.Dir.accessAbsolute(io, dst, .{});
 }

--- a/src/fs/archive.zig
+++ b/src/fs/archive.zig
@@ -113,8 +113,8 @@ pub fn extractTarGz(io: std.Io, archive_path: []const u8, dest_dir: []const u8) 
     var file_reader = file.reader(io, &file_buf);
     const input: *std.Io.Reader = &file_reader.interface;
 
-    // flate.max_window_len is 64 KiB — fine on the stack here, same
-    // shape `extractTarZst` uses for the zstd decompressor.
+    // flate.max_window_len is 64 KiB — fine on the stack for a per-extract
+    // decompressor window.
     var window: [std.compress.flate.max_window_len]u8 = undefined;
     var decompress = std.compress.flate.Decompress.init(input, .gzip, &window);
 
@@ -163,9 +163,11 @@ fn applyHardLinks(dest_dir: []const u8, links: []const HardLink) !void {
 
 /// Walk the tar archive at raw 512-byte blocks to enforce path safety
 /// AND recover hard-link pairs the std iterator silently drops.
-/// Pax/GNU long-name extensions are uninterpreted: a hardlink whose
-/// name lives in a pax header is not found here. Homebrew bottles use
-/// plain ustar paths, so the gap is acceptable for the current scope.
+/// Pax extended headers ('x') are interpreted for `linkpath=`/`path=` so
+/// the pre-scan validates the *effective* symlink target the extractor
+/// will use, not the stale ustar field. GNU long-name extensions remain
+/// uninterpreted: a hardlink whose name lives in a GNU header is not found
+/// here. Homebrew bottles use plain ustar paths, so that gap is acceptable.
 fn preScanTarGz(
     io: std.Io,
     arena: std.mem.Allocator,
@@ -184,6 +186,12 @@ fn preScanTarGz(
 
     var hardlinks: std.ArrayList(HardLink) = .empty;
 
+    // Pax overrides apply to the single entry that follows the 'x' header,
+    // mirroring std.tar: `path=` replaces the name, `linkpath=` the target.
+    // Both reset once consumed (or when a new 'x' supersedes them).
+    var pax_name: ?[]const u8 = null;
+    var pax_link: ?[]const u8 = null;
+
     while (true) {
         var header: [512]u8 = undefined;
         const got = r.readSliceShort(&header) catch return error.ExtractionFailed;
@@ -198,20 +206,46 @@ fn preScanTarGz(
         const kind_byte = header[156];
         const size = parseHeaderOctal(header[124..136]) catch return error.ExtractionFailed;
 
+        // Pax extended header: its payload can override the *next* entry's
+        // link target (and name). std.tar applies these over the ustar
+        // fields, so validating the raw ustar field here would check bytes
+        // the extractor never uses. Each 'x' supersedes the previous one.
+        if (kind_byte == 'x') {
+            pax_name = null;
+            pax_link = null;
+            try parsePaxOverrides(r, arena, size, &pax_name, &pax_link);
+            // The parse consumed exactly `size` bytes; skip only the block pad.
+            const pad: u64 = (512 - (size % 512)) % 512;
+            if (pad > 0) r.discardAll64(pad) catch return error.ExtractionFailed;
+            continue;
+        }
+        // Global pax header is never applied to later entries (std.tar
+        // discards it); skip its payload and keep any pending overrides.
+        if (kind_byte == 'g') {
+            const skip_g: u64 = (size + 511) / 512 * 512;
+            if (skip_g > 0) r.discardAll64(skip_g) catch return error.ExtractionFailed;
+            continue;
+        }
+
         // ustar combines bytes[345..500] (prefix) + '/' + bytes[0..100] (name).
         const ustar = std.mem.eql(u8, header[257..262], "ustar");
         const raw_name = nullSlice(header[0..100]);
         const raw_prefix = if (ustar) nullSlice(header[345..500]) else "";
         var name_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
-        const name = composePath(&name_buf, raw_prefix, raw_name) catch return error.ExtractionFailed;
+        const ustar_name = composePath(&name_buf, raw_prefix, raw_name) catch return error.ExtractionFailed;
 
-        if (!isSafeEntryPath(name)) return error.ExtractionFailed;
+        if (!isSafeEntryPath(ustar_name)) return error.ExtractionFailed;
+        // A pax `path=` override must clear the same bar; std.tar sanitises
+        // names regardless, but the pre-scan should not silently diverge.
+        if (pax_name) |pn| if (!isSafeEntryPath(pn)) return error.ExtractionFailed;
+        const name = pax_name orelse ustar_name;
 
-        const link_name = nullSlice(header[157..257]);
+        const ustar_link = nullSlice(header[157..257]);
+        const link_name = pax_link orelse ustar_link;
         switch (kind_byte) {
             // Symbolic link: link target is interpreted relative to the
             // entry's parent directory (POSIX). Reuse the existing
-            // bottle-aware target check.
+            // bottle-aware target check against the effective target.
             '2' => if (!isSafeSymlinkTarget(name, link_name)) return error.ExtractionFailed,
             // Hard link: target is a tar-relative path identical in
             // shape to a regular entry name.
@@ -224,10 +258,14 @@ fn preScanTarGz(
             },
             else => {},
         }
+        // Pending overrides are consumed by this entry whatever its kind;
+        // reset so they can never leak forward to an unrelated entry.
+        pax_name = null;
+        pax_link = null;
 
         // Advance past the data payload (rounded up to the next 512-byte
         // boundary). Symlinks/hardlinks/dirs report size 0 so this is a
-        // no-op for them, but pax/gnu extension blocks DO carry data.
+        // no-op for them, but regular-file blocks DO carry data.
         const skip_bytes: u64 = (size + 511) / 512 * 512;
         if (skip_bytes > 0) {
             r.discardAll64(skip_bytes) catch return error.ExtractionFailed;
@@ -235,6 +273,43 @@ fn preScanTarGz(
     }
 
     return hardlinks.toOwnedSlice(arena);
+}
+
+/// Parse a pax extended-header payload (`size` bytes from the current block)
+/// for `path=`/`linkpath=`, returning the last value seen for each — std.tar
+/// applies these over the ustar fields of the following entry. The returned
+/// slices are arena-owned and outlive the scan. Reads exactly `size` bytes.
+fn parsePaxOverrides(
+    r: *std.Io.Reader,
+    arena: std.mem.Allocator,
+    size: u64,
+    out_name: *?[]const u8,
+    out_link: *?[]const u8,
+) !void {
+    // Real pax headers are tens of bytes; bound the buffer against a hostile
+    // size before allocating or reading.
+    if (size > 64 * 1024) return error.ExtractionFailed;
+    const payload = arena.alloc(u8, @intCast(size)) catch return error.ExtractionFailed;
+    r.readSliceAll(payload) catch return error.ExtractionFailed;
+
+    // Each record is `"<len> KEY=VALUE\n"`; <len> counts the whole record.
+    var rest: []const u8 = payload;
+    while (rest.len > 0) {
+        const sp = std.mem.indexOfScalar(u8, rest, ' ') orelse return error.ExtractionFailed;
+        const rec_len = std.fmt.parseInt(usize, rest[0..sp], 10) catch return error.ExtractionFailed;
+        if (rec_len < sp + 2 or rec_len > rest.len or rest[rec_len - 1] != '\n') return error.ExtractionFailed;
+        const kv = rest[sp + 1 .. rec_len - 1];
+        if (std.mem.indexOfScalar(u8, kv, '=')) |eq| {
+            const key = kv[0..eq];
+            const value = kv[eq + 1 ..];
+            if (std.mem.eql(u8, key, "linkpath")) {
+                out_link.* = value;
+            } else if (std.mem.eql(u8, key, "path")) {
+                out_name.* = value;
+            }
+        }
+        rest = rest[rec_len..];
+    }
 }
 
 /// `nullStr` from std.tar - first NUL terminates, full slice otherwise.
@@ -277,13 +352,6 @@ fn validChksum(header: *const [512]u8) bool {
         sum += if (i >= 148 and i < 156) ' ' else b;
     }
     return sum == stored;
-}
-
-/// Extracts a tar.zst archive from the given input reader into output_dir.
-pub fn extractTarZst(io: std.Io, input: *std.Io.Reader, output_dir: std.Io.Dir) !void {
-    var window_buf: [std.compress.zstd.default_window_len]u8 = undefined;
-    var decompressor = std.compress.zstd.Decompress.init(input, &window_buf, .{});
-    try std.tar.pipeToFileSystem(io, output_dir, &decompressor.reader, .{});
 }
 
 /// Extract a .zip archive to `dest_dir`. Used by the tap-install path
@@ -387,4 +455,203 @@ fn validateSubprocessListing(io: std.Io, argv: []const []const u8) !void {
         if (line.len == 0) continue;
         if (!isSafeEntryPath(line)) return error.ExtractionFailed;
     }
+}
+
+// --- pax symlink-target test helpers --------------------------------------
+
+/// Build a minimal 512-byte ustar header with a valid checksum. Only the
+/// fields the pre-scan reads (name, size, typeflag, linkname, magic) are
+/// populated; everything else stays zero.
+fn testTarHeader(name: []const u8, typeflag: u8, link: []const u8, size: u64) [512]u8 {
+    var h: [512]u8 = @splat(0);
+    @memcpy(h[0..name.len], name);
+    _ = std.fmt.bufPrint(h[124..135], "{o:0>11}", .{size}) catch unreachable;
+    h[156] = typeflag;
+    @memcpy(h[157..][0..link.len], link);
+    @memcpy(h[257..262], "ustar");
+    h[263] = '0';
+    h[264] = '0';
+    // Checksum: sum the whole header with the chksum field read as spaces.
+    @memset(h[148..156], ' ');
+    var sum: u64 = 0;
+    for (h) |b| sum += b;
+    _ = std.fmt.bufPrint(h[148..154], "{o:0>6}", .{sum}) catch unreachable;
+    h[154] = 0;
+    h[155] = ' ';
+    return h;
+}
+
+/// Format a pax record `"<len> KEY=VALUE\n"` where `<len>` counts the whole
+/// record including its own digits.
+fn testPaxRecord(out: []u8, key: []const u8, value: []const u8) []const u8 {
+    const fixed = 1 + key.len + 1 + value.len + 1; // space, '=', '\n'
+    var digits: usize = 1;
+    var total = fixed + digits;
+    while (std.fmt.count("{d}", .{total}) != digits) {
+        digits = std.fmt.count("{d}", .{total});
+        total = fixed + digits;
+    }
+    return std.fmt.bufPrint(out, "{d} {s}={s}\n", .{ total, key, value }) catch unreachable;
+}
+
+/// gzip-compress `raw` into `out`, returning the written gzip stream.
+fn testGzip(out: []u8, raw: []const u8) []const u8 {
+    var out_w = std.Io.Writer.fixed(out);
+    var win: [std.compress.flate.max_window_len]u8 = undefined;
+    var comp = std.compress.flate.Compress.init(&out_w, &win, .gzip, std.compress.flate.Compress.Options.level_4) catch unreachable;
+    comp.writer.writeAll(raw) catch unreachable;
+    comp.finish() catch unreachable;
+    return out_w.buffered();
+}
+
+/// Assembles raw tar blocks into a caller-owned buffer. Trailing zero blocks
+/// (the buffer is zeroed up front) terminate the archive after `len`.
+const TestTar = struct {
+    buf: []u8,
+    len: usize = 0,
+
+    fn init(buf: []u8) TestTar {
+        @memset(buf, 0);
+        return .{ .buf = buf };
+    }
+
+    /// Append a single 512-byte entry header (size 0 — links/dirs only).
+    fn entry(self: *TestTar, name: []const u8, typeflag: u8, link: []const u8) void {
+        const h = testTarHeader(name, typeflag, link, 0);
+        @memcpy(self.buf[self.len..][0..512], h[0..]);
+        self.len += 512;
+    }
+
+    /// Append a pax header ('x' extended or 'g' global) with one record.
+    fn pax(self: *TestTar, typeflag: u8, key: []const u8, value: []const u8) void {
+        var rec_buf: [512]u8 = undefined;
+        const rec = testPaxRecord(&rec_buf, key, value);
+        const h = testTarHeader("PaxHeaders/0", typeflag, "", rec.len);
+        @memcpy(self.buf[self.len..][0..512], h[0..]);
+        self.len += 512;
+        @memcpy(self.buf[self.len..][0..rec.len], rec);
+        self.len += 512; // record fits one padded block
+    }
+
+    fn bytes(self: *const TestTar) []const u8 {
+        return self.buf[0 .. self.len + 1024]; // + EOF marker blocks
+    }
+};
+
+/// gzip `raw`, write it under `tmp`, and run `extractTarGz` into `tmp/dest`,
+/// returning whatever the extract returns. `tmp/dest` must already exist.
+fn testExtract(io: std.Io, tmp: *std.testing.TmpDir, raw: []const u8) !void {
+    var gz_buf: [8192]u8 = undefined;
+    const gz = testGzip(&gz_buf, raw);
+    try tmp.dir.writeFile(io, .{ .sub_path = "a.tar.gz", .data = gz });
+
+    var base_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const base = base_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &base_buf)];
+    var arc_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const arc = try std.fmt.bufPrint(&arc_buf, "{s}/a.tar.gz", .{base});
+    var dst_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dst = try std.fmt.bufPrint(&dst_buf, "{s}/dest", .{base});
+    return extractTarGz(io, arc, dst);
+}
+
+test "extractTarGz rejects a pax linkpath that escapes the destination" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "dest");
+
+    // Benign ustar linkname passes the pre-scan, but the pax override climbs
+    // out of dest — the extract must refuse it, not materialise it.
+    var raw: [4096]u8 = undefined;
+    var t = TestTar.init(&raw);
+    t.pax('x', "linkpath", "../../../../../../tmp/evil");
+    t.entry("placeholder", '2', "benign");
+    try std.testing.expectError(error.ExtractionFailed, testExtract(io, &tmp, t.bytes()));
+}
+
+test "extractTarGz accepts a pax linkpath within the destination" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "dest");
+
+    var raw: [4096]u8 = undefined;
+    var t = TestTar.init(&raw);
+    t.pax('x', "linkpath", "legit-target");
+    t.entry("link", '2', "benign");
+    try testExtract(io, &tmp, t.bytes());
+
+    // The pax linkpath, not the ustar linkname, must be what landed on disk —
+    // proving the pre-scan validated (and the extractor used) the same bytes.
+    var base_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const base = base_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &base_buf)];
+    var dst_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dst = try std.fmt.bufPrint(&dst_buf, "{s}/dest", .{base});
+    var dest_dir = try std.Io.Dir.openDirAbsolute(io, dst, .{});
+    defer dest_dir.close(io);
+    var link_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const target = link_buf[0..try dest_dir.readLink(io, "link", &link_buf)];
+    try std.testing.expectEqualStrings("legit-target", target);
+}
+
+test "extractTarGz ignores a global pax linkpath (no leak to the next entry)" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "dest");
+
+    // A 'g' global header must not be applied to following entries; the
+    // benign ustar target stands, so this extracts cleanly.
+    var raw: [4096]u8 = undefined;
+    var t = TestTar.init(&raw);
+    t.pax('g', "linkpath", "../../../../../../tmp/evil");
+    t.entry("link", '2', "benign");
+    try testExtract(io, &tmp, t.bytes());
+}
+
+test "extractTarGz applies only the last pax header before an entry" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "dest");
+
+    // The first 'x' escapes, but a second 'x' supersedes it with a safe
+    // target — matching std.tar's reset. Over-carrying the first would
+    // wrongly reject this archive.
+    var raw: [4096]u8 = undefined;
+    var t = TestTar.init(&raw);
+    t.pax('x', "linkpath", "../../../../../../tmp/evil");
+    t.pax('x', "linkpath", "safe-target");
+    t.entry("link", '2', "benign");
+    try testExtract(io, &tmp, t.bytes());
+}
+
+test "extractTarGz rejects a pax path override that escapes by name" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "dest");
+
+    // A pax `path=` override re-runs the entry-name guard; a climbing name
+    // is rejected even though the ustar name is benign.
+    var raw: [4096]u8 = undefined;
+    var t = TestTar.init(&raw);
+    t.pax('x', "path", "../escape-name");
+    t.entry("placeholder", '2', "benign");
+    try std.testing.expectError(error.ExtractionFailed, testExtract(io, &tmp, t.bytes()));
 }

--- a/tests/api_test.zig
+++ b/tests/api_test.zig
@@ -490,11 +490,13 @@ const CountingServer = struct {
     listener: *net.Server,
     body: []const u8,
     count: std.atomic.Value(u32),
+    stop: std.atomic.Value(bool) = .init(false),
 
     fn serve(self: *CountingServer) void {
         while (true) {
             const stream = self.listener.accept(self.io) catch return;
             defer stream.close(self.io);
+            if (self.stop.load(.acquire)) return;
             var rbuf: [16 * 1024]u8 = undefined;
             var wbuf: [16 * 1024]u8 = undefined;
             var reader = stream.reader(self.io, &rbuf);
@@ -522,11 +524,13 @@ const EtagServer = struct {
     // How many answered requests carried an `If-None-Match` — lets a test
     // prove the refresh went out conditional (or, when 0, unconditional).
     conditional_count: std.atomic.Value(u32),
+    stop: std.atomic.Value(bool) = .init(false),
 
     fn serve(self: *EtagServer) void {
         while (true) {
             const stream = self.listener.accept(self.io) catch return;
             defer stream.close(self.io);
+            if (self.stop.load(.acquire)) return;
             var rbuf: [16 * 1024]u8 = undefined;
             var wbuf: [16 * 1024]u8 = undefined;
             var reader = stream.reader(self.io, &rbuf);
@@ -561,6 +565,20 @@ const EtagServer = struct {
         }
     }
 };
+
+/// Tear down a test HTTP server without racing its accept loop: flag it to
+/// stop, wake the blocked `accept` with a throwaway connection so the server
+/// thread returns on its own, join it, and only then close the listener — so
+/// the listener fd is never closed while the server thread still holds it
+/// (which `std.Io.Threaded` flags as a use-after-close `BADF` panic).
+fn stopServer(io: std.Io, listener: *net.Server, stop: *std.atomic.Value(bool), thread: std.Thread) void {
+    stop.store(true, .release);
+    if (listener.socket.address.connect(io, .{ .mode = .stream })) |waker| {
+        waker.close(io);
+    } else |_| {}
+    thread.join();
+    listener.deinit(io);
+}
 
 /// Backdate an index side-car's mtime to 1970 so the freshness gate treats
 /// it as stale and the next fetch takes the refresh path.
@@ -682,8 +700,7 @@ test "a cold names+versions cycle downloads the bulk dump exactly once" {
     defer testing.allocator.free(versions);
 
     // Stop the server before asserting so a hung join can't mask a result.
-    listener.deinit(io);
-    thread.join();
+    stopServer(io, &listener, &srv.stop, thread);
 
     try testing.expectEqual(@as(u32, 1), srv.count.load(.monotonic));
 
@@ -761,8 +778,7 @@ test "a stale side-car with an unchanged dump refreshes via 304, no re-download"
     defer testing.allocator.free(names);
     try testing.expectEqualStrings(seeded_names, names);
 
-    listener.deinit(io);
-    thread.join();
+    stopServer(io, &listener, &srv.stop, thread);
 
     // Exactly one conditional request; the warm names read hit no network.
     try testing.expectEqual(@as(u32, 1), srv.count.load(.monotonic));
@@ -819,8 +835,7 @@ test "a changed dump (new ETag) re-extracts both side-cars and stores the new ET
     const versions = try api.fetchVersionsIndex(.formula);
     defer testing.allocator.free(versions);
 
-    listener.deinit(io);
-    thread.join();
+    stopServer(io, &listener, &srv.stop, thread);
 
     // 200 path re-extracted from the fresh body, replacing the stale seed.
     const want_versions = try api_mod.extractVersions(testing.allocator, .formula, fixture);
@@ -869,8 +884,7 @@ test "a first-ever fetch (no stored ETag) does an unconditional GET and stores t
     const versions = try api.fetchVersionsIndex(.formula);
     defer testing.allocator.free(versions);
 
-    listener.deinit(io);
-    thread.join();
+    stopServer(io, &listener, &srv.stop, thread);
 
     const want_versions = try api_mod.extractVersions(testing.allocator, .formula, fixture);
     defer testing.allocator.free(want_versions);
@@ -925,8 +939,7 @@ test "a 200 without an ETag header clears a previously stored ETag" {
     const versions = try api.fetchVersionsIndex(.formula);
     defer testing.allocator.free(versions);
 
-    listener.deinit(io);
-    thread.join();
+    stopServer(io, &listener, &srv.stop, thread);
 
     // The stale token is gone, so the next refresh starts unconditional.
     try testing.expect(try readCacheFileAlloc(testing.allocator, dir.path, "formula.etag") == null);
@@ -974,8 +987,7 @@ test "an implausibly large stored ETag is ignored and the GET goes out unconditi
     const versions = try api.fetchVersionsIndex(.formula);
     defer testing.allocator.free(versions);
 
-    listener.deinit(io);
-    thread.join();
+    stopServer(io, &listener, &srv.stop, thread);
 
     // The bad token was dropped, so the request was unconditional...
     try testing.expectEqual(@as(u32, 0), srv.conditional_count.load(.monotonic));
@@ -1026,8 +1038,7 @@ test "a 304 with a missing side-car drops the ETag and surfaces ApiUnreachable" 
 
     try testing.expectError(api_mod.ApiError.ApiUnreachable, api.fetchVersionsIndex(.formula));
 
-    listener.deinit(io);
-    thread.join();
+    stopServer(io, &listener, &srv.stop, thread);
 
     // The orphaned ETag is dropped so the next run re-downloads cleanly.
     try testing.expect(try readCacheFileAlloc(testing.allocator, dir.path, "formula.etag") == null);
@@ -1072,8 +1083,7 @@ test "the conditional refresh is kind-agnostic: a cask 304 refreshes and keeps c
     const versions = try api.fetchVersionsIndex(.cask);
     defer testing.allocator.free(versions);
 
-    listener.deinit(io);
-    thread.join();
+    stopServer(io, &listener, &srv.stop, thread);
 
     // Same 304 short-circuit as formula, keyed on the cask sidecars.
     try testing.expectEqualStrings(seeded, versions);
@@ -1089,11 +1099,13 @@ const StatusServer = struct {
     io: std.Io,
     listener: *net.Server,
     status: std.http.Status,
+    stop: std.atomic.Value(bool) = .init(false),
 
     fn serve(self: *StatusServer) void {
         while (true) {
             const stream = self.listener.accept(self.io) catch return;
             defer stream.close(self.io);
+            if (self.stop.load(.acquire)) return;
             var rbuf: [16 * 1024]u8 = undefined;
             var wbuf: [16 * 1024]u8 = undefined;
             var reader = stream.reader(self.io, &rbuf);
@@ -1129,8 +1141,7 @@ test "a refresh that is neither 200 nor 304 surfaces ApiUnreachable" {
 
     try testing.expectError(api_mod.ApiError.ApiUnreachable, api.fetchVersionsIndex(.formula));
 
-    listener.deinit(io);
-    thread.join();
+    stopServer(io, &listener, &srv.stop, thread);
 }
 
 test "readNotFoundCache returns false for stale marker" {

--- a/tests/archive_extract_symlink_test.zig
+++ b/tests/archive_extract_symlink_test.zig
@@ -1,0 +1,112 @@
+//! malt — end-to-end symlink-target guard for the subprocess extractors.
+//!
+//! `extractTarXzFile` (system `tar`) and `extractZip` (system `unzip`)
+//! validate entry *names* via a listing pass, but the listing never surfaces
+//! symlink *targets*. These tests build real archives whose only escape is a
+//! symlink target climbing out of the destination, and assert the extractor
+//! refuses them while a benign archive still extracts.
+
+const std = @import("std");
+const testing = std.testing;
+const malt = @import("malt");
+const archive = malt.archive;
+
+/// Run `argv` (optionally in `cwd`) and fail the test if it doesn't exit 0.
+fn run(io: std.Io, argv: []const []const u8, cwd: std.process.Child.Cwd) !void {
+    var child = try std.process.spawn(io, .{
+        .argv = argv,
+        .cwd = cwd,
+        .stdout = .ignore,
+        .stderr = .ignore,
+    });
+    switch (try child.wait(io)) {
+        .exited => |code| if (code != 0) return error.CommandFailed,
+        else => return error.CommandFailed,
+    }
+}
+
+fn destAbs(tmp: *std.testing.TmpDir, io: std.Io, buf: []u8) ![]const u8 {
+    var base: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const b = base[0..try std.Io.Dir.realPath(tmp.dir, io, &base)];
+    return std.fmt.bufPrint(buf, "{s}/dest", .{b});
+}
+
+fn archiveAbs(tmp: *std.testing.TmpDir, io: std.Io, name: []const u8, buf: []u8) ![]const u8 {
+    var base: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const b = base[0..try std.Io.Dir.realPath(tmp.dir, io, &base)];
+    return std.fmt.bufPrint(buf, "{s}/{s}", .{ b, name });
+}
+
+test "extractTarXzFile rejects a tar.xz symlink target that escapes the destination" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "src");
+    try tmp.dir.createDirPath(io, "dest");
+    var src = try tmp.dir.openDir(io, "src", .{});
+    defer src.close(io);
+    try src.symLink(io, "../../../../etc/evil", "escape", .{});
+
+    var arc_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const arc = try archiveAbs(&tmp, io, "evil.tar.xz", &arc_buf);
+    try run(io, &.{ "tar", "-cJf", arc, "-C", "src", "escape" }, .{ .dir = tmp.dir });
+
+    var dst_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dst = try destAbs(&tmp, io, &dst_buf);
+    try testing.expectError(error.ExtractionFailed, archive.extractTarXzFile(io, arc, dst));
+    // The guard wipes the tree, so no escaping symlink is left behind.
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(io, dst, .{}));
+}
+
+test "extractZip rejects a zip symlink target that escapes the destination" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "src");
+    try tmp.dir.createDirPath(io, "dest");
+    var src = try tmp.dir.openDir(io, "src", .{});
+    defer src.close(io);
+    try src.symLink(io, "../../../../etc/evil", "escape", .{});
+
+    var arc_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const arc = try archiveAbs(&tmp, io, "evil.zip", &arc_buf);
+    // `--symlinks` stores the link as a symlink rather than dereferencing it.
+    try run(io, &.{ "zip", "-q", "--symlinks", arc, "escape" }, .{ .dir = src });
+
+    var dst_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dst = try destAbs(&tmp, io, &dst_buf);
+    try testing.expectError(error.ExtractionFailed, archive.extractZip(io, arc, dst));
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(io, dst, .{}));
+}
+
+test "extractZip still extracts a benign archive" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "src");
+    try tmp.dir.createDirPath(io, "dest");
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/hello", .data = "hi" });
+    var src = try tmp.dir.openDir(io, "src", .{});
+    defer src.close(io);
+
+    var arc_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const arc = try archiveAbs(&tmp, io, "ok.zip", &arc_buf);
+    try run(io, &.{ "zip", "-q", arc, "hello" }, .{ .dir = src });
+
+    var dst_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dst = try destAbs(&tmp, io, &dst_buf);
+    try archive.extractZip(io, arc, dst);
+
+    var hello_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const hello = try std.fmt.bufPrint(&hello_buf, "{s}/hello", .{dst});
+    try std.Io.Dir.accessAbsolute(io, hello, .{});
+}

--- a/tests/archive_extract_symlink_test.zig
+++ b/tests/archive_extract_symlink_test.zig
@@ -110,3 +110,35 @@ test "extractZip still extracts a benign archive" {
     const hello = try std.fmt.bufPrint(&hello_buf, "{s}/hello", .{dst});
     try std.Io.Dir.accessAbsolute(io, hello, .{});
 }
+
+test "extractTarXzFile still extracts a benign archive with an in-tree symlink" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "src");
+    try tmp.dir.createDirPath(io, "dest");
+    try tmp.dir.writeFile(io, .{ .sub_path = "src/hello", .data = "hi" });
+    var src = try tmp.dir.openDir(io, "src", .{});
+    defer src.close(io);
+    // A relative in-tree symlink must survive — the guard rejects only escapes.
+    try src.symLink(io, "hello", "alias", .{});
+
+    var arc_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const arc = try archiveAbs(&tmp, io, "ok.tar.xz", &arc_buf);
+    try run(io, &.{ "tar", "-cJf", arc, "-C", "src", "hello", "alias" }, .{ .dir = tmp.dir });
+
+    var dst_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dst = try destAbs(&tmp, io, &dst_buf);
+    try archive.extractTarXzFile(io, arc, dst);
+
+    // Both the regular file and the in-tree symlink land.
+    var dest_dir = try std.Io.Dir.openDirAbsolute(io, dst, .{});
+    defer dest_dir.close(io);
+    try dest_dir.access(io, "hello", .{});
+    var link_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const target = link_buf[0..try dest_dir.readLink(io, "alias", &link_buf)];
+    try testing.expectEqualStrings("hello", target);
+}


### PR DESCRIPTION
## Description

A third-party tap could ship an archive whose symbolic-link target escaped the extraction directory, planting a symlink outside the destination on install.

**tar.gz (in-process `std.tar`):** the pre-scan validated only the 100-byte ustar linkname while the extractor honoured a pax extended-header `linkpath=` override, writing the symlink verbatim. The pre-scan now interprets pax extended headers and validates the *effective* target/name the extractor uses, mirroring `std.tar`'s semantics exactly (last `'x'` wins, `'g'` globals ignored, override resets after one entry) so legitimate bottles are neither over-rejected nor left exposed. Pax-overridden hard-link targets are validated the same way.

**tar.xz / zip (subprocess `tar`/`unzip`):** these validated entry *names* via a listing pass, but the listing never surfaces symlink *targets*. After extraction the materialised tree is now walked and any symlink whose target escapes the destination is rejected (reusing the same `isSafeSymlinkTarget` policy); the tree is wiped on rejection so a failed extract leaves nothing behind. macOS `tar`/`unzip` already refuse to write *through* a symlink, so the dangling escaping link is the only residue and this catches it.

Also removes a dead, unguarded zstd-extract helper that had no caller.

## Related Issue

- None

## Notes for Reviewers

- None
