### PR TITLE
fix(dsl): mask chmod mode to permission bits instead of narrowing

### DIFF
--- a/scripts/regressions/dsl-chmod-mode-cast-panic-large-literal.sh
+++ b/scripts/regressions/dsl-chmod-mode-cast-panic-large-literal.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Regression: the `chmod` DSL builtin must mask a formula-supplied mode down to
+# the permission bits, not narrow it through i32/u16. A mode arrives as an i64;
+# values outside i32 range, negative values, or values past mode_t (u16) hit a
+# checked cast that aborts the whole `mt` process in a safe build — a malformed
+# formula could crash malt mid-evaluation instead of degrading.
+#
+# No CLI subcommand drives the builtin without a network install, and a real
+# cast panic aborts the test runner, so a standalone ReleaseSafe `zig test`
+# harness drives chmod with an out-of-range mode against a temp keg file. The
+# harness must reach its assertion without aborting; if chmod narrows the mode
+# the @intCast aborts and `zig test` dies by signal (exit > 128).
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# The harness imports the builtin via a repo-relative path, so it must sit at the
+# repo root: the builtin's sibling imports (`../values.zig`, `../sandbox.zig`)
+# only resolve from inside the source tree's module boundary.
+HARNESS="$ROOT/.chmod-mode-cast-regression.zig"
+trap 'rm -f "$HARNESS"' EXIT
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const fileutils = @import("src/core/dsl/builtins/fileutils.zig");
+
+// An i64 mode well outside i32 range: the old cast chain aborted here.
+test "chmod masks an out-of-range mode instead of narrowing" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const keg = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+    const file = try std.fs.path.join(alloc, &.{ keg, "x" });
+    defer alloc.free(file);
+    (try std.Io.Dir.createFileAbsolute(io, file, .{})).close(io);
+
+    const v = try fileutils.chmod(.{
+        .allocator = alloc,
+        .io = io,
+        .environ = std.process.Environ.empty,
+        .cellar_path = keg,
+        .malt_prefix = keg,
+    }, null, &.{ .{ .int = 9999999999 }, .{ .string = file } });
+    try std.testing.expect(v == .nil);
+}
+ZIG
+
+if (cd "$ROOT" && zig test -OReleaseSafe "$HARNESS") >/dev/null 2>&1; then
+  echo "PASS: chmod masks an out-of-range mode instead of narrowing through i32"
+else
+  echo "FAIL: chmod aborted on an out-of-range mode (narrowed instead of masked)" >&2
+  exit 1
+fi

--- a/src/core/dsl/builtins/fileutils.zig
+++ b/src/core/dsl/builtins/fileutils.zig
@@ -147,7 +147,9 @@ pub fn chmod(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
         .int => |i| i,
         else => return Value{ .nil = {} },
     };
-    const mode: std.posix.mode_t = @intCast(@as(u32, @bitCast(@as(i32, @intCast(mode_val)))));
+    // chmod(2) only consults the low permission bits; mask so any i64 formula
+    // mode fits mode_t without a checked-cast panic on out-of-range input.
+    const mode: std.posix.mode_t = @intCast(mode_val & 0o7777);
 
     switch (args[1]) {
         .array => |items| {

--- a/tests/dsl_builtins_test.zig
+++ b/tests/dsl_builtins_test.zig
@@ -730,6 +730,47 @@ test "FileUtils.chmod returns nil for a non-int mode and is a no-op" {
     try testing.expect(v == .nil);
 }
 
+// A formula carries its mode as an i64; chmod must mask to the permission bits
+// rather than narrow through i32/u16, where any of three windows aborts the
+// process: out of i32 range, negative, or in-i32 but past mode_t (u16).
+test "FileUtils.chmod masks an out-of-i32-range mode instead of aborting" {
+    const root = try uniqueSandbox("fileutils_chmod_overflow");
+    defer testing.allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const ctx = mkCtx(root);
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/f", .{root});
+    defer testing.allocator.free(path);
+    (try test_io.createFileAbsolute(std.Options.debug_io, path, .{})).close(std.Options.debug_io);
+    const v = try fileutils.chmod(ctx, null, &.{ .{ .int = 9999999999 }, .{ .string = path } });
+    try testing.expect(v == .nil);
+}
+
+test "FileUtils.chmod masks a negative mode instead of aborting" {
+    const root = try uniqueSandbox("fileutils_chmod_negative");
+    defer testing.allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const ctx = mkCtx(root);
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/f", .{root});
+    defer testing.allocator.free(path);
+    (try test_io.createFileAbsolute(std.Options.debug_io, path, .{})).close(std.Options.debug_io);
+    const v = try fileutils.chmod(ctx, null, &.{ .{ .int = -1 }, .{ .string = path } });
+    try testing.expect(v == .nil);
+}
+
+test "FileUtils.chmod masks high non-permission bits down to 0o7777" {
+    const root = try uniqueSandbox("fileutils_chmod_mask");
+    defer testing.allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const ctx = mkCtx(root);
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/f", .{root});
+    defer testing.allocator.free(path);
+    (try test_io.createFileAbsolute(std.Options.debug_io, path, .{})).close(std.Options.debug_io);
+    // 70000 fits i32 but exceeds mode_t; 70000 & 0o7777 == 0o560.
+    _ = try fileutils.chmod(ctx, null, &.{ .{ .int = 70000 }, .{ .string = path } });
+    const got = (try std.Io.Dir.cwd().statFile(std.Options.debug_io, path, .{})).permissions.toMode();
+    try testing.expectEqual(@as(std.posix.mode_t, 0o560), got & 0o7777);
+}
+
 // ---------------------------------------------------------------------------
 // Process builtins
 //


### PR DESCRIPTION
## Description

A formula-supplied `chmod` mode is carried as an `i64`. The builtin narrowed it through `i32`->`u32`->`mode_t`, so a mode outside `i32` range (or negative, or one past `mode_t`) tripped a checked cast - aborting `mt` mid-evaluation in a safe build, undefined behavior in ReleaseFast. A malformed or hostile formula could crash the process instead of degrading.

`chmod(2)` only consults the low permission bits, so the mode is now masked with `& 0o7777` before the cast. Any `i64` lands in `0..4095`, which always fits `mode_t`, so the cast can never abort - matching the kernel's own truncation.

## Related Issue

- None

## Notes for Reviewers

- None