### PR TITLE
fix(cli): surface migrate path failures instead of silent success

### DIFF
--- a/src/cli/migrate.zig
+++ b/src/cli/migrate.zig
@@ -15,6 +15,7 @@ const lock_report = @import("lock_report.zig");
 const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
+const prefix_path = @import("../fs/prefix_path.zig");
 const codesign = @import("../macho/codesign.zig");
 const api_mod = @import("../net/api.zig");
 const client_mod = @import("../net/client.zig");
@@ -130,8 +131,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     // ── Step 1: Detect Homebrew prefix ──────────────────────────────
     const brew_prefix = detectBrewPrefix(ctx);
-    var cellar_buf: [256]u8 = undefined;
-    const brew_cellar = std.fmt.bufPrint(&cellar_buf, "{s}/Cellar", .{brew_prefix}) catch return;
+    var cellar_buf: [prefix_path.path_buf_len]u8 = undefined;
+    // brew_prefix is unvalidated HOMEBREW_PREFIX — a too-long value must fail
+    // loud, not no-op.
+    const brew_cellar = prefix_path.join(&cellar_buf, brew_prefix, "/Cellar") catch {
+        output.err("Homebrew prefix path too long", .{});
+        return error.Aborted;
+    };
 
     std.Io.Dir.accessAbsolute(ctx.io, brew_cellar, .{}) catch {
         output.err("No Homebrew installation found at {s}", .{brew_prefix});
@@ -209,8 +215,11 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     ensureDirs(ctx, prefix) catch return error.Aborted;
 
     // Open database
-    var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
+    var db_path_buf: [prefix_path.path_buf_len]u8 = undefined;
+    const db_path = prefix_path.joinZ(&db_path_buf, prefix, "/db/malt.db") catch {
+        output.err("Failed to open database", .{});
+        return error.Aborted;
+    };
     var db = sqlite.Database.open(db_path) catch {
         output.err("Failed to open database at {s}", .{db_path});
         return error.Aborted;
@@ -223,8 +232,11 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     };
 
     // Acquire lock; `MALT_LOCK_TIMEOUT_MS` tunes the 30 s default.
-    var lock_path_buf: [512]u8 = undefined;
-    const lock_path = std.fmt.bufPrint(&lock_path_buf, "{s}/db/malt.lock", .{prefix}) catch return;
+    var lock_path_buf: [prefix_path.path_buf_len]u8 = undefined;
+    const lock_path = prefix_path.join(&lock_path_buf, prefix, "/db/malt.lock") catch {
+        output.err("Failed to acquire lock", .{});
+        return error.Aborted;
+    };
     var lk = lock_mod.LockFile.acquire(ctx.io, lock_path, lockTimeoutMs(ctx)) catch |e| switch (e) {
         // The DB is already open here, so db/ exists — DirMissing can't occur.
         error.DirMissing => return error.Aborted,
@@ -244,8 +256,11 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     defer http.deinit();
     http.offline = ctx.offline;
 
-    var cache_dir_buf: [512]u8 = undefined;
-    const cache_dir = std.fmt.bufPrint(&cache_dir_buf, "{s}/cache", .{prefix}) catch return;
+    var cache_dir_buf: [prefix_path.path_buf_len]u8 = undefined;
+    const cache_dir = prefix_path.join(&cache_dir_buf, prefix, "/cache") catch {
+        output.err("Failed to resolve cache directory", .{});
+        return error.Aborted;
+    };
     var api = api_mod.BrewApi.init(ctx.io, allocator, &http, cache_dir);
     api.base_url = ctx.mirrors.api_base;
     api.offline = ctx.offline;
@@ -259,12 +274,15 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     // Resume manifest: a crashed/^C run resumes from where it stopped
     // instead of redoing every keg.
-    var manifest_path_buf: [512]u8 = undefined;
-    const manifest_path = std.fmt.bufPrint(
+    var manifest_path_buf: [prefix_path.path_buf_len]u8 = undefined;
+    const manifest_path = prefix_path.join(
         &manifest_path_buf,
-        "{s}/cache/migrate.progress.json",
-        .{prefix},
-    ) catch return;
+        prefix,
+        "/cache/migrate.progress.json",
+    ) catch {
+        output.err("Failed to resolve resume manifest path", .{});
+        return error.Aborted;
+    };
     var manifest = manifest_mod.loadFromPath(ctx, allocator, manifest_path) catch |e| blk: {
         output.warn("Could not read resume manifest ({s}); starting fresh", .{@errorName(e)});
         break :blk manifest_mod.Manifest.init(allocator);

--- a/tests/migrate_smoke_test.zig
+++ b/tests/migrate_smoke_test.zig
@@ -62,6 +62,21 @@ fn pathExists(path: []const u8) bool {
     return true;
 }
 
+// Build a valid absolute prefix of exactly `total` bytes rooted at `base`,
+// padding with '/'-separated ≤255-byte components so it still passes
+// validatePrefix. Used to exercise the long-but-valid MALT_PREFIX band.
+fn buildLongPrefix(allocator: std.mem.Allocator, base: []const u8, total: usize) ![]u8 {
+    std.debug.assert(base.len + 2 <= total);
+    const buf = try allocator.alloc(u8, total);
+    @memcpy(buf[0..base.len], base);
+    @memset(buf[base.len..], 'a');
+    // Separators every 201 bytes keep components under NAME_MAX and the
+    // trailing component non-empty.
+    var sep = base.len;
+    while (sep < total - 1) : (sep += 201) buf[sep] = '/';
+    return buf;
+}
+
 // ── Flag parsing / input validation ─────────────────────────────────────
 
 test "migrate --help short-circuits before touching the filesystem" {
@@ -142,6 +157,84 @@ test "missing Homebrew installation yields error.Aborted" {
         error.Aborted,
         migrate.execute(&ctx, arena.allocator(), &.{"--dry-run"}),
     );
+}
+
+// ── Fail-loud on path-construction overflow ─────────────────────────────
+
+test "over-long HOMEBREW_PREFIX fails loud instead of exiting 0" {
+    resetOutput();
+    // detectBrewPrefix returns HOMEBREW_PREFIX unvalidated. A ~600-byte value
+    // overflows the Cellar path buffer; the old [256]u8 + `catch return`
+    // reported success. The overflow fires before any filesystem access, so
+    // no Cellar dir needs to exist.
+    var brew_buf: [600]u8 = undefined;
+    brew_buf[0] = '/';
+    @memset(brew_buf[1..], 'a');
+    try setenvZ("HOMEBREW_PREFIX", &brew_buf);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+
+    // Capturing stderr pins the "loud" half: a non-zero exit alone would also
+    // pass if the diagnostic were dropped, but silence is the bug being fixed.
+    var errbuf: std.ArrayList(u8) = .empty;
+    defer errbuf.deinit(testing.allocator);
+    io_mod.beginStderrCapture(testing.allocator, &errbuf);
+    defer io_mod.endStderrCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = malt.app_ctx.processEnviron() };
+    try testing.expectError(
+        error.Aborted,
+        migrate.execute(&ctx, arena.allocator(), &.{"--dry-run"}),
+    );
+    try testing.expect(containsLine(errbuf.items, "Homebrew prefix path too long"));
+}
+
+test "long-but-valid MALT_PREFIX reaches the real db failure instead of exiting 0" {
+    resetOutput();
+    const brew = try scratchDir("brew_longpfx");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, brew) catch {};
+        testing.allocator.free(brew);
+    }
+    const base = try scratchDir("mt_longpfx");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, base) catch {};
+        testing.allocator.free(base);
+    }
+    try seedFakeBrew(brew, &.{"tree"});
+
+    // A 512-byte MALT_PREFIX passes validatePrefix (≤ 512) but overflowed the
+    // old 512-byte "{s}/db/malt.db" buffer at the db-open site, so migrate hit
+    // `catch return` and exited 0 having done nothing. Grown to 576 the format
+    // fits, so it reaches db.open — which fails here because db/malt.db is a
+    // directory — and must surface Aborted.
+    const prefix = try buildLongPrefix(testing.allocator, base, 512);
+    defer testing.allocator.free(prefix);
+    try malt.atomic.validatePrefix(prefix); // precondition: this prefix is valid
+    const db_as_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.db", .{prefix});
+    defer testing.allocator.free(db_as_dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, db_as_dir);
+
+    const prefixz = try testing.allocator.dupeZ(u8, prefix);
+    defer testing.allocator.free(prefixz);
+    try setenvZ("HOMEBREW_PREFIX", brew);
+    defer _ = c.unsetenv("HOMEBREW_PREFIX");
+    _ = c.setenv("MALT_PREFIX", prefixz.ptr, 1);
+    defer _ = c.unsetenv("MALT_PREFIX");
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = malt.app_ctx.processEnviron() };
+    try testing.expectError(
+        error.Aborted,
+        migrate.execute(&ctx, arena.allocator(), &.{"--quiet"}),
+    );
+    resetOutput();
 }
 
 test "empty Cellar exits cleanly with no malt state created" {


### PR DESCRIPTION
## Description

`mt migrate` no longer reports success when a path construction fails. Five sites that formatted a prefix-relative path into a fixed stack buffer and swallowed the overflow now route through the overflow-safe `prefix_path.join`/`joinZ` primitive and surface `error.Aborted` with a diagnostic.

The highest-value fix is the Homebrew-Cellar path: its base is the unvalidated `HOMEBREW_PREFIX` env in a 256-byte buffer, so an over-long value used to silently no-op and now fails loud.

## Related Issue

- None

## Notes for Reviewers

- None