### PR TITLE
fix(tui): keep wrapped rows on UTF-8 rune boundaries

### DIFF
--- a/scripts/regressions/tui-wrap-rune-boundary-tui-text-wrap-splits-utf8-sequence.sh
+++ b/scripts/regressions/tui-wrap-rune-boundary-tui-text-wrap-splits-utf8-sequence.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Regression: tui/text_wrap.wrapTake hard-breaks an over-long spaceless token
+# at a raw byte index. Without a rune-boundary check the cut can land between
+# a UTF-8 lead byte and its continuation bytes, so one wrapped row ends with
+# an orphan lead byte and the next starts mid-sequence — mojibake at the wrap
+# point in the detail pane (tab.Frame.putContent passes bytes >= 0x80 through
+# by design, so the split reaches the terminal verbatim).
+#
+# text_wrap.zig is a leaf module (imports only std), so the shipped file is
+# copied to a temp dir, assertion tests are appended, and `zig test` runs the
+# copy directly — no malt build, no network, well under 30s.
+#
+# Exits 0 when every hard-break lands on a rune boundary and the iterator
+# terminates on degenerate widths; non-zero with a clear message otherwise.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+cp "$ROOT/src/tui/text_wrap.zig" "$TMP/text_wrap_regression.zig"
+cat >>"$TMP/text_wrap_regression.zig" <<'ZIG'
+
+test "REGRESSION: hard-break never splits a multibyte rune" {
+    const s = "caféteria"; // 'é' = 0xC3 0xA9 at byte offsets 3..5
+    const take = wrapTake(s, 4);
+    try testing.expect(std.unicode.utf8ValidateSlice(s[0..take]));
+    try testing.expect(std.unicode.utf8ValidateSlice(s[take..]));
+}
+
+test "REGRESSION: width narrower than the leading rune still terminates" {
+    var it = iter("é", 1);
+    var rows: usize = 0;
+    while (it.next()) |_| {
+        rows += 1;
+        if (rows > 8) return error.WrapIterDidNotTerminate;
+    }
+}
+ZIG
+
+zig test "$TMP/text_wrap_regression.zig" ||
+  {
+    echo "FAIL: text_wrap hard-break splits UTF-8 sequences" >&2
+    exit 1
+  }
+echo "OK: text_wrap hard-break is rune-safe"

--- a/src/tui/text_wrap.zig
+++ b/src/tui/text_wrap.zig
@@ -31,12 +31,23 @@ pub fn iter(s: []const u8, width: usize) Iter {
 
 /// Bytes of `s` for one row of at most `max` columns: break at the last space
 /// that fits, else hard-break at `max` (a single word wider than the row).
-/// Grapheme-naive — one byte ≈ one column.
+/// Grapheme-naive — one byte ≈ one column — but the hard-break is rune-safe:
+/// it never cuts inside a multibyte UTF-8 sequence.
 pub fn wrapTake(s: []const u8, max: usize) usize {
     if (s.len <= max) return s.len;
     var i = max;
     while (i > 0) : (i -= 1) if (s[i - 1] == ' ') return i; // include the break space
-    return max; // no space in the window: hard break
+    // No space in the window: hard break, walked back off any continuation
+    // bytes so the split lands on a rune boundary (a raw cut at `max` would
+    // orphan a lead byte on one row and its continuations on the next).
+    i = max;
+    var steps: usize = 0; // valid UTF-8 has at most 3 continuation bytes
+    while (i > 0 and steps < 3 and (s[i] & 0xC0) == 0x80) : (steps += 1) i -= 1;
+    if ((s[i] & 0xC0) == 0x80) return max; // invalid continuation run: raw cut on garbage
+    if (i > 0) return i;
+    // Window narrower than the leading rune: one over-wide row beats stalling.
+    const rune_len = std.unicode.utf8ByteSequenceLength(s[0]) catch 1;
+    return @min(rune_len, s.len);
 }
 
 fn trimLeading(s: []const u8) []const u8 {
@@ -64,6 +75,26 @@ test "iter yields successive rows and trims the break space" {
     try testing.expectEqualStrings("two ", it.next().?);
     try testing.expectEqualStrings("three", it.next().?);
     try testing.expect(it.next() == null);
+}
+
+test "wrapTake hard-break lands on a rune boundary" {
+    const s = "caféteria"; // 'é' = 0xC3 0xA9 at byte offsets 3..5
+    const take = wrapTake(s, 4);
+    try testing.expectEqual(@as(usize, 3), take); // walked back before the 'é'
+    try testing.expect(std.unicode.utf8ValidateSlice(s[0..take]));
+    try testing.expect(std.unicode.utf8ValidateSlice(s[take..]));
+}
+
+test "wrapTake window narrower than the leading rune yields the whole rune" {
+    try testing.expectEqual(@as(usize, 2), wrapTake("étage", 1)); // one over-wide row beats stalling
+    var it = iter("é", 1);
+    try testing.expectEqualStrings("é", it.next().?);
+    try testing.expect(it.next() == null);
+}
+
+test "wrapTake cuts invalid continuation runs at max" {
+    const s = "\x80\x80\x80\x80\x80\x80"; // no lead byte to walk back to
+    try testing.expectEqual(@as(usize, 5), wrapTake(s, 5));
 }
 
 test "iter on a degenerate zero width still terminates" {


### PR DESCRIPTION
## Description

Long spaceless tokens in the TUI (detail-pane values, footer help line) could show a broken glyph at the wrap point. 

The wrap now lands on a rune boundary, so non-ASCII characters render whole on one of the two rows.

## Related Issue

- None

## Notes for Reviewers

- None