### PR TITLE
fix(purge): create nested parent directories for absolute manifest paths

### DIFF
--- a/scripts/regressions/purge-manifest-nested-absolute-parents.sh
+++ b/scripts/regressions/purge-manifest-nested-absolute-parents.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Regression: `purge --wipe --backup <absolute nested path>` must create the
+# whole parent chain for the safety manifest, matching the relative case.
+#
+# The bug: the manifest writer created absolute parents with a single-level
+# mkdir (createDirAbsolute) while relative parents went through a recursive
+# createDirPath. A nested absolute --backup path with a missing grandparent
+# therefore failed, aborting the wipe before it could write the safety net.
+#
+# Drives a real wipe against a throwaway prefix, pointing --backup at a nested
+# absolute path whose grandparent does not exist, and asserts the manifest is
+# written. No network; well under 30s.
+#
+# Exits 0 when the manifest is created, non-zero with a message otherwise.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+# The shell harness runs the built binary, which `zig build test` does not
+# rebuild — build it here so a stale binary never masks the fix.
+(cd "$ROOT" && zig build >/dev/null)
+
+ROOTDIR="$(mktemp -d)"
+trap 'rm -rf "$ROOTDIR"' EXIT
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+
+PREFIX="$ROOTDIR/opt-malt"
+mkdir -p "$PREFIX/store" "$PREFIX/Cellar"
+
+# grandparent intentionally absent: $ROOTDIR/mani does not exist yet
+manifest="$ROOTDIR/mani/a/backup.txt"
+
+MALT_PREFIX="$PREFIX" "$BIN" purge --wipe --yes --backup "$manifest" >/dev/null 2>&1 || true
+
+[ -s "$manifest" ] || {
+  echo "FAIL: purge did not write the manifest to a nested absolute path ($manifest)" >&2
+  exit 1
+}
+
+echo "ok: purge writes its backup manifest to a nested absolute path"

--- a/src/cli/purge/wipe.zig
+++ b/src/cli/purge/wipe.zig
@@ -141,18 +141,24 @@ fn writeBytesToPath(ctx: *const AppCtx, path: []const u8, bytes: []const u8) Err
     const io = ctx.io;
     if (std.fs.path.dirname(path)) |dir| {
         if (dir.len > 0) {
-            // Parent may already exist; the subsequent createFile reports real errors.
-            if (std.fs.path.isAbsolute(dir)) {
-                std.Io.Dir.createDirAbsolute(io, dir, .default_dir) catch {};
-            } else {
-                std.Io.Dir.cwd().createDirPath(io, dir) catch {};
+            // Create the parent chain recursively (mkdir -p); an absolute
+            // sub_path ignores the cwd handle, so one call covers both kinds.
+            // createDirPath's kind check is nofollow, so it rejects an
+            // existing symlink-to-dir parent (e.g. /tmp) as NotDir — skip
+            // creation when the parent already resolves to a directory, and
+            // surface genuine failures instead of deferring to the leaf.
+            const already_dir = if (std.Io.Dir.cwd().statFile(io, dir, .{})) |st|
+                st.kind == .directory
+            else |_|
+                false;
+            if (!already_dir) {
+                std.Io.Dir.cwd().createDirPath(io, dir) catch return Error.OpenFileFailed;
             }
         }
     }
-    const file = if (std.fs.path.isAbsolute(path))
-        std.Io.Dir.createFileAbsolute(io, path, .{ .truncate = true }) catch return Error.OpenFileFailed
-    else
-        std.Io.Dir.cwd().createFile(io, path, .{ .truncate = true }) catch return Error.OpenFileFailed;
+    // createFileAbsolute is just createFile on cwd (an absolute path ignores
+    // the cwd handle), so one call covers both path kinds.
+    const file = std.Io.Dir.cwd().createFile(io, path, .{ .truncate = true }) catch return Error.OpenFileFailed;
     defer file.close(io);
     file.writeStreamingAll(io, bytes) catch return Error.WriteFailed;
 }
@@ -360,4 +366,67 @@ test "freedBytes credits the full total when every delete succeeded" {
 
 test "freedBytes is zero for an empty plan" {
     try std.testing.expectEqual(@as(u64, 0), freedBytes(&.{}, &.{}));
+}
+
+test "writeBytesToPath creates a full absolute parent chain with a missing grandparent" {
+    // The safety manifest must land even when the user points --backup at a
+    // nested absolute path whose grandparent is absent — createDirPath is
+    // recursive and an absolute sub_path ignores the cwd handle.
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = std.fmt.bufPrint(&buf, "/tmp/malt_purge_abschain_{d}", .{ts}) catch unreachable;
+    std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "{s}/a/b/manifest.txt", .{root}) catch unreachable;
+
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+    try writeBytesToPath(&ctx, dest, "formula git\n");
+
+    const f = try std.Io.Dir.cwd().openFile(io, dest, .{});
+    defer f.close(io);
+    const stat = try f.stat(io);
+    try std.testing.expect(stat.size > 0);
+}
+
+test "writeBytesToPath propagates a real parent-dir failure as OpenFileFailed" {
+    // Genuine mkdir errors (here: a parent component that is a regular file)
+    // must surface instead of being swallowed and deferred to the leaf.
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = std.fmt.bufPrint(&buf, "/tmp/malt_purge_parentfile_{d}", .{ts}) catch unreachable;
+    std.Io.Dir.cwd().createDirPath(io, root) catch unreachable;
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    var blocker_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const blocker = std.fmt.bufPrint(&blocker_buf, "{s}/afile", .{root}) catch unreachable;
+    (std.Io.Dir.cwd().createFile(io, blocker, .{ .truncate = true }) catch unreachable).close(io);
+
+    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "{s}/afile/sub/manifest.txt", .{root}) catch unreachable;
+
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+    try std.testing.expectError(Error.OpenFileFailed, writeBytesToPath(&ctx, dest, "formula git\n"));
+}
+
+test "writeBytesToPath accepts a symlink-to-directory parent (e.g. /tmp)" {
+    // createDirPath's nofollow kind check rejects an existing symlink-to-dir
+    // as NotDir; the writer must still succeed when the parent resolves to a
+    // real directory (macOS /tmp is a symlink to /private/tmp).
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "/tmp/malt_purge_symlinkparent_{d}.txt", .{ts}) catch unreachable;
+    defer std.Io.Dir.cwd().deleteTree(io, dest) catch {};
+
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+    try writeBytesToPath(&ctx, dest, "formula git\n");
+
+    const f = try std.Io.Dir.cwd().openFile(io, dest, .{});
+    defer f.close(io);
+    const stat = try f.stat(io);
+    try std.testing.expect(stat.size > 0);
 }

--- a/tests/purge_scopes_test.zig
+++ b/tests/purge_scopes_test.zig
@@ -453,6 +453,38 @@ test "--wipe --yes --backup writes the manifest before the delete pass" {
     try test_io.accessAbsolute(std.Options.debug_io, backup_path, .{});
 }
 
+test "--wipe --yes --backup creates a nested absolute manifest path" {
+    // The manifest writer must create the full parent chain for a nested
+    // absolute --backup path whose grandparent is missing, matching the
+    // relative case — otherwise the wipe aborts before writing its safety net.
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "wipe_backup_nested");
+    defer prefix.deinit(allocator);
+
+    try writeFileAt(allocator, &.{ prefix.path, "Cellar", "marker" }, "x");
+
+    // grandparent (`.../mani`) intentionally absent; lives outside the prefix.
+    const root = try std.fmt.allocPrint(allocator, "/tmp/malt_wipe_nested_{d}", .{
+        test_io.nanoTimestamp(std.Options.debug_io),
+    });
+    defer allocator.free(root);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
+    const backup_path = try std.fmt.allocPrint(allocator, "{s}/mani/a/backup.txt", .{root});
+    defer allocator.free(backup_path);
+
+    const prior = OutputState.save();
+    defer prior.restore();
+    output.setMode(.human);
+    output.setDryRun(false);
+    output.setNdjson(false);
+    output.setQuiet(true);
+
+    const ctx = malt.app_ctx.debug_ctx;
+    try purge.execute(&ctx, allocator, &.{ "--wipe", "--yes", "--backup", backup_path });
+
+    try test_io.accessAbsolute(std.Options.debug_io, backup_path, .{});
+}
+
 test "multi-scope dry-run renders the summary table when more than one scope ran" {
     // The summary table only renders when summary.rows.items.len > 1.
     // Pinning this guards the "--housekeeping prints a table" UX guarantee.


### PR DESCRIPTION
## Description

`purge --wipe --backup <path>` writes a safety manifest before deleting. When `<path>` was a **nested absolute** path whose parent chain didn't yet exist, the write failed and aborted the wipe — the relative equivalent succeeded. The manifest writer created absolute parents with a single-level `createDirAbsolute` (vs recursive `createDirPath` for relative) and additionally swallowed real errors (EACCES/ENOSPC) with `catch {}`, deferring them to a confusing leaf failure.

Both path kinds now create the full parent chain recursively, and genuine failures surface at the mkdir site. An existing symlink-to-directory parent (e.g. `/tmp`) is accepted rather than rejected as `NotDir` — `createDirPath`'s internal kind check is nofollow, so the writer pre-checks whether the parent already resolves to a directory. The redundant absolute/relative split on the leaf `createFile` is collapsed to a single call (`createFileAbsolute` is `createFile` on cwd for an absolute path).

Same defect and fix shape as the backup `-o` nested-path fix.

## Related Issue

- None

## Notes for Reviewers

- None