### PR TITLE
feat(tui): hit-test clicks to Outdated rows

### DIFF
--- a/scripts/regressions/tui-mouse-tracking-dropped-after-inline-command.sh
+++ b/scripts/regressions/tui-mouse-tracking-dropped-after-inline-command.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Regression: the dashboard came back from an inline command keyboard-only. The
+# TUI hands the terminal to the child for a real `mt <subcommand>` — which drops
+# mouse tracking along with raw mode and the alt-screen — but the re-enter path
+# restored raw mode, the alt-screen and the cursor and forgot the mouse. The
+# wheel and every click were dead for the rest of the session, and nothing short
+# of quitting brought them back.
+#
+# The unit tests around the re-enter used a fake terminal that pinned only the
+# leave → spawn → enter *ordering*, so a missing re-enable was invisible to them.
+# This drives the real binary on a real pty through a real delegation and asserts
+# on the bytes the terminal actually received.
+#
+# Asserts:
+#   - mouse tracking was enabled at launch and disabled for the child (proving
+#     the round-trip really happened and this test isn't vacuous);
+#   - it was re-enabled afterwards — a second `?1000h` — so the dashboard comes
+#     back clickable.
+#
+# Every inline path (upgrade, install, uninstall, doctor fix) shares one
+# re-enter seam, so the cheapest offline delegation stands in for all of them.
+#
+# Usage:   MT_BIN=./zig-out/bin/malt ./scripts/regressions/tui-mouse-tracking-dropped-after-inline-command.sh
+# Exit:    0 when the bug is absent, 1 when present, 2 when tooling is missing.
+
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+# shellcheck source=scripts/lib/tui_pty.sh
+# shellcheck disable=SC1091 # sourced lib resolved at runtime; absent when this file is linted alone
+source "$ROOT/scripts/lib/tui_pty.sh"
+
+tui_pty_guard
+tui_pty_make_prefix
+trap 'rm -rf "$TUI_PREFIX"' EXIT
+tui_pty_seed_keg_real solopkg
+
+fail() {
+  echo "tui-mouse-reenter: FAIL — $*" >&2
+  exit 1
+}
+
+CAP="$TUI_PREFIX/cap.bin"
+# Launch opens on Search; one `tab` reaches Installed. `x` raises the uninstall
+# guard, `y` confirms and delegates to the real `mt uninstall solopkg`, which
+# hands over the terminal and re-enters on the way back.
+out=$(
+  tui_pty_drive "$CAP" 90 24 <<'ACT'
+settle 0.4
+send \t
+settle 0.4
+send x
+settle 0.4
+send y
+settle 2.0
+send q
+quitwait 3.0
+ACT
+)
+echo "$out" | grep -q "EXIT_STATUS=0" || fail "mt tui did not exit 0 on q ($out)"
+
+# Guard against a vacuous pass: the delegation must actually have happened, or
+# the counts below would prove nothing. A second alt-screen enter is the marker.
+alt=$(grep -c -a -F $'\x1b[?1049h' "$CAP" || true)
+[[ "$alt" -ge 2 ]] || fail "no inline delegation happened (alt-screen enters=$alt) — test is vacuous"
+
+# The child ran with the mouse off: the leave must have emitted a disable.
+grep -qa -F $'\x1b[?1000l' "$CAP" || fail "mouse tracking was never disabled for the child"
+
+# The bug: exactly one enable — armed at launch, never re-armed after the child.
+enable=$(grep -c -a -F $'\x1b[?1000h' "$CAP" || true)
+[[ "$enable" -ge 2 ]] ||
+  fail "mouse tracking not re-armed after the inline command (?1000h seen ${enable}x, want >=2) — the dashboard came back keyboard-only"
+
+echo "tui-mouse-reenter: OK — the wheel and clicks survive an inline command"

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -213,8 +213,8 @@ fn filterRow(size: term.Size) ?u16 {
 }
 
 /// Hit-test a click against the active tab's list, or null when the tab exposes no
-/// `hitTest` (Doctor/Services/Outdated have no clickable list). The `@hasDecl` gate
-/// keeps those tabs free of a dead arm, matching the optional tab contract.
+/// `hitTest` (Doctor/Services have no clickable list). The `@hasDecl` gate keeps
+/// those tabs free of a dead arm, matching the optional tab contract.
 fn activeHitTest(app: *const App, body: tab.Rect, click_row: u16, click_col: u16) ?tab.Hit {
     switch (app.active) {
         inline else => |t| {
@@ -1334,6 +1334,13 @@ const click_pkgs = [_]installed.Pkg{
     .{ .name = "pkgc", .version = "1", .kind = .formula, .pinned = false, .size_bytes = null, .linked = null },
 };
 
+// Index 2 (pkgc) is pinned: shown, but held back from any bulk upgrade.
+const click_rows = [_]outdated.Row{
+    .{ .name = "pkga", .installed = "1", .latest = "2", .kind = .formula, .pinned = false, .tap = "" },
+    .{ .name = "pkgb", .installed = "1", .latest = "2", .kind = .formula, .pinned = false, .tap = "" },
+    .{ .name = "pkgc", .installed = "1", .latest = "2", .kind = .formula, .pinned = true, .tap = "" },
+};
+
 const search_matches = [_]search.Match{
     .{ .name = "wget", .kind = .formula, .installed = false },
     .{ .name = "curl", .kind = .formula, .installed = false },
@@ -1372,6 +1379,64 @@ test "a left-press on a Search results row picks it into the basket" {
     try std.testing.expectEqual(@as(usize, 1), a.states.search.chrome.view.selected); // cursor moved
     try std.testing.expectEqual(@as(usize, 1), a.states.search.selected_count); // picked into the basket
     try std.testing.expect(a.states.search.detail == null); // still no pane
+}
+
+test "a left-press on an Outdated row picks it for the upgrade batch" {
+    var a: App = .{ .active = .outdated };
+    var checked = [_]bool{false} ** 3;
+    a.states.outdated.items = &click_rows;
+    a.states.outdated.checked = &checked;
+    try serviceMouseA(&a, leftAt(first_row + 1)); // second list row
+    try std.testing.expectEqual(@as(usize, 1), activeChrome(&a).view.selected); // cursor moved
+    try std.testing.expect(checked[1]); // the click picks the row, same as `space`
+    try std.testing.expect(!checked[0]); // and only that row
+}
+
+test "a left-press mid-filter moves the cursor without picking or typing into the box" {
+    var a: App = .{ .active = .outdated };
+    var checked = [_]bool{false} ** 3;
+    a.states.outdated.items = &click_rows;
+    a.states.outdated.checked = &checked;
+    stepA(&a, ch('/')); // start editing the filter
+    try serviceMouseA(&a, leftAt(first_row + 1));
+    try std.testing.expectEqual(@as(usize, 1), activeChrome(&a).view.selected); // the cursor still follows
+    // The pick rides a synthesized `space`, which the filter editor drops. That keeps
+    // the click from picking *and* from typing a blank — both hang on `space` staying
+    // inert mid-edit.
+    try std.testing.expect(!checked[1]);
+    try std.testing.expectEqualStrings("", activeChrome(&a).filter.slice());
+    try std.testing.expect(a.editing); // and the click doesn't end the edit
+}
+
+test "a left-press on a pinned Outdated row moves the cursor but never picks it" {
+    var a: App = .{ .active = .outdated };
+    var checked = [_]bool{false} ** 3;
+    a.states.outdated.items = &click_rows;
+    a.states.outdated.checked = &checked;
+    try serviceMouseA(&a, leftAt(first_row + 2)); // pkgc, pinned
+    try std.testing.expectEqual(@as(usize, 2), activeChrome(&a).view.selected);
+    try std.testing.expect(!checked[2]); // the pin outranks the click, as it does `space`
+}
+
+test "a right-press on an Outdated row moves the cursor but finds no pane to open" {
+    var a: App = .{ .active = .outdated };
+    var checked = [_]bool{false} ** 3;
+    a.states.outdated.items = &click_rows;
+    a.states.outdated.checked = &checked;
+    try serviceMouseA(&a, rightAt(first_row + 1));
+    try std.testing.expectEqual(@as(usize, 1), activeChrome(&a).view.selected); // cursor still moves
+    try std.testing.expect(!checked[1]); // right-press never picks
+    try std.testing.expect(!a.shared.banner.isSet()); // and starts no upgrade
+}
+
+test "a click below the populated Outdated rows leaves the cursor alone" {
+    var a: App = .{ .active = .outdated };
+    var checked = [_]bool{false} ** 3;
+    a.states.outdated.items = &click_rows;
+    a.states.outdated.checked = &checked;
+    try serviceMouseA(&a, leftAt(first_row + 7)); // blank tail past the three rows
+    try std.testing.expectEqual(@as(usize, 0), activeChrome(&a).view.selected);
+    for (checked) |c| try std.testing.expect(!c); // a miss picks nothing
 }
 
 test "a right-press on an Installed row selects it and runs the open (Enter) path" {

--- a/src/tui/outdated_tab.zig
+++ b/src/tui/outdated_tab.zig
@@ -165,11 +165,34 @@ pub fn render(s: *const State, f: *tab.Frame, r: tab.Rect) void {
     renderList(s, f, r);
 }
 
+pub const Hit = tab.Hit;
+
+/// The list's on-screen geometry: the sub-rect below the heading, the view
+/// `clamp`ed to that height, and the filtered row `count`. The single source of
+/// truth `render` and `hitTest` share, so the painted rows and the hit-test can
+/// never disagree about where a row is.
+fn listGeometry(s: *const State, rect: tab.Rect) struct { list: tab.Rect, view: scroll_list.View, count: usize } {
+    const nf = filteredCount(s.items, s.chrome.filter.slice());
+    // The bold heading rides row 0 and costs the list one row.
+    const list: tab.Rect = .{ .row = rect.row + 1, .col = rect.col, .width = rect.width, .height = rect.height -| 1 };
+    return .{ .list = list, .view = scroll_list.clamp(s.chrome.view, nf, list.height), .count = nf };
+}
+
+/// Map a click to the list row it lands on. `open` is always false — Outdated has
+/// no detail pane, so the shell's left-press moves the cursor and picks the row;
+/// a right-press finds nothing to open. `click_col` is unused: rows are full-width.
+pub fn hitTest(s: *const State, rect: tab.Rect, click_row: u16, click_col: u16) ?Hit {
+    _ = click_col; // full-width rows: the column carries no row identity
+    const g = listGeometry(s, rect);
+    const idx = scroll_list.rowAt(g.view, g.list.row, g.list.height, g.count, click_row) orelse return null;
+    return .{ .index = idx, .open = false };
+}
+
 fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
     if (rect.height == 0) return;
     const filter = s.chrome.filter.slice();
-    const nf = filteredCount(s.items, filter);
-    if (nf == 0) return tab.renderHint(f, rect, if (filter.len != 0) "No matches." else "Everything is up to date.");
+    const g = listGeometry(s, rect);
+    if (g.count == 0) return tab.renderHint(f, rect, if (filter.len != 0) "No matches." else "Everything is up to date.");
     // A fixed bold heading rides above the list and costs it one row.
     tab.renderHeading(f, rect, 4, &.{
         .{ .label = "NAME", .width = 22 },
@@ -177,9 +200,9 @@ fn renderList(s: *const State, f: *tab.Frame, rect: tab.Rect) void {
         .{ .label = "AVAILABLE", .width = 12 },
         .{ .label = "KIND", .width = 8 },
     });
-    const list: tab.Rect = .{ .row = rect.row + 1, .col = rect.col, .width = rect.width, .height = rect.height -| 1 };
+    const list = g.list;
     if (list.height == 0) return; // the heading took the only row
-    const v = scroll_list.clamp(s.chrome.view, nf, list.height);
+    const v = g.view;
 
     var fi: usize = 0;
     for (s.items, 0..) |p, i| {
@@ -743,6 +766,66 @@ test "render on an empty list shows the up-to-date placeholder, not a blank pane
     const s: State = .{ .items = &.{} };
     render(&s, &f, .{ .row = 1, .col = 1, .width = 80, .height = 12 }); // must not trap
     try std.testing.expect(std.mem.indexOf(u8, f.slice(), "up to date") != null);
+}
+
+test "hitTest maps a click on the first list row to a selectable, unopenable row" {
+    const s: State = .{ .items = &sample };
+    // rect.row = 5 → heading at 5, list starts at 6. Clicking row 6 hits index 0.
+    const hit = hitTest(&s, .{ .row = 5, .col = 1, .width = 80, .height = 10 }, 6, 1);
+    try testing.expectEqual(@as(?usize, 0), if (hit) |h| h.index else null);
+    try testing.expect(!hit.?.open); // no detail pane: an Outdated row is upgraded, not opened
+}
+
+test "hitTest rejects the heading row and rows above the list" {
+    const s: State = .{ .items = &sample };
+    const rect: tab.Rect = .{ .row = 5, .col = 1, .width = 80, .height = 10 };
+    try testing.expect(hitTest(&s, rect, 5, 1) == null); // the heading row
+    try testing.expect(hitTest(&s, rect, 4, 1) == null); // above the list
+}
+
+test "hitTest resolves against the filtered list, not the raw items" {
+    var s: State = .{ .items = &sample };
+    s.chrome.filter.push("f"); // firefox, ffmpeg
+    const rect: tab.Rect = .{ .row = 1, .col = 1, .width = 80, .height = 10 };
+    try testing.expectEqual(@as(?usize, 0), hitTest(&s, rect, 2, 1).?.index); // first filtered row
+    try testing.expectEqual(@as(?usize, 1), hitTest(&s, rect, 3, 1).?.index); // second filtered row
+    try testing.expect(hitTest(&s, rect, 4, 1) == null); // past the two matches
+}
+
+test "hitTest adds the scrolled view offset" {
+    var s: State = .{ .items = &sample };
+    s.chrome.view.selected = 3; // forces clamp to scroll a 2-tall list to offset 2
+    // rect.height 3 → list height 2; the top list row (row 2) maps to the offset.
+    const hit = hitTest(&s, .{ .row = 1, .col = 1, .width = 80, .height = 3 }, 2, 1);
+    try testing.expectEqual(@as(?usize, 2), hit.?.index);
+}
+
+test "hitTest rejects a blank row past the populated tail" {
+    var s: State = .{ .items = &sample };
+    s.chrome.filter.push("curl"); // one match
+    const rect: tab.Rect = .{ .row = 1, .col = 1, .width = 80, .height = 10 };
+    try testing.expectEqual(@as(?usize, 0), hitTest(&s, rect, 2, 1).?.index); // the one match
+    try testing.expect(hitTest(&s, rect, 3, 1) == null); // blank tail
+}
+
+test "hitTest on an empty list hits nothing" {
+    const s: State = .{ .items = &.{} }; // count 0 must reach rowAt, not a stray index
+    const rect: tab.Rect = .{ .row = 1, .col = 1, .width = 80, .height = 10 };
+    try testing.expect(hitTest(&s, rect, 2, 1) == null);
+}
+
+test "hitTest when the heading ate the only row hits nothing" {
+    const s: State = .{ .items = &sample };
+    // height 1 → list.height 0. The list height, not the rect height, drives the hit.
+    try testing.expect(hitTest(&s, .{ .row = 1, .col = 1, .width = 80, .height = 1 }, 2, 1) == null);
+}
+
+test "hitTest ignores the column — a click anywhere on the row hits it" {
+    const s: State = .{ .items = &sample };
+    const rect: tab.Rect = .{ .row = 1, .col = 1, .width = 80, .height = 10 };
+    // The checkbox occupies the first 4 cols; clicking it must not differ from the name.
+    try testing.expectEqual(@as(?usize, 0), hitTest(&s, rect, 2, 1).?.index);
+    try testing.expectEqual(@as(?usize, 0), hitTest(&s, rect, 2, 60).?.index);
 }
 
 test "the cores tolerate a checked slice shorter than items without trapping" {

--- a/src/tui/spawn.zig
+++ b/src/tui/spawn.zig
@@ -261,7 +261,9 @@ fn around(ctrl: anytype, body: anytype) !void {
 }
 
 /// Live controller over a `term.Term`: leave drops everything entered, enter
-/// re-establishes raw + alt-screen + hidden cursor in the same order `run` does.
+/// re-establishes raw + alt-screen + hidden cursor + mouse tracking in the same
+/// order `run` does. `leave` disables the mouse, so `enter` must re-arm it or the
+/// dashboard comes back from a child keyboard-only.
 const TermCtrl = struct {
     t: *term.Term,
     fn leave(self: TermCtrl) void {
@@ -271,6 +273,7 @@ const TermCtrl = struct {
         try self.t.enterRaw();
         try self.t.enterAltScreen();
         try self.t.hideCursor();
+        try self.t.enableMouse();
     }
 };
 
@@ -508,6 +511,22 @@ const FakeBody = struct {
         if (self.fails) return error.Spawn;
     }
 };
+
+test "the real re-enter re-arms mouse tracking, not just raw and the alt-screen" {
+    // The fakes above pin the leave/enter *order*; this pins what `enter` restores.
+    // `leave` disables the mouse, so an enter that forgets it leaves the dashboard
+    // keyboard-only for the rest of the session.
+    var fds: [2]std.posix.fd_t = undefined;
+    try testing.expectEqual(@as(c_int, 0), std.c.pipe(&fds));
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+
+    // A non-null `saved` trips enterRaw's idempotent guard, so the re-enter runs
+    // against a pipe without a tty probe.
+    var t: term.Term = .{ .io = undefined, .fd = fds[1], .saved = std.mem.zeroes(std.posix.termios) };
+    try (TermCtrl{ .t = &t }).enter();
+    try testing.expect(t.mouse_on); // the wheel and clicks live again, like the keys
+}
 
 test "runInline order: leave → spawn → re-enter, ending in the dashboard" {
     var log: std.ArrayList(u8) = .empty;


### PR DESCRIPTION
## Description

Lets a click drive the Outdated upgrade pane. The tab has no detail pane - its job is to check rows and upgrade them - so a left-click moves the cursor to the clicked package and picks it for the batch, the same thing `space` does, and a right-click moves the cursor but has no pane to open. A pinned row is still never checked: the pin outranks the click exactly as it outranks `space`.

Also fixes a bug that made mouse input unusable in practice: after any inline command (`u` upgrade, install, doctor fix), the dashboard came back keyboard-only. Handing the terminal to a child disables mouse tracking, and the re-enter path restored raw mode, the alt-screen and the cursor but never re-armed the mouse. Every inline path shares that one seam, so one line brings the wheel and clicks back everywhere. It is a separate commit, so it can ship on its own.

## Related Issue

- None

## Notes for Reviewers

- None