### PR TITLE
fix(help): give bundle and services real help topics

### DIFF
--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -6,6 +6,7 @@ const AppCtx = @import("../app_ctx.zig").AppCtx;
 const brewfile_mod = @import("../core/bundle/brewfile.zig");
 const brewfile_emit = @import("../core/bundle/brewfile_emit.zig");
 const cleanup_mod = @import("../core/bundle/cleanup.zig");
+const help_mod = @import("help.zig");
 const manifest_mod = @import("../core/bundle/manifest.zig");
 const runner_mod = @import("../core/bundle/runner.zig");
 const schema = @import("../db/schema.zig");
@@ -130,13 +131,11 @@ pub fn describeError(err: BundleError) []const u8 {
 }
 
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
-    if (args.len == 0 or
-        std.mem.eql(u8, args[0], "-h") or
-        std.mem.eql(u8, args[0], "--help"))
-    {
-        try printHelp(ctx);
+    if (args.len == 0) {
+        printHelp(ctx);
         return;
     }
+    if (help_mod.showIfRequested(ctx, args[0..1], "bundle")) return;
 
     const sub = args[0];
     const rest = args[1..];
@@ -804,35 +803,11 @@ fn openDb(ctx: *const AppCtx) !sqlite.Database {
     return db;
 }
 
-fn printHelp(ctx: *const AppCtx) !void {
-    const msg =
-        \\Usage: malt bundle <subcommand> [args]
-        \\
-        \\Subcommands:
-        \\  install [--isolate-deps] [file]
-        \\                              Install formulae/casks/taps/services from a Brewfile or Maltfile.json.
-        \\                              --isolate-deps keeps transitive runtime deps out of <prefix>/bin
-        \\                              and <prefix>/sbin (per-keg state, replays on upgrade).
-        \\  cleanup [--yes] [--dry-run] [file]
-        \\                              Uninstall packages present on disk but absent from the Brewfile.
-        \\  create  [--format brewfile|json] [--services] [path]
-        \\                              Write currently-installed set to a bundle file.
-        \\                              --services also emits auto-start services (JSON only).
-        \\  list                        List bundles registered in the database.
-        \\  remove  [--purge] [--yes] [--dry-run] <name>
-        \\                              Unregister a bundle. Without --purge the members stay
-        \\                              installed; --purge also uninstalls every member that is
-        \\                              currently installed (typed confirm unless --yes).
-        \\  export  [--format brewfile|json] [--services] [name]
-        \\                              Print bundle (or current install) to stdout.
-        \\                              --services also emits auto-start services (JSON only).
-        \\  import  <file>              Register a bundle definition without installing.
-        \\
-        \\Lookup order for install/export without an explicit path:
-        \\  ./Brewfile, ./Maltfile.json, ~/.config/malt/Brewfile, ~/.config/malt/Maltfile.json
-        \\
-    ;
-    ctx.stderr.writeStreamingAll(ctx.io, msg) catch {};
+/// Bare `malt bundle` is a usage error, so the text goes to stderr. An explicit
+/// `--help` is a successful request and goes to stdout via `showIfRequested`,
+/// matching every other command. Both read the same text from `help.zig`.
+fn printHelp(ctx: *const AppCtx) void {
+    ctx.stderr.writeStreamingAll(ctx.io, help_mod.helpFor("bundle")) catch {};
 }
 
 test "remove: bare name defaults to unregister-only" {

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -48,6 +48,8 @@ pub fn helpFor(command: []const u8) []const u8 {
         .{ "which", which_help },
         .{ "pin", pin_help },
         .{ "unpin", unpin_help },
+        .{ "bundle", bundle_help },
+        .{ "services", services_help },
         .{ "tui", tui_help },
         .{ "version", version_help },
     });
@@ -657,6 +659,49 @@ const deps_help =
     \\  malt deps --recursive ffmpeg
     \\  malt deps --installed -r node@20
     \\  malt --json deps wget
+    \\
+;
+
+const bundle_help =
+    \\Usage: malt bundle <subcommand> [args]
+    \\
+    \\Subcommands:
+    \\  install [--isolate-deps] [file]
+    \\                              Install formulae/casks/taps/services from a Brewfile or Maltfile.json.
+    \\                              --isolate-deps keeps transitive runtime deps out of <prefix>/bin
+    \\                              and <prefix>/sbin (per-keg state, replays on upgrade).
+    \\  cleanup [--yes] [--dry-run] [file]
+    \\                              Uninstall packages present on disk but absent from the Brewfile.
+    \\  create  [--format brewfile|json] [--services] [path]
+    \\                              Write currently-installed set to a bundle file.
+    \\                              --services also emits auto-start services (JSON only).
+    \\  list                        List bundles registered in the database.
+    \\  remove  [--purge] [--yes] [--dry-run] <name>
+    \\                              Unregister a bundle. Without --purge the members stay
+    \\                              installed; --purge also uninstalls every member that is
+    \\                              currently installed (typed confirm unless --yes).
+    \\  export  [--format brewfile|json] [--services] [name]
+    \\                              Print bundle (or current install) to stdout.
+    \\                              --services also emits auto-start services (JSON only).
+    \\  import  <file>              Register a bundle definition without installing.
+    \\
+    \\Lookup order for install/export without an explicit path:
+    \\  ./Brewfile, ./Maltfile.json, ~/.config/malt/Brewfile, ~/.config/malt/Maltfile.json
+    \\
+;
+
+const services_help =
+    \\Usage: malt services <subcommand> [args]
+    \\
+    \\Subcommands:
+    \\  list              Show registered services.
+    \\  start <name>      Bootstrap the service under launchd.
+    \\  stop <name>       Boot the service out of launchd.
+    \\  restart <name>    stop then start.
+    \\  status [name]     Show registered state (falls back to list).
+    \\  logs <name> [--tail N] [--stderr] [--follow|-f]
+    \\                    Print the last N lines of the service log.
+    \\                    --follow / -f tails appended bytes until SIGINT.
     \\
 ;
 

--- a/src/cli/services.zig
+++ b/src/cli/services.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const AppCtx = @import("../app_ctx.zig").AppCtx;
 const sqlite = @import("../db/sqlite.zig");
 const schema = @import("../db/schema.zig");
+const help_mod = @import("help.zig");
 const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
 const signals = @import("../core/signals.zig");
@@ -66,13 +67,11 @@ pub fn servicesStart(ctx: *const AppCtx, allocator: std.mem.Allocator, name: []c
 }
 
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
-    if (args.len == 0 or
-        std.mem.eql(u8, args[0], "-h") or
-        std.mem.eql(u8, args[0], "--help"))
-    {
-        try printHelp(ctx);
+    if (args.len == 0) {
+        printHelp(ctx);
         return;
     }
+    if (help_mod.showIfRequested(ctx, args[0..1], "services")) return;
 
     const sub = args[0];
     const rest = args[1..];
@@ -274,20 +273,9 @@ test "writeServicesJson: emits the schedule label as a trailing field per row" {
     );
 }
 
-fn printHelp(ctx: *const AppCtx) !void {
-    const msg =
-        \\Usage: malt services <subcommand> [args]
-        \\
-        \\Subcommands:
-        \\  list              Show registered services.
-        \\  start <name>      Bootstrap the service under launchd.
-        \\  stop <name>       Boot the service out of launchd.
-        \\  restart <name>    stop then start.
-        \\  status [name]     Show registered state (falls back to list).
-        \\  logs <name> [--tail N] [--stderr] [--follow|-f]
-        \\                    Print the last N lines of the service log.
-        \\                    --follow / -f tails appended bytes until SIGINT.
-        \\
-    ;
-    ctx.stderr.writeStreamingAll(ctx.io, msg) catch {};
+/// Bare `malt services` is a usage error, so the text goes to stderr. An
+/// explicit `--help` is a successful request and goes to stdout via
+/// `showIfRequested`. Both read the same text from `help.zig`.
+fn printHelp(ctx: *const AppCtx) void {
+    ctx.stderr.writeStreamingAll(ctx.io, help_mod.helpFor("services")) catch {};
 }

--- a/tests/help_test.zig
+++ b/tests/help_test.zig
@@ -39,12 +39,13 @@ test "showIfRequested returns true for long --help" {
 test "showIfRequested covers every documented command (exercises every branch of the static map)" {
     const ctx = quietCtx();
     const commands = [_][]const u8{
-        "install",  "uninstall",   "upgrade", "update",
-        "outdated", "list",        "info",    "search",
-        "doctor",   "tap",         "migrate", "rollback",
-        "run",      "link",        "unlink",  "pin",
-        "unpin",    "completions", "backup",  "restore",
-        "purge",    "tui",         "version", "not-a-real-command",
+        "install",  "uninstall",          "upgrade", "update",
+        "outdated", "list",               "info",    "search",
+        "doctor",   "tap",                "migrate", "rollback",
+        "run",      "link",               "unlink",  "pin",
+        "unpin",    "completions",        "backup",  "restore",
+        "purge",    "tui",                "version", "bundle",
+        "services", "not-a-real-command",
     };
     const args = [_][]const u8{"--help"};
     for (commands) |cmd| {
@@ -223,4 +224,14 @@ test "help command falls back gracefully for unknown topics" {
 
     try testing.expectEqual(std.process.Child.Term{ .exited = 0 }, result.term);
     try testing.expect(std.mem.indexOf(u8, result.stdout, "No help available.") != null);
+}
+
+test "bundle and services have help topics" {
+    // Both commands used to own a local printHelp, so `malt help bundle` fell
+    // through to the generic "No help available" fallback while `--help`
+    // worked. One text, reachable both ways.
+    try testing.expect(std.mem.indexOf(u8, help.helpFor("bundle"), "malt bundle") != null);
+    try testing.expect(std.mem.indexOf(u8, help.helpFor("bundle"), "--purge") != null);
+    try testing.expect(std.mem.indexOf(u8, help.helpFor("services"), "malt services") != null);
+    try testing.expect(std.mem.indexOf(u8, help.helpFor("services"), "restart") != null);
 }


### PR DESCRIPTION
## Description

`bundle` and `services` each owned a private `printHelp`, so neither appeared in the help topic map. Two consequences:

- `malt help bundle` and `malt help services` answered "No help available" even though `malt bundle --help` printed a full page.
- Those private copies wrote to **stderr**, while every other command's `--help` goes to stdout. The repo already pins that contract in a test (`--help output lands on stdout, not stderr`); these two quietly sat outside it.

Both texts move into `help.zig` as the single source, and the commands route through `showIfRequested` like everything else. A bare `malt bundle` is still a usage error and keeps its stderr path, now reading the same text - so there is one copy, reachable both ways, rather than a second copy free to drift.

## Related Issue

- None

## Notes for Reviewers
- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #735
- <kbd>&nbsp;4&nbsp;</kbd> #733 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #732
- <kbd>&nbsp;2&nbsp;</kbd> #731
- <kbd>&nbsp;1&nbsp;</kbd> #730
<!-- GitButler Footer Boundary Bottom -->