### PR TITLE
refactor(outdated): follow the fetch for the dry-run snapshot and unify the currency compare

### DIFF
--- a/scripts/regressions/dry-run-snapshot-follows-fetch-collapse-compare-sites-onto-index.sh
+++ b/scripts/regressions/dry-run-snapshot-follows-fetch-collapse-compare-sites-onto-index.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Regression: the persisted `outdated.json` a full `mt upgrade --dry-run` writes
+# must follow the per-package fetch, not the bulk index. When the two skew for a
+# `needs_upgrade` row (index says behind, the fetch says current, or the two name
+# different targets), the snapshot must record the fetch's verdict, the same one
+# the install decision, the printed line, and the NDJSON event already use.
+#
+# Hermetic, no network: the audit reads the on-disk versions index
+# ({prefix}/cache/api/versions_<kind>.txt) while phase 2 reads the per-package
+# document ({prefix}/cache/api/formula_<name>.json). Seeding the two with
+# disagreeing versions reproduces the skew deterministically.
+#
+# Pins two contracts on the warmed snapshot:
+#   1. A row the fetch reports current is absent from the snapshot, even when the
+#      index lists it behind (pre-fix: the index target leaked in).
+#   2. A row both agree is behind is recorded at the fetch's target, not the
+#      index's, when the two differ.
+#
+# Usage: scripts/regressions/dry-run-snapshot-follows-fetch-collapse-compare-sites-onto-index.sh
+# Requirements: built malt at $MALT_BIN or zig-out/bin/malt; sqlite3 on PATH.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+
+PREFIX=$(mktemp -d -t malt_snap_follows_fetch.XXXXXX)
+trap 'rm -rf "$PREFIX"' EXIT
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+unset MALT_OFFLINE MALT_OUTDATED_MAX_AGE MALT_CACHE CI
+
+DB="$PREFIX/db/malt.db"
+SNAP="$PREFIX/cache/outdated.json"
+API="$PREFIX/cache/api"
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+mkdir -p "$PREFIX/db" "$API"
+"$BIN" list >/dev/null 2>&1 || true
+sqlite3 "$DB" "DELETE FROM kegs; DELETE FROM casks;" 2>/dev/null || true
+rm -f "$SNAP"
+
+seed_keg() {
+  local name="$1" version="$2"
+  sqlite3 "$DB" "INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+    VALUES ('$name', '$name', '$version', 0, 'seedsha', '/tmp/c/$name/$version');"
+}
+
+# Fake upstream, per-package fetch (phase 2 reads this).
+seed_formula_cache() {
+  local name="$1" stable="$2"
+  printf '{"name":"%s","versions":{"stable":"%s"},"revision":0}' "$name" "$stable" \
+    >"$API/formula_$name.json"
+}
+
+# Two installed core formulas, both at 1.0.
+seed_keg current_row 1.0
+seed_keg behind_row 1.0
+
+# Bulk index (the audit's needs_upgrade source): both look behind.
+printf 'current_row\t2.0\t0\nbehind_row\t4.0\t0\n' >"$API/versions_formula.txt"
+
+# Per-package fetch (the authoritative install decision):
+#   current_row -> 1.0  (agrees with installed: nothing to do)
+#   behind_row  -> 3.0  (behind, but at a target the index does not name)
+seed_formula_cache current_row 1.0
+seed_formula_cache behind_row 3.0
+
+"$BIN" upgrade --dry-run >/dev/null 2>&1 || true
+[[ -f "$SNAP" ]] || fail "full dry-run wrote no outdated.json"
+
+# Contract 1: the fetch says current_row is current, so it must not appear.
+if grep -q '"name":"current_row"' "$SNAP"; then
+  fail "snapshot advertises current_row, which the fetch reports current; got: $(cat "$SNAP")"
+fi
+pass "a fetch-current row is absent from the warmed snapshot"
+
+# Contract 2: behind_row is recorded at the fetch's 3.0, not the index's 4.0.
+grep -q '"name":"behind_row","installed":"1.0","latest":"3.0"' "$SNAP" ||
+  fail "behind_row not recorded at the fetch target 3.0; got: $(cat "$SNAP")"
+if grep -q '"latest":"4.0"' "$SNAP"; then
+  fail "snapshot carries the stale index target 4.0; got: $(cat "$SNAP")"
+fi
+pass "a behind row is recorded at the fetch target, not the index target"
+
+printf '\n\xe2\x9c\x94 dry-run snapshot follows the fetch regression passed\n'

--- a/src/cli/outdated.zig
+++ b/src/cli/outdated.zig
@@ -37,6 +37,16 @@ pub const loadCaskRows = rows_mod.loadCaskRows;
 pub const freeKegRows = rows_mod.freeKegRows;
 pub const tapExists = rows_mod.tapExists;
 const snap_mod = @import("outdated/snapshot.zig");
+
+// The dry-run snapshot is written from the per-package fetch, whose TTL matches
+// the bulk versions index. If the index could outlive the snapshot's freshness
+// window, `mt outdated` could serve a target the always-live `mt upgrade` has
+// already moved past. This module sees both constants, so enforce it here rather
+// than forcing a `net -> cli` import inversion from api.zig.
+comptime {
+    std.debug.assert(api_mod.versions_ttl_secs <= @as(i64, @intCast(snap_mod.snapshot_default_max_age_minutes)) * 60);
+}
+
 pub const snapshot_default_max_age_minutes = snap_mod.snapshot_default_max_age_minutes;
 pub const snapshot_max_age_env = snap_mod.snapshot_max_age_env;
 pub const snapshot_version = snap_mod.snapshot_version;

--- a/src/cli/outdated/refresh.zig
+++ b/src/cli/outdated/refresh.zig
@@ -190,19 +190,20 @@ fn isCorePathRow(row: KegRow) bool {
     return if (row.tap) |t| install_args_mod.isCoreTap(t) else true;
 }
 
-// Outdated policy — the single normative statement; every other compare site
-// points here rather than restating it. malt treats the tap as the source of
-// truth. A keg is "outdated" whenever its revision-qualified installed version
-// is not byte-equal to the current upstream version — NOT when it is strictly
-// older (casks have no revision, so theirs is bare). This never
-// misses an upgrade (any difference surfaces); the trade-off is that the tap is
+// Outdated policy — the normative statement. malt treats the tap as the source
+// of truth. A keg is "outdated" whenever its revision-qualified installed
+// version is not byte-equal to the current upstream version — NOT when it is
+// strictly older (casks have no revision, so theirs is bare). This never misses
+// an upgrade (any difference surfaces); the trade-off is that the tap is
 // followed in both directions, so if upstream moves backward (a yanked release)
 // `outdated` lists it and `upgrade` follows the tap down. That downgrade is by
 // design and no longer silent: `outdated` marks the row and `upgrade` warns
-// before proceeding - reported, never blocked. Which way a move points is the
-// comparator's call, not restated here. Matching Homebrew's `PkgVersion`
-// ordering instead would risk a
-// divergent comparator silently skipping a real upgrade — a worse failure mode.
+// before proceeding - reported, never blocked. Matching Homebrew's `PkgVersion`
+// ordering instead would risk a divergent comparator silently skipping a real
+// upgrade — a worse failure mode.
+//
+// The compare itself lives in one place, `core/formula.isCurrent`; every site
+// here and in `cli/upgrade` calls it rather than restating the byte-compare.
 
 /// What the audit could prove about one row. `proven_current` is the only
 /// answer that lets a caller skip work, so it is mintable on exactly one
@@ -249,13 +250,14 @@ fn mapDisposition(
     const entry = map.get(row.name) orelse return .unknown;
 
     var latest_buf: [256]u8 = undefined;
-    var installed_buf: [256]u8 = undefined;
-    // pkgVersion only fails on buffer overflow. Unproven, so `unknown`:
+    // pkgVersion only fails on buffer overflow. Unproven maps to `unknown`:
     // reading it as current would skip a real upgrade.
     const latest = formula_mod.pkgVersion(&latest_buf, entry.stable, entry.revision) catch return .unknown;
-    const installed = formula_mod.pkgVersion(&installed_buf, row.version, row.revision) catch return .unknown;
-    if (std.mem.eql(u8, installed, latest)) return .proven_current;
-    return .{ .needs_upgrade = try allocator.dupe(u8, latest) };
+    return switch (formula_mod.isCurrent(row.version, row.revision, latest)) {
+        .unprovable => .unknown,
+        .current => .proven_current,
+        .differs => .{ .needs_upgrade = try allocator.dupe(u8, latest) },
+    };
 }
 
 /// Warn that the bulk version map matched none of the installed core
@@ -1013,13 +1015,11 @@ fn fetchLatest(
     row: KegRow,
 ) std.mem.Allocator.Error!?[]u8 {
     const v = upstreamLatest(allocator, head_cache, db, api, io, environ, kind, row) orelse return null;
-    // Compare the revision-qualified installed string against the (now also
-    // revision-qualified) upstream so a revision-only bump isn't read as bare.
-    // `!eql` is deliberate: malt mirrors the tap as source of truth — see the
-    // outdated-policy note above `Disposition`.
-    var installed_buf: [256]u8 = undefined;
-    const installed = formula_mod.pkgVersion(&installed_buf, row.version, row.revision) catch row.version;
-    if (std.mem.eql(u8, installed, v)) {
+    // The shared currency policy qualifies the installed side and compares it to
+    // the (already revision-qualified) upstream. Anything but a proven match is
+    // outdated: malt mirrors the tap as source of truth — see the outdated-policy
+    // note above `Disposition`.
+    if (formula_mod.isCurrent(row.version, row.revision, v) == .current) {
         allocator.free(v);
         return null;
     }
@@ -1117,11 +1117,9 @@ fn runOne(out_alloc: std.mem.Allocator, wctx: *WorkerCtx) void {
     local_api.base_url = wctx.api_base;
     local_api.offline = wctx.offline;
     const latest = upstreamLatest(arena_alloc, wctx.head_cache, wctx.db, &local_api, wctx.io, wctx.environ, wctx.kind, wctx.row) orelse return;
-    // Qualify the installed side so a revision-only bump isn't read as bare
-    // (same fix as the serial `fetchLatest` path).
-    var installed_buf: [256]u8 = undefined;
-    const installed = formula_mod.pkgVersion(&installed_buf, wctx.row.version, wctx.row.revision) catch wctx.row.version;
-    if (std.mem.eql(u8, installed, latest)) return;
+    // Same shared currency policy as the serial `fetchLatest` path: qualify the
+    // installed side so a revision-only bump isn't read as bare.
+    if (formula_mod.isCurrent(wctx.row.version, wctx.row.revision, latest) == .current) return;
 
     // Move into the caller's allocator so the result outlives `arena.deinit()`.
     wctx.out = out_alloc.dupe(u8, latest) catch |e| blk: {

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -1306,13 +1306,12 @@ fn upgradeAllFormulas(
             tally.fold(.up_to_date);
             continue;
         }
-        // The audit already resolved `needs_upgrade` rows, so warm them from
-        // the plan rather than having phase 2 fetch the same version again;
-        // phase 2 runs with no sink for those so the row is not collected
-        // twice. `unknown` rows carry no plan latest and still collect below.
-        if (sink) |s| if (d == .needs_upgrade and !pinnedHolds(row, force, pinned_only)) s.collectFormula(row.name, row.version, row.revision, d.needs_upgrade);
-        const phase2_sink: ?*EntrySink = if (d == .needs_upgrade) null else sink;
-        if (upgradeFormula(ctx, allocator, row.name, db, api, http, prefix, dry_run, force, pinned_only, isolate_deps, use_system_ruby, true, phase2_sink)) |o| {
+        // `upgradeFormula` fetches every `needs_upgrade` row anyway (it needs the
+        // full formula for the bottle), so let its own dry-run collect, keyed on
+        // the fetched version, be the sole snapshot writer. Pre-seeding from the
+        // index bought no fetch and only leaked the index target when the two
+        // caches skewed inside their shared TTL.
+        if (upgradeFormula(ctx, allocator, row.name, db, api, http, prefix, dry_run, force, pinned_only, isolate_deps, use_system_ruby, true, sink)) |o| {
             tally.fold(o);
         } else |_| {
             failed_count += 1;
@@ -1503,12 +1502,11 @@ fn upgradeAllCasks(ctx: *const AppCtx, allocator: std.mem.Allocator, db: *sqlite
             tally.fold(.up_to_date);
             continue;
         }
-        // Warm a plan-resolved cask from the audit; casks carry no revision,
-        // so the recorded version is the entry's `installed` as-is. Phase 2
-        // runs with no sink for those rows so the cask is not collected twice.
-        if (sink) |s| if (d == .needs_upgrade and !pinnedHolds(row, force, pinned_only)) s.collectCask(row.name, row.version, d.needs_upgrade);
-        const phase2_sink: ?*EntrySink = if (d == .needs_upgrade) null else sink;
-        if (upgradeCask(ctx, allocator, row.name, db, api, prefix, dry_run, force, pinned_only, true, phase2_sink)) |o| {
+        // Symmetric with the formula walk: `upgradeCask` fetches the cask
+        // document to install it, so its own dry-run collect (keyed on the
+        // fetched version) is the sole snapshot writer, with no index pre-seed
+        // to skew.
+        if (upgradeCask(ctx, allocator, row.name, db, api, prefix, dry_run, force, pinned_only, true, sink)) |o| {
             tally.fold(o);
         } else |_| {
             failed_count += 1;
@@ -2181,12 +2179,12 @@ fn writeTestCaskCache(cache_dir: []const u8, token: []const u8, version: []const
     try f.writeStreamingAll(io, body);
 }
 
-test "the warmed formula set merges plan and phase-2 rows, each once, freed once" {
-    // The merge, entire: a `needs_upgrade` row (warmed from the plan), an
-    // `unknown` row the index never listed (warmed by phase 2's fetch), and a
-    // `proven_current` row (excluded, current). The result must be exactly the
-    // two would-upgrade rows — the plan row appearing once, not doubled by a
-    // second phase-2 collect — and the test allocator proves it all frees once.
+test "the warmed formula set collects each fetched row once, freed once" {
+    // The per-package fetch is the sole snapshot writer: a `needs_upgrade` row
+    // and an `unknown` row the index never listed both land from the fetch,
+    // while a `proven_current` row is excluded before the fetch runs. The result
+    // must be exactly the two would-upgrade rows, each once, and the test
+    // allocator proves it all frees once.
     const alloc = std.testing.allocator;
     const ctx = @import("../app_ctx.zig").debug_ctx;
 
@@ -2205,7 +2203,7 @@ test "the warmed formula set merges plan and phase-2 rows, each once, freed once
     const cache_dir = s.base;
     // Index lists `cur` (current) and `up` (behind); `miss` is absent.
     try writeTestVersionsIndex(cache_dir, .formula, "cur\t5.0\t0\nup\t2.0\t0\n");
-    // Phase 2 fetches only rows the plan could not exclude: `miss` and `up`.
+    // The fetch runs for every non-current row: `miss` and `up`.
     try writeTestFormulaCache(cache_dir, "miss", "3.0");
     try writeTestFormulaCache(cache_dir, "up", "2.0");
 
@@ -2224,8 +2222,8 @@ test "the warmed formula set merges plan and phase-2 rows, each once, freed once
     var tally: Tally = .{};
     try upgradeAllFormulas(&ctx, alloc, &db, &api, &http, "/opt/malt", true, false, false, false, &.{}, plan, &tally, &sink);
 
-    // Exactly the two would-upgrade rows: `miss` (phase 2) then `up` (plan),
-    // in row order, with `up` present once. `cur` contributes nothing.
+    // Exactly the two would-upgrade rows: `miss` then `up`, in row order, each
+    // present once from the fetch. `cur` contributes nothing.
     try std.testing.expectEqual(@as(usize, 2), sink.formulas.items.len);
     try std.testing.expectEqualStrings("miss", sink.formulas.items[0].name);
     try std.testing.expectEqualStrings("3.0", sink.formulas.items[0].latest);
@@ -2236,11 +2234,10 @@ test "the warmed formula set merges plan and phase-2 rows, each once, freed once
     try std.testing.expectEqual(@as(usize, 2), tally.would_upgrade); // miss + up
 }
 
-test "the warmed cask set merges plan and phase-2 rows, each once, freed once" {
-    // The cask walker is separate code from the formula one, so its half of
-    // the merge is proven independently: `up` (plan-resolved) must appear once,
-    // not doubled by phase 2's own collect; `miss` (index-absent) is warmed by
-    // phase 2's fetch; `cur` (proven current) contributes nothing.
+test "the warmed cask set collects each fetched row once, freed once" {
+    // The cask walker is separate code from the formula one, so its half is
+    // proven independently: `up` (index-behind) and `miss` (index-absent) both
+    // land once from the fetch; `cur` (proven current) contributes nothing.
     const alloc = std.testing.allocator;
     const ctx = @import("../app_ctx.zig").debug_ctx;
 
@@ -2505,83 +2502,6 @@ test "a row missing from the index is still handed to phase 2, never skipped" {
     try std.testing.expectEqual(@as(usize, 2), tally.checked());
 }
 
-test "a needs_upgrade formula is warmed from the plan, not phase 2's fetch" {
-    // The merge's formula half: the audit already resolved `latest`, so the
-    // warm takes it from the plan without waiting on phase 2. Proven by going
-    // offline — phase 2 fails to fetch, yet the entry still lands. The strings
-    // come from the plan and the row, so no network can supply them.
-    const alloc = std.testing.allocator;
-    const ctx = @import("../app_ctx.zig").debug_ctx;
-
-    var db = try sqlite.Database.open(":memory:");
-    defer db.close();
-    try schema.initSchema(&db);
-    try db.exec("INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path) VALUES ('behind', 'behind', '1.0', 'sha', '/cellar/behind/1.0');");
-
-    var s = try Scratch.init("warm_formula_from_plan");
-    defer s.deinit();
-    const cache_dir = s.base;
-    try writeTestVersionsIndex(cache_dir, .formula, "behind\t2.0\t0\n");
-
-    var http = client_mod.HttpClient.init(ctx.io, ctx.environ, alloc);
-    defer http.deinit();
-    http.offline = true; // phase 2's fetch fails; the plan still warms the row
-    var api = api_mod.BrewApi.init(ctx.io, alloc, &http, cache_dir);
-
-    var plan = try audit_mod.audit(alloc, &db, &api, .formula, .{});
-    defer plan.deinit(alloc);
-    try std.testing.expectEqualStrings("2.0", plan.dispositions[0].needs_upgrade);
-
-    var sink = EntrySink.init(alloc);
-    defer sink.deinit();
-    var tally: Tally = .{};
-    upgradeAllFormulas(&ctx, alloc, &db, &api, &http, "/opt/malt", true, false, false, false, &.{}, plan, &tally, &sink) catch {};
-
-    try std.testing.expectEqual(@as(usize, 1), sink.formulas.items.len);
-    try std.testing.expectEqualStrings("behind", sink.formulas.items[0].name);
-    try std.testing.expectEqualStrings("1.0", sink.formulas.items[0].installed);
-    try std.testing.expectEqualStrings("2.0", sink.formulas.items[0].latest);
-    try std.testing.expect(!sink.tainted);
-}
-
-test "a needs_upgrade cask is warmed from the plan, not phase 2's fetch" {
-    // The merge's cask half, symmetric with the formula case above: a NULL-tap
-    // cask the index proves behind is warmed from the plan even though the
-    // offline fetch below cannot reach its cask document.
-    const alloc = std.testing.allocator;
-    const ctx = @import("../app_ctx.zig").debug_ctx;
-
-    var db = try sqlite.Database.open(":memory:");
-    defer db.close();
-    try schema.initSchema(&db);
-    try db.exec("INSERT INTO casks (token, name, version, url) VALUES ('vlc', 'vlc', '1.0', 'https://example/vlc');");
-
-    var s = try Scratch.init("warm_cask_from_plan");
-    defer s.deinit();
-    const cache_dir = s.base;
-    try writeTestVersionsIndex(cache_dir, .cask, "vlc\t2.0\t0\n");
-
-    var http = client_mod.HttpClient.init(ctx.io, ctx.environ, alloc);
-    defer http.deinit();
-    http.offline = true;
-    var api = api_mod.BrewApi.init(ctx.io, alloc, &http, cache_dir);
-
-    var plan = try audit_mod.audit(alloc, &db, &api, .cask, .{});
-    defer plan.deinit(alloc);
-    try std.testing.expectEqualStrings("2.0", plan.dispositions[0].needs_upgrade);
-
-    var sink = EntrySink.init(alloc);
-    defer sink.deinit();
-    var tally: Tally = .{};
-    upgradeAllCasks(&ctx, alloc, &db, &api, "/opt/malt", true, false, false, plan, &tally, &sink) catch {};
-
-    try std.testing.expectEqual(@as(usize, 1), sink.casks.items.len);
-    try std.testing.expectEqualStrings("vlc", sink.casks.items[0].name);
-    try std.testing.expectEqualStrings("1.0", sink.casks.items[0].installed);
-    try std.testing.expectEqualStrings("2.0", sink.casks.items[0].latest);
-    try std.testing.expect(!sink.tainted);
-}
-
 test "a pinned needs_upgrade row stays out of the warm, as phase 2's pinSkip would keep it" {
     // A held-but-outdated row reports `.pinned` in phase 2 and never collects,
     // so the plan warm must skip it too or the snapshot would gain a row the
@@ -2615,4 +2535,101 @@ test "a pinned needs_upgrade row stays out of the warm, as phase 2's pinSkip wou
 
     try std.testing.expectEqual(@as(usize, 0), sink.formulas.items.len);
     try std.testing.expectEqual(@as(usize, 1), tally.pinned);
+}
+
+test "the dry-run snapshot follows the fetch, not the index, when the two skew" {
+    // The index and the per-package fetch can disagree for a `needs_upgrade` row
+    // inside the shared TTL. The persisted snapshot must record the fetch's
+    // verdict (the one the install actually follows), not the stale index
+    // target. `now_current` reads current from its fetch (dropped from the
+    // snapshot); `still_behind` reads a fetch target that differs from the index
+    // (collected at the fetch's value, not the index's).
+    const alloc = std.testing.allocator;
+    const ctx = @import("../app_ctx.zig").debug_ctx;
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path) VALUES
+        \\  ('now_current', 'now_current', '1.0', 'sha', '/cellar/now_current/1.0'),
+        \\  ('still_behind', 'still_behind', '1.0', 'sha', '/cellar/still_behind/1.0');
+    );
+
+    var s = try Scratch.init("snapshot_follows_fetch");
+    defer s.deinit();
+    const cache_dir = s.base;
+    // Index: both look behind, and `still_behind`'s target (4.0) is not the one
+    // the fetch will resolve.
+    try writeTestVersionsIndex(cache_dir, .formula, "now_current\t2.0\t0\nstill_behind\t4.0\t0\n");
+    // Fetch: `now_current` is actually current; `still_behind` is behind at 3.0.
+    try writeTestFormulaCache(cache_dir, "now_current", "1.0");
+    try writeTestFormulaCache(cache_dir, "still_behind", "3.0");
+
+    var http = client_mod.HttpClient.init(ctx.io, ctx.environ, alloc);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(ctx.io, alloc, &http, cache_dir);
+
+    var plan = try audit_mod.audit(alloc, &db, &api, .formula, .{});
+    defer plan.deinit(alloc);
+    try std.testing.expectEqualStrings("2.0", plan.dispositions[0].needs_upgrade); // index target
+    try std.testing.expectEqualStrings("4.0", plan.dispositions[1].needs_upgrade); // index target
+
+    var sink = EntrySink.init(alloc);
+    defer sink.deinit();
+    var tally: Tally = .{};
+    try upgradeAllFormulas(&ctx, alloc, &db, &api, &http, "/opt/malt", true, false, false, false, &.{}, plan, &tally, &sink);
+
+    // `now_current` is gone (the fetch folds it up_to_date); `still_behind` is
+    // recorded at the fetch's 3.0, never the index's 4.0.
+    try std.testing.expectEqual(@as(usize, 1), sink.formulas.items.len);
+    try std.testing.expectEqualStrings("still_behind", sink.formulas.items[0].name);
+    try std.testing.expectEqualStrings("3.0", sink.formulas.items[0].latest);
+    try std.testing.expectEqual(@as(usize, 1), tally.up_to_date); // now_current
+    try std.testing.expectEqual(@as(usize, 1), tally.would_upgrade); // still_behind
+}
+
+test "the dry-run cask snapshot follows the fetch, not the index, when the two skew" {
+    // Cask sibling of the formula case: the cask walker is separate code, so the
+    // skew must be proven against it too. `now_current` reads current from its
+    // fetch (dropped); `still_behind` is recorded at the fetch's 3.0, not the
+    // index's 4.0. Casks carry no revision, so both sides compare bare.
+    const alloc = std.testing.allocator;
+    const ctx = @import("../app_ctx.zig").debug_ctx;
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try db.exec(
+        \\INSERT INTO casks (token, name, version, url) VALUES
+        \\  ('now_current', 'now_current', '1.0', 'https://example/now_current'),
+        \\  ('still_behind', 'still_behind', '1.0', 'https://example/still_behind');
+    );
+
+    var s = try Scratch.init("cask_snapshot_follows_fetch");
+    defer s.deinit();
+    const cache_dir = s.base;
+    try writeTestVersionsIndex(cache_dir, .cask, "now_current\t2.0\t0\nstill_behind\t4.0\t0\n");
+    try writeTestCaskCache(cache_dir, "now_current", "1.0");
+    try writeTestCaskCache(cache_dir, "still_behind", "3.0");
+
+    var http = client_mod.HttpClient.init(ctx.io, ctx.environ, alloc);
+    defer http.deinit();
+    var api = api_mod.BrewApi.init(ctx.io, alloc, &http, cache_dir);
+
+    var plan = try audit_mod.audit(alloc, &db, &api, .cask, .{});
+    defer plan.deinit(alloc);
+    try std.testing.expectEqualStrings("2.0", plan.dispositions[0].needs_upgrade); // index target
+    try std.testing.expectEqualStrings("4.0", plan.dispositions[1].needs_upgrade); // index target
+
+    var sink = EntrySink.init(alloc);
+    defer sink.deinit();
+    var tally: Tally = .{};
+    try upgradeAllCasks(&ctx, alloc, &db, &api, "/opt/malt", true, false, false, plan, &tally, &sink);
+
+    try std.testing.expectEqual(@as(usize, 1), sink.casks.items.len);
+    try std.testing.expectEqualStrings("still_behind", sink.casks.items[0].name);
+    try std.testing.expectEqualStrings("3.0", sink.casks.items[0].latest);
+    try std.testing.expectEqual(@as(usize, 1), tally.up_to_date); // now_current
+    try std.testing.expectEqual(@as(usize, 1), tally.would_upgrade); // still_behind
 }

--- a/src/cli/upgrade.zig
+++ b/src/cli/upgrade.zig
@@ -601,10 +601,10 @@ fn upgradeFormula(
     };
     defer formula.deinit();
 
-    // Compare versions. On the bulk path the "already
-    // current" line is suppressed — the footer tallies it instead — but the
-    // NDJSON event is always emitted so the machine stream is unchanged.
-    if (std.mem.eql(u8, old_pkg_version, formula.pkg_version)) {
+    // Compare versions through the shared currency policy. On the bulk path the
+    // "already current" line is suppressed — the footer tallies it instead — but
+    // the NDJSON event is always emitted so the machine stream is unchanged.
+    if (formula_mod.isCurrent(old.version, old.revision, formula.pkg_version) == .current) {
         if (!bulk) output.skip("{s} is already at latest version {s}", .{ name, formula.pkg_version });
         output.emitNdjsonEvent(.up_to_date, name, null);
         return .up_to_date;
@@ -1385,7 +1385,7 @@ fn upgradeCask(ctx: *const AppCtx, allocator: std.mem.Allocator, token: []const 
     // policy (see `src/cli/outdated/refresh.zig`). Should a cask ever gain a
     // revision, this compare and the prints below go wrong together.
     const installed_version = installed.version();
-    if (std.mem.eql(u8, installed_version, parsed_cask.version)) {
+    if (formula_mod.isCurrent(installed_version, 0, parsed_cask.version) == .current) {
         if (!bulk) output.skip("{s} is already at latest version {s}", .{ token, parsed_cask.version });
         output.emitNdjsonEvent(.up_to_date, token, null);
         return .up_to_date;

--- a/src/core/formula.zig
+++ b/src/core/formula.zig
@@ -533,6 +533,25 @@ fn compareDigitRun(a: []const u8, b: []const u8) std.math.Order {
     return std.mem.order(u8, x, y);
 }
 
+/// Three-state currency verdict, installed vs upstream.
+pub const Currency = enum { current, differs, unprovable };
+
+/// The single policy behind "is this installed keg current?": qualify the
+/// installed (version, revision) pair and byte-compare it to the already
+/// revision-qualified `upstream`. malt mirrors the tap as the source of truth,
+/// so it follows a move in BOTH directions; any inequality is `differs`, never
+/// a silent "upstream is newer so we are fine". `unprovable` means the installed
+/// version overflowed pkgVersion's buffer: a caller must treat it as not-current
+/// (never skip a real upgrade), never as `current`.
+///
+/// The one anchor for the compare that used to be copy-pasted across the
+/// outdated audit, the per-package fetch fallbacks, and the upgrade walks.
+pub fn isCurrent(installed_version: []const u8, installed_revision: i64, upstream: []const u8) Currency {
+    var buf: [256]u8 = undefined;
+    const installed = pkgVersion(&buf, installed_version, installed_revision) catch return .unprovable;
+    return if (std.mem.eql(u8, installed, upstream)) .current else .differs;
+}
+
 const testing = std.testing;
 
 test "relate reads an ordinary forward move as newer" {
@@ -553,6 +572,27 @@ test "relate lets the revision decide when the versions match" {
 test "relate reads a yanked release as older" {
     // A real pip-audit transition: the event this whole signal exists for.
     try testing.expectEqual(Rel.older, relate("2.4.15", "2.4.14"));
+}
+
+test "isCurrent qualifies the installed revision before comparing" {
+    // A revision-only bump must read as `differs`, not a bare match, or a
+    // 1.2.3 -> 1.2.3_1 upgrade would be silently skipped.
+    try testing.expectEqual(Currency.current, isCurrent("1.2.3", 0, "1.2.3"));
+    try testing.expectEqual(Currency.current, isCurrent("1.2.3", 1, "1.2.3_1"));
+    try testing.expectEqual(Currency.differs, isCurrent("1.2.3", 0, "1.2.3_1"));
+}
+
+test "isCurrent follows the tap in both directions" {
+    // A yank (upstream moves backward) is still `differs`: malt mirrors the tap,
+    // so it never reads "we are newer" as up to date.
+    try testing.expectEqual(Currency.differs, isCurrent("2.4.15", 0, "2.4.14"));
+}
+
+test "isCurrent declines to prove currency on an overflowing version" {
+    // pkgVersion overflows past 256 bytes; the safe answer is `unprovable`, which
+    // callers route to a re-check, never to `current`.
+    const long = "1." ** 200;
+    try testing.expectEqual(Currency.unprovable, isCurrent(long, 3, "whatever"));
 }
 
 test "relate catches a mistyped bump" {


### PR DESCRIPTION
## Description

A full `mt upgrade --dry-run` pre-seeded the `outdated.json` snapshot from the bulk index for `needs_upgrade` rows, while the install decision came from the per-package fetch. When the two caches skewed inside their shared 5-minute TTL, the snapshot recorded a stale target the upgrade would never install, and a later `mt outdated` / TUI showed it until the caches expired.

- Delete the index pre-seed for formulas and casks; the per-package fetch that runs anyway (it needs the full formula/cask to install) is now the sole snapshot writer, keyed on the fetched version. No skew possible.
- Promote the matched-TTL invariant that bounds the window from a comment to a `comptime` assert, placed in `cli/outdated` so it sees both constants without a `net -> cli` import inversion.
- Extract the revision-qualify-then-byte-compare policy (copy-pasted across five sites) into one `core.formula.isCurrent`. Zero new module edges; behaviour unchanged.

## Related Issue

- None

## Notes for Reviewers

- Behaviour-preserving refactor. The only nuance: `isCurrent` returns `unprovable` (routed to a re-check, never "current") on a version that overflows the 256-byte buffer, where one fetch-fallback path previously did a bare compare. This differs only for a >256-char version Homebrew never emits, and always errs toward a re-check, never a missed upgrade.
