### PR TITLE
fix(update): never offer a downgrade and refresh stale version notices faster

### DIFF
--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -35,6 +35,14 @@ pub const Opts = struct {
     cleanup: bool = false,
 };
 
+/// The single gate for "is there a newer release to install". Routed
+/// through the same comparator as the passive notifier so the explicit
+/// updater and the nag never disagree — an equal or ahead-of-latest build
+/// is never offered a downgrade.
+pub fn updateAvailable(latest: []const u8, current: []const u8) bool {
+    return release.order(latest, current) == .gt;
+}
+
 pub fn parseArgs(args: []const []const u8) Opts {
     var opts = Opts{};
     for (args) |a| {
@@ -101,10 +109,10 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     };
     const latest = release.stripVPrefix(tag);
 
-    if (std.mem.eql(u8, latest, current_version)) {
-        // Freshen the passive notifier cache so a manual `--check` that
-        // confirms the running version stops the next invocation from
-        // nagging about an already-installed release.
+    if (!updateAvailable(latest, current_version)) {
+        // Nothing strictly newer to install — equal, or an ahead-of-latest
+        // dev build. Freshen the passive notifier cache so a manual `--check`
+        // stops the next invocation from nagging about an installed release.
         notifier.markUpdatedTo(ctx, tag, current_version);
         output.info("Already up to date ({s})", .{current_version});
         return;

--- a/src/update/notifier.zig
+++ b/src/update/notifier.zig
@@ -19,6 +19,8 @@ const policy = @import("notifier/policy.zig");
 
 pub const cache_ttl_secs = policy.cache_ttl_secs;
 pub const failure_backoff_secs = policy.failure_backoff_secs;
+pub const behind_refresh_secs = policy.behind_refresh_secs;
+pub const refreshTtl = policy.refreshTtl;
 pub const shouldNotify = policy.shouldNotify;
 pub const cacheStale = policy.cacheStale;
 pub const inFailureBackoff = policy.inFailureBackoff;
@@ -161,18 +163,24 @@ fn runNotify(ctx: *const AppCtx, allocator: std.mem.Allocator, current_version: 
     defer if (state) |s| freeState(allocator, s);
 
     const now = std.Io.Clock.real.now(ctx.io).toSeconds();
+
+    // Whether the cached view already says the user is behind. Computed
+    // first so a behind state can shorten the refresh window below — a
+    // faster point release gets re-fetched promptly instead of waiting out
+    // the full TTL, while up-to-date users still refresh only every TTL.
+    const wants_print = blk: {
+        const s = state orelse break :blk false;
+        break :blk shouldNotify(current_version, s.latest_tag, s.current_seen);
+    };
+
     const need_refresh = if (state) |s| blk: {
-        if (!cacheStale(now, s.checked_at, cache_ttl_secs)) break :blk false;
+        if (!cacheStale(now, s.checked_at, refreshTtl(wants_print))) break :blk false;
         break :blk !inFailureBackoff(now, s.last_attempt, s.checked_at, failure_backoff_secs);
     } else true;
 
     // The 33%-savings clause: cache fresh + no notice due → return without
     // touching `executablePath`/`realpath`. The dominant path on a healthy
     // workstation between refresh windows.
-    const wants_print = blk: {
-        const s = state orelse break :blk false;
-        break :blk shouldNotify(current_version, s.latest_tag, s.current_seen);
-    };
     if (!need_refresh and !wants_print) return;
 
     // Brew installs are owned by `brew upgrade --cask malt`; refresh and

--- a/src/update/notifier/policy.zig
+++ b/src/update/notifier/policy.zig
@@ -14,6 +14,19 @@ pub const cache_ttl_secs: i64 = 24 * 60 * 60;
 /// network is picked up the next time the user runs anything.
 pub const failure_backoff_secs: i64 = 5 * 60;
 
+/// Refresh window once the cache already shows the user is behind. Shorter
+/// than the full TTL so a faster point release is re-fetched promptly
+/// instead of waiting out the 24 h — up-to-date users keep `cache_ttl_secs`
+/// and pay no extra probes.
+pub const behind_refresh_secs: i64 = 60 * 60;
+
+/// Pick the cache freshness window from whether a notice is already due:
+/// the shorter behind-window when the cache says the user is behind, the
+/// full TTL otherwise.
+pub fn refreshTtl(wants_notice: bool) i64 {
+    return if (wants_notice) behind_refresh_secs else cache_ttl_secs;
+}
+
 /// The `current == seen == latest_no_v` clause silences the notice for
 /// users who've just updated while the cache TTL is still alive.
 pub fn shouldNotify(current: []const u8, latest_tag: []const u8, current_seen: []const u8) bool {
@@ -134,6 +147,14 @@ test "shouldNotify: latest behind current never fires (no downgrade nag)" {
 test "shouldNotify: a pre-release build ahead of latest stays quiet" {
     // Running 0.20.0-dev while the published latest is v0.19.3 — you're ahead.
     try std.testing.expect(!shouldNotify("0.20.0-dev", "v0.19.3", ""));
+}
+
+test "refreshTtl: behind shortens the window; up-to-date keeps the full TTL" {
+    try std.testing.expectEqual(cache_ttl_secs, refreshTtl(false));
+    try std.testing.expectEqual(behind_refresh_secs, refreshTtl(true));
+    // The whole point of the fix: the behind window must actually be shorter,
+    // or a faster point release would still wait out the full TTL.
+    try std.testing.expect(behind_refresh_secs < cache_ttl_secs);
 }
 
 test "cacheStale: TTL boundary" {

--- a/tests/version_update_test.zig
+++ b/tests/version_update_test.zig
@@ -58,6 +58,20 @@ test "parseArgs: unrecognised flags are ignored (do not crash)" {
     try testing.expect(opts.yes);
 }
 
+// --- updateAvailable ------------------------------------------------------
+//
+// The single gate for "is there a release to install". Routed through the
+// same semver comparator as the passive notifier so `mt version update` and
+// the nag can never disagree — an ahead-of-latest dev build must report
+// "up to date", not be offered a downgrade.
+
+test "updateAvailable: only a strictly newer release counts" {
+    try testing.expect(updater.updateAvailable("0.10.1", "0.10.0")); // newer
+    try testing.expect(!updater.updateAvailable("0.10.0", "0.10.0")); // equal
+    try testing.expect(!updater.updateAvailable("0.9.0", "0.10.0")); // behind (byte-greater!)
+    try testing.expect(!updater.updateAvailable("0.19.3", "0.20.0-dev")); // ahead dev build
+}
+
 // --- writeResponseBody ---------------------------------------------------
 //
 // BUG-012 regression guard: the old `writeDownload` allocated `path` and


### PR DESCRIPTION
Two follow-ups to the version-notifier semver fix (#573 )

**1. The explicit updater could install a downgrade.** `mt version update` decided "is there an update?"
The decision now routes through the same `release.order` comparator the passive notifier uses (`updateAvailable` -> `release.order(latest, current) == .gt`), so the explicit updater and the passive nag can never disagree, and an equal or ahead build is reported as up to date instead of offered a downgrade.

**2. The notice named a stale `latest_tag` for up to 24 h.** While the cache was fresh, the notifier printed the first-seen tag without re-checking. The refresh window is now shortened (`behind_refresh_secs`, 1 h) **only when the cache already shows the user is behind**, so the correct upgrade target is re-fetched promptly. Up-to-date users keep the full 24 h TTL and pay no extra probes, freshness is spent exactly where it matters.

## Related Issue

- None

## Notes for Reviewers

- Non