### PR TITLE
fix(cask): reject path traversal in cask token and version

### DIFF
--- a/scripts/regressions/cask-token-version-unsanitized-path-traversal.sh
+++ b/scripts/regressions/cask-token-version-unsanitized-path-traversal.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Regression: a cask whose JSON `token` or `version` carries a path-traversal
+# payload must be rejected at parse time, before either field reaches a
+# filesystem sink.
+#
+# The bug: parseCask copied `token` and `version` verbatim out of the cask
+# JSON with no predicate between parse and use. Both are interpolated as raw
+# path components downstream — the cache dest `<cache>/<token>-<version><ext>`,
+# the DMG mount `<prefix>/tmp/cask_mount_<token>`, `Caskroom/<token>/<version>`,
+# and on uninstall `deleteTree("<prefix>/Caskroom/<token>")`. A `..` or `/` in
+# either field is honoured by the kernel as a real path hop, so a compromised
+# or third-party tap could write the artifact, the Caskroom, or a privileged
+# installer target outside the prefix — and later delete outside it.
+#
+# The fix adds one traversal guard in parseCask, at the single ingestion choke
+# point, that rejects an empty value, `.`/`..`, or an embedded `/`, `..`, or
+# NUL in `token` or `version` (charset-agnostic so real versions still pass).
+#
+# No CLI surface drives parseCask offline without standing up a local tap, and
+# the guard fires before any download, so it is exercised by the colocated unit
+# tests in the inline suite (`lib_tests`). This script builds and runs only that
+# binary: it stays well under 30s and needs no network. A pass means every
+# inline test — including the traversal-rejection guard — held; a regression
+# flips that binary to a non-zero exit.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+SRC="src/core/cask.zig"
+TEST_NAME="parseCask rejects path-traversal in token or version"
+
+# If the guard or its test is ever dropped, the unit binary would go green
+# vacuously. Fail loudly instead: both the predicate call and the test must be
+# present in the source.
+if ! grep -Fqs -- "$TEST_NAME" "$SRC"; then
+  echo "FAIL: the traversal-rejection guard test is missing from $SRC" >&2
+  exit 1
+fi
+if ! grep -Fqs -- "isPathComponent" "$SRC"; then
+  echo "FAIL: the parseCask path-component guard is missing from $SRC" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+# Always rebuild so the binary reflects current source — a prebuilt
+# lib_tests could predate the guard. Zig's cache makes a no-op rebuild
+# cheap, so this stays well under the time budget.
+if ! zig build test-bin >/dev/null 2>&1; then
+  echo "FAIL: could not build the unit test binary (zig build test-bin)" >&2
+  exit 1
+fi
+
+# The runner has no per-test filter, so run the inline suite and judge by its
+# summary line and exit code. Pre-fix, parseCask accepts the traversal payloads
+# the guard test feeds it, so that test fails and the binary exits non-zero.
+OUT=$("$BIN" 2>&1) && STATUS=0 || STATUS=$?
+if [[ "$STATUS" -ne 0 ]]; then
+  echo "FAIL: cask token/version traversal was accepted at parse time" >&2
+  printf '%s\n' "$OUT" | grep -iE "failed|leaked|panic" >&2 || true
+  exit 1
+fi
+
+echo "PASS: cask token/version path-traversal rejected before any path use"

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -57,10 +57,18 @@ pub fn parseCask(allocator: std.mem.Allocator, json_bytes: []const u8) !Cask {
 
     const obj = parsed.value.object;
 
+    const token = getStr(obj, "token") orelse return CaskError.ParseFailed;
+    const version = getStr(obj, "version") orelse "unknown";
+    // `token` and `version` are interpolated verbatim into Caskroom,
+    // cache, and mount paths, so a value that escapes its own path
+    // component must be rejected here — the one ingestion choke point —
+    // before any sink sees it. A compromised tap is the threat.
+    if (!isPathComponent(token) or !isPathComponent(version)) return CaskError.ParseFailed;
+
     return .{
-        .token = getStr(obj, "token") orelse return CaskError.ParseFailed,
-        .name = getFirstName(obj) orelse getStr(obj, "token") orelse return CaskError.ParseFailed,
-        .version = getStr(obj, "version") orelse "unknown",
+        .token = token,
+        .name = getFirstName(obj) orelse token,
+        .version = version,
         .desc = getStr(obj, "desc") orelse "",
         .homepage = getStr(obj, "homepage") orelse "",
         .url = getStr(obj, "url") orelse return CaskError.ParseFailed,
@@ -1404,6 +1412,20 @@ pub fn isInstalled(db: *sqlite.Database, token: []const u8) bool {
 
 // --- JSON helpers ---
 
+/// True when `s` is a single, safe path segment. Charset-agnostic on
+/// purpose: real cask versions carry uppercase, commas, and colons that
+/// an allowlist would wrongly reject, so this only bars the shapes that
+/// hop out of a path component — empty, `.`/`..`, an embedded `/` or
+/// `..`, or a NUL the kernel reads as a string terminator.
+fn isPathComponent(s: []const u8) bool {
+    if (s.len == 0) return false;
+    if (std.mem.eql(u8, s, ".") or std.mem.eql(u8, s, "..")) return false;
+    if (std.mem.indexOfScalar(u8, s, '/') != null) return false;
+    if (std.mem.indexOf(u8, s, "..") != null) return false;
+    if (std.mem.indexOfScalar(u8, s, 0) != null) return false;
+    return true;
+}
+
 fn getStr(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
     const val = obj.get(key) orelse return null;
     return switch (val) {
@@ -1435,4 +1457,75 @@ fn getFirstName(obj: std.json.ObjectMap) ?[]const u8 {
         .string => |s| return s,
         else => return null,
     }
+}
+
+test "parseCask rejects path-traversal in token or version" {
+    const a = std.testing.allocator;
+    // Each carries a `/`, `..`, lone `.`, or NUL in `token` or `version` —
+    // all of which become raw path segments downstream. The `\u0000`
+    // sequences are JSON escapes the parser turns into real NUL bytes.
+    const bad = [_][]const u8{
+        \\{"token":"ev/../x","version":"1.0","url":"https://e/x.dmg"}
+        ,
+        \\{"token":"a/b","version":"1.0","url":"https://e/x.dmg"}
+        ,
+        \\{"token":"..","version":"1.0","url":"https://e/x.dmg"}
+        ,
+        \\{"token":".","version":"1.0","url":"https://e/x.dmg"}
+        ,
+        \\{"token":"","version":"1.0","url":"https://e/x.dmg"}
+        ,
+        \\{"token":"ok","version":"","url":"https://e/x.dmg"}
+        ,
+        \\{"token":"ok","version":"1.0/../../../../tmp/x","url":"https://e/x.dmg"}
+        ,
+        \\{"token":"a..b","version":"1.0","url":"https://e/x.dmg"}
+        ,
+        \\{"token":"ok","version":"a..b","url":"https://e/x.dmg"}
+        ,
+        \\{"token":"ok\u0000x","version":"1.0","url":"https://e/x.dmg"}
+        ,
+        \\{"token":"ok","version":"1.0\u0000","url":"https://e/x.dmg"}
+        ,
+    };
+    for (bad) |json| {
+        try std.testing.expectError(error.ParseFailed, parseCask(a, json));
+    }
+}
+
+test "parseCask accepts legitimate token and version" {
+    const a = std.testing.allocator;
+    // The guard is charset-agnostic, so real versions an allowlist would
+    // reject — uppercase, comma, colon, space — must survive, and the
+    // absent-version `"unknown"` default must too.
+    const ok = [_][]const u8{
+        \\{"token":"google-chrome","version":"1.2.3,400","url":"https://e/x.dmg"}
+        ,
+        \\{"token":"firefox","version":"2.0:1 (Beta)","url":"https://e/x.dmg"}
+        ,
+        \\{"token":"firefox","url":"https://e/x.dmg"}
+        ,
+    };
+    for (ok) |json| {
+        var cask = try parseCask(a, json);
+        cask.deinit();
+    }
+}
+
+test "parseCask does not length-cap a clean version" {
+    const a = std.testing.allocator;
+    // Versions have no length convention, so the guard must stay length-
+    // agnostic — this locks out a future regression that grows an
+    // over-eager cap and rejects a long but otherwise-clean version.
+    var ver: [200]u8 = undefined;
+    @memset(&ver, '9');
+    const json = try std.fmt.allocPrint(
+        a,
+        \\{{"token":"firefox","version":"{s}","url":"https://e/x.dmg"}}
+    ,
+        .{ver},
+    );
+    defer a.free(json);
+    var cask = try parseCask(a, json);
+    cask.deinit();
 }


### PR DESCRIPTION
## Description 

This adds one traversal guard at `parseCask`, the single ingestion choke point, so every downstream sink is covered without per-call-site edits. The predicate is charset-agnostic: it rejects only empty, `.`/`..`, an embedded `/` or `..`, or a NUL, so real cask versions (uppercase, commas, colons, spaces) and the absent-version `"unknown"` default still parse.

## Related Issue

- None

## Notes for Reviewers

- None