### PR TITLE
fix(doctor): repair a stale lock by truncating instead of unlinking it

### DIFF
--- a/scripts/regressions/doctor_fix_selector.sh
+++ b/scripts/regressions/doctor_fix_selector.sh
@@ -4,7 +4,7 @@
 # Pinned behaviour:
 #   1. `--fix <id>` applies only the named class (stale_lock here) and
 #      leaves the other safe-class offenders (a broken symlink) in place.
-#   2. `--fix` with no id stays apply-all: lock + symlink both go.
+#   2. `--fix` with no id stays apply-all: lock cleared, symlink unlinked.
 #   3. An unknown id exits non-zero and mutates nothing.
 #   4. `--fix <id> --dry-run` plans but mutates nothing.
 #
@@ -48,8 +48,10 @@ export MALT_PREFIX="$PFX"
 seed_prefix "$PFX"
 
 "$MALT_BIN" doctor --fix stale_lock >/dev/null 2>&1 || true
-[[ ! -f "$PFX/db/malt.lock" ]] ||
-  fail '--fix stale_lock did not remove the stale lock'
+# Repair truncates the lock in place (mirrors LockFile.release); unlinking
+# the inode would break flock exclusion, so assert present-and-empty.
+[[ -f "$PFX/db/malt.lock" && ! -s "$PFX/db/malt.lock" ]] ||
+  fail '--fix stale_lock did not truncate the stale lock in place'
 [[ -L "$PFX/bin/dead" ]] ||
   fail '--fix stale_lock also removed the broken symlink (should target only stale_lock)'
 rm -rf "$PFX"
@@ -60,8 +62,8 @@ export MALT_PREFIX="$PFX"
 seed_prefix "$PFX"
 
 "$MALT_BIN" doctor --fix >/dev/null 2>&1 || true
-[[ ! -f "$PFX/db/malt.lock" ]] ||
-  fail 'apply-all --fix did not remove the stale lock'
+[[ -f "$PFX/db/malt.lock" && ! -s "$PFX/db/malt.lock" ]] ||
+  fail 'apply-all --fix did not truncate the stale lock in place'
 [[ ! -L "$PFX/bin/dead" ]] ||
   fail 'apply-all --fix did not remove the broken symlink'
 rm -rf "$PFX"

--- a/scripts/regressions/doctor_fix_selector.sh
+++ b/scripts/regressions/doctor_fix_selector.sh
@@ -93,7 +93,7 @@ export MALT_PREFIX="$PFX"
 seed_prefix "$PFX"
 
 out=$("$MALT_BIN" doctor --fix stale_lock --dry-run 2>&1 || true)
-printf '%s' "$out" | grep -qi 'would remove stale lock file' ||
+printf '%s' "$out" | grep -qi 'would clear stale lock file' ||
   fail '--fix stale_lock --dry-run did not print the planned action'
 [[ -f "$PFX/db/malt.lock" ]] ||
   fail '--fix stale_lock --dry-run removed the lock (dry-run must mutate nothing)'

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -471,7 +471,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
                 output.dim("would {s}", .{fix_mod.safeLabel(kind)});
             }
         } else {
-            if (outcome.stale_lock_removed) output.success("removed stale lock file", .{});
+            if (outcome.stale_lock_removed) output.success("cleared stale lock file", .{});
             if (outcome.broken_symlinks_removed > 0) {
                 output.success("unlinked {d} broken symlink(s)", .{outcome.broken_symlinks_removed});
             }

--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -129,13 +129,17 @@ fn walkBrokenSymlinks(io: std.Io, prefix: []const u8, do_remove: bool) u32 {
     return count;
 }
 
-/// Best-effort removal of the prefix's lock file when its PID is dead.
-/// Idempotent: a missing or live lock file is a no-op (returns false).
+/// Clear the prefix's stale lock in place when its PID is dead — truncate,
+/// never unlink, mirroring `LockFile.release`. Idempotent: a missing or live
+/// lock file is a no-op (returns false).
 pub fn fixStaleLock(io: std.Io, prefix: []const u8) bool {
     if (probeStaleLockState(io, prefix) != .stale) return false;
     var lock_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix}) catch return false;
-    std.Io.Dir.deleteFileAbsolute(io, lock_path) catch return false;
+    // Unlinking would break flock exclusion: the inode is the lock identity.
+    const file = std.Io.Dir.openFileAbsolute(io, lock_path, .{ .mode = .write_only }) catch return false;
+    defer file.close(io);
+    lock_mod.LockFile.clearInPlace(io, file) catch return false;
     return true;
 }
 

--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -277,7 +277,7 @@ pub fn parseFix(args: []const []const u8) FixRequest {
 /// dry-run plan and the post-action confirmation.
 pub fn safeLabel(kind: FixKind) []const u8 {
     return switch (kind) {
-        .stale_lock => "remove stale lock file",
+        .stale_lock => "clear stale lock file",
         .orphaned_store => "sweep orphaned store entries",
         .broken_symlinks => "unlink broken symlinks under prefix",
     };
@@ -506,7 +506,7 @@ test "renderPlan: dry-run uses 'would apply' verb" {
     const plan = planFixes(.{ .stale_lock = true });
     const out = try renderToBuf(plan, true, &buf);
     try std.testing.expectEqualStrings(
-        "  would apply:\n    - remove stale lock file\n",
+        "  would apply:\n    - clear stale lock file\n",
         out,
     );
 }
@@ -527,7 +527,7 @@ test "renderPlan: manual section follows safe section" {
     const out = try renderToBuf(plan, true, &buf);
     try std.testing.expectEqualStrings(
         "  would apply:\n" ++
-            "    - remove stale lock file\n" ++
+            "    - clear stale lock file\n" ++
             "  manual action required:\n" ++
             "  corrupt database — restore from backup or reinstall malt\n",
         out,

--- a/src/db/lock.zig
+++ b/src/db/lock.zig
@@ -59,13 +59,23 @@ pub const LockFile = struct {
     /// that may already have it open.
     pub fn release(self: *LockFile, io: std.Io) void {
         // Vacate the pid before unlock so a racing reader sees an empty
-        // file, not the just-released holder's pid. The truncate+sync are
-        // best-effort: any failure leaves a stale pid that the next
-        // acquire immediately overwrites.
-        self.file.setLength(io, 0) catch {};
-        self.file.sync(io) catch {};
+        // file, not the just-released holder's pid. Best-effort: any failure
+        // leaves a stale pid that the next acquire immediately overwrites.
+        clearInPlace(io, self.file) catch {};
         self.file.unlock(io);
         self.file.close(io);
+    }
+
+    /// Clear a lock file's contents in place: truncate to 0, then flush.
+    /// Never unlinks — flock is inode-bound, so removing the inode would let
+    /// a live holder keep its lock while a fresh `acquire` takes a new one.
+    /// `release` and doctor's stale-lock repair share this one owner of the
+    /// clear so the lock file's lifecycle has a single authority.
+    pub fn clearInPlace(io: std.Io, file: std.Io.File) std.Io.File.SetLengthError!void {
+        try file.setLength(io, 0);
+        // Durability is best-effort: a lost flush only leaves a stale pid the
+        // next acquire overwrites.
+        file.sync(io) catch {};
     }
 
     /// Read the PID from an existing lock file. Returns null when the file

--- a/tests/doctor_fix_test.zig
+++ b/tests/doctor_fix_test.zig
@@ -52,13 +52,21 @@ fn pathExists(path: []const u8) bool {
     return true;
 }
 
+/// Stat an absolute path through a short-lived handle — used to assert the
+/// stale-lock repair keeps the same inode and empties it (R-010).
+fn statAbsolute(io: std.Io, path: []const u8) !std.Io.File.Stat {
+    const f = try fs_compat.openFileAbsolute(io, path, .{});
+    defer f.close(io);
+    return f.stat(io);
+}
+
 // Pick a PID that almost certainly does not exist. PIDs above 2^22 are
 // outside the macOS default range so kill(0) returns ESRCH.
 const dead_pid_str = "999999";
 
 // ── stale lock ──────────────────────────────────────────────────────
 
-test "fixStaleLock: dead PID lock file is removed" {
+test "fixStaleLock: dead PID lock is truncated in place, not unlinked" {
     var prefix_buf: [128]u8 = undefined;
     const prefix = try makePrefix(&prefix_buf, "stalelock");
     defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
@@ -75,9 +83,24 @@ test "fixStaleLock: dead PID lock file is removed" {
     defer threaded.deinit();
     const io = threaded.io();
 
+    const before = try statAbsolute(io, lock_path);
+    try testing.expect(before.size > 0);
+
     try testing.expect(fix.probeStaleLock(io, prefix));
     try testing.expect(fix.fixStaleLock(io, prefix));
-    try testing.expect(!pathExists(lock_path));
+
+    // R-010: the inode is the flock identity. Repair mirrors LockFile.release
+    // — truncate to zero and leave the file in place. Unlinking would let a
+    // fresh acquire take a new inode and break exclusion.
+    try testing.expect(pathExists(lock_path));
+    const after = try statAbsolute(io, lock_path);
+    try testing.expectEqual(before.inode, after.inode);
+    try testing.expectEqual(@as(u64, 0), after.size);
+
+    // Truncation must resolve the finding, not just zero bytes: an emptied
+    // lock reads as vacated, so a re-run is a no-op (idempotent).
+    try testing.expect(!fix.probeStaleLock(io, prefix));
+    try testing.expect(!fix.fixStaleLock(io, prefix));
 }
 
 test "fixStaleLock: live PID is left alone" {
@@ -239,7 +262,9 @@ test "executeFix: live run sweeps stale lock + broken symlinks together" {
     try testing.expect(outcome.stale_lock_removed);
     try testing.expectEqual(@as(u32, 1), outcome.broken_symlinks_removed);
     try testing.expectEqual(@as(u32, 2), outcome.fixesApplied());
-    try testing.expect(!pathExists(lock_path));
+    // Stale lock is vacated in place, not unlinked (R-010).
+    try testing.expect(pathExists(lock_path));
+    try testing.expectEqual(@as(u64, 0), (try statAbsolute(io, lock_path)).size);
 
     var ghost_buf: [256]u8 = undefined;
     const ghost = try std.fmt.bufPrint(&ghost_buf, "{s}/bin/ghost", .{prefix});
@@ -506,7 +531,9 @@ test "executeFix: only=stale_lock removes the lock and leaves broken symlinks" {
     try testing.expectEqual(@as(usize, 1), outcome.plan.safe.count());
     try testing.expect(outcome.plan.safe.contains(.stale_lock));
 
-    try testing.expect(!pathExists(lock_path));
+    // Stale lock is vacated in place, not unlinked (R-010).
+    try testing.expect(pathExists(lock_path));
+    try testing.expectEqual(@as(u64, 0), (try statAbsolute(io, lock_path)).size);
     // `access()` follows the link, so a surviving dangling symlink reads
     // as absent — confirm the entry itself is still present by iterating.
     try testing.expect(symlinkEntryExists(io, bin_dir, "dead"));


### PR DESCRIPTION
## Description

`doctor --fix` no longer breaks flock exclusion when clearing a stale lock. It now vacates the lock the same way a normal release does, truncate in place, never unlink, so a stale-lock repair can't hand two processes the same lock.

## Related Issue

- None

## Notes for Reviewers

- None