### PR TITLE
fix(security): enforce the terminal sanitizer's anti-injection guarantee

### DIFF
--- a/scripts/regressions/term-sanitize-anti-injection-guarantee.sh
+++ b/scripts/regressions/term-sanitize-anti-injection-guarantee.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Regression: the terminal sanitizer promises a hostile formula's post_install
+# output cannot rewrite scrollback or exfiltrate via terminal extensions. Three
+# gaps broke that guarantee:
+#   - passable() admitted every byte >= 0x80, so the 8-bit C1 introducers
+#     (0x80..0x9F: CSI/OSC/DCS/ST) passed verbatim, re-opening OSC 52.
+#   - a CSI buffered any non-final byte, replaying smuggled C0 (e.g. BEL) or ESC.
+#   - csiAllowed keyed only on the final byte, so `CSI 3 J` erased scrollback.
+#
+# The sanitizer has no standalone CLI surface (it wraps child stdout/stderr), so
+# a standalone ReleaseSafe `zig test` harness drives Sanitizer.feed/flush through
+# a capturing sink and asserts on the emitted bytes: the three hostile inputs
+# drop to nothing while legitimate UTF-8 (whose continuation bytes fall in the
+# C1 range) and whitelisted SGR/erase sequences pass intact.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# The harness imports the sanitizer via a repo-relative path, so it must sit at
+# the repo root for the source tree's module boundary to resolve.
+HARNESS="$ROOT/.term-sanitize-anti-injection-regression.zig"
+trap 'rm -f "$HARNESS"' EXIT
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const ts = @import("src/ui/term_sanitize.zig");
+
+const Buf = struct {
+    list: std.ArrayList(u8) = .empty,
+
+    fn sink(self: *Buf) ts.Sink {
+        return .{ .ctx = self, .write_fn = writeFn };
+    }
+    fn writeFn(ctx: *anyopaque, bytes: []const u8) ts.SinkError!void {
+        const self: *Buf = @ptrCast(@alignCast(ctx));
+        self.list.appendSlice(std.testing.allocator, bytes) catch return error.WriteFailed;
+    }
+    fn deinit(self: *Buf) void {
+        self.list.deinit(std.testing.allocator);
+    }
+};
+
+fn run(input: []const u8, out: *Buf) !void {
+    var s = ts.Sanitizer.init();
+    try s.feed(input, out.sink());
+    try s.flush(out.sink());
+}
+
+test "8-bit OSC 52 (C1 introducers) dropped" {
+    var b: Buf = .{};
+    defer b.deinit();
+    try run("\x9d52;c;cHduZWQ=\x9c", &b);
+    try std.testing.expectEqual(@as(usize, 0), b.list.items.len);
+}
+
+test "BEL smuggled inside a CSI dropped" {
+    var b: Buf = .{};
+    defer b.deinit();
+    try run("\x1b[\x07m", &b);
+    try std.testing.expect(std.mem.indexOfScalar(u8, b.list.items, 0x07) == null);
+}
+
+test "CSI 3 J (erase scrollback) dropped" {
+    var b: Buf = .{};
+    defer b.deinit();
+    try run("\x1b[3J", &b);
+    try std.testing.expectEqual(@as(usize, 0), b.list.items.len);
+}
+
+test "legit UTF-8 with C1-range continuation preserved" {
+    // é=C3 A9, ✓=E2 9C 93 — the 0x9C continuation byte lands in the C1 range.
+    var b: Buf = .{};
+    defer b.deinit();
+    try run("caf\xc3\xa9 \xe2\x9c\x93", &b);
+    try std.testing.expectEqualStrings("caf\xc3\xa9 \xe2\x9c\x93", b.list.items);
+}
+
+test "whitelisted SGR + screen erase still pass" {
+    var b: Buf = .{};
+    defer b.deinit();
+    try run("\x1b[31mX\x1b[0m\x1b[2J", &b);
+    try std.testing.expectEqualStrings("\x1b[31mX\x1b[0m\x1b[2J", b.list.items);
+}
+ZIG
+
+if (cd "$ROOT" && zig test -OReleaseSafe "$HARNESS") >/dev/null 2>&1; then
+  echo "PASS: sanitizer enforces its anti-injection guarantee"
+else
+  echo "FAIL: sanitizer leaked a C1/C0/scrollback sequence" >&2
+  exit 1
+fi

--- a/src/ui/term_sanitize.zig
+++ b/src/ui/term_sanitize.zig
@@ -1,11 +1,16 @@
 //! malt — terminal escape-sequence sanitizer
 //!
 //! Filters bytes from an untrusted child process before they reach
-//! the user's terminal. Permits printable ASCII + CR/LF/TAB + the
-//! common UTF-8 continuation range + a whitelisted subset of CSI
-//! escape sequences (SGR colours and cursor positioning). Everything
-//! else — OSC (including clipboard-reading OSC 52), DCS, SOS/PM/APC,
-//! other CSI commands, C0 controls, stray ESC — is dropped.
+//! the user's terminal. Permits printable ASCII + CR/LF/TAB + valid
+//! UTF-8 (tracked with a small continuation counter, so lone C1
+//! controls in 0x80..0x9F drop while real multibyte output passes) +
+//! a whitelisted subset of CSI sequences: SGR colours, relative
+//! cursor motion (A–G/E/F), line erase (K), and visible-screen erase
+//! (J with no param or 0/1/2).
+//! Everything else — OSC (including clipboard-reading OSC 52), DCS,
+//! SOS/PM/APC, 8-bit C1 introducers, absolute positioning (H/f),
+//! cursor save/restore (s/u), scrollback erase (CSI 3 J), other CSI
+//! commands, C0 controls, stray/mid-sequence ESC — is dropped.
 //!
 //! Used to wrap post_install stdout/stderr so a hostile formula
 //! cannot rewrite scrollback or exfiltrate via terminal extensions.
@@ -42,6 +47,9 @@ pub const Sanitizer = struct {
     csi_overflow: bool = false,
     out_buf: [out_buf]u8 = undefined,
     out_len: usize = 0,
+    // Outstanding UTF-8 continuation bytes expected after a lead byte, so a
+    // continuation in 0x80..0x9F passes while a lone C1 control is dropped.
+    utf8_remaining: u2 = 0,
 
     const State = enum {
         normal,
@@ -76,59 +84,68 @@ pub const Sanitizer = struct {
             .normal => {
                 if (b == 0x1B) {
                     try self.flush(sink);
+                    self.utf8_remaining = 0;
                     self.state = .esc;
-                } else if (passable(b)) {
+                } else if (self.utf8_remaining == 0) {
+                    if (c1Target(b)) |target| {
+                        // 8-bit C1 introducer: drop it and its payload just like
+                        // the 7-bit ESC form, so an 8-bit terminal can't
+                        // reconstruct the sequence the 7-bit path filters.
+                        try self.flush(sink);
+                        switch (target) {
+                            .csi => self.beginCsi(),
+                            else => self.state = target,
+                        }
+                    } else if (self.passable(b)) {
+                        try self.emit(b, sink);
+                    }
+                } else if (self.passable(b)) {
+                    // Mid-codepoint: a continuation byte passes; a stray
+                    // non-continuation is reclassified and dropped by passable.
                     try self.emit(b, sink);
                 }
-                // else: drop silently
             },
             .esc => switch (b) {
-                '[' => {
-                    self.state = .csi;
-                    self.csi_len = 0;
-                    self.csi_overflow = false;
-                },
+                '[' => self.beginCsi(),
                 ']' => self.state = .osc,
                 'P', 'X', '^', '_' => self.state = .dcs,
                 // Two-byte ESC X: drop both (we already dropped ESC).
                 else => self.state = .normal,
             },
-            .csi => {
-                if (b >= 0x40 and b <= 0x7E) {
-                    // Final byte: decide.
-                    if (!self.csi_overflow and csiAllowed(b)) {
+            .csi => switch (b) {
+                0x40...0x7E => {
+                    // Final byte: replay only a clean, whitelisted sequence.
+                    if (!self.csi_overflow and csiAllowed(b, self.csi_buf[0..self.csi_len])) {
                         try self.emit(0x1B, sink);
                         try self.emit('[', sink);
                         for (self.csi_buf[0..self.csi_len]) |p| try self.emit(p, sink);
                         try self.emit(b, sink);
                     }
                     self.state = .normal;
-                } else if (self.csi_len < self.csi_buf.len) {
+                },
+                // A mid-CSI ESC aborts this sequence and starts a new one, so a
+                // smuggled ESC can never be replayed with the final byte.
+                0x1B => self.state = .esc,
+                // Legal CSI parameter/intermediate byte.
+                0x20...0x3F => if (self.csi_len < self.csi_buf.len) {
                     self.csi_buf[self.csi_len] = b;
                     self.csi_len += 1;
                 } else {
-                    // Too many param bytes — fail-closed when the
-                    // final byte arrives.
-                    self.csi_overflow = true;
-                }
+                    self.csi_overflow = true; // too many params — drop at final byte
+                },
+                // C0 control or DEL inside a CSI is illegal; fail closed so the
+                // whole sequence drops rather than replaying the byte.
+                else => self.csi_overflow = true,
             },
-            .osc, .dcs => {
-                if (b == 0x07) {
-                    self.state = .normal; // BEL terminates OSC
-                } else if (b == 0x1B) {
-                    self.state = .st_maybe;
-                }
-                // else: drop
+            .osc, .dcs => switch (b) {
+                0x07, 0x9C => self.state = .normal, // BEL or 8-bit ST terminates
+                0x1B => self.state = .st_maybe, // 7-bit ST begins with ESC
+                else => {}, // body byte: drop
             },
-            .st_maybe => {
-                if (b == '\\') {
-                    self.state = .normal;
-                } else if (b == 0x1B) {
-                    // Stay waiting.
-                } else {
-                    // Not ST; back into OSC/DCS body.
-                    self.state = .osc;
-                }
+            .st_maybe => switch (b) {
+                '\\' => self.state = .normal, // ESC \ = ST
+                0x1B => {}, // another ESC: keep waiting
+                else => self.state = .osc, // not ST; back into the body
             },
         }
     }
@@ -138,28 +155,116 @@ pub const Sanitizer = struct {
         self.out_buf[self.out_len] = b;
         self.out_len += 1;
     }
+
+    fn beginCsi(self: *Sanitizer) void {
+        self.state = .csi;
+        self.csi_len = 0;
+        self.csi_overflow = false;
+    }
+
+    fn passable(self: *Sanitizer, b: u8) bool {
+        // A continuation byte passes only while a lead byte is still expecting
+        // one; this is what tells a real 0x80..0x9F continuation from a lone C1
+        // control (the 8-bit CSI/OSC/DCS/ST introducers we must drop).
+        if (self.utf8_remaining > 0) switch (b) {
+            0x80...0xBF => {
+                self.utf8_remaining -= 1;
+                return true;
+            },
+            else => self.utf8_remaining = 0, // truncated — reclassify below
+        };
+        return switch (b) {
+            0x20...0x7E, '\n', '\r', '\t' => true,
+            // UTF-8 lead byte: pass raw and arm the continuation counter. std
+            // rejects continuation bytes and invalid leads (0xF8..0xFF), both of
+            // which fall through to `false` — closing the lone-C1 hole.
+            0x80...0xFF => blk: {
+                const len = std.unicode.utf8ByteSequenceLength(b) catch break :blk false;
+                self.utf8_remaining = @intCast(len - 1);
+                break :blk true;
+            },
+            else => false, // C0 controls, DEL
+        };
+    }
 };
 
-fn passable(b: u8) bool {
-    // Printable ASCII, common whitespace, and UTF-8 continuation /
-    // leading bytes. UTF-8 is passed raw rather than validated —
-    // the terminal will do its own validation, and stripping mid-
-    // sequence would corrupt legitimate non-ASCII output.
-    return (b >= 0x20 and b <= 0x7E) or
-        b == '\n' or b == '\r' or b == '\t' or
-        b >= 0x80;
+/// Maps an 8-bit C1 control introducer to the state that drops or filters
+/// its payload, mirroring the 7-bit ESC forms. `null` for any other byte.
+fn c1Target(b: u8) ?Sanitizer.State {
+    return switch (b) {
+        0x9B => .csi, // CSI  (ESC [)
+        0x9D => .osc, // OSC  (ESC ])
+        0x90, 0x98, 0x9E, 0x9F => .dcs, // DCS/SOS/PM/APC
+        else => null,
+    };
 }
 
-fn csiAllowed(final: u8) bool {
+fn csiAllowed(final: u8, params: []const u8) bool {
     return switch (final) {
         'm' => true, // SGR: colours, bold, underline
         'A', 'B', 'C', 'D' => true, // cursor up/down/right/left
         'E', 'F' => true, // cursor next/prev line
         'G' => true, // cursor column
-        'H', 'f' => true, // cursor position
-        'J' => true, // erase display
+        // H/f absolute positioning and s/u save/restore enable screen
+        // spoofing and no in-repo progress output uses them (relative motion
+        // only); dropped, keeping save/restore uniformly out (ESC 7/8 already
+        // drop as stray ESC).
+        'J' => eraseDisplayAllowed(params), // reject CSI 3 J (erase scrollback)
         'K' => true, // erase line
-        's', 'u' => true, // save/restore cursor
         else => false,
     };
+}
+
+// CSI J erases the visible screen; CSI 3 J also clears scrollback, which the
+// sanitizer must not permit. Allow only the visible-screen variants: no
+// param, or a single 0/1/2.
+fn eraseDisplayAllowed(params: []const u8) bool {
+    return switch (params.len) {
+        0 => true, // CSI J
+        1 => params[0] >= '0' and params[0] <= '2', // 0/1/2; reject 3 (scrollback)
+        else => false, // multi-param forms are not whitelisted
+    };
+}
+
+// ── inline unit tests: private classifier helpers ───────────────────
+// Full feed()/flush() byte-stream behaviour lives in tests/term_sanitize_test.zig;
+// these cover the file-private classifiers that the integration file can't reach.
+
+test "csiAllowed whitelists SGR/relative motion, drops positioning + save/restore" {
+    for ("mABCDEFGK") |f| try std.testing.expect(csiAllowed(f, ""));
+    // Absolute positioning (H/f) and cursor save/restore (s/u) are spoofing aids.
+    for ("Hfsu") |f| try std.testing.expect(!csiAllowed(f, ""));
+    // J is param-gated, not final-byte-only.
+    try std.testing.expect(csiAllowed('J', "2"));
+    try std.testing.expect(!csiAllowed('J', "3"));
+}
+
+test "eraseDisplayAllowed permits only visible-screen variants" {
+    for ([_][]const u8{ "", "0", "1", "2" }) |p| try std.testing.expect(eraseDisplayAllowed(p));
+    // 3 clears scrollback; other/multi-param forms are not whitelisted.
+    for ([_][]const u8{ "3", "9", "33", "3;4" }) |p| try std.testing.expect(!eraseDisplayAllowed(p));
+}
+
+test "c1Target maps 8-bit introducers to their drop/filter state" {
+    try std.testing.expectEqual(Sanitizer.State.csi, c1Target(0x9B).?);
+    try std.testing.expectEqual(Sanitizer.State.osc, c1Target(0x9D).?);
+    for ([_]u8{ 0x90, 0x98, 0x9E, 0x9F }) |b| try std.testing.expectEqual(Sanitizer.State.dcs, c1Target(b).?);
+    // ST (0x9C) is a terminator, not an introducer; ASCII and non-C1 bytes map to none.
+    for ([_]u8{ 0x9C, 'A', 0x80, 0x1B }) |b| try std.testing.expect(c1Target(b) == null);
+}
+
+test "passable drops lone C1 but passes UTF-8 continuation under an armed counter" {
+    var s = Sanitizer.init();
+    // Printable ASCII and whitespace pass; C0 and DEL drop.
+    try std.testing.expect(s.passable('A'));
+    try std.testing.expect(s.passable('\t'));
+    for ([_]u8{ 0x00, 0x07, 0x7F }) |b| try std.testing.expect(!s.passable(b));
+    // Lone C1 controls drop — no lead byte has armed the counter.
+    for ([_]u8{ 0x80, 0x9B, 0x9C }) |b| try std.testing.expect(!s.passable(b));
+    // A lead byte arms the counter so its continuations pass, even in the C1
+    // range (0x9C, 0x93 here), then a drained counter drops a lone C1 again.
+    try std.testing.expect(s.passable(0xE2)); // lead of ✓ = E2 9C 93
+    try std.testing.expect(s.passable(0x9C));
+    try std.testing.expect(s.passable(0x93));
+    try std.testing.expect(!s.passable(0x9C));
 }

--- a/tests/term_sanitize_test.zig
+++ b/tests/term_sanitize_test.zig
@@ -95,16 +95,35 @@ test "cursor up passes" {
     try check("\x1b[3A", "\x1b[3A");
 }
 
-test "cursor position passes" {
-    try check("\x1b[10;20H", "\x1b[10;20H");
+test "absolute cursor position dropped" {
+    // H/f absolute positioning enables screen spoofing; progress output uses
+    // relative motion only, so the sanitizer drops absolute positioning.
+    try check("\x1b[10;20H", "");
+    try check("\x1b[10;20f", "");
 }
 
 test "erase line passes" {
     try check("\x1b[2K", "\x1b[2K");
 }
 
-test "save/restore cursor passes" {
-    try check("\x1b[s\x1b[u", "\x1b[s\x1b[u");
+test "erase display screen variants pass" {
+    try check("\x1b[J", "\x1b[J");
+    try check("\x1b[0J", "\x1b[0J");
+    try check("\x1b[1J", "\x1b[1J");
+    try check("\x1b[2J", "\x1b[2J");
+}
+
+test "erase display unknown params dropped" {
+    // Only the visible-screen variants are whitelisted; 3 (scrollback) and any
+    // other/multi-param form fail closed.
+    try check("a\x1b[4Jb", "ab");
+    try check("a\x1b[3;4Jb", "ab");
+}
+
+test "save/restore cursor dropped" {
+    // Save/restore aids screen spoofing and no in-repo output needs it; the
+    // DEC ESC 7/8 form already drops, so drop the CSI form too.
+    try check("a\x1b[sb\x1b[uc", "abc");
 }
 
 // ── CSI other commands dropped ──────────────────────────────────────
@@ -120,6 +139,67 @@ test "mode reset CSI l dropped" {
 
 test "scroll region CSI r dropped" {
     try check("a\x1b[1;24rb", "ab");
+}
+
+test "CSI 3 J erase scrollback dropped" {
+    try check("a\x1b[3Jb", "ab");
+}
+
+// ── anti-injection: 8-bit C1 introducers handled like 7-bit ─────────
+
+test "8-bit CSI introducer routed through the CSI filter" {
+    // 0x9B is the C1 form of ESC [ . Like the 7-bit path it filters: a
+    // whitelisted SGR normalises to 7-bit and passes…
+    try check("a\x9b31mXb", "a\x1b[31mXb");
+    // …but scrollback erase via the 8-bit introducer is still dropped.
+    try check("a\x9b3Jb", "ab");
+}
+
+test "8-bit OSC 52 clipboard attempt dropped" {
+    // C1 OSC (0x9D) … C1 ST (0x9C): the 8-bit twin of ESC ] 52 … ST.
+    try check("a\x9d52;c;cHduZWQ=\x9cb", "ab");
+}
+
+test "8-bit DCS dropped, 8-bit ST terminates" {
+    try check("a\x90payload\x9cb", "ab");
+}
+
+test "lone C1 control dropped" {
+    // 0x9C (ST) and 0x99 are C1 controls but not introducers: dropped outright.
+    try check("a\x9cb\x99b", "abb");
+}
+
+// ── anti-injection: C0/ESC inside a CSI fails closed ────────────────
+
+test "BEL smuggled inside a CSI drops the whole sequence" {
+    try check("a\x1b[\x07mb", "ab");
+}
+
+test "ESC inside a CSI aborts it" {
+    // Mid-CSI ESC restarts escape parsing; the first (aborted) CSI vanishes,
+    // the second is a valid SGR that passes.
+    try check("\x1b[3\x1b[31mX", "\x1b[31mX");
+}
+
+// ── UTF-8 preservation with C1-range continuation bytes ─────────────
+
+test "UTF-8 codepoint with C1-range continuation preserved" {
+    // ✓ = E2 9C 93; the 0x9C continuation byte overlaps the C1 range but must
+    // pass because a lead byte is expecting it.
+    try check("\xe2\x9c\x93", "\xe2\x9c\x93");
+    // U+0080 = C2 80 — lowest C1 codepoint, continuation byte 0x80.
+    try check("\xc2\x80", "\xc2\x80");
+    // U+1F600 😀 = F0 9F 98 80 — 4-byte lead, continuation 0x98 in the C1 range.
+    try check("\xf0\x9f\x98\x80", "\xf0\x9f\x98\x80");
+    // U+265B ♛ = E2 99 9B — its trailing continuation byte is 0x9B, the C1 CSI
+    // introducer. Mid-codepoint it must pass, never start a CSI.
+    try check("\xe2\x99\x9b", "\xe2\x99\x9b");
+}
+
+test "incomplete UTF-8 lead is flushed when a control follows" {
+    // A truncated codepoint (lead with no continuation) followed by ESC: the
+    // lead byte still emits, the escape is parsed fresh (dropped here).
+    try check("x\xe2\x1b[?25ly", "x\xe2y");
 }
 
 // ── OSC always dropped ──────────────────────────────────────────────
@@ -190,6 +270,58 @@ test "OSC split across chunks is dropped end-to-end" {
     try s.feed("\x1b\\b", buf.sink());
     try s.flush(buf.sink());
     try testing.expectEqualStrings("ab", buf.list.items);
+}
+
+test "UTF-8 codepoint split across feed() calls is reassembled" {
+    // The real filter reads fixed-size chunks, so a multibyte codepoint will
+    // straddle a boundary; the continuation counter must survive across calls.
+    var buf: Buf = .{};
+    defer buf.deinit();
+    var s = ts.Sanitizer.init();
+    try s.feed("caf\xc3", buf.sink()); // é lead only
+    try s.feed("\xa9 \xe2\x9c", buf.sink()); // é continuation + ✓ lead+cont1
+    try s.feed("\x93!", buf.sink()); // ✓ final continuation
+    try s.flush(buf.sink());
+    try testing.expectEqualStrings("caf\xc3\xa9 \xe2\x9c\x93!", buf.list.items);
+}
+
+test "8-bit OSC split across chunks is dropped end-to-end" {
+    var buf: Buf = .{};
+    defer buf.deinit();
+    var s = ts.Sanitizer.init();
+    try s.feed("a\x9d52;c;", buf.sink());
+    try s.feed("PAYLOAD", buf.sink());
+    try s.feed("\x9cb", buf.sink()); // 8-bit ST terminates
+    try s.flush(buf.sink());
+    try testing.expectEqualStrings("ab", buf.list.items);
+}
+
+// ── defense-in-depth invariant over a hostile corpus ────────────────
+
+test "no BEL or bare ESC survives a dense hostile control corpus" {
+    const hostile =
+        "\x1b[\x07m" ++ // BEL in CSI
+        "\x9d52;c;x\x9c" ++ // 8-bit OSC 52
+        "\x1b]0;title\x07" ++ // OSC BEL-terminated
+        "\x9b3J" ++ // 8-bit CSI erase scrollback
+        "\x1b[3J" ++ // 7-bit erase scrollback
+        "\x00\x7f\x9c\x90p\x9c" ++ // NUL, DEL, stray ST, DCS
+        "ok\x1b[31mX\x1b[0m\x1b[2Jy"; // legit SGR + screen erase
+    var buf: Buf = .{};
+    defer buf.deinit();
+    var s = ts.Sanitizer.init();
+    try s.feed(hostile, buf.sink());
+    try s.flush(buf.sink());
+    const out = buf.list.items;
+    // No BEL leaks; every emitted ESC begins a whitelisted CSI (ESC [ …).
+    try testing.expect(std.mem.indexOfScalar(u8, out, 0x07) == null);
+    for (out, 0..) |c, i| {
+        if (c == 0x1B) try testing.expect(i + 1 < out.len and out[i + 1] == '[');
+        try testing.expect(!(c >= 0x80 and c <= 0x9F)); // no C1 leak (corpus has no UTF-8)
+        try testing.expect(c >= 0x20 or c == 0x1B); // no other C0 leak
+    }
+    // Legitimate output still passes through.
+    try testing.expect(std.mem.indexOf(u8, out, "\x1b[31mX\x1b[0m") != null);
 }
 
 // ── empty + pathological inputs ─────────────────────────────────────


### PR DESCRIPTION
## Description

The terminal sanitizer wraps a hostile formula's `post_install` output so it "cannot rewrite scrollback or exfiltrate via terminal extensions." That guarantee was broken: a malicious formula could still clear a user's scrollback, overwrite already-printed lines to spoof earlier output, and on terminals in 8-bit mode smuggle an OSC 52 clipboard write straight through.

This restores the guarantee end to end:

- 8-bit C1 control introducers are no longer passed verbatim; they are dropped or filtered exactly like their 7-bit `ESC` forms, while genuine UTF-8 (whose continuation bytes overlap that range) is preserved intact.
- Control bytes smuggled inside an otherwise-allowed escape can no longer be replayed to the terminal — such a sequence now fails closed.
- Scrollback erase is rejected while ordinary screen/line erase still works, and absolute cursor positioning plus cursor save/restore are dropped as screen-spoofing aids that no in-repo progress output relies on.

Legitimate coloured, progress-style output is unaffected.

## Related Issue

- None

## Notes for Reviewers

- None