### PR TITLE
perf(outdated): warm the snapshot from the recompute's entries instead of re-auditing

### DIFF
--- a/scripts/regressions/outdated-recompute-warms-snapshot-not-reaudit.sh
+++ b/scripts/regressions/outdated-recompute-warms-snapshot-not-reaudit.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Regression: `mt outdated`'s live recompute warms the shared `outdated.json`
+# snapshot from the entries it just audited, instead of re-auditing the full
+# keg set a second time inside `refreshSnapshot`.
+#
+# The redundant second audit is only observable as extra network traffic (a
+# duplicate tap-HEAD GET per tap), and the mirror layer is HTTPS-only with no
+# local injection seam — so the *count* of audits cannot be asserted
+# hermetically. What this pins hermetically is the observable contract the
+# warm must preserve, with zero kegs => no API calls => no network:
+#
+#   1. Full recompute (no scope flags) writes the snapshot: a pre-seeded bogus
+#      snapshot is overwritten by the recompute's own (empty) result.
+#   2. Narrowed recompute (`--pinned-only`) writes NO snapshot: warming from a
+#      partial audit would make the next reader under-report, so the bogus
+#      snapshot is left untouched.
+#
+# If the warm were dropped, (1) fails (bogus entry survives); if the
+# full-keg-only gate were lost, (2) fails (bogus entry overwritten).
+#
+# Usage: scripts/regressions/outdated-recompute-warms-snapshot-not-reaudit.sh
+# Requirements: a built malt binary at $MALT_BIN or zig-out/bin/malt.
+# No network access required.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+PREFIX=$(mktemp -d -t malt_outdated_warm.XXXXXX)
+trap 'rm -rf "$PREFIX"' EXIT
+export MALT_PREFIX="$PREFIX"
+export MALT_CACHE="$PREFIX/cache"
+unset MALT_OFFLINE MALT_OUTDATED_MAX_AGE NO_COLOR CI
+
+SNAP="$MALT_CACHE/outdated.json"
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+# Zero kegs: `mt list` migrates the schema only when db/ exists.
+mkdir -p "$PREFIX/db" "$MALT_CACHE"
+"$BIN" list >/dev/null 2>&1 || true
+
+# Seed a snapshot generated `$1` seconds ago carrying a bogus entry. With no
+# kegs the entry never survives a recompute, so it is purely a marker for
+# "was this snapshot overwritten by the recompute, or left alone?".
+seed_snapshot() {
+  local age_secs="$1" gen_ms
+  gen_ms=$((($(date +%s) - age_secs) * 1000))
+  printf '{"version":2,"generated_at_ms":%s,"formulas":[{"name":"alpha","installed":"1.0","latest":"9.9"}],"casks":[]}' \
+    "$gen_ms" >"$SNAP"
+}
+
+# (1) Full recompute (stale snapshot => recompute) warms the snapshot from its
+# own audit, overwriting the bogus marker.
+seed_snapshot 600
+"$BIN" outdated >/dev/null 2>&1 || true
+if grep -q '9.9' "$SNAP"; then
+  fail "full recompute did not warm the snapshot — the bogus marker survived (warm dropped)"
+fi
+pass "full recompute warms the snapshot (bogus marker overwritten)"
+
+# (2) Narrowed recompute (--pinned-only forces a recompute) must NOT warm: a
+# partial audit would persist a snapshot the next reader trusts as complete.
+seed_snapshot 600
+"$BIN" outdated --pinned-only >/dev/null 2>&1 || true
+if ! grep -q '9.9' "$SNAP"; then
+  fail "narrowed recompute overwrote the snapshot — a partial audit was persisted (gate lost)"
+fi
+pass "narrowed recompute leaves the snapshot untouched (no partial warm)"
+
+printf '\n\xe2\x9c\x94 outdated recompute warm-not-reaudit regression passed\n'

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -464,6 +464,130 @@ test "summaryMessage picks the message that matches the active scope" {
     );
 }
 
+test "warmSnapshotFromRecompute writes the in-hand entries on a full-keg walk" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var base_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_dir = base_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &base_buf)];
+
+    const formulas = [_]OutdatedEntry{
+        .{ .name = @constCast("wget"), .installed = @constCast("1.21.3"), .latest = @constCast("1.21.4") },
+    };
+    const casks = [_]OutdatedEntry{
+        .{ .name = @constCast("firefox"), .installed = @constCast("120.0"), .latest = @constCast("121.0") },
+    };
+
+    warmSnapshotFromRecompute(&ctx, std.testing.allocator, cache_dir, .all, .{}, &formulas, &casks);
+
+    const read = readSnapshot(io, std.testing.allocator, cache_dir) orelse
+        return error.SnapshotUnreadable;
+    defer snap_mod.freeSnapshot(std.testing.allocator, read);
+    try std.testing.expectEqual(@as(usize, 1), read.formulas.len);
+    try std.testing.expectEqualStrings("wget", read.formulas[0].name);
+    try std.testing.expectEqualStrings("1.21.4", read.formulas[0].latest);
+    try std.testing.expectEqual(@as(usize, 1), read.casks.len);
+    try std.testing.expectEqualStrings("firefox", read.casks[0].name);
+}
+
+test "warmSnapshotFromRecompute writes no snapshot on a narrowed walk" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var base_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_dir = base_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &base_buf)];
+
+    const formulas = [_]OutdatedEntry{
+        .{ .name = @constCast("wget"), .installed = @constCast("1.21.3"), .latest = @constCast("1.21.4") },
+    };
+
+    // A pinned/tap/formula-only walk is not the full keg set; warming from it
+    // would persist a partial snapshot the next reader would trust as complete.
+    warmSnapshotFromRecompute(&ctx, std.testing.allocator, cache_dir, .pinned_only, .{ .pinned_only = true }, &formulas, &.{});
+
+    try std.testing.expect(readSnapshot(io, std.testing.allocator, cache_dir) == null);
+}
+
+test "warmSnapshotFromRecompute gate is closed for every narrowed walk, not just pinned" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+
+    const entries = [_]OutdatedEntry{
+        .{ .name = @constCast("wget"), .installed = @constCast("1.21.3"), .latest = @constCast("1.21.4") },
+    };
+
+    // Every scope that audited a subset must leave the snapshot alone. Covering
+    // the whole switch guards against a future filter flipping the gate open.
+    const narrowed = [_]struct { filter: KegFilter, scope: ScopeFlags }{
+        .{ .filter = .all, .scope = .{ .formula_only = true } },
+        .{ .filter = .all, .scope = .{ .cask_only = true } },
+        .{ .filter = .{ .by_tap = "user/repo" }, .scope = .{ .tap = "user/repo" } },
+    };
+    for (narrowed) |case| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        var base_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const cache_dir = base_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &base_buf)];
+
+        warmSnapshotFromRecompute(&ctx, std.testing.allocator, cache_dir, case.filter, case.scope, &entries, &entries);
+        try std.testing.expect(readSnapshot(io, std.testing.allocator, cache_dir) == null);
+    }
+}
+
+test "warmSnapshotFromRecompute writes an empty snapshot when a full walk finds nothing outdated" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var base_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_dir = base_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &base_buf)];
+
+    // The zero-keg full recompute: an empty audit still writes, so a later
+    // cached read serves "nothing outdated" instead of a stale snapshot.
+    warmSnapshotFromRecompute(&ctx, std.testing.allocator, cache_dir, .all, .{}, &.{}, &.{});
+
+    const read = readSnapshot(io, std.testing.allocator, cache_dir) orelse
+        return error.SnapshotUnreadable;
+    defer snap_mod.freeSnapshot(std.testing.allocator, read);
+    try std.testing.expectEqual(@as(usize, 0), read.formulas.len);
+    try std.testing.expectEqual(@as(usize, 0), read.casks.len);
+}
+
+test "warmSnapshotFromRecompute swallows a write failure without crashing" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    const ctx: AppCtx = .{ .io = io, .environ = .empty };
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var base_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const base = base_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &base_buf)];
+
+    // Point cache_dir at a regular file so writing `<dir>/outdated.json` hits
+    // ENOTDIR. The best-effort gate must absorb the failure so a snapshot
+    // hiccup never sinks the recompute the user already saw, and leave nothing
+    // half-written behind.
+    (try tmp.dir.createFile(io, "not_a_dir", .{})).close(io);
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const file_as_dir = try std.fmt.bufPrint(&path_buf, "{s}/not_a_dir", .{base});
+    warmSnapshotFromRecompute(&ctx, std.testing.allocator, file_as_dir, .all, .{}, &.{}, &.{});
+    try std.testing.expect(readSnapshot(io, std.testing.allocator, file_as_dir) == null);
+}
+
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (help.showIfRequested(ctx, args, "outdated")) return;
 
@@ -726,15 +850,35 @@ fn recomputeAndEmit(
         .cask_rows = c_rows orelse &.{},
     });
 
-    // Refresh the snapshot only when we walked the full keg set; any
-    // narrowed recompute (pinned, tap, formula-only, cask-only) would
-    // mislead the next reader. Best-effort: a write failure shouldn't
-    // shadow the listing the user already saw.
+    // Warm the shared snapshot from the entries we just audited instead of
+    // re-auditing the same keg set inside `refreshSnapshot`.
+    warmSnapshotFromRecompute(ctx, allocator, cache_dir, filter, scope, f_entries orelse &.{}, c_entries orelse &.{});
+}
+
+fn warmSnapshotFromRecompute(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    cache_dir: []const u8,
+    filter: KegFilter,
+    scope: ScopeFlags,
+    f_entries: []const OutdatedEntry,
+    c_entries: []const OutdatedEntry,
+) void {
+    // Warm only from a full-keg walk. The snapshot's readers — the cached
+    // `mt outdated` serve path and the TUI Outdated tab — treat it as the
+    // whole outdated set: they filter it against the live DB but never
+    // re-expand it, so anything absent reads as "up to date". A narrowed
+    // recompute (pinned, tap, formula-only, cask-only) audits only a subset,
+    // so persisting it here would silently under-report every keg it skipped.
+    // `refresh_ok ⇒ full-keg audit` is the invariant that prevents that.
     const refresh_ok = switch (filter) {
         .all => !scope.cask_only and !scope.formula_only,
         .pinned_only, .by_tap => false,
     };
-    if (refresh_ok) {
-        refreshSnapshot(ctx, allocator, db, &api, cache_dir, workers_override) catch {};
-    }
+    if (!refresh_ok) return;
+
+    // Best-effort: a write failure must not shadow the listing the user
+    // already saw. The entries are the recompute's own audit, so this warms
+    // the snapshot without the second full audit `refreshSnapshot` would run.
+    writeSnapshotEntries(ctx, allocator, cache_dir, f_entries, c_entries) catch {};
 }


### PR DESCRIPTION
## Description

`mt outdated`'s live recompute audited the full keg set twice - once to print the results, then again inside the snapshot writer just to produce `outdated.json`, re-issuing a tap-HEAD GET per tap for data it already had. This warms the snapshot from the entries the recompute already computed, deleting the entire second audit.

Work removed per full `mt outdated`: one complete re-audit - two version-index reads and one tap-HEAD GET per distinct installed tap.

## Related Issue

- None

## Notes for Reviewers

- None