### PR TITLE
fix(core/child): prevent install-path hang on verbose child output

### DIFF
--- a/scripts/regressions/child-run-sequential-pipe-drain-deadlock.sh
+++ b/scripts/regressions/child-run-sequential-pipe-drain-deadlock.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Regression: core/child.run must drain stdout and stderr concurrently. A child
+# that floods one stream past the kernel pipe buffer (~64 KiB on Darwin) while
+# the other stays open blocks in write(2); if run drains the streams one after
+# the other the child never exits, the first drain never sees EOF, and malt
+# hangs forever on the install path (runOrFail wraps hdiutil/ditto/codesign).
+#
+# child.zig imports only std, so it is pulled in as a standalone module and the
+# shipped run() is exercised directly — no copy, no full build. The driver
+# spawns `/bin/sh -c` (banned under src/ by the spawn invariant, fine here) to
+# flood >64 KiB to stderr with stdout held open, under a hard timeout.
+#
+# Exits 0 when both pipes drain concurrently (child returns, full stderr
+# captured), non-zero with a clear message when run deadlocks or captures short.
+# No network; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+cat >"$TMP/driver.zig" <<'ZIG'
+const std = @import("std");
+const child = @import("child");
+
+pub fn main() !void {
+    var t: std.Io.Threaded = .init(std.heap.page_allocator, .{});
+    defer t.deinit();
+    // >64 KiB to stderr while stdout stays open until sh exits.
+    const argv = [_][]const u8{ "/bin/sh", "-c", "yes | head -c 200000 1>&2" };
+    var r = try child.run(t.io(), std.heap.page_allocator, &argv);
+    defer r.deinit(std.heap.page_allocator);
+    if (r.stderr.len < 200000) std.process.exit(3);
+}
+ZIG
+
+if ! zig build-exe -femit-bin="$TMP/driver" \
+  --dep child -Mmain="$TMP/driver.zig" \
+  -Mchild="$ROOT/src/core/child.zig" >/dev/null 2>&1; then
+  echo "FAIL: driver build error" >&2
+  exit 2
+fi
+
+set +e
+timeout 20 "$TMP/driver"
+rc=$?
+set -e
+
+if [ "$rc" -eq 124 ]; then
+  echo "FAIL: child.run deadlocked draining a >64KiB stderr stream" >&2
+  exit 1
+fi
+if [ "$rc" -ne 0 ]; then
+  echo "FAIL: child.run errored or captured short (rc=$rc)" >&2
+  exit 1
+fi
+
+echo "PASS: child.run drained both pipes concurrently"

--- a/src/core/child.zig
+++ b/src/core/child.zig
@@ -35,10 +35,23 @@ pub const RunReport = struct {
     }
 };
 
+/// Carries one stream's drain result across the worker-thread boundary.
+const DrainCtx = struct {
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    pipe: ?std.Io.File,
+    result: ChildError![]u8 = undefined,
+};
+
+fn drainWorker(ctx: *DrainCtx) void {
+    ctx.result = drainPipe(ctx.io, ctx.allocator, ctx.pipe);
+}
+
 /// Spawn `argv` with stdout + stderr piped, wait, and return the
 /// captured output alongside the exit code. Caller frees the buffers
-/// via `RunReport.deinit`. Reads stdout then stderr; both pipes are
-/// drained before `wait` so the child can't block on a full pipe.
+/// via `RunReport.deinit`. Both pipes are drained concurrently (a worker
+/// thread per stream) so a child that overflows one pipe buffer can't
+/// block the drain of the other.
 pub fn run(
     io: std.Io,
     allocator: std.mem.Allocator,
@@ -50,15 +63,31 @@ pub fn run(
         .stderr = .pipe,
     }) catch return error.SpawnFailed;
 
-    const stdout_bytes = drainPipe(io, allocator, child.stdout) catch |e| {
-        // Best-effort cleanup — kill the child so wait doesn't hang on
-        // a half-drained pipe, then surface the read failure.
+    // Drain stderr on a worker thread while the calling thread drains
+    // stdout — sequential drains deadlock when the not-yet-read stream
+    // fills its pipe buffer and the child blocks in write before exit.
+    var err_ctx: DrainCtx = .{ .io = io, .allocator = allocator, .pipe = child.stderr };
+    const err_thread = std.Thread.spawn(.{}, drainWorker, .{&err_ctx}) catch {
         child.kill(io);
+        return error.IoError;
+    };
+
+    const stdout_res = drainPipe(io, allocator, child.stdout);
+
+    // Either drain failing means the child may still hold a pipe open;
+    // kill it so the worker's read returns EOF before we join.
+    if (stdout_res) |_| {} else |_| child.kill(io);
+    err_thread.join();
+    const stderr_res = err_ctx.result;
+
+    const stdout_bytes = stdout_res catch |e| {
+        // Child already killed above; free whatever the worker collected.
+        if (stderr_res) |b| allocator.free(b) else |_| {}
         return e;
     };
     errdefer allocator.free(stdout_bytes);
 
-    const stderr_bytes = drainPipe(io, allocator, child.stderr) catch |e| {
+    const stderr_bytes = stderr_res catch |e| {
         child.kill(io);
         return e;
     };
@@ -100,10 +129,26 @@ fn drainPipe(
     const file = pipe orelse return allocator.alloc(u8, 0) catch error.OutOfMemory;
     var read_buf: [4096]u8 = undefined;
     var reader = file.readerStreaming(io, &read_buf);
-    return reader.interface.allocRemaining(allocator, std.Io.Limit.limited(max_capture_bytes)) catch |e| switch (e) {
-        error.OutOfMemory => error.OutOfMemory,
-        else => error.IoError,
-    };
+    const r = &reader.interface;
+
+    var captured: std.Io.Writer.Allocating = .init(allocator);
+    errdefer captured.deinit();
+
+    // Capture up to the cap. The allocating writer only fails on OOM.
+    var room: usize = max_capture_bytes;
+    while (room > 0) {
+        const n = r.stream(&captured.writer, std.Io.Limit.limited(room)) catch |e| switch (e) {
+            error.EndOfStream => break,
+            error.WriteFailed => return error.OutOfMemory,
+            error.ReadFailed => return error.IoError,
+        };
+        room -= n;
+    }
+    // Drain the overflow to EOF so the child can't block in write on a full
+    // pipe once the cap is reached — that is the deadlock this guards.
+    _ = r.discardRemaining() catch return error.IoError;
+
+    return captured.toOwnedSlice() catch error.OutOfMemory;
 }
 
 test "runOrFail returns void on exit code 0" {

--- a/tests/child_test.zig
+++ b/tests/child_test.zig
@@ -38,3 +38,35 @@ test "run on a successful child still returns the captured stdout" {
     try std.testing.expectEqual(@as(u8, 0), report.code);
     try std.testing.expect(std.mem.indexOf(u8, report.stdout, "silent-but-recorded") != null);
 }
+
+test "run drains a stream that overflows the pipe buffer while the other stays open" {
+    // Two-pipe deadlock guard: a child that floods one stream past the
+    // kernel pipe buffer (~64 KiB on Darwin) blocks in write until that
+    // pipe is read. Draining the streams sequentially never reads the
+    // flooded one until the child exits, but the child cannot exit until
+    // it is drained — so run must drain both concurrently. 200000 bytes
+    // to stderr (well past one buffer) with stdout held open until exit.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const argv = [_][]const u8{ "/bin/sh", "-c", "yes | head -c 200000 1>&2" };
+    var report = try child.run(threaded.io(), std.testing.allocator, &argv);
+    defer report.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u8, 0), report.code);
+    try std.testing.expectEqual(@as(usize, 200000), report.stderr.len);
+    try std.testing.expectEqual(@as(usize, 0), report.stdout.len);
+}
+
+test "run truncates an over-cap stream to the cap without hanging" {
+    // A stream larger than the 256 KiB capture cap plus a pipe buffer would
+    // deadlock if the drain stopped reading at the cap while the child kept
+    // writing. The drain must keep consuming past the cap to EOF, retaining
+    // only the first 256 KiB. 400000 bytes to stderr exceeds cap + buffer.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const argv = [_][]const u8{ "/bin/sh", "-c", "yes | head -c 400000 1>&2" };
+    var report = try child.run(threaded.io(), std.testing.allocator, &argv);
+    defer report.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u8, 0), report.code);
+    try std.testing.expectEqual(@as(usize, 256 * 1024), report.stderr.len);
+    try std.testing.expectEqual(@as(usize, 0), report.stdout.len);
+}


### PR DESCRIPTION
## Description

`core/child.run` could hang malt indefinitely on the install path. It drained the child's stdout to EOF first and only then stderr, both on one thread. A child that writes more than one pipe buffer (~64 KiB on Darwin) to the not-yet-drained stream blocks in `write(2)`, so it never exits, the first drain never sees EOF, and the run deadlocks. Since `runOrFail` wraps `hdiutil`/`ditto`/`codesign`, a verbose tool on a DMG/cask install could freeze the process permanently.

The streams are now drained concurrently, one worker thread per stream, joined before `wait`, so neither pipe can back-pressure the other. The kill-on-error and per-stream 256 KiB cap are preserved; the child is killed before joining the worker on any drain failure so its read returns EOF. The `run` doc comment, which previously claimed the opposite, is corrected.

## Related Issue

- None

## Notes for Reviewers

- None