### PR TITLE
refactor(tui): make step return a Cmd value and demote the search basket ops to pure state

### DIFF
--- a/scripts/regressions/tui-end-key-inert.sh
+++ b/scripts/regressions/tui-end-key-inert.sh
@@ -27,7 +27,8 @@ for tab in installed_tab outdated_tab services_tab doctor_tab search_tab; do
 done
 
 # 2. The shell must still defer .end to the tab (the row count lives there).
-rg -q '\.space, \.end, \.esc => routeToTab' src/tui/app.zig ||
+#    Post-reify `routeToTab` returns the tab's `Cmd`, so the arm returns it.
+rg -q '\.space, \.end, \.esc => return routeToTab' src/tui/app.zig ||
   fail "app.zig no longer routes .end to the active tab"
 
 # 3. The last-row unit tests must exist and pass.

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -1,8 +1,10 @@
 //! malt — `mt tui` app shell: event loop, tab dispatch, filter, rendering.
 //!
-//! Leaf module. The pure cores — `step(app, key) -> app` and
-//! `renderFrame(buf, app, cols, rows) -> bytes` — are The Elm Architecture and
-//! are unit-tested without a PTY. `run` is the only impure part: it owns the
+//! Leaf module. `step(app, key) -> Cmd` maps a key to the active tab's effect
+//! (pure over `(app, key)`; nav/editing mutate `app` in place) and
+//! `renderFrame(buf, app, cols, rows) -> bytes` paints — The Elm Architecture,
+//! unit-tested without a PTY. The `perform`/`update` pump in `serviceKey` runs the
+//! `Cmd`, folds the `Msg` back, and repaints. `run` is the only impure part: it owns the
 //! terminal lifecycle (raw mode + alt-screen + hidden cursor, each undone by an
 //! `errdefer` restore; panics and termination signals restore through the
 //! `ui/term_restore` crash registry), refuses to launch on a non-interactive
@@ -14,6 +16,7 @@ const std = @import("std");
 
 const color = @import("../ui/color.zig");
 const spinner_frames = @import("../ui/spinner_frames.zig");
+const cmd = @import("cmd.zig");
 const ctx = @import("ctx.zig");
 const doctor = @import("doctor_tab.zig");
 const filter_input = @import("filter_input.zig");
@@ -145,9 +148,11 @@ fn activeFilterLabel(a: *const App) []const u8 {
     return if (a.active == .search) "search: " else "filter: ";
 }
 
-fn routeToTab(a: *App, key: Key) void {
+/// Route a key to the active tab's `step`, returning the `Cmd` it produces. The
+/// tab's pure state changes land in place; the effect (if any) is the return.
+fn routeToTab(allocator: std.mem.Allocator, mt_path: []const u8, a: *App, key: Key) cmd.Cmd {
     switch (a.active) {
-        inline else => |t| moduleFor(t).step(&@field(a.states, @tagName(t)), key),
+        inline else => |t| return moduleFor(t).step(allocator, mt_path, &@field(a.states, @tagName(t)), &@field(a.storages, @tagName(t)), key),
     }
 }
 
@@ -177,26 +182,27 @@ fn tabTitles() [tab_bar.count][]const u8 {
     return t;
 }
 
-/// Pure transition: keys split between filter editing and normal navigation;
-/// keys the shell does not own fall through to the active tab.
-pub fn step(app: App, key: Key) App {
-    var a = app;
-    a.shared.banner.clear(); // a keypress dismisses the prior transient error banner
-    if (a.editing) stepFilter(&a, key) else stepNormal(&a, key);
-    return a;
+/// Transition: keys split between filter editing and normal navigation; keys the
+/// shell does not own fall through to the active tab. Nav/editing mutate `app` in
+/// place; the return is the active tab's effect `Cmd` (`none` for a pure key), which
+/// the `serviceKey` pump performs. Not a value-returning `App -> App` anymore because
+/// a `Cmd` carries a heap argv the pump owns.
+pub fn step(allocator: std.mem.Allocator, mt_path: []const u8, app: *App, key: Key) cmd.Cmd {
+    app.shared.banner.clear(); // a keypress dismisses the prior transient error banner
+    return if (app.editing) stepFilter(allocator, mt_path, app, key) else stepNormal(allocator, mt_path, app, key);
 }
 
-fn stepFilter(a: *App, key: Key) void {
+fn stepFilter(allocator: std.mem.Allocator, mt_path: []const u8, a: *App, key: Key) cmd.Cmd {
     switch (key) {
         .char => |c| activeChrome(a).filter.push(c.slice()),
         .backspace => activeChrome(a).filter.backspace(),
         .enter => { // commit, keep the filter
             a.editing = false;
-            // Search divergence: its filter doubles as the search box, so
-            // committing the query *is* the search. Set the request directly
-            // rather than routing Enter to the tab, whose Enter now means "open
-            // info" — every other tab's filter just narrows a loaded list.
-            if (a.active == .search) a.states.search.request = .search;
+            // Search divergence: its filter doubles as the search box, so committing
+            // the query *is* the search — ask the tab for the query `Cmd` rather than
+            // routing Enter (whose tab meaning is "open info"). Every other tab's
+            // filter just narrows a loaded list, so their commit is a pure no-op.
+            if (a.active == .search) return search.searchCmd(allocator, mt_path, &a.states.search);
         },
         .esc => { // cancel: clear the filter
             activeChrome(a).filter.clear();
@@ -205,19 +211,22 @@ fn stepFilter(a: *App, key: Key) void {
         .ctrl_c => a.quit = true, // always escapes, even mid-edit
         .up, .down, .left, .right, .space, .tab, .page_up, .page_down, .home, .end, .unknown => {},
     }
+    return .none;
 }
 
-fn stepNormal(a: *App, key: Key) void {
+fn stepNormal(allocator: std.mem.Allocator, mt_path: []const u8, a: *App, key: Key) cmd.Cmd {
     // The Installed uninstall guard is modal: while it is up, route every key
     // to the tab so its one-key resolve sees keys this switch would otherwise
     // consume — navigation, tab switches, digits, and `/` then cancel the
     // guard instead of bypassing it.
     if (a.active == .installed and a.states.installed.confirm_uninstall != null) {
         switch (key) {
-            .ctrl_c => a.quit = true,
-            else => routeToTab(a, key),
+            .ctrl_c => {
+                a.quit = true;
+                return .none;
+            },
+            else => return routeToTab(allocator, mt_path, a, key),
         }
-        return;
     }
     switch (key) {
         .ctrl_c => a.quit = true,
@@ -232,19 +241,19 @@ fn stepNormal(a: *App, key: Key) void {
             if (c.len == 1) switch (c.bytes[0]) {
                 'q' => {
                     a.quit = true;
-                    return;
+                    return .none;
                 },
                 '/' => {
                     a.editing = true;
-                    return;
+                    return .none;
                 },
                 '1'...'5' => {
                     if (tab_bar.fromDigit(c.bytes[0])) |t| a.active = t;
-                    return;
+                    return .none;
                 },
                 else => {},
             };
-            routeToTab(a, key); // a domain key (e.g. u/f) belongs to the tab
+            return routeToTab(allocator, mt_path, a, key); // a domain key (e.g. u/f) belongs to the tab
         },
         .enter => {
             // On Search, Enter focuses the query box when there are no results
@@ -252,14 +261,15 @@ fn stepNormal(a: *App, key: Key) void {
             // results are loaded. Every other tab uses Enter as a domain key.
             if (a.active == .search and a.states.search.items.len == 0) {
                 a.editing = true;
-            } else routeToTab(a, key);
+            } else return routeToTab(allocator, mt_path, a, key);
         },
-        .space, .end, .esc => routeToTab(a, key),
+        .space, .end, .esc => return routeToTab(allocator, mt_path, a, key),
         // `end` needs the row count to land on the last row — deferred to the
         // data tab; Esc routes so a tab can close a pane / cancel its guard;
         // `backspace`/`unknown` are inert outside edit mode.
         .backspace, .unknown => {},
     }
+    return .none;
 }
 
 /// Pure render: full-screen clear, then each region painted at its cursor
@@ -443,14 +453,14 @@ fn refusalMessage(r: Refusal) []const u8 {
     };
 }
 
-// Composed from each tab's own effect `Error` set (which already unions the parser
-// errors it can raise) plus the terminal/loop faults — so the hub no longer names
-// any `json/*` parser directly. `classify` below stays exhaustive over the same
-// concrete tags.
+// The terminal/loop/spawn faults the pump and the header count-read can raise.
+// A tab parser's own errors flow back through the interpreter as a `.failed` `Msg`
+// (recoverable, bannered from the `Cmd`'s `fail_op`), never up here — only the
+// count-read's `BadJson` still surfaces directly. `classify` stays exhaustive over
+// these concrete tags.
 pub const RunError = term.TermError || std.mem.Allocator.Error ||
     spawn.ReadError || spawn.InlineError ||
-    installed.Error || outdated.Error || services.Error || doctor.Error || search.Error ||
-    error{ReadFailed};
+    error{ ReadFailed, BadJson };
 
 /// How the event loop treats a run-loop error: a `recoverable` backend fault
 /// becomes an inline banner and the session keeps running; a `fatal` fault
@@ -501,25 +511,6 @@ const TickBind = struct {
         _ = term.takeResized();
         // Best-effort, like paintLoading: a dropped animation frame is cosmetic.
         repaint(b.fd, b.frame, b.allocator, b.app) catch {};
-    }
-};
-
-/// Binds the hub-owned header keg-count refresh into a tab's `ctx.Ctx`. Only the hub
-/// reads the shared count (it stays app/header-side), so it injects the closure here;
-/// a tab that grows the keg set (search's install) fires it through the port without
-/// importing the hub. A failed read banners and is dropped — a stale count is cosmetic
-/// and the mutation already landed.
-const CountRefresh = struct {
-    io: std.Io,
-    allocator: std.mem.Allocator,
-    mt_path: []const u8,
-    shared: *SharedModel,
-    fn call(p: *anyopaque) void {
-        // `p` was set from a `*CountRefresh` in `serviceTab`, so the round-trip is sound.
-        const self: *CountRefresh = @ptrCast(@alignCast(p));
-        // A failed count read already bannered via its errdefer; a stale header count
-        // is cosmetic and the mutation landed, so the error is dropped here.
-        refreshInstalledCount(self.io, self.allocator, self.mt_path, self.shared) catch {};
     }
 };
 
@@ -760,89 +751,162 @@ fn serviceFetches(io: std.Io, allocator: std.mem.Allocator, painter: Painter, fe
     }
 }
 
-/// True when any tab has a pending request that will spawn a DB-mutating inline
-/// child (uninstall, upgrade, service action, doctor --fix, install). A generic fold
-/// over each tab's own `mutates` capability — read-only requests
-/// (detail/info/search/basket toggles) declare `false`, so they do not gate the
-/// pre-mutation drain.
-fn mutationPending(app: *const App) bool {
-    inline for (@typeInfo(Tab).@"enum".fields) |fld| {
-        const tag = @field(Tab, fld.name);
-        if (moduleFor(tag).mutates(&@field(app.states, @tagName(tag)))) return true;
-    }
-    return false;
-}
-
-/// Quiesce every in-flight background audit before an inline mutator opens the
-/// DB. The TUI is the sole DB orchestrator: a live `mt … --json` child still
-/// holds the WAL writer on each open (`initSchema` writes on every connect), so
-/// a mutating child spawned alongside it races the single writer and fails with
-/// `Busy`. Polls only the fetch fds — never the tty — so a queued keystroke
-/// cannot starve the drain into a spin; the spinner still ticks so a cold-cache
-/// audit reads as progress, not a freeze. Best-effort like the teardown reap:
-/// a poll fault reaps the lot rather than leaving a child to outlive the mutation.
-fn drainActiveFetches(io: std.Io, allocator: std.mem.Allocator, painter: Painter, fetches: *Fetches, app: *App, store: *Storages) void {
-    while (anyFetchActive(fetches)) {
-        var fds: [tab_bar.count]std.posix.fd_t = undefined;
-        var tabs: [tab_bar.count]Tab = undefined;
-        var n: usize = 0;
-        var it = fetches.iterator();
-        while (it.next()) |e| if (e.value.*) |*f| {
-            fds[n] = f.fd;
-            tabs[n] = e.key;
-            n += 1;
-        };
-        var pfds_buf: [tab_bar.count]std.posix.pollfd = undefined;
-        const pfds = pfds_buf[0..n];
-        for (fds[0..n], 0..) |fd, i| pfds[i] = .{ .fd = fd, .events = std.posix.POLL.IN, .revents = 0 };
-        const ready = std.posix.poll(pfds, fetch_tick_ms) catch return reapAllFetches(io, allocator, fetches);
-        if (ready == 0) { // tick: animate the spinner so the wait isn't a freeze
-            app.spinner_frame +%= 1;
-            repaint(painter.fd, painter.frame, allocator, app) catch {};
-            continue;
-        }
-        for (0..n) |i| if (pfds[i].revents != 0) drainTabFetch(io, allocator, painter, fetches, app, store, tabs[i]);
-    }
-}
-
-/// Drain the active tab's pending effects after a keypress. Only the active tab's
-/// `step` runs, so only its `service` can have anything to do — dispatched through
-/// the same comptime `moduleFor` switch the render path uses.
-fn service(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, app: *App, store: *Storages) RunError!void {
-    // Sole-orchestrator invariant: quiesce any in-flight audit before an inline
-    // mutator opens the DB, else the two opens race the single WAL writer and the
-    // mutation fails with `Busy`. Read-only turns never drain — navigation stays live.
-    if (anyFetchActive(fetches) and mutationPending(app)) drainActiveFetches(io, allocator, painter, fetches, app, store);
-    switch (app.active) {
-        inline else => |tag| try serviceTab(tag, io, allocator, t, painter, fetches, app),
-    }
-}
-
-/// Route the active tab's post-keypress effects through `moduleFor`: build the
-/// effect ports and call the tab's `service`. Every tab conforms, so the dispatch is
-/// uniform — no per-tab fork.
-fn serviceTab(comptime tag: Tab, io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, app: *App) RunError!void {
-    const M = moduleFor(tag);
-    // The hub owns the shared keg-count read (it stays app/header-side), so bind it
-    // into the ports here; a tab that grows the keg set fires it without importing
-    // the hub. Stack-lived — the `service` call below is synchronous.
-    var count_bind: CountRefresh = .{ .io = io, .allocator = allocator, .mt_path = app.mt_path, .shared = &app.shared };
-    var c: ctx.Ctx = .{
-        .io = io,
-        .allocator = allocator,
-        .term = t,
-        .painter = painter,
-        .fetches = fetches,
-        .shared = &app.shared,
-        .mt_path = app.mt_path,
-        .loading = &app.loading,
-        .refresh_installed_count = .{ .ctx = &count_bind, .call = CountRefresh.call },
+/// Quiesce every in-flight background audit before an inline mutation opens the
+/// DB. The TUI is the sole DB orchestrator: a live `mt … --json` child holds the
+/// WAL writer on each open (`initSchema` writes on connect), so a mutating child
+/// spawned alongside it races the single writer and fails with `Busy`.
+///
+/// Crucially this *kills* each audit without applying its payload, rather than
+/// waiting for it and swapping in the result: the pending mutation's argv borrows
+/// the active tab's parse storage (the checked rows / selected name), which an
+/// apply-swap would free while the argv still points into it. Killing also avoids
+/// blocking the mutation behind a slow cold-cache audit. Each reaped tab is
+/// re-marked dirty so its audit re-runs afterwards; the storage is left intact, so
+/// the mutation acts on exactly the rows the user saw.
+fn quiesceFetches(io: std.Io, allocator: std.mem.Allocator, fetches: *Fetches, app: *App) void {
+    var it = fetches.iterator();
+    while (it.next()) |e| if (e.value.*) |*f| {
+        reapTabFetch(io, allocator, f); // kill + reap (closes the DB connection) + free the buffer
+        e.value.* = null;
+        app.tab_loading.remove(e.key);
+        app.shared.dirty.insert(e.key); // re-audit after the mutation, off the intact storage
     };
-    try M.service(&@field(app.states, @tagName(tag)), &@field(app.storages, @tagName(tag)), &c);
-    // The lazy background (re)load stays loop machinery: kick the tab's audit on
-    // first entry / after a mutation marked it dirty. A tab without a fetch spec is
-    // skipped (its lazy-load, if any, is its own concern inside `service`).
-    if (M.fetch_spec != null and takeDirty(app, tag)) startTabFetch(io, allocator, fetches, app, tag);
+}
+
+// ── The Cmd/Msg pump (temporary shim over the phase-1 spawn/mux machinery) ──
+// `step` → `Cmd` → `perform` → `Msg` → `update` → `Cmd`, until `Cmd.none`. A later
+// pass generalizes this into one domain-agnostic `perform(cmd)` and folds it into
+// the loop; for now it performs each variant with the existing `spawn` helpers and
+// routes the result to the active tab's `update`.
+
+/// Free a `Cmd`'s heap argv once it is performed — the ownership contract: the tab
+/// (in `step`/`update`) builds the argv, the interpreter frees the slice (never its
+/// elements, which borrow parse storage).
+fn freeCmdArgv(allocator: std.mem.Allocator, c: cmd.Cmd) void {
+    switch (c) {
+        .read => |r| allocator.free(r.argv),
+        .run_mutation => |m| allocator.free(m.argv),
+        .none, .batch => {},
+    }
+}
+
+/// Route a `Msg` to the active tab's `update` — the same comptime `moduleFor`
+/// switch the render path uses. The active tab is stable across a synchronous pump
+/// cycle (no input is read mid-chain), and every pump `Cmd` was produced for it, so
+/// the `Parsed` member always matches the tab.
+fn updateActive(allocator: std.mem.Allocator, app: *App, store: *Storages, msg: cmd.Msg) cmd.Cmd {
+    switch (app.active) {
+        inline else => |t| return moduleFor(t).update(allocator, app.mt_path, &@field(app.states, @tagName(t)), &@field(store, @tagName(t)), &app.shared, msg),
+    }
+}
+
+/// Perform one `Cmd`, returning the `Msg` to fold back. A recoverable fault sets the
+/// banner from the `Cmd`'s `fail_op` and returns `.failed`/`.mutated`; only a fatal
+/// (terminal/OOM) fault propagates. `.none`/`.batch` never reach here.
+fn perform(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, app: *App, c: cmd.Cmd) RunError!cmd.Msg {
+    switch (c) {
+        .none, .batch => unreachable, // the pump never performs these; no tab emits a batch
+        .read => |r| return performRead(io, allocator, painter, app, r),
+        .run_mutation => |m| return performMutation(io, allocator, t, fetches, app, m),
+    }
+}
+
+/// Perform a `read`: paint the pre-read status, capture `mt … --json`, and parse it
+/// with the `Cmd`'s carried parser. An `allow_empty` empty read is `.cleared`; a
+/// recoverable read/parse fault banners and is `.failed`; a fatal fault propagates.
+fn performRead(io: std.Io, allocator: std.mem.Allocator, painter: Painter, app: *App, r: cmd.Cmd.Read) RunError!cmd.Msg {
+    // Paint before the blocking freeze so it reads as intentional. Search shows its
+    // own "searching…" via `phase`; the others get the "Loading…" footer.
+    const show_loading = r.tag != .search;
+    if (show_loading) app.loading = true;
+    repaint(painter.fd, painter.frame, allocator, app) catch {};
+    if (show_loading) app.loading = false;
+
+    const bytes: ?[]u8 = readBytes(io, allocator, painter, app, r) catch |err| switch (classify(err)) {
+        .fatal => return err,
+        .recoverable => {
+            app.shared.banner.set(r.fail_op, @errorName(err));
+            return .failed;
+        },
+    };
+    const payload = bytes orelse return .cleared; // an exit-0 empty read
+    defer allocator.free(payload);
+    const parsed = r.parse(allocator, payload) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory; // fatal
+        app.shared.banner.set(r.fail_op, @errorName(err));
+        return .failed;
+    };
+    return .{ .loaded = parsed };
+}
+
+/// The read-mode dispatch over the phase-1 `spawn` readers. Blocking non-empty is
+/// `readJson`; blocking empty-ok is `readJsonAllowEmpty`; polled is spinner-animated
+/// via the painter. `background` never reaches here — those go through `startTabFetch`.
+fn readBytes(io: std.Io, allocator: std.mem.Allocator, painter: Painter, app: *App, r: cmd.Cmd.Read) spawn.ReadError!?[]u8 {
+    return switch (r.mode) {
+        .blocking => if (r.allow_empty) spawn.readJsonAllowEmpty(io, allocator, r.argv) else @as(?[]u8, try spawn.readJson(io, allocator, r.argv)),
+        .polled => blk: {
+            // Keep `loading` set across the poll so each tick paints the spinner.
+            app.loading = true;
+            defer app.loading = false;
+            break :blk try spawn.readJsonPolled(io, allocator, r.argv, r.max_ok_exit, painter);
+        },
+        .background => unreachable,
+    };
+}
+
+/// Perform a `run_mutation`: quiesce background audits (the WAL single-writer
+/// invariant), re-exec `mt` inline, and return the child's exit code as `.mutated`
+/// for the tab's `update` to judge. A spawn/re-enter fault banners and is `.failed`;
+/// a terminal fault propagates.
+fn performMutation(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, fetches: *Fetches, app: *App, m: cmd.Cmd.Mutation) RunError!cmd.Msg {
+    // Sole-orchestrator invariant: a live `mt … --json` child holds the WAL writer,
+    // so a mutating child spawned alongside it races and fails `Busy`. Quiesce first.
+    if (anyFetchActive(fetches)) quiesceFetches(io, allocator, fetches, app);
+    const code = spawn.runInlineReenterStatus(t, m.argv) catch |err| switch (classify(err)) {
+        .fatal => return err,
+        .recoverable => {
+            app.shared.banner.set(m.fail_op, @errorName(err));
+            return .failed;
+        },
+    };
+    return .{ .mutated = code };
+}
+
+/// Drive one `Cmd` chain to completion: perform → fold → repeat until `Cmd.none`.
+/// The interpreter frees each performed argv; a successful Search-tab mutation grows
+/// the keg set while Installed is off-tab, so the header count is refreshed eagerly.
+fn pump(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, app: *App, store: *Storages, initial: cmd.Cmd) RunError!void {
+    var c = initial;
+    while (c != .none) {
+        const performed = c;
+        const msg = perform(io, allocator, t, painter, fetches, app, performed) catch |err| {
+            freeCmdArgv(allocator, performed);
+            return err;
+        };
+        if (performed == .run_mutation and performed.run_mutation.tag == .search)
+            // Installed won't lazy-reload while off-tab, so keep `<n> kegs` live now.
+            refreshInstalledCount(io, allocator, app.mt_path, &app.shared) catch {};
+        freeCmdArgv(allocator, performed);
+        c = updateActive(allocator, app, store, msg);
+    }
+}
+
+/// After the keypress chain, the active tab's lazy on-entry (re)load if it is dirty:
+/// a background-fetch tab kicks its audit (loop machinery); a synchronous tab that
+/// exposes `refreshCmd` (Installed) pumps its read now. Search declares neither, so
+/// entering it never triggers a surprise remote read.
+fn onEntryReload(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, app: *App, store: *Storages) RunError!void {
+    switch (app.active) {
+        inline else => |tag| {
+            const M = moduleFor(tag);
+            if (M.fetch_spec != null) {
+                if (takeDirty(app, tag)) startTabFetch(io, allocator, fetches, app, tag);
+            } else if (@hasDecl(M, "refreshCmd")) {
+                if (takeDirty(app, tag)) try pump(io, allocator, t, painter, fetches, app, store, M.refreshCmd(allocator, app.mt_path));
+            }
+        },
+    }
 }
 
 fn isTty(io: std.Io, fd: std.posix.fd_t) bool {
@@ -994,45 +1058,20 @@ fn ttyReadable(fd: std.posix.fd_t, timeout_ms: i32) bool {
     return n > 0;
 }
 
-/// One decoded key's full turn: pure step, the pre-spawn status paints, then
-/// the requested effects with the recoverable/fatal split. Shared by the
-/// streaming decode path and the timeout-flushed lone Esc so both behave
-/// identically.
+/// One decoded key's full turn: `step` yields the active tab's `Cmd`, the pump
+/// performs it and folds the `Msg` chain back, then the tab's lazy on-entry reload
+/// runs. Shared by the streaming decode path and the timeout-flushed lone Esc so
+/// both behave identically. A recoverable fault is already a banner (set by the
+/// interpreter from the `Cmd`'s `fail_op`); only a fatal fault propagates to the
+/// errdefer restore + exit.
 fn serviceKey(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, app: *App, store: *Storages, key: Key) RunError!void {
-    app.* = step(app.*, key); // also clears any prior banner
-    if (app.quit) return;
-    paintSearching(painter.fd, painter.frame, allocator, app); // status before the blocking search
-    paintLoading(painter.fd, painter.frame, allocator, app); // "Loading…" before a blocking lazy refetch
-    // A recoverable backend fault becomes the banner the failing op already
-    // set and the loop continues; only a fatal fault (terminal/OOM)
-    // propagates to the errdefer restore + exit.
-    service(io, allocator, t, painter, fetches, app, store) catch |err| switch (classify(err)) {
-        .recoverable => {},
-        .fatal => return err,
-    };
-}
-
-/// Search is the dashboard's first remote read: when the user commits a query,
-/// flip the phase and repaint a "searching…" status *before* the blocking call,
-/// so the synchronous freeze isn't a dead terminal. The only tab-specific paint
-/// in the otherwise tab-agnostic loop, earned by that first-remote-read cost.
-/// Best-effort: a paint failure just means the real read's repaint follows.
-fn paintSearching(fd: std.posix.fd_t, frame: *[]u8, allocator: std.mem.Allocator, app: *App) void {
-    if (app.active != .search or app.states.search.request != .search) return;
-    if (app.states.search.chrome.filter.slice().len == 0) return; // empty query: no spawn
-    app.states.search.phase = .searching;
-    repaint(fd, frame, allocator, app) catch {};
-}
-
-/// Before the active tab runs a blocking lazy refetch (it is dirty and will
-/// refetch on entry), paint a "Loading…" footer so the synchronous read reads as
-/// intentional, not a frozen or — before stderr was suppressed — garbled frame.
-/// Best-effort, like `paintSearching`; the read's own repaint draws the result.
-fn paintLoading(fd: std.posix.fd_t, frame: *[]u8, allocator: std.mem.Allocator, app: *App) void {
-    if (!app.shared.dirty.contains(app.active)) return; // nothing will refetch this turn
-    app.loading = true;
-    repaint(fd, frame, allocator, app) catch {};
-    app.loading = false;
+    const c = step(allocator, app.mt_path, app, key); // mutates nav/editing in place; clears the banner
+    if (app.quit) {
+        freeCmdArgv(allocator, c); // a quit key can still return a stray Cmd (it won't)
+        return;
+    }
+    try pump(io, allocator, t, painter, fetches, app, store, c);
+    try onEntryReload(io, allocator, t, painter, fetches, app, store);
 }
 
 fn repaint(fd: std.posix.fd_t, frame: *[]u8, allocator: std.mem.Allocator, app: *App) std.mem.Allocator.Error!void {
@@ -1046,6 +1085,12 @@ fn repaint(fd: std.posix.fd_t, frame: *[]u8, allocator: std.mem.Allocator, app: 
 
 fn ch(c: u8) Key {
     return .{ .char = .{ .bytes = .{ c, 0, 0, 0 }, .len = 1 } };
+}
+
+/// Drive `step` in place for a nav/editing test and free any effect argv it
+/// produces — these tests assert on the resulting `App` state, not the `Cmd`.
+fn stepA(a: *App, key: Key) void {
+    freeCmdArgv(std.testing.allocator, step(std.testing.allocator, a.mt_path, a, key));
 }
 
 /// A no-op paint handle for unit tests that drive a lazy loader directly: the
@@ -1067,44 +1112,44 @@ test "a data-free App renders the full chrome so the skeleton paint is real" {
 test "tab cycles and 1-5 jump to a tab" {
     var a: App = .{};
     try std.testing.expectEqual(Tab.search, a.active); // the dashboard opens on Search
-    a = step(a, .tab);
+    stepA(&a, .tab);
     try std.testing.expectEqual(Tab.installed, a.active);
-    a = step(a, ch('3'));
+    stepA(&a, ch('3'));
     try std.testing.expectEqual(Tab.outdated, a.active);
-    a = step(a, ch('1'));
+    stepA(&a, ch('1'));
     try std.testing.expectEqual(Tab.search, a.active);
 }
 
 test "left and right arrows switch tabs both directions and wrap" {
     var a: App = .{};
-    a = step(a, .right);
+    stepA(&a, .right);
     try std.testing.expectEqual(Tab.installed, a.active);
-    a = step(a, .left);
+    stepA(&a, .left);
     try std.testing.expectEqual(Tab.search, a.active);
-    a = step(a, .left); // wrap backward to the last tab
+    stepA(&a, .left); // wrap backward to the last tab
     try std.testing.expectEqual(Tab.doctor, a.active);
 }
 
 test "a committed filter survives a tab round-trip" {
     var a: App = .{};
-    a = step(a, ch('/')); // enter filter mode
+    stepA(&a, ch('/')); // enter filter mode
     try std.testing.expect(a.editing);
-    a = step(a, ch('w'));
-    a = step(a, ch('g'));
-    a = step(a, .enter); // commit
+    stepA(&a, ch('w'));
+    stepA(&a, ch('g'));
+    stepA(&a, .enter); // commit
     try std.testing.expect(!a.editing);
-    a = step(a, .tab); // leave the tab
-    a = step(a, .tab);
-    a = step(a, .tab);
-    a = step(a, .tab);
-    a = step(a, .tab); // and come back (five tabs now)
+    stepA(&a, .tab); // leave the tab
+    stepA(&a, .tab);
+    stepA(&a, .tab);
+    stepA(&a, .tab);
+    stepA(&a, .tab); // and come back (five tabs now)
     try std.testing.expectEqualStrings("wg", activeFilterText(&a));
 }
 
 test "esc in normal mode routes to the active tab so it can cancel its guard" {
     var a: App = .{ .active = .installed };
     a.states.installed.confirm_uninstall = installed.ConfirmTarget.init("curl");
-    a = step(a, .esc); // not editing → must reach the tab, which lowers the guard
+    stepA(&a, .esc); // not editing → must reach the tab, which lowers the guard
     try std.testing.expect(a.states.installed.confirm_uninstall == null);
 }
 
@@ -1149,20 +1194,20 @@ const guard_pkgs = [_]installed.Pkg{
 test "navigation while the uninstall guard is up cancels it instead of retargeting" {
     var a: App = .{ .active = .installed };
     a.states.installed.items = &guard_pkgs;
-    a = step(a, ch('x')); // arm on pkga (row 0)
+    stepA(&a, ch('x')); // arm on pkga (row 0)
     try std.testing.expect(a.states.installed.confirm_uninstall != null);
-    a = step(a, .down); // modal: the key resolves the guard (cancel), not the list
+    stepA(&a, .down); // modal: the key resolves the guard (cancel), not the list
     try std.testing.expect(a.states.installed.confirm_uninstall == null);
-    a = step(a, ch('y')); // no longer a confirmation — must not request an uninstall
-    try std.testing.expect(a.states.installed.request == .none);
+    stepA(&a, ch('y')); // no longer a confirmation — must not spawn an uninstall
+    try std.testing.expect(a.states.installed.pending_uninstall == null);
     try std.testing.expectEqual(@as(usize, 0), a.states.installed.chrome.view.selected);
 }
 
 test "q while the uninstall guard is up cancels it instead of quitting" {
     var a: App = .{ .active = .installed };
     a.states.installed.items = &guard_pkgs;
-    a = step(a, ch('x'));
-    a = step(a, ch('q'));
+    stepA(&a, ch('x'));
+    stepA(&a, ch('q'));
     try std.testing.expect(!a.quit); // the guard consumed the key
     try std.testing.expect(a.states.installed.confirm_uninstall == null);
 }
@@ -1170,8 +1215,8 @@ test "q while the uninstall guard is up cancels it instead of quitting" {
 test "slash while the uninstall guard is up cancels it instead of opening the filter" {
     var a: App = .{ .active = .installed };
     a.states.installed.items = &guard_pkgs;
-    a = step(a, ch('x'));
-    a = step(a, ch('/'));
+    stepA(&a, ch('x'));
+    stepA(&a, ch('/'));
     try std.testing.expect(!a.editing);
     try std.testing.expect(a.states.installed.confirm_uninstall == null);
 }
@@ -1179,82 +1224,86 @@ test "slash while the uninstall guard is up cancels it instead of opening the fi
 test "tab switch while the uninstall guard is up resolves the guard, not the tab bar" {
     var a: App = .{ .active = .installed };
     a.states.installed.items = &guard_pkgs;
-    a = step(a, ch('x'));
-    a = step(a, .tab);
+    stepA(&a, ch('x'));
+    stepA(&a, .tab);
     try std.testing.expect(a.states.installed.confirm_uninstall == null); // never left armed
     try std.testing.expectEqual(Tab.installed, a.active); // the key was consumed by the guard
 }
 
 test "esc clears the filter and leaves edit mode" {
     var a: App = .{};
-    a = step(a, ch('/'));
-    a = step(a, ch('x'));
-    a = step(a, .esc);
+    stepA(&a, ch('/'));
+    stepA(&a, ch('x'));
+    stepA(&a, .esc);
     try std.testing.expect(!a.editing);
     try std.testing.expectEqualStrings("", activeFilterText(&a));
 }
 
 test "backspace edits the active filter while typing" {
     var a: App = .{};
-    a = step(a, ch('/'));
-    a = step(a, ch('a'));
-    a = step(a, ch('b'));
-    a = step(a, .backspace);
+    stepA(&a, ch('/'));
+    stepA(&a, ch('a'));
+    stepA(&a, ch('b'));
+    stepA(&a, .backspace);
     try std.testing.expectEqualStrings("a", activeFilterText(&a));
 }
 
 test "q and ctrl_c request quit" {
-    const a: App = .{};
-    try std.testing.expect(step(a, ch('q')).quit);
-    try std.testing.expect(step(a, .ctrl_c).quit);
+    var a: App = .{};
+    stepA(&a, ch('q'));
+    try std.testing.expect(a.quit);
+    var b: App = .{};
+    stepA(&b, .ctrl_c);
+    try std.testing.expect(b.quit);
 }
 
 test "down increments the selection, up saturates at zero" {
     var a: App = .{};
-    a = step(a, .down);
-    a = step(a, .down);
+    stepA(&a, .down);
+    stepA(&a, .down);
     try std.testing.expectEqual(@as(usize, 2), activeChrome(&a).view.selected);
-    a = step(a, .up);
-    a = step(a, .up);
-    a = step(a, .up);
+    stepA(&a, .up);
+    stepA(&a, .up);
+    stepA(&a, .up);
     try std.testing.expectEqual(@as(usize, 0), activeChrome(&a).view.selected);
 }
 
 test "page keys jump by a page and saturate; home returns to the top" {
     var a: App = .{};
-    a = step(a, .page_down);
+    stepA(&a, .page_down);
     try std.testing.expectEqual(@as(usize, page_step), activeChrome(&a).view.selected);
-    a = step(a, .page_up);
-    a = step(a, .page_up); // already at 0 → saturates, no underflow
+    stepA(&a, .page_up);
+    stepA(&a, .page_up); // already at 0 → saturates, no underflow
     try std.testing.expectEqual(@as(usize, 0), activeChrome(&a).view.selected);
-    a = step(a, .down);
-    a = step(a, .down);
-    a = step(a, .home);
+    stepA(&a, .down);
+    stepA(&a, .down);
+    stepA(&a, .home);
     try std.testing.expectEqual(@as(usize, 0), activeChrome(&a).view.selected);
 }
 
 test "a non-command printable key in normal mode is inert (routed, no state change)" {
-    const a: App = .{};
-    const b = step(a, ch('z')); // not q / 1-4 / /
-    try std.testing.expectEqual(a.active, b.active);
+    var b: App = .{};
+    stepA(&b, ch('z')); // not q / 1-4 / /
+    try std.testing.expectEqual(Tab.search, b.active);
     try std.testing.expect(!b.editing);
     try std.testing.expect(!b.quit);
 }
 
 test "per-tab filters are independent across tabs" {
     var a: App = .{};
-    a = step(a, ch('/'));
-    a = step(a, ch('a')); // installed filter = "a"
-    a = step(a, .enter);
-    a = step(a, .tab); // outdated
+    stepA(&a, ch('/'));
+    stepA(&a, ch('a')); // installed filter = "a"
+    stepA(&a, .enter);
+    stepA(&a, .tab); // outdated
     try std.testing.expectEqualStrings("", activeFilterText(&a)); // its own empty filter
 }
 
 test "Enter on the Search tab focuses the query box rather than firing an empty search" {
     var a: App = .{ .active = .search };
-    a = step(a, .enter);
+    const c = step(std.testing.allocator, a.mt_path, &a, .enter);
+    defer freeCmdArgv(std.testing.allocator, c);
     try std.testing.expect(a.editing); // the query box is now focused for typing
-    try std.testing.expectEqual(search.Request.none, a.states.search.request); // no search fired yet
+    try std.testing.expect(c == .none); // no search fired yet
 }
 
 test "Enter on the Search tab opens info once results are loaded" {
@@ -1262,24 +1311,28 @@ test "Enter on the Search tab opens info once results are loaded" {
     var a: App = .{ .active = .search };
     a.states.search.items = &items;
     a.states.search.phase = .loaded;
-    a = step(a, .enter);
+    const c = step(std.testing.allocator, a.mt_path, &a, .enter);
+    defer freeCmdArgv(std.testing.allocator, c);
     try std.testing.expect(!a.editing); // a row is active, so Enter inspects it, not the box
-    try std.testing.expectEqual(search.Request.info, a.states.search.request);
+    try std.testing.expect(c == .read); // the `mt info` read for the active hit
+    try std.testing.expectEqualStrings("info", c.read.argv[1]);
 }
 
 test "Enter on a data tab still routes as that tab's domain key, not a focus" {
     var a: App = .{ .active = .installed };
-    a = step(a, .enter);
+    a.states.installed.items = &guard_pkgs;
+    const c = step(std.testing.allocator, a.mt_path, &a, .enter);
+    defer freeCmdArgv(std.testing.allocator, c);
     try std.testing.expect(!a.editing);
-    try std.testing.expect(a.states.installed.request == .open_detail);
+    try std.testing.expect(c == .read); // installed Enter opens the `mt info` detail read
 }
 
 test "renderFrame shows the committed filter and the editing footer" {
     var a: App = .{};
-    a = step(a, ch('2')); // Installed tab: its box is a filter over the loaded list
-    a = step(a, ch('/'));
-    a = step(a, ch('j'));
-    a = step(a, ch('q')); // 'q' is a literal char while editing, not quit
+    stepA(&a, ch('2')); // Installed tab: its box is a filter over the loaded list
+    stepA(&a, ch('/'));
+    stepA(&a, ch('j'));
+    stepA(&a, ch('q')); // 'q' is a literal char while editing, not quit
     try std.testing.expect(!a.quit);
     var buf: [8192]u8 = undefined;
     const out = renderFrame(&buf, &a, 80, 24);
@@ -1289,9 +1342,9 @@ test "renderFrame shows the committed filter and the editing footer" {
 
 test "the Search tab labels its input box as a query, not a filter" {
     var a: App = .{ .active = .search };
-    a = step(a, ch('/'));
-    a = step(a, ch('r'));
-    a = step(a, ch('g'));
+    stepA(&a, ch('/'));
+    stepA(&a, ch('r'));
+    stepA(&a, ch('g'));
     var buf: [8192]u8 = undefined;
     const out = renderFrame(&buf, &a, 80, 24);
     try std.testing.expect(std.mem.indexOf(u8, out, "search: rg_") != null);
@@ -1590,105 +1643,46 @@ test "a malformed payload banners and keeps the outdated count unknown, never ze
     try std.testing.expectEqualStrings("outdated refresh failed: BadJson", app.shared.banner.slice());
 }
 
-test "mutationPending gates only on requests that spawn a DB-mutating child" {
-    var app: App = .{};
-    try std.testing.expect(!mutationPending(&app)); // all .none
-
-    // Read-only requests never take the WAL writer, so they must not gate.
-    app.states.installed.request = .open_detail;
-    app.states.search.request = .info;
-    try std.testing.expect(!mutationPending(&app));
-
-    // Each mutating request, in isolation, gates the drain.
-    app = .{};
-    app.states.installed.request = .{ .uninstall = installed.ConfirmTarget.init("wget") };
-    try std.testing.expect(mutationPending(&app));
-    app = .{};
-    app.states.outdated.request = .upgrade;
-    try std.testing.expect(mutationPending(&app));
-    app = .{};
-    app.states.services.request = .restart;
-    try std.testing.expect(mutationPending(&app));
-    app = .{};
-    app.states.doctor.request = .fix;
-    try std.testing.expect(mutationPending(&app));
-    app = .{};
-    app.states.search.request = .install;
-    try std.testing.expect(mutationPending(&app));
-}
-
-test "drainActiveFetches reaps every in-flight audit and lands its payload" {
+test "quiesceFetches kills an in-flight audit and re-marks it dirty, leaving storage intact" {
     var t = std.Io.Threaded.init(std.testing.allocator, .{});
     defer t.deinit();
-    const child = try std.process.spawn(t.io(), .{
-        .argv = &.{ "/bin/echo", "{\"outdated\":[{\"name\":\"wget\",\"installed\":\"1\",\"latest\":\"2\",\"type\":\"formula\",\"pinned\":false}]}" },
-        .stdout = .pipe,
-        .stderr = .ignore,
-    });
-    var app: App = .{};
+    // A slow child so the audit is genuinely in flight (never drained) when killed —
+    // the case where the pending mutation's argv still borrows the live storage.
+    const child = try std.process.spawn(t.io(), .{ .argv = &.{ "/bin/sleep", "5" }, .stdout = .pipe, .stderr = .ignore });
+    var app: App = .{ .shared = .{ .outdated_count = 7 } }; // a prior good count
     app.tab_loading.insert(.outdated);
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
     var fetches: Fetches = .initFill(null);
     fetches.set(.outdated, .{ .tab = .outdated, .child = child, .fd = child.stdout.?.handle, .max_ok_exit = 0 });
-    var frame: []u8 = try std.testing.allocator.alloc(u8, 256);
-    defer std.testing.allocator.free(frame);
 
-    drainActiveFetches(t.io(), std.testing.allocator, testPainter(&frame), &fetches, &app, &store);
+    quiesceFetches(t.io(), std.testing.allocator, &fetches, &app);
 
-    try std.testing.expect(!anyFetchActive(&fetches)); // the audit closed its DB connection
-    try std.testing.expectEqual(@as(?usize, 1), app.shared.outdated_count); // payload still landed
+    try std.testing.expect(!anyFetchActive(&fetches)); // the writer is released for the mutation
+    try std.testing.expect(!app.tab_loading.contains(.outdated)); // no longer flagged loading
+    try std.testing.expect(app.shared.dirty.contains(.outdated)); // re-audit after the mutation
+    // The audit is *not* applied: storage is untouched, so the mutation's argv (which
+    // borrows those rows) cannot dangle. A wait-and-apply drain would swap it to 1.
+    try std.testing.expectEqual(@as(?usize, 7), app.shared.outdated_count);
 }
 
-// The sole-orchestrator guard: with an audit in flight, a mutating dispatch must
-// drain it first so the inline child never opens the DB beside a live writer.
-// The mutation no-ops on an empty selection, so no child is spawned — the test
-// asserts only the quiescing, which is the falsifiable invariant.
+// The sole-orchestrator guard is a straight-line call in `performMutation` (quiesce,
+// then re-exec). A read-only turn produces no `run_mutation` `Cmd`, so it never
+// reaches the quiesce; only a mutation does.
 test "service quiesces an in-flight audit before a mutating dispatch" {
     var t = std.Io.Threaded.init(std.testing.allocator, .{});
     defer t.deinit();
-    const child = try std.process.spawn(t.io(), .{
-        .argv = &.{ "/bin/echo", "{\"outdated\":[{\"name\":\"wget\",\"installed\":\"1\",\"latest\":\"2\",\"type\":\"formula\",\"pinned\":false}]}" },
-        .stdout = .pipe,
-        .stderr = .ignore,
-    });
-    var app: App = .{};
-    app.tab_loading.insert(.outdated);
-    app.states.outdated.request = .upgrade; // a mutating request, but nothing is checked → no spawn
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
-    var fetches: Fetches = .initFill(null);
-    fetches.set(.outdated, .{ .tab = .outdated, .child = child, .fd = child.stdout.?.handle, .max_ok_exit = 0 });
-    var frame: []u8 = try std.testing.allocator.alloc(u8, 256);
-    defer std.testing.allocator.free(frame);
-    var tm = term.Term.init(t.io(), -1);
-
-    try service(t.io(), std.testing.allocator, &tm, testPainter(&frame), &fetches, &app, &store);
-
-    try std.testing.expect(!anyFetchActive(&fetches)); // drained before the dispatch
-    try std.testing.expect(!app.shared.banner.isSet()); // a clean drain, no upgrade failure
-}
-
-test "service leaves an in-flight audit running when no mutation is pending" {
-    var t = std.Io.Threaded.init(std.testing.allocator, .{});
-    defer t.deinit();
-    // `sleep` keeps the fetch genuinely in flight across the call; a read-only
-    // turn must not block on it.
     const child = try std.process.spawn(t.io(), .{ .argv = &.{ "/bin/sleep", "5" }, .stdout = .pipe, .stderr = .ignore });
     var app: App = .{};
-    app.tab_loading.insert(.outdated); // no request set → nothing mutating
-    var store: Storages = .{};
-    defer store.deinit(std.testing.allocator);
+    app.tab_loading.insert(.outdated);
     var fetches: Fetches = .initFill(null);
     fetches.set(.outdated, .{ .tab = .outdated, .child = child, .fd = child.stdout.?.handle, .max_ok_exit = 0 });
-    var frame: []u8 = try std.testing.allocator.alloc(u8, 256);
-    defer std.testing.allocator.free(frame);
     var tm = term.Term.init(t.io(), -1);
 
-    try service(t.io(), std.testing.allocator, &tm, testPainter(&frame), &fetches, &app, &store);
+    // The re-exec re-enter faults on the headless (-1) term, but the quiesce runs
+    // *first*; assert the audit was killed regardless of the mutation's outcome.
+    const m: cmd.Cmd.Mutation = .{ .argv = &.{"/usr/bin/true"}, .tag = .outdated };
+    _ = performMutation(t.io(), std.testing.allocator, &tm, &fetches, &app, m) catch {};
 
-    try std.testing.expect(anyFetchActive(&fetches)); // untouched: navigation never blocks on an audit
-    reapAllFetches(t.io(), std.testing.allocator, &fetches); // tidy the still-running child
+    try std.testing.expect(!anyFetchActive(&fetches)); // quiesced before the dispatch
 }
 
 test "a non-zero child exit fails the fetch without parsing a half-written doc" {
@@ -1814,7 +1808,7 @@ test "any keypress clears a transient banner" {
     var a: App = .{};
     a.shared.banner.set("uninstall failed", "ChildFailed");
     try std.testing.expect(a.shared.banner.isSet());
-    a = step(a, .down); // a navigation key dismisses the stale banner
+    stepA(&a, .down); // a navigation key dismisses the stale banner
     try std.testing.expect(!a.shared.banner.isSet());
 }
 
@@ -2004,30 +1998,34 @@ test "committing the filter fires a search on the Search tab but no domain key e
     // On Search the filter doubles as the search box, so Enter commits *and*
     // requests the read — 'i' typed mid-edit is literal query text, not install.
     var a: App = .{ .active = .search };
-    a = step(a, ch('/'));
-    a = step(a, ch('f'));
-    a = step(a, ch('i'));
-    a = step(a, .enter);
+    stepA(&a, ch('/'));
+    stepA(&a, ch('f'));
+    stepA(&a, ch('i'));
+    const c = step(std.testing.allocator, a.mt_path, &a, .enter); // commit → the search read
+    defer freeCmdArgv(std.testing.allocator, c);
     try std.testing.expect(!a.editing);
-    try std.testing.expectEqual(search.Request.search, a.states.search.request);
+    try std.testing.expect(c == .read); // committing the query *is* the search
+    try std.testing.expectEqualStrings("search", c.read.argv[1]);
+    try std.testing.expectEqual(search.Phase.searching, a.states.search.phase); // flipped for the paint
     try std.testing.expectEqualStrings("fi", activeFilterText(&a));
 
     // The same commit on a non-search tab must not be routed to its domain key
-    // (outdated's Enter would otherwise request an upgrade).
+    // (outdated's Enter would otherwise fire an upgrade); the commit is a pure no-op.
     var b: App = .{ .active = .outdated };
-    b = step(b, ch('/'));
-    b = step(b, ch('x'));
-    b = step(b, .enter);
+    stepA(&b, ch('/'));
+    stepA(&b, ch('x'));
+    const bc = step(std.testing.allocator, b.mt_path, &b, .enter);
+    defer freeCmdArgv(std.testing.allocator, bc);
     try std.testing.expect(!b.editing);
-    try std.testing.expectEqual(outdated.Request.none, b.states.outdated.request);
+    try std.testing.expect(bc == .none); // no effect from committing a filter
 }
 
 test "the 1 key jumps to the Search tab, the 5 key to Doctor" {
     var a: App = .{};
-    a = step(a, .tab); // move off Search first
-    a = step(a, ch('1'));
+    stepA(&a, .tab); // move off Search first
+    stepA(&a, ch('1'));
     try std.testing.expectEqual(Tab.search, a.active);
-    a = step(a, ch('5'));
+    stepA(&a, ch('5'));
     try std.testing.expectEqual(Tab.doctor, a.active);
 }
 

--- a/src/tui/cmd.zig
+++ b/src/tui/cmd.zig
@@ -99,6 +99,10 @@ pub const Cmd = union(enum) {
         mode: Mode,
         parse: ParseFn,
         tag: MsgTag,
+        /// Banner op for a recoverable read fault (bad exit, empty, parse error).
+        /// The tab authors it so the interpreter needs no per-tab knowledge; the
+        /// last-good model is kept behind it.
+        fail_op: []const u8 = "refresh failed",
     };
 
     pub const Mutation = struct {
@@ -106,6 +110,9 @@ pub const Cmd = union(enum) {
         /// Highest child exit still a success — e.g. `mt doctor --fix`'s severity.
         max_ok_exit: u8 = 0,
         tag: MsgTag,
+        /// Banner op for a recoverable spawn/re-enter fault (not a non-zero child
+        /// exit, which flows back as `.mutated` for the tab's `update` to judge).
+        fail_op: []const u8 = "action failed",
     };
 };
 
@@ -113,13 +120,66 @@ pub const Cmd = union(enum) {
 pub const Msg = union(enum) {
     /// A read completed: the parsed document, typed by its union member.
     loaded: Parsed,
+    /// An `allow_empty` read returned an exit-0 empty document (a fresh prefix
+    /// with no db): the tab clears to its known-zero state, no parse to fold.
+    cleared,
     /// A mutation completed with this child exit code. 0 is success; a tolerated
     /// non-zero (Doctor's severity, the cask app-running refusal) is the owning
     /// tab's to interpret.
     mutated: u8,
+    /// A read faulted recoverably (bad exit, parse error). The interpreter has
+    /// already set the recoverable banner from the `Cmd`'s `fail_op`; this lets the
+    /// tab undo any pre-effect state it set (e.g. Search leaving `searching`). The
+    /// last-good model is kept; a fatal fault propagates instead of arriving here.
+    failed,
 };
 
+/// Build `[mt_path, tail...]` — a mutation `Cmd`'s argv, letting a tab name a
+/// `mt <sub>` without importing the runner. Strings are borrowed from the caller;
+/// only the returned slice is owned (the interpreter frees it, not its elements).
+pub fn inlineArgv(
+    allocator: Allocator,
+    mt_path: []const u8,
+    tail: []const []const u8,
+) Allocator.Error![]const []const u8 {
+    const argv = try allocator.alloc([]const u8, 1 + tail.len);
+    argv[0] = mt_path;
+    @memcpy(argv[1..], tail);
+    return argv;
+}
+
+/// Build `[mt_path, tail..., "--json"]` — a read `Cmd`'s argv. Same ownership
+/// contract as `inlineArgv`.
+pub fn jsonArgv(
+    allocator: Allocator,
+    mt_path: []const u8,
+    tail: []const []const u8,
+) Allocator.Error![]const []const u8 {
+    const argv = try allocator.alloc([]const u8, 2 + tail.len);
+    argv[0] = mt_path;
+    @memcpy(argv[1 .. 1 + tail.len], tail);
+    argv[argv.len - 1] = "--json";
+    return argv;
+}
+
 // ── tests (written first; the decls above are added to make them pass) ───────
+
+test "inlineArgv prepends the resolved mt path to the subcommand tail" {
+    const argv = try inlineArgv(testing.allocator, "/opt/malt/bin/mt", &.{ "services", "start", "redis" });
+    defer testing.allocator.free(argv);
+    try testing.expectEqual(@as(usize, 4), argv.len);
+    try testing.expectEqualStrings("/opt/malt/bin/mt", argv[0]);
+    try testing.expectEqualStrings("redis", argv[3]);
+}
+
+test "jsonArgv wraps the tail as `mt <tail...> --json`" {
+    const argv = try jsonArgv(testing.allocator, "/bin/mt", &.{ "services", "list" });
+    defer testing.allocator.free(argv);
+    try testing.expectEqual(@as(usize, 4), argv.len);
+    try testing.expectEqualStrings("/bin/mt", argv[0]);
+    try testing.expectEqualStrings("services", argv[1]);
+    try testing.expectEqualStrings("--json", argv[3]);
+}
 
 test "Parsed preserves the active member's tag round-trip" {
     const p = try services_json.parse(testing.allocator, "{\"services\":[]}");
@@ -220,7 +280,7 @@ test "Msg delivers a loaded Parsed and a mutation exit code" {
     const loaded: Msg = .{ .loaded = .{ .services = p } };
     defer switch (loaded) {
         .loaded => |parsed| parsed.deinit(),
-        .mutated => {},
+        .cleared, .mutated, .failed => {},
     };
     try testing.expect(loaded == .loaded);
 

--- a/src/tui/doctor_tab.zig
+++ b/src/tui/doctor_tab.zig
@@ -1,8 +1,10 @@
 //! malt — Doctor tab for `mt tui`: the health-check pane.
 //!
-//! Leaf module. Pure cores only: `step(state, key)` records a fix intent as a
-//! `request` for the impure shell to delegate to the real `mt doctor --fix
-//! <class>`; `render(state, frame, rect)` is a pure function of `(state, rect)`
+//! Leaf module. Pure cores only: `step` maps `f` to a fix `Cmd` (a `run_mutation`
+//! for the real `mt doctor --fix <class>`), and `update` folds the pump's result
+//! back (a finished fix asks for a fresh read, a delivered read swaps in the
+//! findings). The tab names effects as data and never imports the runner.
+//! `render(state, frame, rect)` is a pure function of `(state, rect)`
 //! so a resize is a re-render. The shell owns the finding data; `items` borrow
 //! from that storage. Findings are shown severity-first (errors, then warnings,
 //! then ok) for scan-ability, each with a local `✓`/`⚠`/`✗` glyph — the mapping
@@ -14,29 +16,23 @@ const std = @import("std");
 const testing = std.testing;
 
 const color = @import("../ui/color.zig");
+const cmd = @import("cmd.zig");
 const ctx = @import("ctx.zig");
 const doctor_json = @import("json/doctor.zig");
 pub const Row = doctor_json.Finding;
 const Severity = doctor_json.Severity;
 const detail_pane = @import("detail_pane.zig");
 const scroll_list = @import("scroll_list.zig");
-const spawn = @import("spawn.zig");
 const tab = @import("tab.zig");
-
-/// A fix effect the pure `step` defers to the impure shell, which performs it and
-/// resets the field. `step` never does I/O — this is the command channel.
-pub const Request = enum { none, fix };
 
 pub const State = struct {
     chrome: tab.Chrome = .{},
     /// Findings, borrowed from shell-owned parse storage.
     items: []const Row = &.{},
     /// Reclaimable disk/tap totals, copied from the parse by the shell. Plain
-    /// scalars (T-003's `Stats`), defaulted to zero so a tab built without a
-    /// parse — or against an older `mt` — simply shows no reclaimable line.
+    /// scalars, defaulted to zero so a tab built without a parse — or against an
+    /// older `mt` — simply shows no reclaimable line.
     stats: doctor_json.Stats = .{},
-    /// Pending fix effect for the shell to perform, then clear.
-    request: Request = .none,
 };
 
 /// Tab-private parse storage: the `doctor` findings the tab borrows. Owned beside
@@ -53,13 +49,6 @@ pub const Storage = struct {
 
 /// Doctor audits in the background; it exits by severity, so it tolerates ≤2.
 pub const fetch_spec: ?tab.FetchSpec = .{ .verb = &.{"doctor"}, .max_ok_exit = 2, .refresh_op = "doctor refresh failed" };
-
-/// Whether the pending request will spawn a DB-mutating child (`mt doctor --fix`).
-/// The shell folds this over every tab before opening the DB so a live background
-/// audit is drained first — the WAL single-writer invariant.
-pub fn mutates(s: *const State) bool {
-    return s.request == .fix;
-}
 
 pub fn title() []const u8 {
     return "Doctor";
@@ -116,89 +105,81 @@ pub fn selectedFinding(s: *const State) ?Row {
     return orderedNth(s.items, filter, sel);
 }
 
-/// Pure transition: `f` records a fix intent for the shell — but only when the
-/// selected finding is `fixable`. A non-fixable finding's `f` is inert.
-pub fn step(s: *State, key: tab.Key) void {
+/// Pure transition: `f` maps to a fix `Cmd` — but only when the selected finding
+/// is `fixable`. A non-fixable finding's `f`, or `f` on an empty list, is `.none`.
+pub fn step(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, key: tab.Key) cmd.Cmd {
+    _ = storage;
     switch (key) {
-        .char => |c| if (c.len == 1 and c.bytes[0] == 'f') {
-            const sel = selectedFinding(s) orelse return;
-            if (sel.fixable) s.request = .fix;
-        },
+        .char => |c| if (c.len == 1 and c.bytes[0] == 'f') return fixCmd(allocator, mt_path, s),
         // Only the tab knows its filtered row count, so the shell defers End here.
         .end => s.chrome.view.selected = filteredCount(s.items, s.chrome.filter.slice()) -| 1,
         else => {},
     }
+    return .none;
 }
 
-// ─── impure zone ───────────────────────────────────────────────────────
-// The effect half of the tab, reunited beside its pure producer (`step` sets the
-// `request`; the code below drains it). Everything here takes its I/O ports
-// explicitly through the shared `ctx.Ctx` — never a global — so the pure/impure
-// line is the function signature: a decl that touches `io`/`allocator` lives here.
+// ─── effect producers ───────────────────────────────────────────────────
+// The tab names effects as `Cmd` values; the pump performs them and folds the
+// result back through `update`. No I/O and no runner import here.
 
-/// The effect chain's error set, composed from the source sets so it tracks them
-/// automatically. It is a subset of the shell's `RunError`, which is the exhaustive
-/// boundary that classifies each fault recoverable-vs-fatal; naming it here keeps
-/// the public `service` explicit without hand-listing errors.
-pub const Error = std.mem.Allocator.Error || spawn.ReadError || spawn.InlineError || doctor_json.Error;
+/// Build `mt doctor --fix <class>` for the selected finding, or `Cmd.none` when
+/// nothing fixable is selected. The token is the finding's `fix_class` — the only
+/// thing `mt doctor --fix` resolves — not its descriptive `id`. `max_ok_exit = 2`
+/// because `mt doctor --fix` exits by pre-fix severity (1 warn / 2 err), not
+/// pass/fail. The pump frees only the returned slice, not its elements.
+/// Banner op strings for a recoverable fault, kept as parity with the pre-reify
+/// error names so the dashboard shows the same banners it always has.
+const fix_fail_op = "doctor fix failed";
+const refresh_fail_op = "doctor refresh failed";
 
-/// Perform any fix effect the pure `step` requested, then clear it — the consumer
-/// half of the `request` seam. The shell dispatches this only for the active tab;
-/// the lazy (re)load on entry / after staleness stays loop machinery, so this owns
-/// only the tab's own effect.
-pub fn service(s: *State, storage: *Storage, c: *ctx.Ctx) Error!void {
-    const req = s.request;
-    s.request = .none;
-    switch (req) {
-        .none => {},
-        .fix => try doDoctorFix(s, storage, c),
+/// Highest `mt doctor --fix` exit still a success: its code is the pre-fix
+/// severity (1 warn / 2 err), not pass/fail, so a clean sweep of a warning still
+/// exits 1. Mirrors the read's tolerance.
+const fix_max_ok_exit: u8 = 2;
+
+fn fixCmd(allocator: std.mem.Allocator, mt_path: []const u8, s: *const State) cmd.Cmd {
+    const fnd = selectedFinding(s) orelse return .none; // empty list: no-op
+    if (!fnd.fixable) return .none; // a non-fixable finding has no fix target
+    // An argv-build OOM drops this keystroke's effect, not the TUI; the user retries.
+    const argv = cmd.inlineArgv(allocator, mt_path, &.{ "doctor", "--fix", doctor_json.fixClassTag(fnd.fix_class) }) catch return .none;
+    return .{ .run_mutation = .{ .argv = argv, .max_ok_exit = fix_max_ok_exit, .tag = .doctor, .fail_op = fix_fail_op } };
+}
+
+/// Fold a completed effect back into the model. A finished fix (exit ≤2, a
+/// severity code, not a fault) marks the siblings stale and asks for a fresh
+/// `mt doctor --json` read (the exit can't say what remains — the refresh is the
+/// truth); a real fault (exit >2) surfaces the recoverable banner. A delivered
+/// read swaps in the findings + reclaimable stats.
+pub fn update(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, shared: *ctx.SharedModel, msg: cmd.Msg) cmd.Cmd {
+    switch (msg) {
+        .mutated => |code| {
+            if (code > fix_max_ok_exit) {
+                shared.banner.set(fix_fail_op, "ChildFailed");
+                return .none;
+            }
+            shared.markStaleAfter(.doctor); // this tab refreshes next; the others may be stale
+            // A fresh prefix reads empty, so allow an empty document too.
+            const argv = cmd.jsonArgv(allocator, mt_path, &.{"doctor"}) catch return .none;
+            return .{ .read = .{ .argv = argv, .max_ok_exit = 2, .allow_empty = true, .mode = .polled, .parse = cmd.parserFor(.doctor, doctor_json.parse), .tag = .doctor, .fail_op = refresh_fail_op } };
+        },
+        .loaded => |parsed| {
+            applyDoctorParse(s, storage, parsed.doctor);
+            return .none;
+        },
+        .cleared => {
+            clear(s, storage); // an exit-0 empty read: a fresh prefix, no findings
+            return .none;
+        },
+        .failed => return .none, // the pump set the banner; keep the last-good findings
     }
 }
 
-/// Delegate the selected finding's fix to the real `mt` inline, then refresh.
-fn doDoctorFix(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
-    const argv = (try doctorFixArgv(c.allocator, c.mt_path, s)) orelse return; // nothing fixable selected
-    defer c.allocator.free(argv);
-    {
-        // `mt doctor --fix` exits by severity (1 warn / 2 err), not pass/fail — a
-        // clean sweep of a warning-class finding still exits 1 — so tolerate exits
-        // up to 2 (symmetric with the read). A real fault (exit > 2, signal) still
-        // surfaces as a banner; a severity exit re-enters cleanly and falls through
-        // to the refresh. Scoped so the refresh reports under its own op, not the fix.
-        errdefer |err| c.shared.banner.set("doctor fix failed", @errorName(err));
-        try spawn.runInlineReenterTolerant(c.term, argv, 2);
-    }
-    try loadDoctor(s, storage, c); // exit can't say what remains — the refresh is the truth
-    c.shared.markStaleAfter(.doctor); // this tab is fresh; the others may now be stale
-}
-
-/// Build `mt doctor --fix <class>` for the selected finding. Pure over the tab
-/// state: null when nothing is selected or the finding is not fixable (the no-op),
-/// else an owned argv. The token is the finding's `fix_class` — the only thing
-/// `mt doctor --fix` resolves — not its descriptive `id`. Caller frees the slice.
-fn doctorFixArgv(allocator: std.mem.Allocator, mt_path: []const u8, s: *const State) std.mem.Allocator.Error!?[]const []const u8 {
-    const fnd = selectedFinding(s) orelse return null; // empty list: no-op
-    if (!fnd.fixable) return null; // a non-fixable finding has no fix target
-    return try spawn.inlineArgv(allocator, mt_path, &.{ "doctor", "--fix", doctor_json.fixClassTag(fnd.fix_class) });
-}
-
-/// (Re)read `mt doctor --json` and repoint the tab's findings at the fresh parse.
-/// The polled read animates the shell's spinner through `c.painter` while it
-/// blocks; the storage is swapped only after a clean parse, so a failure keeps the
-/// last-good findings and their selection behind a banner.
-fn loadDoctor(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
-    errdefer |err| c.shared.banner.set("doctor refresh failed", @errorName(err));
-    const argv = try spawn.jsonArgv(c.allocator, c.mt_path, &.{"doctor"});
-    defer c.allocator.free(argv);
-    // Keep `loading` set across the poll so each tick paints the spinner, cleared
-    // once the result (or the empty/banner state) replaces it.
-    c.loading.* = true;
-    defer c.loading.* = false;
-    // `mt doctor` exits non-zero by severity (1 warn / 2 err) while still emitting
-    // findings — exactly when the tab is most useful — so tolerate exits up to 2.
-    const bytes = try spawn.readJsonPolled(c.io, c.allocator, argv, 2, c.painter);
-    defer if (bytes) |b| c.allocator.free(b);
-    try applyDoctorBytes(c.allocator, s, storage, bytes);
+/// Clear to no findings, freeing any held parse. Shared by a null background
+/// payload and a `.cleared` keypress read.
+fn clear(st: *State, storage: *Storage) void {
+    if (storage.doctor) |old| old.deinit();
+    storage.doctor = null;
+    st.items = &.{};
 }
 
 /// Repoint the Doctor tab at a drained `--json` payload. `null` (a fresh prefix)
@@ -207,18 +188,13 @@ fn loadDoctor(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
 /// swapped only after a clean parse, so a failure keeps the last-good findings.
 /// Public because the shell's fetch drain routes a background payload through it.
 pub fn applyDoctorBytes(allocator: std.mem.Allocator, st: *State, storage: *Storage, bytes: ?[]const u8) doctor_json.Error!void {
-    const payload = bytes orelse {
-        if (storage.doctor) |old| old.deinit();
-        storage.doctor = null;
-        st.items = &.{};
-        return;
-    };
+    const payload = bytes orelse return clear(st, storage);
     const parsed = try doctor_json.parse(allocator, payload);
     applyDoctorParse(st, storage, parsed);
 }
 
 /// Repoint the tab at a fresh parse, freeing the previous one. Split from the
-/// spawn so the findings + reclaimable stats wiring is testable without a child.
+/// child run so the findings + reclaimable stats wiring is testable without one.
 fn applyDoctorParse(st: *State, storage: *Storage, parsed: doctor_json.Parsed) void {
     if (storage.doctor) |old| old.deinit();
     storage.doctor = parsed;
@@ -812,6 +788,14 @@ fn ch(c: u8) tab.Key {
     return .{ .char = .{ .bytes = .{ c, 0, 0, 0 }, .len = 1 } };
 }
 
+/// Drive `step` with a throwaway storage and a fixed mt path. Doctor's `step`
+/// ignores storage, so this keeps the pure-behaviour tests readable.
+fn stepKey(s: *State, key: tab.Key) cmd.Cmd {
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    return step(testing.allocator, "/opt/malt/bin/mt", s, &storage, key);
+}
+
 const sample = [_]Row{
     .{ .id = "malt_prefix", .severity = .ok, .title = "MALT_PREFIX", .detail = "/opt/malt (default)", .fixable = false, .fix_class = .none },
     .{ .id = "orphaned_store_entries", .severity = .warn, .title = "Orphaned store entries", .detail = "3 orphaned entries", .fixable = true, .fix_class = .orphaned_store },
@@ -850,7 +834,7 @@ test "matches is a case-insensitive substring; empty filter matches all" {
 
 test "End jumps to the last filtered row" {
     var s: State = .{ .items = &sample };
-    step(&s, .end);
+    _ = stepKey(&s, .end);
     try testing.expectEqual(@as(usize, 3), s.chrome.view.selected);
 }
 
@@ -898,27 +882,31 @@ test "an info finding is in-progress: its own glyph, never counted as attention"
     try testing.expectEqualStrings("ℹ", glyph(.info));
 }
 
-test "f on a fixable finding requests a fix" {
+test "f on a fixable finding returns the tolerant `doctor --fix <class>` mutation" {
     var s: State = .{ .items = &sample };
     s.chrome.view.selected = 1; // orphaned_store_entries — fixable
-    step(&s, ch('f'));
-    try testing.expectEqual(Request.fix, s.request);
+    const eff = stepKey(&s, ch('f'));
+    defer testing.allocator.free(eff.run_mutation.argv);
+    try testing.expect(eff == .run_mutation);
+    try testing.expectEqual(@as(u8, 2), eff.run_mutation.max_ok_exit); // severity exit is not a fault
+    try testing.expectEqual(cmd.MsgTag.doctor, eff.run_mutation.tag);
+    const argv = eff.run_mutation.argv;
+    try testing.expectEqualStrings("doctor", argv[1]);
+    try testing.expectEqualStrings("--fix", argv[2]);
+    try testing.expectEqualStrings("orphaned_store", argv[3]); // the fix_class token, not the id
 }
 
-test "f on a non-fixable finding is inert" {
+test "f on a non-fixable finding is inert (Cmd.none)" {
     var s: State = .{ .items = &sample };
     s.chrome.view.selected = 0; // sqlite_integrity — not fixable
-    step(&s, ch('f'));
-    try testing.expectEqual(Request.none, s.request);
+    try testing.expect(stepKey(&s, ch('f')) == .none);
 }
 
-test "an unrelated key leaves the request alone" {
+test "an unrelated key or Enter returns Cmd.none" {
     var s: State = .{ .items = &sample };
     s.chrome.view.selected = 1;
-    step(&s, ch('z'));
-    try testing.expectEqual(Request.none, s.request);
-    step(&s, .enter);
-    try testing.expectEqual(Request.none, s.request);
+    try testing.expect(stepKey(&s, ch('z')) == .none);
+    try testing.expect(stepKey(&s, .enter) == .none);
 }
 
 test "render lists findings with a severity glyph and title" {
@@ -1522,8 +1510,7 @@ test "a single reclaimable figure shows no ratio bar — there is nothing to com
 test "the purge guidance is inert: f on a non-fixable selection stays a no-op with stats present" {
     var s: State = .{ .items = &sample, .stats = .{ .cask_bytes = 2048, .tap_cache_bytes = 512 } };
     s.chrome.view.selected = 0; // sqlite_integrity — not fixable
-    step(&s, ch('f'));
-    try testing.expectEqual(Request.none, s.request); // the advisory added no action
+    try testing.expect(stepKey(&s, ch('f')) == .none); // the advisory added no action
 }
 
 test "the reclaimable bullet glyph falls back to ASCII when emoji are off" {
@@ -1552,13 +1539,6 @@ test "the reclaimable section renders on a narrow pane without wrapping into the
     try testing.expect(std.mem.indexOf(u8, out, "SQLite integrity") != null); // the list stays the floor
 }
 
-test "mutates is true only for a pending fix — the request that takes the WAL writer" {
-    var s: State = .{};
-    try testing.expect(!mutates(&s)); // .none never gates the pre-mutation drain
-    s.request = .fix;
-    try testing.expect(mutates(&s)); // a fix spawns `mt doctor --fix`, a DB writer
-}
-
 test "applyDoctorBytes repoints the tab at parsed findings + reclaimable stats; null clears" {
     const allocator = testing.allocator;
     var st: State = .{};
@@ -1580,112 +1560,56 @@ test "applyDoctorBytes repoints the tab at parsed findings + reclaimable stats; 
     try testing.expectEqual(@as(usize, 0), st.items.len);
 }
 
-// Backing storage for a `ctx.Ctx` in an effect test: dummy term/fetches/shared,
-// a no-op painter (fd = -1; the test children finish before the first poll tick,
-// so it is never touched), and the synchronous-load flag.
-const TestEnv = struct {
-    term_h: ctx.Term,
-    fetches: ctx.Fetches = ctx.Fetches.initFill(null),
-    shared: ctx.SharedModel = .{},
-    frame: []u8 = &.{},
-    loading: bool = false,
-};
-
-fn mkCtx(io: std.Io, e: *TestEnv, mt_path: []const u8) ctx.Ctx {
-    return .{
-        .io = io,
-        .allocator = testing.allocator,
-        .term = &e.term_h,
-        .painter = .{ .fd = -1, .frame = &e.frame },
-        .fetches = &e.fetches,
-        .shared = &e.shared,
-        .mt_path = mt_path,
-        .loading = &e.loading,
-    };
-}
-
-test "doctorFixArgv builds `mt doctor --fix <class>` from the finding's fix_class, not its id" {
-    const items = [_]Row{
-        .{ .id = "sqlite_integrity", .severity = .err, .title = "SQLite integrity", .fixable = false, .fix_class = .none },
-        .{ .id = "orphaned_store_entries", .severity = .warn, .title = "Orphaned store entries", .fixable = true, .fix_class = .orphaned_store },
-    };
-    var st: State = .{ .items = &items };
-    st.chrome.view.selected = 1; // the fixable finding (display order: err then warn)
-    const argv = (try doctorFixArgv(testing.allocator, "/opt/homebrew/bin/mt", &st)).?;
-    defer testing.allocator.free(argv);
-    try testing.expectEqual(@as(usize, 4), argv.len);
-    try testing.expectEqualStrings("/opt/homebrew/bin/mt", argv[0]);
-    try testing.expectEqualStrings("doctor", argv[1]);
-    try testing.expectEqualStrings("--fix", argv[2]);
-    try testing.expectEqualStrings("orphaned_store", argv[3]); // the class, not "orphaned_store_entries"
-}
-
-test "doctorFixArgv returns null for a non-fixable selection so f is a no-op" {
-    const items = [_]Row{
-        .{ .id = "sqlite_integrity", .severity = .err, .title = "SQLite integrity", .fixable = false, .fix_class = .none },
-    };
-    const st: State = .{ .items = &items };
-    try testing.expect((try doctorFixArgv(testing.allocator, "/bin/mt", &st)) == null);
-}
-
-test "doctorFixArgv returns null on an empty list" {
-    const st: State = .{ .items = &.{} };
-    try testing.expect((try doctorFixArgv(testing.allocator, "/bin/mt", &st)) == null);
-}
-
-test "loadDoctor treats an exit-0 empty response (fresh prefix) as an empty tab" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
-    var storage: Storage = .{};
-    defer storage.deinit(testing.allocator);
+test "a severity-exit fix (≤2) marks siblings stale and asks for a fresh doctor read" {
     var st: State = .{};
-    var c = mkCtx(thr.io(), &env, "/usr/bin/true");
-    try loadDoctor(&st, &storage, &c);
-    try testing.expectEqual(@as(usize, 0), st.items.len);
-    try testing.expect(!env.shared.banner.isSet());
-}
-
-test "a failed doctor refresh names the op in the banner and keeps the last-good findings" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
     var storage: Storage = .{};
     defer storage.deinit(testing.allocator);
+    var shared: ctx.SharedModel = .{};
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .mutated = 1 });
+    defer testing.allocator.free(next.read.argv);
+    try testing.expect(next == .read);
+    try testing.expectEqual(cmd.Cmd.Mode.polled, next.read.mode);
+    try testing.expectEqual(@as(u8, 2), next.read.max_ok_exit); // severity exit is not a fault
+    try testing.expect(next.read.allow_empty); // a fresh prefix reads empty
+    try testing.expectEqual(cmd.MsgTag.doctor, next.read.tag);
+    try testing.expectEqualStrings("doctor", next.read.argv[1]);
+    try testing.expectEqualStrings("--json", next.read.argv[2]);
+    try testing.expect(shared.takeDirty(.installed)); // siblings were marked stale
+}
+
+test "a fix exit above the severity cap surfaces the recoverable banner, no reload" {
     var st: State = .{};
-    var c = mkCtx(thr.io(), &env, "/bin/echo"); // echo emits non-JSON → parse fails
-    try testing.expectError(error.BadJson, loadDoctor(&st, &storage, &c));
-    try testing.expectEqualStrings("doctor refresh failed: BadJson", env.shared.banner.slice());
-    try testing.expectEqual(@as(usize, 0), st.items.len); // last-good kept
-}
-
-test "service on a .none request is a clean no-op — no spawn, no banner" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
     var storage: Storage = .{};
     defer storage.deinit(testing.allocator);
-    var st: State = .{}; // .none: the pure `step` set nothing to perform
-    var c = mkCtx(thr.io(), &env, "/bin/false"); // would fail if it ever spawned
-    try service(&st, &storage, &c);
-    try testing.expectEqual(Request.none, st.request);
-    try testing.expect(!env.shared.banner.isSet());
+    var shared: ctx.SharedModel = .{};
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .mutated = 5 });
+    try testing.expect(next == .none);
+    try testing.expect(std.mem.startsWith(u8, shared.banner.slice(), "doctor fix failed"));
 }
 
-test "service drains a fix request; a fix with nothing fixable never spawns" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+test "update on a cleared read (an exit-0 empty reload) drops to no findings" {
+    var st: State = .{ .items = &sample, .stats = .{ .cask_bytes = 4096 } };
     var storage: Storage = .{};
     defer storage.deinit(testing.allocator);
-    // An empty list means `doctorFixArgv` resolves to null: the request drains but
-    // no `mt doctor --fix` child runs, so `/bin/false` is never reached.
-    var st: State = .{ .request = .fix };
-    var c = mkCtx(thr.io(), &env, "/bin/false");
-    try service(&st, &storage, &c);
-    try testing.expectEqual(Request.none, st.request); // the producer/consumer seam drained it
-    try testing.expect(!env.shared.banner.isSet()); // never spawned → no failure banner
+    var shared: ctx.SharedModel = .{};
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .cleared);
+    try testing.expect(next == .none);
     try testing.expectEqual(@as(usize, 0), st.items.len);
+}
+
+test "update on a loaded document swaps in findings + stats and returns none" {
+    var st: State = .{ .items = &sample };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    var shared: ctx.SharedModel = .{};
+    const parsed = try doctor_json.parse(testing.allocator,
+        \\{"checks":[{"id":"a","severity":"warn","title":"A","fixable":true,"fix_class":"stale_lock"}],
+        \\"cask_history":{"retained_versions":3,"bytes":4096},"tap_cache":{"bytes":512}}
+    );
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .loaded = .{ .doctor = parsed } });
+    try testing.expect(next == .none);
+    try testing.expectEqual(@as(usize, 1), st.items.len);
+    try testing.expectEqual(@as(u64, 4096), st.stats.cask_bytes);
 }
 
 test "conforms to the tab contract" {

--- a/src/tui/installed_tab.zig
+++ b/src/tui/installed_tab.zig
@@ -1,8 +1,10 @@
 //! malt — Installed tab for `mt tui`: the first data-bearing pane.
 //!
-//! Leaf module. Pure cores only: `step(state, key)` records the user's intent as
-//! a `request` for the impure shell to perform (read `mt info`, re-exec
-//! `mt uninstall`), and `render(state, frame, rect)` is a pure function of
+//! Leaf module. Pure cores only: `step(...)` maps a key to a `Cmd` (Enter reads
+//! `mt info`, a confirmed `x` re-execs `mt uninstall`), and `update` folds the
+//! pump's result back (an info read opens the pane, a list read swaps rows, a
+//! finished uninstall refetches). The tab names effects as data and never imports
+//! the runner. `render(state, frame, rect)` is a pure function of
 //! `(state, rect)` so a resize is a re-render. The shell owns the I/O and the
 //! row data's lifetime; `items` and `detail` borrow from that storage. Rows are
 //! filtered by the shared filter, the selection is highlighted, and a selected
@@ -15,8 +17,8 @@
 
 const std = @import("std");
 const tab = @import("tab.zig");
+const cmd = @import("cmd.zig");
 const ctx = @import("ctx.zig");
-const spawn = @import("spawn.zig");
 const detail_pane = @import("detail_pane.zig");
 const scroll_list = @import("scroll_list.zig");
 const list_json = @import("json/list.zig");
@@ -24,12 +26,6 @@ const info_json = @import("json/info.zig");
 const color = @import("../ui/color.zig");
 
 pub const Pkg = list_json.Pkg;
-
-/// An effect the pure `step` defers to the impure shell, which performs it and
-/// resets the field. `step` never does I/O — this is the command channel.
-/// `uninstall` carries the guard's latched target so the shell never re-derives
-/// it from a selection that may have moved since the guard was armed.
-pub const Request = union(enum) { none, open_detail, uninstall: ConfirmTarget };
 
 /// Scratch bound shared by a formatted row, the guard banner, and the latched
 /// target name, so none of the three can silently outgrow the others.
@@ -69,8 +65,10 @@ pub const State = struct {
     detail: ?Detail = null,
     /// The `[y/N]` uninstall guard, latched on the package it was armed over.
     confirm_uninstall: ?ConfirmTarget = null,
-    /// Pending effect for the shell to perform, then clear.
-    request: Request = .none,
+    /// The target of an uninstall in flight, latched out of the guard so its name
+    /// (borrowed by the `run_mutation` argv) outlives the guard banner clearing and
+    /// the synchronous re-enter. `update` clears it when the mutation lands.
+    pending_uninstall: ?ConfirmTarget = null,
 };
 
 /// Tab-private parse storage: the `list` rows the tab borrows and the open detail
@@ -89,14 +87,6 @@ pub const Storage = struct {
 
 /// Installed reads synchronously from the DB; it never background-fetches.
 pub const fetch_spec: ?tab.FetchSpec = null;
-
-/// Whether the pending request will spawn a DB-mutating child (`mt uninstall`).
-/// The shell folds this over every tab before opening the DB so a live background
-/// audit is drained first — the WAL single-writer invariant. Read-only requests
-/// (detail) never take the writer.
-pub fn mutates(s: *const State) bool {
-    return s.request == .uninstall;
-}
 
 pub fn title() []const u8 {
     return "Installed";
@@ -137,12 +127,14 @@ pub fn selectedPkg(s: *const State) ?Pkg {
     return null; // unreachable: sel < nf
 }
 
-/// Pure transition: record the user's intent for the shell to act on. While the
-/// guard is up, the next key resolves it.
-pub fn step(s: *State, key: tab.Key) void {
-    if (s.confirm_uninstall != null) return resolveGuard(s, key);
+/// Pure transition: map a key to a `Cmd`. Enter reads the selected row's `mt info`
+/// into the detail pane; `x` arms the fat-finger uninstall guard (pure state);
+/// Esc/End are pure. While the guard is up, the next key resolves it.
+pub fn step(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, key: tab.Key) cmd.Cmd {
+    _ = storage;
+    if (s.confirm_uninstall != null) return resolveGuard(allocator, mt_path, s, key);
     switch (key) {
-        .enter => s.request = .open_detail,
+        .enter => return openDetailCmd(allocator, mt_path, s),
         .esc => s.detail = null, // close the detail pane
         // Only the tab knows its filtered row count, so the shell defers End here.
         .end => s.chrome.view.selected = filteredCount(s.items, s.chrome.filter.slice()) -| 1,
@@ -153,18 +145,24 @@ pub fn step(s: *State, key: tab.Key) void {
         },
         else => {},
     }
+    return .none;
 }
 
-/// `y` confirms (request the real `mt uninstall` of the latched target); every
-/// other key — `n`, Esc, Enter — cancels. A fat-finger gate, not a typed-confirm.
-fn resolveGuard(s: *State, key: tab.Key) void {
+/// `y` confirms (the real `mt uninstall` of the latched target); every other key —
+/// `n`, Esc, Enter — cancels. A fat-finger gate, not a typed-confirm. The guard is
+/// cleared here regardless of outcome so a failed uninstall never leaves it stuck;
+/// the target moves to `pending_uninstall` so its name outlives the guard for the
+/// argv the mutation borrows.
+fn resolveGuard(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, key: tab.Key) cmd.Cmd {
+    defer s.confirm_uninstall = null;
     switch (key) {
         .char => |c| if (c.len == 1 and (c.bytes[0] == 'y' or c.bytes[0] == 'Y')) {
-            s.request = .{ .uninstall = s.confirm_uninstall.? };
+            s.pending_uninstall = s.confirm_uninstall.?;
+            return uninstallCmd(allocator, mt_path, &s.pending_uninstall.?);
         },
         else => {},
     }
-    s.confirm_uninstall = null;
+    return .none;
 }
 
 /// Pure render: an optional guard banner on top, an optional detail pane at the
@@ -298,16 +296,9 @@ fn appendPad(buf: []u8, len: *usize, s: []const u8, width: usize) void {
 
 // ─── tests ───────────────────────────────────────────────────────────
 
-// ── Impure zone ────────────────────────────────────────────────────────────
-// The effects the pure `step` requested. Each takes its I/O ports explicitly
-// through the shared `ctx.Ctx` — never a global — so the pure/impure line lands
-// at the signature: these functions carry `io`/`allocator`, the pure ones above
-// do not.
-
-/// The effect chain's error set, composed from the source sets so it tracks them
-/// automatically. A subset of the shell's `RunError`, which classifies each fault
-/// recoverable-vs-fatal; naming it here keeps the public `service` explicit.
-pub const Error = std.mem.Allocator.Error || spawn.ReadError || spawn.InlineError || list_json.Error || info_json.Error;
+// ─── effect producers ───────────────────────────────────────────────────
+// The tab names effects as `Cmd` values; the pump performs them and folds the
+// result back through `update`. No I/O and no runner import here.
 
 /// Cheap keg count from `mt list --json` bytes (no `--size --linked` walk). Header
 /// infrastructure: parses to a temporary and returns only the count, touching no
@@ -319,93 +310,110 @@ pub fn countFromJson(allocator: std.mem.Allocator, bytes: []const u8) list_json.
     return parsed.items.len;
 }
 
-/// (Re)read `mt list --json --size --linked` and repoint the tab's rows at the
-/// fresh parse, freeing the previous one. The `--size`/`--linked` keg-dir walk is
-/// paid only here — on the Installed tab, lazily. The storage is swapped only after
-/// a clean parse, so a failure keeps the last-good rows.
-fn loadInstalled(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
-    errdefer |err| c.shared.banner.set("list refresh failed", @errorName(err));
-    const argv = try spawn.jsonArgv(c.allocator, c.mt_path, &.{ "list", "--size", "--linked" });
-    defer c.allocator.free(argv);
-    const bytes = (try spawn.readJsonAllowEmpty(c.io, c.allocator, argv)) orelse {
-        // Fresh prefix: an empty Cellar, not a failure. Clear the rows.
-        if (storage.installed) |old| old.deinit();
-        storage.installed = null;
-        s.items = &.{};
-        s.detail = null;
-        c.shared.installed_count = 0; // empty Cellar is a known zero, not "unknown"
-        return;
-    };
-    defer c.allocator.free(bytes);
-
-    const parsed = try list_json.parse(c.allocator, bytes);
-    if (storage.installed) |old| old.deinit();
-    storage.installed = parsed;
-    s.items = parsed.items;
-    s.detail = null; // a refreshed list invalidates the old detail
-    c.shared.installed_count = parsed.items.len;
+/// Build the `mt info <pkg> --json` read for the selected row (a blocking read, no
+/// alt-screen drop), or `Cmd.none` when nothing is selected. `update` folds the
+/// info into the detail pane.
+fn openDetailCmd(allocator: std.mem.Allocator, mt_path: []const u8, s: *const State) cmd.Cmd {
+    const sel = selectedPkg(s) orelse return .none; // nothing selected
+    const argv = cmd.jsonArgv(allocator, mt_path, &.{ "info", sel.name }) catch return .none;
+    return .{ .read = .{ .argv = argv, .mode = .blocking, .parse = cmd.parserFor(.info, info_json.parse), .tag = .installed, .fail_op = "info read failed" } };
 }
 
-/// Read `mt info <pkg> --json` for the selected row into the detail pane. A read
-/// (no alt-screen drop); the detail is set only after a clean parse, so a failure
-/// names the package in a banner and leaves the pane closed.
-fn openDetail(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
-    const sel = selectedPkg(s) orelse return; // nothing selected
-    errdefer |err| {
-        var sb: [96]u8 = undefined;
-        const op = std.fmt.bufPrint(&sb, "info for {s} failed", .{sel.name}) catch "info read failed";
-        c.shared.banner.set(op, @errorName(err));
-    }
-    const argv = try spawn.jsonArgv(c.allocator, c.mt_path, &.{ "info", sel.name });
-    defer c.allocator.free(argv);
-    const bytes = try spawn.readJson(c.io, c.allocator, argv);
-    defer c.allocator.free(bytes);
+/// Build the `mt uninstall <name>` mutation for the guard's latched target. The
+/// name borrows `pending_uninstall`, which outlives the guard and the re-enter.
+fn uninstallCmd(allocator: std.mem.Allocator, mt_path: []const u8, target: *const ConfirmTarget) cmd.Cmd {
+    const argv = cmd.inlineArgv(allocator, mt_path, &.{ "uninstall", target.name() }) catch return .none;
+    return .{ .run_mutation = .{ .argv = argv, .tag = .installed, .fail_op = "uninstall failed" } };
+}
 
-    const parsed = try info_json.parse(c.allocator, bytes);
+/// The `mt list --json --size --linked` read: the `--size`/`--linked` keg-dir walk
+/// is paid only here, lazily. Blocking, empty-ok (a fresh prefix's empty Cellar).
+fn listReadCmd(allocator: std.mem.Allocator, mt_path: []const u8) cmd.Cmd {
+    const argv = cmd.jsonArgv(allocator, mt_path, &.{ "list", "--size", "--linked" }) catch return .none;
+    return .{ .read = .{ .argv = argv, .allow_empty = true, .mode = .blocking, .parse = cmd.parserFor(.list, list_json.parse), .tag = .installed, .fail_op = "list refresh failed" } };
+}
+
+/// The lazy on-entry reload: Installed has no background fetch, so the pump asks
+/// for this `list` read when the tab is entered dirty (a cross-tab mutation, or
+/// launch). Distinct from the post-uninstall reload `update` returns.
+pub fn refreshCmd(allocator: std.mem.Allocator, mt_path: []const u8) cmd.Cmd {
+    return listReadCmd(allocator, mt_path);
+}
+
+/// Fold a completed effect back into the model. A delivered `info` read opens the
+/// detail pane; a delivered `list` read swaps in the rows; an empty `list` read
+/// clears the Cellar; a finished uninstall (exit 0) refetches the list, else banners.
+pub fn update(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, shared: *ctx.SharedModel, msg: cmd.Msg) cmd.Cmd {
+    switch (msg) {
+        .loaded => |parsed| {
+            switch (parsed) {
+                .info => |info_p| setDetail(s, storage, info_p),
+                .list => |list_p| swapRows(s, storage, shared, list_p),
+                // Installed only issues info/list reads; free any misrouted parse.
+                inline else => |p| p.deinit(),
+            }
+            return .none;
+        },
+        .failed => return .none, // the pump set the banner; keep the last-good rows
+        .cleared => {
+            clear(s, storage, shared); // an empty `mt list` read: a fresh, empty Cellar
+            return .none;
+        },
+        .mutated => |code| {
+            s.pending_uninstall = null; // the in-flight target is spent
+            if (code != 0) {
+                shared.banner.set("uninstall failed", "ChildFailed");
+                return .none;
+            }
+            shared.markStaleAfter(.installed); // the keg is gone; the siblings may be stale
+            return listReadCmd(allocator, mt_path); // the keg is gone — refetch
+        },
+    }
+}
+
+/// Open the detail pane over the delivered `mt info` parse, freeing the previous.
+/// If the selection vanished between the read and the fold, drop the parse.
+fn setDetail(s: *State, storage: *Storage, parsed: info_json.Parsed) void {
+    const sel = selectedPkg(s) orelse {
+        parsed.deinit();
+        return;
+    };
     if (storage.detail) |old| old.deinit();
     storage.detail = parsed;
     s.detail = .{ .pkg = sel, .info = parsed.info };
 }
 
-/// Delegate uninstall to the real `mt` inline, then refresh the list. The target
-/// is the guard's latched copy — it neither borrows the list storage the post-spawn
-/// reload frees nor tracks a selection that moved after arming.
-fn doUninstall(s: *State, storage: *Storage, c: *ctx.Ctx, target: ConfirmTarget) !void {
-    const argv = try spawn.inlineArgv(c.allocator, c.mt_path, &.{ "uninstall", target.name() });
-    defer c.allocator.free(argv);
-    {
-        // A non-zero `mt uninstall` re-enters the dashboard (the user still has
-        // malt's real output in their scrollback) and surfaces the failure as a
-        // recoverable banner — only a terminal fault is fatal. Scoped so the
-        // post-mutation refresh below reports under its own op, not "uninstall".
-        errdefer |err| c.shared.banner.set("uninstall failed", @errorName(err));
-        try spawn.runInlineReenter(c.term, argv);
-    }
-    try loadInstalled(s, storage, c); // the keg is gone — refetch
-    c.shared.markStaleAfter(.installed); // the other tabs may now be stale too
+/// Repoint the rows at a fresh `list` parse, freeing the previous one. Swapped only
+/// after a clean parse upstream, so a failed refresh keeps the last-good rows.
+fn swapRows(s: *State, storage: *Storage, shared: *ctx.SharedModel, parsed: list_json.Parsed) void {
+    if (storage.installed) |old| old.deinit();
+    storage.installed = parsed;
+    s.items = parsed.items;
+    s.detail = null; // a refreshed list invalidates the old detail
+    shared.installed_count = parsed.items.len;
 }
 
-/// Perform any effect the pure `step` requested, then clear it — the consumer half
-/// of the `request` seam. The shell dispatches this only for the active tab, so the
-/// lazy dirty-reload runs when Installed is entered after a cross-tab mutation.
-pub fn service(s: *State, storage: *Storage, c: *ctx.Ctx) Error!void {
-    const req = s.request;
-    s.request = .none;
-    switch (req) {
-        .none => {},
-        .open_detail => try openDetail(s, storage, c),
-        .uninstall => |target| try doUninstall(s, storage, c, target),
-    }
-    // Lazy per-tab refresh: a mutation elsewhere marked this tab dirty; reload on
-    // entry. Only the active tab's `service` runs, so the old `app.active` guard is
-    // now structural.
-    if (c.shared.takeDirty(.installed)) try loadInstalled(s, storage, c);
+/// Clear to an empty Cellar (a fresh prefix), freeing any held list parse.
+fn clear(s: *State, storage: *Storage, shared: *ctx.SharedModel) void {
+    if (storage.installed) |old| old.deinit();
+    storage.installed = null;
+    s.items = &.{};
+    s.detail = null;
+    shared.installed_count = 0; // empty Cellar is a known zero, not "unknown"
 }
 
 const testing = std.testing;
 
 fn ch(c: u8) tab.Key {
     return .{ .char = .{ .bytes = .{ c, 0, 0, 0 }, .len = 1 } };
+}
+
+/// Drive `step` with a throwaway storage and a fixed mt path. Installed's `step`
+/// ignores storage, so this keeps the pure-behaviour tests readable.
+fn stepKey(s: *State, key: tab.Key) cmd.Cmd {
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    return step(testing.allocator, "/opt/malt/bin/mt", s, &storage, key);
 }
 
 const sample = [_]Pkg{
@@ -443,85 +451,90 @@ test "selectedPkg applies the filter and clamps an out-of-range selection" {
 
 test "End jumps to the last filtered row; an empty list stays at zero" {
     var s: State = .{ .items = &sample };
-    step(&s, .end);
+    _ = stepKey(&s, .end);
     try testing.expectEqual(@as(usize, 3), s.chrome.view.selected);
 
     s.chrome.filter.push("f"); // ffmpeg, flux
-    step(&s, .end);
+    _ = stepKey(&s, .end);
     try testing.expectEqual(@as(usize, 1), s.chrome.view.selected);
 
     var e: State = .{ .items = &.{} };
-    step(&e, .end);
+    _ = stepKey(&e, .end);
     try testing.expectEqual(@as(usize, 0), e.chrome.view.selected);
 }
 
-test "Enter requests the detail effect for the shell to perform" {
+test "Enter returns the `mt info` read for the selected row" {
     var s: State = .{ .items = &sample };
-    step(&s, .enter);
-    try testing.expect(s.request == .open_detail);
+    const eff = stepKey(&s, .enter);
+    defer testing.allocator.free(eff.read.argv);
+    try testing.expect(eff == .read);
+    try testing.expectEqual(cmd.MsgTag.installed, eff.read.tag);
+    try testing.expectEqualStrings("info", eff.read.argv[1]);
+    try testing.expectEqualStrings("brotli", eff.read.argv[2]); // the selected row
 }
 
 test "Esc closes an open detail pane" {
     var s: State = .{ .items = &sample, .detail = .{ .pkg = sample[0], .info = .{} } };
-    step(&s, .esc);
+    try testing.expect(stepKey(&s, .esc) == .none);
     try testing.expect(s.detail == null);
 }
 
-test "x raises the uninstall guard without spawning anything" {
+test "x raises the uninstall guard, producing no effect yet" {
     var s: State = .{ .items = &sample };
-    step(&s, ch('x'));
+    try testing.expect(stepKey(&s, ch('x')) == .none); // no effect yet
     try testing.expect(s.confirm_uninstall != null);
     try testing.expectEqualStrings("brotli", s.confirm_uninstall.?.name()); // latched at arm time
-    try testing.expect(s.request == .none); // no spawn yet
 }
 
-test "y confirms the guard: requests uninstall of the latched name and lowers the guard" {
+test "y confirms the guard: returns the uninstall of the latched name and lowers the guard" {
     var s: State = .{ .items = &sample };
-    step(&s, ch('x'));
-    step(&s, ch('y'));
-    try testing.expect(s.request == .uninstall);
-    try testing.expectEqualStrings("brotli", s.request.uninstall.name());
-    try testing.expect(s.confirm_uninstall == null);
+    _ = stepKey(&s, ch('x'));
+    const eff = stepKey(&s, ch('y'));
+    defer testing.allocator.free(eff.run_mutation.argv);
+    try testing.expect(eff == .run_mutation);
+    try testing.expectEqualStrings("uninstall", eff.run_mutation.argv[1]);
+    try testing.expectEqualStrings("brotli", eff.run_mutation.argv[2]);
+    try testing.expect(s.confirm_uninstall == null); // guard lowered
+    try testing.expectEqualStrings("brotli", s.pending_uninstall.?.name()); // latched for the argv
 }
 
-test "n and Esc cancel the guard with no request" {
+test "n and Esc cancel the guard with no effect" {
     var s: State = .{ .items = &sample };
-    step(&s, ch('x'));
-    step(&s, ch('n'));
+    _ = stepKey(&s, ch('x'));
+    try testing.expect(stepKey(&s, ch('n')) == .none);
     try testing.expect(s.confirm_uninstall == null);
-    try testing.expect(s.request == .none);
 
-    step(&s, ch('x'));
-    step(&s, .esc);
+    _ = stepKey(&s, ch('x'));
+    try testing.expect(stepKey(&s, .esc) == .none);
     try testing.expect(s.confirm_uninstall == null);
-    try testing.expect(s.request == .none);
 }
 
 test "arming latches the target: moving the selection cannot retarget the confirm" {
     var s: State = .{ .items = &sample };
-    step(&s, ch('x')); // arm on brotli (row 0)
+    _ = stepKey(&s, ch('x')); // arm on brotli (row 0)
     s.chrome.view.selected = 2; // the shell moved the selection to ffmpeg
-    step(&s, ch('y'));
-    try testing.expect(s.request == .uninstall);
-    try testing.expectEqualStrings("brotli", s.request.uninstall.name());
+    const eff = stepKey(&s, ch('y'));
+    defer testing.allocator.free(eff.run_mutation.argv);
+    try testing.expectEqualStrings("brotli", eff.run_mutation.argv[2]); // still brotli
 }
 
 test "a list reloaded while the guard is up cannot retarget the latched confirm" {
     var s: State = .{ .items = &sample };
-    step(&s, ch('x')); // arm on brotli (row 0)
+    _ = stepKey(&s, ch('x')); // arm on brotli (row 0)
     // A dirty-tab refetch swaps the rows with no keypress; the latch must hold.
     const reloaded = [_]Pkg{sample[2]}; // ffmpeg is now row 0
     s.items = &reloaded;
-    step(&s, ch('y'));
-    try testing.expect(s.request == .uninstall);
-    try testing.expectEqualStrings("brotli", s.request.uninstall.name());
+    const eff = stepKey(&s, ch('y'));
+    defer testing.allocator.free(eff.run_mutation.argv);
+    try testing.expectEqualStrings("brotli", eff.run_mutation.argv[2]);
 }
 
 test "uppercase Y confirms the guard like y" {
     var s: State = .{ .items = &sample };
-    step(&s, ch('x'));
-    step(&s, ch('Y'));
-    try testing.expect(s.request == .uninstall);
+    _ = stepKey(&s, ch('x'));
+    const eff = stepKey(&s, ch('Y'));
+    defer testing.allocator.free(eff.run_mutation.argv);
+    try testing.expect(eff == .run_mutation);
     try testing.expect(s.confirm_uninstall == null);
 }
 
@@ -534,12 +547,12 @@ test "the latch truncates an oversized name instead of overflowing" {
 
 test "x on an empty or fully filtered-out list does not arm a targetless guard" {
     var s: State = .{ .items = &.{} };
-    step(&s, ch('x'));
+    try testing.expect(stepKey(&s, ch('x')) == .none);
     try testing.expect(s.confirm_uninstall == null);
 
     var t: State = .{ .items = &sample };
     t.chrome.filter.push("zzznomatch");
-    step(&t, ch('x'));
+    try testing.expect(stepKey(&t, ch('x')) == .none);
     try testing.expect(t.confirm_uninstall == null);
 }
 
@@ -548,18 +561,17 @@ test "the guard banner names the latched package even after the selection moved"
     var f: tab.Frame = .{ .buf = &buf };
     var s: State = .{ .items = &sample };
     s.chrome.view.selected = 1; // curl
-    step(&s, ch('x')); // arm on curl
+    _ = stepKey(&s, ch('x')); // arm on curl
     s.chrome.view.selected = 2; // selection moved to ffmpeg
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 10 });
     try testing.expect(std.mem.indexOf(u8, f.slice(), "Uninstall curl? [y/N]") != null);
 }
 
-test "while the guard is up, x's domain keys do not re-arm or leak" {
+test "while the guard is up, Enter cancels it and does not open a detail read" {
     var s: State = .{ .items = &sample };
-    step(&s, ch('x'));
-    step(&s, .enter); // Enter is "default No" — cancels, no detail request
+    _ = stepKey(&s, ch('x'));
+    try testing.expect(stepKey(&s, .enter) == .none); // Enter is "default No" — cancels
     try testing.expect(s.confirm_uninstall == null);
-    try testing.expect(s.request == .none);
 }
 
 test "render heads the columns in bold, aligned over their values" {
@@ -657,7 +669,7 @@ test "render draws the [y/N] guard banner naming the package when confirming" {
     var f: tab.Frame = .{ .buf = &buf };
     var s: State = .{ .items = &sample };
     s.chrome.view.selected = 1; // curl
-    step(&s, ch('x')); // arm through the real transition so the target latches
+    _ = stepKey(&s, ch('x')); // arm through the real transition so the target latches
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 10 });
     const out = f.slice();
     try testing.expect(std.mem.indexOf(u8, out, "curl") != null);
@@ -706,15 +718,6 @@ test "Storage.deinit frees the installed and detail parses" {
     storage.deinit(allocator);
 }
 
-test "mutates gates only on the uninstall request" {
-    var s: State = .{};
-    try testing.expect(!mutates(&s)); // .none never takes the WAL writer
-    s.request = .open_detail;
-    try testing.expect(!mutates(&s)); // a read-only detail request does not gate
-    s.request = .{ .uninstall = ConfirmTarget.init("wget") };
-    try testing.expect(mutates(&s)); // the one DB-mutating request
-}
-
 test "countFromJson returns the row count without retaining the parse" {
     const allocator = std.testing.allocator;
     // A leaked parse arena would trip `testing.allocator` at scope end, so this
@@ -731,86 +734,75 @@ test "countFromJson reports zero for an empty Cellar" {
     try testing.expectEqual(@as(usize, 0), n);
 }
 
-// Backing storage for a `ctx.Ctx` in an effect test: dummy term/fetches/shared, a
-// no-op painter (fd = -1; the synchronous reads never reach a poll tick), and the
-// loading flag.
-const TestEnv = struct {
-    term_h: ctx.Term,
-    fetches: ctx.Fetches = ctx.Fetches.initFill(null),
-    shared: ctx.SharedModel = .{},
-    frame: []u8 = &.{},
-    loading: bool = false,
-};
-
-fn mkCtx(io: std.Io, e: *TestEnv, mt_path: []const u8) ctx.Ctx {
-    return .{
-        .io = io,
-        .allocator = testing.allocator,
-        .term = &e.term_h,
-        .painter = .{ .fd = -1, .frame = &e.frame },
-        .fetches = &e.fetches,
-        .shared = &e.shared,
-        .mt_path = mt_path,
-        .loading = &e.loading,
-    };
-}
-
-test "service on the synchronous read path never starts a background fetch" {
-    // Installed reads the DB inline; it declares no fetch spec, so no branch of its
-    // service may spawn a background audit — the loop multiplexes only the slow tabs.
+test "Installed declares no background fetch — its reads are synchronous" {
     try testing.expect(fetch_spec == null);
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
-    var storage: Storage = .{};
-    defer storage.deinit(testing.allocator);
-    var st: State = .{}; // .none: the pure `step` set nothing to perform
-    var c = mkCtx(thr.io(), &env, "/bin/false"); // would fail if it ever spawned
-    try service(&st, &storage, &c);
-    for (&env.fetches.values) |v| try testing.expect(v == null); // nothing backgrounded
-    try testing.expect(!env.shared.banner.isSet());
 }
 
-test "a failed list refresh names the op in the banner and keeps the last-good rows" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+test "update on a loaded info parse opens the detail pane over the selected row" {
+    var st: State = .{ .items = &sample };
     var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
     defer storage.deinit(testing.allocator);
-    var st: State = .{};
-    var c = mkCtx(thr.io(), &env, "/bin/echo"); // echo emits non-JSON → parse fails
-    try testing.expectError(error.BadJson, loadInstalled(&st, &storage, &c));
-    try testing.expectEqualStrings("list refresh failed: BadJson", env.shared.banner.slice());
-    try testing.expectEqual(@as(usize, 0), st.items.len); // last-good kept
+    const info = try info_json.parse(testing.allocator, "{\"name\":\"brotli\",\"dependencies\":[]}");
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .loaded = .{ .info = info } });
+    try testing.expect(next == .none);
+    try testing.expect(st.detail != null);
 }
 
-// A fresh prefix (no db yet) makes every `mt … --json` read exit 0 with no output.
-// That is an empty Cellar, not a failure — the tab must show an empty list, never
-// crash on `EmptyOutput`. `/usr/bin/true` reproduces it exactly: exit 0, zero bytes.
-test "loadInstalled treats an exit-0 empty response (fresh prefix) as an empty tab" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
-    var storage: Storage = .{};
-    defer storage.deinit(testing.allocator);
+test "update on a loaded list parse swaps rows in and sets the keg count" {
     var st: State = .{};
-    var c = mkCtx(thr.io(), &env, "/usr/bin/true");
-    try loadInstalled(&st, &storage, &c);
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    const list = try list_json.parse(testing.allocator, "{\"installed\":[{\"name\":\"jq\",\"version\":\"1\",\"type\":\"formula\",\"pinned\":false}]}");
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .loaded = .{ .list = list } });
+    try testing.expect(next == .none);
+    try testing.expectEqual(@as(usize, 1), st.items.len);
+    try testing.expectEqual(@as(?usize, 1), shared.installed_count);
+}
+
+test "update on a cleared read empties the Cellar to a known zero" {
+    var st: State = .{ .items = &sample };
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .cleared);
+    try testing.expect(next == .none);
     try testing.expectEqual(@as(usize, 0), st.items.len);
-    try testing.expect(!env.shared.banner.isSet());
-    try testing.expectEqual(@as(?usize, 0), env.shared.installed_count);
+    try testing.expectEqual(@as(?usize, 0), shared.installed_count);
 }
 
-test "a failed info read names the package in the banner and leaves the pane closed" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+test "a successful uninstall clears the pending target, marks siblings stale, refetches" {
+    var st: State = .{ .pending_uninstall = ConfirmTarget.init("brotli") };
     var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
     defer storage.deinit(testing.allocator);
-    const items = [_]Pkg{.{ .name = "jq", .version = "1", .kind = .formula, .pinned = false, .size_bytes = null, .linked = null }};
-    var st: State = .{ .items = &items };
-    var c = mkCtx(thr.io(), &env, "/bin/echo");
-    try testing.expectError(error.BadJson, openDetail(&st, &storage, &c));
-    try testing.expectEqualStrings("info for jq failed: BadJson", env.shared.banner.slice());
-    try testing.expect(st.detail == null); // the pane never opened
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .mutated = 0 });
+    defer testing.allocator.free(next.read.argv);
+    try testing.expect(next == .read);
+    try testing.expectEqualStrings("list", next.read.argv[1]); // refetch the list
+    try testing.expect(st.pending_uninstall == null);
+    try testing.expect(shared.takeDirty(.outdated)); // siblings marked stale
+}
+
+test "a failed uninstall banners and does not refetch" {
+    var st: State = .{ .pending_uninstall = ConfirmTarget.init("brotli") };
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .mutated = 1 });
+    try testing.expect(next == .none);
+    try testing.expect(st.pending_uninstall == null);
+    try testing.expect(std.mem.startsWith(u8, shared.banner.slice(), "uninstall failed"));
+}
+
+test "refreshCmd is the `mt list --size --linked` read for the lazy on-entry reload" {
+    const eff = refreshCmd(testing.allocator, "/bin/mt");
+    defer testing.allocator.free(eff.read.argv);
+    try testing.expect(eff == .read);
+    try testing.expect(eff.read.allow_empty); // a fresh prefix reads empty
+    try testing.expectEqualStrings("list", eff.read.argv[1]);
+    try testing.expectEqualStrings("--size", eff.read.argv[2]);
+    try testing.expectEqualStrings("--linked", eff.read.argv[3]);
+    try testing.expectEqualStrings("--json", eff.read.argv[4]);
 }

--- a/src/tui/outdated_tab.zig
+++ b/src/tui/outdated_tab.zig
@@ -1,8 +1,11 @@
 //! malt — Outdated tab for `mt tui`: the multi-select upgrade pane.
 //!
-//! Leaf module. Pure cores only: `step(state, key)` toggles the per-row checkbox
-//! set and records an `upgrade` request for the impure shell to delegate to the
-//! real `mt upgrade`; `render(state, frame, rect)` is a pure function of
+//! Leaf module. Pure cores only: `step` toggles the per-row checkbox set (pure
+//! state) or returns an upgrade `Cmd` for the real `mt upgrade`; `update` folds
+//! the pump's result back — a finished pass drops its rows, then chains the cask
+//! pass after the formula one (`mt upgrade <name>` is formula-first, so the kinds
+//! run separately). The tab names effects as data and never imports the runner.
+//! `render(state, frame, rect)` is a pure function of
 //! `(state, rect)` so a resize is a re-render. The shell owns the row data and
 //! the parallel `checked` buffer; the tab borrows both. Pinned rows are shown
 //! greyed and can never enter the checked set — the wireframe holds them back
@@ -11,18 +14,15 @@
 //! selection is a no-op surfaced by the action line.
 
 const std = @import("std");
+const cmd = @import("cmd.zig");
 const ctx = @import("ctx.zig");
 const tab = @import("tab.zig");
 const scroll_list = @import("scroll_list.zig");
 const outdated_json = @import("json/outdated.zig");
-const spawn = @import("spawn.zig");
 const color = @import("../ui/color.zig");
 
 pub const Row = outdated_json.OutdatedRow;
-
-/// An effect the pure `step` defers to the impure shell, which performs it and
-/// resets the field. `step` never does I/O — this is the command channel.
-pub const Request = enum { none, upgrade };
+const Kind = outdated_json.Kind;
 
 pub const State = struct {
     chrome: tab.Chrome = .{},
@@ -32,8 +32,10 @@ pub const State = struct {
     /// row's slot is never set. The cores guard against a shorter slice so a
     /// not-yet-sized buffer (before the shell allocates it) never traps.
     checked: []bool = &.{},
-    /// Pending effect for the shell to perform, then clear.
-    request: Request = .none,
+    /// The upgrade pass in flight, so `update` knows which kind's checked rows a
+    /// finished `mt upgrade` covered. `mt upgrade <name>` is formula-first, so the
+    /// two kinds run as separate passes; `null` when no upgrade is in flight.
+    pending_kind: ?Kind = null,
 };
 
 /// Tab-private parse storage: the Outdated audit's parsed rows plus the parallel
@@ -52,13 +54,6 @@ pub const Storage = struct {
 
 /// Outdated audits in the background; a non-clean exit means a failed refresh.
 pub const fetch_spec: ?tab.FetchSpec = .{ .verb = &.{"outdated"}, .max_ok_exit = 0, .refresh_op = "outdated refresh failed" };
-
-/// Whether the pending request will spawn a DB-mutating child (`mt upgrade`). The
-/// shell folds this over every tab before opening the DB so a live background
-/// audit is drained first — the WAL single-writer invariant.
-pub fn mutates(s: *const State) bool {
-    return s.request == .upgrade;
-}
 
 pub fn title() []const u8 {
     return "Outdated";
@@ -124,22 +119,25 @@ pub fn selectedNames(s: *const State, out: [][]const u8) usize {
     return n;
 }
 
-/// Pure transition: toggle the cursor row, bulk select/clear, or request the
-/// upgrade. A pinned cursor row cannot be toggled.
-pub fn step(s: *State, key: tab.Key) void {
+/// Pure transition: toggle the cursor row / bulk select / clear are pure state
+/// (`Cmd.none`); `u`/Enter with a non-empty selection returns the upgrade `Cmd`.
+/// A pinned cursor row cannot be toggled.
+pub fn step(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, key: tab.Key) cmd.Cmd {
+    _ = storage;
     switch (key) {
         .space => toggleSelected(s),
-        .enter => requestUpgrade(s),
+        .enter => return upgradeCmd(allocator, mt_path, s),
         // Only the tab knows its filtered row count, so the shell defers End here.
         .end => s.chrome.view.selected = filteredCount(s.items, s.chrome.filter.slice()) -| 1,
         .char => |c| if (c.len == 1) switch (c.bytes[0]) {
-            'u' => requestUpgrade(s),
+            'u' => return upgradeCmd(allocator, mt_path, s),
             'a' => setAll(s, true),
             'n' => setAll(s, false),
             else => {},
         },
         else => {},
     }
+    return .none;
 }
 
 fn toggleSelected(s: *State) void {
@@ -155,10 +153,6 @@ fn setAll(s: *State, on: bool) void {
         if (i >= s.checked.len) break;
         s.checked[i] = on and !p.pinned;
     }
-}
-
-fn requestUpgrade(s: *State) void {
-    if (selectedCount(s) > 0) s.request = .upgrade; // empty selection is a no-op
 }
 
 /// Pure render: the filtered + scrolled checkbox list. The multi-select keys
@@ -253,50 +247,46 @@ fn appendPad(buf: []u8, len: *usize, s: []const u8, width: usize) void {
 // ports explicitly through the shared `ctx.Ctx` — never a global — so the
 // pure/impure line is the function signature.
 
-/// The effect chain's error set, composed from the source sets so it tracks them
-/// automatically. A subset of the shell's `RunError`, which classifies each fault
-/// recoverable-vs-fatal; naming it here keeps the public `service` explicit.
-pub const Error = std.mem.Allocator.Error || spawn.ReadError || spawn.InlineError || outdated_json.Error;
+// ─── effect producers ───────────────────────────────────────────────────
+// The tab names effects as `Cmd` values; the pump performs them and folds the
+// result back through `update`. No I/O and no runner import here.
 
-/// Perform any upgrade effect the pure `step` requested, then clear it — the
-/// consumer half of the `request` seam. The shell dispatches this only for the
-/// active tab; the lazy (re)load on entry / after staleness stays loop machinery.
-pub fn service(s: *State, storage: *Storage, c: *ctx.Ctx) Error!void {
-    const req = s.request;
-    s.request = .none;
-    switch (req) {
-        .none => {},
-        .upgrade => try doUpgrade(s, storage, c),
-    }
-}
+/// Banner op strings for a recoverable fault, parity with the pre-reify error
+/// names so the dashboard shows the same banners it always has.
+const upgrade_fail_op = "upgrade failed";
+const refresh_fail_op = "outdated refresh failed";
 
 /// One upgraded row, identified by `(name, kind)` so a formula and a cask that
 /// share a name (e.g. `docker`) are never confused for one another.
-const UpgradedRef = struct { name: []const u8, kind: outdated_json.Kind };
+const UpgradedRef = struct { name: []const u8, kind: Kind };
 
-/// Collect the checked, non-pinned rows into `out` as `(name, kind)` refs,
-/// formula rows first then cask rows; returns the formula count (the split
-/// index). `out` must be sized to `selectedCount`. Partitioning by kind lets
-/// `doUpgrade` issue one `--formula` pass and one `--cask` pass.
-fn collectUpgraded(s: *const State, out: []UpgradedRef) usize {
-    // The two item-order passes below cover exactly `{formula, cask}`; a new
-    // Kind variant would leave its rows uncollected. Lock it at compile time.
-    comptime std.debug.assert(@typeInfo(outdated_json.Kind).@"enum".fields.len == 2);
+/// Count checked, non-pinned rows of one kind — a single upgrade pass's size.
+fn countKind(s: *const State, kind: Kind) usize {
     var n: usize = 0;
-    var split: usize = 0;
-    // Two item-order passes so each kind's names stay in display order and the
-    // formula refs land in `out[0..split]`, casks in `out[split..]`.
-    for ([_]outdated_json.Kind{ .formula, .cask }) |kind| {
-        for (s.items, 0..) |row, i| {
-            // Same rule as `selectedNames`: checked, non-pinned, this kind.
-            if (i < s.checked.len and s.checked[i] and !row.pinned and row.kind == kind and n < out.len) {
-                out[n] = .{ .name = row.name, .kind = row.kind };
-                n += 1;
-            }
-        }
-        if (kind == .formula) split = n;
+    for (s.items, 0..) |row, i| {
+        if (i < s.checked.len and s.checked[i] and !row.pinned and row.kind == kind) n += 1;
     }
-    return split;
+    return n;
+}
+
+/// Collect one kind's checked, non-pinned rows into `out` (item order); returns
+/// the count written. `out` must be sized to `countKind`.
+fn collectKind(s: *const State, kind: Kind, out: []UpgradedRef) usize {
+    var n: usize = 0;
+    for (s.items, 0..) |row, i| {
+        if (i < s.checked.len and s.checked[i] and !row.pinned and row.kind == kind and n < out.len) {
+            out[n] = .{ .name = row.name, .kind = kind };
+            n += 1;
+        }
+    }
+    return n;
+}
+
+fn kindFlag(kind: Kind) []const u8 {
+    return switch (kind) {
+        .formula => "--formula",
+        .cask => "--cask",
+    };
 }
 
 /// Build `[mt, upgrade, <flag>, names...]` for a single-kind ref slice, or null
@@ -314,7 +304,76 @@ fn kindUpgradeArgv(
     rest[0] = "upgrade";
     rest[1] = flag;
     for (refs, rest[2..]) |r, *slot| slot.* = r.name;
-    return try spawn.inlineArgv(allocator, mt_path, rest);
+    return try cmd.inlineArgv(allocator, mt_path, rest);
+}
+
+/// Start the first upgrade pass for a non-empty selection: formula-first, since
+/// `mt upgrade <name>` resolves formula-first so a checked cask must go through a
+/// `--cask` pass, never folded into a formula one. Records the in-flight kind so
+/// `update` knows which rows a finished pass covered.
+fn upgradeCmd(allocator: std.mem.Allocator, mt_path: []const u8, s: *State) cmd.Cmd {
+    if (selectedCount(s) == 0) return .none; // empty selection: no-op
+    return startPass(allocator, mt_path, s, .formula) orelse
+        startPass(allocator, mt_path, s, .cask) orelse .none;
+}
+
+/// Build one kind's upgrade `run_mutation` and mark it pending, or `null` when no
+/// row of that kind is checked. An argv-build OOM drops the effect, not the TUI.
+fn startPass(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, kind: Kind) ?cmd.Cmd {
+    const n = countKind(s, kind);
+    if (n == 0) return null;
+    const refs = allocator.alloc(UpgradedRef, n) catch return null;
+    defer allocator.free(refs);
+    _ = collectKind(s, kind, refs);
+    const argv = (kindUpgradeArgv(allocator, mt_path, refs, kindFlag(kind)) catch return null) orelse return null;
+    s.pending_kind = kind;
+    return .{ .run_mutation = .{ .argv = argv, .tag = .outdated, .fail_op = upgrade_fail_op } };
+}
+
+/// Fold a completed effect back into the model. A finished upgrade pass drops its
+/// upgraded rows on success (preserving other rows' checked state) or surfaces the
+/// recoverable banner on failure, then chains the cask pass after the formula one.
+/// A delivered read swaps in fresh rows + an all-clear checkbox set.
+pub fn update(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, shared: *ctx.SharedModel, msg: cmd.Msg) cmd.Cmd {
+    switch (msg) {
+        .mutated => |code| return foldUpgradePass(allocator, mt_path, s, storage, shared, code),
+        .loaded => |parsed| {
+            // `update` owns the delivered parse: store it, or free it if the
+            // checkbox-buffer alloc fails, and keep the last-good rows behind a banner.
+            applyOutdatedParse(allocator, s, storage, shared, parsed.outdated) catch |err| {
+                parsed.outdated.deinit();
+                shared.banner.set(refresh_fail_op, @errorName(err));
+            };
+            return .none;
+        },
+        .cleared => {
+            clearRows(allocator, s, storage, shared); // exit-0 empty read: nothing outdated
+            return .none;
+        },
+        .failed => return .none, // the pump set the banner; keep the last-good rows
+    }
+}
+
+/// Fold one finished upgrade pass: drop its rows on success (exit 0), else banner;
+/// then advance formula → cask so both kinds upgrade under the right flag.
+fn foldUpgradePass(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, shared: *ctx.SharedModel, code: u8) cmd.Cmd {
+    const kind = s.pending_kind orelse return .none; // defensive: no pass in flight
+    if (code == 0) {
+        // A checkbox-buffer realloc OOM keeps the rows behind a banner, never traps.
+        dropCheckedKind(allocator, s, storage, shared, kind) catch |err|
+            shared.banner.set(upgrade_fail_op, @errorName(err));
+        shared.markStaleAfter(.outdated); // Installed sizes/versions changed too
+    } else {
+        var dbuf: [96]u8 = undefined;
+        shared.banner.set(upgrade_fail_op, failDetail(&dbuf, s, kind, code));
+    }
+    // Passes are independent: run the cask pass after the formula one regardless of
+    // the formula outcome, so a failed formula pass still lets checked casks upgrade.
+    if (kind == .formula) {
+        if (startPass(allocator, mt_path, s, .cask)) |next| return next;
+    }
+    s.pending_kind = null;
+    return .none;
 }
 
 /// The exit code `mt upgrade` returns when it refused a cask because the app is
@@ -322,54 +381,28 @@ fn kindUpgradeArgv(
 /// process contract, like the doctor severity cap the inline runner already knows.
 const cask_app_running_exit: u8 = 3;
 
-/// Footer detail for a failed cask upgrade pass: on the app-running refusal name
-/// the live app (or "a selected app" when the pass carried several) so the footer
-/// says *why*, not an opaque "ChildFailed". `buf` backs the single-cask name;
-/// `Banner.set` copies the result, so a stack buffer is enough.
-fn upgradeFailDetail(buf: []u8, code: u8, refs: []const UpgradedRef) []const u8 {
+/// Banner detail for a failed upgrade pass: on the cask app-running refusal name
+/// the live app (or "a selected app" when the pass carried several) so the banner
+/// says *why*, not an opaque "ChildFailed". `buf` backs the single-cask name.
+fn failDetail(buf: []u8, s: *const State, kind: Kind, code: u8) []const u8 {
     if (code != cask_app_running_exit) return "ChildFailed";
-    if (refs.len == 1) return std.fmt.bufPrint(buf, "{s} is running", .{refs[0].name}) catch "an app is running";
+    if (countKind(s, kind) == 1) {
+        var one: [1]UpgradedRef = undefined;
+        _ = collectKind(s, kind, &one);
+        return std.fmt.bufPrint(buf, "{s} is running", .{one[0].name}) catch "an app is running";
+    }
     return "a selected app is running";
 }
 
-/// Delegate the checked upgrades to the real `mt` inline, then drop the upgraded
-/// rows in place. Runs one pass per kind (`--formula`, `--cask`) so the row the
-/// user checked is the row upgraded — `mt upgrade <name>` is formula-first, so a
-/// checked cask would otherwise upgrade a same-named formula. Names borrow the
-/// parse arena, which `dropUpgradedRows` keeps alive across both passes.
-fn doUpgrade(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
-    const count = selectedCount(s);
-    if (count == 0) return; // empty selection: no-op
-    // Snapshot the selection (formula refs first, then cask) before any upgrade
-    // or drop — the drop rebuilds the checkbox buffer, erasing the selection.
-    const upgraded = try c.allocator.alloc(UpgradedRef, count);
-    defer c.allocator.free(upgraded);
-    const split = collectUpgraded(s, upgraded);
-
-    const passes = [_]struct { refs: []const UpgradedRef, flag: []const u8 }{
-        .{ .refs = upgraded[0..split], .flag = "--formula" },
-        .{ .refs = upgraded[split..], .flag = "--cask" },
-    };
-    // Passes run independently: a failed formula pass still lets the cask pass
-    // proceed, and only a succeeded pass's rows are dropped. A non-zero `mt
-    // upgrade` re-enters the dashboard and surfaces as a recoverable banner.
-    var dropped_any = false;
-    for (passes) |pass| {
-        const argv = (try kindUpgradeArgv(c.allocator, c.mt_path, pass.refs, pass.flag)) orelse continue;
-        defer c.allocator.free(argv);
-        if (spawn.runInlineReenterStatus(c.term, argv)) |code| {
-            if (code == 0) {
-                try dropUpgradedRows(c.allocator, s, storage, c.shared, pass.refs);
-                dropped_any = true;
-            } else {
-                var dbuf: [96]u8 = undefined;
-                c.shared.banner.set("upgrade failed", upgradeFailDetail(&dbuf, code, pass.refs));
-            }
-        } else |err| {
-            c.shared.banner.set("upgrade failed", @errorName(err));
-        }
-    }
-    if (dropped_any) c.shared.markStaleAfter(.outdated); // Installed sizes/versions changed too
+/// Drop the checked rows of one kind — the just-upgraded set — preserving the
+/// kept rows' checked state. Collects the refs for `dropUpgradedRows`.
+fn dropCheckedKind(allocator: std.mem.Allocator, s: *State, storage: *Storage, shared: *ctx.SharedModel, kind: Kind) std.mem.Allocator.Error!void {
+    const n = countKind(s, kind);
+    if (n == 0) return;
+    const refs = try allocator.alloc(UpgradedRef, n);
+    defer allocator.free(refs);
+    _ = collectKind(s, kind, refs);
+    try dropUpgradedRows(allocator, s, storage, shared, refs);
 }
 
 /// True when `row` is one of the upgraded rows (linear scan — a batch is small).
@@ -437,20 +470,32 @@ fn dropUpgradedRows(
 /// last-good rows for the caller's banner to explain. Public because the shell's
 /// fetch drain routes a background payload through it.
 pub fn applyOutdatedBytes(allocator: std.mem.Allocator, st: *State, storage: *Storage, shared: *ctx.SharedModel, bytes: ?[]const u8) outdated_json.Error!void {
-    const payload = bytes orelse {
-        if (storage.outdated) |old| old.deinit();
-        if (storage.checked.len != 0) allocator.free(storage.checked);
-        storage.outdated = null;
-        storage.checked = &.{};
-        st.items = &.{};
-        st.checked = &.{};
-        shared.outdated_count = 0; // nothing outdated is a known zero, not "unknown"
-        return;
-    };
+    const payload = bytes orelse return clearRows(allocator, st, storage, shared);
     const parsed = try outdated_json.parse(allocator, payload);
     errdefer parsed.deinit();
-    // A fresh checkbox buffer, all clear: an upgrade removes the upgraded rows, so
-    // carrying the old selection forward would point at the wrong packages.
+    try applyOutdatedParse(allocator, st, storage, shared, parsed);
+}
+
+/// Clear to the known-zero state, freeing the parse and the shell-owned checkbox
+/// buffer. Shared by a null background payload and a `.cleared` keypress read.
+fn clearRows(allocator: std.mem.Allocator, st: *State, storage: *Storage, shared: *ctx.SharedModel) void {
+    if (storage.outdated) |old| old.deinit();
+    if (storage.checked.len != 0) allocator.free(storage.checked);
+    storage.outdated = null;
+    storage.checked = &.{};
+    st.items = &.{};
+    st.checked = &.{};
+    shared.outdated_count = 0; // nothing outdated is a known zero, not "unknown"
+}
+
+/// Repoint the Outdated tab + header count at a fresh parse, allocating a new
+/// all-clear checkbox buffer (shell-owned) and freeing the previous parse/buffer.
+/// An upgrade removes the upgraded rows, so carrying the old selection forward
+/// would point at the wrong packages — the buffer starts clear. Shared by the
+/// background fetch drain (`applyOutdatedBytes`) and the keypress reload (`update`
+/// on `.loaded`). The swap runs only after `checked` is allocated, so a fold OOM
+/// leaves `parsed` for the caller's `errdefer`/banner and never half-applies.
+fn applyOutdatedParse(allocator: std.mem.Allocator, st: *State, storage: *Storage, shared: *ctx.SharedModel, parsed: outdated_json.Parsed) std.mem.Allocator.Error!void {
     const checked = try allocator.alloc(bool, parsed.items.len);
     @memset(checked, false);
 
@@ -471,6 +516,14 @@ fn ch(c: u8) tab.Key {
     return .{ .char = .{ .bytes = .{ c, 0, 0, 0 }, .len = 1 } };
 }
 
+/// Drive `step` with a throwaway storage and a fixed mt path. Outdated's `step`
+/// ignores storage, so this keeps the pure-behaviour tests readable.
+fn stepKey(s: *State, key: tab.Key) cmd.Cmd {
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    return step(testing.allocator, "/opt/malt/bin/mt", s, &storage, key);
+}
+
 // Index 1 (curl) is pinned: shown but held back from any bulk upgrade.
 const sample = [_]Row{
     .{ .name = "wget", .installed = "1.24.5", .latest = "1.25.0", .kind = .formula, .pinned = false, .tap = "" },
@@ -481,11 +534,11 @@ const sample = [_]Row{
 
 test "End jumps to the last filtered row" {
     var s: State = .{ .items = &sample };
-    step(&s, .end);
+    _ = stepKey(&s, .end);
     try testing.expectEqual(@as(usize, 3), s.chrome.view.selected);
 
     s.chrome.filter.push("f"); // firefox, ffmpeg
-    step(&s, .end);
+    _ = stepKey(&s, .end);
     try testing.expectEqual(@as(usize, 1), s.chrome.view.selected);
 }
 
@@ -499,9 +552,9 @@ test "space toggles the cursor row's checkbox" {
     var checked = [_]bool{false} ** 4;
     var s: State = .{ .items = &sample, .checked = &checked };
     s.chrome.view.selected = 0; // wget
-    step(&s, .space);
+    _ = stepKey(&s, .space);
     try testing.expect(checked[0]);
-    step(&s, .space); // toggles back off
+    _ = stepKey(&s, .space); // toggles back off
     try testing.expect(!checked[0]);
 }
 
@@ -509,14 +562,14 @@ test "space on a pinned cursor row never checks it" {
     var checked = [_]bool{false} ** 4;
     var s: State = .{ .items = &sample, .checked = &checked };
     s.chrome.view.selected = 1; // curl (pinned)
-    step(&s, .space);
+    _ = stepKey(&s, .space);
     try testing.expect(!checked[1]);
 }
 
 test "a checks every non-pinned row and leaves pinned rows unchecked" {
     var checked = [_]bool{false} ** 4;
     var s: State = .{ .items = &sample, .checked = &checked };
-    step(&s, ch('a'));
+    _ = stepKey(&s, ch('a'));
     try testing.expect(checked[0]); // wget
     try testing.expect(!checked[1]); // curl is pinned — excluded
     try testing.expect(checked[2]); // firefox
@@ -526,32 +579,42 @@ test "a checks every non-pinned row and leaves pinned rows unchecked" {
 test "n clears every checkbox" {
     var checked = [_]bool{ true, false, true, true };
     var s: State = .{ .items = &sample, .checked = &checked };
-    step(&s, ch('n'));
+    _ = stepKey(&s, ch('n'));
     for (checked) |b| try testing.expect(!b);
 }
 
-test "u requests the upgrade only when something is selected" {
+test "u returns the upgrade mutation only when something is selected" {
     var checked = [_]bool{false} ** 4;
     var s: State = .{ .items = &sample, .checked = &checked };
-    step(&s, ch('u')); // empty selection → no-op
-    try testing.expectEqual(Request.none, s.request);
-    checked[0] = true;
-    step(&s, ch('u'));
-    try testing.expectEqual(Request.upgrade, s.request);
+    try testing.expect(stepKey(&s, ch('u')) == .none); // empty selection → no-op
+    checked[0] = true; // wget (formula)
+    const eff = stepKey(&s, ch('u'));
+    defer testing.allocator.free(eff.run_mutation.argv);
+    try testing.expect(eff == .run_mutation);
+    try testing.expectEqual(cmd.MsgTag.outdated, eff.run_mutation.tag);
+    try testing.expectEqual(Kind.formula, s.pending_kind.?); // formula pass in flight
+    const argv = eff.run_mutation.argv;
+    try testing.expectEqualStrings("upgrade", argv[1]);
+    try testing.expectEqualStrings("--formula", argv[2]);
+    try testing.expectEqualStrings("wget", argv[3]);
 }
 
-test "Enter requests the upgrade like u" {
+test "Enter returns the upgrade mutation like u" {
     var checked = [_]bool{ true, false, false, false };
     var s: State = .{ .items = &sample, .checked = &checked };
-    step(&s, .enter);
-    try testing.expectEqual(Request.upgrade, s.request);
+    const eff = stepKey(&s, .enter);
+    defer testing.allocator.free(eff.run_mutation.argv);
+    try testing.expect(eff == .run_mutation);
 }
 
-test "mutates is true only for a pending upgrade — the request that takes the WAL writer" {
-    var s: State = .{};
-    try testing.expect(!mutates(&s)); // .none never gates the pre-mutation drain
-    s.request = .upgrade;
-    try testing.expect(mutates(&s));
+test "a cask-only selection starts with the cask pass" {
+    var checked = [_]bool{ false, false, true, false }; // firefox (cask)
+    var s: State = .{ .items = &sample, .checked = &checked };
+    const eff = stepKey(&s, ch('u'));
+    defer testing.allocator.free(eff.run_mutation.argv);
+    try testing.expectEqual(Kind.cask, s.pending_kind.?);
+    try testing.expectEqualStrings("--cask", eff.run_mutation.argv[2]);
+    try testing.expectEqualStrings("firefox", eff.run_mutation.argv[3]);
 }
 
 test "selectedCount counts checked, non-pinned rows" {
@@ -677,44 +740,49 @@ test "the cores tolerate a checked slice shorter than items without trapping" {
     // Before the shell sizes `checked`, the cores must not index out of bounds.
     var checked = [_]bool{false}; // len 1, items len 4
     var s: State = .{ .items = &sample, .checked = &checked };
-    step(&s, ch('a')); // setAll must stop at the slice end
-    step(&s, .space); // toggle the cursor row only if in range
+    _ = stepKey(&s, ch('a')); // setAll must stop at the slice end
+    _ = stepKey(&s, .space); // toggle the cursor row only if in range
     _ = selectedCount(&s);
     var out: [4][]const u8 = undefined;
     _ = selectedNames(&s, &out);
 }
 
-test "upgradeFailDetail names the live app on the refusal code, else stays generic" {
+test "failDetail names the live app on the cask refusal code, else stays generic" {
     var buf: [96]u8 = undefined;
-    const one = [_]UpgradedRef{.{ .name = "flux-markdown", .kind = .cask }};
-    const many = [_]UpgradedRef{ .{ .name = "a", .kind = .cask }, .{ .name = "b", .kind = .cask } };
+    const one = [_]Row{.{ .name = "flux-markdown", .installed = "1", .latest = "2", .kind = .cask, .pinned = false, .tap = "" }};
+    var checked1 = [_]bool{true};
+    const s1: State = .{ .items = &one, .checked = &checked1 };
+    try testing.expectEqualStrings("flux-markdown is running", failDetail(&buf, &s1, .cask, cask_app_running_exit));
 
-    // The refusal code names the one cask, or stays generic for a batch.
-    try testing.expectEqualStrings("flux-markdown is running", upgradeFailDetail(&buf, cask_app_running_exit, &one));
-    try testing.expectEqualStrings("a selected app is running", upgradeFailDetail(&buf, cask_app_running_exit, &many));
+    const two = [_]Row{
+        .{ .name = "a", .installed = "1", .latest = "2", .kind = .cask, .pinned = false, .tap = "" },
+        .{ .name = "b", .installed = "1", .latest = "2", .kind = .cask, .pinned = false, .tap = "" },
+    };
+    var checked2 = [_]bool{ true, true };
+    const s2: State = .{ .items = &two, .checked = &checked2 };
+    try testing.expectEqualStrings("a selected app is running", failDetail(&buf, &s2, .cask, cask_app_running_exit));
+
     // Any other non-zero exit is the generic child failure, unnamed.
-    try testing.expectEqualStrings("ChildFailed", upgradeFailDetail(&buf, 1, &one));
-
-    // Edge: a name longer than the buffer falls back rather than truncating mid-name.
+    try testing.expectEqualStrings("ChildFailed", failDetail(&buf, &s1, .cask, 1));
+    // A name longer than the buffer falls back rather than truncating mid-name.
     var tiny: [4]u8 = undefined;
-    try testing.expectEqualStrings("an app is running", upgradeFailDetail(&tiny, cask_app_running_exit, &one));
+    try testing.expectEqualStrings("an app is running", failDetail(&tiny, &s1, .cask, cask_app_running_exit));
 }
 
-test "collectUpgraded partitions checked rows formula-first, then cask, excluding pinned" {
+test "countKind and collectKind cover the checked, non-pinned rows of a kind" {
     const items = [_]Row{
         .{ .name = "firefox", .installed = "1", .latest = "2", .kind = .cask, .pinned = false, .tap = "" },
         .{ .name = "wget", .installed = "1", .latest = "2", .kind = .formula, .pinned = false, .tap = "" },
         .{ .name = "held", .installed = "1", .latest = "2", .kind = .formula, .pinned = true, .tap = "" },
     };
     var checked = [_]bool{ true, true, true }; // held is pinned → excluded
-    var st: State = .{ .items = &items, .checked = &checked };
-    var buf: [3]UpgradedRef = undefined;
-    const split = collectUpgraded(&st, buf[0..selectedCount(&st)]);
-    try testing.expectEqual(@as(usize, 1), split); // one formula, before the cask
-    try testing.expectEqualStrings("wget", buf[0].name);
-    try testing.expectEqual(outdated_json.Kind.formula, buf[0].kind);
-    try testing.expectEqualStrings("firefox", buf[1].name);
-    try testing.expectEqual(outdated_json.Kind.cask, buf[1].kind);
+    const st: State = .{ .items = &items, .checked = &checked };
+    try testing.expectEqual(@as(usize, 1), countKind(&st, .formula)); // wget (held pinned)
+    try testing.expectEqual(@as(usize, 1), countKind(&st, .cask)); // firefox
+    var out: [1]UpgradedRef = undefined;
+    try testing.expectEqual(@as(usize, 1), collectKind(&st, .formula, &out));
+    try testing.expectEqualStrings("wget", out[0].name);
+    try testing.expectEqual(Kind.formula, out[0].kind);
 }
 
 test "kindUpgradeArgv builds `mt upgrade <flag> <names>`, null for no refs" {
@@ -731,42 +799,67 @@ test "kindUpgradeArgv builds `mt upgrade <flag> <names>`, null for no refs" {
     try testing.expect((try kindUpgradeArgv(testing.allocator, "/bin/mt", &.{}, "--cask")) == null);
 }
 
-test "a mixed selection yields a --formula pass and a --cask pass" {
-    const items = [_]Row{
-        .{ .name = "wget", .installed = "1", .latest = "2", .kind = .formula, .pinned = false, .tap = "" },
-        .{ .name = "firefox", .installed = "1", .latest = "2", .kind = .cask, .pinned = false, .tap = "" },
-    };
-    var checked = [_]bool{ true, true };
-    var st: State = .{ .items = &items, .checked = &checked };
-    var buf: [2]UpgradedRef = undefined;
-    const split = collectUpgraded(&st, buf[0..selectedCount(&st)]);
+test "an upgrade runs a --formula pass, then chains a --cask pass, dropping each" {
+    var st: State = .{};
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    const json =
+        \\{"outdated":[
+        \\{"name":"wget","installed":"1","latest":"2","type":"formula","pinned":false},
+        \\{"name":"firefox","installed":"1","latest":"2","type":"cask","pinned":false}
+        \\]}
+    ;
+    try applyOutdatedBytes(testing.allocator, &st, &storage, &shared, json);
+    storage.checked[0] = true; // wget (formula)
+    storage.checked[1] = true; // firefox (cask)
+    st.checked = storage.checked;
 
-    const f = (try kindUpgradeArgv(testing.allocator, "/bin/mt", buf[0..split], "--formula")).?;
-    defer testing.allocator.free(f);
-    try testing.expectEqualStrings("--formula", f[2]);
-    try testing.expectEqualStrings("wget", f[3]);
+    // step → formula pass in flight.
+    const first = step(testing.allocator, "/bin/mt", &st, &storage, ch('u'));
+    testing.allocator.free(first.run_mutation.argv);
+    try testing.expectEqual(Kind.formula, st.pending_kind.?);
 
-    const c = (try kindUpgradeArgv(testing.allocator, "/bin/mt", buf[split..], "--cask")).?;
-    defer testing.allocator.free(c);
-    try testing.expectEqualStrings("--cask", c[2]);
-    try testing.expectEqualStrings("firefox", c[3]);
+    // A successful formula pass drops wget and returns the cask pass.
+    const second = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .mutated = 0 });
+    defer testing.allocator.free(second.run_mutation.argv);
+    try testing.expect(second == .run_mutation);
+    try testing.expectEqualStrings("--cask", second.run_mutation.argv[2]);
+    try testing.expectEqual(Kind.cask, st.pending_kind.?);
+    try testing.expectEqual(@as(usize, 1), st.items.len); // wget dropped
+    try testing.expectEqualStrings("firefox", st.items[0].name);
+
+    // A successful cask pass drops firefox and ends the chain.
+    const done = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .mutated = 0 });
+    try testing.expect(done == .none);
+    try testing.expectEqual(@as(usize, 0), st.items.len);
+    try testing.expect(st.pending_kind == null);
 }
 
-test "a cask-only selection runs no formula pass and upgrades the cask" {
-    const items = [_]Row{
-        .{ .name = "wget", .installed = "1", .latest = "2", .kind = .formula, .pinned = false, .tap = "" },
-        .{ .name = "firefox", .installed = "1", .latest = "2", .kind = .cask, .pinned = false, .tap = "" },
-    };
-    var checked = [_]bool{ false, true }; // only the cask is checked
-    var st: State = .{ .items = &items, .checked = &checked };
-    var buf: [1]UpgradedRef = undefined;
-    const split = collectUpgraded(&st, buf[0..selectedCount(&st)]);
-    try testing.expectEqual(@as(usize, 0), split); // no formula rows
-    try testing.expect((try kindUpgradeArgv(testing.allocator, "/bin/mt", buf[0..split], "--formula")) == null);
-    const c = (try kindUpgradeArgv(testing.allocator, "/bin/mt", buf[split..], "--cask")).?;
-    defer testing.allocator.free(c);
-    try testing.expectEqualStrings("--cask", c[2]);
-    try testing.expectEqualStrings("firefox", c[3]);
+test "a failed formula pass keeps its rows and still chains the cask pass" {
+    var st: State = .{};
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    const json =
+        \\{"outdated":[
+        \\{"name":"wget","installed":"1","latest":"2","type":"formula","pinned":false},
+        \\{"name":"firefox","installed":"1","latest":"2","type":"cask","pinned":false}
+        \\]}
+    ;
+    try applyOutdatedBytes(testing.allocator, &st, &storage, &shared, json);
+    storage.checked[0] = true;
+    storage.checked[1] = true;
+    st.checked = storage.checked;
+    st.pending_kind = .formula; // a formula pass was in flight
+
+    // A non-zero formula pass banners and keeps wget, but still returns the cask pass.
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .mutated = 1 });
+    defer testing.allocator.free(next.run_mutation.argv);
+    try testing.expect(next == .run_mutation);
+    try testing.expectEqual(Kind.cask, st.pending_kind.?);
+    try testing.expectEqual(@as(usize, 2), st.items.len); // nothing dropped
+    try testing.expect(std.mem.startsWith(u8, shared.banner.slice(), "upgrade failed"));
 }
 
 test "dropUpgradedRows removes upgraded rows in place and preserves kept checked state" {
@@ -903,58 +996,6 @@ test "dropUpgradedRows clears the list when every row was upgraded" {
     try dropUpgradedRows(testing.allocator, &st, &storage, &shared, &.{ .{ .name = "a", .kind = .formula }, .{ .name = "b", .kind = .formula } });
     try testing.expectEqual(@as(usize, 0), storage.outdated.?.items.len);
     try testing.expectEqual(@as(?usize, 0), shared.outdated_count);
-}
-
-// Backing storage for a `ctx.Ctx` in an effect test: dummy term/fetches/shared,
-// a no-op painter (fd = -1; the test children never reach a poll tick), and the
-// synchronous-load flag.
-const TestEnv = struct {
-    term_h: ctx.Term,
-    fetches: ctx.Fetches = ctx.Fetches.initFill(null),
-    shared: ctx.SharedModel = .{},
-    frame: []u8 = &.{},
-    loading: bool = false,
-};
-
-fn mkCtx(io: std.Io, e: *TestEnv, mt_path: []const u8) ctx.Ctx {
-    return .{
-        .io = io,
-        .allocator = testing.allocator,
-        .term = &e.term_h,
-        .painter = .{ .fd = -1, .frame = &e.frame },
-        .fetches = &e.fetches,
-        .shared = &e.shared,
-        .mt_path = mt_path,
-        .loading = &e.loading,
-    };
-}
-
-test "service on a .none request is a clean no-op — no spawn, no banner" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
-    var storage: Storage = .{};
-    defer storage.deinit(testing.allocator);
-    var st: State = .{}; // .none: the pure `step` set nothing to perform
-    var c = mkCtx(thr.io(), &env, "/bin/false"); // would fail if it ever spawned
-    try service(&st, &storage, &c);
-    try testing.expectEqual(Request.none, st.request);
-    try testing.expect(!env.shared.banner.isSet());
-}
-
-test "service drains an upgrade request; an empty selection never spawns" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
-    var storage: Storage = .{};
-    defer storage.deinit(testing.allocator);
-    // An empty selection means `doUpgrade` resolves count == 0: the request drains
-    // but no `mt upgrade` child runs, so `/bin/false` is never reached.
-    var st: State = .{ .request = .upgrade };
-    var c = mkCtx(thr.io(), &env, "/bin/false");
-    try service(&st, &storage, &c);
-    try testing.expectEqual(Request.none, st.request); // the producer/consumer seam drained it
-    try testing.expect(!env.shared.banner.isSet()); // never spawned → no failure banner
 }
 
 test "conforms to the tab contract" {

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -1,9 +1,11 @@
 //! malt — Search tab for `mt tui`: find and install new packages.
 //!
-//! Leaf module. Pure cores only: `step(state, key)` records an intent (re-run
-//! the query, or install the selected hit) as a `request` for the impure shell
-//! to delegate; `render(state, frame, rect)` is a pure function of `(state,
-//! rect)` so a resize is a re-render.
+//! Leaf module. Pure cores only: `step` maps a key to a `Cmd` (`i` installs the
+//! selection, Enter reads `mt info`) or performs a pure basket op in place; the
+//! shell commits the filter-as-query via `searchCmd`. `update` folds the pump's
+//! result back (a search parse becomes the results, an install refetches). The tab
+//! names effects as data and never imports the runner. `render(state, frame, rect)`
+//! is a pure function of `(state, rect)` so a resize is a re-render.
 //!
 //! **Divergence from the other tabs.** Everywhere else `chrome.filter` narrows a
 //! static, already-loaded list. Here the filter *doubles as the search box*: the
@@ -22,8 +24,8 @@ const std = @import("std");
 const testing = std.testing;
 
 const color = @import("../ui/color.zig");
+const cmd = @import("cmd.zig");
 const ctx = @import("ctx.zig");
-const spawn = @import("spawn.zig");
 const detail_pane = @import("detail_pane.zig");
 const info_json = @import("json/info.zig");
 const search_json = @import("json/search.zig");
@@ -31,15 +33,6 @@ pub const Match = search_json.Match;
 const Kind = search_json.Kind;
 const scroll_list = @import("scroll_list.zig");
 const tab = @import("tab.zig");
-
-/// An effect the pure `step` defers to the impure shell, which performs it and
-/// resets the field. `step` never does I/O — this is the command channel.
-/// `search` (re)runs the committed query; `install` installs the selection;
-/// `info` opens `mt info` for the active hit (works for uninstalled hits too);
-/// `toggle` adds/removes the active hit in the shell-owned cross-query basket
-/// (selection outlives the per-query result list, so the leaf cannot own it);
-/// `remove` drops the highlighted basket pick; `clear` empties the whole basket.
-pub const Request = enum { none, search, install, info, toggle, remove, clear };
 
 /// The read lifecycle the render reflects. `idle` before any query is committed
 /// (show guidance), `searching` while the blocking remote read runs (the shell
@@ -62,8 +55,6 @@ pub const State = struct {
     /// The open info pane for the active hit, if Enter requested one. Borrows
     /// from shell-owned parse storage; cleared on Esc or a fresh query.
     detail: ?info_json.Info = null,
-    /// Pending effect for the shell to perform, then clear.
-    request: Request = .none,
     /// Where the tab is in the read lifecycle; drives the render's status line.
     phase: Phase = .idle,
     /// Cross-query basket size, mirrored from the shell-owned selection (no
@@ -80,14 +71,6 @@ pub const State = struct {
 
 /// Search runs synchronously on demand; it never background-fetches.
 pub const fetch_spec: ?tab.FetchSpec = null;
-
-/// Whether the pending request will spawn a DB-mutating child (`mt install`). The
-/// shell folds this over every tab before opening the DB so a live background audit
-/// is drained first — the WAL single-writer invariant. The read-only requests
-/// (search/info) and the pure basket ops (toggle/remove/clear) never gate.
-pub fn mutates(s: *const State) bool {
-    return s.request == .install;
-}
 
 /// One basket row the shell hands the leaf: a borrowed `(name, kind)`. The bytes
 /// are owned (and freed) by the shell-owned set; the leaf renders them (scrubbed)
@@ -204,10 +187,14 @@ pub fn selectedIndex(s: *const State) ?usize {
 /// Request a basket toggle for the active row. An already-installed hit is never
 /// selectable, so it is inert. The shell owns the cross-query basket and writes
 /// the projected `checked` slice; the pure leaf only signals intent here.
-fn requestToggle(s: *State) void {
+fn doToggle(allocator: std.mem.Allocator, s: *State, storage: *Storage) void {
     const m = selectedMatch(s) orelse return;
-    if (m.installed) return;
-    s.request = .toggle;
+    if (m.installed) return; // an already-installed hit is never selectable
+    // OOM drops the toggle, not the TUI; the user retries. The basket op is pure
+    // state (no I/O), so it stays out of the effect path.
+    storage.selected.toggle(allocator, m.name, m.kind) catch return;
+    projectSearchChecked(storage);
+    syncSelected(s, storage);
 }
 
 /// The basket pick the cursor points at, clamping the (shell-driven, unbounded)
@@ -218,46 +205,50 @@ pub fn selectedBasketEntry(s: *const State) ?SelEntry {
     return s.basket[@min(s.chrome.view.selected, s.basket.len - 1)];
 }
 
-/// Request dropping the highlighted basket pick; inert on an empty basket.
-fn requestRemove(s: *State) void {
-    if (selectedBasketEntry(s) != null) s.request = .remove;
+/// Drop the highlighted basket pick, then re-project; inert on an empty basket.
+fn doRemove(allocator: std.mem.Allocator, s: *State, storage: *Storage) void {
+    const e = selectedBasketEntry(s) orelse return;
+    storage.selected.remove(allocator, e.name, e.kind);
+    projectSearchChecked(storage);
+    syncSelected(s, storage);
+}
+
+/// Empty the whole basket, then re-project; inert when it is already empty.
+fn doClear(allocator: std.mem.Allocator, s: *State, storage: *Storage) void {
+    if (s.selected_count == 0) return;
+    storage.selected.clear(allocator);
+    projectSearchChecked(storage);
+    syncSelected(s, storage);
 }
 
 /// `space` selects in the results view and removes in the basket view — the one
 /// key, its meaning set by the view.
-fn selectKey(s: *State) void {
+fn selectKey(allocator: std.mem.Allocator, s: *State, storage: *Storage) void {
     switch (s.view) {
-        .results => requestToggle(s),
-        .basket => requestRemove(s),
+        .results => doToggle(allocator, s, storage),
+        .basket => doRemove(allocator, s, storage),
     }
 }
 
-/// Pure transition. Enter (re)runs the committed query — the filter doubles as
-/// the search box, so committing it is the search. `i` installs the selected hit
-/// when it is not already installed; on an installed hit it is inert.
-pub fn step(s: *State, key: tab.Key) void {
+/// Pure transition. `i` returns the install `Cmd`; Enter opens `mt info`; the
+/// basket ops (`space`/`d`/`n`) mutate the shell-owned selection in place (pure
+/// state, `Cmd.none`) — they leave the effect path. Committing the query (Enter's
+/// other meaning) is driven by the shell on filter-commit via `searchCmd`.
+pub fn step(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, key: tab.Key) cmd.Cmd {
     switch (key) {
-        // Enter on a result opens `mt info` for it. Committing the query (the
-        // other meaning of Enter) is driven by the shell on filter-commit, not
-        // here, so the two never collide.
-        .enter => if (selectedMatch(s) != null) {
-            s.request = .info;
-        },
+        // Enter on a result opens `mt info` for it. Committing the query is driven
+        // by the shell on filter-commit, so the two never collide.
+        .enter => if (selectedMatch(s) != null) return openSearchInfoCmd(allocator, mt_path, s),
         // `space` selects in the results view and removes in the basket view; `d`
         // is the basket-view remove alias and is inert in the results view.
-        .space => selectKey(s),
+        .space => selectKey(allocator, s, storage),
         .char => |c| if (c.len == 1) switch (c.bytes[0]) {
             // `i` installs the multi-selection (or the active row when nothing is
             // checked); inert when there is nothing installable to do.
-            'i' => if (anyInstallable(s)) {
-                s.request = .install;
-            },
+            'i' => if (anyInstallable(s)) return installCmd(allocator, mt_path, s, storage),
             'l' => s.view = if (s.view == .results) .basket else .results,
-            // `n` clears the whole basket from either view; inert when it is empty.
-            'n' => if (s.selected_count > 0) {
-                s.request = .clear;
-            },
-            'd' => if (s.view == .basket) requestRemove(s),
+            'n' => doClear(allocator, s, storage), // clears the whole basket; inert when empty
+            'd' => if (s.view == .basket) doRemove(allocator, s, storage),
             else => {},
         },
         .esc => s.detail = null, // close the info pane
@@ -268,6 +259,7 @@ pub fn step(s: *State, key: tab.Key) void {
         }) -| 1,
         else => {},
     }
+    return .none;
 }
 
 /// True when `i` would install something: a non-empty basket (which installs as a
@@ -457,24 +449,54 @@ fn appendPad(buf: []u8, len: *usize, s: []const u8, width: usize) void {
     while (i < width) : (i += 1) append(buf, len, " ");
 }
 
-// ── Impure zone ────────────────────────────────────────────────────────────
-// The effects the pure `step` requested. Each carries its I/O ports explicitly
-// through the shared `ctx.Ctx` — never a global — so the pure/impure line lands at
-// the signature: these take `io`/`allocator`, the pure functions above do not.
+// ─── effect producers ───────────────────────────────────────────────────
+// The tab names reads/mutations as `Cmd` values; the pump performs them and folds
+// the result back through `update`. The basket ops are pure state (done in `step`)
+// and never appear here. No I/O and no runner import.
 
-/// The effect chain's error set, composed from the source sets so it tracks them
-/// automatically. A subset of the shell's `RunError`, which classifies each fault
-/// recoverable-vs-fatal; naming it here keeps the public `service` explicit.
-pub const Error = std.mem.Allocator.Error || spawn.ReadError || spawn.InlineError || search_json.Error || info_json.Error;
+/// Banner op strings for a recoverable fault, parity with the pre-reify error names.
+const search_fail_op = "search failed";
+const install_fail_op = "install failed";
+const info_fail_op = "info read failed";
 
-/// Build `mt search <query> --json` for the committed query. Pure over the tab
-/// state: null when the query is empty (the no-op — the view shows guidance, no
-/// spawn), else an owned argv whose `query` element borrows the filter buffer.
-/// Caller frees the returned slice (not its elements).
+/// Build `mt search <query> --json` for the committed query, null when the query is
+/// empty (the no-op — the view shows guidance, no read). The `query` element borrows
+/// the filter buffer; the pump frees the returned slice, not its elements.
 fn searchArgv(allocator: std.mem.Allocator, mt_path: []const u8, st: *const State) std.mem.Allocator.Error!?[]const []const u8 {
     const query = st.chrome.filter.slice();
     if (query.len == 0) return null; // empty query: no remote read
-    return try spawn.jsonArgv(allocator, mt_path, &.{ "search", query });
+    return try cmd.jsonArgv(allocator, mt_path, &.{ "search", query });
+}
+
+/// The committed query's `mt search --json` read, or `Cmd.none` for an empty query.
+fn searchReadCmd(allocator: std.mem.Allocator, mt_path: []const u8, s: *const State) cmd.Cmd {
+    const argv = (searchArgv(allocator, mt_path, s) catch return .none) orelse return .none;
+    return .{ .read = .{ .argv = argv, .mode = .blocking, .parse = cmd.parserFor(.search, search_json.parse), .tag = .search, .fail_op = search_fail_op } };
+}
+
+/// The shell commits the filter-as-query on Enter and asks for this. Flips `phase`
+/// to `searching` before the blocking read (the shell repaints first); the fold
+/// resets it to `loaded`, and a failed read resets it via `update` on `.failed`.
+pub fn searchCmd(allocator: std.mem.Allocator, mt_path: []const u8, s: *State) cmd.Cmd {
+    const c = searchReadCmd(allocator, mt_path, s);
+    if (c == .read) s.phase = .searching;
+    return c;
+}
+
+/// The `mt info <pkg> --json` read for the active hit, or `Cmd.none` when nothing is
+/// selected. `mt info` resolves uninstalled hits too, so a result is inspectable
+/// before any install.
+fn openSearchInfoCmd(allocator: std.mem.Allocator, mt_path: []const u8, s: *const State) cmd.Cmd {
+    const m = selectedMatch(s) orelse return .none; // empty list: no-op
+    const argv = cmd.jsonArgv(allocator, mt_path, &.{ "info", m.name }) catch return .none;
+    return .{ .read = .{ .argv = argv, .mode = .blocking, .parse = cmd.parserFor(.info, info_json.parse), .tag = .search, .fail_op = info_fail_op } };
+}
+
+/// The basket's `mt install …` mutation, or `Cmd.none` when nothing installable is
+/// selected. `update` re-runs the query on success so the installed markers flip.
+fn installCmd(allocator: std.mem.Allocator, mt_path: []const u8, s: *const State, storage: *const Storage) cmd.Cmd {
+    const argv = (installArgv(allocator, mt_path, &storage.selected, s) catch return .none) orelse return .none;
+    return .{ .run_mutation = .{ .argv = argv, .tag = .search, .fail_op = install_fail_op } };
 }
 
 /// Project the persistent selection onto a result list: a row is checked iff it is
@@ -493,40 +515,57 @@ fn projectSearchChecked(storage: *Storage) void {
 
 /// Mirror the tab-owned basket onto the leaf state: the count (so the core can gate
 /// `i` and the footer can size `N selected`) and the entries slice the basket view
-/// renders. The pure core holds no allocator and never owns the picks — it borrows
-/// this slice, refreshed after every basket mutation (an append can move the backing
-/// buffer, so a stale slice would dangle).
+/// renders. The pure core never owns the picks — it borrows this slice, refreshed
+/// after every basket mutation (an append can move the backing buffer).
 pub fn syncSelected(s: *State, storage: *const Storage) void {
     s.selected_count = storage.selected.entries.items.len;
     s.basket = storage.selected.entries.items;
 }
 
-/// Run the committed query's `mt search --json`, parse, and repoint the results at
-/// the fresh parse. Search is a remote read, so it goes through `readJson` like the
-/// other reads (no alt-screen drop). The storage is swapped only after a clean parse,
-/// so a failure keeps the last-good results.
-fn loadSearch(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
-    const argv = (try searchArgv(c.allocator, c.mt_path, s)) orelse return; // empty query: no-op
-    defer c.allocator.free(argv);
-    // Annotate any failure as a recoverable banner; the loop boundary decides
-    // recoverable vs fatal. A failed read must also leave the "searching…" phase
-    // (set by the pre-spawn paint): fall back to the last-good results, or guidance
-    // if none were ever loaded — never a stuck spinner behind the banner.
-    errdefer |err| {
-        c.shared.banner.set("search failed", @errorName(err));
-        s.phase = if (storage.search != null) .loaded else .idle;
+/// Fold a completed effect back into the model. A delivered `search` parse becomes
+/// the ranked results; an `info` parse opens the pane; a finished install refetches;
+/// a `.failed` read leaves the "searching…" phase behind its banner.
+pub fn update(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, shared: *ctx.SharedModel, msg: cmd.Msg) cmd.Cmd {
+    switch (msg) {
+        .loaded => |parsed| switch (parsed) {
+            .search => |sp| {
+                applySearchParse(allocator, s, storage, sp) catch |err| {
+                    sp.deinit(); // the fold failed to take ownership; free the arena
+                    shared.banner.set(search_fail_op, @errorName(err));
+                    s.phase = if (storage.search != null) .loaded else .idle;
+                };
+                return .none;
+            },
+            .info => |ip| {
+                setInfoDetail(s, storage, ip);
+                return .none;
+            },
+            // Search only issues search/info reads; free any misrouted parse.
+            inline else => |p| {
+                p.deinit();
+                return .none;
+            },
+        },
+        .mutated => |code| return foldInstall(allocator, mt_path, s, storage, shared, code),
+        .cleared => return .none, // search/info reads are never `allow_empty`
+        .failed => {
+            // Leave the "searching…" phase behind the banner (already set): the last
+            // good results, or guidance if none ever loaded — never a stuck spinner.
+            s.phase = if (storage.search != null) .loaded else .idle;
+            return .none;
+        },
     }
-    const bytes = try spawn.readJson(c.io, c.allocator, argv);
-    defer c.allocator.free(bytes);
+}
 
-    const parsed = try search_json.parse(c.allocator, bytes);
-    errdefer parsed.deinit();
+/// Repoint the results at a fresh `search` parse, projecting the persistent basket
+/// onto the new `checked` slice. Swapped only after `checked` is allocated, so a
+/// fold OOM leaves the parse for the caller to free and keeps the last-good results.
+fn applySearchParse(allocator: std.mem.Allocator, s: *State, storage: *Storage, parsed: search_json.Parsed) std.mem.Allocator.Error!void {
     // `checked` is a projection of the persistent basket, not per-query state: a pick
     // survives a re-query and re-checks its row when the package returns.
-    const checked = try c.allocator.alloc(bool, parsed.items.len);
-
+    const checked = try allocator.alloc(bool, parsed.items.len);
     if (storage.search) |old| old.deinit();
-    if (storage.checked.len != 0) c.allocator.free(storage.checked);
+    if (storage.checked.len != 0) allocator.free(storage.checked);
     storage.search = parsed;
     storage.checked = checked;
     projectSearchChecked(storage);
@@ -544,15 +583,35 @@ fn loadSearch(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
     }
 }
 
+/// Open the info pane over the delivered `mt info` parse, freeing the previous one.
+fn setInfoDetail(s: *State, storage: *Storage, parsed: info_json.Parsed) void {
+    if (storage.detail) |old| old.deinit();
+    storage.detail = parsed;
+    s.detail = parsed.info;
+}
+
+/// Fold a finished install: a clean exit consumed the basket (clear it, mark the
+/// siblings stale, re-run the query so markers flip); a non-zero exit retains the
+/// basket behind a recoverable banner.
+fn foldInstall(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, shared: *ctx.SharedModel, code: u8) cmd.Cmd {
+    const ok = code == 0;
+    applyInstallOutcome(storage, allocator, ok); // clear on success, retain on failure
+    syncSelected(s, storage); // basket may now be empty → leaf gate + footer reflect it
+    if (!ok) {
+        shared.banner.set(install_fail_op, "ChildFailed");
+        return .none;
+    }
+    shared.markStaleAfter(.search); // Installed/Outdated/Services may have changed too
+    return searchReadCmd(allocator, mt_path, s); // re-run the query; markers flip
+}
+
 /// Build the `mt install …` argv from the cross-query basket. The whole basket
 /// installs, so an off-screen pick installs too. Empty basket ⇒ fall back to the
 /// active row (the no-selection case); null when that row is absent or already
 /// installed (the no-op). A single target keeps the explicit `--formula`/`--cask`
 /// flag, because a name can exist as both and bare `mt install <name>` silently picks
 /// the formula; a multi install passes bare names and lets `mt` detect each one's
-/// kind. Basket names are owned, so the argv outlives the parse it was checked in (the
-/// active-row fallback name borrows the live parse, read before any re-search frees
-/// it). Caller frees the returned slice, not its elements.
+/// kind. Basket names are owned, so the argv outlives the parse it was checked in.
 fn installArgv(allocator: std.mem.Allocator, mt_path: []const u8, sel: *const Selection, st: *const State) std.mem.Allocator.Error!?[]const []const u8 {
     const entries = sel.entries.items;
     if (entries.len == 0) {
@@ -560,11 +619,11 @@ fn installArgv(allocator: std.mem.Allocator, mt_path: []const u8, sel: *const Se
         const i = selectedIndex(st) orelse return null;
         const m = st.items[i];
         if (m.installed) return null;
-        return try spawn.inlineArgv(allocator, mt_path, &.{ "install", kindFlag(m.kind), m.name });
+        return try cmd.inlineArgv(allocator, mt_path, &.{ "install", kindFlag(m.kind), m.name });
     }
     if (entries.len == 1) {
         const e = entries[0];
-        return try spawn.inlineArgv(allocator, mt_path, &.{ "install", kindFlag(e.kind), e.name });
+        return try cmd.inlineArgv(allocator, mt_path, &.{ "install", kindFlag(e.kind), e.name });
     }
     const argv = try allocator.alloc([]const u8, 2 + entries.len);
     argv[0] = mt_path;
@@ -593,95 +652,6 @@ fn applyInstallOutcome(storage: *Storage, allocator: std.mem.Allocator, ok: bool
     projectSearchChecked(storage);
 }
 
-/// Delegate the basket's install to the real `mt` inline, then re-run the query so
-/// installed markers flip. The argv's names are owned by the basket (the active-row
-/// fallback name borrows the live parse, read before the re-search frees it). A clean
-/// install clears the basket; a failed one keeps it.
-fn doInstall(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
-    const argv = (try installArgv(c.allocator, c.mt_path, &storage.selected, s)) orelse return; // nothing installable selected
-    defer c.allocator.free(argv);
-    // A non-zero `mt install` re-enters the dashboard (the user keeps malt's real
-    // output, including any prompt, in their scrollback) and surfaces as a recoverable
-    // banner; only a terminal fault is fatal — the loop boundary decides which on the
-    // re-raised error. The basket is retained either way.
-    spawn.runInlineReenter(c.term, argv) catch |err| {
-        c.shared.banner.set("install failed", @errorName(err));
-        applyInstallOutcome(storage, c.allocator, false); // retain for retry
-        return err;
-    };
-    applyInstallOutcome(storage, c.allocator, true); // a clean install consumed the basket
-    syncSelected(s, storage); // basket now empty → leaf gate + footer reflect it
-    // Re-run the same query so the freshly installed hit's marker flips — the
-    // backend's install-aware `installed` flag does the rest (no `mt list` call).
-    try loadSearch(s, storage, c);
-    c.shared.markStaleAfter(.search); // Installed/Outdated/Services may have changed too
-    // The keg set grew but we are on Search, so the lazy Installed reload won't run
-    // until that tab is entered — refresh just the count now (cheaply, through the
-    // hub-owned port) so the header is live immediately, not stale until Installed.
-    c.refreshInstalledCount();
-}
-
-/// Open the `mt info` pane for the active hit. `mt info` resolves installed and
-/// uninstalled packages alike, so a search result can be inspected before any
-/// install. A read (no alt-screen drop); failure names the package in a banner and
-/// leaves the pane closed.
-fn openSearchInfo(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
-    const m = selectedMatch(s) orelse return; // empty list: no-op
-    errdefer |err| {
-        var sb: [96]u8 = undefined;
-        const op = std.fmt.bufPrint(&sb, "info for {s} failed", .{m.name}) catch "info read failed";
-        c.shared.banner.set(op, @errorName(err));
-    }
-    const argv = try spawn.jsonArgv(c.allocator, c.mt_path, &.{ "info", m.name });
-    defer c.allocator.free(argv);
-    const bytes = try spawn.readJson(c.io, c.allocator, argv);
-    defer c.allocator.free(bytes);
-
-    const parsed = try info_json.parse(c.allocator, bytes);
-    if (storage.detail) |old| old.deinit();
-    storage.detail = parsed;
-    s.detail = parsed.info;
-}
-
-/// Perform any effect the pure `step` requested, then clear it — the consumer half of
-/// the `request` seam. Unlike the other tabs there is no lazy dirty-load: Search is
-/// idle until the user commits a query, and a remote read on every tab-entry after an
-/// unrelated mutation would be a surprising freeze, so the dirty flag `markStaleAfter`
-/// may set for Search is deliberately never consumed on entry.
-pub fn service(s: *State, storage: *Storage, c: *ctx.Ctx) Error!void {
-    const req = s.request;
-    s.request = .none;
-    switch (req) {
-        .none => {},
-        .search => try loadSearch(s, storage, c),
-        .install => try doInstall(s, storage, c),
-        .info => try openSearchInfo(s, storage, c),
-        // Add/remove the active hit in the persistent basket, then re-project the
-        // `checked` slice so the row reflects it immediately. The leaf already refused
-        // installed rows, so the match here is always selectable.
-        .toggle => {
-            const m = selectedMatch(s) orelse return;
-            try storage.selected.toggle(c.allocator, m.name, m.kind);
-            projectSearchChecked(storage);
-            syncSelected(s, storage);
-        },
-        // Drop the highlighted basket pick (read its name/kind before freeing it),
-        // then re-project so any on-screen row for it clears its checkmark.
-        .remove => {
-            const e = selectedBasketEntry(s) orelse return;
-            storage.selected.remove(c.allocator, e.name, e.kind);
-            projectSearchChecked(storage);
-            syncSelected(s, storage);
-        },
-        // Empty the whole basket; the projection then clears every on-screen check.
-        .clear => {
-            storage.selected.clear(c.allocator);
-            projectSearchChecked(storage);
-            syncSelected(s, storage);
-        },
-    }
-}
-
 // ─── tests ───────────────────────────────────────────────────────────
 
 fn ch(c: u8) tab.Key {
@@ -693,6 +663,11 @@ const sample = [_]Match{
     .{ .name = "firefox", .kind = .cask, .installed = true },
     .{ .name = "ripgrep", .kind = .formula, .installed = false },
 };
+
+/// Drive `step` with an explicit storage (basket ops mutate it) and a fixed mt path.
+fn stepKey(s: *State, storage: *Storage, key: tab.Key) cmd.Cmd {
+    return step(testing.allocator, "/opt/malt/bin/mt", s, storage, key);
+}
 
 test "selectedMatch clamps the unbounded cursor into the result list" {
     var s: State = .{ .items = &sample, .phase = .loaded };
@@ -707,100 +682,134 @@ test "selectedMatch on an empty list is null (the action becomes a no-op)" {
     try testing.expect(selectedMatch(&s) == null);
 }
 
-test "enter opens info for the active hit" {
+test "enter returns the `mt info` read for the active hit" {
     var s: State = .{ .items = &sample, .phase = .loaded };
-    step(&s, .enter);
-    try testing.expectEqual(Request.info, s.request);
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    const eff = stepKey(&s, &storage, .enter);
+    defer testing.allocator.free(eff.read.argv);
+    try testing.expect(eff == .read);
+    try testing.expectEqual(cmd.MsgTag.search, eff.read.tag);
+    try testing.expectEqualStrings("info", eff.read.argv[1]);
+    try testing.expectEqualStrings("wget", eff.read.argv[2]);
 }
 
 test "enter is inert on an empty result list" {
     var s: State = .{ .items = &.{} };
-    step(&s, .enter);
-    try testing.expectEqual(Request.none, s.request);
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    try testing.expect(stepKey(&s, &storage, .enter) == .none);
 }
 
 test "esc closes the info pane" {
     const info: info_json.Info = .{ .name = "wget", .version = "1", .tap = "", .dependencies = &.{} };
     var s: State = .{ .items = &sample, .detail = info };
-    step(&s, .esc);
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    try testing.expect(stepKey(&s, &storage, .esc) == .none);
     try testing.expect(s.detail == null);
 }
 
-test "i on a not-installed hit requests install; on an installed hit it is inert" {
+test "i on a not-installed active row (empty basket) returns the install mutation" {
     var s: State = .{ .items = &sample, .phase = .loaded };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
     s.chrome.view.selected = 0; // wget, not installed
-    step(&s, ch('i'));
-    try testing.expectEqual(Request.install, s.request);
+    const eff = stepKey(&s, &storage, ch('i'));
+    defer testing.allocator.free(eff.run_mutation.argv);
+    try testing.expect(eff == .run_mutation);
+    try testing.expectEqual(cmd.MsgTag.search, eff.run_mutation.tag);
+    try testing.expectEqualStrings("install", eff.run_mutation.argv[1]);
+    try testing.expectEqualStrings("--formula", eff.run_mutation.argv[2]);
+    try testing.expectEqualStrings("wget", eff.run_mutation.argv[3]);
+}
 
-    s.request = .none;
+test "i on an already-installed active row (empty basket) is inert" {
+    var s: State = .{ .items = &sample, .phase = .loaded };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
     s.chrome.view.selected = 1; // firefox, already installed
-    step(&s, ch('i'));
-    try testing.expectEqual(Request.none, s.request); // inert
+    try testing.expect(stepKey(&s, &storage, ch('i')) == .none);
 }
 
 test "i on an empty list is inert" {
     var s: State = .{ .items = &.{} };
-    step(&s, ch('i'));
-    try testing.expectEqual(Request.none, s.request);
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    try testing.expect(stepKey(&s, &storage, ch('i')) == .none);
 }
 
-test "an unrelated key leaves the request alone" {
+test "an unrelated key is inert" {
     var s: State = .{ .items = &sample };
-    step(&s, ch('z'));
-    try testing.expectEqual(Request.none, s.request);
-    step(&s, .down);
-    try testing.expectEqual(Request.none, s.request);
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    try testing.expect(stepKey(&s, &storage, ch('z')) == .none);
+    try testing.expect(stepKey(&s, &storage, .down) == .none);
 }
 
-test "space requests a basket toggle for the active not-installed row" {
+test "space adds the active not-installed row to the basket in place, no effect" {
     var s: State = .{ .items = &sample, .phase = .loaded };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
     s.chrome.view.selected = 0; // wget, not installed
-    step(&s, .space);
-    try testing.expectEqual(Request.toggle, s.request);
+    try testing.expect(stepKey(&s, &storage, .space) == .none); // pure state, no Cmd
+    try testing.expect(storage.selected.contains("wget", .formula)); // in the basket now
+    try testing.expectEqual(@as(usize, 1), s.selected_count); // mirrored onto the leaf
+
+    // A second space toggles it back out.
+    try testing.expect(stepKey(&s, &storage, .space) == .none);
+    try testing.expect(!storage.selected.contains("wget", .formula));
+    try testing.expectEqual(@as(usize, 0), s.selected_count);
 }
 
 test "space is inert on an already-installed row (never selectable)" {
     var s: State = .{ .items = &sample, .phase = .loaded };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
     s.chrome.view.selected = 1; // firefox, already installed
-    step(&s, .space);
-    try testing.expectEqual(Request.none, s.request);
+    try testing.expect(stepKey(&s, &storage, .space) == .none);
+    try testing.expectEqual(@as(usize, 0), s.selected_count); // nothing added
 }
 
 test "space is inert on an empty result list" {
     var s: State = .{ .items = &.{} };
-    step(&s, .space);
-    try testing.expectEqual(Request.none, s.request);
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    try testing.expect(stepKey(&s, &storage, .space) == .none);
 }
 
 test "i installs the basket even when the active row is already installed" {
-    var s: State = .{ .items = &sample, .selected_count = 1, .phase = .loaded };
-    s.chrome.view.selected = 1; // active = firefox (installed); the basket still wins
-    step(&s, ch('i'));
-    try testing.expectEqual(Request.install, s.request);
-}
-
-test "i installs the basket even when none of its picks are on screen" {
-    // The cross-query case: the basket holds off-list picks, so `i` must fire even
-    // though the current query returned nothing checkable.
-    var s: State = .{ .items = &.{}, .selected_count = 2, .phase = .loaded };
-    step(&s, ch('i'));
-    try testing.expectEqual(Request.install, s.request);
+    var s: State = .{ .items = &sample, .phase = .loaded };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    // Basket holds ripgrep; the active row is the installed firefox — the basket wins.
+    s.chrome.view.selected = 2; // ripgrep, not installed
+    _ = stepKey(&s, &storage, .space); // basket = {ripgrep}
+    s.chrome.view.selected = 1; // active = firefox (installed)
+    const eff = stepKey(&s, &storage, ch('i'));
+    defer testing.allocator.free(eff.run_mutation.argv);
+    try testing.expect(eff == .run_mutation);
+    try testing.expectEqualStrings("ripgrep", eff.run_mutation.argv[3]); // the basket pick
 }
 
 test "i is inert only when the basket is empty and the active row is not installable" {
-    var s: State = .{ .items = &sample, .selected_count = 0, .phase = .loaded };
+    var s: State = .{ .items = &sample, .phase = .loaded };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
     s.chrome.view.selected = 1; // empty basket + active firefox (installed) → nothing to do
-    step(&s, ch('i'));
-    try testing.expectEqual(Request.none, s.request);
+    try testing.expect(stepKey(&s, &storage, ch('i')) == .none);
 }
 
 test "the cores tolerate a checked slice shorter than items without trapping" {
-    // Before the shell sizes `checked` it can be empty; the cores must not index
-    // past it. Toggle is then inert and install falls back to the active row.
+    // Before a search sizes `checked` it is empty; the basket op must not index past
+    // it (projection is a no-op with no results), and install falls back to the row.
     var s: State = .{ .items = &sample, .checked = &.{}, .phase = .loaded };
-    step(&s, .space); // no checked slot for the active row → inert, no trap
-    step(&s, ch('i')); // resolves over the empty set + the active (installable) row
-    try testing.expectEqual(Request.install, s.request);
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    _ = stepKey(&s, &storage, .space); // wget → basket, projection skipped (no results loaded)
+    const eff = stepKey(&s, &storage, ch('i')); // resolves over the basket pick
+    defer testing.allocator.free(eff.run_mutation.argv);
+    try testing.expect(eff == .run_mutation);
 }
 
 test "render draws a multi-select checkbox per result row" {
@@ -893,10 +902,12 @@ test "footerHint exposes the tab's action keys for the shared footer" {
 
 test "l flips the body between the results and basket views" {
     var s: State = .{ .items = &sample, .phase = .loaded };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
     try testing.expectEqual(View.results, s.view); // results by default
-    step(&s, ch('l'));
+    _ = stepKey(&s, &storage, ch('l'));
     try testing.expectEqual(View.basket, s.view);
-    step(&s, ch('l')); // and back
+    _ = stepKey(&s, &storage, ch('l')); // and back
     try testing.expectEqual(View.results, s.view);
 }
 
@@ -907,15 +918,17 @@ const basket_sample = [_]SelEntry{
 
 test "End jumps to the last row of the active view: results or basket" {
     var s: State = .{ .items = &sample, .phase = .loaded, .basket = &basket_sample };
-    step(&s, .end);
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    _ = stepKey(&s, &storage, .end);
     try testing.expectEqual(@as(usize, 2), s.chrome.view.selected); // 3 hits
 
     s.view = .basket;
-    step(&s, .end);
+    _ = stepKey(&s, &storage, .end);
     try testing.expectEqual(@as(usize, 1), s.chrome.view.selected); // 2 picks
 
     var e: State = .{ .phase = .loaded }; // empty results: no underflow
-    step(&e, .end);
+    _ = stepKey(&e, &storage, .end);
     try testing.expectEqual(@as(usize, 0), e.chrome.view.selected);
 }
 
@@ -985,47 +998,65 @@ test "selectedBasketEntry on an empty basket is null" {
     try testing.expect(selectedBasketEntry(&s) == null);
 }
 
-test "space in the basket view requests removing the highlighted pick" {
-    var s: State = .{ .view = .basket, .basket = &basket_sample };
+test "space in the basket view removes the highlighted pick in place" {
+    var s: State = .{ .items = &sample, .phase = .loaded };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
     s.chrome.view.selected = 0;
-    step(&s, .space);
-    try testing.expectEqual(Request.remove, s.request);
+    _ = stepKey(&s, &storage, .space); // wget → basket
+    s.chrome.view.selected = 2;
+    _ = stepKey(&s, &storage, .space); // ripgrep → basket
+    s.view = .basket;
+    s.chrome.view.selected = 0; // highlight the first pick
+    try testing.expect(stepKey(&s, &storage, .space) == .none); // remove, pure state
+    try testing.expect(!storage.selected.contains("wget", .formula)); // removed
+    try testing.expect(storage.selected.contains("ripgrep", .formula)); // kept
 }
 
-test "d in the basket view also requests a remove" {
-    var s: State = .{ .view = .basket, .basket = &basket_sample };
-    s.chrome.view.selected = 1;
-    step(&s, ch('d'));
-    try testing.expectEqual(Request.remove, s.request);
+test "d in the basket view also removes the highlighted pick" {
+    var s: State = .{ .items = &sample, .phase = .loaded };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    s.chrome.view.selected = 0;
+    _ = stepKey(&s, &storage, .space); // wget → basket
+    s.view = .basket;
+    s.chrome.view.selected = 0;
+    try testing.expect(stepKey(&s, &storage, ch('d')) == .none);
+    try testing.expect(!storage.selected.contains("wget", .formula));
 }
 
 test "d in the results view is inert (remove is a basket-only key)" {
     var s: State = .{ .items = &sample, .phase = .loaded, .view = .results };
-    step(&s, ch('d'));
-    try testing.expectEqual(Request.none, s.request);
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    try testing.expect(stepKey(&s, &storage, ch('d')) == .none);
 }
 
 test "space in the basket view is inert when the basket is empty" {
-    var s: State = .{ .view = .basket, .basket = &.{} };
-    step(&s, .space);
-    try testing.expectEqual(Request.none, s.request);
+    var s: State = .{ .view = .basket };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    try testing.expect(stepKey(&s, &storage, .space) == .none);
 }
 
-test "n requests clearing the basket from either view when it holds picks" {
-    var s: State = .{ .items = &sample, .phase = .loaded, .selected_count = 2 };
-    step(&s, ch('n')); // results view
-    try testing.expectEqual(Request.clear, s.request);
-
-    s.request = .none;
-    s.view = .basket;
-    step(&s, ch('n')); // basket view
-    try testing.expectEqual(Request.clear, s.request);
+test "n clears the basket from the results view when it holds picks" {
+    var s: State = .{ .items = &sample, .phase = .loaded };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    s.chrome.view.selected = 0;
+    _ = stepKey(&s, &storage, .space); // wget
+    s.chrome.view.selected = 2;
+    _ = stepKey(&s, &storage, .space); // ripgrep
+    try testing.expectEqual(@as(usize, 2), s.selected_count);
+    try testing.expect(stepKey(&s, &storage, ch('n')) == .none); // clear, pure state
+    try testing.expectEqual(@as(usize, 0), s.selected_count);
 }
 
 test "n on an empty basket is inert" {
-    var s: State = .{ .items = &sample, .phase = .loaded, .selected_count = 0 };
-    step(&s, ch('n'));
-    try testing.expectEqual(Request.none, s.request);
+    var s: State = .{ .items = &sample, .phase = .loaded };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    try testing.expect(stepKey(&s, &storage, ch('n')) == .none);
 }
 
 test "the footer hint reflects the active view" {
@@ -1094,97 +1125,47 @@ test "Storage.deinit frees the results, checkbox buffer, basket, and detail pars
 
 // ── Effect tests ─────────────────────────────────────────────────────────
 
-test "mutates gates only on the install request" {
-    var s: State = .{};
-    try testing.expect(!mutates(&s)); // .none never takes the WAL writer
-    s.request = .info;
-    try testing.expect(!mutates(&s)); // a read-only info request does not gate
-    s.request = .toggle;
-    try testing.expect(!mutates(&s)); // a pure basket op does not gate
-    s.request = .install;
-    try testing.expect(mutates(&s)); // the one DB-mutating request
-}
-
-// Backing storage for a `ctx.Ctx` in an effect test: dummy term/fetches/shared, a
-// no-op painter (fd = -1; these reads never reach a poll tick), and the loading flag.
-const TestEnv = struct {
-    term_h: ctx.Term,
-    fetches: ctx.Fetches = ctx.Fetches.initFill(null),
-    shared: ctx.SharedModel = .{},
-    frame: []u8 = &.{},
-    loading: bool = false,
-};
-
-fn mkCtx(io: std.Io, e: *TestEnv, mt_path: []const u8) ctx.Ctx {
-    return .{
-        .io = io,
-        .allocator = testing.allocator,
-        .term = &e.term_h,
-        .painter = .{ .fd = -1, .frame = &e.frame },
-        .fetches = &e.fetches,
-        .shared = &e.shared,
-        .mt_path = mt_path,
-        .loading = &e.loading,
-    };
-}
-
-test "service on the synchronous read path never starts a background fetch" {
-    // Search reads remotely but synchronously; it declares no fetch spec, so no
-    // branch of its service may spawn a background audit.
+test "Search declares no background fetch and no lazy on-entry reload" {
+    // Search reads remotely but synchronously (no fetch spec), and unlike Installed
+    // it exposes no `refreshCmd`: a remote read on every tab-entry would be a
+    // surprising freeze, so entering never re-queries even when marked dirty.
     try testing.expect(fetch_spec == null);
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
-    var storage: Storage = .{};
-    defer storage.deinit(testing.allocator);
-    var st: State = .{}; // .none
-    var c = mkCtx(thr.io(), &env, "/bin/false"); // would fail if it ever spawned
-    try service(&st, &storage, &c);
-    for (&env.fetches.values) |v| try testing.expect(v == null);
-    try testing.expect(!env.shared.banner.isSet());
+    try testing.expect(!@hasDecl(@This(), "refreshCmd"));
 }
 
-test "service consumes a toggle request into the basket and mirrors it onto the leaf" {
+test "space projects the basket toggle onto the on-screen checkbox row" {
     const alloc = testing.allocator;
-    var thr = std.Io.Threaded.init(alloc, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
     var storage: Storage = .{};
     defer storage.deinit(alloc);
-    // A loaded result the cursor points at; a basket op is pure — no spawn.
+    // A loaded result the cursor points at; the toggle re-projects `checked`.
     storage.search = try search_json.parse(alloc,
         \\{"results":[{"name":"bat","type":"formula","installed":false}]}
     );
     storage.checked = try alloc.alloc(bool, 1);
     @memset(storage.checked, false);
-    var st: State = .{ .items = storage.search.?.items, .request = .toggle };
-    var c = mkCtx(thr.io(), &env, "/bin/false"); // would fail if the pure op ever spawned
-    try service(&st, &storage, &c);
-    try testing.expectEqual(Request.none, st.request); // consumed
+    var st: State = .{ .items = storage.search.?.items, .checked = storage.checked, .phase = .loaded };
+    try testing.expect(stepKey(&st, &storage, .space) == .none); // pure state, no effect
     try testing.expect(storage.selected.contains("bat", .formula)); // added to the basket
     try testing.expectEqual(@as(usize, 1), st.selected_count); // mirrored onto the leaf
     try testing.expect(storage.checked[0]); // and re-projected onto the on-screen row
-    try testing.expect(!env.shared.banner.isSet());
 }
 
-test "entering the tab does not trigger a remote read even when marked dirty" {
-    // Search diverges from the other tabs: no lazy dirty-load on entry. A mutation
-    // elsewhere marks it dirty, but entering must stay idle — a surprise remote read
-    // on a tab switch would freeze the frame. `/bin/false` would fail if ever spawned.
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
-    env.shared.dirty.insert(.search);
-    var storage: Storage = .{};
-    defer storage.deinit(testing.allocator);
-    var st: State = .{}; // .none request, idle phase
-    st.chrome.filter.push("firefox"); // a committed query exists, yet entry must not read it
-    var c = mkCtx(thr.io(), &env, "/bin/false");
-    try service(&st, &storage, &c);
-    try testing.expectEqual(Phase.idle, st.phase); // never searched on entry
-    try testing.expectEqual(@as(usize, 0), st.items.len);
-    try testing.expect(!env.shared.banner.isSet());
-    try testing.expect(env.shared.dirty.contains(.search)); // flag left unconsumed
+test "searchCmd flips to the searching phase and carries the query read" {
+    var st: State = .{};
+    st.chrome.filter.push("fire");
+    const eff = searchCmd(testing.allocator, "/opt/homebrew/bin/mt", &st);
+    defer testing.allocator.free(eff.read.argv);
+    try testing.expect(eff == .read);
+    try testing.expectEqual(Phase.searching, st.phase); // flipped before the blocking read
+    try testing.expectEqual(cmd.MsgTag.search, eff.read.tag);
+    try testing.expectEqualStrings("search", eff.read.argv[1]);
+    try testing.expectEqualStrings("fire", eff.read.argv[2]);
+}
+
+test "searchCmd on an empty query is a no-op and leaves the phase alone" {
+    var st: State = .{ .phase = .idle };
+    try testing.expect(searchCmd(testing.allocator, "/bin/mt", &st) == .none);
+    try testing.expectEqual(Phase.idle, st.phase);
 }
 
 test "searchArgv builds `mt search <query> --json` for the committed query" {
@@ -1536,45 +1517,77 @@ test "a failed install (non-zero exit) retains the whole basket for retry" {
     try testing.expect(storage.selected.contains("redis", .formula));
 }
 
-test "a failed search names the op in the banner and leaves no stuck searching phase" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+test "update on a failed search leaves no stuck searching phase (guidance when none loaded)" {
+    var st: State = .{ .phase = .searching }; // as the pre-read paint left it
     var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
     defer storage.deinit(testing.allocator);
-    var st: State = .{};
-    st.chrome.filter.push("fire");
-    st.phase = .searching; // as the pre-spawn paint left it
-    var c = mkCtx(thr.io(), &env, "/bin/echo"); // echo emits non-JSON → parse fails
-    try testing.expectError(error.BadJson, loadSearch(&st, &storage, &c));
-    try testing.expectEqualStrings("search failed: BadJson", env.shared.banner.slice());
-    // No prior results → guidance, not a spinner frozen behind the banner.
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .failed);
+    try testing.expect(next == .none);
+    // No prior results → guidance, not a spinner frozen behind the (pump-set) banner.
     try testing.expectEqual(Phase.idle, st.phase);
-    try testing.expectEqual(@as(usize, 0), st.items.len);
 }
 
-test "a failed search keeps the last-good results and selection, falling back to the list" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+test "update on a failed search falls back to the last-good results, keeping the cursor" {
     var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
     defer storage.deinit(testing.allocator);
     // Prime a prior successful search: storage + leaf borrow these results.
     storage.search = try search_json.parse(testing.allocator,
         \\{"results":[{"name":"jq","type":"formula","installed":true},{"name":"yq","type":"formula","installed":false}]}
     );
-    var st: State = .{};
-    st.items = storage.search.?.items;
-    st.chrome.filter.push("q");
+    var st: State = .{ .items = storage.search.?.items, .phase = .searching };
     st.chrome.view.selected = 1; // cursor on yq
-    st.phase = .searching; // as the pre-spawn paint left it
-    var c = mkCtx(thr.io(), &env, "/bin/echo"); // non-JSON → BadJson on the new query
-
-    try testing.expectError(error.BadJson, loadSearch(&st, &storage, &c));
-    try testing.expectEqualStrings("search failed: BadJson", env.shared.banner.slice());
-    // Prior results exist → fall back to the list, not guidance; and the storage is
-    // swapped only after a clean parse, so the rows and the cursor both survive.
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .failed);
+    try testing.expect(next == .none);
+    // Prior results exist → fall back to the list, not guidance; the rows and cursor survive.
     try testing.expectEqual(Phase.loaded, st.phase);
     try testing.expectEqual(@as(usize, 2), st.items.len);
     try testing.expectEqual(@as(usize, 1), st.chrome.view.selected);
+}
+
+test "update on a loaded search parse swaps in the ranked results and lands loaded" {
+    var st: State = .{ .phase = .searching };
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    try storage.selected.toggle(testing.allocator, "bat", .formula); // a prior pick
+    const parsed = try search_json.parse(testing.allocator,
+        \\{"results":[{"name":"bat","type":"formula","installed":false},{"name":"jq","type":"formula","installed":true}]}
+    );
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .loaded = .{ .search = parsed } });
+    try testing.expect(next == .none);
+    try testing.expectEqual(Phase.loaded, st.phase);
+    try testing.expectEqual(@as(usize, 2), st.items.len);
+    try testing.expect(st.checked[0]); // bat re-checked from the persistent basket
+    try testing.expect(!st.checked[1]); // jq installed → never checked
+}
+
+test "a successful install clears the basket, marks siblings stale, and re-runs the query" {
+    var st: State = .{};
+    st.chrome.filter.push("bat");
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    try storage.selected.toggle(testing.allocator, "bat", .formula);
+    syncSelected(&st, &storage);
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .mutated = 0 });
+    defer testing.allocator.free(next.read.argv);
+    try testing.expect(next == .read); // re-run the query so markers flip
+    try testing.expectEqualStrings("search", next.read.argv[1]);
+    try testing.expectEqual(@as(usize, 0), st.selected_count); // basket consumed
+    try testing.expect(shared.takeDirty(.installed)); // siblings marked stale
+}
+
+test "a failed install retains the basket behind a recoverable banner and does not re-query" {
+    var st: State = .{};
+    var storage: Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    try storage.selected.toggle(testing.allocator, "bat", .formula);
+    syncSelected(&st, &storage);
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .mutated = 1 });
+    try testing.expect(next == .none); // no re-query on failure
+    try testing.expectEqual(@as(usize, 1), st.selected_count); // basket retained for retry
+    try testing.expect(std.mem.startsWith(u8, shared.banner.slice(), "install failed"));
 }

--- a/src/tui/services_tab.zig
+++ b/src/tui/services_tab.zig
@@ -1,9 +1,12 @@
 //! malt — Services tab for `mt tui`: the service lifecycle pane.
 //!
-//! Leaf module. Pure cores only: `step(state, key)` records a lifecycle intent
-//! (`start`/`stop`/`restart`) as a `request` for the impure shell to delegate to
-//! the real `mt services <action> <name>`; `render(state, frame, rect)` is a pure
-//! function of `(state, rect)` so a resize is a re-render. The shell owns the row
+//! Leaf module. Pure cores only: `step` maps a lifecycle key to a `Cmd`
+//! (`start`/`stop`/`restart` → a `run_mutation` for the real `mt services
+//! <action> <name>`); `update` folds the pump's result back (a finished mutation
+//! asks for a fresh read, a delivered read swaps in the rows). The tab names
+//! effects as data and never imports the runner. `render(state, frame, rect)` is
+//! a pure function of `(state, rect)` so a resize is a re-render. The shell owns
+//! the row
 //! data; `items` borrow from that storage. Each row shows a state dot (running /
 //! stopped / unknown) and the auto-start hint. The `state` string is bucketed,
 //! not matched against an enum, so a future/unusual runtime state still renders.
@@ -14,24 +17,18 @@ const std = @import("std");
 const testing = std.testing;
 
 const color = @import("../ui/color.zig");
+const cmd = @import("cmd.zig");
 const ctx = @import("ctx.zig");
 const services_json = @import("json/services.zig");
 pub const Row = services_json.ServiceRow;
 const detail_pane = @import("detail_pane.zig");
 const scroll_list = @import("scroll_list.zig");
-const spawn = @import("spawn.zig");
 const tab = @import("tab.zig");
-
-/// A lifecycle effect the pure `step` defers to the impure shell, which performs
-/// it and resets the field. `step` never does I/O — this is the command channel.
-pub const Request = enum { none, start, stop, restart };
 
 pub const State = struct {
     chrome: tab.Chrome = .{},
     /// Service rows, borrowed from shell-owned parse storage.
     items: []const Row = &.{},
-    /// Pending lifecycle effect for the shell to perform, then clear.
-    request: Request = .none,
     /// The row whose detail pane is open (Enter), or null when closed (Esc).
     /// A copy of the selected Row — its slices borrow the same shell storage.
     detail: ?Row = null,
@@ -51,13 +48,6 @@ pub const Storage = struct {
 
 /// Services audits in the background; a non-clean exit means a failed refresh.
 pub const fetch_spec: ?tab.FetchSpec = .{ .verb = &.{ "services", "list" }, .max_ok_exit = 0, .refresh_op = "services refresh failed" };
-
-/// Whether the pending request will spawn a DB-mutating child. Unlike the other
-/// tabs' single mutating verb, *every* non-`.none` lifecycle action (start / stop
-/// / restart) opens the DB, so the classifier is "any pending request".
-pub fn mutates(s: *const State) bool {
-    return s.request != .none;
-}
 
 pub fn title() []const u8 {
     return "Services";
@@ -99,24 +89,27 @@ pub fn selectedService(s: *const State) ?Row {
     return null; // unreachable: sel < nf
 }
 
-/// Pure transition: record a lifecycle intent for the shell to act on. `s` start,
+/// Pure transition: map a key to a `Cmd` for the pump to perform. `s` start,
 /// `x`/`X` stop, `r` restart — reversible, so no confirm guard. Enter opens the
-/// detail pane (all its fields are already on the Row, so no shell round-trip),
-/// Esc closes it.
-pub fn step(s: *State, key: tab.Key) void {
+/// detail pane (all its fields are already on the Row, so no round-trip), Esc
+/// closes it — both pure state, `Cmd.none`. The lifecycle keys return a
+/// `run_mutation` carrying `mt services <action> <name>`.
+pub fn step(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, key: tab.Key) cmd.Cmd {
+    _ = storage;
     switch (key) {
         .enter => s.detail = selectedService(s),
         .esc => s.detail = null,
         // Only the tab knows its filtered row count, so the shell defers End here.
         .end => s.chrome.view.selected = filteredCount(s.items, s.chrome.filter.slice()) -| 1,
         .char => |c| if (c.len == 1) switch (c.bytes[0]) {
-            's' => s.request = .start,
-            'x', 'X' => s.request = .stop,
-            'r' => s.request = .restart,
+            's' => return actionCmd(allocator, mt_path, s, "start"),
+            'x', 'X' => return actionCmd(allocator, mt_path, s, "stop"),
+            'r' => return actionCmd(allocator, mt_path, s, "restart"),
             else => {},
         },
         else => {},
     }
+    return .none;
 }
 
 /// The three state buckets the dot encodes. `state` is bucketed rather than
@@ -254,99 +247,94 @@ fn appendPad(buf: []u8, len: *usize, s: []const u8, width: usize) void {
     while (i < width) : (i += 1) append(buf, len, " ");
 }
 
-// ─── impure zone ───────────────────────────────────────────────────────
-// The effect half of the tab, reunited beside its pure producer (`step` records
-// the lifecycle `request`; the code below drains it). Every decl here takes its
-// I/O ports explicitly through the shared `ctx.Ctx` — never a global — so the
-// pure/impure line is the function signature.
+// ─── effect producers ───────────────────────────────────────────────────
+// The tab names effects as `Cmd` values; the pump performs them and folds the
+// result back through `update`. No I/O and no runner import here — the
+// file-level purity a structural grep for the runner pins.
 
-/// The effect chain's error set, composed from the source sets so it tracks them
-/// automatically. A subset of the shell's `RunError`, which classifies each fault
-/// recoverable-vs-fatal; naming it here keeps the public `service` explicit.
-pub const Error = std.mem.Allocator.Error || spawn.ReadError || spawn.InlineError || services_json.Error;
+/// Banner op strings for a recoverable fault, kept as parity with the pre-reify
+/// error names so the dashboard shows the same banners it always has.
+const action_fail_op = "service action failed";
+const refresh_fail_op = "services refresh failed";
 
-/// Perform any lifecycle effect the pure `step` requested, then clear it — the
-/// consumer half of the `request` seam. The shell dispatches this only for the
-/// active tab; the lazy (re)load on entry / after staleness stays loop machinery.
-pub fn service(s: *State, storage: *Storage, c: *ctx.Ctx) Error!void {
-    const req = s.request;
-    s.request = .none;
-    switch (req) {
-        .none => {},
-        .start => try doServiceAction(s, storage, c, "start"),
-        .stop => try doServiceAction(s, storage, c, "stop"),
-        .restart => try doServiceAction(s, storage, c, "restart"),
+/// Build the `mt services <action> <name>` mutation for the selected service, or
+/// `Cmd.none` when nothing is selected (the empty-list no-op). The argv's `name`
+/// borrows the parse storage; the pump reads it before the post-mutation reload
+/// frees that storage, and frees only the returned slice, not its elements.
+fn actionCmd(allocator: std.mem.Allocator, mt_path: []const u8, s: *const State, action: []const u8) cmd.Cmd {
+    const svc = selectedService(s) orelse return .none; // empty list: no-op
+    // An argv-build OOM drops this keystroke's effect rather than the TUI; the
+    // user retries. The pump owns runner faults and the recoverable banner.
+    const argv = cmd.inlineArgv(allocator, mt_path, &.{ "services", action, svc.name }) catch return .none;
+    return .{ .run_mutation = .{ .argv = argv, .tag = .services, .fail_op = action_fail_op } };
+}
+
+/// Fold a completed effect back into the model. A successful lifecycle mutation
+/// (exit 0) marks the sibling tabs stale and asks for a fresh `mt services list
+/// --json` read; a non-zero exit surfaces the recoverable banner and stops. A
+/// delivered read swaps its rows into storage — the tab's Elm `update`.
+pub fn update(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, shared: *ctx.SharedModel, msg: cmd.Msg) cmd.Cmd {
+    switch (msg) {
+        .mutated => |code| {
+            if (code != 0) {
+                shared.banner.set(action_fail_op, "ChildFailed");
+                return .none;
+            }
+            shared.markStaleAfter(.services); // this tab refreshes next; the others may be stale
+            const argv = cmd.jsonArgv(allocator, mt_path, &.{ "services", "list" }) catch return .none;
+            return .{ .read = .{ .argv = argv, .allow_empty = true, .mode = .polled, .parse = cmd.parserFor(.services, services_json.parse), .tag = .services, .fail_op = refresh_fail_op } };
+        },
+        .loaded => |parsed| {
+            swapRows(s, storage, parsed.services);
+            return .none;
+        },
+        .cleared => {
+            clear(s, storage); // an exit-0 empty read: no services registered
+            return .none;
+        },
+        .failed => return .none, // the pump set the banner; keep the last-good rows
     }
 }
 
-/// Build `mt services <action> <name>` for the selected service. Pure over the
-/// tab state: null when nothing is selected (the no-op), else an owned argv whose
-/// `name` element borrows from the parse storage. Caller frees the returned slice
-/// (not its elements).
-fn serviceActionArgv(allocator: std.mem.Allocator, mt_path: []const u8, action: []const u8, s: *const State) std.mem.Allocator.Error!?[]const []const u8 {
-    const svc = selectedService(s) orelse return null; // empty list: no-op
-    return try spawn.inlineArgv(allocator, mt_path, &.{ "services", action, svc.name });
-}
-
-/// Delegate a service lifecycle action to the real `mt` inline, then refresh. The
-/// argv's `name` borrows from the current parse storage; the post-spawn reload
-/// frees that storage, so the name is not read afterwards.
-fn doServiceAction(s: *State, storage: *Storage, c: *ctx.Ctx, action: []const u8) !void {
-    const argv = (try serviceActionArgv(c.allocator, c.mt_path, action, s)) orelse return; // nothing selected
-    defer c.allocator.free(argv);
-    {
-        // A non-zero `mt services <action>` re-enters the dashboard (the user
-        // keeps malt's real output in their scrollback) and surfaces as a
-        // recoverable banner; only a terminal fault is fatal. Scoped so the
-        // refresh below reports under its own op, not the action.
-        errdefer |err| c.shared.banner.set("service action failed", @errorName(err));
-        try spawn.runInlineReenter(c.term, argv);
-    }
-    try loadServices(s, storage, c); // the state changed — refetch
-    c.shared.markStaleAfter(.services); // this tab is fresh; the others may now be stale
-}
-
-/// (Re)read `mt services list --json` and repoint the Services tab's rows at the
-/// fresh parse, freeing the previous one. The polled read animates the shell's
-/// spinner through `c.painter` while it blocks; the storage is swapped only after
-/// a clean parse, so a failure keeps the last-good rows and their selection.
-fn loadServices(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
-    errdefer |err| c.shared.banner.set("services refresh failed", @errorName(err));
-    const argv = try spawn.jsonArgv(c.allocator, c.mt_path, &.{ "services", "list" });
-    defer c.allocator.free(argv);
-    // Keep `loading` set across the poll so each tick paints the spinner, cleared
-    // once the result (or the empty/banner state) replaces it.
-    c.loading.* = true;
-    defer c.loading.* = false;
-    const bytes = try spawn.readJsonPolled(c.io, c.allocator, argv, 0, c.painter);
-    defer if (bytes) |b| c.allocator.free(b);
-    try applyServicesBytes(c.allocator, s, storage, bytes);
-}
-
-/// Repoint the Services tab at a drained `--json` payload. `null` (a fresh prefix)
-/// clears to an empty list; a parsed document swaps in the rows. Shared by the
-/// synchronous reload and the background fetch; the storage is swapped only after
-/// a clean parse, so a failure keeps the last-good rows. Public because the shell's
-/// fetch drain routes a background payload through it.
-pub fn applyServicesBytes(allocator: std.mem.Allocator, st: *State, storage: *Storage, bytes: ?[]const u8) services_json.Error!void {
-    const payload = bytes orelse {
-        if (storage.services) |old| old.deinit();
-        storage.services = null;
-        st.items = &.{};
-        st.detail = null; // the old detail borrowed the freed rows
-        return;
-    };
-    const parsed = try services_json.parse(allocator, payload);
+/// Repoint the rows at a fresh parse, freeing the previous one. The swap happens
+/// only after a clean parse upstream, so a failed refresh keeps the last-good rows.
+fn swapRows(s: *State, storage: *Storage, parsed: services_json.Parsed) void {
     if (storage.services) |old| old.deinit();
     storage.services = parsed;
-    st.items = parsed.items;
-    st.detail = null; // a refreshed list invalidates the old detail
+    s.items = parsed.items;
+    s.detail = null; // a refreshed list invalidates the old detail
+}
+
+/// Clear to the empty-list state, freeing any held parse. Shared by a null
+/// background payload and a `.cleared` keypress read.
+fn clear(s: *State, storage: *Storage) void {
+    if (storage.services) |old| old.deinit();
+    storage.services = null;
+    s.items = &.{};
+    s.detail = null; // the old detail borrowed the freed rows
+}
+
+/// Repoint the Services tab at a drained background `--json` payload. `null` (a
+/// fresh prefix) clears to an empty list; a document parses and swaps in. The
+/// shell's fetch drain routes a background payload here; the keypress reload folds
+/// the same swap through `update`.
+pub fn applyServicesBytes(allocator: std.mem.Allocator, st: *State, storage: *Storage, bytes: ?[]const u8) services_json.Error!void {
+    const payload = bytes orelse return clear(st, storage);
+    swapRows(st, storage, try services_json.parse(allocator, payload));
 }
 
 // ─── tests ───────────────────────────────────────────────────────────
 
 fn ch(c: u8) tab.Key {
     return .{ .char = .{ .bytes = .{ c, 0, 0, 0 }, .len = 1 } };
+}
+
+/// Drive `step` with a throwaway storage and a fixed mt path. Services' `step`
+/// ignores storage, so this keeps the pure-behaviour tests readable.
+fn stepKey(s: *State, key: tab.Key) cmd.Cmd {
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    return step(testing.allocator, "/opt/malt/bin/mt", s, &storage, key);
 }
 
 const sample = [_]Row{
@@ -364,7 +352,7 @@ test "footerHint advertises the details affordance alongside the lifecycle keys"
 
 test "End jumps to the last filtered row" {
     var s: State = .{ .items = &sample };
-    step(&s, .end);
+    _ = stepKey(&s, .end);
     try testing.expectEqual(@as(usize, 3), s.chrome.view.selected);
 }
 
@@ -374,35 +362,36 @@ test "matches is a case-insensitive substring; empty filter matches all" {
     try testing.expect(!matches("redis", "zzz"));
 }
 
-test "s requests start, x and X request stop, r requests restart" {
-    var s: State = .{ .items = &sample };
-    step(&s, ch('s'));
-    try testing.expectEqual(Request.start, s.request);
-    step(&s, ch('x'));
-    try testing.expectEqual(Request.stop, s.request);
-    step(&s, ch('X'));
-    try testing.expectEqual(Request.stop, s.request);
-    step(&s, ch('r'));
-    try testing.expectEqual(Request.restart, s.request);
+test "s/x/r return the run_mutation for `mt services <action> <selected>`" {
+    var s: State = .{ .items = &sample }; // selection defaults to row 0 (redis)
+    const cases = [_]struct { key: tab.Key, action: []const u8 }{
+        .{ .key = ch('s'), .action = "start" },
+        .{ .key = ch('x'), .action = "stop" },
+        .{ .key = ch('X'), .action = "stop" },
+        .{ .key = ch('r'), .action = "restart" },
+    };
+    for (cases) |c| {
+        const eff = stepKey(&s, c.key);
+        defer testing.allocator.free(eff.run_mutation.argv);
+        try testing.expect(eff == .run_mutation);
+        try testing.expectEqual(cmd.MsgTag.services, eff.run_mutation.tag);
+        const argv = eff.run_mutation.argv;
+        try testing.expectEqualStrings("services", argv[1]);
+        try testing.expectEqualStrings(c.action, argv[2]);
+        try testing.expectEqualStrings("redis", argv[3]);
+    }
 }
 
-test "mutates is true for any pending lifecycle action, false only for none" {
-    var s: State = .{};
-    try testing.expect(!mutates(&s)); // .none never gates the pre-mutation drain
-    s.request = .start;
-    try testing.expect(mutates(&s));
-    s.request = .stop;
-    try testing.expect(mutates(&s));
-    s.request = .restart;
-    try testing.expect(mutates(&s));
+test "a lifecycle key on an empty list is a Cmd.none no-op — no effect" {
+    var s: State = .{ .items = &.{} };
+    try testing.expect(stepKey(&s, ch('s')) == .none);
 }
 
-test "an unrelated key leaves the request alone" {
+test "an unrelated key returns Cmd.none; a pure-nav key changes state but stays none" {
     var s: State = .{ .items = &sample };
-    step(&s, ch('z'));
-    try testing.expectEqual(Request.none, s.request);
-    step(&s, .enter);
-    try testing.expectEqual(Request.none, s.request);
+    try testing.expect(stepKey(&s, ch('z')) == .none);
+    try testing.expect(stepKey(&s, .enter) == .none); // opens the detail pane…
+    try testing.expect(s.detail != null); // …but that is pure state, not an effect
 }
 
 test "selectedService maps the cursor through the filter and clamps out-of-range" {
@@ -470,7 +459,7 @@ test "ENTER opens a detail pane showing the schedule label; ESC closes it" {
         .{ .name = "backup", .state = "loaded", .auto_start = false, .keg_name = "backup", .schedule = "interval 300s" },
     };
     var s: State = .{ .items = &rows };
-    step(&s, .enter);
+    _ = stepKey(&s, .enter);
     try testing.expect(s.detail != null);
 
     render(&s, &f, .{ .row = 1, .col = 1, .width = 60, .height = 12 });
@@ -479,7 +468,7 @@ test "ENTER opens a detail pane showing the schedule label; ESC closes it" {
     try testing.expect(std.mem.indexOf(u8, out, "Schedule") != null);
     try testing.expect(std.mem.indexOf(u8, out, "interval 300s") != null);
 
-    step(&s, .esc);
+    _ = stepKey(&s, .esc);
     try testing.expect(s.detail == null);
 }
 
@@ -490,7 +479,7 @@ test "detail pane shows no schedule label for a run-at-load service" {
         .{ .name = "redis", .state = "running", .auto_start = true, .keg_name = "redis", .schedule = "" },
     };
     var s: State = .{ .items = &rows };
-    step(&s, .enter);
+    _ = stepKey(&s, .enter);
     render(&s, &f, .{ .row = 1, .col = 1, .width = 60, .height = 12 });
     const out = f.slice();
     try testing.expect(std.mem.indexOf(u8, out, "Schedule") != null);
@@ -603,103 +592,78 @@ test "render clamps to a height of one without crashing" {
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 1 }); // one list row fits
 }
 
-test "serviceActionArgv builds `mt services <action> <name>` for the selected service" {
+test "the mutation targets the selected row's name" {
     const items = [_]Row{
         .{ .name = "redis", .state = "running", .auto_start = true, .keg_name = "redis" },
         .{ .name = "postgresql", .state = "stopped", .auto_start = false, .keg_name = "postgresql@16" },
     };
     var st: State = .{ .items = &items };
     st.chrome.view.selected = 1; // postgresql
-    const argv = (try serviceActionArgv(testing.allocator, "/opt/homebrew/bin/mt", "restart", &st)).?;
-    defer testing.allocator.free(argv);
+    const eff = actionCmd(testing.allocator, "/opt/homebrew/bin/mt", &st, "restart");
+    defer testing.allocator.free(eff.run_mutation.argv);
+    const argv = eff.run_mutation.argv;
     try testing.expectEqual(@as(usize, 4), argv.len);
     try testing.expectEqualStrings("/opt/homebrew/bin/mt", argv[0]);
-    try testing.expectEqualStrings("services", argv[1]);
     try testing.expectEqualStrings("restart", argv[2]);
     try testing.expectEqualStrings("postgresql", argv[3]); // the selected row's name
 }
 
-test "serviceActionArgv returns null when nothing is selected so the action is a no-op" {
-    const st: State = .{ .items = &.{} };
-    try testing.expect((try serviceActionArgv(testing.allocator, "/bin/mt", "start", &st)) == null);
-}
-
-// Backing storage for a `ctx.Ctx` in an effect test: dummy term/fetches/shared,
-// a no-op painter (fd = -1; the test children finish before the first poll tick,
-// so it is never touched), and the synchronous-load flag.
-const TestEnv = struct {
-    term_h: ctx.Term,
-    fetches: ctx.Fetches = ctx.Fetches.initFill(null),
-    shared: ctx.SharedModel = .{},
-    frame: []u8 = &.{},
-    loading: bool = false,
-};
-
-fn mkCtx(io: std.Io, e: *TestEnv, mt_path: []const u8) ctx.Ctx {
-    return .{
-        .io = io,
-        .allocator = testing.allocator,
-        .term = &e.term_h,
-        .painter = .{ .fd = -1, .frame = &e.frame },
-        .fetches = &e.fetches,
-        .shared = &e.shared,
-        .mt_path = mt_path,
-        .loading = &e.loading,
-    };
-}
-
-test "loadServices treats an exit-0 empty response (fresh prefix) as an empty tab" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+test "update on a successful mutation marks siblings stale and asks for a fresh read" {
+    var st: State = .{};
     var storage: Storage = .{};
     defer storage.deinit(testing.allocator);
+    var shared: ctx.SharedModel = .{};
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .mutated = 0 });
+    defer testing.allocator.free(next.read.argv);
+    try testing.expect(next == .read);
+    try testing.expectEqual(cmd.Cmd.Mode.polled, next.read.mode); // blocking, spinner-animated
+    try testing.expectEqual(cmd.MsgTag.services, next.read.tag);
+    try testing.expectEqualStrings("services", next.read.argv[1]);
+    try testing.expectEqualStrings("list", next.read.argv[2]);
+    try testing.expectEqualStrings("--json", next.read.argv[3]);
+    try testing.expect(shared.takeDirty(.installed)); // siblings were marked stale
+}
+
+test "update on a failed mutation shows the recoverable banner and does not reload" {
     var st: State = .{};
-    var c = mkCtx(thr.io(), &env, "/usr/bin/true");
-    try loadServices(&st, &storage, &c);
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    var shared: ctx.SharedModel = .{};
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .mutated = 1 });
+    try testing.expect(next == .none); // no reload on failure
+    try testing.expect(std.mem.startsWith(u8, shared.banner.slice(), "service action failed"));
+}
+
+test "update on a loaded document swaps rows in, drops the stale detail, returns none" {
+    var st: State = .{ .items = &sample, .detail = sample[0] };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    var shared: ctx.SharedModel = .{};
+    const parsed = try services_json.parse(testing.allocator, "{\"schema_version\":1,\"services\":[]}");
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .{ .loaded = .{ .services = parsed } });
+    try testing.expect(next == .none);
+    try testing.expectEqual(@as(usize, 0), st.items.len); // swapped to the fresh (empty) parse
+    try testing.expect(st.detail == null);
+}
+
+test "update on a cleared read (an exit-0 empty reload) empties the list" {
+    var st: State = .{ .items = &sample, .detail = sample[0] };
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    var shared: ctx.SharedModel = .{};
+    const next = update(testing.allocator, "/bin/mt", &st, &storage, &shared, .cleared);
+    try testing.expect(next == .none);
     try testing.expectEqual(@as(usize, 0), st.items.len);
-    try testing.expect(!env.shared.banner.isSet());
+    try testing.expect(st.detail == null); // the stale detail borrowed the freed rows
 }
 
-test "a failed services refresh names the op in the banner and keeps the last-good rows" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
+test "applyServicesBytes on a null (fresh-prefix) payload clears to an empty list" {
+    var st: State = .{ .items = &sample };
     var storage: Storage = .{};
     defer storage.deinit(testing.allocator);
-    var st: State = .{};
-    var c = mkCtx(thr.io(), &env, "/bin/echo"); // echo emits non-JSON → parse fails
-    try testing.expectError(error.BadJson, loadServices(&st, &storage, &c));
-    try testing.expectEqualStrings("services refresh failed: BadJson", env.shared.banner.slice());
-    try testing.expectEqual(@as(usize, 0), st.items.len); // last-good kept
-}
-
-test "service on a .none request is a clean no-op — no spawn, no banner" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
-    var storage: Storage = .{};
-    defer storage.deinit(testing.allocator);
-    var st: State = .{}; // .none: the pure `step` set nothing to perform
-    var c = mkCtx(thr.io(), &env, "/bin/false"); // would fail if it ever spawned
-    try service(&st, &storage, &c);
-    try testing.expectEqual(Request.none, st.request);
-    try testing.expect(!env.shared.banner.isSet());
-}
-
-test "service drains a lifecycle request; an empty list never spawns" {
-    var thr = std.Io.Threaded.init(testing.allocator, .{});
-    defer thr.deinit();
-    var env: TestEnv = .{ .term_h = ctx.Term.init(thr.io(), -1) };
-    var storage: Storage = .{};
-    defer storage.deinit(testing.allocator);
-    // An empty list means `serviceActionArgv` resolves to null: the request drains
-    // but no `mt services start` child runs, so `/bin/false` is never reached.
-    var st: State = .{ .request = .start };
-    var c = mkCtx(thr.io(), &env, "/bin/false");
-    try service(&st, &storage, &c);
-    try testing.expectEqual(Request.none, st.request); // the producer/consumer seam drained it
-    try testing.expect(!env.shared.banner.isSet()); // never spawned → no failure banner
+    try applyServicesBytes(testing.allocator, &st, &storage, null);
+    try testing.expectEqual(@as(usize, 0), st.items.len);
+    try testing.expect(st.detail == null);
 }
 
 test "conforms to the tab contract" {

--- a/src/tui/tab.zig
+++ b/src/tui/tab.zig
@@ -10,6 +10,7 @@
 
 const std = @import("std");
 const color = @import("../ui/color.zig");
+const cmd = @import("cmd.zig");
 const ctx = @import("ctx.zig");
 const scroll_list = @import("scroll_list.zig");
 const layout = @import("layout.zig");
@@ -175,41 +176,16 @@ pub fn verify(comptime M: type) void {
     if (!@hasDecl(M, "State")) @compileError(@typeName(M) ++ ": tab must expose `pub const State`");
     if (!@hasField(M.State, "chrome")) @compileError(@typeName(M) ++ ".State must embed a `chrome` field");
     if (@FieldType(M.State, "chrome") != Chrome) @compileError(@typeName(M) ++ ".State.chrome must be tab.Chrome");
-    for ([_][]const u8{ "title", "footerHint", "step", "render" }) |decl| {
+    for ([_][]const u8{ "title", "footerHint", "step", "render", "update" }) |decl| {
         if (!@hasDecl(M, decl)) @compileError(@typeName(M) ++ ": tab must expose `pub fn " ++ decl ++ "`");
     }
     // A tab declares its background-fetch capability as data, read generically by
     // the shell; `null` for a synchronous tab. Total coverage, no runtime switch.
     if (!@hasDecl(M, "fetch_spec")) @compileError(@typeName(M) ++ ": tab must expose `pub const fetch_spec: ?FetchSpec`");
     if (@TypeOf(M.fetch_spec) != ?FetchSpec) @compileError(@typeName(M) ++ ".fetch_spec must be `?FetchSpec`");
-
-    // Optional typed capability decls — a tab migrates its impure surface
-    // incrementally, so these are type-checked *iff* declared, never required
-    // present here (the shell falls back to the legacy dispatch for a tab still
-    // missing `service`). A declared-but-mistyped capability is a build error, so
-    // the uniform effect shape is pinned at comptime the moment a tab conforms.
-    if (@hasDecl(M, "mutates") and @TypeOf(M.mutates) != fn (*const M.State) bool)
-        @compileError(@typeName(M) ++ ".mutates must be `fn (*const State) bool`");
-    if (@hasDecl(M, "service")) verifyService(M);
-}
-
-/// Pin a declared `service` to the uniform `fn (*State, *Storage, *ctx.Ctx) !void`
-/// shape. The error set is inferred per tab, so the parameters — not the whole fn
-/// type — are the contract; the return set is validated where the shell `try`s it.
-fn verifyService(comptime M: type) void {
-    // `service` owns the tab's parse storage, so a conforming tab must expose one —
-    // reported here, not as a raw "no member" when the params are checked below.
-    if (!@hasDecl(M, "Storage")) @compileError(@typeName(M) ++ ": a tab exposing `service` must also expose `pub const Storage`");
-    const fn_info = switch (@typeInfo(@TypeOf(M.service))) {
-        .@"fn" => |f| f,
-        else => @compileError(@typeName(M) ++ ".service must be a function"),
-    };
-    const want = [_]type{ *M.State, *M.Storage, *ctx.Ctx };
-    const shape = @typeName(M) ++ ".service must be `fn (*State, *Storage, *ctx.Ctx) !void`";
-    if (fn_info.params.len != want.len) @compileError(shape);
-    inline for (fn_info.params, want) |got, w| {
-        if (got.type != w) @compileError(shape);
-    }
+    // `step`/`update` are the Elm effect seam: they return a `cmd.Cmd` and own the
+    // tab's parse storage, so a conforming tab must expose one — reported here.
+    if (!@hasDecl(M, "Storage")) @compileError(@typeName(M) ++ ": tab must expose `pub const Storage`");
 }
 
 // ─── tests ───────────────────────────────────────────────────────────
@@ -229,30 +205,34 @@ const GoodTab = struct {
     pub fn footerHint() []const u8 {
         return "g: go";
     }
-    pub fn step(s: *State, key: Key) void {
+    pub fn step(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, key: Key) cmd.Cmd {
+        _ = allocator;
+        _ = mt_path;
         _ = s;
+        _ = storage;
         _ = key;
+        return .none;
+    }
+    pub fn update(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, shared: *ctx.SharedModel, msg: cmd.Msg) cmd.Cmd {
+        _ = allocator;
+        _ = mt_path;
+        _ = s;
+        _ = storage;
+        _ = shared;
+        _ = msg;
+        return .none;
     }
     pub fn render(s: *const State, f: *Frame, r: Rect) void {
         _ = s;
         _ = f;
         _ = r;
     }
-    pub fn mutates(s: *const State) bool {
-        _ = s;
-        return false;
-    }
-    pub fn service(s: *State, storage: *Storage, c: *ctx.Ctx) !void {
-        _ = s;
-        _ = storage;
-        _ = c;
-    }
 };
 
-test "verify accepts a conforming tab module, including a well-typed service + mutates" {
-    // The optional effect capabilities are type-checked here: had `service`'s
-    // params or `mutates`'s signature drifted from the contract, this would not
-    // compile — the comptime guard the migrated tabs rely on.
+test "verify accepts a conforming tab module exposing step/update/Storage" {
+    // The effect seam is checked here: a tab missing `update` or `Storage`, or with
+    // the wrong `State.chrome` type, would not compile — the comptime guard the
+    // migrated tabs rely on.
     comptime verify(GoodTab);
 }
 

--- a/tests/tui_app_test.zig
+++ b/tests/tui_app_test.zig
@@ -19,24 +19,33 @@ fn ch(c: u8) Key {
     return .{ .char = .{ .bytes = .{ c, 0, 0, 0 }, .len = 1 } };
 }
 
+/// Drive `step` in place for a nav/editing test. These keys produce `Cmd.none`
+/// (no heap argv), so the discarded `Cmd` owns nothing to free.
+fn stepA(a: *app.App, key: Key) void {
+    _ = app.step(testing.allocator, a.mt_path, a, key);
+}
+
 test "tab and digit keys switch the active tab" {
     var a: app.App = .{};
-    a = app.step(a, .tab);
+    stepA(&a, .tab);
     try testing.expectEqual(Tab.installed, a.active);
-    a = app.step(a, ch('4'));
+    stepA(&a, ch('4'));
     try testing.expectEqual(Tab.services, a.active);
-    a = app.step(a, ch('1'));
+    stepA(&a, ch('1'));
     try testing.expectEqual(Tab.search, a.active);
 }
 
 test "filter editing toggles edit mode and quit keys set quit" {
     var a: app.App = .{};
-    a = app.step(a, ch('/'));
+    stepA(&a, ch('/'));
     try testing.expect(a.editing);
-    a = app.step(a, .enter);
+    stepA(&a, .enter);
     try testing.expect(!a.editing);
-    try testing.expect(app.step(a, ch('q')).quit);
-    try testing.expect(app.step(a, .ctrl_c).quit);
+    stepA(&a, ch('q'));
+    try testing.expect(a.quit);
+    var b: app.App = .{};
+    stepA(&b, .ctrl_c);
+    try testing.expect(b.quit);
 }
 
 test "renderFrame is a pure function of size — a resize re-renders from cached state" {
@@ -75,7 +84,7 @@ test "a recoverable banner is painted in the footer and a keypress dismisses it"
     const shown = app.renderFrame(&buf, &a, 80, 24);
     try testing.expect(std.mem.indexOf(u8, shown, "info for jq failed: BadJson") != null);
 
-    a = app.step(a, .down); // any key clears the transient banner
+    stepA(&a, .down); // any key clears the transient banner
     try testing.expect(!a.shared.banner.isSet());
     const cleared = app.renderFrame(&buf, &a, 80, 24);
     try testing.expect(std.mem.indexOf(u8, cleared, "info for jq failed") == null);

--- a/tests/tui_doctor_test.zig
+++ b/tests/tui_doctor_test.zig
@@ -60,16 +60,20 @@ test "f over the fixture targets the selected fixable finding by its fix_class" 
     defer parsed.deinit();
 
     var st: doctor.State = .{ .items = parsed.items };
+    var storage: doctor.Storage = .{};
+    defer storage.deinit(testing.allocator);
 
     // Display order: sqlite (err), orphaned (warn), stale_lock (warn), malt_prefix (ok).
-    // Cursor on the orphaned finding; `f` requests a fix of exactly that finding.
+    // Cursor on the orphaned finding; `f` builds a fix mutation over exactly that finding.
     st.chrome.view.selected = 1;
     const sel = doctor.selectedFinding(&st).?;
     try testing.expectEqualStrings("orphaned_store_entries", sel.id); // the descriptive id…
     try testing.expectEqualStrings("orphaned_store", doctor_json.fixClassTag(sel.fix_class)); // …vs the --fix token
 
-    doctor.step(&st, .{ .char = .{ .bytes = .{ 'f', 0, 0, 0 }, .len = 1 } });
-    try testing.expectEqual(doctor.Request.fix, st.request);
+    const eff = doctor.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, .{ .char = .{ .bytes = .{ 'f', 0, 0, 0 }, .len = 1 } });
+    defer testing.allocator.free(eff.run_mutation.argv);
+    try testing.expectEqualStrings("--fix", eff.run_mutation.argv[2]);
+    try testing.expectEqualStrings("orphaned_store", eff.run_mutation.argv[3]); // the fix_class token
 }
 
 test "f on a non-fixable finding over the fixture is inert" {
@@ -79,10 +83,11 @@ test "f on a non-fixable finding over the fixture is inert" {
     defer parsed.deinit();
 
     var st: doctor.State = .{ .items = parsed.items };
+    var storage: doctor.Storage = .{};
+    defer storage.deinit(testing.allocator);
     st.chrome.view.selected = 0; // sqlite_integrity — an error, not fixable
     try testing.expectEqual(false, doctor.selectedFinding(&st).?.fixable);
-    doctor.step(&st, .{ .char = .{ .bytes = .{ 'f', 0, 0, 0 }, .len = 1 } });
-    try testing.expectEqual(doctor.Request.none, st.request);
+    try testing.expect(doctor.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, .{ .char = .{ .bytes = .{ 'f', 0, 0, 0 }, .len = 1 } }) == .none);
 }
 
 test "a filter narrows the fix target to a matching finding" {

--- a/tests/tui_outdated_test.zig
+++ b/tests/tui_outdated_test.zig
@@ -67,9 +67,11 @@ test "select-all over the fixture upgrades every non-pinned row in order, holdin
     defer testing.allocator.free(checked);
     @memset(checked, false);
     var st: outdated.State = .{ .items = parsed.items, .checked = checked };
+    var storage: outdated.Storage = .{};
+    defer storage.deinit(testing.allocator);
 
     // `a` checks all non-pinned rows; curl (index 1) is pinned and stays clear.
-    outdated.step(&st, .{ .char = .{ .bytes = .{ 'a', 0, 0, 0 }, .len = 1 } });
+    _ = outdated.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, .{ .char = .{ .bytes = .{ 'a', 0, 0, 0 }, .len = 1 } });
     try testing.expect(!checked[1]); // pinned curl
     try testing.expectEqual(@as(usize, 4), outdated.selectedCount(&st)); // 5 rows − 1 pinned
 
@@ -93,12 +95,14 @@ test "toggling individual fixture rows selects exactly those, in item order" {
     defer testing.allocator.free(checked);
     @memset(checked, false);
     var st: outdated.State = .{ .items = parsed.items, .checked = checked };
+    var storage: outdated.Storage = .{};
+    defer storage.deinit(testing.allocator);
 
     // Toggle ffmpeg (index 2) and visual-studio-code (index 4) via the cursor.
     st.chrome.view.selected = 2;
-    outdated.step(&st, .space);
+    _ = outdated.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, .space);
     st.chrome.view.selected = 4;
-    outdated.step(&st, .space);
+    _ = outdated.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, .space);
 
     var names: [8][]const u8 = undefined;
     const n = outdated.selectedNames(&st, &names);

--- a/tests/tui_search_test.zig
+++ b/tests/tui_search_test.zig
@@ -68,19 +68,21 @@ test "i over the fixture installs the selected not-yet-installed hit and is iner
     defer parsed.deinit();
 
     var st: search.State = .{ .items = parsed.items, .phase = .loaded };
+    var storage: search.Storage = .{};
+    defer storage.deinit(testing.allocator);
 
     // Cursor on firefox (index 0, already installed): `i` is inert.
     st.chrome.view.selected = 0;
-    search.step(&st, ch('i'));
-    try testing.expectEqual(search.Request.none, st.request);
+    try testing.expect(search.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, ch('i')) == .none);
 
-    // Cursor on firefox@developer-edition (index 1, not installed): `i` installs
-    // exactly that hit — the name the `mt install <name>` argv would carry.
+    // Cursor on firefox@developer-edition (index 1, not installed): `i` builds the
+    // install of exactly that hit — the argv `mt install --cask <name>` would carry.
     st.chrome.view.selected = 1;
-    search.step(&st, ch('i'));
-    try testing.expectEqual(search.Request.install, st.request);
-    try testing.expectEqualStrings("firefox@developer-edition", search.selectedMatch(&st).?.name);
-    try testing.expectEqual(search_json.Kind.cask, search.selectedMatch(&st).?.kind);
+    const eff = search.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, ch('i'));
+    defer testing.allocator.free(eff.run_mutation.argv);
+    try testing.expect(eff == .run_mutation);
+    try testing.expectEqualStrings("--cask", eff.run_mutation.argv[2]);
+    try testing.expectEqualStrings("firefox@developer-edition", eff.run_mutation.argv[3]);
 }
 
 test "i fires for a cross-query basket even when the cursor sits on an installed row" {
@@ -89,19 +91,24 @@ test "i fires for a cross-query basket even when the cursor sits on an installed
     var parsed = try search_json.parse(testing.allocator, bytes);
     defer parsed.deinit();
 
-    // The shell mirrors the cross-query basket onto the leaf as `selected_count`
-    // (picks from earlier queries, none on this result set). `i` must install the
-    // basket even with the cursor parked on an already-installed hit.
-    var st: search.State = .{ .items = parsed.items, .phase = .loaded, .selected_count = 2 };
-    st.chrome.view.selected = 0; // firefox (index 0, already installed)
-    search.step(&st, ch('i'));
-    try testing.expectEqual(search.Request.install, st.request);
+    var st: search.State = .{ .items = parsed.items, .phase = .loaded };
+    var storage: search.Storage = .{};
+    defer storage.deinit(testing.allocator);
+
+    // Build a cross-query basket by checking the not-installed hit (index 1).
+    st.chrome.view.selected = 1;
+    _ = search.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, .space);
+    try testing.expectEqual(@as(usize, 1), st.selected_count);
+
+    // Cursor parked on the already-installed firefox (index 0); the basket wins.
+    st.chrome.view.selected = 0;
+    const eff = search.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, ch('i'));
+    defer testing.allocator.free(eff.run_mutation.argv);
+    try testing.expect(eff == .run_mutation);
 
     // Empty basket + the same installed row → nothing to do, so `i` is inert.
-    st.request = .none;
-    st.selected_count = 0;
-    search.step(&st, ch('i'));
-    try testing.expectEqual(search.Request.none, st.request);
+    _ = search.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, ch('n')); // clear the basket
+    try testing.expect(search.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, ch('i')) == .none);
 }
 
 test "the basket view surfaces and removes an off-results pick from a real query" {
@@ -110,28 +117,29 @@ test "the basket view surfaces and removes an off-results pick from a real query
     var parsed = try search_json.parse(testing.allocator, bytes);
     defer parsed.deinit();
 
-    // The cross-query case the basket exists for: `gimp` was checked under an
-    // earlier query and is absent from this result set, while `firejail` is on
-    // screen. The shell hands both to the leaf as the borrowed basket.
-    const basket = [_]search.SelEntry{
-        .{ .name = "gimp", .kind = .cask }, // off the current results
-        .{ .name = "firejail", .kind = .formula }, // also a row in the fixture
-    };
-    var st: search.State = .{ .items = parsed.items, .phase = .loaded, .basket = &basket };
+    var st: search.State = .{ .items = parsed.items, .phase = .loaded };
+    var storage: search.Storage = .{};
+    defer storage.deinit(testing.allocator);
+
+    // The cross-query case the basket exists for: `gimp` was checked under an earlier
+    // query and is absent from this result set, while `firejail` is on screen.
+    try storage.selected.toggle(testing.allocator, "gimp", .cask); // off the current results
+    try storage.selected.toggle(testing.allocator, "firejail", .formula); // also a row in the fixture
+    search.syncSelected(&st, &storage);
 
     // `l` opens the basket; the off-results pick is the highlighted row.
-    search.step(&st, ch('l'));
+    _ = search.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, ch('l'));
     try testing.expectEqual(search.View.basket, st.view);
     st.chrome.view.selected = 0;
     try testing.expectEqualStrings("gimp", search.selectedBasketEntry(&st).?.name);
 
-    // `d` asks the shell to drop exactly that pick — the name the removal carries.
-    search.step(&st, ch('d'));
-    try testing.expectEqual(search.Request.remove, st.request);
-    try testing.expectEqualStrings("gimp", search.selectedBasketEntry(&st).?.name);
+    // `d` drops exactly that pick from the basket.
+    try testing.expect(search.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, ch('d')) == .none);
+    try testing.expect(!storage.selected.contains("gimp", .cask)); // dropped
+    try testing.expect(storage.selected.contains("firejail", .formula)); // the on-screen pick stays
 }
 
-test "Enter over a result requests its info (committing the query is the shell's job)" {
+test "Enter over a result opens its info read (committing the query is the shell's job)" {
     const bytes = try readFixture(testing.allocator, "tui_search.json");
     defer testing.allocator.free(bytes);
     var parsed = try search_json.parse(testing.allocator, bytes);
@@ -140,6 +148,10 @@ test "Enter over a result requests its info (committing the query is the shell's
     // Enter over a loaded result opens `mt info` for it; the query-commit path
     // (filter editing → search) is driven by the app shell, not the tab core.
     var st: search.State = .{ .items = parsed.items, .phase = .loaded };
-    search.step(&st, .enter);
-    try testing.expectEqual(search.Request.info, st.request);
+    var storage: search.Storage = .{};
+    defer storage.deinit(testing.allocator);
+    const eff = search.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, .enter);
+    defer testing.allocator.free(eff.read.argv);
+    try testing.expect(eff == .read);
+    try testing.expectEqualStrings("info", eff.read.argv[1]);
 }

--- a/tests/tui_services_test.zig
+++ b/tests/tui_services_test.zig
@@ -63,19 +63,22 @@ test "a lifecycle key over the fixture targets the selected service" {
     defer parsed.deinit();
 
     var st: services.State = .{ .items = parsed.items };
+    var storage: services.Storage = .{};
+    defer storage.deinit(testing.allocator);
 
-    // Cursor on dnsmasq (index 2); `r` requests a restart of exactly that row.
+    // Cursor on dnsmasq (index 2); `r` builds a restart mutation over exactly that row.
     st.chrome.view.selected = 2;
-    services.step(&st, .{ .char = .{ .bytes = .{ 'r', 0, 0, 0 }, .len = 1 } });
-    try testing.expectEqual(services.Request.restart, st.request);
-    try testing.expectEqualStrings("dnsmasq", services.selectedService(&st).?.name);
+    const restart = services.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, .{ .char = .{ .bytes = .{ 'r', 0, 0, 0 }, .len = 1 } });
+    defer testing.allocator.free(restart.run_mutation.argv);
+    try testing.expectEqualStrings("restart", restart.run_mutation.argv[2]);
+    try testing.expectEqualStrings("dnsmasq", restart.run_mutation.argv[3]);
 
-    // `s` on postgresql@16 requests a start of that row — the argv `mt services`
-    // would receive is `start postgresql@16`.
+    // `s` on postgresql@16 → `mt services start postgresql@16`.
     st.chrome.view.selected = 1;
-    services.step(&st, .{ .char = .{ .bytes = .{ 's', 0, 0, 0 }, .len = 1 } });
-    try testing.expectEqual(services.Request.start, st.request);
-    try testing.expectEqualStrings("postgresql@16", services.selectedService(&st).?.name);
+    const start = services.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, .{ .char = .{ .bytes = .{ 's', 0, 0, 0 }, .len = 1 } });
+    defer testing.allocator.free(start.run_mutation.argv);
+    try testing.expectEqualStrings("start", start.run_mutation.argv[2]);
+    try testing.expectEqualStrings("postgresql@16", start.run_mutation.argv[3]);
 }
 
 test "a filter narrows the lifecycle target to a matching service" {
@@ -85,9 +88,12 @@ test "a filter narrows the lifecycle target to a matching service" {
     defer parsed.deinit();
 
     var st: services.State = .{ .items = parsed.items };
+    var storage: services.Storage = .{};
+    defer storage.deinit(testing.allocator);
     st.chrome.filter.push("postgres"); // only postgresql@16 matches
     st.chrome.view.selected = 0;
-    services.step(&st, .{ .char = .{ .bytes = .{ 'x', 0, 0, 0 }, .len = 1 } });
-    try testing.expectEqual(services.Request.stop, st.request);
-    try testing.expectEqualStrings("postgresql@16", services.selectedService(&st).?.name);
+    const stop = services.step(testing.allocator, "/opt/malt/bin/mt", &st, &storage, .{ .char = .{ .bytes = .{ 'x', 0, 0, 0 }, .len = 1 } });
+    defer testing.allocator.free(stop.run_mutation.argv);
+    try testing.expectEqualStrings("stop", stop.run_mutation.argv[2]);
+    try testing.expectEqualStrings("postgresql@16", stop.run_mutation.argv[3]);
 }


### PR DESCRIPTION
## Description

TUI effects become values. Each tab's pure `step` now returns a `Cmd` that names an effect (carrying a pointer to the tab's own parser), and the tab's result-handling becomes a pure `update` that folds the outcome back - the Elm shape the code was already half-built for. The search basket toggles, which never spawned anything, are demoted to pure state changes and leave the effect path.

The payoff is provable purity: no tab imports the process runner anymore. The five hand-written per-tab performers and the flat dispatcher collapse into one small `perform`/`update` pump. A temporary bridge in the app module performs the returned commands the old way so behaviour is preserved; it is removed when the domain-agnostic interpreter lands next.

## Related Issue

- None

## Notes for Reviewers

- None