### PR TITLE
fix(post-install): run the commands formulas declare in post-install steps

### DIFF
--- a/scripts/regressions/post-install-run-step-gh804.sh
+++ b/scripts/regressions/post-install-run-step-gh804.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Regression: `run` is the most common declarative post-install step upstream,
+# but it was missing from the executor's dispatch table. Every formula that
+# declared one fell through to the unknown-step branch, so the install ended
+# in the loud partial-skip envelope with the command never executed —
+# ca-certificates never built its keychain-validated bundle, fontconfig never
+# regenerated its cache. A second gap compounded it: `var` resolved as a path
+# base but had no inline template mapping, so `{{var}}` reached the child
+# process verbatim.
+#
+# No CLI subcommand drives the executor without a network install, so a
+# standalone `zig test` harness feeds it a synthetic formula whose `run` step
+# invokes a script staged in the keg's libexec, with `{{var}}` inside an
+# argument. The script records the argument it received; the harness asserts
+# the command ran, the token expanded, and the FallbackLog stayed clean.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when
+# present. No network required; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+STUBS=$(mktemp -d)
+
+# The harness imports the executor via a repo-relative path, so it must sit at
+# the repo root: the module's sibling imports (`dsl/sandbox.zig`,
+# `../fs/atomic.zig`) only resolve from inside the source tree.
+HARNESS="$ROOT/.post-install-run-step-regression.zig"
+trap 'rm -rf "$STUBS" "$HARNESS"' EXIT
+
+# The executor's module graph reaches the clonefile/statfs bindings that
+# build.zig generates with translate-c. Only the `copy` step calls them and
+# this harness never runs one, so declarations are enough to link.
+cat >"$STUBS/c_clonefile.zig" <<'ZIG'
+pub extern "c" fn clonefile(src: [*:0]const u8, dst: [*:0]const u8, flags: c_uint) c_int;
+ZIG
+cat >"$STUBS/c_mount.zig" <<'ZIG'
+pub const struct_statfs = extern struct { f_fstypename: [16]u8 };
+pub extern "c" fn statfs(path: [*:0]const u8, buf: *struct_statfs) c_int;
+ZIG
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const steps = @import("src/core/post_install_steps.zig");
+
+test "a run step executes the command with its templates expanded" {
+    // A spawning Io: the debug one has no allocator for the child's argv.
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = path_buf[0..try std.Io.Dir.realPath(tmp.dir, io, &path_buf)];
+
+    const keg = try std.fmt.allocPrint(a, "{s}/Cellar/probe/1.0", .{prefix});
+    const libexec = try std.fmt.allocPrint(a, "{s}/libexec", .{keg});
+    try std.Io.Dir.cwd().createDirPath(io, libexec);
+    try std.Io.Dir.cwd().createDirPath(io, try std.fmt.allocPrint(a, "{s}/etc", .{prefix}));
+
+    // Echoes its first argument into a file the harness reads back, so the
+    // assertion covers argument expansion and not just the exit code.
+    const receipt = try std.fmt.allocPrint(a, "{s}/etc/receipt", .{prefix});
+    const script = try std.fmt.allocPrint(a, "{s}/post-install", .{libexec});
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, script, .{});
+        defer f.close(io);
+        var w = f.writer(io, &.{});
+        try w.interface.print("#!/bin/sh\nprintf '%s' \"$1\" > '{s}'\n", .{receipt});
+        try w.interface.flush();
+        try f.setPermissions(io, @enumFromInt(0o755));
+    }
+
+    var flog = steps.FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+    const ctx: steps.StepsCtx = .{
+        .io = io,
+        .allocator = a,
+        .name = "probe",
+        .version = "1.0",
+        .prefix = prefix,
+        .keg_path = keg,
+        .flog = &flog,
+    };
+
+    const formula =
+        \\{"name":"probe","versions":{"stable":"1.0"},"post_install_steps":
+        \\[{"type":"run","command":{"base":"libexec","path":"post-install"},
+        \\  "args":["--ensure={{var}}/lib/machine-id"]}]}
+    ;
+
+    try std.testing.expect(steps.execute(ctx, formula));
+    if (flog.hasErrors()) {
+        for (flog.entries()) |e| std.debug.print("unexpected fallback: {s}\n", .{e.detail});
+        return error.RunStepNotDispatched;
+    }
+
+    var got: [256]u8 = undefined;
+    const f = std.Io.Dir.openFileAbsolute(io, receipt, .{}) catch return error.RunStepDidNotExecute;
+    defer f.close(io);
+    var r = f.reader(io, &.{});
+    const n = try r.interface.readSliceShort(&got);
+    const want = try std.fmt.allocPrint(a, "--ensure={s}/var/lib/machine-id", .{prefix});
+    if (!std.mem.eql(u8, want, got[0..n])) {
+        std.debug.print("want '{s}', got '{s}'\n", .{ want, got[0..n] });
+        return error.VarTemplateNotExpanded;
+    }
+}
+ZIG
+
+run_harness() {
+  (cd "$ROOT" && zig test -lc \
+    --dep c_clonefile --dep c_mount \
+    -Mroot="$HARNESS" \
+    -Mc_clonefile="$STUBS/c_clonefile.zig" \
+    -Mc_mount="$STUBS/c_mount.zig")
+}
+
+if run_harness >/dev/null 2>&1; then
+  echo "PASS: run steps execute with their templates expanded"
+else
+  run_harness 2>&1 | grep -Ev '\.\.\.OK$' | tail -20 >&2
+  echo "FAIL: a declarative run step did not execute as specified" >&2
+  exit 1
+fi

--- a/scripts/regressions/post-install-steps-inreplace-config-templating.sh
+++ b/scripts/regressions/post-install-steps-inreplace-config-templating.sh
@@ -52,7 +52,7 @@ if ! grep -q 'fn anchoredLineLiteral' "$STEPS"; then
   echo "FAIL: the regexp allowlist is gone — richer patterns would be approximated" >&2
   exit 1
 fi
-if ! grep -q 'fn guardsSatisfied' "$STEPS"; then
+if ! grep -q 'fn evalGuards' "$STEPS"; then
   echo "FAIL: guards are no longer evaluated — inreplace would run on absent config" >&2
   exit 1
 fi

--- a/scripts/regressions/ssl_ca_bundle.sh
+++ b/scripts/regressions/ssl_ca_bundle.sh
@@ -10,10 +10,14 @@
 #      symlink dangled.
 #
 # This asserts the native fix end-to-end:
-#   * mt install ca-certificates → <prefix>/etc/ca-certificates/cert.pem is a
-#     symlink to the shipped cacert.pem and matches it by sha256.
+#   * mt install ca-certificates → <prefix>/etc/ca-certificates/cert.pem is the
+#     bundle the keg's own helper builds: a real file holding the shipped store
+#     *plus* the roots the system keychain trusts, not a copy of the store.
 #   * mt install openssl@3 → <prefix>/etc/openssl@3/cert.pem resolves (no
-#     dangle) through to the same bundle and matches it by sha256.
+#     dangle) through to that bundle byte for byte.
+#
+# The shipped `cacert.pem` is only an input to the helper. Asserting the
+# installed bundle equals it would pin the state where the helper never ran.
 #
 # Usage: scripts/regressions/ssl_ca_bundle.sh
 # Requirements: built `malt` binary at $MALT_BIN or zig-out/bin/malt,
@@ -55,13 +59,17 @@ pass "installed ca-certificates"
 [[ -e "$SHIPPED" ]] || fail "keg shipped no cacert.pem at $SHIPPED"
 
 CA_CERT="$PREFIX/etc/ca-certificates/cert.pem"
-[[ -L "$CA_CERT" ]] || fail "$CA_CERT is not a symlink"
-[[ -e "$CA_CERT" ]] || fail "$CA_CERT dangles (target missing)"
-pass "etc/ca-certificates/cert.pem is a symlink that resolves"
+[[ -e "$CA_CERT" ]] || fail "$CA_CERT was not provisioned"
+pass "etc/ca-certificates/cert.pem exists"
 
-[[ "$(sha "$CA_CERT")" == "$(sha "$SHIPPED")" ]] ||
-  fail "etc/ca-certificates/cert.pem does not match the shipped cacert.pem by sha256"
-pass "etc/ca-certificates/cert.pem matches the shipped bundle by sha256"
+certs() { grep -c 'BEGIN CERTIFICATE' "$1"; }
+SHIPPED_N=$(certs "$SHIPPED")
+CA_N=$(certs "$CA_CERT")
+[[ "$CA_N" -ge "$SHIPPED_N" ]] ||
+  fail "etc/ca-certificates/cert.pem holds $CA_N certs, fewer than the $SHIPPED_N shipped"
+[[ "$(sha "$CA_CERT")" != "$(sha "$SHIPPED")" ]] ||
+  fail "etc/ca-certificates/cert.pem is a copy of the shipped store — the keg's helper never ran"
+pass "etc/ca-certificates/cert.pem is the helper's bundle ($CA_N certs vs $SHIPPED_N shipped)"
 
 # ── 2. openssl@3 links etc/openssl@3/cert.pem through the chain. ─────
 printf '▸ malt install openssl@3\n'
@@ -73,8 +81,8 @@ OSSL_CERT="$PREFIX/etc/openssl@3/cert.pem"
 [[ -e "$OSSL_CERT" ]] || fail "$OSSL_CERT dangles — the cross-formula pkgetc chain is broken"
 pass "etc/openssl@3/cert.pem is a symlink that resolves (no dangle)"
 
-[[ "$(sha "$OSSL_CERT")" == "$(sha "$SHIPPED")" ]] ||
-  fail "etc/openssl@3/cert.pem does not resolve to the shipped cacert.pem"
-pass "etc/openssl@3/cert.pem reaches the shipped bundle (sha256 match)"
+[[ "$(sha "$OSSL_CERT")" == "$(sha "$CA_CERT")" ]] ||
+  fail "etc/openssl@3/cert.pem does not resolve to the ca-certificates bundle"
+pass "etc/openssl@3/cert.pem reaches the ca-certificates bundle (sha256 match)"
 
 printf '\n✔ ssl ca-bundle provisioning regression passed\n'

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -1173,7 +1173,19 @@ pub fn formatSslCertDetail(present: bool) ?[]const u8 {
     return if (present)
         null
     else
-        "ca-certificates installed but cert.pem isn't linked";
+        "ca-certificates installed but openssl@3's cert.pem isn't linked";
+}
+
+/// Hand-fix for the "SSL CA bundle" row. `pub` so the render test can pin a
+/// command that actually succeeds: the target directory is created rather than
+/// assumed, and the source is the bundle `ca-certificates` builds — not the
+/// raw upstream store, which is only ever an input to it.
+pub fn formatSslCertRemedy(buf: []u8, prefix: []const u8) ?[]const u8 {
+    return std.fmt.bufPrint(
+        buf,
+        "mkdir -p {s}/etc/openssl@3 && ln -sf {s}/etc/ca-certificates/cert.pem {s}/etc/openssl@3/cert.pem",
+        .{ prefix, prefix, prefix },
+    ) catch null;
 }
 
 /// Check gated on its precondition: `<prefix>/etc/openssl@3/cert.pem` is
@@ -1201,15 +1213,14 @@ fn checkSslCaBundle(ctx: CheckCtx, name: []const u8) CheckResult {
     const status: CheckStatus = if (present) .ok else .warn_status;
     printCheck(name, status, formatSslCertDetail(present));
     if (!present) {
-        // Verbose-only remediation: the keg is on disk, so relink the
-        // bundle by hand.
-        var manual_buf: [768]u8 = undefined;
-        const manual = std.fmt.bufPrint(
-            &manual_buf,
-            "ln -sf {s}/opt/ca-certificates/share/ca-certificates/cacert.pem {s}/etc/openssl@3/cert.pem",
-            .{ ctx.prefix, ctx.prefix },
-        ) catch "ln -sf <prefix>/opt/ca-certificates/share/ca-certificates/cacert.pem <prefix>/etc/openssl@3/cert.pem";
-        writeVerboseList(&.{manual});
+        // Verbose-only remediation. The link source is ca-certificates' own
+        // bundle: without it there is nothing to point at, and `ln` into the
+        // missing openssl@3 dir would just exit 1, so create it first.
+        var src_buf: [512]u8 = undefined;
+        const src = std.fmt.bufPrint(&src_buf, "{s}/etc/ca-certificates/cert.pem", .{ctx.prefix}) catch return status;
+        std.Io.Dir.cwd().access(ctx.io, src, .{}) catch return status;
+        var manual_buf: [1024]u8 = undefined;
+        writeVerboseList(&.{formatSslCertRemedy(&manual_buf, ctx.prefix) orelse return status});
     }
     return status;
 }
@@ -1547,6 +1558,25 @@ test "formatSslCertDetail: null when present, unlinked-bundle hint when absent" 
     // the actual fault (the bundle isn't linked) so a user can act on it.
     try testing.expect(std.mem.indexOf(u8, missing, "ca-certificates") != null);
     try testing.expect(std.mem.indexOf(u8, missing, "isn't linked") != null);
+    // The row probes openssl@3's cert.pem, so that is what it must name.
+    try testing.expect(std.mem.indexOf(u8, missing, "openssl@3") != null);
+}
+
+test "formatSslCertRemedy: a command that runs on the state the row fires in" {
+    var buf: [1024]u8 = undefined;
+    const remedy = formatSslCertRemedy(&buf, "/opt/malt") orelse return error.TestUnexpectedResult;
+    // The row fires when etc/openssl@3 may not exist, so a bare `ln -sf` into
+    // it would exit 1; and the link source is the built bundle, not the raw
+    // upstream store the helper consumes.
+    try testing.expectEqualStrings(
+        "mkdir -p /opt/malt/etc/openssl@3 && ln -sf /opt/malt/etc/ca-certificates/cert.pem /opt/malt/etc/openssl@3/cert.pem",
+        remedy,
+    );
+
+    // A buffer too small for the command yields nothing rather than a
+    // truncated one the user would paste.
+    var tiny: [8]u8 = undefined;
+    try testing.expect(formatSslCertRemedy(&tiny, "/opt/malt") == null);
 }
 
 test "emitFixHintIfNeeded: silent without arming" {

--- a/src/core/post_install_steps.zig
+++ b/src/core/post_install_steps.zig
@@ -62,6 +62,7 @@ const StepTag = enum {
     update_mime_database,
     update_desktop_database,
     init_data_dir,
+    run,
 };
 
 /// Single source of truth for the native step set: `runStep` dispatch and
@@ -83,6 +84,7 @@ const step_map = std.StaticStringMap(StepTag).initComptime(.{
     .{ "update_mime_database", .update_mime_database },
     .{ "update_desktop_database", .update_desktop_database },
     .{ "init_data_dir", .init_data_dir },
+    .{ "run", .run },
 });
 
 /// True when the formula JSON carries a non-empty steps array whose every
@@ -178,6 +180,7 @@ fn runStep(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
         .gdk_pixbuf_query_loaders => stepGdkPixbufQueryLoaders(ctx),
         .gtk_update_icon_cache => stepGtkUpdateIconCache(ctx, obj),
         .init_data_dir => stepInitDataDir(ctx, obj),
+        .run => stepRun(ctx, obj),
     };
 }
 
@@ -214,6 +217,7 @@ const template_map = std.StaticStringMap(enum {
     version_major_minor,
     homebrew_prefix,
     prefix_etc,
+    prefix_var,
     user,
     keg_bin,
     keg_libexec,
@@ -231,6 +235,7 @@ const template_map = std.StaticStringMap(enum {
     .{ "version.major_minor", .version_major_minor },
     .{ "HOMEBREW_PREFIX", .homebrew_prefix },
     .{ "etc", .prefix_etc },
+    .{ "var", .prefix_var },
     .{ "user", .user },
     .{ "bin", .keg_bin },
     // Also usable inline, not just as a base — an unresolved `{{pkgetc}}` reads
@@ -255,6 +260,7 @@ fn templateValue(ctx: StepsCtx, token: []const u8) ?[]const u8 {
         .version_major_minor => versionComponents(ctx.version, 2),
         .homebrew_prefix => ctx.prefix,
         .prefix_etc => std.fmt.allocPrint(a, "{s}/etc", .{ctx.prefix}) catch null,
+        .prefix_var => std.fmt.allocPrint(a, "{s}/var", .{ctx.prefix}) catch null,
         // Null when the environment has no USER: the caller must refuse
         // rather than write an unresolved token into a live config.
         .user => std.process.Environ.getPosix(ctx.environ, "USER"),
@@ -517,20 +523,23 @@ fn stepSymlink(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
     return true;
 }
 
-/// `guards` gate a step on the target's state. Only `if_exists` appears
-/// upstream; an unknown condition counts as unmet, so the step is skipped
-/// rather than run against an assumption that was never checked.
-fn guardsSatisfied(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
-    const guards = obj.get("guards") orelse return true;
-    if (guards != .array) return true;
+/// `guards` gate a step on the target's state. `if_exists` is the only
+/// condition this executor evaluates; `unsupported` keeps a condition it
+/// cannot check distinguishable from one that genuinely did not hold, so a
+/// caller can refuse loudly instead of reading it as a deliberate skip.
+const GuardOutcome = enum { met, unmet, unsupported };
+
+fn evalGuards(ctx: StepsCtx, obj: std.json.ObjectMap) GuardOutcome {
+    const guards = obj.get("guards") orelse return .met;
+    if (guards != .array) return .met;
     for (guards.array.items) |item| {
         if (item != .object) continue;
-        const raw = getString(item.object, "path") orelse return false;
-        const path = expandTemplates(ctx, raw) catch return false;
-        if (!std.mem.eql(u8, getString(item.object, "condition") orelse "", "if_exists")) return false;
-        std.Io.Dir.accessAbsolute(ctx.io, path, .{}) catch return false;
+        if (!std.mem.eql(u8, getString(item.object, "condition") orelse "", "if_exists")) return .unsupported;
+        const raw = getString(item.object, "path") orelse return .unsupported;
+        const path = expandTemplates(ctx, raw) catch return .unmet;
+        std.Io.Dir.accessAbsolute(ctx.io, path, .{}) catch return .unmet;
     }
-    return true;
+    return .met;
 }
 
 /// Replace every line beginning with `literal` wholesale. Caller must have
@@ -568,7 +577,7 @@ fn anchoredLineLiteral(pattern: []const u8) ?[]const u8 {
 /// unresolved template, empty needle, unsupported regexp — refuses instead.
 fn stepInreplace(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
     // An unmet guard is the step declining to run, not a failure to report.
-    if (!guardsSatisfied(ctx, obj)) return true;
+    if (evalGuards(ctx, obj) != .met) return true;
 
     const path = resolvePathSpec(ctx, obj, "path") orelse return false;
     if (!confined(ctx, path)) return false;
@@ -743,6 +752,122 @@ fn stepGtkUpdateIconCache(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
     if (fileExists(ctx.io, gtk4))
         return runPathTool(ctx, obj, "gtk4", "gtk4-update-icon-cache", &.{ "-q", "-t", "-f" });
     return runPathTool(ctx, obj, "gtk+3", "gtk3-update-icon-cache", &.{ "-q", "-t", "-f" });
+}
+
+// --- arbitrary commands ------------------------------------------------------
+
+/// A `run` command's base is keg-relative: upstream resolves it through the
+/// Formula object, so `bin` is `<keg>/bin` — not `<prefix>/bin`, which is what
+/// the same token means as a *path* base in `base_map`.
+const CommandBase = enum { keg, bin, sbin, lib, libexec };
+
+const command_base_map = std.StaticStringMap(CommandBase).initComptime(.{
+    .{ "prefix", .keg },
+    .{ "bin", .bin },
+    .{ "sbin", .sbin },
+    .{ "lib", .lib },
+    .{ "libexec", .libexec },
+});
+
+/// Fields upstream's `run` accepts that malt does not honour. Spawning without
+/// them would run a command whose declared environment, redirection, or working
+/// directory silently did not apply, so their presence refuses instead.
+const run_unsupported_keys = [_][]const u8{ "env", "stdin_path", "stdout_path", "chdir", "writable_paths" };
+
+/// Absolute path to a `run` step's command, or null (already logged) when the
+/// spec is malformed. A bare name is refused rather than resolved through the
+/// fence's PATH: which binary that finds is not the formula's to decide.
+fn resolveCommandPath(ctx: StepsCtx, obj: std.json.ObjectMap) ?[]const u8 {
+    const spec = getObject(obj, "command") orelse {
+        logUnsupported(ctx, "run without a command");
+        return null;
+    };
+    const raw = getString(spec, "path") orelse {
+        logUnsupported(ctx, "run without a command path");
+        return null;
+    };
+    const path = expandTemplates(ctx, raw) catch return null;
+    const base = getString(spec, "base") orelse "absolute";
+    if (std.mem.eql(u8, base, "absolute")) {
+        if (!std.fs.path.isAbsolute(path)) {
+            logUnsupported(ctx, "run with a relative command");
+            return null;
+        }
+        return path;
+    }
+    const tag = command_base_map.get(base) orelse {
+        logUnsupported(ctx, std.fmt.allocPrint(ctx.allocator, "run command base {s}", .{base}) catch base);
+        return null;
+    };
+    if (path.len == 0) {
+        logUnsupported(ctx, "run with an empty command path");
+        return null;
+    }
+    const root = if (tag == .keg)
+        ctx.keg_path
+    else
+        std.fmt.allocPrint(ctx.allocator, "{s}/{s}", .{ ctx.keg_path, @tagName(tag) }) catch return null;
+    return std.fs.path.join(ctx.allocator, &.{ root, path }) catch null;
+}
+
+/// The formula's own helper: upstream's most common step, and the only one
+/// whose argv the formula supplies wholesale. It goes through the same argv
+/// lint and sandbox fence as every other spawn, with no extra grants.
+fn stepRun(ctx: StepsCtx, obj: std.json.ObjectMap) bool {
+    for (run_unsupported_keys) |key| {
+        if (obj.get(key) != null) {
+            logUnsupported(ctx, std.fmt.allocPrint(ctx.allocator, "run with {s}", .{key}) catch key);
+            return false;
+        }
+    }
+    // Only an explicit `false` — the compacted default — is a request malt can
+    // satisfy; malt never escalates.
+    if (obj.get("sudo")) |v| {
+        if (v != .bool or v.bool) {
+            logUnsupported(ctx, "run with sudo");
+            return false;
+        }
+    }
+    switch (evalGuards(ctx, obj)) {
+        .met => {},
+        .unmet => return true,
+        .unsupported => {
+            logUnsupported(ctx, "run with an unevaluable guard");
+            return false;
+        },
+    }
+
+    const cmd = resolveCommandPath(ctx, obj) orelse return false;
+    var argv: std.ArrayList([]const u8) = .empty;
+    argv.append(ctx.allocator, cmd) catch return false;
+    if (obj.get("args")) |args_val| {
+        if (args_val != .array) {
+            logUnsupported(ctx, "run with non-array args");
+            return false;
+        }
+        for (args_val.array.items) |item| {
+            const raw = switch (item) {
+                .string => |s| s,
+                else => {
+                    logUnsupported(ctx, "run with a non-string argument");
+                    return false;
+                },
+            };
+            const arg = expandTemplates(ctx, raw) catch return false;
+            argv.append(ctx.allocator, arg) catch return false;
+        }
+    }
+    // Lint before probing, so a traversal out of the keg reports as the
+    // confinement violation it is rather than as a missing file.
+    sandbox.validateArgv(argv.items, ctx.keg_path, ctx.prefix) catch {
+        logViolation(ctx, cmd);
+        return false;
+    };
+    if (!fileExists(ctx.io, cmd)) {
+        logCmdFail(ctx, std.fmt.allocPrint(ctx.allocator, "{s} not found", .{cmd}) catch cmd);
+        return false;
+    }
+    return spawnFenced(ctx, argv.items, null, std.fs.path.basename(cmd), .{});
 }
 
 // --- data-dir initialisers ---------------------------------------------------
@@ -1906,11 +2031,215 @@ test "supportedStepType matches the executable tier and rejects the rest" {
         "mkdir_p",                  "touch",                 "write",                     "symlink",
         "link_dir",                 "link_children",         "compile_gsettings_schemas", "gio_querymodules",
         "gdk_pixbuf_query_loaders", "gtk_update_icon_cache", "update_mime_database",      "update_desktop_database",
-        "init_data_dir",            "remove",                "inreplace",
+        "init_data_dir",            "remove",                "inreplace",                 "run",
     };
     for (native) |t| try testing.expect(supportedStepType(t));
     const routed = [_][]const u8{ "mkdir", "move", "move_children", "frobnicate" };
     for (routed) |t| try testing.expect(!supportedStepType(t));
+}
+
+/// Parse one step object out of its JSON literal, for the helpers that take an
+/// already-parsed step rather than a whole formula.
+fn parseStep(h: *TestHarness, json: []const u8) !std.json.ObjectMap {
+    const parsed = try std.json.parseFromSlice(std.json.Value, h.arena.allocator(), json, .{});
+    return parsed.value.object;
+}
+
+test "resolveCommandPath resolves a command base against the keg, not the prefix" {
+    // Upstream sends a command base through the Formula object, so `bin` here
+    // means `<keg>/bin` — the opposite of what the same token means as a path
+    // base. dbus (`bin/dbus-uuidgen`) and ca-certificates (`libexec/…`) would
+    // both reach the wrong file under prefix semantics.
+    var h = try TestHarness.init();
+    defer h.deinit();
+    const c = h.ctx();
+    const a = h.arena.allocator();
+
+    const cases = [_]struct { spec: []const u8, want: []const u8 }{
+        .{ .spec =
+        \\{"command":{"base":"bin","path":"dbus-uuidgen"}}
+        , .want = try std.fmt.allocPrint(a, "{s}/bin/dbus-uuidgen", .{h.keg}) },
+        .{ .spec =
+        \\{"command":{"base":"libexec","path":"post-install"}}
+        , .want = try std.fmt.allocPrint(a, "{s}/libexec/post-install", .{h.keg}) },
+        .{ .spec =
+        \\{"command":{"base":"sbin","path":"daemon"}}
+        , .want = try std.fmt.allocPrint(a, "{s}/sbin/daemon", .{h.keg}) },
+        .{ .spec =
+        \\{"command":{"base":"lib","path":"helper"}}
+        , .want = try std.fmt.allocPrint(a, "{s}/lib/helper", .{h.keg}) },
+        .{ .spec =
+        \\{"command":{"base":"prefix","path":"bin/tool"}}
+        , .want = try std.fmt.allocPrint(a, "{s}/bin/tool", .{h.keg}) },
+        // glib-networking ships a base-less absolute command carrying a token.
+        .{ .spec =
+        \\{"command":{"path":"{{HOMEBREW_PREFIX}}/opt/glib/bin/gio-querymodules"}}
+        , .want = try std.fmt.allocPrint(a, "{s}/opt/glib/bin/gio-querymodules", .{h.prefix}) },
+    };
+    for (cases) |case| {
+        const got = resolveCommandPath(c, try parseStep(&h, case.spec)) orelse return error.TestUnexpectedResult;
+        try testing.expectEqualStrings(case.want, got);
+    }
+    try testing.expect(!h.flog.hasErrors());
+
+    // A bare name would resolve through the fence's PATH; an empty or unknown
+    // base has no keg-relative meaning. All three refuse loudly.
+    const refused = [_][]const u8{
+        \\{"command":{"path":"fc-cache"}}
+        ,
+        \\{"command":{"base":"libexec","path":""}}
+        ,
+        \\{"command":{"base":"home","path":"tool"}}
+        ,
+        \\{"command":{"base":"bin"}}
+        ,
+        \\{"args":["x"]}
+        ,
+    };
+    for (refused) |spec| {
+        try testing.expect(resolveCommandPath(c, try parseStep(&h, spec)) == null);
+    }
+    try testing.expectEqual(@as(usize, refused.len), h.flog.entries().len);
+    for (h.flog.entries()) |e| try testing.expectEqual(fallback_log.FallbackReason.unknown_method, e.reason);
+}
+
+test "run executes the formula's own helper with its arguments expanded" {
+    // The debug Io cannot spawn (no allocator for the child argv), so this is
+    // the one step tier that needs a real threaded Io.
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    var h = try TestHarness.init();
+    defer h.deinit();
+    h.io = threaded.io();
+    const a = h.arena.allocator();
+
+    // A helper the keg "ships": a system tool whose effect is observable, so
+    // the assertion covers the resolved base and the expanded argument rather
+    // than just an exit code.
+    const libexec = try std.fmt.allocPrint(a, "{s}/libexec", .{h.keg});
+    try std.Io.Dir.cwd().createDirPath(h.io, libexec);
+    try std.Io.Dir.symLinkAbsolute(h.io, "/bin/mkdir", try std.fmt.allocPrint(a, "{s}/post-install", .{libexec}), .{});
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"run","command":{"base":"libexec","path":"post-install"},
+        \\  "args":["-p","{{var}}/lib/dbus"]}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqual(@as(usize, 1), h.flog.handled_top_level);
+
+    // The created directory proves the child saw an expanded argument.
+    try testing.expect(dirExists(h.io, try std.fmt.allocPrint(a, "{s}/var/lib/dbus", .{h.prefix})));
+}
+
+test "run refuses the execution fields malt does not honour" {
+    // Compaction drops defaults, so a key that survives into the JSON is one
+    // the formula meant. Running without honouring it would be a truncated
+    // command, so each refuses instead.
+    const refused = [_][]const u8{
+        \\[{"type":"run","command":{"base":"bin","path":"t"},"sudo":true}]
+        ,
+        \\[{"type":"run","command":{"base":"bin","path":"t"},"sudo":"yes"}]
+        ,
+        \\[{"type":"run","command":{"base":"bin","path":"t"},"env":{"LC_ALL":"C"}}]
+        ,
+        \\[{"type":"run","command":{"base":"bin","path":"t"},"chdir":"/tmp"}]
+        ,
+        \\[{"type":"run","command":{"base":"bin","path":"t"},"stdin_path":"/dev/null"}]
+        ,
+        \\[{"type":"run","command":{"base":"bin","path":"t"},"stdout_path":"/tmp/o"}]
+        ,
+        \\[{"type":"run","command":{"base":"bin","path":"t"},"writable_paths":["/tmp"]}]
+        ,
+        \\[{"type":"run","command":{"base":"bin","path":"t"},"args":"--all"}]
+        ,
+        \\[{"type":"run","command":{"base":"bin","path":"t"},"args":[7]}]
+        ,
+    };
+    for (refused) |steps_json| {
+        var h = try TestHarness.init();
+        defer h.deinit();
+        try testing.expect(execute(h.ctx(), try testFormulaJson(&h, steps_json)));
+        try testing.expect(h.flog.hasErrors());
+        try testing.expect(!h.flog.hasFatal());
+        try testing.expectEqual(@as(usize, 1), h.flog.entries().len);
+        try testing.expectEqual(fallback_log.FallbackReason.unknown_method, h.flog.entries()[0].reason);
+        try testing.expectEqual(@as(usize, 0), h.flog.handled_top_level);
+    }
+
+    // `sudo: false` is the default spelled out, not a refusal.
+    var h = try TestHarness.init();
+    defer h.deinit();
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"run","command":{"base":"bin","path":"t"},"sudo":false}]
+    )));
+    try testing.expectEqual(fallback_log.FallbackReason.system_command_failed, h.flog.entries()[0].reason);
+}
+
+test "run refuses a guard it cannot evaluate rather than reading it as a skip" {
+    // `unless_exists` and platform guards ship on real formulas. Treating an
+    // unevaluable condition as "declined to run" would turn a missing feature
+    // into a silent no-op — the exact failure the loud envelope exists for.
+    const unevaluable = [_][]const u8{
+        \\[{"type":"run","command":{"base":"bin","path":"t"},
+        \\  "guards":[{"base":"var","path":"rpm/rpmdb.sqlite","condition":"unless_exists","id":"1"}]}]
+        ,
+        \\[{"type":"run","command":{"base":"bin","path":"t"},
+        \\  "guards":[{"condition":"on","value":"macos","id":"1"}]}]
+        ,
+        \\[{"type":"run","command":{"base":"bin","path":"t"},
+        \\  "guards":[{"condition":"if_exists","id":"1"}]}]
+        ,
+    };
+    for (unevaluable) |steps_json| {
+        var h = try TestHarness.init();
+        defer h.deinit();
+        try testing.expect(execute(h.ctx(), try testFormulaJson(&h, steps_json)));
+        try testing.expectEqual(@as(usize, 1), h.flog.entries().len);
+        try testing.expectEqual(fallback_log.FallbackReason.unknown_method, h.flog.entries()[0].reason);
+    }
+}
+
+test "run declines quietly when an if_exists guard is unmet" {
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    // The command does not exist either; an unmet guard must short-circuit
+    // before that would be reported.
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"run","command":{"base":"bin","path":"t"},
+        \\  "guards":[{"path":"{{etc}}/absent.conf","condition":"if_exists","id":"1"}]}]
+    )));
+    try testing.expect(!h.flog.hasErrors());
+    try testing.expectEqual(@as(usize, 1), h.flog.handled_top_level);
+}
+
+test "run cannot escape the keg through its command path" {
+    // The base is keg-relative, so traversal in the path is the only way out;
+    // the shared argv lint catches it before anything spawns.
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"run","command":{"base":"libexec","path":"../../../../../usr/bin/killall"}},
+        \\ {"type":"mkdir_p","path":{"base":"var","path":"unreached"}}]
+    )));
+    try testing.expectEqual(fallback_log.FallbackReason.sandbox_violation, h.flog.entries()[0].reason);
+    // A violation is fatal, so the following step never ran.
+    try testing.expect(h.flog.hasFatal());
+    try testing.expect(!dirExists(h.io, try std.fmt.allocPrint(h.arena.allocator(), "{s}/var/unreached", .{h.prefix})));
+}
+
+test "run reports a command missing from the keg as a loud failure" {
+    // A helper the bottle should have shipped is a broken install, not an
+    // unsupported step — it must not read as "malt can't do this".
+    var h = try TestHarness.init();
+    defer h.deinit();
+
+    try testing.expect(execute(h.ctx(), try testFormulaJson(&h,
+        \\[{"type":"run","command":{"base":"libexec","path":"post-install"}}]
+    )));
+    try testing.expectEqual(@as(usize, 1), h.flog.entries().len);
+    try testing.expectEqual(fallback_log.FallbackReason.system_command_failed, h.flog.entries()[0].reason);
 }
 
 test "expandTemplates resolves the keg/prefix tokens that only existed as bases" {
@@ -1936,6 +2265,12 @@ test "expandTemplates resolves the keg/prefix tokens that only existed as bases"
     try testing.expectEqualStrings(
         try std.fmt.allocPrint(h.arena.allocator(), "{s}/share/glow", .{h.prefix}),
         try expandTemplates(c, "{{pkgshare}}"),
+    );
+    // dbus embeds `{{var}}` in a run argument; it resolved as a base but had
+    // no inline mapping, so the token reached the child verbatim.
+    try testing.expectEqualStrings(
+        try std.fmt.allocPrint(h.arena.allocator(), "{s}/var/lib/dbus", .{h.prefix}),
+        try expandTemplates(c, "{{var}}/lib/dbus"),
     );
     // `{{bin}}` must keep meaning the *keg's* bin: the template and base maps
     // disagree on that name on purpose, and merging them would repoint every


### PR DESCRIPTION
## Description

`run` is the step type formulas most often use to finish their own installation, and malt did not implement it. Every formula that declared one installed with a partial-skip warning and the command never executed - `ca-certificates` shipped the raw upstream trust store instead of the keychain-validated bundle its helper builds, and `fontconfig` never regenerated its cache. Thirty-three formulas were blocked by this step alone.

Commands now execute through the same argv lint and sandbox fence as every other spawn, with no extra grants. Command paths resolve against the keg (as upstream does) rather than the prefix, `{{var}}` expands inline instead of reaching the child verbatim, and anything malt cannot honour - elevation, a declared environment, redirection, a working directory, an uncheckable guard - refuses loudly rather than running a truncated command.

The doctor row that reported this is fixed alongside it: it now names the file it actually probes, and its suggested command creates the directory it links into and points at the bundle that exists, so pasting it works.

## Related Issue

- Closes #804

## Notes for Reviewers

- None