### PR TITLE
fix(tui): stop the filter row ghosting a caret when the query is cleared

### DIFF
--- a/scripts/regressions/tui-filter-line-ghost-seach-installed-placeholder-kept-after-clearing-filter-input.sh
+++ b/scripts/regressions/tui-filter-line-ghost-seach-installed-placeholder-kept-after-clearing-filter-input.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Regression: the `/`-filter line in `mt tui` is shared shell chrome whose width
+# shrinks as the query is backspaced. Once the per-frame whole-screen clear was
+# dropped (the flicker fix), every region self-erases via moveClear — but the
+# filter line kept a moveTo-only paint, so the old caret at the now-vacant
+# rightmost column was never overwritten and ghosted one column to the right.
+#
+# app.zig is not a leaf module (it imports the whole tui graph), so the
+# copy-and-append pattern used by tui-wrap-rune-boundary-*.sh does not apply and
+# a full `zig build test` here would both duplicate `just test` and blow the
+# time budget. The behavioural assertion (a focused, non-empty filter frame must
+# emit `\x1b[K` on the filter row) rides `just test`; this script is the fast
+# structural backstop guarding that the fix and its guard test stay in place.
+#
+# Exits 0 when the filter row self-erases (moveClear) and the guard test is
+# present; non-zero with a clear message otherwise. No build, no network, <1s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# The fix: the filter line must be painted with moveClear, not a moveTo-only
+# paint that leaves last frame's caret un-erased on a shrinking query.
+rg -q 'moveClear\(r\.filter\.row' "$ROOT/src/tui/app.zig" ||
+  {
+    echo "FAIL: filter line no longer painted with moveClear — caret can ghost" >&2
+    exit 1
+  }
+
+# The behavioural guard: the inline frame test that asserts the filter row emits
+# `\x1b[K` must survive, or the fix could be reverted without a test noticing.
+rg -q 'self-erases the filter row' "$ROOT/src/tui/app.zig" ||
+  {
+    echo "FAIL: filter-row self-erase guard test is missing" >&2
+    exit 1
+  }
+
+echo "OK: mt tui filter row self-erases; no caret ghost on shrink"

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -325,7 +325,7 @@ pub fn renderFrame(buf: []u8, app: *const App, cols: u16, rows: u16) []const u8 
             f.put(tab_bar.render(&tb, app.active, tabTitles(), cols));
             f.put(color.Style.reset.code()); // a truncated active title must not bleed bold downward
 
-            f.moveTo(r.filter.row, 1);
+            f.moveClear(r.filter.row, 1); // variable-width chrome: self-erase or a shrinking query ghosts its caret
             var fb: [filter_input.max_len + 8]u8 = undefined;
             f.put(filter_input.render(&fb, activeFilterLabel(app), activeFilterText(app), app.editing, cols));
 
@@ -1218,6 +1218,21 @@ test "renderFrame shows the committed filter and the editing footer" {
     const out = renderFrame(&buf, &a, 80, 24);
     try std.testing.expect(std.mem.indexOf(u8, out, "filter: jq_") != null); // filter line with caret
     try std.testing.expect(std.mem.indexOf(u8, out, "accept") != null); // editing footer
+}
+
+test "renderFrame self-erases the filter row so a shrinking query drops its caret" {
+    // The filter line is variable-width shared chrome; once the 2J is gone it
+    // must own its line from col 1 rightward (moveClear), or backspacing leaves
+    // last frame's caret ghosting one column right. render emits no style, so
+    // the row's `\x1b[K` sits immediately before the label.
+    var a: App = .{};
+    stepA(&a, ch('2'));
+    stepA(&a, ch('/'));
+    stepA(&a, ch('j'));
+    stepA(&a, ch('q'));
+    var buf: [8192]u8 = undefined;
+    const out = renderFrame(&buf, &a, 80, 24);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\x1b[Kfilter: jq") != null);
 }
 
 test "the Search tab labels its input box as a query, not a filter" {


### PR DESCRIPTION
## Description

In `mt tui`, clearing or backspacing the `/`-filter left a stray caret (`_`) ghosting one column to the right of the shrinking text - visible on every list tab (Installed, Search, Outdated, Services).

The fix switches the filter-line paint to `moveClear`, restoring the per-region self-erase invariant every sibling region already honours. Filtering behaviour was already correct; this is purely how the returned slice is laid down.

## Related Issue

- None

## Notes for Reviewers

- None