### PR TITLE
ci(bench): restore the weekly benchmark after nanobrew's relocation change

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,8 +16,10 @@ jobs:
     env:
       # Wipe the malt prefix between cold runs so the published numbers
       # reflect a real network download, not a store-cache hit. Fail loud
-      # if any install returns non-zero so a broken install path can never
-      # silently publish fake timings.
+      # if a *malt* install returns non-zero so a broken install path can
+      # never silently publish fake timings; a peer tool's failure only
+      # withholds its own cell (⚠️) so its upstream regression can't take
+      # down malt's numbers or the stress step that follows.
       BENCH_TRUE_COLD: "1"
       BENCH_FAIL_FAST: "1"
       # Bench malt's shipped release (highest release/N.M branch), not the dev
@@ -173,16 +175,16 @@ jobs:
 
           # Explain any ⚠️ cell so a reader isn't left guessing why a number is
           # missing. The marker is only ever emitted for a peer tool whose cold
-          # median blew past BENCH_MAX_COLD, so the legend is appended only when
-          # such a cell exists — and it lands inside the START/END block, so a
-          # later clean run drops it again.
+          # install failed or blew past BENCH_MAX_COLD, so the legend is appended
+          # only when such a cell exists - and it lands inside the START/END
+          # block, so a later clean run drops it again.
           if grep -q '⚠️' /tmp/cold_table.md; then
             cat >> /tmp/cold_table.md << 'NOTE'
 
-          > ⚠️ = cell omitted. That tool's cold install exceeded the sanity
-          > ceiling (50 s), which reflects a regression in that tool rather than
-          > a comparable install time, so the number is withheld instead of
-          > published. malt is never omitted — a real malt slowdown stays visible.
+          > ⚠️ = cell omitted. That tool's cold install failed, or exceeded the
+          > sanity ceiling (50 s), which reflects a regression in that tool rather
+          > than a comparable install time, so the number is withheld instead of
+          > published. malt is never omitted - a real malt slowdown stays visible.
           NOTE
           fi
 

--- a/README.md
+++ b/README.md
@@ -832,33 +832,39 @@ For installing malt from a local checkout (the end-user path), see [From source]
 Install times on macOS 14 (Apple Silicon).
 
 <!-- BENCH:COLD:START -->
+
 ### Cold Install (median ±σ)
 
-| Package | malt 0.22.3 | nanobrew v0.1.205 | zerobrew v0.3.2 | Homebrew |
-| ------- | ---- | -------- | -------- | -------- |
-| **tree** (0 deps) | 0.648±0.019s | 0.743±0.033s | 1.349±0.047s | 2.101±0.137s |
-| **wget** (6 deps) | 2.911±0.229s | 4.553±0.155s | 5.270±0.312s | 2.131±0.020s |
-| **ffmpeg** (11 deps) | 3.509±0.339s | 4.350±0.148s | 6.348±0.461s | 4.343±4.228s |
+| Package              | malt 0.22.3  | nanobrew v0.1.205 | zerobrew v0.3.2 | Homebrew     |
+| -------------------- | ------------ | ----------------- | --------------- | ------------ |
+| **tree** (0 deps)    | 0.648±0.019s | 0.743±0.033s      | 1.349±0.047s    | 2.101±0.137s |
+| **wget** (6 deps)    | 2.911±0.229s | 4.553±0.155s      | 5.270±0.312s    | 2.131±0.020s |
+| **ffmpeg** (11 deps) | 3.509±0.339s | 4.350±0.148s      | 6.348±0.461s    | 4.343±4.228s |
+
 <!-- BENCH:COLD:END -->
 
 <!-- BENCH:WARM:START -->
+
 ### Warm Install
 
-| Package | malt | nanobrew | zerobrew |
-| ------- | ---- | -------- | -------- |
-| **tree** (0 deps) | 0.008s | 0.012s | 0.268s |
-| **wget** (6 deps) | 0.015s | 0.015s | 0.695s |
-| **ffmpeg** (11 deps) | 0.020s | 0.016s | 2.367s |
+| Package              | malt   | nanobrew | zerobrew |
+| -------------------- | ------ | -------- | -------- |
+| **tree** (0 deps)    | 0.008s | 0.012s   | 0.268s   |
+| **wget** (6 deps)    | 0.015s | 0.015s   | 0.695s   |
+| **ffmpeg** (11 deps) | 0.020s | 0.016s   | 2.367s   |
+
 <!-- BENCH:WARM:END -->
 
 <!-- BENCH:SIZE:START -->
+
 ### Binary Size
 
-| Tool | Size |
-| ---- | ---- |
+| Tool     | Size   |
+| -------- | ------ |
 | **malt** | 4.0 MB |
 | nanobrew | 3.1 MB |
 | zerobrew | 8.7 MB |
+
 <!-- BENCH:SIZE:END -->
 
 Apple Silicon (GitHub Actions macos-14), 2026-08-10. Auto-updated weekly via the [benchmark workflow](.github/workflows/benchmark.yml).
@@ -893,7 +899,9 @@ Each package bench opens with a discarded warmup round: every tool runs one inst
 
 The measured rounds then rotate tool order (round _r_ starts with `tools[r mod N]`), so no single tool reliably eats the "cold network" slot or benefits from the warmest one.
 
-`scripts/bench.sh` `git fetch`es nanobrew and zerobrew before each build so the comparison is always malt-today vs. each peer's latest commit, not a weeks-old snapshot. Set `BENCH_SKIP_UPDATE=1` to pin whatever is already checked out.
+`scripts/bench.sh` resolves nanobrew's and zerobrew's latest release tag before each build, so a peer is never benched as a weeks-old snapshot nor as a mid-development commit. Set `BENCH_SKIP_UPDATE=1` to pin whatever is already checked out. CI additionally sets `BENCH_MALT_RELEASE=1` so the published table is release-vs-release; a local run benches your working tree.
+
+A peer tool whose cold install fails, or exceeds `BENCH_MAX_COLD` (50 s), has that cell withheld as ⚠️ - a regression in their tool is not a comparable number. malt is never withheld: its own numbers stay in the table however bad they get, and a failed malt install aborts the run instead of publishing anything.
 
 Each tool is built using the release flags its upstream ships with: malt `ReleaseSafe` (matches [`.goreleaser.yaml`](.goreleaser.yaml)), nanobrew `ReleaseFast`, zerobrew `cargo build --release`. Binary sizes may differ from the numbers shown on each tool's own repo - the gap is almost always version drift, not a flag difference.
 

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -357,8 +357,27 @@ malt_version() {
   "$MALT_BIN" --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[^ ]*' | head -1
 }
 
+# nanobrew ≥v0.1.208 relocates binaries through a `/opt/nb` symlink pointing
+# at its prefix, and now *fails* an install outright when that link is missing
+# ("incomplete relocation (run `sudo nb init` and retry)"). `nb init` can only
+# create it as root, so do it here: it is the one path the bench cannot keep
+# under /tmp. Never clobber an existing /opt/nb: on a dev box it belongs to a
+# real nanobrew install.
+ensure_nb_short_prefix() {
+  local target="$NB_BENCH_PREFIX/prefix" cur
+  cur=$(readlink /opt/nb 2>/dev/null || true)
+  [ "$cur" = "$target" ] && return 0
+  if [ -n "$cur" ] || [ -e /opt/nb ]; then
+    warn "/opt/nb exists (-> ${cur:-not a symlink}) - leaving it alone; nanobrew installs will fail"
+    return 0
+  fi
+  sudo -n ln -s "$target" /opt/nb 2>/dev/null ||
+    warn "could not create /opt/nb -> $target (needs sudo) - nanobrew installs will fail"
+}
+
 build_nanobrew() {
   local url="https://github.com/justrach/nanobrew.git"
+  ensure_nb_short_prefix
   if [ "$SKIP_BUILD" = "1" ] && [ -x "$NB_BIN" ]; then
     set_result ver_nb "$(git -C "$NB_DIR" describe --tags --always 2>/dev/null || true)"
     return

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -464,8 +464,15 @@ build_zerobrew() {
 # Unlike the upstream workflow, this checks the install exit code: a silent
 # install failure (e.g. permission denied, tap missing) would otherwise look
 # like a sub-millisecond "install" in the captured time, making the table lie.
+#
+# `<key>` is the tool key (mt/nb/zb) and decides who fail-fast applies to:
+# only malt aborts the run. A peer tool's upstream regression used to take
+# the whole workflow down with it - including malt's own stress/race step,
+# which never ran - while the rest of the script already treats peer trouble
+# as a degraded cell (BENCH_MAX_COLD, emit_skipped_peers). A peer FAIL now
+# follows that same policy and surfaces as a loud marker in finalize_results.
 time_install() {
-  local bin="$1" install="$2" uninstall="$3" pkg="$4" t rc=0
+  local bin="$1" install="$2" uninstall="$3" pkg="$4" key="$5" t rc=0
   "$bin" "$uninstall" "$pkg" >/dev/null 2>&1 || true
   t=$({
     TIMEFORMAT='%R'
@@ -474,7 +481,7 @@ time_install() {
   if [ "$rc" -ne 0 ]; then
     warn "$bin install $pkg FAILED (exit=$rc); output:"
     sed 's/^/    /' /tmp/malt-bench.out >&2
-    if [ "$BENCH_FAIL_FAST" = "1" ]; then
+    if [ "$BENCH_FAIL_FAST" = "1" ] && [ "$key" = "mt" ]; then
       err "aborting (BENCH_FAIL_FAST=1)"
     fi
     printf 'FAIL'
@@ -483,6 +490,8 @@ time_install() {
   printf '%s' "$t"
 }
 
+# Homebrew is a peer column like nanobrew/zerobrew, so a brew failure never
+# aborts the run either - see the fail-fast note on time_install.
 time_brew_install() {
   local pkg="$1" t rc=0
   brew uninstall "$pkg" >/dev/null 2>&1 || true
@@ -492,9 +501,6 @@ time_brew_install() {
   } 2>&1) || rc=$?
   if [ "$rc" -ne 0 ]; then
     warn "brew install $pkg FAILED (exit=$rc)"
-    if [ "$BENCH_FAIL_FAST" = "1" ]; then
-      err "aborting (BENCH_FAIL_FAST=1)"
-    fi
     printf 'FAIL'
     return
   fi
@@ -768,8 +774,8 @@ run_one() {
   local bin="$1" install="$2" uninstall="$3" pkg="$4" key="$5" prep="$6" record="$7" round="${8:-0}"
   local c w
   if [ -n "$prep" ] && [ "$BENCH_TRUE_COLD" = "1" ]; then "$prep"; fi
-  c=$(time_install "$bin" "$install" "$uninstall" "$pkg")
-  w=$(time_install "$bin" "$install" "$uninstall" "$pkg")
+  c=$(time_install "$bin" "$install" "$uninstall" "$pkg" "$key")
+  w=$(time_install "$bin" "$install" "$uninstall" "$pkg" "$key")
   "$bin" "$uninstall" "$pkg" >/dev/null 2>&1 || true
   if [ "$record" = "1" ]; then
     append_sample cold "$key" "$pkg" "$c"
@@ -839,16 +845,26 @@ finalize_results() {
       local cold_med cold_disp
       cold_med=$(get_result "cold_${tool}_$pkg")
       cold_disp=$(fmt_disp "$cold_med" "$(get_result "cold_${tool}_${pkg}_std")")
-      # Anomaly guard: a peer tool's cold install above the sanity ceiling is
-      # a regression in *their* tool, not a comparable number — omit the cell
-      # (loud marker) instead of publishing garbage. malt is exempt so a real
-      # malt slowdown stays visible rather than hidden.
-      if [ "$tool" != "mt" ] && over_threshold "$cold_med" "$BENCH_MAX_COLD"; then
-        local tver
+      # Anomaly guard: a peer tool's cold install that fails outright, or lands
+      # above the sanity ceiling, is a regression in *their* tool rather than a
+      # comparable number - omit the cell (loud marker) instead of publishing
+      # garbage. malt is exempt so a real malt slowdown stays visible.
+      local tver note=""
+      if [ "$tool" != "mt" ]; then
+        case "$cold_med" in
+        *FAIL*) note="install failed" ;;
+        *)
+          if over_threshold "$cold_med" "$BENCH_MAX_COLD"; then
+            note=">${BENCH_MAX_COLD}s"
+          fi
+          ;;
+        esac
+      fi
+      if [ -n "$note" ]; then
         tver=$(get_result "ver_$tool")
-        warn "ANOMALY: $tool ${tver:+$tver }cold $pkg = ${cold_med}s > BENCH_MAX_COLD=${BENCH_MAX_COLD}s — omitting cell"
-        gha_warning "$tool ${tver:+($tver) }cold install of $pkg regressed: ${cold_med}s exceeds ${BENCH_MAX_COLD}s ceiling — cell omitted"
-        cold_disp="⚠️ n/a (>${BENCH_MAX_COLD}s)"
+        warn "ANOMALY: $tool ${tver:+$tver }cold $pkg = ${cold_med} ($note) - omitting cell"
+        gha_warning "$tool ${tver:+($tver) }cold install of $pkg: $note - cell omitted"
+        cold_disp="⚠️ n/a ($note)"
       fi
       emit_output "${tool}_cold_disp=$cold_disp"
     fi
@@ -862,7 +878,16 @@ finalize_results() {
         set_result "warm_${tool}_${pkg}_min" "$(min_of $samples)"
         # shellcheck disable=SC2086
         set_result "warm_${tool}_${pkg}_std" "$(stddev_of $samples)"
-        emit_output "${tool}_warm=$(get_result "warm_${tool}_$pkg")s"
+        # The README warm table reads this bare median, so a peer whose
+        # install failed must not land there as "FAILs" - same marker the
+        # cold cell and emit_skipped_peers use.
+        local warm_med warm_cell
+        warm_med=$(get_result "warm_${tool}_$pkg")
+        warm_cell="${warm_med}s"
+        if [ "$tool" != "mt" ]; then
+          case "$warm_med" in *FAIL*) warm_cell="⚠️ n/a (install failed)" ;; esac
+        fi
+        emit_output "${tool}_warm=$warm_cell"
         emit_output "${tool}_warm_min=$(get_result "warm_${tool}_${pkg}_min")s"
         emit_output "${tool}_warm_stddev=$(get_result "warm_${tool}_${pkg}_std")s"
         emit_output "${tool}_warm_disp=$(fmt_disp "$(get_result "warm_${tool}_$pkg")" "$(get_result "warm_${tool}_${pkg}_std")")"

--- a/scripts/test/bench_release_resolution_test.sh
+++ b/scripts/test/bench_release_resolution_test.sh
@@ -11,6 +11,10 @@
 #   2. over_threshold — the guard predicate: a peer tool's cold median above
 #      the ceiling trips; FAIL/empty medians and a disabled (0) ceiling never
 #      trip, so a legitimately slow-but-fine number is never hidden by mistake.
+#   3. fail-fast scope + failed-peer cells — a peer tool's broken install must
+#      degrade to a marked cell (like the ceiling guard already does) instead
+#      of aborting the run, which would also cost malt its own stress step;
+#      malt's own failure must still abort and stay visible in the table.
 #
 # Usage:
 #   ./scripts/test/bench_release_resolution_test.sh
@@ -112,6 +116,46 @@ check "active peer warm cell not clobbered" "" "$(emitted zb_warm)"
 set_result skip_nb ""
 emit_skipped_peers tree
 check "no-reason skip falls back to n/a" "⚠️ n/a" "$(emitted nb_cold_disp)"
+
+echo "fail-fast scope:"
+# BENCH_FAIL_FAST guards malt only. A peer's broken install records FAIL and
+# lets the run continue (its cell gets marked below); malt's aborts, so a
+# broken malt install can never publish a fake number.
+# Read by the sourced time_install, not locally.
+# shellcheck disable=SC2034
+BENCH_FAIL_FAST=1
+check "peer install failure records FAIL and continues" \
+  "FAIL" "$(time_install "$(command -v false)" install uninstall tree nb 2>/dev/null)"
+peer_rc=0
+(time_install "$(command -v false)" install uninstall tree mt) >/dev/null 2>&1 || peer_rc=$?
+check "malt install failure aborts" "1" "$peer_rc"
+
+echo "finalize_results (failed peer):"
+: >"$GITHUB_OUTPUT"
+# Two rounds of a peer whose install failed outright, and a healthy malt.
+append_sample cold nb tree FAIL
+append_sample cold nb tree FAIL
+append_sample warm nb tree FAIL
+append_sample warm nb tree FAIL
+append_sample cold mt tree 1.100
+append_sample cold mt tree 1.200
+append_sample warm mt tree 0.300
+append_sample warm mt tree 0.320
+finalize_results tree mt nb >/dev/null
+check "failed peer cold cell is a marker" "⚠️ n/a (install failed)" "$(emitted nb_cold_disp)"
+check "failed peer warm cell is a marker" "⚠️ n/a (install failed)" "$(emitted nb_warm)"
+check "healthy malt cold cell unaffected" "1.100±0.071s" "$(emitted mt_cold_disp)"
+check "healthy malt warm cell unaffected" "0.300s" "$(emitted mt_warm)"
+
+echo "finalize_results (slow peer):"
+: >"$GITHUB_OUTPUT"
+append_sample cold zb wget 130.802
+append_sample cold zb wget 131.000
+append_sample warm zb wget 0.400
+append_sample warm zb wget 0.410
+finalize_results wget zb >/dev/null
+check "over-ceiling peer cold cell is a marker" "⚠️ n/a (>${BENCH_MAX_COLD}s)" "$(emitted zb_cold_disp)"
+check "over-ceiling peer warm cell still published" "0.400s" "$(emitted zb_warm)"
 
 rm -f "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Description

The weekly benchmark has been failing since nanobrew started relocating binaries through a `/opt/nb` symlink and failing installs outright when it is missing. The bench prefix lives under `/tmp`, so every multi-dependency package failed and the run aborted before ffmpeg, the race stress step, and the README refresh.

Two changes: the bench now creates that symlink for nanobrew's isolated prefix, and fail-fast guards malt only. A peer tool's regression withholds its own cell - the policy the sanity ceiling already used - instead of taking down malt's numbers and its stress run.

## Related Issue

- None

## Notes for Reviewers

- None