### PR TITLE
perf(core): stream the bottle download to disk while hashing

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -158,6 +158,7 @@ pub fn build(b: *std.Build) void {
         "tests/ghcr_test.zig",
         "tests/ghcr_401_retry_test.zig",
         "tests/net_get_to_writer_test.zig",
+        "tests/bottle_download_test.zig",
         "tests/linker_core_test.zig",
         "tests/supervisor_pure_test.zig",
         "tests/install_pure_test.zig",

--- a/scripts/regressions/response-size-cap-soft-enforced-after-write.sh
+++ b/scripts/regressions/response-size-cap-soft-enforced-after-write.sh
@@ -30,7 +30,7 @@ SRC="src/net/client.zig"
 #    inner writer's drain delegation. If the order flips, the cap goes soft.
 drain_body=$(awk '/fn drain\(w: \*std\.Io\.Writer/,/^        }$/' "$SRC")
 check_line=$(grep -n 'countSplat\|max_bytes' <<<"$drain_body" | head -1 | cut -d: -f1 || true)
-write_line=$(grep -n 'inner.writer.vtable.drain' <<<"$drain_body" | head -1 | cut -d: -f1 || true)
+write_line=$(grep -n 'inner.vtable.drain' <<<"$drain_body" | head -1 | cut -d: -f1 || true)
 if [ -z "$check_line" ] || [ -z "$write_line" ] || [ "$check_line" -gt "$write_line" ]; then
   echo "FAIL: CountingWriter.drain writes before enforcing max_bytes (soft cap)" >&2
   exit 1

--- a/src/core/bottle.zig
+++ b/src/core/bottle.zig
@@ -41,21 +41,11 @@ pub const MismatchInfo = struct {
     body_len: u64,
 };
 
-/// Pure SHA verification: returns null when `body`'s SHA256 matches the
-/// 64-hex-char `expected` value, or a populated `MismatchInfo` otherwise.
-/// Split out of `download` so tests can exercise the mismatch surface
-/// without spinning up GHCR / an HTTP client.
-pub fn checkBottleSha(expected: []const u8, body: []const u8) ?MismatchInfo {
-    var hash: [32]u8 = undefined;
-    std.crypto.hash.sha2.Sha256.hash(body, &hash, .{});
-    return checkStreamedSha(expected, std.fmt.bytesToHex(hash, .lower), body.len);
-}
-
-/// Slice-free twin of `checkBottleSha`: given a pre-computed 64-hex-char
-/// digest (e.g. from the streaming tee, where no `body` slice survives to
-/// re-hash) and the byte count, returns null on match or the same
-/// `MismatchInfo` as the slice path. Owning the compare + diagnostic here
-/// keeps that decision defined once for both the in-RAM and streamed paths.
+/// SHA verification for the streaming download: given the digest the tee
+/// computed while writing the bottle to disk (no `body` slice survives to
+/// re-hash) and the byte count, returns null on a match or a populated
+/// `MismatchInfo` otherwise. Split out of `download` so tests can exercise the
+/// mismatch surface without spinning up GHCR / an HTTP client.
 pub fn checkStreamedSha(expected: []const u8, computed_hex: [64]u8, body_len: u64) ?MismatchInfo {
     // Constant-time compare — deny a byte-by-byte timing oracle against
     // the expected hash.
@@ -74,6 +64,59 @@ pub fn checkStreamedSha(expected: []const u8, computed_hex: [64]u8, body_len: u6
     @memcpy(info.expected[0..n], expected[0..n]);
     return info;
 }
+
+/// Streaming sink that tees every drained chunk to a temp file *and* a
+/// `Sha256` hasher in one pass, so the bottle is hashed as it is written to
+/// disk — peak RSS stays bounded by the transfer buffer, never the bottle
+/// size. It sits *below* net's `CountingWriter` (which caps + reports), so
+/// chunks reaching here are already cap-checked and counted. Same
+/// `@fieldParentPtr("writer", …)` vtable shape as that precedent.
+const HashingFileSink = struct {
+    io: std.Io,
+    file: std.Io.File,
+    hasher: std.crypto.hash.sha2.Sha256,
+    len: u64,
+    writer: std.Io.Writer,
+
+    fn init(io: std.Io, file: std.Io.File) HashingFileSink {
+        return .{
+            .io = io,
+            .file = file,
+            .hasher = std.crypto.hash.sha2.Sha256.init(.{}),
+            .len = 0,
+            .writer = .{ .buffer = &.{}, .vtable = &vtable },
+        };
+    }
+
+    const vtable: std.Io.Writer.VTable = .{ .drain = drain };
+
+    fn drain(w: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
+        // @alignCast is sound: `w` always points at the `writer` field of a
+        // properly aligned `HashingFileSink` (created by `init`).
+        const self: *HashingFileSink = @alignCast(@fieldParentPtr("writer", w));
+        var written: usize = 0;
+        // All but the last slice are written once; the last is repeated `splat`
+        // times (mirrors std.Io.Writer's drain contract).
+        for (data[0 .. data.len - 1]) |bytes| {
+            try self.feed(bytes);
+            written += bytes.len;
+        }
+        const pattern = data[data.len - 1];
+        var i: usize = 0;
+        while (i < splat) : (i += 1) try self.feed(pattern);
+        written += pattern.len * splat;
+        return written;
+    }
+
+    fn feed(self: *HashingFileSink, bytes: []const u8) std.Io.Writer.Error!void {
+        if (bytes.len == 0) return;
+        // Tee: same bytes to the file and the hasher, so the on-disk archive
+        // and the digest can never diverge.
+        self.file.writeStreamingAll(self.io, bytes) catch return error.WriteFailed;
+        self.hasher.update(bytes);
+        self.len += @intCast(bytes.len);
+    }
+};
 
 /// Download a bottle from GHCR, verify SHA256, and extract to tmp.
 /// Returns the SHA256 and path to extracted contents.
@@ -97,46 +140,49 @@ pub fn download(
     progress: ?client_mod.ProgressCallback,
     mismatch_info: ?*MismatchInfo,
 ) BottleError!BottleResult {
-    // Download blob into memory
-    var body: std.ArrayList(u8) = .empty;
-    defer body.deinit(allocator);
+    _ = allocator; // Signature kept stable for callers; the streaming path is allocation-free.
 
-    ghcr.downloadBlob(allocator, http, repo, digest, &body, progress) catch |e| {
-        return switch (e) {
-            ghcr_mod.GhcrError.DownloadHttpClientError => BottleError.DownloadPermanent,
-            ghcr_mod.GhcrError.DownloadRateLimited => BottleError.DownloadRateLimited,
-            else => BottleError.DownloadFailed,
-        };
-    };
-
-    if (checkBottleSha(expected_sha256, body.items)) |info| {
-        // Clean up dest_dir on mismatch; Sha256Mismatch is the real error.
-        std.Io.Dir.cwd().deleteTree(io, dest_dir) catch {};
-        if (mismatch_info) |out| out.* = info;
-        return BottleError.Sha256Mismatch;
-    }
-
-    // Ensure dest_dir exists
+    // Create dest_dir and the temp file *before* the first byte arrives — the
+    // bottle streams straight to disk while hashing, so there is no in-RAM copy.
     std.Io.Dir.createDirAbsolute(io, dest_dir, .default_dir) catch |e| switch (e) {
         error.PathAlreadyExists => {},
         else => return BottleError.IoError,
     };
 
-    // Write bottle to temp file for extraction
     var tmp_path_buf: [512]u8 = undefined;
     const tmp_path = try buildTmpArchivePath(&tmp_path_buf, dest_dir);
 
-    // `truncate = true` so a leftover tmp from a prior attempt (e.g. a
-    // shared-tmp caller or a future retry that reuses the same path)
-    // can't leak a longer tail into the extract step.
-    const tmp_file = std.Io.Dir.createFileAbsolute(io, tmp_path, .{ .truncate = true }) catch return BottleError.IoError;
-    tmp_file.writeStreamingAll(io, body.items) catch {
-        tmp_file.close(io);
+    // `truncate = true` so a leftover tmp from a prior attempt can't leak a
+    // longer tail into the extract step.
+    const tmp_file = std.Io.Dir.createFileAbsolute(io, tmp_path, .{ .truncate = true }) catch
         return BottleError.IoError;
-    };
-    tmp_file.close(io);
 
-    // Extract
+    // The temp file exists before the SHA is known, so every early return must
+    // remove it. It lives inside dest_dir, so wiping the tree drops both the
+    // partial (or over-cap) archive and the dir — nothing unverified can reach
+    // extract, and the outer install loop retries with a fresh temp dir.
+    errdefer std.Io.Dir.cwd().deleteTree(io, dest_dir) catch {};
+
+    var sink = HashingFileSink.init(io, tmp_file);
+    const dl = ghcr.downloadBlob(http, repo, digest, &sink.writer, progress);
+    tmp_file.close(io); // fd no longer needed; extract reopens by path
+    dl catch |e| return switch (e) {
+        ghcr_mod.GhcrError.DownloadHttpClientError => BottleError.DownloadPermanent,
+        ghcr_mod.GhcrError.DownloadRateLimited => BottleError.DownloadRateLimited,
+        else => BottleError.DownloadFailed,
+    };
+
+    var raw: [32]u8 = undefined;
+    sink.hasher.final(&raw);
+    const computed_hex = std.fmt.bytesToHex(raw, .lower);
+
+    if (checkStreamedSha(expected_sha256, computed_hex, sink.len)) |info| {
+        // errdefer wipes the temp + dest_dir; an unverified bottle never extracts.
+        if (mismatch_info) |out| out.* = info;
+        return BottleError.Sha256Mismatch;
+    }
+
+    // Verified: extract the stored archive, then drop the temp file.
     archive.extractTarGz(io, tmp_path, dest_dir) catch return BottleError.ExtractionFailed;
 
     // Remove the temp archive file; a leftover tmp is harmless, overwritten on retry.
@@ -288,125 +334,10 @@ test "buildTmpArchivePath joins a normal dest_dir with the archive name" {
 }
 
 // ---------------------------------------------------------------------------
-// checkBottleSha — pure SHA verification helper extracted from `download`.
-// Covers the happy path, the diagnostic path, and pathological inputs. The
-// allocator-free contract is what makes `download` testable end-to-end
-// without spinning up a fake GHCR.
+// checkStreamedSha — the compare + diagnostic construction the streaming
+// download drives after the tee finalizes its digest. Covers the match path,
+// the diagnostic payload, and pathological `expected` inputs.
 // ---------------------------------------------------------------------------
-
-test "checkBottleSha returns null for matching SHA" {
-    const body = "hello world";
-    // SHA256("hello world") = b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
-    const expected = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
-    try std.testing.expect(checkBottleSha(expected, body) == null);
-}
-
-test "checkBottleSha returns null for matching SHA on empty body" {
-    // SHA256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-    const expected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-    try std.testing.expect(checkBottleSha(expected, "") == null);
-}
-
-test "checkBottleSha returns MismatchInfo with body length when SHA differs" {
-    const body = "hello world";
-    const wrong = "0000000000000000000000000000000000000000000000000000000000000000";
-    const info = checkBottleSha(wrong, body) orelse return error.TestUnexpectedNull;
-    try std.testing.expectEqual(@as(u64, body.len), info.body_len);
-    // computed must be the actual SHA of "hello world", lower-hex.
-    try std.testing.expectEqualStrings(
-        "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
-        &info.computed,
-    );
-    // expected must echo the caller's input verbatim in the first 64 bytes.
-    try std.testing.expectEqualStrings(wrong, info.expected[0..64]);
-}
-
-test "checkBottleSha mismatch on a single byte difference (constant-time-equivalent)" {
-    // Flip the last hex char of the correct SHA — must still reject.
-    const body = "hello world";
-    const off_by_one = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcdea";
-    try std.testing.expect(checkBottleSha(off_by_one, body) != null);
-}
-
-test "checkBottleSha mismatch on first-byte difference" {
-    const body = "hello world";
-    const off = "094d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
-    try std.testing.expect(checkBottleSha(off, body) != null);
-}
-
-test "checkBottleSha records body length on a large payload" {
-    // Use a one-MiB body; verify body_len matches even when the buffer
-    // is larger than typical formula JSON. SHA value isn't asserted here —
-    // the property is "len carried through" — which is the diagnostic
-    // signal the worker logs.
-    const alloc = std.testing.allocator;
-    const big = try alloc.alloc(u8, 1024 * 1024);
-    defer alloc.free(big);
-    @memset(big, 'x');
-    const wrong = "0000000000000000000000000000000000000000000000000000000000000000";
-    const info = checkBottleSha(wrong, big) orelse return error.TestUnexpectedNull;
-    try std.testing.expectEqual(@as(u64, 1024 * 1024), info.body_len);
-}
-
-test "checkBottleSha tolerates an empty expected slice without crashing" {
-    // Hostile input: an empty expected hash should never match a real SHA.
-    // The constant-time compare returns false on length mismatch (it's
-    // strict on length), so we get a populated MismatchInfo back.
-    const info = checkBottleSha("", "x") orelse return error.TestUnexpectedNull;
-    try std.testing.expectEqual(@as(u64, 1), info.body_len);
-    // expected buffer is zero-filled (no caller bytes to copy).
-    for (info.expected) |b| try std.testing.expectEqual(@as(u8, 0), b);
-}
-
-test "checkBottleSha tolerates an oversized expected (longer than 64)" {
-    // Pathological: the hex pads beyond 64 chars. Helper truncates to 64
-    // for the captured echo (no overflow, no crash), but the comparator
-    // sees the full slice — so the result is still "mismatch".
-    const long_expected = "a" ** 128;
-    const info = checkBottleSha(long_expected, "y") orelse return error.TestUnexpectedNull;
-    try std.testing.expectEqual(@as(u64, 1), info.body_len);
-    // First 64 bytes of expected captured.
-    for (info.expected) |b| try std.testing.expectEqual(@as(u8, 'a'), b);
-}
-
-test "checkBottleSha mismatch when body contains the expected hex literally" {
-    // A body whose bytes happen to spell the expected SHA hex must NOT
-    // accidentally match — the hash of the bytes is what counts, not
-    // the bytes themselves.
-    const expected = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
-    try std.testing.expect(checkBottleSha(expected, expected) != null);
-}
-
-test "checkBottleSha is symmetric on body equality (idempotent over identical bytes)" {
-    // Same body twice → same SHA → same null/non-null verdict.
-    const a = checkBottleSha(
-        "0000000000000000000000000000000000000000000000000000000000000000",
-        "abc",
-    );
-    const b = checkBottleSha(
-        "0000000000000000000000000000000000000000000000000000000000000000",
-        "abc",
-    );
-    try std.testing.expectEqual(a == null, b == null);
-    if (a) |ai| if (b) |bi| {
-        try std.testing.expectEqualStrings(&ai.computed, &bi.computed);
-        try std.testing.expectEqual(ai.body_len, bi.body_len);
-    };
-}
-
-test "checkBottleSha computed hash is always lowercase hex" {
-    // The diagnostic format compares directly against the caller-supplied
-    // `expected` (lowercase by Homebrew API convention). A stray uppercase
-    // character would silently mismatch even a correct hash.
-    const info = checkBottleSha(
-        "0000000000000000000000000000000000000000000000000000000000000000",
-        "any-payload",
-    ) orelse return error.TestUnexpectedNull;
-    for (info.computed) |c| {
-        const ok = (c >= '0' and c <= '9') or (c >= 'a' and c <= 'f');
-        try std.testing.expect(ok);
-    }
-}
 
 test "checkStreamedSha returns null when computed matches expected" {
     const expected = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
@@ -426,24 +357,23 @@ test "checkStreamedSha carries computed and a 400MB body_len into MismatchInfo" 
     try std.testing.expectEqualStrings(expected, info.expected[0..64]);
 }
 
-test "checkStreamedSha agrees with checkBottleSha for the same body (delegation equivalence)" {
+test "checkStreamedSha over a freshly hashed body matches the good SHA and rejects a wrong one" {
+    // Mirrors the production sequence (hash-while-writing → compare) on a real
+    // body: the correct digest passes, a wrong `expected` yields a diagnostic
+    // carrying the true computed digest, the echoed expected, and the length.
     const body = "hello world";
     var h: [32]u8 = undefined;
     std.crypto.hash.sha2.Sha256.hash(body, &h, .{});
     const computed = std.fmt.bytesToHex(h, .lower);
 
     const good = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
-    try std.testing.expectEqual(
-        checkBottleSha(good, body) == null,
-        checkStreamedSha(good, computed, body.len) == null,
-    );
+    try std.testing.expect(checkStreamedSha(good, computed, body.len) == null);
 
     const wrong = "0000000000000000000000000000000000000000000000000000000000000000";
-    const a = checkBottleSha(wrong, body) orelse return error.TestUnexpectedNull;
-    const b = checkStreamedSha(wrong, computed, body.len) orelse return error.TestUnexpectedNull;
-    try std.testing.expectEqualStrings(&a.computed, &b.computed);
-    try std.testing.expectEqualStrings(&a.expected, &b.expected);
-    try std.testing.expectEqual(a.body_len, b.body_len);
+    const info = checkStreamedSha(wrong, computed, body.len) orelse return error.TestUnexpectedNull;
+    try std.testing.expectEqualStrings(&computed, &info.computed);
+    try std.testing.expectEqualStrings(wrong, info.expected[0..64]);
+    try std.testing.expectEqual(@as(u64, body.len), info.body_len);
 }
 
 test "checkStreamedSha tolerates empty and oversized expected without crashing" {
@@ -456,6 +386,84 @@ test "checkStreamedSha tolerates empty and oversized expected without crashing" 
 
     const long_info = checkStreamedSha("b" ** 128, computed, 1) orelse return error.TestUnexpectedNull;
     for (long_info.expected) |byte| try std.testing.expectEqual(@as(u8, 'b'), byte);
+}
+
+// ---------------------------------------------------------------------------
+// HashingFileSink — the tee that folds the SHA into the write stream. Feeding
+// it a chunked byte sequence (a multi-slice drain and a splat) must leave the
+// temp file byte-equal to the input, produce a digest identical to a one-shot
+// hash of the same bytes, and count every byte in `len`.
+// ---------------------------------------------------------------------------
+
+test "HashingFileSink tees each chunk to the file and the hasher" {
+    const io = std.Options.debug_io;
+    const base = "/tmp/malt_hashing_file_sink";
+    std.Io.Dir.cwd().deleteTree(io, base) catch {};
+    std.Io.Dir.createDirAbsolute(io, base, .default_dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, base) catch {};
+
+    const path = base ++ "/bottle.tar.gz";
+    const file = try std.Io.Dir.createFileAbsolute(io, path, .{ .truncate = true });
+
+    var sink = HashingFileSink.init(io, file);
+    const w = &sink.writer;
+
+    // Multiple drain calls — a single slice, a two-slice call, and a splat —
+    // mirror how streamRemaining fans decompressed chunks into the sink.
+    try std.testing.expectEqual(@as(usize, 9), try w.vtable.drain(w, &.{"chunk-one"}, 1));
+    try std.testing.expectEqual(@as(usize, 4), try w.vtable.drain(w, &.{ "AB", "CD" }, 1));
+    try std.testing.expectEqual(@as(usize, 6), try w.vtable.drain(w, &.{"xy"}, 3));
+    file.close(io);
+
+    const input = "chunk-one" ++ "AB" ++ "CD" ++ "xyxyxy";
+
+    // Finalized digest equals a one-shot hash of the exact streamed bytes.
+    var raw: [32]u8 = undefined;
+    sink.hasher.final(&raw);
+    var expected: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(input, &expected, .{});
+    try std.testing.expectEqualSlices(u8, &expected, &raw);
+
+    // File on disk holds exactly the concatenated stream (re-hash it).
+    const expected_hex = std.fmt.bytesToHex(expected, .lower);
+    try std.testing.expect(try verify(io, path, &expected_hex));
+
+    // `len` counts every teed byte.
+    try std.testing.expectEqual(@as(u64, input.len), sink.len);
+}
+
+test "HashingFileSink drain tolerates empty chunks and a zero splat" {
+    // Boundary cases of the drain contract: an empty slice contributes
+    // nothing, and a zero splat writes the pattern zero times. Both must leave
+    // the file, digest, and len consistent with the bytes actually written.
+    const io = std.Options.debug_io;
+    const base = "/tmp/malt_hashing_file_sink_edge";
+    std.Io.Dir.cwd().deleteTree(io, base) catch {};
+    std.Io.Dir.createDirAbsolute(io, base, .default_dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, base) catch {};
+
+    const path = base ++ "/bottle.tar.gz";
+    const file = try std.Io.Dir.createFileAbsolute(io, path, .{ .truncate = true });
+
+    var sink = HashingFileSink.init(io, file);
+    const w = &sink.writer;
+
+    // Empty leading slice is skipped; the pattern is written once.
+    try std.testing.expectEqual(@as(usize, 3), try w.vtable.drain(w, &.{ "", "abc" }, 1));
+    // Zero splat writes nothing and reports zero bytes consumed.
+    try std.testing.expectEqual(@as(usize, 0), try w.vtable.drain(w, &.{"tail"}, 0));
+    file.close(io);
+
+    const input = "abc";
+    var expected: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(input, &expected, .{});
+    var raw: [32]u8 = undefined;
+    sink.hasher.final(&raw);
+    try std.testing.expectEqualSlices(u8, &expected, &raw);
+
+    const expected_hex = std.fmt.bytesToHex(expected, .lower);
+    try std.testing.expect(try verify(io, path, &expected_hex));
+    try std.testing.expectEqual(@as(u64, input.len), sink.len);
 }
 
 test "checkStreamedSha NUL-pads a shorter-than-64 expected in the echo" {

--- a/src/net/ghcr.zig
+++ b/src/net/ghcr.zig
@@ -233,11 +233,10 @@ pub const GhcrClient = struct {
     /// cache inside this struct remains mutex-protected.
     pub fn downloadBlob(
         self: *GhcrClient,
-        allocator: std.mem.Allocator,
         http: *client_mod.HttpClient,
         repo: []const u8,
         digest: []const u8,
-        body_out: *std.ArrayList(u8),
+        sink: *std.Io.Writer,
         progress: ?client_mod.ProgressCallback,
     ) GhcrError!void {
         var url_buf: [512]u8 = undefined;
@@ -265,21 +264,35 @@ pub const GhcrClient = struct {
                 .{ .name = "Authorization", .value = auth_value },
             };
 
-            var resp = http.getWithHeaders(url, &headers, progress) catch
-                return GhcrError.DownloadFailed;
-            defer resp.deinit();
+            // Streams a definitive 200 body straight into `sink`; non-200
+            // bodies (incl. the 401 we re-auth on) go to net's throwaway, so
+            // the sink stays pristine until the retry loop settles on a 200.
+            const status = http.getToWriter(url, &headers, sink, progress) catch |e| switch (e) {
+                error.OutOfMemory => return GhcrError.OutOfMemory,
+                // Every transport-level failure collapses to a retryable
+                // DownloadFailed, exactly as the buffered path did — the outer
+                // install loop recreates the temp dir and re-streams.
+                error.OfflineRequired,
+                error.RequestFailed,
+                error.TlsDowngradeRefused,
+                error.TooManyHttpRedirects,
+                error.HttpRedirectInvalid,
+                error.ResponseTooLarge,
+                error.ReadFailed,
+                error.WatchdogSpawnFailed,
+                error.Canceled,
+                => return GhcrError.DownloadFailed,
+            };
 
-            if (resp.status == 401) {
+            if (status == 401) {
                 if (retried) return GhcrError.Unauthorized;
                 retried = true;
                 self.invalidateToken();
                 continue;
             }
-            if (resp.status != 200) {
-                return classifyGhcrStatus(resp.status);
+            if (status != 200) {
+                return classifyGhcrStatus(status);
             }
-
-            body_out.appendSlice(allocator, resp.body) catch return GhcrError.OutOfMemory;
             return;
         }
     }

--- a/tests/bottle_download_test.zig
+++ b/tests/bottle_download_test.zig
@@ -1,0 +1,377 @@
+//! malt — `bottle.download` streaming integration tests.
+//!
+//! Drives the whole download path against a loopback `std.http.Server` that
+//! answers `/token` and `/blobs/…` (the same offline transport the other net
+//! tests use), so the create-temp → stream+hash → compare → extract pipeline
+//! is exercised end to end with no real network.
+//!
+//! These pin the invariants the streaming rewrite must preserve: a verified
+//! bottle extracts and the temp file is dropped; a SHA mismatch populates
+//! `MismatchInfo` and wipes the temp + dest without ever extracting; a
+//! mid-stream transport failure leaves nothing behind; and the digest is taken
+//! over the stored (identity-encoded) `.tar.gz` bytes, matching Homebrew.
+
+const std = @import("std");
+const malt = @import("malt");
+const test_io = @import("test_io");
+const testing = std.testing;
+const bottle = malt.bottle;
+const client = malt.client;
+const ghcr = malt.ghcr;
+const net = std.Io.net;
+
+const Stub = struct {
+    io: std.Io,
+    listener: *net.Server,
+    body: []const u8,
+    // When true the blob GET sends a short chunk then drops the connection
+    // without the terminating chunk, so the client's body read fails mid-200.
+    truncate: bool = false,
+    // When set, the blob 200 carries this `Content-Encoding` so the client
+    // decodes `body` before the tee sees it (exercises the SHA domain).
+    content_encoding: ?[]const u8 = null,
+};
+
+fn serveStub(s: *Stub) void {
+    const stream = s.listener.accept(s.io) catch return;
+    defer stream.close(s.io);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var reader = stream.reader(s.io, &rbuf);
+    var writer = stream.writer(s.io, &wbuf);
+    var srv = std.http.Server.init(&reader.interface, &writer.interface);
+    while (true) {
+        var req = srv.receiveHead() catch return;
+        const target = req.head.target;
+        if (std.mem.indexOf(u8, target, "/token") != null) {
+            req.respond("{\"token\":\"t1\"}", .{}) catch return;
+        } else if (std.mem.indexOf(u8, target, "/blobs/") != null) {
+            if (s.truncate) {
+                var body_buf: [64]u8 = undefined;
+                var bw = req.respondStreaming(&body_buf, .{}) catch return;
+                bw.writer.writeAll("partial") catch return;
+                bw.flush() catch return;
+                return; // drop the socket before the terminating chunk
+            }
+            const extra: []const std.http.Header = if (s.content_encoding) |enc|
+                &.{.{ .name = "content-encoding", .value = enc }}
+            else
+                &.{};
+            req.respond(s.body, .{ .extra_headers = extra }) catch return;
+        } else {
+            req.respond("not found\n", .{ .status = .not_found }) catch return;
+        }
+    }
+}
+
+// Real `Threaded` io to spawn `tar` — `std.Options.debug_io`'s failing
+// allocator can't back a child spawn. Mints a valid bottle fixture.
+fn runTar(argv: []const []const u8) !void {
+    var threaded: std.Io.Threaded = .init(std.heap.c_allocator, .{ .environ = malt.app_ctx.processEnviron() });
+    defer threaded.deinit();
+    const io = threaded.io();
+    var child = try std.process.spawn(io, .{ .argv = argv, .stdout = .ignore, .stderr = .ignore });
+    switch (try child.wait(io)) {
+        .exited => |code| if (code != 0) return error.TarFailed,
+        else => return error.TarFailed,
+    }
+}
+
+fn uniqueBase(suffix: []const u8) ![]u8 {
+    return std.fmt.allocPrint(
+        testing.allocator,
+        "/tmp/malt_bottle_dl_{d}_{s}",
+        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
+    );
+}
+
+fn hexSha(bytes: []const u8) [64]u8 {
+    var raw: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(bytes, &raw, .{});
+    return std.fmt.bytesToHex(raw, .lower);
+}
+
+// gzip-compress `raw` into `out`, returning the wire bytes (same primitive the
+// archive tests use to mint fixtures).
+fn gzipInto(out: []u8, raw: []const u8) ![]const u8 {
+    var out_w = std.Io.Writer.fixed(out);
+    var win: [std.compress.flate.max_window_len]u8 = undefined;
+    var comp = try std.compress.flate.Compress.init(&out_w, &win, .gzip, std.compress.flate.Compress.Options.level_4);
+    try comp.writer.writeAll(raw);
+    try comp.finish();
+    return out_w.buffered();
+}
+
+fn pathExists(io: std.Io, path: []const u8) bool {
+    test_io.accessAbsolute(io, path, .{}) catch return false;
+    return true;
+}
+
+test "download streams a verified bottle to disk, extracts it, and drops the temp file" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const base = try uniqueBase("ok");
+    defer testing.allocator.free(base);
+    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    try test_io.cwd().createDirPath(io, base);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+
+    // Mint a real gzip tarball: payload/hello.txt.
+    const payload_dir = try std.fmt.allocPrint(testing.allocator, "{s}/work/payload", .{base});
+    defer testing.allocator.free(payload_dir);
+    try test_io.cwd().createDirPath(io, payload_dir);
+    const hello = try std.fmt.allocPrint(testing.allocator, "{s}/hello.txt", .{payload_dir});
+    defer testing.allocator.free(hello);
+    {
+        const f = try test_io.createFileAbsolute(io, hello, .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "bottle payload\n");
+    }
+    const work = try std.fmt.allocPrint(testing.allocator, "{s}/work", .{base});
+    defer testing.allocator.free(work);
+    const archive_path = try std.fmt.allocPrint(testing.allocator, "{s}/bottle-fixture.tar.gz", .{base});
+    defer testing.allocator.free(archive_path);
+    try runTar(&.{ "tar", "czf", archive_path, "-C", work, "payload" });
+
+    const body = try test_io.readFileAbsoluteAlloc(io, testing.allocator, archive_path, 1 << 20);
+    defer testing.allocator.free(body);
+    const sha = hexSha(body);
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+    var stub = Stub{ .io = io, .listener = &listener, .body = body };
+    const server_thread = try std.Thread.spawn(.{}, serveStub, .{&stub});
+
+    var base_buf: [64]u8 = undefined;
+    const base_url = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+
+    var g = ghcr.GhcrClient.init(io, testing.allocator, &http);
+    defer g.deinit();
+    g.base_url = base_url;
+
+    const dest_dir = try std.fmt.allocPrint(testing.allocator, "{s}/dest", .{base});
+    defer testing.allocator.free(dest_dir);
+
+    var mismatch: bottle.MismatchInfo = undefined;
+    const result = bottle.download(io, testing.allocator, &g, &http, "homebrew/core/pkg", "sha256:abc", &sha, dest_dir, null, &mismatch);
+
+    http.deinit();
+    server_thread.join();
+
+    _ = try result;
+
+    // Extracted content is present; the temp archive was removed.
+    const extracted = try std.fmt.allocPrint(testing.allocator, "{s}/payload/hello.txt", .{dest_dir});
+    defer testing.allocator.free(extracted);
+    try testing.expect(pathExists(io, extracted));
+    const tmp_archive = try std.fmt.allocPrint(testing.allocator, "{s}/bottle.tar.gz", .{dest_dir});
+    defer testing.allocator.free(tmp_archive);
+    try testing.expect(!pathExists(io, tmp_archive));
+}
+
+test "download rejects a SHA mismatch: populates MismatchInfo, wipes temp + dest, never extracts" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const base = try uniqueBase("mismatch");
+    defer testing.allocator.free(base);
+    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    try test_io.cwd().createDirPath(io, base);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+
+    // Any bytes will do — the bottle is never extracted on a mismatch.
+    const blob = "these-identity-encoded-bytes-are-not-a-real-bottle-0123456789";
+    const real = hexSha(blob);
+    const wrong = "0" ** 64;
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+    var stub = Stub{ .io = io, .listener = &listener, .body = blob };
+    const server_thread = try std.Thread.spawn(.{}, serveStub, .{&stub});
+
+    var base_buf: [64]u8 = undefined;
+    const base_url = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+
+    var g = ghcr.GhcrClient.init(io, testing.allocator, &http);
+    defer g.deinit();
+    g.base_url = base_url;
+
+    const dest_dir = try std.fmt.allocPrint(testing.allocator, "{s}/dest", .{base});
+    defer testing.allocator.free(dest_dir);
+
+    var mismatch: bottle.MismatchInfo = undefined;
+    const result = bottle.download(io, testing.allocator, &g, &http, "homebrew/core/pkg", "sha256:abc", wrong, dest_dir, null, &mismatch);
+
+    http.deinit();
+    server_thread.join();
+
+    try testing.expectError(bottle.BottleError.Sha256Mismatch, result);
+    // body_len comes from the tee, and computed is the SHA of exactly the
+    // served identity bytes — pinning the SHA domain to the stored .tar.gz,
+    // not a re-inflated stream.
+    try testing.expectEqual(@as(u64, blob.len), mismatch.body_len);
+    try testing.expectEqualStrings(&real, &mismatch.computed);
+    try testing.expectEqualStrings(wrong, mismatch.expected[0..64]);
+    // The whole dest dir (temp archive included) is gone — nothing extracted.
+    try testing.expect(!pathExists(io, dest_dir));
+}
+
+test "a verified-but-unextractable archive fails closed: ExtractionFailed wipes the dest dir" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const base = try uniqueBase("extractfail");
+    defer testing.allocator.free(base);
+    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    try test_io.cwd().createDirPath(io, base);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+
+    // A body that passes its SHA check but is not a gzip archive: extraction
+    // rejects it on the magic-byte sniff. The SHA is over these exact bytes.
+    const blob = "definitely-not-a-gzip-archive-but-its-own-valid-sha256";
+    const sha = hexSha(blob);
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+    var stub = Stub{ .io = io, .listener = &listener, .body = blob };
+    const server_thread = try std.Thread.spawn(.{}, serveStub, .{&stub});
+
+    var base_buf: [64]u8 = undefined;
+    const base_url = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+
+    var g = ghcr.GhcrClient.init(io, testing.allocator, &http);
+    defer g.deinit();
+    g.base_url = base_url;
+
+    const dest_dir = try std.fmt.allocPrint(testing.allocator, "{s}/dest", .{base});
+    defer testing.allocator.free(dest_dir);
+
+    var mismatch: bottle.MismatchInfo = undefined;
+    const result = bottle.download(io, testing.allocator, &g, &http, "homebrew/core/pkg", "sha256:abc", &sha, dest_dir, null, &mismatch);
+
+    http.deinit();
+    server_thread.join();
+
+    // SHA matched, so this is not a mismatch — extraction is what fails, and
+    // the errdefer still wipes the dest dir (and the temp archive with it).
+    try testing.expectError(bottle.BottleError.ExtractionFailed, result);
+    try testing.expect(!pathExists(io, dest_dir));
+}
+
+test "the tee hashes the transport-decoded bottle, not the wire bytes (SHA domain under gzip)" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const base = try uniqueBase("gzipdomain");
+    defer testing.allocator.free(base);
+    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    try test_io.cwd().createDirPath(io, base);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+
+    // The bytes Homebrew signs are the decoded .tar.gz; here the transport adds
+    // a gzip Content-Encoding on top, which the client strips before the tee.
+    const decoded = "the-decoded-bottle-bytes-that-homebrew-actually-hashes-0123456789";
+    var wire_buf: [512]u8 = undefined;
+    const wire = try gzipInto(&wire_buf, decoded);
+
+    const decoded_sha = hexSha(decoded);
+    const wire_sha = hexSha(wire);
+    // The two domains must differ, or the assertion below proves nothing.
+    try testing.expect(!std.mem.eql(u8, &decoded_sha, &wire_sha));
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+    var stub = Stub{ .io = io, .listener = &listener, .body = wire, .content_encoding = "gzip" };
+    const server_thread = try std.Thread.spawn(.{}, serveStub, .{&stub});
+
+    var base_buf: [64]u8 = undefined;
+    const base_url = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+
+    var g = ghcr.GhcrClient.init(io, testing.allocator, &http);
+    defer g.deinit();
+    g.base_url = base_url;
+
+    const dest_dir = try std.fmt.allocPrint(testing.allocator, "{s}/dest", .{base});
+    defer testing.allocator.free(dest_dir);
+
+    const wrong = "0" ** 64;
+    var mismatch: bottle.MismatchInfo = undefined;
+    const result = bottle.download(io, testing.allocator, &g, &http, "homebrew/core/pkg", "sha256:abc", wrong, dest_dir, null, &mismatch);
+
+    http.deinit();
+    server_thread.join();
+
+    try testing.expectError(bottle.BottleError.Sha256Mismatch, result);
+    // computed is the SHA of the decoded bytes (what Homebrew signs), never the
+    // gzip wire; body_len is the decoded length, not the compressed one.
+    try testing.expectEqualStrings(&decoded_sha, &mismatch.computed);
+    try testing.expectEqual(@as(u64, decoded.len), mismatch.body_len);
+}
+
+test "a mid-stream transport failure leaves no temp file and no dest dir" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const base = try uniqueBase("truncated");
+    defer testing.allocator.free(base);
+    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    try test_io.cwd().createDirPath(io, base);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+    var stub = Stub{ .io = io, .listener = &listener, .body = "unused", .truncate = true };
+    const server_thread = try std.Thread.spawn(.{}, serveStub, .{&stub});
+
+    var base_buf: [64]u8 = undefined;
+    const base_url = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+
+    var g = ghcr.GhcrClient.init(io, testing.allocator, &http);
+    defer g.deinit();
+    g.base_url = base_url;
+
+    const dest_dir = try std.fmt.allocPrint(testing.allocator, "{s}/dest", .{base});
+    defer testing.allocator.free(dest_dir);
+
+    var mismatch: bottle.MismatchInfo = undefined;
+    const result = bottle.download(io, testing.allocator, &g, &http, "homebrew/core/pkg", "sha256:abc", "0" ** 64, dest_dir, null, &mismatch);
+
+    http.deinit();
+    server_thread.join();
+
+    // A partial 200 became a transport error; the partial .tar.gz and the dest
+    // dir were both cleaned up (the same errdefer path an over-cap stream takes).
+    try testing.expectError(bottle.BottleError.DownloadFailed, result);
+    try testing.expect(!pathExists(io, dest_dir));
+}

--- a/tests/bottle_test.zig
+++ b/tests/bottle_test.zig
@@ -1,5 +1,5 @@
 //! malt — bottle.zig integration tests
-//! Covers the SHA verification surface (`checkBottleSha` + `MismatchInfo`)
+//! Covers the SHA verification surface (`checkStreamedSha` + `MismatchInfo`)
 //! and the `isDeterministicDownloadError` classifier reachable through the
 //! install facade. The full network-driven `bottle.download` path stays
 //! out of scope — these tests pin the *pure* invariants the worker relies
@@ -11,6 +11,15 @@ const testing = std.testing;
 const malt = @import("malt");
 const bottle = malt.bottle;
 const install_download = malt.install_download;
+
+// Mirrors the production download sequence (hash-while-writing → streamed
+// compare) without a GHCR client, so the worker's diagnostic invariants stay
+// pinned at the body level even though `download` no longer re-hashes a slice.
+fn checkBodySha(expected: []const u8, body: []const u8) ?bottle.MismatchInfo {
+    var h: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(body, &h, .{});
+    return bottle.checkStreamedSha(expected, std.fmt.bytesToHex(h, .lower), body.len);
+}
 
 // ---------------------------------------------------------------------------
 // MismatchInfo shape — pinned so the worker's log format never drifts
@@ -29,11 +38,11 @@ test "MismatchInfo struct shape: 64-byte expected, 64-byte computed, u64 length"
 }
 
 // ---------------------------------------------------------------------------
-// checkBottleSha — happy path against vector hashes from RFC test corpus
+// Body SHA check — happy path against vector hashes from RFC test corpus
 // and Homebrew-style 64-hex bodies.
 // ---------------------------------------------------------------------------
 
-test "checkBottleSha: SHA matches a 64-byte body of mixed bytes" {
+test "body SHA check: SHA matches a 64-byte body of mixed bytes" {
     // SHA256(0x00..0x3F) — deterministic, easily re-derivable.
     const body = [_]u8{
         0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
@@ -44,11 +53,11 @@ test "checkBottleSha: SHA matches a 64-byte body of mixed bytes" {
     var hash: [32]u8 = undefined;
     std.crypto.hash.sha2.Sha256.hash(&body, &hash, .{});
     const expected = std.fmt.bytesToHex(hash, .lower);
-    try testing.expect(bottle.checkBottleSha(&expected, &body) == null);
+    try testing.expect(checkBodySha(&expected, &body) == null);
 }
 
-test "checkBottleSha: byte-level fuzz — any single-byte body change invalidates the hash" {
-    // The pure helper is the only thing standing between the install
+test "body SHA check: byte-level fuzz — any single-byte body change invalidates the hash" {
+    // The compare is the only thing standing between the install
     // pipeline and an attacker who can flip a single bottle byte. Walk
     // all 256 trailing-byte variants of an 8-byte body and confirm only
     // the canonical one passes.
@@ -57,13 +66,13 @@ test "checkBottleSha: byte-level fuzz — any single-byte body change invalidate
     body[7] = 0x42;
     std.crypto.hash.sha2.Sha256.hash(&body, &hash, .{});
     const canonical_expected = std.fmt.bytesToHex(hash, .lower);
-    try testing.expect(bottle.checkBottleSha(&canonical_expected, &body) == null);
+    try testing.expect(checkBodySha(&canonical_expected, &body) == null);
 
     var i: u16 = 0;
     while (i < 256) : (i += 1) {
         if (i == 0x42) continue;
         body[7] = @intCast(i);
-        try testing.expect(bottle.checkBottleSha(&canonical_expected, &body) != null);
+        try testing.expect(checkBodySha(&canonical_expected, &body) != null);
     }
 }
 
@@ -81,7 +90,7 @@ test "MismatchInfo.body_len is the actual byte count, not a clamped value" {
     defer alloc.free(big);
     @memset(big, 0xAB);
     const wrong = "0" ** 64;
-    const info = bottle.checkBottleSha(wrong, big) orelse return error.TestUnexpectedNull;
+    const info = checkBodySha(wrong, big) orelse return error.TestUnexpectedNull;
     try testing.expectEqual(@as(u64, big_size), info.body_len);
 }
 
@@ -90,7 +99,7 @@ test "MismatchInfo.expected echoes caller bytes verbatim (no normalisation)" {
     // any normalisation (case fold, trim, etc.) would break the visual
     // diff a user does between the API hash and the log line.
     const expected = "DeAdBeEfDeAdBeEfDeAdBeEfDeAdBeEfDeAdBeEfDeAdBeEfDeAdBeEfDeAdBeEf";
-    const info = bottle.checkBottleSha(expected, "x") orelse return error.TestUnexpectedNull;
+    const info = checkBodySha(expected, "x") orelse return error.TestUnexpectedNull;
     try testing.expectEqualStrings(expected, info.expected[0..64]);
 }
 
@@ -101,7 +110,7 @@ test "MismatchInfo.computed is independent from MismatchInfo.expected (no aliasi
     // useless — assert by comparing computed to a known SHA.
     const body = "xyz"; // SHA256 = 3608bca1e44ea6c4d268eb6db02260269892c0b42b86bbf1e77a6fa16c3c9282
     const wrong = "0" ** 64;
-    const info = bottle.checkBottleSha(wrong, body) orelse return error.TestUnexpectedNull;
+    const info = checkBodySha(wrong, body) orelse return error.TestUnexpectedNull;
     try testing.expectEqualStrings(
         "3608bca1e44ea6c4d268eb6db02260269892c0b42b86bbf1e77a6fa16c3c9282",
         &info.computed,
@@ -144,8 +153,8 @@ test "install_download.isDeterministicDownloadError: transport errors all retry"
 }
 
 // ---------------------------------------------------------------------------
-// Verify (existing surface) — round-trip a body through `checkBottleSha`
-// and `verify` to confirm the on-disk and in-memory paths agree on the
+// Verify (existing surface) — round-trip a body through the streamed SHA
+// check and `verify` to confirm the on-disk and in-memory paths agree on the
 // same SHA contract.
 // ---------------------------------------------------------------------------
 
@@ -186,7 +195,7 @@ test "MismatchInfo formats cleanly through the worker's log template" {
     try testing.expect(line.len < 4096);
 }
 
-test "checkBottleSha and verify agree on the same body's SHA" {
+test "body SHA check and verify agree on the same body's SHA" {
     const test_io = @import("test_io");
     const path = try std.fmt.allocPrint(
         testing.allocator,
@@ -208,11 +217,11 @@ test "checkBottleSha and verify agree on the same body's SHA" {
     const sha_hex = std.fmt.bytesToHex(hash, .lower);
 
     // Both routes agree this body matches its hash.
-    try testing.expect(bottle.checkBottleSha(&sha_hex, body) == null);
+    try testing.expect(checkBodySha(&sha_hex, body) == null);
     try testing.expect(try bottle.verify(std.Options.debug_io, path, &sha_hex));
 
     // And both reject the same wrong hash.
     const wrong = "0" ** 64;
-    try testing.expect(bottle.checkBottleSha(wrong, body) != null);
+    try testing.expect(checkBodySha(wrong, body) != null);
     try testing.expect(!(try bottle.verify(std.Options.debug_io, path, wrong)));
 }

--- a/tests/ghcr_401_retry_test.zig
+++ b/tests/ghcr_401_retry_test.zig
@@ -100,10 +100,10 @@ test "downloadBlob invalidates the cached token and retries once on a 401" {
     defer g.deinit();
     g.base_url = base;
 
-    var body: std.ArrayList(u8) = .empty;
-    defer body.deinit(std.testing.allocator);
+    var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer sink.deinit();
 
-    const result = g.downloadBlob(std.testing.allocator, &http, "homebrew/core/tree", "sha256:abc", &body, null);
+    const result = g.downloadBlob(&http, "homebrew/core/tree", "sha256:abc", &sink.writer, null);
 
     // Close the client so the server's keep-alive loop ends, then join
     // before reading server-side counters to avoid a data race.
@@ -111,7 +111,7 @@ test "downloadBlob invalidates the cached token and retries once on a 401" {
     server_thread.join();
 
     try result;
-    try std.testing.expectEqualStrings(blob_body, body.items);
+    try std.testing.expectEqualStrings(blob_body, sink.writer.buffered());
     // Two token fetches: the initial one plus the post-invalidation refresh.
     try std.testing.expectEqual(@as(usize, 2), stub.token_count);
     try std.testing.expectEqual(@as(usize, 2), stub.blob_count);
@@ -142,10 +142,10 @@ test "downloadBlob returns Unauthorized after a second 401 (retry bounded to onc
     defer g.deinit();
     g.base_url = base;
 
-    var body: std.ArrayList(u8) = .empty;
-    defer body.deinit(std.testing.allocator);
+    var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer sink.deinit();
 
-    const result = g.downloadBlob(std.testing.allocator, &http, "homebrew/core/tree", "sha256:abc", &body, null);
+    const result = g.downloadBlob(&http, "homebrew/core/tree", "sha256:abc", &sink.writer, null);
 
     http.deinit();
     server_thread.join();
@@ -182,10 +182,10 @@ test "downloadBlob does not refresh the token on a non-401 error" {
     defer g.deinit();
     g.base_url = base;
 
-    var body: std.ArrayList(u8) = .empty;
-    defer body.deinit(std.testing.allocator);
+    var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer sink.deinit();
 
-    const result = g.downloadBlob(std.testing.allocator, &http, "homebrew/core/tree", "sha256:abc", &body, null);
+    const result = g.downloadBlob(&http, "homebrew/core/tree", "sha256:abc", &sink.writer, null);
 
     http.deinit();
     server_thread.join();
@@ -218,13 +218,12 @@ const ProgressRec = struct {
     }
 };
 
-test "downloadBlob progress fires across the failed and retried attempts" {
-    // Characterizes an accepted quirk: the 401 error body streams through the
-    // progress callback, then the real blob streams a second, independent
-    // sequence (bytes reset to 0, content-length differs). A consumer that
-    // assumes monotonic bytes sees a reset — cosmetic on this rare recovery
-    // path, pinned here so a future change can't turn the reset into silent
-    // double-counting.
+test "downloadBlob progress reports only the streamed blob, not the discarded 401 body" {
+    // The streaming path drains every non-200 body (including the 401 we
+    // re-auth on) into net's throwaway with no progress callback, so the
+    // caller's progress only ever sees the definitive 200 blob. No reset, no
+    // double-count across the failed + retried attempts — the old buffered
+    // path's double-fire quirk is gone.
     var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
     defer threaded.deinit();
     const io = threaded.io();
@@ -247,21 +246,22 @@ test "downloadBlob progress fires across the failed and retried attempts" {
     defer g.deinit();
     g.base_url = base;
 
-    var body: std.ArrayList(u8) = .empty;
-    defer body.deinit(std.testing.allocator);
+    var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer sink.deinit();
 
     var rec = ProgressRec{};
     const progress = client.ProgressCallback{ .context = &rec, .func = ProgressRec.record };
-    const result = g.downloadBlob(std.testing.allocator, &http, "homebrew/core/tree", "sha256:abc", &body, progress);
+    const result = g.downloadBlob(&http, "homebrew/core/tree", "sha256:abc", &sink.writer, progress);
 
     http.deinit();
     server_thread.join();
 
     try result;
-    try std.testing.expectEqualStrings(blob_body, body.items);
-    // Two distinct content-lengths => progress fired for two different
-    // responses (the 401 body then the blob): the double-fire.
-    try std.testing.expect(rec.len_count >= 2);
+    try std.testing.expectEqualStrings(blob_body, sink.writer.buffered());
+    // Exactly one content-length was reported: only the 200 blob streamed
+    // through progress; the discarded 401 body never did.
+    try std.testing.expectEqual(@as(usize, 1), rec.len_count);
+    try std.testing.expect(rec.calls >= 1);
     // The final report reflects the real blob, not the discarded error body.
     try std.testing.expectEqual(@as(u64, blob_body.len), rec.last_bytes);
 }
@@ -327,12 +327,12 @@ fn serveConc(cs: *ConcStub) void {
 const WorkerCtx = struct {
     g: *ghcr.GhcrClient,
     http: *client.HttpClient,
-    body: std.ArrayList(u8) = .empty,
+    sink: std.Io.Writer.Allocating,
     ok: bool = false,
 };
 
 fn concWorker(ctx: *WorkerCtx) void {
-    ctx.g.downloadBlob(std.testing.allocator, ctx.http, "homebrew/core/tree", "sha256:abc", &ctx.body, null) catch return;
+    ctx.g.downloadBlob(ctx.http, "homebrew/core/tree", "sha256:abc", &ctx.sink.writer, null) catch return;
     ctx.ok = true;
 }
 
@@ -366,10 +366,10 @@ test "concurrent downloadBlob workers recover from 401 without cache corruption"
     defer g.deinit();
     g.base_url = base;
 
-    var w1 = WorkerCtx{ .g = &g, .http = &http1 };
-    var w2 = WorkerCtx{ .g = &g, .http = &http2 };
-    defer w1.body.deinit(std.testing.allocator);
-    defer w2.body.deinit(std.testing.allocator);
+    var w1 = WorkerCtx{ .g = &g, .http = &http1, .sink = .init(std.testing.allocator) };
+    var w2 = WorkerCtx{ .g = &g, .http = &http2, .sink = .init(std.testing.allocator) };
+    defer w1.sink.deinit();
+    defer w2.sink.deinit();
 
     const t1 = try std.Thread.spawn(.{}, concWorker, .{&w1});
     const t2 = try std.Thread.spawn(.{}, concWorker, .{&w2});
@@ -383,8 +383,8 @@ test "concurrent downloadBlob workers recover from 401 without cache corruption"
 
     try std.testing.expect(w1.ok);
     try std.testing.expect(w2.ok);
-    try std.testing.expectEqualStrings(blob_body, w1.body.items);
-    try std.testing.expectEqualStrings(blob_body, w2.body.items);
+    try std.testing.expectEqualStrings(blob_body, w1.sink.writer.buffered());
+    try std.testing.expectEqualStrings(blob_body, w2.sink.writer.buffered());
     // Each worker fetched, hit 401, invalidated, re-fetched: at least the two
     // initial fetches happened (the exact total races by design).
     try std.testing.expect(cs.token_count.load(.monotonic) >= 2);


### PR DESCRIPTION
## Description

The bottle download used to hold the entire bottle in RAM: it buffered the whole payload into a heap list, copied it a second time, hashed that copy, then wrote it to disk - peak memory scaled with bottle size (~2× a 200–400 MB
bottle).

This folds the SHA into the write stream: each downloaded chunk is teed straight to the temp file and a running hasher in a single pass, so peak memory no longer depends on bottle size and stays within a small fixed window, matching the bounded model the sibling `verify` path already advertises.

Both full-size buffer copies are gone, verification still covers the whole payload, and because the temp file is now created before the SHA is known every early return (stream error, hash mismatch, over-cap, transport failure, **and a verified-but-unextractable archive**) deletes the temp file and the dest dir, so nothing unverified or half-written can ever survive. Verify-before-extract holds by construction: extraction is only reachable on the verified branch. No `download(...)` caller signature changed.

Small hardening delta on the extract-failure path: previously a valid-SHA bottle that failed to extract left a partially populated dest dir behind; the new create-before-hash ordering makes that early return fail closed and wipe it.

Dead-code cleanup: `checkBottleSha` (the one-shot-hash-over-a-slice helper) had no production caller left once `download` computes its digest via the tee, so it was removed. Its coverage moved onto the production `checkStreamedSha`.

## Related Issue

- None

## Notes for Reviewers

- **Retry semantics for `run`/`migrate`.** The streaming sink is single-use, so a mid-body transport failure is surfaced rather than retried inside net. The install path absorbs this - its outer loop re-drives the download with a fresh temp dir - but `mt run` and `migrate keg` have no outer loop, so a mid-body failure there is now a hard fail on the first error instead of net's few in-body retries.
- `bottle.download` keeps its `allocator` parameter for call-site stability even though the streaming path is allocation-free (`_ = allocator;`).