### PR TITLE
fix(tui): refuse to start rather than re-exec through PATH

### DIFF
--- a/scripts/.spawn-lint-allow
+++ b/scripts/.spawn-lint-allow
@@ -13,3 +13,11 @@ src/core/services/plist\.zig:.*"/(bin|usr/bin)/(sh|bash|zsh|ksh|env|tcsh|python|
 # docstrings/error messages.
 src/core/services/plist\.zig:.*///.*/bin/sh
 src/core/services/plist\.zig:.*//.*/bin/sh
+# `install_name_tool` also names the doctor row and the backend's tool label,
+# neither of which is an argv.
+src/macho/patcher\.zig:[0-9]+:pub const external_tool_name
+src/core/patch\.zig:[0-9]+:.*expectEqualStrings\("install_name_tool"
+# `sudo` is a declarative post_install_steps JSON key, not a command.
+src/core/post_install_steps\.zig:[0-9]+:.*obj\.get\("sudo"\)
+src/core/post_install_steps\.zig:[0-9]+:.*"args", "sudo"
+src/core/post_install_steps\.zig:[0-9]+:.*"sudo":

--- a/scripts/lint-spawn-invariants.sh
+++ b/scripts/lint-spawn-invariants.sh
@@ -43,3 +43,40 @@ if [ -n "$hits" ]; then
 fi
 
 printf '✓ argv-only spawn invariant holds across src/\n'
+
+# A platform helper named without a path resolves through PATH, and a package's
+# own bin directory can sit ahead of the system one. Every tool in
+# src/system_tools.zig is spawned by absolute path; this catches a bare name
+# creeping back. Matching the bare literal anywhere beats matching an argv
+# shape: a multi-line argv literal puts the name on its own line, which is the
+# form the original bug had.
+#
+# `install` is skipped: it is also a malt subcommand, so the bare literal is
+# ambiguous and would fire on ordinary argv tails.
+TOOLS=$(grep -oE '^pub const [a-z_]+ = "/[^"]+"' src/system_tools.zig |
+  sed -E 's|^pub const [a-z_]+ = "/.*/([^/"]+)"|\1|' | grep -vx install | tr '\n' ' ')
+
+bare=""
+for bin in $TOOLS; do
+  found=$(grep -RnF --include='*.zig' "\"$bin\"" src || true)
+  [ -n "$found" ] && bare="$bare$found
+"
+done
+
+if [ -s "$ALLOW_FILE" ]; then
+  while IFS= read -r rule; do
+    [ -z "$rule" ] && continue
+    [[ "$rule" == \#* ]] && continue
+    bare=$(printf '%s\n' "$bare" | grep -vE "$rule" || true)
+  done <"$ALLOW_FILE"
+fi
+bare=$(printf '%s' "$bare" | grep -v '^$' || true)
+
+if [ -n "$bare" ]; then
+  printf '✗ platform helper named without a path (resolves through PATH):\n\n' >&2
+  printf '%s\n' "$bare" >&2
+  printf '\nUse the matching constant in src/system_tools.zig, or allowlist in %s.\n' "$ALLOW_FILE" >&2
+  exit 1
+fi
+
+printf '✓ platform helpers are named by absolute path\n'

--- a/scripts/regressions/spawn-lint-misses-multiline-argv.sh
+++ b/scripts/regressions/spawn-lint-misses-multiline-argv.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Regression: the spawn lint must catch a platform helper reintroduced by bare
+# name, including in a multi-line argv literal.
+#
+# The bug: malt resolves every platform helper through `src/system_tools.zig`
+# so a package's own bin directory cannot shadow one via PATH. Nothing enforced
+# that, so a bare name could be added back silently. The first guard matched an
+# argv *shape* (`[_][]const u8{ "tool"`), which grep evaluates a line at a time
+# — and a multi-line argv literal puts the name on its own line. That is the
+# exact form the pre-fix code had, so the guard passed on the bug it existed to
+# catch.
+#
+# This drives the real lint: it must be clean on the tree as committed, and
+# must fail once a bare `hdiutil` is reintroduced in the multi-line form. The
+# edit is reverted whether the check passes or not.
+#
+# Exits 0 when the guard works, non-zero (with a clear message) when it does
+# not. No network required; finishes in seconds.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+LINT=scripts/lint-spawn-invariants.sh
+TARGET=src/core/cask.zig
+BACKUP=$(mktemp)
+# The edit lands in the working tree, so restore on any exit path, not just
+# a clean one. `run-regressions.sh` drives these sequentially, so no other
+# script sees the window.
+trap '/bin/cp -f "$BACKUP" "$TARGET"; rm -f "$BACKUP"' EXIT INT TERM
+
+/bin/cp -f "$TARGET" "$BACKUP"
+
+if ! bash "$LINT" >/dev/null 2>&1; then
+  echo "FAIL: the lint already reports a violation on the committed tree" >&2
+  bash "$LINT" >&2 || true
+  exit 1
+fi
+
+# Same shape as the original: the helper name sits on its own line.
+python3 - "$TARGET" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p, encoding="utf-8").read()
+needle = '            system_tools.hdiutil, "attach",'
+if needle not in s:
+    sys.exit("FAIL: fixture anchor missing from " + p)
+open(p, "w", encoding="utf-8").write(s.replace(needle, '            "hdiutil", "attach",', 1))
+PY
+
+if bash "$LINT" >/dev/null 2>&1; then
+  echo "FAIL: the lint accepted a bare 'hdiutil' in a multi-line argv literal" >&2
+  exit 1
+fi
+
+echo "OK: the spawn lint catches a bare platform helper across lines"

--- a/src/main.zig
+++ b/src/main.zig
@@ -731,8 +731,8 @@ fn dispatch(allocator: std.mem.Allocator, ctx: *const AppCtx, cmd: Command, cmd_
             // through PATH, where a package's own bin directory can shadow us.
             var self_buf: [std.fs.max_path_bytes]u8 = undefined;
             const n = std.process.executablePath(ctx.io, &self_buf) catch {
-                ctx.stderr.writeStreamingAll(ctx.io, "mt: cannot resolve its own executable path; refusing to start the dashboard\n") catch {};
-                return error.ExecutablePathUnavailable;
+                output_mod.err("cannot resolve malt's own path; refusing to start the dashboard", .{});
+                return error.Aborted;
             };
             const mt_path = self_buf[0..n];
             try @import("tui/app.zig").run(ctx.io, allocator, ctx.stderr, ctx.environ, mt_path, version);

--- a/src/main.zig
+++ b/src/main.zig
@@ -727,9 +727,14 @@ fn dispatch(allocator: std.mem.Allocator, ctx: *const AppCtx, cmd: Command, cmd_
         .tui => {
             if (cli_help.showIfRequested(ctx, cmd_args, "tui")) return;
             // Resolve this binary's path so the TUI re-execs the *same* `mt` for
-            // delegated mutations; fall back to `mt` (PATH) if it can't be read.
+            // delegated mutations. Falling back to a bare `mt` would resolve
+            // through PATH, where a package's own bin directory can shadow us.
             var self_buf: [std.fs.max_path_bytes]u8 = undefined;
-            const mt_path = if (std.process.executablePath(ctx.io, &self_buf)) |n| self_buf[0..n] else |_| "mt";
+            const n = std.process.executablePath(ctx.io, &self_buf) catch {
+                ctx.stderr.writeStreamingAll(ctx.io, "mt: cannot resolve its own executable path; refusing to start the dashboard\n") catch {};
+                return error.ExecutablePathUnavailable;
+            };
+            const mt_path = self_buf[0..n];
             try @import("tui/app.zig").run(ctx.io, allocator, ctx.stderr, ctx.environ, mt_path, version);
         },
         .bundle => try bundle.execute(ctx, allocator, cmd_args),


### PR DESCRIPTION
## Description

The dashboard re-execs malt for delegated mutations and resolves its own executable path to do it, but fell back to a bare `mt` when that lookup failed. A bare name resolves through PATH, where a package's own bin directory can sit ahead of the prefix - the substitution the trusted-path work removed everywhere else. It now reports the failure and declines to start.

The spawn lint gains a second invariant so those trusted paths cannot quietly erode: every helper named in `system_tools.zig` is checked for a bare-name occurrence in `src/`.

## Related Issue

- None

## Notes for Reviewers

- None