### PR TITLE
perf(linker): cut warm-install link time by ~3x on large kegs

### DIFF
--- a/scripts/regressions/link-phase-per-leaf-cost.sh
+++ b/scripts/regressions/link-phase-per-leaf-cost.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Regression: the link phase cost ~0.19 ms per symlinked leaf because the
+# per-leaf loop paid four filesystem syscalls (an unconditional mkdir -p of
+# the leaf's parent, an unlink of a temp name that never existed, a symlink
+# and a rename) plus one prepare/step/finalize INSERT in autocommit, i.e.
+# one WAL commit with its own fsync per linked file. A keg with a large
+# include/ or share/ tree therefore linked in seconds: openssl@3 (7616
+# leaves) took 1.30s.
+#
+# The assertion is on cost per leaf, measured against a synthetic keg of
+# known leaf count, so it is about malt's link loop and not about bottle
+# size or network weather. No network is used at all.
+#
+# Measured before the fix: 0.183 ms/leaf (ReleaseSafe), 0.226 (Debug).
+# After: 0.058 (ReleaseSafe), 0.073 (Debug). The ceiling sits between the
+# two bands with room for a loaded box. It guards against the
+# autocommit-per-leaf shape returning, not a microbenchmark.
+#
+# Exits 0 when the bug is absent, non-zero (with the measured figure) when
+# present. Finishes well under 30s once built.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null || {
+  echo "sqlite3 required" >&2
+  exit 2
+}
+command -v python3 >/dev/null || {
+  echo "python3 required" >&2
+  exit 2
+}
+
+LEAVES=2000
+CEILING_MS=0.130
+
+PREFIX="$(mktemp -d)/malt-prefix"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1 MALT_NO_EMOJI=1
+trap 'rm -rf "$(dirname "$PREFIX")"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+DB="$PREFIX/db/malt.db"
+mkdir -p "$PREFIX/db"
+
+# Init the schema with a benign command against the empty DB file.
+: >"$DB"
+"$BIN" link __absent__ >/dev/null 2>&1 || true
+sqlite3 "$DB" "SELECT 1 FROM kegs LIMIT 1;" >/dev/null 2>&1 ||
+  fail "schema init did not create the kegs table"
+
+# Synthetic keg: one flat directory of many leaves. Flat is the honest
+# shape here: the fix caches the leaf's parent dir, and a deep tree would
+# flatter it.
+KEG="$PREFIX/Cellar/synth/1.0"
+mkdir -p "$KEG/include"
+i=0
+while [[ $i -lt $LEAVES ]]; do
+  : >"$KEG/include/h$i.h"
+  i=$((i + 1))
+done
+
+sqlite3 "$DB" \
+  "INSERT INTO kegs(name,full_name,version,store_sha256,cellar_path) \
+   VALUES('synth','synth','1.0','deadbeef','$KEG');"
+
+start=$(python3 -c 'import time; print(time.time())')
+"$BIN" link synth >/dev/null 2>&1 || fail "malt link errored"
+elapsed=$(python3 -c "import time; print(time.time() - $start)")
+
+rows=$(sqlite3 "$DB" "SELECT count(*) FROM links;")
+[[ "$rows" == "$LEAVES" ]] ||
+  fail "linked $rows of $LEAVES leaves - the cost assertion below is meaningless"
+pass "all $LEAVES leaves linked and recorded"
+
+per_leaf=$(python3 -c "print('%.4f' % ($elapsed / $LEAVES * 1000))")
+awk -v v="$per_leaf" -v c="$CEILING_MS" 'BEGIN { exit !(v > c) }' &&
+  fail "link phase costs ${per_leaf} ms/leaf, ceiling ${CEILING_MS} ms/leaf"
+pass "link phase costs ${per_leaf} ms/leaf (ceiling ${CEILING_MS})"
+
+printf '\n✔ link-phase per-leaf cost regression passed\n'

--- a/src/core/linker.zig
+++ b/src/core/linker.zig
@@ -194,20 +194,38 @@ pub const Linker = struct {
     /// `LC_LOAD_DYLIB` paths continue to resolve via `lib`, so compiled
     /// formulae are unaffected; only the global PATH entries disappear.
     pub fn link(self: *Linker, keg_path: []const u8, name: []const u8, keg_id: i64, bin_isolated: bool) !void {
+        _ = name;
         // bin-isolated drops the leading `bin`/`sbin`; full keeps them.
         const dirs_to_link: []const []const u8 = if (bin_isolated) linkable_dirs[2..] else &linkable_dirs;
+
+        // One statement and one transaction per keg, not per leaf: in
+        // autocommit every row cost its own WAL commit and fsync.
+        var insert = try self.db.prepare(
+            "INSERT OR REPLACE INTO links (keg_id, link_path, target) VALUES (?1, ?2, ?3);",
+        );
+        defer insert.finalize();
+
+        // `rollback` and `upgrade` link inside their own transaction, and
+        // SQLite has no nested BEGIN.
+        const own_txn = !self.db.inTransaction();
+        if (own_txn) try self.db.beginTransaction();
+        // Rows are a ledger of symlinks already on disk, so a partial run keeps
+        // what it wrote; rolling back would strand those symlinks untracked.
+        errdefer if (own_txn) {
+            self.db.commit() catch self.db.rollback();
+        };
 
         for (dirs_to_link) |subdir| {
             // linkSubdir swallows per-leaf filesystem hiccups but propagates a
             // DB write failure; surface it so install can roll the keg back
             // rather than leave it silently half-linked.
-            try self.linkSubdir(keg_path, subdir, name, keg_id);
+            try self.linkSubdir(keg_path, subdir, keg_id, &insert);
         }
+
+        if (own_txn) try self.db.commit();
     }
 
-    fn linkSubdir(self: *Linker, keg_path: []const u8, subdir: []const u8, name: []const u8, keg_id: i64) !void {
-        _ = name;
-
+    fn linkSubdir(self: *Linker, keg_path: []const u8, subdir: []const u8, keg_id: i64, insert: *sqlite.Statement) !void {
         // Mirror the keg's tree as real dirs under the prefix and symlink
         // each leaf — the same traversal `checkConflicts` uses, so a nested
         // conflict the pre-check flags is exactly what link would create.
@@ -234,34 +252,32 @@ pub const Linker = struct {
         var parent_dir = std.Io.Dir.openDirAbsolute(self.io, parent, .{}) catch return;
         defer parent_dir.close(self.io);
 
+        // Leaves arrive clustered by directory, so caching the last parent
+        // skips nearly every createDirPath. A miss just costs the usual call.
+        var last_parent: ?[]const u8 = null;
+
         for (leaves.items) |rel| {
             // `rel` is relative and may nest (e.g. "pkgconfig/foo.pc").
             // Create the leaf's prefix-side parent before linking.
             const rel_parent = std.fs.path.dirname(rel);
-            if (rel_parent) |rp| parent_dir.createDirPath(self.io, rp) catch continue;
+            if (rel_parent) |rp| {
+                if (last_parent == null or !std.mem.eql(u8, last_parent.?, rp)) {
+                    parent_dir.createDirPath(self.io, rp) catch continue;
+                    last_parent = rp;
+                }
+            }
 
             // Path buffers sized to the OS path max so a real keg leaf never
             // truncates (see collectLeafPaths).
             var target_buf: [std.fs.max_path_bytes]u8 = undefined;
             const target = std.fmt.bufPrint(&target_buf, "{s}/{s}/{s}", .{ keg_path, subdir, rel }) catch continue;
 
-            // Atomic symlink: create at a temp name, then rename into place.
-            // This avoids a window where the link is absent after deleteFile.
-            // The temp sits in the leaf's own parent so the rename stays
-            // within one directory.
-            var tmp_name_buf: [std.fs.max_path_bytes]u8 = undefined;
-            const tmp_name = if (rel_parent) |rp|
-                std.fmt.bufPrint(&tmp_name_buf, "{s}/.malt_tmp_{s}", .{ rp, std.fs.path.basename(rel) }) catch continue
-            else
-                std.fmt.bufPrint(&tmp_name_buf, ".malt_tmp_{s}", .{rel}) catch continue;
-            // Stale tmp from a prior aborted link; symLink would otherwise EEXIST.
-            parent_dir.deleteFile(self.io, tmp_name) catch {};
-            parent_dir.symLink(self.io, target, tmp_name, .{}) catch continue;
-            parent_dir.rename(tmp_name, parent_dir, rel, self.io) catch {
-                // Rename failed — fall back to direct replacement (non-atomic).
-                parent_dir.deleteFile(self.io, tmp_name) catch {};
-                parent_dir.deleteFile(self.io, rel) catch {};
-                parent_dir.symLink(self.io, target, rel, .{}) catch continue;
+            // An empty slot needs one syscall, not the three temp+rename cost.
+            // Only an occupied slot needs atomic replacement; `replaceLink`
+            // still gives it that, so the link is never momentarily absent.
+            parent_dir.symLink(self.io, target, rel, .{}) catch |e| switch (e) {
+                error.PathAlreadyExists => self.replaceLink(parent_dir, target, rel) catch continue,
+                else => continue,
             };
 
             // Build the full link path for DB recording
@@ -272,22 +288,45 @@ pub const Linker = struct {
             // made — a DB-less symlink is an orphan `unlink` can't find — and
             // propagate so the caller (install) rolls the keg back instead of
             // reporting a half-linked keg as success.
-            self.recordLink(keg_id, link_path, target) catch |e| {
+            recordLink(insert, keg_id, link_path, target) catch |e| {
                 parent_dir.deleteFile(self.io, rel) catch {};
                 return e;
             };
         }
     }
 
-    fn recordLink(self: *Linker, keg_id: i64, link_path: []const u8, target: []const u8) !void {
-        var stmt = try self.db.prepare(
-            "INSERT OR REPLACE INTO links (keg_id, link_path, target) VALUES (?1, ?2, ?3);",
-        );
-        defer stmt.finalize();
+    /// Replace an occupied leaf slot without ever emptying it: symlink at a
+    /// temp name in the same directory, then rename over the old entry.
+    fn replaceLink(self: *Linker, dir: std.Io.Dir, target: []const u8, rel: []const u8) !void {
+        var tmp_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const tmp = if (std.fs.path.dirname(rel)) |rp|
+            try std.fmt.bufPrint(&tmp_buf, "{s}/.malt_tmp_{s}", .{ rp, std.fs.path.basename(rel) })
+        else
+            try std.fmt.bufPrint(&tmp_buf, ".malt_tmp_{s}", .{rel});
+
+        // Stale tmp from a prior aborted link; symLink would otherwise EEXIST.
+        dir.deleteFile(self.io, tmp) catch {};
+        try dir.symLink(self.io, target, tmp, .{});
+        dir.rename(tmp, dir, rel, self.io) catch {
+            // Rename failed — fall back to direct replacement (non-atomic).
+            dir.deleteFile(self.io, tmp) catch {};
+            dir.deleteFile(self.io, rel) catch {};
+            try dir.symLink(self.io, target, rel, .{});
+        };
+    }
+
+    /// Bind and run one row on the statement `link` prepared for this keg.
+    fn recordLink(stmt: *sqlite.Statement, keg_id: i64, link_path: []const u8, target: []const u8) !void {
+        try stmt.reset();
         try stmt.bindInt(1, keg_id);
         try stmt.bindText(2, link_path);
         try stmt.bindText(3, target);
-        _ = try stmt.step();
+        _ = stmt.step() catch |e| {
+            // `link` commits on the way out, and SQLite can refuse a COMMIT
+            // while a statement is still active. Reset only re-reports `e`.
+            stmt.reset() catch {};
+            return e;
+        };
     }
 
     /// Create `opt/{name} -> Cellar/{name}/{version}` symlink.

--- a/src/db/sqlite.zig
+++ b/src/db/sqlite.zig
@@ -177,6 +177,12 @@ pub const Database = struct {
         return Statement{ ._stmt = stmt.? };
     }
 
+    /// Whether an explicit transaction is already open. SQLite has no nested
+    /// `BEGIN`, so a callee that batches writes must ask before opening one.
+    pub fn inTransaction(self: *Database) bool {
+        return c.sqlite3_get_autocommit(self._handle) == 0;
+    }
+
     /// Begin an immediate transaction.
     pub fn beginTransaction(self: *Database) SqliteError!void {
         return self.exec("BEGIN IMMEDIATE;");
@@ -202,6 +208,23 @@ pub fn threadsafeMode() c_int {
 }
 
 const testing = std.testing;
+
+test "inTransaction reports an explicit BEGIN, not autocommit" {
+    var db = try Database.open(":memory:");
+    defer db.close();
+
+    // Callers batching writes ask this before opening one of their own, so it
+    // has to clear on both exits, not just commit.
+    try testing.expect(!db.inTransaction());
+    try db.beginTransaction();
+    try testing.expect(db.inTransaction());
+    try db.commit();
+    try testing.expect(!db.inTransaction());
+
+    try db.beginTransaction();
+    db.rollback();
+    try testing.expect(!db.inTransaction());
+}
 
 test "threadsafeMode returns one of the three documented values" {
     const m = threadsafeMode();

--- a/tests/linker_core_test.zig
+++ b/tests/linker_core_test.zig
@@ -455,6 +455,248 @@ test "link propagates a DB write failure and backs out the orphaned symlink" {
     try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(std.Options.debug_io, lp, .{}));
 }
 
+test "link joins a transaction the caller already holds instead of nesting one" {
+    // `rollback` and `upgrade` wrap their DB work — including the link call —
+    // in one transaction. SQLite has no nested BEGIN, so batching the link
+    // rows must piggyback on the open transaction rather than open its own.
+    const prefix = try uniquePrefix("link_in_caller_txn");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/nest/1.0", .{prefix});
+    defer testing.allocator.free(keg);
+    const bin = try std.fmt.allocPrint(testing.allocator, "{s}/bin/tool", .{keg});
+    defer testing.allocator.free(bin);
+    const man = try std.fmt.allocPrint(testing.allocator, "{s}/share/man/man1/tool.1", .{keg});
+    defer testing.allocator.free(man);
+    try writeFile(bin, "#!/bin/sh\n");
+    try writeFile(man, ".TH TOOL 1\n");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try insertKeg(&db, 1, "nest", keg);
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try db.beginTransaction();
+    try linker.link(keg, "nest", 1, false);
+    try db.commit();
+
+    var count = try db.prepare("SELECT COUNT(*) FROM links WHERE keg_id = 1;");
+    defer count.finalize();
+    _ = try count.step();
+    try testing.expectEqual(@as(i64, 2), count.columnInt(0));
+}
+
+test "a failed link leaves no transaction open and keeps the rows it did write" {
+    // The batched rows are a ledger of symlinks already on disk: after a
+    // mid-run failure the caller's `unlink(keg_id)` is what sweeps them, so
+    // the rows must survive — and the connection must be back in autocommit
+    // so the next writer isn't locked out.
+    const prefix = try uniquePrefix("link_fail_txn_state");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/nest/1.0", .{prefix});
+    defer testing.allocator.free(keg);
+    const bin = try std.fmt.allocPrint(testing.allocator, "{s}/bin/tool", .{keg});
+    defer testing.allocator.free(bin);
+    try writeFile(bin, "#!/bin/sh\n");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    // No kegs row: every links insert violates the FK.
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try testing.expectError(sqlite.SqliteError.ConstraintViolation, linker.link(keg, "nest", 1, false));
+
+    // A leaked open transaction would make this BEGIN fail.
+    try db.beginTransaction();
+    try db.commit();
+}
+
+test "a leaf failing mid-run keeps the rows already written so unlink can sweep them" {
+    // The batched rows are a ledger of symlinks already on disk. `link` runs
+    // subdirs in `linkable_dirs` order, so bin/tool is recorded before
+    // lib/boom.so aborts — and the bin row must survive the failure, or
+    // install's `unlink(keg_id)` rollback leaves that symlink stranded.
+    const prefix = try uniquePrefix("link_partial_ledger");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/nest/1.0", .{prefix});
+    defer testing.allocator.free(keg);
+    const bin = try std.fmt.allocPrint(testing.allocator, "{s}/bin/tool", .{keg});
+    defer testing.allocator.free(bin);
+    const boom = try std.fmt.allocPrint(testing.allocator, "{s}/lib/boom.so", .{keg});
+    defer testing.allocator.free(boom);
+    try writeFile(bin, "#!/bin/sh\n");
+    try writeFile(boom, "x\n");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try insertKeg(&db, 1, "nest", keg);
+    // Fail exactly one leaf, deterministically, after a good one has landed.
+    try db.exec(
+        \\CREATE TRIGGER boom_guard BEFORE INSERT ON links
+        \\WHEN NEW.link_path LIKE '%boom.so'
+        \\BEGIN SELECT RAISE(ABORT, 'boom'); END;
+    );
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try testing.expectError(sqlite.SqliteError.ConstraintViolation, linker.link(keg, "nest", 1, false));
+
+    // The bin row committed despite the later abort...
+    var count = try db.prepare("SELECT COUNT(*) FROM links WHERE keg_id = 1 AND link_path LIKE '%bin/tool';");
+    defer count.finalize();
+    _ = try count.step();
+    try testing.expectEqual(@as(i64, 1), count.columnInt(0));
+
+    // ...and it describes a symlink that really is on disk, so unlink sweeps it.
+    var lp_buf: [512]u8 = undefined;
+    const lp = try std.fmt.bufPrint(&lp_buf, "{s}/bin/tool", .{prefix});
+    var tgt_buf: [std.fs.max_path_bytes]u8 = undefined;
+    _ = try test_io.readLinkAbsolute(std.Options.debug_io, lp, &tgt_buf);
+
+    try linker.unlink(1);
+    try testing.expectError(error.FileNotFound, test_io.openFileAbsolute(std.Options.debug_io, lp, .{}));
+}
+
+test "link replaces a leaf already occupied by another keg's symlink" {
+    // Linking straight to the leaf name hits EEXIST when a prior keg owns the
+    // slot; the replacement must land, not be skipped, and must not leave the
+    // temp name behind.
+    const prefix = try uniquePrefix("link_replace_existing");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const keg_a = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/alpha/1.0", .{prefix});
+    defer testing.allocator.free(keg_a);
+    const keg_b = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/beta/1.0", .{prefix});
+    defer testing.allocator.free(keg_b);
+    // A nested leaf and a depth-1 one: the temp name is built differently when
+    // `rel` has no parent component, so both branches need to replace cleanly.
+    for ([_][]const u8{ keg_a, keg_b }) |k| {
+        const man = try std.fmt.allocPrint(testing.allocator, "{s}/share/man/man1/tool.1", .{k});
+        defer testing.allocator.free(man);
+        const bin = try std.fmt.allocPrint(testing.allocator, "{s}/bin/tool", .{k});
+        defer testing.allocator.free(bin);
+        try writeFile(man, ".TH TOOL 1\n");
+        try writeFile(bin, "#!/bin/sh\n");
+    }
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try insertKeg(&db, 1, "alpha", keg_a);
+    try insertKeg(&db, 2, "beta", keg_b);
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg_a, "alpha", 1, false);
+    try linker.link(keg_b, "beta", 2, false);
+
+    for ([_][]const u8{ "share/man/man1/tool.1", "bin/tool" }) |leaf| {
+        var lp_buf: [512]u8 = undefined;
+        const lp = try std.fmt.bufPrint(&lp_buf, "{s}/{s}", .{ prefix, leaf });
+        var tgt_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const tgt = try test_io.readLinkAbsolute(std.Options.debug_io, lp, &tgt_buf);
+        try testing.expect(std.mem.indexOf(u8, tgt, "/Cellar/beta/1.0/") != null);
+    }
+
+    // No `.malt_tmp_*` residue in either destination directory.
+    for ([_][]const u8{ "share/man/man1", "bin" }) |sub| {
+        var dir_buf: [512]u8 = undefined;
+        const dp = try std.fmt.bufPrint(&dir_buf, "{s}/{s}", .{ prefix, sub });
+        var d = try std.Io.Dir.openDirAbsolute(std.Options.debug_io, dp, .{ .iterate = true });
+        defer d.close(std.Options.debug_io);
+        var it = d.iterate();
+        while (try it.next(std.Options.debug_io)) |entry| {
+            try testing.expect(!std.mem.startsWith(u8, entry.name, ".malt_tmp_"));
+        }
+    }
+}
+
+test "a keg with nothing linkable succeeds and records no rows" {
+    // Batching opens a transaction up front, so the no-leaf case now runs an
+    // empty BEGIN/COMMIT that has to close cleanly.
+    const prefix = try uniquePrefix("link_nothing");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    // Only a non-linkable dir, so no subdir in linkable_dirs yields a leaf.
+    const keg = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/bare/1.0", .{prefix});
+    defer testing.allocator.free(keg);
+    const doc = try std.fmt.allocPrint(testing.allocator, "{s}/doc/README", .{keg});
+    defer testing.allocator.free(doc);
+    try writeFile(doc, "nothing to link\n");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try insertKeg(&db, 1, "bare", keg);
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg, "bare", 1, false);
+
+    var count = try db.prepare("SELECT COUNT(*) FROM links WHERE keg_id = 1;");
+    defer count.finalize();
+    _ = try count.step();
+    try testing.expectEqual(@as(i64, 0), count.columnInt(0));
+
+    // The connection is back in autocommit: the empty transaction closed.
+    try db.beginTransaction();
+    try db.commit();
+}
+
+test "a leaf slot held by a directory is skipped, not forced" {
+    // alpha puts a real directory at share/data; beta ships a file there.
+    // Linking beta cannot win that slot, and must skip the leaf without
+    // erroring or disturbing what alpha already linked.
+    const prefix = try uniquePrefix("link_leaf_is_dir");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    const keg_a = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/alpha/1.0", .{prefix});
+    defer testing.allocator.free(keg_a);
+    const keg_b = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar/beta/1.0", .{prefix});
+    defer testing.allocator.free(keg_b);
+    const inner = try std.fmt.allocPrint(testing.allocator, "{s}/share/data/inner", .{keg_a});
+    defer testing.allocator.free(inner);
+    const file_b = try std.fmt.allocPrint(testing.allocator, "{s}/share/data", .{keg_b});
+    defer testing.allocator.free(file_b);
+    try writeFile(inner, "inner\n");
+    try writeFile(file_b, "payload\n");
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+    try insertKeg(&db, 1, "alpha", keg_a);
+    try insertKeg(&db, 2, "beta", keg_b);
+
+    var linker = linker_mod.Linker.init(std.Options.debug_io, testing.allocator, &db, prefix);
+    try linker.link(keg_a, "alpha", 1, false);
+    // Must not error even though beta's only leaf cannot be placed.
+    try linker.link(keg_b, "beta", 2, false);
+
+    // alpha's nested link survives, and beta recorded no row for the lost leaf.
+    var lp_buf: [512]u8 = undefined;
+    const lp = try std.fmt.bufPrint(&lp_buf, "{s}/share/data/inner", .{prefix});
+    var tgt_buf: [std.fs.max_path_bytes]u8 = undefined;
+    _ = try test_io.readLinkAbsolute(std.Options.debug_io, lp, &tgt_buf);
+
+    var count = try db.prepare("SELECT COUNT(*) FROM links WHERE keg_id = 2;");
+    defer count.finalize();
+    _ = try count.step();
+    try testing.expectEqual(@as(i64, 0), count.columnInt(0));
+}
+
 test "checkConflicts flags a file-vs-directory collision the symlink probe misses" {
     const prefix = try uniquePrefix("conflict_filedir");
     defer testing.allocator.free(prefix);


### PR DESCRIPTION
## Description

Relinking a keg cost ~0.19 ms per symlinked file, so a package with a big `include/` or `share/` tree was slow out of proportion to the rest of the install - openssl@3 took 1.30s to relink.

Every leaf paid its own WAL commit and fsync, recreated its parent directory, and built the link at a temp name before renaming it into place. Now the rows for a keg go in one transaction on one reused statement, the parent directory
is remembered across leaves, and links are created directly - keeping the atomic temp+rename only where something is actually being replaced.

Warm install: tree 0.010 -> 0.004s, wget 0.028 -> 0.014s, ffmpeg 0.064 ->
0.022s. Binary size +64 bytes.

## Related Issue

- None

## Notes for Reviewers

- None