### PR TITLE
fix(doctor): serialize --fix prefix mutations behind malt.lock

### DIFF
--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -28,6 +28,7 @@ pub const FixConditions = fix_mod.Conditions;
 pub const FixPlan = fix_mod.Plan;
 pub const planFixes = fix_mod.planFixes;
 const post_install = @import("doctor/post_install.zig");
+const lock_report = @import("lock_report.zig");
 const render = @import("doctor/render.zig");
 pub const CheckStatus = render.CheckStatus;
 pub const CheckStyle = render.CheckStyle;
@@ -484,6 +485,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
                     outcome.orphans_block_reason orelse "unknown reason",
                 });
             }
+            // The acquire is the in-flight gate: a live op or a failed acquire
+            // skips the prefix-mutating sweeps rather than corrupting them.
+            if (outcome.mutations_skipped) |e| switch (e) {
+                error.Timeout => output.info("skipped orphan and symlink sweeps: {s}", .{op_in_flight_note}),
+                error.DirMissing => output.info("skipped orphan and symlink sweeps: no db/ directory — nothing installed to serialize against", .{}),
+                error.AccessDenied, error.OpenFailed, error.WriteFailed => lock_report.reportAcquireFailure(e, prefix),
+            };
         }
 
         var mit = outcome.plan.manual.iterator();

--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -372,6 +372,10 @@ pub const FixOutcome = struct {
     orphans_blocked: u32 = 0,
     orphans_block_reason: ?[]const u8 = null,
     broken_symlinks_removed: u32 = 0,
+    /// Why the prefix-mutating sweeps were skipped, when they were: `Timeout` =
+    /// a live op holds the lock; `DirMissing` = no db/ (nothing installed); the
+    /// acquire failures are surfaced by the caller.
+    mutations_skipped: ?lock_mod.LockError = null,
 
     pub fn fixesApplied(self: FixOutcome) u32 {
         var n: u32 = 0;
@@ -382,9 +386,28 @@ pub const FixOutcome = struct {
     }
 };
 
-/// Drive the safe-fix policy end-to-end. Pure of UI: the caller emits
-/// styled lines via the project's output helpers from the returned
-/// outcome. In `dry_run` mode no filesystem mutation happens.
+/// `stale_lock` is repaired without the lock (a dead holder has nothing to
+/// serialize against); the two prefix mutations must run behind `malt.lock`.
+fn requiresPrefixLock(kind: FixKind) bool {
+    return switch (kind) {
+        .stale_lock => false,
+        .orphaned_store, .broken_symlinks => true,
+    };
+}
+
+fn planNeedsPrefixLock(plan: Plan) bool {
+    var it = plan.safe.iterator();
+    while (it.next()) |kind| if (requiresPrefixLock(kind)) return true;
+    return false;
+}
+
+/// Non-blocking single pass: doctor-fix skips fast, never waits behind a
+/// live install (contrast uninstall's multi-second wait).
+const fix_lock_timeout_ms: u32 = 0;
+
+/// Drive the safe-fix policy end-to-end in three ordered steps. Pure of UI:
+/// the caller emits styled lines from the returned outcome. In `dry_run`
+/// mode no filesystem mutation happens.
 pub fn executeFix(ctx: FixCtx, dry_run: bool) FixOutcome {
     const conditions: Conditions = ctx.conditions orelse .{
         .stale_lock = probeStaleLock(ctx.io, ctx.prefix),
@@ -396,11 +419,30 @@ pub fn executeFix(ctx: FixCtx, dry_run: bool) FixOutcome {
     const plan = if (ctx.only) |kind| planFixes(conditions).onlySafe(kind) else planFixes(conditions);
 
     var outcome: FixOutcome = .{ .plan = plan };
+    // Early return keeps the acquire after it: `--fix --dry-run` never
+    // touches the lock.
     if (dry_run) return outcome;
 
+    // Step 1: reconcile the stale lock outside any held region — no acquire.
     if (plan.safe.contains(.stale_lock)) {
         outcome.stale_lock_removed = fixStaleLock(ctx.io, ctx.prefix);
     }
+
+    // Step 2: the prefix-mutating classes run only while `malt.lock` is held.
+    if (!planNeedsPrefixLock(plan)) return outcome;
+
+    var lock_buf: [512]u8 = undefined;
+    const lock_path = std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{ctx.prefix}) catch return outcome;
+    // The acquire IS the gate — do NOT re-probe `operationInFlight` first,
+    // which would reopen the TOCTOU this closes.
+    var lock = lock_mod.LockFile.acquire(ctx.io, lock_path, fix_lock_timeout_ms) catch |e| {
+        // Any skip reason — live op, fresh prefix, or a real failure — is
+        // recorded so the caller reports it, never a silent no-op.
+        outcome.mutations_skipped = e;
+        return outcome;
+    };
+    defer lock.release(ctx.io);
+
     if (plan.safe.contains(.orphaned_store)) {
         const sweep = fixOrphanedStore(ctx.io, ctx.prefix);
         outcome.orphans_removed = sweep.count;

--- a/tests/doctor_fix_test.zig
+++ b/tests/doctor_fix_test.zig
@@ -14,6 +14,7 @@ const fs_compat = test_io;
 const sqlite = malt.sqlite;
 const schema = malt.schema;
 const store_mod = malt.store;
+const lock_mod = malt.lock;
 
 // macOS user-immutable flag: makes a directory undeletable (rmdir → EPERM)
 // even for root, so a blocked sweep is deterministic across environments.
@@ -610,4 +611,240 @@ test "executeFix: dangerous classes carry into the plan, not the safe set" {
     try testing.expectEqual(@as(usize, 0), outcome.plan.safe.count());
     try testing.expect(outcome.plan.manual.contains(.corrupt_database));
     try testing.expect(outcome.plan.manual.contains(.missing_kegs));
+}
+
+// ── serialization: mutating sweeps run only under malt.lock ──────────
+
+/// Create `<prefix>/db` and `<prefix>/bin`, plant one dangling symlink under
+/// bin, and return the lock path — the shared scaffold for the held-lock
+/// serialization tests. `lock_out` receives the `<prefix>/db/malt.lock` path.
+fn seedLockAndDanglingLink(prefix: []const u8, lock_out: *[256]u8) ![]const u8 {
+    const io = std.Options.debug_io;
+    var db_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_buf, "{s}/db", .{prefix});
+    try fs_compat.makeDirAbsolute(io, db_dir);
+
+    var bin_buf: [256]u8 = undefined;
+    const bin_dir = try std.fmt.bufPrint(&bin_buf, "{s}/bin", .{prefix});
+    try fs_compat.makeDirAbsolute(io, bin_dir);
+    var bin = try fs_compat.openDirAbsolute(io, bin_dir, .{ .iterate = true });
+    defer bin.close(io);
+    try bin.symLink(io, "/tmp/malt-doctor-fix-held-target-dne", "ghost", .{});
+
+    return std.fmt.bufPrint(lock_out, "{s}/db/malt.lock", .{prefix});
+}
+
+test "executeFix: a live-held malt.lock blocks the broken-symlink sweep" {
+    // R-011: the prefix-mutating classes must not run while another process
+    // holds malt.lock — else `--fix` can delete an install's in-flight state.
+    // A live holder makes the sweep a clean skip; the identical call once the
+    // lock frees must remove the link. The acquire is the gate, so the round
+    // trip is the proof.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "held-lock");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var lock_buf: [256]u8 = undefined;
+    const lock_path = try seedLockAndDanglingLink(prefix, &lock_buf);
+
+    var bin_buf: [256]u8 = undefined;
+    const bin_dir = try std.fmt.bufPrint(&bin_buf, "{s}/bin", .{prefix});
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // A synthetic live holder: our own process takes the lock.
+    var held = try lock_mod.LockFile.acquire(io, lock_path, 1000);
+
+    const skipped = fix.executeFix(
+        .{ .prefix = prefix, .io = io, .conditions = .{ .broken_symlink_count = 1 } },
+        false,
+    );
+    try testing.expectEqual(@as(u32, 0), skipped.broken_symlinks_removed);
+    try testing.expect(symlinkEntryExists(io, bin_dir, "ghost"));
+
+    // Free the lock; the identical call now sweeps the link away.
+    held.release(io);
+    const swept = fix.executeFix(
+        .{ .prefix = prefix, .io = io, .conditions = .{ .broken_symlink_count = 1 } },
+        false,
+    );
+    try testing.expectEqual(@as(u32, 1), swept.broken_symlinks_removed);
+    try testing.expect(!symlinkEntryExists(io, bin_dir, "ghost"));
+}
+
+test "executeFix: the held-lock skip carries a reason, not a silent no-op" {
+    // A live holder must read as "operation in progress", not a clean prefix:
+    // both mutating classes skip and the outcome names Timeout as the cause.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "skip-reason");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var lock_buf: [256]u8 = undefined;
+    const lock_path = try seedLockAndDanglingLink(prefix, &lock_buf);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var held = try lock_mod.LockFile.acquire(io, lock_path, 1000);
+    defer held.release(io);
+
+    const outcome = fix.executeFix(
+        .{ .prefix = prefix, .io = io, .conditions = .{ .orphan_store_count = 1, .broken_symlink_count = 1 } },
+        false,
+    );
+    try testing.expectEqual(@as(u32, 0), outcome.orphans_removed);
+    try testing.expectEqual(@as(u32, 0), outcome.broken_symlinks_removed);
+    try testing.expectEqual(lock_mod.LockError.Timeout, outcome.mutations_skipped.?);
+}
+
+test "acquire(timeout=0) on a held malt.lock times out at once (pins the executor's gate)" {
+    // The executor gates the sweeps with a single non-blocking pass. Pin that
+    // a live holder surfaces as Timeout immediately, so the timeout-0 choice
+    // can't silently regress into a wait.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "timeout0");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_buf, "{s}/db", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, db_dir);
+    var lock_buf: [256]u8 = undefined;
+    const lock_path = try std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix});
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var held = try lock_mod.LockFile.acquire(io, lock_path, 1000);
+    defer held.release(io);
+    try testing.expectError(error.Timeout, lock_mod.LockFile.acquire(io, lock_path, 0));
+}
+
+test "executeFix: a prefix with no db/ dir reports the skip (DirMissing), never silently" {
+    // No db/ → nothing to serialize against, so the sweep is declined — but
+    // recorded, not silent, so the caller can say why (like every other
+    // declined mutation in the codebase).
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "no-db-dir");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var bin_buf: [256]u8 = undefined;
+    const bin_dir = try std.fmt.bufPrint(&bin_buf, "{s}/bin", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, bin_dir);
+    var bin = try fs_compat.openDirAbsolute(std.Options.debug_io, bin_dir, .{ .iterate = true });
+    defer bin.close(std.Options.debug_io);
+    try bin.symLink(std.Options.debug_io, "/tmp/malt-doctor-fix-nodb-target-dne", "ghost", .{});
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const outcome = fix.executeFix(
+        .{ .prefix = prefix, .io = io, .conditions = .{ .broken_symlink_count = 1 } },
+        false,
+    );
+    try testing.expectEqual(@as(u32, 0), outcome.broken_symlinks_removed);
+    try testing.expectEqual(lock_mod.LockError.DirMissing, outcome.mutations_skipped.?);
+    try testing.expect(symlinkEntryExists(io, bin_dir, "ghost"));
+}
+
+test "executeFix: an unwritable db/ dir surfaces the acquire failure, not a silent skip" {
+    // AccessDenied would read as "clean" if swallowed. It must reach the
+    // outcome so doctor can point the user at the ownership fix.
+    if (std.c.geteuid() == 0) return error.SkipZigTest; // root bypasses the perm wall
+
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "denied");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var lock_buf: [256]u8 = undefined;
+    _ = try seedLockAndDanglingLink(prefix, &lock_buf);
+
+    var db_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_buf, "{s}/db", .{prefix});
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // No lock file yet + a mode-0 db/ → the acquire's create hits EACCES.
+    var db_dir_h = try fs_compat.openDirAbsolute(io, db_dir, .{});
+    defer db_dir_h.close(io);
+    try db_dir_h.setPermissions(io, std.Io.File.Permissions.fromMode(0));
+    // Restore so the prefix teardown can recurse in.
+    defer db_dir_h.setPermissions(io, std.Io.File.Permissions.fromMode(0o755)) catch {};
+
+    const outcome = fix.executeFix(
+        .{ .prefix = prefix, .io = io, .conditions = .{ .broken_symlink_count = 1 } },
+        false,
+    );
+    try testing.expectEqual(@as(u32, 0), outcome.broken_symlinks_removed);
+    try testing.expectEqual(lock_mod.LockError.AccessDenied, outcome.mutations_skipped.?);
+}
+
+test "executeFix: --dry-run never touches the lock, even while one is held" {
+    // The acquire sits after the dry_run early return, so a plan-only run must
+    // not contend the lock at all — no skip signal despite a live holder.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "dry-held");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var lock_buf: [256]u8 = undefined;
+    const lock_path = try seedLockAndDanglingLink(prefix, &lock_buf);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var held = try lock_mod.LockFile.acquire(io, lock_path, 1000);
+    defer held.release(io);
+
+    const outcome = fix.executeFix(
+        .{ .prefix = prefix, .io = io, .conditions = .{ .broken_symlink_count = 1 } },
+        true,
+    );
+    try testing.expectEqual(@as(u32, 0), outcome.fixesApplied());
+    try testing.expect(outcome.mutations_skipped == null);
+    try testing.expect(outcome.plan.safe.contains(.broken_symlinks));
+}
+
+test "executeFix: the lock policy keys off the class, not the invocation" {
+    // `--fix stale_lock` must not need the lock (repairing the lock can't
+    // require it); `--fix broken_symlinks` must still serialize. Prove both
+    // under one live holder.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "targeted");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var lock_buf: [256]u8 = undefined;
+    const lock_path = try seedLockAndDanglingLink(prefix, &lock_buf);
+
+    var bin_buf: [256]u8 = undefined;
+    const bin_dir = try std.fmt.bufPrint(&bin_buf, "{s}/bin", .{prefix});
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var held = try lock_mod.LockFile.acquire(io, lock_path, 1000);
+    defer held.release(io);
+
+    // stale_lock target never reaches the acquire.
+    const s = fix.executeFix(
+        .{ .prefix = prefix, .io = io, .only = .stale_lock, .conditions = .{ .stale_lock = true } },
+        false,
+    );
+    try testing.expect(s.mutations_skipped == null);
+
+    // broken_symlinks target contends and skips, leaving the link intact.
+    const b = fix.executeFix(
+        .{ .prefix = prefix, .io = io, .only = .broken_symlinks, .conditions = .{ .broken_symlink_count = 1 } },
+        false,
+    );
+    try testing.expectEqual(lock_mod.LockError.Timeout, b.mutations_skipped.?);
+    try testing.expectEqual(@as(u32, 0), b.broken_symlinks_removed);
+    try testing.expect(symlinkEntryExists(io, bin_dir, "ghost"));
 }


### PR DESCRIPTION
## Description

`doctor --fix` now takes the same `malt.lock` every other mutating command holds before it sweeps orphaned stores or unlinks broken symlinks, so it can no longer corrupt an install/upgrade in flight. When a live op holds the lock it skips those repairs cleanly and says so; a stale lock (dead PID) is still repaired without waiting, because there's nothing live to serialize against.

The executor now runs three ordered steps: 
- reconcile the stale lock outside any held region (no acquire - a dead holder has nothing to serialize against)
- gate the two prefix-mutating classes on a single non-blocking `malt.lock` acquire
- report a skip when the acquire can't be taken. 
 
The pure planner (`planFixes` / `Plan.onlySafe`) is untouched.

## Related Issue

- None

## Notes for Reviewers

- None