### PR TITLE
feat(tui): decode SGR mouse reports into a typed event

### DIFF
--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -878,6 +878,7 @@ pub fn run(io: std.Io, allocator: std.mem.Allocator, stderr: std.Io.File, enviro
                     try serviceKey(io, allocator, &t, painter, &fetches, &app, &app.storages, k.key);
                     if (app.quit) break;
                 },
+                .mouse => |m| consumed += m.consumed, // decoded but not yet wired to a handler
             }
         }
         // A buffered tail can be a lone Esc, which the blocking read would sit

--- a/src/tui/keys.zig
+++ b/src/tui/keys.zig
@@ -9,7 +9,9 @@
 
 const std = @import("std");
 
-const cap = 8; // longest sequence buffered before draining to `.unknown`
+// Worst realistic SGR report `\x1b[<BBB;CCCC;RRRRM` is 17 bytes; 20 gives
+// headroom, and anything longer still drains safely at the cap.
+const cap = 20; // longest sequence buffered before draining to `.unknown`
 
 /// A printable character as its raw UTF-8 bytes (1–4). Display width is *not*
 /// decoded here — that is the layout layer's job (matches `term_sanitize`'s
@@ -45,11 +47,22 @@ pub const Key = union(enum) {
     unknown,
 };
 
+/// One decoded SGR mouse report. Its own event so the keyboard `Key` union
+/// stays pure — a click carries coordinates a key never does.
+pub const Mouse = struct {
+    button: u8, // SGR code: 0 = left, 64 = wheel-up, 65 = wheel-down
+    col: u16, // 1-based cell column (matches layout's origin)
+    row: u16, // 1-based cell row
+    press: bool, // final 'M' = press, 'm' = release
+};
+
 /// Result of one `decode` call.
 pub const Decoded = union(enum) {
     /// A decoded key plus how many bytes of *this* slice it consumed. Bytes
     /// carried over from a prior call are not re-counted.
     key: struct { key: Key, consumed: usize },
+    /// A decoded mouse report, with the same `consumed` accounting as `key`.
+    mouse: struct { mouse: Mouse, consumed: usize },
     /// The slice ended mid-sequence; the tail is buffered. Feed more bytes, or
     /// call `flush` at EOF to surface a lone ESC.
     incomplete,
@@ -80,6 +93,13 @@ pub const Decoder = struct {
                     self.len = 0;
                     return .{ .key = .{ .key = d.key, .consumed = i - leftover } };
                 },
+                .mouse => |m| {
+                    // Same accounting as `.done`: an SGR report always ends on
+                    // its final byte, so `m.len` spans the whole buffer.
+                    const leftover = self.len - m.len;
+                    self.len = 0;
+                    return .{ .mouse = .{ .mouse = m.mouse, .consumed = i - leftover } };
+                },
                 .need_more => if (self.len == cap) {
                     // Buffer full with no match: drain it as one unknown event so
                     // a hostile stream can never overflow or stall the decoder.
@@ -107,10 +127,15 @@ pub const Decoder = struct {
 const Step = union(enum) {
     need_more,
     done: struct { key: Key, len: usize },
+    mouse: struct { mouse: Mouse, len: usize },
 };
 
 fn done(key: Key, len: usize) Step {
     return .{ .done = .{ .key = key, .len = len } };
+}
+
+fn mouseDone(m: Mouse, len: usize) Step {
+    return .{ .mouse = .{ .mouse = m, .len = len } };
 }
 
 fn char1(b: u8) Key {
@@ -141,9 +166,61 @@ fn recognizeEsc(buf: []const u8) Step {
     if (buf[1] != '[') return done(.esc, 1);
     if (buf.len == 2) return .need_more; // "ESC [" alone
     const last = buf[buf.len - 1];
-    if (last >= 0x40 and last <= 0x7e) return done(csiKey(buf[2..]), buf.len); // final byte
+    if (last >= 0x40 and last <= 0x7e) { // final byte: CSI complete
+        const body = buf[2..];
+        if (body.len >= 1 and body[0] == '<') return mouseStep(body, buf.len);
+        return done(csiKey(body), buf.len);
+    }
     if (last >= 0x20 and last <= 0x3f) return .need_more; // param/intermediate
     return done(.unknown, buf.len); // malformed CSI byte
+}
+
+/// Classify an SGR mouse body (`<` params final). A trust boundary: the CSI
+/// framing admits arbitrary param bytes, so any malformed body resolves to a
+/// complete `.unknown` — never an error, never a mis-decoded key.
+fn mouseStep(body: []const u8, len: usize) Step {
+    return if (parseSgr(body)) |m| mouseDone(m, len) else done(.unknown, len);
+}
+
+/// Parse an SGR mouse body `<button;col;row(M|m)` into a `Mouse`, or `null` for
+/// any malformed input. Allocation-free and overflow-safe: each field folds
+/// into a `u16` with an overflow guard, so hostile params can only yield `null`.
+fn parseSgr(body: []const u8) ?Mouse {
+    if (body.len < 2 or body[0] != '<') return null;
+    const press = switch (body[body.len - 1]) {
+        'M' => true,
+        'm' => false,
+        else => return null, // wrong final byte
+    };
+    var fields = std.mem.splitScalar(u8, body[1 .. body.len - 1], ';');
+    const button = parseU16(fields.next() orelse return null) orelse return null;
+    const col = parseU16(fields.next() orelse return null) orelse return null;
+    const row = parseU16(fields.next() orelse return null) orelse return null;
+    if (fields.next() != null) return null; // extra field
+    return .{
+        .button = std.math.cast(u8, button) orelse return null,
+        .col = col,
+        .row = row,
+        .press = press,
+    };
+}
+
+/// Fold decimal digits into a `u16`; `null` on empty, non-digit, or overflow.
+/// Deliberately stricter than `std.fmt.parseInt`, which accepts a leading `+`
+/// and `_` separators — SGR params are pure digit runs, and this is a trust
+/// boundary, so anything non-canonical must be rejected, not coerced.
+fn parseU16(s: []const u8) ?u16 {
+    if (s.len == 0) return null;
+    var v: u16 = 0;
+    for (s) |c| {
+        if (c < '0' or c > '9') return null;
+        const mul = @mulWithOverflow(v, 10);
+        if (mul[1] != 0) return null;
+        const add = @addWithOverflow(mul[0], @as(u16, c - '0'));
+        if (add[1] != 0) return null;
+        v = add[0];
+    }
+    return v;
 }
 
 /// Map a CSI body (params + final byte) to a key. Unmapped-but-complete
@@ -226,8 +303,100 @@ test "csiKey maps the supported finals and is unknown otherwise" {
 
 test "an over-long escape sequence drains to unknown at the buffer cap" {
     var d: Decoder = .{};
-    const r = d.decode("\x1b[1;2;3;4;5A"); // far longer than the param forms we map
+    // All-param body with no final byte: it can never resolve, so the decoder
+    // drains it as one `.unknown` every `cap` bytes (the hostile-stream backstop).
+    const r = d.decode("\x1b[<9999;9999;9999;9999;9999");
     try std.testing.expect(r == .key);
     try std.testing.expect(r.key.key == .unknown);
     try std.testing.expectEqual(@as(usize, cap), r.key.consumed);
+}
+
+test "wheel-up SGR report decodes to a mouse event" {
+    var d: Decoder = .{};
+    const r = d.decode("\x1b[<64;12;5M");
+    try std.testing.expect(r == .mouse);
+    try std.testing.expectEqual(@as(u8, 64), r.mouse.mouse.button);
+    try std.testing.expectEqual(@as(u16, 12), r.mouse.mouse.col);
+    try std.testing.expectEqual(@as(u16, 5), r.mouse.mouse.row);
+    try std.testing.expect(r.mouse.mouse.press);
+    try std.testing.expectEqual(@as(usize, 11), r.mouse.consumed);
+}
+
+test "wheel-down SGR report decodes with button 65" {
+    var d: Decoder = .{};
+    const r = d.decode("\x1b[<65;12;5M");
+    try std.testing.expect(r == .mouse);
+    try std.testing.expectEqual(@as(u8, 65), r.mouse.mouse.button);
+}
+
+test "left press decodes press=true, left release press=false" {
+    var dp: Decoder = .{};
+    const p = dp.decode("\x1b[<0;40;12M");
+    try std.testing.expect(p == .mouse);
+    try std.testing.expectEqual(@as(u8, 0), p.mouse.mouse.button);
+    try std.testing.expect(p.mouse.mouse.press);
+
+    var dr: Decoder = .{};
+    const rel = dr.decode("\x1b[<0;40;12m");
+    try std.testing.expect(rel == .mouse);
+    try std.testing.expect(!rel.mouse.mouse.press);
+}
+
+test "malformed SGR bodies resolve to a complete .unknown, never incomplete" {
+    const cases = [_][]const u8{
+        "\x1b[<0;a;12M", // non-digit param
+        "\x1b[<0;99999;12M", // field overflow (> u16)
+        "\x1b[<0;12M", // missing field
+        "\x1b[<0;40;12X", // wrong final byte
+        "\x1b[<M", // empty body after '<'
+    };
+    for (cases) |c| {
+        var d: Decoder = .{};
+        const r = d.decode(c);
+        try std.testing.expect(r == .key); // complete, not .incomplete or .mouse
+        try std.testing.expect(r.key.key == .unknown);
+        try std.testing.expect(r.key.consumed > 0);
+    }
+}
+
+test "an SGR report split across two reads resumes and decodes once" {
+    var d: Decoder = .{};
+    try std.testing.expect(d.decode("\x1b[<64;12;") == .incomplete);
+    const r = d.decode("5M");
+    try std.testing.expect(r == .mouse);
+    try std.testing.expectEqual(@as(u8, 64), r.mouse.mouse.button);
+    try std.testing.expectEqual(@as(usize, 2), r.mouse.consumed); // only this slice's bytes
+}
+
+test "arbitrary junk param bytes after '<' never panic and resolve to .unknown" {
+    const junk = [_][]const u8{
+        "\x1b[<;;;M",
+        "\x1b[<-1;2;3M",
+        "\x1b[< 0 ;1;2M",
+        "\x1b[<0;;M",
+        "\x1b[<0/1/2M",
+        "\x1b[<0;1;2;3M", // extra field
+    };
+    for (junk) |c| {
+        var d: Decoder = .{};
+        const r = d.decode(c);
+        try std.testing.expect(r == .key);
+        try std.testing.expect(r.key.key == .unknown);
+    }
+}
+
+test "canonical-looking but non-strict SGR bodies are rejected, not coerced" {
+    // '+' (0x2b) is a CSI param byte, so it reaches the field parser where
+    // std.fmt.parseInt would accept "+64"; the digit-only parse rejects it. A
+    // button past u8 is caught by the cast. Both must be .unknown, never a Mouse.
+    const cases = [_][]const u8{
+        "\x1b[<+64;12;5M", // leading '+' — parseInt-lenient, SGR-invalid
+        "\x1b[<300;12;5M", // button exceeds u8
+    };
+    for (cases) |c| {
+        var d: Decoder = .{};
+        const r = d.decode(c);
+        try std.testing.expect(r == .key);
+        try std.testing.expect(r.key.key == .unknown);
+    }
 }


### PR DESCRIPTION
## Description

Adds SGR mouse-report decoding to the TUI input decoder without touching the keyboard `Key` union. An `\x1b[<btn;col;row M/m` report now decodes into a typed `Mouse` event on a new `Decoded.mouse` arm; the buffer cap grows to cover the worst-case report length. The parse is allocation-free and treats any malformed body as an inert `.unknown`, so hostile terminal input can never panic or mis-decode. No behaviour change yet - the event has no consumer until the wheel and click work land on top.

## Related Issue

- None

## Notes for Reviewers

- None