### PR TITLE
fix(services): reject path separators in service label at the validation gate

### DIFF
--- a/scripts/regressions/service-label-unvalidated-path-separators.sh
+++ b/scripts/regressions/service-label-unvalidated-path-separators.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Regression: a service whose `label` carries a path separator or `..` must be
+# rejected at the validation gate, before it can become a directory name.
+#
+# The bug: plist.validate ran a battery of path-escape checks on every string
+# that becomes a filesystem path — program_args[0], working_dir, the log paths —
+# but the label only passed checkString (length + NUL). register then feeds the
+# label straight into serviceDir → `<prefix>/var/malt/services/<label>` and
+# createDirPath, so a label containing `/` or `..` writes the plist directory
+# outside the services subtree — enough `../` segments escape the prefix into
+# any writable dir. A compromised or third-party tap is the delivery vector.
+#
+# The fix adds a single-path-component guard on `label` inside validate, at the
+# one gate every disk write and launchctl bootstrap flows through, rejecting an
+# empty value, `.`/`..`, or an embedded `/` or `..` (charset-agnostic so real
+# `com.malt.<name>` labels still pass).
+#
+# No CLI surface drives validate offline without standing up launchd, and the
+# guard fires before any write, so it is exercised by the colocated inline unit
+# tests (`lib_tests`). This script builds and runs only that binary: it stays
+# well under 30s and needs no network. A pass means every inline test —
+# including the label-rejection guard — held; a regression flips that binary to
+# a non-zero exit.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+SRC="src/core/services/plist.zig"
+TEST_NAME="validate rejects path separators in label"
+
+# If the guard or its test is ever dropped, the unit binary would go green
+# vacuously. Fail loudly instead: both the predicate and the test must be
+# present in the source.
+if ! grep -Fqs -- "$TEST_NAME" "$SRC"; then
+  echo "FAIL: the label-rejection guard test is missing from $SRC" >&2
+  exit 1
+fi
+if ! grep -Fqs -- "isSafeLabelComponent" "$SRC"; then
+  echo "FAIL: the validate label path-component guard is missing from $SRC" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+# Always rebuild so the binary reflects current source — a prebuilt lib_tests
+# could predate the guard. Zig's cache makes a no-op rebuild cheap, so this
+# stays well under the time budget.
+if ! zig build test-bin >/dev/null 2>&1; then
+  echo "FAIL: could not build the unit test binary (zig build test-bin)" >&2
+  exit 1
+fi
+
+# The runner has no per-test filter, so run the inline suite and judge by its
+# exit code. Pre-fix, validate accepts the traversal label the guard test feeds
+# it, so that test fails and the binary exits non-zero.
+OUT=$("$BIN" 2>&1) && STATUS=0 || STATUS=$?
+if [[ "$STATUS" -ne 0 ]]; then
+  echo "FAIL: service label path separators accepted by validate" >&2
+  printf '%s\n' "$OUT" | grep -iE "failed|leaked|panic" >&2 || true
+  exit 1
+fi
+
+echo "PASS: service label path separators rejected by validate"

--- a/src/core/services/plist.zig
+++ b/src/core/services/plist.zig
@@ -133,6 +133,9 @@ pub fn validate(
 
     for (spec.program_args) |a| try checkString(a);
     try checkString(spec.label);
+    // The label becomes a single directory component under var/malt/services,
+    // so a `/` or `..` inside it escapes that subtree once register writes it.
+    if (!isSafeLabelComponent(spec.label)) return ValidationError.PathEscape;
     try checkString(spec.stdout_path);
     try checkString(spec.stderr_path);
     if (spec.working_dir) |wd| try checkString(wd);
@@ -182,6 +185,18 @@ fn calInRange(ci: CalendarInterval) bool {
 fn checkString(s: []const u8) ValidationError!void {
     if (s.len > max_arg_len) return ValidationError.ArgTooLong;
     if (std.mem.indexOfScalar(u8, s, 0) != null) return ValidationError.EmbeddedNul;
+}
+
+/// True when `label` is a single, safe path component. Charset-agnostic: a real
+/// label is `com.malt.<name>` and may carry dots, `-`, `_`, `@`, `+`, so this
+/// bars only the shapes that hop out of a component — empty, `.`/`..`, an
+/// embedded `/`, or an embedded `..`. NUL is already screened by checkString.
+fn isSafeLabelComponent(label: []const u8) bool {
+    if (label.len == 0) return false;
+    if (std.mem.eql(u8, label, ".") or std.mem.eql(u8, label, "..")) return false;
+    if (std.mem.indexOfScalar(u8, label, '/') != null) return false;
+    if (std.mem.indexOf(u8, label, "..") != null) return false;
+    return true;
 }
 
 pub fn render(spec: ServiceSpec, writer: *std.Io.Writer) !void {
@@ -343,4 +358,35 @@ test "expandPrefix matches the whole token, not a sibling Homebrew variable" {
     const out = try expandPrefix(testing.allocator, "$HOMEBREW_CELLAR/redis", "/opt/malt");
     defer testing.allocator.free(out);
     try testing.expectEqualStrings("$HOMEBREW_CELLAR/redis", out);
+}
+
+test "validate rejects path separators in label" {
+    // The label becomes a directory component under var/malt/services; a `/` or
+    // `..` inside it hops the plist write outside that subtree, so the gate
+    // must refuse it before register turns it into a real path.
+    const base = ServiceSpec{
+        .label = "com.malt.redis",
+        .program_args = &.{"/opt/malt/Cellar/foo/1.0/bin/foo"},
+        .stdout_path = "/opt/malt/var/log/foo.out",
+        .stderr_path = "/opt/malt/var/log/foo.err",
+    };
+
+    // Component-hopping shapes: empty, the dot dirs, an embedded `/`, and an
+    // embedded `..` even when the label is not exactly `..` (`a..b`).
+    for ([_][]const u8{ "../../evil", "..", "a/b", ".", "", "a..b", "foo/" }) |bad| {
+        var spec = base;
+        spec.label = bad;
+        try testing.expectError(
+            ValidationError.PathEscape,
+            validate(spec, "/opt/malt/Cellar/foo/1.0", "/opt/malt"),
+        );
+    }
+
+    // Real labels are charset-agnostic single components: single dots, digits,
+    // and `@`/`+` from formula names must all pass.
+    for ([_][]const u8{ "com.malt.redis", "com.malt.openssl@3", "com.malt.gtk+" }) |ok| {
+        var spec = base;
+        spec.label = ok;
+        try validate(spec, "/opt/malt/Cellar/foo/1.0", "/opt/malt");
+    }
 }


### PR DESCRIPTION
## Description

`plist.validate` is the single gate every service disk write and `launchctl bootstrap` flows through, and it already rejects path escapes in `program_args[0]`, `working_dir`, and the log paths. The `label`, however, only passed the length/NUL screen - yet `register` interpolates it verbatim into `<prefix>/var/malt/services/<label>/service.plist` and `createDirPath`. A label carrying `/` or `..` therefore wrote the plist directory outside the services subtree, escaping the prefix entirely with enough `../` segments. Since a formula's embedded `name` never re-passes the fetch-time name screen, a compromised or third-party tap was the realistic delivery vector.

This adds a single-path-component guard on `label` inside `validate` (the gate itself, so every caller inherits it), rejecting empty, `.`/`..`, an embedded `/`, or an embedded `..`. The predicate is inlined to avoid a `services → cask` import, per the modularity constraints. The guard is charset-agnostic, so real `com.malt.<name>` labels still pass. This is defence-in-depth, purely a filesystem-component concern; the label is already XML-escaped in `render`.

## Related Issue

- None 
## Notes for Reviewers

- None