### PR TITLE
fix(ui/progress): make shared progress counters race-free under concurrent repaints

### DIFF
--- a/scripts/regressions/progress-shared-counters-atomic-progressbar-update-lock-free-data-race.sh
+++ b/scripts/regressions/progress-shared-counters-atomic-progressbar-update-lock-free-data-race.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Regression: ProgressBar's cross-thread counters must be atomic. update()
+# stores the byte count and render() bumps the spinner frame from the owning
+# worker, while a sibling worker holding the group mutex repaints every bar
+# on a resize tick and reads those same fields — a lock-free write racing a
+# locked read is a data race even when the torn value is never visible.
+#
+# ThreadSanitizer cannot be the oracle here (a -fsanitize-thread hello-world
+# segfaults on the target toolchain), so the synchronization discipline is
+# pinned structurally at compile time, plus a two-thread smoke run that must
+# survive a resize-repaint storm. progress.zig compiles as a standalone
+# module with its relative sibling imports — no malt build, no network.
+#
+# Exits 0 when the counters are atomic and the storm run is clean; non-zero
+# with a clear message otherwise.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+cat >"$TMP/driver.zig" <<'ZIG'
+const std = @import("std");
+const progress = @import("progress");
+
+comptime {
+    // The group mutex only guards draws; the counters cross threads on their own.
+    if (@FieldType(progress.ProgressBar, "current") != std.atomic.Value(u64))
+        @compileError("ProgressBar.current must be atomic: update() races repaintIfResized()");
+    if (@FieldType(progress.ProgressBar, "spinner_frame") != std.atomic.Value(u8))
+        @compileError("ProgressBar.spinner_frame must be atomic: render() races sibling repaints");
+}
+
+var stop = std.atomic.Value(bool).init(false);
+
+fn hammer(bar: *progress.ProgressBar) void {
+    var i: u64 = 0;
+    while (!stop.load(.acquire)) : (i += 1) bar.update(i);
+}
+
+fn repainter(bar: *progress.ProgressBar) void {
+    var j: u64 = 0;
+    while (!stop.load(.acquire)) : (j += 1) {
+        bar.last_render_ns = 0; // defeat the 10 Hz gate: render every call
+        std.posix.raise(std.posix.SIG.WINCH) catch {};
+        bar.update(j); // render -> mutex -> repaintIfResized reads the sibling
+    }
+}
+
+pub fn main() !void {
+    var t: std.Io.Threaded = .init(std.heap.page_allocator, .{});
+    defer t.deinit();
+    progress.setRuntime(t.io(), std.Io.File.stderr());
+    progress.setSupportsAnsiForTest(true);
+    progress.setMode(.tty);
+    progress.setColsForTest(80);
+
+    var mp = progress.MultiProgress.init(2); // arms the WINCH flag handler
+    var bars: [2]progress.ProgressBar = undefined;
+    for (&bars, 0..) |*b, idx| {
+        b.* = progress.ProgressBar.init("pkg", 1_000_000);
+        b.line_index = @intCast(idx);
+        b.multi = &mp;
+    }
+    mp.bars = &bars;
+
+    const a = try std.Thread.spawn(.{}, hammer, .{&bars[0]});
+    const b = try std.Thread.spawn(.{}, repainter, .{&bars[1]});
+    std.Io.sleep(t.io(), std.Io.Duration.fromNanoseconds(2 * std.time.ns_per_s), .awake) catch {};
+    stop.store(true, .release);
+    a.join();
+    b.join();
+    mp.finish();
+}
+ZIG
+
+if ! zig build-exe -femit-bin="$TMP/driver" \
+  --dep progress -Mmain="$TMP/driver.zig" \
+  -Mprogress="$ROOT/src/ui/progress.zig" 2>"$TMP/build_err.txt"; then
+  if grep -q "must be atomic" "$TMP/build_err.txt"; then
+    echo "FAIL: shared progress counters are not atomic" >&2
+  else
+    echo "FAIL: driver build error" >&2
+    cat "$TMP/build_err.txt" >&2
+  fi
+  exit 1
+fi
+
+timeout 20 "$TMP/driver" 2>/dev/null ||
+  {
+    echo "FAIL: concurrent update + resize repaint crashed or hung" >&2
+    exit 1
+  }
+echo "OK: shared progress counters are atomic and repaint-safe"

--- a/src/ui/progress.zig
+++ b/src/ui/progress.zig
@@ -292,10 +292,13 @@ pub const MultiProgress = struct {
 pub const ProgressBar = struct {
     label: []const u8,
     total: u64,
-    current: u64,
+    /// Atomic: the owning worker stores lock-free on every `update` while a
+    /// sibling holding the group mutex reads it during a resize repaint.
+    current: std.atomic.Value(u64),
     last_render_ns: i128,
     start_time_ms: i64,
-    spinner_frame: u8,
+    /// Atomic for the same reason as `current` — sibling repaints read it.
+    spinner_frame: std.atomic.Value(u8),
     is_tty: bool,
     /// Minimum label column width for alignment across multiple bars.
     label_width: u8,
@@ -314,10 +317,10 @@ pub const ProgressBar = struct {
         return .{
             .label = label,
             .total = total,
-            .current = 0,
+            .current = .init(0),
             .last_render_ns = 0,
             .start_time_ms = nowMs(),
-            .spinner_frame = 0,
+            .spinner_frame = .init(0),
             .is_tty = supportsAnsi(),
             .label_width = 0,
             .line_index = 0,
@@ -328,7 +331,7 @@ pub const ProgressBar = struct {
     }
 
     pub fn update(self: *ProgressBar, current: u64) void {
-        self.current = current;
+        self.current.store(current, .monotonic);
         if (output.isQuiet()) return;
         switch (pkg_mode) {
             .none => return,
@@ -351,7 +354,7 @@ pub const ProgressBar = struct {
             .tty => {
                 if (!self.is_tty) return;
                 if (self.total > 0) {
-                    self.current = self.total;
+                    self.current.store(self.total, .monotonic);
                 }
                 // Every bar belongs to a group that reserves its row up
                 // front (`SingleBar` for the one-bar case), so the final
@@ -377,7 +380,7 @@ pub const ProgressBar = struct {
         // Advance the animation frame on every render tick. Both determinate
         // and indeterminate bars use this to animate the spinner glyph in
         // front of the label.
-        self.spinner_frame +%= 1;
+        _ = self.spinner_frame.fetchAdd(1, .monotonic);
 
         // The group mutex guards every multi-bar draw; hold it across the
         // resize check + draw so a resize repaints the whole group atomically
@@ -392,6 +395,13 @@ pub const ProgressBar = struct {
         }
     }
 
+    /// Monotonic read of the shared byte counter: draws run under the group
+    /// mutex, but the owning worker stores lock-free, so a repaint may see a
+    /// value one tick stale — never a torn one.
+    fn cur(self: *const ProgressBar) u64 {
+        return self.current.load(.monotonic);
+    }
+
     /// Draw this bar's single line in place — no locking, so the group mutex
     /// is held by the caller (`render`) and by `repaintIfResized`. Determinacy
     /// selects the body; both honour the group's cursor-up/down math.
@@ -404,18 +414,18 @@ pub const ProgressBar = struct {
     /// The spinner uses Braille Pattern chars (not emoji); only the done
     /// glyph has an ASCII fallback to match `output.success()` in no-emoji mode.
     fn glyph(self: *const ProgressBar) []const u8 {
-        const done = self.total > 0 and self.current >= self.total;
+        const done = self.total > 0 and self.cur() >= self.total;
         if (done) {
             return if (color.isEmojiEnabled()) "\xe2\x9c\x93" else "*"; // ✓
         }
-        return spinner_frames.frames[self.spinner_frame % spinner_frames.count];
+        return spinner_frames.frames[self.spinner_frame.load(.monotonic) % spinner_frames.count];
     }
 
     fn computeRate(self: *const ProgressBar) f64 {
         const now_ms = nowMs();
         const elapsed_ms = now_ms - self.start_time_ms;
         if (elapsed_ms <= 0) return 0;
-        return @as(f64, @floatFromInt(self.current)) / (@as(f64, @floatFromInt(elapsed_ms)) / 1000.0);
+        return @as(f64, @floatFromInt(self.cur())) / (@as(f64, @floatFromInt(elapsed_ms)) / 1000.0);
     }
 
     pub fn formatRate(buf: []u8, rate: f64) []const u8 {
@@ -447,7 +457,7 @@ pub const ProgressBar = struct {
         pos += 1;
 
         // Glyph: animated spinner while in progress, green ✓ when done.
-        const done = self.total > 0 and self.current >= self.total;
+        const done = self.total > 0 and self.cur() >= self.total;
         const use_color = color.isColorEnabled();
         const g = self.glyph();
 
@@ -504,7 +514,7 @@ pub const ProgressBar = struct {
     /// fallback over a corrupt frame.
     fn writeCounterLine(self: *const ProgressBar, buf: []u8, start_pos: usize, cols: u16, value: []const u8) usize {
         var pos = start_pos;
-        const done = self.total > 0 and self.current >= self.total;
+        const done = self.total > 0 and self.cur() >= self.total;
         const use_color = color.isColorEnabled();
 
         buf[pos] = ' ';
@@ -560,7 +570,7 @@ pub const ProgressBar = struct {
     fn drawDeterminate(self: *const ProgressBar) void {
         const cols = queryCols();
         const layout = barLayout(cols, self.label_width);
-        const pct: u64 = if (self.total > 0) @min((self.current * 100) / self.total, 100) else 0;
+        const pct: u64 = if (self.total > 0) @min((self.cur() * 100) / self.total, 100) else 0;
 
         var buf: [768]u8 = undefined;
         var pos: usize = 0;
@@ -587,7 +597,7 @@ pub const ProgressBar = struct {
                 pos = self.writeLabel(&buf, pos);
 
                 // Bar
-                const filled: u64 = if (self.total > 0) @min((self.current * bw) / self.total, bw) else 0;
+                const filled: u64 = if (self.total > 0) @min((self.cur() * bw) / self.total, bw) else 0;
                 const empty = bw - filled;
                 if (color.isColorEnabled()) {
                     const cyan_code = color.SemanticStyle.info.code();
@@ -668,8 +678,10 @@ pub const ProgressBar = struct {
         const dim_code = if (use_color) color.SemanticStyle.detail.code() else "";
         const reset_code = if (use_color) color.Style.reset.code() else "";
 
+        // One snapshot for the whole detail so size/rate/ETA agree.
+        const current = self.cur();
         var size_buf: [48]u8 = undefined;
-        const size_kb = self.current / 1024;
+        const size_kb = current / 1024;
         const total_kb = self.total / 1024;
         const size_str = if (total_kb > 1024)
             std.fmt.bufPrint(&size_buf, "{d:.1}/{d:.1} MB", .{
@@ -684,12 +696,12 @@ pub const ProgressBar = struct {
         const rate_str = formatRate(&rate_buf, rate);
 
         var eta_buf: [32]u8 = undefined;
-        const eta_str = if (self.total > 0 and self.current < self.total and rate > 0)
-            formatEta(&eta_buf, self.total - self.current, rate)
+        const eta_str = if (self.total > 0 and current < self.total and rate > 0)
+            formatEta(&eta_buf, self.total - current, rate)
         else
             "";
 
-        var show_rate = self.current > 0;
+        var show_rate = current > 0;
         var show_eta = eta_str.len > 0;
         if (cols) |c| {
             const budget: usize = c;
@@ -737,7 +749,7 @@ pub const ProgressBar = struct {
         buf[pos] = '\r';
         pos += 1;
 
-        const size_kb = self.current / 1024;
+        const size_kb = self.cur() / 1024;
         var size_buf: [32]u8 = undefined;
         const size_str = if (size_kb > 1024)
             std.fmt.bufPrint(&size_buf, "{d:.1} MB", .{@as(f64, @floatFromInt(size_kb)) / 1024.0}) catch ""
@@ -1912,4 +1924,57 @@ test "indeterminate render collapses to label + bytes on a very narrow terminal"
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "kafka") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "MB") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "(") == null); // no detail parens
+}
+
+test "update publishes the byte count through the atomic counter" {
+    const prior_mode = mode();
+    setMode(.none); // no rendering — this pins the store, not the draw
+    defer setMode(prior_mode);
+
+    var bar = ProgressBar.init("tree", 1000);
+    bar.update(42);
+    try std.testing.expectEqual(@as(u64, 42), bar.cur());
+}
+
+test "finish clamps the counter to total through the atomic" {
+    const prior_mode = mode();
+    setMode(.tty);
+    defer setMode(prior_mode);
+    setSupportsAnsiForTest(true);
+    defer setSupportsAnsiForTest(null);
+    setColsForTest(80);
+    defer setColsForTest(null);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    beginStderrCapture(std.testing.allocator, &buf);
+    defer endStderrCapture();
+
+    var bar = ProgressBar.init("tree", 1000);
+    bar.is_tty = true;
+    bar.update(400);
+    bar.finish();
+
+    try std.testing.expectEqual(@as(u64, 1000), bar.cur());
+}
+
+test "render advances the spinner frame and wraps at u8 overflow" {
+    const prior_mode = mode();
+    setMode(.tty);
+    defer setMode(prior_mode);
+    setSupportsAnsiForTest(true);
+    defer setSupportsAnsiForTest(null);
+    setColsForTest(80);
+    defer setColsForTest(null);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    beginStderrCapture(std.testing.allocator, &buf);
+    defer endStderrCapture();
+
+    var bar = ProgressBar.init("tree", 1000);
+    bar.is_tty = true;
+    bar.spinner_frame.store(255, .monotonic);
+    bar.update(1); // first render tick: 255 +% 1 wraps to 0
+    try std.testing.expectEqual(@as(u8, 0), bar.spinner_frame.load(.monotonic));
 }

--- a/tests/progress_test.zig
+++ b/tests/progress_test.zig
@@ -15,15 +15,15 @@ const output_mod = @import("malt").output;
 test "init sets correct defaults" {
     const bar = progress_mod.ProgressBar.init("test-label", 1000);
     try testing.expectEqual(@as(u64, 1000), bar.total);
-    try testing.expectEqual(@as(u64, 0), bar.current);
+    try testing.expectEqual(@as(u64, 0), bar.current.load(.monotonic));
     try testing.expectEqualStrings("test-label", bar.label);
-    try testing.expectEqual(@as(u8, 0), bar.spinner_frame);
+    try testing.expectEqual(@as(u8, 0), bar.spinner_frame.load(.monotonic));
 }
 
 test "init with zero total starts in indeterminate mode" {
     const bar = progress_mod.ProgressBar.init("download", 0);
     try testing.expectEqual(@as(u64, 0), bar.total);
-    try testing.expectEqual(@as(u64, 0), bar.current);
+    try testing.expectEqual(@as(u64, 0), bar.current.load(.monotonic));
 }
 
 test "update advances current position" {
@@ -33,10 +33,10 @@ test "update advances current position" {
 
     var bar = progress_mod.ProgressBar.init("test", 1000);
     bar.update(500);
-    try testing.expectEqual(@as(u64, 500), bar.current);
+    try testing.expectEqual(@as(u64, 500), bar.current.load(.monotonic));
 
     bar.update(999);
-    try testing.expectEqual(@as(u64, 999), bar.current);
+    try testing.expectEqual(@as(u64, 999), bar.current.load(.monotonic));
 }
 
 test "finish sets current to total for determinate bar" {
@@ -47,10 +47,10 @@ test "finish sets current to total for determinate bar" {
 
     var bar = progress_mod.ProgressBar.init("test", 2048);
     bar.update(1024);
-    try testing.expectEqual(@as(u64, 1024), bar.current);
+    try testing.expectEqual(@as(u64, 1024), bar.current.load(.monotonic));
     bar.finish();
     // In quiet mode, finish skips rendering — current stays at last update value
-    try testing.expectEqual(@as(u64, 1024), bar.current);
+    try testing.expectEqual(@as(u64, 1024), bar.current.load(.monotonic));
 }
 
 test "finish does not change current for indeterminate bar" {
@@ -62,7 +62,7 @@ test "finish does not change current for indeterminate bar" {
     bar.finish();
     // total remains 0, current stays at 5000
     try testing.expectEqual(@as(u64, 0), bar.total);
-    try testing.expectEqual(@as(u64, 5000), bar.current);
+    try testing.expectEqual(@as(u64, 5000), bar.current.load(.monotonic));
 }
 
 test "update in quiet mode does not crash" {
@@ -76,7 +76,7 @@ test "update in quiet mode does not crash" {
         bar.update(i);
     }
     bar.finish();
-    try testing.expectEqual(@as(u64, 100), bar.current);
+    try testing.expectEqual(@as(u64, 100), bar.current.load(.monotonic));
 }
 
 // --- ProgressCallback tests ---
@@ -136,16 +136,16 @@ test "ProgressCallback bridges to ProgressBar" {
     // First report sets total from Content-Length
     cb.report(1000, 5000);
     try testing.expectEqual(@as(u64, 5000), bar.total);
-    try testing.expectEqual(@as(u64, 1000), bar.current);
+    try testing.expectEqual(@as(u64, 1000), bar.current.load(.monotonic));
 
     // Subsequent reports don't change total
     cb.report(3000, 5000);
     try testing.expectEqual(@as(u64, 5000), bar.total);
-    try testing.expectEqual(@as(u64, 3000), bar.current);
+    try testing.expectEqual(@as(u64, 3000), bar.current.load(.monotonic));
 
     // Clamping: bytes > total gets clamped
     cb.report(6000, 5000);
-    try testing.expectEqual(@as(u64, 5000), bar.current);
+    try testing.expectEqual(@as(u64, 5000), bar.current.load(.monotonic));
 }
 
 test "ProgressCallback with null content_length stays indeterminate" {
@@ -169,11 +169,11 @@ test "ProgressCallback with null content_length stays indeterminate" {
 
     cb.report(1000, null);
     try testing.expectEqual(@as(u64, 0), bar.total); // stays indeterminate
-    try testing.expectEqual(@as(u64, 1000), bar.current);
+    try testing.expectEqual(@as(u64, 1000), bar.current.load(.monotonic));
 
     cb.report(5000, null);
     try testing.expectEqual(@as(u64, 0), bar.total);
-    try testing.expectEqual(@as(u64, 5000), bar.current);
+    try testing.expectEqual(@as(u64, 5000), bar.current.load(.monotonic));
 }
 
 // --- Rate/ETA helper tests ---
@@ -242,7 +242,7 @@ test "ProgressBar render path executes when forced into TTY mode" {
     bar.last_render_ns = 0;
     bar.update(1000);
     bar.finish();
-    try testing.expectEqual(@as(u64, 1000), bar.current);
+    try testing.expectEqual(@as(u64, 1000), bar.current.load(.monotonic));
 }
 
 test "ProgressBar indeterminate render path executes when forced into TTY mode" {


### PR DESCRIPTION
## Description

During parallel installs, each download worker updates its own progress bar while whichever worker observes a terminal resize repaints the whole group under the group mutex — reading every sibling bar's byte count and spinner frame while their owners keep writing them lock-free. That unsynchronized write/locked-read pair is a data race (undefined behavior by the language model), even though on aligned words the practical symptom was at most a transiently stale repaint.

The two cross-thread counters are now atomics with monotonic ordering, matching the module's existing `Spinner.stop_flag` idiom: workers store, repaints load, and a repaint can see a value one tick stale but never a torn one. A monotonic store compiles to a plain register store on the target architectures, so the install hot path pays nothing.

## Related Issue

- None

## Notes for Reviewers

- None