### PR TITLE
feat(outdated): mark rows whose upstream moved backward

### DIFF
--- a/scripts/regressions/outdated-downgrade-marker-not-persisted.sh
+++ b/scripts/regressions/outdated-downgrade-marker-not-persisted.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Regression: `mt outdated` marks a row whose tap moved *backward*, and the
+# marker stays derived — it never reaches the cached `outdated.json`.
+#
+# The marker is computed at emit time from the two version labels the row
+# already carries, so the snapshot codec is untouched and `snapshot_version`
+# does not move. That is what keeps an older malt able to read a snapshot
+# written by a newer one, and a newer malt able to mark a row served from a
+# snapshot written before the marker existed. If the marker were ever
+# persisted instead, this script fails on the last two assertions.
+#
+# Hermetic: a keg is seeded straight into the DB and the snapshot is served
+# offline, so no API call and no network are involved.
+#
+# Usage: scripts/regressions/outdated-downgrade-marker-not-persisted.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt, sqlite3 on PATH.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+PREFIX=$(mktemp -d -t malt_outdated_downgrade.XXXXXX)
+trap 'rm -rf "$PREFIX"' EXIT
+export MALT_PREFIX="$PREFIX"
+export MALT_CACHE="$PREFIX/cache"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+unset MALT_OUTDATED_MAX_AGE CI
+
+SNAP="$MALT_CACHE/outdated.json"
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+mkdir -p "$PREFIX/db" "$MALT_CACHE"
+"$BIN" list >/dev/null 2>&1 || true
+
+DB="$PREFIX/db/malt.db"
+[[ -f "$DB" ]] || fail "expected DB at $DB after schema init"
+
+# A real yanked-release pair: upstream 2.4.14 is behind the installed 2.4.15.
+sqlite3 "$DB" "INSERT INTO kegs (name, full_name, version, revision, tap, store_sha256, cellar_path) \
+  VALUES ('pip-audit', 'pip-audit', '2.4.15', 0, 'homebrew/core', 'sha', '${PREFIX}/Cellar/pip-audit/2.4.15');"
+
+gen_ms=$((($(date +%s) - 60) * 1000))
+printf '{"version":2,"generated_at_ms":%s,"formulas":[{"name":"pip-audit","installed":"2.4.15","latest":"2.4.14"}],"casks":[]}' \
+  "$gen_ms" >"$SNAP"
+
+JSON_OUT=$(MALT_OFFLINE=1 "$BIN" outdated --json 2>/dev/null)
+grep -q '"downgrade":true' <<<"$JSON_OUT" ||
+  fail "--json did not mark the backward row: $JSON_OUT"
+pass "--json marks the backward row"
+
+HUMAN_OUT=$(MALT_OFFLINE=1 "$BIN" outdated 2>/dev/null)
+grep -q '\[downgrade\]' <<<"$HUMAN_OUT" ||
+  fail "the human row did not mark the backward move: $HUMAN_OUT"
+pass "the human row marks the backward move"
+
+grep -q '"version":2' "$SNAP" ||
+  fail "snapshot_version moved — a derived marker must not need a codec bump"
+pass "the snapshot keeps snapshot_version 2"
+
+if grep -q 'downgrade' "$SNAP"; then
+  fail "the marker leaked into the cached snapshot — it must stay derived"
+fi
+pass "the cached snapshot carries no marker field"
+
+printf '\n\xe2\x9c\x94 outdated downgrade-marker regression passed\n'

--- a/src/cli/outdated/render.zig
+++ b/src/cli/outdated/render.zig
@@ -8,6 +8,7 @@
 const std = @import("std");
 
 const color = @import("../../ui/color.zig");
+const formula_mod = @import("../../core/formula.zig");
 const output = @import("../../ui/output.zig");
 const snap_mod = @import("snapshot.zig");
 const OutdatedEntry = snap_mod.OutdatedEntry;
@@ -72,6 +73,9 @@ pub fn writeJsonArray(
         try w.writeAll(if (r.pinned) "true" else "false");
         try w.writeAll(",\"tap\":");
         try output.jsonStr(w, r.tap);
+        // Additive and only when proven, so every other row stays
+        // byte-identical and `schema_version` need not move.
+        if (isDowngrade(r.installed, r.latest)) try w.writeAll(",\"downgrade\":true");
         try w.writeAll("}");
     }
     try w.writeAll("]}\n");
@@ -95,7 +99,16 @@ fn writeEntry(stdout: *std.Io.Writer, e: OutdatedEntry, kind_tag: ?[]const u8) v
     // `≠`, not `<`: outdated is decided by inequality with the tap.
     writeStyledSpan(stdout, color.SemanticStyle.warn.code(), " \xe2\x89\xa0 ", e.latest, "");
     if (kind_tag) |t| writeStyledSpan(stdout, color.SemanticStyle.detail.code(), " [", t, "]");
+    // A word, not a glyph: it has to survive `NO_COLOR`.
+    if (isDowngrade(e.installed, e.latest))
+        writeStyledSpan(stdout, color.SemanticStyle.warn.code(), " [", "downgrade", "]");
     stdout.writeAll("\n") catch return;
+}
+
+/// True only when the tap is *provably* behind. An unrankable pair
+/// renders unmarked, which is what keeps this safe for odd taps.
+fn isDowngrade(installed: []const u8, latest: []const u8) bool {
+    return formula_mod.relate(installed, latest) == .older;
 }
 
 fn writeBullet(stdout: *std.Io.Writer) void {
@@ -124,17 +137,37 @@ fn writeStyledSpan(
 }
 
 test "writeJsonArray wraps formulae and casks in a versioned root with all six fields" {
+    // Also the byte pin for the marker: the two forward rows must stay
+    // exactly as they were, and only the backward row gains `downgrade`.
     var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer aw.deinit();
 
     const rows = [_]Row{
         .{ .name = "alpha", .installed = "1.0", .latest = "2.0", .kind = .formula, .pinned = false, .tap = "" },
         .{ .name = "beta-cask", .installed = "3.0", .latest = "4.0", .kind = .cask, .pinned = true, .tap = "user/repo" },
+        .{ .name = "yanked", .installed = "2.4.15", .latest = "2.4.14", .kind = .formula, .pinned = false, .tap = "" },
     };
     try writeJsonArray(std.testing.allocator, &aw.writer, &rows);
 
     const want =
-        \\{"schema_version":1,"outdated":[{"name":"alpha","installed":"1.0","latest":"2.0","type":"formula","pinned":false,"tap":""},{"name":"beta-cask","installed":"3.0","latest":"4.0","type":"cask","pinned":true,"tap":"user/repo"}]}
+        \\{"schema_version":1,"outdated":[{"name":"alpha","installed":"1.0","latest":"2.0","type":"formula","pinned":false,"tap":""},{"name":"beta-cask","installed":"3.0","latest":"4.0","type":"cask","pinned":true,"tap":"user/repo"},{"name":"yanked","installed":"2.4.15","latest":"2.4.14","type":"formula","pinned":false,"tap":"","downgrade":true}]}
+    ++ "\n";
+    try std.testing.expectEqualStrings(want, aw.written());
+}
+
+test "writeJsonArray leaves an incomparable pair unmarked" {
+    // The give-up arm is what makes the marker safe for casks and unusual
+    // taps: uncertainty must render as a plain row, never as an alarm.
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+
+    const rows = [_]Row{
+        .{ .name = "odd", .installed = "1.0rc2", .latest = "1.0", .kind = .formula, .pinned = false, .tap = "" },
+    };
+    try writeJsonArray(std.testing.allocator, &aw.writer, &rows);
+
+    const want =
+        \\{"schema_version":1,"outdated":[{"name":"odd","installed":"1.0rc2","latest":"1.0","type":"formula","pinned":false,"tap":""}]}
     ++ "\n";
     try std.testing.expectEqualStrings(want, aw.written());
 }
@@ -274,4 +307,56 @@ test "the plain-text row contains no directional comparison glyph" {
 
     try std.testing.expectEqualStrings("  \xe2\x96\xb8 alpha (1.0) ≠ 2.0\n", aw.written());
     try std.testing.expect(std.mem.indexOfAny(u8, aw.written(), "<>") == null);
+}
+
+test "a backward cask row keeps both tags, kind first" {
+    color.setForTest(false, null);
+    output.setQuiet(false);
+    defer color.setForTest(null, null);
+
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+
+    const entries = [_]OutdatedEntry{
+        .{ .name = @constCast("font"), .installed = @constCast("3.0,55"), .latest = @constCast("2.0,40") },
+    };
+    writeCaskEntries(&aw.writer, &entries);
+
+    try std.testing.expectEqualStrings("  \xe2\x96\xb8 font (3.0,55) ≠ 2.0,40 [cask] [downgrade]\n", aw.written());
+}
+
+test "quiet mode stays name-only for a backward row" {
+    // `--quiet` feeds shell pipelines; a marker there would corrupt them.
+    color.setForTest(false, null);
+    output.setQuiet(true);
+    defer color.setForTest(null, null);
+    defer output.setQuiet(false);
+
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+
+    const entries = [_]OutdatedEntry{
+        .{ .name = @constCast("yanked"), .installed = @constCast("2.4.15"), .latest = @constCast("2.4.14") },
+    };
+    writeFormulaEntries(&aw.writer, &entries);
+
+    try std.testing.expectEqualStrings("yanked\n", aw.written());
+}
+
+test "the plain-text row names a backward move in words" {
+    // The ordering claim is earned here, not glyphed: a checked marker that
+    // survives NO_COLOR and reads as English, unlike the arrow it replaces.
+    color.setForTest(false, null);
+    output.setQuiet(false);
+    defer color.setForTest(null, null);
+
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+
+    const entries = [_]OutdatedEntry{
+        .{ .name = @constCast("yanked"), .installed = @constCast("2.4.15"), .latest = @constCast("2.4.14") },
+    };
+    writeFormulaEntries(&aw.writer, &entries);
+
+    try std.testing.expectEqualStrings("  \xe2\x96\xb8 yanked (2.4.15) ≠ 2.4.14 [downgrade]\n", aw.written());
 }

--- a/src/core/formula.zig
+++ b/src/core/formula.zig
@@ -455,7 +455,183 @@ pub fn parsePkgVersion(label: []const u8) ParsedPkgVersion {
     return .{ .version = label[0..us], .revision = rev };
 }
 
+/// Direction of a version move, installed → upstream. `incomparable` is
+/// load-bearing: a caller acting on `older` never acts on a guess.
+pub const Rel = enum { older, same, newer, incomparable };
+
+/// Which way upstream moved relative to what is installed, or decline.
+/// Advisory: `outdated` still triggers on byte inequality, so a wrong
+/// answer here mislabels a row and can never hide an upgrade. No
+/// pre-release ranking table — measured over real Homebrew transitions it
+/// buys almost nothing and costs confident wrong answers.
+pub fn relate(installed: []const u8, upstream: []const u8) Rel {
+    if (std.mem.eql(u8, installed, upstream)) return .same;
+
+    const a = parsePkgVersion(installed);
+    const b = parsePkgVersion(upstream);
+    return switch (relateVersion(a.version, b.version)) {
+        .same => if (b.revision > a.revision)
+            .newer
+        else if (b.revision < a.revision)
+            .older
+        else
+            .same,
+        .older => .older,
+        .newer => .newer,
+        .incomparable => .incomparable,
+    };
+}
+
+/// Walk both versions in runs of digits and non-digits. Digit runs
+/// compare numerically; a differing non-digit run gives up.
+fn relateVersion(a: []const u8, b: []const u8) Rel {
+    var i: usize = 0;
+    var j: usize = 0;
+    while (i < a.len and j < b.len) {
+        const digits = std.ascii.isDigit(a[i]);
+        if (digits != std.ascii.isDigit(b[j])) return .incomparable;
+
+        const a_end = runEnd(a, i, digits);
+        const b_end = runEnd(b, j, digits);
+        if (digits) {
+            switch (compareDigitRun(a[i..a_end], b[j..b_end])) {
+                .lt => return .newer,
+                .gt => return .older,
+                .eq => {},
+            }
+        } else if (!std.mem.eql(u8, a[i..a_end], b[j..b_end])) return .incomparable;
+
+        i = a_end;
+        j = b_end;
+    }
+    if (i == a.len and j == b.len) return .same;
+
+    // A tail with letters is a pre-release marker this refuses to rank; an
+    // all-zero tail is the padding Homebrew applies anyway (`1.0` is `1.0.0`).
+    const tail = if (i < a.len) a[i..] else b[j..];
+    var significant = false;
+    for (tail) |c| {
+        if (std.ascii.isAlphabetic(c)) return .incomparable;
+        if (std.ascii.isDigit(c) and c != '0') significant = true;
+    }
+    if (!significant) return .same;
+    return if (i < a.len) .older else .newer;
+}
+
+fn runEnd(s: []const u8, start: usize, digits: bool) usize {
+    var k = start;
+    while (k < s.len and std.ascii.isDigit(s[k]) == digits) k += 1;
+    return k;
+}
+
+/// Numeric order without parsing, so a long run (a date stamp) cannot
+/// overflow.
+fn compareDigitRun(a: []const u8, b: []const u8) std.math.Order {
+    const x = std.mem.trimStart(u8, a, "0");
+    const y = std.mem.trimStart(u8, b, "0");
+    if (x.len != y.len) return std.math.order(x.len, y.len);
+    return std.mem.order(u8, x, y);
+}
+
 const testing = std.testing;
+
+test "relate reads an ordinary forward move as newer" {
+    // The overwhelmingly common case; multi-digit and date-stamped runs
+    // both have to compare numerically rather than byte-wise.
+    try testing.expectEqual(Rel.newer, relate("1.9", "1.10"));
+    try testing.expectEqual(Rel.newer, relate("1.2.3", "1.2.4"));
+    try testing.expectEqual(Rel.newer, relate("20240115", "20240116"));
+}
+
+test "relate lets the revision decide when the versions match" {
+    // Keeps the comparator agreeing with `pkgVersion`'s own output.
+    try testing.expectEqual(Rel.same, relate("1.2.3", "1.2.3"));
+    try testing.expectEqual(Rel.newer, relate("1.2.3", "1.2.3_1"));
+    try testing.expectEqual(Rel.older, relate("1.2.3_2", "1.2.3_1"));
+}
+
+test "relate reads a yanked release as older" {
+    // A real pip-audit transition: the event this whole signal exists for.
+    try testing.expectEqual(Rel.older, relate("2.4.15", "2.4.14"));
+}
+
+test "relate catches a mistyped bump" {
+    // A real llvm transition nobody intended, which review did not catch.
+    try testing.expectEqual(Rel.older, relate("19.1.3", "1.19.4"));
+}
+
+test "relate gives up rather than rank pre-release markers" {
+    // Ranking these is the tempting mistake: a wrong answer would turn a
+    // legitimate upgrade into a false alarm.
+    try testing.expectEqual(Rel.incomparable, relate("1.0rc2", "1.0"));
+    try testing.expectEqual(Rel.incomparable, relate("1.0", "1.0beta"));
+}
+
+test "relate misreads a date-scheme change as older" {
+    // A real minio transition, pinned deliberately: both sides open with a
+    // digit run, so the walk answers confidently and wrongly. Recorded so
+    // nobody "fixes" it by accident; nothing blocks on the label.
+    try testing.expectEqual(Rel.older, relate("20250312180418", "2025-04-03T14-56-28Z"));
+}
+
+test "relate treats a zero-padded tail as the same version" {
+    // Homebrew pads a missing component with zero, so `1.0` and `1.0.0` are
+    // one version. Reading the longer side as newer would cry downgrade on a
+    // tap that merely dropped a trailing `.0`.
+    try testing.expectEqual(Rel.same, relate("1.0.0", "1.0"));
+    try testing.expectEqual(Rel.same, relate("1.0", "1.0.0"));
+    try testing.expectEqual(Rel.newer, relate("1.2", "1.2.3"));
+    try testing.expectEqual(Rel.older, relate("1.2.3", "1.2"));
+}
+
+test "relate ignores leading zeros inside a component" {
+    try testing.expectEqual(Rel.same, relate("1.02", "1.2"));
+    try testing.expectEqual(Rel.newer, relate("1.02", "1.10"));
+}
+
+test "relate declines when the two sides start with different run kinds" {
+    // Also the empty-label guard: nothing here may index past an end.
+    try testing.expectEqual(Rel.incomparable, relate("1.0", "v1.0"));
+    try testing.expectEqual(Rel.incomparable, relate("", "beta"));
+    try testing.expectEqual(Rel.newer, relate("", "1.0"));
+}
+
+test "relate reads the version before the revision" {
+    // A revision bump never rescues a version that moved backward.
+    try testing.expectEqual(Rel.older, relate("1.2.4", "1.2.3_5"));
+}
+
+test "relate answers the same question both ways round" {
+    // Swapping the arguments must mirror the answer, never invent or lose
+    // one: `upgrade` reads the pair in the opposite order from `outdated`.
+    const pairs = [_][2][]const u8{
+        .{ "1.9", "1.10" },        .{ "1.2.3", "1.2.3_1" },
+        .{ "2.4.15", "2.4.14" },   .{ "1.0rc2", "1.0" },
+        .{ "1.0.0", "1.0" },       .{ "1.2.3,4567", "1.2.4,4600" },
+        .{ "20240115", "2024-1" }, .{ "", "1.0" },
+    };
+    for (pairs) |p| {
+        const forward = relate(p[0], p[1]);
+        const back = relate(p[1], p[0]);
+        try testing.expectEqual(switch (forward) {
+            .older => Rel.newer,
+            .newer => Rel.older,
+            .same => Rel.same,
+            .incomparable => Rel.incomparable,
+        }, back);
+    }
+}
+
+test "relate misreads a dropped cask build suffix as older" {
+    // Measured at 7 in 54,850 real cask transitions. Special-casing it would
+    // grow the comparator for a rounding error, so it is recorded, not fixed.
+    try testing.expectEqual(Rel.older, relate("1.4.3,167", "1.4.3"));
+}
+
+test "relate walks cask-shaped build suffixes" {
+    // The `,build` comma is an identical non-digit run and must not block.
+    try testing.expectEqual(Rel.newer, relate("1.2.3,4567", "1.2.4,4600"));
+}
 
 test "parsePkgVersion splits revision suffix" {
     const r = parsePkgVersion("1.9.2_2");


### PR DESCRIPTION
## Description

`mt outdated` now says when the tap moved backward, instead of leaving the user to compare two version strings by eye. Rows are otherwise unchanged: nothing is filtered, nothing is reordered, and the set of packages reported is provably the same as before.

An earlier change removed an ordering glyph from this row because malt never actually checked ordering. It does now, via a comparator that answers direction when it is sure and explicitly declines when it is not - which is why an unusual version string produces no marker rather than a wrong one.

`--json` gains an additive field; the cached snapshot is untouched and the TUI is
unaffected.

## Related Issue

- None

## Notes for Reviewers

- Measured against 109,073 real Homebrew upgrade transitions, it classifies 99.86% correctly and gives up on 0.09%. 