### PR TITLE
fix(dsl): create symlinks with the target a formula wrote

### DIFF
--- a/src/core/dsl/builtins/fileutils.zig
+++ b/src/core/dsl/builtins/fileutils.zig
@@ -1339,3 +1339,57 @@ test "ln_sf leaves no link for an empty target" {
     _ = try lnSf(ctx, null, &.{ Value{ .string = "" }, Value{ .string = link } });
     try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, link, .{}));
 }
+
+test "ln_sf array form links a relative target under its basename" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var s = try Scratch.init("lnsf_array_relative");
+    defer s.deinit();
+    const keg = s.base;
+
+    const libexec = try std.fs.path.join(alloc, &.{ keg, "libexec" });
+    defer alloc.free(libexec);
+    const bin = try std.fs.path.join(alloc, &.{ keg, "bin" });
+    defer alloc.free(bin);
+    try std.Io.Dir.cwd().createDirPath(io, libexec);
+    try std.Io.Dir.cwd().createDirPath(io, bin);
+    const real = try std.fs.path.join(alloc, &.{ libexec, "tool" });
+    defer alloc.free(real);
+    (try std.Io.Dir.createFileAbsolute(io, real, .{})).close(io);
+
+    // The array form names the link after `basename(target)`, so a relative
+    // target has to survive that trip as well as the scalar form does.
+    const items = [_]Value{Value{ .string = "../libexec/tool" }};
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    _ = try lnSf(ctx, null, &.{ Value{ .array = &items }, Value{ .string = bin } });
+
+    const link = try std.fs.path.join(alloc, &.{ bin, "tool" });
+    defer alloc.free(link);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try std.Io.Dir.cwd().readLink(io, link, &buf);
+    try std.testing.expectEqualStrings("../libexec/tool", buf[0..n]);
+    try std.Io.Dir.cwd().access(io, link, .{});
+}
+
+test "ln_s accepts a relative target that does not exist yet" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var s = try Scratch.init("lns_relative_dangling");
+    defer s.deinit();
+    const keg = s.base;
+
+    const bin = try std.fs.path.join(alloc, &.{ keg, "bin" });
+    defer alloc.free(bin);
+    try std.Io.Dir.cwd().createDirPath(io, bin);
+    const link = try std.fs.path.join(alloc, &.{ bin, "tool" });
+    defer alloc.free(link);
+
+    // Formulae link ahead of the file they point at; an in-keg target that is
+    // still missing must link rather than be mistaken for an escape.
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    _ = try lnS(ctx, null, &.{ Value{ .string = "../libexec/later" }, Value{ .string = link } });
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try std.Io.Dir.cwd().readLink(io, link, &buf);
+    try std.testing.expectEqualStrings("../libexec/later", buf[0..n]);
+}

--- a/src/core/dsl/builtins/fileutils.zig
+++ b/src/core/dsl/builtins/fileutils.zig
@@ -220,7 +220,9 @@ pub fn lnS(ctx: ExecCtx, _: ?Value, args: []const Value) BuiltinError!Value {
     if (std.fs.path.dirname(link_path)) |parent| {
         std.Io.Dir.cwd().createDirPath(ctx.io, parent) catch {};
     }
-    std.Io.Dir.symLinkAbsolute(ctx.io, target, link_path, .{}) catch {};
+    // Relative targets are ordinary in formulae and already bounds-checked above;
+    // `symLinkAbsolute` would assert on one and abort the process.
+    std.Io.Dir.cwd().symLink(ctx.io, target, link_path, .{}) catch {};
     return Value{ .nil = {} };
 }
 
@@ -264,7 +266,9 @@ fn forceSymlink(ctx: ExecCtx, target: []const u8, link_path: []const u8) Builtin
         std.Io.Dir.cwd().createDirPath(ctx.io, parent) catch {};
     }
     std.Io.Dir.cwd().deleteFile(ctx.io, link_path) catch {};
-    std.Io.Dir.symLinkAbsolute(ctx.io, target, link_path, .{}) catch {};
+    // Relative targets are ordinary in formulae and already bounds-checked above;
+    // `symLinkAbsolute` would assert on one and abort the process.
+    std.Io.Dir.cwd().symLink(ctx.io, target, link_path, .{}) catch {};
 }
 
 const fs_test_io = std.Options.debug_io;
@@ -1212,4 +1216,126 @@ fn copyDirRecursive(io: std.Io, allocator: std.mem.Allocator, src: []const u8, d
             copyFileConfined(io, src_child, dst_child, cellar_path, malt_prefix) catch {};
         }
     }
+}
+
+test "ln_s keeps a relative in-keg target instead of aborting" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var s = try Scratch.init("lns_relative_target");
+    defer s.deinit();
+    const keg = s.base;
+
+    // `ln_s "../libexec/tool", bin/"tool"` is ordinary Homebrew shorthand: the
+    // target is relative so the link survives the keg being relocated.
+    const libexec = try std.fs.path.join(alloc, &.{ keg, "libexec" });
+    defer alloc.free(libexec);
+    const bin = try std.fs.path.join(alloc, &.{ keg, "bin" });
+    defer alloc.free(bin);
+    try std.Io.Dir.cwd().createDirPath(io, libexec);
+    try std.Io.Dir.cwd().createDirPath(io, bin);
+    const real = try std.fs.path.join(alloc, &.{ libexec, "tool" });
+    defer alloc.free(real);
+    (try std.Io.Dir.createFileAbsolute(io, real, .{})).close(io);
+    const link = try std.fs.path.join(alloc, &.{ bin, "tool" });
+    defer alloc.free(link);
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    _ = try lnS(ctx, null, &.{ Value{ .string = "../libexec/tool" }, Value{ .string = link } });
+
+    // Stored verbatim, and it resolves to the real file.
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try std.Io.Dir.cwd().readLink(io, link, &buf);
+    try std.testing.expectEqualStrings("../libexec/tool", buf[0..n]);
+    try std.Io.Dir.cwd().access(io, link, .{});
+}
+
+test "ln_sf keeps a relative in-keg target instead of aborting" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var s = try Scratch.init("lnsf_relative_target");
+    defer s.deinit();
+    const keg = s.base;
+
+    const libexec = try std.fs.path.join(alloc, &.{ keg, "libexec" });
+    defer alloc.free(libexec);
+    const bin = try std.fs.path.join(alloc, &.{ keg, "bin" });
+    defer alloc.free(bin);
+    try std.Io.Dir.cwd().createDirPath(io, libexec);
+    try std.Io.Dir.cwd().createDirPath(io, bin);
+    const real = try std.fs.path.join(alloc, &.{ libexec, "tool" });
+    defer alloc.free(real);
+    (try std.Io.Dir.createFileAbsolute(io, real, .{})).close(io);
+    const link = try std.fs.path.join(alloc, &.{ bin, "tool" });
+    defer alloc.free(link);
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    _ = try lnSf(ctx, null, &.{ Value{ .string = "../libexec/tool" }, Value{ .string = link } });
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try std.Io.Dir.cwd().readLink(io, link, &buf);
+    try std.testing.expectEqualStrings("../libexec/tool", buf[0..n]);
+}
+
+test "ln_s refuses a relative target that escapes the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var s = try Scratch.init("lns_relative_escape");
+    defer s.deinit();
+    const base = s.base;
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const bin = try std.fs.path.join(alloc, &.{ keg, "bin" });
+    defer alloc.free(bin);
+    try std.Io.Dir.cwd().createDirPath(io, bin);
+    const link = try std.fs.path.join(alloc, &.{ bin, "pwn" });
+    defer alloc.free(link);
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    // Relative spelling must not become a way around the boundary check, and
+    // must be refused rather than abort the process.
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        lnS(ctx, null, &.{ Value{ .string = "../../outside" }, Value{ .string = link } }),
+    );
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, link, .{}));
+}
+
+test "ln_sf refuses a relative target that escapes the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var s = try Scratch.init("lnsf_relative_escape");
+    defer s.deinit();
+    const base = s.base;
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const bin = try std.fs.path.join(alloc, &.{ keg, "bin" });
+    defer alloc.free(bin);
+    try std.Io.Dir.cwd().createDirPath(io, bin);
+    const link = try std.fs.path.join(alloc, &.{ bin, "pwn" });
+    defer alloc.free(link);
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        lnSf(ctx, null, &.{ Value{ .string = "../../outside" }, Value{ .string = link } }),
+    );
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, link, .{}));
+}
+
+test "ln_sf leaves no link for an empty target" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var s = try Scratch.init("lnsf_empty_target");
+    defer s.deinit();
+    const keg = s.base;
+
+    const link = try std.fs.path.join(alloc, &.{ keg, "tool" });
+    defer alloc.free(link);
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    // `ln_s` guards this arg but the force variant does not; it must still be
+    // an inert no-op rather than a crash or an empty dangling link.
+    _ = try lnSf(ctx, null, &.{ Value{ .string = "" }, Value{ .string = link } });
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, link, .{}));
 }

--- a/src/core/dsl/builtins/pathname.zig
+++ b/src/core/dsl/builtins/pathname.zig
@@ -588,3 +588,34 @@ test "install_symlink refuses a relative source that escapes the keg" {
     defer alloc.free(link);
     try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, link, .{}));
 }
+
+test "install_symlink hash form keeps a relative source under the given name" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var s = try Scratch.init("install_symlink_hash_relative");
+    defer s.deinit();
+    const keg = s.base;
+
+    const libexec = try std.fs.path.join(alloc, &.{ keg, "libexec" });
+    defer alloc.free(libexec);
+    try std.Io.Dir.cwd().createDirPath(io, libexec);
+    const real = try std.fs.path.join(alloc, &.{ libexec, "tool" });
+    defer alloc.free(real);
+    (try std.Io.Dir.createFileAbsolute(io, real, .{})).close(io);
+    const bin = try std.fs.path.join(alloc, &.{ keg, "bin" });
+    defer alloc.free(bin);
+
+    const pairs = [_]Value.HashPair{.{
+        .key = Value{ .string = "../libexec/tool" },
+        .value = Value{ .string = "alias" },
+    }};
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    _ = try installSymlink(ctx, Value{ .pathname = bin }, &.{Value{ .hash = &pairs }});
+
+    const link = try std.fs.path.join(alloc, &.{ bin, "alias" });
+    defer alloc.free(link);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try std.Io.Dir.cwd().readLink(io, link, &buf);
+    try std.testing.expectEqualStrings("../libexec/tool", buf[0..n]);
+    try std.Io.Dir.cwd().access(io, link, .{});
+}

--- a/src/core/dsl/builtins/pathname.zig
+++ b/src/core/dsl/builtins/pathname.zig
@@ -279,7 +279,9 @@ fn linkInto(ctx: ExecCtx, dir: []const u8, source: []const u8, name: []const u8)
     };
 
     std.Io.Dir.cwd().deleteFile(ctx.io, link) catch {};
-    std.Io.Dir.symLinkAbsolute(ctx.io, source, link, .{}) catch {};
+    // Relative targets are ordinary in formulae and already bounds-checked above;
+    // `symLinkAbsolute` would assert on one and abort the process.
+    std.Io.Dir.cwd().symLink(ctx.io, source, link, .{}) catch {};
 }
 
 /// glob(pattern) — match files in a directory against a glob pattern
@@ -535,4 +537,54 @@ test "write refuses to follow a symlink out of the keg" {
     defer vf.close(io);
     const n = try vf.readPositionalAll(io, &rb, 0);
     try std.testing.expectEqualStrings("PRECIOUS", rb[0..n]);
+}
+
+test "install_symlink keeps a relative in-keg source instead of aborting" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var s = try Scratch.init("install_symlink_relative");
+    defer s.deinit();
+    const keg = s.base;
+
+    const libexec = try std.fs.path.join(alloc, &.{ keg, "libexec" });
+    defer alloc.free(libexec);
+    try std.Io.Dir.cwd().createDirPath(io, libexec);
+    const real = try std.fs.path.join(alloc, &.{ libexec, "tool" });
+    defer alloc.free(real);
+    (try std.Io.Dir.createFileAbsolute(io, real, .{})).close(io);
+    const bin = try std.fs.path.join(alloc, &.{ keg, "bin" });
+    defer alloc.free(bin);
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    _ = try installSymlink(ctx, Value{ .pathname = bin }, &.{Value{ .string = "../libexec/tool" }});
+
+    const link = try std.fs.path.join(alloc, &.{ bin, "tool" });
+    defer alloc.free(link);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try std.Io.Dir.cwd().readLink(io, link, &buf);
+    try std.testing.expectEqualStrings("../libexec/tool", buf[0..n]);
+    try std.Io.Dir.cwd().access(io, link, .{});
+}
+
+test "install_symlink refuses a relative source that escapes the keg" {
+    const io = std.Options.debug_io;
+    const alloc = std.testing.allocator;
+    var s = try Scratch.init("install_symlink_rel_escape");
+    defer s.deinit();
+    const base = s.base;
+
+    const keg = try std.fs.path.join(alloc, &.{ base, "keg" });
+    defer alloc.free(keg);
+    const bin = try std.fs.path.join(alloc, &.{ keg, "bin" });
+    defer alloc.free(bin);
+    try std.Io.Dir.cwd().createDirPath(io, bin);
+
+    const ctx: ExecCtx = .{ .allocator = alloc, .io = io, .environ = undefined, .cellar_path = keg, .malt_prefix = keg };
+    try std.testing.expectError(
+        BuiltinError.PathSandboxViolation,
+        installSymlink(ctx, Value{ .pathname = bin }, &.{Value{ .string = "../../outside" }}),
+    );
+    const link = try std.fs.path.join(alloc, &.{ bin, "outside" });
+    defer alloc.free(link);
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, link, .{}));
 }

--- a/tests/dsl_interpreter_test.zig
+++ b/tests/dsl_interpreter_test.zig
@@ -3266,3 +3266,35 @@ test "interpreter: <<~ output is byte-identical to system Ruby" {
         };
     }
 }
+
+test "interpreter: ln_s with a relative target links instead of aborting" {
+    var arena = testArena();
+    defer arena.deinit();
+
+    var scratch = try makeTempPrefix();
+    defer scratch.deinit();
+    const prefix = scratch.path;
+
+    // `ln_s "../libexec/tool", bin/"tool"` is everyday formula shorthand. It
+    // used to abort the whole process, so this drives the real interpreter
+    // rather than the builtin, to prove no formula can take malt down.
+    const src =
+        \\(prefix/"libexec").mkpath
+        \\(prefix/"bin").mkpath
+        \\(prefix/"libexec"/"tool").write("#!/bin/sh\n")
+        \\ln_s "../libexec/tool", prefix/"bin"/"tool"
+    ;
+    const err = try runSnippet(&arena, src, prefix);
+    try testing.expect(err == null);
+
+    const link = try std.fs.path.join(
+        testing.allocator,
+        &.{ prefix, "Cellar", "testpkg", "1.0", "bin", "tool" },
+    );
+    defer testing.allocator.free(link);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try test_io.cwd().readLink(std.Options.debug_io, link, &buf);
+    try testing.expectEqualStrings("../libexec/tool", buf[0..n]);
+    // Resolves through to the real file, so the keg is actually usable.
+    try test_io.cwd().access(std.Options.debug_io, link, .{});
+}


### PR DESCRIPTION
## Description

A relative symlink target aborted malt. The three native symlink builtins handed the formula's target to `symLinkAbsolute`, which asserts the target is absolute, so `ln_s "../libexec/tool", bin/"tool"` - everyday formula shorthand, and the spelling bottles themselves already ship - crashed the process instead of linking.

They now create the link through the non-asserting call and store the formula's spelling verbatim, so a relative in-keg link keeps resolving if the keg moves. The boundary check already resolved the target beforehand, so a relative spelling that leaves the keg is still refused.

## Related Issue

- None

## Notes for Reviewers

- Found while reviewing the security PRs; it is a stability bug rather than hardening, and predates them.