### PR TITLE
fix(outdated): keep revision-bumped formulas in cached listing

### DIFF
--- a/scripts/regressions/cached-outdated-drops-revision-bumped-packages.sh
+++ b/scripts/regressions/cached-outdated-drops-revision-bumped-packages.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Regression: the cached `outdated` serve path filters the snapshot against the
+# live DB with `intersectWithDb`. The snapshot's `installed` field is written
+# revision-qualified (`pkgVersion(version, revision)`, e.g. "1.2.3_1"), but the
+# intersect compared it against the bare `kegs.version` column ("1.2.3"). For any
+# keg with a non-zero Homebrew revision the two strings never matched, so the
+# entry was treated as "upgraded since snapshot" and silently dropped — cached
+# `outdated` hid revision-bumped formulas that `--refresh` lists and `upgrade`
+# still upgrades.
+#
+# No CLI subcommand exercises the pure intersect without seeding a DB and a
+# snapshot, so a standalone ReleaseSafe `zig test` harness drives
+# `intersectWithDb` directly with a revisioned keg row and a revision-qualified
+# snapshot entry. The harness must keep the entry (len == 1); the pre-fix code
+# drops it (len == 0) and the assertion fails.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# The harness imports the module via a repo-relative path, so it must sit at the
+# repo root: outdated.zig's sibling imports (`../app_ctx.zig`, `../db/...`) only
+# resolve from inside the source tree's module boundary.
+HARNESS="$ROOT/.cached-outdated-revision-regression.zig"
+trap 'rm -f "$HARNESS"' EXIT
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const outdated = @import("src/cli/outdated.zig");
+
+// A revisioned keg: DB carries bare version + revision; snapshot carries the
+// revision-qualified `installed`. The intersect must keep it listed.
+test "cached outdated keeps a revision-bumped formula" {
+    const a = std.testing.allocator;
+    const rows = [_]outdated.KegRow{
+        .{ .name = "foo", .version = "1.2.3", .revision = 1 },
+    };
+    const snap = [_]outdated.OutdatedEntry{
+        .{
+            .name = @constCast("foo"),
+            .installed = @constCast("1.2.3_1"),
+            .latest = @constCast("1.3.0"),
+        },
+    };
+    const out = try outdated.intersectWithDb(a, &rows, &snap);
+    defer {
+        for (out) |e| {
+            a.free(e.name);
+            a.free(e.installed);
+            a.free(e.latest);
+        }
+        a.free(out);
+    }
+    try std.testing.expectEqual(@as(usize, 1), out.len);
+}
+ZIG
+
+if (cd "$ROOT" && zig test -OReleaseSafe "$HARNESS") >/dev/null 2>&1; then
+  echo "PASS: cached outdated keeps revision-bumped formulas"
+else
+  echo "FAIL: cached outdated dropped a revision-bumped formula (intersect compared revision-qualified installed against bare version)" >&2
+  exit 1
+fi

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 
 const AppCtx = @import("../app_ctx.zig").AppCtx;
+const formula_mod = @import("../core/formula.zig");
 const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
@@ -94,7 +95,13 @@ pub fn intersectWithDb(
     for (db_rows) |row| {
         const e_ptr = by_name.get(row.name) orelse continue;
         const e = e_ptr.*;
-        if (!std.mem.eql(u8, e.installed, row.version)) continue;
+        // Snapshot `installed` is revision-qualified (assembleEntries); rebuild
+        // the same string from the bare DB version + revision so revisioned
+        // kegs match. Overflow degrades to the bare version, matching the write
+        // side's fallback.
+        var installed_buf: [256]u8 = undefined;
+        const installed = formula_mod.pkgVersion(&installed_buf, row.version, row.revision) catch row.version;
+        if (!std.mem.eql(u8, e.installed, installed)) continue;
         const dup = try dupEntry(allocator, e);
         out.appendAssumeCapacity(dup);
     }
@@ -301,6 +308,37 @@ test "intersectWithDb drops entries whose installed version no longer matches" {
         // user upgraded alpha 1.0 -> 1.5 manually; we don't know if 1.5 is
         // outdated until the snapshot is refreshed, so we drop it.
         .{ .name = "alpha", .version = "1.5" },
+    };
+    const out = try intersectWithDb(std.testing.allocator, &db, &snap);
+    defer freeEntrySlice(std.testing.allocator, out);
+    try std.testing.expectEqual(@as(usize, 0), out.len);
+}
+
+test "intersectWithDb keeps a revision-bumped formula" {
+    // Snapshot writes `installed` revision-qualified (pkgVersion), but the DB
+    // keeps the bare version + separate revision; the match must reconstruct
+    // the qualified string so revisioned kegs survive the intersect.
+    const snap = [_]OutdatedEntry{
+        .{ .name = @constCast("foo"), .installed = @constCast("1.2.3_1"), .latest = @constCast("1.3.0") },
+    };
+    const db = [_]KegRow{
+        .{ .name = "foo", .version = "1.2.3", .revision = 1 },
+    };
+    const out = try intersectWithDb(std.testing.allocator, &db, &snap);
+    defer freeEntrySlice(std.testing.allocator, out);
+    try std.testing.expectEqual(@as(usize, 1), out.len);
+    try std.testing.expectEqualStrings("foo", out[0].name);
+    try std.testing.expectEqualStrings("1.2.3_1", out[0].installed);
+}
+
+test "intersectWithDb drops a keg whose revision moved past the snapshot" {
+    // Match key is the revision-aware installed string, so a manual revision
+    // upgrade (1.2.3_1 -> 1.2.3_2) past the snapshot still re-drops the entry.
+    const snap = [_]OutdatedEntry{
+        .{ .name = @constCast("foo"), .installed = @constCast("1.2.3_1"), .latest = @constCast("1.3.0") },
+    };
+    const db = [_]KegRow{
+        .{ .name = "foo", .version = "1.2.3", .revision = 2 },
     };
     const out = try intersectWithDb(std.testing.allocator, &db, &snap);
     defer freeEntrySlice(std.testing.allocator, out);

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -1252,6 +1252,44 @@ test "outdated execute drops snapshot entries whose keg was uninstalled" {
     try testing.expectEqualStrings("alpha", filtered[0].name);
 }
 
+test "intersectWithDb keeps a revisioned keg loaded from the DB" {
+    // End-to-end: a revisioned keg loads as bare version + revision, while the
+    // snapshot stores the revision-qualified installed. The intersect must
+    // rebuild the qualified string from the row so the keg stays listed.
+    var env = try UpdateEnv.init("outdated_revision_intersect");
+    defer env.deinit();
+
+    {
+        var db = try openUpdateDb(env.prefix_path);
+        defer db.close();
+        try db.exec(
+            "INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path) " ++
+                "VALUES ('alpha', 'alpha', '1.2.3', 1, 'deadbeef', '/cellar/alpha/1.2.3_1');",
+        );
+    }
+
+    const formulas = [_]outdated_mod.OutdatedEntry{
+        .{ .name = @constCast("alpha"), .installed = @constCast("1.2.3_1"), .latest = @constCast("1.3.0") },
+    };
+
+    var db = try openUpdateDb(env.prefix_path);
+    defer db.close();
+    const rows = try outdated_mod.loadFormulaRows(testing.allocator, &db, .all);
+    defer outdated_mod.freeKegRows(testing.allocator, rows);
+    const filtered = try outdated_mod.intersectWithDb(testing.allocator, rows, &formulas);
+    defer {
+        for (filtered) |e| {
+            testing.allocator.free(e.name);
+            testing.allocator.free(e.installed);
+            testing.allocator.free(e.latest);
+        }
+        testing.allocator.free(filtered);
+    }
+    try testing.expectEqual(@as(usize, 1), filtered.len);
+    try testing.expectEqualStrings("alpha", filtered[0].name);
+    try testing.expectEqualStrings("1.2.3_1", filtered[0].installed);
+}
+
 test "outdated execute serves a stale snapshot offline rather than recomputing" {
     var env = try UpdateEnv.init("outdated_stale_uses_cache");
     defer env.deinit();


### PR DESCRIPTION
## Description

Cached `mt outdated` silently hid every revision-bumped formula. The snapshot serve path filtered cached entries against the live DB by comparing the snapshot's revision-qualified `installed` (e.g. `1.2.3_1`) against the bare
`kegs.version` column (`1.2.3`). For any keg with a non-zero Homebrew revision the two strings never matched, so the entry was treated as upgraded-since-
snapshot and dropped - the cached listing diverged from `--refresh` (which lists the package) and from `upgrade` (which still upgrades it).

The intersect now rebuilds the revision-qualified install string from the row's bare version + revision before the equality check, mirroring how the snapshot
write side produces `installed`. Casks and revision-0 formulas are unchanged (`pkgVersion` returns the bare version for revision ≤ 0). The match key stays `(name, revision-aware installed)`, so a genuine manual upgrade past the snapshot still drops the stale entry.

## Related Issue

- None

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #583
- <kbd>&nbsp;1&nbsp;</kbd> #582 👈 
<!-- GitButler Footer Boundary Bottom -->