### PR TITLE
fix(cli): give untap, help and the command aliases real help topics

### DIFF
--- a/scripts/regressions/help-topic-coverage-untap-no-help.sh
+++ b/scripts/regressions/help-topic-coverage-untap-no-help.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Regression: every command name the dispatcher accepts must resolve to a real
+# help topic. `helpFor` looks names up in a hand-maintained static map and falls
+# back to an 18-byte "No help available." stub that still exits 0, so a command
+# missing from the map degrades silently, in both help doors (`mt <cmd> -h` and
+# `mt help <cmd>`) and with nothing in CI treating it as a failure. `untap`,
+# `help` and the `remove`/`ls` aliases were all in that hole.
+#
+# The name list is derived from main.zig's `command_names` block, not hand
+# written, so a command added tomorrow is covered the day it lands. The stub
+# itself must survive for genuine typos; otherwise the check could be passed by
+# deleting the fallback rather than filling the map.
+#
+# No network (-h short-circuits before any fetch), no DB writes, well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "FAIL: malt binary not found at $BIN - run 'zig build' first." >&2
+  exit 2
+}
+
+TMP=$(mktemp -d -t mt_helpcov.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+export MALT_PREFIX="$TMP/prefix"
+export NO_COLOR=1
+
+STUB="No help available."
+
+# `--help`, `-h` and `--version` are argv spellings main.zig consumes before any
+# topic lookup, not topics of their own.
+names=()
+while IFS= read -r name; do
+  names+=("$name")
+done < <(
+  rg -o '\.names = &\.\{[^}]*\}' "$ROOT/src/main.zig" |
+    rg -o '"[^"]+"' | tr -d '"' |
+    rg -v '^(--help|-h|--version)$' | sort -u
+)
+
+if ((${#names[@]} <= 25)); then
+  echo "FAIL: command_names extractor found only ${#names[@]} names - parse drift?" >&2
+  exit 1
+fi
+
+fails=()
+for n in "${names[@]}"; do
+  for door in "-h" "help"; do
+    if [[ "$door" == "-h" ]]; then
+      out=$("$BIN" "$n" -h 2>&1 || true)
+      label="$n -h"
+    else
+      out=$("$BIN" help "$n" 2>&1 || true)
+      label="help $n"
+    fi
+    [[ "$out" == *"$STUB"* ]] && fails+=("$label")
+  done
+done
+
+# The stub is correct behaviour for a genuine typo; it must not be deleted.
+if ! "$BIN" help not-a-real-command 2>&1 | rg -q "$STUB"; then
+  echo "FAIL: unknown-topic fallback disappeared" >&2
+  exit 1
+fi
+
+if ((${#fails[@]} > 0)); then
+  echo "FAIL: no help topic for:" >&2
+  printf '  mt %s\n' "${fails[@]}" >&2
+  exit 1
+fi
+
+echo "PASS: every command name resolves to a real help topic (${#names[@]} names, both doors)"

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -32,6 +32,7 @@ pub fn helpFor(command: []const u8) []const u8 {
         .{ "search", search_help },
         .{ "doctor", doctor_help },
         .{ "tap", tap_help },
+        .{ "untap", untap_help },
         .{ "migrate", migrate_help },
         .{ "rollback", rollback_help },
         .{ "run", run_help },
@@ -52,6 +53,16 @@ pub fn helpFor(command: []const u8) []const u8 {
         .{ "services", services_help },
         .{ "tui", tui_help },
         .{ "version", version_help },
+        .{ "help", help_help },
+        // `malt help -h` hands the spelling straight to the lookup, so the
+        // argv forms of `help` resolve to the same topic as the word.
+        .{ "-h", help_help },
+        .{ "--help", help_help },
+        // Aliases point at the canonical text; `main.zig`'s `command_names` is
+        // the source of truth for them, but importing it here would invert the
+        // main -> cli dependency edge.
+        .{ "remove", uninstall_help },
+        .{ "ls", list_help },
     });
     return map.get(command) orelse "No help available.\n";
 }
@@ -365,6 +376,16 @@ const tap_help =
     \\
     \\Taps are auto-resolved during install, so explicit `tap` is
     \\usually unnecessary — the auto-tap also pins the SHA on first use.
+    \\
+;
+
+const untap_help =
+    \\Usage: malt untap <user>/<repo>
+    \\
+    \\Drop a tap from the registry, along with the commit SHA it was
+    \\pinned to. Packages already installed from that tap stay installed
+    \\and keep working (`malt outdated --tap` still recognises them), but
+    \\nothing new resolves against the tap until it is re-added.
     \\
 ;
 
@@ -755,6 +776,21 @@ const which_help =
     \\  malt which jq
     \\  malt which /opt/malt/bin/jq
     \\  malt --json which jq
+    \\
+;
+
+const help_help =
+    \\Usage: malt help [<command>]
+    \\
+    \\Show help. Without a command, prints the general usage and the
+    \\command table; with one, prints that command's topic.
+    \\
+    \\  malt help              general usage
+    \\  malt help install      the `install` topic
+    \\  malt install --help    same topic, from the command itself
+    \\
+    \\Every subcommand accepts -h / --help, and both doors print the same
+    \\text to stdout, so `malt install --help | less` works.
     \\
 ;
 

--- a/tests/help_test.zig
+++ b/tests/help_test.zig
@@ -36,20 +36,59 @@ test "showIfRequested returns true for long --help" {
     try testing.expect(help.showIfRequested(&ctx, &args, "purge"));
 }
 
-test "showIfRequested covers every documented command (exercises every branch of the static map)" {
-    const ctx = quietCtx();
-    const commands = [_][]const u8{
-        "install",  "uninstall",          "upgrade", "update",
-        "outdated", "list",               "info",    "search",
-        "doctor",   "tap",                "migrate", "rollback",
-        "run",      "link",               "unlink",  "pin",
-        "unpin",    "completions",        "backup",  "restore",
-        "purge",    "tui",                "version", "bundle",
-        "services", "not-a-real-command",
-    };
-    const args = [_][]const u8{"--help"};
-    for (commands) |cmd| {
-        try testing.expect(help.showIfRequested(&ctx, &args, cmd));
+/// `--version` prints the version and never reaches a topic lookup, so it is
+/// the one name in the block that is not expected to resolve. `-h`/`--help` do
+/// reach it, because `malt help -h` passes the spelling through verbatim.
+const not_topics = [_][]const u8{"--version"};
+
+/// Extract every argv spelling from `main.zig`'s `command_names` block. The old
+/// guard hand-listed command strings and asserted `showIfRequested` returned
+/// true, which it does even when the lookup falls through to the stub, so it
+/// could never catch a missing map entry. Deriving the list from the dispatcher
+/// means a command added tomorrow is covered the day it lands.
+fn commandNames(allocator: std.mem.Allocator, src: []const u8) !std.ArrayList([]const u8) {
+    var names: std.ArrayList([]const u8) = .empty;
+    errdefer names.deinit(allocator);
+
+    const block_start = std.mem.indexOf(u8, src, "const command_names = [_]struct {") orelse
+        return error.MissingCommandNames;
+    var rest = src[block_start..];
+    const block_end = std.mem.indexOf(u8, rest, "\n};") orelse return error.MissingCommandNames;
+    rest = rest[0..block_end];
+
+    var lines = std.mem.splitScalar(u8, rest, '\n');
+    while (lines.next()) |line| {
+        const list_start = std.mem.indexOf(u8, line, ".names = &.{") orelse continue;
+        var tail = line[list_start..];
+        while (std.mem.indexOfScalar(u8, tail, '"')) |open| {
+            tail = tail[open + 1 ..];
+            const close = std.mem.indexOfScalar(u8, tail, '"') orelse break;
+            try names.append(allocator, tail[0..close]);
+            tail = tail[close + 1 ..];
+        }
+    }
+    return names;
+}
+
+test "every command name the dispatcher accepts has a real help topic" {
+    const allocator = testing.allocator;
+
+    const f = try test_io.cwd().openFile(std.Options.debug_io, "src/main.zig", .{});
+    defer f.close(std.Options.debug_io);
+    const src = try test_io.readFileToEndAlloc(f, allocator, 4 * 1024 * 1024);
+    defer allocator.free(src);
+
+    var names = try commandNames(allocator, src);
+    defer names.deinit(allocator);
+
+    // A vanished or renamed block must fail loudly, not pass vacuously.
+    try testing.expect(names.items.len > 25);
+
+    for (names.items) |name| {
+        var skip = false;
+        for (not_topics) |n| skip = skip or std.mem.eql(u8, n, name);
+        if (skip) continue;
+        try testing.expect(!std.mem.eql(u8, help.helpFor(name), "No help available.\n"));
     }
 }
 


### PR DESCRIPTION
## Description

`malt untap -h` and `malt help untap|remove|ls|help` printed "No help available." and exited 0. Four names the dispatcher and all three completion scripts treat as real commands had no entry in `helpFor`'s static map, so tab completion offered topics the binary could not print.

Adds the missing `untap` and `help` topics, points the `remove`/`ls` aliases at the canonical `uninstall`/`list` text, and resolves the `-h`/`--help` spellings of `help`.

## Related Issue

- None

## Notes for Reviewers

- None
