### PR TITLE
chore(help): document that malt announces backward moves

### DIFF
--- a/man/malt.1
+++ b/man/malt.1
@@ -157,7 +157,9 @@ Upgrade installed packages to latest versions. Pinned kegs and
 casks are skipped with a "pinned, skipped" line; pass --force to
 override. malt follows the tap: if the tap version differs from the
 installed one it is applied, even if that moves the version down
-(e.g. an upstream revert) — preview with --dry-run.
+(e.g. an upstream revert). A backward move is announced with a warning
+that names both versions and points at `mt rollback`; it never blocks
+the upgrade, and stays quiet when the versions cannot be ranked.
 Formulas from a third-party tap are the exception: they upgrade when
 the tap content changes, not when the version changes, so a reinstall
 with no version movement is expected. Core formulas and casks follow
@@ -211,7 +213,9 @@ live (or serves the cached read offline). --refresh always recomputes.
 
 A package is "outdated" when its installed version differs from the
 current tap version (revision bumps included), not only when it is
-older: malt follows the tap as source of truth.
+older: malt follows the tap as source of truth. A row the tap has
+moved behind is tagged [downgrade]; the tag only reports the direction
+and filters nothing - a pair malt cannot rank is listed without it.
 .fi
 .SS list
 .nf

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -148,7 +148,9 @@ const upgrade_help =
     \\casks are skipped with a "pinned, skipped" line; pass --force to
     \\override. malt follows the tap: if the tap version differs from the
     \\installed one it is applied, even if that moves the version down
-    \\(e.g. an upstream revert) — preview with --dry-run.
+    \\(e.g. an upstream revert). A backward move is announced with a warning
+    \\that names both versions and points at `mt rollback`; it never blocks
+    \\the upgrade, and stays quiet when the versions cannot be ranked.
     \\Formulas from a third-party tap are the exception: they upgrade when
     \\the tap content changes, not when the version changes, so a reinstall
     \\with no version movement is expected. Core formulas and casks follow
@@ -204,7 +206,9 @@ const outdated_help =
     \\
     \\A package is "outdated" when its installed version differs from the
     \\current tap version (revision bumps included), not only when it is
-    \\older: malt follows the tap as source of truth.
+    \\older: malt follows the tap as source of truth. A row the tap has
+    \\moved behind is tagged [downgrade]; the tag only reports the direction
+    \\and filters nothing - a pair malt cannot rank is listed without it.
     \\
 ;
 

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -195,10 +195,13 @@ fn isCorePathRow(row: KegRow) bool {
 // truth. A keg is "outdated" whenever its revision-qualified installed version
 // is not byte-equal to the current upstream version — NOT when it is strictly
 // older (casks have no revision, so theirs is bare). This never
-// misses an upgrade (any difference surfaces); the trade-off is that if upstream
-// moves backward (a yanked release), `outdated` lists it and `upgrade` follows
-// the tap down. That downgrade is by design, surfaced as `old -> new` in
-// `--dry-run`. Matching Homebrew's `PkgVersion` ordering instead would risk a
+// misses an upgrade (any difference surfaces); the trade-off is that the tap is
+// followed in both directions, so if upstream moves backward (a yanked release)
+// `outdated` lists it and `upgrade` follows the tap down. That downgrade is by
+// design and no longer silent: `outdated` marks the row and `upgrade` warns
+// before proceeding - reported, never blocked. Which way a move points is the
+// comparator's call, not restated here. Matching Homebrew's `PkgVersion`
+// ordering instead would risk a
 // divergent comparator silently skipping a real upgrade — a worse failure mode.
 
 /// What the audit could prove about one row. `proven_current` is the only


### PR DESCRIPTION
## Description

Two commands changed what they show when a package moves backward. The policy note and the help text still described the silent behaviour they replaced.

The canonical note now says the tap is followed in both directions and that a backward move is reported, and `outdated --help` and `upgrade --help` explain what the marker and the warning mean - including that neither one filters or blocks anything, and that malt stays quiet when it cannot tell.

Strings only: no behaviour change.

## Related Issue

- None

## Notes for Reviewers

- None