### PR TITLE
fix(core): fail loud when a forge auth token overflows its buffer

### DIFF
--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -1043,7 +1043,10 @@ fn writeJsonString(allocator: std.mem.Allocator, out: *std.ArrayList(u8), s: []c
 fn mapTapResolveError(e: tap_mod.TapError) InstallError {
     return switch (e) {
         error.RateLimited => InstallError.RateLimited,
-        error.NetworkError => InstallError.NetworkError,
+        error.NetworkError,
+        // A too-long token can't reach the network either; same exit path.
+        error.AuthTokenTooLong,
+        => InstallError.NetworkError,
         error.NotFound,
         error.MalformedJson,
         error.InvalidSha,
@@ -1151,6 +1154,8 @@ test "mapTapResolveError surfaces rate limit and network failure as their own ta
     // story when the real cause was a 60/hr rate-limit or a flaky DNS.
     try std.testing.expectEqual(InstallError.RateLimited, mapTapResolveError(error.RateLimited));
     try std.testing.expectEqual(InstallError.NetworkError, mapTapResolveError(error.NetworkError));
+    // A too-long token shares the network exit path, not FormulaNotFound.
+    try std.testing.expectEqual(InstallError.NetworkError, mapTapResolveError(error.AuthTokenTooLong));
 }
 
 test "mapTapResolveError keeps non-classified causes on FormulaNotFound" {

--- a/src/core/forge.zig
+++ b/src/core/forge.zig
@@ -310,6 +310,12 @@ pub fn commitUrl(
     }
 }
 
+/// A token that does not fit its caller-owned buffer is a loud error, not
+/// a silent drop: `null` means the token is unset/empty (anonymous is
+/// intended), so overflow needs its own signal or an oversized token would
+/// be indistinguishable from "no token" and go out unauthenticated.
+pub const AuthError = error{AuthTokenTooLong};
+
 /// Auth header for the forge's **API** request (the `commits/HEAD`
 /// call), built into `buf` from the forge's token env var, or null when
 /// unset/empty. The token contract is one env var per forge, keyed by
@@ -320,12 +326,12 @@ pub fn commitUrl(
 ///   - gitea: `MALT_GITEA_TOKEN`    → `Authorization: token <t>`
 /// The reach is deliberately narrow — only the tap-resolution callers
 /// pass this header — so the token never leaks onto unrelated requests.
-pub fn authHeader(forge: Forge, environ: std.process.Environ, buf: []u8) ?std.http.Header {
+pub fn authHeader(forge: Forge, environ: std.process.Environ, buf: []u8) AuthError!?std.http.Header {
     switch (forge) {
         .github => {
             const raw = std.process.Environ.getPosix(environ, "MALT_GITHUB_TOKEN") orelse return null;
             if (raw.len == 0) return null;
-            const value = std.fmt.bufPrint(buf, "Bearer {s}", .{raw}) catch return null;
+            const value = std.fmt.bufPrint(buf, "Bearer {s}", .{raw}) catch return error.AuthTokenTooLong;
             return .{ .name = "Authorization", .value = value };
         },
         .gitlab => return gitlabPrivateToken(environ, buf),
@@ -337,11 +343,11 @@ pub fn authHeader(forge: Forge, environ: std.process.Environ, buf: []u8) ?std.ht
 /// GitLab's `PRIVATE-TOKEN` header from `MALT_GITLAB_TOKEN`, or null when
 /// unset/empty. Shared by the API and the instance-host raw fetch — both
 /// authenticate the same way, against the same host.
-fn gitlabPrivateToken(environ: std.process.Environ, buf: []u8) ?std.http.Header {
+fn gitlabPrivateToken(environ: std.process.Environ, buf: []u8) AuthError!?std.http.Header {
     const raw = std.process.Environ.getPosix(environ, "MALT_GITLAB_TOKEN") orelse return null;
     if (raw.len == 0) return null;
     // Bare PAT — no scheme prefix, unlike github's Bearer.
-    const value = std.fmt.bufPrint(buf, "{s}", .{raw}) catch return null;
+    const value = std.fmt.bufPrint(buf, "{s}", .{raw}) catch return error.AuthTokenTooLong;
     return .{ .name = "PRIVATE-TOKEN", .value = value };
 }
 
@@ -351,10 +357,10 @@ fn gitlabPrivateToken(environ: std.process.Environ, buf: []u8) ?std.http.Header 
 /// the codeberg.org instance. Shared by the API and the instance-host raw
 /// fetch — both authenticate the same way, against the same host. The
 /// `token` scheme is Gitea's, not github's `Bearer`.
-fn giteaToken(environ: std.process.Environ, buf: []u8) ?std.http.Header {
+fn giteaToken(environ: std.process.Environ, buf: []u8) AuthError!?std.http.Header {
     const raw = std.process.Environ.getPosix(environ, "MALT_GITEA_TOKEN") orelse return null;
     if (raw.len == 0) return null;
-    const value = std.fmt.bufPrint(buf, "token {s}", .{raw}) catch return null;
+    const value = std.fmt.bufPrint(buf, "token {s}", .{raw}) catch return error.AuthTokenTooLong;
     return .{ .name = "Authorization", .value = value };
 }
 
@@ -364,12 +370,12 @@ fn giteaToken(environ: std.process.Environ, buf: []u8) ?std.http.Header {
 /// attaching it there would only widen the token's reach, so the github
 /// raw fetch stays unauthenticated, exactly as before. Forges whose raw
 /// path lives on the authenticated instance host attach their token here.
-pub fn rawAuthHeader(forge: Forge, environ: std.process.Environ, buf: []u8) ?std.http.Header {
+pub fn rawAuthHeader(forge: Forge, environ: std.process.Environ, buf: []u8) AuthError!?std.http.Header {
     return switch (forge) {
         .github => null,
-        .gitlab => gitlabPrivateToken(environ, buf),
+        .gitlab => try gitlabPrivateToken(environ, buf),
         // Gitea/Gogs serve `/raw` from the authenticated instance host, like gitlab.
-        .gitea, .gogs => giteaToken(environ, buf),
+        .gitea, .gogs => try giteaToken(environ, buf),
     };
 }
 
@@ -567,13 +573,13 @@ fn envWith(comptime entries: anytype) std.process.Environ {
 
 test "authHeader github: null when MALT_GITHUB_TOKEN unset" {
     var buf: [256]u8 = undefined;
-    try std.testing.expect(authHeader(.github, .empty, &buf) == null);
+    try std.testing.expect(try authHeader(.github, .empty, &buf) == null);
 }
 
 test "authHeader github: Bearer header when MALT_GITHUB_TOKEN set" {
     const entries = [_:null]?[*:0]const u8{"MALT_GITHUB_TOKEN=ghp_testtoken"};
     var buf: [256]u8 = undefined;
-    const h = authHeader(.github, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
+    const h = try authHeader(.github, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
     try std.testing.expectEqualStrings("Authorization", h.name);
     try std.testing.expectEqualStrings("Bearer ghp_testtoken", h.value);
 }
@@ -581,7 +587,7 @@ test "authHeader github: Bearer header when MALT_GITHUB_TOKEN set" {
 test "authHeader github: empty-string token behaves as unset" {
     const entries = [_:null]?[*:0]const u8{"MALT_GITHUB_TOKEN="};
     var buf: [256]u8 = undefined;
-    try std.testing.expect(authHeader(.github, envWith(entries), &buf) == null);
+    try std.testing.expect(try authHeader(.github, envWith(entries), &buf) == null);
 }
 
 test "rawAuthHeader github: null even when MALT_GITHUB_TOKEN is set" {
@@ -589,8 +595,8 @@ test "rawAuthHeader github: null even when MALT_GITHUB_TOKEN is set" {
     // fetch stays unauthenticated so the token's reach never widens.
     const entries = [_:null]?[*:0]const u8{"MALT_GITHUB_TOKEN=ghp_testtoken"};
     var buf: [256]u8 = undefined;
-    try std.testing.expect(rawAuthHeader(.github, envWith(entries), &buf) == null);
-    try std.testing.expect(rawAuthHeader(.github, .empty, &buf) == null);
+    try std.testing.expect(try rawAuthHeader(.github, envWith(entries), &buf) == null);
+    try std.testing.expect(try rawAuthHeader(.github, .empty, &buf) == null);
 }
 
 // ── authHeader (gitlab) ────────────────────────────────────────────
@@ -600,13 +606,13 @@ test "rawAuthHeader github: null even when MALT_GITHUB_TOKEN is set" {
 
 test "authHeader gitlab: null when MALT_GITLAB_TOKEN unset" {
     var buf: [256]u8 = undefined;
-    try std.testing.expect(authHeader(.gitlab, .empty, &buf) == null);
+    try std.testing.expect(try authHeader(.gitlab, .empty, &buf) == null);
 }
 
 test "authHeader gitlab: PRIVATE-TOKEN header when MALT_GITLAB_TOKEN set" {
     const entries = [_:null]?[*:0]const u8{"MALT_GITLAB_TOKEN=glpat-xyz"};
     var buf: [256]u8 = undefined;
-    const h = authHeader(.gitlab, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
+    const h = try authHeader(.gitlab, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
     try std.testing.expectEqualStrings("PRIVATE-TOKEN", h.name);
     try std.testing.expectEqualStrings("glpat-xyz", h.value);
 }
@@ -614,7 +620,7 @@ test "authHeader gitlab: PRIVATE-TOKEN header when MALT_GITLAB_TOKEN set" {
 test "authHeader gitlab: empty-string token behaves as unset" {
     const entries = [_:null]?[*:0]const u8{"MALT_GITLAB_TOKEN="};
     var buf: [256]u8 = undefined;
-    try std.testing.expect(authHeader(.gitlab, envWith(entries), &buf) == null);
+    try std.testing.expect(try authHeader(.gitlab, envWith(entries), &buf) == null);
 }
 
 test "rawAuthHeader gitlab: PRIVATE-TOKEN attached — raw lives on the instance host" {
@@ -623,14 +629,76 @@ test "rawAuthHeader gitlab: PRIVATE-TOKEN attached — raw lives on the instance
     // the token. Same var, same header as the API call.
     const entries = [_:null]?[*:0]const u8{"MALT_GITLAB_TOKEN=glpat-xyz"};
     var buf: [256]u8 = undefined;
-    const h = rawAuthHeader(.gitlab, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
+    const h = try rawAuthHeader(.gitlab, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
     try std.testing.expectEqualStrings("PRIVATE-TOKEN", h.name);
     try std.testing.expectEqualStrings("glpat-xyz", h.value);
 }
 
 test "rawAuthHeader gitlab: null when MALT_GITLAB_TOKEN unset" {
     var buf: [256]u8 = undefined;
-    try std.testing.expect(rawAuthHeader(.gitlab, .empty, &buf) == null);
+    try std.testing.expect(try rawAuthHeader(.gitlab, .empty, &buf) == null);
+}
+
+// ── auth header overflow (all forges) ──────────────────────────────
+// The regression: a token too long for its caller-owned buffer must be a
+// loud `error.AuthTokenTooLong`, never a silent `null` - `null` would be
+// indistinguishable from "unset" and send the request out unauthenticated.
+// `null` stays reserved for the unset/empty path (covered by the tests above).
+
+test "authHeader github: overflow is a loud error, not a silent anonymous drop" {
+    const entries = [_:null]?[*:0]const u8{"MALT_GITHUB_TOKEN=" ++ "x" ** 300};
+    var small_buf: [64]u8 = undefined;
+    try std.testing.expectError(error.AuthTokenTooLong, authHeader(.github, envWith(entries), &small_buf));
+}
+
+test "authHeader gitlab: overflow is a loud error" {
+    const entries = [_:null]?[*:0]const u8{"MALT_GITLAB_TOKEN=" ++ "x" ** 300};
+    var small_buf: [64]u8 = undefined;
+    try std.testing.expectError(error.AuthTokenTooLong, authHeader(.gitlab, envWith(entries), &small_buf));
+}
+
+test "authHeader gitea: overflow is a loud error" {
+    const entries = [_:null]?[*:0]const u8{"MALT_GITEA_TOKEN=" ++ "x" ** 300};
+    var small_buf: [64]u8 = undefined;
+    try std.testing.expectError(error.AuthTokenTooLong, authHeader(.gitea, envWith(entries), &small_buf));
+}
+
+test "rawAuthHeader gitlab: overflow is a loud error via the raw path too" {
+    const entries = [_:null]?[*:0]const u8{"MALT_GITLAB_TOKEN=" ++ "x" ** 300};
+    var small_buf: [64]u8 = undefined;
+    try std.testing.expectError(error.AuthTokenTooLong, rawAuthHeader(.gitlab, envWith(entries), &small_buf));
+}
+
+test "authHeader github: a realistic long token fits the widened buffer" {
+    // A 600-byte token (GitHub-App / fine-grained PAT scale) must
+    // authenticate in full, not error, against a buffer sized like tap.zig's.
+    const entries = [_:null]?[*:0]const u8{"MALT_GITHUB_TOKEN=" ++ "t" ** 600};
+    var buf: [8 * 1024]u8 = undefined;
+    const h = try authHeader(.github, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
+    try std.testing.expectEqualStrings("Authorization", h.name);
+    try std.testing.expectEqualStrings("Bearer " ++ "t" ** 600, h.value);
+}
+
+test "authHeader gitlab: a realistic long bare PAT fits the widened buffer" {
+    const entries = [_:null]?[*:0]const u8{"MALT_GITLAB_TOKEN=" ++ "t" ** 600};
+    var buf: [8 * 1024]u8 = undefined;
+    const h = try authHeader(.gitlab, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
+    try std.testing.expectEqualStrings("PRIVATE-TOKEN", h.name);
+    try std.testing.expectEqualStrings("t" ** 600, h.value);
+}
+
+test "authHeader github: a value that exactly fills the buffer authenticates" {
+    // Boundary: value length == buf.len is a fit, not an overflow.
+    const entries = [_:null]?[*:0]const u8{"MALT_GITHUB_TOKEN=" ++ "t" ** 57};
+    var buf: [64]u8 = undefined; // "Bearer " (7) + 57 == 64
+    const h = try authHeader(.github, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
+    try std.testing.expectEqualStrings("Bearer " ++ "t" ** 57, h.value);
+}
+
+test "authHeader github: one byte past the buffer is a loud error" {
+    const entries = [_:null]?[*:0]const u8{"MALT_GITHUB_TOKEN=" ++ "t" ** 58};
+    var buf: [64]u8 = undefined; // "Bearer " (7) + 58 == 65 > 64
+    try std.testing.expectError(error.AuthTokenTooLong, authHeader(.github, envWith(entries), &buf));
 }
 
 // ── buildBaseUrls (github) ─────────────────────────────────────────
@@ -1022,13 +1090,13 @@ test "rawFileUrl gitea: formula_root kind builds the /raw root tail" {
 
 test "authHeader gitea: null when MALT_GITEA_TOKEN unset" {
     var buf: [256]u8 = undefined;
-    try std.testing.expect(authHeader(.gitea, .empty, &buf) == null);
+    try std.testing.expect(try authHeader(.gitea, .empty, &buf) == null);
 }
 
 test "authHeader gitea: token header when MALT_GITEA_TOKEN set" {
     const entries = [_:null]?[*:0]const u8{"MALT_GITEA_TOKEN=gitea_tok"};
     var buf: [256]u8 = undefined;
-    const h = authHeader(.gitea, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
+    const h = try authHeader(.gitea, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
     try std.testing.expectEqualStrings("Authorization", h.name);
     try std.testing.expectEqualStrings("token gitea_tok", h.value);
 }
@@ -1036,7 +1104,7 @@ test "authHeader gitea: token header when MALT_GITEA_TOKEN set" {
 test "authHeader gitea: empty-string token behaves as unset" {
     const entries = [_:null]?[*:0]const u8{"MALT_GITEA_TOKEN="};
     var buf: [256]u8 = undefined;
-    try std.testing.expect(authHeader(.gitea, envWith(entries), &buf) == null);
+    try std.testing.expect(try authHeader(.gitea, envWith(entries), &buf) == null);
 }
 
 test "rawAuthHeader gitea: token attached — raw lives on the instance host" {
@@ -1044,14 +1112,14 @@ test "rawAuthHeader gitea: token attached — raw lives on the instance host" {
     // unlike github's public CDN), so a private tap's raw fetch carries it.
     const entries = [_:null]?[*:0]const u8{"MALT_GITEA_TOKEN=gitea_tok"};
     var buf: [256]u8 = undefined;
-    const h = rawAuthHeader(.gitea, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
+    const h = try rawAuthHeader(.gitea, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
     try std.testing.expectEqualStrings("Authorization", h.name);
     try std.testing.expectEqualStrings("token gitea_tok", h.value);
 }
 
 test "rawAuthHeader gitea: null when MALT_GITEA_TOKEN unset" {
     var buf: [256]u8 = undefined;
-    try std.testing.expect(rawAuthHeader(.gitea, .empty, &buf) == null);
+    try std.testing.expect(try rawAuthHeader(.gitea, .empty, &buf) == null);
 }
 
 // ── commitUrl ──────────────────────────────────────────────────────
@@ -1208,20 +1276,20 @@ test "repoBrowseUrl gogs: the instance host drives the browse URL" {
 test "authHeader gogs: token header from MALT_GITEA_TOKEN (shared family token)" {
     const entries = [_:null]?[*:0]const u8{"MALT_GITEA_TOKEN=gitea_tok"};
     var buf: [256]u8 = undefined;
-    const h = authHeader(.gogs, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
+    const h = try authHeader(.gogs, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
     try std.testing.expectEqualStrings("Authorization", h.name);
     try std.testing.expectEqualStrings("token gitea_tok", h.value);
 }
 
 test "authHeader gogs: null when MALT_GITEA_TOKEN unset" {
     var buf: [256]u8 = undefined;
-    try std.testing.expect(authHeader(.gogs, .empty, &buf) == null);
+    try std.testing.expect(try authHeader(.gogs, .empty, &buf) == null);
 }
 
 test "rawAuthHeader gogs: token attached — raw lives on the instance host" {
     const entries = [_:null]?[*:0]const u8{"MALT_GITEA_TOKEN=gitea_tok"};
     var buf: [256]u8 = undefined;
-    const h = rawAuthHeader(.gogs, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
+    const h = try rawAuthHeader(.gogs, envWith(entries), &buf) orelse return error.TestUnexpectedNull;
     try std.testing.expectEqualStrings("token gitea_tok", h.value);
 }
 

--- a/src/core/tap.zig
+++ b/src/core/tap.zig
@@ -29,6 +29,10 @@ pub const TapError = error{
     MalformedJson,
     /// Network layer failure before a status could be read.
     NetworkError,
+    /// The forge token overflowed the auth-header buffer. A loud config
+    /// error, kept distinct from NetworkError so the user is told to check
+    /// the token, not their connection.
+    AuthTokenTooLong,
     OutOfMemory,
 };
 
@@ -65,6 +69,7 @@ fn githubResolveError(err: TapError) []const u8 {
         error.RateLimited => "GitHub API rate limit reached. Set MALT_GITHUB_TOKEN to an authorized GitHub token to lift the 60/hr anonymous cap.",
         error.NotFound => "GitHub returned 404 for the tap repo. If the repo lives at github.com/<user>/<exact-name> instead of github.com/<user>/homebrew-<repo>, rerun with --repo <user>/<exact-name>.",
         error.NetworkError => "Network failure while reaching api.github.com — check connectivity and retry.",
+        error.AuthTokenTooLong => "MALT_GITHUB_TOKEN is too long to fit the auth request buffer — verify the token value.",
         error.MalformedJson => "Unexpected response shape from GitHub — rerun with --debug and attach the log when filing an issue.",
         error.InvalidSha => "GitHub returned a commit SHA that failed validation (not 40-char lowercase hex).",
         error.ResolveFailed => "GitHub returned an unexpected status while resolving HEAD — retry, or set MALT_GITHUB_TOKEN if this persists.",
@@ -90,6 +95,7 @@ fn forgeResolveError(
         // No homebrew-/--repo hint: that synthesis is github-only.
         error.NotFound => std.fmt.bufPrint(buf, "{s} returned 404 for the tap repo at {s}. Verify the owner/repo, or set {s} if the repo is private.", .{ name, host, token_var }) catch unreachable,
         error.NetworkError => std.fmt.bufPrint(buf, "Network failure while reaching {s} — check connectivity and retry.", .{host}) catch unreachable,
+        error.AuthTokenTooLong => std.fmt.bufPrint(buf, "The {s} token in {s} is too long to fit the auth request buffer.", .{ name, token_var }) catch unreachable,
         error.MalformedJson => std.fmt.bufPrint(buf, "Unexpected response shape from {s} ({s}) — rerun with --debug and attach the log when filing an issue.", .{ name, host }) catch unreachable,
         error.InvalidSha => std.fmt.bufPrint(buf, "{s} ({s}) returned a commit SHA that failed validation (not 40-char lowercase hex).", .{ name, host }) catch unreachable,
         error.ResolveFailed => std.fmt.bufPrint(buf, "{s} ({s}) returned an unexpected status while resolving HEAD — retry, or set {s} if this persists.", .{ name, host, token_var }) catch unreachable,
@@ -152,6 +158,23 @@ test "describeResolveError gitea: a self-hosted Forgejo host is named" {
     var buf: [512]u8 = undefined;
     const msg = describeResolveError(&buf, error.MalformedJson, .gitea, "git.example.org");
     try std.testing.expect(std.mem.indexOf(u8, msg, "git.example.org") != null);
+}
+
+test "describeResolveError github: AuthTokenTooLong names the token, not the network" {
+    var buf: [512]u8 = undefined;
+    const msg = describeResolveError(&buf, error.AuthTokenTooLong, .github, "github.com");
+    try std.testing.expect(std.mem.indexOf(u8, msg, "MALT_GITHUB_TOKEN") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "too long") != null);
+    // Must not be misreported as a connectivity failure.
+    try std.testing.expect(std.mem.indexOf(u8, msg, "Network failure") == null);
+}
+
+test "describeResolveError gitlab: AuthTokenTooLong names the forge's own token var" {
+    var buf: [512]u8 = undefined;
+    const msg = describeResolveError(&buf, error.AuthTokenTooLong, .gitlab, "gitlab.com");
+    try std.testing.expect(std.mem.indexOf(u8, msg, "MALT_GITLAB_TOKEN") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "too long") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "MALT_GITHUB_TOKEN") == null);
 }
 
 test "describeResolveError gogs: names the instance host and the shared MALT_GITEA_TOKEN" {
@@ -1378,8 +1401,11 @@ pub fn resolveHeadCommit(
     // request; falling through to `extra=&.{}` lets net/client's
     // HOMEBREW_GITHUB_API_TOKEN auto-inject still apply for github hosts.
     // 304s don't spend the rate-limit quota either way.
-    var auth_buf: [256]u8 = undefined;
-    var resp = if (forge.authHeader(forge_kind, environ, &auth_buf)) |header| blk: {
+    // Generous fixed cap so realistic long tokens (fine-grained / GitHub-App
+    // PATs) fit; overflow is a loud, token-specific error, never a silent
+    // anonymous request.
+    var auth_buf: [8 * 1024]u8 = undefined;
+    var resp = if (forge.authHeader(forge_kind, environ, &auth_buf) catch return TapError.AuthTokenTooLong) |header| blk: {
         const headers = [_]std.http.Header{header};
         break :blk http.getConditional(api_head_url, cached_etag, &headers) catch return TapError.NetworkError;
     } else http.getConditional(api_head_url, cached_etag, &.{}) catch return TapError.NetworkError;
@@ -1400,8 +1426,10 @@ pub fn getRawFile(
     forge_kind: forge.Forge,
     rb_url: []const u8,
 ) !client_mod.Response {
-    var auth_buf: [256]u8 = undefined;
-    if (forge.rawAuthHeader(forge_kind, environ, &auth_buf)) |header| {
+    // Generous fixed cap so realistic long tokens fit; overflow propagates
+    // as a loud error rather than a silent anonymous fetch.
+    var auth_buf: [8 * 1024]u8 = undefined;
+    if (try forge.rawAuthHeader(forge_kind, environ, &auth_buf)) |header| {
         const headers = [_]std.http.Header{header};
         return http.getWithHeaders(rb_url, &headers, null);
     }

--- a/tests/tap_raw_rb_auth_test.zig
+++ b/tests/tap_raw_rb_auth_test.zig
@@ -45,6 +45,71 @@ fn envWithToken() std.process.Environ {
     return .{ .block = .{ .slice = entries[0..1 :null] } };
 }
 
+// Records the value of the PRIVATE-TOKEN header the request carried, so a
+// test can prove a long token arrives intact rather than truncated/dropped.
+const TokenFixture = struct {
+    io: std.Io,
+    listener: *net.Server,
+    token_buf: [1024]u8 = undefined,
+    token_len: usize = 0,
+};
+
+fn serveCapturingToken(fx: *TokenFixture) void {
+    const stream = fx.listener.accept(fx.io) catch return;
+    defer stream.close(fx.io);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var reader = stream.reader(fx.io, &rbuf);
+    var writer = stream.writer(fx.io, &wbuf);
+    var srv = std.http.Server.init(&reader.interface, &writer.interface);
+    var req = srv.receiveHead() catch return;
+    var it = req.iterateHeaders();
+    while (it.next()) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, "private-token")) {
+            const n = @min(h.value.len, fx.token_buf.len);
+            @memcpy(fx.token_buf[0..n], h.value[0..n]);
+            fx.token_len = h.value.len;
+        }
+    }
+    req.respond(body_rb, .{}) catch return;
+}
+
+fn envWithLongGitlabToken() std.process.Environ {
+    const entries = [_:null]?[*:0]const u8{"MALT_GITLAB_TOKEN=" ++ "t" ** 600};
+    return .{ .block = .{ .slice = entries[0..1 :null] } };
+}
+
+test "getRawFile: gitlab raw fetch carries a 600-byte token in full through the widened buffer" {
+    // End-to-end guard for tap.zig's widened auth buffer: a realistic long
+    // token must reach the instance host intact. On the pre-fix 256-byte
+    // buffer this token overflowed to `null` and no header was sent.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var fx = TokenFixture{ .io = io, .listener = &listener };
+    const server_thread = try std.Thread.spawn(.{}, serveCapturingToken, .{&fx});
+    defer server_thread.join();
+
+    var url_buf: [80]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/-/raw/glow.rb", .{port});
+
+    var inner: std.http.Client = .{ .allocator = std.testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, envWithLongGitlabToken(), std.testing.allocator);
+    defer http.deinit();
+
+    var resp = try tap.getRawFile(&http, envWithLongGitlabToken(), .gitlab, url);
+    defer resp.deinit();
+    try std.testing.expectEqual(@as(u16, 200), resp.status);
+    try std.testing.expectEqual(@as(usize, 600), fx.token_len);
+    try std.testing.expectEqualStrings("t" ** 600, fx.token_buf[0..fx.token_len]);
+}
+
 test "getRawFile: github raw fetch carries no auth header even with MALT_GITHUB_TOKEN set" {
     var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
     defer threaded.deinit();


### PR DESCRIPTION
## Description

The forge auth-header builders formatted a token into a fixed 256-byte buffer and returned `null` on overflow - the same value that means "no token set". A long fine-grained / GitHub-App / GitLab / Gitea token was therefore dropped silently and the request went out unauthenticated, seen only as a lower rate limit or a 403/404 on a private resource.

Overflow now fails loud: the builders return `AuthTokenTooLong` while `null` keeps its single meaning (token unset).

## Related Issue

- None

## Notes for Reviewers

- None