### PR TITLE
fix(update): only notify when the released version is actually newer

### DIFF
--- a/scripts/regressions/version-notifier-semver-ordering-version-update.sh
+++ b/scripts/regressions/version-notifier-semver-ordering-version-update.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Regression: the passive version notifier decided whether to nag with a
+# pure string inequality (current != latest), never a semver ordering. A
+# build whose running version was *ahead* of the cached `latest_tag` was
+# still told "A newer malt is available", i.e. nagged to downgrade.
+#
+# Pre-seed a fresh cache (far-future checked_at => never stale, so no
+# network is needed) naming a LOWER latest than the running version, force
+# a TTY (the notifier suppresses on non-TTY stderr), and assert it stays
+# silent. Exits non-zero when the downgrade nag is present, 0 once the
+# semver guard lands. No network; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+cur="$("$BIN" version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[^ ]*')"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Fresh cache (far-future checked_at => never stale) naming a LOWER latest
+# than current. last_attempt == checked_at is the success shape.
+future=$(($(date +%s) + 86400))
+printf '{"checked_at":%d,"latest_tag":"v0.0.1","current_seen":"%s","last_attempt":%d}\n' \
+  "$future" "$cur" "$future" >"$tmp/version-notify.json"
+
+# Force a TTY (notifier is suppressed on non-TTY stderr); clear CI/json/quiet
+# suppressors. `script -q /dev/null` allocates a pty on macOS.
+out="$(env -u CI -u GITHUB_ACTIONS MALT_CACHE="$tmp" \
+  script -q /dev/null "$BIN" list 2>&1 || true)"
+
+if grep -q "A newer malt is available" <<<"$out"; then
+  echo "FAIL: notifier nagged about v0.0.1 while on $cur (latest < current must be silent)" >&2
+  exit 1
+fi
+
+# Positive guard: a clearly higher latest must still fire, so the fix
+# rejects equal/behind without over-suppressing real updates.
+printf '{"checked_at":%d,"latest_tag":"v999.0.0","current_seen":"%s","last_attempt":%d}\n' \
+  "$future" "$cur" "$future" >"$tmp/version-notify.json"
+out_hi="$(env -u CI -u GITHUB_ACTIONS MALT_CACHE="$tmp" \
+  script -q /dev/null "$BIN" list 2>&1 || true)"
+if ! grep -q "A newer malt is available" <<<"$out_hi"; then
+  echo "FAIL: notifier stayed silent about v999.0.0 while on $cur (real update suppressed)" >&2
+  exit 1
+fi
+
+echo "ok: no downgrade nag when cached latest < current; still nags when latest > current"

--- a/src/update/notifier/policy.zig
+++ b/src/update/notifier/policy.zig
@@ -19,9 +19,10 @@ pub const failure_backoff_secs: i64 = 5 * 60;
 pub fn shouldNotify(current: []const u8, latest_tag: []const u8, current_seen: []const u8) bool {
     const latest_no_v = release.stripVPrefix(latest_tag);
     if (latest_no_v.len == 0) return false;
-    if (std.mem.eql(u8, current, latest_no_v)) return false;
     if (std.mem.eql(u8, current, current_seen) and std.mem.eql(u8, current_seen, latest_no_v)) return false;
-    return true;
+    // Fire only when the released version is semantically newer — an equal
+    // or behind `latest` (e.g. an ahead-of-release dev build) must not nag.
+    return release.order(latest_no_v, current) == .gt;
 }
 
 pub fn cacheStale(now_secs: i64, checked_at: i64, ttl: i64) bool {
@@ -123,6 +124,16 @@ test "shouldNotify: post-update suppression — current_seen matches both" {
 test "shouldNotify: stale cache with mismatched current_seen still fires" {
     // Cache predates a downgrade-then-cache-rewrite; safe default is to fire.
     try std.testing.expect(shouldNotify("0.9.0", "v0.10.0", "0.8.0"));
+}
+
+test "shouldNotify: latest behind current never fires (no downgrade nag)" {
+    try std.testing.expect(!shouldNotify("0.20.0", "v0.0.1", ""));
+    try std.testing.expect(!shouldNotify("0.10.0", "v0.9.0", "0.10.0"));
+}
+
+test "shouldNotify: a pre-release build ahead of latest stays quiet" {
+    // Running 0.20.0-dev while the published latest is v0.19.3 — you're ahead.
+    try std.testing.expect(!shouldNotify("0.20.0-dev", "v0.19.3", ""));
 }
 
 test "cacheStale: TTL boundary" {

--- a/src/update/release.zig
+++ b/src/update/release.zig
@@ -107,3 +107,52 @@ pub fn strField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
 pub fn stripVPrefix(tag: []const u8) []const u8 {
     return if (tag.len > 0 and tag[0] == 'v') tag[1..] else tag;
 }
+
+/// Order two release strings by their `major.minor.patch` core, ignoring
+/// any pre-release suffix (everything from the first `-`). Degrades to a
+/// byte comparison when either side is not a clean numeric triple, so a
+/// malformed tag never silences a real update — it just behaves as the
+/// old string compare did. Callers strip a leading `v` first.
+pub fn order(a: []const u8, b: []const u8) std.math.Order {
+    const ta = coreTriple(a) orelse return std.mem.order(u8, a, b);
+    const tb = coreTriple(b) orelse return std.mem.order(u8, a, b);
+    for (ta, tb) |x, y| {
+        const o = std.math.order(x, y);
+        if (o != .eq) return o;
+    }
+    return .eq;
+}
+
+fn coreTriple(tag: []const u8) ?[3]u64 {
+    const core = if (std.mem.indexOfScalar(u8, tag, '-')) |i| tag[0..i] else tag;
+    var it = std.mem.splitScalar(u8, core, '.');
+    var out: [3]u64 = undefined;
+    inline for (0..3) |i| {
+        const part = it.next() orelse return null;
+        out[i] = std.fmt.parseInt(u64, part, 10) catch return null;
+    }
+    if (it.next() != null) return null; // extra components ⇒ not a clean triple
+    return out;
+}
+
+// --- inline tests --------------------------------------------------------
+
+test "order: numeric semver, not byte ordering" {
+    try std.testing.expectEqual(std.math.Order.lt, order("0.19.3", "0.20.0"));
+    try std.testing.expectEqual(std.math.Order.gt, order("0.20.0", "0.19.3"));
+    try std.testing.expectEqual(std.math.Order.eq, order("0.20.0", "0.20.0"));
+    // Byte comparison ranks "0.9.0" after "0.10.0"; semver must not.
+    try std.testing.expectEqual(std.math.Order.gt, order("0.10.0", "0.9.0"));
+}
+
+test "order: pre-release suffix compares by the core triple" {
+    try std.testing.expectEqual(std.math.Order.eq, order("0.20.0-dev", "0.20.0"));
+    try std.testing.expectEqual(std.math.Order.gt, order("0.20.0-dev", "0.19.3"));
+    try std.testing.expectEqual(std.math.Order.lt, order("0.19.3", "0.20.0-rc1"));
+}
+
+test "order: malformed component degrades to byte comparison" {
+    try std.testing.expectEqual(std.mem.order(u8, "1.x.0", "1.2.0"), order("1.x.0", "1.2.0"));
+    try std.testing.expectEqual(std.mem.order(u8, "1.2", "1.2.0"), order("1.2", "1.2.0"));
+    try std.testing.expectEqual(std.mem.order(u8, "1.2.3.4", "1.2.3"), order("1.2.3.4", "1.2.3"));
+}

--- a/tests/version_notify_test.zig
+++ b/tests/version_notify_test.zig
@@ -31,7 +31,8 @@ test "shouldNotify: full table — equal/newer/post-update" {
         .{ .current = "0.10.0", .latest = "0.10.1", .seen = "", .want = true },
         .{ .current = "0.10.1", .latest = "v0.10.1", .seen = "0.10.1", .want = false },
         .{ .current = "0.10.0", .latest = "", .seen = "", .want = false },
-        .{ .current = "0.10.0", .latest = "v0.9.0", .seen = "", .want = true },
+        // Latest semver-behind current: byte inequality once nagged; semver stays quiet.
+        .{ .current = "0.10.0", .latest = "v0.9.0", .seen = "", .want = false },
     };
     for (cases) |c| {
         const got = notifier.shouldNotify(c.current, c.latest, c.seen);


### PR DESCRIPTION
## Description


This adds:

- a small pure comparator `release.order(a, b)` parsing the
`major.minor.patch` core, ignores any pre-release suffix, and degrades to abyte comparison on a malformed tag so a real update is never silenced 
- rewires `shouldNotify` to fire only when `release.order(latest, current) == .gt`.

## Related Issue

- None

## Notes for Reviewers

- None