### PR TITLE
refactor(tui): let each tab own its background-fetch behavior

### DIFF
--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -799,26 +799,12 @@ const TabFetch = struct {
 /// (synchronous by design) never background-fetch, so their slots stay null.
 const Fetches = std.EnumArray(Tab, ?TabFetch);
 
-/// The `mt` subcommand + exit tolerance for a slow tab's `--json` audit, or null
-/// for a tab that does not background-fetch. Doctor exits by severity while still
-/// emitting findings, so it tolerates ≤2 where the others require 0.
-fn fetchSpec(t: Tab) ?struct { verb: []const []const u8, max_ok_exit: u8 } {
+/// The tab's background-fetch descriptor, read from its module — runtime `t`
+/// bridged to the comptime `moduleFor` dispatch the render path already uses.
+/// Null for a tab that does not background-fetch (installed, search).
+fn fetchSpec(t: Tab) ?tab.FetchSpec {
     return switch (t) {
-        .outdated => .{ .verb = &.{"outdated"}, .max_ok_exit = 0 },
-        .services => .{ .verb = &.{ "services", "list" }, .max_ok_exit = 0 },
-        .doctor => .{ .verb = &.{"doctor"}, .max_ok_exit = 2 },
-        else => null,
-    };
-}
-
-/// The banner op for a tab's failed background refresh — the same wording the
-/// synchronous reload uses, so a failure reads the same either way.
-fn tabRefreshOp(t: Tab) []const u8 {
-    return switch (t) {
-        .outdated => "outdated refresh failed",
-        .services => "services refresh failed",
-        .doctor => "doctor refresh failed",
-        else => "refresh failed",
+        inline else => |ct| moduleFor(ct).fetch_spec,
     };
 }
 
@@ -891,10 +877,13 @@ fn applyTabBytes(allocator: std.mem.Allocator, app: *App, store: *Store, t: Tab,
 /// recoverable banner the synchronous reload uses and keeps the last-good data —
 /// never fatal, the loop keeps running.
 fn finishTabFetch(allocator: std.mem.Allocator, painter: Painter, fetches: *Fetches, app: *App, store: *Store, t: Tab, outcome: FetchOutcome) void {
+    // Only reached for a tab with an active fetch, so the spec is present; the
+    // fallback matches the old switch's default for a would-be non-fetch tab.
+    const refresh_op = if (fetchSpec(t)) |s| s.refresh_op else "refresh failed";
     switch (outcome) {
-        .failed => |err| app.banner.set(tabRefreshOp(t), @errorName(err)),
-        .empty => applyTabBytes(allocator, app, store, t, null) catch |e| app.banner.set(tabRefreshOp(t), @errorName(e)),
-        .bytes => |b| applyTabBytes(allocator, app, store, t, b) catch |e| app.banner.set(tabRefreshOp(t), @errorName(e)),
+        .failed => |err| app.banner.set(refresh_op, @errorName(err)),
+        .empty => applyTabBytes(allocator, app, store, t, null) catch |e| app.banner.set(refresh_op, @errorName(e)),
+        .bytes => |b| applyTabBytes(allocator, app, store, t, b) catch |e| app.banner.set(refresh_op, @errorName(e)),
     }
     if (fetches.getPtr(t).*) |*f| f.buf.deinit(allocator);
     fetches.set(t, null);
@@ -1926,6 +1915,29 @@ test "ttyReadable sees a buffered byte and times out on silence" {
     try std.testing.expect(!ttyReadable(fds[0], 1)); // silent pipe: the window elapses
     try std.testing.expectEqual(@as(isize, 1), std.c.write(fds[1], "x", 1));
     try std.testing.expect(ttyReadable(fds[0], 1)); // a byte is waiting: ready
+}
+
+test "fetch_spec declares each tab's background audit, byte-identical to the old switches" {
+    // Read generically through the same `moduleFor` dispatch the render path uses.
+    const outdated_spec = fetchSpec(.outdated).?;
+    try std.testing.expectEqualDeep(@as([]const []const u8, &.{"outdated"}), outdated_spec.verb);
+    try std.testing.expectEqual(@as(u8, 0), outdated_spec.max_ok_exit);
+    try std.testing.expectEqualStrings("outdated refresh failed", outdated_spec.refresh_op);
+
+    const services_spec = fetchSpec(.services).?;
+    try std.testing.expectEqualDeep(@as([]const []const u8, &.{ "services", "list" }), services_spec.verb);
+    try std.testing.expectEqual(@as(u8, 0), services_spec.max_ok_exit);
+    try std.testing.expectEqualStrings("services refresh failed", services_spec.refresh_op);
+
+    // Doctor tolerates its severity exit (≤2) where the others require a clean 0.
+    const doctor_spec = fetchSpec(.doctor).?;
+    try std.testing.expectEqualDeep(@as([]const []const u8, &.{"doctor"}), doctor_spec.verb);
+    try std.testing.expectEqual(@as(u8, 2), doctor_spec.max_ok_exit);
+    try std.testing.expectEqualStrings("doctor refresh failed", doctor_spec.refresh_op);
+
+    // Synchronous tabs never background-fetch.
+    try std.testing.expectEqual(@as(?tab.FetchSpec, null), fetchSpec(.installed));
+    try std.testing.expectEqual(@as(?tab.FetchSpec, null), fetchSpec(.search));
 }
 
 const guard_pkgs = [_]installed.Pkg{

--- a/src/tui/doctor_tab.zig
+++ b/src/tui/doctor_tab.zig
@@ -37,6 +37,9 @@ pub const State = struct {
     request: Request = .none,
 };
 
+/// Doctor audits in the background; it exits by severity, so it tolerates ≤2.
+pub const fetch_spec: ?tab.FetchSpec = .{ .verb = &.{"doctor"}, .max_ok_exit = 2, .refresh_op = "doctor refresh failed" };
+
 pub fn title() []const u8 {
     return "Doctor";
 }

--- a/src/tui/installed_tab.zig
+++ b/src/tui/installed_tab.zig
@@ -71,6 +71,9 @@ pub const State = struct {
     request: Request = .none,
 };
 
+/// Installed reads synchronously from the DB; it never background-fetches.
+pub const fetch_spec: ?tab.FetchSpec = null;
+
 pub fn title() []const u8 {
     return "Installed";
 }

--- a/src/tui/outdated_tab.zig
+++ b/src/tui/outdated_tab.zig
@@ -34,6 +34,9 @@ pub const State = struct {
     request: Request = .none,
 };
 
+/// Outdated audits in the background; a non-clean exit means a failed refresh.
+pub const fetch_spec: ?tab.FetchSpec = .{ .verb = &.{"outdated"}, .max_ok_exit = 0, .refresh_op = "outdated refresh failed" };
+
 pub fn title() []const u8 {
     return "Outdated";
 }

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -76,6 +76,9 @@ pub const State = struct {
     view: View = .results,
 };
 
+/// Search runs synchronously on demand; it never background-fetches.
+pub const fetch_spec: ?tab.FetchSpec = null;
+
 /// One basket row the shell hands the leaf: a borrowed `(name, kind)`. The bytes
 /// are owned (and freed) by the shell-owned set; the leaf renders them (scrubbed)
 /// and reads them to name a removal — never interprets or frees them.

--- a/src/tui/services_tab.zig
+++ b/src/tui/services_tab.zig
@@ -35,6 +35,9 @@ pub const State = struct {
     detail: ?Row = null,
 };
 
+/// Services audits in the background; a non-clean exit means a failed refresh.
+pub const fetch_spec: ?tab.FetchSpec = .{ .verb = &.{ "services", "list" }, .max_ok_exit = 0, .refresh_op = "services refresh failed" };
+
 pub fn title() []const u8 {
     return "Services";
 }

--- a/src/tui/tab.zig
+++ b/src/tui/tab.zig
@@ -27,6 +27,17 @@ pub const Chrome = struct {
     view: scroll_list.View = .{},
 };
 
+/// A background tab's `--json` audit descriptor, declared beside the tab instead
+/// of hand-switched in the shell: the `mt` subcommand `verb`, the exit tolerance
+/// (Doctor exits by severity while still emitting findings, so it tolerates ≤2
+/// where the others require a clean 0), and the `refresh_op` banner wording a
+/// failed refresh shows. `null` for a tab that does not background-fetch.
+pub const FetchSpec = struct {
+    verb: []const []const u8,
+    max_ok_exit: u8,
+    refresh_op: []const u8,
+};
+
 /// A bounded frame-byte appender. Writes stop at the buffer end (the frame is
 /// truncated, never overflows) — same discipline as `layout.render`.
 pub const Frame = struct {
@@ -166,12 +177,17 @@ pub fn verify(comptime M: type) void {
     for ([_][]const u8{ "title", "footerHint", "step", "render" }) |decl| {
         if (!@hasDecl(M, decl)) @compileError(@typeName(M) ++ ": tab must expose `pub fn " ++ decl ++ "`");
     }
+    // A tab declares its background-fetch capability as data, read generically by
+    // the shell; `null` for a synchronous tab. Total coverage, no runtime switch.
+    if (!@hasDecl(M, "fetch_spec")) @compileError(@typeName(M) ++ ": tab must expose `pub const fetch_spec: ?FetchSpec`");
+    if (@TypeOf(M.fetch_spec) != ?FetchSpec) @compileError(@typeName(M) ++ ".fetch_spec must be `?FetchSpec`");
 }
 
 // ─── tests ───────────────────────────────────────────────────────────
 
 const GoodTab = struct {
     pub const State = struct { chrome: Chrome = .{} };
+    pub const fetch_spec: ?FetchSpec = null;
     pub fn title() []const u8 {
         return "Good";
     }


### PR DESCRIPTION
## Description

Each background tab now declares its own `--json` audit - the subcommand, the exit tolerance, and the refresh-banner wording - as data beside the tab, instead of the app hub hand-switching on tab tag in two places. The shell reads it through the same generic path it already uses to dispatch rendering, so a tab's fetch behavior lives with the tab. Behaviour is unchanged: verbs, Doctor's exit-2 tolerance, and every banner string are identical.

## Related Issue

- None

## Notes for Reviewers

- None