### PR TITLE
fix(outdated): stop qualifying tap cask versions with a stray revision

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -126,6 +126,7 @@ pub fn build(b: *std.Build) void {
         "tests/progress_e2e_test.zig",
         "tests/completions_test.zig",
         "tests/flag_drift_test.zig",
+        "tests/cask_revision_invariant_test.zig",
         "tests/backup_test.zig",
         "tests/purge_test.zig",
         "tests/purge_output_test.zig",

--- a/src/cli/install/rb_parse.zig
+++ b/src/cli/install/rb_parse.zig
@@ -79,6 +79,8 @@ pub fn parseRubyFormula(rb_content: []const u8) ?RubyFormulaInfo {
 
         // Extract `revision N` (global, unquoted integer). Ignored by the
         // install path; the outdated audit uses it to spot revision bumps.
+        // Layout-blind and formula-oriented: it matches at any indentation, in
+        // any block, so the cask caller discards what it finds.
         if (revision == 0 and std.mem.startsWith(u8, line, "revision ")) {
             const rest = std.mem.trim(u8, line["revision ".len..], " \t");
             revision = std.fmt.parseInt(i64, rest, 10) catch 0;

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -190,9 +190,11 @@ fn isCorePathRow(row: KegRow) bool {
     return if (row.tap) |t| install_args_mod.isCoreTap(t) else true;
 }
 
-// Outdated policy: malt treats the tap as the source of truth. A keg is
-// "outdated" whenever its revision-qualified installed version is not byte-equal
-// to the current upstream version — NOT when it is strictly older. This never
+// Outdated policy — the single normative statement; every other compare site
+// points here rather than restating it. malt treats the tap as the source of
+// truth. A keg is "outdated" whenever its revision-qualified installed version
+// is not byte-equal to the current upstream version — NOT when it is strictly
+// older (casks have no revision, so theirs is bare). This never
 // misses an upgrade (any difference surfaces); the trade-off is that if upstream
 // moves backward (a yanked release), `outdated` lists it and `upgrade` follows
 // the tap down. That downgrade is by design, surfaced as `old -> new` in
@@ -952,9 +954,16 @@ fn tapVersionFromSubtrees(
                 return null;
             };
             // Qualify with the .rb revision so a tap revision-only bump is
-            // detected, matching the core fetch path.
+            // detected, matching the core fetch path. Casks have no revision to
+            // qualify with, so a qualified string here could never equal an
+            // installed one — see the outdated policy note above.
+            // Keyed on the primary subtree, not the list length, so adding a
+            // root-layout cask fallback the way `.formula_root` was added
+            // cannot silently re-qualify.
+            const is_cask = subtrees.len > 0 and subtrees[0] == .cask;
+            const revision = if (is_cask) 0 else rb_info.revision;
             var ver_buf: [256]u8 = undefined;
-            const qualified = formula_mod.pkgVersion(&ver_buf, rb_info.version, rb_info.revision) catch rb_info.version;
+            const qualified = formula_mod.pkgVersion(&ver_buf, rb_info.version, revision) catch rb_info.version;
             return alloc.dupe(u8, qualified) catch null;
         },
     }
@@ -1618,6 +1627,50 @@ test "tapVersionFromSubtrees qualifies the resolved version with the .rb revisio
     defer if (v) |vv| std.testing.allocator.free(vv);
     try std.testing.expect(v != null);
     try std.testing.expectEqualStrings("1.2.3_2", v.?);
+}
+
+test "tapVersionFromSubtrees discards the revision on the cask leg" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+
+    // A hand-written tap cask carrying a stray `revision`: no Cask DSL stanza
+    // produces one, but the shared Ruby parser picks it up anyway.
+    const cask_rb =
+        \\cask "pkg" do
+        \\  version "1.2"
+        \\  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+        \\  url "https://x/pkg-1.2.dmg"
+        \\  revision 2
+        \\end
+    ;
+    // Primed to 1: the cask leg has no root-layout fallback to spend the
+    // server's opening 404 on.
+    var srv = RbFallbackServer{ .io = io, .listener = &listener, .root_rb = cask_rb, .idx = std.atomic.Value(usize).init(1) };
+    const thread = try std.Thread.spawn(.{}, RbFallbackServer.serve, .{&srv});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client_mod.HttpClient.initWith(&inner, io, std.process.Environ.empty, std.testing.allocator);
+    defer http.deinit();
+
+    var base_buf: [64]u8 = undefined;
+    const raw_base = try std.fmt.bufPrint(&base_buf, "http://127.0.0.1:{d}", .{port});
+
+    const v = tapVersionFromSubtrees(std.testing.allocator, &http, std.process.Environ.empty, .github, raw_base, "deadbeef", "pkg", &.{.cask}, "cask", "user/repo");
+    listener.deinit(io);
+    thread.join();
+
+    defer if (v) |vv| std.testing.allocator.free(vv);
+    try std.testing.expect(v != null);
+    try std.testing.expectEqualStrings("1.2", v.?);
+    // The convergence that actually failed: byte-equal to the bare `version`
+    // upgrade's cask skip decision compares against.
+    const parsed = install_rb_parse_mod.parseRubyFormula(cask_rb).?;
+    try std.testing.expectEqualStrings(parsed.version, v.?);
 }
 
 test "tap rows reuse the caller-supplied client (the tap path constructs no HttpClient)" {

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -1009,13 +1009,10 @@ fn upgradeRoutedTapCask(
     }
 
     if (dry_run) {
-        if (sink) |s| {
-            // Qualify with the .rb revision to match `assembleEntries`'
-            // tap-cask latest (`pkgVersion(version, revision)`).
-            var latest_buf: [256]u8 = undefined;
-            const latest = formula_mod.pkgVersion(&latest_buf, rb_info.version, rb_info.revision) catch rb_info.version;
-            s.collectCask(token, installed_version, latest);
-        }
+        // Bare, like the skip decision above: this warms the snapshot that
+        // `outdated` reads, and a cask's installed version can never carry a
+        // revision to match a qualified one against.
+        if (sink) |s| s.collectCask(token, installed_version, rb_info.version);
         output.info("Dry run: would upgrade cask {s} {s} -> {s}", .{ token, installed_version, rb_info.version });
         output.emitNdjsonEvent(.would_install, token, null);
         return .would_upgrade;

--- a/tests/cask_revision_invariant_test.zig
+++ b/tests/cask_revision_invariant_test.zig
@@ -1,0 +1,98 @@
+//! malt — parsed-revision consumer guard
+//!
+//! A cask has no revision: the Cask DSL has no such stanza and the `casks`
+//! table has no such column. But `parseRubyFormula` serves both the formula
+//! and cask legs and greps `revision` layout-blind, so a hand-written tap
+//! `.rb` can hand one to either caller. Qualifying a cask version with it
+//! mints a string no installed cask can ever equal — the row is listed
+//! forever and the upgrade is skipped forever.
+//!
+//! Keeping that correct means keeping every consumer of the parsed revision
+//! accounted for. A cask-side consumer that qualifies is a bug; the failure
+//! is silent, needs hand-written tap content to trigger, and lives in a
+//! different file from the code it contradicts. So the count is pinned here:
+//! a new consumer fails this test and has to declare which leg it serves.
+//!
+//! The guard keys on `rb_info.revision`, the binding both call sites use for
+//! `parseRubyFormula`'s result. Renaming that binding means updating this
+//! list.
+
+const std = @import("std");
+const testing = std.testing;
+const test_io = @import("test_io");
+
+const TOKEN = "rb_info.revision";
+
+/// Every accounted-for consumer, with the leg it serves. Paths are relative
+/// to `src/cli`, the walked root.
+const allowed = [_]struct {
+    path: []const u8,
+    why: []const u8,
+}{
+    .{
+        .path = "outdated/refresh.zig",
+        .why = "shared fetch leg — forces 0 on the cask subtree before qualifying",
+    },
+    .{
+        .path = "upgrade.zig",
+        .why = "tap formula leg — formulas do carry revisions, so it qualifies",
+    },
+};
+
+fn allowedFor(path: []const u8) ?usize {
+    for (allowed, 0..) |entry, i| {
+        if (std.mem.eql(u8, path, entry.path)) return i;
+    }
+    return null;
+}
+
+test "every consumer of a parsed .rb revision is accounted for" {
+    const allocator = testing.allocator;
+
+    var dir = try test_io.cwd().openDir(std.Options.debug_io, "src/cli", .{ .iterate = true });
+    defer dir.close(std.Options.debug_io);
+
+    var walker = try dir.walk(allocator);
+    defer walker.deinit();
+
+    var seen = [_]usize{0} ** allowed.len;
+
+    while (try walker.next(std.Options.debug_io)) |ent| {
+        if (ent.kind != .file) continue;
+        if (!std.mem.endsWith(u8, ent.basename, ".zig")) continue;
+
+        const f = try ent.dir.openFile(std.Options.debug_io, ent.basename, .{});
+        defer f.close(std.Options.debug_io);
+        const src = try test_io.readFileToEndAlloc(f, allocator, 4 * 1024 * 1024);
+        defer allocator.free(src);
+
+        var hits: usize = 0;
+        var it = std.mem.splitScalar(u8, src, '\n');
+        while (it.next()) |line| {
+            if (std.mem.indexOf(u8, line, TOKEN) != null) hits += 1;
+        }
+        if (hits == 0) continue;
+
+        const idx = allowedFor(ent.path) orelse {
+            std.debug.print(
+                "\nsrc/cli/{s} consumes the parsed .rb revision and is not accounted for.\n" ++
+                    "If it serves casks it must force 0 — see the outdated policy note\n" ++
+                    "in src/cli/outdated/refresh.zig. If it serves formulas, add it here.\n",
+                .{ent.path},
+            );
+            return error.UnaccountedRevisionConsumer;
+        };
+        seen[idx] += hits;
+    }
+
+    // One use each: the guarded ternary and the formula-leg qualification. A
+    // second use in the same file is the shape the cask dry-run sink had.
+    for (allowed, seen) |entry, count| {
+        if (count == 1) continue;
+        std.debug.print(
+            "\n{s} uses the parsed .rb revision {d} time(s), expected 1 ({s}).\n",
+            .{ entry.path, count, entry.why },
+        );
+        return error.RevisionConsumerCountChanged;
+    }
+}


### PR DESCRIPTION
## Description

A tap cask whose `.rb` happens to contain a `revision` line could get stuck in the outdated list forever: `mt outdated` qualified the upstream version with that revision while `mt upgrade`'s skip decision compared the bare one, so the row was always listed and always reported already-current.

Casks have no revision by construction - the Cask DSL has no such stanza and the database has no such column.

This is a robustness fix: it takes hand-written tap content to trigger, so no released package is expected to change behaviour. The value is that malt trusts one less field out of third-party `.rb` bytes and no longer produces a version string nothing else agrees with.

## Related Issue

- None

## Notes for Reviewers

- None