### PR TITLE
ci: restore push credentials for the workflows that publish branches

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,9 +25,9 @@ jobs:
       # latest release tags. Local runs leave this unset and bench the tree.
       BENCH_MALT_RELEASE: "1"
     steps:
+      # Credentials must persist: the publish step pushes the benchmark
+      # branch with the ambient GITHUB_TOKEN.
       - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
 
       - name: Install Zig
         uses: mlugg/setup-zig@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -364,8 +364,6 @@ jobs:
     steps:
       - name: Checkout tag
         uses: actions/checkout@v7
-        with:
-          persist-credentials: false
         # persist-credentials defaults true so `git push` can auth via the
         # ambient GITHUB_TOKEN. HEAD is the tag commit on a push:tags event.
 


### PR DESCRIPTION

## Description

The workflow hardening pass disabled persisted checkout credentials everywhere, including the two jobs that push with the ambient token, so the benchmark publish and the release-branch cut now fail to authenticate. This re-enables credentials on just those two checkouts.

## Related Issue

- None

## Notes for Reviewers

- None
