### PR TITLE
fix(relocation): report kegs left behind when relocation logic changes

### DIFF
--- a/scripts/regressions/relocated-store-logic-version.pin
+++ b/scripts/regressions/relocated-store-logic-version.pin
@@ -1,2 +1,2 @@
-version=3
-digest=f1ed07e25bc179c84b72e73b3a8903e6afd9ba3745f5d4a9a44773feacc2f8f9
+version=5
+digest=1d49d5c5d292ca31596d55fdf5b40a672451b9cb3a3bb99da0bc0e82f4274ecb

--- a/scripts/regressions/relocated-store-logic-version.pin
+++ b/scripts/regressions/relocated-store-logic-version.pin
@@ -1,2 +1,2 @@
 version=5
-digest=5bd8ecd92a6ede248e4cdef039468b1e071a7ccd9c47714ced3980e0ec8ccbf4
+digest=52ba3520914f7b1f7db180026eb7da8cd022cd9428f6c6c146cee3592f6a789a

--- a/scripts/regressions/relocated-store-logic-version.pin
+++ b/scripts/regressions/relocated-store-logic-version.pin
@@ -1,2 +1,2 @@
 version=5
-digest=1d49d5c5d292ca31596d55fdf5b40a672451b9cb3a3bb99da0bc0e82f4274ecb
+digest=5bd8ecd92a6ede248e4cdef039468b1e071a7ccd9c47714ced3980e0ec8ccbf4

--- a/scripts/regressions/stale-relocation-is-reported.sh
+++ b/scripts/regressions/stale-relocation-is-reported.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Regression: relocation rules change over time, and a keg materialised under
+# older rules keeps whatever paths those rules produced. `wget` installed
+# before the Mach-O string pass existed still reads `/opt/homebrew/etc/wgetrc`
+# - it links and runs, so nothing surfaces the staleness.
+#
+# Relocation now stamps each keg with the logic version that produced it, and
+# doctor reports kegs left behind by a later bump. The keg's own contents
+# cannot answer this: a relocatable bottle legitimately keeps build-prefix
+# strings, so only the recorded version separates the two cases.
+#
+# Pinned behaviour:
+#   1. a keg stamped with the current version is silent;
+#   2. a keg stamped with an older version is reported, by name, in both the
+#      human and json views;
+#   3. a keg with no stamp at all is silent - it predates tracking, and
+#      "reinstall everything" is a guess, not a diagnosis.
+#
+# Exits 0 when all three hold, non-zero naming the failed one. No network.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+
+PREFIX=$(mktemp -d)/malt-prefix
+mkdir -p "$PREFIX"
+trap 'rm -rf "$(dirname "$PREFIX")"' EXIT
+
+export MALT_PREFIX="$PREFIX" NO_COLOR=1 MALT_NO_EMOJI=1 MALT_OFFLINE=1
+
+pass() { printf '  ✓ %s\n' "$*"; }
+fail() {
+  printf '  ✗ %s\n' "$*" >&2
+  exit 1
+}
+
+MARKER=.malt-reloc-version
+CUR=$(grep -oE 'RELOC_LOGIC_VERSION: u32 = [0-9]+' "$ROOT/src/core/relocated_store.zig" | grep -oE '[0-9]+$')
+[[ -n "$CUR" ]] || fail "could not read the current relocation logic version"
+
+KEG="$PREFIX/Cellar/probe/1.0"
+mkdir -p "$KEG/bin" "$PREFIX/store" "$PREFIX/db"
+
+# doctor exits non-zero once it warns, so every capture tolerates that -
+# under `pipefail` an untolerated exit fails the assertion, not the check.
+row() {
+  local out
+  out=$("$BIN" doctor --verbose 2>&1 1>/dev/null || true)
+  printf '%s' "$out"
+}
+json() { "$BIN" doctor --json 2>/dev/null || true; }
+
+# ── 1. current stamp → silent ────────────────────────────────────────
+printf '%s\n' "$CUR" >"$KEG/$MARKER"
+if row | grep -q 'Relocation freshness .*older malt'; then
+  fail "a keg stamped with the current version was still reported"
+fi
+pass "a keg relocated by the current logic is silent"
+
+# ── 2. older stamp → reported by name ────────────────────────────────
+printf '%s\n' "$((CUR - 1))" >"$KEG/$MARKER"
+HUMAN=$(row)
+printf '%s' "$HUMAN" | grep -q 'Relocation freshness .*older malt' ||
+  fail "a keg stamped with an older version drew no warning"
+printf '%s' "$HUMAN" | grep -q 'probe 1.0' ||
+  fail "the relocation-freshness row did not name the affected keg"
+json | grep -q '"id":"relocation_freshness","severity":"warn"' ||
+  fail "doctor --json did not serialize a warn finding for relocation_freshness"
+pass "a keg relocated by older logic is reported by name"
+
+# ── 3. no stamp → silent ─────────────────────────────────────────────
+# Every keg installed before this shipped is unstamped. Reporting them would
+# recommend reinstalling the whole prefix on the strength of a guess.
+rm -f "$KEG/$MARKER"
+if row | grep -q 'Relocation freshness .*older malt'; then
+  fail "an unstamped keg was reported as stale"
+fi
+pass "a keg predating the stamp is silent"
+
+printf '\n✔ stale relocation is reported, unknown relocation is not\n'

--- a/scripts/regressions/stale-relocation-is-reported.sh
+++ b/scripts/regressions/stale-relocation-is-reported.sh
@@ -73,7 +73,17 @@ json | grep -q '"id":"relocation_freshness","severity":"warn"' ||
   fail "doctor --json did not serialize a warn finding for relocation_freshness"
 pass "a keg relocated by older logic is reported by name"
 
-# ── 3. no stamp → silent ─────────────────────────────────────────────
+# ── 3. "relocation never ran" → silent at any version ────────────────
+# Kegs extracted from a tap archive are never relocated, so no bump can
+# leave them behind. Stamping that positively keeps them out of the row
+# instead of relying on the absent-stamp case below.
+printf 'n/a\n' >"$KEG/$MARKER"
+if row | grep -q 'Relocation freshness .*older malt'; then
+  fail "a keg marked as never-relocated was reported as stale"
+fi
+pass "a keg relocation never applied to is silent"
+
+# ── 4. no stamp → silent ─────────────────────────────────────────────
 # Every keg installed before this shipped is unstamped. Reporting them would
 # recommend reinstalling the whole prefix on the strength of a guess.
 rm -f "$KEG/$MARKER"

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -1181,12 +1181,14 @@ fn checkRelocationFreshness(ctx: CheckCtx, name: []const u8) CheckResult {
             if (ver.kind != .directory) continue;
             var keg_buf: [512]u8 = undefined;
             const keg = std.fmt.bufPrint(&keg_buf, "{s}/{s}/{s}", .{ cellar_root, pkg.name, ver.name }) catch continue;
-            // No marker means the keg predates relocation tracking, not that
-            // it is stale — malt cannot tell which logic built it. Flagging
-            // every such keg would recommend reinstalling the whole prefix on
-            // the strength of a guess.
-            const got = cellar.readKegMarker(ctx.io, keg, cellar.reloc_version_marker) orelse continue;
-            if (got >= relocated_store.RELOC_LOGIC_VERSION) continue;
+            // An absent stamp means the keg predates stamping, not that it is
+            // stale — flagging those would recommend reinstalling the whole
+            // prefix on a guess. `not_applicable` never goes stale at all.
+            const stamp = cellar.readRelocStamp(ctx.io, keg) orelse continue;
+            switch (stamp) {
+                .not_applicable => continue,
+                .version => |v| if (v >= relocated_store.RELOC_LOGIC_VERSION) continue,
+            }
             const key = std.fmt.allocPrint(ctx.allocator, "{s} {s}", .{ pkg.name, ver.name }) catch continue;
             stale.append(ctx.allocator, key) catch {
                 ctx.allocator.free(key);

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -7,6 +7,7 @@ const mount_c = @import("c_mount");
 
 const AppCtx = @import("../app_ctx.zig").AppCtx;
 const cellar = @import("../core/cellar.zig");
+const relocated_store = @import("../core/relocated_store.zig");
 const patch = @import("../core/patch.zig");
 const perms_mod = @import("../core/perms.zig");
 const lock_mod = @import("../db/lock.zig");
@@ -126,6 +127,7 @@ pub const checks = [_]Check{
     .{ .name = "Broken symlinks", .run = checkBrokenSymlinks },
     .{ .name = "Mach-O placeholders", .run = checkMachOPlaceholders },
     .{ .name = "Relocated prefix paths", .run = checkUnrelocatedPrefix },
+    .{ .name = "Relocation freshness", .run = checkRelocationFreshness },
     .{ .name = "Disk space", .run = checkDiskSpace },
     .{ .name = "Local formula sources", .run = checkLocalSources },
     .{ .name = "Dependency bin/sbin link census", .run = checkIsolationLeaks },
@@ -1145,6 +1147,70 @@ fn checkMachOPlaceholders(ctx: CheckCtx, name: []const u8) CheckResult {
     return .err_status;
 }
 
+/// Kegs whose relocation predates the current logic. Their embedded paths were
+/// rewritten by rules malt has since corrected, so they can still name the
+/// build prefix — `wget` reading `/opt/homebrew/etc/wgetrc` is the shape of it.
+/// The marker is the only sound signal: a relocatable bottle legitimately keeps
+/// build-prefix strings, so the keg's contents cannot distinguish the two.
+fn checkRelocationFreshness(ctx: CheckCtx, name: []const u8) CheckResult {
+    var cellar_root_buf: [512]u8 = undefined;
+    const cellar_root = std.fmt.bufPrint(&cellar_root_buf, "{s}/Cellar", .{ctx.prefix}) catch {
+        printCheck(name, .ok, null);
+        return .ok;
+    };
+    var cellar_dir = std.Io.Dir.openDirAbsolute(ctx.io, cellar_root, .{ .iterate = true }) catch {
+        printCheck(name, .ok, null);
+        return .ok;
+    };
+    defer cellar_dir.close(ctx.io);
+
+    var stale: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (stale.items) |s| ctx.allocator.free(s);
+        stale.deinit(ctx.allocator);
+    }
+
+    var names = cellar_dir.iterate();
+    while (names.next(ctx.io) catch null) |pkg| {
+        if (pkg.kind != .directory) continue;
+        var pkg_dir = cellar_dir.openDir(ctx.io, pkg.name, .{ .iterate = true }) catch continue;
+        defer pkg_dir.close(ctx.io);
+
+        var versions = pkg_dir.iterate();
+        while (versions.next(ctx.io) catch null) |ver| {
+            if (ver.kind != .directory) continue;
+            var keg_buf: [512]u8 = undefined;
+            const keg = std.fmt.bufPrint(&keg_buf, "{s}/{s}/{s}", .{ cellar_root, pkg.name, ver.name }) catch continue;
+            // No marker means the keg predates relocation tracking, not that
+            // it is stale — malt cannot tell which logic built it. Flagging
+            // every such keg would recommend reinstalling the whole prefix on
+            // the strength of a guess.
+            const got = cellar.readKegMarker(ctx.io, keg, cellar.reloc_version_marker) orelse continue;
+            if (got >= relocated_store.RELOC_LOGIC_VERSION) continue;
+            const key = std.fmt.allocPrint(ctx.allocator, "{s} {s}", .{ pkg.name, ver.name }) catch continue;
+            stale.append(ctx.allocator, key) catch {
+                ctx.allocator.free(key);
+                continue;
+            };
+        }
+    }
+
+    if (stale.items.len == 0) {
+        printCheck(name, .ok, null);
+        return .ok;
+    }
+    var msg_buf: [512]u8 = undefined;
+    const msg = std.fmt.bufPrint(
+        &msg_buf,
+        "{d} keg(s) were relocated by an older malt and may still reference the build prefix. Reinstall them to refresh: mt reinstall <name>",
+        .{stale.items.len},
+    ) catch "Some kegs were relocated by an older malt; reinstall them to refresh.";
+    printCheck(name, .warn_status, msg);
+    armVerboseHint();
+    if (output.isVerbose()) writeVerboseList(stale.items);
+    return .warn_status;
+}
+
 /// Relocation's own verdict — see `cellar.unrelocated_marker`. Scanning the
 /// kegs instead cannot work: a surviving `Cellar/<self>/share/…` is
 /// load-bearing in one bottle and inert build provenance in the next.
@@ -1589,6 +1655,7 @@ test "findingId: slugifies a title into a stable lowercase id" {
         .{ .title = "Orphaned store entries", .id = "orphaned_store_entries" },
         .{ .title = "Mach-O placeholders", .id = "mach_o_placeholders" },
         .{ .title = "Relocated prefix paths", .id = "relocated_prefix_paths" },
+        .{ .title = "Relocation freshness", .id = "relocation_freshness" },
         .{ .title = "Dependency bin/sbin link census", .id = "dependency_bin_sbin_link_census" },
         .{ .title = "Prefix on PATH", .id = "prefix_on_path" },
     };
@@ -1633,6 +1700,17 @@ test "formatSslCertRemedy: a command that runs on the state the row fires in" {
     // truncated one the user would paste.
     var tiny: [8]u8 = undefined;
     try testing.expect(formatSslCertRemedy(&tiny, "/opt/malt") == null);
+}
+
+test "checks table and json id list both carry the relocation-freshness row" {
+    var in_checks = false;
+    for (checks) |c| {
+        if (std.mem.eql(u8, c.name, "Relocation freshness")) in_checks = true;
+    }
+    try testing.expect(in_checks);
+    const id = try findingId(testing.allocator, "Relocation freshness");
+    defer testing.allocator.free(id);
+    try testing.expectEqualStrings("relocation_freshness", id);
 }
 
 test "unrelocatedMarkerPredicate: matches the sidecar, not a keg's own files" {

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -8,6 +8,7 @@ const std = @import("std");
 
 const AppCtx = @import("../../app_ctx.zig").AppCtx;
 const cask_mod = @import("../../core/cask.zig");
+const cellar_mod = @import("../../core/cellar.zig");
 const hash = @import("../../core/hash.zig");
 const linker_mod = @import("../../core/linker.zig");
 const tap_mod = @import("../../core/tap.zig");
@@ -739,6 +740,10 @@ pub fn materializeRubyFormula(
             return InstallError.CellarFailed;
         },
     }
+
+    // This path never relocates, so nothing overwrites a marker the archive
+    // shipped — and a forged one would let its author drive doctor's verdict.
+    cellar_mod.stripKegMarkers(ctx.io, cellar_path);
 
     // Promote the binary to bin/ (GoReleaser may extract directly or
     // into a subdirectory — walk to handle both). For casks that

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -744,6 +744,8 @@ pub fn materializeRubyFormula(
     // This path never relocates, so nothing overwrites a marker the archive
     // shipped — and a forged one would let its author drive doctor's verdict.
     cellar_mod.stripKegMarkers(ctx.io, cellar_path);
+    // Positively "relocation never ran", so no future bump names this keg.
+    cellar_mod.writeRelocStamp(ctx.io, allocator, cellar_path, .not_applicable);
 
     // Promote the binary to bin/ (GoReleaser may extract directly or
     // into a subdirectory — walk to handle both). For casks that

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -391,13 +391,36 @@ pub fn cellarLinksPath(io: std.Io, allocator: std.mem.Allocator, cellar_path: []
 pub const unrelocated_marker = ".malt-unrelocated";
 
 fn writeUnrelocatedMarker(io: std.Io, allocator: std.mem.Allocator, cellar_path: []const u8, count: u32) void {
-    const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ cellar_path, unrelocated_marker }) catch return;
+    writeKegMarker(io, allocator, cellar_path, unrelocated_marker, count);
+}
+
+/// Relocation logic that produced this keg. Written on every relocation, so a
+/// keg materialised by an older malt is distinguishable from a current one —
+/// the bottle itself carries no such signal, and the surviving paths cannot
+/// tell the two apart (a relocatable bottle legitimately keeps build-prefix
+/// strings). Kegs predating this marker read as stale, which they are.
+pub const reloc_version_marker = ".malt-reloc-version";
+
+fn writeKegMarker(io: std.Io, allocator: std.mem.Allocator, cellar_path: []const u8, name: []const u8, value: u32) void {
+    const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ cellar_path, name }) catch return;
     defer allocator.free(path);
-    const body = std.fmt.allocPrint(allocator, "{d}\n", .{count}) catch return;
+    const body = std.fmt.allocPrint(allocator, "{d}\n", .{value}) catch return;
     defer allocator.free(body);
-    // Best-effort: the warning already fired, so a failed write costs the
-    // doctor row, not the install.
+    // Best-effort: a failed write costs a doctor row, never the install.
     atomic.atomicWriteFile(io, path, body) catch {};
+}
+
+/// Read a keg marker's `u32`, or null when absent or malformed.
+pub fn readKegMarker(io: std.Io, cellar_path: []const u8, name: []const u8) ?u32 {
+    var path_buf: [512]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ cellar_path, name }) catch return null;
+    const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return null;
+    defer file.close(io);
+    var buf: [32]u8 = undefined;
+    // Short read is the normal case: the marker is a few digits.
+    const n = file.readPositional(io, &.{&buf}, 0) catch return null;
+    const text = std.mem.trim(u8, buf[0..n], " \t\r\n");
+    return std.fmt.parseInt(u32, text, 10) catch null;
 }
 
 fn relocateKegTree(
@@ -498,6 +521,9 @@ fn relocateKegTree(
     // After text patching, so the poured configs already carry the malt
     // prefix instead of the bottled `/opt/homebrew` paths.
     installBottleEtcVar(io, allocator, cellar_path, new_prefix);
+
+    // Last: only a keg that got this far was relocated by this logic.
+    writeKegMarker(io, allocator, cellar_path, reloc_version_marker, relocated_store.RELOC_LOGIC_VERSION);
 }
 
 /// Pour the bottle's `.bottle/etc` and `.bottle/var` overlay into the
@@ -775,6 +801,39 @@ pub fn remove(io: std.Io, prefix: []const u8, name: []const u8, version: []const
 
 // Pins the describeError split: only the user-actionable mappings carry
 // prose; every other tag falls through to @errorName.
+test "keg markers round-trip, and a missing or malformed one reads as absent" {
+    const testing = std.testing;
+    const io = std.Options.debug_io;
+
+    var s = try Scratch.init("keg_marker");
+    defer s.deinit();
+    const keg = s.p("/Cellar/glow/1.2.3");
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+
+    // Absent: the only signal that a keg predates marker tracking, so it must
+    // never read as a version.
+    try testing.expect(readKegMarker(io, keg, reloc_version_marker) == null);
+
+    writeKegMarker(io, testing.allocator, keg, reloc_version_marker, 4);
+    try testing.expectEqual(@as(?u32, 4), readKegMarker(io, keg, reloc_version_marker));
+
+    // Trailing newline is how the marker is written; leading space and CRLF
+    // cover a hand-edited file.
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ keg, reloc_version_marker });
+    defer testing.allocator.free(path);
+    try atomic.atomicWriteFile(io, path, " 12 \r\n");
+    try testing.expectEqual(@as(?u32, 12), readKegMarker(io, keg, reloc_version_marker));
+
+    // Garbage must not be coerced to a version — a bogus 0 would flag every
+    // keg as stale.
+    try atomic.atomicWriteFile(io, path, "v4\n");
+    try testing.expect(readKegMarker(io, keg, reloc_version_marker) == null);
+    try atomic.atomicWriteFile(io, path, "");
+    try testing.expect(readKegMarker(io, keg, reloc_version_marker) == null);
+    try atomic.atomicWriteFile(io, path, "99999999999999999999\n");
+    try testing.expect(readKegMarker(io, keg, reloc_version_marker) == null);
+}
+
 test "describeError: action-hint tags keep prose, trivial tags fall back to @errorName" {
     try std.testing.expect(std.mem.indexOf(u8, describeError(CellarError.InsufficientHeaderPad), "-headerpad_max_install_names") != null);
     try std.testing.expect(std.mem.indexOf(u8, describeError(CellarError.InstallNameToolMissing), "install_name_tool not found on PATH") != null);

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -410,6 +410,20 @@ fn writeKegMarker(io: std.Io, allocator: std.mem.Allocator, cellar_path: []const
     atomic.atomicWriteFile(io, path, body) catch {};
 }
 
+/// Marker names malt owns inside a keg. Relocation rewrites them last, so a
+/// bottle cannot forge one — but a path that extracts an archive without
+/// relocating must strip them, or the archive's author decides what doctor
+/// reports about the keg.
+pub const keg_markers = [_][]const u8{ unrelocated_marker, reloc_version_marker };
+
+pub fn stripKegMarkers(io: std.Io, cellar_path: []const u8) void {
+    for (keg_markers) |name| {
+        var buf: [512]u8 = undefined;
+        const path = std.fmt.bufPrint(&buf, "{s}/{s}", .{ cellar_path, name }) catch continue;
+        std.Io.Dir.cwd().deleteFile(io, path) catch {};
+    }
+}
+
 /// Read a keg marker's `u32`, or null when absent or malformed.
 pub fn readKegMarker(io: std.Io, cellar_path: []const u8, name: []const u8) ?u32 {
     var path_buf: [512]u8 = undefined;
@@ -832,6 +846,33 @@ test "keg markers round-trip, and a missing or malformed one reads as absent" {
     try testing.expect(readKegMarker(io, keg, reloc_version_marker) == null);
     try atomic.atomicWriteFile(io, path, "99999999999999999999\n");
     try testing.expect(readKegMarker(io, keg, reloc_version_marker) == null);
+}
+
+test "stripKegMarkers clears a marker the extracted archive supplied" {
+    const testing = std.testing;
+    const io = std.Options.debug_io;
+
+    var s = try Scratch.init("strip_markers");
+    defer s.deinit();
+    const keg = s.p("/Cellar/glow/1.2.3");
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+
+    // An archive that ships a stamp would otherwise decide what doctor says
+    // about the keg — a high one silences it, a low one warns forever, since
+    // the path that extracted it never relocates and so never restamps.
+    for (keg_markers) |name| {
+        const p = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ keg, name });
+        defer testing.allocator.free(p);
+        try atomic.atomicWriteFile(io, p, "999\n");
+    }
+    try testing.expectEqual(@as(?u32, 999), readKegMarker(io, keg, reloc_version_marker));
+
+    stripKegMarkers(io, keg);
+    for (keg_markers) |name| {
+        try testing.expect(readKegMarker(io, keg, name) == null);
+    }
+    // Idempotent: the strip runs on every such install, most with no markers.
+    stripKegMarkers(io, keg);
 }
 
 test "describeError: action-hint tags keep prose, trivial tags fall back to @errorName" {

--- a/src/core/cellar.zig
+++ b/src/core/cellar.zig
@@ -394,20 +394,56 @@ fn writeUnrelocatedMarker(io: std.Io, allocator: std.mem.Allocator, cellar_path:
     writeKegMarker(io, allocator, cellar_path, unrelocated_marker, count);
 }
 
-/// Relocation logic that produced this keg. Written on every relocation, so a
-/// keg materialised by an older malt is distinguishable from a current one —
-/// the bottle itself carries no such signal, and the surviving paths cannot
-/// tell the two apart (a relocatable bottle legitimately keeps build-prefix
-/// strings). Kegs predating this marker read as stale, which they are.
+/// Holds the keg's `RelocStamp`. The bottle carries no such signal and its
+/// surviving paths cannot supply one — a relocatable bottle legitimately keeps
+/// build-prefix strings — so the stamp is written at the one place that knows.
 pub const reloc_version_marker = ".malt-reloc-version";
 
 fn writeKegMarker(io: std.Io, allocator: std.mem.Allocator, cellar_path: []const u8, name: []const u8, value: u32) void {
+    var buf: [16]u8 = undefined;
+    const text = std.fmt.bufPrint(&buf, "{d}", .{value}) catch return;
+    writeKegMarkerText(io, allocator, cellar_path, name, text);
+}
+
+fn writeKegMarkerText(io: std.Io, allocator: std.mem.Allocator, cellar_path: []const u8, name: []const u8, text: []const u8) void {
     const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ cellar_path, name }) catch return;
     defer allocator.free(path);
-    const body = std.fmt.allocPrint(allocator, "{d}\n", .{value}) catch return;
+    const body = std.fmt.allocPrint(allocator, "{s}\n", .{text}) catch return;
     defer allocator.free(body);
     // Best-effort: a failed write costs a doctor row, never the install.
     atomic.atomicWriteFile(io, path, body) catch {};
+}
+
+/// What relocation did to a keg. `not_applicable` is its own answer, not a
+/// version: a keg that is extracted rather than relocated has nothing to
+/// refresh, so no future bump should ever name it. A missing stamp is a third
+/// state — the keg predates stamping and malt cannot say which rules built it.
+pub const RelocStamp = union(enum) {
+    not_applicable,
+    version: u32,
+};
+
+const not_applicable_text = "n/a";
+
+pub fn writeRelocStamp(io: std.Io, allocator: std.mem.Allocator, cellar_path: []const u8, stamp: RelocStamp) void {
+    switch (stamp) {
+        .not_applicable => writeKegMarkerText(io, allocator, cellar_path, reloc_version_marker, not_applicable_text),
+        .version => |v| writeKegMarker(io, allocator, cellar_path, reloc_version_marker, v),
+    }
+}
+
+/// Null when the stamp is absent or unreadable — never a version, since a
+/// coerced number would read as stale and send the user to reinstall.
+pub fn readRelocStamp(io: std.Io, cellar_path: []const u8) ?RelocStamp {
+    var path_buf: [512]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ cellar_path, reloc_version_marker }) catch return null;
+    const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return null;
+    defer file.close(io);
+    var buf: [32]u8 = undefined;
+    const n = file.readPositional(io, &.{&buf}, 0) catch return null;
+    const text = std.mem.trim(u8, buf[0..n], " \t\r\n");
+    if (std.mem.eql(u8, text, not_applicable_text)) return .not_applicable;
+    return .{ .version = std.fmt.parseInt(u32, text, 10) catch return null };
 }
 
 /// Marker names malt owns inside a keg. Relocation rewrites them last, so a
@@ -422,19 +458,6 @@ pub fn stripKegMarkers(io: std.Io, cellar_path: []const u8) void {
         const path = std.fmt.bufPrint(&buf, "{s}/{s}", .{ cellar_path, name }) catch continue;
         std.Io.Dir.cwd().deleteFile(io, path) catch {};
     }
-}
-
-/// Read a keg marker's `u32`, or null when absent or malformed.
-pub fn readKegMarker(io: std.Io, cellar_path: []const u8, name: []const u8) ?u32 {
-    var path_buf: [512]u8 = undefined;
-    const path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ cellar_path, name }) catch return null;
-    const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return null;
-    defer file.close(io);
-    var buf: [32]u8 = undefined;
-    // Short read is the normal case: the marker is a few digits.
-    const n = file.readPositional(io, &.{&buf}, 0) catch return null;
-    const text = std.mem.trim(u8, buf[0..n], " \t\r\n");
-    return std.fmt.parseInt(u32, text, 10) catch null;
 }
 
 fn relocateKegTree(
@@ -537,7 +560,7 @@ fn relocateKegTree(
     installBottleEtcVar(io, allocator, cellar_path, new_prefix);
 
     // Last: only a keg that got this far was relocated by this logic.
-    writeKegMarker(io, allocator, cellar_path, reloc_version_marker, relocated_store.RELOC_LOGIC_VERSION);
+    writeRelocStamp(io, allocator, cellar_path, .{ .version = relocated_store.RELOC_LOGIC_VERSION });
 }
 
 /// Pour the bottle's `.bottle/etc` and `.bottle/var` overlay into the
@@ -815,37 +838,37 @@ pub fn remove(io: std.Io, prefix: []const u8, name: []const u8, version: []const
 
 // Pins the describeError split: only the user-actionable mappings carry
 // prose; every other tag falls through to @errorName.
-test "keg markers round-trip, and a missing or malformed one reads as absent" {
+test "reloc stamp round-trips both states; anything unreadable is absent" {
     const testing = std.testing;
     const io = std.Options.debug_io;
 
-    var s = try Scratch.init("keg_marker");
+    var s = try Scratch.init("reloc_stamp");
     defer s.deinit();
     const keg = s.p("/Cellar/glow/1.2.3");
     try std.Io.Dir.cwd().createDirPath(io, keg);
 
-    // Absent: the only signal that a keg predates marker tracking, so it must
-    // never read as a version.
-    try testing.expect(readKegMarker(io, keg, reloc_version_marker) == null);
+    // Absent is its own state: the keg predates stamping, and reading it as a
+    // version would send the user to reinstall on no evidence.
+    try testing.expect(readRelocStamp(io, keg) == null);
 
-    writeKegMarker(io, testing.allocator, keg, reloc_version_marker, 4);
-    try testing.expectEqual(@as(?u32, 4), readKegMarker(io, keg, reloc_version_marker));
+    writeRelocStamp(io, testing.allocator, keg, .{ .version = 4 });
+    try testing.expectEqual(RelocStamp{ .version = 4 }, readRelocStamp(io, keg).?);
 
-    // Trailing newline is how the marker is written; leading space and CRLF
-    // cover a hand-edited file.
+    // A keg that was extracted, never relocated: no bump can make it stale.
+    writeRelocStamp(io, testing.allocator, keg, .not_applicable);
+    try testing.expectEqual(RelocStamp.not_applicable, readRelocStamp(io, keg).?);
+
     const path = try std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ keg, reloc_version_marker });
     defer testing.allocator.free(path);
+    // Hand-edited spacing still reads.
     try atomic.atomicWriteFile(io, path, " 12 \r\n");
-    try testing.expectEqual(@as(?u32, 12), readKegMarker(io, keg, reloc_version_marker));
+    try testing.expectEqual(RelocStamp{ .version = 12 }, readRelocStamp(io, keg).?);
 
-    // Garbage must not be coerced to a version — a bogus 0 would flag every
-    // keg as stale.
-    try atomic.atomicWriteFile(io, path, "v4\n");
-    try testing.expect(readKegMarker(io, keg, reloc_version_marker) == null);
-    try atomic.atomicWriteFile(io, path, "");
-    try testing.expect(readKegMarker(io, keg, reloc_version_marker) == null);
-    try atomic.atomicWriteFile(io, path, "99999999999999999999\n");
-    try testing.expect(readKegMarker(io, keg, reloc_version_marker) == null);
+    // Garbage must never coerce to a version — a bogus 0 flags every keg.
+    for ([_][]const u8{ "v4\n", "", "99999999999999999999\n", "n/a extra\n" }) |bad| {
+        try atomic.atomicWriteFile(io, path, bad);
+        try testing.expect(readRelocStamp(io, keg) == null);
+    }
 }
 
 test "stripKegMarkers clears a marker the extracted archive supplied" {
@@ -865,12 +888,10 @@ test "stripKegMarkers clears a marker the extracted archive supplied" {
         defer testing.allocator.free(p);
         try atomic.atomicWriteFile(io, p, "999\n");
     }
-    try testing.expectEqual(@as(?u32, 999), readKegMarker(io, keg, reloc_version_marker));
+    try testing.expectEqual(RelocStamp{ .version = 999 }, readRelocStamp(io, keg).?);
 
     stripKegMarkers(io, keg);
-    for (keg_markers) |name| {
-        try testing.expect(readKegMarker(io, keg, name) == null);
-    }
+    try testing.expect(readRelocStamp(io, keg) == null);
     // Idempotent: the strip runs on every such install, most with no markers.
     stripKegMarkers(io, keg);
 }

--- a/src/core/relocated_store.zig
+++ b/src/core/relocated_store.zig
@@ -46,7 +46,10 @@ pub const RelocatedStoreError = error{
 /// v4: relocation records the paths it could not rewrite in a keg sidecar.
 /// v3 trees carry no sidecar, so a keg restored from one reads as clean
 /// however badly its embedded paths were dropped.
-pub const RELOC_LOGIC_VERSION: u32 = 4;
+///
+/// v5: every keg is stamped with the logic version that produced it, so a
+/// later bump can name the kegs it left behind instead of guessing.
+pub const RELOC_LOGIC_VERSION: u32 = 5;
 
 /// Reject anything that is not exactly 64 lowercase hex characters.
 /// Run this before forming any path so traversal sequences (`..`, `/`) and


### PR DESCRIPTION

## Description

Relocation rules improve, but a keg already on disk keeps whatever paths the rules of its day produced, and nothing says so - a `wget` installed before the Mach-O string pass still reads `/opt/homebrew/etc/wgetrc` and silently ignores the user's own config. Six kegs are in that state on a real prefix here.

Relocation now stamps each keg with the logic version that produced it, and `mt doctor` names the kegs a later bump leaves behind.

An unstamped keg is deliberately not reported: malt cannot tell which rules built it, and guessing would recommend reinstalling the whole prefix.

## Related Issue

- None

## Notes for Reviewers

The keg's contents cannot answer this - a relocatable bottle legitimately keeps build-prefix strings - so the stamp is the only sound signal.