### PR TITLE
test: make every scratch fixture path unique per process and call

### DIFF
--- a/tests/api_test.zig
+++ b/tests/api_test.zig
@@ -49,17 +49,23 @@ test "validateName rejects slashes and spaces" {
 // --- BrewApi cache tests (no network) ---
 
 const TempCacheDir = struct {
+    arena: std.heap.ArenaAllocator,
     path: []const u8,
 
-    fn init(comptime tag: []const u8) !TempCacheDir {
-        const p = "/tmp/malt_api_test_" ++ tag;
+    /// Process-unique root: a fixed /tmp name lets an overlapping run's
+    /// deleteTree wipe this fixture mid-test.
+    fn init(tag: []const u8) !TempCacheDir {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const p = try test_io.uniqueTempPath(arena.allocator(), "api", tag);
         test_io.deleteTreeAbsolute(std.Options.debug_io, p) catch {};
         try test_io.makeDirAbsolute(std.Options.debug_io, p);
-        return .{ .path = p };
+        return .{ .arena = arena, .path = p };
     }
 
     fn deinit(self: *TempCacheDir) void {
         test_io.deleteTreeAbsolute(std.Options.debug_io, self.path) catch {};
+        self.arena.deinit();
     }
 
     fn writeCacheFile(self: *TempCacheDir, rel: []const u8, content: []const u8) !void {

--- a/tests/archive_test.zig
+++ b/tests/archive_test.zig
@@ -7,11 +7,37 @@ const test_io = @import("test_io");
 const testing = std.testing;
 const archive = @import("malt").archive;
 
-fn resetDir(path: []const u8) !std.Io.Dir {
-    test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, path);
-    return test_io.openDirAbsolute(std.Options.debug_io, path, .{});
-}
+/// Per-test scratch tree under a process-unique base, so overlapping test
+/// runs cannot wipe each other's fixtures.
+const Fixture = struct {
+    arena: std.heap.ArenaAllocator,
+    base: []const u8,
+    dir: std.Io.Dir,
+
+    fn init(tag: []const u8) !Fixture {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "archive", tag);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+        try test_io.makeDirAbsolute(std.Options.debug_io, base);
+        return .{
+            .arena = arena,
+            .base = base,
+            .dir = try test_io.openDirAbsolute(std.Options.debug_io, base, .{}),
+        };
+    }
+
+    /// Absolute path to `sub` inside the fixture; valid until `deinit`.
+    fn p(self: *Fixture, sub: []const u8) []const u8 {
+        return std.fmt.allocPrint(self.arena.allocator(), "{s}/{s}", .{ self.base, sub }) catch @panic("OOM");
+    }
+
+    fn deinit(self: *Fixture) void {
+        self.dir.close(std.Options.debug_io);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.base) catch {};
+        self.arena.deinit();
+    }
+};
 
 fn runTar(argv: []const []const u8) !void {
     var threaded: std.Io.Threaded = .init(std.heap.c_allocator, .{ .environ = malt.app_ctx.processEnviron() });
@@ -36,28 +62,26 @@ fn spawnIo() std.Io.Threaded {
 }
 
 test "extractTarGz decompresses a real tar.gz produced by system tar" {
-    const base = "/tmp/malt_archive_targz_ok";
-    var dir = try resetDir(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("targz_ok");
+    defer fx.deinit();
 
     // Build a simple payload: base/src/hello.txt
-    try dir.createDirPath(std.Options.debug_io, "src");
+    try fx.dir.createDirPath(std.Options.debug_io, "src");
     {
-        const f = try dir.createFile(std.Options.debug_io, "src/hello.txt", .{});
+        const f = try fx.dir.createFile(std.Options.debug_io, "src/hello.txt", .{});
         try f.writeStreamingAll(std.Options.debug_io, "hi");
         f.close(std.Options.debug_io);
     }
 
-    const archive_path = base ++ "/payload.tar.gz";
-    try runTar(&.{ "tar", "czf", archive_path, "-C", base, "src" });
+    const archive_path = fx.p("payload.tar.gz");
+    try runTar(&.{ "tar", "czf", archive_path, "-C", fx.base, "src" });
 
     // Remove the src dir so we can observe extraction re-creating it.
-    try test_io.deleteTreeAbsolute(std.Options.debug_io, base ++ "/src");
+    try test_io.deleteTreeAbsolute(std.Options.debug_io, fx.p("src"));
 
-    try archive.extractTarGz(std.Options.debug_io, archive_path, base);
+    try archive.extractTarGz(std.Options.debug_io, archive_path, fx.base);
 
-    const f = try dir.openFile(std.Options.debug_io, "src/hello.txt", .{});
+    const f = try fx.dir.openFile(std.Options.debug_io, "src/hello.txt", .{});
     defer f.close(std.Options.debug_io);
     var out: [8]u8 = undefined;
     const n = try f.readPositionalAll(std.Options.debug_io, &out, 0);
@@ -71,29 +95,27 @@ test "extractTarGz decompresses a real tar.gz produced by system tar" {
 // silently failed with `CellarFailed`. Covers both halves of the fix:
 // caller-supplied archive path, caller-supplied dest dir.
 test "extractTarGz extracts an archive living outside the destination dir" {
-    const src_dir = "/tmp/malt_archive_targz_split_src";
-    const dest_dir = "/tmp/malt_archive_targz_split_dest";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, src_dir) catch {};
-    test_io.deleteTreeAbsolute(std.Options.debug_io, dest_dir) catch {};
+    var fx = try Fixture.init("targz_split");
+    defer fx.deinit();
+    const src_dir = fx.p("src");
+    const dest_dir = fx.p("dest");
     try test_io.makeDirAbsolute(std.Options.debug_io, src_dir);
     try test_io.makeDirAbsolute(std.Options.debug_io, dest_dir);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, src_dir) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, dest_dir) catch {};
 
     // Build payload in src_dir and tarball it into src_dir/tap_download.tar.gz.
-    try test_io.makeDirAbsolute(std.Options.debug_io, src_dir ++ "/payload");
+    try test_io.makeDirAbsolute(std.Options.debug_io, fx.p("src/payload"));
     {
-        const f = try test_io.createFileAbsolute(std.Options.debug_io, src_dir ++ "/payload/bin", .{});
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, fx.p("src/payload/bin"), .{});
         try f.writeStreamingAll(std.Options.debug_io, "#!/bin/sh\n");
         f.close(std.Options.debug_io);
     }
-    const archive_path = src_dir ++ "/tap_download.tar.gz";
+    const archive_path = fx.p("src/tap_download.tar.gz");
     try runTar(&.{ "tar", "czf", archive_path, "-C", src_dir, "payload" });
 
     try archive.extractTarGz(std.Options.debug_io, archive_path, dest_dir);
 
     // The payload landed in dest_dir, not next to the archive.
-    const f = try test_io.openFileAbsolute(std.Options.debug_io, dest_dir ++ "/payload/bin", .{});
+    const f = try test_io.openFileAbsolute(std.Options.debug_io, fx.p("dest/payload/bin"), .{});
     defer f.close(std.Options.debug_io);
 }
 
@@ -105,30 +127,28 @@ test "extractTarGz extracts an archive living outside the destination dir" {
 // `<name>/<version>/share/...`). A single tarball exercises all three
 // so a regression in any one tripps this test.
 test "extractTarGz preserves exec bits, symlinks, and deep paths" {
-    const base = "/tmp/malt_archive_targz_perms";
-    var dir = try resetDir(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("targz_perms");
+    defer fx.deinit();
 
     // Build the source tree to tar up: an executable, a deep file, and
     // a relative symlink pointing at the executable.
-    const src_root = base ++ "/src";
+    const src_root = fx.p("src");
     try test_io.makeDirAbsolute(std.Options.debug_io, src_root);
-    try dir.createDirPath(std.Options.debug_io, "src/bin");
-    try dir.createDirPath(std.Options.debug_io, "src/a/b/c/d/e/f");
+    try fx.dir.createDirPath(std.Options.debug_io, "src/bin");
+    try fx.dir.createDirPath(std.Options.debug_io, "src/a/b/c/d/e/f");
     {
-        const f = try dir.createFile(std.Options.debug_io, "src/bin/hello", .{ .permissions = std.Io.File.Permissions.fromMode(0o755) });
+        const f = try fx.dir.createFile(std.Options.debug_io, "src/bin/hello", .{ .permissions = std.Io.File.Permissions.fromMode(0o755) });
         try f.writeStreamingAll(std.Options.debug_io, "#!/bin/sh\necho hi\n");
         f.close(std.Options.debug_io);
     }
     {
-        const f = try dir.createFile(std.Options.debug_io, "src/a/b/c/d/e/f/deep.txt", .{});
+        const f = try fx.dir.createFile(std.Options.debug_io, "src/a/b/c/d/e/f/deep.txt", .{});
         try f.writeStreamingAll(std.Options.debug_io, "deep");
         f.close(std.Options.debug_io);
     }
     // Relative symlink sitting next to the executable, pointing at it
     // by basename — the usual bottle shape.
-    const src_subdir = try dir.openDir(std.Options.debug_io, "src/bin", .{});
+    const src_subdir = try fx.dir.openDir(std.Options.debug_io, "src/bin", .{});
     defer {
         var m = src_subdir;
         m.close(std.Options.debug_io);
@@ -138,29 +158,29 @@ test "extractTarGz preserves exec bits, symlinks, and deep paths" {
     // Tar it up; GNU/BSD tar both preserve exec bits and symlinks by
     // default, so the round-trip through our native extractor is the
     // thing under test, not tar's archive-building behaviour.
-    const archive_path = base ++ "/payload.tar.gz";
-    try runTar(&.{ "tar", "czf", archive_path, "-C", base, "src" });
+    const archive_path = fx.p("payload.tar.gz");
+    try runTar(&.{ "tar", "czf", archive_path, "-C", fx.base, "src" });
 
     // Nuke the source tree so observed state after extract can only
     // come from our extractor.
     try test_io.deleteTreeAbsolute(std.Options.debug_io, src_root);
 
-    try archive.extractTarGz(std.Options.debug_io, archive_path, base);
+    try archive.extractTarGz(std.Options.debug_io, archive_path, fx.base);
 
     // Exec bit preserved (tar.ExtractOptions.ModeMode.executable_bit_only
     // is the default — owner-x copied to group/other).
-    const st = try dir.statFile(std.Options.debug_io, "src/bin/hello", .{});
+    const st = try fx.dir.statFile(std.Options.debug_io, "src/bin/hello", .{});
     const mode = st.permissions.toMode();
     try testing.expect(mode & 0o111 != 0);
 
     // Symlink extracted as a link, not a copy — readLink succeeds and
     // returns the original relative target.
     var link_buf: [64]u8 = undefined;
-    const target_len = try dir.readLink(std.Options.debug_io, "src/bin/hello_link", &link_buf);
+    const target_len = try fx.dir.readLink(std.Options.debug_io, "src/bin/hello_link", &link_buf);
     try testing.expectEqualStrings("hello", link_buf[0..target_len]);
 
     // Deep nested path reached intact.
-    const deep = try dir.openFile(std.Options.debug_io, "src/a/b/c/d/e/f/deep.txt", .{});
+    const deep = try fx.dir.openFile(std.Options.debug_io, "src/a/b/c/d/e/f/deep.txt", .{});
     defer deep.close(std.Options.debug_io);
     var buf: [8]u8 = undefined;
     const n = try deep.readPositionalAll(std.Options.debug_io, &buf, 0);
@@ -174,43 +194,41 @@ test "extractTarGz preserves exec bits, symlinks, and deep paths" {
 // "Download failed" surface. Pre-scan + post-pass `link()` recovers
 // the alias without touching the bulk extraction pipeline.
 test "extractTarGz materialises a tar hard-link entry" {
-    const base = "/tmp/malt_archive_targz_hardlink";
-    var dir = try resetDir(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("targz_hardlink");
+    defer fx.deinit();
 
     // Build payload: src/bin/primary holds 'pri', src/bin/aliased is a
     // hard link to primary. We use `ln` (not `ln -s`) so tar records a
     // type-'1' header; with `ln -s` it would be a symlink instead.
-    try dir.createDirPath(std.Options.debug_io, "src/bin");
+    try fx.dir.createDirPath(std.Options.debug_io, "src/bin");
     {
-        const f = try dir.createFile(std.Options.debug_io, "src/bin/primary", .{
+        const f = try fx.dir.createFile(std.Options.debug_io, "src/bin/primary", .{
             .permissions = std.Io.File.Permissions.fromMode(0o755),
         });
         try f.writeStreamingAll(std.Options.debug_io, "pri");
         f.close(std.Options.debug_io);
     }
-    try runCmd(&.{ "ln", base ++ "/src/bin/primary", base ++ "/src/bin/aliased" });
+    try runCmd(&.{ "ln", fx.p("src/bin/primary"), fx.p("src/bin/aliased") });
 
-    const archive_path = base ++ "/payload.tar.gz";
-    try runTar(&.{ "tar", "czf", archive_path, "-C", base, "src" });
+    const archive_path = fx.p("payload.tar.gz");
+    try runTar(&.{ "tar", "czf", archive_path, "-C", fx.base, "src" });
 
     // Wipe so observed state can only come from our extractor.
-    try test_io.deleteTreeAbsolute(std.Options.debug_io, base ++ "/src");
+    try test_io.deleteTreeAbsolute(std.Options.debug_io, fx.p("src"));
 
-    try archive.extractTarGz(std.Options.debug_io, archive_path, base);
+    try archive.extractTarGz(std.Options.debug_io, archive_path, fx.base);
 
     // Both names land on disk with the same content; that's necessary
     // for libdeflate-style multi-binary kegs to actually function.
     var buf: [8]u8 = undefined;
     {
-        const f = try dir.openFile(std.Options.debug_io, "src/bin/primary", .{});
+        const f = try fx.dir.openFile(std.Options.debug_io, "src/bin/primary", .{});
         defer f.close(std.Options.debug_io);
         const n = try f.readPositionalAll(std.Options.debug_io, &buf, 0);
         try testing.expectEqualStrings("pri", buf[0..n]);
     }
     {
-        const f = try dir.openFile(std.Options.debug_io, "src/bin/aliased", .{});
+        const f = try fx.dir.openFile(std.Options.debug_io, "src/bin/aliased", .{});
         defer f.close(std.Options.debug_io);
         const n = try f.readPositionalAll(std.Options.debug_io, &buf, 0);
         try testing.expectEqualStrings("pri", buf[0..n]);
@@ -220,8 +238,8 @@ test "extractTarGz materialises a tar hard-link entry" {
     // a `link()` call rather than copying the bytes (which would defeat
     // the point of hard-link entries in the bottle and double the disk
     // footprint per multi-binary keg).
-    const stat_a = try dir.statFile(std.Options.debug_io, "src/bin/primary", .{});
-    const stat_b = try dir.statFile(std.Options.debug_io, "src/bin/aliased", .{});
+    const stat_a = try fx.dir.statFile(std.Options.debug_io, "src/bin/primary", .{});
+    const stat_b = try fx.dir.statFile(std.Options.debug_io, "src/bin/aliased", .{});
     try testing.expectEqual(stat_a.inode, stat_b.inode);
     try testing.expect(stat_a.nlink >= 2);
 }
@@ -234,36 +252,35 @@ test "extractTarGz materialises a tar hard-link entry" {
 // the first non-zero trailer, surfacing ExtractionFailed for archives
 // the stock `tar xzf` would extract cleanly.
 test "extractTarGz stops scanning at end-of-archive and ignores trailing garbage" {
-    const base = "/tmp/malt_archive_targz_eofgarbage";
-    var dir = try resetDir(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("targz_eofgarbage");
+    defer fx.deinit();
 
-    try dir.createDirPath(std.Options.debug_io, "src");
+    try fx.dir.createDirPath(std.Options.debug_io, "src");
     {
-        const f = try dir.createFile(std.Options.debug_io, "src/legit.txt", .{});
+        const f = try fx.dir.createFile(std.Options.debug_io, "src/legit.txt", .{});
         try f.writeStreamingAll(std.Options.debug_io, "ok");
         f.close(std.Options.debug_io);
     }
 
     // Uncompressed tar first - we need to splice garbage past the
     // end-of-archive zeros before re-compressing.
-    const uncompressed = base ++ "/payload.tar";
-    try runTar(&.{ "tar", "cf", uncompressed, "-C", base, "src" });
+    const uncompressed = fx.p("payload.tar");
+    try runTar(&.{ "tar", "cf", uncompressed, "-C", fx.base, "src" });
 
     // A single non-zero trailer is enough: the next 512-byte chunk read
     // by preScanTarGz is no longer all-zero, so a `continue` past the
     // first zero block would parse it as a header and trip the checksum.
-    try runCmd(&.{ "sh", "-c", "printf 'GARBAGE!' >> '" ++ uncompressed ++ "'" });
+    const append_garbage = try std.fmt.allocPrint(fx.arena.allocator(), "printf 'GARBAGE!' >> '{s}'", .{uncompressed});
+    try runCmd(&.{ "sh", "-c", append_garbage });
     try runCmd(&.{ "gzip", "-f", uncompressed });
 
     // Wipe the source tree so observed state can only come from our extractor.
-    try test_io.deleteTreeAbsolute(std.Options.debug_io, base ++ "/src");
+    try test_io.deleteTreeAbsolute(std.Options.debug_io, fx.p("src"));
 
-    const archive_path = base ++ "/payload.tar.gz";
-    try archive.extractTarGz(std.Options.debug_io, archive_path, base);
+    const archive_path = fx.p("payload.tar.gz");
+    try archive.extractTarGz(std.Options.debug_io, archive_path, fx.base);
 
-    const f = try dir.openFile(std.Options.debug_io, "src/legit.txt", .{});
+    const f = try fx.dir.openFile(std.Options.debug_io, "src/legit.txt", .{});
     defer f.close(std.Options.debug_io);
     var out: [8]u8 = undefined;
     const n = try f.readPositionalAll(std.Options.debug_io, &out, 0);
@@ -282,18 +299,16 @@ test "extractTarGz stops scanning at end-of-archive and ignores trailing garbage
 // a hostile bottle could craft a hard-link-of-symlink pair to land
 // an inode shared with a file the symlink dereferences to.
 test "extractTarGz hard-link to a symlink shares the symlink inode, not the target" {
-    const base = "/tmp/malt_archive_targz_hardlink_symlink";
-    var dir = try resetDir(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("targz_hardlink_symlink");
+    defer fx.deinit();
 
-    try dir.createDirPath(std.Options.debug_io, "src");
+    try fx.dir.createDirPath(std.Options.debug_io, "src");
     {
-        const f = try dir.createFile(std.Options.debug_io, "src/data.txt", .{});
+        const f = try fx.dir.createFile(std.Options.debug_io, "src/data.txt", .{});
         try f.writeStreamingAll(std.Options.debug_io, "data");
         f.close(std.Options.debug_io);
     }
-    var src_dir = try dir.openDir(std.Options.debug_io, "src", .{});
+    var src_dir = try fx.dir.openDir(std.Options.debug_io, "src", .{});
     defer {
         var sd = src_dir;
         sd.close(std.Options.debug_io);
@@ -301,81 +316,75 @@ test "extractTarGz hard-link to a symlink shares the symlink inode, not the targ
     try src_dir.symLink(std.Options.debug_io, "data.txt", "linkalias", .{});
     // `ln -P` forces a hard link to the symlink itself rather than
     // dereferencing - macOS BSD `ln` follows symlinks by default.
-    try runCmd(&.{ "ln", "-P", base ++ "/src/linkalias", base ++ "/src/link" });
+    try runCmd(&.{ "ln", "-P", fx.p("src/linkalias"), fx.p("src/link") });
 
-    const archive_path = base ++ "/payload.tar.gz";
-    try runTar(&.{ "tar", "czf", archive_path, "-C", base, "src" });
+    const archive_path = fx.p("payload.tar.gz");
+    try runTar(&.{ "tar", "czf", archive_path, "-C", fx.base, "src" });
 
-    try test_io.deleteTreeAbsolute(std.Options.debug_io, base ++ "/src");
+    try test_io.deleteTreeAbsolute(std.Options.debug_io, fx.p("src"));
 
-    try archive.extractTarGz(std.Options.debug_io, archive_path, base);
+    try archive.extractTarGz(std.Options.debug_io, archive_path, fx.base);
 
     // Both names readlink to the same symlink target. If link() had
     // dereferenced, one of the two would be a regular file with
     // 'data' as content - not a symlink at all.
     var link_buf: [64]u8 = undefined;
     var alias_buf: [64]u8 = undefined;
-    const link_target_len = try dir.readLink(std.Options.debug_io, "src/link", &link_buf);
-    const alias_target_len = try dir.readLink(std.Options.debug_io, "src/linkalias", &alias_buf);
+    const link_target_len = try fx.dir.readLink(std.Options.debug_io, "src/link", &link_buf);
+    const alias_target_len = try fx.dir.readLink(std.Options.debug_io, "src/linkalias", &alias_buf);
     try testing.expectEqualStrings("data.txt", link_buf[0..link_target_len]);
     try testing.expectEqualStrings("data.txt", alias_buf[0..alias_target_len]);
 
     // Inode equality (no follow): link and linkalias share the symlink
     // inode; data.txt has its own. This is the security-relevant check.
-    const link_stat = try dir.statFile(std.Options.debug_io, "src/link", .{ .follow_symlinks = false });
-    const alias_stat = try dir.statFile(std.Options.debug_io, "src/linkalias", .{ .follow_symlinks = false });
-    const data_stat = try dir.statFile(std.Options.debug_io, "src/data.txt", .{ .follow_symlinks = false });
+    const link_stat = try fx.dir.statFile(std.Options.debug_io, "src/link", .{ .follow_symlinks = false });
+    const alias_stat = try fx.dir.statFile(std.Options.debug_io, "src/linkalias", .{ .follow_symlinks = false });
+    const data_stat = try fx.dir.statFile(std.Options.debug_io, "src/data.txt", .{ .follow_symlinks = false });
     try testing.expectEqual(link_stat.inode, alias_stat.inode);
     try testing.expect(data_stat.inode != link_stat.inode);
     try testing.expect(link_stat.nlink >= 2);
 }
 
 test "extractTarGz rejects an archive containing a fifo entry" {
-    const base = "/tmp/malt_archive_targz_fifo";
-    var dir = try resetDir(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("targz_fifo");
+    defer fx.deinit();
 
-    try dir.createDirPath(std.Options.debug_io, "src");
+    try fx.dir.createDirPath(std.Options.debug_io, "src");
     {
-        const f = try dir.createFile(std.Options.debug_io, "src/regular.txt", .{});
+        const f = try fx.dir.createFile(std.Options.debug_io, "src/regular.txt", .{});
         try f.writeStreamingAll(std.Options.debug_io, "ok");
         f.close(std.Options.debug_io);
     }
     // mkfifo is what makes tar emit a type-'6' header; nothing in zig's
     // std lets us synthesise one without invoking the system tool.
-    try runCmd(&.{ "mkfifo", base ++ "/src/pipe" });
+    try runCmd(&.{ "mkfifo", fx.p("src/pipe") });
 
-    const archive_path = base ++ "/payload.tar.gz";
-    try runTar(&.{ "tar", "czf", archive_path, "-C", base, "src" });
+    const archive_path = fx.p("payload.tar.gz");
+    try runTar(&.{ "tar", "czf", archive_path, "-C", fx.base, "src" });
 
-    try test_io.deleteTreeAbsolute(std.Options.debug_io, base ++ "/src");
+    try test_io.deleteTreeAbsolute(std.Options.debug_io, fx.p("src"));
 
-    try testing.expectError(error.ExtractionFailed, archive.extractTarGz(std.Options.debug_io, archive_path, base));
+    try testing.expectError(error.ExtractionFailed, archive.extractTarGz(std.Options.debug_io, archive_path, fx.base));
 }
 
 test "extractTarGz rejects a non-gzip archive" {
-    const base = "/tmp/malt_archive_targz_badmagic";
-    var dir = try resetDir(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("targz_badmagic");
+    defer fx.deinit();
 
     // Write an archive file with wrong magic bytes.
-    const archive_path = base ++ "/payload.tar.gz";
+    const archive_path = fx.p("payload.tar.gz");
     const f = try test_io.createFileAbsolute(std.Options.debug_io, archive_path, .{});
     try f.writeStreamingAll(std.Options.debug_io, "NOPE, not gzip");
     f.close(std.Options.debug_io);
 
-    try testing.expectError(error.ExtractionFailed, archive.extractTarGz(std.Options.debug_io, archive_path, base));
+    try testing.expectError(error.ExtractionFailed, archive.extractTarGz(std.Options.debug_io, archive_path, fx.base));
 }
 
 test "extractTarGz rejects a missing archive" {
-    const base = "/tmp/malt_archive_targz_missing";
-    var dir = try resetDir(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("targz_missing");
+    defer fx.deinit();
 
-    try testing.expectError(error.ExtractionFailed, archive.extractTarGz(std.Options.debug_io, base ++ "/nope.tar.gz", base));
+    try testing.expectError(error.ExtractionFailed, archive.extractTarGz(std.Options.debug_io, fx.p("nope.tar.gz"), fx.base));
 }
 
 fn runCmd(argv: []const []const u8) !void {
@@ -395,29 +404,27 @@ fn runCmd(argv: []const []const u8) !void {
 }
 
 test "extractZip decompresses a real zip produced by system zip" {
-    const base = "/tmp/malt_archive_zip_ok";
-    var dir = try resetDir(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("zip_ok");
+    defer fx.deinit();
 
     // Build a payload mirroring what a HashiCorp-style release contains:
     // a single executable at the archive root, no nested directory. The
     // binary-finding walker in the tap-install path depends on exactly
     // this shape.
     {
-        const f = try dir.createFile(std.Options.debug_io, "terraform", .{ .permissions = std.Io.File.Permissions.fromMode(0o755) });
+        const f = try fx.dir.createFile(std.Options.debug_io, "terraform", .{ .permissions = std.Io.File.Permissions.fromMode(0o755) });
         try f.writeStreamingAll(std.Options.debug_io, "#!/bin/sh\necho hi\n");
         f.close(std.Options.debug_io);
     }
-    const archive_path = base ++ "/payload.zip";
-    try runCmd(&.{ "zip", "-j", "-q", archive_path, base ++ "/terraform" });
-    try test_io.deleteFileAbsolute(std.Options.debug_io, base ++ "/terraform");
+    const archive_path = fx.p("payload.zip");
+    try runCmd(&.{ "zip", "-j", "-q", archive_path, fx.p("terraform") });
+    try test_io.deleteFileAbsolute(std.Options.debug_io, fx.p("terraform"));
 
     var threaded = spawnIo();
     defer threaded.deinit();
-    try archive.extractZip(threaded.io(), archive_path, base);
+    try archive.extractZip(threaded.io(), archive_path, fx.base);
 
-    const f = try dir.openFile(std.Options.debug_io, "terraform", .{});
+    const f = try fx.dir.openFile(std.Options.debug_io, "terraform", .{});
     defer f.close(std.Options.debug_io);
     var buf: [32]u8 = undefined;
     const n = try f.readPositionalAll(std.Options.debug_io, &buf, 0);
@@ -426,26 +433,22 @@ test "extractZip decompresses a real zip produced by system zip" {
 }
 
 test "extractZip rejects a non-zip archive" {
-    const base = "/tmp/malt_archive_zip_badmagic";
-    var dir = try resetDir(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("zip_badmagic");
+    defer fx.deinit();
 
-    const archive_path = base ++ "/payload.zip";
+    const archive_path = fx.p("payload.zip");
     const f = try test_io.createFileAbsolute(std.Options.debug_io, archive_path, .{});
     try f.writeStreamingAll(std.Options.debug_io, "NOPE, not a zip");
     f.close(std.Options.debug_io);
 
-    try testing.expectError(error.ExtractionFailed, archive.extractZip(std.Options.debug_io, archive_path, base));
+    try testing.expectError(error.ExtractionFailed, archive.extractZip(std.Options.debug_io, archive_path, fx.base));
 }
 
 test "extractZip rejects a missing archive" {
-    const base = "/tmp/malt_archive_zip_missing";
-    var dir = try resetDir(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("zip_missing");
+    defer fx.deinit();
 
-    try testing.expectError(error.ExtractionFailed, archive.extractZip(std.Options.debug_io, base ++ "/nope.zip", base));
+    try testing.expectError(error.ExtractionFailed, archive.extractZip(std.Options.debug_io, fx.p("nope.zip"), fx.base));
 }
 
 // tar-slip: pre-scan must reject the whole archive before any entry
@@ -454,106 +457,98 @@ test "extractZip rejects a missing archive" {
 // order — if the extractor streamed entries it would write good.txt
 // before hitting the bad one, which the test forbids.
 test "extractTarGz rejects tar-slip and leaves dest untouched" {
-    const base = "/tmp/malt_archive_tarslip_targz";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, base);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    const dest = base ++ "/dest";
+    var fx = try Fixture.init("tarslip_targz");
+    defer fx.deinit();
+    const dest = fx.p("dest");
     try test_io.makeDirAbsolute(std.Options.debug_io, dest);
 
-    const src_dir = base ++ "/src";
+    const src_dir = fx.p("src");
     try test_io.makeDirAbsolute(std.Options.debug_io, src_dir);
     {
-        const f = try test_io.createFileAbsolute(std.Options.debug_io, src_dir ++ "/good.txt", .{});
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, fx.p("src/good.txt"), .{});
         try f.writeStreamingAll(std.Options.debug_io, "safe");
         f.close(std.Options.debug_io);
     }
     {
-        const f = try test_io.createFileAbsolute(std.Options.debug_io, src_dir ++ "/bad.txt", .{});
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, fx.p("src/bad.txt"), .{});
         try f.writeStreamingAll(std.Options.debug_io, "hostile");
         f.close(std.Options.debug_io);
     }
 
-    const archive_path = base ++ "/hostile.tar.gz";
+    const archive_path = fx.p("hostile.tar.gz");
     try runCmd(&.{ "tar", "czf", archive_path, "-C", src_dir, "-s", "|^bad.txt|../escape.txt|", "good.txt", "bad.txt" });
 
     try testing.expectError(error.ExtractionFailed, archive.extractTarGz(std.Options.debug_io, archive_path, dest));
-    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(std.Options.debug_io, dest ++ "/good.txt", .{}));
-    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(std.Options.debug_io, base ++ "/escape.txt", .{}));
+    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(std.Options.debug_io, fx.p("dest/good.txt"), .{}));
+    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(std.Options.debug_io, fx.p("escape.txt"), .{}));
 }
 
 // tar-slip for zip: macOS `zip` normalises `..` out at creation, so
 // we lean on python3's zipfile to emit the entry name verbatim.
 test "extractZip rejects tar-slip and leaves dest untouched" {
-    const base = "/tmp/malt_archive_tarslip_zip";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, base);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    const dest = base ++ "/dest";
+    var fx = try Fixture.init("tarslip_zip");
+    defer fx.deinit();
+    const dest = fx.p("dest");
     try test_io.makeDirAbsolute(std.Options.debug_io, dest);
 
-    const archive_path = base ++ "/hostile.zip";
-    const script = "import zipfile\n" ++
-        "with zipfile.ZipFile('" ++ archive_path ++ "', 'w') as z:\n" ++
+    const archive_path = fx.p("hostile.zip");
+    const script = try std.fmt.allocPrint(fx.arena.allocator(), "import zipfile\n" ++
+        "with zipfile.ZipFile('{s}', 'w') as z:\n" ++
         "    z.writestr('good.txt', b'safe')\n" ++
-        "    z.writestr('../escape.txt', b'hostile')\n";
+        "    z.writestr('../escape.txt', b'hostile')\n", .{archive_path});
     try runCmd(&.{ "python3", "-c", script });
 
     var threaded = spawnIo();
     defer threaded.deinit();
     try testing.expectError(error.ExtractionFailed, archive.extractZip(threaded.io(), archive_path, dest));
-    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(std.Options.debug_io, dest ++ "/good.txt", .{}));
-    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(std.Options.debug_io, base ++ "/escape.txt", .{}));
+    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(std.Options.debug_io, fx.p("dest/good.txt"), .{}));
+    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(std.Options.debug_io, fx.p("escape.txt"), .{}));
 }
 
 test "extractTarXzFile rejects tar-slip and leaves dest untouched" {
-    const base = "/tmp/malt_archive_tarslip_tarxz";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, base);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    const dest = base ++ "/dest";
+    var fx = try Fixture.init("tarslip_tarxz");
+    defer fx.deinit();
+    const dest = fx.p("dest");
     try test_io.makeDirAbsolute(std.Options.debug_io, dest);
 
-    const src_dir = base ++ "/src";
+    const src_dir = fx.p("src");
     try test_io.makeDirAbsolute(std.Options.debug_io, src_dir);
     {
-        const f = try test_io.createFileAbsolute(std.Options.debug_io, src_dir ++ "/good.txt", .{});
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, fx.p("src/good.txt"), .{});
         try f.writeStreamingAll(std.Options.debug_io, "safe");
         f.close(std.Options.debug_io);
     }
     {
-        const f = try test_io.createFileAbsolute(std.Options.debug_io, src_dir ++ "/bad.txt", .{});
+        const f = try test_io.createFileAbsolute(std.Options.debug_io, fx.p("src/bad.txt"), .{});
         try f.writeStreamingAll(std.Options.debug_io, "hostile");
         f.close(std.Options.debug_io);
     }
 
-    const archive_path = base ++ "/hostile.tar.xz";
+    const archive_path = fx.p("hostile.tar.xz");
     try runCmd(&.{ "tar", "cJf", archive_path, "-C", src_dir, "-s", "|^bad.txt|../escape.txt|", "good.txt", "bad.txt" });
 
     var threaded = spawnIo();
     defer threaded.deinit();
     try testing.expectError(error.ExtractionFailed, archive.extractTarXzFile(threaded.io(), archive_path, dest));
-    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(std.Options.debug_io, dest ++ "/good.txt", .{}));
-    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(std.Options.debug_io, base ++ "/escape.txt", .{}));
+    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(std.Options.debug_io, fx.p("dest/good.txt"), .{}));
+    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(std.Options.debug_io, fx.p("escape.txt"), .{}));
 }
 
 test "extractTarGz rejects a symlink entry whose target escapes dest" {
-    const base = "/tmp/malt_archive_tarslip_targz_symlink";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, base);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    const dest = base ++ "/dest";
+    var fx = try Fixture.init("tarslip_targz_symlink");
+    defer fx.deinit();
+    const dest = fx.p("dest");
     try test_io.makeDirAbsolute(std.Options.debug_io, dest);
 
-    const src_dir = base ++ "/src";
+    const src_dir = fx.p("src");
     try test_io.makeDirAbsolute(std.Options.debug_io, src_dir);
-    try test_io.symLinkAbsolute(std.Options.debug_io, "/etc/passwd", src_dir ++ "/badlink", .{});
+    try test_io.symLinkAbsolute(std.Options.debug_io, "/etc/passwd", fx.p("src/badlink"), .{});
 
-    const archive_path = base ++ "/sym.tar.gz";
+    const archive_path = fx.p("sym.tar.gz");
     try runCmd(&.{ "tar", "czf", archive_path, "-C", src_dir, "badlink" });
 
     try testing.expectError(error.ExtractionFailed, archive.extractTarGz(std.Options.debug_io, archive_path, dest));
-    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(std.Options.debug_io, dest ++ "/badlink", .{}));
+    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(std.Options.debug_io, fx.p("dest/badlink"), .{}));
 }
 
 test "isSafeEntryPath rejects escape paths" {
@@ -624,12 +619,10 @@ test "extractTarGz accepts a symlink whose relative target stays inside dest" {
     // target resolves to a sibling within the extracted tree. Rejecting
     // these would break every Homebrew bottle that ships xctoolchain-style
     // cross-dir links.
-    const base = "/tmp/malt_archive_targz_intra_symlink";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, base);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("targz_intra_symlink");
+    defer fx.deinit();
 
-    const src_root = base ++ "/src";
+    const src_root = fx.p("src");
     try test_io.makeDirAbsolute(std.Options.debug_io, src_root);
     var src_dir = try test_io.openDirAbsolute(std.Options.debug_io, src_root, .{});
     defer {
@@ -652,14 +645,14 @@ test "extractTarGz accepts a symlink whose relative target stays inside dest" {
     }
     try usr_dir.symLink(std.Options.debug_io, "../../../bin", "bin", .{});
 
-    const archive_path = base ++ "/payload.tar.gz";
-    try runTar(&.{ "tar", "czf", archive_path, "-C", base, "src" });
+    const archive_path = fx.p("payload.tar.gz");
+    try runTar(&.{ "tar", "czf", archive_path, "-C", fx.base, "src" });
     try test_io.deleteTreeAbsolute(std.Options.debug_io, src_root);
 
-    try archive.extractTarGz(std.Options.debug_io, archive_path, base);
+    try archive.extractTarGz(std.Options.debug_io, archive_path, fx.base);
 
     var link_buf: [64]u8 = undefined;
-    var dest_dir = try test_io.openDirAbsolute(std.Options.debug_io, base, .{});
+    var dest_dir = try test_io.openDirAbsolute(std.Options.debug_io, fx.base, .{});
     defer {
         var dd = dest_dir;
         dd.close(std.Options.debug_io);

--- a/tests/atomic_test.zig
+++ b/tests/atomic_test.zig
@@ -25,6 +25,38 @@ fn unsetCache() void {
     _ = c.unsetenv("MALT_CACHE");
 }
 
+/// Scratch tree under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
+const Fixture = struct {
+    arena: std.heap.ArenaAllocator,
+    base: [:0]const u8,
+
+    fn init(tag: []const u8) !Fixture {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "atomic", tag);
+        const base_z = try arena.allocator().dupeZ(u8, base);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base_z) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, base_z);
+        return .{ .arena = arena, .base = base_z };
+    }
+
+    /// Absolute path to `sub` inside the fixture; valid until `deinit`.
+    fn p(self: *Fixture, sub: []const u8) [:0]const u8 {
+        return std.fmt.allocPrintSentinel(
+            self.arena.allocator(),
+            "{s}/{s}",
+            .{ self.base, sub },
+            0,
+        ) catch @panic("OOM");
+    }
+
+    fn deinit(self: *Fixture) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.base) catch {};
+        self.arena.deinit();
+    }
+};
+
 test "maltPrefixOrAbort returns default when env unset" {
     unsetPrefix();
     const got = atomic.maltPrefixOrAbort();
@@ -263,18 +295,16 @@ test "maltCacheDir honours MALT_CACHE env var" {
 }
 
 test "createTempDir creates a unique directory under the prefix and cleanup removes it" {
-    const base = "/tmp/malt_atomic_ctmp";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    test_io.makeDirAbsolute(std.Options.debug_io, base) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    setPrefix("/tmp/malt_atomic_ctmp");
+    var fx = try Fixture.init("ctmp");
+    defer fx.deinit();
+    setPrefix(fx.base);
     defer unsetPrefix();
 
     const dir = try atomic.createTempDir(std.Options.debug_io, testing.allocator, "label");
     defer testing.allocator.free(dir);
 
     // Must exist as an absolute dir under {prefix}/tmp/
-    try testing.expect(std.mem.startsWith(u8, dir, "/tmp/malt_atomic_ctmp/tmp/label_"));
+    try testing.expect(std.mem.startsWith(u8, dir, fx.p("tmp/label_")));
     var open_dir = try test_io.openDirAbsolute(std.Options.debug_io, dir, .{});
     open_dir.close(std.Options.debug_io);
 
@@ -283,13 +313,11 @@ test "createTempDir creates a unique directory under the prefix and cleanup remo
 }
 
 test "atomicRename moves a file within the same filesystem" {
-    const base = "/tmp/malt_atomic_rename";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    test_io.makeDirAbsolute(std.Options.debug_io, base) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("rename");
+    defer fx.deinit();
 
-    const src = "/tmp/malt_atomic_rename/src.txt";
-    const dst = "/tmp/malt_atomic_rename/dst.txt";
+    const src = fx.p("src.txt");
+    const dst = fx.p("dst.txt");
     const f = try test_io.createFileAbsolute(std.Options.debug_io, src, .{});
     try f.writeStreamingAll(std.Options.debug_io, "payload");
     f.close(std.Options.debug_io);
@@ -312,12 +340,10 @@ test "cleanupTempDir is a no-op on a non-existent path" {
 // file, never a partial write. These tests cover the observable
 // contract — fresh path, overwrite, no stale tempfile, missing parent.
 test "atomicWriteFile writes full payload to a fresh path" {
-    const base = "/tmp/malt_atomic_write_fresh";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, base);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("write_fresh");
+    defer fx.deinit();
 
-    const dst = base ++ "/cache.json";
+    const dst = fx.p("cache.json");
     try atomic.atomicWriteFile(std.Options.debug_io, dst, "{\"formulae\":[]}");
 
     const f = try test_io.openFileAbsolute(std.Options.debug_io, dst, .{});
@@ -328,12 +354,10 @@ test "atomicWriteFile writes full payload to a fresh path" {
 }
 
 test "atomicWriteFile replaces an existing file's contents in one step" {
-    const base = "/tmp/malt_atomic_write_replace";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, base);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("write_replace");
+    defer fx.deinit();
 
-    const dst = base ++ "/cache.json";
+    const dst = fx.p("cache.json");
     // Seed with old bytes so we can prove the replacement lands whole.
     {
         const f = try test_io.createFileAbsolute(std.Options.debug_io, dst, .{});
@@ -351,17 +375,15 @@ test "atomicWriteFile replaces an existing file's contents in one step" {
 }
 
 test "atomicWriteFile leaves no sibling .tmp files behind on success" {
-    const base = "/tmp/malt_atomic_write_no_tmp";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, base);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("write_no_tmp");
+    defer fx.deinit();
 
-    const dst = base ++ "/cache.json";
+    const dst = fx.p("cache.json");
     try atomic.atomicWriteFile(std.Options.debug_io, dst, "payload");
 
     // Only `cache.json` must remain — a stale tempfile would accumulate
     // across calls and eventually blow up a user's cache dir.
-    var dir = try test_io.openDirAbsolute(std.Options.debug_io, base, .{ .iterate = true });
+    var dir = try test_io.openDirAbsolute(std.Options.debug_io, fx.base, .{ .iterate = true });
     defer dir.close(std.Options.debug_io);
     var iter = dir.iterate();
     var count: usize = 0;
@@ -388,12 +410,10 @@ test "atomicWriteFile surfaces FileNotFound when the parent dir is missing" {
 // when its only caller (the macho/patcher) is refactored.
 
 test "atomicReplaceFile preserves the existing file's mode" {
-    const base = "/tmp/malt_atomic_replace_preserve";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, base);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("replace_preserve");
+    defer fx.deinit();
 
-    const dst = base ++ "/wrapper";
+    const dst = fx.p("wrapper");
     {
         const f = try test_io.createFileAbsolute(std.Options.debug_io, dst, .{});
         defer f.close(std.Options.debug_io);
@@ -415,12 +435,10 @@ test "atomicReplaceFile preserves the existing file's mode" {
 }
 
 test "atomicReplaceFile writes a fresh file when dst is missing" {
-    const base = "/tmp/malt_atomic_replace_fresh";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, base);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("replace_fresh");
+    defer fx.deinit();
 
-    const dst = base ++ "/new.txt";
+    const dst = fx.p("new.txt");
     try atomic.atomicReplaceFile(std.Options.debug_io, dst, "hello");
 
     const f = try test_io.openFileAbsolute(std.Options.debug_io, dst, .{});
@@ -434,11 +452,11 @@ test "atomicReplaceFile leaves the original intact when staging fails" {
     // Root would bypass the 0o555 the test relies on to fail the rename.
     if (std.c.geteuid() == 0) return error.SkipZigTest;
 
-    const base = "/tmp/malt_atomic_replace_intact";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, base);
+    // Declared first so its deleteTree runs after the unlock defer below.
+    var fx = try Fixture.init("replace_intact");
+    defer fx.deinit();
 
-    const dst = base ++ "/wrapper";
+    const dst = fx.p("wrapper");
     {
         const f = try test_io.createFileAbsolute(std.Options.debug_io, dst, .{});
         defer f.close(std.Options.debug_io);
@@ -447,19 +465,18 @@ test "atomicReplaceFile leaves the original intact when staging fails" {
 
     // Lock the parent so the helper cannot stage a sibling tempfile.
     {
-        var d = try test_io.openDirAbsolute(std.Options.debug_io, base, .{});
+        var d = try test_io.openDirAbsolute(std.Options.debug_io, fx.base, .{});
         defer d.close(std.Options.debug_io);
         const handle: std.Io.File = .{ .handle = d.handle, .flags = .{ .nonblocking = false } };
         handle.setPermissions(std.Options.debug_io, std.Io.File.Permissions.fromMode(0o555)) catch return error.SkipZigTest;
     }
     defer {
         unlock: {
-            var d = test_io.openDirAbsolute(std.Options.debug_io, base, .{}) catch break :unlock;
+            var d = test_io.openDirAbsolute(std.Options.debug_io, fx.base, .{}) catch break :unlock;
             defer d.close(std.Options.debug_io);
             const handle: std.Io.File = .{ .handle = d.handle, .flags = .{ .nonblocking = false } };
             handle.setPermissions(std.Options.debug_io, std.Io.File.Permissions.fromMode(0o755)) catch {};
         }
-        test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
     }
 
     // Whatever error the helper surfaces, the load-bearing invariant is
@@ -467,7 +484,7 @@ test "atomicReplaceFile leaves the original intact when staging fails" {
     _ = atomic.atomicReplaceFile(std.Options.debug_io, dst, "NEW") catch {};
 
     {
-        var d = try test_io.openDirAbsolute(std.Options.debug_io, base, .{});
+        var d = try test_io.openDirAbsolute(std.Options.debug_io, fx.base, .{});
         defer d.close(std.Options.debug_io);
         const handle: std.Io.File = .{ .handle = d.handle, .flags = .{ .nonblocking = false } };
         try handle.setPermissions(std.Options.debug_io, std.Io.File.Permissions.fromMode(0o755));
@@ -481,19 +498,17 @@ test "atomicReplaceFile leaves the original intact when staging fails" {
 }
 
 test "atomicRename moves a directory tree within the same filesystem" {
-    const base = "/tmp/malt_atomic_rename_dir";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    test_io.makeDirAbsolute(std.Options.debug_io, base) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("rename_dir");
+    defer fx.deinit();
 
-    const src = "/tmp/malt_atomic_rename_dir/src";
-    const dst = "/tmp/malt_atomic_rename_dir/dst";
+    const src = fx.p("src");
+    const dst = fx.p("dst");
     try test_io.makeDirAbsolute(std.Options.debug_io, src);
 
     // Put a file inside so an accidental copy+delete fallback would be
     // observable — a plain `rename(2)` on a same-FS directory must not
     // drop child entries.
-    const child = "/tmp/malt_atomic_rename_dir/src/inner.txt";
+    const child = fx.p("src/inner.txt");
     {
         const f = try test_io.createFileAbsolute(std.Options.debug_io, child, .{});
         defer f.close(std.Options.debug_io);

--- a/tests/backup_cli_test.zig
+++ b/tests/backup_cli_test.zig
@@ -24,13 +24,11 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_backup_exec_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        // Process-unique: a bare timestamp collides between overlapping runs.
+        const raw = try test_io.uniqueTempPath(allocator, "backup_exec", tag);
+        defer allocator.free(raw);
+        const path = try allocator.dupeZ(u8, raw);
+        errdefer allocator.free(path);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});
@@ -126,11 +124,14 @@ test "execute --output without a value is rejected" {
 test "execute fails fast when the database is unopenable" {
     // No DB file pre-created and no db/ dir means SQLite cannot create
     // the file (no parent). That's the DatabaseError branch.
-    const path = "/tmp/malt_backup_no_db_dir";
+    const raw = try test_io.uniqueTempPath(testing.allocator, "backup_cli", "no_db_dir");
+    defer testing.allocator.free(raw);
+    const path = try testing.allocator.dupeZ(u8, raw);
+    defer testing.allocator.free(path);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
-    _ = c.setenv("MALT_PREFIX", path, 1);
+    _ = c.setenv("MALT_PREFIX", path.ptr, 1);
     defer _ = c.unsetenv("MALT_PREFIX");
 
     quiet();

--- a/tests/bottle_download_test.zig
+++ b/tests/bottle_download_test.zig
@@ -77,12 +77,8 @@ fn runTar(argv: []const []const u8) !void {
     }
 }
 
-fn uniqueBase(suffix: []const u8) ![]u8 {
-    return std.fmt.allocPrint(
-        testing.allocator,
-        "/tmp/malt_bottle_dl_{d}_{s}",
-        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
-    );
+fn uniqueBase(suffix: []const u8) ![]const u8 {
+    return test_io.uniqueTempPath(testing.allocator, "bottle_dl", suffix);
 }
 
 fn hexSha(bytes: []const u8) [64]u8 {

--- a/tests/bottle_test.zig
+++ b/tests/bottle_test.zig
@@ -197,11 +197,7 @@ test "MismatchInfo formats cleanly through the worker's log template" {
 
 test "body SHA check and verify agree on the same body's SHA" {
     const test_io = @import("test_io");
-    const path = try std.fmt.allocPrint(
-        testing.allocator,
-        "/tmp/malt_bottle_roundtrip_{d}",
-        .{test_io.nanoTimestamp(std.Options.debug_io)},
-    );
+    const path = try test_io.uniqueTempPath(testing.allocator, "bottle_roundtrip", "sha");
     defer testing.allocator.free(path);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
 

--- a/tests/bundle_cleanup_test.zig
+++ b/tests/bundle_cleanup_test.zig
@@ -16,7 +16,10 @@ test "cli bundle cleanup --dry-run plans removal without dispatching" {
     // We can't inject a fake dispatcher through `cli_bundle.execute`, so
     // dry-run is the proof — any uninstall would mutate the database, and
     // we assert it stays intact.
-    const dir_z: [:0]const u8 = "/tmp/malt_bundle_cleanup_cli_dry_run";
+    const dir = try test_io.uniqueTempPath(testing.allocator, "bundle_cleanup", "cli_dry_run");
+    defer testing.allocator.free(dir);
+    const dir_z = try testing.allocator.dupeZ(u8, dir);
+    defer testing.allocator.free(dir_z);
     test_io.deleteTreeAbsolute(std.Options.debug_io, dir_z) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, dir_z);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, dir_z) catch {};

--- a/tests/bundle_cli_test.zig
+++ b/tests/bundle_cli_test.zig
@@ -25,13 +25,9 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_bundle_cli_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "bundle_cli", tag);
+        defer allocator.free(base);
+        const path = try allocator.dupeZ(u8, base);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});

--- a/tests/bundle_test.zig
+++ b/tests/bundle_test.zig
@@ -15,12 +15,17 @@ const install = malt.install;
 const install_sink = malt.install_sink;
 const output = malt.output;
 
+/// Scratch DB under a process-unique dir, so overlapping test runs cannot
+/// wipe each other's fixtures.
 const TempDb = struct {
+    arena: std.heap.ArenaAllocator,
     dir: []const u8,
     db: sqlite.Database,
 
-    fn init(comptime tag: []const u8) !TempDb {
-        const dir = "/tmp/malt_bundle_test_" ++ tag;
+    fn init(tag: []const u8) !TempDb {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const dir = try test_io.uniqueTempPath(arena.allocator(), "bundle", tag);
         test_io.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
         try test_io.makeDirAbsolute(std.Options.debug_io, dir);
         var db_path_buf: [256]u8 = undefined;
@@ -28,12 +33,13 @@ const TempDb = struct {
         var db = try sqlite.Database.open(db_path);
         errdefer db.close();
         try schema.initSchema(&db);
-        return .{ .dir = dir, .db = db };
+        return .{ .arena = arena, .dir = dir, .db = db };
     }
 
     fn deinit(self: *TempDb) void {
         self.db.close();
         test_io.deleteTreeAbsolute(std.Options.debug_io, self.dir) catch {};
+        self.arena.deinit();
     }
 };
 
@@ -345,7 +351,10 @@ test "bundle install honors the global --dry-run flag set by main.zig" {
     // `cmdInstall`, so the local arm never fires and the runner ran with
     // `dry_run = false`. Pin the contract: when `output.isDryRun()` is true,
     // the runner must skip `recordBundle`, leaving the `bundles` table empty.
-    const dir_z: [:0]const u8 = "/tmp/malt_bundle_dry_run_cli_wire";
+    const dir = try test_io.uniqueTempPath(testing.allocator, "bundle", "dry_run_cli_wire");
+    defer testing.allocator.free(dir);
+    const dir_z = try testing.allocator.dupeZ(u8, dir);
+    defer testing.allocator.free(dir_z);
     test_io.deleteTreeAbsolute(std.Options.debug_io, dir_z) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, dir_z);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, dir_z) catch {};

--- a/tests/cask_extra_test.zig
+++ b/tests/cask_extra_test.zig
@@ -18,6 +18,38 @@ fn testEnviron() std.process.Environ {
     return malt.app_ctx.processEnviron();
 }
 
+/// Scratch tree under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
+const Fixture = struct {
+    arena: std.heap.ArenaAllocator,
+    base: [:0]const u8,
+
+    fn init(tag: []const u8) !Fixture {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "cask_extra", tag);
+        const base_z = try arena.allocator().dupeZ(u8, base);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base_z) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, base_z);
+        return .{ .arena = arena, .base = base_z };
+    }
+
+    /// Absolute path to `sub` inside the fixture; valid until `deinit`.
+    fn p(self: *Fixture, sub: []const u8) [:0]const u8 {
+        return std.fmt.allocPrintSentinel(
+            self.arena.allocator(),
+            "{s}/{s}",
+            .{ self.base, sub },
+            0,
+        ) catch @panic("OOM");
+    }
+
+    fn deinit(self: *Fixture) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.base) catch {};
+        self.arena.deinit();
+    }
+};
+
 test "isAppRunningPub returns false for a path no pgrep match can cover" {
     // An impossible sentinel path — pgrep will not match, so isAppRunning
     // exits non-zero and the wrapper returns false.
@@ -97,12 +129,9 @@ test "CaskInstaller.uninstall refuses with AppRunning while the app bundle is li
     defer db.close();
     try schema.initSchema(&db);
 
-    const base = "/tmp/malt_cask_running_test";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, base);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    const app_path_z = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/Running.app", .{base}, 0);
-    defer testing.allocator.free(app_path_z);
+    var bundle = try Fixture.init("running_bundle");
+    defer bundle.deinit();
+    const app_path_z = bundle.p("Running.app");
     try test_io.makeDirAbsolute(std.Options.debug_io, app_path_z);
     try cask.recordInstall(&db, &c, app_path_z, null);
 
@@ -126,10 +155,9 @@ test "CaskInstaller.uninstall refuses with AppRunning while the app bundle is li
     var tries: usize = 0;
     while (tries < 300 and !cask.CaskInstaller.isAppRunningPub(io, app_path_z)) : (tries += 1) {}
 
-    const prefix: [:0]const u8 = "/tmp/mc-running";
-    test_io.cwd().createDirPath(std.Options.debug_io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
-    var installer = cask.CaskInstaller.init(io, testEnviron(), testing.allocator, &db, prefix);
+    var fx = try Fixture.init("running_prefix");
+    defer fx.deinit();
+    var installer = cask.CaskInstaller.init(io, testEnviron(), testing.allocator, &db, fx.base);
     // Distinct from UninstallFailed so the CLI can say "the app is running".
     try testing.expectError(cask.CaskError.AppRunning, installer.uninstall("running-app"));
 }
@@ -181,18 +209,18 @@ test "artifact_type_override bypasses URL detection" {
     defer db.close();
     try schema.initSchema(&db);
 
-    const prefix: [:0]const u8 = "/tmp/mc4";
+    var fx = try Fixture.init("override");
+    defer fx.deinit();
     var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
     defer threaded.deinit();
-    var installer = cask.CaskInstaller.init(threaded.io(), testEnviron(), testing.allocator, &db, prefix);
+    var installer = cask.CaskInstaller.init(threaded.io(), testEnviron(), testing.allocator, &db, fx.base);
 
     // Without override: fails at the type gate with InstallFailed
     try testing.expectError(cask.CaskError.InstallFailed, installer.install(&c));
 
     // With override: passes the type gate (gets further before failing)
     installer.artifact_type_override = .dmg;
-    test_io.cwd().createDirPath(std.Options.debug_io, prefix ++ "/cache/Cask") catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    test_io.cwd().createDirPath(std.Options.debug_io, fx.p("cache/Cask")) catch {};
     const result = installer.install(&c);
     // Should fail on download, not on the type gate
     try testing.expectError(cask.CaskError.DownloadFailed, result);
@@ -216,18 +244,10 @@ test "CaskInstaller.uninstall propagates removeRecord SqliteError" {
     defer db.close();
     try schema.initSchema(&db);
 
-    const base = "/tmp/malt_cask_uninstall_readonly_test";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, base);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var bundle = try Fixture.init("uninstall_readonly_bundle");
+    defer bundle.deinit();
 
-    const app_path_z = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "{s}/Firefox.app",
-        .{base},
-        0,
-    );
-    defer testing.allocator.free(app_path_z);
+    const app_path_z = bundle.p("Firefox.app");
     try test_io.makeDirAbsolute(std.Options.debug_io, app_path_z);
 
     try cask.recordInstall(&db, &c, app_path_z, null);
@@ -236,12 +256,11 @@ test "CaskInstaller.uninstall propagates removeRecord SqliteError" {
     // the previously-swallowed `removeRecord` call.
     try db.exec("PRAGMA query_only=ON;");
 
-    const prefix: [:0]const u8 = "/tmp/mc-uninstall-readonly";
-    test_io.cwd().createDirPath(std.Options.debug_io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    var fx = try Fixture.init("uninstall_readonly_prefix");
+    defer fx.deinit();
     var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
     defer threaded.deinit();
-    var installer = cask.CaskInstaller.init(threaded.io(), testEnviron(), testing.allocator, &db, prefix);
+    var installer = cask.CaskInstaller.init(threaded.io(), testEnviron(), testing.allocator, &db, fx.base);
 
     try testing.expectError(sqlite.SqliteError.StepFailed, installer.uninstall("firefox"));
 }
@@ -261,29 +280,20 @@ test "CaskInstaller.uninstall removes app_path, caskroom, cache, and the DB row"
     try schema.initSchema(&db);
 
     // Stage a scratch "app bundle" that uninstall will try to delete.
-    const base = "/tmp/malt_cask_uninstall_test";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, base);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var bundle = try Fixture.init("uninstall_bundle");
+    defer bundle.deinit();
 
-    const app_path_z = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "{s}/Firefox.app",
-        .{base},
-        0,
-    );
-    defer testing.allocator.free(app_path_z);
+    const app_path_z = bundle.p("Firefox.app");
     try test_io.makeDirAbsolute(std.Options.debug_io, app_path_z);
 
     try cask.recordInstall(&db, &c, app_path_z, null);
     try testing.expect(cask.isInstalled(&db, "firefox"));
 
-    const prefix: [:0]const u8 = "/tmp/mc-uninstall";
-    test_io.cwd().createDirPath(std.Options.debug_io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    var fx = try Fixture.init("uninstall_prefix");
+    defer fx.deinit();
     var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
     defer threaded.deinit();
-    var installer = cask.CaskInstaller.init(threaded.io(), testEnviron(), testing.allocator, &db, prefix);
+    var installer = cask.CaskInstaller.init(threaded.io(), testEnviron(), testing.allocator, &db, fx.base);
     try installer.uninstall("firefox");
 
     // DB row is gone and the staged "app bundle" has been removed.

--- a/tests/cask_font_install_test.zig
+++ b/tests/cask_font_install_test.zig
@@ -35,17 +35,49 @@ fn newInstaller(threaded: *std.Io.Threaded, db: *sqlite.Database, prefix: [:0]co
     return cask.CaskInstaller.init(threaded.io(), testEnviron(), testing.allocator, db, prefix);
 }
 
+/// Scratch tree under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
+const Fixture = struct {
+    arena: std.heap.ArenaAllocator,
+    base: [:0]const u8,
+
+    fn init(tag: []const u8) !Fixture {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "font_install", tag);
+        const base_z = try arena.allocator().dupeZ(u8, base);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base_z) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, base_z);
+        return .{ .arena = arena, .base = base_z };
+    }
+
+    /// Absolute path to `sub` inside the fixture; valid until `deinit`.
+    fn p(self: *Fixture, sub: []const u8) [:0]const u8 {
+        return std.fmt.allocPrintSentinel(
+            self.arena.allocator(),
+            "{s}/{s}",
+            .{ self.base, sub },
+            0,
+        ) catch @panic("OOM");
+    }
+
+    fn deinit(self: *Fixture) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.base) catch {};
+        self.arena.deinit();
+    }
+};
+
 test "placeExtracted routes a font cask: places files and returns the Caskroom manifest path" {
     const io = std.Options.debug_io;
     // Non-default prefix → resolveFontsDir lands in <prefix>/Fonts, isolating
     // the test from the real ~/Library/Fonts.
-    const prefix: [:0]const u8 = "/tmp/malt_font_install_it";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+    var fx = try Fixture.init("basic");
+    defer fx.deinit();
+    const prefix = fx.base;
 
-    const extract = prefix ++ "/extract";
-    try putFile(io, extract ++ "/ttf/FiraCode-Bold.ttf", "BOLD");
-    try putFile(io, extract ++ "/HackNerdFont-Regular.ttf", "HACK");
+    const extract = fx.p("extract");
+    try putFile(io, fx.p("extract/ttf/FiraCode-Bold.ttf"), "BOLD");
+    try putFile(io, fx.p("extract/HackNerdFont-Regular.ttf"), "HACK");
 
     const cask_json =
         \\{"token":"font-fira-code","name":["FiraCode"],"version":"6.2","desc":"","homepage":"",
@@ -67,29 +99,32 @@ test "placeExtracted routes a font cask: places files and returns the Caskroom m
     var installer = newInstaller(&threaded, &db, prefix);
 
     // app_dir is irrelevant on the font path; pass a scratch one.
-    const app_path = try installer.placeExtracted(extract, prefix ++ "/Applications", &c);
+    const app_path = try installer.placeExtracted(extract, fx.p("Applications"), &c);
     defer testing.allocator.free(app_path);
 
     // Returns the manifest path under Caskroom/<token>/<version>/.
-    try testing.expectEqualStrings(prefix ++ "/Caskroom/font-fira-code/6.2/" ++ cask_font.MANIFEST_NAME, app_path);
+    try testing.expectEqualStrings(fx.p("Caskroom/font-fira-code/6.2/" ++ cask_font.MANIFEST_NAME), app_path);
 
     // Both fonts placed by basename into <prefix>/Fonts.
-    const fonts = prefix ++ "/Fonts";
-    try expectFileBody(io, fonts ++ "/FiraCode-Bold.ttf", "BOLD");
-    try expectFileBody(io, fonts ++ "/HackNerdFont-Regular.ttf", "HACK");
+    const fira = fx.p("Fonts/FiraCode-Bold.ttf");
+    const hack = fx.p("Fonts/HackNerdFont-Regular.ttf");
+    try expectFileBody(io, fira, "BOLD");
+    try expectFileBody(io, hack, "HACK");
 
     // Manifest lists every placed absolute path, newline-joined.
-    try expectFileBody(io, app_path, fonts ++ "/FiraCode-Bold.ttf\n" ++ fonts ++ "/HackNerdFont-Regular.ttf");
+    const manifest_body = try std.fmt.allocPrint(testing.allocator, "{s}\n{s}", .{ fira, hack });
+    defer testing.allocator.free(manifest_body);
+    try expectFileBody(io, app_path, manifest_body);
 }
 
 test "placeExtracted prefers the font branch when a cask carries both app and font artifacts" {
     const io = std.Options.debug_io;
-    const prefix: [:0]const u8 = "/tmp/malt_font_install_mixed_it";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+    var fx = try Fixture.init("mixed");
+    defer fx.deinit();
+    const prefix = fx.base;
 
-    const extract = prefix ++ "/extract";
-    try putFile(io, extract ++ "/A.ttf", "AAA");
+    const extract = fx.p("extract");
+    try putFile(io, fx.p("extract/A.ttf"), "AAA");
 
     // A non-empty font stanza must win over a sibling app stanza so a font
     // cask never falls into the .app demand below it.
@@ -109,23 +144,23 @@ test "placeExtracted prefers the font branch when a cask carries both app and fo
     defer threaded.deinit();
     var installer = newInstaller(&threaded, &db, prefix);
 
-    const app_path = try installer.placeExtracted(extract, prefix ++ "/Applications", &c);
+    const app_path = try installer.placeExtracted(extract, fx.p("Applications"), &c);
     defer testing.allocator.free(app_path);
 
-    try testing.expectEqualStrings(prefix ++ "/Caskroom/mixed/3.0/" ++ cask_font.MANIFEST_NAME, app_path);
-    try expectFileBody(io, prefix ++ "/Fonts/A.ttf", "AAA");
+    try testing.expectEqualStrings(fx.p("Caskroom/mixed/3.0/" ++ cask_font.MANIFEST_NAME), app_path);
+    try expectFileBody(io, fx.p("Fonts/A.ttf"), "AAA");
 }
 
 test "placeExtracted drops a traversal entry and manifests only the safe font" {
     const io = std.Options.debug_io;
-    const prefix: [:0]const u8 = "/tmp/malt_font_install_evil_it";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+    var fx = try Fixture.init("evil");
+    defer fx.deinit();
+    const prefix = fx.base;
 
-    const extract = prefix ++ "/extract";
-    try putFile(io, extract ++ "/Good.ttf", "GOOD");
+    const extract = fx.p("extract");
+    try putFile(io, fx.p("extract/Good.ttf"), "GOOD");
     // A file the cask must never be able to reach via a `..` hop.
-    try putFile(io, prefix ++ "/secret", "SECRET");
+    try putFile(io, fx.p("secret"), "SECRET");
 
     const cask_json =
         \\{"token":"evil","name":["Evil"],"version":"1.0","desc":"","homepage":"",
@@ -143,25 +178,24 @@ test "placeExtracted drops a traversal entry and manifests only the safe font" {
     defer threaded.deinit();
     var installer = newInstaller(&threaded, &db, prefix);
 
-    const app_path = try installer.placeExtracted(extract, prefix ++ "/Applications", &c);
+    const app_path = try installer.placeExtracted(extract, fx.p("Applications"), &c);
     defer testing.allocator.free(app_path);
 
     // Only the safe font is placed and recorded; the `..` entry is skipped.
-    const fonts = prefix ++ "/Fonts";
-    try expectFileBody(io, app_path, fonts ++ "/Good.ttf");
-    try expectFileBody(io, fonts ++ "/Good.ttf", "GOOD");
-    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, fonts ++ "/secret", .{}));
+    try expectFileBody(io, app_path, fx.p("Fonts/Good.ttf"));
+    try expectFileBody(io, fx.p("Fonts/Good.ttf"), "GOOD");
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, fx.p("Fonts/secret"), .{}));
 }
 
 test "placeExtracted on an all-unsafe font cask places nothing and records an empty manifest" {
     const io = std.Options.debug_io;
-    const prefix: [:0]const u8 = "/tmp/malt_font_install_allevil_it";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+    var fx = try Fixture.init("allevil");
+    defer fx.deinit();
+    const prefix = fx.base;
 
-    const extract = prefix ++ "/extract";
-    try putFile(io, extract ++ "/decoy.ttf", "DECOY");
-    try putFile(io, prefix ++ "/secret", "SECRET");
+    const extract = fx.p("extract");
+    try putFile(io, fx.p("extract/decoy.ttf"), "DECOY");
+    try putFile(io, fx.p("secret"), "SECRET");
 
     // Every stanza is attacker-crafted: a `..` hop and an absolute path. The
     // worst case must be a no-op, never a traversal or a crash.
@@ -181,25 +215,25 @@ test "placeExtracted on an all-unsafe font cask places nothing and records an em
     defer threaded.deinit();
     var installer = newInstaller(&threaded, &db, prefix);
 
-    const app_path = try installer.placeExtracted(extract, prefix ++ "/Applications", &c);
+    const app_path = try installer.placeExtracted(extract, fx.p("Applications"), &c);
     defer testing.allocator.free(app_path);
 
     // A manifest is still written (the recorded app_path stays valid) but it
     // lists nothing, and no file escaped into the Fonts dir.
     try expectFileBody(io, app_path, "");
-    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, prefix ++ "/Fonts/secret", .{}));
-    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, prefix ++ "/Fonts/hosts", .{}));
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, fx.p("Fonts/secret"), .{}));
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, fx.p("Fonts/hosts"), .{}));
 }
 
 test "placeExtracted leaves a normal app zip on the .app path and writes no font manifest" {
     const io = std.Options.debug_io;
-    const prefix: [:0]const u8 = "/tmp/malt_font_install_app_it";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+    var fx = try Fixture.init("app");
+    defer fx.deinit();
+    const prefix = fx.base;
 
-    const extract = prefix ++ "/extract";
-    const app_dir = prefix ++ "/Applications";
-    try putFile(io, extract ++ "/Foo.app/Contents/Info.plist", "PLIST");
+    const extract = fx.p("extract");
+    const app_dir = fx.p("Applications");
+    try putFile(io, fx.p("extract/Foo.app/Contents/Info.plist"), "PLIST");
     try test_io.cwd().createDirPath(io, app_dir);
 
     const cask_json =
@@ -223,9 +257,9 @@ test "placeExtracted leaves a normal app zip on the .app path and writes no font
 
     // App branch: returns the promoted bundle path, whose contents are now
     // in place under app_dir.
-    try testing.expectEqualStrings(app_dir ++ "/Foo.app", app_path);
-    try expectFileBody(io, app_dir ++ "/Foo.app/Contents/Info.plist", "PLIST");
+    try testing.expectEqualStrings(fx.p("Applications/Foo.app"), app_path);
+    try expectFileBody(io, fx.p("Applications/Foo.app/Contents/Info.plist"), "PLIST");
 
     // The font dispatch did not fire: no Caskroom manifest was written.
-    try testing.expectError(error.FileNotFound, test_io.openDirAbsolute(io, prefix ++ "/Caskroom", .{}));
+    try testing.expectError(error.FileNotFound, test_io.openDirAbsolute(io, fx.p("Caskroom"), .{}));
 }

--- a/tests/cask_font_rollback_test.zig
+++ b/tests/cask_font_rollback_test.zig
@@ -42,14 +42,46 @@ fn newInstaller(threaded: *std.Io.Threaded, db: *sqlite.Database, prefix: [:0]co
     return cask.CaskInstaller.init(threaded.io(), testEnviron(), testing.allocator, db, prefix);
 }
 
+/// Scratch tree under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
+const Fixture = struct {
+    arena: std.heap.ArenaAllocator,
+    base: [:0]const u8,
+
+    fn init(tag: []const u8) !Fixture {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "font_rollback", tag);
+        const base_z = try arena.allocator().dupeZ(u8, base);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base_z) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, base_z);
+        return .{ .arena = arena, .base = base_z };
+    }
+
+    /// Absolute path to `sub` inside the fixture; valid until `deinit`.
+    fn p(self: *Fixture, sub: []const u8) [:0]const u8 {
+        return std.fmt.allocPrintSentinel(
+            self.arena.allocator(),
+            "{s}/{s}",
+            .{ self.base, sub },
+            0,
+        ) catch @panic("OOM");
+    }
+
+    fn deinit(self: *Fixture) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.base) catch {};
+        self.arena.deinit();
+    }
+};
+
 test "placeExtracted honors font_entries_override on an artifact-less cask" {
     const io = std.Options.debug_io;
-    const prefix: [:0]const u8 = "/tmp/malt_font_rollback_override_it";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+    var fx = try Fixture.init("override");
+    defer fx.deinit();
+    const prefix = fx.base;
 
-    const extract = prefix ++ "/extract";
-    try putFile(io, extract ++ "/ttf/A.ttf", "AAA");
+    const extract = fx.p("extract");
+    try putFile(io, fx.p("extract/ttf/A.ttf"), "AAA");
 
     var c = try cask.parseCask(testing.allocator, synthetic_json);
     defer c.deinit();
@@ -68,11 +100,11 @@ test "placeExtracted honors font_entries_override on an artifact-less cask" {
     const entries = [_]cask_font.FontEntry{.{ .source = "ttf/A.ttf", .target = null }};
     installer.font_entries_override = &entries;
 
-    const app_path = try installer.placeExtracted(extract, prefix ++ "/Applications", &c);
+    const app_path = try installer.placeExtracted(extract, fx.p("Applications"), &c);
     defer testing.allocator.free(app_path);
 
-    try testing.expectEqualStrings(prefix ++ "/Caskroom/font-x/1.0/" ++ cask_font.MANIFEST_NAME, app_path);
-    try expectFileBody(io, prefix ++ "/Fonts/A.ttf", "AAA");
+    try testing.expectEqualStrings(fx.p("Caskroom/font-x/1.0/" ++ cask_font.MANIFEST_NAME), app_path);
+    try expectFileBody(io, fx.p("Fonts/A.ttf"), "AAA");
 }
 
 const font_cask_json =
@@ -86,13 +118,13 @@ const font_cask_json =
 
 test "font_entries_override is re-sanitized: a tampered sidecar entry cannot traverse" {
     const io = std.Options.debug_io;
-    const prefix: [:0]const u8 = "/tmp/malt_font_rollback_tamper_it";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+    var fx = try Fixture.init("tamper");
+    defer fx.deinit();
+    const prefix = fx.base;
 
-    const extract = prefix ++ "/extract";
-    try putFile(io, extract ++ "/Good.ttf", "GOOD");
-    try putFile(io, prefix ++ "/secret", "SECRET");
+    const extract = fx.p("extract");
+    try putFile(io, fx.p("extract/Good.ttf"), "GOOD");
+    try putFile(io, fx.p("secret"), "SECRET");
 
     var c = try cask.parseCask(testing.allocator, synthetic_json);
     defer c.deinit();
@@ -113,23 +145,22 @@ test "font_entries_override is re-sanitized: a tampered sidecar entry cannot tra
     };
     installer.font_entries_override = &entries;
 
-    const app_path = try installer.placeExtracted(extract, prefix ++ "/Applications", &c);
+    const app_path = try installer.placeExtracted(extract, fx.p("Applications"), &c);
     defer testing.allocator.free(app_path);
 
-    const fonts = prefix ++ "/Fonts";
-    try expectFileBody(io, fonts ++ "/Good.ttf", "GOOD");
-    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, fonts ++ "/secret", .{}));
+    try expectFileBody(io, fx.p("Fonts/Good.ttf"), "GOOD");
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, fx.p("Fonts/secret"), .{}));
 }
 
 test "a fresh font install persists a per-version sidecar that round-trips the stanzas" {
     const io = std.Options.debug_io;
-    const prefix: [:0]const u8 = "/tmp/malt_font_rollback_sidecar_it";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+    var fx = try Fixture.init("sidecar");
+    defer fx.deinit();
+    const prefix = fx.base;
 
-    const extract = prefix ++ "/extract";
-    try putFile(io, extract ++ "/ttf/A.ttf", "AAA");
-    try putFile(io, extract ++ "/B.ttf", "BBB");
+    const extract = fx.p("extract");
+    try putFile(io, fx.p("extract/ttf/A.ttf"), "AAA");
+    try putFile(io, fx.p("extract/B.ttf"), "BBB");
 
     var c = try cask.parseCask(testing.allocator, font_cask_json);
     defer c.deinit();
@@ -144,7 +175,7 @@ test "a fresh font install persists a per-version sidecar that round-trips the s
 
     // Installing (the font branch) must persist the stanzas next to the cached
     // artifact so a later rollback can restore them offline, JSON-free.
-    const app_path = try installer.placeExtracted(extract, prefix ++ "/Applications", &c);
+    const app_path = try installer.placeExtracted(extract, fx.p("Applications"), &c);
     defer testing.allocator.free(app_path);
 
     var spec = (try installer.readFontSpec("font-x", "1.0")).?;
@@ -167,20 +198,19 @@ fn readSpecUnderOom(alloc: std.mem.Allocator, db: *sqlite.Database, prefix: [:0]
 
 test "readFontSpec frees its buffers on allocation failure" {
     const io = std.Options.debug_io;
-    const prefix: [:0]const u8 = "/tmp/malt_font_rollback_oom_it";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
-    try putFile(io, prefix ++ "/cache/Cask/font-x-1.0.fonts", "ttf/A.ttf\t/x/Renamed.ttf\nB.ttf\n");
+    var fx = try Fixture.init("oom");
+    defer fx.deinit();
+    try putFile(io, fx.p("cache/Cask/font-x-1.0.fonts"), "ttf/A.ttf\t/x/Renamed.ttf\nB.ttf\n");
 
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
-    try testing.checkAllAllocationFailures(testing.allocator, readSpecUnderOom, .{ &db, prefix });
+    try testing.checkAllAllocationFailures(testing.allocator, readSpecUnderOom, .{ &db, fx.base });
 }
 
 test "readFontSpec returns null when no sidecar was written" {
-    const prefix: [:0]const u8 = "/tmp/malt_font_rollback_nospec_it";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    var fx = try Fixture.init("nospec");
+    defer fx.deinit();
+    const prefix = fx.base;
 
     var db = try sqlite.Database.open(":memory:");
     defer db.close();

--- a/tests/cask_font_uninstall_test.zig
+++ b/tests/cask_font_uninstall_test.zig
@@ -34,19 +34,54 @@ fn newInstaller(threaded: *std.Io.Threaded, db: *sqlite.Database, prefix: [:0]co
     return cask.CaskInstaller.init(threaded.io(), testEnviron(), testing.allocator, db, prefix);
 }
 
+/// Scratch tree under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
+const Fixture = struct {
+    arena: std.heap.ArenaAllocator,
+    base: [:0]const u8,
+
+    fn init(tag: []const u8) !Fixture {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "font_uninstall", tag);
+        const base_z = try arena.allocator().dupeZ(u8, base);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base_z) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, base_z);
+        return .{ .arena = arena, .base = base_z };
+    }
+
+    /// Absolute path to `sub` inside the fixture; valid until `deinit`.
+    fn p(self: *Fixture, sub: []const u8) [:0]const u8 {
+        return std.fmt.allocPrintSentinel(
+            self.arena.allocator(),
+            "{s}/{s}",
+            .{ self.base, sub },
+            0,
+        ) catch @panic("OOM");
+    }
+
+    fn deinit(self: *Fixture) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.base) catch {};
+        self.arena.deinit();
+    }
+};
+
 test "uninstall unlinks every font listed in the manifest, then drops Caskroom and the DB row" {
     const io = std.Options.debug_io;
-    const prefix: [:0]const u8 = "/tmp/malt_font_uninstall_it";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+    var fx = try Fixture.init("basic");
+    defer fx.deinit();
+    const prefix = fx.base;
 
     // Reconstruct the post-install on-disk state without driving a real
     // install: two placed fonts plus the manifest that records them.
-    const fonts = prefix ++ "/Fonts";
-    try putFile(io, fonts ++ "/A.ttf", "AAA");
-    try putFile(io, fonts ++ "/B.ttf", "BBB");
-    const manifest_path = prefix ++ "/Caskroom/font-x/1.0/" ++ cask_font.MANIFEST_NAME;
-    try cask_font.writeManifest(io, manifest_path, fonts ++ "/A.ttf\n" ++ fonts ++ "/B.ttf");
+    const font_a = fx.p("Fonts/A.ttf");
+    const font_b = fx.p("Fonts/B.ttf");
+    try putFile(io, font_a, "AAA");
+    try putFile(io, font_b, "BBB");
+    const manifest_path = fx.p("Caskroom/font-x/1.0/" ++ cask_font.MANIFEST_NAME);
+    const manifest_body = try std.fmt.allocPrint(testing.allocator, "{s}\n{s}", .{ font_a, font_b });
+    defer testing.allocator.free(manifest_body);
+    try cask_font.writeManifest(io, manifest_path, manifest_body);
 
     var c = try cask.parseCask(testing.allocator, font_cask_json);
     defer c.deinit();
@@ -65,27 +100,29 @@ test "uninstall unlinks every font listed in the manifest, then drops Caskroom a
 
     // Every manifested font is gone, the Caskroom (and the manifest) is wiped,
     // and the DB row is cleared.
-    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, fonts ++ "/A.ttf", .{}));
-    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, fonts ++ "/B.ttf", .{}));
-    try testing.expectError(error.FileNotFound, test_io.openDirAbsolute(io, prefix ++ "/Caskroom/font-x", .{}));
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, font_a, .{}));
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, font_b, .{}));
+    try testing.expectError(error.FileNotFound, test_io.openDirAbsolute(io, fx.p("Caskroom/font-x"), .{}));
     try testing.expect(!cask.isInstalled(&db, "font-x"));
 }
 
 test "uninstall removes only manifested fonts and tolerates a stale entry" {
     const io = std.Options.debug_io;
-    const prefix: [:0]const u8 = "/tmp/malt_font_uninstall_precise_it";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+    var fx = try Fixture.init("precise");
+    defer fx.deinit();
+    const prefix = fx.base;
 
-    const fonts = prefix ++ "/Fonts";
-    try putFile(io, fonts ++ "/A.ttf", "AAA"); // manifested, present
-    try putFile(io, fonts ++ "/Keep.ttf", "KEEP"); // a co-resident font from another cask
+    const font_a = fx.p("Fonts/A.ttf");
+    try putFile(io, font_a, "AAA"); // manifested, present
+    try putFile(io, fx.p("Fonts/Keep.ttf"), "KEEP"); // a co-resident font from another cask
 
     // The manifest also lists a font that was already manually deleted; the
     // stale entry must not abort uninstall, and Keep.ttf (never recorded here)
     // must survive — the manifest is the exact record of what this cask placed.
-    const manifest_path = prefix ++ "/Caskroom/font-x/1.0/" ++ cask_font.MANIFEST_NAME;
-    try cask_font.writeManifest(io, manifest_path, fonts ++ "/A.ttf\n" ++ fonts ++ "/Gone.ttf");
+    const manifest_path = fx.p("Caskroom/font-x/1.0/" ++ cask_font.MANIFEST_NAME);
+    const manifest_body = try std.fmt.allocPrint(testing.allocator, "{s}\n{s}", .{ font_a, fx.p("Fonts/Gone.ttf") });
+    defer testing.allocator.free(manifest_body);
+    try cask_font.writeManifest(io, manifest_path, manifest_body);
 
     var c = try cask.parseCask(testing.allocator, font_cask_json);
     defer c.deinit();
@@ -101,8 +138,8 @@ test "uninstall removes only manifested fonts and tolerates a stale entry" {
 
     try installer.uninstall("font-x");
 
-    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, fonts ++ "/A.ttf", .{}));
-    try expectKept(io, fonts ++ "/Keep.ttf", "KEEP");
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(io, font_a, .{}));
+    try expectKept(io, fx.p("Fonts/Keep.ttf"), "KEEP");
     try testing.expect(!cask.isInstalled(&db, "font-x"));
 }
 
@@ -113,15 +150,14 @@ fn expectKept(io: std.Io, path: []const u8, body: []const u8) !void {
 }
 
 test "uninstall survives a missing manifest and still clears the DB row" {
-    const io = std.Options.debug_io;
-    const prefix: [:0]const u8 = "/tmp/malt_font_uninstall_drift_it";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
+    var fx = try Fixture.init("drift");
+    defer fx.deinit();
+    const prefix = fx.base;
 
     // The Caskroom (and its manifest) was manually nuked: app_path points at a
     // manifest that no longer exists. Uninstall must treat this as "nothing to
     // unlink" and still finish cleaning the DB row.
-    const manifest_path = prefix ++ "/Caskroom/font-x/1.0/" ++ cask_font.MANIFEST_NAME;
+    const manifest_path = fx.p("Caskroom/font-x/1.0/" ++ cask_font.MANIFEST_NAME);
 
     var c = try cask.parseCask(testing.allocator, font_cask_json);
     defer c.deinit();

--- a/tests/cask_test.zig
+++ b/tests/cask_test.zig
@@ -15,6 +15,38 @@ fn testIo() std.Io {
     return std.Options.debug_io;
 }
 
+/// Scratch tree under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
+const Fixture = struct {
+    arena: std.heap.ArenaAllocator,
+    base: [:0]const u8,
+
+    fn init(tag: []const u8) !Fixture {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "cask", tag);
+        const base_z = try arena.allocator().dupeZ(u8, base);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base_z) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, base_z);
+        return .{ .arena = arena, .base = base_z };
+    }
+
+    /// Absolute path to `sub` inside the fixture; valid until `deinit`.
+    fn p(self: *Fixture, sub: []const u8) [:0]const u8 {
+        return std.fmt.allocPrintSentinel(
+            self.arena.allocator(),
+            "{s}/{s}",
+            .{ self.base, sub },
+            0,
+        ) catch @panic("OOM");
+    }
+
+    fn deinit(self: *Fixture) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.base) catch {};
+        self.arena.deinit();
+    }
+};
+
 // --- artifactTypeFromUrl ---
 
 test "artifactTypeFromUrl detects .dmg" {
@@ -123,16 +155,11 @@ const test_cask_json_v2 =
     \\}
 ;
 
-fn openTempCaskDb(comptime tag: []const u8) !struct { dir: []const u8, db: sqlite.Database } {
-    const dir = "/tmp/malt_cask_recordinstall_" ++ tag;
-    test_io.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, dir);
-    var buf: [256]u8 = undefined;
-    const path = try std.fmt.bufPrintSentinel(&buf, "{s}/test.db", .{dir}, 0);
-    var db = try sqlite.Database.open(path);
+fn openTempCaskDb(fx: *Fixture) !sqlite.Database {
+    var db = try sqlite.Database.open(fx.p("test.db"));
     errdefer db.close();
     try schema.initSchema(&db);
-    return .{ .dir = dir, .db = db };
+    return db;
 }
 
 fn readCaskPinned(db: *sqlite.Database, token: []const u8) !bool {
@@ -145,39 +172,37 @@ fn readCaskPinned(db: *sqlite.Database, token: []const u8) !bool {
 }
 
 test "recordInstall preserves an existing pinned flag (force-upgrade keeps the hold)" {
-    var t = try openTempCaskDb("preserve_pin");
-    defer {
-        t.db.close();
-        test_io.deleteTreeAbsolute(std.Options.debug_io, t.dir) catch {};
-    }
+    var fx = try Fixture.init("recordinstall_preserve_pin");
+    defer fx.deinit();
+    var db = try openTempCaskDb(&fx);
+    defer db.close();
 
     // Seed firefox at version 1 with pinned = 1.
-    try t.db.exec(
+    try db.exec(
         \\INSERT INTO casks (token, name, version, url, pinned)
         \\VALUES ('firefox', 'Firefox', '123.0', 'https://example.invalid', 1);
     );
-    try std.testing.expectEqual(true, try readCaskPinned(&t.db, "firefox"));
+    try std.testing.expectEqual(true, try readCaskPinned(&db, "firefox"));
 
     // Simulate a force-upgrade rewriting the row at version 200.
     var c2 = try cask.parseCask(std.testing.allocator, test_cask_json_v2);
     defer c2.deinit();
-    try cask.recordInstall(&t.db, &c2, "/Applications/Firefox.app", null);
+    try cask.recordInstall(&db, &c2, "/Applications/Firefox.app", null);
 
-    try std.testing.expectEqual(true, try readCaskPinned(&t.db, "firefox"));
+    try std.testing.expectEqual(true, try readCaskPinned(&db, "firefox"));
 }
 
 test "recordInstall on a fresh cask defaults pinned to 0" {
-    var t = try openTempCaskDb("fresh_pin");
-    defer {
-        t.db.close();
-        test_io.deleteTreeAbsolute(std.Options.debug_io, t.dir) catch {};
-    }
+    var fx = try Fixture.init("recordinstall_fresh_pin");
+    defer fx.deinit();
+    var db = try openTempCaskDb(&fx);
+    defer db.close();
 
     var c2 = try cask.parseCask(std.testing.allocator, test_cask_json_v2);
     defer c2.deinit();
-    try cask.recordInstall(&t.db, &c2, "/Applications/Firefox.app", null);
+    try cask.recordInstall(&db, &c2, "/Applications/Firefox.app", null);
 
-    try std.testing.expectEqual(false, try readCaskPinned(&t.db, "firefox"));
+    try std.testing.expectEqual(false, try readCaskPinned(&db, "firefox"));
 }
 
 // --- parseAppName ---
@@ -451,9 +476,10 @@ test "isOutdated surfaces SqliteError when schema is missing" {
 const CHUNK: usize = 64 * 1024;
 
 fn tempFilePath(tag: []const u8, buf: []u8) ![]const u8 {
-    return std.fmt.bufPrint(buf, "/tmp/malt_cask_verify_{s}_{d}", .{ tag, malt_fs.nanoTimestamp(
-        std.Options.debug_io,
-    ) });
+    // Process-unique: a bare timestamp collides between overlapping runs.
+    const p = try test_io.uniqueTempPath(testing.allocator, "cask_verify", tag);
+    defer testing.allocator.free(p);
+    return std.fmt.bufPrint(buf, "{s}", .{p});
 }
 
 fn writeFile(path: []const u8, bytes: []const u8) !void {
@@ -664,9 +690,10 @@ test "verifyFileSha256 propagates FileNotFound rather than Sha256Mismatch" {
 // ── findAppInDir: owns the returned name past iterator teardown ─────
 
 fn scratchDir(tag: []const u8, buf: []u8) ![]const u8 {
-    const p = try std.fmt.bufPrint(buf, "/tmp/malt_cask_findapp_{s}_{d}", .{ tag, malt_fs.nanoTimestamp(
-        std.Options.debug_io,
-    ) });
+    // Process-unique: a bare timestamp collides between overlapping runs.
+    const raw = try test_io.uniqueTempPath(testing.allocator, "cask_findapp", tag);
+    defer testing.allocator.free(raw);
+    const p = try std.fmt.bufPrint(buf, "{s}", .{raw});
     try malt_fs.makeDirAbsolute(std.Options.debug_io, p);
     return p;
 }
@@ -952,10 +979,9 @@ test "artifactTypeFromTag maps unknown strings to .unknown" {
 
 test "sweepOwnedVersionCache deletes only the token's own recorded versions" {
     const io = testIo();
-    const prefix = "/tmp/malt_cask_sweep";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
-    try test_io.cwd().createDirPath(io, prefix ++ "/cache/Cask");
+    var fx = try Fixture.init("sweep");
+    defer fx.deinit();
+    try test_io.cwd().createDirPath(io, fx.p("cache/Cask"));
 
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
@@ -966,10 +992,10 @@ test "sweepOwnedVersionCache deletes only the token's own recorded versions" {
     try cask.recordCaskVersion(&db, "git", "2.38.0", "u", "aa", "dmg", null);
 
     const seeds = [_][]const u8{
-        prefix ++ "/cache/Cask/git-2.39.0.dmg", // owned current — removed
-        prefix ++ "/cache/Cask/git-2.38.0.dmg", // owned rollback — removed
-        prefix ++ "/cache/Cask/git-lfs-2.0.dmg", // prefix sibling — must survive
-        prefix ++ "/cache/Cask/git.dmg", // legacy unprefixed — untouched here
+        fx.p("cache/Cask/git-2.39.0.dmg"), // owned current — removed
+        fx.p("cache/Cask/git-2.38.0.dmg"), // owned rollback — removed
+        fx.p("cache/Cask/git-lfs-2.0.dmg"), // prefix sibling — must survive
+        fx.p("cache/Cask/git.dmg"), // legacy unprefixed — untouched here
     };
     for (seeds) |p| {
         const f = try test_io.createFileAbsolute(io, p, .{ .truncate = true });
@@ -977,7 +1003,7 @@ test "sweepOwnedVersionCache deletes only the token's own recorded versions" {
         try f.writeStreamingAll(io, "x");
     }
 
-    cask.sweepOwnedVersionCache(io, &db, prefix, "git");
+    cask.sweepOwnedVersionCache(io, &db, fx.base, "git");
 
     // Recorded versions gone; the prefix sibling and legacy shape survive.
     try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, seeds[0], .{}));
@@ -998,10 +1024,9 @@ test "sweepOwnedVersionCache is a no-op when the token has no history rows" {
 
 test "sweepOwnedVersionCache handles a dash-bearing version without touching siblings" {
     const io = testIo();
-    const prefix = "/tmp/malt_cask_sweep_rev";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
-    try test_io.cwd().createDirPath(io, prefix ++ "/cache/Cask");
+    var fx = try Fixture.init("sweep_rev");
+    defer fx.deinit();
+    try test_io.cwd().createDirPath(io, fx.p("cache/Cask"));
 
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
@@ -1011,15 +1036,15 @@ test "sweepOwnedVersionCache handles a dash-bearing version without touching sib
     // the sibling token `git-lfs`. Exact `<token>-<version>` is the only signal.
     try cask.recordCaskVersion(&db, "git", "2.39.0-1", "u", "aa", "dmg", null);
 
-    const owned = prefix ++ "/cache/Cask/git-2.39.0-1.dmg";
-    const sibling = prefix ++ "/cache/Cask/git-lfs-2.0.dmg";
+    const owned = fx.p("cache/Cask/git-2.39.0-1.dmg");
+    const sibling = fx.p("cache/Cask/git-lfs-2.0.dmg");
     for ([_][]const u8{ owned, sibling }) |p| {
         const f = try test_io.createFileAbsolute(io, p, .{ .truncate = true });
         defer f.close(io);
         try f.writeStreamingAll(io, "x");
     }
 
-    cask.sweepOwnedVersionCache(io, &db, prefix, "git");
+    cask.sweepOwnedVersionCache(io, &db, fx.base, "git");
 
     try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, owned, .{}));
     try test_io.accessAbsolute(io, sibling, .{});
@@ -1027,10 +1052,9 @@ test "sweepOwnedVersionCache handles a dash-bearing version without touching sib
 
 test "sweepOwnedVersionCache sweeps a pre-v7 row with NULL artifact_type" {
     const io = testIo();
-    const prefix = "/tmp/malt_cask_sweep_null";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
-    try test_io.cwd().createDirPath(io, prefix ++ "/cache/Cask");
+    var fx = try Fixture.init("sweep_null");
+    defer fx.deinit();
+    try test_io.cwd().createDirPath(io, fx.p("cache/Cask"));
 
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
@@ -1042,14 +1066,14 @@ test "sweepOwnedVersionCache sweeps a pre-v7 row with NULL artifact_type" {
         \\VALUES ('git', '2.39.0', 'https://x.invalid/git.zip');
     );
 
-    const owned = prefix ++ "/cache/Cask/git-2.39.0.zip";
+    const owned = fx.p("cache/Cask/git-2.39.0.zip");
     {
         const f = try test_io.createFileAbsolute(io, owned, .{ .truncate = true });
         defer f.close(io);
         try f.writeStreamingAll(io, "x");
     }
 
-    cask.sweepOwnedVersionCache(io, &db, prefix, "git");
+    cask.sweepOwnedVersionCache(io, &db, fx.base, "git");
     try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, owned, .{}));
 }
 
@@ -1057,31 +1081,23 @@ test "sweepOwnedVersionCache sweeps a pre-v7 row with NULL artifact_type" {
 
 test "reinstallFromHistory refuses when no history row matches" {
     const io = testIo();
-    const prefix: [:0]const u8 = "/tmp/malt_cask_reinstall_missing";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
-    try test_io.cwd().createDirPath(io, prefix);
+    var fx = try Fixture.init("reinstall_missing");
+    defer fx.deinit();
 
-    var buf: [256]u8 = undefined;
-    const db_path = try std.fmt.bufPrintZ(&buf, "{s}/test.db", .{prefix});
-    var db = try sqlite.Database.open(db_path);
+    var db = try sqlite.Database.open(fx.p("test.db"));
     defer db.close();
     try schema.initSchema(&db);
 
-    var installer = cask.CaskInstaller.init(io, .empty, testing.allocator, &db, prefix);
+    var installer = cask.CaskInstaller.init(io, .empty, testing.allocator, &db, fx.base);
     try testing.expectError(cask.CaskError.InstallFailed, installer.reinstallFromHistory("missing-token", "1.0"));
 }
 
 test "reinstallFromHistory refuses on a history row whose artifact_type is unknown" {
     const io = testIo();
-    const prefix: [:0]const u8 = "/tmp/malt_cask_reinstall_unknown";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
-    try test_io.cwd().createDirPath(io, prefix);
+    var fx = try Fixture.init("reinstall_unknown");
+    defer fx.deinit();
 
-    var buf: [256]u8 = undefined;
-    const db_path = try std.fmt.bufPrintZ(&buf, "{s}/test.db", .{prefix});
-    var db = try sqlite.Database.open(db_path);
+    var db = try sqlite.Database.open(fx.p("test.db"));
     defer db.close();
     try schema.initSchema(&db);
 
@@ -1090,7 +1106,7 @@ test "reinstallFromHistory refuses on a history row whose artifact_type is unkno
         \\VALUES ('mystery', '1.0', 'https://x.invalid/m.bin', 'aa', 'unknown');
     );
 
-    var installer = cask.CaskInstaller.init(io, .empty, testing.allocator, &db, prefix);
+    var installer = cask.CaskInstaller.init(io, .empty, testing.allocator, &db, fx.base);
     try testing.expectError(cask.CaskError.InstallFailed, installer.reinstallFromHistory("mystery", "1.0"));
 }
 
@@ -1257,15 +1273,11 @@ test "lookupCaskVersion returns null when a required column is NULL" {
 
 test "uninstall removes per-version cache files and drops every cask_versions row" {
     const io = testIo();
-    const prefix: [:0]const u8 = "/tmp/malt_cask_uninstall_sweep";
-    test_io.deleteTreeAbsolute(io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(io, prefix) catch {};
-    try test_io.cwd().createDirPath(io, prefix);
-    try test_io.cwd().createDirPath(io, prefix ++ "/cache/Cask");
+    var fx = try Fixture.init("uninstall_sweep");
+    defer fx.deinit();
+    try test_io.cwd().createDirPath(io, fx.p("cache/Cask"));
 
-    var buf: [256]u8 = undefined;
-    const db_path = try std.fmt.bufPrintZ(&buf, "{s}/test.db", .{prefix});
-    var db = try sqlite.Database.open(db_path);
+    var db = try sqlite.Database.open(fx.p("test.db"));
     defer db.close();
     try schema.initSchema(&db);
 
@@ -1281,25 +1293,25 @@ test "uninstall removes per-version cache files and drops every cask_versions ro
         \\       ('flux-markdown', '1.32.427', 'u', 'aa', 'dmg');
     );
     for ([_][]const u8{
-        prefix ++ "/cache/Cask/flux-markdown-1.30.0.dmg",
-        prefix ++ "/cache/Cask/flux-markdown-1.32.427.dmg",
-        prefix ++ "/cache/Cask/flux-markdown.dmg", // legacy unprefixed
+        fx.p("cache/Cask/flux-markdown-1.30.0.dmg"),
+        fx.p("cache/Cask/flux-markdown-1.32.427.dmg"),
+        fx.p("cache/Cask/flux-markdown.dmg"), // legacy unprefixed
     }) |p| {
         const f = try test_io.createFileAbsolute(io, p, .{ .truncate = true });
         defer f.close(io);
         try f.writeStreamingAll(io, "x");
     }
 
-    var installer = cask.CaskInstaller.init(io, .empty, testing.allocator, &db, prefix);
+    var installer = cask.CaskInstaller.init(io, .empty, testing.allocator, &db, fx.base);
     // Uninstall paths the app via app_path; the test seed names a path
     // outside the sandbox so the real /Applications wipe is a no-op.
     installer.uninstall("flux-markdown") catch {};
 
     // Per-version + legacy cache files all gone.
     for ([_][]const u8{
-        prefix ++ "/cache/Cask/flux-markdown-1.30.0.dmg",
-        prefix ++ "/cache/Cask/flux-markdown-1.32.427.dmg",
-        prefix ++ "/cache/Cask/flux-markdown.dmg",
+        fx.p("cache/Cask/flux-markdown-1.30.0.dmg"),
+        fx.p("cache/Cask/flux-markdown-1.32.427.dmg"),
+        fx.p("cache/Cask/flux-markdown.dmg"),
     }) |p| {
         try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, p, .{}));
     }

--- a/tests/cleanup_cli_test.zig
+++ b/tests/cleanup_cli_test.zig
@@ -23,13 +23,9 @@ const ScratchPrefix = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !ScratchPrefix {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_cleanup_cli_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "cleanup_cli", tag);
+        defer allocator.free(base);
+        const path = try allocator.dupeZ(u8, base);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});
@@ -119,13 +115,9 @@ test "cleanup with no extra args matches purge --housekeeping byte-for-byte" {
 test "cleanup --help shows cleanup's help, not purge's" {
     const allocator = testing.allocator;
 
-    const ts = test_io.nanoTimestamp(std.Options.debug_io);
-    const path = try std.fmt.allocPrintSentinel(
-        allocator,
-        "/tmp/malt_cleanup_help_{d}",
-        .{ts},
-        0,
-    );
+    const base = try test_io.uniqueTempPath(allocator, "cleanup_help", "out");
+    defer allocator.free(base);
+    const path = try allocator.dupeZ(u8, base);
     defer allocator.free(path);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
 

--- a/tests/cli_services_test.zig
+++ b/tests/cli_services_test.zig
@@ -15,14 +15,9 @@ const c = struct {
 };
 
 fn setupPrefix(suffix: []const u8) ![:0]u8 {
-    const path = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "/tmp/malt_cli_services_{d}_{s}",
-        .{ test_io.nanoTimestamp(
-            std.Options.debug_io,
-        ), suffix },
-        0,
-    );
+    const base = try test_io.uniqueTempPath(testing.allocator, "cli_services", suffix);
+    defer testing.allocator.free(base);
+    const path = try testing.allocator.dupeZ(u8, base);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{path});
@@ -119,7 +114,10 @@ test "execute start/stop/restart with wrong arity returns InvalidArgs" {
 test "execute list --json on a prefix with no db/ directory emits `[]`" {
     // `openDb` auto-creates `db/` and the sqlite file. CI consumers piping
     // through `jq` need a parseable empty array on first run.
-    const path = "/tmp/malt_cli_services_fresh_no_db";
+    const base = try test_io.uniqueTempPath(testing.allocator, "cli_services", "fresh_no_db");
+    defer testing.allocator.free(base);
+    const path = try testing.allocator.dupeZ(u8, base);
+    defer testing.allocator.free(path);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};

--- a/tests/cli_tap_test.zig
+++ b/tests/cli_tap_test.zig
@@ -17,14 +17,11 @@ const c = struct {
 };
 
 fn setupPrefix(suffix: []const u8) ![:0]u8 {
-    const path = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "/tmp/malt_cli_tap_{d}_{s}",
-        .{ test_io.nanoTimestamp(
-            std.Options.debug_io,
-        ), suffix },
-        0,
-    );
+    // Process-unique: a bare timestamp collides between overlapping runs.
+    const raw = try test_io.uniqueTempPath(testing.allocator, "cli_tap", suffix);
+    defer testing.allocator.free(raw);
+    const path = try testing.allocator.dupeZ(u8, raw);
+    errdefer testing.allocator.free(path);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{path});
@@ -50,11 +47,14 @@ test "execute with --json on a prefix with no db/ directory still emits `[]`" {
     // Fresh MALT_PREFIX where the `db/` dir doesn't exist yet: `sqlite.open`
     // fails. CI consumers piping through `jq` need a parseable empty array,
     // not silently-empty stdout.
-    const path = "/tmp/malt_cli_tap_fresh_no_db";
+    const raw = try test_io.uniqueTempPath(testing.allocator, "cli_tap", "fresh_no_db");
+    defer testing.allocator.free(raw);
+    const path = try testing.allocator.dupeZ(u8, raw);
+    defer testing.allocator.free(path);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
-    _ = c.setenv("MALT_PREFIX", path, 1);
+    _ = c.setenv("MALT_PREFIX", path.ptr, 1);
     defer _ = c.unsetenv("MALT_PREFIX");
 
     const prior_json = malt.output.isJson();

--- a/tests/custom_theme_test.zig
+++ b/tests/custom_theme_test.zig
@@ -9,14 +9,13 @@
 const std = @import("std");
 const testing = std.testing;
 const malt = @import("malt");
+const test_io = @import("test_io");
 
 const color = malt.color;
 const output = malt.output;
 const theme_file = malt.theme_file;
 const tab_bar = malt.tui_tab_bar;
 
-const base = "/tmp/malt_custom_theme_test";
-const fixture = base ++ "/themes.json";
 const dbg_io = std.Options.debug_io;
 
 // Distinct truecolor values so the assertions cannot pass by coincidence.
@@ -33,25 +32,51 @@ const valid_file =
 
 const titles: [tab_bar.count][]const u8 = .{ "Search", "Installed", "Outdated", "Services", "Doctor" };
 
-fn cleanup() void {
-    var tmp = std.Io.Dir.openDirAbsolute(dbg_io, "/tmp", .{}) catch return;
-    defer tmp.close(dbg_io);
-    tmp.deleteTree(dbg_io, "malt_custom_theme_test") catch {};
-}
+/// Themes file under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures. Owns the environ block that points at it.
+const Fixture = struct {
+    arena: std.heap.ArenaAllocator,
+    base: [:0]const u8,
+    file: [:0]const u8,
+    environ: std.process.Environ,
 
-fn writeFixture(body: []const u8) !void {
-    cleanup();
-    try std.Io.Dir.createDirAbsolute(dbg_io, base, .default_dir);
-    const f = try std.Io.Dir.createFileAbsolute(dbg_io, fixture, .{});
-    defer f.close(dbg_io);
-    try f.writeStreamingAll(dbg_io, body);
-}
+    fn init(tag: []const u8) !Fixture {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const a = arena.allocator();
+        const unique = try test_io.uniqueTempPath(a, "custom_theme", tag);
+        const base = try a.dupeZ(u8, unique);
+        test_io.deleteTreeAbsolute(dbg_io, base) catch {};
+        try std.Io.Dir.createDirAbsolute(dbg_io, base, .default_dir);
+        const file = try std.fmt.allocPrintSentinel(a, "{s}/themes.json", .{base}, 0);
+        const kv = try std.fmt.allocPrintSentinel(a, "MALT_THEMES_FILE={s}", .{file}, 0);
+        const block = try a.allocSentinel(?[*:0]const u8, 1, null);
+        block[0] = kv.ptr;
+        return .{
+            .arena = arena,
+            .base = base,
+            .file = file,
+            .environ = .{ .block = .{ .slice = block } },
+        };
+    }
+
+    fn write(self: *Fixture, body: []const u8) !void {
+        const f = try std.Io.Dir.createFileAbsolute(dbg_io, self.file, .{});
+        defer f.close(dbg_io);
+        try f.writeStreamingAll(dbg_io, body);
+    }
+
+    fn deinit(self: *Fixture) void {
+        test_io.deleteTreeAbsolute(dbg_io, self.base) catch {};
+        self.arena.deinit();
+    }
+};
 
 /// Seed environ (pointing MALT_THEMES_FILE at the fixture, MALT_THEME unset so
 /// the file's `default` selects), force a truecolor tier, and boot-load the file
 /// the way `main` does.
-fn boot() color.InstallResult {
-    const environ: std.process.Environ = .{ .block = .{ .slice = &[_:null]?[*:0]const u8{"MALT_THEMES_FILE=" ++ fixture} } };
+fn boot(fx: *Fixture) color.InstallResult {
+    const environ = fx.environ;
     color.setRuntime(dbg_io, environ);
     color.setForTest(true, false); // colour on so CLI output emits SGR
     color.setTruecolorForTest(true);
@@ -68,13 +93,14 @@ fn reset() void {
     color.setForTest(null, null);
     color.setTruecolorForTest(null);
     color.setBackgroundForTest(null);
-    cleanup();
 }
 
 test "a valid themes file recolours both a CLI line and a TUI frame" {
-    try writeFixture(valid_file);
+    var fx = try Fixture.init("valid");
+    defer fx.deinit();
+    try fx.write(valid_file);
     defer reset();
-    try testing.expectEqual(color.InstallResult.loaded, boot());
+    try testing.expectEqual(color.InstallResult.loaded, boot(&fx));
 
     // TUI frame: the tab bar paints titles through color.roleCode(.accent).
     var fb: [256]u8 = undefined;
@@ -91,9 +117,11 @@ test "a valid themes file recolours both a CLI line and a TUI frame" {
 }
 
 test "a malformed themes file leaves built-in output unchanged" {
-    try writeFixture("{\"version\":1,\"themes\":{\"x\":{\"polarity\":\"dark\"}}}"); // missing roles
+    var fx = try Fixture.init("malformed");
+    defer fx.deinit();
+    try fx.write("{\"version\":1,\"themes\":{\"x\":{\"polarity\":\"dark\"}}}"); // missing roles
     defer reset();
-    try testing.expectEqual(color.InstallResult.rejected, boot());
+    try testing.expectEqual(color.InstallResult.rejected, boot(&fx));
 
     // The TUI frame must carry the built-in default accent, not a custom one.
     const builtin_accent = color.resolveRole(.default, .accent, .unknown, true);

--- a/tests/db_schema_v2_test.zig
+++ b/tests/db_schema_v2_test.zig
@@ -8,24 +8,30 @@ const sqlite = malt.sqlite;
 const schema = malt.schema;
 const test_io = @import("test_io");
 
+/// Scratch DB under a process-unique dir, so overlapping test runs cannot
+/// wipe each other's fixtures.
 const TempDb = struct {
+    arena: std.heap.ArenaAllocator,
     dir: []const u8,
     db: sqlite.Database,
 
-    fn init(comptime tag: []const u8) !TempDb {
-        const dir = "/tmp/malt_schema_v2_test_" ++ tag;
+    fn init(tag: []const u8) !TempDb {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const dir = try test_io.uniqueTempPath(arena.allocator(), "schema_v2", tag);
         test_io.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
         try test_io.makeDirAbsolute(std.Options.debug_io, dir);
         var db_path_buf: [256]u8 = undefined;
         const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/test.db", .{dir}, 0);
         var db = try sqlite.Database.open(db_path);
         errdefer db.close();
-        return .{ .dir = dir, .db = db };
+        return .{ .arena = arena, .dir = dir, .db = db };
     }
 
     fn deinit(self: *TempDb) void {
         self.db.close();
         test_io.deleteTreeAbsolute(std.Options.debug_io, self.dir) catch {};
+        self.arena.deinit();
     }
 };
 

--- a/tests/deps_cli_exec_test.zig
+++ b/tests/deps_cli_exec_test.zig
@@ -24,13 +24,9 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_deps_cli_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "deps_cli", tag);
+        defer allocator.free(base);
+        const path = try allocator.dupeZ(u8, base);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});
@@ -113,11 +109,14 @@ test "execute with no positional formula returns Aborted" {
 
 test "execute on a fresh prefix without --installed still completes" {
     // No db, no api hit either — must degrade cleanly without panic.
-    const path = "/tmp/malt_deps_cli_no_db";
+    const unique = try test_io.uniqueTempPath(testing.allocator, "deps_cli", "no_db");
+    defer testing.allocator.free(unique);
+    const path = try testing.allocator.dupeZ(u8, unique);
+    defer testing.allocator.free(path);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
-    _ = c.setenv("MALT_PREFIX", path, 1);
+    _ = c.setenv("MALT_PREFIX", path.ptr, 1);
     defer _ = c.unsetenv("MALT_PREFIX");
 
     const ctx = ctxWithSink();

--- a/tests/deps_leak_test.zig
+++ b/tests/deps_leak_test.zig
@@ -27,40 +27,48 @@ const client_mod = malt.client;
 /// Minimal on-disk SQLite DB wrapper: just enough to let
 /// `deps.resolve()` run `isInstalled` lookups.
 const TempDb = struct {
+    arena: std.heap.ArenaAllocator,
     dir: []const u8,
     db: sqlite.Database,
 
-    fn init(comptime tag: []const u8) !TempDb {
-        const dir = "/tmp/malt_deps_leak_test_" ++ tag;
+    fn init(tag: []const u8) !TempDb {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const dir = try test_io.uniqueTempPath(arena.allocator(), "deps_leak_test", tag);
         test_io.makeDirAbsolute(std.Options.debug_io, dir) catch {};
         var buf: [256]u8 = undefined;
         const path = try std.fmt.bufPrintSentinel(&buf, "{s}/test.db", .{dir}, 0);
         var db = try sqlite.Database.open(path);
         errdefer db.close();
         try schema.initSchema(&db);
-        return .{ .dir = dir, .db = db };
+        return .{ .arena = arena, .dir = dir, .db = db };
     }
 
     fn deinit(self: *TempDb) void {
         self.db.close();
         test_io.deleteTreeAbsolute(std.Options.debug_io, self.dir) catch {};
+        self.arena.deinit();
     }
 };
 
 /// Cache directory wrapper used to pre-seed `BrewApi` with fake
 /// formula JSON files, short-circuiting the network.
 const TempCacheDir = struct {
+    arena: std.heap.ArenaAllocator,
     path: []const u8,
 
-    fn init(comptime tag: []const u8) !TempCacheDir {
-        const p = "/tmp/malt_deps_leak_cache_" ++ tag;
+    fn init(tag: []const u8) !TempCacheDir {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const p = try test_io.uniqueTempPath(arena.allocator(), "deps_leak_cache", tag);
         test_io.deleteTreeAbsolute(std.Options.debug_io, p) catch {};
         try test_io.makeDirAbsolute(std.Options.debug_io, p);
-        return .{ .path = p };
+        return .{ .arena = arena, .path = p };
     }
 
     fn deinit(self: *TempCacheDir) void {
         test_io.deleteTreeAbsolute(std.Options.debug_io, self.path) catch {};
+        self.arena.deinit();
     }
 
     fn writeFormula(self: *TempCacheDir, name: []const u8, json: []const u8) !void {

--- a/tests/deps_test.zig
+++ b/tests/deps_test.zig
@@ -51,24 +51,30 @@ test "formula dependencies parsed from JSON" {
 
 // --- findOrphans / resolve coverage (seeded DB, no network) ---
 
+/// The scratch dir sits under a process-unique base, so overlapping test runs
+/// cannot wipe each other's fixtures.
 const TempDb = struct {
+    arena: std.heap.ArenaAllocator,
     dir: []const u8,
     db: sqlite.Database,
 
-    fn init(comptime tag: []const u8) !TempDb {
-        const dir = "/tmp/malt_deps_test_" ++ tag;
+    fn init(tag: []const u8) !TempDb {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const dir = try test_io.uniqueTempPath(arena.allocator(), "deps_test", tag);
         test_io.makeDirAbsolute(std.Options.debug_io, dir) catch {};
         var buf: [256]u8 = undefined;
         const path = try std.fmt.bufPrintSentinel(&buf, "{s}/test.db", .{dir}, 0);
         var db = try sqlite.Database.open(path);
         errdefer db.close();
         try schema.initSchema(&db);
-        return .{ .dir = dir, .db = db };
+        return .{ .arena = arena, .dir = dir, .db = db };
     }
 
     fn deinit(self: *TempDb) void {
         self.db.close();
         test_io.deleteTreeAbsolute(std.Options.debug_io, self.dir) catch {};
+        self.arena.deinit();
     }
 };
 
@@ -209,17 +215,21 @@ test "ResolvedDep carries name and already_installed flag" {
 // --- resolve() BFS tests with a cache-backed BrewApi (no network) ---
 
 const TempCacheDir = struct {
+    arena: std.heap.ArenaAllocator,
     path: []const u8,
 
-    fn init(comptime tag: []const u8) !TempCacheDir {
-        const p = "/tmp/malt_deps_cache_" ++ tag;
+    fn init(tag: []const u8) !TempCacheDir {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const p = try test_io.uniqueTempPath(arena.allocator(), "deps_cache", tag);
         test_io.deleteTreeAbsolute(std.Options.debug_io, p) catch {};
         try test_io.makeDirAbsolute(std.Options.debug_io, p);
-        return .{ .path = p };
+        return .{ .arena = arena, .path = p };
     }
 
     fn deinit(self: *TempCacheDir) void {
         test_io.deleteTreeAbsolute(std.Options.debug_io, self.path) catch {};
+        self.arena.deinit();
     }
 
     fn writeFormula(self: *TempCacheDir, name: []const u8, json: []const u8) !void {
@@ -474,11 +484,14 @@ test "resolve treats a DB keg with a vanished cellar_path as not-installed" {
 }
 
 const TempPrefix = struct {
+    arena: std.heap.ArenaAllocator,
     root: []const u8,
     db: sqlite.Database,
 
-    fn init(comptime tag: []const u8) !TempPrefix {
-        const root = "/tmp/malt_opt_link_" ++ tag;
+    fn init(tag: []const u8) !TempPrefix {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const root = try test_io.uniqueTempPath(arena.allocator(), "opt_link", tag);
         test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
         try test_io.makeDirAbsolute(std.Options.debug_io, root);
         errdefer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
@@ -488,12 +501,13 @@ const TempPrefix = struct {
         var db = try sqlite.Database.open(db_path);
         errdefer db.close();
         try schema.initSchema(&db);
-        return .{ .root = root, .db = db };
+        return .{ .arena = arena, .root = root, .db = db };
     }
 
     fn deinit(self: *TempPrefix) void {
         self.db.close();
         test_io.deleteTreeAbsolute(std.Options.debug_io, self.root) catch {};
+        self.arena.deinit();
     }
 
     fn cellarFor(self: *const TempPrefix, name: []const u8, version: []const u8) ![]const u8 {

--- a/tests/doctor_cask_history_test.zig
+++ b/tests/doctor_cask_history_test.zig
@@ -20,13 +20,9 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_doctor_cask_history_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "doctor_cask_history", tag);
+        defer allocator.free(base);
+        const path = try allocator.dupeZ(u8, base);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const subs = [_][]const u8{ "db", "cache/Cask", "Caskroom" };

--- a/tests/doctor_dispatch_test.zig
+++ b/tests/doctor_dispatch_test.zig
@@ -26,13 +26,9 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_doctor_disp_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "doctor_disp", tag);
+        defer allocator.free(base);
+        const path = try allocator.dupeZ(u8, base);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const subs = [_][]const u8{ "store", "Cellar", "Caskroom", "opt", "bin", "lib", "tmp", "cache", "db" };

--- a/tests/doctor_fix_test.zig
+++ b/tests/doctor_fix_test.zig
@@ -23,20 +23,13 @@ const c = struct {
 };
 const UF_IMMUTABLE: c_uint = 0x00000002;
 
-fn randHex(buf: *[16]u8) void {
-    var rand: [8]u8 = undefined;
-    fs_compat.randomBytes(std.Options.debug_io, &rand);
-    const hex_chars = "0123456789abcdef";
-    for (rand, 0..) |b, i| {
-        buf[i * 2] = hex_chars[b >> 4];
-        buf[i * 2 + 1] = hex_chars[b & 0x0f];
-    }
-}
-
+/// Process-unique scratch prefix, so overlapping test runs cannot wipe each
+/// other's fixtures. Written into the caller's buffer via a fixed allocator.
 fn makePrefix(prefix_buf: *[128]u8, label: []const u8) ![]const u8 {
-    var hex: [16]u8 = undefined;
-    randHex(&hex);
-    const prefix = try std.fmt.bufPrint(prefix_buf, "/tmp/malt-doctor-fix-{s}-{s}", .{ label, &hex });
+    var scratch: [512]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&scratch);
+    const unique = try test_io.uniqueTempPath(fba.allocator(), "doctor_fix", label);
+    const prefix = try std.fmt.bufPrint(prefix_buf, "{s}", .{unique});
     fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
     try fs_compat.makeDirAbsolute(std.Options.debug_io, prefix);
     return prefix;

--- a/tests/doctor_isolation_test.zig
+++ b/tests/doctor_isolation_test.zig
@@ -10,12 +10,8 @@ const sqlite = malt.sqlite;
 const schema = malt.schema;
 const output = malt.output;
 
-fn uniquePrefix(suffix: []const u8) ![]u8 {
-    return std.fmt.allocPrint(
-        testing.allocator,
-        "/tmp/malt_doctor_iso_{d}_{s}",
-        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
-    );
+fn uniquePrefix(suffix: []const u8) ![]const u8 {
+    return test_io.uniqueTempPath(testing.allocator, "doctor_iso", suffix);
 }
 
 // Seed: direct keg with bin links, isolated dep with no bin links, and

--- a/tests/doctor_json_test.zig
+++ b/tests/doctor_json_test.zig
@@ -18,11 +18,10 @@ const store_mod = malt.store;
 const output = malt.output;
 
 const Scratch = struct {
-    path: []u8,
+    path: []const u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrint(allocator, "/tmp/malt_doctor_json_{s}_{d}", .{ tag, ts });
+        const path = try test_io.uniqueTempPath(allocator, "doctor_json", tag);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const subs = [_][]const u8{ "store", "Cellar", "Caskroom", "opt", "bin", "lib", "tmp", "cache", "db" };

--- a/tests/doctor_ssl_test.zig
+++ b/tests/doctor_ssl_test.zig
@@ -15,17 +15,13 @@ const test_io = @import("test_io");
 const doctor = malt.doctor;
 const output = malt.output;
 
-fn uniquePrefix(suffix: []const u8) ![]u8 {
-    return std.fmt.allocPrint(
-        testing.allocator,
-        "/tmp/malt_doctor_ssl_{d}_{s}",
-        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
-    );
+fn uniquePrefix(suffix: []const u8) ![]const u8 {
+    return test_io.uniqueTempPath(testing.allocator, "doctor_ssl", suffix);
 }
 
 /// Seed a scratch prefix. `with_ca` links `opt/ca-certificates` (the
 /// "installed" signal); `with_cert` lands `etc/openssl@3/cert.pem`.
-fn makePrefix(suffix: []const u8, with_ca: bool, with_cert: bool) ![]u8 {
+fn makePrefix(suffix: []const u8, with_ca: bool, with_cert: bool) ![]const u8 {
     const prefix = try uniquePrefix(suffix);
     try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
     if (with_ca) {

--- a/tests/doctor_tap_forge_test.zig
+++ b/tests/doctor_tap_forge_test.zig
@@ -19,13 +19,9 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_doctor_tap_forge_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "doctor_tap_forge", tag);
+        defer allocator.free(base);
+        const path = try allocator.dupeZ(u8, base);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});

--- a/tests/dsl_builtins_test.zig
+++ b/tests/dsl_builtins_test.zig
@@ -21,14 +21,8 @@ const c = struct {
     extern "c" fn unsetenv(name: [*:0]const u8) c_int;
 };
 
-fn uniqueSandbox(suffix: []const u8) ![]u8 {
-    const p = try std.fmt.allocPrint(
-        testing.allocator,
-        "/tmp/malt_dsl_builtins_{d}_{s}",
-        .{ test_io.nanoTimestamp(
-            std.Options.debug_io,
-        ), suffix },
-    );
+fn uniqueSandbox(suffix: []const u8) ![]const u8 {
+    const p = try test_io.uniqueTempPath(testing.allocator, "dsl_builtins", suffix);
     test_io.cwd().createDirPath(std.Options.debug_io, p) catch {};
     return p;
 }

--- a/tests/info_cli_test.zig
+++ b/tests/info_cli_test.zig
@@ -25,13 +25,9 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_info_exec_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "info_exec", tag);
+        defer allocator.free(base);
+        const path = try allocator.dupeZ(u8, base);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const subs = [_][]const u8{ "db", "Cellar", "Caskroom", "cache/api" };
@@ -120,13 +116,9 @@ fn captureExecute(
     // stderr is a TTY (e.g. under `kcov`).
     color.setForTest(false, null);
 
-    const ts = test_io.nanoTimestamp(std.Options.debug_io);
-    const cap_path = try std.fmt.allocPrintSentinel(
-        allocator,
-        "/tmp/malt_info_cap_{s}_{d}",
-        .{ tag, ts },
-        0,
-    );
+    const cap_base = try test_io.uniqueTempPath(allocator, "info_cap", tag);
+    defer allocator.free(cap_base);
+    const cap_path = try allocator.dupeZ(u8, cap_base);
     defer allocator.free(cap_path);
     defer test_io.deleteFileAbsolute(std.Options.debug_io, cap_path) catch {};
 

--- a/tests/info_test.zig
+++ b/tests/info_test.zig
@@ -19,28 +19,54 @@ const c = struct {
     extern "c" fn unsetenv(name: [*:0]const u8) c_int;
 };
 
+/// Scratch tree under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
+const Fixture = struct {
+    arena: std.heap.ArenaAllocator,
+    base: [:0]const u8,
+
+    fn init(tag: []const u8) !Fixture {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "info", tag);
+        const base_z = try arena.allocator().dupeZ(u8, base);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base_z) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, base_z);
+        return .{ .arena = arena, .base = base_z };
+    }
+
+    /// Absolute path to `sub` inside the fixture; valid until `deinit`.
+    fn p(self: *Fixture, sub: []const u8) [:0]const u8 {
+        return std.fmt.allocPrintSentinel(
+            self.arena.allocator(),
+            "{s}/{s}",
+            .{ self.base, sub },
+            0,
+        ) catch @panic("OOM");
+    }
+
+    fn deinit(self: *Fixture) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.base) catch {};
+        self.arena.deinit();
+    }
+};
+
 test "openDb returns null when the prefix has no db/ directory" {
     // Fresh prefix with no db/ subdir at all — SQLite's OPEN_CREATE
     // cannot create intermediate dirs, so the open must fail and
     // the helper must turn that into a null instead of an error.
-    const prefix = "/tmp/malt_info_test_missing_db";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, prefix);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    var fx = try Fixture.init("missing_db");
+    defer fx.deinit();
 
-    try testing.expect(info.openDb(prefix) == null);
+    try testing.expect(info.openDb(fx.base) == null);
 }
 
 test "openDb succeeds and returns a usable handle when db/ exists" {
-    const prefix = "/tmp/malt_info_test_ok_db";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, prefix);
-    var db_buf: [512]u8 = undefined;
-    const db_dir = try std.fmt.bufPrint(&db_buf, "{s}/db", .{prefix});
-    try test_io.makeDirAbsolute(std.Options.debug_io, db_dir);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    var fx = try Fixture.init("ok_db");
+    defer fx.deinit();
+    try test_io.makeDirAbsolute(std.Options.debug_io, fx.p("db"));
 
-    var db = info.openDb(prefix) orelse return error.ExpectedDatabase;
+    var db = info.openDb(fx.base) orelse return error.ExpectedDatabase;
     defer db.close();
 }
 
@@ -48,8 +74,8 @@ test "openDb returns null when the prefix itself does not exist" {
     // A completely absent prefix path — typical when MALT_PREFIX is
     // pointed at a freshly-minted directory that hasn't been
     // populated by any malt command yet.
-    const prefix = "/tmp/malt_info_test_no_prefix_at_all";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    const prefix = try test_io.uniqueTempPath(testing.allocator, "info", "no_prefix_at_all");
+    defer testing.allocator.free(prefix);
     try testing.expect(info.openDb(prefix) == null);
 }
 
@@ -60,11 +86,10 @@ test "openDb returns null when the prefix itself does not exist" {
 // build a tiny kegs+dependencies fixture and pin the caller-observable
 // list, including the empty-deps and not-installed edges.
 
-fn makeDepsDb(tag: []const u8) !sqlite.Database {
-    var path_buf: [256]u8 = undefined;
-    const path = try std.fmt.bufPrintSentinel(&path_buf, "/tmp/malt_info_deps_test_{s}.db", .{tag}, 0);
-    test_io.deleteFileAbsolute(std.Options.debug_io, path) catch {};
-    var db = try sqlite.Database.open(path);
+/// The db lives inside `fx` so `fx.deinit()` takes the `-wal`/`-shm`
+/// siblings with it. Close the returned db before the fixture goes.
+fn makeDepsDb(fx: *Fixture) !sqlite.Database {
+    var db = try sqlite.Database.open(fx.p("deps.db"));
     try schema.initSchema(&db);
     return db;
 }
@@ -96,7 +121,9 @@ fn freeDepsSlice(deps: []const []const u8) void {
 }
 
 test "collectInstalledDeps reads a fixture keg's recorded deps, alphabetised" {
-    var db = try makeDepsDb("populated");
+    var fx = try Fixture.init("deps_populated");
+    defer fx.deinit(); // runs after db.close(): LIFO
+    var db = try makeDepsDb(&fx);
     defer db.close();
 
     // Insert deps out of order to prove the reader sorts rather than
@@ -114,7 +141,9 @@ test "collectInstalledDeps reads a fixture keg's recorded deps, alphabetised" {
 }
 
 test "collectInstalledDeps returns an empty slice for an installed leaf" {
-    var db = try makeDepsDb("leaf");
+    var fx = try Fixture.init("deps_leaf");
+    defer fx.deinit(); // runs after db.close(): LIFO
+    var db = try makeDepsDb(&fx);
     defer db.close();
 
     _ = try insertKegRow(&db, "tree");
@@ -126,7 +155,9 @@ test "collectInstalledDeps returns an empty slice for an installed leaf" {
 }
 
 test "collectInstalledDeps returns an empty slice when the keg is not installed" {
-    var db = try makeDepsDb("absent");
+    var fx = try Fixture.init("deps_absent");
+    defer fx.deinit(); // runs after db.close(): LIFO
+    var db = try makeDepsDb(&fx);
     defer db.close();
 
     const deps = info.collectInstalledDeps(testing.allocator, &db, "ghost");
@@ -147,8 +178,9 @@ const Prefix = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Prefix {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(allocator, "/tmp/malt_info_dispatch_{s}_{d}", .{ tag, ts }, 0);
+        const base = try test_io.uniqueTempPath(allocator, "info_dispatch", tag);
+        defer allocator.free(base);
+        const path = try allocator.dupeZ(u8, base);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});
         defer allocator.free(db_dir);
@@ -202,8 +234,9 @@ const Prefix = struct {
 // Drive `info.execute` with stdout backed by a real fd so the encoder
 // writes survive for byte assertions; offline so no network is attempted.
 fn captureInfo(allocator: std.mem.Allocator, args: []const []const u8, tag: []const u8) ![]u8 {
-    const ts = test_io.nanoTimestamp(std.Options.debug_io);
-    const cap_path = try std.fmt.allocPrintSentinel(allocator, "/tmp/malt_info_cap_{s}_{d}", .{ tag, ts }, 0);
+    const cap_base = try test_io.uniqueTempPath(allocator, "info_cap", tag);
+    defer allocator.free(cap_base);
+    const cap_path = try allocator.dupeZ(u8, cap_base);
     defer allocator.free(cap_path);
     defer test_io.deleteFileAbsolute(std.Options.debug_io, cap_path) catch {};
 

--- a/tests/install_download_only_test.zig
+++ b/tests/install_download_only_test.zig
@@ -25,12 +25,9 @@ const c = struct {
 };
 
 fn setupPrefix(suffix: []const u8) ![:0]u8 {
-    const path = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "/tmp/malt_install_dlonly_{d}_{s}",
-        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
-        0,
-    );
+    const base = try test_io.uniqueTempPath(testing.allocator, "install_dlonly", suffix);
+    defer testing.allocator.free(base);
+    const path = try testing.allocator.dupeZ(u8, base);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     inline for (.{ "store", "Cellar", "cache", "db" }) |sub| {

--- a/tests/install_execute_test.zig
+++ b/tests/install_execute_test.zig
@@ -15,15 +15,12 @@ const c = struct {
     extern "c" fn unsetenv(name: [*:0]const u8) c_int;
 };
 
+/// Scratch MALT_PREFIX under a process-unique base, so overlapping test runs
+/// cannot wipe each other's fixtures. Caller frees and removes the tree.
 fn setupPrefix(suffix: []const u8) ![:0]u8 {
-    const path = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "/tmp/malt_install_exec_{d}_{s}",
-        .{ test_io.nanoTimestamp(
-            std.Options.debug_io,
-        ), suffix },
-        0,
-    );
+    const unique = try test_io.uniqueTempPath(testing.allocator, "install_exec", suffix);
+    defer testing.allocator.free(unique);
+    const path = try testing.allocator.dupeZ(u8, unique);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     _ = c.setenv("MALT_PREFIX", path.ptr, 1);
@@ -60,13 +57,11 @@ fn seedFormulaCache(prefix: []const u8, name: []const u8, json: []const u8) !voi
 }
 
 test "execute --dry-run prints a plan for a cached formula" {
-    const prefix_z: [:0]const u8 = "/tmp/mm";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
-    const prefix: []const u8 = prefix_z;
-    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    const prefix_z = try setupPrefix("mm");
+    defer testing.allocator.free(prefix_z);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
+    const prefix: []const u8 = prefix_z;
 
     const json =
         \\{"name":"alpha","full_name":"alpha","tap":"homebrew/core","desc":"","homepage":"",
@@ -98,10 +93,8 @@ test "execute --dry-run prints a plan for a cached formula" {
 }
 
 test "execute with --formula forces formula-only and errors on an unresolvable name" {
-    const prefix_z: [:0]const u8 = "/tmp/mf";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
-    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    const prefix_z = try setupPrefix("mf");
+    defer testing.allocator.free(prefix_z);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
 
@@ -121,10 +114,8 @@ test "execute with --formula forces formula-only and errors on an unresolvable n
 }
 
 test "execute with a tap-formula-shaped name routes through the tap path in dry-run" {
-    const prefix_z: [:0]const u8 = "/tmp/mt";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
-    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    const prefix_z = try setupPrefix("mt");
+    defer testing.allocator.free(prefix_z);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
 
@@ -147,10 +138,8 @@ test "execute with neither --formula nor --cask: 404 cache markers route through
     // `installCask`'s `fetchCask` 404s too → both catches now count into
     // `failed_count` so a single-package miss exits non-zero. The two
     // `.404` markers keep the test offline-clean — no network roundtrip.
-    const prefix_z: [:0]const u8 = "/tmp/mcft";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
-    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    const prefix_z = try setupPrefix("mcft");
+    defer testing.allocator.free(prefix_z);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
 
@@ -180,10 +169,8 @@ test "execute in offline mode with no cached snapshot exits PartialFailure on th
     // when `ctx.offline` is set and the formula isn't cached, the catch
     // prints the snapshot-miss line *without* probing cask. T-049 counts
     // that miss into `failed_count` so the exit code is non-zero.
-    const prefix_z: [:0]const u8 = "/tmp/mofl";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
-    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    const prefix_z = try setupPrefix("mofl");
+    defer testing.allocator.free(prefix_z);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
 
@@ -208,13 +195,11 @@ test "execute --dry-run with one cached + one 404 package exits PartialFailure" 
     // dispatch loop counts the miss. Pre-fix the dry-run early return
     // ignored `failed_count` and exited 0; the gate now mirrors the
     // empty-list path so any planned-vs-failed mismatch surfaces.
-    const prefix_z: [:0]const u8 = "/tmp/mmix";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
-    const prefix: []const u8 = prefix_z;
-    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    const prefix_z = try setupPrefix("mmix");
+    defer testing.allocator.free(prefix_z);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
+    const prefix: []const u8 = prefix_z;
 
     const json =
         \\{"name":"alpha","full_name":"alpha","tap":"homebrew/core","desc":"","homepage":"",
@@ -261,10 +246,8 @@ test "Ctrl-C between pool and link sweeps !job.succeeded and exits PartialFailur
     // first poll (poll 3 after L581 + iter 1 L588) so the worker exits
     // before draining the queue, the pool joins with !job.succeeded,
     // and the new sweep + gate surfaces PartialFailure.
-    const prefix_z: [:0]const u8 = "/tmp/mirq2";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
-    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    const prefix_z = try setupPrefix("mirq2");
+    defer testing.allocator.free(prefix_z);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
 
@@ -313,10 +296,8 @@ test "Ctrl-C mid-resolution after a counted miss exits PartialFailure" {
     // had counted a miss. The arm seam flips the flag on the 3rd poll
     // so iter 1 dispatches (and fails) and iter 2's interrupt check
     // fires the new gate.
-    const prefix_z: [:0]const u8 = "/tmp/mirq";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
-    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    const prefix_z = try setupPrefix("mirq");
+    defer testing.allocator.free(prefix_z);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
 
@@ -350,10 +331,8 @@ test "Ctrl-C mid-resolution after a counted miss exits PartialFailure" {
 }
 
 test "execute --dry-run with an already-installed package short-circuits" {
-    const prefix_z: [:0]const u8 = "/tmp/mi";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
-    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    const prefix_z = try setupPrefix("mi");
+    defer testing.allocator.free(prefix_z);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
 
@@ -373,7 +352,9 @@ test "execute --dry-run with an already-installed package short-circuits" {
     try stmt.bindText(2, "seeded");
     try stmt.bindText(3, "1.0");
     try stmt.bindText(4, "0" ** 64);
-    try stmt.bindText(5, "/tmp/mi/Cellar/seeded/1.0");
+    const cellar_path = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/seeded/1.0", .{prefix_z});
+    defer testing.allocator.free(cellar_path);
+    try stmt.bindText(5, cellar_path);
     _ = try stmt.step();
     stmt.finalize();
     db.close();
@@ -418,10 +399,8 @@ test "execute --only-dependencies on a leaf formula plans nothing" {
     // Leaf formula → after dropping top-level the queue is empty, so the
     // "Dry run: would install ..." line never fires. Pins the early-return
     // branch so a future refactor cannot accidentally print a 0-package plan.
-    const prefix_z: [:0]const u8 = "/tmp/mol";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
-    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    const prefix_z = try setupPrefix("mol");
+    defer testing.allocator.free(prefix_z);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
 
@@ -469,10 +448,8 @@ test "execute --only-deps --dry-run plans deps but skips the requested formula" 
     // the cheapest way to assert the plan's contents from the outside.
     // The earlier `--only-dependencies` test pins the brew-parity alias;
     // this one pins the canonical short spelling.
-    const prefix_z: [:0]const u8 = "/tmp/mod";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
-    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    const prefix_z = try setupPrefix("mod");
+    defer testing.allocator.free(prefix_z);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
 
@@ -545,10 +522,8 @@ test "execute --dry-run routes a revisioned formula through the install pipeline
     // → collectFormulaJobs → print plan → return. A revisioned formula
     // exercises every call site that reads `formula.pkg_version` in
     // place of the plain `version`.
-    const prefix_z: [:0]const u8 = "/tmp/mr";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
-    _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
+    const prefix_z = try setupPrefix("mr");
+    defer testing.allocator.free(prefix_z);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     defer _ = c.unsetenv("MALT_PREFIX");
 

--- a/tests/install_idempotent_test.zig
+++ b/tests/install_idempotent_test.zig
@@ -29,14 +29,9 @@ fn seedCellarKeg(prefix: []const u8, name: []const u8, version: []const u8) !voi
 }
 
 fn setupPrefix(suffix: []const u8) ![:0]u8 {
-    const path = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "/tmp/malt_install_idem_{d}_{s}",
-        .{ test_io.nanoTimestamp(
-            std.Options.debug_io,
-        ), suffix },
-        0,
-    );
+    const base = try test_io.uniqueTempPath(testing.allocator, "install_idem", suffix);
+    defer testing.allocator.free(base);
+    const path = try testing.allocator.dupeZ(u8, base);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     _ = c.setenv("MALT_PREFIX", path.ptr, 1);

--- a/tests/install_isolation_test.zig
+++ b/tests/install_isolation_test.zig
@@ -34,12 +34,8 @@ const fake_formula_json =
     \\}
 ;
 
-fn uniquePrefix(suffix: []const u8) ![]u8 {
-    return std.fmt.allocPrint(
-        testing.allocator,
-        "/tmp/malt_install_iso_{d}_{s}",
-        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
-    );
+fn uniquePrefix(suffix: []const u8) ![]const u8 {
+    return test_io.uniqueTempPath(testing.allocator, "install_iso", suffix);
 }
 
 fn makeKegWithBin(prefix: []const u8, name: []const u8, version: []const u8) ![]u8 {
@@ -388,12 +384,9 @@ test "execute accepts --isolate-deps without erroring during dry-run" {
 // counts as proof the parser reached past the flag stage; raising
 // any other error means the flag was rejected.
 fn runFlagAcceptanceProbe(suffix: []const u8, flag: []const u8) !void {
-    const prefix = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "/tmp/malt_iso_probe_{d}_{s}",
-        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
-        0,
-    );
+    const base = try test_io.uniqueTempPath(testing.allocator, "iso_probe", suffix);
+    defer testing.allocator.free(base);
+    const prefix = try testing.allocator.dupeZ(u8, base);
     defer testing.allocator.free(prefix);
     test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, prefix);

--- a/tests/install_keg_from_bottle_test.zig
+++ b/tests/install_keg_from_bottle_test.zig
@@ -13,12 +13,9 @@ const sqlite = malt.sqlite;
 const schema = malt.schema;
 
 fn setupPrefix(suffix: []const u8) ![:0]u8 {
-    const path = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "/tmp/malt_installkfb_{d}_{s}",
-        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
-        0,
-    );
+    const base = try test_io.uniqueTempPath(testing.allocator, "installkfb", suffix);
+    defer testing.allocator.free(base);
+    const path = try testing.allocator.dupeZ(u8, base);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     // Mandatory layout subdirs — Cellar / store live here.

--- a/tests/install_parse_cache_test.zig
+++ b/tests/install_parse_cache_test.zig
@@ -17,21 +17,10 @@ const sqlite = malt.sqlite;
 const schema = malt.schema;
 const test_io = @import("test_io");
 
-const sys = struct {
-    extern "c" fn getpid() c_int;
-};
-
-var temp_seq = std.atomic.Value(u32).init(0);
-
-/// Build a process-unique temp path. Two overlapping `zig build test` runs
-/// (or a manual run racing the pre-push hook) otherwise share a fixed path,
-/// and one run's `deleteTree` wipes the other's seeded API cache — which
-/// silently falls through to the real network and fails on a 404.
-/// Mirrors the same fix in `tests/outdated_test.zig`.
+/// A shared path would let one run's `deleteTree` wipe the other's seeded API
+/// cache, which then silently falls through to the real network and 404s.
 fn uniqueTempPath(allocator: std.mem.Allocator, tag: []const u8) ![]const u8 {
-    return std.fmt.allocPrint(allocator, "/tmp/malt_parse_cache_test_{s}_{d}_{d}", .{
-        tag, sys.getpid(), temp_seq.fetchAdd(1, .monotonic),
-    });
+    return test_io.uniqueTempPath(allocator, "parse_cache_test", tag);
 }
 
 const TempDb = struct {

--- a/tests/install_pool_test.zig
+++ b/tests/install_pool_test.zig
@@ -17,12 +17,9 @@ const schema = malt.schema;
 const test_io = @import("test_io");
 
 fn setupPrefix(suffix: []const u8) ![:0]u8 {
-    const path = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "/tmp/malt_installpool_{d}_{s}",
-        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
-        0,
-    );
+    const base = try test_io.uniqueTempPath(testing.allocator, "installpool", suffix);
+    defer testing.allocator.free(base);
+    const path = try testing.allocator.dupeZ(u8, base);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     inline for (.{ "store", "Cellar" }) |sub| {

--- a/tests/install_pure_test.zig
+++ b/tests/install_pure_test.zig
@@ -752,13 +752,7 @@ test "isInstalled is false before recordKeg, true after" {
 }
 
 test "pruneCellarForReinstall wipes an existing Cellar dir so --force can re-materialize" {
-    const prefix = try std.fmt.allocPrint(
-        testing.allocator,
-        "/tmp/malt_prune_cellar_{d}",
-        .{test_io.nanoTimestamp(
-            std.Options.debug_io,
-        )},
-    );
+    const prefix = try test_io.uniqueTempPath(testing.allocator, "prune", "cellar");
     defer testing.allocator.free(prefix);
     test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
@@ -783,13 +777,7 @@ test "pruneCellarForReinstall wipes an existing Cellar dir so --force can re-mat
 }
 
 test "pruneCellarForReinstall is a no-op when the destination is missing" {
-    const prefix = try std.fmt.allocPrint(
-        testing.allocator,
-        "/tmp/malt_prune_cellar_missing_{d}",
-        .{test_io.nanoTimestamp(
-            std.Options.debug_io,
-        )},
-    );
+    const prefix = try test_io.uniqueTempPath(testing.allocator, "prune", "cellar_missing");
     defer testing.allocator.free(prefix);
     test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
@@ -1056,13 +1044,7 @@ test "deleteKeg removes the row and isInstalled reports false again" {
 }
 
 test "ensureDirs creates every required subdirectory under a fresh prefix" {
-    const prefix = try std.fmt.allocPrint(
-        testing.allocator,
-        "/tmp/malt_install_ensure_dirs_{d}",
-        .{test_io.nanoTimestamp(
-            std.Options.debug_io,
-        )},
-    );
+    const prefix = try test_io.uniqueTempPath(testing.allocator, "install", "ensure_dirs");
     defer testing.allocator.free(prefix);
     test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};

--- a/tests/install_sink_test.zig
+++ b/tests/install_sink_test.zig
@@ -56,7 +56,10 @@ const RecordingSink = struct {
 };
 
 test "installAll routes the per-keg failure line through the injected sink" {
-    const prefix_z: [:0]const u8 = "/tmp/malt_install_sink_route";
+    const unique = try test_io.uniqueTempPath(testing.allocator, "install_sink", "route");
+    defer testing.allocator.free(unique);
+    const prefix_z = try testing.allocator.dupeZ(u8, unique);
+    defer testing.allocator.free(prefix_z);
     test_io.deleteTreeAbsolute(std.Options.debug_io, prefix_z) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, prefix_z);
     _ = c.setenv("MALT_PREFIX", prefix_z.ptr, 1);
@@ -96,7 +99,9 @@ fn runUnresolvable(
     suffix: []const u8,
     out_buf: *std.ArrayList(u8),
 ) anyerror!void {
-    const prefix = try std.fmt.allocPrintSentinel(testing.allocator, "/tmp/malt_install_sink_{s}", .{suffix}, 0);
+    const unique = try test_io.uniqueTempPath(testing.allocator, "install_sink", suffix);
+    defer testing.allocator.free(unique);
+    const prefix = try testing.allocator.dupeZ(u8, unique);
     defer testing.allocator.free(prefix);
     test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, prefix);

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -47,24 +47,50 @@ fn postInstallFormulaJson() []const u8 {
 /// Opens a fresh temp-dir SQLite DB with the current schema applied.
 /// The caller is responsible for closing the returned DB and removing
 /// the temp dir.
+/// The temp dir lives under a process-unique base, so overlapping test runs
+/// cannot wipe each other's fixtures.
 const TempDb = struct {
+    arena: std.heap.ArenaAllocator,
     dir: []const u8,
     db: sqlite.Database,
 
-    fn init(comptime tag: []const u8) !TempDb {
-        const dir = "/tmp/malt_install_test_" ++ tag;
+    fn init(tag: []const u8) !TempDb {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const dir = try test_io.uniqueTempPath(arena.allocator(), "install_test", tag);
         test_io.makeDirAbsolute(std.Options.debug_io, dir) catch {};
         var db_path_buf: [256]u8 = undefined;
         const db_path = try std.fmt.bufPrintSentinel(&db_path_buf, "{s}/test.db", .{dir}, 0);
         var db = try sqlite.Database.open(db_path);
         errdefer db.close();
         try schema.initSchema(&db);
-        return .{ .dir = dir, .db = db };
+        return .{ .arena = arena, .dir = dir, .db = db };
     }
 
     fn deinit(self: *TempDb) void {
         self.db.close();
         test_io.deleteTreeAbsolute(std.Options.debug_io, self.dir) catch {};
+        self.arena.deinit();
+    }
+};
+
+/// Scratch dir under a process-unique base, for the BrewApi cache roots the
+/// tests seed and delete.
+const TempDir = struct {
+    arena: std.heap.ArenaAllocator,
+    path: []const u8,
+
+    fn init(tag: []const u8) !TempDir {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const p = try test_io.uniqueTempPath(arena.allocator(), "install_test", tag);
+        test_io.makeDirAbsolute(std.Options.debug_io, p) catch {};
+        return .{ .arena = arena, .path = p };
+    }
+
+    fn deinit(self: *TempDir) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.path) catch {};
+        self.arena.deinit();
     }
 };
 
@@ -96,9 +122,9 @@ test "collectFormulaJobs queues a steps-migrated formula despite post_install_de
         "\"bottle\":{\"stable\":{\"root_url\":\"https://ghcr.io/v2/homebrew/core/glowsteps/blobs\"," ++
         "\"files\":{\"all\":{\"cellar\":\":any\",\"url\":\"https://ghcr.io/v2/glowsteps\",\"sha256\":\"deadbeef\"}}}}}";
 
-    const cache_dir = "/tmp/malt_install_test_postinstall_steps_cache";
-    test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
+    var cache_fx = try TempDir.init("postinstall_steps_cache");
+    defer cache_fx.deinit();
+    const cache_dir = cache_fx.path;
 
     var http = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
     defer http.deinit();
@@ -138,9 +164,9 @@ test "collectFormulaJobs queues a formula with a post_install hook" {
     // skipped and the API / pool pointers are never dereferenced.
     const json = postInstallFormulaJson();
 
-    const cache_dir = "/tmp/malt_install_test_postinstall_accept_cache";
-    test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
+    var cache_fx = try TempDir.init("postinstall_accept_cache");
+    defer cache_fx.deinit();
+    const cache_dir = cache_fx.path;
 
     var http = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
     defer http.deinit();
@@ -379,9 +405,9 @@ test "collectFormulaJobs queues the main formula when nothing is installed" {
     // empty dep list skips the parallel-fetch phase.
     const json = bottleJsonWithoutDeps("hello");
 
-    const cache_dir = "/tmp/malt_install_test_happy_path_cache";
-    test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
+    var cache_fx = try TempDir.init("happy_path_cache");
+    defer cache_fx.deinit();
+    const cache_dir = cache_fx.path;
 
     var http = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
     defer http.deinit();
@@ -498,10 +524,9 @@ test "collectFormulaJobs queues a dep and its parent from a seeded cache" {
     var tdb = try TempDb.init("with_dep");
     defer tdb.deinit();
 
-    const cache_dir = "/tmp/malt_install_test_with_dep_cache";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
-    test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
+    var cache_fx = try TempDir.init("with_dep_cache");
+    defer cache_fx.deinit();
+    const cache_dir = cache_fx.path;
 
     // Seed BOTH the dep and the root formula JSON. deps.resolve re-fetches
     // the root from the API to discover its dep list (even though
@@ -549,10 +574,9 @@ test "collectFormulaJobs deduplicates deps already queued by a prior call" {
     var tdb = try TempDb.init("dedup_dep");
     defer tdb.deinit();
 
-    const cache_dir = "/tmp/malt_install_test_dedup_cache";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
-    test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
+    var cache_fx = try TempDir.init("dedup_cache");
+    defer cache_fx.deinit();
+    const cache_dir = cache_fx.path;
 
     const dep_json = bottleJsonWithoutDeps("beta");
     try seedCache(cache_dir, "beta", dep_json);
@@ -627,9 +651,9 @@ test "collectFormulaJobs with post_install leaves the DB untouched" {
 
     const json = postInstallFormulaJson();
 
-    const cache_dir = "/tmp/malt_install_test_postinstall_db_cache";
-    test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
+    var cache_fx = try TempDir.init("postinstall_db_cache");
+    defer cache_fx.deinit();
+    const cache_dir = cache_fx.path;
 
     var http = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
     defer http.deinit();
@@ -691,9 +715,9 @@ test "collectFormulaJobs carries the _<revision> suffix in version_str" {
         \\ }}}}
     ;
 
-    const cache_dir = "/tmp/malt_install_test_rev_jobs_cache";
-    test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
+    var cache_fx = try TempDir.init("rev_jobs_cache");
+    defer cache_fx.deinit();
+    const cache_dir = cache_fx.path;
 
     var http = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
     defer http.deinit();
@@ -731,9 +755,9 @@ test "collectFormulaJobs leaves plain-version formulas unchanged" {
 
     const json = postInstallFormulaJson(); // revision: 0 fixture.
 
-    const cache_dir = "/tmp/malt_install_test_norev_jobs_cache";
-    test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
+    var cache_fx = try TempDir.init("norev_jobs_cache");
+    defer cache_fx.deinit();
+    const cache_dir = cache_fx.path;
 
     var http = try malt.client_pool.HttpClientPool.init(std.Options.debug_io, std.process.Environ.empty, alloc, 1);
     defer http.deinit();
@@ -824,10 +848,9 @@ test "collectFormulaJobs leaves no parsed-tree leaks under testing.allocator (>=
     var tdb = try TempDb.init("parsed_tree_leak");
     defer tdb.deinit();
 
-    const cache_dir = "/tmp/malt_install_test_parsed_tree_leak_cache";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
-    test_io.makeDirAbsolute(std.Options.debug_io, cache_dir) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, cache_dir) catch {};
+    var cache_fx = try TempDir.init("parsed_tree_leak_cache");
+    defer cache_fx.deinit();
+    const cache_dir = cache_fx.path;
 
     try seedCache(cache_dir, "dep_a", bottleJsonUniqueSha("dep_a", "aa"));
     try seedCache(cache_dir, "dep_b", bottleJsonUniqueSha("dep_b", "bb"));

--- a/tests/link_cli_test.zig
+++ b/tests/link_cli_test.zig
@@ -23,13 +23,9 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_link_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "link", tag);
+        defer allocator.free(base);
+        const path = try std.fmt.allocPrintSentinel(allocator, "{s}", .{base}, 0);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const sub = [_][]const u8{ "db", "bin", "opt" };

--- a/tests/linker_core_test.zig
+++ b/tests/linker_core_test.zig
@@ -10,14 +10,8 @@ const sqlite = malt.sqlite;
 const schema = malt.schema;
 const linker_mod = malt.linker;
 
-fn uniquePrefix(suffix: []const u8) ![]u8 {
-    return std.fmt.allocPrint(
-        testing.allocator,
-        "/tmp/malt_linker_test_{d}_{s}",
-        .{ test_io.nanoTimestamp(
-            std.Options.debug_io,
-        ), suffix },
-    );
+fn uniquePrefix(suffix: []const u8) ![]const u8 {
+    return test_io.uniqueTempPath(testing.allocator, "linker_test", suffix);
 }
 
 fn makeKegWithBinary(prefix: []const u8, name: []const u8, version: []const u8, bin_name: []const u8) ![]u8 {

--- a/tests/linker_isolation_test.zig
+++ b/tests/linker_isolation_test.zig
@@ -11,12 +11,8 @@ const sqlite = malt.sqlite;
 const schema = malt.schema;
 const linker_mod = malt.linker;
 
-fn uniquePrefix(suffix: []const u8) ![]u8 {
-    return std.fmt.allocPrint(
-        testing.allocator,
-        "/tmp/malt_linker_iso_{d}_{s}",
-        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
-    );
+fn uniquePrefix(suffix: []const u8) ![]const u8 {
+    return test_io.uniqueTempPath(testing.allocator, "linker_iso", suffix);
 }
 
 // Build a keg with one file under each named subdir so both

--- a/tests/linker_test.zig
+++ b/tests/linker_test.zig
@@ -7,12 +7,34 @@ const malt = @import("malt");
 const test_io = @import("test_io");
 const testing = std.testing;
 
+/// Scratch tree under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
+const Fixture = struct {
+    arena: std.heap.ArenaAllocator,
+    base: [:0]const u8,
+
+    fn init(tag: []const u8) !Fixture {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "linker", tag);
+        const base_z = try arena.allocator().dupeZ(u8, base);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base_z) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, base_z);
+        return .{ .arena = arena, .base = base_z };
+    }
+
+    fn deinit(self: *Fixture) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.base) catch {};
+        self.arena.deinit();
+    }
+};
+
 test "atomic symlink via tmp+rename pattern" {
     // Verify the atomic symlink pattern used in linker.zig:
     // create at tmp name, then rename into place.
-    const tmp_dir = "/tmp/malt_link_test";
-    test_io.makeDirAbsolute(std.Options.debug_io, tmp_dir) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, tmp_dir) catch {};
+    var fx = try Fixture.init("link_test");
+    defer fx.deinit();
+    const tmp_dir = fx.base;
 
     var dir = try test_io.openDirAbsolute(std.Options.debug_io, tmp_dir, .{});
     defer dir.close(std.Options.debug_io);
@@ -38,9 +60,9 @@ test "atomic symlink via tmp+rename pattern" {
 }
 
 test "symlink replacement is atomic" {
-    const tmp_dir = "/tmp/malt_link_replace_test";
-    test_io.makeDirAbsolute(std.Options.debug_io, tmp_dir) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, tmp_dir) catch {};
+    var fx = try Fixture.init("link_replace_test");
+    defer fx.deinit();
+    const tmp_dir = fx.base;
 
     var dir = try test_io.openDirAbsolute(std.Options.debug_io, tmp_dir, .{});
     defer dir.close(std.Options.debug_io);
@@ -75,9 +97,9 @@ test "symlink replacement is atomic" {
 }
 
 test "conflict detection by reading existing symlink targets" {
-    const tmp_dir = "/tmp/malt_conflict_test";
-    test_io.makeDirAbsolute(std.Options.debug_io, tmp_dir) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, tmp_dir) catch {};
+    var fx = try Fixture.init("conflict_test");
+    defer fx.deinit();
+    const tmp_dir = fx.base;
 
     var dir = try test_io.openDirAbsolute(std.Options.debug_io, tmp_dir, .{});
     defer dir.close(std.Options.debug_io);

--- a/tests/list_cli_test.zig
+++ b/tests/list_cli_test.zig
@@ -22,13 +22,9 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_list_cli_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "list_cli", tag);
+        defer allocator.free(base);
+        const path = try allocator.dupeZ(u8, base);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});
@@ -96,7 +92,10 @@ test "execute --help short-circuits" {
 
 test "execute on a fresh prefix with no db is a clean no-op" {
     // No db/ subdir → SQLite open fails → list takes the "empty dir" branch.
-    const path = "/tmp/malt_list_cli_no_db";
+    const base = try test_io.uniqueTempPath(testing.allocator, "list_cli", "no_db");
+    defer testing.allocator.free(base);
+    const path = try testing.allocator.dupeZ(u8, base);
+    defer testing.allocator.free(path);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};

--- a/tests/list_test.zig
+++ b/tests/list_test.zig
@@ -11,12 +11,18 @@ const sqlite = malt.sqlite;
 const schema = malt.schema;
 const cli_list = malt.cli_list;
 
+/// Scratch DB under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
 const TempDb = struct {
-    dir: []const u8,
+    arena: std.heap.ArenaAllocator,
+    dir: [:0]const u8,
     db: sqlite.Database,
 
-    fn init(comptime tag: []const u8) !TempDb {
-        const dir = "/tmp/malt_list_test_" ++ tag;
+    fn init(tag: []const u8) !TempDb {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "list", tag);
+        const dir = try arena.allocator().dupeZ(u8, base);
         test_io.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
         try test_io.makeDirAbsolute(std.Options.debug_io, dir);
         var buf: [256]u8 = undefined;
@@ -24,12 +30,13 @@ const TempDb = struct {
         var db = try sqlite.Database.open(path);
         errdefer db.close();
         try schema.initSchema(&db);
-        return .{ .dir = dir, .db = db };
+        return .{ .arena = arena, .dir = dir, .db = db };
     }
 
     fn deinit(self: *TempDb) void {
         self.db.close();
         test_io.deleteTreeAbsolute(std.Options.debug_io, self.dir) catch {};
+        self.arena.deinit();
     }
 };
 

--- a/tests/lock_test.zig
+++ b/tests/lock_test.zig
@@ -10,11 +10,7 @@ const lock = @import("malt").lock;
 const io = std.Options.debug_io;
 
 fn uniquePath(suffix: []const u8) ![]const u8 {
-    return std.fmt.allocPrint(
-        testing.allocator,
-        "/tmp/malt_lock_test_{d}_{s}",
-        .{ test_io.nanoTimestamp(io), suffix },
-    );
+    return test_io.uniqueTempPath(testing.allocator, "lock_test", suffix);
 }
 
 test "acquire writes pid, release clears the file, holderPid parses back" {

--- a/tests/ndjson_test.zig
+++ b/tests/ndjson_test.zig
@@ -188,14 +188,9 @@ test "upgrade emits bracketing lock_acquired + install_complete under ndjson" {
     // through lock acquire → "no formulas installed" → release without
     // touching the network. The test pins the bracketing events so the
     // ndjson stream stays well-formed even when no work is done.
-    const path = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "/tmp/malt_ndjson_upgrade_{d}",
-        .{test_io.nanoTimestamp(
-            std.Options.debug_io,
-        )},
-        0,
-    );
+    const base = try test_io.uniqueTempPath(testing.allocator, "ndjson", "upgrade");
+    defer testing.allocator.free(base);
+    const path = try testing.allocator.dupeZ(u8, base);
     defer testing.allocator.free(path);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};

--- a/tests/offline_mode_test.zig
+++ b/tests/offline_mode_test.zig
@@ -85,7 +85,10 @@ test "BrewApi.fetchFormula composes with HttpClient.offline so cache hits still 
     defer http.deinit();
     http.offline = true;
 
-    const tmp = "/tmp/malt_offline_int_compose";
+    // Process-unique root: a fixed /tmp name lets an overlapping run's
+    // deleteTree wipe this fixture mid-test.
+    const tmp = try test_io.uniqueTempPath(testing.allocator, "offline", "int_compose");
+    defer testing.allocator.free(tmp);
     test_io.deleteTreeAbsolute(std.Options.debug_io, tmp) catch {};
     try test_io.makeDirAbsolute(std.Options.debug_io, tmp);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, tmp) catch {};

--- a/tests/origin_test.zig
+++ b/tests/origin_test.zig
@@ -61,8 +61,10 @@ test "classify is slash-anchored — no false positives on 'cellar' substrings" 
 
 const fs_compat = test_io;
 
-fn resetScratch(allocator: std.mem.Allocator, tag: []const u8) ![]u8 {
-    const dir = try std.fmt.allocPrint(allocator, "/tmp/malt_origin_test_{s}", .{tag});
+/// Process-unique scratch root, so overlapping test runs cannot wipe each
+/// other's fixtures.
+fn resetScratch(allocator: std.mem.Allocator, tag: []const u8) ![]const u8 {
+    const dir = try test_io.uniqueTempPath(allocator, "origin", tag);
     fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
     try fs_compat.makeDirAbsolute(std.Options.debug_io, dir);
     return dir;

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -18,25 +18,17 @@ const schema = malt.schema;
 const c = struct {
     extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
     extern "c" fn unsetenv(name: [*:0]const u8) c_int;
-    extern "c" fn getpid() c_int;
 };
 
 // --- Integration: collectOutdatedFormulas / collectOutdatedCasks ---
-
-// Per-init counter; with the pid it makes every cache dir unique across both
-// concurrent processes and repeated inits within one process.
-var temp_seq = std.atomic.Value(u32).init(0);
 
 const TempCacheDir = struct {
     allocator: std.mem.Allocator,
     path: []const u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !TempCacheDir {
-        // Unique per process+init so overlapping test runs never share a tree
-        // (a shared tree let one init's deleteTree wipe another's seeded cache).
-        const p = try std.fmt.allocPrint(allocator, "/tmp/malt_outdated_test_{s}_{d}_{d}", .{
-            tag, c.getpid(), temp_seq.fetchAdd(1, .monotonic),
-        });
+        // A shared tree let one init's deleteTree wipe another's seeded cache.
+        const p = try test_io.uniqueTempPath(allocator, "outdated_test", tag);
         errdefer allocator.free(p);
         test_io.deleteTreeAbsolute(std.Options.debug_io, p) catch {};
         try test_io.makeDirAbsolute(std.Options.debug_io, p);
@@ -1452,9 +1444,7 @@ test "readSnapshot returns null on garbage contents" {
 test "writeSnapshot creates the cache directory if missing" {
     // Unique per process+init so overlapping runs don't share this dir; it must
     // not exist yet, so writeSnapshot is the one that creates it.
-    const path = try std.fmt.allocPrint(testing.allocator, "/tmp/malt_outdated_test_snapshot_mkdir_{d}_{d}", .{
-        c.getpid(), temp_seq.fetchAdd(1, .monotonic),
-    });
+    const path = try test_io.uniqueTempPath(testing.allocator, "outdated_test", "snapshot_mkdir");
     defer testing.allocator.free(path);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};

--- a/tests/outdated_test.zig
+++ b/tests/outdated_test.zig
@@ -410,14 +410,9 @@ test "collectOutdated fetch fallback detects an upstream revision-only bump" {
 // --- --pinned-only filter ---
 
 fn setupPinnedPrefix(suffix: []const u8) ![:0]u8 {
-    const path = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "/tmp/malt_outdated_pinned_{d}_{s}",
-        .{ test_io.nanoTimestamp(
-            std.Options.debug_io,
-        ), suffix },
-        0,
-    );
+    const base = try test_io.uniqueTempPath(testing.allocator, "outdated_pinned", suffix);
+    defer testing.allocator.free(base);
+    const path = try testing.allocator.dupeZ(u8, base);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{path});
@@ -1029,14 +1024,9 @@ const UpdateEnv = struct {
     cache_path: [:0]u8,
 
     fn init(suffix: []const u8) !UpdateEnv {
-        const prefix = try std.fmt.allocPrintSentinel(
-            testing.allocator,
-            "/tmp/malt_update_test_{d}_{s}",
-            .{ test_io.nanoTimestamp(
-                std.Options.debug_io,
-            ), suffix },
-            0,
-        );
+        const prefix_base = try test_io.uniqueTempPath(testing.allocator, "update_test", suffix);
+        defer testing.allocator.free(prefix_base);
+        const prefix = try testing.allocator.dupeZ(u8, prefix_base);
         const cache = try std.fmt.allocPrintSentinel(
             testing.allocator,
             "{s}/cache",

--- a/tests/perms_test.zig
+++ b/tests/perms_test.zig
@@ -63,33 +63,63 @@ test "classify: setuid bit does not count as writable" {
 
 // ── walker integration ────────────────────────────────────────────
 
-test "walkPrefix: clean tree yields no findings" {
-    const base = "/tmp/malt_perms_clean";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, base ++ "/bin");
-    (try test_io.createFileAbsolute(std.Options.debug_io, base ++ "/bin/foo", .{})).close(std.Options.debug_io);
+/// Scratch tree under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
+const Fixture = struct {
+    arena: std.heap.ArenaAllocator,
+    base: [:0]const u8,
 
-    const findings = try perms.walkPrefix(std.Options.debug_io, testing.allocator, base, perms.currentUid(), 64);
+    fn init(tag: []const u8) !Fixture {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "perms", tag);
+        const base_z = try arena.allocator().dupeZ(u8, base);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base_z) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, base_z);
+        return .{ .arena = arena, .base = base_z };
+    }
+
+    /// Absolute path to `sub` inside the fixture; valid until `deinit`.
+    fn p(self: *Fixture, sub: []const u8) [:0]const u8 {
+        return std.fmt.allocPrintSentinel(
+            self.arena.allocator(),
+            "{s}/{s}",
+            .{ self.base, sub },
+            0,
+        ) catch @panic("OOM");
+    }
+
+    fn deinit(self: *Fixture) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.base) catch {};
+        self.arena.deinit();
+    }
+};
+
+const c = struct {
+    extern "c" fn chmod(path: [*:0]const u8, mode: u16) c_int;
+};
+
+test "walkPrefix: clean tree yields no findings" {
+    var fx = try Fixture.init("clean");
+    defer fx.deinit();
+    try test_io.cwd().createDirPath(std.Options.debug_io, fx.p("bin"));
+    (try test_io.createFileAbsolute(std.Options.debug_io, fx.p("bin/foo"), .{})).close(std.Options.debug_io);
+
+    const findings = try perms.walkPrefix(std.Options.debug_io, testing.allocator, fx.base, perms.currentUid(), 64);
     defer perms.freeFindings(testing.allocator, findings);
     try testing.expectEqual(@as(usize, 0), findings.len);
 }
 
 test "walkPrefix: detects other-writable file" {
-    const base = "/tmp/malt_perms_other_writable";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, base);
-    const path = base ++ "/world_writable.txt";
+    var fx = try Fixture.init("other_writable");
+    defer fx.deinit();
+    const path = fx.p("world_writable.txt");
     (try test_io.createFileAbsolute(std.Options.debug_io, path, .{})).close(std.Options.debug_io);
 
     // chmod o+w
-    const c = struct {
-        extern "c" fn chmod(path: [*:0]const u8, mode: u16) c_int;
-    };
     if (c.chmod(path, 0o666) != 0) return error.TestUnexpectedResult;
 
-    const findings = try perms.walkPrefix(std.Options.debug_io, testing.allocator, base, perms.currentUid(), 64);
+    const findings = try perms.walkPrefix(std.Options.debug_io, testing.allocator, fx.base, perms.currentUid(), 64);
     defer perms.freeFindings(testing.allocator, findings);
 
     // Must find at least the world_writable file; may also flag the
@@ -107,25 +137,20 @@ test "walkPrefix: detects other-writable file" {
 test "walkPrefix: a symlink is judged on itself, not its target" {
     // The walker stats with SYMLINK_NOFOLLOW so a symlink planted in the prefix
     // cannot make it report (or clear) the permissions of something elsewhere.
-    const base = "/tmp/malt_perms_nofollow";
-    const target = "/tmp/malt_perms_nofollow_target.txt";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    test_io.deleteTreeAbsolute(std.Options.debug_io, target) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, target) catch {};
+    var fx = try Fixture.init("nofollow");
+    defer fx.deinit();
+    // The target lives outside the walked tree, so only following the link
+    // could surface its mode.
+    var outside = try Fixture.init("nofollow_target");
+    defer outside.deinit();
 
-    try test_io.cwd().createDirPath(std.Options.debug_io, base);
+    const target = outside.p("target.txt");
     (try test_io.createFileAbsolute(std.Options.debug_io, target, .{})).close(std.Options.debug_io);
-
-    const c = struct {
-        extern "c" fn chmod(path: [*:0]const u8, mode: u16) c_int;
-    };
     if (c.chmod(target, 0o666) != 0) return error.TestUnexpectedResult;
 
-    const link = base ++ "/link";
-    try std.Io.Dir.symLinkAbsolute(std.Options.debug_io, target, link, .{});
+    try std.Io.Dir.symLinkAbsolute(std.Options.debug_io, target, fx.p("link"), .{});
 
-    const findings = try perms.walkPrefix(std.Options.debug_io, testing.allocator, base, perms.currentUid(), 64);
+    const findings = try perms.walkPrefix(std.Options.debug_io, testing.allocator, fx.base, perms.currentUid(), 64);
     defer perms.freeFindings(testing.allocator, findings);
 
     // Following would inherit the target's 0o666 and flag the link.
@@ -147,22 +172,18 @@ test "walkPrefix: missing prefix returns empty findings, no error" {
 }
 
 test "walkPrefix: respects max_findings cap" {
-    const base = "/tmp/malt_perms_cap";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    try test_io.cwd().createDirPath(std.Options.debug_io, base);
-    const c = struct {
-        extern "c" fn chmod(path: [*:0]const u8, mode: u16) c_int;
-    };
+    var fx = try Fixture.init("cap");
+    defer fx.deinit();
     // Seed 5 world-writable files.
     for (0..5) |i| {
-        var buf: [64]u8 = undefined;
-        const p = try std.fmt.bufPrintSentinel(&buf, "{s}/f{d}", .{ base, i }, 0);
+        var buf: [16]u8 = undefined;
+        const name = try std.fmt.bufPrint(&buf, "f{d}", .{i});
+        const p = fx.p(name);
         (try test_io.createFileAbsolute(std.Options.debug_io, p, .{})).close(std.Options.debug_io);
         if (c.chmod(p.ptr, 0o666) != 0) return error.TestUnexpectedResult;
     }
 
-    const findings = try perms.walkPrefix(std.Options.debug_io, testing.allocator, base, perms.currentUid(), 2);
+    const findings = try perms.walkPrefix(std.Options.debug_io, testing.allocator, fx.base, perms.currentUid(), 2);
     defer perms.freeFindings(testing.allocator, findings);
     try testing.expect(findings.len <= 2);
 }

--- a/tests/pin_test.zig
+++ b/tests/pin_test.zig
@@ -17,14 +17,9 @@ const c = struct {
 };
 
 fn setupPrefix(suffix: []const u8) ![:0]u8 {
-    const path = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "/tmp/malt_pin_test_{d}_{s}",
-        .{ test_io.nanoTimestamp(
-            std.Options.debug_io,
-        ), suffix },
-        0,
-    );
+    const base = try test_io.uniqueTempPath(testing.allocator, "pin", suffix);
+    defer testing.allocator.free(base);
+    const path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}", .{base}, 0);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{path});

--- a/tests/purge_json_test.zig
+++ b/tests/purge_json_test.zig
@@ -22,13 +22,9 @@ const ScratchPrefix = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !ScratchPrefix {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_purge_json_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "purge_json", tag);
+        defer allocator.free(base);
+        const path = try allocator.dupeZ(u8, base);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});

--- a/tests/purge_scopes_test.zig
+++ b/tests/purge_scopes_test.zig
@@ -25,13 +25,9 @@ const ScratchPrefix = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !ScratchPrefix {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_purge_scopes_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "purge_scopes", tag);
+        defer allocator.free(base);
+        const path = try std.fmt.allocPrintSentinel(allocator, "{s}", .{base}, 0);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});
@@ -434,9 +430,9 @@ test "--wipe --yes --backup writes the manifest before the delete pass" {
     try writeFileAt(allocator, &.{ prefix.path, "Cellar", "marker" }, "x");
 
     // Backup lives outside the wipe target so the assertion can read it.
-    const backup_path = try std.fmt.allocPrint(allocator, "/tmp/malt_wipe_backup_{d}.txt", .{
-        test_io.nanoTimestamp(std.Options.debug_io),
-    });
+    const backup_base = try test_io.uniqueTempPath(allocator, "wipe", "backup");
+    defer allocator.free(backup_base);
+    const backup_path = try std.fmt.allocPrint(allocator, "{s}.txt", .{backup_base});
     defer allocator.free(backup_path);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, backup_path) catch {};
 
@@ -464,9 +460,7 @@ test "--wipe --yes --backup creates a nested absolute manifest path" {
     try writeFileAt(allocator, &.{ prefix.path, "Cellar", "marker" }, "x");
 
     // grandparent (`.../mani`) intentionally absent; lives outside the prefix.
-    const root = try std.fmt.allocPrint(allocator, "/tmp/malt_wipe_nested_{d}", .{
-        test_io.nanoTimestamp(std.Options.debug_io),
-    });
+    const root = try test_io.uniqueTempPath(allocator, "wipe", "nested");
     defer allocator.free(root);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, root) catch {};
     const backup_path = try std.fmt.allocPrint(allocator, "{s}/mani/a/backup.txt", .{root});

--- a/tests/reinstall_test.zig
+++ b/tests/reinstall_test.zig
@@ -28,12 +28,9 @@ fn pathExists(path: []const u8) bool {
 }
 
 fn setupPrefix(suffix: []const u8) ![:0]u8 {
-    const path = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "/tmp/malt_reinstall_{d}_{s}",
-        .{ test_io.nanoTimestamp(std.Options.debug_io), suffix },
-        0,
-    );
+    const base = try test_io.uniqueTempPath(testing.allocator, "reinstall", suffix);
+    defer testing.allocator.free(base);
+    const path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}", .{base}, 0);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     _ = c.setenv("MALT_PREFIX", path.ptr, 1);

--- a/tests/release_test.zig
+++ b/tests/release_test.zig
@@ -133,13 +133,32 @@ test "pickAssetUrl returns null when nothing matches" {
 
 // --- extracted-tarball layout ---------------------------------------------
 
-/// Reset a scratch directory tree for a single test. Fixtures from
-/// earlier runs must not influence the current one.
-fn resetTree(path: []const u8) !std.Io.Dir {
-    test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
-    try test_io.makeDirAbsolute(std.Options.debug_io, path);
-    return test_io.openDirAbsolute(std.Options.debug_io, path, .{ .iterate = true });
-}
+/// Scratch tree under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
+const Fixture = struct {
+    arena: std.heap.ArenaAllocator,
+    base: []const u8,
+    dir: std.Io.Dir,
+
+    fn init(tag: []const u8) !Fixture {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "findbin", tag);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+        try test_io.makeDirAbsolute(std.Options.debug_io, base);
+        return .{
+            .arena = arena,
+            .base = base,
+            .dir = try test_io.openDirAbsolute(std.Options.debug_io, base, .{ .iterate = true }),
+        };
+    }
+
+    fn deinit(self: *Fixture) void {
+        self.dir.close(std.Options.debug_io);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.base) catch {};
+        self.arena.deinit();
+    }
+};
 
 fn touch(dir: std.Io.Dir, rel: []const u8, content: []const u8) !void {
     const f = try dir.createFile(std.Options.debug_io, rel, .{});
@@ -149,20 +168,18 @@ fn touch(dir: std.Io.Dir, rel: []const u8, content: []const u8) !void {
 
 test "findReleaseBinary locates malt nested under GoReleaser's versioned dir" {
     // Mirrors the real tarball layout: malt_<ver>_darwin_all/{LICENSE,README,malt}
-    const base = "/tmp/malt_findbin_nested";
-    var dir = try resetTree(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("nested");
+    defer fx.deinit();
 
-    try dir.createDirPath(std.Options.debug_io, "malt_0.3.1_darwin_all");
-    var sub = try dir.openDir(std.Options.debug_io, "malt_0.3.1_darwin_all", .{});
+    try fx.dir.createDirPath(std.Options.debug_io, "malt_0.3.1_darwin_all");
+    var sub = try fx.dir.openDir(std.Options.debug_io, "malt_0.3.1_darwin_all", .{});
     defer sub.close(std.Options.debug_io);
     try touch(sub, "LICENSE", "MIT");
     try touch(sub, "README.md", "# malt");
     try touch(sub, "malt", "binary-bytes");
 
     var out_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const found = release.findReleaseBinary(std.Options.debug_io, testing.allocator, base, &out_buf) orelse
+    const found = release.findReleaseBinary(std.Options.debug_io, testing.allocator, fx.base, &out_buf) orelse
         return error.ExpectedMatch;
 
     try testing.expect(std.mem.endsWith(u8, found, "/malt_0.3.1_darwin_all/malt"));
@@ -175,49 +192,43 @@ test "findReleaseBinary locates malt nested under GoReleaser's versioned dir" {
 
 test "findReleaseBinary accepts a flat layout with the binary at the root" {
     // Forks or future layouts may drop the wrap-in-dir.
-    const base = "/tmp/malt_findbin_flat";
-    var dir = try resetTree(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("flat");
+    defer fx.deinit();
 
-    try touch(dir, "malt", "binary-bytes");
+    try touch(fx.dir, "malt", "binary-bytes");
 
     var out_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const found = release.findReleaseBinary(std.Options.debug_io, testing.allocator, base, &out_buf) orelse
+    const found = release.findReleaseBinary(std.Options.debug_io, testing.allocator, fx.base, &out_buf) orelse
         return error.ExpectedMatch;
     try testing.expect(std.mem.endsWith(u8, found, "/malt"));
 }
 
 test "findReleaseBinary accepts the `mt` alias when `malt` is absent" {
     // Survives a release that renames the binary to the short alias.
-    const base = "/tmp/malt_findbin_mt_only";
-    var dir = try resetTree(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("mt_only");
+    defer fx.deinit();
 
-    try dir.createDirPath(std.Options.debug_io, "wrap");
-    var sub = try dir.openDir(std.Options.debug_io, "wrap", .{});
+    try fx.dir.createDirPath(std.Options.debug_io, "wrap");
+    var sub = try fx.dir.openDir(std.Options.debug_io, "wrap", .{});
     defer sub.close(std.Options.debug_io);
     try touch(sub, "mt", "binary-bytes");
 
     var out_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const found = release.findReleaseBinary(std.Options.debug_io, testing.allocator, base, &out_buf) orelse
+    const found = release.findReleaseBinary(std.Options.debug_io, testing.allocator, fx.base, &out_buf) orelse
         return error.ExpectedMatch;
     try testing.expect(std.mem.endsWith(u8, found, "/wrap/mt"));
 }
 
 test "findReleaseBinary returns null when the archive has no matching binary" {
     // Caller surfaces a clear error instead of silently no-op'ing.
-    const base = "/tmp/malt_findbin_missing";
-    var dir = try resetTree(base);
-    defer dir.close(std.Options.debug_io);
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("missing");
+    defer fx.deinit();
 
-    try touch(dir, "LICENSE", "MIT");
-    try touch(dir, "README.md", "# malt");
+    try touch(fx.dir, "LICENSE", "MIT");
+    try touch(fx.dir, "README.md", "# malt");
 
     var out_buf: [std.fs.max_path_bytes]u8 = undefined;
-    try testing.expect(release.findReleaseBinary(std.Options.debug_io, testing.allocator, base, &out_buf) == null);
+    try testing.expect(release.findReleaseBinary(std.Options.debug_io, testing.allocator, fx.base, &out_buf) == null);
 }
 
 test "findReleaseBinary returns null when the prefix does not exist" {

--- a/tests/restore_cli_test.zig
+++ b/tests/restore_cli_test.zig
@@ -22,13 +22,11 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_restore_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        // Process-unique: a bare timestamp collides between overlapping runs.
+        const raw = try test_io.uniqueTempPath(allocator, "restore", tag);
+        defer allocator.free(raw);
+        const path = try allocator.dupeZ(u8, raw);
+        errdefer allocator.free(path);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         _ = c.setenv("MALT_PREFIX", path.ptr, 1);

--- a/tests/run_cli_test.zig
+++ b/tests/run_cli_test.zig
@@ -22,13 +22,9 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_run_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "run", tag);
+        defer allocator.free(base);
+        const path = try std.fmt.allocPrintSentinel(allocator, "{s}", .{base}, 0);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const cache_api = try std.fmt.allocPrint(allocator, "{s}/cache/api", .{path});

--- a/tests/run_test.zig
+++ b/tests/run_test.zig
@@ -9,10 +9,42 @@ const test_io = @import("test_io");
 const testing = std.testing;
 const cli_run = malt.cli_run;
 
+/// Scratch tree under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
+const Fixture = struct {
+    arena: std.heap.ArenaAllocator,
+    base: [:0]const u8,
+
+    fn init(tag: []const u8) !Fixture {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "run", tag);
+        const base_z = try arena.allocator().dupeZ(u8, base);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base_z) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, base_z);
+        return .{ .arena = arena, .base = base_z };
+    }
+
+    /// Absolute path to `sub` inside the fixture; valid until `deinit`.
+    fn p(self: *Fixture, sub: []const u8) [:0]const u8 {
+        return std.fmt.allocPrintSentinel(
+            self.arena.allocator(),
+            "{s}/{s}",
+            .{ self.base, sub },
+            0,
+        ) catch @panic("OOM");
+    }
+
+    fn deinit(self: *Fixture) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.base) catch {};
+        self.arena.deinit();
+    }
+};
+
 test "findCachedBinary returns the path when the cached binary exists" {
-    const base = "/tmp/malt_run_keep_hit";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("keep_hit");
+    defer fx.deinit();
+    const base = fx.base;
 
     const sha = "abc123";
     const pkg = "jq";
@@ -38,9 +70,9 @@ test "findCachedBinary returns the path when the cached binary exists" {
 }
 
 test "findCachedBinary reports miss when the cache is empty" {
-    const base = "/tmp/malt_run_keep_miss";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("keep_miss");
+    defer fx.deinit();
+    const base = fx.base;
 
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
@@ -55,9 +87,9 @@ test "findCachedBinary reports miss when the cache is empty" {
 // a probe for another SHA — guards against accidental cross-version reuse
 // when an upstream rebuilds with the same `version` string.
 test "findCachedBinary keys cache slot on sha256, not just pkg+version" {
-    const base = "/tmp/malt_run_keep_sha_isolation";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("keep_sha_isolation");
+    defer fx.deinit();
+    const base = fx.base;
 
     const sha_a = "aaa111";
     const sha_b = "bbb222";
@@ -85,9 +117,9 @@ test "findCachedBinary keys cache slot on sha256, not just pkg+version" {
 }
 
 test "findCachedBinary requires the version directory to match" {
-    const base = "/tmp/malt_run_keep_ver_isolation";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+    var fx = try Fixture.init("keep_ver_isolation");
+    defer fx.deinit();
+    const base = fx.base;
 
     const sha = "abc";
     const pkg = "jq";
@@ -113,9 +145,9 @@ test "findCachedBinary requires the version directory to match" {
 // time out (flock is per-process on the SAME fd path here, but separate
 // LockFile.acquire calls open new fds, which on macOS/Linux contend).
 test "LockFile blocks a second acquire on the same path" {
-    const lock_path = "/tmp/malt_run_keep_lock_test.lock";
-    test_io.deleteFileAbsolute(std.Options.debug_io, lock_path) catch {};
-    defer test_io.deleteFileAbsolute(std.Options.debug_io, lock_path) catch {};
+    var fx = try Fixture.init("keep_lock_test");
+    defer fx.deinit();
+    const lock_path = fx.p("lock");
 
     const io = std.Options.debug_io;
     var first = try malt.lock.LockFile.acquire(io, lock_path, 1_000);

--- a/tests/search_cli_test.zig
+++ b/tests/search_cli_test.zig
@@ -23,13 +23,9 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_search_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "search", tag);
+        defer allocator.free(base);
+        const path = try allocator.dupeZ(u8, base);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const cache_api = try std.fmt.allocPrint(allocator, "{s}/cache/api", .{path});
@@ -112,13 +108,9 @@ fn captureExecute(
     args: []const []const u8,
     tag: []const u8,
 ) ![]u8 {
-    const ts = test_io.nanoTimestamp(std.Options.debug_io);
-    const cap_path = try std.fmt.allocPrintSentinel(
-        allocator,
-        "/tmp/malt_search_cap_{s}_{d}",
-        .{ tag, ts },
-        0,
-    );
+    const cap_base = try test_io.uniqueTempPath(allocator, "search_cap", tag);
+    defer allocator.free(cap_base);
+    const cap_path = try allocator.dupeZ(u8, cap_base);
     defer allocator.free(cap_path);
     defer test_io.deleteFileAbsolute(std.Options.debug_io, cap_path) catch {};
 

--- a/tests/search_test.zig
+++ b/tests/search_test.zig
@@ -90,18 +90,25 @@ test "findNameMatches rejects over-long queries to keep lowercase buf bounded" {
 
 // --- fetchNamesIndex cache read path (no network) ---
 
+/// Scratch cache under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
 const TempCacheDir = struct {
-    path: []const u8,
+    arena: std.heap.ArenaAllocator,
+    path: [:0]const u8,
 
-    fn init(comptime tag: []const u8) !TempCacheDir {
-        const p = "/tmp/malt_search_test_" ++ tag;
+    fn init(tag: []const u8) !TempCacheDir {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "search", tag);
+        const p = try arena.allocator().dupeZ(u8, base);
         test_io.deleteTreeAbsolute(std.Options.debug_io, p) catch {};
         try test_io.makeDirAbsolute(std.Options.debug_io, p);
-        return .{ .path = p };
+        return .{ .arena = arena, .path = p };
     }
 
     fn deinit(self: *TempCacheDir) void {
         test_io.deleteTreeAbsolute(std.Options.debug_io, self.path) catch {};
+        self.arena.deinit();
     }
 
     fn writeCacheFile(self: *TempCacheDir, rel: []const u8, content: []const u8) !void {

--- a/tests/services_test.zig
+++ b/tests/services_test.zig
@@ -12,12 +12,18 @@ const sqlite = malt.sqlite;
 const schema = malt.schema;
 const supervisor = malt.services_supervisor;
 
+/// Scratch DB under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
 const TempDb = struct {
-    dir: []const u8,
+    arena: std.heap.ArenaAllocator,
+    dir: [:0]const u8,
     db: sqlite.Database,
 
-    fn init(comptime tag: []const u8) !TempDb {
-        const dir = "/tmp/malt_services_test_" ++ tag;
+    fn init(tag: []const u8) !TempDb {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "services", tag);
+        const dir = try arena.allocator().dupeZ(u8, base);
         test_io.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
         try test_io.makeDirAbsolute(std.Options.debug_io, dir);
         var db_path_buf: [256]u8 = undefined;
@@ -25,12 +31,23 @@ const TempDb = struct {
         var db = try sqlite.Database.open(db_path);
         errdefer db.close();
         try schema.initSchema(&db);
-        return .{ .dir = dir, .db = db };
+        return .{ .arena = arena, .dir = dir, .db = db };
+    }
+
+    /// Absolute path to `sub` inside the scratch dir; valid until `deinit`.
+    fn p(self: *TempDb, sub: []const u8) [:0]const u8 {
+        return std.fmt.allocPrintSentinel(
+            self.arena.allocator(),
+            "{s}/{s}",
+            .{ self.dir, sub },
+            0,
+        ) catch @panic("OOM");
     }
 
     fn deinit(self: *TempDb) void {
         self.db.close();
         test_io.deleteTreeAbsolute(std.Options.debug_io, self.dir) catch {};
+        self.arena.deinit();
     }
 };
 
@@ -90,7 +107,7 @@ test "tailLog returns last N lines of a small file" {
     var t = try TempDb.init("tail");
     defer t.deinit();
 
-    const log_path = "/tmp/malt_services_test_tail/sample.log";
+    const log_path = t.p("sample.log");
     {
         var f = try test_io.createFileAbsolute(std.Options.debug_io, log_path, .{ .truncate = true });
         defer f.close(std.Options.debug_io);

--- a/tests/supervisor_pure_test.zig
+++ b/tests/supervisor_pure_test.zig
@@ -17,6 +17,38 @@ const c = struct {
     extern "c" fn unsetenv(name: [*:0]const u8) c_int;
 };
 
+/// Scratch tree under a process-unique base, so overlapping test runs cannot
+/// wipe each other's fixtures.
+const Fixture = struct {
+    arena: std.heap.ArenaAllocator,
+    base: [:0]const u8,
+
+    fn init(tag: []const u8) !Fixture {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        errdefer arena.deinit();
+        const base = try test_io.uniqueTempPath(arena.allocator(), "supervisor", tag);
+        const base_z = try arena.allocator().dupeZ(u8, base);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base_z) catch {};
+        try test_io.cwd().createDirPath(std.Options.debug_io, base_z);
+        return .{ .arena = arena, .base = base_z };
+    }
+
+    /// Absolute path to `sub` inside the fixture; valid until `deinit`.
+    fn p(self: *Fixture, sub: []const u8) [:0]const u8 {
+        return std.fmt.allocPrintSentinel(
+            self.arena.allocator(),
+            "{s}/{s}",
+            .{ self.base, sub },
+            0,
+        ) catch @panic("OOM");
+    }
+
+    fn deinit(self: *Fixture) void {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, self.base) catch {};
+        self.arena.deinit();
+    }
+};
+
 test "SupervisorCtx bundles allocator and db into one param" {
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
@@ -88,12 +120,12 @@ test "list is empty on a fresh database and hasService returns false" {
 }
 
 test "register writes a plist and a DB row that list reports back" {
-    const prefix = "/tmp/malt_sup_register";
-    const cellar = "/tmp/malt_sup_register/Cellar/testkeg/1.0";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    var fx = try Fixture.init("register");
+    defer fx.deinit();
+    const prefix = fx.base;
+    const cellar = fx.p("Cellar/testkeg/1.0");
     _ = c.setenv("MALT_PREFIX", prefix, 1);
     defer _ = c.unsetenv("MALT_PREFIX");
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
 
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
@@ -103,12 +135,12 @@ test "register writes a plist and a DB row that list reports back" {
     // log paths must live under malt_prefix.
     const spec = plist_mod.ServiceSpec{
         .label = "com.malt.test.svc",
-        .program_args = &.{ "/tmp/malt_sup_register/Cellar/testkeg/1.0/bin/echo", "hi" },
+        .program_args = &.{ fx.p("Cellar/testkeg/1.0/bin/echo"), "hi" },
         .working_dir = null,
         .env = &.{},
         .keep_alive = false,
-        .stdout_path = "/tmp/malt_sup_register/out.log",
-        .stderr_path = "/tmp/malt_sup_register/err.log",
+        .stdout_path = fx.p("out.log"),
+        .stderr_path = fx.p("err.log"),
     };
     const ctx: supervisor.SupervisorCtx = .{ .allocator = testing.allocator, .io = std.Options.debug_io, .db = &db };
     try supervisor.register(ctx, spec, "testkeg", true, cellar, prefix);
@@ -131,12 +163,12 @@ test "register writes a plist and a DB row that list reports back" {
 }
 
 test "register writes an interval plist with StartInterval and RunAtLoad false" {
-    const prefix = "/tmp/malt_sup_interval";
-    const cellar = "/tmp/malt_sup_interval/Cellar/testkeg/1.0";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    var fx = try Fixture.init("interval");
+    defer fx.deinit();
+    const prefix = fx.base;
+    const cellar = fx.p("Cellar/testkeg/1.0");
     _ = c.setenv("MALT_PREFIX", prefix, 1);
     defer _ = c.unsetenv("MALT_PREFIX");
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
 
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
@@ -144,9 +176,9 @@ test "register writes an interval plist with StartInterval and RunAtLoad false" 
 
     const spec = plist_mod.ServiceSpec{
         .label = "com.malt.test.interval",
-        .program_args = &.{"/tmp/malt_sup_interval/Cellar/testkeg/1.0/bin/backup"},
-        .stdout_path = "/tmp/malt_sup_interval/out.log",
-        .stderr_path = "/tmp/malt_sup_interval/err.log",
+        .program_args = &.{fx.p("Cellar/testkeg/1.0/bin/backup")},
+        .stdout_path = fx.p("out.log"),
+        .stderr_path = fx.p("err.log"),
         .schedule = .{ .interval = 3600 },
     };
     const ctx: supervisor.SupervisorCtx = .{ .allocator = testing.allocator, .io = std.Options.debug_io, .db = &db };
@@ -168,12 +200,12 @@ test "register writes an interval plist with StartInterval and RunAtLoad false" 
 }
 
 test "register stores a cron schedule label that list reports back" {
-    const prefix = "/tmp/malt_sup_cron_label";
-    const cellar = prefix ++ "/Cellar/testkeg/1.0";
-    test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    var fx = try Fixture.init("cron_label");
+    defer fx.deinit();
+    const prefix = fx.base;
+    const cellar = fx.p("Cellar/testkeg/1.0");
     _ = c.setenv("MALT_PREFIX", prefix, 1);
     defer _ = c.unsetenv("MALT_PREFIX");
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
 
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
@@ -184,9 +216,9 @@ test "register stores a cron schedule label that list reports back" {
     const entries = [_]plist_mod.CalendarInterval{.{ .minute = 30, .hour = 4, .weekday = 6 }};
     const spec = plist_mod.ServiceSpec{
         .label = "com.malt.test.cron",
-        .program_args = &.{cellar ++ "/bin/backup"},
-        .stdout_path = prefix ++ "/out.log",
-        .stderr_path = prefix ++ "/err.log",
+        .program_args = &.{fx.p("Cellar/testkeg/1.0/bin/backup")},
+        .stdout_path = fx.p("out.log"),
+        .stderr_path = fx.p("err.log"),
         .schedule = .{ .calendar = &entries },
     };
     const ctx: supervisor.SupervisorCtx = .{ .allocator = testing.allocator, .io = std.Options.debug_io, .db = &db };
@@ -219,9 +251,9 @@ test "register rejects an out-of-range interval via the validate gate" {
 }
 
 test "tailLog writes the last N lines into the provided writer" {
-    const path = "/tmp/malt_sup_tail.log";
-    test_io.cwd().deleteFile(std.Options.debug_io, path) catch {};
-    defer test_io.cwd().deleteFile(std.Options.debug_io, path) catch {};
+    var fx = try Fixture.init("tail");
+    defer fx.deinit();
+    const path = fx.p("tail.log");
 
     const f = try test_io.createFileAbsolute(std.Options.debug_io, path, .{});
     try f.writeStreamingAll(std.Options.debug_io, "a\nb\nc\nd\ne\n");

--- a/tests/swap_test.zig
+++ b/tests/swap_test.zig
@@ -12,8 +12,10 @@ const test_io = @import("test_io");
 const swap = malt.update_swap;
 const fs_compat = test_io;
 
-fn resetScratch(allocator: std.mem.Allocator, tag: []const u8) ![]u8 {
-    const dir = try std.fmt.allocPrint(allocator, "/tmp/malt_swap_test_{s}", .{tag});
+/// Process-unique scratch root, so overlapping test runs cannot wipe each
+/// other's fixtures.
+fn resetScratch(allocator: std.mem.Allocator, tag: []const u8) ![]const u8 {
+    const dir = try test_io.uniqueTempPath(allocator, "swap", tag);
     fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
     try fs_compat.makeDirAbsolute(std.Options.debug_io, dir);
     return dir;
@@ -40,7 +42,7 @@ fn modeBits(path: []const u8) !u32 {
 /// Build a scratch dir + its target/new/old/staged triple of paths.
 /// All four live in the same dir so rename-based atomicity holds.
 const Paths = struct {
-    dir: []u8,
+    dir: []const u8,
     target: []u8,
     new: []u8,
     old: []u8,

--- a/tests/tap_cli_test.zig
+++ b/tests/tap_cli_test.zig
@@ -24,13 +24,11 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_tap_cli_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        // Process-unique: a bare timestamp collides between overlapping runs.
+        const raw = try test_io.uniqueTempPath(allocator, "tap_cli", tag);
+        defer allocator.free(raw);
+        const path = try allocator.dupeZ(u8, raw);
+        errdefer allocator.free(path);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});
@@ -119,11 +117,14 @@ test "execute --help short-circuits without opening the database" {
 }
 
 test "execute on a fresh prefix with no db is a clean no-op" {
-    const path = "/tmp/malt_tap_cli_no_db";
+    const raw = try test_io.uniqueTempPath(testing.allocator, "tap_cli", "no_db");
+    defer testing.allocator.free(raw);
+    const path = try testing.allocator.dupeZ(u8, raw);
+    defer testing.allocator.free(path);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
-    _ = c.setenv("MALT_PREFIX", path, 1);
+    _ = c.setenv("MALT_PREFIX", path.ptr, 1);
     defer _ = c.unsetenv("MALT_PREFIX");
 
     quiet();

--- a/tests/test_io.zig
+++ b/tests/test_io.zig
@@ -9,6 +9,17 @@ pub const path = std.fs.path;
 pub const max_path_bytes = std.Io.Dir.max_path_bytes;
 pub const max_name_bytes = std.Io.Dir.max_name_bytes;
 
+var temp_seq = std.atomic.Value(u32).init(0);
+
+/// Scratch path unique to this process and call. A fixed `/tmp` name is shared
+/// by any overlapping run — a manual `zig build test` racing the pre-push hook —
+/// and one run's `deleteTree` then wipes the other's fixtures mid-test.
+pub fn uniqueTempPath(allocator: std.mem.Allocator, group: []const u8, tag: []const u8) ![]const u8 {
+    return std.fmt.allocPrint(allocator, "/tmp/malt_{s}_{s}_{d}_{d}", .{
+        group, tag, std.c.getpid(), temp_seq.fetchAdd(1, .monotonic),
+    });
+}
+
 /// Lazy `/dev/null` handle used to sink writes under the test runner. The
 /// runner owns fd 1 for its IPC protocol, and dumps any captured stderr
 /// next to a "failed command:" trailer — both swamp the summary with noise

--- a/tests/tui_purity_test.zig
+++ b/tests/tui_purity_test.zig
@@ -315,14 +315,19 @@ fn writeFixture(io: std.Io, abs_path: []const u8, content: []const u8) !void {
 // correct in isolation.
 test "the anti-cycle scan flags a guarded file that imports the hub, and only that file" {
     const io = std.Options.debug_io;
-    const base = "/tmp/malt_anticycle_fixture";
+    // Process-unique base so an overlapping test run cannot wipe these
+    // fixtures mid-scan.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const base = try test_io.uniqueTempPath(arena.allocator(), "tui_purity", "anticycle");
     test_io.deleteTreeAbsolute(io, base) catch {};
     try test_io.makeDirAbsolute(io, base);
     defer test_io.deleteTreeAbsolute(io, base) catch {};
 
-    try writeFixture(io, base ++ "/evil_tab.zig", "const app = @import(\"app.zig\");\n");
-    try writeFixture(io, base ++ "/ctx.zig", "const term = @import(\"term.zig\");\n"); // clean sink
-    try writeFixture(io, base ++ "/list.zig", "const app = @import(\"app.zig\");\n"); // not guarded → ignored
+    const a = arena.allocator();
+    try writeFixture(io, try std.fmt.allocPrint(a, "{s}/evil_tab.zig", .{base}), "const app = @import(\"app.zig\");\n");
+    try writeFixture(io, try std.fmt.allocPrint(a, "{s}/ctx.zig", .{base}), "const term = @import(\"term.zig\");\n"); // clean sink
+    try writeFixture(io, try std.fmt.allocPrint(a, "{s}/list.zig", .{base}), "const app = @import(\"app.zig\");\n"); // not guarded → ignored
 
     var failures: std.ArrayList([]const u8) = .empty;
     defer {

--- a/tests/uninstall_test.zig
+++ b/tests/uninstall_test.zig
@@ -24,13 +24,9 @@ const ScratchPrefix = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !ScratchPrefix {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_uninstall_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "uninstall", tag);
+        defer allocator.free(base);
+        const path = try std.fmt.allocPrintSentinel(allocator, "{s}", .{base}, 0);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});

--- a/tests/upgrade_cli_test.zig
+++ b/tests/upgrade_cli_test.zig
@@ -23,13 +23,9 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_upgrade_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "upgrade", tag);
+        defer allocator.free(base);
+        const path = try std.fmt.allocPrintSentinel(allocator, "{s}", .{base}, 0);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});
@@ -269,11 +265,14 @@ test "execute --pinned --dry-run audits without leaking the parsed Formula" {
 test "execute --dry-run on a fresh prefix without db dir exits silently" {
     // No db/ subdir — lock acquire fails, dry-run takes the silent
     // exit branch instead of surfacing it as contention.
-    const path = "/tmp/malt_upgrade_no_db_dir_dry";
+    const unique = try test_io.uniqueTempPath(testing.allocator, "upgrade", "no_db_dir_dry");
+    defer testing.allocator.free(unique);
+    const path = try testing.allocator.dupeZ(u8, unique);
+    defer testing.allocator.free(path);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
-    _ = c.setenv("MALT_PREFIX", path, 1);
+    _ = c.setenv("MALT_PREFIX", path.ptr, 1);
     defer _ = c.unsetenv("MALT_PREFIX");
 
     output.setDryRun(true);

--- a/tests/upgrade_test.zig
+++ b/tests/upgrade_test.zig
@@ -23,14 +23,9 @@ const c = struct {
 };
 
 fn setupPrefix(suffix: []const u8) ![:0]u8 {
-    const path = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "/tmp/malt_upgrade_exec_{d}_{s}",
-        .{ test_io.nanoTimestamp(
-            std.Options.debug_io,
-        ), suffix },
-        0,
-    );
+    const base = try test_io.uniqueTempPath(testing.allocator, "upgrade_exec", suffix);
+    defer testing.allocator.free(base);
+    const path = try testing.allocator.dupeZ(u8, base);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     _ = c.setenv("MALT_PREFIX", path.ptr, 1);

--- a/tests/uses_cli_test.zig
+++ b/tests/uses_cli_test.zig
@@ -23,13 +23,9 @@ const Scratch = struct {
     path: [:0]u8,
 
     fn init(allocator: std.mem.Allocator, tag: []const u8) !Scratch {
-        const ts = test_io.nanoTimestamp(std.Options.debug_io);
-        const path = try std.fmt.allocPrintSentinel(
-            allocator,
-            "/tmp/malt_uses_cli_{s}_{d}",
-            .{ tag, ts },
-            0,
-        );
+        const base = try test_io.uniqueTempPath(allocator, "uses_cli", tag);
+        defer allocator.free(base);
+        const path = try std.fmt.allocPrintSentinel(allocator, "{s}", .{base}, 0);
         test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
         try test_io.cwd().createDirPath(std.Options.debug_io, path);
         const db_dir = try std.fmt.allocPrint(allocator, "{s}/db", .{path});
@@ -110,11 +106,14 @@ test "execute with no positional formula returns Aborted" {
 }
 
 test "execute on a fresh prefix with no db emits an empty result" {
-    const path = "/tmp/malt_uses_cli_no_db";
+    const unique = try test_io.uniqueTempPath(testing.allocator, "uses_cli", "no_db");
+    defer testing.allocator.free(unique);
+    const path = try testing.allocator.dupeZ(u8, unique);
+    defer testing.allocator.free(path);
     test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
     try test_io.cwd().createDirPath(std.Options.debug_io, path);
     defer test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
-    _ = c.setenv("MALT_PREFIX", path, 1);
+    _ = c.setenv("MALT_PREFIX", path.ptr, 1);
     defer _ = c.unsetenv("MALT_PREFIX");
 
     const ctx = ctxWithSink();

--- a/tests/verify_test.zig
+++ b/tests/verify_test.zig
@@ -141,7 +141,8 @@ test "verifyCosignBlob returns CosignNotFound when the binary is missing" {
 test "verifyCosignBlob accepts a cosign that exits 0" {
     var lio = LiveIo.init();
     defer lio.deinit();
-    const path = "/tmp/malt_fake_cosign_ok";
+    const path = try fs_compat.uniqueTempPath(testing.allocator, "verify", "fake_cosign_ok");
+    defer testing.allocator.free(path);
     try writeFakeCosign(path, 0);
     defer fs_compat.deleteFileAbsolute(std.Options.debug_io, path) catch {};
 
@@ -161,12 +162,15 @@ test "verifyCosignBlob finds a bare 'cosign' via PATH (regression: gh#151)" {
     // `/usr/local/bin:/bin/:/usr/bin` and missed `/opt/homebrew/bin`. Drop
     // a fake `cosign` into a scratch dir, prepend to PATH, and assert
     // bare-name spawn resolves it.
-    const dir = "/tmp/malt_cosign_path_lookup";
+    const dir = try fs_compat.uniqueTempPath(testing.allocator, "verify", "cosign_path_lookup");
+    defer testing.allocator.free(dir);
     fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
     try fs_compat.makeDirAbsolute(std.Options.debug_io, dir);
     defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
 
-    try writeFakeCosign(dir ++ "/cosign", 0);
+    const fake_cosign = try std.fmt.allocPrint(testing.allocator, "{s}/cosign", .{dir});
+    defer testing.allocator.free(fake_cosign);
+    try writeFakeCosign(fake_cosign, 0);
 
     // Snapshot PATH before mutating: `getenv` points into libc's environ,
     // which `setenv` may realloc, so copy into a stable sentinel buffer.
@@ -206,7 +210,7 @@ const Fixture = struct {
     cosign_bin: []const u8,
 
     fn setup(allocator: std.mem.Allocator, tag: []const u8, tarball_bytes: []const u8, checksums_bytes: []const u8, cosign_exit: u8) !Fixture {
-        const dir = try std.fmt.allocPrint(allocator, "/tmp/malt_verifyall_{s}", .{tag});
+        const dir = try fs_compat.uniqueTempPath(allocator, "verifyall", tag);
         fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
         try fs_compat.makeDirAbsolute(std.Options.debug_io, dir);
 
@@ -338,7 +342,8 @@ test "verifyAll streams a large tarball without loading it whole (smoke)" {
     if (mib == 0) return error.SkipZigTest;
     const total: usize = mib * 1024 * 1024;
 
-    const dir = "/tmp/malt_verifyall_smoke";
+    const dir = try fs_compat.uniqueTempPath(testing.allocator, "verifyall", "smoke");
+    defer testing.allocator.free(dir);
     fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
     try fs_compat.makeDirAbsolute(std.Options.debug_io, dir);
     defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
@@ -444,7 +449,8 @@ test "verifyAll rejects a multi-chunk tarball whose content was tampered" {
 test "verifyCosignBlob errors when cosign exits non-zero" {
     var lio = LiveIo.init();
     defer lio.deinit();
-    const path = "/tmp/malt_fake_cosign_fail";
+    const path = try fs_compat.uniqueTempPath(testing.allocator, "verify", "fake_cosign_fail");
+    defer testing.allocator.free(path);
     try writeFakeCosign(path, 1);
     defer fs_compat.deleteFileAbsolute(std.Options.debug_io, path) catch {};
 

--- a/tests/version_notify_test.zig
+++ b/tests/version_notify_test.zig
@@ -186,10 +186,8 @@ test "writeFailureMarker preserves prior cache and bumps last_attempt" {
     const allocator = testing.allocator;
     const io = std.Options.debug_io;
 
-    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notify_fail_{d}", .{fs_compat.nanoTimestamp(
-        std.Options.debug_io,
-    )});
+    const dir = try test_io.uniqueTempPath(allocator, "notify", "fail");
+    defer allocator.free(dir);
     fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
     defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
 
@@ -224,10 +222,10 @@ test "markUpdatedTo bumps current_seen so a manual --check stops the nag" {
     const allocator = testing.allocator;
     const io = std.Options.debug_io;
 
-    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const dir = try std.fmt.bufPrintZ(&dir_buf, "/tmp/malt_notify_check_{d}", .{fs_compat.nanoTimestamp(
-        std.Options.debug_io,
-    )});
+    const dir_base = try test_io.uniqueTempPath(allocator, "notify", "check");
+    defer allocator.free(dir_base);
+    const dir = try std.fmt.allocPrintSentinel(allocator, "{s}", .{dir_base}, 0);
+    defer allocator.free(dir);
     fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
     try fs_compat.makeDirAbsolute(std.Options.debug_io, dir);
     defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
@@ -262,10 +260,8 @@ test "writeFailureMarker on a first-ever run records only the failed attempt" {
     const allocator = testing.allocator;
     const io = std.Options.debug_io;
 
-    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notify_first_{d}", .{fs_compat.nanoTimestamp(
-        std.Options.debug_io,
-    )});
+    const dir = try test_io.uniqueTempPath(allocator, "notify", "first");
+    defer allocator.free(dir);
     fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
     defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
 
@@ -295,10 +291,8 @@ test "writeCache + readCache full round-trip on disk" {
     const allocator = testing.allocator;
     const io = std.Options.debug_io;
 
-    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notify_test_{d}", .{fs_compat.nanoTimestamp(
-        std.Options.debug_io,
-    )});
+    const dir = try test_io.uniqueTempPath(allocator, "notify", "test");
+    defer allocator.free(dir);
     fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
     defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
 
@@ -325,10 +319,8 @@ test "writeCache creates the parent directory when absent" {
     const allocator = testing.allocator;
     const io = std.Options.debug_io;
 
-    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notify_mkdir_{d}", .{fs_compat.nanoTimestamp(
-        std.Options.debug_io,
-    )});
+    const dir = try test_io.uniqueTempPath(allocator, "notify", "mkdir");
+    defer allocator.free(dir);
     fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
     defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
 
@@ -349,10 +341,10 @@ test "writeCache creates the parent directory when absent" {
 
 test "readCache: missing file is null, not an error" {
     const io = std.Options.debug_io;
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const path = try std.fmt.bufPrint(&buf, "/tmp/malt_notify_absent_{d}.json", .{fs_compat.nanoTimestamp(
-        std.Options.debug_io,
-    )});
+    const base = try test_io.uniqueTempPath(testing.allocator, "notify", "absent");
+    defer testing.allocator.free(base);
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}.json", .{base});
+    defer testing.allocator.free(path);
     fs_compat.deleteFileAbsolute(std.Options.debug_io, path) catch {};
     const got = try notifier.readCache(io, testing.allocator, path);
     try testing.expect(got == null);
@@ -360,10 +352,8 @@ test "readCache: missing file is null, not an error" {
 
 test "readCache: corrupt file surfaces InvalidPayload (caller can choose to ignore)" {
     const io = std.Options.debug_io;
-    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const dir = try std.fmt.bufPrint(&dir_buf, "/tmp/malt_notify_corrupt_{d}", .{fs_compat.nanoTimestamp(
-        std.Options.debug_io,
-    )});
+    const dir = try test_io.uniqueTempPath(testing.allocator, "notify", "corrupt");
+    defer testing.allocator.free(dir);
     fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};
     try fs_compat.makeDirAbsolute(std.Options.debug_io, dir);
     defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, dir) catch {};

--- a/tests/which_test.zig
+++ b/tests/which_test.zig
@@ -20,14 +20,9 @@ const c = struct {
 /// `bin/<name>` symlink pointing at it. Returns the prefix path; caller
 /// frees + deletes it.
 fn makePrefixWithKeg(suffix: []const u8, name: []const u8, version: []const u8) ![:0]u8 {
-    const prefix = try std.fmt.allocPrintSentinel(
-        testing.allocator,
-        "/tmp/malt_which_{d}_{s}",
-        .{ test_io.nanoTimestamp(
-            std.Options.debug_io,
-        ), suffix },
-        0,
-    );
+    const base = try test_io.uniqueTempPath(testing.allocator, "which", suffix);
+    defer testing.allocator.free(base);
+    const prefix = try std.fmt.allocPrintSentinel(testing.allocator, "{s}", .{base}, 0);
     test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
 
     const keg_bin = try std.fmt.allocPrint(


### PR DESCRIPTION
## Description

Test fixtures shared fixed `/tmp` paths, so two overlapping runs - a manual `zig build test` racing the pre-push hook - would have one run's `deleteTree` wipe the other's fixtures mid-test. 

One shared helper, `test_io.uniqueTempPath`, now mints `/tmp/malt_<group>_<tag>_<pid>_<seq>`. Two files already carried near-identical private copies of that logic, one of them with a comment apologising for mirroring the other; both now delegate to the shared helper.

## Related Issue

- None

## Notes for Reviewers

Pure test-hygiene change: no source file is touched, and the suite count is byte-identical before and after

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #741 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #740
<!-- GitButler Footer Boundary Bottom -->