### PR TITLE
ci(bench): publish the shipped release and explain omitted cells

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,6 +20,10 @@ jobs:
       # silently publish fake timings.
       BENCH_TRUE_COLD: "1"
       BENCH_FAIL_FAST: "1"
+      # Bench malt's shipped release (highest release/N.M branch), not the dev
+      # tree, so the published table compares like-for-like with the peers'
+      # latest release tags. Local runs leave this unset and bench the tree.
+      BENCH_MALT_RELEASE: "1"
     steps:
       - uses: actions/checkout@v7
 
@@ -94,7 +98,7 @@ jobs:
           | **wget** (6 deps) | ${{ steps.wget.outputs.mt_cold_disp }} | ${{ steps.wget.outputs.nb_cold_disp }} | ${{ steps.wget.outputs.zb_cold_disp }} | ${{ steps.wget.outputs.brew_cold_disp }} |
           | **ffmpeg** (11 deps) | ${{ steps.ffmpeg.outputs.mt_cold_disp }} | ${{ steps.ffmpeg.outputs.nb_cold_disp }} | ${{ steps.ffmpeg.outputs.zb_cold_disp }} | ${{ steps.ffmpeg.outputs.brew_cold_disp }} |
 
-          **Benchmarked releases:** malt `${{ steps.tree.outputs.mt_ver }}`, nanobrew `${{ steps.tree.outputs.nb_ver }}`, zerobrew `${{ steps.tree.outputs.zb_ver }}` (peer tools pinned to their latest release tag).
+          **Benchmarked releases:** malt `${{ steps.tree.outputs.mt_ver }}`, nanobrew `${{ steps.tree.outputs.nb_ver }}`, zerobrew `${{ steps.tree.outputs.zb_ver }}` (malt pinned to its latest release branch; peer tools to their latest release tag).
 
           ### Warm Install
           | Package | malt | nanobrew | zerobrew |
@@ -135,8 +139,26 @@ jobs:
           | **tree** (0 deps) | ${{ steps.tree.outputs.mt_cold_disp }} | ${{ steps.tree.outputs.nb_cold_disp }} | ${{ steps.tree.outputs.zb_cold_disp }} | ${{ steps.tree.outputs.brew_cold_disp }} |
           | **wget** (6 deps) | ${{ steps.wget.outputs.mt_cold_disp }} | ${{ steps.wget.outputs.nb_cold_disp }} | ${{ steps.wget.outputs.zb_cold_disp }} | ${{ steps.wget.outputs.brew_cold_disp }} |
           | **ffmpeg** (11 deps) | ${{ steps.ffmpeg.outputs.mt_cold_disp }} | ${{ steps.ffmpeg.outputs.nb_cold_disp }} | ${{ steps.ffmpeg.outputs.zb_cold_disp }} | ${{ steps.ffmpeg.outputs.brew_cold_disp }} |
-          <!-- BENCH:COLD:END -->
           TABLE
+
+          # Explain any ⚠️ cell so a reader isn't left guessing why a number is
+          # missing. The marker is only ever emitted for a peer tool whose cold
+          # median blew past BENCH_MAX_COLD, so the legend is appended only when
+          # such a cell exists — and it lands inside the START/END block, so a
+          # later clean run drops it again.
+          if grep -q '⚠️' /tmp/cold_table.md; then
+            cat >> /tmp/cold_table.md << 'NOTE'
+
+          > ⚠️ = cell omitted. That tool's cold install exceeded the sanity
+          > ceiling (50 s), which reflects a regression in that tool rather than
+          > a comparable install time, so the number is withheld instead of
+          > published. malt is never omitted — a real malt slowdown stays visible.
+          NOTE
+          fi
+
+          cat >> /tmp/cold_table.md << 'END'
+          <!-- BENCH:COLD:END -->
+          END
 
           # Generate warm install table
           cat > /tmp/warm_table.md << TABLE

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -270,6 +270,26 @@ latest_release_tag() {
   git ls-remote --tags "$1" 'v*' 2>/dev/null | pick_latest_tag
 }
 
+# pick_latest_release_branch — read `git ls-remote --heads` lines (or bare ref
+# names) on stdin and print the highest `release/N.M...` branch name. malt
+# patch-releases from a per-minor branch (release/0.20, release/0.19, …), so
+# the highest one is the current release line. Version-sorts so release/0.20
+# wins over release/0.9. Pure/offline — unit-tested alongside pick_latest_tag.
+pick_latest_release_branch() {
+  sed 's|.*refs/heads/||' |
+    grep -E '^release/[0-9]+(\.[0-9]+)*$' |
+    sort -V |
+    tail -1
+}
+
+# latest_release_branch — highest `release/N.M` branch of this repo's origin,
+# malt's own "latest release" proxy (matching how peer tools resolve their
+# latest release tag). Empty on failure — caller falls back to the working tree.
+latest_release_branch() {
+  git -C "$REPO_ROOT" ls-remote --heads origin 'release/*' 2>/dev/null |
+    pick_latest_release_branch
+}
+
 # over_threshold <value> <threshold> — true (exit 0) only when value is a
 # finite number strictly greater than threshold. Non-numeric (FAIL/empty) or a
 # zero/empty threshold (guard disabled) is never "over". Float-safe via awk.
@@ -295,11 +315,35 @@ build_malt() {
     return
   fi
   need zig
+
+  # Source to build from. Default: the working tree, so a local run benches
+  # your actual change (the `no regression vs baseline` gate). CI sets
+  # BENCH_MALT_RELEASE=1 to bench the shipped release instead — the published
+  # table then compares malt's latest release branch against the peers' latest
+  # release tags (apples to apples). Build from a detached tree extracted with
+  # `git archive` (version comes from the tracked .version file, so no .git is
+  # needed) and fall back to the working tree if no release branch resolves.
+  local src="$REPO_ROOT"
+  if [ "${BENCH_MALT_RELEASE:-0}" = "1" ]; then
+    local branch
+    branch=$(latest_release_branch)
+    if [ -n "$branch" ]; then
+      src="$WORK_DIR/malt-src"
+      info "pinning malt to latest release branch $branch"
+      git -C "$REPO_ROOT" fetch --depth 1 origin "$branch"
+      rm -rf "$src"
+      mkdir -p "$src"
+      git -C "$REPO_ROOT" archive FETCH_HEAD | tar -x -C "$src"
+    else
+      warn "BENCH_MALT_RELEASE=1 but no release/* branch resolved — benching the working tree"
+    fi
+  fi
+
   info "build malt (ReleaseSafe) → $BENCH_BUILD_PREFIX"
   # Wipe the dedicated bench prefix so we never pick up a stale debug binary
   # left behind by `zig build` / `just build` / IDE builds in ./zig-out.
   rm -rf "$BENCH_BUILD_PREFIX"
-  (cd "$REPO_ROOT" && zig build -Doptimize=ReleaseSafe --prefix "$BENCH_BUILD_PREFIX")
+  (cd "$src" && zig build -Doptimize=ReleaseSafe --prefix "$BENCH_BUILD_PREFIX")
   if [ ! -x "$MALT_BIN" ]; then
     err "build did not produce $MALT_BIN"
   fi

--- a/scripts/test/bench_release_resolution_test.sh
+++ b/scripts/test/bench_release_resolution_test.sh
@@ -61,6 +61,22 @@ check "bare tag list" "v0.3.2" "$(printf 'v0.2.1\nv0.3.0\nv0.3.2\nv0.2.9\n' | pi
 check "empty input yields empty" "" "$(printf '' | pick_latest_tag)"
 check "no stable tags yields empty" "" "$(printf 'v1.0.0-rc1\nmain\n' | pick_latest_tag)"
 
+echo "pick_latest_release_branch:"
+# Real ls-remote --heads shape for the release/N.M branch line.
+heads=$(
+  cat <<'EOF'
+1111111111111111111111111111111111111111	refs/heads/main
+2222222222222222222222222222222222222222	refs/heads/release/0.9
+3333333333333333333333333333333333333333	refs/heads/release/0.19
+4444444444444444444444444444444444444444	refs/heads/release/0.20
+5555555555555555555555555555555555555555	refs/heads/feature/release-notes
+EOF
+)
+check "highest minor wins (0.20 > 0.19 > 0.9)" "release/0.20" "$(printf '%s\n' "$heads" | pick_latest_release_branch)"
+check "bare ref list" "release/0.20" "$(printf 'release/0.18\nrelease/0.20\nrelease/0.19\n' | pick_latest_release_branch)"
+check "empty input yields empty" "" "$(printf '' | pick_latest_release_branch)"
+check "non-release refs ignored" "" "$(printf 'main\nfeature/release/0.20\n' | pick_latest_release_branch)"
+
 echo "over_threshold:"
 check_pred "130.802 over 30 trips" 0 over_threshold "130.802" "30"
 check_pred "2.9 under 30 does not trip" 1 over_threshold "2.933" "30"


### PR DESCRIPTION
## Description

Makes the weekly benchmark compare like-for-like and self-explanatory:

- The published table now benchmarks malt's shipped release - the highest `release/N.M` branch (currently `release/0.20` -> `0.20.10`)  instead of the dev tree, matching how the peer tools are already pinned to their latest release tag. CI opts in via `BENCH_MALT_RELEASE=1`; local runs still bench the working tree so the no-regression gate keeps measuring your change.
- When a peer tool's cold cell is withheld (`⚠️ n/a`), the README now carries a short legend explaining why the number was omitted, rendered only when such a cell exists and kept inside the `BENCH:COLD` markers so a later clean run drops it again.

## Related Issue

- None

## Notes for Reviewers

- None