### PR TITLE
fix(ui): strip terminal control sequences from formula and tap text

### DIFF
--- a/scripts/regressions/ui-output-missing-control-byte-scrub.sh
+++ b/scripts/regressions/ui-output-missing-control-byte-scrub.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Regression: text lifted from a tap or a formula must reach the terminal as
+# inert characters, never as terminal control sequences.
+#
+# The bug: every `ui/output` writer interpolated its runtime argument bytes
+# verbatim. A formula/cask `desc` (free text, no parse-time predicate) and a
+# DSL-authored ohai/opoo/odie/raise message could therefore carry OSC, DCS or
+# arbitrary CSI straight into the user's terminal — clipboard writes, scrollback
+# rewrites, prompt spoofing — from `mt info` or a post_install run.
+#
+# The fix scrubs the interpolated bytes at the render choke points, dropping
+# ESC, other C0, DEL and lone C1 while leaving multibyte UTF-8 intact.
+#
+# Driving a hostile `desc` end to end would need a local HTTP fixture server the
+# repo does not have, so the guarantee is pinned by colocated inline tests that
+# assert against the real writers. This script builds and runs only that unit
+# binary: no network, no state outside zig-cache/zig-out, well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT"
+
+# The unit binary would go green vacuously if the scrub call or its tests were
+# dropped, so require both call sites and both assertions to still be present.
+for src in src/ui/output.zig src/cli/install/post_install.zig; do
+  if ! grep -Fqs -- "scrubInPlace" "$src"; then
+    echo "FAIL: $src no longer scrubs interpolated text before writing it" >&2
+    exit 1
+  fi
+done
+
+while IFS= read -r name; do
+  if ! grep -Fqs -- "$name" src/ui/output.zig; then
+    echo "FAIL: the control-byte test is missing from src/ui/output.zig: $name" >&2
+    exit 1
+  fi
+done <<'NAMES'
+info drops OSC 52 from an interpolated message
+writeField drops OSC 52 from a tap-sourced value
+NAMES
+
+BIN="$ROOT/zig-out/test-bin/lib_tests"
+# Always rebuild: a prebuilt binary could predate the scrub. Zig's cache keeps
+# the no-op rebuild cheap.
+if ! zig build test-bin >/dev/null 2>&1; then
+  echo "FAIL: could not build the unit test binary (zig build test-bin)" >&2
+  exit 1
+fi
+
+OUT=$(MALT_PREFIX=/tmp/malt-test-prefix "$BIN" 2>&1) && STATUS=0 || STATUS=$?
+if [[ "$STATUS" -ne 0 ]]; then
+  echo "FAIL: interpolated tap/formula text reached the terminal unscrubbed" >&2
+  printf '%s\n' "$OUT" | grep -iE "failed|leaked|panic" >&2 || true
+  exit 1
+fi
+
+echo "PASS: ui/output scrubs terminal control bytes from interpolated text"

--- a/src/cli/install/post_install.zig
+++ b/src/cli/install/post_install.zig
@@ -14,6 +14,7 @@ const ruby_sub = @import("../../core/ruby_subprocess.zig");
 const steps_mod = @import("../../core/post_install_steps.zig");
 const sandbox = @import("../../core/sandbox/macos.zig");
 const output = @import("../../ui/output.zig");
+const term_sanitize = @import("../../ui/term_sanitize.zig");
 const download = @import("download.zig");
 pub const DownloadJob = download.DownloadJob;
 const sink_mod = @import("sink.zig");
@@ -224,7 +225,25 @@ fn renderUnknown(flog: *const dsl.FallbackLog, tag: []const u8) void {
 /// fallback warnings) plus any OOM-drop notice. The DSL records these
 /// during execution; rendering is the CLI's job so core/dsl stays UI-free.
 fn renderNotes(flog: *const dsl.FallbackLog) void {
-    for (flog.notes()) |line| output.writeStderrAll(line);
+    // Note bodies are formula-authored, and the log owns them immutably, so a
+    // stack window buys a mutable copy to scrub without dropping long notes.
+    var window: [1024]u8 = undefined;
+    for (flog.notes()) |line| {
+        var rest = line;
+        while (rest.len > 0) {
+            var n = @min(rest.len, window.len);
+            // Splitting a codepoint would leave the scrub's counter unarmed for
+            // the tail, so back off to a lead byte. A window with no boundary
+            // at all is malformed anyway; take it whole and let the scrub judge.
+            if (n < rest.len) {
+                while (n > 0 and rest[n] & 0xC0 == 0x80) n -= 1;
+                if (n == 0) n = window.len;
+            }
+            @memcpy(window[0..n], rest[0..n]);
+            output.writeStderrAll(term_sanitize.scrubInPlace(window[0..n]));
+            rest = rest[n..];
+        }
+    }
     if (flog.dropped_oom)
         output.writeStderrAll("malt: fallback log dropped an entry due to OOM\n");
 }
@@ -783,4 +802,72 @@ test "provisionShippedCaBundle: self-heals a stale dangling cert.pem symlink" {
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const n = try std.Io.Dir.cwd().readLink(std.Options.debug_io, dest, &buf);
     try std.testing.expectEqualStrings(s.p("/opt/ca-certificates/share/ca-certificates/cacert.pem"), buf[0..n]);
+}
+
+// The render seam is the last place to strip control bytes out of
+// formula-authored note text.
+test "renderNotes drops terminal control bytes from a formula-authored note" {
+    var flog = dsl.FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+    flog.note("boom\x1b]52;c;ZXZpbA==\x07 done\n");
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    output.beginStderrCapture(std.testing.allocator, &buf);
+    defer output.endStderrCapture();
+
+    renderNotes(&flog);
+    try std.testing.expect(std.mem.indexOfScalar(u8, buf.items, 0x1b) == null);
+    try std.testing.expect(std.mem.indexOfScalar(u8, buf.items, 0x07) == null);
+    try std.testing.expect(std.mem.startsWith(u8, buf.items, "boom"));
+    try std.testing.expect(std.mem.endsWith(u8, buf.items, " done\n"));
+}
+
+test "renderNotes keeps a codepoint that straddles the scrub buffer intact" {
+    var flog = dsl.FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+    // 1023 filler bytes put the coffee cup's lead byte on the window edge.
+    const note = ("x" ** 1023) ++ "\u{2615}tail\n";
+    flog.note(note);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    output.beginStderrCapture(std.testing.allocator, &buf);
+    defer output.endStderrCapture();
+
+    renderNotes(&flog);
+    try std.testing.expectEqualStrings(note, buf.items);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(buf.items));
+}
+
+test "renderNotes makes progress on a note that is all continuation bytes" {
+    var flog = dsl.FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+    // No lead byte anywhere: the boundary walk-back finds nothing to back off
+    // to, so this pins that the loop still advances instead of spinning.
+    flog.note("\x80" ** 1100 ++ "ok\n");
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    output.beginStderrCapture(std.testing.allocator, &buf);
+    defer output.endStderrCapture();
+
+    renderNotes(&flog);
+    try std.testing.expectEqualStrings("ok\n", buf.items);
+}
+
+test "renderNotes keeps a note longer than the scrub buffer whole" {
+    var flog = dsl.FallbackLog.init(std.testing.allocator);
+    defer flog.deinit();
+    const long = "x" ** 3000;
+    flog.note(long ++ "\x1btail\n");
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    output.beginStderrCapture(std.testing.allocator, &buf);
+    defer output.endStderrCapture();
+
+    renderNotes(&flog);
+    try std.testing.expect(std.mem.indexOfScalar(u8, buf.items, 0x1b) == null);
+    try std.testing.expectEqual(long.len + "tail\n".len, buf.items.len);
 }

--- a/src/ui/output.zig
+++ b/src/ui/output.zig
@@ -9,6 +9,7 @@ var pkg_io: std.Io = std.Options.debug_io;
 const builtin = @import("builtin");
 
 const color = @import("color.zig");
+const term_sanitize = @import("term_sanitize.zig");
 
 pub const OutputMode = enum {
     human,
@@ -323,7 +324,9 @@ inline fn emitPrefixLine(
     if (spec.respect_quiet and quiet) return;
     var buf: [4096]u8 = undefined;
     const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
-    writePrefixLine(spec.role, spec.emoji_prefix, spec.plain_prefix, spec.shape, msg);
+    // The comptime `fmt` is trusted; the interpolated args carry tap and
+    // formula text. Scrub the message only — the role colour is added outside.
+    writePrefixLine(spec.role, spec.emoji_prefix, spec.plain_prefix, spec.shape, term_sanitize.scrubInPlace(msg));
 }
 
 pub fn info(comptime fmt: []const u8, args: anytype) void {
@@ -497,7 +500,8 @@ pub fn writeField(
         try w.writeAll("\n");
         return;
     };
-    try w.writeAll(value);
+    // Values are tap-sourced free text (`desc`); keys are compile-time literals.
+    try w.writeAll(term_sanitize.scrubInPlace(value));
     try w.writeAll("\n");
 }
 
@@ -977,4 +981,90 @@ test "isInteractive treats a pty slave as interactive" {
 
     const slave_file: std.Io.File = .{ .handle = slave, .flags = .{ .nonblocking = false } };
     try std.testing.expect(isInteractive(slave_file, std.Options.debug_io));
+}
+
+// ── interpolated-text scrub ─────────────────────────────────────────
+// Asserted on bytes, not on the rendered string: which characters survive
+// is a policy choice, but no escape may.
+
+/// A clipboard-write escape a hostile tap could hide in free-form text.
+const osc52_payload = "evil\x1b]52;c;ZXZpbA==\x07tail";
+
+test "info drops OSC 52 from an interpolated message" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    const prior_quiet = isQuiet();
+    color.setForTest(false, false);
+    setQuiet(false);
+    beginStderrCapture(std.testing.allocator, &buf);
+    defer {
+        endStderrCapture();
+        color.setForTest(null, null);
+        setQuiet(prior_quiet);
+    }
+
+    info("{s}", .{osc52_payload});
+    try std.testing.expect(std.mem.indexOfScalar(u8, buf.items, 0x1b) == null);
+    try std.testing.expect(std.mem.indexOfScalar(u8, buf.items, 0x07) == null);
+    try std.testing.expect(std.mem.startsWith(u8, buf.items, "  > evil"));
+    try std.testing.expect(std.mem.endsWith(u8, buf.items, "tail\n"));
+}
+
+test "err drops OSC 52 even though it ignores --quiet" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    const prior_quiet = isQuiet();
+    color.setForTest(false, false);
+    setQuiet(true);
+    beginStderrCapture(std.testing.allocator, &buf);
+    defer {
+        endStderrCapture();
+        color.setForTest(null, null);
+        setQuiet(prior_quiet);
+    }
+
+    err("{s}", .{osc52_payload});
+    try std.testing.expect(std.mem.indexOfScalar(u8, buf.items, 0x1b) == null);
+    try std.testing.expect(std.mem.indexOfScalar(u8, buf.items, 0x07) == null);
+}
+
+test "the role colour codes survive the message scrub" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    const prior_quiet = isQuiet();
+    color.setForTest(true, true);
+    setQuiet(false);
+    beginStderrCapture(std.testing.allocator, &buf);
+    defer {
+        endStderrCapture();
+        color.setForTest(null, null);
+        setQuiet(prior_quiet);
+    }
+
+    info("{s}", .{"a\x1b[31mb"});
+    // The prefix is coloured outside the scrubbed message, so ESC survives
+    // in the line while the payload's own escape is gone from the body.
+    try std.testing.expect(std.mem.indexOfScalar(u8, buf.items, 0x1b) != null);
+    try std.testing.expect(std.mem.endsWith(u8, buf.items, "a[31mb\n"));
+}
+
+test "writeField drops OSC 52 from a tap-sourced value" {
+    var out: [512]u8 = undefined;
+    var w = std.Io.Writer.fixed(&out);
+    var scratch: [256]u8 = undefined;
+    try writeField(&w, &scratch, false, 14, "Description", "{s}", .{osc52_payload});
+    const got = w.buffered();
+    try std.testing.expect(std.mem.indexOfScalar(u8, got, 0x1b) == null);
+    try std.testing.expect(std.mem.indexOfScalar(u8, got, 0x07) == null);
+    try std.testing.expect(std.mem.startsWith(u8, got, "Description:"));
+    try std.testing.expect(std.mem.endsWith(u8, got, "tail\n"));
+}
+
+test "writeField keeps an accented, emoji-bearing description intact" {
+    const desc = "Café ☕ pour déjà-vu 🚀";
+    var out: [512]u8 = undefined;
+    var w = std.Io.Writer.fixed(&out);
+    var scratch: [256]u8 = undefined;
+    try writeField(&w, &scratch, false, 14, "Description", "{s}", .{desc});
+    try std.testing.expect(std.mem.indexOf(u8, w.buffered(), desc) != null);
 }

--- a/src/ui/term_sanitize.zig
+++ b/src/ui/term_sanitize.zig
@@ -163,30 +163,51 @@ pub const Sanitizer = struct {
     }
 
     fn passable(self: *Sanitizer, b: u8) bool {
-        // A continuation byte passes only while a lead byte is still expecting
-        // one; this is what tells a real 0x80..0x9F continuation from a lone C1
-        // control (the 8-bit CSI/OSC/DCS/ST introducers we must drop).
-        if (self.utf8_remaining > 0) switch (b) {
-            0x80...0xBF => {
-                self.utf8_remaining -= 1;
-                return true;
-            },
-            else => self.utf8_remaining = 0, // truncated — reclassify below
-        };
-        return switch (b) {
-            0x20...0x7E, '\n', '\r', '\t' => true,
-            // UTF-8 lead byte: pass raw and arm the continuation counter. std
-            // rejects continuation bytes and invalid leads (0xF8..0xFF), both of
-            // which fall through to `false` — closing the lone-C1 hole.
-            0x80...0xFF => blk: {
-                const len = std.unicode.utf8ByteSequenceLength(b) catch break :blk false;
-                self.utf8_remaining = @intCast(len - 1);
-                break :blk true;
-            },
-            else => false, // C0 controls, DEL
-        };
+        // CR is a stream byte here: child output uses it for in-place progress.
+        return passableByte(b, &self.utf8_remaining) or b == '\r';
     }
 };
+
+/// Shared pass predicate. The continuation counter is what tells a real
+/// 0x80..0xBF continuation from a lone C1 control, so both callers must
+/// classify through here rather than reimplement the rule.
+fn passableByte(b: u8, utf8_remaining: *u2) bool {
+    if (utf8_remaining.* > 0) switch (b) {
+        0x80...0xBF => {
+            utf8_remaining.* -= 1;
+            return true;
+        },
+        else => utf8_remaining.* = 0, // truncated — reclassify below
+    };
+    return switch (b) {
+        0x20...0x7E, '\n', '\t' => true,
+        // UTF-8 lead byte: pass raw and arm the continuation counter. std
+        // rejects continuation bytes and invalid leads (0xF8..0xFF), both of
+        // which fall through to `false` — closing the lone-C1 hole.
+        0x80...0xFF => blk: {
+            const len = std.unicode.utf8ByteSequenceLength(b) catch break :blk false;
+            utf8_remaining.* = @intCast(len - 1);
+            break :blk true;
+        },
+        else => false, // C0 controls, DEL
+    };
+}
+
+/// Filter `buf` in place, returning the kept prefix.
+///
+/// Stricter than `Sanitizer` by design: text interpolated into malt's own
+/// output has no legitimate reason to carry an escape, so there is no CSI
+/// whitelist here and CR drops with the other C0 controls.
+pub fn scrubInPlace(buf: []u8) []u8 {
+    var out: usize = 0;
+    var utf8_remaining: u2 = 0;
+    for (buf) |b| {
+        if (!passableByte(b, &utf8_remaining)) continue;
+        buf[out] = b;
+        out += 1;
+    }
+    return buf[0..out];
+}
 
 /// Maps an 8-bit C1 control introducer to the state that drops or filters
 /// its payload, mirroring the 7-bit ESC forms. `null` for any other byte.
@@ -267,4 +288,53 @@ test "passable drops lone C1 but passes UTF-8 continuation under an armed counte
     try std.testing.expect(s.passable(0x9C));
     try std.testing.expect(s.passable(0x93));
     try std.testing.expect(!s.passable(0x9C));
+}
+
+// ── inline unit tests: scrubInPlace ─────────────────────────────────
+
+test "scrubInPlace drops ESC, other C0, DEL and CR but keeps TAB/LF" {
+    var buf = "a\x1bb\x00c\x07d\x7fe\rf\tg\nh".*;
+    try std.testing.expectEqualStrings("abcdef\tg\nh", scrubInPlace(&buf));
+}
+
+test "scrubInPlace keeps accented UTF-8 and emoji byte-identical" {
+    const text = "Café ☕ déjà-vu 🚀";
+    var buf: [64]u8 = undefined;
+    @memcpy(buf[0..text.len], text);
+    try std.testing.expectEqualStrings(text, scrubInPlace(buf[0..text.len]));
+}
+
+test "scrubInPlace drops lone C1 introducers but keeps them as continuations" {
+    // 0x9B/0x9D are the 8-bit CSI/OSC forms; bare they must go.
+    var lone = [_]u8{ 'a', 0x9B, 0x9D, 0x80, 'b' };
+    try std.testing.expectEqualStrings("ab", scrubInPlace(&lone));
+    // Inside ✓ (E2 9C 93) the same byte values are continuations and stay.
+    var check = "x\u{2713}y".*;
+    try std.testing.expectEqualStrings("x\u{2713}y", scrubInPlace(&check));
+}
+
+test "scrubInPlace drops a truncated multibyte lead and its stray bytes" {
+    // Lead byte promising two continuations, followed by ASCII: the lead is
+    // kept (it is a valid lead) but the counter unwinds so 'b' still passes.
+    var buf = [_]u8{ 0xE2, 'a', 'b' };
+    const got = scrubInPlace(&buf);
+    try std.testing.expect(std.mem.indexOfScalar(u8, got, 0x1b) == null);
+    try std.testing.expectEqualStrings("ab", got[got.len - 2 ..]);
+    // An invalid lead (0xFF) has no sequence length and drops outright.
+    var bad = [_]u8{ 'a', 0xFF, 'b' };
+    try std.testing.expectEqualStrings("ab", scrubInPlace(&bad));
+}
+
+test "scrubInPlace strips a whole OSC 52 clipboard payload of its controls" {
+    var buf = "evil\x1b]52;c;ZXZpbA==\x07tail".*;
+    const got = scrubInPlace(&buf);
+    try std.testing.expect(std.mem.indexOfScalar(u8, got, 0x1b) == null);
+    try std.testing.expect(std.mem.indexOfScalar(u8, got, 0x07) == null);
+    try std.testing.expect(std.mem.startsWith(u8, got, "evil"));
+    try std.testing.expect(std.mem.endsWith(u8, got, "tail"));
+}
+
+test "scrubInPlace handles an empty buffer" {
+    var buf: [0]u8 = undefined;
+    try std.testing.expectEqual(@as(usize, 0), scrubInPlace(&buf).len);
 }


### PR DESCRIPTION
## Description

A formula or cask description from a tap, and any message a formula's post_install writes, reached the terminal byte for byte. That let a hostile tap drive the terminal rather than just print to it - write the clipboard, rewrite scrollback, spoof a prompt - from something as ordinary as `mt info <name>`.

Those bytes are now filtered where malt renders them, so they land as inert characters. Accented text and emoji are untouched, and so are malt's own colours and progress output.

## Related Issue

- None

## Notes for Reviewers

- Scoped to the description field and post_install messages. 