### PR TITLE
fix(doctor): find broken symlinks below the top level of each link dir

### DIFF
--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -126,11 +126,20 @@ pub fn isDanglingLinkError(err: anyerror) bool {
 
 const link_dirs = [_][]const u8{ "bin", "lib", "include", "share", "sbin" };
 
-/// Visit every *dangling* symlink under the prefix's link dirs: one target is
-/// resolved per entry and only `FileNotFound` counts, so an inaccessible-but-
-/// intact link is skipped. `visit` receives the open dir plus the subdir/name
-/// pair. The single traversal behind both the fix walk and the doctor check, so
-/// the two cannot report different link sets.
+/// Deepest nesting the walk descends. Prefix trees are shallow in practice
+/// (`share/locale/<lang>/LC_MESSAGES` is about the worst case); the cap only
+/// bounds stack use if something pathological shows up.
+const max_link_depth: u8 = 16;
+
+/// Visit every *dangling* symlink under the prefix's link dirs, recursing into
+/// nested directories: the linker mirrors keg trees, so a broken link can sit
+/// at `share/man/man1/foo.1` as easily as at `bin/foo`. One target is resolved
+/// per entry and only `FileNotFound` counts, so an inaccessible-but-intact link
+/// is skipped. `visit` receives the open containing dir, that dir's
+/// prefix-relative path, and the entry name — so `<subdir>/<name>` is the full
+/// path and `dir.deleteFile(name)` still resolves. The single traversal behind
+/// both the fix walk and the doctor check, so the two cannot report different
+/// link sets.
 pub fn forEachBrokenSymlink(
     io: std.Io,
     prefix: []const u8,
@@ -138,19 +147,40 @@ pub fn forEachBrokenSymlink(
     comptime visit: fn (@TypeOf(context), dir: std.Io.Dir, subdir: []const u8, name: []const u8) void,
 ) void {
     for (link_dirs) |subdir| {
-        var dir_buf: [512]u8 = undefined;
-        const dir_path = std.fmt.bufPrint(&dir_buf, "{s}/{s}", .{ prefix, subdir }) catch continue;
-        var dir = std.Io.Dir.openDirAbsolute(io, dir_path, .{ .iterate = true }) catch continue;
-        defer dir.close(io);
+        walkLinkDir(io, prefix, subdir, 0, context, visit);
+    }
+}
 
-        var iter = dir.iterate();
-        while (iter.next(io) catch null) |entry| {
-            if (entry.kind != .sym_link) continue;
-            _ = dir.statFile(io, entry.name, .{}) catch |err| {
-                if (isDanglingLinkError(err)) visit(context, dir, subdir, entry.name);
-                continue;
-            };
+fn walkLinkDir(
+    io: std.Io,
+    prefix: []const u8,
+    rel: []const u8,
+    depth: u8,
+    context: anytype,
+    comptime visit: fn (@TypeOf(context), dir: std.Io.Dir, subdir: []const u8, name: []const u8) void,
+) void {
+    if (depth >= max_link_depth) return;
+
+    var dir_buf: [512]u8 = undefined;
+    const dir_path = std.fmt.bufPrint(&dir_buf, "{s}/{s}", .{ prefix, rel }) catch return;
+    var dir = std.Io.Dir.openDirAbsolute(io, dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(io);
+
+    var iter = dir.iterate();
+    while (iter.next(io) catch null) |entry| {
+        // A symlinked directory reports as `.sym_link`, so descending here
+        // never leaves the prefix or loops.
+        if (entry.kind == .directory) {
+            var child_buf: [512]u8 = undefined;
+            const child = std.fmt.bufPrint(&child_buf, "{s}/{s}", .{ rel, entry.name }) catch continue;
+            walkLinkDir(io, prefix, child, depth + 1, context, visit);
+            continue;
         }
+        if (entry.kind != .sym_link) continue;
+        _ = dir.statFile(io, entry.name, .{}) catch |err| {
+            if (isDanglingLinkError(err)) visit(context, dir, rel, entry.name);
+            continue;
+        };
     }
 }
 

--- a/tests/doctor_fix_test.zig
+++ b/tests/doctor_fix_test.zig
@@ -230,6 +230,96 @@ test "fixBrokenSymlinks: dangling links are unlinked, valid links survive" {
     try testing.expectEqual(@as(u32, 0), fix.probeBrokenSymlinks(io, prefix));
 }
 
+test "fixBrokenSymlinks: nested dangling links are found, not just top-level ones" {
+    // The linker mirrors keg trees, so most links live below the top level:
+    // share/man/man1, lib/pkgconfig, share/locale/<lang>/LC_MESSAGES. A walk
+    // that only iterates `<prefix>/<subdir>` reports a clean prefix while
+    // leaving those broken links in place.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "nestedsymlinks");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var anchor_buf: [256]u8 = undefined;
+    const anchor = try std.fmt.bufPrint(&anchor_buf, "{s}/anchor", .{prefix});
+    try writeFile(anchor, "x");
+
+    // One dangling link per nesting depth, plus a live nested link that must
+    // survive, and a deep chain matching share/locale's real shape.
+    const nested_dirs = [_][]const u8{
+        "share/man/man1",
+        "lib/pkgconfig",
+        "share/locale/en_US/LC_MESSAGES",
+    };
+    for (nested_dirs) |sub| {
+        var d_buf: [256]u8 = undefined;
+        const d = try std.fmt.bufPrint(&d_buf, "{s}/{s}", .{ prefix, sub });
+        try fs_compat.cwd().createDirPath(std.Options.debug_io, d);
+
+        var dir = try fs_compat.openDirAbsolute(std.Options.debug_io, d, .{ .iterate = true });
+        defer dir.close(std.Options.debug_io);
+        try dir.symLink(std.Options.debug_io, "/tmp/malt-doctor-nested-vanished", "dead", .{});
+        try dir.symLink(std.Options.debug_io, anchor, "alive", .{});
+    }
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    try testing.expectEqual(@as(u32, nested_dirs.len), fix.probeBrokenSymlinks(io, prefix));
+    try testing.expectEqual(@as(u32, nested_dirs.len), fix.fixBrokenSymlinks(io, prefix));
+
+    for (nested_dirs) |sub| {
+        var dead_buf: [256]u8 = undefined;
+        const dead = try std.fmt.bufPrint(&dead_buf, "{s}/{s}/dead", .{ prefix, sub });
+        try testing.expect(!pathExists(dead));
+        var alive_buf: [256]u8 = undefined;
+        const alive = try std.fmt.bufPrint(&alive_buf, "{s}/{s}/alive", .{ prefix, sub });
+        try testing.expect(pathExists(alive));
+    }
+
+    try testing.expectEqual(@as(u32, 0), fix.probeBrokenSymlinks(io, prefix));
+}
+
+test "fixBrokenSymlinks: a symlinked directory is not descended into" {
+    // Directory symlinks report as `.sym_link`, so the walk treats them as
+    // leaves. Descending one would let the sweep escape the prefix.
+    var prefix_buf: [128]u8 = undefined;
+    const prefix = try makePrefix(&prefix_buf, "symlinkeddir");
+    defer fs_compat.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    var outside_buf: [256]u8 = undefined;
+    const outside = try std.fmt.bufPrint(&outside_buf, "{s}/outside", .{prefix});
+    try fs_compat.cwd().createDirPath(std.Options.debug_io, outside);
+    var outside_dir = try fs_compat.openDirAbsolute(std.Options.debug_io, outside, .{ .iterate = true });
+    defer outside_dir.close(std.Options.debug_io);
+    try outside_dir.symLink(std.Options.debug_io, "/tmp/malt-doctor-offlimits", "dead", .{});
+
+    var share_buf: [256]u8 = undefined;
+    const share = try std.fmt.bufPrint(&share_buf, "{s}/share", .{prefix});
+    try fs_compat.cwd().createDirPath(std.Options.debug_io, share);
+    var share_dir = try fs_compat.openDirAbsolute(std.Options.debug_io, share, .{ .iterate = true });
+    defer share_dir.close(std.Options.debug_io);
+    try share_dir.symLink(std.Options.debug_io, outside, "linked", .{});
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // `share/linked` resolves, so it is not dangling; the dead link inside the
+    // directory it points at is out of scope and must be left alone.
+    try testing.expectEqual(@as(u32, 0), fix.probeBrokenSymlinks(io, prefix));
+    try testing.expectEqual(@as(u32, 0), fix.fixBrokenSymlinks(io, prefix));
+
+    // The dangling link is still there as a directory entry. `pathExists`
+    // follows the link and would report absent, so check the entry itself.
+    var found = false;
+    var it = outside_dir.iterate();
+    while (try it.next(std.Options.debug_io)) |entry| {
+        if (std.mem.eql(u8, entry.name, "dead")) found = true;
+    }
+    try testing.expect(found);
+}
+
 test "fixBrokenSymlinks: prefix without link dirs reports zero" {
     var prefix_buf: [128]u8 = undefined;
     const prefix = try makePrefix(&prefix_buf, "emptylinks");


### PR DESCRIPTION
## Description

The sweep only looked directly inside `bin`, `lib`, `include`, `share` and `sbin`. The linker mirrors keg trees, so most links live deeper - `share/man/man1`, `lib/pkgconfig`, `share/locale/<lang>/LC_MESSAGES`. A prefix whose broken links were all nested reported clean, and `--fix` left them there.

Walk each link dir recursively.

## Related Issue

- None

## Notes for Reviewers

- A symlinked directory reports as a symlink, so descending never follows one out of the prefix; a depth cap bounds the walk. Both are covered by tests.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #782
- <kbd>&nbsp;1&nbsp;</kbd> #781 👈 
<!-- GitButler Footer Boundary Bottom -->