### PR TITLE
refactor(cli): collapse redundant absolute/relative file-open branches

### DIFF
--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -503,10 +503,9 @@ fn readManifest(
     path: []const u8,
     diag: ?*brewfile_mod.Diagnostics,
 ) !manifest_mod.Manifest {
-    const file = if (std.fs.path.isAbsolute(path))
-        std.Io.Dir.openFileAbsolute(ctx.io, path, .{}) catch return BundleError.BundlefileNotFound
-    else
-        std.Io.Dir.cwd().openFile(ctx.io, path, .{}) catch return BundleError.BundlefileNotFound;
+    // openFileAbsolute is just openFile on cwd (an absolute path ignores the
+    // cwd handle), so one call covers both path kinds.
+    const file = std.Io.Dir.cwd().openFile(ctx.io, path, .{}) catch return BundleError.BundlefileNotFound;
     defer file.close(ctx.io);
 
     const stat = file.stat(ctx.io) catch return BundleError.BundlefileNotFound;
@@ -537,10 +536,9 @@ fn writeManifest(
     path: []const u8,
     format: Format,
 ) !void {
-    const file = if (std.fs.path.isAbsolute(path))
-        std.Io.Dir.createFileAbsolute(ctx.io, path, .{ .truncate = true }) catch return BundleError.WriteFailed
-    else
-        std.Io.Dir.cwd().createFile(ctx.io, path, .{ .truncate = true }) catch return BundleError.WriteFailed;
+    // createFileAbsolute is just createFile on cwd for an absolute path, so
+    // one call covers both path kinds.
+    const file = std.Io.Dir.cwd().createFile(ctx.io, path, .{ .truncate = true }) catch return BundleError.WriteFailed;
     defer file.close(ctx.io);
     var write_buf: [4096]u8 = undefined;
     var fw = file.writer(ctx.io, &write_buf);

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -387,16 +387,12 @@ pub fn installLocalFormula(
     // messages and the kegs row — defeating the "relative path in a
     // shared Brewfile" footgun.
     var real_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
-    const real_n = if (std.fs.path.isAbsolute(expanded))
-        std.Io.Dir.realPathFileAbsolute(ctx.io, expanded, &real_buf) catch {
-            sink.err("Cannot open local formula: {s}", .{pkg_arg});
-            return InstallError.LocalFormulaNotReadable;
-        }
-    else
-        std.Io.Dir.cwd().realPathFile(ctx.io, expanded, &real_buf) catch {
-            sink.err("Cannot open local formula: {s}", .{pkg_arg});
-            return InstallError.LocalFormulaNotReadable;
-        };
+    // realPathFileAbsolute is just realPathFile on cwd for an absolute path,
+    // so one call covers both path kinds.
+    const real_n = std.Io.Dir.cwd().realPathFile(ctx.io, expanded, &real_buf) catch {
+        sink.err("Cannot open local formula: {s}", .{pkg_arg});
+        return InstallError.LocalFormulaNotReadable;
+    };
     const realpath = real_buf[0..real_n];
 
     // Security warning on every install — the `.rb` is a code-execution

--- a/src/cli/restore.zig
+++ b/src/cli/restore.zig
@@ -169,10 +169,9 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 }
 
 fn readFile(ctx: *const AppCtx, allocator: std.mem.Allocator, path: []const u8) ![]u8 {
-    const file = if (std.fs.path.isAbsolute(path))
-        try std.Io.Dir.openFileAbsolute(ctx.io, path, .{})
-    else
-        try std.Io.Dir.cwd().openFile(ctx.io, path, .{});
+    // openFileAbsolute is just openFile on cwd for an absolute path, so one
+    // call covers both path kinds.
+    const file = try std.Io.Dir.cwd().openFile(ctx.io, path, .{});
     defer file.close(ctx.io);
 
     const stat = try file.stat(ctx.io);


### PR DESCRIPTION
## Description

Several call sites branch on `std.fs.path.isAbsolute(path)` to pick a `*Absolute` helper vs the `cwd()` variant. The `*Absolute` helpers are defined as the `cwd()` call on the same path (an absolute path ignores the cwd handle), so both arms are identical and the branch is dead weight. Collapsed to the single `cwd()` call at:

- `bundle.zig` `readManifest` - `openFileAbsolute` -> `cwd().openFile`
- `bundle.zig` `writeManifest` - `createFileAbsolute` -> `cwd().createFile`
- `install/local.zig` - `realPathFileAbsolute` -> `cwd().realPathFile`
- `restore.zig` `readFile` - `openFileAbsolute` -> `cwd().openFile`

No behavior change; pure simplification.

## Related Issue

- None

## Notes for Reviewers

- None