### PR TITLE
fix(cask): prompt visibly and confirm before sudo for PKG casks

### DIFF
--- a/scripts/e2e/pkg-cask-nontty-refusal.sh
+++ b/scripts/e2e/pkg-cask-nontty-refusal.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# scripts/e2e/pkg-cask-nontty-refusal.sh
+#
+# End-to-end proof that EVERY verb which can escalate a PKG cask to
+# `sudo installer -target /` refuses when stdin is not a terminal, and never
+# reaches sudo. Drives the real CLI with empty stdin and asserts, per verb,
+# malt's own actionable "interactive terminal" message plus a `sudo` stub on
+# PATH that stays untouched:
+#   - install --cask <pkg>   (fresh install; needs the cask JSON — network)
+#   - upgrade <pkg>          (seeded as installed-old; needs the cask JSON)
+#   - rollback <pkg>         (seeded pkg history; fully offline)
+# The refusal fires before any download or the upgrade's uninstall, so a
+# refusal leaves disk untouched. The pure guard is unit-tested; this pins every
+# verb at the binary edge, which no unit test can reach.
+#
+# Network: install/upgrade fetch one cask JSON from formulae.brew.sh (a CDN —
+# no GitHub auth, no rate limit). Classified network failures SKIP those cases
+# (matching the other cask e2e scripts). rollback needs no network and always
+# runs, so the script always makes at least one hard assertion.
+#
+# Hermetic: throwaway MALT_PREFIX per case and a throwaway PATH dir, all cleaned
+# up. Upgrade/rollback seed state via sqlite3 and are skipped if it is absent.
+# Well under 30s.
+#
+# Usage:   MT_BIN=./zig-out/bin/malt ./scripts/e2e/pkg-cask-nontty-refusal.sh
+# Exit:    0 on pass or a clean upstream skip, 1 on failure, 2 when MT_BIN missing.
+
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+MT_BIN="${MT_BIN:-$ROOT/zig-out/bin/malt}"
+
+if [[ ! -x "$MT_BIN" ]]; then
+  echo "pkg-nontty: $MT_BIN not found or not executable (run 'zig build' or set MT_BIN)" >&2
+  exit 2
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+
+# One sudo stub on PATH for every case: record any invocation, then succeed —
+# so a broken guard that reached escalation leaves a marker (and "passes" sudo).
+mark="$tmp/sudo_calls"
+: >"$mark"
+printf '#!/usr/bin/env bash\necho "invoked: $*" >>"%s"\nexit 0\n' "$mark" >"$tmp/sudo"
+chmod +x "$tmp/sudo"
+
+net_skip_re='rate limit|cannot reach|not found|network|could not resolve|offline|failed to (download|install)|could not fetch'
+
+pass() { echo "pkg-nontty: OK — $*"; }
+skip() { echo "pkg-nontty: skip — $*" >&2; }
+fail() {
+  echo "pkg-nontty: FAIL — $*" >&2
+  exit 1
+}
+
+# Any sudo call means a guard let escalation through — fail hard regardless of
+# which case triggered it (the stub marker is shared across cases).
+assert_no_sudo() {
+  [[ -s "$mark" ]] && fail "$1 escalated to sudo off a TTY: $(cat "$mark")"
+  return 0
+}
+
+# Fresh prefix with an initialised DB (schema created by any real command).
+fresh_prefix() {
+  local p="$tmp/$1"
+  mkdir -p "$p/db"
+  MALT_PREFIX="$p" "$MT_BIN" list >/dev/null 2>&1
+  echo "$p"
+}
+
+# ── Case 1: fresh install (network) ─────────────────────────────────────────
+install_ok=skip
+for token in basictex temurin dotnet-sdk; do
+  p="$tmp/inst_$token"
+  mkdir -p "$p"
+  log="$tmp/inst_$token.log"
+  printf '' | PATH="$tmp:$PATH" MALT_PREFIX="$p" "$MT_BIN" install --cask "$token" >"$log" 2>&1 || true
+  assert_no_sudo "install $token"
+  if grep -qi 'interactive terminal' "$log"; then
+    pass "install --cask $token refused off a TTY"
+    install_ok=ok
+    break
+  fi
+  if grep -qiE "$net_skip_re" "$log"; then
+    skip "install $token: classified upstream condition; trying next"
+    continue
+  fi
+  tail -15 "$log" >&2
+  fail "install $token neither refused nor reported a known upstream skip"
+done
+[[ "$install_ok" == skip ]] && skip "install: all candidates hit upstream conditions"
+
+# ── Cases 2 & 3 seed installed/history state, which needs sqlite3 ────────────
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  skip "upgrade/rollback cases need sqlite3; skipped"
+  echo "pkg-nontty: DONE (install case only)"
+  exit 0
+fi
+
+# ── Case 3: rollback (offline, deterministic) ───────────────────────────────
+# Seed a cask with two PKG history versions; roll back to the older one. No
+# network — the gate fires before reinstall reads the (fake) URL.
+p=$(fresh_prefix rb)
+db="$p/db/malt.db"
+sqlite3 "$db" \
+  "INSERT INTO casks(token,name,version,url) VALUES('faketpkg','faketpkg','2.0','https://example.invalid/f-2.0.pkg');
+   INSERT INTO cask_versions(token,version,url,sha256,artifact_type) VALUES('faketpkg','2.0','https://example.invalid/f-2.0.pkg','','pkg');
+   INSERT INTO cask_versions(token,version,url,sha256,artifact_type) VALUES('faketpkg','1.0','https://example.invalid/f-1.0.pkg','','pkg');"
+log="$tmp/rb.log"
+printf '' | PATH="$tmp:$PATH" MALT_PREFIX="$p" "$MT_BIN" rollback faketpkg --to 1.0 >"$log" 2>&1 || true
+assert_no_sudo "rollback"
+grep -qi 'interactive terminal' "$log" || {
+  tail -15 "$log" >&2
+  fail "rollback of a PKG cask did not refuse off a TTY"
+}
+pass "rollback (PKG history) refused off a TTY, no sudo"
+
+# ── Case 2: upgrade (network) ───────────────────────────────────────────────
+# Seed a real PKG cask as installed at an ancient version so the upgrade sees
+# it as outdated and reaches the gate before the uninstall.
+p=$(fresh_prefix up)
+db="$p/db/malt.db"
+sqlite3 "$db" \
+  "INSERT INTO casks(token,name,version,url) VALUES('basictex','basictex','0.0','https://example.invalid/basictex-0.0.pkg');"
+log="$tmp/up.log"
+printf '' | PATH="$tmp:$PATH" MALT_PREFIX="$p" "$MT_BIN" upgrade basictex >"$log" 2>&1 || true
+assert_no_sudo "upgrade"
+if grep -qi 'interactive terminal' "$log"; then
+  pass "upgrade (PKG cask) refused off a TTY, no sudo"
+elif grep -qiE "$net_skip_re" "$log"; then
+  skip "upgrade basictex: classified upstream condition"
+else
+  tail -15 "$log" >&2
+  fail "upgrade neither refused nor reported a known upstream skip"
+fi
+
+# ── Cases 4 & 5: the interactive confirm branch (needs a real pty) ──────────
+# The cases above only prove the refusal direction. On a real terminal the gate
+# must ACCEPT "y" (proceed) and DECLINE anything else — an inverted or
+# always-off confirm would otherwise ship green. Drive a pty with the shared
+# perl driver against the offline fake cask so it stays fast and deterministic;
+# skip (don't fail) when IO::Pty is unavailable, exactly like the tui e2e.
+PTY_DRIVER="$ROOT/scripts/lib/tui_pty_drive.pl"
+if perl -MIO::Pty -e 1 >/dev/null 2>&1 && perl -c "$PTY_DRIVER" >/dev/null 2>&1; then
+  p=$(fresh_prefix cf)
+  db="$p/db/malt.db"
+  sqlite3 "$db" \
+    "INSERT INTO casks(token,name,version,url) VALUES('faketpkg','faketpkg','2.0','https://example.invalid/f-2.0.pkg');
+     INSERT INTO cask_versions(token,version,url,sha256,artifact_type) VALUES('faketpkg','2.0','https://example.invalid/f-2.0.pkg','','pkg');
+     INSERT INTO cask_versions(token,version,url,sha256,artifact_type) VALUES('faketpkg','1.0','https://example.invalid/f-1.0.pkg','','pkg');"
+
+  # Decline: "n" must abort at the gate — no reinstall attempt, no sudo.
+  cap="$tmp/cf_no.cap"
+  PATH="$tmp:$PATH" MALT_PREFIX="$p" MALT_OFFLINE=1 perl "$PTY_DRIVER" "$cap" 80 24 \
+    "$MT_BIN" rollback faketpkg --to 1.0 <<<'settle 1
+send n\n
+quitwait 5' >/dev/null
+  assert_no_sudo "confirm-decline"
+  tr -d '\r' <"$cap" | grep -qi 'not confirmed' || {
+    tr -d '\r' <"$cap" >&2
+    fail "declining the PKG prompt did not abort at the gate"
+  }
+  tr -d '\r' <"$cap" | grep -qi 'reinstall' && {
+    tr -d '\r' <"$cap" >&2
+    fail "declining the PKG prompt still proceeded to reinstall"
+  }
+  pass "interactive decline ('n') aborts before reinstall, no sudo"
+
+  # Accept: "y" must proceed past the gate. Offline, the fake URL then fails the
+  # download — that failure is the observable "we got past confirmation".
+  cap="$tmp/cf_yes.cap"
+  PATH="$tmp:$PATH" MALT_PREFIX="$p" MALT_OFFLINE=1 perl "$PTY_DRIVER" "$cap" 80 24 \
+    "$MT_BIN" rollback faketpkg --to 1.0 <<<'settle 1
+send y\n
+quitwait 10' >/dev/null
+  assert_no_sudo "confirm-accept"
+  tr -d '\r' <"$cap" | grep -qi 'reinstall' || {
+    tr -d '\r' <"$cap" >&2
+    fail "accepting the PKG prompt did not proceed past the gate"
+  }
+  pass "interactive accept ('y') proceeds past the gate, no sudo"
+else
+  skip "interactive confirm cases need Perl IO::Pty; skipped"
+fi
+
+echo "pkg-nontty: DONE — every verb that can sudo refuses off a TTY"
+exit 0

--- a/scripts/regressions/pkg-cask-sudo-prompt-ask-for-sudo-when-needed.sh
+++ b/scripts/regressions/pkg-cask-sudo-prompt-ask-for-sudo-when-needed.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Regression: a PKG-cask install must refuse to escalate via
+# `sudo installer -pkg … -target /` when there is no controlling terminal.
+#
+# The bug: the only guard before escalation was a warn() line. Off a TTY
+# (piped stdin, CI, a `--json` consumer) `sudo` reads the password from
+# /dev/tty, finds none, and fails — but the call runs through child.run,
+# which captures stderr, so `sudo: a terminal is required …` surfaced only
+# post-mortem, after a silent stall and a non-zero exit. The fix probes stdin
+# for a TTY before the install and refuses up front with malt's own
+# actionable message ("requires an interactive terminal"); on a TTY it also
+# requires an explicit confirmation before the system-wide install.
+#
+# No CLI surface reaches the PKG artifact-type branch offline without standing
+# up a local tap and a real download, and the guard fires before that branch —
+# so the behaviour is pinned by the colocated unit test in the inline suite
+# (lib_tests). This script asserts the predicate, the gate, both call sites,
+# and the user-facing message are all present (so the suite cannot go green
+# vacuously), then builds and runs that binary. Offline, well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+OUT="src/ui/output.zig"
+CLI="src/cli/install.zig"
+LOCAL="src/cli/install/local.zig"
+UPGRADE="src/cli/upgrade.zig"
+ROLLBACK="src/cli/rollback.zig"
+TEST_NAME="isInteractive treats a non-terminal stdin as non-interactive"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# If the guard or its test is dropped, the unit binary would go green
+# vacuously. Fail loudly instead: predicate, test, gate, every call site, and
+# the actionable message must all be present in source. Every verb that can
+# reach `sudo installer` — install, upgrade, rollback — must route through the
+# one gate, or that verb regresses to the silent-stall behaviour.
+grep -Fqs -- "$TEST_NAME" "$OUT" || fail "the non-tty guard test is missing from $OUT"
+grep -Fqs -- "fn isInteractive" "$OUT" || fail "the stdin TTY predicate is missing from $OUT"
+grep -Fqs -- "fn confirmPkgSudo" "$CLI" || fail "the PKG sudo gate is missing from $CLI"
+grep -Fqs -- "interactive terminal" "$CLI" || fail "the actionable non-tty message is missing from $CLI"
+grep -Fqs -- "confirmPkgSudo(" "$CLI" || fail "the brew-API install PKG path does not route through the sudo gate"
+grep -Fqs -- "confirmPkgSudo(" "$LOCAL" || fail "the tap install PKG path does not route through the sudo gate"
+grep -Fqs -- "confirmPkgSudo(" "$UPGRADE" || fail "the cask upgrade PKG path does not route through the sudo gate"
+grep -Fqs -- "confirmPkgSudo(" "$ROLLBACK" || fail "the cask rollback PKG path does not route through the sudo gate"
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+# Always rebuild so the binary reflects current source — a prebuilt
+# lib_tests could predate the guard. Zig's cache makes a no-op rebuild cheap.
+zig build test-bin >/dev/null 2>&1 || fail "could not build the unit test binary (zig build test-bin)"
+
+# The runner has no per-test filter, so run the inline suite and judge by exit
+# code. Pre-fix, the guard predicate does not exist and its test cannot hold,
+# so the binary exits non-zero.
+RUN=$("$BIN" 2>&1) && STATUS=0 || STATUS=$?
+if [[ "$STATUS" -ne 0 ]]; then
+  echo "FAIL: PKG-cask non-tty sudo guard unit test did not hold" >&2
+  printf '%s\n' "$RUN" | grep -iE "failed|leaked|panic" >&2 || true
+  exit 1
+fi
+
+echo "PASS: PKG-cask install refuses sudo escalation off a TTY"

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1358,6 +1358,27 @@ fn resolveCaskArtifactViaHead(ctx: *const AppCtx, allocator: std.mem.Allocator, 
     return cask_mod.resolveArtifactType(allocator, resolved.final_url, resolved.content_disposition);
 }
 
+/// Gate the system-wide `sudo installer -pkg … -target /` escalation a PKG
+/// cask needs. Shared by every verb that can reach it — install, upgrade,
+/// rollback — so the confirmation is identical everywhere. `sudo` reads the
+/// password from the controlling terminal, so off a TTY the spawn stalls and
+/// then fails with a captured, post-mortem error; refuse up front with an
+/// actionable message instead. On a TTY, require an explicit confirmation
+/// before touching the whole system. Emits via the global `output` sink (the
+/// caller may print its own warn first). Returns true only when the escalation
+/// may proceed; on refusal the reason is already reported.
+pub fn confirmPkgSudo(token: []const u8) bool {
+    if (!output.stdinIsInteractive()) {
+        output.err("{s} is a PKG cask: it needs an interactive terminal for the sudo password. Re-run in a terminal.", .{token});
+        return false;
+    }
+    if (!output.confirmTyped("y", "This runs `sudo installer -target /` and installs system-wide. Continue? [y/N] ")) {
+        output.warn("Skipped {s}: PKG install not confirmed.", .{token});
+        return false;
+    }
+    return true;
+}
+
 /// Install a cask (DMG, ZIP, or PKG). When `download_only` is set, the
 /// flow stops after `<prefix>/cache/Cask/<file>` is sha-verified — no
 /// `/Applications` writes, no DB inserts.
@@ -1422,9 +1443,12 @@ fn installCask(
         return InstallError.CaskNotFound;
     }
 
-    // Warn for PKG casks (require sudo)
+    // PKG casks escalate to `sudo installer -target /`. Warn, then gate the
+    // escalation on a live TTY + confirmation before any download. `--download-only`
+    // never escalates, so it skips the gate.
     if (artifact_type == .pkg) {
         sink.warn("{s} is a PKG cask and requires sudo to install via macOS Installer.", .{cask.token});
+        if (!download_only and !confirmPkgSudo(cask.token)) return InstallError.CaskNotFound;
     }
 
     const prefix = atomic.maltPrefixOrAbort();

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -948,6 +948,7 @@ fn materializeTapCask(
 
     if (kind == .pkg) {
         sink.warn("{s} is a PKG cask and requires sudo to install via macOS Installer.", .{cask.token});
+        if (!download_only and !install_mod.confirmPkgSudo(cask.token)) return InstallError.CaskNotFound;
     }
 
     // `--download-only` for a cask-shaped tap entry reuses the cask

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -15,6 +15,7 @@ const atomic = @import("../fs/atomic.zig");
 const color = @import("../ui/color.zig");
 const output = @import("../ui/output.zig");
 const help = @import("help.zig");
+const install_mod = @import("install.zig");
 const formula_mod = @import("../core/formula.zig");
 
 /// `error.Aborted` is returned on every user-facing failure. The caller has
@@ -284,6 +285,18 @@ fn dispatchCask(
     if (parsed.dry_run) {
         output.info("Dry run: would reinstall {s} {s} from cask history", .{ token, target_pkg_version });
         return;
+    }
+
+    // A PKG-cask rollback re-runs `sudo installer -target /`. Gate it before the
+    // lock + reinstall so a refusal off a TTY changes nothing on disk.
+    const target_is_pkg = blk: {
+        var row = (cask_mod.lookupCaskVersion(allocator, db, token, target_pkg_version) catch null) orelse break :blk false;
+        defer row.deinit(allocator);
+        break :blk cask_mod.artifactTypeFromTag(row.artifact_type) == .pkg;
+    };
+    if (target_is_pkg) {
+        output.warn("{s} is a PKG cask and requires sudo to install via macOS Installer.", .{token});
+        if (!install_mod.confirmPkgSudo(token)) return error.Aborted;
     }
 
     const prefix = atomic.maltPrefixOrAbort();

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -1042,6 +1042,14 @@ fn upgradeCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []const 
         return;
     }
 
+    // A PKG-cask upgrade re-runs `sudo installer -target /`. Gate it on a live
+    // terminal + confirmation here, before the uninstall below, so a refusal
+    // off a TTY leaves the installed version untouched.
+    if (cask_mod.artifactTypeFromUrl(parsed_cask.url) == .pkg) {
+        output.warn("{s} is a PKG cask and requires sudo to install via macOS Installer.", .{token});
+        if (!install_mod.confirmPkgSudo(token)) return error.Aborted;
+    }
+
     output.info("Upgrading {s} {s} -> {s}...", .{ token, installed_version, parsed_cask.version });
 
     // Snapshot the pin BEFORE uninstall removes the cask row; re-apply

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -1160,9 +1160,12 @@ pub const CaskInstaller = struct {
     }
 
     fn installPkg(self: *CaskInstaller, pkg_path: []const u8) ![]const u8 {
-        // PKG installs require sudo — the caller must confirm
+        // The CLI gate already refused off a TTY and took the user's
+        // confirmation, so sudo here has a terminal to prompt on. Inherit
+        // stdio (not the captured `run`) so the password prompt and the
+        // installer's progress reach the user live, not as a post-mortem dump.
         const argv = [_][]const u8{ "sudo", "installer", "-pkg", pkg_path, "-target", "/" };
-        child_mod.runOrFail(self.io, self.allocator, &argv) catch return error.InstallFailed;
+        child_mod.runOrFailInherit(self.io, &argv) catch return error.InstallFailed;
         // PKG installs don't have a single app path — record the pkg location
         return std.fmt.allocPrint(self.allocator, "{s}", .{pkg_path}) catch return error.OutOfMemory;
     }

--- a/src/core/child.zig
+++ b/src/core/child.zig
@@ -35,6 +35,15 @@ pub const RunReport = struct {
     }
 };
 
+/// Collapse a wait `Term` to an exit code: the real code on a clean exit, a
+/// `255` sentinel for signal/stopped/unknown terminations.
+fn termToCode(term: std.process.Child.Term) u8 {
+    return switch (term) {
+        .exited => |c| c,
+        .signal, .stopped, .unknown => 255,
+    };
+}
+
 /// Carries one stream's drain result across the worker-thread boundary.
 const DrainCtx = struct {
     io: std.Io,
@@ -94,10 +103,7 @@ pub fn run(
     errdefer allocator.free(stderr_bytes);
 
     const term = child.wait(io) catch return error.WaitFailed;
-    const code: u8 = switch (term) {
-        .exited => |c| c,
-        .signal, .stopped, .unknown => 255,
-    };
+    const code = termToCode(term);
 
     return .{ .code = code, .stdout = stdout_bytes, .stderr = stderr_bytes };
 }
@@ -119,6 +125,18 @@ pub fn runOrFail(
     if (report.stderr.len > 0) stderr_file.writeStreamingAll(io, report.stderr) catch {};
     if (report.stdout.len > 0) stderr_file.writeStreamingAll(io, report.stdout) catch {};
     return error.NonZeroExit;
+}
+
+/// Spawn `argv` with the parent's stdin/stdout/stderr inherited, wait, and
+/// map a non-zero exit to `error.NonZeroExit`. Unlike `run`, nothing is
+/// captured — use this for a child that must talk to the terminal live, e.g.
+/// `sudo installer`, whose password prompt and progress must reach the user
+/// as they happen instead of being buffered and replayed only on failure.
+pub fn runOrFailInherit(io: std.Io, argv: []const []const u8) ChildError!void {
+    // Stdio defaults to `.inherit`; unlike `run`, we deliberately do not pipe.
+    var child = std.process.spawn(io, .{ .argv = argv }) catch return error.SpawnFailed;
+    const term = child.wait(io) catch return error.WaitFailed;
+    if (termToCode(term) != 0) return error.NonZeroExit;
 }
 
 fn drainPipe(
@@ -170,6 +188,27 @@ test "runOrFail returns SpawnFailed when program does not exist" {
     defer threaded.deinit();
     const argv = [_][]const u8{"/nonexistent/binary/malt_child_test"};
     try std.testing.expectError(ChildError.SpawnFailed, runOrFail(threaded.io(), std.testing.allocator, &argv));
+}
+
+test "runOrFailInherit returns void on exit code 0" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const argv = [_][]const u8{"/usr/bin/true"};
+    try runOrFailInherit(threaded.io(), &argv);
+}
+
+test "runOrFailInherit returns NonZeroExit on a non-zero exit" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const argv = [_][]const u8{"/usr/bin/false"};
+    try std.testing.expectError(ChildError.NonZeroExit, runOrFailInherit(threaded.io(), &argv));
+}
+
+test "runOrFailInherit returns SpawnFailed when program does not exist" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const argv = [_][]const u8{"/nonexistent/binary/malt_child_test"};
+    try std.testing.expectError(ChildError.SpawnFailed, runOrFailInherit(threaded.io(), &argv));
 }
 
 // Capture-content tests (dual-stream, non-zero exit) live in

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -427,6 +427,21 @@ pub fn skip(comptime fmt: []const u8, args: anytype) void {
     emitPrefixLine(.skip, fmt, args);
 }
 
+/// True only when `file` is an interactive terminal. A probe error is
+/// treated as non-interactive so an escalation gated on this refuses to
+/// proceed unattended. Kept file-parameterised so tests can drive it
+/// against a pipe without a real TTY.
+fn isInteractive(file: std.Io.File, io: std.Io) bool {
+    return file.isTty(io) catch false;
+}
+
+/// True when stdin is an interactive terminal. PKG-cask install probes this
+/// before escalating to `sudo`, whose password read stalls off a TTY.
+pub fn stdinIsInteractive() bool {
+    const stdin_file: std.Io.File = .{ .handle = std.posix.STDIN_FILENO, .flags = .{ .nonblocking = false } };
+    return isInteractive(stdin_file, pkg_io);
+}
+
 /// Read a single line from stdin and return true iff the trimmed input
 /// matches `expected` exactly. Prints `prompt` via `question` first.
 ///
@@ -434,8 +449,7 @@ pub fn skip(comptime fmt: []const u8, args: anytype) void {
 /// refuse to run unattended without an explicit `--yes` opt-in.
 pub fn confirmTyped(expected: []const u8, prompt: []const u8) bool {
     const stdin_file: std.Io.File = .{ .handle = std.posix.STDIN_FILENO, .flags = .{ .nonblocking = false } };
-    const is_tty = stdin_file.isTty(pkg_io) catch false;
-    if (!is_tty) return false;
+    if (!isInteractive(stdin_file, pkg_io)) return false;
 
     question("{s}", .{prompt});
     return readMatchingLine(stdin_file, pkg_io, expected);
@@ -923,4 +937,44 @@ test "readMatchingLine returns false when stdin is at EOF" {
 
     const stdin_file: std.Io.File = .{ .handle = fds[0], .flags = .{ .nonblocking = false } };
     try std.testing.expect(!readMatchingLine(stdin_file, std.Options.debug_io, "yes"));
+}
+
+// A pipe is never a terminal, so the PKG-cask sudo gate must classify it as
+// non-interactive and refuse escalation — the safety-critical direction: a
+// false positive here would let `sudo installer -target /` run unattended.
+test "isInteractive treats a non-terminal stdin as non-interactive" {
+    const fds = try pipeForTest();
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+
+    const stdin_file: std.Io.File = .{ .handle = fds[0], .flags = .{ .nonblocking = false } };
+    try std.testing.expect(!isInteractive(stdin_file, std.Options.debug_io));
+}
+
+// A probe error (here: a closed fd) must fail safe to non-interactive so the
+// sudo gate never proceeds on an ambiguous result.
+test "isInteractive fails safe to non-interactive when the tty probe errors" {
+    const fds = try pipeForTest();
+    _ = std.c.close(fds[0]);
+    _ = std.c.close(fds[1]);
+
+    const closed_file: std.Io.File = .{ .handle = fds[0], .flags = .{ .nonblocking = false } };
+    try std.testing.expect(!isInteractive(closed_file, std.Options.debug_io));
+}
+
+extern "c" fn openpty(amaster: *c_int, aslave: *c_int, name: ?[*]u8, termp: ?*anyopaque, winp: ?*anyopaque) c_int;
+
+// The positive direction: a real terminal (a pty slave) must read as
+// interactive. Without this only the refusal path is covered, so a probe
+// broken to always report non-interactive would ship green yet make every
+// PKG-cask install/upgrade/rollback impossible.
+test "isInteractive treats a pty slave as interactive" {
+    var master: c_int = undefined;
+    var slave: c_int = undefined;
+    if (openpty(&master, &slave, null, null, null) != 0) return error.SkipZigTest;
+    defer _ = std.c.close(master);
+    defer _ = std.c.close(slave);
+
+    const slave_file: std.Io.File = .{ .handle = slave, .flags = .{ .nonblocking = false } };
+    try std.testing.expect(isInteractive(slave_file, std.Options.debug_io));
 }


### PR DESCRIPTION
## Description

PKG-backed casks install by escalating to `sudo installer -pkg … -target /`, but malt only emitted a `warn()` before doing so - there was no confirmation and no terminal check. The consequences:

- **Off a TTY** (CI, piped stdin, `--json`/`--ndjson` consumers) `sudo` stalled waiting for a password it could never read, then failed with an opaque, buffered error only after a non-zero exit — a silent hang followed by a post-mortem dump.
- **On a TTY** the whole-system install ran after nothing more than a warning - a `sudo installer -target /` touches the entire machine, not the malt keg.

This adds one shared gate, `confirmPkgSudo`, in front of **every** verb that can reach `sudo installer`:

- **install** (brew-API and tap casks), **upgrade**, and **rollback** now all route through the same gate — consistent behaviour across every escalation path.
- Off a TTY it refuses up front with an actionable message ("re-run in a terminal") and never spawns `sudo`.
- On a TTY it requires an explicit `[y/N]` confirmation before the system-wide install.
- For `upgrade` and `rollback` the gate fires **before** any destructive step (the upgrade's uninstall, the rollback's reinstall), so a refusal leaves disk untouched.

The privileged call now inherits stdio (a new `child.runOrFailInherit`) so `sudo`'s password prompt and the installer's progress are live rather than buffered and replayed only on failure. `.dmg`/`.zip`/`.tar_gz` casks and all formula installs are unaffected - they never escalate.

## Related Issue

- None

## Notes for Reviewers

- None