### PR TITLE
fix(rollback): never leave a package broken by a failed rollback

### DIFF
--- a/scripts/regressions/rollback-destroys-current-keg-before-materialize.sh
+++ b/scripts/regressions/rollback-destroys-current-keg-before-materialize.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Regression: a `mt rollback` that cannot materialize its target leaves the
+# currently installed version fully usable.
+#
+# Pre-fix, rollback ran `linker.unlink` and removed the current Cellar dir
+# BEFORE calling `cellar.materializeWithCellar`. Store entries are on-disk
+# input, so a corrupt or unreadable one made materialize fail after the
+# destructive half had already landed:
+#
+#   ✗ Failed to materialize wget 1.20 from store
+#
+# leaving no Cellar tree, no `bin/` symlink, and a kegs row pointing at a
+# path that no longer exists - a machine with no working version and no
+# restore path. `upgrade` already materialized first and restored old links
+# on failure; rollback now follows the same order.
+#
+# Usage: scripts/regressions/rollback-destroys-current-keg-before-materialize.sh
+# Requirements: built `malt` at $MALT_BIN or zig-out/bin/malt,
+# `sqlite3` on PATH. No network.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+BIN="${MALT_BIN:-$ROOT/zig-out/bin/malt}"
+[[ -x "$BIN" ]] || {
+  echo "build malt first: zig build" >&2
+  exit 2
+}
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "this regression needs sqlite3 on PATH" >&2
+  exit 2
+}
+[[ "$(id -u)" -ne 0 ]] || {
+  echo "skip: chmod 000 does not deny root" >&2
+  exit 0
+}
+
+PREFIX="/tmp/mt_rb_materialize_fail_$$"
+export MALT_PREFIX="$PREFIX"
+export NO_COLOR=1
+export MALT_NO_EMOJI=1
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX/db"
+cleanup() {
+  chmod -R u+rwx "$PREFIX" 2>/dev/null || true
+  rm -rf "$PREFIX"
+}
+trap cleanup EXIT
+
+pass() { printf '  \xe2\x9c\x93 %s\n' "$*"; }
+fail() {
+  printf '  \xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+DB="$PREFIX/db/malt.db"
+
+# Bootstrap the schema by letting malt open the DB once.
+"$BIN" list --quiet >/dev/null 2>&1 || true
+[[ -f "$DB" ]] || fail "DB was not initialised by mt list"
+
+# Seed a real installation of wget 1.22: Cellar tree, bin/ symlink, and
+# the kegs + links rows that `unlink` walks.
+KEG="$PREFIX/Cellar/wget/1.22"
+mkdir -p "$KEG/bin" "$PREFIX/bin"
+printf '#!/bin/sh\n' >"$KEG/bin/wget"
+chmod +x "$KEG/bin/wget"
+ln -s "$KEG/bin/wget" "$PREFIX/bin/wget"
+
+sqlite3 "$DB" <<SQL
+INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason)
+VALUES ('wget', 'wget', '1.22', 0, 'sha_cur', '$KEG', 'direct');
+INSERT INTO links (keg_id, link_path, target)
+VALUES (last_insert_rowid(), '$PREFIX/bin/wget', '$KEG/bin/wget');
+SQL
+
+# Seed a rollback target that is discoverable but unreadable, so
+# materialize fails the way a corrupt store entry does.
+OLD="$PREFIX/store/sha_old/wget/1.20"
+mkdir -p "$OLD"
+touch "$OLD/INSTALL_RECEIPT.json"
+chmod 000 "$OLD"
+
+if "$BIN" rollback wget >/dev/null 2>&1; then
+  fail "rollback succeeded against an unreadable store entry"
+fi
+pass "rollback refused and exited non-zero"
+
+[[ -d "$KEG" ]] || fail "current Cellar dir was destroyed by the failed rollback"
+pass "Cellar/wget/1.22 survived"
+
+[[ -L "$PREFIX/bin/wget" && -e "$PREFIX/bin/wget" ]] ||
+  fail "current bin/wget symlink was destroyed by the failed rollback"
+pass "bin/wget still resolves"
+
+[[ "$(sqlite3 "$DB" "SELECT version FROM kegs WHERE name='wget';")" == "1.22" ]] ||
+  fail "kegs row no longer names the current version"
+pass "kegs row still names 1.22"
+
+[[ "$(sqlite3 "$DB" "SELECT count(*) FROM links WHERE link_path='$PREFIX/bin/wget';")" == "1" ]] ||
+  fail "links row for the current version was dropped"
+pass "links row survived"
+
+echo "rollback keeps the current version on a failed materialize: OK"

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -209,17 +209,21 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         output.err("Failed to materialize {s} {s} from store", .{ name, target.pkg_version });
         return error.Aborted;
     };
+    defer allocator.free(keg.path);
 
     // Update DB: delete old record, insert new one. Capture the old
     // pin BEFORE the delete so the new row can inherit it — rolling
     // back a held formula must not silently clear the user's hold.
-    const old_pinned = capturePinnedById(&db, current_id);
+    const carried: Carried = .{
+        .pinned = capturePinnedById(&db, current_id),
+        .bin_isolated = current_bin_isolated,
+    };
 
     var linker = linker_mod.Linker.init(ctx.io, allocator, &db, prefix);
 
     db.beginTransaction() catch return error.Aborted;
 
-    const keg_id = swapKeg(&db, &linker, current_id, name, target, keg.path, old_pinned) catch {
+    const keg_id = swapKeg(&db, &linker, current_id, name, target, keg.path, carried) catch {
         db.rollback();
         restoreCurrentLinks(&linker, current_cellar_path, name, current_id, current_bin_isolated);
         cellar.remove(ctx.io, prefix, name, target.pkg_version) catch {};
@@ -262,14 +266,14 @@ fn swapKeg(
     name: []const u8,
     target: Entry,
     keg_path: []const u8,
-    pinned: bool,
+    carried: Carried,
 ) !i64 {
     try linker.unlink(current_id);
     // target.pkg_version carries the on-disk pkg_version label (the store
     // dir name), so replaceKegRow can split it back into version +
     // revision and persist the rolled-back keg's true revision.
-    const keg_id = try replaceKegRow(db, current_id, name, target.pkg_version, target.sha256, keg_path, pinned);
-    try linker.link(keg_path, name, keg_id, false);
+    const keg_id = try replaceKegRow(db, current_id, name, target.pkg_version, target.sha256, keg_path, carried);
+    try linker.link(keg_path, name, keg_id, carried.bin_isolated);
     return keg_id;
 }
 
@@ -491,6 +495,13 @@ pub fn capturePinnedById(db: *sqlite.Database, keg_id: i64) bool {
     return stmt.columnBool(0);
 }
 
+/// Columns that describe the user's intent rather than the version being
+/// installed, so the row swap has to carry them across.
+pub const Carried = struct {
+    pinned: bool,
+    bin_isolated: bool,
+};
+
 /// Swap the keg row identified by `old_keg_id` for a fresh row pointing
 /// at `pkg_version` (the on-disk label, e.g. "1.9.2_2"). Splits the
 /// label into `version` + `revision` so the new row reflects the
@@ -503,7 +514,7 @@ pub fn replaceKegRow(
     pkg_version: []const u8,
     store_sha256: []const u8,
     cellar_path: []const u8,
-    pinned: bool,
+    carried: Carried,
 ) !i64 {
     const parsed = formula_mod.parsePkgVersion(pkg_version);
 
@@ -516,8 +527,8 @@ pub fn replaceKegRow(
 
     {
         var ins = try db.prepare(
-            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason, pinned)
-            \\VALUES (?1, ?1, ?2, ?3, ?4, ?5, 'direct', ?6);
+            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason, pinned, bin_isolated)
+            \\VALUES (?1, ?1, ?2, ?3, ?4, ?5, 'direct', ?6, ?7);
         );
         defer ins.finalize();
         try ins.bindText(1, name);
@@ -525,7 +536,8 @@ pub fn replaceKegRow(
         try ins.bindInt(3, parsed.revision);
         try ins.bindText(4, store_sha256);
         try ins.bindText(5, cellar_path);
-        try ins.bindInt(6, @intFromBool(pinned));
+        try ins.bindInt(6, @intFromBool(carried.pinned));
+        try ins.bindInt(7, @intFromBool(carried.bin_isolated));
         _ = try ins.step();
     }
 
@@ -1281,7 +1293,7 @@ test "replaceKegRow splits pkg_version into version + revision" {
         break :blk s.columnInt(0);
     };
 
-    const new_id = try replaceKegRow(&db, old_id, "libgit2", "1.9.2", "sha-old", "/c/libgit2/1.9.2", true);
+    const new_id = try replaceKegRow(&db, old_id, "libgit2", "1.9.2", "sha-old", "/c/libgit2/1.9.2", .{ .pinned = true, .bin_isolated = false });
 
     var stmt = try db.prepare("SELECT version, revision, pinned FROM kegs WHERE id = ?1;");
     defer stmt.finalize();
@@ -1310,7 +1322,7 @@ test "replaceKegRow recovers a non-zero revision from pkg_version" {
     };
 
     // Rolling back to an earlier revision-2 build.
-    const new_id = try replaceKegRow(&db, old_id, "python@3.14", "3.14.3_2", "sha-old", "/c/python@3.14/3.14.3_2", false);
+    const new_id = try replaceKegRow(&db, old_id, "python@3.14", "3.14.3_2", "sha-old", "/c/python@3.14/3.14.3_2", .{ .pinned = false, .bin_isolated = false });
 
     var stmt = try db.prepare("SELECT version, revision FROM kegs WHERE id = ?1;");
     defer stmt.finalize();
@@ -1325,6 +1337,66 @@ test "replaceKegRow recovers a non-zero revision from pkg_version" {
     defer cnt.finalize();
     _ = try cnt.step();
     try testing.expectEqual(@as(i64, 1), cnt.columnInt(0));
+}
+
+// A rolled-back keg the user had installed bin-isolated must stay
+// bin-isolated: the swap replaces the version, not the user's intent.
+test "replaceKegRow carries pinned and bin_isolated across the swap" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, pinned, bin_isolated)
+        \\VALUES ('node', 'node', '22.1.0', 0, 'sha-cur', '/c/node/22.1.0', 1, 1);
+    );
+    const old_id = blk: {
+        var s = try db.prepare("SELECT id FROM kegs WHERE name='node';");
+        defer s.finalize();
+        _ = try s.step();
+        break :blk s.columnInt(0);
+    };
+
+    const new_id = try replaceKegRow(&db, old_id, "node", "22.0.0", "sha-old", "/c/node/22.0.0", .{
+        .pinned = true,
+        .bin_isolated = true,
+    });
+
+    var stmt = try db.prepare("SELECT pinned, bin_isolated FROM kegs WHERE id = ?1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, new_id);
+    _ = try stmt.step();
+    try testing.expect(stmt.columnBool(0));
+    try testing.expect(stmt.columnBool(1));
+}
+
+test "replaceKegRow leaves a non-isolated keg non-isolated" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+        \\VALUES ('jq', 'jq', '1.7.1', 0, 'sha-cur', '/c/jq/1.7.1');
+    );
+    const old_id = blk: {
+        var s = try db.prepare("SELECT id FROM kegs WHERE name='jq';");
+        defer s.finalize();
+        _ = try s.step();
+        break :blk s.columnInt(0);
+    };
+
+    const new_id = try replaceKegRow(&db, old_id, "jq", "1.7", "sha-old", "/c/jq/1.7", .{
+        .pinned = false,
+        .bin_isolated = false,
+    });
+
+    var stmt = try db.prepare("SELECT pinned, bin_isolated FROM kegs WHERE id = ?1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, new_id);
+    _ = try stmt.step();
+    try testing.expect(!stmt.columnBool(0));
+    try testing.expect(!stmt.columnBool(1));
 }
 
 test "removeCurrentCellarDir wipes the revision-bumped on-disk dir" {

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -84,7 +84,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     // Find current installed version
     var cur_stmt = db.prepare(
-        "SELECT id, version, revision, store_sha256, cellar_path, bin_isolated, install_reason, tap FROM kegs WHERE name = ?1 ORDER BY installed_at DESC LIMIT 1;",
+        "SELECT id, version, revision, store_sha256, cellar_path, bin_isolated FROM kegs WHERE name = ?1 ORDER BY installed_at DESC LIMIT 1;",
     ) catch return error.Aborted;
     defer cur_stmt.finalize();
     cur_stmt.bindText(1, name) catch return error.Aborted;
@@ -111,10 +111,6 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     const current_cellar_ptr = cur_stmt.columnText(4);
     const current_cellar_path = if (current_cellar_ptr) |c| std.mem.sliceTo(c, 0) else "";
     const current_bin_isolated = cur_stmt.columnInt(5) != 0;
-    const current_reason_ptr = cur_stmt.columnText(6);
-    const current_install_reason = if (current_reason_ptr) |r| std.mem.sliceTo(r, 0) else "direct";
-    const current_tap_ptr = cur_stmt.columnText(7);
-    const current_tap: ?[]const u8 = if (current_tap_ptr) |t| std.mem.sliceTo(t, 0) else null;
 
     // pkg_version is what the on-disk Cellar / store dir is named after,
     // so the store-scan below must compare against this — not the bare
@@ -215,35 +211,29 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     };
     defer allocator.free(keg.path);
 
-    // Update DB: delete old record, insert new one. Capture the old
-    // pin BEFORE the delete so the new row can inherit it — rolling
-    // back a held formula must not silently clear the user's hold.
-    const carried: Carried = .{
-        .pinned = capturePinnedById(&db, current_id),
-        .bin_isolated = current_bin_isolated,
-        .install_reason = current_install_reason,
-        .tap = current_tap,
-    };
-
     var linker = linker_mod.Linker.init(ctx.io, allocator, &db, prefix);
+    const undo: Undo = .{
+        .io = ctx.io,
+        .db = &db,
+        .linker = &linker,
+        .prefix = prefix,
+        .name = name,
+        .keg_id = current_id,
+        .cellar_path = current_cellar_path,
+        .bin_isolated = current_bin_isolated,
+        .abandoned_pkg_version = target.pkg_version,
+    };
 
     db.beginTransaction() catch return error.Aborted;
 
-    const keg_id = swapKeg(&db, &linker, current_id, name, target, keg.path, carried) catch {
-        db.rollback();
-        restoreCurrentLinks(&linker, current_cellar_path, name, current_id, current_bin_isolated);
-        cellar.remove(ctx.io, prefix, name, target.pkg_version) catch {};
+    swapKeg(&db, &linker, current_id, name, target, keg.path, current_bin_isolated) catch {
+        undo.run();
         output.err("Failed to record rollback of {s} in the database", .{name});
         return error.Aborted;
     };
 
     db.commit() catch {
-        // Drop the new symlinks first: the filesystem isn't transactional,
-        // so rolling back the DB alone would strand them.
-        linker.unlink(keg_id) catch {};
-        db.rollback();
-        restoreCurrentLinks(&linker, current_cellar_path, name, current_id, current_bin_isolated);
-        cellar.remove(ctx.io, prefix, name, target.pkg_version) catch {};
+        undo.run();
         output.err("Failed to commit rollback of {s}", .{name});
         return error.Aborted;
     };
@@ -262,41 +252,51 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     output.info("{s} rolled back to {s}", .{ name, target.pkg_version });
 }
 
-/// Swap the current keg for `target` inside the caller's transaction.
-/// `unlink` deletes `links` rows, so all three steps have to share one
-/// transaction or a mid-flight failure strands them.
+/// Point the keg at `target` inside the caller's transaction. `unlink`
+/// deletes `links` rows, so all three steps have to share one transaction
+/// or a mid-flight failure strands them.
 fn swapKeg(
     db: *sqlite.Database,
     linker: *linker_mod.Linker,
-    current_id: i64,
+    keg_id: i64,
     name: []const u8,
     target: Entry,
     keg_path: []const u8,
-    carried: Carried,
-) !i64 {
-    try linker.unlink(current_id);
-    // target.pkg_version carries the on-disk pkg_version label (the store
-    // dir name), so replaceKegRow can split it back into version +
-    // revision and persist the rolled-back keg's true revision.
-    const keg_id = try replaceKegRow(db, current_id, name, target.pkg_version, target.sha256, keg_path, carried);
-    try linker.link(keg_path, name, keg_id, carried.bin_isolated);
-    return keg_id;
+    bin_isolated: bool,
+) !void {
+    try linker.unlink(keg_id);
+    try retargetKegRow(db, keg_id, target.pkg_version, target.sha256, keg_path);
+    try linker.link(keg_path, name, keg_id, bin_isolated);
 }
 
-/// Rebuild the symlinks of the version we were rolling away from. The DB
-/// transaction restores the `links` rows; the filesystem needs replaying.
-fn restoreCurrentLinks(
+/// Everything needed to put the machine back the way it was when a swap
+/// fails. One shape for both failure sites, so the recovery every rollback
+/// depends on is exercised wherever it runs.
+const Undo = struct {
+    io: std.Io,
+    db: *sqlite.Database,
     linker: *linker_mod.Linker,
-    cellar_path: []const u8,
+    prefix: []const u8,
     name: []const u8,
     keg_id: i64,
+    cellar_path: []const u8,
     bin_isolated: bool,
-) void {
-    if (cellar_path.len == 0) return;
-    linker.link(cellar_path, name, keg_id, bin_isolated) catch {
-        output.err("CRITICAL: could not restore symlinks for {s} - run: mt link {s}", .{ name, name });
-    };
-}
+    abandoned_pkg_version: []const u8,
+
+    fn run(self: Undo) void {
+        // Drop whatever links the swap managed to write before rolling the
+        // DB back: the filesystem isn't transactional, so the rows would
+        // come back without the symlinks they describe going away.
+        self.linker.unlink(self.keg_id) catch {};
+        self.db.rollback();
+        if (self.cellar_path.len > 0) {
+            self.linker.link(self.cellar_path, self.name, self.keg_id, self.bin_isolated) catch {
+                output.err("CRITICAL: could not restore symlinks for {s} - run: mt link {s}", .{ self.name, self.name });
+            };
+        }
+        cellar.remove(self.io, self.prefix, self.name, self.abandoned_pkg_version) catch {};
+    }
+};
 
 /// Handle the cask side of `mt rollback`. Mirrors the keg flow:
 ///   - `--list` prints retained versions (excluding current).
@@ -501,87 +501,35 @@ pub fn capturePinnedById(db: *sqlite.Database, keg_id: i64) bool {
     return stmt.columnBool(0);
 }
 
-/// Columns that describe the user's intent rather than the version being
-/// installed, so the row swap has to carry them across.
-pub const Carried = struct {
-    pinned: bool,
-    bin_isolated: bool,
-    /// Dropping this to 'direct' would strand a dependency-installed keg:
-    /// autoremove and cleanup only reclaim rows marked 'dependency'.
-    install_reason: []const u8,
-    /// Null for core formulas. Losing it sends the next `upgrade` looking
-    /// for a tap-only formula in core.
-    tap: ?[]const u8,
-};
-
-/// Swap the keg row identified by `old_keg_id` for a fresh row pointing
-/// at `pkg_version` (the on-disk label, e.g. "1.9.2_2"). Splits the
-/// label into `version` + `revision` so the new row reflects the
-/// rolled-back keg's true revision instead of silently writing 0.
-/// Returns the new keg row id. Caller owns the surrounding transaction.
-pub fn replaceKegRow(
+/// Point the keg row identified by `keg_id` at `pkg_version` (the on-disk
+/// label, e.g. "1.9.2_2"), splitting the label back into version + revision
+/// so the row reflects the rolled-back keg's true revision instead of
+/// silently writing 0. Updating in place rather than swapping the row keeps
+/// its id, so the `links` and `dependencies` rows hanging off it - and every
+/// column that records user intent - survive without being re-derived.
+/// Caller owns the surrounding transaction.
+pub fn retargetKegRow(
     db: *sqlite.Database,
-    old_keg_id: i64,
-    name: []const u8,
+    keg_id: i64,
     pkg_version: []const u8,
     store_sha256: []const u8,
     cellar_path: []const u8,
-    carried: Carried,
-) !i64 {
+) !void {
     const parsed = formula_mod.parsePkgVersion(pkg_version);
 
-    // Insert before deleting: `dependencies.keg_id` cascades, so removing
-    // the old row first would take the keg's dependency edges with it and
-    // leave cleanup free to reclaim packages that are still needed. The two
-    // rows coexist safely because the rollback target's (version, revision)
-    // always differs from the current one.
-    {
-        var ins = try db.prepare(
-            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason, pinned, bin_isolated, tap)
-            \\VALUES (?1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9);
-        );
-        defer ins.finalize();
-        try ins.bindText(1, name);
-        try ins.bindText(2, parsed.version);
-        try ins.bindInt(3, parsed.revision);
-        try ins.bindText(4, store_sha256);
-        try ins.bindText(5, cellar_path);
-        try ins.bindText(6, carried.install_reason);
-        try ins.bindInt(7, @intFromBool(carried.pinned));
-        try ins.bindInt(8, @intFromBool(carried.bin_isolated));
-        if (carried.tap) |t| try ins.bindText(9, t) else try ins.bindNull(9);
-        _ = try ins.step();
-    }
-
-    const keg_id = blk: {
-        var id_stmt = try db.prepare("SELECT last_insert_rowid();");
-        defer id_stmt.finalize();
-        if (!(try id_stmt.step())) return error.RecordFailed;
-        break :blk id_stmt.columnInt(0);
-    };
-
-    // Copied rather than re-parsed from the target's formula: a partial
-    // store entry may ship no formula source at all, and the rows already
-    // carry the real `dep_type`.
-    {
-        var copy = try db.prepare(
-            \\INSERT OR IGNORE INTO dependencies (keg_id, dep_name, dep_type)
-            \\SELECT ?1, dep_name, dep_type FROM dependencies WHERE keg_id = ?2;
-        );
-        defer copy.finalize();
-        try copy.bindInt(1, keg_id);
-        try copy.bindInt(2, old_keg_id);
-        _ = try copy.step();
-    }
-
-    {
-        var del = try db.prepare("DELETE FROM kegs WHERE id = ?1;");
-        defer del.finalize();
-        try del.bindInt(1, old_keg_id);
-        _ = try del.step();
-    }
-
-    return keg_id;
+    var up = try db.prepare(
+        \\UPDATE kegs
+        \\SET version = ?1, revision = ?2, store_sha256 = ?3, cellar_path = ?4,
+        \\    installed_at = datetime('now')
+        \\WHERE id = ?5;
+    );
+    defer up.finalize();
+    try up.bindText(1, parsed.version);
+    try up.bindInt(2, parsed.revision);
+    try up.bindText(3, store_sha256);
+    try up.bindText(4, cellar_path);
+    try up.bindInt(5, keg_id);
+    _ = try up.step();
 }
 
 /// A single rolled-back-to candidate discovered in the malt store.
@@ -1313,7 +1261,7 @@ test "writeListJson escapes embedded quotes in the package name" {
     try testing.expectEqualStrings("weird\"name", parsed.value.object.get("name").?.string);
 }
 
-test "replaceKegRow splits pkg_version into version + revision" {
+test "retargetKegRow splits pkg_version into version + revision" {
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
     try schema.initSchema(&db);
@@ -1323,26 +1271,26 @@ test "replaceKegRow splits pkg_version into version + revision" {
         \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, pinned)
         \\VALUES ('libgit2', 'libgit2', '1.9.2', 2, 'sha-cur', '/c/libgit2/1.9.2_2', 1);
     );
-    const old_id = blk: {
+    const keg_id = blk: {
         var s = try db.prepare("SELECT id FROM kegs WHERE name='libgit2';");
         defer s.finalize();
         _ = try s.step();
         break :blk s.columnInt(0);
     };
 
-    const new_id = try replaceKegRow(&db, old_id, "libgit2", "1.9.2", "sha-old", "/c/libgit2/1.9.2", .{ .pinned = true, .bin_isolated = false, .install_reason = "direct", .tap = null });
+    try retargetKegRow(&db, keg_id, "1.9.2", "sha-old", "/c/libgit2/1.9.2");
 
-    var stmt = try db.prepare("SELECT version, revision, pinned FROM kegs WHERE id = ?1;");
+    var stmt = try db.prepare("SELECT version, revision, store_sha256, cellar_path FROM kegs WHERE id = ?1;");
     defer stmt.finalize();
-    try stmt.bindInt(1, new_id);
+    try stmt.bindInt(1, keg_id);
     _ = try stmt.step();
-    const ver = stmt.columnText(0) orelse return error.TestUnexpectedResult;
-    try testing.expectEqualStrings("1.9.2", std.mem.sliceTo(ver, 0));
+    try testing.expectEqualStrings("1.9.2", std.mem.sliceTo(stmt.columnText(0).?, 0));
     try testing.expectEqual(@as(i64, 0), stmt.columnInt(1));
-    try testing.expect(stmt.columnBool(2));
+    try testing.expectEqualStrings("sha-old", std.mem.sliceTo(stmt.columnText(2).?, 0));
+    try testing.expectEqualStrings("/c/libgit2/1.9.2", std.mem.sliceTo(stmt.columnText(3).?, 0));
 }
 
-test "replaceKegRow recovers a non-zero revision from pkg_version" {
+test "retargetKegRow recovers a non-zero revision from pkg_version" {
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
     try schema.initSchema(&db);
@@ -1351,7 +1299,7 @@ test "replaceKegRow recovers a non-zero revision from pkg_version" {
         \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
         \\VALUES ('python@3.14', 'python@3.14', '3.14.4', 1, 'sha-cur', '/c/python@3.14/3.14.4_1');
     );
-    const old_id = blk: {
+    const keg_id = blk: {
         var s = try db.prepare("SELECT id FROM kegs WHERE name='python@3.14';");
         defer s.finalize();
         _ = try s.step();
@@ -1359,202 +1307,85 @@ test "replaceKegRow recovers a non-zero revision from pkg_version" {
     };
 
     // Rolling back to an earlier revision-2 build.
-    const new_id = try replaceKegRow(&db, old_id, "python@3.14", "3.14.3_2", "sha-old", "/c/python@3.14/3.14.3_2", .{ .pinned = false, .bin_isolated = false, .install_reason = "direct", .tap = null });
+    try retargetKegRow(&db, keg_id, "3.14.3_2", "sha-old", "/c/python@3.14/3.14.3_2");
 
     var stmt = try db.prepare("SELECT version, revision FROM kegs WHERE id = ?1;");
     defer stmt.finalize();
-    try stmt.bindInt(1, new_id);
+    try stmt.bindInt(1, keg_id);
     _ = try stmt.step();
-    const ver = stmt.columnText(0) orelse return error.TestUnexpectedResult;
-    try testing.expectEqualStrings("3.14.3", std.mem.sliceTo(ver, 0));
+    try testing.expectEqualStrings("3.14.3", std.mem.sliceTo(stmt.columnText(0).?, 0));
     try testing.expectEqual(@as(i64, 2), stmt.columnInt(1));
 
-    // Old row was deleted in the same swap.
+    // Still exactly one row for the package.
     var cnt = try db.prepare("SELECT COUNT(*) FROM kegs WHERE name='python@3.14';");
     defer cnt.finalize();
     _ = try cnt.step();
     try testing.expectEqual(@as(i64, 1), cnt.columnInt(0));
 }
 
-// A rolled-back keg the user had installed bin-isolated must stay
-// bin-isolated: the swap replaces the version, not the user's intent.
-test "replaceKegRow carries pinned and bin_isolated across the swap" {
+// The reason this updates in place instead of swapping the row: a DELETE
+// cascades `dependencies`/`links` away and every user-intent column has to
+// be re-bound by hand, which is how holds, bin isolation, install_reason and
+// tap attribution each got silently dropped in turn.
+test "retargetKegRow leaves user intent, tap and dependency edges untouched" {
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
     try schema.initSchema(&db);
 
     try db.exec(
-        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, pinned, bin_isolated)
-        \\VALUES ('node', 'node', '22.1.0', 0, 'sha-cur', '/c/node/22.1.0', 1, 1);
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path,
+        \\                  install_reason, pinned, bin_isolated, tap)
+        \\VALUES ('prowl', 'prowl', '1.2', 0, 'sha-cur', '/c/prowl/1.2',
+        \\        'dependency', 1, 1, 'caarlos0/tap');
     );
-    const old_id = blk: {
-        var s = try db.prepare("SELECT id FROM kegs WHERE name='node';");
-        defer s.finalize();
-        _ = try s.step();
-        break :blk s.columnInt(0);
-    };
-
-    const new_id = try replaceKegRow(&db, old_id, "node", "22.0.0", "sha-old", "/c/node/22.0.0", .{
-        .pinned = true,
-        .bin_isolated = true,
-        .install_reason = "direct",
-        .tap = null,
-    });
-
-    var stmt = try db.prepare("SELECT pinned, bin_isolated FROM kegs WHERE id = ?1;");
-    defer stmt.finalize();
-    try stmt.bindInt(1, new_id);
-    _ = try stmt.step();
-    try testing.expect(stmt.columnBool(0));
-    try testing.expect(stmt.columnBool(1));
-}
-
-test "replaceKegRow leaves a non-isolated keg non-isolated" {
-    var db = try sqlite.Database.open(":memory:");
-    defer db.close();
-    try schema.initSchema(&db);
-
-    try db.exec(
-        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
-        \\VALUES ('jq', 'jq', '1.7.1', 0, 'sha-cur', '/c/jq/1.7.1');
-    );
-    const old_id = blk: {
-        var s = try db.prepare("SELECT id FROM kegs WHERE name='jq';");
-        defer s.finalize();
-        _ = try s.step();
-        break :blk s.columnInt(0);
-    };
-
-    const new_id = try replaceKegRow(&db, old_id, "jq", "1.7", "sha-old", "/c/jq/1.7", .{
-        .pinned = false,
-        .bin_isolated = false,
-        .install_reason = "direct",
-        .tap = null,
-    });
-
-    var stmt = try db.prepare("SELECT pinned, bin_isolated FROM kegs WHERE id = ?1;");
-    defer stmt.finalize();
-    try stmt.bindInt(1, new_id);
-    _ = try stmt.step();
-    try testing.expect(!stmt.columnBool(0));
-    try testing.expect(!stmt.columnBool(1));
-}
-
-// A dependency-installed keg that rolls back must stay a dependency:
-// relabelling it 'direct' hides it from autoremove forever.
-test "replaceKegRow carries install_reason across the swap" {
-    var db = try sqlite.Database.open(":memory:");
-    defer db.close();
-    try schema.initSchema(&db);
-
-    try db.exec(
-        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason)
-        \\VALUES ('pcre2', 'pcre2', '10.45', 0, 'sha-cur', '/c/pcre2/10.45', 'dependency');
-    );
-    const old_id = blk: {
-        var s = try db.prepare("SELECT id FROM kegs WHERE name='pcre2';");
-        defer s.finalize();
-        _ = try s.step();
-        break :blk s.columnInt(0);
-    };
-
-    const new_id = try replaceKegRow(&db, old_id, "pcre2", "10.44", "sha-old", "/c/pcre2/10.44", .{
-        .pinned = false,
-        .bin_isolated = false,
-        .install_reason = "dependency",
-        .tap = null,
-    });
-
-    var stmt = try db.prepare("SELECT install_reason FROM kegs WHERE id = ?1;");
-    defer stmt.finalize();
-    try stmt.bindInt(1, new_id);
-    _ = try stmt.step();
-    const reason = stmt.columnText(0) orelse return error.TestUnexpectedResult;
-    try testing.expectEqualStrings("dependency", std.mem.sliceTo(reason, 0));
-}
-
-// The row swap deletes the old keg, and `dependencies.keg_id` cascades.
-// Losing those edges makes cleanup reclaim packages the keg still needs.
-test "replaceKegRow moves dependency edges onto the new keg row" {
-    var db = try sqlite.Database.open(":memory:");
-    defer db.close();
-    try schema.initSchema(&db);
-
-    try db.exec(
-        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
-        \\VALUES ('wget', 'wget', '1.22', 0, 'sha-cur', '/c/wget/1.22');
-    );
-    const old_id = blk: {
-        var s = try db.prepare("SELECT id FROM kegs WHERE name='wget';");
+    const keg_id = blk: {
+        var s = try db.prepare("SELECT id FROM kegs WHERE name='prowl';");
         defer s.finalize();
         _ = try s.step();
         break :blk s.columnInt(0);
     };
     try db.exec("INSERT INTO dependencies (keg_id, dep_name, dep_type) VALUES (1, 'openssl@3', 'runtime');");
     try db.exec("INSERT INTO dependencies (keg_id, dep_name, dep_type) VALUES (1, 'cmake', 'build');");
+    try db.exec("INSERT INTO links (keg_id, link_path, target) VALUES (1, '/opt/malt/bin/prowl', '/c/prowl/1.2/bin/prowl');");
 
-    const new_id = try replaceKegRow(&db, old_id, "wget", "1.20", "sha-old", "/c/wget/1.20", .{
-        .pinned = false,
-        .bin_isolated = false,
-        .install_reason = "direct",
-        .tap = null,
-    });
+    try retargetKegRow(&db, keg_id, "1.1", "sha-old", "/c/prowl/1.1");
 
-    var stmt = try db.prepare("SELECT dep_name, dep_type FROM dependencies WHERE keg_id = ?1 ORDER BY dep_name;");
-    defer stmt.finalize();
-    try stmt.bindInt(1, new_id);
-
-    _ = try stmt.step();
-    try testing.expectEqualStrings("cmake", std.mem.sliceTo(stmt.columnText(0).?, 0));
-    // dep_type is preserved, not flattened to 'runtime'.
-    try testing.expectEqualStrings("build", std.mem.sliceTo(stmt.columnText(1).?, 0));
-
-    _ = try stmt.step();
-    try testing.expectEqualStrings("openssl@3", std.mem.sliceTo(stmt.columnText(0).?, 0));
-
-    // Nothing is left pointing at the deleted row.
-    var orphans = try db.prepare("SELECT COUNT(*) FROM dependencies WHERE keg_id = ?1;");
-    defer orphans.finalize();
-    try orphans.bindInt(1, old_id);
-    _ = try orphans.step();
-    try testing.expectEqual(@as(i64, 0), orphans.columnInt(0));
+    {
+        var stmt = try db.prepare(
+            "SELECT id, install_reason, pinned, bin_isolated, tap FROM kegs WHERE name='prowl';",
+        );
+        defer stmt.finalize();
+        _ = try stmt.step();
+        // Same row, so nothing hanging off the id needs re-pointing.
+        try testing.expectEqual(keg_id, stmt.columnInt(0));
+        try testing.expectEqualStrings("dependency", std.mem.sliceTo(stmt.columnText(1).?, 0));
+        try testing.expect(stmt.columnBool(2));
+        try testing.expect(stmt.columnBool(3));
+        try testing.expectEqualStrings("caarlos0/tap", std.mem.sliceTo(stmt.columnText(4).?, 0));
+    }
+    {
+        var stmt = try db.prepare("SELECT dep_name, dep_type FROM dependencies WHERE keg_id = ?1 ORDER BY dep_name;");
+        defer stmt.finalize();
+        try stmt.bindInt(1, keg_id);
+        _ = try stmt.step();
+        try testing.expectEqualStrings("cmake", std.mem.sliceTo(stmt.columnText(0).?, 0));
+        // dep_type survives too, not flattened to 'runtime'.
+        try testing.expectEqualStrings("build", std.mem.sliceTo(stmt.columnText(1).?, 0));
+        _ = try stmt.step();
+        try testing.expectEqualStrings("openssl@3", std.mem.sliceTo(stmt.columnText(0).?, 0));
+    }
+    {
+        var stmt = try db.prepare("SELECT COUNT(*) FROM links WHERE keg_id = ?1;");
+        defer stmt.finalize();
+        try stmt.bindInt(1, keg_id);
+        _ = try stmt.step();
+        try testing.expectEqual(@as(i64, 1), stmt.columnInt(0));
+    }
 }
 
-// A tap-installed keg must stay attributed to its tap: a NULL `tap` sends
-// the next upgrade looking for the formula in core, where it isn't.
-test "replaceKegRow carries the tap across the swap" {
-    var db = try sqlite.Database.open(":memory:");
-    defer db.close();
-    try schema.initSchema(&db);
-
-    try db.exec(
-        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, tap)
-        \\VALUES ('prowl', 'prowl', '1.2', 0, 'sha-cur', '/c/prowl/1.2', 'caarlos0/tap');
-    );
-    const old_id = blk: {
-        var s = try db.prepare("SELECT id FROM kegs WHERE name='prowl';");
-        defer s.finalize();
-        _ = try s.step();
-        break :blk s.columnInt(0);
-    };
-
-    const new_id = try replaceKegRow(&db, old_id, "prowl", "1.1", "sha-old", "/c/prowl/1.1", .{
-        .pinned = false,
-        .bin_isolated = false,
-        .install_reason = "direct",
-        .tap = "caarlos0/tap",
-    });
-
-    var stmt = try db.prepare("SELECT tap FROM kegs WHERE id = ?1;");
-    defer stmt.finalize();
-    try stmt.bindInt(1, new_id);
-    _ = try stmt.step();
-    try testing.expectEqualStrings("caarlos0/tap", std.mem.sliceTo(stmt.columnText(0).?, 0));
-}
-
-// Core kegs carry a NULL tap; binding "" instead would make them look
-// tap-owned to `install`'s tap-ownership probe.
-test "replaceKegRow leaves a core keg's tap NULL" {
+// A core keg carries a NULL tap; writing "" would make it look tap-owned
+// to install's tap-ownership probe.
+test "retargetKegRow leaves a core keg's tap NULL" {
     var db = try sqlite.Database.open(":memory:");
     defer db.close();
     try schema.initSchema(&db);
@@ -1563,23 +1394,18 @@ test "replaceKegRow leaves a core keg's tap NULL" {
         \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
         \\VALUES ('jq', 'jq', '1.7.1', 0, 'sha-cur', '/c/jq/1.7.1');
     );
-    const old_id = blk: {
+    const keg_id = blk: {
         var s = try db.prepare("SELECT id FROM kegs WHERE name='jq';");
         defer s.finalize();
         _ = try s.step();
         break :blk s.columnInt(0);
     };
 
-    const new_id = try replaceKegRow(&db, old_id, "jq", "1.7", "sha-old", "/c/jq/1.7", .{
-        .pinned = false,
-        .bin_isolated = false,
-        .install_reason = "direct",
-        .tap = null,
-    });
+    try retargetKegRow(&db, keg_id, "1.7", "sha-old", "/c/jq/1.7");
 
     var stmt = try db.prepare("SELECT tap IS NULL FROM kegs WHERE id = ?1;");
     defer stmt.finalize();
-    try stmt.bindInt(1, new_id);
+    try stmt.bindInt(1, keg_id);
     _ = try stmt.step();
     try testing.expect(stmt.columnBool(0));
 }

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -1335,7 +1335,7 @@ test "retargetKegRow leaves user intent, tap and dependency edges untouched" {
     try db.exec(
         \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path,
         \\                  install_reason, pinned, bin_isolated, tap)
-        \\VALUES ('prowl', 'prowl', '1.2', 0, 'sha-cur', '/c/prowl/1.2',
+        \\VALUES ('prowl', 'caarlos0/prowl', '1.2', 0, 'sha-cur', '/c/prowl/1.2',
         \\        'dependency', 1, 1, 'caarlos0/tap');
     );
     const keg_id = blk: {
@@ -1352,7 +1352,7 @@ test "retargetKegRow leaves user intent, tap and dependency edges untouched" {
 
     {
         var stmt = try db.prepare(
-            "SELECT id, install_reason, pinned, bin_isolated, tap FROM kegs WHERE name='prowl';",
+            "SELECT id, install_reason, pinned, bin_isolated, tap, full_name FROM kegs WHERE name='prowl';",
         );
         defer stmt.finalize();
         _ = try stmt.step();
@@ -1362,6 +1362,8 @@ test "retargetKegRow leaves user intent, tap and dependency edges untouched" {
         try testing.expect(stmt.columnBool(2));
         try testing.expect(stmt.columnBool(3));
         try testing.expectEqualStrings("caarlos0/tap", std.mem.sliceTo(stmt.columnText(4).?, 0));
+        // Tap-qualified, so it must not collapse back to the bare name.
+        try testing.expectEqualStrings("caarlos0/prowl", std.mem.sliceTo(stmt.columnText(5).?, 0));
     }
     {
         var stmt = try db.prepare("SELECT dep_name, dep_type FROM dependencies WHERE keg_id = ?1 ORDER BY dep_name;");

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -84,7 +84,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     // Find current installed version
     var cur_stmt = db.prepare(
-        "SELECT id, version, revision, store_sha256, cellar_path, bin_isolated FROM kegs WHERE name = ?1 ORDER BY installed_at DESC LIMIT 1;",
+        "SELECT id, version, revision, store_sha256, cellar_path, bin_isolated, install_reason FROM kegs WHERE name = ?1 ORDER BY installed_at DESC LIMIT 1;",
     ) catch return error.Aborted;
     defer cur_stmt.finalize();
     cur_stmt.bindText(1, name) catch return error.Aborted;
@@ -111,6 +111,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     const current_cellar_ptr = cur_stmt.columnText(4);
     const current_cellar_path = if (current_cellar_ptr) |c| std.mem.sliceTo(c, 0) else "";
     const current_bin_isolated = cur_stmt.columnInt(5) != 0;
+    const current_reason_ptr = cur_stmt.columnText(6);
+    const current_install_reason = if (current_reason_ptr) |r| std.mem.sliceTo(r, 0) else "direct";
 
     // pkg_version is what the on-disk Cellar / store dir is named after,
     // so the store-scan below must compare against this — not the bare
@@ -217,6 +219,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     const carried: Carried = .{
         .pinned = capturePinnedById(&db, current_id),
         .bin_isolated = current_bin_isolated,
+        .install_reason = current_install_reason,
     };
 
     var linker = linker_mod.Linker.init(ctx.io, allocator, &db, prefix);
@@ -500,6 +503,9 @@ pub fn capturePinnedById(db: *sqlite.Database, keg_id: i64) bool {
 pub const Carried = struct {
     pinned: bool,
     bin_isolated: bool,
+    /// Dropping this to 'direct' would strand a dependency-installed keg:
+    /// autoremove and cleanup only reclaim rows marked 'dependency'.
+    install_reason: []const u8,
 };
 
 /// Swap the keg row identified by `old_keg_id` for a fresh row pointing
@@ -528,7 +534,7 @@ pub fn replaceKegRow(
     {
         var ins = try db.prepare(
             \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason, pinned, bin_isolated)
-            \\VALUES (?1, ?1, ?2, ?3, ?4, ?5, 'direct', ?6, ?7);
+            \\VALUES (?1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8);
         );
         defer ins.finalize();
         try ins.bindText(1, name);
@@ -536,8 +542,9 @@ pub fn replaceKegRow(
         try ins.bindInt(3, parsed.revision);
         try ins.bindText(4, store_sha256);
         try ins.bindText(5, cellar_path);
-        try ins.bindInt(6, @intFromBool(carried.pinned));
-        try ins.bindInt(7, @intFromBool(carried.bin_isolated));
+        try ins.bindText(6, carried.install_reason);
+        try ins.bindInt(7, @intFromBool(carried.pinned));
+        try ins.bindInt(8, @intFromBool(carried.bin_isolated));
         _ = try ins.step();
     }
 
@@ -1293,7 +1300,7 @@ test "replaceKegRow splits pkg_version into version + revision" {
         break :blk s.columnInt(0);
     };
 
-    const new_id = try replaceKegRow(&db, old_id, "libgit2", "1.9.2", "sha-old", "/c/libgit2/1.9.2", .{ .pinned = true, .bin_isolated = false });
+    const new_id = try replaceKegRow(&db, old_id, "libgit2", "1.9.2", "sha-old", "/c/libgit2/1.9.2", .{ .pinned = true, .bin_isolated = false, .install_reason = "direct" });
 
     var stmt = try db.prepare("SELECT version, revision, pinned FROM kegs WHERE id = ?1;");
     defer stmt.finalize();
@@ -1322,7 +1329,7 @@ test "replaceKegRow recovers a non-zero revision from pkg_version" {
     };
 
     // Rolling back to an earlier revision-2 build.
-    const new_id = try replaceKegRow(&db, old_id, "python@3.14", "3.14.3_2", "sha-old", "/c/python@3.14/3.14.3_2", .{ .pinned = false, .bin_isolated = false });
+    const new_id = try replaceKegRow(&db, old_id, "python@3.14", "3.14.3_2", "sha-old", "/c/python@3.14/3.14.3_2", .{ .pinned = false, .bin_isolated = false, .install_reason = "direct" });
 
     var stmt = try db.prepare("SELECT version, revision FROM kegs WHERE id = ?1;");
     defer stmt.finalize();
@@ -1360,6 +1367,7 @@ test "replaceKegRow carries pinned and bin_isolated across the swap" {
     const new_id = try replaceKegRow(&db, old_id, "node", "22.0.0", "sha-old", "/c/node/22.0.0", .{
         .pinned = true,
         .bin_isolated = true,
+        .install_reason = "direct",
     });
 
     var stmt = try db.prepare("SELECT pinned, bin_isolated FROM kegs WHERE id = ?1;");
@@ -1389,6 +1397,7 @@ test "replaceKegRow leaves a non-isolated keg non-isolated" {
     const new_id = try replaceKegRow(&db, old_id, "jq", "1.7", "sha-old", "/c/jq/1.7", .{
         .pinned = false,
         .bin_isolated = false,
+        .install_reason = "direct",
     });
 
     var stmt = try db.prepare("SELECT pinned, bin_isolated FROM kegs WHERE id = ?1;");
@@ -1397,6 +1406,38 @@ test "replaceKegRow leaves a non-isolated keg non-isolated" {
     _ = try stmt.step();
     try testing.expect(!stmt.columnBool(0));
     try testing.expect(!stmt.columnBool(1));
+}
+
+// A dependency-installed keg that rolls back must stay a dependency:
+// relabelling it 'direct' hides it from autoremove forever.
+test "replaceKegRow carries install_reason across the swap" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason)
+        \\VALUES ('pcre2', 'pcre2', '10.45', 0, 'sha-cur', '/c/pcre2/10.45', 'dependency');
+    );
+    const old_id = blk: {
+        var s = try db.prepare("SELECT id FROM kegs WHERE name='pcre2';");
+        defer s.finalize();
+        _ = try s.step();
+        break :blk s.columnInt(0);
+    };
+
+    const new_id = try replaceKegRow(&db, old_id, "pcre2", "10.44", "sha-old", "/c/pcre2/10.44", .{
+        .pinned = false,
+        .bin_isolated = false,
+        .install_reason = "dependency",
+    });
+
+    var stmt = try db.prepare("SELECT install_reason FROM kegs WHERE id = ?1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, new_id);
+    _ = try stmt.step();
+    const reason = stmt.columnText(0) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings("dependency", std.mem.sliceTo(reason, 0));
 }
 
 test "removeCurrentCellarDir wipes the revision-bumped on-disk dir" {

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -84,7 +84,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     // Find current installed version
     var cur_stmt = db.prepare(
-        "SELECT id, version, revision, store_sha256 FROM kegs WHERE name = ?1 ORDER BY installed_at DESC LIMIT 1;",
+        "SELECT id, version, revision, store_sha256, cellar_path, bin_isolated FROM kegs WHERE name = ?1 ORDER BY installed_at DESC LIMIT 1;",
     ) catch return error.Aborted;
     defer cur_stmt.finalize();
     cur_stmt.bindText(1, name) catch return error.Aborted;
@@ -105,6 +105,12 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     const current_ver_ptr = cur_stmt.columnText(1);
     const current_ver = if (current_ver_ptr) |v| std.mem.sliceTo(v, 0) else "unknown";
     const current_revision = cur_stmt.columnInt(2);
+
+    // Kept so a failed swap can rebuild the current version's symlinks:
+    // the filesystem half of the swap isn't covered by the DB transaction.
+    const current_cellar_ptr = cur_stmt.columnText(4);
+    const current_cellar_path = if (current_cellar_ptr) |c| std.mem.sliceTo(c, 0) else "";
+    const current_bin_isolated = cur_stmt.columnInt(5) != 0;
 
     // pkg_version is what the on-disk Cellar / store dir is named after,
     // so the store-scan below must compare against this — not the bare
@@ -173,18 +179,6 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     };
     defer lk.release(ctx.io);
 
-    // Unlink current version
-    var linker = linker_mod.Linker.init(ctx.io, allocator, &db, prefix);
-    linker.unlink(current_id) catch {
-        output.warn("Could not unlink current {s} — links may be stale", .{name});
-    };
-
-    // Remove current cellar entry — pkg_version-aware so a revision-bumped
-    // current keg dir (e.g. "1.9.2_2") doesn't get left on disk.
-    removeCurrentCellarDir(ctx.io, prefix, name, current_ver, current_revision) catch {
-        output.warn("Could not remove cellar entry for {s} {s}", .{ name, current_pkg_version });
-    };
-
     // No parsed formula here, and the DB rows describe the version being
     // rolled away from — so read the target's own shipped formula source.
     var ph_buf: [512]u8 = undefined;
@@ -198,7 +192,9 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         target.pkg_version,
     );
 
-    // Materialize the old version from store
+    // Materialize before touching the current install: store entries are
+    // on-disk input, so a corrupt one must not cost the user a working
+    // version. Nothing is destroyed yet, so failure needs no restore.
     const keg = cellar.materializeWithCellar(
         ctx.io,
         allocator,
@@ -219,33 +215,77 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     // back a held formula must not silently clear the user's hold.
     const old_pinned = capturePinnedById(&db, current_id);
 
+    var linker = linker_mod.Linker.init(ctx.io, allocator, &db, prefix);
+
     db.beginTransaction() catch return error.Aborted;
-    errdefer db.rollback();
 
-    // target.pkg_version carries the on-disk pkg_version label (the store
-    // dir name), so replaceKegRow can split it back into version +
-    // revision and persist the rolled-back keg's true revision.
-    const keg_id = replaceKegRow(
-        &db,
-        current_id,
-        name,
-        target.pkg_version,
-        target.sha256,
-        keg.path,
-        old_pinned,
-    ) catch return error.Aborted;
-
-    // Link the old version
-    linker.link(keg.path, name, keg_id, false) catch {
-        output.warn("Could not link restored {s} — try: mt link {s}", .{ name, name });
+    const keg_id = swapKeg(&db, &linker, current_id, name, target, keg.path, old_pinned) catch {
+        db.rollback();
+        restoreCurrentLinks(&linker, current_cellar_path, name, current_id, current_bin_isolated);
+        cellar.remove(ctx.io, prefix, name, target.pkg_version) catch {};
+        output.err("Failed to record rollback of {s} in the database", .{name});
+        return error.Aborted;
     };
+
+    db.commit() catch {
+        // Drop the new symlinks first: the filesystem isn't transactional,
+        // so rolling back the DB alone would strand them.
+        linker.unlink(keg_id) catch {};
+        db.rollback();
+        restoreCurrentLinks(&linker, current_cellar_path, name, current_id, current_bin_isolated);
+        cellar.remove(ctx.io, prefix, name, target.pkg_version) catch {};
+        output.err("Failed to commit rollback of {s}", .{name});
+        return error.Aborted;
+    };
+
+    // Only now is the previous version expendable. pkg_version-aware so a
+    // revision-bumped current keg dir (e.g. "1.9.2_2") doesn't linger.
+    removeCurrentCellarDir(ctx.io, prefix, name, current_ver, current_revision) catch {
+        output.warn("Could not remove cellar entry for {s} {s}", .{ name, current_pkg_version });
+    };
+
+    // opt/ is a plain symlink, so it stays outside the transaction.
     linker.linkOpt(name, target.pkg_version) catch {
         output.warn("Could not create opt link for {s}", .{name});
     };
 
-    db.commit() catch return error.Aborted;
-
     output.info("{s} rolled back to {s}", .{ name, target.pkg_version });
+}
+
+/// Swap the current keg for `target` inside the caller's transaction.
+/// `unlink` deletes `links` rows, so all three steps have to share one
+/// transaction or a mid-flight failure strands them.
+fn swapKeg(
+    db: *sqlite.Database,
+    linker: *linker_mod.Linker,
+    current_id: i64,
+    name: []const u8,
+    target: Entry,
+    keg_path: []const u8,
+    pinned: bool,
+) !i64 {
+    try linker.unlink(current_id);
+    // target.pkg_version carries the on-disk pkg_version label (the store
+    // dir name), so replaceKegRow can split it back into version +
+    // revision and persist the rolled-back keg's true revision.
+    const keg_id = try replaceKegRow(db, current_id, name, target.pkg_version, target.sha256, keg_path, pinned);
+    try linker.link(keg_path, name, keg_id, false);
+    return keg_id;
+}
+
+/// Rebuild the symlinks of the version we were rolling away from. The DB
+/// transaction restores the `links` rows; the filesystem needs replaying.
+fn restoreCurrentLinks(
+    linker: *linker_mod.Linker,
+    cellar_path: []const u8,
+    name: []const u8,
+    keg_id: i64,
+    bin_isolated: bool,
+) void {
+    if (cellar_path.len == 0) return;
+    linker.link(cellar_path, name, keg_id, bin_isolated) catch {
+        output.err("CRITICAL: could not restore symlinks for {s} - run: mt link {s}", .{ name, name });
+    };
 }
 
 /// Handle the cask side of `mt rollback`. Mirrors the keg flow:

--- a/src/cli/rollback.zig
+++ b/src/cli/rollback.zig
@@ -84,7 +84,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
 
     // Find current installed version
     var cur_stmt = db.prepare(
-        "SELECT id, version, revision, store_sha256, cellar_path, bin_isolated, install_reason FROM kegs WHERE name = ?1 ORDER BY installed_at DESC LIMIT 1;",
+        "SELECT id, version, revision, store_sha256, cellar_path, bin_isolated, install_reason, tap FROM kegs WHERE name = ?1 ORDER BY installed_at DESC LIMIT 1;",
     ) catch return error.Aborted;
     defer cur_stmt.finalize();
     cur_stmt.bindText(1, name) catch return error.Aborted;
@@ -113,6 +113,8 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
     const current_bin_isolated = cur_stmt.columnInt(5) != 0;
     const current_reason_ptr = cur_stmt.columnText(6);
     const current_install_reason = if (current_reason_ptr) |r| std.mem.sliceTo(r, 0) else "direct";
+    const current_tap_ptr = cur_stmt.columnText(7);
+    const current_tap: ?[]const u8 = if (current_tap_ptr) |t| std.mem.sliceTo(t, 0) else null;
 
     // pkg_version is what the on-disk Cellar / store dir is named after,
     // so the store-scan below must compare against this — not the bare
@@ -220,6 +222,7 @@ pub fn execute(ctx: *const AppCtx, allocator: std.mem.Allocator, args: []const [
         .pinned = capturePinnedById(&db, current_id),
         .bin_isolated = current_bin_isolated,
         .install_reason = current_install_reason,
+        .tap = current_tap,
     };
 
     var linker = linker_mod.Linker.init(ctx.io, allocator, &db, prefix);
@@ -506,6 +509,9 @@ pub const Carried = struct {
     /// Dropping this to 'direct' would strand a dependency-installed keg:
     /// autoremove and cleanup only reclaim rows marked 'dependency'.
     install_reason: []const u8,
+    /// Null for core formulas. Losing it sends the next `upgrade` looking
+    /// for a tap-only formula in core.
+    tap: ?[]const u8,
 };
 
 /// Swap the keg row identified by `old_keg_id` for a fresh row pointing
@@ -524,17 +530,15 @@ pub fn replaceKegRow(
 ) !i64 {
     const parsed = formula_mod.parsePkgVersion(pkg_version);
 
-    {
-        var del = try db.prepare("DELETE FROM kegs WHERE id = ?1;");
-        defer del.finalize();
-        try del.bindInt(1, old_keg_id);
-        _ = try del.step();
-    }
-
+    // Insert before deleting: `dependencies.keg_id` cascades, so removing
+    // the old row first would take the keg's dependency edges with it and
+    // leave cleanup free to reclaim packages that are still needed. The two
+    // rows coexist safely because the rollback target's (version, revision)
+    // always differs from the current one.
     {
         var ins = try db.prepare(
-            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason, pinned, bin_isolated)
-            \\VALUES (?1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8);
+            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason, pinned, bin_isolated, tap)
+            \\VALUES (?1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9);
         );
         defer ins.finalize();
         try ins.bindText(1, name);
@@ -545,13 +549,39 @@ pub fn replaceKegRow(
         try ins.bindText(6, carried.install_reason);
         try ins.bindInt(7, @intFromBool(carried.pinned));
         try ins.bindInt(8, @intFromBool(carried.bin_isolated));
+        if (carried.tap) |t| try ins.bindText(9, t) else try ins.bindNull(9);
         _ = try ins.step();
     }
 
-    var id_stmt = try db.prepare("SELECT last_insert_rowid();");
-    defer id_stmt.finalize();
-    if (!(try id_stmt.step())) return error.RecordFailed;
-    return id_stmt.columnInt(0);
+    const keg_id = blk: {
+        var id_stmt = try db.prepare("SELECT last_insert_rowid();");
+        defer id_stmt.finalize();
+        if (!(try id_stmt.step())) return error.RecordFailed;
+        break :blk id_stmt.columnInt(0);
+    };
+
+    // Copied rather than re-parsed from the target's formula: a partial
+    // store entry may ship no formula source at all, and the rows already
+    // carry the real `dep_type`.
+    {
+        var copy = try db.prepare(
+            \\INSERT OR IGNORE INTO dependencies (keg_id, dep_name, dep_type)
+            \\SELECT ?1, dep_name, dep_type FROM dependencies WHERE keg_id = ?2;
+        );
+        defer copy.finalize();
+        try copy.bindInt(1, keg_id);
+        try copy.bindInt(2, old_keg_id);
+        _ = try copy.step();
+    }
+
+    {
+        var del = try db.prepare("DELETE FROM kegs WHERE id = ?1;");
+        defer del.finalize();
+        try del.bindInt(1, old_keg_id);
+        _ = try del.step();
+    }
+
+    return keg_id;
 }
 
 /// A single rolled-back-to candidate discovered in the malt store.
@@ -1300,7 +1330,7 @@ test "replaceKegRow splits pkg_version into version + revision" {
         break :blk s.columnInt(0);
     };
 
-    const new_id = try replaceKegRow(&db, old_id, "libgit2", "1.9.2", "sha-old", "/c/libgit2/1.9.2", .{ .pinned = true, .bin_isolated = false, .install_reason = "direct" });
+    const new_id = try replaceKegRow(&db, old_id, "libgit2", "1.9.2", "sha-old", "/c/libgit2/1.9.2", .{ .pinned = true, .bin_isolated = false, .install_reason = "direct", .tap = null });
 
     var stmt = try db.prepare("SELECT version, revision, pinned FROM kegs WHERE id = ?1;");
     defer stmt.finalize();
@@ -1329,7 +1359,7 @@ test "replaceKegRow recovers a non-zero revision from pkg_version" {
     };
 
     // Rolling back to an earlier revision-2 build.
-    const new_id = try replaceKegRow(&db, old_id, "python@3.14", "3.14.3_2", "sha-old", "/c/python@3.14/3.14.3_2", .{ .pinned = false, .bin_isolated = false, .install_reason = "direct" });
+    const new_id = try replaceKegRow(&db, old_id, "python@3.14", "3.14.3_2", "sha-old", "/c/python@3.14/3.14.3_2", .{ .pinned = false, .bin_isolated = false, .install_reason = "direct", .tap = null });
 
     var stmt = try db.prepare("SELECT version, revision FROM kegs WHERE id = ?1;");
     defer stmt.finalize();
@@ -1368,6 +1398,7 @@ test "replaceKegRow carries pinned and bin_isolated across the swap" {
         .pinned = true,
         .bin_isolated = true,
         .install_reason = "direct",
+        .tap = null,
     });
 
     var stmt = try db.prepare("SELECT pinned, bin_isolated FROM kegs WHERE id = ?1;");
@@ -1398,6 +1429,7 @@ test "replaceKegRow leaves a non-isolated keg non-isolated" {
         .pinned = false,
         .bin_isolated = false,
         .install_reason = "direct",
+        .tap = null,
     });
 
     var stmt = try db.prepare("SELECT pinned, bin_isolated FROM kegs WHERE id = ?1;");
@@ -1430,6 +1462,7 @@ test "replaceKegRow carries install_reason across the swap" {
         .pinned = false,
         .bin_isolated = false,
         .install_reason = "dependency",
+        .tap = null,
     });
 
     var stmt = try db.prepare("SELECT install_reason FROM kegs WHERE id = ?1;");
@@ -1438,6 +1471,117 @@ test "replaceKegRow carries install_reason across the swap" {
     _ = try stmt.step();
     const reason = stmt.columnText(0) orelse return error.TestUnexpectedResult;
     try testing.expectEqualStrings("dependency", std.mem.sliceTo(reason, 0));
+}
+
+// The row swap deletes the old keg, and `dependencies.keg_id` cascades.
+// Losing those edges makes cleanup reclaim packages the keg still needs.
+test "replaceKegRow moves dependency edges onto the new keg row" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+        \\VALUES ('wget', 'wget', '1.22', 0, 'sha-cur', '/c/wget/1.22');
+    );
+    const old_id = blk: {
+        var s = try db.prepare("SELECT id FROM kegs WHERE name='wget';");
+        defer s.finalize();
+        _ = try s.step();
+        break :blk s.columnInt(0);
+    };
+    try db.exec("INSERT INTO dependencies (keg_id, dep_name, dep_type) VALUES (1, 'openssl@3', 'runtime');");
+    try db.exec("INSERT INTO dependencies (keg_id, dep_name, dep_type) VALUES (1, 'cmake', 'build');");
+
+    const new_id = try replaceKegRow(&db, old_id, "wget", "1.20", "sha-old", "/c/wget/1.20", .{
+        .pinned = false,
+        .bin_isolated = false,
+        .install_reason = "direct",
+        .tap = null,
+    });
+
+    var stmt = try db.prepare("SELECT dep_name, dep_type FROM dependencies WHERE keg_id = ?1 ORDER BY dep_name;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, new_id);
+
+    _ = try stmt.step();
+    try testing.expectEqualStrings("cmake", std.mem.sliceTo(stmt.columnText(0).?, 0));
+    // dep_type is preserved, not flattened to 'runtime'.
+    try testing.expectEqualStrings("build", std.mem.sliceTo(stmt.columnText(1).?, 0));
+
+    _ = try stmt.step();
+    try testing.expectEqualStrings("openssl@3", std.mem.sliceTo(stmt.columnText(0).?, 0));
+
+    // Nothing is left pointing at the deleted row.
+    var orphans = try db.prepare("SELECT COUNT(*) FROM dependencies WHERE keg_id = ?1;");
+    defer orphans.finalize();
+    try orphans.bindInt(1, old_id);
+    _ = try orphans.step();
+    try testing.expectEqual(@as(i64, 0), orphans.columnInt(0));
+}
+
+// A tap-installed keg must stay attributed to its tap: a NULL `tap` sends
+// the next upgrade looking for the formula in core, where it isn't.
+test "replaceKegRow carries the tap across the swap" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, tap)
+        \\VALUES ('prowl', 'prowl', '1.2', 0, 'sha-cur', '/c/prowl/1.2', 'caarlos0/tap');
+    );
+    const old_id = blk: {
+        var s = try db.prepare("SELECT id FROM kegs WHERE name='prowl';");
+        defer s.finalize();
+        _ = try s.step();
+        break :blk s.columnInt(0);
+    };
+
+    const new_id = try replaceKegRow(&db, old_id, "prowl", "1.1", "sha-old", "/c/prowl/1.1", .{
+        .pinned = false,
+        .bin_isolated = false,
+        .install_reason = "direct",
+        .tap = "caarlos0/tap",
+    });
+
+    var stmt = try db.prepare("SELECT tap FROM kegs WHERE id = ?1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, new_id);
+    _ = try stmt.step();
+    try testing.expectEqualStrings("caarlos0/tap", std.mem.sliceTo(stmt.columnText(0).?, 0));
+}
+
+// Core kegs carry a NULL tap; binding "" instead would make them look
+// tap-owned to `install`'s tap-ownership probe.
+test "replaceKegRow leaves a core keg's tap NULL" {
+    var db = try sqlite.Database.open(":memory:");
+    defer db.close();
+    try schema.initSchema(&db);
+
+    try db.exec(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path)
+        \\VALUES ('jq', 'jq', '1.7.1', 0, 'sha-cur', '/c/jq/1.7.1');
+    );
+    const old_id = blk: {
+        var s = try db.prepare("SELECT id FROM kegs WHERE name='jq';");
+        defer s.finalize();
+        _ = try s.step();
+        break :blk s.columnInt(0);
+    };
+
+    const new_id = try replaceKegRow(&db, old_id, "jq", "1.7", "sha-old", "/c/jq/1.7", .{
+        .pinned = false,
+        .bin_isolated = false,
+        .install_reason = "direct",
+        .tap = null,
+    });
+
+    var stmt = try db.prepare("SELECT tap IS NULL FROM kegs WHERE id = ?1;");
+    defer stmt.finalize();
+    try stmt.bindInt(1, new_id);
+    _ = try stmt.step();
+    try testing.expect(stmt.columnBool(0));
 }
 
 test "removeCurrentCellarDir wipes the revision-bumped on-disk dir" {

--- a/tests/rollback_test.zig
+++ b/tests/rollback_test.zig
@@ -612,3 +612,131 @@ test "rollback <cask> with empty history refuses with a useful diagnostic" {
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "No previous version") != null);
     try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "1.32.427") != null);
 }
+
+// --- failed-rollback safety -----------------------------------------------
+
+/// Seed a fully installed keg: Cellar tree, a linked `bin/` symlink, and the
+/// matching `kegs` + `links` rows. Enough for `execute` to have something
+/// real to destroy if the rollback isn't ordered correctly.
+fn installKeg(prefix: [:0]const u8, name: []const u8, pkg_version: []const u8) !void {
+    const io = std.Options.debug_io;
+
+    var keg_buf: [512]u8 = undefined;
+    const keg_bin = try std.fmt.bufPrint(&keg_buf, "{s}/Cellar/{s}/{s}/bin", .{ prefix, name, pkg_version });
+    try test_io.cwd().createDirPath(io, keg_bin);
+
+    var exe_buf: [600]u8 = undefined;
+    const exe = try std.fmt.bufPrint(&exe_buf, "{s}/{s}", .{ keg_bin, name });
+    {
+        const f = try test_io.createFileAbsolute(io, exe, .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, "#!/bin/sh\n");
+    }
+
+    var bin_dir_buf: [512]u8 = undefined;
+    const bin_dir = try std.fmt.bufPrint(&bin_dir_buf, "{s}/bin", .{prefix});
+    try test_io.cwd().createDirPath(io, bin_dir);
+
+    var link_buf: [600]u8 = undefined;
+    const link = try std.fmt.bufPrint(&link_buf, "{s}/{s}", .{ bin_dir, name });
+    try test_io.symLinkAbsolute(io, exe, link, .{});
+
+    var cellar_buf: [512]u8 = undefined;
+    const cellar_path = try std.fmt.bufPrint(&cellar_buf, "{s}/Cellar/{s}/{s}", .{ prefix, name, pkg_version });
+
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintZ(&db_path_buf, "{s}/db/malt.db", .{prefix});
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+
+    {
+        var stmt = try db.prepare(
+            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason)
+            \\VALUES (?1, ?1, ?2, 0, 'cur-sha', ?3, 'direct');
+        );
+        defer stmt.finalize();
+        try stmt.bindText(1, name);
+        try stmt.bindText(2, pkg_version);
+        try stmt.bindText(3, cellar_path);
+        _ = try stmt.step();
+    }
+    {
+        var stmt = try db.prepare(
+            "INSERT INTO links (keg_id, link_path, target) VALUES (last_insert_rowid(), ?1, ?2);",
+        );
+        defer stmt.finalize();
+        try stmt.bindText(1, link);
+        try stmt.bindText(2, exe);
+        _ = try stmt.step();
+    }
+}
+
+/// Deny all access to a store keg dir so `materializeWithCellar` fails the
+/// way a corrupt or unreadable store entry does, without deleting it (the
+/// entry has to stay discoverable by `collectEntries`).
+fn denyAccess(prefix: [:0]const u8, sha: []const u8, name: []const u8, pkg_version: []const u8, mode: c_uint) void {
+    var buf: [512]u8 = undefined;
+    const dir = std.fmt.bufPrintZ(&buf, "{s}/store/{s}/{s}/{s}", .{ prefix, sha, name, pkg_version }) catch return;
+    _ = std.c.chmod(dir.ptr, @intCast(mode));
+}
+
+fn installedVersion(prefix: [:0]const u8, allocator: std.mem.Allocator, name: []const u8) ![]u8 {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintZ(&db_path_buf, "{s}/db/malt.db", .{prefix});
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+
+    var stmt = try db.prepare("SELECT version FROM kegs WHERE name = ?1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    if (!(try stmt.step())) return allocator.dupe(u8, "");
+    const v = stmt.columnText(0) orelse return allocator.dupe(u8, "");
+    return allocator.dupe(u8, std.mem.sliceTo(v, 0));
+}
+
+// The failure this pins: rollback used to unlink and delete the current keg
+// before the fallible materialize, so a bad store entry left the machine with
+// no working version and a DB row pointing at nothing.
+test "a rollback that cannot materialize leaves the current version installed" {
+    if (std.c.geteuid() == 0) return error.SkipZigTest; // chmod 000 doesn't bite root
+
+    var pbuf: [64]u8 = undefined;
+    const prefix = rbPrefix(&pbuf, "materialize_fail");
+    try makeSandbox(prefix);
+    defer {
+        denyAccess(prefix, "sha_old", "wget", "1.20", 0o755);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    }
+
+    try installKeg(prefix, "wget", "1.22");
+    try seedStoreEntry(prefix, "sha_old", "wget", "1.20", 0);
+    denyAccess(prefix, "sha_old", "wget", "1.20", 0o000);
+
+    setPrefix(prefix);
+    defer unsetPrefix();
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try testing.expectError(error.Aborted, rollback.execute(&ctx, testing.allocator, &.{"wget"}));
+
+    const io = std.Options.debug_io;
+    var buf: [512]u8 = undefined;
+
+    const cellar = try std.fmt.bufPrint(&buf, "{s}/Cellar/wget/1.22", .{prefix});
+    try test_io.accessAbsolute(io, cellar, .{});
+
+    var buf2: [512]u8 = undefined;
+    const link = try std.fmt.bufPrint(&buf2, "{s}/bin/wget", .{prefix});
+    try test_io.accessAbsolute(io, link, .{});
+
+    const ver = try installedVersion(prefix, testing.allocator, "wget");
+    defer testing.allocator.free(ver);
+    try testing.expectEqualStrings("1.22", ver);
+}

--- a/tests/rollback_test.zig
+++ b/tests/rollback_test.zig
@@ -861,3 +861,149 @@ test "rolling back a dependency keeps it marked as a dependency" {
     defer testing.allocator.free(reason);
     try testing.expectEqualStrings("dependency", reason);
 }
+
+fn depNames(prefix: [:0]const u8, allocator: std.mem.Allocator, name: []const u8) ![]u8 {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintZ(&db_path_buf, "{s}/db/malt.db", .{prefix});
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+
+    var stmt = try db.prepare(
+        \\SELECT d.dep_name FROM dependencies d
+        \\JOIN kegs k ON k.id = d.keg_id WHERE k.name = ?1 ORDER BY d.dep_name;
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    while (try stmt.step()) {
+        const n = stmt.columnText(0) orelse continue;
+        if (out.items.len > 0) try out.append(allocator, ',');
+        try out.appendSlice(allocator, std.mem.sliceTo(n, 0));
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn addDep(prefix: [:0]const u8, name: []const u8, dep: []const u8) !void {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintZ(&db_path_buf, "{s}/db/malt.db", .{prefix});
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+
+    var stmt = try db.prepare(
+        "INSERT INTO dependencies (keg_id, dep_name) SELECT id, ?2 FROM kegs WHERE name = ?1;",
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    try stmt.bindText(2, dep);
+    _ = try stmt.step();
+}
+
+// Without this the rolled-back keg has no recorded dependencies, and the
+// next cleanup reclaims the packages it still links against.
+test "a completed rollback keeps the keg's dependency edges" {
+    var pbuf: [64]u8 = undefined;
+    const prefix = rbPrefix(&pbuf, "carry_deps");
+    try makeSandbox(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try installKeg(prefix, "wget", "1.22");
+    try addDep(prefix, "wget", "openssl@3");
+    try addDep(prefix, "wget", "libidn2");
+    try seedStoreEntry(prefix, "sha_old", "wget", "1.20", 0);
+
+    setPrefix(prefix);
+    defer unsetPrefix();
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try rollback.execute(&ctx, testing.allocator, &.{"wget"});
+
+    const deps = try depNames(prefix, testing.allocator, "wget");
+    defer testing.allocator.free(deps);
+    try testing.expectEqualStrings("libidn2,openssl@3", deps);
+}
+
+/// Park a decoy keg row on the version we are about to roll back to, so the
+/// swap's INSERT trips `UNIQUE(name, version, revision)` after `unlink` has
+/// already torn the current version's symlinks down.
+fn seedColliding(prefix: [:0]const u8, name: []const u8, version: []const u8) !void {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintZ(&db_path_buf, "{s}/db/malt.db", .{prefix});
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+
+    var stmt = try db.prepare(
+        \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, installed_at)
+        \\VALUES (?1, ?1, ?2, 0, 'sha-decoy', '/c/decoy', '1970-01-01 00:00:00');
+    );
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    try stmt.bindText(2, version);
+    _ = try stmt.step();
+}
+
+// The restore half of the fix: once `unlink` has run, a failing swap has to
+// put the current version's symlinks back and drop the half-installed target.
+test "a rollback that fails mid-swap restores the current version's links" {
+    var pbuf: [64]u8 = undefined;
+    const prefix = rbPrefix(&pbuf, "swap_fail");
+    try makeSandbox(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try installKeg(prefix, "wget", "1.22");
+    try seedStoreEntry(prefix, "sha_old", "wget", "1.20", 0);
+    try seedColliding(prefix, "wget", "1.20");
+
+    setPrefix(prefix);
+    defer unsetPrefix();
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try testing.expectError(error.Aborted, rollback.execute(&ctx, testing.allocator, &.{"wget"}));
+
+    const io = std.Options.debug_io;
+
+    // The symlink `unlink` removed is back on disk...
+    var link_buf: [512]u8 = undefined;
+    const link = try std.fmt.bufPrint(&link_buf, "{s}/bin/wget", .{prefix});
+    try test_io.accessAbsolute(io, link, .{});
+
+    // ...and so is its DB row, courtesy of the transaction rollback.
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintZ(&db_path_buf, "{s}/db/malt.db", .{prefix});
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        var stmt = try db.prepare("SELECT COUNT(*) FROM links WHERE link_path = ?1;");
+        defer stmt.finalize();
+        try stmt.bindText(1, link);
+        _ = try stmt.step();
+        try testing.expectEqual(@as(i64, 1), stmt.columnInt(0));
+    }
+
+    // The current version's Cellar tree was never touched...
+    var cur_buf: [512]u8 = undefined;
+    const cur_cellar = try std.fmt.bufPrint(&cur_buf, "{s}/Cellar/wget/1.22", .{prefix});
+    try test_io.accessAbsolute(io, cur_cellar, .{});
+
+    // ...and the half-installed target was cleaned up.
+    var new_buf: [512]u8 = undefined;
+    const new_cellar = try std.fmt.bufPrint(&new_buf, "{s}/Cellar/wget/1.20", .{prefix});
+    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, new_cellar, .{}));
+}

--- a/tests/rollback_test.zig
+++ b/tests/rollback_test.zig
@@ -121,44 +121,6 @@ test "rollback returns error.Aborted when no previous version exists in store" {
     try testing.expectError(error.Aborted, err);
 }
 
-test "capturePinnedById reads the pinned column for a given keg id" {
-    var pbuf: [64]u8 = undefined;
-    const prefix = rbPrefix(&pbuf, "capture_pin");
-    test_io.makeDirAbsolute(std.Options.debug_io, prefix) catch {};
-    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
-
-    var db_buf: [96]u8 = undefined;
-    const db_path = try std.fmt.bufPrintZ(&db_buf, "{s}/db.db", .{prefix});
-    var db = try sqlite.Database.open(db_path);
-    defer db.close();
-    try schema.initSchema(&db);
-
-    try db.exec(
-        \\INSERT INTO kegs (name, full_name, version, store_sha256, cellar_path, pinned)
-        \\VALUES ('held', 'held', '1.0', 'sha', '/cellar/held/1.0', 1),
-        \\       ('loose', 'loose', '1.0', 'sha2', '/cellar/loose/1.0', 0);
-    );
-
-    const held_id = blk: {
-        var s = try db.prepare("SELECT id FROM kegs WHERE name = 'held';");
-        defer s.finalize();
-        _ = try s.step();
-        break :blk s.columnInt(0);
-    };
-    const loose_id = blk: {
-        var s = try db.prepare("SELECT id FROM kegs WHERE name = 'loose';");
-        defer s.finalize();
-        _ = try s.step();
-        break :blk s.columnInt(0);
-    };
-
-    try testing.expect(rollback.capturePinnedById(&db, held_id));
-    try testing.expect(!rollback.capturePinnedById(&db, loose_id));
-    // Unknown id collapses to false rather than erroring — matches the
-    // "best-effort, never lose data" stance the rollback flow needs.
-    try testing.expect(!rollback.capturePinnedById(&db, 999_999));
-}
-
 test "rollback distinguishes a cask token from a truly missing package" {
     var pbuf: [64]u8 = undefined;
     const prefix = rbPrefix(&pbuf, "cask_diag");
@@ -1006,4 +968,70 @@ test "a rollback that fails mid-swap restores the current version's links" {
     var new_buf: [512]u8 = undefined;
     const new_cellar = try std.fmt.bufPrint(&new_buf, "{s}/Cellar/wget/1.20", .{prefix});
     try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, new_cellar, .{}));
+}
+
+/// Make a keg dir's contents un-unlinkable so `cellar.remove` fails without
+/// affecting anything else in the prefix.
+fn freezeKegDir(prefix: [:0]const u8, name: []const u8, pkg_version: []const u8, mode: c_uint) void {
+    var buf: [512]u8 = undefined;
+    const bin = std.fmt.bufPrintZ(&buf, "{s}/Cellar/{s}/{s}/bin", .{ prefix, name, pkg_version }) catch return;
+    _ = std.c.chmod(bin.ptr, @intCast(mode));
+    var buf2: [512]u8 = undefined;
+    const dir = std.fmt.bufPrintZ(&buf2, "{s}/Cellar/{s}/{s}", .{ prefix, name, pkg_version }) catch return;
+    _ = std.c.chmod(dir.ptr, @intCast(mode));
+}
+
+// Sweeping the replaced version is housekeeping, not part of the swap: if it
+// fails the user still has a working, correctly recorded package and only
+// garbage is left behind.
+test "a rollback still succeeds when the old cellar dir cannot be removed" {
+    if (std.c.geteuid() == 0) return error.SkipZigTest; // chmod doesn't deny root
+
+    var pbuf: [64]u8 = undefined;
+    const prefix = rbPrefix(&pbuf, "stuck_cellar");
+    try makeSandbox(prefix);
+    defer {
+        freezeKegDir(prefix, "wget", "1.22", 0o755);
+        test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+    }
+
+    try installKeg(prefix, "wget", "1.22");
+    try seedStoreEntry(prefix, "sha_old", "wget", "1.20", 0);
+    freezeKegDir(prefix, "wget", "1.22", 0o500);
+
+    setPrefix(prefix);
+    defer unsetPrefix();
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    var stderr_buf: std.ArrayList(u8) = .empty;
+    defer stderr_buf.deinit(testing.allocator);
+    output.beginStderrCapture(testing.allocator, &stderr_buf);
+    defer output.endStderrCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try rollback.execute(&ctx, testing.allocator, &.{"wget"});
+
+    // The rollback itself landed...
+    const ver = try installedVersion(prefix, testing.allocator, "wget");
+    defer testing.allocator.free(ver);
+    try testing.expectEqualStrings("1.20", ver);
+
+    const io = std.Options.debug_io;
+    var buf: [512]u8 = undefined;
+    const new_cellar = try std.fmt.bufPrint(&buf, "{s}/Cellar/wget/1.20", .{prefix});
+    try test_io.accessAbsolute(io, new_cellar, .{});
+
+    // ...the stale dir is all that is left behind...
+    const old_cellar = try std.fmt.bufPrint(&buf, "{s}/Cellar/wget/1.22", .{prefix});
+    try test_io.accessAbsolute(io, old_cellar, .{});
+
+    // ...and the user was told about it.
+    try testing.expect(std.mem.indexOf(u8, stderr_buf.items, "Could not remove cellar entry") != null);
 }

--- a/tests/rollback_test.zig
+++ b/tests/rollback_test.zig
@@ -619,6 +619,10 @@ test "rollback <cask> with empty history refuses with a useful diagnostic" {
 /// matching `kegs` + `links` rows. Enough for `execute` to have something
 /// real to destroy if the rollback isn't ordered correctly.
 fn installKeg(prefix: [:0]const u8, name: []const u8, pkg_version: []const u8) !void {
+    return installKegIsolated(prefix, name, pkg_version, false);
+}
+
+fn installKegIsolated(prefix: [:0]const u8, name: []const u8, pkg_version: []const u8, bin_isolated: bool) !void {
     const io = std.Options.debug_io;
 
     var keg_buf: [512]u8 = undefined;
@@ -651,13 +655,14 @@ fn installKeg(prefix: [:0]const u8, name: []const u8, pkg_version: []const u8) !
 
     {
         var stmt = try db.prepare(
-            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason)
-            \\VALUES (?1, ?1, ?2, 0, 'cur-sha', ?3, 'direct');
+            \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason, bin_isolated)
+            \\VALUES (?1, ?1, ?2, 0, 'cur-sha', ?3, 'direct', ?4);
         );
         defer stmt.finalize();
         try stmt.bindText(1, name);
         try stmt.bindText(2, pkg_version);
         try stmt.bindText(3, cellar_path);
+        try stmt.bindInt(4, @intFromBool(bin_isolated));
         _ = try stmt.step();
     }
     {
@@ -739,4 +744,65 @@ test "a rollback that cannot materialize leaves the current version installed" {
     const ver = try installedVersion(prefix, testing.allocator, "wget");
     defer testing.allocator.free(ver);
     try testing.expectEqualStrings("1.22", ver);
+}
+
+fn kegFlag(prefix: [:0]const u8, name: []const u8, column: []const u8) !bool {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintZ(&db_path_buf, "{s}/db/malt.db", .{prefix});
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+
+    var sql_buf: [128]u8 = undefined;
+    const sql = try std.fmt.bufPrintZ(&sql_buf, "SELECT {s} FROM kegs WHERE name = ?1;", .{column});
+    var stmt = try db.prepare(sql);
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    if (!(try stmt.step())) return error.TestUnexpectedResult;
+    return stmt.columnBool(0);
+}
+
+// Pins the whole happy path plus the columns the row swap has to carry:
+// a bin-isolated, held keg must come back bin-isolated and still held.
+test "a completed rollback preserves bin isolation and the hold" {
+    var pbuf: [64]u8 = undefined;
+    const prefix = rbPrefix(&pbuf, "carry_flags");
+    try makeSandbox(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try installKegIsolated(prefix, "wget", "1.22", true);
+    {
+        var db_path_buf: [512]u8 = undefined;
+        const db_path = try std.fmt.bufPrintZ(&db_path_buf, "{s}/db/malt.db", .{prefix});
+        var db = try sqlite.Database.open(db_path);
+        defer db.close();
+        try db.exec("UPDATE kegs SET pinned = 1 WHERE name = 'wget';");
+    }
+    try seedStoreEntry(prefix, "sha_old", "wget", "1.20", 0);
+
+    setPrefix(prefix);
+    defer unsetPrefix();
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try rollback.execute(&ctx, testing.allocator, &.{"wget"});
+
+    const ver = try installedVersion(prefix, testing.allocator, "wget");
+    defer testing.allocator.free(ver);
+    try testing.expectEqualStrings("1.20", ver);
+
+    try testing.expect(try kegFlag(prefix, "wget", "bin_isolated"));
+    try testing.expect(try kegFlag(prefix, "wget", "pinned"));
+
+    // The version we rolled away from is gone from disk only after the swap.
+    const io = std.Options.debug_io;
+    var buf: [512]u8 = undefined;
+    const old_cellar = try std.fmt.bufPrint(&buf, "{s}/Cellar/wget/1.22", .{prefix});
+    try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, old_cellar, .{}));
 }

--- a/tests/rollback_test.zig
+++ b/tests/rollback_test.zig
@@ -778,6 +778,13 @@ test "a completed rollback preserves bin isolation and the hold" {
     var buf: [512]u8 = undefined;
     const old_cellar = try std.fmt.bufPrint(&buf, "{s}/Cellar/wget/1.22", .{prefix});
     try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, old_cellar, .{}));
+
+    // Dependents resolve through opt/, so it has to follow the rollback.
+    var opt_buf: [512]u8 = undefined;
+    const opt_link = try std.fmt.bufPrint(&opt_buf, "{s}/opt/wget", .{prefix});
+    var target_buf: [512]u8 = undefined;
+    const opt_target = try test_io.readLinkAbsolute(io, opt_link, &target_buf);
+    try testing.expect(std.mem.endsWith(u8, opt_target, "/Cellar/wget/1.20"));
 }
 
 fn kegInstallReason(prefix: [:0]const u8, allocator: std.mem.Allocator, name: []const u8) ![]u8 {

--- a/tests/rollback_test.zig
+++ b/tests/rollback_test.zig
@@ -623,6 +623,16 @@ fn installKeg(prefix: [:0]const u8, name: []const u8, pkg_version: []const u8) !
 }
 
 fn installKegIsolated(prefix: [:0]const u8, name: []const u8, pkg_version: []const u8, bin_isolated: bool) !void {
+    return installKegAs(prefix, name, pkg_version, bin_isolated, "direct");
+}
+
+fn installKegAs(
+    prefix: [:0]const u8,
+    name: []const u8,
+    pkg_version: []const u8,
+    bin_isolated: bool,
+    install_reason: []const u8,
+) !void {
     const io = std.Options.debug_io;
 
     var keg_buf: [512]u8 = undefined;
@@ -656,13 +666,14 @@ fn installKegIsolated(prefix: [:0]const u8, name: []const u8, pkg_version: []con
     {
         var stmt = try db.prepare(
             \\INSERT INTO kegs (name, full_name, version, revision, store_sha256, cellar_path, install_reason, bin_isolated)
-            \\VALUES (?1, ?1, ?2, 0, 'cur-sha', ?3, 'direct', ?4);
+            \\VALUES (?1, ?1, ?2, 0, 'cur-sha', ?3, ?5, ?4);
         );
         defer stmt.finalize();
         try stmt.bindText(1, name);
         try stmt.bindText(2, pkg_version);
         try stmt.bindText(3, cellar_path);
         try stmt.bindInt(4, @intFromBool(bin_isolated));
+        try stmt.bindText(5, install_reason);
         _ = try stmt.step();
     }
     {
@@ -805,4 +816,48 @@ test "a completed rollback preserves bin isolation and the hold" {
     var buf: [512]u8 = undefined;
     const old_cellar = try std.fmt.bufPrint(&buf, "{s}/Cellar/wget/1.22", .{prefix});
     try testing.expectError(error.FileNotFound, test_io.accessAbsolute(io, old_cellar, .{}));
+}
+
+fn kegInstallReason(prefix: [:0]const u8, allocator: std.mem.Allocator, name: []const u8) ![]u8 {
+    var db_path_buf: [512]u8 = undefined;
+    const db_path = try std.fmt.bufPrintZ(&db_path_buf, "{s}/db/malt.db", .{prefix});
+    var db = try sqlite.Database.open(db_path);
+    defer db.close();
+
+    var stmt = try db.prepare("SELECT install_reason FROM kegs WHERE name = ?1;");
+    defer stmt.finalize();
+    try stmt.bindText(1, name);
+    if (!(try stmt.step())) return error.TestUnexpectedResult;
+    const r = stmt.columnText(0) orelse return error.TestUnexpectedResult;
+    return allocator.dupe(u8, std.mem.sliceTo(r, 0));
+}
+
+// A keg pulled in as a dependency stays reclaimable after a rollback:
+// relabelling it 'direct' would make autoremove skip it forever.
+test "rolling back a dependency keeps it marked as a dependency" {
+    var pbuf: [64]u8 = undefined;
+    const prefix = rbPrefix(&pbuf, "carry_reason");
+    try makeSandbox(prefix);
+    defer test_io.deleteTreeAbsolute(std.Options.debug_io, prefix) catch {};
+
+    try installKegAs(prefix, "pcre2", "10.45", false, "dependency");
+    try seedStoreEntry(prefix, "sha_old", "pcre2", "10.44", 0);
+
+    setPrefix(prefix);
+    defer unsetPrefix();
+
+    var stdout_buf: std.ArrayList(u8) = .empty;
+    defer stdout_buf.deinit(testing.allocator);
+    output.beginStdoutCapture(testing.allocator, &stdout_buf);
+    defer output.endStdoutCapture();
+
+    var threaded: std.Io.Threaded = .init(testing.allocator, .{});
+    defer threaded.deinit();
+    const ctx: malt.app_ctx.AppCtx = .{ .io = threaded.io(), .environ = .empty };
+
+    try rollback.execute(&ctx, testing.allocator, &.{"pcre2"});
+
+    const reason = try kegInstallReason(prefix, testing.allocator, "pcre2");
+    defer testing.allocator.free(reason);
+    try testing.expectEqualStrings("dependency", reason);
 }


### PR DESCRIPTION
## Description

A failed `mt rollback` could leave the machine with no working version of the package: the current version's symlinks and Cellar directory were removed before the fallible step that restores the older one, and nothing put them back. Rollback now prepares the old version first and only touches the installed one once the swap is guaranteed, restoring everything if it isn't.

A successful rollback was also quietly losing state recorded against the package - its hold, bin isolation, dependency edges, tap attribution and tap-qualified name - which left dependencies exposed to being reclaimed by cleanup and sent later upgrades looking in the wrong place. The keg record is now updated in place instead of being replaced, so that state survives by construction rather than by being copied field by field.

## Related Issue

- None

## Notes for Reviewers

- None