### PR TITLE
fix(net): refresh GHCR token and retry once on a 401 blob download

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -156,6 +156,7 @@ pub fn build(b: *std.Build) void {
         "tests/help_test.zig",
         "tests/archive_test.zig",
         "tests/ghcr_test.zig",
+        "tests/ghcr_401_retry_test.zig",
         "tests/linker_core_test.zig",
         "tests/supervisor_pure_test.zig",
         "tests/install_pure_test.zig",

--- a/scripts/regressions/ghcr-downloadblob-401-retry-not-implemented.sh
+++ b/scripts/regressions/ghcr-downloadblob-401-retry-not-implemented.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Regression: a GHCR blob GET that 401s on a locally-unexpired token must
+# invalidate the cached token, re-fetch a fresh one, and replay the GET once.
+#
+# The bug: downloadBlob documented "401 -> token -> retry" but treated the
+# first 401 as terminal (returned Unauthorized, cache untouched). A token the
+# local clock still considers valid but the registry rejects — clock skew,
+# early revocation, a scope gap — failed the download outright, and the stale
+# token poisoned every sibling batch worker until the expiry buffer lapsed.
+#
+# No CLI surface points downloadBlob at an arbitrary registry, so the retry is
+# exercised by an integration test: a loopback stub registry answers /token
+# (fresh token per call) and 401s the first blob GET, then 200s the second only
+# if a new bearer is presented. The test asserts the download succeeds, two
+# token fetches happened, and the retry carried a different bearer. This script
+# builds and runs only that test binary, so it stays well under 30s, cleans up
+# after itself (no temp state), and needs no network.
+#
+# Exits 0 when the invalidate-and-retry path works, non-zero when the first
+# 401 is terminal (retry not implemented).
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+TEST_NAME="downloadBlob invalidates the cached token and retries once on a 401"
+TEST_SRC="tests/ghcr_401_retry_test.zig"
+
+# If the guard test is ever deleted, the runner would report "no tests" and
+# pass silently. Fail loudly instead.
+if ! grep -Rqs -- "$TEST_NAME" "$TEST_SRC"; then
+  echo "FAIL: the blob 401 retry guard test is missing from $TEST_SRC" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/ghcr_401_retry_test"
+if [[ ! -x "$BIN" ]]; then
+  if ! zig build test-bin >/dev/null 2>&1; then
+    echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+    exit 1
+  fi
+fi
+
+# The runner has no per-test filter, so run the file's suite and judge the
+# retry guard by name: a pass ends in "OK", a regression prints "FAIL" there
+# (the first 401 was terminal) and the binary exits non-zero.
+OUT=$("$BIN" 2>&1 || true)
+LINE=$(printf '%s\n' "$OUT" | grep -F -- "$TEST_NAME" || true)
+if [[ -z "$LINE" ]]; then
+  echo "FAIL: the blob 401 retry guard test did not run" >&2
+  printf '%s\n' "$OUT" >&2
+  exit 1
+fi
+if [[ "$LINE" != *OK ]]; then
+  echo "FAIL: downloadBlob returned Unauthorized on a recoverable 401 (retry not implemented)" >&2
+  printf '%s\n' "$OUT" >&2
+  exit 1
+fi
+
+echo "PASS: a 401 blob download triggers token invalidation + a single retry"

--- a/src/net/ghcr.zig
+++ b/src/net/ghcr.zig
@@ -57,6 +57,16 @@ pub const GhcrClient = struct {
         self.cached_scopes.deinit(self.allocator);
     }
 
+    /// Mutex-guarded cache drop for callers that run *outside* the lock
+    /// (`downloadBlob`). `clearCache` assumes the caller already holds
+    /// `self.mutex`; reaching into it bare from the unlocked blob path would
+    /// race a sibling worker's `fetchToken`, so take the lock here.
+    fn invalidateToken(self: *GhcrClient) void {
+        self.mutex.lockUncancelable(self.io);
+        defer self.mutex.unlock(self.io);
+        self.clearCache();
+    }
+
     /// Drop any cached token + the owned scope keys. Caller holds
     /// `self.mutex` where concurrent access is possible.
     fn clearCache(self: *GhcrClient) void {
@@ -230,30 +240,48 @@ pub const GhcrClient = struct {
         body_out: *std.ArrayList(u8),
         progress: ?client_mod.ProgressCallback,
     ) GhcrError!void {
-        const token = self.fetchToken(http, repo) catch return GhcrError.TokenFetchFailed;
-        defer self.allocator.free(token);
-
         var url_buf: [512]u8 = undefined;
         const url = try buildBlobUrl(&url_buf, self.base_url, repo, digest);
 
-        var auth_buf: [2048]u8 = undefined;
-        const auth_value = std.fmt.bufPrint(&auth_buf, "Bearer {s}", .{token}) catch
-            return GhcrError.OutOfMemory;
+        // A 401 on a token the local clock still deems valid means the
+        // registry rejected it (skew / early revocation / scope gap), so
+        // routine expiry — already caught by `fetchToken`'s clock check — is
+        // not the case we retry. Invalidate the cache and re-fetch once; a
+        // fresh single-scope round-trip replaces the dead token. This also
+        // drops the shared multi-scope token `prefetchTokens` seeded, so
+        // sibling batch workers re-fetch per-repo on their next call — the
+        // cache re-converges, and that beats replaying a token the registry
+        // is actively rejecting. A second 401 is terminal.
+        var retried = false;
+        while (true) {
+            const token = self.fetchToken(http, repo) catch return GhcrError.TokenFetchFailed;
+            defer self.allocator.free(token);
 
-        const headers = [_]std.http.Header{
-            .{ .name = "Authorization", .value = auth_value },
-        };
+            var auth_buf: [2048]u8 = undefined;
+            const auth_value = std.fmt.bufPrint(&auth_buf, "Bearer {s}", .{token}) catch
+                return GhcrError.OutOfMemory;
 
-        var resp = http.getWithHeaders(url, &headers, progress) catch
-            return GhcrError.DownloadFailed;
-        defer resp.deinit();
+            const headers = [_]std.http.Header{
+                .{ .name = "Authorization", .value = auth_value },
+            };
 
-        if (resp.status == 401) return GhcrError.Unauthorized;
-        if (resp.status != 200) {
-            return classifyGhcrStatus(resp.status);
+            var resp = http.getWithHeaders(url, &headers, progress) catch
+                return GhcrError.DownloadFailed;
+            defer resp.deinit();
+
+            if (resp.status == 401) {
+                if (retried) return GhcrError.Unauthorized;
+                retried = true;
+                self.invalidateToken();
+                continue;
+            }
+            if (resp.status != 200) {
+                return classifyGhcrStatus(resp.status);
+            }
+
+            body_out.appendSlice(allocator, resp.body) catch return GhcrError.OutOfMemory;
+            return;
         }
-
-        body_out.appendSlice(allocator, resp.body) catch return GhcrError.OutOfMemory;
     }
 
     pub fn classifyGhcrStatus(status: u16) GhcrError {
@@ -323,4 +351,29 @@ test "buildBlobUrl threads the override base into the blob path" {
 test "buildBlobUrl returns OutOfMemory when the buffer can't hold the URL" {
     var tiny: [8]u8 = undefined;
     try testing.expectError(GhcrError.OutOfMemory, GhcrClient.buildBlobUrl(&tiny, "https://reg.example.com", "homebrew/core/wget", "sha256:abc"));
+}
+
+test "invalidateToken clears a seeded cache and is a no-op when already empty" {
+    var pool = try pool_mod.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator, 1);
+    defer pool.deinit();
+    const http = pool.acquire();
+    defer pool.release(http);
+
+    var g = GhcrClient.init(std.Options.debug_io, testing.allocator, http);
+    defer g.deinit();
+
+    // Empty cache: invalidation must not underflow or double-free.
+    g.invalidateToken();
+    try testing.expect(g.cached_token == null);
+
+    g.cached_token = try testing.allocator.dupe(u8, "dead-token");
+    try g.cached_scopes.put(testing.allocator, try testing.allocator.dupe(u8, "homebrew/core/tree"), {});
+    g.token_expiry = std.math.maxInt(i64);
+
+    // The blob-path invalidation the 401 retry relies on: a locally-unexpired
+    // but registry-rejected token is dropped so the next fetch re-fetches.
+    g.invalidateToken();
+    try testing.expect(g.cached_token == null);
+    try testing.expectEqual(@as(usize, 0), g.cached_scopes.count());
+    try testing.expect(!g.hasTokenFor("homebrew/core/tree"));
 }

--- a/tests/ghcr_401_retry_test.zig
+++ b/tests/ghcr_401_retry_test.zig
@@ -1,0 +1,391 @@
+//! malt — GHCR blob 401 invalidate-and-retry integration test.
+//! Stands up a localhost `std.http.Server` that answers `/token` and
+//! `/blobs/…`, and drives `GhcrClient.downloadBlob` against it. A blob
+//! GET that 401s on a locally-unexpired token must invalidate the cache,
+//! re-fetch a fresh token, and replay the GET exactly once — the contract
+//! the doc-comment promises. No real network: the stub is loopback.
+
+const std = @import("std");
+const client = @import("malt").client;
+const ghcr = @import("malt").ghcr;
+const net = std.Io.net;
+
+const blob_body = "BOTTLE-BYTES";
+
+const Stub = struct {
+    io: std.Io,
+    listener: *net.Server,
+    // When true every blob GET answers 401 (terminal-second-401 case);
+    // otherwise the first blob GET 401s and later ones succeed.
+    always_401: bool = false,
+    // When set, every blob GET answers this status (used to prove a non-401
+    // error is NOT treated as the skew/revocation retry case).
+    force_status: ?std.http.Status = null,
+    token_count: usize = 0,
+    blob_count: usize = 0,
+    // Bearer value presented on each blob GET, copied out of the per-request
+    // buffer so the test can compare token#1 vs token#2 after the join.
+    blob_auth: [2][256]u8 = undefined,
+    blob_auth_len: [2]usize = .{ 0, 0 },
+};
+
+// Serves the whole token→blob→token→blob sequence on one keep-alive
+// connection. Loops until the client closes (via `http.deinit`), which
+// surfaces as a `receiveHead` error and ends the thread cleanly whether the
+// download succeeded, retried, or bailed on the first 401.
+fn serveStub(s: *Stub) void {
+    const stream = s.listener.accept(s.io) catch return;
+    defer stream.close(s.io);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var reader = stream.reader(s.io, &rbuf);
+    var writer = stream.writer(s.io, &wbuf);
+    var srv = std.http.Server.init(&reader.interface, &writer.interface);
+    while (true) {
+        var req = srv.receiveHead() catch return;
+        const target = req.head.target;
+        if (std.mem.indexOf(u8, target, "/token") != null) {
+            s.token_count += 1;
+            var body_buf: [64]u8 = undefined;
+            const body = std.fmt.bufPrint(&body_buf, "{{\"token\":\"t{d}\"}}", .{s.token_count}) catch return;
+            req.respond(body, .{}) catch return;
+        } else if (std.mem.indexOf(u8, target, "/blobs/") != null) {
+            const idx = @min(s.blob_count, s.blob_auth.len - 1);
+            var it = req.iterateHeaders();
+            while (it.next()) |h| {
+                if (std.ascii.eqlIgnoreCase(h.name, "authorization")) {
+                    const n = @min(h.value.len, s.blob_auth[idx].len);
+                    @memcpy(s.blob_auth[idx][0..n], h.value[0..n]);
+                    s.blob_auth_len[idx] = n;
+                }
+            }
+            s.blob_count += 1;
+            if (s.force_status) |st| {
+                req.respond("error\n", .{ .status = st }) catch return;
+            } else if (s.always_401 or s.blob_count == 1) {
+                req.respond("unauthorized\n", .{ .status = .unauthorized }) catch return;
+            } else {
+                req.respond(blob_body, .{}) catch return;
+            }
+        } else {
+            req.respond("not found\n", .{ .status = .not_found }) catch return;
+        }
+    }
+}
+
+fn blobAuth(s: *const Stub, idx: usize) []const u8 {
+    return s.blob_auth[idx][0..s.blob_auth_len[idx]];
+}
+
+test "downloadBlob invalidates the cached token and retries once on a 401" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var stub = Stub{ .io = io, .listener = &listener };
+    const server_thread = try std.Thread.spawn(.{}, serveStub, .{&stub});
+
+    var base_buf: [64]u8 = undefined;
+    const base = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+
+    var g = ghcr.GhcrClient.init(io, std.testing.allocator, &http);
+    defer g.deinit();
+    g.base_url = base;
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(std.testing.allocator);
+
+    const result = g.downloadBlob(std.testing.allocator, &http, "homebrew/core/tree", "sha256:abc", &body, null);
+
+    // Close the client so the server's keep-alive loop ends, then join
+    // before reading server-side counters to avoid a data race.
+    http.deinit();
+    server_thread.join();
+
+    try result;
+    try std.testing.expectEqualStrings(blob_body, body.items);
+    // Two token fetches: the initial one plus the post-invalidation refresh.
+    try std.testing.expectEqual(@as(usize, 2), stub.token_count);
+    try std.testing.expectEqual(@as(usize, 2), stub.blob_count);
+    // The retry must present a *fresh* bearer, not replay the rejected one.
+    try std.testing.expect(!std.mem.eql(u8, blobAuth(&stub, 0), blobAuth(&stub, 1)));
+}
+
+test "downloadBlob returns Unauthorized after a second 401 (retry bounded to once)" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var stub = Stub{ .io = io, .listener = &listener, .always_401 = true };
+    const server_thread = try std.Thread.spawn(.{}, serveStub, .{&stub});
+
+    var base_buf: [64]u8 = undefined;
+    const base = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+
+    var g = ghcr.GhcrClient.init(io, std.testing.allocator, &http);
+    defer g.deinit();
+    g.base_url = base;
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(std.testing.allocator);
+
+    const result = g.downloadBlob(std.testing.allocator, &http, "homebrew/core/tree", "sha256:abc", &body, null);
+
+    http.deinit();
+    server_thread.join();
+
+    try std.testing.expectError(ghcr.GhcrError.Unauthorized, result);
+    // Exactly one retry: two token fetches, two blob GETs — never a third.
+    try std.testing.expectEqual(@as(usize, 2), stub.token_count);
+    try std.testing.expectEqual(@as(usize, 2), stub.blob_count);
+}
+
+test "downloadBlob does not refresh the token on a non-401 error" {
+    // Pins the retry boundary: only 401 is the skew/revocation case. A 403
+    // must surface immediately with no cache invalidation and no re-fetch,
+    // so a future edit can't silently widen the retry to every error.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var stub = Stub{ .io = io, .listener = &listener, .force_status = .forbidden };
+    const server_thread = try std.Thread.spawn(.{}, serveStub, .{&stub});
+
+    var base_buf: [64]u8 = undefined;
+    const base = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+
+    var g = ghcr.GhcrClient.init(io, std.testing.allocator, &http);
+    defer g.deinit();
+    g.base_url = base;
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(std.testing.allocator);
+
+    const result = g.downloadBlob(std.testing.allocator, &http, "homebrew/core/tree", "sha256:abc", &body, null);
+
+    http.deinit();
+    server_thread.join();
+
+    try std.testing.expectError(ghcr.GhcrError.DownloadHttpClientError, result);
+    // No refresh: the token was fetched once and the blob GET issued once.
+    try std.testing.expectEqual(@as(usize, 1), stub.token_count);
+    try std.testing.expectEqual(@as(usize, 1), stub.blob_count);
+}
+
+// Records every progress report so a test can inspect how the callback fires
+// across the failed + retried attempts.
+const ProgressRec = struct {
+    calls: usize = 0,
+    last_bytes: u64 = 0,
+    // Distinct content-lengths seen: one report sequence per response body.
+    lens: [8]u64 = undefined,
+    len_count: usize = 0,
+
+    fn record(ctx: *anyopaque, bytes_so_far: u64, content_length: ?u64) void {
+        const self: *ProgressRec = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        self.last_bytes = bytes_so_far;
+        const cl = content_length orelse return;
+        for (self.lens[0..self.len_count]) |v| if (v == cl) return;
+        if (self.len_count < self.lens.len) {
+            self.lens[self.len_count] = cl;
+            self.len_count += 1;
+        }
+    }
+};
+
+test "downloadBlob progress fires across the failed and retried attempts" {
+    // Characterizes an accepted quirk: the 401 error body streams through the
+    // progress callback, then the real blob streams a second, independent
+    // sequence (bytes reset to 0, content-length differs). A consumer that
+    // assumes monotonic bytes sees a reset — cosmetic on this rare recovery
+    // path, pinned here so a future change can't turn the reset into silent
+    // double-counting.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var stub = Stub{ .io = io, .listener = &listener };
+    const server_thread = try std.Thread.spawn(.{}, serveStub, .{&stub});
+
+    var base_buf: [64]u8 = undefined;
+    const base = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+
+    var g = ghcr.GhcrClient.init(io, std.testing.allocator, &http);
+    defer g.deinit();
+    g.base_url = base;
+
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(std.testing.allocator);
+
+    var rec = ProgressRec{};
+    const progress = client.ProgressCallback{ .context = &rec, .func = ProgressRec.record };
+    const result = g.downloadBlob(std.testing.allocator, &http, "homebrew/core/tree", "sha256:abc", &body, progress);
+
+    http.deinit();
+    server_thread.join();
+
+    try result;
+    try std.testing.expectEqualStrings(blob_body, body.items);
+    // Two distinct content-lengths => progress fired for two different
+    // responses (the 401 body then the blob): the double-fire.
+    try std.testing.expect(rec.len_count >= 2);
+    // The final report reflects the real blob, not the discarded error body.
+    try std.testing.expectEqual(@as(u64, blob_body.len), rec.last_bytes);
+}
+
+const ConcStub = struct {
+    io: std.Io,
+    listener: *net.Server,
+    // Shared across both handler threads; atomic so the two workers' token
+    // fetches can't race the increment.
+    token_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+};
+
+fn concToken(cs: *ConcStub) usize {
+    return cs.token_count.fetchAdd(1, .monotonic) + 1;
+}
+
+// One connection carries one worker's token→blob(401)→token→blob(200) run;
+// a per-connection blob counter gives each worker its own first-401.
+fn serveConcConn(cs: *ConcStub, stream: net.Stream) void {
+    defer stream.close(cs.io);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var reader = stream.reader(cs.io, &rbuf);
+    var writer = stream.writer(cs.io, &wbuf);
+    var srv = std.http.Server.init(&reader.interface, &writer.interface);
+    var local_blob: usize = 0;
+    while (true) {
+        var req = srv.receiveHead() catch return;
+        const target = req.head.target;
+        if (std.mem.indexOf(u8, target, "/token") != null) {
+            var body_buf: [64]u8 = undefined;
+            const body = std.fmt.bufPrint(&body_buf, "{{\"token\":\"t{d}\"}}", .{concToken(cs)}) catch return;
+            req.respond(body, .{}) catch return;
+        } else if (std.mem.indexOf(u8, target, "/blobs/") != null) {
+            local_blob += 1;
+            if (local_blob == 1) {
+                req.respond("unauthorized\n", .{ .status = .unauthorized }) catch return;
+            } else {
+                req.respond(blob_body, .{}) catch return;
+            }
+        } else {
+            req.respond("not found\n", .{ .status = .not_found }) catch return;
+        }
+    }
+}
+
+// Serves the two worker connections concurrently, one handler thread each.
+// Keep-alive means each worker reuses a single connection, so two accepts
+// cover the whole run; handlers exit on EOF when the workers' clients close.
+fn serveConc(cs: *ConcStub) void {
+    var handlers: [2]std.Thread = undefined;
+    var n: usize = 0;
+    while (n < handlers.len) : (n += 1) {
+        const stream = cs.listener.accept(cs.io) catch break;
+        handlers[n] = std.Thread.spawn(.{}, serveConcConn, .{ cs, stream }) catch {
+            stream.close(cs.io);
+            break;
+        };
+    }
+    for (handlers[0..n]) |h| h.join();
+}
+
+const WorkerCtx = struct {
+    g: *ghcr.GhcrClient,
+    http: *client.HttpClient,
+    body: std.ArrayList(u8) = .empty,
+    ok: bool = false,
+};
+
+fn concWorker(ctx: *WorkerCtx) void {
+    ctx.g.downloadBlob(std.testing.allocator, ctx.http, "homebrew/core/tree", "sha256:abc", &ctx.body, null) catch return;
+    ctx.ok = true;
+}
+
+test "concurrent downloadBlob workers recover from 401 without cache corruption" {
+    // Registry-wide revocation: two workers sharing one GhcrClient each hit a
+    // 401 and invalidate + re-fetch the shared token. That re-fetch storm is
+    // by design (extra /token round-trips), but the mutex-guarded cache must
+    // never corrupt or leak — both downloads complete and the testing
+    // allocator reports no leak.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var cs = ConcStub{ .io = io, .listener = &listener };
+    const server_thread = try std.Thread.spawn(.{}, serveConc, .{&cs});
+
+    var base_buf: [64]u8 = undefined;
+    const base = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    var inner1: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http1 = client.HttpClient.initWith(&inner1, io, std.process.Environ.empty, std.testing.allocator);
+    var inner2: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http2 = client.HttpClient.initWith(&inner2, io, std.process.Environ.empty, std.testing.allocator);
+
+    var g = ghcr.GhcrClient.init(io, std.testing.allocator, &http1);
+    defer g.deinit();
+    g.base_url = base;
+
+    var w1 = WorkerCtx{ .g = &g, .http = &http1 };
+    var w2 = WorkerCtx{ .g = &g, .http = &http2 };
+    defer w1.body.deinit(std.testing.allocator);
+    defer w2.body.deinit(std.testing.allocator);
+
+    const t1 = try std.Thread.spawn(.{}, concWorker, .{&w1});
+    const t2 = try std.Thread.spawn(.{}, concWorker, .{&w2});
+    t1.join();
+    t2.join();
+
+    // Close both clients so the server handlers see EOF and exit, then join.
+    http1.deinit();
+    http2.deinit();
+    server_thread.join();
+
+    try std.testing.expect(w1.ok);
+    try std.testing.expect(w2.ok);
+    try std.testing.expectEqualStrings(blob_body, w1.body.items);
+    try std.testing.expectEqualStrings(blob_body, w2.body.items);
+    // Each worker fetched, hit 401, invalidated, re-fetched: at least the two
+    // initial fetches happened (the exact total races by design).
+    try std.testing.expect(cs.token_count.load(.monotonic) >= 2);
+}


### PR DESCRIPTION
## Description

A cached GHCR token the local clock still considers valid but the registry rejects - clock skew, server-side early revocation, or a scope the token doesn't actually cover — used to fail a bottle download outright. `downloadBlob` documented "401 -> token -> retry" but treated the first 401 as terminal, so the caller surfaced `DownloadFailed` and the stale token kept poisoning every sibling batch worker until the expiry buffer lapsed.

This honours the documented contract: on a 401 the cached token is invalidated under the mutex, a fresh token is re-fetched, and the blob GET is replayed exactly once. A second 401 is terminal. Routine expiry is still caught earlier by the clock check, so the retry adds value only for the narrow server-rejected-but-locally-unexpired window it was always meant to cover.

## Related Issue

- None

## Notes for Reviewers

- The fix reuses the existing `GhcrError` variants (`Unauthorized`, `TokenFetchFailed`); no new error type, no change to the `bottle.zig` mapping.