### PR TITLE
fix(doctor): don't remove an intact symlink whose target is inaccessible

### DIFF
--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -1019,31 +1019,24 @@ fn checkMissingKegs(ctx: CheckCtx, name: []const u8) CheckResult {
 }
 
 fn checkBrokenSymlinks(ctx: CheckCtx, name: []const u8) CheckResult {
-    const link_dirs = [_][]const u8{ "bin", "lib", "include", "share", "sbin" };
     var offenders: std.ArrayList([]u8) = .empty;
     defer freeOwnedStringList(ctx.allocator, &offenders);
 
-    for (link_dirs) |subdir| {
-        var dir_buf: [512]u8 = undefined;
-        const dir_path = std.fmt.bufPrint(&dir_buf, "{s}/{s}", .{ ctx.prefix, subdir }) catch continue;
-        var dir = std.Io.Dir.openDirAbsolute(ctx.io, dir_path, .{ .iterate = true }) catch continue;
-        defer dir.close(ctx.io);
-
-        var dir_iter = dir.iterate();
-        while (dir_iter.next(ctx.io) catch null) |entry| {
-            if (entry.kind == .sym_link) {
-                _ = dir.statFile(ctx.io, entry.name, .{}) catch |err| {
-                    if (!fix_mod.isDanglingLinkError(err)) continue; // inaccessible ≠ missing
-                    const path = std.fmt.allocPrint(ctx.allocator, "{s}/{s}", .{ subdir, entry.name }) catch continue;
-                    offenders.append(ctx.allocator, path) catch {
-                        ctx.allocator.free(path);
-                        continue;
-                    };
-                    continue;
-                };
-            }
+    // Same walk the fix executor uses, so report and remove never disagree.
+    const Collect = struct {
+        allocator: std.mem.Allocator,
+        offenders: *std.ArrayList([]u8),
+        fn visit(self: @This(), _: std.Io.Dir, subdir: []const u8, entry_name: []const u8) void {
+            const path = std.fmt.allocPrint(self.allocator, "{s}/{s}", .{ subdir, entry_name }) catch return;
+            self.offenders.append(self.allocator, path) catch self.allocator.free(path);
         }
-    }
+    };
+    fix_mod.forEachBrokenSymlink(
+        ctx.io,
+        ctx.prefix,
+        Collect{ .allocator = ctx.allocator, .offenders = &offenders },
+        Collect.visit,
+    );
 
     if (offenders.items.len == 0) {
         printCheck(name, .ok, null);

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -1032,7 +1032,8 @@ fn checkBrokenSymlinks(ctx: CheckCtx, name: []const u8) CheckResult {
         var dir_iter = dir.iterate();
         while (dir_iter.next(ctx.io) catch null) |entry| {
             if (entry.kind == .sym_link) {
-                _ = dir.statFile(ctx.io, entry.name, .{}) catch {
+                _ = dir.statFile(ctx.io, entry.name, .{}) catch |err| {
+                    if (!fix_mod.isDanglingLinkError(err)) continue; // inaccessible ≠ missing
                     const path = std.fmt.allocPrint(ctx.allocator, "{s}/{s}", .{ subdir, entry.name }) catch continue;
                     offenders.append(ctx.allocator, path) catch {
                         ctx.allocator.free(path);
@@ -1574,6 +1575,48 @@ test "emitTapCacheReport: human one-liner when cache holds bytes" {
         "  > Tap archive cache: 256.0 B. Run: mt purge --cache\n",
         buf.items,
     );
+}
+
+test "checkBrokenSymlinks: an intact link with an inaccessible target is not reported" {
+    // Read side must agree with the fix walk — a link whose target sits
+    // behind a permission wall is live, so it is not "broken".
+    if (std.c.geteuid() == 0) return error.SkipZigTest; // root bypasses the perm wall
+
+    const allocator = testing.allocator;
+    const io = std.Options.debug_io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    var wb: [std.fs.max_path_bytes]u8 = undefined;
+    const walled = try std.fmt.bufPrint(&wb, "{s}/walled", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(io, walled);
+    var tb: [std.fs.max_path_bytes]u8 = undefined;
+    const target = try std.fmt.bufPrint(&tb, "{s}/keg", .{walled});
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, target, .{});
+        f.close(io);
+    }
+    var walled_dir = try std.Io.Dir.openDirAbsolute(io, walled, .{});
+    defer walled_dir.close(io);
+    try walled_dir.setPermissions(io, std.Io.File.Permissions.fromMode(0));
+    defer walled_dir.setPermissions(io, std.Io.File.Permissions.fromMode(0o755)) catch {};
+
+    var pb: [std.fs.max_path_bytes]u8 = undefined;
+    const bin = try std.fmt.bufPrint(&pb, "{s}/bin", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(io, bin);
+    var lb: [std.fs.max_path_bytes]u8 = undefined;
+    const link = try std.fmt.bufPrint(&lb, "{s}/wall", .{bin});
+    try std.Io.Dir.symLinkAbsolute(io, target, link, .{});
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    output.beginStderrCapture(allocator, &out);
+    defer output.endStderrCapture();
+
+    const ctx: CheckCtx = .{ .allocator = allocator, .prefix = prefix, .io = io, .environ = .empty };
+    try testing.expectEqual(CheckResult.ok, checkBrokenSymlinks(ctx, "Broken symlinks"));
 }
 
 test "checks table includes the mirror-overrides row" {

--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -113,8 +113,17 @@ pub fn isDanglingLinkError(err: anyerror) bool {
 
 const link_dirs = [_][]const u8{ "bin", "lib", "include", "share", "sbin" };
 
-fn walkBrokenSymlinks(io: std.Io, prefix: []const u8, do_remove: bool) u32 {
-    var count: u32 = 0;
+/// Visit every *dangling* symlink under the prefix's link dirs: one target is
+/// resolved per entry and only `FileNotFound` counts, so an inaccessible-but-
+/// intact link is skipped. `visit` receives the open dir plus the subdir/name
+/// pair. The single traversal behind both the fix walk and the doctor check, so
+/// the two cannot report different link sets.
+pub fn forEachBrokenSymlink(
+    io: std.Io,
+    prefix: []const u8,
+    context: anytype,
+    comptime visit: fn (@TypeOf(context), dir: std.Io.Dir, subdir: []const u8, name: []const u8) void,
+) void {
     for (link_dirs) |subdir| {
         var dir_buf: [512]u8 = undefined;
         const dir_path = std.fmt.bufPrint(&dir_buf, "{s}/{s}", .{ prefix, subdir }) catch continue;
@@ -124,18 +133,28 @@ fn walkBrokenSymlinks(io: std.Io, prefix: []const u8, do_remove: bool) u32 {
         var iter = dir.iterate();
         while (iter.next(io) catch null) |entry| {
             if (entry.kind != .sym_link) continue;
-            // Only a genuinely dangling target counts; an inaccessible one is left alone.
             _ = dir.statFile(io, entry.name, .{}) catch |err| {
-                if (!isDanglingLinkError(err)) continue;
-                if (do_remove) {
-                    dir.deleteFile(io, entry.name) catch continue;
-                }
-                count += 1;
+                if (isDanglingLinkError(err)) visit(context, dir, subdir, entry.name);
                 continue;
             };
         }
     }
-    return count;
+}
+
+fn walkBrokenSymlinks(io: std.Io, prefix: []const u8, do_remove: bool) u32 {
+    const Sweep = struct {
+        io: std.Io,
+        do_remove: bool,
+        count: u32 = 0,
+        fn visit(self: *@This(), dir: std.Io.Dir, _: []const u8, name: []const u8) void {
+            // A link we cannot unlink was not removed — don't count it.
+            if (self.do_remove) dir.deleteFile(self.io, name) catch return;
+            self.count += 1;
+        }
+    };
+    var sweep = Sweep{ .io = io, .do_remove = do_remove };
+    forEachBrokenSymlink(io, prefix, &sweep, Sweep.visit);
+    return sweep.count;
 }
 
 /// Clear the prefix's stale lock in place when its PID is dead — truncate,

--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -103,6 +103,14 @@ pub fn fixBrokenSymlinks(io: std.Io, prefix: []const u8) u32 {
     return walkBrokenSymlinks(io, prefix, true);
 }
 
+/// A broken symlink is one whose target genuinely does not exist. Any other
+/// `statFile` failure (AccessDenied, …) means "can't tell" — the link is live,
+/// so it must be left intact. Shared by the fix walk and the doctor check so
+/// the two cannot drift into report-vs-remove disagreement.
+pub fn isDanglingLinkError(err: anyerror) bool {
+    return err == error.FileNotFound;
+}
+
 const link_dirs = [_][]const u8{ "bin", "lib", "include", "share", "sbin" };
 
 fn walkBrokenSymlinks(io: std.Io, prefix: []const u8, do_remove: bool) u32 {
@@ -116,8 +124,9 @@ fn walkBrokenSymlinks(io: std.Io, prefix: []const u8, do_remove: bool) u32 {
         var iter = dir.iterate();
         while (iter.next(io) catch null) |entry| {
             if (entry.kind != .sym_link) continue;
-            // statFile resolves the link; failure means the target is missing.
-            _ = dir.statFile(io, entry.name, .{}) catch {
+            // Only a genuinely dangling target counts; an inaccessible one is left alone.
+            _ = dir.statFile(io, entry.name, .{}) catch |err| {
+                if (!isDanglingLinkError(err)) continue;
                 if (do_remove) {
                     dir.deleteFile(io, entry.name) catch continue;
                 }
@@ -638,4 +647,73 @@ test "isPurgeableOrphan: only a refcount<=0 row is an orphan" {
     try std.testing.expect(!isPurgeableOrphan(true, 1));
     // No ref row: a warm / in-flight commit purge cannot clear — not an orphan.
     try std.testing.expect(!isPurgeableOrphan(false, 0));
+}
+
+test "isDanglingLinkError: only a missing target is dangling" {
+    // The single source of truth for check and fix: FileNotFound → remove,
+    // every other errno → leave intact (can't tell ≠ broken).
+    try std.testing.expect(isDanglingLinkError(error.FileNotFound));
+    try std.testing.expect(!isDanglingLinkError(error.AccessDenied));
+    try std.testing.expect(!isDanglingLinkError(error.SymLinkLoop));
+}
+
+test "walkBrokenSymlinks: a dangling link is detected and removed" {
+    const io = std.Options.debug_io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    var pb: [std.fs.max_path_bytes]u8 = undefined;
+    const bin = try std.fmt.bufPrint(&pb, "{s}/bin", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(io, bin);
+    var lb: [std.fs.max_path_bytes]u8 = undefined;
+    const link = try std.fmt.bufPrint(&lb, "{s}/gone", .{bin});
+    try std.Io.Dir.symLinkAbsolute(io, "/no/such/target", link, .{});
+
+    try std.testing.expectEqual(@as(u32, 1), probeBrokenSymlinks(io, prefix));
+    try std.testing.expectEqual(@as(u32, 1), fixBrokenSymlinks(io, prefix));
+    // The dangling link is gone after the walk.
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().deleteFile(io, link));
+}
+
+test "walkBrokenSymlinks: an intact link with an inaccessible target is left alone" {
+    // A link whose target sits behind a permission wall is live and valid;
+    // doctor must not report or remove it. AccessDenied ≠ missing.
+    if (std.c.geteuid() == 0) return error.SkipZigTest; // root bypasses the perm wall
+
+    const io = std.Options.debug_io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var bb: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = bb[0..try std.Io.Dir.realPath(tmp.dir, io, &bb)];
+
+    // A real target under a mode-0 dir: stat traversal fails with EACCES.
+    var wb: [std.fs.max_path_bytes]u8 = undefined;
+    const walled = try std.fmt.bufPrint(&wb, "{s}/walled", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(io, walled);
+    var tb: [std.fs.max_path_bytes]u8 = undefined;
+    const target = try std.fmt.bufPrint(&tb, "{s}/keg", .{walled});
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, target, .{});
+        f.close(io);
+    }
+    var walled_dir = try std.Io.Dir.openDirAbsolute(io, walled, .{});
+    defer walled_dir.close(io);
+    try walled_dir.setPermissions(io, std.Io.File.Permissions.fromMode(0));
+    // Restore mode so tmp cleanup can recurse into the walled dir.
+    defer walled_dir.setPermissions(io, std.Io.File.Permissions.fromMode(0o755)) catch {};
+
+    var pb: [std.fs.max_path_bytes]u8 = undefined;
+    const bin = try std.fmt.bufPrint(&pb, "{s}/bin", .{prefix});
+    try std.Io.Dir.cwd().createDirPath(io, bin);
+    var lb: [std.fs.max_path_bytes]u8 = undefined;
+    const link = try std.fmt.bufPrint(&lb, "{s}/wall", .{bin});
+    try std.Io.Dir.symLinkAbsolute(io, target, link, .{});
+
+    try std.testing.expectEqual(@as(u32, 0), probeBrokenSymlinks(io, prefix));
+    try std.testing.expectEqual(@as(u32, 0), fixBrokenSymlinks(io, prefix));
+    // The link entry survives the walk (readLink inspects the link, not the target).
+    var rl: [std.fs.max_path_bytes]u8 = undefined;
+    _ = try std.Io.Dir.readLinkAbsolute(io, link, &rl);
 }


### PR DESCRIPTION
## Description

`doctor --fix` no longer deletes a healthy symlink just because its target sits behind a permission wall. It removes only genuinely dangling links; a link it can't inspect is left untouched, and the doctor check agrees so it never reports a "broken" link that `--fix` then refuses to remove.

## Related Issue

- None

## Notes for Reviewers

- None