### PR TITLE
refactor(net): stream a GET response body to a caller sink

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -157,6 +157,7 @@ pub fn build(b: *std.Build) void {
         "tests/archive_test.zig",
         "tests/ghcr_test.zig",
         "tests/ghcr_401_retry_test.zig",
+        "tests/net_get_to_writer_test.zig",
         "tests/linker_core_test.zig",
         "tests/supervisor_pure_test.zig",
         "tests/install_pure_test.zig",

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -19,6 +19,24 @@ pub const DownloadError = error{
     OfflineRequired,
 };
 
+/// Explicit error set for the streaming GET (`getToWriter`). Net is a leaf
+/// (Rule U1), so it returns a typed set the caller `switch`es on rather than
+/// leaking std.http's inferred errors. Transport-level failures
+/// (connect / TLS / reading the head) collapse to `RequestFailed`; by the time
+/// one escapes, the retry loop has already exhausted its attempts.
+pub const GetError = error{
+    OfflineRequired,
+    RequestFailed,
+    TlsDowngradeRefused,
+    TooManyHttpRedirects,
+    HttpRedirectInvalid,
+    ResponseTooLarge,
+    ReadFailed,
+    WatchdogSpawnFailed,
+    Canceled,
+    OutOfMemory,
+};
+
 pub const DownloadDiagnostic = struct {
     status: ?u16,
     url: []const u8,
@@ -436,6 +454,23 @@ pub const HttpClient = struct {
         return self.doGetWithRetry(url, extra_headers, max_blob_bytes, progress);
     }
 
+    /// Streaming sibling of `getWithHeaders`: drains a 200 body straight into
+    /// `sink` and returns only the status — no full-size body buffer. Non-200
+    /// bodies go to a bounded throwaway so `sink` stays pristine until the
+    /// response is definitively good, and a mid-200-stream failure is returned
+    /// (never retried) so the single-use `sink` is written at most once. Net is
+    /// a leaf, so the error set is explicit (Rule U1).
+    pub fn getToWriter(
+        self: *HttpClient,
+        url: []const u8,
+        extra_headers: []const std.http.Header,
+        sink: *std.Io.Writer,
+        progress: ?ProgressCallback,
+    ) GetError!u16 {
+        if (self.offline) return error.OfflineRequired;
+        return self.doGetToWriterWithRetry(url, extra_headers, sink, progress);
+    }
+
     /// Perform a HEAD request and return only the HTTP status code.
     pub fn head(self: *HttpClient, url: []const u8) !u16 {
         if (self.offline) return error.OfflineRequired;
@@ -644,24 +679,25 @@ pub const HttpClient = struct {
         return self.doGetWithRetry(url, extra_headers, max_metadata_bytes, null);
     }
 
-    /// Read a response body with the same decompress + idle/total
-    /// watchdog + size cap that the legacy `doGetLimited` path uses.
-    /// Both the generic GET and the conditional GET converge here so
-    /// the single transport policy is enforced in one place — only the
-    /// `total_timeout_ns` differs between callers (blob downloads scale
-    /// it from `content_length`; metadata reads pin it to `self.timeout_ns`).
-    fn readResponseBody(
+    /// Stream a response body into a caller-provided `sink` with the same
+    /// decompress + idle/total watchdog + size cap the buffer path uses. The
+    /// watchdog's spawn/join wraps the streaming call so a stalled sink is
+    /// still killed. Both the generic GET and the conditional GET converge here
+    /// so the single transport policy lives in one place — only the
+    /// `total_timeout_ns` differs between callers (blob downloads scale it from
+    /// `content_length`; metadata reads pin it to `self.timeout_ns`). The sink
+    /// is single-use: on error it holds whatever bytes already arrived and net
+    /// never rewinds it.
+    fn streamResponseBody(
         self: *HttpClient,
         req: *std.http.Client.Request,
         response: *std.http.Client.Response,
+        sink: *std.Io.Writer,
         max_bytes: usize,
         progress: ?ProgressCallback,
         total_timeout_ns: u64,
-    ) !([]const u8) {
+    ) !void {
         const content_length: ?u64 = response.head.content_length;
-
-        var body_writer: std.Io.Writer.Allocating = .init(self.allocator);
-        errdefer body_writer.deinit();
 
         const decompress_buffer: []u8 = switch (response.head.content_encoding) {
             .identity => &.{},
@@ -675,7 +711,7 @@ pub const HttpClient = struct {
         var body_reader = response.readerDecompressing(&transfer_buffer, &decompress, decompress_buffer);
 
         var counting = CountingWriter{
-            .inner = &body_writer.writer,
+            .inner = sink,
             .bytes_written = std.atomic.Value(u64).init(0),
             .max_bytes = max_bytes,
             .limit_exceeded = false,
@@ -713,7 +749,22 @@ pub const HttpClient = struct {
         };
 
         if (counting.limit_exceeded) return error.ResponseTooLarge;
+    }
 
+    /// Buffer wrapper over `streamResponseBody`: supplies its own `Allocating`
+    /// writer so every existing metadata/JSON/blob GET keeps returning an owned
+    /// slice, byte-for-byte unchanged by the sink split.
+    fn readResponseBody(
+        self: *HttpClient,
+        req: *std.http.Client.Request,
+        response: *std.http.Client.Response,
+        max_bytes: usize,
+        progress: ?ProgressCallback,
+        total_timeout_ns: u64,
+    ) !([]const u8) {
+        var body_writer: std.Io.Writer.Allocating = .init(self.allocator);
+        errdefer body_writer.deinit();
+        try self.streamResponseBody(req, response, &body_writer.writer, max_bytes, progress, total_timeout_ns);
         return try body_writer.toOwnedSlice();
     }
 
@@ -946,6 +997,122 @@ pub const HttpClient = struct {
             .body = out.body,
             .allocator = self.allocator,
         };
+    }
+
+    /// Streaming counterpart of `doGetWithRetry`: threads `sink` through and
+    /// returns status only. The pre-body retry (transient status, transport
+    /// failure) still fires because the sink is untouched until a 200 body
+    /// starts draining — `followGetToWriter` flips `sink_committed` at that
+    /// point, and once it is set a mid-stream failure is surfaced, never
+    /// retried, keeping the sink single-use.
+    fn doGetToWriterWithRetry(
+        self: *HttpClient,
+        url: []const u8,
+        extra_headers: []const std.http.Header,
+        sink: *std.Io.Writer,
+        progress: ?ProgressCallback,
+    ) GetError!u16 {
+        var attempt: usize = 0;
+        while (true) {
+            var sink_committed = false;
+            const result = self.followGetToWriter(url, extra_headers, sink, progress, &sink_committed);
+            if (result) |status| {
+                if (classifyStatus(status)) |dl_err| {
+                    if (isTransientError(dl_err) and attempt < max_retries) {
+                        try self.retrySleep(attempt);
+                        attempt += 1;
+                        continue;
+                    }
+                }
+                return status;
+            } else |err| {
+                // Past the 200 commit the sink holds partial bytes and cannot
+                // be rewound, so the caller owns recovery: surface the error
+                // instead of retrying into a dirty sink.
+                if (sink_committed) return err;
+                if (attempt < max_retries) {
+                    try self.retrySleep(attempt);
+                    attempt += 1;
+                    continue;
+                }
+                return err;
+            }
+        }
+    }
+
+    /// Redirect-following streaming GET (mirrors `followGet`, minus the etag
+    /// capture and the owned-slice return). A 200 body streams into `sink`
+    /// after `sink_committed` is set; any non-200 body drains into a bounded
+    /// discard so status classification and connection reuse behave as on the
+    /// buffer path while `sink` stays pristine.
+    fn followGetToWriter(
+        self: *HttpClient,
+        url: []const u8,
+        creds: []const std.http.Header,
+        sink: *std.Io.Writer,
+        progress: ?ProgressCallback,
+        sink_committed: *bool,
+    ) GetError!u16 {
+        var current: []const u8 = self.allocator.dupe(u8, url) catch return error.OutOfMemory;
+        defer self.allocator.free(current);
+        var live_creds = creds;
+        var hops: usize = 0;
+
+        while (true) : (hops += 1) {
+            const uri = std.Uri.parse(current) catch return error.RequestFailed;
+            const https_origin = schemeIsHttps(uri.scheme);
+
+            var req = self.client.request(.GET, uri, .{
+                .extra_headers = live_creds,
+                .redirect_behavior = .unhandled,
+            }) catch return error.RequestFailed;
+            errdefer req.deinit();
+
+            req.sendBodiless() catch return error.RequestFailed;
+            var redirect_buf: [32 * 1024]u8 = undefined;
+            var response = req.receiveHead(&redirect_buf) catch return error.RequestFailed;
+            const status: u16 = @intFromEnum(response.head.status);
+
+            if (isFollowableRedirect(status)) {
+                const loc = response.head.location orelse return error.HttpRedirectInvalid;
+                if (hops >= max_get_redirects) return error.TooManyHttpRedirects;
+                const next = self.resolveRedirectUrl(uri, loc) catch |e| switch (e) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    else => return error.HttpRedirectInvalid,
+                };
+                errdefer self.allocator.free(next);
+                const next_uri = std.Uri.parse(next) catch return error.HttpRedirectInvalid;
+                if (https_origin and !schemeIsHttps(next_uri.scheme))
+                    return error.TlsDowngradeRefused;
+                if (!credsSurviveRedirect(current, next)) live_creds = &.{};
+                req.deinit();
+                self.allocator.free(current);
+                current = next;
+                continue;
+            }
+
+            const total_timeout = @max(blob_timeout_ns, scaledTimeoutNs(response.head.content_length));
+
+            if (status == 200) {
+                // Commit point: past here a transport failure must not retry.
+                sink_committed.* = true;
+                try self.streamResponseBody(&req, &response, sink, max_blob_bytes, progress, total_timeout);
+                req.deinit();
+                return status;
+            }
+
+            // Non-200: drain the error body into a bounded discard so status
+            // classification / pre-body retry behave as on the buffer path and
+            // the pooled connection stays reusable — all while `sink` is left
+            // untouched.
+            // Zero-length buffer: `CountingWriter` sits on top and delegates
+            // every write straight to `drain`, so the discard never buffers.
+            var discard_buf: [0]u8 = undefined;
+            var discarding: std.Io.Writer.Discarding = .init(&discard_buf);
+            try self.streamResponseBody(&req, &response, &discarding.writer, max_metadata_bytes, null, self.timeout_ns);
+            req.deinit();
+            return status;
+        }
     }
 
     /// On a fired deadline (or cancellation), shuts down the request's

--- a/tests/net_get_to_writer_test.zig
+++ b/tests/net_get_to_writer_test.zig
@@ -1,0 +1,338 @@
+//! malt — offline integration tests for `HttpClient.getToWriter`, the
+//! streaming GET that drains a 200 body straight into a caller-provided
+//! `*std.Io.Writer` and returns only the status. Each test stands up a
+//! localhost `std.http.Server` (the same loopback transport the other net
+//! tests use), so no real network is touched.
+//!
+//! The invariant under test is the retry × stateful-sink policy: the sink is
+//! written *only* once the response is a definitive 200, and a mid-200-stream
+//! transport failure surfaces to the caller instead of being retried into the
+//! now-dirty sink.
+
+const std = @import("std");
+const client = @import("malt").client;
+const net = std.Io.net;
+
+const body_200 = "STREAMED-BOTTLE-BYTES-0123456789-ABCDEF";
+
+const Mode = enum {
+    /// Every GET answers 200 with `body_200`.
+    ok,
+    /// First GET answers 503 (a transient error net retries), later ones 200.
+    err_then_ok,
+    /// First GET answers 401 (a non-transient status the caller re-auths on),
+    /// later ones 200 — mirrors GHCR's re-auth handshake.
+    unauth_then_ok,
+    /// A 200 that sends one chunk then drops the connection without the
+    /// terminating chunk: the client's body read fails mid-stream.
+    truncated,
+    /// First GET answers a 302 to `/final`; the followed GET answers 200 —
+    /// exercises the streaming redirect loop.
+    redirect_then_ok,
+};
+
+const Stub = struct {
+    io: std.Io,
+    listener: *net.Server,
+    mode: Mode,
+    get_count: usize = 0,
+};
+
+// Serves the request sequence on one keep-alive connection, looping until the
+// client closes (which surfaces as a `receiveHead` error). The truncated mode
+// closes the connection itself after a short partial body.
+fn serve(s: *Stub) void {
+    const stream = s.listener.accept(s.io) catch return;
+    defer stream.close(s.io);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var reader = stream.reader(s.io, &rbuf);
+    var writer = stream.writer(s.io, &wbuf);
+    var srv = std.http.Server.init(&reader.interface, &writer.interface);
+    while (true) {
+        var req = srv.receiveHead() catch return;
+        const target = req.head.target;
+        s.get_count += 1;
+        switch (s.mode) {
+            .ok => req.respond(body_200, .{}) catch return,
+            .redirect_then_ok => if (std.mem.indexOf(u8, target, "/final") != null)
+                req.respond(body_200, .{}) catch return
+            else
+                req.respond("", .{
+                    .status = .found,
+                    .extra_headers = &.{.{ .name = "location", .value = "/final" }},
+                }) catch return,
+            .err_then_ok => if (s.get_count == 1)
+                req.respond("service unavailable\n", .{ .status = .service_unavailable }) catch return
+            else
+                req.respond(body_200, .{}) catch return,
+            .unauth_then_ok => if (s.get_count == 1)
+                req.respond("unauthorized\n", .{ .status = .unauthorized }) catch return
+            else
+                req.respond(body_200, .{}) catch return,
+            .truncated => {
+                // Chunked 200: emit one chunk, flush it, then drop the socket
+                // without the terminating 0-chunk so the client's body read
+                // fails mid-stream.
+                var body_buf: [64]u8 = undefined;
+                var bw = req.respondStreaming(&body_buf, .{}) catch return;
+                bw.writer.writeAll("partial") catch return;
+                bw.flush() catch return;
+                return;
+            },
+        }
+    }
+}
+
+test "getToWriter streams a 200 body into the caller sink and returns 200" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var stub = Stub{ .io = io, .listener = &listener, .mode = .ok };
+    const server_thread = try std.Thread.spawn(.{}, serve, .{&stub});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/blobs/sha256:abc", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+
+    var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer sink.deinit();
+
+    const status = http.getToWriter(url, &.{}, &sink.writer, null);
+
+    http.deinit();
+    server_thread.join();
+
+    try std.testing.expectEqual(@as(u16, 200), try status);
+    try std.testing.expectEqualStrings(body_200, sink.writer.buffered());
+}
+
+test "getWithHeaders remains byte-identical against the same fixture (buffer path guard)" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var stub = Stub{ .io = io, .listener = &listener, .mode = .ok };
+    const server_thread = try std.Thread.spawn(.{}, serve, .{&stub});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/blobs/sha256:abc", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+
+    const result = http.getWithHeaders(url, &.{}, null);
+
+    http.deinit();
+    server_thread.join();
+
+    var resp = try result;
+    defer resp.deinit();
+    try std.testing.expectEqual(@as(u16, 200), resp.status);
+    // The buffer wrapper still returns the whole body as an owned slice.
+    try std.testing.expectEqualStrings(body_200, resp.body);
+}
+
+test "getToWriter drains a non-200 to a throwaway, keeps the sink pristine, streams the 200 on retry" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var stub = Stub{ .io = io, .listener = &listener, .mode = .err_then_ok };
+    const server_thread = try std.Thread.spawn(.{}, serve, .{&stub});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/blobs/sha256:abc", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+
+    var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer sink.deinit();
+
+    const status = http.getToWriter(url, &.{}, &sink.writer, null);
+
+    http.deinit();
+    server_thread.join();
+
+    // net retried the transient 503 internally and reached the 200.
+    try std.testing.expectEqual(@as(u16, 200), try status);
+    // The 503 error page never reached the caller's sink.
+    try std.testing.expectEqualStrings(body_200, sink.writer.buffered());
+    try std.testing.expectEqual(@as(usize, 2), stub.get_count);
+}
+
+test "getToWriter keeps the sink pristine across a caller-driven 401 re-auth" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var stub = Stub{ .io = io, .listener = &listener, .mode = .unauth_then_ok };
+    const server_thread = try std.Thread.spawn(.{}, serve, .{&stub});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/blobs/sha256:abc", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+
+    var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer sink.deinit();
+
+    // First attempt: 401 is non-transient, so net returns it without retrying
+    // and without touching the sink — exactly what lets the caller re-auth.
+    const first = http.getToWriter(url, &.{}, &sink.writer, null);
+    try std.testing.expectEqual(@as(u16, 401), try first);
+    try std.testing.expectEqual(@as(usize, 0), sink.writer.buffered().len);
+
+    // Caller re-issues (as GHCR does with a fresh bearer): now the sink fills
+    // once with the 200 body — never the 401 page.
+    const second = http.getToWriter(url, &.{}, &sink.writer, null);
+
+    http.deinit();
+    server_thread.join();
+
+    try std.testing.expectEqual(@as(u16, 200), try second);
+    try std.testing.expectEqualStrings(body_200, sink.writer.buffered());
+}
+
+test "getToWriter surfaces a mid-200-stream transport failure without retrying" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var stub = Stub{ .io = io, .listener = &listener, .mode = .truncated };
+    const server_thread = try std.Thread.spawn(.{}, serve, .{&stub});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/blobs/sha256:abc", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+
+    var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer sink.deinit();
+
+    const status = http.getToWriter(url, &.{}, &sink.writer, null);
+
+    http.deinit();
+    server_thread.join();
+
+    // A typed transport error, not a status; the sink was written at most once.
+    try std.testing.expectError(error.ReadFailed, status);
+    // The commit-to-sink was single-shot: net did NOT re-issue the GET.
+    try std.testing.expectEqual(@as(usize, 1), stub.get_count);
+}
+
+// Records the final progress report so a test can prove the callback fires on
+// the streaming path (not just the legacy buffer path).
+const ProgressRec = struct {
+    calls: usize = 0,
+    last_bytes: u64 = 0,
+    last_len: ?u64 = null,
+
+    fn record(ctx: *anyopaque, bytes_so_far: u64, content_length: ?u64) void {
+        const self: *ProgressRec = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        self.last_bytes = bytes_so_far;
+        self.last_len = content_length;
+    }
+};
+
+test "getToWriter reports progress as the 200 body streams into the sink" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var stub = Stub{ .io = io, .listener = &listener, .mode = .ok };
+    const server_thread = try std.Thread.spawn(.{}, serve, .{&stub});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/blobs/sha256:abc", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+
+    var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer sink.deinit();
+
+    var rec = ProgressRec{};
+    const progress = client.ProgressCallback{ .context = &rec, .func = ProgressRec.record };
+    const status = http.getToWriter(url, &.{}, &sink.writer, progress);
+
+    http.deinit();
+    server_thread.join();
+
+    try std.testing.expectEqual(@as(u16, 200), try status);
+    // The callback fired and its final tally matches the streamed body — the
+    // progress plumbing rides the sink path, not just the buffer path.
+    try std.testing.expect(rec.calls >= 1);
+    try std.testing.expectEqual(@as(u64, body_200.len), rec.last_bytes);
+    try std.testing.expectEqual(@as(u64, body_200.len), rec.last_len.?);
+}
+
+test "getToWriter follows a redirect and streams only the final 200 body into the sink" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var stub = Stub{ .io = io, .listener = &listener, .mode = .redirect_then_ok };
+    const server_thread = try std.Thread.spawn(.{}, serve, .{&stub});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/blobs/sha256:abc", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+
+    var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer sink.deinit();
+
+    const status = http.getToWriter(url, &.{}, &sink.writer, null);
+
+    http.deinit();
+    server_thread.join();
+
+    try std.testing.expectEqual(@as(u16, 200), try status);
+    // The 302 has an empty body; only the followed 200 reaches the sink.
+    try std.testing.expectEqualStrings(body_200, sink.writer.buffered());
+    try std.testing.expectEqual(@as(usize, 2), stub.get_count);
+}

--- a/tests/offline_mode_test.zig
+++ b/tests/offline_mode_test.zig
@@ -46,15 +46,19 @@ test "AppCtx-built-without-env defaults to online" {
 
 // ── HttpClient composition: every public entrypoint refuses ──────────
 
-test "HttpClient.get / getWithHeaders / head / headResolved all refuse offline" {
+test "HttpClient.get / getWithHeaders / getToWriter / head / headResolved all refuse offline" {
     // One-stop pinning so adding a new gated entrypoint without wiring
     // it lands here as a fresh test red.
     var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
     defer http.deinit();
     http.offline = true;
 
+    var discard_buf: [0]u8 = undefined;
+    var sink: std.Io.Writer.Discarding = .init(&discard_buf);
+
     try testing.expectError(error.OfflineRequired, http.get("https://example.invalid/x"));
     try testing.expectError(error.OfflineRequired, http.getWithHeaders("https://example.invalid/x", &.{}, null));
+    try testing.expectError(error.OfflineRequired, http.getToWriter("https://example.invalid/x", &.{}, &sink.writer, null));
     try testing.expectError(error.OfflineRequired, http.head("https://example.invalid/x"));
     try testing.expectError(error.OfflineRequired, http.headResolved("https://example.invalid/x"));
 }


### PR DESCRIPTION
## Description

malt's HTTP client can now stream a GET response body straight into a caller-provided `*std.Io.Writer` and return just the status, instead of always buffering the whole body. `readResponseBody` splits into a sink-taking core (`streamResponseBody`, owning decompress + cap + progress + idle/total watchdog) and a thin buffer wrapper, so every existing metadata/JSON/blob fetch keeps returning its owned slice byte-for-byte unchanged.

The new `getToWriter` verb enforces the retry × stateful-sink policy the streamed bottle download depends on:

- **Non-200 bodies never touch the sink.** They drain into a bounded `std.Io.Writer.Discarding`, so status classification, the transient-status retry, and connection reuse behave exactly as on the buffer path - GHCR's 401 re-auth still works because the caller re-issues with the sink pristine.
- **A mid-200-stream transport failure is returned, never retried inside net.** Once the 200 body starts draining, a `sink_committed` flag makes the retry loop surface the error so the single-use sink is written at most once; the caller owns recovery.

## Related Issue

- None

## Notes for Reviewers

- `followGet` is intentionally left untouched; `followGetToWriter` duplicates its redirect loop rather than extracting a shared helper, to keep the change surgical and avoid perturbing the proven buffer path.
- The non-200 discard uses a zero-length buffer because `CountingWriter` sits on top and delegates every write straight to `drain`.
