### PR TITLE
fix(cli): stop consuming global flags after the -- separator

### DIFF
--- a/scripts/regressions/global-flag-parsing-ignores-double-dash.sh
+++ b/scripts/regressions/global-flag-parsing-ignores-double-dash.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Regression: tokens after the POSIX `--` end-of-options separator must reach
+# the child binary verbatim and must not flip malt's own output mode.
+#
+# The bug: the pre-dispatch global-flag loop in main() walked the whole argv
+# with no `--` boundary, so a global-looking flag after `--` (e.g. --json,
+# --dry-run) was consumed there — stripped from the subcommand's argv and
+# mutating malt's process-wide output state. `mt run <pkg> -- <args…>` lost
+# the child's flags and silently switched malt into JSON mode.
+#
+# Exercised fully offline via the installed path in run.execute: when
+# {MALT_PREFIX}/bin/<pkg> exists, run execs it directly and never hits the
+# network. Exits 0 when the child received the post-`--` flags verbatim,
+# non-zero (with expected-vs-actual argv) when they were stripped.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+# The shell harness runs the built binary, which `zig build test` does not
+# rebuild — build it here so a stale binary never masks the fix.
+zig build >/dev/null
+
+prefix="$(mktemp -d)"
+trap 'rm -rf "$prefix"' EXIT
+
+# Stub "child" that echoes exactly the argv it was handed.
+mkdir -p "$prefix/bin"
+cat >"$prefix/bin/echoargs" <<'EOF'
+#!/usr/bin/env bash
+printf 'ARGV:%s\n' "$*"
+EOF
+chmod +x "$prefix/bin/echoargs"
+
+# --offline is consumed by a separate inline branch in main (not the flag
+# map), so include it to guard that branch's boundary too.
+expected='ARGV:--json --offline --dry-run'
+out="$(MALT_PREFIX="$prefix" "$BIN" run echoargs -- --json --offline --dry-run 2>/dev/null)"
+if ! grep -q "$expected" <<<"$out"; then
+  echo "FAIL: post-'--' args stripped before child" >&2
+  echo "  expected: $expected" >&2
+  echo "  actual:   $out" >&2
+  exit 1
+fi
+
+echo "ok: run pass-through preserves post-'--' global-looking flags"

--- a/src/main.zig
+++ b/src/main.zig
@@ -219,6 +219,32 @@ pub fn applyGlobalFlag(arg: []const u8) bool {
     return true;
 }
 
+/// Index at which verbatim pass-through begins: the position of the first
+/// `--` at or after the command token. Everything from there on is the
+/// subcommand's business (e.g. `mt run <pkg> -- <child args>`), so the
+/// dispatch loop must stop applying global-flag semantics past this point.
+/// Returns null when there is no such separator. Pure so the boundary is
+/// testable without touching the process-wide `output.*` globals.
+fn passthroughStart(args: []const []const u8) ?usize {
+    var found_cmd = false;
+    for (args, 0..) |arg, i| {
+        if (!found_cmd) {
+            // Mirror the command-token detection in `main`: the first bare
+            // positional, or --help/-h/--version acting as a command.
+            if (!std.mem.startsWith(u8, arg, "-") or
+                std.mem.eql(u8, arg, "--help") or
+                std.mem.eql(u8, arg, "-h") or
+                std.mem.eql(u8, arg, "--version"))
+            {
+                found_cmd = true;
+            }
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--")) return i;
+    }
+    return null;
+}
+
 test "applyGlobalFlag --output-format=ndjson toggles ndjson mode" {
     const output = @import("ui/output.zig");
     const prior = output.isNdjson();
@@ -255,6 +281,46 @@ test "applyGlobalFlag returns false for unrecognised flags" {
 test "dispatch accepts AppCtx and routes help without panic" {
     const ctx: AppCtx = .{ .io = std.Options.debug_io, .environ = .empty };
     try dispatch(std.testing.allocator, &ctx, .help, &.{});
+}
+
+test "passthroughStart finds the first -- after the command token" {
+    const argv = &[_][]const u8{ "run", "jq", "--", "--json" };
+    try std.testing.expectEqual(@as(?usize, 2), passthroughStart(argv));
+}
+
+test "passthroughStart ignores -- appearing before any command" {
+    // A `--` with no command yet is not a pass-through boundary; the loop
+    // still needs to discover the command token first.
+    const argv = &[_][]const u8{ "--", "run" };
+    try std.testing.expectEqual(@as(?usize, null), passthroughStart(argv));
+}
+
+test "passthroughStart returns null when there is no separator" {
+    const argv = &[_][]const u8{ "run", "jq", "--json" };
+    try std.testing.expectEqual(@as(?usize, null), passthroughStart(argv));
+}
+
+test "passthroughStart treats help-as-command as the command token" {
+    // `--help`/`-h`/`--version` act as the command when seen first, so a
+    // later `--` still opens a pass-through region.
+    inline for (.{ "--help", "-h", "--version" }) |cmd| {
+        const argv = &[_][]const u8{ cmd, "--", "--json" };
+        try std.testing.expectEqual(@as(?usize, 1), passthroughStart(argv));
+    }
+}
+
+test "passthroughStart returns the first separator, not a later one" {
+    // A second `--` is child argv, not a fresh boundary; everything from the
+    // first `--` on is passed verbatim.
+    const argv = &[_][]const u8{ "run", "jq", "--", "-a", "--", "-b" };
+    try std.testing.expectEqual(@as(?usize, 2), passthroughStart(argv));
+}
+
+test "passthroughStart handles a global flag before the command token" {
+    // A leading global flag is not a command; the command is the first bare
+    // positional after it, and the `--` past that opens the region.
+    const argv = &[_][]const u8{ "--json", "run", "--", "-x" };
+    try std.testing.expectEqual(@as(?usize, 2), passthroughStart(argv));
 }
 
 test "applyGlobalFlag does not consume --offline (handled inline by main)" {
@@ -455,7 +521,17 @@ pub fn main(init: std.process.Init.Minimal) !void {
     defer filtered.deinit(allocator);
     var cmd_str: []const u8 = "";
     var found_cmd = false;
-    for (args) |arg| {
+    // Everything at/after the first `--` (once a command is seen) is the
+    // subcommand's business — POSIX end-of-options. Passing it verbatim stops
+    // global flags meant for a `run` child from being consumed here.
+    const passthrough = passthroughStart(args);
+    for (args, 0..) |arg, i| {
+        if (passthrough) |p| {
+            if (i >= p) {
+                try filtered.append(allocator, arg);
+                continue;
+            }
+        }
         if (!found_cmd and !std.mem.startsWith(u8, arg, "-")) {
             cmd_str = arg;
             found_cmd = true;


### PR DESCRIPTION
## Description

`mt run <pkg> -- <args>` now passes everything after the POSIX `--` separator to the child verbatim and no longer flips malt's own output mode from a flag that was meant for the child.

The pre-dispatch global-flag loop walked the entire argv with no `--` boundary, so a post-`--` `--json` / `--dry-run` / `--offline` was stripped from the subcommand's argv and mutated malt's process-wide output state - corrupting the child's arguments and silently switching malt into (e.g.) JSON mode.

The dispatch loop now stops applying global-flag semantics at the first `--` that follows the command token and passes the rest through verbatim. The boundary is POSIX end-of-options, applied universally rather than special-cased to `run`; the `--` separator itself is preserved so downstream parsing still locates the child arguments.

## Related Issue

- None

## Notes for Reviewers

- None