### PR TITLE
fix(tui): propagate parse-time OOM instead of relabeling it as BadJson

### DIFF
--- a/src/tui/json/doctor.zig
+++ b/src/tui/json/doctor.zig
@@ -82,7 +82,10 @@ pub fn parse(allocator: std.mem.Allocator, bytes: []const u8) Error!Parsed {
         // Copy strings into the arena: the shell frees the source buffer right
         // after parsing while the tab keeps borrowing the findings.
         .allocate = .alloc_always,
-    }) catch return error.BadJson;
+    }) catch |e| switch (e) {
+        error.OutOfMemory => |o| return o,
+        else => return error.BadJson,
+    };
     return .{
         .doc = doc,
         .items = doc.value.checks,
@@ -254,6 +257,16 @@ test "parse rejects malformed input, an absent checks key, and an unknown tag" {
     try testing.expectError(error.BadJson, parse(testing.allocator, "{}")); // no checks key
     // An unknown severity is a contract break, not a tolerated unknown — reject it.
     try testing.expectError(error.BadJson, parse(testing.allocator, "{\"checks\":[{\"id\":\"a\",\"severity\":\"meh\",\"title\":\"A\"}]}"));
+}
+
+test "parse propagates a parse-time OOM instead of relabeling it BadJson" {
+    // A real allocator exhaustion during the parse is fatal, not a malformed
+    // contract; the fatal-OOM guard must restore the terminal, not banner BadJson.
+    const bytes =
+        \\{"checks":[{"id":"a","severity":"ok","title":"A"}]}
+    ;
+    var fa = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    try testing.expectError(error.OutOfMemory, parse(fa.allocator(), bytes));
 }
 
 test "stats survive overwriting the source buffer — plain scalars, no borrow" {

--- a/src/tui/json/info.zig
+++ b/src/tui/json/info.zig
@@ -9,7 +9,7 @@
 
 const std = @import("std");
 
-pub const Error = error{BadJson};
+pub const Error = error{ BadJson, OutOfMemory };
 
 /// The detail-pane-relevant subset of `mt info <pkg> --json`. `dependencies` is
 /// empty for casks and not-installed packages; `tap` is empty when unattributed.
@@ -39,7 +39,10 @@ pub fn parse(allocator: std.mem.Allocator, bytes: []const u8) Error!Parsed {
         // Copy strings into the arena: the shell frees the source buffer right
         // after parsing while the detail pane keeps borrowing tap + deps.
         .allocate = .alloc_always,
-    }) catch return error.BadJson;
+    }) catch |e| switch (e) {
+        error.OutOfMemory => |o| return o,
+        else => return error.BadJson,
+    };
     return .{ .doc = doc, .info = doc.value };
 }
 
@@ -84,6 +87,16 @@ test "parse yields an empty dependency list, not a crash, when deps are empty" {
 test "parse rejects malformed and empty input as BadJson" {
     try testing.expectError(error.BadJson, parse(testing.allocator, "not json"));
     try testing.expectError(error.BadJson, parse(testing.allocator, ""));
+}
+
+test "parse propagates a parse-time OOM instead of relabeling it BadJson" {
+    // A real allocator exhaustion during the parse is fatal, not a malformed
+    // contract; the fatal-OOM guard must restore the terminal, not banner BadJson.
+    const bytes =
+        \\{"name":"curl","tap":"homebrew/core","dependencies":["brotli","zstd"],"pinned":true}
+    ;
+    var fa = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    try testing.expectError(error.OutOfMemory, parse(fa.allocator(), bytes));
 }
 
 test "parsed strings own their bytes — the source buffer can be freed/overwritten" {

--- a/src/tui/json/list.zig
+++ b/src/tui/json/list.zig
@@ -57,7 +57,10 @@ pub fn parse(allocator: std.mem.Allocator, bytes: []const u8) Error!Parsed {
         // Copy strings into the arena: the shell frees the source buffer right
         // after parsing while the tab keeps borrowing the rows.
         .allocate = .alloc_always,
-    }) catch return error.BadJson;
+    }) catch |e| switch (e) {
+        error.OutOfMemory => |o| return o,
+        else => return error.BadJson,
+    };
     errdefer doc.deinit();
 
     // Restructure into the public `Pkg` (wire key `type` → `kind`); strings stay
@@ -130,6 +133,16 @@ test "parse rejects malformed and empty input as BadJson" {
     try testing.expectError(error.BadJson, parse(testing.allocator, "not json"));
     try testing.expectError(error.BadJson, parse(testing.allocator, ""));
     try testing.expectError(error.BadJson, parse(testing.allocator, "{}")); // no installed key
+}
+
+test "parse propagates a parse-time OOM instead of relabeling it BadJson" {
+    // A real allocator exhaustion during the parse is fatal, not a malformed
+    // contract; the fatal-OOM guard must restore the terminal, not banner BadJson.
+    const bytes =
+        \\{"installed":[{"name":"a","version":"1","type":"formula","pinned":false}]}
+    ;
+    var fa = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    try testing.expectError(error.OutOfMemory, parse(fa.allocator(), bytes));
 }
 
 test "parsed strings own their bytes — the source buffer can be freed/overwritten" {

--- a/src/tui/json/outdated.zig
+++ b/src/tui/json/outdated.zig
@@ -58,7 +58,10 @@ pub fn parse(allocator: std.mem.Allocator, bytes: []const u8) Error!Parsed {
         // Copy strings into the arena: the shell frees the source buffer right
         // after parsing while the tab keeps borrowing the rows.
         .allocate = .alloc_always,
-    }) catch return error.BadJson;
+    }) catch |e| switch (e) {
+        error.OutOfMemory => |o| return o,
+        else => return error.BadJson,
+    };
     errdefer doc.deinit();
 
     // Restructure into the public `OutdatedRow` (wire key `type` → `kind`);
@@ -133,6 +136,16 @@ test "parse rejects malformed and empty input as BadJson" {
     try testing.expectError(error.BadJson, parse(testing.allocator, "not json"));
     try testing.expectError(error.BadJson, parse(testing.allocator, ""));
     try testing.expectError(error.BadJson, parse(testing.allocator, "{}")); // no outdated key
+}
+
+test "parse propagates a parse-time OOM instead of relabeling it BadJson" {
+    // A real allocator exhaustion during the parse is fatal, not a malformed
+    // contract; the fatal-OOM guard must restore the terminal, not banner BadJson.
+    const bytes =
+        \\{"outdated":[{"name":"a","installed":"1","latest":"2","type":"formula","pinned":false,"tap":""}]}
+    ;
+    var fa = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    try testing.expectError(error.OutOfMemory, parse(fa.allocator(), bytes));
 }
 
 test "parsed strings own their bytes — the source buffer can be freed/overwritten" {

--- a/src/tui/json/search.zig
+++ b/src/tui/json/search.zig
@@ -53,7 +53,10 @@ pub fn parse(allocator: std.mem.Allocator, bytes: []const u8) Error!Parsed {
         // Copy strings into the arena: the shell frees the source buffer right
         // after parsing while the tab keeps borrowing the matches.
         .allocate = .alloc_always,
-    }) catch return error.BadJson;
+    }) catch |e| switch (e) {
+        error.OutOfMemory => |o| return o,
+        else => return error.BadJson,
+    };
     errdefer doc.deinit();
 
     // Restructure into the public `Match` (wire key `type` → `kind`); strings
@@ -112,6 +115,16 @@ test "parse rejects malformed and empty input as BadJson" {
     try testing.expectError(error.BadJson, parse(testing.allocator, "not json"));
     try testing.expectError(error.BadJson, parse(testing.allocator, ""));
     try testing.expectError(error.BadJson, parse(testing.allocator, "{}")); // no results key
+}
+
+test "parse propagates a parse-time OOM instead of relabeling it BadJson" {
+    // A real allocator exhaustion during the parse is fatal, not a malformed
+    // contract; the fatal-OOM guard must restore the terminal, not banner BadJson.
+    const bytes =
+        \\{"results":[{"name":"jq","type":"formula","installed":true}]}
+    ;
+    var fa = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    try testing.expectError(error.OutOfMemory, parse(fa.allocator(), bytes));
 }
 
 test "parse rejects an unknown kind so the closed enum never silently widens" {

--- a/src/tui/json/services.zig
+++ b/src/tui/json/services.zig
@@ -51,7 +51,10 @@ pub fn parse(allocator: std.mem.Allocator, bytes: []const u8) Error!Parsed {
         // Copy strings into the arena: the shell frees the source buffer right
         // after parsing while the tab keeps borrowing the rows.
         .allocate = .alloc_always,
-    }) catch return error.BadJson;
+    }) catch |e| switch (e) {
+        error.OutOfMemory => |o| return o,
+        else => return error.BadJson,
+    };
     return .{ .doc = doc, .items = doc.value.services };
 }
 
@@ -134,6 +137,16 @@ test "parse rejects malformed and empty input as BadJson" {
     try testing.expectError(error.BadJson, parse(testing.allocator, "not json"));
     try testing.expectError(error.BadJson, parse(testing.allocator, ""));
     try testing.expectError(error.BadJson, parse(testing.allocator, "{}")); // no services key
+}
+
+test "parse propagates a parse-time OOM instead of relabeling it BadJson" {
+    // A real allocator exhaustion during the parse is fatal, not a malformed
+    // contract; the fatal-OOM guard must restore the terminal, not banner BadJson.
+    const bytes =
+        \\{"services":[{"name":"redis","state":"running","auto_start":true,"keg_name":"redis"}]}
+    ;
+    var fa = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    try testing.expectError(error.OutOfMemory, parse(fa.allocator(), bytes));
 }
 
 test "parsed strings own their bytes — the source buffer can be freed/overwritten" {

--- a/src/tui/json/snapshot.zig
+++ b/src/tui/json/snapshot.zig
@@ -33,7 +33,10 @@ const WireDoc = struct { outdated: []const WireRow };
 pub fn parse(allocator: std.mem.Allocator, bytes: []const u8) outdated_json.Error!outdated_json.Parsed {
     const snap = std.json.parseFromSlice(Snapshot, allocator, bytes, .{
         .ignore_unknown_fields = true,
-    }) catch return error.BadJson;
+    }) catch |e| switch (e) {
+        error.OutOfMemory => |o| return o,
+        else => return error.BadJson,
+    };
     defer snap.deinit();
 
     var rows: std.ArrayList(WireRow) = .empty;
@@ -112,6 +115,16 @@ test "parse tolerates a missing casks array" {
 test "parse rejects malformed input as BadJson" {
     try testing.expectError(error.BadJson, parse(testing.allocator, "not json"));
     try testing.expectError(error.BadJson, parse(testing.allocator, ""));
+}
+
+test "parse propagates a parse-time OOM instead of relabeling it BadJson" {
+    // A real allocator exhaustion during the envelope parse is fatal, not a
+    // malformed snapshot; the fatal-OOM guard must restore the terminal.
+    const bytes =
+        \\{"version":2,"generated_at_ms":0,"formulas":[{"name":"wget","installed":"1.24.5","latest":"1.25.0"}],"casks":[]}
+    ;
+    var fa = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    try testing.expectError(error.OutOfMemory, parse(fa.allocator(), bytes));
 }
 
 test "read returns null when the snapshot file is absent" {


### PR DESCRIPTION
## Description

The TUI JSON parsers closed their `parseFromSlice` call with `catch return error.BadJson`. Under `.allocate = .alloc_always` the parse error set includes `OutOfMemory`, so a genuine allocator exhaustion during the parse was shown to the user as a malformed-data banner and treated as recoverable 
The malformed-JSON and success paths are unchanged; a `FailingAllocator` test in every touched module guards against a silent revert.

## Related Issue

- None

## Notes for Reviewers

- None