### PR TITLE
fix(upgrade): warm the Outdated snapshot even with third-party-tap kegs

### DIFF
--- a/scripts/regressions/upgrade-tap-formula-taint-upgrade-formula-taint.sh
+++ b/scripts/regressions/upgrade-tap-formula-taint-upgrade-formula-taint.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Regression: a `mt upgrade --dry-run` whose only "would-refresh" tap keg is
+# actually version-current (its tap HEAD moved without a version bump) no
+# longer poisons the whole snapshot warm. The dry-run resolves the tap's
+# `.rb` version, sees it matches the installed version, and warms a snapshot
+# that simply omits that keg — instead of tainting and discarding every
+# collected core/cask row.
+#
+# Pre-fix behaviour (the coverage gap this closes): the tap path decided
+# purely by repo HEAD sha, had no `.rb` version in scope, and set a
+# sink-wide taint. One tap keg vetoed the entire warm, so a box with any
+# third-party-tap keg got no warmed snapshot at all.
+#
+# Pins four contracts against a real tap (the tap HEAD + one `.rb` GET are
+# the only network the bug inherently needs; a classified network condition
+# skips-loud rather than failing):
+#   1. The full dry-run writes an outdated.json (the tap keg did NOT taint).
+#   2. That snapshot contains the genuinely-outdated core keg (coverage
+#      delivered — the valid rows are no longer collateral of the taint).
+#   3. That snapshot does NOT list the version-current tap keg (no
+#      over-report of a sha-only tap move).
+#   4. `mt outdated --json` (version truth) also omits the tap keg.
+#
+# Usage: scripts/regressions/upgrade-tap-formula-taint-upgrade-formula-taint.sh
+# Requirements: built malt at $MALT_BIN or zig-out/bin/malt; sqlite3 on PATH;
+# network access to the tap HEAD + its `.rb`.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+PREFIX=$(mktemp -d -t malt_tap_warm.XXXXXX)
+trap 'rm -rf "$PREFIX"' EXIT
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+unset MALT_OFFLINE MALT_OUTDATED_MAX_AGE MALT_CACHE CI
+
+DB="$PREFIX/db/malt.db"
+SNAP="$PREFIX/cache/outdated.json"
+API="$PREFIX/cache/api"
+mkdir -p "$PREFIX/db" "$API"
+
+# A stable third-party tap whose formula malt is known to fetch + parse
+# (URL-derived version, proven by tap_formula_url_version.sh).
+TAP="aeroxy/tap"
+NAME="ast-outline"
+CORE="regcore" # core keg seeded outdated via the on-disk API cache
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+skip() { printf '  - %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+is_network_blip() { grep -qE "rate limit|Network failure|Could not resolve|timed out" "$1"; }
+
+# --- Register the tap (real; writes owner/repo/url correctly) -------------
+"$BIN" list >/dev/null 2>&1 || true
+TAP_LOG="$PREFIX/tap.log"
+if ! "$BIN" tap "$TAP" >"$TAP_LOG" 2>&1; then
+  if is_network_blip "$TAP_LOG"; then
+    skip "${TAP}: tap registration hit a classified network condition"
+    exit 0
+  fi
+  tail -20 "$TAP_LOG" >&2
+  fail "${TAP}: tap registration failed for an unclassified reason"
+fi
+[[ -f "$DB" ]] || fail "expected DB at $DB after tap"
+
+# --- Seed the tap keg impossibly old, learn the real upstream version -----
+sqlite3 "$DB" "INSERT INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path) \
+  VALUES ('${NAME}', '${TAP}/${NAME}', '0.0.0', 0, '${TAP}', 'sha', '${PREFIX}/Cellar/${NAME}/0.0.0');"
+
+PROBE_LOG="$PREFIX/probe.log"
+PROBE_JSON=$("$BIN" outdated --json 2>"$PROBE_LOG" || true)
+if is_network_blip "$PROBE_LOG"; then
+  skip "outdated probe hit a classified network condition"
+  exit 0
+fi
+# Extract the tap keg's upstream `latest` from the outdated JSON.
+V=$(printf '%s' "$PROBE_JSON" |
+  grep -oE "\"name\":\"${NAME}\"[^}]*\"latest\":\"[^\"]*\"" |
+  grep -oE '"latest":"[^"]*"' | head -1 | sed 's/.*:"//; s/"$//')
+[[ -n "$V" ]] || {
+  skip "could not learn ${NAME} upstream version from outdated (tap shape changed?)"
+  exit 0
+}
+
+# --- Reseed the tap keg current (installed == upstream) -------------------
+sqlite3 "$DB" "UPDATE kegs SET version='${V}' WHERE name='${NAME}';"
+
+# --- Seed a core keg that is genuinely outdated (offline via API cache) ----
+sqlite3 "$DB" "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path) \
+  VALUES ('${CORE}', '${CORE}', '1.0', 'seedsha', '${PREFIX}/Cellar/${CORE}/1.0');"
+printf '{"name":"%s","versions":{"stable":"2.0"}}' "$CORE" >"$API/formula_${CORE}.json"
+
+# --- Force the tap HEAD to look moved -------------------------------------
+# Bogus cached sha so the real HEAD differs; stale etag so the conditional
+# GET returns 200 (a fresh real sha) instead of 304 (which would fall back
+# to the bogus cached sha and read as unchanged).
+sqlite3 "$DB" "UPDATE taps SET commit_sha='0000000000000000000000000000000000000000', head_etag='W/\"stale-force-200\"' WHERE name='${TAP}';"
+
+# --- The run under test ---------------------------------------------------
+rm -f "$SNAP"
+UP_LOG="$PREFIX/upgrade.log"
+"$BIN" upgrade --dry-run >"$UP_LOG" 2>&1 || true
+if is_network_blip "$UP_LOG"; then
+  skip "upgrade --dry-run hit a classified network condition"
+  exit 0
+fi
+
+# Invariant 1: the tap keg did not taint the warm — a snapshot was written.
+[[ -f "$SNAP" ]] ||
+  fail "dry-run warmed no snapshot: a version-current tap keg still taints the whole warm"
+pass "dry-run warmed a snapshot despite a sha-only tap move"
+
+# Invariant 2: the genuinely-outdated core keg made it into the warm.
+grep -q "\"name\":\"${CORE}\"" "$SNAP" ||
+  fail "warmed snapshot dropped the outdated core keg ${CORE}; got: $(cat "$SNAP")"
+pass "warmed snapshot covers the outdated core keg ${CORE}"
+
+# Invariant 3: the version-current tap keg is NOT over-reported in the warm.
+grep -q "\"name\":\"${NAME}\"" "$SNAP" &&
+  fail "warmed snapshot over-reports the sha-only-moved tap keg ${NAME} (installed==${V})"
+pass "warmed snapshot omits the version-current tap keg ${NAME}"
+
+# Invariant 4: version-truth outdated also omits the tap keg.
+OUT_JSON=$("$BIN" outdated --json 2>/dev/null || true)
+printf '%s' "$OUT_JSON" | grep -q "\"name\":\"${NAME}\"" &&
+  fail "outdated over-reports the sha-only-moved tap keg ${NAME}"
+pass "outdated omits the version-current tap keg ${NAME}"
+
+printf '\n\xe2\x9c\x94 tap-formula snapshot-warm regression passed\n'

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -768,10 +768,10 @@ fn tapRawLatestVersion(
     return tapVersionFromSubtrees(alloc, &http, environ, urls.forge, urls.raw_base, fresh_sha, name, subtrees, noun, tap_label);
 }
 
-/// Fetch the `.rb` from each `subtrees` layout in order (first 200 wins) and
-/// parse its `version`, else warn + null. Split out from `tapRawLatestVersion`
-/// so the per-layout fetch loop can be driven by a localhost server in tests,
-/// without the live HEAD resolve.
+/// Fetch the `.rb` via the shared `tap.fetchRawFile` leaf (first 200 wins) and
+/// parse its `version`, else warn + null. The fetch loop lives in `core/tap`
+/// so the upgrade dry-run shares it; the parse + messaging stay here (leaf is
+/// UI-agnostic). Driven by a localhost server in tests via `raw_base`.
 fn tapVersionFromSubtrees(
     alloc: std.mem.Allocator,
     http: *client_mod.HttpClient,
@@ -784,17 +784,19 @@ fn tapVersionFromSubtrees(
     noun: []const u8,
     tap_label: []const u8,
 ) ?[]u8 {
-    var last_status: u16 = 0;
-    for (subtrees) |subtree| {
-        var rb_url_buf: [512]u8 = undefined;
-        const rb_url = forge.rawFileUrl(&rb_url_buf, forge_kind, raw_base, sha, subtree, name) catch continue;
-
-        var rb_resp = tap_mod.getRawFile(http, environ, forge_kind, rb_url) catch {
-            warnTapCaskFetchFailed(tap_label, name, "Network failure while reading the .rb");
+    var fetch = tap_mod.fetchRawFile(http, environ, forge_kind, raw_base, sha, name, subtrees) catch {
+        warnTapCaskFetchFailed(tap_label, name, "Network failure while reading the .rb");
+        return null;
+    };
+    switch (fetch) {
+        .not_found => |status| {
+            var status_buf: [64]u8 = undefined;
+            const reason = std.fmt.bufPrint(&status_buf, "GitHub returned status {d} for the .rb", .{status}) catch "GitHub returned a non-200 status for the .rb";
+            warnTapCaskFetchFailed(tap_label, name, reason);
             return null;
-        };
-        defer rb_resp.deinit();
-        if (rb_resp.status == 200) {
+        },
+        .found => |*rb_resp| {
+            defer rb_resp.deinit();
             const rb_info = install_rb_parse_mod.parseRubyFormula(rb_resp.body) orelse {
                 var dsl_buf: [96]u8 = undefined;
                 const reason = std.fmt.bufPrint(&dsl_buf, "unsupported Ruby DSL shape — use `brew upgrade` for this {s}", .{noun}) catch "unsupported Ruby DSL shape";
@@ -806,15 +808,8 @@ fn tapVersionFromSubtrees(
             var ver_buf: [256]u8 = undefined;
             const qualified = formula_mod.pkgVersion(&ver_buf, rb_info.version, rb_info.revision) catch rb_info.version;
             return alloc.dupe(u8, qualified) catch null;
-        }
-        // Non-200 (likely a 404 for this layout) — try the next subtree.
-        last_status = rb_resp.status;
+        },
     }
-
-    var status_buf: [64]u8 = undefined;
-    const reason = std.fmt.bufPrint(&status_buf, "GitHub returned status {d} for the .rb", .{last_status}) catch "GitHub returned a non-200 status for the .rb";
-    warnTapCaskFetchFailed(tap_label, name, reason);
-    return null;
 }
 
 /// Tap cask: `Casks/<token>.rb` at the tap HEAD.

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -487,7 +487,7 @@ fn upgradeFormula(
     // before touching `formulae.brew.sh`. `old.tap` is owned and lives
     // until this function returns, so it is safe to pass across the call.
     if (!install_args_mod.isCoreTap(old.tap)) {
-        return upgradeTapFormula(ctx, allocator, name, old.tap, db, prefix, dry_run, force, audit_mode, tally, sink);
+        return upgradeTapFormula(ctx, allocator, name, old.tap, old.version, old.revision, db, prefix, dry_run, force, audit_mode, tally, sink);
     }
 
     // Reconstruct the revision-aware path label for the old keg so
@@ -686,6 +686,57 @@ fn upgradeFormula(
     if (tally) |t| t.upgraded += 1;
 }
 
+/// How a dry-run tap formula feeds the snapshot warm. `taint` degrades the
+/// whole run to a full recompute (never a partial warm); `skip` is a sha-only
+/// move the tap `.rb` proves current; `collect` is a genuine would-upgrade row.
+const TapWarmDecision = enum { collect, skip, taint };
+
+/// null `upstream` (fetch/parse failed) taints rather than skips: without a
+/// version we cannot prove the row current, and skipping it would silently
+/// under-report a genuinely-outdated tap keg — a taint re-audits everything
+/// instead. A match is current (skip); a difference is outdated (collect),
+/// mirroring the audit's `!eql` filter so both agree on tap version-truth.
+fn tapWarmDecision(upstream: ?[]const u8, installed: []const u8) TapWarmDecision {
+    const up = upstream orelse return .taint;
+    return if (std.mem.eql(u8, up, installed)) .skip else .collect;
+}
+
+test "tapWarmDecision: null taints, equal skips, differing collects" {
+    try std.testing.expectEqual(TapWarmDecision.taint, tapWarmDecision(null, "1.2.0"));
+    try std.testing.expectEqual(TapWarmDecision.skip, tapWarmDecision("1.2.0", "1.2.0"));
+    try std.testing.expectEqual(TapWarmDecision.collect, tapWarmDecision("1.3.0", "1.2.0"));
+    // Revision-qualified strings compare byte-for-byte, so a revision-only
+    // bump (`1.2.0` vs `1.2.0_1`) is a collect, not a skip.
+    try std.testing.expectEqual(TapWarmDecision.collect, tapWarmDecision("1.2.0_1", "1.2.0"));
+}
+
+/// Resolve a tap formula's upstream version from its `.rb` at `sha`, for the
+/// dry-run warm. Reuses the shared `tap.fetchRawFile` leaf; the parse is local
+/// (the outdated audit taints differently, so per-caller failure policy stays
+/// here). Null on any fetch/parse failure so the caller degrades to a taint.
+fn tapFormulaUpstreamVersion(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    forge_kind: forge.Forge,
+    raw_base: []const u8,
+    sha: []const u8,
+    name: []const u8,
+) ?[]u8 {
+    var http = client_mod.HttpClient.init(ctx.io, ctx.environ, allocator);
+    defer http.deinit();
+    var fetch = tap_mod.fetchRawFile(&http, ctx.environ, forge_kind, raw_base, sha, name, &.{ .formula, .formula_root }) catch return null;
+    switch (fetch) {
+        .not_found => return null,
+        .found => |*resp| {
+            defer resp.deinit();
+            const rb_info = install_rb_parse_mod.parseRubyFormula(resp.body) orelse return null;
+            var ver_buf: [256]u8 = undefined;
+            const qualified = formula_mod.pkgVersion(&ver_buf, rb_info.version, rb_info.revision) catch rb_info.version;
+            return allocator.dupe(u8, qualified) catch null;
+        },
+    }
+}
+
 /// Upgrade a tap-installed formula. The reported `tap_label` is
 /// `<user>/<repo>` (the value `kegs.tap` carries for everything that did
 /// not come from `homebrew/core`). We re-resolve the tap's HEAD commit,
@@ -698,6 +749,8 @@ fn upgradeTapFormula(
     allocator: std.mem.Allocator,
     name: []const u8,
     tap_label: []const u8,
+    installed_version: []const u8,
+    installed_revision: i64,
     db: *sqlite.Database,
     prefix: [:0]const u8,
     dry_run: bool,
@@ -763,10 +816,21 @@ fn upgradeTapFormula(
 
     if (dry_run) {
         if (tally) |t| t.would_upgrade += 1;
-        // Tap formulae decide by commit sha, not version — no snapshot-shaped
-        // `latest` exists here, so taint and skip the warm rather than persist
-        // an under-reporting snapshot.
-        if (sink) |s| s.tainted = true;
+        // The would-upgrade set is sha-driven (so `mt upgrade` still refreshes
+        // on any HEAD move); the snapshot warm must be version-truth to match
+        // `mt outdated`. Resolve the tap `.rb` version so a sha-only move no
+        // longer taints the whole warm — only a real version bump lands a row.
+        if (sink) |s| {
+            var qbuf: [256]u8 = undefined;
+            const installed = formula_mod.pkgVersion(&qbuf, installed_version, installed_revision) catch installed_version;
+            const upstream = tapFormulaUpstreamVersion(ctx, allocator, urls.forge, urls.raw_base, fresh_sha, name);
+            defer if (upstream) |u| allocator.free(u);
+            switch (tapWarmDecision(upstream, installed)) {
+                .taint => s.tainted = true, // fetch/parse failure → full recompute
+                .skip => {}, // sha-only move: legitimately current
+                .collect => s.collectFormula(name, installed_version, installed_revision, upstream.?),
+            }
+        }
         const short_len = @min(@as(usize, 8), fresh_sha.len);
         output.info("Dry run: would refresh tap {s} to {s} for {s}", .{ tap_label, fresh_sha[0..short_len], name });
         output.emitNdjsonEvent(.would_install, name, null);

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -1407,3 +1407,156 @@ pub fn getRawFile(
     }
     return http.get(rb_url);
 }
+
+/// Outcome of probing a tap `.rb` across candidate layouts.
+pub const RawFetch = union(enum) {
+    /// The first layout that answered HTTP 200. Caller owns it and must
+    /// `deinit()` after reading `.body`.
+    found: client_mod.Response,
+    /// No layout answered 200; carries the last layout's status (usually
+    /// 404). A transport failure surfaces as the error union instead, so the
+    /// caller can tell "no such file" from "couldn't reach the forge".
+    not_found: u16,
+};
+
+/// Fetch a tap package's `.rb` by trying each `subtree` layout at `sha` in
+/// order; the first HTTP 200 wins. The "try the next layout" decision keys
+/// only on HTTP status, so the Ruby parse stays in the caller — keeping this
+/// leaf UI-agnostic and shared by both the outdated audit and the upgrade
+/// dry-run (a shared home avoids an `upgrade → outdated` command edge).
+pub fn fetchRawFile(
+    http: *client_mod.HttpClient,
+    environ: std.process.Environ,
+    forge_kind: forge.Forge,
+    raw_base: []const u8,
+    sha: []const u8,
+    name: []const u8,
+    subtrees: []const forge.RawKind,
+) !RawFetch {
+    var last_status: u16 = 0;
+    for (subtrees) |subtree| {
+        var rb_url_buf: [512]u8 = undefined;
+        const rb_url = forge.rawFileUrl(&rb_url_buf, forge_kind, raw_base, sha, subtree, name) catch continue;
+
+        var rb_resp = try getRawFile(http, environ, forge_kind, rb_url);
+        if (rb_resp.status == 200) return .{ .found = rb_resp };
+        last_status = rb_resp.status;
+        rb_resp.deinit();
+    }
+    return .{ .not_found = last_status };
+}
+
+// Serves `status` for the first `misses` requests, then 200 with `body` — so a
+// test can exercise the layout fallback (404 → 404 → 200) or an all-miss run.
+const RawFileTestServer = struct {
+    io: std.Io,
+    listener: *std.Io.net.Server,
+    body: []const u8,
+    miss_status: std.http.Status,
+    misses: usize,
+    seen: std.atomic.Value(usize),
+
+    fn serve(self: *RawFileTestServer) void {
+        while (true) {
+            const stream = self.listener.accept(self.io) catch return;
+            defer stream.close(self.io);
+            var rbuf: [16 * 1024]u8 = undefined;
+            var wbuf: [16 * 1024]u8 = undefined;
+            var reader = stream.reader(self.io, &rbuf);
+            var writer = stream.writer(self.io, &wbuf);
+            var srv = std.http.Server.init(&reader.interface, &writer.interface);
+            var req = srv.receiveHead() catch return;
+            const n = self.seen.fetchAdd(1, .monotonic);
+            if (n < self.misses) {
+                req.respond("", .{ .status = self.miss_status }) catch return;
+            } else {
+                req.respond(self.body, .{ .status = .ok }) catch return;
+            }
+        }
+    }
+};
+
+test "fetchRawFile returns the first 200 across layouts" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+
+    // First layout (Formula/) 404s; the root layout serves.
+    var srv = RawFileTestServer{ .io = io, .listener = &listener, .body = "ok-body", .miss_status = .not_found, .misses = 1, .seen = std.atomic.Value(usize).init(0) };
+    const thread = try std.Thread.spawn(.{}, RawFileTestServer.serve, .{&srv});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client_mod.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    var base_buf: [64]u8 = undefined;
+    const raw_base = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    var fetch = try fetchRawFile(&http, std.process.Environ.empty, .github, raw_base, "deadbeef", "pkg", &.{ .formula, .formula_root });
+    listener.deinit(io);
+    thread.join();
+
+    switch (fetch) {
+        .found => |*resp| {
+            defer resp.deinit();
+            try std.testing.expectEqualStrings("ok-body", resp.body);
+        },
+        .not_found => return error.TestUnexpectedResult,
+    }
+}
+
+test "fetchRawFile reports not_found when no layout hits" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+
+    // Both layouts 404 (misses exceeds the subtree count).
+    var srv = RawFileTestServer{ .io = io, .listener = &listener, .body = "", .miss_status = .not_found, .misses = 8, .seen = std.atomic.Value(usize).init(0) };
+    const thread = try std.Thread.spawn(.{}, RawFileTestServer.serve, .{&srv});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client_mod.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    var base_buf: [64]u8 = undefined;
+    const raw_base = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    const fetch = try fetchRawFile(&http, std.process.Environ.empty, .github, raw_base, "deadbeef", "pkg", &.{ .formula, .formula_root });
+    listener.deinit(io);
+    thread.join();
+
+    try std.testing.expectEqual(@as(u16, 404), fetch.not_found);
+}
+
+test "fetchRawFile surfaces a transport failure as an error, not not_found" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // Claim a port, then release it so the connect is refused — a transport
+    // failure must reach the caller as the error union, distinct from a
+    // not_found (which means the forge answered, just not 200).
+    var addr = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+    listener.deinit(io);
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client_mod.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    var base_buf: [64]u8 = undefined;
+    const raw_base = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    if (fetchRawFile(&http, std.process.Environ.empty, .github, raw_base, "deadbeef", "pkg", &.{.formula})) |_| {
+        return error.TestExpectedTransportError; // a refused connect must not read as not_found
+    } else |_| {}
+}


### PR DESCRIPTION
## Description

On any box with a third-party-tap keg installed, `mt upgrade --dry-run` warmed **nothing** — so the TUI Outdated tab fell back to a slow live recompute ("Loading") instead of rendering instantly.

The tap-formula dry-run path decided purely by the tap's repo HEAD sha and had no upstream version in scope, so it set a sink-wide taint. That taint vetoed the *entire* snapshot write — one tap keg discarded every valid core-formula and cask row the run had already collected.

This resolves the tap `.rb` version during the dry-run and compares it to the installed version, exactly as `mt outdated` does:

- sha-only tap move (version unchanged) → the row is current, emit nothing, no taint;
- real version bump → collect a would-upgrade row;
- fetch/parse failure → keep the taint as a safe fallback (degrade to full recompute, never a partial warm).

`mt upgrade` (non-dry-run) is unchanged: it still re-materializes on any HEAD move, and never warms. Casks keep their existing taint.

The tap `.rb` fetch loop is extracted into a shared `core/tap.fetchRawFile` leaf so both the outdated audit and the upgrade dry-run reuse it — no `upgrade → outdated` command edge, zero new module edges.

## Related Issue

- None

## Notes for Reviewers

- None