### PR TITLE
fix(backup): create nested parent directories for absolute output paths

### DIFF
--- a/scripts/regressions/backup-absolute-nested-path-no-mkdir.sh
+++ b/scripts/regressions/backup-absolute-nested-path-no-mkdir.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Regression: `backup -o <absolute nested path>` must create the whole parent
+# chain, matching the relative case.
+#
+# The bug: writeToPath created absolute parents with a single-level mkdir
+# (createDirAbsolute) while relative parents went through a recursive
+# createDirPath. A nested absolute destination with a missing grandparent
+# therefore failed with a generic leaf "Failed to create ..." error, while the
+# identically-shaped relative path succeeded.
+#
+# Asserts both the absolute and relative nested destinations create their
+# parents and write a non-empty file. Uses a throwaway tmp tree; no network.
+#
+# Exits 0 when parents are created in both cases, non-zero with a message
+# naming the offending case otherwise.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+# The shell harness runs the built binary, which `zig build test` does not
+# rebuild — build it here so a stale binary never masks the fix.
+zig build >/dev/null
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+
+# grandparent intentionally absent: $tmp/a does not exist yet
+dest="$tmp/a/b/backup.txt"
+
+if ! "$BIN" backup -o "$dest" >/dev/null 2>&1; then
+  echo "FAIL: backup to absolute nested path did not create parents ($dest)" >&2
+  exit 1
+fi
+[ -s "$dest" ] || {
+  echo "FAIL: destination missing or empty ($dest)" >&2
+  exit 1
+}
+
+# sanity: relative parity still holds
+(cd "$tmp" && "$BIN" backup -o rel/c/backup.txt >/dev/null 2>&1 &&
+  [ -s rel/c/backup.txt ]) ||
+  {
+    echo "FAIL: relative nested backup regressed" >&2
+    exit 1
+  }
+
+echo "PASS: absolute and relative nested backup destinations both create parents"

--- a/src/cli/backup.zig
+++ b/src/cli/backup.zig
@@ -278,15 +278,14 @@ fn writeToPath(ctx: *const AppCtx, path: []const u8, bytes: []const u8) Error!vo
     // Create parent directories when the user supplied a nested path.
     if (std.fs.path.dirname(path)) |dir| {
         if (dir.len > 0) {
-            if (std.fs.path.isAbsolute(dir)) {
-                std.Io.Dir.createDirAbsolute(ctx.io, dir, .default_dir) catch |e| switch (e) {
-                    error.PathAlreadyExists => {},
-                    else => {},
-                };
-            } else {
-                // Parent may already exist; the subsequent createFile reports real errors.
-                std.Io.Dir.cwd().createDirPath(ctx.io, dir) catch {};
-            }
+            // createDirPath is recursive (mkdir -p) and treats an existing
+            // dir as success; an absolute sub_path ignores the cwd handle, so
+            // one branch covers both. Surface real errors here instead of
+            // deferring to a confusing leaf createFile failure.
+            std.Io.Dir.cwd().createDirPath(ctx.io, dir) catch {
+                output.err("Failed to create {s}", .{dir});
+                return Error.OpenFileFailed;
+            };
         }
     }
 
@@ -517,6 +516,52 @@ test "parseLine parses a service line and keeps `@` inside the name" {
     try std.testing.expectEqual(Kind.service, b.kind);
     try std.testing.expectEqualStrings("redis", b.name);
     try std.testing.expectEqualStrings("", b.version);
+}
+
+test "writeToPath creates a full absolute parent chain with a missing grandparent" {
+    // Regression: the absolute branch must be recursive (mkdir -p), matching
+    // the relative branch. A nested destination whose grandparent is absent
+    // must still be created, not fail at the leaf createFile.
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = std.fmt.bufPrint(&buf, "/tmp/malt_backup_abschain_{d}", .{ts}) catch unreachable;
+    std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "{s}/a/b/backup.txt", .{root}) catch unreachable;
+
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+    try writeToPath(&ctx, dest, "formula git\n");
+
+    const f = try std.Io.Dir.cwd().openFile(io, dest, .{});
+    defer f.close(io);
+    const stat = try f.stat(io);
+    try std.testing.expect(stat.size > 0);
+}
+
+test "writeToPath propagates a real parent-dir failure as OpenFileFailed" {
+    // The recursive branch must surface genuine mkdir errors (here: a
+    // parent path component that is a regular file) instead of swallowing
+    // them and letting the leaf createFile emit a misleading error.
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = std.fmt.bufPrint(&buf, "/tmp/malt_backup_parentfile_{d}", .{ts}) catch unreachable;
+    std.Io.Dir.cwd().createDirPath(io, root) catch unreachable;
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    // A file where a directory component is expected blocks mkdir -p.
+    var blocker_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const blocker = std.fmt.bufPrint(&blocker_buf, "{s}/afile", .{root}) catch unreachable;
+    (std.Io.Dir.cwd().createFile(io, blocker, .{ .truncate = true }) catch unreachable).close(io);
+
+    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "{s}/afile/sub/backup.txt", .{root}) catch unreachable;
+
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+    try std.testing.expectError(Error.OpenFileFailed, writeToPath(&ctx, dest, "formula git\n"));
 }
 
 test "parseBackup silently drops any future unknown kind (forward-compat)" {

--- a/tests/backup_cli_test.zig
+++ b/tests/backup_cli_test.zig
@@ -167,6 +167,28 @@ test "execute --output <path> writes only direct-install rows + casks" {
     try testing.expect(std.mem.indexOf(u8, body, "zlib") == null);
 }
 
+test "execute --output <nested absolute path> creates the missing parent chain" {
+    // Absolute destinations must get recursive parent creation, matching
+    // the relative case — a nested path whose grandparent is absent still
+    // writes the file instead of failing at the leaf createFile.
+    var s = try Scratch.init(testing.allocator, "nested_abs");
+    defer s.deinit(testing.allocator);
+    try seedRows(s.path);
+
+    // `$prefix/gp` does not exist yet; `gp/parent` must be created.
+    const out_path = try std.fmt.allocPrint(testing.allocator, "{s}/gp/parent/snap.txt", .{s.path});
+    defer testing.allocator.free(out_path);
+
+    quiet();
+    defer unquiet();
+
+    try backup.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "--output", out_path });
+
+    const body = try readAll(testing.allocator, out_path);
+    defer testing.allocator.free(body);
+    try testing.expect(std.mem.indexOf(u8, body, "formula wget") != null);
+}
+
 test "execute -o <path> short alias mirrors --output" {
     var s = try Scratch.init(testing.allocator, "short");
     defer s.deinit(testing.allocator);


### PR DESCRIPTION
## Description

`malt backup -o <path>` failed for a nested absolute destination whose parent chain didn't yet exist (e.g. `-o /tmp/a/b/backup.txt` with `/tmp/a` missing), while the identical relative path succeeded. The absolute branch created only a single directory level and silently swallowed genuine errors (EACCES/ENOSPC), which then resurfaced as a misleading generic "failed to create file" at the leaf.

Both absolute and relative destinations now create the full parent chain, and real failures surface at the point they occur giving consistent, honest behavior regardless of how the output path is written.

## Related Issue

- None

## Notes for Reviewers

- None