### PR TITLE
fix(tui): make End jump to the last row in every tab

### DIFF
--- a/scripts/regressions/tui-end-key-inert.sh
+++ b/scripts/regressions/tui-end-key-inert.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Regression: End must jump the cursor to the last visible (filtered) row in
+# every TUI tab. Home works; End must not be a dead affordance.
+#
+# The bug: the shell routes .end to the active tab because only the tab knows
+# its row count, but no tab's step had a .end arm — the key fell into the
+# else => {} of all five tabs.
+#
+# The logic is pure-core, so this leans on the always-rebuilt unit tests plus
+# source-level guards that fail on a pre-fix tree (Zig has no --test-filter,
+# per the repo's established pattern).
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+fail() {
+  echo "REGRESSION: $1" >&2
+  exit 1
+}
+
+# 1. Every tab's step must have a .end arm; else => {} swallowing it is the bug.
+for tab in installed_tab outdated_tab services_tab doctor_tab search_tab; do
+  rg -q '^\s*\.end\s*=>' "src/tui/${tab}.zig" ||
+    fail "${tab}.zig step does not handle .end"
+done
+
+# 2. The shell must still defer .end to the tab (the row count lives there).
+rg -q '\.space, \.end, \.esc => routeToTab' src/tui/app.zig ||
+  fail "app.zig no longer routes .end to the active tab"
+
+# 3. The last-row unit tests must exist and pass.
+rg -qi 'end.*last' src/tui/installed_tab.zig ||
+  fail "End-key last-row test missing from installed_tab.zig"
+zig build test || fail "unit tests failed"
+
+echo "OK: End jumps to the last row in every tab"

--- a/src/tui/doctor_tab.zig
+++ b/src/tui/doctor_tab.zig
@@ -100,6 +100,8 @@ pub fn step(s: *State, key: tab.Key) void {
             const sel = selectedFinding(s) orelse return;
             if (sel.fixable) s.request = .fix;
         },
+        // Only the tab knows its filtered row count, so the shell defers End here.
+        .end => s.chrome.view.selected = filteredCount(s.items, s.chrome.filter.slice()) -| 1,
         else => {},
     }
 }
@@ -724,6 +726,12 @@ test "matches is a case-insensitive substring; empty filter matches all" {
     try testing.expect(matches("SQLite integrity", ""));
     try testing.expect(matches("SQLite integrity", "sqlite"));
     try testing.expect(!matches("Stale lock", "zzz"));
+}
+
+test "End jumps to the last filtered row" {
+    var s: State = .{ .items = &sample };
+    step(&s, .end);
+    try testing.expectEqual(@as(usize, 3), s.chrome.view.selected);
 }
 
 test "selectedFinding orders by severity (err, then warn, then ok) and clamps" {

--- a/src/tui/installed_tab.zig
+++ b/src/tui/installed_tab.zig
@@ -117,6 +117,8 @@ pub fn step(s: *State, key: tab.Key) void {
     switch (key) {
         .enter => s.request = .open_detail,
         .esc => s.detail = null, // close the detail pane
+        // Only the tab knows its filtered row count, so the shell defers End here.
+        .end => s.chrome.view.selected = filteredCount(s.items, s.chrome.filter.slice()) -| 1,
         .char => |c| if (c.len == 1 and c.bytes[0] == 'x') {
             // Fat-finger guard before delegating uninstall. Latch the target at
             // arm time; an empty or filtered-out list has nothing to guard.
@@ -306,6 +308,20 @@ test "selectedPkg applies the filter and clamps an out-of-range selection" {
     s.chrome.filter.clear();
     s.chrome.filter.push("zzz");
     try testing.expect(selectedPkg(&s) == null);
+}
+
+test "End jumps to the last filtered row; an empty list stays at zero" {
+    var s: State = .{ .items = &sample };
+    step(&s, .end);
+    try testing.expectEqual(@as(usize, 3), s.chrome.view.selected);
+
+    s.chrome.filter.push("f"); // ffmpeg, flux
+    step(&s, .end);
+    try testing.expectEqual(@as(usize, 1), s.chrome.view.selected);
+
+    var e: State = .{ .items = &.{} };
+    step(&e, .end);
+    try testing.expectEqual(@as(usize, 0), e.chrome.view.selected);
 }
 
 test "Enter requests the detail effect for the shell to perform" {

--- a/src/tui/outdated_tab.zig
+++ b/src/tui/outdated_tab.zig
@@ -104,6 +104,8 @@ pub fn step(s: *State, key: tab.Key) void {
     switch (key) {
         .space => toggleSelected(s),
         .enter => requestUpgrade(s),
+        // Only the tab knows its filtered row count, so the shell defers End here.
+        .end => s.chrome.view.selected = filteredCount(s.items, s.chrome.filter.slice()) -| 1,
         .char => |c| if (c.len == 1) switch (c.bytes[0]) {
             'u' => requestUpgrade(s),
             'a' => setAll(s, true),
@@ -234,6 +236,16 @@ const sample = [_]Row{
     .{ .name = "firefox", .installed = "120.0", .latest = "121.0", .kind = .cask, .pinned = false, .tap = "user/repo" },
     .{ .name = "ffmpeg", .installed = "8.0", .latest = "8.1", .kind = .formula, .pinned = false, .tap = "" },
 };
+
+test "End jumps to the last filtered row" {
+    var s: State = .{ .items = &sample };
+    step(&s, .end);
+    try testing.expectEqual(@as(usize, 3), s.chrome.view.selected);
+
+    s.chrome.filter.push("f"); // firefox, ffmpeg
+    step(&s, .end);
+    try testing.expectEqual(@as(usize, 1), s.chrome.view.selected);
+}
 
 test "matches is a case-insensitive substring; empty filter matches all" {
     try testing.expect(matches("firefox", ""));

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -177,6 +177,11 @@ pub fn step(s: *State, key: tab.Key) void {
             else => {},
         },
         .esc => s.detail = null, // close the info pane
+        // No narrowing filter here; the cursor indexes the active view's list.
+        .end => s.chrome.view.selected = (switch (s.view) {
+            .results => s.items.len,
+            .basket => s.basket.len,
+        }) -| 1,
         else => {},
     }
 }
@@ -590,6 +595,20 @@ const basket_sample = [_]SelEntry{
     .{ .name = "bat", .kind = .formula },
     .{ .name = "firefox", .kind = .cask },
 };
+
+test "End jumps to the last row of the active view: results or basket" {
+    var s: State = .{ .items = &sample, .phase = .loaded, .basket = &basket_sample };
+    step(&s, .end);
+    try testing.expectEqual(@as(usize, 2), s.chrome.view.selected); // 3 hits
+
+    s.view = .basket;
+    step(&s, .end);
+    try testing.expectEqual(@as(usize, 1), s.chrome.view.selected); // 2 picks
+
+    var e: State = .{ .phase = .loaded }; // empty results: no underflow
+    step(&e, .end);
+    try testing.expectEqual(@as(usize, 0), e.chrome.view.selected);
+}
 
 test "the basket view lists every pick, including ones off the current results" {
     var buf: [4096]u8 = undefined;

--- a/src/tui/services_tab.zig
+++ b/src/tui/services_tab.zig
@@ -83,6 +83,8 @@ pub fn step(s: *State, key: tab.Key) void {
     switch (key) {
         .enter => s.detail = selectedService(s),
         .esc => s.detail = null,
+        // Only the tab knows its filtered row count, so the shell defers End here.
+        .end => s.chrome.view.selected = filteredCount(s.items, s.chrome.filter.slice()) -| 1,
         .char => |c| if (c.len == 1) switch (c.bytes[0]) {
             's' => s.request = .start,
             'x', 'X' => s.request = .stop,
@@ -245,6 +247,12 @@ test "footerHint advertises the details affordance alongside the lifecycle keys"
     const h = footerHint();
     try testing.expect(std.mem.indexOf(u8, h, "enter: details") != null);
     try testing.expect(std.mem.indexOf(u8, h, "s: start") != null);
+}
+
+test "End jumps to the last filtered row" {
+    var s: State = .{ .items = &sample };
+    step(&s, .end);
+    try testing.expectEqual(@as(usize, 3), s.chrome.view.selected);
 }
 
 test "matches is a case-insensitive substring; empty filter matches all" {


### PR DESCRIPTION
## Description

End was a dead affordance across the dashboard: the shell defers it to the active tab because only the tab knows its filtered row count, but no tab handled it - Home worked, End did nothing. Each tab's step now maps End to its last visible row: the filterable tabs through their filtered count, Search through whichever view is active (results or basket). Home and End are now symmetric everywhere, including on an empty list (no underflow).

## Related Issue

- None

## Notes for Reviewers

- While the uninstall guard is up, End cancels it like every other non-confirm key - that is the guard's modal contract, not a gap.