### PR TITLE
fix(install): stop re-fetching metadata for packages already installed

### DIFF
--- a/scripts/regressions/bundle-install-refetches-installed-members-gh821.sh
+++ b/scripts/regressions/bundle-install-refetches-installed-members-gh821.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Pin that a warm `bundle install` does no network work.
+#
+# `install` has an idempotent fast path that skips the DB, the lock and every
+# HTTP call when the named package is already installed. Every Brewfile member
+# kind but the plain formula was vetoed out of it: `--cask` (which the bundle
+# dispatcher sets for every cask line) and the `owner/repo/name` tap form,
+# which covers tap formulas and tap casks alike. All of them then took slow
+# paths that fetched metadata *before* testing installed state, so a re-run
+# where nothing had changed paid one serial round trip per member.
+#
+# Pinned behaviour:
+#   1. A bundle whose members are all installed completes without fetching.
+#   2. The skip is a presence check, not a blanket one - an uninstalled cask
+#      is still attempted.
+#
+# Hermetic: MALT_OFFLINE=1 turns any attempted fetch into an immediate typed
+# failure, so "reached the network" is observable without a network.
+#
+# Usage: scripts/regressions/bundle-install-refetches-installed-members-gh821.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s - run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+PFX=$(mktemp -d -t mt_warm_bundle.XXXXXX)
+trap 'rm -rf "$PFX"' EXIT
+
+export MALT_PREFIX="$PFX" MALT_OFFLINE=1 NO_COLOR=1
+
+# Real schema straight from the binary: an unresolvable name creates
+# db/malt.db before it fails offline.
+"$MALT_BIN" install --quiet nope-not-real >/dev/null 2>&1 || true
+[[ -f "$PFX/db/malt.db" ]] || fail 'could not bootstrap the fixture database'
+
+mkdir -p "$PFX/Cellar/jq/1.7" "$PFX/Cellar/prowl/1.9.0" "$PFX/Caskroom/iterm2/3.5.0"
+
+# `deckclip` deliberately gets no Caskroom dir: recording it is best-effort,
+# so the row has to be enough on its own.
+sqlite3 "$PFX/db/malt.db" <<SQL
+INSERT INTO kegs(name,full_name,version,tap,store_sha256,cellar_path)
+  VALUES ('jq','jq','1.7','homebrew/core','x','$PFX/Cellar/jq/1.7'),
+         ('prowl','caarlos0/tap/prowl','1.9.0','caarlos0/tap','x','$PFX/Cellar/prowl/1.9.0');
+INSERT INTO casks(token,name,version,url,sha256,app_path,tap)
+  VALUES ('iterm2','iTerm2','3.5.0','u','x','/Applications/iTerm.app','homebrew/cask'),
+         ('deckclip','Deck','1.4.5','u','x','/Applications/Deck.app','yuzeguitarist/deck');
+INSERT INTO taps(name,url,commit_sha,github_owner,github_repo)
+  VALUES ('caarlos0/tap','https://github.com/caarlos0/homebrew-tap','deadbeef','caarlos0','homebrew-tap'),
+         ('yuzeguitarist/deck','https://github.com/yuzeguitarist/homebrew-deck','deadbeef','yuzeguitarist','homebrew-deck');
+SQL
+
+cat >"$PFX/Brewfile" <<'EOF'
+brew "jq"
+brew "caarlos0/tap/prowl"
+cask "iterm2"
+cask "yuzeguitarist/deck/deckclip"
+EOF
+
+OUT="$PFX/out.txt"
+if ! "$MALT_BIN" bundle install "$PFX/Brewfile" >"$OUT" 2>&1; then
+  fail "warm bundle install reached the network: $(tr '\n' ' ' <"$OUT")"
+fi
+grep -q 'bundle install complete' "$OUT" ||
+  fail 'bundle install never reported completion'
+
+# A member that is genuinely absent must still be attempted, otherwise the
+# fast path is an unconditional skip rather than a presence check.
+printf 'cask "not-installed-xyz"\n' >"$PFX/Brewfile2"
+if "$MALT_BIN" bundle install "$PFX/Brewfile2" >/dev/null 2>&1; then
+  fail 'an uninstalled cask was silently skipped'
+fi
+
+printf 'PASS: a warm bundle install skips the network for members already installed\n'

--- a/scripts/regressions/install_download_only.sh
+++ b/scripts/regressions/install_download_only.sh
@@ -100,6 +100,21 @@ pass "--only-dependencies combo refused"
 [[ -d "$PREFIX/Cellar/$TARGET" ]] || fail "Cellar/$TARGET missing after follow-up install"
 pass "follow-up install populated Cellar/$TARGET"
 
+# ── 4b. Warming over an installed keg must still warm, not no-op. ─────
+# An installed row says nothing about whether the current version's bottle
+# is cached, so the already-installed gate must not swallow the request.
+WARM_LOG="$PREFIX/warm-installed.log"
+"$BIN" install --download-only "$TARGET" >"$WARM_LOG" 2>&1 ||
+  fail "--download-only over an installed keg failed - see $WARM_LOG"
+grep -q 'is already installed' "$WARM_LOG" &&
+  fail "--download-only over an installed keg was skipped instead of warming"
+grep -q 'downloaded to' "$WARM_LOG" ||
+  fail "--download-only over an installed keg reported no download"
+keg_rows_warm=$(sqlite3 "$DB" "SELECT COUNT(*) FROM kegs WHERE name='$TARGET';")
+[[ "$keg_rows_warm" = "1" ]] ||
+  fail "--download-only over an installed keg disturbed the kegs table (rows=$keg_rows_warm)"
+pass "--download-only warms the store over an installed keg without touching it"
+
 # ── 5. Cask --download-only: cache filled, no Caskroom row, no app. ───
 # copilot-cli is a binary cask with no /Applications slot — safe to
 # exercise without touching shared system state.

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -276,16 +276,63 @@ fn kegPresent(ctx: *const AppCtx, prefix: []const u8, name: []const u8) bool {
     return true;
 }
 
+/// Open `<prefix>/db/malt.db` only when it is already there. `Database.open`
+/// carries `SQLITE_OPEN_CREATE`, and the fast path must not bring the DB
+/// into existence just by probing it.
+fn openExistingDb(ctx: *const AppCtx, prefix: []const u8) ?sqlite.Database {
+    var buf: [512]u8 = undefined;
+    const path = std.fmt.bufPrintSentinel(&buf, "{s}/db/malt.db", .{prefix}, 0) catch return null;
+    std.Io.Dir.accessAbsolute(ctx.io, path, .{}) catch return null;
+    return sqlite.Database.open(path) catch null;
+}
+
+/// Presence probe for a `--cask` name. The `casks` row is the marker rather
+/// than `Caskroom/<token>`: `recordCaskroom` is best-effort, so the
+/// directory can be absent under a genuinely installed cask.
+fn caskPresent(ctx: *const AppCtx, prefix: []const u8, token: []const u8) bool {
+    var db = openExistingDb(ctx, prefix) orelse return false;
+    defer db.close();
+    return cask_mod.isInstalled(&db, token);
+}
+
+/// Presence probe for the `owner/repo/leaf` form, which resolves to either
+/// a keg or a cask. The row's `tap` must match in both cases - without
+/// that, `owner/repo/jq` would claim the homebrew/core `jq` as its own.
+fn tapPackagePresent(ctx: *const AppCtx, prefix: []const u8, name: []const u8) bool {
+    const parts = args_mod.parseTapName(name) orelse return false;
+
+    var slug_buf: [256]u8 = undefined;
+    const slug = std.fmt.bufPrint(&slug_buf, "{s}/{s}", .{ parts.user, parts.repo }) catch return false;
+
+    var db = openExistingDb(ctx, prefix) orelse return false;
+    defer db.close();
+
+    // Cask by row alone; its Caskroom dir is best-effort. Keg by row plus
+    // the Cellar entry, same as the plain-formula probe.
+    if (local_mod.tapCaskRecorded(&db, parts.formula, slug)) return true;
+    return kegPresent(ctx, prefix, parts.formula) and
+        local_mod.tapKegRecorded(&db, parts.formula, slug);
+}
+
+/// Route one package name to the probe that matches how it would install.
+/// Mirrors the slow path's dispatch order (tap form wins over `--cask`) so
+/// the gate can never answer for a different install kind than the one the
+/// pipeline would take, and its `--download-only` carve-out: cask and tap
+/// slow paths refresh the cached artefact over an installed package, which
+/// is what `mt upgrade`'s prefetch relies on.
+fn alreadyInstalled(ctx: *const AppCtx, prefix: []const u8, pkg: []const u8, flags: args_mod.InstallFlags) bool {
+    if (isTapFormula(pkg)) return !flags.download_only and tapPackagePresent(ctx, prefix, pkg);
+    if (flags.force_cask) return !flags.download_only and caskPresent(ctx, prefix, pkg);
+    return kegPresent(ctx, prefix, pkg);
+}
+
 /// Read-only DB probe used by the fast-path gate. Returns true iff any
 /// named pkg currently has `install_reason='dependency'` AND
 /// `bin_isolated=1` — i.e. the user is asking us to promote a dep keg
 /// the install pipeline must then re-link bin/sbin for. Quiet on
 /// errors: a missing DB is the empty case, not a failure to surface.
 fn anyNamedNeedsPromotion(ctx: *const AppCtx, prefix: []const u8, packages: []const []const u8) bool {
-    var db_path_buf: [512]u8 = undefined;
-    const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return false;
-    std.Io.Dir.accessAbsolute(ctx.io, db_path, .{}) catch return false;
-    var db = sqlite.Database.open(db_path) catch return false;
+    var db = openExistingDb(ctx, prefix) orelse return false;
     defer db.close();
 
     var stmt = db.prepare(
@@ -294,8 +341,11 @@ fn anyNamedNeedsPromotion(ctx: *const AppCtx, prefix: []const u8, packages: []co
     defer stmt.finalize();
 
     for (packages) |pkg| {
+        // Tap kegs are recorded under their leaf name, so the tap form has
+        // to be reduced before it can match a row.
+        const keg_name = if (args_mod.parseTapName(pkg)) |p| p.formula else pkg;
         stmt.reset() catch return false;
-        stmt.bindText(1, pkg) catch return false;
+        stmt.bindText(1, keg_name) catch return false;
         if (stmt.step() catch false) return true;
     }
     return false;
@@ -497,15 +547,16 @@ fn runInstall(
     };
 
     // Idempotent fast path — skip DB / lock / HTTP setup when every named
-    // arg already has a Cellar entry. Flags that change semantics
-    // (--force / --cask / --local / --dry-run / --only-deps) and
-    // tap-form / .rb-path args route to the regular flow. All-or-nothing
-    // on multi-arg keeps the gate state-free.
+    // arg is already installed. Flags that change semantics
+    // (--force / --local / --dry-run / --only-deps) route to the regular
+    // flow, as do `.rb`-path args: a local formula can change on disk with
+    // no version bump, so it must be re-read. All-or-nothing on multi-arg
+    // keeps the gate state-free.
     const fastpath_eligible = flags.fastpathEligible();
     if (fastpath_eligible) fast: {
         for (packages) |pkg| {
-            if (isTapFormula(pkg) or isLocalFormulaPath(pkg)) break :fast;
-            if (!kegPresent(ctx, prefix, pkg)) break :fast;
+            if (isLocalFormulaPath(pkg)) break :fast;
+            if (!alreadyInstalled(ctx, prefix, pkg, flags)) break :fast;
         }
         // Promotion target — a named pkg currently recorded as an
         // isolated dependency — needs `install_reason` cleared and
@@ -1305,6 +1356,14 @@ fn installCask(
     flags: args_mod.InstallFlags,
     sink: OutputSink,
 ) !void {
+    // Callers that legitimately bypass the fast path would otherwise fetch
+    // just to discover there is nothing to do. The post-parse check below
+    // stays for a cask that ever renames its token.
+    if (!flags.download_only and cask_mod.isInstalled(db, token)) {
+        sink.info("{s} is already installed", .{token});
+        return;
+    }
+
     const cask_json = api.fetchCask(token) catch |e| {
         // Propagate the typed OfflineRequired so the outer dispatch
         // surfaces the snapshot-miss message instead of "not found".

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -317,12 +317,12 @@ fn tapPackagePresent(ctx: *const AppCtx, prefix: []const u8, name: []const u8) b
 /// Route one package name to the probe that matches how it would install.
 /// Mirrors the slow path's dispatch order (tap form wins over `--cask`) so
 /// the gate can never answer for a different install kind than the one the
-/// pipeline would take, and its `--download-only` carve-out: cask and tap
-/// slow paths refresh the cached artefact over an installed package, which
-/// is what `mt upgrade`'s prefetch relies on.
+/// pipeline would take. `--download-only` never reaches here: it vetoes the
+/// gate outright, because warming a cache is work an installed package does
+/// not excuse.
 fn alreadyInstalled(ctx: *const AppCtx, prefix: []const u8, pkg: []const u8, flags: args_mod.InstallFlags) bool {
-    if (isTapFormula(pkg)) return !flags.download_only and tapPackagePresent(ctx, prefix, pkg);
-    if (flags.force_cask) return !flags.download_only and caskPresent(ctx, prefix, pkg);
+    if (isTapFormula(pkg)) return tapPackagePresent(ctx, prefix, pkg);
+    if (flags.force_cask) return caskPresent(ctx, prefix, pkg);
     return kegPresent(ctx, prefix, pkg);
 }
 
@@ -771,6 +771,7 @@ fn runInstall(
                 .cache = &formula_cache,
                 .worker_backing = std.heap.smp_allocator,
                 .sink = sink,
+                .download_only = flags.download_only,
             }, pkg_name, formula_json, flags.force, &all_jobs) catch |e| {
                 sink.err("Failed to resolve {s}: {s}", .{ pkg_name, @errorName(e) });
                 failed_count += 1;

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -270,6 +270,11 @@ pub fn pruneOtherCellarVersionsForReinstall(
 /// down the parent when the last version goes; an orphan empty dir is
 /// `mt doctor --fix` territory rather than something to paper over.
 fn kegPresent(ctx: *const AppCtx, prefix: []const u8, name: []const u8) bool {
+    // The gate runs before the pipeline validates anything, so a dot-entry
+    // like `.` or `..` would otherwise resolve to a directory that always
+    // exists and report a bogus "already installed".
+    if (name.len == 0 or name[0] == '.') return false;
+    api_mod.validateName(name) catch return false;
     var buf: [512]u8 = undefined;
     const cellar_path = std.fmt.bufPrint(&buf, "{s}/Cellar/{s}", .{ prefix, name }) catch return false;
     std.Io.Dir.accessAbsolute(ctx.io, cellar_path, .{}) catch return false;

--- a/src/cli/install/args.zig
+++ b/src/cli/install/args.zig
@@ -189,12 +189,14 @@ pub const InstallFlags = struct {
     // ── Derived predicates: the flag interaction, named ───────────────
 
     /// Eligible for the idempotent fast path that skips DB/lock/HTTP.
-    /// Only modes that change install semantics veto it. `force_cask`
-    /// disambiguates a name rather than changing what install means, so it
-    /// stays out — the gate picks a cask-shaped presence probe instead.
+    /// Only modes that change install semantics veto it. `download_only`
+    /// is one of them: its job is warming the cache, which an installed
+    /// package neither satisfies nor excuses. `force_cask` is not - it
+    /// disambiguates a name rather than changing what install means, so
+    /// the gate picks a cask-shaped presence probe instead.
     pub fn fastpathEligible(self: InstallFlags) bool {
         return !self.force and !self.local_only and
-            !self.dry_run and !self.only_deps;
+            !self.dry_run and !self.only_deps and !self.download_only;
     }
 
     /// Whether the `--force` pre-materialize prune should run.
@@ -376,20 +378,22 @@ test "InstallFlags.fastpathEligible: clear when no semantic flag is set" {
     try std.testing.expect((InstallFlags{}).fastpathEligible());
 }
 
-test "InstallFlags.fastpathEligible: force/local/dry_run/only_deps each veto it" {
+test "InstallFlags.fastpathEligible: force/local/dry_run/only_deps/download_only each veto it" {
     try std.testing.expect(!(InstallFlags{ .force = true }).fastpathEligible());
     try std.testing.expect(!(InstallFlags{ .local_only = true }).fastpathEligible());
     try std.testing.expect(!(InstallFlags{ .dry_run = true }).fastpathEligible());
     try std.testing.expect(!(InstallFlags{ .only_deps = true }).fastpathEligible());
+    // An installed package is not a warm cache: `--download-only` must
+    // still reach the download path so the artefact lands in the store.
+    try std.testing.expect(!(InstallFlags{ .download_only = true }).fastpathEligible());
 }
 
-test "InstallFlags.fastpathEligible: cask/download_only/isolate_deps/force_formula do NOT gate it" {
-    // These four are absent from the fast-path conjunction; the test fails
+test "InstallFlags.fastpathEligible: cask/isolate_deps/force_formula do NOT gate it" {
+    // These three are absent from the fast-path conjunction; the test fails
     // if someone folds one into it and narrows the fast path. `--cask` in
     // particular only disambiguates a name - every bundle cask line sets it,
     // so vetoing on it costs the whole bundle path its fast path.
     try std.testing.expect((InstallFlags{ .force_cask = true }).fastpathEligible());
-    try std.testing.expect((InstallFlags{ .download_only = true }).fastpathEligible());
     try std.testing.expect((InstallFlags{ .isolate_deps = true }).fastpathEligible());
     try std.testing.expect((InstallFlags{ .force_formula = true }).fastpathEligible());
 }

--- a/src/cli/install/args.zig
+++ b/src/cli/install/args.zig
@@ -189,10 +189,11 @@ pub const InstallFlags = struct {
     // ── Derived predicates: the flag interaction, named ───────────────
 
     /// Eligible for the idempotent fast path that skips DB/lock/HTTP.
-    /// Only modes that change install semantics veto it; `download_only`,
-    /// `isolate_deps`, and `force_formula` don't reach the fast path gate.
+    /// Only modes that change install semantics veto it. `force_cask`
+    /// disambiguates a name rather than changing what install means, so it
+    /// stays out — the gate picks a cask-shaped presence probe instead.
     pub fn fastpathEligible(self: InstallFlags) bool {
-        return !self.force and !self.force_cask and !self.local_only and
+        return !self.force and !self.local_only and
             !self.dry_run and !self.only_deps;
     }
 
@@ -375,17 +376,19 @@ test "InstallFlags.fastpathEligible: clear when no semantic flag is set" {
     try std.testing.expect((InstallFlags{}).fastpathEligible());
 }
 
-test "InstallFlags.fastpathEligible: force/cask/local/dry_run/only_deps each veto it" {
+test "InstallFlags.fastpathEligible: force/local/dry_run/only_deps each veto it" {
     try std.testing.expect(!(InstallFlags{ .force = true }).fastpathEligible());
-    try std.testing.expect(!(InstallFlags{ .force_cask = true }).fastpathEligible());
     try std.testing.expect(!(InstallFlags{ .local_only = true }).fastpathEligible());
     try std.testing.expect(!(InstallFlags{ .dry_run = true }).fastpathEligible());
     try std.testing.expect(!(InstallFlags{ .only_deps = true }).fastpathEligible());
 }
 
-test "InstallFlags.fastpathEligible: download_only/isolate_deps/force_formula do NOT gate it" {
-    // These three are absent from the fast-path conjunction; the test
-    // fails if someone folds one into it and narrows the fast path.
+test "InstallFlags.fastpathEligible: cask/download_only/isolate_deps/force_formula do NOT gate it" {
+    // These four are absent from the fast-path conjunction; the test fails
+    // if someone folds one into it and narrows the fast path. `--cask` in
+    // particular only disambiguates a name - every bundle cask line sets it,
+    // so vetoing on it costs the whole bundle path its fast path.
+    try std.testing.expect((InstallFlags{ .force_cask = true }).fastpathEligible());
     try std.testing.expect((InstallFlags{ .download_only = true }).fastpathEligible());
     try std.testing.expect((InstallFlags{ .isolate_deps = true }).fastpathEligible());
     try std.testing.expect((InstallFlags{ .force_formula = true }).fastpathEligible());

--- a/src/cli/install/download.zig
+++ b/src/cli/install/download.zig
@@ -44,6 +44,10 @@ pub const InstallJobDeps = struct {
     /// Where resolution-phase human lines go; terminal by default so the
     /// upgrade re-entry and `mt install` are unchanged.
     sink: OutputSink = sink_mod.terminal,
+    /// `--download-only`: collect jobs even for an installed package, so a
+    /// version bump lands in the store ahead of the upgrade that needs it.
+    /// The pool still stops before materialise/link/record.
+    download_only: bool = false,
 };
 
 /// A bottle download job for parallel processing.
@@ -253,8 +257,10 @@ pub fn collectFormulaJobs(
         return InstallError.FormulaNotFound;
     };
 
-    // Check if already installed
-    if (!force and record.isInstalled(db, formula.name)) {
+    // Check if already installed. `--download-only` skips the gate for the
+    // same reason the cask and tap paths do: the row says nothing about
+    // whether the *current* version's bottle is in the store.
+    if (!force and !ctx.download_only and record.isInstalled(db, formula.name)) {
         ctx.sink.info("{s} is already installed", .{formula.name});
         return;
     }

--- a/src/cli/install/local.zig
+++ b/src/cli/install/local.zig
@@ -188,6 +188,26 @@ pub fn installTapCask(
     return installTapRb(ctx, allocator, pkg_name, db, linker, prefix, dry_run, force, false, .cask_only, sink);
 }
 
+/// True when a row matching `(leaf, tap_slug)` exists. The tap match is what
+/// stops `owner/repo/jq` claiming a homebrew/core `jq` of the same leaf name.
+fn tapRowExists(db: *sqlite.Database, sql: [:0]const u8, leaf: []const u8, tap_slug: []const u8) bool {
+    var stmt = db.prepare(sql) catch return false;
+    defer stmt.finalize();
+    stmt.bindText(1, leaf) catch return false;
+    stmt.bindText(2, tap_slug) catch return false;
+    return stmt.step() catch false;
+}
+
+pub fn tapKegRecorded(db: *sqlite.Database, leaf: []const u8, tap_slug: []const u8) bool {
+    return tapRowExists(db, "SELECT 1 FROM kegs WHERE name=?1 AND tap=?2 LIMIT 1;", leaf, tap_slug);
+}
+
+/// `owner/repo/<token>` resolves to a cask as readily as to a formula, so
+/// the tap probes have to cover both tables.
+pub fn tapCaskRecorded(db: *sqlite.Database, leaf: []const u8, tap_slug: []const u8) bool {
+    return tapRowExists(db, "SELECT 1 FROM casks WHERE token=?1 AND tap=?2 LIMIT 1;", leaf, tap_slug);
+}
+
 fn installTapRb(
     ctx: *const AppCtx,
     allocator: std.mem.Allocator,
@@ -206,16 +226,27 @@ fn installTapRb(
         return InstallError.FormulaNotFound;
     };
 
+    var tap_slug_buf: [128]u8 = undefined;
+    const tap_slug = std.fmt.bufPrint(&tap_slug_buf, "{s}/{s}", .{ parts.user, parts.repo }) catch
+        return InstallError.FormulaNotFound;
+
+    // An already-recorded package needs no `.rb` at all - the post-parse
+    // checks further down reach the same verdict several round trips later.
+    // `--force` and `--download-only` must still re-fetch, and `--dry-run`
+    // still owes the user a plan.
+    const recorded = tapKegRecorded(db, parts.formula, tap_slug) or
+        tapCaskRecorded(db, parts.formula, tap_slug);
+    if (!force and !download_only and !dry_run and recorded) {
+        sink.info("{s} is already installed", .{parts.formula});
+        return;
+    }
+
     sink.info("Resolving tap {s}/{s}/{s}...", .{ parts.user, parts.repo, parts.formula });
 
     // Determine the commit SHA to fetch against. Prefer the pin
     // already in the DB (set at tap-add or last --refresh); if no pin
     // exists yet, resolve HEAD once and record it below. Refuses to
     // build a URL from a floating HEAD at install time.
-    var tap_slug_buf: [128]u8 = undefined;
-    const tap_slug = std.fmt.bufPrint(&tap_slug_buf, "{s}/{s}", .{ parts.user, parts.repo }) catch
-        return InstallError.FormulaNotFound;
-
     const urls = try tap_mod.resolveTapBaseUrls(allocator, db, tap_slug);
     defer urls.deinit(allocator);
 
@@ -1183,6 +1214,29 @@ test "mapTapResolveError handles every TapError tag" {
             mapped == InstallError.FormulaNotFound or
             mapped == InstallError.RecordFailed);
     }
+}
+
+test "tap presence probes require the owning tap to match" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try db.exec(
+        \\CREATE TABLE kegs (name TEXT, tap TEXT);
+        \\CREATE TABLE casks (token TEXT, tap TEXT);
+        \\INSERT INTO kegs VALUES ('jq', 'homebrew/core'), ('prowl', 'caarlos0/tap');
+        \\INSERT INTO casks VALUES ('deckclip', 'yuzeguitarist/deck');
+    );
+
+    try std.testing.expect(tapKegRecorded(&db, "prowl", "caarlos0/tap"));
+    try std.testing.expect(tapCaskRecorded(&db, "deckclip", "yuzeguitarist/deck"));
+
+    // Same leaf name, different owner: claiming this one would install the
+    // wrong package under the right name.
+    try std.testing.expect(!tapKegRecorded(&db, "jq", "caarlos0/tap"));
+    try std.testing.expect(!tapCaskRecorded(&db, "deckclip", "someone/else"));
+
+    // The two tables are not interchangeable.
+    try std.testing.expect(!tapKegRecorded(&db, "deckclip", "yuzeguitarist/deck"));
+    try std.testing.expect(!tapCaskRecorded(&db, "prowl", "caarlos0/tap"));
 }
 
 test "finalizeTapCaskInstall persists the cask row on the happy path" {

--- a/tests/install_idempotent_test.zig
+++ b/tests/install_idempotent_test.zig
@@ -28,6 +28,22 @@ fn seedCellarKeg(prefix: []const u8, name: []const u8, version: []const u8) !voi
     try test_io.cwd().createDirPath(std.Options.debug_io, dir);
 }
 
+/// Create `<prefix>/db/malt.db` with the real schema and run `sql` against
+/// it. The cask and tap-form probes read that DB, so their fixtures need a
+/// genuine one rather than a hand-rolled table.
+fn seedDb(prefix: []const u8, sql: [:0]const u8) !void {
+    const dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{prefix});
+    defer testing.allocator.free(dir);
+    try test_io.cwd().createDirPath(std.Options.debug_io, dir);
+
+    const path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/db/malt.db", .{prefix}, 0);
+    defer testing.allocator.free(path);
+    var db = try malt.sqlite.Database.open(path);
+    defer db.close();
+    try malt.schema.initSchema(&db);
+    try db.exec(sql);
+}
+
 fn setupPrefix(suffix: []const u8) ![:0]u8 {
     const base = try test_io.uniqueTempPath(testing.allocator, "install_idem", suffix);
     defer testing.allocator.free(base);
@@ -125,6 +141,292 @@ test "execute falls through when one of several args is missing from the Cellar"
     install.execute(&ctx, arena.allocator(), &.{ "--quiet", "ALPHA_FIXTURE", "MISSING_FIXTURE" }) catch {};
 
     try testing.expect(pathExists(db_file));
+}
+
+test "execute --cask short-circuits when the cask is recorded in the DB" {
+    const prefix = try setupPrefix("cask");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    try seedDb(prefix,
+        \\INSERT INTO casks(token,name,version,url,sha256,app_path)
+        \\  VALUES('seedcask','SeedCask','1.0','https://example.invalid/a.dmg','x','/Applications/Seed.app');
+    );
+
+    const lock_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.lock", .{prefix});
+    defer testing.allocator.free(lock_file);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try install.execute(&ctx, arena.allocator(), &.{ "--cask", "seedcask" });
+
+    // The DB file is part of the fixture, so the lock is what pins that the
+    // heavy setup never ran.
+    try testing.expect(!pathExists(lock_file));
+    try testing.expect(std.mem.indexOf(u8, captured.items, "seedcask is already installed") != null);
+}
+
+test "execute --cask falls through when no cask row backs the token" {
+    const prefix = try setupPrefix("caskmiss");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    // A Cellar entry must not stand in for a cask row: the two live in
+    // different layouts and only the row survives a partial install.
+    try seedCellarKeg(prefix, "SEEDCASK_FIXTURE", "1.0");
+    try seedDb(prefix, "SELECT 1;");
+
+    const lock_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.lock", .{prefix});
+    defer testing.allocator.free(lock_file);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = malt.app_ctx.processEnviron() };
+    install.execute(&ctx, arena.allocator(), &.{ "--cask", "--quiet", "SEEDCASK_FIXTURE" }) catch {};
+
+    try testing.expect(pathExists(lock_file));
+}
+
+test "execute short-circuits on the tap form when the keg is recorded against that tap" {
+    const prefix = try setupPrefix("tap");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    // A tap keg lands in the Cellar under its leaf name, so the probe needs
+    // both the directory and the row that names the owning tap.
+    try seedCellarKeg(prefix, "tapleaf", "1.0");
+    try seedDb(prefix,
+        \\INSERT INTO kegs(name,full_name,version,tap,store_sha256,cellar_path)
+        \\  VALUES('tapleaf','owner/repo/tapleaf','1.0','owner/repo','x','/Cellar/tapleaf/1.0');
+    );
+
+    const lock_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.lock", .{prefix});
+    defer testing.allocator.free(lock_file);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try install.execute(&ctx, arena.allocator(), &.{"owner/repo/tapleaf"});
+
+    try testing.expect(!pathExists(lock_file));
+    try testing.expect(std.mem.indexOf(u8, captured.items, "owner/repo/tapleaf is already installed") != null);
+}
+
+test "execute falls through when the tap form names a keg owned by another tap" {
+    const prefix = try setupPrefix("tapmismatch");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    // Without the tap match, `owner/repo/tapleaf` would claim the
+    // homebrew/core keg of the same leaf name is what the user asked for.
+    try seedCellarKeg(prefix, "tapleaf", "1.0");
+    try seedDb(prefix,
+        \\INSERT INTO kegs(name,full_name,version,tap,store_sha256,cellar_path)
+        \\  VALUES('tapleaf','tapleaf','1.0','homebrew/core','x','/Cellar/tapleaf/1.0');
+    );
+
+    const lock_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.lock", .{prefix});
+    defer testing.allocator.free(lock_file);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    // No `taps` row for owner/repo, so the fall-through fails at URL
+    // resolution and never reaches the network.
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    install.execute(&ctx, arena.allocator(), &.{ "--quiet", "owner/repo/tapleaf" }) catch {};
+
+    try testing.expect(pathExists(lock_file));
+}
+
+test "execute short-circuits on the tap form when a cask row backs the token" {
+    const prefix = try setupPrefix("tapcask");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    // No Cellar and no Caskroom dir: `recordCaskroom` is best-effort, so the
+    // row is the only marker a tap cask is guaranteed to leave.
+    try seedDb(prefix,
+        \\INSERT INTO casks(token,name,version,url,sha256,app_path,tap)
+        \\  VALUES('deckclip','Deck','1.4.5','https://example.invalid/d.dmg','x','/Applications/Deck.app','owner/repo');
+    );
+
+    const lock_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.lock", .{prefix});
+    defer testing.allocator.free(lock_file);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    try install.execute(&ctx, arena.allocator(), &.{"owner/repo/deckclip"});
+
+    try testing.expect(!pathExists(lock_file));
+    try testing.expect(std.mem.indexOf(u8, captured.items, "owner/repo/deckclip is already installed") != null);
+}
+
+test "execute falls through when the tap form names a cask owned by another tap" {
+    const prefix = try setupPrefix("tapcaskmismatch");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    try seedDb(prefix,
+        \\INSERT INTO casks(token,name,version,url,sha256,app_path,tap)
+        \\  VALUES('deckclip','Deck','1.4.5','https://example.invalid/d.dmg','x','/Applications/Deck.app','homebrew/cask');
+    );
+
+    const lock_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.lock", .{prefix});
+    defer testing.allocator.free(lock_file);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    install.execute(&ctx, arena.allocator(), &.{ "--quiet", "owner/repo/deckclip" }) catch {};
+
+    try testing.expect(pathExists(lock_file));
+}
+
+test "execute --download-only on the tap form still refreshes the cached artefact" {
+    const prefix = try setupPrefix("tapdlonly");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    try seedCellarKeg(prefix, "tapleaf", "1.0");
+    try seedDb(prefix,
+        \\INSERT INTO kegs(name,full_name,version,tap,store_sha256,cellar_path)
+        \\  VALUES('tapleaf','owner/repo/tapleaf','1.0','owner/repo','x','/Cellar/tapleaf/1.0');
+    );
+
+    const lock_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.lock", .{prefix});
+    defer testing.allocator.free(lock_file);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+    install.execute(&ctx, arena.allocator(), &.{ "--download-only", "--quiet", "owner/repo/tapleaf" }) catch {};
+
+    // The prefetch `mt upgrade` relies on must not be swallowed by the gate.
+    try testing.expect(pathExists(lock_file));
+}
+
+test "installTapFormula returns before any fetch when the keg is recorded against that tap" {
+    // Direct entry point: callers that legitimately bypass the fast path
+    // must not pay a `.rb` round trip either. No `taps` row is seeded, so a
+    // regression that drops the short-circuit fails at URL resolution
+    // rather than silently passing.
+    const prefix = try setupPrefix("tapdirect");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    try seedDb(prefix,
+        \\INSERT INTO kegs(name,full_name,version,tap,store_sha256,cellar_path)
+        \\  VALUES('tapleaf','owner/repo/tapleaf','1.0','owner/repo','x','/Cellar/tapleaf/1.0');
+    );
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    const db_path = try std.fmt.allocPrintSentinel(testing.allocator, "{s}/db/malt.db", .{prefix}, 0);
+    defer testing.allocator.free(db_path);
+    var db = try malt.sqlite.Database.open(db_path);
+    defer db.close();
+    var linker = malt.linker.Linker.init(ctx.io, allocator, &db, prefix);
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    try malt.install_local.installTapFormula(
+        &ctx,
+        allocator,
+        "owner/repo/tapleaf",
+        &db,
+        &linker,
+        prefix,
+        false, // dry_run
+        false, // force
+        false, // download_only
+        malt.install_sink.terminal,
+    );
+
+    try testing.expect(std.mem.indexOf(u8, captured.items, "tapleaf is already installed") != null);
+    try testing.expect(std.mem.indexOf(u8, captured.items, "Resolving tap") == null);
 }
 
 test "execute --dry-run skips the fast path so the plan still reaches the user" {

--- a/tests/install_idempotent_test.zig
+++ b/tests/install_idempotent_test.zig
@@ -143,6 +143,41 @@ test "execute falls through when one of several args is missing from the Cellar"
     try testing.expect(pathExists(db_file));
 }
 
+test "execute never claims a dot-entry name is already installed" {
+    const prefix = try setupPrefix("dotentry");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    // `Cellar/.` and `Cellar/..` always resolve, so an unguarded probe
+    // reports success for a name that can never have been installed.
+    const cellar = try std.fmt.allocPrint(testing.allocator, "{s}/Cellar", .{prefix});
+    defer testing.allocator.free(cellar);
+    try test_io.cwd().createDirPath(std.Options.debug_io, cellar);
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    for ([_][]const u8{ ".", "..", "./x" }) |name| {
+        var captured: std.ArrayList(u8) = .empty;
+        defer captured.deinit(testing.allocator);
+        malt.output.beginStderrCapture(testing.allocator, &captured);
+        defer malt.output.endStderrCapture();
+
+        var arena = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+        defer threaded.deinit();
+        const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+        install.execute(&ctx, arena.allocator(), &.{name}) catch {};
+
+        try testing.expect(std.mem.indexOf(u8, captured.items, "is already installed") == null);
+    }
+}
+
 test "execute --cask short-circuits when the cask is recorded in the DB" {
     const prefix = try setupPrefix("cask");
     defer {

--- a/tests/install_idempotent_test.zig
+++ b/tests/install_idempotent_test.zig
@@ -344,6 +344,31 @@ test "execute falls through when the tap form names a cask owned by another tap"
     try testing.expect(pathExists(lock_file));
 }
 
+test "execute --download-only still warms the store for an installed formula" {
+    const prefix = try setupPrefix("dlonlyformula");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    // The keg row says nothing about whether the *current* version's bottle
+    // is in the store, so warming it is never a no-op worth skipping.
+    try seedCellarKeg(prefix, "ALPHA_FIXTURE", "1.0");
+
+    const db_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.db", .{prefix});
+    defer testing.allocator.free(db_file);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = malt.app_ctx.processEnviron() };
+    install.execute(&ctx, arena.allocator(), &.{ "--download-only", "--quiet", "ALPHA_FIXTURE" }) catch {};
+
+    try testing.expect(pathExists(db_file));
+}
+
 test "execute --download-only on the tap form still refreshes the cached artefact" {
     const prefix = try setupPrefix("tapdlonly");
     defer {

--- a/tests/install_test.zig
+++ b/tests/install_test.zig
@@ -477,6 +477,47 @@ test "collectFormulaJobs no-ops when the formula is already installed" {
     try testing.expectEqual(@as(usize, 0), jobs.items.len);
 }
 
+test "collectFormulaJobs still queues an installed formula under --download-only" {
+    // `--download-only` warms the store; an installed row proves nothing
+    // about whether the current version's bottle is cached, so the
+    // already-installed gate must not swallow the request.
+    var arena = testArena();
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var tdb = try TempDb.init("dlonly_installed");
+    defer tdb.deinit();
+
+    var stmt = try tdb.db.prepare(
+        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, install_reason)
+        \\VALUES ('hello', 'hello', '1.0', 'sha', '/tmp', 'direct');
+    );
+    defer stmt.finalize();
+    _ = try stmt.step();
+
+    const json = bottleJsonWithoutDeps("hello");
+
+    var http: malt.client_pool.HttpClientPool = undefined;
+    var api: malt.api.BrewApi = undefined;
+    var store_inst: malt.store.Store = undefined;
+    var jobs: std.ArrayList(install_download.DownloadJob) = .empty;
+    defer jobs.deinit(alloc);
+
+    var cache = malt.deps.FormulaCache.init(alloc);
+    defer cache.deinit();
+
+    try install_download.collectFormulaJobs(
+        .{ .io = std.Options.debug_io, .allocator = alloc, .api = &api, .http_pool = &http, .db = &tdb.db, .store = &store_inst, .cache = &cache, .worker_backing = alloc, .download_only = true },
+        "hello",
+        json,
+        false, // force=false
+        &jobs,
+    );
+
+    try testing.expectEqual(@as(usize, 1), jobs.items.len);
+    try testing.expectEqualStrings("hello", jobs.items[0].name);
+}
+
 /// Seed a BrewApi cache_dir with a freshly-written formula JSON file
 /// under the `formula_<name>.json` naming convention that readCache
 /// honours. Used to avoid hitting the network when collectFormulaJobs


### PR DESCRIPTION
## Description

A `bundle install` where nothing had changed still paid a serial network round trip for every cask and every tap-qualified formula, because only plain formulas were allowed on the idempotent fast path. A hundred-member Brewfile spent minutes discovering it had no work to do. Each name form now has a presence probe of its own, so a warm bundle does no network work at all.

Two related corrections came out of the same gate:

- `--download-only` over an installed formula was a silent no-op, so warming the store ahead of an upgrade fetched nothing. It now warms, as the help text has always promised, and as the cask and tap paths already did.
- `mt install .` and `mt install ..` exited 0 claiming the package was installed, because the probe ran before any name validation.

## Related Issue

- Closes #821

## Notes for Reviewers
- None