### PR TITLE
fix(doctor): reap orphan store entries atomically so a partial delete never outlives its ref row

### DIFF
--- a/scripts/regressions/partial-deletetree-corrupt-referenced-store.sh
+++ b/scripts/regressions/partial-deletetree-corrupt-referenced-store.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Regression: `mt doctor --fix` must never leave a store entry that is partially
+# emptied on disk yet still claimed by a live `store_refs` row.
+#
+# The orphan reaper deleted the entry's directory tree in place and only cleared
+# the ref row on full success. `deleteTree` is not atomic: an undeletable *child*
+# left the earlier siblings gone while the row survived — a corrupt entry the DB
+# still reports as valid, so a later link/verify reads truncated store content.
+#
+# This seeds a true refcount-0 orphan with two children, makes one *child*
+# undeletable with the macOS immutable flag (root-proof, so it reproduces in any
+# CI), runs `mt doctor --fix`, and asserts the consistent end-state: the entry is
+# gone from the referenced path and its ref row is cleared.
+#
+# Usage: scripts/regressions/partial-deletetree-corrupt-referenced-store.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt, sqlite3 on PATH,
+# macOS (chflags). Offline; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+command -v sqlite3 >/dev/null 2>&1 || {
+  printf 'SKIP: sqlite3 not on PATH — needed to seed the refcount-0 row.\n' >&2
+  exit 2
+}
+command -v chflags >/dev/null 2>&1 || {
+  printf 'SKIP: chflags not available — this guard needs macOS.\n' >&2
+  exit 2
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+SHA="deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+PFX=$(mktemp -d -t mt_partial_deletetree.XXXXXX)
+export MALT_PREFIX="$PFX"
+# Clear the immutable flag before removing, or cleanup itself is blocked. The
+# reaped child may end up under .malt-reap-*, so clear recursively.
+trap 'chflags -R nouchg "$PFX" 2>/dev/null || true; rm -rf "$PFX"' EXIT
+
+mkdir -p "$PFX/db" "$PFX/store/$SHA"
+# Two children so a failure on one leaves the other behind — the partial state.
+: >"$PFX/store/$SHA/a"
+: >"$PFX/store/$SHA/b"
+
+# Materialise the schema via the real initializer, then seed a refcount-0 row so
+# the store dir is a true orphan the reaper will try to sweep.
+"$MALT_BIN" purge --store-orphans </dev/null >/dev/null 2>&1 || true
+sqlite3 "$PFX/db/malt.db" \
+  "INSERT OR REPLACE INTO store_refs (store_sha256, refcount) VALUES ('$SHA', 0);"
+
+# Undeletable child under a deletable parent: unlink of an immutable file fails.
+chflags uchg "$PFX/store/$SHA/b"
+
+"$MALT_BIN" doctor --fix </dev/null >/dev/null 2>&1 || true
+
+# Bug present (pre-fix): the entry survives half-emptied (child 'a' gone) while
+# its ref row lives on — corrupt-but-referenced.
+# Bug absent (post-fix): the entry is gone from the referenced path and the row
+# is cleared; the immutable bytes are left as unreferenced junk elsewhere.
+row_count=$(sqlite3 "$PFX/db/malt.db" \
+  "SELECT count(*) FROM store_refs WHERE store_sha256='$SHA';")
+
+if [[ -d "$PFX/store/$SHA" ]]; then
+  fail "store/$SHA survived the sweep (partial: 'a'=$([[ -e "$PFX/store/$SHA/a" ]] && echo present || echo gone)) while store_refs row count=$row_count"
+fi
+[[ "$row_count" == "0" ]] ||
+  fail "store/$SHA was reaped but its store_refs row survived (count=$row_count) — corrupt-but-referenced"
+
+printf 'PASS: orphan sweep leaves no partial store entry under a live ref row\n'

--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -181,10 +181,14 @@ pub fn probeOrphanedStoreCount(io: std.Io, prefix: []const u8) u32 {
 
 /// Outcome of an orphan walk. Probe (`do_remove = false`): `count` is the
 /// number of orphans detected, `blocked` is always 0. Reap (`do_remove =
-/// true`): `count` is the number removed, `blocked` is the number of orphans
-/// that could not be removed (undeletable dir — permissions, a held file, an
-/// immutable flag); `reason` names the blocker so `--fix` can explain a
-/// partial sweep rather than report a silent no-op.
+/// true`): `count` is the number de-referenced (entry renamed out of the store
+/// namespace and its ref row cleared, regardless of whether every byte was then
+/// reclaimed); `blocked` is the number whose *entry dir* could not even be
+/// renamed aside (permissions, an immutable entry dir), leaving it referenced.
+/// A surviving immutable *child* is not blocked — the entry is already
+/// de-referenced, so it counts as removed and the leftover bytes are a reclaim
+/// concern, not store corruption. `reason` names the blocker so `--fix` can
+/// explain a partial sweep rather than report a silent no-op.
 pub const OrphanSweep = struct {
     count: u32 = 0,
     blocked: u32 = 0,
@@ -201,6 +205,11 @@ pub fn fixOrphanedStore(io: std.Io, prefix: []const u8) OrphanSweep {
 
 fn walkOrphans(io: std.Io, prefix: []const u8, do_remove: bool) OrphanSweep {
     var result: OrphanSweep = .{};
+    // Reclaim `.malt-reap-*` leftovers from a prior sweep whose byte reclaim was
+    // blocked, so un-reapable bytes cannot leak across runs. Reap path only — a
+    // read-only probe must never mutate disk.
+    if (do_remove) reapStaleLeftovers(io, prefix);
+
     var db_path_buf: [512]u8 = undefined;
     const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return result;
     var db = sqlite.Database.open(db_path) catch return result;
@@ -224,13 +233,61 @@ fn walkOrphans(io: std.Io, prefix: []const u8, do_remove: bool) OrphanSweep {
     return result;
 }
 
-/// Remove one orphan's store dir and clear its ref row. Returns false when
-/// the directory could not be removed, so the caller can report it.
+/// Best-effort removal of `.malt-reap-*` staging dirs a previous sweep renamed
+/// aside but could not fully delete (immutable child). Housekeeping, not an
+/// orphan sweep — never counted. In-pass deletion mirrors `forEachBrokenSymlink`.
+fn reapStaleLeftovers(io: std.Io, prefix: []const u8) void {
+    var dir = std.Io.Dir.openDirAbsolute(io, prefix, .{ .iterate = true }) catch return;
+    defer dir.close(io);
+    var it = dir.iterate();
+    while (it.next(io) catch null) |entry| {
+        if (!std.mem.startsWith(u8, entry.name, ".malt-reap-")) continue;
+        var path_buf: [768]u8 = undefined;
+        const p = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ prefix, entry.name }) catch continue;
+        std.Io.Dir.cwd().deleteTree(io, p) catch {};
+    }
+}
+
+/// How many staging names to probe before giving up. Only a stranded
+/// `.malt-reap-*` (an immutable child a prior sweep could not reclaim) occupies
+/// a candidate, so one or two suffice in practice; the cap is a safety bound.
+const reap_name_attempts: u8 = 16;
+
+/// Remove one orphan's store dir and clear its ref row. Returns false when the
+/// entry could not be de-referenced (an undeletable *entry dir* — permissions,
+/// immutable flag), so the caller can report it as blocked.
+///
+/// `deleteTree` is non-atomic: a mid-tree failure on an undeletable *child* used
+/// to leave the entry half-emptied while its ref row survived — a corrupt entry
+/// the DB still called valid. Renaming the entry out of the referenced path
+/// first makes the removal atomic from the ref row's view: once renamed, the row
+/// is cleared and any surviving bytes are unreferenced junk, never a corrupt
+/// referenced entry. Reap names are siblings of `store/` (never visited by its
+/// iteration, same filesystem → no CrossDevice) and probed for a free slot so a
+/// prior stranded leftover cannot block an otherwise-deletable entry.
 fn removeEntry(io: std.Io, prefix: []const u8, db: *sqlite.Database, name: []const u8) bool {
     var entry_buf: [768]u8 = undefined;
     const entry_path = std.fmt.bufPrint(&entry_buf, "{s}/store/{s}", .{ prefix, name }) catch return false;
-    std.Io.Dir.cwd().deleteTree(io, entry_path) catch return false;
+
+    var reap_buf: [768]u8 = undefined;
+    var attempt: u8 = 0;
+    const reap_path = while (attempt < reap_name_attempts) : (attempt += 1) {
+        const candidate = (if (attempt == 0)
+            std.fmt.bufPrint(&reap_buf, "{s}/.malt-reap-{s}", .{ prefix, name })
+        else
+            std.fmt.bufPrint(&reap_buf, "{s}/.malt-reap-{s}-{d}", .{ prefix, name, attempt })) catch return false;
+        std.Io.Dir.renameAbsolute(entry_path, candidate, io) catch |e| switch (e) {
+            // A non-empty stranded staging dir holds this name — try the next.
+            error.DirNotEmpty => continue,
+            // Undeletable entry dir (permissions/immutable): genuinely blocked.
+            else => return false,
+        };
+        break candidate;
+    } else return false;
+
     deleteRefRow(db, name);
+    // Best-effort byte reclaim; a surviving immutable child is left unreferenced.
+    std.Io.Dir.cwd().deleteTree(io, reap_path) catch {};
     return true;
 }
 

--- a/tests/doctor_fix_test.zig
+++ b/tests/doctor_fix_test.zig
@@ -410,6 +410,173 @@ test "fixOrphanedStore: a partial sweep removes what it can and reports the rest
     try testing.expect(sweep.reason != null);
 }
 
+test "fixOrphanedStore: an immutable child never leaves a partial entry under a live ref row" {
+    // The corruption case: a deletable orphan dir with one undeletable child.
+    // An in-place tree delete unlinks the siblings, fails on the child, and
+    // keeps the ref row — leaving a half-empty entry the DB still calls valid.
+    // The sweep must de-reference the entry atomically: gone from the store
+    // namespace with its row cleared, the un-reapable bytes left as unreferenced
+    // junk, never a corrupt-but-referenced entry.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "immutable-child");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db_dir_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_dir_buf, "{s}/db", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, db_dir);
+    var store_dir_buf: [256]u8 = undefined;
+    const store_dir = try std.fmt.bufPrint(&store_dir_buf, "{s}/store", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, store_dir);
+
+    var db_path_buf: [256]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    const sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    var entry_dir_buf: [320]u8 = undefined;
+    const entry_dir = try std.fmt.bufPrint(&entry_dir_buf, "{s}/store/{s}", .{ prefix, sha });
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, entry_dir);
+
+    // Two children so a failure on one leaves the other behind — the partial state.
+    var a_buf: [384]u8 = undefined;
+    try writeFile(try std.fmt.bufPrint(&a_buf, "{s}/a", .{entry_dir}), "x");
+    var b_buf: [384]u8 = undefined;
+    try writeFile(try std.fmt.bufPrint(&b_buf, "{s}/b", .{entry_dir}), "x");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var store = store_mod.Store.init(io, testing.allocator, &db, prefix);
+    try store.incrementRef(sha);
+    try store.decrementRef(sha);
+
+    // Make one child undeletable; clear the flag wherever it ends up (the sweep
+    // renames the entry aside), or the prefix teardown itself would block.
+    var child_z_buf: [384]u8 = undefined;
+    const child_z = try std.fmt.bufPrintSentinel(&child_z_buf, "{s}/b", .{entry_dir}, 0);
+    try testing.expectEqual(@as(c_int, 0), c.chflags(child_z.ptr, UF_IMMUTABLE));
+    defer _ = c.chflags(child_z.ptr, 0);
+    var reap_child_z_buf: [384]u8 = undefined;
+    const reap_child_z = try std.fmt.bufPrintSentinel(&reap_child_z_buf, "{s}/.malt-reap-{s}/b", .{ prefix, sha }, 0);
+    defer _ = c.chflags(reap_child_z.ptr, 0);
+
+    const sweep = fix.fixOrphanedStore(io, prefix);
+    // De-referenced and gone from the store namespace → credited, not blocked.
+    try testing.expectEqual(@as(u32, 1), sweep.count);
+    try testing.expectEqual(@as(u32, 0), sweep.blocked);
+    // Consistent end-state: entry gone from the referenced path, ref row cleared.
+    try testing.expect(!pathExists(entry_dir));
+    try testing.expectEqual(@as(u32, 0), fix.probeOrphanedStoreCount(io, prefix));
+    // The un-reapable child survives only as unreferenced junk, not corruption.
+    var reap_dir_buf: [320]u8 = undefined;
+    const reap_child = try std.fmt.bufPrint(&reap_dir_buf, "{s}/.malt-reap-{s}/b", .{ prefix, sha });
+    try testing.expect(pathExists(reap_child));
+}
+
+test "fixOrphanedStore: a stale .malt-reap-* leftover is reclaimed by the reap, not the probe, and never counted" {
+    // A prior sweep can strand a `.malt-reap-*` staging dir (immutable child).
+    // The reap reclaims it as housekeeping — never counted as an orphan — while
+    // the read-only probe must leave disk untouched.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "reap-leftover");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db_dir_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_dir_buf, "{s}/db", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, db_dir);
+    var store_dir_buf: [256]u8 = undefined;
+    const store_dir = try std.fmt.bufPrint(&store_dir_buf, "{s}/store", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, store_dir);
+
+    var db_path_buf: [256]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // A leftover staging dir, a sibling of store/ (never a valid orphan sha).
+    var reap_buf: [320]u8 = undefined;
+    const reap_dir = try std.fmt.bufPrint(&reap_buf, "{s}/.malt-reap-deadbeef", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, reap_dir);
+    var leaf_buf: [384]u8 = undefined;
+    try writeFile(try std.fmt.bufPrint(&leaf_buf, "{s}/x", .{reap_dir}), "x");
+
+    // The probe is read-only: leftover untouched, nothing counted.
+    try testing.expectEqual(@as(u32, 0), fix.probeOrphanedStoreCount(io, prefix));
+    try testing.expect(pathExists(reap_dir));
+
+    // The reap reclaims the leftover without crediting it as a swept orphan.
+    const sweep = fix.fixOrphanedStore(io, prefix);
+    try testing.expectEqual(@as(u32, 0), sweep.count);
+    try testing.expectEqual(@as(u32, 0), sweep.blocked);
+    try testing.expect(!pathExists(reap_dir));
+}
+
+test "fixOrphanedStore: a stranded reap dir does not block reaping a fresh same-sha orphan" {
+    // The corner a fixed staging name would trip: a prior sweep stranded
+    // `.malt-reap-<sha>` (an immutable child housekeeping cannot reclaim), then
+    // the same sha reappears as a fresh, fully-deletable orphan. Renaming onto
+    // the stranded non-empty dir fails with DirNotEmpty; the sweep must probe a
+    // free staging name and still reap the entry, not report it blocked.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "reap-collision");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db_dir_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_dir_buf, "{s}/db", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, db_dir);
+    var store_dir_buf: [256]u8 = undefined;
+    const store_dir = try std.fmt.bufPrint(&store_dir_buf, "{s}/store", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, store_dir);
+
+    var db_path_buf: [256]u8 = undefined;
+    const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0);
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+    try schema.initSchema(&db);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+    // A stranded, unreclaimable staging dir occupying the primary reap name.
+    var stranded_buf: [320]u8 = undefined;
+    const stranded = try std.fmt.bufPrint(&stranded_buf, "{s}/.malt-reap-{s}", .{ prefix, sha });
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, stranded);
+    var stuck_z_buf: [384]u8 = undefined;
+    const stuck_z = try std.fmt.bufPrintSentinel(&stuck_z_buf, "{s}/stuck", .{stranded}, 0);
+    try writeFile(std.mem.sliceTo(stuck_z, 0), "x");
+    try testing.expectEqual(@as(c_int, 0), c.chflags(stuck_z.ptr, UF_IMMUTABLE));
+    defer _ = c.chflags(stuck_z.ptr, 0);
+
+    // A fresh, fully-deletable orphan under the same sha.
+    var entry_dir_buf: [320]u8 = undefined;
+    const entry_dir = try std.fmt.bufPrint(&entry_dir_buf, "{s}/store/{s}", .{ prefix, sha });
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, entry_dir);
+    var leaf_buf: [384]u8 = undefined;
+    try writeFile(try std.fmt.bufPrint(&leaf_buf, "{s}/a", .{entry_dir}), "x");
+
+    var store = store_mod.Store.init(io, testing.allocator, &db, prefix);
+    try store.incrementRef(sha);
+    try store.decrementRef(sha);
+
+    const sweep = fix.fixOrphanedStore(io, prefix);
+    // Reaped despite the stranded name — probed to a free slot, not blocked.
+    try testing.expectEqual(@as(u32, 1), sweep.count);
+    try testing.expectEqual(@as(u32, 0), sweep.blocked);
+    try testing.expect(!pathExists(entry_dir));
+    try testing.expectEqual(@as(u32, 0), fix.probeOrphanedStoreCount(io, prefix));
+}
+
 test "orphan parity: a no-row store entry is invisible to both doctor and purge" {
     // A store dir with no `store_refs` row is a warm / in-flight commit
     // (`--download-only`, or an install interrupted before `incrementRef`).


### PR DESCRIPTION
## Description

`mt doctor --fix` swept an orphaned store entry with an in place `deleteTree` and only cleared its `store_refs` row on full success. `deleteTree` is not atomic: an undeletable *child* (held-open, permission-denied, immutable) left the earlier siblings gone while the ref row survived - a store entry the database still reported as valid but whose bytes were truncated, so a later link/verify against that sha read corrupt content.

The sweep now renames the entry out of its referenced path before reclaiming bytes. Once renamed, the row is cleared and any surviving bytes are unreferenced junk under a staging name, never a corrupt-but-referenced entry. The two consistent end-states (present & referenced, or absent & unreferenced) are the only ones reachable; the partial-and referenced state is gone.

## Related Issue

- None

## Notes for Reviewers

- None