### PR TITLE
fix(upgrade): preserve dependency edges so cleanup can't delete live runtime deps

### DIFF
--- a/scripts/e2e/migrate_dry_run_check.sh
+++ b/scripts/e2e/migrate_dry_run_check.sh
@@ -27,8 +27,22 @@ if ! command -v brew >/dev/null 2>&1; then
   echo "migrate-check: brew not on PATH — nothing to compare against" >&2
   exit 2
 fi
-if ! command -v jq >/dev/null 2>&1; then
-  echo "migrate-check: jq is required to parse --json output" >&2
+# A malt/brew-installed jq can sit on PATH yet fail to run when a removed
+# dependency leaves its dylib dangling. A crashing jq emits no kegs, which
+# would otherwise read as a keg mismatch instead of a broken tool. Pick the
+# first jq that actually executes; fall back to the system one.
+# Probe via command substitution so a jq that dies on a signal (SIGABRT
+# from a missing dylib) doesn't leak an "Abort trap" notice to stderr.
+JQ=""
+for cand in jq /usr/bin/jq; do
+  command -v "$cand" >/dev/null 2>&1 || continue
+  _v=$("$cand" --version 2>/dev/null) || continue
+  JQ="$cand"
+  break
+done
+unset _v
+if [[ -z "$JQ" ]]; then
+  echo "migrate-check: no runnable jq found (a PATH jq may be failing to load a dylib)" >&2
   exit 2
 fi
 
@@ -40,7 +54,7 @@ brew list --formulae | sort -u >"$TMP/brew.txt"
 
 # 2. What `mt migrate --dry-run` discovers in the same Cellar. JSON
 #    output is stable + parseable; the keg list lives at `.kegs`.
-"$MT_BIN" migrate --dry-run --json | jq -r '.kegs[]' | sort -u >"$TMP/mt.txt"
+"$MT_BIN" migrate --dry-run --json | "$JQ" -r '.kegs[]' | sort -u >"$TMP/mt.txt"
 
 BREW_N=$(wc -l <"$TMP/brew.txt" | tr -d ' ')
 MT_N=$(wc -l <"$TMP/mt.txt" | tr -d ' ')

--- a/scripts/regressions/cleanup-keeps-binary-linked-deps.sh
+++ b/scripts/regressions/cleanup-keeps-binary-linked-deps.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Regression (defense-in-depth): `cleanup` (`purge --housekeeping`) must
+# never delete a dependency that a still-installed package's Mach-O
+# actually links, even when the `dependencies` table has lost the edge.
+# `findOrphans` trusts the table alone, so a single dropped edge would
+# otherwise let `runUnusedDeps` reap a live runtime dependency.
+#
+# The guard probes installed binaries (LC_LOAD_DYLIB into `opt/<name>/`)
+# before reaping an orphan and keeps anything still linked. No CLI path
+# seeds a corrupted-table-plus-live-linkage state in isolation, so the
+# guard is a colocated `test {}` that builds a fake dependent binary,
+# drops the edge, runs the scope, and asserts the dependency survives.
+# This script builds the test binary and judges that test by name; it
+# exits non-zero if the guard regresses or the test goes missing.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when
+# present. No network required; finishes well under 30s once built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+FILTER="runUnusedDeps keeps a dependency a still-installed keg's Mach-O links despite a missing edge"
+
+if ! grep -Rqs -- "$FILTER" "$ROOT/src/cli/purge/scopes.zig"; then
+  echo "FAIL: the cleanup binary-linkage guard test is missing from scopes.zig" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+if [[ ! -x "$BIN" ]]; then
+  (cd "$ROOT" && zig build test-bin -Doptimize=ReleaseSafe >/dev/null 2>&1) || {
+    echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+    exit 1
+  }
+fi
+
+OUT=$("$BIN" 2>&1 || true)
+LINE=$(printf '%s\n' "$OUT" | grep -F -- "$FILTER" || true)
+if [[ -z "$LINE" ]]; then
+  echo "FAIL: the cleanup binary-linkage guard test did not run" >&2
+  exit 1
+fi
+if [[ "$LINE" != *OK ]]; then
+  echo "FAIL: cleanup reaped a dependency a binary still links" >&2
+  exit 1
+fi
+
+echo "PASS: cleanup keeps dependencies that installed binaries still link"

--- a/scripts/regressions/upgrade-preserves-dependency-rows.sh
+++ b/scripts/regressions/upgrade-preserves-dependency-rows.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Regression: `upgradeDbAtomic` records the new keg row and deletes the
+# old one, but never re-records the upgraded keg's runtime dependencies.
+# `deleteKeg` drops the old keg's `dependencies` rows as part of removing
+# it, so after `upgrade <keg>` the keg has zero dependency edges. The next
+# `cleanup` runs `findOrphans` over the (now incomplete) `dependencies`
+# table, classifies the still-linked dependency keg as an orphan, and
+# deletes it — silently breaking a working binary.
+#
+# The fix re-records the edges on the new keg id inside upgradeDbAtomic's
+# transaction. No CLI subcommand drives the upgrade DB transaction in
+# isolation against a seeded edge, so the guard is a colocated `test {}`
+# that runs the transaction and asserts both the surviving edge and that
+# `findOrphans` excludes the dependency. This script builds the test
+# binary and judges that test by name; it exits non-zero if the guard
+# regresses or the test goes missing.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when
+# present. No network required; finishes well under 30s once built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+FILTER="upgradeDbAtomic re-records dependency edges so cleanup keeps live runtime deps"
+
+# The guard lives in a colocated `test {}`; if it is ever deleted the name
+# filter below would match nothing and silently pass. Fail loudly instead.
+if ! grep -Rqs -- "$FILTER" "$ROOT/src/cli/upgrade.zig"; then
+  echo "FAIL: the upgrade dependency-rows guard test is missing from upgrade.zig" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+if [[ ! -x "$BIN" ]]; then
+  (cd "$ROOT" && zig build test-bin -Doptimize=ReleaseSafe >/dev/null 2>&1) || {
+    echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+    exit 1
+  }
+fi
+
+# The runner has no per-test filter, so run the colocated suite and judge only
+# this guard's line: a pass ends in "OK", a regression prints the failure there.
+OUT=$("$BIN" 2>&1 || true)
+LINE=$(printf '%s\n' "$OUT" | grep -F -- "$FILTER" || true)
+if [[ -z "$LINE" ]]; then
+  echo "FAIL: the upgrade dependency-rows guard test did not run" >&2
+  exit 1
+fi
+if [[ "$LINE" != *OK ]]; then
+  echo "FAIL: upgrade dropped the keg's dependency edges; cleanup would reap a live dep" >&2
+  exit 1
+fi
+
+echo "PASS: upgrade re-records dependency edges; live deps survive cleanup"

--- a/src/cli/purge/scopes.zig
+++ b/src/cli/purge/scopes.zig
@@ -128,16 +128,33 @@ pub fn runUnusedDeps(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
         return result;
     }
 
-    rep.header(orphans.len, "package", "packages");
+    const io = ctx.io;
+
+    // Defense-in-depth: never reap a dep that a still-installed keg's
+    // Mach-O actually links. Its `dependencies` edge may have been lost
+    // (e.g. an upgrade that predated edge re-recording), so the DB calls
+    // it an orphan while the binary still needs it — the binary wins.
+    var removable: std.ArrayList([]const u8) = .empty;
+    defer removable.deinit(allocator);
+    for (orphans) |name| {
+        if (orphanStillLinked(io, allocator, &db, name)) {
+            rep.note("keeping {s} — still linked by an installed package", .{name});
+        } else {
+            removable.append(allocator, name) catch {};
+        }
+    }
+
+    if (removable.items.len == 0) return result;
+
+    rep.header(removable.items.len, "package", "packages");
 
     if (dry_run) {
-        for (orphans) |name| rep.item(name);
-        rep.done(orphans.len);
-        result.removed = @intCast(orphans.len);
+        for (removable.items) |name| rep.item(name);
+        rep.done(removable.items.len);
+        result.removed = @intCast(removable.items.len);
         return result;
     }
 
-    const io = ctx.io;
     var linker = linker_mod.Linker.init(io, allocator, &db, prefix);
     var store = store_mod.Store.init(io, allocator, &db, prefix);
 
@@ -145,7 +162,7 @@ pub fn runUnusedDeps(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
     // or partially-materialized keg must still be cleanable. Callers rely on
     // the DB `DELETE` as the authoritative removal signal; filesystem and
     // refcount side-effects converge on subsequent runs.
-    for (orphans) |name| {
+    for (removable.items) |name| {
         var stmt = db.prepare("SELECT id, version, store_sha256 FROM kegs WHERE name = ?1;") catch continue;
         defer stmt.finalize();
         stmt.bindText(1, name) catch continue;
@@ -185,8 +202,32 @@ pub fn runUnusedDeps(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
             result.removed += 1;
         }
     }
-    rep.done(orphans.len);
+    rep.done(removable.items.len);
     return result;
+}
+
+/// True iff some installed keg other than `name` carries a Mach-O hard
+/// link into `opt/<name>/`. The orphan scan trusts the `dependencies`
+/// table; this read-only fallback trusts the binaries, so a dropped edge
+/// can't get a still-linked dependency deleted. Best-effort: any DB or
+/// I/O failure reads as "not linked" so cleanup keeps working.
+///
+/// ponytail: O(orphans × installed-kegs) with first-match short-circuit.
+/// Only runs when orphans exist (rare) so it's fine; if cleanup ever gets
+/// slow on huge prefixes, hoist to a single pass collecting the linked
+/// opt-name set once.
+fn orphanStillLinked(io: std.Io, allocator: std.mem.Allocator, db: *sqlite.Database, name: []const u8) bool {
+    var needle_buf: [256]u8 = undefined;
+    const needle = std.fmt.bufPrint(&needle_buf, "/opt/{s}/", .{name}) catch return false;
+
+    var stmt = db.prepare("SELECT cellar_path FROM kegs WHERE name != ?1;") catch return false;
+    defer stmt.finalize();
+    stmt.bindText(1, name) catch return false;
+    while (stmt.step() catch false) {
+        const cp = stmt.columnText(0) orelse continue;
+        if (cellar_mod.cellarLinksPath(io, allocator, std.mem.sliceTo(cp, 0), needle)) return true;
+    }
+    return false;
 }
 
 // ── Tier: --cache[=DAYS] (was `cleanup --prune=`) ───────────────────────────
@@ -997,4 +1038,80 @@ test "runOldVersions ignores pin status when sweeping old cask versions" {
         error.FileNotFound,
         std.Io.Dir.accessAbsolute(fs_test_io, prefix ++ "/cache/Cask/flux-1.0.dmg", .{}),
     );
+}
+
+// Build a minimal Mach-O carrying one LC_LOAD_DYLIB that names `dylib`,
+// and write it at `path`. Lets the linkage-guard test stand in for a
+// relocated bottle binary without shipping a real one.
+fn writeFakeDylibLinker(io: std.Io, path: []const u8, dylib: [:0]const u8) !void {
+    const macho = std.macho;
+    const lc_size = @sizeOf(macho.dylib_command);
+    const name_offset: u32 = @intCast(lc_size);
+    const cmdsize: u32 = @intCast(lc_size + dylib.len + 1);
+    const cmdsize_aligned: u32 = (cmdsize + 7) & ~@as(u32, 7);
+    const header_size = @sizeOf(macho.mach_header_64);
+    const total_len = header_size + cmdsize_aligned;
+
+    const buf = try testing.allocator.alloc(u8, total_len);
+    defer testing.allocator.free(buf);
+    @memset(buf, 0);
+
+    const header = std.mem.bytesAsValue(macho.mach_header_64, buf[0..header_size]);
+    header.* = .{ .magic = macho.MH_MAGIC_64, .ncmds = 1, .sizeofcmds = cmdsize_aligned };
+    const dy = std.mem.bytesAsValue(macho.dylib_command, buf[header_size..][0..lc_size]);
+    dy.* = .{
+        .cmd = .LOAD_DYLIB,
+        .cmdsize = cmdsize_aligned,
+        .dylib = .{ .name = name_offset, .timestamp = 0, .current_version = 0, .compatibility_version = 0 },
+    };
+    @memcpy(buf[header_size + lc_size ..][0..dylib.len], dylib);
+
+    const f = try std.Io.Dir.createFileAbsolute(io, path, .{ .truncate = true });
+    defer f.close(io);
+    try f.writeStreamingAll(io, buf);
+}
+
+test "runUnusedDeps keeps a dependency a still-installed keg's Mach-O links despite a missing edge" {
+    const allocator = testing.allocator;
+
+    const prefix = "/tmp/malt_unuseddeps_linkguard";
+    std.Io.Dir.cwd().deleteTree(fs_test_io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(fs_test_io, prefix) catch {};
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix ++ "/db");
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, prefix ++ "/Cellar/jq/1.0/bin");
+
+    // jq (direct) + oniguruma (dependency) installed, but NO dependency
+    // edge — the corrupted-table state a pre-fix upgrade left behind.
+    {
+        var db = try sqlite.Database.open(prefix ++ "/db/malt.db");
+        defer db.close();
+        try schema.initSchema(&db);
+        try db.exec(
+            \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, install_reason)
+            \\VALUES ('jq', 'jq', '1.0', 'sha-jq', '/tmp/malt_unuseddeps_linkguard/Cellar/jq/1.0', 'direct'),
+            \\       ('oniguruma', 'oniguruma', '6.9', 'sha-onig', '/tmp/malt_unuseddeps_linkguard/Cellar/oniguruma/6.9', 'dependency');
+        );
+    }
+
+    // jq's binary hard-links opt/oniguruma — the linkage the DB table lost.
+    try writeFakeDylibLinker(fs_test_io, prefix ++ "/Cellar/jq/1.0/bin/jq", "/opt/oniguruma/lib/libonig.5.dylib");
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(allocator);
+    output.beginStderrCapture(allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    const ctx = AppCtx{ .io = fs_test_io, .environ = .empty };
+    const result = try runUnusedDeps(&ctx, allocator, prefix, false);
+
+    try testing.expectEqual(util.ScopeStatus.ok, result.status);
+    // Nothing reaped: the only orphan is still linked by jq's binary.
+    try testing.expectEqual(@as(u32, 0), result.removed);
+
+    var db = try sqlite.Database.open(prefix ++ "/db/malt.db");
+    defer db.close();
+    var stmt = try db.prepare("SELECT COUNT(*) FROM kegs WHERE name = 'oniguruma';");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    try testing.expectEqual(@as(i64, 1), stmt.columnInt(0));
 }

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -856,6 +856,11 @@ pub fn upgradeDbAtomic(
         bin_isolated,
         .{ .in_transaction = true },
     );
+    // Re-record the upgraded keg's runtime deps on the new id: deleteKeg
+    // wipes the old keg's `dependencies` rows, and without rebuilding them
+    // the keg ends up edge-less — `cleanup`'s orphan scan would then reap
+    // a still-live dependency. Same call the install/migrate paths make.
+    install_record_mod.recordDeps(db, new_keg_id, formula);
     try linker.link(new_cellar_path, formula.name, new_keg_id, bin_isolated);
     install_record_mod.deleteKeg(db, old_keg_id);
     return new_keg_id;

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -1271,3 +1271,63 @@ test "printSummary respects --quiet" {
     printSummary(.{ .upgraded = 1, .up_to_date = 2 }, false);
     try std.testing.expectEqualStrings("", buf.items);
 }
+
+// `upgradeDbAtomic` records the new keg and deletes the old one, whose
+// `dependencies` rows go with it. Without re-recording the edges on the
+// new keg id, the upgraded keg ends up with zero deps — and the next
+// `cleanup` (which trusts the `dependencies` table) reaps a still-live
+// runtime dependency as an orphan. Pin both halves: the surviving edge
+// and `findOrphans` excluding the dep it points at.
+test "upgradeDbAtomic re-records dependency edges so cleanup keeps live runtime deps" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    // direct keg (jq) → dependency keg (oniguruma), plus the edge.
+    try db.exec(
+        \\INSERT INTO kegs (id, name, full_name, version, store_sha256, cellar_path, install_reason)
+        \\VALUES (1, 'jq', 'jq', '1.7', 'sha-jq-old', '/c/jq/1.7', 'direct'),
+        \\       (2, 'oniguruma', 'oniguruma', '6.9', 'sha-onig', '/c/oniguruma/6.9', 'dependency');
+    );
+    try db.exec("INSERT INTO dependencies (keg_id, dep_name) VALUES (1, 'oniguruma');");
+
+    // New jq formula (version bump) still declaring oniguruma as a dep.
+    const json =
+        \\{"name":"jq","full_name":"jq","tap":"homebrew/core","desc":"","homepage":"","license":null,"revision":0,"keg_only":false,"post_install_defined":false,"versions":{"stable":"1.7.1"},"dependencies":["oniguruma"]}
+    ;
+    var formula = try formula_mod.parseFormula(std.testing.allocator, json);
+    defer formula.deinit();
+
+    // link/unlink no-op against a non-existent prefix/cellar — this test
+    // exercises the DB transaction, not the filesystem.
+    var linker = linker_mod.Linker.init(std.Options.debug_io, std.testing.allocator, &db, "/nonexistent/malt-prefix");
+
+    try db.beginTransaction();
+    errdefer db.rollback();
+    const new_keg_id = try upgradeDbAtomic(&db, &linker, 1, &formula, "sha-jq-new", "/nonexistent/Cellar/jq/1.7.1", false);
+    try db.commit();
+
+    // The edge must survive on the new keg id.
+    {
+        var stmt = try db.prepare(
+            \\SELECT d.dep_name FROM dependencies d
+            \\JOIN kegs k ON k.id = d.keg_id
+            \\WHERE k.name = 'jq';
+        );
+        defer stmt.finalize();
+        try std.testing.expect(try stmt.step());
+        const dep = stmt.columnText(0) orelse return error.TestUnexpectedResult;
+        try std.testing.expectEqualStrings("oniguruma", std.mem.sliceTo(dep, 0));
+    }
+    try std.testing.expect(new_keg_id != 1);
+
+    // …so cleanup's orphan scan must not classify oniguruma as unused.
+    const orphans = try deps_mod.findOrphans(std.testing.allocator, &db);
+    defer {
+        for (orphans) |o| std.testing.allocator.free(o);
+        std.testing.allocator.free(orphans);
+    }
+    for (orphans) |o| {
+        try std.testing.expect(!std.mem.eql(u8, o, "oniguruma"));
+    }
+}

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -279,6 +279,27 @@ fn walkMachOAndPatch(
     }
 }
 
+/// Read-only: does any binary under `cellar_path` link a path containing
+/// `needle` (e.g. `/opt/<dep>/`)? Lets cleanup keep a dependency a
+/// still-installed keg actually links even if its `dependencies` edge was
+/// lost. Best-effort over the relocation facade so the ELF backend slots
+/// in unchanged; an unreadable keg dir or file is simply "no link found".
+pub fn cellarLinksPath(io: std.Io, allocator: std.mem.Allocator, cellar_path: []const u8, needle: []const u8) bool {
+    var dir = std.Io.Dir.openDirAbsolute(io, cellar_path, .{ .iterate = true }) catch return false;
+    defer dir.close(io);
+
+    var walker = dir.walk(allocator) catch return false;
+    defer walker.deinit();
+
+    while (walker.next(io) catch null) |entry| {
+        if (entry.kind != .file) continue;
+        const full_path = std.fs.path.join(allocator, &.{ cellar_path, entry.path }) catch continue;
+        defer allocator.free(full_path);
+        if (patch.fileLinksPath(io, allocator, full_path, needle)) return true;
+    }
+    return false;
+}
+
 /// Write a brew-compatible INSTALL_RECEIPT.json to the keg directory.
 /// This allows Homebrew to recognize malt-installed packages.
 /// Relocate a freshly-cloned keg tree at `cellar_path` so its embedded

--- a/src/core/patch.zig
+++ b/src/core/patch.zig
@@ -26,6 +26,9 @@ pub const patchPathsCollecting = backend.patchPathsCollecting;
 pub const patchTextFiles = backend.patchTextFiles;
 pub const flushOverflow = backend.flushOverflow;
 pub const external_tool_name = backend.external_tool_name;
+/// Read-only "does this binary link a path containing `needle`" probe.
+/// The ELF backend supplies a `DT_NEEDED`/`RUNPATH` equivalent.
+pub const fileLinksPath = backend.fileLinksPath;
 
 test "facade re-exports the patcher surface cellar / doctor rely on" {
     _ = Replacement;
@@ -37,6 +40,7 @@ test "facade re-exports the patcher surface cellar / doctor rely on" {
     _ = patchTextFiles;
     _ = flushOverflow;
     _ = external_tool_name;
+    _ = fileLinksPath;
 }
 
 test "facade external_tool_name matches the macOS backend" {

--- a/src/macho/patcher.zig
+++ b/src/macho/patcher.zig
@@ -483,4 +483,78 @@ fn hasPrefix(path: []const u8, prefix: []const u8) bool {
     return std.mem.eql(u8, path[0..prefix.len], prefix);
 }
 
+/// Read-only probe: true iff `file_path` is a Mach-O that *links* a dylib
+/// whose path contains `needle` (LC_LOAD_DYLIB and its weak/reexport
+/// siblings). `LC_ID_DYLIB` (a dylib's own install name) and search-path
+/// commands like `LC_RPATH` are excluded — only a hard link to the dylib
+/// counts. Best-effort: an unreadable, non-Mach-O, or unparseable file
+/// reads as "no". Opens read-only and never mutates.
+pub fn fileLinksPath(io: std.Io, allocator: std.mem.Allocator, file_path: []const u8, needle: []const u8) bool {
+    const file = std.Io.Dir.cwd().openFile(io, file_path, .{}) catch return false;
+    defer file.close(io);
+
+    const stat = file.stat(io) catch return false;
+    if (stat.size == 0) return false;
+    const data = allocator.alloc(u8, stat.size) catch return false;
+    defer allocator.free(data);
+    const n = file.readPositionalAll(io, data, 0) catch return false;
+    if (n < data.len) return false;
+
+    if (!parser.isMachO(data)) return false;
+    var macho = parser.parse(allocator, data) catch return false;
+    defer macho.deinit();
+
+    for (macho.paths) |p| {
+        switch (p.cmd) {
+            @intFromEnum(std.macho.LC.LOAD_DYLIB),
+            @intFromEnum(std.macho.LC.LOAD_WEAK_DYLIB),
+            @intFromEnum(std.macho.LC.REEXPORT_DYLIB),
+            => if (std.mem.indexOf(u8, p.path, needle) != null) return true,
+            else => {},
+        }
+    }
+    return false;
+}
+
 const replaceAll = text_replace.replaceAll;
+
+test "fileLinksPath detects a needle in an LC_LOAD_DYLIB and ignores misses" {
+    const testing = std.testing;
+    const macho = std.macho;
+
+    // Minimal Mach-O: header + one LC_LOAD_DYLIB naming an opt path.
+    const lc_size = @sizeOf(macho.dylib_command);
+    const path_str = "/opt/malt/opt/oniguruma/lib/libonig.5.dylib\x00";
+    const name_offset: u32 = @intCast(lc_size);
+    const cmdsize: u32 = @intCast(lc_size + path_str.len);
+    const cmdsize_aligned: u32 = (cmdsize + 7) & ~@as(u32, 7);
+    const header_size = @sizeOf(macho.mach_header_64);
+    const total_len = header_size + cmdsize_aligned;
+
+    const buf = try testing.allocator.alloc(u8, total_len);
+    defer testing.allocator.free(buf);
+    @memset(buf, 0);
+
+    const header = std.mem.bytesAsValue(macho.mach_header_64, buf[0..header_size]);
+    header.* = .{ .magic = macho.MH_MAGIC_64, .ncmds = 1, .sizeofcmds = cmdsize_aligned };
+    const dy = std.mem.bytesAsValue(macho.dylib_command, buf[header_size..][0..lc_size]);
+    dy.* = .{
+        .cmd = .LOAD_DYLIB,
+        .cmdsize = cmdsize_aligned,
+        .dylib = .{ .name = name_offset, .timestamp = 0, .current_version = 0, .compatibility_version = 0 },
+    };
+    @memcpy(buf[header_size + lc_size ..][0..path_str.len], path_str);
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const io = std.Options.debug_io;
+    try tmp.dir.writeFile(io, .{ .sub_path = "dependent", .data = buf });
+
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_abs = dir_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &dir_buf)];
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const abs = try std.fmt.bufPrint(&path_buf, "{s}/dependent", .{dir_abs});
+
+    try testing.expect(fileLinksPath(io, testing.allocator, abs, "/opt/oniguruma/"));
+    try testing.expect(!fileLinksPath(io, testing.allocator, abs, "/opt/missing/"));
+}


### PR DESCRIPTION
## Description

The fix re-records the upgraded keg's dependency edges on the new keg id inside the existing atomic transaction - the same `recordDeps` call the install and migrate paths already make. `cleanup` then behaves correctly because the table is complete again; the orphan/refcount logic is unchanged. A partial upgrade still rolls back as a unit.

## Related Issue

- None

## Notes for Reviewers

- None