### PR TITLE
fix(deps): make the declared resolve error set the real one

### DIFF
--- a/src/core/deps.zig
+++ b/src/core/deps.zig
@@ -1,4 +1,4 @@
-//! malt — BFS dep resolution with cycle detection and orphan finding.
+//! malt — BFS dep resolution and orphan finding.
 
 const std = @import("std");
 const sqlite = @import("../db/sqlite.zig");
@@ -7,9 +7,7 @@ const atomic = @import("../fs/atomic.zig");
 const formula_mod = @import("formula.zig");
 
 pub const DepError = error{
-    CycleDetected,
     ResolutionFailed,
-    OutOfMemory,
 };
 
 pub const ResolvedDep = struct {
@@ -97,9 +95,12 @@ pub fn resolve(
     api: *api_mod.BrewApi,
     db: *sqlite.Database,
     cache: *FormulaCache,
-) ![]ResolvedDep {
+) DepError![]ResolvedDep {
     var result: std.ArrayList(ResolvedDep) = .empty;
 
+    // Records "seen at all", not "seen on this path": a back-edge and a
+    // diamond collapse to the same event, so a repeat name is dropped and
+    // never reported. That is what guarantees termination on any graph shape.
     var visited = std.StringHashMap(void).init(allocator);
     defer visited.deinit();
 
@@ -608,4 +609,91 @@ test "resolve aborts when a transitive dependency's formula can't be fetched" {
         error.ResolutionFailed,
         resolve(io, testing.allocator, "rootpkg", &api, &db, &cache),
     );
+}
+
+test "resolve's declared error set is the one it can actually return" {
+    // Guards the drift this signature binding closes: an aspirational variant
+    // added to `DepError`, or a `return` of an undeclared error, must fail
+    // here (or at compile time) instead of surviving review.
+    const ret = @typeInfo(@TypeOf(resolve)).@"fn".return_type.?;
+    try testing.expect(@typeInfo(ret).error_union.error_set == DepError);
+}
+
+test "resolve terminates on a dependency cycle, listing each name once" {
+    const client_mod = @import("../net/client.zig");
+    const schema_mod = @import("../db/schema.zig");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var http = client_mod.HttpClient.init(io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(io, testing.allocator, &http, "/tmp/malt_resolve_cycle_cache");
+    api.base_url = "http://127.0.0.1:9";
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema_mod.initSchema(&db);
+
+    var cache = FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+    // Both nodes primed so getDeps never dials out: cyclea → cycleb → cyclea.
+    _ = try cache.getOrParse(
+        "cyclea",
+        "{\"name\":\"cyclea\",\"versions\":{\"stable\":\"1.0\"}," ++
+            "\"dependencies\":[\"cycleb\"],\"oldnames\":[]}",
+    );
+    _ = try cache.getOrParse(
+        "cycleb",
+        "{\"name\":\"cycleb\",\"versions\":{\"stable\":\"1.0\"}," ++
+            "\"dependencies\":[\"cyclea\"],\"oldnames\":[]}",
+    );
+
+    // Policy: a repeat name is collapsed by `visited`, never reported. The
+    // back-edge to the root is simply dropped and the walk ends.
+    const deps = try resolve(io, testing.allocator, "cyclea", &api, &db, &cache);
+    defer {
+        for (deps) |d| testing.allocator.free(d.name);
+        testing.allocator.free(deps);
+    }
+
+    try testing.expectEqual(@as(usize, 1), deps.len);
+    try testing.expectEqualStrings("cycleb", deps[0].name);
+}
+
+test "resolve drops a self-dependency instead of listing the root as its own dep" {
+    const client_mod = @import("../net/client.zig");
+    const schema_mod = @import("../db/schema.zig");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var http = client_mod.HttpClient.init(io, std.process.Environ.empty, testing.allocator);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(io, testing.allocator, &http, "/tmp/malt_resolve_selfcycle_cache");
+    api.base_url = "http://127.0.0.1:9";
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema_mod.initSchema(&db);
+
+    var cache = FormulaCache.init(testing.allocator);
+    defer cache.deinit();
+    _ = try cache.getOrParse(
+        "selfdep",
+        "{\"name\":\"selfdep\",\"versions\":{\"stable\":\"1.0\"}," ++
+            "\"dependencies\":[\"selfdep\"],\"oldnames\":[]}",
+    );
+
+    // Shortest cycle: the root reaches the queue-side dedup rather than the
+    // fan-out one, so it exercises the other half of the collapse.
+    const deps = try resolve(io, testing.allocator, "selfdep", &api, &db, &cache);
+    defer {
+        for (deps) |d| testing.allocator.free(d.name);
+        testing.allocator.free(deps);
+    }
+
+    try testing.expectEqual(@as(usize, 0), deps.len);
 }

--- a/tests/deps_test.zig
+++ b/tests/deps_test.zig
@@ -394,6 +394,49 @@ test "resolve fails the resolve when a dep's sub-fetch fails" {
     );
 }
 
+test "resolve's only failure across the module boundary is ResolutionFailed" {
+    // Boundary check on the public re-export: `DepError` is what a consumer of
+    // `malt.deps` may have to handle, so the exhaustive switch below stops
+    // compiling the moment the set grows a variant nobody can produce.
+    try comptime testing.expect(deps_mod.DepError == error{ResolutionFailed});
+    const e: deps_mod.DepError = error.ResolutionFailed;
+    switch (e) {
+        error.ResolutionFailed => {},
+    }
+}
+
+test "resolve walks a dependency cycle to completion through the public module" {
+    const alloc = testing.allocator;
+
+    var dir = try TempCacheDir.init("resolve_cycle");
+    defer dir.deinit();
+
+    // ring_a → ring_b → ring_a, served from disk so nothing dials out.
+    try dir.writeFormula("ring_a", "{\"name\":\"ring_a\",\"dependencies\":[\"ring_b\"]}");
+    try dir.writeFormula("ring_b", "{\"name\":\"ring_b\",\"dependencies\":[\"ring_a\"]}");
+
+    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, alloc);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(std.Options.debug_io, alloc, &http, dir.path);
+
+    var tdb = try TempDb.init("resolve_cycle");
+    defer tdb.deinit();
+
+    var cache = deps_mod.FormulaCache.init(alloc);
+    defer cache.deinit();
+
+    // A back-edge is collapsed by the visited set, never reported: the resolve
+    // succeeds and each name lands once.
+    const deps = try deps_mod.resolve(std.Options.debug_io, alloc, "ring_a", &api, &tdb.db, &cache);
+    defer {
+        for (deps) |d| alloc.free(d.name);
+        alloc.free(deps);
+    }
+
+    try testing.expectEqual(@as(usize, 1), deps.len);
+    try testing.expectEqualStrings("ring_b", deps[0].name);
+}
+
 // --- ensureOptLink / stale-cellar heal coverage ---------------------------
 
 test "resolve treats a DB keg with a vanished cellar_path as not-installed" {


### PR DESCRIPTION
## Description

`core/deps` declared three ways dependency resolution can fail; only one of them could ever happen. The declared set was attached to no function, so it was free to drift from reality - and had: neither the cycle error nor the out-of-memory error can be produced, because cycles are absorbed by the visited set by design and every allocation failure inside the resolver degrades instead of propagating.

This narrows the declaration to the failure that is real and puts it on the function's signature, so the two can no longer diverge without the compiler saying so. Behaviour is unchanged; the docstring and the visited-set comment now describe what the code actually does about cycles.

## Related Issue

- None

## Notes for Reviewers

- None