### PR TITLE
fix(doctor): stop misjudging which process holds the database lock

### DIFF
--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -91,11 +91,7 @@ pub fn operationInFlight(io: std.Io, prefix: []const u8) bool {
     return pidAlive(pid);
 }
 
-/// kill(pid, 0): true when the process exists (and is signalable). Shared by
-/// `operationInFlight` and `checkStaleLock` so live-vs-dead stays one rule.
-fn pidAlive(pid: std.posix.pid_t) bool {
-    return std.c.kill(pid, @enumFromInt(0)) == 0;
-}
+const pidAlive = fix_mod.pidAlive;
 
 /// One entry in the health walk. `run` prints its row(s) and returns
 /// the walker's tally tag.
@@ -1791,11 +1787,4 @@ test "runChecks: an info_status finding counts as neither warning nor error" {
     }, &table);
     try testing.expectEqual(@as(u32, 0), tally.warnings);
     try testing.expectEqual(@as(u32, 0), tally.errors);
-}
-
-test "pidAlive: true for our own PID, false for a dead one" {
-    // The downgrade gates on this: a live holder means an operation is in
-    // flight; a dead PID is a stale lock that must not mask real findings.
-    try testing.expect(pidAlive(std.c.getpid()));
-    try testing.expect(!pidAlive(999999));
 }

--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -78,12 +78,25 @@ pub fn planFixes(c: Conditions) Plan {
 
 const StaleLockState = enum { absent, live, stale };
 
+/// kill(pid, 0): does the process exist? The one live-vs-dead rule, shared by
+/// the doctor walker and the `--fix` probe.
+///
+/// Only ESRCH means gone. EPERM means it exists and we merely may not signal it
+/// (root-owned holder, unprivileged doctor) — reading that as dead would let
+/// `--fix` clear a lock guarding a live operation.
+pub fn pidAlive(pid: std.posix.pid_t) bool {
+    // kill(2) reads <= 0 as a process group, which would signal ourselves and
+    // report a corrupt "0" lock file as live forever.
+    if (pid <= 0) return false;
+    std.posix.kill(pid, @enumFromInt(0)) catch |e| return e != error.ProcessNotFound;
+    return true;
+}
+
 fn probeStaleLockState(io: std.Io, prefix: []const u8) StaleLockState {
     var lock_buf: [512]u8 = undefined;
     const lock_path = std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix}) catch return .absent;
     const pid = lock_mod.LockFile.holderPid(io, lock_path) orelse return .absent;
-    const is_alive = std.c.kill(pid, @enumFromInt(0)) == 0;
-    return if (is_alive) .live else .stale;
+    return if (pidAlive(pid)) .live else .stale;
 }
 
 /// True when the lock file holds a PID that no longer exists.
@@ -776,6 +789,25 @@ test "fixStaleLock: missing lock file is a no-op" {
 
 test "probeStaleLock: missing prefix returns false" {
     try std.testing.expect(!probeStaleLock(std.Options.debug_io, "/nonexistent/malt/prefix"));
+}
+
+test "pidAlive: true for our own PID, false for a dead one" {
+    // The doctor downgrade gates on this: a live holder means an operation is
+    // in flight; a dead PID is a stale lock that must not mask real findings.
+    try std.testing.expect(pidAlive(std.c.getpid()));
+    try std.testing.expect(!pidAlive(999999));
+}
+
+test "pidAlive: a process we may not signal counts as alive" {
+    if (std.c.geteuid() == 0) return error.SkipZigTest; // root can signal pid 1
+    try std.testing.expect(pidAlive(1)); // launchd: live, never signalable
+}
+
+test "pidAlive: non-positive PIDs are dead, not process groups" {
+    // A corrupt lock file parses to 0 or a negative; kill(2) would read those
+    // as "our process group" and report an in-flight operation that never ends.
+    try std.testing.expect(!pidAlive(0));
+    try std.testing.expect(!pidAlive(-1));
 }
 
 test "isPurgeableOrphan: only a refcount<=0 row is an orphan" {

--- a/src/core/perms.zig
+++ b/src/core/perms.zig
@@ -23,8 +23,8 @@ pub const PermReport = struct {
 /// is unit-testable without real files.
 pub fn classifyPermissions(
     mode: u16,
-    file_uid: std.c.uid_t,
-    current_uid: std.c.uid_t,
+    file_uid: std.posix.uid_t,
+    current_uid: std.posix.uid_t,
 ) PermReport {
     return .{
         .group_writable = (mode & 0o020) != 0,
@@ -44,11 +44,6 @@ pub fn freeFindings(allocator: std.mem.Allocator, findings: []WalkFinding) void 
     allocator.free(findings);
 }
 
-/// macOS lstat — doesn't follow symlinks; used here so a malicious
-/// symlink can't make the walker stat the target instead of the link
-/// itself. The Stat shape matches std.c.Stat on macOS.
-extern "c" fn lstat(path: [*:0]const u8, buf: *std.c.Stat) c_int;
-
 /// Walk `prefix` recursively and collect every entry whose permissions
 /// violate `classifyPermissions`. Caps at `max_findings` to bound
 /// memory on pathologically large prefixes.
@@ -56,7 +51,7 @@ pub fn walkPrefix(
     io: std.Io,
     allocator: std.mem.Allocator,
     prefix: []const u8,
-    current_uid: std.c.uid_t,
+    current_uid: std.posix.uid_t,
     max_findings: usize,
 ) ![]WalkFinding {
     var findings: std.ArrayList(WalkFinding) = .empty;
@@ -90,7 +85,7 @@ pub fn walkPrefix(
 fn checkPath(
     allocator: std.mem.Allocator,
     path: []const u8,
-    current_uid: std.c.uid_t,
+    current_uid: std.posix.uid_t,
     findings: *std.ArrayList(WalkFinding),
     max_findings: usize,
 ) !void {
@@ -102,8 +97,11 @@ fn checkPath(
     cstr_buf[path.len] = 0;
     const cstr: [*:0]const u8 = @ptrCast(&cstr_buf);
 
+    // NOFOLLOW: a planted symlink must not redirect the walker to its target.
+    // Still libc — no std peer on 0.16 surfaces st_uid.
     var st: std.c.Stat = undefined;
-    if (lstat(cstr, &st) != 0) return; // skip unstatable entries silently
+    if (std.c.fstatat(std.c.AT.FDCWD, cstr, &st, std.c.AT.SYMLINK_NOFOLLOW) != 0)
+        return; // skip unstatable entries silently
 
     const mode: u16 = @intCast(st.mode & 0o777);
     const report = classifyPermissions(mode, st.uid, current_uid);
@@ -116,7 +114,7 @@ fn checkPath(
     };
 }
 
-pub fn currentUid() std.c.uid_t {
+pub fn currentUid() std.posix.uid_t {
     return std.c.getuid();
 }
 

--- a/src/fs/archive.zig
+++ b/src/fs/archive.zig
@@ -89,7 +89,7 @@ fn sniffMagic(io: std.Io, absolute_path: []const u8, out: []u8) !usize {
 ///
 /// Hard-link entries (zig 0.16's `std.tar.FileKind` lacks `.hard_link`)
 /// are recovered via a raw header pre-scan and re-applied with
-/// `std.c.link` after `pipeToFileSystem` returns.
+/// `std.Io.Dir.hardLink` after `pipeToFileSystem` returns.
 pub fn extractTarGz(io: std.Io, archive_path: []const u8, dest_dir: []const u8) !void {
     var magic: [2]u8 = undefined;
     const n = try sniffMagic(io, archive_path, &magic);
@@ -133,7 +133,7 @@ pub fn extractTarGz(io: std.Io, archive_path: []const u8, dest_dir: []const u8) 
     };
 
     if (hardlinks.len > 0) {
-        try applyHardLinks(dest_dir, hardlinks);
+        try applyHardLinks(io, dir, hardlinks);
     }
 }
 
@@ -142,22 +142,14 @@ const HardLink = struct {
     target: []const u8,
 };
 
-/// Recreate each `target -> name` hard link inside `dest_dir`. Uses
-/// `linkat` with flags=0 (no AT_SYMLINK_FOLLOW) so a hardlink whose
-/// target is itself a symlink shares the symlink inode rather than the
-/// symlink's target inode - macOS `link(2)` follows by default, which
-/// would let an archive craft a hardlink that escapes via a symlink hop.
-fn applyHardLinks(dest_dir: []const u8, links: []const HardLink) !void {
-    var target_buf: [std.Io.Dir.max_path_bytes * 2]u8 = undefined;
-    var name_buf: [std.Io.Dir.max_path_bytes * 2]u8 = undefined;
+/// Recreate each `target -> name` hard link inside `dir`. `follow_symlinks`
+/// stays false (the default): macOS `link(2)` follows, which would let an
+/// archive craft a hardlink that escapes via a symlink hop. Paths stay relative
+/// to the open handle so no absolute path is rebuilt from an entry name.
+fn applyHardLinks(io: std.Io, dir: std.Io.Dir, links: []const HardLink) !void {
     for (links) |hl| {
-        const target_z = std.fmt.bufPrintZ(&target_buf, "{s}/{s}", .{ dest_dir, hl.target }) catch
+        std.Io.Dir.hardLink(dir, hl.target, dir, hl.name, io, .{}) catch
             return error.ExtractionFailed;
-        const name_z = std.fmt.bufPrintZ(&name_buf, "{s}/{s}", .{ dest_dir, hl.name }) catch
-            return error.ExtractionFailed;
-        if (std.c.linkat(std.c.AT.FDCWD, target_z.ptr, std.c.AT.FDCWD, name_z.ptr, 0) != 0) {
-            return error.ExtractionFailed;
-        }
     }
 }
 

--- a/tests/doctor_fix_test.zig
+++ b/tests/doctor_fix_test.zig
@@ -104,6 +104,60 @@ test "fixStaleLock: dead PID lock is truncated in place, not unlinked" {
     try testing.expect(!fix.fixStaleLock(io, prefix));
 }
 
+test "fixStaleLock: a holder we cannot signal is left alone" {
+    // A root-owned malt holding the lock while doctor runs unprivileged: kill(2)
+    // reports EPERM, not ESRCH. Clearing on EPERM would drop the lock metadata
+    // of a live operation, so the holder must read as live.
+    if (std.c.geteuid() == 0) return error.SkipZigTest; // root can signal pid 1
+
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "epermlock");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_buf, "{s}/db", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, db_dir);
+
+    var lock_buf: [256]u8 = undefined;
+    const lock_path = try std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix});
+    try writeFile(lock_path, "1"); // launchd: live, never signalable by us
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const before = try statAbsolute(io, lock_path);
+    try testing.expect(!fix.probeStaleLock(io, prefix));
+    try testing.expect(!fix.fixStaleLock(io, prefix));
+
+    // Untouched, not merely un-unlinked: the pid must survive intact.
+    const after = try statAbsolute(io, lock_path);
+    try testing.expectEqual(before.size, after.size);
+}
+
+test "fixStaleLock: a corrupt zero PID is stale, not an endless operation" {
+    // kill(0, 0) targets our own process group and succeeds, so a truncated or
+    // garbled lock file would otherwise pin doctor at "operation in flight".
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "zeropidlock");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var db_buf: [256]u8 = undefined;
+    const db_dir = try std.fmt.bufPrint(&db_buf, "{s}/db", .{prefix});
+    try fs_compat.makeDirAbsolute(std.Options.debug_io, db_dir);
+
+    var lock_buf: [256]u8 = undefined;
+    const lock_path = try std.fmt.bufPrint(&lock_buf, "{s}/db/malt.lock", .{prefix});
+    try writeFile(lock_path, "0");
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    try testing.expect(fix.probeStaleLock(io, prefix));
+    try testing.expect(fix.fixStaleLock(io, prefix));
+}
+
 test "fixStaleLock: live PID is left alone" {
     var prefix_buf: [128]u8 = undefined;
     const prefix = try makePrefix(&prefix_buf, "livelock");

--- a/tests/perms_test.zig
+++ b/tests/perms_test.zig
@@ -104,6 +104,36 @@ test "walkPrefix: detects other-writable file" {
     try testing.expect(saw_target);
 }
 
+test "walkPrefix: a symlink is judged on itself, not its target" {
+    // The walker stats with SYMLINK_NOFOLLOW so a symlink planted in the prefix
+    // cannot make it report (or clear) the permissions of something elsewhere.
+    const base = "/tmp/malt_perms_nofollow";
+    const target = "/tmp/malt_perms_nofollow_target.txt";
+    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    test_io.deleteTreeAbsolute(std.Options.debug_io, target) catch {};
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, target) catch {};
+
+    try test_io.cwd().createDirPath(std.Options.debug_io, base);
+    (try test_io.createFileAbsolute(std.Options.debug_io, target, .{})).close(std.Options.debug_io);
+
+    const c = struct {
+        extern "c" fn chmod(path: [*:0]const u8, mode: u16) c_int;
+    };
+    if (c.chmod(target, 0o666) != 0) return error.TestUnexpectedResult;
+
+    const link = base ++ "/link";
+    try std.Io.Dir.symLinkAbsolute(std.Options.debug_io, target, link, .{});
+
+    const findings = try perms.walkPrefix(std.Options.debug_io, testing.allocator, base, perms.currentUid(), 64);
+    defer perms.freeFindings(testing.allocator, findings);
+
+    // Following would inherit the target's 0o666 and flag the link.
+    for (findings) |f| {
+        if (std.mem.endsWith(u8, f.path, "/link")) return error.TestUnexpectedResult;
+    }
+}
+
 test "walkPrefix: missing prefix returns empty findings, no error" {
     const findings = try perms.walkPrefix(
         std.Options.debug_io,


### PR DESCRIPTION
## Description

`doctor` decided whether a lock holder was alive with `kill(pid, 0) == 0`, which collapses every failure into "dead". EPERM means the opposite: the process exists and we merely lack permission to signal it - a root-owned malt holding the lock while `doctor` runs unprivileged. `doctor --fix` then cleared a lock that was guarding a live operation.

The probe now uses `std.posix.kill`, whose typed `KillError` separates `ProcessNotFound` from `PermissionDenied`. Only ESRCH counts as dead. A non-positive PID is also treated as dead: `kill(2)` reads `<= 0` as a process group, so a truncated or garbled lock file would otherwise pin `doctor` at "operation in flight" forever, with `--fix` never able to clear it.

The rule lived in two copies that had already drifted from the comment claiming they were shared; it now lives once, in the `--fix` probe that both callers use.

Also folds in two idiom fixes that removed hand-rolled surface:

- Hard-link re-application after tar extraction moves from a raw `linkat` with a magic `0` flag to `std.Io.Dir.hardLink`, whose `follow_symlinks: false` default *is* the security invariant the `0` encoded. Passing the open destination handle also removed both absolute-path joins, so nothing rebuilds a path from an archive-supplied entry name.
- The permission walker drops a hand-declared `extern "c" fn lstat` - whose own comment admitted it was matching an ABI shape by hand - for `std.c.fstatat` with `AT.SYMLINK_NOFOLLOW`, and its public signatures now say `std.posix.uid_t`.

## Related Issue

- None

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #741
- <kbd>&nbsp;1&nbsp;</kbd> #740 👈 
<!-- GitButler Footer Boundary Bottom -->