### PR TITLE
fix(macho): reject fat slice bounds that overflow 32-bit arithmetic

### DIFF
--- a/scripts/regressions/parsefat-u32-bounds-check-overflow.sh
+++ b/scripts/regressions/parsefat-u32-bounds-check-overflow.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Regression: a fat header whose fat_arch offset+size overflows 32-bit
+# arithmetic must be rejected with a clean ParseError.TruncatedFile, not a
+# panic (safe builds) or an out-of-bounds slice (ReleaseFast).
+#
+# The bug: parseFat read the slice offset and size as u32 and computed both
+# the bounds check (offset+size > data.len) and the slice expression in u32.
+# A crafted offset+size summing past 0xFFFFFFFF wrapped to a small value: in
+# Debug/ReleaseSafe the add panicked (integer overflow → SIGABRT, which the
+# patcher's `catch` cannot contain — a DoS on a malicious-tap bottle); in
+# ReleaseFast the wrapped sum passed the guard and produced an illegal
+# start>end slice. The input is fully untrusted bottle bytes from a tap.
+#
+# The fix widens both fields to usize at the read site. Both are ≤ 2³², so
+# their sum fits a 64-bit usize and the bounds check stays honest.
+#
+# No CLI surface drives parseFat offline without standing up a tap, so the
+# guard is exercised by the colocated integration test in tests/macho_test.zig
+# (the `macho_test` binary). This script builds and runs only that binary: it
+# stays well under 30s and needs no network. Pre-fix the overflow test panics
+# and aborts the binary (non-zero exit); post-fix it returns the expected
+# error and the suite is green.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+SRC="tests/macho_test.zig"
+TEST_NAME="parse rejects a fat slice whose offset+size overflows 32 bits"
+
+# If the test is ever dropped, the binary would go green vacuously. Fail loudly.
+if ! grep -Fqs -- "$TEST_NAME" "$SRC"; then
+  echo "FAIL: the fat-slice overflow guard test is missing from $SRC" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/macho_test"
+# Always rebuild so the binary reflects current source — a prebuilt binary
+# could predate the fix. Zig's cache makes a no-op rebuild cheap.
+if ! zig build test-bin >/dev/null 2>&1; then
+  echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+  exit 1
+fi
+
+# The runner has no per-test filter, so run the suite and judge by exit code.
+# Pre-fix, parseFat panics on the overflowing offset+size and the process is
+# killed by a signal (exit > 128), so the suite exits non-zero.
+OUT=$("$BIN" 2>&1) && STATUS=0 || STATUS=$?
+if [[ "$STATUS" -ne 0 ]]; then
+  echo "FAIL: parseFat panicked or admitted an out-of-bounds fat slice on u32 overflow" >&2
+  printf '%s\n' "$OUT" | grep -iE "failed|leaked|panic|overflow" >&2 || true
+  exit 1
+fi
+
+echo "PASS: parseFat rejects a u32-overflowing fat slice with a clean error"

--- a/src/macho/parser.zig
+++ b/src/macho/parser.zig
@@ -113,8 +113,11 @@ fn parseFat(allocator: std.mem.Allocator, data: []const u8) ParseError!MachO {
         if (offset + 20 > data.len) return ParseError.TruncatedFile;
 
         // fat_arch layout: cputype(4), cpusubtype(4), offset(4), size(4), align(4).
-        const slice_offset = std.mem.readInt(u32, data[offset + 8 ..][0..4], .big);
-        const slice_size = std.mem.readInt(u32, data[offset + 12 ..][0..4], .big);
+        // Widen to usize: both fields are ≤ 2³², so their sum can't overflow a
+        // 64-bit usize and the bounds check below stays honest. In u32 a crafted
+        // offset+size wraps and bypasses the guard.
+        const slice_offset: usize = std.mem.readInt(u32, data[offset + 8 ..][0..4], .big);
+        const slice_size: usize = std.mem.readInt(u32, data[offset + 12 ..][0..4], .big);
 
         offset += 20;
 

--- a/tests/macho_test.zig
+++ b/tests/macho_test.zig
@@ -190,6 +190,19 @@ test "parse rejects a fat archive whose slice extends beyond data" {
     try testing.expectError(parser.ParseError.TruncatedFile, parser.parse(testing.allocator, &buf));
 }
 
+test "parse rejects a fat slice whose offset+size overflows 32 bits" {
+    // offset + size wraps past 0xFFFFFFFF: a u32 bounds check sees a small
+    // sum and either panics on overflow (safe builds) or admits an illegal
+    // start>end slice (ReleaseFast). Must surface as a clean TruncatedFile.
+    var buf: [28]u8 = undefined;
+    @memset(&buf, 0);
+    std.mem.writeInt(u32, buf[0..4], macho.FAT_MAGIC, .big);
+    std.mem.writeInt(u32, buf[4..8], 1, .big); // nfat_arch = 1
+    std.mem.writeInt(u32, buf[16..20], 0xFFFFFF00, .big); // slice offset
+    std.mem.writeInt(u32, buf[20..24], 0x200, .big); // slice size
+    try testing.expectError(parser.ParseError.TruncatedFile, parser.parse(testing.allocator, &buf));
+}
+
 test "parse bubbles InvalidLoadCommand from a corrupt fat slice" {
     // A fat archive whose only slice is a Mach-O 64 with a bogus load
     // command (cmdsize < sizeof(load_command)). The parser must surface


### PR DESCRIPTION
## Description

`parseFat` computed a fat slice's bounds check and slice in `u32`, so a crafted `offset + size` overflowing 32 bits panicked safe builds (uncatchable abort → DoS) or yielded an out-of-bounds slice in ReleaseFast. Widen both fields to `usize` at the read site; the sum can no longer wrap. Adds a unit test and a regression guard.

## Related Issue

- None

## Notes for Reviewers

- None