### PR TITLE
fix(cli): stop network commands cleanly on Ctrl-C

### DIFF
--- a/scripts/regressions/upgrade-honors-sigint-ctrl-c.sh
+++ b/scripts/regressions/upgrade-honors-sigint-ctrl-c.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Regression: Ctrl-C stops `mt upgrade --dry-run` instead of being swallowed.
+#
+# The signal handler installed at startup replaces SIGINT's default kill with a
+# flag flip, so interruptibility depends on the upgrade audit both wiring
+# `http.cancel` (to abort the in-flight fetch) and polling the flag between
+# packages. When either is missing, Ctrl-C during a network-bound dry-run does
+# nothing and the full keg set is audited to completion.
+#
+# What this pins end to end: seed N outdated core kegs, start a streaming
+# dry-run, send SIGINT the moment the audit emits its first per-package event,
+# and assert (a) the process reaps promptly and (b) it emitted FEWER per-package
+# events than kegs seeded — i.e. it stopped early. Before the fix the flag is
+# ignored: every keg is audited (event count == N) or the run outlives the
+# SIGINT and is only killed by the outer timeout. Either way this fails.
+#
+# The dry-run's blocking wall-clock is a real HTTPS fetch per keg, so this needs
+# network to formulae.brew.sh (the bug itself needs it). With no connectivity it
+# SKIPs cleanly rather than flaking.
+#
+# Usage: scripts/regressions/upgrade-honors-sigint-ctrl-c.sh
+# Requirements: a built malt binary at $MALT_BIN or zig-out/bin/malt; network.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+PREFIX=$(mktemp -d -t malt_upgrade_sigint.XXXXXX)
+trap 'rm -rf "$PREFIX"' EXIT
+export MALT_PREFIX="$PREFIX"
+export MALT_CACHE="$PREFIX/cache"
+unset MALT_OFFLINE NO_COLOR CI
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+skip() {
+  printf '  \xe2\x8a\x98 SKIP: %s\n' "$*"
+  exit 0
+}
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+# Real core formulae — stable, unlikely to vanish. Each must return 200 JSON so
+# the audit spends time fetching. Seeded as outdated (version 0.0.1) so every
+# one would be a candidate the loop must walk.
+FORMULAE=(
+  git curl wget jq tree htop tmux vim node ruby go rust cmake make
+  openssl@3 sqlite zlib readline pcre2 xz lz4 zstd gmp libyaml
+)
+N=${#FORMULAE[@]}
+
+# Connectivity probe — one of the seeded names must be reachable.
+curl -sfI --max-time 8 "https://formulae.brew.sh/api/formula/jq.json" >/dev/null 2>&1 ||
+  skip "no network to formulae.brew.sh"
+
+# Init + migrate the schema, then seed the kegs.
+mkdir -p "$PREFIX/db" "$MALT_CACHE"
+"$BIN" list >/dev/null 2>&1 || true
+DB="$PREFIX/db/malt.db"
+[[ -f "$DB" ]] || fail "malt did not create $DB"
+
+{
+  echo "BEGIN;"
+  for f in "${FORMULAE[@]}"; do
+    printf "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path) VALUES ('%s','%s','0.0.1','sha-%s','/c/%s/0.0.1');\n" \
+      "$f" "$f" "$f" "$f"
+  done
+  echo "COMMIT;"
+} | sqlite3 "$DB"
+
+OUT="$PREFIX/events.ndjson"
+
+# Start the streaming dry-run; capture PID.
+"$BIN" --output-format=ndjson upgrade --dry-run >"$OUT" 2>/dev/null &
+PID=$!
+
+# Wait until the audit emits its first per-package event (a line carrying a
+# "name" field), then interrupt. Bail as SKIP if nothing streams in time — that
+# is an environmental stall, not a swallowed signal.
+waited=0
+until grep -q '"name":' "$OUT" 2>/dev/null; do
+  kill -0 "$PID" 2>/dev/null || break
+  sleep 0.2
+  waited=$((waited + 1))
+  if [[ $waited -ge 60 ]]; then # ~12s
+    kill -INT "$PID" 2>/dev/null || true
+    wait "$PID" 2>/dev/null || true
+    skip "audit produced no events in 12s (network stall)"
+  fi
+done
+
+kill -INT "$PID" 2>/dev/null || true
+
+# The process must reap promptly after SIGINT. Poll for up to 8s.
+reaped=0
+for _ in $(seq 1 40); do
+  if ! kill -0 "$PID" 2>/dev/null; then
+    reaped=1
+    break
+  fi
+  sleep 0.2
+done
+if [[ $reaped -eq 0 ]]; then
+  kill -9 "$PID" 2>/dev/null || true
+  wait "$PID" 2>/dev/null || true
+  fail "SIGINT was swallowed — dry-run did not stop within 8s"
+fi
+wait "$PID" 2>/dev/null || true
+pass "dry-run reaped promptly after SIGINT"
+
+# It must have stopped early: fewer per-package events than kegs seeded.
+events=$(grep -c '"name":' "$OUT" 2>/dev/null || echo 0)
+if [[ "$events" -ge "$N" ]]; then
+  fail "audit walked all $N kegs after SIGINT ($events events) — loop guard missing"
+fi
+pass "audit stopped early after SIGINT ($events of $N kegs)"
+
+printf '\n\xe2\x9c\x94 upgrade honors SIGINT (Ctrl-C) regression passed\n'

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const AppCtx = @import("../app_ctx.zig").AppCtx;
 const cask_mod = @import("../core/cask.zig");
 const cellar_mod = @import("../core/cellar.zig");
+const signals = @import("../core/signals.zig");
 const deps_mod = @import("../core/deps.zig");
 const formula_mod = @import("../core/formula.zig");
 const linker_mod = @import("../core/linker.zig");
@@ -1222,6 +1223,9 @@ fn upgradeAllFormulas(
     defer failed_names.deinit(allocator);
 
     for (names.items) |name| {
+        // Stop between packages on Ctrl-C; the in-flight fetch is torn down by
+        // http.cancel, this keeps us from starting the next one.
+        if (signals.isInterrupted()) break;
         upgradeFormula(ctx, allocator, name, db, api, http, prefix, dry_run, force, pinned_only, isolate_deps, use_system_ruby, tally, sink) catch {
             failed_count += 1;
             tally.failed += 1;
@@ -1427,6 +1431,7 @@ fn upgradeAllCasks(ctx: *const AppCtx, allocator: std.mem.Allocator, db: *sqlite
     defer failed_tokens.deinit(allocator);
 
     for (tokens.items) |token| {
+        if (signals.isInterrupted()) break;
         upgradeCask(ctx, allocator, token, db, api, prefix, dry_run, force, pinned_only, tally, sink) catch {
             failed_count += 1;
             tally.failed += 1;
@@ -1756,4 +1761,116 @@ test "readOldKeg maps a NULL tap column to an owned empty string" {
     defer old.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("", old.tap);
     try std.testing.expect(install_args_mod.isCoreTap(old.tap));
+}
+
+test "upgradeAllFormulas stops between packages once interrupted" {
+    const alloc = std.testing.allocator;
+    const ctx = @import("../app_ctx.zig").debug_ctx;
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    // Two core kegs so the loop must iterate more than once; NULL tap keeps
+    // them on the offline-failing homebrew/core fetch path.
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, tap)
+        \\VALUES ('aaa', 'aaa', '1.0', 's1', '/c/aaa/1.0', NULL),
+        \\       ('bbb', 'bbb', '1.0', 's2', '/c/bbb/1.0', NULL);
+    );
+
+    // Offline so each fetch fails instantly from a cache miss — no network.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var cbuf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_dir = cbuf[0..try std.Io.Dir.realPath(tmp.dir, ctx.io, &cbuf)];
+
+    var http = client_mod.HttpClient.init(ctx.io, ctx.environ, alloc);
+    defer http.deinit();
+    http.offline = true;
+    var api = api_mod.BrewApi.init(ctx.io, alloc, &http, cache_dir);
+    api.offline = true;
+
+    // Fire on the 2nd interrupt poll: iteration 1 processes `aaa`, iteration 2
+    // sees the flag and must break before touching `bbb`.
+    const prior = signals.isInterrupted();
+    defer signals.setInterruptedForTest(prior);
+    signals.setInterruptedForTest(false);
+    signals.armInterruptAfterForTest(2);
+    defer signals.armInterruptAfterForTest(0);
+
+    var tally: Tally = .{};
+    upgradeAllFormulas(&ctx, alloc, &db, &api, &http, "/opt/malt", true, false, false, false, &.{}, &tally, null) catch {};
+
+    // Only the first keg was attempted; the interrupt stopped the loop.
+    try std.testing.expectEqual(@as(usize, 1), tally.checked());
+}
+
+test "upgradeAllFormulas processes nothing when interrupted before the loop" {
+    const alloc = std.testing.allocator;
+    const ctx = @import("../app_ctx.zig").debug_ctx;
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, tap)
+        \\VALUES ('aaa', 'aaa', '1.0', 's1', '/c/aaa/1.0', NULL);
+    );
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var cbuf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_dir = cbuf[0..try std.Io.Dir.realPath(tmp.dir, ctx.io, &cbuf)];
+    var http = client_mod.HttpClient.init(ctx.io, ctx.environ, alloc);
+    defer http.deinit();
+    http.offline = true;
+    var api = api_mod.BrewApi.init(ctx.io, alloc, &http, cache_dir);
+    api.offline = true;
+
+    const prior = signals.isInterrupted();
+    defer signals.setInterruptedForTest(prior);
+    signals.setInterruptedForTest(true);
+
+    var tally: Tally = .{};
+    upgradeAllFormulas(&ctx, alloc, &db, &api, &http, "/opt/malt", true, false, false, false, &.{}, &tally, null) catch {};
+
+    try std.testing.expectEqual(@as(usize, 0), tally.checked());
+}
+
+test "upgradeAllCasks stops between casks once interrupted" {
+    const alloc = std.testing.allocator;
+    const ctx = @import("../app_ctx.zig").debug_ctx;
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    // Two core casks (NULL tap) so the loop iterates and each falls to the
+    // offline-failing core-API fetch path — no network, no registered taps.
+    try db.exec(
+        \\INSERT INTO casks (token, name, version, url) VALUES
+        \\  ('aaa', 'aaa', '1.0', 'https://example/aaa'),
+        \\  ('bbb', 'bbb', '1.0', 'https://example/bbb');
+    );
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var cbuf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_dir = cbuf[0..try std.Io.Dir.realPath(tmp.dir, ctx.io, &cbuf)];
+    var http = client_mod.HttpClient.init(ctx.io, ctx.environ, alloc);
+    defer http.deinit();
+    http.offline = true;
+    var api = api_mod.BrewApi.init(ctx.io, alloc, &http, cache_dir);
+    api.offline = true;
+
+    // Fire on the 2nd poll: cask `aaa` is attempted, `bbb` is skipped.
+    const prior = signals.isInterrupted();
+    defer signals.setInterruptedForTest(prior);
+    signals.setInterruptedForTest(false);
+    signals.armInterruptAfterForTest(2);
+    defer signals.armInterruptAfterForTest(0);
+
+    var tally: Tally = .{};
+    upgradeAllCasks(&ctx, alloc, &db, &api, "/opt/malt", true, false, false, &tally, null) catch {};
+
+    try std.testing.expectEqual(@as(usize, 1), tally.checked());
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -523,6 +523,9 @@ pub fn main(init: std.process.Init.Minimal) !void {
     // immediately killing the process. Install commands check the flag at
     // step boundaries and clean up before exiting.
     signals.installHandler();
+    // Seed every HTTP client with the interrupt flag so any command's
+    // in-flight fetch aborts on Ctrl-C instead of blocking to its timeout.
+    @import("net/client.zig").HttpClient.setDefaultCancel(signals.isInterrupted);
 
     var arena = std.heap.ArenaAllocator.init(backing);
     defer arena.deinit();

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -289,6 +289,20 @@ pub const HttpClient = struct {
     /// Blob downloads (bottles, cask DMGs) get a much longer timeout.
     const blob_timeout_ns: u64 = 600 * std.time.ns_per_s; // 10 minutes
 
+    /// Process-wide cancel predicate seeded into every new client's `cancel`
+    /// field. `main` injects the SIGINT flag once so all HTTP-using commands
+    /// abort an in-flight fetch on Ctrl-C without each site re-wiring it; net/
+    /// stays agnostic to which signal mechanism the caller chose.
+    var default_cancel: ?*const fn () bool = null;
+
+    pub fn setDefaultCancel(f: ?*const fn () bool) void {
+        default_cancel = f;
+    }
+
+    pub fn defaultCancel() ?*const fn () bool {
+        return default_cancel;
+    }
+
     pub fn init(io: std.Io, environ: std.process.Environ, allocator: std.mem.Allocator) HttpClient {
         var c: std.http.Client = .{ .allocator = allocator, .io = io };
         return initWith(&c, io, environ, allocator);
@@ -310,6 +324,7 @@ pub const HttpClient = struct {
             .environ = environ,
             .allocator = allocator,
             .client = client.*,
+            .cancel = default_cancel,
         };
     }
 
@@ -1263,6 +1278,29 @@ test "HttpClient.initWith: preserves field defaults" {
     try std.testing.expectEqual(@as(?*const fn () bool, null), http.cancel);
     try std.testing.expectEqual(@as(?[]u8, null), http.zstd_window);
     try std.testing.expectEqual(@as(?[]u8, null), http.flate_window);
+}
+
+test "HttpClient.init: inherits the process-wide default cancel predicate" {
+    const Probe = struct {
+        fn cancel() bool {
+            return true;
+        }
+    };
+    const prior = HttpClient.defaultCancel();
+    defer HttpClient.setDefaultCancel(prior);
+
+    // Once `main` injects a predicate, every client is interruptible without
+    // each call site re-wiring `http.cancel`.
+    HttpClient.setDefaultCancel(&Probe.cancel);
+    var http = HttpClient.init(std.Options.debug_io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+    try std.testing.expectEqual(@as(?*const fn () bool, &Probe.cancel), http.cancel);
+
+    // Clearing the default returns clients to non-cancelling.
+    HttpClient.setDefaultCancel(null);
+    var plain = HttpClient.init(std.Options.debug_io, std.process.Environ.empty, std.testing.allocator);
+    defer plain.deinit();
+    try std.testing.expectEqual(@as(?*const fn () bool, null), plain.cancel);
 }
 
 test "HttpClient.init: delegates to initWith without losing defaults" {


### PR DESCRIPTION
## Description

Ctrl-C now stops any network-bound command instead of being swallowed.

The interrupt flag is now seeded once as the default cancel predicate for every HTTP client, so any in-flight fetch aborts on Ctrl-C across all commands. 

The interactive TUI is unaffected: it runs with `ISIG` off, so Ctrl-C stays a keystroke there.

## Related Issue

- None

## Notes for Reviewers

- None