### PR TITLE
refactor(tui): add a ctx sink leaf for the shared read-model and effect ports

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -104,6 +104,7 @@ pub const term_sanitize = @import("ui/term_sanitize.zig");
 pub const theme_registry = @import("ui/theme_registry.zig");
 pub const themes = @import("ui/themes.zig");
 pub const tui_app = @import("tui/app.zig");
+pub const tui_ctx = @import("tui/ctx.zig");
 pub const tui_detail_pane = @import("tui/detail_pane.zig");
 pub const tui_filter_input = @import("tui/filter_input.zig");
 pub const tui_header = @import("tui/header.zig");

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -14,7 +14,7 @@ const std = @import("std");
 
 const color = @import("../ui/color.zig");
 const spinner_frames = @import("../ui/spinner_frames.zig");
-const term_sanitize = @import("../ui/term_sanitize.zig");
+const ctx = @import("ctx.zig");
 const doctor = @import("doctor_tab.zig");
 const filter_input = @import("filter_input.zig");
 const header = @import("header.zig");
@@ -38,6 +38,13 @@ const tab_bar = @import("tab_bar.zig");
 const Tab = tab_bar.Tab;
 const term = @import("term.zig");
 const text_wrap = @import("text_wrap.zig");
+
+// Shared read-model + effect-port handles now live in the `ctx.zig` sink leaf;
+// the hub references them downward instead of owning their definitions.
+const Banner = ctx.Banner;
+const Painter = ctx.Painter;
+const TabFetch = ctx.TabFetch;
+const Fetches = ctx.Fetches;
 
 /// Every tab's state, all present at once so a tab switch preserves each one's
 /// filter / scroll / data. Field names match `Tab` tags for `@field` dispatch.
@@ -71,58 +78,6 @@ comptime {
 /// `step`, so a fixed page is the data-agnostic approximation; the render's
 /// `scroll_list.clamp` still bounds it to the real list.
 const page_step = 10;
-
-/// Cap on the recoverable-error banner. An op label + an error name fit well
-/// inside this; the cap keeps the buffer fixed so the banner never allocates.
-pub const banner_max = 160;
-
-/// A transient banner for a recoverable backend failure, shown in the footer.
-/// Fixed buffer, no allocation, like the filter. Set when a delegated op fails
-/// recoverably, cleared on the next keypress (`step`). The message is run
-/// through `term_sanitize` at set-time because the op label may carry a
-/// child-derived package name — the leaf's untrusted-input rule.
-pub const Banner = struct {
-    buf: [banner_max]u8 = undefined,
-    len: usize = 0,
-
-    pub fn slice(self: *const Banner) []const u8 {
-        return self.buf[0..self.len];
-    }
-
-    pub fn isSet(self: *const Banner) bool {
-        return self.len != 0;
-    }
-
-    pub fn clear(self: *Banner) void {
-        self.len = 0;
-    }
-
-    /// Format "<op>: <reason>" into the fixed buffer, run through `term_sanitize`
-    /// so a child-derived package name in `op` cannot inject escape sequences.
-    /// Truncated at the cap; the footer render also strips line-breakers the
-    /// sanitizer lets through (`putContent`).
-    pub fn set(self: *Banner, op: []const u8, reason: []const u8) void {
-        self.len = 0;
-        var san = term_sanitize.Sanitizer.init();
-        const sink: term_sanitize.Sink = .{ .ctx = self, .write_fn = appendSink };
-        // The buffered sink never fails — it truncates at the cap — so the
-        // sanitizer's propagated error cannot occur here; ignore it deliberately.
-        san.feed(op, sink) catch {};
-        san.feed(": ", sink) catch {};
-        san.feed(reason, sink) catch {};
-        san.flush(sink) catch {};
-    }
-
-    /// `term_sanitize.Sink` callback: append clean bytes, bounded by the cap.
-    /// `@ptrCast` is the sink's `*anyopaque` → `*Banner` round-trip; the ctx was
-    /// set from a `*Banner` just above, so the cast is sound.
-    fn appendSink(ctx: *anyopaque, bytes: []const u8) term_sanitize.SinkError!void {
-        const self: *Banner = @ptrCast(@alignCast(ctx));
-        const n = @min(bytes.len, self.buf.len - self.len);
-        @memcpy(self.buf[self.len..][0..n], bytes[0..n]);
-        self.len += n;
-    }
-};
 
 pub const App = struct {
     active: Tab = .search,
@@ -544,14 +499,6 @@ pub fn classify(err: RunError) ErrorClass {
     };
 }
 
-/// Mid-load repaint handle for the polled lazy reads: the controlling-tty fd and
-/// the (resizable) frame buffer, threaded from `run` to wherever a lazy `loadX`
-/// runs so its spinner can repaint without `spawn.zig` knowing about rendering.
-const Painter = struct {
-    fd: std.posix.fd_t,
-    frame: *[]u8,
-};
-
 /// The `tick` callback `spawn.readJsonPolled` invokes on every poll timeout while
 /// a lazy tab is loading: advance the spinner one frame and repaint. Closes over
 /// the paint handle + `App`, so the animation lives here, not in the generic
@@ -782,22 +729,6 @@ pub fn pollMux(tty_fd: std.posix.fd_t, fetch_fds: []const std.posix.fd_t, timeou
     for (0..fetch_fds.len) |i| if (pfds[1 + i].revents != 0) return .{ .fetch = i };
     return .timeout; // defensive: poll reported ready but nothing matched
 }
-
-/// One in-flight background tab fetch: a non-blocking `mt <verb> --json` child
-/// whose stdout the loop drains. `tab` routes the drained bytes to the owning
-/// store; `max_ok_exit` tolerates Doctor's severity exits (≤2) where the others
-/// require a clean 0.
-const TabFetch = struct {
-    tab: Tab,
-    child: std.process.Child,
-    fd: std.posix.fd_t, // the child's stdout, polled alongside the tty
-    buf: std.ArrayList(u8) = .empty,
-    max_ok_exit: u8,
-};
-
-/// At most one in-flight fetch per tab. Installed (a cheap DB read) and Search
-/// (synchronous by design) never background-fetch, so their slots stay null.
-const Fetches = std.EnumArray(Tab, ?TabFetch);
 
 /// The tab's background-fetch descriptor, read from its module — runtime `t`
 /// bridged to the comptime `moduleFor` dispatch the render path already uses.
@@ -2787,34 +2718,6 @@ test "every data tab is dirty at launch so none blocks the first paint" {
     try std.testing.expect(a.dirty.contains(.services));
     try std.testing.expect(a.dirty.contains(.doctor));
     try std.testing.expect(!a.dirty.contains(.search)); // active tab renders without data
-}
-
-test "banner formats op + reason and reports set/clear" {
-    var b: Banner = .{};
-    try std.testing.expect(!b.isSet());
-    b.set("info for jq failed", "BadJson");
-    try std.testing.expect(b.isSet());
-    try std.testing.expectEqualStrings("info for jq failed: BadJson", b.slice());
-    b.clear();
-    try std.testing.expect(!b.isSet());
-    try std.testing.expectEqualStrings("", b.slice());
-}
-
-test "banner sanitizes a child-derived op so a package name cannot inject escapes" {
-    var b: Banner = .{};
-    // A hostile tap could name a package with an OSC title-set; it must be dropped.
-    b.set("info for \x1b]0;pwn\x07evil failed", "BadJson");
-    try std.testing.expect(std.mem.indexOfScalar(u8, b.slice(), 0x1b) == null); // no stray ESC
-    try std.testing.expect(std.mem.indexOf(u8, b.slice(), "evil failed: BadJson") != null);
-}
-
-test "banner truncates an over-cap op to the fixed buffer without overflow" {
-    var b: Banner = .{};
-    var huge: [banner_max * 2]u8 = undefined;
-    @memset(&huge, 'x');
-    b.set(&huge, "BadJson");
-    try std.testing.expect(b.isSet());
-    try std.testing.expect(b.slice().len <= banner_max); // bounded, no overrun
 }
 
 test "a newline in a child-derived op cannot inject an extra footer frame line" {

--- a/src/tui/ctx.zig
+++ b/src/tui/ctx.zig
@@ -1,0 +1,176 @@
+//! Sink leaf for the TUI's shared read-model and effect ports. Both `app.zig`
+//! (the hub) and every `*_tab.zig` import this *downward*: it names the types
+//! they share so a tab never has to reach up into `app.zig` for them, which
+//! would turn the hub into an import cycle. It imports only `std` and existing
+//! tui leaves — never `app.zig` or any tab.
+
+const std = @import("std");
+const term = @import("term.zig");
+const tab_bar = @import("tab_bar.zig");
+const term_sanitize = @import("../ui/term_sanitize.zig");
+
+const Tab = tab_bar.Tab;
+
+/// The already-leaf terminal handle, re-exported so `Ctx` can name it without a
+/// second import edge radiating from the hub.
+pub const Term = term.Term;
+
+/// Cap on the recoverable-error banner. An op label + an error name fit well
+/// inside this; the cap keeps the buffer fixed so the banner never allocates.
+pub const banner_max = 160;
+
+/// A transient banner for a recoverable backend failure, shown in the footer.
+/// Fixed buffer, no allocation, like the filter. Set when a delegated op fails
+/// recoverably, cleared on the next keypress (`step`). The message is run
+/// through `term_sanitize` at set-time because the op label may carry a
+/// child-derived package name — the leaf's untrusted-input rule.
+pub const Banner = struct {
+    buf: [banner_max]u8 = undefined,
+    len: usize = 0,
+
+    pub fn slice(self: *const Banner) []const u8 {
+        return self.buf[0..self.len];
+    }
+
+    pub fn isSet(self: *const Banner) bool {
+        return self.len != 0;
+    }
+
+    pub fn clear(self: *Banner) void {
+        self.len = 0;
+    }
+
+    /// Format "<op>: <reason>" into the fixed buffer, run through `term_sanitize`
+    /// so a child-derived package name in `op` cannot inject escape sequences.
+    /// Truncated at the cap; the footer render also strips line-breakers the
+    /// sanitizer lets through (`putContent`).
+    pub fn set(self: *Banner, op: []const u8, reason: []const u8) void {
+        self.len = 0;
+        var san = term_sanitize.Sanitizer.init();
+        const sink: term_sanitize.Sink = .{ .ctx = self, .write_fn = appendSink };
+        // The buffered sink never fails — it truncates at the cap — so the
+        // sanitizer's propagated error cannot occur here; ignore it deliberately.
+        san.feed(op, sink) catch {};
+        san.feed(": ", sink) catch {};
+        san.feed(reason, sink) catch {};
+        san.flush(sink) catch {};
+    }
+
+    /// `term_sanitize.Sink` callback: append clean bytes, bounded by the cap.
+    /// `@ptrCast` is the sink's `*anyopaque` → `*Banner` round-trip; the ctx was
+    /// set from a `*Banner` just above, so the cast is sound.
+    fn appendSink(ctx: *anyopaque, bytes: []const u8) term_sanitize.SinkError!void {
+        const self: *Banner = @ptrCast(@alignCast(ctx));
+        const n = @min(bytes.len, self.buf.len - self.len);
+        @memcpy(self.buf[self.len..][0..n], bytes[0..n]);
+        self.len += n;
+    }
+};
+
+/// Mid-load repaint handle for the polled lazy reads: the controlling-tty fd and
+/// the (resizable) frame buffer, threaded to wherever a lazy load runs so its
+/// spinner can repaint without `spawn.zig` knowing about rendering.
+pub const Painter = struct {
+    fd: std.posix.fd_t,
+    frame: *[]u8,
+};
+
+/// One in-flight background tab fetch: a non-blocking `mt <verb> --json` child
+/// whose stdout the loop drains. `tab` routes the drained bytes to the owning
+/// store; `max_ok_exit` tolerates Doctor's severity exits (≤2) where the others
+/// require a clean 0.
+pub const TabFetch = struct {
+    tab: Tab,
+    child: std.process.Child,
+    fd: std.posix.fd_t, // the child's stdout, polled alongside the tty
+    buf: std.ArrayList(u8) = .empty,
+    max_ok_exit: u8,
+};
+
+/// At most one in-flight fetch per tab. Installed (a cheap DB read) and Search
+/// (synchronous by design) never background-fetch, so their slots stay null.
+pub const Fetches = std.EnumArray(Tab, ?TabFetch);
+
+/// The genuinely multi-writer/multi-reader read-model: header counts, the
+/// cross-tab dirty set, and the recoverable-failure banner. App-owned and passed
+/// by pointer so cross-tab writers touch only these scalars, never another tab's
+/// private storage.
+pub const SharedModel = struct {
+    installed_count: ?usize = null,
+    outdated_count: ?usize = null,
+    dirty: std.EnumSet(Tab) = .initEmpty(),
+    banner: Banner = .{},
+};
+
+/// The effect ports bundle, passed by pointer to whatever performs an effect.
+/// Names the leaves it composes (`Term`, `Painter`, `Fetches`) plus the shared
+/// read-model — nothing here reaches back into the hub.
+pub const Ctx = struct {
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    term: *Term,
+    painter: Painter,
+    fetches: *Fetches,
+    shared: *SharedModel,
+};
+
+test "SharedModel defaults and mutation mirror the old inline App fields" {
+    var m: SharedModel = .{};
+    try std.testing.expectEqual(@as(?usize, null), m.installed_count);
+    try std.testing.expectEqual(@as(?usize, null), m.outdated_count);
+    try std.testing.expect(!m.dirty.contains(.outdated));
+    try std.testing.expect(!m.banner.isSet());
+
+    m.installed_count = 3;
+    m.outdated_count = 1;
+    m.dirty.insert(.outdated);
+    try std.testing.expectEqual(@as(?usize, 3), m.installed_count);
+    try std.testing.expectEqual(@as(?usize, 1), m.outdated_count);
+    try std.testing.expect(m.dirty.contains(.outdated));
+
+    // The dirty set tracks tabs independently — a second mark leaves the first
+    // set and an unmarked tab clear, so a cross-tab staleness never bleeds.
+    m.dirty.insert(.services);
+    try std.testing.expect(m.dirty.contains(.services));
+    try std.testing.expect(m.dirty.contains(.outdated));
+    try std.testing.expect(!m.dirty.contains(.installed));
+}
+
+test "banner formats op + reason and reports set/clear" {
+    var b: Banner = .{};
+    try std.testing.expect(!b.isSet());
+    b.set("info for jq failed", "BadJson");
+    try std.testing.expect(b.isSet());
+    try std.testing.expectEqualStrings("info for jq failed: BadJson", b.slice());
+    b.clear();
+    try std.testing.expect(!b.isSet());
+    try std.testing.expectEqualStrings("", b.slice());
+}
+
+test "banner sanitizes a child-derived op so a package name cannot inject escapes" {
+    var b: Banner = .{};
+    // A hostile tap could name a package with an OSC title-set; it must be dropped.
+    b.set("info for \x1b]0;pwn\x07evil failed", "BadJson");
+    try std.testing.expect(std.mem.indexOfScalar(u8, b.slice(), 0x1b) == null); // no stray ESC
+    try std.testing.expect(std.mem.indexOf(u8, b.slice(), "evil failed: BadJson") != null);
+}
+
+test "banner truncates an over-cap op to the fixed buffer without overflow" {
+    var b: Banner = .{};
+    var huge: [banner_max * 2]u8 = undefined;
+    @memset(&huge, 'x');
+    b.set(&huge, "BadJson");
+    try std.testing.expect(b.isSet());
+    try std.testing.expect(b.slice().len <= banner_max); // bounded, no overrun
+}
+
+test "Ctx bundles the effect ports and points at the shared read-model" {
+    try std.testing.expect(@hasField(Ctx, "io"));
+    try std.testing.expect(@hasField(Ctx, "allocator"));
+    // The mutable, borrowed handles are held by pointer; the small `Painter` is
+    // passed by value, mirroring how the hub threads them today.
+    try std.testing.expectEqual(*Term, @FieldType(Ctx, "term"));
+    try std.testing.expectEqual(Painter, @FieldType(Ctx, "painter"));
+    try std.testing.expectEqual(*Fetches, @FieldType(Ctx, "fetches"));
+    try std.testing.expectEqual(*SharedModel, @FieldType(Ctx, "shared"));
+}

--- a/tests/tui_purity_test.zig
+++ b/tests/tui_purity_test.zig
@@ -167,3 +167,118 @@ test "importAllowed rejects an outward reach from any depth" {
     try testing.expect(!importAllowed("src/tui", "../ui/output.zig")); // not whitelisted
     try testing.expect(!importAllowed("src/tui/json", "../../cli/list.zig"));
 }
+
+// ── Anti-cycle guard ───────────────────────────────────────────────────────
+// The leaf whitelist above still permits an *intra*-leaf `@import("app.zig")` —
+// `app.zig` lives inside `src/tui`. That is the one intra-leaf edge that must
+// never form: a tab (or the shared `ctx.zig` sink) importing the hub upward
+// turns the hub into an import cycle, strictly worse than the hub it replaces.
+// This guard pins the direction so a later effect move cannot regress it.
+
+const app_import = "@import(\"app.zig\")";
+
+/// A file bound by the anti-cycle rule: the `ctx.zig` sink and every `*_tab.zig`
+/// must import only downward. `app.zig` itself and the leaves it composes are
+/// exempt — the ban is on the upward edge into the hub, not on the hub.
+fn antiCycleGuarded(rel_path: []const u8) bool {
+    const base = if (std.mem.lastIndexOfScalar(u8, rel_path, '/')) |slash|
+        rel_path[slash + 1 ..]
+    else
+        rel_path;
+    return std.mem.eql(u8, base, "ctx.zig") or std.mem.endsWith(u8, base, "_tab.zig");
+}
+
+fn scanAntiCycle(io: std.Io, root: []const u8, failures: *std.ArrayList([]const u8)) !void {
+    var dir = try test_io.cwd().openDir(io, root, .{ .iterate = true });
+    defer dir.close(io);
+
+    var walker = try dir.walk(testing.allocator);
+    defer walker.deinit();
+
+    while (try walker.next(io)) |entry| {
+        if (entry.kind != .file) continue;
+        if (!antiCycleGuarded(entry.path)) continue;
+
+        const file = try dir.openFile(io, entry.path, .{});
+        defer file.close(io);
+        const stat = try file.stat(io);
+        const content = try testing.allocator.alloc(u8, @intCast(stat.size));
+        defer testing.allocator.free(content);
+        _ = try file.readPositionalAll(io, content, 0);
+
+        if (std.mem.indexOf(u8, content, app_import) != null) {
+            const msg = try std.fmt.allocPrint(
+                testing.allocator,
+                "{s}/{s} imports the hub \"app.zig\" (would form an import cycle)",
+                .{ root, entry.path },
+            );
+            try failures.append(testing.allocator, msg);
+        }
+    }
+}
+
+test "antiCycleGuarded covers ctx.zig and every *_tab.zig, not the hub or its leaves" {
+    try testing.expect(antiCycleGuarded("ctx.zig"));
+    try testing.expect(antiCycleGuarded("src/tui/outdated_tab.zig"));
+    try testing.expect(antiCycleGuarded("installed_tab.zig"));
+    try testing.expect(!antiCycleGuarded("app.zig"));
+    try testing.expect(!antiCycleGuarded("tab.zig"));
+    try testing.expect(!antiCycleGuarded("tab_bar.zig"));
+}
+
+test "the anti-cycle scan detects an upward app.zig import edge" {
+    const forbidden = "const app = @import(\"app.zig\");\n";
+    const clean = "const term = @import(\"term.zig\");\n";
+    try testing.expect(std.mem.indexOf(u8, forbidden, app_import) != null);
+    try testing.expect(std.mem.indexOf(u8, clean, app_import) == null);
+}
+
+test "no tab or ctx sink imports app.zig" {
+    const io = std.Options.debug_io;
+
+    var failures: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (failures.items) |s| testing.allocator.free(s);
+        failures.deinit(testing.allocator);
+    }
+
+    try scanAntiCycle(io, scanned_root, &failures);
+
+    if (failures.items.len != 0) {
+        for (failures.items) |f| std.debug.print("{s}\n", .{f});
+        return error.TuiAntiCycleViolated;
+    }
+}
+
+fn writeFixture(io: std.Io, abs_path: []const u8, content: []const u8) !void {
+    const f = try test_io.createFileAbsolute(io, abs_path, .{});
+    defer f.close(io);
+    try f.writeStreamingAll(io, content);
+}
+
+// End-to-end teeth for the scan: a synthetic tree where only a guarded file
+// carries the upward edge must produce exactly one failure — proving the walk,
+// the `antiCycleGuarded` gate, and the detection are wired together, not just
+// correct in isolation.
+test "the anti-cycle scan flags a guarded file that imports the hub, and only that file" {
+    const io = std.Options.debug_io;
+    const base = "/tmp/malt_anticycle_fixture";
+    test_io.deleteTreeAbsolute(io, base) catch {};
+    try test_io.makeDirAbsolute(io, base);
+    defer test_io.deleteTreeAbsolute(io, base) catch {};
+
+    try writeFixture(io, base ++ "/evil_tab.zig", "const app = @import(\"app.zig\");\n");
+    try writeFixture(io, base ++ "/ctx.zig", "const term = @import(\"term.zig\");\n"); // clean sink
+    try writeFixture(io, base ++ "/list.zig", "const app = @import(\"app.zig\");\n"); // not guarded → ignored
+
+    var failures: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (failures.items) |s| testing.allocator.free(s);
+        failures.deinit(testing.allocator);
+    }
+
+    try scanAntiCycle(io, base, &failures);
+
+    try testing.expectEqual(@as(usize, 1), failures.items.len);
+    try testing.expect(std.mem.indexOf(u8, failures.items[0], "evil_tab.zig") != null);
+}


### PR DESCRIPTION
## Description

Dissolving the TUI hub needs the shared read-model (header counts, the cross-tab dirty set, the banner) and the effect ports to live somewhere every tab can import *downward* - importing the app module upward would turn the hub into an import cycle, which is worse. This adds a `tui/ctx.zig` sink leaf that owns those shared types; the app module now depends on the leaf instead of defining them inline. Types-only relocation, no behaviour change, and a boundary guard pins the no-upward-import rule so later effect moves can't regress it.

## Related Issue

- None

## Notes for Reviewers

- None