### PR TITLE
fix(services): resolve the service name once per operation, not per lookup

### DIFF
--- a/man/malt.1
+++ b/man/malt.1
@@ -686,6 +686,9 @@ Subcommands:
   logs <name> [--tail N] [--stderr] [--follow|-f]
                     Print the last N lines of the service log.
                     --follow / -f tails appended bytes until SIGINT.
+
+<name> accepts the formula name (mosquitto) or the launchd label
+(com.malt.mosquitto). Both are shown by `list`.
 .fi
 .SS tui
 .nf

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -733,6 +733,9 @@ const services_help =
     \\                    Print the last N lines of the service log.
     \\                    --follow / -f tails appended bytes until SIGINT.
     \\
+    \\<name> accepts the formula name (mosquitto) or the launchd label
+    \\(com.malt.mosquitto). Both are shown by `list`.
+    \\
 ;
 
 const tui_help =

--- a/src/cli/services.zig
+++ b/src/cli/services.zig
@@ -147,6 +147,10 @@ fn cmdStatus(io: std.Io, allocator: std.mem.Allocator, db: *sqlite.Database, res
         output.err("no such service: {s}", .{name});
         return ServicesError.SupervisorError;
     }
+    // Rows and launchd are both keyed by the label; the user may have typed the
+    // keg name, which every other verb accepts.
+    const label = try supervisor.resolveLabel(allocator, db, name);
+    defer allocator.free(label);
     if (output.isJson()) {
         // Reuse `supervisor.list` filtered down to `name`, so the JSON shape
         // matches `list --json` (single-element array, identical fields).
@@ -154,11 +158,11 @@ fn cmdStatus(io: std.Io, allocator: std.mem.Allocator, db: *sqlite.Database, res
         defer supervisor.freeServiceInfos(allocator, items);
         var picked: std.ArrayList(supervisor.ServiceInfo) = .empty;
         defer picked.deinit(allocator);
-        for (items) |s| if (std.mem.eql(u8, s.name, name)) try picked.append(allocator, s);
+        for (items) |s| if (std.mem.eql(u8, s.name, label)) try picked.append(allocator, s);
         return emitJson(io, allocator, picked.items);
     }
-    const runtime = supervisor.queryRuntime(io, allocator, name);
-    output.info("service {s}: {s}", .{ name, supervisor.runtimeStateName(runtime) });
+    const runtime = supervisor.queryRuntime(io, allocator, label);
+    output.info("service {s}: {s}", .{ label, supervisor.runtimeStateName(runtime) });
 }
 
 /// Render the supervisor's list of services as `--json`. Runtime state
@@ -205,7 +209,12 @@ fn cmdLogs(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []con
             follow = true;
         }
     }
-    const path = try supervisor.logPath(allocator, name, if (stream == .stdout) .stdout else .stderr);
+    // Log dirs are named by the label, so resolve what the user typed first.
+    var db = try openDb(ctx);
+    defer db.close();
+    const label = try supervisor.resolveLabel(allocator, &db, name);
+    defer allocator.free(label);
+    const path = try supervisor.logPath(allocator, label, if (stream == .stdout) .stdout else .stderr);
     defer allocator.free(path);
     const stdout = ctx.stdout;
     var write_buf: [4096]u8 = undefined;

--- a/src/core/services/supervisor.zig
+++ b/src/core/services/supervisor.zig
@@ -321,27 +321,33 @@ fn lookupPlistPath(allocator: std.mem.Allocator, db: *sqlite.Database, name: []c
 pub fn start(ctx: SupervisorCtx, name: []const u8) SupervisorError!void {
     if (builtin.os.tag != .macos) return SupervisorError.OsNotSupported;
     const allocator = ctx.allocator;
-    const plist_path = try lookupPlistPath(allocator, ctx.db, name);
+    // Resolve once: every row is keyed by the label, so the status write below
+    // silently matched nothing when the user typed the keg name.
+    const label = try resolveLabel(allocator, ctx.db, name);
+    defer allocator.free(label);
+    const plist_path = try lookupPlistPath(allocator, ctx.db, label);
     defer allocator.free(plist_path);
     const domain = userDomain(allocator) catch return SupervisorError.OutOfMemory;
     defer allocator.free(domain);
 
     try runLaunchctl(ctx.io, &.{ "launchctl", "bootstrap", domain, plist_path });
     // Status is a UI hint; launchctl is the source of truth for liveness.
-    setStatus(ctx.db, name, "running") catch {};
+    setStatus(ctx.db, label, "running") catch {};
 }
 
 pub fn stop(ctx: SupervisorCtx, name: []const u8) SupervisorError!void {
     if (builtin.os.tag != .macos) return SupervisorError.OsNotSupported;
     const allocator = ctx.allocator;
-    const plist_path = try lookupPlistPath(allocator, ctx.db, name);
+    const label = try resolveLabel(allocator, ctx.db, name);
+    defer allocator.free(label);
+    const plist_path = try lookupPlistPath(allocator, ctx.db, label);
     defer allocator.free(plist_path);
     const domain = userDomain(allocator) catch return SupervisorError.OutOfMemory;
     defer allocator.free(domain);
 
     try runLaunchctl(ctx.io, &.{ "launchctl", "bootout", domain, plist_path });
     // Status is a UI hint; launchctl is the source of truth for liveness.
-    setStatus(ctx.db, name, "stopped") catch {};
+    setStatus(ctx.db, label, "stopped") catch {};
 }
 
 pub fn restart(ctx: SupervisorCtx, name: []const u8) SupervisorError!void {
@@ -351,11 +357,15 @@ pub fn restart(ctx: SupervisorCtx, name: []const u8) SupervisorError!void {
 }
 
 pub fn stopAndUnregister(ctx: SupervisorCtx, name: []const u8) void {
+    // `cli/uninstall.zig` passes the formula name, so resolve before deleting —
+    // matching on the raw name removed nothing and orphaned the row.
+    const label = resolveLabel(ctx.allocator, ctx.db, name) catch return;
+    defer ctx.allocator.free(label);
     // Unregister must remove the DB row even if the service is already down.
-    stop(ctx, name) catch {};
+    stop(ctx, label) catch {};
     var stmt = ctx.db.prepare("DELETE FROM services WHERE name = ?;") catch return;
     defer stmt.finalize();
-    stmt.bindText(1, name) catch return;
+    stmt.bindText(1, label) catch return;
     // Row may not exist; DELETE is idempotent either way.
     _ = stmt.step() catch {};
 }

--- a/tests/cli_services_test.zig
+++ b/tests/cli_services_test.zig
@@ -409,3 +409,90 @@ test "writeServicesJson: an errored row serialises as state \"errored\" without 
         aw.written(),
     );
 }
+
+test "execute status by keg name emits the row registered under its launchd label" {
+    // Every other verb takes the formula name, so `services status mosquitto`
+    // must find `com.malt.mosquitto`. `hasService` already accepted the keg
+    // name, so this used to pass that gate and then filter the row back out.
+    const prefix = try setupPrefix("status_by_keg");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+    try seedService(prefix, "com.malt.mosquitto", "mosquitto", false);
+
+    const prior_json = malt.output.isJson();
+    malt.output.setMode(.json);
+    defer malt.output.setMode(if (prior_json) .json else .human);
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    malt.output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer malt.output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try services_cli.execute(&ctx, testing.allocator, &.{ "status", "mosquitto" });
+
+    try testing.expect(std.mem.indexOf(u8, stdout_buf.items, "\"name\":\"com.malt.mosquitto\"") != null);
+    try testing.expect(std.mem.endsWith(u8, stdout_buf.items, "}]}\n"));
+}
+
+test "execute logs by keg name reads the log under the launchd label" {
+    // Log dirs are named by the label, so an unresolved keg name pointed at a
+    // path nothing ever creates.
+    const prefix = try setupPrefix("logs_by_keg");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+    try seedService(prefix, "com.malt.mosquitto", "mosquitto", false);
+
+    var dir_buf: [512]u8 = undefined;
+    const log_dir = try std.fmt.bufPrintSentinel(&dir_buf, "{s}/var/malt/services/com.malt.mosquitto", .{prefix}, 0);
+    try test_io.cwd().createDirPath(std.Options.debug_io, log_dir);
+    var log_buf: [512]u8 = undefined;
+    const log_path = try std.fmt.bufPrintSentinel(&log_buf, "{s}/stdout.log", .{log_dir}, 0);
+    {
+        const f = try std.Io.Dir.createFileAbsolute(std.Options.debug_io, log_path, .{ .truncate = true });
+        defer f.close(std.Options.debug_io);
+        try f.writeStreamingAll(std.Options.debug_io, "MOSQUITTO-LOG-LINE\n");
+    }
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // `cmdLogs` writes straight to `ctx.stdout`, which defaults to a closed
+    // handle so a test cannot reach the runner's fd 1.
+    var out_buf: [512]u8 = undefined;
+    const out_path = try std.fmt.bufPrintSentinel(&out_buf, "{s}/captured.out", .{prefix}, 0);
+    const out_file = try std.Io.Dir.createFileAbsolute(io, out_path, .{ .truncate = true });
+    const ctx: malt.app_ctx.AppCtx = .{ .io = io, .environ = .empty, .stdout = out_file };
+    try services_cli.execute(&ctx, testing.allocator, &.{ "logs", "mosquitto" });
+    out_file.close(io);
+
+    const f = try std.Io.Dir.openFileAbsolute(io, out_path, .{});
+    defer f.close(io);
+    var read_buf: [512]u8 = undefined;
+    const n = try f.readPositionalAll(io, &read_buf, 0);
+    try testing.expect(std.mem.indexOf(u8, read_buf[0..n], "MOSQUITTO-LOG-LINE") != null);
+}
+
+test "execute status refuses to guess when one formula registers two services" {
+    // Resolution happens after `hasService`, so the ambiguity has to surface
+    // rather than the first row winning silently.
+    const prefix = try setupPrefix("status_ambiguous");
+    defer testing.allocator.free(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    defer _ = c.unsetenv("MALT_PREFIX");
+    try seedService(prefix, "com.malt.pg.main", "postgresql@16", false);
+    try seedService(prefix, "com.malt.pg.repl", "postgresql@16", false);
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try testing.expectError(
+        error.AmbiguousService,
+        services_cli.execute(&ctx, testing.allocator, &.{ "status", "postgresql@16" }),
+    );
+}

--- a/tests/progress_e2e_test.zig
+++ b/tests/progress_e2e_test.zig
@@ -55,9 +55,6 @@ test "HTTP GET with progress callback reports every byte of the body" {
     const port = listener.socket.address.getPort();
     var stub = Stub{ .io = io, .listener = &listener };
     const t = try std.Thread.spawn(.{}, serve, .{&stub});
-    // Declared first so it runs last: closing the listener first lets a
-    // pending `accept` fail and the thread exit even if an assertion trips.
-    defer t.join();
     defer listener.deinit(io);
 
     var http = client_mod.HttpClient.init(io, std.process.Environ.empty, testing.allocator);
@@ -73,6 +70,9 @@ test "HTTP GET with progress callback reports every byte of the body" {
     const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/payload", .{port});
     var resp = try http.getWithHeaders(url, &.{}, cb);
     defer resp.deinit();
+    // Join before the listener's deferred close: closing a socket a thread is
+    // blocked in `accept` on is a use-after-close.
+    t.join();
 
     tracker.bar.finish();
 
@@ -95,7 +95,6 @@ test "HTTP GET without a progress callback still returns the whole body" {
     const port = listener.socket.address.getPort();
     var stub = Stub{ .io = io, .listener = &listener };
     const t = try std.Thread.spawn(.{}, serve, .{&stub});
-    defer t.join();
     defer listener.deinit(io);
 
     var http = client_mod.HttpClient.init(io, std.process.Environ.empty, testing.allocator);
@@ -105,6 +104,7 @@ test "HTTP GET without a progress callback still returns the whole body" {
     const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/payload", .{port});
     var resp = try http.get(url);
     defer resp.deinit();
+    t.join();
 
     try testing.expectEqual(@as(u16, 200), resp.status);
     try testing.expectEqualStrings(payload, resp.body);

--- a/tests/progress_test.zig
+++ b/tests/progress_test.zig
@@ -436,7 +436,10 @@ const RetryStub = struct {
 /// retries a retry-eligible status ends up with the body, and one that does
 /// not ends up with the 503.
 fn serveFlaky(s: *RetryStub) void {
-    while (true) {
+    // Stops once the retry has been answered, so the caller can join before
+    // closing the listener. Closing a socket another thread is blocked in
+    // `accept` on is a use-after-close, and Zig panics on the resulting BADF.
+    while (s.hits.load(.monotonic) < 2) {
         const stream = s.listener.accept(s.io) catch return;
         defer stream.close(s.io);
         var rbuf: [8 * 1024]u8 = undefined;
@@ -444,7 +447,7 @@ fn serveFlaky(s: *RetryStub) void {
         var reader = stream.reader(s.io, &rbuf);
         var writer = stream.writer(s.io, &wbuf);
         var srv = std.http.Server.init(&reader.interface, &writer.interface);
-        while (true) {
+        while (s.hits.load(.monotonic) < 2) {
             var req = srv.receiveHead() catch break;
             const n = s.hits.fetchAdd(1, .monotonic);
             if (n == 0) {
@@ -469,7 +472,6 @@ test "HttpClient.get retries a 503 and returns the body from the next attempt" {
     const port = listener.socket.address.getPort();
     var stub = RetryStub{ .io = io, .listener = &listener };
     const t = try std.Thread.spawn(.{}, serveFlaky, .{&stub});
-    defer t.join();
     defer listener.deinit(io);
 
     var http = client_mod.HttpClient.init(io, std.process.Environ.empty, testing.allocator);
@@ -479,6 +481,8 @@ test "HttpClient.get retries a 503 and returns the body from the next attempt" {
     const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/flaky", .{port});
     var resp = try http.get(url);
     defer resp.deinit();
+    // Join before the listener's deferred close, not after.
+    t.join();
 
     try testing.expectEqual(@as(u16, 200), resp.status);
     try testing.expectEqualStrings("recovered", resp.body);

--- a/tests/services_test.zig
+++ b/tests/services_test.zig
@@ -189,3 +189,26 @@ test "resolveLabel refuses to guess when one formula registers two services" {
     defer testing.allocator.free(exact);
     try testing.expectEqualStrings("com.malt.pg.repl", exact);
 }
+
+test "stopAndUnregister removes the row when given the keg name" {
+    // `cli/uninstall.zig` passes the formula name, but the DELETE matched on
+    // the launchd label — so uninstalling a formula with a service left the
+    // row behind and the job loaded.
+    var t = try TempDb.init("unregister_keg");
+    defer t.deinit();
+
+    try t.db.exec(
+        \\INSERT INTO services(name, keg_name, plist_path, auto_start, last_status)
+        \\VALUES ('com.malt.mosquitto', 'mosquitto', '/dev/null', 0, 'registered');
+    );
+
+    const ctx: supervisor.SupervisorCtx = .{
+        .allocator = testing.allocator,
+        .io = std.Options.debug_io,
+        .db = &t.db,
+    };
+    supervisor.stopAndUnregister(ctx, "mosquitto");
+
+    try testing.expect(!supervisor.hasService(&t.db, "mosquitto"));
+    try testing.expect(!supervisor.hasService(&t.db, "com.malt.mosquitto"));
+}


### PR DESCRIPTION
## Description

Accepting the formula name only reached the plist lookup, so four other sites still matched on the raw string: the status write-back after start and stop silently updated nothing, `status` filtered the row back out, `logs` read a path nothing creates, and uninstall left the row behind with the job still loaded.

Also fixes a crash on main: a loopback test closed its listener while the server thread was still blocked in `accept`, which aborts on the resulting bad descriptor.

## Related Issue

- None

## Notes for Reviewers

- None