### PR TITLE
fix(linker): link nested keg subdirectories into the prefix

### DIFF
--- a/scripts/regressions/keg-linker-links-nested-subdirs.sh
+++ b/scripts/regressions/keg-linker-links-nested-subdirs.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Regression: the keg linker iterated only the top level of each linkable
+# dir and dropped every directory entry, so nested keg content —
+# lib/pkgconfig/*.pc, share/tessdata/*, share/man/man1/* — was never
+# symlinked into the prefix. The keg was intact; the prefix links were
+# absent, so pkg-config/tesseract could not find their data.
+#
+# This script seeds a synthetic keg with both depth-1 (bin/fixture) and
+# nested (share/tessdata, lib/pkgconfig) content, registers it with a
+# kegs row, then runs `malt link`. After the fix every leaf — nested
+# included — must resolve under the prefix.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when
+# present. No network required; finishes well under 30s once built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null || {
+  echo "sqlite3 required" >&2
+  exit 2
+}
+
+PREFIX="$(mktemp -d)/malt-prefix"
+export MALT_PREFIX="$PREFIX"
+trap 'rm -rf "$(dirname "$PREFIX")"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+DB="$PREFIX/db/malt.db"
+mkdir -p "$PREFIX/db"
+
+# Init the schema with a benign command against the empty DB file.
+: >"$DB"
+"$BIN" link __absent__ >/dev/null 2>&1 || true
+sqlite3 "$DB" "SELECT 1 FROM kegs LIMIT 1;" >/dev/null 2>&1 ||
+  fail "schema init did not create the kegs table"
+
+# Synthetic keg: one depth-1 leaf plus nested leaves under several linkable
+# dirs, including two sibling subdirs under share/ (tessdata and man) so a
+# sibling-skipping walk is caught too.
+KEG="$PREFIX/Cellar/fixture/1.0"
+mkdir -p "$KEG/bin" "$KEG/share/tessdata" "$KEG/share/man/man1" "$KEG/lib/pkgconfig"
+printf '#!/bin/sh\n' >"$KEG/bin/fixture"
+chmod +x "$KEG/bin/fixture"
+echo data >"$KEG/share/tessdata/eng.traineddata"
+echo '.TH FIXTURE 1' >"$KEG/share/man/man1/fixture.1"
+echo 'Name: fixture' >"$KEG/lib/pkgconfig/fixture.pc"
+
+sqlite3 "$DB" \
+  "INSERT INTO kegs(name,full_name,version,store_sha256,cellar_path) \
+   VALUES('fixture','fixture','1.0','sha','$KEG');"
+
+"$BIN" link fixture >/dev/null 2>&1 || fail "malt link errored"
+
+[[ -e "$PREFIX/bin/fixture" ]] ||
+  fail "depth-1 bin/fixture not linked"
+pass "depth-1 bin/fixture linked"
+[[ -e "$PREFIX/share/tessdata/eng.traineddata" ]] ||
+  fail "nested share/tessdata/eng.traineddata not linked"
+pass "nested share/tessdata linked"
+[[ -e "$PREFIX/share/man/man1/fixture.1" ]] ||
+  fail "sibling nested share/man/man1/fixture.1 not linked"
+pass "sibling nested share/man linked"
+[[ -e "$PREFIX/lib/pkgconfig/fixture.pc" ]] ||
+  fail "nested lib/pkgconfig/fixture.pc not linked"
+pass "nested lib/pkgconfig linked"
+
+# The recorded link_path must be the full nested path so unlink removes it.
+sqlite3 "$DB" "SELECT link_path FROM links;" | grep -q "share/tessdata/eng.traineddata" ||
+  fail "nested leaf missing a links row"
+pass "nested leaf recorded in links table"
+
+printf '\n✔ keg-linker nested-subdir regression passed\n'

--- a/src/core/linker.zig
+++ b/src/core/linker.zig
@@ -269,12 +269,27 @@ pub const Linker = struct {
             const path_slice = std.mem.sliceTo(link_path, 0);
             // Symlink may already be gone from the filesystem; DB row is the source of truth we're flushing.
             std.Io.Dir.cwd().deleteFile(self.io, path_slice) catch {};
+            // Prune the nested dirs `link` created (share/man/man1, …) so
+            // they don't linger once emptied.
+            self.pruneEmptyParents(path_slice);
         }
 
         var del_stmt = try self.db.prepare("DELETE FROM links WHERE keg_id = ?1;");
         defer del_stmt.finalize();
         try del_stmt.bindInt(1, keg_id);
         _ = try del_stmt.step();
+    }
+
+    /// Remove now-empty ancestor dirs of `link_path`, climbing until the
+    /// first non-empty dir or the prefix root. `deleteDirAbsolute` only
+    /// succeeds on an empty dir, so a dir another keg still links into
+    /// survives; the prefix itself is never touched.
+    fn pruneEmptyParents(self: *Linker, link_path: []const u8) void {
+        var dir = std.fs.path.dirname(link_path) orelse return;
+        while (dir.len > self.prefix.len and std.mem.startsWith(u8, dir, self.prefix)) {
+            std.Io.Dir.deleteDirAbsolute(self.io, dir) catch return;
+            dir = std.fs.path.dirname(dir) orelse return;
+        }
     }
 };
 

--- a/src/core/linker.zig
+++ b/src/core/linker.zig
@@ -17,10 +17,11 @@ pub const Linker = struct {
     db: *sqlite.Database,
     prefix: []const u8,
 
-    /// Keg subdirectories whose top-level files get symlinked into the
-    /// prefix. `bin`/`sbin` lead so the bin-isolated variant is a tail
-    /// slice (`[2..]`). The install path also reads this to decide whether
-    /// an extracted archive produced anything linkable at all — keep that
+    /// Keg subdirectories whose contents get symlinked into the prefix,
+    /// recursing into nested subdirs (lib/pkgconfig, share/man, …).
+    /// `bin`/`sbin` lead so the bin-isolated variant is a tail slice
+    /// (`[2..]`). The install path also reads this to decide whether an
+    /// extracted archive produced anything linkable at all — keep that
     /// check and `link` reading the same list so they cannot drift.
     pub const linkable_dirs = [_][]const u8{ "bin", "sbin", "lib", "include", "share", "etc" };
 
@@ -39,11 +40,15 @@ pub const Linker = struct {
         var conflicts: std.ArrayList(Conflict) = .empty;
 
         for (dirs_to_check) |subdir| {
-            var keg_dir_buf: [512]u8 = undefined;
-            const keg_subdir = std.fmt.bufPrint(&keg_dir_buf, "{s}/{s}", .{ keg_path, subdir }) catch continue;
-
-            var dir = std.Io.Dir.openDirAbsolute(self.io, keg_subdir, .{ .iterate = true }) catch continue;
-            defer dir.close(self.io);
+            // Collect nested leaves first (share/man/man1/*, lib/pkgconfig/*),
+            // then probe each — keep this in step with linkSubdir's walk.
+            var leaves: std.ArrayList([]u8) = .empty;
+            defer {
+                for (leaves.items) |p| self.allocator.free(p);
+                leaves.deinit(self.allocator);
+            }
+            self.collectLeafPaths(keg_path, subdir, &leaves);
+            if (leaves.items.len == 0) continue;
 
             var prefix_dir_buf: [512]u8 = undefined;
             const prefix_subdir = std.fmt.bufPrint(&prefix_dir_buf, "{s}/{s}", .{ self.prefix, subdir }) catch continue;
@@ -51,22 +56,20 @@ pub const Linker = struct {
             var prefix_dir = std.Io.Dir.openDirAbsolute(self.io, prefix_subdir, .{}) catch continue;
             defer prefix_dir.close(self.io);
 
-            var iter = dir.iterate();
-            while (iter.next(self.io) catch null) |entry| {
-                if (entry.kind == .directory) continue;
-
+            for (leaves.items) |rel| {
                 // Check if a symlink already exists at the target location.
                 // 1 KiB fits every path malt produces under its prefix — the
                 // previous `max_path_bytes` (~4 KiB) was stack-wasteful when
-                // scanning kegs with many files.
+                // scanning kegs with many files. `rel` is the full nested
+                // path relative to the linkable dir.
                 var link_target_buf: [1024]u8 = undefined;
-                const link_target_len = prefix_dir.readLink(self.io, entry.name, &link_target_buf) catch continue;
+                const link_target_len = prefix_dir.readLink(self.io, rel, &link_target_buf) catch continue;
                 const link_target = link_target_buf[0..link_target_len];
 
                 // If the existing symlink points into a different keg, it's a conflict
                 if (!std.mem.startsWith(u8, link_target, keg_path)) {
                     var link_path_buf: [512]u8 = undefined;
-                    const link_path = std.fmt.bufPrint(&link_path_buf, "{s}/{s}/{s}", .{ self.prefix, subdir, entry.name }) catch continue;
+                    const link_path = std.fmt.bufPrint(&link_path_buf, "{s}/{s}/{s}", .{ self.prefix, subdir, rel }) catch continue;
 
                     // Extract the existing keg path from the symlink target
                     // Targets look like: /opt/malt/Cellar/<name>/<ver>/bin/<file>
@@ -81,6 +84,51 @@ pub const Linker = struct {
         }
 
         return conflicts.toOwnedSlice(self.allocator) catch return &.{};
+    }
+
+    /// Collect the relative paths of every leaf (file or symlink) under
+    /// `keg_path/subdir`, recursing into nested dirs. Read-only BFS: the
+    /// caller mutates the prefix afterward. Shared by `link` and
+    /// `checkConflicts` so both act on the same leaf set and cannot drift.
+    /// Caller owns and frees the returned paths.
+    fn collectLeafPaths(self: *Linker, keg_path: []const u8, subdir: []const u8, out: *std.ArrayList([]u8)) void {
+        var base_buf: [512]u8 = undefined;
+        const base = std.fmt.bufPrint(&base_buf, "{s}/{s}", .{ keg_path, subdir }) catch return;
+
+        // BFS: `pending` holds dir paths relative to `base`; "" is the root.
+        var pending: std.ArrayList([]u8) = .empty;
+        defer {
+            for (pending.items) |p| self.allocator.free(p);
+            pending.deinit(self.allocator);
+        }
+        pending.append(self.allocator, self.allocator.dupe(u8, "") catch return) catch return;
+
+        var i: usize = 0;
+        while (i < pending.items.len) : (i += 1) {
+            const rel = pending.items[i];
+            var lvl_buf: [512]u8 = undefined;
+            const lvl_path = if (rel.len == 0)
+                base
+            else
+                std.fmt.bufPrint(&lvl_buf, "{s}/{s}", .{ base, rel }) catch continue;
+
+            var lvl = std.Io.Dir.openDirAbsolute(self.io, lvl_path, .{ .iterate = true }) catch continue;
+            defer lvl.close(self.io);
+            var it = lvl.iterate();
+            while (it.next(self.io) catch null) |entry| {
+                var child_buf: [512]u8 = undefined;
+                const child = if (rel.len == 0)
+                    std.fmt.bufPrint(&child_buf, "{s}", .{entry.name}) catch continue
+                else
+                    std.fmt.bufPrint(&child_buf, "{s}/{s}", .{ rel, entry.name }) catch continue;
+                const dup = self.allocator.dupe(u8, child) catch continue;
+                if (entry.kind == .directory) {
+                    pending.append(self.allocator, dup) catch self.allocator.free(dup);
+                } else {
+                    out.append(self.allocator, dup) catch self.allocator.free(dup);
+                }
+            }
+        }
     }
 
     /// Extract "Cellar/<name>/<ver>" from a full path like "/opt/malt/Cellar/foo/1.0/bin/foo"
@@ -111,13 +159,23 @@ pub const Linker = struct {
 
     fn linkSubdir(self: *Linker, keg_path: []const u8, subdir: []const u8, name: []const u8, keg_id: i64) !void {
         _ = name;
-        var keg_dir_buf: [512]u8 = undefined;
-        const keg_subdir = std.fmt.bufPrint(&keg_dir_buf, "{s}/{s}", .{ keg_path, subdir }) catch return;
 
-        var dir = std.Io.Dir.openDirAbsolute(self.io, keg_subdir, .{ .iterate = true }) catch return;
-        defer dir.close(self.io);
+        // Mirror the keg's tree as real dirs under the prefix and symlink
+        // each leaf — the same traversal `checkConflicts` uses, so a nested
+        // conflict the pre-check flags is exactly what link would create.
+        // Whole-dir symlinking would break when two kegs share a nested dir
+        // (share/man/man1, lib/pkgconfig, share/locale). Empty keg dirs
+        // yield no leaf, so there is nothing to link.
+        var leaves: std.ArrayList([]u8) = .empty;
+        defer {
+            for (leaves.items) |p| self.allocator.free(p);
+            leaves.deinit(self.allocator);
+        }
+        self.collectLeafPaths(keg_path, subdir, &leaves);
+        if (leaves.items.len == 0) return;
 
-        // Ensure parent dir exists
+        // Ensure the top-level prefix dir exists; nested parents are created
+        // per-leaf below.
         var parent_buf: [512]u8 = undefined;
         const parent = std.fmt.bufPrint(&parent_buf, "{s}/{s}", .{ self.prefix, subdir }) catch return;
         std.Io.Dir.createDirAbsolute(self.io, parent, .default_dir) catch |e| switch (e) {
@@ -128,30 +186,37 @@ pub const Linker = struct {
         var parent_dir = std.Io.Dir.openDirAbsolute(self.io, parent, .{}) catch return;
         defer parent_dir.close(self.io);
 
-        var iter = dir.iterate();
-        while (iter.next(self.io) catch null) |entry| {
-            if (entry.kind == .directory) continue;
+        for (leaves.items) |rel| {
+            // `rel` is relative and may nest (e.g. "pkgconfig/foo.pc").
+            // Create the leaf's prefix-side parent before linking.
+            const rel_parent = std.fs.path.dirname(rel);
+            if (rel_parent) |rp| parent_dir.createDirPath(self.io, rp) catch continue;
 
             var target_buf: [512]u8 = undefined;
-            const target = std.fmt.bufPrint(&target_buf, "{s}/{s}/{s}", .{ keg_path, subdir, entry.name }) catch continue;
+            const target = std.fmt.bufPrint(&target_buf, "{s}/{s}/{s}", .{ keg_path, subdir, rel }) catch continue;
 
             // Atomic symlink: create at a temp name, then rename into place.
             // This avoids a window where the link is absent after deleteFile.
-            var tmp_name_buf: [280]u8 = undefined;
-            const tmp_name = std.fmt.bufPrint(&tmp_name_buf, ".malt_tmp_{s}", .{entry.name}) catch continue;
+            // The temp sits in the leaf's own parent so the rename stays
+            // within one directory.
+            var tmp_name_buf: [512]u8 = undefined;
+            const tmp_name = if (rel_parent) |rp|
+                std.fmt.bufPrint(&tmp_name_buf, "{s}/.malt_tmp_{s}", .{ rp, std.fs.path.basename(rel) }) catch continue
+            else
+                std.fmt.bufPrint(&tmp_name_buf, ".malt_tmp_{s}", .{rel}) catch continue;
             // Stale tmp from a prior aborted link; symLink would otherwise EEXIST.
             parent_dir.deleteFile(self.io, tmp_name) catch {};
             parent_dir.symLink(self.io, target, tmp_name, .{}) catch continue;
-            parent_dir.rename(tmp_name, parent_dir, entry.name, self.io) catch {
+            parent_dir.rename(tmp_name, parent_dir, rel, self.io) catch {
                 // Rename failed — fall back to direct replacement (non-atomic).
                 parent_dir.deleteFile(self.io, tmp_name) catch {};
-                parent_dir.deleteFile(self.io, entry.name) catch {};
-                parent_dir.symLink(self.io, target, entry.name, .{}) catch continue;
+                parent_dir.deleteFile(self.io, rel) catch {};
+                parent_dir.symLink(self.io, target, rel, .{}) catch continue;
             };
 
             // Build the full link path for DB recording
             var link_buf: [512]u8 = undefined;
-            const link_path = std.fmt.bufPrint(&link_buf, "{s}/{s}/{s}", .{ self.prefix, subdir, entry.name }) catch continue;
+            const link_path = std.fmt.bufPrint(&link_buf, "{s}/{s}/{s}", .{ self.prefix, subdir, rel }) catch continue;
 
             // Record in DB
             var stmt = try self.db.prepare(

--- a/src/core/linker.zig
+++ b/src/core/linker.zig
@@ -57,6 +57,26 @@ pub const Linker = struct {
             defer prefix_dir.close(self.io);
 
             for (leaves.items) |rel| {
+                // File-vs-directory clash (ancestor is a non-dir, or the leaf
+                // slot is a dir): invisible to readLink, but linking would
+                // fail — flag it so the pre-check isn't falsely clean.
+                if (self.structuralConflict(prefix_dir, rel)) |clash| {
+                    var lp_buf: [std.fs.max_path_bytes]u8 = undefined;
+                    const link_path = std.fmt.bufPrint(&lp_buf, "{s}/{s}/{s}", .{ self.prefix, subdir, clash }) catch continue;
+                    // Name the owning keg when the clashing node is a keg
+                    // symlink; otherwise report the bare structural clash.
+                    var owner_buf: [std.fs.max_path_bytes]u8 = undefined;
+                    const owner: []const u8 = if (prefix_dir.readLink(self.io, clash, &owner_buf)) |n|
+                        (extractKegFromPath(owner_buf[0..n]) orelse owner_buf[0..n])
+                    else |_|
+                        "existing directory";
+                    conflicts.append(self.allocator, .{
+                        .link_path = self.allocator.dupe(u8, link_path) catch continue,
+                        .existing_keg = self.allocator.dupe(u8, owner) catch continue,
+                    }) catch continue;
+                    continue;
+                }
+
                 // Check if a symlink already exists at the target location.
                 // 1 KiB fits every path malt produces under its prefix — the
                 // previous `max_path_bytes` (~4 KiB) was stack-wasteful when
@@ -68,7 +88,7 @@ pub const Linker = struct {
 
                 // If the existing symlink points into a different keg, it's a conflict
                 if (!std.mem.startsWith(u8, link_target, keg_path)) {
-                    var link_path_buf: [512]u8 = undefined;
+                    var link_path_buf: [std.fs.max_path_bytes]u8 = undefined;
                     const link_path = std.fmt.bufPrint(&link_path_buf, "{s}/{s}/{s}", .{ self.prefix, subdir, rel }) catch continue;
 
                     // Extract the existing keg path from the symlink target
@@ -106,7 +126,10 @@ pub const Linker = struct {
         var i: usize = 0;
         while (i < pending.items.len) : (i += 1) {
             const rel = pending.items[i];
-            var lvl_buf: [512]u8 = undefined;
+            // Path buffers are sized to the OS path max: a leaf read from the
+            // filesystem is a real path (≤ PATH_MAX), so composing it here
+            // never truncates — no real leaf is silently dropped.
+            var lvl_buf: [std.fs.max_path_bytes]u8 = undefined;
             const lvl_path = if (rel.len == 0)
                 base
             else
@@ -116,7 +139,7 @@ pub const Linker = struct {
             defer lvl.close(self.io);
             var it = lvl.iterate();
             while (it.next(self.io) catch null) |entry| {
-                var child_buf: [512]u8 = undefined;
+                var child_buf: [std.fs.max_path_bytes]u8 = undefined;
                 const child = if (rel.len == 0)
                     std.fmt.bufPrint(&child_buf, "{s}", .{entry.name}) catch continue
                 else
@@ -129,6 +152,29 @@ pub const Linker = struct {
                 }
             }
         }
+    }
+
+    /// Detect a file-vs-directory clash the symlink probe can't see: an
+    /// ancestor of `rel` already exists as a non-directory (so `rel`'s nested
+    /// parent can't be created), or `rel` itself is an existing directory (so
+    /// the leaf slot is taken). `prefix_dir` is opened at `<prefix>/<subdir>`.
+    /// Returns the offending prefix-relative component, or null when clear.
+    fn structuralConflict(self: *Linker, prefix_dir: std.Io.Dir, rel: []const u8) ?[]const u8 {
+        var pos: usize = 0;
+        while (pos < rel.len) {
+            const slash = std.mem.indexOfScalarPos(u8, rel, pos, '/');
+            const partial = rel[0 .. slash orelse rel.len]; // cumulative path so far
+            const is_last = slash == null;
+            const st = prefix_dir.statFile(self.io, partial, .{ .follow_symlinks = false }) catch
+                return null; // component absent → nothing below can clash
+            if (is_last) {
+                if (st.kind == .directory) return partial; // leaf slot is a dir
+            } else if (st.kind != .directory) {
+                return partial; // an ancestor is a file/symlink
+            }
+            pos = (slash orelse rel.len) + 1;
+        }
+        return null;
     }
 
     /// Extract "Cellar/<name>/<ver>" from a full path like "/opt/malt/Cellar/foo/1.0/bin/foo"
@@ -153,7 +199,10 @@ pub const Linker = struct {
         const dirs_to_link: []const []const u8 = if (bin_isolated) linkable_dirs[2..] else &linkable_dirs;
 
         for (dirs_to_link) |subdir| {
-            self.linkSubdir(keg_path, subdir, name, keg_id) catch continue;
+            // linkSubdir swallows per-leaf filesystem hiccups but propagates a
+            // DB write failure; surface it so install can roll the keg back
+            // rather than leave it silently half-linked.
+            try self.linkSubdir(keg_path, subdir, name, keg_id);
         }
     }
 
@@ -192,14 +241,16 @@ pub const Linker = struct {
             const rel_parent = std.fs.path.dirname(rel);
             if (rel_parent) |rp| parent_dir.createDirPath(self.io, rp) catch continue;
 
-            var target_buf: [512]u8 = undefined;
+            // Path buffers sized to the OS path max so a real keg leaf never
+            // truncates (see collectLeafPaths).
+            var target_buf: [std.fs.max_path_bytes]u8 = undefined;
             const target = std.fmt.bufPrint(&target_buf, "{s}/{s}/{s}", .{ keg_path, subdir, rel }) catch continue;
 
             // Atomic symlink: create at a temp name, then rename into place.
             // This avoids a window where the link is absent after deleteFile.
             // The temp sits in the leaf's own parent so the rename stays
             // within one directory.
-            var tmp_name_buf: [512]u8 = undefined;
+            var tmp_name_buf: [std.fs.max_path_bytes]u8 = undefined;
             const tmp_name = if (rel_parent) |rp|
                 std.fmt.bufPrint(&tmp_name_buf, "{s}/.malt_tmp_{s}", .{ rp, std.fs.path.basename(rel) }) catch continue
             else
@@ -215,19 +266,29 @@ pub const Linker = struct {
             };
 
             // Build the full link path for DB recording
-            var link_buf: [512]u8 = undefined;
+            var link_buf: [std.fs.max_path_bytes]u8 = undefined;
             const link_path = std.fmt.bufPrint(&link_buf, "{s}/{s}/{s}", .{ self.prefix, subdir, rel }) catch continue;
 
-            // Record in DB
-            var stmt = try self.db.prepare(
-                "INSERT OR REPLACE INTO links (keg_id, link_path, target) VALUES (?1, ?2, ?3);",
-            );
-            defer stmt.finalize();
-            try stmt.bindInt(1, keg_id);
-            try stmt.bindText(2, link_path);
-            try stmt.bindText(3, target);
-            _ = try stmt.step();
+            // Record the link. On DB failure, back out the symlink we just
+            // made — a DB-less symlink is an orphan `unlink` can't find — and
+            // propagate so the caller (install) rolls the keg back instead of
+            // reporting a half-linked keg as success.
+            self.recordLink(keg_id, link_path, target) catch |e| {
+                parent_dir.deleteFile(self.io, rel) catch {};
+                return e;
+            };
         }
+    }
+
+    fn recordLink(self: *Linker, keg_id: i64, link_path: []const u8, target: []const u8) !void {
+        var stmt = try self.db.prepare(
+            "INSERT OR REPLACE INTO links (keg_id, link_path, target) VALUES (?1, ?2, ?3);",
+        );
+        defer stmt.finalize();
+        try stmt.bindInt(1, keg_id);
+        try stmt.bindText(2, link_path);
+        try stmt.bindText(3, target);
+        _ = try stmt.step();
     }
 
     /// Create `opt/{name} -> Cellar/{name}/{version}` symlink.

--- a/tests/linker_core_test.zig
+++ b/tests/linker_core_test.zig
@@ -232,6 +232,59 @@ test "checkConflicts detects a nested cross-keg collision" {
     try testing.expect(matched);
 }
 
+test "unlink prunes emptied nested dirs but keeps dirs another keg still links" {
+    const prefix = try uniquePrefix("unlink_prune");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    // Two kegs share share/man/man1; each ships its own page there.
+    const keg_a = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/alpha/1.0", .{prefix});
+    defer testing.allocator.free(keg_a);
+    const keg_b = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/beta/1.0", .{prefix});
+    defer testing.allocator.free(keg_b);
+    const man_a = try std.fmt.allocPrint(testing.allocator, "{s}/share/man/man1/a.1", .{keg_a});
+    defer testing.allocator.free(man_a);
+    const man_b = try std.fmt.allocPrint(testing.allocator, "{s}/share/man/man1/b.1", .{keg_b});
+    defer testing.allocator.free(man_b);
+    try writeFile(man_a, ".TH A 1\n");
+    try writeFile(man_b, ".TH B 1\n");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var ins = try db.prepare(
+        \\INSERT INTO kegs (id, name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (1, 'alpha', 'alpha', '1.0', 'aa', ?1), (2, 'beta', 'beta', '1.0', 'bb', ?2);
+    );
+    try ins.bindText(1, keg_a);
+    try ins.bindText(2, keg_b);
+    _ = try ins.step();
+    ins.finalize();
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg_a, "alpha", 1, false);
+    try linker.link(keg_b, "beta", 2, false);
+
+    // Unlink alpha: its page goes, but beta's b.1 keeps share/man/man1 alive.
+    try linker.unlink(1);
+    var man1_buf: [512]u8 = undefined;
+    const man1 = try std.fmt.bufPrint(&man1_buf, "{s}/share/man/man1", .{prefix});
+    var d = try std.Io.Dir.openDirAbsolute(std.Options.debug_io, man1, .{});
+    d.close(std.Options.debug_io);
+
+    // Unlink beta: now share/man/man1, share/man and share are all empty and
+    // must be pruned — no lingering nested dirs — while the prefix survives.
+    try linker.unlink(2);
+    for ([_][]const u8{ "share/man/man1", "share/man", "share" }) |sub| {
+        var buf: [512]u8 = undefined;
+        const p = try std.fmt.bufPrint(&buf, "{s}/{s}", .{ prefix, sub });
+        try testing.expectError(error.FileNotFound, std.Io.Dir.openDirAbsolute(std.Options.debug_io, p, .{}));
+    }
+    var pd = try std.Io.Dir.openDirAbsolute(std.Options.debug_io, prefix, .{});
+    pd.close(std.Options.debug_io);
+}
+
 test "linkOpt creates opt/{name} -> Cellar/{name}/{version}" {
     const prefix = try uniquePrefix("link_opt");
     defer testing.allocator.free(prefix);

--- a/tests/linker_core_test.zig
+++ b/tests/linker_core_test.zig
@@ -91,6 +91,147 @@ test "link creates symlinks for every file in a keg and records them in the DB" 
     try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(std.Options.debug_io, link_path, .{}));
 }
 
+fn writeFile(path: []const u8, body: []const u8) !void {
+    if (std.fs.path.dirname(path)) |parent| {
+        try test_io.cwd().createDirPath(std.Options.debug_io, parent);
+    }
+    const f = try test_io.createFileAbsolute(std.Options.debug_io, path, .{});
+    defer f.close(std.Options.debug_io);
+    try f.writeStreamingAll(std.Options.debug_io, body);
+}
+
+test "link mirrors nested keg subdirectories and records each nested leaf" {
+    const prefix = try uniquePrefix("link_nested");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/nest/1.0", .{prefix});
+    defer testing.allocator.free(keg);
+
+    // Depth-1 leaf, a nested chain four levels deep, and two sibling subdirs
+    // under one linkable dir (share/locale + share/man) — the sibling case
+    // must not stop after the first leaf.
+    const bin = try std.fmt.allocPrint(testing.allocator, "{s}/bin/tool", .{keg});
+    defer testing.allocator.free(bin);
+    const pc = try std.fmt.allocPrint(testing.allocator, "{s}/lib/pkgconfig/nest.pc", .{keg});
+    defer testing.allocator.free(pc);
+    const mo = try std.fmt.allocPrint(testing.allocator, "{s}/share/locale/en_US/LC_MESSAGES/nest.mo", .{keg});
+    defer testing.allocator.free(mo);
+    const man = try std.fmt.allocPrint(testing.allocator, "{s}/share/man/man1/tool.1", .{keg});
+    defer testing.allocator.free(man);
+    try writeFile(bin, "#!/bin/sh\n");
+    try writeFile(pc, "Name: nest\n");
+    try writeFile(mo, "mo\n");
+    try writeFile(man, ".TH TOOL 1\n");
+
+    // A keg-shipped symlink leaf (Homebrew ships e.g. lib/libfoo.dylib ->
+    // libfoo.1.dylib) must be linked like a file, not descended into. The
+    // link's own target is irrelevant here — the linker links to the keg's
+    // symlink file, never dereferencing it — so any absolute target works.
+    const dylib = try std.fmt.allocPrint(testing.allocator, "{s}/lib/libnest.dylib", .{keg});
+    defer testing.allocator.free(dylib);
+    const dylib_target = try std.fmt.allocPrint(testing.allocator, "{s}/lib/libnest.1.dylib", .{keg});
+    defer testing.allocator.free(dylib_target);
+    try test_io.symLinkAbsolute(std.Options.debug_io, dylib_target, dylib, .{});
+
+    // An empty nested dir must contribute no leaf and no prefix dir.
+    const empty = try std.fmt.allocPrint(testing.allocator, "{s}/share/empty", .{keg});
+    defer testing.allocator.free(empty);
+    try test_io.cwd().createDirPath(std.Options.debug_io, empty);
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    // A kegs row so the links FK is satisfied and the rows actually record.
+    var ins = try db.prepare(
+        \\INSERT INTO kegs (id, name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (1, 'nest', 'nest', '1.0', 'aa', ?1);
+    );
+    try ins.bindText(1, keg);
+    _ = try ins.step();
+    ins.finalize();
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg, "nest", 1, false);
+
+    // Every leaf — nested, sibling, and the keg symlink — must resolve.
+    const leaves = [_][]const u8{
+        "bin/tool",
+        "lib/pkgconfig/nest.pc",
+        "lib/libnest.dylib",
+        "share/locale/en_US/LC_MESSAGES/nest.mo",
+        "share/man/man1/tool.1",
+    };
+    for (leaves) |leaf| {
+        var lp_buf: [512]u8 = undefined;
+        const lp = try std.fmt.bufPrint(&lp_buf, "{s}/{s}", .{ prefix, leaf });
+        var tgt_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const tgt = try test_io.readLinkAbsolute(std.Options.debug_io, lp, &tgt_buf);
+        try testing.expect(std.mem.endsWith(u8, tgt, leaf));
+    }
+
+    // The empty keg dir is skipped: no prefix dir is created for it.
+    var empty_lp_buf: [512]u8 = undefined;
+    const empty_lp = try std.fmt.bufPrint(&empty_lp_buf, "{s}/share/empty", .{prefix});
+    try testing.expectError(error.FileNotFound, std.Io.Dir.openDirAbsolute(std.Options.debug_io, empty_lp, .{}));
+
+    // One links row per leaf, each keyed on its full nested path so unlink
+    // removes it.
+    var count = try db.prepare("SELECT COUNT(*) FROM links WHERE keg_id = 1;");
+    defer count.finalize();
+    _ = try count.step();
+    try testing.expectEqual(@as(i64, leaves.len), count.columnInt(0));
+
+    // unlink clears the nested symlinks too.
+    try linker.unlink(1);
+    var data_lp_buf: [512]u8 = undefined;
+    const data_lp = try std.fmt.bufPrint(&data_lp_buf, "{s}/share/man/man1/tool.1", .{prefix});
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(std.Options.debug_io, data_lp, .{}));
+}
+
+test "checkConflicts detects a nested cross-keg collision" {
+    const prefix = try uniquePrefix("link_nested_conflict");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    // Two kegs that both ship the same nested man page.
+    const keg_a = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/alpha/1.0", .{prefix});
+    defer testing.allocator.free(keg_a);
+    const keg_b = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/beta/1.0", .{prefix});
+    defer testing.allocator.free(keg_b);
+    const man_a = try std.fmt.allocPrint(testing.allocator, "{s}/share/man/man1/tool.1", .{keg_a});
+    defer testing.allocator.free(man_a);
+    const man_b = try std.fmt.allocPrint(testing.allocator, "{s}/share/man/man1/tool.1", .{keg_b});
+    defer testing.allocator.free(man_b);
+    try writeFile(man_a, ".TH TOOL 1\n");
+    try writeFile(man_b, ".TH TOOL 1\n");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg_a, "alpha", 1, false);
+
+    const conflicts = try linker.checkConflicts(keg_b, false);
+    defer {
+        for (conflicts) |c| {
+            testing.allocator.free(c.link_path);
+            testing.allocator.free(c.existing_keg);
+        }
+        testing.allocator.free(conflicts);
+    }
+    var matched = false;
+    for (conflicts) |c| {
+        if (std.mem.endsWith(u8, c.link_path, "/share/man/man1/tool.1")) {
+            matched = true;
+            try testing.expect(std.mem.indexOf(u8, c.existing_keg, "alpha") != null);
+        }
+    }
+    try testing.expect(matched);
+}
+
 test "linkOpt creates opt/{name} -> Cellar/{name}/{version}" {
     const prefix = try uniquePrefix("link_opt");
     defer testing.allocator.free(prefix);

--- a/tests/linker_core_test.zig
+++ b/tests/linker_core_test.zig
@@ -285,6 +285,141 @@ test "unlink prunes emptied nested dirs but keeps dirs another keg still links" 
     pd.close(std.Options.debug_io);
 }
 
+test "unlink still prunes emptied nested dirs when the link file is already gone" {
+    // unlink treats the DB rows as the source of truth: even if a symlink
+    // was removed out-of-band, the emptied nested dirs must still be pruned.
+    const prefix = try uniquePrefix("unlink_prune_gone");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/nest/1.0", .{prefix});
+    defer testing.allocator.free(keg);
+    const man = try std.fmt.allocPrint(testing.allocator, "{s}/share/man/man1/tool.1", .{keg});
+    defer testing.allocator.free(man);
+    try writeFile(man, ".TH TOOL 1\n");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var ins = try db.prepare(
+        \\INSERT INTO kegs (id, name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (1, 'nest', 'nest', '1.0', 'aa', ?1);
+    );
+    try ins.bindText(1, keg);
+    _ = try ins.step();
+    ins.finalize();
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg, "nest", 1, false);
+
+    // Remove the symlink out-of-band; the DB row still points at it.
+    var lp_buf: [512]u8 = undefined;
+    const lp = try std.fmt.bufPrint(&lp_buf, "{s}/share/man/man1/tool.1", .{prefix});
+    try test_io.cwd().deleteFile(std.Options.debug_io, lp);
+
+    try linker.unlink(1);
+    var man1_buf: [512]u8 = undefined;
+    const man1 = try std.fmt.bufPrint(&man1_buf, "{s}/share/man/man1", .{prefix});
+    try testing.expectError(error.FileNotFound, std.Io.Dir.openDirAbsolute(std.Options.debug_io, man1, .{}));
+}
+
+test "checkConflicts under bin_isolated skips bin but still catches nested lib conflicts" {
+    const prefix = try uniquePrefix("conflict_isolated");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    // Both kegs ship the same bin and the same nested lib/pkgconfig file.
+    const keg_a = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/alpha/1.0", .{prefix});
+    defer testing.allocator.free(keg_a);
+    const keg_b = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/beta/1.0", .{prefix});
+    defer testing.allocator.free(keg_b);
+    for ([_][]const u8{ keg_a, keg_b }) |k| {
+        const bin = try std.fmt.allocPrint(testing.allocator, "{s}/bin/tool", .{k});
+        defer testing.allocator.free(bin);
+        const pc = try std.fmt.allocPrint(testing.allocator, "{s}/lib/pkgconfig/lib.pc", .{k});
+        defer testing.allocator.free(pc);
+        try writeFile(bin, "#!/bin/sh\n");
+        try writeFile(pc, "Name: lib\n");
+    }
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var ins = try db.prepare(
+        \\INSERT INTO kegs (id, name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (1, 'alpha', 'alpha', '1.0', 'aa', ?1);
+    );
+    try ins.bindText(1, keg_a);
+    _ = try ins.step();
+    ins.finalize();
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg_a, "alpha", 1, false);
+
+    // Isolated probe: bin is not linked for an isolated dep, so a bin
+    // collision must be suppressed, but the nested lib one must still fire.
+    const conflicts = try linker.checkConflicts(keg_b, true);
+    defer {
+        for (conflicts) |c| {
+            testing.allocator.free(c.link_path);
+            testing.allocator.free(c.existing_keg);
+        }
+        testing.allocator.free(conflicts);
+    }
+    var lib_hit = false;
+    for (conflicts) |c| {
+        try testing.expect(!std.mem.endsWith(u8, c.link_path, "/bin/tool"));
+        if (std.mem.endsWith(u8, c.link_path, "/lib/pkgconfig/lib.pc")) lib_hit = true;
+    }
+    try testing.expect(lib_hit);
+}
+
+test "re-linking a nested keg is idempotent: no error, no duplicate rows" {
+    const prefix = try uniquePrefix("relink_nested");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/nest/1.0", .{prefix});
+    defer testing.allocator.free(keg);
+    const pc = try std.fmt.allocPrint(testing.allocator, "{s}/lib/pkgconfig/nest.pc", .{keg});
+    defer testing.allocator.free(pc);
+    const man = try std.fmt.allocPrint(testing.allocator, "{s}/share/man/man1/tool.1", .{keg});
+    defer testing.allocator.free(man);
+    try writeFile(pc, "Name: nest\n");
+    try writeFile(man, ".TH TOOL 1\n");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var ins = try db.prepare(
+        \\INSERT INTO kegs (id, name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (1, 'nest', 'nest', '1.0', 'aa', ?1);
+    );
+    try ins.bindText(1, keg);
+    _ = try ins.step();
+    ins.finalize();
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    // The nested tmp-symlink-then-rename path must survive a second run: the
+    // rename lands atop the existing link, INSERT OR REPLACE dedups the row.
+    try linker.link(keg, "nest", 1, false);
+    try linker.link(keg, "nest", 1, false);
+
+    var count = try db.prepare("SELECT COUNT(*) FROM links WHERE keg_id = 1;");
+    defer count.finalize();
+    _ = try count.step();
+    try testing.expectEqual(@as(i64, 2), count.columnInt(0));
+
+    var lp_buf: [512]u8 = undefined;
+    const lp = try std.fmt.bufPrint(&lp_buf, "{s}/share/man/man1/tool.1", .{prefix});
+    var tgt_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const tgt = try test_io.readLinkAbsolute(std.Options.debug_io, lp, &tgt_buf);
+    try testing.expect(std.mem.endsWith(u8, tgt, "share/man/man1/tool.1"));
+}
+
 test "linkOpt creates opt/{name} -> Cellar/{name}/{version}" {
     const prefix = try uniquePrefix("link_opt");
     defer testing.allocator.free(prefix);

--- a/tests/linker_core_test.zig
+++ b/tests/linker_core_test.zig
@@ -91,6 +91,18 @@ test "link creates symlinks for every file in a keg and records them in the DB" 
     try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(std.Options.debug_io, link_path, .{}));
 }
 
+fn insertKeg(db: *sqlite.Database, id: i64, name: []const u8, cellar_path: []const u8) !void {
+    var s = try db.prepare(
+        \\INSERT INTO kegs (id, name, full_name, version, store_sha256, cellar_path)
+        \\VALUES (?1, ?2, ?2, '1.0', 'aa', ?3);
+    );
+    defer s.finalize();
+    try s.bindInt(1, id);
+    try s.bindText(2, name);
+    try s.bindText(3, cellar_path);
+    _ = try s.step();
+}
+
 fn writeFile(path: []const u8, body: []const u8) !void {
     if (std.fs.path.dirname(path)) |parent| {
         try test_io.cwd().createDirPath(std.Options.debug_io, parent);
@@ -211,6 +223,7 @@ test "checkConflicts detects a nested cross-keg collision" {
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
     try schema.initSchema(&db);
+    try insertKeg(&db, 1, "alpha", keg_a);
     var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
     try linker.link(keg_a, "alpha", 1, false);
 
@@ -420,6 +433,107 @@ test "re-linking a nested keg is idempotent: no error, no duplicate rows" {
     try testing.expect(std.mem.endsWith(u8, tgt, "share/man/man1/tool.1"));
 }
 
+test "link propagates a DB write failure and backs out the orphaned symlink" {
+    // No kegs row -> the links FK insert fails. link() must surface the error
+    // (so install can roll back) and leave no symlink the DB can't track.
+    const prefix = try uniquePrefix("link_db_fail");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/nest/1.0", .{prefix});
+    defer testing.allocator.free(keg);
+    const bin = try std.fmt.allocPrint(testing.allocator, "{s}/bin/tool", .{keg});
+    defer testing.allocator.free(bin);
+    try writeFile(bin, "#!/bin/sh\n");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+
+    // FK violation propagates instead of being swallowed.
+    try testing.expectError(sqlite.SqliteError.ConstraintViolation, linker.link(keg, "nest", 1, false));
+
+    // The symlink created just before the failed insert was backed out.
+    var lp_buf: [512]u8 = undefined;
+    const lp = try std.fmt.bufPrint(&lp_buf, "{s}/bin/tool", .{prefix});
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(std.Options.debug_io, lp, .{}));
+}
+
+test "checkConflicts flags a file-vs-directory collision the symlink probe misses" {
+    const prefix = try uniquePrefix("conflict_filedir");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    // alpha ships a FILE at share/data; beta ships share/data/inner (so beta
+    // needs `data` to be a directory). Linking beta would fail — the
+    // pre-check must not report a clean bill of health.
+    const keg_a = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/alpha/1.0", .{prefix});
+    defer testing.allocator.free(keg_a);
+    const keg_b = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/beta/1.0", .{prefix});
+    defer testing.allocator.free(keg_b);
+    const file_a = try std.fmt.allocPrint(testing.allocator, "{s}/share/data", .{keg_a});
+    defer testing.allocator.free(file_a);
+    const file_b = try std.fmt.allocPrint(testing.allocator, "{s}/share/data/inner", .{keg_b});
+    defer testing.allocator.free(file_b);
+    try writeFile(file_a, "payload\n");
+    try writeFile(file_b, "inner\n");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try insertKeg(&db, 1, "alpha", keg_a);
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg_a, "alpha", 1, false);
+
+    const conflicts = try linker.checkConflicts(keg_b, false);
+    defer {
+        for (conflicts) |c| {
+            testing.allocator.free(c.link_path);
+            testing.allocator.free(c.existing_keg);
+        }
+        testing.allocator.free(conflicts);
+    }
+    var hit = false;
+    for (conflicts) |c| {
+        if (std.mem.endsWith(u8, c.link_path, "/share/data")) hit = true;
+    }
+    try testing.expect(hit);
+}
+
+test "link handles a nested path longer than 512 bytes without dropping it" {
+    // Two ~250-char component dirs push the composed path past the old 512-byte
+    // buffers; the leaf must still be linked (no silent truncation drop).
+    const prefix = try uniquePrefix("link_deep");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const seg = "d" ** 250;
+    const rel = try std.fmt.allocPrint(testing.allocator, "share/{s}/{s}/leaf.txt", .{ seg, seg });
+    defer testing.allocator.free(rel);
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/nest/1.0", .{prefix});
+    defer testing.allocator.free(keg);
+    const leaf = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ keg, rel });
+    defer testing.allocator.free(leaf);
+    try writeFile(leaf, "deep\n");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try insertKeg(&db, 1, "nest", keg);
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg, "nest", 1, false);
+
+    var lp_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const lp = try std.fmt.bufPrint(&lp_buf, "{s}/{s}", .{ prefix, rel });
+    var tgt_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const tgt = try test_io.readLinkAbsolute(std.Options.debug_io, lp, &tgt_buf);
+    try testing.expect(std.mem.endsWith(u8, tgt, "leaf.txt"));
+}
+
 test "linkOpt creates opt/{name} -> Cellar/{name}/{version}" {
     const prefix = try uniquePrefix("link_opt");
     defer testing.allocator.free(prefix);
@@ -529,6 +643,7 @@ test "checkConflicts flags a symlink that points into a different keg" {
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
     try schema.initSchema(&db);
+    try insertKeg(&db, 1, "alpha", keg_a);
     var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
     try linker.link(keg_a, "alpha", 1, false);
 


### PR DESCRIPTION
## Description

The keg linker only symlinked the top-level files of each linkable dir and skipped every directory entry, so nested keg content never appeared in the prefix.

`link` and `checkConflicts` now recurse through a shared read-only walk, mirroring each keg's tree as real directories and symlinking every leaf
(multi-keg-safe, unlike a whole-dir symlink), recording one `links` row per leaf so `unlink` still removes them. `unlink` prunes the nested directories
once they are emptied, up to but never including the prefix root.


## Related Issue

- None

## Notes for Reviewers

- None