### PR TITLE
fix(dsl): read a leading-zero formula literal as octal

### DIFF
--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -1337,6 +1337,14 @@ fn parseIntValue(lexeme: []const u8) i64 {
         if (lexeme[1] == 'b' or lexeme[1] == 'B') {
             return std.fmt.parseInt(i64, lexeme[2..], 2) catch 0;
         }
+        if (lexeme[1] == 'd' or lexeme[1] == 'D') {
+            return std.fmt.parseInt(i64, lexeme[2..], 10) catch 0;
+        }
+    }
+    // Ruby reads a bare leading zero as octal, which is how every formula
+    // spells a file mode: `chmod 0755`.
+    if (lexeme.len > 1 and lexeme[0] == '0' and std.ascii.isDigit(lexeme[1])) {
+        return std.fmt.parseInt(i64, lexeme[1..], 8) catch 0;
     }
     return std.fmt.parseInt(i64, lexeme, 10) catch 0;
 }
@@ -1345,6 +1353,28 @@ fn parseIntValue(lexeme: []const u8) i64 {
 // bounded `ParseError` with a diagnostic — never recurse into a native
 // stack overflow. Balanced parens so that, without the guard, the body
 // would parse cleanly; the guard is what converts it into an error.
+// Formulae are Ruby, where a leading zero means octal. Reading `chmod 0755`
+// as decimal 755 yields mode 0o1363 — owner loses read, and the sticky bit
+// appears — so every mode literal in every formula lands wrong.
+test "parser: a leading-zero integer literal is octal, as in Ruby" {
+    try std.testing.expectEqual(@as(i64, 0o755), parseIntValue("0755"));
+    try std.testing.expectEqual(@as(i64, 0o644), parseIntValue("0644"));
+    try std.testing.expectEqual(@as(i64, 0o600), parseIntValue("0600"));
+    try std.testing.expectEqual(@as(i64, 0o4755), parseIntValue("04755"));
+}
+
+test "parser: integer literals without a leading zero stay decimal" {
+    try std.testing.expectEqual(@as(i64, 0), parseIntValue("0"));
+    try std.testing.expectEqual(@as(i64, 755), parseIntValue("755"));
+    try std.testing.expectEqual(@as(i64, 10), parseIntValue("10"));
+}
+
+test "parser: explicit radix prefixes keep their meaning" {
+    try std.testing.expectEqual(@as(i64, 0x1F), parseIntValue("0x1F"));
+    try std.testing.expectEqual(@as(i64, 0o17), parseIntValue("0o17"));
+    try std.testing.expectEqual(@as(i64, 0b101), parseIntValue("0b101"));
+}
+
 test "parser: expression nesting beyond the depth limit is a bounded ParseError" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -585,6 +585,15 @@ test "interpreter: chmod array no error" {
     ;
     const err = try runSnippet(&arena, src, prefix);
     try testing.expect(err == null);
+
+    // The mode has to survive the parser, not just the builtin: a formula
+    // spells it `0755`, and Ruby reads a leading zero as octal. Reading it as
+    // decimal lands 0o1363 here, which also denies owner read and so wedges
+    // the scratch teardown.
+    for ([_][]const u8{ bin_dir, sbin_dir }) |d| {
+        const got = (try test_io.cwd().statFile(std.Options.debug_io, d, .{})).permissions.toMode();
+        try testing.expectEqual(@as(std.posix.mode_t, 0o755), got & 0o777);
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Formulae are Ruby, where a leading zero makes a numeric literal octal. The DSL parser handled the `0x`, `0o` and `0b` prefixes but read a bare leading zero as decimal, so `chmod 0755` applied decimal 755 - mode `0o1363`.

The parser now reads a bare leading zero as octal, and `0d` as decimal while that branch was open.

## Related Issue

- None

## Notes for Reviewers

**Why this survived.** The builtin's own test passes a Zig literal - `Value{ .int = 0o755 }` - straight to `chmod`, so it never crosses the parser. The snippet-level test ran `chmod 0755` through the whole pipeline but only asserted that no error came back, never the resulting mode. The one test where both halves met asserted nothing about the outcome, so each half looked covered.

The interpreter test now asserts the mode a formula actually produces, which is the assertion that was missing.

**How it surfaced.** As a cleanup failure, not a permissions complaint: `0o1363` denies owner read, so the test's own scratch tree became undeletable and quietly accumulated. Chasing those leaked directories is what led here.
