### PR TITLE
test(net): cover getToWriter's streaming blob-size cap

### DIFF
--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -275,6 +275,11 @@ pub const HttpClient = struct {
     /// plane fails fast instead of waiting for connect timeouts.
     offline: bool = false,
 
+    /// Upper bound on a streamed blob body before the cap trips
+    /// `error.ResponseTooLarge`. Defaults to the production bound; tests lower
+    /// it to exercise the cap without a multi-GiB fixture.
+    blob_cap: usize = max_blob_bytes,
+
     /// Reused across requests; each HttpClient is borrowed single-threaded
     /// from a pool, so no concurrent access.
     zstd_window: ?[]u8 = null,
@@ -1096,7 +1101,7 @@ pub const HttpClient = struct {
             if (status == 200) {
                 // Commit point: past here a transport failure must not retry.
                 sink_committed.* = true;
-                try self.streamResponseBody(&req, &response, sink, max_blob_bytes, progress, total_timeout);
+                try self.streamResponseBody(&req, &response, sink, self.blob_cap, progress, total_timeout);
                 req.deinit();
                 return status;
             }

--- a/tests/net_get_to_writer_test.zig
+++ b/tests/net_get_to_writer_test.zig
@@ -336,3 +336,39 @@ test "getToWriter follows a redirect and streams only the final 200 body into th
     try std.testing.expectEqualStrings(body_200, sink.writer.buffered());
     try std.testing.expectEqual(@as(usize, 2), stub.get_count);
 }
+
+test "getToWriter trips ResponseTooLarge when the 200 body exceeds the blob cap" {
+    // The cap normally guards a multi-GiB body; lower it below the fixture so a
+    // normal 200 overshoots it. The cap fires past the 200 commit, so it is
+    // surfaced (never retried), and the over-cap chunk is refused before the
+    // sink can grow past the bound.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var stub = Stub{ .io = io, .listener = &listener, .mode = .ok };
+    const server_thread = try std.Thread.spawn(.{}, serve, .{&stub});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/blobs/sha256:abc", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    http.blob_cap = 8; // below body_200.len
+
+    var sink: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer sink.deinit();
+
+    const status = http.getToWriter(url, &.{}, &sink.writer, null);
+
+    http.deinit();
+    server_thread.join();
+
+    try std.testing.expectError(error.ResponseTooLarge, status);
+    try std.testing.expect(sink.writer.buffered().len <= 8);
+}


### PR DESCRIPTION
## Description

The streaming download verb `getToWriter` enforces a 2 GiB size cap (`max_blob_bytes`) mid-stream via `CountingWriter`, but that cap had no direct test on the streaming path - driving it needed a body larger than 2 GiB.

This adds a small testability seam: an injectable `blob_cap` field on `HttpClient`, defaulting to the production `max_blob_bytes` bound, that `getToWriter`'s 200-stream now reads. 

Production behaviour is unchanged (the default is the same 2 GiB); only tests set a lower value. 

## Related Issue

- None

## Notes for Reviewers

- None