### PR TITLE
fix(bundle): honor explicit create path regardless of --format order

### DIFF
--- a/scripts/regressions/bundle-create-format-order-bundle-create-clobbers-output-path-on-format.sh
+++ b/scripts/regressions/bundle-create-format-order-bundle-create-clobbers-output-path-on-format.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Regression: an explicit positional out_path for `bundle create` must win
+# regardless of where `--format json` sits on the command line.
+#
+# The bug: cmdCreate derived the JSON default filename inside the `--format`
+# parse arm, so `--format json` appearing after the positional path overwrote
+# the user's filename with `Maltfile.json`. The default-filename choice was
+# coupled to argument order instead of to "did the user give a path".
+#
+# Asserts both orderings honour the explicit path; runs the built binary
+# against a throwaway workdir so no real keg is touched. No network.
+#
+# Exits 0 when the explicit path is honoured in both orderings, non-zero with a
+# message naming the offending ordering otherwise.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+# The shell harness runs the built binary, which `zig build test` does not
+# rebuild — build it here so a stale binary never masks the fix.
+zig build >/dev/null
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+export MALT_PREFIX="$tmp/p"
+mkdir -p "$MALT_PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+
+cd "$tmp"
+
+# Ordering A: path before flag (the broken case).
+"$BIN" bundle create myfile --format json >/dev/null 2>&1 || true
+[ -f myfile ] || {
+  echo "FAIL: 'create myfile --format json' did not write myfile" >&2
+  exit 1
+}
+[ -f Maltfile.json ] && {
+  echo "FAIL: explicit path clobbered by Maltfile.json default (path before --format)" >&2
+  exit 1
+}
+rm -f myfile
+
+# Ordering B: flag before path (already worked) — guard against regression.
+"$BIN" bundle create --format json myfile >/dev/null 2>&1 || true
+[ -f myfile ] || {
+  echo "FAIL: 'create --format json myfile' did not write myfile" >&2
+  exit 1
+}
+
+echo "PASS: explicit out_path honoured regardless of --format position"

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -348,32 +348,48 @@ fn cmdRemove(ctx: *const AppCtx, rest: []const []const u8) !void {
     output.success("bundle removed: {s}", .{name});
 }
 
-fn cmdCreate(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []const u8) !void {
+const CreateArgs = struct { format: Format, out_path: []const u8, include_services: bool };
+
+/// Parse `bundle create` args. The default filename is resolved once after the
+/// loop so an explicit positional path wins no matter where `--format` sits.
+/// Null signals an invalid format value.
+fn resolveCreateArgs(rest: []const []const u8) ?CreateArgs {
     var format: Format = .brewfile;
-    var out_path: []const u8 = "Brewfile";
+    var out_path: ?[]const u8 = null;
     var include_services = false;
     var i: usize = 0;
     while (i < rest.len) : (i += 1) {
         const a = rest[i];
         if (std.mem.eql(u8, a, "--format") and i + 1 < rest.len) {
             i += 1;
-            format = parseFormat(rest[i]) orelse return BundleError.InvalidArgs;
-            if (format == .json) out_path = "Maltfile.json";
+            format = parseFormat(rest[i]) orelse return null;
         } else if (std.mem.eql(u8, a, "--services")) {
             include_services = true;
         } else if (!std.mem.startsWith(u8, a, "-")) {
             out_path = a;
         }
     }
+    return .{
+        .format = format,
+        .out_path = out_path orelse switch (format) {
+            .brewfile => "Brewfile",
+            .json => "Maltfile.json",
+        },
+        .include_services = include_services,
+    };
+}
+
+fn cmdCreate(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []const u8) !void {
+    const args = resolveCreateArgs(rest) orelse return BundleError.InvalidArgs;
 
     var db = try openDb(ctx);
     defer db.close();
 
     var manifest = manifest_mod.Manifest.init(allocator);
     defer manifest.deinit();
-    try populateFromInstalled(&manifest, &db, .{ .include_services = include_services });
-    try writeManifest(ctx, manifest, out_path, format);
-    output.success("wrote {s}", .{out_path});
+    try populateFromInstalled(&manifest, &db, .{ .include_services = args.include_services });
+    try writeManifest(ctx, manifest, args.out_path, args.format);
+    output.success("wrote {s}", .{args.out_path});
 }
 
 fn cmdExport(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []const u8) !void {
@@ -679,4 +695,26 @@ fn printHelp(ctx: *const AppCtx) !void {
         \\
     ;
     ctx.stderr.writeStreamingAll(ctx.io, msg) catch {};
+}
+
+test "create: explicit out_path wins regardless of --format position" {
+    // Path before the flag was the broken order: a late --format json used to
+    // clobber the explicit path with the JSON default.
+    const a = resolveCreateArgs(&.{ "myfile", "--format", "json" }).?;
+    try std.testing.expectEqualStrings("myfile", a.out_path);
+    try std.testing.expectEqual(Format.json, a.format);
+
+    const b = resolveCreateArgs(&.{ "--format", "json", "myfile" }).?;
+    try std.testing.expectEqualStrings("myfile", b.out_path);
+
+    // No explicit path falls back to the format default.
+    try std.testing.expectEqualStrings("Maltfile.json", resolveCreateArgs(&.{ "--format", "json" }).?.out_path);
+    try std.testing.expectEqualStrings("Brewfile", resolveCreateArgs(&.{}).?.out_path);
+
+    // Repeated --format must not strand the JSON default on a brewfile result.
+    try std.testing.expectEqualStrings("Brewfile", resolveCreateArgs(&.{ "--format", "json", "--format", "brewfile" }).?.out_path);
+
+    // An invalid format is rejected; --services rides through to the result.
+    try std.testing.expect(resolveCreateArgs(&.{ "--format", "yaml" }) == null);
+    try std.testing.expect(resolveCreateArgs(&.{"--services"}).?.include_services);
 }


### PR DESCRIPTION
## Description

`mt bundle create <path> --format json` silently ignored the user's filename and wrote `Maltfile.json` instead. The JSON default filename was chosen inside the `--format` parse arm, so a `--format json` appearing after the positional path overwrote it — the output path depended on flag order rather than on whether the user gave an explicit path.

The fix resolves the default filename once, after argument parsing, gated on whether a positional was seen. An explicit path now wins in both orderings; with no path, the format still selects `Brewfile` / `Maltfile.json`.

The resolution is a `switch (format)` so any future format forces a compile-time case. `cmdExport` (streams to stdout, no out_path) is untouched.

## Related Issue

- None

## Notes for Reviewers

- None