### PR TITLE
fix(cli): surface link path and bind failures instead of silent success

### DIFF
--- a/src/cli/link.zig
+++ b/src/cli/link.zig
@@ -7,6 +7,7 @@ const sqlite = @import("../db/sqlite.zig");
 const schema = @import("../db/schema.zig");
 const linker_mod = @import("../core/linker.zig");
 const atomic = @import("../fs/atomic.zig");
+const prefix_path = @import("../fs/prefix_path.zig");
 const output = @import("../ui/output.zig");
 const help = @import("help.zig");
 
@@ -42,8 +43,11 @@ pub fn executeLink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []con
 
     const prefix = atomic.maltPrefixOrAbort();
 
-    var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
+    var db_path_buf: [prefix_path.path_buf_len]u8 = undefined;
+    const db_path = prefix_path.joinZ(&db_path_buf, prefix, "/db/malt.db") catch {
+        output.err("Failed to open database", .{});
+        return error.Aborted;
+    };
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database", .{});
         return error.Aborted;
@@ -58,7 +62,10 @@ pub fn executeLink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []con
         return error.Aborted;
     };
     defer stmt.finalize();
-    stmt.bindText(1, target_name) catch return;
+    stmt.bindText(1, target_name) catch {
+        output.err("Database query failed", .{});
+        return error.Aborted;
+    };
 
     const has_row = stmt.step() catch false;
     if (!has_row) {
@@ -141,8 +148,11 @@ fn executeLinkIsolate(ctx: *const AppCtx, allocator: std.mem.Allocator, name: ?[
 
     const prefix = atomic.maltPrefixOrAbort();
 
-    var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
+    var db_path_buf: [prefix_path.path_buf_len]u8 = undefined;
+    const db_path = prefix_path.joinZ(&db_path_buf, prefix, "/db/malt.db") catch {
+        output.err("Failed to open database", .{});
+        return error.Aborted;
+    };
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database", .{});
         return error.Aborted;
@@ -259,8 +269,11 @@ pub fn executeUnlink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []c
     const name = args[0];
     const prefix = atomic.maltPrefixOrAbort();
 
-    var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
+    var db_path_buf: [prefix_path.path_buf_len]u8 = undefined;
+    const db_path = prefix_path.joinZ(&db_path_buf, prefix, "/db/malt.db") catch {
+        output.err("Failed to open database", .{});
+        return error.Aborted;
+    };
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database", .{});
         return error.Aborted;
@@ -275,7 +288,10 @@ pub fn executeUnlink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []c
         return error.Aborted;
     };
     defer stmt.finalize();
-    stmt.bindText(1, name) catch return;
+    stmt.bindText(1, name) catch {
+        output.err("Database query failed", .{});
+        return error.Aborted;
+    };
 
     const has_row = stmt.step() catch false;
     if (!has_row) {
@@ -293,8 +309,11 @@ pub fn executeUnlink(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []c
     };
 
     // Also remove opt/ symlink
-    var opt_buf: [512]u8 = undefined;
-    const opt_path = std.fmt.bufPrint(&opt_buf, "{s}/opt/{s}", .{ prefix, name }) catch return;
+    var opt_buf: [prefix_path.path_buf_len]u8 = undefined;
+    const opt_path = std.fmt.bufPrint(&opt_buf, "{s}/opt/{s}", .{ prefix, name }) catch {
+        output.err("Failed to remove symlinks for {s}", .{name});
+        return error.Aborted;
+    };
     std.Io.Dir.cwd().deleteFile(ctx.io, opt_path) catch {}; // opt/ link absent on never-linked kegs
 
     output.success("{s} unlinked (keg remains installed)", .{name});

--- a/tests/link_cli_test.zig
+++ b/tests/link_cli_test.zig
@@ -219,6 +219,34 @@ test "executeUnlink on a non-installed package returns Aborted" {
     );
 }
 
+// --- long-but-valid prefix must fail loud, not silently succeed ---------
+
+test "executeLink on a long-but-valid prefix fails loud instead of exiting 0" {
+    // A ~505-byte MALT_PREFIX passes validatePrefix (<=512) but overflowed
+    // the old 512-byte "{s}/db/malt.db" buffer, so the command hit
+    // `catch return` and exited 0 having done nothing. With the buffer grown
+    // to prefix_path.path_buf_len the format fits; the prefix dir does not
+    // exist, so db.open fails and the command must surface Aborted.
+    const allocator = testing.allocator;
+    var prefix_buf: [505]u8 = undefined;
+    prefix_buf[0] = '/';
+    @memset(prefix_buf[1..256], 'a'); // component 1: 255 bytes (<= NAME_MAX)
+    prefix_buf[256] = '/';
+    @memset(prefix_buf[257..505], 'b'); // component 2: 248 bytes
+    const prefixz = try allocator.dupeZ(u8, &prefix_buf);
+    defer allocator.free(prefixz);
+
+    _ = c.setenv("MALT_PREFIX", prefixz.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    quiet();
+    defer unquiet();
+    try testing.expectError(
+        error.Aborted,
+        link_mod.executeLink(&malt.app_ctx.debug_ctx, allocator, &.{"somepkg"}),
+    );
+}
+
 // --- executeLink --isolate ----------------------------------------------
 
 // Seed a keg row and tag it dependency so the --isolate gate accepts.


### PR DESCRIPTION
## Description

`mt link` and `mt unlink` no longer report success when a fallible step fails. Three database-path constructions now go through the overflow-safe `prefix_path.joinZ` primitive and surface `error.Aborted` with a diagnostic on overflow; the opt-link path build and the two SQLite `bindText` calls get the same fail-loud treatment inline, matching the file's existing `db.open` error idiom. A previously silent class of failures - a long-but-valid MALT_PREFIX that overflowed the fixed path buffer - now either completes correctly (buffer grown to 576 B) or fails loud, never exits 0 having done nothing.

## Related Issue

- None

## Notes for Reviewers

- None