### PR TITLE
fix(security): refuse an undeclared cask digest and a symlinked link target

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ The supply-chain story:
 - **Signed releases.** Every release is cosign-signed keyless via GitHub OIDC; `install.sh` verifies the signature before trusting the SHA256 checksum. A leaked GitHub token is not enough to ship a malicious malt binary.
 - **Pinned third-party source.** `homebrew-core` and third-party taps are pinned to a specific commit SHA. Formula Ruby source is SHA256-verified against an embedded manifest at that commit. A rewritten upstream branch cannot substitute a formula's bottle URL mid-install. Advance a tap pin explicitly with `mt tap --refresh user/repo`.
 - **Sandboxed `post_install`.** The opt-in `--use-system-ruby` path runs inside a `sandbox-exec` profile scoped to the formula's cellar. Hostile formulas can affect their own install prefix and nothing else.
-- **Boundary validation.** `MALT_PREFIX`, launchd service declarations, install-script checksums, and HTTP redirects fail-closed on malformed or suspicious input - no silent HTTPS→HTTP downgrades, no `/bin/sh` in service argv, no `..` in prefix paths.
+- **Boundary validation.** `MALT_PREFIX`, launchd service declarations, install-script checksums, and HTTP redirects fail-closed on malformed or suspicious input - no silent HTTPS→HTTP downgrades, no `/bin/sh` in service argv, no `..` in prefix paths. A cask that declares no `sha256` is refused rather than treated as opted out; only the explicit `sha256 :no_check` skips verification.
 - **Posture visibility.** `mt doctor` flags world- or group-writable paths and unexpected ownership under `/opt/malt`, so multi-user machines see their attack surface at a glance.
 
 ### Local formulas: the trust boundary

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -954,7 +954,7 @@ fn materializeTapCask(
             output.emitNdjsonEvent(.download_complete, cask.token, "failed");
             sink.err("Failed to download cask {s}: {s}", .{ cask.token, @errorName(e) });
             return switch (e) {
-                error.DownloadFailed, error.Sha256Mismatch => InstallError.DownloadFailed,
+                error.DownloadFailed, error.Sha256Mismatch, error.Sha256Missing => InstallError.DownloadFailed,
                 error.OutOfMemory => InstallError.RecordFailed,
                 else => InstallError.CaskNotFound,
             };
@@ -970,7 +970,7 @@ fn materializeTapCask(
         if (sp) |*s| s.bar.finish();
         sink.err("Failed to install cask {s}: {s}", .{ cask.token, @errorName(e) });
         return switch (e) {
-            error.DownloadFailed, error.Sha256Mismatch => InstallError.DownloadFailed,
+            error.DownloadFailed, error.Sha256Mismatch, error.Sha256Missing => InstallError.DownloadFailed,
             error.OutOfMemory => InstallError.RecordFailed,
             else => InstallError.CaskNotFound,
         };

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -1681,6 +1681,20 @@ test "parseCask rejects path-traversal in a binary artifact" {
     }
 }
 
+test "an app artifact's target hint is ignored, so it never becomes a path" {
+    const a = std.testing.allocator;
+    // `binary` targets are screened because malt turns them into
+    // `<prefix>/bin/<target>`. `app` targets are not screened because nothing
+    // reads them — `parseAppName` takes the first string and stops. Pin that,
+    // so the asymmetry stays a decision rather than looking like an oversight.
+    const json =
+        \\{"token":"ok","version":"1.0","url":"https://e/x.zip","artifacts":[{"app":["Real.app",{"target":"../../../Evil.app"}]}]}
+    ;
+    var cask = try parseCask(a, json);
+    defer cask.deinit();
+    try std.testing.expectEqualStrings("Real.app", parseAppName(cask.parsed.value.object).?);
+}
+
 test "parseCask accepts the artifact shapes real casks use" {
     const a = std.testing.allocator;
     // The guard must not narrow what already installs: nested app bundles,

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -19,6 +19,10 @@ pub const CaskError = error{
     // Distinct from UninstallFailed so callers can say *why*: the app is live.
     AppRunning,
     Sha256Mismatch,
+    // Distinct from Sha256Mismatch: the manifest declared no digest at all.
+    // Callers retry a mismatch as transient corruption; this one never
+    // succeeds on a retry, so it must not wear the same name.
+    Sha256Missing,
     OutOfMemory,
 };
 
@@ -581,8 +585,12 @@ pub const CaskInstaller = struct {
             self.allocator.free(cache_path);
         }
 
-        self.verifySha256(cache_path, cask.sha256) catch
-            return CaskError.Sha256Mismatch;
+        self.verifySha256(cache_path, cask.sha256) catch |e| switch (e) {
+            // A retry re-downloads and fails identically, so it must not
+            // reach the caller wearing the transient error's name.
+            error.Sha256Missing => return CaskError.Sha256Missing,
+            else => return CaskError.Sha256Mismatch,
+        };
 
         return cache_path;
     }

--- a/src/core/dsl/builtins/fileutils.zig
+++ b/src/core/dsl/builtins/fileutils.zig
@@ -29,7 +29,10 @@ fn validateLinkTarget(ctx: ExecCtx, target: []const u8, link_path: []const u8) B
         return BuiltinError.OutOfMemory;
     // Scratch only — the check consumes it, nothing downstream holds it.
     defer ctx.allocator.free(resolved);
-    sandbox.validatePath(resolved, ctx.cellar_path, ctx.malt_prefix) catch
+    // Resolve the target's own parent chain, not just its spelling: a bottle
+    // can ship a directory symlink that a lexically in-keg target walks
+    // through. Same guard `rm_r`/`mkdir_p` use.
+    sandbox.validateWriteDir(ctx.io, resolved, ctx.cellar_path, ctx.malt_prefix) catch
         return BuiltinError.PathSandboxViolation;
 }
 
@@ -409,6 +412,37 @@ test "ln_s still links to a target inside the keg" {
     const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
     _ = try lnS(ctx, null, &.{ Value{ .string = target }, Value{ .string = link } });
     try std.Io.Dir.cwd().access(io, link, .{});
+}
+
+test "ln_s refuses a target that reaches out through a planted directory symlink" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var s = try Scratch.init("fileutils_lns_dirlink");
+    defer s.deinit();
+    const base = s.base;
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const outside = try std.fs.path.join(alloc, &.{ base, "outside" });
+    defer alloc.free(outside);
+    const dirlink = try std.fs.path.join(alloc, &.{ keg, "d" });
+    defer alloc.free(dirlink);
+    // Lexically inside the keg, but `d` is a doorway the bottle shipped.
+    const target = try std.fs.path.join(alloc, &.{ dirlink, "secret" });
+    defer alloc.free(target);
+    const link = try std.fs.path.join(alloc, &.{ keg, "alias" });
+    defer alloc.free(link);
+
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    try std.Io.Dir.cwd().createDirPath(io, outside);
+    try std.Io.Dir.symLinkAbsolute(io, outside, dirlink, .{});
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        lnS(ctx, null, &.{ Value{ .string = target }, Value{ .string = link } }),
+    );
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, link, .{}));
 }
 
 test "rm_r refuses to delete through an intermediate-directory symlink out of the keg" {

--- a/tests/cask_extra_test.zig
+++ b/tests/cask_extra_test.zig
@@ -300,3 +300,65 @@ test "CaskInstaller.uninstall removes app_path, caskroom, cache, and the DB row"
     try testing.expect(!cask.isInstalled(&db, "firefox"));
     try testing.expectError(error.FileNotFound, test_io.openDirAbsolute(std.Options.debug_io, app_path_z, .{}));
 }
+
+// --- absent cask digest fails closed, and says so ------------------------
+
+/// Minimal loopback origin: answers every GET with `body`. Enough to drive
+/// `downloadOnly` through a real fetch without touching the network.
+const BodyStub = struct { io: std.Io, listener: *std.Io.net.Server, body: []const u8 };
+
+fn serveBody(s: *BodyStub) void {
+    const stream = s.listener.accept(s.io) catch return;
+    defer stream.close(s.io);
+    var rbuf: [8 * 1024]u8 = undefined;
+    var wbuf: [8 * 1024]u8 = undefined;
+    var reader = stream.reader(s.io, &rbuf);
+    var writer = stream.writer(s.io, &wbuf);
+    var srv = std.http.Server.init(&reader.interface, &writer.interface);
+    var req = srv.receiveHead() catch return;
+    req.respond(s.body, .{}) catch return;
+}
+
+test "downloadOnly reports a missing cask digest as its own error, not a mismatch" {
+    // Homebrew always emits `sha256` for a cask, so an absent one is a
+    // malformed or hostile manifest. Reporting it as Sha256Mismatch sends the
+    // user hunting for a corrupted download, and callers treat a mismatch as
+    // transient — so a hash-less cask would re-download and fail forever.
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = testEnviron() });
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+
+    var stub = BodyStub{ .io = io, .listener = &listener, .body = "ARTIFACT BYTES" };
+    const t = try std.Thread.spawn(.{}, serveBody, .{&stub});
+    // Declared before the listener's, so it runs *after* it: closing the
+    // listener unblocks `accept` and lets the thread exit even when the
+    // assertion below fails before any request is made.
+    defer t.join();
+    defer listener.deinit(io);
+
+    var fx = try Fixture.init("sha_missing");
+    defer fx.deinit();
+    // `downloadOnly` creates `cache/Cask` with a single-level makedir.
+    try test_io.cwd().createDirPath(std.Options.debug_io, fx.p("cache"));
+
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    const json = try std.fmt.allocPrint(
+        testing.allocator,
+        "{{\"token\":\"nosha\",\"version\":\"1.0\",\"url\":\"http://127.0.0.1:{d}/x.zip\"}}",
+        .{port},
+    );
+    defer testing.allocator.free(json);
+    var c = try cask.parseCask(testing.allocator, json);
+    defer c.deinit();
+    try testing.expect(c.sha256 == null);
+
+    var installer = cask.CaskInstaller.init(io, testEnviron(), testing.allocator, &db, fx.base);
+    try testing.expectError(error.Sha256Missing, installer.downloadOnly(&c));
+}

--- a/tests/progress_e2e_test.zig
+++ b/tests/progress_e2e_test.zig
@@ -1,5 +1,6 @@
 //! malt — progress integration test
-//! End-to-end test: fetch a real HTTP resource and verify the ProgressCallback fires.
+//! Drives a real HTTP fetch against a loopback `std.http.Server` and verifies
+//! the ProgressCallback fires with the byte counts the transfer actually saw.
 
 const std = @import("std");
 const testing = std.testing;
@@ -26,63 +27,85 @@ const TestTracker = struct {
     }
 };
 
-/// Live-network tests are opt-in — see `tests/progress_test.zig`. Set
-/// `MALT_TEST_NETWORK=1` to run them.
-fn liveNetworkAllowed() bool {
-    const v = std.process.Environ.getPosix(malt.app_ctx.processEnviron(), "MALT_TEST_NETWORK") orelse
-        return false;
-    return std.mem.eql(u8, v, "1");
+/// Body big enough that the transfer is worth reporting on, small enough to
+/// keep the fixture in the binary.
+const payload = "malt-progress-fixture-" ** 256;
+
+const Stub = struct { io: std.Io, listener: *std.Io.net.Server };
+
+fn serve(s: *Stub) void {
+    const stream = s.listener.accept(s.io) catch return;
+    defer stream.close(s.io);
+    var rbuf: [8 * 1024]u8 = undefined;
+    var wbuf: [8 * 1024]u8 = undefined;
+    var reader = stream.reader(s.io, &rbuf);
+    var writer = stream.writer(s.io, &wbuf);
+    var srv = std.http.Server.init(&reader.interface, &writer.interface);
+    var req = srv.receiveHead() catch return;
+    req.respond(payload, .{}) catch return;
 }
 
-test "HTTP GET with progress callback fires correctly" {
-    if (!liveNetworkAllowed()) return error.SkipZigTest;
-    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+test "HTTP GET with progress callback reports every byte of the body" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+    var stub = Stub{ .io = io, .listener = &listener };
+    const t = try std.Thread.spawn(.{}, serve, .{&stub});
+    // Declared first so it runs last: closing the listener first lets a
+    // pending `accept` fail and the thread exit even if an assertion trips.
+    defer t.join();
+    defer listener.deinit(io);
+
+    var http = client_mod.HttpClient.init(io, std.process.Environ.empty, testing.allocator);
     defer http.deinit();
 
-    var tracker = TestTracker{
-        .bar = progress_mod.ProgressBar.init("e2e-test", 0),
-    };
+    var tracker = TestTracker{ .bar = progress_mod.ProgressBar.init("e2e-test", 0) };
     const cb = client_mod.ProgressCallback{
         .context = @ptrCast(&tracker),
         .func = &TestTracker.callback,
     };
 
-    // Fetch a small, stable public URL (Homebrew API formula JSON for jq — ~3 KB)
-    var resp = http.getWithHeaders(
-        "https://formulae.brew.sh/api/formula/jq.json",
-        &.{},
-        cb,
-    ) catch |err| {
-        // Network may be unavailable in CI — skip rather than fail
-        std.debug.print("Skipping e2e test (network error: {s})\n", .{@errorName(err)});
-        return;
-    };
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/payload", .{port});
+    var resp = try http.getWithHeaders(url, &.{}, cb);
     defer resp.deinit();
 
     tracker.bar.finish();
 
-    // The callback should have been called at least once
-    try testing.expect(tracker.call_count > 0);
-    // Last bytes should match the response body length
-    try testing.expectEqual(@as(u64, resp.body.len), tracker.last_bytes);
-    // HTTP 200
     try testing.expectEqual(@as(u16, 200), resp.status);
+    try testing.expectEqualStrings(payload, resp.body);
+    try testing.expect(tracker.call_count > 0);
+    // The final tick accounts for the whole body, and the declared length
+    // reached the callback so a determinate bar was possible.
+    try testing.expectEqual(@as(u64, resp.body.len), tracker.last_bytes);
+    try testing.expectEqual(@as(?u64, payload.len), tracker.last_total);
 }
 
-test "HTTP GET without progress (null) still works" {
-    if (!liveNetworkAllowed()) return error.SkipZigTest;
-    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+test "HTTP GET without a progress callback still returns the whole body" {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+    var stub = Stub{ .io = io, .listener = &listener };
+    const t = try std.Thread.spawn(.{}, serve, .{&stub});
+    defer t.join();
+    defer listener.deinit(io);
+
+    var http = client_mod.HttpClient.init(io, std.process.Environ.empty, testing.allocator);
     defer http.deinit();
 
-    // Use get() which goes through the standard metadata path (no progress)
-    var resp = http.get(
-        "https://formulae.brew.sh/api/formula/jq.json",
-    ) catch |err| {
-        std.debug.print("Skipping e2e test (network error: {s})\n", .{@errorName(err)});
-        return;
-    };
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/payload", .{port});
+    var resp = try http.get(url);
     defer resp.deinit();
 
     try testing.expectEqual(@as(u16, 200), resp.status);
-    try testing.expect(resp.body.len > 100);
+    try testing.expectEqualStrings(payload, resp.body);
 }

--- a/tests/progress_test.zig
+++ b/tests/progress_test.zig
@@ -426,32 +426,63 @@ test "Response.deinit frees the owned body buffer" {
 extern fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
 extern fn unsetenv(name: [*:0]const u8) c_int;
 
-/// Live-network tests are opt-in. They reach third-party hosts, which makes the
-/// suite non-hermetic, dependent on someone else's uptime, and noisy on a
-/// firewalled or sandboxed machine. Set `MALT_TEST_NETWORK=1` to run them.
-fn liveNetworkAllowed() bool {
-    const v = std.process.Environ.getPosix(malt.app_ctx.processEnviron(), "MALT_TEST_NETWORK") orelse
-        return false;
-    return std.mem.eql(u8, v, "1");
+const RetryStub = struct {
+    io: std.Io,
+    listener: *std.Io.net.Server,
+    hits: std.atomic.Value(u32) = .init(0),
+};
+
+/// Answers the first request 503, every later one 200 — so a client that
+/// retries a retry-eligible status ends up with the body, and one that does
+/// not ends up with the 503.
+fn serveFlaky(s: *RetryStub) void {
+    while (true) {
+        const stream = s.listener.accept(s.io) catch return;
+        defer stream.close(s.io);
+        var rbuf: [8 * 1024]u8 = undefined;
+        var wbuf: [8 * 1024]u8 = undefined;
+        var reader = stream.reader(s.io, &rbuf);
+        var writer = stream.writer(s.io, &wbuf);
+        var srv = std.http.Server.init(&reader.interface, &writer.interface);
+        while (true) {
+            var req = srv.receiveHead() catch break;
+            const n = s.hits.fetchAdd(1, .monotonic);
+            if (n == 0) {
+                req.respond("", .{ .status = .service_unavailable }) catch break;
+            } else {
+                req.respond("recovered", .{}) catch break;
+            }
+        }
+    }
 }
 
-test "HttpClient.get retries on a 503 response status" {
-    if (!liveNetworkAllowed()) return error.SkipZigTest;
-    // httpbin.org/status/503 returns a deterministic 503 which is one of
-    // the retry-eligible codes (429/503/504). We don't care about the
-    // final result — we just need kcov to see the retry branch execute.
-    //
-    // Network-dependent: if the DNS lookup or TCP connect fails we skip.
-    var http = client_mod.HttpClient.init(std.Options.debug_io, std.process.Environ.empty, testing.allocator);
+test "HttpClient.get retries a 503 and returns the body from the next attempt" {
+    // 503 is one of the retry-eligible statuses (429/503/504). Asserting the
+    // recovered body *and* the second request is what distinguishes a real
+    // retry from a client that simply surfaced the first response.
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    const port = listener.socket.address.getPort();
+    var stub = RetryStub{ .io = io, .listener = &listener };
+    const t = try std.Thread.spawn(.{}, serveFlaky, .{&stub});
+    defer t.join();
+    defer listener.deinit(io);
+
+    var http = client_mod.HttpClient.init(io, std.process.Environ.empty, testing.allocator);
     defer http.deinit();
 
-    const result = http.get("https://httpbin.org/status/503");
-    if (result) |r| {
-        var rr = r;
-        rr.deinit();
-    } else |_| {
-        // Silent skip — the test is a coverage tripwire only.
-    }
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/flaky", .{port});
+    var resp = try http.get(url);
+    defer resp.deinit();
+
+    try testing.expectEqual(@as(u16, 200), resp.status);
+    try testing.expectEqualStrings("recovered", resp.body);
+    try testing.expect(stub.hits.load(.monotonic) >= 2);
 }
 
 test "HttpClient.get retries on connection failure before giving up" {


### PR DESCRIPTION
## Description

Two follow-ups to the tap-escape fixes. A cask declaring no digest surfaced as a checksum mismatch, which reads as a corrupted download and gets retried forever instead of failing closed. And `ln_s` held its target to a lexical check, so a bottle-shipped directory symlink still reached out of the keg.

Also drops the `MALT_TEST_NETWORK` opt-out: the last live-network tests now run against a loopback origin, so they assert instead of skipping.

## Related Issue

- None

## Notes for Reviewers

- None