### PR TITLE
feat(tui): switch tabs by clicking the tab bar

### DIFF
--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -212,6 +212,13 @@ fn filterRow(size: term.Size) ?u16 {
     };
 }
 
+fn tabBarRow(size: term.Size) ?u16 {
+    return switch (layout.compute(size.cols, size.rows)) {
+        .too_small => null,
+        .ok => |r| r.tab_bar.row,
+    };
+}
+
 /// Hit-test a click against the active tab's list, or null when the tab exposes no
 /// `hitTest` (Doctor/Services have no clickable list). The `@hasDecl` gate keeps
 /// those tabs free of a dead arm, matching the optional tab contract.
@@ -984,7 +991,19 @@ fn serviceMouse(io: std.Io, allocator: std.mem.Allocator, t: *term.Term, painter
     // A left-click on the query/filter input row focuses it for typing — mouse parity
     // with `/`. It sits above the list, so it never collides with a row hit-test.
     if (m.button == 0) {
-        if (filterRow(term.currentSize())) |fr| if (m.row == fr) {
+        const size = term.currentSize();
+        // A left-click on a tab title switches to it — mouse parity with `tab`/digits,
+        // including the on-entry load, or the tab paints empty under a counted header.
+        // A gap hits nothing; either way the bar never falls through to the list.
+        if (tabBarRow(size)) |tbr| if (m.row == tbr) {
+            if (tab_bar.tabAt(tabTitles(), size.cols, m.col)) |clicked| {
+                app.active = clicked;
+                app.editing = false; // the click is navigation: arrive ready for commands
+                try onEntryReload(io, allocator, t, painter, fetches, app, store);
+            }
+            return;
+        };
+        if (filterRow(size)) |fr| if (m.row == fr) {
             app.editing = true;
             return;
         };
@@ -1465,6 +1484,67 @@ test "a right-press on a Search basket row selects it but opens nothing" {
     try serviceMouseA(&a, rightAt(first_row + 2)); // row 8 → second basket row
     try std.testing.expectEqual(@as(usize, 1), a.states.search.chrome.view.selected);
     try std.testing.expect(!a.shared.banner.isSet()); // basket has no detail pane — no read
+}
+
+// The tab-bar row at 80x24, and the first column of the "Installed" title.
+const tab_bar_row: u16 = 2;
+const installed_title_col: u16 = 10;
+const outdated_title_col: u16 = 22;
+const tab_divider_col: u16 = 7;
+
+fn leftAtCol(row: u16, col: u16) keys.Mouse {
+    return .{ .button = 0, .col = col, .row = row, .press = true };
+}
+
+test "a left-press on a tab title switches to it, leaving that tab's state untouched" {
+    var a: App = .{ .active = .search };
+    a.states.installed.items = &click_pkgs;
+    a.states.installed.chrome.view.selected = 2; // the tab keeps its own cursor
+    try serviceMouseA(&a, leftAtCol(tab_bar_row, installed_title_col));
+    try std.testing.expectEqual(Tab.installed, a.active);
+    try std.testing.expectEqual(@as(usize, 2), a.states.installed.chrome.view.selected); // cursor kept
+    try std.testing.expect(a.states.installed.detail == null);
+    try serviceMouseA(&a, leftAt(first_row)); // the body still hit-tests the new tab
+
+    try std.testing.expectEqual(@as(usize, 0), activeChrome(&a).view.selected);
+}
+
+test "a click-switch runs the tab's lazy on-entry load, like tab and the digits do" {
+    // Without the reload the tab arrives empty while the header still counts its kegs.
+    var a: App = .{ .active = .search, .mt_path = "/bin/echo" };
+    defer a.storages.deinit(std.testing.allocator);
+    a.shared.dirty.insert(.installed);
+    try serviceMouseA(&a, leftAtCol(tab_bar_row, installed_title_col));
+    try std.testing.expectEqual(Tab.installed, a.active);
+    try std.testing.expect(!a.shared.dirty.contains(.installed)); // the on-entry load ran
+}
+
+test "a click-switch mid-edit lands in normal mode, keeping the filter it leaves behind" {
+    // The click is navigation: the arrived-at tab must take the next keystroke as a
+    // command, not as filter text. `tab` can't switch mid-edit, so only the mouse gets here.
+    var a: App = .{ .active = .installed };
+    a.states.installed.items = &click_pkgs;
+    stepA(&a, ch('/'));
+    stepA(&a, ch('c'));
+    try serviceMouseA(&a, leftAtCol(tab_bar_row, outdated_title_col));
+    try std.testing.expectEqual(Tab.outdated, a.active);
+    try std.testing.expect(!a.editing);
+    try std.testing.expectEqualStrings("c", a.states.installed.chrome.filter.slice()); // kept, as Enter does
+}
+
+test "a left-press on a tab-bar divider leaves the active tab alone" {
+    var a: App = .{ .active = .search };
+    a.states.search.items = &search_matches;
+    a.states.search.phase = .loaded;
+    try serviceMouseA(&a, leftAtCol(tab_bar_row, tab_divider_col));
+    try std.testing.expectEqual(Tab.search, a.active); // a gap hits no title
+    try std.testing.expectEqual(@as(usize, 0), activeChrome(&a).view.selected); // and picks no row
+}
+
+test "a right-press on the tab bar is inert — only left switches tabs" {
+    var a: App = .{ .active = .search };
+    try serviceMouseA(&a, .{ .button = 2, .col = installed_title_col, .row = tab_bar_row, .press = true });
+    try std.testing.expectEqual(Tab.search, a.active);
 }
 
 test "a click on a tab with no hit-test is a no-op, never a crash" {

--- a/src/tui/tab_bar.zig
+++ b/src/tui/tab_bar.zig
@@ -38,26 +38,8 @@ fn append(buf: []u8, len: *usize, s: []const u8) void {
     len.* += n;
 }
 
-/// Render the bar — titles separated by two spaces, the active one wrapped in
-/// bold + reset. SGR is zero-width to `scroll_list.truncate`, so only the
-/// visible runes are bounded by `cols`. Returns a prefix of `buf`.
-pub fn render(buf: []u8, active: Tab, titles: [count][]const u8, cols: u16) []const u8 {
-    var len: usize = 0;
-    for (titles, 0..) |t, i| {
-        if (i != 0) append(buf, &len, sep);
-        append(buf, &len, accentCode()); // every title carries the accent
-        if (i == @intFromEnum(active)) { // active is a reverse-video, bold block
-            append(buf, &len, color.Style.reverse.code());
-            append(buf, &len, color.Style.bold.code());
-        }
-        append(buf, &len, t);
-        append(buf, &len, color.Style.reset.code());
-    }
-    return scroll_list.truncate(buf[0..len], cols);
-}
-
-const test_titles: [count][]const u8 = .{ "Search", "Installed", "Outdated", "Services", "Doctor" };
-
+/// Display columns `s` occupies: one per rune, zero for SGR — the same model
+/// `scroll_list.truncate` bounds the bar by.
 fn visibleWidth(s: []const u8) usize {
     var w: usize = 0;
     var i: usize = 0;
@@ -76,6 +58,90 @@ fn visibleWidth(s: []const u8) usize {
         w += 1;
     }
     return w;
+}
+
+/// Render the bar — titles separated by two spaces, the active one wrapped in
+/// bold + reset. SGR is zero-width to `scroll_list.truncate`, so only the
+/// visible runes are bounded by `cols`. Returns a prefix of `buf`.
+pub fn render(buf: []u8, active: Tab, titles: [count][]const u8, cols: u16) []const u8 {
+    var len: usize = 0;
+    for (titles, 0..) |t, i| {
+        if (i != 0) append(buf, &len, sep);
+        append(buf, &len, accentCode()); // every title carries the accent
+        if (i == @intFromEnum(active)) { // active is a reverse-video, bold block
+            append(buf, &len, color.Style.reverse.code());
+            append(buf, &len, color.Style.bold.code());
+        }
+        append(buf, &len, t);
+        append(buf, &len, color.Style.reset.code());
+    }
+    return scroll_list.truncate(buf[0..len], cols);
+}
+
+/// The tab whose title covers 1-based `click_col`; null for a divider, past the last
+/// title, or one truncated away at `cols`. Walks the layout `render` draws, so the
+/// click target can't drift from what is on screen. Pure — the source of truth for
+/// click→tab.
+pub fn tabAt(titles: [count][]const u8, cols: u16, click_col: u16) ?Tab {
+    if (click_col == 0 or click_col > cols) return null;
+    const sep_w = comptime visibleWidth(sep);
+    var first: usize = 1; // 1-based, matching the bar's origin at layout col 1
+    for (titles, 0..) |t, i| {
+        const w = visibleWidth(t);
+        if (click_col < first) return null; // landed in the divider before this title
+        if (click_col < first + w) return @enumFromInt(i);
+        first += w + sep_w;
+    }
+    return null; // past the last title
+}
+
+const test_titles: [count][]const u8 = .{ "Search", "Installed", "Outdated", "Services", "Doctor" };
+
+// The spans `render` lays out for `test_titles`: each title follows the earlier
+// ones plus a three-column divider.
+const search_span = .{ .first = 1, .last = 6 };
+const installed_span = .{ .first = 10, .last = 18 };
+const doctor_span = .{ .first = 44, .last = 49 };
+
+test "tabAt maps the first and last column of every title to that tab" {
+    var first: u16 = 1;
+    for (test_titles, 0..) |t, i| {
+        const w: u16 = @intCast(visibleWidth(t));
+        const want: Tab = @enumFromInt(i);
+        try std.testing.expectEqual(want, tabAt(test_titles, 80, first).?);
+        try std.testing.expectEqual(want, tabAt(test_titles, 80, first + w - 1).?); // span boundary
+        first += w + @as(u16, @intCast(visibleWidth(sep)));
+    }
+    try std.testing.expectEqual(Tab.search, tabAt(test_titles, 80, search_span.first).?);
+    try std.testing.expectEqual(Tab.doctor, tabAt(test_titles, 80, doctor_span.last).?);
+}
+
+test "tabAt returns null for a divider, a column past the last title, and col 0" {
+    try std.testing.expect(tabAt(test_titles, 80, search_span.last + 1) == null); // the divider
+    try std.testing.expect(tabAt(test_titles, 80, installed_span.first - 1) == null);
+    try std.testing.expect(tabAt(test_titles, 80, doctor_span.last + 1) == null); // past the bar
+    try std.testing.expect(tabAt(test_titles, 80, 0) == null); // columns are 1-based
+}
+
+test "tabAt hits nothing past cols, where render truncated the title away" {
+    // cols 12 shows Search, the divider and the first three runes of Installed only.
+    try std.testing.expectEqual(Tab.installed, tabAt(test_titles, 12, installed_span.first).?);
+    try std.testing.expect(tabAt(test_titles, 12, installed_span.last) == null); // cut off
+    try std.testing.expect(tabAt(test_titles, 12, doctor_span.first) == null); // never drawn
+    try std.testing.expect(tabAt(test_titles, 0, 1) == null); // nothing visible at all
+}
+
+test "tabAt agrees with the column render actually draws, whichever tab is active" {
+    // Styling is zero-width, so no span shifts. Read the column back out of render's
+    // own output — the two must not drift.
+    for ([_]Tab{ .search, .installed, .doctor }) |active| {
+        var buf: [256]u8 = undefined;
+        const out = render(&buf, active, test_titles, 80);
+        const at = std.mem.indexOf(u8, out, "Installed").?;
+        const col: u16 = @intCast(visibleWidth(out[0..at]) + 1);
+        try std.testing.expectEqual(installed_span.first, col);
+        try std.testing.expectEqual(Tab.installed, tabAt(test_titles, 80, col).?);
+    }
 }
 
 test "next cycles through every tab and wraps" {


### PR DESCRIPTION
## Description

Lets you switch tabs by clicking their titles in the tab bar, completing mouse-driven navigation - a mouse user no longer has to reach for Tab or the digit keys.

The shell's left-click handler switches the active tab when the click lands on the tab-bar row and otherwise falls through to the list hit-test unchanged. A click-switch runs the arrived-at tab's lazy on-entry load, so it lands on real data rather than an empty pane under a counted header - full parity with a keyboard switch. Scoped to tab-label clicks only; no new effect and no new import into the app hub.

## Related Issue

- None

## Notes for Reviewers

- None