### PR TITLE
fix(tui): open the Outdated tab instantly from the cached snapshot

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -265,6 +265,7 @@ pub fn build(b: *std.Build) void {
         "tests/tui_search_test.zig",
         "tests/tui_purity_test.zig",
         "tests/tui_selection_theme_test.zig",
+        "tests/tui_outdated_warm_read_test.zig",
     };
 
     const test_step = b.step("test", "Run all unit tests");

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -115,6 +115,7 @@ pub const tui_json_list = @import("tui/json/list.zig");
 pub const tui_json_outdated = @import("tui/json/outdated.zig");
 pub const tui_json_search = @import("tui/json/search.zig");
 pub const tui_json_services = @import("tui/json/services.zig");
+pub const tui_json_snapshot = @import("tui/json/snapshot.zig");
 pub const tui_keys = @import("tui/keys.zig");
 pub const tui_layout = @import("tui/layout.zig");
 pub const tui_scroll_list = @import("tui/scroll_list.zig");

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -837,6 +837,14 @@ pub fn run(io: std.Io, allocator: std.mem.Allocator, stderr: std.Io.File, enviro
     // the tab; its dirty flag is consumed once the fetch owns the load, so the
     // first entry doesn't spawn a duplicate audit. Enqueued through the pump like
     // any background read — the one interpreter path.
+    // Warm-read first: seed the tab from the last snapshot so it opens with data
+    // instead of a spinner; the audit below then refreshes it (pinned/tap fill in).
+    // Cache dir resolved locally (MALT_CACHE, else <prefix>/cache) so the TUI
+    // stays clear of the fs leaf.
+    var cache_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_dir: ?[]const u8 = std.process.Environ.getPosix(environ, "MALT_CACHE") orelse
+        (std.fmt.bufPrint(&cache_buf, "{s}/cache", .{prefix}) catch null);
+    if (cache_dir) |cd| outdated.warmRead(io, allocator, cd, &app.states.outdated, &app.storages.outdated, &app.shared);
     if (backgroundReadCmd(allocator, app.mt_path, .outdated)) |bg| try pump(io, allocator, &t, painter, &fetches, &app, &app.storages, bg);
     if (app.shared.tab_loading.contains(.outdated)) _ = takeDirty(&app, .outdated);
     try repaint(fd, &frame, allocator, &app); // first interactive frame: kegs + the outdated spinner

--- a/src/tui/json/snapshot.zig
+++ b/src/tui/json/snapshot.zig
@@ -1,0 +1,155 @@
+//! malt — parse the on-disk `outdated.json` snapshot into TUI outdated rows.
+//!
+//! Leaf module: imports only `std` and the sibling `--json` parser. Feeds the
+//! Outdated tab a warm paint the instant the dashboard opens, before the live
+//! `mt outdated` refresh lands. The snapshot carries no per-row `pinned`/`tap`
+//! (both are DB-derived at emit time), so rows come back unpinned and untagged
+//! — a provisional view the refresh corrects. Safe: `mt upgrade` enforces pins
+//! itself, so an unpinned provisional row can never be upgraded past its pin.
+
+const std = @import("std");
+const outdated_json = @import("outdated.zig");
+
+/// The snapshot's per-entry shape: name + versions only. `formulas`/`casks`
+/// default so a document missing either array still parses.
+const Entry = struct { name: []const u8, installed: []const u8, latest: []const u8 };
+const Snapshot = struct { formulas: []Entry = &.{}, casks: []Entry = &.{} };
+
+/// The `--json` wire row the sibling parser reads. `pinned`/`tap` take their
+/// safe defaults since the snapshot cannot supply them.
+const WireRow = struct {
+    name: []const u8,
+    installed: []const u8,
+    latest: []const u8,
+    type: []const u8,
+    pinned: bool = false,
+    tap: []const u8 = "",
+};
+const WireDoc = struct { outdated: []const WireRow };
+
+/// Parse snapshot bytes into `outdated_json.Parsed`. Re-emits the snapshot as
+/// the `--json` wire shape and delegates to the live parser, so the returned
+/// row storage and lifetime match the refresh path byte-for-byte (one `deinit`).
+pub fn parse(allocator: std.mem.Allocator, bytes: []const u8) outdated_json.Error!outdated_json.Parsed {
+    const snap = std.json.parseFromSlice(Snapshot, allocator, bytes, .{
+        .ignore_unknown_fields = true,
+    }) catch return error.BadJson;
+    defer snap.deinit();
+
+    var rows: std.ArrayList(WireRow) = .empty;
+    defer rows.deinit(allocator);
+    for (snap.value.formulas) |e| rows.append(allocator, wireRow(e, "formula")) catch return error.OutOfMemory;
+    for (snap.value.casks) |e| rows.append(allocator, wireRow(e, "cask")) catch return error.OutOfMemory;
+
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    std.json.Stringify.value(WireDoc{ .outdated = rows.items }, .{}, &aw.writer) catch return error.OutOfMemory;
+
+    // The live parser copies every string into its own arena, so `snap`/`aw`
+    // are free to release once it returns.
+    return outdated_json.parse(allocator, aw.written());
+}
+
+fn wireRow(e: Entry, kind: []const u8) WireRow {
+    return .{ .name = e.name, .installed = e.installed, .latest = e.latest, .type = kind };
+}
+
+/// Cap the warm-read: a snapshot is a handful of KB, so a larger file is
+/// corrupt and not worth loading before the live audit lands.
+const read_cap: u64 = 1 << 20;
+
+/// Read `{cache_dir}/outdated.json` and parse it, or null if absent, unreadable,
+/// or malformed — the caller then just lets the live audit populate the tab.
+pub fn read(io: std.Io, allocator: std.mem.Allocator, cache_dir: []const u8) ?outdated_json.Parsed {
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/outdated.json", .{cache_dir}) catch return null;
+    const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return null;
+    defer file.close(io);
+    const st = file.stat(io) catch return null;
+    const size: usize = @intCast(@min(read_cap, st.size));
+    const bytes = allocator.alloc(u8, size) catch return null;
+    defer allocator.free(bytes);
+    const n = file.readPositionalAll(io, bytes, 0) catch return null;
+    return parse(allocator, bytes[0..n]) catch null;
+}
+
+// ─── tests ───────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "parse maps formulas and casks to kinded rows, unpinned and untagged" {
+    const bytes =
+        \\{"version":2,"generated_at_ms":1700000000000,
+        \\"formulas":[{"name":"wget","installed":"1.24.5","latest":"1.25.0"}],
+        \\"casks":[{"name":"firefox","installed":"120.0","latest":"121.0"}]}
+    ;
+    var p = try parse(testing.allocator, bytes);
+    defer p.deinit();
+    try testing.expectEqual(@as(usize, 2), p.items.len);
+    // formulas come first, then casks.
+    try testing.expectEqualStrings("wget", p.items[0].name);
+    try testing.expectEqual(outdated_json.Kind.formula, p.items[0].kind);
+    try testing.expectEqualStrings("1.25.0", p.items[0].latest);
+    try testing.expectEqual(outdated_json.Kind.cask, p.items[1].kind);
+    // No snapshot field supplies these, so every warm row is safe-by-default.
+    try testing.expectEqual(false, p.items[0].pinned);
+    try testing.expectEqualStrings("", p.items[0].tap);
+}
+
+test "parse yields zero rows for an all-current snapshot" {
+    var p = try parse(testing.allocator, "{\"version\":2,\"generated_at_ms\":0,\"formulas\":[],\"casks\":[]}");
+    defer p.deinit();
+    try testing.expectEqual(@as(usize, 0), p.items.len);
+}
+
+test "parse tolerates a missing casks array" {
+    var p = try parse(testing.allocator, "{\"version\":2,\"generated_at_ms\":0,\"formulas\":[{\"name\":\"a\",\"installed\":\"1\",\"latest\":\"2\"}]}");
+    defer p.deinit();
+    try testing.expectEqual(@as(usize, 1), p.items.len);
+    try testing.expectEqual(outdated_json.Kind.formula, p.items[0].kind);
+}
+
+test "parse rejects malformed input as BadJson" {
+    try testing.expectError(error.BadJson, parse(testing.allocator, "not json"));
+    try testing.expectError(error.BadJson, parse(testing.allocator, ""));
+}
+
+test "read returns null when the snapshot file is absent" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    try testing.expect(read(threaded.io(), testing.allocator, "/nonexistent/malt/cache") == null);
+}
+
+test "read round-trips a snapshot written to a temp cache dir" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var base_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_dir = base_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &base_buf)];
+
+    var f = try tmp.dir.createFile(io, "outdated.json", .{});
+    try f.writeStreamingAll(io, "{\"version\":2,\"generated_at_ms\":0,\"formulas\":[{\"name\":\"tree\",\"installed\":\"2.1.0\",\"latest\":\"2.2.0\"}],\"casks\":[]}");
+    f.close(io);
+
+    var p = read(io, testing.allocator, cache_dir) orelse return error.TestExpectedWarmRead;
+    defer p.deinit();
+    try testing.expectEqual(@as(usize, 1), p.items.len);
+    try testing.expectEqualStrings("tree", p.items[0].name);
+    try testing.expectEqual(outdated_json.Kind.formula, p.items[0].kind);
+}
+
+test "parsed rows own their bytes — the snapshot buffer can be freed" {
+    const src =
+        \\{"version":2,"generated_at_ms":0,"formulas":[{"name":"dav1d","installed":"1.5.3","latest":"1.5.4"}],"casks":[]}
+    ;
+    const buf = try testing.allocator.dupe(u8, src);
+    var p = try parse(testing.allocator, buf);
+    defer p.deinit();
+    @memset(buf, 'X'); // scribble the source; a referencing parse would now read garbage
+    testing.allocator.free(buf);
+    try testing.expectEqualStrings("dav1d", p.items[0].name);
+    try testing.expectEqualStrings("1.5.4", p.items[0].latest);
+}

--- a/src/tui/outdated_tab.zig
+++ b/src/tui/outdated_tab.zig
@@ -19,6 +19,7 @@ const ctx = @import("ctx.zig");
 const tab = @import("tab.zig");
 const scroll_list = @import("scroll_list.zig");
 const outdated_json = @import("json/outdated.zig");
+const snapshot_json = @import("json/snapshot.zig");
 const color = @import("../ui/color.zig");
 
 pub const Row = outdated_json.OutdatedRow;
@@ -494,7 +495,21 @@ fn applyOutdatedParse(allocator: std.mem.Allocator, st: *State, storage: *Storag
     shared.outdated_count = parsed.items.len;
 }
 
+/// Seed the tab from the on-disk snapshot for an instant warm paint before the
+/// live audit lands, so the dashboard opens with data instead of a spinner (the
+/// audit recomputes a stale snapshot and can stall on the network). Best-effort:
+/// a miss leaves the tab to the audit. Rows come back unpinned/untagged — the
+/// snapshot has neither — and the refresh corrects them; `mt upgrade` enforces
+/// pins itself, so an unpinned provisional row is never upgraded past its pin.
+pub fn warmRead(io: std.Io, allocator: std.mem.Allocator, cache_dir: []const u8, s: *State, storage: *Storage, shared: *ctx.SharedModel) void {
+    const parsed = snapshot_json.read(io, allocator, cache_dir) orelse return;
+    applyOutdatedParse(allocator, s, storage, shared, parsed) catch parsed.deinit();
+}
+
 // ─── tests ───────────────────────────────────────────────────────────
+// warmRead's end-to-end wiring (snapshot file → tab rows) lives in
+// tests/tui_outdated_warm_read_test.zig; the pure snapshot shapes are
+// unit-tested inline in json/snapshot.zig.
 
 const testing = std.testing;
 

--- a/tests/tui_outdated_warm_read_test.zig
+++ b/tests/tui_outdated_warm_read_test.zig
@@ -1,0 +1,54 @@
+//! malt — integration tests for the Outdated tab's warm-read.
+//!
+//! Warm-read assembles the on-disk `outdated.json` snapshot into the Outdated
+//! tab's rows at launch, so the dashboard opens with data instead of a spinner.
+//! These pin that end-to-end wiring through a real cache file; the snapshot
+//! parser's own shapes are unit-tested inline in `tui/json/snapshot.zig`.
+
+const std = @import("std");
+const testing = std.testing;
+
+const malt = @import("malt");
+const outdated = malt.tui_tab_outdated;
+const ctx = malt.tui_ctx;
+const outdated_json = malt.tui_json_outdated;
+
+test "warmRead seeds the tab and header count from a present snapshot" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var base_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_dir = base_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &base_buf)];
+    var f = try tmp.dir.createFile(io, "outdated.json", .{});
+    try f.writeStreamingAll(io, "{\"version\":2,\"generated_at_ms\":0,\"formulas\":[{\"name\":\"wget\",\"installed\":\"1.24.5\",\"latest\":\"1.25.0\"}],\"casks\":[{\"name\":\"firefox\",\"installed\":\"120\",\"latest\":\"121\"}]}");
+    f.close(io);
+
+    var st: outdated.State = .{};
+    var storage: outdated.Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    outdated.warmRead(io, testing.allocator, cache_dir, &st, &storage, &shared);
+
+    try testing.expectEqual(@as(usize, 2), st.items.len);
+    try testing.expectEqualStrings("wget", st.items[0].name);
+    try testing.expectEqual(outdated_json.Kind.cask, st.items[1].kind);
+    try testing.expectEqual(@as(?usize, 2), shared.outdated_count); // header reflects the warm rows
+    // Warm rows are provisional: no snapshot field supplies pinned, so it defaults safe.
+    try testing.expect(!st.items[0].pinned);
+}
+
+test "warmRead on an absent snapshot leaves the tab empty and untouched" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+
+    var st: outdated.State = .{};
+    var storage: outdated.Storage = .{};
+    var shared: ctx.SharedModel = .{};
+    defer storage.deinit(testing.allocator);
+    outdated.warmRead(threaded.io(), testing.allocator, "/nonexistent/malt/cache", &st, &storage, &shared);
+    try testing.expectEqual(@as(usize, 0), st.items.len);
+    try testing.expect(storage.outdated == null); // nothing seeded on a miss
+}


### PR DESCRIPTION
## Description

Opening `mt tui` showed the Outdated tab stuck on "Loading" whenever the cached snapshot was older than the 5-minute freshness window: the tab blocked on a live `mt outdated` audit, which recomputes a stale snapshot and can stall for a minute-plus on the network (a tap HEAD/`.rb` fetch with no deadline).

The dashboard now paints the last snapshot the instant it opens — a warm read — so the Outdated tab shows data immediately instead of a spinner. The live audit still runs in the background and swaps in the DB-attributed set (pinned/tap) when it lands; if it stalls, the warm rows stay put instead of a "Loading" wall.

The warm rows come from the raw snapshot, which carries no per-row pinned/tap (both are DB-derived at emit time), so they render unpinned and untagged until the refresh corrects them. This is safe: `mt upgrade` enforces pins itself, so an unpinned provisional row can never be upgraded past its pin.

## Related Issue

- None

## Notes for Reviewers

- None