### PR TITLE
fix(update): report a restored self-update as a clean failure, not a broken rollback

### DIFF
--- a/scripts/regressions/atomicreplace-false-rollbackfailed.sh
+++ b/scripts/regressions/atomicreplace-false-rollbackfailed.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Regression: a self-update swap whose staged -> target rename fails but whose
+# .old -> target restore succeeds must be reported as SwapFailed, not
+# RollbackFailed.
+#
+# The bug: the second rename's failure was mapped unconditionally to
+# RollbackFailed while an errdefer quietly restored target from .old. The tree
+# ended up consistent (original binary back in place, .old consumed) but the
+# caller printed "rollback also failed" plus a `mv <self>.old <self>` hint that
+# errors because .old no longer exists. The genuine inconsistent state (the
+# restore itself failing) was unreachable.
+#
+# The failure needs the second rename to fail after the first succeeds, which
+# is not reachable from the malt CLI. A colocated `test {}` block injects that
+# rename failure through a file-private seam and asserts the returned error is
+# SwapFailed, target holds the original bytes, and no <target>.old remains.
+# This script builds the colocated test binary and runs that test by name; it
+# exits non-zero if the guard regresses or the test goes missing.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s once the test binary is built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+SRC="$ROOT/src/update/swap.zig"
+
+TEST_NAME="atomicReplace reports a successful restore as SwapFailed, not RollbackFailed"
+
+# The guard lives in a colocated `test {}` block; if it is ever deleted the
+# name match below would find nothing and silently pass. Fail loudly instead.
+if ! grep -Rqs -- "$TEST_NAME" "$SRC"; then
+  echo "FAIL: rollback-reporting guard test missing from swap.zig" >&2
+  exit 1
+fi
+
+# Rebuild the colocated test binary so the run reflects the working tree.
+if ! (cd "$ROOT" && zig build test-bin >/dev/null 2>&1); then
+  echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+
+# The runner has no per-test filter, so run the colocated suite and judge only
+# this guard's line: a pass ends in "OK", the bug prints the returned code.
+OUT=$("$BIN" 2>&1 || true)
+LINE=$(printf '%s\n' "$OUT" | grep -F -- "$TEST_NAME" || true)
+if [[ -z "$LINE" ]]; then
+  echo "FAIL: rollback-reporting guard test did not run" >&2
+  exit 1
+fi
+if [[ "$LINE" != *OK ]]; then
+  echo "FAIL: successful rollback still reported as RollbackFailed: $LINE" >&2
+  exit 1
+fi
+
+echo "PASS: rollback after rename-#2 failure reports SwapFailed, target restored, no .old"

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -54,6 +54,27 @@ pub fn parseArgs(args: []const []const u8) Opts {
     return opts;
 }
 
+/// Emit the manual-recovery hint for a failed self-replace, split out so the
+/// error→message mapping is unit-testable. `RollbackFailed` strands the old
+/// binary at `.old` (loud `mv` recovery); everything else leaves the target
+/// intact (normal install hint). Printing the wrong one misleads the user.
+fn printReplaceFailure(err: swap.SwapError, new_binary: []const u8, self_exe: []const u8) void {
+    switch (err) {
+        error.RollbackFailed => {
+            // Two renames went one-and-a-half: target is gone, .old is still
+            // the previous binary. The next invocation the user makes cannot
+            // find `malt` on PATH, so surface the recovery path loudly.
+            output.err("Update aborted mid-swap; rollback also failed.", .{});
+            output.info("Restore the previous binary with:", .{});
+            output.info("  sudo mv {s}.old {s}", .{ self_exe, self_exe });
+        },
+        else => {
+            output.err("Failed to replace {s}.", .{self_exe});
+            output.info("Manual update: sudo install -m 0755 -b -B .old {s} {s}", .{ new_binary, self_exe });
+        },
+    }
+}
+
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
     const opts = parseArgs(args);
 
@@ -242,17 +263,11 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             return error.Aborted;
         },
         error.StagingFailed, error.SwapFailed => {
-            output.err("Failed to replace {s}.", .{self_exe});
-            output.info("Manual update: sudo install -m 0755 -b -B .old {s} {s}", .{ new_binary, self_exe });
+            printReplaceFailure(error.SwapFailed, new_binary, self_exe);
             return;
         },
         error.RollbackFailed => {
-            // Two renames went one-and-a-half: target is gone, .old is still
-            // the previous binary. The next invocation the user makes
-            // cannot find `malt` on PATH, so surface the recovery path loudly.
-            output.err("Update aborted mid-swap; rollback also failed.", .{});
-            output.info("Restore the previous binary with:", .{});
-            output.info("  sudo mv {s}.old {s}", .{ self_exe, self_exe });
+            printReplaceFailure(error.RollbackFailed, new_binary, self_exe);
             return error.Aborted;
         },
         else => return e,
@@ -546,4 +561,28 @@ fn detectOrigin(io: std.Io) origin.Origin {
 fn unverifiedAllowed(environ: std.process.Environ) bool {
     const v = std.process.Environ.getPosix(environ, "MALT_ALLOW_UNVERIFIED") orelse return false;
     return std.mem.eql(u8, v, "1");
+}
+
+test "printReplaceFailure emits the loud mv-recovery only for RollbackFailed" {
+    const testing = std.testing;
+    const self_exe = "/opt/malt/bin/malt";
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(testing.allocator);
+
+    // SwapFailed: target untouched, so the normal install hint — and NOT the
+    // `mv .old` line, which would fail because a successful swap never left a
+    // stranded `.old`.
+    output.beginStderrCapture(testing.allocator, &buf);
+    printReplaceFailure(error.SwapFailed, "/tmp/malt.new", self_exe);
+    output.endStderrCapture();
+    try testing.expect(std.mem.indexOf(u8, buf.items, "sudo install -m 0755 -b -B .old") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "sudo mv") == null);
+
+    // RollbackFailed: previous binary stranded at `.old`, so the loud recovery
+    // hint must name the exact `mv` that puts it back.
+    buf.clearRetainingCapacity();
+    output.beginStderrCapture(testing.allocator, &buf);
+    printReplaceFailure(error.RollbackFailed, "/tmp/malt.new", self_exe);
+    output.endStderrCapture();
+    try testing.expect(std.mem.indexOf(u8, buf.items, "sudo mv /opt/malt/bin/malt.old /opt/malt/bin/malt") != null);
 }

--- a/src/update/swap.zig
+++ b/src/update/swap.zig
@@ -24,6 +24,15 @@ pub const SwapError = error{
     PermissionDenied,
 };
 
+/// The rename primitive that `atomicReplaceImpl` moves files with. The
+/// public entry point wires the real `renameAbsolute`; a test injects a
+/// stub to fail a chosen rename without a real cross-device move.
+const RenameFn = *const fn (old_path: []const u8, new_path: []const u8, io: std.Io) std.Io.Dir.RenameError!void;
+
+fn realRename(old_path: []const u8, new_path: []const u8, io: std.Io) std.Io.Dir.RenameError!void {
+    return std.Io.Dir.renameAbsolute(old_path, new_path, io);
+}
+
 /// Replace `target_path` with the contents of `new_path`. On success,
 /// the previous binary is kept at `<target_path>.old` for manual
 /// rollback. On failure during the swap, the previous binary is
@@ -33,6 +42,10 @@ pub const SwapError = error{
 /// extraction in `$TMPDIR` without caring whether it shares a volume
 /// with the target.
 pub fn atomicReplace(io: std.Io, target_path: []const u8, new_path: []const u8) SwapError!void {
+    return atomicReplaceImpl(io, target_path, new_path, realRename);
+}
+
+fn atomicReplaceImpl(io: std.Io, target_path: []const u8, new_path: []const u8, rename_fn: RenameFn) SwapError!void {
     const target_dir = std.fs.path.dirname(target_path) orelse return error.SwapFailed;
 
     var old_path_buf: [std.fs.max_path_bytes]u8 = undefined;
@@ -78,21 +91,18 @@ pub fn atomicReplace(io: std.Io, target_path: []const u8, new_path: []const u8) 
 
     // Atomic rename #1: target -> target.old. EACCES/EPERM here means
     // the dir is unwritable — same sudo-fallback path as the staging copy.
-    std.Io.Dir.renameAbsolute(target_path, old_path, io) catch |e| switch (e) {
+    rename_fn(target_path, old_path, io) catch |e| switch (e) {
         error.AccessDenied, error.PermissionDenied => return error.PermissionDenied,
         else => return error.SwapFailed,
     };
-    // Rollback on late failure: restore target from .old and drop the
-    // never-installed stage in one explicit block so the unwind reads
-    // top-to-bottom. The stage errdefer above also fires after this and
-    // is a no-op once the file is gone.
-    errdefer {
-        std.Io.Dir.renameAbsolute(old_path, target_path, io) catch {};
-        std.Io.Dir.deleteFileAbsolute(io, staged_path) catch {};
-    }
 
-    // Atomic rename #2: staged -> target.
-    std.Io.Dir.renameAbsolute(staged_path, target_path, io) catch return error.RollbackFailed;
+    // Atomic rename #2: staged -> target. On failure, restore from .old: a
+    // confirmed restore is a clean SwapFailed, only an unconfirmed one is
+    // RollbackFailed. The stage-drop errdefer clears the temp on both.
+    rename_fn(staged_path, target_path, io) catch {
+        rename_fn(old_path, target_path, io) catch return error.RollbackFailed;
+        return error.SwapFailed;
+    };
 
     // Flush the parent so both rename dirents are durable. Swallowing
     // errors here is fine: the swap already succeeded in the page cache;
@@ -102,4 +112,110 @@ pub fn atomicReplace(io: std.Io, target_path: []const u8, new_path: []const u8) 
     defer dir.close(io);
     const dir_file: std.Io.File = .{ .handle = dir.handle, .flags = .{ .nonblocking = false } };
     dir_file.sync(io) catch {};
+}
+
+// --- tests ---------------------------------------------------------------
+
+const testing = std.testing;
+
+// The rename stubs are non-capturing fn pointers, so they can't hold a
+// per-call counter of their own; they share this file-scope one, which
+// each test resets before use.
+var rename_calls: usize = 0;
+
+// Fails rename #2 (staged -> target) with EXDEV; rename #1 and the restore
+// succeed.
+fn failStagedRename(old_path: []const u8, new_path: []const u8, io: std.Io) std.Io.Dir.RenameError!void {
+    rename_calls += 1;
+    if (rename_calls == 2) return error.CrossDevice;
+    return std.Io.Dir.renameAbsolute(old_path, new_path, io);
+}
+
+// Fails rename #2 and every rename after it, so the restore also fails and
+// target is left unrecovered — the only genuinely inconsistent state.
+fn failStagedAndRestore(old_path: []const u8, new_path: []const u8, io: std.Io) std.Io.Dir.RenameError!void {
+    rename_calls += 1;
+    if (rename_calls >= 2) return error.CrossDevice;
+    return std.Io.Dir.renameAbsolute(old_path, new_path, io);
+}
+
+fn expectMissing(io: std.Io, path: []const u8) !void {
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(io, path, .{}));
+}
+
+fn expectBytes(io: std.Io, path: []const u8, want: []const u8) !void {
+    var buf: [16]u8 = undefined;
+    const f = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer f.close(io);
+    const n = try f.readPositionalAll(io, &buf, 0);
+    try testing.expectEqualStrings(want, buf[0..n]);
+}
+
+// A fresh scratch dir holding a `target` (OLD) and `new` (NEW), with the
+// `.old` and staged paths the impl derives. Mirrors the fixture style in
+// tests/swap_test.zig; `staged` uses the same pid the impl does.
+const Scratch = struct {
+    dir: []u8,
+    target: []u8,
+    new: []u8,
+    old: []u8,
+    staged: []u8,
+
+    fn init(a: std.mem.Allocator, io: std.Io, tag: []const u8) !Scratch {
+        const dir = try std.fmt.allocPrint(a, "/tmp/malt-swap-{s}-{d}", .{ tag, std.c.getpid() });
+        std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+        try std.Io.Dir.createDirAbsolute(io, dir, .default_dir);
+        const s: Scratch = .{
+            .dir = dir,
+            .target = try std.fmt.allocPrint(a, "{s}/malt", .{dir}),
+            .new = try std.fmt.allocPrint(a, "{s}/malt.new", .{dir}),
+            .old = try std.fmt.allocPrint(a, "{s}/malt.old", .{dir}),
+            .staged = try std.fmt.allocPrint(a, "{s}/.malt-update-{d}", .{ dir, std.c.getpid() }),
+        };
+        const t = try std.Io.Dir.createFileAbsolute(io, s.target, .{});
+        try t.writeStreamingAll(io, "OLD");
+        t.close(io);
+        const n = try std.Io.Dir.createFileAbsolute(io, s.new, .{});
+        try n.writeStreamingAll(io, "NEW");
+        n.close(io);
+        return s;
+    }
+
+    fn deinit(self: Scratch, io: std.Io, a: std.mem.Allocator) void {
+        std.Io.Dir.cwd().deleteTree(io, self.dir) catch {};
+        for ([_][]u8{ self.dir, self.target, self.new, self.old, self.staged }) |p| a.free(p);
+    }
+};
+
+test "atomicReplace reports a successful restore as SwapFailed, not RollbackFailed" {
+    const io = std.Options.debug_io;
+    const s = try Scratch.init(testing.allocator, io, "swapfailed");
+    defer s.deinit(io, testing.allocator);
+
+    rename_calls = 0;
+    const result = atomicReplaceImpl(io, s.target, s.new, failStagedRename);
+
+    // Restore consumed `.old`, so the tree is consistent: the caller must be
+    // told the swap failed (target intact), NOT that the rollback failed —
+    // the latter's `mv <self>.old <self>` hint would error, `.old` is gone.
+    try testing.expectError(error.SwapFailed, result);
+    try expectBytes(io, s.target, "OLD");
+    try expectMissing(io, s.old);
+    try expectMissing(io, s.staged);
+}
+
+test "atomicReplace reports RollbackFailed only when the restore itself fails" {
+    const io = std.Options.debug_io;
+    const s = try Scratch.init(testing.allocator, io, "rollbackfailed");
+    defer s.deinit(io, testing.allocator);
+
+    rename_calls = 0;
+    const result = atomicReplaceImpl(io, s.target, s.new, failStagedAndRestore);
+
+    // Restore failed: target is gone, the previous binary sits at `.old`.
+    // This is exactly the state the loud recovery hint is for.
+    try testing.expectError(error.RollbackFailed, result);
+    try expectMissing(io, s.target);
+    try expectBytes(io, s.old, "OLD");
+    try expectMissing(io, s.staged);
 }


### PR DESCRIPTION
## Description

When a self-update swap failed on the second rename (`staged → target`) but the rollback then succeeded, `mt version update` reported the worst-case `RollbackFailed` and told the user to run `sudo mv <self>.old <self>` - a command that always failed, because the rollback had already consumed `.old`. The loud "rollback also failed" message also misrepresented a fully-recovered tree as
catastrophic.

The second-rename failure is now handled explicitly: the target is restored from `.old`, and a **confirmed** restore returns `SwapFailed` (target intact → normal manual-install hint). `RollbackFailed` is returned **only** when the restore itself cannot be confirmed - the one genuinely inconsistent state the loud recovery hint exists for.

## Related Issue

- None

## Notes for Reviewers

- None