### PR TITLE
refactor(install): move flag parse + validation into the args leaf

### DIFF
--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -386,42 +386,6 @@ const ExecuteOpts = struct {
     sink: OutputSink = sink_mod.terminal,
 };
 
-const InstallFlag = enum {
-    cask,
-    formula,
-    dry_run,
-    force,
-    local,
-    use_system_ruby,
-    quiet,
-    json,
-    only_deps,
-    download_only,
-    isolate_deps,
-};
-
-const install_flag_map = std.StaticStringMap(InstallFlag).initComptime(.{
-    .{ "--cask", .cask },
-    .{ "--formula", .formula },
-    .{ "--dry-run", .dry_run },
-    .{ "--force", .force },
-    .{ "--local", .local },
-    .{ "--use-system-ruby", .use_system_ruby },
-    .{ "--quiet", .quiet },
-    .{ "-q", .quiet },
-    .{ "--json", .json },
-    .{ "--only-deps", .only_deps },
-    // brew-parity alias — `--only-dependencies` is what `brew install`
-    // accepts, so muscle memory keeps working alongside the canonical
-    // `--only-deps` spelling that mirrors `--isolate-deps`.
-    .{ "--only-dependencies", .only_deps },
-    .{ "--download-only", .download_only },
-    .{ "--isolate-deps", .isolate_deps },
-    // Long-form alias — mirrors the `--only-deps` / `--only-dependencies`
-    // pair so the flag surface stays predictable.
-    .{ "--isolate-dependencies", .isolate_deps },
-});
-
 /// `allocator` must be an arena (see `installAll`).
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
     return executeWithOpts(ctx, allocator, args, .{});
@@ -438,137 +402,52 @@ fn executeWithOpts(
     // Single emission seam for this run; default forwards to `ui/output`.
     const sink = exec_opts.sink;
 
-    // Parse flags
-    var packages: std.ArrayList([]const u8) = .empty;
-    defer packages.deinit(allocator);
-    var force_cask = false;
-    var force_formula = false;
-    // Honour the global `--dry-run` flag consumed by main.zig, while still
-    // allowing programmatic callers to pass `--dry-run` directly in `args`.
-    var dry_run = output.isDryRun();
-    var force = false;
-    // Scoped `--use-system-ruby` — a bare flag with multiple formulas would
-    // let a DSL parse failure on one silently widen Ruby trust across the rest.
-    var use_system_ruby_bare = false;
-    var use_system_ruby_scope: std.ArrayList([]const u8) = .empty;
-    defer use_system_ruby_scope.deinit(allocator);
-    // `--local` forces .rb-path interpretation — explicit trust opt-in in
-    // argv instead of shape-based autodetection.
-    var local_only = false;
-    // brew parity: resolve the dep graph, bail before the requested package's
-    // materialise+link. Deps stay marked `dependency` for `mt purge --unused-deps`.
-    var only_deps = false;
-    // Warm the bottle store; skip materialise/link/record. Refcount stays
-    // at 0 so warmed entries are invisible to `purge --store-orphans`
-    // until a follow-up install picks them up.
-    var download_only = false;
-    // Per-pass user intent: every dep keg materialised during this run
-    // gets `bin_isolated=1`. Direct kegs (the names the user asked for)
-    // are unaffected so they still land in PATH.
-    var isolate_deps = false;
-
-    // StaticStringMap + exhaustive switch: the compiler checks every flag
-    // has a handler, so adding a new variant without wiring it fails to build.
-    for (args) |arg| {
-        if (std.mem.startsWith(u8, arg, "--use-system-ruby=")) {
-            const list = arg["--use-system-ruby=".len..];
-            var it = std.mem.splitScalar(u8, list, ',');
-            while (it.next()) |name| {
-                if (name.len > 0) try use_system_ruby_scope.append(allocator, name);
+    // Parse + validate argv in the leaf: the rules live there, the words
+    // stay caller-owned (the `checkPrefixSane` precedent). Each refusal maps
+    // to its verbatim sink line + return code below. A scoped arena backs the
+    // parsed package/scope slices so every return path reclaims them even when
+    // the caller's allocator isn't itself an arena.
+    var parse_arena = std.heap.ArenaAllocator.init(allocator);
+    defer parse_arena.deinit();
+    const parsed = switch (try args_mod.parse(parse_arena.allocator(), args)) {
+        .ok => |p| p,
+        .invalid => |v| {
+            switch (v.err) {
+                .local_requires_path => sink.err("--local requires a path to a .rb file", .{}),
+                .local_with_cask => sink.err("--local cannot be combined with --cask (a .rb file is never a cask)", .{}),
+                .local_with_formula => sink.err("--local already selects formula mode; drop --formula", .{}),
+                .local_with_system_ruby => sink.err("--local does not run post_install; --use-system-ruby has no effect and is refused", .{}),
+                .download_only_with_only_deps => sink.err("--download-only cannot be combined with --only-deps", .{}),
+                .no_packages => sink.err("No package names specified", .{}),
+                .self_install => sink.err("Refusing to install malt itself ('{s}'). Use 'mt version update' to upgrade.", .{v.arg}),
+                .ambiguous_system_ruby_scope => sink.err(
+                    "--use-system-ruby needs a scope when multiple packages are installed; use --use-system-ruby={s}[,<name>...]",
+                    .{v.arg},
+                ),
             }
-            continue;
-        }
-        if (install_flag_map.get(arg)) |flag| switch (flag) {
-            .cask => force_cask = true,
-            .formula => force_formula = true,
-            .dry_run => dry_run = true,
-            .force => force = true,
-            .local => local_only = true,
-            .use_system_ruby => use_system_ruby_bare = true,
-            .quiet => output.setQuiet(true),
-            .json => output.setMode(.json),
-            .only_deps => only_deps = true,
-            .download_only => download_only = true,
-            .isolate_deps => isolate_deps = true,
-        } else if (!std.mem.startsWith(u8, arg, "-")) {
-            packages.append(allocator, arg) catch return error.OutOfMemory;
-        }
-    }
-
-    if (local_only and packages.items.len == 0) {
-        // `error.Aborted` per the main.zig contract — avoids a raw stack trace.
-        sink.err("--local requires a path to a .rb file", .{});
-        return error.Aborted;
-    }
-
-    // Refuse ambiguous argv so `--local` cannot silently drop another mode.
-    if (local_only) {
-        if (force_cask) {
-            sink.err("--local cannot be combined with --cask (a .rb file is never a cask)", .{});
-            return error.Aborted;
-        }
-        if (force_formula) {
-            sink.err("--local already selects formula mode; drop --formula", .{});
-            return error.Aborted;
-        }
-        if (use_system_ruby_bare or use_system_ruby_scope.items.len > 0) {
-            sink.err("--local does not run post_install; --use-system-ruby has no effect and is refused", .{});
-            return error.Aborted;
-        }
-    }
-
-    // The two flags pull in opposite directions: --only-deps skips the
-    // requested package, --download-only skips materialise+link entirely.
-    // Document the refusal up front rather than silently picking a winner.
-    if (download_only and only_deps) {
-        sink.err("--download-only cannot be combined with --only-deps", .{});
-        return error.Aborted;
-    }
-
-    if (packages.items.len == 0) {
-        sink.err("No package names specified", .{});
-        return InstallError.NoPackages;
-    }
-
-    // Refuse self-install in every shape the dispatcher accepts.
-    // `mt version update` is the supported upgrade channel; letting
-    // install proceed would relink `<prefix>/bin/malt` outside its
-    // rev/origin tracking.
-    for (packages.items) |pkg| {
-        if (isSelfInstall(pkg)) {
-            sink.err("Refusing to install malt itself ('{s}'). Use 'mt version update' to upgrade.", .{pkg});
-            return error.Aborted;
-        }
-    }
-
-    // Bare `--use-system-ruby` only valid for a single formula; otherwise
-    // require an explicit scope.
-    if (use_system_ruby_bare) {
-        if (packages.items.len == 1) {
-            try use_system_ruby_scope.append(allocator, packages.items[0]);
-        } else {
-            sink.err(
-                "--use-system-ruby needs a scope when multiple packages are installed; use --use-system-ruby={s}[,<name>...]",
-                .{packages.items[0]},
-            );
-            return InstallError.AmbiguousSystemRubyScope;
-        }
-    }
-    const use_system_ruby_list: []const []const u8 = use_system_ruby_scope.items;
-
-    // Snapshot the parsed modes as one typed value object; every read site
-    // below names intent off `flags` instead of threading loose bools.
-    const flags: args_mod.InstallFlags = .{
-        .force_cask = force_cask,
-        .force_formula = force_formula,
-        .dry_run = dry_run,
-        .force = force,
-        .local_only = local_only,
-        .only_deps = only_deps,
-        .download_only = download_only,
-        .isolate_deps = isolate_deps,
-        .system_ruby = use_system_ruby_list,
+            return switch (v.err) {
+                .no_packages => InstallError.NoPackages,
+                .ambiguous_system_ruby_scope => InstallError.AmbiguousSystemRubyScope,
+                // `error.Aborted` per the main.zig contract — avoids a raw stack trace.
+                .local_requires_path,
+                .local_with_cask,
+                .local_with_formula,
+                .local_with_system_ruby,
+                .download_only_with_only_deps,
+                .self_install,
+                => error.Aborted,
+            };
+        },
     };
+
+    // Global side effects the UI-agnostic leaf can't apply: `--quiet` / `--json`
+    // are surfaced by `parse` and applied once here; the global `--dry-run`
+    // (consumed by main.zig) ORs with the parsed flag.
+    if (parsed.quiet) output.setQuiet(true);
+    if (parsed.json) output.setMode(.json);
+    const packages = parsed.packages;
+    var flags = parsed.flags;
+    flags.dry_run = flags.dry_run or output.isDryRun();
 
     // Initialize infrastructure
     const prefix = atomic.maltPrefixOrAbort();
@@ -592,7 +471,7 @@ fn executeWithOpts(
     // on multi-arg keeps the gate state-free.
     const fastpath_eligible = flags.fastpathEligible();
     if (fastpath_eligible) fast: {
-        for (packages.items) |pkg| {
+        for (packages) |pkg| {
             if (isTapFormula(pkg) or isLocalFormulaPath(pkg)) break :fast;
             if (!kegPresent(ctx, prefix, pkg)) break :fast;
         }
@@ -601,8 +480,8 @@ fn executeWithOpts(
         // bin/sbin symlinks materialised. That work fails open the DB
         // and the lock, so it lives in the slow path; here we just
         // gate the early return.
-        if (anyNamedNeedsPromotion(ctx, prefix, packages.items)) break :fast;
-        for (packages.items) |pkg| {
+        if (anyNamedNeedsPromotion(ctx, prefix, packages)) break :fast;
+        for (packages) |pkg| {
             sink.info("{s} is already installed", .{pkg});
             // Fast-path skips the protocol; positive signal so consumers
             // can tell idempotent success from "command never ran".
@@ -694,7 +573,7 @@ fn executeWithOpts(
     // Done before resolution so the subsequent flow sees the post-
     // promotion state ("direct + present") and `collectFormulaJobs`
     // correctly short-circuits without re-downloading the keg.
-    for (packages.items) |pkg_name| {
+    for (packages) |pkg_name| {
         if (promoteIsolatedDepIfAny(&db, &linker, pkg_name)) {
             sink.success("{s} promoted to direct: bin/sbin links restored", .{pkg_name});
         }
@@ -718,7 +597,7 @@ fn executeWithOpts(
         return;
     }
 
-    for (packages.items) |pkg_name| {
+    for (packages) |pkg_name| {
         // Check for Ctrl-C between packages during resolution
         if (signals.isInterrupted()) {
             sink.warn("Interrupted during resolution.", .{});

--- a/src/cli/install/args.zig
+++ b/src/cli/install/args.zig
@@ -1,6 +1,7 @@
-//! Pure argv + path helpers used by `cli/install.zig`. Every function
-//! here is allocation-free and filesystem-free so tests can call them
-//! without fixtures.
+//! Pure argv + path helpers used by `cli/install.zig`. The path/predicate
+//! helpers are allocation-free and filesystem-free so tests can call them
+//! without fixtures; `parse` is the one exception — it takes the caller's
+//! arena to build the package list and split the `--use-system-ruby=` scope.
 
 const std = @import("std");
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
@@ -211,6 +212,153 @@ pub const InstallFlags = struct {
     }
 };
 
+/// One variant per argv refusal. Data, not words: the orchestrator maps
+/// each to its user-facing `sink.err` line and return code, so the leaf
+/// stays UI-agnostic (the `checkPrefixSane` precedent).
+pub const ParseError = enum {
+    local_requires_path,
+    local_with_cask,
+    local_with_formula,
+    local_with_system_ruby,
+    download_only_with_only_deps,
+    no_packages,
+    self_install,
+    ambiguous_system_ruby_scope,
+};
+
+/// The validated argv: resolved flags plus the package list. `quiet` /
+/// `json` are surfaced (not applied) because touching `output` would break
+/// the leaf boundary; `dry_run` here reflects only `--dry-run` in `args`,
+/// leaving the global `output.isDryRun()` OR to the caller.
+pub const Parsed = struct {
+    flags: InstallFlags,
+    packages: []const []const u8,
+    quiet: bool,
+    json: bool,
+};
+
+pub const ParseResult = union(enum) {
+    ok: Parsed,
+    /// `arg` borrows into `args` — the offending package for `self_install`,
+    /// the first package for `ambiguous_system_ruby_scope`.
+    invalid: struct { err: ParseError, arg: []const u8 = "" },
+};
+
+const InstallFlag = enum {
+    cask,
+    formula,
+    dry_run,
+    force,
+    local,
+    use_system_ruby,
+    quiet,
+    json,
+    only_deps,
+    download_only,
+    isolate_deps,
+};
+
+const install_flag_map = std.StaticStringMap(InstallFlag).initComptime(.{
+    .{ "--cask", .cask },
+    .{ "--formula", .formula },
+    .{ "--dry-run", .dry_run },
+    .{ "--force", .force },
+    .{ "--local", .local },
+    .{ "--use-system-ruby", .use_system_ruby },
+    .{ "--quiet", .quiet },
+    .{ "-q", .quiet },
+    .{ "--json", .json },
+    .{ "--only-deps", .only_deps },
+    // brew-parity alias — `--only-dependencies` is what `brew install`
+    // accepts, so muscle memory keeps working alongside the canonical
+    // `--only-deps` spelling that mirrors `--isolate-deps`.
+    .{ "--only-dependencies", .only_deps },
+    .{ "--download-only", .download_only },
+    .{ "--isolate-deps", .isolate_deps },
+    // Long-form alias — mirrors the `--only-deps` / `--only-dependencies`
+    // pair so the flag surface stays predictable.
+    .{ "--isolate-dependencies", .isolate_deps },
+});
+
+/// Scan + validate the install argv in one place. Returns validated data or
+/// a tagged refusal — never a message. `arena` builds the package list and
+/// the split `--use-system-ruby=` scope; the caller owns it (the `installAll`
+/// contract already threads a run arena).
+pub fn parse(arena: std.mem.Allocator, args: []const []const u8) error{OutOfMemory}!ParseResult {
+    var packages: std.ArrayList([]const u8) = .empty;
+    var system_ruby: std.ArrayList([]const u8) = .empty;
+    var flags: InstallFlags = .{};
+    var quiet = false;
+    var json = false;
+    // A bare `--use-system-ruby` across multiple formulas would let one DSL
+    // parse failure silently widen Ruby trust; resolved or rejected below.
+    var use_system_ruby_bare = false;
+
+    // StaticStringMap + exhaustive switch: the compiler checks every flag has
+    // a handler, so adding a variant without wiring it fails to build.
+    for (args) |arg| {
+        if (std.mem.startsWith(u8, arg, "--use-system-ruby=")) {
+            const list = arg["--use-system-ruby=".len..];
+            var it = std.mem.splitScalar(u8, list, ',');
+            while (it.next()) |name| {
+                if (name.len > 0) try system_ruby.append(arena, name);
+            }
+            continue;
+        }
+        if (install_flag_map.get(arg)) |flag| switch (flag) {
+            .cask => flags.force_cask = true,
+            .formula => flags.force_formula = true,
+            .dry_run => flags.dry_run = true,
+            .force => flags.force = true,
+            .local => flags.local_only = true,
+            .use_system_ruby => use_system_ruby_bare = true,
+            .quiet => quiet = true,
+            .json => json = true,
+            .only_deps => flags.only_deps = true,
+            .download_only => flags.download_only = true,
+            .isolate_deps => flags.isolate_deps = true,
+        } else if (!std.mem.startsWith(u8, arg, "-")) {
+            try packages.append(arena, arg);
+        }
+    }
+
+    if (flags.local_only and packages.items.len == 0) {
+        return .{ .invalid = .{ .err = .local_requires_path } };
+    }
+    // Refuse ambiguous argv so `--local` cannot silently drop another mode.
+    if (flags.local_only) {
+        if (flags.force_cask) return .{ .invalid = .{ .err = .local_with_cask } };
+        if (flags.force_formula) return .{ .invalid = .{ .err = .local_with_formula } };
+        if (use_system_ruby_bare or system_ruby.items.len > 0) {
+            return .{ .invalid = .{ .err = .local_with_system_ruby } };
+        }
+    }
+    // --only-deps skips the requested package, --download-only skips
+    // materialise+link entirely; refuse rather than pick a winner.
+    if (flags.download_only and flags.only_deps) {
+        return .{ .invalid = .{ .err = .download_only_with_only_deps } };
+    }
+    if (packages.items.len == 0) {
+        return .{ .invalid = .{ .err = .no_packages } };
+    }
+    // Refuse self-install in every shape the dispatcher accepts; `mt version
+    // update` is the supported upgrade channel.
+    for (packages.items) |pkg| {
+        if (isSelfInstall(pkg)) return .{ .invalid = .{ .err = .self_install, .arg = pkg } };
+    }
+    // Bare `--use-system-ruby` is only valid for a single formula.
+    if (use_system_ruby_bare) {
+        if (packages.items.len == 1) {
+            try system_ruby.append(arena, packages.items[0]);
+        } else {
+            return .{ .invalid = .{ .err = .ambiguous_system_ruby_scope, .arg = packages.items[0] } };
+        }
+    }
+
+    flags.system_ruby = system_ruby.items;
+    return .{ .ok = .{ .flags = flags, .packages = packages.items, .quiet = quiet, .json = json } };
+}
+
 test "InstallFlags.fastpathEligible: clear when no semantic flag is set" {
     try std.testing.expect((InstallFlags{}).fastpathEligible());
 }
@@ -251,6 +399,170 @@ test "InstallFlags.isolatesDep: gated on isolate_deps AND is_dep" {
     try std.testing.expect(!(InstallFlags{ .isolate_deps = true }).isolatesDep(false));
     try std.testing.expect(!(InstallFlags{}).isolatesDep(true));
     try std.testing.expect(!(InstallFlags{}).isolatesDep(false));
+}
+
+fn expectInvalid(res: ParseResult, want: ParseError) !void {
+    switch (res) {
+        .ok => return error.TestUnexpectedResult,
+        .invalid => |v| try std.testing.expectEqual(want, v.err),
+    }
+}
+
+test "parse: a bare package name yields ok with default flags" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const res = try parse(arena.allocator(), &.{"wget"});
+    switch (res) {
+        .invalid => return error.TestUnexpectedResult,
+        .ok => |p| {
+            try std.testing.expectEqual(@as(usize, 1), p.packages.len);
+            try std.testing.expectEqualStrings("wget", p.packages[0]);
+            try std.testing.expectEqual(InstallFlags{}, p.flags);
+        },
+    }
+}
+
+test "parse: --local without a path is refused (a .rb path is required)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    try expectInvalid(try parse(arena.allocator(), &.{"--local"}), .local_requires_path);
+}
+
+test "parse: --local + --cask is refused (a .rb file is never a cask)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    try expectInvalid(try parse(arena.allocator(), &.{ "--local", "--cask", "./x.rb" }), .local_with_cask);
+}
+
+test "parse: --local + --formula is refused (--local already selects formula)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    try expectInvalid(try parse(arena.allocator(), &.{ "--local", "--formula", "./x.rb" }), .local_with_formula);
+}
+
+test "parse: --local + --use-system-ruby is refused (local runs no post_install)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    try expectInvalid(try parse(arena.allocator(), &.{ "--local", "--use-system-ruby", "./x.rb" }), .local_with_system_ruby);
+}
+
+test "parse: --download-only + --only-deps is refused (they pull opposite ways)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    try expectInvalid(try parse(arena.allocator(), &.{ "wget", "--download-only", "--only-deps" }), .download_only_with_only_deps);
+}
+
+test "parse: an empty package list is refused" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    try expectInvalid(try parse(arena.allocator(), &.{"--force"}), .no_packages);
+}
+
+test "parse: self-install is refused and carries the offending arg" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const res = try parse(arena.allocator(), &.{"malt"});
+    switch (res) {
+        .ok => return error.TestUnexpectedResult,
+        .invalid => |v| {
+            try std.testing.expectEqual(ParseError.self_install, v.err);
+            try std.testing.expectEqualStrings("malt", v.arg);
+        },
+    }
+}
+
+test "parse: bare --use-system-ruby with multiple packages needs a scope" {
+    // A bare flag across many formulas would let one DSL parse failure
+    // silently widen Ruby trust across the rest — refuse and name the
+    // first package so the caller can suggest the scoped form.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const res = try parse(arena.allocator(), &.{ "--use-system-ruby", "wget", "jq" });
+    switch (res) {
+        .ok => return error.TestUnexpectedResult,
+        .invalid => |v| {
+            try std.testing.expectEqual(ParseError.ambiguous_system_ruby_scope, v.err);
+            try std.testing.expectEqualStrings("wget", v.arg);
+        },
+    }
+}
+
+test "parse: bare --use-system-ruby folds into scope for a single formula" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const res = try parse(arena.allocator(), &.{ "--use-system-ruby", "wget" });
+    switch (res) {
+        .invalid => return error.TestUnexpectedResult,
+        .ok => |p| {
+            try std.testing.expectEqual(@as(usize, 1), p.flags.system_ruby.len);
+            try std.testing.expectEqualStrings("wget", p.flags.system_ruby[0]);
+        },
+    }
+}
+
+test "parse: --use-system-ruby=<scope> splits the comma list into system_ruby" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const res = try parse(arena.allocator(), &.{ "--use-system-ruby=wget,jq", "wget", "jq" });
+    switch (res) {
+        .invalid => return error.TestUnexpectedResult,
+        .ok => |p| {
+            try std.testing.expectEqual(@as(usize, 2), p.flags.system_ruby.len);
+            try std.testing.expectEqualStrings("wget", p.flags.system_ruby[0]);
+            try std.testing.expectEqualStrings("jq", p.flags.system_ruby[1]);
+        },
+    }
+}
+
+test "parse: dry_run reflects only --dry-run, never the global (leaf purity)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const with = try parse(arena.allocator(), &.{ "--dry-run", "wget" });
+    switch (with) {
+        .invalid => return error.TestUnexpectedResult,
+        .ok => |p| try std.testing.expect(p.flags.dry_run),
+    }
+    // A bare invocation must leave dry_run false even if the process global
+    // is on — the OR happens in the caller, not the leaf.
+    const without = try parse(arena.allocator(), &.{"wget"});
+    switch (without) {
+        .invalid => return error.TestUnexpectedResult,
+        .ok => |p| try std.testing.expect(!p.flags.dry_run),
+    }
+}
+
+test "parse: --quiet / --json are surfaced on the result, not applied" {
+    // The leaf must not call output.setQuiet/setMode; it reports intent and
+    // the orchestrator applies it once, post-parse.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const res = try parse(arena.allocator(), &.{ "--quiet", "--json", "wget" });
+    switch (res) {
+        .invalid => return error.TestUnexpectedResult,
+        .ok => |p| {
+            try std.testing.expect(p.quiet);
+            try std.testing.expect(p.json);
+        },
+    }
+}
+
+test "parse: brew-parity aliases resolve to the same flags as their canonical spelling" {
+    // The relocated flag map must keep the long-form + `-q` aliases. A typo in
+    // the move would silently route `--only-dependencies` into the package list
+    // instead of setting only_deps — this guards the whole moved map.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const res = try parse(arena.allocator(), &.{ "-q", "--only-dependencies", "--isolate-dependencies", "wget" });
+    switch (res) {
+        .invalid => return error.TestUnexpectedResult,
+        .ok => |p| {
+            try std.testing.expect(p.quiet);
+            try std.testing.expect(p.flags.only_deps);
+            try std.testing.expect(p.flags.isolate_deps);
+            try std.testing.expectEqual(@as(usize, 1), p.packages.len);
+            try std.testing.expectEqualStrings("wget", p.packages[0]);
+        },
+    }
 }
 
 test "isCoreTap recognises homebrew/core and homebrew/cask" {


### PR DESCRIPTION
## Description

Flag parsing and the six validation refusals move out of the install orchestrator into a single `parse` function in the args leaf. It returns validated data and a tagged error -never a message -and the orchestrator maps that error to the same user-facing strings and the same exit codes as before, so the leaf stays UI-agnostic and the contract tests are untouched. The payoff: "which flag combinations are legal" is now a small, pure, unit-tested function instead of logic smeared across the orchestrator behind DB/lock/HTTP setup. `dry_run`'s global source and the `quiet`/`json` side-effects stay in the caller; only the rules move.

`parse` takes the caller's arena to build the package list and split the `--use-system-ruby=` scope; the orchestrator wraps it in a scoped arena so every return path reclaims those allocations even when the caller's allocator isn't itself an arena (preserving the prior leak-free refusal paths). The `args.zig` header's blanket "every function is allocation-free" claim is narrowed to exempt `parse`. No public signature changed (`execute`, `installAll`, `install/local.zig`).

## Related Issue

- None

## Notes for Reviewers

- None