### PR TITLE
fix(install): drop rpaths that relocation collapses onto one prefix

### DIFF
--- a/scripts/regressions/duplicate-lc-rpath-on-relocation-gh754.sh
+++ b/scripts/regressions/duplicate-lc-rpath-on-relocation-gh754.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Regression: a bottle carrying two rpaths that name different Homebrew
+# prefixes (e.g. `@@HOMEBREW_PREFIX@@/lib` and `/usr/local/lib`) had both
+# rewritten to the same MALT_PREFIX during relocation. The Mach-O patcher
+# had no LC_RPATH dedup, so the installed binary shipped two identical
+# LC_RPATHs and dyld aborted every launch with SIGABRT.
+#
+# The fix keeps the first occurrence of each relocated rpath value and
+# queues any later collider for `install_name_tool -delete_rpath`, riding
+# the existing fallback spawn. Both guards live in colocated `test {}`
+# blocks; this script asserts the fix is present statically, then runs the
+# integration test binary and judges its guard's line.
+#
+# Exits 0 when the bug is absent, non-zero (with a message naming the
+# failing assertion) when present. The default path needs no network and
+# finishes well under 30s once the test binaries are built.
+#
+# Opt-in live check: set MALT_LIVE_RPATH_CHECK=1 to additionally install the
+# reported formula (fastfetch — two colliding rpaths) into a throwaway prefix
+# and assert the collapsed rpath survives exactly once and the binary really
+# runs. Needs network + a built `mt`, so it is off by default.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+PATCHER="$ROOT/src/macho/patcher.zig"
+
+# 1. Static guard: the relocation walk must dedup LC_RPATH and the fallback
+#    must be able to emit -delete_rpath. Absence of either is the bug.
+if ! grep -q 'seen_rpaths' "$PATCHER"; then
+  echo "FAIL: patcher no longer deduplicates relocated LC_RPATH slots" >&2
+  exit 1
+fi
+if ! grep -q -- '-delete_rpath' "$PATCHER"; then
+  echo "FAIL: fallback cannot strip a collapsed LC_RPATH (-delete_rpath missing)" >&2
+  exit 1
+fi
+
+# 2. Behavioural guards live in colocated `test {}` blocks; if either is
+#    ever deleted the run below would silently pass. Fail loudly instead.
+UNIT_TEST="patchPathsCollecting dedups an LC_RPATH that relocation collapses onto a kept one"
+INTEG_TEST="patchPathsCollecting collapses two rpaths onto one target with a single kept slot"
+if ! grep -Rqs -- "$UNIT_TEST" "$PATCHER"; then
+  echo "FAIL: inline rpath-dedup guard test missing from patcher.zig" >&2
+  exit 1
+fi
+if ! grep -Rqs -- "$INTEG_TEST" "$ROOT/tests/patcher_test.zig"; then
+  echo "FAIL: integration rpath-dedup guard test missing from patcher_test.zig" >&2
+  exit 1
+fi
+
+# Rebuild the test binaries so the run reflects the working tree.
+if ! (cd "$ROOT" && zig build test-bin >/dev/null 2>&1); then
+  echo "FAIL: could not build the test binaries (zig build test-bin)" >&2
+  exit 1
+fi
+
+# The runner has no per-test filter, so run the suite and judge only the
+# integration guard's line: a pass ends in "OK".
+out=$("$ROOT/zig-out/test-bin/patcher_test" 2>&1 || true)
+line=$(printf '%s\n' "$out" | grep -F -- "$INTEG_TEST" || true)
+if [[ -z "$line" ]]; then
+  echo "FAIL: rpath-dedup guard test did not run in patcher_test" >&2
+  exit 1
+fi
+if [[ "$line" != *OK ]]; then
+  echo "FAIL: $INTEG_TEST: $line" >&2
+  exit 1
+fi
+
+# Opt-in: prove it end-to-end against the real formula from the report.
+if [[ "${MALT_LIVE_RPATH_CHECK:-0}" == "1" ]]; then
+  MT="$ROOT/zig-out/bin/mt"
+  if [[ ! -x "$MT" ]]; then
+    (cd "$ROOT" && zig build >/dev/null 2>&1) || {
+      echo "FAIL: could not build mt for the live check" >&2
+      exit 1
+    }
+  fi
+
+  # Short throwaway prefix keeps relocated rpaths from outgrowing their slots.
+  live="/tmp/mt-rpath-live-$$"
+  trap 'rm -rf "$live"' EXIT
+  rm -rf "$live"
+  mkdir -p "$live"
+
+  # gh token dodges the anonymous GitHub API cap; harmless if gh is absent.
+  MALT_GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)" \
+  MALT_PREFIX="$live" "$MT" install fastfetch >/dev/null 2>&1 ||
+    {
+      echo "FAIL: live install of fastfetch failed" >&2
+      exit 1
+    }
+
+  bin=$(echo "$live"/Cellar/fastfetch/*/bin/fastfetch)
+  n=$(otool -l "$bin" | grep -c "path $live/lib ")
+  [[ "$n" -eq 1 ]] || {
+    echo "FAIL: $n LC_RPATH '$live/lib' in installed fastfetch (want 1)" >&2
+    exit 1
+  }
+
+  # dyld aborts before main on a duplicate, so a real render is the proof.
+  if ! "$bin" --logo none >/dev/null 2>"$live/err"; then
+    echo "FAIL: fastfetch did not run after relocation" >&2
+    cat "$live/err" >&2
+    exit 1
+  fi
+  grep -q 'duplicate LC_RPATH' "$live/err" &&
+    {
+      echo "FAIL: dyld reports duplicate LC_RPATH at launch" >&2
+      exit 1
+    }
+
+  echo "OK: live fastfetch install carries one LC_RPATH and runs"
+fi
+
+echo "OK: relocation dedups colliding LC_RPATHs; no duplicate ships"

--- a/src/macho/parser.zig
+++ b/src/macho/parser.zig
@@ -23,6 +23,10 @@ pub const LoadCommandPath = struct {
     max_path_len: usize,
     /// The current path string
     path: []const u8,
+    /// File offset of the owning arch slice (0 for a thin Mach-O). Lets the
+    /// patcher scope LC_RPATH dedup per slice — a fat binary carries the same
+    /// rpath in each slice, and only within-slice duplicates matter to dyld.
+    slice_offset: usize,
 };
 
 /// A `__TEXT,__cstring` (or any S_CSTRING_LITERALS) section located in
@@ -219,6 +223,7 @@ fn parseMachO64(allocator: std.mem.Allocator, data: []const u8, base_offset: usi
                     .path_offset = base_offset + path_start,
                     .max_path_len = cmdsize - name_offset,
                     .path = path,
+                    .slice_offset = base_offset,
                 }) catch return ParseError.OutOfMemory;
             },
             .RPATH => {
@@ -251,6 +256,7 @@ fn parseMachO64(allocator: std.mem.Allocator, data: []const u8, base_offset: usi
                     .path_offset = base_offset + path_start,
                     .max_path_len = cmdsize - path_offset,
                     .path = path,
+                    .slice_offset = base_offset,
                 }) catch return ParseError.OutOfMemory;
             },
             .SEGMENT_64 => {

--- a/src/macho/patcher.zig
+++ b/src/macho/patcher.zig
@@ -27,10 +27,15 @@ pub const OverflowEntry = struct {
     /// Drives the `-change` vs `-rpath` vs `-id` argv shape downstream.
     cmd: u32,
     /// Original path embedded in the slot (the `install_name_tool -change`
-    /// "old" argument).
+    /// "old" argument). For a delete entry, the rpath to strip.
     old_path: []const u8,
-    /// Replacement path the in-place patcher could not fit.
+    /// Replacement path the in-place patcher could not fit. Empty for a
+    /// delete entry (`-delete_rpath` takes no new path).
     new_path: []const u8,
+    /// True when relocation folded this LC_RPATH onto an already-kept one:
+    /// the slot keeps its original bytes and the fallback strips it via
+    /// `-delete_rpath old_path` so dyld never sees a duplicate LC_RPATH.
+    delete: bool = false,
 };
 
 pub const PatchOutcome = struct {
@@ -102,11 +107,54 @@ pub fn patchPathsCollecting(
         overflow.deinit(allocator);
     }
 
+    // Final (post-relocation) value of every LC_RPATH kept so far, tagged
+    // with its arch slice so a fat binary's per-slice rpaths don't collide.
+    // Scratch only — never returned; freed unconditionally below.
+    const SeenRpath = struct { slice: usize, value: []const u8 };
+    var seen_rpaths: std.ArrayList(SeenRpath) = .empty;
+    defer {
+        for (seen_rpaths.items) |v| allocator.free(v.value);
+        seen_rpaths.deinit(allocator);
+    }
+
     var patched: u32 = 0;
     var skipped: u32 = 0;
 
     for (macho.paths) |lcp| {
-        const r = pickReplacement(lcp.path, replacements) orelse {
+        const r_opt = pickReplacement(lcp.path, replacements);
+
+        // dyld aborts on a duplicate LC_RPATH, and relocation can fold two
+        // distinct prefixes onto one target. Keep the first occurrence of
+        // each final value; queue any later collider for `-delete_rpath`.
+        // Scoped to LC_RPATH — duplicate LC_LOAD_DYLIB is legal.
+        if (lcp.cmd == @intFromEnum(std.macho.LC.RPATH)) {
+            var final_buf: [1024]u8 = undefined;
+            if (rpathFinalValue(&final_buf, lcp.path, r_opt)) |final| {
+                var seen = false;
+                for (seen_rpaths.items) |e| {
+                    if (e.slice == lcp.slice_offset and std.mem.eql(u8, e.value, final)) {
+                        seen = true;
+                        break;
+                    }
+                }
+                if (seen) {
+                    // `-delete_rpath` is fat-wide by path, so a universal
+                    // binary's per-slice colliders share one deletion.
+                    if (!deleteQueued(overflow.items, lcp.path))
+                        try recordDelete(allocator, &overflow, lcp);
+                    continue;
+                }
+                const dup = allocator.dupe(u8, final) catch return PatchError.OutOfMemory;
+                seen_rpaths.append(allocator, .{ .slice = lcp.slice_offset, .value = dup }) catch {
+                    allocator.free(dup);
+                    return PatchError.OutOfMemory;
+                };
+            }
+            // A value past the scratch buffer can't fit any slot anyway;
+            // fall through so normal handling drops it.
+        }
+
+        const r = r_opt orelse {
             skipped += 1;
             continue;
         };
@@ -296,6 +344,43 @@ fn recordOverflow(
     }) catch return PatchError.OutOfMemory;
 }
 
+/// Post-relocation value of one rpath: the matched replacement applied, or
+/// the original path when nothing matched. Returns null when the result
+/// exceeds `buf` — such a path can't fit any slot, so the caller skips
+/// dedup and lets normal handling drop it.
+fn rpathFinalValue(buf: []u8, path: []const u8, r_opt: ?Replacement) ?[]const u8 {
+    const r = r_opt orelse return path;
+    const suffix = path[r.old.len..];
+    const total = r.new.len + suffix.len;
+    if (total > buf.len) return null;
+    @memcpy(buf[0..r.new.len], r.new);
+    @memcpy(buf[r.new.len..total], suffix);
+    return buf[0..total];
+}
+
+fn deleteQueued(entries: []const OverflowEntry, old_path: []const u8) bool {
+    for (entries) |e| if (e.delete and std.mem.eql(u8, e.old_path, old_path)) return true;
+    return false;
+}
+
+/// Queue a collapsed LC_RPATH for removal. Deletes by the *original* path:
+/// the kept duplicate was already rewritten to the shared target, so the two
+/// stay distinct at flush time and `-delete_rpath` strips exactly this slot.
+fn recordDelete(
+    allocator: std.mem.Allocator,
+    list: *std.ArrayList(OverflowEntry),
+    lcp: parser.LoadCommandPath,
+) PatchError!void {
+    const old_dup = allocator.dupe(u8, lcp.path) catch return PatchError.OutOfMemory;
+    errdefer allocator.free(old_dup);
+    list.append(allocator, .{
+        .cmd = lcp.cmd,
+        .old_path = old_dup,
+        .new_path = "",
+        .delete = true,
+    }) catch return PatchError.OutOfMemory;
+}
+
 /// A single (needle → replacement) pair for `patchTextFiles`.
 pub const Replacement = struct {
     old: []const u8,
@@ -333,24 +418,32 @@ pub fn buildInstallNameToolArgv(
     errdefer argv.deinit(allocator);
 
     argv.appendAssumeCapacity(external_tool_name);
-    for (entries) |e| switch (installNameToolForm(e.cmd)) {
-        .change => {
-            argv.appendAssumeCapacity("-change");
+    for (entries) |e| {
+        if (e.delete) {
+            // -delete_rpath <old> <file>: strip the collapsed duplicate.
+            argv.appendAssumeCapacity("-delete_rpath");
             argv.appendAssumeCapacity(e.old_path);
-            argv.appendAssumeCapacity(e.new_path);
-        },
-        .rpath => {
-            argv.appendAssumeCapacity("-rpath");
-            argv.appendAssumeCapacity(e.old_path);
-            argv.appendAssumeCapacity(e.new_path);
-        },
-        .id => {
-            // -id takes only the new install name; the old one is
-            // implicit (LC_ID_DYLIB carries a single name).
-            argv.appendAssumeCapacity("-id");
-            argv.appendAssumeCapacity(e.new_path);
-        },
-    };
+            continue;
+        }
+        switch (installNameToolForm(e.cmd)) {
+            .change => {
+                argv.appendAssumeCapacity("-change");
+                argv.appendAssumeCapacity(e.old_path);
+                argv.appendAssumeCapacity(e.new_path);
+            },
+            .rpath => {
+                argv.appendAssumeCapacity("-rpath");
+                argv.appendAssumeCapacity(e.old_path);
+                argv.appendAssumeCapacity(e.new_path);
+            },
+            .id => {
+                // -id takes only the new install name; the old one is
+                // implicit (LC_ID_DYLIB carries a single name).
+                argv.appendAssumeCapacity("-id");
+                argv.appendAssumeCapacity(e.new_path);
+            },
+        }
+    }
     argv.appendAssumeCapacity(file_path);
     return argv.toOwnedSlice(allocator);
 }
@@ -603,6 +696,182 @@ const Scratch = struct {
         self.arena.deinit();
     }
 };
+
+/// Minimal Mach-O 64 carrying two LC_RPATH load commands, each in its own
+/// `cmdsize` slot. Mirrors the two-prefix rpath shape a fastfetch-style
+/// bottle ships so the dedup walk can be exercised without a real binary.
+fn buildTwoRpathMachO(
+    allocator: std.mem.Allocator,
+    path1: []const u8,
+    cmdsize1: u32,
+    path2: []const u8,
+    cmdsize2: u32,
+) ![]u8 {
+    const macho = std.macho;
+    const header_size = @sizeOf(macho.mach_header_64);
+    const path_off: u32 = @sizeOf(macho.rpath_command);
+    const buf = try allocator.alloc(u8, header_size + cmdsize1 + cmdsize2);
+    @memset(buf, 0);
+
+    const hdr = std.mem.bytesAsValue(macho.mach_header_64, buf[0..header_size]);
+    hdr.* = .{ .magic = macho.MH_MAGIC_64, .ncmds = 2, .sizeofcmds = cmdsize1 + cmdsize2 };
+
+    const off1 = header_size;
+    const rp1 = std.mem.bytesAsValue(macho.rpath_command, buf[off1..][0..path_off]);
+    rp1.* = .{ .cmd = .RPATH, .cmdsize = cmdsize1, .path = path_off };
+    std.debug.assert(path1.len + 1 <= cmdsize1 - path_off);
+    @memcpy(buf[off1 + path_off ..][0..path1.len], path1);
+
+    const off2 = header_size + cmdsize1;
+    const rp2 = std.mem.bytesAsValue(macho.rpath_command, buf[off2..][0..path_off]);
+    rp2.* = .{ .cmd = .RPATH, .cmdsize = cmdsize2, .path = path_off };
+    std.debug.assert(path2.len + 1 <= cmdsize2 - path_off);
+    @memcpy(buf[off2 + path_off ..][0..path2.len], path2);
+
+    return buf;
+}
+
+test "patchPathsCollecting dedups an LC_RPATH that relocation collapses onto a kept one" {
+    const testing = std.testing;
+    const io = std.Options.debug_io;
+
+    // Both rpaths shrink to "/opt/malt/lib" — the fast in-place path fires.
+    const bytes = try buildTwoRpathMachO(
+        testing.allocator,
+        "@@HOMEBREW_PREFIX@@/lib",
+        40,
+        "/usr/local/lib",
+        32,
+    );
+    defer testing.allocator.free(bytes);
+
+    var s = try Scratch.init("patcher_dedup");
+    defer s.deinit();
+    try s.dir.writeFile(io, .{ .sub_path = "bin", .data = bytes });
+    const abs = s.p("/bin");
+
+    // The four replacements relocateKegTree applies to a concrete-cellar bottle.
+    const reps = [_]Replacement{
+        .{ .old = "@@HOMEBREW_PREFIX@@", .new = "/opt/malt" },
+        .{ .old = "@@HOMEBREW_CELLAR@@", .new = "/opt/malt/Cellar" },
+        .{ .old = "/opt/homebrew", .new = "/opt/malt" },
+        .{ .old = "/usr/local", .new = "/opt/malt" },
+    };
+    var outcome = try patchPathsCollecting(io, testing.allocator, abs, &reps);
+    defer outcome.deinit(testing.allocator);
+
+    // First rpath kept + rewritten in place; the colliding second is queued
+    // for `-delete_rpath` by its original (pre-relocation) path.
+    try testing.expectEqual(@as(u32, 1), outcome.patched_count);
+    try testing.expectEqual(@as(usize, 1), outcome.overflow.len);
+    try testing.expect(outcome.overflow[0].delete);
+    try testing.expectEqual(@intFromEnum(std.macho.LC.RPATH), outcome.overflow[0].cmd);
+    try testing.expectEqualStrings("/usr/local/lib", outcome.overflow[0].old_path);
+}
+
+test "patchPathsCollecting deletes a collider when the kept rpath needs no relocation" {
+    const testing = std.testing;
+    const io = std.Options.debug_io;
+
+    // First rpath is already the target (no replacement matches it); the
+    // second relocates onto it. Nothing is rewritten in place — the only
+    // change is the deletion, which must still be reported.
+    const bytes = try buildTwoRpathMachO(
+        testing.allocator,
+        "/opt/malt/lib",
+        32,
+        "/usr/local/lib",
+        32,
+    );
+    defer testing.allocator.free(bytes);
+
+    var s = try Scratch.init("patcher_delete_only");
+    defer s.deinit();
+    try s.dir.writeFile(io, .{ .sub_path = "bin", .data = bytes });
+    const abs = s.p("/bin");
+
+    const reps = [_]Replacement{.{ .old = "/usr/local", .new = "/opt/malt" }};
+    var outcome = try patchPathsCollecting(io, testing.allocator, abs, &reps);
+    defer outcome.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u32, 0), outcome.patched_count);
+    try testing.expectEqual(@as(usize, 1), outcome.overflow.len);
+    try testing.expect(outcome.overflow[0].delete);
+    try testing.expectEqualStrings("/usr/local/lib", outcome.overflow[0].old_path);
+}
+
+test "patchPathsCollecting keeps distinct rpaths when relocation does not collapse them" {
+    const testing = std.testing;
+    const io = std.Options.debug_io;
+
+    // `:any` bottle: only placeholders are rewritten, so `/usr/local/lib`
+    // stays distinct from the relocated `@@HOMEBREW_PREFIX@@/lib`.
+    const bytes = try buildTwoRpathMachO(
+        testing.allocator,
+        "@@HOMEBREW_PREFIX@@/lib",
+        40,
+        "/usr/local/lib",
+        32,
+    );
+    defer testing.allocator.free(bytes);
+
+    var s = try Scratch.init("patcher_no_collide");
+    defer s.deinit();
+    try s.dir.writeFile(io, .{ .sub_path = "bin", .data = bytes });
+    const abs = s.p("/bin");
+
+    const reps = [_]Replacement{
+        .{ .old = "@@HOMEBREW_PREFIX@@", .new = "/opt/malt" },
+        .{ .old = "@@HOMEBREW_CELLAR@@", .new = "/opt/malt/Cellar" },
+    };
+    var outcome = try patchPathsCollecting(io, testing.allocator, abs, &reps);
+    defer outcome.deinit(testing.allocator);
+
+    // One rewrite, no deletion: the two rpaths remain byte-distinct.
+    try testing.expectEqual(@as(u32, 1), outcome.patched_count);
+    try testing.expectEqual(@as(usize, 0), outcome.overflow.len);
+}
+
+test "patchPathsCollecting never dedups duplicate LC_LOAD_DYLIB commands" {
+    const testing = std.testing;
+    const io = std.Options.debug_io;
+    const macho = std.macho;
+
+    // Two LC_LOAD_DYLIB slots that relocate to the same target. Duplicate
+    // load-dylib commands are legal — dyld only aborts on duplicate rpaths,
+    // so the dedup must leave these alone.
+    const header_size = @sizeOf(macho.mach_header_64);
+    const name_off: u32 = @sizeOf(macho.dylib_command);
+    const cmdsize: u32 = 40;
+    const buf = try testing.allocator.alloc(u8, header_size + cmdsize * 2);
+    defer testing.allocator.free(buf);
+    @memset(buf, 0);
+
+    const hdr = std.mem.bytesAsValue(macho.mach_header_64, buf[0..header_size]);
+    hdr.* = .{ .magic = macho.MH_MAGIC_64, .ncmds = 2, .sizeofcmds = cmdsize * 2 };
+    inline for (.{ header_size, header_size + cmdsize }) |off| {
+        const dy = std.mem.bytesAsValue(macho.dylib_command, buf[off..][0..name_off]);
+        dy.* = .{
+            .cmd = .LOAD_DYLIB,
+            .cmdsize = cmdsize,
+            .dylib = .{ .name = name_off, .timestamp = 0, .current_version = 0, .compatibility_version = 0 },
+        };
+        @memcpy(buf[off + name_off ..][0.."/usr/local/x".len], "/usr/local/x");
+    }
+
+    var s = try Scratch.init("patcher_dylib_dup");
+    defer s.deinit();
+    try s.dir.writeFile(io, .{ .sub_path = "bin", .data = buf });
+    const abs = s.p("/bin");
+
+    const reps = [_]Replacement{.{ .old = "/usr/local", .new = "/opt/malt" }};
+    var outcome = try patchPathsCollecting(io, testing.allocator, abs, &reps);
+    defer outcome.deinit(testing.allocator);
+
+    // Both rewritten in place, nothing queued for deletion.
+    try testing.expectEqual(@as(u32, 2), outcome.patched_count);
+    try testing.expectEqual(@as(usize, 0), outcome.overflow.len);
+}
 
 test "fileLinksPath detects a needle in an LC_LOAD_DYLIB and ignores misses" {
     const testing = std.testing;

--- a/tests/macho_test.zig
+++ b/tests/macho_test.zig
@@ -190,6 +190,45 @@ test "parse a Mach-O 64 with an LC_RPATH command extracts the path" {
     defer m.deinit();
     try testing.expectEqual(@as(usize, 1), m.paths.len);
     try testing.expectEqualStrings("@executable_path/../lib", m.paths[0].path);
+    // Thin binary: the sole slice starts at offset 0.
+    try testing.expectEqual(@as(usize, 0), m.paths[0].slice_offset);
+}
+
+test "parse tags each fat-slice path with its own slice offset" {
+    // The rpath-dedup relies on this to scope collisions per arch slice: a
+    // universal binary carries the same rpath in each slice, and those must
+    // not read as duplicates of each other.
+    const header_size = @sizeOf(macho.mach_header_64);
+    const cmdsize: u32 = 40;
+    const slice_bytes: u32 = header_size + cmdsize;
+    const slice0: u32 = 8 + 2 * 20;
+    const slice1: u32 = slice0 + slice_bytes;
+    const path_off: u32 = @sizeOf(macho.rpath_command);
+
+    const buf = try testing.allocator.alloc(u8, slice1 + slice_bytes);
+    defer testing.allocator.free(buf);
+    @memset(buf, 0);
+
+    std.mem.writeInt(u32, buf[0..4], macho.FAT_MAGIC, .big);
+    std.mem.writeInt(u32, buf[4..8], 2, .big);
+    inline for (.{ .{ 8, 0x0100000C, slice0 }, .{ 28, 0x01000007, slice1 } }) |a| {
+        std.mem.writeInt(u32, buf[a[0]..][0..4], a[1], .big); // cputype
+        std.mem.writeInt(u32, buf[a[0] + 8 ..][0..4], a[2], .big); // offset
+        std.mem.writeInt(u32, buf[a[0] + 12 ..][0..4], slice_bytes, .big); // size
+    }
+    for ([_]u32{ slice0, slice1 }) |sl| {
+        const hdr = std.mem.bytesAsValue(macho.mach_header_64, buf[sl..][0..header_size]);
+        hdr.* = .{ .magic = macho.MH_MAGIC_64, .ncmds = 1, .sizeofcmds = cmdsize };
+        const rp = std.mem.bytesAsValue(macho.rpath_command, buf[sl + header_size ..][0..path_off]);
+        rp.* = .{ .cmd = .RPATH, .cmdsize = cmdsize, .path = path_off };
+        @memcpy(buf[sl + header_size + path_off ..][0..@as(usize, "@rpath\x00".len)], "@rpath\x00");
+    }
+
+    var m = try parser.parse(testing.allocator, buf);
+    defer m.deinit();
+    try testing.expectEqual(@as(usize, 2), m.paths.len);
+    try testing.expectEqual(@as(usize, slice0), m.paths[0].slice_offset);
+    try testing.expectEqual(@as(usize, slice1), m.paths[1].slice_offset);
 }
 
 test "parse rejects a truncated fat header" {

--- a/tests/patcher_test.zig
+++ b/tests/patcher_test.zig
@@ -270,6 +270,263 @@ test "patchPathsCollecting persists in-place rewrites to disk" {
     try testing.expectEqualStrings("/O/x", re.paths[1].path);
 }
 
+/// Build a Mach-O 64 binary with two LC_RPATH load commands, mirroring a
+/// bottle that names two Homebrew prefixes in its rpaths.
+fn buildTwoRpathFixture(
+    allocator: std.mem.Allocator,
+    path1: []const u8,
+    cmdsize1: u32,
+    path2: []const u8,
+    cmdsize2: u32,
+) ![]u8 {
+    const header_size = @sizeOf(macho.mach_header_64);
+    const path_off: u32 = @sizeOf(macho.rpath_command);
+    const buf = try allocator.alloc(u8, header_size + cmdsize1 + cmdsize2);
+    @memset(buf, 0);
+
+    const hdr = std.mem.bytesAsValue(macho.mach_header_64, buf[0..header_size]);
+    hdr.* = .{ .magic = macho.MH_MAGIC_64, .ncmds = 2, .sizeofcmds = cmdsize1 + cmdsize2 };
+
+    const off1 = header_size;
+    const rp1 = std.mem.bytesAsValue(macho.rpath_command, buf[off1..][0..path_off]);
+    rp1.* = .{ .cmd = .RPATH, .cmdsize = cmdsize1, .path = path_off };
+    std.debug.assert(path1.len + 1 <= cmdsize1 - path_off);
+    @memcpy(buf[off1 + path_off ..][0..path1.len], path1);
+
+    const off2 = header_size + cmdsize1;
+    const rp2 = std.mem.bytesAsValue(macho.rpath_command, buf[off2..][0..path_off]);
+    rp2.* = .{ .cmd = .RPATH, .cmdsize = cmdsize2, .path = path_off };
+    std.debug.assert(path2.len + 1 <= cmdsize2 - path_off);
+    @memcpy(buf[off2 + path_off ..][0..path2.len], path2);
+
+    return buf;
+}
+
+/// Minimal fat Mach-O with two arch slices (arm64 + x86_64), each carrying
+/// one identical LC_RPATH — the shape every universal bottle ships.
+fn buildFatTwoSliceRpath(allocator: std.mem.Allocator, rpath: []const u8, cmdsize: u32) ![]u8 {
+    const header_size = @sizeOf(macho.mach_header_64);
+    const path_off: u32 = @sizeOf(macho.rpath_command);
+    const slice_bytes: u32 = header_size + cmdsize;
+    const slice0: u32 = 8 + 2 * 20;
+    const slice1: u32 = slice0 + slice_bytes;
+    const buf = try allocator.alloc(u8, slice1 + slice_bytes);
+    @memset(buf, 0);
+
+    std.mem.writeInt(u32, buf[0..4], macho.FAT_MAGIC, .big);
+    std.mem.writeInt(u32, buf[4..8], 2, .big);
+    inline for (.{ .{ 8, 0x0100000C, slice0 }, .{ 28, 0x01000007, slice1 } }) |a| {
+        std.mem.writeInt(u32, buf[a[0]..][0..4], a[1], .big); // cputype
+        std.mem.writeInt(u32, buf[a[0] + 8 ..][0..4], a[2], .big); // offset
+        std.mem.writeInt(u32, buf[a[0] + 12 ..][0..4], slice_bytes, .big); // size
+    }
+    for ([_]u32{ slice0, slice1 }) |sl| {
+        const hdr = std.mem.bytesAsValue(macho.mach_header_64, buf[sl..][0..header_size]);
+        hdr.* = .{ .magic = macho.MH_MAGIC_64, .ncmds = 1, .sizeofcmds = cmdsize };
+        const rp = std.mem.bytesAsValue(macho.rpath_command, buf[sl + header_size ..][0..path_off]);
+        rp.* = .{ .cmd = .RPATH, .cmdsize = cmdsize, .path = path_off };
+        @memcpy(buf[sl + header_size + path_off ..][0..rpath.len], rpath);
+    }
+    return buf;
+}
+
+/// Fat Mach-O whose two arch slices each carry the same two colliding
+/// rpaths (`@@HOMEBREW_PREFIX@@/lib` + `/usr/local/lib`).
+fn buildFatTwoSliceCollidingRpaths(allocator: std.mem.Allocator) ![]u8 {
+    const header_size = @sizeOf(macho.mach_header_64);
+    const path_off: u32 = @sizeOf(macho.rpath_command);
+    const cmdsize: u32 = 40;
+    const slice_bytes: u32 = header_size + cmdsize * 2;
+    const slice0: u32 = 8 + 2 * 20;
+    const slice1: u32 = slice0 + slice_bytes;
+    const buf = try allocator.alloc(u8, slice1 + slice_bytes);
+    @memset(buf, 0);
+
+    std.mem.writeInt(u32, buf[0..4], macho.FAT_MAGIC, .big);
+    std.mem.writeInt(u32, buf[4..8], 2, .big);
+    inline for (.{ .{ 8, 0x0100000C, slice0 }, .{ 28, 0x01000007, slice1 } }) |a| {
+        std.mem.writeInt(u32, buf[a[0]..][0..4], a[1], .big);
+        std.mem.writeInt(u32, buf[a[0] + 8 ..][0..4], a[2], .big);
+        std.mem.writeInt(u32, buf[a[0] + 12 ..][0..4], slice_bytes, .big);
+    }
+    for ([_]u32{ slice0, slice1 }) |sl| {
+        const hdr = std.mem.bytesAsValue(macho.mach_header_64, buf[sl..][0..header_size]);
+        hdr.* = .{ .magic = macho.MH_MAGIC_64, .ncmds = 2, .sizeofcmds = cmdsize * 2 };
+        inline for (.{ .{ header_size, "@@HOMEBREW_PREFIX@@/lib" }, .{ header_size + cmdsize, "/usr/local/lib" } }) |rp| {
+            const lc = std.mem.bytesAsValue(macho.rpath_command, buf[sl + rp[0] ..][0..path_off]);
+            lc.* = .{ .cmd = .RPATH, .cmdsize = cmdsize, .path = path_off };
+            @memcpy(buf[sl + rp[0] + path_off ..][0..rp[1].len], rp[1]);
+        }
+    }
+    return buf;
+}
+
+test "patchPathsCollecting emits one deletion for a universal binary's per-slice colliders" {
+    var threaded: std.Io.Threaded = undefined;
+    const io = testIo(&threaded);
+    defer threaded.deinit();
+
+    // Each slice keeps one rpath and collapses the other. `-delete_rpath` is
+    // fat-wide by path, so the two per-slice colliders must share a single
+    // deletion — a second identical one would make install_name_tool fail.
+    const bytes = try buildFatTwoSliceCollidingRpaths(testing.allocator);
+    defer testing.allocator.free(bytes);
+
+    const dir = try tmpSubdir(io, "rpath_fat_collide");
+    defer {
+        std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(io, dir, "bin", bytes);
+    defer testing.allocator.free(path);
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "@@HOMEBREW_PREFIX@@", .new = "/opt/malt" },
+        .{ .old = "/usr/local", .new = "/opt/malt" },
+    };
+    var outcome = try patcher.patchPathsCollecting(io, testing.allocator, path, &replacements);
+    defer outcome.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u32, 2), outcome.patched_count);
+    try testing.expectEqual(@as(usize, 1), outcome.overflow.len);
+    try testing.expect(outcome.overflow[0].delete);
+    try testing.expectEqualStrings("/usr/local/lib", outcome.overflow[0].old_path);
+}
+
+test "patchPathsCollecting keeps a fat binary's per-slice identical rpaths" {
+    var threaded: std.Io.Threaded = undefined;
+    const io = testIo(&threaded);
+    defer threaded.deinit();
+
+    // Same rpath in each arch slice is normal, not a duplicate — dyld only
+    // aborts on a within-slice collision, so neither slice may be deleted.
+    const bytes = try buildFatTwoSliceRpath(testing.allocator, "@@HOMEBREW_PREFIX@@/lib", 40);
+    defer testing.allocator.free(bytes);
+
+    const dir = try tmpSubdir(io, "rpath_fat");
+    defer {
+        std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(io, dir, "bin", bytes);
+    defer testing.allocator.free(path);
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "@@HOMEBREW_PREFIX@@", .new = "/opt/malt" },
+    };
+    var outcome = try patcher.patchPathsCollecting(io, testing.allocator, path, &replacements);
+    defer outcome.deinit(testing.allocator);
+
+    // Both slices rewritten in place; nothing queued for deletion.
+    try testing.expectEqual(@as(u32, 2), outcome.patched_count);
+    try testing.expectEqual(@as(usize, 0), outcome.overflow.len);
+}
+
+test "patchPathsCollecting collapses two rpaths onto one target with a single kept slot" {
+    var threaded: std.Io.Threaded = undefined;
+    const io = testIo(&threaded);
+    defer threaded.deinit();
+
+    // fastfetch-shaped: two rpaths naming different prefixes that both
+    // relocate to "<prefix>/lib". The kept slot is rewritten in place; the
+    // colliding one is left byte-identical and queued for -delete_rpath.
+    const bytes = try buildTwoRpathFixture(
+        testing.allocator,
+        "@@HOMEBREW_PREFIX@@/lib",
+        40,
+        "/usr/local/lib",
+        32,
+    );
+    defer testing.allocator.free(bytes);
+
+    const dir = try tmpSubdir(io, "rpath_dedup");
+    defer {
+        std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(io, dir, "bin", bytes);
+    defer testing.allocator.free(path);
+
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "@@HOMEBREW_PREFIX@@", .new = "/opt/malt" },
+        .{ .old = "@@HOMEBREW_CELLAR@@", .new = "/opt/malt/Cellar" },
+        .{ .old = "/opt/homebrew", .new = "/opt/malt" },
+        .{ .old = "/usr/local", .new = "/opt/malt" },
+    };
+    var outcome = try patcher.patchPathsCollecting(io, testing.allocator, path, &replacements);
+    defer outcome.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(u32, 1), outcome.patched_count);
+    try testing.expectEqual(@as(usize, 1), outcome.overflow.len);
+    try testing.expect(outcome.overflow[0].delete);
+    try testing.expectEqualStrings("/usr/local/lib", outcome.overflow[0].old_path);
+
+    // On disk: first slot relocated, second slot left as-is for the
+    // fallback's -delete_rpath to strip.
+    const opened = try std.Io.Dir.openFileAbsolute(io, path, .{});
+    defer opened.close(io);
+    const stat_after = try opened.stat(io);
+    const data = try testing.allocator.alloc(u8, @intCast(stat_after.size));
+    defer testing.allocator.free(data);
+    _ = try opened.readPositionalAll(io, data, 0);
+
+    var re = try parser.parse(testing.allocator, data);
+    defer re.deinit();
+    try testing.expectEqual(@as(usize, 2), re.paths.len);
+    try testing.expectEqualStrings("/opt/malt/lib", re.paths[0].path);
+    try testing.expectEqualStrings("/usr/local/lib", re.paths[1].path);
+}
+
+test "patchPathsCollecting deletes a collider even when the kept rpath overflows" {
+    var threaded: std.Io.Threaded = undefined;
+    const io = testIo(&threaded);
+    defer threaded.deinit();
+
+    // The kept rpath relocates to a value too long for its slot (→ overflow
+    // `-rpath`), while the collider still collapses onto it (→ delete). Both
+    // must ride the same batch: one rewrite entry plus one deletion.
+    const bytes = try buildTwoRpathFixture(
+        testing.allocator,
+        "@@HOMEBREW_PREFIX@@/lib",
+        40,
+        "/usr/local/lib",
+        32,
+    );
+    defer testing.allocator.free(bytes);
+
+    const dir = try tmpSubdir(io, "rpath_overflow_delete");
+    defer {
+        std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+        testing.allocator.free(dir);
+    }
+    const path = try writeFixture(io, dir, "bin", bytes);
+    defer testing.allocator.free(path);
+
+    const long = "/opt/very-long-relocation-target";
+    const replacements = [_]patcher.Replacement{
+        .{ .old = "@@HOMEBREW_PREFIX@@", .new = long },
+        .{ .old = "/usr/local", .new = long },
+    };
+    var outcome = try patcher.patchPathsCollecting(io, testing.allocator, path, &replacements);
+    defer outcome.deinit(testing.allocator);
+
+    // Nothing fit in place; the batch carries the kept rewrite then the delete.
+    try testing.expectEqual(@as(u32, 0), outcome.patched_count);
+    try testing.expectEqual(@as(usize, 2), outcome.overflow.len);
+    try testing.expect(!outcome.overflow[0].delete);
+    try testing.expectEqualStrings("@@HOMEBREW_PREFIX@@/lib", outcome.overflow[0].old_path);
+    try testing.expectEqualStrings(long ++ "/lib", outcome.overflow[0].new_path);
+    try testing.expect(outcome.overflow[1].delete);
+    try testing.expectEqualStrings("/usr/local/lib", outcome.overflow[1].old_path);
+
+    // And that mixed batch builds one valid install_name_tool invocation.
+    const argv = try patcher.buildInstallNameToolArgv(testing.allocator, path, outcome.overflow);
+    defer testing.allocator.free(argv);
+    try testing.expectEqualStrings("-rpath", argv[1]);
+    try testing.expectEqualStrings("-delete_rpath", argv[4]);
+    try testing.expectEqualStrings("/usr/local/lib", argv[5]);
+}
+
 // ---------------------------------------------------------------------------
 // flushOverflow / install_name_tool driver
 // ---------------------------------------------------------------------------
@@ -319,6 +576,25 @@ test "buildInstallNameToolArgv routes LC_RPATH through -rpath" {
     try testing.expectEqualStrings("-rpath", argv[1]);
     try testing.expectEqualStrings(entries[0].old_path, argv[2]);
     try testing.expectEqualStrings(entries[0].new_path, argv[3]);
+}
+
+test "buildInstallNameToolArgv routes a delete entry through -delete_rpath" {
+    const entries = [_]patcher.OverflowEntry{
+        .{
+            .cmd = @intFromEnum(macho.LC.RPATH),
+            .old_path = "/usr/local/lib",
+            .new_path = "",
+            .delete = true,
+        },
+    };
+    const argv = try patcher.buildInstallNameToolArgv(testing.allocator, "/tmp/binary", &entries);
+    defer testing.allocator.free(argv);
+
+    // -delete_rpath <old> <binary>: no new path — the command is removed.
+    try testing.expectEqual(@as(usize, 4), argv.len);
+    try testing.expectEqualStrings("-delete_rpath", argv[1]);
+    try testing.expectEqualStrings("/usr/local/lib", argv[2]);
+    try testing.expectEqualStrings("/tmp/binary", argv[3]);
 }
 
 test "buildInstallNameToolArgv routes LC_ID_DYLIB through -id (no old arg)" {


### PR DESCRIPTION
## Description

Relocation rewrites `@@HOMEBREW_PREFIX@@`, `/opt/homebrew`, and `/usr/local` all onto `MALT_PREFIX`, so a bottle that names two of those prefixes in its rpaths (e.g. fastfetch) ends up with two identical `LC_RPATH`s and dyld aborts the process with SIGABRT before `main`. The Mach-O patcher now keeps the first occurrence of each relocated rpath value - scoped per arch slice so universal binaries keep their per-slice rpaths - and strips later colliders via `install_name_tool -delete_rpath`, so no duplicate ships. Verified end-to-end: installing the reported formula into a throwaway prefix yields a single `LC_RPATH` and the binary runs.

## Related Issue

Closes #754

## Notes for Reviewers

- None