### PR TITLE
fix(rollback): serialize cask rollback and unify lock-failure diagnostics

### DIFF
--- a/scripts/regressions/cask-rollback-malt-lock-cask-rollback-without-malt-lock.sh
+++ b/scripts/regressions/cask-rollback-malt-lock-cask-rollback-without-malt-lock.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Regression: `mt rollback <cask>` must serialize on the prefix advisory lock.
+#
+# The cask rollback path runs an uninstall+reinstall that writes the
+# casks/cask_versions rows and mutates the Caskroom on disk. Every other
+# mutating command — including the keg rollback path — acquires
+# `<prefix>/db/malt.lock` before touching shared state, giving mutual
+# exclusion against a concurrent install/upgrade/uninstall. The cask
+# rollback dispatcher skipped that acquisition, so it raced freely.
+#
+# This holds the advisory lock from a side process (the same flock(2) malt
+# uses), then runs `mt rollback <cask>`. With the lock present, the rollback
+# must BLOCK on the lock; with the bug it skips the lock and proceeds to
+# mutate immediately. `timeout` distinguishes the two: a blocked rollback is
+# killed (exit 124), an unlocked one returns fast (any other code).
+#
+# Read-only paths (`--list`) must stay lock-free and succeed even while the
+# lock is held.
+#
+# Usage: scripts/regressions/cask-rollback-malt-lock-cask-rollback-without-malt-lock.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt; sqlite3, perl,
+# and timeout (coreutils/gtimeout) on PATH. Offline, no network.
+
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+command -v perl >/dev/null 2>&1 || {
+  echo "this regression needs perl to hold the advisory lock" >&2
+  exit 2
+}
+TIMEOUT=$(command -v timeout || command -v gtimeout || true)
+[[ -n "$TIMEOUT" ]] || {
+  echo "this regression needs timeout (coreutils/gtimeout) on PATH" >&2
+  exit 2
+}
+
+PREFIX=$(mktemp -d)
+export MALT_PREFIX="$PREFIX"
+export MALT_OFFLINE=1
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+HOLDER=""
+cleanup() {
+  [[ -n "$HOLDER" ]] && kill "$HOLDER" 2>/dev/null
+  rm -rf "$PREFIX"
+}
+trap cleanup EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+mkdir -p "$PREFIX/db"
+
+# Bootstrap the schema by letting malt open the DB once.
+"$BIN" list --quiet >/dev/null 2>&1 || true
+DB="$PREFIX/db/malt.db"
+[[ -f "$DB" ]] || fail "DB was not initialised by mt list"
+
+# Seed an installed cask plus >=2 cask_versions rows so a rollback target
+# exists and dispatchCask reaches the mutation (and therefore the lock).
+sqlite3 "$DB" <<SQL
+INSERT INTO casks (token, name, version, url, sha256)
+VALUES ('seeded-cask', 'seeded-cask', '2.0.0',
+        'https://example.invalid/cur.dmg', 'aa');
+INSERT INTO cask_versions (token, version, url, sha256, artifact_type, installed_at)
+VALUES ('seeded-cask','1.0.0','https://example.invalid/old.dmg','bb','dmg','2026-01-01T00:00:00'),
+       ('seeded-cask','2.0.0','https://example.invalid/cur.dmg','aa','dmg','2026-02-01T00:00:00');
+SQL
+
+LOCK="$PREFIX/db/malt.lock"
+READY="$PREFIX/db/.holder_ready"
+
+# Hold the advisory lock exactly as malt does (flock(2) exclusive) from a side
+# process; touch READY only after the lock is owned so we never race the test.
+perl -e 'open(my $f, ">", $ARGV[0]) or die "open: $!";
+         flock($f, 2) or die "flock: $!";
+         open(my $r, ">", $ARGV[1]); close($r);
+         sleep $ARGV[2];' "$LOCK" "$READY" 20 &
+HOLDER=$!
+
+for _ in $(seq 1 50); do
+  [[ -f "$READY" ]] && break
+  sleep 0.1
+done
+[[ -f "$READY" ]] || fail "lock holder failed to acquire the advisory lock"
+
+# With the lock held, cask rollback must block on it. Without the fix it skips
+# the lock and mutates immediately, returning a non-124 code well under 3s.
+RB_OUT="$PREFIX/rb.out"
+"$TIMEOUT" 3 "$BIN" rollback seeded-cask --to 1.0.0 >"$RB_OUT" 2>&1
+RC=$?
+
+[[ "$RC" -eq 124 ]] || {
+  printf '%s\n' "$(cat "$RB_OUT")" >&2
+  fail "cask rollback did not block on a held malt.lock (rc=$RC) — no mutual exclusion"
+}
+pass "cask rollback serializes on malt.lock (blocked while held)"
+
+# Read-only paths must stay lock-free even while the lock is held.
+"$TIMEOUT" 5 "$BIN" rollback seeded-cask --list >/dev/null 2>&1 ||
+  fail "rollback --list blocked or failed under a held lock — read-only paths must stay lock-free"
+pass "rollback --list stays lock-free under a held lock"
+
+printf '\n\xe2\x9c\x94 cask-rollback-malt-lock regression passed\n'

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -21,6 +21,7 @@ const supervisor_mod = @import("../core/services/supervisor.zig");
 const signals = @import("../core/signals.zig");
 const store_mod = @import("../core/store.zig");
 const lock_mod = @import("../db/lock.zig");
+const lock_report = @import("lock_report.zig");
 const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
@@ -634,9 +635,16 @@ fn executeWithOpts(
         var lock_path_buf: [512]u8 = undefined;
         const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch
             return InstallError.LockError;
-        lk = lock_mod.LockFile.acquire(ctx.io, lock_path, 30000) catch {
-            sink.err("Another mt process is running. Wait or run mt doctor.", .{});
-            return InstallError.LockError;
+        lk = lock_mod.LockFile.acquire(ctx.io, lock_path, 30000) catch |e| switch (e) {
+            // The DB is already open here, so db/ exists — DirMissing can't occur.
+            error.DirMissing => return InstallError.LockError,
+            // Emit via the sink so bundle mode stays quiet, with the same
+            // per-error diagnostic the other commands surface.
+            else => {
+                var msg_buf: [512]u8 = undefined;
+                sink.err("{s}", .{lock_report.acquireFailureMessage(&msg_buf, e, prefix)});
+                return InstallError.LockError;
+            },
         };
         output.emitNdjsonEvent(.lock_acquired, "", null);
     }

--- a/src/cli/lock_report.zig
+++ b/src/cli/lock_report.zig
@@ -9,28 +9,68 @@ const std = @import("std");
 const output = @import("../ui/output.zig");
 const lock = @import("../db/lock.zig");
 
-/// Emit a clear, actionable message for every lock failure other than
-/// `DirMissing`. `prefix` is the install prefix, used to point the user at
-/// the exact `db/` directory involved.
-pub fn reportAcquireFailure(e: lock.LockError, prefix: []const u8) void {
-    switch (e) {
+/// Build the clear, actionable message for every lock failure other than
+/// `DirMissing` into `buf` and return the written slice. `prefix` is the
+/// install prefix, used to point the user at the exact `db/` directory
+/// involved. Split from emission so callers on an injected output sink
+/// (the install pipeline) report the same text as the global `output`.
+pub fn acquireFailureMessage(buf: []u8, e: lock.LockError, prefix: []const u8) []const u8 {
+    return switch (e) {
         // Callers must handle the fresh-prefix case themselves.
         error.DirMissing => unreachable,
-        error.AccessDenied => output.err(
+        error.AccessDenied => std.fmt.bufPrint(
+            buf,
             "Cannot write the malt lock under {s}/db — the directory exists but isn't writable. Fix ownership with: sudo chown -R \"$USER\" {s}",
             .{ prefix, prefix },
-        ),
-        error.Timeout => output.err(
+        ) catch "Cannot acquire the malt lock.",
+        error.Timeout => std.fmt.bufPrint(
+            buf,
             "Timed out waiting for the malt lock under {s}/db — another malt process is still running. Wait for it to finish, or run `mt doctor` to clear a stale lock.",
             .{prefix},
-        ),
-        error.OpenFailed => output.err(
+        ) catch "Cannot acquire the malt lock.",
+        error.OpenFailed => std.fmt.bufPrint(
+            buf,
             "Could not open the malt lock under {s}/db.",
             .{prefix},
-        ),
-        error.WriteFailed => output.err(
+        ) catch "Cannot acquire the malt lock.",
+        error.WriteFailed => std.fmt.bufPrint(
+            buf,
             "Took the malt lock under {s}/db but failed to record the process id.",
             .{prefix},
-        ),
-    }
+        ) catch "Cannot acquire the malt lock.",
+    };
+}
+
+/// Emit a clear, actionable message for every lock failure other than
+/// `DirMissing` on the global `output` channel.
+pub fn reportAcquireFailure(e: lock.LockError, prefix: []const u8) void {
+    var buf: [512]u8 = undefined;
+    output.err("{s}", .{acquireFailureMessage(&buf, e, prefix)});
+}
+
+test "acquireFailureMessage distinguishes each non-DirMissing failure" {
+    var buf: [512]u8 = undefined;
+    const prefix = "/opt/malt";
+
+    // AccessDenied points at the writability fix; the others name their cause.
+    const denied = acquireFailureMessage(&buf, error.AccessDenied, prefix);
+    try std.testing.expect(std.mem.indexOf(u8, denied, "isn't writable") != null);
+    try std.testing.expect(std.mem.indexOf(u8, denied, prefix) != null);
+
+    const timeout = acquireFailureMessage(&buf, error.Timeout, prefix);
+    try std.testing.expect(std.mem.indexOf(u8, timeout, "another malt process") != null);
+
+    const open = acquireFailureMessage(&buf, error.OpenFailed, prefix);
+    try std.testing.expect(std.mem.indexOf(u8, open, "Could not open") != null);
+
+    const write = acquireFailureMessage(&buf, error.WriteFailed, prefix);
+    try std.testing.expect(std.mem.indexOf(u8, write, "process id") != null);
+}
+
+test "acquireFailureMessage degrades to a generic line when buf is too small" {
+    // Each arm's `catch` fallback keeps the reporter total even on an
+    // undersized buffer rather than dropping the diagnostic entirely.
+    var tiny: [8]u8 = undefined;
+    const msg = acquireFailureMessage(&tiny, error.Timeout, "/opt/malt");
+    try std.testing.expectEqualStrings("Cannot acquire the malt lock.", msg);
 }

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -11,6 +11,7 @@ const linker_mod = @import("../core/linker.zig");
 const signals = @import("../core/signals.zig");
 const store_mod = @import("../core/store.zig");
 const lock_mod = @import("../db/lock.zig");
+const lock_report = @import("lock_report.zig");
 const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
@@ -224,9 +225,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // Acquire lock; `MALT_LOCK_TIMEOUT_MS` tunes the 30 s default.
     var lock_path_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return;
-    var lk = lock_mod.LockFile.acquire(ctx.io, lock_path, lockTimeoutMs(ctx)) catch {
-        output.err("Another mt process is running. Wait or run mt doctor.", .{});
-        return error.Aborted;
+    var lk = lock_mod.LockFile.acquire(ctx.io, lock_path, lockTimeoutMs(ctx)) catch |e| switch (e) {
+        // The DB is already open here, so db/ exists — DirMissing can't occur.
+        error.DirMissing => return error.Aborted,
+        else => {
+            lock_report.reportAcquireFailure(e, prefix);
+            return error.Aborted;
+        },
     };
     defer lk.release(ctx.io);
     // LIFO: install_complete fires before lk.release. Inline gate keeps

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -280,6 +280,18 @@ fn dispatchCask(
     }
 
     const prefix = atomic.maltPrefixOrAbort();
+
+    // Serialize the uninstall+reinstall on the prefix lock, exactly like the
+    // keg path — acquired only after the read-only early returns so --list and
+    // --dry-run stay lock-free.
+    var lock_buf: [512]u8 = undefined;
+    const lock_path = std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix}) catch return error.Aborted;
+    var lk = lock_mod.LockFile.acquire(ctx.io, lock_path, 30000) catch {
+        output.err("Another mt process is running", .{});
+        return error.Aborted;
+    };
+    defer lk.release(ctx.io);
+
     var installer = cask_mod.CaskInstaller.init(ctx.io, ctx.environ, allocator, db, prefix);
     installer.offline = ctx.offline;
     installer.reinstallFromHistory(token, target_pkg_version) catch |e| {
@@ -1250,4 +1262,44 @@ test "removeCurrentCellarDir wipes a plain version dir when revision is zero" {
     try removeCurrentCellarDir(io, prefix, name, version, 0);
 
     try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(io, keg_dir, .{}));
+}
+
+test "dispatchCask acquires malt.lock before the reinstall mutation" {
+    // dispatchCask drives a real CaskInstaller against a live prefix, so it
+    // can't be exercised in isolation. The invariant that matters — the
+    // uninstall+reinstall must serialize on the prefix lock, like every other
+    // mutating command — is pinned at the source level: `LockFile.acquire`
+    // must precede `reinstallFromHistory` inside the function body.
+    const src = @embedFile("rollback.zig");
+    const marker = "fn dispatchCask(";
+    const start = std.mem.indexOf(u8, src, marker) orelse return error.DispatchCaskFnNotFound;
+
+    var depth: usize = 0;
+    var seen_open = false;
+    var body_end: usize = 0;
+    var i: usize = start + marker.len;
+    while (i < src.len) : (i += 1) {
+        switch (src[i]) {
+            '{' => {
+                depth += 1;
+                seen_open = true;
+            },
+            '}' => {
+                depth -= 1;
+                if (seen_open and depth == 0) {
+                    body_end = i;
+                    break;
+                }
+            },
+            else => {},
+        }
+    }
+    try testing.expect(body_end > start);
+    const body = src[start..body_end];
+
+    const acquire_pos = std.mem.indexOf(u8, body, "LockFile.acquire") orelse
+        return error.LockAcquireMissing;
+    const mutate_pos = std.mem.indexOf(u8, body, "reinstallFromHistory") orelse
+        return error.ReinstallCallMissing;
+    try testing.expect(acquire_pos < mutate_pos);
 }

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -6,6 +6,7 @@ const AppCtx = @import("../app_ctx.zig").AppCtx;
 const sqlite = @import("../db/sqlite.zig");
 const schema = @import("../db/schema.zig");
 const lock_mod = @import("../db/lock.zig");
+const lock_report = @import("lock_report.zig");
 const cellar = @import("../core/cellar.zig");
 const cask_mod = @import("../core/cask.zig");
 const linker_mod = @import("../core/linker.zig");
@@ -159,9 +160,15 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // Acquire lock
     var lock_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix}) catch return error.Aborted;
-    var lk = lock_mod.LockFile.acquire(ctx.io, lock_path, 30000) catch {
-        output.err("Another mt process is running", .{});
-        return error.Aborted;
+    var lk = lock_mod.LockFile.acquire(ctx.io, lock_path, 30000) catch |e| switch (e) {
+        // The DB is already open here, so db/ exists — DirMissing can't occur.
+        error.DirMissing => return error.Aborted,
+        // Every other failure gets an accurate, actionable diagnostic
+        // (permissions, contention, …) instead of a blanket message.
+        else => {
+            lock_report.reportAcquireFailure(e, prefix);
+            return error.Aborted;
+        },
     };
     defer lk.release(ctx.io);
 
@@ -286,9 +293,15 @@ fn dispatchCask(
     // --dry-run stay lock-free.
     var lock_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix}) catch return error.Aborted;
-    var lk = lock_mod.LockFile.acquire(ctx.io, lock_path, 30000) catch {
-        output.err("Another mt process is running", .{});
-        return error.Aborted;
+    var lk = lock_mod.LockFile.acquire(ctx.io, lock_path, 30000) catch |e| switch (e) {
+        // The DB is already open here, so db/ exists — DirMissing can't occur.
+        error.DirMissing => return error.Aborted,
+        // Every other failure gets an accurate, actionable diagnostic
+        // (permissions, contention, …) instead of a blanket message.
+        else => {
+            lock_report.reportAcquireFailure(e, prefix);
+            return error.Aborted;
+        },
     };
     defer lk.release(ctx.io);
 
@@ -1302,4 +1315,8 @@ test "dispatchCask acquires malt.lock before the reinstall mutation" {
     const mutate_pos = std.mem.indexOf(u8, body, "reinstallFromHistory") orelse
         return error.ReinstallCallMissing;
     try testing.expect(acquire_pos < mutate_pos);
+
+    // Acquire failures must surface accurate per-error diagnostics via the
+    // shared reporter, not a blanket "another process" message.
+    try testing.expect(std.mem.indexOf(u8, body, "reportAcquireFailure") != null);
 }


### PR DESCRIPTION
## Description

`mt rollback <cask>` ran its uninstall+reinstall writing the `casks`/`cask_versions` rows and mutating the Caskroom on disk without acquiring the prefix advisory lock. Every other mutating command, including the keg rollback path, takes `<prefix>/db/malt.lock` before touching shared state, so a concurrent `install`/`upgrade`/`uninstall` was free to interleave its DB and Caskroom writes with a cask rollback.

This makes cask rollback serialize on `malt.lock` exactly like the keg path: the lock is acquired only after the `--list` and `--dry-run` early returns and released via `defer`, so read-only paths stay lock-free while the mutating path now has the same mutual-exclusion guarantee as the rest of the CLI. The fix lives entirely at the CLI layer, `core/cask.zig` is not self-locked because `install`/`upgrade` already hold the lock when they call into it.

It also removes a long-standing UX divergence: `rollback`, `migrate`, and `install` collapsed every lock-acquire failure into a blanket "Another mt process is running", while `uninstall`/`upgrade` already surfaced accurate,
actionable diagnostics. All commands now share one reporter, so a permission problem, a real timeout, or a stale lock each get their own clear message and fix hint. `install` keeps emitting through its output sink, so bundle mode
stays quiet.

## Related Issue

- None

## Notes for Reviewers

- None