### PR TITLE
fix(cli): keep revisioned kegs intact on autoremove, link, and promote

### DIFF
--- a/scripts/regressions/cellar-paths-keep-revision-suffix.sh
+++ b/scripts/regressions/cellar-paths-keep-revision-suffix.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Regression: several DB-row -> filesystem-path builders used the raw
+# `kegs.version` column, but the on-disk Cellar dir is named by
+# pkg_version (`<version>_<revision>` when revision > 0). For a revisioned
+# keg this means:
+#   * `purge --unused-deps` targeted Cellar/<name>/<version> (no suffix),
+#     so the real <version>_<revision> dir was left orphaned on disk;
+#   * `link <name>` pointed opt/<name> at the suffix-less path, creating a
+#     dangling symlink that breaks dyld at runtime.
+#
+# Both scenarios are seeded with a revisioned keg whose dir carries the
+# `_<revision>` suffix. After the fix autoremove deletes the real dir and
+# `link` produces a resolvable opt symlink.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when
+# present. No network required; finishes well under 30s once built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null || {
+  echo "sqlite3 required" >&2
+  exit 2
+}
+
+PREFIX="$(mktemp -d)/malt-prefix"
+export MALT_PREFIX="$PREFIX"
+trap 'rm -rf "$(dirname "$PREFIX")"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+DB="$PREFIX/db/malt.db"
+mkdir -p "$PREFIX/db"
+
+# Init the schema once via a no-op purge on a Cellar-free prefix.
+: >"$DB"
+"$BIN" purge --unused-deps -y >/dev/null 2>&1 || true
+sqlite3 "$DB" "SELECT revision FROM kegs LIMIT 1;" >/dev/null 2>&1 ||
+  fail "schema init did not create the kegs table with a revision column"
+
+# ── Scenario 1: autoremove must delete the revisioned dir ────────────
+# Orphan dependency keg: version 0.22, revision 1 -> dir 0.22_1.
+mkdir -p "$PREFIX/Cellar/gettext/0.22_1/lib"
+sqlite3 "$DB" \
+  "INSERT INTO kegs(name,full_name,version,revision,store_sha256,cellar_path,install_reason) \
+   VALUES('gettext','gettext','0.22',1,'sha','$PREFIX/Cellar/gettext/0.22_1','dependency');"
+
+"$BIN" purge --unused-deps -y >/dev/null 2>&1 || fail "purge --unused-deps errored"
+[[ ! -d "$PREFIX/Cellar/gettext/0.22_1" ]] ||
+  fail "revisioned orphan dir Cellar/gettext/0.22_1 not removed by autoremove"
+pass "autoremove deleted the revisioned keg's dir"
+
+# ── Scenario 2: link must point opt/<name> at the real dir ───────────
+mkdir -p "$PREFIX/Cellar/jq/1.7_2/bin"
+: >"$PREFIX/Cellar/jq/1.7_2/bin/jq"
+sqlite3 "$DB" \
+  "INSERT INTO kegs(name,full_name,version,revision,store_sha256,cellar_path,install_reason) \
+   VALUES('jq','jq','1.7',2,'sha','$PREFIX/Cellar/jq/1.7_2','direct');"
+
+"$BIN" link jq >/dev/null 2>&1 || fail "link jq errored"
+[[ -L "$PREFIX/opt/jq" ]] || fail "opt/jq symlink not created"
+[[ -e "$PREFIX/opt/jq" ]] || fail "opt/jq is dangling (points at a suffix-less path)"
+TARGET=$(readlink "$PREFIX/opt/jq")
+case "$TARGET" in
+*/jq/1.7_2) pass "opt/jq resolves to the revisioned dir" ;;
+*) fail "opt/jq points at '$TARGET', expected the 1.7_2 dir" ;;
+esac
+
+printf '\n✔ cellar-paths keep-revision-suffix regression passed\n'

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -320,20 +320,21 @@ fn promoteIsolatedDepIfAny(
     name: []const u8,
 ) bool {
     var sel = db.prepare(
-        "SELECT id, version, cellar_path FROM kegs WHERE name=?1 AND install_reason='dependency' AND bin_isolated=1 LIMIT 1;",
+        "SELECT id, cellar_path FROM kegs WHERE name=?1 AND install_reason='dependency' AND bin_isolated=1 LIMIT 1;",
     ) catch return false;
     defer sel.finalize();
     sel.bindText(1, name) catch return false;
     const ok = sel.step() catch false;
     if (!ok) return false;
     const keg_id = sel.columnInt(0);
-    const ver_ptr = sel.columnText(1) orelse return false;
-    const cellar_ptr = sel.columnText(2) orelse return false;
-    const version = std.mem.sliceTo(ver_ptr, 0);
+    const cellar_ptr = sel.columnText(1) orelse return false;
     const cellar = std.mem.sliceTo(cellar_ptr, 0);
 
     linker.link(cellar, name, keg_id, false) catch return false;
-    linker.linkOpt(name, version) catch {}; // opt link already present on a promoted dep; best-effort refresh.
+    // opt link already present on a promoted dep; best-effort refresh. The
+    // dir is named by pkg_version (`<version>_<revision>`), so derive the
+    // leaf from cellar_path — raw `version` would dangle for a revisioned dep.
+    linker.linkOpt(name, std.fs.path.basename(cellar)) catch {};
 
     var upd = db.prepare(
         "UPDATE kegs SET install_reason='direct', bin_isolated=0 WHERE id=?1;",
@@ -1486,6 +1487,62 @@ fn formatMaterializeFailure(buf: []u8, name: []const u8, err: cellar_mod.CellarE
     // Overflow only fires on pathologically long names; fall back to a
     // truncated form rather than swallowing the failure silently.
     return result catch "Failed to materialize <truncated>";
+}
+
+test "promoteIsolatedDepIfAny opt-links the revisioned dir, not the raw version" {
+    // Isolated dep at version 1.3 revision 1 lives on disk as
+    // Cellar/zlib/1.3_1. Promotion must point opt/zlib at that dir; a
+    // raw-version opt link (Cellar/zlib/1.3) would dangle.
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    const prefix = try std.fmt.bufPrint(&path_buf, "/tmp/malt_promote_rev_{d}", .{ts});
+    std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+
+    var mk_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const keg_lib = try std.fmt.bufPrint(&mk_buf, "{s}/Cellar/zlib/1.3_1/lib", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(io, keg_lib);
+    var db_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_dir_buf, "{s}/db", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(io, db_dir);
+
+    var dbp_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&dbp_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+    var ins_buf: [std.fs.max_path_bytes + 256]u8 = undefined;
+    const insert = try std.fmt.bufPrintSentinel(
+        &ins_buf,
+        "INSERT INTO kegs(name,full_name,version,revision,store_sha256,cellar_path,install_reason,bin_isolated) " ++
+            "VALUES('zlib','zlib','1.3',1,'sha','{s}/Cellar/zlib/1.3_1','dependency',1);",
+        .{prefix},
+        0,
+    );
+    try db.exec(insert);
+
+    var linker = linker_mod.Linker.init(io, allocator, &db, prefix);
+    try testing.expect(promoteIsolatedDepIfAny(&db, &linker, "zlib"));
+
+    // opt/zlib must resolve (accessAbsolute follows the symlink; a
+    // dangling link would surface FileNotFound).
+    var opt_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const opt = try std.fmt.bufPrint(&opt_buf, "{s}/opt/zlib", .{prefix});
+    try std.Io.Dir.accessAbsolute(io, opt, .{});
+
+    // …and the row is promoted: direct + no longer bin-isolated.
+    var row = try db.prepare("SELECT install_reason, bin_isolated FROM kegs WHERE name='zlib';");
+    defer row.finalize();
+    try testing.expect(try row.step());
+    try testing.expectEqualStrings("direct", std.mem.sliceTo(row.columnText(0).?, 0));
+    try testing.expectEqual(@as(i64, 0), row.columnInt(1));
 }
 
 test "mapApiFetchError surfaces ApiUnreachable as NetworkError" {

--- a/src/cli/link.zig
+++ b/src/cli/link.zig
@@ -53,7 +53,7 @@ pub fn executeLink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []con
     schema.initSchema(&db) catch {};
 
     // Look up the keg
-    var stmt = db.prepare("SELECT id, version, cellar_path FROM kegs WHERE name = ?1 LIMIT 1;") catch {
+    var stmt = db.prepare("SELECT id, cellar_path FROM kegs WHERE name = ?1 LIMIT 1;") catch {
         output.err("Database query failed", .{});
         return error.Aborted;
     };
@@ -67,7 +67,7 @@ pub fn executeLink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []con
     }
 
     const keg_id = stmt.columnInt(0);
-    const cellar_path_raw = stmt.columnText(2) orelse {
+    const cellar_path_raw = stmt.columnText(1) orelse {
         output.err("No cellar path recorded for {s}", .{target_name});
         return error.Aborted;
     };
@@ -103,16 +103,10 @@ pub fn executeLink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []con
         return error.Aborted;
     };
 
-    // Also create the version from DB for opt link
-    var ver_stmt = db.prepare("SELECT version FROM kegs WHERE id = ?1;") catch return;
-    defer ver_stmt.finalize();
-    ver_stmt.bindInt(1, keg_id) catch return;
-    if (ver_stmt.step() catch false) {
-        if (ver_stmt.columnText(0)) |v| {
-            // opt/ link is a convenience pointer; primary link.link already succeeded.
-            linker.linkOpt(target_name, std.mem.sliceTo(v, 0)) catch {};
-        }
-    }
+    // opt/ link is a convenience pointer; primary link.link already
+    // succeeded. The dir is named by pkg_version (`<version>_<revision>`),
+    // so derive the leaf from cellar_path — raw `version` would dangle.
+    linker.linkOpt(target_name, std.fs.path.basename(cellar_path)) catch {};
 
     // A full link materialises bin/sbin, so the row's `bin_isolated`
     // must agree with the filesystem; clear it unconditionally. Best-

--- a/src/cli/purge/scopes.zig
+++ b/src/cli/purge/scopes.zig
@@ -164,26 +164,31 @@ pub fn runUnusedDeps(ctx: *const AppCtx, allocator: std.mem.Allocator, prefix: [
     // the DB `DELETE` as the authoritative removal signal; filesystem and
     // refcount side-effects converge on subsequent runs.
     for (removable.items) |name| {
-        var stmt = db.prepare("SELECT id, version, store_sha256 FROM kegs WHERE name = ?1;") catch continue;
+        var stmt = db.prepare("SELECT id, store_sha256, cellar_path FROM kegs WHERE name = ?1;") catch continue;
         defer stmt.finalize();
         stmt.bindText(1, name) catch continue;
 
         if (stmt.step() catch false) {
             const keg_id = stmt.columnInt(0);
-            const version_ptr = stmt.columnText(1);
-            const sha_ptr = stmt.columnText(2);
+            const sha_ptr = stmt.columnText(1);
+            const cellar_ptr = stmt.columnText(2);
+
+            // The on-disk dir is named by pkg_version (`<version>_<revision>`),
+            // so derive the leaf from cellar_path — raw `version` would miss a
+            // revisioned keg's dir and leave it orphaned.
+            const pkg_version = if (cellar_ptr) |c| std.fs.path.basename(std.mem.sliceTo(c, 0)) else "";
 
             // Credit cellar bytes before unlink: removing the keg deletes
             // the directory we'd otherwise stat.
-            if (version_ptr) |v| {
+            if (pkg_version.len > 0) {
                 var path_buf: [512]u8 = undefined;
-                const cellar_path = std.fmt.bufPrint(&path_buf, "{s}/Cellar/{s}/{s}", .{ prefix, name, std.mem.sliceTo(v, 0) }) catch "";
+                const cellar_path = std.fmt.bufPrint(&path_buf, "{s}/Cellar/{s}/{s}", .{ prefix, name, pkg_version }) catch "";
                 if (cellar_path.len > 0) result.bytes += util.pathSize(io, allocator, cellar_path);
             }
 
             linker.unlink(keg_id) catch {};
-            if (version_ptr) |v| {
-                cellar_mod.remove(io, prefix, name, std.mem.sliceTo(v, 0)) catch {};
+            if (pkg_version.len > 0) {
+                cellar_mod.remove(io, prefix, name, pkg_version) catch {};
             }
             {
                 var parent_buf: [512]u8 = undefined;
@@ -1425,4 +1430,48 @@ test "runUnusedDeps keeps a dependency a still-installed keg's Mach-O links desp
     defer stmt.finalize();
     _ = try stmt.step();
     try testing.expectEqual(@as(i64, 1), stmt.columnInt(0));
+}
+
+test "runUnusedDeps removes a revisioned orphan's Cellar dir named with the _<revision> suffix" {
+    // Orphan dependency keg at version 0.22 revision 1 lives on disk as
+    // Cellar/gettext/0.22_1. Autoremove must hit that dir, not the
+    // suffix-less raw-version path, or it orphans the keg on disk.
+    const allocator = testing.allocator;
+
+    const prefix = try uniqueCellarPrefix(allocator, "unuseddeps_revision");
+    defer allocator.free(prefix);
+    defer std.Io.Dir.cwd().deleteTree(fs_test_io, prefix) catch {};
+
+    const db_dir = try joinZ(allocator, prefix, "/db");
+    defer allocator.free(db_dir);
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, db_dir);
+    const keg_lib = try joinZ(allocator, prefix, "/Cellar/gettext/0.22_1/lib");
+    defer allocator.free(keg_lib);
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, keg_lib);
+
+    const db_path = try joinZ(allocator, prefix, "/db/malt.db");
+    defer allocator.free(db_path);
+    {
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try schema.initSchema(&db);
+        const insert = try std.fmt.allocPrintSentinel(
+            allocator,
+            "INSERT INTO kegs(name,full_name,version,revision,store_sha256,cellar_path,install_reason) " ++
+                "VALUES('gettext','gettext','0.22',1,'sha','{s}/Cellar/gettext/0.22_1','dependency');",
+            .{prefix},
+            0,
+        );
+        defer allocator.free(insert);
+        try db.exec(insert);
+    }
+
+    const ctx = AppCtx{ .io = fs_test_io, .environ = .empty };
+    const result = try runUnusedDeps(&ctx, allocator, prefix, false);
+
+    try testing.expectEqual(util.ScopeStatus.ok, result.status);
+    try testing.expectEqual(@as(u32, 1), result.removed);
+    const ver_dir = try joinZ(allocator, prefix, "/Cellar/gettext/0.22_1");
+    defer allocator.free(ver_dir);
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(fs_test_io, ver_dir, .{}));
 }


### PR DESCRIPTION
## Description 

Several DB-row -> filesystem-path builders used the raw `kegs.version` column, but the on-disk Cellar directory is named by `pkg_version` — `<version>_<revision>` once a keg carries a revision (bottle rebuilds bump it routinely). For a revisioned keg this misnamed the path:

- `purge --unused-deps` (autoremove) targeted `Cellar/<name>/<version>`, so the real `<version>_<revision>` directory was left orphaned on disk (and its bytes uncounted).
- `link <name>` pointed `opt/<name>` at the suffix-less path, creating a dangling symlink that breaks dyld at runtime.
- Promoting an isolated dependency to direct during install replaced a good `opt/<name>` with a dangling one.

All three now derive the directory leaf from the keg's recorded `cellar_path` (the authoritative on-disk name) instead of recomputing from raw `version`. Revision-0 kegs resolve to the identical path as before, so non-revisioned behavior is unchanged. `doctor`, `rollback`, local install, and migrate were audited and already handle this correctly.

## Related Issue

- None

## Notes for Reviewers

- None