### PR TITLE
fix(ui): drop CSI sequences whose parameters are not plain numeric

### DIFF
--- a/scripts/regressions/csi-whitelist-ignores-private-parameter-bytes.sh
+++ b/scripts/regressions/csi-whitelist-ignores-private-parameter-bytes.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Regression: the CSI whitelist keyed only on the final byte, so every buffered
+# parameter byte was replayed verbatim. A private prefix or an intermediate byte
+# changes which command a sequence is -- `CSI > 4 ; 2 m` is XTMODKEYS (it
+# rewrites the terminal's modifier-key reporting), not SGR -- so a whitelisted
+# final admitted a whole family of commands the whitelist never reviewed.
+#
+# The sanitizer has no standalone CLI surface (it wraps child stdout/stderr), so
+# a standalone ReleaseSafe `zig test` harness drives Sanitizer.feed/flush through
+# a capturing sink and asserts on the emitted bytes. It checks both directions:
+# hostile private/intermediate forms drop to nothing, and legitimate numeric
+# SGR/erase/motion still passes byte-identically -- so simply disabling the
+# whitelist does not make it pass.
+#
+# Exits 0 when the bug is absent, non-zero (with a clear message) when present.
+# No network required; finishes well under 30s.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+
+# The standalone harness proves the byte-level property directly, but it cannot
+# notice the real tests being deleted, so guard their names too.
+while IFS= read -r name; do
+  if ! grep -Fqs -- "$name" "$ROOT/tests/term_sanitize_test.zig"; then
+    echo "FAIL: the CSI parameter test is missing from tests/term_sanitize_test.zig: $name" >&2
+    exit 1
+  fi
+done <<'NAMES'
+private-prefix CSI with a whitelisted final dropped
+intermediate byte CSI with a whitelisted final dropped
+private prefix via the 8-bit CSI introducer dropped
+NAMES
+
+# The harness imports the sanitizer via a repo-relative path, so it must sit at
+# the repo root for the source tree's module boundary to resolve; $$ keeps
+# concurrent runs from clobbering each other's file.
+HARNESS="$ROOT/.csi-private-param-regression.$$.zig"
+trap 'rm -f "$HARNESS"' EXIT
+
+cat >"$HARNESS" <<'ZIG'
+const std = @import("std");
+const ts = @import("src/ui/term_sanitize.zig");
+
+const Buf = struct {
+    list: std.ArrayList(u8) = .empty,
+
+    fn sink(self: *Buf) ts.Sink {
+        return .{ .ctx = self, .write_fn = writeFn };
+    }
+    fn writeFn(ctx: *anyopaque, bytes: []const u8) ts.SinkError!void {
+        const self: *Buf = @ptrCast(@alignCast(ctx));
+        self.list.appendSlice(std.testing.allocator, bytes) catch return error.WriteFailed;
+    }
+    fn deinit(self: *Buf) void {
+        self.list.deinit(std.testing.allocator);
+    }
+};
+
+fn run(input: []const u8, out: *Buf) !void {
+    var s = ts.Sanitizer.init();
+    try s.feed(input, out.sink());
+    try s.flush(out.sink());
+}
+
+test "private-parameter and intermediate CSI forms drop" {
+    const hostile = [_][]const u8{
+        "\x1b[>4;2m", // XTMODKEYS: rewrites modifier-key reporting
+        "\x1b[?4m", // XTQMODKEYS: terminal writes a report into stdin
+        "\x1b[<0;0;0m",
+        "\x1b[=5m",
+        "\x1b[0;1$m",
+        "\x1b[!K",
+        "\x1b[ A", // SL (scroll left) smuggled under the cursor-up arm
+    };
+    for (hostile) |bad| {
+        var b: Buf = .{};
+        defer b.deinit();
+        try run(bad, &b);
+        try std.testing.expectEqual(@as(usize, 0), b.list.items.len);
+    }
+}
+
+test "legitimate numeric sequences still pass byte-identically" {
+    const good = [_][]const u8{
+        "\x1b[0m",
+        "\x1b[1;31m",
+        "\x1b[4:3m", // SGR subparameters: curly underline
+        "\x1b[2K",
+        "\x1b[2J",
+        "\x1b[3A",
+    };
+    for (good) |ok| {
+        var b: Buf = .{};
+        defer b.deinit();
+        try run(ok, &b);
+        try std.testing.expectEqualStrings(ok, b.list.items);
+    }
+}
+
+test "text around a dropped sequence survives" {
+    var b: Buf = .{};
+    defer b.deinit();
+    try run("ab\x1b[>4;2mcd", &b);
+    try std.testing.expectEqualStrings("abcd", b.list.items);
+}
+ZIG
+
+if (cd "$ROOT" && zig test -OReleaseSafe "$HARNESS") >/dev/null 2>&1; then
+  echo "PASS: CSI whitelist rejects non-numeric parameter bytes"
+else
+  echo "FAIL: CSI whitelist still replays private/intermediate parameter bytes" >&2
+  exit 1
+fi

--- a/src/ui/term_sanitize.zig
+++ b/src/ui/term_sanitize.zig
@@ -4,13 +4,16 @@
 //! the user's terminal. Permits printable ASCII + CR/LF/TAB + valid
 //! UTF-8 (tracked with a small continuation counter, so lone C1
 //! controls in 0x80..0x9F drop while real multibyte output passes) +
-//! a whitelisted subset of CSI sequences: SGR colours, relative
-//! cursor motion (A–G/E/F), line erase (K), and visible-screen erase
-//! (J with no param or 0/1/2).
+//! a whitelisted subset of CSI sequences, gated on the final byte AND
+//! numeric-only parameters: SGR colours, relative cursor motion
+//! (A–G/E/F), line erase (K), and visible-screen erase (J with no
+//! param or 0/1/2).
 //! Everything else — OSC (including clipboard-reading OSC 52), DCS,
 //! SOS/PM/APC, 8-bit C1 introducers, absolute positioning (H/f),
 //! cursor save/restore (s/u), scrollback erase (CSI 3 J), other CSI
-//! commands, C0 controls, stray/mid-sequence ESC — is dropped.
+//! commands, C0 controls, stray/mid-sequence ESC, and any CSI carrying
+//! a private prefix or intermediate byte (`CSI > 4 ; 2 m` is XTMODKEYS,
+//! not SGR) — is dropped.
 //!
 //! Used to wrap post_install stdout/stderr so a hostile formula
 //! cannot rewrite scrollback or exfiltrate via terminal extensions.
@@ -221,6 +224,12 @@ fn c1Target(b: u8) ?Sanitizer.State {
 }
 
 fn csiAllowed(final: u8, params: []const u8) bool {
+    // The prefix is part of the opcode: `CSI > 4 ; 2 m` is XTMODKEYS, not SGR.
+    // ':' stays for SGR subparameters (`CSI 4:3 m`).
+    for (params) |p| switch (p) {
+        '0'...'9', ';', ':' => {},
+        else => return false,
+    };
     return switch (final) {
         'm' => true, // SGR: colours, bold, underline
         'A', 'B', 'C', 'D' => true, // cursor up/down/right/left
@@ -258,6 +267,23 @@ test "csiAllowed whitelists SGR/relative motion, drops positioning + save/restor
     // J is param-gated, not final-byte-only.
     try std.testing.expect(csiAllowed('J', "2"));
     try std.testing.expect(!csiAllowed('J', "3"));
+}
+
+test "csiAllowed rejects private-prefix and intermediate parameter bytes" {
+    // The prefix is part of the opcode: `CSI > 4 ; 2 m` is XTMODKEYS, not SGR.
+    for ([_][]const u8{ ">4;2", "?4", "<0;0;0", "=5" }) |p|
+        try std.testing.expect(!csiAllowed('m', p));
+    // Intermediates likewise: `CSI SP A` is SL (scroll left), not cursor up.
+    try std.testing.expect(!csiAllowed('m', "0;1$"));
+    try std.testing.expect(!csiAllowed('K', "!"));
+    try std.testing.expect(!csiAllowed('A', " "));
+    // Bytes either side of the accepted '0'..'9' ';' ':' run.
+    try std.testing.expect(!csiAllowed('m', "/"));
+    try std.testing.expect(!csiAllowed('m', "<"));
+    // Numeric params, including SGR subparameters, stay allowed.
+    try std.testing.expect(csiAllowed('m', "1;31"));
+    try std.testing.expect(csiAllowed('m', "4:3"));
+    try std.testing.expect(csiAllowed('A', "3"));
 }
 
 test "eraseDisplayAllowed permits only visible-screen variants" {

--- a/tests/term_sanitize_test.zig
+++ b/tests/term_sanitize_test.zig
@@ -145,6 +145,43 @@ test "CSI 3 J erase scrollback dropped" {
     try check("a\x1b[3Jb", "ab");
 }
 
+// ── CSI private-prefix / intermediate forms dropped ─────────────────
+// A whitelisted final byte does not identify the command: these all use one
+// (m/K/A) yet are different commands with different side effects.
+
+test "private-prefix CSI with a whitelisted final dropped" {
+    // ESC [ > 4 ; 2 m — XTMODKEYS, rewrites modifier-key reporting.
+    try check("a\x1b[>4;2mb", "ab");
+    // ESC [ ? 4 m — XTQMODKEYS, makes the terminal report into stdin.
+    try check("a\x1b[?4mb", "ab");
+    try check("a\x1b[<0;0;0mb", "ab");
+    try check("a\x1b[=5mb", "ab");
+}
+
+test "intermediate byte CSI with a whitelisted final dropped" {
+    try check("a\x1b[0;1$mb", "ab");
+    try check("a\x1b[!Kb", "ab");
+    // ESC [ SP A is SL (scroll left), not cursor up.
+    try check("a\x1b[ Ab", "ab");
+}
+
+test "numeric SGR subparameters still pass" {
+    // CSI 4:3 m is a curly underline real build output emits.
+    try check("a\x1b[4:3mb", "a\x1b[4:3mb");
+}
+
+test "byte just below the digit range dropped" {
+    // '/' (0x2F) is a legal CSI intermediate one code point under '0'.
+    try check("a\x1b[/mb", "ab");
+}
+
+test "private prefix via the 8-bit CSI introducer dropped" {
+    // 0x9B reaches the same filter, so the C1 form must not be a way around it.
+    try check("a\x9b>4;2mb", "ab");
+    // A bare prefix with no digits is still not SGR.
+    try check("a\x1b[>mb", "ab");
+}
+
 // ── anti-injection: 8-bit C1 introducers handled like 7-bit ─────────
 
 test "8-bit CSI introducer routed through the CSI filter" {


### PR DESCRIPTION
## Description

A whitelisted CSI final byte didn't identify the command - the parameter bytes were replayed verbatim, so `ESC [ > 4 ; 2 m` passed as if it were SGR when it is actually XTMODKEYS and reconfigures modifier-key reporting for the terminal that outlives malt. The whitelist now requires numeric-only parameters too, so a hostile formula's build output can't smuggle a different command in under an approved final byte.

## Related Issue

- None

## Notes for Reviewers

- None