### PR TITLE
fix(cleanup): sweep broken symlinks so doctor's advice works

### DIFF
--- a/man/malt.1
+++ b/man/malt.1
@@ -617,7 +617,9 @@ Scopes (one or more required):
   --downloads          Wipe {cache}/downloads entirely        (typed confirm)
   --stale-casks        Cask cache + Caskroom for uninstalled casks
   --old-versions       Non-latest Cellar versions + retained cask history (typed confirm)
+  --broken-symlinks    Prefix symlinks whose target no longer exists
   --housekeeping       = --store-orphans --unused-deps --cache --stale-casks
+                         --broken-symlinks
   --wipe               Nuclear: every malt artefact on disk    (typed confirm)
 
 Shared flags:
@@ -651,8 +653,9 @@ For per-package removal use `mt uninstall <name>`.
 Usage: malt cleanup [flags]
 
 Shorthand for `malt purge --housekeeping` — the safe daily-driver
-scope (store-orphans + unused-deps + cache + stale-casks). For the
-full menu (downloads scrub, old-versions, wipe) use `mt purge`.
+scope (store-orphans + unused-deps + cache + stale-casks +
+broken-symlinks). For the full menu (downloads scrub, old-versions,
+wipe) use `mt purge`.
 
 Flags pass through to `purge`; the common ones:
   --dry-run, -n        Preview only

--- a/scripts/regressions/cleanup-sweeps-broken-symlinks.sh
+++ b/scripts/regressions/cleanup-sweeps-broken-symlinks.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Regression: `mt doctor` reports broken symlinks with "Run: mt cleanup", but
+# cleanup had no symlink sweep at all - only `mt doctor --fix broken_symlinks`
+# removed them, so following the advice left the prefix exactly as it was.
+#
+# The sweep also used its own copy of the link-dir list, which had lost `etc`,
+# and it never descended past the top level of each dir. Since the linker
+# mirrors keg trees, most links live deeper: share/man/man1, lib/pkgconfig,
+# share/locale/<lang>/LC_MESSAGES.
+#
+# Plants dangling links at the top level, nested, and under etc/, plus a live
+# link beside each that must survive. No network required.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+PREFIX="$(mktemp -d)/malt-prefix"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1 MALT_NO_EMOJI=1
+trap 'rm -rf "$(dirname "$PREFIX")"' EXIT
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+mkdir -p "$PREFIX/db" "$PREFIX/cache"
+: >"$PREFIX/anchor"
+
+# One dangling link and one live link in each location.
+planted=("bin" "share/man/man1" "lib/pkgconfig" "etc")
+for sub in "${planted[@]}"; do
+  mkdir -p "$PREFIX/$sub"
+  ln -s "/malt-regression-target-that-does-not-exist" "$PREFIX/$sub/dead"
+  ln -s "$PREFIX/anchor" "$PREFIX/$sub/alive"
+done
+
+# Dry run must report without removing, so the advice can be previewed.
+"$BIN" cleanup --dry-run --yes >/dev/null 2>&1 || true
+for sub in "${planted[@]}"; do
+  [[ -L "$PREFIX/$sub/dead" ]] ||
+    fail "--dry-run removed $sub/dead; preview must not mutate the prefix"
+done
+pass "--dry-run left every planted link in place"
+
+"$BIN" cleanup --yes >/dev/null 2>&1 || true
+
+for sub in "${planted[@]}"; do
+  [[ -L "$PREFIX/$sub/dead" ]] &&
+    fail "cleanup left the broken symlink at $sub/dead"
+  [[ -L "$PREFIX/$sub/alive" ]] ||
+    fail "cleanup removed the live symlink at $sub/alive"
+  pass "$sub: broken link swept, live link kept"
+done
+
+printf '\n✔ cleanup broken-symlink sweep regression passed\n'

--- a/src/cli/completions.zig
+++ b/src/cli/completions.zig
@@ -154,7 +154,7 @@ pub const bash_script =
     \\        reinstall)        cmd_flags="--cask --dry-run --isolate-deps --isolate-dependencies --quiet -q --json" ;;
     \\        backup)           cmd_flags="--output -o --versions --services --quiet -q" ;;
     \\        restore)          cmd_flags="--dry-run --force --quiet -q" ;;
-    \\        purge)            cmd_flags="--store-orphans --unused-deps --cache --cache= --downloads --stale-casks --old-versions --housekeeping --wipe --backup -b --keep-cache --remove-binary --yes -y --dry-run -n" ;;
+    \\        purge)            cmd_flags="--store-orphans --unused-deps --cache --cache= --downloads --stale-casks --old-versions --broken-symlinks --housekeeping --wipe --backup -b --keep-cache --remove-binary --yes -y --dry-run -n" ;;
     \\        uninstall|remove) cmd_flags="--cask --force --dry-run" ;;
     \\        upgrade)          cmd_flags="--cask --formula --dry-run --pinned --force -f --isolate-deps --isolate-dependencies --use-system-ruby=" ;;
     \\        outdated)         cmd_flags="--json --formula --formulae --cask --casks --pinned-only --tap --refresh --quiet -q" ;;
@@ -441,6 +441,7 @@ pub const zsh_script =
     \\                        '--downloads[Wipe the downloads cache]' \
     \\                        '--stale-casks[Remove cache + Caskroom for uninstalled casks]' \
     \\                        '--old-versions[Remove non-latest Cellar versions + retained cask history]' \
+    \\                        '--broken-symlinks[Remove prefix symlinks whose target no longer exists]' \
     \\                        '--housekeeping[All safe scopes at once]' \
     \\                        '--wipe[Nuclear: remove every malt artefact]' \
     \\                        '(--backup -b)'{--backup,-b}'[Write a restorable manifest before deleting]:path:_files' \
@@ -764,6 +765,7 @@ pub const fish_script =
     \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l downloads        -d 'Wipe the downloads cache (typed confirm)'
     \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l stale-casks      -d 'Cask cache + Caskroom for uninstalled casks'
     \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l old-versions     -d 'Non-latest Cellar versions + retained cask history (typed confirm)'
+    \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l broken-symlinks  -d 'Prefix symlinks whose target no longer exists'
     \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l housekeeping     -d 'All safe scopes at once'
     \\    complete -c $__malt_bin -n '__malt_using_command purge'      -l wipe             -d 'Nuclear: every malt artefact (typed confirm)'
     \\    # purge — shared / wipe-only flags

--- a/src/cli/doctor/fix.zig
+++ b/src/cli/doctor/fix.zig
@@ -7,6 +7,7 @@
 const std = @import("std");
 const lock_mod = @import("../../db/lock.zig");
 const sqlite = @import("../../db/sqlite.zig");
+const linker_mod = @import("../../core/linker.zig");
 
 /// Auto-fix classes that are reversible and never touch user data.
 pub const FixKind = enum { stale_lock, orphaned_store, broken_symlinks };
@@ -116,73 +117,13 @@ pub fn fixBrokenSymlinks(io: std.Io, prefix: []const u8) u32 {
     return walkBrokenSymlinks(io, prefix, true);
 }
 
-/// A broken symlink is one whose target genuinely does not exist. Any other
-/// `statFile` failure (AccessDenied, …) means "can't tell" — the link is live,
-/// so it must be left intact. Shared by the fix walk and the doctor check so
-/// the two cannot drift into report-vs-remove disagreement.
-pub fn isDanglingLinkError(err: anyerror) bool {
-    return err == error.FileNotFound;
-}
+/// Re-exported so doctor's own callers keep one name for the predicate.
+pub const isDanglingLinkError = linker_mod.isDanglingLinkError;
 
-const link_dirs = [_][]const u8{ "bin", "lib", "include", "share", "sbin" };
-
-/// Deepest nesting the walk descends. Prefix trees are shallow in practice
-/// (`share/locale/<lang>/LC_MESSAGES` is about the worst case); the cap only
-/// bounds stack use if something pathological shows up.
-const max_link_depth: u8 = 16;
-
-/// Visit every *dangling* symlink under the prefix's link dirs, recursing into
-/// nested directories: the linker mirrors keg trees, so a broken link can sit
-/// at `share/man/man1/foo.1` as easily as at `bin/foo`. One target is resolved
-/// per entry and only `FileNotFound` counts, so an inaccessible-but-intact link
-/// is skipped. `visit` receives the open containing dir, that dir's
-/// prefix-relative path, and the entry name — so `<subdir>/<name>` is the full
-/// path and `dir.deleteFile(name)` still resolves. The single traversal behind
-/// both the fix walk and the doctor check, so the two cannot report different
-/// link sets.
-pub fn forEachBrokenSymlink(
-    io: std.Io,
-    prefix: []const u8,
-    context: anytype,
-    comptime visit: fn (@TypeOf(context), dir: std.Io.Dir, subdir: []const u8, name: []const u8) void,
-) void {
-    for (link_dirs) |subdir| {
-        walkLinkDir(io, prefix, subdir, 0, context, visit);
-    }
-}
-
-fn walkLinkDir(
-    io: std.Io,
-    prefix: []const u8,
-    rel: []const u8,
-    depth: u8,
-    context: anytype,
-    comptime visit: fn (@TypeOf(context), dir: std.Io.Dir, subdir: []const u8, name: []const u8) void,
-) void {
-    if (depth >= max_link_depth) return;
-
-    var dir_buf: [512]u8 = undefined;
-    const dir_path = std.fmt.bufPrint(&dir_buf, "{s}/{s}", .{ prefix, rel }) catch return;
-    var dir = std.Io.Dir.openDirAbsolute(io, dir_path, .{ .iterate = true }) catch return;
-    defer dir.close(io);
-
-    var iter = dir.iterate();
-    while (iter.next(io) catch null) |entry| {
-        // A symlinked directory reports as `.sym_link`, so descending here
-        // never leaves the prefix or loops.
-        if (entry.kind == .directory) {
-            var child_buf: [512]u8 = undefined;
-            const child = std.fmt.bufPrint(&child_buf, "{s}/{s}", .{ rel, entry.name }) catch continue;
-            walkLinkDir(io, prefix, child, depth + 1, context, visit);
-            continue;
-        }
-        if (entry.kind != .sym_link) continue;
-        _ = dir.statFile(io, entry.name, .{}) catch |err| {
-            if (isDanglingLinkError(err)) visit(context, dir, rel, entry.name);
-            continue;
-        };
-    }
-}
+/// The prefix walk lives in `core/linker` next to the code that creates the
+/// links, so the set of directories swept is derived from the set written
+/// rather than kept in a second list that can drift.
+pub const forEachBrokenSymlink = linker_mod.forEachBrokenLink;
 
 fn walkBrokenSymlinks(io: std.Io, prefix: []const u8, do_remove: bool) u32 {
     const Sweep = struct {

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -557,7 +557,9 @@ const purge_help =
     \\  --downloads          Wipe {cache}/downloads entirely        (typed confirm)
     \\  --stale-casks        Cask cache + Caskroom for uninstalled casks
     \\  --old-versions       Non-latest Cellar versions + retained cask history (typed confirm)
+    \\  --broken-symlinks    Prefix symlinks whose target no longer exists
     \\  --housekeeping       = --store-orphans --unused-deps --cache --stale-casks
+    \\                         --broken-symlinks
     \\  --wipe               Nuclear: every malt artefact on disk    (typed confirm)
     \\
     \\Shared flags:
@@ -592,8 +594,9 @@ const cleanup_help =
     \\Usage: malt cleanup [flags]
     \\
     \\Shorthand for `malt purge --housekeeping` — the safe daily-driver
-    \\scope (store-orphans + unused-deps + cache + stale-casks). For the
-    \\full menu (downloads scrub, old-versions, wipe) use `mt purge`.
+    \\scope (store-orphans + unused-deps + cache + stale-casks +
+    \\broken-symlinks). For the full menu (downloads scrub, old-versions,
+    \\wipe) use `mt purge`.
     \\
     \\Flags pass through to `purge`; the common ones:
     \\  --dry-run, -n        Preview only

--- a/src/cli/purge.zig
+++ b/src/cli/purge.zig
@@ -28,6 +28,10 @@ pub const freePlan = wipe_mod.freePlan;
 
 pub const formatBytes = util.formatBytes;
 
+/// Exposed so the scope can be exercised directly: it mutates the prefix but
+/// needs no database, so a test does not have to drive the whole command.
+pub const runBrokenSymlinks = scopes_mod.runBrokenSymlinks;
+
 const TierResult = util.TierResult;
 
 /// Closed enum of non-wipe scopes. Field names match `Scope` so
@@ -40,6 +44,7 @@ const ScopeKey = enum {
     downloads,
     stale_casks,
     old_versions,
+    broken_symlinks,
 
     fn label(k: ScopeKey) []const u8 {
         return switch (k) {
@@ -49,13 +54,15 @@ const ScopeKey = enum {
             .downloads => "downloads",
             .stale_casks => "stale-casks",
             .old_versions => "old-versions",
+            .broken_symlinks => "broken-symlinks",
         };
     }
 };
 
 /// Run order matters: unused-deps must precede store-orphans because
 /// removing a keg decrements its store ref to 0, and those fresh
-/// orphans only get swept on the second pass.
+/// orphans only get swept on the second pass. broken-symlinks runs last
+/// so it also catches links the earlier scopes left dangling.
 const scope_run_order = [_]ScopeKey{
     .unused_deps,
     .store_orphans,
@@ -63,6 +70,7 @@ const scope_run_order = [_]ScopeKey{
     .downloads,
     .stale_casks,
     .old_versions,
+    .broken_symlinks,
 };
 
 pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8) !void {
@@ -206,6 +214,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
                 .downloads => scopes_mod.runDownloads(ctx, cache_dir, dry_run),
                 .stale_casks => scopes_mod.runStaleCasks(ctx, allocator, prefix, dry_run),
                 .old_versions => scopes_mod.runOldVersions(ctx, allocator, prefix, dry_run),
+                .broken_symlinks => scopes_mod.runBrokenSymlinks(ctx, prefix, dry_run),
             };
             try summary.add(allocator, .{
                 .name = name,

--- a/src/cli/purge/args.zig
+++ b/src/cli/purge/args.zig
@@ -24,16 +24,19 @@ pub const Scope = struct {
     downloads: bool = false,
     stale_casks: bool = false,
     old_versions: bool = false,
+    broken_symlinks: bool = false,
     wipe: bool = false,
 
     pub fn isEmpty(self: Scope) bool {
         return !(self.store_orphans or self.unused_deps or self.cache or
-            self.downloads or self.stale_casks or self.old_versions or self.wipe);
+            self.downloads or self.stale_casks or self.old_versions or
+            self.broken_symlinks or self.wipe);
     }
 
     pub fn anyNonWipe(self: Scope) bool {
         return self.store_orphans or self.unused_deps or self.cache or
-            self.downloads or self.stale_casks or self.old_versions;
+            self.downloads or self.stale_casks or self.old_versions or
+            self.broken_symlinks;
     }
 };
 
@@ -85,6 +88,7 @@ const Flag = enum {
     downloads,
     stale_casks,
     old_versions,
+    broken_symlinks,
     housekeeping,
     wipe,
     yes,
@@ -100,6 +104,7 @@ const flag_map = std.StaticStringMap(Flag).initComptime(.{
     .{ "--downloads", .downloads },
     .{ "--stale-casks", .stale_casks },
     .{ "--old-versions", .old_versions },
+    .{ "--broken-symlinks", .broken_symlinks },
     .{ "--housekeeping", .housekeeping },
     .{ "--wipe", .wipe },
     .{ "--yes", .yes },
@@ -137,11 +142,13 @@ pub fn parseArgs(args: []const []const u8) Error!Options {
             .downloads => opts.scope.downloads = true,
             .stale_casks => opts.scope.stale_casks = true,
             .old_versions => opts.scope.old_versions = true,
+            .broken_symlinks => opts.scope.broken_symlinks = true,
             .housekeeping => {
                 opts.scope.store_orphans = true;
                 opts.scope.unused_deps = true;
                 opts.scope.cache = true;
                 opts.scope.stale_casks = true;
+                opts.scope.broken_symlinks = true;
             },
             .wipe => opts.scope.wipe = true,
             .yes => opts.yes = true,

--- a/src/cli/purge/scopes.zig
+++ b/src/cli/purge/scopes.zig
@@ -301,6 +301,53 @@ fn pruneCacheRecursive(io: std.Io, cache_dir: []const u8, max_age_days: i64, dry
 
 // ── Tier: --downloads (was `cleanup -s`) ────────────────────────────────────
 
+// ── Tier: --broken-symlinks ────────────────────────────────────────────────
+
+/// Unlink prefix symlinks whose target is gone. `doctor` names `mt cleanup` as
+/// the repair for these, so the sweep has to live here and not only behind
+/// `doctor --fix`.
+pub fn runBrokenSymlinks(ctx: *const AppCtx, prefix: []const u8, dry_run: bool) !TierResult {
+    var result: TierResult = .{};
+    var rep = report.Reporter.init("broken-symlinks", dry_run);
+
+    // Two-pass so the header count is accurate before any item prints,
+    // matching the other scopes. The walk is the same both times.
+    const Counter = struct {
+        n: usize = 0,
+        fn visit(self: *@This(), _: std.Io.Dir, _: []const u8, _: []const u8) void {
+            self.n += 1;
+        }
+    };
+    var counter = Counter{};
+    linker_mod.forEachBrokenLink(ctx.io, prefix, &counter, Counter.visit);
+
+    if (counter.n == 0) {
+        rep.empty("no broken symlinks");
+        return result;
+    }
+    rep.header(counter.n, "broken symlink", "broken symlinks");
+
+    const Sweep = struct {
+        io: std.Io,
+        rep: *report.Reporter,
+        dry_run: bool,
+        removed: u32 = 0,
+        fn visit(self: *@This(), dir: std.Io.Dir, subdir: []const u8, name: []const u8) void {
+            // A link we cannot unlink was not removed, so don't count it.
+            if (!self.dry_run) dir.deleteFile(self.io, name) catch return;
+            var buf: [512]u8 = undefined;
+            self.rep.item(std.fmt.bufPrint(&buf, "{s}/{s}", .{ subdir, name }) catch name);
+            self.removed += 1;
+        }
+    };
+    var sweep = Sweep{ .io = ctx.io, .rep = &rep, .dry_run = dry_run };
+    linker_mod.forEachBrokenLink(ctx.io, prefix, &sweep, Sweep.visit);
+
+    result.removed = sweep.removed;
+    rep.done(counter.n);
+    return result;
+}
+
 pub fn runDownloads(ctx: *const AppCtx, cache_dir: []const u8, dry_run: bool) !TierResult {
     var result: TierResult = .{};
     const io = ctx.io;

--- a/src/core/linker.zig
+++ b/src/core/linker.zig
@@ -392,6 +392,86 @@ pub const Linker = struct {
     }
 };
 
+/// A broken symlink is one whose target genuinely does not exist. Any other
+/// `statFile` failure (AccessDenied, …) means "can't tell", so the link is
+/// left intact.
+pub fn isDanglingLinkError(err: anyerror) bool {
+    return err == error.FileNotFound;
+}
+
+/// Deepest nesting `forEachBrokenLink` descends. Prefix trees are shallow
+/// (`share/locale/<lang>/LC_MESSAGES` is about the worst case); the cap only
+/// bounds stack use if something pathological shows up.
+const max_link_depth: u8 = 16;
+
+/// Visit every *dangling* symlink under the prefix's linkable dirs, recursing
+/// into nested directories the way `link` creates them. Keyed off
+/// `linkable_dirs`, so what the sweep inspects cannot drift from what the
+/// linker writes. `visit` receives the open containing dir, that dir's
+/// prefix-relative path, and the entry name, so `<subdir>/<name>` is the full
+/// path while `dir.deleteFile(name)` still resolves.
+pub fn forEachBrokenLink(
+    io: std.Io,
+    prefix: []const u8,
+    context: anytype,
+    comptime visit: fn (@TypeOf(context), dir: std.Io.Dir, subdir: []const u8, name: []const u8) void,
+) void {
+    for (Linker.linkable_dirs) |subdir| {
+        walkLinkDir(io, prefix, subdir, 0, context, visit);
+    }
+}
+
+fn walkLinkDir(
+    io: std.Io,
+    prefix: []const u8,
+    rel: []const u8,
+    depth: u8,
+    context: anytype,
+    comptime visit: fn (@TypeOf(context), dir: std.Io.Dir, subdir: []const u8, name: []const u8) void,
+) void {
+    if (depth >= max_link_depth) return;
+
+    var dir_buf: [512]u8 = undefined;
+    const dir_path = std.fmt.bufPrint(&dir_buf, "{s}/{s}", .{ prefix, rel }) catch return;
+    var dir = std.Io.Dir.openDirAbsolute(io, dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(io);
+
+    var iter = dir.iterate();
+    while (iter.next(io) catch null) |entry| {
+        // A symlinked directory reports as `.sym_link`, so descending here
+        // never leaves the prefix or loops.
+        if (entry.kind == .directory) {
+            var child_buf: [512]u8 = undefined;
+            const child = std.fmt.bufPrint(&child_buf, "{s}/{s}", .{ rel, entry.name }) catch continue;
+            walkLinkDir(io, prefix, child, depth + 1, context, visit);
+            continue;
+        }
+        if (entry.kind != .sym_link) continue;
+        _ = dir.statFile(io, entry.name, .{}) catch |err| {
+            if (isDanglingLinkError(err)) visit(context, dir, rel, entry.name);
+            continue;
+        };
+    }
+}
+
+test "the broken-link sweep covers every dir the linker writes into" {
+    // The sweep used to keep its own copy of this list, which silently lost
+    // `etc`. Deriving it here is what stops that happening again.
+    const swept: []const []const u8 = &Linker.linkable_dirs;
+    var has_etc = false;
+    for (swept) |d| {
+        if (std.mem.eql(u8, d, "etc")) has_etc = true;
+    }
+    try testing.expect(has_etc);
+    try testing.expectEqual(@as(usize, 6), swept.len);
+}
+
+test "isDanglingLinkError: only a missing target counts" {
+    try testing.expect(isDanglingLinkError(error.FileNotFound));
+    try testing.expect(!isDanglingLinkError(error.AccessDenied));
+    try testing.expect(!isDanglingLinkError(error.SymLinkLoop));
+}
+
 /// Read-only link status for a keg: true iff any symlink is recorded for
 /// it in `links`. Counterpart to `link`/`unlink`; `mt list --json
 /// --linked` uses it to report whether a keg is active in the prefix.

--- a/tests/purge_test.zig
+++ b/tests/purge_test.zig
@@ -65,16 +65,26 @@ test "parseArgs sets each scope flag independently" {
     }
 }
 
-test "--housekeeping expands to the four safe scopes" {
+test "--housekeeping expands to the safe scopes and no destructive one" {
     const opts = try purge.parseArgs(&[_][]const u8{"--housekeeping"});
     try testing.expect(opts.scope.store_orphans);
     try testing.expect(opts.scope.unused_deps);
     try testing.expect(opts.scope.cache);
     try testing.expect(opts.scope.stale_casks);
+    // doctor names `mt cleanup` as the repair for broken symlinks, so the
+    // safe set has to contain them or that advice goes nowhere.
+    try testing.expect(opts.scope.broken_symlinks);
     // Destructive scopes stay opt-in.
     try testing.expect(!opts.scope.downloads);
     try testing.expect(!opts.scope.old_versions);
     try testing.expect(!opts.scope.wipe);
+
+    // Every field above is asserted one way or the other. A new scope must be
+    // classified here as safe or opt-in rather than silently inheriting its
+    // default: this test previously said "four" while five were set.
+    comptime {
+        std.debug.assert(@typeInfo(purge.Scope).@"struct".fields.len == 8);
+    }
 }
 
 test "--cache=<bad-int> is rejected" {
@@ -382,4 +392,62 @@ test "applying the plan with --keep-cache leaves the cache directory intact" {
     try testing.expect(pathExists(marker));
     // Cellar must be gone.
     try testing.expect(!pathExists(cellar_dir));
+}
+
+// ── --broken-symlinks scope ─────────────────────────────────────────────────
+
+fn plantLinks(prefix: []const u8, sub: []const u8, anchor: []const u8) !void {
+    var buf: [512]u8 = undefined;
+    const dir_path = try std.fmt.bufPrint(&buf, "{s}/{s}", .{ prefix, sub });
+    try test_io.cwd().createDirPath(std.Options.debug_io, dir_path);
+    var dir = try std.Io.Dir.openDirAbsolute(std.Options.debug_io, dir_path, .{ .iterate = true });
+    defer dir.close(std.Options.debug_io);
+    try dir.symLink(std.Options.debug_io, "/malt-test-target-that-does-not-exist", "dead", .{});
+    try dir.symLink(std.Options.debug_io, anchor, "alive", .{});
+}
+
+fn linkExists(prefix: []const u8, rel: []const u8) bool {
+    var buf: [512]u8 = undefined;
+    const p = std.fmt.bufPrint(&buf, "{s}/{s}", .{ prefix, rel }) catch return false;
+    _ = std.Io.Dir.cwd().statFile(std.Options.debug_io, p, .{ .follow_symlinks = false }) catch return false;
+    return true;
+}
+
+test "--broken-symlinks removes dangling prefix links and keeps live ones" {
+    const allocator = testing.allocator;
+    const prefix = try test_io.uniqueTempPath(allocator, "purge_brokenlinks", "run");
+    defer allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, prefix);
+
+    var anchor_buf: [512]u8 = undefined;
+    const anchor = try std.fmt.bufPrint(&anchor_buf, "{s}/anchor", .{prefix});
+    const f = try test_io.createFileAbsolute(std.Options.debug_io, anchor, .{});
+    f.close(std.Options.debug_io);
+
+    // One top-level, one nested, and one under `etc`, the dir the sweep's
+    // old private list omitted entirely.
+    try plantLinks(prefix, "bin", anchor);
+    try plantLinks(prefix, "share/man/man1", anchor);
+    try plantLinks(prefix, "etc", anchor);
+
+    const ctx = malt.app_ctx.AppCtx{ .io = std.Options.debug_io, .environ = .empty };
+    const dry = try malt.purge.runBrokenSymlinks(&ctx, prefix, true);
+    try testing.expectEqual(@as(u32, 3), dry.removed);
+    // Dry run reports without touching anything.
+    try testing.expect(linkExists(prefix, "bin/dead"));
+    try testing.expect(linkExists(prefix, "etc/dead"));
+
+    const applied = try malt.purge.runBrokenSymlinks(&ctx, prefix, false);
+    try testing.expectEqual(@as(u32, 3), applied.removed);
+    for ([_][]const u8{ "bin/dead", "share/man/man1/dead", "etc/dead" }) |gone| {
+        try testing.expect(!linkExists(prefix, gone));
+    }
+    for ([_][]const u8{ "bin/alive", "share/man/man1/alive", "etc/alive" }) |kept| {
+        try testing.expect(linkExists(prefix, kept));
+    }
+
+    // Nothing left to do on a clean prefix.
+    const again = try malt.purge.runBrokenSymlinks(&ctx, prefix, false);
+    try testing.expectEqual(@as(u32, 0), again.removed);
 }


### PR DESCRIPTION
## Description

`doctor` reports broken symlinks with "Run: mt cleanup", but cleanup had no symlink sweep. Only `doctor --fix broken_symlinks` removed them, so following the printed advice did nothing.

Adds a `--broken-symlinks` scope, included in `--housekeeping` (what `mt cleanup` runs). Honours `--dry-run`.

Also fixes `etc/`: the sweep kept its own copy of the link-dir list which had lost that entry, so broken symlinks under `etc/` were invisible to both commands. The walk now lives in `core/linker` and derives the list from
`linkable_dirs`, so it cannot drift again.

## Related Issue

- None

## Notes for Reviewers

- None

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #782 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #781
<!-- GitButler Footer Boundary Bottom -->