### PR TITLE
refactor(tui): move the outdated and services effect groups beside their tabs

### DIFF
--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -494,30 +494,10 @@ pub fn classify(err: RunError) ErrorClass {
     };
 }
 
-/// The `tick` callback `spawn.readJsonPolled` invokes on every poll timeout while
-/// a lazy tab is loading: advance the spinner one frame and repaint. Closes over
-/// the paint handle + `App`, so the animation lives here, not in the generic
-/// leaf `spawn.zig`.
-const LoadTicker = struct {
-    p: Painter,
-    allocator: std.mem.Allocator,
-    app: *App,
-    pub fn tick(self: LoadTicker) void {
-        self.app.spinner_frame +%= 1;
-        // A resize during the load is absorbed here: repaint reads currentSize so
-        // it reflows; consume the flag so the loop's own resize check doesn't
-        // redundantly repaint the same frame once the read returns.
-        _ = term.takeResized();
-        // Best-effort, like paintLoading/paintSearching: a dropped animation frame
-        // is cosmetic, and a genuine OOM resurfaces on the next real allocation.
-        repaint(self.p.fd, self.p.frame, self.allocator, self.app) catch {};
-    }
-};
-
 /// Binds the whole-dashboard repaint for a migrated tab's synchronous polled load
-/// (the Doctor reload after a fix). Type-erased into `Painter.on_tick` so the tab
-/// animates its spinner without importing the hub — only the hub can render every
-/// tab. Mirrors `LoadTicker.tick`, which the not-yet-migrated tabs still use directly.
+/// (the Doctor reload after a fix, and the Services reload after a lifecycle
+/// action). Type-erased into `Painter.on_tick` so the tab animates its spinner
+/// without importing the hub — only the hub can render every tab.
 const TickBind = struct {
     allocator: std.mem.Allocator,
     app: *App,
@@ -744,8 +724,8 @@ const FetchOutcome = union(enum) { bytes: []const u8, empty, failed: anyerror };
 /// the per-tab `applyXBytes` own the empty-vs-document split and the swap.
 fn applyTabBytes(allocator: std.mem.Allocator, app: *App, store: *Storages, t: Tab, bytes: ?[]const u8) RunError!void {
     switch (t) {
-        .outdated => try applyOutdatedBytes(allocator, app, store, bytes),
-        .services => try applyServicesBytes(allocator, app, store, bytes),
+        .outdated => try outdated.applyOutdatedBytes(allocator, &app.states.outdated, &store.outdated, &app.shared, bytes),
+        .services => try services.applyServicesBytes(allocator, &app.states.services, &store.services, bytes),
         .doctor => try doctor.applyDoctorBytes(allocator, &app.states.doctor, &store.doctor, bytes),
         else => {},
     }
@@ -883,301 +863,6 @@ fn serviceInstalled(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, app
     // Lazy per-tab refresh: a tab marked dirty by a mutation refetches on entry.
     if (app.active == .installed and takeDirty(app, .installed)) {
         try loadInstalled(io, allocator, app, store);
-    }
-}
-
-/// Repoint the Outdated tab and the header count at a drained `--json` payload.
-/// `null` (a fresh prefix's exit-0 no-output) clears to a known-zero tab; a parsed
-/// document swaps in the rows and a fresh, all-clear checkbox buffer. Shared by
-/// the synchronous reload and the background launch fetch, so both land the same
-/// state. The store is swapped only after a clean parse — a failure keeps the
-/// last-good rows for the caller's banner to explain.
-fn applyOutdatedBytes(allocator: std.mem.Allocator, app: *App, store: *Storages, bytes: ?[]const u8) RunError!void {
-    const payload = bytes orelse {
-        if (store.outdated.outdated) |old| old.deinit();
-        if (store.outdated.checked.len != 0) allocator.free(store.outdated.checked);
-        store.outdated.outdated = null;
-        store.outdated.checked = &.{};
-        app.states.outdated.items = &.{};
-        app.states.outdated.checked = &.{};
-        app.shared.outdated_count = 0; // nothing outdated is a known zero, not "unknown"
-        return;
-    };
-    const parsed = try outdated_json.parse(allocator, payload);
-    errdefer parsed.deinit();
-    // A fresh checkbox buffer, all clear: an upgrade removes the upgraded rows, so
-    // carrying the old selection forward would point at the wrong packages.
-    const checked = try allocator.alloc(bool, parsed.items.len);
-    @memset(checked, false);
-
-    if (store.outdated.outdated) |old| old.deinit();
-    if (store.outdated.checked.len != 0) allocator.free(store.outdated.checked);
-    store.outdated.outdated = parsed;
-    store.outdated.checked = checked;
-    app.states.outdated.items = parsed.items;
-    app.states.outdated.checked = checked;
-    app.shared.outdated_count = parsed.items.len;
-}
-
-/// Collect the checked, non-pinned rows into `out` as `(name, kind)` refs,
-/// formula rows first then cask rows; returns the formula count (the split
-/// index). `out` must be sized to `selectedCount`. Partitioning by kind lets
-/// `doUpgrade` issue one `--formula` pass and one `--cask` pass.
-fn collectUpgraded(st: *const outdated.State, out: []UpgradedRef) usize {
-    // The two item-order passes below cover exactly `{formula, cask}`; a new
-    // Kind variant would leave its rows uncollected. Lock it at compile time.
-    comptime std.debug.assert(@typeInfo(outdated_json.Kind).@"enum".fields.len == 2);
-    var n: usize = 0;
-    var split: usize = 0;
-    // Two item-order passes so each kind's names stay in display order and the
-    // formula refs land in `out[0..split]`, casks in `out[split..]`.
-    for ([_]outdated_json.Kind{ .formula, .cask }) |kind| {
-        for (st.items, 0..) |row, i| {
-            // Same rule as `selectedNames`: checked, non-pinned, this kind.
-            if (i < st.checked.len and st.checked[i] and !row.pinned and row.kind == kind and n < out.len) {
-                out[n] = .{ .name = row.name, .kind = row.kind };
-                n += 1;
-            }
-        }
-        if (kind == .formula) split = n;
-    }
-    return split;
-}
-
-/// Build `[mt, upgrade, <flag>, names...]` for a single-kind ref slice, or null
-/// when the slice is empty. `flag` is `--formula` / `--cask` so the kind the
-/// user picked is the kind upgraded (`mt upgrade <name>` is formula-first).
-fn kindUpgradeArgv(
-    allocator: std.mem.Allocator,
-    mt_path: []const u8,
-    refs: []const UpgradedRef,
-    flag: []const u8,
-) std.mem.Allocator.Error!?[]const []const u8 {
-    if (refs.len == 0) return null;
-    const rest = try allocator.alloc([]const u8, 2 + refs.len);
-    defer allocator.free(rest);
-    rest[0] = "upgrade";
-    rest[1] = flag;
-    for (refs, rest[2..]) |r, *slot| slot.* = r.name;
-    return try spawn.inlineArgv(allocator, mt_path, rest);
-}
-
-/// The exit code `mt upgrade` returns when it refused a cask because the app is
-/// still running. Mirrors `main.zig`'s `AppRunning` exit mapping — the mt→TUI
-/// process contract, like the doctor severity cap the inline runner already knows.
-const cask_app_running_exit: u8 = 3;
-
-/// Footer detail for a failed cask upgrade pass: on the app-running refusal name
-/// the live app (or "a selected app" when the pass carried several) so the footer
-/// says *why*, not an opaque "ChildFailed". `buf` backs the single-cask name;
-/// `Banner.set` copies the result, so a stack buffer is enough.
-fn upgradeFailDetail(buf: []u8, code: u8, refs: []const UpgradedRef) []const u8 {
-    if (code != cask_app_running_exit) return "ChildFailed";
-    if (refs.len == 1) return std.fmt.bufPrint(buf, "{s} is running", .{refs[0].name}) catch "an app is running";
-    return "a selected app is running";
-}
-
-/// Delegate the checked upgrades to the real `mt` inline, then drop the upgraded
-/// rows in place. Runs one pass per kind (`--formula`, `--cask`) so the row the
-/// user checked is the row upgraded — `mt upgrade <name>` is formula-first, so a
-/// checked cask would otherwise upgrade a same-named formula. Names borrow the
-/// parse arena, which `dropUpgradedRows` keeps alive across both passes.
-fn doUpgrade(allocator: std.mem.Allocator, t: *term.Term, app: *App, store: *Storages) RunError!void {
-    const st = &app.states.outdated;
-    const count = outdated.selectedCount(st);
-    if (count == 0) return; // empty selection: no-op
-    // Snapshot the selection (formula refs first, then cask) before any upgrade
-    // or drop — the drop rebuilds the checkbox buffer, erasing the selection.
-    const upgraded = try allocator.alloc(UpgradedRef, count);
-    defer allocator.free(upgraded);
-    const split = collectUpgraded(st, upgraded);
-
-    const passes = [_]struct { refs: []const UpgradedRef, flag: []const u8 }{
-        .{ .refs = upgraded[0..split], .flag = "--formula" },
-        .{ .refs = upgraded[split..], .flag = "--cask" },
-    };
-    // Passes run independently: a failed formula pass still lets the cask pass
-    // proceed, and only a succeeded pass's rows are dropped. A non-zero `mt
-    // upgrade` re-enters the dashboard and surfaces as a recoverable banner.
-    var dropped_any = false;
-    for (passes) |pass| {
-        const argv = (try kindUpgradeArgv(allocator, app.mt_path, pass.refs, pass.flag)) orelse continue;
-        defer allocator.free(argv);
-        if (spawn.runInlineReenterStatus(t, argv)) |code| {
-            if (code == 0) {
-                try dropUpgradedRows(allocator, app, store, pass.refs);
-                dropped_any = true;
-            } else {
-                var dbuf: [96]u8 = undefined;
-                app.shared.banner.set("upgrade failed", upgradeFailDetail(&dbuf, code, pass.refs));
-            }
-        } else |err| {
-            app.shared.banner.set("upgrade failed", @errorName(err));
-        }
-    }
-    if (dropped_any) markStaleAfterMutation(&app.shared, app.active); // Installed sizes/versions changed too
-}
-
-/// One upgraded row, identified by `(name, kind)` so a formula and a cask that
-/// share a name (e.g. `docker`) are never confused for one another.
-const UpgradedRef = struct { name: []const u8, kind: outdated_json.Kind };
-
-/// True when `row` is one of the upgraded rows (linear scan — a batch is small).
-/// Matches on `(name, kind)`: `mt upgrade <name>` resolves formula-first, so a
-/// same-named cask is left outdated and must not be dropped with the formula.
-fn rowUpgraded(upgraded: []const UpgradedRef, row: outdated_json.OutdatedRow) bool {
-    for (upgraded) |u| {
-        if (u.kind == row.kind and std.mem.eql(u8, u.name, row.name)) return true;
-    }
-    return false;
-}
-
-/// Drop the just-upgraded rows from the Outdated tab in place: the post-upgrade
-/// outdated set is the pre-upgrade set minus the upgraded tokens, so a second
-/// `mt outdated` walk is unnecessary. The parsed storage is kept alive (rows
-/// borrow its arena) and `items` is re-pointed at the survivors within that
-/// arena; only the checkbox buffer is reallocated, preserving each kept row's
-/// checked state so a partial-selection upgrade survives.
-fn dropUpgradedRows(
-    allocator: std.mem.Allocator,
-    app: *App,
-    store: *Storages,
-    upgraded: []const UpgradedRef,
-) std.mem.Allocator.Error!void {
-    if (store.outdated.outdated == null) return; // nothing loaded → nothing to drop
-    const parsed = &store.outdated.outdated.?;
-    const old_items = parsed.items;
-    const old_checked = store.outdated.checked;
-
-    var keep: usize = 0;
-    for (old_items) |row| {
-        if (!rowUpgraded(upgraded, row)) keep += 1;
-    }
-
-    // Survivors live in the parse arena alongside the strings they borrow, so
-    // they free together on the next full reload. The checkbox buffer is shell-
-    // owned, so it is reallocated and the old one freed.
-    const arena = parsed.doc.arena.allocator();
-    const new_items = try arena.alloc(outdated_json.OutdatedRow, keep);
-    const new_checked = try allocator.alloc(bool, keep);
-    errdefer allocator.free(new_checked);
-
-    var j: usize = 0;
-    for (old_items, 0..) |row, i| {
-        if (rowUpgraded(upgraded, row)) continue;
-        new_items[j] = row;
-        new_checked[j] = i < old_checked.len and old_checked[i];
-        j += 1;
-    }
-
-    if (old_checked.len != 0) allocator.free(old_checked);
-    parsed.items = new_items;
-    store.outdated.checked = new_checked;
-    app.states.outdated.items = new_items;
-    app.states.outdated.checked = new_checked;
-    app.shared.outdated_count = new_items.len;
-}
-
-/// Perform any effect the pure `step` requested on the Outdated tab, then clear
-/// it, and lazily (re)load on first entry or after a mutation marked it dirty.
-fn serviceOutdated(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, fetches: *Fetches, app: *App, store: *Storages) RunError!void {
-    const req = app.states.outdated.request;
-    app.states.outdated.request = .none;
-    switch (req) {
-        .none => {},
-        .upgrade => try doUpgrade(allocator, t, app, store),
-    }
-    // Lazy per-tab load: first activation and post-mutation staleness both arrive
-    // as the dirty flag (set at init and by `markStaleAfterMutation`).
-    // Background, non-blocking: spawn the audit and let the loop drain it so the
-    // input stays live — a cold-cache outdated audit never traps the tab.
-    if (app.active == .outdated and takeDirty(app, .outdated)) {
-        startTabFetch(io, allocator, fetches, app, .outdated);
-    }
-}
-
-/// (Re)read `mt services list --json` and repoint the Services tab's rows at the
-/// fresh parse, freeing the previous one.
-fn loadServices(io: std.Io, allocator: std.mem.Allocator, painter: Painter, app: *App, store: *Storages) RunError!void {
-    // Annotate any failure as a recoverable banner; the loop boundary decides
-    // recoverable vs fatal. The store is swapped only after a clean parse, so a
-    // failure keeps the last-good rows and their selection.
-    errdefer |err| app.shared.banner.set("services refresh failed", @errorName(err));
-    const argv = try spawn.jsonArgv(allocator, app.mt_path, &.{ "services", "list" });
-    defer allocator.free(argv);
-    // Animate the spinner across the poll: `loading` stays set so each tick
-    // paints it, cleared once the result (or the empty/banner state) replaces it.
-    app.loading = true;
-    defer app.loading = false;
-    const ticker = LoadTicker{ .p = painter, .allocator = allocator, .app = app };
-    const bytes = try spawn.readJsonPolled(io, allocator, argv, 0, ticker);
-    defer if (bytes) |b| allocator.free(b);
-    try applyServicesBytes(allocator, app, store, bytes);
-}
-
-/// Repoint the Services tab at a drained `--json` payload. `null` (a fresh prefix)
-/// clears to an empty list; a parsed document swaps in the rows. Shared by the
-/// synchronous reload and the background fetch; the store is swapped only after a
-/// clean parse, so a failure keeps the last-good rows.
-fn applyServicesBytes(allocator: std.mem.Allocator, app: *App, store: *Storages, bytes: ?[]const u8) RunError!void {
-    const payload = bytes orelse {
-        if (store.services.services) |old| old.deinit();
-        store.services.services = null;
-        app.states.services.items = &.{};
-        app.states.services.detail = null; // the old detail borrowed the freed rows
-        return;
-    };
-    const parsed = try services_json.parse(allocator, payload);
-    if (store.services.services) |old| old.deinit();
-    store.services.services = parsed;
-    app.states.services.items = parsed.items;
-    app.states.services.detail = null; // a refreshed list invalidates the old detail
-}
-
-/// Build `mt services <action> <name>` for the selected service. Pure over the
-/// tab state: null when nothing is selected (the no-op), else an owned argv whose
-/// `name` element borrows from the parse storage. Caller frees the returned slice
-/// (not its elements).
-fn serviceActionArgv(allocator: std.mem.Allocator, mt_path: []const u8, action: []const u8, st: *const services.State) std.mem.Allocator.Error!?[]const []const u8 {
-    const svc = services.selectedService(st) orelse return null; // empty list: no-op
-    return try spawn.inlineArgv(allocator, mt_path, &.{ "services", action, svc.name });
-}
-
-/// Delegate a service lifecycle action to the real `mt` inline, then refresh. The
-/// argv's `name` borrows from the current parse storage; the post-spawn reload
-/// frees that storage, so the name is not read afterwards.
-fn doServiceAction(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, app: *App, store: *Storages, action: []const u8) RunError!void {
-    const argv = (try serviceActionArgv(allocator, app.mt_path, action, &app.states.services)) orelse return; // nothing selected
-    defer allocator.free(argv);
-    {
-        // A non-zero `mt services <action>` re-enters the dashboard (the user
-        // keeps malt's real output in their scrollback) and surfaces as a
-        // recoverable banner; only a terminal fault is fatal. Scoped so the
-        // refresh below reports under its own op, not the action.
-        errdefer |err| app.shared.banner.set("service action failed", @errorName(err));
-        try spawn.runInlineReenter(t, argv);
-    }
-    try loadServices(io, allocator, painter, app, store); // the state changed — refetch
-    markStaleAfterMutation(&app.shared, app.active);
-}
-
-/// Perform any lifecycle effect the pure `step` requested on the Services tab,
-/// then clear it, and lazily (re)load on first entry or after a mutation marked
-/// it dirty.
-fn serviceServices(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, app: *App, store: *Storages) RunError!void {
-    const req = app.states.services.request;
-    app.states.services.request = .none;
-    switch (req) {
-        .none => {},
-        .start => try doServiceAction(io, allocator, t, painter, app, store, "start"),
-        .stop => try doServiceAction(io, allocator, t, painter, app, store, "stop"),
-        .restart => try doServiceAction(io, allocator, t, painter, app, store, "restart"),
-    }
-    // Lazy per-tab load: first activation and post-mutation staleness both arrive
-    // as the dirty flag (set at init and by `markStaleAfterMutation`).
-    // Background, non-blocking — see `serviceOutdated`.
-    if (app.active == .services and takeDirty(app, .services)) {
-        startTabFetch(io, allocator, fetches, app, .services);
     }
 }
 
@@ -1379,9 +1064,9 @@ fn openSearchInfo(io: std.Io, allocator: std.mem.Allocator, app: *App, store: *S
 /// they do not gate the pre-mutation drain.
 fn mutationPending(app: *const App) bool {
     return app.states.installed.request == .uninstall or
-        app.states.outdated.request == .upgrade or
-        app.states.services.request != .none or
-        doctor.mutates(&app.states.doctor) or // the migrated tab declares this as a capability
+        outdated.mutates(&app.states.outdated) or // migrated tabs declare this as a capability
+        services.mutates(&app.states.services) or
+        doctor.mutates(&app.states.doctor) or
         app.states.search.request == .install;
 }
 
@@ -1458,19 +1143,19 @@ fn serviceTab(comptime tag: Tab, io: std.Io, allocator: std.mem.Allocator, t: *t
         // is skipped (its lazy-load, if any, is its own concern).
         if (M.fetch_spec != null and takeDirty(app, tag)) startTabFetch(io, allocator, fetches, app, tag);
     } else {
-        try legacyService(tag, io, allocator, t, painter, fetches, app, store);
+        try legacyService(tag, io, allocator, t, app, store);
     }
 }
 
 /// The pre-contract dispatch for a tab whose effect group still lives in the hub.
+/// Only Installed and Search remain here; the three background-fetch tabs
+/// (doctor, outdated, services) are conforming and route through `moduleFor`.
 /// Removed once the last tab exposes `service`.
-fn legacyService(comptime tag: Tab, io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, app: *App, store: *Storages) RunError!void {
+fn legacyService(comptime tag: Tab, io: std.Io, allocator: std.mem.Allocator, t: *term.Term, app: *App, store: *Storages) RunError!void {
     switch (tag) {
         .installed => try serviceInstalled(io, allocator, t, app, store),
-        .outdated => try serviceOutdated(io, allocator, t, fetches, app, store),
-        .services => try serviceServices(io, allocator, t, painter, fetches, app, store),
         .search => try serviceSearch(io, allocator, t, app, store),
-        .doctor => comptime unreachable, // doctor is conforming — handled above
+        .outdated, .services, .doctor => comptime unreachable, // conforming — handled above
     }
 }
 
@@ -2320,149 +2005,6 @@ test "service leaves an in-flight audit running when no mutation is pending" {
     reapAllFetches(t.io(), std.testing.allocator, &fetches); // tidy the still-running child
 }
 
-test "upgradeFailDetail names the live app on the refusal code, else stays generic" {
-    var buf: [96]u8 = undefined;
-    const one = [_]UpgradedRef{.{ .name = "flux-markdown", .kind = .cask }};
-    const many = [_]UpgradedRef{ .{ .name = "a", .kind = .cask }, .{ .name = "b", .kind = .cask } };
-
-    // The refusal code names the one cask, or stays generic for a batch.
-    try std.testing.expectEqualStrings("flux-markdown is running", upgradeFailDetail(&buf, cask_app_running_exit, &one));
-    try std.testing.expectEqualStrings("a selected app is running", upgradeFailDetail(&buf, cask_app_running_exit, &many));
-    // Any other non-zero exit is the generic child failure, unnamed.
-    try std.testing.expectEqualStrings("ChildFailed", upgradeFailDetail(&buf, 1, &one));
-
-    // Edge: a name longer than the buffer falls back rather than truncating mid-name.
-    var tiny: [4]u8 = undefined;
-    try std.testing.expectEqualStrings("an app is running", upgradeFailDetail(&tiny, cask_app_running_exit, &one));
-}
-
-test "dropUpgradedRows removes upgraded rows in place and preserves kept checked state" {
-    var app: App = .{};
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
-    const json =
-        \\{"outdated":[
-        \\{"name":"a","installed":"1","latest":"2","type":"formula","pinned":false},
-        \\{"name":"b","installed":"1","latest":"2","type":"formula","pinned":false},
-        \\{"name":"c","installed":"1","latest":"2","type":"formula","pinned":false}
-        \\]}
-    ;
-    try applyOutdatedBytes(std.testing.allocator, &app, &store, json);
-    // Check a and c (b is the one being upgraded); the kept rows must stay checked.
-    store.outdated.checked[0] = true;
-    store.outdated.checked[2] = true;
-
-    try dropUpgradedRows(std.testing.allocator, &app, &store, &.{.{ .name = "b", .kind = .formula }});
-
-    try std.testing.expectEqual(@as(usize, 2), store.outdated.outdated.?.items.len);
-    try std.testing.expectEqualStrings("a", store.outdated.outdated.?.items[0].name);
-    try std.testing.expectEqualStrings("c", store.outdated.outdated.?.items[1].name);
-    try std.testing.expectEqual(@as(?usize, 2), app.shared.outdated_count);
-    try std.testing.expectEqual(@as(usize, 2), app.states.outdated.items.len);
-    // a and c stay checked in the rebuilt lockstep buffer.
-    try std.testing.expect(app.states.outdated.checked[0]);
-    try std.testing.expect(app.states.outdated.checked[1]);
-}
-
-test "a second outdated apply frees the prior parse arena and repoints at the live one" {
-    var app: App = .{};
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
-    // First parse (two rows). Its arena must be freed when the second lands, or the
-    // test allocator trips — this pins that the arena lifetime moved into the tab's
-    // own Storage, so a re-load frees the prior parse rather than leaking it.
-    try applyOutdatedBytes(std.testing.allocator, &app, &store, "{\"outdated\":[{\"name\":\"a\",\"installed\":\"1\",\"latest\":\"2\",\"type\":\"formula\",\"pinned\":false},{\"name\":\"b\",\"installed\":\"1\",\"latest\":\"2\",\"type\":\"formula\",\"pinned\":false}]}");
-    store.outdated.checked[0] = true; // a stale selection the swap must not carry forward
-    try std.testing.expectEqual(@as(usize, 2), store.outdated.outdated.?.items.len);
-    // Second parse (one row) swaps in a fresh arena + an all-clear checkbox buffer.
-    try applyOutdatedBytes(std.testing.allocator, &app, &store, "{\"outdated\":[{\"name\":\"z\",\"installed\":\"1\",\"latest\":\"9\",\"type\":\"cask\",\"pinned\":false}]}");
-    // The survivor borrows the live arena: the name resolves and the count follows.
-    try std.testing.expectEqual(@as(usize, 1), store.outdated.outdated.?.items.len);
-    try std.testing.expectEqualStrings("z", store.outdated.outdated.?.items[0].name);
-    try std.testing.expectEqual(@as(?usize, 1), app.shared.outdated_count);
-    try std.testing.expect(!store.outdated.checked[0]); // fresh buffer, all clear
-}
-
-test "dropUpgradedRows on an unloaded store is a no-op" {
-    var app: App = .{};
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
-    try dropUpgradedRows(std.testing.allocator, &app, &store, &.{.{ .name = "anything", .kind = .formula }});
-    try std.testing.expect(store.outdated.outdated == null);
-}
-
-test "dropUpgradedRows drops only the upgraded kind when a formula and cask share a name" {
-    var app: App = .{};
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
-    const json =
-        \\{"outdated":[
-        \\{"name":"docker","installed":"1","latest":"2","type":"formula","pinned":false},
-        \\{"name":"docker","installed":"1","latest":"2","type":"cask","pinned":false}
-        \\]}
-    ;
-    try applyOutdatedBytes(std.testing.allocator, &app, &store, json);
-    // Only the formula docker was upgraded; the same-named cask must remain.
-    try dropUpgradedRows(std.testing.allocator, &app, &store, &.{.{ .name = "docker", .kind = .formula }});
-    try std.testing.expectEqual(@as(usize, 1), store.outdated.outdated.?.items.len);
-    try std.testing.expectEqual(outdated_json.Kind.cask, store.outdated.outdated.?.items[0].kind);
-}
-
-test "dropUpgradedRows survives two sequential drops (the formula then cask passes)" {
-    var app: App = .{};
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
-    const json =
-        \\{"outdated":[
-        \\{"name":"wget","installed":"1","latest":"2","type":"formula","pinned":false},
-        \\{"name":"firefox","installed":"1","latest":"2","type":"cask","pinned":false}
-        \\]}
-    ;
-    try applyOutdatedBytes(std.testing.allocator, &app, &store, json);
-
-    // Formula pass drops wget; the cask ref (still borrowing the live parse
-    // arena) must survive the first drop's store mutation and rebuilt buffer.
-    try dropUpgradedRows(std.testing.allocator, &app, &store, &.{.{ .name = "wget", .kind = .formula }});
-    try std.testing.expectEqual(@as(usize, 1), store.outdated.outdated.?.items.len);
-    try std.testing.expectEqual(outdated_json.Kind.cask, store.outdated.outdated.?.items[0].kind);
-
-    // Cask pass drops firefox → empty, no leak / use-after-free.
-    try dropUpgradedRows(std.testing.allocator, &app, &store, &.{.{ .name = "firefox", .kind = .cask }});
-    try std.testing.expectEqual(@as(usize, 0), store.outdated.outdated.?.items.len);
-    try std.testing.expectEqual(@as(?usize, 0), app.shared.outdated_count);
-}
-
-test "dropUpgradedRows keeps every row when no upgraded ref matches" {
-    var app: App = .{};
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
-    const json =
-        \\{"outdated":[
-        \\{"name":"a","installed":"1","latest":"2","type":"formula","pinned":false},
-        \\{"name":"b","installed":"1","latest":"2","type":"formula","pinned":false}
-        \\]}
-    ;
-    try applyOutdatedBytes(std.testing.allocator, &app, &store, json);
-    try dropUpgradedRows(std.testing.allocator, &app, &store, &.{.{ .name = "z", .kind = .formula }});
-    try std.testing.expectEqual(@as(usize, 2), store.outdated.outdated.?.items.len);
-}
-
-test "dropUpgradedRows clears the list when every row was upgraded" {
-    var app: App = .{};
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
-    const json =
-        \\{"outdated":[
-        \\{"name":"a","installed":"1","latest":"2","type":"formula","pinned":false},
-        \\{"name":"b","installed":"1","latest":"2","type":"formula","pinned":false}
-        \\]}
-    ;
-    try applyOutdatedBytes(std.testing.allocator, &app, &store, json);
-    try dropUpgradedRows(std.testing.allocator, &app, &store, &.{ .{ .name = "a", .kind = .formula }, .{ .name = "b", .kind = .formula } });
-    try std.testing.expectEqual(@as(usize, 0), store.outdated.outdated.?.items.len);
-    try std.testing.expectEqual(@as(?usize, 0), app.shared.outdated_count);
-}
-
 test "a non-zero child exit fails the fetch without parsing a half-written doc" {
     var t = std.Io.Threaded.init(std.testing.allocator, .{});
     defer t.deinit();
@@ -2778,18 +2320,6 @@ test "a broken keg-count read banners and leaves the prior count untouched" {
     try std.testing.expectEqual(@as(?usize, 6), app.shared.installed_count); // a failed read keeps the last-good count
 }
 
-test "loadServices treats an exit-0 empty response (fresh prefix) as an empty tab" {
-    var t = std.Io.Threaded.init(std.testing.allocator, .{});
-    defer t.deinit();
-    var app: App = .{ .mt_path = "/usr/bin/true" };
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
-    var frame: []u8 = &.{};
-    try loadServices(t.io(), std.testing.allocator, testPainter(&frame), &app, &store);
-    try std.testing.expectEqual(@as(usize, 0), app.states.services.items.len);
-    try std.testing.expect(!app.shared.banner.isSet());
-}
-
 test "a failed info read names the package in the banner and leaves the pane closed" {
     var t = std.Io.Threaded.init(std.testing.allocator, .{});
     defer t.deinit();
@@ -2801,108 +2331,6 @@ test "a failed info read names the package in the banner and leaves the pane clo
     try std.testing.expectError(error.BadJson, openDetail(t.io(), std.testing.allocator, &app, &store));
     try std.testing.expectEqualStrings("info for jq failed: BadJson", app.shared.banner.slice());
     try std.testing.expect(app.states.installed.detail == null); // the pane never opened
-}
-
-test "collectUpgraded partitions checked rows formula-first, then cask, excluding pinned" {
-    const items = [_]outdated.Row{
-        .{ .name = "firefox", .installed = "1", .latest = "2", .kind = .cask, .pinned = false, .tap = "" },
-        .{ .name = "wget", .installed = "1", .latest = "2", .kind = .formula, .pinned = false, .tap = "" },
-        .{ .name = "held", .installed = "1", .latest = "2", .kind = .formula, .pinned = true, .tap = "" },
-    };
-    var checked = [_]bool{ true, true, true }; // held is pinned → excluded
-    var st: outdated.State = .{ .items = &items, .checked = &checked };
-    var buf: [3]UpgradedRef = undefined;
-    const split = collectUpgraded(&st, buf[0..outdated.selectedCount(&st)]);
-    try std.testing.expectEqual(@as(usize, 1), split); // one formula, before the cask
-    try std.testing.expectEqualStrings("wget", buf[0].name);
-    try std.testing.expectEqual(outdated_json.Kind.formula, buf[0].kind);
-    try std.testing.expectEqualStrings("firefox", buf[1].name);
-    try std.testing.expectEqual(outdated_json.Kind.cask, buf[1].kind);
-}
-
-test "kindUpgradeArgv builds `mt upgrade <flag> <names>`, null for no refs" {
-    const refs = [_]UpgradedRef{ .{ .name = "firefox", .kind = .cask }, .{ .name = "vlc", .kind = .cask } };
-    const maybe = try kindUpgradeArgv(std.testing.allocator, "/bin/mt", &refs, "--cask");
-    try std.testing.expect(maybe != null);
-    const argv = maybe.?;
-    defer std.testing.allocator.free(argv);
-    try std.testing.expectEqual(@as(usize, 5), argv.len);
-    try std.testing.expectEqualStrings("upgrade", argv[1]);
-    try std.testing.expectEqualStrings("--cask", argv[2]);
-    try std.testing.expectEqualStrings("firefox", argv[3]);
-    try std.testing.expectEqualStrings("vlc", argv[4]);
-    try std.testing.expect((try kindUpgradeArgv(std.testing.allocator, "/bin/mt", &.{}, "--cask")) == null);
-}
-
-test "a mixed selection yields a --formula pass and a --cask pass" {
-    const items = [_]outdated.Row{
-        .{ .name = "wget", .installed = "1", .latest = "2", .kind = .formula, .pinned = false, .tap = "" },
-        .{ .name = "firefox", .installed = "1", .latest = "2", .kind = .cask, .pinned = false, .tap = "" },
-    };
-    var checked = [_]bool{ true, true };
-    var st: outdated.State = .{ .items = &items, .checked = &checked };
-    var buf: [2]UpgradedRef = undefined;
-    const split = collectUpgraded(&st, buf[0..outdated.selectedCount(&st)]);
-
-    const f = (try kindUpgradeArgv(std.testing.allocator, "/bin/mt", buf[0..split], "--formula")).?;
-    defer std.testing.allocator.free(f);
-    try std.testing.expectEqualStrings("--formula", f[2]);
-    try std.testing.expectEqualStrings("wget", f[3]);
-
-    const c = (try kindUpgradeArgv(std.testing.allocator, "/bin/mt", buf[split..], "--cask")).?;
-    defer std.testing.allocator.free(c);
-    try std.testing.expectEqualStrings("--cask", c[2]);
-    try std.testing.expectEqualStrings("firefox", c[3]);
-}
-
-test "a cask-only selection runs no formula pass and upgrades the cask" {
-    const items = [_]outdated.Row{
-        .{ .name = "wget", .installed = "1", .latest = "2", .kind = .formula, .pinned = false, .tap = "" },
-        .{ .name = "firefox", .installed = "1", .latest = "2", .kind = .cask, .pinned = false, .tap = "" },
-    };
-    var checked = [_]bool{ false, true }; // only the cask is checked
-    var st: outdated.State = .{ .items = &items, .checked = &checked };
-    var buf: [1]UpgradedRef = undefined;
-    const split = collectUpgraded(&st, buf[0..outdated.selectedCount(&st)]);
-    try std.testing.expectEqual(@as(usize, 0), split); // no formula rows
-    try std.testing.expect((try kindUpgradeArgv(std.testing.allocator, "/bin/mt", buf[0..split], "--formula")) == null);
-    const c = (try kindUpgradeArgv(std.testing.allocator, "/bin/mt", buf[split..], "--cask")).?;
-    defer std.testing.allocator.free(c);
-    try std.testing.expectEqualStrings("--cask", c[2]);
-    try std.testing.expectEqualStrings("firefox", c[3]);
-}
-
-test "serviceActionArgv builds `mt services <action> <name>` for the selected service" {
-    const items = [_]services.Row{
-        .{ .name = "redis", .state = "running", .auto_start = true, .keg_name = "redis" },
-        .{ .name = "postgresql", .state = "stopped", .auto_start = false, .keg_name = "postgresql@16" },
-    };
-    var st: services.State = .{ .items = &items };
-    st.chrome.view.selected = 1; // postgresql
-    const argv = (try serviceActionArgv(std.testing.allocator, "/opt/homebrew/bin/mt", "restart", &st)).?;
-    defer std.testing.allocator.free(argv);
-    try std.testing.expectEqual(@as(usize, 4), argv.len);
-    try std.testing.expectEqualStrings("/opt/homebrew/bin/mt", argv[0]);
-    try std.testing.expectEqualStrings("services", argv[1]);
-    try std.testing.expectEqualStrings("restart", argv[2]);
-    try std.testing.expectEqualStrings("postgresql", argv[3]); // the selected row's name
-}
-
-test "serviceActionArgv returns null when nothing is selected so the action is a no-op" {
-    const st: services.State = .{ .items = &.{} };
-    try std.testing.expect((try serviceActionArgv(std.testing.allocator, "/bin/mt", "start", &st)) == null);
-}
-
-test "a failed services refresh names the op in the banner and keeps the last-good rows" {
-    var t = std.Io.Threaded.init(std.testing.allocator, .{});
-    defer t.deinit();
-    var app: App = .{ .mt_path = "/bin/echo" }; // echo emits non-JSON → parse fails
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
-    var frame: []u8 = &.{};
-    try std.testing.expectError(error.BadJson, loadServices(t.io(), std.testing.allocator, testPainter(&frame), &app, &store));
-    try std.testing.expectEqualStrings("services refresh failed: BadJson", app.shared.banner.slice());
-    try std.testing.expectEqual(@as(usize, 0), app.states.services.items.len); // last-good kept
 }
 
 test "searchArgv builds `mt search <query> --json` for the committed query" {

--- a/src/tui/outdated_tab.zig
+++ b/src/tui/outdated_tab.zig
@@ -11,9 +11,11 @@
 //! selection is a no-op surfaced by the action line.
 
 const std = @import("std");
+const ctx = @import("ctx.zig");
 const tab = @import("tab.zig");
 const scroll_list = @import("scroll_list.zig");
 const outdated_json = @import("json/outdated.zig");
+const spawn = @import("spawn.zig");
 const color = @import("../ui/color.zig");
 
 pub const Row = outdated_json.OutdatedRow;
@@ -50,6 +52,13 @@ pub const Storage = struct {
 
 /// Outdated audits in the background; a non-clean exit means a failed refresh.
 pub const fetch_spec: ?tab.FetchSpec = .{ .verb = &.{"outdated"}, .max_ok_exit = 0, .refresh_op = "outdated refresh failed" };
+
+/// Whether the pending request will spawn a DB-mutating child (`mt upgrade`). The
+/// shell folds this over every tab before opening the DB so a live background
+/// audit is drained first — the WAL single-writer invariant.
+pub fn mutates(s: *const State) bool {
+    return s.request == .upgrade;
+}
 
 pub fn title() []const u8 {
     return "Outdated";
@@ -238,6 +247,222 @@ fn appendPad(buf: []u8, len: *usize, s: []const u8, width: usize) void {
     while (i < width) : (i += 1) append(buf, len, " ");
 }
 
+// ─── impure zone ───────────────────────────────────────────────────────
+// The effect half of the tab, reunited beside its pure producer (`step` records
+// the `upgrade` request; the code below drains it). Every decl here takes its I/O
+// ports explicitly through the shared `ctx.Ctx` — never a global — so the
+// pure/impure line is the function signature.
+
+/// The effect chain's error set, composed from the source sets so it tracks them
+/// automatically. A subset of the shell's `RunError`, which classifies each fault
+/// recoverable-vs-fatal; naming it here keeps the public `service` explicit.
+pub const Error = std.mem.Allocator.Error || spawn.ReadError || spawn.InlineError || outdated_json.Error;
+
+/// Perform any upgrade effect the pure `step` requested, then clear it — the
+/// consumer half of the `request` seam. The shell dispatches this only for the
+/// active tab; the lazy (re)load on entry / after staleness stays loop machinery.
+pub fn service(s: *State, storage: *Storage, c: *ctx.Ctx) Error!void {
+    const req = s.request;
+    s.request = .none;
+    switch (req) {
+        .none => {},
+        .upgrade => try doUpgrade(s, storage, c),
+    }
+}
+
+/// One upgraded row, identified by `(name, kind)` so a formula and a cask that
+/// share a name (e.g. `docker`) are never confused for one another.
+const UpgradedRef = struct { name: []const u8, kind: outdated_json.Kind };
+
+/// Collect the checked, non-pinned rows into `out` as `(name, kind)` refs,
+/// formula rows first then cask rows; returns the formula count (the split
+/// index). `out` must be sized to `selectedCount`. Partitioning by kind lets
+/// `doUpgrade` issue one `--formula` pass and one `--cask` pass.
+fn collectUpgraded(s: *const State, out: []UpgradedRef) usize {
+    // The two item-order passes below cover exactly `{formula, cask}`; a new
+    // Kind variant would leave its rows uncollected. Lock it at compile time.
+    comptime std.debug.assert(@typeInfo(outdated_json.Kind).@"enum".fields.len == 2);
+    var n: usize = 0;
+    var split: usize = 0;
+    // Two item-order passes so each kind's names stay in display order and the
+    // formula refs land in `out[0..split]`, casks in `out[split..]`.
+    for ([_]outdated_json.Kind{ .formula, .cask }) |kind| {
+        for (s.items, 0..) |row, i| {
+            // Same rule as `selectedNames`: checked, non-pinned, this kind.
+            if (i < s.checked.len and s.checked[i] and !row.pinned and row.kind == kind and n < out.len) {
+                out[n] = .{ .name = row.name, .kind = row.kind };
+                n += 1;
+            }
+        }
+        if (kind == .formula) split = n;
+    }
+    return split;
+}
+
+/// Build `[mt, upgrade, <flag>, names...]` for a single-kind ref slice, or null
+/// when the slice is empty. `flag` is `--formula` / `--cask` so the kind the
+/// user picked is the kind upgraded (`mt upgrade <name>` is formula-first).
+fn kindUpgradeArgv(
+    allocator: std.mem.Allocator,
+    mt_path: []const u8,
+    refs: []const UpgradedRef,
+    flag: []const u8,
+) std.mem.Allocator.Error!?[]const []const u8 {
+    if (refs.len == 0) return null;
+    const rest = try allocator.alloc([]const u8, 2 + refs.len);
+    defer allocator.free(rest);
+    rest[0] = "upgrade";
+    rest[1] = flag;
+    for (refs, rest[2..]) |r, *slot| slot.* = r.name;
+    return try spawn.inlineArgv(allocator, mt_path, rest);
+}
+
+/// The exit code `mt upgrade` returns when it refused a cask because the app is
+/// still running. Mirrors `main.zig`'s `AppRunning` exit mapping — the mt→TUI
+/// process contract, like the doctor severity cap the inline runner already knows.
+const cask_app_running_exit: u8 = 3;
+
+/// Footer detail for a failed cask upgrade pass: on the app-running refusal name
+/// the live app (or "a selected app" when the pass carried several) so the footer
+/// says *why*, not an opaque "ChildFailed". `buf` backs the single-cask name;
+/// `Banner.set` copies the result, so a stack buffer is enough.
+fn upgradeFailDetail(buf: []u8, code: u8, refs: []const UpgradedRef) []const u8 {
+    if (code != cask_app_running_exit) return "ChildFailed";
+    if (refs.len == 1) return std.fmt.bufPrint(buf, "{s} is running", .{refs[0].name}) catch "an app is running";
+    return "a selected app is running";
+}
+
+/// Delegate the checked upgrades to the real `mt` inline, then drop the upgraded
+/// rows in place. Runs one pass per kind (`--formula`, `--cask`) so the row the
+/// user checked is the row upgraded — `mt upgrade <name>` is formula-first, so a
+/// checked cask would otherwise upgrade a same-named formula. Names borrow the
+/// parse arena, which `dropUpgradedRows` keeps alive across both passes.
+fn doUpgrade(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
+    const count = selectedCount(s);
+    if (count == 0) return; // empty selection: no-op
+    // Snapshot the selection (formula refs first, then cask) before any upgrade
+    // or drop — the drop rebuilds the checkbox buffer, erasing the selection.
+    const upgraded = try c.allocator.alloc(UpgradedRef, count);
+    defer c.allocator.free(upgraded);
+    const split = collectUpgraded(s, upgraded);
+
+    const passes = [_]struct { refs: []const UpgradedRef, flag: []const u8 }{
+        .{ .refs = upgraded[0..split], .flag = "--formula" },
+        .{ .refs = upgraded[split..], .flag = "--cask" },
+    };
+    // Passes run independently: a failed formula pass still lets the cask pass
+    // proceed, and only a succeeded pass's rows are dropped. A non-zero `mt
+    // upgrade` re-enters the dashboard and surfaces as a recoverable banner.
+    var dropped_any = false;
+    for (passes) |pass| {
+        const argv = (try kindUpgradeArgv(c.allocator, c.mt_path, pass.refs, pass.flag)) orelse continue;
+        defer c.allocator.free(argv);
+        if (spawn.runInlineReenterStatus(c.term, argv)) |code| {
+            if (code == 0) {
+                try dropUpgradedRows(c.allocator, s, storage, c.shared, pass.refs);
+                dropped_any = true;
+            } else {
+                var dbuf: [96]u8 = undefined;
+                c.shared.banner.set("upgrade failed", upgradeFailDetail(&dbuf, code, pass.refs));
+            }
+        } else |err| {
+            c.shared.banner.set("upgrade failed", @errorName(err));
+        }
+    }
+    if (dropped_any) c.shared.markStaleAfter(.outdated); // Installed sizes/versions changed too
+}
+
+/// True when `row` is one of the upgraded rows (linear scan — a batch is small).
+/// Matches on `(name, kind)`: `mt upgrade <name>` resolves formula-first, so a
+/// same-named cask is left outdated and must not be dropped with the formula.
+fn rowUpgraded(upgraded: []const UpgradedRef, row: Row) bool {
+    for (upgraded) |u| {
+        if (u.kind == row.kind and std.mem.eql(u8, u.name, row.name)) return true;
+    }
+    return false;
+}
+
+/// Drop the just-upgraded rows from the Outdated tab in place: the post-upgrade
+/// outdated set is the pre-upgrade set minus the upgraded tokens, so a second
+/// `mt outdated` walk is unnecessary. The parsed storage is kept alive (rows
+/// borrow its arena) and `items` is re-pointed at the survivors within that
+/// arena; only the checkbox buffer is reallocated, preserving each kept row's
+/// checked state so a partial-selection upgrade survives.
+fn dropUpgradedRows(
+    allocator: std.mem.Allocator,
+    st: *State,
+    storage: *Storage,
+    shared: *ctx.SharedModel,
+    upgraded: []const UpgradedRef,
+) std.mem.Allocator.Error!void {
+    if (storage.outdated == null) return; // nothing loaded → nothing to drop
+    const parsed = &storage.outdated.?;
+    const old_items = parsed.items;
+    const old_checked = storage.checked;
+
+    var keep: usize = 0;
+    for (old_items) |row| {
+        if (!rowUpgraded(upgraded, row)) keep += 1;
+    }
+
+    // Survivors live in the parse arena alongside the strings they borrow, so
+    // they free together on the next full reload. The checkbox buffer is shell-
+    // owned, so it is reallocated and the old one freed.
+    const arena = parsed.doc.arena.allocator();
+    const new_items = try arena.alloc(outdated_json.OutdatedRow, keep);
+    const new_checked = try allocator.alloc(bool, keep);
+    errdefer allocator.free(new_checked);
+
+    var j: usize = 0;
+    for (old_items, 0..) |row, i| {
+        if (rowUpgraded(upgraded, row)) continue;
+        new_items[j] = row;
+        new_checked[j] = i < old_checked.len and old_checked[i];
+        j += 1;
+    }
+
+    if (old_checked.len != 0) allocator.free(old_checked);
+    parsed.items = new_items;
+    storage.checked = new_checked;
+    st.items = new_items;
+    st.checked = new_checked;
+    shared.outdated_count = new_items.len;
+}
+
+/// Repoint the Outdated tab and the header count at a drained `--json` payload.
+/// `null` (a fresh prefix's exit-0 no-output) clears to a known-zero tab; a parsed
+/// document swaps in the rows and a fresh, all-clear checkbox buffer. Shared by
+/// the synchronous reload and the background launch fetch, so both land the same
+/// state. The storage is swapped only after a clean parse — a failure keeps the
+/// last-good rows for the caller's banner to explain. Public because the shell's
+/// fetch drain routes a background payload through it.
+pub fn applyOutdatedBytes(allocator: std.mem.Allocator, st: *State, storage: *Storage, shared: *ctx.SharedModel, bytes: ?[]const u8) outdated_json.Error!void {
+    const payload = bytes orelse {
+        if (storage.outdated) |old| old.deinit();
+        if (storage.checked.len != 0) allocator.free(storage.checked);
+        storage.outdated = null;
+        storage.checked = &.{};
+        st.items = &.{};
+        st.checked = &.{};
+        shared.outdated_count = 0; // nothing outdated is a known zero, not "unknown"
+        return;
+    };
+    const parsed = try outdated_json.parse(allocator, payload);
+    errdefer parsed.deinit();
+    // A fresh checkbox buffer, all clear: an upgrade removes the upgraded rows, so
+    // carrying the old selection forward would point at the wrong packages.
+    const checked = try allocator.alloc(bool, parsed.items.len);
+    @memset(checked, false);
+
+    if (storage.outdated) |old| old.deinit();
+    if (storage.checked.len != 0) allocator.free(storage.checked);
+    storage.outdated = parsed;
+    storage.checked = checked;
+    st.items = parsed.items;
+    st.checked = checked;
+    shared.outdated_count = parsed.items.len;
+}
+
 // ─── tests ───────────────────────────────────────────────────────────
 
 const testing = std.testing;
@@ -320,6 +545,13 @@ test "Enter requests the upgrade like u" {
     var s: State = .{ .items = &sample, .checked = &checked };
     step(&s, .enter);
     try testing.expectEqual(Request.upgrade, s.request);
+}
+
+test "mutates is true only for a pending upgrade — the request that takes the WAL writer" {
+    var s: State = .{};
+    try testing.expect(!mutates(&s)); // .none never gates the pre-mutation drain
+    s.request = .upgrade;
+    try testing.expect(mutates(&s));
 }
 
 test "selectedCount counts checked, non-pinned rows" {
@@ -450,6 +682,279 @@ test "the cores tolerate a checked slice shorter than items without trapping" {
     _ = selectedCount(&s);
     var out: [4][]const u8 = undefined;
     _ = selectedNames(&s, &out);
+}
+
+test "upgradeFailDetail names the live app on the refusal code, else stays generic" {
+    var buf: [96]u8 = undefined;
+    const one = [_]UpgradedRef{.{ .name = "flux-markdown", .kind = .cask }};
+    const many = [_]UpgradedRef{ .{ .name = "a", .kind = .cask }, .{ .name = "b", .kind = .cask } };
+
+    // The refusal code names the one cask, or stays generic for a batch.
+    try testing.expectEqualStrings("flux-markdown is running", upgradeFailDetail(&buf, cask_app_running_exit, &one));
+    try testing.expectEqualStrings("a selected app is running", upgradeFailDetail(&buf, cask_app_running_exit, &many));
+    // Any other non-zero exit is the generic child failure, unnamed.
+    try testing.expectEqualStrings("ChildFailed", upgradeFailDetail(&buf, 1, &one));
+
+    // Edge: a name longer than the buffer falls back rather than truncating mid-name.
+    var tiny: [4]u8 = undefined;
+    try testing.expectEqualStrings("an app is running", upgradeFailDetail(&tiny, cask_app_running_exit, &one));
+}
+
+test "collectUpgraded partitions checked rows formula-first, then cask, excluding pinned" {
+    const items = [_]Row{
+        .{ .name = "firefox", .installed = "1", .latest = "2", .kind = .cask, .pinned = false, .tap = "" },
+        .{ .name = "wget", .installed = "1", .latest = "2", .kind = .formula, .pinned = false, .tap = "" },
+        .{ .name = "held", .installed = "1", .latest = "2", .kind = .formula, .pinned = true, .tap = "" },
+    };
+    var checked = [_]bool{ true, true, true }; // held is pinned → excluded
+    var st: State = .{ .items = &items, .checked = &checked };
+    var buf: [3]UpgradedRef = undefined;
+    const split = collectUpgraded(&st, buf[0..selectedCount(&st)]);
+    try testing.expectEqual(@as(usize, 1), split); // one formula, before the cask
+    try testing.expectEqualStrings("wget", buf[0].name);
+    try testing.expectEqual(outdated_json.Kind.formula, buf[0].kind);
+    try testing.expectEqualStrings("firefox", buf[1].name);
+    try testing.expectEqual(outdated_json.Kind.cask, buf[1].kind);
+}
+
+test "kindUpgradeArgv builds `mt upgrade <flag> <names>`, null for no refs" {
+    const refs = [_]UpgradedRef{ .{ .name = "firefox", .kind = .cask }, .{ .name = "vlc", .kind = .cask } };
+    const maybe = try kindUpgradeArgv(testing.allocator, "/bin/mt", &refs, "--cask");
+    try testing.expect(maybe != null);
+    const argv = maybe.?;
+    defer testing.allocator.free(argv);
+    try testing.expectEqual(@as(usize, 5), argv.len);
+    try testing.expectEqualStrings("upgrade", argv[1]);
+    try testing.expectEqualStrings("--cask", argv[2]);
+    try testing.expectEqualStrings("firefox", argv[3]);
+    try testing.expectEqualStrings("vlc", argv[4]);
+    try testing.expect((try kindUpgradeArgv(testing.allocator, "/bin/mt", &.{}, "--cask")) == null);
+}
+
+test "a mixed selection yields a --formula pass and a --cask pass" {
+    const items = [_]Row{
+        .{ .name = "wget", .installed = "1", .latest = "2", .kind = .formula, .pinned = false, .tap = "" },
+        .{ .name = "firefox", .installed = "1", .latest = "2", .kind = .cask, .pinned = false, .tap = "" },
+    };
+    var checked = [_]bool{ true, true };
+    var st: State = .{ .items = &items, .checked = &checked };
+    var buf: [2]UpgradedRef = undefined;
+    const split = collectUpgraded(&st, buf[0..selectedCount(&st)]);
+
+    const f = (try kindUpgradeArgv(testing.allocator, "/bin/mt", buf[0..split], "--formula")).?;
+    defer testing.allocator.free(f);
+    try testing.expectEqualStrings("--formula", f[2]);
+    try testing.expectEqualStrings("wget", f[3]);
+
+    const c = (try kindUpgradeArgv(testing.allocator, "/bin/mt", buf[split..], "--cask")).?;
+    defer testing.allocator.free(c);
+    try testing.expectEqualStrings("--cask", c[2]);
+    try testing.expectEqualStrings("firefox", c[3]);
+}
+
+test "a cask-only selection runs no formula pass and upgrades the cask" {
+    const items = [_]Row{
+        .{ .name = "wget", .installed = "1", .latest = "2", .kind = .formula, .pinned = false, .tap = "" },
+        .{ .name = "firefox", .installed = "1", .latest = "2", .kind = .cask, .pinned = false, .tap = "" },
+    };
+    var checked = [_]bool{ false, true }; // only the cask is checked
+    var st: State = .{ .items = &items, .checked = &checked };
+    var buf: [1]UpgradedRef = undefined;
+    const split = collectUpgraded(&st, buf[0..selectedCount(&st)]);
+    try testing.expectEqual(@as(usize, 0), split); // no formula rows
+    try testing.expect((try kindUpgradeArgv(testing.allocator, "/bin/mt", buf[0..split], "--formula")) == null);
+    const c = (try kindUpgradeArgv(testing.allocator, "/bin/mt", buf[split..], "--cask")).?;
+    defer testing.allocator.free(c);
+    try testing.expectEqualStrings("--cask", c[2]);
+    try testing.expectEqualStrings("firefox", c[3]);
+}
+
+test "dropUpgradedRows removes upgraded rows in place and preserves kept checked state" {
+    var st: State = .{};
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    const json =
+        \\{"outdated":[
+        \\{"name":"a","installed":"1","latest":"2","type":"formula","pinned":false},
+        \\{"name":"b","installed":"1","latest":"2","type":"formula","pinned":false},
+        \\{"name":"c","installed":"1","latest":"2","type":"formula","pinned":false}
+        \\]}
+    ;
+    try applyOutdatedBytes(testing.allocator, &st, &storage, &shared, json);
+    // Check a and c (b is the one being upgraded); the kept rows must stay checked.
+    storage.checked[0] = true;
+    storage.checked[2] = true;
+
+    try dropUpgradedRows(testing.allocator, &st, &storage, &shared, &.{.{ .name = "b", .kind = .formula }});
+
+    try testing.expectEqual(@as(usize, 2), storage.outdated.?.items.len);
+    try testing.expectEqualStrings("a", storage.outdated.?.items[0].name);
+    try testing.expectEqualStrings("c", storage.outdated.?.items[1].name);
+    try testing.expectEqual(@as(?usize, 2), shared.outdated_count);
+    try testing.expectEqual(@as(usize, 2), st.items.len);
+    // a and c stay checked in the rebuilt lockstep buffer.
+    try testing.expect(st.checked[0]);
+    try testing.expect(st.checked[1]);
+}
+
+test "applyOutdatedBytes reallocs the checkbox buffer to the new row count" {
+    var st: State = .{};
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    // First parse (two rows). Its arena must be freed when the second lands, or the
+    // test allocator trips — this pins that the arena lifetime moved into the tab's
+    // own Storage, so a re-load frees the prior parse rather than leaking it.
+    try applyOutdatedBytes(testing.allocator, &st, &storage, &shared, "{\"outdated\":[{\"name\":\"a\",\"installed\":\"1\",\"latest\":\"2\",\"type\":\"formula\",\"pinned\":false},{\"name\":\"b\",\"installed\":\"1\",\"latest\":\"2\",\"type\":\"formula\",\"pinned\":false}]}");
+    storage.checked[0] = true; // a stale selection the swap must not carry forward
+    try testing.expectEqual(@as(usize, 2), storage.outdated.?.items.len);
+    try testing.expectEqual(@as(usize, 2), storage.checked.len);
+    // Second parse (one row) swaps in a fresh arena + an all-clear checkbox buffer.
+    try applyOutdatedBytes(testing.allocator, &st, &storage, &shared, "{\"outdated\":[{\"name\":\"z\",\"installed\":\"1\",\"latest\":\"9\",\"type\":\"cask\",\"pinned\":false}]}");
+    // The survivor borrows the live arena: the name resolves and the count follows.
+    try testing.expectEqual(@as(usize, 1), storage.outdated.?.items.len);
+    try testing.expectEqual(@as(usize, 1), storage.checked.len); // buffer resized to the new row count
+    try testing.expectEqualStrings("z", storage.outdated.?.items[0].name);
+    try testing.expectEqual(@as(?usize, 1), shared.outdated_count);
+    try testing.expect(!storage.checked[0]); // fresh buffer, all clear
+}
+
+test "dropUpgradedRows on an unloaded store is a no-op" {
+    var st: State = .{};
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    try dropUpgradedRows(testing.allocator, &st, &storage, &shared, &.{.{ .name = "anything", .kind = .formula }});
+    try testing.expect(storage.outdated == null);
+}
+
+test "dropUpgradedRows drops only the upgraded kind when a formula and cask share a name" {
+    var st: State = .{};
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    const json =
+        \\{"outdated":[
+        \\{"name":"docker","installed":"1","latest":"2","type":"formula","pinned":false},
+        \\{"name":"docker","installed":"1","latest":"2","type":"cask","pinned":false}
+        \\]}
+    ;
+    try applyOutdatedBytes(testing.allocator, &st, &storage, &shared, json);
+    // Only the formula docker was upgraded; the same-named cask must remain.
+    try dropUpgradedRows(testing.allocator, &st, &storage, &shared, &.{.{ .name = "docker", .kind = .formula }});
+    try testing.expectEqual(@as(usize, 1), storage.outdated.?.items.len);
+    try testing.expectEqual(outdated_json.Kind.cask, storage.outdated.?.items[0].kind);
+}
+
+test "dropUpgradedRows survives two sequential drops (the formula then cask passes)" {
+    var st: State = .{};
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    const json =
+        \\{"outdated":[
+        \\{"name":"wget","installed":"1","latest":"2","type":"formula","pinned":false},
+        \\{"name":"firefox","installed":"1","latest":"2","type":"cask","pinned":false}
+        \\]}
+    ;
+    try applyOutdatedBytes(testing.allocator, &st, &storage, &shared, json);
+
+    // Formula pass drops wget; the cask ref (still borrowing the live parse
+    // arena) must survive the first drop's store mutation and rebuilt buffer.
+    try dropUpgradedRows(testing.allocator, &st, &storage, &shared, &.{.{ .name = "wget", .kind = .formula }});
+    try testing.expectEqual(@as(usize, 1), storage.outdated.?.items.len);
+    try testing.expectEqual(outdated_json.Kind.cask, storage.outdated.?.items[0].kind);
+
+    // Cask pass drops firefox → empty, no leak / use-after-free.
+    try dropUpgradedRows(testing.allocator, &st, &storage, &shared, &.{.{ .name = "firefox", .kind = .cask }});
+    try testing.expectEqual(@as(usize, 0), storage.outdated.?.items.len);
+    try testing.expectEqual(@as(?usize, 0), shared.outdated_count);
+}
+
+test "dropUpgradedRows keeps every row when no upgraded ref matches" {
+    var st: State = .{};
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    const json =
+        \\{"outdated":[
+        \\{"name":"a","installed":"1","latest":"2","type":"formula","pinned":false},
+        \\{"name":"b","installed":"1","latest":"2","type":"formula","pinned":false}
+        \\]}
+    ;
+    try applyOutdatedBytes(testing.allocator, &st, &storage, &shared, json);
+    try dropUpgradedRows(testing.allocator, &st, &storage, &shared, &.{.{ .name = "z", .kind = .formula }});
+    try testing.expectEqual(@as(usize, 2), storage.outdated.?.items.len);
+}
+
+test "dropUpgradedRows clears the list when every row was upgraded" {
+    var st: State = .{};
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    const json =
+        \\{"outdated":[
+        \\{"name":"a","installed":"1","latest":"2","type":"formula","pinned":false},
+        \\{"name":"b","installed":"1","latest":"2","type":"formula","pinned":false}
+        \\]}
+    ;
+    try applyOutdatedBytes(testing.allocator, &st, &storage, &shared, json);
+    try dropUpgradedRows(testing.allocator, &st, &storage, &shared, &.{ .{ .name = "a", .kind = .formula }, .{ .name = "b", .kind = .formula } });
+    try testing.expectEqual(@as(usize, 0), storage.outdated.?.items.len);
+    try testing.expectEqual(@as(?usize, 0), shared.outdated_count);
+}
+
+// Backing storage for a `ctx.Ctx` in an effect test: dummy term/fetches/shared,
+// a no-op painter (fd = -1; the test children never reach a poll tick), and the
+// synchronous-load flag.
+const TestEnv = struct {
+    term_h: ctx.Term,
+    fetches: ctx.Fetches = ctx.Fetches.initFill(null),
+    shared: ctx.SharedModel = .{},
+    frame: []u8 = &.{},
+    loading: bool = false,
+};
+
+fn mkCtx(io: std.Io, e: *TestEnv, mt_path: []const u8) ctx.Ctx {
+    return .{
+        .io = io,
+        .allocator = testing.allocator,
+        .term = &e.term_h,
+        .painter = .{ .fd = -1, .frame = &e.frame },
+        .fetches = &e.fetches,
+        .shared = &e.shared,
+        .mt_path = mt_path,
+        .loading = &e.loading,
+    };
+}
+
+test "service on a .none request is a clean no-op — no spawn, no banner" {
+    var thr = std.Io.Threaded.init(testing.allocator, .{});
+    defer thr.deinit();
+    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    var st: State = .{}; // .none: the pure `step` set nothing to perform
+    var c = mkCtx(thr.io(), &env, "/bin/false"); // would fail if it ever spawned
+    try service(&st, &storage, &c);
+    try testing.expectEqual(Request.none, st.request);
+    try testing.expect(!env.shared.banner.isSet());
+}
+
+test "service drains an upgrade request; an empty selection never spawns" {
+    var thr = std.Io.Threaded.init(testing.allocator, .{});
+    defer thr.deinit();
+    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    // An empty selection means `doUpgrade` resolves count == 0: the request drains
+    // but no `mt upgrade` child runs, so `/bin/false` is never reached.
+    var st: State = .{ .request = .upgrade };
+    var c = mkCtx(thr.io(), &env, "/bin/false");
+    try service(&st, &storage, &c);
+    try testing.expectEqual(Request.none, st.request); // the producer/consumer seam drained it
+    try testing.expect(!env.shared.banner.isSet()); // never spawned → no failure banner
 }
 
 test "conforms to the tab contract" {

--- a/src/tui/services_tab.zig
+++ b/src/tui/services_tab.zig
@@ -14,10 +14,12 @@ const std = @import("std");
 const testing = std.testing;
 
 const color = @import("../ui/color.zig");
+const ctx = @import("ctx.zig");
 const services_json = @import("json/services.zig");
 pub const Row = services_json.ServiceRow;
 const detail_pane = @import("detail_pane.zig");
 const scroll_list = @import("scroll_list.zig");
+const spawn = @import("spawn.zig");
 const tab = @import("tab.zig");
 
 /// A lifecycle effect the pure `step` defers to the impure shell, which performs
@@ -49,6 +51,13 @@ pub const Storage = struct {
 
 /// Services audits in the background; a non-clean exit means a failed refresh.
 pub const fetch_spec: ?tab.FetchSpec = .{ .verb = &.{ "services", "list" }, .max_ok_exit = 0, .refresh_op = "services refresh failed" };
+
+/// Whether the pending request will spawn a DB-mutating child. Unlike the other
+/// tabs' single mutating verb, *every* non-`.none` lifecycle action (start / stop
+/// / restart) opens the DB, so the classifier is "any pending request".
+pub fn mutates(s: *const State) bool {
+    return s.request != .none;
+}
 
 pub fn title() []const u8 {
     return "Services";
@@ -245,6 +254,95 @@ fn appendPad(buf: []u8, len: *usize, s: []const u8, width: usize) void {
     while (i < width) : (i += 1) append(buf, len, " ");
 }
 
+// ─── impure zone ───────────────────────────────────────────────────────
+// The effect half of the tab, reunited beside its pure producer (`step` records
+// the lifecycle `request`; the code below drains it). Every decl here takes its
+// I/O ports explicitly through the shared `ctx.Ctx` — never a global — so the
+// pure/impure line is the function signature.
+
+/// The effect chain's error set, composed from the source sets so it tracks them
+/// automatically. A subset of the shell's `RunError`, which classifies each fault
+/// recoverable-vs-fatal; naming it here keeps the public `service` explicit.
+pub const Error = std.mem.Allocator.Error || spawn.ReadError || spawn.InlineError || services_json.Error;
+
+/// Perform any lifecycle effect the pure `step` requested, then clear it — the
+/// consumer half of the `request` seam. The shell dispatches this only for the
+/// active tab; the lazy (re)load on entry / after staleness stays loop machinery.
+pub fn service(s: *State, storage: *Storage, c: *ctx.Ctx) Error!void {
+    const req = s.request;
+    s.request = .none;
+    switch (req) {
+        .none => {},
+        .start => try doServiceAction(s, storage, c, "start"),
+        .stop => try doServiceAction(s, storage, c, "stop"),
+        .restart => try doServiceAction(s, storage, c, "restart"),
+    }
+}
+
+/// Build `mt services <action> <name>` for the selected service. Pure over the
+/// tab state: null when nothing is selected (the no-op), else an owned argv whose
+/// `name` element borrows from the parse storage. Caller frees the returned slice
+/// (not its elements).
+fn serviceActionArgv(allocator: std.mem.Allocator, mt_path: []const u8, action: []const u8, s: *const State) std.mem.Allocator.Error!?[]const []const u8 {
+    const svc = selectedService(s) orelse return null; // empty list: no-op
+    return try spawn.inlineArgv(allocator, mt_path, &.{ "services", action, svc.name });
+}
+
+/// Delegate a service lifecycle action to the real `mt` inline, then refresh. The
+/// argv's `name` borrows from the current parse storage; the post-spawn reload
+/// frees that storage, so the name is not read afterwards.
+fn doServiceAction(s: *State, storage: *Storage, c: *ctx.Ctx, action: []const u8) !void {
+    const argv = (try serviceActionArgv(c.allocator, c.mt_path, action, s)) orelse return; // nothing selected
+    defer c.allocator.free(argv);
+    {
+        // A non-zero `mt services <action>` re-enters the dashboard (the user
+        // keeps malt's real output in their scrollback) and surfaces as a
+        // recoverable banner; only a terminal fault is fatal. Scoped so the
+        // refresh below reports under its own op, not the action.
+        errdefer |err| c.shared.banner.set("service action failed", @errorName(err));
+        try spawn.runInlineReenter(c.term, argv);
+    }
+    try loadServices(s, storage, c); // the state changed — refetch
+    c.shared.markStaleAfter(.services); // this tab is fresh; the others may now be stale
+}
+
+/// (Re)read `mt services list --json` and repoint the Services tab's rows at the
+/// fresh parse, freeing the previous one. The polled read animates the shell's
+/// spinner through `c.painter` while it blocks; the storage is swapped only after
+/// a clean parse, so a failure keeps the last-good rows and their selection.
+fn loadServices(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
+    errdefer |err| c.shared.banner.set("services refresh failed", @errorName(err));
+    const argv = try spawn.jsonArgv(c.allocator, c.mt_path, &.{ "services", "list" });
+    defer c.allocator.free(argv);
+    // Keep `loading` set across the poll so each tick paints the spinner, cleared
+    // once the result (or the empty/banner state) replaces it.
+    c.loading.* = true;
+    defer c.loading.* = false;
+    const bytes = try spawn.readJsonPolled(c.io, c.allocator, argv, 0, c.painter);
+    defer if (bytes) |b| c.allocator.free(b);
+    try applyServicesBytes(c.allocator, s, storage, bytes);
+}
+
+/// Repoint the Services tab at a drained `--json` payload. `null` (a fresh prefix)
+/// clears to an empty list; a parsed document swaps in the rows. Shared by the
+/// synchronous reload and the background fetch; the storage is swapped only after
+/// a clean parse, so a failure keeps the last-good rows. Public because the shell's
+/// fetch drain routes a background payload through it.
+pub fn applyServicesBytes(allocator: std.mem.Allocator, st: *State, storage: *Storage, bytes: ?[]const u8) services_json.Error!void {
+    const payload = bytes orelse {
+        if (storage.services) |old| old.deinit();
+        storage.services = null;
+        st.items = &.{};
+        st.detail = null; // the old detail borrowed the freed rows
+        return;
+    };
+    const parsed = try services_json.parse(allocator, payload);
+    if (storage.services) |old| old.deinit();
+    storage.services = parsed;
+    st.items = parsed.items;
+    st.detail = null; // a refreshed list invalidates the old detail
+}
+
 // ─── tests ───────────────────────────────────────────────────────────
 
 fn ch(c: u8) tab.Key {
@@ -286,6 +384,17 @@ test "s requests start, x and X request stop, r requests restart" {
     try testing.expectEqual(Request.stop, s.request);
     step(&s, ch('r'));
     try testing.expectEqual(Request.restart, s.request);
+}
+
+test "mutates is true for any pending lifecycle action, false only for none" {
+    var s: State = .{};
+    try testing.expect(!mutates(&s)); // .none never gates the pre-mutation drain
+    s.request = .start;
+    try testing.expect(mutates(&s));
+    s.request = .stop;
+    try testing.expect(mutates(&s));
+    s.request = .restart;
+    try testing.expect(mutates(&s));
 }
 
 test "an unrelated key leaves the request alone" {
@@ -492,6 +601,105 @@ test "render clamps to a height of one without crashing" {
     var f: tab.Frame = .{ .buf = &buf };
     const s: State = .{ .items = &sample };
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 1 }); // one list row fits
+}
+
+test "serviceActionArgv builds `mt services <action> <name>` for the selected service" {
+    const items = [_]Row{
+        .{ .name = "redis", .state = "running", .auto_start = true, .keg_name = "redis" },
+        .{ .name = "postgresql", .state = "stopped", .auto_start = false, .keg_name = "postgresql@16" },
+    };
+    var st: State = .{ .items = &items };
+    st.chrome.view.selected = 1; // postgresql
+    const argv = (try serviceActionArgv(testing.allocator, "/opt/homebrew/bin/mt", "restart", &st)).?;
+    defer testing.allocator.free(argv);
+    try testing.expectEqual(@as(usize, 4), argv.len);
+    try testing.expectEqualStrings("/opt/homebrew/bin/mt", argv[0]);
+    try testing.expectEqualStrings("services", argv[1]);
+    try testing.expectEqualStrings("restart", argv[2]);
+    try testing.expectEqualStrings("postgresql", argv[3]); // the selected row's name
+}
+
+test "serviceActionArgv returns null when nothing is selected so the action is a no-op" {
+    const st: State = .{ .items = &.{} };
+    try testing.expect((try serviceActionArgv(testing.allocator, "/bin/mt", "start", &st)) == null);
+}
+
+// Backing storage for a `ctx.Ctx` in an effect test: dummy term/fetches/shared,
+// a no-op painter (fd = -1; the test children finish before the first poll tick,
+// so it is never touched), and the synchronous-load flag.
+const TestEnv = struct {
+    term_h: ctx.Term,
+    fetches: ctx.Fetches = ctx.Fetches.initFill(null),
+    shared: ctx.SharedModel = .{},
+    frame: []u8 = &.{},
+    loading: bool = false,
+};
+
+fn mkCtx(io: std.Io, e: *TestEnv, mt_path: []const u8) ctx.Ctx {
+    return .{
+        .io = io,
+        .allocator = testing.allocator,
+        .term = &e.term_h,
+        .painter = .{ .fd = -1, .frame = &e.frame },
+        .fetches = &e.fetches,
+        .shared = &e.shared,
+        .mt_path = mt_path,
+        .loading = &e.loading,
+    };
+}
+
+test "loadServices treats an exit-0 empty response (fresh prefix) as an empty tab" {
+    var thr = std.Io.Threaded.init(testing.allocator, .{});
+    defer thr.deinit();
+    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    var st: State = .{};
+    var c = mkCtx(thr.io(), &env, "/usr/bin/true");
+    try loadServices(&st, &storage, &c);
+    try testing.expectEqual(@as(usize, 0), st.items.len);
+    try testing.expect(!env.shared.banner.isSet());
+}
+
+test "a failed services refresh names the op in the banner and keeps the last-good rows" {
+    var thr = std.Io.Threaded.init(testing.allocator, .{});
+    defer thr.deinit();
+    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    var st: State = .{};
+    var c = mkCtx(thr.io(), &env, "/bin/echo"); // echo emits non-JSON → parse fails
+    try testing.expectError(error.BadJson, loadServices(&st, &storage, &c));
+    try testing.expectEqualStrings("services refresh failed: BadJson", env.shared.banner.slice());
+    try testing.expectEqual(@as(usize, 0), st.items.len); // last-good kept
+}
+
+test "service on a .none request is a clean no-op — no spawn, no banner" {
+    var thr = std.Io.Threaded.init(testing.allocator, .{});
+    defer thr.deinit();
+    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    var st: State = .{}; // .none: the pure `step` set nothing to perform
+    var c = mkCtx(thr.io(), &env, "/bin/false"); // would fail if it ever spawned
+    try service(&st, &storage, &c);
+    try testing.expectEqual(Request.none, st.request);
+    try testing.expect(!env.shared.banner.isSet());
+}
+
+test "service drains a lifecycle request; an empty list never spawns" {
+    var thr = std.Io.Threaded.init(testing.allocator, .{});
+    defer thr.deinit();
+    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    // An empty list means `serviceActionArgv` resolves to null: the request drains
+    // but no `mt services start` child runs, so `/bin/false` is never reached.
+    var st: State = .{ .request = .start };
+    var c = mkCtx(thr.io(), &env, "/bin/false");
+    try service(&st, &storage, &c);
+    try testing.expectEqual(Request.none, st.request); // the producer/consumer seam drained it
+    try testing.expect(!env.shared.banner.isSet()); // never spawned → no failure banner
 }
 
 test "conforms to the tab contract" {


### PR DESCRIPTION
## Description

Following the doctor reference migration, the two remaining background-fetch tabs - outdated and services - move their whole effect groups (load, apply, mutate, service) out of the app hub and beside their tabs, routed through the widened `moduleFor` service dispatch. The subtle bits move intact: outdated's exit-code-keyed row surgery that preserves partial upgrade selections and its checkbox realloc, and services' "any pending request mutates" classifier. 

Behaviour is unchanged.

## Related Issue

- None

## Notes for Reviewers

- None