### PR TITLE
fix(bundle): escape names and versions in JSON, Brewfile and receipt emitters

### DIFF
--- a/scripts/regressions/emitters-dont-escape-names-versions.sh
+++ b/scripts/regressions/emitters-dont-escape-names-versions.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Regression: the JSON, Brewfile and install-receipt emitters must escape the
+# names, versions and taps they interpolate, so the emit -> parse round-trip
+# survives a `"` or `\` byte in any of those fields.
+#
+# The bug: all three emitters wrote DB/user strings into quoted output with a
+# raw `{s}` and no escaping. `emitJson`, `brewfile_emit.emit` and
+# `writeInstallReceiptFull` each produced malformed JSON/Brewfile the moment a
+# field held a quote or backslash, so `parse(emit(m))` no longer equalled `m`
+# (JSON re-parse failed; the Brewfile value truncated at the first quote).
+#
+# No CLI surface round-trips a quoted identifier offline without standing up a
+# tap or seeding the DB with an adversarial name, so the guarantee is pinned by
+# the colocated inline tests (`lib_tests`). This script builds and runs only
+# that binary: it stays well under 30s and needs no network. Pre-fix, the three
+# round-trip tests fail and the binary exits non-zero; the fix flips it green.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+# If any emitter's escaper or its round-trip test is dropped, the unit binary
+# would go green vacuously. Fail loudly instead: both the escaper and its test
+# must be present in each source file.
+declare -a GUARDS=(
+  "src/core/bundle/manifest.zig|writeJsonString|the JSON emitter escaper"
+  "src/core/bundle/manifest.zig|round-trip survives quotes and backslashes|the JSON round-trip test"
+  "src/core/bundle/brewfile_emit.zig|writeRubyString|the Brewfile emitter escaper"
+  "src/core/bundle/brewfile.zig|decodeEscapes|the Brewfile escape decoder"
+  "src/core/bundle/brewfile.zig|Brewfile round-trip preserves quotes|the Brewfile round-trip test"
+  "src/core/cellar.zig|jsonEscapeInto|the install-receipt escaper"
+  "src/core/cellar.zig|install receipt with quoted tap and version|the install-receipt round-trip test"
+)
+for g in "${GUARDS[@]}"; do
+  IFS='|' read -r file needle label <<<"$g"
+  if ! grep -Fqs -- "$needle" "$file"; then
+    echo "FAIL: $label is missing from $file" >&2
+    exit 1
+  fi
+done
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+# Always rebuild so the binary reflects current source — a prebuilt lib_tests
+# could predate the fix. Zig's cache makes a no-op rebuild cheap.
+if ! zig build test-bin >/dev/null 2>&1; then
+  echo "FAIL: could not build the unit test binary (zig build test-bin)" >&2
+  exit 1
+fi
+
+# The runner has no per-test filter, so run the inline suite and judge by exit
+# code. Pre-fix, the three round-trip tests fail and this binary exits non-zero.
+OUT=$("$BIN" 2>&1) && STATUS=0 || STATUS=$?
+if [[ "$STATUS" -ne 0 ]]; then
+  echo "FAIL: an emitter round-trip did not survive quote/backslash bytes" >&2
+  printf '%s\n' "$OUT" | grep -iE "failed|leaked|panic" >&2 || true
+  exit 1
+fi
+
+echo "PASS: JSON, Brewfile and receipt emitters escape names/versions/taps"

--- a/src/core/bundle/brewfile.zig
+++ b/src/core/bundle/brewfile.zig
@@ -307,20 +307,70 @@ fn expectString(a: std.mem.Allocator, s: []const u8, cursor: *usize) BrewfileErr
     if (quote != '"' and quote != '\'') return BrewfileError.ExpectedString;
     cursor.* += 1;
     const start = cursor.*;
+    var saw_escape = false;
     while (cursor.* < s.len) {
         const c = s[cursor.*];
         if (c == '\\' and cursor.* + 1 < s.len) {
+            saw_escape = true;
             cursor.* += 2;
             continue;
         }
         if (c == quote) {
             const raw = s[start..cursor.*];
             cursor.* += 1;
-            return a.dupe(u8, raw) catch return BrewfileError.OutOfMemory;
+            // Faithful round-trip: undo the emitter's `\"`/`\\` escaping. Common
+            // case (no backslash) keeps the original raw-span dup, no scan.
+            if (!saw_escape) return a.dupe(u8, raw) catch return BrewfileError.OutOfMemory;
+            return decodeEscapes(a, raw, quote) catch return BrewfileError.OutOfMemory;
         }
         cursor.* += 1;
     }
     return BrewfileError.UnterminatedString;
+}
+
+/// Decode the escapes the emitter writes, per Ruby quote semantics. Unknown
+/// escapes stay verbatim, so no bytes are lost and malt stays a narrow subset
+/// rather than a full Ruby string evaluator. Escapes never grow the string, so
+/// the raw length is a safe upper bound.
+fn decodeEscapes(a: std.mem.Allocator, raw: []const u8, quote: u8) BrewfileError![]const u8 {
+    const out = a.alloc(u8, raw.len) catch return BrewfileError.OutOfMemory;
+    var w: usize = 0;
+    var i: usize = 0;
+    while (i < raw.len) {
+        if (raw[i] == '\\' and i + 1 < raw.len) {
+            if (decodeEscape(quote, raw[i + 1])) |byte| {
+                out[w] = byte;
+                w += 1;
+                i += 2;
+                continue;
+            }
+        }
+        out[w] = raw[i];
+        w += 1;
+        i += 1;
+    }
+    return out[0..w];
+}
+
+/// The byte `\c` decodes to under `quote`'s Ruby semantics, or null when `\c`
+/// is not a recognized escape (kept verbatim). Single quotes process only `\\`
+/// and `\'`; double quotes also decode `\"` and the `\n`/`\r`/`\t` whitespace
+/// controls the emitter escapes.
+fn decodeEscape(quote: u8, c: u8) ?u8 {
+    if (quote == '\'') return switch (c) {
+        '\\' => '\\',
+        '\'' => '\'',
+        else => null,
+    };
+    return switch (c) {
+        '\\' => '\\',
+        '\'' => '\'',
+        '"' => '"',
+        'n' => '\n',
+        'r' => '\r',
+        't' => '\t',
+        else => null,
+    };
 }
 
 fn expectBool(s: []const u8, cursor: *usize) BrewfileError!bool {
@@ -457,6 +507,157 @@ test "double-quoted interpolation is rejected, single-quoted is literal" {
     defer m.deinit();
     try testing.expectEqual(@as(usize, 1), m.formulas.len);
     try testing.expectEqualStrings("foo#{bar}", m.formulas[0].name);
+}
+
+test "Brewfile round-trip preserves quotes, backslashes and newlines in names" {
+    const emit = @import("brewfile_emit.zig");
+    // Build a manifest whose fields carry quote/backslash/newline bytes, emit
+    // it, then re-parse: a faithful round-trip must return the same bytes, not a
+    // value truncated at the first unescaped quote or split across a raw newline.
+    var src = manifest_mod.Manifest.init(testing.allocator);
+    defer src.deinit();
+    const a = src.allocator();
+
+    const taps = try a.alloc([]const u8, 1);
+    taps[0] = try a.dupe(u8, "t\"p");
+    src.taps = taps;
+    const formulas = try a.alloc(manifest_mod.FormulaEntry, 1);
+    formulas[0] = .{ .name = try a.dupe(u8, "a\"b\\c\nd"), .version = try a.dupe(u8, "1\"2") };
+    src.formulas = formulas;
+    const casks = try a.alloc(manifest_mod.CaskEntry, 1);
+    casks[0] = .{ .name = try a.dupe(u8, "c\\k") };
+    src.casks = casks;
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try emit.emit(src, &aw.writer);
+
+    var back = try parse(testing.allocator, aw.written(), null);
+    defer back.deinit();
+
+    try testing.expectEqualStrings("t\"p", back.taps[0]);
+    try testing.expectEqualStrings("a\"b\\c\nd", back.formulas[0].name);
+    try testing.expectEqualStrings("1\"2", back.formulas[0].version.?);
+    try testing.expectEqualStrings("c\\k", back.casks[0].name);
+}
+
+test "single quotes decode only Ruby's literal escapes" {
+    // Ruby single-quoted strings process only \\ and \'; every other backslash
+    // (notably \") stays literal. Double quotes still unescape \".
+    var m = try parse(
+        testing.allocator,
+        "tap 'e\\'f'\nbrew 'a\\\"b'\ncask 'c\\\\d'\n",
+        null,
+    );
+    defer m.deinit();
+
+    try testing.expectEqualStrings("e'f", m.taps[0]); // \' -> '
+    try testing.expectEqualStrings("a\\\"b", m.formulas[0].name); // \" stays literal
+    try testing.expectEqualStrings("c\\d", m.casks[0].name); // \\ -> \
+
+    // Double-quoted \" still collapses, so the emit->parse round-trip holds.
+    var d = try parse(testing.allocator, "brew \"a\\\"b\"\n", null);
+    defer d.deinit();
+    try testing.expectEqualStrings("a\"b", d.formulas[0].name);
+}
+
+test "Brewfile emit output format is byte-stable for a plain manifest" {
+    // Golden lock for the escaper refactor: escape-free input must keep its
+    // exact single-line layout.
+    const emit = @import("brewfile_emit.zig");
+    const original =
+        \\tap "homebrew/core"
+        \\brew "wget"
+        \\brew "jq", version: "1.7"
+        \\cask "ghostty"
+    ;
+    var m = try parse(testing.allocator, original, null);
+    defer m.deinit();
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try emit.emit(m, &aw.writer);
+
+    const expected =
+        \\tap "homebrew/core"
+        \\brew "wget"
+        \\brew "jq", version: "1.7"
+        \\cask "ghostty"
+        \\
+    ;
+    try testing.expectEqualStrings(expected, aw.written());
+}
+
+test "Brewfile round-trip covers CR, tab, empty and utf-8 values" {
+    const emit = @import("brewfile_emit.zig");
+    var src = manifest_mod.Manifest.init(testing.allocator);
+    defer src.deinit();
+    const a = src.allocator();
+
+    const formulas = try a.alloc(manifest_mod.FormulaEntry, 4);
+    formulas[0] = .{ .name = try a.dupe(u8, "a\r\tb") }; // CR + tab escape/decode
+    formulas[1] = .{ .name = try a.dupe(u8, "") }; // empty value
+    formulas[2] = .{ .name = try a.dupe(u8, "cafÉ🍺") }; // raw UTF-8 passes through
+    formulas[3] = .{ .name = try a.dupe(u8, "trail\\") }; // trailing backslash -> \\
+    src.formulas = formulas;
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try emit.emit(src, &aw.writer);
+
+    // Emitted text stays single-line-per-entry: one line per formula + trailing \n.
+    try testing.expectEqual(@as(usize, 4), std.mem.count(u8, aw.written(), "\n"));
+
+    var back = try parse(testing.allocator, aw.written(), null);
+    defer back.deinit();
+    try testing.expectEqual(@as(usize, 4), back.formulas.len);
+    try testing.expectEqualStrings("a\r\tb", back.formulas[0].name);
+    try testing.expectEqualStrings("", back.formulas[1].name);
+    try testing.expectEqualStrings("cafÉ🍺", back.formulas[2].name);
+    try testing.expectEqualStrings("trail\\", back.formulas[3].name);
+}
+
+test "unknown double-quote escapes are kept verbatim" {
+    // malt is a narrow subset, not a full Ruby evaluator: \z is not a known
+    // escape, so the backslash is preserved rather than dropped.
+    var m = try parse(testing.allocator, "brew \"a\\zb\"\n", null);
+    defer m.deinit();
+    try testing.expectEqualStrings("a\\zb", m.formulas[0].name);
+}
+
+test "Brewfile round-trips every byte value in a name" {
+    // Exhaustive proof that leaving rare control bytes unescaped is safe: with
+    // the value always interior (`brew "..."`), no byte can break line splitting
+    // (only \n does, and it is escaped) or get eaten by trim (VT/FF are interior,
+    // never leading/trailing). Every byte 0..255 must survive emit->parse.
+    const emit = @import("brewfile_emit.zig");
+    var b: usize = 0;
+    while (b < 256) : (b += 1) {
+        var src = manifest_mod.Manifest.init(testing.allocator);
+        defer src.deinit();
+        const a = src.allocator();
+        const name = try a.alloc(u8, 3);
+        name[0] = 'x';
+        name[1] = @intCast(b);
+        name[2] = 'y';
+        const formulas = try a.alloc(manifest_mod.FormulaEntry, 1);
+        formulas[0] = .{ .name = name };
+        src.formulas = formulas;
+
+        var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+        defer aw.deinit();
+        try emit.emit(src, &aw.writer);
+
+        var back = parse(testing.allocator, aw.written(), null) catch |e| {
+            std.debug.print("byte 0x{x:0>2} failed to parse: {s}\n", .{ b, @errorName(e) });
+            return e;
+        };
+        defer back.deinit();
+        testing.expectEqualStrings(name, back.formulas[0].name) catch |e| {
+            std.debug.print("byte 0x{x:0>2} did not round-trip\n", .{b});
+            return e;
+        };
+    }
 }
 
 test "diagnostics records the 1-based line of a parse failure" {

--- a/src/core/bundle/brewfile_emit.zig
+++ b/src/core/bundle/brewfile_emit.zig
@@ -3,17 +3,52 @@
 const std = @import("std");
 const manifest_mod = @import("manifest.zig");
 
+/// Write `s` as a double-quoted Ruby string. Brewfile is line-based, so `"`,
+/// `\` and the whitespace controls `\n`/`\r`/`\t` are escaped — `\n`/`\r` must
+/// be, to keep the value on one line, and `\t` is for clean output; the parser's
+/// `expectString` decodes exactly these back. Rarer control bytes still
+/// round-trip as raw bytes through the line parser, so they are left as-is.
+fn writeRubyString(w: *std.Io.Writer, s: []const u8) !void {
+    try w.writeByte('"');
+    var start: usize = 0;
+    for (s, 0..) |byte, i| {
+        const esc: ?[]const u8 = switch (byte) {
+            '"' => "\\\"",
+            '\\' => "\\\\",
+            '\n' => "\\n",
+            '\r' => "\\r",
+            '\t' => "\\t",
+            else => null,
+        };
+        if (esc) |e| {
+            if (i > start) try w.writeAll(s[start..i]);
+            try w.writeAll(e);
+            start = i + 1;
+        }
+    }
+    if (start < s.len) try w.writeAll(s[start..]);
+    try w.writeByte('"');
+}
+
 pub fn emit(manifest: manifest_mod.Manifest, writer: *std.Io.Writer) !void {
     for (manifest.taps) |t| {
-        try writer.print("tap \"{s}\"\n", .{t});
+        try writer.writeAll("tap ");
+        try writeRubyString(writer, t);
+        try writer.writeAll("\n");
     }
     for (manifest.formulas) |f| {
-        try writer.print("brew \"{s}\"", .{f.name});
-        if (f.version) |v| try writer.print(", version: \"{s}\"", .{v});
+        try writer.writeAll("brew ");
+        try writeRubyString(writer, f.name);
+        if (f.version) |v| {
+            try writer.writeAll(", version: ");
+            try writeRubyString(writer, v);
+        }
         if (f.restart_service) try writer.writeAll(", restart_service: true");
         try writer.writeAll("\n");
     }
     for (manifest.casks) |c| {
-        try writer.print("cask \"{s}\"\n", .{c.name});
+        try writer.writeAll("cask ");
+        try writeRubyString(writer, c.name);
+        try writer.writeAll("\n");
     }
 }

--- a/src/core/bundle/manifest.zig
+++ b/src/core/bundle/manifest.zig
@@ -158,16 +158,49 @@ pub fn parseJson(parent: std.mem.Allocator, json_text: []const u8) ManifestError
     return manifest;
 }
 
+/// Write `s` as a quoted JSON string literal (RFC 8259 escapes). Duplicated
+/// from `ui.output.jsonStr` on purpose: `core → ui` is an upward layer edge,
+/// so the ~15 lines are copied rather than imported.
+fn writeJsonString(w: *std.Io.Writer, s: []const u8) !void {
+    try w.writeByte('"');
+    var start: usize = 0;
+    for (s, 0..) |byte, i| {
+        const escape: ?[]const u8 = switch (byte) {
+            '"' => "\\\"",
+            '\\' => "\\\\",
+            '\n' => "\\n",
+            '\r' => "\\r",
+            '\t' => "\\t",
+            0x08 => "\\b",
+            0x0c => "\\f",
+            else => null,
+        };
+        if (escape) |esc| {
+            if (i > start) try w.writeAll(s[start..i]);
+            try w.writeAll(esc);
+            start = i + 1;
+        } else if (byte < 0x20) {
+            if (i > start) try w.writeAll(s[start..i]);
+            var hex_buf: [6]u8 = undefined;
+            const hex = std.fmt.bufPrint(&hex_buf, "\\u{x:0>4}", .{byte}) catch unreachable;
+            try w.writeAll(hex);
+            start = i + 1;
+        }
+    }
+    if (start < s.len) try w.writeAll(s[start..]);
+    try w.writeByte('"');
+}
+
 pub fn emitJson(manifest: Manifest, writer: *std.Io.Writer) !void {
-    try writer.writeAll("{\n");
-    try writer.print("  \"name\": \"{s}\",\n", .{manifest.name});
-    try writer.print("  \"version\": {d}", .{manifest.version});
+    try writer.writeAll("{\n  \"name\": ");
+    try writeJsonString(writer, manifest.name);
+    try writer.print(",\n  \"version\": {d}", .{manifest.version});
 
     if (manifest.taps.len > 0) {
         try writer.writeAll(",\n  \"taps\": [");
         for (manifest.taps, 0..) |t, i| {
             if (i != 0) try writer.writeAll(", ");
-            try writer.print("\"{s}\"", .{t});
+            try writeJsonString(writer, t);
         }
         try writer.writeAll("]");
     }
@@ -176,8 +209,12 @@ pub fn emitJson(manifest: Manifest, writer: *std.Io.Writer) !void {
         try writer.writeAll(",\n  \"formulas\": [");
         for (manifest.formulas, 0..) |f, i| {
             if (i != 0) try writer.writeAll(", ");
-            try writer.print("{{\"name\": \"{s}\"", .{f.name});
-            if (f.version) |v| try writer.print(", \"version\": \"{s}\"", .{v});
+            try writer.writeAll("{\"name\": ");
+            try writeJsonString(writer, f.name);
+            if (f.version) |v| {
+                try writer.writeAll(", \"version\": ");
+                try writeJsonString(writer, v);
+            }
             if (f.restart_service) try writer.writeAll(", \"restart_service\": true");
             try writer.writeAll("}");
         }
@@ -188,7 +225,9 @@ pub fn emitJson(manifest: Manifest, writer: *std.Io.Writer) !void {
         try writer.writeAll(",\n  \"casks\": [");
         for (manifest.casks, 0..) |c, i| {
             if (i != 0) try writer.writeAll(", ");
-            try writer.print("{{\"name\": \"{s}\"}}", .{c.name});
+            try writer.writeAll("{\"name\": ");
+            try writeJsonString(writer, c.name);
+            try writer.writeAll("}");
         }
         try writer.writeAll("]");
     }
@@ -197,7 +236,8 @@ pub fn emitJson(manifest: Manifest, writer: *std.Io.Writer) !void {
         try writer.writeAll(",\n  \"services\": [");
         for (manifest.services, 0..) |s, i| {
             if (i != 0) try writer.writeAll(", ");
-            try writer.print("{{\"name\": \"{s}\"", .{s.name});
+            try writer.writeAll("{\"name\": ");
+            try writeJsonString(writer, s.name);
             if (s.auto_start) try writer.writeAll(", \"auto_start\": true");
             try writer.writeAll("}");
         }
@@ -259,6 +299,146 @@ test "reject version mismatch" {
 test "reject malformed json" {
     const testing = std.testing;
     try testing.expectError(ManifestError.MalformedJson, parseJson(testing.allocator, "not json at all"));
+}
+
+test "round-trip survives quotes and backslashes in every string field" {
+    const testing = std.testing;
+    // std.json decodes \" \\ \n \t on the way in, so these fields hold raw
+    // quote/backslash/control bytes — the exact case a raw {s} emitter corrupts.
+    // The name carries a newline+tab to also exercise the control-char escapes.
+    const json =
+        \\{"name":"a\"b\\c\n\t","version":1,"taps":["t\"p"],"formulas":[{"name":"w\"g","version":"1\\2"}],"casks":[{"name":"c\"k"}],"services":[{"name":"s\"v","auto_start":true}]}
+    ;
+    var m1 = try parseJson(testing.allocator, json);
+    defer m1.deinit();
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try emitJson(m1, &aw.writer);
+
+    var m2 = try parseJson(testing.allocator, aw.written());
+    defer m2.deinit();
+
+    try testing.expectEqualStrings(m1.name, m2.name);
+    try testing.expectEqualStrings(m1.taps[0], m2.taps[0]);
+    try testing.expectEqualStrings(m1.formulas[0].name, m2.formulas[0].name);
+    try testing.expectEqualStrings(m1.formulas[0].version.?, m2.formulas[0].version.?);
+    try testing.expectEqualStrings(m1.casks[0].name, m2.casks[0].name);
+    try testing.expectEqualStrings(m1.services[0].name, m2.services[0].name);
+}
+
+test "emitJson output format is byte-stable for a plain manifest" {
+    // Golden lock: the escaper refactor must not drift the emitted layout for
+    // ordinary (escape-free) input. Any format change fails here loudly.
+    const testing = std.testing;
+    const json =
+        \\{"name":"dev","version":1,"taps":["homebrew/core"],"formulas":[{"name":"wget"},{"name":"jq","version":"1.7","restart_service":true}],"casks":[{"name":"ghostty"}],"services":[{"name":"pg","auto_start":true}]}
+    ;
+    var m = try parseJson(testing.allocator, json);
+    defer m.deinit();
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try emitJson(m, &aw.writer);
+
+    const expected =
+        \\{
+        \\  "name": "dev",
+        \\  "version": 1,
+        \\  "taps": ["homebrew/core"],
+        \\  "formulas": [{"name": "wget"}, {"name": "jq", "version": "1.7", "restart_service": true}],
+        \\  "casks": [{"name": "ghostty"}],
+        \\  "services": [{"name": "pg", "auto_start": true}]
+        \\}
+        \\
+    ;
+    try testing.expectEqualStrings(expected, aw.written());
+}
+
+test "round-trip covers control chars, utf-8, empty strings and multiple entries" {
+    const testing = std.testing;
+    // The name mixes \b (0x08), \f (0x0c) named escapes with a raw UTF-8
+    // sequence; taps/version/cask carry empty strings. Every value must
+    // survive emit->parse, and the emitted text must be valid JSON.
+    const json =
+        \\{"name":"\b\fé🍺","version":1,"taps":["",""],"formulas":[{"name":"a\"1","version":""},{"name":"b\\2"}],"casks":[{"name":""}],"services":[{"name":"s\ty"}]}
+    ;
+    var m1 = try parseJson(testing.allocator, json);
+    defer m1.deinit();
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try emitJson(m1, &aw.writer);
+
+    // Emitted text is well-formed JSON (independent of our own parser).
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, aw.written(), .{});
+    parsed.deinit();
+
+    var m2 = try parseJson(testing.allocator, aw.written());
+    defer m2.deinit();
+
+    try testing.expectEqualStrings(m1.name, m2.name);
+    try testing.expectEqual(@as(usize, 2), m2.taps.len);
+    try testing.expectEqualStrings("", m2.taps[0]);
+    try testing.expectEqualStrings("a\"1", m2.formulas[0].name);
+    try testing.expectEqualStrings("", m2.formulas[0].version.?);
+    try testing.expectEqualStrings("b\\2", m2.formulas[1].name);
+    try testing.expectEqualStrings("", m2.casks[0].name);
+    try testing.expectEqualStrings("s\ty", m2.services[0].name);
+}
+
+test "writeJsonString escapes unnamed control bytes as \\uXXXX and round-trips" {
+    const testing = std.testing;
+    // Build in-memory so the raw 0x01/0x1f bytes never sit in a source literal.
+    var m1 = Manifest.init(testing.allocator);
+    defer m1.deinit();
+    const a = m1.allocator();
+    m1.name = try a.dupe(u8, "x\x01y\x1fz");
+
+    var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer aw.deinit();
+    try emitJson(m1, &aw.writer);
+
+    // The two unnamed controls must appear as \u0001 / \u001f, not raw bytes.
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "\\u0001") != null);
+    try testing.expect(std.mem.indexOf(u8, aw.written(), "\\u001f") != null);
+    try testing.expect(std.mem.indexOfScalar(u8, aw.written(), 0x01) == null);
+
+    var m2 = try parseJson(testing.allocator, aw.written());
+    defer m2.deinit();
+    try testing.expectEqualStrings(m1.name, m2.name);
+}
+
+test "emitJson round-trips every ASCII byte in a name" {
+    // Exhaustive over 0x00..0x7f — the range that is a valid lone byte in a JSON
+    // string (higher bytes are only legal as multi-byte UTF-8). Every one must
+    // emit as valid JSON and survive the round-trip.
+    const testing = std.testing;
+    var b: usize = 0;
+    while (b < 0x80) : (b += 1) {
+        var m1 = Manifest.init(testing.allocator);
+        defer m1.deinit();
+        const a = m1.allocator();
+        const name = try a.alloc(u8, 3);
+        name[0] = 'x';
+        name[1] = @intCast(b);
+        name[2] = 'y';
+        m1.name = name;
+
+        var aw: std.Io.Writer.Allocating = .init(testing.allocator);
+        defer aw.deinit();
+        try emitJson(m1, &aw.writer);
+
+        var m2 = parseJson(testing.allocator, aw.written()) catch |e| {
+            std.debug.print("byte 0x{x:0>2} emitted invalid JSON: {s}\n", .{ b, @errorName(e) });
+            return e;
+        };
+        defer m2.deinit();
+        testing.expectEqualStrings(name, m2.name) catch |e| {
+            std.debug.print("byte 0x{x:0>2} did not round-trip\n", .{b});
+            return e;
+        };
+    }
 }
 
 test "round-trip parse emit parse" {

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -442,6 +442,40 @@ pub fn materializeFromLocalCellar(
     return .{ .name = name, .version = version, .path = owned_path };
 }
 
+/// Escape `s` as JSON string *contents* (no surrounding quotes) into `buf`,
+/// returning the written slice or null on overflow. Duplicated from the bundle
+/// emitter's escaper rather than importing across modules; this sink is a fixed
+/// buffer, not a `std.Io.Writer`, so it can't share the same signature.
+fn jsonEscapeInto(buf: []u8, s: []const u8) ?[]const u8 {
+    var w: usize = 0;
+    for (s) |byte| {
+        const esc: ?[]const u8 = switch (byte) {
+            '"' => "\\\"",
+            '\\' => "\\\\",
+            '\n' => "\\n",
+            '\r' => "\\r",
+            '\t' => "\\t",
+            0x08 => "\\b",
+            0x0c => "\\f",
+            else => null,
+        };
+        if (esc) |e| {
+            if (w + e.len > buf.len) return null;
+            @memcpy(buf[w..][0..e.len], e);
+            w += e.len;
+        } else if (byte < 0x20) {
+            if (w + 6 > buf.len) return null;
+            _ = std.fmt.bufPrint(buf[w..], "\\u{x:0>4}", .{byte}) catch return null;
+            w += 6;
+        } else {
+            if (w >= buf.len) return null;
+            buf[w] = byte;
+            w += 1;
+        }
+    }
+    return buf[0..w];
+}
+
 fn writeInstallReceipt(io: std.Io, cellar_path: []const u8, name: []const u8, version: []const u8, store_sha256: []const u8) void {
     writeInstallReceiptFull(io, cellar_path, name, version, store_sha256, null, true);
 }
@@ -463,9 +497,15 @@ pub fn writeInstallReceiptFull(
     defer file.close(io);
 
     const timestamp = std.Io.Clock.real.now(io).toSeconds();
-    const tap_str = tap orelse "homebrew/core";
     const reason = if (is_direct) "true" else "false";
     const dep_reason = if (is_direct) "false" else "true";
+
+    // Escape tap/version before interpolating them into quoted JSON slots: a
+    // `"`/`\` from a hand-authored tap would otherwise emit malformed receipts.
+    var tap_scratch: [256]u8 = undefined;
+    var ver_scratch: [256]u8 = undefined;
+    const tap_str = jsonEscapeInto(&tap_scratch, tap orelse "homebrew/core") orelse return;
+    const version_str = jsonEscapeInto(&ver_scratch, version) orelse return;
 
     var buf: [2048]u8 = undefined;
     const json = std.fmt.bufPrint(&buf,
@@ -497,7 +537,7 @@ pub fn writeInstallReceiptFull(
         reason,
         timestamp,
         tap_str,
-        version,
+        version_str,
         if (@import("builtin").cpu.arch == .aarch64) "arm64" else "x86_64",
         store_sha256,
     }) catch return;
@@ -535,4 +575,61 @@ test "describeError: action-hint tags keep prose, trivial tags fall back to @err
     inline for (fallback_tags) |e| {
         try std.testing.expectEqualStrings(@errorName(e), describeError(e));
     }
+}
+
+/// Test helper: write a receipt with the given tap/version into a unique temp
+/// dir, read it back, clean up, and return the owned bytes. `tag` keeps
+/// concurrent test binaries from colliding on the same path.
+fn writeReceiptAndRead(io: std.Io, alloc: std.mem.Allocator, tag: []const u8, tap: []const u8, version: []const u8) ![]u8 {
+    const ts = std.Io.Clock.real.now(io).toNanoseconds();
+    var dir_buf: [128]u8 = undefined;
+    const dir = std.fmt.bufPrint(&dir_buf, "/tmp/malt_receipt_{s}_{d}", .{ tag, ts }) catch unreachable;
+    std.Io.Dir.cwd().createDirPath(io, dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+
+    writeInstallReceiptFull(io, dir, "pkg", version, "abc123", tap, true);
+
+    var path_buf: [160]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/INSTALL_RECEIPT.json", .{dir}) catch unreachable;
+    const f = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer f.close(io);
+    const st = try f.stat(io);
+    const bytes = try alloc.alloc(u8, @intCast(st.size));
+    errdefer alloc.free(bytes);
+    _ = try f.readPositionalAll(io, bytes, 0);
+    return bytes;
+}
+
+test "install receipt with quoted tap and version stays valid JSON" {
+    const testing = std.testing;
+    const bytes = try writeReceiptAndRead(std.Options.debug_io, testing.allocator, "quoted", "ta\"p/\\core", "1\"0\\rc");
+    defer testing.allocator.free(bytes);
+
+    // The whole point: the receipt must re-parse despite quote/backslash bytes.
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, bytes, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("ta\"p/\\core", parsed.value.object.get("source").?.object.get("tap").?.string);
+    try testing.expectEqualStrings("1\"0\\rc", parsed.value.object.get("source").?.object.get("versions").?.object.get("stable").?.string);
+}
+
+test "install receipt escapes control chars in tap and version" {
+    const testing = std.testing;
+    const bytes = try writeReceiptAndRead(std.Options.debug_io, testing.allocator, "ctrl", "a\nb\tc", "v\x01w");
+    defer testing.allocator.free(bytes);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, bytes, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("a\nb\tc", parsed.value.object.get("source").?.object.get("tap").?.string);
+    try testing.expectEqualStrings("v\x01w", parsed.value.object.get("source").?.object.get("versions").?.object.get("stable").?.string);
+}
+
+test "install receipt with an over-long value degrades without crashing" {
+    const testing = std.testing;
+    // A tap longer than the escape scratch buffer overruns; the writer must
+    // bail out gracefully (best-effort path) rather than panic or truncate mid-JSON.
+    const long_tap = "a" ** 300;
+    const bytes = try writeReceiptAndRead(std.Options.debug_io, testing.allocator, "overflow", long_tap, "1.0");
+    defer testing.allocator.free(bytes);
+    // Nothing was written; the empty receipt is the graceful degradation.
+    try testing.expectEqual(@as(usize, 0), bytes.len);
 }


### PR DESCRIPTION
## Description

The JSON, Brewfile and install-receipt emitters interpolated names, versions and taps with a raw `{s}` and no escaping, so any value containing `"` or `\` produced malformed output that no longer re-parsed - the parse→emit→parse round-trip was not stable. A hand-authored `Maltfile.json`/`Brewfile` with such a value broke import/export silently.

All three emitters now route every emitted string through an escaper:

- JSON manifest and install receipt: RFC 8259 escaping (`"`, `\`, control chars, `\uXXXX` fallback).
- Brewfile: double-quoted Ruby escaping of `"`, `\`, and the whitespace controls `\n`/`\r`/`\t`.

The Brewfile round-trip is faithful, not merely re-parseable: `expectString` now decodes the emitted escapes back into the value, quote-aware so single quotes keep Ruby-literal semantics. `parse(emit(m)) == m` holds. The no-escape fast path is byte-identical to before, and emit output for ordinary input is pinned by golden tests.

## Related Issue

- None

## Notes for Reviewers

- None