### PR TITLE
fix: use trusted paths for macOS system tools

### DIFF
--- a/src/cli/doctor.zig
+++ b/src/cli/doctor.zig
@@ -747,16 +747,15 @@ fn checkStaleLock(ctx: CheckCtx, name: []const u8) CheckResult {
 }
 
 fn checkExternalTool(ctx: CheckCtx, name: []const u8) CheckResult {
-    // Row title is also the PATH binary to probe.
-    if (externalToolAvailable(ctx.io, ctx.environ, name)) {
+    if (externalToolAvailable(ctx.io, patch.external_tool_path)) {
         printCheck(name, .ok, null);
         return .ok;
     }
     var et_buf: [256]u8 = undefined;
     const msg = std.fmt.bufPrint(
         &et_buf,
-        "`{s}` not found on PATH. Install Xcode Command Line Tools: xcode-select --install",
-        .{name},
+        "`{s}` not found. Install Xcode Command Line Tools: xcode-select --install",
+        .{patch.external_tool_path},
     ) catch "External relocation tool missing. Install Xcode Command Line Tools.";
     printCheck(name, .warn_status, msg);
     return .warn_status;
@@ -1545,28 +1544,13 @@ pub fn pathContainsDir(path_env: []const u8, dir: []const u8) bool {
     return false;
 }
 
-/// Fast existence check for a platform relocation tool on PATH.
-/// Tries `/usr/bin/<tool>` first (where Xcode Command Line Tools land
-/// install_name_tool) and then walks `PATH` entry-by-entry. `pub` so
-/// the doctor render test can exercise both branches.
-pub fn externalToolAvailable(io: std.Io, environ: std.process.Environ, tool: []const u8) bool {
-    // Fast path for the common macOS case — avoids allocating a PATH
-    // walk on every `mt doctor` invocation.
-    var fast_buf: [64]u8 = undefined;
-    const fast_path = std.fmt.bufPrint(&fast_buf, "/usr/bin/{s}", .{tool}) catch null;
-    if (fast_path) |p| {
-        if (std.Io.Dir.accessAbsolute(io, p, .{})) |_| return true else |_| {}
-    }
-
-    const path_env = std.process.Environ.getPosix(environ, "PATH") orelse return false;
-    var it = std.mem.splitScalar(u8, path_env, ':');
-    while (it.next()) |dir| {
-        if (dir.len == 0) continue;
-        var buf: [std.fs.max_path_bytes]u8 = undefined;
-        const full = std.fmt.bufPrint(&buf, "{s}/{s}", .{ dir, tool }) catch continue;
-        if (std.Io.Dir.accessAbsolute(io, full, .{})) |_| return true else |_| {}
-    }
-    return false;
+/// Check the exact platform helper path used by the relocation backend.
+/// A PATH lookup could report a prefix-resident shim as healthy even though
+/// production deliberately refuses to execute it.
+pub fn externalToolAvailable(io: std.Io, tool_path: []const u8) bool {
+    if (!std.fs.path.isAbsolute(tool_path)) return false;
+    std.Io.Dir.accessAbsolute(io, tool_path, .{}) catch return false;
+    return true;
 }
 
 /// Summary of how many locally-installed kegs still point at their

--- a/src/cli/version_update.zig
+++ b/src/cli/version_update.zig
@@ -8,6 +8,7 @@
 //! `MALT_ALLOW_UNVERIFIED=1`.
 
 const std = @import("std");
+const system_tools = @import("../system_tools.zig");
 const builtin = @import("builtin");
 const client_mod = @import("../net/client.zig");
 const archive = @import("../fs/archive.zig");
@@ -340,7 +341,7 @@ fn replaceBinary(
 /// emits, so cleanup paths see one layout regardless of how the swap
 /// happened. macOS BSD-install spelling: GNU's `-S .old` is wrong here.
 pub fn buildSudoInstallArgv(new_binary: []const u8, target: []const u8) [9][]const u8 {
-    return .{ "sudo", "install", "-m", "0755", "-b", "-B", ".old", new_binary, target };
+    return .{ system_tools.sudo, system_tools.install, "-m", "0755", "-b", "-B", ".old", new_binary, target };
 }
 
 /// Spawn `sudo install` with the user's TTY inherited. Sudo prompts for
@@ -371,9 +372,9 @@ fn migrateTwinToSymlink(
     const mt_path = try std.fmt.bufPrint(&mt_buf, "{s}/mt", .{dir});
 
     const argv: []const []const u8 = if (mode == .sudo)
-        &.{ "sudo", "ln", "-sfn", "malt", mt_path }
+        &.{ system_tools.sudo, system_tools.ln, "-sfn", "malt", mt_path }
     else
-        &.{ "ln", "-sfn", "malt", mt_path };
+        &.{ system_tools.ln, "-sfn", "malt", mt_path };
 
     var child = std.process.spawn(ctx.io, .{ .argv = argv }) catch return error.SpawnFailed;
     const term = child.wait(ctx.io) catch return error.SpawnFailed;

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -2,6 +2,7 @@
 //! Cask JSON parsing and installation (DMG, PKG, ZIP, tar.gz).
 
 const std = @import("std");
+const builtin = @import("builtin");
 const system_tools = @import("../system_tools.zig");
 
 const sqlite = @import("../db/sqlite.zig");
@@ -1675,6 +1676,29 @@ test "pgrepPattern rejects an empty path and a buffer it would overrun" {
     try std.testing.expect(pgrepPattern(&buf, "") == null);
     var tiny: [4]u8 = undefined;
     try std.testing.expect(pgrepPattern(&tiny, "/tmp/x/Running.app") == null);
+}
+
+test "isAppRunning ignores a PATH-resident pgrep shim" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+
+    const io = std.Options.debug_io;
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const root = try std.fmt.allocPrintSentinel(a, "/tmp/malt_pgrep_shim_{d}", .{std.c.getpid()}, 0);
+    std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    const shim = try std.fmt.allocPrint(a, "{s}/pgrep", .{root});
+    try std.Io.Dir.cwd().createDirPath(io, root);
+    try std.Io.Dir.symLinkAbsolute(io, "/usr/bin/true", shim, .{});
+
+    const path_entry = try std.fmt.allocPrintSentinel(a, "PATH={s}", .{root}, 0);
+    const entries = [_:null]?[*:0]const u8{path_entry.ptr};
+    const environ: std.process.Environ = .{ .block = .{ .slice = &entries } };
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{ .environ = environ });
+    defer threaded.deinit();
+
+    try std.testing.expect(!isAppRunning(threaded.io(), "/nonexistent/Malt-test-never-running.app"));
 }
 
 test "parseCask rejects path-traversal in token or version" {

--- a/src/core/cask.zig
+++ b/src/core/cask.zig
@@ -2,6 +2,7 @@
 //! Cask JSON parsing and installation (DMG, PKG, ZIP, tar.gz).
 
 const std = @import("std");
+const system_tools = @import("../system_tools.zig");
 
 const sqlite = @import("../db/sqlite.zig");
 const client_mod = @import("../net/client.zig");
@@ -928,16 +929,16 @@ pub const CaskInstaller = struct {
 
         // Mount DMG (hdiutil attach -nobrowse -readonly -mountpoint {path} {dmg})
         const mount_argv = [_][]const u8{
-            "hdiutil",     "attach",
-            "-nobrowse",   "-readonly",
-            "-mountpoint", mount_point,
+            system_tools.hdiutil, "attach",
+            "-nobrowse",          "-readonly",
+            "-mountpoint",        mount_point,
             dmg_path,
         };
         child_mod.runOrFail(self.io, self.allocator, &mount_argv) catch return error.InstallFailed;
 
         // Unmount on any exit; kernel reaps stuck mounts on reboot if both fail.
         defer {
-            const detach_argv = [_][]const u8{ "hdiutil", "detach", mount_point, "-quiet" };
+            const detach_argv = [_][]const u8{ system_tools.hdiutil, "detach", mount_point, "-quiet" };
             child_mod.runOrFail(self.io, self.allocator, &detach_argv) catch {};
             std.Io.Dir.deleteDirAbsolute(self.io, mount_point) catch {};
         }
@@ -961,7 +962,7 @@ pub const CaskInstaller = struct {
         std.Io.Dir.cwd().deleteTree(self.io, dst_app) catch {};
 
         // Copy .app bundle using ditto (preserves resource forks, xattrs)
-        const ditto_argv = [_][]const u8{ "ditto", src_app, dst_app };
+        const ditto_argv = [_][]const u8{ system_tools.ditto, src_app, dst_app };
         child_mod.runOrFail(self.io, self.allocator, &ditto_argv) catch return error.InstallFailed;
 
         return dst_app;
@@ -980,7 +981,7 @@ pub const CaskInstaller = struct {
         defer std.Io.Dir.cwd().deleteTree(self.io, extract_dir) catch {};
 
         // Extract with ditto -xk (handles macOS-specific ZIP features)
-        const ditto_argv = [_][]const u8{ "ditto", "-xk", zip_path, extract_dir };
+        const ditto_argv = [_][]const u8{ system_tools.ditto, "-xk", zip_path, extract_dir };
         child_mod.runOrFail(self.io, self.allocator, &ditto_argv) catch return error.InstallFailed;
 
         return self.placeExtracted(extract_dir, app_dir, cask);
@@ -1021,7 +1022,7 @@ pub const CaskInstaller = struct {
         std.Io.Dir.cwd().deleteTree(self.io, dst_app) catch {};
 
         // Move .app to /Applications
-        const mv_argv = [_][]const u8{ "ditto", src_app, dst_app };
+        const mv_argv = [_][]const u8{ system_tools.ditto, src_app, dst_app };
         child_mod.runOrFail(self.io, self.allocator, &mv_argv) catch return error.InstallFailed;
 
         return dst_app;
@@ -1216,7 +1217,7 @@ pub const CaskInstaller = struct {
 
         // existing app may not be present.
         std.Io.Dir.cwd().deleteTree(self.io, dst_app) catch {};
-        const mv_argv = [_][]const u8{ "ditto", src_app, dst_app };
+        const mv_argv = [_][]const u8{ system_tools.ditto, src_app, dst_app };
         child_mod.runOrFail(self.io, self.allocator, &mv_argv) catch return error.InstallFailed;
         return dst_app;
     }
@@ -1296,7 +1297,7 @@ pub const CaskInstaller = struct {
         // confirmation, so sudo here has a terminal to prompt on. Inherit
         // stdio (not the captured `run`) so the password prompt and the
         // installer's progress reach the user live, not as a post-mortem dump.
-        const argv = [_][]const u8{ "sudo", "installer", "-pkg", pkg_path, "-target", "/" };
+        const argv = [_][]const u8{ system_tools.sudo, system_tools.installer, "-pkg", pkg_path, "-target", "/" };
         child_mod.runOrFailInherit(self.io, &argv) catch return error.InstallFailed;
         // PKG installs don't have a single app path — record the pkg location
         return std.fmt.allocPrint(self.allocator, "{s}", .{pkg_path}) catch return error.OutOfMemory;
@@ -1436,7 +1437,7 @@ fn isAppRunning(io: std.Io, app_path: []const u8) bool {
     // pgrep -f reads its pattern as a regex over every process's whole command line.
     var pat_buf: [std.Io.Dir.max_path_bytes * 2 + 2]u8 = undefined;
     const pattern = pgrepPattern(&pat_buf, app_path) orelse return false;
-    const argv = [_][]const u8{ "pgrep", "-f", pattern };
+    const argv = [_][]const u8{ system_tools.pgrep, "-f", pattern };
     var child = std.process.spawn(io, .{
         .argv = &argv,
         .stdout = .ignore,

--- a/src/core/dsl/builtins/process.zig
+++ b/src/core/dsl/builtins/process.zig
@@ -2,6 +2,7 @@
 //! system() builtin using std.process.spawn
 
 const std = @import("std");
+const system_tools = @import("../../../system_tools.zig");
 const values = @import("../values.zig");
 const pathname = @import("pathname.zig");
 const sandbox = @import("../sandbox.zig");
@@ -211,7 +212,7 @@ pub fn osLinux(_: ExecCtx, _: ?Value, _: []const Value) BuiltinError!Value {
 /// MacOS.version — return version as string (used for comparisons)
 pub fn macosVersion(ctx: ExecCtx, _: ?Value, _: []const Value) BuiltinError!Value {
     // Get macOS version from sw_vers
-    const argv = [_][]const u8{ "sw_vers", "-productVersion" };
+    const argv = [_][]const u8{ system_tools.sw_vers, "-productVersion" };
     var child = std.process.spawn(ctx.io, .{
         .argv = &argv,
         .stdout = .pipe,

--- a/src/core/patch.zig
+++ b/src/core/patch.zig
@@ -26,6 +26,7 @@ pub const patchPathsCollecting = backend.patchPathsCollecting;
 pub const patchTextFiles = backend.patchTextFiles;
 pub const flushOverflow = backend.flushOverflow;
 pub const external_tool_name = backend.external_tool_name;
+pub const external_tool_path = backend.external_tool_path;
 /// Read-only "does this binary link a path containing `needle`" probe.
 /// The ELF backend supplies a `DT_NEEDED`/`RUNPATH` equivalent.
 pub const fileLinksPath = backend.fileLinksPath;
@@ -44,6 +45,7 @@ test "facade re-exports the patcher surface cellar / doctor rely on" {
     _ = patchTextFiles;
     _ = flushOverflow;
     _ = external_tool_name;
+    _ = external_tool_path;
     _ = fileLinksPath;
     _ = VerifyError;
     _ = verifyFile;
@@ -52,6 +54,8 @@ test "facade re-exports the patcher surface cellar / doctor rely on" {
 test "facade external_tool_name matches the macOS backend" {
     try std.testing.expectEqualStrings("install_name_tool", external_tool_name);
     try std.testing.expectEqualStrings(backend.external_tool_name, external_tool_name);
+    try std.testing.expectEqualStrings("/usr/bin/install_name_tool", external_tool_path);
+    try std.testing.expectEqualStrings(backend.external_tool_path, external_tool_path);
 }
 
 test "facade Replacement / OverflowEntry / PatchOutcome are identical to the backend's" {

--- a/src/core/services/supervisor.zig
+++ b/src/core/services/supervisor.zig
@@ -27,6 +27,7 @@
 //!   files.
 
 const std = @import("std");
+const system_tools = @import("../../system_tools.zig");
 const builtin = @import("builtin");
 const sqlite = @import("../../db/sqlite.zig");
 const plist_mod = @import("plist.zig");
@@ -330,7 +331,7 @@ pub fn start(ctx: SupervisorCtx, name: []const u8) SupervisorError!void {
     const domain = userDomain(allocator) catch return SupervisorError.OutOfMemory;
     defer allocator.free(domain);
 
-    try runLaunchctl(ctx.io, &.{ "launchctl", "bootstrap", domain, plist_path });
+    try runLaunchctl(ctx.io, &.{ system_tools.launchctl, "bootstrap", domain, plist_path });
     // Status is a UI hint; launchctl is the source of truth for liveness.
     setStatus(ctx.db, label, "running") catch {};
 }
@@ -345,7 +346,7 @@ pub fn stop(ctx: SupervisorCtx, name: []const u8) SupervisorError!void {
     const domain = userDomain(allocator) catch return SupervisorError.OutOfMemory;
     defer allocator.free(domain);
 
-    try runLaunchctl(ctx.io, &.{ "launchctl", "bootout", domain, plist_path });
+    try runLaunchctl(ctx.io, &.{ system_tools.launchctl, "bootout", domain, plist_path });
     // Status is a UI hint; launchctl is the source of truth for liveness.
     setStatus(ctx.db, label, "stopped") catch {};
 }
@@ -429,7 +430,7 @@ pub fn queryRuntime(io: std.Io, allocator: std.mem.Allocator, label: []const u8)
     // a sub-millisecond parse cost but the codebase doesn't otherwise
     // use that API, so the complexity isn't worth it for this cold path.
     const result = std.process.run(allocator, io, .{
-        .argv = &.{ "launchctl", "list" },
+        .argv = &.{ system_tools.launchctl, "list" },
         .stdout_limit = .limited(4 * 1024 * 1024),
         .stderr_limit = .limited(4 * 1024 * 1024),
     }) catch return .not_loaded;

--- a/src/fs/archive.zig
+++ b/src/fs/archive.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const system_tools = @import("../system_tools.zig");
 
 /// `c_allocator` is used for `std.process.Child` internals (argv/env
@@ -712,6 +713,45 @@ fn testExtract(io: std.Io, s: *Scratch, raw: []const u8) !void {
     const gz = testGzip(&gz_buf, raw);
     try s.dir.writeFile(io, .{ .sub_path = "a.tar.gz", .data = gz });
     return extractTarGz(io, s.p("/a.tar.gz"), s.p("/dest"));
+}
+
+test "extractZip ignores a PATH-resident unzip shim" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+
+    var s = try Scratch.init("zip_path_shim");
+    defer s.deinit();
+    const source = s.p("/payload");
+    const archive_path = s.p("/payload.zip");
+    const dest = s.p("/dest");
+    const shim_dir = s.p("/shim");
+    const shim = s.p("/shim/unzip");
+    try s.dir.createDirPath(test_io, "dest");
+    try s.dir.createDirPath(test_io, "shim");
+    {
+        const f = try std.Io.Dir.createFileAbsolute(test_io, source, .{});
+        defer f.close(test_io);
+        try f.writeStreamingAll(test_io, "payload");
+    }
+
+    var host_io: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer host_io.deinit();
+    var zip = try std.process.spawn(host_io.io(), .{
+        .argv = &.{ "/usr/bin/zip", "-j", "-q", archive_path, source },
+        .stdout = .ignore,
+        .stderr = .ignore,
+    });
+    const zip_term = try zip.wait(host_io.io());
+    try std.testing.expect(zip_term == .exited and zip_term.exited == 0);
+    try std.Io.Dir.symLinkAbsolute(test_io, "/usr/bin/false", shim, .{});
+
+    const path_entry = try std.fmt.allocPrintSentinel(s.arena.allocator(), "PATH={s}", .{shim_dir}, 0);
+    const entries = [_:null]?[*:0]const u8{path_entry.ptr};
+    const environ: std.process.Environ = .{ .block = .{ .slice = &entries } };
+    var shim_io: std.Io.Threaded = .init(std.testing.allocator, .{ .environ = environ });
+    defer shim_io.deinit();
+
+    try extractZip(shim_io.io(), archive_path, dest);
+    try std.Io.Dir.accessAbsolute(test_io, s.p("/dest/payload"), .{});
 }
 
 test "extractTarGz rejects a pax linkpath that escapes the destination" {

--- a/src/fs/archive.zig
+++ b/src/fs/archive.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const system_tools = @import("../system_tools.zig");
 
 /// `c_allocator` is used for `std.process.Child` internals (argv/env
 /// bookkeeping) throughout this module. Callers may be running under an
@@ -431,7 +432,7 @@ pub fn extractZip(io: std.Io, archive_path: []const u8, dest_dir: []const u8) !v
     try validateZip(io, archive_path);
 
     // -q: quiet, -o: overwrite without prompting, -d: destination dir.
-    const argv = [_][]const u8{ "unzip", "-q", "-o", archive_path, "-d", dest_dir };
+    const argv = [_][]const u8{ system_tools.unzip, "-q", "-o", archive_path, "-d", dest_dir };
     var child = std.process.spawn(io, .{
         .argv = &argv,
     }) catch return error.ExtractionFailed;
@@ -451,7 +452,7 @@ pub fn extractZip(io: std.Io, archive_path: []const u8, dest_dir: []const u8) !v
 fn validateZip(io: std.Io, archive_path: []const u8) !void {
     // `-Z1` prints one entry name per line with no headers or sizes —
     // a zero-column listing we can scan without parsing unzip's table.
-    const argv = [_][]const u8{ "unzip", "-Z1", archive_path };
+    const argv = [_][]const u8{ system_tools.unzip, "-Z1", archive_path };
     try validateSubprocessListing(io, &argv);
 }
 
@@ -464,7 +465,7 @@ fn validateZip(io: std.Io, archive_path: []const u8) !void {
 pub fn extractTarXzFile(io: std.Io, archive_path: []const u8, dest_dir: []const u8) !void {
     try validateTarListing(io, archive_path);
 
-    const argv = [_][]const u8{ "tar", "xf", archive_path, "-C", dest_dir, "--no-same-permissions", "--no-same-owner" };
+    const argv = [_][]const u8{ system_tools.tar, "xf", archive_path, "-C", dest_dir, "--no-same-permissions", "--no-same-owner" };
     var child = std.process.spawn(io, .{
         .argv = &argv,
     }) catch return error.ExtractionFailed;
@@ -482,7 +483,7 @@ pub fn extractTarXzFile(io: std.Io, archive_path: []const u8, dest_dir: []const 
 }
 
 fn validateTarListing(io: std.Io, archive_path: []const u8) !void {
-    const argv = [_][]const u8{ "tar", "tf", archive_path };
+    const argv = [_][]const u8{ system_tools.tar, "tf", archive_path };
     try validateSubprocessListing(io, &argv);
 }
 

--- a/src/macho/codesign.zig
+++ b/src/macho/codesign.zig
@@ -2,6 +2,7 @@
 //! Ad-hoc codesigning wrapper for arm64 Mach-O binaries.
 
 const std = @import("std");
+const system_tools = @import("../system_tools.zig");
 const builtin = @import("builtin");
 
 pub const CodesignError = error{
@@ -34,11 +35,11 @@ pub fn adHocSign(io: std.Io, allocator: std.mem.Allocator, path: []const u8) Cod
 pub fn adHocSignAll(io: std.Io, allocator: std.mem.Allocator, paths: []const []const u8) CodesignError!void {
     if (paths.len == 0) return;
 
-    // argv = ["codesign", "--force", "--sign", "-", path1, path2, ...]
+    // argv = ["/usr/bin/codesign", "--force", "--sign", "-", path1, path2, ...]
     var argv = std.ArrayList([]const u8).initCapacity(allocator, paths.len + 4) catch
         return CodesignError.OutOfMemory;
     defer argv.deinit(allocator);
-    argv.appendAssumeCapacity("codesign");
+    argv.appendAssumeCapacity(system_tools.codesign);
     argv.appendAssumeCapacity("--force");
     argv.appendAssumeCapacity("--sign");
     argv.appendAssumeCapacity("-");
@@ -57,4 +58,30 @@ pub fn adHocSignAll(io: std.Io, allocator: std.mem.Allocator, paths: []const []c
         },
         else => return CodesignError.CodesignFailed,
     }
+}
+
+test "adHocSignAll does not execute a prefix-resident codesign shim" {
+    const testing = std.testing;
+    const io = std.Options.debug_io;
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const root = try std.fmt.allocPrintSentinel(a, "/tmp/malt_codesign_shim_{d}", .{std.c.getpid()}, 0);
+    std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    const bin = try std.fmt.allocPrint(a, "{s}/bin", .{root});
+    const shim = try std.fmt.allocPrint(a, "{s}/codesign", .{bin});
+    try std.Io.Dir.cwd().createDirPath(io, bin);
+    try std.Io.Dir.symLinkAbsolute(io, "/usr/bin/true", shim, .{});
+
+    const path_entry = try std.fmt.allocPrintSentinel(a, "PATH={s}:/usr/bin:/bin", .{bin}, 0);
+    const entries = [_:null]?[*:0]const u8{path_entry.ptr};
+    const environ: std.process.Environ = .{ .block = .{ .slice = &entries } };
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{ .environ = environ });
+    defer threaded.deinit();
+
+    try testing.expectError(
+        CodesignError.CodesignFailed,
+        adHocSignAll(threaded.io(), a, &.{"/no/such/macho"}),
+    );
 }

--- a/src/macho/patcher.zig
+++ b/src/macho/patcher.zig
@@ -2,6 +2,7 @@
 //! Path relocation in load commands and text file patching.
 
 const std = @import("std");
+const system_tools = @import("../system_tools.zig");
 const parser = @import("parser.zig");
 const text_replace = @import("../text_replace.zig");
 const atomic = @import("../fs/atomic.zig");
@@ -414,6 +415,7 @@ pub const FallbackError = error{
 /// `comptime` so the doctor check renders the right name without a
 /// runtime branch; the future Linux backend swaps this for `"patchelf"`.
 pub const external_tool_name: []const u8 = "install_name_tool";
+pub const external_tool_path: []const u8 = system_tools.install_name_tool;
 
 /// Build the `install_name_tool` argv for one binary's overflow batch.
 /// Caller owns the returned slice (`allocator.free`); the strings inside
@@ -427,7 +429,7 @@ pub fn buildInstallNameToolArgv(
     var argv: std.ArrayList([]const u8) = try .initCapacity(allocator, 1 + entries.len * 3 + 1);
     errdefer argv.deinit(allocator);
 
-    argv.appendAssumeCapacity(external_tool_name);
+    argv.appendAssumeCapacity(external_tool_path);
     for (entries) |e| {
         if (e.delete) {
             // -delete_rpath <old> <file>: strip the collapsed duplicate.
@@ -507,10 +509,8 @@ pub fn flushOverflow(
         .stdout = .ignore,
         .stderr = .pipe,
     }) catch |e| switch (e) {
-        // `FileNotFound` is what `std.process.spawn` returns when the
-        // binary is not on PATH — caller's doctor check should have
-        // surfaced this already, but bottle installs may run before
-        // doctor on a fresh box.
+        // `FileNotFound` means the fixed Command Line Tools path is absent.
+        // Doctor should surface this, but bottle installs may run first.
         error.FileNotFound => return FallbackError.InstallNameToolMissing,
         else => return FallbackError.IoError,
     };
@@ -529,6 +529,36 @@ pub fn flushOverflow(
         },
         else => return FallbackError.InstallNameToolFailed,
     }
+}
+
+test "flushOverflow does not execute a prefix-resident install_name_tool shim" {
+    const io = std.Options.debug_io;
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const root = try std.fmt.allocPrintSentinel(a, "/tmp/malt_install_name_tool_shim_{d}", .{std.c.getpid()}, 0);
+    std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, root) catch {};
+    const bin = try std.fmt.allocPrint(a, "{s}/bin", .{root});
+    const shim = try std.fmt.allocPrint(a, "{s}/{s}", .{ bin, external_tool_name });
+    try std.Io.Dir.cwd().createDirPath(io, bin);
+    try std.Io.Dir.symLinkAbsolute(io, "/usr/bin/true", shim, .{});
+
+    const path_entry = try std.fmt.allocPrintSentinel(a, "PATH={s}:/usr/bin:/bin", .{bin}, 0);
+    const entries = [_:null]?[*:0]const u8{path_entry.ptr};
+    const environ: std.process.Environ = .{ .block = .{ .slice = &entries } };
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{ .environ = environ });
+    defer threaded.deinit();
+
+    const entries_to_flush = [_]OverflowEntry{.{
+        .cmd = @intFromEnum(std.macho.LC.LOAD_DYLIB),
+        .old_path = "/usr/local/lib/libx.dylib",
+        .new_path = "/opt/malt/lib/libx.dylib",
+    }};
+    try std.testing.expectError(
+        FallbackError.InstallNameToolFailed,
+        flushOverflow(threaded.io(), a, "/no/such/macho", &entries_to_flush),
+    );
 }
 
 /// Patch text files in a directory tree with a batch of replacements.

--- a/src/system_tools.zig
+++ b/src/system_tools.zig
@@ -1,0 +1,29 @@
+//! Canonical paths for operating-system tools that must not resolve through
+//! the user's PATH. A package can populate the prefix's bin directory, so a
+//! bare helper name is attacker-controlled after that directory reaches PATH.
+
+const std = @import("std");
+
+pub const codesign = "/usr/bin/codesign";
+pub const install_name_tool = "/usr/bin/install_name_tool";
+pub const unzip = "/usr/bin/unzip";
+pub const tar = "/usr/bin/tar";
+pub const ditto = "/usr/bin/ditto";
+pub const hdiutil = "/usr/bin/hdiutil";
+pub const sudo = "/usr/bin/sudo";
+pub const installer = "/usr/sbin/installer";
+pub const install = "/usr/bin/install";
+pub const ln = "/bin/ln";
+pub const launchctl = "/bin/launchctl";
+pub const pgrep = "/usr/bin/pgrep";
+pub const sw_vers = "/usr/bin/sw_vers";
+
+test "every trusted system tool uses an absolute path" {
+    const paths = [_][]const u8{
+        codesign,  install_name_tool, unzip, tar,       ditto, hdiutil, sudo,
+        installer, install,           ln,    launchctl, pgrep, sw_vers,
+    };
+    for (paths) |path| {
+        try std.testing.expect(std.fs.path.isAbsolute(path));
+    }
+}

--- a/tests/doctor_dispatch_test.zig
+++ b/tests/doctor_dispatch_test.zig
@@ -282,13 +282,12 @@ test "execute --post-install-status returns without invoking the walker" {
 
 // --- pure helpers ------------------------------------------------------
 
-test "externalToolAvailable returns false when PATH does not contain the tool" {
+test "externalToolAvailable rejects a missing absolute tool path" {
     quiet();
     defer unquiet();
     try testing.expect(!doctor.externalToolAvailable(
         std.Options.debug_io,
-        .empty,
-        "tool-name-that-cannot-possibly-exist-on-any-machine-xyz123",
+        "/usr/bin/tool-name-that-cannot-possibly-exist-on-any-machine-xyz123",
     ));
 }
 

--- a/tests/doctor_render_test.zig
+++ b/tests/doctor_render_test.zig
@@ -331,26 +331,25 @@ const patch = malt.patch;
 // ── external-tool availability check ─────────────────────────────────
 //
 // Guards the doctor row that surfaces `install_name_tool` (today) or
-// `patchelf` (after the Linux backend lands). The tool name is read
-// from the facade so the check is platform-agnostic at the call site.
+// `patchelf` (after the Linux backend lands). The trusted tool path is read
+// from the facade so the check matches what the backend will execute.
 
-test "doctor.externalToolAvailable returns true when the tool is on PATH" {
+test "doctor.externalToolAvailable checks the exact trusted tool path" {
     // `install_name_tool` is part of Xcode Command Line Tools and is
     // always installed in the repo's dev environment — any bot that
     // can build malt can find it.
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
     const io = threaded.io();
-    const environ = malt.app_ctx.processEnviron();
-    try testing.expect(malt.doctor.externalToolAvailable(io, environ, patch.external_tool_name));
+    try testing.expect(malt.doctor.externalToolAvailable(io, patch.external_tool_path));
 }
 
 test "doctor.externalToolAvailable returns false for a clearly-missing binary" {
     var threaded: std.Io.Threaded = .init(testing.allocator, .{});
     defer threaded.deinit();
     const io = threaded.io();
-    const environ = malt.app_ctx.processEnviron();
-    try testing.expect(!malt.doctor.externalToolAvailable(io, environ, "mt_no_such_binary_ever_xyz"));
+    try testing.expect(!malt.doctor.externalToolAvailable(io, "/usr/bin/mt_no_such_binary_ever_xyz"));
+    try testing.expect(!malt.doctor.externalToolAvailable(io, "install_name_tool"));
 }
 
 fn seedKeg(db: *sqlite.Database, name: []const u8, tap: []const u8, full_name: []const u8) !void {

--- a/tests/patcher_test.zig
+++ b/tests/patcher_test.zig
@@ -552,7 +552,7 @@ test "buildInstallNameToolArgv batches -change pairs into a single invocation" {
     defer testing.allocator.free(argv);
 
     try testing.expectEqual(@as(usize, 8), argv.len);
-    try testing.expectEqualStrings("install_name_tool", argv[0]);
+    try testing.expectEqualStrings("/usr/bin/install_name_tool", argv[0]);
     try testing.expectEqualStrings("-change", argv[1]);
     try testing.expectEqualStrings(entries[0].old_path, argv[2]);
     try testing.expectEqualStrings(entries[0].new_path, argv[3]);

--- a/tests/version_update_test.zig
+++ b/tests/version_update_test.zig
@@ -235,8 +235,8 @@ test "resolveTwinRegularFile: returns null for unrelated basenames" {
 test "buildSudoInstallArgv: shape matches BSD install with .old backup suffix" {
     const argv = updater.buildSudoInstallArgv("/tmp/new-malt", "/usr/local/bin/malt");
     try testing.expectEqual(@as(usize, 9), argv.len);
-    try testing.expectEqualStrings("sudo", argv[0]);
-    try testing.expectEqualStrings("install", argv[1]);
+    try testing.expectEqualStrings("/usr/bin/sudo", argv[0]);
+    try testing.expectEqualStrings("/usr/bin/install", argv[1]);
     try testing.expectEqualStrings("-m", argv[2]);
     try testing.expectEqualStrings("0755", argv[3]);
     try testing.expectEqualStrings("-b", argv[4]);


### PR DESCRIPTION
## Description

This PR runs macOS-owned helpers from canonical absolute paths instead of resolving them through `PATH`. Doctor now checks the exact `install_name_tool` path used by the Mach-O backend. Regression tests prove that `PATH` shims cannot fake successful codesigning or Mach-O relocation.

A formula can place executables in the package prefix, and that prefix is commonly near the front of `PATH`. Before this change, a malicious package could install a shim such as `codesign` or `install_name_tool` and have it run automatically during a later install. The same bare-name pattern affected archive extraction, cask installation, service management, version detection, and update elevation.

## Related Issue

Closes #851.

## Notes for Reviewers

The original regressions cover prefix-resident shims for codesigning and Mach-O relocation. A follow-up adds direct coverage for archive extraction and the cask process probe. The tests put a failing `unzip` shim and a successful `pgrep` shim first in `PATH`, then exercise the real call sites.

On unmodified `origin/main`, both follow-up tests fail: 2,424 tests pass and 2 fail. On this branch, the focused suite passes all 2,429 tests.

Local verification after the follow-up completed with:

- `zig build`: 8 of 8 steps succeeded
- `zig build test-one`: 2,429 passed
- `zig fmt --check src/fs/archive.zig src/core/cask.zig`
- `git verify-commit HEAD`

The network-dependent full suite did not finish locally. Two attempts became stuck on GitHub HTTPS connections in `CLOSE_WAIT` and were stopped with exit 130. Upstream CI completed successfully on the same commit: the macOS build and test job, security smoke, universal build, lint, and pins-drift checks all passed.