### PR TITLE
fix(outdated): refuse stale snapshots after revision-format change

### DIFF
--- a/scripts/regressions/outdated_snapshot_ttl.sh
+++ b/scripts/regressions/outdated_snapshot_ttl.sh
@@ -55,7 +55,7 @@ mkdir -p "$PREFIX/db" "$MALT_CACHE"
 seed_snapshot() {
   local age_secs="$1" gen_ms
   gen_ms=$((($(date +%s) - age_secs) * 1000))
-  printf '{"version":1,"generated_at_ms":%s,"formulas":[{"name":"alpha","installed":"1.0","latest":"9.9"}],"casks":[]}' \
+  printf '{"version":2,"generated_at_ms":%s,"formulas":[{"name":"alpha","installed":"1.0","latest":"9.9"}],"casks":[]}' \
     "$gen_ms" >"$SNAP"
 }
 

--- a/scripts/smokes/smoke_test.sh
+++ b/scripts/smokes/smoke_test.sh
@@ -201,7 +201,7 @@ else
 fi
 run_ok t2.update.check -- "$MT_BIN" update --check
 # mt update --check must write a parseable snapshot at the documented path.
-if [[ -s "$CACHE/outdated.json" ]] && grep -q '"version":1' "$CACHE/outdated.json"; then
+if [[ -s "$CACHE/outdated.json" ]] && grep -q '"version":2' "$CACHE/outdated.json"; then
   printf '  PASS  [t2.update.check.writes-snapshot] cache/outdated.json present\n'
   PASS=$((PASS + 1))
 else

--- a/src/cli/outdated/snapshot.zig
+++ b/src/cli/outdated/snapshot.zig
@@ -21,8 +21,11 @@ pub const snapshot_default_max_age_minutes: u64 = 5;
 pub const snapshot_max_age_env = "MALT_OUTDATED_MAX_AGE";
 
 /// On-disk snapshot version. Mismatched snapshots are treated as misses
-/// so a downgrade never tries to read a future shape.
-pub const snapshot_version: u32 = 1;
+/// so a downgrade never tries to read a future shape. Bumped to 2 when
+/// `installed` changed from a bare version to a revision-qualified one:
+/// a v1 snapshot's bare `installed` would mis-match the revision-aware
+/// intersect, so old snapshots must be refused and recomputed.
+pub const snapshot_version: u32 = 2;
 
 /// Snapshot filename under `{cache}/`.
 pub const snapshot_file = "outdated.json";
@@ -333,7 +336,7 @@ test "renderSnapshot emits the canonical JSON shape" {
     defer std.testing.allocator.free(json);
 
     const want =
-        \\{"version":1,"generated_at_ms":1700000000000,"formulas":[{"name":"alpha","installed":"1.0","latest":"2.0"}],"casks":[{"name":"beta","installed":"3.0","latest":"3.5"}]}
+        \\{"version":2,"generated_at_ms":1700000000000,"formulas":[{"name":"alpha","installed":"1.0","latest":"2.0"}],"casks":[{"name":"beta","installed":"3.0","latest":"3.5"}]}
     ;
     try std.testing.expectEqualStrings(want, json);
 }
@@ -376,15 +379,22 @@ test "parseSnapshot rejects mismatched version, missing fields, garbage" {
         error.InvalidSnapshot,
         parseSnapshot(std.testing.allocator, "{\"version\":99,\"generated_at_ms\":0,\"formulas\":[],\"casks\":[]}"),
     );
+    // v1 stored `installed` bare; reading it under the revision-qualified
+    // shape would mis-match the intersect, so the old version is refused
+    // and the caller recomputes.
+    try std.testing.expectError(
+        error.InvalidSnapshot,
+        parseSnapshot(std.testing.allocator, "{\"version\":1,\"generated_at_ms\":0,\"formulas\":[],\"casks\":[]}"),
+    );
     // Missing required field.
     try std.testing.expectError(
         error.InvalidSnapshot,
-        parseSnapshot(std.testing.allocator, "{\"version\":1,\"formulas\":[],\"casks\":[]}"),
+        parseSnapshot(std.testing.allocator, "{\"version\":2,\"formulas\":[],\"casks\":[]}"),
     );
     // Wrong type for formulas.
     try std.testing.expectError(
         error.InvalidSnapshot,
-        parseSnapshot(std.testing.allocator, "{\"version\":1,\"generated_at_ms\":0,\"formulas\":\"x\",\"casks\":[]}"),
+        parseSnapshot(std.testing.allocator, "{\"version\":2,\"generated_at_ms\":0,\"formulas\":\"x\",\"casks\":[]}"),
     );
 }
 
@@ -395,7 +405,7 @@ test "parseSnapshot bounds per-string allocation against tampered input" {
     const oversized_len = snapshot_max_value_len + 1;
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
-    try buf.appendSlice(std.testing.allocator, "{\"version\":1,\"generated_at_ms\":0,\"formulas\":[{\"name\":\"");
+    try buf.appendSlice(std.testing.allocator, "{\"version\":2,\"generated_at_ms\":0,\"formulas\":[{\"name\":\"");
     try buf.appendNTimes(std.testing.allocator, 'a', oversized_len);
     try buf.appendSlice(std.testing.allocator, "\",\"installed\":\"1\",\"latest\":\"2\"}],\"casks\":[]}");
 
@@ -408,7 +418,7 @@ test "parseSnapshot bounds per-string allocation against tampered input" {
 test "parseSnapshot tolerates unknown forward-compatible fields" {
     // Adding a field server-side shouldn't invalidate existing snapshots.
     const json =
-        \\{"version":1,"generated_at_ms":0,"formulas":[],"casks":[],"future":42}
+        \\{"version":2,"generated_at_ms":0,"formulas":[],"casks":[],"future":42}
     ;
     const parsed = try parseSnapshot(std.testing.allocator, json);
     defer freeSnapshot(std.testing.allocator, parsed);
@@ -425,7 +435,7 @@ test "renderSnapshot handles empty formula and cask lists" {
     defer std.testing.allocator.free(json);
 
     const want =
-        \\{"version":1,"generated_at_ms":0,"formulas":[],"casks":[]}
+        \\{"version":2,"generated_at_ms":0,"formulas":[],"casks":[]}
     ;
     try std.testing.expectEqualStrings(want, json);
 }


### PR DESCRIPTION
## Description

The cached `outdated` snapshot's `installed` field changed meaning from a bare version to a revision-qualified one (`1.2.3` -> `1.2.3_1`), but the on-disk
`snapshot_version` stayed at 1. A snapshot written before that change could still be read within its 5-minute TTL across an upgrade, where its bare `installed` mis-matches the now revision-aware intersect, silently dropping revisioned formulas for that window.

Bump `snapshot_version` to 2 so any pre-change snapshot is refused at parse and recomputed. Rejection already degrades gracefully (`readSnapshot` returns null ->
the caller recomputes), so the only cost is one recompute on first run after upgrade.

## Related Issue

- None

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #583 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #582
<!-- GitButler Footer Boundary Bottom -->