### PR TITLE
feat(tui): enable and cleanly restore mouse tracking

### DIFF
--- a/src/tui/term.zig
+++ b/src/tui/term.zig
@@ -38,6 +38,10 @@ pub const seq = struct {
     pub const cursor_hide = "\x1b[?25l";
     pub const cursor_show = "\x1b[?25h";
     pub const erase_line = "\x1b[K"; // erase from cursor to end of line
+    // ?1000 button+wheel, ?1006 SGR extended coords. Not ?1002/?1003 motion,
+    // which would flood the loop.
+    pub const mouse_enable = "\x1b[?1000h\x1b[?1006h";
+    pub const mouse_disable = "\x1b[?1000l\x1b[?1006l";
     // Bracket a frame so a supporting terminal buffers the whole repaint and
     // swaps it atomically; a terminal that ignores them still renders correctly.
     pub const sync_begin = "\x1b[?2026h";
@@ -63,6 +67,7 @@ pub const Term = struct {
     saved: ?std.posix.termios = null,
     in_alt: bool = false,
     cursor_hidden: bool = false,
+    mouse_on: bool = false,
 
     pub fn init(io: std.Io, fd: std.posix.fd_t) Term {
         return .{ .io = io, .fd = fd };
@@ -102,11 +107,26 @@ pub const Term = struct {
         self.cursor_hidden = false;
     }
 
+    pub fn enableMouse(self: *Term) TermError!void {
+        if (self.mouse_on) return;
+        try self.writeAll(seq.mouse_enable);
+        self.mouse_on = true;
+    }
+
+    pub fn disableMouse(self: *Term) void {
+        if (!self.mouse_on) return;
+        // Best-effort on the way out: a vanished tty has nothing to restore.
+        self.writeAll(seq.mouse_disable) catch {};
+        self.mouse_on = false;
+    }
+
     /// Idempotent undo of everything entered, safe to call twice and mid-render.
-    /// Reverse of a typical entry (raw → alt → hide): show cursor, leave the
-    /// alt-screen, then drop back to cooked mode.
+    /// Reverse of entry (raw → alt → hide): show cursor, leave the alt-screen,
+    /// then drop back to cooked mode. disableMouse is folded in ahead of the
+    /// alt-screen leave so a later enableMouse unwinds here too.
     pub fn restore(self: *Term) void {
         self.showCursor();
+        self.disableMouse();
         self.exitAltScreen();
         self.exitRaw();
     }
@@ -159,10 +179,92 @@ test "alt-screen and cursor escape sequences are the expected bytes" {
     try std.testing.expectEqualStrings("\x1b[K", seq.erase_line);
     try std.testing.expectEqualStrings("\x1b[?2026h", seq.sync_begin);
     try std.testing.expectEqualStrings("\x1b[?2026l", seq.sync_end);
+    try std.testing.expectEqualStrings("\x1b[?1000h\x1b[?1006h", seq.mouse_enable);
+    try std.testing.expectEqualStrings("\x1b[?1000l\x1b[?1006l", seq.mouse_disable);
 }
 
 test "cursorMove writes a 1-based CUP sequence" {
     var buf: [32]u8 = undefined;
     try std.testing.expectEqualStrings("\x1b[3;5H", try cursorMove(&buf, 3, 5));
     try std.testing.expectEqualStrings("\x1b[1;1H", try cursorMove(&buf, 1, 1));
+}
+
+// A pipe stands in for the tty so tests can read back exactly what `Term`
+// writes; `io` is untouched by the write helpers, so `undefined` is safe.
+fn termOnPipe(write_fd: std.posix.fd_t) Term {
+    return .{ .io = undefined, .fd = write_fd };
+}
+
+// Non-blocking read end so an under-writing helper fails the read assertion
+// instead of hanging the test.
+fn setNonblock(read_fd: std.posix.fd_t) !void {
+    const nonblock: c_int = @bitCast(std.posix.O{ .NONBLOCK = true });
+    try std.testing.expect(std.c.fcntl(read_fd, std.posix.F.SETFL, nonblock) != -1);
+}
+
+test "enableMouse twice writes mouse_enable once and flips mouse_on" {
+    var fds: [2]std.posix.fd_t = undefined;
+    try std.testing.expectEqual(@as(c_int, 0), std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+
+    try setNonblock(fds[0]);
+
+    var t = termOnPipe(fds[1]);
+    try t.enableMouse();
+    try t.enableMouse(); // idempotent guard: no second write
+    try std.testing.expect(t.mouse_on);
+
+    // Sentinel proves the guard wrote nothing after the first enable.
+    try std.testing.expectEqual(@as(isize, 1), std.c.write(fds[1], "S", 1));
+    var buf: [seq.mouse_enable.len + 1]u8 = undefined;
+    var got: usize = 0;
+    while (got < buf.len) {
+        const n = std.c.read(fds[0], buf[got..].ptr, buf.len - got);
+        try std.testing.expect(n > 0);
+        got += @intCast(n);
+    }
+    try std.testing.expectEqualStrings(seq.mouse_enable ++ "S", &buf);
+}
+
+test "disableMouse writes nothing when mouse_on is false" {
+    var fds: [2]std.posix.fd_t = undefined;
+    try std.testing.expectEqual(@as(c_int, 0), std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+
+    try setNonblock(fds[0]);
+
+    var t = termOnPipe(fds[1]);
+    t.disableMouse(); // never enabled -> guard skips the write
+
+    // A sentinel must be the first byte readable; a stray disable would precede it.
+    try std.testing.expectEqual(@as(isize, 1), std.c.write(fds[1], "S", 1));
+    var buf: [1]u8 = undefined;
+    try std.testing.expectEqual(@as(isize, 1), std.c.read(fds[0], &buf, buf.len));
+    try std.testing.expectEqual(@as(u8, 'S'), buf[0]);
+}
+
+test "restore emits mouse_disable before alt_leave" {
+    var fds: [2]std.posix.fd_t = undefined;
+    try std.testing.expectEqual(@as(c_int, 0), std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+
+    try setNonblock(fds[0]);
+
+    // Cursor not hidden, not in raw: restore's only writes are the mouse and
+    // alt-screen ones, so their order is observable in isolation.
+    var t = Term{ .io = undefined, .fd = fds[1], .in_alt = true, .mouse_on = true };
+    t.restore();
+
+    const want = seq.mouse_disable ++ seq.alt_leave;
+    var buf: [want.len]u8 = undefined;
+    var got: usize = 0;
+    while (got < buf.len) {
+        const n = std.c.read(fds[0], buf[got..].ptr, buf.len - got);
+        try std.testing.expect(n > 0);
+        got += @intCast(n);
+    }
+    try std.testing.expectEqualStrings(want, &buf);
 }

--- a/src/ui/term_restore.zig
+++ b/src/ui/term_restore.zig
@@ -10,10 +10,11 @@
 const std = @import("std");
 
 /// Everything a crashing raw-mode process must emit: leave the alt screen,
-/// show the cursor, re-enable autowrap, return to column 0. Emitting
-/// `?1049l` while not on the alt buffer is a no-op on xterm-family
-/// terminals, so the crash path never tracks alt-screen state separately.
-pub const restore_seq = "\x1b[?1049l\x1b[?25h\x1b[?7h\r";
+/// show the cursor, re-enable autowrap, return to column 0, and stop mouse
+/// reporting so a dead shell isn't buried in report bytes. Emitting these
+/// while the mode was never entered is a no-op on xterm-family terminals, so
+/// the crash path never tracks alt-screen or mouse state separately.
+pub const restore_seq = "\x1b[?1049l\x1b[?25h\x1b[?7h\r\x1b[?1000l\x1b[?1006l";
 
 // The flag flips `.release` only after fd/termios are in place, so a crash
 // path's `.acquire` load never observes a half-written registration.
@@ -77,6 +78,13 @@ pub fn installCrashSignals() void {
 // pins that HUP and QUIT get the same restore-then-die wiring. SA_RESETHAND
 // is not asserted here — Darwin does not report it back through a sigaction
 // query — its effect is covered by the death-by-signal test below.
+test "restore_seq disables mouse tracking so a dead shell stops receiving reports" {
+    try std.testing.expectEqualStrings(
+        "\x1b[?1049l\x1b[?25h\x1b[?7h\r\x1b[?1000l\x1b[?1006l",
+        restore_seq,
+    );
+}
+
 test "installCrashSignals wires TERM/HUP/QUIT to the restore handler" {
     var prev: [crash_signals.len]std.posix.Sigaction = undefined;
     for (crash_signals, 0..) |sig, i| std.posix.sigaction(sig, null, &prev[i]);


### PR DESCRIPTION
## Description

Teaches the TUI to turn mouse tracking on and off cleanly. Adds the ?1000+?1006 enable / disable escape sequences and `Term.enableMouse`/`disableMouse` guarded like the existing cursor helpers, folds disableMouse into restore() so it unwinds with the rest of the terminal state, and extends the crash restore sequence so a panic or termination signal also stops mouse reporting - otherwise a dead shell keeps receiving report bytes. The run loop does not enable mouse mode yet; that lands with the wheel behaviour so mouse reporting is only ever on when something consumes it.

## Related Issue

- None

## Notes for Reviewers

- ?1000 only (button + wheel), not ?1002/?1003 motion, which would flood the loop.
- Disable/crash sequences are idempotent, so merging this before the consumer is safe.