### PR TITLE
chore(test): guard against shared fixture paths and leaked scratch

### DIFF
--- a/justfile
+++ b/justfile
@@ -49,6 +49,13 @@ test: regressions-static
 regressions *scripts:
     @./scripts/run-regressions.sh {{ scripts }}
 
+# Run the suite as several simultaneous processes to catch tests that share
+# a fixture path. `just test` runs one process and cannot see those.
+# Also fails if any run leaves a scratch tree behind.
+[group('test')]
+test-concurrent copies="6" rounds="2":
+    ./scripts/test-concurrent.sh {{ copies }} {{ rounds }}
+
 # Run tests under kcov, print line-coverage percentage, and refresh
 # the README badge SVG at .github/badges/coverage.svg.
 # HTML report lands at coverage/merged/kcov-merged/index.html.

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -108,6 +108,17 @@ for pattern in \
   done
 done
 
+# The sandbox fence tests cannot root their scratch under /tmp: the macOS
+# profile grants blanket write there, so the fence would pass without
+# proving anything. They use ~/.cache instead, which the loop above misses.
+if [ -n "${HOME:-}" ]; then
+  echo "▸ Fence scratch under \$HOME/.cache"
+  for path in "$HOME"/.cache/malt_fence_*; do
+    [ -e "$path" ] || continue
+    remove_tree "$path"
+  done
+fi
+
 echo "▸ Bench peer-tool prefixes"
 # Mirror bench.sh defaults; honour env overrides so user-tweaked paths
 # still get cleaned.

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -35,6 +35,17 @@ src_dir="$(pwd)/src"
 # affected tests gate on `MALT_SKIP_SUBPROCESS_TESTS` and stay live under
 # `zig build test`; only this loop opts out of them.
 export MALT_SKIP_SUBPROCESS_TESTS=1
+
+# A test that abandons its scratch tree leaks silently: nothing fails, the
+# directory just stays. That went unnoticed until 7066 of them had piled up
+# under .zig-cache/tmp, some left unreadable and so immune to ordinary
+# cleanup. Counting either side of the run turns the next one into a
+# failure instead of a slow accumulation.
+count_scratch() {
+  find .zig-cache/tmp -mindepth 1 -maxdepth 1 2>/dev/null | wc -l | tr -d ' '
+}
+scratch_before=$(count_scratch)
+
 for bin in zig-out/test-bin/*; do
   # Skip .dSYM debug bundles and any non-regular files
   [ -f "$bin" ] || continue
@@ -42,6 +53,18 @@ for bin in zig-out/test-bin/*; do
   echo "→ kcov: $(basename "$bin")"
   kcov --include-path="$src_dir" coverage "$bin" </dev/null >/dev/null
 done
+
+scratch_after=$(count_scratch)
+if [ "$scratch_after" -gt "$scratch_before" ]; then
+  leaked=$((scratch_after - scratch_before))
+  echo "error: $leaked test scratch dir(s) leaked under .zig-cache/tmp" >&2
+  echo "  A test built a scratch tree and never removed it. Tests must use" >&2
+  echo "  the /tmp Scratch helper, not std.testing.tmpDir, which roots under" >&2
+  echo "  the build cache. Newest offenders:" >&2
+  find .zig-cache/tmp -mindepth 1 -maxdepth 1 2>/dev/null |
+    tail -n 5 | sed 's/^/    /' >&2
+  exit 1
+fi
 
 # kcov 43 on macOS doesn't reliably auto-merge, so do it explicitly.
 # The per-binary reports are in hash-suffixed dirs (e.g. cellar_test.a934ecd0).

--- a/scripts/test-concurrent.sh
+++ b/scripts/test-concurrent.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Run the test suite as several simultaneous processes.
+#
+# `zig build test` runs one process, so it cannot see a test that shares a
+# fixture path with another run. Those bugs surface only under parallelism:
+# two processes build a tree at the same path and delete each other's files,
+# which reads as OpenFailed, PathAlreadyExists, FileNotFound or a sqlite
+# LockError somewhere unrelated to the real culprit.
+#
+# Usage: scripts/test-concurrent.sh [copies] [rounds]
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+copies=${1:-6}
+rounds=${2:-2}
+
+log_dir=$(mktemp -d "/tmp/malt_concurrent.XXXXXX")
+trap 'rm -rf "$log_dir"' EXIT
+
+echo "▸ Building test binaries"
+zig build test-bin
+
+bin=zig-out/test-bin/lib_tests
+if [ ! -x "$bin" ]; then
+  echo "error: $bin missing — did 'zig build test-bin' change its output?" >&2
+  exit 1
+fi
+
+# Scratch trees are keyed by pid, so a leak only shows up as a directory
+# nobody removed. Count around the run rather than trusting exit codes.
+count_scratch() {
+  {
+    find .zig-cache/tmp -mindepth 1 -maxdepth 1 2>/dev/null
+    find /tmp -maxdepth 1 -name 'malt_*' 2>/dev/null
+  } | wc -l | tr -d ' '
+}
+scratch_before=$(count_scratch)
+
+failed=0
+for round in $(seq 1 "$rounds"); do
+  echo "▸ Round $round/$rounds — $copies concurrent copies"
+  pids=""
+  for i in $(seq 1 "$copies"); do
+    "$bin" >"$log_dir/r${round}_$i.log" 2>&1 &
+    pids="$pids $!"
+  done
+
+  # Collect every exit status; a bare `wait` would report only the last.
+  for pid in $pids; do
+    if ! wait "$pid"; then
+      failed=$((failed + 1))
+    fi
+  done
+done
+
+if [ "$failed" -gt 0 ]; then
+  echo "error: $failed of $((copies * rounds)) concurrent runs failed" >&2
+  echo "  Two processes almost certainly shared a fixture path. Failing tests:" >&2
+  grep -h 'FAIL' "$log_dir"/*.log 2>/dev/null | sort -u | sed 's/^/    /' >&2
+  exit 1
+fi
+
+scratch_after=$(count_scratch)
+if [ "$scratch_after" -gt "$scratch_before" ]; then
+  echo "error: $((scratch_after - scratch_before)) scratch dir(s) leaked" >&2
+  echo "  A test built a scratch tree and never removed it." >&2
+  exit 1
+fi
+
+echo "✓ $((copies * rounds)) concurrent runs clean, no scratch leaked"


### PR DESCRIPTION
## Description

Two failure modes in the test suite were invisible by construction.

A test that builds its fixtures at the same path as a concurrent run will delete another run's files. `zig build test` is a single process, so it never sees this - the failure only appears when several copies run at once, and then it surfaces as `OpenFailed`, `PathAlreadyExists`, `FileNotFound` or a sqlite `LockError` somewhere unrelated to the test at fault.

A test that abandons its scratch tree fails nothing at all. The directory simply stays. Nobody counts, so it accumulates.

This adds a guard for each:

- `just test-concurrent [copies] [rounds]` runs the suite as several simultaneous processes (default 6 x 2) and fails if any copy fails or if any run leaves a scratch tree behind. It collects every process's exit status rather than only the last.
- `scripts/coverage.sh` now counts scratch directories either side of its kcov loop and fails with the newest offenders listed, instead of quietly accumulating them.

It also closes two holes in `scripts/clean.sh`, whose stated job is to leave nothing behind:

- The install fixtures build their prefix under a 13-byte cap - the width of `/opt/homebrew` - because the Mach-O patcher rewrites install names in place. The generated name matched none of the cleanup globs, so a crashed run left a whole Cellar tree with nothing to sweep it. It now uses a prefix of the same length inside a family the script already covers, rather than widening a glob to `/tmp/m???????` and risking unrelated directories.
- The sandbox fence scratch lives outside `/tmp` on purpose, because the macOS profile grants blanket write there and a `/tmp` root would let the fence tests pass without proving anything. That location was never swept.

## Related Issue

- None

## Notes for Reviewers

- None