### PR TITLE
fix(tui): restore the terminal on panic and termination signals

### DIFF
--- a/scripts/regressions/tui-crash-restore-tui-panic-sigterm-leaves-terminal-raw.sh
+++ b/scripts/regressions/tui-crash-restore-tui-panic-sigterm-leaves-terminal-raw.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Regression: a termination signal delivered to `mt tui` must not wedge the
+# user's shell. The dashboard enters raw mode + the alternate screen, but its
+# restore ran only on error-return and normal-exit paths; SIGTERM/SIGHUP/
+# SIGQUIT kept their default disposition (immediate death), leaving the pty
+# with echo off, byte-at-a-time input, and the alt buffer active — the user
+# had to blind-type `reset`.
+#
+# Drives the built binary on a real pty via BSD script(1), kills it with
+# SIGTERM, then asserts the pty came back in cooked mode (echo restored) and
+# the alt-screen leave sequence was emitted before death.
+#
+# Exits 0 when the bug is absent, non-zero with a message when present.
+# No network (a throwaway MALT_PREFIX keeps the launch audits local); cleans
+# up its temp state; finishes well under 30s once built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+OUT=$(mktemp -t mt_tui_sigterm.XXXXXX)
+PREFIX=$(mktemp -d -t mt_tui_sigterm_prefix.XXXXXX)
+trap 'rm -rf "$OUT" "$PREFIX"' EXIT
+
+# script(1) gives the child a fresh pty and records everything written to it.
+# The TUI refuses under CI/NO_COLOR, so both are scrubbed inside; the
+# throwaway prefix keeps the launch audits off the real store and the network.
+# The KILL fallback only bounds a hang — a killed TUI never restored, so the
+# assertions below still fail.
+# shellcheck disable=SC2016 # the inner sh expands these, not this shell
+MALT_TUI_BIN="$BIN" MALT_PREFIX="$PREFIX" \
+  script -q "$OUT" sh -c '
+    # `&` defaults stdin to /dev/null; the TUI reads and draws through fd 0,
+    # so hand it the pty read-write.
+    env -u CI -u NO_COLOR "$MALT_TUI_BIN" tui 0<>/dev/tty &
+    pid=$!
+    sleep 2
+    kill -TERM "$pid" 2>/dev/null
+    i=0
+    while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 50 ]; do
+      sleep 0.1
+      i=$((i + 1))
+    done
+    kill -KILL "$pid" 2>/dev/null
+    wait "$pid" 2>/dev/null
+    echo "WAITSTATUS:$?"
+    stty -a
+  ' </dev/null >/dev/null || true
+
+# Cooked mode restored: stty must not report echo disabled. Right-anchored so
+# `-echonl`/`-echoprt` (off even in cooked mode) do not false-positive.
+if grep -aqE '(^|[[:space:]])-echo([[:space:]]|$)' "$OUT"; then
+  fail 'pty left in raw mode (-echo) after SIGTERM'
+fi
+
+# The alt-screen leave sequence must have been emitted before death.
+grep -aqF $'\x1b[?1049l' "$OUT" ||
+  fail 'alt-screen leave sequence never emitted after SIGTERM'
+
+# Death must still be BY SIGTERM (128+15): a handler whose re-raise is not
+# fatal loops until the KILL fallback (137) or exits cleanly — both wrong.
+grep -aq 'WAITSTATUS:143' "$OUT" ||
+  fail 'tui did not die by SIGTERM after restoring'
+
+printf 'PASS: SIGTERM restored the pty to cooked mode and left the alt-screen\n'

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -98,6 +98,7 @@ pub const custom_theme = @import("ui/custom_theme.zig");
 pub const output = @import("ui/output.zig");
 pub const progress = @import("ui/progress.zig");
 pub const spinner_frames = @import("ui/spinner_frames.zig");
+pub const term_restore = @import("ui/term_restore.zig");
 pub const term_sanitize = @import("ui/term_sanitize.zig");
 pub const theme_registry = @import("ui/theme_registry.zig");
 pub const themes = @import("ui/themes.zig");

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -4,41 +4,40 @@
 //! `renderFrame(buf, app, cols, rows) -> bytes` — are The Elm Architecture and
 //! are unit-tested without a PTY. `run` is the only impure part: it owns the
 //! terminal lifecycle (raw mode + alt-screen + hidden cursor, each undone by an
-//! `errdefer` restore), refuses to launch on a non-interactive terminal, and
-//! drives the read→decode→step→repaint loop. A `SIGWINCH` re-renders from cached
+//! `errdefer` restore; panics and termination signals restore through the
+//! `ui/term_restore` crash registry), refuses to launch on a non-interactive
+//! terminal, and drives the read→decode→step→repaint loop. A `SIGWINCH` re-renders from cached
 //! state with no keypress. The TUI module is referenced only from the lazy
 //! `mt tui` dispatch arm, so non-`tui` commands pay no cold-start cost.
 
 const std = @import("std");
+
 const color = @import("../ui/color.zig");
-const term_sanitize = @import("../ui/term_sanitize.zig");
 const spinner_frames = @import("../ui/spinner_frames.zig");
+const term_sanitize = @import("../ui/term_sanitize.zig");
+const doctor = @import("doctor_tab.zig");
+const filter_input = @import("filter_input.zig");
+const header = @import("header.zig");
+const installed = @import("installed_tab.zig");
+const doctor_json = @import("json/doctor.zig");
+const info_json = @import("json/info.zig");
+const list_json = @import("json/list.zig");
+const outdated_json = @import("json/outdated.zig");
+const search_json = @import("json/search.zig");
+const services_json = @import("json/services.zig");
+const keys = @import("keys.zig");
+const Key = keys.Key;
+const layout = @import("layout.zig");
+const outdated = @import("outdated_tab.zig");
+const scroll_list = @import("scroll_list.zig");
+const search = @import("search_tab.zig");
+const services = @import("services_tab.zig");
+const spawn = @import("spawn.zig");
 const tab = @import("tab.zig");
 const tab_bar = @import("tab_bar.zig");
-const header = @import("header.zig");
-const filter_input = @import("filter_input.zig");
-const keys = @import("keys.zig");
-const term = @import("term.zig");
-const layout = @import("layout.zig");
-const scroll_list = @import("scroll_list.zig");
-const text_wrap = @import("text_wrap.zig");
-
-const spawn = @import("spawn.zig");
-const list_json = @import("json/list.zig");
-const info_json = @import("json/info.zig");
-const outdated_json = @import("json/outdated.zig");
-const services_json = @import("json/services.zig");
-const doctor_json = @import("json/doctor.zig");
-const search_json = @import("json/search.zig");
-
-const installed = @import("installed_tab.zig");
-const outdated = @import("outdated_tab.zig");
-const services = @import("services_tab.zig");
-const doctor = @import("doctor_tab.zig");
-const search = @import("search_tab.zig");
-
 const Tab = tab_bar.Tab;
-const Key = keys.Key;
+const term = @import("term.zig");
+const text_wrap = @import("text_wrap.zig");
 
 /// Every tab's state, all present at once so a tab switch preserves each one's
 /// filter / scroll / data. Field names match `Tab` tags for `@field` dispatch.
@@ -505,7 +504,9 @@ pub const RunError = term.TermError || std.mem.Allocator.Error ||
 
 /// How the event loop treats a run-loop error: a `recoverable` backend fault
 /// becomes an inline banner and the session keeps running; a `fatal` fault
-/// restores the terminal and exits (the TUI-012 crash-safety guarantee).
+/// restores the terminal and exits (the crash-safety guarantee for
+/// error returns; panics and termination signals restore via the
+/// `ui/term_restore` crash registry instead).
 pub const ErrorClass = enum { recoverable, fatal };
 
 /// Pure, exhaustive classifier over `RunError`. A child-process or parse fault
@@ -1689,6 +1690,12 @@ pub fn run(io: std.Io, allocator: std.mem.Allocator, stderr: std.Io.File, enviro
     // The tty is read+write through one fd; the refusal guard proved it is one.
     const fd = in_fd;
     var t = term.Term.init(io, fd);
+    // SIGTERM/SIGHUP/SIGQUIT restore the terminal then re-raise; errdefers
+    // cover error returns but never a signal death. Installed before raw
+    // entry so no signal can land in between — with an empty registry the
+    // handler is a no-op that just dies. SIGINT stays untouched: raw mode
+    // delivers Ctrl-C as a byte that quits cleanly.
+    term.installCrashSignals();
     try t.enterRaw();
     errdefer t.restore();
     try t.enterAltScreen();
@@ -2746,7 +2753,7 @@ test "classify splits recoverable backend faults from fatal terminal/OOM faults"
     try std.testing.expectEqual(ErrorClass.recoverable, classify(error.EmptyOutput));
     try std.testing.expectEqual(ErrorClass.recoverable, classify(error.ReadFailed)); // child pipe
     try std.testing.expectEqual(ErrorClass.recoverable, classify(error.BadJson));
-    // Terminal-integrity + OOM: fatal — restore and exit (the TUI-012 guarantee).
+    // Terminal-integrity + OOM: fatal — restore and exit (the crash-safety guarantee).
     try std.testing.expectEqual(ErrorClass.fatal, classify(error.NotATty));
     try std.testing.expectEqual(ErrorClass.fatal, classify(error.WriteFailed));
     try std.testing.expectEqual(ErrorClass.fatal, classify(error.TermiosFailed));

--- a/src/tui/term.zig
+++ b/src/tui/term.zig
@@ -1,15 +1,18 @@
 //! malt — terminal control primitives for `mt tui`.
 //!
-//! Leaf module: imports only `std` and the shared `ui/termsize` leaf (the
-//! `mt tui` dashboard pressure-tests the `--json` contract instead of reaching
-//! into `cli/*`/`core/*`). Provides raw-mode, alternate-screen, and cursor
-//! machinery; window-size + `SIGWINCH` tracking lives in `ui/termsize` and is
-//! re-exported here. A single idempotent `restore()` undoes everything entered
-//! and is wired through `errdefer` downstream so a crash can never wedge the
-//! terminal.
+//! Leaf module: imports only `std` and the shared `ui/termsize` +
+//! `ui/term_restore` leaves (the `mt tui` dashboard pressure-tests the
+//! `--json` contract instead of reaching into `cli/*`/`core/*`). Provides
+//! raw-mode, alternate-screen, and cursor machinery; window-size + `SIGWINCH`
+//! tracking lives in `ui/termsize` and is re-exported here. A single
+//! idempotent `restore()` undoes everything entered and is wired through
+//! `errdefer` downstream; `enterRaw` also mirrors the saved termios into the
+//! `ui/term_restore` registry so the panic hook and termination-signal
+//! handlers can restore even when defers never run.
 
 const std = @import("std");
 const termsize = @import("../ui/termsize.zig");
+const term_restore = @import("../ui/term_restore.zig");
 
 /// Window-size + `SIGWINCH` tracking lives in the shared `ui/termsize` leaf so
 /// the CLI side can reuse it without reaching into the TUI. Re-exported here so
@@ -22,6 +25,10 @@ pub const takeResized = termsize.takeResized;
 pub const currentSize = termsize.currentSize;
 pub const setWinchInstalledForTest = termsize.setWinchInstalledForTest;
 pub const setResizedForTest = termsize.setResizedForTest;
+
+/// Crash-only escape hatch, re-exported from `ui/term_restore` so the TUI
+/// run loop wires termination signals next to `installWinch`.
+pub const installCrashSignals = term_restore.installCrashSignals;
 
 /// Escape sequences whose effect is idempotent at the terminal level, so the
 /// state guards below only exist to avoid redundant writes, not to stay correct.
@@ -123,10 +130,15 @@ pub const Term = struct {
         raw.cc[@intFromEnum(std.posix.V.TIME)] = 0;
         std.posix.tcsetattr(self.fd, .FLUSH, raw) catch return TermError.TermiosFailed;
         self.saved = saved;
+        // Mirror into the crash registry: defers never run on panic or a
+        // termination signal, and this stack-local `saved` is unreachable
+        // from those process-global paths.
+        term_restore.register(self.fd, saved);
     }
 
     pub fn exitRaw(self: *Term) void {
         const saved = self.saved orelse return;
+        term_restore.clear();
         // Best-effort: a gone tty cannot be put back, and there is no sane
         // recovery from inside restore/errdefer.
         std.posix.tcsetattr(self.fd, .FLUSH, saved) catch {};

--- a/src/ui/progress.zig
+++ b/src/ui/progress.zig
@@ -17,6 +17,7 @@ const builtin = @import("builtin");
 const color = @import("color.zig");
 const output = @import("output.zig");
 const termsize = @import("termsize.zig");
+const term_restore = @import("term_restore.zig");
 const spinner_frames = @import("spinner_frames.zig");
 
 var pkg_stderr: std.Io.File = .{ .handle = -1, .flags = .{ .nonblocking = false } };
@@ -156,7 +157,11 @@ fn writePlainLine(label: []const u8, status: []const u8) void {
 /// or `Spinner.start`: re-enable autowrap, show the cursor, return to
 /// column 0. Safe to call from a panic / signal handler — the bytes are
 /// idempotent, and writes silently drop when stderr is unconfigured.
+/// When the TUI registered a raw terminal, its crash restore (alt-screen
+/// leave + `tcsetattr`) runs first, so a panic message lands on a readable
+/// cooked screen instead of trapping inside the alt buffer.
 pub fn restoreTerminal() void {
+    term_restore.crashRestore();
     writeStderrAll("\x1b[?7h\x1b[?25h\r");
 }
 

--- a/src/ui/term_restore.zig
+++ b/src/ui/term_restore.zig
@@ -1,0 +1,179 @@
+//! malt — signal-safe crash-restore registry for terminal state.
+//!
+//! `std`-only leaf in the `ui/` sink layer, below both the CLI progress
+//! engine and `tui/term.zig`. The TUI's saved termios lives on the run
+//! loop's stack, unreachable from the process-global panic hook and from
+//! signal handlers; this registry mirrors the two fields the crash path
+//! needs — the terminal fd and the pre-raw termios — so either path can
+//! put the terminal back before the process dies.
+
+const std = @import("std");
+
+/// Everything a crashing raw-mode process must emit: leave the alt screen,
+/// show the cursor, re-enable autowrap, return to column 0. Emitting
+/// `?1049l` while not on the alt buffer is a no-op on xterm-family
+/// terminals, so the crash path never tracks alt-screen state separately.
+pub const restore_seq = "\x1b[?1049l\x1b[?25h\x1b[?7h\r";
+
+// The flag flips `.release` only after fd/termios are in place, so a crash
+// path's `.acquire` load never observes a half-written registration.
+var active: std.atomic.Value(bool) = .init(false);
+var reg_fd: std.posix.fd_t = -1;
+var reg_termios: std.posix.termios = undefined;
+
+/// Record the terminal to restore on a crash. One registration at a time —
+/// the TUI owns at most one raw terminal.
+pub fn register(fd: std.posix.fd_t, saved: std.posix.termios) void {
+    reg_fd = fd;
+    reg_termios = saved;
+    active.store(true, .release);
+}
+
+/// Forget the registration; a clean exit restores through `Term` instead.
+pub fn clear() void {
+    active.store(false, .release);
+}
+
+/// Put the registered terminal back from a panic or signal handler.
+/// Async-signal-safe: no allocation, no locks, only `write` + `tcsetattr`,
+/// both best-effort. Idempotent and a no-op when nothing is registered.
+pub fn crashRestore() void {
+    if (!active.load(.acquire)) return;
+    var off: usize = 0;
+    while (off < restore_seq.len) {
+        const n = std.c.write(reg_fd, restore_seq[off..].ptr, restore_seq.len - off);
+        if (n <= 0) break; // best-effort: a vanished tty has nothing to restore
+        off += @intCast(n);
+    }
+    std.posix.tcsetattr(reg_fd, .FLUSH, reg_termios) catch {};
+}
+
+/// Termination signals that must restore the terminal before the process
+/// dies. `SIGINT` is absent by design: TUI raw mode turns `ISIG` off, so
+/// Ctrl-C arrives as a byte and exits through the clean restore path.
+const crash_signals = [_]std.posix.SIG{ .TERM, .HUP, .QUIT };
+
+fn crashSignalHandler(sig: std.posix.SIG) callconv(.c) void {
+    crashRestore();
+    // SA_RESETHAND already restored the default disposition; re-raising
+    // delivers it when the handler returns, so the parent still observes
+    // death-by-signal and SIGQUIT keeps its core-dump semantics.
+    std.posix.raise(sig) catch {};
+}
+
+/// Wire `SIGTERM`/`SIGHUP`/`SIGQUIT` to restore-then-die. TUI-only by
+/// contract — plain CLI commands never enter raw mode. Handled signals
+/// reset to default on `execve`, so delegated children are unaffected.
+pub fn installCrashSignals() void {
+    const act = std.posix.Sigaction{
+        .handler = .{ .handler = &crashSignalHandler },
+        .mask = std.posix.sigemptyset(),
+        .flags = std.posix.SA.RESETHAND,
+    };
+    for (crash_signals) |sig| std.posix.sigaction(sig, &act, null);
+}
+
+// The regression script exercises SIGTERM end-to-end on a real pty; this
+// pins that HUP and QUIT get the same restore-then-die wiring. SA_RESETHAND
+// is not asserted here — Darwin does not report it back through a sigaction
+// query — its effect is covered by the death-by-signal test below.
+test "installCrashSignals wires TERM/HUP/QUIT to the restore handler" {
+    var prev: [crash_signals.len]std.posix.Sigaction = undefined;
+    for (crash_signals, 0..) |sig, i| std.posix.sigaction(sig, null, &prev[i]);
+    defer for (crash_signals, 0..) |sig, i| std.posix.sigaction(sig, &prev[i], null);
+
+    installCrashSignals();
+    for (crash_signals) |sig| {
+        var act: std.posix.Sigaction = undefined;
+        std.posix.sigaction(sig, null, &act);
+        try std.testing.expectEqual(&crashSignalHandler, act.handler.handler);
+    }
+}
+
+// Forked child: install the crash handlers, then raise the signal on
+// ourselves. With SA_RESETHAND intact the handler's re-raise is fatal; if
+// the flag ever regressed, delivery would loop through the handler forever
+// and the parent's deadline below catches it. Exit 0 marks "survived", which
+// the parent treats as failure.
+fn raiseAndDie(sig: std.posix.SIG) noreturn {
+    clear(); // inherited registration would make crashRestore scribble on a test pipe
+    installCrashSignals();
+    std.posix.raise(sig) catch {};
+    std.process.exit(0);
+}
+
+// Darwin won't report SA_RESETHAND back through a sigaction query, so pin
+// its observable contract instead: a handled termination signal still kills
+// the process *by that signal* (the parent must see a signaled wait status,
+// not an exit).
+test "a handled termination signal is fatal and preserves death-by-signal" {
+    for (crash_signals) |sig| {
+        const pid = std.c.fork();
+        try std.testing.expect(pid >= 0);
+        if (pid == 0) raiseAndDie(sig);
+
+        var status: c_int = undefined;
+        var waited_ms: usize = 0;
+        const reaped = while (waited_ms < 5000) : (waited_ms += 50) {
+            if (std.c.waitpid(pid, &status, std.c.W.NOHANG) == pid) break true;
+            var ts: std.c.timespec = .{ .sec = 0, .nsec = 50 * std.time.ns_per_ms };
+            _ = std.c.nanosleep(&ts, null);
+        } else false;
+        if (!reaped) {
+            // A child still alive is the RESETHAND regression: its handler
+            // re-raise loops instead of dying. Reap and fail.
+            std.posix.kill(pid, .KILL) catch {};
+            _ = std.c.waitpid(pid, &status, 0);
+            return error.HandledSignalNotFatal;
+        }
+
+        const st: u32 = @bitCast(status);
+        try std.testing.expect(std.c.W.IFSIGNALED(st));
+        try std.testing.expectEqual(sig, std.c.W.TERMSIG(st));
+    }
+}
+
+test "crashRestore writes exactly the restore sequence and is safe to call twice" {
+    var fds: [2]std.posix.fd_t = undefined;
+    try std.testing.expectEqual(@as(c_int, 0), std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+    // Non-blocking read end: a restore that writes nothing fails the test
+    // instead of hanging it.
+    const nonblock: c_int = @bitCast(std.posix.O{ .NONBLOCK = true });
+    try std.testing.expect(std.c.fcntl(fds[0], std.posix.F.SETFL, nonblock) != -1);
+
+    // tcsetattr on a pipe fails — swallowing it IS the best-effort contract.
+    register(fds[1], std.mem.zeroes(std.posix.termios));
+    defer clear();
+    crashRestore();
+    crashRestore(); // still registered: panic hook and signal path may both fire
+
+    var buf: [2 * restore_seq.len]u8 = undefined;
+    var got: usize = 0;
+    while (got < buf.len) {
+        const n = std.c.read(fds[0], buf[got..].ptr, buf.len - got);
+        try std.testing.expect(n > 0);
+        got += @intCast(n);
+    }
+    try std.testing.expectEqualStrings(restore_seq ++ restore_seq, &buf);
+}
+
+test "crashRestore after register/clear round-trip writes nothing" {
+    var fds: [2]std.posix.fd_t = undefined;
+    try std.testing.expectEqual(@as(c_int, 0), std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+
+    register(fds[1], std.mem.zeroes(std.posix.termios));
+    clear();
+    crashRestore();
+
+    // A sentinel byte must be the first thing readable — an unregistered
+    // restore that wrote anything would land ahead of it.
+    try std.testing.expectEqual(@as(isize, 1), std.c.write(fds[1], "S", 1));
+    var buf: [restore_seq.len]u8 = undefined;
+    const n = std.c.read(fds[0], &buf, buf.len);
+    try std.testing.expectEqual(@as(isize, 1), n);
+    try std.testing.expectEqual(@as(u8, 'S'), buf[0]);
+}

--- a/tests/tui_purity_test.zig
+++ b/tests/tui_purity_test.zig
@@ -98,6 +98,7 @@ fn importAllowed(importer_dir: []const u8, path: []const u8) bool {
     return std.mem.eql(u8, resolved, "src/ui/color.zig") or
         std.mem.eql(u8, resolved, "src/ui/term_sanitize.zig") or
         std.mem.eql(u8, resolved, "src/ui/termsize.zig") or
+        std.mem.eql(u8, resolved, "src/ui/term_restore.zig") or
         std.mem.eql(u8, resolved, "src/ui/spinner_frames.zig");
 }
 
@@ -147,6 +148,11 @@ test "importAllowed permits a subdirectory sibling and the ui helpers from a sub
 test "importAllowed permits the shared termsize leaf" {
     try testing.expect(importAllowed("src/tui", "../ui/termsize.zig"));
     try testing.expect(importAllowed("src/tui/json", "../../ui/termsize.zig"));
+}
+
+test "importAllowed permits the shared term_restore leaf" {
+    try testing.expect(importAllowed("src/tui", "../ui/term_restore.zig"));
+    try testing.expect(importAllowed("src/tui/json", "../../ui/term_restore.zig"));
 }
 
 test "importAllowed permits the shared spinner_frames leaf" {


### PR DESCRIPTION
## Description

A panic or a termination signal (`SIGTERM`/`SIGHUP`/`SIGQUIT`) used to kill `mt tui` without leaving raw mode or the alternate screen: the saved termios lived on the run loop's stack, unreachable from the panic hook, and no termination-signal handler existed. The user's shell was left with no echo and byte-at-a-time input until they blind-typed `reset`.

This PR adds a signal-safe crash-restore registry (`ui/term_restore`) that mirrors the terminal fd and pre-raw termios. Raw-mode entry registers, clean exit clears. The panic hook reaches it through `progress.restoreTerminal()`, and the TUI installs restore-then-die handlers for the three termination signals before entering raw mode, so there is no window where the terminal is raw without crash coverage. The process still dies by its signal (`SA_RESETHAND` + re-raise), so parents observe the real cause of death and `SIGQUIT` keeps its core-dump semantics. In-TUI Ctrl-C is untouched - raw mode delivers it as a byte that quits through the clean restore path.

## Related Issue

- None

## Notes for Reviewers

- None