### PR TITLE
fix(net): stop stalling on responses that carry no body

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -106,6 +106,7 @@ pub fn build(b: *std.Build) void {
 
     // --- Unit tests ---
     const test_modules = .{
+        "tests/http_bodiless_status_test.zig",
         "tests/aggregate_drift_test.zig",
         "tests/formula_test.zig",
         "tests/deps_test.zig",

--- a/scripts/regressions/conditional-request-304-drain-stall-gh821.sh
+++ b/scripts/regressions/conditional-request-304-drain-stall-gh821.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Pin that a conditional request answered 304 returns immediately.
+#
+# Re-resolving a tap sends If-None-Match and normally gets 304 Not Modified.
+# A 304 carries no body and no framing headers, which the HTTP release path
+# read as "body ends when the peer closes" - so it blocked on a keep-alive
+# socket until the idle timeout, roughly 30 s per request, and only then
+# returned the (correct) cached commit. A warm `bundle install` therefore
+# paid ~30 s per tap line while doing no useful work at all.
+#
+# Pinned behaviour: the second resolve of the same tap is fast. The failure
+# mode is a fixed ~30 s stall per request, so the threshold sits far below
+# one timeout and far above any plausible round trip.
+#
+# Needs the network. Set MALT_GITHUB_TOKEN to avoid the anonymous API cap.
+#
+# Usage: scripts/regressions/conditional-request-304-drain-stall-gh821.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s - run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+# One timeout is ~30 s; a healthy conditional resolve is well under a second.
+MAX_WARM_SECS=10
+TAP=${TAP:-keith/formulae}
+
+PFX=$(mktemp -d -t mt_cond304.XXXXXX)
+trap 'rm -rf "$PFX"' EXIT
+export MALT_PREFIX="$PFX" NO_COLOR=1
+
+# `tap` is a no-op against a prefix with no database, so bring one into
+# existence first: an unresolvable name creates it and then fails.
+"$MALT_BIN" install --quiet nope-not-real >/dev/null 2>&1 || true
+[[ -f "$PFX/db/malt.db" ]] || fail 'could not bootstrap the fixture database'
+
+# Cold resolve: no cached etag yet, so this one gets a 200 and stores the
+# validator the warm run below sends back.
+"$MALT_BIN" tap "$TAP" >"$PFX/cold.log" 2>&1 ||
+  fail "could not resolve $TAP - see $PFX/cold.log"
+grep -q 'Tapped' "$PFX/cold.log" || fail "cold resolve did not register the tap"
+
+etag=$(sqlite3 "$PFX/db/malt.db" "SELECT COALESCE(head_etag,'') FROM taps WHERE name='$TAP';")
+[[ -n "$etag" ]] ||
+  fail 'no ETag stored, so the warm run would not send If-None-Match and would prove nothing'
+
+start=$(date +%s)
+"$MALT_BIN" tap "$TAP" >"$PFX/warm.log" 2>&1 ||
+  fail "warm resolve of $TAP failed - see $PFX/warm.log"
+elapsed=$(($(date +%s) - start))
+
+grep -q 'Tapped' "$PFX/warm.log" || fail "warm resolve did not register the tap"
+((elapsed < MAX_WARM_SECS)) ||
+  fail "warm conditional resolve took ${elapsed}s (limit ${MAX_WARM_SECS}s) - the 304 stalled until timeout"
+
+printf 'PASS: a 304 conditional resolve returned in %ss\n' "$elapsed"

--- a/src/net/client.zig
+++ b/src/net/client.zig
@@ -80,6 +80,14 @@ pub fn classifyStatus(status: u16) ?DownloadError {
     return null;
 }
 
+/// Statuses that never carry a body (RFC 9110 6.4.1). The release path
+/// decides by request method alone, so a bodiless response that also omits
+/// framing headers reads as "body ends when the peer closes" and blocks on
+/// a keep-alive socket until the idle timeout.
+pub fn statusHasNoBody(status: u16) bool {
+    return (status >= 100 and status < 200) or status == 204 or status == 304;
+}
+
 pub fn isTransientError(err: DownloadError) bool {
     return switch (err) {
         error.Timeout, error.ConnectionReset, error.HttpServerError, error.RateLimited, error.ReadFailed, error.WatchdogSpawnFailed => true,
@@ -957,6 +965,21 @@ pub const HttpClient = struct {
         return try out.toOwnedSlice();
     }
 
+    /// Release a request whose response carries no body. stdlib's `deinit`
+    /// decides by method alone, so on a bodiless status it drains until the
+    /// peer closes — on a keep-alive 304 that is a full idle timeout.
+    /// Declaring the body zero-length makes that drain a no-op.
+    ///
+    /// The connection is retired rather than pooled: if a broken peer did
+    /// send bytes we never read, reuse would feed them to the next request
+    /// as its response head.
+    fn finishBodiless(req: *std.http.Client.Request) void {
+        req.response_content_length = 0;
+        req.response_transfer_encoding = .none;
+        if (req.connection) |conn| conn.closing = true;
+        req.deinit();
+    }
+
     /// GET that follows redirects manually so credential/validator headers are
     /// stripped before leaving the origin's scope. In Zig 0.16 stdlib,
     /// `extra_headers` ride every redirect and `privileged_headers` are never
@@ -1022,12 +1045,11 @@ pub const HttpClient = struct {
                     etag_owned = try self.allocator.dupe(u8, e);
             }
 
-            // 304 has no body per HTTP spec — empty owned slice keeps deinit's
-            // `free(body)` uniform.
-            if (status == 304) {
+            // Empty owned slice keeps deinit's `free(body)` uniform.
+            if (statusHasNoBody(status)) {
                 const empty = try self.allocator.alloc(u8, 0);
-                req.deinit();
-                return .{ .status = status, .body = empty, .etag = etag_owned, .not_modified = true };
+                finishBodiless(&req);
+                return .{ .status = status, .body = empty, .etag = etag_owned, .not_modified = status == 304 };
             }
 
             const total_timeout = if (max_bytes > max_metadata_bytes)
@@ -1196,6 +1218,13 @@ pub const HttpClient = struct {
                 return status;
             }
 
+            // Nothing to drain when the status forbids a body, and trying
+            // would block until the idle timeout.
+            if (statusHasNoBody(status)) {
+                finishBodiless(&req);
+                return status;
+            }
+
             // Non-200: drain the error body into a bounded discard so status
             // classification / pre-body retry behave as on the buffer path and
             // the pooled connection stays reusable — all while `sink` is left
@@ -1282,6 +1311,28 @@ test "extractEtagFromHead: preserves GitHub's weak-ETag W/ prefix verbatim" {
     const bytes = "304 Not Modified\r\nETag: W/\"deadbeef\"\r\n\r\n";
     const et = extractEtagFromHead(bytes);
     try std.testing.expectEqualStrings("W/\"deadbeef\"", et.?);
+}
+
+test "statusHasNoBody covers exactly the bodiless statuses" {
+    // 204 and 304 are the reachable ones; 1xx is in the rule regardless.
+    try std.testing.expect(statusHasNoBody(204));
+    try std.testing.expect(statusHasNoBody(304));
+
+    // Both ends of the 1xx range, and the values just outside it.
+    try std.testing.expect(statusHasNoBody(100));
+    try std.testing.expect(statusHasNoBody(199));
+    try std.testing.expect(!statusHasNoBody(99));
+    try std.testing.expect(!statusHasNoBody(200));
+
+    // Everything else carries a body, and draining it is what keeps a
+    // pooled connection reusable. 205 and 304 are one apart; so are 204
+    // and 205.
+    try std.testing.expect(!statusHasNoBody(203));
+    try std.testing.expect(!statusHasNoBody(205));
+    try std.testing.expect(!statusHasNoBody(303));
+    try std.testing.expect(!statusHasNoBody(305));
+    try std.testing.expect(!statusHasNoBody(404));
+    try std.testing.expect(!statusHasNoBody(500));
 }
 
 test "extractEtagFromHead: returns null when ETag header is absent" {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -59,6 +59,7 @@ comptime {
     _ = @import("flag_drift_test.zig");
     _ = @import("forge_purity_test.zig");
     _ = @import("formula_test.zig");
+    _ = @import("http_bodiless_status_test.zig");
     _ = @import("ghcr_401_retry_test.zig");
     _ = @import("ghcr_test.zig");
     _ = @import("hash_test.zig");

--- a/tests/http_bodiless_status_test.zig
+++ b/tests/http_bodiless_status_test.zig
@@ -1,0 +1,119 @@
+//! malt — bodiless-status release integration tests.
+//!
+//! A 204 or 304 carries no body, and real servers send them with no
+//! Content-Length and no Transfer-Encoding either. The stdlib release path
+//! decides whether to drain by request *method*, so unless the response is
+//! declared zero-length it reads until the peer closes — on a keep-alive
+//! connection that is a full idle timeout per request.
+//!
+//! The stub below answers with raw bytes (no framing headers) and then holds
+//! the connection open: closing it would let the drain hit EOF and hide the
+//! very stall these tests exist to catch. A regression shows up as a
+//! multi-second wall time, not a wrong value.
+
+const std = @import("std");
+const client = @import("malt").client;
+const net = std.Io.net;
+const testing = std.testing;
+
+/// A healthy release returns in milliseconds. A regressed one blocks until
+/// the stub gives up, so the budget sits between the two.
+const stall_budget_ms: i64 = 3_000;
+
+/// How long the stub keeps a bodiless response's connection open. Bounds the
+/// damage of a regression: the drain ends at EOF here instead of hanging the
+/// suite, and the elapsed assertion then fails cleanly.
+const hold_open_ms: i32 = 6_000;
+
+const Stub = struct {
+    io: std.Io,
+    listener: *net.Server,
+    /// Full response head, terminated by a blank line. Deliberately carries
+    /// no Content-Length and no Transfer-Encoding.
+    head: []const u8,
+};
+
+fn serveBodiless(s: *Stub) void {
+    const stream = s.listener.accept(s.io) catch return;
+    defer stream.close(s.io);
+
+    var rbuf: [8 * 1024]u8 = undefined;
+    var wbuf: [1024]u8 = undefined;
+    var reader = stream.reader(s.io, &rbuf);
+    var writer = stream.writer(s.io, &wbuf);
+
+    // One blocking read is enough: the client's whole GET head arrives in a
+    // single loopback segment, and it has already finished writing by then.
+    _ = reader.interface.peek(1) catch return;
+
+    writer.interface.writeAll(s.head) catch return;
+    writer.interface.flush() catch return;
+
+    // Hold the connection open: an undeclared body has nothing to read, which
+    // is the keep-alive condition the bug needs. A healthy client closes at
+    // once and `poll` returns immediately; a regressed one is still blocked,
+    // so the wait is bounded rather than infinite.
+    var pfds = [_]std.posix.pollfd{.{
+        .fd = stream.socket.handle,
+        .events = std.posix.POLL.IN,
+        .revents = 0,
+    }};
+    _ = std.posix.poll(&pfds, hold_open_ms) catch {};
+}
+
+const Probe = struct { status: u16, not_modified: bool, elapsed_ms: i64 };
+
+fn runBodiless(head: []const u8, if_none_match: ?[]const u8) !Probe {
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var addr = try net.IpAddress.parseIp4("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var stub = Stub{ .io = io, .listener = &listener, .head = head };
+    const server_thread = try std.Thread.spawn(.{}, serveBodiless, .{&stub});
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/probe", .{port});
+
+    var inner: std.http.Client = .{ .allocator = testing.allocator, .io = io };
+    var http = client.HttpClient.initWith(&inner, io, std.process.Environ.empty, testing.allocator);
+
+    const started_ns: i128 = std.Io.Clock.real.now(io).toNanoseconds();
+    var resp = try http.getConditional(url, if_none_match, &.{});
+    const elapsed: i64 = @intCast(@divTrunc(std.Io.Clock.real.now(io).toNanoseconds() - started_ns, std.time.ns_per_ms));
+    defer resp.deinit();
+
+    const out = Probe{ .status = resp.status, .not_modified = resp.not_modified, .elapsed_ms = elapsed };
+
+    http.deinit();
+    server_thread.join();
+    return out;
+}
+
+test "a 304 with no framing headers is released without draining the connection" {
+    const r = try runBodiless("HTTP/1.1 304 Not Modified\r\nETag: W/\"deadbeef\"\r\n\r\n", "W/\"deadbeef\"");
+
+    try testing.expectEqual(@as(u16, 304), r.status);
+    try testing.expect(r.not_modified);
+    if (r.elapsed_ms >= stall_budget_ms) {
+        std.debug.print("304 took {d}ms — the release path drained a body that never comes\n", .{r.elapsed_ms});
+        return error.ConditionalRequestStalled;
+    }
+}
+
+test "a 204 with no framing headers is released without draining the connection" {
+    // Same rule, different status: not_modified stays false so a 204 is never
+    // mistaken for a validated cache hit.
+    const r = try runBodiless("HTTP/1.1 204 No Content\r\n\r\n", null);
+
+    try testing.expectEqual(@as(u16, 204), r.status);
+    try testing.expect(!r.not_modified);
+    if (r.elapsed_ms >= stall_budget_ms) {
+        std.debug.print("204 took {d}ms — the release path drained a body that never comes\n", .{r.elapsed_ms});
+        return error.BodilessResponseStalled;
+    }
+}


### PR DESCRIPTION
## Description

A warm `bundle install` still took about 150 s after v0.23.0. The members were already being skipped by then - the cost was in the tap lines. Every conditional request answered `304 Not Modified` waited out a 30 s idle timeout before carrying on with the correct answer, so a run scaled at roughly 30 s per tap while doing no actual work.

Responses that cannot carry a body are now released immediately. The reporter's five-tap bundle goes from 2 m 32 s to 2.9 s, and a single warm tap re-resolve from 30.4 s to 0.4 s. 204 is covered by the same rule, since it stalls the same way.

## Related Issue
- Closes #821

## Notes for Reviewers

- One deliberate trade: a bodiless response now retires its connection instead of returning it to the pool. If a peer sent bytes we never read, reuse would hand them to the next request as its response head. The extra handshake does not register at tap-resolution frequency.
- The v0.23.0 fix was real - warm members genuinely no longer hit the network - but it was never going to move this number.