### PR TITLE
fix(core/dsl): run post_install against revisioned keg paths and surface command failures

### DIFF
--- a/scripts/regressions/post-install-revisioned-keg-paths-git-cola-fails.sh
+++ b/scripts/regressions/post-install-revisioned-keg-paths-git-cola-fails.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Regression: the DSL's ExecContext built `cellar_path` — and every
+# keg-relative binding (prefix, bin, pkgshare, ...) — from the raw
+# `version`, while the on-disk keg dir is named by pkg_version
+# (`<version>_<revision>`). For any revision-bumped formula a
+# post_install `system bin/"tool"` spawned a nonexistent argv0 and
+# execvp failed. Compounding it, `system()` mapped a non-zero child
+# exit to a plain `false` without recording anything in the
+# FallbackLog, so the router printed "post_install completed" over a
+# failed hook.
+#
+# Both defects are pinned by colocated `test {}` blocks; this script
+# asserts the fix is present statically and then runs the lib test
+# binary and judges those guards' lines.
+#
+# Exits 0 when the bugs are absent, non-zero (with a message naming
+# the failing assertion) when present. No network required; finishes
+# well under 30s once the test binary is built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# 1. Static guard: cellar_path must be formatted from pkg_version.
+if ! grep -q 'ref\.pkg_version' "$ROOT/src/core/dsl/context.zig"; then
+  echo "FAIL: ExecContext cellar_path no longer uses ref.pkg_version" >&2
+  exit 1
+fi
+
+# 2. Behavioural guards live in colocated `test {}` blocks; if either is
+#    ever deleted the run below would silently pass. Fail loudly instead.
+PATH_TEST="ExecContext binds keg paths from the revision-qualified pkg_version"
+EXIT_TEST="system records a fatal flog entry when the child exits non-zero"
+if ! grep -Rqs -- "$PATH_TEST" "$ROOT/src/core/dsl/context.zig"; then
+  echo "FAIL: revisioned keg-path guard test missing from context.zig" >&2
+  exit 1
+fi
+if ! grep -Rqs -- "$EXIT_TEST" "$ROOT/src/core/dsl/builtins/process.zig"; then
+  echo "FAIL: system() exit-status guard test missing from process.zig" >&2
+  exit 1
+fi
+
+# Rebuild the lib test binary so the run reflects the working tree.
+if ! (cd "$ROOT" && zig build test-bin >/dev/null 2>&1); then
+  echo "FAIL: could not build the test binary (zig build test-bin)" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+
+# The runner has no per-test filter, so run the suite and judge only the
+# two guards' lines: a pass ends in "OK".
+OUT=$("$BIN" 2>&1 || true)
+for NAME in "$PATH_TEST" "$EXIT_TEST"; do
+  LINE=$(printf '%s\n' "$OUT" | grep -F -- "$NAME" || true)
+  if [[ -z "$LINE" ]]; then
+    echo "FAIL: guard test did not run: $NAME" >&2
+    exit 1
+  fi
+  if [[ "$LINE" != *OK ]]; then
+    echo "FAIL: $NAME: $LINE" >&2
+    exit 1
+  fi
+done
+
+echo "OK: post_install keg paths revision-qualified; failures surface"

--- a/src/core/dsl/builtins/pathname.zig
+++ b/src/core/dsl/builtins/pathname.zig
@@ -35,6 +35,8 @@ pub const ExecCtx = struct {
     /// Record-only diagnostics sink for builtins (e.g. inreplace's
     /// atomic-write fallback). Optional so test contexts can omit it.
     fallback_log: ?*fallback_log.FallbackLog = null,
+    /// Formula name stamped on fallback-log entries a builtin records.
+    formula_name: []const u8 = "",
 };
 
 /// mkpath — recursive directory creation

--- a/src/core/dsl/builtins/process.zig
+++ b/src/core/dsl/builtins/process.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 const values = @import("../values.zig");
 const pathname = @import("pathname.zig");
 const sandbox = @import("../sandbox.zig");
+const fallback_log = @import("../fallback_log.zig");
 
 const Value = values.Value;
 const BuiltinError = pathname.BuiltinError;
@@ -52,17 +53,39 @@ pub fn system(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     }) catch return BuiltinError.SystemCommandFailed;
     const term = child.wait(ctx.io) catch return BuiltinError.SystemCommandFailed;
 
-    return switch (term) {
-        .exited => |code| if (code == 0) Value{ .bool = true } else Value{ .bool = false },
-        else => Value{ .bool = false },
-    };
+    switch (term) {
+        .exited => |code| if (code == 0) return Value{ .bool = true } else recordFailure(ctx, argv_slice[0], code),
+        else => recordFailure(ctx, argv_slice[0], null),
+    }
+    return Value{ .bool = false };
+}
+
+/// Homebrew's formula-context `system` raises on failure, so a child that
+/// runs and exits non-zero is a fatal failure — record it or the router
+/// reports the hook as completed over a failed post_install.
+fn recordFailure(ctx: ExecCtx, argv0: []const u8, exit_code: ?u32) void {
+    const flog = ctx.fallback_log orelse return;
+    const detail = if (exit_code) |code|
+        std.fmt.allocPrint(ctx.allocator, "{s} exited with code {d}", .{ argv0, code }) catch argv0
+    else
+        std.fmt.allocPrint(ctx.allocator, "{s} terminated abnormally", .{argv0}) catch argv0;
+    flog.log(.{
+        .formula = ctx.formula_name,
+        .reason = .system_command_failed,
+        .detail = detail,
+        .loc = null,
+    });
 }
 
 /// quiet_system — execute a command, suppress output
 pub fn quietSystem(ctx: ExecCtx, recv: ?Value, args: []const Value) BuiltinError!Value {
-    // Ruby's `quiet_system` returns true/false and never raises; we drop the
-    // bool too because the DSL sites that use it ignore the result.
-    _ = system(ctx, recv, args) catch {};
+    // Ruby's `quiet_system` returns true/false and never raises — formulas
+    // use it for may-fail probes, so strip the failure entry `system`
+    // would record. We drop the bool too because the DSL sites that use
+    // it ignore the result.
+    var quiet_ctx = ctx;
+    quiet_ctx.fallback_log = null;
+    _ = system(quiet_ctx, recv, args) catch {};
     return Value{ .nil = {} };
 }
 
@@ -249,6 +272,136 @@ test "childStdoutMode ignores subprocess stdout only when suppression is request
     // can't corrupt the document; otherwise it inherits malt's fd.
     try std.testing.expect(std.meta.activeTag(childStdoutMode(true)) == .ignore);
     try std.testing.expect(std.meta.activeTag(childStdoutMode(false)) == .inherit);
+}
+
+// Homebrew's formula-context `system` raises on failure, so a child
+// that runs and exits non-zero must surface as a recorded failure —
+// otherwise the router reports a failed hook as completed.
+test "system records a fatal flog entry when the child exits non-zero" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var lio: std.Io.Threaded = .init(arena.allocator(), .{});
+    defer lio.deinit();
+    var flog = fallback_log.FallbackLog.init(arena.allocator());
+    defer flog.deinit();
+    const ctx = ExecCtx{
+        .allocator = arena.allocator(),
+        .io = lio.io(),
+        .environ = .empty,
+        .cellar_path = "/opt/malt/Cellar/foo/1.0",
+        .malt_prefix = "/opt/malt",
+        .fallback_log = &flog,
+        .formula_name = "foo",
+    };
+
+    const result = try system(ctx, null, &.{.{ .string = "/usr/bin/false" }});
+
+    try std.testing.expect(result == .bool and !result.bool);
+    try std.testing.expect(flog.hasFatal());
+    const entry = flog.entries()[0];
+    try std.testing.expectEqualStrings("foo", entry.formula);
+    try std.testing.expect(std.mem.indexOf(u8, entry.detail, "/usr/bin/false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, entry.detail, "1") != null);
+}
+
+// The failure entry must be failure-only: a clean exit that logged
+// anything would route every successful hook as fatal.
+test "system records nothing when the child exits zero" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var lio: std.Io.Threaded = .init(arena.allocator(), .{});
+    defer lio.deinit();
+    var flog = fallback_log.FallbackLog.init(arena.allocator());
+    defer flog.deinit();
+    const ctx = ExecCtx{
+        .allocator = arena.allocator(),
+        .io = lio.io(),
+        .environ = .empty,
+        .cellar_path = "/opt/malt/Cellar/foo/1.0",
+        .malt_prefix = "/opt/malt",
+        .fallback_log = &flog,
+        .formula_name = "foo",
+    };
+
+    const result = try system(ctx, null, &.{.{ .string = "/usr/bin/true" }});
+
+    try std.testing.expect(result == .bool and result.bool);
+    try std.testing.expect(!flog.hasErrors());
+}
+
+// Test contexts omit the log (it is optional on ExecCtx); a failing
+// child must still degrade to `false` instead of dereferencing null.
+test "system tolerates a missing fallback log on failure" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var lio: std.Io.Threaded = .init(arena.allocator(), .{});
+    defer lio.deinit();
+    const ctx = ExecCtx{
+        .allocator = arena.allocator(),
+        .io = lio.io(),
+        .environ = .empty,
+        .cellar_path = "/opt/malt/Cellar/foo/1.0",
+        .malt_prefix = "/opt/malt",
+    };
+
+    const result = try system(ctx, null, &.{.{ .string = "/usr/bin/false" }});
+
+    try std.testing.expect(result == .bool and !result.bool);
+}
+
+// A child that dies to a signal never reaches an exit code; that is
+// still a failed hook and must surface as a recorded fatal failure.
+test "system records an abnormal termination when the child dies to a signal" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var lio: std.Io.Threaded = .init(arena.allocator(), .{});
+    defer lio.deinit();
+    var flog = fallback_log.FallbackLog.init(arena.allocator());
+    defer flog.deinit();
+    const ctx = ExecCtx{
+        .allocator = arena.allocator(),
+        .io = lio.io(),
+        .environ = .empty,
+        .cellar_path = "/opt/malt/Cellar/foo/1.0",
+        .malt_prefix = "/opt/malt",
+        .fallback_log = &flog,
+        .formula_name = "foo",
+    };
+
+    const result = try system(ctx, null, &.{
+        .{ .string = "/usr/bin/perl" },
+        .{ .string = "-e" },
+        .{ .string = "kill 'KILL', $$" },
+    });
+
+    try std.testing.expect(result == .bool and !result.bool);
+    try std.testing.expect(flog.hasFatal());
+    const entry = flog.entries()[0];
+    try std.testing.expect(std.mem.indexOf(u8, entry.detail, "terminated abnormally") != null);
+}
+
+// Ruby's `quiet_system` never raises — formulas use it for may-fail
+// probes, so the failure entry `system` records must not leak through.
+test "quiet_system suppresses the failure entry for may-fail probes" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var lio: std.Io.Threaded = .init(arena.allocator(), .{});
+    defer lio.deinit();
+    var flog = fallback_log.FallbackLog.init(arena.allocator());
+    defer flog.deinit();
+    const ctx = ExecCtx{
+        .allocator = arena.allocator(),
+        .io = lio.io(),
+        .environ = .empty,
+        .cellar_path = "/opt/malt/Cellar/foo/1.0",
+        .malt_prefix = "/opt/malt",
+        .fallback_log = &flog,
+        .formula_name = "foo",
+    };
+
+    _ = try quietSystem(ctx, null, &.{.{ .string = "/usr/bin/false" }});
+
+    try std.testing.expect(!flog.hasErrors());
 }
 
 test "system rejects an argv0 outside the sandbox roots before spawning" {

--- a/src/core/dsl/context.zig
+++ b/src/core/dsl/context.zig
@@ -139,8 +139,10 @@ pub const ExecContext = struct {
         malt_prefix: []const u8,
         flog: *FallbackLog,
     ) DslError!ExecContext {
+        // pkg_version, not version: the keg dir carries the `_<revision>`
+        // suffix, so raw-version bindings point beside the real keg.
         const cellar_path = std.fmt.allocPrint(arena, "{s}/Cellar/{s}/{s}", .{
-            malt_prefix, ref.name, ref.version,
+            malt_prefix, ref.name, ref.pkg_version,
         }) catch malt_prefix;
 
         var paths = std.EnumArray(PathBinding, []const u8).initUndefined();
@@ -235,4 +237,30 @@ pub const ExecContext = struct {
 
 pub fn joinPath(allocator: std.mem.Allocator, base: []const u8, sub: []const u8) []const u8 {
     return std.fs.path.join(allocator, &.{ base, sub }) catch base;
+}
+
+// The on-disk keg dir is named by pkg_version (`<version>_<revision>`
+// when revision > 0), so every keg-anchored binding must use it — a
+// raw-version path points one directory sideways from the real keg.
+test "ExecContext binds keg paths from the revision-qualified pkg_version" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var flog = FallbackLog.init(alloc);
+    defer flog.deinit();
+
+    var ctx = try ExecContext.init(alloc, std.Options.debug_io, .empty, .{
+        .name = "dbus",
+        .version = "1.16.2",
+        .pkg_version = "1.16.2_1",
+    }, "/opt/malt", &flog);
+    defer ctx.deinit();
+
+    try std.testing.expectEqualStrings("/opt/malt/Cellar/dbus/1.16.2_1", ctx.paths.get(.prefix));
+    try std.testing.expectEqualStrings("/opt/malt/Cellar/dbus/1.16.2_1/bin", ctx.paths.get(.bin));
+    try std.testing.expectEqualStrings("/opt/malt/Cellar/dbus/1.16.2_1/share/dbus", ctx.paths.get(.pkgshare));
+    // Version-agnostic bindings must stay revision-free by design.
+    try std.testing.expectEqualStrings("/opt/malt/opt/dbus", ctx.paths.get(.opt_prefix));
+    try std.testing.expectEqualStrings("/opt/malt/etc/dbus", ctx.paths.get(.pkgetc));
 }

--- a/src/core/dsl/interpreter.zig
+++ b/src/core/dsl/interpreter.zig
@@ -279,6 +279,7 @@ pub const Interpreter = struct {
             .malt_prefix = self.ctx.malt_prefix,
             .suppress_child_stdout = self.ctx.suppress_child_stdout,
             .fallback_log = self.ctx.fallback_log_writer,
+            .formula_name = self.ctx.formula_name,
         };
 
         if (mc.receiver) |receiver_node| {
@@ -771,6 +772,7 @@ pub const Interpreter = struct {
             .malt_prefix = self.ctx.malt_prefix,
             .suppress_child_stdout = self.ctx.suppress_child_stdout,
             .fallback_log = self.ctx.fallback_log_writer,
+            .formula_name = self.ctx.formula_name,
         };
         if (builtins_root.receiver_builtins.get(sym)) |func| {
             return func(builtin_ctx, item, &.{}) catch |e| mapBuiltinError(e);


### PR DESCRIPTION
## Description

Installing any revision-bumped formula (dbus `1.16.2_1` and friends) left its post_install hook broken in two compounding ways:

- The DSL bound every keg-relative path (`prefix`, `bin`, `pkgshare`, …) from the raw upstream version, while the on-disk keg directory carries the `_<revision>` suffix — so hooks invoked keg binaries at a path one directory sideways from the real keg and execvp failed.
- A hook command that ran and exited non-zero was reported as `post_install completed`, silently masking the failure. Users ended up with installs that looked healthy but lacked their post-install side effects (dbus machine-id, font caches, …).

With this change keg paths are bound from the revision-qualified version, and a failing `system()` call records a fatal entry so the router reports `post_install DSL failed` instead of success. `quiet_system` keeps its Ruby semantics (may-fail probes stay silent), and version-agnostic bindings (`etc`, `var`, `opt_prefix`) are unchanged and test-pinned.

## Related Issue

- None

## Notes for Reviewers

- The user-visible flip is intentional fail-loud behaviour: hooks that were silently failing now print `post_install DSL failed for <name> (fatal)` plus the logged reason.
