### PR TITLE
fix(purge): credit only successfully-freed bytes on partial wipe

### DIFF
--- a/scripts/regressions/purge-wipe-overstates-freed-bytes.sh
+++ b/scripts/regressions/purge-wipe-overstates-freed-bytes.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Regression: `purge --wipe` returned the preflight byte sum over every
+# existing target as `totals.bytes`, regardless of how many deletes failed.
+# On a partial wipe (an undeletable target) the byte total claimed space
+# that was never freed, disagreeing with `removed` (which excludes the
+# failures). Every other purge tier credits bytes only on success; wipe is
+# brought in line.
+#
+# This drives a real partial wipe against a throwaway prefix holding one
+# sized, undeletable Cellar target plus one freeable store target, parses
+# `--json`, and asserts that `totals.bytes` excludes the un-freed 1 MiB
+# blob. Exits 0 when the bug is absent, non-zero (with a diagnostic) when
+# `totals.bytes` still carries the preflight sum. No network; under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v python3 >/dev/null || {
+  echo "python3 required" >&2
+  exit 2
+}
+
+ROOTDIR="$(mktemp -d)"
+PREFIX="$ROOTDIR/opt-malt"
+cleanup() {
+  chflags -R nouchg "$PREFIX/Cellar" 2>/dev/null || true
+  rm -rf "$ROOTDIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$PREFIX/Cellar/demo" "$PREFIX/store"
+head -c 1048576 /dev/zero >"$PREFIX/Cellar/demo/blob" # 1 MiB, will fail to delete
+head -c 4096 /dev/zero >"$PREFIX/store/free"          # 4 KiB, will be freed
+chflags -R uchg "$PREFIX/Cellar"                      # make Cellar undeletable
+
+out="$(MALT_PREFIX="$PREFIX" "$BIN" purge --wipe --yes --json)"
+
+# The JSON summary is the one line carrying a `totals` object; the rest of
+# stdout is the human plan/banner. Pull totals.bytes from it.
+bytes="$(printf '%s\n' "$out" | python3 -c '
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if not line.startswith("{"):
+        continue
+    try:
+        o = json.loads(line)
+    except ValueError:
+        continue
+    if "totals" in o:
+        print(o["totals"]["bytes"])
+        break
+')"
+
+[[ -n "$bytes" ]] || {
+  echo "FAIL: could not parse totals.bytes from --json output" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+}
+
+# Bug present if bytes still includes the 1 MiB un-freed Cellar blob.
+if [[ "$bytes" -ge 1048576 ]]; then
+  echo "FAIL: totals.bytes=$bytes credits the undeletable 1 MiB target" >&2
+  exit 1
+fi
+
+echo "OK: freed bytes ($bytes) exclude the un-freed target"

--- a/src/cli/purge/wipe.zig
+++ b/src/cli/purge/wipe.zig
@@ -218,12 +218,18 @@ pub fn runWipe(ctx: *const AppCtx, allocator: std.mem.Allocator, opts: Options, 
     // would inflate the count to plan.len on a half-installed prefix.
     const existed = try allocator.alloc(bool, plan.len);
     defer allocator.free(existed);
+    // Per-path preflight sizes so a failed delete can be excluded from the
+    // freed-byte total; `total_bytes` stays the "bytes present" figure used
+    // by the dry-run return and the pre-flight "total:" display line.
+    const sizes = try allocator.alloc(u64, plan.len);
+    defer allocator.free(sizes);
 
     var total_bytes: u64 = 0;
     var existing_count: u32 = 0;
     for (plan, 0..) |t, idx| {
         existed[idx] = pathExists(io, t.path);
         const size = if (existed[idx]) util.pathSize(io, allocator, t.path) else 0;
+        sizes[idx] = size;
         total_bytes += size;
         if (existed[idx]) existing_count += 1;
         var sz_buf: [32]u8 = undefined;
@@ -259,6 +265,11 @@ pub fn runWipe(ctx: *const AppCtx, allocator: std.mem.Allocator, opts: Options, 
     var removed: usize = 0;
     var skipped: usize = 0;
     var freed_paths: u32 = 0;
+    // Mirror of the freed-path decision, indexed by plan slot, so the byte
+    // total credits exactly the targets the path count does.
+    const freed = try allocator.alloc(bool, plan.len);
+    defer allocator.free(freed);
+    @memset(freed, false);
     var db_idx: ?usize = null;
     var prefix_idx: ?usize = null;
 
@@ -276,7 +287,10 @@ pub fn runWipe(ctx: *const AppCtx, allocator: std.mem.Allocator, opts: Options, 
         }
         if (deleteTarget(io, t.path)) {
             removed += 1;
-            if (existed[idx]) freed_paths += 1;
+            if (existed[idx]) {
+                freed_paths += 1;
+                freed[idx] = true;
+            }
         } else skipped += 1;
     }
 
@@ -285,13 +299,19 @@ pub fn runWipe(ctx: *const AppCtx, allocator: std.mem.Allocator, opts: Options, 
     if (db_idx) |idx| {
         if (deleteTarget(io, plan[idx].path)) {
             removed += 1;
-            if (existed[idx]) freed_paths += 1;
+            if (existed[idx]) {
+                freed_paths += 1;
+                freed[idx] = true;
+            }
         } else skipped += 1;
     }
     if (prefix_idx) |idx| {
         if (deletePrefixRoot(io, plan[idx].path)) {
             removed += 1;
-            if (existed[idx]) freed_paths += 1;
+            if (existed[idx]) {
+                freed_paths += 1;
+                freed[idx] = true;
+            }
         } else skipped += 1;
     }
 
@@ -300,5 +320,44 @@ pub fn runWipe(ctx: *const AppCtx, allocator: std.mem.Allocator, opts: Options, 
     var sum_buf: [128]u8 = undefined;
     const sum = std.fmt.bufPrint(&sum_buf, "removed {d} target(s), skipped {d}", .{ removed, skipped }) catch "";
     output.success("{s}", .{sum});
-    return .{ .removed = freed_paths, .bytes = total_bytes };
+    return .{ .removed = freed_paths, .bytes = freedBytes(sizes, freed) };
+}
+
+/// Bytes credited by a wipe: only targets whose delete succeeded, using the
+/// preflight size. A target that resizes between the preflight stat and the
+/// unlink is a benign TOCTOU — this is a reporting figure, not a safety gate.
+/// `sizes[i]` is already 0 for non-existing paths, so `freed[i]` alone gates
+/// the sum and keeps the byte total consistent with the freed-path count.
+fn freedBytes(sizes: []const u64, freed: []const bool) u64 {
+    var total: u64 = 0;
+    for (sizes, freed) |s, f| {
+        if (f) total += s;
+    }
+    return total;
+}
+
+test "freedBytes credits only successfully-freed targets" {
+    const sizes = [_]u64{ 1048576, 4096, 8192 };
+    // Middle target's delete failed: its bytes must not be credited even
+    // though it was present in the preflight sum.
+    const freed = [_]bool{ true, false, true };
+    try std.testing.expectEqual(@as(u64, 1048576 + 8192), freedBytes(&sizes, &freed));
+}
+
+test "freedBytes is zero when every delete failed" {
+    const sizes = [_]u64{ 1048576, 4096 };
+    const freed = [_]bool{ false, false };
+    try std.testing.expectEqual(@as(u64, 0), freedBytes(&sizes, &freed));
+}
+
+test "freedBytes credits the full total when every delete succeeded" {
+    // The happy path: a fully successful wipe must still report all bytes,
+    // matching the old `total_bytes` behaviour that this fix preserves.
+    const sizes = [_]u64{ 1048576, 4096, 8192 };
+    const freed = [_]bool{ true, true, true };
+    try std.testing.expectEqual(@as(u64, 1048576 + 4096 + 8192), freedBytes(&sizes, &freed));
+}
+
+test "freedBytes is zero for an empty plan" {
+    try std.testing.expectEqual(@as(u64, 0), freedBytes(&.{}, &.{}));
 }


### PR DESCRIPTION
## Description

`purge --wipe` reported `totals.bytes` as the preflight size of every target present, even when some deletes failed - so a partial wipe (e.g. an undeletable Cellar) claimed it freed space it never did, contradicting the `removed` count.

This credits bytes only for targets that were actually deleted, bringing wipe in line with every other purge tier. The dry-run estimate and the pre-flight "total:" line are unchanged.

## Related Issue

- None

## Notes for Reviewers

- None