### PR TITLE
chore(tui): pin the tab-bar buffer to what the bar can draw

### DIFF
--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -373,7 +373,7 @@ pub fn renderFrame(buf: []u8, app: *const App, cols: u16, rows: u16) []const u8 
             f.put(color.Style.reset.code()); // a truncated muted segment must not bleed downward
 
             f.moveTo(r.tab_bar.row, 1);
-            var tb: [256]u8 = undefined;
+            var tb: [tab_bar.buf_cap]u8 = undefined;
             f.put(tab_bar.render(&tb, app.active, tabTitles(), cols));
             f.put(color.Style.reset.code()); // a truncated active title must not bleed bold downward
 
@@ -1110,6 +1110,26 @@ test "a data-free App renders the full chrome so the skeleton paint is real" {
     for ([_][]const u8{ "Search", "Installed", "Outdated", "Services", "Doctor" }) |title|
         try std.testing.expect(std.mem.indexOf(u8, out, title) != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "quit") != null); // footer help present
+}
+
+test "the tab-bar buffer holds every theme's fully styled bar, so only cols truncates" {
+    // Guard, not new behaviour: `render` clamps at capacity while `tabAt` models only
+    // `cols`, so a buffer cut would let a click reach a title that was never drawn.
+    // The widest case is every title accented, one of them reverse+bold on top.
+    defer color.setThemeForTest(null);
+    defer color.setBackgroundForTest(null);
+    defer color.setTruecolorForTest(null);
+    color.setTruecolorForTest(true); // truecolor codes are the longest role escapes
+    for (std.enums.values(color.Theme)) |theme| {
+        for ([_]color.Background{ .dark, .light, .unknown }) |bg| {
+            color.setThemeForTest(theme);
+            color.setBackgroundForTest(bg);
+            var tb: [tab_bar.buf_cap]u8 = undefined;
+            const out = tab_bar.render(&tb, .doctor, tabTitles(), 1000); // cols far past the bar
+            for (tabTitles()) |title|
+                try std.testing.expect(std.mem.indexOf(u8, out, title) != null);
+        }
+    }
 }
 
 test "renderActive covers its whole content rectangle so a self-drawn tab leaves no ghost row" {

--- a/src/tui/tab_bar.zig
+++ b/src/tui/tab_bar.zig
@@ -60,9 +60,15 @@ fn visibleWidth(s: []const u8) usize {
     return w;
 }
 
-/// Render the bar — titles separated by two spaces, the active one wrapped in
-/// bold + reset. SGR is zero-width to `scroll_list.truncate`, so only the
-/// visible runes are bounded by `cols`. Returns a prefix of `buf`.
+/// Bytes a caller's render buffer must hold. `append` clamps at capacity, so a
+/// buffer this size keeps `cols` the *only* thing that truncates the bar — a
+/// capacity cut would drop titles `tabAt` still maps, and a click could switch to
+/// a tab that was never drawn. The app's title/theme sweep pins the bound.
+pub const buf_cap: usize = 256;
+
+/// Render the bar — titles separated by `sep`, the active one wrapped in accent +
+/// reverse + bold. SGR is zero-width to `scroll_list.truncate`, so only the visible
+/// runes are bounded by `cols`. Returns a prefix of `buf`.
 pub fn render(buf: []u8, active: Tab, titles: [count][]const u8, cols: u16) []const u8 {
     var len: usize = 0;
     for (titles, 0..) |t, i| {


### PR DESCRIPTION
## Description

Keeps a tab click honest at any theme or width: the bar's render buffer now has a named capacity owned by the tab-bar module, pinned by a test that renders the fully styled bar under every theme and background. Without it, a buffer too small to hold the bar would silently drop titles the click hit-test still maps, so a click could switch to a tab that was never drawn. No behaviour change today - the bound already held; this stops it drifting. Also corrects the divider the render doc described.

## Related Issue

- None

## Notes for Reviewers

- None
