### PR TITLE
fix(search): collapse mixed-case local exact match to one canonical row

### DIFF
--- a/scripts/regressions/local-search-raw-query-duplicate-rows.sh
+++ b/scripts/regressions/local-search-raw-query-duplicate-rows.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Regression: a mixed-case local exact-match search must collapse to ONE
+# row for the package, carrying the canonical (lowercase) name, in both
+# human and JSON output. The exactness decision case-folds, but the
+# writers used to echo the raw query and dedupe the canonical substring
+# hit case-sensitively, so `mt search --installed JQ` emitted both
+# `JQ` and `jq`.
+#
+# Hermetic: a seeded keg row in a throwaway prefix, MALT_OFFLINE=1 so the
+# local lookup is the only thing under test — no live Homebrew metadata.
+#
+# Usage: scripts/regressions/local-search-raw-query-duplicate-rows.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt, sqlite3 + jq on PATH.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+command -v jq >/dev/null 2>&1 || {
+  echo "this regression needs jq on PATH" >&2
+  exit 2
+}
+
+PREFIX="$(mktemp -d)"
+mkdir -p "$PREFIX/db"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+export MALT_OFFLINE=1
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+DB="$PREFIX/db/malt.db"
+
+# Bootstrap schema by letting malt open the DB once, then seed a keg whose
+# canonical name is lowercase.
+"$BIN" list --quiet >/dev/null 2>&1 || true
+[[ -f "$DB" ]] || fail "DB was not initialised by mt list"
+sqlite3 "$DB" <<SQL
+INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason)
+VALUES ('jq', 'jq', '1.7.1', 0, 'sha_jq', '$PREFIX/Cellar/jq/1.7.1', 'direct');
+SQL
+mkdir -p "$PREFIX/Cellar/jq/1.7.1"
+
+# Human: a non-canonical-case query must yield exactly ONE formula row,
+# carrying the canonical lowercase name and no raw-query echo.
+HOUT="$("$BIN" search --installed JQ)"
+n=$(printf '%s\n' "$HOUT" | grep -c '(formula)' || true)
+[ "$n" -eq 1 ] || fail "human: expected 1 formula row, got $n:
+$HOUT"
+printf '%s\n' "$HOUT" | grep -q 'jq (formula)' ||
+  fail "human: canonical 'jq (formula)' row missing:
+$HOUT"
+printf '%s\n' "$HOUT" | grep -q 'JQ (formula)' &&
+  fail "human: raw-query echo 'JQ (formula)' present:
+$HOUT"
+pass "human: one canonical 'jq (formula)' row, no raw-query echo"
+
+# JSON: exactly one formula result object, name == "jq".
+JOUT="$("$BIN" search --installed --json JQ)"
+cnt=$(printf '%s' "$JOUT" | jq '[.results[] | select(.type=="formula")] | length')
+[ "$cnt" -eq 1 ] || fail "json: expected 1 formula result, got $cnt: $JOUT"
+name=$(printf '%s' "$JOUT" | jq -r '.results[0].name')
+[ "$name" = "jq" ] || fail "json: name=$name, expected jq: $JOUT"
+pass "json: one result object, name=jq"
+
+printf '\n\xe2\x9c\x94 local-search mixed-case dedup regression passed\n'

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -637,11 +637,23 @@ fn writeHuman(
     r: KindResults,
     query: []const u8,
 ) void {
-    if (r.exact) writeResult(stdout, query, kind);
+    const exact_name = exactDisplayName(query, r.matches);
+    if (r.exact) writeResult(stdout, exact_name, kind);
     for (r.matches) |m| {
-        if (r.exact and std.mem.eql(u8, m, query)) continue;
+        if (r.exact and std.ascii.eqlIgnoreCase(m, query)) continue;
         writeResult(stdout, m, kind);
     }
+}
+
+/// Display name for the pinned exact row. Exactness is decided case-folded,
+/// so echoing the raw query would mis-case the row and dodge the dedup; use
+/// the canonical match instead, falling back to the query only on the
+/// day-of-release case where the index doesn't yet list it.
+fn exactDisplayName(query: []const u8, matches: []const []const u8) []const u8 {
+    for (matches) |m| {
+        if (std.ascii.eqlIgnoreCase(m, query)) return m;
+    }
+    return query;
 }
 
 /// One row of the unified `mt search --json` array. `installed` is derived
@@ -719,10 +731,11 @@ fn appendKind(
     set: InstalledSet,
 ) !void {
     if (r.exact) {
-        try list.append(allocator, .{ .name = query, .kind = kind, .installed = set.has(kind, query) });
+        const name = exactDisplayName(query, r.matches);
+        try list.append(allocator, .{ .name = name, .kind = kind, .installed = set.has(kind, name) });
     }
     for (r.matches) |m| {
-        if (r.exact and std.mem.eql(u8, m, query)) continue;
+        if (r.exact and std.ascii.eqlIgnoreCase(m, query)) continue;
         try list.append(allocator, .{ .name = m, .kind = kind, .installed = set.has(kind, m) });
     }
 }
@@ -865,6 +878,63 @@ test "buildResults pins the exact match first, dedupes it, and tags type" {
     try testing.expectEqualStrings("jira", results[2].name);
     try testing.expectEqual(api_mod.BrewApi.Kind.cask, results[2].kind);
     try testing.expect(!results[2].installed);
+}
+
+test "buildResults collapses a mixed-case exact match to one canonical row" {
+    // Query "JQ" matches canonical "jq" case-insensitively: the exact row
+    // must carry the canonical name and the substring "jq" must be deduped.
+    const formula: KindResults = .{ .exact = true, .matches = &.{ "jq", "jqp" } };
+    const set: InstalledSet = .{ .formulae = &.{"jq"}, .casks = &.{} };
+
+    const results = try buildResults(testing.allocator, formula, .{}, "JQ", set);
+    defer testing.allocator.free(results);
+
+    try testing.expectEqual(@as(usize, 2), results.len);
+    try testing.expectEqualStrings("jq", results[0].name);
+    try testing.expect(results[0].installed);
+    try testing.expectEqualStrings("jqp", results[1].name);
+}
+
+test "buildResults keeps the raw query when no match supplies a canonical name" {
+    // Day-of-release: API reports exact but the substring index lacks it,
+    // so the exact row falls back to the user's typed case — one row, no dup.
+    const formula: KindResults = .{ .exact = true, .matches = &.{} };
+    const results = try buildResults(testing.allocator, formula, .{}, "JQ", .{});
+    defer testing.allocator.free(results);
+
+    try testing.expectEqual(@as(usize, 1), results.len);
+    try testing.expectEqualStrings("JQ", results[0].name);
+}
+
+test "writeHuman collapses a mixed-case exact match to one canonical row" {
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    const r: KindResults = .{ .exact = true, .matches = &.{ "jq", "jqp" } };
+    writeHuman(&aw.writer, "formula", r, "JQ");
+
+    try testing.expectEqualStrings(
+        "  \xe2\x96\xb8 jq (formula)\n  \xe2\x96\xb8 jqp (formula)\n",
+        aw.written(),
+    );
+}
+
+test "writeHuman keeps the raw query when no match supplies a canonical name" {
+    // Day-of-release: API reports exact but the substring index lacks it,
+    // so the human row falls back to the user's typed case — still one row.
+    color.setForTest(false, false);
+    defer color.setForTest(null, null);
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+
+    const r: KindResults = .{ .exact = true, .matches = &.{} };
+    writeHuman(&aw.writer, "formula", r, "JQ");
+
+    try testing.expectEqualStrings("  \xe2\x96\xb8 JQ (formula)\n", aw.written());
 }
 
 test "buildResults marks an installed substring hit regardless of case" {


### PR DESCRIPTION
## Description

A local exact-match search (`mt search --installed`/`--all`) with a query whose case differs from the installed package's canonical name printed the package twice - once in the typed case, once canonical - in both human and `--json` output (e.g. `JQ` searched against installed `jq` yielded both `JQ (formula)` and `jq (formula)`).

The exact row now displays the canonical name (resolved from the matches the search already found, falling back to the raw query on the day-of-release case where the index doesn't yet list it), and both writers dedupe case-insensitively. A mixed-case local exact match now collapses to a single canonical row everywhere.

## Related Issue

- None

## Notes for Reviewers

- None