### PR TITLE
fix(store): re-relocate kegs cached before the rpath dedup landed

### DIFF
--- a/justfile
+++ b/justfile
@@ -36,6 +36,7 @@ install:
 [group('test')]
 regressions-static:
     @./scripts/regressions/tap-resolution-contract.sh
+    @./scripts/regressions/relocated-store-logic-version-pin.sh
     @./scripts/test/bench_release_resolution_test.sh
 
 # Run unit tests + cheap static regression guards.

--- a/scripts/regressions/relocated-store-logic-version-pin.sh
+++ b/scripts/regressions/relocated-store-logic-version-pin.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Regression: a change to the relocation logic must be paired with a decision
+# about `RELOC_LOGIC_VERSION`.
+#
+# The bug: the Mach-O patcher gained LC_RPATH dedup, but the relocated-keg
+# cache version stayed at 1. `store-relocated/v1/<bottle-sha>` still held the
+# keg relocated by the OLD patcher, and `cellar.materializeWithCellar` serves
+# that snapshot before it ever extracts or patches. Every user who had already
+# installed the affected bottle kept the broken binary across reinstall,
+# uninstall+install and cleanup - the shipped fix could not reach them.
+#
+# The versioned cache key (guarded by relocated-store-versioned-cache-key.sh)
+# only helps if somebody remembers to bump it, so this script removes the
+# remembering: it pins a digest of every source file whose behaviour ends up
+# baked into a cached keg. When one of them changes, the digest stops matching
+# and the run fails, forcing the bump-or-not call to be made explicitly.
+#
+# Answering the prompt:
+#   - relocated bytes change  -> bump RELOC_LOGIC_VERSION, then re-run --update
+#   - comments/tests only     -> re-run --update, leave the version alone
+#
+# Exits 0 when the pin matches the tree, non-zero otherwise. No network, no
+# build; pure source inspection.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+PIN="$ROOT/scripts/regressions/relocated-store-logic-version.pin"
+STORE="$ROOT/src/core/relocated_store.zig"
+
+# Everything whose output is captured in a `store-relocated` snapshot: the
+# keg relocation walk, the Mach-O patcher it drives, and the ad-hoc codesign
+# applied on the way out. relocated_store.zig itself is deliberately absent -
+# it carries the version constant, so including it would make every bump
+# invalidate its own pin.
+SOURCES=(
+  src/core/cellar.zig
+  src/core/patch.zig
+  src/macho/patcher.zig
+  src/macho/parser.zig
+  src/macho/codesign.zig
+)
+
+for rel in "${SOURCES[@]}"; do
+  [ -f "$ROOT/$rel" ] || {
+    echo "FAIL: relocation-logic source $rel is missing; the pin no longer covers the real code" >&2
+    exit 1
+  }
+done
+
+# Digest of the per-file digests: order is fixed by SOURCES, so the result is
+# independent of directory listing order and of where the repo is checked out.
+digest_now() {
+  (cd "$ROOT" && shasum -a 256 "${SOURCES[@]}" | shasum -a 256 | cut -d' ' -f1)
+}
+
+version_now() {
+  grep -Eo 'RELOC_LOGIC_VERSION: u32 = [0-9]+' "$STORE" | grep -Eo '[0-9]+$'
+}
+
+version=$(version_now)
+[ -n "$version" ] || {
+  echo "FAIL: could not read RELOC_LOGIC_VERSION from relocated_store.zig" >&2
+  exit 1
+}
+digest=$(digest_now)
+
+if [ "${1:-}" = "--update" ]; then
+  printf 'version=%s\ndigest=%s\n' "$version" "$digest" >"$PIN"
+  echo "OK: pinned relocation logic at version $version"
+  exit 0
+fi
+
+[ -f "$PIN" ] || {
+  echo "FAIL: pin file missing at $PIN; run '$0 --update' to create it" >&2
+  exit 1
+}
+
+pinned_version=$(grep -E '^version=' "$PIN" | cut -d= -f2)
+pinned_digest=$(grep -E '^digest=' "$PIN" | cut -d= -f2)
+
+if [ "$digest" != "$pinned_digest" ]; then
+  echo "FAIL: relocation logic changed since the pin was written." >&2
+  echo "      If the relocated bytes change, bump RELOC_LOGIC_VERSION (currently $version)" >&2
+  echo "      in src/core/relocated_store.zig so cached kegs are re-relocated." >&2
+  echo "      Then run: $0 --update" >&2
+  exit 1
+fi
+
+if [ "$version" != "$pinned_version" ]; then
+  echo "FAIL: RELOC_LOGIC_VERSION is $version but the pin records $pinned_version." >&2
+  echo "      Run: $0 --update" >&2
+  exit 1
+fi
+
+echo "OK: relocation logic matches the pin at version $version"

--- a/scripts/regressions/relocated-store-logic-version.pin
+++ b/scripts/regressions/relocated-store-logic-version.pin
@@ -1,0 +1,2 @@
+version=2
+digest=ab87d2dff7843c3ecbb4ea05558e690542672b82b42c94242bfe92f5268b5bdb

--- a/src/core/relocated_store.zig
+++ b/src/core/relocated_store.zig
@@ -31,10 +31,14 @@ pub const RelocatedStoreError = error{
 /// the bottle sha. Bump this whenever `relocateKegTree` / `patchTextFiles` /
 /// the `@@HOMEBREW_*@@` replacement set / codesign behaviour changes: the bump
 /// turns every prior `v<N-1>/` entry into a cache miss, forcing correct
-/// re-relocation. Prior `v<N-1>/` trees are orphaned on disk — there is no
-/// automatic sweeper for `store-relocated` yet — so a bump trades a one-time
-/// disk cost for correctness; bumps are rare (only on relocation-logic change).
-pub const RELOC_LOGIC_VERSION: u32 = 1;
+/// re-relocation. Prior `v<N-1>/` trees are reclaimed by `reapStaleVersions`
+/// on the next fresh `save`, so a bump trades one cold reinstall per cached
+/// bottle for correctness; bumps are rare (only on relocation-logic change).
+///
+/// v2: the Mach-O patcher learned to drop LC_RPATHs that relocation collapses
+/// onto one prefix; v1 entries were snapshotted before that and ship the
+/// duplicate that makes dyld abort at launch.
+pub const RELOC_LOGIC_VERSION: u32 = 2;
 
 /// Reject anything that is not exactly 64 lowercase hex characters.
 /// Run this before forming any path so traversal sequences (`..`, `/`) and


### PR DESCRIPTION
## Description

The rpath dedup shipped in v0.22.0 never reached the users who hit the bug. `store-relocated` is keyed on `(RELOC_LOGIC_VERSION, bottle sha)` and the version stayed at 1, so an affected package kept being served its pre-fix snapshot on reinstall, uninstall+install and cleanup - the cache short-circuits before extraction and patching ever run.

Bumping to 2 turns those entries into a miss, so the keg is relocated again with the fixed patcher and the stale tree is reclaimed on the next save. Users only need `mt reinstall <package>`; no manual cache wipe.

A new static guard pins a digest of every source whose behaviour ends up baked into a cached keg, so the next relocation-logic change cannot silently skip the bump-or-not decision.

## Related Issue

Fixes #754

## Notes for Reviewers

- The guard runs in `just test` via `regressions-static`. When it fails on a legitimate comment- or test-only edit, re-pin with `scripts/regressions/relocated-store-logic-version-pin.sh --update` and leave the version alone.
- Verified in a throwaway prefix: install now writes `store-relocated/v2`, the binary carries one `LC_RPATH` and runs.