### PR TITLE
fix(core/cellar): pour bottle etc/var overlays and relocate embedded config paths

### DIFF
--- a/scripts/regressions/bottle-etc-overlay-relocation-git-cola-fails.sh
+++ b/scripts/regressions/bottle-etc-overlay-relocation-git-cola-fails.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Regression: a bottle's `.bottle/etc` / `.bottle/var` overlay was never
+# poured into the prefix, so formulas like fontconfig could not load
+# their default config; fontconfig then fell back to a compiled-in XML
+# blob whose `/opt/homebrew` paths sit MID-string in one `__cstring`
+# literal, which the head-anchored cstring patcher never rewrote. Net
+# effect: unwritable brew-prefixed cache dirs and a font cache that was
+# never built, behind an install that looked healthy.
+#
+# Both defects are pinned by colocated `test {}` blocks; this script
+# asserts the fixes are present statically, then runs the two test
+# binaries and judges those guards' lines.
+#
+# Exits 0 when the bugs are absent, non-zero (with a message naming
+# the failing assertion) when present. No network required; finishes
+# well under 30s once the test binaries are built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# 1. Static guard: the relocation pipeline must pour the overlay.
+if ! grep -q 'installBottleEtcVar' "$ROOT/src/core/cellar.zig"; then
+  echo "FAIL: relocateKegTree no longer pours the .bottle etc/var overlay" >&2
+  exit 1
+fi
+
+# 2. Behavioural guards live in colocated `test {}` blocks; if either is
+#    ever deleted the runs below would silently pass. Fail loudly instead.
+MIDSTR_TEST="patchPathsCollecting relocates prefixes embedded mid-string in a cstring slot"
+OVERLAY_TEST="installBottleEtcVar pours a missing overlay file into the prefix"
+if ! grep -Rqs -- "$MIDSTR_TEST" "$ROOT/tests/patcher_test.zig"; then
+  echo "FAIL: mid-string cstring guard test missing from patcher_test.zig" >&2
+  exit 1
+fi
+if ! grep -Rqs -- "$OVERLAY_TEST" "$ROOT/tests/cellar_test.zig"; then
+  echo "FAIL: bottle overlay guard test missing from cellar_test.zig" >&2
+  exit 1
+fi
+
+# Rebuild the test binaries so the run reflects the working tree.
+if ! (cd "$ROOT" && zig build test-bin >/dev/null 2>&1); then
+  echo "FAIL: could not build the test binaries (zig build test-bin)" >&2
+  exit 1
+fi
+
+# The runners have no per-test filter, so run each suite and judge only
+# its guard's line: a pass ends in "OK".
+check() {
+  local bin="$1" name="$2"
+  local out line
+  out=$("$ROOT/zig-out/test-bin/$bin" 2>&1 || true)
+  line=$(printf '%s\n' "$out" | grep -F -- "$name" || true)
+  if [[ -z "$line" ]]; then
+    echo "FAIL: guard test did not run in $bin: $name" >&2
+    exit 1
+  fi
+  if [[ "$line" != *OK ]]; then
+    echo "FAIL: $name: $line" >&2
+    exit 1
+  fi
+}
+
+check patcher_test "$MIDSTR_TEST"
+check cellar_test "$OVERLAY_TEST"
+
+echo "OK: bottle etc/var overlay poured; embedded config paths relocated"

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -101,6 +101,10 @@ pub fn materializeWithCellar(
             break :cache_hit;
         };
         writeInstallReceipt(io, cellar_path, name, version, store_sha256);
+        // Homebrew re-pours etc/var on every install; the cached keg
+        // carries `.bottle`, so a wiped or drifted live config is
+        // restored even when relocation is skipped.
+        installBottleEtcVar(io, allocator, cellar_path, prefix);
         const owned = allocator.dupe(u8, cellar_path) catch return CellarError.OutOfMemory;
         return .{ .name = name, .version = version, .path = owned };
     }
@@ -378,6 +382,102 @@ fn relocateKegTree(
             else => std.log.warn("codesigning failed for {s}: {s}", .{ cellar_path, @errorName(e) }),
         };
     }
+
+    // After text patching, so the poured configs already carry the malt
+    // prefix instead of the bottled `/opt/homebrew` paths.
+    installBottleEtcVar(io, allocator, cellar_path, new_prefix);
+}
+
+/// Pour the bottle's `.bottle/etc` and `.bottle/var` overlay into the
+/// live prefix, mirroring Homebrew's pour: a missing file is installed,
+/// an identical one skipped, and a user-modified config receives the
+/// new bottled default beside it as `<name>.default` instead of a
+/// clobber. Best-effort like the text pass — a per-file failure is
+/// warned about, never fatal to the install.
+/// Pub so the cellar tests can drive it against a scratch prefix.
+pub fn installBottleEtcVar(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    cellar_path: []const u8,
+    prefix: []const u8,
+) void {
+    for ([_][]const u8{ "etc", "var" }) |sub| {
+        const src_root = std.fs.path.join(allocator, &.{ cellar_path, ".bottle", sub }) catch continue;
+        defer allocator.free(src_root);
+
+        // Most bottles ship no overlay — a missing dir is the normal case.
+        var dir = std.Io.Dir.openDirAbsolute(io, src_root, .{ .iterate = true }) catch continue;
+        defer dir.close(io);
+
+        var walker = dir.walk(allocator) catch continue;
+        defer walker.deinit();
+
+        while (walker.next(io) catch null) |entry| {
+            if (entry.kind == .directory) {
+                // Bottles ship empty overlay dirs (dbus's `var/lib/dbus`)
+                // that hooks rely on; pour the tree shape, not just files.
+                const dst = std.fs.path.join(allocator, &.{ prefix, sub, entry.path }) catch continue;
+                defer allocator.free(dst);
+                std.Io.Dir.cwd().createDirPath(io, dst) catch |e| {
+                    std.log.warn("bottle overlay {s}/{s} dir not created: {s}", .{ sub, entry.path, @errorName(e) });
+                };
+                continue;
+            }
+            if (entry.kind != .file) {
+                std.log.warn("bottle overlay {s}/{s} skipped (unsupported kind)", .{ sub, entry.path });
+                continue;
+            }
+            pourOverlayFile(io, allocator, src_root, entry.path, prefix, sub) catch |e| {
+                std.log.warn("bottle overlay {s}/{s} not poured: {s}", .{ sub, entry.path, @errorName(e) });
+            };
+        }
+    }
+}
+
+/// One overlay file: install-if-missing, skip-if-identical, else write
+/// the bottled content as `<dst>.default` so user edits survive.
+fn pourOverlayFile(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    src_root: []const u8,
+    rel: []const u8,
+    prefix: []const u8,
+    sub: []const u8,
+) !void {
+    const src_path = try std.fs.path.join(allocator, &.{ src_root, rel });
+    defer allocator.free(src_path);
+    const dst_path = try std.fs.path.join(allocator, &.{ prefix, sub, rel });
+    defer allocator.free(dst_path);
+
+    const content = try readOverlayFile(io, allocator, src_path);
+    defer allocator.free(content);
+
+    if (readOverlayFile(io, allocator, dst_path)) |existing| {
+        defer allocator.free(existing);
+        if (std.mem.eql(u8, existing, content)) return;
+        const default_path = try std.mem.concat(allocator, u8, &.{ dst_path, ".default" });
+        defer allocator.free(default_path);
+        try atomic.atomicReplaceFile(io, default_path, content);
+    } else |_| {
+        if (std.fs.path.dirname(dst_path)) |parent| {
+            try std.Io.Dir.cwd().createDirPath(io, parent);
+        }
+        try atomic.atomicReplaceFile(io, dst_path, content);
+    }
+}
+
+fn readOverlayFile(io: std.Io, allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    const file = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer file.close(io);
+    const stat = try file.stat(io);
+    // Overlays are config seeds; anything bigger is not a config we
+    // should buffer or silently clobber.
+    if (stat.size > 10 * 1024 * 1024) return error.FileTooBig;
+    const buf = try allocator.alloc(u8, stat.size);
+    errdefer allocator.free(buf);
+    const n = try file.readPositionalAll(io, buf, 0);
+    if (n < buf.len) return error.EndOfStream;
+    return buf;
 }
 
 /// Copy a keg tree from a sibling Homebrew install at `src_keg_path`

--- a/src/macho/patcher.zig
+++ b/src/macho/patcher.zig
@@ -170,17 +170,18 @@ fn pickReplacement(path: []const u8, replacements: []const Replacement) ?Replace
 
 const CstringPatchCounts = struct { patched: u32, skipped: u32 };
 
-/// Rewrite NUL-terminated strings inside one `__cstring` region whose
-/// content begins with any configured old prefix. In-place only — the
-/// section's file offset cannot grow without rewriting every fixup in
-/// the binary, which `install_name_tool` does not do for cstring data.
+/// Rewrite NUL-terminated strings inside one `__cstring` region that
+/// contain any configured old prefix — anywhere in the string, not just
+/// at its head. In-place only — the section's file offset cannot grow
+/// without rewriting every fixup in the binary, which
+/// `install_name_tool` does not do for cstring data.
 ///
 /// Each slot's original length (from its NUL terminator) becomes the
-/// hard budget. When the replacement fits, the slot is overwritten and
-/// the tail up to the original NUL is zero-padded so no fragment of the
-/// old path remains. When it doesn't fit, the string is left intact and
-/// counted as skipped — fundamental constraint, not a recoverable
-/// error.
+/// hard budget. When every occurrence shrinks or keeps its length, the
+/// slot is rewritten and the freed tail zero-padded so no fragment of
+/// the old path remains. A growing replacement can't fit and leaves the
+/// slot byte-identical, counted as skipped — fundamental constraint,
+/// not a recoverable error.
 ///
 /// Pointer safety: clang+ld64 with the default `-fmerge-constants`
 /// behaviour deduplicate identical strings but do not tail-merge
@@ -201,40 +202,74 @@ fn patchCstringRegion(
     var i: usize = 0;
     while (i < blob.len) {
         const nul = std.mem.indexOfScalarPos(u8, blob, i, 0) orelse break;
-        const old_len = nul - i;
-        if (old_len == 0) {
-            i = nul + 1;
-            continue;
-        }
-
-        const current = blob[i..nul];
-        if (pickReplacement(current, replacements)) |r| {
-            const new_len = r.new.len + (old_len - r.old.len);
-            if (new_len <= old_len) {
-                // Stage in a stack buffer because the suffix aliases bytes
-                // we are about to overwrite.
-                var staging: [1024]u8 = undefined;
-                if (new_len <= staging.len) {
-                    @memcpy(staging[0..r.new.len], r.new);
-                    @memcpy(
-                        staging[r.new.len..new_len],
-                        current[r.old.len..],
-                    );
-                    @memcpy(blob[i..][0..new_len], staging[0..new_len]);
-                    @memset(blob[i + new_len .. nul], 0);
-                    counts.patched += 1;
-                } else {
-                    counts.skipped += 1;
-                }
-            } else {
-                counts.skipped += 1;
+        if (nul != i) {
+            switch (rewriteCstringSlot(blob[i..nul], replacements)) {
+                .patched => counts.patched += 1,
+                .skipped => counts.skipped += 1,
+                .untouched => {},
             }
         }
-
         i = nul + 1;
     }
 
     return counts;
+}
+
+const SlotOutcome = enum { patched, skipped, untouched };
+
+/// Rewrite every occurrence of any configured old prefix inside one
+/// NUL-terminated slot, in place. Compiled-in fallback configs
+/// (fontconfig's XML blob) embed the prefix mid-string, so matching is
+/// per-occurrence, not head-anchored. Shrink-or-equal replacements let
+/// the tail shift left (write index never passes read index); a growing
+/// pair can't fit the fixed slot, so the pre-scan bails before any byte
+/// is written — a slot is rewritten whole or left byte-identical.
+fn rewriteCstringSlot(slot: []u8, replacements: []const Replacement) SlotOutcome {
+    var scan: usize = 0;
+    var found = false;
+    while (scan < slot.len) {
+        if (matchReplacementAt(slot, scan, replacements)) |r| {
+            if (r.new.len > r.old.len) return .skipped;
+            found = true;
+            scan += r.old.len;
+        } else {
+            scan += 1;
+        }
+    }
+    if (!found) return .untouched;
+
+    var read: usize = 0;
+    var write: usize = 0;
+    while (read < slot.len) {
+        if (matchReplacementAt(slot, read, replacements)) |r| {
+            @memcpy(slot[write..][0..r.new.len], r.new);
+            write += r.new.len;
+            read += r.old.len;
+        } else {
+            slot[write] = slot[read];
+            write += 1;
+            read += 1;
+        }
+    }
+    // Zero the freed tail up to the original NUL so no fragment of the
+    // old path remains.
+    @memset(slot[write..], 0);
+    return .patched;
+}
+
+/// First configured replacement whose old prefix matches at `pos` —
+/// same first-match-wins order as `pickReplacement`.
+fn matchReplacementAt(
+    slot: []const u8,
+    pos: usize,
+    replacements: []const Replacement,
+) ?Replacement {
+    for (replacements) |r| {
+        if (r.old.len == 0) continue;
+        if (pos + r.old.len <= slot.len and
+            std.mem.eql(u8, slot[pos..][0..r.old.len], r.old)) return r;
+    }
+    return null;
 }
 
 /// Dupe both old/new strings into the caller's allocator and append.

--- a/tests/cellar_test.zig
+++ b/tests/cellar_test.zig
@@ -1059,3 +1059,221 @@ test "materialize rewrites @@HOMEBREW_CELLAR@@ in Mach-O rpath for :any bottle" 
     }
     try testing.expect(found);
 }
+
+// ---------------------------------------------------------------------------
+// Bottle etc/var overlay pour
+// ---------------------------------------------------------------------------
+
+fn writeAbs(path: []const u8, content: []const u8) !void {
+    const f = try test_io.createFileAbsolute(std.Options.debug_io, path, .{});
+    try f.writeStreamingAll(std.Options.debug_io, content);
+    f.close(std.Options.debug_io);
+}
+
+fn overlayFixture(allocator: std.mem.Allocator, prefix: []const u8) ![]const u8 {
+    const keg = try std.fmt.allocPrint(allocator, "{s}/Cellar/fc/1.0", .{prefix});
+    errdefer allocator.free(keg);
+    const etc_dir = try std.fmt.allocPrint(allocator, "{s}/.bottle/etc/fonts", .{keg});
+    defer allocator.free(etc_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, etc_dir);
+    const conf = try std.fmt.allocPrint(allocator, "{s}/fonts.conf", .{etc_dir});
+    defer allocator.free(conf);
+    try writeAbs(conf, "<fontconfig>poured</fontconfig>\n");
+    return keg;
+}
+
+test "installBottleEtcVar pours a missing overlay file into the prefix" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    const keg = try overlayFixture(testing.allocator, prefix);
+    defer testing.allocator.free(keg);
+    // A var payload rides the same overlay mechanism as etc.
+    const var_dir = try std.fmt.allocPrint(testing.allocator, "{s}/.bottle/var/db", .{keg});
+    defer testing.allocator.free(var_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, var_dir);
+    const seed = try std.fmt.allocPrint(testing.allocator, "{s}/seed", .{var_dir});
+    defer testing.allocator.free(seed);
+    try writeAbs(seed, "seed\n");
+
+    cellar_mod.installBottleEtcVar(std.Options.debug_io, testing.allocator, keg, prefix);
+
+    const conf_path = try std.fmt.allocPrint(testing.allocator, "{s}/etc/fonts/fonts.conf", .{prefix});
+    defer testing.allocator.free(conf_path);
+    const poured = try readFile(testing.allocator, conf_path);
+    defer testing.allocator.free(poured);
+    try testing.expectEqualStrings("<fontconfig>poured</fontconfig>\n", poured);
+
+    const seed_path = try std.fmt.allocPrint(testing.allocator, "{s}/var/db/seed", .{prefix});
+    defer testing.allocator.free(seed_path);
+    const seeded = try readFile(testing.allocator, seed_path);
+    defer testing.allocator.free(seeded);
+    try testing.expectEqualStrings("seed\n", seeded);
+}
+
+test "installBottleEtcVar keeps a user-modified config and writes the new default beside it" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    const keg = try overlayFixture(testing.allocator, prefix);
+    defer testing.allocator.free(keg);
+
+    const live_dir = try std.fmt.allocPrint(testing.allocator, "{s}/etc/fonts", .{prefix});
+    defer testing.allocator.free(live_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, live_dir);
+    const live = try std.fmt.allocPrint(testing.allocator, "{s}/fonts.conf", .{live_dir});
+    defer testing.allocator.free(live);
+    try writeAbs(live, "<fontconfig>user-edited</fontconfig>\n");
+
+    cellar_mod.installBottleEtcVar(std.Options.debug_io, testing.allocator, keg, prefix);
+
+    const kept = try readFile(testing.allocator, live);
+    defer testing.allocator.free(kept);
+    try testing.expectEqualStrings("<fontconfig>user-edited</fontconfig>\n", kept);
+
+    const default_path = try std.fmt.allocPrint(testing.allocator, "{s}.default", .{live});
+    defer testing.allocator.free(default_path);
+    const dflt = try readFile(testing.allocator, default_path);
+    defer testing.allocator.free(dflt);
+    try testing.expectEqualStrings("<fontconfig>poured</fontconfig>\n", dflt);
+}
+
+test "installBottleEtcVar leaves an identical config alone" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    const keg = try overlayFixture(testing.allocator, prefix);
+    defer testing.allocator.free(keg);
+
+    const live_dir = try std.fmt.allocPrint(testing.allocator, "{s}/etc/fonts", .{prefix});
+    defer testing.allocator.free(live_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, live_dir);
+    const live = try std.fmt.allocPrint(testing.allocator, "{s}/fonts.conf", .{live_dir});
+    defer testing.allocator.free(live);
+    try writeAbs(live, "<fontconfig>poured</fontconfig>\n");
+
+    cellar_mod.installBottleEtcVar(std.Options.debug_io, testing.allocator, keg, prefix);
+
+    const default_path = try std.fmt.allocPrint(testing.allocator, "{s}.default", .{live});
+    defer testing.allocator.free(default_path);
+    try testing.expectError(
+        error.FileNotFound,
+        test_io.openFileAbsolute(std.Options.debug_io, default_path, .{}),
+    );
+}
+
+test "installBottleEtcVar no-ops for kegs without a bottle overlay" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/plain/1.0", .{prefix});
+    defer testing.allocator.free(keg);
+    try test_io.cwd().createDirPath(std.Options.debug_io, keg);
+
+    cellar_mod.installBottleEtcVar(std.Options.debug_io, testing.allocator, keg, prefix);
+
+    const etc_path = try std.fmt.allocPrint(testing.allocator, "{s}/etc", .{prefix});
+    defer testing.allocator.free(etc_path);
+    try testing.expectError(
+        error.FileNotFound,
+        test_io.openFileAbsolute(std.Options.debug_io, etc_path, .{}),
+    );
+}
+
+test "warm cache-hit reinstall re-pours a wiped overlay config" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    try setupMaltDirs(testing.allocator, prefix);
+
+    const old_env = setMaltPrefix(prefix);
+    defer restoreMaltPrefix(old_env);
+
+    // Cold install: bottle fixture carrying an etc overlay populates the
+    // relocated cache and pours the config.
+    try createBottleFixture(testing.allocator, prefix, valid_test_sha, "fc", "1.0");
+    const overlay_dir = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/store/{s}/fc/1.0/.bottle/etc/fonts",
+        .{ prefix, valid_test_sha },
+    );
+    defer testing.allocator.free(overlay_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, overlay_dir);
+    const overlay_conf = try std.fmt.allocPrint(testing.allocator, "{s}/fonts.conf", .{overlay_dir});
+    defer testing.allocator.free(overlay_conf);
+    try writeAbs(overlay_conf, "<fontconfig>poured</fontconfig>\n");
+
+    const keg_cold = try cellar_mod.materializeWithCellar(
+        std.Options.debug_io,
+        testing.allocator,
+        prefix,
+        valid_test_sha,
+        "fc",
+        "1.0",
+        ":any",
+    );
+    testing.allocator.free(keg_cold.path);
+    try testing.expect(relocated_mod.has(std.Options.debug_io, prefix, valid_test_sha));
+
+    // Wipe the poured config and the Cellar entry; the reinstall must take
+    // the cache short-circuit AND restore the config.
+    const live_conf = try std.fmt.allocPrint(testing.allocator, "{s}/etc/fonts/fonts.conf", .{prefix});
+    defer testing.allocator.free(live_conf);
+    const poured_cold = try readFile(testing.allocator, live_conf);
+    defer testing.allocator.free(poured_cold);
+    try testing.expectEqualStrings("<fontconfig>poured</fontconfig>\n", poured_cold);
+    try test_io.deleteTreeAbsolute(std.Options.debug_io, live_conf);
+    const keg_dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/fc/1.0", .{prefix});
+    defer testing.allocator.free(keg_dir);
+    try test_io.deleteTreeAbsolute(std.Options.debug_io, keg_dir);
+    const store_dir = try std.fmt.allocPrint(testing.allocator, "{s}/store/{s}", .{ prefix, valid_test_sha });
+    defer testing.allocator.free(store_dir);
+    try test_io.deleteTreeAbsolute(std.Options.debug_io, store_dir);
+
+    const keg_warm = try cellar_mod.materializeWithCellar(
+        std.Options.debug_io,
+        testing.allocator,
+        prefix,
+        valid_test_sha,
+        "fc",
+        "1.0",
+        ":any",
+    );
+    testing.allocator.free(keg_warm.path);
+
+    const poured_warm = try readFile(testing.allocator, live_conf);
+    defer testing.allocator.free(poured_warm);
+    try testing.expectEqualStrings("<fontconfig>poured</fontconfig>\n", poured_warm);
+}
+
+test "installBottleEtcVar creates empty overlay directories hooks rely on" {
+    const prefix = try createTestDir(testing.allocator);
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    // dbus ships `.bottle/var/lib/dbus/` with no files; post_install's
+    // dbus-uuidgen expects the directory to exist.
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/dbus/1.0", .{prefix});
+    defer testing.allocator.free(keg);
+    const empty_dir = try std.fmt.allocPrint(testing.allocator, "{s}/.bottle/var/lib/dbus", .{keg});
+    defer testing.allocator.free(empty_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, empty_dir);
+
+    cellar_mod.installBottleEtcVar(std.Options.debug_io, testing.allocator, keg, prefix);
+
+    const poured_dir = try std.fmt.allocPrint(testing.allocator, "{s}/var/lib/dbus", .{prefix});
+    defer testing.allocator.free(poured_dir);
+    var dir = try std.Io.Dir.openDirAbsolute(std.Options.debug_io, poured_dir, .{});
+    dir.close(std.Options.debug_io);
+}

--- a/tests/patcher_test.zig
+++ b/tests/patcher_test.zig
@@ -673,6 +673,91 @@ test "patchPathsCollecting leaves __cstring strings whose replacement does not f
     );
 }
 
+test "patchPathsCollecting relocates prefixes embedded mid-string in a cstring slot" {
+    var threaded: std.Io.Threaded = undefined;
+    const io = testIo(&threaded);
+    defer threaded.deinit();
+
+    // Compiled-in fallback configs (fontconfig's XML blob) carry the brew
+    // prefix mid-string, twice in one literal. Both occurrences must be
+    // rewritten, the tail left-shifted, and the freed bytes NUL-padded so
+    // the following slot stays intact.
+    const a = "<cachedir>/opt/homebrew/var/cache</cachedir><include>/opt/homebrew/etc/fonts</include>\x00";
+    const b = "neighbour\x00";
+    const blob = a ++ b;
+
+    const fix = try buildCstringFixture(testing.allocator, blob);
+    defer testing.allocator.free(fix.bytes);
+
+    const dir = try tmpSubdir(io, "cstr_midstring");
+    defer {
+        std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(io, dir, "bin", fix.bytes);
+    defer testing.allocator.free(path);
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "/opt/homebrew", .new = "/opt/malt" },
+    };
+    var outcome = try patcher.patchPathsCollecting(io, testing.allocator, path, &replacements);
+    defer outcome.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u32, 1), outcome.patched_count);
+
+    const file = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer file.close(io);
+    const got = try testing.allocator.alloc(u8, fix.bytes.len);
+    defer testing.allocator.free(got);
+    _ = try file.readPositionalAll(io, got, 0);
+    const region = got[fix.cstring_offset..][0..blob.len];
+
+    const want = "<cachedir>/opt/malt/var/cache</cachedir><include>/opt/malt/etc/fonts</include>";
+    try testing.expectEqualStrings(want, std.mem.sliceTo(region[0..a.len], 0));
+    // Freed tail bytes up to the original NUL must be zeroed.
+    for (region[want.len..a.len]) |byte| try testing.expectEqual(@as(u8, 0), byte);
+    // The neighbouring slot is untouched.
+    try testing.expectEqualStrings("neighbour", std.mem.sliceTo(region[a.len..][0..b.len], 0));
+}
+
+test "patchPathsCollecting leaves a slot byte-identical when a mid-string replacement would grow it" {
+    var threaded: std.Io.Threaded = undefined;
+    const io = testIo(&threaded);
+    defer threaded.deinit();
+
+    // A growing pair can't fit the fixed slot; the slot must stay
+    // byte-identical — never half-rewritten by a bail mid-scan.
+    const blob = "<dir>/x/fonts</dir><dir>/x/extra</dir>\x00";
+    const fix = try buildCstringFixture(testing.allocator, blob);
+    defer testing.allocator.free(fix.bytes);
+
+    const dir = try tmpSubdir(io, "cstr_midgrow");
+    defer {
+        std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(io, dir, "bin", fix.bytes);
+    defer testing.allocator.free(path);
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "/x", .new = "/much-longer-prefix" },
+    };
+    var outcome = try patcher.patchPathsCollecting(io, testing.allocator, path, &replacements);
+    defer outcome.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u32, 0), outcome.patched_count);
+
+    const file = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer file.close(io);
+    const got = try testing.allocator.alloc(u8, fix.bytes.len);
+    defer testing.allocator.free(got);
+    _ = try file.readPositionalAll(io, got, 0);
+    try testing.expectEqualStrings(
+        "<dir>/x/fonts</dir><dir>/x/extra</dir>",
+        std.mem.sliceTo(got[fix.cstring_offset..][0..blob.len], 0),
+    );
+}
+
 test "patchPathsCollecting picks the first matching prefix for cstrings" {
     var threaded: std.Io.Threaded = undefined;
     const io = testIo(&threaded);
@@ -708,6 +793,46 @@ test "patchPathsCollecting picks the first matching prefix for cstrings" {
     _ = try file.readPositionalAll(io, got, 0);
     try testing.expectEqualStrings(
         "/A/lib/x",
+        std.mem.sliceTo(got[fix.cstring_offset..][0..blob.len], 0),
+    );
+}
+
+test "patchPathsCollecting skips a whole slot when one replacement shrinks and another grows" {
+    var threaded: std.Io.Threaded = undefined;
+    const io = testIo(&threaded);
+    defer threaded.deinit();
+
+    // A slot is rewritten whole or left byte-identical: with one shrinking
+    // and one growing pair matching the same slot, the pre-scan must bail
+    // before any byte is written.
+    const blob = "@@HOMEBREW_PREFIX@@/etc:/x/share\x00";
+    const fix = try buildCstringFixture(testing.allocator, blob);
+    defer testing.allocator.free(fix.bytes);
+
+    const dir = try tmpSubdir(io, "cstr_mixedfit");
+    defer {
+        std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(io, dir, "bin", fix.bytes);
+    defer testing.allocator.free(path);
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "@@HOMEBREW_PREFIX@@", .new = "/opt/malt" },
+        .{ .old = "/x", .new = "/much-longer-prefix" },
+    };
+    var outcome = try patcher.patchPathsCollecting(io, testing.allocator, path, &replacements);
+    defer outcome.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u32, 0), outcome.patched_count);
+
+    const file = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer file.close(io);
+    const got = try testing.allocator.alloc(u8, fix.bytes.len);
+    defer testing.allocator.free(got);
+    _ = try file.readPositionalAll(io, got, 0);
+    try testing.expectEqualStrings(
+        "@@HOMEBREW_PREFIX@@/etc:/x/share",
         std.mem.sliceTo(got[fix.cstring_offset..][0..blob.len], 0),
     );
 }


### PR DESCRIPTION
## Description

Formulas whose bottles ship configuration were left broken after install, even when every hook reported success:

- Homebrew bottles carry their `etc`/`var` payload inside the keg at `.bottle/etc` and `.bottle/var`, poured into the prefix at install time. malt never poured it, so defaults like fontconfig's `etc/fonts/fonts.conf` and required directories like dbus's `var/lib/dbus` simply never existed — fontconfig could not load its default config and dbus could not write its machine id.
- With the config missing, fontconfig falls back to a compiled-in XML blob whose `/opt/homebrew` paths sit mid-string inside one C-string literal. The Mach-O cstring patcher only matched prefixes at the head of a string, so those embedded paths were never relocated and the fallback pointed at another package manager's tree.

This change pours the overlay with Homebrew's semantics — install missing files (and empty directories hooks rely on), skip identical ones, and write a user-modified config's new default beside it as `<name>.default` — on both the cold install path and the warm relocated-cache reinstall path. The cstring patcher now rewrites embedded prefixes anywhere in a NUL-terminated slot, shrink-in-place with zero padding, leaving a slot byte-identical when a growing replacement cannot fit.

Verified end to end: a clean `malt install git-cola` completes with all hooks genuinely succeeding — dbus generates its machine id, fontconfig loads its poured config and builds the font cache under the malt prefix.

## Related Issue

- None

## Notes for Reviewers

- None