### PR TITLE
fix(tap): act on a prefix that has no database yet

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -107,6 +107,7 @@ pub fn build(b: *std.Build) void {
     // --- Unit tests ---
     const test_modules = .{
         "tests/http_bodiless_status_test.zig",
+        "tests/tap_fresh_prefix_test.zig",
         "tests/aggregate_drift_test.zig",
         "tests/formula_test.zig",
         "tests/deps_test.zig",

--- a/scripts/regressions/tap-fresh-prefix-silent-noop.sh
+++ b/scripts/regressions/tap-fresh-prefix-silent-noop.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Pin that tap commands do their work on a prefix that has no database yet.
+#
+# sqlite cannot create its file inside a `db/` that does not exist, and the
+# tap command read that failure as "no taps registered" for every intent.
+# That is only true for listing: add, refresh, pin and untap all reported
+# success while doing nothing, so a tap the user believed was registered
+# simply was not.
+#
+# Pinned behaviour:
+#   1. A mutating intent works on a fresh prefix and leaves the database
+#      behind, rather than exiting 0 having done nothing.
+#   2. Listing still answers for an empty prefix without creating one, in
+#      both human and --json form.
+#
+# Hermetic: untap and listing need no network, so nothing here leaves the box.
+#
+# Usage: scripts/regressions/tap-fresh-prefix-silent-noop.sh
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+MALT_BIN=${MALT_BIN:-$ROOT/zig-out/bin/malt}
+if [[ ! -x "$MALT_BIN" ]]; then
+  printf 'FAIL: malt binary not found at %s - run "zig build" first.\n' "$MALT_BIN" >&2
+  exit 1
+fi
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+PFX=$(mktemp -d -t mt_tapfresh.XXXXXX)
+trap 'rm -rf "$PFX"' EXIT
+export MALT_PREFIX="$PFX" NO_COLOR=1
+
+# Listing is read-only: it must answer, and leave the prefix untouched.
+out=$("$MALT_BIN" tap 2>&1) || fail "listing an empty prefix failed: $out"
+grep -q 'No taps registered' <<<"$out" ||
+  fail "listing an empty prefix said nothing at all: [$out]"
+[[ -d "$PFX/db" ]] && fail 'listing created a database on a read-only command'
+
+json=$("$MALT_BIN" --json tap 2>&1) || fail "--json listing failed: $json"
+[[ "$json" == "[]" ]] || fail "--json listing emitted [$json], expected []"
+
+# A mutating intent must actually run. untap needs no network, so it carries
+# this half on its own.
+out=$("$MALT_BIN" untap nosuch/tap 2>&1) || fail "untap on a fresh prefix failed: $out"
+grep -q 'Untapped nosuch/tap' <<<"$out" ||
+  fail "untap on a fresh prefix reported nothing: [$out]"
+[[ -f "$PFX/db/malt.db" ]] ||
+  fail 'untap reported success without ever creating the database'
+
+printf 'PASS: tap intents act on a fresh prefix, listing leaves it alone\n'

--- a/src/cli/tap.zig
+++ b/src/cli/tap.zig
@@ -525,6 +525,32 @@ pub fn executeUntap(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []co
     return run(ctx, allocator, args, .remove);
 }
 
+/// True when argv asks only to *read* the tap list. Everything else has work
+/// to do and therefore needs `db/` on disk, so a new mutating flag that
+/// forgets to land here would silently go back to doing nothing.
+fn isListingIntent(
+    positional: ?[]const u8,
+    pin_slug: ?[]const u8,
+    refresh_target: ?[]const u8,
+    refresh_all: bool,
+) bool {
+    return positional == null and pin_slug == null and
+        refresh_target == null and !refresh_all;
+}
+
+test "isListingIntent: bare argv is the only read-only shape" {
+    try std.testing.expect(isListingIntent(null, null, null, false));
+}
+
+test "isListingIntent: each intent that mutates opts out on its own" {
+    // One per argv shape: a flag missing from the conjunction would leave its
+    // command unable to create the database it is about to write to.
+    try std.testing.expect(!isListingIntent("user/repo", null, null, false));
+    try std.testing.expect(!isListingIntent(null, "user/repo", null, false));
+    try std.testing.expect(!isListingIntent(null, null, "user/repo", false));
+    try std.testing.expect(!isListingIntent(null, null, null, true));
+}
+
 const Action = enum { add, remove };
 
 fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u8, action: Action) !void {
@@ -717,18 +743,30 @@ fn run(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const []const u
 
     const prefix = atomic.maltPrefixOrAbort();
 
-    // Listing-intent under `--json` needs a parseable empty array even on a
-    // fresh prefix where `db/` doesn't exist — otherwise `jq` chokes on
-    // silently-empty stdout. Detect intent from already-parsed argv.
-    const is_listing = positional == null and pin_slug == null and
-        refresh_target == null and !refresh_all;
+    const is_listing = isListingIntent(positional, pin_slug, refresh_target, refresh_all);
 
     var db_path_buf: [512]u8 = undefined;
     const db_path = std.fmt.bufPrintSentinel(&db_path_buf, "{s}/db/malt.db", .{prefix}, 0) catch return;
+
+    // sqlite cannot create its file inside a `db/` that does not exist, so
+    // every intent with work to do has to make the directory first. Listing
+    // stays read-only: it answers for the empty prefix without building one.
+    if (!is_listing) {
+        var dir_buf: [512]u8 = undefined;
+        const db_dir = std.fmt.bufPrint(&dir_buf, "{s}/db", .{prefix}) catch return;
+        std.Io.Dir.cwd().createDirPath(ctx.io, db_dir) catch {
+            output.err("Cannot create {s} - check the prefix is writable.", .{db_dir});
+            return error.Aborted;
+        };
+    }
+
     var db = sqlite.Database.open(db_path) catch {
-        // Fresh prefix with no `db/` yet = no taps registered.
-        if (is_listing and output.isJson()) output.writeStdoutAll("[]\n");
-        return;
+        if (is_listing) {
+            if (output.isJson()) output.writeStdoutAll("[]\n") else output.info("No taps registered", .{});
+            return;
+        }
+        output.err("Cannot open the tap database at {s}", .{db_path});
+        return error.Aborted;
     };
     defer db.close();
     schema.initSchema(&db) catch return;

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -7,6 +7,7 @@
 //! build if this list ever falls behind the directory.
 
 comptime {
+    _ = @import("tap_fresh_prefix_test.zig");
     _ = @import("aggregate_drift_test.zig");
     _ = @import("api_test.zig");
     _ = @import("archive_extract_symlink_test.zig");

--- a/tests/tap_fresh_prefix_test.zig
+++ b/tests/tap_fresh_prefix_test.zig
@@ -1,0 +1,100 @@
+//! malt — tap-on-a-fresh-prefix integration tests.
+//!
+//! `sqlite.Database.open` cannot create its file inside a `db/` that does not
+//! exist yet, and the tap command treated that failure as "no taps registered"
+//! for every intent. Listing is the only intent that reading is true for: add,
+//! refresh, pin and untap all reported success while doing nothing at all.
+
+const std = @import("std");
+const malt = @import("malt");
+const test_io = @import("test_io");
+const testing = std.testing;
+const tap = malt.cli_tap;
+
+const c = struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+};
+
+fn pathExists(path: []const u8) bool {
+    test_io.accessAbsolute(std.Options.debug_io, path, .{}) catch return false;
+    return true;
+}
+
+fn setupPrefix(suffix: []const u8) ![:0]u8 {
+    const base = try test_io.uniqueTempPath(testing.allocator, "tap_fresh", suffix);
+    defer testing.allocator.free(base);
+    const path = try testing.allocator.dupeZ(u8, base);
+    test_io.deleteTreeAbsolute(std.Options.debug_io, path) catch {};
+    try test_io.cwd().createDirPath(std.Options.debug_io, path);
+    _ = c.setenv("MALT_PREFIX", path.ptr, 1);
+    return path;
+}
+
+test "untap on a fresh prefix does the work instead of reporting a silent success" {
+    // Untap needs no network, so it pins the "mutating intent must not no-op"
+    // half of the contract on its own.
+    const prefix = try setupPrefix("untap");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    const db_file = try std.fmt.allocPrint(testing.allocator, "{s}/db/malt.db", .{prefix});
+    defer testing.allocator.free(db_file);
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try tap.executeUntap(&ctx, arena.allocator(), &.{"nosuch/tap"});
+
+    try testing.expect(pathExists(db_file));
+    try testing.expect(std.mem.indexOf(u8, captured.items, "Untapped nosuch/tap") != null);
+}
+
+test "listing on a fresh prefix reports empty without creating a database" {
+    // Read-only intent: it must answer the same way it does against an
+    // initialised prefix, and leave nothing behind.
+    const prefix = try setupPrefix("list");
+    defer {
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+        testing.allocator.free(prefix);
+        _ = c.unsetenv("MALT_PREFIX");
+    }
+
+    const db_dir = try std.fmt.allocPrint(testing.allocator, "{s}/db", .{prefix});
+    defer testing.allocator.free(db_dir);
+
+    const prior_quiet = malt.output.isQuiet();
+    malt.output.setQuiet(false);
+    defer malt.output.setQuiet(prior_quiet);
+
+    var captured: std.ArrayList(u8) = .empty;
+    defer captured.deinit(testing.allocator);
+    malt.output.beginStderrCapture(testing.allocator, &captured);
+    defer malt.output.endStderrCapture();
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try tap.execute(&ctx, arena.allocator(), &.{});
+
+    try testing.expect(std.mem.indexOf(u8, captured.items, "No taps registered") != null);
+    try testing.expect(!pathExists(db_dir));
+}


### PR DESCRIPTION
## Description

On a prefix with no database, `mt tap <slug>`, `--refresh`, `--pin` and `untap` all exited 0 having done nothing. Someone taps a repo as their first command on a new prefix, sees no error, and the tap simply is not there.

sqlite cannot create its file inside a `db/` that does not exist, and that failure was read as "no taps registered" whatever had been asked for. It is only the right answer for listing. Intents with work to do now create the directory first, the way `mt install` already does.

## Related Issue

- None

## Notes for Reviewers

- Listing changes too, though less visibly: on a fresh prefix it now prints `No taps registered` instead of nothing at all, matching what it already printed once a database existed. It stays read-only and creates nothing.
- `--refresh --all` is silent when no taps are registered. That is unchanged here - it behaves the same with or without a database - but it is the same silent-on-empty shape if you want it picked up separately.