### PR TITLE
feat(upgrade): announce when a package moves backward

### DIFF
--- a/scripts/regressions/upgrade-backward-move-warns.sh
+++ b/scripts/regressions/upgrade-backward-move-warns.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Regression: `mt upgrade` announces a backward version move and still
+# performs it.
+#
+# `mt upgrade` follows the tap: when upstream moves backward (a yanked
+# release), it walks the keg down. That is intended — `mt rollback` makes it
+# cheap to undo — but it used to happen silently, visible only in a dry run
+# nobody reads. The move is now announced, with both versions named and
+# `mt rollback` pointed at as the undo. It is a warning, not a refusal.
+#
+# Fixture: install a real formula, then rewind its recorded version to a
+# value the comparator reads as strictly newer than upstream. The next
+# `mt upgrade` therefore sees a backward move. We assert BOTH halves — the
+# warning appeared AND the keg was upgraded to the upstream version — because
+# a warning that also blocked would be the failure this feature exists to
+# avoid. A second run under `--force` pins that the flag did not become a
+# consent gate: the warning is identical with or without it.
+#
+# Usage: scripts/regressions/upgrade-backward-move-warns.sh
+# Requirements: built malt at $MALT_BIN or zig-out/bin/malt; sqlite3 on PATH;
+# network access for the seeding install and the upgrade's API fetch.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+# MALT_PREFIX kept short (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_bwd"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+unset MALT_OFFLINE MALT_OUTDATED_MAX_AGE CI
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+skip() { printf '  \xe2\x8a\x98 SKIP: %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+is_network_blip() { grep -qiE "rate limit|Network failure|Could not resolve|timed out|No bottle available|Could not fetch" "$1"; }
+
+# Light formula: no deps, lands fast, has a stable bottle.
+NAME="${NAME:-tree}"
+DB="$PREFIX/db/malt.db"
+
+INSTALL_LOG="$PREFIX/install.log"
+printf '\xe2\x96\xb8 seeding with mt install %s (logs \xe2\x86\x92 %s)\n' "$NAME" "$INSTALL_LOG"
+if ! "$BIN" install "$NAME" >"$INSTALL_LOG" 2>&1; then
+  if is_network_blip "$INSTALL_LOG"; then
+    skip "$NAME: seed install hit a classified network condition"
+    exit 0
+  fi
+  tail -30 "$INSTALL_LOG" >&2
+  fail "$NAME: seed install failed for an unclassified reason"
+fi
+[[ -f "$DB" ]] || fail "expected DB at $DB after install"
+
+UPSTREAM=$(sqlite3 "$DB" "SELECT version FROM kegs WHERE name='${NAME}';")
+[[ -n "$UPSTREAM" ]] || fail "$NAME: post-install keg row missing"
+pass "$NAME installed at upstream version '${UPSTREAM}'"
+
+# Rewind the recorded version to one that reads as strictly newer than any
+# real upstream, so the next upgrade is a provable backward move. `9999` as
+# the leading numeric run outranks every real first component.
+FAKE="9999.0"
+run_backward() {
+  local log="$1"
+  shift
+  sqlite3 "$DB" "UPDATE kegs SET version='${FAKE}' WHERE name='${NAME}';"
+  set +e
+  "$BIN" upgrade "$@" "$NAME" >"$log" 2>&1
+  local rc=$?
+  set -e
+  return $rc
+}
+
+# --- 0. Dry run over a backward move: warns, changes nothing -----------
+DRY_LOG="$PREFIX/upgrade_dry.log"
+printf '\xe2\x96\xb8 mt upgrade --dry-run %s over a rewound version (logs \xe2\x86\x92 %s)\n' "$NAME" "$DRY_LOG"
+run_backward "$DRY_LOG" --dry-run || {
+  if is_network_blip "$DRY_LOG"; then
+    skip "dry-run hit a classified network condition"
+    exit 0
+  fi
+  tail -30 "$DRY_LOG" >&2
+  fail "$NAME: dry-run exited non-zero over a backward move"
+}
+grep -qi "moving backward" "$DRY_LOG" || fail "$NAME: --dry-run did not warn on a backward move"
+DRY_NOW=$(sqlite3 "$DB" "SELECT version FROM kegs WHERE name='${NAME}';")
+[[ "$DRY_NOW" == "$FAKE" ]] ||
+  fail "$NAME: --dry-run changed the keg version ('${DRY_NOW}') — dry run must not upgrade"
+pass "$NAME: --dry-run warns and leaves the keg untouched"
+
+# --- 1. Plain backward move: warns AND upgrades ------------------------
+UP_LOG="$PREFIX/upgrade.log"
+printf '\xe2\x96\xb8 mt upgrade %s over a rewound version (logs \xe2\x86\x92 %s)\n' "$NAME" "$UP_LOG"
+run_backward "$UP_LOG" || {
+  if is_network_blip "$UP_LOG"; then
+    skip "upgrade hit a classified network condition; cannot assert the move"
+    exit 0
+  fi
+  tail -30 "$UP_LOG" >&2
+  fail "$NAME: upgrade exited non-zero over a backward move"
+}
+pass "$NAME: upgrade exited 0 over a backward move"
+
+grep -qi "moving backward" "$UP_LOG" ||
+  fail "$NAME: no backward-move warning printed ('$(grep -i backward "$UP_LOG" || true)')"
+grep -q "$FAKE" "$UP_LOG" || fail "$NAME: warning did not name the installed version '${FAKE}'"
+grep -q "$UPSTREAM" "$UP_LOG" || fail "$NAME: warning did not name the upstream version '${UPSTREAM}'"
+grep -qi "rollback" "$UP_LOG" || fail "$NAME: warning did not point at 'mt rollback'"
+pass "$NAME: backward move announced, naming both versions and the undo"
+
+# The move actually happened: the keg is back at upstream, not stuck at FAKE.
+NOW=$(sqlite3 "$DB" "SELECT version FROM kegs WHERE name='${NAME}';")
+[[ "$NOW" == "$UPSTREAM" ]] ||
+  fail "$NAME: keg is at '${NOW}', expected upstream '${UPSTREAM}' — the warning blocked the move"
+pass "$NAME: keg walked back to upstream '${UPSTREAM}' (warned, not blocked)"
+
+# --- 2. Same move under --force: warning is unchanged ------------------
+# Pins that --force was not overloaded into a downgrade-consent gate.
+FORCE_LOG="$PREFIX/upgrade_force.log"
+printf '\xe2\x96\xb8 mt upgrade --force %s over a rewound version (logs \xe2\x86\x92 %s)\n' "$NAME" "$FORCE_LOG"
+run_backward "$FORCE_LOG" --force || {
+  if is_network_blip "$FORCE_LOG"; then
+    skip "forced upgrade hit a classified network condition"
+    exit 0
+  fi
+  tail -30 "$FORCE_LOG" >&2
+  fail "$NAME: forced upgrade exited non-zero over a backward move"
+}
+grep -qi "moving backward" "$FORCE_LOG" ||
+  fail "$NAME: --force suppressed the backward-move warning"
+pass "$NAME: --force leaves the warning intact (not a consent gate)"
+
+printf '\n\xe2\x9c\x94 upgrade backward-move warning regression passed\n'

--- a/scripts/regressions/upgrade-tap-cask-backward-move-warns.sh
+++ b/scripts/regressions/upgrade-tap-cask-backward-move-warns.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Regression: `mt upgrade <tap-cask>` announces a backward version move and
+# still performs it — the cask twin of upgrade-backward-move-warns.sh.
+#
+# The warning is emitted from a shared helper at all three version-compare
+# sites; the formula site is proven elsewhere. This pins the routed tap-cask
+# site (`upgradeRoutedTapCask`), reached when a tap cask's recorded version
+# reads as newer than upstream. Casks mostly land in the comparator's
+# `incomparable` arm (no warning), so we force a provable backward move by
+# rewinding the recorded version to one that outranks any real upstream.
+#
+# Asserts BOTH halves — the warning appeared AND the cask walked back to the
+# upstream version — because a warning that also blocked is the failure this
+# feature exists to avoid.
+#
+# Usage: scripts/regressions/upgrade-tap-cask-backward-move-warns.sh
+# Requirements: built malt at $MALT_BIN or zig-out/bin/malt; sqlite3 on PATH;
+# network access to GitHub raw + the upstream release host. macOS only.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+# MALT_PREFIX kept short (Mach-O in-place patching budget).
+PREFIX="/tmp/mt_cbwd"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+unset MALT_OFFLINE MALT_OUTDATED_MAX_AGE CI
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+trap 'rm -rf "$PREFIX"' EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+skip() { printf '  \xe2\x8a\x98 SKIP: %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+is_network_blip() { grep -qiE "rate limit|Network failure|Could not resolve|timed out|Failed to (install|download)|Sha256Mismatch|DownloadFailed|Tap formula/cask not found" "$1"; }
+
+# A stable third-party tap cask malt is known to install (shared with
+# upgrade_tap_cask_force.sh).
+SLUG="yuzeguitarist/deck/deckclip"
+TOKEN="${SLUG##*/}"
+BUNDLE="Deck.app"
+APP_PATH="$PREFIX/Applications/$BUNDLE"
+DB="$PREFIX/db/malt.db"
+
+INSTALL_LOG="$PREFIX/install_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt install %s (logs \xe2\x86\x92 %s)\n' "$SLUG" "$INSTALL_LOG"
+if ! "$BIN" install "$SLUG" >"$INSTALL_LOG" 2>&1; then
+  if is_network_blip "$INSTALL_LOG"; then
+    skip "${SLUG}: install hit a classified upstream condition"
+    exit 0
+  fi
+  tail -30 "$INSTALL_LOG" >&2
+  fail "${SLUG}: install failed for an unclassified reason"
+fi
+[[ -d "$APP_PATH" ]] || fail "${SLUG}: expected ${APP_PATH} after install"
+[[ -f "$DB" ]] || fail "expected DB at $DB after install"
+
+UPSTREAM=$(sqlite3 "$DB" "SELECT version FROM casks WHERE token='${TOKEN}';")
+[[ -n "$UPSTREAM" ]] || fail "${TOKEN}: post-install casks row missing"
+pass "${TOKEN}: installed at upstream version '${UPSTREAM}'"
+
+# Rewind the recorded version so the next upgrade is a provable backward
+# move. '9999.0' outranks every real first component.
+FAKE="9999.0"
+sqlite3 "$DB" "UPDATE casks SET version='${FAKE}' WHERE token='${TOKEN}';"
+
+UP_LOG="$PREFIX/upgrade_${TOKEN}.log"
+printf '\xe2\x96\xb8 mt upgrade %s over a rewound version (logs \xe2\x86\x92 %s)\n' "$TOKEN" "$UP_LOG"
+"$BIN" upgrade "$TOKEN" >"$UP_LOG" 2>&1 || {
+  if is_network_blip "$UP_LOG"; then
+    skip "upgrade hit a classified network condition; cannot assert the move"
+    exit 0
+  fi
+  tail -30 "$UP_LOG" >&2
+  fail "${TOKEN}: upgrade exited non-zero over a backward move"
+}
+
+grep -qi "moving backward" "$UP_LOG" ||
+  fail "${TOKEN}: no backward-move warning printed"
+grep -q "$FAKE" "$UP_LOG" || fail "${TOKEN}: warning did not name installed '${FAKE}'"
+grep -q "$UPSTREAM" "$UP_LOG" || fail "${TOKEN}: warning did not name upstream '${UPSTREAM}'"
+grep -qi "rollback" "$UP_LOG" || fail "${TOKEN}: warning did not point at 'mt rollback'"
+pass "${TOKEN}: backward move announced, naming both versions and the undo"
+
+# The move actually happened: the cask is back at upstream, not stuck at FAKE.
+NOW=$(sqlite3 "$DB" "SELECT version FROM casks WHERE token='${TOKEN}';")
+[[ "$NOW" == "$UPSTREAM" ]] ||
+  fail "${TOKEN}: cask is at '${NOW}', expected upstream '${UPSTREAM}' — the warning blocked the move"
+[[ -d "$APP_PATH" ]] || fail "${TOKEN}: app bundle missing after the backward move"
+pass "${TOKEN}: cask walked back to upstream '${UPSTREAM}' (warned, not blocked)"
+
+printf '\n\xe2\x9c\x94 upgrade tap-cask backward-move warning regression passed\n'

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -146,6 +146,27 @@ fn printSummary(tally: Tally, dry_run: bool) void {
     output.notice("{s}", .{tally.summaryLine(&buf, dry_run)});
 }
 
+/// The one-line heads-up `upgrade` prints on a backward move, else null.
+/// Advisory, not a consent gate: it takes no `force`, so a reader cannot
+/// turn it into a refusal. `incomparable` stays silent — a guessed
+/// direction would cry wolf on every unusual version string.
+fn downgradeWarning(buf: []u8, name: []const u8, installed: []const u8, upstream: []const u8) ?[]const u8 {
+    if (formula_mod.relate(installed, upstream) != .older) return null;
+    // Bounded inputs (a keg name and two version labels); on the impossible
+    // overflow, drop the advisory rather than fail an upgrade over a heads-up.
+    return std.fmt.bufPrint(buf, "{s} is moving backward: {s} -> {s} (undo with `mt rollback {s}`)", .{ name, installed, upstream, name }) catch null;
+}
+
+/// Print the backward-move heads-up at a compare site when the move is
+/// backward. Not gated on `bulk`: the rare backward move is the exception
+/// bulk quieting should not swallow. Advisory — the caller upgrades anyway.
+fn warnIfBackward(name: []const u8, installed: []const u8, upstream: []const u8) void {
+    // ponytail: may fire on a date-scheme forward move (both sides open with
+    // digits); accepted, not fixed here — see relate's pinned limitation.
+    var buf: [256]u8 = undefined;
+    if (downgradeWarning(&buf, name, installed, upstream)) |w| output.warn("{s}", .{w});
+}
+
 /// Side-channel collector for a full `mt upgrade --dry-run`. `Tally` is
 /// counters only, so the would-upgrade *rows* are gathered here as
 /// snapshot-shaped `OutdatedEntry`s to warm the shared `outdated.json`.
@@ -589,6 +610,8 @@ fn upgradeFormula(
         return .up_to_date;
     }
 
+    warnIfBackward(name, old_pkg_version, formula.pkg_version);
+
     if (dry_run) {
         if (sink) |s| s.collectFormula(name, old.version, old.revision, formula.pkg_version);
         output.info("Dry run: would upgrade {s} {s} -> {s}", .{ name, old_pkg_version, formula.pkg_version });
@@ -1017,6 +1040,8 @@ fn upgradeRoutedTapCask(
         return .up_to_date;
     }
 
+    warnIfBackward(token, installed_version, rb_info.version);
+
     if (dry_run) {
         // Bare, like the skip decision above: this warms the snapshot that
         // `outdated` reads, and a cask's installed version can never carry a
@@ -1367,6 +1392,8 @@ fn upgradeCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []const 
         return .up_to_date;
     }
 
+    warnIfBackward(token, installed_version, parsed_cask.version);
+
     if (dry_run) {
         if (sink) |s| s.collectCask(token, installed_version, parsed_cask.version);
         output.info("Dry run: would upgrade cask {s} {s} -> {s}", .{ token, installed_version, parsed_cask.version });
@@ -1698,6 +1725,32 @@ test "summaryLine renders a real run with no failures" {
         "47 checked · 1 upgraded · 45 up to date · 1 pinned",
         t.summaryLine(&buf, false),
     );
+}
+
+test "downgradeWarning speaks up on a backward move and stays silent otherwise" {
+    var buf: [256]u8 = undefined;
+
+    // A backward move: the whole point of the warning. Must name both
+    // versions and point at the undo so the line stands on its own.
+    const w = downgradeWarning(&buf, "tree", "2.2.1", "2.2.0") orelse
+        return error.ExpectedWarning;
+    try std.testing.expect(std.mem.indexOf(u8, w, "2.2.1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, w, "2.2.0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, w, "rollback") != null);
+
+    // The ordinary forward path runs on every upgrade of every package;
+    // one stray line here is a daily regression for everyone.
+    try std.testing.expect(downgradeWarning(&buf, "tree", "2.2.0", "2.2.1") == null);
+    // Equal versions never reach here in practice, but must not warn.
+    try std.testing.expect(downgradeWarning(&buf, "tree", "2.2.1", "2.2.1") == null);
+    // The give-up arm is what makes this safe for casks and odd taps.
+    try std.testing.expect(downgradeWarning(&buf, "tree", "1.0rc2", "1.0") == null);
+    // A revision-only rewind is still a backward move: the qualified label
+    // matches what upgrade compares, so it must warn and name that label.
+    const rev = downgradeWarning(&buf, "tree", "1.2.3_2", "1.2.3_1") orelse
+        return error.ExpectedWarning;
+    try std.testing.expect(std.mem.indexOf(u8, rev, "1.2.3_2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rev, "1.2.3_1") != null);
 }
 
 test "summaryLine swaps in 'would upgrade' under dry-run" {


### PR DESCRIPTION
## Description

`mt upgrade` follows the tap, and when the tap moves backward it follows it down.

That is intended - a maintainer who yanks a bad release wants users moved back quickly - but until now it happened silently, visible only as `old -> new` in a dry run nobody reads before a routine upgrade.

The move is now announced, with both versions named and `mt rollback` pointed at as the undo. It is a warning, not a refusal: rollback already makes regret cheap for formulas and casks alike, so blocking would buy a keystroke while delaying the yanked-release case that matters most. Roughly half of all backward moves measured in Homebrew's history are version-scheme changes rather than real regressions, which is accurate enough to mention and not accurate enough to block on.

Forward and unclassifiable moves print nothing new, `--force` is unchanged, and the set of packages upgraded is identical to before.

## Related Issue

- None

## Notes for Reviewers

- Reviewer checkpoints: no control flow change at any of the four compare sites; the ordinary forward path is byte-identical; `--force` was not overloaded into consent.
- The sha-decided tap-formula path is deliberately untouched - it compares no versions, so there is no direction to report.