### PR TITLE
fix(security): reject path separators in tap-supplied names and versions

### DIFF
--- a/scripts/regressions/formula-embedded-name-version-unvalidated.sh
+++ b/scripts/regressions/formula-embedded-name-version-unvalidated.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Regression: a formula whose embedded JSON `name` or `version` carries a path
+# separator or `..` must be rejected at parse time, before either field becomes
+# an on-disk directory component.
+#
+# The bug: parseFormula copied `name` and `version` verbatim out of the formula
+# JSON with no predicate between parse and use. Both are interpolated as raw
+# path components downstream — the keg/cellar dir `Cellar/<name>/<version>`, the
+# receipt, the opt symlink, the service label. The fetch-time name screen only
+# guards the *requested* name; the JSON's own fields are independent values that
+# never re-pass it, so a compromised or third-party tap could steer a write
+# outside the prefix.
+#
+# The fix adds one charset-agnostic path-component guard in parseFormula, at the
+# single ingestion choke point, rejecting `.`/`..`, an embedded `/` or `..`, or
+# a NUL in `name` or a present `version` (real names/versions carry `@`/`+`/dots
+# and still pass; an empty version stays legitimate). `full_name` is left alone
+# because it is legitimately tap-qualified with `/`.
+#
+# No CLI surface drives parseFormula offline without standing up a local tap,
+# and the guard fires before any download, so it is exercised by the colocated
+# inline unit tests (`lib_tests`). This script builds and runs only that binary:
+# it stays well under 30s and needs no network. A pass means every inline test —
+# including the guard — held; a regression flips that binary to a non-zero exit.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+SRC="src/core/formula.zig"
+TEST_NAME="parseFormula rejects path separators in embedded name or version"
+
+# If the guard or its test is ever dropped, the unit binary would go green
+# vacuously. Fail loudly instead: both the predicate and the test must be
+# present in the source.
+if ! grep -Fqs -- "$TEST_NAME" "$SRC"; then
+  echo "FAIL: the embedded name/version guard test is missing from $SRC" >&2
+  exit 1
+fi
+if ! grep -Fqs -- "isSafePathComponent" "$SRC"; then
+  echo "FAIL: the parseFormula path-component guard is missing from $SRC" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+# Always rebuild so the binary reflects current source — a prebuilt lib_tests
+# could predate the guard. Zig's cache makes a no-op rebuild cheap, so this
+# stays well under the time budget.
+if ! zig build test-bin >/dev/null 2>&1; then
+  echo "FAIL: could not build the unit test binary (zig build test-bin)" >&2
+  exit 1
+fi
+
+# The runner has no per-test filter, so run the inline suite and judge by its
+# exit code. Pre-fix, parseFormula accepts the traversal payloads the guard test
+# feeds it, so that test fails and the binary exits non-zero.
+OUT=$("$BIN" 2>&1) && STATUS=0 || STATUS=$?
+if [[ "$STATUS" -ne 0 ]]; then
+  echo "FAIL: formula embedded name/version path separators accepted at parse time" >&2
+  printf '%s\n' "$OUT" | grep -iE "failed|leaked|panic" >&2 || true
+  exit 1
+fi
+
+echo "PASS: formula embedded name/version path separators rejected at parse time"

--- a/scripts/regressions/formula-embedded-name-version-unvalidated.sh
+++ b/scripts/regressions/formula-embedded-name-version-unvalidated.sh
@@ -38,7 +38,7 @@ if ! grep -Fqs -- "$TEST_NAME" "$SRC"; then
   echo "FAIL: the embedded name/version guard test is missing from $SRC" >&2
   exit 1
 fi
-if ! grep -Fqs -- "isSafePathComponent" "$SRC"; then
+if ! grep -Fqs -- "isPathComponent" "$SRC"; then
   echo "FAIL: the parseFormula path-component guard is missing from $SRC" >&2
   exit 1
 fi

--- a/scripts/regressions/service-label-unvalidated-path-separators.sh
+++ b/scripts/regressions/service-label-unvalidated-path-separators.sh
@@ -37,7 +37,7 @@ if ! grep -Fqs -- "$TEST_NAME" "$SRC"; then
   echo "FAIL: the label-rejection guard test is missing from $SRC" >&2
   exit 1
 fi
-if ! grep -Fqs -- "isSafeLabelComponent" "$SRC"; then
+if ! grep -Fqs -- "isPathComponent" "$SRC"; then
   echo "FAIL: the validate label path-component guard is missing from $SRC" >&2
   exit 1
 fi

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const sqlite = @import("../db/sqlite.zig");
 const client_mod = @import("../net/client.zig");
 const archive_mod = @import("../fs/archive.zig");
+const path_component = @import("../fs/path_component.zig");
 const hash_mod = @import("hash.zig");
 const child_mod = @import("child.zig");
 const cask_font = @import("cask_font.zig");
@@ -65,7 +66,7 @@ pub fn parseCask(allocator: std.mem.Allocator, json_bytes: []const u8) !Cask {
     // cache, and mount paths, so a value that escapes its own path
     // component must be rejected here — the one ingestion choke point —
     // before any sink sees it. A compromised tap is the threat.
-    if (!isPathComponent(token) or !isPathComponent(version)) return CaskError.ParseFailed;
+    if (!path_component.isPathComponent(token) or !path_component.isPathComponent(version)) return CaskError.ParseFailed;
 
     return .{
         .token = token,
@@ -1415,20 +1416,6 @@ pub fn isInstalled(db: *sqlite.Database, token: []const u8) bool {
 }
 
 // --- JSON helpers ---
-
-/// True when `s` is a single, safe path segment. Charset-agnostic on
-/// purpose: real cask versions carry uppercase, commas, and colons that
-/// an allowlist would wrongly reject, so this only bars the shapes that
-/// hop out of a path component — empty, `.`/`..`, an embedded `/` or
-/// `..`, or a NUL the kernel reads as a string terminator.
-fn isPathComponent(s: []const u8) bool {
-    if (s.len == 0) return false;
-    if (std.mem.eql(u8, s, ".") or std.mem.eql(u8, s, "..")) return false;
-    if (std.mem.indexOfScalar(u8, s, '/') != null) return false;
-    if (std.mem.indexOf(u8, s, "..") != null) return false;
-    if (std.mem.indexOfScalar(u8, s, 0) != null) return false;
-    return true;
-}
 
 fn getStr(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
     const val = obj.get(key) orelse return null;

--- a/src/core/formula.zig
+++ b/src/core/formula.zig
@@ -18,6 +18,9 @@ pub const FormulaError = error{
     /// `run_type :interval` with a missing, non-numeric, or out-of-range
     /// `interval`. Never falls back to `.immediate`.
     InvalidInterval,
+    /// The embedded `name` or `version` carries a path separator or `..`,
+    /// so it would hop out of its on-disk directory component.
+    UnsafePathComponent,
 };
 
 /// Bottle descriptor for one platform. All three strings live in the
@@ -184,6 +187,19 @@ fn getStringArray(allocator: std.mem.Allocator, obj: std.json.ObjectMap, key: []
 // Parsing
 // ---------------------------------------------------------------------------
 
+/// True when `s` is a single, safe path component. Charset-agnostic: formula
+/// names and versions carry `@`, `+`, and dots that an allowlist would wrongly
+/// reject, so this bars only the shapes that hop out of a component — `.`/`..`,
+/// an embedded `/` or `..`, or a NUL. Empty is left to the caller (a missing
+/// version is legitimate; a missing name is caught as MissingField).
+fn isSafePathComponent(s: []const u8) bool {
+    if (std.mem.eql(u8, s, ".") or std.mem.eql(u8, s, "..")) return false;
+    if (std.mem.indexOfScalar(u8, s, '/') != null) return false;
+    if (std.mem.indexOf(u8, s, "..") != null) return false;
+    if (std.mem.indexOfScalar(u8, s, 0) != null) return false;
+    return true;
+}
+
 /// Parse a Homebrew formula JSON blob into a `Formula`.
 /// The returned value borrows from the parsed JSON; call `deinit()` when done.
 pub fn parseFormula(allocator: std.mem.Allocator, json_data: []const u8) !Formula {
@@ -205,6 +221,9 @@ pub fn parseFormula(allocator: std.mem.Allocator, json_data: []const u8) !Formul
 
     // Required string fields
     const name = getString(root, "name") orelse return FormulaError.MissingField;
+    // The embedded name never re-passes the requested-name screen yet becomes
+    // every keg/cellar/receipt path; full_name is tap-qualified (`/`), so skip.
+    if (!isSafePathComponent(name)) return FormulaError.UnsafePathComponent;
     const full_name = getString(root, "full_name") orelse name;
     const tap = getString(root, "tap") orelse "";
     const desc = getString(root, "desc") orelse "";
@@ -223,6 +242,10 @@ pub fn parseFormula(allocator: std.mem.Allocator, json_data: []const u8) !Formul
         };
         break :blk getString(versions_obj, "stable") orelse "";
     };
+    // version feeds pkg_version → the revision-tagged cellar/keg dir; an empty
+    // version is legitimate, but a present one must stay a single component.
+    if (version_str.len != 0 and !isSafePathComponent(version_str))
+        return FormulaError.UnsafePathComponent;
 
     // dependencies
     const dependencies = try getStringArray(arena, root, "dependencies");
@@ -453,6 +476,49 @@ test "parsePkgVersion round-trips with pkgVersion" {
     const r = parsePkgVersion(formatted);
     try testing.expectEqualStrings("3.14.4", r.version);
     try testing.expectEqual(@as(i64, 1), r.revision);
+}
+
+test "parseFormula rejects path separators in embedded name or version" {
+    // `name` and `version` become on-disk directory components (keg, cellar,
+    // receipt, service label); the JSON's own fields never re-pass the
+    // fetch-time name screen, so parse must reject a component-hopping value.
+    const bad = [_][]const u8{
+        \\{"name":"../evil","versions":{"stable":"1.0"}}
+        ,
+        \\{"name":"a/b","versions":{"stable":"1.0"}}
+        ,
+        \\{"name":".","versions":{"stable":"1.0"}}
+        ,
+        \\{"name":"..","versions":{"stable":"1.0"}}
+        ,
+        \\{"name":"foo/","versions":{"stable":"1.0"}}
+        ,
+        \\{"name":"a\u0000b","versions":{"stable":"1.0"}}
+        ,
+        \\{"name":"ok","versions":{"stable":"../1.0"}}
+        ,
+        \\{"name":"ok","versions":{"stable":"1..0"}}
+        ,
+    };
+    for (bad) |json| {
+        try testing.expectError(FormulaError.UnsafePathComponent, parseFormula(testing.allocator, json));
+    }
+
+    // Real names/versions carry `@`, `+`, dots — charset-agnostic, must pass.
+    const ok =
+        \\{"name":"openssl@3","versions":{"stable":"3.2.1+dfsg"}}
+    ;
+    var formula = try parseFormula(testing.allocator, ok);
+    defer formula.deinit();
+    try testing.expectEqualStrings("openssl@3", formula.name);
+
+    // A formula with no stable version parses to an empty version, unchanged.
+    const nover =
+        \\{"name":"nostable","versions":{}}
+    ;
+    var f2 = try parseFormula(testing.allocator, nover);
+    defer f2.deinit();
+    try testing.expectEqualStrings("", f2.version);
 }
 
 test "parseFormula releases every auxiliary allocation through deinit" {

--- a/src/core/formula.zig
+++ b/src/core/formula.zig
@@ -7,6 +7,7 @@ const builtin = @import("builtin");
 
 const service_types = @import("services/types.zig");
 const cron = @import("services/cron.zig");
+const path_component = @import("../fs/path_component.zig");
 pub const Schedule = service_types.Schedule;
 
 pub const FormulaError = error{
@@ -187,19 +188,6 @@ fn getStringArray(allocator: std.mem.Allocator, obj: std.json.ObjectMap, key: []
 // Parsing
 // ---------------------------------------------------------------------------
 
-/// True when `s` is a single, safe path component. Charset-agnostic: formula
-/// names and versions carry `@`, `+`, and dots that an allowlist would wrongly
-/// reject, so this bars only the shapes that hop out of a component — `.`/`..`,
-/// an embedded `/` or `..`, or a NUL. Empty is left to the caller (a missing
-/// version is legitimate; a missing name is caught as MissingField).
-fn isSafePathComponent(s: []const u8) bool {
-    if (std.mem.eql(u8, s, ".") or std.mem.eql(u8, s, "..")) return false;
-    if (std.mem.indexOfScalar(u8, s, '/') != null) return false;
-    if (std.mem.indexOf(u8, s, "..") != null) return false;
-    if (std.mem.indexOfScalar(u8, s, 0) != null) return false;
-    return true;
-}
-
 /// Parse a Homebrew formula JSON blob into a `Formula`.
 /// The returned value borrows from the parsed JSON; call `deinit()` when done.
 pub fn parseFormula(allocator: std.mem.Allocator, json_data: []const u8) !Formula {
@@ -223,7 +211,7 @@ pub fn parseFormula(allocator: std.mem.Allocator, json_data: []const u8) !Formul
     const name = getString(root, "name") orelse return FormulaError.MissingField;
     // The embedded name never re-passes the requested-name screen yet becomes
     // every keg/cellar/receipt path; full_name is tap-qualified (`/`), so skip.
-    if (!isSafePathComponent(name)) return FormulaError.UnsafePathComponent;
+    if (!path_component.isPathComponent(name)) return FormulaError.UnsafePathComponent;
     const full_name = getString(root, "full_name") orelse name;
     const tap = getString(root, "tap") orelse "";
     const desc = getString(root, "desc") orelse "";
@@ -244,7 +232,7 @@ pub fn parseFormula(allocator: std.mem.Allocator, json_data: []const u8) !Formul
     };
     // version feeds pkg_version → the revision-tagged cellar/keg dir; an empty
     // version is legitimate, but a present one must stay a single component.
-    if (version_str.len != 0 and !isSafePathComponent(version_str))
+    if (version_str.len != 0 and !path_component.isPathComponent(version_str))
         return FormulaError.UnsafePathComponent;
 
     // dependencies

--- a/src/core/services/plist.zig
+++ b/src/core/services/plist.zig
@@ -7,6 +7,7 @@ const std = @import("std");
 const testing = std.testing;
 
 const dsl_sandbox = @import("../dsl/sandbox.zig");
+const path_component = @import("../../fs/path_component.zig");
 const types = @import("types.zig");
 
 pub const Schedule = types.Schedule;
@@ -135,7 +136,7 @@ pub fn validate(
     try checkString(spec.label);
     // The label becomes a single directory component under var/malt/services,
     // so a `/` or `..` inside it escapes that subtree once register writes it.
-    if (!isSafeLabelComponent(spec.label)) return ValidationError.PathEscape;
+    if (!path_component.isPathComponent(spec.label)) return ValidationError.PathEscape;
     try checkString(spec.stdout_path);
     try checkString(spec.stderr_path);
     if (spec.working_dir) |wd| try checkString(wd);
@@ -185,18 +186,6 @@ fn calInRange(ci: CalendarInterval) bool {
 fn checkString(s: []const u8) ValidationError!void {
     if (s.len > max_arg_len) return ValidationError.ArgTooLong;
     if (std.mem.indexOfScalar(u8, s, 0) != null) return ValidationError.EmbeddedNul;
-}
-
-/// True when `label` is a single, safe path component. Charset-agnostic: a real
-/// label is `com.malt.<name>` and may carry dots, `-`, `_`, `@`, `+`, so this
-/// bars only the shapes that hop out of a component — empty, `.`/`..`, an
-/// embedded `/`, or an embedded `..`. NUL is already screened by checkString.
-fn isSafeLabelComponent(label: []const u8) bool {
-    if (label.len == 0) return false;
-    if (std.mem.eql(u8, label, ".") or std.mem.eql(u8, label, "..")) return false;
-    if (std.mem.indexOfScalar(u8, label, '/') != null) return false;
-    if (std.mem.indexOf(u8, label, "..") != null) return false;
-    return true;
 }
 
 pub fn render(spec: ServiceSpec, writer: *std.Io.Writer) !void {

--- a/src/fs/path_component.zig
+++ b/src/fs/path_component.zig
@@ -1,0 +1,27 @@
+//! One definition of "safe path component" for tap-controlled strings.
+//! Formula names/versions, cask tokens/versions, and service labels all reach
+//! disk as single directory components; every ingestion point screens here.
+
+const std = @import("std");
+
+/// True when `s` is a usable single path component. Charset-agnostic so real
+/// names/versions (`@`, `+`, `,`, `:`, dots) pass — it bars only what hops out
+/// of a component: empty, `.`, an embedded `..`, a `/`, or a NUL.
+pub fn isPathComponent(s: []const u8) bool {
+    if (s.len == 0) return false;
+    if (std.mem.eql(u8, s, ".")) return false;
+    if (std.mem.indexOf(u8, s, "..") != null) return false; // also rejects ".."
+    if (std.mem.indexOfScalar(u8, s, '/') != null) return false;
+    if (std.mem.indexOfScalar(u8, s, 0) != null) return false;
+    return true;
+}
+
+test "isPathComponent rejects component-hopping shapes" {
+    const bad = [_][]const u8{ "", ".", "..", "a/b", "../evil", "foo/", "a..b", "1..0", "a\x00b" };
+    for (bad) |s| try std.testing.expect(!isPathComponent(s));
+}
+
+test "isPathComponent accepts real names and versions" {
+    const ok = [_][]const u8{ "com.malt.redis", "openssl@3", "gtk+", "3.2.1+dfsg", "1.2,340:5", "a b" };
+    for (ok) |s| try std.testing.expect(isPathComponent(s));
+}

--- a/src/net/api.zig
+++ b/src/net/api.zig
@@ -3,6 +3,7 @@
 
 const std = @import("std");
 const atomic = @import("../fs/atomic.zig");
+const path_component = @import("../fs/path_component.zig");
 const client_mod = @import("client.zig");
 const mirror_mod = @import("mirror.zig");
 
@@ -73,7 +74,9 @@ pub fn extractNames(
                 .{ .ignore_unknown_fields = true },
             );
             for (parsed) |e| {
-                if (e.name.len == 0) continue;
+                // Drop tap-controlled names that aren't a clean path component;
+                // the search index feeds path-building sinks downstream.
+                if (!path_component.isPathComponent(e.name)) continue;
                 try out.appendSlice(allocator, e.name);
                 try out.append(allocator, '\n');
             }
@@ -87,7 +90,7 @@ pub fn extractNames(
                 .{ .ignore_unknown_fields = true },
             );
             for (parsed) |e| {
-                if (e.token.len == 0) continue;
+                if (!path_component.isPathComponent(e.token)) continue;
                 try out.appendSlice(allocator, e.token);
                 try out.append(allocator, '\n');
             }
@@ -168,7 +171,10 @@ fn appendVersionLine(
     stable: []const u8,
     revision: i64,
 ) !void {
-    if (name.len == 0 or stable.len == 0) return;
+    if (stable.len == 0) return;
+    // Drop a name/token that isn't a clean path component (rejects empty too);
+    // it keys the outdated map against on-disk kegs.
+    if (!path_component.isPathComponent(name)) return;
     // Untrusted dump fields: a tab or newline would corrupt the line-
     // delimited side-car the consumer splits on, so drop the whole entry
     // rather than emit a record that mis-parses downstream.
@@ -865,6 +871,28 @@ test "extractVersions drops entries whose name or version embeds a delimiter" {
     const out = try extractVersions(testing.allocator, .formula, body);
     defer testing.allocator.free(out);
     try testing.expectEqualStrings("ok\t4.0\t0\n", out);
+}
+
+test "extractVersions drops a name that isn't a clean path component" {
+    // The name keys the outdated map against on-disk kegs; a `/` or `..` from
+    // a hostile tap must never reach that sink.
+    const body =
+        \\[{"name":"../evil","versions":{"stable":"1.0"}},
+        \\ {"name":"a/b","versions":{"stable":"1.0"}},
+        \\ {"name":"ok","versions":{"stable":"2.0"}}]
+    ;
+    const out = try extractVersions(testing.allocator, .formula, body);
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("ok\t2.0\t0\n", out);
+}
+
+test "extractNames drops a name that isn't a clean path component" {
+    const body =
+        \\[{"name":"../evil"},{"name":"redis"}]
+    ;
+    const out = try extractNames(testing.allocator, .formula, body);
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("redis\n", out);
 }
 
 test "extractVersions clamps a negative revision to 0" {


### PR DESCRIPTION
## Description

The formula parser copied the embedded `name` and `version` straight out of tap JSON into keg/cellar/receipt paths without re-screening them - the fetch-time name check only covers the *requested* name, not the JSON's own fields, so a compromised or third-party tap could steer a write out of the prefix. 

This adds a guard at `parseFormula`, then centralizes the rule: cask token/version, service label, and formula name/version each carried a near-identical private predicate, now replaced by one `fs/path_component.zig` leaf that every ingestion point screens against - so tap-controlled strings are clean by construction and every current and future path sink inherits the check. The bulk index parsers (`extractNames`/`extractVersions`) that feed search and the outdated side-car are screened too.

## Related Issue

- None

## Notes for Reviewers

- None