### PR TITLE
fix(dsl): keep a dangling #{ from aborting formula parsing

### DIFF
--- a/scripts/regressions/trailing-interpolation-oob-slice-panic.sh
+++ b/scripts/regressions/trailing-interpolation-oob-slice-panic.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Regression: a double-quoted string whose content ends in a dangling `#{`
+# (no matching `}`) must parse to a plain literal, not abort the process.
+#
+# The bug: parseStringInterpolation opened an interpolation segment on `#{`
+# but always sliced the inner expression as `content[i + 2 .. j - 1]`,
+# assuming `j` landed one byte past a matching brace. When `#{` were the
+# final two bytes, the brace scan never advanced (`j == content.len`,
+# depth stays 1) and the slice became `content[len .. len - 1]` —
+# start > end — an unconditional safety panic. A formula post_install body
+# carrying a lexeme as innocuous as `"#{"` aborted the whole `mt` process
+# before the --use-system-ruby fallback could engage.
+#
+# No CLI subcommand drives the DSL parser without a full network install,
+# and a real slice panic aborts the whole test runner, so the guard is
+# exercised by a colocated `test {}` that feeds dangling `#{` strings to
+# parseStringInterpolation and asserts a single literal part comes back.
+# This script builds the test binary and judges that test by name; it
+# exits non-zero if the guard regresses or the test goes missing.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when
+# present. No network required; finishes well under 30s once the test
+# binary is built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+FILTER="parser: dangling #{ in a string is a literal, not an out-of-bounds slice"
+
+# The guard lives in a colocated `test {}`; if it is ever deleted the name
+# filter below would match nothing and silently pass. Fail loudly instead.
+if ! grep -Rqs -- "$FILTER" "$ROOT/src/core/dsl/parser.zig"; then
+  echo "FAIL: the dangling-interpolation guard test is missing from parser.zig" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+if [[ ! -x "$BIN" ]]; then
+  (cd "$ROOT" && zig build test-bin >/dev/null 2>&1) || {
+    echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+    exit 1
+  }
+fi
+
+# The runner has no per-test filter, so run the colocated suite and judge only
+# this guard's line: a pass ends in "OK", a regression aborts the runner with a
+# slice panic so the line never reaches "OK".
+OUT=$("$BIN" 2>&1 || true)
+LINE=$(printf '%s\n' "$OUT" | grep -F -- "$FILTER" || true)
+if [[ -z "$LINE" ]]; then
+  echo "FAIL: the dangling-interpolation guard test did not run (parser aborted?)" >&2
+  exit 1
+fi
+if [[ "$LINE" != *OK ]]; then
+  echo "FAIL: a dangling #{ sliced out of bounds and aborted the parser" >&2
+  exit 1
+fi
+
+echo "PASS: dangling #{ handled as a literal without panic"

--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -1159,6 +1159,16 @@ pub const Parser = struct {
                     if (content[j] == '{') depth += 1;
                     if (content[j] == '}') depth -= 1;
                 }
+                // No matching `}`: `j == content.len`, so `j - 1` would slice
+                // start > end (panic) or drop a real byte. Treat the dangling
+                // `#{…` to end-of-content as a literal, like the parse-failure
+                // fallback below.
+                if (depth != 0) {
+                    parts_list.append(self.allocator, .{ .literal = content[i..] }) catch return DslError.OutOfMemory;
+                    i = content.len;
+                    literal_start = i;
+                    continue;
+                }
                 const expr_src = content[i + 2 .. j - 1];
                 // Parse the expression inside #{...}
                 var inner_lexer = lexer_mod.Lexer.init(expr_src);
@@ -1478,4 +1488,45 @@ test "parser: deeply nested interpolation stays bounded and does not overflow" {
     // collapses to a literal, so the top-level parse completes — no crash.
     const nodes = try p.parseBlock();
     try std.testing.expectEqual(@as(usize, 1), nodes.len);
+}
+
+// A `#{` with no matching `}` must not slice `content[i + 2 .. j - 1]` with
+// start > end. Trailing `#{` (j == content.len, depth stays 1) is the panic;
+// unclosed `#{foo` is its silent truncation sibling. Both collapse to a
+// single literal; a genuine `#{x}` still yields one interpolation part.
+test "parser: dangling #{ in a string is a literal, not an out-of-bounds slice" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const loc: SourceLoc = .{ .line = 1, .col = 1 };
+
+    var lex = Lexer.init("");
+    var p = Parser.init(alloc, &lex);
+
+    // Trailing `#{` — the panic case: one literal holding the raw bytes.
+    const trailing = try p.parseStringInterpolation("#{", loc);
+    try std.testing.expectEqual(@as(usize, 1), trailing.len);
+    try std.testing.expectEqualStrings("#{", trailing[0].literal);
+
+    // Unclosed non-empty `#{foo` — no `j - 1` truncation to "fo".
+    const unclosed = try p.parseStringInterpolation("#{foo", loc);
+    try std.testing.expectEqual(@as(usize, 1), unclosed.len);
+    try std.testing.expectEqualStrings("#{foo", unclosed[0].literal);
+
+    // Control: a real `#{x}` still parses to one interpolation part.
+    const closed = try p.parseStringInterpolation("#{x}", loc);
+    try std.testing.expectEqual(@as(usize, 1), closed.len);
+    try std.testing.expect(closed[0] == .interpolation);
+
+    // Anti-regression: empty-but-closed `#{}` stays a literal via the inner
+    // parse-failure fallback — the dangling branch must not steal this case.
+    const empty = try p.parseStringInterpolation("#{}", loc);
+    try std.testing.expectEqual(@as(usize, 1), empty.len);
+    try std.testing.expectEqualStrings("#{}", empty[0].literal);
+
+    // A preceding literal is still flushed before the dangling tail.
+    const prefixed = try p.parseStringInterpolation("a#{", loc);
+    try std.testing.expectEqual(@as(usize, 2), prefixed.len);
+    try std.testing.expectEqualStrings("a", prefixed[0].literal);
+    try std.testing.expectEqualStrings("#{", prefixed[1].literal);
 }

--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -1530,3 +1530,26 @@ test "parser: dangling #{ in a string is a literal, not an out-of-bounds slice" 
     try std.testing.expectEqualStrings("a", prefixed[0].literal);
     try std.testing.expectEqualStrings("#{", prefixed[1].literal);
 }
+
+// The `\` escape arm runs before `#{` detection, so a backslash-escaped `\#{`
+// never opens an interpolation segment — it can't reach the slice at all.
+// Lock that: escaped `#{` stays literal whether dangling or "closed".
+test "parser: an escaped \\#{ stays literal and never interpolates" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+    const loc: SourceLoc = .{ .line = 1, .col = 1 };
+
+    var lex = Lexer.init("");
+    var p = Parser.init(alloc, &lex);
+
+    // Escaped + dangling: a single literal, no panic.
+    const dangling = try p.parseStringInterpolation("\\#{", loc);
+    try std.testing.expectEqual(@as(usize, 1), dangling.len);
+    try std.testing.expectEqualStrings("\\#{", dangling[0].literal);
+
+    // Escaped over a would-be interpolation: still suppressed to a literal.
+    const closed = try p.parseStringInterpolation("\\#{x}", loc);
+    try std.testing.expectEqual(@as(usize, 1), closed.len);
+    try std.testing.expectEqualStrings("\\#{x}", closed[0].literal);
+}


### PR DESCRIPTION
## Description

The fix branches on whether a closing brace was actually found: an unterminated `#{…` to end-of-content is now appended as a plain literal, exactly like the existing inner-parse-failure fallback. This also fixes a silent sibling bug where `#{foo` was truncated to `fo` by the unconditional `j - 1`.

No new error variant, no signature change - the dangling case is recovered inline.

## Related Issue

- None

## Notes for Reviewers

- None