### PR TITLE
fix(store): version the relocated-keg cache key and reclaim stale versions

### DIFF
--- a/scripts/regressions/relocated-store-reclaims-stale-versions.sh
+++ b/scripts/regressions/relocated-store-reclaims-stale-versions.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Regression: `purge --cache` must reclaim relocated kegs left under a
+# superseded relocation-logic version, and must never touch foreign entries.
+#
+# The relocated-keg cache is keyed `store-relocated/v<N>/<sha>`. Bumping the
+# logic version turns old `v<N-1>/` trees into orphans that no command
+# reclaimed — the cache is path-only, so `purge --store-orphans` (DB-driven)
+# and `doctor` both skip it. The fix folds a version-aware reap into the
+# `--cache` scope so `purge --cache` / `--housekeeping` / `cleanup` reclaim it.
+#
+# Drives the built binary end-to-end under a throwaway prefix, offline, and
+# cleans up. Exits 0 when the stale version tree is reclaimed and the foreign
+# sibling survives; non-zero otherwise.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+# Shell regressions run the built binary, which `zig build test` does not
+# rebuild — build it here so a stale binary never masks the fix.
+zig build >/dev/null
+
+PREFIX="$(mktemp -d)/malt"
+export MALT_PREFIX="$PREFIX"
+trap 'rm -rf "$(dirname "$PREFIX")"' EXIT
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+
+sha=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+# A version segment far above any real logic version → always stale.
+stale="$PREFIX/store-relocated/v999999"
+mkdir -p "$stale/$sha"
+printf 'x' >"$stale/$sha/keg-file"
+
+# A non-`v<digits>` sibling must never be reaped.
+foreign="$PREFIX/store-relocated/keep"
+mkdir -p "$foreign"
+
+"$BIN" purge --cache --yes >/dev/null 2>&1 || true
+
+[ ! -d "$stale" ] || {
+  echo "FAIL: purge --cache did not reclaim the stale relocated version tree ($stale)" >&2
+  exit 1
+}
+[ -d "$foreign" ] || {
+  echo "FAIL: purge --cache deleted a foreign store-relocated entry ($foreign)" >&2
+  exit 1
+}
+
+echo "PASS: purge --cache reclaims stale relocated-keg versions and spares foreign entries"

--- a/scripts/regressions/relocated-store-versioned-cache-key.sh
+++ b/scripts/regressions/relocated-store-versioned-cache-key.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Regression: the relocated-keg cache must key on the relocation-logic version,
+# not the bottle sha alone.
+#
+# The bug: `store-relocated/<sha>` cached the output of relocateKegTree
+# (placeholder substitution + install_name_tool + ad-hoc codesign) keyed by the
+# bottle sha only. That output depends on the relocation *rules* too, so a
+# change to those rules would serve the previously-relocated keg on a warm
+# reinstall of an unchanged bottle — the fix would silently not apply.
+#
+# The fix folds a `RELOC_LOGIC_VERSION` token into the key
+# (`store-relocated/v<N>/<sha>`); bumping it invalidates every prior entry.
+#
+# This is a content-addressed-store *contract* guard. relocated_store.zig pulls
+# in C-backed clonefile modules wired through build.zig, so the store API cannot
+# be exercised standalone offline; the inline `zig build test` suite drives the
+# real save/has behaviour, and this script guards the on-disk key layout at the
+# source of truth so the version dimension can never silently disappear.
+#
+# Exits 0 when the cache key carries a version segment, non-zero otherwise.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+SRC="$ROOT/src/core/relocated_store.zig"
+
+[ -f "$SRC" ] || {
+  echo "FAIL: relocated_store.zig not found at $SRC" >&2
+  exit 1
+}
+
+# The path builder must interpolate a version segment between store-relocated/
+# and the sha (the bare `store-relocated/{s}` layout is the pre-fix, stale key).
+if ! grep -Eq 'store-relocated/v\{[^}]*\}/\{s\}' "$SRC"; then
+  echo "FAIL: cache key is unversioned (store-relocated/<sha>); a relocation-logic change would serve a stale keg" >&2
+  exit 1
+fi
+
+# The version token must exist as a bump-on-change constant.
+if ! grep -Eq 'RELOC_LOGIC_VERSION' "$SRC"; then
+  echo "FAIL: RELOC_LOGIC_VERSION token missing; nothing to bump on a relocation-logic change" >&2
+  exit 1
+fi
+
+echo "OK: relocated-store cache key carries a relocation-logic version segment"

--- a/src/cli/purge.zig
+++ b/src/cli/purge.zig
@@ -198,7 +198,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             r = try switch (k) {
                 .unused_deps => scopes_mod.runUnusedDeps(ctx, allocator, prefix, dry_run),
                 .store_orphans => scopes_mod.runStoreOrphans(ctx, allocator, prefix, dry_run),
-                .cache => scopes_mod.runCache(ctx, cache_dir, opts.cache_days, dry_run),
+                .cache => scopes_mod.runCache(ctx, allocator, cache_dir, prefix, opts.cache_days, dry_run),
                 .downloads => scopes_mod.runDownloads(ctx, cache_dir, dry_run),
                 .stale_casks => scopes_mod.runStaleCasks(ctx, allocator, prefix, dry_run),
                 .old_versions => scopes_mod.runOldVersions(ctx, allocator, prefix, dry_run),

--- a/src/cli/purge/scopes.zig
+++ b/src/cli/purge/scopes.zig
@@ -15,6 +15,7 @@ const linker_mod = @import("../../core/linker.zig");
 const cellar_mod = @import("../../core/cellar.zig");
 const formula_mod = @import("../../core/formula.zig");
 const cask_mod = @import("../../core/cask.zig");
+const relocated_store = @import("../../core/relocated_store.zig");
 const util = @import("util.zig");
 const report = @import("report.zig");
 
@@ -238,7 +239,7 @@ fn orphanStillLinked(io: std.Io, allocator: std.mem.Allocator, db: *sqlite.Datab
 
 // ── Tier: --cache[=DAYS] (was `cleanup --prune=`) ───────────────────────────
 
-pub fn runCache(ctx: *const AppCtx, cache_dir: []const u8, max_age_days: i64, dry_run: bool) !TierResult {
+pub fn runCache(ctx: *const AppCtx, allocator: std.mem.Allocator, cache_dir: []const u8, prefix: []const u8, max_age_days: i64, dry_run: bool) !TierResult {
     var result: TierResult = .{};
 
     var rep = report.Reporter.init("cache", dry_run);
@@ -248,6 +249,22 @@ pub fn runCache(ctx: *const AppCtx, cache_dir: []const u8, max_age_days: i64, dr
         cache_dir,
     });
     pruneCacheRecursive(ctx.io, cache_dir, max_age_days, dry_run, &result, &rep);
+
+    // Relocated kegs left by a past relocation-logic bump are pure cache and
+    // DB-independent, so the cache sweep is their reclaim path. Each version
+    // tree counts as one reclaimed item.
+    const reaped = relocated_store.reapStaleVersions(ctx.io, allocator, prefix, !dry_run);
+    if (reaped.removed > 0) {
+        var lbl: [96]u8 = undefined;
+        const label = std.fmt.bufPrint(&lbl, "store-relocated: {d} stale version {s}", .{
+            reaped.removed,
+            report.pluralize(reaped.removed, "tree", "trees"),
+        }) catch "store-relocated: stale version trees";
+        rep.item(label);
+        result.removed += reaped.removed;
+        result.bytes += reaped.bytes;
+    }
+
     rep.done(result.removed);
     return result;
 }
@@ -907,6 +924,35 @@ test "runStaleCasks self-heals a schema-less db rather than reporting it as a fa
     try testing.expectEqual(util.ScopeStatus.ok, result.status);
     try testing.expect(result.error_kind == null);
     try testing.expectEqual(@as(u32, 0), result.removed);
+}
+
+test "runCache reclaims relocated kegs orphaned by a past logic-version bump" {
+    const allocator = testing.allocator;
+
+    const prefix = "/tmp/malt_runCache_reloc_reap";
+    std.Io.Dir.cwd().deleteTree(fs_test_io, prefix) catch {};
+    defer std.Io.Dir.cwd().deleteTree(fs_test_io, prefix) catch {};
+
+    const cache_dir = prefix ++ "/cache";
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, cache_dir);
+
+    const sha = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    // A version segment that is clearly not the current one → stale.
+    const stale_root = prefix ++ "/store-relocated/v999999";
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, stale_root ++ "/" ++ sha);
+    // The live version segment must survive the sweep.
+    const current = try std.fmt.allocPrint(allocator, "{s}/store-relocated/v{d}/{s}", .{
+        prefix, relocated_store.RELOC_LOGIC_VERSION, sha,
+    });
+    defer allocator.free(current);
+    try std.Io.Dir.cwd().createDirPath(fs_test_io, current);
+
+    const ctx = AppCtx{ .io = fs_test_io, .environ = .empty };
+    const result = try runCache(&ctx, allocator, cache_dir, prefix, 30, false);
+
+    try testing.expectEqual(@as(u32, 1), result.removed);
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(fs_test_io, stale_root, .{}));
+    try std.Io.Dir.accessAbsolute(fs_test_io, current, .{});
 }
 
 // ── runOldVersions cask history sweep ──────────────────────────────────────

--- a/src/core/relocated_store.zig
+++ b/src/core/relocated_store.zig
@@ -1,7 +1,8 @@
 //! malt — post-relocation keg cache.
 //!
-//! `<MALT_PREFIX>/store-relocated/<sha256>/` snapshots a fully-relocated
-//! Cellar keg keyed by bottle sha256. On warm reinstalls of a bottle whose
+//! `<MALT_PREFIX>/store-relocated/v<N>/<sha256>/` snapshots a fully-relocated
+//! Cellar keg keyed by (relocation-logic version, bottle sha256). On warm
+//! reinstalls of a bottle whose
 //! content has not changed, the install pipeline can skip
 //! extract → placeholder substitution → install_name_tool → ad-hoc
 //! codesign and clonefile-restore the keg directly. APFS clonefile makes
@@ -22,6 +23,18 @@ pub const RelocatedStoreError = error{
     MaterializeFailed,
 };
 
+/// Relocation-logic version, folded into the cache path as
+/// `store-relocated/v<N>/<sha>`. The cached bytes are the output of
+/// `cellar.relocateKegTree` (placeholder substitution + install_name_tool +
+/// ad-hoc codesign), whose result depends on the relocation *rules*, not just
+/// the bottle sha. Bump this whenever `relocateKegTree` / `patchTextFiles` /
+/// the `@@HOMEBREW_*@@` replacement set / codesign behaviour changes: the bump
+/// turns every prior `v<N-1>/` entry into a cache miss, forcing correct
+/// re-relocation. Prior `v<N-1>/` trees are orphaned on disk — there is no
+/// automatic sweeper for `store-relocated` yet — so a bump trades a one-time
+/// disk cost for correctness; bumps are rare (only on relocation-logic change).
+pub const RELOC_LOGIC_VERSION: u32 = 1;
+
 /// Reject anything that is not exactly 64 lowercase hex characters.
 /// Run this before forming any path so traversal sequences (`..`, `/`) and
 /// case variants never reach the filesystem.
@@ -34,8 +47,8 @@ fn isValidSha256(sha: []const u8) bool {
     return true;
 }
 
-fn cacheDir(buf: []u8, prefix: []const u8, sha: []const u8) RelocatedStoreError![]u8 {
-    return std.fmt.bufPrint(buf, "{s}/store-relocated/{s}", .{ prefix, sha }) catch
+fn cacheDir(buf: []u8, prefix: []const u8, version: u32, sha: []const u8) RelocatedStoreError![]u8 {
+    return std.fmt.bufPrint(buf, "{s}/store-relocated/v{d}/{s}", .{ prefix, version, sha }) catch
         return RelocatedStoreError.PathTooLong;
 }
 
@@ -56,7 +69,7 @@ fn cellarParentDir(buf: []u8, prefix: []const u8, name: []const u8) RelocatedSto
 pub fn has(io: std.Io, prefix: []const u8, sha: []const u8) bool {
     if (!isValidSha256(sha)) return false;
     var buf: [512]u8 = undefined;
-    const dir = cacheDir(&buf, prefix, sha) catch return false;
+    const dir = cacheDir(&buf, prefix, RELOC_LOGIC_VERSION, sha) catch return false;
     std.Io.Dir.accessAbsolute(io, dir, .{}) catch return false;
     return true;
 }
@@ -76,7 +89,7 @@ pub fn save(
     if (!isValidSha256(sha)) return RelocatedStoreError.InvalidSha256;
 
     var dst_buf: [512]u8 = undefined;
-    const dst = try cacheDir(&dst_buf, prefix, sha);
+    const dst = try cacheDir(&dst_buf, prefix, RELOC_LOGIC_VERSION, sha);
 
     // Idempotent: already cached → done. Concurrent installs race here, and
     // the loser would otherwise fail at `renameAbsolute` below.
@@ -103,10 +116,9 @@ fn saveFresh(
     // outside. Surface as `SaveFailed` (debug-logged by the caller).
     std.Io.Dir.accessAbsolute(io, src, .{}) catch return RelocatedStoreError.SaveFailed;
 
-    // Ensure the parent `<prefix>/store-relocated/` directory exists.
-    var parent_buf: [512]u8 = undefined;
-    const parent = std.fmt.bufPrint(&parent_buf, "{s}/store-relocated", .{prefix}) catch
-        return RelocatedStoreError.PathTooLong;
+    // Ensure the versioned parent `<prefix>/store-relocated/v<N>/` exists.
+    // Derive it from `dst` so the version segment stays in one place.
+    const parent = std.fs.path.dirname(dst) orelse return RelocatedStoreError.SaveFailed;
     std.Io.Dir.cwd().createDirPath(io, parent) catch return RelocatedStoreError.SaveFailed;
 
     // Atomic write: clone into a sibling temp dir, then rename into place.
@@ -153,7 +165,7 @@ pub fn materialize(
     if (!isValidSha256(sha)) return RelocatedStoreError.InvalidSha256;
 
     var src_buf: [512]u8 = undefined;
-    const src = try cacheDir(&src_buf, prefix, sha);
+    const src = try cacheDir(&src_buf, prefix, RELOC_LOGIC_VERSION, sha);
     std.Io.Dir.accessAbsolute(io, src, .{}) catch return RelocatedStoreError.MaterializeFailed;
 
     var parent_buf: [512]u8 = undefined;
@@ -175,7 +187,7 @@ pub fn materialize(
 pub fn remove(io: std.Io, prefix: []const u8, sha: []const u8) RelocatedStoreError!void {
     if (!isValidSha256(sha)) return RelocatedStoreError.InvalidSha256;
     var buf: [512]u8 = undefined;
-    const dir = try cacheDir(&buf, prefix, sha);
+    const dir = try cacheDir(&buf, prefix, RELOC_LOGIC_VERSION, sha);
     std.Io.Dir.cwd().deleteTree(io, dir) catch return;
 }
 
@@ -400,23 +412,15 @@ test "saveFresh cleans the tempdir on the race-loss branch" {
 
     // Force the race-loss branch: pre-create dst so saveFresh's second
     // accessAbsolute(dst) succeeds, skipping the rename and falling through.
-    const dst = try std.fmt.allocPrint(
-        testing.allocator,
-        "{s}/store-relocated/{s}",
-        .{ prefix, valid_sha_for_tests },
-    );
-    defer testing.allocator.free(dst);
+    var dst_buf: [512]u8 = undefined;
+    const dst = try cacheDir(&dst_buf, prefix, RELOC_LOGIC_VERSION, valid_sha_for_tests);
     try std.Io.Dir.cwd().createDirPath(testIo(), dst);
 
     try saveFresh(testIo(), testing.allocator, prefix, "rl", "1.0", dst);
 
-    // Race winner kept dst; the loser's tempdir must not survive.
-    const store_root = try std.fmt.allocPrint(
-        testing.allocator,
-        "{s}/store-relocated",
-        .{prefix},
-    );
-    defer testing.allocator.free(store_root);
+    // Race winner kept dst; the loser's tempdir must not survive. The temp is
+    // a sibling of dst, so scan dst's parent (the versioned segment dir).
+    const store_root = std.fs.path.dirname(dst).?;
     var root_dir = try std.Io.Dir.openDirAbsolute(testIo(), store_root, .{ .iterate = true });
     defer root_dir.close(testIo());
     var iter = root_dir.iterate();
@@ -440,4 +444,75 @@ test "remove deletes the cache entry" {
 
     // remove on a missing entry is an idempotent no-op success.
     try remove(testIo(), prefix, valid_sha_for_tests);
+}
+
+// ── Relocation-logic version keying ─────────────────────────────────────────
+
+test "same sha under two logic versions resolves to distinct paths" {
+    var a_buf: [512]u8 = undefined;
+    var b_buf: [512]u8 = undefined;
+    const a = try cacheDir(&a_buf, "/opt/malt", 1, valid_sha_for_tests);
+    const b = try cacheDir(&b_buf, "/opt/malt", 2, valid_sha_for_tests);
+    try testing.expect(!std.mem.eql(u8, a, b));
+    try testing.expect(std.mem.indexOf(u8, a, "/v1/") != null);
+    try testing.expect(std.mem.indexOf(u8, b, "/v2/") != null);
+}
+
+test "save nests the entry under the current version, not the bare sha path" {
+    const prefix = try tmpPrefixForTests(testing.allocator, "versioned_layout");
+    defer {
+        std.Io.Dir.cwd().deleteTree(testIo(), prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    try buildKegForTests(testing.allocator, prefix, "ver", "1.0");
+    try save(testIo(), testing.allocator, prefix, valid_sha_for_tests, "ver", "1.0");
+    try testing.expect(has(testIo(), prefix, valid_sha_for_tests));
+
+    // The old unversioned layout (`store-relocated/<sha>`) must not be produced —
+    // a logic change would otherwise serve that stale entry forever.
+    const bare = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/store-relocated/{s}",
+        .{ prefix, valid_sha_for_tests },
+    );
+    defer testing.allocator.free(bare);
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(testIo(), bare, .{}));
+
+    // The entry lives under the current version segment.
+    var ver_buf: [512]u8 = undefined;
+    const versioned = try cacheDir(&ver_buf, prefix, RELOC_LOGIC_VERSION, valid_sha_for_tests);
+    try std.Io.Dir.accessAbsolute(testIo(), versioned, .{});
+}
+
+test "has misses an entry saved under a different logic version" {
+    const prefix = try tmpPrefixForTests(testing.allocator, "version_miss");
+    defer {
+        std.Io.Dir.cwd().deleteTree(testIo(), prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    // Seed an entry under a neighbouring logic version (simulating a bump).
+    var buf: [512]u8 = undefined;
+    const other = try cacheDir(&buf, prefix, RELOC_LOGIC_VERSION +% 1, valid_sha_for_tests);
+    try std.Io.Dir.cwd().createDirPath(testIo(), other);
+
+    // `has` probes the current version only, so the neighbour is a miss.
+    try testing.expect(!has(testIo(), prefix, valid_sha_for_tests));
+}
+
+test "save is not shadowed by a leftover entry from another version" {
+    const prefix = try tmpPrefixForTests(testing.allocator, "version_no_shadow");
+    defer {
+        std.Io.Dir.cwd().deleteTree(testIo(), prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    // A stale entry from a previous logic version sits on disk.
+    var buf: [512]u8 = undefined;
+    const other = try cacheDir(&buf, prefix, RELOC_LOGIC_VERSION +% 1, valid_sha_for_tests);
+    try std.Io.Dir.cwd().createDirPath(testIo(), other);
+
+    // The current-version save must still run (its idempotency check targets
+    // the current version), so a bump can never be shadowed by the leftover.
+    try buildKegForTests(testing.allocator, prefix, "ns", "1.0");
+    try save(testIo(), testing.allocator, prefix, valid_sha_for_tests, "ns", "1.0");
+    try testing.expect(has(testIo(), prefix, valid_sha_for_tests));
 }

--- a/src/core/relocated_store.zig
+++ b/src/core/relocated_store.zig
@@ -15,6 +15,7 @@
 
 const std = @import("std");
 const clonefile = @import("../fs/clonefile.zig");
+const dirsize = @import("../fs/dirsize.zig");
 
 pub const RelocatedStoreError = error{
     InvalidSha256,
@@ -95,7 +96,11 @@ pub fn save(
     // the loser would otherwise fail at `renameAbsolute` below.
     std.Io.Dir.accessAbsolute(io, dst, .{}) catch {
         // Not present yet — proceed with snapshot.
-        return saveFresh(io, allocator, prefix, name, version, dst);
+        try saveFresh(io, allocator, prefix, name, version, dst);
+        // A fresh save under the current version is the natural point to
+        // reclaim kegs orphaned by a past logic-version bump. Best-effort.
+        _ = reapStaleVersions(io, allocator, prefix, true);
+        return;
     };
     return;
 }
@@ -189,6 +194,59 @@ pub fn remove(io: std.Io, prefix: []const u8, sha: []const u8) RelocatedStoreErr
     var buf: [512]u8 = undefined;
     const dir = try cacheDir(&buf, prefix, RELOC_LOGIC_VERSION, sha);
     std.Io.Dir.cwd().deleteTree(io, dir) catch return;
+}
+
+pub const Reaped = struct { removed: u32 = 0, bytes: u64 = 0 };
+
+/// Reclaim relocated kegs left under a superseded logic version: delete every
+/// `store-relocated/v<M>/` tree whose M != `RELOC_LOGIC_VERSION` (with
+/// `do_remove` false, only measure them, for a `purge --dry-run` preview).
+/// Best-effort — unreadable or undeletable entries are skipped so a partial
+/// failure never aborts the caller (an install's opportunistic sweep or
+/// `purge`). Race-safe: same-version peers only ever touch the current
+/// `v<N>/`, so an older version has no live reader to disturb.
+pub fn reapStaleVersions(io: std.Io, allocator: std.mem.Allocator, prefix: []const u8, do_remove: bool) Reaped {
+    var root_buf: [512]u8 = undefined;
+    const root = std.fmt.bufPrint(&root_buf, "{s}/store-relocated", .{prefix}) catch return .{};
+    var dir = std.Io.Dir.openDirAbsolute(io, root, .{ .iterate = true }) catch return .{};
+    defer dir.close(io);
+
+    // Collect stale segment names before deleting — mutating a directory
+    // mid-iteration can invalidate its cursor.
+    var stale: std.ArrayList([]u8) = .empty;
+    defer {
+        for (stale.items) |n| allocator.free(n);
+        stale.deinit(allocator);
+    }
+    var it = dir.iterate();
+    while (it.next(io) catch null) |entry| {
+        if (entry.kind != .directory) continue;
+        const ver = parseVersionSegment(entry.name) orelse continue;
+        if (ver == RELOC_LOGIC_VERSION) continue;
+        const owned = allocator.dupe(u8, entry.name) catch continue;
+        stale.append(allocator, owned) catch {
+            allocator.free(owned);
+            continue;
+        };
+    }
+
+    var reaped: Reaped = .{};
+    for (stale.items) |name| {
+        var child_buf: [512]u8 = undefined;
+        const child = std.fmt.bufPrint(&child_buf, "{s}/{s}", .{ root, name }) catch continue;
+        const bytes = dirsize.dirSizeBytes(io, child);
+        if (do_remove) std.Io.Dir.cwd().deleteTree(io, child) catch continue;
+        reaped.removed += 1;
+        reaped.bytes +|= bytes;
+    }
+    return reaped;
+}
+
+/// Parse a `v<digits>` cache segment name into its version, else null so
+/// foreign entries at the store root are never touched.
+fn parseVersionSegment(name: []const u8) ?u32 {
+    if (name.len < 2 or name[0] != 'v') return null;
+    return std.fmt.parseInt(u32, name[1..], 10) catch null;
 }
 
 // ---------------------------------------------------------------------------
@@ -515,4 +573,83 @@ test "save is not shadowed by a leftover entry from another version" {
     try buildKegForTests(testing.allocator, prefix, "ns", "1.0");
     try save(testIo(), testing.allocator, prefix, valid_sha_for_tests, "ns", "1.0");
     try testing.expect(has(testIo(), prefix, valid_sha_for_tests));
+}
+
+test "reapStaleVersions removes prior-version trees and keeps the current one" {
+    const prefix = try tmpPrefixForTests(testing.allocator, "reap");
+    defer {
+        std.Io.Dir.cwd().deleteTree(testIo(), prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    // One current-version entry and two stale ones from past bumps.
+    try buildKegForTests(testing.allocator, prefix, "cur", "1.0");
+    try save(testIo(), testing.allocator, prefix, valid_sha_for_tests, "cur", "1.0");
+    var b1: [512]u8 = undefined;
+    var b2: [512]u8 = undefined;
+    const old_a = try cacheDir(&b1, prefix, RELOC_LOGIC_VERSION +% 1, valid_sha_for_tests);
+    const old_b = try cacheDir(&b2, prefix, RELOC_LOGIC_VERSION +% 2, valid_sha_for_tests);
+    try std.Io.Dir.cwd().createDirPath(testIo(), old_a);
+    try std.Io.Dir.cwd().createDirPath(testIo(), old_b);
+
+    const reaped = reapStaleVersions(testIo(), testing.allocator, prefix, true);
+    try testing.expectEqual(@as(u32, 2), reaped.removed);
+
+    // Stale gone, current survives.
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(testIo(), old_a, .{}));
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(testIo(), old_b, .{}));
+    try testing.expect(has(testIo(), prefix, valid_sha_for_tests));
+}
+
+test "reapStaleVersions with do_remove=false measures without deleting" {
+    const prefix = try tmpPrefixForTests(testing.allocator, "reap_dry");
+    defer {
+        std.Io.Dir.cwd().deleteTree(testIo(), prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    var buf: [512]u8 = undefined;
+    const old = try cacheDir(&buf, prefix, RELOC_LOGIC_VERSION +% 1, valid_sha_for_tests);
+    try std.Io.Dir.cwd().createDirPath(testIo(), old);
+    // A real file so the byte count is non-zero.
+    try writeFileForTests(testing.allocator, old, "bin/tool", fixture_script);
+
+    const reaped = reapStaleVersions(testIo(), testing.allocator, prefix, false);
+    try testing.expectEqual(@as(u32, 1), reaped.removed);
+    try testing.expect(reaped.bytes > 0);
+    // Dry-run must not delete.
+    try std.Io.Dir.accessAbsolute(testIo(), old, .{});
+}
+
+test "reapStaleVersions ignores foreign entries and a missing store" {
+    const prefix = try tmpPrefixForTests(testing.allocator, "reap_foreign");
+    defer {
+        std.Io.Dir.cwd().deleteTree(testIo(), prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    // No store-relocated dir yet → no-op, no error.
+    try testing.expectEqual(@as(u32, 0), reapStaleVersions(testIo(), testing.allocator, prefix, true).removed);
+
+    // A non-`v<digits>` sibling must never be touched.
+    const foreign = try std.fmt.allocPrint(testing.allocator, "{s}/store-relocated/notes", .{prefix});
+    defer testing.allocator.free(foreign);
+    try std.Io.Dir.cwd().createDirPath(testIo(), foreign);
+    try testing.expectEqual(@as(u32, 0), reapStaleVersions(testIo(), testing.allocator, prefix, true).removed);
+    try std.Io.Dir.accessAbsolute(testIo(), foreign, .{});
+}
+
+test "save self-heals a prior-version entry" {
+    const prefix = try tmpPrefixForTests(testing.allocator, "save_selfheal");
+    defer {
+        std.Io.Dir.cwd().deleteTree(testIo(), prefix) catch {};
+        testing.allocator.free(prefix);
+    }
+    // A stale entry from a past bump is present before the install.
+    var buf: [512]u8 = undefined;
+    const old = try cacheDir(&buf, prefix, RELOC_LOGIC_VERSION +% 1, valid_sha_for_tests);
+    try std.Io.Dir.cwd().createDirPath(testIo(), old);
+
+    // A fresh save under the current version reclaims it opportunistically.
+    try buildKegForTests(testing.allocator, prefix, "heal", "1.0");
+    try save(testIo(), testing.allocator, prefix, valid_sha_for_tests, "heal", "1.0");
+    try testing.expect(has(testIo(), prefix, valid_sha_for_tests));
+    try testing.expectError(error.FileNotFound, std.Io.Dir.accessAbsolute(testIo(), old, .{}));
 }


### PR DESCRIPTION
## Description

The post-relocation keg cache keyed entries on the bottle sha256 alone, but the cached bytes are the output of malt's relocation rules (placeholder substitution + `install_name_tool` + ad-hoc codesign), not just the bottle. A change to those rules - a new placeholder token, a widened path rewrite, a patcher fix - would serve the *previously* relocated keg on a warm reinstall of
an unchanged bottle, so the fix would silently not apply to already-cached bottles.

The cache key now carries a relocation-logic version: `store-relocated/v<N>/<sha>`.
Bumping the single `RELOC_LOGIC_VERSION` constant (next to a doc comment listing
what invalidates it) turns every prior entry into a cache miss, forcing correct re-relocation.

Versioning creates orphaned `v<N-1>/` trees on disk, and the relocated store is path-only (DB-independent), so neither `purge --store-orphans` nor `doctor` reclaimed them. Those trees are now reclaimed two ways:

- **Self-healing** -  a fresh install's snapshot opportunistically sweeps stale sibling versions, so the next install after a bump reclaims everything.
- **On demand** - folded into the `--cache` purge scope, so
  `purge --cache` / `--housekeeping` / `cleanup` reap them (dry-run aware, reports freed bytes).

## Related Issue

- None

## Notes for Reviewers

- None