### PR TITLE
fix(cli): route the help command's argument to its command topic

### DIFF
--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -121,6 +121,12 @@ pub const bash_script =
     \\                return 0
     \\            fi
     \\            ;;
+    \\        help)
+    \\            if [[ "$cur" != -* ]]; then
+    \\                COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
+    \\                return 0
+    \\            fi
+    \\            ;;
     \\        services)
     \\            if [[ "$cur" != -* ]]; then
     \\                COMPREPLY=( $(compgen -W "list start stop restart status logs" -- "$cur") )
@@ -383,6 +389,9 @@ pub const zsh_script =
     \\                    ;;
     \\                completions|shellenv)
     \\                    _values 'shell' bash zsh fish
+    \\                    ;;
+    \\                help)
+    \\                    _describe -t commands 'malt command' commands
     \\                    ;;
     \\                backup)
     \\                    _arguments \
@@ -740,6 +749,9 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command services' -l tail   -d 'Number of trailing log lines'
     \\    complete -c $__malt_bin -n '__malt_using_command services' -l stderr -d 'Read stderr instead of stdout'
     \\    complete -c $__malt_bin -n '__malt_using_command services' -l follow -s f -d 'Tail appended bytes until SIGINT'
+    \\
+    \\    # help — command topic
+    \\    complete -c $__malt_bin -n '__malt_using_command help' -f -a 'install reinstall uninstall remove upgrade update outdated list ls info search uses deps which doctor tap untap migrate rollback link unlink pin unpin run version completions shellenv backup restore purge cleanup services tui bundle' -d 'Help topic'
     \\
     \\    # bundle — sub-subcommands
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -f -a 'install' -d 'Install Brewfile/Maltfile.json members'

--- a/src/main.zig
+++ b/src/main.zig
@@ -740,7 +740,15 @@ fn dispatch(allocator: std.mem.Allocator, ctx: *const AppCtx, cmd: Command, cmd_
                 printVersion(ctx);
             }
         },
-        .help => printUsage(ctx),
+        .help => {
+            // `malt help <cmd>` routes to that command's topic; bare
+            // `malt help` keeps the general usage.
+            if (cmd_args.len > 0) {
+                ctx.stdout.writeStreamingAll(ctx.io, cli_help.helpFor(cmd_args[0])) catch {};
+            } else {
+                printUsage(ctx);
+            }
+        },
         .version_flag => printVersion(ctx),
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -282,6 +282,14 @@ test "dispatch accepts AppCtx and routes help without panic" {
     try dispatch(std.testing.allocator, &ctx, .help, &.{});
 }
 
+test "dispatch routes a help topic argument without panic" {
+    // Both the known-topic and unknown-topic branches must stay total —
+    // an unknown topic falls back to helpFor's stock message, not an error.
+    const ctx: AppCtx = .{ .io = std.Options.debug_io, .environ = .empty };
+    try dispatch(std.testing.allocator, &ctx, .help, &.{"install"});
+    try dispatch(std.testing.allocator, &ctx, .help, &.{"not-a-real-command"});
+}
+
 test "passthroughStart finds the first -- after the command token" {
     const argv = &[_][]const u8{ "run", "jq", "--", "--json" };
     try std.testing.expectEqual(@as(?usize, 2), passthroughStart(argv));

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -233,3 +233,11 @@ test "backup completions expose --services across every shell" {
     try expectContains(completions.zsh_script, "'--services[");
     try expectContains(completions.fish_script, "-l services");
 }
+
+test "help completions offer command topics across every shell" {
+    // `mt help <cmd>` takes a command topic; each shell must suggest the
+    // command names after `help` so topics are discoverable.
+    try expectContains(completions.bash_script, "help)");
+    try expectContains(completions.zsh_script, "help)");
+    try expectContains(completions.fish_script, "__malt_using_command help");
+}

--- a/tests/help_test.zig
+++ b/tests/help_test.zig
@@ -203,3 +203,24 @@ test "help command routes its argument to the per-command topic" {
     try testing.expectEqual(std.process.Child.Term{ .exited = 0 }, result.term);
     try testing.expect(std.mem.indexOf(u8, result.stdout, "Usage: malt install") != null);
 }
+
+// Integration: an unknown help topic degrades to the stock fallback and
+// still exits 0 — help must never fail. Skipped if the binary is absent.
+test "help command falls back gracefully for unknown topics" {
+    const io = std.Options.debug_io;
+    const bin_path = "zig-out/bin/malt";
+    test_io.cwd().access(io, bin_path, .{}) catch return error.SkipZigTest;
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const result = try std.process.run(testing.allocator, threaded.io(), .{
+        .argv = &[_][]const u8{ bin_path, "help", "not-a-real-command" },
+        .stdout_limit = .limited(1 << 16),
+        .stderr_limit = .limited(1 << 16),
+    });
+    defer testing.allocator.free(result.stdout);
+    defer testing.allocator.free(result.stderr);
+
+    try testing.expectEqual(std.process.Child.Term{ .exited = 0 }, result.term);
+    try testing.expect(std.mem.indexOf(u8, result.stdout, "No help available.") != null);
+}

--- a/tests/help_test.zig
+++ b/tests/help_test.zig
@@ -182,3 +182,24 @@ test "--help output lands on stdout, not stderr" {
     try testing.expectEqual(@as(usize, 0), result.stderr.len);
     try testing.expect(std.mem.indexOf(u8, result.stdout, "malt install") != null);
 }
+
+// Integration: `malt help <cmd>` must show that command's help topic,
+// not the general usage. Relies on the pre-built binary; skipped if absent.
+test "help command routes its argument to the per-command topic" {
+    const io = std.Options.debug_io;
+    const bin_path = "zig-out/bin/malt";
+    test_io.cwd().access(io, bin_path, .{}) catch return error.SkipZigTest;
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const result = try std.process.run(testing.allocator, threaded.io(), .{
+        .argv = &[_][]const u8{ bin_path, "help", "install" },
+        .stdout_limit = .limited(1 << 16),
+        .stderr_limit = .limited(1 << 16),
+    });
+    defer testing.allocator.free(result.stdout);
+    defer testing.allocator.free(result.stderr);
+
+    try testing.expectEqual(std.process.Child.Term{ .exited = 0 }, result.term);
+    try testing.expect(std.mem.indexOf(u8, result.stdout, "Usage: malt install") != null);
+}


### PR DESCRIPTION
## Description

`malt help <cmd>` silently ignored its argument and printed the general
usage for every command, so the per-command topics were only reachable
via `<cmd> --help`. The `help` dispatch arm now routes its first
argument through the same per-command help table: `malt help install`
prints the install topic, bare `malt help` keeps the general usage, and
an unknown topic falls back to "No help available." — the same
behaviour `--help` has for unmapped commands.

All three shell completions now also suggest the command names after
`help`, so topics are discoverable from the prompt.

Covered by integration tests that spawn the built binary (known topic
and unknown-topic fallback), an inline dispatch-totality test, and a
completions test pinning the topic suggestions in bash, zsh, and fish.

## Related Issue

- None

## Notes for Reviewers

- The man page is untouched by design: `scripts/gen-man.sh` builds it
  from `<cmd> --help` output, which this change does not alter
  (`just man-check` stays green).