### PR TITLE
fix(net): stop credential headers from following cross-domain redirects

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -169,6 +169,7 @@ pub fn build(b: *std.Build) void {
         "tests/child_test.zig",
         "tests/net_client_test.zig",
         "tests/net_client_pool_test.zig",
+        "tests/net_redirect_auth_test.zig",
         "tests/http_inject_test.zig",
         "tests/term_sanitize_test.zig",
         "tests/perms_test.zig",

--- a/scripts/regressions/auth-headers-ride-cross-domain-redirects.sh
+++ b/scripts/regressions/auth-headers-ride-cross-domain-redirects.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Regression: a credential header (GitHub PAT / GHCR bearer) must NOT follow a
+# redirect off the origin's scheme+parent-domain.
+#
+# The bug: malt injected credentials through stdlib's `extra_headers`, which are
+# deliberately kept across a redirect to a different domain. GitHub release and
+# GHCR blob URLs 302 to object storage on another domain, so the secret rode the
+# hop and was re-sent verbatim to the CDN (and, on an https->http downgrade, to a
+# cleartext socket). stdlib's `privileged_headers` slot is never written to the
+# wire in this toolchain, so the fix takes over redirect-following and drops the
+# credential whenever the next hop changes scheme or leaves the parent domain.
+#
+# No CLI surface points a credentialed GET at an arbitrary URL, so the guard is
+# exercised by an integration test (loopback hop-1 302s to a different-host
+# hop-2 that records request headers; the test asserts the origin is still
+# authenticated but the cross-domain target sees no Authorization). This script
+# builds and runs only that test binary, so it stays well under 30s and needs no
+# network.
+#
+# Exits 0 when credentials are stripped on the cross-domain hop, non-zero when
+# they ride.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+TEST_NAME="auth headers stripped on redirect across a cross-domain hop"
+TEST_SRC="tests/net_redirect_auth_test.zig"
+
+# If the guard test is ever deleted, the runner would simply report "no tests"
+# and pass. Fail loudly instead.
+if ! grep -Rqs -- "$TEST_NAME" "$TEST_SRC"; then
+  echo "FAIL: the cross-domain auth-strip guard test is missing from $TEST_SRC" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/net_redirect_auth_test"
+if [[ ! -x "$BIN" ]]; then
+  if ! zig build test-bin >/dev/null 2>&1; then
+    echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+    exit 1
+  fi
+fi
+
+# The runner has no per-test filter, so run the file's suite and judge the
+# cross-domain guard by name: a pass ends in "OK", a regression prints "FAIL"
+# there (the credential rode to the off-domain target) and the binary exits
+# non-zero.
+OUT=$("$BIN" 2>&1 || true)
+LINE=$(printf '%s\n' "$OUT" | grep -F -- "$TEST_NAME" || true)
+if [[ -z "$LINE" ]]; then
+  echo "FAIL: the cross-domain auth-strip guard test did not run" >&2
+  printf '%s\n' "$OUT" >&2
+  exit 1
+fi
+if [[ "$LINE" != *OK ]]; then
+  echo "FAIL: a credential header rode a cross-domain redirect" >&2
+  printf '%s\n' "$OUT" >&2
+  exit 1
+fi
+
+echo "PASS: credential headers stripped across cross-domain / downgrade redirects"

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -347,6 +347,46 @@ pub const HttpClient = struct {
         return false;
     }
 
+    /// http(s) scheme of a malt URL, or null for non-http(s). Used to gate
+    /// whether a credential may follow a redirect — the scheme must match.
+    fn urlScheme(url: []const u8) ?[]const u8 {
+        if (std.mem.startsWith(u8, url, "https://")) return "https";
+        if (std.mem.startsWith(u8, url, "http://")) return "http";
+        return null;
+    }
+
+    /// Mirrors std `HostName.sameParentDomain`: true iff `child` is `parent`
+    /// or a dot-boundary subdomain of it (case-insensitive). A shared suffix
+    /// without a dot boundary (`evilgithub.com` vs `github.com`) is not a match.
+    fn hostIsSameOrSubdomain(parent: []const u8, child: []const u8) bool {
+        if (!std.ascii.endsWithIgnoreCase(child, parent)) return false;
+        if (child.len == parent.len) return true;
+        if (parent.len > child.len) return false;
+        return child[child.len - parent.len - 1] == '.';
+    }
+
+    /// Whether caller credentials/validators may survive a redirect `from`→`to`.
+    /// Faithful to stdlib's `keep_privileged_headers`: same scheme AND the new
+    /// host is the old host or a subdomain of it. Anything else drops the
+    /// headers so a GitHub PAT / GHCR bearer never reaches an off-domain CDN or
+    /// object store.
+    /// HTTP status codes malt follows as a redirect. Deliberately an explicit
+    /// set, not a `301..308` range: 304 (Not Modified) and 306 (unused) sit in
+    /// that range but are NOT redirects — treating 304 as one breaks every
+    /// conditional GET.
+    fn isFollowableRedirect(status: u16) bool {
+        return status == 301 or status == 302 or status == 303 or status == 307 or status == 308;
+    }
+
+    fn credsSurviveRedirect(from: []const u8, to: []const u8) bool {
+        const fs = urlScheme(from) orelse return false;
+        const ts = urlScheme(to) orelse return false;
+        if (!std.ascii.eqlIgnoreCase(fs, ts)) return false;
+        const fh = urlHost(from) orelse return false;
+        const th = urlHost(to) orelse return false;
+        return hostIsSameOrSubdomain(fh, th);
+    }
+
     /// GET request; auto-injects HOMEBREW_GITHUB_API_TOKEN as Authorization
     /// for GitHub/Homebrew hosts. Caller owns the returned `Response`.
     pub fn get(self: *HttpClient, url: []const u8) !Response {
@@ -696,52 +736,133 @@ pub const HttpClient = struct {
         url: []const u8,
         extra_headers: []const std.http.Header,
     ) !ConditionalResponse {
-        const uri = try std.Uri.parse(url);
-        const https_origin = schemeIsHttps(uri.scheme);
-
-        var req = try self.client.request(.GET, uri, .{ .extra_headers = extra_headers });
-        defer req.deinit();
-
-        try req.sendBodiless();
-
-        var redirect_buf: [32 * 1024]u8 = undefined;
-        var response = try req.receiveHead(&redirect_buf);
-
-        if (https_origin and !schemeIsHttps(req.uri.scheme))
-            return error.TlsDowngradeRefused;
-
-        const status: u16 = @intFromEnum(response.head.status);
-        // Etag is borrowed from response.head.bytes; dupe before the head
-        // buffer is dropped on function exit.
-        const etag_owned: ?[]const u8 = if (extractEtagFromHead(response.head.bytes)) |e|
-            try self.allocator.dupe(u8, e)
-        else
-            null;
-        errdefer if (etag_owned) |e| self.allocator.free(e);
-
-        // 304 has no body per HTTP spec — return immediately with an
-        // empty owned slice so deinit's `free(body)` stays uniform.
-        if (status == 304) {
-            const empty = try self.allocator.alloc(u8, 0);
-            return .{
-                .status = status,
-                .not_modified = true,
-                .body = empty,
-                .etag = etag_owned,
-                .allocator = self.allocator,
-            };
-        }
-
-        // Conditional GETs target tiny JSON, never blobs — pin both
-        // size cap and total timeout to the metadata constants.
-        const body = try self.readResponseBody(&req, &response, max_metadata_bytes, null, self.timeout_ns);
+        // Conditional GETs target tiny JSON, never blobs — the metadata cap
+        // and timeout follow from `max_metadata_bytes` inside `followGet`.
+        const out = try self.followGet(url, extra_headers, max_metadata_bytes, null, true);
         return .{
-            .status = status,
-            .not_modified = false,
-            .body = body,
-            .etag = etag_owned,
+            .status = out.status,
+            .not_modified = out.not_modified,
+            .body = out.body,
+            .etag = out.etag,
             .allocator = self.allocator,
         };
+    }
+
+    /// Max redirects followed on a credentialed GET — matches stdlib's default
+    /// so download depth is unchanged by taking over redirect handling.
+    const max_get_redirects: usize = 3;
+
+    const GetOutcome = struct {
+        status: u16,
+        body: []const u8,
+        etag: ?[]const u8,
+        not_modified: bool,
+    };
+
+    /// Resolve a redirect `Location` (absolute or relative) against `base`
+    /// into an owned absolute URL, dropping any userinfo. Uses std's own
+    /// resolver so relative targets behave exactly as stdlib's auto-follow did.
+    fn resolveRedirectUrl(self: *HttpClient, base: std.Uri, location: []const u8) ![]const u8 {
+        var buf: [8 * 1024]u8 = undefined;
+        if (location.len > buf.len) return error.HttpRedirectLocationOversize;
+        @memcpy(buf[0..location.len], location);
+        var aux: []u8 = buf[0..];
+        const resolved = base.resolveInPlace(location.len, &aux) catch
+            return error.HttpRedirectLocationInvalid;
+
+        var out: std.Io.Writer.Allocating = .init(self.allocator);
+        errdefer out.deinit();
+        resolved.writeToStream(&out.writer, .{
+            .scheme = true,
+            .authority = true,
+            .port = true,
+            .path = true,
+            .query = true,
+        }) catch return error.HttpRedirectLocationInvalid;
+        return try out.toOwnedSlice();
+    }
+
+    /// GET that follows redirects manually so credential/validator headers are
+    /// stripped before leaving the origin's scope. In Zig 0.16 stdlib,
+    /// `extra_headers` ride every redirect and `privileged_headers` are never
+    /// sent at all — neither slot both authenticates the origin and drops on a
+    /// cross-domain hop, so we own the loop. Credentials survive a hop only
+    /// when scheme and parent domain are preserved; an https→http downgrade is
+    /// refused outright (the secret would otherwise hit a cleartext socket and
+    /// the plaintext body could be substituted).
+    fn followGet(
+        self: *HttpClient,
+        url: []const u8,
+        creds: []const std.http.Header,
+        max_bytes: usize,
+        progress: ?ProgressCallback,
+        capture_etag: bool,
+    ) !GetOutcome {
+        var current: []const u8 = try self.allocator.dupe(u8, url);
+        defer self.allocator.free(current);
+        var live_creds = creds;
+        var hops: usize = 0;
+
+        while (true) : (hops += 1) {
+            const uri = try std.Uri.parse(current);
+            const https_origin = schemeIsHttps(uri.scheme);
+
+            var req = try self.client.request(.GET, uri, .{
+                .extra_headers = live_creds,
+                .redirect_behavior = .unhandled,
+            });
+            errdefer req.deinit();
+
+            try req.sendBodiless();
+            var redirect_buf: [32 * 1024]u8 = undefined;
+            var response = try req.receiveHead(&redirect_buf);
+            const status: u16 = @intFromEnum(response.head.status);
+
+            if (isFollowableRedirect(status)) {
+                // A redirect without a Location is malformed — fail loud rather
+                // than hand the redirect's body back to the caller as a "success".
+                const loc = response.head.location orelse return error.HttpRedirectLocationMissing;
+                if (hops >= max_get_redirects) return error.TooManyHttpRedirects;
+                const next = try self.resolveRedirectUrl(uri, loc);
+                errdefer self.allocator.free(next);
+                const next_uri = std.Uri.parse(next) catch return error.HttpRedirectLocationInvalid;
+                if (https_origin and !schemeIsHttps(next_uri.scheme))
+                    return error.TlsDowngradeRefused;
+                if (!credsSurviveRedirect(current, next)) live_creds = &.{};
+                // Hop committed: no fallible op past here, so the errdefers
+                // stay dormant while we hand `req`/`current` off cleanly.
+                req.deinit();
+                self.allocator.free(current);
+                current = next;
+                continue;
+            }
+
+            // Terminal response. Etag is borrowed from the head buffer; dupe it
+            // before the body read drops that buffer. `req`'s errdefer covers
+            // every error path below; on a value return we deinit explicitly.
+            var etag_owned: ?[]const u8 = null;
+            errdefer if (etag_owned) |e| self.allocator.free(e);
+            if (capture_etag) {
+                if (extractEtagFromHead(response.head.bytes)) |e|
+                    etag_owned = try self.allocator.dupe(u8, e);
+            }
+
+            // 304 has no body per HTTP spec — empty owned slice keeps deinit's
+            // `free(body)` uniform.
+            if (status == 304) {
+                const empty = try self.allocator.alloc(u8, 0);
+                req.deinit();
+                return .{ .status = status, .body = empty, .etag = etag_owned, .not_modified = true };
+            }
+
+            const total_timeout = if (max_bytes > max_metadata_bytes)
+                @max(blob_timeout_ns, scaledTimeoutNs(response.head.content_length))
+            else
+                self.timeout_ns;
+            const body = try self.readResponseBody(&req, &response, max_bytes, progress, total_timeout);
+            req.deinit();
+            return .{ .status = status, .body = body, .etag = etag_owned, .not_modified = false };
+        }
     }
 
     fn doGetWithRetry(
@@ -790,39 +911,10 @@ pub const HttpClient = struct {
         max_bytes: usize,
         progress: ?ProgressCallback,
     ) !Response {
-        const uri = try std.Uri.parse(url);
-        const https_origin = schemeIsHttps(uri.scheme);
-
-        var req = try self.client.request(.GET, uri, .{
-            .extra_headers = extra_headers,
-        });
-        defer req.deinit();
-
-        try req.sendBodiless();
-
-        // 32 KiB header buffer — see `head()`.
-        var redirect_buf: [32 * 1024]u8 = undefined;
-        var response = try req.receiveHead(&redirect_buf);
-
-        // Refuse https → http downgrade across 3xx — plaintext bodies are
-        // a metadata-substitution vector even with stdlib header stripping.
-        if (https_origin and !schemeIsHttps(req.uri.scheme))
-            return error.TlsDowngradeRefused;
-
-        const status: u16 = @intFromEnum(response.head.status);
-
-        // Blob downloads scale the total deadline from the projected
-        // transfer time; metadata reads keep the per-request constant.
-        // Idle-timeout backstop lives inside `readResponseBody`.
-        const total_timeout = if (max_bytes > max_metadata_bytes)
-            @max(blob_timeout_ns, scaledTimeoutNs(response.head.content_length))
-        else
-            self.timeout_ns;
-        const body = try self.readResponseBody(&req, &response, max_bytes, progress, total_timeout);
-
+        const out = try self.followGet(url, extra_headers, max_bytes, progress, false);
         return .{
-            .status = status,
-            .body = body,
+            .status = out.status,
+            .body = out.body,
             .allocator = self.allocator,
         };
     }
@@ -1270,4 +1362,47 @@ test "watchdogLoop: fires on cancellation predicate" {
     };
     const fired = watchdogLoop(io, wake.read_fd, &bytes, 10 * std.time.ns_per_s, 10 * std.time.ns_per_s, &Stub.cancel);
     try std.testing.expect(fired);
+}
+
+// --- credential strip across redirects (keep_privileged_headers parity) ---
+
+test "credsSurviveRedirect: kept on the same host and scheme" {
+    try std.testing.expect(HttpClient.credsSurviveRedirect("https://github.com/a", "https://github.com/b"));
+}
+
+test "credsSurviveRedirect: kept descending to a subdomain of the origin" {
+    try std.testing.expect(HttpClient.credsSurviveRedirect("https://github.com/a", "https://api.github.com/b"));
+}
+
+test "credsSurviveRedirect: dropped on a cross parent-domain hop" {
+    try std.testing.expect(!HttpClient.credsSurviveRedirect("https://github.com/x", "https://objects.githubusercontent.com/y"));
+}
+
+test "credsSurviveRedirect: dropped when ascending to a broader host" {
+    try std.testing.expect(!HttpClient.credsSurviveRedirect("https://api.github.com/x", "https://github.com/y"));
+}
+
+test "credsSurviveRedirect: dropped on https to http downgrade" {
+    try std.testing.expect(!HttpClient.credsSurviveRedirect("https://github.com/x", "http://github.com/y"));
+}
+
+test "credsSurviveRedirect: dropped for a look-alike suffix without a dot boundary" {
+    try std.testing.expect(!HttpClient.credsSurviveRedirect("https://github.com/x", "https://evilgithub.com/y"));
+}
+
+test "isFollowableRedirect: follows 301/302/303/307/308" {
+    for ([_]u16{ 301, 302, 303, 307, 308 }) |s|
+        try std.testing.expect(HttpClient.isFollowableRedirect(s));
+}
+
+test "isFollowableRedirect: never follows 304 Not Modified or 306" {
+    // 304 sits inside 301..308 but must fall through to the conditional-GET
+    // handler, not the redirect path.
+    try std.testing.expect(!HttpClient.isFollowableRedirect(304));
+    try std.testing.expect(!HttpClient.isFollowableRedirect(306));
+}
+
+test "isFollowableRedirect: ignores 2xx/300/305 and other statuses" {
+    for ([_]u16{ 200, 204, 300, 305, 400, 404, 500 }) |s|
+        try std.testing.expect(!HttpClient.isFollowableRedirect(s));
 }

--- a/tests/net_redirect_auth_test.zig
+++ b/tests/net_redirect_auth_test.zig
@@ -1,0 +1,170 @@
+//! malt — offline integration test: a credential header must not follow a
+//! cross-domain redirect, but must still reach the origin and survive a
+//! same-host redirect. Two loopback `std.http.Server` hops on distinct host
+//! strings (so stdlib's `sameParentDomain` is false) let us assert the strip
+//! without any TLS fixture.
+
+const std = @import("std");
+const client = @import("malt").client;
+const net = std.Io.net;
+
+const auth_value = "token SECRET-PAT";
+const blob_body = "the-protected-blob";
+
+const Hop = struct {
+    io: std.Io,
+    listener: *net.Server,
+    saw_auth: bool = false,
+    // Request-line target the hop received (path+query), copied out of the
+    // per-request read buffer so it outlives `serveOne`.
+    target_buf: [512]u8 = undefined,
+    target_len: usize = 0,
+    // When set, answer 302 to this Location; otherwise 200 with `blob_body`.
+    redirect_to: ?[]const u8 = null,
+};
+
+// Serves exactly one request. Records whether the client sent Authorization and
+// the request target, then either redirects or returns the blob. Errors are
+// swallowed: a failed serve surfaces as a client-side failure the test asserts on.
+fn serveOne(hop: *Hop) void {
+    const stream = hop.listener.accept(hop.io) catch return;
+    defer stream.close(hop.io);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var reader = stream.reader(hop.io, &rbuf);
+    var writer = stream.writer(hop.io, &wbuf);
+    var srv = std.http.Server.init(&reader.interface, &writer.interface);
+    var req = srv.receiveHead() catch return;
+    const target = req.head.target;
+    if (target.len <= hop.target_buf.len) {
+        @memcpy(hop.target_buf[0..target.len], target);
+        hop.target_len = target.len;
+    }
+    var it = req.iterateHeaders();
+    while (it.next()) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, "authorization")) hop.saw_auth = true;
+    }
+    if (hop.redirect_to) |loc| {
+        // A non-empty 302 body exercises the redirect-body drain on hop teardown.
+        req.respond("redirecting\n", .{
+            .status = .found,
+            .extra_headers = &.{.{ .name = "location", .value = loc }},
+        }) catch return;
+    } else {
+        req.respond(blob_body, .{}) catch return;
+    }
+}
+
+fn hopTarget(hop: *const Hop) []const u8 {
+    return hop.target_buf[0..hop.target_len];
+}
+
+fn bindIp4(io: std.Io) !net.Server {
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    return try addr.listen(io, .{ .reuse_address = true });
+}
+
+fn bindIp6(io: std.Io) !net.Server {
+    var addr = try net.IpAddress.parseIp6("::1", 0);
+    return try addr.listen(io, .{ .reuse_address = true });
+}
+
+test "auth headers stripped on redirect across a cross-domain hop" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // hop2 on ::1, named by "localhost" in the redirect target so its host
+    // string differs from hop1's "127.0.0.1" (stdlib's same-parent-domain check
+    // is false → strip). "localhost" resolves to both ::1 and 127.0.0.1 and the
+    // client tries every address, so it reaches the ::1-bound hop regardless of
+    // which family the resolver lists first.
+    var l2 = try bindIp6(io);
+    defer l2.deinit(io);
+    const p2 = l2.socket.address.getPort();
+    var hop2 = Hop{ .io = io, .listener = &l2 };
+    const t2 = try std.Thread.spawn(.{}, serveOne, .{&hop2});
+
+    // Redirect to a signed-URL-style target: the path and its percent-encoded
+    // query must reach hop2 byte-exact (a CDN/object-store signature breaks if
+    // the resolve→reissue round-trip mangles it).
+    const blob_target = "/blob/sha256:abc?X-Amz-Signature=9f86d081&X-Amz-Credential=AKIA%2Fus-east-1%2Fs3&token=v2%3Dfoo%2Bbar%3D%3D";
+    var loc_buf: [256]u8 = undefined;
+    const loc = try std.fmt.bufPrint(&loc_buf, "http://localhost:{d}{s}", .{ p2, blob_target });
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+    var hop1 = Hop{ .io = io, .listener = &l1, .redirect_to = loc };
+    const t1 = try std.Thread.spawn(.{}, serveOne, .{&hop1});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/start", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    const headers = [_]std.http.Header{.{ .name = "Authorization", .value = auth_value }};
+    const result = http.getWithHeaders(url, &headers, null);
+
+    // Both hops always complete the chain (pre- and post-fix), so joining
+    // never hangs; join before reading server-side state.
+    t1.join();
+    t2.join();
+
+    var resp = try result;
+    defer resp.deinit();
+
+    try std.testing.expectEqual(@as(u16, 200), resp.status);
+    try std.testing.expectEqualStrings(blob_body, resp.body);
+    // The origin must still be authenticated…
+    try std.testing.expect(hop1.saw_auth);
+    // …but the credential must not ride to the cross-domain target.
+    try std.testing.expect(!hop2.saw_auth);
+    // …and the signed path+query must survive the redirect intact.
+    try std.testing.expectEqualStrings(blob_target, hopTarget(&hop2));
+}
+
+test "auth headers kept across a same-host redirect" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // hop2 on the SAME host (127.0.0.1), different port — same parent domain
+    // and scheme, so the credential is preserved (e.g. github.com → github.com).
+    var l2 = try bindIp4(io);
+    defer l2.deinit(io);
+    const p2 = l2.socket.address.getPort();
+    var hop2 = Hop{ .io = io, .listener = &l2 };
+    const t2 = try std.Thread.spawn(.{}, serveOne, .{&hop2});
+
+    var loc_buf: [64]u8 = undefined;
+    const loc = try std.fmt.bufPrint(&loc_buf, "http://127.0.0.1:{d}/blob", .{p2});
+
+    var l1 = try bindIp4(io);
+    defer l1.deinit(io);
+    const p1 = l1.socket.address.getPort();
+    var hop1 = Hop{ .io = io, .listener = &l1, .redirect_to = loc };
+    const t1 = try std.Thread.spawn(.{}, serveOne, .{&hop1});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/start", .{p1});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    const headers = [_]std.http.Header{.{ .name = "Authorization", .value = auth_value }};
+    const result = http.getWithHeaders(url, &headers, null);
+
+    t1.join();
+    t2.join();
+
+    var resp = try result;
+    defer resp.deinit();
+
+    try std.testing.expectEqual(@as(u16, 200), resp.status);
+    try std.testing.expect(hop1.saw_auth);
+    try std.testing.expect(hop2.saw_auth);
+}


### PR DESCRIPTION
## Description

This change makes the credentialed GET path follow redirects itself instead of letting the transport auto-follow. A credential survives a hop only when the scheme and parent domain are preserved (the origin's own subdomains); it is dropped before any cross-domain hop, and an `https→http` downgrade is refused outright (the secret would otherwise hit a cleartext socket and the plaintext body could be substituted). The common non-redirecting request takes the same single-request path as before. Redirect depth and the existing downgrade refusal are unchanged.

## Related Issue

- None

## Notes for Reviewers

- None