### PR TITLE
refactor(fs): extract path_write leaf and route backup/purge/bundle through it

### DIFF
--- a/scripts/regressions/bundle-create-nested-path-no-mkdir.sh
+++ b/scripts/regressions/bundle-create-nested-path-no-mkdir.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Regression: `bundle create <nested path>` must create parent directories
+# for both absolute and relative destinations.
+#
+# The bug: writeManifest did a bare createFile with no parent creation, so a
+# nested output path whose parent was missing failed with no file written —
+# the same defect already fixed for `backup -o` and `purge --backup`.
+#
+# Exits 0 when both nested destinations are created, non-zero with a message
+# otherwise. No network; well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+# The shell harness runs the built binary, which `zig build test` does not
+# rebuild — build it here so a stale binary never masks the fix.
+zig build >/dev/null
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+export MALT_PREFIX="$tmp/p"
+mkdir -p "$MALT_PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+
+# absolute nested destination: grandparent $tmp/abs is missing
+abs="$tmp/abs/sub/Brewfile"
+"$BIN" bundle create "$abs" >/dev/null 2>&1 || true
+[ -f "$abs" ] || {
+  echo "FAIL: bundle create did not create parents for an absolute nested path ($abs)" >&2
+  exit 1
+}
+
+# relative nested destination, same shape
+(cd "$tmp" && "$BIN" bundle create rel/sub/Brewfile >/dev/null 2>&1 && [ -f rel/sub/Brewfile ]) || {
+  echo "FAIL: bundle create did not create parents for a relative nested path" >&2
+  exit 1
+}
+
+echo "ok: bundle create writes nested absolute and relative destinations"

--- a/src/cli/backup.zig
+++ b/src/cli/backup.zig
@@ -20,6 +20,7 @@ const AppCtx = @import("../app_ctx.zig").AppCtx;
 const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
+const path_write = @import("../fs/path_write.zig");
 const output = @import("../ui/output.zig");
 const help = @import("help.zig");
 
@@ -275,37 +276,18 @@ fn executeJson(
 }
 
 fn writeToPath(ctx: *const AppCtx, path: []const u8, bytes: []const u8) Error!void {
-    // Create parent directories when the user supplied a nested path.
-    if (std.fs.path.dirname(path)) |dir| {
-        if (dir.len > 0) {
-            // Create the parent chain recursively (mkdir -p); an absolute
-            // sub_path ignores the cwd handle, so one call covers both kinds.
-            // createDirPath's kind check is nofollow, so it rejects an
-            // existing symlink-to-dir parent (e.g. /tmp) as NotDir — skip
-            // creation when the parent already resolves to a directory, and
-            // surface genuine failures instead of deferring to the leaf.
-            const already_dir = if (std.Io.Dir.cwd().statFile(ctx.io, dir, .{})) |st|
-                st.kind == .directory
-            else |_|
-                false;
-            if (!already_dir) {
-                std.Io.Dir.cwd().createDirPath(ctx.io, dir) catch {
-                    output.err("Failed to create {s}", .{dir});
-                    return Error.OpenFileFailed;
-                };
-            }
-        }
-    }
-
-    // createFileAbsolute is just createFile on cwd (an absolute path ignores
-    // the cwd handle), so one call covers both path kinds — mirrors the
-    // createDirPath collapse above.
-    const file = std.Io.Dir.cwd().createFile(ctx.io, path, .{ .truncate = true }) catch {
-        output.err("Failed to create {s}", .{path});
-        return Error.OpenFileFailed;
+    path_write.writeFile(ctx.io, path, bytes) catch |e| switch (e) {
+        // On a parent-dir failure the offending path is its dirname.
+        error.MakeParentDirFailed => {
+            output.err("Failed to create {s}", .{std.fs.path.dirname(path) orelse path});
+            return Error.OpenFileFailed;
+        },
+        error.OpenFileFailed => {
+            output.err("Failed to create {s}", .{path});
+            return Error.OpenFileFailed;
+        },
+        error.WriteFailed => return Error.WriteFailed,
     };
-    defer file.close(ctx.io);
-    file.writeStreamingAll(ctx.io, bytes) catch return Error.WriteFailed;
 }
 
 /// Plain-data view of one formula row for the `--json` writer.
@@ -524,9 +506,8 @@ test "parseLine parses a service line and keeps `@` inside the name" {
 }
 
 test "writeToPath creates a full absolute parent chain with a missing grandparent" {
-    // Regression: the absolute branch must be recursive (mkdir -p), matching
-    // the relative branch. A nested destination whose grandparent is absent
-    // must still be created, not fail at the leaf createFile.
+    // Delegation smoke: a nested destination whose grandparent is absent is
+    // still written (parent creation happens in path_write.writeFile).
     const io = std.Options.debug_io;
     const ts = std.Io.Clock.real.now(io).toNanoseconds();
     var buf: [std.fs.max_path_bytes]u8 = undefined;
@@ -547,9 +528,8 @@ test "writeToPath creates a full absolute parent chain with a missing grandparen
 }
 
 test "writeToPath propagates a real parent-dir failure as OpenFileFailed" {
-    // The recursive branch must surface genuine mkdir errors (here: a
-    // parent path component that is a regular file) instead of swallowing
-    // them and letting the leaf createFile emit a misleading error.
+    // Pins the other mapping arm: a parent-dir failure (a parent component is
+    // a regular file → MakeParentDirFailed) must surface as OpenFileFailed.
     const io = std.Options.debug_io;
     const ts = std.Io.Clock.real.now(io).toNanoseconds();
     var buf: [std.fs.max_path_bytes]u8 = undefined;
@@ -569,52 +549,10 @@ test "writeToPath propagates a real parent-dir failure as OpenFileFailed" {
     try std.testing.expectError(Error.OpenFileFailed, writeToPath(&ctx, dest, "formula git\n"));
 }
 
-test "writeToPath creates a relative nested parent chain (relative input)" {
-    // The collapsed path must accept a relative destination too, resolved
-    // against cwd. A uniquely-named dir under the test cwd exercises it
-    // without chdir or shared state, so coverage of the relative case
-    // doesn't hinge on the shell regression running.
-    const io = std.Options.debug_io;
-    const ts = std.Io.Clock.real.now(io).toNanoseconds();
-    var rel_buf: [64]u8 = undefined;
-    const rel_root = std.fmt.bufPrint(&rel_buf, "zz_malt_backup_rel_{d}", .{ts}) catch unreachable;
-    defer std.Io.Dir.cwd().deleteTree(io, rel_root) catch {};
-
-    var dest_buf: [128]u8 = undefined;
-    const dest = std.fmt.bufPrint(&dest_buf, "{s}/sub/backup.txt", .{rel_root}) catch unreachable;
-
-    const ctx: AppCtx = .{ .io = io, .environ = .empty };
-    try writeToPath(&ctx, dest, "formula git\n");
-
-    const f = try std.Io.Dir.cwd().openFile(io, dest, .{});
-    defer f.close(io);
-    const stat = try f.stat(io);
-    try std.testing.expect(stat.size > 0);
-}
-
-test "writeToPath accepts a symlink-to-directory parent (e.g. /tmp)" {
-    // createDirPath's nofollow kind check rejects an existing symlink-to-dir
-    // as NotDir; the writer must still succeed when the parent resolves to a
-    // real directory (macOS /tmp is a symlink to /private/tmp).
-    const io = std.Options.debug_io;
-    const ts = std.Io.Clock.real.now(io).toNanoseconds();
-    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const dest = std.fmt.bufPrint(&dest_buf, "/tmp/malt_backup_symlinkparent_{d}.txt", .{ts}) catch unreachable;
-    defer std.Io.Dir.cwd().deleteTree(io, dest) catch {};
-
-    const ctx: AppCtx = .{ .io = io, .environ = .empty };
-    try writeToPath(&ctx, dest, "formula git\n");
-
-    const f = try std.Io.Dir.cwd().openFile(io, dest, .{});
-    defer f.close(io);
-    const stat = try f.stat(io);
-    try std.testing.expect(stat.size > 0);
-}
-
 test "writeToPath maps a failing leaf createFile to OpenFileFailed" {
-    // Parent creation succeeds, but the destination path is itself a
-    // directory, so the leaf createFile fails — the catch must surface
-    // OpenFileFailed rather than propagate a raw fs error.
+    // Exhaustive path_write edge cases live in `fs/path_write.zig`; here we
+    // only pin the caller's error mapping. Destination is a directory, so the
+    // leaf createFile fails and the catch must surface OpenFileFailed.
     const io = std.Options.debug_io;
     const ts = std.Io.Clock.real.now(io).toNanoseconds();
     var buf: [std.fs.max_path_bytes]u8 = undefined;

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -11,6 +11,7 @@ const runner_mod = @import("../core/bundle/runner.zig");
 const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
+const path_write = @import("../fs/path_write.zig");
 const output = @import("../ui/output.zig");
 const install_sink_mod = @import("install/sink.zig");
 const install_cmd = @import("install.zig");
@@ -536,8 +537,9 @@ fn writeManifest(
     path: []const u8,
     format: Format,
 ) !void {
-    // createFileAbsolute is just createFile on cwd for an absolute path, so
-    // one call covers both path kinds.
+    // Create parents for a nested out_path; streams into the file below, so
+    // only the parent step is shared with backup/purge's path_write.writeFile.
+    path_write.ensureParentDir(ctx.io, path) catch return BundleError.WriteFailed;
     const file = std.Io.Dir.cwd().createFile(ctx.io, path, .{ .truncate = true }) catch return BundleError.WriteFailed;
     defer file.close(ctx.io);
     var write_buf: [4096]u8 = undefined;
@@ -715,4 +717,27 @@ test "create: explicit out_path wins regardless of --format position" {
     // An invalid format is rejected; --services rides through to the result.
     try std.testing.expect(resolveCreateArgs(&.{ "--format", "yaml" }) == null);
     try std.testing.expect(resolveCreateArgs(&.{"--services"}).?.include_services);
+}
+
+test "writeManifest creates parent directories for a nested output path" {
+    // A nested out_path whose parent is missing must be created, not fail with
+    // no file — parity with `backup -o` / `purge --backup`.
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = std.fmt.bufPrint(&buf, "/tmp/malt_bundle_nested_{d}", .{ts}) catch unreachable;
+    std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "{s}/a/b/Brewfile", .{root}) catch unreachable;
+
+    var manifest = manifest_mod.Manifest.init(std.testing.allocator);
+    defer manifest.deinit();
+
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+    try writeManifest(&ctx, manifest, dest, .brewfile);
+
+    const f = try std.Io.Dir.cwd().openFile(io, dest, .{});
+    f.close(io);
 }

--- a/src/cli/purge/wipe.zig
+++ b/src/cli/purge/wipe.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
 const sqlite = @import("../../db/sqlite.zig");
 const atomic = @import("../../fs/atomic.zig");
+const path_write = @import("../../fs/path_write.zig");
 const output = @import("../../ui/output.zig");
 const lock_mod = @import("../../db/lock.zig");
 const backup_mod = @import("../backup.zig");
@@ -138,29 +139,12 @@ pub fn writeManifest(ctx: *const AppCtx, allocator: std.mem.Allocator, path: []c
 }
 
 fn writeBytesToPath(ctx: *const AppCtx, path: []const u8, bytes: []const u8) Error!void {
-    const io = ctx.io;
-    if (std.fs.path.dirname(path)) |dir| {
-        if (dir.len > 0) {
-            // Create the parent chain recursively (mkdir -p); an absolute
-            // sub_path ignores the cwd handle, so one call covers both kinds.
-            // createDirPath's kind check is nofollow, so it rejects an
-            // existing symlink-to-dir parent (e.g. /tmp) as NotDir — skip
-            // creation when the parent already resolves to a directory, and
-            // surface genuine failures instead of deferring to the leaf.
-            const already_dir = if (std.Io.Dir.cwd().statFile(io, dir, .{})) |st|
-                st.kind == .directory
-            else |_|
-                false;
-            if (!already_dir) {
-                std.Io.Dir.cwd().createDirPath(io, dir) catch return Error.OpenFileFailed;
-            }
-        }
-    }
-    // createFileAbsolute is just createFile on cwd (an absolute path ignores
-    // the cwd handle), so one call covers both path kinds.
-    const file = std.Io.Dir.cwd().createFile(io, path, .{ .truncate = true }) catch return Error.OpenFileFailed;
-    defer file.close(io);
-    file.writeStreamingAll(io, bytes) catch return Error.WriteFailed;
+    // Silent mapping — the outer wipe command reports; a parent-dir failure
+    // and an open failure are both "couldn't create the manifest".
+    path_write.writeFile(ctx.io, path, bytes) catch |e| switch (e) {
+        error.MakeParentDirFailed, error.OpenFileFailed => return Error.OpenFileFailed,
+        error.WriteFailed => return Error.WriteFailed,
+    };
 }
 
 pub fn deleteTarget(io: std.Io, path: []const u8) bool {
@@ -369,9 +353,9 @@ test "freedBytes is zero for an empty plan" {
 }
 
 test "writeBytesToPath creates a full absolute parent chain with a missing grandparent" {
-    // The safety manifest must land even when the user points --backup at a
-    // nested absolute path whose grandparent is absent — createDirPath is
-    // recursive and an absolute sub_path ignores the cwd handle.
+    // Delegation smoke: the safety manifest lands even when --backup points at
+    // a nested absolute path whose grandparent is absent (path_write creates
+    // it). Exhaustive edge cases live in `fs/path_write.zig`.
     const io = std.Options.debug_io;
     const ts = std.Io.Clock.real.now(io).toNanoseconds();
     var buf: [std.fs.max_path_bytes]u8 = undefined;
@@ -391,9 +375,9 @@ test "writeBytesToPath creates a full absolute parent chain with a missing grand
     try std.testing.expect(stat.size > 0);
 }
 
-test "writeBytesToPath propagates a real parent-dir failure as OpenFileFailed" {
-    // Genuine mkdir errors (here: a parent component that is a regular file)
-    // must surface instead of being swallowed and deferred to the leaf.
+test "writeBytesToPath maps a path_write failure to OpenFileFailed" {
+    // Pins the caller's error mapping: a parent-dir failure (a parent
+    // component is a regular file) must surface as OpenFileFailed.
     const io = std.Options.debug_io;
     const ts = std.Io.Clock.real.now(io).toNanoseconds();
     var buf: [std.fs.max_path_bytes]u8 = undefined;
@@ -410,23 +394,4 @@ test "writeBytesToPath propagates a real parent-dir failure as OpenFileFailed" {
 
     const ctx: AppCtx = .{ .io = io, .environ = .empty };
     try std.testing.expectError(Error.OpenFileFailed, writeBytesToPath(&ctx, dest, "formula git\n"));
-}
-
-test "writeBytesToPath accepts a symlink-to-directory parent (e.g. /tmp)" {
-    // createDirPath's nofollow kind check rejects an existing symlink-to-dir
-    // as NotDir; the writer must still succeed when the parent resolves to a
-    // real directory (macOS /tmp is a symlink to /private/tmp).
-    const io = std.Options.debug_io;
-    const ts = std.Io.Clock.real.now(io).toNanoseconds();
-    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const dest = std.fmt.bufPrint(&dest_buf, "/tmp/malt_purge_symlinkparent_{d}.txt", .{ts}) catch unreachable;
-    defer std.Io.Dir.cwd().deleteTree(io, dest) catch {};
-
-    const ctx: AppCtx = .{ .io = io, .environ = .empty };
-    try writeBytesToPath(&ctx, dest, "formula git\n");
-
-    const f = try std.Io.Dir.cwd().openFile(io, dest, .{});
-    defer f.close(io);
-    const stat = try f.stat(io);
-    try std.testing.expect(stat.size > 0);
 }

--- a/src/fs/atomic.zig
+++ b/src/fs/atomic.zig
@@ -152,6 +152,11 @@ const default_sync_ops: DefaultSyncOps = .{};
 /// the new ones — never a partial write. A crash before the rename
 /// leaves the tempfile behind; the next call writes its own and
 /// overwrites atomically.
+///
+/// Preconditions: `dst_path` must be absolute and its parent directory must
+/// already exist (the tempfile is a sibling and the parent is fsync'd). For an
+/// arbitrary user-supplied path that may need parents created, use
+/// `fs/path_write.zig` instead (non-atomic).
 pub fn atomicWriteFile(io: std.Io, dst_path: []const u8, data: []const u8) !void {
     return atomicWriteFileImpl(io, dst_path, data, default_sync_ops, .default_file);
 }

--- a/src/fs/path_write.zig
+++ b/src/fs/path_write.zig
@@ -1,0 +1,179 @@
+//! Non-atomic writes to a user-supplied output path (`backup -o`,
+//! `purge --backup`): creates the parent chain and accepts absolute or
+//! relative paths. Use `atomic.zig` when a partial write must never be
+//! visible. Leaf: depends only on `std`; errors are typed and UI-agnostic
+//! so callers own the messaging.
+
+const std = @import("std");
+
+pub const ParentError = error{MakeParentDirFailed};
+pub const WriteError = ParentError || error{ OpenFileFailed, WriteFailed };
+
+/// Create the parent chain of `path` (recursive; absolute or relative).
+///
+/// `createDirPath`'s existence check is nofollow, so an existing
+/// symlink-to-dir parent (e.g. macOS `/tmp`) would be rejected as `NotDir` —
+/// skip creation when the parent already resolves to a directory.
+pub fn ensureParentDir(io: std.Io, path: []const u8) ParentError!void {
+    const dir = std.fs.path.dirname(path) orelse return;
+    if (dir.len == 0) return;
+
+    // Follows symlinks, so a symlink-to-dir parent counts as already present.
+    if (std.Io.Dir.cwd().statFile(io, dir, .{})) |st| {
+        if (st.kind == .directory) return;
+    } else |_| {}
+
+    std.Io.Dir.cwd().createDirPath(io, dir) catch return error.MakeParentDirFailed;
+}
+
+/// Write `bytes` to `path`, creating parent directories as needed and
+/// truncating any existing file. Not atomic — a crash mid-write can leave a
+/// partial file; use `atomic.zig` when readers must never see one.
+pub fn writeFile(io: std.Io, path: []const u8, bytes: []const u8) WriteError!void {
+    try ensureParentDir(io, path);
+    // createFileAbsolute is createFile on cwd for an absolute path, so one
+    // call covers both path kinds.
+    const file = std.Io.Dir.cwd().createFile(io, path, .{ .truncate = true }) catch
+        return error.OpenFileFailed;
+    defer file.close(io);
+    file.writeStreamingAll(io, bytes) catch return error.WriteFailed;
+}
+
+// ── tests ──────────────────────────────────────────────────────────────
+
+test "writeFile creates a full absolute parent chain with a missing grandparent" {
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = std.fmt.bufPrint(&buf, "/tmp/malt_pathwrite_abschain_{d}", .{ts}) catch unreachable;
+    std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "{s}/a/b/out.txt", .{root}) catch unreachable;
+
+    try writeFile(io, dest, "data\n");
+
+    const f = try std.Io.Dir.cwd().openFile(io, dest, .{});
+    defer f.close(io);
+    try std.testing.expect((try f.stat(io)).size > 0);
+}
+
+test "writeFile creates a relative nested parent chain" {
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var rel_buf: [64]u8 = undefined;
+    const rel_root = std.fmt.bufPrint(&rel_buf, "zz_malt_pathwrite_rel_{d}", .{ts}) catch unreachable;
+    defer std.Io.Dir.cwd().deleteTree(io, rel_root) catch {};
+
+    var dest_buf: [128]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "{s}/sub/out.txt", .{rel_root}) catch unreachable;
+
+    try writeFile(io, dest, "data\n");
+
+    const f = try std.Io.Dir.cwd().openFile(io, dest, .{});
+    defer f.close(io);
+    try std.testing.expect((try f.stat(io)).size > 0);
+}
+
+test "writeFile accepts a symlink-to-directory parent (e.g. /tmp)" {
+    // createDirPath's nofollow kind check rejects an existing symlink-to-dir
+    // as NotDir; the writer must still succeed (macOS /tmp → /private/tmp).
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "/tmp/malt_pathwrite_symlink_{d}.txt", .{ts}) catch unreachable;
+    defer std.Io.Dir.cwd().deleteTree(io, dest) catch {};
+
+    try writeFile(io, dest, "data\n");
+
+    const f = try std.Io.Dir.cwd().openFile(io, dest, .{});
+    defer f.close(io);
+    try std.testing.expect((try f.stat(io)).size > 0);
+}
+
+test "writeFile surfaces MakeParentDirFailed when a parent component is a file" {
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = std.fmt.bufPrint(&buf, "/tmp/malt_pathwrite_parentfile_{d}", .{ts}) catch unreachable;
+    std.Io.Dir.cwd().createDirPath(io, root) catch unreachable;
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    var blocker_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const blocker = std.fmt.bufPrint(&blocker_buf, "{s}/afile", .{root}) catch unreachable;
+    (std.Io.Dir.cwd().createFile(io, blocker, .{ .truncate = true }) catch unreachable).close(io);
+
+    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "{s}/afile/sub/out.txt", .{root}) catch unreachable;
+
+    try std.testing.expectError(error.MakeParentDirFailed, writeFile(io, dest, "data\n"));
+}
+
+test "writeFile surfaces OpenFileFailed when the destination is a directory" {
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = std.fmt.bufPrint(&buf, "/tmp/malt_pathwrite_destdir_{d}", .{ts}) catch unreachable;
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    var dest_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&dest_buf, "{s}/target", .{root}) catch unreachable;
+    std.Io.Dir.cwd().createDirPath(io, dest) catch unreachable; // dest is a dir
+
+    try std.testing.expectError(error.OpenFileFailed, writeFile(io, dest, "data\n"));
+}
+
+test "ensureParentDir is a no-op for a bare filename (no directory component)" {
+    // dirname("out.txt") is null → nothing to create, no error.
+    try ensureParentDir(std.Options.debug_io, "out.txt");
+}
+
+test "ensureParentDir creates a missing directory chain" {
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = std.fmt.bufPrint(&buf, "/tmp/malt_pathwrite_ensure_{d}", .{ts}) catch unreachable;
+    std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+
+    var child_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const child = std.fmt.bufPrint(&child_buf, "{s}/x/y/out.txt", .{root}) catch unreachable;
+    try ensureParentDir(io, child);
+
+    var parent_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const parent = std.fmt.bufPrint(&parent_buf, "{s}/x/y", .{root}) catch unreachable;
+    const st = try std.Io.Dir.cwd().statFile(io, parent, .{});
+    try std.testing.expect(st.kind == .directory);
+}
+
+test "writeFile truncates an existing file and reuses its existing parent" {
+    // A second write to the same path: parent already exists (skip create),
+    // and a shorter payload must leave no stale tail.
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&buf, "/tmp/malt_pathwrite_trunc_{d}.txt", .{ts}) catch unreachable;
+    defer std.Io.Dir.cwd().deleteTree(io, dest) catch {};
+
+    try writeFile(io, dest, "a long first payload");
+    try writeFile(io, dest, "x");
+
+    const f = try std.Io.Dir.cwd().openFile(io, dest, .{});
+    defer f.close(io);
+    try std.testing.expectEqual(@as(u64, 1), (try f.stat(io)).size);
+}
+
+test "writeFile writes a zero-length file for empty bytes" {
+    const io = std.Options.debug_io;
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dest = std.fmt.bufPrint(&buf, "/tmp/malt_pathwrite_empty_{d}.txt", .{ts}) catch unreachable;
+    defer std.Io.Dir.cwd().deleteTree(io, dest) catch {};
+
+    try writeFile(io, dest, "");
+
+    const f = try std.Io.Dir.cwd().openFile(io, dest, .{});
+    defer f.close(io);
+    try std.testing.expectEqual(@as(u64, 0), (try f.stat(io)).size);
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -81,6 +81,7 @@ pub const archive = @import("fs/archive.zig");
 pub const atomic = @import("fs/atomic.zig");
 pub const clonefile = @import("fs/clonefile.zig");
 pub const dirsize = @import("fs/dirsize.zig");
+pub const path_write = @import("fs/path_write.zig");
 pub const theme_file = @import("fs/theme_file.zig");
 pub const codesign = @import("macho/codesign.zig");
 pub const parser = @import("macho/parser.zig");

--- a/tests/bundle_cli_test.zig
+++ b/tests/bundle_cli_test.zig
@@ -394,6 +394,23 @@ test "bundle create --format json emits registered taps in the manifest" {
     try testing.expectEqualStrings("xykong/tap", taps.array.items[1].string);
 }
 
+test "bundle create writes a nested output path, creating missing parents" {
+    // The out_path's parent dir does not exist yet; create must make it
+    // rather than fail — parity with `backup -o` / `purge --backup`.
+    var s = try Scratch.init(testing.allocator, "create_nested");
+    defer s.deinit(testing.allocator);
+
+    const out_path = try std.fmt.allocPrint(testing.allocator, "{s}/nested/sub/Brewfile", .{s.path});
+    defer testing.allocator.free(out_path);
+
+    quiet();
+    defer unquiet();
+    try bundle.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{ "create", out_path });
+
+    const f = try test_io.openFileAbsolute(std.Options.debug_io, out_path, .{});
+    f.close(std.Options.debug_io);
+}
+
 test "bundle create --format json --services emits auto_start services only" {
     var s = try Scratch.init(testing.allocator, "create_services");
     defer s.deinit(testing.allocator);


### PR DESCRIPTION
## Description

The nested-parent write logic — "create the parent chain, accept absolute or
relative paths, tolerate a symlink-to-directory parent" — was duplicated across
`backup -o` and `purge --backup`, and a third writer (`bundle create`) was
missing it entirely.

This extracts the logic into a single leaf, `fs/path_write.zig`, and routes all
three writers through it:

- **`fs/path_write.zig`** (new leaf) — `ensureParentDir` + `writeFile`. Depends
  only on `std`; returns typed, UI-agnostic errors so callers own their
  messaging. Distinct from `fs/atomic.zig` (durable tempfile+rename+fsync,
  absolute-only): this is the simple non-atomic "write bytes where the user
  asked" primitive.
- **`backup` / `purge`** now delegate to `path_write.writeFile` and map its
  errors to their own `Error` (backup prints, purge stays silent) — behaviour is
  byte-identical.
- **`bundle create` fix** — `writeManifest` did a bare `createFile` with no
  parent creation, so `bundle create <nested/path>` (e.g.
  `~/dotfiles/Brewfile`) failed with no file written. It now creates parents via
  `path_write.ensureParentDir`, closing the last instance of this bug class.
- Documents `atomicWriteFile`'s preconditions (absolute path, existing parent)
  so the next contributor picks the right primitive.

Modularity: all three callers already imported `fs/atomic.zig`, so the new leaf
adds zero new module edges — a pure sink, not a hub.

## Related Issue

- None

## Notes for Reviewers

- Exhaustive edge cases live once in `fs/path_write.zig`'s inline tests (missing
  grandparent, relative, symlink-to-dir parent, parent-is-a-file, dest-is-a-dir,
  truncation, empty bytes, bare-filename no-op). Callers keep only success +
  error-mapping smokes, per the modularity guidelines ("callers smoke-test the
  wiring, not the re-derived edge cases").
- The bundle fix adds an inline unit test, a `tests/bundle_cli_test.zig`
  integration test, and `scripts/regressions/bundle-create-nested-path-no-mkdir.sh`.
- Verified: `zig build test` green; the backup, purge, and bundle regression
  scripts pass; spawn-invariant lint clean; `zig fmt --check` clean. No behaviour
  change for backup/purge (regression scripts + preserved messages).