### PR TITLE
fix(completions): stop advertising flags the CLI does not accept

### DIFF
--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -155,7 +155,7 @@ pub const bash_script =
     \\        backup)           cmd_flags="--output -o --versions --services --quiet -q" ;;
     \\        restore)          cmd_flags="--dry-run --force --quiet -q" ;;
     \\        purge)            cmd_flags="--store-orphans --unused-deps --cache --cache= --downloads --stale-casks --old-versions --housekeeping --wipe --backup -b --keep-cache --remove-binary --yes -y --dry-run -n" ;;
-    \\        uninstall|remove) cmd_flags="--force --zap --dry-run" ;;
+    \\        uninstall|remove) cmd_flags="--cask --force --zap --dry-run" ;;
     \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --pinned --force -f --isolate-deps --isolate-dependencies --use-system-ruby=" ;;
     \\        outdated)         cmd_flags="--json --formula --cask --pinned-only --tap --refresh --quiet -q" ;;
     \\        update)           cmd_flags="--check --quiet -q" ;;
@@ -166,13 +166,13 @@ pub const bash_script =
     \\        uses)             cmd_flags="--recursive -r --json --quiet -q" ;;
     \\        deps)             cmd_flags="--recursive -r --installed --json --quiet -q" ;;
     \\        which)            cmd_flags="--json" ;;
-    \\        migrate)          cmd_flags="--dry-run --use-system-ruby=" ;;
+    \\        migrate)          cmd_flags="--dry-run --parallel --use-system-ruby=" ;;
     \\        rollback)         cmd_flags="--dry-run --list --to --json" ;;
     \\        link)             cmd_flags="--overwrite --force -f --isolate --all" ;;
     \\        services)         cmd_flags="--tail --stderr --follow -f --system --json" ;;
-    \\        bundle)           cmd_flags="--dry-run -n --format --from-installed --purge --yes -y --isolate-deps --isolate-dependencies" ;;
+    \\        bundle)           cmd_flags="--dry-run -n --format --services --purge --yes -y --isolate-deps --isolate-dependencies" ;;
     \\        run)              cmd_flags="--keep" ;;
-    \\        doctor)           cmd_flags="--fix --dry-run" ;;
+    \\        doctor)           cmd_flags="--fix --dry-run --post-install-status" ;;
     \\        tap)              cmd_flags="--refresh --all --pin --repo --host --forge --url --force --yes -y --json" ;;
     \\    esac
     \\
@@ -294,6 +294,7 @@ pub const zsh_script =
     \\                    ;;
     \\                uninstall|remove)
     \\                    _arguments \
+    \\                        '--cask[Treat the name as a cask]' \
     \\                        '--force[Remove even if depended on]' \
     \\                        '--zap[Deep clean (cask only)]' \
     \\                        '--dry-run[Show what would be removed]' \
@@ -318,6 +319,21 @@ pub const zsh_script =
     \\                run)
     \\                    _arguments \
     \\                        '--keep[Cache extracted bottle under {cache}/run/<sha256>/]' \
+    \\                        '*::package:'
+    \\                    ;;
+    \\                uses)
+    \\                    _arguments \
+    \\                        '(--recursive -r)'{--recursive,-r}'[Include transitive dependents]' \
+    \\                        '--json[Output as JSON]' \
+    \\                        '(--quiet -q)'{--quiet,-q}'[Suppress status messages]' \
+    \\                        '*::package:'
+    \\                    ;;
+    \\                deps)
+    \\                    _arguments \
+    \\                        '(--recursive -r)'{--recursive,-r}'[Walk transitive deps]' \
+    \\                        '--installed[Restrict to locally-resolved kegs]' \
+    \\                        '--json[Output as JSON]' \
+    \\                        '(--quiet -q)'{--quiet,-q}'[Suppress status messages]' \
     \\                        '*::package:'
     \\                    ;;
     \\                which)
@@ -371,8 +387,9 @@ pub const zsh_script =
     \\                        '*::query:'
     \\                    ;;
     \\                migrate)
-    \\                    _arguments \\
-    \\                        '--dry-run[Preview without executing]' \\
+    \\                    _arguments \
+    \\                        '--dry-run[Preview without executing]' \
+    \\                        '--parallel[Migrate kegs concurrently with a bounded worker pool]' \
     \\                        '--use-system-ruby=[Run post_install via system Ruby for the named kegs]:names:'
     \\                    ;;
     \\                rollback)
@@ -440,23 +457,24 @@ pub const zsh_script =
     \\                        '1:subcommand:(update)'
     \\                    ;;
     \\                services)
-    \\                    _values 'subcommand' \
-    \\                        'list[Show registered services and runtime state]' \
-    \\                        'start[Bootstrap a service under launchd]' \
-    \\                        'stop[Boot a service out of launchd]' \
-    \\                        'restart[stop then start]' \
-    \\                        'status[Show registered + runtime state]' \
-    \\                        'logs[Tail a service log file]'
+    \\                    _arguments \
+    \\                        '--tail[Number of trailing log lines]:lines:' \
+    \\                        '--stderr[Read stderr instead of stdout]' \
+    \\                        '(--follow -f)'{--follow,-f}'[Tail appended bytes until SIGINT]' \
+    \\                        '--system[Operate on system-level services]' \
+    \\                        '--json[Output as JSON]' \
+    \\                        '1:subcommand:(list start stop restart status logs)'
     \\                    ;;
     \\                bundle)
-    \\                    _values 'subcommand' \
-    \\                        'install[Install members of a Brewfile/Maltfile.json]' \
-    \\                        'cleanup[Uninstall packages absent from the Brewfile]' \
-    \\                        'create[Write currently-installed set to a bundle file]' \
-    \\                        'list[List bundles registered in the database]' \
-    \\                        'remove[Unregister a bundle]' \
-    \\                        'export[Print bundle to stdout]' \
-    \\                        'import[Register a bundle definition without installing]'
+    \\                    _arguments \
+    \\                        '(--dry-run -n)'{--dry-run,-n}'[Preview without installing/uninstalling]' \
+    \\                        '--format[Output format]:format:(brewfile json)' \
+    \\                        '--services[Include auto-start services (JSON only)]' \
+    \\                        '--purge[With remove: also uninstall the members]' \
+    \\                        '(--yes -y)'{--yes,-y}'[Skip the confirmation prompt]' \
+    \\                        '--isolate-deps[Apply isolation to transitive deps of every member]' \
+    \\                        '--isolate-dependencies[Alias of --isolate-deps]' \
+    \\                        '1:subcommand:(install cleanup create list remove export import)'
     \\                    ;;
     \\                tap)
     \\                    _arguments \
@@ -475,7 +493,8 @@ pub const zsh_script =
     \\                doctor)
     \\                    _arguments \
     \\                        '--fix[Apply safe-class fixers; with <id>, only that class]::fix-id:(stale_lock orphaned_store broken_symlinks)' \
-    \\                        '--dry-run[Preview the fix plan without applying]'
+    \\                        '--dry-run[Preview the fix plan without applying]' \
+    \\                        '--post-install-status[Report post_install state per keg]'
     \\                    ;;
     \\            esac
     \\            ;;
@@ -602,9 +621,11 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command reinstall' -l json    -d 'JSON output'
     \\
     \\    # uninstall / remove
+    \\    complete -c $__malt_bin -n '__malt_using_command uninstall' -l cask    -d 'Treat the name as a cask'
     \\    complete -c $__malt_bin -n '__malt_using_command uninstall' -l force   -d 'Remove even if depended on'
     \\    complete -c $__malt_bin -n '__malt_using_command uninstall' -l zap     -d 'Deep clean (cask only)'
     \\    complete -c $__malt_bin -n '__malt_using_command uninstall' -l dry-run -d 'Preview'
+    \\    complete -c $__malt_bin -n '__malt_using_command remove'    -l cask    -d 'Treat the name as a cask'
     \\    complete -c $__malt_bin -n '__malt_using_command remove'    -l force   -d 'Remove even if depended on'
     \\    complete -c $__malt_bin -n '__malt_using_command remove'    -l zap     -d 'Deep clean (cask only)'
     \\    complete -c $__malt_bin -n '__malt_using_command remove'    -l dry-run -d 'Preview'
@@ -644,7 +665,10 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l formula  -d 'Formulas only'
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l cask     -d 'Casks only'
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l pinned   -d 'Pinned only'
+    \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l tap      -x -d 'Only packages from <label>'
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l json     -d 'JSON output'
+    \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l size     -d 'With --json: add on-disk size_bytes'
+    \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l linked   -d 'With --json: add link status'
     \\
     \\    # info
     \\    complete -c $__malt_bin -n '__malt_using_command info' -l formula -d 'Formula only'
@@ -677,9 +701,11 @@ pub const fish_script =
     \\    # doctor — --fix takes an optional safe-fix class id
     \\    complete -c $__malt_bin -n '__malt_using_command doctor' -l fix -r -a 'stale_lock orphaned_store broken_symlinks' -d 'Apply safe-class fixers; with <id>, only that class'
     \\    complete -c $__malt_bin -n '__malt_using_command doctor' -l dry-run -d 'Preview the fix plan without applying'
+    \\    complete -c $__malt_bin -n '__malt_using_command doctor' -l post-install-status -d 'Report post_install state per keg'
     \\
     \\    # migrate / rollback
     \\    complete -c $__malt_bin -n '__malt_using_command migrate'    -l dry-run -d 'Preview'
+    \\    complete -c $__malt_bin -n '__malt_using_command migrate'    -l parallel -d 'Migrate kegs concurrently with a bounded worker pool'
     \\    complete -c $__malt_bin -n '__malt_using_command migrate'    -l use-system-ruby -d 'Run post_install via system Ruby for the named kegs'
     \\    complete -c $__malt_bin -n '__malt_using_command rollback'   -l dry-run -d 'Preview'
     \\    complete -c $__malt_bin -n '__malt_using_command rollback'   -l list    -d 'List every reachable store entry'
@@ -771,8 +797,8 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l dry-run -s n  -d 'Preview without installing/uninstalling'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l yes     -s y  -d 'Skip the cleanup confirmation prompt'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l format -r -a 'brewfile json' -d 'Output format'
-    \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l from-installed -d 'Populate from installed packages'
-    \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l purge          -d 'Also uninstall members on remove'
+    \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l services       -d 'Include auto-start services (JSON only)'
+    \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l purge          -d 'With remove: also uninstall the members'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l isolate-deps         -d 'Apply isolation to transitive deps of every member'
     \\    complete -c $__malt_bin -n '__malt_using_command bundle' -l isolate-dependencies -d 'Alias of --isolate-deps'
     \\end

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -259,3 +259,106 @@ test "all install, migrate, and upgrade completions expose --use-system-ruby" {
         try std.testing.expect(count >= 3);
     }
 }
+
+/// Slice a script between `start` and the next `end`. Flag assertions have to
+/// be scoped to one command's block: a bare `indexOf("--services")` over the
+/// whole script is satisfied by `backup --services` and proves nothing about
+/// `bundle`.
+fn sectionAfter(script: []const u8, start: []const u8, end: []const u8) ![]const u8 {
+    const s = std.mem.indexOf(u8, script, start) orelse return error.MissingSectionStart;
+    const rest = script[s + start.len ..];
+    const e = std.mem.indexOf(u8, rest, end) orelse return error.MissingSectionEnd;
+    return rest[0..e];
+}
+
+/// The bash per-command flag table, excluding the earlier positional-completion
+/// `case`, which also has `bundle)` and `services)` labels.
+fn bashFlagsFor(command: []const u8) ![]const u8 {
+    const table = try sectionAfter(completions.bash_script, "local cmd_flags=\"\"", "esac");
+    return sectionAfter(table, command, "\n");
+}
+
+fn zshCaseFor(command: []const u8) ![]const u8 {
+    return sectionAfter(completions.zsh_script, command, ";;");
+}
+
+test "bundle completions advertise only flags bundle.zig parses" {
+    // --from-installed was advertised for a mode that does not exist: `bundle
+    // create` always populates from installed, so the flag could never change
+    // anything. Its absence is the assertion.
+    try testing.expect(std.mem.indexOf(u8, completions.bash_script, "from-installed") == null);
+    try testing.expect(std.mem.indexOf(u8, completions.zsh_script, "from-installed") == null);
+    try testing.expect(std.mem.indexOf(u8, completions.fish_script, "from-installed") == null);
+}
+
+test "all bundle completions expose --services" {
+    try expectContains(try bashFlagsFor("bundle)"), "--services");
+    try expectContains(try zshCaseFor("                bundle)"), "'--services[");
+    try expectContains(completions.fish_script, "__malt_using_command bundle' -l services");
+}
+
+test "all bundle completions expose --purge" {
+    try expectContains(try bashFlagsFor("bundle)"), "--purge");
+    try expectContains(try zshCaseFor("                bundle)"), "'--purge[");
+    try expectContains(completions.fish_script, "__malt_using_command bundle' -l purge");
+}
+
+test "all migrate completions expose --parallel" {
+    try expectContains(try bashFlagsFor("migrate)"), "--parallel");
+    try expectContains(try zshCaseFor("                migrate)"), "'--parallel[");
+    try expectContains(completions.fish_script, "__malt_using_command migrate'    -l parallel");
+}
+
+test "zsh completes uses and deps flags" {
+    // zsh had no case for either command, so it fell through to no completion
+    // at all while bash and fish offered flags.
+    const uses = try zshCaseFor("                uses)");
+    try expectContains(uses, "--recursive");
+    try expectContains(uses, "--json");
+
+    const deps = try zshCaseFor("                deps)");
+    try expectContains(deps, "--recursive");
+    try expectContains(deps, "--installed");
+    try expectContains(deps, "--json");
+}
+
+test "zsh services completions offer flags alongside the subcommands" {
+    const services = try zshCaseFor("                services)");
+    try expectContains(services, "--tail");
+    try expectContains(services, "--stderr");
+    try expectContains(services, "--follow");
+    // The subcommands must survive the switch from _values to _arguments.
+    try expectContains(services, "list start stop restart status logs");
+}
+
+test "zsh bundle completions offer flags alongside the subcommands" {
+    const bundle = try zshCaseFor("                bundle)");
+    try expectContains(bundle, "--dry-run");
+    try expectContains(bundle, "--format");
+    try expectContains(bundle, "install cleanup create list remove export import");
+}
+
+test "fish ls alias completes the same flags as list" {
+    // `ls` is an alias of `list` (main.zig command table), so a user who types
+    // the short form must not silently lose --tap/--size/--linked.
+    for ([_][]const u8{ "versions", "formula", "cask", "pinned", "tap", "json", "size", "linked" }) |flag| {
+        var buf: [64]u8 = undefined;
+        const needle = try std.fmt.bufPrint(&buf, "__malt_using_command ls'   -l {s}", .{flag});
+        try expectContains(completions.fish_script, needle);
+    }
+}
+
+test "zsh line continuations are single backslashes" {
+    // Zig multiline literals do no escape processing, so a doubled backslash
+    // reaches zsh as an escaped backslash rather than a continuation: the
+    // command ends early and the remaining flag specs run as commands. This
+    // parses cleanly under `zsh -n`, so only a shape check catches it.
+    var it = std.mem.splitScalar(u8, completions.zsh_script, '\n');
+    while (it.next()) |line| {
+        const trimmed = std.mem.trimEnd(u8, line, " \t");
+        if (std.mem.endsWith(u8, trimmed, "\\\\")) {
+            std.debug.print("doubled backslash continuation: '{s}'\n", .{trimmed});
+            return error.DoubledBackslash;
+        }
+    }
+}


### PR DESCRIPTION
## Description

Shell completions had drifted from the CLI, so users were offered flags that do nothing and denied flags that work.

Removed - advertised but accepted by no parser:

- `bundle --from-installed`. `bundle create` always populates from installed packages, so the flag could never have changed anything. Deleted rather than implemented.

Added - real flags that reached no shell:

- `bundle --services`, `migrate --parallel`, `uninstall --cask`, `doctor --post-install-status`

Filled in per-shell gaps:

- zsh had no `uses` or `deps` case at all, and offered zero flags for `bundle` and `services` where bash and fish offered them.
- The fish `ls` alias completed three fewer flags than `list`, so using the short form silently lost `--tap`, `--size` and `--linked`.

Also fixes a zsh block that never worked: the `migrate` case ended its lines with doubled backslashes. Zig multiline literals do no escape processing, so zsh received an escaped backslash instead of a line continuation - `_arguments` got a single backslash and the flag specs ran as commands. Measured before and after with a stubbed `_arguments`: `ARGC=1 ARGS=[\]` plus two command-not-found errors, now `ARGC=3`.

## Related Issue

- None

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #735
- <kbd>&nbsp;4&nbsp;</kbd> #733
- <kbd>&nbsp;3&nbsp;</kbd> #732
- <kbd>&nbsp;2&nbsp;</kbd> #731 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #730
<!-- GitButler Footer Boundary Bottom -->