### PR TITLE
fix(upgrade): drop upgraded packages from the cached outdated view

### DIFF
--- a/scripts/regressions/upgrade-prunes-outdated-snapshot-upgrade-does-not-update-outdated-json.sh
+++ b/scripts/regressions/upgrade-prunes-outdated-snapshot-upgrade-does-not-update-outdated-json.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Regression: a real (non-dry-run) `mt upgrade` mutates `kegs`/`casks` but left
+# `{prefix}/cache/outdated.json` untouched, so the snapshot kept listing the
+# just-upgraded package at its pre-upgrade `installed` version for the rest of
+# the 5-minute TTL. `mt outdated` self-heals (it filters the snapshot through
+# the live DB with `intersectWithDb`), but the TUI's warm read parses the file
+# raw with no DB intersect — so the Outdated tab painted an already-upgraded
+# package until the background audit overwrote it.
+#
+# The fix reconciles the snapshot against the live DB after a real upgrade:
+# entries whose keg has moved are dropped, untouched entries survive, and
+# `generated_at_ms` is preserved so survivors keep the lease they earned
+# rather than a falsely extended one.
+#
+# Driving `mt upgrade` end-to-end would need the network and a real bottle, so
+# — matching the offline style of
+# `cached-outdated-drops-revision-bumped-packages.sh` — a standalone
+# ReleaseSafe `zig test` harness seeds a DB plus a hand-written snapshot file
+# and drives the prune directly, then reads the file back.
+#
+# `pruneSnapshot` transitively pulls SQLite, whose `c_sqlite` module only
+# exists inside the build graph — so the harness reuses the build's own wiring
+# (the `src/lib.zig` module root + translated C modules + vendored sqlite3.c)
+# rather than a raw `zig test` that can't resolve it.
+#
+# Asserts, in one driver:
+#   1. an upgraded formula (DB moved past the snapshot's `installed`) is dropped
+#   2. an untouched formula survives the prune
+#   3. an upgraded cask is dropped from its own array
+#   4. `generated_at_ms` is preserved, not re-stamped
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Translate the C-interop headers the malt module depends on, mirroring
+# build.zig's addTranslateC set (sqlite needs vendor/ on its include path).
+zig translate-c -I "$ROOT/vendor/" "$ROOT/c/sqlite.h" >"$TMP/c_sqlite.zig" 2>/dev/null
+zig translate-c "$ROOT/c/clonefile.h" >"$TMP/c_clonefile.zig" 2>/dev/null
+zig translate-c "$ROOT/c/mount.h" >"$TMP/c_mount.zig" 2>/dev/null
+
+cat >"$TMP/driver.zig" <<'ZIG'
+const std = @import("std");
+const malt = @import("malt");
+const outdated = malt.cli_outdated;
+const sqlite = malt.sqlite;
+const schema = malt.schema;
+
+// `jq` upgraded 1.7.1 -> 1.8.0 and `firefox` (cask) 120 -> 121; `wget` never
+// moved. The snapshot predates all of it.
+const stamp: i64 = 1_700_000_000_000;
+
+test "a real upgrade prunes the upgraded packages out of the cached snapshot" {
+    const a = std.testing.allocator;
+    const io = std.Options.debug_io;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_dir = buf[0..try std.Io.Dir.realPath(tmp.dir, io, &buf)];
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    // The live DB as it stands *after* the upgrade.
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES ('jq', 'jq', '1.8.0', 's', '/c'), ('wget', 'wget', '1.24', 's', '/c');
+    );
+    try db.exec(
+        \\INSERT INTO casks (token, name, version, url)
+        \\VALUES ('firefox', 'Firefox', '121', 'https://example.invalid/f.dmg');
+    );
+
+    // The snapshot as written *before* the upgrade.
+    try outdated.writeSnapshot(io, a, cache_dir, .{
+        .generated_at_ms = stamp,
+        .formulas = &.{
+            .{ .name = @constCast("jq"), .installed = @constCast("1.7.1"), .latest = @constCast("1.8.0") },
+            .{ .name = @constCast("wget"), .installed = @constCast("1.24"), .latest = @constCast("1.25") },
+        },
+        .casks = &.{
+            .{ .name = @constCast("firefox"), .installed = @constCast("120"), .latest = @constCast("121") },
+        },
+    });
+
+    outdated.pruneSnapshot(io, a, &db, cache_dir);
+
+    const snap = outdated.readSnapshot(io, a, cache_dir) orelse return error.SnapshotVanished;
+    defer outdated.freeSnapshot(a, snap);
+
+    // The upgraded formula is gone; the untouched one survives.
+    try std.testing.expectEqual(@as(usize, 1), snap.formulas.len);
+    try std.testing.expectEqualStrings("wget", snap.formulas[0].name);
+
+    // The upgraded cask is gone from its own array.
+    try std.testing.expectEqual(@as(usize, 0), snap.casks.len);
+
+    // Survivors keep the lease they earned — a re-stamp would falsely extend
+    // the 5-minute TTL.
+    try std.testing.expectEqual(stamp, snap.generated_at_ms);
+}
+ZIG
+
+if zig test -OReleaseSafe \
+  --dep malt -Mroot="$TMP/driver.zig" \
+  --dep c_sqlite --dep c_clonefile --dep c_mount \
+  -Mmalt="$ROOT/src/lib.zig" -lc -I "$ROOT/vendor/" -I "$ROOT/c/" \
+  -cflags -DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_THREADSAFE=1 -DSQLITE_DQS=0 -- "$ROOT/vendor/sqlite3.c" \
+  -Mc_sqlite="$TMP/c_sqlite.zig" \
+  -Mc_clonefile="$TMP/c_clonefile.zig" \
+  -Mc_mount="$TMP/c_mount.zig" >"$TMP/out.log" 2>&1; then
+  echo "PASS: a real upgrade prunes upgraded packages from the cached snapshot"
+else
+  echo "FAIL: the cached outdated snapshot still lists a package the DB says is already upgraded" >&2
+  echo "----- harness output -----" >&2
+  cat "$TMP/out.log" >&2
+  exit 1
+fi

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -109,6 +109,46 @@ pub fn intersectWithDb(
     return out.toOwnedSlice(allocator);
 }
 
+/// Reconcile the cached snapshot against the live DB, dropping entries whose
+/// keg has moved past the `installed` the snapshot recorded. `mt upgrade` is
+/// the caller: it mutates kegs without touching the file, and the TUI's warm
+/// read parses that file raw — so an unreconciled snapshot paints a
+/// just-upgraded package as outdated until the background audit lands.
+///
+/// Reuses `intersectWithDb`, so the file converges on exactly what the
+/// DB-filtering reader would print; each array is matched against its own
+/// table, so a token that is both a formula and a cask cannot cross over.
+/// `generated_at_ms` is preserved — survivors keep the lease they earned
+/// rather than a falsely extended one.
+///
+/// Best-effort and all-or-nothing: a load failure abandons the prune outright.
+/// `intersectWithDb` yields an empty set for zero rows, so degrading a failed
+/// load to "no rows" would persist an empty array and silently under-report
+/// every package — hence `catch return` before the single write, never a
+/// partial one.
+pub fn pruneSnapshot(io: std.Io, allocator: std.mem.Allocator, db: *sqlite.Database, cache_dir: []const u8) void {
+    // A missing or unparseable snapshot is left alone: an upgrade run knows
+    // only what it touched and must never synthesise a whole file.
+    const snap = readSnapshot(io, allocator, cache_dir) orelse return;
+    defer freeSnapshot(allocator, snap);
+
+    const f_rows = loadFormulaRows(allocator, db, .all) catch return;
+    defer freeKegRows(allocator, f_rows);
+    const c_rows = loadCaskRows(allocator, db, .all) catch return;
+    defer freeKegRows(allocator, c_rows);
+
+    const f_entries = intersectWithDb(allocator, f_rows, snap.formulas) catch return;
+    defer freeEntrySlice(allocator, f_entries);
+    const c_entries = intersectWithDb(allocator, c_rows, snap.casks) catch return;
+    defer freeEntrySlice(allocator, c_entries);
+
+    writeSnapshot(io, allocator, cache_dir, .{
+        .generated_at_ms = snap.generated_at_ms,
+        .formulas = f_entries,
+        .casks = c_entries,
+    }) catch {};
+}
+
 fn dupEntry(allocator: std.mem.Allocator, e: OutdatedEntry) std.mem.Allocator.Error!OutdatedEntry {
     const name = try allocator.dupe(u8, e.name);
     errdefer allocator.free(name);
@@ -330,6 +370,141 @@ test "intersectWithDb keeps a revision-bumped formula" {
     try std.testing.expectEqual(@as(usize, 1), out.len);
     try std.testing.expectEqualStrings("foo", out[0].name);
     try std.testing.expectEqualStrings("1.2.3_1", out[0].installed);
+}
+
+/// Seed a temp cache dir + in-memory DB for the `pruneSnapshot` tests.
+const PruneEnv = struct {
+    tmp: std.testing.TmpDir,
+    db: sqlite.Database,
+    buf: [std.fs.max_path_bytes]u8 = undefined,
+    len: usize = 0,
+
+    fn init() !PruneEnv {
+        var env: PruneEnv = .{ .tmp = std.testing.tmpDir(.{}), .db = try sqlite.Database.open(":memory:") };
+        try schema.initSchema(&env.db);
+        env.len = try std.Io.Dir.realPath(env.tmp.dir, std.Options.debug_io, &env.buf);
+        return env;
+    }
+
+    /// Derived on call: `init` returns by value, so a stored slice would
+    /// point into the moved-from copy's buffer.
+    fn dir(self: *const PruneEnv) []const u8 {
+        return self.buf[0..self.len];
+    }
+
+    fn deinit(self: *PruneEnv) void {
+        self.db.close();
+        self.tmp.cleanup();
+    }
+};
+
+test "pruneSnapshot drops an upgraded keg, keeps an untouched one, and preserves the lease" {
+    // The whole point: `mt upgrade jq` moves the keg but the TUI's warm read
+    // parses the snapshot raw, so an unreconciled file paints jq as outdated.
+    // wget must survive — a plain delete would cost it a needless audit.
+    const a = std.testing.allocator;
+    const io = std.Options.debug_io;
+    var env = try PruneEnv.init();
+    defer env.deinit();
+
+    try env.db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES ('jq', 'jq', '1.8.0', 's', '/c'), ('wget', 'wget', '1.24', 's', '/c');
+    );
+    const stamp: i64 = 1_700_000_000_000;
+    try writeSnapshot(io, a, env.dir(), .{
+        .generated_at_ms = stamp,
+        .formulas = &.{
+            .{ .name = @constCast("jq"), .installed = @constCast("1.7.1"), .latest = @constCast("1.8.0") },
+            .{ .name = @constCast("wget"), .installed = @constCast("1.24"), .latest = @constCast("1.25") },
+        },
+        .casks = &.{},
+    });
+
+    pruneSnapshot(io, a, &env.db, env.dir());
+
+    const snap = readSnapshot(io, a, env.dir()).?;
+    defer freeSnapshot(a, snap);
+    try std.testing.expectEqual(@as(usize, 1), snap.formulas.len);
+    try std.testing.expectEqualStrings("wget", snap.formulas[0].name);
+    // A re-stamp would grant the survivor a 5-minute lease it never earned.
+    try std.testing.expectEqual(stamp, snap.generated_at_ms);
+}
+
+test "pruneSnapshot matches each array against its own table" {
+    // A token installed as both a formula and a cask must not let one array's
+    // upgrade drop the other's still-valid entry.
+    const a = std.testing.allocator;
+    const io = std.Options.debug_io;
+    var env = try PruneEnv.init();
+    defer env.deinit();
+
+    try env.db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
+        \\VALUES ('docker', 'docker', '27.0', 's', '/c');
+    );
+    try env.db.exec(
+        \\INSERT INTO casks (token, name, version, url)
+        \\VALUES ('docker', 'Docker', '4.30', 'https://example.invalid/d.dmg');
+    );
+    try writeSnapshot(io, a, env.dir(), .{
+        .generated_at_ms = 1,
+        // the formula moved 26.0 -> 27.0; the cask never budged
+        .formulas = &.{
+            .{ .name = @constCast("docker"), .installed = @constCast("26.0"), .latest = @constCast("27.0") },
+        },
+        .casks = &.{
+            .{ .name = @constCast("docker"), .installed = @constCast("4.30"), .latest = @constCast("4.31") },
+        },
+    });
+
+    pruneSnapshot(io, a, &env.db, env.dir());
+
+    const snap = readSnapshot(io, a, env.dir()).?;
+    defer freeSnapshot(a, snap);
+    try std.testing.expectEqual(@as(usize, 0), snap.formulas.len);
+    try std.testing.expectEqual(@as(usize, 1), snap.casks.len);
+    try std.testing.expectEqualStrings("docker", snap.casks[0].name);
+}
+
+test "pruneSnapshot keeps a pinned keg an upgrade refused to move" {
+    // A pin veto reports success without upgrading, so the entry is still
+    // genuinely outdated — pruning it would silently under-report.
+    const a = std.testing.allocator;
+    const io = std.Options.debug_io;
+    var env = try PruneEnv.init();
+    defer env.deinit();
+
+    try env.db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, pinned)
+        \\VALUES ('held', 'held', '1.0', 's', '/c', 1);
+    );
+    try writeSnapshot(io, a, env.dir(), .{
+        .generated_at_ms = 1,
+        .formulas = &.{
+            .{ .name = @constCast("held"), .installed = @constCast("1.0"), .latest = @constCast("2.0") },
+        },
+        .casks = &.{},
+    });
+
+    pruneSnapshot(io, a, &env.db, env.dir());
+
+    const snap = readSnapshot(io, a, env.dir()).?;
+    defer freeSnapshot(a, snap);
+    try std.testing.expectEqual(@as(usize, 1), snap.formulas.len);
+    try std.testing.expectEqualStrings("held", snap.formulas[0].name);
+}
+
+test "pruneSnapshot never synthesises a snapshot that was not there" {
+    // An upgrade run knows only what it touched; writing a file from that
+    // partial view is the under-reporting `WarmGate` exists to veto.
+    const a = std.testing.allocator;
+    const io = std.Options.debug_io;
+    var env = try PruneEnv.init();
+    defer env.deinit();
+
+    pruneSnapshot(io, a, &env.db, env.dir());
+    try std.testing.expect(readSnapshot(io, a, env.dir()) == null);
 }
 
 test "intersectWithDb drops a keg whose revision moved past the snapshot" {

--- a/src/cli/update.zig
+++ b/src/cli/update.zig
@@ -60,8 +60,12 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     output.info("Cache cleared. Metadata will be re-fetched on next operation.", .{});
 }
 
-/// Best-effort: a leftover snapshot is harmless because the read path
-/// filters through the live DB; worst case is one extra recompute.
+/// Best-effort: deleting is safe because the next read recomputes; worst
+/// case is one extra audit. Note the snapshot has two readers and only one
+/// filters through the live DB — `mt outdated` intersects, the TUI's warm
+/// read parses raw — so a leftover snapshot is *not* self-correcting for
+/// the TUI. Deletion here sidesteps that; producers that keep the file must
+/// reconcile it themselves.
 fn invalidateSnapshot(ctx: *const AppCtx, allocator: std.mem.Allocator, cache_dir: []const u8) void {
     const path = outdated_mod.snapshotPath(allocator, cache_dir) catch return;
     defer allocator.free(path);

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -186,7 +186,8 @@ fn freeEntries(allocator: std.mem.Allocator, list: *std.ArrayList(OutdatedEntry)
 /// collector would each persist a partial snapshot and make the Outdated
 /// view silently under-report — so every one vetoes the write. A real
 /// (non-dry-run) upgrade never warms: the pre-upgrade set is stale the
-/// instant kegs mutate.
+/// instant kegs mutate. It prunes instead — see `pruneSnapshot`, which
+/// subtracts the moved kegs rather than persisting a stale set.
 const WarmGate = struct {
     dry_run: bool = false,
     has_names: bool = false,
@@ -368,6 +369,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             };
         }
     }
+
+    // A real upgrade moved kegs, so the shared snapshot now lists packages at
+    // versions they no longer carry. Reconcile it against the DB — one call
+    // covers both branches above, including the named path. Best-effort: a
+    // cache write must not fail an upgrade that already succeeded. A dry-run
+    // mutates nothing, so it has nothing to reconcile.
+    if (!dry_run) outdated_mod.pruneSnapshot(ctx.io, allocator, &db, cache_dir);
 
     // A batch whose only failure was a live cask app exits with the dedicated
     // code so the TUI can footer the real cause; any other failure (even mixed


### PR DESCRIPTION
## Description

After a real `mt upgrade`, the Outdated tab could still show the package you just upgraded. Launch the TUI within five minutes of upgrading and the first frame painted `jq 1.7.1 -> 1.8.0` for a `jq` already on 1.8.0, until the background audit landed and it vanished.

An upgrade moved the kegs but never touched the shared `outdated.json` snapshot, so the file kept describing the world as it was before. The CLI hid this: `mt outdated` filters the snapshot through the live DB and quietly drops anything that no longer matches. The TUI's warm read is the second reader, and it parses the file raw - nothing filtered the stale entry out, so it got painted.

A real upgrade now reconciles the snapshot against the DB, reusing the same intersect the CLI reader already trusts. Packages that moved are dropped; untouched packages survive, so the next launch keeps its warm paint instead of paying for a fresh network audit. The snapshot's original timestamp is kept, so survivors keep the five-minute lease they earned rather than a falsely extended one.

Because it reconciles against the DB rather than tracking what this run touched, it also heals divergence from other sources - an upgrade made behind malt's back no longer lingers in the tab either.

## Related Issue

- None

## Notes for Reviewers

- None