### PR TITLE
ci(release): auto-cut release/<minor> branch on minor releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,6 +348,43 @@ jobs:
             --latest \
             --notes-file "$notes_file"
 
+  # Cut the release/<minor> branch on a minor release so the patch line
+  # is ready without remembering to run `just release-branch` by hand.
+  # Gated on create-release-notes so the branch only exists for a release
+  # that actually shipped. Idempotent and minor-only: patch releases are
+  # tagged from the existing release/X.Y branch and cut nothing here.
+  cut-release-branch:
+    name: Cut release branch
+    runs-on: ubuntu-latest
+    needs: create-release-notes
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v7
+        # persist-credentials defaults true so `git push` can auth via the
+        # ambient GITHUB_TOKEN. HEAD is the tag commit on a push:tags event.
+
+      - name: Cut release/<minor> for minor releases
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          ver="${TAG_NAME#v}"
+          # Only X.Y.0 opens a new patch line; patches ride the existing branch.
+          if [ "${ver##*.}" != "0" ]; then
+            echo "::notice::$TAG_NAME is a patch release - no new branch"
+            exit 0
+          fi
+          target="release/${ver%.*}"
+          if git ls-remote --exit-code --heads origin "$target" >/dev/null 2>&1; then
+            echo "::notice::$target already exists - nothing to do"
+            exit 0
+          fi
+          git branch "$target"          # from HEAD == the tag commit
+          git push origin "$target"
+          echo "✓ cut $target from $TAG_NAME"
+
   # End-to-end smoke against the live release: install via the README
   # one-liner, cosign + checksum + install a real formula. Runs here
   # (not in a separate `release: published` workflow) so the order stays


### PR DESCRIPTION
## Description

Adds a `cut-release-branch` job to the release workflow. On a minor tag (`X.Y.0`) it cuts `release/X.Y` from the tag commit, so the patch line exists without running `just release-branch` by hand. Gated on the release being published; patch tags and pre-existing branches are skipped.

## Related Issue

- None

## Notes for Reviewers

- Uses the default GITHUB_TOKEN, so cutting the branch does not re-trigger CI on `release/*`.