### PR TITLE
fix(cli/run): forward the run binary's exit code, args, and failures

### DIFF
--- a/scripts/e2e/run_download_roundtrip.sh
+++ b/scripts/e2e/run_download_roundtrip.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# scripts/e2e/run_download_roundtrip.sh
+#
+# Opt-in e2e for the `mt run` ephemeral DOWNLOAD path — the one surface the
+# offline regression can't reach (it drives the installed fast path). Does a
+# real download+extract+exec of a tiny dependency-free formula and asserts:
+#   1. the child's exit code is forwarded (both zero and non-zero), and
+#   2. the ephemeral extract under $MALT_PREFIX/tmp is cleaned up, since the
+#      exit-forwarding path calls std.process.exit and skips Zig `defer`s.
+#
+# Needs network (formulae API + GHCR) and a GitHub token, so it self-SKIPs
+# (exit 0) when no token is available — it must never flake a push. Run it
+# on demand, or in a job that exports MALT_GITHUB_TOKEN.
+#
+# Usage:
+#   MALT_GITHUB_TOKEN=$(gh auth token) ./scripts/e2e/run_download_roundtrip.sh
+#   MT_BIN=./zig-out/bin/malt RUN_E2E_PKG=tree ./scripts/e2e/run_download_roundtrip.sh
+set -uo pipefail
+
+MT_BIN="${MT_BIN:-./zig-out/bin/malt}"
+PKG="${RUN_E2E_PKG:-tree}" # dependency-free single binary; a single-bottle run suffices
+
+if [[ ! -x "$MT_BIN" ]]; then
+  echo "run-download: $MT_BIN not found — run 'zig build' first (or set MT_BIN)" >&2
+  exit 2
+fi
+
+# Mirror pre-push: borrow the gh token so the anonymous GitHub API cap doesn't
+# turn a real regression into a silent network failure.
+if [[ -z "${MALT_GITHUB_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
+  MALT_GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+  export MALT_GITHUB_TOKEN
+fi
+if [[ -z "${MALT_GITHUB_TOKEN:-}" ]]; then
+  echo "SKIP  run-download: no MALT_GITHUB_TOKEN (and gh not authed) — needs GitHub API/GHCR"
+  exit 0
+fi
+
+PREFIX=$(mktemp -d /tmp/mt-run-e2e.XXX)
+CACHE=$(mktemp -d /tmp/mc-run-e2e.XXX)
+trap 'rm -rf "$PREFIX" "$CACHE"' EXIT
+export MALT_PREFIX="$PREFIX"
+export MALT_CACHE="$CACHE"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+mkdir -p "$PREFIX/bin"
+
+# (1a) success path: exit 0 forwards through download+exec.
+"$MT_BIN" run "$PKG" -- --version >/dev/null
+code=$?
+[[ "$code" -eq 0 ]] || {
+  echo "FAIL run-download: expected 0 from '$PKG --version', got $code" >&2
+  exit 1
+}
+
+# (1b) failure path: a non-zero exit forwards. The pre-fix bug forced 0, so a
+# non-zero here is what distinguishes the fix — '-@' is a bogus flag $PKG rejects.
+"$MT_BIN" run "$PKG" -- -@ >/dev/null 2>&1
+code=$?
+[[ "$code" -ne 0 ]] || {
+  echo "FAIL run-download: expected non-zero from '$PKG -@', got 0 (exit code not forwarded)" >&2
+  exit 1
+}
+
+# (2) temp cleanup: no ephemeral extract may survive the run.
+shopt -s nullglob
+leftover=("$PREFIX"/tmp/run_*)
+[[ ${#leftover[@]} -eq 0 ]] || {
+  echo "FAIL run-download: ephemeral extract leaked: ${leftover[*]}" >&2
+  exit 1
+}
+
+echo "OK  run-download: exit codes forwarded and \$MALT_PREFIX/tmp is clean"

--- a/scripts/regressions/mt-run-discards-exit-code-truncates-args.sh
+++ b/scripts/regressions/mt-run-discards-exit-code-truncates-args.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Regression: `mt run` must forward the child's exit status and every
+# forwarded argument to the shell.
+#
+# The bug: execBinary waited fire-and-forget (`_ = child.wait() catch {}`),
+# so `mt run` always exited 0 regardless of what the run binary returned —
+# breaking `mt run … && …` and any scripted conditional. It also assembled
+# argv into a fixed [64]-slot stack buffer and clamped with `@min(len, 63)`,
+# silently dropping the 64th and later forwarded arguments.
+#
+# Drives the installed fast path ({prefix}/bin/<name>) so this is offline,
+# deterministic, and fast — that path routes through the same execBinary as
+# the download path.
+set -euo pipefail
+
+malt="$(pwd)/zig-out/bin/malt" # plain `zig build` first — shell regs don't rebuild
+[ -x "$malt" ] || {
+  echo "SKIP: build malt first (zig build)"
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+export MALT_PREFIX="$tmp/prefix"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+mkdir -p "$MALT_PREFIX/bin"
+
+# (a) exit-code forwarding: a fake bin that exits 7 makes `mt run` exit 7.
+printf '#!/bin/sh\nexit 7\n' >"$MALT_PREFIX/bin/faila"
+chmod +x "$MALT_PREFIX/bin/faila"
+set +e
+"$malt" run faila
+code=$?
+set -e
+[ "$code" -eq 7 ] || {
+  echo "FAIL(a): expected exit 7, got $code"
+  exit 1
+}
+
+# (c) argv not truncated at 63: forward all 100 args and count them.
+printf '#!/bin/sh\necho $#\n' >"$MALT_PREFIX/bin/countargs"
+chmod +x "$MALT_PREFIX/bin/countargs"
+# shellcheck disable=SC2046
+n="$("$malt" run countargs -- $(seq 1 100) | tail -1)"
+[ "$n" -eq 100 ] || {
+  echo "FAIL(c): expected 100 args, got $n"
+  exit 1
+}
+
+echo "OK"

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -7,6 +7,7 @@ const AppCtx = @import("../app_ctx.zig").AppCtx;
 const formula_mod = @import("../core/formula.zig");
 const bottle_mod = @import("../core/bottle.zig");
 const client_mod = @import("../net/client.zig");
+const child_mod = @import("../core/child.zig");
 const ghcr_mod = @import("../net/ghcr.zig");
 const api_mod = @import("../net/api.zig");
 const atomic = @import("../fs/atomic.zig");
@@ -104,13 +105,16 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     const prefix = atomic.maltPrefixOrAbort();
 
     var bin_buf: [512]u8 = undefined;
-    const installed_bin = std.fmt.bufPrint(&bin_buf, "{s}/bin/{s}", .{ prefix, parsed.pkg_name }) catch return;
+    const installed_bin = std.fmt.bufPrint(&bin_buf, "{s}/bin/{s}", .{ prefix, parsed.pkg_name }) catch {
+        output.err("Installed binary path too long for {s}", .{parsed.pkg_name});
+        return error.Aborted;
+    };
     std.Io.Dir.accessAbsolute(ctx.io, installed_bin, .{}) catch {
         return ephemeralRun(ctx, allocator, parsed.pkg_name, parsed.cmd_args, parsed.keep, prefix);
     };
 
     output.info("Running installed {s}...", .{parsed.pkg_name});
-    return try execBinary(ctx, allocator, installed_bin, parsed.cmd_args);
+    return try execBinary(ctx, allocator, installed_bin, parsed.cmd_args, null);
 }
 
 fn ephemeralRun(
@@ -128,7 +132,10 @@ fn ephemeralRun(
     http.offline = ctx.offline;
 
     var cache_buf: [512]u8 = undefined;
-    const cache_dir = std.fmt.bufPrint(&cache_buf, "{s}/cache", .{prefix}) catch return;
+    const cache_dir = std.fmt.bufPrint(&cache_buf, "{s}/cache", .{prefix}) catch {
+        output.err("Cache path too long for {s}", .{pkg_name});
+        return error.Aborted;
+    };
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
     api.base_url = ctx.mirrors.api_base;
     api.offline = ctx.offline;
@@ -191,7 +198,7 @@ fn ephemeralRun(
             // Drop the lock before exec so peers can run the cached binary unblocked.
             releaseKeepLock(ctx.io, &keep_lock);
             output.info("Running cached {s} {s}...", .{ pkg_name, formula.version });
-            return try execBinary(ctx, allocator, cached_bin, cmd_args);
+            return try execBinary(ctx, allocator, cached_bin, cmd_args, null);
         }
     }
 
@@ -239,10 +246,22 @@ fn ephemeralRun(
     if (std.mem.startsWith(u8, bottle.url, ghcr_prefix)) {
         const path = bottle.url[ghcr_prefix.len..];
         if (std.mem.indexOf(u8, path, "/blobs/")) |blobs_pos| {
-            repo = std.fmt.bufPrint(&repo_buf, "{s}", .{path[0..blobs_pos]}) catch return;
-            digest = std.fmt.bufPrint(&digest_buf, "{s}", .{path[blobs_pos + "/blobs/".len ..]}) catch return;
-        } else return;
-    } else return;
+            repo = std.fmt.bufPrint(&repo_buf, "{s}", .{path[0..blobs_pos]}) catch {
+                output.err("Bottle repo path too long for {s}", .{pkg_name});
+                return error.Aborted;
+            };
+            digest = std.fmt.bufPrint(&digest_buf, "{s}", .{path[blobs_pos + "/blobs/".len ..]}) catch {
+                output.err("Bottle digest too long for {s}", .{pkg_name});
+                return error.Aborted;
+            };
+        } else {
+            output.err("Bottle for '{s}' is not a GHCR blob reference: {s}", .{ pkg_name, bottle.url });
+            return error.Aborted;
+        }
+    } else {
+        output.err("Bottle for '{s}' is not a GHCR blob reference: {s}", .{ pkg_name, bottle.url });
+        return error.Aborted;
+    }
 
     output.info("Downloading {s} {s}...", .{ pkg_name, formula.version });
     _ = bottle_mod.download(ctx.io, allocator, &ghcr, &http, repo, digest, bottle.sha256, dest_dir, null, null) catch {
@@ -256,7 +275,10 @@ fn ephemeralRun(
         pkg_name,
         formula.version,
         pkg_name,
-    }) catch return;
+    }) catch {
+        output.err("Bottle binary path too long for {s}", .{pkg_name});
+        return error.Aborted;
+    };
 
     std.Io.Dir.accessAbsolute(ctx.io, bin_path, .{}) catch {
         output.err("Binary '{s}' not found in bottle", .{pkg_name});
@@ -264,7 +286,10 @@ fn ephemeralRun(
     };
 
     {
-        const f = std.Io.Dir.openFileAbsolute(ctx.io, bin_path, .{ .mode = .read_write }) catch return;
+        const f = std.Io.Dir.openFileAbsolute(ctx.io, bin_path, .{ .mode = .read_write }) catch {
+            output.err("Binary '{s}' not accessible in bottle", .{pkg_name});
+            return error.Aborted;
+        };
         defer f.close(ctx.io);
         // Bottles ship with +x; chmod is belt-and-suspenders. exec below surfaces EACCES.
         f.setPermissions(ctx.io, std.Io.File.Permissions.fromMode(0o755)) catch {};
@@ -283,24 +308,69 @@ fn ephemeralRun(
     // Separator is purely cosmetic; a closed stderr shouldn't kill the run.
     stderr.writeStreamingAll(ctx.io, "---\n") catch {};
 
-    try execBinary(ctx, allocator, bin_path, cmd_args);
+    // Pass owned_tmp so the exit path deletes the ephemeral extract; it is
+    // null on --keep, where the slot under {cache} is intentionally retained.
+    try execBinary(ctx, allocator, bin_path, cmd_args, owned_tmp);
 }
 
-fn execBinary(ctx: *const AppCtx, _: std.mem.Allocator, path: []const u8, cmd_args: []const []const u8) !void {
-    // Build argv: [path] ++ cmd_args
-    var argv_buf: [64][]const u8 = undefined;
-    argv_buf[0] = path;
-    const argc = @min(cmd_args.len, argv_buf.len - 1);
-    for (cmd_args[0..argc], 1..) |arg, i| {
-        argv_buf[i] = arg;
-    }
+/// Assemble `[path] ++ cmd_args` into a freshly allocated argv. Heap-backed
+/// (not a fixed stack buffer) so no forwarded argument is ever dropped.
+fn buildArgv(allocator: std.mem.Allocator, path: []const u8, cmd_args: []const []const u8) ![]const []const u8 {
+    const argv = try allocator.alloc([]const u8, cmd_args.len + 1);
+    argv[0] = path;
+    for (cmd_args, 1..) |arg, i| argv[i] = arg;
+    return argv;
+}
 
-    var child = std.process.spawn(ctx.io, .{ .argv = argv_buf[0 .. argc + 1] }) catch {
+fn execBinary(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    cmd_args: []const []const u8,
+    cleanup_dir: ?[]const u8,
+) !void {
+    const argv = try buildArgv(allocator, path, cmd_args);
+    defer allocator.free(argv);
+
+    var child = std.process.spawn(ctx.io, .{ .argv = argv }) catch {
         output.err("Failed to execute binary", .{});
         return error.Aborted;
     };
-    // Ephemeral run is fire-and-forget; child exit code isn't surfaced to the shell.
-    _ = child.wait(ctx.io) catch {};
+    const term = child.wait(ctx.io) catch {
+        output.err("Failed to wait for {s}", .{path});
+        return error.Aborted;
+    };
+    // The child has exited, so its binary is no longer mapped: delete the
+    // ephemeral extract dir here, because std.process.exit below skips the
+    // caller's `defer` cleanup. Errors on error-return paths are left to it.
+    if (cleanup_dir) |dir| atomic.cleanupTempDir(ctx.io, dir);
+    // Forward the child's real exit status so `mt run … && …` and CI
+    // conditionals see what the run binary returned. exec wrapper has no
+    // return channel for arbitrary codes, so exit directly.
+    std.process.exit(child_mod.termToCode(term));
+}
+
+test "buildArgv prepends path and forwards every arg" {
+    const allocator = std.testing.allocator;
+    // 100 args past the old 63-slot cap — none may be dropped.
+    var cmd_args: [100][]const u8 = undefined;
+    for (&cmd_args, 0..) |*a, i| a.* = if (i % 2 == 0) "a" else "b";
+
+    const argv = try buildArgv(allocator, "/opt/malt/bin/foo", &cmd_args);
+    defer allocator.free(argv);
+
+    try std.testing.expectEqual(@as(usize, 101), argv.len);
+    try std.testing.expectEqualStrings("/opt/malt/bin/foo", argv[0]);
+    try std.testing.expectEqualStrings("a", argv[1]);
+    try std.testing.expectEqualStrings("b", argv[100]);
+}
+
+test "buildArgv with no cmd args is just the path" {
+    const allocator = std.testing.allocator;
+    const argv = try buildArgv(allocator, "/bin/x", &[_][]const u8{});
+    defer allocator.free(argv);
+    try std.testing.expectEqual(@as(usize, 1), argv.len);
+    try std.testing.expectEqualStrings("/bin/x", argv[0]);
 }
 
 test "parseArgs splits at double dash" {

--- a/src/core/child.zig
+++ b/src/core/child.zig
@@ -37,7 +37,7 @@ pub const RunReport = struct {
 
 /// Collapse a wait `Term` to an exit code: the real code on a clean exit, a
 /// `255` sentinel for signal/stopped/unknown terminations.
-fn termToCode(term: std.process.Child.Term) u8 {
+pub fn termToCode(term: std.process.Child.Term) u8 {
     return switch (term) {
         .exited => |c| c,
         .signal, .stopped, .unknown => 255,

--- a/src/main.zig
+++ b/src/main.zig
@@ -219,12 +219,10 @@ pub fn applyGlobalFlag(arg: []const u8) bool {
     return true;
 }
 
-/// Index at which verbatim pass-through begins: the position of the first
-/// `--` at or after the command token. Everything from there on is the
-/// subcommand's business (e.g. `mt run <pkg> -- <child args>`), so the
-/// dispatch loop must stop applying global-flag semantics past this point.
-/// Returns null when there is no such separator. Pure so the boundary is
-/// testable without touching the process-wide `output.*` globals.
+/// First index that passes through verbatim — the `--` at or after the
+/// command token, past which argv belongs to the subcommand (e.g. a `run`
+/// child). Pure, so the boundary is unit-testable without touching the
+/// `output.*` globals that `applyGlobalFlag` mutates.
 fn passthroughStart(args: []const []const u8) ?usize {
     var found_cmd = false;
     for (args, 0..) |arg, i| {
@@ -521,9 +519,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     defer filtered.deinit(allocator);
     var cmd_str: []const u8 = "";
     var found_cmd = false;
-    // Everything at/after the first `--` (once a command is seen) is the
-    // subcommand's business — POSIX end-of-options. Passing it verbatim stops
-    // global flags meant for a `run` child from being consumed here.
+    // Stop global-flag parsing at the POSIX `--`; the rest is the subcommand's.
     const passthrough = passthroughStart(args);
     for (args, 0..) |arg, i| {
         if (passthrough) |p| {


### PR DESCRIPTION
## Description

`mt run` now behaves like a real exec wrapper.

- **Exit code is forwarded.** The run binary's termination status now becomes `mt run`'s own exit code, so `mt run … && …` and CI conditionals finally see what the tool returned. Previously every run reported success (exit 0) regardless of outcome.
- **All arguments reach the child.** Forwarded argv is no longer capped.
- **Internal bail-outs are loud.** Paths that used to swallow a failure and exit 0 with no output, now print a diagnostic and fail. No more silent no-op "success".
- **No leaked extracts.** Because the exit path bypasses Zig's deferred cleanup, the ephemeral extract under the prefix is now removed explicitly before exit, so an uninstalled `mt run <pkg>` no longer leaves its unpacked bottle behind.

## Related Issue

- None

## Notes for Reviewers

- None