### PR TITLE
fix(cask): sweep only the uninstalled cask's own cached versions

### DIFF
--- a/scripts/regressions/per-version-cache-sweep-prefix-matches-siblings.sh
+++ b/scripts/regressions/per-version-cache-sweep-prefix-matches-siblings.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Regression: uninstalling a cask must sweep only its OWN cached per-version
+# artefacts — the versions recorded in cask_versions — not every file whose
+# basename shares a bare `<token>-` prefix.
+#
+# The bug: the uninstall cache sweep matched `startsWith("<token>-")`. The
+# token `git` is a lexical prefix of the sibling token `git-lfs`, so
+# uninstalling `git` also deleted `git-lfs`'s cached artefact. Versions
+# legitimately contain dashes, so no purely lexical tightening can separate a
+# real version from a sibling token's suffix; the authoritative version list
+# is the only safe signal.
+#
+# The fix drives the sweep from `SELECT version FROM cask_versions WHERE
+# token = ?1` and deletes the exact `<token>-<version>.<ext>` shape per row.
+# The download cache is recoverable, but forcing an unrelated cask to
+# re-download on its next install is a real cost the sweep must never impose.
+#
+# End-to-end, offline: seed a DB row + cached artefact for `git` and a sibling
+# cache file for `git-lfs`, run `malt uninstall git`, and assert the sibling
+# survives. Pre-fix the sibling is wiped (exit 1); post-fix it survives.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+PREFIX="/tmp/mt_swp"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX/db" "$PREFIX/cache/Cask"
+trap 'rm -rf "$PREFIX"' EXIT
+
+DB="$PREFIX/db/malt.db"
+
+# Let malt create the DB with the current schema. A fresh prefix has no
+# install, so this exits non-zero ("not installed") — we only want the schema.
+"$BIN" uninstall git >/dev/null 2>&1 || true
+[[ -f "$DB" ]] || {
+  echo "FAIL: malt did not initialise its database" >&2
+  exit 1
+}
+
+# Seed an installed `git` cask + its per-version history row. app_path points
+# at an absent bundle so the uninstall's deleteTree is a no-op.
+sqlite3 "$DB" "
+INSERT INTO casks (token, name, version, url, app_path)
+VALUES ('git', 'Git', '2.39.0', 'https://x.invalid/git.dmg', '$PREFIX/Caskroom/git/2.39.0/Git.app');
+INSERT INTO cask_versions (token, version, url, artifact_type)
+VALUES ('git', '2.39.0', 'https://x.invalid/git.dmg', 'dmg');
+" || {
+  echo "FAIL: could not seed cask rows" >&2
+  exit 1
+}
+
+: >"$PREFIX/cache/Cask/git-2.39.0.dmg"  # git's own artefact — expected swept
+: >"$PREFIX/cache/Cask/git-lfs-2.0.dmg" # prefix sibling — must survive
+
+"$BIN" uninstall git >/dev/null 2>&1 || true
+
+[[ ! -e "$PREFIX/cache/Cask/git-2.39.0.dmg" ]] || {
+  echo "FAIL: git's own cached artefact was not swept" >&2
+  exit 1
+}
+[[ -e "$PREFIX/cache/Cask/git-lfs-2.0.dmg" ]] || {
+  echo "FAIL: sibling git-lfs cached artefact was deleted by git's uninstall" >&2
+  exit 1
+}
+
+echo "PASS: uninstall swept only the cask's own cached versions"

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -264,10 +264,9 @@ pub fn artifactTypeTag(t: ArtifactType) []const u8 {
 }
 
 /// Delete the per-version cache file for one `(token, version)` pair.
-/// Mirrors the `<prefix>/cache/Cask/<token>-<version>.<ext>` naming
-/// `sweepPerVersionCache` matches by prefix, but stays surgical so
-/// `purge --old-versions` can drop a stale version without touching
-/// the current one. Iterates every known extension because
+/// Writes to the `<prefix>/cache/Cask/<token>-<version>.<ext>` naming and
+/// stays surgical so `purge --old-versions` can drop a stale version
+/// without touching the current one. Iterates every known extension because
 /// `cask_versions.artifact_type` is nullable on rows backfilled
 /// before v7. Returns true when every file that existed was removed
 /// (or none existed); false when an existing file could not be
@@ -283,25 +282,22 @@ pub fn deletePerVersionCacheFile(io: std.Io, prefix: []const u8, token: []const 
     return true;
 }
 
-/// Iterate `{prefix}/cache/Cask/` and delete any file whose basename
-/// starts with `{token}-` — the per-version cache shape this binary
-/// writes. Used by uninstall + purge so per-version artefacts don't
-/// outlive their owning cask. Best-effort; silent on missing dirs.
-pub fn sweepPerVersionCache(io: std.Io, prefix: []const u8, token: []const u8) void {
-    var dir_buf: [512]u8 = undefined;
-    const cache_dir_path = std.fmt.bufPrint(&dir_buf, "{s}/cache/Cask", .{prefix}) catch return;
+/// Delete the cached per-version artefacts this token owns, resolved from
+/// its `cask_versions` history rather than a lexical `{token}-` prefix. A
+/// bare prefix also matches sibling tokens (`git` is a prefix of `git-lfs`),
+/// and versions legitimately contain dashes, so the recorded version list is
+/// the only signal that separates a real version from a sibling's suffix.
+/// Enumerates every history row so stale rollback artefacts are swept too.
+/// Best-effort: a failed delete never gates uninstall. Call BEFORE the
+/// history rows are deleted, or the version list is already empty.
+pub fn sweepOwnedVersionCache(io: std.Io, db: *sqlite.Database, prefix: []const u8, token: []const u8) void {
+    var stmt = db.prepare("SELECT version FROM cask_versions WHERE token = ?1;") catch return;
+    defer stmt.finalize();
+    stmt.bindText(1, token) catch return;
 
-    var dir = std.Io.Dir.openDirAbsolute(io, cache_dir_path, .{ .iterate = true }) catch return;
-    defer dir.close(io);
-
-    var prefix_buf: [256]u8 = undefined;
-    const name_prefix = std.fmt.bufPrint(&prefix_buf, "{s}-", .{token}) catch return;
-
-    var iter = dir.iterate();
-    while (iter.next(io) catch null) |entry| {
-        if (entry.kind != .file) continue;
-        if (!std.mem.startsWith(u8, entry.name, name_prefix)) continue;
-        dir.deleteFile(io, entry.name) catch {};
+    while (stmt.step() catch false) {
+        const ver_ptr = stmt.columnText(0) orelse continue;
+        _ = deletePerVersionCacheFile(io, prefix, token, std.mem.sliceTo(ver_ptr, 0));
     }
 }
 
@@ -641,7 +637,9 @@ pub const CaskInstaller = struct {
             const cache_file = std.fmt.bufPrint(&cache_buf, "{s}/cache/Cask/{s}{s}", .{ self.prefix, token, ext }) catch continue;
             std.Io.Dir.cwd().deleteFile(self.io, cache_file) catch {};
         }
-        sweepPerVersionCache(self.io, self.prefix, token);
+        // Must precede the history wipe below — the sweep reads the version
+        // list from `cask_versions`, which the DELETE would otherwise empty.
+        sweepOwnedVersionCache(self.io, self.db, self.prefix, token);
 
         // Drop every history row so a future install starts clean.
         if (self.db.prepare("DELETE FROM cask_versions WHERE token = ?1;")) |prepared| {

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -950,18 +950,26 @@ test "artifactTypeFromTag maps unknown strings to .unknown" {
 
 // --- per-version cache sweep -------------------------------------------
 
-test "sweepPerVersionCache deletes only files prefixed by '<token>-'" {
+test "sweepOwnedVersionCache deletes only the token's own recorded versions" {
     const io = testIo();
     const prefix = "/tmp/malt_cask_sweep";
     test_io.deleteTreeAbsolute(io, prefix) catch {};
     defer test_io.deleteTreeAbsolute(io, prefix) catch {};
     try test_io.cwd().createDirPath(io, prefix ++ "/cache/Cask");
 
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    // Two history rows for `git` (current + a rollback target) exercise the
+    // "sweep every version, not just casks.version" contract.
+    try cask.recordCaskVersion(&db, "git", "2.39.0", "u", "aa", "dmg", null);
+    try cask.recordCaskVersion(&db, "git", "2.38.0", "u", "aa", "dmg", null);
+
     const seeds = [_][]const u8{
-        prefix ++ "/cache/Cask/flux-markdown-1.0.dmg",
-        prefix ++ "/cache/Cask/flux-markdown-2.0.dmg",
-        prefix ++ "/cache/Cask/flux-markdown.dmg", // legacy unprefixed — preserved by sweep
-        prefix ++ "/cache/Cask/other-1.0.dmg", // unrelated token — must survive
+        prefix ++ "/cache/Cask/git-2.39.0.dmg", // owned current — removed
+        prefix ++ "/cache/Cask/git-2.38.0.dmg", // owned rollback — removed
+        prefix ++ "/cache/Cask/git-lfs-2.0.dmg", // prefix sibling — must survive
+        prefix ++ "/cache/Cask/git.dmg", // legacy unprefixed — untouched here
     };
     for (seeds) |p| {
         const f = try test_io.createFileAbsolute(io, p, .{ .truncate = true });
@@ -969,24 +977,80 @@ test "sweepPerVersionCache deletes only files prefixed by '<token>-'" {
         try f.writeStreamingAll(io, "x");
     }
 
-    cask.sweepPerVersionCache(io, prefix, "flux-markdown");
+    cask.sweepOwnedVersionCache(io, &db, prefix, "git");
 
-    // Per-version files are gone; legacy + unrelated remain.
+    // Recorded versions gone; the prefix sibling and legacy shape survive.
     try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, seeds[0], .{}));
     try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, seeds[1], .{}));
     try test_io.accessAbsolute(io, seeds[2], .{});
     try test_io.accessAbsolute(io, seeds[3], .{});
 }
 
-test "sweepPerVersionCache silently skips a missing cache directory" {
+test "sweepOwnedVersionCache is a no-op when the token has no history rows" {
     const io = testIo();
-    const prefix = "/tmp/malt_cask_sweep_missing";
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    // No rows and an absent cache dir — the sweep must not error.
+    cask.sweepOwnedVersionCache(io, &db, "/tmp/malt_cask_sweep_missing", "git");
+}
+
+test "sweepOwnedVersionCache handles a dash-bearing version without touching siblings" {
+    const io = testIo();
+    const prefix = "/tmp/malt_cask_sweep_rev";
     test_io.deleteTreeAbsolute(io, prefix) catch {};
     defer test_io.deleteTreeAbsolute(io, prefix) catch {};
-    try test_io.cwd().createDirPath(io, prefix);
+    try test_io.cwd().createDirPath(io, prefix ++ "/cache/Cask");
 
-    // Cache dir deliberately absent — function must not error.
-    cask.sweepPerVersionCache(io, prefix, "flux-markdown");
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    // A revision-bearing version proves why the sweep is DB-driven: dashes are
+    // legal in versions, so a lexical `git-` prefix can't tell `2.39.0-1` from
+    // the sibling token `git-lfs`. Exact `<token>-<version>` is the only signal.
+    try cask.recordCaskVersion(&db, "git", "2.39.0-1", "u", "aa", "dmg", null);
+
+    const owned = prefix ++ "/cache/Cask/git-2.39.0-1.dmg";
+    const sibling = prefix ++ "/cache/Cask/git-lfs-2.0.dmg";
+    for ([_][]const u8{ owned, sibling }) |p| {
+        const f = try test_io.createFileAbsolute(io, p, .{ .truncate = true });
+        defer f.close(io);
+        try f.writeStreamingAll(io, "x");
+    }
+
+    cask.sweepOwnedVersionCache(io, &db, prefix, "git");
+
+    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, owned, .{}));
+    try test_io.accessAbsolute(io, sibling, .{});
+}
+
+test "sweepOwnedVersionCache sweeps a pre-v7 row with NULL artifact_type" {
+    const io = testIo();
+    const prefix = "/tmp/malt_cask_sweep_null";
+    test_io.deleteTreeAbsolute(io, prefix) catch {};
+    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+    try test_io.cwd().createDirPath(io, prefix ++ "/cache/Cask");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    // Backfill-shape row: artifact_type NULL. The sweep must still find the
+    // artefact by iterating every extension, not narrow to the recorded type.
+    try db.exec(
+        \\INSERT INTO cask_versions (token, version, url)
+        \\VALUES ('git', '2.39.0', 'https://x.invalid/git.zip');
+    );
+
+    const owned = prefix ++ "/cache/Cask/git-2.39.0.zip";
+    {
+        const f = try test_io.createFileAbsolute(io, owned, .{ .truncate = true });
+        defer f.close(io);
+        try f.writeStreamingAll(io, "x");
+    }
+
+    cask.sweepOwnedVersionCache(io, &db, prefix, "git");
+    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, owned, .{}));
 }
 
 // --- reinstallFromHistory dispatch contract ---------------------------------


### PR DESCRIPTION
## Description

Uninstalling a cask used to delete every cached file whose basename shared a bare `<token>-` prefix. Because `git` is a lexical prefix of `git-lfs`, `malt uninstall git` also wiped `git-lfs`'s cached artifact. Versions legitimately contain dashes, so no purely lexical rule can separate a real version from a sibling token's suffix.

**Impact was cache-only (artifacts re-download), but an unrelated cask should never be forced to re-download.**

The uninstall sweep now enumerates the token's own versions from `cask_versions` and deletes the exact `<token>-<version>.<ext>` shape for each row, running before the history rows are dropped. Every recorded version is swept (so stale rollback artifacts still go), the pre-per-version `<token>.<ext>` wipe is untouched, and pre-v7 rows with a NULL `artifact_type` are still found via extension iteration. 

The cask upgrade path reuses this uninstall before downloading the new version, so it inherits the fix with no behavior change for the cask's own versions.

## Related Issue

- None

## Notes for Reviewers

- None