### PR TITLE
fix(dsl): stop adversarial formulas from crashing the installer

### DIFF
--- a/scripts/regressions/unbounded-recursion-parser-interpreter-dos.sh
+++ b/scripts/regressions/unbounded-recursion-parser-interpreter-dos.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Regression: an adversarial formula body with pathological expression nesting
+# or unbounded self-recursion must degrade to a catchable DSL diagnostic, not
+# abort the process.
+#
+# The bug: the recursive-descent parser had no nesting-depth limit and the
+# interpreter had no user-method call-depth limit. A post_install body of the
+# form `((((( ... )))))` drove `parseExpression` one native frame per level,
+# and `def f; f; end\nf` drove `invokeUserMethod` one frame per call. Both
+# exhausted the native stack — an uncatchable SIGSEGV on Zig, below the
+# `executePostInstall(...) catch {}` boundary — so the whole `malt install`
+# process died instead of the formula degrading to a partial skip.
+#
+# A real overflow assertion is hostile to the test runner (it aborts the whole
+# process, not one test), so the guard is exercised by two colocated `test {}`
+# blocks that assert the depth limits fire as a bounded ParseError / diagnostic
+# well before any native limit. This script builds the lib test binary and runs
+# those tests by name; it exits non-zero if either guard regresses or its test
+# goes missing.
+#
+# Exits 0 when the guards hold, non-zero (with a clear message) when the bug is
+# present. No network required; finishes well under 30s once the binary builds.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# One test per recursion axis: bracket nesting, `!` chains, statement-block
+# nesting, and `#{…}` interpolation each bypass the others, so every guard is
+# checked independently.
+PARSER_FILTERS=(
+  "parser: expression nesting beyond the depth limit is a bounded ParseError"
+  "parser: unary-not chain beyond the depth limit is a bounded ParseError"
+  "parser: block nesting beyond the depth limit is a bounded ParseError"
+  "parser: deeply nested interpolation stays bounded and does not overflow"
+)
+INTERP_FILTER="interpreter: self-recursive method hits the call-depth guard and degrades"
+
+# The guards live in colocated `test {}` blocks; if one is deleted the name
+# filter below would match nothing and silently pass. Fail loudly instead.
+for filter in "${PARSER_FILTERS[@]}"; do
+  if ! grep -Rqs -- "$filter" "$ROOT/src/core/dsl/parser.zig"; then
+    echo "FAIL: a parser depth-guard test is missing from parser.zig: $filter" >&2
+    exit 1
+  fi
+done
+if ! grep -Rqs -- "$INTERP_FILTER" "$ROOT/src/core/dsl/interpreter.zig"; then
+  echo "FAIL: the interpreter call-depth guard test is missing from interpreter.zig" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+if [[ ! -x "$BIN" ]]; then
+  (cd "$ROOT" && zig build test-bin >/dev/null 2>&1) || {
+    echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+    exit 1
+  }
+fi
+
+# The runner has no per-test filter, so run the colocated suite once and judge
+# each guard's line: a pass ends in "OK", a regression prints the failure there.
+OUT=$("$BIN" 2>&1 || true)
+
+for filter in "${PARSER_FILTERS[@]}" "$INTERP_FILTER"; do
+  LINE=$(printf '%s\n' "$OUT" | grep -F -- "$filter" || true)
+  if [[ -z "$LINE" ]]; then
+    echo "FAIL: depth-guard test did not run: $filter" >&2
+    exit 1
+  fi
+  if [[ "$LINE" != *OK ]]; then
+    echo "FAIL: a DSL depth guard regressed (process can overflow on adversarial input): $filter" >&2
+    exit 1
+  fi
+done
+
+echo "PASS: parser + interpreter depth guards hold; adversarial input degrades without a crash"

--- a/src/core/dsl/interpreter.zig
+++ b/src/core/dsl/interpreter.zig
@@ -46,6 +46,14 @@ pub const Interpreter = struct {
     ctx: *ExecContext,
     /// Mirror of `ctx.arena` — held for brevity in hot eval paths.
     allocator: std.mem.Allocator,
+    /// User-method call depth. Caps self-recursive `def f; f; end` before it
+    /// exhausts the native stack (an uncatchable SIGSEGV) and converts the
+    /// abort into a catchable `ParseError` the post_install router degrades on.
+    call_depth: u32 = 0,
+
+    /// Max user-method nesting before degrading. Deep enough for any real
+    /// helper, shallow enough to fire well below the native stack limit.
+    pub const max_call_depth: u32 = 512;
 
     pub fn init(ctx: *ExecContext) Interpreter {
         return .{
@@ -153,6 +161,21 @@ pub const Interpreter = struct {
         md: ast.MethodDef,
         args: []const Value,
     ) DslError!Value {
+        self.call_depth += 1;
+        defer self.call_depth -= 1;
+        if (self.call_depth > max_call_depth) {
+            // The CLI swallows the returned error and routes purely off `flog`,
+            // so log an entry or the skip is silent in verbose/debug output.
+            // `parse_error` degrades to a partial skip, not a fatal abort.
+            self.ctx.fallback_log_writer.log(.{
+                .formula = self.ctx.formula_name,
+                .reason = .parse_error,
+                .detail = "recursion limit exceeded",
+                .loc = null,
+            });
+            return DslError.ParseError;
+        }
+
         try self.ctx.pushMethodScope();
         defer self.ctx.popScope();
 
@@ -972,4 +995,36 @@ pub fn executePostInstallWithOpts(
     ctx.suppress_child_stdout = opts.suppress_child_stdout;
     var interp = Interpreter.init(&ctx);
     try interp.execute(nodes);
+}
+
+// A self-recursive method must hit the call-depth cap and degrade to a logged
+// `parse_error` (a partial skip), never recurse into a native stack overflow.
+// Running this unguarded would abort the test runner, so the cap *is* the test.
+test "interpreter: self-recursive method hits the call-depth guard and degrades" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var flog = FallbackLog.init(alloc);
+    defer flog.deinit();
+
+    var ctx = try ExecContext.init(alloc, std.Options.debug_io, .empty, .{
+        .name = "t",
+        .version = "1",
+        .pkg_version = "1",
+    }, "/tmp/malt-recursion-guard", &flog);
+    defer ctx.deinit();
+
+    var lex = lexer_mod.Lexer.init("def f; f; end\nf\n");
+    var p = parser_mod.Parser.init(alloc, &lex);
+    const nodes = try p.parseBlock();
+
+    var interp = Interpreter.init(&ctx);
+    interp.execute(nodes) catch {};
+
+    var found = false;
+    for (flog.entries()) |e| {
+        if (std.mem.indexOf(u8, e.detail, "recursion limit") != null) found = true;
+    }
+    try std.testing.expect(found);
 }

--- a/src/core/dsl/lexer.zig
+++ b/src/core/dsl/lexer.zig
@@ -231,15 +231,26 @@ pub const Lexer = struct {
         const start_col = self.col;
         self.advance(); // skip opening "
 
-        // Find the end of the string, handling escapes
-        while (self.pos < self.source.len and self.source[self.pos] != '"') {
-            if (self.source[self.pos] == '\\') {
+        // Scan to the closing quote, but stay inside `#{...}` interpolation so
+        // an inner `"` doesn't end the string early. brace_depth tracks open
+        // `#{`/`{`; a `"` only terminates the string at brace_depth 0.
+        var brace_depth: u32 = 0;
+        while (self.pos < self.source.len) {
+            const c = self.source[self.pos];
+            if (c == '\\') {
                 self.advance(); // skip escape char
                 if (self.pos < self.source.len) self.advance();
                 continue;
             }
-            // For Phase 1 we treat #{} as part of the string literal.
-            // Phase 2 will add interpolation splitting.
+            if (brace_depth == 0 and c == '"') break;
+            if (c == '#' and self.pos + 1 < self.source.len and self.source[self.pos + 1] == '{') {
+                brace_depth += 1;
+                self.advance();
+                self.advance();
+                continue;
+            }
+            if (brace_depth > 0 and c == '{') brace_depth += 1;
+            if (brace_depth > 0 and c == '}') brace_depth -= 1;
             self.advance();
         }
 

--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -30,6 +30,19 @@ pub const Parser = struct {
     /// Use `diagnostics()` from outside; the list is append-only internal state.
     _diagnostics: std.ArrayList(Diagnostic),
     current: Token,
+    /// Recursive-descent nesting depth, bumped at every genuine recursion
+    /// re-entry: parseExpression (brackets), parseUnaryNot (`!` chains), and
+    /// parseBlock (statement blocks). One shared counter caps adversarial
+    /// `(((…)))` / `!!!…` / nested `if…end` input before it exhausts the native
+    /// stack (an uncatchable SIGSEGV), turning the abort into a catchable
+    /// `ParseError` the caller can degrade on.
+    depth: u32 = 0,
+
+    /// Max nesting before a `ParseError`. No real homebrew-core formula nests
+    /// anywhere near this. Kept conservative because the heaviest axis —
+    /// `#{…}` interpolation — spawns a sub-parser and allocates per level, so
+    /// the cap must leave ample margin under the multi-MB thread stack.
+    pub const max_depth: u32 = 512;
 
     pub fn init(allocator: std.mem.Allocator, lex: *Lexer) Parser {
         const first = lex.next();
@@ -48,6 +61,12 @@ pub const Parser = struct {
 
     /// Parse a complete post_install block body (sequence of statements).
     pub fn parseBlock(self: *Parser) DslError![]const *const Node {
+        // Nested if/unless/begin/each/def bodies recurse through here without
+        // re-entering parseExpression, so cap block nesting on the same counter.
+        self.depth += 1;
+        defer self.depth -= 1;
+        if (self.depth > max_depth) return self.emitError("block nesting too deep");
+
         var stmts: std.ArrayList(*const Node) = .empty;
 
         while (self.current.kind != .eof and
@@ -117,6 +136,13 @@ pub const Parser = struct {
     }
 
     fn parseExpression(self: *Parser) DslError!*const Node {
+        // One of three depth choke points (with parseUnaryNot and parseBlock)
+        // feeding a shared counter. This one caps bracket nesting — `()`, `[]`,
+        // hash/array elements, call args all re-enter here.
+        self.depth += 1;
+        defer self.depth -= 1;
+        if (self.depth > max_depth) return self.emitError("expression nesting too deep");
+
         // Expression-form `if`/`unless` on RHS of assignment — lets
         // `x = if cond then a else b end` round-trip without call-site hacks.
         if (self.current.kind == .kw_if) return self.parseIf();
@@ -188,6 +214,12 @@ pub const Parser = struct {
 
     fn parseUnaryNot(self: *Parser) DslError!*const Node {
         if (self.current.kind == .bang) {
+            // `!` self-recurses without re-entering parseExpression, so cap
+            // `!!!…` chains on the shared counter or they overflow unchecked.
+            self.depth += 1;
+            defer self.depth -= 1;
+            if (self.depth > max_depth) return self.emitError("expression nesting too deep");
+
             const loc = self.currentLoc();
             self.advanceToken();
             const operand = try self.parseUnaryNot();
@@ -1131,6 +1163,10 @@ pub const Parser = struct {
                 // Parse the expression inside #{...}
                 var inner_lexer = lexer_mod.Lexer.init(expr_src);
                 var inner_parser = Parser.init(self.allocator, &inner_lexer);
+                // Carry the depth budget so nested `#{…}` interpolation can't
+                // reset it — a fresh sub-parser would otherwise start at 0 and
+                // let deeply nested interpolation recurse past the cap.
+                inner_parser.depth = self.depth;
                 const expr_node = inner_parser.parseExpression() catch {
                     // If parsing fails, treat as literal
                     parts_list.append(self.allocator, .{ .literal = content[i..j] }) catch return DslError.OutOfMemory;
@@ -1293,4 +1329,153 @@ fn parseIntValue(lexeme: []const u8) i64 {
         }
     }
     return std.fmt.parseInt(i64, lexeme, 10) catch 0;
+}
+
+// Adversarial deeply-nested input must hit the depth cap and surface a
+// bounded `ParseError` with a diagnostic — never recurse into a native
+// stack overflow. Balanced parens so that, without the guard, the body
+// would parse cleanly; the guard is what converts it into an error.
+test "parser: expression nesting beyond the depth limit is a bounded ParseError" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const n = Parser.max_depth + 50;
+    const src = try alloc.alloc(u8, n * 2 + 1);
+    @memset(src[0..n], '(');
+    src[n] = '1';
+    @memset(src[n + 1 ..], ')');
+
+    var lex = Lexer.init(src);
+    var p = Parser.init(alloc, &lex);
+    try std.testing.expectError(DslError.ParseError, p.parseBlock());
+
+    var found = false;
+    for (p.diagnostics()) |d| {
+        if (std.mem.indexOf(u8, d.message, "nesting too deep") != null) found = true;
+    }
+    try std.testing.expect(found);
+}
+
+// `!` self-recurses in parseUnaryNot without re-entering parseExpression, so a
+// `!!!…` chain bypasses the bracket guard. It must hit the shared cap instead
+// of overflowing the native stack.
+test "parser: unary-not chain beyond the depth limit is a bounded ParseError" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const n = Parser.max_depth + 50;
+    const src = try alloc.alloc(u8, n + 1);
+    @memset(src[0..n], '!');
+    src[n] = '1';
+
+    var lex = Lexer.init(src);
+    var p = Parser.init(alloc, &lex);
+    try std.testing.expectError(DslError.ParseError, p.parseBlock());
+
+    var found = false;
+    for (p.diagnostics()) |d| {
+        if (std.mem.indexOf(u8, d.message, "nesting too deep") != null) found = true;
+    }
+    try std.testing.expect(found);
+}
+
+// Nested if/unless/begin/each/def bodies recurse through parseBlock, not
+// parseExpression — the condition's expression returns before the body
+// descends. Deeply nested `if … end` must hit the shared cap, not overflow.
+test "parser: block nesting beyond the depth limit is a bounded ParseError" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // `if 1\n` repeated — the guard fires mid-descent, before any matching end.
+    const n = Parser.max_depth + 50;
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var i: usize = 0;
+    while (i < n) : (i += 1) try buf.appendSlice(alloc, "if 1\n");
+
+    var lex = Lexer.init(buf.items);
+    var p = Parser.init(alloc, &lex);
+    try std.testing.expectError(DslError.ParseError, p.parseBlock());
+
+    var found = false;
+    for (p.diagnostics()) |d| {
+        if (std.mem.indexOf(u8, d.message, "nesting too deep") != null) found = true;
+    }
+    try std.testing.expect(found);
+}
+
+// No false positives: nesting at a depth no real formula approaches — across
+// all three axes combined — must parse cleanly with no diagnostics.
+test "parser: legitimate moderate nesting parses without tripping the guard" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // 100 nested parens + a `!` + an if/end block: far deeper than any real
+    // post_install, yet well under the cap.
+    const k = 100;
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    try buf.appendSlice(alloc, "if !");
+    try buf.appendNTimes(alloc, '(', k);
+    try buf.appendSlice(alloc, "1");
+    try buf.appendNTimes(alloc, ')', k);
+    try buf.appendSlice(alloc, "\nohai \"ok\"\nend\n");
+
+    var lex = Lexer.init(buf.items);
+    var p = Parser.init(alloc, &lex);
+    const nodes = try p.parseBlock();
+    try std.testing.expectEqual(@as(usize, 1), nodes.len);
+    try std.testing.expectEqual(@as(usize, 0), p.diagnostics().len);
+}
+
+// Anti-regression: the counter must decrement on return, so many *sequential*
+// (closed, non-nested) blocks far exceeding the cap never trip the guard — a
+// missing decrement would falsely reject ordinary multi-statement formulas.
+test "parser: sequential blocks past the cap do not trip the guard" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const n = Parser.max_depth + 200;
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var i: usize = 0;
+    while (i < n) : (i += 1) try buf.appendSlice(alloc, "if 1\nohai \"x\"\nend\n");
+
+    var lex = Lexer.init(buf.items);
+    var p = Parser.init(alloc, &lex);
+    const nodes = try p.parseBlock();
+    try std.testing.expectEqual(@as(usize, n), nodes.len);
+    try std.testing.expectEqual(@as(usize, 0), p.diagnostics().len);
+}
+
+// `#{…}` interpolation parses its inner expression with a fresh sub-parser; the
+// depth budget is carried into it so deeply nested interpolation can't reset
+// the counter and recurse unbounded. Running this without that carry overflows
+// the native stack and aborts the runner, so completion *is* the proof.
+test "parser: deeply nested interpolation stays bounded and does not overflow" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // N levels of `"#{ … }"` nested inside each other, past the cap.
+    const n = Parser.max_depth + 200;
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    var i: usize = 0;
+    while (i < n) : (i += 1) try buf.appendSlice(alloc, "\"#{");
+    try buf.appendSlice(alloc, "1");
+    i = 0;
+    while (i < n) : (i += 1) try buf.appendSlice(alloc, "}\"");
+
+    var lex = Lexer.init(buf.items);
+    var p = Parser.init(alloc, &lex);
+    // The guard fires deep inside, is caught at the interpolation boundary and
+    // collapses to a literal, so the top-level parse completes — no crash.
+    const nodes = try p.parseBlock();
+    try std.testing.expectEqual(@as(usize, 1), nodes.len);
 }

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -1719,6 +1719,104 @@ test "parse_error: malformed source populates fallback log with location" {
     try testing.expect(saw_parse_error);
 }
 
+// A formula whose post_install nests expressions pathologically deep must
+// degrade through the full pipeline (catchable ParseError + logged diagnostic)
+// instead of overflowing the native stack and aborting `malt install`.
+test "depth guard: deeply nested expression degrades through the post_install path" {
+    var arena = testArena();
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    const json = try minimalJson(alloc, "testpkg", "1.0");
+    var f = try formula_mod.parseFormula(alloc, json);
+    defer f.deinit();
+
+    var flog = dsl.FallbackLog.init(alloc);
+    defer flog.deinit();
+
+    // Balanced nesting well past the cap; the guard must fire mid-descent.
+    const n: usize = 4000;
+    const body = try alloc.alloc(u8, n * 2 + 2);
+    @memset(body[0..n], '(');
+    body[n] = '1';
+    @memset(body[n + 1 .. n * 2 + 1], ')');
+    body[n * 2 + 1] = '\n';
+
+    const result = dsl.executePostInstall(std.Options.debug_io, malt.app_ctx.processEnviron(), alloc, .{
+        .name = f.name,
+        .version = f.version,
+        .pkg_version = f.pkg_version,
+    }, body, prefix, &flog);
+    try testing.expectError(dsl.DslError.ParseError, result);
+
+    // Non-fatal: routes to a partial skip, not an abort.
+    try testing.expect(!flog.hasFatal());
+    var saw_depth_diag = false;
+    for (flog.entries()) |entry| {
+        if (entry.reason == .parse_error and
+            std.mem.indexOf(u8, entry.detail, "nesting too deep") != null) saw_depth_diag = true;
+    }
+    try testing.expect(saw_depth_diag);
+}
+
+// A self-recursive helper must hit the interpreter's call-depth cap and
+// degrade with a logged diagnostic, never recurse into a stack overflow.
+test "depth guard: self-recursive method degrades through the post_install path" {
+    var arena = testArena();
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    var flog = dsl.FallbackLog.init(alloc);
+    defer flog.deinit();
+
+    // The error is swallowed at the CLI seam; the router degrades off `flog`,
+    // so the test asserts on the logged entry rather than the return value.
+    try runSnippetInto(&arena, "def f; f; end\nf\n", prefix, &flog);
+
+    try testing.expect(!flog.hasFatal());
+    var saw_recursion_diag = false;
+    for (flog.entries()) |entry| {
+        if (entry.reason == .parse_error and
+            std.mem.indexOf(u8, entry.detail, "recursion limit") != null) saw_recursion_diag = true;
+    }
+    try testing.expect(saw_recursion_diag);
+}
+
+// Anti-regression: the call-depth counter must decrement on return, so many
+// *sequential* (non-nested) calls far exceeding the cap never trip the guard.
+// A missing decrement would falsely flag ordinary formulas with helper loops.
+test "depth guard: sequential method calls past the cap do not trip the guard" {
+    var arena = testArena();
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const prefix = try makeTempPrefix();
+    defer testing.allocator.free(prefix);
+
+    var flog = dsl.FallbackLog.init(alloc);
+    defer flog.deinit();
+
+    // One trivial helper invoked far more times than max_call_depth, but each
+    // call returns before the next — depth peaks at 1, never accumulates.
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(alloc);
+    try body.appendSlice(alloc, "def g; 1; end\n");
+    var i: usize = 0;
+    while (i < 600) : (i += 1) try body.appendSlice(alloc, "g\n");
+
+    try runSnippetInto(&arena, body.items, prefix, &flog);
+
+    for (flog.entries()) |entry| {
+        try testing.expect(std.mem.indexOf(u8, entry.detail, "recursion limit") == null);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // User-defined methods (`def ... end`) and `return` semantics.
 //

--- a/tests/dsl_lexer_test.zig
+++ b/tests/dsl_lexer_test.zig
@@ -404,9 +404,25 @@ test "lexer: percent_w with parens" {
 }
 
 test "lexer: string with interpolation syntax" {
-    // Lexer Phase 1 treats #{} as part of the string_double token
+    // `#{...}` is kept inside the string_double token; the parser splits it.
     var lex = Lexer.init("\"hello #{name}\"");
     try expectToken(&lex, .string_double, "\"hello #{name}\"");
+    try expectKind(&lex, .eof);
+}
+
+test "lexer: interpolation with an inner string is one token" {
+    // A `"` inside `#{...}` must not end the string early — brace-aware
+    // scanning keeps the interpolated string literal in the same token.
+    var lex = Lexer.init("\"a #{b(\"c\")} d\"");
+    try expectToken(&lex, .string_double, "\"a #{b(\"c\")} d\"");
+    try expectKind(&lex, .eof);
+}
+
+test "lexer: nested interpolation is one token" {
+    // `"#{"#{1}"}"` — interpolation nested inside interpolation, with inner
+    // quoted strings. The whole thing is a single string_double token.
+    var lex = Lexer.init("\"#{\"#{1}\"}\"");
+    try expectToken(&lex, .string_double, "\"#{\"#{1}\"}\"");
     try expectKind(&lex, .eof);
 }
 


### PR DESCRIPTION
## Description 

A malformed or adversarial formula from a third-party tap could crash the whole `malt install` process. A `post_install` body with pathologically deep nesting, or a self-recursive helper, drove the DSL parser and interpreter into unbounded native recursion — an uncatchable stack overflow that bypassed every error-handling layer and aborted the installer instead of letting the formula degrade to a partial skip.

This bounds every recursion path in the DSL so that adversarial input now fails safe: the depth limit fires as an ordinary, catchable parse diagnostic, the formula degrades to `partially_skipped` (or the system-Ruby fallback when eligible), and the installer keeps running.

Coverage spans the full recursion surface, not just the obvious one:

- Bracket nesting (`(((…)))`, arrays, hashes, call args)
- Unary `!` chains
- Statement-block nesting (`if`/`unless`/`begin`/`each`/`def` bodies)
- `#{…}` string interpolation nested inside interpolation
- Self-recursive user methods in the interpreter

A shared, conservative depth budget bounds total descent regardless of how the nesting is mixed, leaving ample margin under the thread stack. Legitimate formulas are unaffected - the limit sits far above anything real homebrew-core formulas reach.

## Related Issue

- None

## Notes for Reviewers

- None