### PR TITLE
fix(tui): reword a test comment that tripped the spawn-invariant lint

### DIFF
--- a/src/tui/spawn.zig
+++ b/src/tui/spawn.zig
@@ -591,7 +591,7 @@ test "StatusBody.run yields the real child exit code and faults on a missing pro
     defer t.deinit();
     // `true`/`false` exit 0/1 with no shell — a non-zero code is a value here,
     // not the collapsed ChildFailed. The specific 3 mapping is covered by the
-    // FakeStatusBody test above; src/ forbids `sh -c` literals.
+    // FakeStatusBody test above; src/ forbids shell-invocation argv literals.
     try testing.expectEqual(@as(u8, 0), try StatusBody.run(.{ .io = t.io(), .argv = &.{"/usr/bin/true"} }));
     try testing.expectEqual(@as(u8, 1), try StatusBody.run(.{ .io = t.io(), .argv = &.{"/usr/bin/false"} }));
     try testing.expectError(error.SpawnFailed, StatusBody.run(.{ .io = t.io(), .argv = &.{"/nonexistent/mt"} }));


### PR DESCRIPTION
## Description

The argv spawn-lint (`scripts/lint-spawn-invariants.sh`, run by the security smoke) greps `src/**.zig` for shell-invocation literals. A test comment in `src/tui/spawn.zig` contained the forbidden pattern verbatim while explaining the rule, so the comment tripped the rule and failed CI. Reworded to drop the literal - no behaviour change.

## Related Issue

- None

## Notes for Reviewers

- None