### PR TITLE
fix(upgrade): print the revision-qualified installed version

### DIFF
--- a/scripts/regressions/upgrade-dry-run-warms-outdated-snapshot.sh
+++ b/scripts/regressions/upgrade-dry-run-warms-outdated-snapshot.sh
@@ -63,16 +63,16 @@ reset_state() {
 
 # Seed one installed formula keg (core path: tap is NULL).
 seed_keg() {
-  local name="$1" version="$2"
-  sqlite3 "$DB" "INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path)
-    VALUES ('$name', '$name', '$version', 'seedsha', '/tmp/c/$name/$version');"
+  local name="$1" version="$2" revision="${3:-0}"
+  sqlite3 "$DB" "INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+    VALUES ('$name', '$name', '$version', $revision, 'seedsha', '/tmp/c/$name/$version');"
 }
 
 # Fake upstream: a fresh cached formula document at $stable. parseFormula only
 # needs name + versions.stable to derive pkg_version.
 seed_formula_cache() {
-  local name="$1" stable="$2"
-  printf '{"name":"%s","versions":{"stable":"%s"}}' "$name" "$stable" \
+  local name="$1" stable="$2" revision="${3:-0}"
+  printf '{"name":"%s","versions":{"stable":"%s"},"revision":%s}' "$name" "$stable" "$revision" \
     >"$API/formula_$name.json"
 }
 
@@ -126,5 +126,25 @@ seed_bogus_snapshot
 grep -q '"name":"bogus"' "$SNAP" ||
   fail "a real upgrade warmed the snapshot — the pre-upgrade set is stale once kegs mutate"
 pass "real upgrade leaves the snapshot untouched"
+
+# --- 5. Both sides of the would-upgrade line carry the revision ---
+# malt follows the tap down on an upstream yank (see the outdated policy note in
+# src/cli/outdated/refresh.zig), and --dry-run is the only preview of that. A
+# bare installed version against a qualified upstream one renders the yank
+# `1.2.3 -> 1.2.3_1`, i.e. backwards, so the one promised surprise is invisible.
+reset_state
+seed_keg regrev 1.2.3 2
+seed_formula_cache regrev 1.2.3 1
+
+OUT=$("$BIN" upgrade --dry-run 2>&1 || true)
+echo "$OUT" | grep -q "would upgrade regrev 1.2.3_2 -> 1.2.3_1" ||
+  fail "dry-run hid the installed revision (a downgrade rendered as an upgrade); got:\n$OUT"
+pass "would-upgrade line qualifies the installed version with its revision"
+
+# The warmed snapshot is the --json boundary the TUI reads: it was already
+# qualified before this fix and must stay byte-identical.
+grep -q '"name":"regrev","installed":"1.2.3_2","latest":"1.2.3_1"' "$SNAP" ||
+  fail "warmed snapshot entry changed shape; got: $(cat "$SNAP")"
+pass "warmed snapshot entry is unchanged by the display fix"
 
 printf '\n\xe2\x9c\x94 upgrade dry-run warms-outdated-snapshot regression passed\n'

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -561,7 +561,9 @@ fn upgradeFormula(
     }
 
     // Reconstruct the revision-aware path label for the old keg so
-    // cellar_mod.remove / linker calls target the actual on-disk dir.
+    // cellar_mod.remove / linker calls target the actual on-disk dir. It is
+    // also what the skip compare and the upgrade lines below must use: both
+    // sides have to be qualified or a revision move renders inverted.
     var old_pkgver_buf: [128]u8 = undefined;
     const old_pkg_version = formula_mod.pkgVersion(&old_pkgver_buf, old.version, old.revision) catch old.version;
 
@@ -589,13 +591,13 @@ fn upgradeFormula(
 
     if (dry_run) {
         if (sink) |s| s.collectFormula(name, old.version, old.revision, formula.pkg_version);
-        output.info("Dry run: would upgrade {s} {s} -> {s}", .{ name, old.version, formula.pkg_version });
+        output.info("Dry run: would upgrade {s} {s} -> {s}", .{ name, old_pkg_version, formula.pkg_version });
         // Same vocabulary across install/upgrade/migrate — one parser fits all.
         output.emitNdjsonEvent(.would_install, name, null);
         return .would_upgrade;
     }
 
-    output.info("Upgrading {s} {s} -> {s}...", .{ name, old.version, formula.pkg_version });
+    output.info("Upgrading {s} {s} -> {s}...", .{ name, old_pkg_version, formula.pkg_version });
     output.emitNdjsonEvent(.resolved, name, null);
 
     // Bottles bake LC_LOAD_DYLIB paths against their own dep set, so a
@@ -760,6 +762,9 @@ fn upgradeFormula(
 /// move the tap `.rb` proves current; `collect` is a genuine would-upgrade row.
 const TapWarmDecision = enum { collect, skip, taint };
 
+/// Equality — not ordering — is the definition of outdated; the normative
+/// statement lives in `src/cli/outdated/refresh.zig` and is not restated here.
+///
 /// null `upstream` (fetch/parse failed) taints rather than skips: without a
 /// version we cannot prove the row current, and skipping it would silently
 /// under-report a genuinely-outdated tap keg — a taint re-audits everything
@@ -1347,6 +1352,10 @@ fn upgradeCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []const 
     };
     defer parsed_cask.deinit();
 
+    // Bare on both sides, and correct only because a cask carries no revision
+    // anywhere — the formula leg has to qualify both sides to obey the same
+    // policy (see `src/cli/outdated/refresh.zig`). Should a cask ever gain a
+    // revision, this compare and the prints below go wrong together.
     const installed_version = installed.version();
     if (std.mem.eql(u8, installed_version, parsed_cask.version)) {
         if (!bulk) output.skip("{s} is already at latest version {s}", .{ token, parsed_cask.version });


### PR DESCRIPTION
## Description

Take a formula installed at `1.2.3_2` whose tap reverts to `1.2.3_1`. malt treats any difference from the tap as "outdated", so `mt upgrade` follows the tap **down** - that is a downgrade, and it is by design. The upgrade line, however, printed the installed side bare and the upstream side revision-qualified, so the move rendered as `1.2.3 -> 1.2.3_1`: the `_2` actually on disk was invisible, and losing a revision looked like gaining a version. It now reads `1.2.3_2 -> 1.2.3_1`.

`--dry-run` is the documented preview for exactly this case, and that promise only holds if the preview is honest. Packages installed at revision 0 - nearly all of them - render exactly as before, since a bare version is what `pkgVersion` returns for them.

Display only: the skip decision was already comparing the qualified string, so no package's upgrade outcome changes. `--json` and the NDJSON stream are byte-identical, so the TUI and machine consumers are unaffected.

## Related Issue

- None

## Notes for Reviewers

- None