### PR TITLE
test(outdated): de-flake the recompute-warm regression against timestamp digits

### DIFF
--- a/scripts/regressions/outdated-recompute-warms-snapshot-not-reaudit.sh
+++ b/scripts/regressions/outdated-recompute-warms-snapshot-not-reaudit.sh
@@ -63,7 +63,9 @@ seed_snapshot() {
 # own audit, overwriting the bogus marker.
 seed_snapshot 600
 "$BIN" outdated >/dev/null 2>&1 || true
-if grep -q '9.9' "$SNAP"; then
+# -F: match the literal marker. A bare `9.9` regex also matches `9<any>9`,
+# e.g. the `9094` in a freshly warmed snapshot's ms timestamp — a false hit.
+if grep -qF '9.9' "$SNAP"; then
   fail "full recompute did not warm the snapshot — the bogus marker survived (warm dropped)"
 fi
 pass "full recompute warms the snapshot (bogus marker overwritten)"
@@ -72,7 +74,7 @@ pass "full recompute warms the snapshot (bogus marker overwritten)"
 # partial audit would persist a snapshot the next reader trusts as complete.
 seed_snapshot 600
 "$BIN" outdated --pinned-only >/dev/null 2>&1 || true
-if ! grep -q '9.9' "$SNAP"; then
+if ! grep -qF '9.9' "$SNAP"; then
   fail "narrowed recompute overwrote the snapshot — a partial audit was persisted (gate lost)"
 fi
 pass "narrowed recompute leaves the snapshot untouched (no partial warm)"


### PR DESCRIPTION
## Description

`outdated-recompute-warms-snapshot-not-reaudit.sh` matched its bogus marker with `grep -q '9.9'`, where `.` is a regex wildcard - so it also matched `9<any>9`, e.g. the `909` inside a freshly warmed snapshot's millisecond timestamp. That produced a false "warm dropped" failure on roughly 1 in 8 runs even though the snapshot had been overwritten correctly. Both grep sites now use `grep -qF` (literal), which a digit-only timestamp can never match. Verified: 40/40 runs pass (previously ~12% flaky).

## Related Issue

- None

## Notes for Reviewers

- None