### PR TITLE
fix(backup): honor symlink-to-directory parents; collapse redundant leaf in writeToPath

### DIFF
--- a/src/cli/backup.zig
+++ b/src/cli/backup.zig
@@ -278,14 +278,22 @@ fn writeToPath(ctx: *const AppCtx, path: []const u8, bytes: []const u8) Error!vo
     // Create parent directories when the user supplied a nested path.
     if (std.fs.path.dirname(path)) |dir| {
         if (dir.len > 0) {
-            // createDirPath is recursive (mkdir -p) and treats an existing
-            // dir as success; an absolute sub_path ignores the cwd handle, so
-            // one branch covers both. Surface real errors here instead of
-            // deferring to a confusing leaf createFile failure.
-            std.Io.Dir.cwd().createDirPath(ctx.io, dir) catch {
-                output.err("Failed to create {s}", .{dir});
-                return Error.OpenFileFailed;
-            };
+            // Create the parent chain recursively (mkdir -p); an absolute
+            // sub_path ignores the cwd handle, so one call covers both kinds.
+            // createDirPath's kind check is nofollow, so it rejects an
+            // existing symlink-to-dir parent (e.g. /tmp) as NotDir — skip
+            // creation when the parent already resolves to a directory, and
+            // surface genuine failures instead of deferring to the leaf.
+            const already_dir = if (std.Io.Dir.cwd().statFile(ctx.io, dir, .{})) |st|
+                st.kind == .directory
+            else |_|
+                false;
+            if (!already_dir) {
+                std.Io.Dir.cwd().createDirPath(ctx.io, dir) catch {
+                    output.err("Failed to create {s}", .{dir});
+                    return Error.OpenFileFailed;
+                };
+            }
         }
     }
 
@@ -574,6 +582,25 @@ test "writeToPath creates a relative nested parent chain (relative input)" {
 
     var dest_buf: [128]u8 = undefined;
     const dest = std.fmt.bufPrint(&dest_buf, "{s}/sub/backup.txt", .{rel_root}) catch unreachable;
+
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+    try writeToPath(&ctx, dest, "formula git\n");
+
+    const f = try std.Io.Dir.cwd().openFile(io, dest, .{});
+    defer f.close(io);
+    const stat = try f.stat(io);
+    try std.testing.expect(stat.size > 0);
+}
+
+test "writeToPath accepts a symlink-to-directory parent (e.g. /tmp)" {
+    // createDirPath's nofollow kind check rejects an existing symlink-to-dir
+    // as NotDir; the writer must still succeed when the parent resolves to a
+    // real directory (macOS /tmp is a symlink to /private/tmp).
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "/tmp/malt_backup_symlinkparent_{d}.txt", .{ts}) catch unreachable;
+    defer std.Io.Dir.cwd().deleteTree(io, dest) catch {};
 
     const ctx: AppCtx = .{ .io = io, .environ = .empty };
     try writeToPath(&ctx, dest, "formula git\n");

--- a/src/cli/backup.zig
+++ b/src/cli/backup.zig
@@ -289,16 +289,13 @@ fn writeToPath(ctx: *const AppCtx, path: []const u8, bytes: []const u8) Error!vo
         }
     }
 
-    const file = if (std.fs.path.isAbsolute(path))
-        std.Io.Dir.createFileAbsolute(ctx.io, path, .{ .truncate = true }) catch {
-            output.err("Failed to create {s}", .{path});
-            return Error.OpenFileFailed;
-        }
-    else
-        std.Io.Dir.cwd().createFile(ctx.io, path, .{ .truncate = true }) catch {
-            output.err("Failed to create {s}", .{path});
-            return Error.OpenFileFailed;
-        };
+    // createFileAbsolute is just createFile on cwd (an absolute path ignores
+    // the cwd handle), so one call covers both path kinds — mirrors the
+    // createDirPath collapse above.
+    const file = std.Io.Dir.cwd().createFile(ctx.io, path, .{ .truncate = true }) catch {
+        output.err("Failed to create {s}", .{path});
+        return Error.OpenFileFailed;
+    };
     defer file.close(ctx.io);
     file.writeStreamingAll(ctx.io, bytes) catch return Error.WriteFailed;
 }
@@ -559,6 +556,47 @@ test "writeToPath propagates a real parent-dir failure as OpenFileFailed" {
 
     var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
     const dest = std.fmt.bufPrint(&dest_buf, "{s}/afile/sub/backup.txt", .{root}) catch unreachable;
+
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+    try std.testing.expectError(Error.OpenFileFailed, writeToPath(&ctx, dest, "formula git\n"));
+}
+
+test "writeToPath creates a relative nested parent chain (relative input)" {
+    // The collapsed path must accept a relative destination too, resolved
+    // against cwd. A uniquely-named dir under the test cwd exercises it
+    // without chdir or shared state, so coverage of the relative case
+    // doesn't hinge on the shell regression running.
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var rel_buf: [64]u8 = undefined;
+    const rel_root = std.fmt.bufPrint(&rel_buf, "zz_malt_backup_rel_{d}", .{ts}) catch unreachable;
+    defer std.Io.Dir.cwd().deleteTree(io, rel_root) catch {};
+
+    var dest_buf: [128]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "{s}/sub/backup.txt", .{rel_root}) catch unreachable;
+
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+    try writeToPath(&ctx, dest, "formula git\n");
+
+    const f = try std.Io.Dir.cwd().openFile(io, dest, .{});
+    defer f.close(io);
+    const stat = try f.stat(io);
+    try std.testing.expect(stat.size > 0);
+}
+
+test "writeToPath maps a failing leaf createFile to OpenFileFailed" {
+    // Parent creation succeeds, but the destination path is itself a
+    // directory, so the leaf createFile fails — the catch must surface
+    // OpenFileFailed rather than propagate a raw fs error.
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = std.fmt.bufPrint(&buf, "/tmp/malt_backup_leafdir_{d}", .{ts}) catch unreachable;
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "{s}/target", .{root}) catch unreachable;
+    std.Io.Dir.cwd().createDirPath(io, dest) catch unreachable; // dest is a dir
 
     const ctx: AppCtx = .{ .io = io, .environ = .empty };
     try std.testing.expectError(Error.OpenFileFailed, writeToPath(&ctx, dest, "formula git\n"));


### PR DESCRIPTION
## Description

Two related changes to `backup.zig`'s `writeToPath`, plus coverage that pins the whole function in the zig suite.

**Fix — symlink-to-directory parents.** The nested-parent `backup -o` fix regressed one case: `backup -o /tmp/x.txt` (or any destination whose parent dir is an existing symlink-to-directory) returned `OpenFileFailed`. `createDirPath`'s internal kind check is nofollow, so it rejects an existing symlink parent like `/tmp` as `NotDir`. The writer now pre-checks whether the parent already resolves to a directory and only creates when it doesn't — real failures still surface at the mkdir site.

**Refactor — collapse the redundant leaf.** The directory fix collapsed the absolute/relative asymmetry for `createDirPath` but left the identical `isAbsolute` split on the leaf `createFile`. That split is dead: `createFileAbsolute(io, path, flags)` is defined as `createFile(.cwd(), io, path, flags)`. Collapsed to a single `cwd().createFile(path)`; `writeToPath` now has no `isAbsolute` branching at all.

Behavior otherwise unchanged (the regression script still passes).

Tests pin every path of `writeToPath` in the zig suite (previously the relative, symlink-parent, and leaf paths were only exercised by the shell regression running the real binary):

- absolute nested destination with a missing grandparent → full chain created
- parent-dir creation failure (a parent component is a file) → `OpenFileFailed`
- relative nested destination → resolved against cwd, full chain created
- symlink-to-directory parent (`/tmp`) → accepted, file written
- leaf `createFile` failure (destination is a directory) → `OpenFileFailed`

## Related Issue

- None

## Notes for Reviewers

- The symlink-parent regression also affected `purge --backup` (same helper shape); fixed in a separate PR.
- No chdir in the tests: Zig 0.16 exposes `chdir` only as a backend free function (not on the `Io` interface) with no matching `getcwd`, so mutating process cwd in a shared test binary would be fragile. The relative tests use uniquely-named `zz_malt_backup_*` dirs under the existing cwd and remove them on `defer`.
