### PR TITLE
fix(install): fail loudly when a dependency formula can't be fetched

### DIFF
--- a/scripts/regressions/getdeps-swallows-fetch-failures-empty-list.sh
+++ b/scripts/regressions/getdeps-swallows-fetch-failures-empty-list.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Regression: deps.resolve must fail loudly when a dependency's own formula
+# JSON can't be fetched. getDeps ran `api.fetchFormula(name) catch return &.{}`,
+# so a transient ApiUnreachable (or a 404/OOM) on a dep was indistinguishable
+# from "this formula declares zero dependencies". resolve folded that empty
+# result in and the install proceeded with a truncated graph: the keg reports
+# success but is unloadable at runtime (`dyld: Library not loaded`) because the
+# missing transitive deps were never queued.
+#
+# The fix propagates the fetch failure out of getDeps and maps it to
+# error.ResolutionFailed in resolve, which the install caller already routes
+# into "Failed to resolve <pkg>". No CLI subcommand drives resolve against an
+# unreachable API without real network, so the guard is a colocated `test {}`
+# that points BrewApi at a refused loopback port (no egress) and asserts the
+# empty cache forces getDeps → fetchFormula → ApiUnreachable to surface as
+# error.ResolutionFailed rather than a zero-length success slice. This script
+# builds the test binary and judges that test by name; it exits non-zero if the
+# guard regresses or the test goes missing.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required (loopback-only); finishes well under 30s once built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+FILTER="resolve surfaces a dependency-fetch failure as ResolutionFailed, not an empty graph"
+
+# The guard lives in a colocated `test {}`; if it is ever deleted the name
+# filter below would match nothing and silently pass. Fail loudly instead.
+if ! grep -Rqs -- "$FILTER" "$ROOT/src/core/deps.zig"; then
+  echo "FAIL: the resolve fail-loud guard test is missing from deps.zig" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+if [[ ! -x "$BIN" ]]; then
+  (cd "$ROOT" && zig build test-bin -Doptimize=ReleaseSafe >/dev/null 2>&1) || {
+    echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+    exit 1
+  }
+fi
+
+# The runner has no per-test filter, so run the colocated suite and judge only
+# this guard's line: a pass ends in "OK", a regression prints the failure there.
+OUT=$("$BIN" 2>&1 || true)
+LINE=$(printf '%s\n' "$OUT" | grep -F -- "$FILTER" || true)
+if [[ -z "$LINE" ]]; then
+  echo "FAIL: the resolve fail-loud guard test did not run" >&2
+  exit 1
+fi
+if [[ "$LINE" != *OK ]]; then
+  echo "FAIL: a dependency-fetch failure was swallowed into an empty graph" >&2
+  exit 1
+fi
+
+echo "PASS: resolve surfaces a dependency-fetch failure instead of a truncated graph"

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -261,11 +261,14 @@ pub fn collectFormulaJobs(
     // (the same caller allocator) — so the allocator here must match
     // `allocator`, otherwise free on the API-allocated bytes is a no-op
     // on the wrong allocator.
-    const deps = deps_mod.resolve(ctx.io, allocator, formula.name, api, db, cache) catch &.{};
+    // Let a resolve failure propagate: the caller routes it into
+    // "Failed to resolve <pkg>" + failed_count, rather than installing a
+    // truncated dep graph as success.
+    const deps = try deps_mod.resolve(ctx.io, allocator, formula.name, api, db, cache);
     defer {
         for (deps) |d| allocator.free(d.name);
-        // `catch &.{}` yields a static empty slice with no backing
-        // allocation — freeing it would be "invalid free" on safe
+        // A genuinely zero-dep formula resolves to a static empty slice with
+        // no backing allocation — freeing it would be "invalid free" on safe
         // allocators.
         if (deps.len > 0) allocator.free(deps);
     }

--- a/src/core/deps.zig
+++ b/src/core/deps.zig
@@ -112,11 +112,11 @@ pub fn resolve(
         queue.deinit(allocator);
     }
 
+    // A fetch failure on the root's own formula aborts the resolve loudly;
+    // never fold it into an empty graph the caller would treat as success.
     const root_deps = getDeps(allocator, root_name, api, cache) catch {
-        return result.toOwnedSlice(allocator) catch blk: {
-            result.deinit(allocator);
-            break :blk &.{};
-        };
+        result.deinit(allocator);
+        return error.ResolutionFailed;
     };
     defer allocator.free(root_deps);
 
@@ -154,7 +154,15 @@ pub fn resolve(
 
         // Fan out into this dep's own dependencies.
         if (!installed) {
-            const sub_deps = getDeps(allocator, dep_name, api, cache) catch continue;
+            // A dep whose own formula can't be fetched would leave its
+            // transitive closure silently missing — abort instead of folding
+            // a truncated graph into success. `dep_name` is already owned by
+            // `result`, so freeing `result`'s names covers it.
+            const sub_deps = getDeps(allocator, dep_name, api, cache) catch {
+                for (result.items) |r| allocator.free(r.name);
+                result.deinit(allocator);
+                return error.ResolutionFailed;
+            };
             defer allocator.free(sub_deps);
 
             for (sub_deps) |sub_dep| {
@@ -292,7 +300,10 @@ fn getDeps(
 ) ![][]const u8 {
     if (cache.get(name)) |formula| return dupeDepNames(allocator, formula.dependencies);
 
-    const json_bytes = api.fetchFormula(name) catch return &.{};
+    // Propagate the fetch failure — a missing/unreachable formula JSON must
+    // not masquerade as "zero deps". The Value-walk fallback below stays
+    // reachable only for bytes that fetched but failed `parseFormula`.
+    const json_bytes = try api.fetchFormula(name);
     defer allocator.free(json_bytes);
 
     if (cache.getOrParse(name, json_bytes)) |formula| {
@@ -501,4 +512,100 @@ test "isInstalled returns true when both cellar and opt link resolve" {
     try parent_dir.symLink(io, cellar_path, "beta", .{});
 
     try testing.expect(isInstalled(io, &db, "beta"));
+}
+
+// --- resolve fail-loud on dependency-fetch failure ------------------------
+
+test "resolve surfaces a dependency-fetch failure as ResolutionFailed, not an empty graph" {
+    const client_mod = @import("../net/client.zig");
+    const schema_mod = @import("../db/schema.zig");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var http = client_mod.HttpClient.init(io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+
+    // Refused loopback port → fetchFormula returns ApiUnreachable. Loopback
+    // only, so no real network egress.
+    var api = api_mod.BrewApi.init(io, testing.allocator, &http, "/tmp/malt_resolve_unreachable_cache");
+    api.base_url = "http://127.0.0.1:9";
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema_mod.initSchema(&db);
+
+    var cache = FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+
+    // Empty cache → resolve hits getDeps → fetchFormula → ApiUnreachable. A
+    // swallowed fetch error would yield a zero-length success slice; the
+    // distinct error is what stops a truncated install graph landing.
+    try testing.expectError(
+        error.ResolutionFailed,
+        resolve(io, testing.allocator, "ghost", &api, &db, &cache),
+    );
+}
+
+test "resolve of a genuinely zero-dep formula returns a success empty slice" {
+    const client_mod = @import("../net/client.zig");
+    const schema_mod = @import("../db/schema.zig");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var http = client_mod.HttpClient.init(io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(io, testing.allocator, &http, "/tmp/malt_resolve_zerodep_cache");
+    api.base_url = "http://127.0.0.1:9";
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema_mod.initSchema(&db);
+
+    var cache = FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+    // Prime the root with a genuinely zero-dep formula so getDeps hits the
+    // cache and never dials out — empty graph here is success, not failure.
+    _ = try cache.getOrParse("solo", testFormulaJson("solo"));
+
+    const deps = try resolve(io, testing.allocator, "solo", &api, &db, &cache);
+    defer testing.allocator.free(deps);
+    try testing.expectEqual(@as(usize, 0), deps.len);
+}
+
+test "resolve aborts when a transitive dependency's formula can't be fetched" {
+    const client_mod = @import("../net/client.zig");
+    const schema_mod = @import("../db/schema.zig");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var http = client_mod.HttpClient.init(io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(io, testing.allocator, &http, "/tmp/malt_resolve_subdep_cache");
+    api.base_url = "http://127.0.0.1:9";
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema_mod.initSchema(&db);
+
+    var cache = FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+    // Root is primed (so its own getDeps hits the cache), but its declared
+    // dep is uncached and the API is unreachable: the dep-level fan-out fetch
+    // must abort the whole resolve, not drop the dep's transitive closure.
+    _ = try cache.getOrParse(
+        "rootpkg",
+        "{\"name\":\"rootpkg\",\"versions\":{\"stable\":\"1.0\"}," ++
+            "\"dependencies\":[\"ghostdep\"],\"oldnames\":[]}",
+    );
+
+    try testing.expectError(
+        error.ResolutionFailed,
+        resolve(io, testing.allocator, "rootpkg", &api, &db, &cache),
+    );
 }

--- a/tests/deps_test.zig
+++ b/tests/deps_test.zig
@@ -329,7 +329,7 @@ test "resolve marks already-installed kegs and skips their sub-deps" {
     try testing.expect(result[0].already_installed);
 }
 
-test "resolve returns empty when root formula JSON is missing from cache" {
+test "resolve fails loudly when the root formula JSON is missing" {
     const alloc = testing.allocator;
 
     var dir = try TempCacheDir.init("resolve_missing_root");
@@ -352,25 +352,26 @@ test "resolve returns empty when root formula JSON is missing from cache" {
     var tdb = try TempDb.init("resolve_missing_root");
     defer tdb.deinit();
 
-    // resolve's getDeps catches errors and returns &.{}, so resolve returns
-    // an empty list (no deps to walk).
     var cache = deps_mod.FormulaCache.init(alloc);
     defer cache.deinit();
 
-    const result = try deps_mod.resolve(std.Options.debug_io, alloc, "nope", &api, &tdb.db, &cache);
-    defer freeResolved(alloc, result);
-    try testing.expectEqual(@as(usize, 0), result.len);
+    // A 404 on the root's own formula is an anomaly, not "zero deps": resolve
+    // must surface it instead of returning an empty graph as success.
+    try testing.expectError(
+        error.ResolutionFailed,
+        deps_mod.resolve(std.Options.debug_io, alloc, "nope", &api, &tdb.db, &cache),
+    );
 }
 
-test "resolve handles a dep whose sub-fetch fails by falling through" {
+test "resolve fails the resolve when a dep's sub-fetch fails" {
     const alloc = testing.allocator;
 
     var dir = try TempCacheDir.init("resolve_dep_missing");
     defer dir.deinit();
 
     // alpha → [missing]. missing has no cache file AND we mark it 404 so the
-    // sub-getDeps fails. The BFS loop should still append `missing` as a
-    // dep before trying to recurse.
+    // sub-getDeps fails. A missing transitive dep must abort the resolve, not
+    // leave its closure silently truncated.
     try dir.writeFormula("alpha", "{\"name\":\"alpha\",\"dependencies\":[\"missing\"]}");
     var marker_buf: [512]u8 = undefined;
     const marker = try std.fmt.bufPrint(&marker_buf, "{s}/api/formula_missing.404", .{dir.path});
@@ -387,11 +388,10 @@ test "resolve handles a dep whose sub-fetch fails by falling through" {
     var cache = deps_mod.FormulaCache.init(alloc);
     defer cache.deinit();
 
-    const result = try deps_mod.resolve(std.Options.debug_io, alloc, "alpha", &api, &tdb.db, &cache);
-    defer freeResolved(alloc, result);
-
-    try testing.expectEqual(@as(usize, 1), result.len);
-    try testing.expectEqualStrings("missing", result[0].name);
+    try testing.expectError(
+        error.ResolutionFailed,
+        deps_mod.resolve(std.Options.debug_io, alloc, "alpha", &api, &tdb.db, &cache),
+    );
 }
 
 // --- ensureOptLink / stale-cellar heal coverage ---------------------------


### PR DESCRIPTION
## Description

A transient or 404 failure fetching a dependency's formula JSON was silently collapsed into "this formula declares zero dependencies." The install then proceeded with a truncated dependency graph and reported **success**, even though the keg was unloadable at runtime (`dyld: Library not loaded`) because its transitive dependencies were never queued.

Dependency resolution now fails loudly: a fetch failure on any formula, the root or a transitive dependency, aborts the resolve with a distinct error. The install path already surfaces that as `Failed to resolve <pkg>` and counts it as a failure, so a half-resolved graph never lands as a successful install. A formula with genuinely zero dependencies still resolves to a successful empty result.

## Related Issue

- None

## Notes for Reviewers

- None