### PR TITLE
ci(bench): mark skipped peer tools instead of publishing blank cells

### DIFF
--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -852,6 +852,29 @@ finalize_results() {
   done
 }
 
+# emit_skipped_peers <pkg>
+#
+# nanobrew/zerobrew always have a README column. When a peer fails to build (a
+# broken upstream release tag, a missing toolchain) it is dropped from the
+# active tool list, so finalize_results never emits its cell and the workflow
+# renders a *blank* - silently passing off a missing comparison as if it were
+# data. Stamp a loud marker for any declared peer whose binary is absent so the
+# published table never lies. Active peers (binary present) are left to
+# finalize_results; this only fills the holes it leaves behind.
+emit_skipped_peers() {
+  local pkg="$1" tool bin reason
+  for tool in nb zb; do
+    case "$tool" in
+    nb) bin="$NB_BIN" ;;
+    zb) bin="$ZB_BIN" ;;
+    esac
+    [ -x "$bin" ] && continue
+    reason=$(get_result "skip_$tool")
+    emit_output "${tool}_cold_disp=⚠️ ${reason:-n/a}"
+    emit_output "${tool}_warm=⚠️ ${reason:-n/a}"
+  done
+}
+
 # --- orchestration -----------------------------------------------------------
 
 run_bench_for() {
@@ -878,6 +901,7 @@ run_bench_for() {
   done
 
   finalize_results "$pkg" "${tools[@]}"
+  [ "$SKIP_OTHERS" = "1" ] || emit_skipped_peers "$pkg"
 }
 
 # --- run ---------------------------------------------------------------------
@@ -900,11 +924,18 @@ if [ "$BENCH_STRESS" -gt 0 ]; then
 fi
 
 if [ "$SKIP_OTHERS" != "1" ]; then
-  build_nanobrew || warn "nanobrew build failed — skipping"
+  build_nanobrew || {
+    warn "nanobrew build failed — skipping"
+    set_result skip_nb "build failed"
+  }
   if command -v cargo >/dev/null 2>&1; then
-    build_zerobrew || warn "zerobrew build failed — skipping"
+    build_zerobrew || {
+      warn "zerobrew build failed — skipping"
+      set_result skip_zb "build failed"
+    }
   else
     warn "cargo missing — skipping zerobrew"
+    set_result skip_zb "n/a"
   fi
 fi
 

--- a/scripts/test/bench_release_resolution_test.sh
+++ b/scripts/test/bench_release_resolution_test.sh
@@ -85,6 +85,36 @@ check_pred "FAIL never trips" 1 over_threshold "FAIL" "30"
 check_pred "empty median never trips" 1 over_threshold "" "30"
 check_pred "disabled ceiling (0) off" 1 over_threshold "999" "0"
 
+echo "emit_skipped_peers:"
+# A peer whose binary never built is dropped from the active tool list, so its
+# README cell would render blank - silently hiding that the comparison lost a
+# column. emit_skipped_peers must stamp a loud marker instead. We capture the
+# emitted key=value lines by pointing GITHUB_OUTPUT at a temp file.
+GITHUB_OUTPUT=$(mktemp)
+emitted() { grep "^$1=" "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-; }
+
+# Missing binary + recorded reason -> loud marker in both cold and warm cells.
+# NB_BIN/ZB_BIN are read by emit_skipped_peers (sourced globals), not locally.
+: >"$GITHUB_OUTPUT"
+# shellcheck disable=SC2034
+NB_BIN="/nonexistent/nb"
+# shellcheck disable=SC2034
+ZB_BIN=$(command -v sh) # an existing executable: an *active* peer, not skipped
+set_result skip_nb "build failed"
+emit_skipped_peers tree
+check "skipped peer cold cell is a marker" "⚠️ build failed" "$(emitted nb_cold_disp)"
+check "skipped peer warm cell is a marker" "⚠️ build failed" "$(emitted nb_warm)"
+check "active peer cold cell not clobbered" "" "$(emitted zb_cold_disp)"
+check "active peer warm cell not clobbered" "" "$(emitted zb_warm)"
+
+# Missing binary + no recorded reason -> generic n/a marker (never blank).
+: >"$GITHUB_OUTPUT"
+set_result skip_nb ""
+emit_skipped_peers tree
+check "no-reason skip falls back to n/a" "⚠️ n/a" "$(emitted nb_cold_disp)"
+
+rm -f "$GITHUB_OUTPUT"
+
 if [ "$fail" -ne 0 ]; then
   echo "bench release-resolution tests FAILED" >&2
   exit 1


### PR DESCRIPTION
## Description

Guards the weekly benchmark tables against false data: when a peer tool is missing from a run, its cold and warm cells now carry a visible marker instead of rendering blank. A silently empty cell reads as "no data missing"; the marker makes a dropped comparison obvious in the PR diff. Covered by unit tests.

## Related Issue

- None

## Notes for Reviewers

- None