### PR TITLE
fix(bundle): stop trailing comments from aborting Brewfile imports

### DIFF
--- a/scripts/regressions/brewfile-parser-rejects-if-do-in-comment.sh
+++ b/scripts/regressions/brewfile-parser-rejects-if-do-in-comment.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Regression: a Brewfile directive whose trailing comment contains "if" or a
+# "do"-prefixed word (download, documentation, done, "do not") must still parse.
+#
+# The bug: the conditional/block guard scanned the raw line *including* its
+# trailing comment for " if " and " do", before comment stripping ran. So any
+# valid directive carrying such a comment was rejected with
+# Conditionals/BlocksUnsupported, and because the guard returns out of the
+# parser the whole Brewfile import aborted — not just the offending line. The
+# " do" arm was also substring-only, firing mid-word on "download".
+#
+# Asserts the comment-bearing lines round-trip all three packages via a
+# read-only `bundle install --dry-run`, and that a genuine `if`/`do` block is
+# still rejected.
+#
+# Exits 0 when valid comments parse and real conditionals are rejected;
+# non-zero otherwise. No network; runs the built binary against a throwaway
+# MALT_PREFIX so no real keg is touched.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+# The shell harness runs the built binary, which `zig build test` does not
+# rebuild — build it here so a stale binary never masks the fix.
+zig build >/dev/null
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+export MALT_PREFIX="$tmp/p"
+mkdir -p "$MALT_PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+
+bf="$tmp/Brewfile"
+cat >"$bf" <<'EOF'
+brew "wget" # build if needed
+brew "git"  # download manager
+cask "firefox" # do not remove
+EOF
+
+# Positive: comments containing if/do must not abort the import.
+out="$("$BIN" --dry-run bundle install "$bf" 2>&1)" || {
+  echo "FAIL: valid comments containing if/do were rejected:" >&2
+  echo "$out" >&2
+  exit 1
+}
+echo "$out" | grep -q wget || {
+  echo "FAIL: wget missing" >&2
+  echo "$out" >&2
+  exit 1
+}
+echo "$out" | grep -q git || {
+  echo "FAIL: git missing" >&2
+  echo "$out" >&2
+  exit 1
+}
+echo "$out" | grep -q firefox || {
+  echo "FAIL: firefox missing" >&2
+  echo "$out" >&2
+  exit 1
+}
+
+# Negative: a real conditional must still be rejected.
+printf 'if OS.mac?\nbrew "wget"\nend\n' >"$bf"
+if "$BIN" --dry-run bundle install "$bf" >/dev/null 2>&1; then
+  echo "FAIL: real conditional was not rejected" >&2
+  exit 1
+fi
+
+# Negative: real do…end block openers must still be rejected, including the
+# pipe-without-space form that a literal " do " check would silently accept.
+for opener in 'brew "wget" do |f|' 'brew "wget" do|f|'; do
+  printf '%s\nend\n' "$opener" >"$bf"
+  if "$BIN" --dry-run bundle install "$bf" >/dev/null 2>&1; then
+    echo "FAIL: real do block was not rejected: $opener" >&2
+    exit 1
+  fi
+done
+
+echo "PASS"

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -502,7 +502,17 @@ fn readManifest(
     if (std.mem.endsWith(u8, path, ".json")) {
         return manifest_mod.parseJson(allocator, body) catch return BundleError.BundlefileParse;
     }
-    return brewfile_mod.parse(allocator, body, diag) catch return BundleError.BundlefileParse;
+    return brewfile_mod.parse(allocator, body, diag) catch |e| {
+        // Surface the specific cause (and line, when the parser recorded one);
+        // otherwise the user only sees the generic BundlefileParse.
+        const reason = brewfile_mod.describeError(e);
+        if (diag) |d| {
+            if (d.error_line) |ln| {
+                output.err("Brewfile parse error at line {d}: {s}", .{ ln, reason });
+            } else output.err("Brewfile parse error: {s}", .{reason});
+        }
+        return BundleError.BundlefileParse;
+    };
 }
 
 fn writeManifest(

--- a/src/core/bundle/brewfile.zig
+++ b/src/core/bundle/brewfile.zig
@@ -83,14 +83,14 @@ pub fn parse(
         if (trimmed.len == 0) continue;
         if (trimmed[0] == '#') continue;
 
-        if (std.mem.indexOf(u8, trimmed, " if ") != null or std.mem.endsWith(u8, trimmed, " if")) {
-            return BrewfileError.ConditionalsUnsupported;
-        }
-        if (std.mem.indexOf(u8, trimmed, " do") != null or std.mem.endsWith(u8, trimmed, " do")) {
-            return BrewfileError.BlocksUnsupported;
-        }
+        // Strip the comment once, then reject `if`/`do` only as bare code
+        // tokens — never inside the quoted arg ("my if tool") or as longer
+        // words ("download"). parseLine reuses the stripped slice.
+        const code = stripTrailingComment(trimmed);
+        if (hasKeyword(code, "if")) return BrewfileError.ConditionalsUnsupported;
+        if (hasKeyword(code, "do")) return BrewfileError.BlocksUnsupported;
 
-        try parseLine(a, trimmed, line_no, &taps, &formulas, &casks, &services, diag);
+        try parseLine(a, code, line_no, &taps, &formulas, &casks, &services, diag);
     }
 
     m.taps = taps.toOwnedSlice(a) catch return BrewfileError.OutOfMemory;
@@ -103,7 +103,7 @@ pub fn parse(
 
 fn parseLine(
     a: std.mem.Allocator,
-    line: []const u8,
+    code: []const u8,
     line_no: usize,
     taps: *std.ArrayList([]const u8),
     formulas: *std.ArrayList(manifest_mod.FormulaEntry),
@@ -113,7 +113,6 @@ fn parseLine(
 ) BrewfileError!void {
     _ = line_no;
 
-    const code = stripTrailingComment(line);
     var cursor: usize = 0;
     const directive = nextIdent(code, &cursor) orelse return BrewfileError.UnexpectedToken;
     skipSpaces(code, &cursor);
@@ -209,6 +208,42 @@ fn stripTrailingComment(s: []const u8) []const u8 {
     return s;
 }
 
+/// True when `word` occurs in `code` as a whole identifier token outside any
+/// string literal. Catches Ruby `if`/`do` openers in every spacing form
+/// (`if cond`, `if(cond)`, `do`, `do|f|`) while ignoring keyword text inside
+/// quoted args ("my if tool") and longer words ("download"/"redo").
+fn hasKeyword(code: []const u8, word: []const u8) bool {
+    var in_str = false;
+    var quote: u8 = 0;
+    var i: usize = 0;
+    while (i < code.len) : (i += 1) {
+        const c = code[i];
+        if (in_str) {
+            if (c == '\\' and i + 1 < code.len) {
+                i += 1; // skip the escaped byte
+            } else if (c == quote) {
+                in_str = false;
+            }
+            continue;
+        }
+        if (c == '"' or c == '\'') {
+            in_str = true;
+            quote = c;
+        } else if (isIdentByte(c)) {
+            const start = i;
+            while (i < code.len and isIdentByte(code[i])) i += 1;
+            if (std.mem.eql(u8, code[start..i], word)) return true;
+            i -= 1; // re-examine the boundary byte next iteration
+        }
+    }
+    return false;
+}
+
+fn isIdentByte(c: u8) bool {
+    return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or
+        (c >= '0' and c <= '9') or c == '_';
+}
+
 fn skipSpaces(s: []const u8, cursor: *usize) void {
     while (cursor.* < s.len and (s[cursor.*] == ' ' or s[cursor.*] == '\t')) cursor.* += 1;
 }
@@ -283,4 +318,82 @@ fn consumeValue(s: []const u8, cursor: *usize) []const u8 {
     }
     while (cursor.* < s.len and s[cursor.*] != ',') cursor.* += 1;
     return s[start..cursor.*];
+}
+
+const testing = std.testing;
+
+test "comment containing if does not abort the import" {
+    // The conditional guard must run on code, not on the trailing comment.
+    var m = try parse(testing.allocator, "brew \"wget\" # build if needed\n", null);
+    defer m.deinit();
+
+    try testing.expectEqual(@as(usize, 1), m.formulas.len);
+    try testing.expectEqualStrings("wget", m.formulas[0].name);
+}
+
+test "comment with do-prefixed word does not abort the import" {
+    // `do` needs a word boundary so "download"/"do not" stay valid, and a
+    // formula name that embeds "do" (pandoc) must not trip the guard.
+    const txt =
+        \\brew "git" # download manager
+        \\brew "pandoc"
+        \\cask "firefox" # do not remove
+    ;
+    var m = try parse(testing.allocator, txt, null);
+    defer m.deinit();
+
+    try testing.expectEqual(@as(usize, 2), m.formulas.len);
+    try testing.expectEqualStrings("git", m.formulas[0].name);
+    try testing.expectEqualStrings("pandoc", m.formulas[1].name);
+    try testing.expectEqual(@as(usize, 1), m.casks.len);
+    try testing.expectEqualStrings("firefox", m.casks[0].name);
+}
+
+test "real conditional still rejected after comment stripping" {
+    try testing.expectError(
+        BrewfileError.ConditionalsUnsupported,
+        parse(testing.allocator, "brew \"wget\" if OS.mac?\n", null),
+    );
+}
+
+test "real do block opener still rejected across boundary forms" {
+    // Every `do` opener form must trip BlocksUnsupported: trailing EOL,
+    // space-pipe, and the pipe-without-space / tab forms the literal " do "
+    // check used to miss (silent partial parse).
+    const openers = [_][]const u8{
+        "brew \"wget\" do\n  link\nend\n",
+        "brew \"wget\" do |f|\nend\n",
+        "brew \"wget\" do|f|\nend\n",
+        "brew \"wget\" do\t|f|\nend\n",
+    };
+    for (openers) |txt| {
+        try testing.expectError(
+            BrewfileError.BlocksUnsupported,
+            parse(testing.allocator, txt, null),
+        );
+    }
+}
+
+test "conditional without spacing around the keyword is rejected" {
+    // `foo if(cond)` is a valid Ruby modifier; the keyword needs no flanking
+    // spaces, only token boundaries.
+    try testing.expectError(
+        BrewfileError.ConditionalsUnsupported,
+        parse(testing.allocator, "brew \"wget\" if(OS.mac?)\n", null),
+    );
+}
+
+test "keyword inside the quoted argument does not trip the guard" {
+    // The arg is a string literal, not code — `if`/`do` within it are data.
+    const txt =
+        \\brew "my if tool"
+        \\cask "my do thing"
+    ;
+    var m = try parse(testing.allocator, txt, null);
+    defer m.deinit();
+
+    try testing.expectEqual(@as(usize, 1), m.formulas.len);
+    try testing.expectEqualStrings("my if tool", m.formulas[0].name);
+    try testing.expectEqual(@as(usize, 1), m.casks.len);
+    try testing.expectEqualStrings("my do thing", m.casks[0].name);
 }

--- a/src/core/bundle/brewfile.zig
+++ b/src/core/bundle/brewfile.zig
@@ -18,6 +18,7 @@ pub const BrewfileError = error{
     ExpectedString,
     ConditionalsUnsupported,
     BlocksUnsupported,
+    InterpolationUnsupported,
     OutOfMemory,
     MalformedJson,
     UnsupportedVersion,
@@ -31,6 +32,7 @@ pub fn describeError(err: BrewfileError) []const u8 {
         BrewfileError.ExpectedString => "directive expects a quoted string argument",
         BrewfileError.ConditionalsUnsupported => "Brewfile conditionals are unsupported; convert to Maltfile.json",
         BrewfileError.BlocksUnsupported => "Brewfile `do ... end` blocks are unsupported",
+        BrewfileError.InterpolationUnsupported => "Brewfile string interpolation (`#{...}`) is unsupported; convert to Maltfile.json",
         BrewfileError.OutOfMemory => "out of memory parsing Brewfile",
         BrewfileError.MalformedJson => "malformed bundle JSON",
         BrewfileError.UnsupportedVersion => "unsupported bundle schema version",
@@ -38,17 +40,14 @@ pub fn describeError(err: BrewfileError) []const u8 {
     };
 }
 
-const Line = struct {
-    text: []const u8,
-    num: usize,
-};
-
 /// Caller-owned out-bag for non-fatal parser warnings (currently: unknown
-/// directives we skip). Core returns outcomes; UI renders at the
-/// boundary — `cli/bundle.zig` drains this into `output.warn`.
+/// directives we skip) plus the 1-based line of a fatal parse error. Core
+/// returns outcomes; UI renders at the boundary — `cli/bundle.zig` drains
+/// `warnings` into `output.warn` and reports `error_line` on failure.
 pub const Diagnostics = struct {
     allocator: std.mem.Allocator,
     warnings: std.ArrayList([]const u8),
+    error_line: ?usize = null,
 
     pub fn init(allocator: std.mem.Allocator) Diagnostics {
         return .{ .allocator = allocator, .warnings = .empty };
@@ -60,6 +59,17 @@ pub const Diagnostics = struct {
         self.* = undefined;
     }
 };
+
+// Ruby control-flow keywords the narrow subset can't model. They are rejected
+// up front so the user gets a clear error instead of a misleading token error.
+const conditional_keywords = [_][]const u8{ "if", "unless", "elsif", "else", "case", "when" };
+const block_keywords = [_][]const u8{ "do", "while", "until", "for", "begin", "end" };
+
+/// Record the failing line for the UI boundary and propagate the error.
+fn parseFail(diag: ?*Diagnostics, line_no: usize, err: BrewfileError) BrewfileError {
+    if (diag) |d| d.error_line = line_no;
+    return err;
+}
 
 pub fn parse(
     parent: std.mem.Allocator,
@@ -83,14 +93,15 @@ pub fn parse(
         if (trimmed.len == 0) continue;
         if (trimmed[0] == '#') continue;
 
-        // Strip the comment once, then reject `if`/`do` only as bare code
-        // tokens — never inside the quoted arg ("my if tool") or as longer
-        // words ("download"). parseLine reuses the stripped slice.
+        // Strip the comment once and reject unsupported Ruby on the code only;
+        // parseLine reuses the stripped slice (matchers handle string spans).
         const code = stripTrailingComment(trimmed);
-        if (hasKeyword(code, "if")) return BrewfileError.ConditionalsUnsupported;
-        if (hasKeyword(code, "do")) return BrewfileError.BlocksUnsupported;
+        if (firstMatch(code, &conditional_keywords)) return parseFail(diag, line_no, BrewfileError.ConditionalsUnsupported);
+        if (firstMatch(code, &block_keywords)) return parseFail(diag, line_no, BrewfileError.BlocksUnsupported);
+        if (hasInterpolation(code)) return parseFail(diag, line_no, BrewfileError.InterpolationUnsupported);
 
-        try parseLine(a, code, line_no, &taps, &formulas, &casks, &services, diag);
+        parseLine(a, code, &taps, &formulas, &casks, &services, diag) catch |e|
+            return parseFail(diag, line_no, e);
     }
 
     m.taps = taps.toOwnedSlice(a) catch return BrewfileError.OutOfMemory;
@@ -104,15 +115,12 @@ pub fn parse(
 fn parseLine(
     a: std.mem.Allocator,
     code: []const u8,
-    line_no: usize,
     taps: *std.ArrayList([]const u8),
     formulas: *std.ArrayList(manifest_mod.FormulaEntry),
     casks: *std.ArrayList(manifest_mod.CaskEntry),
     services: *std.ArrayList(manifest_mod.ServiceEntry),
     diag: ?*Diagnostics,
 ) BrewfileError!void {
-    _ = line_no;
-
     var cursor: usize = 0;
     const directive = nextIdent(code, &cursor) orelse return BrewfileError.UnexpectedToken;
     skipSpaces(code, &cursor);
@@ -242,6 +250,35 @@ fn hasKeyword(code: []const u8, word: []const u8) bool {
 fn isIdentByte(c: u8) bool {
     return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or
         (c >= '0' and c <= '9') or c == '_';
+}
+
+fn firstMatch(code: []const u8, words: []const []const u8) bool {
+    for (words) |w| if (hasKeyword(code, w)) return true;
+    return false;
+}
+
+/// True when a double-quoted string in `code` contains a `#{...}` interpolation.
+/// Single-quoted strings are literal in Ruby, so only `"` spans count.
+fn hasInterpolation(code: []const u8) bool {
+    var in_str = false;
+    var quote: u8 = 0;
+    var i: usize = 0;
+    while (i < code.len) : (i += 1) {
+        const c = code[i];
+        if (in_str) {
+            if (c == '\\' and i + 1 < code.len) {
+                i += 1; // skip the escaped byte
+            } else if (c == quote) {
+                in_str = false;
+            } else if (quote == '"' and c == '#' and i + 1 < code.len and code[i + 1] == '{') {
+                return true;
+            }
+        } else if (c == '"' or c == '\'') {
+            in_str = true;
+            quote = c;
+        }
+    }
+    return false;
 }
 
 fn skipSpaces(s: []const u8, cursor: *usize) void {
@@ -396,4 +433,38 @@ test "keyword inside the quoted argument does not trip the guard" {
     try testing.expectEqualStrings("my if tool", m.formulas[0].name);
     try testing.expectEqual(@as(usize, 1), m.casks.len);
     try testing.expectEqualStrings("my do thing", m.casks[0].name);
+}
+
+test "other control-flow keywords are rejected with a clear error" {
+    try testing.expectError(
+        BrewfileError.ConditionalsUnsupported,
+        parse(testing.allocator, "unless OS.linux?\nbrew \"wget\"\nend\n", null),
+    );
+    try testing.expectError(
+        BrewfileError.BlocksUnsupported,
+        parse(testing.allocator, "brew \"wget\" while retry?\n", null),
+    );
+}
+
+test "double-quoted interpolation is rejected, single-quoted is literal" {
+    // Ruby interpolates only in double quotes, so `'a#{b}'` is a literal name.
+    try testing.expectError(
+        BrewfileError.InterpolationUnsupported,
+        parse(testing.allocator, "brew \"foo#{ENV['X']}\"\n", null),
+    );
+
+    var m = try parse(testing.allocator, "brew 'foo#{bar}'\n", null);
+    defer m.deinit();
+    try testing.expectEqual(@as(usize, 1), m.formulas.len);
+    try testing.expectEqualStrings("foo#{bar}", m.formulas[0].name);
+}
+
+test "diagnostics records the 1-based line of a parse failure" {
+    var diag = Diagnostics.init(testing.allocator);
+    defer diag.deinit();
+    try testing.expectError(
+        BrewfileError.ConditionalsUnsupported,
+        parse(testing.allocator, "brew \"wget\"\n\nbrew \"jq\" if OS.mac?\n", &diag),
+    );
+    try testing.expectEqual(@as(?usize, 3), diag.error_line);
 }


### PR DESCRIPTION
## Description

A Brewfile directive carrying a trailing comment that happened to contain `if` or a `do`-prefixed word aborted the **entire** import. `brew "wget" # build if needed` and `brew "git" # download manager` both failed, because the conditional/block guard scanned the raw line, comment included, with plain substring matching.

This branch makes Brewfile import robust and its failures legible:

- The `if`/`do` guard now runs on the comment-stripped code and matches only whole tokens outside string literals. Valid files with such comments import cleanly; names that merely embed a keyword (`pandoc`) no longer false-trip, while every real block opener (`do`, `do |f|`, `do|f|`) is still rejected.
- Unsupported Brewfile syntax - conditionals, `do…end` blocks, `#{...}` interpolation, and the broader Ruby control keywords (`unless`, `while`, …) - is now reported with a clear reason **and the failing line number**, instead of a generic parse failure that hid the cause.
- String interpolation is rejected only in double-quoted args (Ruby semantics); single-quoted `'foo#{bar}'` stays a literal name.

## Related Issue

- None

## Notes for Reviewers

- None