### PR TITLE
fix(relocation): report the paths a long prefix leaves pointing at the build prefix

### DIFF
--- a/scripts/regressions/unrelocatable-prefix-paths-are-surfaced.sh
+++ b/scripts/regressions/unrelocatable-prefix-paths-are-surfaced.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Regression: relocation rewrites a bottle's embedded paths in place, so a
+# string can shrink but never grow. A malt prefix longer than the prefix baked
+# into the bottle leaves those slots byte-identical — the keg keeps live
+# references to the build prefix and the package reads its config from a tree
+# malt does not own. fontconfig hit this: fc-cache read /opt/homebrew/etc/fonts
+# and failed on a cache dir it could not write.
+#
+# The patcher already detected this (`rewriteCstringSlot` returns `.skipped`
+# when the replacement is longer) and the count was discarded. Both halves of
+# the fix are pinned here:
+#   1. install warns, naming the keg and the prefix-length cause;
+#   2. `mt doctor` reports the affected package for a keg already on disk.
+#
+# Driven with a synthetic keg rather than a real install: no network, and the
+# embedded string is a fixture instead of whatever a bottle happens to ship.
+#
+# Exits 0 when both signals are present, non-zero (naming the missing one)
+# when either is absent. Finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+PREFIX=$(mktemp -d)/malt-prefix
+mkdir -p "$PREFIX"
+trap 'rm -rf "$(dirname "$PREFIX")"' EXIT
+
+export MALT_PREFIX="$PREFIX" NO_COLOR=1 MALT_NO_EMOJI=1 MALT_OFFLINE=1
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+# Relocation records its own verdict in a keg sidecar. Whether a bottle was
+# even eligible for the absolute rewrite depends on its `cellar` type, which
+# is not persisted, and the surviving strings look identical either way — so
+# the recorded verdict is what doctor reads, and what this seeds.
+KEG="$PREFIX/Cellar/probe/1.0"
+mkdir -p "$KEG/bin" "$PREFIX/store" "$PREFIX/opt" "$PREFIX/bin" "$PREFIX/db"
+printf '3\n' >"$KEG/.malt-unrelocated"
+
+# ── doctor reports the keg ───────────────────────────────────────────
+HUMAN=$("$BIN" doctor --verbose 2>&1 1>/dev/null || true)
+printf '%s' "$HUMAN" | grep -q 'Relocated prefix paths' ||
+  fail "doctor drew no 'Relocated prefix paths' row for a keg holding the build prefix"
+printf '%s' "$HUMAN" | grep -q 'probe 1.0' ||
+  fail "doctor's relocated-prefix row did not name the affected package"
+pass "doctor reports the package that kept the build prefix"
+
+JSON=$("$BIN" doctor --json 2>/dev/null || true)
+printf '%s' "$JSON" | grep -q '"id":"relocated_prefix_paths","severity":"warn"' ||
+  fail "doctor --json did not serialize a warn finding for relocated_prefix_paths"
+pass "doctor --json serializes the finding"
+
+# ── a keg relocation handled cleanly stays silent ────────────────────
+# Most bottles are `:any`, where the absolute rewrite is skipped by design
+# and nothing is ever dropped. Those must not be reported, however long the
+# prefix is — the earlier heuristic flagged jq and ripgrep here.
+rm -f "$KEG/.malt-unrelocated"
+CLEAN=$("$BIN" doctor --verbose 2>&1 1>/dev/null || true)
+if printf '%s' "$CLEAN" | grep -q 'Relocated prefix paths .*build prefix'; then
+  fail "a keg with no dropped paths was still reported"
+fi
+pass "a keg relocation handled cleanly stays silent"
+
+printf '\n✔ unrelocatable prefix paths are surfaced, not silently dropped\n'

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const mount_c = @import("c_mount");
 
 const AppCtx = @import("../app_ctx.zig").AppCtx;
+const cellar = @import("../core/cellar.zig");
 const patch = @import("../core/patch.zig");
 const perms_mod = @import("../core/perms.zig");
 const lock_mod = @import("../db/lock.zig");
@@ -124,6 +125,7 @@ pub const checks = [_]Check{
     .{ .name = "Missing kegs", .run = checkMissingKegs },
     .{ .name = "Broken symlinks", .run = checkBrokenSymlinks },
     .{ .name = "Mach-O placeholders", .run = checkMachOPlaceholders },
+    .{ .name = "Relocated prefix paths", .run = checkUnrelocatedPrefix },
     .{ .name = "Disk space", .run = checkDiskSpace },
     .{ .name = "Local formula sources", .run = checkLocalSources },
     .{ .name = "Dependency bin/sbin link census", .run = checkIsolationLeaks },
@@ -1049,55 +1051,61 @@ fn checkBrokenSymlinks(ctx: CheckCtx, name: []const u8) CheckResult {
     return .warn_status;
 }
 
-fn checkMachOPlaceholders(ctx: CheckCtx, name: []const u8) CheckResult {
-    var cellar_root_buf: [512]u8 = undefined;
-    const cellar_root = std.fmt.bufPrint(&cellar_root_buf, "{s}/Cellar", .{ctx.prefix}) catch {
-        printCheck(name, .ok, null);
-        return .ok;
-    };
+/// Per-file test a Cellar scan applies. Returning false on any I/O or parse
+/// error keeps every scan best-effort, matching the checks that use them.
+const KegFilePredicate = *const fn (ctx: CheckCtx, base_dir: *std.Io.Dir, rel_path: []const u8) bool;
 
-    var cellar_dir = std.Io.Dir.openDirAbsolute(ctx.io, cellar_root, .{ .iterate = true }) catch {
-        // No Cellar yet — nothing to scan.
-        printCheck(name, .ok, null);
-        return .ok;
-    };
+const KegGroups = std.StringArrayHashMapUnmanaged(void);
+
+/// Walk the Cellar and collect a `<package> <version>` key per keg holding at
+/// least one file that matches `predicate`. Grouping is the point: one keg can
+/// bundle hundreds of offending files (Python site-packages, LLVM tools), and
+/// the user acts on the package, not the file. Null means the Cellar could not
+/// be walked — distinct from "walked, found nothing". Caller owns the keys.
+fn collectOffendingKegs(ctx: CheckCtx, predicate: KegFilePredicate) ?KegGroups {
+    var cellar_root_buf: [512]u8 = undefined;
+    const cellar_root = std.fmt.bufPrint(&cellar_root_buf, "{s}/Cellar", .{ctx.prefix}) catch return null;
+
+    // No Cellar yet — nothing to scan, which is a clean result, not a failure.
+    var cellar_dir = std.Io.Dir.openDirAbsolute(ctx.io, cellar_root, .{ .iterate = true }) catch return .empty;
     defer cellar_dir.close(ctx.io);
 
-    var walker = cellar_dir.walk(ctx.allocator) catch {
+    var walker = cellar_dir.walk(ctx.allocator) catch return null;
+    defer walker.deinit();
+
+    var groups: KegGroups = .empty;
+    while (walker.next(ctx.io) catch null) |entry| {
+        if (entry.kind != .file) continue;
+        if (!predicate(ctx, &cellar_dir, entry.path)) continue;
+        // Best-effort: an allocator failure drops this entry rather than
+        // faking a clean result — the headline reads `groups.count()`, which
+        // only grows when the key actually lands.
+        const key = caskCellarKegKey(ctx.allocator, entry.path) orelse continue;
+        const gop = groups.getOrPut(ctx.allocator, key) catch {
+            ctx.allocator.free(key);
+            continue;
+        };
+        if (gop.found_existing) ctx.allocator.free(key);
+    }
+    return groups;
+}
+
+fn freeKegGroups(ctx: CheckCtx, groups: *KegGroups) void {
+    var it = groups.iterator();
+    while (it.next()) |kv| ctx.allocator.free(kv.key_ptr.*);
+    groups.deinit(ctx.allocator);
+}
+
+fn placeholderPredicate(ctx: CheckCtx, base_dir: *std.Io.Dir, rel_path: []const u8) bool {
+    return hasUnpatchedPlaceholder(ctx.io, ctx.allocator, base_dir, rel_path) catch false;
+}
+
+fn checkMachOPlaceholders(ctx: CheckCtx, name: []const u8) CheckResult {
+    var groups = collectOffendingKegs(ctx, placeholderPredicate) orelse {
         printCheck(name, .warn_status, "Could not walk Cellar tree");
         return .warn_status;
     };
-    defer walker.deinit();
-
-    // Group by `<package> <version>` so the headline reports the
-    // reinstall target — the user reinstalls the keg, not the file.
-    // A single keg can bundle hundreds of placeholder-bearing files
-    // (Python site-packages inside a meta-package, LLVM tools);
-    // counting files there inflates the number without adding
-    // actionable information.
-    var groups: std.StringArrayHashMapUnmanaged(void) = .empty;
-    defer {
-        var it = groups.iterator();
-        while (it.next()) |kv| ctx.allocator.free(kv.key_ptr.*);
-        groups.deinit(ctx.allocator);
-    }
-
-    while (walker.next(ctx.io) catch null) |entry| {
-        if (entry.kind != .file) continue;
-        if (hasUnpatchedPlaceholder(ctx.io, ctx.allocator, &cellar_dir, entry.path) catch false) {
-            // Grouping is best-effort: an allocator failure here
-            // drops the group entry, never silently triggers an
-            // .ok outcome — the headline is still right because
-            // it's derived from `groups.count()` which only grows
-            // when the entry actually lands.
-            const key = caskCellarKegKey(ctx.allocator, entry.path) orelse continue;
-            const gop = groups.getOrPut(ctx.allocator, key) catch {
-                ctx.allocator.free(key);
-                continue;
-            };
-            if (gop.found_existing) ctx.allocator.free(key);
-        }
-    }
+    defer freeKegGroups(ctx, &groups);
 
     if (groups.count() == 0) {
         printCheck(name, .ok, null);
@@ -1135,6 +1143,53 @@ fn checkMachOPlaceholders(ctx: CheckCtx, name: []const u8) CheckResult {
         writeVerboseList(lines.items);
     }
     return .err_status;
+}
+
+/// Relocation's own verdict — see `cellar.unrelocated_marker`. Scanning the
+/// kegs instead cannot work: a surviving `Cellar/<self>/share/…` is
+/// load-bearing in one bottle and inert build provenance in the next.
+fn unrelocatedMarkerPredicate(_: CheckCtx, _: *std.Io.Dir, rel_path: []const u8) bool {
+    // Anchored at `<name>/<version>/` so a package shipping a file of the
+    // same name deeper in its tree cannot fake the verdict.
+    var it = std.mem.splitScalar(u8, rel_path, '/');
+    _ = it.next() orelse return false;
+    _ = it.next() orelse return false;
+    const leaf = it.next() orelse return false;
+    if (it.next() != null) return false;
+    return std.mem.eql(u8, leaf, cellar.unrelocated_marker);
+}
+
+/// Kegs relocation could not fully rewrite, because the malt prefix is longer
+/// than the prefix baked into their bottle.
+fn checkUnrelocatedPrefix(ctx: CheckCtx, name: []const u8) CheckResult {
+    var groups = collectOffendingKegs(ctx, unrelocatedMarkerPredicate) orelse {
+        printCheck(name, .warn_status, "Could not walk Cellar tree");
+        return .warn_status;
+    };
+    defer freeKegGroups(ctx, &groups);
+
+    if (groups.count() == 0) {
+        printCheck(name, .ok, null);
+        return .ok;
+    }
+
+    var msg_buf: [512]u8 = undefined;
+    const msg = std.fmt.bufPrint(
+        &msg_buf,
+        "{d} package(s) still reference the build prefix — this prefix ({d} bytes) is too long for relocation to rewrite their embedded paths. Reinstall under a shorter prefix.",
+        .{ groups.count(), ctx.prefix.len },
+    ) catch "Packages still reference the build prefix; reinstall under a shorter prefix.";
+    printCheck(name, .warn_status, msg);
+    armVerboseHint();
+
+    if (output.isVerbose()) {
+        var lines: std.ArrayList([]const u8) = .empty;
+        defer lines.deinit(ctx.allocator);
+        var it = groups.iterator();
+        while (it.next()) |kv| lines.append(ctx.allocator, kv.key_ptr.*) catch continue;
+        writeVerboseList(lines.items);
+    }
+    return .warn_status;
 }
 
 fn checkDiskSpace(ctx: CheckCtx, name: []const u8) CheckResult {
@@ -1533,6 +1588,7 @@ test "findingId: slugifies a title into a stable lowercase id" {
         .{ .title = "Stale lock", .id = "stale_lock" },
         .{ .title = "Orphaned store entries", .id = "orphaned_store_entries" },
         .{ .title = "Mach-O placeholders", .id = "mach_o_placeholders" },
+        .{ .title = "Relocated prefix paths", .id = "relocated_prefix_paths" },
         .{ .title = "Dependency bin/sbin link census", .id = "dependency_bin_sbin_link_census" },
         .{ .title = "Prefix on PATH", .id = "prefix_on_path" },
     };
@@ -1577,6 +1633,19 @@ test "formatSslCertRemedy: a command that runs on the state the row fires in" {
     // truncated one the user would paste.
     var tiny: [8]u8 = undefined;
     try testing.expect(formatSslCertRemedy(&tiny, "/opt/malt") == null);
+}
+
+test "unrelocatedMarkerPredicate: matches the sidecar, not a keg's own files" {
+    const ctx: CheckCtx = undefined;
+    var dir: std.Io.Dir = undefined;
+
+    // The walk is Cellar-relative, so the predicate sees a nested path.
+    try testing.expect(unrelocatedMarkerPredicate(ctx, &dir, "fontconfig/2.18.3/" ++ cellar.unrelocated_marker));
+    try testing.expect(!unrelocatedMarkerPredicate(ctx, &dir, "fontconfig/2.18.3/bin/fc-cache"));
+    // A package shipping a similarly-named file must not be reported, at the
+    // keg root or anywhere below it.
+    try testing.expect(!unrelocatedMarkerPredicate(ctx, &dir, "x/1.0/.malt-unrelocated.bak"));
+    try testing.expect(!unrelocatedMarkerPredicate(ctx, &dir, "x/1.0/share/" ++ cellar.unrelocated_marker));
 }
 
 test "emitFixHintIfNeeded: silent without arming" {
@@ -1785,6 +1854,19 @@ test "checks table includes the mirror-overrides row" {
         }
     }
     try testing.expect(found);
+}
+
+test "checks table and json id list both carry the relocated-prefix row" {
+    // The row is the only signal a long prefix left packages reading from the
+    // build prefix; a table shuffle that drops either half hides it silently.
+    var in_checks = false;
+    for (checks) |c| {
+        if (std.mem.eql(u8, c.name, "Relocated prefix paths")) in_checks = true;
+    }
+    try testing.expect(in_checks);
+    const id = try findingId(testing.allocator, "Relocated prefix paths");
+    defer testing.allocator.free(id);
+    try testing.expectEqualStrings("relocated_prefix_paths", id);
 }
 
 test "pathContainsDir: matches a complete entry, ignores trailing slashes" {

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -254,6 +254,7 @@ fn walkMachOAndPatch(
     dir_path: []const u8,
     replacements: []const patch.Replacement,
     modified_out: *std.ArrayList([]const u8),
+    unrelocatable_out: *u32,
 ) CellarError!void {
     var dir = std.Io.Dir.openDirAbsolute(io, dir_path, .{ .iterate = true }) catch return;
     defer dir.close(io);
@@ -288,6 +289,8 @@ fn walkMachOAndPatch(
         var outcome = patch.patchPathsCollecting(io, allocator, full_path, replacements) catch
             continue;
         defer outcome.deinit(allocator);
+
+        unrelocatable_out.* += outcome.unrelocatable_count;
 
         if (outcome.overflow.len > 0) {
             patch.flushOverflow(io, allocator, full_path, outcome.overflow) catch |e| switch (e) {
@@ -382,6 +385,21 @@ pub fn cellarLinksPath(io: std.Io, allocator: std.mem.Allocator, cellar_path: []
 /// of whether it came from the store or a sibling brew install.
 /// `extra_replacement` is one caller-resolved substitution applied after the
 /// prefix-derived ones, for tokens this module cannot derive on its own.
+/// Count of embedded paths relocation could not rewrite. Recorded rather than
+/// re-derived later: whether a bottle was eligible for the absolute rewrite at
+/// all is decided here and nowhere else. Lives in the keg so it dies with it.
+pub const unrelocated_marker = ".malt-unrelocated";
+
+fn writeUnrelocatedMarker(io: std.Io, allocator: std.mem.Allocator, cellar_path: []const u8, count: u32) void {
+    const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ cellar_path, unrelocated_marker }) catch return;
+    defer allocator.free(path);
+    const body = std.fmt.allocPrint(allocator, "{d}\n", .{count}) catch return;
+    defer allocator.free(body);
+    // Best-effort: the warning already fired, so a failed write costs the
+    // doctor row, not the install.
+    atomic.atomicWriteFile(io, path, body) catch {};
+}
+
 fn relocateKegTree(
     io: std.Io,
     allocator: std.mem.Allocator,
@@ -422,18 +440,33 @@ fn relocateKegTree(
         modified_macho_paths.deinit(allocator);
     }
 
+    var unrelocatable: u32 = 0;
     walkMachOAndPatch(
         io,
         allocator,
         cellar_path,
         macho_reps_buf[0..macho_reps_len],
         &modified_macho_paths,
+        &unrelocatable,
     ) catch |e| switch (e) {
         CellarError.PathTooLong => return CellarError.PathTooLong,
         CellarError.InsufficientHeaderPad => return CellarError.InsufficientHeaderPad,
         CellarError.InstallNameToolMissing => return CellarError.InstallNameToolMissing,
         else => return CellarError.PatchFailed,
     };
+
+    // An embedded string can only shrink in place, so a prefix longer than
+    // the bottled one leaves live references to the build prefix behind. The
+    // package then reads config from a directory malt does not own and fails
+    // in ways that look unrelated to the prefix — say so, and record it so
+    // doctor can still report the keg once this line has scrolled away.
+    if (unrelocatable > 0) {
+        std.log.warn(
+            "{s}: {d} embedded path(s) still point at the build prefix — the malt prefix ({d} bytes) is longer than the one baked into the bottle; a shorter prefix relocates them",
+            .{ cellar_path, unrelocatable, new_prefix.len },
+        );
+        writeUnrelocatedMarker(io, allocator, cellar_path, unrelocatable);
+    }
 
     // Last on purpose: `patchTextFiles` runs sequential passes, so appending
     // keeps the substituted path out of the prefix rewrites above.

--- a/src/core/relocated_store.zig
+++ b/src/core/relocated_store.zig
@@ -42,7 +42,11 @@ pub const RelocatedStoreError = error{
 /// v3: relocation gained dependency-scoped placeholder substitution. v2 entries
 /// cached the literal token, so an affected wrapper restored from one stays
 /// broken however many times it is reinstalled.
-pub const RELOC_LOGIC_VERSION: u32 = 3;
+///
+/// v4: relocation records the paths it could not rewrite in a keg sidecar.
+/// v3 trees carry no sidecar, so a keg restored from one reads as clean
+/// however badly its embedded paths were dropped.
+pub const RELOC_LOGIC_VERSION: u32 = 4;
 
 /// Reject anything that is not exactly 64 lowercase hex characters.
 /// Run this before forming any path so traversal sequences (`..`, `/`) and

--- a/src/macho/patcher.zig
+++ b/src/macho/patcher.zig
@@ -41,6 +41,13 @@ pub const OverflowEntry = struct {
 pub const PatchOutcome = struct {
     patched_count: u32,
     skipped_count: u32,
+    /// `__cstring` slots that carry a prefix relocation was meant to
+    /// rewrite but could not, because the new prefix is longer than the
+    /// bottled one. Distinct from `skipped_count`, which also counts load
+    /// commands that simply matched no replacement — the common case.
+    /// A non-zero value means the keg keeps live references to the build
+    /// prefix, so the caller must say so rather than record a clean install.
+    unrelocatable_count: u32,
     /// Slots that exceeded their cmd slot. Empty for the fast path.
     overflow: []OverflowEntry,
 
@@ -194,10 +201,12 @@ pub fn patchPathsCollecting(
         patched += 1;
     }
 
+    var unrelocatable: u32 = 0;
     for (macho.cstrings) |region| {
         const counts = patchCstringRegion(data, region, replacements);
         patched += counts.patched;
         skipped += counts.skipped;
+        unrelocatable += counts.skipped;
     }
 
     if (patched > 0) {
@@ -207,6 +216,7 @@ pub fn patchPathsCollecting(
     return .{
         .patched_count = patched,
         .skipped_count = skipped,
+        .unrelocatable_count = unrelocatable,
         .overflow = overflow.toOwnedSlice(allocator) catch return PatchError.OutOfMemory,
     };
 }

--- a/tests/macho_test.zig
+++ b/tests/macho_test.zig
@@ -478,6 +478,76 @@ test "parse a Mach-O 64 with __TEXT,__cstring captures the section region" {
     try testing.expectEqual(@as(usize, blob.len), m.cstrings[0].size);
 }
 
+/// Write a one-`__cstring`-section Mach-O carrying `blob` and patch it.
+/// Returns the outcome so a caller can assert on the relocation verdict.
+fn patchCstringFixture(
+    io: std.Io,
+    scratch: *Scratch,
+    blob: []const u8,
+    replacements: []const patcher.Replacement,
+) !patcher.PatchOutcome {
+    const cstring_offset = @sizeOf(macho.mach_header_64) + @sizeOf(macho.segment_command_64) + @sizeOf(macho.section_64);
+    var sect: macho.section_64 = .{
+        .sectname = [_]u8{0} ** 16,
+        .segname = [_]u8{0} ** 16,
+        .offset = @intCast(cstring_offset),
+        .size = blob.len,
+        .flags = macho.S_CSTRING_LITERALS,
+    };
+    @memcpy(sect.sectname[0.."__cstring".len], "__cstring");
+    @memcpy(sect.segname[0.."__TEXT".len], "__TEXT");
+
+    const buf = try buildSegmentFixture(testing.allocator, &.{sect}, blob);
+    defer testing.allocator.free(buf);
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, "{s}/fixture.bin", .{scratch.path});
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, path, .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, buf);
+    }
+    return patcher.patchPathsCollecting(io, testing.allocator, path, replacements);
+}
+
+test "an embedded path relocation cannot grow into is counted, not silently kept" {
+    // The count is the only signal that a keg still points at the build
+    // prefix: the slot is left byte-identical, so nothing downstream can
+    // tell the difference by looking at the file.
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var scratch = try Scratch.init("cstring_unrelocatable");
+    defer scratch.deinit();
+
+    const blob = "/opt/homebrew/etc/fonts\x00";
+
+    // Longer replacement: cannot fit the fixed slot.
+    var grew = try patchCstringFixture(io, &scratch, blob, &.{
+        .{ .old = "/opt/homebrew", .new = "/tmp/a-much-longer-prefix" },
+    });
+    defer grew.deinit(testing.allocator);
+    try testing.expectEqual(@as(u32, 1), grew.unrelocatable_count);
+    try testing.expectEqual(@as(u32, 0), grew.patched_count);
+
+    // Shorter replacement: fits, so nothing is left pointing at the build prefix.
+    var shrank = try patchCstringFixture(io, &scratch, blob, &.{
+        .{ .old = "/opt/homebrew", .new = "/opt/malt" },
+    });
+    defer shrank.deinit(testing.allocator);
+    try testing.expectEqual(@as(u32, 0), shrank.unrelocatable_count);
+    try testing.expectEqual(@as(u32, 1), shrank.patched_count);
+
+    // A slot naming no configured prefix is untouched, not a near miss —
+    // otherwise every unrelated string would read as damage.
+    var absent = try patchCstringFixture(io, &scratch, "/usr/share/zoneinfo\x00", &.{
+        .{ .old = "/opt/homebrew", .new = "/tmp/a-much-longer-prefix" },
+    });
+    defer absent.deinit(testing.allocator);
+    try testing.expectEqual(@as(u32, 0), absent.unrelocatable_count);
+}
+
 test "parse a Mach-O 64 ignores non-cstring sections in the same segment" {
     const blob = "anything\x00";
     const cstring_offset = @sizeOf(macho.mach_header_64) + @sizeOf(macho.segment_command_64) + 2 * @sizeOf(macho.section_64);


### PR DESCRIPTION
## Description

Relocation rewrites a bottle's embedded paths in place, so a string can shrink but never grow. A malt prefix longer than the one baked into the bottle leaves those references pointing at the build prefix, and the package then reads its data from a tree malt does not own. `fontconfig` fails exactly this way, with nothing in the output connecting it to the prefix.

The patcher already detected this and threw the count away. It is now surfaced twice: a warning naming the keg at install time, and a `mt doctor` row for kegs already on disk. The install still succeeds - some dropped paths are inert, and refusing would reject packages that work today.

## Related Issue

- None

## Notes for Reviewers

- Doctor reads a verdict recorded by relocation rather than scanning kegs itself. Scanning cannot work: whether a bottle was eligible for the absolute rewrite depends on its `cellar` type, which is not persisted, and the surviving strings are indistinguishable either way - a `Cellar/<self>/share/...` reference is load-bearing in one bottle and inert build provenance in the next. An earlier scanning version of this row flagged `jq` and `ripgrep` while missing `gettext`.
- `RELOC_LOGIC_VERSION` is bumped so cached trees predating the sidecar are re-relocated. Kegs installed before this lands carry no sidecar and get no row until their next upgrade; re-relocating them could not repair anything anyway, since the paths still would not fit.