### PR TITLE
chore(help): document that tap formulas upgrade on tap changes

### DIFF
--- a/man/malt.1
+++ b/man/malt.1
@@ -158,6 +158,10 @@ casks are skipped with a "pinned, skipped" line; pass --force to
 override. malt follows the tap: if the tap version differs from the
 installed one it is applied, even if that moves the version down
 (e.g. an upstream revert) — preview with --dry-run.
+Formulas from a third-party tap are the exception: they upgrade when
+the tap content changes, not when the version changes, so a reinstall
+with no version movement is expected. Core formulas and casks follow
+the version rule above.
 
 Flags:
   --cask         Upgrade casks only

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -149,6 +149,10 @@ const upgrade_help =
     \\override. malt follows the tap: if the tap version differs from the
     \\installed one it is applied, even if that moves the version down
     \\(e.g. an upstream revert) — preview with --dry-run.
+    \\Formulas from a third-party tap are the exception: they upgrade when
+    \\the tap content changes, not when the version changes, so a reinstall
+    \\with no version movement is expected. Core formulas and casks follow
+    \\the version rule above.
     \\
     \\Flags:
     \\  --cask         Upgrade casks only

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -881,6 +881,10 @@ fn upgradeTapFormula(
         });
     const same_commit = if (cached_sha_opt) |c| std.mem.eql(u8, c, fresh_sha) else false;
 
+    // Third policy, deliberately not the version policy: a tap formula upgrades
+    // on tap content, so a `.rb` edit with no version bump still reinstalls.
+    // Stated to users in `upgrade_help` (`src/cli/help.zig`); the version rule it
+    // differs from is the note in `src/cli/outdated/refresh.zig`.
     if (!force and same_commit) {
         if (!bulk) output.skip("{s} is already at latest tap commit", .{name});
         output.emitNdjsonEvent(.up_to_date, name, null);


### PR DESCRIPTION
## Description

Third-party tap formulas do not upgrade on version changes - they upgrade when the tap content changes, so a `.rb` edit with no version bump still triggers a reinstall.

That rule has always been in the code and has never been in the help text, which documents only the version-equality policy. A user who read `upgrade --help` had no way to predict it.

`upgrade --help` now states the rule alongside the existing policy paragraph, scoped to tap formulas so it does not blur the version rule that governs core formulas and casks.

Documentation only: the rule's behaviour is unchanged.

## Related Issue

- None

## Notes for Reviewers

- None