### PR TITLE
refactor(tui): widen the tab contract with a service capability and route it through moduleFor

### DIFF
--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -117,15 +117,11 @@ pub const App = struct {
     prefix: []const u8 = "",
 };
 
-/// After a delegated mutation the active tab was just re-read inline, so it is
-/// fresh; the others may now be stale. Mark them dirty — a dirty tab refetches
-/// only when entered (`takeDirty`), so the cost is paid lazily, on view. Takes the
-/// shared read-model by pointer, not the whole `App`: the cross-tab staleness
-/// channel is scalar-mediated, so this writer structurally cannot touch a tab's
-/// private `Storage`.
+/// The legacy free-function spelling for the hub's not-yet-migrated cross-tab
+/// writers; delegates to `SharedModel.markStaleAfter`, which the migrated tabs
+/// call on the shared model directly. Removed when the last writer moves.
 pub fn markStaleAfterMutation(shared: *SharedModel, active: Tab) void {
-    shared.dirty = std.EnumSet(Tab).initFull();
-    shared.dirty.remove(active);
+    shared.markStaleAfter(active);
 }
 
 /// Mark every data tab dirty at launch so each loads lazily on first entry.
@@ -518,6 +514,27 @@ const LoadTicker = struct {
     }
 };
 
+/// Binds the whole-dashboard repaint for a migrated tab's synchronous polled load
+/// (the Doctor reload after a fix). Type-erased into `Painter.on_tick` so the tab
+/// animates its spinner without importing the hub — only the hub can render every
+/// tab. Mirrors `LoadTicker.tick`, which the not-yet-migrated tabs still use directly.
+const TickBind = struct {
+    allocator: std.mem.Allocator,
+    app: *App,
+    fd: std.posix.fd_t,
+    frame: *[]u8,
+    fn call(p: *anyopaque) void {
+        // `p` was set from a `*TickBind` (`&tick_bind` in `run`), so the round-trip is sound.
+        const b: *TickBind = @ptrCast(@alignCast(p));
+        b.app.spinner_frame +%= 1;
+        // A resize during the load reflows here (repaint reads currentSize); consume
+        // the flag so the loop's own resize check doesn't redundantly repaint.
+        _ = term.takeResized();
+        // Best-effort, like paintLoading: a dropped animation frame is cosmetic.
+        repaint(b.fd, b.frame, b.allocator, b.app) catch {};
+    }
+};
+
 /// The Search tab's cross-query selection ("basket") now lives beside its tab —
 /// it is search-private storage. Aliased here so the shell's search helpers still
 /// name it without the definition radiating from the hub.
@@ -729,7 +746,7 @@ fn applyTabBytes(allocator: std.mem.Allocator, app: *App, store: *Storages, t: T
     switch (t) {
         .outdated => try applyOutdatedBytes(allocator, app, store, bytes),
         .services => try applyServicesBytes(allocator, app, store, bytes),
-        .doctor => try applyDoctorBytes(allocator, app, store, bytes),
+        .doctor => try doctor.applyDoctorBytes(allocator, &app.states.doctor, &store.doctor, bytes),
         else => {},
     }
 }
@@ -1164,99 +1181,6 @@ fn serviceServices(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, pain
     }
 }
 
-/// (Re)read `mt doctor --json` and repoint the Doctor tab's findings at the fresh
-/// parse, freeing the previous one.
-fn loadDoctor(io: std.Io, allocator: std.mem.Allocator, painter: Painter, app: *App, store: *Storages) RunError!void {
-    // Annotate any failure as a recoverable banner; the loop boundary decides
-    // recoverable vs fatal. The store is swapped only after a clean parse, so a
-    // failure keeps the last-good findings and their selection.
-    errdefer |err| app.shared.banner.set("doctor refresh failed", @errorName(err));
-    const argv = try spawn.jsonArgv(allocator, app.mt_path, &.{"doctor"});
-    defer allocator.free(argv);
-    // Animate the spinner across the poll: `loading` stays set so each tick
-    // paints it, cleared once the result (or the empty/banner state) replaces it.
-    app.loading = true;
-    defer app.loading = false;
-    const ticker = LoadTicker{ .p = painter, .allocator = allocator, .app = app };
-    // `mt doctor` exits non-zero by severity (1 warn / 2 err) while still emitting
-    // its findings JSON — exactly when the tab is most useful — so the doctor read
-    // tolerates exits up to 2 (`max_ok_exit`) where the generic read rejects them.
-    const bytes = try spawn.readJsonPolled(io, allocator, argv, 2, ticker);
-    defer if (bytes) |b| allocator.free(b);
-    try applyDoctorBytes(allocator, app, store, bytes);
-}
-
-/// Repoint the Doctor tab at a drained `--json` payload. `null` (a fresh prefix)
-/// clears to no findings; a parsed document swaps in the rows + reclaimable stats.
-/// Shared by the synchronous reload and the background fetch; the store is swapped
-/// only after a clean parse, so a failure keeps the last-good findings.
-fn applyDoctorBytes(allocator: std.mem.Allocator, app: *App, store: *Storages, bytes: ?[]const u8) RunError!void {
-    const payload = bytes orelse {
-        if (store.doctor.doctor) |old| old.deinit();
-        store.doctor.doctor = null;
-        app.states.doctor.items = &.{};
-        return;
-    };
-    const parsed = try doctor_json.parse(allocator, payload);
-    applyDoctorParse(app, store, parsed);
-}
-
-/// Repoint the Doctor tab at a fresh parse, freeing the previous one. Split from
-/// the spawn so the findings + reclaimable stats wiring is testable without a
-/// child process.
-fn applyDoctorParse(app: *App, store: *Storages, parsed: doctor_json.Parsed) void {
-    if (store.doctor.doctor) |old| old.deinit();
-    store.doctor.doctor = parsed;
-    app.states.doctor.items = parsed.items;
-    app.states.doctor.stats = parsed.stats;
-}
-
-/// Build `mt doctor --fix <class>` for the selected finding. Pure over the tab
-/// state: null when nothing is selected or the finding is not fixable (the
-/// no-op), else an owned argv. The token is the finding's `fix_class` — the only
-/// thing `mt doctor --fix` resolves — not its descriptive `id`. Caller frees the
-/// returned slice (not its elements).
-fn doctorFixArgv(allocator: std.mem.Allocator, mt_path: []const u8, st: *const doctor.State) std.mem.Allocator.Error!?[]const []const u8 {
-    const fnd = doctor.selectedFinding(st) orelse return null; // empty list: no-op
-    if (!fnd.fixable) return null; // a non-fixable finding has no fix target
-    return try spawn.inlineArgv(allocator, mt_path, &.{ "doctor", "--fix", doctor_json.fixClassTag(fnd.fix_class) });
-}
-
-/// Delegate the selected finding's fix to the real `mt` inline, then refresh.
-fn doDoctorFix(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, app: *App, store: *Storages) RunError!void {
-    const argv = (try doctorFixArgv(allocator, app.mt_path, &app.states.doctor)) orelse return; // nothing fixable selected
-    defer allocator.free(argv);
-    {
-        // `mt doctor --fix` exits by severity (1 warn / 2 err), not pass/fail —
-        // a clean sweep of a warning-class finding still exits 1 — so tolerate
-        // exits up to 2 (symmetric with the doctor read's `max_ok_exit`). A real
-        // fault (exit > 2, signal, terminal fault) still surfaces as a banner;
-        // a severity exit re-enters cleanly and falls through to the refresh.
-        // Scoped so the refresh below reports under its own op, not the fix.
-        errdefer |err| app.shared.banner.set("doctor fix failed", @errorName(err));
-        try spawn.runInlineReenterTolerant(t, argv, 2);
-    }
-    try loadDoctor(io, allocator, painter, app, store); // exit can't say what remains — the refresh is the truth
-    markStaleAfterMutation(&app.shared, app.active);
-}
-
-/// Perform any fix effect the pure `step` requested on the Doctor tab, then clear
-/// it, and lazily (re)load on first entry or after a mutation marked it dirty.
-fn serviceDoctor(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, app: *App, store: *Storages) RunError!void {
-    const req = app.states.doctor.request;
-    app.states.doctor.request = .none;
-    switch (req) {
-        .none => {},
-        .fix => try doDoctorFix(io, allocator, t, painter, app, store),
-    }
-    // Lazy per-tab load: first activation and post-mutation staleness both arrive
-    // as the dirty flag (set at init and by `markStaleAfterMutation`).
-    // Background, non-blocking — see `serviceOutdated`.
-    if (app.active == .doctor and takeDirty(app, .doctor)) {
-        startTabFetch(io, allocator, fetches, app, .doctor);
-    }
-}
-
 /// Build `mt search <query> --json` for the committed query. Pure over the tab
 /// state: null when the query is empty (the no-op — the view shows guidance, no
 /// spawn), else an owned argv whose `query` element borrows the filter buffer.
@@ -1457,7 +1381,7 @@ fn mutationPending(app: *const App) bool {
     return app.states.installed.request == .uninstall or
         app.states.outdated.request == .upgrade or
         app.states.services.request != .none or
-        app.states.doctor.request == .fix or
+        doctor.mutates(&app.states.doctor) or // the migrated tab declares this as a capability
         app.states.search.request == .install;
 }
 
@@ -1495,17 +1419,59 @@ fn drainActiveFetches(io: std.Io, allocator: std.mem.Allocator, painter: Painter
 
 /// Drain the active tab's pending effects after a keypress. Each tab's service is
 /// a no-op unless that tab is active and has a request or is due a lazy refresh,
-/// so calling each one each loop is cheap and keeps the dispatch flat.
+/// so visiting each one each loop is cheap and keeps the dispatch flat.
 fn service(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, app: *App, store: *Storages) RunError!void {
     // Sole-orchestrator invariant: quiesce any in-flight audit before an inline
     // mutator opens the DB, else the two opens race the single WAL writer and the
     // mutation fails with `Busy`. Read-only turns never drain — navigation stays live.
     if (anyFetchActive(fetches) and mutationPending(app)) drainActiveFetches(io, allocator, painter, fetches, app, store);
-    try serviceInstalled(io, allocator, t, app, store);
-    try serviceOutdated(io, allocator, t, fetches, app, store);
-    try serviceServices(io, allocator, t, painter, fetches, app, store);
-    try serviceDoctor(io, allocator, t, painter, fetches, app, store);
-    try serviceSearch(io, allocator, t, app, store);
+    inline for (@typeInfo(Tab).@"enum".fields) |fld| {
+        try serviceTab(@field(Tab, fld.name), io, allocator, t, painter, fetches, app, store);
+    }
+}
+
+/// Route one tab's post-keypress effects. A migrated tab (one exposing the
+/// contract's `service`) runs through the same comptime `moduleFor` switch the
+/// render path uses; the not-yet-migrated tabs fall back to their legacy
+/// `serviceX` until they move too. Temporary scaffolding — the `@hasDecl` fork and
+/// the legacy arm disappear once every tab conforms.
+fn serviceTab(comptime tag: Tab, io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, app: *App, store: *Storages) RunError!void {
+    const M = moduleFor(tag);
+    if (comptime @hasDecl(M, "service")) {
+        // A request or lazy load only ever concerns the active tab (only its `step`
+        // runs), so a conforming tab's `service` runs only when active — the same
+        // scope its legacy `serviceX` guarded internally.
+        if (app.active != tag) return;
+        var c: ctx.Ctx = .{
+            .io = io,
+            .allocator = allocator,
+            .term = t,
+            .painter = painter,
+            .fetches = fetches,
+            .shared = &app.shared,
+            .mt_path = app.mt_path,
+            .loading = &app.loading,
+        };
+        try M.service(&@field(app.states, @tagName(tag)), &@field(app.storages, @tagName(tag)), &c);
+        // The lazy background (re)load stays loop machinery: kick the tab's audit on
+        // first entry / after a mutation marked it dirty. A tab without a fetch spec
+        // is skipped (its lazy-load, if any, is its own concern).
+        if (M.fetch_spec != null and takeDirty(app, tag)) startTabFetch(io, allocator, fetches, app, tag);
+    } else {
+        try legacyService(tag, io, allocator, t, painter, fetches, app, store);
+    }
+}
+
+/// The pre-contract dispatch for a tab whose effect group still lives in the hub.
+/// Removed once the last tab exposes `service`.
+fn legacyService(comptime tag: Tab, io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, app: *App, store: *Storages) RunError!void {
+    switch (tag) {
+        .installed => try serviceInstalled(io, allocator, t, app, store),
+        .outdated => try serviceOutdated(io, allocator, t, fetches, app, store),
+        .services => try serviceServices(io, allocator, t, painter, fetches, app, store),
+        .search => try serviceSearch(io, allocator, t, app, store),
+        .doctor => comptime unreachable, // doctor is conforming — handled above
+    }
 }
 
 fn isTty(io: std.Io, fd: std.posix.fd_t) bool {
@@ -1573,8 +1539,10 @@ pub fn run(io: std.Io, allocator: std.mem.Allocator, stderr: std.Io.File, enviro
     defer app.storages.deinit(allocator); // app owns the per-tab parse storage
     var frame = try allocator.alloc(u8, frameCap(term.currentSize()));
     defer allocator.free(frame);
-    // The paint handle the polled lazy reads tick against to animate the spinner.
-    const painter: Painter = .{ .fd = fd, .frame = &frame };
+    // The paint handle the polled lazy reads tick against to animate the spinner. A
+    // migrated tab repaints through `on_tick` (only the hub can render every tab).
+    var tick_bind: TickBind = .{ .allocator = allocator, .app = &app, .fd = fd, .frame = &frame };
+    const painter: Painter = .{ .fd = fd, .frame = &frame, .on_tick = .{ .ctx = &tick_bind, .call = TickBind.call } };
 
     // Paint the data-free chrome first so the alt-screen never flashes blank,
     // then prime the cheap installed count (a single-digit-ms SQLite read) and
@@ -2822,35 +2790,6 @@ test "loadServices treats an exit-0 empty response (fresh prefix) as an empty ta
     try std.testing.expect(!app.shared.banner.isSet());
 }
 
-test "loadDoctor treats an exit-0 empty response (fresh prefix) as an empty tab" {
-    var t = std.Io.Threaded.init(std.testing.allocator, .{});
-    defer t.deinit();
-    var app: App = .{ .mt_path = "/usr/bin/true" };
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
-    var frame: []u8 = &.{};
-    try loadDoctor(t.io(), std.testing.allocator, testPainter(&frame), &app, &store);
-    try std.testing.expectEqual(@as(usize, 0), app.states.doctor.items.len);
-    try std.testing.expect(!app.shared.banner.isSet());
-}
-
-test "applyDoctorParse points the Doctor tab at the parsed findings and reclaimable stats" {
-    var app: App = .{};
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
-    const bytes =
-        \\{"checks":[{"id":"a","severity":"warn","title":"A","fixable":true,"fix_class":"stale_lock"}],
-        \\"cask_history":{"retained_versions":3,"bytes":4096},"tap_cache":{"bytes":512}}
-    ;
-    const parsed = try doctor_json.parse(std.testing.allocator, bytes);
-    applyDoctorParse(&app, &store, parsed);
-    try std.testing.expectEqual(@as(usize, 1), app.states.doctor.items.len);
-    // The reclaimable figures ride through to the tab so the band can show them.
-    try std.testing.expectEqual(@as(u64, 4096), app.states.doctor.stats.cask_bytes);
-    try std.testing.expectEqual(@as(u64, 512), app.states.doctor.stats.tap_cache_bytes);
-    try std.testing.expectEqual(@as(usize, 3), app.states.doctor.stats.retained_versions);
-}
-
 test "a failed info read names the package in the banner and leaves the pane closed" {
     var t = std.Io.Threaded.init(std.testing.allocator, .{});
     defer t.deinit();
@@ -2964,47 +2903,6 @@ test "a failed services refresh names the op in the banner and keeps the last-go
     try std.testing.expectError(error.BadJson, loadServices(t.io(), std.testing.allocator, testPainter(&frame), &app, &store));
     try std.testing.expectEqualStrings("services refresh failed: BadJson", app.shared.banner.slice());
     try std.testing.expectEqual(@as(usize, 0), app.states.services.items.len); // last-good kept
-}
-
-test "doctorFixArgv builds `mt doctor --fix <class>` from the finding's fix_class, not its id" {
-    const items = [_]doctor.Row{
-        .{ .id = "sqlite_integrity", .severity = .err, .title = "SQLite integrity", .fixable = false, .fix_class = .none },
-        .{ .id = "orphaned_store_entries", .severity = .warn, .title = "Orphaned store entries", .fixable = true, .fix_class = .orphaned_store },
-    };
-    var st: doctor.State = .{ .items = &items };
-    st.chrome.view.selected = 1; // the fixable finding (display order: err then warn)
-    const argv = (try doctorFixArgv(std.testing.allocator, "/opt/homebrew/bin/mt", &st)).?;
-    defer std.testing.allocator.free(argv);
-    try std.testing.expectEqual(@as(usize, 4), argv.len);
-    try std.testing.expectEqualStrings("/opt/homebrew/bin/mt", argv[0]);
-    try std.testing.expectEqualStrings("doctor", argv[1]);
-    try std.testing.expectEqualStrings("--fix", argv[2]);
-    try std.testing.expectEqualStrings("orphaned_store", argv[3]); // the class, not "orphaned_store_entries"
-}
-
-test "doctorFixArgv returns null for a non-fixable selection so f is a no-op" {
-    const items = [_]doctor.Row{
-        .{ .id = "sqlite_integrity", .severity = .err, .title = "SQLite integrity", .fixable = false, .fix_class = .none },
-    };
-    const st: doctor.State = .{ .items = &items };
-    try std.testing.expect((try doctorFixArgv(std.testing.allocator, "/bin/mt", &st)) == null);
-}
-
-test "doctorFixArgv returns null on an empty list" {
-    const st: doctor.State = .{ .items = &.{} };
-    try std.testing.expect((try doctorFixArgv(std.testing.allocator, "/bin/mt", &st)) == null);
-}
-
-test "a failed doctor refresh names the op in the banner and keeps the last-good findings" {
-    var t = std.Io.Threaded.init(std.testing.allocator, .{});
-    defer t.deinit();
-    var app: App = .{ .mt_path = "/bin/echo" }; // echo emits non-JSON → parse fails
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
-    var frame: []u8 = &.{};
-    try std.testing.expectError(error.BadJson, loadDoctor(t.io(), std.testing.allocator, testPainter(&frame), &app, &store));
-    try std.testing.expectEqualStrings("doctor refresh failed: BadJson", app.shared.banner.slice());
-    try std.testing.expectEqual(@as(usize, 0), app.states.doctor.items.len); // last-good kept
 }
 
 test "searchArgv builds `mt search <query> --json` for the committed query" {

--- a/src/tui/ctx.zig
+++ b/src/tui/ctx.zig
@@ -73,6 +73,24 @@ pub const Banner = struct {
 pub const Painter = struct {
     fd: std.posix.fd_t,
     frame: *[]u8,
+    /// Hub-supplied whole-dashboard repaint, type-erased: only the hub can render
+    /// every tab, so it injects the closure here. A tab's synchronous polled load
+    /// ticks it to animate its spinner without importing the hub. Defaults to a
+    /// no-op so a Painter built for a test that never reaches a poll timeout — or
+    /// the background-fetch path, which repaints through the loop — needs no closure.
+    on_tick: Tick = .{},
+
+    pub const Tick = struct {
+        ctx: *anyopaque = undefined,
+        call: *const fn (*anyopaque) void = noop,
+        fn noop(_: *anyopaque) void {}
+    };
+
+    /// Duck-typed for `spawn.readJsonPolled`: fire the injected repaint each poll
+    /// tick. The `noop` default ignores the `undefined` ctx, so a bare Painter is safe.
+    pub fn tick(self: Painter) void {
+        self.on_tick.call(self.on_tick.ctx);
+    }
 };
 
 /// One in-flight background tab fetch: a non-blocking `mt <verb> --json` child
@@ -100,6 +118,16 @@ pub const SharedModel = struct {
     outdated_count: ?usize = null,
     dirty: std.EnumSet(Tab) = .initEmpty(),
     banner: Banner = .{},
+
+    /// After a delegated mutation the active tab was just re-read inline, so it is
+    /// fresh; every other tab may now be stale. A dirty tab refetches only when
+    /// entered, so the cost is paid lazily on view. Scalar-mediated: a mutating
+    /// tab's effect calls this on the shared model, never touching another tab's
+    /// storage — the cross-tab staleness channel that keeps tabs decoupled.
+    pub fn markStaleAfter(self: *SharedModel, active: Tab) void {
+        self.dirty = std.EnumSet(Tab).initFull();
+        self.dirty.remove(active);
+    }
 };
 
 /// The effect ports bundle, passed by pointer to whatever performs an effect.
@@ -112,6 +140,12 @@ pub const Ctx = struct {
     painter: Painter,
     fetches: *Fetches,
     shared: *SharedModel,
+    /// Resolved self-exe path so an effect re-execs *this* `mt` (not whatever PATH
+    /// resolves) for its delegated reads and mutations.
+    mt_path: []const u8,
+    /// The footer "Loading…" flag a tab raises around a synchronous polled load and
+    /// clears after, held by pointer because the hub's renderer reads it.
+    loading: *bool,
 };
 
 test "SharedModel defaults and mutation mirror the old inline App fields" {
@@ -164,6 +198,16 @@ test "banner truncates an over-cap op to the fixed buffer without overflow" {
     try std.testing.expect(b.slice().len <= banner_max); // bounded, no overrun
 }
 
+test "markStaleAfter dirties every tab except the just-refreshed active one" {
+    var m: SharedModel = .{};
+    m.markStaleAfter(.doctor);
+    try std.testing.expect(!m.dirty.contains(.doctor)); // fresh: it was re-read inline
+    try std.testing.expect(m.dirty.contains(.installed));
+    try std.testing.expect(m.dirty.contains(.outdated));
+    try std.testing.expect(m.dirty.contains(.services));
+    try std.testing.expect(m.dirty.contains(.search));
+}
+
 test "Ctx bundles the effect ports and points at the shared read-model" {
     try std.testing.expect(@hasField(Ctx, "io"));
     try std.testing.expect(@hasField(Ctx, "allocator"));
@@ -173,4 +217,7 @@ test "Ctx bundles the effect ports and points at the shared read-model" {
     try std.testing.expectEqual(Painter, @FieldType(Ctx, "painter"));
     try std.testing.expectEqual(*Fetches, @FieldType(Ctx, "fetches"));
     try std.testing.expectEqual(*SharedModel, @FieldType(Ctx, "shared"));
+    // The effect also needs the re-exec target and the synchronous-load flag.
+    try std.testing.expectEqual([]const u8, @FieldType(Ctx, "mt_path"));
+    try std.testing.expectEqual(*bool, @FieldType(Ctx, "loading"));
 }

--- a/src/tui/doctor_tab.zig
+++ b/src/tui/doctor_tab.zig
@@ -14,11 +14,13 @@ const std = @import("std");
 const testing = std.testing;
 
 const color = @import("../ui/color.zig");
+const ctx = @import("ctx.zig");
 const doctor_json = @import("json/doctor.zig");
 pub const Row = doctor_json.Finding;
 const Severity = doctor_json.Severity;
 const detail_pane = @import("detail_pane.zig");
 const scroll_list = @import("scroll_list.zig");
+const spawn = @import("spawn.zig");
 const tab = @import("tab.zig");
 
 /// A fix effect the pure `step` defers to the impure shell, which performs it and
@@ -51,6 +53,13 @@ pub const Storage = struct {
 
 /// Doctor audits in the background; it exits by severity, so it tolerates ≤2.
 pub const fetch_spec: ?tab.FetchSpec = .{ .verb = &.{"doctor"}, .max_ok_exit = 2, .refresh_op = "doctor refresh failed" };
+
+/// Whether the pending request will spawn a DB-mutating child (`mt doctor --fix`).
+/// The shell folds this over every tab before opening the DB so a live background
+/// audit is drained first — the WAL single-writer invariant.
+pub fn mutates(s: *const State) bool {
+    return s.request == .fix;
+}
 
 pub fn title() []const u8 {
     return "Doctor";
@@ -119,6 +128,102 @@ pub fn step(s: *State, key: tab.Key) void {
         .end => s.chrome.view.selected = filteredCount(s.items, s.chrome.filter.slice()) -| 1,
         else => {},
     }
+}
+
+// ─── impure zone ───────────────────────────────────────────────────────
+// The effect half of the tab, reunited beside its pure producer (`step` sets the
+// `request`; the code below drains it). Everything here takes its I/O ports
+// explicitly through the shared `ctx.Ctx` — never a global — so the pure/impure
+// line is the function signature: a decl that touches `io`/`allocator` lives here.
+
+/// The effect chain's error set, composed from the source sets so it tracks them
+/// automatically. It is a subset of the shell's `RunError`, which is the exhaustive
+/// boundary that classifies each fault recoverable-vs-fatal; naming it here keeps
+/// the public `service` explicit without hand-listing errors.
+pub const Error = std.mem.Allocator.Error || spawn.ReadError || spawn.InlineError || doctor_json.Error;
+
+/// Perform any fix effect the pure `step` requested, then clear it — the consumer
+/// half of the `request` seam. The shell dispatches this only for the active tab;
+/// the lazy (re)load on entry / after staleness stays loop machinery, so this owns
+/// only the tab's own effect.
+pub fn service(s: *State, storage: *Storage, c: *ctx.Ctx) Error!void {
+    const req = s.request;
+    s.request = .none;
+    switch (req) {
+        .none => {},
+        .fix => try doDoctorFix(s, storage, c),
+    }
+}
+
+/// Delegate the selected finding's fix to the real `mt` inline, then refresh.
+fn doDoctorFix(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
+    const argv = (try doctorFixArgv(c.allocator, c.mt_path, s)) orelse return; // nothing fixable selected
+    defer c.allocator.free(argv);
+    {
+        // `mt doctor --fix` exits by severity (1 warn / 2 err), not pass/fail — a
+        // clean sweep of a warning-class finding still exits 1 — so tolerate exits
+        // up to 2 (symmetric with the read). A real fault (exit > 2, signal) still
+        // surfaces as a banner; a severity exit re-enters cleanly and falls through
+        // to the refresh. Scoped so the refresh reports under its own op, not the fix.
+        errdefer |err| c.shared.banner.set("doctor fix failed", @errorName(err));
+        try spawn.runInlineReenterTolerant(c.term, argv, 2);
+    }
+    try loadDoctor(s, storage, c); // exit can't say what remains — the refresh is the truth
+    c.shared.markStaleAfter(.doctor); // this tab is fresh; the others may now be stale
+}
+
+/// Build `mt doctor --fix <class>` for the selected finding. Pure over the tab
+/// state: null when nothing is selected or the finding is not fixable (the no-op),
+/// else an owned argv. The token is the finding's `fix_class` — the only thing
+/// `mt doctor --fix` resolves — not its descriptive `id`. Caller frees the slice.
+fn doctorFixArgv(allocator: std.mem.Allocator, mt_path: []const u8, s: *const State) std.mem.Allocator.Error!?[]const []const u8 {
+    const fnd = selectedFinding(s) orelse return null; // empty list: no-op
+    if (!fnd.fixable) return null; // a non-fixable finding has no fix target
+    return try spawn.inlineArgv(allocator, mt_path, &.{ "doctor", "--fix", doctor_json.fixClassTag(fnd.fix_class) });
+}
+
+/// (Re)read `mt doctor --json` and repoint the tab's findings at the fresh parse.
+/// The polled read animates the shell's spinner through `c.painter` while it
+/// blocks; the storage is swapped only after a clean parse, so a failure keeps the
+/// last-good findings and their selection behind a banner.
+fn loadDoctor(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
+    errdefer |err| c.shared.banner.set("doctor refresh failed", @errorName(err));
+    const argv = try spawn.jsonArgv(c.allocator, c.mt_path, &.{"doctor"});
+    defer c.allocator.free(argv);
+    // Keep `loading` set across the poll so each tick paints the spinner, cleared
+    // once the result (or the empty/banner state) replaces it.
+    c.loading.* = true;
+    defer c.loading.* = false;
+    // `mt doctor` exits non-zero by severity (1 warn / 2 err) while still emitting
+    // findings — exactly when the tab is most useful — so tolerate exits up to 2.
+    const bytes = try spawn.readJsonPolled(c.io, c.allocator, argv, 2, c.painter);
+    defer if (bytes) |b| c.allocator.free(b);
+    try applyDoctorBytes(c.allocator, s, storage, bytes);
+}
+
+/// Repoint the Doctor tab at a drained `--json` payload. `null` (a fresh prefix)
+/// clears to no findings; a parsed document swaps in the rows + reclaimable stats.
+/// Shared by the synchronous reload and the background fetch; the storage is
+/// swapped only after a clean parse, so a failure keeps the last-good findings.
+/// Public because the shell's fetch drain routes a background payload through it.
+pub fn applyDoctorBytes(allocator: std.mem.Allocator, st: *State, storage: *Storage, bytes: ?[]const u8) doctor_json.Error!void {
+    const payload = bytes orelse {
+        if (storage.doctor) |old| old.deinit();
+        storage.doctor = null;
+        st.items = &.{};
+        return;
+    };
+    const parsed = try doctor_json.parse(allocator, payload);
+    applyDoctorParse(st, storage, parsed);
+}
+
+/// Repoint the tab at a fresh parse, freeing the previous one. Split from the
+/// spawn so the findings + reclaimable stats wiring is testable without a child.
+fn applyDoctorParse(st: *State, storage: *Storage, parsed: doctor_json.Parsed) void {
+    if (storage.doctor) |old| old.deinit();
+    storage.doctor = parsed;
+    st.items = parsed.items;
+    st.stats = parsed.stats;
 }
 
 /// Local severity → glyph mapping, replicated from the CLI doctor renderer (the
@@ -1445,6 +1550,142 @@ test "the reclaimable section renders on a narrow pane without wrapping into the
     const out = f.slice();
     try testing.expect(std.mem.indexOf(u8, out, "Reclaimable:") != null); // header survives the cut
     try testing.expect(std.mem.indexOf(u8, out, "SQLite integrity") != null); // the list stays the floor
+}
+
+test "mutates is true only for a pending fix — the request that takes the WAL writer" {
+    var s: State = .{};
+    try testing.expect(!mutates(&s)); // .none never gates the pre-mutation drain
+    s.request = .fix;
+    try testing.expect(mutates(&s)); // a fix spawns `mt doctor --fix`, a DB writer
+}
+
+test "applyDoctorBytes repoints the tab at parsed findings + reclaimable stats; null clears" {
+    const allocator = testing.allocator;
+    var st: State = .{};
+    var storage: Storage = .{};
+    defer storage.deinit(allocator);
+    const bytes =
+        \\{"checks":[{"id":"a","severity":"warn","title":"A","fixable":true,"fix_class":"stale_lock"}],
+        \\"cask_history":{"retained_versions":3,"bytes":4096},"tap_cache":{"bytes":512}}
+    ;
+    try applyDoctorBytes(allocator, &st, &storage, bytes);
+    try testing.expectEqual(@as(usize, 1), st.items.len);
+    // The reclaimable figures ride through to the tab so the band can show them.
+    try testing.expectEqual(@as(u64, 4096), st.stats.cask_bytes);
+    try testing.expectEqual(@as(u64, 512), st.stats.tap_cache_bytes);
+    try testing.expectEqual(@as(usize, 3), st.stats.retained_versions);
+
+    // A null payload (a fresh prefix's empty audit) clears the tab to no findings.
+    try applyDoctorBytes(allocator, &st, &storage, null);
+    try testing.expectEqual(@as(usize, 0), st.items.len);
+}
+
+// Backing storage for a `ctx.Ctx` in an effect test: dummy term/fetches/shared,
+// a no-op painter (fd = -1; the test children finish before the first poll tick,
+// so it is never touched), and the synchronous-load flag.
+const TestEnv = struct {
+    term_h: ctx.Term,
+    fetches: ctx.Fetches = ctx.Fetches.initFill(null),
+    shared: ctx.SharedModel = .{},
+    frame: []u8 = &.{},
+    loading: bool = false,
+};
+
+fn mkCtx(io: std.Io, e: *TestEnv, mt_path: []const u8) ctx.Ctx {
+    return .{
+        .io = io,
+        .allocator = testing.allocator,
+        .term = &e.term_h,
+        .painter = .{ .fd = -1, .frame = &e.frame },
+        .fetches = &e.fetches,
+        .shared = &e.shared,
+        .mt_path = mt_path,
+        .loading = &e.loading,
+    };
+}
+
+test "doctorFixArgv builds `mt doctor --fix <class>` from the finding's fix_class, not its id" {
+    const items = [_]Row{
+        .{ .id = "sqlite_integrity", .severity = .err, .title = "SQLite integrity", .fixable = false, .fix_class = .none },
+        .{ .id = "orphaned_store_entries", .severity = .warn, .title = "Orphaned store entries", .fixable = true, .fix_class = .orphaned_store },
+    };
+    var st: State = .{ .items = &items };
+    st.chrome.view.selected = 1; // the fixable finding (display order: err then warn)
+    const argv = (try doctorFixArgv(testing.allocator, "/opt/homebrew/bin/mt", &st)).?;
+    defer testing.allocator.free(argv);
+    try testing.expectEqual(@as(usize, 4), argv.len);
+    try testing.expectEqualStrings("/opt/homebrew/bin/mt", argv[0]);
+    try testing.expectEqualStrings("doctor", argv[1]);
+    try testing.expectEqualStrings("--fix", argv[2]);
+    try testing.expectEqualStrings("orphaned_store", argv[3]); // the class, not "orphaned_store_entries"
+}
+
+test "doctorFixArgv returns null for a non-fixable selection so f is a no-op" {
+    const items = [_]Row{
+        .{ .id = "sqlite_integrity", .severity = .err, .title = "SQLite integrity", .fixable = false, .fix_class = .none },
+    };
+    const st: State = .{ .items = &items };
+    try testing.expect((try doctorFixArgv(testing.allocator, "/bin/mt", &st)) == null);
+}
+
+test "doctorFixArgv returns null on an empty list" {
+    const st: State = .{ .items = &.{} };
+    try testing.expect((try doctorFixArgv(testing.allocator, "/bin/mt", &st)) == null);
+}
+
+test "loadDoctor treats an exit-0 empty response (fresh prefix) as an empty tab" {
+    var thr = std.Io.Threaded.init(testing.allocator, .{});
+    defer thr.deinit();
+    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    var st: State = .{};
+    var c = mkCtx(thr.io(), &env, "/usr/bin/true");
+    try loadDoctor(&st, &storage, &c);
+    try testing.expectEqual(@as(usize, 0), st.items.len);
+    try testing.expect(!env.shared.banner.isSet());
+}
+
+test "a failed doctor refresh names the op in the banner and keeps the last-good findings" {
+    var thr = std.Io.Threaded.init(testing.allocator, .{});
+    defer thr.deinit();
+    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    var st: State = .{};
+    var c = mkCtx(thr.io(), &env, "/bin/echo"); // echo emits non-JSON → parse fails
+    try testing.expectError(error.BadJson, loadDoctor(&st, &storage, &c));
+    try testing.expectEqualStrings("doctor refresh failed: BadJson", env.shared.banner.slice());
+    try testing.expectEqual(@as(usize, 0), st.items.len); // last-good kept
+}
+
+test "service on a .none request is a clean no-op — no spawn, no banner" {
+    var thr = std.Io.Threaded.init(testing.allocator, .{});
+    defer thr.deinit();
+    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    var st: State = .{}; // .none: the pure `step` set nothing to perform
+    var c = mkCtx(thr.io(), &env, "/bin/false"); // would fail if it ever spawned
+    try service(&st, &storage, &c);
+    try testing.expectEqual(Request.none, st.request);
+    try testing.expect(!env.shared.banner.isSet());
+}
+
+test "service drains a fix request; a fix with nothing fixable never spawns" {
+    var thr = std.Io.Threaded.init(testing.allocator, .{});
+    defer thr.deinit();
+    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    // An empty list means `doctorFixArgv` resolves to null: the request drains but
+    // no `mt doctor --fix` child runs, so `/bin/false` is never reached.
+    var st: State = .{ .request = .fix };
+    var c = mkCtx(thr.io(), &env, "/bin/false");
+    try service(&st, &storage, &c);
+    try testing.expectEqual(Request.none, st.request); // the producer/consumer seam drained it
+    try testing.expect(!env.shared.banner.isSet()); // never spawned → no failure banner
+    try testing.expectEqual(@as(usize, 0), st.items.len);
 }
 
 test "conforms to the tab contract" {

--- a/src/tui/tab.zig
+++ b/src/tui/tab.zig
@@ -10,6 +10,7 @@
 
 const std = @import("std");
 const color = @import("../ui/color.zig");
+const ctx = @import("ctx.zig");
 const scroll_list = @import("scroll_list.zig");
 const layout = @import("layout.zig");
 const filter_input = @import("filter_input.zig");
@@ -181,12 +182,46 @@ pub fn verify(comptime M: type) void {
     // the shell; `null` for a synchronous tab. Total coverage, no runtime switch.
     if (!@hasDecl(M, "fetch_spec")) @compileError(@typeName(M) ++ ": tab must expose `pub const fetch_spec: ?FetchSpec`");
     if (@TypeOf(M.fetch_spec) != ?FetchSpec) @compileError(@typeName(M) ++ ".fetch_spec must be `?FetchSpec`");
+
+    // Optional typed capability decls — a tab migrates its impure surface
+    // incrementally, so these are type-checked *iff* declared, never required
+    // present here (the shell falls back to the legacy dispatch for a tab still
+    // missing `service`). A declared-but-mistyped capability is a build error, so
+    // the uniform effect shape is pinned at comptime the moment a tab conforms.
+    if (@hasDecl(M, "mutates") and @TypeOf(M.mutates) != fn (*const M.State) bool)
+        @compileError(@typeName(M) ++ ".mutates must be `fn (*const State) bool`");
+    if (@hasDecl(M, "service")) verifyService(M);
+}
+
+/// Pin a declared `service` to the uniform `fn (*State, *Storage, *ctx.Ctx) !void`
+/// shape. The error set is inferred per tab, so the parameters — not the whole fn
+/// type — are the contract; the return set is validated where the shell `try`s it.
+fn verifyService(comptime M: type) void {
+    // `service` owns the tab's parse storage, so a conforming tab must expose one —
+    // reported here, not as a raw "no member" when the params are checked below.
+    if (!@hasDecl(M, "Storage")) @compileError(@typeName(M) ++ ": a tab exposing `service` must also expose `pub const Storage`");
+    const fn_info = switch (@typeInfo(@TypeOf(M.service))) {
+        .@"fn" => |f| f,
+        else => @compileError(@typeName(M) ++ ".service must be a function"),
+    };
+    const want = [_]type{ *M.State, *M.Storage, *ctx.Ctx };
+    const shape = @typeName(M) ++ ".service must be `fn (*State, *Storage, *ctx.Ctx) !void`";
+    if (fn_info.params.len != want.len) @compileError(shape);
+    inline for (fn_info.params, want) |got, w| {
+        if (got.type != w) @compileError(shape);
+    }
 }
 
 // ─── tests ───────────────────────────────────────────────────────────
 
 const GoodTab = struct {
     pub const State = struct { chrome: Chrome = .{} };
+    pub const Storage = struct {
+        pub fn deinit(self: *Storage, allocator: std.mem.Allocator) void {
+            _ = self;
+            _ = allocator;
+        }
+    };
     pub const fetch_spec: ?FetchSpec = null;
     pub fn title() []const u8 {
         return "Good";
@@ -203,9 +238,21 @@ const GoodTab = struct {
         _ = f;
         _ = r;
     }
+    pub fn mutates(s: *const State) bool {
+        _ = s;
+        return false;
+    }
+    pub fn service(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
+        _ = s;
+        _ = storage;
+        _ = c;
+    }
 };
 
-test "verify accepts a conforming tab module" {
+test "verify accepts a conforming tab module, including a well-typed service + mutates" {
+    // The optional effect capabilities are type-checked here: had `service`'s
+    // params or `mutates`'s signature drifted from the contract, this would not
+    // compile — the comptime guard the migrated tabs rely on.
     comptime verify(GoodTab);
 }
 


### PR DESCRIPTION
## Description

The tab contract only required the pure view/update surface, so every tab's impure effect performer lived in the app hub behind a flat five-call dispatcher. 

This widens the contract with one uniform `service` capability (plus optional typed fetch/mutation decls) and routes it through the same comptime `moduleFor` switch the render path already uses. Doctor migrates first as the reference - its whole effect group (`loadDoctor`/`applyDoctorBytes`/`doctorFixArgv`/`doDoctorFix`/`service` + `mutates`) moves beside the tab - while the other four keep working through a temporary `@hasDecl(M, "service")` fallback until they migrate.

## Related Issue

- None

## Notes for Reviewers

- None