### PR TITLE
feat(tui): hit-test clicks to Installed rows

### DIFF
--- a/src/tui/installed_tab.zig
+++ b/src/tui/installed_tab.zig
@@ -166,6 +166,29 @@ fn resolveGuard(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, ke
     return .none;
 }
 
+pub const Hit = tab.Hit;
+
+/// The list's on-screen geometry: the sub-rect below the heading, the view
+/// `clamp`ed to that height, and the filtered row `count`. The single source of
+/// truth `render` and `hitTest` share, so the painted rows and the hit-test can
+/// never disagree about where a row is.
+fn listGeometry(s: *const State, rect: tab.Rect) struct { list: tab.Rect, view: scroll_list.View, count: usize } {
+    const nf = filteredCount(s.items, s.chrome.filter.slice());
+    // The bold heading rides row 0 and costs the list one row.
+    const list: tab.Rect = .{ .row = rect.row + 1, .col = rect.col, .width = rect.width, .height = rect.height -| 1 };
+    return .{ .list = list, .view = scroll_list.clamp(s.chrome.view, nf, list.height), .count = nf };
+}
+
+/// Map a click to the list row it lands on. The shell consumes `Hit.open` on a
+/// right-click (a detail pane exists); a left-click just uses `index` to move the
+/// cursor. `click_col` is accepted but unused — rows are full-width.
+pub fn hitTest(s: *const State, rect: tab.Rect, click_row: u16, click_col: u16) ?Hit {
+    _ = click_col; // full-width rows: the column carries no row identity
+    const g = listGeometry(s, rect);
+    const idx = scroll_list.rowAt(g.view, g.list.row, g.list.height, g.count, click_row) orelse return null;
+    return .{ .index = idx, .open = true }; // Installed rows open their detail pane
+}
+
 /// Pure render: an optional guard banner on top, an optional detail pane at the
 /// bottom, the filtered + scrolled list in between. A pure function of
 /// `(state, rect)` so a resize is a re-render.
@@ -198,17 +221,17 @@ pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
 fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     if (rect.height == 0) return;
     const filter = s.chrome.filter.slice();
-    const nf = filteredCount(s.items, filter);
-    if (nf == 0) return tab.renderHint(f, rect, if (filter.len != 0) "No matches." else "No packages installed yet.");
+    const g = listGeometry(s, rect);
+    if (g.count == 0) return tab.renderHint(f, rect, if (filter.len != 0) "No matches." else "No packages installed yet.");
     // A fixed bold heading rides above the list and costs it one row.
     tab.renderHeading(f, rect, 0, &.{
         .{ .label = "NAME", .width = 22 },
         .{ .label = "VERSION", .width = 14 },
         .{ .label = "SIZE", .width = 10 },
     });
-    const list: tab.Rect = .{ .row = rect.row + 1, .col = rect.col, .width = rect.width, .height = rect.height -| 1 };
+    const list = g.list;
     if (list.height == 0) return; // the heading took the only row
-    const v = scroll_list.clamp(s.chrome.view, nf, list.height);
+    const v = g.view;
 
     var fi: usize = 0;
     for (s.items) |p| {
@@ -725,6 +748,60 @@ test "a filter that excludes every row shows the no-matches placeholder" {
     s.chrome.filter.push("zzznomatch");
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 10 });
     try testing.expect(std.mem.indexOf(u8, f.slice(), "No matches") != null);
+}
+
+test "hitTest maps a click on the first list row to filtered index 0" {
+    const s: State = .{ .items = &sample };
+    // rect.row = 5 → heading at 5, list starts at 6. Clicking row 6 hits index 0.
+    const hit = hitTest(&s, .{ .row = 5, .col = 1, .width = 80, .height = 10 }, 6, 1);
+    try testing.expectEqual(@as(?usize, 0), if (hit) |h| h.index else null);
+    try testing.expect(hit.?.open); // an Installed row opens its detail pane
+}
+
+test "hitTest rejects the heading row and rows above the list" {
+    const s: State = .{ .items = &sample };
+    const rect: tab.Rect = .{ .row = 5, .col = 1, .width = 80, .height = 10 };
+    try testing.expect(hitTest(&s, rect, 5, 1) == null); // the heading row
+    try testing.expect(hitTest(&s, rect, 4, 1) == null); // above the list
+}
+
+test "hitTest resolves against the filtered list, not the raw items" {
+    var s: State = .{ .items = &sample };
+    s.chrome.filter.push("f"); // ffmpeg, flux
+    const rect: tab.Rect = .{ .row = 1, .col = 1, .width = 80, .height = 10 };
+    try testing.expectEqual(@as(?usize, 0), hitTest(&s, rect, 2, 1).?.index); // first filtered row
+    try testing.expectEqual(@as(?usize, 1), hitTest(&s, rect, 3, 1).?.index); // second filtered row
+    try testing.expect(hitTest(&s, rect, 4, 1) == null); // past the two matches
+}
+
+test "hitTest adds the scrolled view offset" {
+    var s: State = .{ .items = &sample };
+    s.chrome.view.selected = 3; // forces clamp to scroll a 2-tall list to offset 2
+    // rect.height 3 → list height 2; the top list row (row 2) maps to the offset.
+    const hit = hitTest(&s, .{ .row = 1, .col = 1, .width = 80, .height = 3 }, 2, 1);
+    try testing.expectEqual(@as(?usize, 2), hit.?.index);
+}
+
+test "hitTest rejects a blank row past the populated tail" {
+    var s: State = .{ .items = &sample };
+    s.chrome.filter.push("curl"); // one match
+    // Tall list, one row: the second list row (row 3) is blank tail.
+    const rect: tab.Rect = .{ .row = 1, .col = 1, .width = 80, .height = 10 };
+    try testing.expectEqual(@as(?usize, 0), hitTest(&s, rect, 2, 1).?.index); // the one match
+    try testing.expect(hitTest(&s, rect, 3, 1) == null); // blank tail
+}
+
+test "hitTest on an empty list hits nothing" {
+    const s: State = .{ .items = &.{} }; // count 0 must reach rowAt, not a stray index
+    const rect: tab.Rect = .{ .row = 1, .col = 1, .width = 80, .height = 10 };
+    try testing.expect(hitTest(&s, rect, 2, 1) == null);
+}
+
+test "hitTest when the heading ate the only row hits nothing" {
+    const s: State = .{ .items = &sample };
+    // height 1 → list.height 0. Clicking the first would-be list row (row 2) must
+    // resolve to null: the list height (0), not the rect height (1), drives the hit.
+    try testing.expect(hitTest(&s, .{ .row = 1, .col = 1, .width = 80, .height = 1 }, 2, 1) == null);
 }
 
 test "conforms to the tab contract" {

--- a/src/tui/tab.zig
+++ b/src/tui/tab.zig
@@ -119,6 +119,14 @@ pub fn blankRemainder(f: *Frame, rect: Rect, painted: u16) void {
     while (i < rect.height) : (i += 1) f.moveClear(rect.row + i, rect.col);
 }
 
+/// Where a click landed: the list `index` it maps to, and whether that row has a
+/// detail pane worth opening (`open`). The result type of the tab contract's
+/// **optional** `hitTest(s, rect, click_row, click_col) ?Hit` decl. Optional
+/// because only tabs with a clickable list implement it — the shell gates the
+/// call on `@hasDecl`, so Doctor/Services/Outdated carry neither the method nor a
+/// dead arm, and `verify` never requires it.
+pub const Hit = struct { index: usize, open: bool };
+
 /// A multi-select row checkbox: unselected, selected, or blocked (a row that
 /// can't be selected — pinned in Outdated, already-installed in Search).
 pub const Check = enum { off, on, blocked };
@@ -215,6 +223,10 @@ pub fn verify(comptime M: type) void {
     // `step`/`update` are the Elm effect seam: they return a `cmd.Cmd` and own the
     // tab's parse storage, so a conforming tab must expose one — reported here.
     if (!@hasDecl(M, "Storage")) @compileError(@typeName(M) ++ ": tab must expose `pub const Storage`");
+    // `hitTest(s, rect, click_row, click_col) ?Hit` is an OPTIONAL contract decl:
+    // only tabs with a clickable list expose it, and the shell gates the call on
+    // `@hasDecl`. Deliberately not required here, so a tab with no detail pane
+    // carries no dead arm.
 }
 
 // ─── tests ───────────────────────────────────────────────────────────

--- a/tests/tui_installed_tab_test.zig
+++ b/tests/tui_installed_tab_test.zig
@@ -12,6 +12,8 @@ const testing = std.testing;
 const malt = @import("malt");
 const list_json = malt.tui_json_list;
 const info_json = malt.tui_json_info;
+const installed = malt.tui_tab_installed;
+const tab = malt.tui_tab;
 const test_io = @import("test_io");
 
 fn readFixture(allocator: std.mem.Allocator, name: []const u8) ![]u8 {
@@ -63,4 +65,26 @@ test "info parser consumes the recorded mt info <pkg> --json fixture" {
     try testing.expectEqual(@as(usize, 7), parsed.info.dependencies.len);
     try testing.expectEqualStrings("brotli", parsed.info.dependencies[0]);
     try testing.expectEqualStrings("zstd", parsed.info.dependencies[6]);
+}
+
+test "hitTest maps clicks onto the rows parsed from the mt list fixture" {
+    const bytes = try readFixture(testing.allocator, "tui_list.json");
+    defer testing.allocator.free(bytes);
+
+    var parsed = try list_json.parse(testing.allocator, bytes);
+    defer parsed.deinit();
+
+    // Heading at row 1, so the four fixture rows sit at rows 2..5.
+    const s = installed.State{ .items = parsed.items };
+    const rect = tab.Rect{ .row = 1, .col = 1, .width = 80, .height = 10 };
+
+    // A click resolves to the fixture row painted there — index cross-checked by name.
+    const second = installed.hitTest(&s, rect, 3, 1).?;
+    try testing.expectEqual(@as(usize, 1), second.index);
+    try testing.expectEqualStrings("curl", parsed.items[second.index].name);
+    try testing.expect(second.open);
+
+    try testing.expectEqual(@as(usize, 3), installed.hitTest(&s, rect, 5, 1).?.index); // last row
+    try testing.expect(installed.hitTest(&s, rect, 6, 1) == null); // past the four rows
+    try testing.expect(installed.hitTest(&s, rect, 1, 1) == null); // the heading row
 }


### PR DESCRIPTION
## Description

Adds a hit-test to the Installed tab that maps a click to the list row it lands on and says whether that row opens a detail pane. The list geometry (heading offset, filtered count, clamped view) is extracted into one helper that both the render loop and the hit-test call, so a click can never resolve to a different row than the one painted. `hitTest` joins the tab interface as an optional, `@hasDecl`-gated declaration, so tabs without a detail pane carry nothing. No behaviour change to rendering; the shell wires the click next.

## Related Issue

- None

## Notes for Reviewers

- `listGeometry` is the single source of truth shared with `render` - the point of the
  extraction is that the two can't drift. The contract is optional; other tabs untouched.