### PR TITLE
fix(outdated): detect upstream revision-only bumps on the fetch fallback

### DIFF
--- a/man/malt.1
+++ b/man/malt.1
@@ -156,7 +156,9 @@ Usage: malt upgrade [<package>...] [flags]
 
 Upgrade installed packages to latest versions. Pinned kegs and
 casks are skipped with a "pinned, skipped" line; pass --force to
-override.
+override. malt follows the tap: if the tap version differs from the
+installed one it is applied, even if that moves the version down
+(e.g. an upstream revert) — preview with --dry-run.
 
 Flags:
   --all          Upgrade everything (formulas + casks)
@@ -200,6 +202,10 @@ Flags:
 Reads the cached snapshot at {cache}/outdated.json when fresh
 (<= MALT_OUTDATED_MAX_AGE minutes, default 5); past that it recomputes
 live (or serves the cached read offline). --refresh always recomputes.
+
+A package is "outdated" when its installed version differs from the
+current tap version (revision bumps included), not only when it is
+older: malt follows the tap as source of truth.
 .fi
 .SS list
 .nf

--- a/scripts/regressions/outdated-fetch-fallback-revision-blind.sh
+++ b/scripts/regressions/outdated-fetch-fallback-revision-blind.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Regression: the per-keg fetch fallback in `mt outdated` compared the bare
+# installed `kegs.version` against the upstream `versions.stable` (also bare),
+# so an upstream revision-only bump (1.2.3 -> 1.2.3_1) was read as "up to date"
+# and the package silently dropped from the audit. The bulk version-map path was
+# already revision-aware; only the fallback (degraded map / tap packages) lagged.
+#
+# Hermetic: a throwaway prefix + a file-based API cache drive the fallback with
+# an empty version side-car (forces per-keg fetch) and a formula JSON carrying a
+# revision. Offline, so no network. Pre-fix the formula is absent from the
+# listing; after the fix it appears with latest = 1.2.3_1.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+PREFIX="$(mktemp -d)/p"
+export MALT_PREFIX="$PREFIX"
+export MALT_CACHE="$PREFIX/cache"
+export MALT_OFFLINE=1 NO_COLOR=1 MALT_NO_EMOJI=1
+trap 'rm -rf "$(dirname "$PREFIX")"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+mkdir -p "$PREFIX/db" "$MALT_CACHE/api"
+DB="$PREFIX/db/malt.db"
+
+# Initialise the schema.
+"$BIN" list >/dev/null 2>&1 || true
+[[ -f "$DB" ]] || fail "expected DB at $DB after schema init"
+
+# Installed keg at bare 1.2.3 (revision 0).
+sqlite3 "$DB" "INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path) \
+  VALUES ('foo', 'foo', '1.2.3', 0, 'sha', '$PREFIX/Cellar/foo/1.2.3');"
+
+# Empty version side-car forces the per-keg fetch fallback; the JSON keeps the
+# same stable but bumps the revision to 1.
+: >"$MALT_CACHE/api/versions_formula.txt"
+printf '{"name":"foo","versions":{"stable":"1.2.3"},"revision":1}' >"$MALT_CACHE/api/formula_foo.json"
+
+OUT="$PREFIX/out.json"
+"$BIN" outdated --formula --refresh --json >"$OUT" 2>"$PREFIX/err.log" || true
+
+grep -q '"foo"' "$OUT" ||
+  fail "fetch fallback dropped the revision-bumped formula (bare-vs-bare compare)"
+grep -q '1.2.3_1' "$OUT" ||
+  fail "fetch fallback did not report the revision-qualified upstream version"
+pass "fetch fallback lists the revision-bumped formula (latest 1.2.3_1)"
+
+printf '\n\xe2\x9c\x94 outdated fetch-fallback revision regression passed\n'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -144,7 +144,9 @@ const upgrade_help =
     \\
     \\Upgrade installed packages to latest versions. Pinned kegs and
     \\casks are skipped with a "pinned, skipped" line; pass --force to
-    \\override.
+    \\override. malt follows the tap: if the tap version differs from the
+    \\installed one it is applied, even if that moves the version down
+    \\(e.g. an upstream revert) — preview with --dry-run.
     \\
     \\Flags:
     \\  --all          Upgrade everything (formulas + casks)
@@ -190,6 +192,10 @@ const outdated_help =
     \\Reads the cached snapshot at {cache}/outdated.json when fresh
     \\(<= MALT_OUTDATED_MAX_AGE minutes, default 5); past that it recomputes
     \\live (or serves the cached read offline). --refresh always recomputes.
+    \\
+    \\A package is "outdated" when its installed version differs from the
+    \\current tap version (revision bumps included), not only when it is
+    \\older: malt follows the tap as source of truth.
     \\
 ;
 

--- a/src/cli/install/rb_parse.zig
+++ b/src/cli/install/rb_parse.zig
@@ -13,6 +13,9 @@ const cask_mod = @import("../../core/cask.zig");
 /// the caller's use of this struct.
 pub const RubyFormulaInfo = struct {
     version: []const u8,
+    /// Homebrew `revision N` (0 when absent). Lets the outdated audit detect a
+    /// revision-only bump on a tap formula, matching the core path.
+    revision: i64 = 0,
     url: []const u8,
     sha256: []const u8,
     /// Empty by default. Populated only when the cask DSL set `arch`
@@ -41,6 +44,7 @@ pub fn parseRubyFormula(rb_content: []const u8) ?RubyFormulaInfo {
     const is_arm = @import("../../macho/codesign.zig").isArm64();
 
     var version: ?[]const u8 = null;
+    var revision: i64 = 0;
     var url: ?[]const u8 = null;
     var sha256: ?[]const u8 = null;
     var arch_token: []const u8 = "";
@@ -68,6 +72,13 @@ pub fn parseRubyFormula(rb_content: []const u8) ?RubyFormulaInfo {
                 if (extractQuoted(line, "version \"")) |v| {
                     version = v;
                 }
+            }
+
+            // Extract `revision N` (global, unquoted integer). Ignored by the
+            // install path; the outdated audit uses it to spot revision bumps.
+            if (revision == 0 and std.mem.startsWith(u8, line, "revision ")) {
+                const rest = std.mem.trim(u8, line["revision ".len..], " \t");
+                revision = std.fmt.parseInt(i64, rest, 10) catch 0;
             }
 
             // Track on_macos block. The cask DSL uses this as the only
@@ -162,6 +173,7 @@ pub fn parseRubyFormula(rb_content: []const u8) ?RubyFormulaInfo {
         const final_version = version orelse deriveVersionFromUrl(url.?) orelse return null;
         return .{
             .version = final_version,
+            .revision = revision,
             .url = url.?,
             .sha256 = sha256.?,
             .arch_token = arch_token,
@@ -409,6 +421,29 @@ test "parseRubyFormula: extracts version/url/sha256 from a flat formula" {
 
 test "parseRubyFormula: returns null when required fields are missing" {
     try std.testing.expect(parseRubyFormula("class X end") == null);
+}
+
+test "parseRubyFormula: extracts the revision and defaults it to 0" {
+    const with_rev =
+        \\class Foo < Formula
+        \\  url "https://example.com/foo-1.2.3.tar.gz"
+        \\  sha256 "deadbeef"
+        \\  version "1.2.3"
+        \\  revision 2
+        \\end
+    ;
+    const got = parseRubyFormula(with_rev) orelse return error.TestUnexpectedNull;
+    try std.testing.expectEqual(@as(i64, 2), got.revision);
+
+    const no_rev =
+        \\class Foo < Formula
+        \\  url "https://example.com/foo-1.2.3.tar.gz"
+        \\  sha256 "deadbeef"
+        \\  version "1.2.3"
+        \\end
+    ;
+    const got0 = parseRubyFormula(no_rev) orelse return error.TestUnexpectedNull;
+    try std.testing.expectEqual(@as(i64, 0), got0.revision);
 }
 
 test "parseRubyFormula: derives version from /releases/download/ URL" {

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -174,6 +174,15 @@ fn isCorePathRow(row: KegRow) bool {
     return if (row.tap) |t| install_args_mod.isCoreTap(t) else true;
 }
 
+// Outdated policy: malt treats the tap as the source of truth. A keg is
+// "outdated" whenever its revision-qualified installed version is not byte-equal
+// to the current upstream version — NOT when it is strictly older. This never
+// misses an upgrade (any difference surfaces); the trade-off is that if upstream
+// moves backward (a yanked release), `outdated` lists it and `upgrade` follows
+// the tap down. That downgrade is by design, surfaced as `old -> new` in
+// `--dry-run`. Matching Homebrew's `PkgVersion` ordering instead would risk a
+// divergent comparator silently skipping a real upgrade — a worse failure mode.
+
 /// Resolve one keg against its version-map entry. Sets `found` to map
 /// membership (so the caller can tell "current" from "absent"), and
 /// returns a caller-owned `<stable>_<rev>` string when the row is
@@ -776,7 +785,11 @@ fn tapVersionFromSubtrees(
                 warnTapCaskFetchFailed(tap_label, name, reason);
                 return null;
             };
-            return alloc.dupe(u8, rb_info.version) catch null;
+            // Qualify with the .rb revision so a tap revision-only bump is
+            // detected, matching the core fetch path.
+            var ver_buf: [256]u8 = undefined;
+            const qualified = formula_mod.pkgVersion(&ver_buf, rb_info.version, rb_info.revision) catch rb_info.version;
+            return alloc.dupe(u8, qualified) catch null;
         }
         // Non-200 (likely a 404 for this layout) — try the next subtree.
         last_status = rb_resp.status;
@@ -829,7 +842,13 @@ fn fetchLatest(
     row: KegRow,
 ) std.mem.Allocator.Error!?[]u8 {
     const v = upstreamLatest(allocator, head_cache, db, api, io, environ, kind, row) orelse return null;
-    if (std.mem.eql(u8, row.version, v)) {
+    // Compare the revision-qualified installed string against the (now also
+    // revision-qualified) upstream so a revision-only bump isn't read as bare.
+    // `!eql` is deliberate: malt mirrors the tap as source of truth — see the
+    // policy note above `mapLatest`.
+    var installed_buf: [256]u8 = undefined;
+    const installed = formula_mod.pkgVersion(&installed_buf, row.version, row.revision) catch row.version;
+    if (std.mem.eql(u8, installed, v)) {
         allocator.free(v);
         return null;
     }
@@ -852,10 +871,21 @@ fn parseFormulaLatest(allocator: std.mem.Allocator, json_bytes: []const u8) ?[]u
         else => return null,
     };
     const stable_val = versions_obj.get("stable") orelse return null;
-    return switch (stable_val) {
-        .string => |s| allocator.dupe(u8, s) catch null,
-        else => null,
+    const stable = switch (stable_val) {
+        .string => |s| s,
+        else => return null,
     };
+    // Qualify with the top-level revision so the fetch fallback catches a
+    // revision-only bump (1.2.3 -> 1.2.3_1), mirroring the map path. Absent or
+    // non-integer revision is treated as 0; an overflow degrades to the bare
+    // stable rather than dropping the row.
+    const revision: i64 = switch (obj.get("revision") orelse std.json.Value{ .integer = 0 }) {
+        .integer => |n| n,
+        else => 0,
+    };
+    var buf: [256]u8 = undefined;
+    const qualified = formula_mod.pkgVersion(&buf, stable, revision) catch stable;
+    return allocator.dupe(u8, qualified) catch null;
 }
 
 // --- Pool path ---
@@ -916,7 +946,11 @@ fn runOne(out_alloc: std.mem.Allocator, wctx: *WorkerCtx) void {
     local_api.base_url = wctx.api_base;
     local_api.offline = wctx.offline;
     const latest = upstreamLatest(arena_alloc, wctx.head_cache, wctx.db, &local_api, wctx.io, wctx.environ, wctx.kind, wctx.row) orelse return;
-    if (std.mem.eql(u8, wctx.row.version, latest)) return;
+    // Qualify the installed side so a revision-only bump isn't read as bare
+    // (same fix as the serial `fetchLatest` path).
+    var installed_buf: [256]u8 = undefined;
+    const installed = formula_mod.pkgVersion(&installed_buf, wctx.row.version, wctx.row.revision) catch wctx.row.version;
+    if (std.mem.eql(u8, installed, latest)) return;
 
     // Move into the caller's allocator so the result outlives `arena.deinit()`.
     wctx.out = out_alloc.dupe(u8, latest) catch |e| blk: {
@@ -1150,6 +1184,19 @@ test "buildVersionMap parses tab-delimited entries with stable and revision" {
     try std.testing.expectEqual(@as(i64, 2), o.revision);
 }
 
+test "parseFormulaLatest qualifies stable with the top-level revision" {
+    const a = std.testing.allocator;
+    // Revision present → revision-qualified.
+    const bumped = parseFormulaLatest(a, "{\"versions\":{\"stable\":\"1.2.3\"},\"revision\":1}") orelse return error.ParseFailed;
+    defer a.free(bumped);
+    try std.testing.expectEqualStrings("1.2.3_1", bumped);
+
+    // Revision absent → bare stable (revision 0).
+    const bare = parseFormulaLatest(a, "{\"versions\":{\"stable\":\"1.2.3\"}}") orelse return error.ParseFailed;
+    defer a.free(bare);
+    try std.testing.expectEqualStrings("1.2.3", bare);
+}
+
 test "isCorePathRow routes core rows to the map and third-party taps per-HEAD" {
     // No tap or the homebrew core tap → bulk version map (formula and cask alike).
     try std.testing.expect(isCorePathRow(.{ .name = "wget", .version = "1" }));
@@ -1223,6 +1270,44 @@ test "tapVersionFromSubtrees falls back to the root layout and parses the versio
     defer if (v) |vv| std.testing.allocator.free(vv);
     try std.testing.expect(v != null);
     try std.testing.expectEqualStrings("1.2.3", v.?); // resolved from the root `.rb`
+}
+
+test "tapVersionFromSubtrees qualifies the resolved version with the .rb revision" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+
+    // A tap .rb whose stable is unchanged but whose revision bumped: the
+    // resolved latest must carry `_2` so the fetch fallback flags the bump.
+    const rev_rb =
+        \\class Pkg < Formula
+        \\  url "https://x/pkg-1.2.3.tar.gz"
+        \\  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+        \\  version "1.2.3"
+        \\  revision 2
+        \\end
+    ;
+    var srv = RbFallbackServer{ .io = io, .listener = &listener, .root_rb = rev_rb, .idx = std.atomic.Value(usize).init(0) };
+    const thread = try std.Thread.spawn(.{}, RbFallbackServer.serve, .{&srv});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client_mod.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    var base_buf: [64]u8 = undefined;
+    const raw_base = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    const v = tapVersionFromSubtrees(std.testing.allocator, &http, std.process.Environ.empty, .github, raw_base, "deadbeef", "pkg", &.{ .formula, .formula_root }, "formula", "user/repo");
+    listener.deinit(io);
+    thread.join();
+
+    defer if (v) |vv| std.testing.allocator.free(vv);
+    try std.testing.expect(v != null);
+    try std.testing.expectEqualStrings("1.2.3_2", v.?);
 }
 
 test "buildVersionMap skips malformed lines without aborting" {

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -381,6 +381,40 @@ test "collectOutdated warns and falls back to per-keg on an empty version map" {
     try testing.expect(std.mem.indexOf(u8, warn_buf.items, "falling back") != null);
 }
 
+test "collectOutdated fetch fallback detects an upstream revision-only bump" {
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var dir = try TempCacheDir.init(testing.allocator, "rev_bump_fetch");
+    defer dir.deinit();
+
+    // Empty side-car forces the per-keg fetch fallback. Upstream JSON keeps the
+    // same stable but bumps revision to 1; the installed keg is the bare 1.2.3.
+    try dir.writeCacheFile("versions_formula.txt", "");
+    try dir.writeCacheFile("formula_foo.json", "{\"name\":\"foo\",\"versions\":{\"stable\":\"1.2.3\"},\"revision\":1}");
+
+    var api = api_mod.BrewApi.init(std.Options.debug_io, testing.allocator, &http, dir.path);
+    api.offline = true;
+
+    // Swallow the expected "version map degraded" warning the empty side-car emits.
+    var warn_buf: std.ArrayList(u8) = .empty;
+    defer warn_buf.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &warn_buf);
+    defer malt.output.endStderrCapture();
+
+    const kegs = [_]outdated_mod.KegRow{
+        .{ .name = "foo", .version = "1.2.3", .revision = 0 }, // 1.2.3 < 1.2.3_1
+    };
+    var db = try openTestDb();
+    defer db.close();
+    const out = try outdated_mod.collectOutdatedFormulas(&malt.app_ctx.debug_ctx, testing.allocator, &db, &api, dir.path, &kegs, null);
+    defer freeEntries(testing.allocator, out);
+
+    try testing.expectEqual(@as(usize, 1), out.len);
+    try testing.expectEqualStrings("foo", out[0].name);
+    try testing.expectEqualStrings("1.2.3", out[0].installed);
+    try testing.expectEqualStrings("1.2.3_1", out[0].latest);
+}
+
 // --- --pinned-only filter ---
 
 fn setupPinnedPrefix(suffix: []const u8) ![:0]u8 {


### PR DESCRIPTION
## Description

`mt outdated`'s per-keg fetch fallback (used when the bulk version map is unavailable, and for third-party-tap packages) compared the bare installed `kegs.version` against the upstream `versions.stable` , also bare. An upstream revision-only bump (`1.2.3` -> `1.2.3_1`) was therefore read as "up to date" and the package was silently dropped from the listing, even though `upgrade` (always live) would still rebuild it. The bulk version-map path was already revision-aware; only the fallback lagged.

The fallback now qualifies both sides with the revision before comparing, on every source: core formula JSON (top-level `revision`), tap `.rb` (`revision N`, newly parsed), and the installed keg. Casks are unaffected (no revision).

It also makes malt's outdated/upgrade policy explicit, in code and in `outdated`/`upgrade --help`: a package counts as outdated when its installed version differs from the current tap version (revisions included), not only when it is strictly older. malt follows the tap as source of truth - `upgrade` moves to the tap version even on an upstream revert, previewable with `--dry-run`.

## Related Issue

- None

## Notes for Reviewers

- None