### PR TITLE
feat(dsl): interpolate heredoc bodies in the native interpreter

### DIFF
--- a/src/core/dsl/ast.zig
+++ b/src/core/dsl/ast.zig
@@ -31,7 +31,6 @@ pub const Node = struct {
         begin_rescue: BeginRescue,
         array_literal: []const *const Node,
         hash_literal: []const HashEntry,
-        heredoc_literal: []const u8,
         raise_statement: RaiseStatement,
         logical_and: LogicalBinary,
         logical_or: LogicalBinary,

--- a/src/core/dsl/interpreter.zig
+++ b/src/core/dsl/interpreter.zig
@@ -113,7 +113,6 @@ pub const Interpreter = struct {
             .bool_literal => |b| Value{ .bool = b },
             .nil_literal => Value{ .nil = {} },
             .symbol_literal => |s| Value{ .symbol = s },
-            .heredoc_literal => |h| Value{ .string = h },
             .identifier => |name| self.evalIdentifier(name, node.loc),
             .assignment => |a| self.evalAssignment(&a),
             .method_call => |mc| self.evalMethodCall(&mc, node.loc),

--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -592,14 +592,26 @@ pub const Parser = struct {
         self.advanceToken();
         const body = if (self.current.kind == .heredoc_body) self.current.lexeme else "";
         if (self.current.kind == .heredoc_body) self.advanceToken();
-        return self.allocNode(.{ .loc = loc, .kind = .{ .heredoc_literal = body } });
+        return self.heredocNode(body, loc);
     }
 
     fn parseHeredocBody(self: *Parser) DslError!*const Node {
         const loc = self.currentLoc();
         const body = self.current.lexeme;
         self.advanceToken();
-        return self.allocNode(.{ .loc = loc, .kind = .{ .heredoc_literal = body } });
+        return self.heredocNode(body, loc);
+    }
+
+    /// Lower a heredoc body onto the shared `string_literal` path so `#{...}`
+    /// interpolates exactly like a double-quoted string, inheriting its
+    /// hardened dangling / parse-failure fallbacks. A future non-interpolating
+    /// `<<~'EOS'` would bypass this and emit a single literal part instead.
+    fn heredocNode(self: *Parser, body: []const u8, loc: SourceLoc) DslError!*const Node {
+        const parts = try self.parseStringInterpolation(body, loc);
+        return self.allocNode(.{
+            .loc = loc,
+            .kind = .{ .string_literal = .{ .parts = parts } },
+        });
     }
 
     fn parseIntegerLit(self: *Parser) DslError!*const Node {

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -221,6 +221,36 @@ test "interpreter: file write creates file with content" {
     try testing.expectEqualStrings("key=value", buf[0..n]);
 }
 
+test "interpreter: heredoc body interpolates via evalStringLiteral" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    var scratch = try makeTempPrefix();
+    defer scratch.deinit();
+    const prefix = scratch.path;
+
+    // A `#{x}` inside a heredoc body must resolve the bound local, matching
+    // the double-quoted path. Indent is preserved (de-indent is a follow-up).
+    const src =
+        "x = \"world\"\n" ++
+        "greeting = <<~EOS\n  hello #{x}\nEOS\n" ++
+        "(etc/\"greet.conf\").write greeting\n";
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
+
+    const expected_path = try std.fs.path.join(
+        testing.allocator,
+        &.{ prefix, "etc", "greet.conf" },
+    );
+    defer testing.allocator.free(expected_path);
+
+    const file = try test_io.openFileAbsolute(std.Options.debug_io, expected_path, .{});
+    defer file.close(std.Options.debug_io);
+    var buf: [64]u8 = undefined;
+    const n = try file.readPositionalAll(std.Options.debug_io, &buf, 0);
+    try testing.expectEqualStrings("  hello world\n", buf[0..n]);
+}
+
 test "interpreter: system true succeeds" {
     var arena = testArena();
     defer arena.deinit();

--- a/tests/dsl_parser_test.zig
+++ b/tests/dsl_parser_test.zig
@@ -743,7 +743,8 @@ test "parser: Dir peek preserves heredoc lexer state" {
     try testing.expectEqual(@as(usize, 2), nodes.len);
     try testing.expectEqualStrings("Dir", nodes[0].kind.identifier);
 
-    const body = nodes[1].kind.heredoc_literal;
+    // Non-interpolating body lowers to a single literal part (indent kept).
+    const body = nodes[1].kind.string_literal.parts[0].literal;
     try testing.expect(std.mem.indexOf(u8, body, "<<~") == null);
     try testing.expectEqualStrings("  body\n", body);
 }
@@ -759,7 +760,8 @@ test "parser: Formula peek preserves heredoc lexer state" {
     try testing.expectEqual(@as(usize, 2), nodes.len);
     try testing.expectEqualStrings("Formula", nodes[0].kind.identifier);
 
-    const body = nodes[1].kind.heredoc_literal;
+    // Non-interpolating body lowers to a single literal part (indent kept).
+    const body = nodes[1].kind.string_literal.parts[0].literal;
     try testing.expect(std.mem.indexOf(u8, body, "<<~") == null);
     try testing.expectEqualStrings("  body\n", body);
 }
@@ -775,7 +777,8 @@ test "parser: ENV peek preserves heredoc lexer state" {
     try testing.expectEqual(@as(usize, 2), nodes.len);
     try testing.expectEqualStrings("ENV", nodes[0].kind.identifier);
 
-    const body = nodes[1].kind.heredoc_literal;
+    // Non-interpolating body lowers to a single literal part (indent kept).
+    const body = nodes[1].kind.string_literal.parts[0].literal;
     try testing.expect(std.mem.indexOf(u8, body, "<<~") == null);
     try testing.expectEqualStrings("  body\n", body);
 }
@@ -1149,13 +1152,71 @@ test "parser: single-quoted string has no interpolation" {
     try testing.expectEqualStrings("hello #{name}", sl.parts[0].literal);
 }
 
-test "parser: heredoc body lowers to heredoc_literal" {
+test "parser: heredoc body without interpolation is one literal part" {
     var arena = testArena();
     defer arena.deinit();
 
+    // Body value stays raw here (indent preserved); T-002 de-indents it.
     const nodes = try parseSource(&arena, "<<~EOS\n  body\nEOS\n");
     try testing.expectEqual(@as(usize, 1), nodes.len);
-    try testing.expectEqualStrings("  body\n", nodes[0].kind.heredoc_literal);
+    const sl = nodes[0].kind.string_literal;
+    try testing.expectEqual(@as(usize, 1), sl.parts.len);
+    try testing.expectEqualStrings("  body\n", sl.parts[0].literal);
+}
+
+test "parser: heredoc body lowers #{...} to string_literal parts" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    // Heredoc bodies interpolate through the same string_literal path as
+    // double-quoted strings. Indent is preserved here — de-indent is a follow-up.
+    const nodes = try parseSource(&arena, "<<~EOS\n  pre #{x} post\nEOS\n");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+    const sl = nodes[0].kind.string_literal;
+    try testing.expectEqual(@as(usize, 3), sl.parts.len);
+    try testing.expectEqualStrings("  pre ", sl.parts[0].literal);
+    try testing.expectEqualStrings("x", sl.parts[1].interpolation.kind.identifier);
+    try testing.expectEqualStrings(" post\n", sl.parts[2].literal);
+}
+
+test "parser: heredoc interpolation splits across body lines" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    // Heredoc bodies span lines (unlike double-quoted strings), so a `#{}`
+    // sitting among other lines must split literals around it with the
+    // newlines preserved on both sides.
+    const nodes = try parseSource(&arena, "<<~EOS\nfirst\n#{x} mid\nlast\nEOS\n");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+    const sl = nodes[0].kind.string_literal;
+    try testing.expectEqual(@as(usize, 3), sl.parts.len);
+    try testing.expectEqualStrings("first\n", sl.parts[0].literal);
+    try testing.expectEqualStrings("x", sl.parts[1].interpolation.kind.identifier);
+    try testing.expectEqualStrings(" mid\nlast\n", sl.parts[2].literal);
+}
+
+test "parser: empty heredoc body is one empty literal part" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    const nodes = try parseSource(&arena, "<<~EOS\nEOS\n");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+    const sl = nodes[0].kind.string_literal;
+    try testing.expectEqual(@as(usize, 1), sl.parts.len);
+    try testing.expectEqualStrings("", sl.parts[0].literal);
+}
+
+test "parser: heredoc body with dangling #{ stays a literal, no panic" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    // Mirrors the double-quoted dangling-#{ fallback: an unmatched `#{`
+    // survives as literal text rather than a truncated slice or a panic.
+    const nodes = try parseSource(&arena, "<<~EOS\n#{x post\nEOS\n");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+    const sl = nodes[0].kind.string_literal;
+    try testing.expectEqual(@as(usize, 1), sl.parts.len);
+    try testing.expectEqualStrings("#{x post\n", sl.parts[0].literal);
 }
 
 test "parser: paren expression returns inner node verbatim" {
@@ -1219,7 +1280,6 @@ fn dumpNode(w: *std.Io.Writer, node: *const Node) !void {
         .nil_literal => {},
         .symbol_literal => |name| try w.print(" :{s}", .{name}),
         .identifier => |name| try w.print(" {s}", .{name}),
-        .heredoc_literal => |body| try w.print(" {d}b", .{body.len}),
         .string_literal => |sl| {
             try w.writeByte(' ');
             for (sl.parts) |p| switch (p) {


### PR DESCRIPTION
## Description

Heredoc bodies (`<<~EOS ... EOS`) returned `#{...}` verbatim, so the native interpreter wrote literal `#{var}` into config templates. They now lower through the same `string_literal` path as double-quoted strings, so interpolation resolves. Reuse inherits the interpolation robustness (dangling `#{`, inner parse failure, recursion budget) for free; the `heredoc_literal` node is removed.

De-indentation of squiggly heredocs is a follow-up - bodies keep their source indentation here.

## Related Issue

- None

## Notes for Reviewers

- The inner `#{...}` expression is now evaluated: an interpolation referencing an unsupported method logs `unknown_method` and routes to Ruby / partial-skip instead of silently emitting wrong text.