### PR TITLE
fix(cask): anchor ZIP extraction to a fresh directory

### DIFF
--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -968,20 +968,32 @@ pub const CaskInstaller = struct {
     }
 
     fn installZip(self: *CaskInstaller, zip_path: []const u8, app_dir: []const u8, cask: *const Cask) ![]const u8 {
-        // Create temp extraction directory
+        // The cask can pre-create any predictable path under the prefix. Use
+        // fresh OS entropy and exclusive creation so it cannot plant the
+        // extraction root before ditto runs.
+        var nonce: [16]u8 = undefined;
+        self.io.randomSecure(&nonce) catch return error.InstallFailed;
+        const nonce_hex = std.fmt.bytesToHex(nonce, .lower);
         var tmp_buf: [512]u8 = undefined;
-        const extract_dir = std.fmt.bufPrint(&tmp_buf, "{s}/tmp/cask_extract_{s}", .{ self.prefix, cask.token }) catch
+        const extract_dir = std.fmt.bufPrint(&tmp_buf, "{s}/tmp/cask_extract_{s}_{s}", .{ self.prefix, cask.token, nonce_hex }) catch
             return error.InstallFailed;
-        std.Io.Dir.createDirAbsolute(self.io, extract_dir, .default_dir) catch |e| switch (e) {
-            error.PathAlreadyExists => {},
-            else => return error.InstallFailed,
-        };
+        std.Io.Dir.createDirAbsolute(self.io, extract_dir, std.Io.File.Permissions.fromMode(0o700)) catch
+            return error.InstallFailed;
         // temp extract dir; leftover tolerated if teardown races.
         defer std.Io.Dir.cwd().deleteTree(self.io, extract_dir) catch {};
 
-        // Extract with ditto -xk (handles macOS-specific ZIP features)
-        const ditto_argv = [_][]const u8{ "ditto", "-xk", zip_path, extract_dir };
-        child_mod.runOrFail(self.io, self.allocator, &ditto_argv) catch return error.InstallFailed;
+        // Hold the directory itself and make it the child's cwd. `fchdir`
+        // anchors ditto to the created inode, closing the check/use gap that a
+        // later pathname replacement would otherwise reopen.
+        const extract_handle = std.Io.Dir.openDirAbsolute(self.io, extract_dir, .{
+            .follow_symlinks = false,
+        }) catch return error.InstallFailed;
+        defer extract_handle.close(self.io);
+
+        // Extract with ditto -xk (handles macOS-specific ZIP features).
+        const ditto_argv = [_][]const u8{ "ditto", "-xk", zip_path, "." };
+        child_mod.runOrFailInDir(self.io, self.allocator, &ditto_argv, extract_handle) catch
+            return error.InstallFailed;
 
         return self.placeExtracted(extract_dir, app_dir, cask);
     }
@@ -1839,6 +1851,64 @@ test "parseCask accepts legitimate token and version" {
         var cask = try parseCask(a, json);
         cask.deinit();
     }
+}
+
+test "installZip does not extract through a pre-existing predictable symlink" {
+    var threaded: std.Io.Threaded = .init(std.heap.c_allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const base = try std.fmt.allocPrintSentinel(a, "/tmp/malt_cask_zip_root_{d}", .{std.c.getpid()}, 0);
+    std.Io.Dir.cwd().deleteTree(io, base) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, base) catch {};
+
+    const prefix = try std.fmt.allocPrintSentinel(a, "{s}/prefix", .{base}, 0);
+    const tmp_dir = try std.fmt.allocPrint(a, "{s}/tmp", .{prefix});
+    const extract_link = try std.fmt.allocPrint(a, "{s}/cask_extract_evil", .{tmp_dir});
+    const outside = try std.fmt.allocPrint(a, "{s}/outside", .{base});
+    const source = try std.fmt.allocPrint(a, "{s}/source/Evil.app/Contents", .{base});
+    const source_root = try std.fmt.allocPrint(a, "{s}/source/Evil.app", .{base});
+    const payload = try std.fmt.allocPrint(a, "{s}/payload", .{source});
+    const zip_path = try std.fmt.allocPrint(a, "{s}/evil.zip", .{base});
+    const app_dir = try std.fmt.allocPrint(a, "{s}/Applications", .{base});
+
+    try std.Io.Dir.cwd().createDirPath(io, tmp_dir);
+    try std.Io.Dir.cwd().createDirPath(io, outside);
+    try std.Io.Dir.cwd().createDirPath(io, source);
+    try std.Io.Dir.cwd().createDirPath(io, app_dir);
+    {
+        const f = try std.Io.Dir.createFileAbsolute(io, payload, .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "OWNED");
+    }
+    try std.Io.Dir.symLinkAbsolute(io, outside, extract_link, .{});
+
+    const zip_argv = [_][]const u8{ "/usr/bin/ditto", "-c", "-k", "--keepParent", source_root, zip_path };
+    try child_mod.runOrFail(io, a, &zip_argv);
+
+    var cask = try parseCask(a,
+        \\{"token":"evil","name":["Evil"],"version":"1.0","url":"https://example.invalid/evil.zip","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","artifacts":[{"app":["Evil.app"]}]}
+    );
+    defer cask.deinit();
+    var installer: CaskInstaller = .{
+        .allocator = a,
+        .io = io,
+        .environ = .empty,
+        .prefix = prefix,
+        .db = undefined,
+        .progress = null,
+    };
+
+    const installed = try installer.installZip(zip_path, app_dir, &cask);
+    a.free(installed);
+
+    const escaped_payload = try std.fmt.allocPrint(a, "{s}/Evil.app/Contents/payload", .{outside});
+    try std.testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(io, escaped_payload, .{}),
+    );
 }
 
 test "parseCask does not length-cap a clean version" {

--- a/src/core/child.zig
+++ b/src/core/child.zig
@@ -70,8 +70,18 @@ pub fn run(
     allocator: std.mem.Allocator,
     argv: []const []const u8,
 ) ChildError!RunReport {
+    return runWithCwd(io, allocator, argv, .inherit);
+}
+
+fn runWithCwd(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+    cwd: std.process.Child.Cwd,
+) ChildError!RunReport {
     var child = std.process.spawn(io, .{
         .argv = argv,
+        .cwd = cwd,
         .stdout = .pipe,
         .stderr = .pipe,
     }) catch return error.SpawnFailed;
@@ -122,6 +132,25 @@ pub fn runOrFail(
     argv: []const []const u8,
 ) ChildError!void {
     const report = try run(io, allocator, argv);
+    defer report.deinit(allocator);
+    if (report.code == 0) return;
+
+    const stderr_file = std.Io.File.stderr();
+    if (report.stderr.len > 0) stderr_file.writeStreamingAll(io, report.stderr) catch {};
+    if (report.stdout.len > 0) stderr_file.writeStreamingAll(io, report.stdout) catch {};
+    return error.NonZeroExit;
+}
+
+/// Run a command with its working directory anchored to an already-open
+/// directory handle. On POSIX, spawn uses `fchdir`, so a pathname swap cannot
+/// redirect a child that writes relative to `.`.
+pub fn runOrFailInDir(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+    cwd: std.Io.Dir,
+) ChildError!void {
+    const report = try runWithCwd(io, allocator, argv, .{ .dir = cwd });
     defer report.deinit(allocator);
     if (report.code == 0) return;
 
@@ -192,6 +221,44 @@ test "runOrFail returns SpawnFailed when program does not exist" {
     defer threaded.deinit();
     const argv = [_][]const u8{"/nonexistent/binary/malt_child_test"};
     try std.testing.expectError(ChildError.SpawnFailed, runOrFail(threaded.io(), std.testing.allocator, &argv));
+}
+
+test "runOrFailInDir anchors relative writes to the open directory" {
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    const a = std.testing.allocator;
+    const base = try std.fmt.allocPrintSentinel(a, "/tmp/malt_child_cwd_{d}", .{std.c.getpid()}, 0);
+    defer a.free(base);
+    std.Io.Dir.cwd().deleteTree(io, base) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, base) catch {};
+
+    const work = try std.fmt.allocPrint(a, "{s}/work", .{base});
+    defer a.free(work);
+    const held = try std.fmt.allocPrint(a, "{s}/held", .{base});
+    defer a.free(held);
+    const outside = try std.fmt.allocPrint(a, "{s}/outside", .{base});
+    defer a.free(outside);
+    const held_marker = try std.fmt.allocPrint(a, "{s}/marker", .{held});
+    defer a.free(held_marker);
+    const outside_marker = try std.fmt.allocPrint(a, "{s}/marker", .{outside});
+    defer a.free(outside_marker);
+
+    try std.Io.Dir.cwd().createDirPath(io, work);
+    try std.Io.Dir.cwd().createDirPath(io, outside);
+    const work_handle = try std.Io.Dir.openDirAbsolute(io, work, .{ .follow_symlinks = false });
+    defer work_handle.close(io);
+    try std.Io.Dir.renameAbsolute(work, held, io);
+    try std.Io.Dir.symLinkAbsolute(io, outside, work, .{});
+
+    const argv = [_][]const u8{ "/usr/bin/touch", "marker" };
+    try runOrFailInDir(io, a, &argv, work_handle);
+
+    try std.Io.Dir.accessAbsolute(io, held_marker, .{});
+    try std.testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(io, outside_marker, .{}),
+    );
 }
 
 test "runOrFailInherit returns void on exit code 0" {


### PR DESCRIPTION
## Description

ZIP casks used a predictable extraction path based only on the cask token. If that path already existed as a symlink, `ditto` followed it and extracted the archive outside the prefix.

This change creates the extraction directory exclusively with 128 bits of fresh OS entropy and mode `0700`. It keeps the directory open and runs `ditto` with that handle as its working directory, using `.` as the extraction target. On macOS, the child changes directory with `fchdir`, so replacing the pathname after creation cannot redirect the archive write.

## Related Issue

Closes #853.

## Notes for Reviewers

The tests cover a pre-existing symlink at the old predictable path and replacement of an opened working-directory path with an outside symlink. Before the fix, the ZIP regression failed, `test-one` passed 2,424 of 2,425 tests, and the payload appeared outside the prefix.

Verification after the fix completed with:

- `zig build`: 8 of 8 steps succeeded
- `zig build test-one`: 2,426 passed
- `spawn_invariant_test`: 1 passed
- `zig build test`: 331 of 331 steps succeeded; 5,061 tests passed and 3 skipped
- Commit signature verified with `git verify-commit`

Earlier local full-suite attempts reached unchanged networked integration tests, then stalled with GitHub HTTPS sockets in `CLOSE_WAIT`. I stopped those attempts with exit 130. The retry completed with exit 0 after the firewall rules were corrected.