### PR TITLE
test(tui): pin the run loop's synchronous Cmd/Msg fast-path

### DIFF
--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -921,6 +921,16 @@ fn testPainter(frame: *[]u8) Painter {
     return .{ .fd = -1, .frame = frame };
 }
 
+/// A heap-owned `argv` of `/bin/echo <doc>`, so a synchronous read yields a fixed
+/// document with no live `mt`. Owned like a real `Cmd`'s argv — the pump frees the
+/// slice; the elements are static, so nothing else is freed.
+fn echoArgv(allocator: std.mem.Allocator, doc: []const u8) std.mem.Allocator.Error![]const []const u8 {
+    const argv = try allocator.alloc([]const u8, 2);
+    argv[0] = "/bin/echo";
+    argv[1] = doc;
+    return argv;
+}
+
 test "a data-free App renders the full chrome so the skeleton paint is real" {
     var app: App = .{}; // active .search, empty storage, no counts loaded
     var buf: [8192]u8 = undefined;
@@ -1461,6 +1471,67 @@ test "the pump enqueues a background read rather than blocking, then folds it vi
     try driveFetchToEnd(t.io(), std.testing.allocator, &app, &store, &fetches, .outdated);
     try std.testing.expectEqual(@as(?usize, 0), app.shared.outdated_count); // empty read folds to a known zero
     try std.testing.expect(!app.shared.tab_loading.contains(.outdated));
+}
+
+test "a synchronous foreground read folds through the pump into the tab model in one cycle" {
+    // The pump's contract in isolation: a blocking foreground `read` `Cmd` resolves
+    // within the single `pump` call (perform → `.loaded` → `update`), leaving the tab
+    // at its expected model with nothing deferred — the counterpart of the
+    // background-mode test above, which enqueues and folds later.
+    var thr = std.Io.Threaded.init(std.testing.allocator, .{});
+    defer thr.deinit();
+    var app: App = .{ .active = .search };
+    var store: Storages = .{};
+    defer store.deinit(std.testing.allocator);
+    var fetches: Fetches = .initFill(null);
+    var frame: []u8 = try std.testing.allocator.alloc(u8, 256);
+    defer std.testing.allocator.free(frame);
+    var tm = term.Term.init(thr.io(), -1); // headless: a foreground read never touches the term
+
+    // Build the real search read (real parser baked in), then repoint its argv at a
+    // fixed document so the blocking capture is deterministic without a live `mt`.
+    app.states.search.chrome.filter.push("wget"); // non-empty query, so searchCmd is a read
+    var c = search.searchCmd(std.testing.allocator, app.mt_path, &app.states.search);
+    try std.testing.expect(c == .read);
+    std.testing.allocator.free(c.read.argv);
+    c.read.argv = try echoArgv(std.testing.allocator, "{\"results\":[{\"name\":\"wget\",\"type\":\"formula\",\"installed\":false}]}");
+
+    try pump(thr.io(), std.testing.allocator, &tm, testPainter(&frame), &fetches, &app, &store, c);
+
+    try std.testing.expectEqual(search.Phase.loaded, app.states.search.phase); // the fold reset it from searching
+    try std.testing.expectEqual(@as(usize, 1), app.states.search.items.len); // the result landed this cycle
+    try std.testing.expect(!anyFetchActive(&fetches)); // synchronous — no background fetch queued
+}
+
+test "the search info fast-path opens the detail pane in one pump cycle, never deferred" {
+    // The press-Enter-opens-a-pane feel: Enter on a loaded hit yields a blocking `mt
+    // info` read that must complete inside the one pump cycle (no async round-trip),
+    // so the pane is open when the cycle returns and no background fetch is registered.
+    var thr = std.Io.Threaded.init(std.testing.allocator, .{});
+    defer thr.deinit();
+    const items = [_]search.Match{.{ .name = "wget", .kind = .formula, .installed = false }};
+    var app: App = .{ .active = .search };
+    app.states.search.items = &items;
+    app.states.search.phase = .loaded;
+    var store: Storages = .{};
+    defer store.deinit(std.testing.allocator);
+    var fetches: Fetches = .initFill(null);
+    var frame: []u8 = try std.testing.allocator.alloc(u8, 256);
+    defer std.testing.allocator.free(frame);
+    var tm = term.Term.init(thr.io(), -1);
+
+    var c = step(std.testing.allocator, app.mt_path, &app, .enter); // Enter inspects the active hit
+    try std.testing.expect(c == .read);
+    try std.testing.expect(!app.editing);
+    std.testing.allocator.free(c.read.argv);
+    c.read.argv = try echoArgv(std.testing.allocator,
+        \\{"schema_version":1,"name":"wget","type":"formula","installed":false,"version":"1.21","tap":"homebrew/core","dependencies":[],"pinned":false,"installed_at":"","available_rollback_versions":[]}
+    );
+
+    try pump(thr.io(), std.testing.allocator, &tm, testPainter(&frame), &fetches, &app, &store, c);
+
+    try std.testing.expect(app.states.search.detail != null); // the pane opened within the cycle
+    try std.testing.expect(!anyFetchActive(&fetches)); // fast-path is synchronous, not a deferred fetch
 }
 
 test "a background outdated fetch parses a real child's document into the tab" {

--- a/src/tui/cmd.zig
+++ b/src/tui/cmd.zig
@@ -81,8 +81,6 @@ pub const Cmd = union(enum) {
     /// A self-classifying inline mutation (`mt …`). The interpreter drains the
     /// background-fetch pool before running it (the single-writer invariant).
     run_mutation: Mutation,
-    /// Independent passes run in order — upgrade's `--formula` then `--cask`.
-    batch: []const Cmd,
 
     /// How the interpreter drives a read: a non-blocking background child the
     /// loop drains, a blocking capture, or a blocking capture that ticks a
@@ -231,7 +229,7 @@ test "every tab parser is assignable through parserFor with no cast" {
     }
 }
 
-test "Cmd covers the read modes and the mutation/batch surface" {
+test "Cmd covers the read modes and the mutation surface" {
     const none: Cmd = .none;
     try testing.expect(none == .none);
 
@@ -264,15 +262,6 @@ test "Cmd covers the read modes and the mutation/batch surface" {
         .tag = .doctor,
     } };
     try testing.expectEqual(@as(u8, 2), fix.run_mutation.max_ok_exit);
-
-    // Upgrade's two-pass batch: one formula pass, one cask pass.
-    const passes = [_]Cmd{
-        .{ .run_mutation = .{ .argv = &.{ "mt", "upgrade", "--formula", "jq" }, .tag = .outdated } },
-        .{ .run_mutation = .{ .argv = &.{ "mt", "upgrade", "--cask", "docker" }, .tag = .outdated } },
-    };
-    const batch: Cmd = .{ .batch = &passes };
-    try testing.expectEqual(@as(usize, 2), batch.batch.len);
-    try testing.expect(batch.batch[0].run_mutation.tag == .outdated);
 }
 
 test "Msg delivers a loaded Parsed and a mutation exit code" {

--- a/src/tui/perform.zig
+++ b/src/tui/perform.zig
@@ -113,7 +113,7 @@ pub fn freeCmdArgv(allocator: std.mem.Allocator, c: cmd.Cmd) void {
     switch (c) {
         .read => |r| allocator.free(r.argv),
         .run_mutation => |m| allocator.free(m.argv),
-        .none, .batch => {},
+        .none => {},
     }
 }
 
@@ -211,11 +211,11 @@ pub fn foldOutcome(allocator: std.mem.Allocator, shared: *SharedModel, parse: cm
 
 /// Perform one synchronous `Cmd`, returning the `Msg` to fold back. A recoverable
 /// fault sets the banner from the `Cmd`'s `fail_op` and returns `.failed`/`.mutated`;
-/// only a fatal (terminal/OOM) fault propagates. `.none`/`.batch` never reach here,
-/// and a background `.read` is enqueued by the pump (`startBackground`) before this.
+/// only a fatal (terminal/OOM) fault propagates. `.none` never reaches here, and a
+/// background `.read` is enqueued by the pump (`startBackground`) before this.
 pub fn perform(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, shared: *SharedModel, loading: *bool, c: cmd.Cmd) RunError!cmd.Msg {
     switch (c) {
-        .none, .batch => unreachable, // the pump never performs these; no tab emits a batch
+        .none => unreachable, // the pump loops while `c != .none`, so it never performs it
         .read => |r| return performRead(io, allocator, painter, shared, loading, r),
         .run_mutation => |m| return performMutation(io, allocator, t, fetches, shared, m),
     }


### PR DESCRIPTION
## Description

The TUI run loop is already an explicit command/message pump - read a key, run the pure `update` to get a `Cmd`, perform it, fold the resulting `Msg` back, repaint - routed by the same comptime switch the render path uses, with the five per-tab performers and the flat dispatcher gone and every tab provably pure. That structure landed incrementally as `step` was reified to return a `Cmd` and the interpreter was generalized into one `perform(cmd)`; by the time those merged, the loop rewrite this task set out to do was already in place.

## Related Issue

- None

## Notes for Reviewers

- None