### PR TITLE
ci: use force push for benchmark result branch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -197,7 +197,7 @@ jobs:
           git checkout -B "$BRANCH"
           git add README.md
           git commit -m "docs(benchmark): update results ${DATE}"
-          git push --force-with-lease -u origin "$BRANCH"
+          git push --force -u origin "$BRANCH"
 
           cat > /tmp/pr_body.md << 'BODY'
           ## Description


### PR DESCRIPTION
## Description

The weekly benchmark workflow pushes its results to a date-stamped branch (`chore/benchmark-<date>`). When the workflow runs more than once on the same day, the second run recreates the branch locally with `checkout -B` and never fetches the existing remote ref, so `--force-with-lease` aborts with `stale info` and the run fails — even though the benchmark itself succeeded.

The result branch is bot-generated and disposable, so the lease protects nothing. Switching to a plain `--force` lets a re-run overwrite the previous day's branch cleanly.

## Related Issue

- None

## Notes for Reviewers

- None
