### PR TITLE
style: restore zig fmt compliance in path_component

### DIFF
--- a/src/fs/path_component.zig
+++ b/src/fs/path_component.zig
@@ -38,17 +38,17 @@ pub fn isRelativeSubpath(s: []const u8) bool {
 
 test "isRelativeSubpath rejects shapes that leave the base directory" {
     const bad = [_][]const u8{
-        "",              "/abs/path",  "..",         "../x",
-        "a/../../b",     "a/b/..",     "a//b",       "a/",
-        "/",             "a\x00b",     "../",        "sub/../../../etc",
+        "",          "/abs/path", "..",   "../x",
+        "a/../../b", "a/b/..",    "a//b", "a/",
+        "/",         "a\x00b",    "../",  "sub/../../../etc",
     };
     for (bad) |s| try std.testing.expect(!isRelativeSubpath(s));
 }
 
 test "isRelativeSubpath accepts the nested names real casks ship" {
     const ok = [_][]const u8{
-        "Firefox.app",   "Sub Dir/My App.app", "bin/tool",
-        "a..b",          "foo..bar/baz",       "codex-aarch64-apple-darwin",
+        "Firefox.app",        "Sub Dir/My App.app", "bin/tool",
+        "a..b",               "foo..bar/baz",       "codex-aarch64-apple-darwin",
         "share/man/man1/x.1",
     };
     for (ok) |s| try std.testing.expect(isRelativeSubpath(s));


### PR DESCRIPTION
## Description

`just fmt-check` fails on main, so the Lint job is red on every open PR regardless of what it changes. Whitespace only.

## Related Issue

- None

## Notes for Reviewers

- None