### PR TITLE
fix(cli): drop no-op flags and complete the Homebrew plural aliases

### DIFF
--- a/man/malt.1
+++ b/man/malt.1
@@ -147,7 +147,6 @@ Remove installed packages.
 
 Flags:
   --force        Remove even if other packages depend on it
-  --zap          Deep clean (cask only)
   --dry-run      Show what would be removed
 .fi
 .SS upgrade
@@ -161,7 +160,6 @@ installed one it is applied, even if that moves the version down
 (e.g. an upstream revert) — preview with --dry-run.
 
 Flags:
-  --all          Upgrade everything (formulas + casks)
   --cask         Upgrade casks only
   --formula      Upgrade formulas only
   --dry-run      Show what would be upgraded

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -155,21 +155,21 @@ pub const bash_script =
     \\        backup)           cmd_flags="--output -o --versions --services --quiet -q" ;;
     \\        restore)          cmd_flags="--dry-run --force --quiet -q" ;;
     \\        purge)            cmd_flags="--store-orphans --unused-deps --cache --cache= --downloads --stale-casks --old-versions --housekeeping --wipe --backup -b --keep-cache --remove-binary --yes -y --dry-run -n" ;;
-    \\        uninstall|remove) cmd_flags="--cask --force --zap --dry-run" ;;
-    \\        upgrade)          cmd_flags="--all --cask --formula --dry-run --pinned --force -f --isolate-deps --isolate-dependencies --use-system-ruby=" ;;
-    \\        outdated)         cmd_flags="--json --formula --cask --pinned-only --tap --refresh --quiet -q" ;;
+    \\        uninstall|remove) cmd_flags="--cask --force --dry-run" ;;
+    \\        upgrade)          cmd_flags="--cask --formula --dry-run --pinned --force -f --isolate-deps --isolate-dependencies --use-system-ruby=" ;;
+    \\        outdated)         cmd_flags="--json --formula --formulae --cask --casks --pinned-only --tap --refresh --quiet -q" ;;
     \\        update)           cmd_flags="--check --quiet -q" ;;
     \\        version)          cmd_flags="--check --yes -y --no-verify --cleanup" ;;
-    \\        list|ls)          cmd_flags="--versions --formula --cask --pinned --tap --json --size --linked --quiet -q" ;;
+    \\        list|ls)          cmd_flags="--versions --formula --formulae --cask --casks --pinned --tap --json --size --linked --quiet -q" ;;
     \\        info)             cmd_flags="--formula --cask --json" ;;
-    \\        search)           cmd_flags="--formula --cask --json --installed --api --all --offline" ;;
+    \\        search)           cmd_flags="--formula --formulae --cask --casks --json --installed --api --all --offline" ;;
     \\        uses)             cmd_flags="--recursive -r --json --quiet -q" ;;
     \\        deps)             cmd_flags="--recursive -r --installed --json --quiet -q" ;;
     \\        which)            cmd_flags="--json" ;;
     \\        migrate)          cmd_flags="--dry-run --parallel --use-system-ruby=" ;;
     \\        rollback)         cmd_flags="--dry-run --list --to --json" ;;
     \\        link)             cmd_flags="--overwrite --force -f --isolate --all" ;;
-    \\        services)         cmd_flags="--tail --stderr --follow -f --system --json" ;;
+    \\        services)         cmd_flags="--tail --stderr --follow -f --json" ;;
     \\        bundle)           cmd_flags="--dry-run -n --format --services --purge --yes -y --isolate-deps --isolate-dependencies" ;;
     \\        run)              cmd_flags="--keep" ;;
     \\        doctor)           cmd_flags="--fix --dry-run --post-install-status" ;;
@@ -296,13 +296,11 @@ pub const zsh_script =
     \\                    _arguments \
     \\                        '--cask[Treat the name as a cask]' \
     \\                        '--force[Remove even if depended on]' \
-    \\                        '--zap[Deep clean (cask only)]' \
     \\                        '--dry-run[Show what would be removed]' \
     \\                        '*::package:'
     \\                    ;;
     \\                upgrade)
     \\                    _arguments \
-    \\                        '--all[Upgrade everything]' \
     \\                        '--cask[Upgrade casks only]' \
     \\                        '--formula[Upgrade formulas only]' \
     \\                        '--dry-run[Show what would be upgraded]' \
@@ -345,7 +343,9 @@ pub const zsh_script =
     \\                    _arguments \
     \\                        '--json[Output as JSON]' \
     \\                        '--formula[Show outdated formulas only]' \
+    \\                        '--formulae[Alias of --formula]' \
     \\                        '--cask[Show outdated casks only]' \
+    \\                        '--casks[Alias of --cask]' \
     \\                        '--pinned-only[Audit pinned formulas + casks only]' \
     \\                        '--tap[Only packages from <label> (e.g. user/repo)]:tap label:' \
     \\                        '--refresh[Force live recompute, bypass the cached snapshot]' \
@@ -360,7 +360,9 @@ pub const zsh_script =
     \\                    _arguments \
     \\                        '--versions[Show version numbers]' \
     \\                        '--formula[Formulas only]' \
+    \\                        '--formulae[Alias of --formula]' \
     \\                        '--cask[Casks only]' \
+    \\                        '--casks[Alias of --cask]' \
     \\                        '--pinned[Pinned packages only]' \
     \\                        '--tap[Only packages from <label> (e.g. user/repo)]:tap label:' \
     \\                        '--json[Output as JSON]' \
@@ -378,7 +380,9 @@ pub const zsh_script =
     \\                search)
     \\                    _arguments \
     \\                        '--formula[Search formulas only]' \
+    \\                        '--formulae[Alias of --formula]' \
     \\                        '--cask[Search casks only]' \
+    \\                        '--casks[Alias of --cask]' \
     \\                        '--installed[Local DB only, no network]' \
     \\                        '--api[Force Homebrew API path]' \
     \\                        '--all[Run local + API and merge results]' \
@@ -461,7 +465,6 @@ pub const zsh_script =
     \\                        '--tail[Number of trailing log lines]:lines:' \
     \\                        '--stderr[Read stderr instead of stdout]' \
     \\                        '(--follow -f)'{--follow,-f}'[Tail appended bytes until SIGINT]' \
-    \\                        '--system[Operate on system-level services]' \
     \\                        '--json[Output as JSON]' \
     \\                        '1:subcommand:(list start stop restart status logs)'
     \\                    ;;
@@ -623,15 +626,12 @@ pub const fish_script =
     \\    # uninstall / remove
     \\    complete -c $__malt_bin -n '__malt_using_command uninstall' -l cask    -d 'Treat the name as a cask'
     \\    complete -c $__malt_bin -n '__malt_using_command uninstall' -l force   -d 'Remove even if depended on'
-    \\    complete -c $__malt_bin -n '__malt_using_command uninstall' -l zap     -d 'Deep clean (cask only)'
     \\    complete -c $__malt_bin -n '__malt_using_command uninstall' -l dry-run -d 'Preview'
     \\    complete -c $__malt_bin -n '__malt_using_command remove'    -l cask    -d 'Treat the name as a cask'
     \\    complete -c $__malt_bin -n '__malt_using_command remove'    -l force   -d 'Remove even if depended on'
-    \\    complete -c $__malt_bin -n '__malt_using_command remove'    -l zap     -d 'Deep clean (cask only)'
     \\    complete -c $__malt_bin -n '__malt_using_command remove'    -l dry-run -d 'Preview'
     \\
     \\    # upgrade
-    \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l all     -d 'Upgrade everything'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l cask    -d 'Casks only'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l formula -d 'Formulas only'
     \\    complete -c $__malt_bin -n '__malt_using_command upgrade' -l dry-run -d 'Preview'
@@ -644,7 +644,9 @@ pub const fish_script =
     \\    # outdated
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l json        -d 'JSON output'
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l formula     -d 'Formulas only'
+    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l formulae    -d 'Alias of --formula'
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l cask        -d 'Casks only'
+    \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l casks       -d 'Alias of --cask'
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l pinned-only -d 'Pinned formulas + casks only'
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l tap         -x -d 'Only packages from <label>'
     \\    complete -c $__malt_bin -n '__malt_using_command outdated' -l refresh     -d 'Force live recompute, bypass the cached snapshot'
@@ -655,7 +657,9 @@ pub const fish_script =
     \\    # list / ls
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l versions -d 'Show version numbers'
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l formula  -d 'Formulas only'
+    \\    complete -c $__malt_bin -n '__malt_using_command list' -l formulae -d 'Alias of --formula'
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l cask     -d 'Casks only'
+    \\    complete -c $__malt_bin -n '__malt_using_command list' -l casks    -d 'Alias of --cask'
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l pinned   -d 'Pinned only'
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l tap      -x -d 'Only packages from <label>'
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l json     -d 'JSON output'
@@ -663,7 +667,9 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command list' -l linked   -d 'With --json: add link status'
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l versions -d 'Show version numbers'
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l formula  -d 'Formulas only'
+    \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l formulae -d 'Alias of --formula'
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l cask     -d 'Casks only'
+    \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l casks    -d 'Alias of --cask'
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l pinned   -d 'Pinned only'
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l tap      -x -d 'Only packages from <label>'
     \\    complete -c $__malt_bin -n '__malt_using_command ls'   -l json     -d 'JSON output'
@@ -677,7 +683,9 @@ pub const fish_script =
     \\
     \\    # search
     \\    complete -c $__malt_bin -n '__malt_using_command search' -l formula   -d 'Formulas only'
+    \\    complete -c $__malt_bin -n '__malt_using_command search' -l formulae  -d 'Alias of --formula'
     \\    complete -c $__malt_bin -n '__malt_using_command search' -l cask      -d 'Casks only'
+    \\    complete -c $__malt_bin -n '__malt_using_command search' -l casks     -d 'Alias of --cask'
     \\    complete -c $__malt_bin -n '__malt_using_command search' -l installed -d 'Local DB only, no network'
     \\    complete -c $__malt_bin -n '__malt_using_command search' -l api       -d 'Force Homebrew API path'
     \\    complete -c $__malt_bin -n '__malt_using_command search' -l all       -d 'Run local + API and merge'

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -137,7 +137,6 @@ const uninstall_help =
     \\
     \\Flags:
     \\  --force        Remove even if other packages depend on it
-    \\  --zap          Deep clean (cask only)
     \\  --dry-run      Show what would be removed
     \\
 ;
@@ -152,7 +151,6 @@ const upgrade_help =
     \\(e.g. an upstream revert) — preview with --dry-run.
     \\
     \\Flags:
-    \\  --all          Upgrade everything (formulas + casks)
     \\  --cask         Upgrade casks only
     \\  --formula      Upgrade formulas only
     \\  --dry-run      Show what would be upgraded

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -779,7 +779,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     var i: usize = 0;
     while (i < args.len) : (i += 1) {
         const arg = args[i];
-        if (std.mem.eql(u8, arg, "--cask")) {
+        if (std.mem.eql(u8, arg, "--cask") or std.mem.eql(u8, arg, "--casks")) {
             cask_only = true;
         } else if (std.mem.eql(u8, arg, "--formula") or std.mem.eql(u8, arg, "--formulae")) {
             formula_only = true;

--- a/tests/completions_test.zig
+++ b/tests/completions_test.zig
@@ -125,7 +125,9 @@ test "all outdated completions expose --tap" {
     // per-command _arguments block names it with a `:tap label:` slot;
     // fish declares it with `-x` so the next token is treated as the
     // label and not eaten by file completion.
-    try expectContains(completions.bash_script, "outdated)         cmd_flags=\"--json --formula --cask --pinned-only --tap");
+    // Scoped to outdated's own flag list rather than pinning the whole string,
+    // which broke whenever an unrelated flag was added to the same line.
+    try expectContains(try bashFlagsFor("outdated)"), "--tap");
     try expectContains(completions.zsh_script, "'--tap[Only packages from <label> (e.g. user/repo)]:tap label:'");
     try expectContains(completions.fish_script, "'__malt_using_command outdated' -l tap");
 }
@@ -360,5 +362,27 @@ test "zsh line continuations are single backslashes" {
             std.debug.print("doubled backslash continuation: '{s}'\n", .{trimmed});
             return error.DoubledBackslash;
         }
+    }
+}
+
+test "no shell advertises the removed phantom flags" {
+    // uninstall --zap, services --system and upgrade --all were offered by the
+    // shells but read by no parser. Their absence is the assertion.
+    inline for (.{ completions.bash_script, completions.zsh_script, completions.fish_script }) |script| {
+        try testing.expect(std.mem.indexOf(u8, script, "zap") == null);
+        try testing.expect(std.mem.indexOf(u8, script, "--system") == null);
+        try testing.expect(std.mem.indexOf(u8, script, "-l system") == null);
+    }
+    // `--all` is scoped: search, tap and link keep their real ones.
+    try expectNotContains(try bashFlagsFor("upgrade)"), "--all");
+    try expectNotContains(try zshCaseFor("                upgrade)"), "'--all[");
+    try testing.expect(std.mem.indexOf(u8, completions.fish_script, "__malt_using_command upgrade' -l all") == null);
+    try expectContains(try bashFlagsFor("search)"), "--all");
+}
+
+fn expectNotContains(haystack: []const u8, needle: []const u8) !void {
+    if (std.mem.indexOf(u8, haystack, needle) != null) {
+        std.debug.print("expected section to NOT contain '{s}'\n", .{needle});
+        return error.UnexpectedSubstring;
     }
 }

--- a/tests/flag_drift_test.zig
+++ b/tests/flag_drift_test.zig
@@ -74,24 +74,9 @@ const Exception = struct {
     reason: []const u8,
 };
 
-const exceptions = [_]Exception{
-    // Plural aliases accepted for Homebrew muscle memory. The shells offer the
-    // singular canonical spelling on purpose - completing both doubles the
-    // candidate list for no gain.
-    .{ .command = "list", .flag = "--formulae", .reason = "plural alias; shells offer --formula" },
-    .{ .command = "list", .flag = "--casks", .reason = "plural alias; shells offer --cask" },
-    .{ .command = "search", .flag = "--formulae", .reason = "plural alias; shells offer --formula" },
-    .{ .command = "search", .flag = "--casks", .reason = "plural alias; shells offer --cask" },
-    .{ .command = "outdated", .flag = "--formulae", .reason = "plural alias; shells offer --formula" },
-
-    // Advertised but unimplemented. These are real defects the guard found:
-    // help and the shells promise a flag no parser reads, so passing it is
-    // silently ignored. Listed here so the guard stays green while the
-    // implement-or-remove call is made; delete the entry either way.
-    .{ .command = "uninstall", .flag = "--zap", .reason = "documented at help.zig but no parser reads it" },
-    .{ .command = "upgrade", .flag = "--all", .reason = "documented at help.zig but no parser reads it" },
-    .{ .command = "services", .flag = "--system", .reason = "described in a supervisor comment; never implemented" },
-};
+/// Empty on purpose. Every difference the guard found has been resolved in the
+/// code rather than excused here; an entry should be rare and short-lived.
+const exceptions = [_]Exception{};
 
 fn isGlobal(flag: []const u8) bool {
     for (global_flags) |g| if (std.mem.eql(u8, g, flag)) return true;

--- a/tests/help_test.zig
+++ b/tests/help_test.zig
@@ -235,3 +235,18 @@ test "bundle and services have help topics" {
     try testing.expect(std.mem.indexOf(u8, help.helpFor("services"), "malt services") != null);
     try testing.expect(std.mem.indexOf(u8, help.helpFor("services"), "restart") != null);
 }
+
+test "uninstall help no longer advertises the unimplemented --zap" {
+    // --zap promised a cask deep clean that no parser ever read, so running it
+    // silently did nothing while implying preferences and caches were removed.
+    // Nothing parses a cask `zap` stanza yet, so the honest state is silence.
+    try testing.expect(std.mem.indexOf(u8, help.helpFor("uninstall"), "--zap") == null);
+}
+
+test "upgrade help no longer advertises the no-op --all" {
+    // A nameless `upgrade` already does formulas + casks, so --all could only
+    // ever mean "the default". It is not a Homebrew flag either - `brew upgrade
+    // --all` errors with "invalid option" - so there was no compatibility to
+    // preserve, just a line implying the default is narrower than it is.
+    try testing.expect(std.mem.indexOf(u8, help.helpFor("upgrade"), "--all") == null);
+}


### PR DESCRIPTION
## Description

The flag drift guard added in #732 reported five differences between the parsers and the completions, parked there as exceptions. This resolves all five in the code, so **the guard's exception list is now empty** rather than a place to leave them.

They fell into two opposite groups.

### Removed - promised but did nothing

- **`uninstall --zap`** implied a cask deep clean of preferences and caches while doing nothing at all. No cask `zap` stanza is parsed anywhere, so building it is a feature rather than a fix - and until then, silence beats a flag that lets a user believe files were removed.
- **`services --system`** exists only as a comment describing a PID 1 launchd domain that requires root. A privilege-crossing flag that silently no-ops is the worst failure mode available here.
- **`upgrade --all`** could only ever mean "the default": a run that names no packages already upgrades formulas and casks. It is not a Homebrew flag either - `brew upgrade --all` errors with `invalid option: --all` - so there was no compatibility to preserve, just a line implying the default is narrower than it is.

### Completed - real, but undiscoverable

`--formulae` and `--casks` are genuine Homebrew spellings (`brew list --casks`, `brew search --formulae`, `brew outdated --casks` all exist). malt already accepted them on `list` and `search`, and `--formulae` on `outdated`, but offered them in no shell - so they worked while being impossible to discover.

They are now in all three shells, and `outdated` accepts `--casks` to match its own `--formulae`. Removing them instead would have broken `brew` muscle memory, which is the opposite of the point.

## Related Issue

- None

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #735 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #733
- <kbd>&nbsp;3&nbsp;</kbd> #732
- <kbd>&nbsp;2&nbsp;</kbd> #731
- <kbd>&nbsp;1&nbsp;</kbd> #730
<!-- GitButler Footer Boundary Bottom -->