### PR TITLE
fix(dsl): confine cp/mv/cp_r source paths to the keg

### DIFF
--- a/scripts/regressions/dsl-mv-cp-validate-only-destination.sh
+++ b/scripts/regressions/dsl-mv-cp-validate-only-destination.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Regression: the copy/move DSL builtins must confine their SOURCE path to the
+# keg, not only their destination.
+#
+# The bug: `mv`/`cp`/`cp_r` validated only the destination argument and passed
+# the source straight to `renameAbsolute`/`copyFileAbsolute`. A formula could
+# `mv` an out-of-keg file into the keg (rename unlinks the original), or
+# `cp`/`cp_r` an arbitrary readable file — or a keg-planted symlink pointing
+# outside — into the keg and `.read` it back, exfiltrating its contents. The
+# destination guard says where bytes land; it says nothing about where bytes
+# come from.
+#
+# No CLI subcommand exposes a raw copy/move builtin in isolation, so the guard
+# is exercised by colocated `test {}` blocks that plant the out-of-keg source
+# (direct path and via symlink), call the builtin, and assert both rejection
+# and that nothing escaped or was read in. This script builds the colocated
+# test binary and runs those tests by name; it exits non-zero if a guard
+# regresses or a test goes missing.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s once the test binary is built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+SRC="$ROOT/src/core/dsl/builtins/fileutils.zig"
+
+# The guards live in colocated `test {}` blocks; if any is ever deleted the
+# name filter below would match nothing and silently pass. Fail loudly instead.
+FILTERS=(
+  "mv refuses to move a source from outside the keg"
+  "cp refuses to copy a source from outside the keg"
+  "cp refuses to read through a source symlink out of the keg"
+)
+for F in "${FILTERS[@]}"; do
+  if ! grep -Rqs -- "$F" "$SRC"; then
+    echo "FAIL: source-confinement guard test missing: $F" >&2
+    exit 1
+  fi
+done
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+if [[ ! -x "$BIN" ]]; then
+  (cd "$ROOT" && zig build test-bin >/dev/null 2>&1) || {
+    echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+    exit 1
+  }
+fi
+
+# The runner has no per-test filter, so run the colocated suite and judge only
+# these guards' lines: a pass ends in "OK", a regression prints the failure there.
+OUT=$("$BIN" 2>&1 || true)
+for F in "${FILTERS[@]}"; do
+  LINE=$(printf '%s\n' "$OUT" | grep -F -- "$F" || true)
+  if [[ -z "$LINE" ]]; then
+    echo "FAIL: source-confinement guard test did not run: $F" >&2
+    exit 1
+  fi
+  if [[ "$LINE" != *OK ]]; then
+    echo "FAIL: a copy/move builtin read or moved an out-of-keg source: $F" >&2
+    exit 1
+  fi
+done
+
+echo "PASS: cp/mv/cp_r source paths confined to the keg"

--- a/src/core/dsl/builtins/fileutils.zig
+++ b/src/core/dsl/builtins/fileutils.zig
@@ -88,12 +88,16 @@ pub fn cp(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
                 const src = item.asString(ctx.allocator) catch continue;
                 const base = std.fs.path.basename(src);
                 const dest_path = std.fs.path.join(ctx.allocator, &.{ dst, base }) catch continue;
-                std.Io.Dir.copyFileAbsolute(src, dest_path, ctx.io, .{}) catch {};
+                // Best-effort per entry: a forbidden/out-of-keg source is skipped.
+                copyFileConfined(ctx.io, src, dest_path, ctx.cellar_path, ctx.malt_prefix) catch continue;
             }
         },
         else => {
             const src = args[0].asString(ctx.allocator) catch return Value{ .nil = {} };
-            std.Io.Dir.copyFileAbsolute(src, dst, ctx.io, .{}) catch {};
+            copyFileConfined(ctx.io, src, dst, ctx.cellar_path, ctx.malt_prefix) catch |e| switch (e) {
+                error.PathSandboxViolation => return BuiltinError.PathSandboxViolation,
+                error.NotRegularFile => {}, // a directory src is a silent no-op for cp, as before
+            };
         },
     }
     return Value{ .nil = {} };
@@ -107,10 +111,11 @@ pub fn cpR(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     sandbox.validateWriteDir(ctx.io, dst, ctx.cellar_path, ctx.malt_prefix) catch
         return BuiltinError.PathSandboxViolation;
 
-    // Try as single file first
-    std.Io.Dir.copyFileAbsolute(src, dst, ctx.io, .{}) catch {
-        // Try as directory: walk and copy
-        copyDirRecursive(ctx.io, ctx.allocator, src, dst, ctx.cellar_path, ctx.malt_prefix) catch {};
+    // Try as a single file (no-follow read confines the source leaf); a
+    // directory falls through to the recursive walk, which confines each level.
+    copyFileConfined(ctx.io, src, dst, ctx.cellar_path, ctx.malt_prefix) catch |e| switch (e) {
+        error.PathSandboxViolation => return BuiltinError.PathSandboxViolation,
+        error.NotRegularFile => copyDirRecursive(ctx.io, ctx.allocator, src, dst, ctx.cellar_path, ctx.malt_prefix) catch {},
     };
     return Value{ .nil = {} };
 }
@@ -120,7 +125,16 @@ pub fn mv(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     if (args.len < 2) return Value{ .nil = {} };
     const src = try args[0].asString(ctx.allocator);
     const dst = try args[1].asString(ctx.allocator);
-    sandbox.validatePath(dst, ctx.cellar_path, ctx.malt_prefix) catch
+    // Resolve the dest's parent too, so an intermediate-directory symlink can't
+    // pull the move out of the keg; rename replaces a final-component symlink
+    // atomically without following it.
+    sandbox.validateWriteDir(ctx.io, dst, ctx.cellar_path, ctx.malt_prefix) catch
+        return BuiltinError.PathSandboxViolation;
+    // Confine the source too: rename unlinks the source dir-entry, so an
+    // unchecked src is an out-of-keg destroy/relocate primitive. validateWriteDir
+    // rejects a direct out-of-keg src and an intermediate-directory symlink; a
+    // final-component symlink src is fine — rename relinks the link itself.
+    sandbox.validateWriteDir(ctx.io, src, ctx.cellar_path, ctx.malt_prefix) catch
         return BuiltinError.PathSandboxViolation;
     std.Io.Dir.renameAbsolute(src, dst, ctx.io) catch {};
     return Value{ .nil = {} };
@@ -375,6 +389,482 @@ test "cp_r refuses a symlink planted deep in the dest subtree" {
     try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, escaped, .{}));
 }
 
+test "mv refuses to move a source from outside the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const secret = try std.fs.path.join(alloc, &.{ base, "secret" }); // out of keg
+    defer alloc.free(secret);
+    const dst = try std.fs.path.join(alloc, &.{ keg, "loot" });
+    defer alloc.free(dst);
+
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    {
+        const sf = try std.Io.Dir.createFileAbsolute(io, secret, .{});
+        defer sf.close(io);
+        try sf.writeStreamingAll(io, "classified");
+    }
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        mv(ctx, null, &.{ Value{ .string = secret }, Value{ .string = dst } }),
+    );
+    // rename (a destroy/relocate primitive) never fired: the out-of-keg source
+    // still exists where it was, and nothing landed in the keg.
+    try std.Io.Dir.cwd().access(io, secret, .{});
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, dst, .{}));
+}
+
+test "mv moves a regular file within the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const keg = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const src = try std.fs.path.join(alloc, &.{ keg, "a.txt" });
+    defer alloc.free(src);
+    const dst = try std.fs.path.join(alloc, &.{ keg, "b.txt" });
+    defer alloc.free(dst);
+    {
+        const sf = try std.Io.Dir.createFileAbsolute(io, src, .{});
+        defer sf.close(io);
+        try sf.writeStreamingAll(io, "data");
+    }
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    _ = try mv(ctx, null, &.{ Value{ .string = src }, Value{ .string = dst } });
+
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, src, .{}));
+    var rb: [8]u8 = undefined;
+    const df = try std.Io.Dir.openFileAbsolute(io, dst, .{});
+    defer df.close(io);
+    try std.testing.expectEqualStrings("data", rb[0..try df.readPositionalAll(io, &rb, 0)]);
+}
+
+test "cp refuses to copy a source from outside the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const secret = try std.fs.path.join(alloc, &.{ base, "secret" }); // out of keg
+    defer alloc.free(secret);
+    const dst = try std.fs.path.join(alloc, &.{ keg, "leak" });
+    defer alloc.free(dst);
+
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    {
+        const sf = try std.Io.Dir.createFileAbsolute(io, secret, .{});
+        defer sf.close(io);
+        try sf.writeStreamingAll(io, "TOPSECRET");
+    }
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        cp(ctx, null, &.{ Value{ .string = secret }, Value{ .string = dst } }),
+    );
+    // Nothing was exfiltrated into the keg.
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, dst, .{}));
+}
+
+test "cp refuses to read through a source symlink out of the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const secret = try std.fs.path.join(alloc, &.{ base, "secret" }); // out of keg
+    defer alloc.free(secret);
+    const link = try std.fs.path.join(alloc, &.{ keg, "link" }); // keg/link -> base/secret
+    defer alloc.free(link);
+    const dst = try std.fs.path.join(alloc, &.{ keg, "leak" });
+    defer alloc.free(dst);
+
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    {
+        const sf = try std.Io.Dir.createFileAbsolute(io, secret, .{});
+        defer sf.close(io);
+        try sf.writeStreamingAll(io, "TOPSECRET");
+    }
+    try std.Io.Dir.symLinkAbsolute(io, secret, link, .{});
+
+    // The source path is literally in-keg, but its final component is a symlink
+    // out of the keg: the no-follow read must refuse it, not chase the target.
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        cp(ctx, null, &.{ Value{ .string = link }, Value{ .string = dst } }),
+    );
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, dst, .{}));
+}
+
+test "cp array branch skips an out-of-keg source but copies an in-keg one" {
+    const io = std.Options.debug_io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    // cp's array branch joins child paths on ctx.allocator; give it an arena.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    const good = try std.fs.path.join(alloc, &.{ keg, "good.txt" }); // in keg
+    const secret = try std.fs.path.join(alloc, &.{ base, "secret" }); // out of keg
+    const into = try std.fs.path.join(alloc, &.{ keg, "into" }); // dest dir
+    const landed = try std.fs.path.join(alloc, &.{ into, "good.txt" });
+    const escaped = try std.fs.path.join(alloc, &.{ into, "secret" });
+
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    {
+        const gf = try std.Io.Dir.createFileAbsolute(io, good, .{});
+        defer gf.close(io);
+        try gf.writeStreamingAll(io, "GOOD");
+    }
+    {
+        const sf = try std.Io.Dir.createFileAbsolute(io, secret, .{});
+        defer sf.close(io);
+        try sf.writeStreamingAll(io, "SECRET");
+    }
+
+    const items = [_]Value{ Value{ .string = good }, Value{ .string = secret } };
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    // Best-effort per entry: the forbidden source is skipped, the rest succeed —
+    // the call does not abort.
+    _ = try cp(ctx, null, &.{ Value{ .array = &items }, Value{ .string = into } });
+
+    var rb: [8]u8 = undefined;
+    const df = try std.Io.Dir.openFileAbsolute(io, landed, .{});
+    defer df.close(io);
+    try std.testing.expectEqualStrings("GOOD", rb[0..try df.readPositionalAll(io, &rb, 0)]);
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, escaped, .{}));
+}
+
+test "cp_r refuses to copy a source from outside the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const tree = try std.fs.path.join(alloc, &.{ base, "tree" }); // out-of-keg source dir
+    defer alloc.free(tree);
+    const tree_file = try std.fs.path.join(alloc, &.{ base, "tree", "f.txt" });
+    defer alloc.free(tree_file);
+    const dst = try std.fs.path.join(alloc, &.{ keg, "copy" });
+    defer alloc.free(dst);
+
+    try std.Io.Dir.cwd().createDirPath(io, tree);
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    {
+        const tf = try std.Io.Dir.createFileAbsolute(io, tree_file, .{});
+        defer tf.close(io);
+        try tf.writeStreamingAll(io, "x");
+    }
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        cpR(ctx, null, &.{ Value{ .string = tree }, Value{ .string = dst } }),
+    );
+    // Nothing was read into the keg.
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, dst, .{}));
+}
+
+test "cp_r refuses to read a source symlink planted in the source subtree" {
+    const io = std.Options.debug_io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    const secret = try std.fs.path.join(alloc, &.{ base, "secret" }); // out of keg
+    const src = try std.fs.path.join(alloc, &.{ keg, "src" }); // in-keg source dir
+    const link = try std.fs.path.join(alloc, &.{ keg, "src", "link" }); // src/link -> secret
+    const dst = try std.fs.path.join(alloc, &.{ keg, "dst" });
+    const leaked = try std.fs.path.join(alloc, &.{ keg, "dst", "link" });
+
+    try std.Io.Dir.cwd().createDirPath(io, src);
+    {
+        const sf = try std.Io.Dir.createFileAbsolute(io, secret, .{});
+        defer sf.close(io);
+        try sf.writeStreamingAll(io, "LEAK");
+    }
+    try std.Io.Dir.symLinkAbsolute(io, secret, link, .{}); // planted in the source tree
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    // cp_r swallows per-entry failures; the contract is that nothing was read in.
+    _ = try cpR(ctx, null, &.{ Value{ .string = src }, Value{ .string = dst } });
+    // The symlinked source leaf was not followed, so the secret never landed.
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, leaked, .{}));
+}
+
+test "cp_r copies a directory tree within the keg" {
+    const io = std.Options.debug_io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const keg = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const src = try std.fs.path.join(alloc, &.{ keg, "src" });
+    const src_file = try std.fs.path.join(alloc, &.{ keg, "src", "sub", "file.txt" });
+    const dst = try std.fs.path.join(alloc, &.{ keg, "dst" });
+    const copied = try std.fs.path.join(alloc, &.{ keg, "dst", "sub", "file.txt" });
+
+    try std.Io.Dir.cwd().createDirPath(io, std.fs.path.dirname(src_file).?);
+    {
+        const sf = try std.Io.Dir.createFileAbsolute(io, src_file, .{});
+        defer sf.close(io);
+        try sf.writeStreamingAll(io, "hello");
+    }
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    _ = try cpR(ctx, null, &.{ Value{ .string = src }, Value{ .string = dst } });
+
+    var rb: [8]u8 = undefined;
+    const df = try std.Io.Dir.openFileAbsolute(io, copied, .{});
+    defer df.close(io);
+    try std.testing.expectEqualStrings("hello", rb[0..try df.readPositionalAll(io, &rb, 0)]);
+}
+
+test "mv refuses a source under an intermediate-directory symlink out of the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const outside = try std.fs.path.join(alloc, &.{ base, "outside" });
+    defer alloc.free(outside);
+    const victim = try std.fs.path.join(alloc, &.{ base, "outside", "victim" });
+    defer alloc.free(victim);
+    const dirlink = try std.fs.path.join(alloc, &.{ keg, "d" }); // keg/d -> outside
+    defer alloc.free(dirlink);
+    const src = try std.fs.path.join(alloc, &.{ keg, "d", "victim" }); // literal in-keg, resolves out
+    defer alloc.free(src);
+    const dst = try std.fs.path.join(alloc, &.{ keg, "loot" });
+    defer alloc.free(dst);
+
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    try std.Io.Dir.cwd().createDirPath(io, outside);
+    {
+        const vf = try std.Io.Dir.createFileAbsolute(io, victim, .{});
+        defer vf.close(io);
+        try vf.writeStreamingAll(io, "classified");
+    }
+    try std.Io.Dir.symLinkAbsolute(io, outside, dirlink, .{});
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        mv(ctx, null, &.{ Value{ .string = src }, Value{ .string = dst } }),
+    );
+    // The out-of-keg victim was neither moved nor destroyed.
+    try std.Io.Dir.cwd().access(io, victim, .{});
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, dst, .{}));
+}
+
+test "mv refuses a destination under an intermediate-directory symlink out of the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const outside = try std.fs.path.join(alloc, &.{ base, "outside" });
+    defer alloc.free(outside);
+    const src = try std.fs.path.join(alloc, &.{ keg, "src.txt" }); // in-keg source
+    defer alloc.free(src);
+    const dirlink = try std.fs.path.join(alloc, &.{ keg, "d" }); // keg/d -> outside
+    defer alloc.free(dirlink);
+    const dst = try std.fs.path.join(alloc, &.{ keg, "d", "x" }); // literal in-keg, resolves out
+    defer alloc.free(dst);
+    const escaped = try std.fs.path.join(alloc, &.{ outside, "x" });
+    defer alloc.free(escaped);
+
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    try std.Io.Dir.cwd().createDirPath(io, outside);
+    {
+        const sf = try std.Io.Dir.createFileAbsolute(io, src, .{});
+        defer sf.close(io);
+        try sf.writeStreamingAll(io, "data");
+    }
+    try std.Io.Dir.symLinkAbsolute(io, outside, dirlink, .{});
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        mv(ctx, null, &.{ Value{ .string = src }, Value{ .string = dst } }),
+    );
+    // The move never fired: nothing landed outside, and the source is intact.
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, escaped, .{}));
+    try std.Io.Dir.cwd().access(io, src, .{});
+}
+
+test "mv moves an in-keg symlink leaf, relinking it without following" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const keg = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    // A final-component symlink source is acceptable for mv: rename relinks the
+    // link entry itself, it does not read through it. The guard must not reject
+    // it, and the moved entry must remain a symlink (not a dereferenced copy).
+    const link = try std.fs.path.join(alloc, &.{ keg, "link" });
+    defer alloc.free(link);
+    const dst = try std.fs.path.join(alloc, &.{ keg, "moved" });
+    defer alloc.free(dst);
+    try std.Io.Dir.symLinkAbsolute(io, "/etc/hosts", link, .{});
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    _ = try mv(ctx, null, &.{ Value{ .string = link }, Value{ .string = dst } });
+
+    // The link entry moved; the destination is still a symlink to the same target.
+    var lb: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try std.Io.Dir.readLinkAbsolute(io, dst, &lb);
+    try std.testing.expectEqualStrings("/etc/hosts", lb[0..n]);
+}
+
+test "cp refuses a source under an intermediate-directory symlink out of the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const outside = try std.fs.path.join(alloc, &.{ base, "outside" });
+    defer alloc.free(outside);
+    const secret = try std.fs.path.join(alloc, &.{ base, "outside", "secret" });
+    defer alloc.free(secret);
+    const dirlink = try std.fs.path.join(alloc, &.{ keg, "d" }); // keg/d -> outside
+    defer alloc.free(dirlink);
+    const src = try std.fs.path.join(alloc, &.{ keg, "d", "secret" }); // literal in-keg, resolves out
+    defer alloc.free(src);
+    const dst = try std.fs.path.join(alloc, &.{ keg, "leak" });
+    defer alloc.free(dst);
+
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    try std.Io.Dir.cwd().createDirPath(io, outside);
+    {
+        const sf = try std.Io.Dir.createFileAbsolute(io, secret, .{});
+        defer sf.close(io);
+        try sf.writeStreamingAll(io, "TOPSECRET");
+    }
+    try std.Io.Dir.symLinkAbsolute(io, outside, dirlink, .{});
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        cp(ctx, null, &.{ Value{ .string = src }, Value{ .string = dst } }),
+    );
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, dst, .{}));
+}
+
+test "cp_r refuses to follow a symlinked directory in the source subtree" {
+    const io = std.Options.debug_io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const base = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    const outside = try std.fs.path.join(alloc, &.{ base, "outside" }); // out-of-keg dir
+    const outside_file = try std.fs.path.join(alloc, &.{ base, "outside", "secret" });
+    const src = try std.fs.path.join(alloc, &.{ keg, "src" }); // in-keg source dir
+    const sublink = try std.fs.path.join(alloc, &.{ keg, "src", "sub" }); // src/sub -> outside
+    const dst = try std.fs.path.join(alloc, &.{ keg, "dst" });
+    const leaked = try std.fs.path.join(alloc, &.{ keg, "dst", "sub", "secret" });
+
+    try std.Io.Dir.cwd().createDirPath(io, src);
+    try std.Io.Dir.cwd().createDirPath(io, outside);
+    {
+        const of = try std.Io.Dir.createFileAbsolute(io, outside_file, .{});
+        defer of.close(io);
+        try of.writeStreamingAll(io, "LEAK");
+    }
+    try std.Io.Dir.symLinkAbsolute(io, outside, sublink, .{}); // symlinked dir planted in source
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    _ = try cpR(ctx, null, &.{ Value{ .string = src }, Value{ .string = dst } });
+    // The symlinked source directory was not descended into.
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, leaked, .{}));
+}
+
+test "cp preserves the source file mode within the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const keg = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    // The no-follow read + atomic write must keep the executable bit that
+    // copyFileAbsolute used to carry, or poured scripts would lose +x.
+    const src = try std.fs.path.join(alloc, &.{ keg, "exec.sh" });
+    defer alloc.free(src);
+    const dst = try std.fs.path.join(alloc, &.{ keg, "copy.sh" });
+    defer alloc.free(dst);
+    {
+        const sf = try std.Io.Dir.createFileAbsolute(io, src, .{});
+        defer sf.close(io);
+        try sf.writeStreamingAll(io, "#!script\n");
+        try sf.setPermissions(io, std.Io.File.Permissions.fromMode(0o755));
+    }
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    _ = try cp(ctx, null, &.{ Value{ .string = src }, Value{ .string = dst } });
+
+    const got = (try std.Io.Dir.cwd().statFile(io, dst, .{})).permissions.toMode();
+    try std.testing.expectEqual(@as(std.posix.mode_t, 0o755), got & 0o777);
+}
+
 test "cp copies a regular file within the keg" {
     const io = std.Options.debug_io;
     const alloc = std.testing.allocator;
@@ -440,12 +930,59 @@ test "chmod changes the mode of a regular keg file" {
     try std.testing.expectEqual(@as(std.posix.mode_t, 0o755), got & 0o777);
 }
 
+/// Copy a regular file `src` into `dst`, reading the source through an
+/// `O_NOFOLLOW` handle so a symlinked source leaf cannot redirect the read out
+/// of the keg, and landing the dest atomically (createFileAtomic + rename) so
+/// the dst leaf is never followed either. `validatePath`/`validateWriteDir`
+/// confine where bytes land; this confines where they come from. The caller is
+/// responsible for validating the dest's containing directory.
+///
+/// Returns `NotRegularFile` when `src` is a directory (or other non-file) so
+/// `cp_r` can fall through to a recursive walk; `PathSandboxViolation` when the
+/// source escapes the keg. Other IO errors are swallowed, matching the
+/// force-variant contract of this module.
+fn copyFileConfined(
+    io: std.Io,
+    src: []const u8,
+    dst: []const u8,
+    cellar_path: []const u8,
+    malt_prefix: []const u8,
+) (sandbox.SandboxError || error{NotRegularFile})!void {
+    const file = sandbox.openTargetNoFollow(io, src, cellar_path, malt_prefix, .{ .write = false }) catch |e| switch (e) {
+        error.PathSandboxViolation => return error.PathSandboxViolation,
+        else => return, // missing source or IO error: swallow, like copyFileAbsolute catch {}
+    };
+    var file_reader: std.Io.File.Reader = .init(file, io, &.{});
+    defer file_reader.file.close(io);
+
+    const st = file_reader.file.stat(io) catch return;
+    if (st.kind != .file) return error.NotRegularFile;
+    file_reader.size = st.size;
+
+    var atomic_file = std.Io.Dir.cwd().createFileAtomic(io, dst, .{
+        .permissions = st.permissions,
+        .replace = true,
+    }) catch return;
+    defer atomic_file.deinit(io);
+
+    var buffer: [1024]u8 = undefined;
+    var file_writer = atomic_file.file.writer(io, &buffer);
+    _ = file_writer.interface.sendFileAll(&file_reader, .unlimited) catch return;
+    file_writer.flush() catch return;
+    atomic_file.replace(io) catch return;
+}
+
 fn copyDirRecursive(io: std.Io, allocator: std.mem.Allocator, src: []const u8, dst: []const u8, cellar_path: []const u8, malt_prefix: []const u8) !void {
     std.Io.Dir.cwd().createDirPath(io, dst) catch {};
     // Per level: refuse to descend if dst resolves out of the keg, so a symlink
     // planted anywhere in the dest subtree can't redirect the copy. Files land
     // directly in dst (validated here) and replace any leaf symlink atomically.
     sandbox.validateDirTarget(io, dst, cellar_path, malt_prefix) catch return;
+    // Symmetric source guard: refuse to read through a src dir that resolves out
+    // of the keg, so a symlinked directory planted in the source subtree can't
+    // redirect the read walk. A symlinked *file* leaf is caught below by the
+    // no-follow per-file copy.
+    sandbox.validateDirTarget(io, src, cellar_path, malt_prefix) catch return;
 
     var dir = std.Io.Dir.openDirAbsolute(io, src, .{ .iterate = true }) catch return;
     defer dir.close(io);
@@ -458,7 +995,7 @@ fn copyDirRecursive(io: std.Io, allocator: std.mem.Allocator, src: []const u8, d
         if (entry.kind == .directory) {
             try copyDirRecursive(io, allocator, src_child, dst_child, cellar_path, malt_prefix);
         } else {
-            std.Io.Dir.copyFileAbsolute(src_child, dst_child, io, .{}) catch {};
+            copyFileConfined(io, src_child, dst_child, cellar_path, malt_prefix) catch {};
         }
     }
 }


### PR DESCRIPTION
## Description 

The DSL copy/move builtins (`cp`, `cp_r`, `mv`) validated only their destination against the keg/prefix boundary and passed the source straight to `renameAbsolute`/`copyFileAbsolute`. A malicious tap formula could therefore:

- `mv` an out-of-keg file into the keg - `rename` unlinks the source dir-entry, so the original is destroyed/relocated; and
- `cp`/`cp_r` an arbitrary readable file (or a keg-planted symlink pointing outside) into the keg and `.read` it back, exfiltrating its contents.

The fix validates the source with the same boundary primitives and reads it through an `O_NOFOLLOW` handle:

- `mv`: `validateWriteDir` on **both** source and destination rejects a direct out-of-keg path and an intermediate-directory symlink in either parent. A final-component symlink stays allowed because `rename` relinks/replaces the link entry itself without following it.
- `cp`/`cp_r`: the source is opened via `openTargetNoFollow` (validated parent + `O_NOFOLLOW` leaf) and streamed into the destination through the existing atomic write, so a symlinked source leaf can no longer redirect the read out of the keg.
- `copyDirRecursive`: each level now also resolves the source directory inside the boundary (symmetric to the existing destination guard), and per-file copies use the no-follow read, so a symlink planted anywhere in the source subtree cannot redirect the walk.

## Related Issue

- None

## Notes for Reviewers

- Behaviour change to flag: `cp`/`cp_r` now refuse a symlink **leaf** as the source regardless of where it points (the same `O_NOFOLLOW` stance as `touch`/`chmod` and the write path); previously such a source was dereferenced and its target content copied. Symlink entries inside a `cp_r` source tree are likewise skipped rather than dereferenced. This is the intended conservative no-follow contract.