### PR TITLE
fix(update): remove the twin's .old backup and show help without starting the updater

### DIFF
--- a/man/malt.1
+++ b/man/malt.1
@@ -728,7 +728,22 @@ Lookup order for install/export without an explicit path:
 .fi
 .SS version
 .nf
-malt 0.20.0
+Usage: malt version [update] [flags]
+
+Show the installed malt version. `malt version update` downloads
+and installs the latest malt release (cosign + SHA256 verified).
+
+Update flags:
+  --check      Only report whether a newer release exists
+  --yes, -y    Skip the confirmation prompt
+  --no-verify  Skip signature/checksum verification (also needs
+               MALT_ALLOW_UNVERIFIED=1; not recommended)
+  --cleanup    Remove .old backups and staging files, then exit
+
+Examples:
+  malt version
+  malt version update --check
+  malt version update --cleanup
 .fi
 .SH ENVIRONMENT
 .nf

--- a/scripts/regressions/cleanupdateartefacts-misses-malt-old-symlink-layout.sh
+++ b/scripts/regressions/cleanupdateartefacts-misses-malt-old-symlink-layout.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Regression: `version update --cleanup` must remove every self-update
+# artefact in the post-migration layout — malt.old, mt.old, and
+# .malt-update-* staging — when invoked through the `mt` symlink.
+#
+# The bug: an update from the legacy dual-regular-file layout swaps both
+# binaries (producing malt.old AND mt.old) before migrating `mt` to a
+# symlink. Cleanup only deleted `<resolved self>.old` = malt.old, so
+# mt.old was orphaned forever and a second run claimed "Nothing to clean
+# up." while it still sat on disk.
+#
+# Exits 0 when all artefacts are removed, non-zero naming the survivor.
+# Fully offline; finishes well under 30s given a built binary.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# `zig build test` never rebuilds zig-out/bin/malt — build explicitly.
+if [ ! -x "$ROOT/zig-out/bin/malt" ]; then
+  (cd "$ROOT" && zig build)
+fi
+
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+cp "$ROOT/zig-out/bin/malt" "$T/malt"
+ln -s malt "$T/mt"
+touch "$T/malt.old" "$T/mt.old" "$T/.malt-update-99999"
+
+"$T/mt" version update --cleanup >/dev/null
+
+status=0
+for leftover in malt.old mt.old .malt-update-99999; do
+  if [ -e "$T/$leftover" ]; then
+    echo "FAIL: --cleanup left $leftover behind" >&2
+    status=1
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  exit "$status"
+fi
+
+# A clean second run pins the report path: pre-fix it printed
+# "Nothing to clean up." while mt.old was still on disk.
+second=$("$T/mt" version update --cleanup 2>&1)
+if ! printf '%s' "$second" | grep -q "Nothing to clean up"; then
+  echo "FAIL: second cleanup run still reported artefacts" >&2
+  exit 1
+fi
+
+echo "OK: all update artefacts removed"

--- a/scripts/regressions/version-update-help-triggers-live-update-check.sh
+++ b/scripts/regressions/version-update-help-triggers-live-update-check.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Regression: `malt version update --help` must print the version help
+# text instead of starting a live update check, and `malt version --help`
+# must print the same help instead of just the version number.
+#
+# The bug: the `version` dispatch arm never intercepted -h/--help, so
+# `version update --help` went straight into the self-updater (network
+# lookup, download prompt) and there was no `version` entry in the help
+# table at all.
+#
+# Runs with --offline so a regressed binary can never reach the network.
+# Exits 0 when both invocations show the help text, non-zero otherwise.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# `zig build test` never rebuilds zig-out/bin/malt — build explicitly.
+if [ ! -x "$ROOT/zig-out/bin/malt" ]; then
+  (cd "$ROOT" && zig build)
+fi
+
+BIN="$ROOT/zig-out/bin/malt"
+status=0
+
+for argv in "version update --help" "version --help" "version update -h"; do
+  # shellcheck disable=SC2086 # intentional word splitting of the argv string
+  out=$("$BIN" --offline $argv 2>&1) || true
+  if ! printf '%s' "$out" | grep -q "Usage: malt version"; then
+    echo "FAIL: 'malt $argv' did not print the version help" >&2
+    status=1
+  fi
+done
+
+[ "$status" -eq 0 ] && echo "OK: version help intercepted before the updater"
+exit "$status"

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -153,6 +153,7 @@ pub const bash_script =
     \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --pinned --force -f --isolate-deps --isolate-dependencies" ;;
     \\        outdated)         cmd_flags="--json --formula --cask --pinned-only --tap --refresh --quiet -q" ;;
     \\        update)           cmd_flags="--check --quiet -q" ;;
+    \\        version)          cmd_flags="--check --yes -y --no-verify --cleanup" ;;
     \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --tap --json --size --linked --quiet -q" ;;
     \\        info)             cmd_flags="--formula --cask --json" ;;
     \\        search)           cmd_flags="--formula --cask --json --installed --api --all --offline" ;;
@@ -418,7 +419,12 @@ pub const zsh_script =
     \\                        '--output-format=ndjson[Stream one event per scope start/complete + purge_complete]'
     \\                    ;;
     \\                version)
-    \\                    _values 'subcommand' 'update[Self-update the binary]'
+    \\                    _arguments \
+    \\                        '--check[Only report whether a newer release exists]' \
+    \\                        '(--yes -y)'{--yes,-y}'[Skip the confirmation prompt]' \
+    \\                        '--no-verify[Skip signature/checksum verification]' \
+    \\                        '--cleanup[Remove .old backups and staging files]' \
+    \\                        '1:subcommand:(update)'
     \\                    ;;
     \\                services)
     \\                    _values 'subcommand' \
@@ -717,8 +723,12 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command purge' -s y -l yes             -d 'Skip every typed confirmation'
     \\    complete -c $__malt_bin -n '__malt_using_command purge' -s n -l dry-run          -d 'Preview without removing'
     \\
-    \\    # version — sub-subcommand
+    \\    # version — sub-subcommand + update flags
     \\    complete -c $__malt_bin -n '__malt_using_command version' -f -a 'update' -d 'Self-update'
+    \\    complete -c $__malt_bin -n '__malt_using_command version' -l check     -d 'Only report whether a newer release exists'
+    \\    complete -c $__malt_bin -n '__malt_using_command version' -l yes -s y  -d 'Skip the confirmation prompt'
+    \\    complete -c $__malt_bin -n '__malt_using_command version' -l no-verify -d 'Skip signature/checksum verification'
+    \\    complete -c $__malt_bin -n '__malt_using_command version' -l cleanup   -d 'Remove .old backups and staging files'
     \\
     \\    # services — sub-subcommands
     \\    complete -c $__malt_bin -n '__malt_using_command services' -f -a 'list'    -d 'Show registered services'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -49,6 +49,7 @@ pub fn helpFor(command: []const u8) []const u8 {
         .{ "pin", pin_help },
         .{ "unpin", unpin_help },
         .{ "tui", tui_help },
+        .{ "version", version_help },
     });
     return map.get(command) orelse "No help available.\n";
 }
@@ -699,5 +700,25 @@ const which_help =
     \\  malt which jq
     \\  malt which /opt/malt/bin/jq
     \\  malt --json which jq
+    \\
+;
+
+const version_help =
+    \\Usage: malt version [update] [flags]
+    \\
+    \\Show the installed malt version. `malt version update` downloads
+    \\and installs the latest malt release (cosign + SHA256 verified).
+    \\
+    \\Update flags:
+    \\  --check      Only report whether a newer release exists
+    \\  --yes, -y    Skip the confirmation prompt
+    \\  --no-verify  Skip signature/checksum verification (also needs
+    \\               MALT_ALLOW_UNVERIFIED=1; not recommended)
+    \\  --cleanup    Remove .old backups and staging files, then exit
+    \\
+    \\Examples:
+    \\  malt version
+    \\  malt version update --check
+    \\  malt version update --cleanup
     \\
 ;

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -544,7 +544,7 @@ fn runCleanup(ctx: *const AppCtx) !void {
     if (cleaned.total() == 0) {
         output.info("Nothing to clean up.", .{});
     } else {
-        output.info("Removed {d} .old binary, {d} staging file(s).", .{ cleaned.old, cleaned.staging });
+        output.info("Removed {d} .old file(s), {d} staging file(s).", .{ cleaned.old, cleaned.staging });
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -730,6 +730,9 @@ fn dispatch(allocator: std.mem.Allocator, ctx: *const AppCtx, cmd: Command, cmd_
         .deps => try deps_cmd.execute(ctx, allocator, cmd_args),
         .which => try which_cmd.execute(ctx, allocator, cmd_args),
         .version => {
+            // Intercept -h/--help here: the updater must never start a
+            // release lookup just because help was requested.
+            if (cli_help.showIfRequested(ctx, cmd_args, "version")) return;
             // "mt version" — check for "mt version update" subcommand
             if (cmd_args.len > 0 and std.mem.eql(u8, cmd_args[0], "update")) {
                 try version_update.execute(ctx, allocator, cmd_args[1..]);

--- a/src/update/cleanup.zig
+++ b/src/update/cleanup.zig
@@ -1,14 +1,15 @@
 //! malt - cleanup of self-update artefacts.
 //!
-//! `<target>.old` is kept for manual rollback after each update.
+//! `<target>.old` is kept for manual rollback after each update. A
+//! legacy dual-binary update also leaves the twin's `.old` behind.
 //! Over time these accumulate, and killed updates may leave
 //! `.malt-update-<pid>` staging files behind. `cleanUpdateArtefacts`
-//! removes both from the target's directory.
+//! removes all of them from the target's directory.
 
 const std = @import("std");
 
 pub const Cleaned = struct {
-    /// Number of `<target>.old` files removed (0 or 1).
+    /// Number of `.old` files removed (target's and its twin's, 0-2).
     old: u32 = 0,
     /// Number of `.malt-update-<pid>` staging files removed.
     staging: u32 = 0,
@@ -18,9 +19,9 @@ pub const Cleaned = struct {
     }
 };
 
-/// Remove `<target>.old` and any `.malt-update-*` staging files in
-/// `target`'s directory. Silent on missing files - "already clean" is
-/// a success state, not an error.
+/// Remove `<target>.old`, the twin's `.old` (`malt` <-> `mt`), and any
+/// `.malt-update-*` staging files in `target`'s directory. Silent on
+/// missing files - "already clean" is a success state, not an error.
 pub fn cleanUpdateArtefacts(io: std.Io, target_path: []const u8) !Cleaned {
     var cleaned = Cleaned{};
 
@@ -31,6 +32,20 @@ pub fn cleanUpdateArtefacts(io: std.Io, target_path: []const u8) !Cleaned {
     } else |_| {}
 
     const target_dir = std.fs.path.dirname(target_path) orelse return cleaned;
+
+    // A legacy dual-regular-file update swaps both binaries before the
+    // twin becomes a symlink, so the twin's .old must be swept too.
+    const base = std.fs.path.basename(target_path);
+    const twin_base: ?[]const u8 =
+        if (std.mem.eql(u8, base, "malt")) "mt" else if (std.mem.eql(u8, base, "mt")) "malt" else null;
+    if (twin_base) |tb| {
+        var twin_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const twin_old = try std.fmt.bufPrint(&twin_buf, "{s}/{s}.old", .{ target_dir, tb });
+        if (std.Io.Dir.deleteFileAbsolute(io, twin_old)) |_| {
+            cleaned.old += 1;
+        } else |_| {}
+    }
+
     var dir = std.Io.Dir.openDirAbsolute(io, target_dir, .{ .iterate = true }) catch return cleaned;
     defer dir.close(io);
 

--- a/tests/cleanup_test.zig
+++ b/tests/cleanup_test.zig
@@ -45,6 +45,72 @@ test "cleanUpdateArtefacts removes the .old sibling" {
     try testing.expect(exists(target)); // live binary must survive
 }
 
+test "cleanUpdateArtefacts removes the twin's .old alongside the target's" {
+    const dir = try resetScratch(testing.allocator, "twin_both");
+    defer testing.allocator.free(dir);
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
+
+    const target = try std.fmt.allocPrint(testing.allocator, "{s}/malt", .{dir});
+    defer testing.allocator.free(target);
+    const old = try std.fmt.allocPrint(testing.allocator, "{s}/malt.old", .{dir});
+    defer testing.allocator.free(old);
+    const twin_old = try std.fmt.allocPrint(testing.allocator, "{s}/mt.old", .{dir});
+    defer testing.allocator.free(twin_old);
+
+    try writeFile(target, "live");
+    try writeFile(old, "previous");
+    try writeFile(twin_old, "previous twin");
+
+    const cleaned = try cleanup.cleanUpdateArtefacts(std.Options.debug_io, target);
+    try testing.expectEqual(@as(u32, 2), cleaned.old);
+    try testing.expect(!exists(old));
+    try testing.expect(!exists(twin_old));
+    try testing.expect(exists(target));
+}
+
+test "cleanUpdateArtefacts targeting mt removes malt.old via the twin branch" {
+    const dir = try resetScratch(testing.allocator, "twin_only");
+    defer testing.allocator.free(dir);
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
+
+    const target = try std.fmt.allocPrint(testing.allocator, "{s}/mt", .{dir});
+    defer testing.allocator.free(target);
+    const twin_old = try std.fmt.allocPrint(testing.allocator, "{s}/malt.old", .{dir});
+    defer testing.allocator.free(twin_old);
+
+    try writeFile(target, "live");
+    try writeFile(twin_old, "previous twin");
+
+    const cleaned = try cleanup.cleanUpdateArtefacts(std.Options.debug_io, target);
+    try testing.expectEqual(@as(u32, 1), cleaned.old);
+    try testing.expect(!exists(twin_old));
+    try testing.expect(exists(target));
+}
+
+test "cleanUpdateArtefacts skips the twin sweep for generic target names" {
+    // Only the malt/mt pair gets twin treatment - a generic name must
+    // not trigger deletion of unrelated malt.old/mt.old bystanders.
+    const dir = try resetScratch(testing.allocator, "generic_name");
+    defer testing.allocator.free(dir);
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
+
+    const target = try std.fmt.allocPrint(testing.allocator, "{s}/tool", .{dir});
+    defer testing.allocator.free(target);
+    const own_old = try std.fmt.allocPrint(testing.allocator, "{s}/tool.old", .{dir});
+    defer testing.allocator.free(own_old);
+    const bystander = try std.fmt.allocPrint(testing.allocator, "{s}/mt.old", .{dir});
+    defer testing.allocator.free(bystander);
+
+    try writeFile(target, "live");
+    try writeFile(own_old, "previous");
+    try writeFile(bystander, "unrelated");
+
+    const cleaned = try cleanup.cleanUpdateArtefacts(std.Options.debug_io, target);
+    try testing.expectEqual(@as(u32, 1), cleaned.old);
+    try testing.expect(!exists(own_old));
+    try testing.expect(exists(bystander));
+}
+
 test "cleanUpdateArtefacts removes all .malt-update-* staging files" {
     const dir = try resetScratch(testing.allocator, "staging_only");
     defer testing.allocator.free(dir);

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -216,6 +216,15 @@ test "all bundle completions expose the cleanup subcommand and its flags" {
     try expectContains(completions.fish_script, "-l yes");
 }
 
+test "version completions expose the update flags across every shell" {
+    // `mt version update` has a documented flag set; the completions
+    // must surface it so the self-updater is discoverable without --help.
+    try expectContains(completions.bash_script, "--no-verify");
+    try expectContains(completions.zsh_script, "--no-verify[");
+    try expectContains(completions.fish_script, "-l no-verify");
+    try expectContains(completions.fish_script, "-l cleanup");
+}
+
 test "backup completions expose --services across every shell" {
     // `mt backup --services` is the user-visible verb that closes the
     // launchd-bootstrap round-trip; the completions must surface it so

--- a/tests/help_test.zig
+++ b/tests/help_test.zig
@@ -39,12 +39,12 @@ test "showIfRequested returns true for long --help" {
 test "showIfRequested covers every documented command (exercises every branch of the static map)" {
     const ctx = quietCtx();
     const commands = [_][]const u8{
-        "install",  "uninstall",   "upgrade",            "update",
-        "outdated", "list",        "info",               "search",
-        "doctor",   "tap",         "migrate",            "rollback",
-        "run",      "link",        "unlink",             "pin",
-        "unpin",    "completions", "backup",             "restore",
-        "purge",    "tui",         "not-a-real-command",
+        "install",  "uninstall",   "upgrade", "update",
+        "outdated", "list",        "info",    "search",
+        "doctor",   "tap",         "migrate", "rollback",
+        "run",      "link",        "unlink",  "pin",
+        "unpin",    "completions", "backup",  "restore",
+        "purge",    "tui",         "version", "not-a-real-command",
     };
     const args = [_][]const u8{"--help"};
     for (commands) |cmd| {
@@ -150,6 +150,14 @@ test "showIfRequested honours --help for cleanup" {
     const ctx = quietCtx();
     const args = [_][]const u8{"--help"};
     try testing.expect(help.showIfRequested(&ctx, &args, "cleanup"));
+}
+
+test "version help documents the update subcommand and its flags" {
+    const text = help.helpFor("version");
+    try testing.expect(std.mem.indexOf(u8, text, "malt version") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "update") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "--check") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "--cleanup") != null);
 }
 
 // Integration: verify that `malt <cmd> --help` writes to stdout (not stderr).


### PR DESCRIPTION
## Description

Two self-update UX fixes in the `version` command surface:

- **`--cleanup` now removes every update artefact.** An update from the legacy dual-regular-file layout swaps both binaries — leaving `malt.old` and `mt.old` — before migrating `mt` to a symlink. Cleanup only deleted the resolved target's `.old`, orphaning the twin's multi-megabyte backup forever while claiming "Nothing to clean up." It now derives the twin basename (`malt` ↔ `mt`) and sweeps its `.old` too; generic target names keep the previous single-`.old` behaviour.
- **`--help` no longer starts a live update check.** The `version` dispatch arm never intercepted `-h`/`--help`, so `malt version update --help` went straight into the updater (network lookup, download prompt), and there was no `version` entry in the help table at all. Help is now intercepted before dispatch, and `malt version` has a proper help page documenting the `update` flags. The man page is regenerated accordingly.

## Related Issue

- None

## Notes for Reviewers

- None