### PR TITLE
fix(net): honor MALT_GITHUB_TOKEN across all GitHub API calls

### DIFF
--- a/man/malt.1
+++ b/man/malt.1
@@ -747,9 +747,10 @@ Environment:
                     default auto
   MALT_THEMES_FILE  Path to a JSON file of custom themes
                     (default: {prefix}/etc/malt/themes.json)
+  MALT_GITHUB_TOKEN Primary GitHub token for all GitHub API traffic
+                    (tap commit lookups and self-update)
   HOMEBREW_GITHUB_API_TOKEN
-                    GitHub token for higher API rate limits
-  MALT_GITHUB_TOKEN GitHub token sent as Bearer on tap commit lookups
+                    Compatibility fallback when MALT_GITHUB_TOKEN is unset
   MALT_GITLAB_TOKEN GitLab token (PRIVATE-TOKEN) for GitLab-hosted taps
   MALT_GITEA_TOKEN  Codeberg/Forgejo/Gitea token for those taps
   MALT_HTTP_IDLE_TIMEOUT_SECS

--- a/scripts/regressions/selfupdate-honors-malt-github-token-two-different-token-env-vars.sh
+++ b/scripts/regressions/selfupdate-honors-malt-github-token-two-different-token-env-vars.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Regression: the self-update / notifier GitHub API GET (HttpClient.get) must
+# honor MALT_GITHUB_TOKEN, not only HOMEBREW_GITHUB_API_TOKEN.
+#
+# The bug: get() keyed its auto-injected Authorization header exclusively off
+# HOMEBREW_GITHUB_API_TOKEN, while the tap/forge path read MALT_GITHUB_TOKEN.
+# A user who set only MALT_GITHUB_TOKEN still went out unauthenticated on
+# `version update`, hit the anonymous 60/hr cap, and got a hard 403.
+#
+# The host gate (githubTokenApplies) only injects on real GitHub hosts, so a
+# loopback capture server can never exercise the selection end-to-end. Instead
+# the guard is an integration test asserting get()'s token resolution prefers
+# MALT_GITHUB_TOKEN and treats an empty value as unset. This script builds and
+# runs only that test binary, so it stays well under 30s and needs no network.
+#
+# Exits 0 when the token resolution honors MALT_GITHUB_TOKEN, non-zero when it
+# does not (or the guard test is missing).
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+TEST_NAME="HttpClient.get token resolution honors MALT_GITHUB_TOKEN, falls back to HOMEBREW_GITHUB_API_TOKEN"
+TEST_SRC="tests/http_inject_test.zig"
+
+# If the guard test is ever deleted, the runner would simply report "no tests"
+# and pass. Fail loudly instead.
+if ! grep -Rqs -- "$TEST_NAME" "$TEST_SRC"; then
+  echo "FAIL: the self-update token-resolution guard test is missing from $TEST_SRC" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/http_inject_test"
+if [[ ! -x "$BIN" ]]; then
+  if ! zig build test-bin >/dev/null 2>&1; then
+    echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+    exit 1
+  fi
+fi
+
+# The runner has no per-test filter, so run the file's suite and judge the
+# token-resolution guard by name: a pass ends in "OK", a regression prints
+# "FAIL" there and the binary exits non-zero.
+OUT=$("$BIN" 2>&1 || true)
+LINE=$(printf '%s\n' "$OUT" | grep -F -- "$TEST_NAME" || true)
+if [[ -z "$LINE" ]]; then
+  echo "FAIL: the self-update token-resolution guard test did not run" >&2
+  printf '%s\n' "$OUT" >&2
+  exit 1
+fi
+if [[ "$LINE" != *OK ]]; then
+  echo "FAIL: self-update GET did not honor MALT_GITHUB_TOKEN" >&2
+  printf '%s\n' "$OUT" >&2
+  exit 1
+fi
+
+echo "PASS: self-update honors MALT_GITHUB_TOKEN"

--- a/scripts/regressions/tap-resolution-contract.sh
+++ b/scripts/regressions/tap-resolution-contract.sh
@@ -13,9 +13,10 @@
 #   2. `https://github.com/{s}"` — decorative writeback that lied about
 #      the actually-resolvable repo URL
 #   3. `MALT_GITHUB_TOKEN` / `authHeader` outside the seam —
-#      the token reaches exactly the GitHub API HEAD call and never
-#      the raw Formula/Cask fetches. Widening (or narrowing) the reach
-#      without explicit intent is a contract change.
+#      the token reaches the tap-resolution forge seam and the
+#      self-update GitHub API GET, and never the raw Formula/Cask
+#      fetches. Widening (or narrowing) the reach without explicit
+#      intent is a contract change.
 #
 # Allowed sites:
 #   - src/core/forge.zig        the host-shaped seam (URLs, parse, auth)
@@ -23,6 +24,9 @@
 #   - src/cli/migrate/keg.zig   on-disk Cellar path
 #                                 (<prefix>/Library/Taps/<user>/homebrew-<repo>) —
 #                                 Homebrew's filesystem layout, not a URL
+#   - src/net/client.zig        the self-update / notifier GET auto-injects
+#                                 the same primary token (HttpClient.githubApiToken)
+#                                 so `version update` honors it like tap lookups
 #   - Zig multiline-string (`\\`) lines — documentation, e.g. the `--help`
 #                                 env-var listing. A real token reach is
 #                                 executable code; it can never live inside
@@ -56,6 +60,7 @@ filtered=$(printf '%s\n' "$all" |
   grep -v '^src/core/forge\.zig:' |
   grep -v '^src/core/tap\.zig:' |
   grep -v '^src/cli/migrate/keg\.zig:' |
+  grep -v '^src/net/client\.zig:' |
   grep -vE ":[0-9]+:[[:space:]]*${bs}${bs}" |
   grep -v '^$' || true)
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -665,9 +665,10 @@ fn printUsage(ctx: *const AppCtx) void {
         \\                    default auto
         \\  MALT_THEMES_FILE  Path to a JSON file of custom themes
         \\                    (default: {prefix}/etc/malt/themes.json)
+        \\  MALT_GITHUB_TOKEN Primary GitHub token for all GitHub API traffic
+        \\                    (tap commit lookups and self-update)
         \\  HOMEBREW_GITHUB_API_TOKEN
-        \\                    GitHub token for higher API rate limits
-        \\  MALT_GITHUB_TOKEN GitHub token sent as Bearer on tap commit lookups
+        \\                    Compatibility fallback when MALT_GITHUB_TOKEN is unset
         \\  MALT_GITLAB_TOKEN GitLab token (PRIVATE-TOKEN) for GitLab-hosted taps
         \\  MALT_GITEA_TOKEN  Codeberg/Forgejo/Gitea token for those taps
         \\  MALT_HTTP_IDLE_TIMEOUT_SECS

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -347,6 +347,23 @@ pub const HttpClient = struct {
         return false;
     }
 
+    /// Token for the GitHub/Homebrew API `Authorization` header. Prefers
+    /// `MALT_GITHUB_TOKEN` (malt's primary GitHub token, shared with tap
+    /// lookups) and falls back to `HOMEBREW_GITHUB_API_TOKEN` for Homebrew
+    /// compatibility. An empty value is treated as unset for each — mirroring
+    /// `forge.authHeader` — so a leftover `MALT_GITHUB_TOKEN=` never shadows a
+    /// real Homebrew token. Returns the bare token; the caller adds the scheme.
+    pub fn githubApiToken(environ: std.process.Environ) ?[]const u8 {
+        return nonEmptyEnv(environ, "MALT_GITHUB_TOKEN") orelse
+            nonEmptyEnv(environ, "HOMEBREW_GITHUB_API_TOKEN");
+    }
+
+    fn nonEmptyEnv(environ: std.process.Environ, key: []const u8) ?[]const u8 {
+        const raw = std.process.Environ.getPosix(environ, key) orelse return null;
+        const v = std.mem.sliceTo(raw, 0);
+        return if (v.len == 0) null else v;
+    }
+
     /// http(s) scheme of a malt URL, or null for non-http(s). Used to gate
     /// whether a credential may follow a redirect — the scheme must match.
     fn urlScheme(url: []const u8) ?[]const u8 {
@@ -387,16 +404,17 @@ pub const HttpClient = struct {
         return hostIsSameOrSubdomain(fh, th);
     }
 
-    /// GET request; auto-injects HOMEBREW_GITHUB_API_TOKEN as Authorization
-    /// for GitHub/Homebrew hosts. Caller owns the returned `Response`.
+    /// GET request; auto-injects the GitHub API token (`MALT_GITHUB_TOKEN`,
+    /// then `HOMEBREW_GITHUB_API_TOKEN`) as Authorization for GitHub/Homebrew
+    /// hosts. Caller owns the returned `Response`.
     pub fn get(self: *HttpClient, url: []const u8) !Response {
         if (self.offline) return error.OfflineRequired;
-        if (std.process.Environ.getPosix(self.environ, "HOMEBREW_GITHUB_API_TOKEN")) |token| {
+        if (githubApiToken(self.environ)) |token| {
             // Host-component match, not substring: a look-alike host or a
             // path containing "github.com" must never receive the token.
             if (githubTokenApplies(url)) {
                 var auth_buf: [256]u8 = undefined;
-                const auth_value = std.fmt.bufPrint(&auth_buf, "token {s}", .{std.mem.sliceTo(token, 0)}) catch
+                const auth_value = std.fmt.bufPrint(&auth_buf, "token {s}", .{token}) catch
                     return self.doGet(url, &.{});
                 const headers = [_]std.http.Header{
                     .{ .name = "Authorization", .value = auth_value },
@@ -1141,6 +1159,69 @@ test "githubTokenApplies: tolerates the FQDN trailing-dot root form" {
     try std.testing.expect(HttpClient.githubTokenApplies("https://github.com./x"));
     try std.testing.expect(HttpClient.githubTokenApplies("https://api.github.com./x"));
     try std.testing.expect(!HttpClient.githubTokenApplies("https://github.com.evil.tld./x"));
+}
+
+// ── githubApiToken: env-var precedence ─────────────────────────────
+// The self-update GET (api.github.com/releases/latest) must honour the
+// project's primary token, MALT_GITHUB_TOKEN, not only the Homebrew
+// compatibility var — otherwise a user with one token still hits the
+// anonymous rate cap on `version update`.
+
+fn environFrom(entries: [:null]const ?[*:0]const u8) std.process.Environ {
+    return .{ .block = .{ .slice = entries } };
+}
+
+test "githubApiToken: MALT_GITHUB_TOKEN is preferred over HOMEBREW_GITHUB_API_TOKEN" {
+    const entries = [_:null]?[*:0]const u8{
+        "MALT_GITHUB_TOKEN=malt-tok".ptr,
+        "HOMEBREW_GITHUB_API_TOKEN=brew-tok".ptr,
+    };
+    try std.testing.expectEqualStrings("malt-tok", HttpClient.githubApiToken(environFrom(&entries)).?);
+}
+
+test "githubApiToken: empty MALT_GITHUB_TOKEN falls through to HOMEBREW_GITHUB_API_TOKEN" {
+    // A leftover `MALT_GITHUB_TOKEN=` in a shell rc must not shadow a real
+    // HOMEBREW token (mirrors forge.authHeader's empty-as-unset guard).
+    const entries = [_:null]?[*:0]const u8{
+        "MALT_GITHUB_TOKEN=".ptr,
+        "HOMEBREW_GITHUB_API_TOKEN=brew-tok".ptr,
+    };
+    try std.testing.expectEqualStrings("brew-tok", HttpClient.githubApiToken(environFrom(&entries)).?);
+}
+
+test "githubApiToken: MALT_GITHUB_TOKEN alone is honoured" {
+    const entries = [_:null]?[*:0]const u8{"MALT_GITHUB_TOKEN=malt-tok".ptr};
+    try std.testing.expectEqualStrings("malt-tok", HttpClient.githubApiToken(environFrom(&entries)).?);
+}
+
+test "githubApiToken: HOMEBREW_GITHUB_API_TOKEN alone still works (compat fallback)" {
+    const entries = [_:null]?[*:0]const u8{"HOMEBREW_GITHUB_API_TOKEN=brew-tok".ptr};
+    try std.testing.expectEqualStrings("brew-tok", HttpClient.githubApiToken(environFrom(&entries)).?);
+}
+
+test "githubApiToken: null when neither var is set or both are empty" {
+    try std.testing.expect(HttpClient.githubApiToken(std.process.Environ.empty) == null);
+    const empties = [_:null]?[*:0]const u8{
+        "MALT_GITHUB_TOKEN=".ptr,
+        "HOMEBREW_GITHUB_API_TOKEN=".ptr,
+    };
+    try std.testing.expect(HttpClient.githubApiToken(environFrom(&empties)) == null);
+}
+
+test "githubApiToken: empty MALT with HOMEBREW absent is null (no phantom token)" {
+    const entries = [_:null]?[*:0]const u8{"MALT_GITHUB_TOKEN=".ptr};
+    try std.testing.expect(HttpClient.githubApiToken(environFrom(&entries)) == null);
+}
+
+test "githubApiToken: a non-empty value is taken verbatim, not trimmed (matches forge.authHeader)" {
+    // forge.authHeader guards on len==0 only — no whitespace trim — so a
+    // whitespace-only MALT_GITHUB_TOKEN is a set value and must not fall
+    // through to HOMEBREW. Locks that deliberate divergence from mirror.zig.
+    const entries = [_:null]?[*:0]const u8{
+        "MALT_GITHUB_TOKEN=  ".ptr,
+        "HOMEBREW_GITHUB_API_TOKEN=brew-tok".ptr,
+    };
+    try std.testing.expectEqualStrings("  ", HttpClient.githubApiToken(environFrom(&entries)).?);
 }
 
 test "HttpClient.get returns OfflineRequired when offline is set" {

--- a/tests/http_inject_test.zig
+++ b/tests/http_inject_test.zig
@@ -30,6 +30,30 @@ fn serveOnce(fx: *Fixture) void {
     req.respond(body_json, .{}) catch return;
 }
 
+const AuthFixture = struct {
+    io: std.Io,
+    listener: *net.Server,
+    saw_auth: bool = false,
+};
+
+// Like serveOnce, but records whether the request carried an Authorization
+// header. Read `saw_auth` only after joining the server thread.
+fn serveOnceRecordingAuth(fx: *AuthFixture) void {
+    const stream = fx.listener.accept(fx.io) catch return;
+    defer stream.close(fx.io);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var reader = stream.reader(fx.io, &rbuf);
+    var writer = stream.writer(fx.io, &wbuf);
+    var srv = std.http.Server.init(&reader.interface, &writer.interface);
+    var req = srv.receiveHead() catch return;
+    var it = req.iterateHeaders();
+    while (it.next()) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, "authorization")) fx.saw_auth = true;
+    }
+    req.respond(body_json, .{}) catch return;
+}
+
 test "HttpClient.initWith: GET round-trips a body from a localhost server (offline)" {
     var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
     defer threaded.deinit();
@@ -57,6 +81,70 @@ test "HttpClient.initWith: GET round-trips a body from a localhost server (offli
     defer resp.deinit();
     try std.testing.expectEqual(@as(u16, 200), resp.status);
     try std.testing.expectEqualStrings(body_json, resp.body);
+}
+
+test "HttpClient.get token resolution honors MALT_GITHUB_TOKEN, falls back to HOMEBREW_GITHUB_API_TOKEN" {
+    // Self-update / notifier GETs go through HttpClient.get, whose auth must
+    // honor the project's primary token. The loopback host gate
+    // (githubTokenApplies) only fires on real GitHub hosts, so this asserts the
+    // env-var selection directly — the wire-side header path is covered by the
+    // round-trip test above and net_redirect_auth_test.
+    {
+        const entries = [_:null]?[*:0]const u8{
+            "MALT_GITHUB_TOKEN=malt-tok".ptr,
+            "HOMEBREW_GITHUB_API_TOKEN=brew-tok".ptr,
+        };
+        const env: std.process.Environ = .{ .block = .{ .slice = &entries } };
+        try std.testing.expectEqualStrings("malt-tok", client.HttpClient.githubApiToken(env).?);
+    }
+    {
+        // Empty MALT_GITHUB_TOKEN must not shadow a real Homebrew token.
+        const entries = [_:null]?[*:0]const u8{
+            "MALT_GITHUB_TOKEN=".ptr,
+            "HOMEBREW_GITHUB_API_TOKEN=brew-tok".ptr,
+        };
+        const env: std.process.Environ = .{ .block = .{ .slice = &entries } };
+        try std.testing.expectEqualStrings("brew-tok", client.HttpClient.githubApiToken(env).?);
+    }
+}
+
+test "HttpClient.get does not leak the GitHub token to a non-GitHub host (cross-forge guarantee)" {
+    // Even with MALT_GITHUB_TOKEN set, get() must not auto-inject Authorization
+    // on a non-github host. A loopback host is non-github, so it stands in for
+    // any other-forge host (gitlab.com, codeberg.org, a self-hosted Forgejo):
+    // githubTokenApplies rejects them all identically. This proves the gate's
+    // decision reaches the wire — those forges authenticate only via their own
+    // MALT_GITLAB_TOKEN / MALT_GITEA_TOKEN through the forge seam, never here.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var fx = AuthFixture{ .io = io, .listener = &listener };
+    const server_thread = try std.Thread.spawn(.{}, serveOnceRecordingAuth, .{&fx});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/releases/latest", .{port});
+
+    const entries = [_:null]?[*:0]const u8{"MALT_GITHUB_TOKEN=ghp_must_not_leak".ptr};
+    const env: std.process.Environ = .{ .block = .{ .slice = &entries } };
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, env, std.testing.allocator);
+    defer http.deinit();
+
+    // Join before reading server-side state so the assertion can't race the serve.
+    const result = http.get(url);
+    server_thread.join();
+
+    var resp = try result;
+    defer resp.deinit();
+    try std.testing.expectEqual(@as(u16, 200), resp.status);
+    try std.testing.expect(!fx.saw_auth);
 }
 
 test "HttpClient.initWith: HEAD probe returns the server status (doctor's API-reachable path)" {


### PR DESCRIPTION
## Description

malt split GitHub authentication across two env vars for the same `api.github.com` host: tap/forge lookups read `MALT_GITHUB_TOKEN`, but the self-update and passive-notifier path read only `HOMEBREW_GITHUB_API_TOKEN`. A user who set `MALT_GITHUB_TOKEN` expecting it to cover all GitHub traffic still went out unauthenticated on `mt version update`, hit the anonymous 60/hr cap, and got a hard `403`.

`HttpClient.get` now resolves the GitHub API token via a single helper that prefers `MALT_GITHUB_TOKEN` and falls back to `HOMEBREW_GITHUB_API_TOKEN`, treating an empty value as unset (mirroring `forge.authHeader`) so a leftover `MALT_GITHUB_TOKEN=` never shadows a real Homebrew token. The existing `token <t>` scheme and the GitHub/Homebrew host gate are unchanged - the token still rides only real GitHub hosts and never leaks to another forge. Help text and the man page are updated to document `MALT_GITHUB_TOKEN` as the primary token with `HOMEBREW_GITHUB_API_TOKEN` as the compatibility fallback.

The tap-resolution contract guard is widened to recognize `net/client.zig` as the second intended auth site (self-update), reflecting the new one-token contract.

## Related Issue

- None

## Notes for Reviewers

- None