### PR TITLE
fix(tui): uninstall the package the guard was armed on, not the live selection

### DIFF
--- a/scripts/regressions/tui-uninstall-guard-not-modal.sh
+++ b/scripts/regressions/tui-uninstall-guard-not-modal.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Regression: the Installed tab's [y/N] uninstall guard must latch its
+# target when armed. Confirming with `y` after the selection moved (or
+# after a background reload shifted the rows) must uninstall the package
+# the guard was armed on, never the live selection.
+#
+# The bug: the guard was a bare bool, navigation keys bypassed it, and
+# both the banner and the uninstall spawn read the selection live at
+# confirmation time — so `x` on pkgA, `down`, `y` uninstalled pkgB.
+#
+# The logic is pure-core, so this leans on the always-rebuilt unit tests
+# plus source-level guards that fail on a pre-fix tree (Zig has no
+# --test-filter, per the repo's established pattern).
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+fail() {
+  echo "REGRESSION: $1" >&2
+  exit 1
+}
+
+# 1. The latch must exist: a bare bool guard is the bug.
+if rg -q 'confirm_uninstall: bool' src/tui/installed_tab.zig; then
+  fail "uninstall guard is still a target-less bool"
+fi
+
+# 2. The shell must not resolve the target live at confirmation time.
+if rg -A2 'fn doUninstall' src/tui/app.zig | rg -q 'selectedPkg'; then
+  fail "doUninstall still reads the live selection"
+fi
+
+# 3. The latch/modality unit tests must exist and pass.
+rg -q 'latches' src/tui/installed_tab.zig ||
+  fail "guard-latch tests missing from installed_tab.zig"
+zig build test || fail "unit tests failed"
+
+echo "OK: uninstall guard latches its target"

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -273,6 +273,17 @@ fn stepFilter(a: *App, key: Key) void {
 }
 
 fn stepNormal(a: *App, key: Key) void {
+    // The Installed uninstall guard is modal: while it is up, route every key
+    // to the tab so its one-key resolve sees keys this switch would otherwise
+    // consume — navigation, tab switches, digits, and `/` then cancel the
+    // guard instead of bypassing it.
+    if (a.active == .installed and a.states.installed.confirm_uninstall != null) {
+        switch (key) {
+            .ctrl_c => a.quit = true,
+            else => routeToTab(a, key),
+        }
+        return;
+    }
     switch (key) {
         .ctrl_c => a.quit = true,
         .tab, .right => a.active = tab_bar.next(a.active),
@@ -972,12 +983,11 @@ fn openDetail(io: std.Io, allocator: std.mem.Allocator, app: *App, store: *Store
     app.states.installed.detail = .{ .pkg = sel, .info = parsed.info };
 }
 
-/// Delegate uninstall to the real `mt` inline, then refresh the list. `sel.name`
-/// is copied into the argv before the spawn; the post-spawn reload frees the
-/// storage it borrowed from, so it is not read afterwards.
-fn doUninstall(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, app: *App, store: *Store) RunError!void {
-    const sel = installed.selectedPkg(&app.states.installed) orelse return;
-    const argv = try spawn.inlineArgv(allocator, app.mt_path, &.{ "uninstall", sel.name });
+/// Delegate uninstall to the real `mt` inline, then refresh the list. The
+/// target is the guard's latched copy — it neither borrows the list storage the
+/// post-spawn reload frees nor tracks a selection that moved after arming.
+fn doUninstall(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, app: *App, store: *Store, target: installed.ConfirmTarget) RunError!void {
+    const argv = try spawn.inlineArgv(allocator, app.mt_path, &.{ "uninstall", target.name() });
     defer allocator.free(argv);
     {
         // A non-zero `mt uninstall` re-enters the dashboard (the user still has
@@ -999,7 +1009,7 @@ fn serviceInstalled(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, app
     switch (req) {
         .none => {},
         .open_detail => try openDetail(io, allocator, app, store),
-        .uninstall => try doUninstall(io, allocator, t, app, store),
+        .uninstall => |target| try doUninstall(io, allocator, t, app, store, target),
     }
     // Lazy per-tab refresh: a tab marked dirty by a mutation refetches on entry.
     if (app.active == .installed and takeDirty(app, .installed)) {
@@ -1870,9 +1880,53 @@ test "a committed filter survives a tab round-trip" {
 
 test "esc in normal mode routes to the active tab so it can cancel its guard" {
     var a: App = .{ .active = .installed };
-    a.states.installed.confirm_uninstall = true;
+    a.states.installed.confirm_uninstall = installed.ConfirmTarget.init("curl");
     a = step(a, .esc); // not editing → must reach the tab, which lowers the guard
-    try std.testing.expect(!a.states.installed.confirm_uninstall);
+    try std.testing.expect(a.states.installed.confirm_uninstall == null);
+}
+
+const guard_pkgs = [_]installed.Pkg{
+    .{ .name = "pkga", .version = "1", .kind = .formula, .pinned = false, .size_bytes = null, .linked = null },
+    .{ .name = "pkgb", .version = "1", .kind = .formula, .pinned = false, .size_bytes = null, .linked = null },
+};
+
+test "navigation while the uninstall guard is up cancels it instead of retargeting" {
+    var a: App = .{ .active = .installed };
+    a.states.installed.items = &guard_pkgs;
+    a = step(a, ch('x')); // arm on pkga (row 0)
+    try std.testing.expect(a.states.installed.confirm_uninstall != null);
+    a = step(a, .down); // modal: the key resolves the guard (cancel), not the list
+    try std.testing.expect(a.states.installed.confirm_uninstall == null);
+    a = step(a, ch('y')); // no longer a confirmation — must not request an uninstall
+    try std.testing.expect(a.states.installed.request == .none);
+    try std.testing.expectEqual(@as(usize, 0), a.states.installed.chrome.view.selected);
+}
+
+test "q while the uninstall guard is up cancels it instead of quitting" {
+    var a: App = .{ .active = .installed };
+    a.states.installed.items = &guard_pkgs;
+    a = step(a, ch('x'));
+    a = step(a, ch('q'));
+    try std.testing.expect(!a.quit); // the guard consumed the key
+    try std.testing.expect(a.states.installed.confirm_uninstall == null);
+}
+
+test "slash while the uninstall guard is up cancels it instead of opening the filter" {
+    var a: App = .{ .active = .installed };
+    a.states.installed.items = &guard_pkgs;
+    a = step(a, ch('x'));
+    a = step(a, ch('/'));
+    try std.testing.expect(!a.editing);
+    try std.testing.expect(a.states.installed.confirm_uninstall == null);
+}
+
+test "tab switch while the uninstall guard is up resolves the guard, not the tab bar" {
+    var a: App = .{ .active = .installed };
+    a.states.installed.items = &guard_pkgs;
+    a = step(a, ch('x'));
+    a = step(a, .tab);
+    try std.testing.expect(a.states.installed.confirm_uninstall == null); // never left armed
+    try std.testing.expectEqual(Tab.installed, a.active); // the key was consumed by the guard
 }
 
 test "esc clears the filter and leaves edit mode" {
@@ -1961,7 +2015,7 @@ test "Enter on a data tab still routes as that tab's domain key, not a focus" {
     var a: App = .{ .active = .installed };
     a = step(a, .enter);
     try std.testing.expect(!a.editing);
-    try std.testing.expectEqual(installed.Request.open_detail, a.states.installed.request);
+    try std.testing.expect(a.states.installed.request == .open_detail);
 }
 
 test "renderFrame shows the committed filter and the editing footer" {
@@ -2291,7 +2345,7 @@ test "mutationPending gates only on requests that spawn a DB-mutating child" {
 
     // Each mutating request, in isolation, gates the drain.
     app = .{};
-    app.states.installed.request = .uninstall;
+    app.states.installed.request = .{ .uninstall = installed.ConfirmTarget.init("wget") };
     try std.testing.expect(mutationPending(&app));
     app = .{};
     app.states.outdated.request = .upgrade;

--- a/src/tui/installed_tab.zig
+++ b/src/tui/installed_tab.zig
@@ -9,7 +9,9 @@
 //! row's detail (deps / tap / size / linked / pinned) renders through the
 //! reusable `detail_pane`. `x` raises a one-key `[y/N]` guard — the app's single
 //! TUI-side confirm, justified only because `mt uninstall` has no prompt of its
-//! own; `y` then delegates to the real `mt uninstall`, unweakened.
+//! own. Arming latches the target's name by copy, so the confirm always acts on
+//! the package the guard was raised over — a moved selection or a reloaded list
+//! cannot retarget it; `y` then delegates to the real `mt uninstall`, unweakened.
 
 const std = @import("std");
 const tab = @import("tab.zig");
@@ -23,7 +25,32 @@ pub const Pkg = list_json.Pkg;
 
 /// An effect the pure `step` defers to the impure shell, which performs it and
 /// resets the field. `step` never does I/O — this is the command channel.
-pub const Request = enum { none, open_detail, uninstall };
+/// `uninstall` carries the guard's latched target so the shell never re-derives
+/// it from a selection that may have moved since the guard was armed.
+pub const Request = union(enum) { none, open_detail, uninstall: ConfirmTarget };
+
+/// Scratch bound shared by a formatted row, the guard banner, and the latched
+/// target name, so none of the three can silently outgrow the others.
+const row_buf_len = 256;
+
+/// The uninstall guard's target, latched at arm time. The name is copied — not
+/// borrowed — because `items` borrows shell-owned parse storage that a reload
+/// can free while the guard is up.
+pub const ConfirmTarget = struct {
+    buf: [row_buf_len]u8 = undefined,
+    len: usize = 0,
+
+    pub fn init(pkg_name: []const u8) ConfirmTarget {
+        var t: ConfirmTarget = .{};
+        t.len = @min(pkg_name.len, t.buf.len);
+        @memcpy(t.buf[0..t.len], pkg_name[0..t.len]);
+        return t;
+    }
+
+    pub fn name(self: *const ConfirmTarget) []const u8 {
+        return self.buf[0..self.len];
+    }
+};
 
 /// The selected row's detail: the `list` row (size/linked/pinned) plus the
 /// `mt info` payload (deps/tap). Both borrow from shell-owned storage.
@@ -38,8 +65,8 @@ pub const State = struct {
     items: []const Pkg = &.{},
     /// The open detail pane, if a row was selected with Enter.
     detail: ?Detail = null,
-    /// The `[y/N]` uninstall guard is up.
-    confirm_uninstall: bool = false,
+    /// The `[y/N]` uninstall guard, latched on the package it was armed over.
+    confirm_uninstall: ?ConfirmTarget = null,
     /// Pending effect for the shell to perform, then clear.
     request: Request = .none,
 };
@@ -86,27 +113,29 @@ pub fn selectedPkg(s: *const State) ?Pkg {
 /// Pure transition: record the user's intent for the shell to act on. While the
 /// guard is up, the next key resolves it.
 pub fn step(s: *State, key: tab.Key) void {
-    if (s.confirm_uninstall) return resolveGuard(s, key);
+    if (s.confirm_uninstall != null) return resolveGuard(s, key);
     switch (key) {
         .enter => s.request = .open_detail,
         .esc => s.detail = null, // close the detail pane
         .char => |c| if (c.len == 1 and c.bytes[0] == 'x') {
-            s.confirm_uninstall = true; // fat-finger guard before delegating uninstall
+            // Fat-finger guard before delegating uninstall. Latch the target at
+            // arm time; an empty or filtered-out list has nothing to guard.
+            if (selectedPkg(s)) |p| s.confirm_uninstall = ConfirmTarget.init(p.name);
         },
         else => {},
     }
 }
 
-/// `y` confirms (request the real `mt uninstall`); every other key — `n`, Esc,
-/// Enter — cancels. The guard is a fat-finger gate, not a typed-confirm.
+/// `y` confirms (request the real `mt uninstall` of the latched target); every
+/// other key — `n`, Esc, Enter — cancels. A fat-finger gate, not a typed-confirm.
 fn resolveGuard(s: *State, key: tab.Key) void {
     switch (key) {
         .char => |c| if (c.len == 1 and (c.bytes[0] == 'y' or c.bytes[0] == 'Y')) {
-            s.request = .uninstall;
+            s.request = .{ .uninstall = s.confirm_uninstall.? };
         },
         else => {},
     }
-    s.confirm_uninstall = false;
+    s.confirm_uninstall = null;
 }
 
 /// Pure render: an optional guard banner on top, an optional detail pane at the
@@ -114,8 +143,8 @@ fn resolveGuard(s: *State, key: tab.Key) void {
 /// `(state, rect)` so a resize is a re-render.
 pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     var content = r;
-    if (s.confirm_uninstall) {
-        renderGuard(s, f, .{ .row = content.row, .col = content.col, .width = content.width, .height = 1 });
+    if (s.confirm_uninstall) |*target| {
+        renderGuard(target.name(), f, .{ .row = content.row, .col = content.col, .width = content.width, .height = 1 });
         content = .{ .row = content.row + 1, .col = content.col, .width = content.width, .height = content.height -| 1 };
     }
     var list_rect = content;
@@ -166,17 +195,18 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
             f.put(color.selectionAccent());
             f.put(color.Style.reverse.code());
         }
-        var rb: [256]u8 = undefined;
+        var rb: [row_buf_len]u8 = undefined;
         f.putContent(scroll_list.truncate(formatRow(&rb, p), list.width));
         if (selected) f.put(color.Style.reset.code());
     }
 }
 
-fn renderGuard(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
+/// The banner names the latched target, never the live selection — what it
+/// shows is exactly what `y` will uninstall.
+fn renderGuard(name: []const u8, f: *tab.Frame, rect: tab.Rect) void {
     f.moveTo(rect.row, rect.col);
     f.put(color.Style.reverse.code());
-    const name = if (selectedPkg(s)) |p| p.name else "?";
-    var b: [256]u8 = undefined;
+    var b: [row_buf_len]u8 = undefined;
     const line = std.fmt.bufPrint(&b, "Uninstall {s}? [y/N]", .{name}) catch "Uninstall? [y/N]";
     f.putContent(scroll_list.truncate(line, rect.width));
     f.put(color.Style.reset.code());
@@ -281,7 +311,7 @@ test "selectedPkg applies the filter and clamps an out-of-range selection" {
 test "Enter requests the detail effect for the shell to perform" {
     var s: State = .{ .items = &sample };
     step(&s, .enter);
-    try testing.expectEqual(Request.open_detail, s.request);
+    try testing.expect(s.request == .open_detail);
 }
 
 test "Esc closes an open detail pane" {
@@ -293,37 +323,96 @@ test "Esc closes an open detail pane" {
 test "x raises the uninstall guard without spawning anything" {
     var s: State = .{ .items = &sample };
     step(&s, ch('x'));
-    try testing.expect(s.confirm_uninstall);
-    try testing.expectEqual(Request.none, s.request); // no spawn yet
+    try testing.expect(s.confirm_uninstall != null);
+    try testing.expectEqualStrings("brotli", s.confirm_uninstall.?.name()); // latched at arm time
+    try testing.expect(s.request == .none); // no spawn yet
 }
 
-test "y confirms the guard: requests uninstall and lowers the guard" {
+test "y confirms the guard: requests uninstall of the latched name and lowers the guard" {
     var s: State = .{ .items = &sample };
     step(&s, ch('x'));
     step(&s, ch('y'));
-    try testing.expectEqual(Request.uninstall, s.request);
-    try testing.expect(!s.confirm_uninstall);
+    try testing.expect(s.request == .uninstall);
+    try testing.expectEqualStrings("brotli", s.request.uninstall.name());
+    try testing.expect(s.confirm_uninstall == null);
 }
 
 test "n and Esc cancel the guard with no request" {
     var s: State = .{ .items = &sample };
     step(&s, ch('x'));
     step(&s, ch('n'));
-    try testing.expect(!s.confirm_uninstall);
-    try testing.expectEqual(Request.none, s.request);
+    try testing.expect(s.confirm_uninstall == null);
+    try testing.expect(s.request == .none);
 
     step(&s, ch('x'));
     step(&s, .esc);
-    try testing.expect(!s.confirm_uninstall);
-    try testing.expectEqual(Request.none, s.request);
+    try testing.expect(s.confirm_uninstall == null);
+    try testing.expect(s.request == .none);
+}
+
+test "arming latches the target: moving the selection cannot retarget the confirm" {
+    var s: State = .{ .items = &sample };
+    step(&s, ch('x')); // arm on brotli (row 0)
+    s.chrome.view.selected = 2; // the shell moved the selection to ffmpeg
+    step(&s, ch('y'));
+    try testing.expect(s.request == .uninstall);
+    try testing.expectEqualStrings("brotli", s.request.uninstall.name());
+}
+
+test "a list reloaded while the guard is up cannot retarget the latched confirm" {
+    var s: State = .{ .items = &sample };
+    step(&s, ch('x')); // arm on brotli (row 0)
+    // A dirty-tab refetch swaps the rows with no keypress; the latch must hold.
+    const reloaded = [_]Pkg{sample[2]}; // ffmpeg is now row 0
+    s.items = &reloaded;
+    step(&s, ch('y'));
+    try testing.expect(s.request == .uninstall);
+    try testing.expectEqualStrings("brotli", s.request.uninstall.name());
+}
+
+test "uppercase Y confirms the guard like y" {
+    var s: State = .{ .items = &sample };
+    step(&s, ch('x'));
+    step(&s, ch('Y'));
+    try testing.expect(s.request == .uninstall);
+    try testing.expect(s.confirm_uninstall == null);
+}
+
+test "the latch truncates an oversized name instead of overflowing" {
+    const long = "n" ** (row_buf_len + 44);
+    const t = ConfirmTarget.init(long);
+    try testing.expectEqual(@as(usize, row_buf_len), t.name().len);
+    try testing.expectEqualStrings(long[0..row_buf_len], t.name());
+}
+
+test "x on an empty or fully filtered-out list does not arm a targetless guard" {
+    var s: State = .{ .items = &.{} };
+    step(&s, ch('x'));
+    try testing.expect(s.confirm_uninstall == null);
+
+    var t: State = .{ .items = &sample };
+    t.chrome.filter.push("zzznomatch");
+    step(&t, ch('x'));
+    try testing.expect(t.confirm_uninstall == null);
+}
+
+test "the guard banner names the latched package even after the selection moved" {
+    var buf: [4096]u8 = undefined;
+    var f: tab.Frame = .{ .buf = &buf };
+    var s: State = .{ .items = &sample };
+    s.chrome.view.selected = 1; // curl
+    step(&s, ch('x')); // arm on curl
+    s.chrome.view.selected = 2; // selection moved to ffmpeg
+    render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 10 });
+    try testing.expect(std.mem.indexOf(u8, f.slice(), "Uninstall curl? [y/N]") != null);
 }
 
 test "while the guard is up, x's domain keys do not re-arm or leak" {
     var s: State = .{ .items = &sample };
     step(&s, ch('x'));
     step(&s, .enter); // Enter is "default No" — cancels, no detail request
-    try testing.expect(!s.confirm_uninstall);
-    try testing.expectEqual(Request.none, s.request);
+    try testing.expect(s.confirm_uninstall == null);
+    try testing.expect(s.request == .none);
 }
 
 test "render heads the columns in bold, aligned over their values" {
@@ -421,7 +510,7 @@ test "render draws the [y/N] guard banner naming the package when confirming" {
     var f: tab.Frame = .{ .buf = &buf };
     var s: State = .{ .items = &sample };
     s.chrome.view.selected = 1; // curl
-    s.confirm_uninstall = true;
+    step(&s, ch('x')); // arm through the real transition so the target latches
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 10 });
     const out = f.slice();
     try testing.expect(std.mem.indexOf(u8, out, "curl") != null);


### PR DESCRIPTION
## Description

The Installed tab's `[y/N]` uninstall guard read the selection live at confirmation time, so moving the cursor, or a background list reload, between arming and confirming could uninstall a different package than the one the user asked about. Navigation, tab switches, and filter editing all bypassed the armed guard.

The guard now latches its target by copy at arm time: the banner names exactly what `y` will uninstall, the request carries the latched name through to the shell, and the guard is modal — while it is up, any key other than `y` cancels it instead of acting around it (Ctrl-C still quits). Arming on an empty or filtered-out list is refused. 

## Related Issue

- None

## Notes for Reviewers

- Deliberate modal consequence: `q`, `/`, digits, and Tab now cancel an armed guard instead of quitting / editing / switching tabs. Ctrl-C keeps its escape-hatch role.