### PR TITLE
refactor(fs): consolidate readFileAllAbsolute into one shared helper

### DIFF
--- a/src/core/dsl/builtins/inreplace.zig
+++ b/src/core/dsl/builtins/inreplace.zig
@@ -5,6 +5,7 @@
 const std = @import("std");
 const values = @import("../values.zig");
 const sandbox = @import("../sandbox.zig");
+const read = @import("../../../fs/read.zig");
 const pathname = @import("pathname.zig");
 const text_replace = @import("../../../text_replace.zig");
 
@@ -38,7 +39,7 @@ pub fn inreplace(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Valu
         return BuiltinError.PathSandboxViolation;
 
     // Read file contents
-    const content = readFileAllAbsolute(ctx.io, ctx.allocator, path, 4 * 1024 * 1024) catch {
+    const content = read.readFileAllAbsolute(ctx.io, ctx.allocator, path, 4 * 1024 * 1024) catch {
         return Value{ .nil = {} };
     };
 
@@ -125,23 +126,6 @@ fn writeDirectly(ctx: ExecCtx, path: []const u8, content: []const u8) void {
     defer out.close(ctx.io);
     // Fallback path already logged a warning; no error channel left to surface.
     out.writeStreamingAll(ctx.io, content) catch {};
-}
-
-/// Read the entire contents of an absolute file path into a caller-owned slice.
-fn readFileAllAbsolute(io: std.Io, allocator: std.mem.Allocator, abs_path: []const u8, max_bytes: usize) ![]u8 {
-    const f = try std.Io.Dir.openFileAbsolute(io, abs_path, .{});
-    defer f.close(io);
-    const st = try f.stat(io);
-    const size = @min(@as(u64, max_bytes), st.size);
-    const buf = try allocator.alloc(u8, @intCast(size));
-    errdefer allocator.free(buf);
-    const n = try f.readPositionalAll(io, buf, 0);
-    if (n == buf.len) return buf;
-    if (allocator.resize(buf, n)) return buf[0..n];
-    const shrunk = try allocator.alloc(u8, n);
-    @memcpy(shrunk, buf[0..n]);
-    allocator.free(buf);
-    return shrunk;
 }
 
 test "atomic-write failure message preserves the underlying error name" {

--- a/src/core/dsl/builtins/pathname.zig
+++ b/src/core/dsl/builtins/pathname.zig
@@ -8,6 +8,7 @@
 const std = @import("std");
 const values = @import("../values.zig");
 const sandbox = @import("../sandbox.zig");
+const fs_read = @import("../../../fs/read.zig");
 const ast = @import("../ast.zig");
 const fallback_log = @import("../fallback_log.zig");
 
@@ -101,7 +102,7 @@ pub fn write(ctx: ExecCtx, receiver: ?Value, args: []const Value) BuiltinError!V
 pub fn read(ctx: ExecCtx, receiver: ?Value, _: []const Value) BuiltinError!Value {
     const path = try receiverPath(ctx.allocator, receiver);
     if (path.len == 0) return Value{ .string = "" };
-    const content = readFileAllAbsolute(ctx.io, ctx.allocator, path, 1024 * 1024) catch {
+    const content = fs_read.readFileAllAbsolute(ctx.io, ctx.allocator, path, 1024 * 1024) catch {
         return Value{ .string = "" };
     };
     return Value{ .string = content };
@@ -389,23 +390,6 @@ fn receiverPath(allocator: std.mem.Allocator, receiver: ?Value) BuiltinError![]c
         .string => |s| s,
         else => recv.asString(allocator) catch return BuiltinError.OutOfMemory,
     };
-}
-
-/// Read the entire contents of an absolute file path into a caller-owned slice.
-fn readFileAllAbsolute(io: std.Io, allocator: std.mem.Allocator, abs_path: []const u8, max_bytes: usize) ![]u8 {
-    const f = try std.Io.Dir.openFileAbsolute(io, abs_path, .{});
-    defer f.close(io);
-    const st = try f.stat(io);
-    const size = @min(@as(u64, max_bytes), st.size);
-    const buf = try allocator.alloc(u8, @intCast(size));
-    errdefer allocator.free(buf);
-    const n = try f.readPositionalAll(io, buf, 0);
-    if (n == buf.len) return buf;
-    if (allocator.resize(buf, n)) return buf[0..n];
-    const shrunk = try allocator.alloc(u8, n);
-    @memcpy(shrunk, buf[0..n]);
-    allocator.free(buf);
-    return shrunk;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/fs/read.zig
+++ b/src/fs/read.zig
@@ -1,0 +1,169 @@
+//! malt — read an entire file at an absolute path into an owned buffer.
+//!
+//! Shared leaf: the self-update trust layer, the notifier cache, and the DSL
+//! builtins all slurp whole small files this way. `max_bytes` is a per-call
+//! cap so an oversized or hostile file cannot exhaust memory — bytes past the
+//! cap are dropped silently, matching every historical call site.
+
+const std = @import("std");
+
+/// Read up to `max_bytes` of `abs_path` into a freshly-allocated slice the
+/// caller owns and frees. Files larger than `max_bytes` are truncated to the
+/// cap. The slice is shrunk to the bytes actually read.
+pub fn readFileAllAbsolute(io: std.Io, allocator: std.mem.Allocator, abs_path: []const u8, max_bytes: usize) ![]u8 {
+    const f = try std.Io.Dir.openFileAbsolute(io, abs_path, .{});
+    defer f.close(io);
+    const st = try f.stat(io);
+    const size = @min(@as(u64, max_bytes), st.size);
+    const buf = try allocator.alloc(u8, @intCast(size));
+    errdefer allocator.free(buf);
+    const n = try f.readPositionalAll(io, buf, 0);
+    if (n == buf.len) return buf;
+    if (allocator.resize(buf, n)) return buf[0..n];
+    const shrunk = try allocator.alloc(u8, n);
+    @memcpy(shrunk, buf[0..n]);
+    allocator.free(buf);
+    return shrunk;
+}
+
+// ── tests ──────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+// Blocking debug IO drives the real syscalls each test needs.
+const test_io = std.Options.debug_io;
+
+// Unique per-run absolute path so parallel test binaries never collide on
+// a shared /tmp name.
+fn tmpPath(buf: []u8, label: []const u8) []const u8 {
+    const ts = std.Io.Clock.real.now(test_io).toNanoseconds();
+    // A max_path_bytes buffer cannot overflow this short format.
+    return std.fmt.bufPrint(buf, "/tmp/malt_read_{s}_{d}", .{ label, ts }) catch unreachable;
+}
+
+fn writeTmp(path: []const u8, bytes: []const u8) !void {
+    const f = try std.Io.Dir.cwd().createFile(test_io, path, .{ .truncate = true });
+    defer f.close(test_io);
+    try f.writeStreamingAll(test_io, bytes);
+}
+
+test "empty file returns a zero-length slice" {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = tmpPath(&buf, "empty");
+    try writeTmp(path, "");
+    defer std.Io.Dir.cwd().deleteTree(test_io, path) catch {};
+
+    const out = try readFileAllAbsolute(test_io, testing.allocator, path, 1024);
+    defer testing.allocator.free(out);
+    try testing.expectEqual(@as(usize, 0), out.len);
+}
+
+test "file smaller than the cap returns full contents" {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = tmpPath(&buf, "small");
+    try writeTmp(path, "hello");
+    defer std.Io.Dir.cwd().deleteTree(test_io, path) catch {};
+
+    const out = try readFileAllAbsolute(test_io, testing.allocator, path, 1024);
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("hello", out);
+}
+
+test "file exactly at the cap returns full contents" {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = tmpPath(&buf, "exact");
+    try writeTmp(path, "abcdefgh");
+    defer std.Io.Dir.cwd().deleteTree(test_io, path) catch {};
+
+    const out = try readFileAllAbsolute(test_io, testing.allocator, path, 8);
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("abcdefgh", out);
+}
+
+test "file larger than the cap is silently truncated to the cap" {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = tmpPath(&buf, "trunc");
+    try writeTmp(path, "0123456789ABCDEFGHIJ"); // 20 bytes
+    defer std.Io.Dir.cwd().deleteTree(test_io, path) catch {};
+
+    const out = try readFileAllAbsolute(test_io, testing.allocator, path, 8);
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("01234567", out);
+}
+
+// Shrinks the target file the instant its read buffer is allocated — i.e.
+// between the stat and the read inside readFileAllAbsolute — so the read
+// comes up short, then refuses `resize` so the helper takes its
+// @memcpy-into-fresh-alloc fallback. Alloc/free delegate to a real allocator
+// so std.testing's leak check still guards that fallback's free.
+const ShrinkTrigger = struct {
+    parent: std.mem.Allocator,
+    io: std.Io,
+    path: []const u8,
+    truncate_to: u64,
+    fired: bool = false,
+
+    fn allocator(self: *ShrinkTrigger) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &.{
+            .alloc = alloc,
+            .resize = resize,
+            .remap = remap,
+            .free = free,
+        } };
+    }
+
+    // ctx is always a *ShrinkTrigger we handed to the vtable; the cast is the
+    // standard type-erased-allocator round-trip.
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *ShrinkTrigger = @ptrCast(@alignCast(ctx));
+        if (!self.fired) {
+            self.fired = true;
+            const f = std.Io.Dir.openFileAbsolute(self.io, self.path, .{ .mode = .read_write }) catch return null;
+            defer f.close(self.io);
+            f.setLength(self.io, self.truncate_to) catch return null;
+        }
+        return self.parent.rawAlloc(len, alignment, ra);
+    }
+
+    fn resize(_: *anyopaque, _: []u8, _: std.mem.Alignment, _: usize, _: usize) bool {
+        return false; // force the shrink fallback, not an in-place resize
+    }
+
+    fn remap(_: *anyopaque, _: []u8, _: std.mem.Alignment, _: usize, _: usize) ?[*]u8 {
+        return null; // no remap → the alloc-and-copy fallback is exercised
+    }
+
+    fn free(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        const self: *ShrinkTrigger = @ptrCast(@alignCast(ctx));
+        self.parent.rawFree(memory, alignment, ra);
+    }
+};
+
+test "a missing file surfaces error.FileNotFound" {
+    // readCache switches on exactly this error to mean "no cache yet", so the
+    // helper must keep surfacing it rather than mapping it to something else.
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = tmpPath(&buf, "absent");
+    std.Io.Dir.cwd().deleteTree(test_io, path) catch {};
+    try testing.expectError(
+        error.FileNotFound,
+        readFileAllAbsolute(test_io, testing.allocator, path, 1024),
+    );
+}
+
+test "short read falls back to a fresh allocation when resize fails" {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = tmpPath(&buf, "shrink");
+    try writeTmp(path, "0123456789"); // 10 bytes; buffer sized to 10
+    defer std.Io.Dir.cwd().deleteTree(test_io, path) catch {};
+
+    var trigger = ShrinkTrigger{
+        .parent = testing.allocator,
+        .io = test_io,
+        .path = path,
+        .truncate_to = 4, // read comes back short: 4 < 10
+    };
+    const out = try readFileAllAbsolute(test_io, trigger.allocator(), path, 1024);
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("0123", out);
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -84,6 +84,7 @@ pub const atomic = @import("fs/atomic.zig");
 pub const clonefile = @import("fs/clonefile.zig");
 pub const dirsize = @import("fs/dirsize.zig");
 pub const path_write = @import("fs/path_write.zig");
+pub const read = @import("fs/read.zig");
 pub const theme_file = @import("fs/theme_file.zig");
 pub const codesign = @import("macho/codesign.zig");
 pub const parser = @import("macho/parser.zig");

--- a/src/update/notifier/cache.zig
+++ b/src/update/notifier/cache.zig
@@ -6,6 +6,7 @@
 const std = @import("std");
 
 const atomic = @import("../../fs/atomic.zig");
+const read = @import("../../fs/read.zig");
 const output = @import("../../ui/output.zig");
 
 const cache_filename = "version-notify.json";
@@ -140,7 +141,7 @@ pub fn replaceState(state: *?State, allocator: std.mem.Allocator, new_value: Sta
 
 /// Returns null when the file is absent (a torn or first run).
 pub fn readCache(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !?State {
-    const bytes = readFileAllAbsolute(io, allocator, path, 64 * 1024) catch |e| switch (e) {
+    const bytes = read.readFileAllAbsolute(io, allocator, path, 64 * 1024) catch |e| switch (e) {
         error.FileNotFound => return null,
         else => return e,
     };
@@ -158,23 +159,6 @@ pub fn writeCache(io: std.Io, path: []const u8, state: State) !void {
     var buf: [1024]u8 = undefined;
     const encoded = try encodeState(&buf, state);
     try atomic.atomicWriteFile(io, path, encoded);
-}
-
-/// Read the entire contents of an absolute file path into a caller-owned slice.
-fn readFileAllAbsolute(io: std.Io, allocator: std.mem.Allocator, abs_path: []const u8, max_bytes: usize) ![]u8 {
-    const f = try std.Io.Dir.openFileAbsolute(io, abs_path, .{});
-    defer f.close(io);
-    const st = try f.stat(io);
-    const size = @min(@as(u64, max_bytes), st.size);
-    const buf = try allocator.alloc(u8, @intCast(size));
-    errdefer allocator.free(buf);
-    const n = try f.readPositionalAll(io, buf, 0);
-    if (n == buf.len) return buf;
-    if (allocator.resize(buf, n)) return buf[0..n];
-    const shrunk = try allocator.alloc(u8, n);
-    @memcpy(shrunk, buf[0..n]);
-    allocator.free(buf);
-    return shrunk;
 }
 
 // --- inline tests --------------------------------------------------------

--- a/src/update/verify.zig
+++ b/src/update/verify.zig
@@ -11,6 +11,7 @@
 
 const std = @import("std");
 const hash = @import("../core/hash.zig");
+const read = @import("../fs/read.zig");
 
 pub const ChecksumError = error{
     /// `bytes` did not hash to the value named in `expected_hex`.
@@ -109,7 +110,7 @@ pub fn verifyAll(io: std.Io, allocator: std.mem.Allocator, in: VerifyInputs) Ver
         .oidc_issuer = in.oidc_issuer,
     }) catch |e| return e;
 
-    const checksums = readFileAllAbsolute(io, allocator, in.checksums_path, 1 << 20) catch
+    const checksums = read.readFileAllAbsolute(io, allocator, in.checksums_path, 1 << 20) catch
         return error.ReadFailed;
     defer allocator.free(checksums);
 
@@ -148,21 +149,4 @@ pub fn verifyCosignBlob(io: std.Io, args: CosignBlob) CosignError!void {
         .exited => |code| if (code != 0) return error.CosignVerifyFailed,
         else => return error.CosignVerifyFailed,
     }
-}
-
-/// Read the entire contents of an absolute file path into a caller-owned slice.
-fn readFileAllAbsolute(io: std.Io, allocator: std.mem.Allocator, abs_path: []const u8, max_bytes: usize) ![]u8 {
-    const f = try std.Io.Dir.openFileAbsolute(io, abs_path, .{});
-    defer f.close(io);
-    const st = try f.stat(io);
-    const size = @min(@as(u64, max_bytes), st.size);
-    const buf = try allocator.alloc(u8, @intCast(size));
-    errdefer allocator.free(buf);
-    const n = try f.readPositionalAll(io, buf, 0);
-    if (n == buf.len) return buf;
-    if (allocator.resize(buf, n)) return buf[0..n];
-    const shrunk = try allocator.alloc(u8, n);
-    @memcpy(shrunk, buf[0..n]);
-    allocator.free(buf);
-    return shrunk;
 }


### PR DESCRIPTION
## Description

Extracts the `readFileAllAbsolute` read-all-with-shrink helper - duplicated byte-for-byte across four modules - into a single `src/fs/read.zig` leaf, re-exported from `src/lib.zig`, and wires all four consumers to it: the self-update trust layer (`update/verify`), the notifier cache (`update/notifier/cache`), and the two DSL builtins (`pathname` `.read`, `inreplace`). After this change there is exactly one definition, so a correctness fix reaches every caller.

## Related Issue

- None

## Notes for Reviewers

- None