### PR TITLE
fix(install): keep --download-only from pruning the installed keg under --force

### DIFF
--- a/scripts/regressions/install-download-only-force-deletes-kegs.sh
+++ b/scripts/regressions/install-download-only-force-deletes-kegs.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Regression: `mt install --download-only --force <same-version>` must not
+# prune the installed keg. The bottle path ran the --force prune before its
+# download-only early return, deleting the cellar with nothing to re-populate
+# it. Driving the full CLI needs a real bottle download (network) and the bug
+# is a deleteTree, so the guard is exercised through the colocated Zig test.
+set -euo pipefail
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+FILTER="install: --download-only suppresses the --force reinstall prune"
+
+# Guard test must exist, else the name filter silently passes.
+grep -Rqs -- "$FILTER" "$ROOT/src/cli/install.zig" ||
+  {
+    echo "FAIL: download-only force-prune guard test is missing" >&2
+    exit 1
+  }
+
+# The real call site must be gated by the predicate, not a bare `if (force)`.
+# The colocated test re-implements the gate, so this grep is what catches a
+# revert of the wiring at the prune site.
+grep -Rqs -- "if (shouldPruneForReinstall(force, download_only))" "$ROOT/src/cli/install.zig" ||
+  {
+    echo "FAIL: --force prune is not gated by shouldPruneForReinstall" >&2
+    exit 1
+  }
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+[[ -x "$BIN" ]] || (cd "$ROOT" && zig build test-bin >/dev/null 2>&1) ||
+  {
+    echo "FAIL: could not build test binary" >&2
+    exit 1
+  }
+
+# The colocated test creates a temp prefix + Cellar/<name>/<ver>, drives the
+# force/download-only prune decision with download_only=true and asserts the
+# dir survives (and, with download_only=false, that it is pruned). A regression
+# either aborts the run or fails the assertion, so the line never reaches OK.
+LINE=$("$BIN" 2>&1 | grep -F -- "$FILTER" || true)
+[[ -n "$LINE" && "$LINE" == *OK ]] ||
+  {
+    echo "FAIL: --download-only did not suppress the --force prune" >&2
+    exit 1
+  }
+echo "PASS: download-only leaves the installed keg intact under --force"

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -81,6 +81,15 @@ pub fn pruneCellarForReinstall(ctx: *const AppCtx, prefix: []const u8, name: []c
     std.Io.Dir.cwd().deleteTree(ctx.io, cellar_path) catch {};
 }
 
+/// Whether the `--force` pre-materialize prune should run. `--download-only`
+/// stops before the materialize phase, so pruning then would deleteTree an
+/// installed keg with nothing to re-populate it — download-only must never
+/// mutate the installed cellar. Mirrors the tap/local path, which already
+/// returns on download-only before its own force prune.
+pub fn shouldPruneForReinstall(force: bool, download_only: bool) bool {
+    return force and !download_only;
+}
+
 /// Unlink the on-disk symlinks AND drop the `links` rows for every
 /// `kegs` row of `name` whose `cellar_path` differs from
 /// `keep_cellar_path` — i.e. the prior install at an other
@@ -874,7 +883,7 @@ fn executeWithOpts(
     // crash leaves the user's prior keg + row intact for the revision-bump
     // case. Pin survives because `recordKeg` inherits via COALESCE-MAX on
     // `pinned` by name.
-    if (force) {
+    if (shouldPruneForReinstall(force, download_only)) {
         for (all_jobs.items) |job| {
             pruneCellarForReinstall(ctx, prefix, job.name, job.version_str);
         }
@@ -1534,6 +1543,46 @@ test "kegPresent returns true only when <prefix>/Cellar/<name> exists" {
 
     try testing.expect(kegPresent(&ctx, prefix, "ghost"));
     try testing.expect(!kegPresent(&ctx, prefix, "other"));
+}
+
+// `--download-only` must never mutate the installed cellar. The bottle
+// path ran the `--force` prune ahead of its download-only early return,
+// so `mt install --download-only --force <same-version>` deleteTree'd an
+// installed keg and never re-materialized it. The prune is now gated on
+// `shouldPruneForReinstall`, which vetoes the prune under download-only.
+// (The prune loops all jobs, so a multi-dep target would wipe every
+// dependency's cellar; one assertion on the primary keg suffices.)
+test "install: --download-only suppresses the --force reinstall prune" {
+    const testing = std.testing;
+
+    // Pure decision: only a plain `--force` (no download-only) prunes.
+    try testing.expect(shouldPruneForReinstall(true, false));
+    try testing.expect(!shouldPruneForReinstall(true, true));
+    try testing.expect(!shouldPruneForReinstall(false, false));
+    try testing.expect(!shouldPruneForReinstall(false, true));
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const ts = std.Io.Clock.real.now(ctx.io).toNanoseconds();
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_dlonly_force_{d}", .{ts});
+    std.Io.Dir.cwd().deleteTree(ctx.io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(ctx.io, prefix);
+    defer std.Io.Dir.cwd().deleteTree(ctx.io, prefix) catch {};
+
+    var keg_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const keg = try std.fmt.bufPrint(&keg_buf, "{s}/Cellar/wget/1.21", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(ctx.io, keg);
+
+    // download-only gate is false → prune skipped → keg survives.
+    if (shouldPruneForReinstall(true, true)) pruneCellarForReinstall(&ctx, prefix, "wget", "1.21");
+    try std.Io.Dir.accessAbsolute(ctx.io, keg, .{});
+
+    // plain --force gate is true → prune runs → keg gone.
+    if (shouldPruneForReinstall(true, false)) pruneCellarForReinstall(&ctx, prefix, "wget", "1.21");
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(ctx.io, keg, .{}));
 }
 
 // `--force` that resolves to a new revision (e.g. 10.47 → 10.47_1)


### PR DESCRIPTION
## Description

`mt install --download-only --force <pkg>` could silently break an already-installed package. In the bottle path the `--force` pre-materialize prune ran before the download-only early return, so it deleted `Cellar/<name>/<version>` and then returned without ever re-materializing it — leaving dangling `bin/` symlinks, an exit 0 "downloaded", and a `kegs` row still claiming the package is healthy.

The prune is now gated on a small pure predicate, `shouldPruneForReinstall(force, download_only)`, that vetoes the prune whenever `--download-only` is set. This aligns the bottle path with the tap/local path, which already returns before its own force prune — download-only never mutates the installed cellar.

## Related Issue

- None

## Notes for Reviewers

- None
