### PR TITLE
fix(cask): tell the user when a running app blocks a cask upgrade

### DIFF
--- a/scripts/regressions/cask-upgrade-app-running-error.sh
+++ b/scripts/regressions/cask-upgrade-app-running-error.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Regression: upgrading (or uninstalling) a cask whose app is still running used
+# to abort with the opaque `UninstallFailed`. The cask installer now refuses
+# with a distinct `AppRunning` error, the CLI prints "the app is running. Quit
+# it and try again." and exits with a dedicated code, and the TUI maps that code
+# to a named footer instead of "ChildFailed".
+#
+# The detection needs a live process whose command line carries the bundle path
+# (so `pgrep -f` matches), which no plain CLI invocation sets up in isolation.
+# The guard is therefore a colocated integration test that stages a live process
+# and asserts `uninstall` returns `AppRunning`. This script builds the test
+# binary and judges that test by name; it exits non-zero if the guard regresses
+# or the test goes missing.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s once built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+FILTER="CaskInstaller.uninstall refuses with AppRunning while the app bundle is live"
+
+# The guard lives in a test file; if it is ever deleted the name filter below
+# would match nothing and silently pass. Fail loudly instead.
+if ! grep -Rqs -- "$FILTER" "$ROOT/tests/cask_extra_test.zig"; then
+  echo "FAIL: the cask app-running guard test is missing from cask_extra_test.zig" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/cask_extra_test"
+if [[ ! -x "$BIN" ]]; then
+  (cd "$ROOT" && zig build test-bin -Doptimize=ReleaseSafe >/dev/null 2>&1) || {
+    echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+    exit 1
+  }
+fi
+
+# The runner has no per-test filter, so run the suite and judge only this guard's
+# line: a pass ends in "OK", a regression prints the failure there.
+OUT=$("$BIN" 2>&1 || true)
+LINE=$(printf '%s\n' "$OUT" | grep -F -- "$FILTER" || true)
+if [[ -z "$LINE" ]]; then
+  echo "FAIL: the cask app-running guard test did not run" >&2
+  exit 1
+fi
+if [[ "$LINE" != *OK ]]; then
+  echo "FAIL: uninstall no longer reports AppRunning while the app is live" >&2
+  exit 1
+fi
+
+echo "PASS: a live cask app is refused with a distinct AppRunning error"

--- a/src/cli/uninstall.zig
+++ b/src/cli/uninstall.zig
@@ -281,6 +281,10 @@ fn uninstallCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []cons
 
     var installer = cask_mod.CaskInstaller.init(ctx.io, ctx.environ, allocator, db, prefix);
     installer.uninstall(token) catch |un_err| {
+        if (un_err == error.AppRunning) {
+            output.err("Cannot uninstall {s}: the app is running. Quit it and try again.", .{token});
+            return error.AppRunning;
+        }
         output.err(
             "Failed to uninstall cask {s}: {s} ({s})",
             .{ token, @errorName(un_err), db.errMsg() },

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -189,6 +189,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // item used to exit 0, hiding the failure from CI. We aggregate here
     // and surface error.Aborted so main.zig maps it to a non-zero exit.
     var any_failed = false;
+    var app_running = false; // a named cask refused because its app is live
+    var other_failed = false; // any failure that is not the app-running refusal
 
     if (names.items.len == 0) {
         // Upgrade all. A live `*Tally` threaded down both passes is also
@@ -215,17 +217,25 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             if (!cask_only and isFormulaInstalled(&db, name)) {
                 upgradeFormula(ctx, allocator, name, &db, &api, &http, prefix, dry_run, force, pinned_only, isolate_deps, null) catch {
                     any_failed = true;
+                    other_failed = true;
                 };
                 continue;
             }
             // Not a formula (or --cask): try cask
-            upgradeCask(ctx, allocator, name, &db, &api, prefix, dry_run, force, pinned_only, null) catch {
+            upgradeCask(ctx, allocator, name, &db, &api, prefix, dry_run, force, pinned_only, null) catch |e| {
                 any_failed = true;
+                if (e == error.AppRunning) app_running = true else other_failed = true;
             };
         }
     }
 
-    if (any_failed) return error.Aborted;
+    // A batch whose only failure was a live cask app exits with the dedicated
+    // code so the TUI can footer the real cause; any other failure (even mixed
+    // in) stays the generic abort.
+    if (any_failed) {
+        if (app_running and !other_failed) return error.AppRunning;
+        return error.Aborted;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -611,7 +621,7 @@ fn upgradeTapFormula(
 /// attempt failed". The probe loop in `upgradeTapCaskFallback` continues
 /// on either — the pre-routed call from `upgradeCask` continues only on
 /// the latter (a 404 against a recorded `casks.tap` is user-facing).
-const TapRouteError = error{ NotInTap, Aborted };
+const TapRouteError = error{ NotInTap, Aborted, AppRunning };
 
 /// Upgrade a cask whose owning tap is known. Fetches the tap's
 /// `Casks/<token>.rb` once to read the new version, short-circuits when
@@ -720,8 +730,12 @@ fn upgradeRoutedTapCask(
     };
 
     installer.uninstall(token) catch |un_err| {
-        output.err("Failed to remove old version of {s}: {s}", .{ token, @errorName(un_err) });
         db.rollback();
+        if (un_err == error.AppRunning) {
+            output.err("Cannot upgrade {s}: the app is running. Quit it and try again.", .{token});
+            return error.AppRunning;
+        }
+        output.err("Failed to remove old version of {s}: {s}", .{ token, @errorName(un_err) });
         return error.Aborted;
     };
 
@@ -779,7 +793,7 @@ fn upgradeTapCaskFallback(
     dry_run: bool,
     force: bool,
     tally: ?*Tally,
-) bool {
+) error{AppRunning}!bool {
     const taps = tap_mod.list(allocator, db) catch return false;
     defer {
         for (taps) |t| {
@@ -798,6 +812,8 @@ fn upgradeTapCaskFallback(
             // Either "tap doesn't own this token" or "something went
             // wrong with this tap" — neither is fatal to the probe.
             error.NotInTap, error.Aborted => continue,
+            // The owning tap was found and refused: propagate, don't keep probing.
+            error.AppRunning => return error.AppRunning,
         };
 
         // The owning tap is now known. recordInstall sets `casks.tap`
@@ -988,6 +1004,7 @@ fn upgradeCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []const 
                     output.err("Cask {s} is no longer in tap {s}", .{ token, tap_label });
                     return error.Aborted;
                 },
+                error.AppRunning => return error.AppRunning, // already explained; keep the distinct code
                 error.Aborted => return error.Aborted,
             };
             return;
@@ -999,7 +1016,7 @@ fn upgradeCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []const 
     // third-party tap if the core API 404s — the probe also backfills
     // `casks.tap` for the next invocation.
     const cask_json = api.fetchCask(token) catch {
-        if (upgradeTapCaskFallback(ctx, allocator, token, installed.version(), db, prefix, dry_run, force, tally)) return;
+        if (try upgradeTapCaskFallback(ctx, allocator, token, installed.version(), db, prefix, dry_run, force, tally)) return;
         output.err("Could not fetch cask info for {s}", .{token});
         return error.Aborted;
     };
@@ -1047,11 +1064,15 @@ fn upgradeCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []const 
     };
 
     installer.uninstall(token) catch |un_err| {
+        db.rollback();
+        if (un_err == error.AppRunning) {
+            output.err("Cannot upgrade {s}: the app is running. Quit it and try again.", .{token});
+            return error.AppRunning;
+        }
         output.err(
             "Failed to remove old version of {s}: {s}",
             .{ token, @errorName(un_err) },
         );
-        db.rollback();
         return error.Aborted;
     };
 

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -15,6 +15,8 @@ pub const CaskError = error{
     DownloadFailed,
     InstallFailed,
     UninstallFailed,
+    // Distinct from UninstallFailed so callers can say *why*: the app is live.
+    AppRunning,
     Sha256Mismatch,
     OutOfMemory,
 };
@@ -616,8 +618,9 @@ pub const CaskInstaller = struct {
                 // manifest itself.
                 self.removeManifestedFonts(app_path);
             } else {
-                // Check if the app is running (best-effort)
-                if (isAppRunning(self.io, app_path)) return CaskError.UninstallFailed;
+                // Refuse while the app is live: removing the old bundle would
+                // yank a running app. Distinct error so the caller can say so.
+                if (isAppRunning(self.io, app_path)) return CaskError.AppRunning;
 
                 // app may already be gone (manual delete); continue to DB cleanup.
                 std.Io.Dir.cwd().deleteTree(self.io, app_path) catch {};

--- a/src/main.zig
+++ b/src/main.zig
@@ -498,6 +498,9 @@ pub fn main(init: std.process.Init.Minimal) !void {
         // still surface loudly. Truly unexpected errors propagate too.
         const install_family = cmd == .install or cmd == .reinstall or cmd == .upgrade;
         dispatch(allocator, &ctx, cmd, cmd_args) catch |e| switch (e) {
+            // Dedicated code so the TUI can footer the cause; mirrored in
+            // `tui/app.zig`. Message already printed, like Aborted below.
+            error.AppRunning => std.process.exit(3),
             error.Aborted => std.process.exit(1),
             else => if (install_family and install.isReportedInstallError(e)) std.process.exit(1) else return e,
         };

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -1082,6 +1082,21 @@ fn kindUpgradeArgv(
     return try spawn.inlineArgv(allocator, mt_path, rest);
 }
 
+/// The exit code `mt upgrade` returns when it refused a cask because the app is
+/// still running. Mirrors `main.zig`'s `AppRunning` exit mapping — the mt→TUI
+/// process contract, like the doctor severity cap the inline runner already knows.
+const cask_app_running_exit: u8 = 3;
+
+/// Footer detail for a failed cask upgrade pass: on the app-running refusal name
+/// the live app (or "a selected app" when the pass carried several) so the footer
+/// says *why*, not an opaque "ChildFailed". `buf` backs the single-cask name;
+/// `Banner.set` copies the result, so a stack buffer is enough.
+fn upgradeFailDetail(buf: []u8, code: u8, refs: []const UpgradedRef) []const u8 {
+    if (code != cask_app_running_exit) return "ChildFailed";
+    if (refs.len == 1) return std.fmt.bufPrint(buf, "{s} is running", .{refs[0].name}) catch "an app is running";
+    return "a selected app is running";
+}
+
 /// Delegate the checked upgrades to the real `mt` inline, then drop the upgraded
 /// rows in place. Runs one pass per kind (`--formula`, `--cask`) so the row the
 /// user checked is the row upgraded — `mt upgrade <name>` is formula-first, so a
@@ -1108,9 +1123,14 @@ fn doUpgrade(allocator: std.mem.Allocator, t: *term.Term, app: *App, store: *Sto
     for (passes) |pass| {
         const argv = (try kindUpgradeArgv(allocator, app.mt_path, pass.refs, pass.flag)) orelse continue;
         defer allocator.free(argv);
-        if (spawn.runInlineReenter(t, argv)) |_| {
-            try dropUpgradedRows(allocator, app, store, pass.refs);
-            dropped_any = true;
+        if (spawn.runInlineReenterStatus(t, argv)) |code| {
+            if (code == 0) {
+                try dropUpgradedRows(allocator, app, store, pass.refs);
+                dropped_any = true;
+            } else {
+                var dbuf: [96]u8 = undefined;
+                app.banner.set("upgrade failed", upgradeFailDetail(&dbuf, code, pass.refs));
+            }
         } else |err| {
             app.banner.set("upgrade failed", @errorName(err));
         }
@@ -2352,6 +2372,22 @@ test "service leaves an in-flight audit running when no mutation is pending" {
 
     try std.testing.expect(anyFetchActive(&fetches)); // untouched: navigation never blocks on an audit
     reapAllFetches(t.io(), std.testing.allocator, &fetches); // tidy the still-running child
+}
+
+test "upgradeFailDetail names the live app on the refusal code, else stays generic" {
+    var buf: [96]u8 = undefined;
+    const one = [_]UpgradedRef{.{ .name = "flux-markdown", .kind = .cask }};
+    const many = [_]UpgradedRef{ .{ .name = "a", .kind = .cask }, .{ .name = "b", .kind = .cask } };
+
+    // The refusal code names the one cask, or stays generic for a batch.
+    try std.testing.expectEqualStrings("flux-markdown is running", upgradeFailDetail(&buf, cask_app_running_exit, &one));
+    try std.testing.expectEqualStrings("a selected app is running", upgradeFailDetail(&buf, cask_app_running_exit, &many));
+    // Any other non-zero exit is the generic child failure, unnamed.
+    try std.testing.expectEqualStrings("ChildFailed", upgradeFailDetail(&buf, 1, &one));
+
+    // Edge: a name longer than the buffer falls back rather than truncating mid-name.
+    var tiny: [4]u8 = undefined;
+    try std.testing.expectEqualStrings("an app is running", upgradeFailDetail(&tiny, cask_app_running_exit, &one));
 }
 
 test "dropUpgradedRows removes upgraded rows in place and preserves kept checked state" {

--- a/src/tui/spawn.zig
+++ b/src/tui/spawn.zig
@@ -298,14 +298,14 @@ pub fn runInline(t: *term.Term, argv: []const []const u8) InlineError!void {
 /// child outcome is captured (not thrown) so re-entry happens regardless, then
 /// returned, so a failed mutation lands the user back in the dashboard with
 /// `mt`'s real output already in their scrollback.
-fn aroundReenter(ctrl: anytype, body: anytype) !void {
+fn aroundReenter(ctrl: anytype, body: anytype) !@typeInfo(@TypeOf(body.run())).error_union.payload {
     ctrl.leave(); // hand the terminal to the child
-    const child = body.run(); // capture: the child's failure is data, not a throw
+    const child = body.run(); // capture: the child's outcome is data, not a throw
     ctrl.enter() catch |e| {
         ctrl.leave(); // a real terminal fault is fatal — leave it restored
         return e;
     };
-    return child; // back in the dashboard; surface a non-zero child exit as a value
+    return child; // back in the dashboard; surface the child's value (void or exit code)
 }
 
 /// Run a delegated mutation inline on the graceful path: a non-zero child exit
@@ -320,6 +320,29 @@ pub fn runInlineReenter(t: *term.Term, argv: []const []const u8) InlineError!voi
 /// cap, a signal, or a terminal fault surfaces as an error.
 pub fn runInlineReenterTolerant(t: *term.Term, argv: []const []const u8, max_ok_exit: u8) InlineError!void {
     return aroundReenter(TermCtrl{ .t = t }, ChildBody{ .io = t.io, .argv = argv, .max_ok_exit = max_ok_exit });
+}
+
+/// The mutation body that yields the child's exit code instead of collapsing
+/// non-zero to `ChildFailed`. A signal/stop has no code, so it stays an error.
+const StatusBody = struct {
+    io: std.Io,
+    argv: []const []const u8,
+    fn run(self: StatusBody) SpawnError!u8 {
+        var child = std.process.spawn(self.io, .{ .argv = self.argv }) catch return error.SpawnFailed;
+        return switch (child.wait(self.io) catch return error.WaitFailed) {
+            .exited => |code| code,
+            .signal, .stopped, .unknown => error.ChildFailed,
+        };
+    }
+};
+
+/// Like `runInlineReenter`, but return the child's exit code (0 = success)
+/// rather than mapping every non-zero to `ChildFailed`, so the caller can
+/// branch on a specific code — e.g. the cask "app is running" refusal — for a
+/// precise footer. Re-enters the dashboard regardless; only a terminal re-enter
+/// fault (or a spawn/signal fault) surfaces as an error.
+pub fn runInlineReenterStatus(t: *term.Term, argv: []const []const u8) InlineError!u8 {
+    return aroundReenter(TermCtrl{ .t = t }, StatusBody{ .io = t.io, .argv = argv });
 }
 
 // ─── tests ───────────────────────────────────────────────────────────
@@ -542,4 +565,34 @@ test "aroundReenter treats a re-enter fault as fatal and restores the terminal" 
     try testing.expectError(error.Reenter, aroundReenter(&ft, FakeBody{ .fails = false, .log = &log }));
     try testing.expectEqualStrings("LSEL", log.items); // leave, spawn, enter(fail), leave
     try testing.expect(!ft.entered);
+}
+
+const FakeStatusBody = struct {
+    code: u8,
+    log: *std.ArrayList(u8),
+    fn run(self: FakeStatusBody) error{Spawn}!u8 {
+        self.log.append(testing.allocator, 'S') catch {};
+        return self.code;
+    }
+};
+
+test "aroundReenter hands back the child's exit code and ends in the dashboard" {
+    var log: std.ArrayList(u8) = .empty;
+    defer log.deinit(testing.allocator);
+    var ft: FakeTerm = .{ .log = &log };
+    const code = try aroundReenter(&ft, FakeStatusBody{ .code = 3, .log = &log });
+    try testing.expectEqual(@as(u8, 3), code); // a non-zero exit is a value, not a throw
+    try testing.expectEqualStrings("LSE", log.items);
+    try testing.expect(ft.entered);
+}
+
+test "StatusBody.run yields the real child exit code and faults on a missing program" {
+    var t = threaded();
+    defer t.deinit();
+    // `true`/`false` exit 0/1 with no shell — a non-zero code is a value here,
+    // not the collapsed ChildFailed. The specific 3 mapping is covered by the
+    // FakeStatusBody test above; src/ forbids `sh -c` literals.
+    try testing.expectEqual(@as(u8, 0), try StatusBody.run(.{ .io = t.io(), .argv = &.{"/usr/bin/true"} }));
+    try testing.expectEqual(@as(u8, 1), try StatusBody.run(.{ .io = t.io(), .argv = &.{"/usr/bin/false"} }));
+    try testing.expectError(error.SpawnFailed, StatusBody.run(.{ .io = t.io(), .argv = &.{"/nonexistent/mt"} }));
 }

--- a/tests/cask_extra_test.zig
+++ b/tests/cask_extra_test.zig
@@ -38,6 +38,57 @@ test "CaskInstaller.uninstall on a missing token returns UninstallFailed" {
     try testing.expectError(cask.CaskError.UninstallFailed, installer.uninstall("nope-nope"));
 }
 
+test "CaskInstaller.uninstall refuses with AppRunning while the app bundle is live" {
+    const test_cask_json =
+        \\{"token":"running-app","name":["Running"],"version":"1.0","desc":"","homepage":"",
+        \\ "url":"https://example.com/running.dmg",
+        \\ "sha256":"00000000000000000000000000000000000000000000000000000000deadbeef",
+        \\ "auto_updates":false,"artifacts":[{"app":["Running.app"]}]}
+    ;
+    var c = try cask.parseCask(testing.allocator, test_cask_json);
+    defer c.deinit();
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    const base = "/tmp/malt_cask_running_test";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, base);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    const app_path_z = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/Running.app", .{base}, 0);
+    defer testing.allocator.free(app_path_z);
+    try test_io.makeDirAbsolute(std.Options.debug_io, app_path_z);
+    try cask.recordInstall(&db, &c, app_path_z, null);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // Stand in for the running .app: a live process whose argv carries the
+    // bundle path so `pgrep -f` matches. `read x` blocks on the unwritten pipe,
+    // so it stays a single process with no orphaned child to leak.
+    var child = try std.process.spawn(io, .{
+        .argv = &.{ "/bin/sh", "-c", "read x", app_path_z },
+        .stdin = .pipe,
+        .stdout = .ignore,
+        .stderr = .ignore,
+    });
+    defer child.kill(io); // kill also reaps
+
+    // Spawn→exec is async; poll until pgrep can see it. Each probe spawns
+    // pgrep (~ms), so the loop self-paces without a sleep dependency.
+    var tries: usize = 0;
+    while (tries < 300 and !cask.CaskInstaller.isAppRunningPub(io, app_path_z)) : (tries += 1) {}
+
+    const prefix: [:0]const u8 = "/tmp/mc-running";
+    test_io.cwd().createDirPath(std.Options.debug_io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    var installer = cask.CaskInstaller.init(io, testEnviron(), testing.allocator, &db, prefix);
+    // Distinct from UninstallFailed so the CLI can say "the app is running".
+    try testing.expectError(cask.CaskError.AppRunning, installer.uninstall("running-app"));
+}
+
 test "CaskInstaller.isOutdated returns false for an unknown token" {
     var db = try sqlite.Database.open(":memory:");
     defer db.close();


### PR DESCRIPTION
## Description

Upgrading (or uninstalling) a cask whose app was still running aborted with the opaque `Failed to remove old version of <token>: UninstallFailed`, and the TUI showed only `upgrade failed: ChildFailed`, neither said the real cause was a live app.

The cask installer now refuses with a distinct `AppRunning` error. The CLI prints `Cannot upgrade <token>: the app is running. Quit it and try again.` and exits with a dedicated code; `mt upgrade` emits that code only when a live app is the sole failure. The TUI maps the code to a named footer (`upgrade failed: <token> is running`) instead of `ChildFailed`.

## Related Issue

- None

## Notes for Reviewers

- None