### PR TITLE
fix(tui): resolve a lone Esc immediately instead of on the next keypress

### DIFF
--- a/scripts/regressions/tui-esc-resolves-immediately-lone-esc-keypress-delayed.sh
+++ b/scripts/regressions/tui-esc-resolves-immediately-lone-esc-keypress-delayed.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Regression: a lone Esc keypress must act immediately. Under a real pty,
+# pressing Esc with a filter being edited must clear it and repaint within
+# the escape-resolution window — not sit buffered until the next keypress
+# resolves it (and then fire both keys in one turn).
+#
+# The bug: a bare Esc arrives as a single 0x1b byte the decoder cannot tell
+# from the start of a CSI sequence, so it buffered the byte and the run loop
+# parked in a blocking read; Decoder.flush(), the designed resolution point,
+# had no caller. Every Esc-driven action (guard cancel, pane close, filter
+# clear) felt dead until another key arrived.
+#
+# Exits 0 when Esc repaints on its own, non-zero when nothing is emitted
+# until the next key. Offline, throwaway prefix, no network.
+
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+# shellcheck source=scripts/lib/tui_pty.sh
+# shellcheck disable=SC1091 # sourced lib resolved at runtime; absent when this file is linted alone
+source "$ROOT/scripts/lib/tui_pty.sh"
+
+tui_pty_guard
+tui_pty_make_prefix
+trap 'rm -rf "$TUI_PREFIX"' EXIT
+
+cap="$TUI_PREFIX/capture.bin"
+seg="$TUI_PREFIX/esc_segment.bin"
+
+# Installed tab, open the filter, type one char, then send Esc ALONE and
+# give it a settle window. Everything the TUI emits between the two marks
+# was provoked by the lone Esc — the follow-up q only quits.
+tui_pty_drive "$cap" 80 24 <<'ACTIONS' >/dev/null
+send 2
+send /
+send a
+mark PRE_ESC
+send \e
+settle 0.8
+mark POST_ESC
+send q
+quitwait 2
+ACTIONS
+
+# The launch-audit spinner may repaint stale frames inside the window, so
+# judge only the LAST full frame (frames start with the \e[2J clear): by the
+# end of the settle window Esc must have produced a cleared-filter repaint.
+perl -0777 -ne 'my ($s) = /\@\@PRE_ESC\@\@(.*)\@\@POST_ESC\@\@/s or exit; my @f = split /\x1b\[2J/, $s; print $f[-1] // ""' "$cap" >"$seg"
+
+if [[ ! -s "$seg" ]]; then
+  echo "REGRESSION: lone Esc emitted nothing — it did not resolve until the next key" >&2
+  exit 1
+fi
+
+if grep -aq 'filter: a' "$seg"; then
+  echo "REGRESSION: the last frame after Esc still shows the un-cleared filter" >&2
+  exit 1
+fi
+
+echo "OK: a lone Esc clears the filter and repaints immediately"

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -1765,28 +1765,61 @@ pub fn run(io: std.Io, allocator: std.mem.Allocator, stderr: std.Io.File, enviro
         if (rc == 0) break; // EOF
         const bytes = rbuf[0..@intCast(rc)];
         var consumed: usize = 0;
+        var partial = false;
         while (consumed < bytes.len) {
             switch (decoder.decode(bytes[consumed..])) {
-                .incomplete => break,
+                .incomplete => {
+                    partial = true;
+                    break;
+                },
                 .key => |k| {
                     consumed += k.consumed;
-                    app = step(app, k.key); // also clears any prior banner
+                    try serviceKey(io, allocator, &t, painter, &fetches, &app, &store, k.key);
                     if (app.quit) break;
-                    paintSearching(fd, &frame, allocator, &app); // status before the blocking search
-                    paintLoading(fd, &frame, allocator, &app); // "Loading…" before a blocking lazy refetch
-                    // A recoverable backend fault becomes the banner the failing
-                    // op already set and the loop continues; only a fatal fault
-                    // (terminal/OOM) propagates to the errdefer restore + exit.
-                    service(io, allocator, &t, painter, &fetches, &app, &store) catch |err| switch (classify(err)) {
-                        .recoverable => {},
-                        .fatal => return err,
-                    };
                 },
             }
+        }
+        // A buffered tail can be a lone Esc, which the blocking read would sit
+        // on until the next keypress. Give the rest of a genuine sequence one
+        // short window to arrive; silence resolves the tail through flush().
+        if (partial and !app.quit and !ttyReadable(fd, esc_resolve_ms)) {
+            if (decoder.flush()) |k| try serviceKey(io, allocator, &t, painter, &fetches, &app, &store, k);
         }
         try repaint(fd, &frame, allocator, &app);
     }
     t.restore();
+}
+
+/// How long a buffered partial escape sequence may wait for its next byte
+/// before the tail resolves as a lone Esc. A genuine CSI arrives in one
+/// write, so this much tty silence means no more bytes are coming.
+const esc_resolve_ms: i32 = 40;
+
+/// True when `fd` has readable bytes within `timeout_ms`. `std.posix.poll`
+/// retries EINTR internally, so a SIGWINCH mid-wait reads as a timeout — the
+/// flush is safe and the resize is consumed on the next loop turn.
+fn ttyReadable(fd: std.posix.fd_t, timeout_ms: i32) bool {
+    var pfd = [_]std.posix.pollfd{.{ .fd = fd, .events = std.posix.POLL.IN, .revents = 0 }};
+    const n = std.posix.poll(&pfd, timeout_ms) catch return false;
+    return n > 0;
+}
+
+/// One decoded key's full turn: pure step, the pre-spawn status paints, then
+/// the requested effects with the recoverable/fatal split. Shared by the
+/// streaming decode path and the timeout-flushed lone Esc so both behave
+/// identically.
+fn serviceKey(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, app: *App, store: *Store, key: Key) RunError!void {
+    app.* = step(app.*, key); // also clears any prior banner
+    if (app.quit) return;
+    paintSearching(painter.fd, painter.frame, allocator, app); // status before the blocking search
+    paintLoading(painter.fd, painter.frame, allocator, app); // "Loading…" before a blocking lazy refetch
+    // A recoverable backend fault becomes the banner the failing op already
+    // set and the loop continues; only a fatal fault (terminal/OOM)
+    // propagates to the errdefer restore + exit.
+    service(io, allocator, t, painter, fetches, app, store) catch |err| switch (classify(err)) {
+        .recoverable => {},
+        .fatal => return err,
+    };
 }
 
 /// Search is the dashboard's first remote read: when the user commits a query,
@@ -1883,6 +1916,16 @@ test "esc in normal mode routes to the active tab so it can cancel its guard" {
     a.states.installed.confirm_uninstall = installed.ConfirmTarget.init("curl");
     a = step(a, .esc); // not editing → must reach the tab, which lowers the guard
     try std.testing.expect(a.states.installed.confirm_uninstall == null);
+}
+
+test "ttyReadable sees a buffered byte and times out on silence" {
+    var fds: [2]std.c.fd_t = undefined;
+    try std.testing.expectEqual(@as(c_int, 0), std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+    try std.testing.expect(!ttyReadable(fds[0], 1)); // silent pipe: the window elapses
+    try std.testing.expectEqual(@as(isize, 1), std.c.write(fds[1], "x", 1));
+    try std.testing.expect(ttyReadable(fds[0], 1)); // a byte is waiting: ready
 }
 
 const guard_pkgs = [_]installed.Pkg{

--- a/src/tui/keys.zig
+++ b/src/tui/keys.zig
@@ -199,6 +199,24 @@ test "recognizeEsc waits for the byte after ESC then resolves" {
     try std.testing.expectEqual(@as(usize, 1), recognize("\x1bx").done.len);
 }
 
+test "flush resolves a buffered lone ESC as .esc and empties the decoder" {
+    var d: Decoder = .{};
+    try std.testing.expect(d.decode("\x1b") == .incomplete);
+    try std.testing.expect(d.flush().? == .esc);
+    try std.testing.expect(d.flush() == null); // tail consumed, decoder empty
+}
+
+test "flush surfaces a partial CSI tail as .unknown, never as a key" {
+    var d: Decoder = .{};
+    try std.testing.expect(d.decode("\x1b[") == .incomplete);
+    try std.testing.expect(d.flush().? == .unknown);
+}
+
+test "flush with nothing buffered is null" {
+    var d: Decoder = .{};
+    try std.testing.expect(d.flush() == null);
+}
+
 test "csiKey maps the supported finals and is unknown otherwise" {
     try std.testing.expect(csiKey("A") == .up);
     try std.testing.expect(csiKey("1~") == .home);


### PR DESCRIPTION
## Description

A bare Esc arrives as a single byte the decoder cannot tell apart from the start of a CSI sequence, and the run loop parked in a blocking read with that byte buffered. Every Esc-driven action - cancelling the uninstall guard, closing a pane, clearing the filter - felt dead until the next keypress, which then fired both keys in one turn.

After a partial sequence, the loop now gives the tty one short window for the rest of the sequence to arrive; silence resolves the buffered tail through the decoder's flush, and the flushed key runs through exactly the same handling as a streamed one. Arrow keys and other CSI sequences arrive in one write and never wait. A pty regression script proves a lone Esc repaints on its own.

## Related Issue

- None

## Notes for Reviewers

- Tradeoff: a localized post-partial poll instead of loosening the terminal's read settings, which would have turned the fully blocking idle loop into a periodic wakeup. The idle path is unchanged.