### PR TITLE
feat(tui): drive the dashboard with mouse clicks

### DIFF
--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -184,6 +184,47 @@ fn renderActive(a: *const App, f: *tab.Frame, rect: tab.Rect) void {
     }
 }
 
+/// Split the chrome separator off the content band the way `renderFrame` does: the
+/// list tabs lose one row to the dim rule, Doctor keeps the whole band (it draws its
+/// own top rule). The one derivation the paint path and a click both use, so a click
+/// resolves against the exact rect the tab painted.
+fn bodyRect(active: Tab, content: tab.Rect) tab.Rect {
+    if (active == .doctor) return content;
+    return .{ .row = content.row + 1, .col = content.col, .width = content.width, .height = content.height -| 1 };
+}
+
+/// The body rect the active tab paints into for a given terminal size, or null
+/// below the usable minimum (where nothing is clickable). Lets a click hit-test
+/// against the same geometry `renderFrame` paints.
+fn contentBodyRect(app: *const App, size: term.Size) ?tab.Rect {
+    return switch (layout.compute(size.cols, size.rows)) {
+        .too_small => null,
+        .ok => |r| bodyRect(app.active, r.content),
+    };
+}
+
+/// The filter/query input's screen row for a terminal size, or null below the usable
+/// minimum — the row a click focuses the box on.
+fn filterRow(size: term.Size) ?u16 {
+    return switch (layout.compute(size.cols, size.rows)) {
+        .too_small => null,
+        .ok => |r| r.filter.row,
+    };
+}
+
+/// Hit-test a click against the active tab's list, or null when the tab exposes no
+/// `hitTest` (Doctor/Services/Outdated have no clickable list). The `@hasDecl` gate
+/// keeps those tabs free of a dead arm, matching the optional tab contract.
+fn activeHitTest(app: *const App, body: tab.Rect, click_row: u16, click_col: u16) ?tab.Hit {
+    switch (app.active) {
+        inline else => |t| {
+            const M = moduleFor(t);
+            if (!@hasDecl(M, "hitTest")) return null;
+            return M.hitTest(&@field(app.states, @tagName(t)), body, click_row, click_col);
+        },
+    }
+}
+
 fn activeFooterHint(a: *const App) []const u8 {
     switch (a.active) {
         inline else => |t| return moduleFor(t).footerHint(),
@@ -337,12 +378,8 @@ pub fn renderFrame(buf: []u8, app: *const App, cols: u16, rows: u16) []const u8 
             // the list tabs. Doctor paints its own rule at the band top, so it is
             // left out here and never shows a doubled rule; the rule costs the tab
             // one content row.
-            var body = r.content;
-            if (app.active != .doctor) {
-                tab.renderSeparator(&f, r.content, r.content.row, true);
-                body = .{ .row = r.content.row + 1, .col = r.content.col, .width = r.content.width, .height = r.content.height -| 1 };
-            }
-            renderActive(app, &f, body);
+            if (app.active != .doctor) tab.renderSeparator(&f, r.content, r.content.row, true);
+            renderActive(app, &f, bodyRect(app.active, r.content));
 
             // Footer: a rule line separating content, then — by priority — the
             // pre-read loading status, the transient error banner, or the help line.
@@ -931,28 +968,54 @@ fn serviceKey(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: 
     try onEntryReload(io, allocator, t, painter, fetches, app, store);
 }
 
-/// One decoded mouse report's turn. Takes the full `serviceKey` argument list so
-/// the later click arms (left = select, right = open) slot in without a signature
-/// change; today only the wheel acts, a pure `selected` nudge that render's
-/// `clamp` bounds — so it never needs the list length or viewport height. Every
-/// non-wheel event (left/right press, any release) is a deliberate no-op until the
-/// click work lands; the moment `?1000` tracking is on, those all flow in here.
+/// One decoded mouse report's turn. Left-press moves the selection to the row under
+/// the pointer and synthesizes `.space` — the multi-select tabs' basket toggle (inert
+/// where there is no basket, e.g. Installed). Right-press moves the selection and
+/// synthesizes `.enter`, which opens the row's detail pane or toggles it closed when
+/// it is already open for that row — reusing the whole Enter → `mt info` → pump path
+/// verbatim. A left-press on the filter/query input row focuses it for typing (mouse
+/// parity with `/`). The wheel nudges `selected`, which render's `clamp` bounds. Only a
+/// press acts; releases are inert for every button.
 fn serviceMouse(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter: Painter, fetches: *Fetches, app: *App, store: *Storages, m: keys.Mouse) RunError!void {
-    // The uninstall guard is modal for the wheel too: freeze here rather than
-    // routing through the key-trap, which would read the notch as a cancel.
+    // The uninstall guard is modal for every button: freeze here rather than routing
+    // through the key-trap, which would read a click or a notch as a cancel.
     if (app.active == .installed and app.states.installed.confirm_uninstall != null) return;
+    if (!m.press) return; // only a press acts; a release moves and opens nothing
+    // A left-click on the query/filter input row focuses it for typing — mouse parity
+    // with `/`. It sits above the list, so it never collides with a row hit-test.
+    if (m.button == 0) {
+        if (filterRow(term.currentSize())) |fr| if (m.row == fr) {
+            app.editing = true;
+            return;
+        };
+    }
     switch (m.button) {
         64 => activeChrome(app).view.selected -|= wheel_step, // wheel up
         65 => activeChrome(app).view.selected += wheel_step, // wheel down
-        else => {}, // press/release for the click work — inert for now
+        0 => if (clickSelect(app, m)) |_| {
+            // Left picks: `.space` toggles the basket on the multi-select tabs and is
+            // inert elsewhere. Editing swallows space, so a click mid-type just moves
+            // the cursor.
+            try serviceKey(io, allocator, t, painter, fetches, app, store, .space);
+        },
+        2 => if (clickSelect(app, m)) |hit| {
+            // Right opens the row's pane, or toggles it closed on the open row. Inert
+            // while editing so a click can't pop a pane mid-type; flip `!app.editing`.
+            if (hit.open and !app.editing) try serviceKey(io, allocator, t, painter, fetches, app, store, .enter);
+        },
+        else => {}, // modified / horizontal wheel and other buttons: inert
     }
-    // Held for the click arms (left = select, right = open); the wheel needs none.
-    _ = io;
-    _ = allocator;
-    _ = t;
-    _ = painter;
-    _ = fetches;
-    _ = store;
+}
+
+/// Resolve a click to the active tab's list row and move the cursor there, returning
+/// the hit so a right-press can consult `open`. Null when the click misses a row or
+/// the tab has no clickable list. The rect is the one the tab painted, so the row
+/// under the pointer is the row selected.
+fn clickSelect(app: *App, m: keys.Mouse) ?tab.Hit {
+    const body = contentBodyRect(app, term.currentSize()) orelse return null;
+    const hit = activeHitTest(app, body, m.row, m.col) orelse return null;
+    activeChrome(app).view.selected = hit.index;
+    return hit;
 }
 
 fn repaint(fd: std.posix.fd_t, frame: *[]u8, allocator: std.mem.Allocator, app: *App) std.mem.Allocator.Error!void {
@@ -994,13 +1057,22 @@ fn echoArgv(allocator: std.mem.Allocator, doc: []const u8) std.mem.Allocator.Err
 // Synthetic decoded mouse reports, exactly as the decode loop hands `serviceMouse`.
 const wheel_up: keys.Mouse = .{ .button = 64, .col = 1, .row = 1, .press = true };
 const wheel_down: keys.Mouse = .{ .button = 65, .col = 1, .row = 1, .press = true };
-const left_press: keys.Mouse = .{ .button = 0, .col = 5, .row = 3, .press = true };
-const left_release: keys.Mouse = .{ .button = 0, .col = 5, .row = 3, .press = false };
+
+// A left/right button report at a list row. At 80x24 the content body starts at
+// row 5 and each tab's heading eats one row, so populated list rows begin at 6.
+const first_row: u16 = 6;
+fn leftAt(row: u16) keys.Mouse {
+    return .{ .button = 0, .col = 1, .row = row, .press = true };
+}
+fn rightAt(row: u16) keys.Mouse {
+    return .{ .button = 2, .col = 1, .row = row, .press = true };
+}
 
 /// Drive `serviceMouse` in place for a wheel/no-op/modal test. Builds the same
 /// headless rig the pump tests use; the wheel arms touch only `app`, so io/term
 /// stay unused just as the loop's mouse turn leaves them until the click work.
 fn serviceMouseA(a: *App, m: keys.Mouse) !void {
+    term.setSizeForTest(.{ .cols = 80, .rows = 24 }); // deterministic geometry for the click hit-test
     var thr = std.Io.Threaded.init(std.testing.allocator, .{});
     defer thr.deinit();
     var store: Storages = .{};
@@ -1256,15 +1328,135 @@ test "the wheel scrolls the filtered list while the filter is being edited" {
     try std.testing.expect(a.editing); // the notch scrolled without disturbing edit mode
 }
 
-test "a left-press and its release are no-ops until the click work lands" {
+const click_pkgs = [_]installed.Pkg{
+    .{ .name = "pkga", .version = "1", .kind = .formula, .pinned = false, .size_bytes = null, .linked = null },
+    .{ .name = "pkgb", .version = "1", .kind = .formula, .pinned = false, .size_bytes = null, .linked = null },
+    .{ .name = "pkgc", .version = "1", .kind = .formula, .pinned = false, .size_bytes = null, .linked = null },
+};
+
+const search_matches = [_]search.Match{
+    .{ .name = "wget", .kind = .formula, .installed = false },
+    .{ .name = "curl", .kind = .formula, .installed = false },
+};
+
+const search_basket = [_]search.SelEntry{
+    .{ .name = "wget", .kind = .formula },
+    .{ .name = "curl", .kind = .formula },
+};
+
+test "a left-press selects the row under the pointer and opens no pane" {
     var a: App = .{ .active = .installed };
-    a.states.installed.items = &guard_pkgs;
-    try serviceMouseA(&a, left_press);
-    try serviceMouseA(&a, left_release);
-    try std.testing.expectEqual(@as(usize, 0), activeChrome(&a).view.selected); // selection unmoved
-    try std.testing.expect(!a.editing);
-    try std.testing.expect(!a.quit);
-    try std.testing.expect(a.states.installed.confirm_uninstall == null); // nothing armed
+    a.states.installed.items = &click_pkgs;
+    try serviceMouseA(&a, leftAt(first_row + 2)); // third list row
+    try std.testing.expectEqual(@as(usize, 2), activeChrome(&a).view.selected);
+    try std.testing.expect(a.states.installed.detail == null); // select is non-committal — no pane
+    try std.testing.expect(!a.shared.banner.isSet()); // no info read ran
+}
+
+test "a left-press on the query/filter input row focuses it for typing" {
+    var a: App = .{ .active = .search };
+    a.states.search.items = &search_matches;
+    a.states.search.phase = .loaded;
+    try serviceMouseA(&a, leftAt(3)); // 80x24 layout: header 1, tab-bar 2, filter 3
+    try std.testing.expect(a.editing); // clicking the box starts editing, like `/`
+    try std.testing.expectEqual(@as(usize, 0), a.states.search.chrome.view.selected); // not a list pick
+    try std.testing.expectEqual(@as(usize, 0), a.states.search.selected_count); // nothing added to the basket
+}
+
+test "a left-press on a Search results row picks it into the basket" {
+    var a: App = .{ .active = .search };
+    defer a.storages.deinit(std.testing.allocator); // the pick allocates into the app's basket
+    a.states.search.items = &search_matches;
+    a.states.search.phase = .loaded;
+    try serviceMouseA(&a, leftAt(first_row + 1)); // second result
+    try std.testing.expectEqual(@as(usize, 1), a.states.search.chrome.view.selected); // cursor moved
+    try std.testing.expectEqual(@as(usize, 1), a.states.search.selected_count); // picked into the basket
+    try std.testing.expect(a.states.search.detail == null); // still no pane
+}
+
+test "a right-press on an Installed row selects it and runs the open (Enter) path" {
+    var a: App = .{ .active = .installed, .mt_path = "/bin/echo" }; // echo backs the info read
+    a.states.installed.items = &click_pkgs;
+    try serviceMouseA(&a, rightAt(first_row + 1)); // second list row
+    try std.testing.expectEqual(@as(usize, 1), activeChrome(&a).view.selected);
+    // The synthetic Enter reached the real info read (echo's output isn't JSON, so
+    // it banners rather than opening — the pane render itself is proven elsewhere).
+    try std.testing.expect(a.shared.banner.isSet());
+}
+
+test "a right-press on a Search results row runs the open path" {
+    var a: App = .{ .active = .search, .mt_path = "/bin/echo" };
+    a.states.search.items = &search_matches;
+    a.states.search.phase = .loaded;
+    try serviceMouseA(&a, rightAt(first_row));
+    try std.testing.expectEqual(@as(usize, 0), a.states.search.chrome.view.selected);
+    try std.testing.expect(a.shared.banner.isSet()); // results rows are openable
+}
+
+test "a right-press on a Search basket row selects it but opens nothing" {
+    var a: App = .{ .active = .search, .mt_path = "/bin/echo" };
+    a.states.search.basket = &search_basket;
+    a.states.search.view = .basket; // basket's count title + heading push its rows two down
+    try serviceMouseA(&a, rightAt(first_row + 2)); // row 8 → second basket row
+    try std.testing.expectEqual(@as(usize, 1), a.states.search.chrome.view.selected);
+    try std.testing.expect(!a.shared.banner.isSet()); // basket has no detail pane — no read
+}
+
+test "a click on a tab with no hit-test is a no-op, never a crash" {
+    var a: App = .{ .active = .services };
+    try serviceMouseA(&a, leftAt(first_row));
+    try serviceMouseA(&a, rightAt(first_row));
+    try std.testing.expectEqual(@as(usize, 0), activeChrome(&a).view.selected);
+}
+
+test "the uninstall-confirm modal freezes both buttons so the guard is never cancelled" {
+    var a: App = .{ .active = .installed };
+    a.states.installed.items = &click_pkgs;
+    stepA(&a, ch('x')); // arm the guard on row 0
+    try std.testing.expect(a.states.installed.confirm_uninstall != null);
+    try serviceMouseA(&a, leftAt(first_row + 2));
+    try serviceMouseA(&a, rightAt(first_row + 2));
+    try std.testing.expect(a.states.installed.confirm_uninstall != null); // guard intact
+    try std.testing.expectEqual(@as(usize, 0), activeChrome(&a).view.selected); // no selection moved
+}
+
+test "while editing, a left-press still moves the selection" {
+    var a: App = .{ .active = .installed };
+    a.states.installed.items = &click_pkgs;
+    stepA(&a, ch('/')); // enter filter editing
+    try std.testing.expect(a.editing);
+    try serviceMouseA(&a, leftAt(first_row + 2));
+    try std.testing.expectEqual(@as(usize, 2), activeChrome(&a).view.selected);
+    try std.testing.expect(a.editing); // click didn't disturb edit mode
+}
+
+test "while editing, a right-press moves the selection but opens no pane" {
+    var a: App = .{ .active = .installed, .mt_path = "/bin/echo" };
+    a.states.installed.items = &click_pkgs;
+    stepA(&a, ch('/'));
+    try serviceMouseA(&a, rightAt(first_row + 1));
+    try std.testing.expectEqual(@as(usize, 1), activeChrome(&a).view.selected);
+    try std.testing.expect(!a.shared.banner.isSet()); // open is inert mid-type — no read
+}
+
+test "a button release acts on nothing — only a press selects or opens" {
+    var a: App = .{ .active = .installed, .mt_path = "/bin/echo" };
+    a.states.installed.items = &click_pkgs;
+    try serviceMouseA(&a, .{ .button = 0, .col = 1, .row = first_row + 2, .press = false }); // left release
+    try serviceMouseA(&a, .{ .button = 2, .col = 1, .row = first_row + 2, .press = false }); // right release
+    try std.testing.expectEqual(@as(usize, 0), activeChrome(&a).view.selected);
+    try std.testing.expect(!a.shared.banner.isSet());
+}
+
+test "clicking the exact first and last populated rows lands on the right indices" {
+    var a: App = .{ .active = .installed };
+    a.states.installed.items = &click_pkgs; // three rows: 6, 7, 8
+    try serviceMouseA(&a, leftAt(first_row)); // first row
+    try std.testing.expectEqual(@as(usize, 0), activeChrome(&a).view.selected);
+    try serviceMouseA(&a, leftAt(first_row + 2)); // last populated row
+    try std.testing.expectEqual(@as(usize, 2), activeChrome(&a).view.selected);
+    try serviceMouseA(&a, leftAt(first_row + 3)); // blank tail past the list — no move
+    try std.testing.expectEqual(@as(usize, 2), activeChrome(&a).view.selected);
 }
 
 test "a modifier-flagged wheel is inert, never a partial-code scroll" {

--- a/src/tui/detail_pane.zig
+++ b/src/tui/detail_pane.zig
@@ -37,6 +37,15 @@ pub fn neededRows(fields: []const Field, width: u16) u16 {
     return rows;
 }
 
+/// The height a docked pane takes for `fields` in a `height`-row region at `width`:
+/// its content rows, capped at half so the list it docks under survives; 0 when it
+/// wouldn't fit. The one place a paint and a hit-test agree on the split, so a click
+/// resolves against the same rows the pane left for the list.
+pub fn dockHeight(fields: []const Field, width: u16, height: u16) u16 {
+    const dh = @min(neededRows(fields, width), height / 2);
+    return if (dh > 0 and dh < height) dh else 0;
+}
+
 /// Paint a dim separator rule, then `fields`: a dim `label:` then its value, the
 /// value wrapped across rows (continuations indented under it) so a long message
 /// stays readable on a narrow pane instead of being cut off. Clipped to
@@ -136,6 +145,13 @@ test "neededRows grows with a wrapped value and counts at least one row per fiel
     try testing.expect(neededRows(&long, 20) > 2); // wraps to several rows at width 20
     const empty = [_]Field{.{ .label = "Deps", .value = "" }};
     try testing.expectEqual(@as(u16, 2), neededRows(&empty, 40)); // separator + the label row
+}
+
+test "dockHeight caps the pane at half the region and zeroes when it can't fit" {
+    const fields = [_]Field{ .{ .label = "A", .value = "x" }, .{ .label = "B", .value = "y" } };
+    try testing.expectEqual(@as(u16, 3), dockHeight(&fields, 40, 10)); // 3 content rows, under the half-cap
+    try testing.expectEqual(@as(u16, 2), dockHeight(&fields, 40, 4)); // half-cap wins
+    try testing.expectEqual(@as(u16, 0), dockHeight(&fields, 40, 1)); // no room for a pane
 }
 
 test "render clips fields past the pane height" {

--- a/src/tui/installed_tab.zig
+++ b/src/tui/installed_tab.zig
@@ -135,7 +135,11 @@ pub fn step(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storag
     _ = storage;
     if (s.confirm_uninstall != null) return resolveGuard(allocator, mt_path, s, key);
     switch (key) {
-        .enter => return openDetailCmd(allocator, mt_path, s),
+        // Enter opens the selected row's detail pane, or toggles it closed when it is
+        // already open for that row (so a second Enter / a right-click dismisses it).
+        .enter => if (detailOpenForSelected(s)) {
+            s.detail = null;
+        } else return openDetailCmd(allocator, mt_path, s),
         .esc => s.detail = null, // close the detail pane
         // Only the tab knows its filtered row count, so the shell defers End here.
         .end => s.chrome.view.selected = filteredCount(s.items, s.chrome.filter.slice()) -| 1,
@@ -184,9 +188,37 @@ fn listGeometry(s: *const State, rect: tab.Rect) struct { list: tab.Rect, view: 
 /// cursor. `click_col` is accepted but unused — rows are full-width.
 pub fn hitTest(s: *const State, rect: tab.Rect, click_row: u16, click_col: u16) ?Hit {
     _ = click_col; // full-width rows: the column carries no row identity
-    const g = listGeometry(s, rect);
+    const g = listGeometry(s, listContentRect(s, rect)); // the rect the list actually paints into
     const idx = scroll_list.rowAt(g.view, g.list.row, g.list.height, g.count, click_row) orelse return null;
     return .{ .index = idx, .open = true }; // Installed rows open their detail pane
+}
+
+/// The detail pane's fields for the open row, borrowing the caller's scratch for the
+/// humanized size and the joined deps.
+fn detailFields(d: Detail, size_buf: []u8, deps_buf: []u8) [5]detail_pane.Field {
+    return .{
+        .{ .label = "Tap", .value = if (d.info.tap.len != 0) d.info.tap else "-" },
+        .{ .label = "Size", .value = bytes.humanizeOpt(d.pkg.size_bytes, size_buf) },
+        .{ .label = "Linked", .value = yesNo(d.pkg.linked) },
+        .{ .label = "Pinned", .value = if (d.pkg.pinned) "yes" else "no" },
+        .{ .label = "Dependencies", .value = joinDeps(deps_buf, d.info.dependencies) },
+    };
+}
+
+/// The rect `renderList` paints into: the content minus the guard banner (top) and
+/// the docked detail pane (bottom). Shared with `hitTest` so a click lands on the row
+/// under the pointer even with a pane open.
+fn listContentRect(s: *const State, rect: tab.Rect) tab.Rect {
+    var content = rect;
+    if (s.confirm_uninstall != null)
+        content = .{ .row = content.row + 1, .col = content.col, .width = content.width, .height = content.height -| 1 };
+    if (s.detail) |d| {
+        var size_buf: [16]u8 = undefined;
+        var deps_buf: [512]u8 = undefined;
+        const fields = detailFields(d, &size_buf, &deps_buf);
+        content.height -|= detail_pane.dockHeight(&fields, content.width, content.height);
+    }
+    return content;
 }
 
 /// Pure render: an optional guard banner on top, an optional detail pane at the
@@ -202,15 +234,9 @@ pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     if (s.detail) |d| {
         var size_buf: [16]u8 = undefined;
         var deps_buf: [512]u8 = undefined;
-        const fields = [_]detail_pane.Field{
-            .{ .label = "Tap", .value = if (d.info.tap.len != 0) d.info.tap else "-" },
-            .{ .label = "Size", .value = bytes.humanizeOpt(d.pkg.size_bytes, &size_buf) },
-            .{ .label = "Linked", .value = yesNo(d.pkg.linked) },
-            .{ .label = "Pinned", .value = if (d.pkg.pinned) "yes" else "no" },
-            .{ .label = "Dependencies", .value = joinDeps(&deps_buf, d.info.dependencies) },
-        };
-        const dh = @min(detail_pane.neededRows(&fields, content.width), content.height / 2);
-        if (dh > 0 and dh < content.height) {
+        const fields = detailFields(d, &size_buf, &deps_buf);
+        const dh = detail_pane.dockHeight(&fields, content.width, content.height);
+        if (dh > 0) {
             list_rect.height = content.height - dh;
             detail_pane.render(f, &fields, .{ .row = content.row + list_rect.height, .col = content.col, .width = content.width, .height = dh });
         }
@@ -322,6 +348,14 @@ pub fn countFromJson(allocator: std.mem.Allocator, json: []const u8) list_json.E
     const parsed = try list_json.parse(allocator, json);
     defer parsed.deinit();
     return parsed.items.len;
+}
+
+/// True when the detail pane is open for the currently selected row. The pane is
+/// opened for the selection, so a name match means it belongs to that row.
+fn detailOpenForSelected(s: *const State) bool {
+    const d = s.detail orelse return false;
+    const sel = selectedPkg(s) orelse return false;
+    return std.mem.eql(u8, d.pkg.name, sel.name);
 }
 
 /// Build the `mt info <pkg> --json` read for the selected row (a blocking read, no
@@ -491,6 +525,22 @@ test "Esc closes an open detail pane" {
     var s: State = .{ .items = &sample, .detail = .{ .pkg = sample[0], .info = .{} } };
     try testing.expect(stepKey(&s, .esc) == .none);
     try testing.expect(s.detail == null);
+}
+
+test "Enter toggles an open detail pane closed for the selected row" {
+    var s: State = .{ .items = &sample, .detail = .{ .pkg = sample[0], .info = .{ .name = "brotli" } } };
+    // selected defaults to 0 → brotli, exactly the row the pane is open for.
+    try testing.expect(stepKey(&s, .enter) == .none); // toggled closed, no new read
+    try testing.expect(s.detail == null);
+}
+
+test "Enter switches the pane to a newly selected row instead of closing it" {
+    var s: State = .{ .items = &sample, .detail = .{ .pkg = sample[0], .info = .{ .name = "brotli" } } };
+    s.chrome.view.selected = 1; // curl, while the pane belongs to brotli
+    const eff = stepKey(&s, .enter);
+    defer testing.allocator.free(eff.read.argv);
+    try testing.expect(eff == .read); // opens curl's info, not a close
+    try testing.expectEqualStrings("curl", eff.read.argv[2]);
 }
 
 test "x raises the uninstall guard, producing no effect yet" {
@@ -802,6 +852,36 @@ test "hitTest when the heading ate the only row hits nothing" {
     // height 1 → list.height 0. Clicking the first would-be list row (row 2) must
     // resolve to null: the list height (0), not the rect height (1), drives the hit.
     try testing.expect(hitTest(&s, .{ .row = 1, .col = 1, .width = 80, .height = 1 }, 2, 1) == null);
+}
+
+// A list taller than any docked layout, so a scrolled view exposes the offset
+// difference between the full rect and the pane-shrunk rect.
+const tall_sample = blk: {
+    var arr: [30]Pkg = undefined;
+    for (&arr, 0..) |*p, i|
+        p.* = .{ .name = std.fmt.comptimePrint("pkg{d:0>2}", .{i}), .version = "1", .kind = .formula, .pinned = false, .size_bytes = null, .linked = null };
+    break :blk arr;
+};
+
+test "hitTest resolves against the shrunk list when a detail pane is docked" {
+    // rect height 10 → the pane caps at 5 rows (its 5 fields need 6), so the list
+    // shrinks to rows 2..5. A click at row 8 lands in the pane, not on a list row —
+    // against the full rect it would have mis-mapped to a package.
+    const s: State = .{ .items = &tall_sample, .detail = .{ .pkg = tall_sample[0], .info = .{} } };
+    const rect: tab.Rect = .{ .row = 1, .col = 1, .width = 80, .height = 10 };
+    try testing.expectEqual(@as(?usize, 3), hitTest(&s, rect, 5, 1).?.index); // last shrunk row
+    try testing.expect(hitTest(&s, rect, 8, 1) == null); // the docked pane, not a row
+}
+
+test "hitTest uses the shrunk-height scroll offset when a pane is open" {
+    // Scrolled deep: the pane-shrunk clamp scrolls further than the full-rect clamp,
+    // so the top visible row is a different package under each. The click must follow
+    // the painted (shrunk) offset.
+    var s: State = .{ .items = &tall_sample, .detail = .{ .pkg = tall_sample[0], .info = .{} } };
+    s.chrome.view.selected = 20;
+    const rect: tab.Rect = .{ .row = 1, .col = 1, .width = 80, .height = 10 };
+    // shrunk list height 4, selected 20 → offset 17; the top list row (row 2) is item 17.
+    try testing.expectEqual(@as(?usize, 17), hitTest(&s, rect, 2, 1).?.index);
 }
 
 test "conforms to the tab contract" {

--- a/src/tui/search_tab.zig
+++ b/src/tui/search_tab.zig
@@ -183,8 +183,9 @@ pub fn hitTest(s: *const State, rect: tab.Rect, click_row: u16, click_col: u16) 
     _ = click_col; // full-width rows: the column carries no row identity
     const g = switch (s.view) {
         // The results list is painted only when loaded; while a re-query is
-        // searching, stale items linger behind a status line, so map nothing.
-        .results => if (s.phase == .loaded) resultsGeometry(s, rect) else return null,
+        // searching, stale items linger behind a status line, so map nothing. The
+        // docked info pane shrinks the list, so hit-test against the painted rect.
+        .results => if (s.phase == .loaded) resultsGeometry(s, resultsContentRect(s, rect)) else return null,
         .basket => basketGeometry(s, rect), // the basket is phase-independent
     };
     const idx = scroll_list.rowAt(g.view, g.list.row, g.list.height, g.count, click_row) orelse return null;
@@ -275,9 +276,12 @@ fn selectKey(allocator: std.mem.Allocator, s: *State, storage: *Storage) void {
 /// other meaning) is driven by the shell on filter-commit via `searchCmd`.
 pub fn step(allocator: std.mem.Allocator, mt_path: []const u8, s: *State, storage: *Storage, key: tab.Key) cmd.Cmd {
     switch (key) {
-        // Enter on a result opens `mt info` for it. Committing the query is driven
-        // by the shell on filter-commit, so the two never collide.
-        .enter => if (selectedMatch(s) != null) return openSearchInfoCmd(allocator, mt_path, s),
+        // Enter on a result opens `mt info` for it, or toggles the pane closed when it
+        // is already open for that row (a second Enter / a right-click dismisses it).
+        // Committing the query is driven by the shell on filter-commit, so they never collide.
+        .enter => if (selectedMatch(s)) |m| {
+            if (resultsDetailOpen(s, m)) s.detail = null else return openSearchInfoCmd(allocator, mt_path, s);
+        },
         // `space` selects in the results view and removes in the basket view; `d`
         // is the basket-view remove alias and is inert in the results view.
         .space => selectKey(allocator, s, storage),
@@ -399,18 +403,37 @@ fn renderLoaded(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     var list_rect = r;
     if (s.detail) |info| {
         var deps_buf: [512]u8 = undefined;
-        const fields = [_]detail_pane.Field{
-            .{ .label = "Version", .value = if (info.version.len != 0) info.version else "-" },
-            .{ .label = "Tap", .value = if (info.tap.len != 0) info.tap else "-" },
-            .{ .label = "Dependencies", .value = joinDeps(&deps_buf, info.dependencies) },
-        };
-        const dh = @min(detail_pane.neededRows(&fields, r.width), r.height / 2);
-        if (dh > 0 and dh < r.height) {
+        const fields = resultsFields(info, &deps_buf);
+        const dh = detail_pane.dockHeight(&fields, r.width, r.height);
+        if (dh > 0) {
             list_rect.height = r.height - dh;
             detail_pane.render(f, &fields, .{ .row = r.row + list_rect.height, .col = r.col, .width = r.width, .height = dh });
         }
     }
     renderList(s, f, list_rect);
+}
+
+/// The info pane's fields for the open result, borrowing the caller's scratch for
+/// the joined deps.
+fn resultsFields(info: info_json.Info, deps_buf: []u8) [3]detail_pane.Field {
+    return .{
+        .{ .label = "Version", .value = if (info.version.len != 0) info.version else "-" },
+        .{ .label = "Tap", .value = if (info.tap.len != 0) info.tap else "-" },
+        .{ .label = "Dependencies", .value = joinDeps(deps_buf, info.dependencies) },
+    };
+}
+
+/// The results rect `renderLoaded` paints into: the content minus the docked info
+/// pane. Shared with `hitTest` so a click lands on the painted result even with a
+/// pane open.
+fn resultsContentRect(s: *const State, rect: tab.Rect) tab.Rect {
+    var list_rect = rect;
+    if (s.detail) |info| {
+        var deps_buf: [512]u8 = undefined;
+        const fields = resultsFields(info, &deps_buf);
+        list_rect.height -|= detail_pane.dockHeight(&fields, rect.width, rect.height);
+    }
+    return list_rect;
 }
 
 /// Comma-join a dependency list into `buf`; "none" when empty. Truncates if the
@@ -527,6 +550,13 @@ pub fn searchCmd(allocator: std.mem.Allocator, mt_path: []const u8, s: *State) c
 /// The `mt info <pkg> --json` read for the active hit, or `Cmd.none` when nothing is
 /// selected. `mt info` resolves uninstalled hits too, so a result is inspectable
 /// before any install.
+/// True when the info pane is open for the selected result — matched by name, since
+/// the pane is opened for the selection.
+fn resultsDetailOpen(s: *const State, sel: Match) bool {
+    const d = s.detail orelse return false;
+    return std.mem.eql(u8, d.name, sel.name);
+}
+
 fn openSearchInfoCmd(allocator: std.mem.Allocator, mt_path: []const u8, s: *const State) cmd.Cmd {
     const m = selectedMatch(s) orelse return .none; // empty list: no-op
     const argv = cmd.jsonArgv(allocator, mt_path, &.{ "info", m.name }) catch return .none;
@@ -1670,6 +1700,26 @@ test "a failed install retains the basket behind a recoverable banner and does n
     try testing.expect(std.mem.startsWith(u8, shared.banner.slice(), "install failed"));
 }
 
+test "Enter toggles an open results pane closed for the selected row" {
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    var s: State = .{ .items = &sample, .phase = .loaded, .detail = .{ .name = "ripgrep" } };
+    s.chrome.view.selected = 2; // ripgrep, the row the pane is open for
+    try testing.expect(stepKey(&s, &storage, .enter) == .none); // toggled closed
+    try testing.expect(s.detail == null);
+}
+
+test "Enter switches the results pane to a newly selected row instead of closing it" {
+    var storage: Storage = .{};
+    defer storage.deinit(testing.allocator);
+    var s: State = .{ .items = &sample, .phase = .loaded, .detail = .{ .name = "ripgrep" } };
+    s.chrome.view.selected = 0; // wget, while the pane belongs to ripgrep
+    const eff = stepKey(&s, &storage, .enter);
+    defer testing.allocator.free(eff.read.argv);
+    try testing.expect(eff == .read); // opens wget's info
+    try testing.expectEqualStrings("wget", eff.read.argv[2]);
+}
+
 // ── Hit-test tests ─────────────────────────────────────────────────────────
 
 test "hitTest in the results view maps a click to the row it lands on, openable" {
@@ -1687,6 +1737,32 @@ test "hitTest results index lines up with selectedMatch for the same row" {
     const hit = hitTest(&s, rect, 4, 1).?; // ripgrep's row
     s.chrome.view.selected = hit.index; // move the cursor there, as a left-click would
     try testing.expectEqualStrings("ripgrep", selectedMatch(&s).?.name); // Enter opens the same hit
+}
+
+// A results list taller than any docked layout, so a scrolled view exposes the
+// offset difference between the full rect and the pane-shrunk rect.
+const tall_results = blk: {
+    var arr: [30]Match = undefined;
+    for (&arr, 0..) |*m, i|
+        m.* = .{ .name = std.fmt.comptimePrint("pkg{d:0>2}", .{i}), .kind = .formula, .installed = false };
+    break :blk arr;
+};
+
+test "hitTest resolves against the shrunk results list when a detail pane is docked" {
+    // rect height 10 → the pane caps at 4 rows (its 3 fields need 4), so the list
+    // shrinks to rows 2..6. A click at row 8 lands in the pane, not on a result.
+    const s: State = .{ .items = &tall_results, .phase = .loaded, .detail = .{} };
+    const rect: tab.Rect = .{ .row = 1, .col = 1, .width = 80, .height = 10 };
+    try testing.expectEqual(@as(?usize, 4), hitTest(&s, rect, 6, 1).?.index); // last shrunk row
+    try testing.expect(hitTest(&s, rect, 8, 1) == null); // the docked pane, not a result
+}
+
+test "hitTest uses the shrunk-height scroll offset when a results pane is open" {
+    var s: State = .{ .items = &tall_results, .phase = .loaded, .detail = .{} };
+    s.chrome.view.selected = 20;
+    const rect: tab.Rect = .{ .row = 1, .col = 1, .width = 80, .height = 10 };
+    // shrunk results list height 5, selected 20 → offset 16; the top row (row 2) is item 16.
+    try testing.expectEqual(@as(?usize, 16), hitTest(&s, rect, 2, 1).?.index);
 }
 
 test "hitTest rejects the results heading row and rows above the list" {

--- a/src/tui/term.zig
+++ b/src/tui/term.zig
@@ -25,6 +25,7 @@ pub const takeResized = termsize.takeResized;
 pub const currentSize = termsize.currentSize;
 pub const setWinchInstalledForTest = termsize.setWinchInstalledForTest;
 pub const setResizedForTest = termsize.setResizedForTest;
+pub const setSizeForTest = termsize.setSizeForTest;
 
 /// Crash-only escape hatch, re-exported from `ui/term_restore` so the TUI
 /// run loop wires termination signals next to `installWinch`.


### PR DESCRIPTION
## Description

Makes the TUI usable with the mouse:

- A left-click on the query/filter input row focuses it for typing (mouse parity with `/`). A left-click on a row moves the cursor and, on the multi-select tabs (Search now, Outdated next), toggles the row into the basket - reusing the same `space` pick, so the click is the primary action there; on Installed (no basket) it just moves the cursor.
- A right-click on a tab with a detail pane (Installed, Search results) opens that row's pane and closes it on a second click of the open row (a different row switches the pane) - reusing the Enter -> mt info -> detail path verbatim, so no new effect code is added and Enter gains the same open/close toggle for keyboard parity.

## Related Issue

- None

## Notes for Reviewers

- None