### PR TITLE
fix(cli): make Ctrl-C actually stop malt

### DIFF
--- a/scripts/regressions/doctor-honors-sigint-gh820.sh
+++ b/scripts/regressions/doctor-honors-sigint-gh820.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Pin that Ctrl-C actually stops `mt doctor`.
+#
+# malt installs a SIGINT handler that only flips a process-global flag, so
+# the kernel's default terminate disposition is gone for the whole run.
+# Doctor never polled that flag: a Ctrl-C during its multi-second Cellar
+# walk was recorded and then ignored, and the command ran the full check
+# table to completion.
+#
+# Pinned behaviour:
+#   1. A SIGINT delivered mid-walk stops the run — the checks that come
+#      after the Cellar walk never render.
+#   2. The run exits 130 (128 + SIGINT), the shell convention.
+#   3. The checks before the walk still render, so a pass means "stopped
+#      mid-table", not "died before starting".
+#   4. `--fix` never starts: an interrupted walk holds a partial picture, so
+#      no mutating sweep may be planned from it.
+#
+# Hermetic: MALT_OFFLINE short-circuits the network probe, and the prefix is
+# a throwaway mktemp tree. The Cellar is seeded with cloned multi-megabyte
+# files so the placeholder walk lasts long enough for the signal to land
+# inside it — with a fast walk both a fixed and a broken binary finish
+# before the signal and the script would prove nothing.
+#
+# Usage: scripts/regressions/doctor-honors-sigint-gh820.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s — run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+PFX=$(mktemp -d -t mt_doctor_sigint.XXXXXX)
+trap 'rm -rf "$PFX"' EXIT
+
+KEG="$PFX/Cellar/pkg/1.0/bin"
+mkdir -p "$KEG"
+
+# 9MB is just under the 10MB cap doctor scans; the clone keeps the seeding
+# cost near zero on APFS.
+SEED="$PFX/seed"
+dd if=/dev/zero bs=1m count=9 2>/dev/null | tr '\0' 'a' >"$SEED"
+for i in $(seq 1 100); do
+  cp -c "$SEED" "$KEG/f$i" 2>/dev/null || cp "$SEED" "$KEG/f$i"
+done
+rm -f "$SEED"
+
+export MALT_PREFIX="$PFX" MALT_OFFLINE=1
+
+# Run doctor with the given extra args, interrupt it mid-walk, and echo the
+# exit status. Output lands in $1.
+run_interrupted() {
+  local out=$1
+  shift
+  "$MALT_BIN" doctor "$@" >"$out" 2>&1 &
+  local pid=$!
+
+  # Long enough to be inside the Cellar walk, short enough that a swallowed
+  # signal still has most of the walk left to run.
+  sleep 1
+  kill -INT "$pid"
+
+  # Guard against a doctor that neither honours the signal nor terminates.
+  # stdout is closed so the watchdog cannot hold this function's command
+  # substitution open for its full sleep.
+  (
+    sleep 15
+    kill -KILL "$pid" 2>/dev/null || true
+  ) >/dev/null 2>&1 &
+  local watchdog=$!
+
+  local rc
+  set +e
+  wait "$pid"
+  rc=$?
+  set -e
+  kill "$watchdog" 2>/dev/null || true
+  printf '%s' "$rc"
+}
+
+OUT="$PFX/out.txt"
+rc=$(run_interrupted "$OUT")
+
+grep -q 'MALT_PREFIX' "$OUT" ||
+  fail 'doctor never reached the check table — the run died for an unrelated reason'
+
+if grep -q 'Disk space' "$OUT"; then
+  fail 'doctor ran past the Cellar walk despite SIGINT (the signal was swallowed)'
+fi
+
+[[ "$rc" -eq 130 ]] ||
+  fail "expected exit 130 after SIGINT, got $rc"
+
+# --fix must never plan a sweep off a partial walk.
+FIX_OUT="$PFX/fix.txt"
+fix_rc=$(run_interrupted "$FIX_OUT" --fix)
+
+if grep -q 'safe-class fixes' "$FIX_OUT"; then
+  fail 'doctor --fix started applying fixes after SIGINT'
+fi
+
+[[ "$fix_rc" -eq 130 ]] ||
+  fail "expected exit 130 from --fix after SIGINT, got $fix_rc"
+
+printf 'PASS: doctor stops on SIGINT, exits 130, and skips --fix\n'

--- a/src/cli/bundle.zig
+++ b/src/cli/bundle.zig
@@ -14,6 +14,7 @@ const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
 const path_write = @import("../fs/path_write.zig");
 const output = @import("../ui/output.zig");
+const signals = @import("../core/signals.zig");
 const install_sink_mod = @import("install/sink.zig");
 const install_cmd = @import("install.zig");
 const services_cmd = @import("services.zig");
@@ -221,6 +222,11 @@ fn cmdInstall(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []
         any_hard = true;
     }
 
+    // A short report after Ctrl-C is not a completed bundle.
+    if (signals.isInterrupted()) {
+        output.warn("Interrupted — remaining bundle members were not installed.", .{});
+        return error.UserInterrupted;
+    }
     if (any_hard) return BundleError.RunnerFailed;
     output.success("bundle install complete", .{});
 }
@@ -306,6 +312,10 @@ fn cmdCleanup(ctx: *const AppCtx, allocator: std.mem.Allocator, rest: []const []
 
     // The uninstall pipeline already prints rich per-member diagnostics;
     // surface only the count here so users see a single summary line.
+    if (signals.isInterrupted()) {
+        output.warn("Interrupted — remaining bundle members were not removed.", .{});
+        return error.UserInterrupted;
+    }
     if (report.hasFailure()) {
         output.err("bundle cleanup completed with {d} failure(s)", .{report.failures.len});
         return BundleError.RunnerFailed;

--- a/src/cli/deps.zig
+++ b/src/cli/deps.zig
@@ -6,6 +6,7 @@ const testing = std.testing;
 
 const AppCtx = @import("../app_ctx.zig").AppCtx;
 const formula_mod = @import("../core/formula.zig");
+const signals = @import("../core/signals.zig");
 const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
 const atomic = @import("../fs/atomic.zig");
@@ -80,6 +81,9 @@ pub fn collectDeps(
 
     var head: usize = 0;
     while (head < frontier.items.len) : (head += 1) {
+        // One lookup per node, each possibly a network fetch. `execute` turns
+        // the partial graph into a non-zero exit rather than rendering it.
+        if (signals.isInterrupted()) break;
         if (!opts.recursive) break;
         const current = frontier.items[head];
         const idx = entryIndex(entries.items, current) orelse continue;
@@ -401,6 +405,11 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     }) catch empty_entries;
     defer freeEntries(allocator, entries);
 
+    if (signals.isInterrupted()) {
+        output.warn("Interrupted.", .{});
+        return error.UserInterrupted;
+    }
+
     if (json_mode) {
         try encodeJson(stdout, entries);
     } else {
@@ -579,6 +588,36 @@ test "collectDeps --recursive walks the transitive closure once per name" {
     try testing.expectEqualStrings("openssl@3", entries[1].formula);
     try testing.expectEqualStrings("ca-certificates", entries[1].depends_on[0]);
     try testing.expectEqualStrings("wget", entries[2].formula);
+}
+
+test "collectDeps: an interrupt stops the transitive walk" {
+    // One lookup per node, each possibly a network fetch. Uninterrupted this
+    // chain yields all four entries — the closure test above pins that — so a
+    // short result here is the walk stopping, not the graph being small.
+    var db_stub = StubLookup.init(testing.allocator);
+    defer db_stub.deinit();
+    try db_stub.add("a", &.{"b"});
+    try db_stub.add("b", &.{"c"});
+    try db_stub.add("c", &.{"d"});
+    try db_stub.add("d", &.{});
+
+    const prior = signals.isInterrupted();
+    defer signals.setInterruptedForTest(prior);
+    defer signals.armInterruptAfterForTest(0);
+    signals.setInterruptedForTest(false);
+    signals.armInterruptAfterForTest(2); // fires on the second frontier poll
+
+    const entries = try collectDeps(
+        testing.allocator,
+        db_stub.lookup(),
+        null,
+        "a",
+        .{ .recursive = true },
+    );
+    defer freeEntries(testing.allocator, entries);
+
+    // "a" expanded (appending "b"), then the walk stopped: "c"/"d" unreached.
+    try testing.expectEqual(@as(usize, 2), entries.len);
 }
 
 test "collectDeps --recursive terminates on a cycle" {

--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -10,6 +10,7 @@ const cellar = @import("../core/cellar.zig");
 const relocated_store = @import("../core/relocated_store.zig");
 const patch = @import("../core/patch.zig");
 const perms_mod = @import("../core/perms.zig");
+const signals = @import("../core/signals.zig");
 const lock_mod = @import("../db/lock.zig");
 const schema = @import("../db/schema.zig");
 const sqlite = @import("../db/sqlite.zig");
@@ -139,6 +140,8 @@ pub const checks = [_]Check{
 pub fn runChecks(ctx: CheckCtx, table: []const Check) Tally {
     var tally: Tally = .{};
     for (table) |c| {
+        // Ctrl-C between rows. `execute` re-reads the flag for the exit code.
+        if (signals.isInterrupted()) break;
         switch (c.run(ctx, c.name)) {
             .ok => {},
             .warn_status => tally.warnings += 1,
@@ -435,6 +438,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     }, &checks, want_checks_json);
     defer walk.deinit();
     const tally = walk.tally;
+
+    // Partial tally: a truncated-but-well-formed document would read as a
+    // complete run, and `--fix` must not act on an incomplete picture.
+    if (signals.isInterrupted()) {
+        if (!want_checks_json) output.warn("Interrupted.", .{});
+        std.process.exit(130); // 128 + SIGINT
+    }
 
     // `--json` is one merged, versioned document; the human view keeps the
     // three reports split so each renders in its own place after the rows.
@@ -1084,6 +1094,9 @@ fn collectOffendingKegs(ctx: CheckCtx, predicate: KegFilePredicate) ?KegGroups {
 
     var groups: KegGroups = .empty;
     while (walker.next(ctx.io) catch null) |entry| {
+        // Seconds of scanning on a populated Cellar — between-check polling
+        // alone would leave Ctrl-C unanswered for the whole walk.
+        if (signals.isInterrupted()) break;
         if (entry.kind != .file) continue;
         if (!predicate(ctx, &cellar_dir, entry.path)) continue;
         // Best-effort: an allocator failure drops this entry rather than
@@ -1115,6 +1128,8 @@ fn checkMachOPlaceholders(ctx: CheckCtx, name: []const u8) CheckResult {
         return .warn_status;
     };
     defer freeKegGroups(ctx, &groups);
+    // Partial groups: reporting them would blame whatever the scan reached.
+    if (signals.isInterrupted()) return .ok;
 
     if (groups.count() == 0) {
         printCheck(name, .ok, null);
@@ -1181,12 +1196,14 @@ fn checkRelocationFreshness(ctx: CheckCtx, name: []const u8) CheckResult {
 
     var names = cellar_dir.iterate();
     while (names.next(ctx.io) catch null) |pkg| {
+        if (signals.isInterrupted()) break;
         if (pkg.kind != .directory) continue;
         var pkg_dir = cellar_dir.openDir(ctx.io, pkg.name, .{ .iterate = true }) catch continue;
         defer pkg_dir.close(ctx.io);
 
         var versions = pkg_dir.iterate();
         while (versions.next(ctx.io) catch null) |ver| {
+            if (signals.isInterrupted()) break;
             if (ver.kind != .directory) continue;
             var keg_buf: [512]u8 = undefined;
             const keg = std.fmt.bufPrint(&keg_buf, "{s}/{s}/{s}", .{ cellar_root, pkg.name, ver.name }) catch continue;
@@ -1206,6 +1223,7 @@ fn checkRelocationFreshness(ctx: CheckCtx, name: []const u8) CheckResult {
         }
     }
 
+    if (signals.isInterrupted()) return .ok; // partial walk: nothing to report
     if (stale.items.len == 0) {
         printCheck(name, .ok, null);
         return .ok;
@@ -1244,6 +1262,7 @@ fn checkUnrelocatedPrefix(ctx: CheckCtx, name: []const u8) CheckResult {
         return .warn_status;
     };
     defer freeKegGroups(ctx, &groups);
+    if (signals.isInterrupted()) return .ok; // partial walk: nothing to report
 
     if (groups.count() == 0) {
         printCheck(name, .ok, null);
@@ -2054,6 +2073,128 @@ test "runChecks: an info_status finding counts as neither warning nor error" {
     }, &table);
     try testing.expectEqual(@as(u32, 0), tally.warnings);
     try testing.expectEqual(@as(u32, 0), tally.errors);
+}
+
+var checks_run_for_test: u32 = 0;
+
+fn warnCheckForTest(ctx: CheckCtx, name: []const u8) CheckResult {
+    _ = ctx;
+    _ = name;
+    checks_run_for_test += 1;
+    return .warn_status;
+}
+
+fn hermeticCtx() CheckCtx {
+    return .{
+        .allocator = testing.allocator,
+        .prefix = "/nonexistent",
+        .io = std.Options.debug_io,
+        .environ = .empty,
+    };
+}
+
+test "runChecks: an interrupt ends the walk instead of finishing the table" {
+    // Ctrl-C used to be recorded and ignored: doctor ran every remaining
+    // check before exiting, so the user's press changed nothing.
+    const prior = signals.isInterrupted();
+    defer signals.setInterruptedForTest(prior);
+    defer signals.armInterruptAfterForTest(0);
+    signals.setInterruptedForTest(false);
+
+    const table = [_]Check{
+        .{ .name = "a", .run = warnCheckForTest },
+        .{ .name = "b", .run = warnCheckForTest },
+        .{ .name = "c", .run = warnCheckForTest },
+    };
+    checks_run_for_test = 0;
+    signals.armInterruptAfterForTest(2); // lands on the poll before "b"
+
+    output.setQuiet(true);
+    defer output.setQuiet(false);
+    const tally = runChecks(hermeticCtx(), &table);
+
+    try testing.expectEqual(@as(u32, 1), checks_run_for_test);
+    try testing.expectEqual(@as(u32, 1), tally.warnings);
+}
+
+test "runChecks: an interrupt raised before the walk runs no check at all" {
+    const prior = signals.isInterrupted();
+    defer signals.setInterruptedForTest(prior);
+    signals.setInterruptedForTest(true);
+
+    const table = [_]Check{.{ .name = "a", .run = warnCheckForTest }};
+    checks_run_for_test = 0;
+
+    output.setQuiet(true);
+    defer output.setQuiet(false);
+    const tally = runChecks(hermeticCtx(), &table);
+
+    try testing.expectEqual(@as(u32, 0), checks_run_for_test);
+    try testing.expectEqual(@as(u32, 0), tally.warnings);
+}
+
+test "checkMachOPlaceholders: an interrupted Cellar walk reports no fault" {
+    // The walk stops mid-tree, so its groups are partial. Printing a row from
+    // them would blame the packages the scan happened to reach.
+    const allocator = testing.allocator;
+    const io = std.Options.debug_io;
+    var s = try Scratch.init("doctor_sigint_placeholders");
+    defer s.deinit();
+
+    const keg = s.p("/Cellar/pkg/1.0/bin");
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const wrapper = try std.fmt.bufPrint(&path_buf, "{s}/wrapper", .{keg});
+    try atomic.atomicWriteFile(io, wrapper, "prefix=@@HOMEBREW_PREFIX@@\n");
+
+    const ctx: CheckCtx = .{ .allocator = allocator, .prefix = s.base, .io = io, .environ = .empty };
+    defer resetVerboseHint();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    output.beginStderrCapture(allocator, &out);
+    defer output.endStderrCapture();
+
+    // Uninterrupted this tree is an error — that is what makes the
+    // interrupted result below discriminating rather than vacuous.
+    try testing.expectEqual(CheckResult.err_status, checkMachOPlaceholders(ctx, "Relocation placeholders"));
+
+    const prior = signals.isInterrupted();
+    defer signals.setInterruptedForTest(prior);
+    signals.setInterruptedForTest(true);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(CheckResult.ok, checkMachOPlaceholders(ctx, "Relocation placeholders"));
+    try testing.expectEqual(@as(usize, 0), out.items.len);
+}
+
+test "checkRelocationFreshness: an interrupted Cellar walk reports no fault" {
+    const allocator = testing.allocator;
+    const io = std.Options.debug_io;
+    var s = try Scratch.init("doctor_sigint_freshness");
+    defer s.deinit();
+
+    const keg = s.p("/Cellar/pkg/1.0");
+    try std.Io.Dir.cwd().createDirPath(io, keg);
+    cellar.writeRelocStamp(io, allocator, keg, .{ .version = 0 });
+
+    const ctx: CheckCtx = .{ .allocator = allocator, .prefix = s.base, .io = io, .environ = .empty };
+    defer resetVerboseHint();
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+    output.beginStderrCapture(allocator, &out);
+    defer output.endStderrCapture();
+
+    try testing.expectEqual(CheckResult.warn_status, checkRelocationFreshness(ctx, "Relocation freshness"));
+
+    const prior = signals.isInterrupted();
+    defer signals.setInterruptedForTest(prior);
+    signals.setInterruptedForTest(true);
+
+    out.clearRetainingCapacity();
+    try testing.expectEqual(CheckResult.ok, checkRelocationFreshness(ctx, "Relocation freshness"));
+    try testing.expectEqual(@as(usize, 0), out.items.len);
 }
 
 test "textCarriesPlaceholder flags a wrapper script that kept a token" {

--- a/src/cli/purge.zig
+++ b/src/cli/purge.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 const AppCtx = @import("../app_ctx.zig").AppCtx;
 const atomic = @import("../fs/atomic.zig");
 const prefix_path = @import("../fs/prefix_path.zig");
+const signals = @import("../core/signals.zig");
 const output = @import("../ui/output.zig");
 const lock_mod = @import("../db/lock.zig");
 const help = @import("help.zig");
@@ -196,6 +197,13 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     inline for (scope_run_order) |k| {
         if (@field(opts.scope, @tagName(k))) {
+            // Scope boundary only — a half-applied sweep is worse than one
+            // that finishes. Returning before `emitScopeStarted` keeps the
+            // ndjson started/completed pairs balanced.
+            if (signals.isInterrupted()) {
+                output.warn("Interrupted.", .{});
+                return error.UserInterrupted;
+            }
             const name = comptime k.label();
             purge_json.emitScopeStarted(name, dry_run);
             var r: TierResult = .{};

--- a/src/cli/restore.zig
+++ b/src/cli/restore.zig
@@ -7,6 +7,7 @@ const std = @import("std");
 
 const AppCtx = @import("../app_ctx.zig").AppCtx;
 const output = @import("../ui/output.zig");
+const signals = @import("../core/signals.zig");
 const backup_mod = @import("backup.zig");
 const help = @import("help.zig");
 const install_mod = @import("install.zig");
@@ -140,7 +141,9 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         };
     }
 
-    if (casks.items.len > 0) {
+    // `install` stops itself on Ctrl-C; without these guards restore would
+    // then start the next batch as if nothing had happened.
+    if (casks.items.len > 0 and !signals.isInterrupted()) {
         var argv: std.ArrayList([]const u8) = .empty;
         defer argv.deinit(allocator);
         try argv.append(allocator, "--cask");
@@ -158,11 +161,16 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // warn and continue so one missing service doesn't abort the rest
     // of the restore.
     for (services.items) |name| {
+        if (signals.isInterrupted()) break;
         services_mod.servicesStart(ctx, allocator, name) catch |e| {
             output.warn("service {s} skipped: {s}", .{ name, @errorName(e) });
         };
     }
 
+    if (signals.isInterrupted()) {
+        output.warn("Interrupted.", .{});
+        return error.UserInterrupted;
+    }
     if (any_failed) {
         return error.RestoreFailed;
     }

--- a/src/cli/uses.zig
+++ b/src/cli/uses.zig
@@ -7,6 +7,7 @@ const sqlite = @import("../db/sqlite.zig");
 const schema = @import("../db/schema.zig");
 const atomic = @import("../fs/atomic.zig");
 const output = @import("../ui/output.zig");
+const signals = @import("../core/signals.zig");
 const color = @import("../ui/color.zig");
 const cli_info = @import("info.zig");
 const help = @import("help.zig");
@@ -56,6 +57,12 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         dependents = collectDependents(allocator, db, name, recursive) catch &.{};
     }
 
+    // A partial dependent set read as complete would be worse than no answer.
+    if (signals.isInterrupted()) {
+        output.warn("Interrupted.", .{});
+        return error.UserInterrupted;
+    }
+
     if (json_mode) {
         try writeJson(stdout, name, dependents);
     } else {
@@ -86,6 +93,9 @@ pub fn collectDependents(
     // Peak ~2× max-in-flight: compact live tail to front once half-consumed.
     var head: usize = 0;
     while (head < frontier.items.len) {
+        // One reverse-dependency query per node: a wide graph is seconds of
+        // walking, so Ctrl-C is answered here rather than at the end.
+        if (signals.isInterrupted()) break;
         if (head > 0 and head * 2 >= frontier.items.len) {
             const live = frontier.items[head..];
             std.mem.copyForwards([]const u8, frontier.items[0..live.len], live);

--- a/src/core/bundle/cleanup.zig
+++ b/src/core/bundle/cleanup.zig
@@ -6,6 +6,7 @@
 
 const std = @import("std");
 const manifest_mod = @import("manifest.zig");
+const signals = @import("../signals.zig");
 const sqlite = @import("../../db/sqlite.zig");
 const runner_mod = @import("runner.zig");
 
@@ -329,13 +330,17 @@ pub fn run(
             return CleanupError.OutOfMemory;
     } else {
         const d = opts.dispatcher orelse return CleanupError.NoDispatcher;
+        // Each entry is a full uninstall; stop at the next member boundary
+        // rather than draining the plan.
         for (plan.formulas) |n| {
+            if (signals.isInterrupted()) break;
             d.uninstallFormula(d.ctx, allocator, n) catch |e| {
                 failures.append(allocator, .{ .kind = .formula, .name = n, .err = e }) catch
                     return CleanupError.OutOfMemory;
             };
         }
         for (plan.casks) |n| {
+            if (signals.isInterrupted()) break;
             d.uninstallCask(d.ctx, allocator, n) catch |e| {
                 failures.append(allocator, .{ .kind = .cask, .name = n, .err = e }) catch
                     return CleanupError.OutOfMemory;
@@ -711,6 +716,42 @@ test "run executes uninstall via dispatcher in formula-then-cask order" {
     try testing.expectEqual(@as(usize, 1), fake.casks.items.len);
     try testing.expectEqualStrings("ghostty", fake.casks.items[0]);
     try testing.expectEqual(@as(usize, 0), report.failures.len);
+}
+
+test "run stops uninstalling at the next member boundary when interrupted" {
+    // The order test above pins 2 formulas + 1 cask uninterrupted, so a
+    // shorter dispatch here is the plan being abandoned, not a small plan.
+    var fake = TestDispatcher.init(testing.allocator);
+    defer fake.deinit();
+
+    var m = try testManifest(testing.allocator, &.{}, &.{});
+    defer m.deinit();
+    var plan = try diff(
+        testing.allocator,
+        m,
+        &[_][]const u8{ "jq", "wget" },
+        &[_][]const u8{"ghostty"},
+    );
+    defer plan.deinit();
+
+    const dispatcher = Dispatcher{
+        .ctx = &fake,
+        .uninstallFormula = TestDispatcher.uninstallFormulaFn,
+        .uninstallCask = TestDispatcher.uninstallCaskFn,
+    };
+
+    const prior = signals.isInterrupted();
+    defer signals.setInterruptedForTest(prior);
+    defer signals.armInterruptAfterForTest(0);
+    signals.setInterruptedForTest(false);
+    signals.armInterruptAfterForTest(2); // fires before the second formula
+
+    var report = try run(testing.allocator, plan, .{ .dry_run = false, .dispatcher = &dispatcher });
+    defer report.deinit();
+
+    try testing.expectEqual(@as(usize, 1), fake.formulas.items.len);
+    try testing.expectEqualStrings("jq", fake.formulas.items[0]);
+    try testing.expectEqual(@as(usize, 0), fake.casks.items.len);
 }
 
 test "run records per-member failures and keeps going" {

--- a/src/core/bundle/runner.zig
+++ b/src/core/bundle/runner.zig
@@ -21,6 +21,7 @@ const sqlite = @import("../../db/sqlite.zig");
 const schema = @import("../../db/schema.zig");
 const lock_mod = @import("../../db/lock.zig");
 const atomic = @import("../../fs/atomic.zig");
+const signals = @import("../signals.zig");
 const manifest_mod = @import("manifest.zig");
 
 pub const RunnerError = error{
@@ -185,7 +186,9 @@ pub fn run(
     var db_record_error: ?[]const u8 = null;
     // 5. Record bundle and members in DB (even on partial failure). Skipped
     //    in dry-run so the preview path stays read-only.
-    if (!opts.dry_run) recordBundle(io, db, manifest) catch |e| {
+    // An interrupted run installed only part of the manifest; recording it
+    // would claim members that never landed.
+    if (!opts.dry_run and !signals.isInterrupted()) recordBundle(io, db, manifest) catch |e| {
         // recordBundle's inferred set spans sqlite + clock; keep @errorName.
         db_record_error = @errorName(e);
     };
@@ -237,6 +240,10 @@ fn recordMember(
     failures: *std.ArrayList(MemberError),
     previews: *std.ArrayList(MemberPreview),
 ) RunnerError!void {
+    // A member is a whole install, so Ctrl-C cannot wait for the manifest to
+    // drain. One guard covers all four member loops: the rest fall through.
+    if (signals.isInterrupted()) return;
+
     if (opts.dry_run) {
         previews.append(allocator, .{ .kind = call.kind(), .name = call.name() }) catch
             return RunnerError.OutOfMemory;

--- a/src/core/signals.zig
+++ b/src/core/signals.zig
@@ -69,15 +69,61 @@ fn sigintHandler(_: std.posix.SIG) callconv(.c) void {
 /// Wire SIGINT to flip the interrupt flag. Idempotent so repeated CLI
 /// invocations inside a test process do not double-register and do not
 /// clobber a flag the prior handler already set.
+///
+/// `SA_RESETHAND` restores the default disposition after the first delivery:
+/// without it any command that never polls the flag is uninterruptible. The
+/// second press is a hard kill by design — mid-step, no unwind.
 pub fn installHandler() void {
     if (handler_installed.load(.acquire)) return;
     const act = std.posix.Sigaction{
         .handler = .{ .handler = &sigintHandler },
         .mask = std.posix.sigemptyset(),
-        .flags = 0,
+        .flags = std.posix.SA.RESETHAND,
     };
     std.posix.sigaction(std.posix.SIG.INT, &act, null);
     handler_installed.store(true, .release);
+}
+
+// Forked child: wire the handler, then signal ourselves twice. The first
+// SIGINT only flips the flag; with the disposition reset the second one is
+// fatal. Without the reset the child survives both and exits 0, which the
+// parent treats as failure.
+fn raiseSigintTwiceAndDie() noreturn {
+    setSignalHandlerInstalledForTest(false);
+    installHandler();
+    std.posix.raise(.INT) catch {};
+    std.posix.raise(.INT) catch {};
+    std.process.exit(0);
+}
+
+// Darwin won't report SA_RESETHAND back through a sigaction query, so pin its
+// observable contract instead: a second Ctrl-C kills, which is the escape
+// hatch for every command that never polls the flag.
+test "a second SIGINT is fatal even though the first only sets the flag" {
+    // A tracer (kcov) intercepts the child's signal-stop instead of letting it
+    // die, so death-by-signal is unobservable and the wait below times out.
+    if (std.c.getenv("MALT_SKIP_SUBPROCESS_TESTS") != null) return error.SkipZigTest;
+
+    const pid = std.c.fork();
+    try std.testing.expect(pid >= 0);
+    if (pid == 0) raiseSigintTwiceAndDie();
+
+    var status: c_int = undefined;
+    var waited_ms: usize = 0;
+    const reaped = while (waited_ms < 5000) : (waited_ms += 50) {
+        if (std.c.waitpid(pid, &status, std.c.W.NOHANG) == pid) break true;
+        var ts: std.c.timespec = .{ .sec = 0, .nsec = 50 * std.time.ns_per_ms };
+        _ = std.c.nanosleep(&ts, null);
+    } else false;
+    if (!reaped) {
+        std.posix.kill(pid, .KILL) catch {};
+        _ = std.c.waitpid(pid, &status, 0);
+        return error.SecondSigintNotFatal;
+    }
+
+    const st: u32 = @bitCast(status);
+    try std.testing.expect(std.c.W.IFSIGNALED(st));
+    try std.testing.expectEqual(std.posix.SIG.INT, std.c.W.TERMSIG(st));
 }
 
 test "armInterruptAfterForTest fires on the Nth subsequent poll" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -655,6 +655,10 @@ pub fn main(init: std.process.Init.Minimal) !void {
             // Dedicated code so the TUI can footer the cause; mirrored in
             // `tui/app.zig`. Message already printed, like Aborted below.
             error.AppRunning => std.process.exit(3),
+            // Ctrl-C during a long walk. Deliberately not `error.Interrupted`
+            // — that name is std's EINTR value and would silently map an I/O
+            // hiccup onto a user-cancel exit code.
+            error.UserInterrupted => std.process.exit(130), // 128 + SIGINT
             error.Aborted => std.process.exit(1),
             else => if (install_family and install.isReportedInstallError(e)) std.process.exit(1) else return e,
         };

--- a/tests/bundle_test.zig
+++ b/tests/bundle_test.zig
@@ -155,6 +155,52 @@ test "runner routes members through the provided dispatcher" {
     try testing.expectEqual(@as(usize, 0), calls.services.items.len);
 }
 
+// Every bundle member is a whole install, so Ctrl-C has to be answered
+// between members. The run above pins the full dispatch set, so a short one
+// here is the manifest being abandoned.
+test "runner stops dispatching members and records no bundle when interrupted" {
+    var t = try TempDb.init("interrupted");
+    defer t.deinit();
+
+    var calls = Calls.init(testing.allocator);
+    defer calls.deinit();
+
+    const dispatcher = runner.Dispatcher{
+        .ctx = &calls,
+        .installFormula = Calls.installFormulaFn,
+        .installCask = Calls.installCaskFn,
+        .tapAdd = Calls.tapAddFn,
+        .serviceStart = Calls.serviceStartFn,
+    };
+
+    var m = try buildManifest(testing.allocator);
+    defer m.deinit();
+
+    const prior = malt.signals.isInterrupted();
+    defer malt.signals.setInterruptedForTest(prior);
+    defer malt.signals.armInterruptAfterForTest(0);
+    malt.signals.setInterruptedForTest(false);
+    malt.signals.armInterruptAfterForTest(2); // fires on the member after the tap
+
+    var report = try runner.run(std.Options.debug_io, testing.allocator, &t.db, m, .{
+        .dry_run = false,
+        .prefix = t.dir,
+        .dispatcher = &dispatcher,
+    });
+    defer report.deinit();
+
+    try testing.expectEqual(@as(usize, 1), calls.taps.items.len);
+    try testing.expectEqual(@as(usize, 0), calls.formulas.items.len);
+    try testing.expectEqual(@as(usize, 0), calls.casks.items.len);
+
+    // A partial run must not leave a bundle row claiming members that never
+    // landed — `bundle cleanup` would later act on them.
+    var stmt = try t.db.prepare("SELECT COUNT(*) FROM bundles;");
+    defer stmt.finalize();
+    _ = try stmt.step();
+    try testing.expectEqual(@as(i64, 0), stmt.columnInt(0));
+}
+
 const Calls = struct {
     allocator: std.mem.Allocator,
     taps: std.ArrayList([]const u8),

--- a/tests/cleanup_cli_test.zig
+++ b/tests/cleanup_cli_test.zig
@@ -108,6 +108,31 @@ test "cleanup with no extra args matches purge --housekeeping byte-for-byte" {
     try testing.expectEqualStrings(ref_buf.items, shim_buf.items);
 }
 
+// Ctrl-C is answered at the scope boundary, before any sweep starts, and
+// surfaces as the interrupt exit code rather than a silent success.
+test "cleanup stops at the scope boundary when interrupted" {
+    const allocator = testing.allocator;
+    var prefix = try ScratchPrefix.init(allocator, "interrupted");
+    defer prefix.deinit(allocator);
+
+    const prior_out = OutputState.save();
+    defer prior_out.restore();
+    output.setMode(.human);
+    output.setDryRun(true);
+    output.setNdjson(false);
+    output.setQuiet(true);
+
+    const prior = malt.signals.isInterrupted();
+    defer malt.signals.setInterruptedForTest(prior);
+    malt.signals.setInterruptedForTest(true);
+
+    const ctx = malt.app_ctx.debug_ctx;
+    try testing.expectError(
+        error.UserInterrupted,
+        purge.executeCleanup(&ctx, allocator, &.{}),
+    );
+}
+
 // `mt cleanup --help` must show cleanup's own help, not purge's. The
 // shim intercepts before forwarding so the verb the user typed is the
 // verb the help text names. Captures via a real fd so the byte stream

--- a/tests/deps_cli_exec_test.zig
+++ b/tests/deps_cli_exec_test.zig
@@ -125,6 +125,26 @@ test "execute on a fresh prefix without --installed still completes" {
     try deps_cli.execute(&ctx, testing.allocator, &.{ "--installed", "ghost" });
 }
 
+// A partial graph must not be rendered as the answer. The error is what
+// `main` maps to the interrupt exit code, so it is the user-visible contract.
+test "execute surfaces an interrupt instead of printing a partial graph" {
+    var s = try Scratch.init(testing.allocator, "interrupted");
+    defer s.deinit(testing.allocator);
+    try seedDeps(s.path);
+
+    const prior = malt.signals.isInterrupted();
+    defer malt.signals.setInterruptedForTest(prior);
+    malt.signals.setInterruptedForTest(true);
+
+    const ctx = ctxWithSink();
+    quiet();
+    defer unquiet();
+    try testing.expectError(
+        error.UserInterrupted,
+        deps_cli.execute(&ctx, testing.allocator, &.{ "--installed", "-r", "wget" }),
+    );
+}
+
 // --- happy paths ------------------------------------------------------
 
 test "execute --installed reads direct deps from the DB" {

--- a/tests/uses_test.zig
+++ b/tests/uses_test.zig
@@ -140,6 +140,33 @@ test "collectDependents --recursive walks the transitive closure" {
     try testing.expectEqualStrings("whisper", hits[2]);
 }
 
+test "collectDependents: an interrupt stops the recursive walk" {
+    // Same graph as the closure test above, which pins 3 hits uninterrupted —
+    // so a shorter result here means the walk answered the signal.
+    var tdb = try TempDb.init("interrupted");
+    defer tdb.deinit();
+    const db = &tdb.db;
+
+    const node_id = try insertKeg(db, "node");
+    const whisper_id = try insertKeg(db, "whisper");
+    const tauri_id = try insertKeg(db, "tauri");
+    try addDep(db, node_id, "icu4c");
+    try addDep(db, whisper_id, "node");
+    try addDep(db, tauri_id, "node");
+
+    const prior = malt.signals.isInterrupted();
+    defer malt.signals.setInterruptedForTest(prior);
+    defer malt.signals.armInterruptAfterForTest(0);
+    malt.signals.setInterruptedForTest(false);
+    malt.signals.armInterruptAfterForTest(2); // fires on the second frontier poll
+
+    const hits = try uses.collectDependents(testing.allocator, db, "icu4c", true);
+    defer uses.freeDependents(testing.allocator, hits);
+
+    try testing.expectEqual(@as(usize, 1), hits.len);
+    try testing.expectEqualStrings("node", hits[0]);
+}
+
 test "collectDependents returns empty slice when nothing depends on target" {
     var tdb = try TempDb.init("empty");
     defer tdb.deinit();


### PR DESCRIPTION
## Description

Ctrl-C did nothing for most of malt's command surface. The startup SIGINT handler replaces the kernel's terminate disposition with a flag flip, so a command only stops if it polls that flag - and most never did. `mt doctor` was the one slow enough for users to notice.

A second Ctrl-C now always kills, whatever is running. On top of that, the commands with multi-second walks - doctor, `bundle install`/`cleanup`, `purge`/`cleanup`, `restore`, `deps`, `uses` - stop on the first press and exit 130 rather than reporting a partial result as a completed run. Nothing mutating starts from an incomplete picture.

## Related Issue

- Closes #820

## Notes for Reviewers

- `backup` is left unpolled on purpose: sub-second sqlite read, and an interruptible write path risks a truncated manifest.
- `install`/`upgrade`/`migrate` already polled and keep their current finish-cleanly behaviour.