### PR TITLE
test(outdated): fix the cached-outdated regression harness to resolve c_sqlite

### DIFF
--- a/scripts/regressions/cached-outdated-drops-revision-bumped-packages.sh
+++ b/scripts/regressions/cached-outdated-drops-revision-bumped-packages.sh
@@ -14,25 +14,33 @@
 # snapshot entry. The harness must keep the entry (len == 1); the pre-fix code
 # drops it (len == 0) and the assertion fails.
 #
+# `intersectWithDb` transitively pulls SQLite, whose `c_sqlite` module only
+# exists inside the build graph — so the harness reuses the build's own wiring
+# (the `src/lib.zig` module root + translated C modules + vendored sqlite3.c)
+# rather than a raw `zig test` that can't resolve it. malt is a dependency
+# module, so only the driver's single assertion runs, not the whole suite.
+#
 # Exits 0 when the bug is absent, non-zero (with a clear message) when present.
 # No network required; finishes well under 30s.
 
 set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
 
-# The harness imports the module via a repo-relative path, so it must sit at the
-# repo root: outdated.zig's sibling imports (`../app_ctx.zig`, `../db/...`) only
-# resolve from inside the source tree's module boundary.
-HARNESS="$ROOT/.cached-outdated-revision-regression.zig"
-trap 'rm -f "$HARNESS"' EXIT
+# Translate the C-interop headers the malt module depends on, mirroring
+# build.zig's addTranslateC set (sqlite needs vendor/ on its include path).
+zig translate-c -I "$ROOT/vendor/" "$ROOT/c/sqlite.h" >"$TMP/c_sqlite.zig" 2>/dev/null
+zig translate-c "$ROOT/c/clonefile.h" >"$TMP/c_clonefile.zig" 2>/dev/null
+zig translate-c "$ROOT/c/mount.h" >"$TMP/c_mount.zig" 2>/dev/null
 
-cat >"$HARNESS" <<'ZIG'
+# A revisioned keg: DB carries bare version + revision; snapshot carries the
+# revision-qualified `installed`. The intersect must keep it listed.
+cat >"$TMP/driver.zig" <<'ZIG'
 const std = @import("std");
-const outdated = @import("src/cli/outdated.zig");
+const outdated = @import("malt").cli_outdated;
 
-// A revisioned keg: DB carries bare version + revision; snapshot carries the
-// revision-qualified `installed`. The intersect must keep it listed.
 test "cached outdated keeps a revision-bumped formula" {
     const a = std.testing.allocator;
     const rows = [_]outdated.KegRow{
@@ -58,7 +66,14 @@ test "cached outdated keeps a revision-bumped formula" {
 }
 ZIG
 
-if (cd "$ROOT" && zig test -OReleaseSafe "$HARNESS") >/dev/null 2>&1; then
+if zig test -OReleaseSafe \
+  --dep malt -Mroot="$TMP/driver.zig" \
+  --dep c_sqlite --dep c_clonefile --dep c_mount \
+  -Mmalt="$ROOT/src/lib.zig" -lc -I "$ROOT/vendor/" -I "$ROOT/c/" \
+  -cflags -DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_THREADSAFE=1 -DSQLITE_DQS=0 -- "$ROOT/vendor/sqlite3.c" \
+  -Mc_sqlite="$TMP/c_sqlite.zig" \
+  -Mc_clonefile="$TMP/c_clonefile.zig" \
+  -Mc_mount="$TMP/c_mount.zig" >/dev/null 2>&1; then
   echo "PASS: cached outdated keeps revision-bumped formulas"
 else
   echo "FAIL: cached outdated dropped a revision-bumped formula (intersect compared revision-qualified installed against bare version)" >&2


### PR DESCRIPTION
## Description

The `cached-outdated-drops-revision-bumped-packages` regression could not compile on any checkout, so the guard it provides was never actually running. Its standalone `zig test` harness imported `cli/outdated.zig`, which reaches `db/sqlite.zig` and the build-graph `c_sqlite` module a raw `zig test` cannot resolve.

This rebuilds the harness on the build system's own module wiring - `src/lib.zig` as the module root (so the `../../` sibling imports resolve), the translated C interop modules, and the vendored `sqlite3.c` - so the intersect assertion runs again. malt is a dependency module, so only the driver's single test executes, not the whole suite. Restores real, hermetic protection against cached `outdated` silently dropping revision-bumped formulas.

## Related Issue

- None

## Notes for Reviewers

- None