### PR TITLE
refactor(cli, ui): remove three pieces of code that never did what they claimed

### DIFF
--- a/src/cli/info.zig
+++ b/src/cli/info.zig
@@ -496,15 +496,6 @@ pub fn encodeInstallHint(
     );
 }
 
-/// Convenience: format a line into `scratch` and write it to `w`.
-/// Same safety profile as the existing `bufPrint` + `writeAll`
-/// pattern used elsewhere in this file — avoids duplicating the
-/// 4 KiB stack buffer at every call site.
-fn writeLine(w: *std.Io.Writer, scratch: []u8, comptime fmt: []const u8, args: anytype) !void {
-    const line = std.fmt.bufPrint(scratch, fmt, args) catch return;
-    try w.writeAll(line);
-}
-
 /// Open the malt database if present. Returns `null` for any failure
 /// (missing parent directory, permission error, corrupt file) so the
 /// caller can degrade to a stateless response instead of bailing.

--- a/src/cli/search.zig
+++ b/src/cli/search.zig
@@ -32,8 +32,7 @@ pub fn shouldRunLocal(scope: Scope) bool {
 /// Should the API path run? `.installed` is the only scope that bypasses
 /// it entirely; everything else (including `.default`, which mirrors
 /// `brew search`) reaches for the index.
-pub fn shouldRunApi(scope: Scope, has_local_hit: bool) bool {
-    _ = has_local_hit;
+pub fn shouldRunApi(scope: Scope) bool {
     return switch (scope) {
         .default, .api, .all => true,
         .installed => false,
@@ -136,20 +135,16 @@ test "parseScope: ignores non-scope flags and positional args" {
 }
 
 test "shouldRunApi: default mirrors brew search and hits the API" {
-    try testing.expect(shouldRunApi(.default, false));
-    try testing.expect(shouldRunApi(.default, true));
+    try testing.expect(shouldRunApi(.default));
 }
 
 test "shouldRunApi: installed never hits API" {
-    try testing.expect(!shouldRunApi(.installed, false));
-    try testing.expect(!shouldRunApi(.installed, true));
+    try testing.expect(!shouldRunApi(.installed));
 }
 
 test "shouldRunApi: api and all always hit API" {
-    try testing.expect(shouldRunApi(.api, true));
-    try testing.expect(shouldRunApi(.api, false));
-    try testing.expect(shouldRunApi(.all, true));
-    try testing.expect(shouldRunApi(.all, false));
+    try testing.expect(shouldRunApi(.api));
+    try testing.expect(shouldRunApi(.all));
 }
 
 test "shouldRunLocal: default and api skip the local DB" {
@@ -417,10 +412,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         } else |_| {}
     }
 
-    const has_local_hit = formula.exact or cask.exact or
-        formula.matches.len != 0 or cask.matches.len != 0;
-
-    if (shouldRunApi(scope, has_local_hit)) {
+    if (shouldRunApi(scope)) {
         const cache_dir = atomic.maltCacheDir(allocator) catch {
             output.err("Failed to determine cache directory", .{});
             return error.Aborted;
@@ -464,7 +456,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
                 if (search_formula) formula = api_formula;
                 if (search_cask) cask = api_cask;
             },
-            .installed => unreachable, // shouldRunApi(.installed, …) is false.
+            .installed => unreachable, // shouldRunApi(.installed) is false.
         }
     }
 

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -356,7 +356,7 @@ pub fn notice(comptime fmt: []const u8, args: anytype) void {
 pub fn question(comptime fmt: []const u8, args: anytype) void {
     var buf: [4096]u8 = undefined;
     const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
-    const prefix: []const u8 = if (color.isEmojiEnabled()) "  ? " else "  ? ";
+    const prefix: []const u8 = "  ? ";
     const colorize = color.isColorEnabled();
     lockStderr();
     defer unlockStderr();


### PR DESCRIPTION
## Description

Three unrelated fragments advertised behaviour they never performed. One commit each, deletion only, nothing observable moves.

- `cli/info` had a private helper claiming to de-duplicate the format-and-write pattern. Nothing called it, and that de-duplication already exists as `output.writeField` - the helper was a weaker copy of a shipped abstraction, in the wrong module.
- `shouldRunApi` took a "did the local search match anything" flag and discarded it inside the function, so the call site read as if local hits could skip the API query. They never could. The decision is a function of scope alone, and now says so.
- The confirmation prompt chose its prefix with a conditional whose two arms were the same four bytes. Replaced with the constant it always produced.

## Related Issue

- None

## Notes for Reviewers

- None