### PR TITLE
feat(bundle): uninstall members with bundle remove --purge

### DIFF
--- a/man/malt.1
+++ b/man/malt.1
@@ -721,7 +721,10 @@ Subcommands:
                               Write currently-installed set to a bundle file.
                               --services also emits auto-start services (JSON only).
   list                        List bundles registered in the database.
-  remove <name>               Unregister a bundle (does NOT uninstall members).
+  remove  [--purge] [--yes] [--dry-run] <name>
+                              Unregister a bundle. Without --purge the members stay
+                              installed; --purge also uninstalls every member that is
+                              currently installed (typed confirm unless --yes).
   export  [--format brewfile|json] [--services] [name]
                               Print bundle (or current install) to stdout.
                               --services also emits auto-start services (JSON only).

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -145,7 +145,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     if (std.mem.eql(u8, sub, "cleanup")) return cmdCleanup(ctx, allocator, rest);
     if (std.mem.eql(u8, sub, "create")) return cmdCreate(ctx, allocator, rest);
     if (std.mem.eql(u8, sub, "list")) return cmdList(ctx);
-    if (std.mem.eql(u8, sub, "remove")) return cmdRemove(ctx, rest);
+    if (std.mem.eql(u8, sub, "remove")) return cmdRemove(ctx, allocator, rest);
     if (std.mem.eql(u8, sub, "export")) return cmdExport(ctx, allocator, rest);
     if (std.mem.eql(u8, sub, "import")) return cmdImport(ctx, allocator, rest);
 
@@ -332,21 +332,156 @@ fn cmdList(ctx: *const AppCtx) !void {
     if (!any) output.info("no bundles registered", .{});
 }
 
-fn cmdRemove(ctx: *const AppCtx, rest: []const []const u8) !void {
-    if (rest.len != 1) {
+const RemoveArgs = struct { name: []const u8, purge: bool, yes: bool, dry_run: bool };
+
+/// Parse `bundle remove` args. Null signals a missing or duplicated <name>,
+/// which the caller reports as InvalidArgs. `--dry-run` seeds from the global
+/// so `malt --dry-run bundle remove --purge` previews, matching cleanup.
+fn resolveRemoveArgs(rest: []const []const u8, global_dry_run: bool) ?RemoveArgs {
+    var name: ?[]const u8 = null;
+    var purge = false;
+    var yes = false;
+    var dry_run = global_dry_run;
+    for (rest) |a| {
+        if (std.mem.eql(u8, a, "--purge")) {
+            purge = true;
+        } else if (std.mem.eql(u8, a, "--yes") or std.mem.eql(u8, a, "-y")) {
+            yes = true;
+        } else if (std.mem.eql(u8, a, "--dry-run") or std.mem.eql(u8, a, "-n")) {
+            dry_run = true;
+        } else if (std.mem.startsWith(u8, a, "-")) {
+            output.warn("ignored flag: {s}", .{a});
+        } else {
+            if (name != null) return null;
+            name = a;
+        }
+    }
+    return .{
+        .name = name orelse return null,
+        .purge = purge,
+        .yes = yes,
+        .dry_run = dry_run,
+    };
+}
+
+fn cmdRemove(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []const u8) !void {
+    const args = resolveRemoveArgs(rest, output.isDryRun()) orelse {
         output.err("bundle remove: expected <name>", .{});
         return BundleError.InvalidArgs;
+    };
+
+    if (args.purge) try purgeMembers(ctx, allocator, args);
+
+    // Unregister last: on a failed purge we return above, leaving the row in
+    // place so the command stays retryable rather than orphaning the members.
+    if (args.dry_run) {
+        output.info("dry-run: keeping bundle registration for {s}", .{args.name});
+        return;
     }
-    const name = rest[0];
     var db = try openDb(ctx);
     defer db.close();
 
     var stmt = db.prepare("DELETE FROM bundles WHERE name = ?;") catch
         return BundleError.DatabaseError;
     defer stmt.finalize();
-    stmt.bindText(1, name) catch return BundleError.DatabaseError;
+    stmt.bindText(1, args.name) catch return BundleError.DatabaseError;
     _ = stmt.step() catch return BundleError.DatabaseError;
-    output.success("bundle removed: {s}", .{name});
+    output.success("bundle removed: {s}", .{args.name});
+}
+
+/// Uninstall the members of a registered bundle. The `bundles` row stores a
+/// manifest path, not a member list, so the file has to be re-read; a missing
+/// or unparsable manifest is a hard error rather than a silent unregister,
+/// since the caller asked to remove packages and we cannot know which.
+fn purgeMembers(ctx: *const AppCtx, allocator: std.mem.Allocator, args: RemoveArgs) !void {
+    const path = try lookupManifestPath(ctx, allocator, args.name);
+    defer allocator.free(path);
+    output.info("using bundle file: {s}", .{path});
+
+    var diag = brewfile_mod.Diagnostics.init(allocator);
+    defer diag.deinit();
+    var manifest = try readManifest(ctx, allocator, path, &diag);
+    defer manifest.deinit();
+    for (diag.warnings.items) |w| output.warn("{s}", .{w});
+
+    var plan: cleanup_mod.Plan = blk: {
+        var db = try openDb(ctx);
+        defer db.close();
+        var installed = cleanup_mod.collectInstalled(allocator, &db) catch
+            return BundleError.DatabaseError;
+        defer installed.deinit();
+        var p = cleanup_mod.selectMembers(
+            allocator,
+            manifest,
+            installed.formulas,
+            installed.casks,
+        ) catch return BundleError.RunnerFailed;
+        errdefer p.deinit();
+        cleanup_mod.orderForRemoval(allocator, &db, &p) catch
+            return BundleError.DatabaseError;
+        break :blk p;
+    };
+    defer plan.deinit();
+
+    if (plan.isEmpty()) {
+        output.info("no installed members to purge", .{});
+        return;
+    }
+
+    output.info("purge plan:", .{});
+    for (plan.formulas) |n| output.plain("  - {s}", .{n});
+    for (plan.casks) |n| output.plain("  - {s} (cask)", .{n});
+
+    if (args.dry_run) {
+        output.info("dry-run: skipping uninstall", .{});
+        return;
+    }
+
+    if (!args.yes and !output.confirmTyped("yes", "Type 'yes' to remove these packages: ")) {
+        output.warn("aborted", .{});
+        return BundleError.InvalidArgs;
+    }
+
+    const dispatcher = cleanupDispatcher(ctx);
+    var report = cleanup_mod.run(allocator, plan, .{
+        .dry_run = false,
+        .dispatcher = &dispatcher,
+    }) catch |e| {
+        output.err("bundle purge failed: {s}", .{@errorName(e)});
+        return BundleError.RunnerFailed;
+    };
+    defer report.deinit();
+
+    if (report.hasFailure()) {
+        output.err("bundle purge completed with {d} failure(s)", .{report.failures.len});
+        return BundleError.RunnerFailed;
+    }
+}
+
+/// Resolve a registered bundle name to its manifest path. Caller owns the
+/// returned slice.
+fn lookupManifestPath(
+    ctx: *const AppCtx,
+    allocator: std.mem.Allocator,
+    name: []const u8,
+) ![]const u8 {
+    var db = try openDb(ctx);
+    defer db.close();
+
+    var stmt = db.prepare("SELECT manifest_path FROM bundles WHERE name = ?;") catch
+        return BundleError.DatabaseError;
+    defer stmt.finalize();
+    stmt.bindText(1, name) catch return BundleError.DatabaseError;
+
+    if (!(stmt.step() catch return BundleError.DatabaseError)) {
+        output.err("bundle not registered: {s}", .{name});
+        return BundleError.BundlefileNotFound;
+    }
+    const raw = stmt.columnText(0) orelse {
+        output.err("bundle {s} has no recorded manifest path", .{name});
+        return BundleError.BundlefileNotFound;
+    };
+    return allocator.dupe(u8, std.mem.sliceTo(raw, 0)) catch return BundleError.DatabaseError;
 }
 
 const CreateArgs = struct { format: Format, out_path: []const u8, include_services: bool };
@@ -684,7 +819,10 @@ fn printHelp(ctx: *const AppCtx) !void {
         \\                              Write currently-installed set to a bundle file.
         \\                              --services also emits auto-start services (JSON only).
         \\  list                        List bundles registered in the database.
-        \\  remove <name>               Unregister a bundle (does NOT uninstall members).
+        \\  remove  [--purge] [--yes] [--dry-run] <name>
+        \\                              Unregister a bundle. Without --purge the members stay
+        \\                              installed; --purge also uninstalls every member that is
+        \\                              currently installed (typed confirm unless --yes).
         \\  export  [--format brewfile|json] [--services] [name]
         \\                              Print bundle (or current install) to stdout.
         \\                              --services also emits auto-start services (JSON only).
@@ -695,6 +833,44 @@ fn printHelp(ctx: *const AppCtx) !void {
         \\
     ;
     ctx.stderr.writeStreamingAll(ctx.io, msg) catch {};
+}
+
+test "remove: bare name defaults to unregister-only" {
+    const a = resolveRemoveArgs(&.{"work"}, false).?;
+    try std.testing.expectEqualStrings("work", a.name);
+    // The default must stay non-destructive: `bundle remove` predates --purge
+    // and callers rely on it leaving packages installed.
+    try std.testing.expect(!a.purge);
+    try std.testing.expect(!a.yes);
+    try std.testing.expect(!a.dry_run);
+}
+
+test "remove: flags parse in any position relative to the name" {
+    const before = resolveRemoveArgs(&.{ "--purge", "--yes", "work" }, false).?;
+    try std.testing.expectEqualStrings("work", before.name);
+    try std.testing.expect(before.purge);
+    try std.testing.expect(before.yes);
+
+    const after = resolveRemoveArgs(&.{ "work", "--purge", "-y" }, false).?;
+    try std.testing.expectEqualStrings("work", after.name);
+    try std.testing.expect(after.purge);
+    try std.testing.expect(after.yes);
+}
+
+test "remove: --dry-run is set by the flag or inherited from the global" {
+    try std.testing.expect(resolveRemoveArgs(&.{ "work", "--dry-run" }, false).?.dry_run);
+    try std.testing.expect(resolveRemoveArgs(&.{ "work", "-n" }, false).?.dry_run);
+    // `malt --dry-run bundle remove --purge` must preview, not uninstall:
+    // main.zig strips the global, so the flag can only arrive this way.
+    try std.testing.expect(resolveRemoveArgs(&.{"work"}, true).?.dry_run);
+}
+
+test "remove: a missing or duplicated name is rejected" {
+    try std.testing.expect(resolveRemoveArgs(&.{}, false) == null);
+    try std.testing.expect(resolveRemoveArgs(&.{"--purge"}, false) == null);
+    // Two positionals are ambiguous; silently purging the second would be
+    // destructive, so refuse rather than guess.
+    try std.testing.expect(resolveRemoveArgs(&.{ "work", "home" }, false) == null);
 }
 
 test "create: explicit out_path wins regardless of --format position" {

--- a/src/core/bundle/cleanup.zig
+++ b/src/core/bundle/cleanup.zig
@@ -164,13 +164,39 @@ pub fn diff(
     installed_formulas: []const []const u8,
     installed_casks: []const []const u8,
 ) CleanupError!Plan {
+    return planByMembership(allocator, manifest, installed_formulas, installed_casks, false);
+}
+
+/// Compute the purge plan: every installed name the manifest *does* list,
+/// returned sorted by name. Backs `bundle remove --purge`. Intersecting with
+/// installed state is what keeps a member that was never installed here from
+/// reaching the uninstall dispatcher.
+pub fn selectMembers(
+    allocator: std.mem.Allocator,
+    manifest: manifest_mod.Manifest,
+    installed_formulas: []const []const u8,
+    installed_casks: []const []const u8,
+) CleanupError!Plan {
+    return planByMembership(allocator, manifest, installed_formulas, installed_casks, true);
+}
+
+/// Shared body for `diff` and `selectMembers`. Same set operation — filter
+/// installed state by manifest membership — differing only in which side is
+/// kept, so the ownership and sort rules stay in one place.
+fn planByMembership(
+    allocator: std.mem.Allocator,
+    manifest: manifest_mod.Manifest,
+    installed_formulas: []const []const u8,
+    installed_casks: []const []const u8,
+    keep_members: bool,
+) CleanupError!Plan {
     var formulas: std.ArrayList([]const u8) = .empty;
     errdefer freeOwnedNames(allocator, &formulas);
     var casks: std.ArrayList([]const u8) = .empty;
     errdefer freeOwnedNames(allocator, &casks);
 
     for (installed_formulas) |name| {
-        if (manifestHasFormula(manifest, name)) continue;
+        if (manifestHasFormula(manifest, name) != keep_members) continue;
         const owned = allocator.dupe(u8, name) catch return CleanupError.OutOfMemory;
         formulas.append(allocator, owned) catch {
             allocator.free(owned);
@@ -178,7 +204,7 @@ pub fn diff(
         };
     }
     for (installed_casks) |name| {
-        if (manifestHasCask(manifest, name)) continue;
+        if (manifestHasCask(manifest, name) != keep_members) continue;
         const owned = allocator.dupe(u8, name) catch return CleanupError.OutOfMemory;
         casks.append(allocator, owned) catch {
             allocator.free(owned);
@@ -434,6 +460,115 @@ test "diff entries are sorted alphabetically" {
     defer m.deinit();
 
     var plan = try diff(
+        testing.allocator,
+        m,
+        &[_][]const u8{ "zsh", "abc", "midline" },
+        &[_][]const u8{},
+    );
+    defer plan.deinit();
+
+    try testing.expectEqualStrings("abc", plan.formulas[0]);
+    try testing.expectEqualStrings("midline", plan.formulas[1]);
+    try testing.expectEqualStrings("zsh", plan.formulas[2]);
+}
+
+// `selectMembers` is the inverse of `diff` and backs `bundle remove --purge`:
+// cleanup removes what the manifest does NOT list, purge removes what it does.
+// The intersection with installed state is what keeps purge from trying to
+// uninstall a member that was never installed on this machine.
+
+test "selectMembers returns installed formulas that the manifest lists" {
+    var m = try testManifest(testing.allocator, &.{ "wget", "jq" }, &.{});
+    defer m.deinit();
+
+    var plan = try selectMembers(
+        testing.allocator,
+        m,
+        &[_][]const u8{ "wget", "ripgrep", "jq", "fzf" },
+        &[_][]const u8{},
+    );
+    defer plan.deinit();
+
+    try testing.expectEqual(@as(usize, 2), plan.formulas.len);
+    try testing.expectEqualStrings("jq", plan.formulas[0]);
+    try testing.expectEqualStrings("wget", plan.formulas[1]);
+    try testing.expectEqual(@as(usize, 0), plan.casks.len);
+}
+
+test "selectMembers returns installed casks that the manifest lists" {
+    var m = try testManifest(testing.allocator, &.{}, &.{ "ghostty", "firefox" });
+    defer m.deinit();
+
+    var plan = try selectMembers(
+        testing.allocator,
+        m,
+        &[_][]const u8{},
+        &[_][]const u8{ "ghostty", "chrome" },
+    );
+    defer plan.deinit();
+
+    try testing.expectEqual(@as(usize, 0), plan.formulas.len);
+    try testing.expectEqual(@as(usize, 1), plan.casks.len);
+    try testing.expectEqualStrings("ghostty", plan.casks[0]);
+}
+
+// The load-bearing safety property: a manifest member that is not installed
+// must never reach the uninstall dispatcher.
+test "selectMembers skips manifest members that are not installed" {
+    var m = try testManifest(testing.allocator, &.{ "wget", "never-installed" }, &.{"absent-cask"});
+    defer m.deinit();
+
+    var plan = try selectMembers(
+        testing.allocator,
+        m,
+        &[_][]const u8{"wget"},
+        &[_][]const u8{},
+    );
+    defer plan.deinit();
+
+    try testing.expectEqual(@as(usize, 1), plan.formulas.len);
+    try testing.expectEqualStrings("wget", plan.formulas[0]);
+    try testing.expectEqual(@as(usize, 0), plan.casks.len);
+}
+
+test "selectMembers is empty when the manifest shares nothing with installed state" {
+    var m = try testManifest(testing.allocator, &.{"wget"}, &.{});
+    defer m.deinit();
+
+    var plan = try selectMembers(
+        testing.allocator,
+        m,
+        &[_][]const u8{ "ripgrep", "fzf" },
+        &[_][]const u8{},
+    );
+    defer plan.deinit();
+
+    try testing.expect(plan.isEmpty());
+}
+
+// diff and selectMembers must partition installed state, or purge and cleanup
+// would disagree about who owns a package.
+test "selectMembers and diff partition the installed set" {
+    var m = try testManifest(testing.allocator, &.{ "wget", "jq" }, &.{});
+    defer m.deinit();
+    const installed = [_][]const u8{ "wget", "ripgrep", "jq", "fzf" };
+
+    var kept = try selectMembers(testing.allocator, m, &installed, &.{});
+    defer kept.deinit();
+    var dropped = try diff(testing.allocator, m, &installed, &.{});
+    defer dropped.deinit();
+
+    try testing.expectEqual(installed.len, kept.formulas.len + dropped.formulas.len);
+    for (kept.formulas) |k| {
+        for (dropped.formulas) |d| try testing.expect(!std.mem.eql(u8, k, d));
+    }
+}
+
+test "selectMembers entries are sorted alphabetically" {
+    var m = try testManifest(testing.allocator, &.{ "zsh", "abc", "midline" }, &.{});
+    defer m.deinit();
+
+    var plan = try selectMembers(
         testing.allocator,
         m,
         &[_][]const u8{ "zsh", "abc", "midline" },


### PR DESCRIPTION
## Description

`bundle remove` only unregistered a bundle, leaving every package it installed on disk. There was no single command to undo a `bundle install`, so users had to re-read the Brewfile and uninstall by hand.

`bundle remove --purge` now also uninstalls each member that is currently installed. Behaviour that mattered in the design:

- The default stays non-destructive. A bare `bundle remove` still only unregisters, because callers already rely on that.
- The `bundles` row records a manifest *path*, not a member list, so the manifest is re-read. An unreadable manifest aborts rather than unregistering silently - we cannot know which packages were meant to go, and the registration is left intact so the user can restore the file and retry.
- The registration is deleted last, so a failed purge stays retryable instead of orphaning members.
- Typed confirmation unless `--yes`; `--dry-run` previews and inherits the global flag.

Implemented by reusing the existing cleanup pipeline: `selectMembers` is the inverse of `diff` (members that *are* installed, rather than those absent from the manifest), and both share one filter body so ownership and sort rules stay in a single place.


## Related Issue

- None

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #735
- <kbd>&nbsp;4&nbsp;</kbd> #733
- <kbd>&nbsp;3&nbsp;</kbd> #732
- <kbd>&nbsp;2&nbsp;</kbd> #731
- <kbd>&nbsp;1&nbsp;</kbd> #730 👈 
<!-- GitButler Footer Boundary Bottom -->