### PR TITLE
fix(tui): keep the search frame responsive during a slow read

### DIFF
--- a/src/tui/perform.zig
+++ b/src/tui/perform.zig
@@ -259,9 +259,14 @@ fn readBytes(io: std.Io, allocator: std.mem.Allocator, painter: Painter, loading
     return switch (r.mode) {
         .blocking => if (r.allow_empty) spawn.readJsonAllowEmpty(io, allocator, r.argv) else @as(?[]u8, try spawn.readJson(io, allocator, r.argv)),
         .polled => blk: {
-            // Keep `loading` set across the poll so each tick paints the spinner.
-            loading.* = true;
-            defer loading.* = false;
+            // Keep `loading` set across the poll so each tick paints the footer spinner —
+            // except search, which owns its own body "searching…" indicator (mirrors the
+            // `r.tag != .search` gate `performRead` uses for the pre-read paint).
+            const light = r.tag != .search;
+            if (light) loading.* = true;
+            defer if (light) {
+                loading.* = false;
+            };
             break :blk try spawn.readJsonPolled(io, allocator, r.argv, r.max_ok_exit, painter);
         },
         .background => unreachable,
@@ -368,6 +373,46 @@ test "anyFetchActive tracks slot occupancy, not payload" {
     try testing.expect(anyFetchActive(&fetches)); // one in flight → the loop multiplexes
 
     reapTabFetch(t.io(), testing.allocator, &fetches.getPtr(.outdated).*.?); // reap the live child + free its buf
+}
+
+// Observe `loading` from inside a poll tick: the polled reader fires `on_tick` on
+// every ≤80 ms timeout, so a child that outlives one timeout lets the test see
+// whether the footer spinner flag was raised while the read was in flight.
+const LoadWatch = struct {
+    loading: *const bool,
+    ticks: usize = 0,
+    seen_true: bool = false,
+    fn tick(ctx_ptr: *anyopaque) void {
+        const self: *LoadWatch = @ptrCast(@alignCast(ctx_ptr)); // Painter's ctx round-trip, set from a *LoadWatch just below
+        self.ticks += 1;
+        if (self.loading.*) self.seen_true = true;
+    }
+};
+
+test "a polled search read keeps the footer clean while any other tag lights it" {
+    // Search owns its body "searching…" indicator, so the footer "Loading…" flag must
+    // stay dark on the polled arm — every other polled read still raises it per tick.
+    var t = std.Io.Threaded.init(testing.allocator, .{});
+    defer t.deinit();
+    var frame: []u8 = &.{};
+    var loading = false;
+
+    // `/bin/sleep` holds stdout open past one poll timeout (no output, exit 0), so a
+    // tick fires mid-read and the read then resolves to an empty document (null).
+    var search_watch: LoadWatch = .{ .loading = &loading };
+    const search_painter: Painter = .{ .fd = 0, .frame = &frame, .on_tick = .{ .ctx = &search_watch, .call = LoadWatch.tick } };
+    const search_read: cmd.Cmd.Read = .{ .argv = &.{ "/bin/sleep", "0.2" }, .mode = .polled, .parse = unusedParse, .tag = .search };
+    try testing.expect((try readBytes(t.io(), testing.allocator, search_painter, &loading, search_read)) == null);
+    try testing.expect(search_watch.ticks > 0); // the poll actually ticked mid-read
+    try testing.expect(!search_watch.seen_true); // …and the footer stayed clean throughout
+    try testing.expect(!loading); // false after the call
+
+    var outdated_watch: LoadWatch = .{ .loading = &loading };
+    const outdated_painter: Painter = .{ .fd = 0, .frame = &frame, .on_tick = .{ .ctx = &outdated_watch, .call = LoadWatch.tick } };
+    const outdated_read: cmd.Cmd.Read = .{ .argv = &.{ "/bin/sleep", "0.2" }, .mode = .polled, .parse = unusedParse, .tag = .outdated };
+    try testing.expect((try readBytes(t.io(), testing.allocator, outdated_painter, &loading, outdated_read)) == null);
+    try testing.expect(outdated_watch.seen_true); // the footer spinner lit across the poll
+    try testing.expect(!loading); // deferred back to false after the call
 }
 
 test "reapAllFetches tears down every in-flight fetch (no leak, no zombie)" {

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -471,11 +471,11 @@ fn searchArgv(allocator: std.mem.Allocator, mt_path: []const u8, st: *const Stat
 /// The committed query's `mt search --json` read, or `Cmd.none` for an empty query.
 fn searchReadCmd(allocator: std.mem.Allocator, mt_path: []const u8, s: *const State) cmd.Cmd {
     const argv = (searchArgv(allocator, mt_path, s) catch return .none) orelse return .none;
-    return .{ .read = .{ .argv = argv, .mode = .blocking, .parse = cmd.parserFor(.search, search_json.parse), .tag = .search, .fail_op = search_fail_op } };
+    return .{ .read = .{ .argv = argv, .mode = .polled, .parse = cmd.parserFor(.search, search_json.parse), .tag = .search, .fail_op = search_fail_op } };
 }
 
 /// The shell commits the filter-as-query on Enter and asks for this. Flips `phase`
-/// to `searching` before the blocking read (the shell repaints first); the fold
+/// to `searching` before the polled read (the shell repaints first); the fold
 /// resets it to `loaded`, and a failed read resets it via `update` on `.failed`.
 pub fn searchCmd(allocator: std.mem.Allocator, mt_path: []const u8, s: *State) cmd.Cmd {
     const c = searchReadCmd(allocator, mt_path, s);
@@ -489,7 +489,7 @@ pub fn searchCmd(allocator: std.mem.Allocator, mt_path: []const u8, s: *State) c
 fn openSearchInfoCmd(allocator: std.mem.Allocator, mt_path: []const u8, s: *const State) cmd.Cmd {
     const m = selectedMatch(s) orelse return .none; // empty list: no-op
     const argv = cmd.jsonArgv(allocator, mt_path, &.{ "info", m.name }) catch return .none;
-    return .{ .read = .{ .argv = argv, .mode = .blocking, .parse = cmd.parserFor(.info, info_json.parse), .tag = .search, .fail_op = info_fail_op } };
+    return .{ .read = .{ .argv = argv, .mode = .polled, .parse = cmd.parserFor(.info, info_json.parse), .tag = .search, .fail_op = info_fail_op } };
 }
 
 /// The basket's `mt install …` mutation, or `Cmd.none` when nothing installable is
@@ -1166,6 +1166,31 @@ test "searchCmd on an empty query is a no-op and leaves the phase alone" {
     var st: State = .{ .phase = .idle };
     try testing.expect(searchCmd(testing.allocator, "/bin/mt", &st) == .none);
     try testing.expectEqual(Phase.idle, st.phase);
+}
+
+test "searchReadCmd and openSearchInfoCmd build polled reads so the searching frame reflows on resize" {
+    const alloc = testing.allocator;
+
+    // The committed-query search runs polled, off the frozen blocking path, so a
+    // SIGWINCH reflows the "searching…" frame on the next tick instead of after the read.
+    var s: State = .{};
+    s.chrome.filter.push("fire");
+    const search_eff = searchReadCmd(alloc, "/opt/homebrew/bin/mt", &s);
+    defer alloc.free(search_eff.read.argv);
+    try testing.expectEqual(cmd.Cmd.Mode.polled, search_eff.read.mode);
+    try testing.expectEqual(cmd.MsgTag.search, search_eff.read.tag);
+
+    // The info read for the selected hit inherits the same polled path (same tag).
+    var storage: Storage = .{};
+    defer storage.deinit(alloc);
+    storage.search = try search_json.parse(alloc,
+        \\{"results":[{"name":"bat","type":"formula","installed":false}]}
+    );
+    var info_state: State = .{ .items = storage.search.?.items };
+    const info_eff = openSearchInfoCmd(alloc, "/opt/homebrew/bin/mt", &info_state);
+    defer alloc.free(info_eff.read.argv);
+    try testing.expectEqual(cmd.Cmd.Mode.polled, info_eff.read.mode);
+    try testing.expectEqual(cmd.MsgTag.search, info_eff.read.tag);
 }
 
 test "searchArgv builds `mt search <query> --json` for the committed query" {


### PR DESCRIPTION
## Description

During a slow `mt search` / `mt info` read the TUI no longer freezes - the "searching…" frame now reflows on a terminal resize within one poll tick, matching the responsiveness of every other TUI read. Achieved by routing both network-bound reads onto the existing polled reader (a two-token mode swap) and keeping search's footer clean on that arm. No new machinery; `app.zig` and the spawn leaf untouched.

## Related Issue

- None

## Notes for Reviewers

- Footer predicate is recomputed inside `readBytes` (self-contained, no signature change) rather than threaded from `performRead`; call out if you'd prefer threading.