### PR TITLE
fix(info): show installed package when both --cask and --formula are set

### DIFF
--- a/scripts/regressions/info-cask-formula-flags-false-not-installed.sh
+++ b/scripts/regressions/info-cask-formula-flags-false-not-installed.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Regression: `mt info --cask --formula <pkg>` must report an installed
+# package as installed. The two kind-flags are inclusive selectors
+# (mirroring `search`): passing both reads the same as passing neither.
+# When they were modelled as exclusion guards, both-set suppressed every
+# lookup and a present package printed "not installed".
+#
+# Hermetic: a seeded keg row in a throwaway prefix, MALT_OFFLINE=1 so the
+# local-lookup hit is the only thing under test — no live Homebrew metadata.
+#
+# Usage: scripts/regressions/info-cask-formula-flags-false-not-installed.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt, sqlite3 on PATH.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+PREFIX="/tmp/mt_info_bothflags_reg"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+export MALT_OFFLINE=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX/db"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+DB="$PREFIX/db/malt.db"
+
+# Bootstrap schema by letting malt open the DB once.
+"$BIN" list --quiet >/dev/null 2>&1 || true
+[[ -f "$DB" ]] || fail "DB was not initialised by mt list"
+
+sqlite3 "$DB" <<SQL
+INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason)
+VALUES ('wget', 'wget', '1.24.5', 0, 'sha_cur', '$PREFIX/Cellar/wget/1.24.5', 'direct');
+SQL
+mkdir -p "$PREFIX/Cellar/wget/1.24.5"
+
+# 1. Both kind-flags set: the installed record, not "not installed".
+BOTH_OUT="$PREFIX/both.out"
+"$BIN" info --cask --formula wget >"$BOTH_OUT" 2>&1 ||
+  fail "mt info --cask --formula wget exited non-zero (see $BOTH_OUT)"
+grep -q 'not installed' "$BOTH_OUT" &&
+  fail "both flags reported an installed package as not installed (see $BOTH_OUT)"
+grep -q '^wget:' "$BOTH_OUT" ||
+  fail "both flags did not emit the installed record header (see $BOTH_OUT)"
+pass "mt info --cask --formula <pkg> shows the installed record"
+
+# 2. Both kind-flags --json: installed:true root for the present package.
+BOTH_JSON="$PREFIX/both.json"
+"$BIN" --json info --cask --formula wget >"$BOTH_JSON" 2>&1 ||
+  fail "mt --json info --cask --formula wget exited non-zero (see $BOTH_JSON)"
+grep -q '"installed":true' "$BOTH_JSON" ||
+  fail "both flags --json did not emit installed:true (see $BOTH_JSON)"
+pass "mt info --cask --formula <pkg> --json pins installed:true"
+
+# 3. Single-flag paths still narrow correctly.
+"$BIN" info --formula wget | grep -q '^wget:' ||
+  fail "--formula regressed: installed formula no longer shown"
+pass "mt info --formula <pkg> still resolves the installed formula"
+
+printf '\n\xe2\x9c\x94 info both-kind-flags regression passed\n'

--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -20,6 +20,28 @@ const rollback = @import("rollback.zig");
 /// uniform without forcing every caller to allocate an empty slice.
 pub const no_history: []const rollback.Entry = &.{};
 
+/// Which package kinds a lookup should consider.
+const KindSelect = struct { formula: bool, cask: bool };
+
+/// Resolve `--cask`/`--formula` into inclusive kind selectors. Each flag
+/// opts its kind in; "both set" and "neither set" both select both kinds
+/// (formula first). Mirrors `search`'s contract so the two commands agree.
+fn selectKinds(force_cask: bool, force_formula: bool) KindSelect {
+    return .{
+        .formula = force_formula or !force_cask,
+        .cask = force_cask or !force_formula,
+    };
+}
+
+test "selectKinds treats both-set and neither-set as 'both kinds'" {
+    // The both-set case is the regression: it must not collapse to nothing.
+    try std.testing.expectEqual(KindSelect{ .formula = true, .cask = true }, selectKinds(false, false));
+    try std.testing.expectEqual(KindSelect{ .formula = true, .cask = true }, selectKinds(true, true));
+    // Single flag narrows to exactly that kind.
+    try std.testing.expectEqual(KindSelect{ .formula = false, .cask = true }, selectKinds(true, false));
+    try std.testing.expectEqual(KindSelect{ .formula = true, .cask = false }, selectKinds(false, true));
+}
+
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(ctx, args, "info")) return;
 
@@ -67,11 +89,18 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     const colorize = !json_mode and color.isColorEnabled();
 
+    // `--cask`/`--formula` are inclusive selectors, like `search`: each
+    // flag opts its kind in, and "both set" reads the same as "neither set"
+    // (show whatever is installed, formula first). Modelled as exclusion
+    // guards instead, both-set selected nothing and a present package
+    // printed "not installed".
+    const sel = selectKinds(force_cask, force_formula);
+
     if (db_opt) |*db| {
         // Schema is idempotent; info's API fallback handles a broken DB gracefully.
         schema.initSchema(db) catch {};
-        if (!force_cask and try emitInstalledFormula(ctx, allocator, db, name, prefix, stdout, json_mode, colorize)) return;
-        if (!force_formula and try emitInstalledCask(allocator, db, name, stdout, json_mode, colorize)) return;
+        if (sel.formula and try emitInstalledFormula(ctx, allocator, db, name, prefix, stdout, json_mode, colorize)) return;
+        if (sel.cask and try emitInstalledCask(allocator, db, name, stdout, json_mode, colorize)) return;
     }
 
     // Not locally installed — fall back to Homebrew API metadata so
@@ -79,7 +108,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // homepage, version, dependencies) instead of just "not
     // installed". We only reach this path when the local DB lookup
     // missed or the DB was absent entirely.
-    if (try emitApiMetadata(ctx, allocator, name, stdout, json_mode, colorize, force_cask, force_formula)) return;
+    if (try emitApiMetadata(ctx, allocator, name, stdout, json_mode, colorize, sel)) return;
 
     try emitNotFound(name, stdout, json_mode);
 }
@@ -231,8 +260,8 @@ fn emitNotFound(
 }
 
 /// Fetch Homebrew API metadata for a not-locally-installed package and
-/// emit it. Tries formula first (unless `--cask`), then cask (unless
-/// `--formula`). Returns true on any hit so the caller knows to stop.
+/// emit it. Honours the resolved kind selectors: formula first when
+/// selected, then cask. Returns true on any hit so the caller knows to stop.
 /// Silently returns false on network / parse failures — offline machines
 /// should still fall through cleanly to the "not installed" shape.
 fn emitApiMetadata(
@@ -242,8 +271,7 @@ fn emitApiMetadata(
     stdout: *std.Io.Writer,
     json_mode: bool,
     colorize: bool,
-    force_cask: bool,
-    force_formula: bool,
+    sel: KindSelect,
 ) !bool {
     const cache_dir = atomic.maltCacheDir(allocator) catch return false;
     defer allocator.free(cache_dir);
@@ -255,10 +283,10 @@ fn emitApiMetadata(
     api.base_url = ctx.mirrors.api_base;
     api.offline = ctx.offline;
 
-    if (!force_cask) {
+    if (sel.formula) {
         if (try emitApiFormula(allocator, &api, name, stdout, json_mode, colorize)) return true;
     }
-    if (!force_formula) {
+    if (sel.cask) {
         if (try emitApiCask(allocator, &api, name, stdout, json_mode, colorize)) return true;
     }
     return false;

--- a/tests/info_test.zig
+++ b/tests/info_test.zig
@@ -12,6 +12,12 @@ const test_io = @import("test_io");
 const info = malt.cli_info;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
+const output = malt.output;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
 
 test "openDb returns null when the prefix has no db/ directory" {
     // Fresh prefix with no db/ subdir at all — SQLite's OPEN_CREATE
@@ -127,4 +133,210 @@ test "collectInstalledDeps returns an empty slice when the keg is not installed"
     defer freeDepsSlice(deps);
 
     try testing.expectEqual(@as(usize, 0), deps.len);
+}
+
+// --- both kind-flags dispatch: --cask --formula must not hide an install -
+//
+// `--cask`/`--formula` are inclusive selectors (mirroring `search`):
+// passing both reads the same as passing neither. These tests drive the
+// full `execute` dispatch against a seeded prefix so the flag plumbing —
+// not just the encoders — is pinned. Offline so the installed lookup is
+// the only thing under test.
+
+const Prefix = struct {
+    path: [:0]u8,
+
+    fn init(allocator: std.mem.Allocator, tag: []const u8) !Prefix {
+        const ts = test_io.nanoTimestamp(std.Options.debug_io);
+        const path = try std.fmt.allocPrintSentinel(allocator, "/tmp/malt_info_dispatch_{s}_{d}", .{ tag, ts }, 0);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+        const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});
+        defer allocator.free(db_dir);
+        try test_io.cwd().createDirPath(std.Options.debug_io, db_dir);
+        _ = c.setenv("MALT_PREFIX", path.ptr, 1);
+        return .{ .path = path };
+    }
+
+    fn deinit(self: *Prefix, allocator: std.mem.Allocator) void {
+        _ = c.unsetenv("MALT_PREFIX");
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.path) catch {};
+        allocator.free(self.path);
+    }
+
+    // Seed one installed formula keg so the local lookup has a real row.
+    fn seedFormula(self: *Prefix, name: []const u8) !void {
+        var db = try self.openSeedDb();
+        defer db.close();
+        var stmt = try db.prepare(
+            "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)" ++
+                " VALUES (?1, ?1, '1.24.5', ?1, '/c/wget/1.24.5');",
+        );
+        defer stmt.finalize();
+        try stmt.bindText(1, name);
+        _ = try stmt.step();
+    }
+
+    // Seed one installed cask row.
+    fn seedCask(self: *Prefix, token: []const u8) !void {
+        var db = try self.openSeedDb();
+        defer db.close();
+        var stmt = try db.prepare(
+            "INSERT INTO casks (token, name, version, url, sha256)" ++
+                " VALUES (?1, ?1, '120.0', 'https://example.invalid/x.dmg', 'aa');",
+        );
+        defer stmt.finalize();
+        try stmt.bindText(1, token);
+        _ = try stmt.step();
+    }
+
+    fn openSeedDb(self: *Prefix) !sqlite.Database {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{self.path}, 0);
+        var db = try sqlite.Database.open(db_path);
+        errdefer db.close();
+        try schema.initSchema(&db);
+        return db;
+    }
+};
+
+// Drive `info.execute` with stdout backed by a real fd so the encoder
+// writes survive for byte assertions; offline so no network is attempted.
+fn captureInfo(allocator: std.mem.Allocator, args: []const []const u8, tag: []const u8) ![]u8 {
+    const ts = test_io.nanoTimestamp(std.Options.debug_io);
+    const cap_path = try std.fmt.allocPrintSentinel(allocator, "/tmp/malt_info_cap_{s}_{d}", .{ tag, ts }, 0);
+    defer allocator.free(cap_path);
+    defer test_io.deleteFileAbsolute(std.Options.debug_io, cap_path) catch {};
+
+    var file = try test_io.createFileAbsolute(std.Options.debug_io, cap_path, .{ .truncate = true });
+    errdefer file.close(std.Options.debug_io);
+
+    const ctx: malt.app_ctx.AppCtx = .{
+        .io = std.Options.debug_io,
+        .environ = .empty,
+        .offline = true,
+        .stdout = file,
+        .stderr = test_io.testSink(),
+    };
+
+    try info.execute(&ctx, allocator, args);
+    file.close(std.Options.debug_io);
+
+    return try test_io.readFileAbsoluteAlloc(std.Options.debug_io, allocator, cap_path, 64 * 1024);
+}
+
+const OutputState = struct {
+    prior_mode: output.OutputMode,
+    prior_quiet: bool,
+
+    fn save() OutputState {
+        return .{
+            .prior_mode = if (output.isJson()) .json else .human,
+            .prior_quiet = output.isQuiet(),
+        };
+    }
+    fn restore(self: OutputState) void {
+        output.setMode(self.prior_mode);
+        output.setQuiet(self.prior_quiet);
+    }
+};
+
+test "info --cask --formula shows the installed formula, not 'not installed'" {
+    var p = try Prefix.init(testing.allocator, "both_human");
+    defer p.deinit(testing.allocator);
+    try p.seedFormula("wget");
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    const out = try captureInfo(testing.allocator, &.{ "--cask", "--formula", "wget" }, "both_human");
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "not installed") == null);
+    try testing.expect(std.mem.startsWith(u8, out, "wget: "));
+}
+
+test "info --cask --formula --json pins installed:true for an installed package" {
+    var p = try Prefix.init(testing.allocator, "both_json");
+    defer p.deinit(testing.allocator);
+    try p.seedFormula("wget");
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.json);
+    output.setQuiet(true);
+
+    const out = try captureInfo(testing.allocator, &.{ "--cask", "--formula", "wget" }, "both_json");
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "\"installed\":true") != null);
+}
+
+test "info --formula still narrows to the installed formula" {
+    var p = try Prefix.init(testing.allocator, "formula_only");
+    defer p.deinit(testing.allocator);
+    try p.seedFormula("wget");
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    const out = try captureInfo(testing.allocator, &.{ "--formula", "wget" }, "formula_only");
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.startsWith(u8, out, "wget: "));
+}
+
+test "info --cask --formula resolves an installed cask (formula misses, cask runs)" {
+    // The symmetric half of the bug: with both flags set the formula
+    // lookup misses for a cask token, so the cask branch must still run
+    // rather than being suppressed alongside it.
+    var p = try Prefix.init(testing.allocator, "both_cask");
+    defer p.deinit(testing.allocator);
+    try p.seedCask("firefox");
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    const out = try captureInfo(testing.allocator, &.{ "--cask", "--formula", "firefox" }, "both_cask");
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "not installed") == null);
+    try testing.expect(std.mem.startsWith(u8, out, "firefox: "));
+    try testing.expect(std.mem.indexOf(u8, out, "(cask)") != null);
+}
+
+test "info --cask still skips the formula branch for an installed formula" {
+    // Single-flag narrowing must be unchanged: `--cask` on a formula
+    // token must NOT surface the formula — it falls through to not-found.
+    var p = try Prefix.init(testing.allocator, "cask_only_excludes_formula");
+    defer p.deinit(testing.allocator);
+    try p.seedFormula("wget");
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    const out = try captureInfo(testing.allocator, &.{ "--cask", "wget" }, "cask_only_excludes_formula");
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "not installed") != null);
+}
+
+test "info --cask --formula on an absent token still reaches not-found" {
+    // The fix widens which lookups run; it must not suppress the
+    // not-found terminal for a token that is neither formula nor cask.
+    var p = try Prefix.init(testing.allocator, "both_absent");
+    defer p.deinit(testing.allocator);
+    try p.seedFormula("wget");
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setQuiet(true);
+
+    const out = try captureInfo(testing.allocator, &.{ "--cask", "--formula", "ghost-pkg-xyz" }, "both_absent");
+    defer testing.allocator.free(out);
+
+    try testing.expect(std.mem.indexOf(u8, out, "not installed") != null);
 }


### PR DESCRIPTION
## Description

`mt info --cask --formula <pkg>` reported an installed package as `not installed`. The two kind-flags were modelled as exclusion guards (`--cask` suppressed the formula branch, `--formula` the cask branch), so with both set every local and API lookup was skipped and execution fell through to the not-found path, for human and `--json` output alike.

The flags are now inclusive selectors, matching `search`: each flag opts its kind in, and "both set" reads the same as "neither set" (show whatever is installed, formula first). Single-flag narrowing is unchanged.

## Related Issue

- None

## Notes for Reviewers

- None