### PR TITLE
feat(dsl): de-indent squiggly heredoc bodies

### DIFF
--- a/src/core/dsl/parser.zig
+++ b/src/core/dsl/parser.zig
@@ -607,7 +607,11 @@ pub const Parser = struct {
     /// hardened dangling / parse-failure fallbacks. A future non-interpolating
     /// `<<~'EOS'` would bypass this and emit a single literal part instead.
     fn heredocNode(self: *Parser, body: []const u8, loc: SourceLoc) DslError!*const Node {
-        const parts = try self.parseStringInterpolation(body, loc);
+        // Every heredoc malt lexes is squiggly (`<<~`), so strip the common
+        // indent before interpolation — only literal line starts are touched,
+        // never a `#{...}` span, which never opens a line's whitespace.
+        const deindented = try deindentSquiggly(self.allocator, body);
+        const parts = try self.parseStringInterpolation(deindented, loc);
         return self.allocNode(.{
             .loc = loc,
             .kind = .{ .string_literal = .{ .parts = parts } },
@@ -1361,6 +1365,47 @@ fn parseIntValue(lexeme: []const u8) i64 {
     return std.fmt.parseInt(i64, lexeme, 10) catch 0;
 }
 
+/// Ruby `<<~` de-indent: remove the least common leading-whitespace column
+/// count — measured over non-blank lines, tabs and spaces each one column,
+/// no tab expansion — from the start of every physical line. Runs before
+/// `#{...}` lowering, so a single-line `#{...}` (opening on a non-whitespace
+/// `#`) is never touched. Scans physical lines: a multi-line `#{...}` could
+/// skew the min, but interpolation bodies are whitespace-insensitive Ruby, so
+/// the value is unaffected — track brace depth only if a formula ever needs it.
+fn deindentSquiggly(allocator: std.mem.Allocator, body: []const u8) std.mem.Allocator.Error![]const u8 {
+    // Least leading-whitespace width across non-blank lines; blank lines are
+    // excluded so they never force the indent to zero. No non-blank line → 0,
+    // so the min never underflows on empty or all-whitespace bodies.
+    var min_indent: usize = std.math.maxInt(usize);
+    var scan = std.mem.splitScalar(u8, body, '\n');
+    while (scan.next()) |line| {
+        const ws = leadingWs(line);
+        if (ws < line.len and ws < min_indent) min_indent = ws;
+    }
+    if (min_indent == std.math.maxInt(usize)) min_indent = 0;
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    var lines = std.mem.splitScalar(u8, body, '\n');
+    var first = true;
+    while (lines.next()) |line| {
+        if (!first) try out.append(allocator, '\n');
+        first = false;
+        const ws = leadingWs(line);
+        // A blank line drops all its whitespace; others lose the common indent.
+        const strip = if (ws == line.len) line.len else @min(min_indent, ws);
+        try out.appendSlice(allocator, line[strip..]);
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+/// Leading `' '`/`'\t'` count — each one column, no tab expansion (Ruby `<<~`).
+fn leadingWs(line: []const u8) usize {
+    var i: usize = 0;
+    while (i < line.len and (line[i] == ' ' or line[i] == '\t')) : (i += 1) {}
+    return i;
+}
+
 // Adversarial deeply-nested input must hit the depth cap and surface a
 // bounded `ParseError` with a diagnostic — never recurse into a native
 // stack overflow. Balanced parens so that, without the guard, the body
@@ -1385,6 +1430,63 @@ test "parser: explicit radix prefixes keep their meaning" {
     try std.testing.expectEqual(@as(i64, 0x1F), parseIntValue("0x1F"));
     try std.testing.expectEqual(@as(i64, 0o17), parseIntValue("0o17"));
     try std.testing.expectEqual(@as(i64, 0b101), parseIntValue("0b101"));
+}
+
+test "deindent: uniform indent is fully stripped" {
+    const out = try deindentSquiggly(std.testing.allocator, "  a\n  b\n");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("a\nb\n", out);
+}
+
+test "deindent: least-indented line wins" {
+    const out = try deindentSquiggly(std.testing.allocator, "    a\n  b\n");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("  a\nb\n", out);
+}
+
+test "deindent: an empty line is ignored in the minimum and stays empty" {
+    const out = try deindentSquiggly(std.testing.allocator, "  a\n\n  b\n");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("a\n\nb\n", out);
+}
+
+test "deindent: an all-whitespace line does not pull the minimum to zero" {
+    // The 4-space line is excluded from the minimum (min stays 2) and, even
+    // though it has MORE whitespace than the minimum, all of it is dropped so
+    // the line is emitted empty — the task contract, not Ruby's keep-the-excess.
+    const out = try deindentSquiggly(std.testing.allocator, "  a\n    \n  b\n");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("a\n\nb\n", out);
+}
+
+test "deindent: relative indentation of nested lines is preserved" {
+    // The whole point for whitespace-significant formats: only the common
+    // indent is removed, so a nested line keeps its extra columns and the
+    // written YAML / Makefile stays structurally valid.
+    const out = try deindentSquiggly(std.testing.allocator, "  server:\n    host: localhost\n  port: 8080\n");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("server:\n  host: localhost\nport: 8080\n", out);
+}
+
+test "deindent: a tab and a space each count as one column" {
+    // Ruby does not expand tabs — the `\t` line has indent width 1, so the
+    // minimum is 1 and exactly one leading column is removed from every line.
+    const out = try deindentSquiggly(std.testing.allocator, "\ta\n  b\n");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("a\n b\n", out);
+}
+
+test "deindent: adversarial bodies never panic" {
+    inline for (.{
+        .{ "", "" },
+        .{ "\n", "\n" },
+        .{ "   ", "" }, // single all-whitespace line, no newline
+        .{ "  a", "a" }, // no trailing newline
+    }) |case| {
+        const out = try deindentSquiggly(std.testing.allocator, case[0]);
+        defer std.testing.allocator.free(out);
+        try std.testing.expectEqualStrings(case[1], out);
+    }
 }
 
 test "parser: expression nesting beyond the depth limit is a bounded ParseError" {

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -230,7 +230,8 @@ test "interpreter: heredoc body interpolates via evalStringLiteral" {
     const prefix = scratch.path;
 
     // A `#{x}` inside a heredoc body must resolve the bound local, matching
-    // the double-quoted path. Indent is preserved (de-indent is a follow-up).
+    // the double-quoted path, and the squiggly indent is stripped before the
+    // file is written — so config templates come out correctly de-indented.
     const src =
         "x = \"world\"\n" ++
         "greeting = <<~EOS\n  hello #{x}\nEOS\n" ++
@@ -248,7 +249,9 @@ test "interpreter: heredoc body interpolates via evalStringLiteral" {
     defer file.close(std.Options.debug_io);
     var buf: [64]u8 = undefined;
     const n = try file.readPositionalAll(std.Options.debug_io, &buf, 0);
-    try testing.expectEqualStrings("  hello world\n", buf[0..n]);
+    // The old "  hello world\n" expectation encoded the de-indent bug — do
+    // not restore it.
+    try testing.expectEqualStrings("hello world\n", buf[0..n]);
 }
 
 test "interpreter: system true succeeds" {
@@ -3172,4 +3175,94 @@ test "executePostInstall: all-unhandled body leaves dslDidWork false" {
     try testing.expectEqual(@as(usize, 2), flog.total_top_level);
     try testing.expectEqual(@as(usize, 0), flog.handled_top_level);
     try testing.expect(!flog.dslDidWork());
+}
+
+// ---------------------------------------------------------------------------
+// Native vs system-Ruby byte-parity
+//
+// De-indenting `<<~` bodies exists to match Ruby's own output. This drives the
+// native interpreter and real `ruby` over the same heredoc source and asserts
+// the written files are byte-identical. The corpus is space-indented formula
+// shapes where the two must agree; the deliberate task-vs-Ruby divergences
+// (tab counting, over-indented blank lines) are pinned by unit tests, not here.
+// Skips rather than fails when `ruby` is not on PATH (e.g. a minimal CI image).
+// ---------------------------------------------------------------------------
+
+fn readSmallFile(path: []const u8) ![]u8 {
+    var file = try test_io.openFileAbsolute(std.Options.debug_io, path, .{});
+    defer file.close(std.Options.debug_io);
+    var buf: [4096]u8 = undefined;
+    const n = try file.readPositionalAll(std.Options.debug_io, &buf, 0);
+    return testing.allocator.dupe(u8, buf[0..n]);
+}
+
+/// Run `ruby -e prog` (the program writes its own output file). Returns
+/// `error.SkipZigTest` when `ruby` is absent, `error.RubyFailed` on non-zero.
+fn runRuby(alloc: std.mem.Allocator, prog: []const u8) !void {
+    const environ = malt.app_ctx.processEnviron();
+    var threaded: std.Io.Threaded = .init(alloc, .{ .environ = environ });
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const argv = [_][]const u8{ "ruby", "-e", prog };
+    var child = std.process.spawn(io, .{ .argv = &argv }) catch return error.SkipZigTest;
+    const term = child.wait(io) catch return error.RubyFailed;
+    switch (term) {
+        .exited => |code| if (code != 0) return error.RubyFailed,
+        else => return error.RubyFailed,
+    }
+}
+
+test "interpreter: <<~ output is byte-identical to system Ruby" {
+    // Probe once so a ruby-less environment skips before doing any work.
+    {
+        var probe = testArena();
+        defer probe.deinit();
+        try runRuby(probe.allocator(), "");
+    }
+
+    const cases = [_]struct { name: []const u8, body: []const u8 }{
+        .{ .name = "uniform indent + interpolation", .body = "  hello #{x}\n" },
+        .{ .name = "nested structure preserved", .body = "  server:\n    host: localhost\n  port: 8080\n" },
+        .{ .name = "blank line stays empty", .body = "  first\n\n  second\n" },
+        .{ .name = "interpolation on multiple lines", .body = "  key = #{x}\n  n = 42\n" },
+    };
+
+    for (cases) |c| {
+        var arena = testArena();
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        var scratch = try makeTempPrefix();
+        defer scratch.deinit();
+        const prefix = scratch.path;
+
+        // Native: evaluate the heredoc and write it under the prefix.
+        const native_src = try std.fmt.allocPrint(
+            a,
+            "x = \"world\"\ngreeting = <<~EOS\n{s}EOS\n(etc/\"out.conf\").write greeting\n",
+            .{c.body},
+        );
+        try testing.expect((try runSnippet(&arena, native_src, prefix)) == null);
+        const native_path = try std.fs.path.join(a, &.{ prefix, "etc", "out.conf" });
+
+        // Reference: real Ruby writes the same heredoc source to a sibling file.
+        const ruby_path = try std.fs.path.join(a, &.{ prefix, "out.ruby" });
+        const ruby_prog = try std.fmt.allocPrint(
+            a,
+            "x = \"world\"\nFile.write(\"{s}\", <<~EOS)\n{s}EOS\n",
+            .{ ruby_path, c.body },
+        );
+        try runRuby(a, ruby_prog);
+
+        const native_out = try readSmallFile(native_path);
+        defer testing.allocator.free(native_out);
+        const ruby_out = try readSmallFile(ruby_path);
+        defer testing.allocator.free(ruby_out);
+
+        testing.expectEqualStrings(ruby_out, native_out) catch |e| {
+            std.debug.print("byte-parity mismatch in case '{s}'\n", .{c.name});
+            return e;
+        };
+    }
 }

--- a/tests/dsl_parser_test.zig
+++ b/tests/dsl_parser_test.zig
@@ -743,10 +743,11 @@ test "parser: Dir peek preserves heredoc lexer state" {
     try testing.expectEqual(@as(usize, 2), nodes.len);
     try testing.expectEqualStrings("Dir", nodes[0].kind.identifier);
 
-    // Non-interpolating body lowers to a single literal part (indent kept).
+    // Body lowers to one literal part with the squiggly indent stripped. The
+    // old "  body\n" expectation encoded the de-indent bug — do not restore it.
     const body = nodes[1].kind.string_literal.parts[0].literal;
     try testing.expect(std.mem.indexOf(u8, body, "<<~") == null);
-    try testing.expectEqualStrings("  body\n", body);
+    try testing.expectEqualStrings("body\n", body);
 }
 
 test "parser: Formula peek preserves heredoc lexer state" {
@@ -760,10 +761,11 @@ test "parser: Formula peek preserves heredoc lexer state" {
     try testing.expectEqual(@as(usize, 2), nodes.len);
     try testing.expectEqualStrings("Formula", nodes[0].kind.identifier);
 
-    // Non-interpolating body lowers to a single literal part (indent kept).
+    // Body lowers to one literal part with the squiggly indent stripped. The
+    // old "  body\n" expectation encoded the de-indent bug — do not restore it.
     const body = nodes[1].kind.string_literal.parts[0].literal;
     try testing.expect(std.mem.indexOf(u8, body, "<<~") == null);
-    try testing.expectEqualStrings("  body\n", body);
+    try testing.expectEqualStrings("body\n", body);
 }
 
 test "parser: ENV peek preserves heredoc lexer state" {
@@ -777,10 +779,11 @@ test "parser: ENV peek preserves heredoc lexer state" {
     try testing.expectEqual(@as(usize, 2), nodes.len);
     try testing.expectEqualStrings("ENV", nodes[0].kind.identifier);
 
-    // Non-interpolating body lowers to a single literal part (indent kept).
+    // Body lowers to one literal part with the squiggly indent stripped. The
+    // old "  body\n" expectation encoded the de-indent bug — do not restore it.
     const body = nodes[1].kind.string_literal.parts[0].literal;
     try testing.expect(std.mem.indexOf(u8, body, "<<~") == null);
-    try testing.expectEqualStrings("  body\n", body);
+    try testing.expectEqualStrings("body\n", body);
 }
 
 test "parser: ENV read" {
@@ -1156,12 +1159,13 @@ test "parser: heredoc body without interpolation is one literal part" {
     var arena = testArena();
     defer arena.deinit();
 
-    // Body value stays raw here (indent preserved); T-002 de-indents it.
+    // Squiggly de-indent strips the common indent. The old "  body\n"
+    // expectation encoded the de-indent bug — do not restore it.
     const nodes = try parseSource(&arena, "<<~EOS\n  body\nEOS\n");
     try testing.expectEqual(@as(usize, 1), nodes.len);
     const sl = nodes[0].kind.string_literal;
     try testing.expectEqual(@as(usize, 1), sl.parts.len);
-    try testing.expectEqualStrings("  body\n", sl.parts[0].literal);
+    try testing.expectEqualStrings("body\n", sl.parts[0].literal);
 }
 
 test "parser: heredoc body lowers #{...} to string_literal parts" {
@@ -1169,12 +1173,14 @@ test "parser: heredoc body lowers #{...} to string_literal parts" {
     defer arena.deinit();
 
     // Heredoc bodies interpolate through the same string_literal path as
-    // double-quoted strings. Indent is preserved here — de-indent is a follow-up.
+    // double-quoted strings. De-indent runs first, so the leading "  " is
+    // stripped from the literal line start while the `#{x}` span is untouched.
+    // The old "  pre " expectation encoded the de-indent bug — do not restore it.
     const nodes = try parseSource(&arena, "<<~EOS\n  pre #{x} post\nEOS\n");
     try testing.expectEqual(@as(usize, 1), nodes.len);
     const sl = nodes[0].kind.string_literal;
     try testing.expectEqual(@as(usize, 3), sl.parts.len);
-    try testing.expectEqualStrings("  pre ", sl.parts[0].literal);
+    try testing.expectEqualStrings("pre ", sl.parts[0].literal);
     try testing.expectEqualStrings("x", sl.parts[1].interpolation.kind.identifier);
     try testing.expectEqualStrings(" post\n", sl.parts[2].literal);
 }
@@ -1193,6 +1199,36 @@ test "parser: heredoc interpolation splits across body lines" {
     try testing.expectEqualStrings("first\n", sl.parts[0].literal);
     try testing.expectEqualStrings("x", sl.parts[1].interpolation.kind.identifier);
     try testing.expectEqualStrings(" mid\nlast\n", sl.parts[2].literal);
+}
+
+test "parser: de-indent strips the line start but never the interpolation span" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    // Both lines share a two-space indent, and one opens with `#{cfg}` right
+    // after that indent. De-indent runs before interpolation, so it removes the
+    // two literal columns at the line start but leaves the `#{cfg}` expression
+    // byte-for-byte — the interpolation is the first part, not a "  " literal.
+    const nodes = try parseSource(&arena, "<<~EOS\n  #{cfg} = 1\n  key = 2\nEOS\n");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+    const sl = nodes[0].kind.string_literal;
+    try testing.expectEqual(@as(usize, 2), sl.parts.len);
+    try testing.expectEqualStrings("cfg", sl.parts[0].interpolation.kind.identifier);
+    try testing.expectEqualStrings(" = 1\nkey = 2\n", sl.parts[1].literal);
+}
+
+test "parser: an indented <<~ terminator terminates and its indent never leaks" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    // Ruby lets the `<<~` terminator be indented to match surrounding code.
+    // The terminator line is excluded from the body, so its indentation cannot
+    // leak into the value, and the body keeps only its own de-indented content.
+    const nodes = try parseSource(&arena, "<<~EOS\n    key = value\n  EOS\n");
+    try testing.expectEqual(@as(usize, 1), nodes.len);
+    const sl = nodes[0].kind.string_literal;
+    try testing.expectEqual(@as(usize, 1), sl.parts.len);
+    try testing.expectEqualStrings("key = value\n", sl.parts[0].literal);
 }
 
 test "parser: empty heredoc body is one empty literal part" {


### PR DESCRIPTION
## Description

Squiggly heredocs (`<<~EOS`) now strip common leading indentation the way Ruby does, so config templates written from a heredoc come out correctly indented instead of leaking their source whitespace - which produced wrong output for whitespace-significant files (YAML, Makefiles) and pushed the formula back to the system-Ruby fallback.

De-indent runs before interpolation (so `#{...}` spans are untouched); the minimum is measured over non-blank lines only, tabs and spaces each count as one column.

## Related Issue

- None

## Notes for Reviewers

- A native-vs-system-Ruby byte-parity test (`interpreter: <<~ output is byte-identical to system Ruby`) drives the interpreter and real `ruby` over the same heredoc source and diffs the written files. Verified byte-identical against Ruby 2.6.10 and 4.0.6 (`<<~` semantics unchanged across those versions); it skips cleanly when `ruby` is off PATH.
- Two deliberate simplifications sit outside the corpus, pinned by unit tests: tabs count as one column (Ruby expands them) and all-whitespace lines are emitted empty (Ruby keeps the excess). Neither affects space-indented formula bodies - content tabs (e.g. a Makefile recipe) are preserved identically by both.