### PR TITLE
fix(install): run declarative post-install steps across install, upgrade, and migrate

### DIFF
--- a/man/malt.1
+++ b/man/malt.1
@@ -171,6 +171,10 @@ Flags:
                  out of <prefix>/bin and <prefix>/sbin. Existing kegs
                  replay whatever they were already recorded with.
                  `--isolate-dependencies` accepted as an alias.
+  --use-system-ruby=<name>,...  Run post_install via the system Ruby
+                 interpreter (experimental, sandboxed) for the named
+                 kegs only. A bare `--use-system-ruby` is refused —
+                 it would widen the trust boundary to every outdated keg.
 .fi
 .SS update
 .nf

--- a/scripts/gen-pins.sh
+++ b/scripts/gen-pins.sh
@@ -157,6 +157,12 @@ FALLBACK_FORMULAS=(
 # post_install_defined flag is true from formulae.brew.sh — an exhaustive
 # allowlist is what the fail-closed gate actually needs. Fall back to the
 # static seed only when the API is unreachable.
+#
+# Formulas migrated to the declarative `post_install_steps` array report
+# post_install_defined=false and are handled natively from the formula
+# JSON — they need no pinned .rb source, so the manifest legitimately
+# shrinks as upstream migrates. Their count is reported below so a
+# shrinking diff is explainable at a glance.
 if [ -n "${FORMULAS:-}" ]; then
   # shellcheck disable=SC2206
   read -r -a FORMULAS_ARR <<<"$FORMULAS"
@@ -181,6 +187,12 @@ for f in data:
 ' | LC_ALL=C sort -u
     )
     printf '▸ %d formulas have post_install_defined\n' "${#FORMULAS_ARR[@]}" >&2
+    STEPS_COUNT=$(printf '%s' "$api_json" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+print(sum(1 for f in data if f.get("post_install_steps")))
+')
+    printf '▸ %s formulas carry declarative post_install_steps (handled natively; not pinned)\n' "$STEPS_COUNT" >&2
   else
     printf '  ⚠ API fetch failed — falling back to static seed\n' >&2
     FORMULAS_ARR=("${FALLBACK_FORMULAS[@]}")

--- a/scripts/regressions/silent-skip-post-install-steps.sh
+++ b/scripts/regressions/silent-skip-post-install-steps.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Regression: a formula migrated to the declarative `post_install_steps`
+# framework must not be silently skipped at install/migrate time.
+#
+# The bug: migrated formulas report `post_install_defined: false` and carry
+# their hook in a new `post_install_steps` JSON array. parseFormula read only
+# the boolean, so the install gate never attempted post-install at all — no
+# steps, no warning, no JSON event. The tap/migrate arm was blind the same
+# way: body extraction only matches `def post_install`, so a steps-only .rb
+# returned null and the hook was dropped without a word. User-visible result:
+# broken kegs (gdk-pixbuf loaders.cache never regenerated, gsettings schemas
+# never compiled) with nothing in the output to explain why.
+#
+# The fix parses the steps array (non-empty only — the key is present but
+# empty on formulas still using `def post_install`), routes steps-migrated
+# formulas into the existing loud-skip machinery on the bottle arm, detects
+# `post_install_steps do` blocks on the tap arm so migrate warns instead of
+# returning silently, and stops doctor undercounting migrated formulas.
+#
+# No CLI surface drives parseFormula or the tap extraction offline without
+# standing up a live tap, so the behaviour is pinned by colocated inline unit
+# tests (`lib_tests`). This script asserts the load-bearing code and its tests
+# are present, then builds and runs that binary: well under 30s, no network.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+# If any layer of the fix is dropped, lib_tests could go green vacuously.
+# Fail loudly instead: parse layer, both gates, and tap-arm detection must
+# all be present in the source.
+if ! grep -Fqs -- "parseFormula flags a formula migrated to post_install_steps" src/core/formula.zig; then
+  echo "FAIL: formula.zig no longer tests the post_install_steps parse — migrated formulas silently skip post-install" >&2
+  exit 1
+fi
+if ! grep -Fqs -- "has_post_install_steps" src/core/formula.zig; then
+  echo "FAIL: parseFormula dropped the post_install_steps field — migrated formulas parse as 'no post_install'" >&2
+  exit 1
+fi
+if ! grep -Fqs -- "job.wants_post_install" src/cli/install.zig; then
+  echo "FAIL: the install gate no longer honours steps-migrated formulas" >&2
+  exit 1
+fi
+if ! grep -Fqs -- "hasPostInstallHook" src/cli/migrate/keg.zig; then
+  echo "FAIL: the migrate bottle arm gate is blind to steps-migrated formulas again" >&2
+  exit 1
+fi
+if ! grep -Fqs -- "rbHasPostInstallSteps" src/cli/migrate/keg.zig; then
+  echo "FAIL: the migrate tap arm silently drops steps-only formulas again" >&2
+  exit 1
+fi
+if ! grep -Fqs -- "hasPostInstallStepsBlock detects a declarative steps block" src/core/ruby/source.zig; then
+  echo "FAIL: the steps-block detection test is missing from source.zig" >&2
+  exit 1
+fi
+if ! grep -Fqs -- "driveSteps" src/cli/install/post_install.zig; then
+  echo "FAIL: the native steps dispatch is gone from the post-install driver" >&2
+  exit 1
+fi
+if [ ! -f src/core/post_install_steps.zig ]; then
+  echo "FAIL: the declarative steps executor module is missing" >&2
+  exit 1
+fi
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+# Always rebuild so the binary reflects current source; Zig's cache makes a
+# no-op rebuild cheap, so this stays well under the time budget.
+if ! zig build test-bin >/dev/null 2>&1; then
+  echo "FAIL: could not build the unit test binary (zig build test-bin)" >&2
+  exit 1
+fi
+
+OUT=$("$BIN" 2>&1) && STATUS=0 || STATUS=$?
+if [[ "$STATUS" -ne 0 ]]; then
+  echo "FAIL: steps-migrated formulas are silently skipped at post-install" >&2
+  printf '%s\n' "$OUT" | grep -iE "failed|leaked|panic" >&2 || true
+  exit 1
+fi
+
+echo "PASS: steps-migrated formulas are flagged at parse time and routed loudly"

--- a/scripts/regressions/upgrade-skips-post-install.sh
+++ b/scripts/regressions/upgrade-skips-post-install.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Regression: `mt upgrade` must run the formula's post-install phase for
+# the freshly swapped keg.
+#
+# The bug: upgradeFormula materialised the new keg, swapped the DB rows,
+# relinked, and finished — post-install never ran, for any hook form
+# (`def post_install` Ruby or declarative `post_install_steps`). Effects
+# that upstream regenerates on every install/upgrade (loader caches,
+# compiled schema stores, service dirs) silently went stale or missing
+# until the user happened to reinstall.
+#
+# The fix drives the shared post-install router after the swap, exactly
+# like `mt install`: steps and DSL bodies run natively, the system-Ruby
+# fallback stays a scoped opt-in via the new `--use-system-ruby=<name>`
+# upgrade flag.
+#
+# This script seeds a real install of a steps-migrated, dependency-free
+# formula, rewrites its DB row to an older version, deletes the step's
+# artifact, and asserts the upgrade both routes post-install loudly and
+# recreates the artifact. Needs network for the seeding install (same
+# contract as the other upgrade regressions).
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+PREFIX="/tmp/mt_upg_pi"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+# daemontools: zero deps, one declarative step (mkdir_p etc/service).
+SEED="daemontools"
+DB="$PREFIX/db/malt.db"
+
+printf '\xe2\x96\xb8 seeding prefix with mt install %s\n' "$SEED"
+"$BIN" install "$SEED" >"$PREFIX/install.log" 2>&1 ||
+  fail "seed install of $SEED failed — see $PREFIX/install.log"
+[[ -d "$PREFIX/etc/service" ]] ||
+  fail "install did not run the mkdir_p step — is the steps executor broken?"
+pass "$SEED installed with its post-install artifact"
+
+# Rewind the keg row to a fake older version and move the cellar dir to
+# match, so the upgrade path sees a genuine version bump. Drop the step's
+# artifact to prove the upgrade recreates it.
+NEW_DIR=$(basename "$(find "$PREFIX/Cellar/$SEED" -mindepth 1 -maxdepth 1 -type d | head -1)")
+mv "$PREFIX/Cellar/$SEED/$NEW_DIR" "$PREFIX/Cellar/$SEED/0.70"
+sqlite3 "$DB" "UPDATE kegs SET version='0.70', revision=0, store_sha256='',
+  cellar_path='$PREFIX/Cellar/$SEED/0.70' WHERE name='$SEED';" ||
+  fail "could not rewind the keg row"
+rm -rf "$PREFIX/etc/service"
+pass "keg rewound to 0.70 and post-install artifact removed"
+
+OUT=$("$BIN" upgrade "$SEED" 2>&1) || {
+  printf '%s\n' "$OUT" >&2
+  fail "upgrade failed"
+}
+printf '%s\n' "$OUT" | grep -q "post_install" ||
+  fail "upgrade swapped the keg without any post_install routing output"
+[[ -d "$PREFIX/etc/service" ]] ||
+  fail "post-install artifact missing after upgrade — the step never ran"
+pass "upgrade ran post-install and recreated the artifact"
+
+echo "PASS: upgrade drives post-install for the swapped keg"

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -150,13 +150,13 @@ pub const bash_script =
     \\
     \\    local cmd_flags=""
     \\    case "$cmd" in
-    \\        install)          cmd_flags="--cask --formula --local --dry-run --force --download-only --only-deps --only-dependencies --isolate-deps --isolate-dependencies --quiet -q --json" ;;
+    \\        install)          cmd_flags="--cask --formula --local --dry-run --force --download-only --only-deps --only-dependencies --isolate-deps --isolate-dependencies --use-system-ruby= --quiet -q --json" ;;
     \\        reinstall)        cmd_flags="--cask --dry-run --isolate-deps --isolate-dependencies --quiet -q --json" ;;
     \\        backup)           cmd_flags="--output -o --versions --services --quiet -q" ;;
     \\        restore)          cmd_flags="--dry-run --force --quiet -q" ;;
     \\        purge)            cmd_flags="--store-orphans --unused-deps --cache --cache= --downloads --stale-casks --old-versions --housekeeping --wipe --backup -b --keep-cache --remove-binary --yes -y --dry-run -n" ;;
     \\        uninstall|remove) cmd_flags="--force --zap --dry-run" ;;
-    \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --pinned --force -f --isolate-deps --isolate-dependencies" ;;
+    \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --pinned --force -f --isolate-deps --isolate-dependencies --use-system-ruby=" ;;
     \\        outdated)         cmd_flags="--json --formula --cask --pinned-only --tap --refresh --quiet -q" ;;
     \\        update)           cmd_flags="--check --quiet -q" ;;
     \\        version)          cmd_flags="--check --yes -y --no-verify --cleanup" ;;
@@ -166,7 +166,7 @@ pub const bash_script =
     \\        uses)             cmd_flags="--recursive -r --json --quiet -q" ;;
     \\        deps)             cmd_flags="--recursive -r --installed --json --quiet -q" ;;
     \\        which)            cmd_flags="--json" ;;
-    \\        migrate)          cmd_flags="--dry-run" ;;
+    \\        migrate)          cmd_flags="--dry-run --use-system-ruby=" ;;
     \\        rollback)         cmd_flags="--dry-run --list --to --json" ;;
     \\        link)             cmd_flags="--overwrite --force -f --isolate --all" ;;
     \\        services)         cmd_flags="--tail --stderr --follow -f --system --json" ;;
@@ -277,6 +277,7 @@ pub const zsh_script =
     \\                        '--only-dependencies[Brew-parity alias of --only-deps]' \
     \\                        '--isolate-deps[Keep transitive deps out of <prefix>/bin and <prefix>/sbin]' \
     \\                        '--isolate-dependencies[Alias of --isolate-deps]' \
+    \\                        '--use-system-ruby=[Run post_install via system Ruby for the named kegs]:names:' \
     \\                        '(--quiet -q)'{--quiet,-q}'[Suppress non-error output]' \
     \\                        '--json[Output result as JSON]' \
     \\                        '*::package:'
@@ -308,6 +309,7 @@ pub const zsh_script =
     \\                        '(--force -f)'{--force,-f}'[Bypass pin protection]' \
     \\                        '--isolate-deps[Apply isolation to deps newly pulled in by this upgrade]' \
     \\                        '--isolate-dependencies[Alias of --isolate-deps]' \
+    \\                        '--use-system-ruby=[Run post_install via system Ruby for the named kegs]:names:' \
     \\                        '*::package:'
     \\                    ;;
     \\                pin|unpin)
@@ -369,7 +371,9 @@ pub const zsh_script =
     \\                        '*::query:'
     \\                    ;;
     \\                migrate)
-    \\                    _arguments '--dry-run[Preview without executing]'
+    \\                    _arguments \\
+    \\                        '--dry-run[Preview without executing]' \\
+    \\                        '--use-system-ruby=[Run post_install via system Ruby for the named kegs]:names:'
     \\                    ;;
     \\                rollback)
     \\                    _arguments \
@@ -587,6 +591,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l only-dependencies -d 'Brew-parity alias of --only-deps'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l isolate-deps         -d 'Keep transitive deps out of <prefix>/bin and <prefix>/sbin'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l isolate-dependencies -d 'Alias of --isolate-deps'
+    \\    complete -c $__malt_bin -n '__malt_using_command install' -l use-system-ruby -d 'Run post_install via system Ruby for the named kegs'
     \\    complete -c $__malt_bin -n '__malt_using_command install' -l json    -d 'JSON output'
     \\
     \\    # reinstall
@@ -613,6 +618,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -s f -l force -d 'Bypass pin protection'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l isolate-deps         -d 'Apply isolation to deps newly pulled in by this upgrade'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l isolate-dependencies -d 'Alias of --isolate-deps'
+    \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l use-system-ruby -d 'Run post_install via system Ruby for the named kegs'
     \\
     \\    # outdated
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l json        -d 'JSON output'
@@ -674,6 +680,7 @@ pub const fish_script =
     \\
     \\    # migrate / rollback
     \\    complete -c $__malt_bin -n '__malt_using_command migrate'    -l dry-run -d 'Preview'
+    \\    complete -c $__malt_bin -n '__malt_using_command migrate'    -l use-system-ruby -d 'Run post_install via system Ruby for the named kegs'
     \\    complete -c $__malt_bin -n '__malt_using_command rollback'   -l dry-run -d 'Preview'
     \\    complete -c $__malt_bin -n '__malt_using_command rollback'   -l list    -d 'List every reachable store entry'
     \\    complete -c $__malt_bin -n '__malt_using_command rollback'   -l to    -x -d 'Roll back to a specific store entry (pass <version>)'

--- a/src/cli/doctor/post_install.zig
+++ b/src/cli/doctor/post_install.zig
@@ -61,7 +61,7 @@ pub fn checkPostInstallStatus(ctx: *const AppCtx, allocator: std.mem.Allocator, 
         };
         defer formula.deinit();
 
-        if (!formula.post_install_defined) {
+        if (!formula.hasPostInstallHook()) {
             no_pi_count += 1;
             continue;
         }

--- a/src/cli/doctor/post_install.zig
+++ b/src/cli/doctor/post_install.zig
@@ -11,6 +11,7 @@ const output = @import("../../ui/output.zig");
 const ruby_sub = @import("../../core/ruby_subprocess.zig");
 const dsl = @import("../../core/dsl/root.zig");
 const formula_mod = @import("../../core/formula.zig");
+const steps_mod = @import("../../core/post_install_steps.zig");
 const api_mod = @import("../../net/api.zig");
 const client_mod = @import("../../net/client.zig");
 
@@ -63,6 +64,19 @@ pub fn checkPostInstallStatus(ctx: *const AppCtx, allocator: std.mem.Allocator, 
 
         if (!formula.hasPostInstallHook()) {
             no_pi_count += 1;
+            continue;
+        }
+
+        // Steps-migrated formulas have no Ruby body; classify them by the
+        // native executor's step-type coverage instead.
+        if (formula.has_post_install_steps) {
+            if (steps_mod.allStepsSupported(allocator, formula_json)) {
+                native_count += 1;
+                output.success("  {s}: declarative steps (native)", .{name});
+            } else {
+                partial_count += 1;
+                output.warn("  {s}: declarative steps (some types unsupported)", .{name});
+            }
             continue;
         }
 

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -160,6 +160,10 @@ const upgrade_help =
     \\                 out of <prefix>/bin and <prefix>/sbin. Existing kegs
     \\                 replay whatever they were already recorded with.
     \\                 `--isolate-dependencies` accepted as an alias.
+    \\  --use-system-ruby=<name>,...  Run post_install via the system Ruby
+    \\                 interpreter (experimental, sandboxed) for the named
+    \\                 kegs only. A bare `--use-system-ruby` is refused —
+    \\                 it would widen the trust boundary to every outdated keg.
     \\
 ;
 

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1141,7 +1141,7 @@ fn executeWithOpts(
             pruneOtherCellarVersionsForReinstall(ctx, allocator, prefix, job.name, job.version_str);
         }
 
-        if (job.post_install_defined) {
+        if (job.wants_post_install) {
             drive(ctx, allocator, job.name, job.version_str, job.formula_json, prefix, use_system_ruby_list, &formula_cache, sink);
         }
 

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -56,7 +56,9 @@ pub const DownloadJob = struct {
     bottle_url: []const u8,
     is_dep: bool,
     keg_only: bool,
-    post_install_defined: bool,
+    /// Collapses `post_install_defined` and the declarative steps array:
+    /// either one must open the post-install gate.
+    wants_post_install: bool,
     formula_json: []const u8,
     /// Cellar type from bottle metadata (e.g. ":any", ":any_skip_relocation").
     /// Used to skip Mach-O patching for relocatable bottles.
@@ -390,7 +392,7 @@ pub fn collectFormulaJobs(
             .bottle_url = strs.bottle_url,
             .is_dep = true,
             .keg_only = dep_formula.keg_only,
-            .post_install_defined = dep_formula.post_install_defined,
+            .wants_post_install = dep_formula.hasPostInstallHook(),
             .formula_json = dep_json,
             .cellar_type = strs.cellar_type,
             .label_width = 0,
@@ -424,7 +426,7 @@ pub fn collectFormulaJobs(
         .bottle_url = main_strs.bottle_url,
         .is_dep = false,
         .keg_only = formula.keg_only,
-        .post_install_defined = formula.post_install_defined,
+        .wants_post_install = formula.hasPostInstallHook(),
         .formula_json = formula_json,
         .cellar_type = main_strs.cellar_type,
         .label_width = 0,
@@ -835,7 +837,7 @@ fn testJob(succeeded: bool) DownloadJob {
         .bottle_url = "",
         .is_dep = false,
         .keg_only = false,
-        .post_install_defined = false,
+        .wants_post_install = false,
         .formula_json = "",
         .cellar_type = "",
         .label_width = 0,

--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -29,6 +29,13 @@ pub fn extractRbPostInstallBody(io: std.Io, allocator: std.mem.Allocator, rb_pat
     return ruby_sub.extractPostInstallBody(io, allocator, rb_path);
 }
 
+/// Steps-migrated tap formulas carry a declarative `post_install_steps`
+/// block instead of `def post_install`; detect it so migrate can warn
+/// instead of silently dropping the hook.
+pub fn rbHasPostInstallSteps(io: std.Io, allocator: std.mem.Allocator, rb_path: []const u8) bool {
+    return ruby_sub.rbHasPostInstallSteps(io, allocator, rb_path);
+}
+
 /// Whether --use-system-ruby opts the named formula into the Ruby
 /// post_install path. Caller carries the parsed scope from the flag.
 pub fn useSystemRubyForFormula(scope: []const []const u8, formula_name: []const u8) bool {

--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -515,6 +515,7 @@ pub fn driveSteps(
         .keg_path = keg_path,
         .flog = &flog,
         .suppress_child_stdout = output.isJson() or output.isNdjson(),
+        .environ = ctx.environ,
     }, formula_json);
 
     routePostInstallOutcome(ctx, allocator, name, version_str, prefix, &flog, use_system_ruby_list, sink);

--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -11,6 +11,7 @@ const deps_mod = @import("../../core/deps.zig");
 const dsl = @import("../../core/dsl/root.zig");
 const formula_mod = @import("../../core/formula.zig");
 const ruby_sub = @import("../../core/ruby_subprocess.zig");
+const steps_mod = @import("../../core/post_install_steps.zig");
 const sandbox = @import("../../core/sandbox/macos.zig");
 const output = @import("../../ui/output.zig");
 const download = @import("download.zig");
@@ -431,6 +432,11 @@ pub fn drive(
     cache: ?*deps_mod.FormulaCache,
     sink: OutputSink,
 ) void {
+    // Steps-migrated formulas have no Ruby body to extract — the JSON steps
+    // are authoritative and already in hand, so this path goes first.
+    if (driveSteps(ctx, allocator, name, version_str, formula_json, prefix, use_system_ruby_list, cache, sink))
+        return;
+
     if (locateDslSource(ctx, allocator, name)) |src| {
         defer allocator.free(src);
         switch (executeDslPostInstall(
@@ -461,6 +467,58 @@ pub fn drive(
     } else {
         sink.warn("{s}: post_install skipped (use --use-system-ruby={s} or brew install {s})", .{ name, name, name });
     }
+}
+
+/// Native dispatch for formulas migrated to the declarative
+/// `post_install_steps` array. Returns true when the steps path owned the
+/// formula — executed (or loudly downgraded) and routed through the same
+/// outcome envelope as the DSL path. False means "no steps": the caller's
+/// Ruby-body pipeline still owns the formula.
+pub fn driveSteps(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    version_str: []const u8,
+    formula_json: []const u8,
+    prefix: []const u8,
+    use_system_ruby_list: []const []const u8,
+    cache: ?*deps_mod.FormulaCache,
+    sink: OutputSink,
+) bool {
+    var owned: ?formula_mod.Formula = null;
+    defer if (owned) |*f| f.deinit();
+
+    const has_steps: bool, const dsl_version: []const u8, const pkg_version: []const u8 = blk: {
+        if (cache) |c| {
+            const f = c.getOrParse(name, formula_json) catch return false;
+            break :blk .{ f.has_post_install_steps, f.version, f.pkg_version };
+        }
+        owned = formula_mod.parseFormula(allocator, formula_json) catch return false;
+        break :blk .{ owned.?.has_post_install_steps, owned.?.version, owned.?.pkg_version };
+    };
+    if (!has_steps) return false;
+
+    // Arena owns every resolved path and log detail until routing is done;
+    // the flog itself lives on the caller allocator like the DSL path.
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    var flog = dsl.FallbackLog.init(allocator);
+    defer flog.deinit();
+
+    const keg_path = std.fmt.allocPrint(arena.allocator(), "{s}/Cellar/{s}/{s}", .{ prefix, name, pkg_version }) catch return false;
+    _ = steps_mod.execute(.{
+        .io = ctx.io,
+        .allocator = arena.allocator(),
+        .name = name,
+        .version = dsl_version,
+        .prefix = prefix,
+        .keg_path = keg_path,
+        .flog = &flog,
+        .suppress_child_stdout = output.isJson() or output.isNdjson(),
+    }, formula_json);
+
+    routePostInstallOutcome(ctx, allocator, name, version_str, prefix, &flog, use_system_ruby_list, sink);
+    return true;
 }
 
 /// Tap-fallback analog of `drive`: the post_install body has already

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -385,7 +385,7 @@ fn runTapPostInstallIfDefined(
     defer allocator.free(rb_path);
     const body = post_install_mod.extractRbPostInstallBody(ctx.io, allocator, rb_path) orelse {
         if (post_install_mod.rbHasPostInstallSteps(ctx.io, allocator, rb_path))
-            output.warn("    {s}: post_install skipped (declarative post_install_steps not supported yet; run brew postinstall {s})", .{ name, name });
+            output.warn("    {s}: post_install skipped (declarative steps need formula JSON, unavailable for tap kegs; run brew postinstall {s})", .{ name, name });
         return;
     };
     defer allocator.free(body);

--- a/src/cli/migrate/keg.zig
+++ b/src/cli/migrate/keg.zig
@@ -212,7 +212,7 @@ pub fn migrateKeg(
         recordDeps(deps.db, keg_id, &formula);
     }
 
-    if (formula.post_install_defined) {
+    if (formula.hasPostInstallHook()) {
         if (deps.post_install_queue) |q| {
             // Queue dupes the strings so the worker's per-iteration
             // arena is free to die before drain runs.
@@ -369,8 +369,9 @@ fn migrateFromLocalCellar(
 
 /// Resolve the tap's post_install body and either queue it (so it
 /// runs after every keg's `opt/<name>/` symlink is in place) or drive
-/// it inline on the legacy single-keg path. Silent when no body is
-/// found — the formula simply has no hook.
+/// it inline on the legacy single-keg path. Silent when the formula
+/// has no hook at all; a declarative `post_install_steps` block has no
+/// extractable body, so it warns instead of silently dropping the hook.
 fn runTapPostInstallIfDefined(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
@@ -382,7 +383,11 @@ fn runTapPostInstallIfDefined(
 ) void {
     const rb_path = findTapFormulaRb(ctx.io, allocator, deps.homebrew_prefix, tap, name, receipt_source_path) orelse return;
     defer allocator.free(rb_path);
-    const body = post_install_mod.extractRbPostInstallBody(ctx.io, allocator, rb_path) orelse return;
+    const body = post_install_mod.extractRbPostInstallBody(ctx.io, allocator, rb_path) orelse {
+        if (post_install_mod.rbHasPostInstallSteps(ctx.io, allocator, rb_path))
+            output.warn("    {s}: post_install skipped (declarative post_install_steps not supported yet; run brew postinstall {s})", .{ name, name });
+        return;
+    };
     defer allocator.free(body);
 
     if (deps.post_install_queue) |q| {

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -30,10 +30,11 @@ const install_rb_parse_mod = @import("install/rb_parse.zig");
 const install_record_mod = @import("install/record.zig");
 const InstallError = install_record_mod.InstallError;
 const install_sink_mod = @import("install/sink.zig");
+const post_install_mod = @import("install/post_install.zig");
 const install_mod = @import("install.zig");
 const pin_mod = @import("pin.zig");
 
-const UpgradeFlag = enum { quiet, cask, formula, dry_run, force, pinned, isolate_deps };
+const UpgradeFlag = enum { quiet, cask, formula, dry_run, force, pinned, isolate_deps, use_system_ruby };
 
 const upgrade_flag_map = std.StaticStringMap(UpgradeFlag).initComptime(.{
     .{ "-q", .quiet },
@@ -48,6 +49,9 @@ const upgrade_flag_map = std.StaticStringMap(UpgradeFlag).initComptime(.{
     // Long-form alias matching the `--only-dependencies` / `--only-deps`
     // shape so the flag surface stays predictable.
     .{ "--isolate-dependencies", .isolate_deps },
+    // Recognised only to refuse it with a pointed message: a bare flag
+    // would widen the Ruby trust boundary to every outdated keg.
+    .{ "--use-system-ruby", .use_system_ruby },
 });
 
 /// True when this name should be skipped due to a user pin. Pure gate so
@@ -116,10 +120,21 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // `args` (process-lifetime), so no dup is needed.
     var names: std.ArrayList([]const u8) = .empty;
     defer names.deinit(allocator);
+    // Scoped opt-in for the post-install Ruby fallback, same contract as
+    // `migrate`: named kegs only, never a blanket flag.
+    var use_system_ruby_bare = false;
+    var use_system_ruby_scope: std.ArrayList([]const u8) = .empty;
+    defer use_system_ruby_scope.deinit(allocator);
 
     // StaticStringMap + exhaustive switch: every flag routes to a handler.
     for (args) |arg| {
-        if (upgrade_flag_map.get(arg)) |flag| switch (flag) {
+        if (std.mem.startsWith(u8, arg, "--use-system-ruby=")) {
+            const list = arg["--use-system-ruby=".len..];
+            var it = std.mem.splitScalar(u8, list, ',');
+            while (it.next()) |n| {
+                if (n.len > 0) use_system_ruby_scope.append(allocator, n) catch return error.OutOfMemory;
+            }
+        } else if (upgrade_flag_map.get(arg)) |flag| switch (flag) {
             .quiet => output.setQuiet(true),
             .cask => cask_only = true,
             .formula => formula_only = true,
@@ -127,9 +142,15 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             .force => force = true,
             .pinned => pinned_only = true,
             .isolate_deps => isolate_deps = true,
+            .use_system_ruby => use_system_ruby_bare = true,
         } else if (arg.len > 0 and arg[0] != '-') {
             names.append(allocator, arg) catch return error.OutOfMemory;
         }
+    }
+
+    if (use_system_ruby_bare) {
+        output.err("a bare --use-system-ruby would apply to every outdated keg — name them: --use-system-ruby=<name>,...", .{});
+        return error.Aborted;
     }
 
     if (pinned_only) {
@@ -198,7 +219,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         // suppressed in favour of one summary footer printed below.
         var tally: Tally = .{};
         if (!cask_only) {
-            upgradeAllFormulas(ctx, allocator, &db, &api, &http, prefix, dry_run, force, pinned_only, isolate_deps, &tally) catch {
+            upgradeAllFormulas(ctx, allocator, &db, &api, &http, prefix, dry_run, force, pinned_only, isolate_deps, use_system_ruby_scope.items, &tally) catch {
                 any_failed = true;
             };
         }
@@ -215,7 +236,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         // tally keeps each named package's per-package line and no footer.
         for (names.items) |name| {
             if (!cask_only and isFormulaInstalled(&db, name)) {
-                upgradeFormula(ctx, allocator, name, &db, &api, &http, prefix, dry_run, force, pinned_only, isolate_deps, null) catch {
+                upgradeFormula(ctx, allocator, name, &db, &api, &http, prefix, dry_run, force, pinned_only, isolate_deps, use_system_ruby_scope.items, null) catch {
                     any_failed = true;
                     other_failed = true;
                 };
@@ -316,6 +337,7 @@ fn upgradeFormula(
     force: bool,
     audit_mode: bool,
     isolate_deps: bool,
+    use_system_ruby: []const []const u8,
     tally: ?*Tally,
 ) !void {
     // Honor pins before any network or filesystem work — the whole
@@ -531,6 +553,14 @@ fn upgradeFormula(
         // refcount is advisory; upgrade is already complete on disk.
         store.decrementRef(old.sha256) catch {};
     }
+
+    // Same post-install contract as `mt install`: the fresh keg's hook
+    // (declarative steps or Ruby body) runs against the new version, and
+    // the shipped CA bundle is re-linked for kegs that carry one.
+    if (formula.hasPostInstallHook()) {
+        post_install_mod.drive(ctx, allocator, name, formula.pkg_version, formula_json, prefix, use_system_ruby, null, install_sink_mod.terminal);
+    }
+    post_install_mod.provisionShippedCaBundle(ctx.io, prefix, name);
 
     output.success("{s} upgraded to {s}", .{ name, formula.pkg_version });
     if (tally) |t| t.upgraded += 1;
@@ -953,6 +983,7 @@ fn upgradeAllFormulas(
     force: bool,
     pinned_only: bool,
     isolate_deps: bool,
+    use_system_ruby: []const []const u8,
     tally: *Tally,
 ) !void {
     const sql: [:0]const u8 = if (pinned_only)
@@ -992,7 +1023,7 @@ fn upgradeAllFormulas(
     defer failed_names.deinit(allocator);
 
     for (names.items) |name| {
-        upgradeFormula(ctx, allocator, name, db, api, http, prefix, dry_run, force, pinned_only, isolate_deps, tally) catch {
+        upgradeFormula(ctx, allocator, name, db, api, http, prefix, dry_run, force, pinned_only, isolate_deps, use_system_ruby, tally) catch {
             failed_count += 1;
             tally.failed += 1;
             // failed_count is the authoritative counter; list is for UX only.

--- a/src/core/dsl/builtins/process.zig
+++ b/src/core/dsl/builtins/process.zig
@@ -41,7 +41,7 @@ pub fn system(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     // The lint above waves bare/system-dir argv0 through; the real write
     // containment is the sandbox-exec fence wrapping the spawn (parity with
     // the --use-system-ruby path).
-    const spawn_argv = sandbox.fenceArgv(ctx.allocator, argv_slice, ctx.cellar_path, ctx.malt_prefix) catch |e| switch (e) {
+    const spawn_argv = sandbox.fenceArgv(ctx.allocator, argv_slice, ctx.cellar_path, ctx.malt_prefix, .{}) catch |e| switch (e) {
         error.OutOfMemory => return BuiltinError.OutOfMemory,
         error.PathSandboxViolation => return BuiltinError.PathSandboxViolation,
     };

--- a/src/core/dsl/sandbox.zig
+++ b/src/core/dsl/sandbox.zig
@@ -93,10 +93,11 @@ pub fn fenceArgv(
     argv: []const []const u8,
     cellar_path: []const u8,
     malt_prefix: []const u8,
+    opts: macos.ProfileOpts,
 ) FenceError![]const []const u8 {
     if (builtin.os.tag != .macos or argv.len == 0) return argv;
 
-    const profile = macos.renderRubyProfile(allocator, cellar_path, malt_prefix) catch |e| switch (e) {
+    const profile = macos.renderRubyProfile(allocator, cellar_path, malt_prefix, opts) catch |e| switch (e) {
         // The renderer only allocates and validates: an alloc miss is OOM,
         // anything else (unsafe path) means we can't confine — fail closed.
         error.ProfileBuildFailed => return FenceError.OutOfMemory,
@@ -262,7 +263,7 @@ test "fenceArgv wraps argv under sandbox-exec with the keg/prefix profile" {
     if (builtin.os.tag != .macos) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
-    const wrapped = try fenceArgv(arena.allocator(), &.{ "make", "install" }, "/opt/malt/Cellar/foo/1.0", "/opt/malt");
+    const wrapped = try fenceArgv(arena.allocator(), &.{ "make", "install" }, "/opt/malt/Cellar/foo/1.0", "/opt/malt", .{});
     try std.testing.expectEqualStrings("/usr/bin/sandbox-exec", wrapped[0]);
     try std.testing.expectEqualStrings("-p", wrapped[1]);
     try std.testing.expect(std.mem.indexOf(u8, wrapped[2], "(deny default)") != null);
@@ -274,7 +275,7 @@ test "fenceArgv wraps argv under sandbox-exec with the keg/prefix profile" {
 
 test "fenceArgv leaves empty argv untouched" {
     const empty: []const []const u8 = &.{};
-    const out = try fenceArgv(std.testing.allocator, empty, "/opt/malt/Cellar/foo/1.0", "/opt/malt");
+    const out = try fenceArgv(std.testing.allocator, empty, "/opt/malt/Cellar/foo/1.0", "/opt/malt", .{});
     try std.testing.expectEqual(@as(usize, 0), out.len);
 }
 
@@ -286,7 +287,7 @@ test "fenceArgv fails closed when the profile path is unsafe" {
     // spawn rather than running it unconfined.
     try std.testing.expectError(
         FenceError.PathSandboxViolation,
-        fenceArgv(arena.allocator(), &.{"make"}, "/opt/malt\"/evil", "/opt/malt"),
+        fenceArgv(arena.allocator(), &.{"make"}, "/opt/malt\"/evil", "/opt/malt", .{}),
     );
 }
 
@@ -296,7 +297,7 @@ test "fenceArgv maps a profile allocation failure to OutOfMemory" {
     // allocation — it must surface as OutOfMemory, not a sandbox violation.
     try std.testing.expectError(
         FenceError.OutOfMemory,
-        fenceArgv(std.testing.failing_allocator, &.{"make"}, "/opt/malt/Cellar/foo/1.0", "/opt/malt"),
+        fenceArgv(std.testing.failing_allocator, &.{"make"}, "/opt/malt/Cellar/foo/1.0", "/opt/malt", .{}),
     );
 }
 

--- a/src/core/formula.zig
+++ b/src/core/formula.zig
@@ -90,6 +90,12 @@ pub const Formula = struct {
     dependencies: []const []const u8,
     keg_only: bool,
     post_install_defined: bool,
+    /// True when the formula carries a non-empty declarative
+    /// `post_install_steps` array. Migrated formulas report
+    /// `post_install_defined: false`, so this is what keeps the
+    /// post-install gate open for them. The raw steps stay reachable
+    /// through the formula JSON already threaded to the install path.
+    has_post_install_steps: bool,
     /// Map storage is allocated through `_parsed.arena`; map keys and
     /// `BottleFile` string fields live in `_parsed`.
     bottle_files: ?std.json.ArrayHashMap(BottleFile),
@@ -106,6 +112,12 @@ pub const Formula = struct {
     /// Holds the parsed JSON tree. Must stay alive as long as the Formula
     /// is in use because string fields point into the JSON source buffer.
     _parsed: std.json.Parsed(std.json.Value),
+
+    /// True when installing must run a post-install phase — either the
+    /// imperative `def post_install` or the declarative steps array.
+    pub fn hasPostInstallHook(self: *const Formula) bool {
+        return self.post_install_defined or self.has_post_install_steps;
+    }
 
     pub fn deinit(self: *Formula) void {
         self._parsed.deinit();
@@ -220,6 +232,12 @@ pub fn parseFormula(allocator: std.mem.Allocator, json_data: []const u8) !Formul
     const revision = getInt(root, "revision");
     const keg_only = getBool(root, "keg_only");
     const post_install_defined = getBool(root, "post_install_defined");
+    // The steps key is present (empty) on every formula; only a non-empty
+    // array marks a steps-migrated hook.
+    const has_post_install_steps = blk: {
+        const v = root.get("post_install_steps") orelse break :blk false;
+        break :blk v == .array and v.array.items.len > 0;
+    };
 
     // versions.stable -> version
     const version_str = blk: {
@@ -343,6 +361,7 @@ pub fn parseFormula(allocator: std.mem.Allocator, json_data: []const u8) !Formul
         .dependencies = dependencies,
         .keg_only = keg_only,
         .post_install_defined = post_install_defined,
+        .has_post_install_steps = has_post_install_steps,
         .bottle_files = bottle_files,
         .bottle_root_url = bottle_root_url,
         .oldnames = oldnames,
@@ -507,6 +526,42 @@ test "parseFormula rejects path separators in embedded name or version" {
     var f2 = try parseFormula(testing.allocator, nover);
     defer f2.deinit();
     try testing.expectEqualStrings("", f2.version);
+}
+
+test "parseFormula flags a formula migrated to post_install_steps" {
+    // Migrated formulas report post_install_defined=false and carry the
+    // hook in a declarative steps array; the steps are what must keep the
+    // install gate open, or post-install silently never runs.
+    const json =
+        \\{"name":"gdk-pixbuf","versions":{"stable":"2.44.3"},"post_install_defined":false,"post_install_steps":[{"type":"gdk_pixbuf_query_loaders"}]}
+    ;
+    var formula = try parseFormula(testing.allocator, json);
+    defer formula.deinit();
+    try testing.expect(!formula.post_install_defined);
+    try testing.expect(formula.has_post_install_steps);
+    try testing.expect(formula.hasPostInstallHook());
+}
+
+test "parseFormula ignores an empty post_install_steps array" {
+    // The key is present (empty) on every formula; ca-certificates ships
+    // post_install_defined=true with steps=[] — empty must not count.
+    const json =
+        \\{"name":"ca-certificates","versions":{"stable":"2026-07-01"},"post_install_defined":true,"post_install_steps":[]}
+    ;
+    var formula = try parseFormula(testing.allocator, json);
+    defer formula.deinit();
+    try testing.expect(!formula.has_post_install_steps);
+    try testing.expect(formula.hasPostInstallHook());
+}
+
+test "parseFormula treats an absent post_install_steps key as no hook" {
+    const json =
+        \\{"name":"plain","versions":{"stable":"1.0"},"post_install_defined":false}
+    ;
+    var formula = try parseFormula(testing.allocator, json);
+    defer formula.deinit();
+    try testing.expect(!formula.has_post_install_steps);
+    try testing.expect(!formula.hasPostInstallHook());
 }
 
 test "parseFormula releases every auxiliary allocation through deinit" {

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -1,0 +1,856 @@
+//! malt — declarative post-install steps executor.
+//!
+//! Homebrew 6 migrates formula hooks from `def post_install` Ruby to a
+//! literal-only `post_install_steps` array exposed through the formulae
+//! API. This module interprets that array natively: path bases resolve
+//! against the malt prefix, filesystem steps go through the same
+//! keg-confinement guards as the DSL FS builtins, and tool steps spawn
+//! through the same sandbox fence as the DSL `system` builtin.
+//! Unsupported steps land in the FallbackLog so the shared outcome
+//! router downgrades to the loud partial-skip envelope.
+
+const std = @import("std");
+const sandbox = @import("dsl/sandbox.zig");
+const fallback_log = @import("dsl/fallback_log.zig");
+
+pub const FallbackLog = fallback_log.FallbackLog;
+
+/// Formula-scoped inputs for base-token resolution and confinement.
+pub const StepsCtx = struct {
+    io: std.Io,
+    /// Arena-backed: owns every resolved path, parsed JSON node, and log
+    /// detail until the caller finishes routing the FallbackLog.
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    /// Raw upstream version — template tokens read it; the revision-suffixed
+    /// cellar label lives in `keg_path` already.
+    version: []const u8,
+    /// malt prefix (the upstream HOMEBREW_PREFIX analogue).
+    prefix: []const u8,
+    /// `<prefix>/Cellar/<name>/<pkg_version>` — the `prefix` base token.
+    keg_path: []const u8,
+    flog: *FallbackLog,
+    suppress_child_stdout: bool = false,
+};
+
+/// Step types this executor runs natively. Everything else routes to the
+/// partial-skip envelope; doctor reads this to classify migrated formulas.
+pub fn supportedStepType(step_type: []const u8) bool {
+    const native = [_][]const u8{
+        "mkdir_p",
+        "touch",
+        "write",
+        "symlink",
+        "link_dir",
+        "link_children",
+        "compile_gsettings_schemas",
+        "gio_querymodules",
+        "gdk_pixbuf_query_loaders",
+        "gtk_update_icon_cache",
+        "update_mime_database",
+        "update_desktop_database",
+    };
+    for (native) |t| if (std.mem.eql(u8, t, step_type)) return true;
+    return false;
+}
+
+/// True when the formula JSON carries a non-empty steps array whose every
+/// step type runs natively. Read-side classifier for the doctor probe —
+/// execution itself routes per-step through the FallbackLog instead.
+pub fn allStepsSupported(allocator: std.mem.Allocator, formula_json: []const u8) bool {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, formula_json, .{}) catch return false;
+    defer parsed.deinit();
+    const root = switch (parsed.value) {
+        .object => |o| o,
+        else => return false,
+    };
+    const steps_val = root.get("post_install_steps") orelse return false;
+    const steps = switch (steps_val) {
+        .array => |a| a.items,
+        else => return false,
+    };
+    if (steps.len == 0) return false;
+    for (steps) |step_val| {
+        const obj = switch (step_val) {
+            .object => |o| o,
+            else => return false,
+        };
+        const step_type = getString(obj, "type") orelse return false;
+        if (!supportedStepType(step_type)) return false;
+    }
+    return true;
+}
+
+/// Interpret the formula JSON's `post_install_steps` array. Returns false
+/// when the formula carries no steps (caller falls through to the Ruby-DSL
+/// path); true means the steps were attempted and the FallbackLog is the
+/// source of truth for routing, exactly like the DSL interpreter.
+pub fn execute(ctx: StepsCtx, formula_json: []const u8) bool {
+    // Parsed tree is arena-owned via ctx.allocator; no deinit needed.
+    const parsed = std.json.parseFromSlice(std.json.Value, ctx.allocator, formula_json, .{}) catch return false;
+    const root = switch (parsed.value) {
+        .object => |o| o,
+        else => return false,
+    };
+    const steps_val = root.get("post_install_steps") orelse return false;
+    const steps = switch (steps_val) {
+        .array => |a| a.items,
+        else => return false,
+    };
+    if (steps.len == 0) return false;
+
+    for (steps) |step_val| {
+        ctx.flog.total_top_level += 1;
+        const obj = switch (step_val) {
+            .object => |o| o,
+            else => {
+                logUnsupported(ctx, "malformed step (not an object)");
+                continue;
+            },
+        };
+        if (runStep(ctx, obj)) ctx.flog.handled_top_level += 1;
+    }
+    return true;
+}
+
+fn runStep(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    const step_type = getString(obj, "type") orelse {
+        logUnsupported(ctx, "step without a type");
+        return false;
+    };
+
+    if (std.mem.eql(u8, step_type, "mkdir_p")) return stepMkdirP(ctx, obj);
+    if (std.mem.eql(u8, step_type, "touch")) return stepTouch(ctx, obj);
+    if (std.mem.eql(u8, step_type, "write")) return stepWrite(ctx, obj);
+    if (std.mem.eql(u8, step_type, "symlink")) return stepSymlink(ctx, obj);
+    if (std.mem.eql(u8, step_type, "link_dir")) return stepLinkDir(ctx, obj);
+    if (std.mem.eql(u8, step_type, "link_children")) return stepLinkChildren(ctx, obj);
+    if (std.mem.eql(u8, step_type, "compile_gsettings_schemas"))
+        return runPathTool(ctx, obj, "glib", "glib-compile-schemas", &.{});
+    if (std.mem.eql(u8, step_type, "gio_querymodules"))
+        return runPathTool(ctx, obj, "glib", "gio-querymodules", &.{});
+    if (std.mem.eql(u8, step_type, "update_mime_database"))
+        return runPathTool(ctx, obj, "shared-mime-info", "update-mime-database", &.{});
+    if (std.mem.eql(u8, step_type, "update_desktop_database"))
+        return runPathTool(ctx, obj, "desktop-file-utils", "update-desktop-database", &.{});
+    if (std.mem.eql(u8, step_type, "gdk_pixbuf_query_loaders"))
+        return stepGdkPixbufQueryLoaders(ctx);
+    if (std.mem.eql(u8, step_type, "gtk_update_icon_cache")) return stepGtkUpdateIconCache(ctx, obj);
+
+    // init_data_dir spawns database initialisers (initdb/mysqld) with
+    // formula-specific env contracts — routed loudly until they earn a
+    // native runner. mkdir/move/move_children are defined upstream but
+    // unused in homebrew-core today.
+    const detail = if (getString(obj, "using")) |using|
+        std.fmt.allocPrint(ctx.allocator, "{s} ({s})", .{ step_type, using }) catch step_type
+    else
+        step_type;
+    logUnsupported(ctx, detail);
+    return false;
+}
+
+// --- path resolution -------------------------------------------------------
+
+/// Expand `{{token}}` template placeholders the way brew's installer does:
+/// known tokens substitute, unknown ones stay verbatim.
+pub fn expandTemplates(ctx: StepsCtx, s: []const u8) ![]const u8 {
+    if (std.mem.indexOf(u8, s, "{{") == null) return s;
+    var out: std.ArrayList(u8) = .empty;
+    var pos: usize = 0;
+    while (std.mem.indexOfPos(u8, s, pos, "{{")) |start| {
+        const end = std.mem.indexOfPos(u8, s, start + 2, "}}") orelse break;
+        try out.appendSlice(ctx.allocator, s[pos..start]);
+        const token = s[start + 2 .. end];
+        if (templateValue(ctx, token)) |v| {
+            try out.appendSlice(ctx.allocator, v);
+        } else {
+            try out.appendSlice(ctx.allocator, s[start .. end + 2]);
+        }
+        pos = end + 2;
+    }
+    try out.appendSlice(ctx.allocator, s[pos..]);
+    return out.toOwnedSlice(ctx.allocator);
+}
+
+fn templateValue(ctx: StepsCtx, token: []const u8) ?[]const u8 {
+    if (std.mem.eql(u8, token, "name")) return ctx.name;
+    if (std.mem.eql(u8, token, "version")) return ctx.version;
+    if (std.mem.eql(u8, token, "version.major")) return versionComponents(ctx.version, 1);
+    if (std.mem.eql(u8, token, "version.major_minor")) return versionComponents(ctx.version, 2);
+    if (std.mem.eql(u8, token, "HOMEBREW_PREFIX")) return ctx.prefix;
+    return null;
+}
+
+/// First `n` dot-separated components of a version string.
+fn versionComponents(version: []const u8, n: usize) []const u8 {
+    var end: usize = 0;
+    var seen: usize = 0;
+    while (end < version.len) : (end += 1) {
+        if (version[end] == '.') {
+            seen += 1;
+            if (seen == n) return version[0..end];
+        }
+    }
+    return version;
+}
+
+/// Map an upstream base token onto the malt prefix. Null means "no safe
+/// mapping" — `home` deliberately so (it escapes the prefix and would fail
+/// confinement anyway), formula-scoped bases without a formula, and any
+/// token this executor does not know.
+pub fn resolveBase(ctx: StepsCtx, base: []const u8, formula_ref: ?[]const u8) ?[]const u8 {
+    const a = ctx.allocator;
+    if (std.mem.eql(u8, base, "homebrew_prefix")) return ctx.prefix;
+    if (std.mem.eql(u8, base, "prefix")) return ctx.keg_path;
+    if (std.mem.eql(u8, base, "opt_prefix"))
+        return std.fmt.allocPrint(a, "{s}/opt/{s}", .{ ctx.prefix, ctx.name }) catch null;
+    if (std.mem.eql(u8, base, "var"))
+        return std.fmt.allocPrint(a, "{s}/var", .{ctx.prefix}) catch null;
+    if (std.mem.eql(u8, base, "etc"))
+        return std.fmt.allocPrint(a, "{s}/etc", .{ctx.prefix}) catch null;
+    if (std.mem.eql(u8, base, "lib"))
+        return std.fmt.allocPrint(a, "{s}/lib", .{ctx.prefix}) catch null;
+    if (std.mem.eql(u8, base, "bin"))
+        return std.fmt.allocPrint(a, "{s}/bin", .{ctx.prefix}) catch null;
+    if (std.mem.eql(u8, base, "pkgetc"))
+        return std.fmt.allocPrint(a, "{s}/etc/{s}", .{ ctx.prefix, ctx.name }) catch null;
+    if (std.mem.eql(u8, base, "pkgshare"))
+        return std.fmt.allocPrint(a, "{s}/share/{s}", .{ ctx.prefix, ctx.name }) catch null;
+    if (std.mem.eql(u8, base, "opt_pkgshare"))
+        return std.fmt.allocPrint(a, "{s}/opt/{s}/share/{s}", .{ ctx.prefix, ctx.name, ctx.name }) catch null;
+    if (std.mem.eql(u8, base, "formula_pkgetc")) {
+        const f = formula_ref orelse return null;
+        return std.fmt.allocPrint(a, "{s}/etc/{s}", .{ ctx.prefix, f }) catch null;
+    }
+    if (std.mem.eql(u8, base, "formula_opt_prefix")) {
+        const f = formula_ref orelse return null;
+        return std.fmt.allocPrint(a, "{s}/opt/{s}", .{ ctx.prefix, f }) catch null;
+    }
+    return null;
+}
+
+/// Resolve a `{base, path, formula}` spec into an absolute path, or null
+/// (already logged) when the spec is malformed or the base has no mapping.
+fn resolvePathSpec(ctx: StepsCtx, obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const spec = getObject(obj, key) orelse {
+        logUnsupported(ctx, key);
+        return null;
+    };
+    const raw = getString(spec, "path") orelse {
+        logUnsupported(ctx, key);
+        return null;
+    };
+    const path = expandTemplates(ctx, raw) catch return null;
+    const base = getString(spec, "base") orelse "absolute";
+    if (std.mem.eql(u8, base, "absolute") or std.mem.eql(u8, base, "relative")) return path;
+    const root = resolveBase(ctx, base, getString(spec, "formula")) orelse {
+        logUnsupported(ctx, std.fmt.allocPrint(ctx.allocator, "base {s}", .{base}) catch base);
+        return null;
+    };
+    return std.fs.path.join(ctx.allocator, &.{ root, path }) catch null;
+}
+
+// --- filesystem tier -------------------------------------------------------
+
+/// Confinement gate shared by every write path: same predicate the DSL FS
+/// builtins use, same fatal routing on refusal.
+fn confined(ctx: StepsCtx, path: []const u8) bool {
+    sandbox.validatePath(path, ctx.keg_path, ctx.prefix) catch {
+        logViolation(ctx, path);
+        return false;
+    };
+    return true;
+}
+
+fn mkParent(ctx: StepsCtx, path: []const u8) void {
+    if (std.fs.path.dirname(path)) |parent| {
+        std.Io.Dir.cwd().createDirPath(ctx.io, parent) catch {};
+    }
+}
+
+fn stepMkdirP(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    const path = resolvePathSpec(ctx, obj, "path") orelse return false;
+    if (!confined(ctx, path)) return false;
+    std.Io.Dir.cwd().createDirPath(ctx.io, path) catch {};
+    return true;
+}
+
+fn stepTouch(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    const path = resolvePathSpec(ctx, obj, "path") orelse return false;
+    if (!confined(ctx, path)) return false;
+    mkParent(ctx, path);
+    // Create (no truncate) through an O_NOFOLLOW handle, same as the DSL
+    // touch builtin: a symlinked leaf must not reach outside the keg.
+    const file = sandbox.openTargetNoFollow(ctx.io, path, ctx.keg_path, ctx.prefix, .{ .create = true }) catch |e| {
+        if (e == error.PathSandboxViolation) logViolation(ctx, path);
+        return e != error.PathSandboxViolation;
+    };
+    file.close(ctx.io);
+    return true;
+}
+
+fn stepWrite(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    const raw_content = getString(obj, "content") orelse {
+        logUnsupported(ctx, "write without content");
+        return false;
+    };
+    const path = resolvePathSpec(ctx, obj, "path") orelse return false;
+    if (!confined(ctx, path)) return false;
+    // Existing files are the user's unless the step opts into overwrite.
+    if (!getFlag(obj, "overwrite") and fileExists(ctx.io, path)) return true;
+    const content = expandTemplates(ctx, raw_content) catch return false;
+    mkParent(ctx, path);
+    const file = sandbox.openTargetNoFollow(ctx.io, path, ctx.keg_path, ctx.prefix, .{
+        .write = true,
+        .create = true,
+        .truncate = true,
+    }) catch |e| {
+        if (e == error.PathSandboxViolation) logViolation(ctx, path);
+        return e != error.PathSandboxViolation;
+    };
+    defer file.close(ctx.io);
+    file.writeStreamingAll(ctx.io, content) catch {};
+    return true;
+}
+
+fn stepSymlink(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    const target = resolvePathSpec(ctx, obj, "target") orelse return false;
+    if (!confined(ctx, target)) return false;
+    const source = resolvePathSpec(ctx, obj, "source") orelse return false;
+    if (source.len == 0 or source[0] != '/') {
+        // ponytail: relative symlink sources are unused upstream; extend
+        // when a formula ships one.
+        logUnsupported(ctx, "symlink with a relative source");
+        return false;
+    }
+    mkParent(ctx, target);
+    if (getFlag(obj, "force")) std.Io.Dir.cwd().deleteFile(ctx.io, target) catch {};
+    std.Io.Dir.symLinkAbsolute(ctx.io, source, target, .{}) catch {};
+    return true;
+}
+
+fn stepLinkChildren(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    const source = resolvePathSpec(ctx, obj, "source") orelse return false;
+    const target = resolvePathSpec(ctx, obj, "target") orelse return false;
+    if (!confined(ctx, target)) return false;
+    std.Io.Dir.cwd().createDirPath(ctx.io, target) catch {};
+    // Same per-level guards as the DSL cp_r walk: neither side may resolve
+    // out of the keg/prefix through a planted directory symlink.
+    sandbox.validateDirTarget(ctx.io, target, ctx.keg_path, ctx.prefix) catch {
+        logViolation(ctx, target);
+        return false;
+    };
+    sandbox.validateDirTarget(ctx.io, source, ctx.keg_path, ctx.prefix) catch {
+        logViolation(ctx, source);
+        return false;
+    };
+    const link_prefix = expandTemplates(ctx, getString(obj, "prefix") orelse "") catch return false;
+    const link_suffix = expandTemplates(ctx, getString(obj, "suffix") orelse "") catch return false;
+
+    var dir = std.Io.Dir.openDirAbsolute(ctx.io, source, .{ .iterate = true }) catch return true;
+    defer dir.close(ctx.io);
+    var iter = dir.iterate();
+    while (iter.next(ctx.io) catch null) |entry| {
+        const child = std.fs.path.join(ctx.allocator, &.{ source, entry.name }) catch continue;
+        const link_name = std.fmt.allocPrint(ctx.allocator, "{s}{s}{s}", .{ link_prefix, entry.name, link_suffix }) catch continue;
+        const link_path = std.fs.path.join(ctx.allocator, &.{ target, link_name }) catch continue;
+        std.Io.Dir.cwd().deleteFile(ctx.io, link_path) catch {};
+        std.Io.Dir.symLinkAbsolute(ctx.io, child, link_path, .{}) catch {};
+    }
+    return true;
+}
+
+fn stepLinkDir(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    const source = resolvePathSpec(ctx, obj, "source") orelse return false;
+    const target = resolvePathSpec(ctx, obj, "target") orelse return false;
+    if (!confined(ctx, target)) return false;
+    linkDirRecursive(ctx, source, target);
+    return true;
+}
+
+/// Mirror of brew's link_dir walk: directories materialise as real dirs,
+/// files and symlinks become symlinks, `.DS_Store` is skipped. Guarded per
+/// level like the DSL cp_r walk.
+fn linkDirRecursive(ctx: StepsCtx, src: []const u8, dst: []const u8) void {
+    std.Io.Dir.cwd().createDirPath(ctx.io, dst) catch {};
+    sandbox.validateDirTarget(ctx.io, dst, ctx.keg_path, ctx.prefix) catch {
+        logViolation(ctx, dst);
+        return;
+    };
+    sandbox.validateDirTarget(ctx.io, src, ctx.keg_path, ctx.prefix) catch {
+        logViolation(ctx, src);
+        return;
+    };
+
+    var dir = std.Io.Dir.openDirAbsolute(ctx.io, src, .{ .iterate = true }) catch return;
+    defer dir.close(ctx.io);
+    var iter = dir.iterate();
+    while (iter.next(ctx.io) catch null) |entry| {
+        if (std.mem.eql(u8, entry.name, ".DS_Store")) continue;
+        const src_child = std.fs.path.join(ctx.allocator, &.{ src, entry.name }) catch continue;
+        const dst_child = std.fs.path.join(ctx.allocator, &.{ dst, entry.name }) catch continue;
+        if (entry.kind == .directory) {
+            linkDirRecursive(ctx, src_child, dst_child);
+        } else {
+            std.Io.Dir.cwd().deleteFile(ctx.io, dst_child) catch {};
+            std.Io.Dir.symLinkAbsolute(ctx.io, src_child, dst_child, .{}) catch {};
+        }
+    }
+}
+
+// --- tool tier -------------------------------------------------------------
+
+/// Tool steps whose only argument is the step's resolved path.
+fn runPathTool(ctx: StepsCtx, obj: std.json.ObjectMap, tool_formula: []const u8, exe: []const u8, extra: []const []const u8) bool {
+    const path = resolvePathSpec(ctx, obj, "path") orelse return false;
+    var args = std.ArrayList([]const u8).empty;
+    args.appendSlice(ctx.allocator, extra) catch return false;
+    args.append(ctx.allocator, path) catch return false;
+    return runFormulaTool(ctx, tool_formula, exe, args.items);
+}
+
+fn stepGtkUpdateIconCache(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    // brew prefers gtk4's tool when any gtk4 is installed, else gtk+3's.
+    const gtk4 = std.fmt.allocPrint(ctx.allocator, "{s}/opt/gtk4/bin/gtk4-update-icon-cache", .{ctx.prefix}) catch return false;
+    if (fileExists(ctx.io, gtk4))
+        return runPathTool(ctx, obj, "gtk4", "gtk4-update-icon-cache", &.{ "-q", "-t", "-f" });
+    return runPathTool(ctx, obj, "gtk+3", "gtk3-update-icon-cache", &.{ "-q", "-t", "-f" });
+}
+
+const GdkPixbufEnv = struct {
+    moduledir: []const u8,
+    module_file: []const u8,
+};
+
+/// gdk-pixbuf-query-loaders derives both its loader scan dir and the
+/// `--update-cache` write target from its build-time prefix, so under a
+/// custom malt prefix it silently targets the baked upstream location
+/// (and exits 0 even when that write fails). Derive the malt-prefix pair
+/// from the keg's versioned module dir instead.
+pub fn gdkPixbufEnvPaths(ctx: StepsCtx) ?GdkPixbufEnv {
+    const opt_moddir = std.fmt.allocPrint(ctx.allocator, "{s}/opt/gdk-pixbuf/lib/gdk-pixbuf-2.0", .{ctx.prefix}) catch return null;
+    var dir = std.Io.Dir.openDirAbsolute(ctx.io, opt_moddir, .{ .iterate = true }) catch return null;
+    defer dir.close(ctx.io);
+    var iter = dir.iterate();
+    while (iter.next(ctx.io) catch null) |entry| {
+        if (entry.kind != .directory) continue;
+        return .{
+            .moduledir = std.fmt.allocPrint(ctx.allocator, "{s}/lib/gdk-pixbuf-2.0/{s}/loaders", .{ ctx.prefix, entry.name }) catch return null,
+            .module_file = std.fmt.allocPrint(ctx.allocator, "{s}/lib/gdk-pixbuf-2.0/{s}/loaders.cache", .{ ctx.prefix, entry.name }) catch return null,
+        };
+    }
+    return null;
+}
+
+fn stepGdkPixbufQueryLoaders(ctx: StepsCtx) bool {
+    const env = gdkPixbufEnvPaths(ctx) orelse {
+        logCmdFail(ctx, "gdk-pixbuf module dir not found under the prefix");
+        return false;
+    };
+    // The tool exits 0 even when the cache write fails, so the target tree
+    // must exist up front — same real-dirs-at-prefix layout brew links.
+    if (!confined(ctx, env.moduledir)) return false;
+    std.Io.Dir.cwd().createDirPath(ctx.io, env.moduledir) catch {};
+    var env_map = std.process.Environ.Map.init(ctx.allocator);
+    defer env_map.deinit();
+    env_map.put("GDK_PIXBUF_MODULEDIR", env.moduledir) catch return false;
+    env_map.put("GDK_PIXBUF_MODULE_FILE", env.module_file) catch return false;
+    return runFormulaToolEnv(ctx, "gdk-pixbuf", "gdk-pixbuf-query-loaders", &.{"--update-cache"}, &env_map);
+}
+
+/// Spawn `<prefix>/opt/<formula>/bin/<exe>` through the same argv lint +
+/// sandbox fence as the DSL `system` builtin. Failure routes exactly like
+/// a failed formula `system` call.
+fn runFormulaTool(ctx: StepsCtx, tool_formula: []const u8, exe: []const u8, args: []const []const u8) bool {
+    return runFormulaToolEnv(ctx, tool_formula, exe, args, null);
+}
+
+fn runFormulaToolEnv(ctx: StepsCtx, tool_formula: []const u8, exe: []const u8, args: []const []const u8, env_map: ?*const std.process.Environ.Map) bool {
+    const tool = std.fmt.allocPrint(ctx.allocator, "{s}/opt/{s}/bin/{s}", .{ ctx.prefix, tool_formula, exe }) catch return false;
+    if (!fileExists(ctx.io, tool)) {
+        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} not found (is {s} installed?)", .{ exe, tool_formula }) catch exe);
+        return false;
+    }
+
+    var argv = std.ArrayList([]const u8).empty;
+    argv.append(ctx.allocator, tool) catch return false;
+    argv.appendSlice(ctx.allocator, args) catch return false;
+
+    sandbox.validateArgv(argv.items, ctx.keg_path, ctx.prefix) catch {
+        logViolation(ctx, tool);
+        return false;
+    };
+    const fenced = sandbox.fenceArgv(ctx.allocator, argv.items, ctx.keg_path, ctx.prefix) catch {
+        logViolation(ctx, tool);
+        return false;
+    };
+
+    var child = std.process.spawn(ctx.io, .{
+        .argv = fenced,
+        .stdout = if (ctx.suppress_child_stdout) .ignore else .inherit,
+        .environ_map = env_map,
+    }) catch {
+        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} failed to spawn", .{exe}) catch exe);
+        return false;
+    };
+    const term = child.wait(ctx.io) catch {
+        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} did not terminate cleanly", .{exe}) catch exe);
+        return false;
+    };
+    switch (term) {
+        .exited => |code| {
+            if (code == 0) return true;
+            logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} exited with code {d}", .{ exe, code }) catch exe);
+        },
+        else => logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} terminated abnormally", .{exe}) catch exe),
+    }
+    return false;
+}
+
+// --- shared helpers --------------------------------------------------------
+
+fn fileExists(io: std.Io, path: []const u8) bool {
+    const f = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return false;
+    f.close(io);
+    return true;
+}
+
+fn getString(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const v = obj.get(key) orelse return null;
+    return switch (v) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+fn getObject(obj: std.json.ObjectMap, key: []const u8) ?std.json.ObjectMap {
+    const v = obj.get(key) orelse return null;
+    return switch (v) {
+        .object => |o| o,
+        else => null,
+    };
+}
+
+fn getFlag(obj: std.json.ObjectMap, key: []const u8) bool {
+    const v = obj.get(key) orelse return false;
+    return v == .bool and v.bool;
+}
+
+fn logUnsupported(ctx: StepsCtx, detail: []const u8) void {
+    ctx.flog.log(.{ .formula = ctx.name, .reason = .unknown_method, .detail = detail, .loc = null });
+}
+
+fn logViolation(ctx: StepsCtx, path: []const u8) void {
+    ctx.flog.log(.{ .formula = ctx.name, .reason = .sandbox_violation, .detail = path, .loc = null });
+}
+
+fn logCmdFail(ctx: StepsCtx, detail: []const u8) void {
+    ctx.flog.log(.{ .formula = ctx.name, .reason = .system_command_failed, .detail = detail, .loc = null });
+}
+
+// --- tests -----------------------------------------------------------------
+// Inline because base resolution, templating, and the FS tier are pure
+// logic over a caller-supplied prefix; filesystem fixtures use `std.Io`
+// directly, mirroring `ruby/source.zig`.
+
+const testing = std.testing;
+
+fn testIo() std.Io {
+    return std.Options.debug_io;
+}
+
+fn uniquePrefix(io: std.Io) ![]u8 {
+    var rand: [8]u8 = undefined;
+    io.random(&rand);
+    const hex = std.fmt.bytesToHex(rand, .lower);
+    const p = try std.fmt.allocPrint(testing.allocator, "/tmp/malt_steps_{s}", .{hex[0..]});
+    try std.Io.Dir.cwd().createDirPath(io, p);
+    return p;
+}
+
+const TestHarness = struct {
+    arena: std.heap.ArenaAllocator,
+    flog: FallbackLog,
+    prefix: []u8,
+    keg: []const u8,
+    io: std.Io,
+
+    fn init() !TestHarness {
+        const io = testIo();
+        const prefix = try uniquePrefix(io);
+        errdefer testing.allocator.free(prefix);
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        errdefer arena.deinit();
+        const keg = try std.fmt.allocPrint(arena.allocator(), "{s}/Cellar/glow/1.2.3", .{prefix});
+        try std.Io.Dir.cwd().createDirPath(io, keg);
+        return .{
+            .arena = arena,
+            .flog = FallbackLog.init(testing.allocator),
+            .prefix = prefix,
+            .keg = keg,
+            .io = io,
+        };
+    }
+
+    fn ctx(self: *TestHarness) StepsCtx {
+        return .{
+            .io = self.io,
+            .allocator = self.arena.allocator(),
+            .name = "glow",
+            .version = "1.2.3",
+            .prefix = self.prefix,
+            .keg_path = self.keg,
+            .flog = &self.flog,
+        };
+    }
+
+    fn deinit(self: *TestHarness) void {
+        std.Io.Dir.cwd().deleteTree(self.io, self.prefix) catch {};
+        testing.allocator.free(self.prefix);
+        self.flog.deinit();
+        self.arena.deinit();
+    }
+};
+
+fn testFormulaJson(h: *TestHarness, steps_json: []const u8) ![]const u8 {
+    return std.fmt.allocPrint(
+        h.arena.allocator(),
+        \\{{"name":"glow","versions":{{"stable":"1.2.3"}},"post_install_defined":false,"post_install_steps":{s}}}
+    ,
+        .{steps_json},
+    );
+}
+
+test "expandTemplates substitutes known tokens and leaves unknown verbatim" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const c = h.ctx();
+
+    try testing.expectEqualStrings("glow", try expandTemplates(c, "{{name}}"));
+    try testing.expectEqualStrings("v1.2.3", try expandTemplates(c, "v{{version}}"));
+    try testing.expectEqualStrings("1", try expandTemplates(c, "{{version.major}}"));
+    try testing.expectEqualStrings("1.2", try expandTemplates(c, "{{version.major_minor}}"));
+    const hp = try expandTemplates(c, "{{HOMEBREW_PREFIX}}/share");
+    try testing.expect(std.mem.startsWith(u8, hp, h.prefix));
+    try testing.expectEqualStrings("{{mystery}}", try expandTemplates(c, "{{mystery}}"));
+}
+
+test "resolveBase maps every observed upstream token into the malt prefix" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const c = h.ctx();
+    const a = h.arena.allocator();
+
+    const cases = [_]struct { base: []const u8, formula: ?[]const u8, want: []const u8 }{
+        .{ .base = "homebrew_prefix", .formula = null, .want = try std.fmt.allocPrint(a, "{s}", .{h.prefix}) },
+        .{ .base = "prefix", .formula = null, .want = h.keg },
+        .{ .base = "opt_prefix", .formula = null, .want = try std.fmt.allocPrint(a, "{s}/opt/glow", .{h.prefix}) },
+        .{ .base = "var", .formula = null, .want = try std.fmt.allocPrint(a, "{s}/var", .{h.prefix}) },
+        .{ .base = "etc", .formula = null, .want = try std.fmt.allocPrint(a, "{s}/etc", .{h.prefix}) },
+        .{ .base = "lib", .formula = null, .want = try std.fmt.allocPrint(a, "{s}/lib", .{h.prefix}) },
+        .{ .base = "bin", .formula = null, .want = try std.fmt.allocPrint(a, "{s}/bin", .{h.prefix}) },
+        .{ .base = "pkgetc", .formula = null, .want = try std.fmt.allocPrint(a, "{s}/etc/glow", .{h.prefix}) },
+        .{ .base = "pkgshare", .formula = null, .want = try std.fmt.allocPrint(a, "{s}/share/glow", .{h.prefix}) },
+        .{ .base = "opt_pkgshare", .formula = null, .want = try std.fmt.allocPrint(a, "{s}/opt/glow/share/glow", .{h.prefix}) },
+        .{ .base = "formula_pkgetc", .formula = "ca-certificates", .want = try std.fmt.allocPrint(a, "{s}/etc/ca-certificates", .{h.prefix}) },
+        .{ .base = "formula_opt_prefix", .formula = "ca-certificates", .want = try std.fmt.allocPrint(a, "{s}/opt/ca-certificates", .{h.prefix}) },
+    };
+    for (cases) |case| {
+        const got = resolveBase(c, case.base, case.formula) orelse return error.TestUnexpectedResult;
+        try testing.expectEqualStrings(case.want, got);
+    }
+
+    // `home` escapes the prefix; unknown tokens have no safe mapping.
+    try testing.expect(resolveBase(c, "home", null) == null);
+    try testing.expect(resolveBase(c, "carport", null) == null);
+    // formula-scoped bases without a formula are malformed.
+    try testing.expect(resolveBase(c, "formula_pkgetc", null) == null);
+}
+
+test "execute returns false when the formula carries no steps" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    try testing.expect(!execute(h.ctx(), try testFormulaJson(&h, "[]")));
+    try testing.expect(!execute(h.ctx(),
+        \\{"name":"glow","versions":{"stable":"1.2.3"}}
+    ));
+    try testing.expect(!h.flog.hasErrors());
+}
+
+test "execute runs the filesystem tier natively and leaves the log clean" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const io = h.io;
+    const a = h.arena.allocator();
+
+    // A child for link_children / link_dir to walk.
+    const share = try std.fmt.allocPrint(a, "{s}/share/glow", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(io, share);
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, try std.fmt.allocPrint(a, "{s}/glow.dat", .{share}), .{});
+        f.close(io);
+    }
+
+    const json = try testFormulaJson(&h,
+        \\[{"type":"mkdir_p","path":{"base":"var","path":"log/{{name}}"}},
+        \\ {"type":"touch","path":{"base":"var","path":"log/glow/access.log"}},
+        \\ {"type":"write","path":{"base":"var","path":"glow/.env"},"content":"# {{name}}\n"},
+        \\ {"type":"symlink","force":true,"source":{"base":"prefix","path":"share/glow/glow.dat"},"target":{"base":"etc","path":"glow.dat"}},
+        \\ {"type":"link_children","source":{"base":"prefix","path":"share/glow"},"target":{"base":"homebrew_prefix","path":"bin"},"suffix":"-{{version.major}}"},
+        \\ {"type":"link_dir","source":{"base":"prefix","path":"share/glow"},"target":{"base":"homebrew_prefix","path":"share/glow-mirror"}}]
+    );
+    try testing.expect(execute(h.ctx(), json));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqual(@as(usize, 6), h.flog.total_top_level);
+    try testing.expectEqual(@as(usize, 6), h.flog.handled_top_level);
+
+    const checks = [_][]const u8{
+        try std.fmt.allocPrint(a, "{s}/var/log/glow/access.log", .{h.prefix}),
+        try std.fmt.allocPrint(a, "{s}/var/glow/.env", .{h.prefix}),
+        try std.fmt.allocPrint(a, "{s}/etc/glow.dat", .{h.prefix}),
+        try std.fmt.allocPrint(a, "{s}/bin/glow.dat-1", .{h.prefix}),
+        try std.fmt.allocPrint(a, "{s}/share/glow-mirror/glow.dat", .{h.prefix}),
+    };
+    for (checks) |p| {
+        const f = std.Io.Dir.openFileAbsolute(io, p, .{}) catch return error.TestUnexpectedResult;
+        f.close(io);
+    }
+
+    // Template expanded inside written content.
+    var buf: [64]u8 = undefined;
+    const env = try std.Io.Dir.openFileAbsolute(io, checks[1], .{});
+    defer env.close(io);
+    const n = try env.readPositionalAll(io, &buf, 0);
+    try testing.expectEqualStrings("# glow\n", buf[0..n]);
+}
+
+test "write respects existing files unless overwrite is set" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+    const io = h.io;
+
+    const path = try std.fmt.allocPrint(a, "{s}/etc/glow.conf", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(io, std.fs.path.dirname(path).?);
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, path, .{});
+        try f.writeStreamingAll(io, "user edited\n");
+        f.close(io);
+    }
+
+    // Default: an existing file is the user's — leave it alone.
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"write","path":{"base":"etc","path":"glow.conf"},"content":"fresh\n"}]
+    )));
+    var buf: [64]u8 = undefined;
+    {
+        const f = try std.Io.Dir.openFileAbsolute(io, path, .{});
+        defer f.close(io);
+        const n = try f.readPositionalAll(io, &buf, 0);
+        try testing.expectEqualStrings("user edited\n", buf[0..n]);
+    }
+
+    // overwrite:true replaces it.
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"write","path":{"base":"etc","path":"glow.conf"},"content":"fresh\n","overwrite":true}]
+    )));
+    {
+        const f = try std.Io.Dir.openFileAbsolute(io, path, .{});
+        defer f.close(io);
+        const n = try f.readPositionalAll(io, &buf, 0);
+        try testing.expectEqualStrings("fresh\n", buf[0..n]);
+    }
+    try testing.expect(!h.flog.hasErrors());
+}
+
+test "a step resolving outside the prefix is refused and logged as a sandbox violation" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"mkdir_p","path":{"base":"absolute","path":"/tmp/malt_steps_escape_zz"}}]
+    )));
+    try testing.expect(h.flog.hasFatal());
+    var escaped = true;
+    _ = std.Io.Dir.openDirAbsolute(h.io, "/tmp/malt_steps_escape_zz", .{}) catch {
+        escaped = false;
+    };
+    try testing.expect(!escaped);
+}
+
+test "init_data_dir and unknown step types downgrade to the loud partial skip" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"mkdir_p","path":{"base":"var","path":"glow"}},
+        \\ {"type":"init_data_dir","path":{"base":"var","path":"glow"},"using":"postgresql_initdb"},
+        \\ {"type":"frobnicate"}]
+    )));
+    try testing.expect(h.flog.hasErrors());
+    try testing.expect(!h.flog.hasFatal());
+    try testing.expectEqual(@as(usize, 2), h.flog.entries().len);
+    try testing.expectEqual(fallback_log.FallbackReason.unknown_method, h.flog.entries()[0].reason);
+    // The supported step still ran and counted as handled.
+    try testing.expectEqual(@as(usize, 3), h.flog.total_top_level);
+    try testing.expectEqual(@as(usize, 1), h.flog.handled_top_level);
+}
+
+test "a missing helper tool is a loud command failure, not a silent skip" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    // No glib keg exists under the test prefix, so the tool can't resolve.
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"compile_gsettings_schemas","path":{"base":"homebrew_prefix","path":"share/glib-2.0/schemas"}}]
+    )));
+    try testing.expect(h.flog.hasErrors());
+    try testing.expectEqual(fallback_log.FallbackReason.system_command_failed, h.flog.entries()[0].reason);
+}
+
+test "allStepsSupported classifies migrated formulas for the doctor probe" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    try testing.expect(allStepsSupported(a, try testFormulaJson(&h,
+        \\[{"type":"mkdir_p","path":{"base":"var","path":"glow"}},
+        \\ {"type":"gtk_update_icon_cache","path":{"base":"homebrew_prefix","path":"share/icons"}}]
+    )));
+    try testing.expect(!allStepsSupported(a, try testFormulaJson(&h,
+        \\[{"type":"mkdir_p","path":{"base":"var","path":"glow"}},
+        \\ {"type":"init_data_dir","path":{"base":"var","path":"glow"},"using":"postgresql_initdb"}]
+    )));
+    // No steps at all → nothing to support.
+    try testing.expect(!allStepsSupported(a, try testFormulaJson(&h, "[]")));
+}
+
+test "gdkPixbufEnvPaths derives the malt-prefix module dir and cache file" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // No gdk-pixbuf keg → no safe env to derive.
+    try testing.expect(gdkPixbufEnvPaths(h.ctx()) == null);
+
+    const moddir = try std.fmt.allocPrint(a, "{s}/opt/gdk-pixbuf/lib/gdk-pixbuf-2.0/2.10.0", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, moddir);
+
+    const env = gdkPixbufEnvPaths(h.ctx()) orelse return error.TestUnexpectedResult;
+    const want_dir = try std.fmt.allocPrint(a, "{s}/lib/gdk-pixbuf-2.0/2.10.0/loaders", .{h.prefix});
+    const want_file = try std.fmt.allocPrint(a, "{s}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache", .{h.prefix});
+    try testing.expectEqualStrings(want_dir, env.moduledir);
+    try testing.expectEqualStrings(want_file, env.module_file);
+}
+
+test "supportedStepType matches the executable tier and rejects the rest" {
+    const native = [_][]const u8{
+        "mkdir_p",                  "touch",                 "write",                     "symlink",
+        "link_dir",                 "link_children",         "compile_gsettings_schemas", "gio_querymodules",
+        "gdk_pixbuf_query_loaders", "gtk_update_icon_cache", "update_mime_database",      "update_desktop_database",
+    };
+    for (native) |t| try testing.expect(supportedStepType(t));
+    const routed = [_][]const u8{ "init_data_dir", "mkdir", "move", "move_children", "frobnicate" };
+    for (routed) |t| try testing.expect(!supportedStepType(t));
+}

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -31,28 +31,49 @@ pub const StepsCtx = struct {
     keg_path: []const u8,
     flog: *FallbackLog,
     suppress_child_stdout: bool = false,
+    /// Only consulted for the data-dir initialisers (`--user=$USER`).
+    environ: std.process.Environ = .empty,
 };
 
 /// Step types this executor runs natively. Everything else routes to the
 /// partial-skip envelope; doctor reads this to classify migrated formulas.
 pub fn supportedStepType(step_type: []const u8) bool {
-    const native = [_][]const u8{
-        "mkdir_p",
-        "touch",
-        "write",
-        "symlink",
-        "link_dir",
-        "link_children",
-        "compile_gsettings_schemas",
-        "gio_querymodules",
-        "gdk_pixbuf_query_loaders",
-        "gtk_update_icon_cache",
-        "update_mime_database",
-        "update_desktop_database",
-    };
-    for (native) |t| if (std.mem.eql(u8, t, step_type)) return true;
-    return false;
+    return step_map.get(step_type) != null;
 }
+
+const StepTag = enum {
+    mkdir_p,
+    touch,
+    write,
+    symlink,
+    link_dir,
+    link_children,
+    compile_gsettings_schemas,
+    gio_querymodules,
+    gdk_pixbuf_query_loaders,
+    gtk_update_icon_cache,
+    update_mime_database,
+    update_desktop_database,
+    init_data_dir,
+};
+
+/// Single source of truth for the native step set: `runStep` dispatch and
+/// the doctor-facing `supportedStepType` classifier both read it.
+const step_map = std.StaticStringMap(StepTag).initComptime(.{
+    .{ "mkdir_p", .mkdir_p },
+    .{ "touch", .touch },
+    .{ "write", .write },
+    .{ "symlink", .symlink },
+    .{ "link_dir", .link_dir },
+    .{ "link_children", .link_children },
+    .{ "compile_gsettings_schemas", .compile_gsettings_schemas },
+    .{ "gio_querymodules", .gio_querymodules },
+    .{ "gdk_pixbuf_query_loaders", .gdk_pixbuf_query_loaders },
+    .{ "gtk_update_icon_cache", .gtk_update_icon_cache },
+    .{ "update_mime_database", .update_mime_database },
+    .{ "update_desktop_database", .update_desktop_database },
+    .{ "init_data_dir", .init_data_dir },
+});
 
 /// True when the formula JSON carries a non-empty steps array whose every
 /// step type runs natively. Read-side classifier for the doctor probe —
@@ -119,34 +140,27 @@ fn runStep(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
         return false;
     };
 
-    if (std.mem.eql(u8, step_type, "mkdir_p")) return stepMkdirP(ctx, obj);
-    if (std.mem.eql(u8, step_type, "touch")) return stepTouch(ctx, obj);
-    if (std.mem.eql(u8, step_type, "write")) return stepWrite(ctx, obj);
-    if (std.mem.eql(u8, step_type, "symlink")) return stepSymlink(ctx, obj);
-    if (std.mem.eql(u8, step_type, "link_dir")) return stepLinkDir(ctx, obj);
-    if (std.mem.eql(u8, step_type, "link_children")) return stepLinkChildren(ctx, obj);
-    if (std.mem.eql(u8, step_type, "compile_gsettings_schemas"))
-        return runPathTool(ctx, obj, "glib", "glib-compile-schemas", &.{});
-    if (std.mem.eql(u8, step_type, "gio_querymodules"))
-        return runPathTool(ctx, obj, "glib", "gio-querymodules", &.{});
-    if (std.mem.eql(u8, step_type, "update_mime_database"))
-        return runPathTool(ctx, obj, "shared-mime-info", "update-mime-database", &.{});
-    if (std.mem.eql(u8, step_type, "update_desktop_database"))
-        return runPathTool(ctx, obj, "desktop-file-utils", "update-desktop-database", &.{});
-    if (std.mem.eql(u8, step_type, "gdk_pixbuf_query_loaders"))
-        return stepGdkPixbufQueryLoaders(ctx);
-    if (std.mem.eql(u8, step_type, "gtk_update_icon_cache")) return stepGtkUpdateIconCache(ctx, obj);
-
-    // init_data_dir spawns database initialisers (initdb/mysqld) with
-    // formula-specific env contracts — routed loudly until they earn a
-    // native runner. mkdir/move/move_children are defined upstream but
-    // unused in homebrew-core today.
-    const detail = if (getString(obj, "using")) |using|
-        std.fmt.allocPrint(ctx.allocator, "{s} ({s})", .{ step_type, using }) catch step_type
-    else
-        step_type;
-    logUnsupported(ctx, detail);
-    return false;
+    // mkdir/move/move_children are defined upstream but unused in
+    // homebrew-core today — routed loudly until a formula ships one.
+    const tag = step_map.get(step_type) orelse {
+        logUnsupported(ctx, step_type);
+        return false;
+    };
+    return switch (tag) {
+        .mkdir_p => stepMkdirP(ctx, obj),
+        .touch => stepTouch(ctx, obj),
+        .write => stepWrite(ctx, obj),
+        .symlink => stepSymlink(ctx, obj),
+        .link_dir => stepLinkDir(ctx, obj),
+        .link_children => stepLinkChildren(ctx, obj),
+        .compile_gsettings_schemas => runPathTool(ctx, obj, "glib", "glib-compile-schemas", &.{}),
+        .gio_querymodules => runPathTool(ctx, obj, "glib", "gio-querymodules", &.{}),
+        .update_mime_database => runPathTool(ctx, obj, "shared-mime-info", "update-mime-database", &.{}),
+        .update_desktop_database => runPathTool(ctx, obj, "desktop-file-utils", "update-desktop-database", &.{}),
+        .gdk_pixbuf_query_loaders => stepGdkPixbufQueryLoaders(ctx),
+        .gtk_update_icon_cache => stepGtkUpdateIconCache(ctx, obj),
+        .init_data_dir => stepInitDataDir(ctx, obj),
+    };
 }
 
 // --- path resolution -------------------------------------------------------
@@ -172,13 +186,22 @@ pub fn expandTemplates(ctx: StepsCtx, s: []const u8) ![]const u8 {
     return out.toOwnedSlice(ctx.allocator);
 }
 
+const template_map = std.StaticStringMap(enum { name, version, version_major, version_major_minor, homebrew_prefix }).initComptime(.{
+    .{ "name", .name },
+    .{ "version", .version },
+    .{ "version.major", .version_major },
+    .{ "version.major_minor", .version_major_minor },
+    .{ "HOMEBREW_PREFIX", .homebrew_prefix },
+});
+
 fn templateValue(ctx: StepsCtx, token: []const u8) ?[]const u8 {
-    if (std.mem.eql(u8, token, "name")) return ctx.name;
-    if (std.mem.eql(u8, token, "version")) return ctx.version;
-    if (std.mem.eql(u8, token, "version.major")) return versionComponents(ctx.version, 1);
-    if (std.mem.eql(u8, token, "version.major_minor")) return versionComponents(ctx.version, 2);
-    if (std.mem.eql(u8, token, "HOMEBREW_PREFIX")) return ctx.prefix;
-    return null;
+    return switch (template_map.get(token) orelse return null) {
+        .name => ctx.name,
+        .version => ctx.version,
+        .version_major => versionComponents(ctx.version, 1),
+        .version_major_minor => versionComponents(ctx.version, 2),
+        .homebrew_prefix => ctx.prefix,
+    };
 }
 
 /// First `n` dot-separated components of a version string.
@@ -194,39 +217,62 @@ fn versionComponents(version: []const u8, n: usize) []const u8 {
     return version;
 }
 
+const BaseTag = enum {
+    homebrew_prefix,
+    prefix,
+    opt_prefix,
+    var_dir,
+    etc,
+    lib,
+    bin,
+    pkgetc,
+    pkgshare,
+    opt_pkgshare,
+    formula_pkgetc,
+    formula_opt_prefix,
+};
+
+const base_map = std.StaticStringMap(BaseTag).initComptime(.{
+    .{ "homebrew_prefix", .homebrew_prefix },
+    .{ "prefix", .prefix },
+    .{ "opt_prefix", .opt_prefix },
+    .{ "var", .var_dir },
+    .{ "etc", .etc },
+    .{ "lib", .lib },
+    .{ "bin", .bin },
+    .{ "pkgetc", .pkgetc },
+    .{ "pkgshare", .pkgshare },
+    .{ "opt_pkgshare", .opt_pkgshare },
+    .{ "formula_pkgetc", .formula_pkgetc },
+    .{ "formula_opt_prefix", .formula_opt_prefix },
+});
+
 /// Map an upstream base token onto the malt prefix. Null means "no safe
 /// mapping" — `home` deliberately so (it escapes the prefix and would fail
 /// confinement anyway), formula-scoped bases without a formula, and any
 /// token this executor does not know.
 pub fn resolveBase(ctx: StepsCtx, base: []const u8, formula_ref: ?[]const u8) ?[]const u8 {
     const a = ctx.allocator;
-    if (std.mem.eql(u8, base, "homebrew_prefix")) return ctx.prefix;
-    if (std.mem.eql(u8, base, "prefix")) return ctx.keg_path;
-    if (std.mem.eql(u8, base, "opt_prefix"))
-        return std.fmt.allocPrint(a, "{s}/opt/{s}", .{ ctx.prefix, ctx.name }) catch null;
-    if (std.mem.eql(u8, base, "var"))
-        return std.fmt.allocPrint(a, "{s}/var", .{ctx.prefix}) catch null;
-    if (std.mem.eql(u8, base, "etc"))
-        return std.fmt.allocPrint(a, "{s}/etc", .{ctx.prefix}) catch null;
-    if (std.mem.eql(u8, base, "lib"))
-        return std.fmt.allocPrint(a, "{s}/lib", .{ctx.prefix}) catch null;
-    if (std.mem.eql(u8, base, "bin"))
-        return std.fmt.allocPrint(a, "{s}/bin", .{ctx.prefix}) catch null;
-    if (std.mem.eql(u8, base, "pkgetc"))
-        return std.fmt.allocPrint(a, "{s}/etc/{s}", .{ ctx.prefix, ctx.name }) catch null;
-    if (std.mem.eql(u8, base, "pkgshare"))
-        return std.fmt.allocPrint(a, "{s}/share/{s}", .{ ctx.prefix, ctx.name }) catch null;
-    if (std.mem.eql(u8, base, "opt_pkgshare"))
-        return std.fmt.allocPrint(a, "{s}/opt/{s}/share/{s}", .{ ctx.prefix, ctx.name, ctx.name }) catch null;
-    if (std.mem.eql(u8, base, "formula_pkgetc")) {
-        const f = formula_ref orelse return null;
-        return std.fmt.allocPrint(a, "{s}/etc/{s}", .{ ctx.prefix, f }) catch null;
-    }
-    if (std.mem.eql(u8, base, "formula_opt_prefix")) {
-        const f = formula_ref orelse return null;
-        return std.fmt.allocPrint(a, "{s}/opt/{s}", .{ ctx.prefix, f }) catch null;
-    }
-    return null;
+    return switch (base_map.get(base) orelse return null) {
+        .homebrew_prefix => ctx.prefix,
+        .prefix => ctx.keg_path,
+        .opt_prefix => std.fmt.allocPrint(a, "{s}/opt/{s}", .{ ctx.prefix, ctx.name }) catch null,
+        .var_dir => std.fmt.allocPrint(a, "{s}/var", .{ctx.prefix}) catch null,
+        .etc => std.fmt.allocPrint(a, "{s}/etc", .{ctx.prefix}) catch null,
+        .lib => std.fmt.allocPrint(a, "{s}/lib", .{ctx.prefix}) catch null,
+        .bin => std.fmt.allocPrint(a, "{s}/bin", .{ctx.prefix}) catch null,
+        .pkgetc => std.fmt.allocPrint(a, "{s}/etc/{s}", .{ ctx.prefix, ctx.name }) catch null,
+        .pkgshare => std.fmt.allocPrint(a, "{s}/share/{s}", .{ ctx.prefix, ctx.name }) catch null,
+        .opt_pkgshare => std.fmt.allocPrint(a, "{s}/opt/{s}/share/{s}", .{ ctx.prefix, ctx.name, ctx.name }) catch null,
+        .formula_pkgetc => {
+            const f = formula_ref orelse return null;
+            return std.fmt.allocPrint(a, "{s}/etc/{s}", .{ ctx.prefix, f }) catch null;
+        },
+        .formula_opt_prefix => {
+            const f = formula_ref orelse return null;
+            return std.fmt.allocPrint(a, "{s}/opt/{s}", .{ ctx.prefix, f }) catch null;
+        },
+    };
 }
 
 /// Resolve a `{base, path, formula}` spec into an absolute path, or null
@@ -417,6 +463,86 @@ fn stepGtkUpdateIconCache(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
     return runPathTool(ctx, obj, "gtk+3", "gtk3-update-icon-cache", &.{ "-q", "-t", "-f" });
 }
 
+// --- data-dir initialisers ---------------------------------------------------
+
+const InitDataDirPlan = struct {
+    /// Marker file (inside the data dir) whose presence means "already
+    /// initialised — this is user data, never re-run".
+    marker: []const u8,
+    argv: []const []const u8,
+};
+
+/// Pure argv/marker construction for the three upstream initialisers.
+/// Null for an unknown `using` — no safe way to guess a database init.
+/// Binaries come from the formula's own keg; `--tmpdir` points inside the
+/// prefix because the sandbox fence has no /tmp grant (brew uses /tmp).
+const initialiser_map = std.StaticStringMap(enum { postgresql_initdb, mysql_initialize, mariadb_install_db }).initComptime(.{
+    .{ "postgresql_initdb", .postgresql_initdb },
+    .{ "mysql_initialize", .mysql_initialize },
+    .{ "mariadb_install_db", .mariadb_install_db },
+});
+
+fn initDataDirPlan(ctx: StepsCtx, using: []const u8, datadir: []const u8, locale: ?[]const u8) ?InitDataDirPlan {
+    const a = ctx.allocator;
+    const tmpdir = std.fmt.allocPrint(a, "{s}/var/tmp", .{ctx.prefix}) catch return null;
+
+    const mysql_like: struct { exe: []const u8, first: []const u8, marker_rel: []const u8 } =
+        switch (initialiser_map.get(using) orelse return null) {
+            .postgresql_initdb => {
+                var argv = std.ArrayList([]const u8).empty;
+                argv.append(a, std.fmt.allocPrint(a, "{s}/bin/initdb", .{ctx.keg_path}) catch return null) catch return null;
+                argv.append(a, std.fmt.allocPrint(a, "--locale={s}", .{locale orelse "en_US.UTF-8"}) catch return null) catch return null;
+                argv.appendSlice(a, &.{ "-E", "UTF-8", datadir }) catch return null;
+                return .{
+                    .marker = std.fmt.allocPrint(a, "{s}/PG_VERSION", .{datadir}) catch return null,
+                    .argv = argv.items,
+                };
+            },
+            .mysql_initialize => .{ .exe = "mysqld", .first = "--initialize-insecure", .marker_rel = "mysql/general_log.CSM" },
+            .mariadb_install_db => .{ .exe = "mysql_install_db", .first = "--verbose", .marker_rel = "mysql/user.frm" },
+        };
+
+    var argv = std.ArrayList([]const u8).empty;
+    argv.append(a, std.fmt.allocPrint(a, "{s}/bin/{s}", .{ ctx.keg_path, mysql_like.exe }) catch return null) catch return null;
+    argv.append(a, mysql_like.first) catch return null;
+    // `--user` only matters when running as root (mysqld setuids then);
+    // malt installs as the invoking user, so a missing USER is benign.
+    if (std.process.Environ.getPosix(ctx.environ, "USER")) |user|
+        argv.append(a, std.fmt.allocPrint(a, "--user={s}", .{user}) catch return null) catch return null;
+    argv.append(a, std.fmt.allocPrint(a, "--basedir={s}", .{ctx.keg_path}) catch return null) catch return null;
+    argv.append(a, std.fmt.allocPrint(a, "--datadir={s}", .{datadir}) catch return null) catch return null;
+    argv.append(a, std.fmt.allocPrint(a, "--tmpdir={s}", .{tmpdir}) catch return null) catch return null;
+    return .{
+        .marker = std.fmt.allocPrint(a, "{s}/{s}", .{ datadir, mysql_like.marker_rel }) catch return null,
+        .argv = argv.items,
+    };
+}
+
+fn stepInitDataDir(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    const using = getString(obj, "using") orelse {
+        logUnsupported(ctx, "init_data_dir without an initialiser");
+        return false;
+    };
+    const datadir = resolvePathSpec(ctx, obj, "path") orelse return false;
+    if (!confined(ctx, datadir)) return false;
+    const plan = initDataDirPlan(ctx, using, datadir, getString(obj, "locale")) orelse {
+        logUnsupported(ctx, std.fmt.allocPrint(ctx.allocator, "init_data_dir ({s})", .{using}) catch using);
+        return false;
+    };
+    std.Io.Dir.cwd().createDirPath(ctx.io, datadir) catch {};
+    // An initialised data dir is user data — mirror brew's marker guard.
+    if (fileExists(ctx.io, plan.marker)) return true;
+    if (!fileExists(ctx.io, plan.argv[0])) {
+        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} initialiser not found in the keg", .{using}) catch using);
+        return false;
+    }
+    // Never pre-create the marker's parent: the initialisers refuse a
+    // non-empty data dir, and they create their own subtrees.
+    const tmpdir = std.fmt.allocPrint(ctx.allocator, "{s}/var/tmp", .{ctx.prefix}) catch return false;
+    std.Io.Dir.cwd().createDirPath(ctx.io, tmpdir) catch {};
+    return spawnFenced(ctx, plan.argv, null, using);
+}
+
 const GdkPixbufEnv = struct {
     moduledir: []const u8,
     module_file: []const u8,
@@ -476,12 +602,18 @@ fn runFormulaToolEnv(ctx: StepsCtx, tool_formula: []const u8, exe: []const u8, a
     argv.append(ctx.allocator, tool) catch return false;
     argv.appendSlice(ctx.allocator, args) catch return false;
 
-    sandbox.validateArgv(argv.items, ctx.keg_path, ctx.prefix) catch {
-        logViolation(ctx, tool);
+    return spawnFenced(ctx, argv.items, env_map, exe);
+}
+
+/// Argv lint + sandbox fence + spawn + wait — the one exec chokepoint for
+/// every tool and initialiser step. `label` names the child in the log.
+fn spawnFenced(ctx: StepsCtx, argv: []const []const u8, env_map: ?*const std.process.Environ.Map, label: []const u8) bool {
+    sandbox.validateArgv(argv, ctx.keg_path, ctx.prefix) catch {
+        logViolation(ctx, argv[0]);
         return false;
     };
-    const fenced = sandbox.fenceArgv(ctx.allocator, argv.items, ctx.keg_path, ctx.prefix) catch {
-        logViolation(ctx, tool);
+    const fenced = sandbox.fenceArgv(ctx.allocator, argv, ctx.keg_path, ctx.prefix) catch {
+        logViolation(ctx, argv[0]);
         return false;
     };
 
@@ -490,19 +622,19 @@ fn runFormulaToolEnv(ctx: StepsCtx, tool_formula: []const u8, exe: []const u8, a
         .stdout = if (ctx.suppress_child_stdout) .ignore else .inherit,
         .environ_map = env_map,
     }) catch {
-        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} failed to spawn", .{exe}) catch exe);
+        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} failed to spawn", .{label}) catch label);
         return false;
     };
     const term = child.wait(ctx.io) catch {
-        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} did not terminate cleanly", .{exe}) catch exe);
+        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} did not terminate cleanly", .{label}) catch label);
         return false;
     };
     switch (term) {
         .exited => |code| {
             if (code == 0) return true;
-            logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} exited with code {d}", .{ exe, code }) catch exe);
+            logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} exited with code {d}", .{ label, code }) catch label);
         },
-        else => logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} terminated abnormally", .{exe}) catch exe),
+        else => logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} terminated abnormally", .{label}) catch label),
     }
     return false;
 }
@@ -633,6 +765,24 @@ test "expandTemplates substitutes known tokens and leaves unknown verbatim" {
     const hp = try expandTemplates(c, "{{HOMEBREW_PREFIX}}/share");
     try testing.expect(std.mem.startsWith(u8, hp, h.prefix));
     try testing.expectEqualStrings("{{mystery}}", try expandTemplates(c, "{{mystery}}"));
+    // Malformed input stays verbatim rather than corrupting the path.
+    try testing.expectEqualStrings("a{{name", try expandTemplates(c, "a{{name"));
+}
+
+test "versionComponents degrades gracefully on dotless and short versions" {
+    try testing.expectEqualStrings("9", versionComponents("9", 1));
+    try testing.expectEqualStrings("9", versionComponents("9", 2));
+    try testing.expectEqualStrings("2026-07-01", versionComponents("2026-07-01", 1));
+}
+
+test "initDataDirPlan omits --user when USER is absent from the environ" {
+    // The harness environ is empty; --user only matters under root, so a
+    // missing USER must degrade to omission, not a broken argv.
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    const my = initDataDirPlan(h.ctx(), "mysql_initialize", "/p/var/mysql", null) orelse return error.TestUnexpectedResult;
+    for (my.argv) |a| try testing.expect(!std.mem.startsWith(u8, a, "--user="));
 }
 
 test "resolveBase maps every observed upstream token into the malt prefix" {
@@ -779,22 +929,104 @@ test "a step resolving outside the prefix is refused and logged as a sandbox vio
     try testing.expect(!escaped);
 }
 
-test "init_data_dir and unknown step types downgrade to the loud partial skip" {
+test "unknown step types downgrade to the loud partial skip" {
     var h = try TestHarness.init();
     defer h.deinit();
 
     try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
         \\[{"type":"mkdir_p","path":{"base":"var","path":"glow"}},
-        \\ {"type":"init_data_dir","path":{"base":"var","path":"glow"},"using":"postgresql_initdb"},
         \\ {"type":"frobnicate"}]
     )));
     try testing.expect(h.flog.hasErrors());
     try testing.expect(!h.flog.hasFatal());
-    try testing.expectEqual(@as(usize, 2), h.flog.entries().len);
+    try testing.expectEqual(@as(usize, 1), h.flog.entries().len);
     try testing.expectEqual(fallback_log.FallbackReason.unknown_method, h.flog.entries()[0].reason);
     // The supported step still ran and counted as handled.
-    try testing.expectEqual(@as(usize, 3), h.flog.total_top_level);
+    try testing.expectEqual(@as(usize, 2), h.flog.total_top_level);
     try testing.expectEqual(@as(usize, 1), h.flog.handled_top_level);
+}
+
+test "initDataDirPlan builds each initialiser's argv and marker" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const c = h.ctx();
+
+    const pg = initDataDirPlan(c, "postgresql_initdb", "/p/var/postgresql", null) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings("/p/var/postgresql/PG_VERSION", pg.marker);
+    try testing.expect(std.mem.endsWith(u8, pg.argv[0], "/bin/initdb"));
+    try testing.expect(std.mem.startsWith(u8, pg.argv[0], h.keg));
+    try testing.expectEqualStrings("--locale=en_US.UTF-8", pg.argv[1]);
+    try testing.expectEqualStrings("/p/var/postgresql", pg.argv[pg.argv.len - 1]);
+
+    // A step-supplied locale overrides the default.
+    const pg_it = initDataDirPlan(c, "postgresql_initdb", "/p/var/postgresql", "it_IT.UTF-8") orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings("--locale=it_IT.UTF-8", pg_it.argv[1]);
+
+    const my = initDataDirPlan(c, "mysql_initialize", "/p/var/mysql", null) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings("/p/var/mysql/mysql/general_log.CSM", my.marker);
+    try testing.expect(std.mem.endsWith(u8, my.argv[0], "/bin/mysqld"));
+    try testing.expectEqualStrings("--initialize-insecure", my.argv[1]);
+
+    const maria = initDataDirPlan(c, "mariadb_install_db", "/p/var/mysql", null) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings("/p/var/mysql/mysql/user.frm", maria.marker);
+    try testing.expect(std.mem.endsWith(u8, maria.argv[0], "/bin/mysql_install_db"));
+
+    // The confined tmpdir replaces brew's /tmp — the fence has no /tmp grant.
+    var found_tmpdir = false;
+    for (my.argv) |a| {
+        if (std.mem.startsWith(u8, a, "--tmpdir=")) {
+            try testing.expect(std.mem.indexOf(u8, a, h.prefix) != null);
+            found_tmpdir = true;
+        }
+    }
+    try testing.expect(found_tmpdir);
+
+    // Unknown initialisers have no safe plan.
+    try testing.expect(initDataDirPlan(c, "sqlite_seed", "/p/var/x", null) == null);
+}
+
+test "init_data_dir skips initialisation when the marker file exists" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // Marker present → already initialised; the step must count as handled
+    // without spawning anything (no initdb exists in this fixture keg).
+    const datadir = try std.fmt.allocPrint(a, "{s}/var/postgresql", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, datadir);
+    {
+        const f = try std.Io.Dir.createFileAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/PG_VERSION", .{datadir}), .{});
+        f.close(h.io);
+    }
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"init_data_dir","path":{"base":"var","path":"postgresql"},"using":"postgresql_initdb"}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqual(@as(usize, 1), h.flog.handled_top_level);
+}
+
+test "init_data_dir with a missing initialiser binary fails loudly" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"init_data_dir","path":{"base":"var","path":"postgresql"},"using":"postgresql_initdb"}]
+    )));
+    try testing.expect(h.flog.hasErrors());
+    try testing.expectEqual(fallback_log.FallbackReason.system_command_failed, h.flog.entries()[0].reason);
+}
+
+test "init_data_dir with an unknown initialiser downgrades to the partial skip" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"init_data_dir","path":{"base":"var","path":"x"},"using":"sqlite_seed"}]
+    )));
+    try testing.expect(h.flog.hasErrors());
+    try testing.expect(!h.flog.hasFatal());
+    try testing.expectEqual(fallback_log.FallbackReason.unknown_method, h.flog.entries()[0].reason);
 }
 
 test "a missing helper tool is a loud command failure, not a silent skip" {
@@ -818,9 +1050,13 @@ test "allStepsSupported classifies migrated formulas for the doctor probe" {
         \\[{"type":"mkdir_p","path":{"base":"var","path":"glow"}},
         \\ {"type":"gtk_update_icon_cache","path":{"base":"homebrew_prefix","path":"share/icons"}}]
     )));
-    try testing.expect(!allStepsSupported(a, try testFormulaJson(&h,
+    try testing.expect(allStepsSupported(a, try testFormulaJson(&h,
         \\[{"type":"mkdir_p","path":{"base":"var","path":"glow"}},
         \\ {"type":"init_data_dir","path":{"base":"var","path":"glow"},"using":"postgresql_initdb"}]
+    )));
+    try testing.expect(!allStepsSupported(a, try testFormulaJson(&h,
+        \\[{"type":"mkdir_p","path":{"base":"var","path":"glow"}},
+        \\ {"type":"move","source":{"base":"var","path":"a"},"target":{"base":"var","path":"b"}}]
     )));
     // No steps at all → nothing to support.
     try testing.expect(!allStepsSupported(a, try testFormulaJson(&h, "[]")));
@@ -849,8 +1085,9 @@ test "supportedStepType matches the executable tier and rejects the rest" {
         "mkdir_p",                  "touch",                 "write",                     "symlink",
         "link_dir",                 "link_children",         "compile_gsettings_schemas", "gio_querymodules",
         "gdk_pixbuf_query_loaders", "gtk_update_icon_cache", "update_mime_database",      "update_desktop_database",
+        "init_data_dir",
     };
     for (native) |t| try testing.expect(supportedStepType(t));
-    const routed = [_][]const u8{ "init_data_dir", "mkdir", "move", "move_children", "frobnicate" };
+    const routed = [_][]const u8{ "mkdir", "move", "move_children", "frobnicate" };
     for (routed) |t| try testing.expect(!supportedStepType(t));
 }

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -11,6 +11,7 @@
 
 const std = @import("std");
 const sandbox = @import("dsl/sandbox.zig");
+const sandbox_macos = @import("sandbox/macos.zig");
 const fallback_log = @import("dsl/fallback_log.zig");
 
 pub const FallbackLog = fallback_log.FallbackLog;
@@ -130,6 +131,11 @@ pub fn execute(ctx: StepsCtx, formula_json: []const u8) bool {
             },
         };
         if (runStep(ctx, obj)) ctx.flog.handled_top_level += 1;
+        // A confinement violation or hard command failure aborts the rest,
+        // mirroring the Ruby post_install path (a raised step ends the run)
+        // and the DSL interpreter's stop-on-violation. Unknown/unsupported
+        // steps only warn, so they don't abort.
+        if (ctx.flog.hasFatal()) break;
     }
     return true;
 }
@@ -298,10 +304,13 @@ fn resolvePathSpec(ctx: StepsCtx, obj: std.json.ObjectMap, key: []const u8) ?[]c
 
 // --- filesystem tier -------------------------------------------------------
 
-/// Confinement gate shared by every write path: same predicate the DSL FS
-/// builtins use, same fatal routing on refusal.
+/// Confinement gate shared by every write path. Resolves the parent chain
+/// (not just the literal string) so a symlink planted by an earlier step
+/// can't redirect a `mkdir_p`/`write`/`init_data_dir` outside the prefix —
+/// same resolved-boundary guard the DSL `cp`/`mv` builtins use, applied
+/// before any filesystem mutation.
 fn confined(ctx: StepsCtx, path: []const u8) bool {
-    sandbox.validatePath(path, ctx.keg_path, ctx.prefix) catch {
+    sandbox.validateWriteDir(ctx.io, path, ctx.keg_path, ctx.prefix) catch {
         logViolation(ctx, path);
         return false;
     };
@@ -486,21 +495,26 @@ fn initDataDirPlan(ctx: StepsCtx, using: []const u8, datadir: []const u8, locale
     const a = ctx.allocator;
     const tmpdir = std.fmt.allocPrint(a, "{s}/var/tmp", .{ctx.prefix}) catch return null;
 
-    const mysql_like: struct { exe: []const u8, first: []const u8, marker_rel: []const u8 } =
-        switch (initialiser_map.get(using) orelse return null) {
-            .postgresql_initdb => {
-                var argv = std.ArrayList([]const u8).empty;
-                argv.append(a, std.fmt.allocPrint(a, "{s}/bin/initdb", .{ctx.keg_path}) catch return null) catch return null;
-                argv.append(a, std.fmt.allocPrint(a, "--locale={s}", .{locale orelse "en_US.UTF-8"}) catch return null) catch return null;
-                argv.appendSlice(a, &.{ "-E", "UTF-8", datadir }) catch return null;
-                return .{
-                    .marker = std.fmt.allocPrint(a, "{s}/PG_VERSION", .{datadir}) catch return null,
-                    .argv = argv.items,
-                };
-            },
-            .mysql_initialize => .{ .exe = "mysqld", .first = "--initialize-insecure", .marker_rel = "mysql/general_log.CSM" },
-            .mariadb_install_db => .{ .exe = "mysql_install_db", .first = "--verbose", .marker_rel = "mysql/user.frm" },
+    const tag = initialiser_map.get(using) orelse return null;
+
+    // Postgres diverges (locale/encoding argv, top-level marker); handle it
+    // before the shared mysql/mariadb shape below.
+    if (tag == .postgresql_initdb) {
+        var argv = std.ArrayList([]const u8).empty;
+        argv.append(a, std.fmt.allocPrint(a, "{s}/bin/initdb", .{ctx.keg_path}) catch return null) catch return null;
+        argv.append(a, std.fmt.allocPrint(a, "--locale={s}", .{locale orelse "en_US.UTF-8"}) catch return null) catch return null;
+        argv.appendSlice(a, &.{ "-E", "UTF-8", datadir }) catch return null;
+        return .{
+            .marker = std.fmt.allocPrint(a, "{s}/PG_VERSION", .{datadir}) catch return null,
+            .argv = argv.items,
         };
+    }
+
+    const mysql_like: struct { exe: []const u8, first: []const u8, marker_rel: []const u8 } = switch (tag) {
+        .postgresql_initdb => unreachable, // handled above
+        .mysql_initialize => .{ .exe = "mysqld", .first = "--initialize-insecure", .marker_rel = "mysql/general_log.CSM" },
+        .mariadb_install_db => .{ .exe = "mysql_install_db", .first = "--verbose", .marker_rel = "mysql/user.frm" },
+    };
 
     var argv = std.ArrayList([]const u8).empty;
     argv.append(a, std.fmt.allocPrint(a, "{s}/bin/{s}", .{ ctx.keg_path, mysql_like.exe }) catch return null) catch return null;
@@ -529,18 +543,34 @@ fn stepInitDataDir(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
         logUnsupported(ctx, std.fmt.allocPrint(ctx.allocator, "init_data_dir ({s})", .{using}) catch using);
         return false;
     };
-    std.Io.Dir.cwd().createDirPath(ctx.io, datadir) catch {};
-    // An initialised data dir is user data — mirror brew's marker guard.
+    // An initialised (or otherwise pre-populated) data dir is user data —
+    // mirror brew's marker guard. A dir we did not create is never wiped
+    // on failure below, so a partial init from a prior run is preserved
+    // for inspection rather than silently destroyed.
+    const preexisted = fileExists(ctx.io, plan.marker) or dirExists(ctx.io, datadir);
     if (fileExists(ctx.io, plan.marker)) return true;
     if (!fileExists(ctx.io, plan.argv[0])) {
         logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} initialiser not found in the keg", .{using}) catch using);
         return false;
     }
+    std.Io.Dir.cwd().createDirPath(ctx.io, datadir) catch {};
     // Never pre-create the marker's parent: the initialisers refuse a
     // non-empty data dir, and they create their own subtrees.
     const tmpdir = std.fmt.allocPrint(ctx.allocator, "{s}/var/tmp", .{ctx.prefix}) catch return false;
     std.Io.Dir.cwd().createDirPath(ctx.io, tmpdir) catch {};
-    return spawnFenced(ctx, plan.argv, null, using);
+    if (spawnFenced(ctx, plan.argv, null, using, .{ .allow_ipc = true })) return true;
+    // A failed initialiser can leave a partial data dir; mysql/mariadb
+    // then refuse the non-empty dir on every retry. Remove what this run
+    // created so the next install/upgrade starts clean. postgres already
+    // self-cleans, so this is a no-op there.
+    if (!preexisted) std.Io.Dir.cwd().deleteTree(ctx.io, datadir) catch {};
+    return false;
+}
+
+fn dirExists(io: std.Io, path: []const u8) bool {
+    var dir = std.Io.Dir.openDirAbsolute(io, path, .{}) catch return false;
+    dir.close(io);
+    return true;
 }
 
 const GdkPixbufEnv = struct {
@@ -602,17 +632,18 @@ fn runFormulaToolEnv(ctx: StepsCtx, tool_formula: []const u8, exe: []const u8, a
     argv.append(ctx.allocator, tool) catch return false;
     argv.appendSlice(ctx.allocator, args) catch return false;
 
-    return spawnFenced(ctx, argv.items, env_map, exe);
+    return spawnFenced(ctx, argv.items, env_map, exe, .{});
 }
 
 /// Argv lint + sandbox fence + spawn + wait — the one exec chokepoint for
 /// every tool and initialiser step. `label` names the child in the log.
-fn spawnFenced(ctx: StepsCtx, argv: []const []const u8, env_map: ?*const std.process.Environ.Map, label: []const u8) bool {
+/// `opts` carries per-spawn fence knobs (IPC only for the DB initialisers).
+fn spawnFenced(ctx: StepsCtx, argv: []const []const u8, env_map: ?*const std.process.Environ.Map, label: []const u8, opts: sandbox_macos.ProfileOpts) bool {
     sandbox.validateArgv(argv, ctx.keg_path, ctx.prefix) catch {
         logViolation(ctx, argv[0]);
         return false;
     };
-    const fenced = sandbox.fenceArgv(ctx.allocator, argv, ctx.keg_path, ctx.prefix) catch {
+    const fenced = sandbox.fenceArgv(ctx.allocator, argv, ctx.keg_path, ctx.prefix, opts) catch {
         logViolation(ctx, argv[0]);
         return false;
     };
@@ -914,6 +945,39 @@ test "write respects existing files unless overwrite is set" {
     try testing.expect(!h.flog.hasErrors());
 }
 
+test "a planted directory symlink cannot redirect a later step outside the prefix" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+    const io = h.io;
+
+    // A genuinely-outside writable location: a SIBLING of the prefix, so
+    // the component-boundary prefix check does not treat it as contained.
+    const outside = try std.fmt.allocPrint(a, "{s}-OUTSIDE", .{h.prefix});
+    std.Io.Dir.cwd().deleteTree(io, outside) catch {};
+    try std.Io.Dir.cwd().createDirPath(io, outside);
+    defer std.Io.Dir.cwd().deleteTree(io, outside) catch {};
+
+    // Step 1 plants <prefix>/etc/la -> <outside>; step 2 tries to mkdir_p
+    // and write *through* that symlink. Every mutating step must resolve
+    // the parent chain and refuse, so nothing lands under <outside>.
+    const json = try std.fmt.allocPrint(a,
+        \\{{"name":"glow","versions":{{"stable":"1.2.3"}},"post_install_defined":false,"post_install_steps":[
+        \\ {{"type":"symlink","force":true,"source":{{"base":"absolute","path":"{s}"}},"target":{{"base":"etc","path":"la"}}}},
+        \\ {{"type":"mkdir_p","path":{{"base":"etc","path":"la/sub"}}}},
+        \\ {{"type":"write","path":{{"base":"etc","path":"la/pwned"}},"content":"x"}}]}}
+    , .{outside});
+    try testing.expect(execute(h.ctx(), json));
+
+    // The escape must have left nothing behind outside the prefix.
+    const leaked_dir = try std.fmt.allocPrint(a, "{s}/sub", .{outside});
+    const leaked_file = try std.fmt.allocPrint(a, "{s}/pwned", .{outside});
+    try testing.expect(std.Io.Dir.openDirAbsolute(io, leaked_dir, .{}) == error.FileNotFound);
+    try testing.expect(std.Io.Dir.openFileAbsolute(io, leaked_file, .{}) == error.FileNotFound);
+    // And the redirect steps were refused as violations, not counted handled.
+    try testing.expect(h.flog.hasFatal());
+}
+
 test "a step resolving outside the prefix is refused and logged as a sandbox violation" {
     var h = try TestHarness.init();
     defer h.deinit();
@@ -1006,6 +1070,62 @@ test "init_data_dir skips initialisation when the marker file exists" {
     try testing.expectEqual(@as(usize, 1), h.flog.handled_top_level);
 }
 
+test "a confinement violation aborts the remaining steps like the DSL interpreter" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"mkdir_p","path":{"base":"absolute","path":"/tmp/malt_steps_escape_abort"}},
+        \\ {"type":"mkdir_p","path":{"base":"var","path":"after-violation"}}]
+    )));
+    try testing.expect(h.flog.hasFatal());
+    // The step after the violation must never have run.
+    const after = try std.fmt.allocPrint(a, "{s}/var/after-violation", .{h.prefix});
+    var ran_after = true;
+    _ = std.Io.Dir.openDirAbsolute(h.io, after, .{}) catch {
+        ran_after = false;
+    };
+    try testing.expect(!ran_after);
+    try testing.expectEqual(@as(usize, 1), h.flog.total_top_level);
+}
+
+test "init_data_dir removes a datadir it created when the initialiser fails" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+    const io = h.io;
+
+    // An initialiser that runs and exits non-zero: symlink to /usr/bin/false.
+    const keg_bin = try std.fmt.allocPrint(a, "{s}/bin", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(io, keg_bin);
+    try std.Io.Dir.symLinkAbsolute(io, "/usr/bin/false", try std.fmt.allocPrint(a, "{s}/mysqld", .{keg_bin}), .{});
+
+    const step_json = try testFormulaJson(&h,
+        \\[{"type":"init_data_dir","path":{"base":"var","path":"mysql"},"using":"mysql_initialize"}]
+    );
+    try testing.expect(execute(h.ctx(), step_json));
+    try testing.expect(h.flog.hasErrors());
+    // The datadir this run created must be gone so a retry starts clean —
+    // mysqld refuses a non-empty datadir, so leftovers brick every retry.
+    const datadir = try std.fmt.allocPrint(a, "{s}/var/mysql", .{h.prefix});
+    var still_there = true;
+    _ = std.Io.Dir.openDirAbsolute(io, datadir, .{}) catch {
+        still_there = false;
+    };
+    try testing.expect(!still_there);
+
+    // A pre-existing datadir is user data: a failed re-run must not touch it.
+    try std.Io.Dir.cwd().createDirPath(io, datadir);
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, try std.fmt.allocPrint(a, "{s}/precious", .{datadir}), .{});
+        f.close(io);
+    }
+    try testing.expect(execute(h.ctx(), step_json));
+    const f = std.Io.Dir.openFileAbsolute(io, try std.fmt.allocPrint(a, "{s}/precious", .{datadir}), .{}) catch return error.TestUnexpectedResult;
+    f.close(io);
+}
+
 test "init_data_dir with a missing initialiser binary fails loudly" {
     var h = try TestHarness.init();
     defer h.deinit();
@@ -1078,6 +1198,61 @@ test "gdkPixbufEnvPaths derives the malt-prefix module dir and cache file" {
     const want_file = try std.fmt.allocPrint(a, "{s}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache", .{h.prefix});
     try testing.expectEqualStrings(want_dir, env.moduledir);
     try testing.expectEqualStrings(want_file, env.module_file);
+}
+
+test "gtk_update_icon_cache picks the gtk4 tool when present, else falls back to gtk+3" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+
+    // No gtk4 keg → the gtk+3 branch is chosen; the missing-tool failure
+    // names the gtk3 binary, pinning the fallback selection.
+    const step_json = try testFormulaJson(&h,
+        \\[{"type":"gtk_update_icon_cache","path":{"base":"homebrew_prefix","path":"share/icons/hicolor"}}]
+    );
+    try testing.expect(execute(h.ctx(), step_json));
+    try testing.expect(std.mem.indexOf(u8, h.flog.entries()[0].detail, "gtk3-update-icon-cache") != null);
+
+    // A gtk4 probe file flips the selection; the failure now names the
+    // gtk4 binary (present but not executable in this fixture).
+    const gtk4_bin = try std.fmt.allocPrint(a, "{s}/opt/gtk4/bin", .{h.prefix});
+    try std.Io.Dir.cwd().createDirPath(h.io, gtk4_bin);
+    {
+        const f = try std.Io.Dir.createFileAbsolute(h.io, try std.fmt.allocPrint(a, "{s}/gtk4-update-icon-cache", .{gtk4_bin}), .{});
+        f.close(h.io);
+    }
+    try testing.expect(execute(h.ctx(), step_json));
+    const last = h.flog.entries()[h.flog.entries().len - 1];
+    try testing.expect(std.mem.indexOf(u8, last.detail, "gtk4-update-icon-cache") != null);
+}
+
+test "link_children honours the link-name prefix and treats a missing source as a no-op" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const a = h.arena.allocator();
+    const io = h.io;
+
+    const share = try std.fmt.allocPrint(a, "{s}/share/glow", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(io, share);
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, try std.fmt.allocPrint(a, "{s}/tool", .{share}), .{});
+        f.close(io);
+    }
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"link_children","source":{"base":"prefix","path":"share/glow"},"target":{"base":"homebrew_prefix","path":"bin"},"prefix":"{{name}}-"}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+    const linked = try std.fmt.allocPrint(a, "{s}/bin/glow-tool", .{h.prefix});
+    const f = std.Io.Dir.openFileAbsolute(io, linked, .{}) catch return error.TestUnexpectedResult;
+    f.close(io);
+
+    // Missing source dir: counted as handled with nothing created — the
+    // upstream runner iterates zero children the same way.
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"link_children","source":{"base":"prefix","path":"share/ghost"},"target":{"base":"homebrew_prefix","path":"bin"}}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
 }
 
 test "supportedStepType matches the executable tier and rejects the rest" {

--- a/src/core/ruby/source.zig
+++ b/src/core/ruby/source.zig
@@ -259,6 +259,38 @@ fn findMatchingEnd(source: []const u8, start: usize, indent: usize) ?struct {
     return null;
 }
 
+/// True when the source declares a declarative `post_install_steps do`
+/// block. Detection only — the steps grammar (keyword args, symbols) is
+/// outside the DSL, so callers surface a loud skip instead of extracting
+/// a body from it.
+pub fn hasPostInstallStepsBlock(source: []const u8) bool {
+    var it = std.mem.splitScalar(u8, source, '\n');
+    while (it.next()) |line| {
+        const t = std.mem.trim(u8, line, " \t\r");
+        const marker = "post_install_steps";
+        if (!std.mem.startsWith(u8, t, marker)) continue;
+        // Word boundary: `post_install_steps` then whitespace (`do` follows).
+        if (t.len > marker.len and (t[marker.len] == ' ' or t[marker.len] == '\t')) return true;
+    }
+    return false;
+}
+
+/// File-IO twin of `hasPostInstallStepsBlock`, mirroring
+/// `extractPostInstallBody`'s read contract. False on any IO failure —
+/// the caller only uses it to decide whether a skip deserves a warning.
+pub fn rbHasPostInstallSteps(io: std.Io, allocator: std.mem.Allocator, rb_path: []const u8) bool {
+    const file = std.Io.Dir.openFileAbsolute(io, rb_path, .{}) catch return false;
+    defer file.close(io);
+
+    const st = file.stat(io) catch return false;
+    const size: usize = @intCast(@min(@as(u64, max_formula_rb_bytes), st.size));
+    const source = allocator.alloc(u8, size) catch return false;
+    defer allocator.free(source);
+    const n = file.readPositionalAll(io, source, 0) catch return false;
+
+    return hasPostInstallStepsBlock(source[0..n]);
+}
+
 /// Extract the post_install method body + sibling helpers from a formula
 /// .rb source file. Thin file-IO wrapper around `extractPostInstallFromSource`
 /// so the parsing contract lives in one place.
@@ -450,6 +482,53 @@ test "extractPostInstallBody captures the body between def post_install and matc
     defer testing.allocator.free(body.?);
     try testing.expect(std.mem.indexOf(u8, body.?, "mkdir_p \"etc/hello\"") != null);
     try testing.expect(std.mem.indexOf(u8, body.?, "touch \"etc/hello/config\"") != null);
+}
+
+test "hasPostInstallStepsBlock detects a declarative steps block" {
+    // Steps-migrated formulas have no `def post_install`; detection is what
+    // lets the tap arm warn instead of silently dropping the hook.
+    try testing.expect(hasPostInstallStepsBlock(
+        \\class Glow < Formula
+        \\  post_install_steps do
+        \\    gdk_pixbuf_query_loaders
+        \\  end
+        \\end
+        \\
+    ));
+    try testing.expect(!hasPostInstallStepsBlock(
+        \\class Old < Formula
+        \\  def post_install
+        \\    ohai "hi"
+        \\  end
+        \\end
+        \\
+    ));
+    // Commented-out blocks and prefix-sharing identifiers must not count.
+    try testing.expect(!hasPostInstallStepsBlock("  # post_install_steps do\n"));
+    try testing.expect(!hasPostInstallStepsBlock("post_install_steps_helper do\n"));
+}
+
+test "rbHasPostInstallSteps reads the block from a formula .rb on disk" {
+    const io = testIo();
+    const tap = try uniqueDir(io, "steps_only");
+    defer testing.allocator.free(tap);
+    defer std.Io.Dir.cwd().deleteTree(io, tap) catch {};
+    const rb = try std.fmt.allocPrint(testing.allocator, "{s}/glow.rb", .{tap});
+    defer testing.allocator.free(rb);
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, rb, .{});
+        try f.writeStreamingAll(io,
+            \\class Glow < Formula
+            \\  post_install_steps do
+            \\    gdk_pixbuf_query_loaders
+            \\  end
+            \\end
+            \\
+        );
+        f.close(io);
+    }
+    try testing.expect(rbHasPostInstallSteps(io, testing.allocator, rb));
+    try testing.expect(!rbHasPostInstallSteps(io, testing.allocator, "/tmp/malt_ruby_missing_xyz.rb"));
 }
 
 test "fetchPostInstallFromGitHub returns null for an empty name" {

--- a/src/core/ruby_subprocess.zig
+++ b/src/core/ruby_subprocess.zig
@@ -21,6 +21,7 @@ pub const findHomebrewCoreTap = detect.findHomebrewCoreTap;
 pub const resolveFormulaRbPath = detect.resolveFormulaRbPath;
 pub const extractPostInstallBody = source.extractPostInstallBody;
 pub const extractPostInstallFromSource = source.extractPostInstallFromSource;
+pub const rbHasPostInstallSteps = source.rbHasPostInstallSteps;
 pub const fetchPostInstallFromGitHub = source.fetchPostInstallFromGitHub;
 
 pub const RubyError = error{

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -117,7 +117,9 @@ fn writeCellarRule(w: *std.Io.Writer, root: []const u8) !void {
 }
 
 fn writePrefixRules(w: *std.Io.Writer, prefix: []const u8) !void {
-    for ([_][]const u8{ "etc", "var", "share", "opt" }) |sub|
+    // lib carries prefix-level caches the declarative install steps
+    // regenerate (gdk-pixbuf loaders.cache, gio module cache).
+    for ([_][]const u8{ "etc", "var", "share", "opt", "lib" }) |sub|
         try w.print("\n  (subpath \"{s}/{s}\")", .{ prefix, sub });
 }
 
@@ -494,6 +496,10 @@ test "renderRubyProfile emits deny-default + cellar + prefix subpaths" {
     try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/etc\")") != null);
     try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/var\")") != null);
     try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/opt\")") != null);
+    // Declarative install steps write prefix-level caches under lib/
+    // (gdk-pixbuf loaders.cache, gio module cache) — same trust level as
+    // the other prefix subtrees.
+    try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/lib\")") != null);
 }
 
 // The kernel matches subpath filters against resolved vnode paths, so a

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -80,6 +80,12 @@ pub fn renderRubyProfile(
         \\(allow sysctl-read)
         \\(allow mach-lookup)
         \\(allow iokit-open)
+        // Database initialisers (postgres bootstrap) allocate SysV/POSIX
+        // shared memory and SysV semaphores; without these grants initdb
+        // dies in shmget/semctl.
+        \\(allow ipc-sysv-shm)
+        \\(allow ipc-sysv-sem)
+        \\(allow ipc-posix-shm)
         \\(allow file-read*)
         \\(deny network*)
         \\(allow file-write-data
@@ -500,6 +506,11 @@ test "renderRubyProfile emits deny-default + cellar + prefix subpaths" {
     // (gdk-pixbuf loaders.cache, gio module cache) — same trust level as
     // the other prefix subtrees.
     try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/lib\")") != null);
+    // Database initialisers (postgres bootstrap) allocate SysV/POSIX
+    // shared memory; without the grant initdb dies in shmget.
+    try std.testing.expect(std.mem.indexOf(u8, profile, "(allow ipc-sysv-shm)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, profile, "(allow ipc-posix-shm)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, profile, "(allow ipc-sysv-sem)") != null);
 }
 
 // The kernel matches subpath filters against resolved vnode paths, so a

--- a/src/core/sandbox/macos.zig
+++ b/src/core/sandbox/macos.zig
@@ -58,12 +58,19 @@ pub fn validatePathForProfile(p: []const u8) SandboxError!void {
     };
 }
 
+/// Per-spawn profile knobs. `allow_ipc` is opt-in for the database
+/// initialisers only — every other fenced child stays IPC-free.
+pub const ProfileOpts = struct {
+    allow_ipc: bool = false,
+};
+
 /// Render the deny-by-default SCL profile; writes limited to `cellar_path`
-/// and four subtrees of `malt_prefix`. Caller owns the slice.
+/// and a fixed set of `malt_prefix` subtrees. Caller owns the slice.
 pub fn renderRubyProfile(
     allocator: std.mem.Allocator,
     cellar_path: []const u8,
     malt_prefix: []const u8,
+    opts: ProfileOpts,
 ) SandboxError![]const u8 {
     try validatePathForProfile(cellar_path);
     try validatePathForProfile(malt_prefix);
@@ -80,12 +87,6 @@ pub fn renderRubyProfile(
         \\(allow sysctl-read)
         \\(allow mach-lookup)
         \\(allow iokit-open)
-        // Database initialisers (postgres bootstrap) allocate SysV/POSIX
-        // shared memory and SysV semaphores; without these grants initdb
-        // dies in shmget/semctl.
-        \\(allow ipc-sysv-shm)
-        \\(allow ipc-sysv-sem)
-        \\(allow ipc-posix-shm)
         \\(allow file-read*)
         \\(deny network*)
         \\(allow file-write-data
@@ -96,6 +97,19 @@ pub fn renderRubyProfile(
         \\
     ;
     buf.appendSlice(allocator, header) catch return SandboxError.ProfileBuildFailed;
+
+    // Database initialisers (postgres bootstrap) allocate SysV/POSIX shared
+    // memory + SysV semaphores; without these grants initdb dies in
+    // shmget/semctl. Scoped to `init_data_dir` so no other fenced child
+    // (DSL system, cache-regen tools, Ruby fallback) gets IPC access.
+    if (opts.allow_ipc) {
+        buf.appendSlice(allocator,
+            \\(allow ipc-sysv-shm)
+            \\(allow ipc-sysv-sem)
+            \\(allow ipc-posix-shm)
+            \\
+        ) catch return SandboxError.ProfileBuildFailed;
+    }
 
     var aw: std.Io.Writer.Allocating = .fromArrayList(allocator, &buf);
     const w = &aw.writer;
@@ -123,9 +137,10 @@ fn writeCellarRule(w: *std.Io.Writer, root: []const u8) !void {
 }
 
 fn writePrefixRules(w: *std.Io.Writer, prefix: []const u8) !void {
-    // lib carries prefix-level caches the declarative install steps
-    // regenerate (gdk-pixbuf loaders.cache, gio module cache).
-    for ([_][]const u8{ "etc", "var", "share", "opt", "lib" }) |sub|
+    // `<prefix>/lib` is the cross-formula symlink farm — granting all of it
+    // would let one formula's post-install overwrite another's dylib. The
+    // cache-regen steps only touch two subtrees, so grant just those.
+    for ([_][]const u8{ "etc", "var", "share", "opt", "lib/gdk-pixbuf-2.0", "lib/gio" }) |sub|
         try w.print("\n  (subpath \"{s}/{s}\")", .{ prefix, sub });
 }
 
@@ -249,7 +264,7 @@ pub fn runRubySandboxed(
 ) SandboxError!u8 {
     if (builtin.os.tag != .macos) return SandboxError.SandboxUnsupported;
 
-    const profile = try renderRubyProfile(allocator, cellar_path, malt_prefix);
+    const profile = try renderRubyProfile(allocator, cellar_path, malt_prefix, .{});
     defer allocator.free(profile);
 
     const argv = [_][]const u8{
@@ -494,6 +509,7 @@ test "renderRubyProfile emits deny-default + cellar + prefix subpaths" {
         std.testing.allocator,
         "/opt/malt/Cellar/foo/1.0",
         "/opt/malt",
+        .{},
     );
     defer std.testing.allocator.free(profile);
     try std.testing.expect(std.mem.indexOf(u8, profile, "(deny default)") != null);
@@ -502,12 +518,24 @@ test "renderRubyProfile emits deny-default + cellar + prefix subpaths" {
     try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/etc\")") != null);
     try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/var\")") != null);
     try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/opt\")") != null);
-    // Declarative install steps write prefix-level caches under lib/
-    // (gdk-pixbuf loaders.cache, gio module cache) — same trust level as
-    // the other prefix subtrees.
-    try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/lib\")") != null);
-    // Database initialisers (postgres bootstrap) allocate SysV/POSIX
-    // shared memory; without the grant initdb dies in shmget.
+    // Cache-regen steps write only two lib subtrees; the whole `lib` farm
+    // must NOT be granted (cross-formula dylib overwrite surface).
+    try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/lib/gdk-pixbuf-2.0\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/lib/gio\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/lib\")\n") == null);
+    // IPC is opt-in: the default profile must NOT grant it.
+    try std.testing.expect(std.mem.indexOf(u8, profile, "ipc-sysv-shm") == null);
+}
+
+test "renderRubyProfile grants IPC only when allow_ipc is set" {
+    const profile = try renderRubyProfile(
+        std.testing.allocator,
+        "/opt/malt/Cellar/foo/1.0",
+        "/opt/malt",
+        .{ .allow_ipc = true },
+    );
+    defer std.testing.allocator.free(profile);
+    // The database initialisers need SysV/POSIX shm + SysV sem.
     try std.testing.expect(std.mem.indexOf(u8, profile, "(allow ipc-sysv-shm)") != null);
     try std.testing.expect(std.mem.indexOf(u8, profile, "(allow ipc-posix-shm)") != null);
     try std.testing.expect(std.mem.indexOf(u8, profile, "(allow ipc-sysv-sem)") != null);
@@ -525,6 +553,7 @@ test "renderRubyProfile also grants writes under the resolved roots for symlinke
         // Does not exist on disk — must fall back to the literal alone.
         "/tmp/malt_sbx_profile_test/Cellar/foo/1.0",
         "/tmp/malt_sbx_profile_test",
+        .{},
     );
     defer std.testing.allocator.free(profile);
 
@@ -541,6 +570,7 @@ test "renderRubyProfile does not duplicate rules for already-resolved roots" {
         std.testing.allocator,
         "/opt/malt/Cellar/foo/1.0",
         "/opt/malt",
+        .{},
     );
     defer std.testing.allocator.free(profile);
     try std.testing.expectEqual(
@@ -552,6 +582,6 @@ test "renderRubyProfile does not duplicate rules for already-resolved roots" {
 test "renderRubyProfile rejects unsafe cellar path" {
     try std.testing.expectError(
         SandboxError.UnsafePath,
-        renderRubyProfile(std.testing.allocator, "/opt/malt\"/evil", "/opt/malt"),
+        renderRubyProfile(std.testing.allocator, "/opt/malt\"/evil", "/opt/malt", .{}),
     );
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -64,6 +64,7 @@ pub const linker = @import("core/linker.zig");
 pub const patch = @import("core/patch.zig");
 pub const perms = @import("core/perms.zig");
 pub const pins = @import("core/pins.zig");
+pub const post_install_steps = @import("core/post_install_steps.zig");
 pub const relocated_store = @import("core/relocated_store.zig");
 pub const ruby_subprocess = @import("core/ruby_subprocess.zig");
 pub const sandbox_macos = @import("core/sandbox/macos.zig");

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -241,3 +241,21 @@ test "help completions offer command topics across every shell" {
     try expectContains(completions.zsh_script, "help)");
     try expectContains(completions.fish_script, "__malt_using_command help");
 }
+
+test "all install, migrate, and upgrade completions expose --use-system-ruby" {
+    // The scoped Ruby fallback exists on all three commands; each shell
+    // must offer it wherever the command accepts it.
+    try expectContains(completions.bash_script, "--use-system-ruby=");
+    try expectContains(completions.zsh_script, "--use-system-ruby=");
+    try expectContains(completions.fish_script, "-l use-system-ruby");
+    inline for (.{ completions.bash_script, completions.zsh_script, completions.fish_script }) |script| {
+        var count: usize = 0;
+        var pos: usize = 0;
+        while (std.mem.indexOfPos(u8, script, pos, "use-system-ruby")) |i| {
+            count += 1;
+            pos = i + 1;
+        }
+        // install + migrate + upgrade, once per command minimum.
+        try std.testing.expect(count >= 3);
+    }
+}

--- a/tests/install_pool_test.zig
+++ b/tests/install_pool_test.zig
@@ -85,7 +85,7 @@ fn makeJob(name: []const u8, version: []const u8, sha: []const u8) malt.install_
         .bottle_url = "",
         .is_dep = false,
         .keg_only = false,
-        .post_install_defined = false,
+        .wants_post_install = false,
         .formula_json = "",
         .cellar_type = ":any",
         .label_width = 0,

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -1786,3 +1786,103 @@ test "invariant: defer fires on labelled break (FallbackLog no-leak)" {
     }
     try testing.expect(!leaked);
 }
+
+// ---------------------------------------------------------------------------
+// driveSteps — the native executor for formulas migrated to the declarative
+// `post_install_steps` array. The wiring contract: a steps formula is fully
+// handled here (executed + routed through the shared envelope), a stepless
+// formula falls through to the Ruby-DSL body path untouched.
+// ---------------------------------------------------------------------------
+
+fn runDriveSteps(
+    formula_json: []const u8,
+    prefix: []const u8,
+) !struct { handled: bool, out: []u8 } {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(testing.allocator);
+
+    color_mod.setForTest(false, false);
+    defer color_mod.setForTest(null, null);
+    const prior_quiet = output_mod.isQuiet();
+    output_mod.setQuiet(false);
+    defer output_mod.setQuiet(prior_quiet);
+
+    io_mod.beginStderrCapture(testing.allocator, &buf);
+    defer io_mod.endStderrCapture();
+
+    const dn = try devnullCtx();
+    defer closeDevnullCtx(dn.fd);
+
+    const handled = install_post_install.driveSteps(
+        &dn.ctx,
+        testing.allocator,
+        "glow",
+        "1.2.3",
+        formula_json,
+        prefix,
+        &.{},
+        null,
+        install_sink.terminal,
+    );
+    return .{ .handled = handled, .out = try buf.toOwnedSlice(testing.allocator) };
+}
+
+test "driveSteps executes a steps-migrated formula and routes 'completed'" {
+    const io = malt.app_ctx.debug_ctx.io;
+    var rand: [8]u8 = undefined;
+    io.random(&rand);
+    const hex = std.fmt.bytesToHex(rand, .lower);
+    const prefix = try std.fmt.allocPrint(testing.allocator, "/tmp/malt_drivesteps_{s}", .{hex[0..]});
+    defer testing.allocator.free(prefix);
+    try std.Io.Dir.cwd().createDirPath(io, prefix);
+    defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+
+    const json =
+        \\{"name":"glow","versions":{"stable":"1.2.3"},"post_install_defined":false,
+        \\ "post_install_steps":[{"type":"mkdir_p","path":{"base":"var","path":"log/glow"}}]}
+    ;
+    const r = try runDriveSteps(json, prefix);
+    defer testing.allocator.free(r.out);
+
+    try testing.expect(r.handled);
+    try testing.expect(std.mem.indexOf(u8, r.out, "post_install completed for glow") != null);
+
+    const made = try std.fmt.allocPrint(testing.allocator, "{s}/var/log/glow", .{prefix});
+    defer testing.allocator.free(made);
+    var dir = std.Io.Dir.openDirAbsolute(io, made, .{}) catch return error.TestUnexpectedResult;
+    dir.close(io);
+}
+
+test "driveSteps ignores formulas without steps so the Ruby body path still owns them" {
+    const json =
+        \\{"name":"glow","versions":{"stable":"1.2.3"},"post_install_defined":true,
+        \\ "post_install_steps":[]}
+    ;
+    const r = try runDriveSteps(json, "/tmp/malt_drivesteps_unused");
+    defer testing.allocator.free(r.out);
+
+    try testing.expect(!r.handled);
+    try testing.expectEqual(@as(usize, 0), r.out.len);
+}
+
+test "driveSteps routes unsupported step types to the loud partial skip" {
+    const io = malt.app_ctx.debug_ctx.io;
+    var rand: [8]u8 = undefined;
+    io.random(&rand);
+    const hex = std.fmt.bytesToHex(rand, .lower);
+    const prefix = try std.fmt.allocPrint(testing.allocator, "/tmp/malt_drivesteps_{s}", .{hex[0..]});
+    defer testing.allocator.free(prefix);
+    try std.Io.Dir.cwd().createDirPath(io, prefix);
+    defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
+
+    const json =
+        \\{"name":"glow","versions":{"stable":"1.2.3"},"post_install_defined":false,
+        \\ "post_install_steps":[{"type":"init_data_dir","path":{"base":"var","path":"glow"},"using":"postgresql_initdb"}]}
+    ;
+    const r = try runDriveSteps(json, prefix);
+    defer testing.allocator.free(r.out);
+
+    try testing.expect(r.handled);
+    try testing.expect(std.mem.indexOf(u8, r.out, "partially skipped") != null);
+    try testing.expect(std.mem.indexOf(u8, r.out, "--use-system-ruby") != null);
+}

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -1875,9 +1875,11 @@ test "driveSteps routes unsupported step types to the loud partial skip" {
     try std.Io.Dir.cwd().createDirPath(io, prefix);
     defer std.Io.Dir.cwd().deleteTree(io, prefix) catch {};
 
+    // `move` is defined upstream but has no native runner yet — the
+    // canonical "known-shape, unsupported" case.
     const json =
         \\{"name":"glow","versions":{"stable":"1.2.3"},"post_install_defined":false,
-        \\ "post_install_steps":[{"type":"init_data_dir","path":{"base":"var","path":"glow"},"using":"postgresql_initdb"}]}
+        \\ "post_install_steps":[{"type":"move","source":{"base":"var","path":"a"},"target":{"base":"var","path":"b"}}]}
     ;
     const r = try runDriveSteps(json, prefix);
     defer testing.allocator.free(r.out);

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -119,7 +119,7 @@ test "collectFormulaJobs queues a formula with a post_install hook" {
     // post_install after materialisation, so the guard no longer rejects.
     try testing.expectEqual(@as(usize, 1), jobs.items.len);
     try testing.expectEqualStrings("needs-ruby", jobs.items[0].name);
-    try testing.expect(jobs.items[0].post_install_defined);
+    try testing.expect(jobs.items[0].wants_post_install);
 }
 
 // --- Pure helper tests (no DB / network) ---
@@ -864,7 +864,7 @@ fn appendOwnedJob(
         .bottle_url = try alloc.dupe(u8, "https://x"),
         .is_dep = is_dep,
         .keg_only = false,
-        .post_install_defined = false,
+        .wants_post_install = false,
         .formula_json = formula_json,
         .cellar_type = try alloc.dupe(u8, ":any"),
         .label_width = 0,

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -77,6 +77,55 @@ fn testArena() std.heap.ArenaAllocator {
     return std.heap.ArenaAllocator.init(testing.allocator);
 }
 
+test "collectFormulaJobs queues a steps-migrated formula despite post_install_defined false" {
+    // The reproduction shape of the silent-skip bug: migrated formulas
+    // report post_install_defined=false and carry the hook only in the
+    // declarative steps array — the gate must still open.
+    var arena = testArena();
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tdb = try TempDb.init("postinstall_steps_accept");
+    defer tdb.deinit();
+
+    const json = "{\"name\":\"glowsteps\",\"full_name\":\"glowsteps\",\"tap\":\"homebrew/core\"," ++
+        "\"desc\":\"\",\"homepage\":\"\",\"revision\":0,\"keg_only\":false," ++
+        "\"post_install_defined\":false," ++
+        "\"post_install_steps\":[{\"type\":\"mkdir_p\",\"path\":{\"base\":\"var\",\"path\":\"glowsteps\"}}]," ++
+        "\"versions\":{\"stable\":\"1.0\"},\"dependencies\":[],\"oldnames\":[]," ++
+        "\"bottle\":{\"stable\":{\"root_url\":\"https://ghcr.io/v2/homebrew/core/glowsteps/blobs\"," ++
+        "\"files\":{\"all\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/glowsteps\",\"sha256\":\"deadbeef\"}}}}}";
+
+    const cache_dir = "/tmp/malt_install_test_postinstall_steps_cache";
+    test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
+
+    var http = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
+    defer http.deinit();
+    var real_http = malt.client.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, alloc);
+    defer real_http.deinit();
+    var api = malt.api.BrewApi.init(std.Options.debug_io, alloc, &real_http, cache_dir);
+
+    var store_inst: malt.store.Store = undefined;
+
+    var jobs: std.ArrayList(install_download.DownloadJob) = .empty;
+    defer jobs.deinit(alloc);
+
+    var cache = malt.deps.FormulaCache.init(alloc);
+    defer cache.deinit();
+
+    try install_download.collectFormulaJobs(
+        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache, .worker_backing = alloc },
+        "glowsteps",
+        json,
+        false,
+        &jobs,
+    );
+
+    try testing.expectEqual(@as(usize, 1), jobs.items.len);
+    try testing.expect(jobs.items[0].wants_post_install);
+}
+
 test "collectFormulaJobs queues a formula with a post_install hook" {
     var arena = testArena();
     defer arena.deinit();

--- a/tests/sandbox_macos_test.zig
+++ b/tests/sandbox_macos_test.zig
@@ -47,6 +47,7 @@ test "renderRubyProfile deny-by-default, network denied, cellar + prefix subpath
     try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/var\")") != null);
     try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/share\")") != null);
     try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/opt\")") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/lib\")") != null);
 }
 
 test "renderRubyProfile refuses unsafe cellar path" {

--- a/tests/sandbox_macos_test.zig
+++ b/tests/sandbox_macos_test.zig
@@ -37,6 +37,7 @@ test "renderRubyProfile deny-by-default, network denied, cellar + prefix subpath
         testing.allocator,
         "/opt/malt/Cellar/foo/1.0",
         "/opt/malt",
+        .{},
     );
     defer testing.allocator.free(profile);
     try testing.expect(std.mem.indexOf(u8, profile, "(deny default)") != null);
@@ -47,7 +48,22 @@ test "renderRubyProfile deny-by-default, network denied, cellar + prefix subpath
     try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/var\")") != null);
     try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/share\")") != null);
     try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/opt\")") != null);
-    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/lib\")") != null);
+    // lib is granted only at the two cache subtrees, never the whole farm.
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/lib/gdk-pixbuf-2.0\")") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/lib/gio\")") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/lib\")\n") == null);
+    // IPC is opt-in; the default profile omits it.
+    try testing.expect(std.mem.indexOf(u8, profile, "ipc-sysv-shm") == null);
+}
+
+test "renderRubyProfile grants IPC only under allow_ipc" {
+    const profile = try sandbox.renderRubyProfile(
+        testing.allocator,
+        "/opt/malt/Cellar/foo/1.0",
+        "/opt/malt",
+        .{ .allow_ipc = true },
+    );
+    defer testing.allocator.free(profile);
     try testing.expect(std.mem.indexOf(u8, profile, "(allow ipc-sysv-shm)") != null);
     try testing.expect(std.mem.indexOf(u8, profile, "(allow ipc-posix-shm)") != null);
     try testing.expect(std.mem.indexOf(u8, profile, "(allow ipc-sysv-sem)") != null);
@@ -56,14 +72,14 @@ test "renderRubyProfile deny-by-default, network denied, cellar + prefix subpath
 test "renderRubyProfile refuses unsafe cellar path" {
     try testing.expectError(
         error.UnsafePath,
-        sandbox.renderRubyProfile(testing.allocator, "/opt/malt\"/evil", "/opt/malt"),
+        sandbox.renderRubyProfile(testing.allocator, "/opt/malt\"/evil", "/opt/malt", .{}),
     );
 }
 
 test "renderRubyProfile refuses unsafe prefix path" {
     try testing.expectError(
         error.UnsafePath,
-        sandbox.renderRubyProfile(testing.allocator, "/opt/malt/Cellar/foo/1.0", "/opt/m)alt"),
+        sandbox.renderRubyProfile(testing.allocator, "/opt/malt/Cellar/foo/1.0", "/opt/m)alt", .{}),
     );
 }
 

--- a/tests/sandbox_macos_test.zig
+++ b/tests/sandbox_macos_test.zig
@@ -48,6 +48,9 @@ test "renderRubyProfile deny-by-default, network denied, cellar + prefix subpath
     try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/share\")") != null);
     try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/opt\")") != null);
     try testing.expect(std.mem.indexOf(u8, profile, "(subpath \"/opt/malt/lib\")") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(allow ipc-sysv-shm)") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(allow ipc-posix-shm)") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(allow ipc-sysv-sem)") != null);
 }
 
 test "renderRubyProfile refuses unsafe cellar path" {

--- a/tests/upgrade_cli_test.zig
+++ b/tests/upgrade_cli_test.zig
@@ -285,3 +285,29 @@ test "execute --dry-run on a fresh prefix without db dir exits silently" {
 
     try upgrade.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{});
 }
+
+test "execute refuses a bare --use-system-ruby" {
+    // A bare flag would widen the Ruby trust boundary to every outdated
+    // keg in one shot; upgrade only accepts the scoped form. Scratch
+    // prefix so no real prefix is ever touched, refusal or not.
+    var s = try Scratch.init(testing.allocator, "usr_bare");
+    defer s.deinit(testing.allocator);
+
+    quiet();
+    defer unquiet();
+    try testing.expectError(
+        error.Aborted,
+        upgrade.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{"--use-system-ruby"}),
+    );
+}
+
+test "execute accepts a scoped --use-system-ruby on an empty prefix" {
+    // Scope parsing must not disturb the empty-DB no-op contract; the
+    // scope only matters once a keg actually routes through post-install.
+    var s = try Scratch.init(testing.allocator, "usr_scope");
+    defer s.deinit(testing.allocator);
+
+    quiet();
+    defer unquiet();
+    try upgrade.execute(&malt.app_ctx.debug_ctx, testing.allocator, &.{"--use-system-ruby=wget,jq"});
+}


### PR DESCRIPTION
## Description

Homebrew 6 migrates formula hooks from imperative `def post_install` Ruby to a declarative `post_install_steps` array in the formulae API. Roughly half of homebrew-core has migrated already, and for every migrated formula malt silently skipped post-install: no steps ran, no warning, no JSON event - leaving broken kegs (gdk-pixbuf without its loader cache, GTK apps without compiled schemas, databases without initialised data dirs).

This PR makes malt a first-class citizen of the new framework:

- **Parse layer**: `post_install_steps` is read from the formula JSON (non-empty only - the key is present but empty on legacy formulas), and a formula "has a post-install hook" when either form is present.
- **Native executor**: a new core leaf interprets every step type shipping in homebrew-core today - filesystem steps through the same keg-confinement guards as the DSL builtins, tool steps (schema/icon/mime/loader cache regeneration) through the same sandbox fence as the DSL `system`, and the database initialisers (postgres/mysql/mariadb) marker-guarded exactly like upstream so an initialised data dir is never touched twice. Unknown step types route to the existing loud partial-skip envelope, byte-compatible with the current human and `--json` contracts.
- **Upgrade parity**: `mt upgrade` now runs post-install for the swapped keg (it previously never did, for any hook form) and gains the scoped `--use-system-ruby=<name>,...` opt-in for parity with install/migrate; a bare flag is refused. Help text and the man page are updated, and the flag is now offered by bash/zsh/fish completions for all three commands (it was previously absent everywhere).
- **Migrate/tap arm**: steps-only tap formulas warn loudly instead of being dropped silently (no formula JSON exists there to execute).
- **Doctor**: steps-migrated formulas are classified by native step coverage instead of being undercounted as "without post_install".
- **Sandbox profile**: gains the `lib` prefix subtree (prefix-level caches the tool steps regenerate) and SysV/POSIX shared-memory + semaphore grants (postgres bootstrap dies in `shmget`/`semctl` without them). Both widenings are pinned by tests.
- **Pins manifest**: the generator now reports how many formulas are steps-migrated, so the manifest's legitimate shrinkage (migrated formulas need no pinned `.rb` source) is explainable at a glance.

Verified end-to-end against real formulas in throwaway prefixes: daemontools (filesystem steps), gdk-pixbuf (fenced tool run, loader cache written into the prefix, keg proven usable by thumbnailing a PNG), postgresql@18 (fenced initdb, `PG_VERSION` marker present). 

## Related Issue

- None

## Notes for Reviewers

- None