### PR TITLE
refactor(migrate): dedup outcome drain and extract parallel runner

### DIFF
--- a/scripts/regressions/migrate-serial-persists-manifest-per-keg.sh
+++ b/scripts/regressions/migrate-serial-persists-manifest-per-keg.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Regression: serial `mt migrate` persists the resume manifest after EACH
+# success, not batched at the end of the run.
+#
+# The serial arm writes migrate.progress.json inline after every `.migrated`
+# keg, before starting the next one. If that write were ever hoisted to the end
+# of `execute` (e.g. folded back into a single post-loop flush), a Ctrl-C
+# mid-run would break the keg loop before the flush and lose every completed
+# keg — the next run would re-migrate work already done.
+#
+# What this pins end to end: seed N kegs, start a serial migrate, wait until the
+# manifest first shows a completed keg, send SIGINT, and assert the manifest
+# holds a NON-EMPTY PROPER SUBSET (>=1 and <N). Per-keg persistence => the
+# already-migrated kegs are on disk at interrupt time; a batched-at-end write
+# would leave zero migrated entries after the loop breaks, failing the >=1 check.
+#
+# Real bottle downloads give the interrupt a window to land, so this needs
+# network to formulae.brew.sh + ghcr.io (as migrate itself does). With no
+# connectivity it SKIPs cleanly rather than flaking.
+#
+# Usage: scripts/regressions/migrate-serial-persists-manifest-per-keg.sh
+# Requirements: a built malt binary at $MALT_BIN or zig-out/bin/malt; network.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+skip() {
+  printf '  \xe2\x8a\x98 SKIP: %s\n' "$*"
+  exit 0
+}
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+# MALT_PREFIX must stay <= 13 bytes (Mach-O in-place patching budget), so use a
+# fixed short scratch path instead of mktemp's long one.
+PREFIX="/tmp/mt_msr"
+SCRATCH="/tmp/mt-msr-brew"
+rm -rf "$PREFIX" "$SCRATCH"
+trap 'rm -rf "$PREFIX" "$SCRATCH"' EXIT
+export MALT_PREFIX="$PREFIX"
+export MALT_CACHE="$PREFIX/cache"
+unset MALT_OFFLINE NO_COLOR CI
+
+# Small, stable core kegs with real bottles. Enough of them that interrupting on
+# the first completion still leaves several un-migrated (the <N assertion).
+KEGS=(hello tree jq xz lz4 zstd wget gmp)
+N=${#KEGS[@]}
+
+# Connectivity probe — one seeded name must be reachable.
+curl -sfI --max-time 8 "https://formulae.brew.sh/api/formula/jq.json" >/dev/null 2>&1 ||
+  skip "no network to formulae.brew.sh"
+
+# Scratch Cellar of empty named dirs: migrate resolves each keg via the brew API
+# on name alone and never reads inside the dir, so empty dirs drive a real
+# migration. Symlinks would NOT work — the scanner skips non-directory entries.
+mkdir -p "$SCRATCH/Cellar"
+for k in "${KEGS[@]}"; do
+  mkdir -p "$SCRATCH/Cellar/$k"
+done
+export HOMEBREW_PREFIX="$SCRATCH"
+
+MANIFEST="$PREFIX/cache/migrate.progress.json"
+
+# Start the serial migrate (no --parallel); capture PID.
+"$BIN" migrate --quiet >/dev/null 2>&1 &
+PID=$!
+
+# Count completed kegs in the manifest. Format is
+# {"version":N,"completed":["a","b",...]}. Isolate the completed array and count
+# its quoted names — the leading "completed" token is subtracted off. Missing
+# file or empty array => 0.
+manifest_count() {
+  [[ -f "$MANIFEST" ]] || {
+    echo 0
+    return
+  }
+  local arr n
+  arr=$(grep -o '"completed":\[[^]]*\]' "$MANIFEST" 2>/dev/null || true)
+  [[ -n "$arr" ]] || {
+    echo 0
+    return
+  }
+  n=$(printf '%s' "$arr" | grep -o '"[^"]*"' | wc -l | tr -d ' ')
+  echo "$((n - 1))"
+}
+
+# Wait until the first keg lands in the manifest, then interrupt. Bail as SKIP
+# if nothing is persisted in time — an environmental stall, not a lost write.
+waited=0
+until [[ "$(manifest_count)" -ge 1 ]]; do
+  kill -0 "$PID" 2>/dev/null || break
+  sleep 0.2
+  waited=$((waited + 1))
+  if [[ $waited -ge 150 ]]; then # ~30s
+    kill -INT "$PID" 2>/dev/null || true
+    wait "$PID" 2>/dev/null || true
+    skip "no keg migrated in 30s (network stall)"
+  fi
+done
+
+kill -INT "$PID" 2>/dev/null || true
+
+# The process must reap promptly after SIGINT. Poll for up to 20s (an in-flight
+# bottle install has to unwind before the loop checks the interrupt flag).
+reaped=0
+for _ in $(seq 1 100); do
+  if ! kill -0 "$PID" 2>/dev/null; then
+    reaped=1
+    break
+  fi
+  sleep 0.2
+done
+if [[ $reaped -eq 0 ]]; then
+  kill -9 "$PID" 2>/dev/null || true
+  wait "$PID" 2>/dev/null || true
+  fail "SIGINT was swallowed — serial migrate did not stop within 20s"
+fi
+wait "$PID" 2>/dev/null || true
+
+# The completed kegs must be on disk at interrupt time: a non-empty proper
+# subset. >=1 proves per-keg persistence (a batched-at-end write would be lost
+# when the loop broke); <N proves the interrupt actually stopped it mid-run.
+count=$(manifest_count)
+if [[ "$count" -lt 1 ]]; then
+  fail "manifest holds no migrated kegs after SIGINT — persistence was batched, not per-keg"
+fi
+if [[ "$count" -ge "$N" ]]; then
+  skip "all $N kegs migrated before the interrupt landed (too fast to observe partial state)"
+fi
+pass "manifest persisted $count of $N kegs before SIGINT (per-keg, not batched)"
+
+printf '\n\xe2\x9c\x94 migrate serial per-keg manifest persistence regression passed\n'

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -18,7 +18,6 @@ const atomic = @import("../fs/atomic.zig");
 const codesign = @import("../macho/codesign.zig");
 const api_mod = @import("../net/api.zig");
 const client_mod = @import("../net/client.zig");
-const pool_mod = @import("../net/client_pool.zig");
 const ghcr_mod = @import("../net/ghcr.zig");
 const color = @import("../ui/color.zig");
 const output = @import("../ui/output.zig");
@@ -313,119 +312,20 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     if (parallel_flag) {
         last_run_parallel = true;
-
-        const worker_count = parallel_mod.boundWorkerCount(
-            parallel_mod.workerCountFromLiveEnv(ctx),
-            keg_names.items.len,
-        );
-
-        // Enforce the SQLite-threadsafe contract the pool depends on
-        // (lock-free `isInstalled` reads vs `db_mu`-holding writers).
-        // Skip when only one worker will actually run — single-thread
-        // can't race.
-        if (worker_count >= 2) {
-            parallel_mod.ensureSerializedThreading() catch {
-                output.err("malt was built without SQLite serialized threading; parallel migrate disabled. Rebuild with -DSQLITE_THREADSAFE=1 or set MALT_MIGRATE_PARALLEL_WORKERS=1.", .{});
-                return error.Aborted;
-            };
-        }
-
-        // Borrowed clients keep TLS contexts warm across kegs without
-        // paying a fresh handshake per worker.
-        var http_pool = pool_mod.HttpClientPool.init(ctx.io, ctx.environ, allocator, @intCast(@max(worker_count, 1))) catch {
-            output.err("Failed to initialise HTTP client pool", .{});
-            return error.Aborted;
-        };
-        defer http_pool.deinit();
-        http_pool.setOfflineAll(ctx.offline);
-
-        var db_mu: std.Io.Mutex = .init;
-        var manifest_mu: std.Io.Mutex = .init;
-
-        const outcomes = try allocator.alloc(parallel_mod.KegOutcome, keg_names.items.len);
-        defer allocator.free(outcomes);
-        // Pre-populated so an interrupted/short-circuited slot still has a
-        // defined outcome — `.cancelled` so untouched kegs surface as
-        // "you cancelled before I touched it" rather than "I had it already".
-        for (outcomes, 0..) |*o, i| o.* = .{ .name = keg_names.items[i], .result = .cancelled };
-
-        // Pre-filter manifest+DB-confirmed skips so the multi-progress
-        // line count matches actual work — drawing a "✓" for kegs that
-        // never ran would be misleading. The serial path already does
-        // this inline; for parallel we hoist it ahead of bar allocation.
-        const bar_for_keg = try allocator.alloc(?*progress_mod.ProgressBar, keg_names.items.len);
-        defer allocator.free(bar_for_keg);
-        @memset(bar_for_keg, null);
-
-        var work_indices: std.ArrayList(usize) = .empty;
-        defer work_indices.deinit(allocator);
-        try work_indices.ensureTotalCapacity(allocator, keg_names.items.len);
-        var max_name_len: u8 = 0;
-        for (keg_names.items, 0..) |name, i| {
-            if (manifest.contains(name) and keg_mod.isInstalled(&db, name)) {
-                outcomes[i] = .{ .name = name, .result = .skipped_installed };
-                continue;
-            }
-            work_indices.appendAssumeCapacity(i);
-            const len: u8 = @intCast(@min(name.len, 255));
-            if (len > max_name_len) max_name_len = len;
-        }
-
-        // u16 cap: kegs past the first 65,535 still migrate but render no
-        // progress bar. Practically unreachable on a real Homebrew install.
-        const work_count: u16 = @intCast(@min(work_indices.items.len, std.math.maxInt(u16)));
-        var multi = progress_mod.MultiProgress.init(work_count);
-        defer multi.finish();
-
-        const bars = try allocator.alloc(progress_mod.ProgressBar, work_count);
-        defer allocator.free(bars);
-
-        for (work_indices.items[0..work_count], 0..) |keg_idx, slot| {
-            const slot_u16: u16 = @intCast(slot);
-            bars[slot] = progress_mod.ProgressBar.init(keg_names.items[keg_idx], 0);
-            bars[slot].label_width = max_name_len;
-            bars[slot].line_index = slot_u16;
-            bars[slot].multi = &multi;
-            // Initial frame so each reserved row has visible content
-            // before its worker is scheduled.
-            bars[slot].update(0);
-            bar_for_keg[keg_idx] = &bars[slot];
-        }
-        // Hand the group its bars so the first worker to see a resize can
-        // repaint every row at the new width. Set after the loop — the alloc
-        // is uninitialised until each slot is written.
-        multi.bars = bars;
-
-        var pool: parallel_mod.Pool = .{
+        try parallel_mod.runMigration(allocator, .{
             .app_ctx = ctx,
-            .next_idx = std.atomic.Value(usize).init(0),
             .keg_names = keg_names.items,
-            .outcomes = outcomes,
             .cache_dir = cache_dir,
             .prefix = prefix,
             .homebrew_prefix = brew_prefix,
             .use_system_ruby_scope = use_system_ruby_scope.items,
-            .http_pool = &http_pool,
             .store = &store,
             .linker = &linker,
             .db = &db,
-            .db_mu = &db_mu,
             .manifest = &manifest,
-            .manifest_mu = &manifest_mu,
             .manifest_path = manifest_path,
-            .manifest_allocator = allocator,
             .post_install_queue = &post_install_queue,
-            .worker_backing = std.heap.smp_allocator,
-            .bar_for_keg = bar_for_keg,
-        };
-        try parallel_mod.run(allocator, &pool, worker_count);
-        // Mirror the serial loop's interrupt UX so users running with
-        // --parallel still see "Interrupted" instead of silent skips.
-        if (signals.isInterrupted()) {
-            output.warn("Interrupted — skipping remaining kegs.", .{});
-        }
-
-        for (outcomes) |o| try buckets.record(allocator, o.name, o.result);
+        }, buckets);
     } else {
         // Width of the widest keg name so per-keg bars line up vertically
         // with each other (and with `install`'s download phase).

--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -29,6 +29,7 @@ const KegResult = keg_mod.KegResult;
 const MigrateDeps = keg_mod.MigrateDeps;
 const migrateKeg = keg_mod.migrateKeg;
 const manifest_mod = @import("migrate/manifest.zig");
+const outcomes_mod = @import("migrate/outcomes.zig");
 const parallel_mod = @import("migrate/parallel.zig");
 const post_install_queue_mod = @import("migrate/post_install_queue.zig");
 
@@ -286,6 +287,17 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     var cancelled_names: std.ArrayList([]const u8) = .empty;
     defer cancelled_names.deinit(allocator);
 
+    // One drain target both arms share so the six-way KegResult
+    // categorization lives at a single site.
+    const buckets: outcomes_mod.Buckets = .{
+        .migrated = &migrated_names,
+        .skipped_installed = &skipped_installed_names,
+        .skipped_post_install = &skipped_post_install_names,
+        .skipped_no_bottle = &skipped_no_bottle_names,
+        .failed = &failed_names,
+        .cancelled = &cancelled_names,
+    };
+
     // Honour Ctrl-C raised during setup, before any network work starts.
     if (signals.isInterrupted()) {
         output.warn("Interrupted before migration.", .{});
@@ -413,24 +425,11 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             output.warn("Interrupted — skipping remaining kegs.", .{});
         }
 
-        for (outcomes) |o| {
-            switch (o.result) {
-                .migrated => try migrated_names.append(allocator, o.name),
-                .skipped_installed => try skipped_installed_names.append(allocator, o.name),
-                .skipped_post_install => try skipped_post_install_names.append(allocator, o.name),
-                .skipped_no_bottle => try skipped_no_bottle_names.append(allocator, o.name),
-                .failed_api, .failed_download, .failed_install => try failed_names.append(allocator, o.name),
-                .cancelled => try cancelled_names.append(allocator, o.name),
-            }
-        }
+        for (outcomes) |o| try buckets.record(allocator, o.name, o.result);
     } else {
         // Width of the widest keg name so per-keg bars line up vertically
         // with each other (and with `install`'s download phase).
-        var max_name_len: u8 = 0;
-        for (keg_names.items) |n| {
-            const len: u8 = @intCast(@min(n.len, 255));
-            if (len > max_name_len) max_name_len = len;
-        }
+        const max_name_len = outcomes_mod.maxNameLen(keg_names.items);
 
         for (keg_names.items) |keg_name| {
             // Stop at the next keg boundary when the user hits Ctrl-C.
@@ -472,29 +471,21 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
             });
             bar.finish();
 
+            // Persist after each success so a crash leaves the next run with
+            // the smallest possible to-do list. Hoisted out of the drain so
+            // categorization stays pure; the parallel path persists in-worker.
+            if (result == .migrated) {
+                manifest.add(keg_name) catch |e| {
+                    output.warn("Resume manifest update failed for {s}: {s}", .{ keg_name, @errorName(e) });
+                };
+                manifest.writeAtomic(ctx.io, allocator, manifest_path) catch |e| {
+                    output.warn("Resume manifest write failed: {s}", .{@errorName(e)});
+                };
+            }
             // OOM on per-category bookkeeping must not be swallowed: the summary
             // counts and JSON arrays come from these lists, and a silent drop
             // reports fewer failures than actually occurred.
-            switch (result) {
-                .migrated => {
-                    try migrated_names.append(allocator, keg_name);
-                    // Persist after each success so a crash leaves the next
-                    // run with the smallest possible to-do list.
-                    manifest.add(keg_name) catch |e| {
-                        output.warn("Resume manifest update failed for {s}: {s}", .{ keg_name, @errorName(e) });
-                    };
-                    manifest.writeAtomic(ctx.io, allocator, manifest_path) catch |e| {
-                        output.warn("Resume manifest write failed: {s}", .{@errorName(e)});
-                    };
-                },
-                .skipped_installed => try skipped_installed_names.append(allocator, keg_name),
-                .skipped_post_install => try skipped_post_install_names.append(allocator, keg_name),
-                .skipped_no_bottle => try skipped_no_bottle_names.append(allocator, keg_name),
-                .failed_api, .failed_download, .failed_install => try failed_names.append(allocator, keg_name),
-                // The serial loop exits on Ctrl-C before migrateKeg ever
-                // returns; this arm exists only so the switch stays exhaustive.
-                .cancelled => try cancelled_names.append(allocator, keg_name),
-            }
+            try buckets.record(allocator, keg_name, result);
         }
     }
 

--- a/src/cli/migrate/outcomes.zig
+++ b/src/cli/migrate/outcomes.zig
@@ -1,0 +1,96 @@
+//! Shared outcome categorization for `mt migrate`. The parallel and serial
+//! arms both drain a per-keg `KegResult` into the same six name lists; keeping
+//! the six-way switch here makes adding a `KegResult` variant a one-site edit.
+
+const std = @import("std");
+
+const keg_mod = @import("keg.zig");
+
+/// Six per-category name lists the migrate summary reads from. Holds pointers
+/// because each arm owns the backing `ArrayList`s on its own stack.
+pub const Buckets = struct {
+    migrated: *std.ArrayList([]const u8),
+    skipped_installed: *std.ArrayList([]const u8),
+    skipped_post_install: *std.ArrayList([]const u8),
+    skipped_no_bottle: *std.ArrayList([]const u8),
+    failed: *std.ArrayList([]const u8),
+    cancelled: *std.ArrayList([]const u8),
+
+    pub fn record(
+        self: Buckets,
+        allocator: std.mem.Allocator,
+        name: []const u8,
+        result: keg_mod.KegResult,
+    ) !void {
+        switch (result) {
+            .migrated => try self.migrated.append(allocator, name),
+            .skipped_installed => try self.skipped_installed.append(allocator, name),
+            .skipped_post_install => try self.skipped_post_install.append(allocator, name),
+            .skipped_no_bottle => try self.skipped_no_bottle.append(allocator, name),
+            .failed_api, .failed_download, .failed_install => try self.failed.append(allocator, name),
+            .cancelled => try self.cancelled.append(allocator, name),
+        }
+    }
+};
+
+/// Widest name length for progress-bar label alignment, clamped to 255 —
+/// `label_width` is a `u8`, so longer names just align to the cap.
+pub fn maxNameLen(names: []const []const u8) u8 {
+    var m: u8 = 0;
+    for (names) |n| {
+        const len: u8 = @intCast(@min(n.len, 255));
+        if (len > m) m = len;
+    }
+    return m;
+}
+
+test "record routes each KegResult variant to its category" {
+    const a = std.testing.allocator;
+    var migrated: std.ArrayList([]const u8) = .empty;
+    defer migrated.deinit(a);
+    var skipped_installed: std.ArrayList([]const u8) = .empty;
+    defer skipped_installed.deinit(a);
+    var skipped_post_install: std.ArrayList([]const u8) = .empty;
+    defer skipped_post_install.deinit(a);
+    var skipped_no_bottle: std.ArrayList([]const u8) = .empty;
+    defer skipped_no_bottle.deinit(a);
+    var failed: std.ArrayList([]const u8) = .empty;
+    defer failed.deinit(a);
+    var cancelled: std.ArrayList([]const u8) = .empty;
+    defer cancelled.deinit(a);
+
+    const b: Buckets = .{
+        .migrated = &migrated,
+        .skipped_installed = &skipped_installed,
+        .skipped_post_install = &skipped_post_install,
+        .skipped_no_bottle = &skipped_no_bottle,
+        .failed = &failed,
+        .cancelled = &cancelled,
+    };
+
+    try b.record(a, "m", .migrated);
+    try b.record(a, "si", .skipped_installed);
+    try b.record(a, "spi", .skipped_post_install);
+    try b.record(a, "snb", .skipped_no_bottle);
+    try b.record(a, "fa", .failed_api);
+    try b.record(a, "fd", .failed_download);
+    try b.record(a, "fi", .failed_install);
+    try b.record(a, "c", .cancelled);
+
+    try std.testing.expectEqual(@as(usize, 1), migrated.items.len);
+    try std.testing.expectEqualStrings("m", migrated.items[0]);
+    try std.testing.expectEqual(@as(usize, 1), skipped_installed.items.len);
+    try std.testing.expectEqual(@as(usize, 1), skipped_post_install.items.len);
+    try std.testing.expectEqual(@as(usize, 1), skipped_no_bottle.items.len);
+    // All three failed_* collapse into `failed`.
+    try std.testing.expectEqual(@as(usize, 3), failed.items.len);
+    try std.testing.expectEqual(@as(usize, 1), cancelled.items.len);
+    try std.testing.expectEqualStrings("c", cancelled.items[0]);
+}
+
+test "maxNameLen: empty is 0, mixed is the longest, over-long clamps to 255" {
+    try std.testing.expectEqual(@as(u8, 0), maxNameLen(&.{}));
+    try std.testing.expectEqual(@as(u8, 5), maxNameLen(&.{ "a", "abcde", "abc" }));
+    const long = "x" ** 300;
+    try std.testing.expectEqual(@as(u8, 255), maxNameLen(&.{long}));
+}

--- a/src/cli/migrate/parallel.zig
+++ b/src/cli/migrate/parallel.zig
@@ -16,6 +16,7 @@ const output = @import("../../ui/output.zig");
 const progress_mod = @import("../../ui/progress.zig");
 const keg_mod = @import("keg.zig");
 const manifest_mod = @import("manifest.zig");
+const outcomes_mod = @import("outcomes.zig");
 const post_install_queue_mod = @import("post_install_queue.zig");
 
 /// Surfaced when the linked SQLite isn't in serialized threading mode.
@@ -62,6 +63,13 @@ pub fn boundWorkerCount(requested: u32, jobs: usize) u32 {
     if (jobs == 0) return 0;
     const j: u32 = if (jobs > max_workers) max_workers else @intCast(jobs);
     return @min(requested, j);
+}
+
+/// Multi-progress reserves one line per work item (already-migrated kegs
+/// are pre-filtered out and get none), capped at u16 — kegs past 65,535
+/// still migrate but render no bar. The bar slice length must equal this.
+pub fn barCount(work_items: usize) u16 {
+    return @intCast(@min(work_items, std.math.maxInt(u16)));
 }
 
 /// Outcome plus name so the orchestrator can drain into the same
@@ -215,6 +223,139 @@ pub fn run(allocator: std.mem.Allocator, pool: *Pool, worker_count: u32) !void {
     for (threads[0..spawned]) |t| t.join();
 }
 
+/// Irreducible shared state the orchestrator hands the parallel runner —
+/// mirrors the caller-supplied `Pool` fields. The runner builds the `Pool`
+/// (and its internal mutexes, client pool, and bars) from this itself.
+pub const Inputs = struct {
+    app_ctx: *const AppCtx,
+    keg_names: []const []const u8,
+    cache_dir: []const u8,
+    prefix: []const u8,
+    homebrew_prefix: []const u8,
+    use_system_ruby_scope: []const []const u8,
+    store: *store_mod.Store,
+    linker: *linker_mod.Linker,
+    db: *sqlite.Database,
+    manifest: *manifest_mod.Manifest,
+    manifest_path: []const u8,
+    post_install_queue: *post_install_queue_mod.Queue,
+};
+
+/// Runs the whole `--parallel` migrate: bounds workers, enforces the
+/// SQLite-serialized contract, warms the client pool, wires the
+/// multi-progress bars, drives the pool, then drains outcomes into
+/// `buckets`. Hard-fails (non-serialized SQLite, pool init) return
+/// `error.Aborted` with the message already emitted.
+pub fn runMigration(allocator: std.mem.Allocator, in: Inputs, buckets: outcomes_mod.Buckets) !void {
+    const ctx = in.app_ctx;
+
+    const worker_count = boundWorkerCount(workerCountFromLiveEnv(ctx), in.keg_names.len);
+
+    // Enforce the SQLite-threadsafe contract the pool depends on (lock-free
+    // `isInstalled` reads vs `db_mu`-holding writers). Skip when only one
+    // worker will actually run — single-thread can't race.
+    if (worker_count >= 2) {
+        ensureSerializedThreading() catch {
+            output.err("malt was built without SQLite serialized threading; parallel migrate disabled. Rebuild with -DSQLITE_THREADSAFE=1 or set MALT_MIGRATE_PARALLEL_WORKERS=1.", .{});
+            return error.Aborted;
+        };
+    }
+
+    // Borrowed clients keep TLS contexts warm across kegs without paying a
+    // fresh handshake per worker.
+    var http_pool = pool_mod.HttpClientPool.init(ctx.io, ctx.environ, allocator, @intCast(@max(worker_count, 1))) catch {
+        output.err("Failed to initialise HTTP client pool", .{});
+        return error.Aborted;
+    };
+    defer http_pool.deinit();
+    http_pool.setOfflineAll(ctx.offline);
+
+    var db_mu: std.Io.Mutex = .init;
+    var manifest_mu: std.Io.Mutex = .init;
+
+    const outcomes = try allocator.alloc(KegOutcome, in.keg_names.len);
+    defer allocator.free(outcomes);
+    // Pre-populated so an interrupted/short-circuited slot still has a
+    // defined outcome — `.cancelled` so untouched kegs surface as "you
+    // cancelled before I touched it" rather than "I had it already".
+    for (outcomes, 0..) |*o, i| o.* = .{ .name = in.keg_names[i], .result = .cancelled };
+
+    // Pre-filter manifest+DB-confirmed skips so the multi-progress line
+    // count matches actual work — drawing a "✓" for kegs that never ran
+    // would be misleading. The serial path already does this inline.
+    const bar_for_keg = try allocator.alloc(?*progress_mod.ProgressBar, in.keg_names.len);
+    defer allocator.free(bar_for_keg);
+    @memset(bar_for_keg, null);
+
+    var work_indices: std.ArrayList(usize) = .empty;
+    defer work_indices.deinit(allocator);
+    try work_indices.ensureTotalCapacity(allocator, in.keg_names.len);
+    var max_name_len: u8 = 0;
+    for (in.keg_names, 0..) |name, i| {
+        if (in.manifest.contains(name) and keg_mod.isInstalled(in.db, name)) {
+            outcomes[i] = .{ .name = name, .result = .skipped_installed };
+            continue;
+        }
+        work_indices.appendAssumeCapacity(i);
+        const len: u8 = @intCast(@min(name.len, 255));
+        if (len > max_name_len) max_name_len = len;
+    }
+
+    const work_count = barCount(work_indices.items.len);
+    var multi = progress_mod.MultiProgress.init(work_count);
+    defer multi.finish();
+
+    const bars = try allocator.alloc(progress_mod.ProgressBar, work_count);
+    defer allocator.free(bars);
+
+    for (work_indices.items[0..work_count], 0..) |keg_idx, slot| {
+        const slot_u16: u16 = @intCast(slot);
+        bars[slot] = progress_mod.ProgressBar.init(in.keg_names[keg_idx], 0);
+        bars[slot].label_width = max_name_len;
+        bars[slot].line_index = slot_u16;
+        bars[slot].multi = &multi;
+        // Initial frame so each reserved row has visible content before its
+        // worker is scheduled.
+        bars[slot].update(0);
+        bar_for_keg[keg_idx] = &bars[slot];
+    }
+    // Hand the group its bars so the first worker to see a resize can
+    // repaint every row at the new width. Set after the loop — the alloc
+    // is uninitialised until each slot is written.
+    multi.bars = bars;
+
+    var pool: Pool = .{
+        .app_ctx = ctx,
+        .next_idx = std.atomic.Value(usize).init(0),
+        .keg_names = in.keg_names,
+        .outcomes = outcomes,
+        .cache_dir = in.cache_dir,
+        .prefix = in.prefix,
+        .homebrew_prefix = in.homebrew_prefix,
+        .use_system_ruby_scope = in.use_system_ruby_scope,
+        .http_pool = &http_pool,
+        .store = in.store,
+        .linker = in.linker,
+        .db = in.db,
+        .db_mu = &db_mu,
+        .manifest = in.manifest,
+        .manifest_mu = &manifest_mu,
+        .manifest_path = in.manifest_path,
+        .manifest_allocator = allocator,
+        .post_install_queue = in.post_install_queue,
+        .worker_backing = std.heap.smp_allocator,
+        .bar_for_keg = bar_for_keg,
+    };
+    try run(allocator, &pool, worker_count);
+    // Mirror the serial loop's interrupt UX so users running with
+    // --parallel still see "Interrupted" instead of silent skips.
+    if (signals.isInterrupted()) {
+        output.warn("Interrupted — skipping remaining kegs.", .{});
+    }
+
+    for (outcomes) |o| try buckets.record(allocator, o.name, o.result);
+}
+
 // ── Inline unit tests ──────────────────────────────────────────────
 
 test "ensureSerializedThreadingMode passes on mode 1 (serialized)" {
@@ -261,6 +402,13 @@ test "boundWorkerCount caps by job count" {
     try std.testing.expectEqual(@as(u32, 2), boundWorkerCount(4, 2));
     try std.testing.expectEqual(@as(u32, 4), boundWorkerCount(4, 10));
     try std.testing.expectEqual(@as(u32, 0), boundWorkerCount(4, 0));
+}
+
+test "barCount reserves one line per work item, capped at u16" {
+    try std.testing.expectEqual(@as(u16, 0), barCount(0));
+    try std.testing.expectEqual(@as(u16, 3), barCount(3));
+    // Kegs past the u16 line count still migrate but render no bar.
+    try std.testing.expectEqual(std.math.maxInt(u16), barCount(@as(usize, std.math.maxInt(u16)) + 5));
 }
 
 // Pre-set SIGINT with an empty manifest: every slot falls through the

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -24,6 +24,7 @@ pub const cli_link = @import("cli/link.zig");
 pub const cli_list = @import("cli/list.zig");
 pub const cli_migrate = @import("cli/migrate.zig");
 pub const cli_migrate_manifest = @import("cli/migrate/manifest.zig");
+pub const cli_migrate_outcomes = @import("cli/migrate/outcomes.zig");
 pub const cli_migrate_parallel = @import("cli/migrate/parallel.zig");
 pub const cli_outdated = @import("cli/outdated.zig");
 pub const cli_pin = @import("cli/pin.zig");

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -1813,6 +1813,69 @@ test "manifest preserves pre-existing entries across a run with new failures" {
     try testing.expect(!loaded.contains("newfail"));
 }
 
+// Serial per-keg persistence timing: a keg that migrates must be recorded
+// in the resume manifest even when a later keg in the same run fails. Pins
+// the "persist after each success, before the next keg" contract — a fresh
+// success survives on disk regardless of a subsequent failure.
+test "serial: a migrated keg is persisted even when a later keg fails" {
+    resetOutput();
+
+    const brew = try scratchDir("brew_persist_timing");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const mt_z: [:0]const u8 = "/tmp/mt_persist_timing";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, mt_z) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, mt_z);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, mt_z) catch {};
+
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", mt_z.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    // "widget": core keg with a receipt → migrates via the local-Cellar
+    // fallback once its API lookup 404s. "ghostfail": no receipt, so the
+    // same 404 leaves nothing to fall back to → `.failed_api`.
+    const keg_dir = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/widget/2.0", .{brew});
+    defer testing.allocator.free(keg_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, keg_dir);
+    const receipt_path = try std.fmt.allocPrint(testing.allocator, "{s}/INSTALL_RECEIPT.json", .{keg_dir});
+    defer testing.allocator.free(receipt_path);
+    {
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, receipt_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io,
+            \\{"source":{"tap":"homebrew/core","versions":{"stable":"2.0"}}}
+        );
+    }
+    try seedFakeBrew(brew, &.{"ghostfail"});
+
+    const cache_api = try std.fmt.allocPrint(testing.allocator, "{s}/cache/api", .{mt_z});
+    defer testing.allocator.free(cache_api);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cache_api);
+    for ([_][]const u8{ "widget", "ghostfail" }) |name| {
+        const marker = try std.fmt.allocPrint(testing.allocator, "{s}/formula_{s}.404", .{ cache_api, name });
+        defer testing.allocator.free(marker);
+        (try test_io.createFileAbsolute(std.Options.debug_io, marker, .{})).close(std.Options.debug_io);
+    }
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = malt.app_ctx.processEnviron() };
+    try migrate.execute(&ctx, arena.allocator(), &.{"--quiet"});
+
+    const manifest_path = try std.fmt.allocPrint(testing.allocator, "{s}/cache/migrate.progress.json", .{mt_z});
+    defer testing.allocator.free(manifest_path);
+    var loaded = try malt.cli_migrate_manifest.loadFromPath(&malt.app_ctx.debug_ctx, testing.allocator, manifest_path);
+    defer loaded.deinit();
+    try testing.expect(loaded.contains("widget"));
+    try testing.expect(!loaded.contains("ghostfail"));
+}
+
 // `MALT_MIGRATE_PARALLEL_WORKERS` parses correctly in unit tests, but
 // the live-env path goes through `workerCountFromLiveEnv` — wire it
 // up here so a future refactor that broke the env name would fail.


### PR DESCRIPTION
## Description

`migrate.execute` carried two problems: its parallel and serial arms hand-rolled the same six-way `KegResult` drain and widest-name loop, and the parallel arm inlined ~120 lines of pool/progress-bar setup that belongs beside
the pool.

This PR:
- adds a `cli/migrate/outcomes.zig` leaf: `Buckets.record` owns the six-way categorization at one site and `maxNameLen` replaces the duplicated loops. The serial manifest write is hoisted out of the drain switch so the switch is pure categorization, preserving "persist after each success, before the next keg".
- moves the parallel setup behind `parallel.runMigration(allocator, Inputs, buckets)`: worker bound, threadsafe guard, client pool, MultiProgress bars, pool run, and outcome drain now live in `parallel.zig`, which already owns the `Pool` and every import that setup needs. `execute` collapses to flag-parse -> scan -> dispatch.

Zero new module edges - `outcomes.zig` is a `std`+`keg.zig` leaf and `parallel.zig` already imported everything the moved block uses.

## Related Issue

- None

## Notes for Reviewers

-None